### PR TITLE
byok: gate step 4 on per-cloud zero-v1 attestations, not on a markdown cell

### DIFF
--- a/docs/design/byok-aad-v2-attestations.json
+++ b/docs/design/byok-aad-v2-attestations.json
@@ -1,0 +1,5 @@
+{
+  "schema": "trustedrouter/byok-aad-v1-zero-attestation/v1",
+  "about": "Recorded output of scripts/check_no_v1_envelopes.py, one entry per standalone cloud. Read by tests/test_byok_v1_removal_gate.py, which refuses the removal of v1 BYOK envelope support until every cloud here attests zero v1 envelopes. An entry asserts that a run happened against that cloud's database; writing one by hand asserts a run that did not. The gate can check the shape, not the truth.",
+  "attestations": {}
+}

--- a/docs/design/byok-aad-v2-attestations.json
+++ b/docs/design/byok-aad-v2-attestations.json
@@ -1,5 +1,5 @@
 {
-  "schema": "trustedrouter/byok-aad-v1-zero-attestation/v1",
-  "about": "Recorded output of scripts/check_no_v1_envelopes.py, one entry per standalone cloud. Read by tests/test_byok_v1_removal_gate.py, which refuses the removal of v1 BYOK envelope support until every cloud here attests zero v1 envelopes. An entry asserts that a run happened against that cloud's database; writing one by hand asserts a run that did not. The gate can check the shape, not the truth.",
+  "schema": "trustedrouter/byok-aad-v1-zero-attestation/v2",
+  "about": "Recorded output of scripts/check_no_v1_envelopes.py, one entry per standalone cloud. Read by tests/test_byok_v1_removal_gate.py, which refuses the removal of v1 BYOK envelope support until EVERY cloud here attests zero v1 envelopes. It is one fleet-wide verdict, not three: an AWS or Azure enclave falls over to the home control plane when its own cannot be dialled, so a v1 envelope in any cloud's database can be handed to any cloud's enclave. An entry asserts that a run happened against that cloud's database; writing one by hand asserts a run that did not. The gate can check the shape, not the truth.",
   "attestations": {}
 }

--- a/docs/design/byok-aad-v2-migration.md
+++ b/docs/design/byok-aad-v2-migration.md
@@ -10,11 +10,11 @@ whole difficulty — **and it repeats per cloud deployment**, see §4.0.
 Step 4 remains deliberately undone, so every enclave and control plane still
 reads v1 envelopes during the retention window.
 
-| Cloud | Step 1: enclave reads v1/v2 | Step 2: control plane writes v2 | Step 3: database backfill |
-|---|---|---|---|
-| GCP | complete in every serving region | complete | 7 BYOK envelopes migrated; 7 v2, 0 v1 after an independent audit |
-| AWS | complete in Paris and Ireland | complete on both Fargate services and both App Runner services | clean audit: no BYOK or Broadcast secret rows existed |
-| Azure | complete in UAE North and Southeast Asia | complete | clean audit: no BYOK or Broadcast secret rows existed |
+| Cloud | Step 1: enclave reads v1/v2 | Step 2: control plane writes v2 | Step 3: database backfill | Step-4 attestation |
+|---|---|---|---|---|
+| GCP | complete in every serving region | complete | 7 BYOK envelopes migrated; 7 v2, 0 v1 after an independent audit | **not recorded** |
+| AWS | complete in Paris and Ireland | complete on both Fargate services and both App Runner services | read-only audit returned zero rows; nothing was rewritten | **not recorded** |
+| Azure | complete in UAE North and Southeast Asia | complete | read-only audit returned zero rows; nothing was rewritten | **not recorded** |
 
 The backfill implementation landed in quill-router#573. The standalone
 operator configuration and mandatory explicit-KMS apply gate landed in
@@ -23,6 +23,19 @@ identity key-scoped encrypt/decrypt access, then removed it automatically; the
 post-migration IAM audit found no remaining operator binding. AWS and Azure
 were read-only audits because their independent databases contained nothing to
 rewrite.
+
+**Read the AWS and Azure cells carefully, because an earlier revision of this
+table did not let you.** They previously read "clean audit: no BYOK or Broadcast
+secret rows existed", which renders as the same green check as GCP's migration
+and is a different claim. "The audit found no rows" is also what a wrong resume
+cursor, a renamed entity kind, a wrong database, or a credential scoped to the
+wrong project produces — with exit code 0 and identical output. From inside the
+audit those cases are indistinguishable, which means **no cell in this table,
+however carefully worded, is a precondition for step 4.** The last column is,
+because it is a file that a test reads: `byok-aad-v2-attestations.json`, written
+only by `scripts/check_no_v1_envelopes.py`, which pairs the audit with a census
+computed by different SQL and refuses to call an uncorroborated empty result an
+attestation. It is empty today. Nobody has run it against a real database.
 
 ---
 
@@ -74,7 +87,10 @@ wrong, and it is the kind of wrong that becomes reachable the moment someone
 adds a customer-chosen identifier anywhere in the tuple.
 
 `test_aad_encoding_is_not_injective_in_general` asserts the collision today so
-this is not rediscovered. **That test should be deleted as part of this work.**
+this is not rediscovered. **That test should be deleted as part of this work** —
+in step 4, with v1 itself, and not before. `tests/test_byok_v1_removal_gate.py`
+holds those two together in both directions: while v1 envelopes are still
+readable, that test is the only standing record of why any of this exists.
 
 ---
 
@@ -269,12 +285,46 @@ enclave cache entries expire on their own. No cache flush needed.
 ### Step 4 — drop v1
 
 Only when a query proves zero v1 rows remain across every surface **and** the
-backfill has been idle for at least one full retention window.
+backfill has been idle for at least one full retention window. This is the one
+step with no rollback row in §5, so its precondition is executable rather than
+written down:
+
+```bash
+# once per standalone cloud — they are separate databases (§4.0)
+uv run python scripts/check_no_v1_envelopes.py --backend spanner \
+    --cloud gcp --record --operator you@lorehex.co
+uv run python scripts/check_no_v1_envelopes.py --status-only   # what is still owed
+```
+
+The check is read-only and needs no KMS access: it classifies envelopes by
+their stored `algorithm`. It reports one of six outcomes and only two of them —
+`clean` (envelopes were seen, all v2) and `empty_witnessed` (no envelopes, and
+an independently shaped census proves the table was reachable, non-empty, and
+holds zero rows of the migrated kinds) — may be recorded. An empty result with
+nothing behind it is `zero_scan`, which is a loud refusal, not a pass; a scan
+that misses rows the census can count is `scan_disagrees_with_census`. See the
+module docstrings in `src/trusted_router/byok_v1_attestations.py` and
+`tests/test_byok_v1_precondition.py` for the reasoning and its scope limits.
+
+Then, and only then:
 
 - remove `_aad`, `ALGORITHM`, and the v1 branches from both repos
 - delete `test_aad_encoding_is_not_injective_in_general`
 - keep a v1-shaped envelope in a test fixture asserting it is now **rejected**,
   so the removal is deliberate rather than silent
+
+`tests/test_byok_v1_removal_gate.py` fails CI if the first of those happens
+while `docs/design/byok-aad-v2-attestations.json` does not attest zero v1 on
+every cloud, and prints the commands above. It is silent while v1 support is
+present, and it permits the removal once the ledger is complete — it sequences
+the work rather than forbidding it. It also holds that the collision record and
+v1 are deleted together: removing that test earlier drops the only standing
+evidence that the v1 encoding is not injective.
+
+Two things the gate deliberately does not do. It cannot see `quill-cloud-proxy`,
+whose enclave carries its own v1 branch and its own removal decision, so
+ordering across the two repos is still a human responsibility. And it reads one
+module's source: a v1 branch reimplemented somewhere else would leave it quiet.
 
 ---
 
@@ -306,7 +356,12 @@ permanent from the moment it ships; v2 write support is the reversible part.**
 2. **Are there envelopes outside the three surfaces in §3?** The list came from
    grepping `encrypt_byok_secret` / `encrypt_control_secret` call sites in
    `quill-router`. If another service writes envelopes, the backfill misses them
-   and they break at step 4.
+   and they break at step 4. Still open — a grep cannot answer it. What is now
+   handled is the *second* half of the risk: the surface list lives in one place
+   (`byok_v1_attestations.MIGRATED_SURFACES`, from which the backfill's field map
+   is derived) and is fingerprinted into every attestation, so adding a fourth
+   surface invalidates every zero-v1 attestation taken before it existed rather
+   than silently inheriting them.
 3. **Is `provider` the right context for a BYOK key**, or should it be the
    storage slug from `byok_storage_provider_candidates`? They differ for aliased
    providers, and picking the wrong one produces envelopes that decrypt in

--- a/docs/design/byok-aad-v2-migration.md
+++ b/docs/design/byok-aad-v2-migration.md
@@ -218,9 +218,9 @@ Three consequences:
    So an AWS or Azure enclave whose own control plane is undialable is served
    by the **home (GCP) plane**, out of the **GCP database**. Envelopes do cross
    clouds. What actually made the GCP step-2 merge survivable is the sentence
-   further down this section: `internal/byokcache` carries no `//go:build` tag,
-   so v2 *read* support was already compiled into the `cloud_aws` and
-   `cloud_azure` variants — not isolation.
+   further down this section: `byokcache/cache.go`, which holds the algorithm
+   dispatch, carries no `//go:build` tag, so v2 *read* support was already
+   compiled into the `cloud_aws` and `cloud_azure` variants — not isolation.
 
 2. **Therefore step 4 is a fleet-wide decision, not a per-cloud one.** If one
    cloud drops v1 read support while any other cloud's database still holds a
@@ -250,9 +250,15 @@ AWS or Azure:
   was verified against `trust.trustedrouter.com`
 - only then let that cloud's control plane take the step-2 build
 
-The enclave code needs no per-cloud change: `internal/byokcache` carries no
-`//go:build` tag, so v2 read support is already compiled into the `cloud_aws`
-and `cloud_azure` variants and CI exercises all of them. What is missing is a
+The enclave code needs no per-cloud change: the file carrying the v1/v2
+algorithm dispatch, `internal/byokcache/cache.go` (`Algorithm` at :26,
+`AlgorithmV2` at :32, the `switch` at :346-348), has no `//go:build` tag, so v2
+read support is already compiled into the `cloud_aws` and `cloud_azure`
+variants and CI exercises all of them. The *package* is not tag-free — it also
+holds `kms_http_aws.go` (`cloud_aws`), `kms_http_gcp.go` (`!cloud_aws`) and
+`confidential_space_token{,_other}.go` (`cloud_gcp` / `!cloud_gcp`) — but none
+of those touch the envelope format, so the conclusion holds and the earlier
+package-level phrasing of it did not. What is missing is a
 **deploy and rollout** of a build containing it. As of writing,
 `quill-cloud-proxy` has `deploy-enclave-gcp.yml` and a `workflow_dispatch`-only
 `deploy.yml` ("Deploy AWS legacy"); there is no Azure deploy workflow in that
@@ -348,9 +354,11 @@ recorded:
   the literal `TR-BYOK-ENVELOPE-AES-256-GCM-V1` over whole row bodies — no kind
   filter, no assumption about which field holds an envelope — found nothing.
   That last clause is the one carrying the weight: the per-kind census and the
-  walk both derive their predicate from `MIGRATED_KINDS`, so a renamed entity
-  kind or a renamed body field hides rows from both and they corroborate each
-  other's silence. The literal search is a full table scan and is meant to be.
+  walk restrict to the same two kinds (`MIGRATED_KINDS` on both counts and on
+  the Postgres walk; the same two names hardcoded in SQL text on the Spanner
+  walk), so a renamed entity kind or a renamed body field hides rows from both
+  and they corroborate each other's silence. The literal search is a full table
+  scan and is meant to be.
 
 An empty result with nothing behind it is `zero_scan`, a loud refusal. A scan
 that misses rows either census question can see is `scan_disagrees_with_census`.
@@ -358,9 +366,26 @@ that misses rows either census question can see is `scan_disagrees_with_census`.
 **What it cannot tell you:** whether the credential pointed at the right
 database. A wrong-but-populated `tr_entities` is reachable, non-empty and holds
 no v1 envelope, which is what success looks like. The run records
-`census_source` — the server's own answer to "which database am I?" — so check
-it against the cloud the entry claims. See the module docstrings in
-`src/trusted_router/byok_v1_attestations.py` and
+`census_source` — which database the census was taken from — so check it
+against the cloud the entry claims. **Read that field knowing which adapter
+produced it.** On `--backend postgres` it is the server's own answer
+(`current_database()`, `current_user`, `inet_server_addr()`). On `--backend
+spanner` — i.e. the GCP invocation in the code block above — it is not: the
+client builds `projects/…/instances/…/databases/…` by concatenating the
+`--project`, `--spanner-instance` and `--spanner-database` you passed, with no
+RPC, so it echoes your own arguments back and would look the same against a
+local emulator. The recorded string says so. For GCP, corroborate the database
+some other way before treating that line as evidence.
+
+**One false positive worth knowing about:** the literal search is a text search
+over whole row bodies, so any row that merely *mentions*
+`TR-BYOK-ENVELOPE-AES-256-GCM-V1` — a captured provider error, a stored audit
+line — counts and blocks that cloud with `scan_disagrees_with_census` until it
+is removed or rewritten. That is on purpose: narrowing the pattern to a
+JSON-shaped match would tie it to each adapter's serialisation, and a literal
+search that stops matching fails open.
+
+See the module docstrings in `src/trusted_router/byok_v1_attestations.py` and
 `tests/test_byok_v1_precondition.py` for the rest of the scope limits.
 
 Then, and only then:

--- a/docs/design/byok-aad-v2-migration.md
+++ b/docs/design/byok-aad-v2-migration.md
@@ -34,8 +34,14 @@ audit those cases are indistinguishable, which means **no cell in this table,
 however carefully worded, is a precondition for step 4.** The last column is,
 because it is a file that a test reads: `byok-aad-v2-attestations.json`, written
 only by `scripts/check_no_v1_envelopes.py`, which pairs the audit with a census
-computed by different SQL and refuses to call an uncorroborated empty result an
-attestation. It is empty today. Nobody has run it against a real database.
+computed by different SQL — including one question that assumes neither the
+entity kind nor the field name the envelope is stored under — and refuses to
+call an uncorroborated empty result an attestation. It is empty today. Nobody
+has run it against a real database.
+
+And the last column is read as **one row, not three**: see §4.0 point 2. The
+enclaves cross-read on control-plane failover, so a v1 envelope left in any one
+database can be handed to any cloud's enclave.
 
 ---
 
@@ -188,14 +194,45 @@ AWS and Azure are not regions of the GCP deployment. Per
 **standalone TrustedRouter with its own database** — its own credits, API keys,
 workspaces, and therefore **its own BYOK envelopes**. Only identity federates.
 
-Two consequences:
+Three consequences:
 
 1. **Steps 1 and 2 on GCP did not migrate AWS or Azure.** A v2 envelope written
-   by the GCP control plane lands in the GCP database and is read by the GCP
-   enclave. It never reaches another cloud's enclave. That is why merging step
-   2 for GCP was safe with only the GCP enclave upgraded.
+   by the GCP control plane lands in the GCP database, so the AWS and Azure
+   databases were untouched and their own rows still had to be walked.
 
-2. **The ordering constraint reappears on every deployment.** The moment an
+   ⚠️ **An earlier revision of this bullet said that envelope "never reaches
+   another cloud's enclave", and used that to argue merging step 2 for GCP was
+   safe with only the GCP enclave upgraded. That is false, in both directions.**
+   The enclaves are deployed with an *ordered, comma-separated* control-plane
+   list and fail over to the next entry when the current one cannot be dialled
+   (verified 2026-08-15):
+
+   | where | what |
+   |---|---|
+   | `quill-cloud-proxy` `tools/deploy-aws-nitro.sh:888` | `QUILL_TR_CONTROL_PLANE_BASE_URL=https://aws.trustedrouter.com/v1,https://trustedrouter.com/v1` |
+   | `quill-cloud-proxy` `tools/deploy-azure-aci.sh:269` | `TR_CONTROL_PLANE_BASE_URL=https://azure.trustedrouter.com/v1,https://trustedrouter.com/v1` |
+   | `quill-cloud-proxy` `tools/deploy-gcp-mig.sh:208` | `TR_CONTROL_PLANE_BASE_URL=https://trustedrouter.com` (home only) |
+   | `enclave-go/internal/trustedrouter/client.go:41-44` | "baseURLs is ordered: index 0 is this cloud's OWN control plane, later entries are fallbacks used only when an earlier one cannot be dialled." |
+   | `client.go:789-826`, `:216` | `postToFirstDialable` walks that list; the `Authorization` it returns carries `byok_encrypted_secret`. |
+
+   So an AWS or Azure enclave whose own control plane is undialable is served
+   by the **home (GCP) plane**, out of the **GCP database**. Envelopes do cross
+   clouds. What actually made the GCP step-2 merge survivable is the sentence
+   further down this section: `internal/byokcache` carries no `//go:build` tag,
+   so v2 *read* support was already compiled into the `cloud_aws` and
+   `cloud_azure` variants — not isolation.
+
+2. **Therefore step 4 is a fleet-wide decision, not a per-cloud one.** If one
+   cloud drops v1 read support while any other cloud's database still holds a
+   v1 envelope, that cloud's enclave breaks the next time it fails over — i.e.
+   during a control-plane outage, on top of an existing incident, for exactly
+   the customers who brought their own keys. The precondition for dropping v1
+   **anywhere** is zero-v1 **everywhere**. That is why the ledger is read as a
+   single verdict and why `--status-only` exits non-zero until every cloud is
+   recorded; see `byok_v1_attestations.ENCLAVE_CONTROL_PLANE_SOURCES`, which
+   transcribes the table above and is what the required set is derived from.
+
+3. **The ordering constraint reappears on every deployment.** The moment an
    AWS or Azure control plane is updated to a `quill-router` build containing
    the step-2 commit, it starts writing v2 envelopes into *that* cloud's
    database. If that cloud's enclave has not already shipped step 1, every BYOK
@@ -296,15 +333,35 @@ uv run python scripts/check_no_v1_envelopes.py --backend spanner \
 uv run python scripts/check_no_v1_envelopes.py --status-only   # what is still owed
 ```
 
+**Exit 0 from either form means the whole fleet is clear, never that one cloud
+is** (§4.0 point 2). A per-cloud run that attests its own cloud while others
+still owe theirs exits 1, and `--status-only` exits 2 while the ledger blocks,
+so `check_no_v1_envelopes.py --status-only && <next step>` is safe to write.
+
 The check is read-only and needs no KMS access: it classifies envelopes by
-their stored `algorithm`. It reports one of six outcomes and only two of them —
-`clean` (envelopes were seen, all v2) and `empty_witnessed` (no envelopes, and
-an independently shaped census proves the table was reachable, non-empty, and
-holds zero rows of the migrated kinds) — may be recorded. An empty result with
-nothing behind it is `zero_scan`, which is a loud refusal, not a pass; a scan
-that misses rows the census can count is `scan_disagrees_with_census`. See the
-module docstrings in `src/trusted_router/byok_v1_attestations.py` and
-`tests/test_byok_v1_precondition.py` for the reasoning and its scope limits.
+their stored `algorithm`. It reports one of six outcomes and only two may be
+recorded:
+
+- `clean` — envelopes were seen and every one was v2.
+- `empty_witnessed` — no envelope of any format was seen, a census reached the
+  same table with the same credentials and found rows there, and a search for
+  the literal `TR-BYOK-ENVELOPE-AES-256-GCM-V1` over whole row bodies — no kind
+  filter, no assumption about which field holds an envelope — found nothing.
+  That last clause is the one carrying the weight: the per-kind census and the
+  walk both derive their predicate from `MIGRATED_KINDS`, so a renamed entity
+  kind or a renamed body field hides rows from both and they corroborate each
+  other's silence. The literal search is a full table scan and is meant to be.
+
+An empty result with nothing behind it is `zero_scan`, a loud refusal. A scan
+that misses rows either census question can see is `scan_disagrees_with_census`.
+
+**What it cannot tell you:** whether the credential pointed at the right
+database. A wrong-but-populated `tr_entities` is reachable, non-empty and holds
+no v1 envelope, which is what success looks like. The run records
+`census_source` — the server's own answer to "which database am I?" — so check
+it against the cloud the entry claims. See the module docstrings in
+`src/trusted_router/byok_v1_attestations.py` and
+`tests/test_byok_v1_precondition.py` for the rest of the scope limits.
 
 Then, and only then:
 
@@ -313,18 +370,26 @@ Then, and only then:
 - keep a v1-shaped envelope in a test fixture asserting it is now **rejected**,
   so the removal is deliberate rather than silent
 
-`tests/test_byok_v1_removal_gate.py` fails CI if the first of those happens
-while `docs/design/byok-aad-v2-attestations.json` does not attest zero v1 on
-every cloud, and prints the commands above. It is silent while v1 support is
-present, and it permits the removal once the ledger is complete — it sequences
-the work rather than forbidding it. It also holds that the collision record and
-v1 are deleted together: removing that test earlier drops the only standing
+`tests/test_byok_v1_removal_gate.py` fails CI if a v1-shaped envelope stops
+opening while `docs/design/byok-aad-v2-attestations.json` does not attest zero
+v1 on every cloud, and prints the commands above. Note that the third bullet
+above — a fixture asserting a v1 envelope is now **rejected** — is itself an
+edit that makes every stored v1 row unopenable, so it belongs after the ledger
+is complete like the other two, not before. The gate decides by sealing a v1
+envelope the way the stored rows were sealed and asking `decrypt_byok_secret`
+and `decrypt_control_secret` to open it, rather than by reading the source for
+`_aad`/`ALGORITHM`; that catches an entry-point rejection that leaves the v1
+code physically in place, and stays quiet through refactors that keep v1
+working. It permits the removal once the ledger is complete — it sequences the
+work rather than forbidding it. It also holds that the collision record and v1
+are deleted together: removing that test earlier drops the only standing
 evidence that the v1 encoding is not injective.
 
 Two things the gate deliberately does not do. It cannot see `quill-cloud-proxy`,
 whose enclave carries its own v1 branch and its own removal decision, so
-ordering across the two repos is still a human responsibility. And it reads one
-module's source: a v1 branch reimplemented somewhere else would leave it quiet.
+ordering across the two repos is still a human responsibility. And it opens a
+v1 envelope wrapped by the local/test key wrapper, so a v1 regression confined
+to the KMS wrapper is out of its scope.
 
 ---
 
@@ -337,9 +402,13 @@ module's source: a v1 branch reimplemented somewhere else would leave it quiet.
 | 3 | none needed; the job is non-destructive. Stop it and leave mixed v1/v2, which both planes read. |
 | 4 | do not attempt this step until you are willing not to roll it back. |
 
-Per-cloud: rolling back step 2 on one deployment does not affect the others,
-since the databases are separate. But a cloud whose control plane has written
-even one v2 envelope needs its enclave to keep v2 read support permanently.
+Per-cloud: rolling back step 2 on one deployment does not affect what the
+others *write*, since the databases are separate. It does not follow that the
+read side is per-cloud. Once **any** cloud's control plane has written even one
+v2 envelope, **every** enclave that can be served by that control plane needs
+v2 read support permanently — which, per §4.0 point 1, means the AWS and Azure
+enclaves too, because both fail over to the home plane. (They have it: v2 read
+support is compiled into every variant.)
 
 The asymmetry in step 2 is the one to internalise: **v2 read support is
 permanent from the moment it ships; v2 write support is the reversible part.**

--- a/docs/design/byok-aad-v2-migration.md
+++ b/docs/design/byok-aad-v2-migration.md
@@ -252,13 +252,13 @@ AWS or Azure:
 
 The enclave code needs no per-cloud change: the file carrying the v1/v2
 algorithm dispatch, `internal/byokcache/cache.go` (`Algorithm` at :26,
-`AlgorithmV2` at :32, the `switch` at :346-348), has no `//go:build` tag, so v2
-read support is already compiled into the `cloud_aws` and `cloud_azure`
-variants and CI exercises all of them. The *package* is not tag-free — it also
-holds `kms_http_aws.go` (`cloud_aws`), `kms_http_gcp.go` (`!cloud_aws`) and
-`confidential_space_token{,_other}.go` (`cloud_gcp` / `!cloud_gcp`) — but none
-of those touch the envelope format, so the conclusion holds and the earlier
-package-level phrasing of it did not. What is missing is a
+`AlgorithmV2` at :32, the `switch` in `envelopeAAD` at :345-352), has no
+`//go:build` tag, so v2 read support is already compiled into the `cloud_aws`
+and `cloud_azure` variants and CI exercises all of them. The *package* is not
+tag-free — it also holds `kms_http_aws.go` (`cloud_aws`), `kms_http_gcp.go`
+(`!cloud_aws`) and `confidential_space_token{,_other}.go` (`cloud_gcp` /
+`!cloud_gcp`) — but none of those touch the envelope format, so the conclusion
+holds and the earlier package-level phrasing of it did not. What is missing is a
 **deploy and rollout** of a build containing it. As of writing,
 `quill-cloud-proxy` has `deploy-enclave-gcp.yml` and a `workflow_dispatch`-only
 `deploy.yml` ("Deploy AWS legacy"); there is no Azure deploy workflow in that

--- a/scripts/check_no_v1_envelopes.py
+++ b/scripts/check_no_v1_envelopes.py
@@ -15,9 +15,18 @@ access — it classifies envelopes by their stored `algorithm` field.
       --record --operator you@lorehex.co
   uv run python scripts/check_no_v1_envelopes.py --status-only
 
-Exit codes:
-  0  this cloud attests zero v1 envelopes (outcome clean or empty_witnessed)
-  2  it does not, including the case where the run scanned nothing
+Exit codes. **Zero means the FLEET is clear, never that this cloud is** — the
+enclaves cross-read (byok_v1_attestations, "WHY EVERY CLOUD"), so one cloud's
+green is not permission to remove anything. That is what makes
+
+    check_no_v1_envelopes.py --status-only && <proceed with step 4>
+
+correct rather than a trap:
+
+  0  every standalone cloud attests zero v1 envelopes; step 4 is unblocked
+  1  this run attested its own cloud, but other clouds still owe theirs
+  2  this cloud does not attest — including the case where the run scanned
+     nothing — or, with --status-only, the ledger blocks step 4
   3  the run could not be completed at all
 """
 
@@ -94,22 +103,27 @@ def _store(args: argparse.Namespace) -> AuditableStore:
     return PostgresEntityStore(args.postgres_dsn)
 
 
-def _print_ledger_status(ledger: dict[str, Any]) -> None:
+def _print_ledger_status(ledger: dict[str, Any]) -> list[str]:
+    """Print the fleet-wide verdict and return the blockers behind it."""
     blockers = zero_v1_blockers(ledger)
     print(f"ledger surfaces={surface_fingerprint()}")
     if not blockers:
         print("ledger: every standalone cloud attests zero v1 envelopes")
-        return
+        return blockers
     print("ledger: step 4 is blocked")
     for blocker in blockers:
         print(f"  - {blocker}")
+    return blockers
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     if args.status_only:
-        _print_ledger_status(load_ledger(args.ledger))
-        return 0
+        # Exit 2 when blocked, so that `--status-only && <proceed>` is a
+        # correct shell chain. It returned 0 unconditionally once, which made
+        # the loudest possible printed refusal invisible to the only consumer
+        # that does not read.
+        return 2 if _print_ledger_status(load_ledger(args.ledger)) else 0
     if args.cloud is None or args.backend is None:
         raise SystemExit("--cloud and --backend are required unless --status-only is given")
     if args.record and not args.operator.strip():
@@ -152,7 +166,13 @@ def main(argv: list[str] | None = None) -> int:
         print(f"recorded {args.cloud} in the attestation ledger")
     else:
         print("not recorded: pass --record --operator <you> to write it into the ledger")
-    _print_ledger_status(load_ledger(args.ledger))
+    if _print_ledger_status(load_ledger(args.ledger)):
+        print(
+            f"EXIT 1, NOT 0: {args.cloud} attests, the fleet does not. Removing v1 now would "
+            "leave this cloud's enclave unable to open a v1 envelope handed to it by another "
+            "cloud's control plane during a failover."
+        )
+        return 1
     return 0
 
 

--- a/scripts/check_no_v1_envelopes.py
+++ b/scripts/check_no_v1_envelopes.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Step-4 precondition: prove one cloud holds no v1 BYOK envelope, and record it.
+
+Step 4 of docs/design/byok-aad-v2-migration.md deletes v1 envelope support. It
+is the one step in that plan that cannot be rolled back: a v1 row that survives
+it is a customer's provider key that nothing can open again. Until now the only
+thing gating it was a sentence in a table. This is the executable form of that
+sentence, one cloud at a time.
+
+Read-only. It never decrypts, never writes to the database, and never needs KMS
+access — it classifies envelopes by their stored `algorithm` field.
+
+  uv run python scripts/check_no_v1_envelopes.py --backend spanner --cloud gcp
+  uv run python scripts/check_no_v1_envelopes.py --backend postgres --cloud aws \
+      --record --operator you@lorehex.co
+  uv run python scripts/check_no_v1_envelopes.py --status-only
+
+Exit codes:
+  0  this cloud attests zero v1 envelopes (outcome clean or empty_witnessed)
+  2  it does not, including the case where the run scanned nothing
+  3  the run could not be completed at all
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from trusted_router.byok_aad_backfill import (
+    AuditableStore,
+    PostgresEntityStore,
+    SpannerEntityStore,
+    attestation_for,
+    check_no_v1_envelopes,
+)
+from trusted_router.byok_v1_attestations import (
+    STANDALONE_CLOUDS,
+    load_ledger,
+    record_attestation,
+    surface_fingerprint,
+    zero_v1_blockers,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cloud", choices=STANDALONE_CLOUDS)
+    parser.add_argument("--backend", choices=("spanner", "postgres"))
+    parser.add_argument(
+        "--record",
+        action="store_true",
+        help="Write a passing result into the attestation ledger",
+    )
+    parser.add_argument("--operator", default="", help="Who ran this; required with --record")
+    parser.add_argument("--note", default="", help="Free-text context stored with the attestation")
+    parser.add_argument("--ledger", type=Path, help="Ledger path (defaults to the committed one)")
+    parser.add_argument(
+        "--status-only",
+        action="store_true",
+        help="Print what the ledger currently blocks and exit; touches no database",
+    )
+    parser.add_argument("--batch-size", type=int, default=100)
+    parser.add_argument("--census-sample-limit", type=int, default=1000)
+    parser.add_argument(
+        "--project",
+        default=os.environ.get("TR_GCP_PROJECT_ID", "quill-cloud-proxy"),
+    )
+    parser.add_argument(
+        "--spanner-instance",
+        default=os.environ.get("TR_SPANNER_INSTANCE_ID", "trusted-router-nam6"),
+    )
+    parser.add_argument(
+        "--spanner-database",
+        default=os.environ.get("TR_SPANNER_DATABASE_ID", "trusted-router"),
+    )
+    parser.add_argument("--postgres-dsn", default=os.environ.get("TR_POSTGRES_DSN", ""))
+    return parser
+
+
+def _store(args: argparse.Namespace) -> AuditableStore:
+    # No --after-kind/--after-id here, deliberately, unlike the backfill script:
+    # a precondition that can be resumed from a cursor is a precondition that
+    # can be made to skip the rows it would have failed on.
+    if args.backend == "spanner":
+        from google.cloud import spanner
+
+        client = spanner.Client(project=args.project, disable_builtin_metrics=True)
+        database = client.instance(args.spanner_instance).database(args.spanner_database)
+        return SpannerEntityStore(database, spanner.param_types)
+    return PostgresEntityStore(args.postgres_dsn)
+
+
+def _print_ledger_status(ledger: dict[str, Any]) -> None:
+    blockers = zero_v1_blockers(ledger)
+    print(f"ledger surfaces={surface_fingerprint()}")
+    if not blockers:
+        print("ledger: every standalone cloud attests zero v1 envelopes")
+        return
+    print("ledger: step 4 is blocked")
+    for blocker in blockers:
+        print(f"  - {blocker}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.status_only:
+        _print_ledger_status(load_ledger(args.ledger))
+        return 0
+    if args.cloud is None or args.backend is None:
+        raise SystemExit("--cloud and --backend are required unless --status-only is given")
+    if args.record and not args.operator.strip():
+        raise SystemExit("--operator is required with --record")
+
+    try:
+        store = _store(args)
+        result = check_no_v1_envelopes(
+            store,
+            cloud=args.cloud,
+            batch_size=args.batch_size,
+            sample_limit=args.census_sample_limit,
+        )
+    except Exception as exc:  # a run that could not complete attests nothing
+        print(f"INCONCLUSIVE: the precondition did not complete: {type(exc).__name__}: {exc}")
+        print(
+            "This is exit 3, not exit 0. A run that could not query the database has not "
+            "established that the database holds no v1 envelopes."
+        )
+        return 3
+
+    print(f"result={json.dumps(result.as_dict(), sort_keys=True)}")
+    if not result.passed:
+        print(f"NOT AN ATTESTATION [{result.outcome}] for {args.cloud}: {result.detail}")
+        print(
+            "Nothing was recorded. 'the audit found no v1 rows' and 'the audit could have "
+            "found v1 rows and did not' are different claims; only the second one gates step 4."
+        )
+        return 2
+
+    print(f"ATTESTS ZERO V1 [{result.outcome}] for {args.cloud}: {result.detail}")
+    if args.record:
+        attestation = attestation_for(
+            result,
+            backend=args.backend,
+            operator=args.operator.strip(),
+            note=args.note.strip(),
+        )
+        record_attestation(attestation, path=args.ledger)
+        print(f"recorded {args.cloud} in the attestation ledger")
+    else:
+        print("not recorded: pass --record --operator <you> to write it into the ledger")
+    _print_ledger_status(load_ledger(args.ledger))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/trusted_router/byok_aad_backfill.py
+++ b/src/trusted_router/byok_aad_backfill.py
@@ -70,19 +70,39 @@ class EntityCensus:
     from "the audit could not have found anything".
 
     `v1_literal_rows` is the one that does not share the scan's assumptions.
-    Both of the above filter on `MIGRATED_KINDS`, and the scan reads envelopes
-    only out of the field names in `MIGRATED_SURFACES` — so a renamed entity
-    kind or a renamed body field hides the same rows from the walk AND from the
-    count, and the disagreement they exist to expose never happens. This one
-    searches whole row bodies for `V1_ALGORITHM_LITERAL` with no kind filter and
-    no field-name assumption, which is why it is the clause `empty_witnessed`
-    actually rests on.
+    The count and the walk restrict to the same two kinds — the count from
+    `MIGRATED_KINDS` on both adapters, the walk from `MIGRATED_KINDS` on
+    Postgres and from those same two names written out as SQL text on Spanner
+    (`SpannerEntityStore.scan`, which predates this check) — and the walk reads
+    envelopes only out of the field names in `MIGRATED_SURFACES`. So a renamed
+    entity kind or a renamed body field hides the same rows from the walk AND
+    from the count, and the disagreement they exist to expose never happens.
+    This one searches whole row bodies for `V1_ALGORITHM_LITERAL` with no kind
+    filter and no field-name assumption, which is why it is the clause
+    `empty_witnessed` actually rests on.
 
-    `source` is whatever the server says it is — instance and database, or
-    database/user/host. It is not a proof of anything. It is recorded so that a
-    reviewer of the ledger can see which database answered and compare it
-    against the cloud the entry claims to speak for, since nothing offline can
-    tell a correct database from a wrong-but-populated one.
+    That breadth is also its one false positive: it counts any row whose body
+    text merely CONTAINS the literal, including a row of a kind nothing here
+    migrates that only mentions it — a captured upstream error string, a stored
+    audit line. Such a row makes the cloud report `scan_disagrees_with_census`
+    until it is dealt with, even though no v1 envelope exists. That is
+    fail-closed and the message says where to look, but it is a real way for a
+    healthy deployment to be unattestable, and it is named as a scope limit in
+    `byok_v1_attestations` rather than narrowed: narrowing the pattern to a
+    JSON-shaped match would tie it to the exact serialisation each adapter
+    happens to store, and a pattern that stops matching fails OPEN.
+
+    `source` names the database the census was taken from, and the two adapters
+    know it to different depths. Postgres asks the server — `current_database()`,
+    `current_user`, `inet_server_addr()` — so its value is the server's own
+    answer. Spanner composes `projects/…/instances/…/databases/…` client-side
+    from the arguments the CLI was given: `Database.name` is string
+    concatenation in `google.cloud.spanner` and issues no RPC, so that value
+    records what was ASKED FOR, not what answered, and reads identically against
+    an emulator. Neither is a proof of anything. Both are recorded so a reviewer
+    of the ledger can compare the database against the cloud the entry claims to
+    speak for, since nothing offline can tell a correct database from a
+    wrong-but-populated one.
     """
 
     migrated_kind_counts: dict[str, int]
@@ -399,6 +419,13 @@ class SpannerEntityStore:
         renamed entity kind or a renamed body field cannot hide from. This runs
         once, before an irreversible step, on a snapshot read; it is not on any
         request path. On a large table expect it to take a while and let it.
+
+        Unlike the Postgres adapter, `source` here is NOT asked of the server.
+        `Database.name` is assembled locally from `--project`,
+        `--spanner-instance` and `--spanner-database`, so it names the database
+        that was addressed and would read the same against an emulator. The
+        returned string says so out loud, because the reviewer comparing the
+        ledger against the cloud it claims is the person that distinction is for.
         """
         counts: dict[str, int] = {}
         sampled: set[str] = set()
@@ -417,18 +444,30 @@ class SpannerEntityStore:
             )
             for (kind,) in sample:
                 sampled.add(kind)
-            literal_rows = 0
+            # Not initialised to zero: an aggregate that returned no row at all
+            # must raise, exactly as the Postgres adapter does. "The server told
+            # me nothing" must never become "there is nothing", and zero is the
+            # passing value. A GROUP BY or a LIMIT peek may legitimately be
+            # empty — those fail closed on their own, via `reachable` and via
+            # the undercount check — but a COUNT(*) returning no row is broken.
+            literal_rows: int | None = None
             for (count,) in snapshot.execute_sql(
                 "SELECT COUNT(*) FROM tr_entities WHERE STRPOS(body, @literal) > 0",
                 params={"literal": V1_ALGORITHM_LITERAL},
                 param_types={"literal": self._param_types.STRING},
             ):
                 literal_rows = int(count)
+            if literal_rows is None:
+                raise ValueError("the v1 literal count returned no row")
         return EntityCensus(
             migrated_kind_counts=counts,
             sampled_kinds=tuple(sorted(sampled)),
             v1_literal_rows=literal_rows,
-            source=f"spanner:{self._database.name}",
+            # Spelled out because it is not what it looks like: `Database.name`
+            # is built by concatenating the project, instance and database the
+            # CLI was told to use, with no RPC. This says which database was
+            # addressed, not which one answered.
+            source=f"spanner:{self._database.name} (from CLI arguments, not asked of the server)",
         )
 
     def compare_and_swap(self, row: EntityRow, new_body: dict[str, Any]) -> bool:
@@ -656,17 +695,30 @@ def check_no_v1_envelopes(
           same kind list.
         * A renamed entity kind, or an envelope moved to a differently named
           body field — caught by `census.v1_literal_rows`, and by nothing else
-          here. The per-kind counts cannot catch either: both halves derive
-          their predicate from `MIGRATED_KINDS`, so a renamed kind is renamed
-          in both, and neither reads a field name the surface map does not
-          list. An earlier revision of this docstring claimed the per-kind
-          census covered a renamed kind. It did not, and a live v1 envelope
-          under a renamed field passed as `empty_witnessed`.
+          here. The per-kind counts cannot catch either: the count and the walk
+          restrict to the same two kind names, so a renamed kind is hidden from
+          both, and neither reads a field name the surface map does not list.
+          (The count takes those names from `MIGRATED_KINDS` on both adapters;
+          the walk takes them from `MIGRATED_KINDS` on Postgres and from
+          hardcoded SQL text on Spanner. Identical today, and a divergence
+          would show up as an undercount, which is a refusal.) An earlier
+          revision of this docstring claimed the per-kind census covered a
+          renamed kind. It did not, and a live v1 envelope under a renamed
+          field passed as `empty_witnessed`.
         * A credential pointed at a wrong-but-populated database — NOT caught,
           and not catchable from here. Such a database is reachable, non-empty,
           and holds no v1 envelope, which is indistinguishable from success.
           `census.source` is recorded so the mismatch is at least visible in
-          the ledger afterwards.
+          the ledger afterwards — on Postgres that string is the server's own
+          answer, on Spanner it is the database the CLI was pointed at, and it
+          says which it is.
+
+    The literal search is a text search, so it also counts rows that only
+    MENTION `V1_ALGORITHM_LITERAL` — a stored upstream error message, an audit
+    line — and one of those blocks the cloud with `scan_disagrees_with_census`
+    until that row is removed or rewritten. Fail-closed, and a real reason a
+    deployment holding no v1 envelope can be unattestable. See the scope limits
+    in `byok_v1_attestations` for why it is not narrowed.
 
     The census is taken FIRST, on purpose. Taken last, a BYOK key registered
     while the scan was running would be counted by the census and missed by the
@@ -710,13 +762,15 @@ def check_no_v1_envelopes(
             outcome=OUTCOME_SCAN_DISAGREES,
             detail=(
                 f"{census.v1_literal_rows} rows in the table carry the v1 algorithm literal "
-                f"{V1_ALGORITHM_LITERAL!r} but the audit classified only {stats.rows_with_v1} "
-                "rows as v1. The literal search uses no kind filter and no field-name map, so "
-                "the walk is blind to at least "
-                f"{census.v1_literal_rows - stats.rows_with_v1} rows holding a v1 envelope — a "
-                "renamed entity kind, an envelope under a body field this repository does not "
-                "know, or a surface missing from MIGRATED_SURFACES. Find those rows before "
-                "believing anything else this reported."
+                f"{V1_ALGORITHM_LITERAL!r} somewhere in their body, but the audit classified "
+                f"only {stats.rows_with_v1} rows as v1. The literal search uses no kind filter "
+                "and no field-name map, so at least "
+                f"{census.v1_literal_rows - stats.rows_with_v1} rows carry that string where the "
+                "walk cannot see it: a renamed entity kind, an envelope under a body field this "
+                "repository does not know, or a surface missing from MIGRATED_SURFACES. It can "
+                "also be free text that merely mentions the literal — a stored provider error, "
+                "an audit line — which is not a v1 envelope but is not distinguishable from "
+                "here. Find those rows before believing anything else this reported."
             ),
             stats=stats,
             census=census,

--- a/src/trusted_router/byok_aad_backfill.py
+++ b/src/trusted_router/byok_aad_backfill.py
@@ -41,6 +41,7 @@ from trusted_router.byok_v1_attestations import (
     OUTCOME_V1_REMAINS,
     OUTCOME_ZERO_SCAN,
     PASSING_OUTCOMES,
+    V1_ALGORITHM_LITERAL,
     Attestation,
     surface_fingerprint,
     utc_now,
@@ -59,7 +60,7 @@ class EntityRow:
 
 @dataclass(frozen=True)
 class EntityCensus:
-    """A second, differently shaped question about the same table.
+    """Three differently shaped questions about the same table.
 
     `migrated_kind_counts` is an aggregate count per migrated kind; the scan is
     a paged cursor walk. They are computed by different SQL and can therefore
@@ -67,10 +68,27 @@ class EntityCensus:
     still sees them. `sampled_kinds` is a bounded peek at the table's contents
     of any kind at all, so that "the audit found nothing" can be distinguished
     from "the audit could not have found anything".
+
+    `v1_literal_rows` is the one that does not share the scan's assumptions.
+    Both of the above filter on `MIGRATED_KINDS`, and the scan reads envelopes
+    only out of the field names in `MIGRATED_SURFACES` — so a renamed entity
+    kind or a renamed body field hides the same rows from the walk AND from the
+    count, and the disagreement they exist to expose never happens. This one
+    searches whole row bodies for `V1_ALGORITHM_LITERAL` with no kind filter and
+    no field-name assumption, which is why it is the clause `empty_witnessed`
+    actually rests on.
+
+    `source` is whatever the server says it is — instance and database, or
+    database/user/host. It is not a proof of anything. It is recorded so that a
+    reviewer of the ledger can see which database answered and compare it
+    against the cloud the entry claims to speak for, since nothing offline can
+    tell a correct database from a wrong-but-populated one.
     """
 
     migrated_kind_counts: dict[str, int]
     sampled_kinds: tuple[str, ...]
+    v1_literal_rows: int
+    source: str
 
     @property
     def reachable(self) -> bool:
@@ -117,6 +135,11 @@ class BackfillStats:
     # per-kind census, and "we scanned 4000 rows" says nothing about whether
     # any of them were the kind that holds envelopes.
     rows_scanned_by_kind: dict[str, int] = field(default_factory=dict)
+    # Rows carrying at least one v1 envelope. Counted separately from
+    # `v1_envelopes` because the census counts ROWS containing the v1 literal,
+    # and a broadcast destination can hold two v1 envelopes in one row; the
+    # cross-check has to compare like with like.
+    rows_with_v1: int = 0
 
     def as_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -205,6 +228,7 @@ class BackfillRunner:
         new_body = copy.deepcopy(row.body)
         migrations = 0
         row_failed = False
+        row_v1 = 0
         for field_name, envelope_family in _fields_for_kind(row.kind):
             raw_envelope = row.body.get(field_name)
             if raw_envelope is None:
@@ -226,6 +250,7 @@ class BackfillRunner:
                 self._error(row, field_name, "unsupported_algorithm")
                 continue
             stats.v1_envelopes += 1
+            row_v1 += 1
             if not self._apply:
                 continue
             try:
@@ -242,6 +267,9 @@ class BackfillRunner:
                 stats.failures += 1
                 row_failed = True
                 self._error(row, field_name, type(exc).__name__)
+
+        if row_v1:
+            stats.rows_with_v1 += 1
 
         if not self._apply or row_failed or migrations == 0:
             return
@@ -358,12 +386,19 @@ class SpannerEntityStore:
             ]
 
     def census(self, *, sample_limit: int = 1000) -> EntityCensus:
-        """Aggregate counts for the migrated kinds, plus a bounded liveness peek.
+        """Counts per migrated kind, a bounded liveness peek, and a literal search.
 
-        Deliberately not `SELECT kind, COUNT(*) ... GROUP BY kind` over the
-        whole table: `tr_entities` holds every entity in the deployment and a
-        full group-by is an expensive scan on a live database. The peek is a
-        `LIMIT` read, so its cost does not grow with the table.
+        The per-kind count is deliberately not `GROUP BY kind` over the whole
+        table: `tr_entities` holds every entity in the deployment and a full
+        group-by is an expensive scan on a live database. The peek is a `LIMIT`
+        read, so its cost does not grow with the table.
+
+        The v1 literal search IS a full scan, and there is no way around it —
+        that is the whole point of it. It filters on neither the kind list nor
+        the field map the walk uses, so it is the only question here that a
+        renamed entity kind or a renamed body field cannot hide from. This runs
+        once, before an irreversible step, on a snapshot read; it is not on any
+        request path. On a large table expect it to take a while and let it.
         """
         counts: dict[str, int] = {}
         sampled: set[str] = set()
@@ -382,7 +417,19 @@ class SpannerEntityStore:
             )
             for (kind,) in sample:
                 sampled.add(kind)
-        return EntityCensus(migrated_kind_counts=counts, sampled_kinds=tuple(sorted(sampled)))
+            literal_rows = 0
+            for (count,) in snapshot.execute_sql(
+                "SELECT COUNT(*) FROM tr_entities WHERE STRPOS(body, @literal) > 0",
+                params={"literal": V1_ALGORITHM_LITERAL},
+                param_types={"literal": self._param_types.STRING},
+            ):
+                literal_rows = int(count)
+        return EntityCensus(
+            migrated_kind_counts=counts,
+            sampled_kinds=tuple(sorted(sampled)),
+            v1_literal_rows=literal_rows,
+            source=f"spanner:{self._database.name}",
+        )
 
     def compare_and_swap(self, row: EntityRow, new_body: dict[str, Any]) -> bool:
         new_body_json = _json_body(new_body)
@@ -453,7 +500,13 @@ class PostgresEntityStore:
         return result
 
     def census(self, *, sample_limit: int = 1000) -> EntityCensus:
-        """See SpannerEntityStore.census. Same two questions, same reasons."""
+        """See SpannerEntityStore.census. Same three questions, same reasons.
+
+        `body::text LIKE` rather than a JSON path, so the search does not
+        depend on where in the body an envelope sits or what the field holding
+        it is called — the two things the walk assumes and the two things that
+        made an earlier version of this check blind.
+        """
         import psycopg
 
         with psycopg.connect(self._dsn) as conn:
@@ -465,9 +518,30 @@ class PostgresEntityStore:
                 "SELECT DISTINCT kind FROM (SELECT kind FROM tr_entities LIMIT %s) AS peek",
                 (sample_limit,),
             ).fetchall()
+            # A missing row from either aggregate raises rather than defaulting
+            # to zero: "the server told me nothing" must never become "there is
+            # nothing", which is the confusion this whole module exists for.
+            literal_row = conn.execute(
+                "SELECT COUNT(*) FROM tr_entities WHERE body::text LIKE %s",
+                (f"%{V1_ALGORITHM_LITERAL}%",),
+            ).fetchone()
+            if literal_row is None:
+                raise ValueError("the v1 literal count returned no row")
+            source_row = conn.execute(
+                "SELECT current_database(), current_user, "
+                "coalesce(host(inet_server_addr()), 'local'), inet_server_port()"
+            ).fetchone()
+            if source_row is None:
+                raise ValueError("the database could not identify itself")
+        (literal_rows,) = literal_row
+        database, user, host, port = source_row
         return EntityCensus(
             migrated_kind_counts={kind: int(count) for kind, count in counted},
             sampled_kinds=tuple(sorted(kind for (kind,) in sampled)),
+            v1_literal_rows=int(literal_rows),
+            # Asked of the server rather than parsed out of the DSN, and the
+            # DSN never appears here: it carries the password.
+            source=f"postgres:{database}@{host}:{port} as {user}",
         )
 
     def compare_and_swap(self, row: EntityRow, new_body: dict[str, Any]) -> bool:
@@ -554,6 +628,8 @@ class PreconditionResult:
             "census": {
                 "migrated_kind_counts": dict(sorted(self.census.migrated_kind_counts.items())),
                 "sampled_kinds": list(self.census.sampled_kinds),
+                "v1_literal_rows": self.census.v1_literal_rows,
+                "source": self.census.source,
             },
         }
 
@@ -570,11 +646,27 @@ def check_no_v1_envelopes(
 
     The audit alone cannot do this. `BackfillRunner(apply=False)` reports
     `v1_envelopes == 0` just as happily for a migrated database as for a run
-    that scanned nothing at all — a bad resume cursor, a renamed kind, a
-    read-only credential on the wrong project. Both render as a green check,
-    and on AWS and Azure a green check is exactly what a zero-row audit
-    produced. So this function pairs the walk with a census computed by
-    different SQL and refuses to collapse the two cases.
+    that scanned nothing at all. Both render as a green check, and on AWS and
+    Azure a green check is exactly what a zero-row audit produced. So this
+    function pairs the walk with a census and refuses to collapse the cases.
+
+    WHAT THE CENSUS ACTUALLY SEPARATES, AND WHAT IT DOES NOT
+        * A cursor, ordering or pagination bug in the paged walk — caught by
+          the per-kind counts, which are computed by different SQL from the
+          same kind list.
+        * A renamed entity kind, or an envelope moved to a differently named
+          body field — caught by `census.v1_literal_rows`, and by nothing else
+          here. The per-kind counts cannot catch either: both halves derive
+          their predicate from `MIGRATED_KINDS`, so a renamed kind is renamed
+          in both, and neither reads a field name the surface map does not
+          list. An earlier revision of this docstring claimed the per-kind
+          census covered a renamed kind. It did not, and a live v1 envelope
+          under a renamed field passed as `empty_witnessed`.
+        * A credential pointed at a wrong-but-populated database — NOT caught,
+          and not catchable from here. Such a database is reachable, non-empty,
+          and holds no v1 envelope, which is indistinguishable from success.
+          `census.source` is recorded so the mismatch is at least visible in
+          the ledger afterwards.
 
     The census is taken FIRST, on purpose. Taken last, a BYOK key registered
     while the scan was running would be counted by the census and missed by the
@@ -608,6 +700,23 @@ def check_no_v1_envelopes(
                 f"the scan did not see rows the census can count ({detail}). A resume cursor, "
                 "filter, or ordering bug — or a row deleted mid-run. Re-run before believing "
                 "anything else this reported."
+            ),
+            stats=stats,
+            census=census,
+        )
+    if census.v1_literal_rows > stats.rows_with_v1:
+        return PreconditionResult(
+            cloud=cloud,
+            outcome=OUTCOME_SCAN_DISAGREES,
+            detail=(
+                f"{census.v1_literal_rows} rows in the table carry the v1 algorithm literal "
+                f"{V1_ALGORITHM_LITERAL!r} but the audit classified only {stats.rows_with_v1} "
+                "rows as v1. The literal search uses no kind filter and no field-name map, so "
+                "the walk is blind to at least "
+                f"{census.v1_literal_rows - stats.rows_with_v1} rows holding a v1 envelope — a "
+                "renamed entity kind, an envelope under a body field this repository does not "
+                "know, or a surface missing from MIGRATED_SURFACES. Find those rows before "
+                "believing anything else this reported."
             ),
             stats=stats,
             census=census,
@@ -649,14 +758,28 @@ def check_no_v1_envelopes(
             census=census,
         )
     if stats.envelopes_seen == 0:
+        # Every clause of the sentence below is evaluated above: the literal
+        # search returned zero (checked at the top), the census reached rows
+        # (checked immediately above), and envelopes_seen is zero by this
+        # branch. Nothing here asserts a condition the code did not test —
+        # that is the defect this branch used to have, and it is the same
+        # defect the whole file exists to prevent one layer down.
+        migrated_rows = sum(census.migrated_kind_counts.values())
         return PreconditionResult(
             cloud=cloud,
             outcome=OUTCOME_EMPTY_WITNESSED,
             detail=(
-                f"no envelopes exist on this deployment. The census reached "
-                f"{len(census.sampled_kinds)} entity kinds in the same table with the same "
-                "credentials and counts zero rows of every migrated kind, so the empty result "
-                "is the deployment's state and not the query's failure."
+                f"the walk read {stats.rows_scanned} rows of the migrated kinds and found no "
+                f"envelope in any of them ({stats.missing_envelopes} expected envelope fields "
+                "were absent, which is ordinary — both broadcast secret fields and the BYOK "
+                "secret are optional). What makes this an attestation rather than an empty "
+                f"result is the census: it reached {len(census.sampled_kinds)} entity kinds in "
+                f"the same table with the same credentials, counted {migrated_rows} rows of the "
+                "migrated kinds, and found ZERO rows anywhere in the table carrying "
+                f"{V1_ALGORITHM_LITERAL!r} — a search that filters on no kind and assumes no "
+                "field name, so a renamed kind or a renamed body field cannot hide from it. "
+                "This does not establish that this was the right database; the one that "
+                f"answered was {census.source!r}."
             ),
             stats=stats,
             census=census,
@@ -666,7 +789,8 @@ def check_no_v1_envelopes(
         outcome=OUTCOME_CLEAN,
         detail=(
             f"{stats.envelopes_seen} envelopes examined across {stats.rows_scanned} rows; "
-            f"all {stats.v2_envelopes} are v2."
+            f"all {stats.v2_envelopes} are v2, and no row anywhere in the table carries "
+            f"{V1_ALGORITHM_LITERAL!r}. The database that answered was {census.source!r}."
         ),
         stats=stats,
         census=census,
@@ -702,8 +826,11 @@ def attestation_for(
         envelopes_seen=result.stats.envelopes_seen,
         v1_envelopes=result.stats.v1_envelopes,
         v2_envelopes=result.stats.v2_envelopes,
+        missing_envelopes=result.stats.missing_envelopes,
         census_migrated_kind_counts=dict(result.census.migrated_kind_counts),
         census_sampled_kinds=list(result.census.sampled_kinds),
+        census_v1_literal_rows=result.census.v1_literal_rows,
+        census_source=result.census.source,
         operator=operator,
         note=note,
     )

--- a/src/trusted_router/byok_aad_backfill.py
+++ b/src/trusted_router/byok_aad_backfill.py
@@ -832,8 +832,8 @@ def check_no_v1_envelopes(
                 "migrated kinds, and found ZERO rows anywhere in the table carrying "
                 f"{V1_ALGORITHM_LITERAL!r} — a search that filters on no kind and assumes no "
                 "field name, so a renamed kind or a renamed body field cannot hide from it. "
-                "This does not establish that this was the right database; the one that "
-                f"answered was {census.source!r}."
+                "This does not establish that this was the right database; the census "
+                f"records it as {census.source!r}."
             ),
             stats=stats,
             census=census,
@@ -844,7 +844,7 @@ def check_no_v1_envelopes(
         detail=(
             f"{stats.envelopes_seen} envelopes examined across {stats.rows_scanned} rows; "
             f"all {stats.v2_envelopes} are v2, and no row anywhere in the table carries "
-            f"{V1_ALGORITHM_LITERAL!r}. The database that answered was {census.source!r}."
+            f"{V1_ALGORITHM_LITERAL!r}. The census records the database as {census.source!r}."
         ),
         stats=stats,
         census=census,

--- a/src/trusted_router/byok_aad_backfill.py
+++ b/src/trusted_router/byok_aad_backfill.py
@@ -70,10 +70,10 @@ class EntityCensus:
     from "the audit could not have found anything".
 
     `v1_literal_rows` is the one that does not share the scan's assumptions.
-    The count and the walk restrict to the same two kinds — the count from
-    `MIGRATED_KINDS` on both adapters, the walk from `MIGRATED_KINDS` on
-    Postgres and from those same two names written out as SQL text on Spanner
-    (`SpannerEntityStore.scan`, which predates this check) — and the walk reads
+    The count and the walk restrict to the same two kinds — both from
+    `MIGRATED_KINDS`, on both adapters, since `SpannerEntityStore.scan` now
+    binds `@kinds` the way its own census already did rather than writing the
+    two names out as SQL text — and the walk reads
     envelopes only out of the field names in `MIGRATED_SURFACES`. So a renamed
     entity kind or a renamed body field hides the same rows from the walk AND
     from the count, and the disagreement they exist to expose never happens.
@@ -377,7 +377,7 @@ class SpannerEntityStore:
         after_kind, after_id = after or ("", "")
         sql = (
             "SELECT kind, id, body FROM tr_entities "
-            "WHERE kind IN ('broadcast_destination', 'byok') "
+            "WHERE kind IN UNNEST(@kinds) "
             "AND (kind > @after_kind OR (kind = @after_kind AND id > @after_id)) "
             "ORDER BY kind, id LIMIT @limit"
         )
@@ -385,11 +385,13 @@ class SpannerEntityStore:
             rows = snapshot.execute_sql(
                 sql,
                 params={
+                    "kinds": list(MIGRATED_KINDS),
                     "after_kind": after_kind,
                     "after_id": after_id,
                     "limit": limit,
                 },
                 param_types={
+                    "kinds": self._param_types.Array(self._param_types.STRING),
                     "after_kind": self._param_types.STRING,
                     "after_id": self._param_types.STRING,
                     "limit": self._param_types.INT64,

--- a/src/trusted_router/byok_aad_backfill.py
+++ b/src/trusted_router/byok_aad_backfill.py
@@ -6,6 +6,11 @@ outside database transactions; the final write succeeds only when the row is
 still byte-for-byte (Spanner) or JSON-equivalent (Postgres) to the version that
 was decrypted. A concurrent key rotation therefore wins and is never
 overwritten by the backfill.
+
+The non-apply audit mode of `BackfillRunner` is also the measurement half of
+the step-4 precondition: `check_no_v1_envelopes` below wraps it with the one
+thing an audit cannot tell you about itself — whether it looked at anything.
+See `trusted_router.byok_v1_attestations` for the law and the ledger.
 """
 
 from __future__ import annotations
@@ -15,7 +20,7 @@ import hashlib
 import json
 import time
 from collections.abc import Callable
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from typing import Any, Protocol
 
 from trusted_router.byok_crypto import (
@@ -26,10 +31,22 @@ from trusted_router.byok_crypto import (
     encrypt_byok_secret,
     encrypt_control_secret,
 )
+from trusted_router.byok_v1_attestations import (
+    MIGRATED_KINDS,
+    MIGRATED_SURFACES,
+    OUTCOME_CLEAN,
+    OUTCOME_DIRTY,
+    OUTCOME_EMPTY_WITNESSED,
+    OUTCOME_SCAN_DISAGREES,
+    OUTCOME_V1_REMAINS,
+    OUTCOME_ZERO_SCAN,
+    PASSING_OUTCOMES,
+    Attestation,
+    surface_fingerprint,
+    utc_now,
+)
 from trusted_router.key_management import KeyWrapperSettings
 from trusted_router.storage_models import EncryptedSecretEnvelope
-
-_MIGRATED_KINDS = ("broadcast_destination", "byok")
 
 
 @dataclass(frozen=True)
@@ -38,6 +55,31 @@ class EntityRow:
     entity_id: str
     body: dict[str, Any]
     original_body: Any
+
+
+@dataclass(frozen=True)
+class EntityCensus:
+    """A second, differently shaped question about the same table.
+
+    `migrated_kind_counts` is an aggregate count per migrated kind; the scan is
+    a paged cursor walk. They are computed by different SQL and can therefore
+    disagree, which is the point: a cursor bug returns no rows while the count
+    still sees them. `sampled_kinds` is a bounded peek at the table's contents
+    of any kind at all, so that "the audit found nothing" can be distinguished
+    from "the audit could not have found anything".
+    """
+
+    migrated_kind_counts: dict[str, int]
+    sampled_kinds: tuple[str, ...]
+
+    @property
+    def reachable(self) -> bool:
+        """True when the table answered with real rows of some kind.
+
+        A credentials failure raises rather than reaching here; a wrong table
+        name raises; an empty answer leaves this False, which is never a pass.
+        """
+        return bool(self.sampled_kinds)
 
 
 class EntityStore(Protocol):
@@ -49,6 +91,14 @@ class EntityStore(Protocol):
     ) -> list[EntityRow]: ...
 
     def compare_and_swap(self, row: EntityRow, new_body: dict[str, Any]) -> bool: ...
+
+
+class CensusStore(Protocol):
+    def census(self, *, sample_limit: int = 1000) -> EntityCensus: ...
+
+
+class AuditableStore(EntityStore, CensusStore, Protocol):
+    """A store that can be both walked and counted. Required by the precondition."""
 
 
 @dataclass
@@ -63,8 +113,12 @@ class BackfillStats:
     conflicts: int = 0
     failures: int = 0
     unsupported_algorithms: int = 0
+    # Per-kind scan counts. A single total cannot be cross-checked against a
+    # per-kind census, and "we scanned 4000 rows" says nothing about whether
+    # any of them were the kind that holds envelopes.
+    rows_scanned_by_kind: dict[str, int] = field(default_factory=dict)
 
-    def as_dict(self) -> dict[str, int]:
+    def as_dict(self) -> dict[str, Any]:
         return asdict(self)
 
 
@@ -147,11 +201,12 @@ class BackfillRunner:
 
     def _process_row(self, row: EntityRow, stats: BackfillStats) -> None:
         stats.rows_scanned += 1
+        stats.rows_scanned_by_kind[row.kind] = stats.rows_scanned_by_kind.get(row.kind, 0) + 1
         new_body = copy.deepcopy(row.body)
         migrations = 0
         row_failed = False
-        for field, envelope_family in _fields_for_kind(row.kind):
-            raw_envelope = row.body.get(field)
+        for field_name, envelope_family in _fields_for_kind(row.kind):
+            raw_envelope = row.body.get(field_name)
             if raw_envelope is None:
                 stats.missing_envelopes += 1
                 continue
@@ -159,7 +214,7 @@ class BackfillRunner:
             if not isinstance(raw_envelope, dict):
                 stats.failures += 1
                 row_failed = True
-                self._error(row, field, "invalid_envelope_shape")
+                self._error(row, field_name, "invalid_envelope_shape")
                 continue
             algorithm = raw_envelope.get("algorithm")
             if algorithm == ALGORITHM_V2:
@@ -168,7 +223,7 @@ class BackfillRunner:
             if algorithm != ALGORITHM:
                 stats.unsupported_algorithms += 1
                 row_failed = True
-                self._error(row, field, "unsupported_algorithm")
+                self._error(row, field_name, "unsupported_algorithm")
                 continue
             stats.v1_envelopes += 1
             if not self._apply:
@@ -176,9 +231,9 @@ class BackfillRunner:
             try:
                 # One v1 unwrap, one v2 wrap, and one v2 verification unwrap.
                 self._limiter.acquire(3)
-                new_body[field] = self._migrate_envelope(
+                new_body[field_name] = self._migrate_envelope(
                     row,
-                    field=field,
+                    field=field_name,
                     envelope_family=envelope_family,
                     raw_envelope=raw_envelope,
                 )
@@ -186,7 +241,7 @@ class BackfillRunner:
             except Exception as exc:  # fail closed; never expose secret material
                 stats.failures += 1
                 row_failed = True
-                self._error(row, field, type(exc).__name__)
+                self._error(row, field_name, type(exc).__name__)
 
         if not self._apply or row_failed or migrations == 0:
             return
@@ -302,6 +357,33 @@ class SpannerEntityStore:
                 for kind, entity_id, body in rows
             ]
 
+    def census(self, *, sample_limit: int = 1000) -> EntityCensus:
+        """Aggregate counts for the migrated kinds, plus a bounded liveness peek.
+
+        Deliberately not `SELECT kind, COUNT(*) ... GROUP BY kind` over the
+        whole table: `tr_entities` holds every entity in the deployment and a
+        full group-by is an expensive scan on a live database. The peek is a
+        `LIMIT` read, so its cost does not grow with the table.
+        """
+        counts: dict[str, int] = {}
+        sampled: set[str] = set()
+        with self._database.snapshot() as snapshot:
+            rows = snapshot.execute_sql(
+                "SELECT kind, COUNT(*) FROM tr_entities WHERE kind IN UNNEST(@kinds) GROUP BY kind",
+                params={"kinds": list(MIGRATED_KINDS)},
+                param_types={"kinds": self._param_types.Array(self._param_types.STRING)},
+            )
+            for kind, count in rows:
+                counts[kind] = int(count)
+            sample = snapshot.execute_sql(
+                "SELECT kind FROM tr_entities LIMIT @limit",
+                params={"limit": sample_limit},
+                param_types={"limit": self._param_types.INT64},
+            )
+            for (kind,) in sample:
+                sampled.add(kind)
+        return EntityCensus(migrated_kind_counts=counts, sampled_kinds=tuple(sorted(sampled)))
+
     def compare_and_swap(self, row: EntityRow, new_body: dict[str, Any]) -> bool:
         new_body_json = _json_body(new_body)
 
@@ -346,12 +428,11 @@ class PostgresEntityStore:
         with psycopg.connect(self._dsn) as conn:
             rows = conn.execute(
                 "SELECT kind, id, body FROM tr_entities "
-                "WHERE kind IN (%s, %s) "
+                "WHERE kind = ANY(%s) "
                 "AND (kind > %s OR (kind = %s AND id > %s)) "
                 "ORDER BY kind, id LIMIT %s",
                 (
-                    _MIGRATED_KINDS[0],
-                    _MIGRATED_KINDS[1],
+                    list(MIGRATED_KINDS),
                     after_kind,
                     after_kind,
                     after_id,
@@ -371,6 +452,24 @@ class PostgresEntityStore:
             )
         return result
 
+    def census(self, *, sample_limit: int = 1000) -> EntityCensus:
+        """See SpannerEntityStore.census. Same two questions, same reasons."""
+        import psycopg
+
+        with psycopg.connect(self._dsn) as conn:
+            counted = conn.execute(
+                "SELECT kind, COUNT(*) FROM tr_entities WHERE kind = ANY(%s) GROUP BY kind",
+                (list(MIGRATED_KINDS),),
+            ).fetchall()
+            sampled = conn.execute(
+                "SELECT DISTINCT kind FROM (SELECT kind FROM tr_entities LIMIT %s) AS peek",
+                (sample_limit,),
+            ).fetchall()
+        return EntityCensus(
+            migrated_kind_counts={kind: int(count) for kind, count in counted},
+            sampled_kinds=tuple(sorted(kind for (kind,) in sampled)),
+        )
+
     def compare_and_swap(self, row: EntityRow, new_body: dict[str, Any]) -> bool:
         import psycopg
 
@@ -389,14 +488,21 @@ class PostgresEntityStore:
 
 
 def _fields_for_kind(kind: str) -> tuple[tuple[str, str], ...]:
-    if kind == "byok":
-        return (("encrypted_secret", "provider"),)
-    if kind == "broadcast_destination":
-        return (
-            ("encrypted_api_key", "control"),
-            ("encrypted_headers", "control"),
-        )
-    raise ValueError(f"unsupported entity kind: {kind}")
+    """Derived from MIGRATED_SURFACES so the surface list has exactly one home.
+
+    A new encrypted surface added there is walked by the backfill AND changes
+    the attestation fingerprint, which invalidates every zero-v1 attestation
+    recorded before the surface existed. Two copies of this list is how open
+    question #2 in the migration doc turns into an outage.
+    """
+    fields = tuple(
+        (field_name, family)
+        for surface_kind, field_name, family in MIGRATED_SURFACES
+        if surface_kind == kind
+    )
+    if not fields:
+        raise ValueError(f"unsupported entity kind: {kind}")
+    return fields
 
 
 def _broadcast_context(destination_id: str, field: str) -> str:
@@ -420,3 +526,184 @@ def _row_ref(kind: str, entity_id: str) -> str:
 
 def _json_body(value: Any) -> str:
     return json.dumps(value, separators=(",", ":"), sort_keys=True)
+
+
+# ------------------------------------------------- the step-4 precondition ---
+
+
+@dataclass(frozen=True)
+class PreconditionResult:
+    """One cloud's answer to "may v1 be deleted?", with its working shown."""
+
+    cloud: str
+    outcome: str
+    detail: str
+    stats: BackfillStats
+    census: EntityCensus
+
+    @property
+    def passed(self) -> bool:
+        return self.outcome in PASSING_OUTCOMES
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "cloud": self.cloud,
+            "outcome": self.outcome,
+            "detail": self.detail,
+            "audit": self.stats.as_dict(),
+            "census": {
+                "migrated_kind_counts": dict(sorted(self.census.migrated_kind_counts.items())),
+                "sampled_kinds": list(self.census.sampled_kinds),
+            },
+        }
+
+
+def check_no_v1_envelopes(
+    store: AuditableStore,
+    *,
+    cloud: str,
+    batch_size: int = 100,
+    sample_limit: int = 1000,
+    reporter: Callable[[str], None] = print,
+) -> PreconditionResult:
+    """Audit one cloud's database and say whether it attests zero v1 envelopes.
+
+    The audit alone cannot do this. `BackfillRunner(apply=False)` reports
+    `v1_envelopes == 0` just as happily for a migrated database as for a run
+    that scanned nothing at all — a bad resume cursor, a renamed kind, a
+    read-only credential on the wrong project. Both render as a green check,
+    and on AWS and Azure a green check is exactly what a zero-row audit
+    produced. So this function pairs the walk with a census computed by
+    different SQL and refuses to collapse the two cases.
+
+    The census is taken FIRST, on purpose. Taken last, a BYOK key registered
+    while the scan was running would be counted by the census and missed by the
+    walk, and would report as a scan disagreement — a false alarm on the most
+    ordinary event there is. Taken first, that same registration is scanned but
+    not counted, which is harmless. The remaining false-alarm mode is a row
+    deleted mid-run; the answer to that one is to re-run.
+
+    There is no resume cursor here, unlike the backfill. Resuming is what makes
+    a long mutating job survivable and it is exactly what makes an audit
+    unfalsifiable: a precondition that starts halfway through cannot claim to
+    have covered the beginning. This walks the whole table or reports nothing.
+    """
+    census = store.census(sample_limit=sample_limit)
+    stats = BackfillRunner(store, apply=False, reporter=reporter).run(batch_size=batch_size)
+
+    undercounted = {
+        kind: (counted, stats.rows_scanned_by_kind.get(kind, 0))
+        for kind, counted in sorted(census.migrated_kind_counts.items())
+        if counted > stats.rows_scanned_by_kind.get(kind, 0)
+    }
+    if undercounted:
+        detail = ", ".join(
+            f"{kind}: census counted {counted} rows, the scan returned {scanned}"
+            for kind, (counted, scanned) in undercounted.items()
+        )
+        return PreconditionResult(
+            cloud=cloud,
+            outcome=OUTCOME_SCAN_DISAGREES,
+            detail=(
+                f"the scan did not see rows the census can count ({detail}). A resume cursor, "
+                "filter, or ordering bug — or a row deleted mid-run. Re-run before believing "
+                "anything else this reported."
+            ),
+            stats=stats,
+            census=census,
+        )
+    if stats.failures or stats.unsupported_algorithms:
+        return PreconditionResult(
+            cloud=cloud,
+            outcome=OUTCOME_DIRTY,
+            detail=(
+                f"{stats.failures} unreadable and {stats.unsupported_algorithms} "
+                "unknown-algorithm envelopes. Something other than the migration is wrong; "
+                "a row that cannot be classified cannot be attested as v2."
+            ),
+            stats=stats,
+            census=census,
+        )
+    if stats.v1_envelopes:
+        return PreconditionResult(
+            cloud=cloud,
+            outcome=OUTCOME_V1_REMAINS,
+            detail=(
+                f"{stats.v1_envelopes} v1 envelopes are still stored. Run the backfill "
+                "(scripts/backfill_byok_aad_v2.py --apply) before attempting step 4."
+            ),
+            stats=stats,
+            census=census,
+        )
+    if stats.envelopes_seen == 0 and not census.reachable:
+        return PreconditionResult(
+            cloud=cloud,
+            outcome=OUTCOME_ZERO_SCAN,
+            detail=(
+                "the audit saw no envelopes AND the census found no rows of any kind, so "
+                "nothing distinguishes a migrated deployment from a broken query, a wrong "
+                "database, or a credential that can read nothing. This is not zero v1 "
+                "envelopes; it is zero evidence."
+            ),
+            stats=stats,
+            census=census,
+        )
+    if stats.envelopes_seen == 0:
+        return PreconditionResult(
+            cloud=cloud,
+            outcome=OUTCOME_EMPTY_WITNESSED,
+            detail=(
+                f"no envelopes exist on this deployment. The census reached "
+                f"{len(census.sampled_kinds)} entity kinds in the same table with the same "
+                "credentials and counts zero rows of every migrated kind, so the empty result "
+                "is the deployment's state and not the query's failure."
+            ),
+            stats=stats,
+            census=census,
+        )
+    return PreconditionResult(
+        cloud=cloud,
+        outcome=OUTCOME_CLEAN,
+        detail=(
+            f"{stats.envelopes_seen} envelopes examined across {stats.rows_scanned} rows; "
+            f"all {stats.v2_envelopes} are v2."
+        ),
+        stats=stats,
+        census=census,
+    )
+
+
+def attestation_for(
+    result: PreconditionResult,
+    *,
+    backend: str,
+    operator: str,
+    note: str = "",
+    recorded_at: str | None = None,
+) -> Attestation:
+    """Turn a passing precondition run into a ledger entry.
+
+    Refuses non-passing outcomes here rather than only at write time, so that
+    no caller can construct a green-looking Attestation from a zero scan and
+    then hand it to something less careful than `record_attestation`.
+    """
+    if not result.passed:
+        raise ValueError(
+            f"outcome {result.outcome!r} does not attest zero v1 envelopes: {result.detail}"
+        )
+    return Attestation(
+        cloud=result.cloud,
+        outcome=result.outcome,
+        recorded_at=utc_now() if recorded_at is None else recorded_at,
+        backend=backend,
+        surface_fingerprint=surface_fingerprint(),
+        rows_scanned=result.stats.rows_scanned,
+        rows_scanned_by_kind=dict(result.stats.rows_scanned_by_kind),
+        envelopes_seen=result.stats.envelopes_seen,
+        v1_envelopes=result.stats.v1_envelopes,
+        v2_envelopes=result.stats.v2_envelopes,
+        census_migrated_kind_counts=dict(result.census.migrated_kind_counts),
+        census_sampled_kinds=list(result.census.sampled_kinds),
+        operator=operator,
+        note=note,
+    )

--- a/src/trusted_router/byok_v1_attestations.py
+++ b/src/trusted_router/byok_v1_attestations.py
@@ -85,12 +85,12 @@ THE NEAR-MISS THIS ENCODES
                            not classify. **Never a pass.**
 
     The literal census is what makes the last two of those reachable. An
-    earlier revision of this module derived both the scan's WHERE clause and
-    the census's WHERE clause from `MIGRATED_KINDS`, and read envelopes only
-    out of the field names in `MIGRATED_SURFACES` — so a renamed entity kind or
-    a renamed body field hid the same rows from both halves and produced a
-    corroborated-looking `empty_witnessed` over live v1 envelopes. The literal
-    search assumes neither.
+    earlier revision of this module restricted both the scan's WHERE clause and
+    the census's WHERE clause to the same migrated kind list, and read
+    envelopes only out of the field names in `MIGRATED_SURFACES` — so a renamed
+    entity kind or a renamed body field hid the same rows from both halves and
+    produced a corroborated-looking `empty_witnessed` over live v1 envelopes.
+    The literal search assumes neither.
 
 SCOPE LIMIT — what a full ledger does NOT establish
     * It does not prove the enclave side is ready. `quill-cloud-proxy` has its
@@ -99,10 +99,41 @@ SCOPE LIMIT — what a full ledger does NOT establish
       credential pointed at some other project's `tr_entities` — one that is
       reachable, non-empty, and holds no v1 envelope — produces a genuine
       `empty_witnessed`. Nothing offline can close that. What is done instead
-      is to record `census_source`, the server's own description of the
-      database it answered from, in the attestation, so the mismatch is
-      visible to a reviewer rather than invisible. Compare it against the
-      cloud the entry claims.
+      is to record `census_source` — which database the census was taken from
+      — in the attestation, so the mismatch is visible to a reviewer rather
+      than invisible. Compare it against the cloud the entry claims.
+
+      Read that field knowing how each adapter obtains it, because they are
+      not equally strong. `PostgresEntityStore` asks the server
+      (`current_database()`, `current_user`, `inet_server_addr()`), so its
+      value is the server's own answer. `SpannerEntityStore` does not: it
+      composes the name client-side out of the `--project`,
+      `--spanner-instance` and `--spanner-database` the CLI was given —
+      `Database.name` is `Instance.name + "/databases/" + database_id` and
+      issues no RPC — so it records the database that was ADDRESSED and would
+      read identically against a local emulator. Its value says so in the
+      string.
+      GCP is the Spanner deployment and the home plane every cloud fails over
+      to, so this is the weaker half exactly where it matters most; treat a
+      GCP `census_source` as a restatement of the operator's arguments, not as
+      evidence, and corroborate it against the run's own environment.
+    * **A row that only mentions the v1 literal blocks the cloud.**
+      `census_v1_literal_rows` counts rows whose body TEXT contains
+      `TR-BYOK-ENVELOPE-AES-256-GCM-V1` — any row, any kind, any field. A
+      captured upstream error string or a stored audit line containing that
+      name is counted, produces `scan_disagrees_with_census`, and keeps the
+      cloud unattestable until someone removes or rewrites the row. This is
+      fail-closed and the outcome message says where to look, but it is a real
+      way for a deployment holding no v1 envelope to be unable to attest. The
+      match is deliberately not narrowed to a JSON-shaped one
+      (`"algorithm":"TR-…"`), because the two backends do not render the same
+      bytes: Spanner stores `body` as a STRING written by
+      `storage_codec.json_body`, `separators=(",", ":")`, so there is no space
+      after the colon; Postgres stores `body` as JSONB
+      (`storage_postgres_schema.sql:4`) and `::text` re-renders it with one. A
+      pattern tuned to either one silently stops matching on the other, and a
+      literal search that stops matching fails OPEN — the one direction this
+      module must never fail in.
     * The census is issued through the same store object as the scan, so it
       shares the table name. It does NOT prove `tr_entities` is where envelopes
       actually live, and it cannot see a surface that no code path here knows
@@ -280,8 +311,10 @@ class Attestation:
     #: found without a kind filter and without assuming a body field name. The
     #: one count in here that is not downstream of `MIGRATED_SURFACES`.
     census_v1_literal_rows: int
-    #: The server's own description of the database that answered. Not proof of
-    #: the right deployment; the thing a reviewer compares against `cloud`.
+    #: Which database the census was taken from: the server's own answer on
+    #: Postgres, the database the CLI was pointed at on Spanner (the string
+    #: says which). Not proof of the right deployment; the thing a reviewer
+    #: compares against `cloud`. See SCOPE LIMIT in the module docstring.
     census_source: str
     operator: str
     note: str = ""
@@ -452,7 +485,7 @@ def ledger_defects(ledger: dict[str, Any]) -> list[str]:
         if not isinstance(entry["census_source"], str) or not entry["census_source"].strip():
             defects.append(
                 f"{cloud}: attestation has no census_source, so nobody can check which "
-                "database answered"
+                "database was read"
             )
     return defects
 

--- a/src/trusted_router/byok_v1_attestations.py
+++ b/src/trusted_router/byok_v1_attestations.py
@@ -1,4 +1,4 @@
-"""Per-cloud, machine-checkable evidence that no v1 BYOK envelope remains.
+"""Fleet-wide, machine-checkable evidence that no v1 BYOK envelope remains.
 
 THE LAW
     Step 4 of `docs/design/byok-aad-v2-migration.md` — deleting v1 envelope
@@ -8,6 +8,41 @@ THE LAW
 
     Nothing here removes v1. This module is the precondition and the record;
     `tests/test_byok_v1_removal_gate.py` is the thing that refuses.
+
+WHY EVERY CLOUD, AND NOT EACH CLOUD ON ITS OWN
+    Each cloud is a standalone TrustedRouter with its own database, so each one
+    needs its own run. That much was always in the plan. What was written down
+    wrongly — §4.0 point 1 of the migration doc said a v2 envelope written by
+    one cloud's control plane "never reaches another cloud's enclave" — is that
+    the deployments are *isolated*. They are not. Verified 2026-08-15 in
+    `quill-cloud-proxy`:
+
+      tools/deploy-aws-nitro.sh:888
+        QUILL_TR_CONTROL_PLANE_BASE_URL=https://aws.trustedrouter.com/v1,
+                                        https://trustedrouter.com/v1
+      tools/deploy-azure-aci.sh:269
+        TR_CONTROL_PLANE_BASE_URL=https://azure.trustedrouter.com/v1,
+                                  https://trustedrouter.com/v1
+      tools/deploy-gcp-mig.sh:208
+        TR_CONTROL_PLANE_BASE_URL=https://trustedrouter.com
+      enclave-go/internal/trustedrouter/client.go:41-44, 789-826
+        "baseURLs is ordered: index 0 is this cloud's OWN control plane, later
+         entries are fallbacks used only when an earlier one cannot be dialled."
+        `postToFirstDialable` walks that list, and `Authorization` carries
+        `byok_encrypted_secret` (client.go:216) — so the envelope an enclave
+        decrypts comes from whichever control plane answered.
+
+    So an AWS or Azure enclave whose own control plane cannot be dialled falls
+    over to the home (GCP) plane and is handed envelopes out of the GCP
+    database. Dropping v1 read support on one cloud while another cloud still
+    stores v1 envelopes therefore breaks BYOK on that cloud **during an
+    outage** — the worst possible moment and the hardest to attribute.
+
+    `ENCLAVE_CONTROL_PLANE_SOURCES` below records that topology, and the set of
+    clouds that must attest is derived from it rather than asserted. Today the
+    union is all three, which is why the requirement looks the same as before;
+    it now has the right reason underneath it, and adding a fourth deployment
+    with its own fallback list changes the requirement automatically.
 
 WHY THIS EXISTS AS A LEDGER AND NOT AS A SENTENCE
     Until now the only artifact standing between an engineer and permanently
@@ -29,25 +64,47 @@ THE NEAR-MISS THIS ENCODES
     the credentials were wrong renders exactly like a deployment with no BYOK
     customers. So the outcomes here are deliberately not a boolean:
 
-    * `clean`            — envelopes were seen and every one of them was v2.
-    * `empty_witnessed`  — no envelopes were seen, AND an independently shaped
-                           census of the same table proved it was reachable,
-                           non-empty, and held zero rows of the migrated kinds.
+    * `clean`            — envelopes were seen, every one of them was v2, and
+                           no row anywhere in the table carries the v1
+                           algorithm literal.
+    * `empty_witnessed`  — no envelope of any format was seen, the census
+                           proved the table was reachable and non-empty, and a
+                           search that shares neither the scan's kind filter
+                           nor its field-name map found no row anywhere in the
+                           table carrying the v1 algorithm literal.
     * `zero_scan`        — no envelopes were seen and nothing corroborates that
                            the scan could have seen any. **Never a pass, never
                            recordable.** This is the AWS/Azure shape.
     * `scan_disagrees_with_census` — the census counted rows of a migrated kind
-                           that the scan did not return. Bad cursor, bad
-                           filter, or a mid-run delete. **Never a pass.**
+                           that the scan did not return, or counted rows
+                           carrying the v1 literal that the scan did not
+                           classify as v1. Bad cursor, bad kind filter, a
+                           renamed body field, or a mid-run delete. **Never a
+                           pass.**
     * `v1_remains`, `dirty` — the audit found v1 rows, or found rows it could
                            not classify. **Never a pass.**
+
+    The literal census is what makes the last two of those reachable. An
+    earlier revision of this module derived both the scan's WHERE clause and
+    the census's WHERE clause from `MIGRATED_KINDS`, and read envelopes only
+    out of the field names in `MIGRATED_SURFACES` — so a renamed entity kind or
+    a renamed body field hid the same rows from both halves and produced a
+    corroborated-looking `empty_witnessed` over live v1 envelopes. The literal
+    search assumes neither.
 
 SCOPE LIMIT — what a full ledger does NOT establish
     * It does not prove the enclave side is ready. `quill-cloud-proxy` has its
       own v1 branch and its own removal decision; this repo cannot see it.
+    * **It cannot tell a right database from a wrong-but-populated one.** A
+      credential pointed at some other project's `tr_entities` — one that is
+      reachable, non-empty, and holds no v1 envelope — produces a genuine
+      `empty_witnessed`. Nothing offline can close that. What is done instead
+      is to record `census_source`, the server's own description of the
+      database it answered from, in the attestation, so the mismatch is
+      visible to a reviewer rather than invisible. Compare it against the
+      cloud the entry claims.
     * The census is issued through the same store object as the scan, so it
-      shares the table name. It corroborates reachability, credentials, and the
-      scan's cursor/filter — it does NOT prove `tr_entities` is where envelopes
+      shares the table name. It does NOT prove `tr_entities` is where envelopes
       actually live, and it cannot see a surface that no code path here knows
       about (open question #2 in the migration doc). The fingerprint below is
       the partial answer: adding a surface invalidates every attestation.
@@ -76,6 +133,54 @@ from typing import Any
 #: tuple exists to make impossible.
 STANDALONE_CLOUDS: tuple[str, ...] = ("aws", "azure", "gcp")
 
+#: For each cloud's ENCLAVE, the clouds whose control plane — and therefore
+#: whose database — can serve it a BYOK envelope. Index 0 is the cloud's own
+#: plane; later entries are dial-failure fallbacks. `"gcp"` is the home plane at
+#: `https://trustedrouter.com`, which is the deployment the GCP enclave is
+#: pointed at by `tools/deploy-gcp-mig.sh:208`.
+#:
+#: Transcribed by hand from `quill-cloud-proxy` on 2026-08-15; the citations are
+#: in this module's docstring. **Nothing here re-reads that repository**, so
+#: this dict is a claim about a build that was deployed, not a measurement of
+#: the one running now. If a deploy script's list changes, this changes with it
+#: or the requirement below is wrong.
+#:
+#: The point of writing it down is that it is the reason step 4 is a fleet-wide
+#: decision rather than three independent ones: a cloud that drops v1 reads can
+#: still be handed a v1 envelope out of a *different* cloud's database the next
+#: time its own control plane is undialable.
+ENCLAVE_CONTROL_PLANE_SOURCES: dict[str, tuple[str, ...]] = {
+    "aws": ("aws", "gcp"),
+    "azure": ("azure", "gcp"),
+    "gcp": ("gcp",),
+}
+
+
+def clouds_that_must_attest() -> tuple[str, ...]:
+    """Every cloud whose stored envelopes can reach *some* cloud's enclave.
+
+    The union of `STANDALONE_CLOUDS` and every entry in
+    `ENCLAVE_CONTROL_PLANE_SOURCES` — both directions, so that neither table
+    can weaken the requirement by omission. "All three" is a consequence of the
+    failover topology rather than an axiom: v1 support is one codebase deployed
+    everywhere, and the enclaves cross-read, so the removal is permitted only
+    when every database any enclave can be served from is clear.
+
+    Today this returns exactly `STANDALONE_CLOUDS`. A deployment added to
+    either table alone is still required, which is the safe direction; the
+    unsafe direction — a fourth cloud that reaches nobody's tables — is why the
+    union includes `STANDALONE_CLOUDS` outright.
+    """
+    required = set(STANDALONE_CLOUDS)
+    required.update(ENCLAVE_CONTROL_PLANE_SOURCES)
+    required.update(
+        cloud for sources in ENCLAVE_CONTROL_PLANE_SOURCES.values() for cloud in sources
+    )
+    return tuple(cloud for cloud in STANDALONE_CLOUDS if cloud in required) + tuple(
+        sorted(cloud for cloud in required if cloud not in STANDALONE_CLOUDS)
+    )
+
+
 #: Every encrypted surface the backfill knows how to walk: (entity kind, body
 #: field, AAD namespace family). This is the single source of truth — the
 #: backfill's field map is derived from it — so adding a fourth surface here
@@ -92,7 +197,20 @@ MIGRATED_KINDS: tuple[str, ...] = tuple(
     sorted({kind for kind, _field, _family in MIGRATED_SURFACES})
 )
 
-SCHEMA = "trustedrouter/byok-aad-v1-zero-attestation/v1"
+#: The v1 `algorithm` value as it is written into stored envelope bodies.
+#:
+#: Pinned here rather than imported from `byok_crypto.ALGORITHM` on purpose.
+#: The census below searches row bodies for this string, and it has to keep
+#: working in the tree where step 4 has deleted that constant — a precondition
+#: that stops being expressible the moment someone starts the edit it guards is
+#: not a precondition. `tests/test_byok_v1_precondition.py` asserts the two are
+#: equal while both exist.
+V1_ALGORITHM_LITERAL = "TR-BYOK-ENVELOPE-AES-256-GCM-V1"
+
+#: v2: `census_v1_literal_rows` and `census_source` became required, because a
+#: v1 attestation could be earned without either. Entries written under v1 are
+#: not upgradable — the runs behind them never asked those questions.
+SCHEMA = "trustedrouter/byok-aad-v1-zero-attestation/v2"
 
 OUTCOME_CLEAN = "clean"
 OUTCOME_EMPTY_WITNESSED = "empty_witnessed"
@@ -155,8 +273,16 @@ class Attestation:
     envelopes_seen: int
     v1_envelopes: int
     v2_envelopes: int
+    missing_envelopes: int
     census_migrated_kind_counts: dict[str, int]
     census_sampled_kinds: list[str]
+    #: Rows anywhere in the table whose body carries `V1_ALGORITHM_LITERAL`,
+    #: found without a kind filter and without assuming a body field name. The
+    #: one count in here that is not downstream of `MIGRATED_SURFACES`.
+    census_v1_literal_rows: int
+    #: The server's own description of the database that answered. Not proof of
+    #: the right deployment; the thing a reviewer compares against `cloud`.
+    census_source: str
     operator: str
     note: str = ""
 
@@ -172,8 +298,11 @@ class Attestation:
             "envelopes_seen": self.envelopes_seen,
             "v1_envelopes": self.v1_envelopes,
             "v2_envelopes": self.v2_envelopes,
+            "missing_envelopes": self.missing_envelopes,
             "census_migrated_kind_counts": dict(sorted(self.census_migrated_kind_counts.items())),
             "census_sampled_kinds": sorted(self.census_sampled_kinds),
+            "census_v1_literal_rows": self.census_v1_literal_rows,
+            "census_source": self.census_source,
             "operator": self.operator,
             "note": self.note,
         }
@@ -190,9 +319,24 @@ _REQUIRED_FIELDS = (
     "envelopes_seen",
     "v1_envelopes",
     "v2_envelopes",
+    "missing_envelopes",
     "census_migrated_kind_counts",
     "census_sampled_kinds",
+    "census_v1_literal_rows",
+    "census_source",
     "operator",
+)
+
+#: Fields a hand-edited entry could weaken by writing the right-looking value
+#: at the wrong type: `not "0"` is False, so a string count reads as non-zero
+#: and a string zero reads as present. Cheap to check, so checked.
+_INT_FIELDS = (
+    "rows_scanned",
+    "envelopes_seen",
+    "v1_envelopes",
+    "v2_envelopes",
+    "missing_envelopes",
+    "census_v1_literal_rows",
 )
 
 
@@ -202,9 +346,12 @@ def empty_ledger() -> dict[str, Any]:
         "about": (
             "Recorded output of scripts/check_no_v1_envelopes.py, one entry per standalone "
             "cloud. Read by tests/test_byok_v1_removal_gate.py, which refuses the removal of "
-            "v1 BYOK envelope support until every cloud here attests zero v1 envelopes. An "
-            "entry asserts that a run happened against that cloud's database; writing one by "
-            "hand asserts a run that did not. The gate can check the shape, not the truth."
+            "v1 BYOK envelope support until EVERY cloud here attests zero v1 envelopes. It is "
+            "one fleet-wide verdict, not three: an AWS or Azure enclave falls over to the home "
+            "control plane when its own cannot be dialled, so a v1 envelope in any cloud's "
+            "database can be handed to any cloud's enclave. An entry asserts that a run "
+            "happened against that cloud's database; writing one by hand asserts a run that "
+            "did not. The gate can check the shape, not the truth."
         ),
         "attestations": {},
     }
@@ -253,6 +400,14 @@ def ledger_defects(ledger: dict[str, Any]) -> list[str]:
         if missing:
             defects.append(f"{cloud}: attestation is missing {', '.join(missing)}")
             continue
+        mistyped = [
+            name
+            for name in _INT_FIELDS
+            if not isinstance(entry[name], int) or isinstance(entry[name], bool)
+        ]
+        if mistyped:
+            defects.append(f"{cloud}: these counts are not integers: {', '.join(mistyped)}")
+            continue
         if entry["cloud"] != cloud:
             defects.append(f"{cloud}: attestation records cloud={entry['cloud']!r}")
         if entry["outcome"] not in ALL_OUTCOMES:
@@ -271,17 +426,46 @@ def ledger_defects(ledger: dict[str, Any]) -> list[str]:
             )
         if entry["outcome"] == OUTCOME_CLEAN and not entry["envelopes_seen"]:
             defects.append(f"{cloud}: outcome 'clean' with envelopes_seen=0 is self-contradictory")
-        if entry["outcome"] == OUTCOME_EMPTY_WITNESSED and not entry["census_sampled_kinds"]:
-            defects.append(
-                f"{cloud}: outcome 'empty_witnessed' with no census witness is a zero scan"
-            )
+        if entry["outcome"] == OUTCOME_EMPTY_WITNESSED:
+            if not entry["census_sampled_kinds"]:
+                defects.append(
+                    f"{cloud}: outcome 'empty_witnessed' with no census witness is a zero scan"
+                )
+            if entry["envelopes_seen"]:
+                defects.append(
+                    f"{cloud}: outcome 'empty_witnessed' with "
+                    f"envelopes_seen={entry['envelopes_seen']} is self-contradictory"
+                )
         if entry["v1_envelopes"]:
             defects.append(f"{cloud}: attestation records v1_envelopes={entry['v1_envelopes']}")
+        # The structural half of the run-time check. A passing run that saw no
+        # v1 envelope while the literal census could see rows carrying the v1
+        # marker is the renamed-kind / renamed-field case: the scan was blind,
+        # not the deployment empty. check_no_v1_envelopes refuses to produce
+        # this; the reader has to catch what a hand edit could still write.
+        if entry["census_v1_literal_rows"]:
+            defects.append(
+                f"{cloud}: attestation records census_v1_literal_rows="
+                f"{entry['census_v1_literal_rows']} — rows carrying the v1 algorithm literal "
+                "were counted in the table, so this run did not establish zero v1"
+            )
+        if not isinstance(entry["census_source"], str) or not entry["census_source"].strip():
+            defects.append(
+                f"{cloud}: attestation has no census_source, so nobody can check which "
+                "database answered"
+            )
     return defects
 
 
 def zero_v1_blockers(ledger: dict[str, Any]) -> list[str]:
     """Why step 4 may not proceed yet. Empty list means every cloud attests zero v1.
+
+    The required set comes from `clouds_that_must_attest()`, i.e. from the
+    enclave failover topology, so this is a single fleet-wide verdict and never
+    a per-cloud one. There is deliberately no "is cloud X clear?" function to
+    call by mistake: an AWS enclave that has dropped v1 reads is broken by a v1
+    envelope sitting in the GCP database, so "AWS is clear" is not a claim that
+    authorises anything on its own.
 
     Returns sentences rather than a set of clouds because the caller is a CI
     failure message, and "aws" on its own tells the reader nothing about what
@@ -291,7 +475,7 @@ def zero_v1_blockers(ledger: dict[str, Any]) -> list[str]:
     attestations = ledger.get("attestations")
     if not isinstance(attestations, dict):
         attestations = {}
-    for cloud in STANDALONE_CLOUDS:
+    for cloud in clouds_that_must_attest():
         entry = attestations.get(cloud)
         if not isinstance(entry, dict) or "outcome" not in entry:
             blockers.append(
@@ -331,6 +515,14 @@ def record_attestation(
         )
     if attestation.surface_fingerprint != surface_fingerprint():
         raise ValueError("refusing to record an attestation for a different set of surfaces")
+    if attestation.census_v1_literal_rows:
+        raise ValueError(
+            f"refusing to record a pass with census_v1_literal_rows="
+            f"{attestation.census_v1_literal_rows}: rows carrying the v1 algorithm literal were "
+            "counted in that table"
+        )
+    if not attestation.census_source.strip():
+        raise ValueError("refusing to record an attestation that does not name the database read")
     target = DEFAULT_LEDGER_PATH if path is None else path
     current = load_ledger(target) if ledger is None else ledger
     if current.get("schema") != SCHEMA:

--- a/src/trusted_router/byok_v1_attestations.py
+++ b/src/trusted_router/byok_v1_attestations.py
@@ -1,0 +1,352 @@
+"""Per-cloud, machine-checkable evidence that no v1 BYOK envelope remains.
+
+THE LAW
+    Step 4 of `docs/design/byok-aad-v2-migration.md` — deleting v1 envelope
+    support — is permitted only when **every** standalone cloud deployment has
+    a recorded, *passing* zero-v1 attestation whose surface fingerprint equals
+    the set of encrypted surfaces this repository writes today.
+
+    Nothing here removes v1. This module is the precondition and the record;
+    `tests/test_byok_v1_removal_gate.py` is the thing that refuses.
+
+WHY THIS EXISTS AS A LEDGER AND NOT AS A SENTENCE
+    Until now the only artifact standing between an engineer and permanently
+    unreadable customer BYOK keys was a table cell in a markdown file. Step 4
+    is the one irreversible step in the plan: once `_aad`/`ALGORITHM` are gone
+    from the control plane and the enclave, a surviving v1 row is not a bug
+    that can be rolled back — the plaintext provider key is gone, because the
+    AAD that seals both the ciphertext and the wrapped DEK cannot be
+    reconstructed from a format nobody implements any more. A markdown claim is
+    not a precondition. A file that a test reads is.
+
+THE NEAR-MISS THIS ENCODES
+    As of 2026-08-15 the migration doc renders step 3 as a green check on all
+    three clouds. Two of those three checks are a *read-only audit that found
+    no rows to rewrite* — AWS and Azure. "No rows existed" and "the backfill
+    ran and finished" are different sentences with very different failure
+    modes, and they were rendering identically. In particular, a run that
+    returns nothing because the cursor was wrong, the table name was wrong, or
+    the credentials were wrong renders exactly like a deployment with no BYOK
+    customers. So the outcomes here are deliberately not a boolean:
+
+    * `clean`            — envelopes were seen and every one of them was v2.
+    * `empty_witnessed`  — no envelopes were seen, AND an independently shaped
+                           census of the same table proved it was reachable,
+                           non-empty, and held zero rows of the migrated kinds.
+    * `zero_scan`        — no envelopes were seen and nothing corroborates that
+                           the scan could have seen any. **Never a pass, never
+                           recordable.** This is the AWS/Azure shape.
+    * `scan_disagrees_with_census` — the census counted rows of a migrated kind
+                           that the scan did not return. Bad cursor, bad
+                           filter, or a mid-run delete. **Never a pass.**
+    * `v1_remains`, `dirty` — the audit found v1 rows, or found rows it could
+                           not classify. **Never a pass.**
+
+SCOPE LIMIT — what a full ledger does NOT establish
+    * It does not prove the enclave side is ready. `quill-cloud-proxy` has its
+      own v1 branch and its own removal decision; this repo cannot see it.
+    * The census is issued through the same store object as the scan, so it
+      shares the table name. It corroborates reachability, credentials, and the
+      scan's cursor/filter — it does NOT prove `tr_entities` is where envelopes
+      actually live, and it cannot see a surface that no code path here knows
+      about (open question #2 in the migration doc). The fingerprint below is
+      the partial answer: adding a surface invalidates every attestation.
+    * An attestation is a statement about one moment. It does not prevent a v1
+      envelope from being written afterwards — nothing writes v1 any more, but
+      that is a property of the code, not of this file.
+    * `empty_witnessed` is the weaker of the two passes and is recorded under
+      its own name precisely so that a reviewer can see which clouds were
+      attested by observation and which by absence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+#: The standalone deployments. Each is its own TrustedRouter with its own
+#: database — see docs/storage-portability/multi-cloud-separation.md — so each
+#: has its own BYOK envelopes and needs its own attestation. Attesting the one
+#: cloud you happened to have credentials for is exactly the mistake this
+#: tuple exists to make impossible.
+STANDALONE_CLOUDS: tuple[str, ...] = ("aws", "azure", "gcp")
+
+#: Every encrypted surface the backfill knows how to walk: (entity kind, body
+#: field, AAD namespace family). This is the single source of truth — the
+#: backfill's field map is derived from it — so adding a fourth surface here
+#: changes `surface_fingerprint()` and thereby invalidates every recorded
+#: attestation, which is the intended behaviour: the old runs did not look at
+#: the new surface.
+MIGRATED_SURFACES: tuple[tuple[str, str, str], ...] = (
+    ("broadcast_destination", "encrypted_api_key", "control"),
+    ("broadcast_destination", "encrypted_headers", "control"),
+    ("byok", "encrypted_secret", "provider"),
+)
+
+MIGRATED_KINDS: tuple[str, ...] = tuple(
+    sorted({kind for kind, _field, _family in MIGRATED_SURFACES})
+)
+
+SCHEMA = "trustedrouter/byok-aad-v1-zero-attestation/v1"
+
+OUTCOME_CLEAN = "clean"
+OUTCOME_EMPTY_WITNESSED = "empty_witnessed"
+OUTCOME_V1_REMAINS = "v1_remains"
+OUTCOME_ZERO_SCAN = "zero_scan"
+OUTCOME_SCAN_DISAGREES = "scan_disagrees_with_census"
+OUTCOME_DIRTY = "dirty"
+
+#: The only two outcomes that attest "no v1 envelope remains on this cloud".
+PASSING_OUTCOMES = frozenset({OUTCOME_CLEAN, OUTCOME_EMPTY_WITNESSED})
+
+ALL_OUTCOMES = frozenset(
+    {
+        OUTCOME_CLEAN,
+        OUTCOME_EMPTY_WITNESSED,
+        OUTCOME_V1_REMAINS,
+        OUTCOME_ZERO_SCAN,
+        OUTCOME_SCAN_DISAGREES,
+        OUTCOME_DIRTY,
+    }
+)
+
+#: Committed next to the migration plan it makes executable. Absent in a
+#: deployed wheel, where `load_ledger` returns the empty ledger — this is
+#: operator and CI tooling, not request-path code.
+DEFAULT_LEDGER_PATH = (
+    Path(__file__).resolve().parents[2] / "docs" / "design" / "byok-aad-v2-attestations.json"
+)
+
+
+def surface_fingerprint() -> str:
+    """Stable digest of the encrypted surfaces an attestation must have covered.
+
+    Recorded inside every attestation and re-checked when the ledger is read,
+    so that an attestation taken before a new encrypted surface existed cannot
+    silently authorise deleting v1 for a surface it never walked.
+    """
+    digest = hashlib.sha256()
+    for kind, field_name, family in sorted(MIGRATED_SURFACES):
+        digest.update(f"{kind}\x00{field_name}\x00{family}\x00".encode())
+    return digest.hexdigest()[:16]
+
+
+@dataclass(frozen=True)
+class Attestation:
+    """One cloud's zero-v1 evidence, as recorded by check_no_v1_envelopes.py.
+
+    Every count the audit produced is kept, not just the verdict. The verdict
+    is the cheap part; the counts are what lets a reviewer six months later ask
+    "did this run actually look at anything?" without re-running it.
+    """
+
+    cloud: str
+    outcome: str
+    recorded_at: str
+    backend: str
+    surface_fingerprint: str
+    rows_scanned: int
+    rows_scanned_by_kind: dict[str, int]
+    envelopes_seen: int
+    v1_envelopes: int
+    v2_envelopes: int
+    census_migrated_kind_counts: dict[str, int]
+    census_sampled_kinds: list[str]
+    operator: str
+    note: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "cloud": self.cloud,
+            "outcome": self.outcome,
+            "recorded_at": self.recorded_at,
+            "backend": self.backend,
+            "surface_fingerprint": self.surface_fingerprint,
+            "rows_scanned": self.rows_scanned,
+            "rows_scanned_by_kind": dict(sorted(self.rows_scanned_by_kind.items())),
+            "envelopes_seen": self.envelopes_seen,
+            "v1_envelopes": self.v1_envelopes,
+            "v2_envelopes": self.v2_envelopes,
+            "census_migrated_kind_counts": dict(sorted(self.census_migrated_kind_counts.items())),
+            "census_sampled_kinds": sorted(self.census_sampled_kinds),
+            "operator": self.operator,
+            "note": self.note,
+        }
+
+
+_REQUIRED_FIELDS = (
+    "cloud",
+    "outcome",
+    "recorded_at",
+    "backend",
+    "surface_fingerprint",
+    "rows_scanned",
+    "rows_scanned_by_kind",
+    "envelopes_seen",
+    "v1_envelopes",
+    "v2_envelopes",
+    "census_migrated_kind_counts",
+    "census_sampled_kinds",
+    "operator",
+)
+
+
+def empty_ledger() -> dict[str, Any]:
+    return {
+        "schema": SCHEMA,
+        "about": (
+            "Recorded output of scripts/check_no_v1_envelopes.py, one entry per standalone "
+            "cloud. Read by tests/test_byok_v1_removal_gate.py, which refuses the removal of "
+            "v1 BYOK envelope support until every cloud here attests zero v1 envelopes. An "
+            "entry asserts that a run happened against that cloud's database; writing one by "
+            "hand asserts a run that did not. The gate can check the shape, not the truth."
+        ),
+        "attestations": {},
+    }
+
+
+def load_ledger(path: Path | None = None) -> dict[str, Any]:
+    """Read the committed ledger. A missing file is the empty ledger.
+
+    A missing file must read as "nothing is attested", never as "nothing
+    blocks": deleting the ledger is the cheapest way to fake a green gate, and
+    an empty ledger blocks every cloud.
+    """
+    target = DEFAULT_LEDGER_PATH if path is None else path
+    if not target.exists():
+        return empty_ledger()
+    loaded = json.loads(target.read_text())
+    if not isinstance(loaded, dict):
+        return {"schema": None, "attestations": {}, "unparsed": True}
+    return loaded
+
+
+def ledger_defects(ledger: dict[str, Any]) -> list[str]:
+    """Structural complaints about the ledger itself, in reviewer-readable form.
+
+    Separate from `zero_v1_blockers` because a malformed ledger is a different
+    problem from an incomplete one: the first means someone edited this file by
+    hand, the second means the work is not finished.
+    """
+    defects: list[str] = []
+    if ledger.get("schema") != SCHEMA:
+        defects.append(f"ledger schema is {ledger.get('schema')!r}, expected {SCHEMA!r}")
+    attestations = ledger.get("attestations")
+    if not isinstance(attestations, dict):
+        defects.append("ledger has no 'attestations' object")
+        return defects
+    fingerprint = surface_fingerprint()
+    for cloud in sorted(attestations):
+        entry = attestations[cloud]
+        if cloud not in STANDALONE_CLOUDS:
+            defects.append(f"{cloud}: not a known standalone cloud {STANDALONE_CLOUDS}")
+            continue
+        if not isinstance(entry, dict):
+            defects.append(f"{cloud}: attestation is not an object")
+            continue
+        missing = [name for name in _REQUIRED_FIELDS if name not in entry]
+        if missing:
+            defects.append(f"{cloud}: attestation is missing {', '.join(missing)}")
+            continue
+        if entry["cloud"] != cloud:
+            defects.append(f"{cloud}: attestation records cloud={entry['cloud']!r}")
+        if entry["outcome"] not in ALL_OUTCOMES:
+            defects.append(f"{cloud}: unknown outcome {entry['outcome']!r}")
+        elif entry["outcome"] not in PASSING_OUTCOMES:
+            # Recording a non-passing run is not "extra evidence", it is a
+            # green-looking row for a run that established nothing.
+            defects.append(
+                f"{cloud}: outcome {entry['outcome']!r} is not an attestation and must not be "
+                "recorded here"
+            )
+        if entry["surface_fingerprint"] != fingerprint:
+            defects.append(
+                f"{cloud}: attestation covers surfaces {entry['surface_fingerprint']} but this "
+                f"repository now writes {fingerprint} — re-run the precondition"
+            )
+        if entry["outcome"] == OUTCOME_CLEAN and not entry["envelopes_seen"]:
+            defects.append(f"{cloud}: outcome 'clean' with envelopes_seen=0 is self-contradictory")
+        if entry["outcome"] == OUTCOME_EMPTY_WITNESSED and not entry["census_sampled_kinds"]:
+            defects.append(
+                f"{cloud}: outcome 'empty_witnessed' with no census witness is a zero scan"
+            )
+        if entry["v1_envelopes"]:
+            defects.append(f"{cloud}: attestation records v1_envelopes={entry['v1_envelopes']}")
+    return defects
+
+
+def zero_v1_blockers(ledger: dict[str, Any]) -> list[str]:
+    """Why step 4 may not proceed yet. Empty list means every cloud attests zero v1.
+
+    Returns sentences rather than a set of clouds because the caller is a CI
+    failure message, and "aws" on its own tells the reader nothing about what
+    to run.
+    """
+    blockers = list(ledger_defects(ledger))
+    attestations = ledger.get("attestations")
+    if not isinstance(attestations, dict):
+        attestations = {}
+    for cloud in STANDALONE_CLOUDS:
+        entry = attestations.get(cloud)
+        if not isinstance(entry, dict) or "outcome" not in entry:
+            blockers.append(
+                f"{cloud}: no zero-v1 attestation recorded — run "
+                f"scripts/check_no_v1_envelopes.py --cloud {cloud} --record against that "
+                "deployment's database"
+            )
+            continue
+        if entry["outcome"] not in PASSING_OUTCOMES:
+            blockers.append(
+                f"{cloud}: recorded outcome {entry['outcome']!r} does not attest zero v1"
+            )
+    return blockers
+
+
+def record_attestation(
+    attestation: Attestation,
+    *,
+    path: Path | None = None,
+    ledger: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Write one cloud's attestation into the ledger, refusing anything unearned.
+
+    Fails closed on every input the gate would later have to reject: an unknown
+    cloud, a non-passing outcome, a stale surface fingerprint. The refusal
+    lives here as well as in the gate so that an operator finds out at the
+    moment of the run, not in someone else's CI three weeks later.
+    """
+    if attestation.cloud not in STANDALONE_CLOUDS:
+        raise ValueError(
+            f"unknown cloud {attestation.cloud!r}; expected one of {STANDALONE_CLOUDS}"
+        )
+    if attestation.outcome not in PASSING_OUTCOMES:
+        raise ValueError(
+            f"refusing to record outcome {attestation.outcome!r}: only "
+            f"{sorted(PASSING_OUTCOMES)} attest that no v1 envelope remains"
+        )
+    if attestation.surface_fingerprint != surface_fingerprint():
+        raise ValueError("refusing to record an attestation for a different set of surfaces")
+    target = DEFAULT_LEDGER_PATH if path is None else path
+    current = load_ledger(target) if ledger is None else ledger
+    if current.get("schema") != SCHEMA:
+        current = empty_ledger()
+    attestations = current.get("attestations")
+    if not isinstance(attestations, dict):
+        attestations = {}
+    attestations[attestation.cloud] = attestation.to_dict()
+    current["attestations"] = {
+        cloud: attestations[cloud] for cloud in STANDALONE_CLOUDS if cloud in attestations
+    }
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(current, indent=2, sort_keys=False) + "\n")
+    return current
+
+
+def utc_now(clock: Callable[[], datetime] | None = None) -> str:
+    now = datetime.now(UTC) if clock is None else clock()
+    return now.astimezone(UTC).isoformat(timespec="seconds")

--- a/tests/test_byok_envelope_registry_totality_property.py
+++ b/tests/test_byok_envelope_registry_totality_property.py
@@ -1,7 +1,7 @@
 """Proof that the BYOK AAD v2 backfill's envelope registry is total.
 
 `byok_aad_backfill` decides what to migrate from two hand-written tables:
-`_MIGRATED_KINDS` and `_fields_for_kind`. Between them they name three
+`MIGRATED_KINDS` and `_fields_for_kind`. Between them they name three
 locations — byok.encrypted_secret, broadcast_destination.encrypted_api_key and
 broadcast_destination.encrypted_headers — and tag each with the AAD namespace
 ("provider" or "control") its envelope was sealed under. The law:
@@ -94,7 +94,7 @@ disclose was itself a review finding:
 
 `ENVELOPE_ADAPTER_MODULES`, one more hand-maintained list, used to be here too:
 two file names, so the identical write-only-kind defect in storage_postgres.py
-was invisible. Review was right that this file criticised `_MIGRATED_KINDS` for
+was invisible. Review was right that this file criticised `MIGRATED_KINDS` for
 exactly that and then did it. It is gone — `envelope_adjacent_kinds` derives its
 own scope, package-wide — and what replaced it is pinned rather than trusted.
 
@@ -155,11 +155,11 @@ a proof, so unresolvable halves now surface as the `UNPLACED_KIND` /
 `UNSEALED_FAMILY` sentinels and read as locations the registry does not cover.
 
 Finding recorded here because it refutes the assumption this module started
-from — that `_MIGRATED_KINDS` is the one place a kind is listed. It is not, and
+from — that `MIGRATED_KINDS` is the one place a kind is listed. It is not, and
 neither entity store reads it as a set. `SpannerEntityStore.scan` hardcodes
 `kind IN ('broadcast_destination', 'byok')` into its SQL text and never
-references the registry; `PostgresEntityStore.scan` binds `_MIGRATED_KINDS[0],
-_MIGRATED_KINDS[1]` positionally against a two-placeholder IN list. Adding a
+references the registry; `PostgresEntityStore.scan` binds `MIGRATED_KINDS[0],
+MIGRATED_KINDS[1]` positionally against a two-placeholder IN list. Adding a
 third kind to the registry today updates neither scan, so the backfill would
 never fetch the rows it had just been taught to migrate, and would once again
 report clean. The two store tests below capture the statement each scan
@@ -267,7 +267,6 @@ import dataclasses
 import importlib
 import pathlib
 import pkgutil
-import re
 import sys
 import types
 import typing
@@ -278,9 +277,9 @@ import pytest
 
 import trusted_router
 from tests.test_byok_aad_backfill import MemoryEntityStore, _v1_envelope
+from trusted_router import byok_aad_backfill as backfill
 from trusted_router import byok_crypto, storage_models
 from trusted_router.byok_aad_backfill import (
-    _MIGRATED_KINDS,
     BackfillRunner,
     PostgresEntityStore,
     SpannerEntityStore,
@@ -294,6 +293,7 @@ from trusted_router.byok_crypto import (
     decrypt_byok_secret,
     decrypt_control_secret,
 )
+from trusted_router.byok_v1_attestations import MIGRATED_KINDS
 from trusted_router.config import Settings
 from trusted_router.services.broadcast import broadcast_secret_context
 from trusted_router.services.broadcast_adapters import _secret_context as adapter_secret_context
@@ -848,7 +848,7 @@ def envelope_adjacent_kinds(
 
     This replaces a hand-written two-entry list of adapter modules. Adversarial
     review was right that such a list is the same maintenance hazard the module
-    docstring criticises `_MIGRATED_KINDS` for, and proved it by putting the
+    docstring criticises `MIGRATED_KINDS` for, and proved it by putting the
     same defect in a third module the list did not name. The file scope is now
     derived and package-wide.
 
@@ -1028,7 +1028,7 @@ DERIVED_MODEL_FIELDS = envelope_fields(MODULES_BY_PATH.values())
 DERIVED_FIELD_NAMES = frozenset(name for fields in DERIVED_MODEL_FIELDS.values() for name in fields)
 DERIVED_KINDS = entity_kinds(SRC, frozenset(DERIVED_MODEL_FIELDS))
 DERIVED_FAMILIES = sealed_families(SRC, DERIVED_FIELD_NAMES)
-# Seeded with the DERIVED kinds, never with `_MIGRATED_KINDS`: a scope that
+# Seeded with the DERIVED kinds, never with `MIGRATED_KINDS`: a scope that
 # widens by reading the registry it audits would narrow again if a kind were
 # dropped from the registry, which is the direction that must never fail open.
 DERIVED_ADJACENT_KINDS, UNRESOLVABLE_KIND_CALL_SITES = envelope_adjacent_kinds(
@@ -1043,7 +1043,7 @@ DERIVED_ADJACENT_KINDS, UNRESOLVABLE_KIND_CALL_SITES = envelope_adjacent_kinds(
 def _registry_pairs() -> set[tuple[str, str, str]]:
     return {
         (kind, field, family)
-        for kind in _MIGRATED_KINDS
+        for kind in MIGRATED_KINDS
         for field, family in _fields_for_kind(kind)
     }
 
@@ -1081,25 +1081,33 @@ def _resolved_pairs() -> set[tuple[str, str, str]]:
 
 
 def _registry_kind_literals() -> set[str]:
-    """The kinds `_fields_for_kind` will answer for, read off its own source.
+    """The kinds `_fields_for_kind` will answer for, by CALLING it.
 
-    Calling it cannot enumerate them — it raises for everything else — so the
-    "no stale kind" direction needs the literals it compares against.
+    This read the function's source with an AST scan until `_fields_for_kind`
+    stopped comparing `kind` against inline string literals and started
+    deriving its answer from `MIGRATED_SURFACES`. The scan then found no
+    literals and reported that the registry answered for nothing, which is a
+    test measuring how a function is spelled rather than what it does.
+
+    Calling it cannot enumerate the whole universe — it raises for anything
+    unregistered — so the candidates are every kind this module already knows
+    about from another direction. A stale kind outside that set is not caught
+    here; that is what `test_every_kind_an_envelope_handling_function_names_is_registered_or_declared`
+    is for.
     """
-    source = pathlib.Path(trusted_router.__file__).parent / BACKFILL_MODULE
-    tree = ast.parse(source.read_text(), filename=str(source))
-    for node in ast.walk(tree):
-        if isinstance(node, ast.FunctionDef) and node.name == "_fields_for_kind":
-            return {
-                comparator.value
-                for compare in ast.walk(node)
-                if isinstance(compare, ast.Compare)
-                and isinstance(compare.left, ast.Name)
-                and compare.left.id == "kind"
-                for comparator in compare.comparators
-                if isinstance(comparator, ast.Constant) and isinstance(comparator.value, str)
-            }
-    raise AssertionError("_fields_for_kind is no longer a module-level function")
+    candidates = (
+        set(MIGRATED_KINDS)
+        | {kind for kinds in DERIVED_KINDS.values() for kind in kinds}
+        | set(NON_ENVELOPE_KINDS)
+    )
+    answered: set[str] = set()
+    for kind in sorted(candidates):
+        try:
+            if _fields_for_kind(kind):
+                answered.add(kind)
+        except ValueError:
+            continue
+    return answered
 
 
 # ---------------------------------------------------------------------------
@@ -1319,7 +1327,7 @@ def test_every_kind_an_envelope_handling_function_names_is_registered_or_declare
         "reaches it."
     )
     named = set(DERIVED_ADJACENT_KINDS)
-    unaccounted = sorted(named - set(_MIGRATED_KINDS) - set(NON_ENVELOPE_KINDS))
+    unaccounted = sorted(named - set(MIGRATED_KINDS) - set(NON_ENVELOPE_KINDS))
     assert not unaccounted, (
         f"envelope-handling code names kind(s) {unaccounted} that are neither in the "
         "backfill registry nor declared secret-free — at "
@@ -1429,19 +1437,19 @@ def test_the_registry_covers_every_envelope_location_exactly() -> None:
 def test_migrated_kinds_agrees_with_fields_for_kind_and_with_the_models() -> None:
     """The two hand-written tables must name the same kinds as each other.
 
-    They are independent literals: `_MIGRATED_KINDS` drives the Postgres scan,
+    They are independent literals: `MIGRATED_KINDS` drives the Postgres scan,
     `_fields_for_kind` drives what gets migrated. A kind in one and not the
     other is a scan that fetches rows nothing knows how to process, or a
     processor for rows nothing fetches.
     """
     derived = {kind for kinds in DERIVED_KINDS.values() for kind in kinds}
-    assert set(_MIGRATED_KINDS) == derived, (
-        f"_MIGRATED_KINDS is {sorted(_MIGRATED_KINDS)} but the storage dataclasses "
+    assert set(MIGRATED_KINDS) == derived, (
+        f"MIGRATED_KINDS is {sorted(MIGRATED_KINDS)} but the storage dataclasses "
         f"live under {sorted(derived)}"
     )
-    assert _registry_kind_literals() == set(_MIGRATED_KINDS), (
+    assert _registry_kind_literals() == set(MIGRATED_KINDS), (
         f"_fields_for_kind answers for {sorted(_registry_kind_literals())} but "
-        f"_MIGRATED_KINDS lists {sorted(_MIGRATED_KINDS)}"
+        f"MIGRATED_KINDS lists {sorted(MIGRATED_KINDS)}"
     )
 
 
@@ -1594,6 +1602,10 @@ class _FakeParamTypes:
     STRING = "STRING"
     INT64 = "INT64"
 
+    @staticmethod
+    def Array(inner: str) -> str:  # noqa: N802 - mirrors the Spanner param_types API
+        return f"ARRAY<{inner}>"
+
 
 class _FakeCursor:
     def fetchall(self) -> list[Any]:
@@ -1616,33 +1628,30 @@ class _FakeConnection:
         return _FakeCursor()
 
 
-def _kind_in_clause(sql: str) -> str:
-    match = re.search(r"kind IN \(([^)]*)\)", sql)
-    assert match is not None, f"no `kind IN (...)` filter in the scan statement: {sql}"
-    return match.group(1)
+def _restricted_kinds(captured: dict[str, Any]) -> set[str]:
+    """The kinds a captured scan actually restricts to, whatever the dialect.
+
+    Read out of the BOUND PARAMETERS, not the SQL text. The two adapters spell
+    the same restriction differently — Spanner `kind IN UNNEST(@kinds)`,
+    Postgres `kind = ANY(%s)` — and an earlier version of these tests matched
+    `kind IN (...)` with a regex and counted its `%s` placeholders. That
+    version went red when the adapters were FIXED to read the registry, which
+    is the wrong direction for a test to fail in.
+    """
+    params = captured["params"]
+    if isinstance(params, dict):
+        return set(params["kinds"])
+    for value in params:
+        if isinstance(value, (list, tuple)) and value and all(isinstance(v, str) for v in value):
+            return set(value)
+    raise AssertionError(f"no bound kind collection in {params!r}")
 
 
-def test_the_spanner_scan_fetches_every_registered_kind() -> None:
-    """`SpannerEntityStore.scan` embeds its kind filter as SQL text and never
-    reads `_MIGRATED_KINDS`. Registering a kind without editing that literal
-    means the backfill never sees the rows — and reports clean, because a row
-    it never scanned cannot be counted as a v1 envelope."""
-    captured: dict[str, Any] = {}
+def _scan_spanner(captured: dict[str, Any]) -> None:
     SpannerEntityStore(_FakeSpannerDatabase(captured), _FakeParamTypes()).scan(after=None, limit=10)
 
-    filtered = set(re.findall(r"'([^']*)'", _kind_in_clause(captured["sql"])))
-    assert filtered == set(_MIGRATED_KINDS), (
-        f"the Spanner scan filters on {sorted(filtered)} but the registry covers "
-        f"{sorted(_MIGRATED_KINDS)}"
-    )
 
-
-def test_the_postgres_scan_binds_every_registered_kind() -> None:
-    """`PostgresEntityStore.scan` binds `_MIGRATED_KINDS[0], _MIGRATED_KINDS[1]`
-    positionally against a two-placeholder IN list. It is correct only because
-    the registry happens to hold exactly two kinds; a third would be dropped in
-    silence. This test is what makes that arity a checked property."""
-    captured: dict[str, Any] = {}
+def _scan_postgres(captured: dict[str, Any]) -> None:
     fake_psycopg = types.ModuleType("psycopg")
     fake_psycopg.connect = lambda _dsn: _FakeConnection(captured)  # type: ignore[attr-defined]
     original = sys.modules.get("psycopg")
@@ -1655,24 +1664,36 @@ def test_the_postgres_scan_binds_every_registered_kind() -> None:
         else:
             sys.modules["psycopg"] = original
 
-    sql = captured["sql"]
-    placeholders = _kind_in_clause(sql).count("%s")
-    assert placeholders == len(_MIGRATED_KINDS), (
-        f"the Postgres scan has {placeholders} kind placeholder(s) for a registry of "
-        f"{len(_MIGRATED_KINDS)} kind(s); the surplus kinds are never fetched"
-    )
-    # Positionally, not "somewhere in the tuple". The first draft asserted only
-    # that each registered kind appeared among the parameters, which adversarial
-    # review pointed out would still pass if the kinds were bound to the
-    # pagination placeholders and the IN list got the cursor values.
-    assert sql[: sql.index("kind IN (")].count("%s") == 0, (
-        "the kind IN clause is no longer the first bound group, so the parameter "
-        "positions checked below no longer line up with it"
-    )
-    bound = tuple(captured["params"][: len(_MIGRATED_KINDS)])
-    assert bound == tuple(_MIGRATED_KINDS), (
-        f"the Postgres scan binds {bound} into its kind filter, but the registry "
-        f"covers {tuple(_MIGRATED_KINDS)}"
+
+@pytest.mark.parametrize("scan", [_scan_spanner, _scan_postgres], ids=["spanner", "postgres"])
+def test_the_scan_fetches_exactly_the_registered_kinds(scan: Any) -> None:
+    captured: dict[str, Any] = {}
+    scan(captured)
+    assert _restricted_kinds(captured) == set(MIGRATED_KINDS)
+
+
+@pytest.mark.parametrize("scan", [_scan_spanner, _scan_postgres], ids=["spanner", "postgres"])
+def test_a_newly_registered_kind_is_actually_fetched(scan: Any, monkeypatch: Any) -> None:
+    """The finding this file was written for, as a live property.
+
+    Both adapters once derived their filter from something other than the
+    registry: Spanner embedded the two kinds as SQL text, Postgres bound
+    `MIGRATED_KINDS[0], MIGRATED_KINDS[1]` positionally against a
+    two-placeholder list. Registering a third kind would have left both
+    fetching the old two, and the backfill would have reported clean over rows
+    it never scanned — correct only by arity coincidence.
+
+    Asserting today's two kinds cannot see that, because today there are
+    exactly two. Adding a third and requiring it to be fetched can.
+    """
+    widened = (*MIGRATED_KINDS, "totality_probe_kind")
+    monkeypatch.setattr(backfill, "MIGRATED_KINDS", widened, raising=True)
+
+    captured: dict[str, Any] = {}
+    scan(captured)
+    assert "totality_probe_kind" in _restricted_kinds(captured), (
+        "a kind added to the registry is not fetched by this scan; the filter is "
+        "derived from something other than MIGRATED_KINDS"
     )
 
 

--- a/tests/test_byok_v1_precondition.py
+++ b/tests/test_byok_v1_precondition.py
@@ -53,8 +53,20 @@ SCOPE LIMIT — what these tests do NOT establish
       at some other project's `tr_entities`: it is reachable, non-empty, and
       holds no v1 envelope, which is exactly what success looks like. Nothing
       offline distinguishes them. What the run does instead is record
-      `census_source` — the server's own answer to "which database am I?" — so
-      a reviewer can compare it against the cloud the entry claims.
+      `census_source` — which database the census was taken from — so a
+      reviewer can compare it against the cloud the entry claims. On Postgres
+      that is the server's own answer to "which database am I?"; on Spanner it
+      is only the database the CLI was pointed at, composed client-side with no
+      RPC, and GCP is the Spanner deployment. The value says which it is. These
+      tests use a Postgres-shaped `SOURCE` string and therefore prove nothing
+      about either adapter's value; see `byok_v1_attestations`, SCOPE LIMIT.
+    * **A row that only mentions the v1 literal makes a cloud unattestable.**
+      The literal census is a text search over whole bodies, so a stored
+      upstream error string containing `TR-BYOK-ENVELOPE-AES-256-GCM-V1` is
+      counted like an envelope and blocks the cloud until it is dealt with.
+      Fail-closed, deliberate, and covered by
+      `test_a_row_that_only_mentions_the_v1_literal_blocks_the_cloud` below,
+      which exists so that the cost is visible rather than discovered at 2am.
     * A passing precondition is about one moment on one cloud's database. It
       says nothing about the enclave side (`quill-cloud-proxy` has its own v1
       branch), and nothing about a surface no code path in this repo knows
@@ -129,9 +141,14 @@ class FakeCloudDatabase:
 
     The important fidelity here is what the two halves SHARE, because that is
     where an earlier version of these tests lied. Both `scan` and the per-kind
-    census filter on `MIGRATED_KINDS`, exactly as `SpannerEntityStore` and
-    `PostgresEntityStore` do, and the walk reads envelopes only out of the
-    field names in `MIGRATED_SURFACES`. So a test cannot make those two
+    census restrict to the same kind list, as both real adapters do — the
+    per-kind census from `MIGRATED_KINDS` on each, the scan from
+    `MIGRATED_KINDS` on `PostgresEntityStore` and from the same two names
+    hardcoded in SQL text on `SpannerEntityStore` — and the walk reads
+    envelopes only out of the field names in `MIGRATED_SURFACES`. This fixture
+    models the shared list, which is the property that matters; it does not
+    model Spanner's duplicate copy of it, whose only failure mode is an
+    undercount, which is a refusal. So a test cannot make those two
     disagree by renaming a kind — renaming it renames it in both — and any
     fixture that pretends otherwise is testing a decoupling production cannot
     exhibit. `scan_returns_nothing` is kept for the one class where they really
@@ -328,7 +345,7 @@ def test_a_broken_cursor_is_caught_by_the_per_kind_census() -> None:
     The scan returns nothing — a bad cursor, an ordering bug, a page boundary
     mishandled — while the rows are sitting right there. Note what this does
     NOT cover: a renamed kind in the WHERE clause cannot be modelled this way,
-    because both queries build that clause from `MIGRATED_KINDS` and a rename
+    because both queries restrict to the same migrated kind list and a rename
     renames it in both. See the next two tests for the check that does cover it.
     """
     store = FakeCloudDatabase(
@@ -390,9 +407,9 @@ def test_a_renamed_entity_kind_is_not_an_empty_deployment() -> None:
     """The other half of the same blindness, and the one the docstrings claimed.
 
     The rows are under `byok_provider_config` rather than `byok`. Both the walk
-    and the per-kind census filter on `MIGRATED_KINDS`, so BOTH miss them and
-    corroborate each other's silence — the exact shape a census is supposed to
-    break. It does not break it; the literal search does.
+    and the per-kind census are restricted to the migrated kinds, so BOTH miss
+    them and corroborate each other's silence — the exact shape a census is
+    supposed to break. It does not break it; the literal search does.
     """
     store = FakeCloudDatabase(
         {
@@ -408,6 +425,43 @@ def test_a_renamed_entity_kind_is_not_an_empty_deployment() -> None:
     assert result.outcome == OUTCOME_SCAN_DISAGREES
     assert not result.passed
     assert "1 rows in the table carry the v1 algorithm literal" in result.detail
+
+
+def test_a_row_that_only_mentions_the_v1_literal_blocks_the_cloud() -> None:
+    """The price of the literal search, paid here so nobody pays it at 2am.
+
+    `STRPOS(body, …)` / `body::text LIKE` know nothing about envelopes. A
+    generation row that captured an upstream error naming the v1 algorithm is
+    counted exactly like a v1 envelope, and this cloud cannot attest until that
+    row is removed or rewritten — even though every envelope it holds is v2.
+
+    This is the deliberate direction. A search narrowed to a JSON-shaped match
+    would have to assume a serialisation, and the two adapters store different
+    ones; a literal search that stops matching fails OPEN, which is how a
+    customer's key gets deleted. So: fail closed, say where to look, and write
+    the cost down. If someone later narrows the match, this test is what has to
+    change, and changing it is the moment to re-argue the direction.
+    """
+    store = FakeCloudDatabase(
+        {
+            ("byok", "a"): _byok_row(V2),
+            ("generation", "g"): {
+                "model": "gpt",
+                "error": f"unsupported algorithm {V1_ALGORITHM_LITERAL}",
+            },
+        }
+    )
+
+    result = check_no_v1_envelopes(store, cloud="gcp", reporter=lambda _m: None)
+
+    assert result.stats.v1_envelopes == 0, "no v1 envelope exists on this deployment"
+    assert result.census.v1_literal_rows == 1
+    assert result.outcome == OUTCOME_SCAN_DISAGREES
+    assert not result.passed
+    assert "free text that merely mentions the literal" in result.detail
+
+    with pytest.raises(ValueError, match="does not attest zero v1"):
+        attestation_for(result, backend="postgres", operator="you@lorehex.co")
 
 
 def test_a_wrong_but_populated_database_still_passes_and_says_which_one_it_read() -> None:

--- a/tests/test_byok_v1_precondition.py
+++ b/tests/test_byok_v1_precondition.py
@@ -1,0 +1,505 @@
+"""The step-4 precondition: "no v1 envelopes remain" must be earned, per cloud.
+
+THE LAW
+    For each standalone cloud deployment, `check_no_v1_envelopes` reports that
+    the deployment holds no v1 BYOK envelope only when the audit both (a) found
+    zero v1 envelopes and (b) is corroborated by an independently shaped census
+    of the same table showing the scan could have seen rows if any existed.
+    Every other shape — v1 rows found, rows it could not classify, a scan that
+    disagrees with the census, a scan with nothing behind it — is its own named
+    outcome and none of them may be written into the attestation ledger.
+
+WHY THIS IS A PROOF AND NOT A TEST
+    Step 4 of docs/design/byok-aad-v2-migration.md deletes `_aad` and
+    `ALGORITHM`. After that, a surviving v1 row is not recoverable: the AAD
+    that seals both the ciphertext and the KMS-wrapped DEK cannot be rebuilt
+    from a format nobody implements. The precondition for an irreversible step
+    has to be executable, because the cost of it being wrong is a customer's
+    provider key, and the thing it replaces — a green check in a markdown
+    table — cannot be re-run, cannot be dated, and cannot say what it looked at.
+
+THE REAL NEAR-MISS
+    The migration doc, as of 2026-08-15, shows step 3 complete on GCP, AWS and
+    Azure. GCP migrated 7 envelopes. AWS and Azure were **read-only audits that
+    found no rows to rewrite**, and both render in that table as the same green
+    check as GCP's. "No rows existed" and "the backfill ran and finished" are
+    different sentences. Worse, "no rows existed" is also what a wrong cursor,
+    a wrong table, a renamed entity kind, or a credential scoped to the wrong
+    project produces — silently, with exit code 0. The audit cannot tell you
+    whether it looked at anything, because from inside the audit those cases
+    are identical. That is the specific confusion these tests exist to make
+    impossible to commit.
+
+SCOPE LIMIT — what these tests do NOT establish
+    * They exercise the classification and the ledger, against in-memory
+      stores. They do not exercise Spanner or Postgres SQL. `census()` on
+      either real adapter is unproven here, and a census that always returned
+      an empty result would fail closed (zero_scan), not open — that is the
+      direction this gets wrong safely.
+    * A passing precondition is about one moment on one cloud. It says nothing
+      about the enclave side (`quill-cloud-proxy` has its own v1 branch), and
+      nothing about a surface no code path in this repo knows about.
+    * `empty_witnessed` rests on the census reaching the same table as the
+      scan through the same store object. It corroborates credentials,
+      reachability and the scan's cursor. It does NOT prove `tr_entities` is
+      where envelopes live; nothing offline can.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts import check_no_v1_envelopes as check_script
+from trusted_router.byok_aad_backfill import (
+    EntityCensus,
+    EntityRow,
+    attestation_for,
+    check_no_v1_envelopes,
+)
+from trusted_router.byok_v1_attestations import (
+    DEFAULT_LEDGER_PATH,
+    OUTCOME_CLEAN,
+    OUTCOME_DIRTY,
+    OUTCOME_EMPTY_WITNESSED,
+    OUTCOME_SCAN_DISAGREES,
+    OUTCOME_V1_REMAINS,
+    OUTCOME_ZERO_SCAN,
+    STANDALONE_CLOUDS,
+    Attestation,
+    empty_ledger,
+    ledger_defects,
+    load_ledger,
+    record_attestation,
+    surface_fingerprint,
+    zero_v1_blockers,
+)
+
+V1 = "TR-BYOK-ENVELOPE-AES-256-GCM-V1"
+V2 = "TR-BYOK-ENVELOPE-AES-256-GCM-V2"
+
+
+def _envelope(algorithm: str) -> dict[str, str]:
+    """An envelope's shape, not its contents. The audit classifies on
+    `algorithm` alone and never decrypts, so real ciphertext would add nothing
+    but a KMS dependency to a read-only check."""
+    return {
+        "algorithm": algorithm,
+        "key_ref": "projects/example/cryptoKeys/byok",
+        "encrypted_dek": "ZGVr",
+        "dek_nonce": "bm9uY2U",
+        "ciphertext": "Y2lwaGVy",
+        "nonce": "bm9uY2U",
+    }
+
+
+class FakeCloudDatabase:
+    """One cloud's entity table, with the scan and the census as separate
+    answers so a test can make them disagree — which is exactly what a resume
+    cursor bug does in production."""
+
+    def __init__(
+        self,
+        rows: dict[tuple[str, str], dict[str, Any]] | None = None,
+        *,
+        census: EntityCensus | None = None,
+        scan_returns_nothing: bool = False,
+        census_raises: Exception | None = None,
+    ) -> None:
+        self.rows = copy.deepcopy(rows or {})
+        self.scan_returns_nothing = scan_returns_nothing
+        self.census_raises = census_raises
+        self._census = census
+
+    def scan(self, *, after: tuple[str, str] | None, limit: int) -> list[EntityRow]:
+        if self.scan_returns_nothing:
+            return []
+        keys = sorted(key for key in self.rows if after is None or key > after)[:limit]
+        return [
+            EntityRow(
+                kind=kind,
+                entity_id=entity_id,
+                body=copy.deepcopy(self.rows[(kind, entity_id)]),
+                original_body=copy.deepcopy(self.rows[(kind, entity_id)]),
+            )
+            for kind, entity_id in keys
+        ]
+
+    def compare_and_swap(self, row: EntityRow, new_body: dict[str, Any]) -> bool:
+        raise AssertionError("the precondition must never write")
+
+    def census(self, *, sample_limit: int = 1000) -> EntityCensus:
+        if self.census_raises is not None:
+            raise self.census_raises
+        if self._census is not None:
+            return self._census
+        counts: dict[str, int] = {}
+        for kind, _entity_id in self.rows:
+            counts[kind] = counts.get(kind, 0) + 1
+        return EntityCensus(
+            migrated_kind_counts=counts,
+            sampled_kinds=tuple(sorted({kind for kind, _ in self.rows})),
+        )
+
+
+def _byok_row(algorithm: str) -> dict[str, Any]:
+    return {
+        "workspace_id": "11111111-2222-3333-4444-555555555555",
+        "provider": "anthropic",
+        "encrypted_secret": _envelope(algorithm),
+    }
+
+
+# ------------------------------------------------------ the four verdicts ---
+
+
+def test_a_migrated_deployment_attests_clean() -> None:
+    """The only outcome that attests by observation rather than by absence."""
+    store = FakeCloudDatabase(
+        {
+            ("byok", "a"): _byok_row(V2),
+            ("byok", "b"): _byok_row(V2),
+        }
+    )
+
+    result = check_no_v1_envelopes(store, cloud="gcp", reporter=lambda _m: None)
+
+    assert result.outcome == OUTCOME_CLEAN
+    assert result.passed
+    assert result.stats.envelopes_seen == 2
+    assert result.stats.v2_envelopes == 2
+    assert result.stats.rows_scanned_by_kind == {"byok": 2}
+
+
+def test_a_single_surviving_v1_envelope_blocks_the_cloud() -> None:
+    store = FakeCloudDatabase(
+        {
+            ("byok", "a"): _byok_row(V2),
+            ("byok", "b"): _byok_row(V1),
+        }
+    )
+
+    result = check_no_v1_envelopes(store, cloud="gcp", reporter=lambda _m: None)
+
+    assert result.outcome == OUTCOME_V1_REMAINS
+    assert not result.passed
+    assert "1 v1 envelopes are still stored" in result.detail
+
+
+def test_rows_the_audit_cannot_classify_are_not_a_pass() -> None:
+    """An unknown algorithm might be a v1 row under a name we do not know.
+
+    Counting it as "not v1" is the assumption that gets a key deleted.
+    """
+    store = FakeCloudDatabase({("byok", "a"): _byok_row("TR-BYOK-ENVELOPE-AES-256-GCM-V9")})
+
+    result = check_no_v1_envelopes(store, cloud="azure", reporter=lambda _m: None)
+
+    assert result.outcome == OUTCOME_DIRTY
+    assert not result.passed
+
+
+# ------------------------------------- the distinction that motivated this ---
+
+
+def test_a_zero_scan_is_not_reportable_as_zero_v1() -> None:
+    """The AWS/Azure shape, and the whole reason this file exists.
+
+    An empty database and a broken query produce the same BackfillStats:
+    rows_scanned=0, v1_envelopes=0. The audit alone therefore reports success
+    for a run that established nothing. Here nothing corroborates the scan, so
+    the outcome is `zero_scan` — a distinct, loud, unrecordable result.
+    """
+    store = FakeCloudDatabase({})
+
+    result = check_no_v1_envelopes(store, cloud="aws", reporter=lambda _m: None)
+
+    assert result.stats.v1_envelopes == 0  # the tempting half
+    assert result.outcome == OUTCOME_ZERO_SCAN
+    assert not result.passed
+    assert "zero evidence" in result.detail
+
+    with pytest.raises(ValueError, match="does not attest zero v1"):
+        attestation_for(result, backend="postgres", operator="you@lorehex.co")
+
+
+def test_an_empty_deployment_passes_only_with_a_census_witness() -> None:
+    """Same scan result as the test above; different, corroborated conclusion.
+
+    A deployment with no BYOK customers must still be able to reach step 4 or
+    the gate becomes something people route around. What makes this a pass is
+    not the empty scan — it is the census reaching the same table with the same
+    credentials, finding rows of other kinds, and counting zero rows of every
+    migrated kind.
+    """
+    store = FakeCloudDatabase(
+        {},
+        census=EntityCensus(
+            migrated_kind_counts={},
+            sampled_kinds=("api_key", "generation", "workspace"),
+        ),
+    )
+
+    result = check_no_v1_envelopes(store, cloud="aws", reporter=lambda _m: None)
+
+    assert result.outcome == OUTCOME_EMPTY_WITNESSED
+    assert result.passed
+    assert result.outcome != OUTCOME_CLEAN, "an absence is a weaker claim and is named as one"
+
+
+def test_a_broken_cursor_is_caught_by_the_census() -> None:
+    """The failure mode a self-reported audit cannot see.
+
+    The scan returns nothing — a bad `--after` cursor, an ordering bug, a
+    renamed kind in the WHERE clause — while the rows are sitting right there.
+    Without the census this is indistinguishable from a migrated deployment.
+    """
+    store = FakeCloudDatabase(
+        {("byok", "a"): _byok_row(V1)},
+        scan_returns_nothing=True,
+    )
+
+    result = check_no_v1_envelopes(store, cloud="gcp", reporter=lambda _m: None)
+
+    assert result.outcome == OUTCOME_SCAN_DISAGREES
+    assert not result.passed
+    assert "census counted 1 rows, the scan returned 0" in result.detail
+
+
+def test_a_credentials_failure_cannot_be_mistaken_for_an_empty_database() -> None:
+    """A store that cannot answer must raise, never return an empty census.
+
+    The script turns this into exit 3 and the word INCONCLUSIVE; what matters
+    here is that no code path converts "the query failed" into "there is
+    nothing there".
+    """
+    store = FakeCloudDatabase({}, census_raises=PermissionError("caller lacks spanner.read"))
+
+    with pytest.raises(PermissionError):
+        check_no_v1_envelopes(store, cloud="azure", reporter=lambda _m: None)
+
+
+# ------------------------------------------------------------- the ledger ---
+
+
+def _passing_attestation(cloud: str, **overrides: Any) -> Attestation:
+    base = {
+        "cloud": cloud,
+        "outcome": OUTCOME_CLEAN,
+        "recorded_at": "2026-08-15T12:00:00+00:00",
+        "backend": "spanner",
+        "surface_fingerprint": surface_fingerprint(),
+        "rows_scanned": 7,
+        "rows_scanned_by_kind": {"byok": 7},
+        "envelopes_seen": 7,
+        "v1_envelopes": 0,
+        "v2_envelopes": 7,
+        "census_migrated_kind_counts": {"byok": 7},
+        "census_sampled_kinds": ["byok", "workspace"],
+        "operator": "you@lorehex.co",
+        "note": "",
+    }
+    base.update(overrides)
+    return Attestation(**base)
+
+
+def test_one_cloud_attested_is_not_three_clouds_attested(tmp_path: Path) -> None:
+    """Each cloud is a separate database (multi-cloud-separation.md), so the
+    cloud you happened to hold credentials for is the one you can speak for."""
+    ledger_path = tmp_path / "attestations.json"
+    record_attestation(_passing_attestation("gcp"), path=ledger_path)
+
+    blockers = zero_v1_blockers(load_ledger(ledger_path))
+
+    assert any("aws: no zero-v1 attestation" in blocker for blocker in blockers)
+    assert any("azure: no zero-v1 attestation" in blocker for blocker in blockers)
+    assert not any(blocker.startswith("gcp:") for blocker in blockers)
+
+
+def test_a_full_ledger_clears_the_gate(tmp_path: Path) -> None:
+    ledger_path = tmp_path / "attestations.json"
+    for cloud in STANDALONE_CLOUDS:
+        record_attestation(_passing_attestation(cloud), path=ledger_path)
+
+    assert zero_v1_blockers(load_ledger(ledger_path)) == []
+
+
+def test_a_missing_ledger_blocks_every_cloud(tmp_path: Path) -> None:
+    """Deleting the ledger is the cheapest possible forgery. It must read as
+    "nothing is attested", never as "nothing blocks"."""
+    blockers = zero_v1_blockers(load_ledger(tmp_path / "does-not-exist.json"))
+
+    assert len(blockers) == len(STANDALONE_CLOUDS)
+
+
+def test_the_ledger_refuses_to_record_what_was_not_established(tmp_path: Path) -> None:
+    ledger_path = tmp_path / "attestations.json"
+
+    with pytest.raises(ValueError, match="refusing to record outcome 'zero_scan'"):
+        record_attestation(_passing_attestation("aws", outcome=OUTCOME_ZERO_SCAN), path=ledger_path)
+    with pytest.raises(ValueError, match="unknown cloud"):
+        record_attestation(_passing_attestation("gcp2"), path=ledger_path)
+    assert not ledger_path.exists()
+
+
+def test_a_hand_written_non_passing_entry_is_reported_as_a_defect() -> None:
+    """`record_attestation` refuses these, so an entry like this arrived by
+    someone editing the JSON. The reader has to catch what the writer refused."""
+    ledger = empty_ledger()
+    ledger["attestations"]["aws"] = _passing_attestation("aws", outcome=OUTCOME_ZERO_SCAN).to_dict()
+
+    defects = ledger_defects(ledger)
+
+    assert any("is not an attestation and must not be recorded" in defect for defect in defects)
+    assert any("aws" in blocker for blocker in zero_v1_blockers(ledger))
+
+
+def test_an_empty_witnessed_entry_with_no_witness_is_a_zero_scan() -> None:
+    """The one field that carries the whole weight of `empty_witnessed`."""
+    ledger = empty_ledger()
+    ledger["attestations"]["azure"] = _passing_attestation(
+        "azure",
+        outcome=OUTCOME_EMPTY_WITNESSED,
+        envelopes_seen=0,
+        v2_envelopes=0,
+        census_sampled_kinds=[],
+        census_migrated_kind_counts={},
+        rows_scanned=0,
+        rows_scanned_by_kind={},
+    ).to_dict()
+
+    assert any("is a zero scan" in defect for defect in ledger_defects(ledger))
+
+
+def test_adding_an_encrypted_surface_invalidates_every_attestation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Open question #2 in the migration doc, made executable.
+
+    "Are there envelopes outside the three surfaces?" — if the answer ever
+    becomes "yes, here is a fourth", every attestation recorded before it was
+    taken by a run that never walked that surface. The fingerprint makes those
+    attestations stale rather than silently reusable.
+    """
+    from trusted_router import byok_v1_attestations as attestations_module
+
+    ledger_path = tmp_path / "attestations.json"
+    for cloud in STANDALONE_CLOUDS:
+        record_attestation(_passing_attestation(cloud), path=ledger_path)
+    assert zero_v1_blockers(load_ledger(ledger_path)) == []
+
+    monkeypatch.setattr(
+        attestations_module,
+        "MIGRATED_SURFACES",
+        (
+            *attestations_module.MIGRATED_SURFACES,
+            ("smtp_credential", "encrypted_password", "control"),
+        ),
+    )
+
+    blockers = zero_v1_blockers(load_ledger(ledger_path))
+
+    assert len(blockers) == len(STANDALONE_CLOUDS)
+    assert all("re-run the precondition" in blocker for blocker in blockers)
+
+
+def test_the_committed_ledger_is_well_formed() -> None:
+    """The real file, as committed. Empty is fine — forged is not.
+
+    Recording nothing is the honest state today: nobody has run this against a
+    real database. What this asserts is that whatever is in there parses, is
+    for a known cloud, carries a passing outcome, and covers the surfaces this
+    repository writes now.
+
+    The path assertion is not ceremony. A missing ledger reads as the empty
+    ledger — the fail-closed choice — so a default path that quietly stopped
+    pointing at the committed file would leave every test here green while the
+    gate judged a file nobody maintains.
+    """
+    assert DEFAULT_LEDGER_PATH.name == "byok-aad-v2-attestations.json"
+    assert DEFAULT_LEDGER_PATH.exists(), f"the committed ledger is not at {DEFAULT_LEDGER_PATH}"
+    assert ledger_defects(load_ledger()) == []
+
+
+# ---------------------------------------------------------------- the CLI ---
+
+
+def test_the_script_exits_loudly_on_a_zero_scan(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ledger_path = tmp_path / "attestations.json"
+    monkeypatch.setattr(check_script, "_store", lambda _args: FakeCloudDatabase({}))
+
+    code = check_script.main(
+        [
+            "--cloud",
+            "aws",
+            "--backend",
+            "postgres",
+            "--ledger",
+            str(ledger_path),
+            "--record",
+            "--operator",
+            "you@lorehex.co",
+        ]
+    )
+
+    out = capsys.readouterr().out
+    assert code == 2
+    assert "NOT AN ATTESTATION [zero_scan]" in out
+    assert not ledger_path.exists(), "a zero scan must not reach the ledger"
+
+
+def test_the_script_records_a_pass_and_then_reports_what_is_still_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ledger_path = tmp_path / "attestations.json"
+    store = FakeCloudDatabase({("byok", "a"): _byok_row(V2)})
+    monkeypatch.setattr(check_script, "_store", lambda _args: store)
+
+    code = check_script.main(
+        [
+            "--cloud",
+            "gcp",
+            "--backend",
+            "spanner",
+            "--ledger",
+            str(ledger_path),
+            "--record",
+            "--operator",
+            "you@lorehex.co",
+            "--note",
+            "post-backfill re-audit",
+        ]
+    )
+
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "ATTESTS ZERO V1 [clean]" in out
+    assert "step 4 is blocked" in out, "one cloud recorded is not the gate cleared"
+    recorded = json.loads(ledger_path.read_text())["attestations"]["gcp"]
+    assert recorded["outcome"] == OUTCOME_CLEAN
+    assert recorded["surface_fingerprint"] == surface_fingerprint()
+    assert recorded["note"] == "post-backfill re-audit"
+
+
+def test_the_script_reports_a_failed_run_as_inconclusive(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Exit 3, not exit 0, and not exit 2: the run did not happen."""
+    monkeypatch.setattr(
+        check_script,
+        "_store",
+        lambda _args: FakeCloudDatabase({}, census_raises=PermissionError("no spanner.read")),
+    )
+
+    code = check_script.main(
+        ["--cloud", "azure", "--backend", "spanner", "--ledger", str(tmp_path / "l.json")]
+    )
+
+    assert code == 3
+    assert "INCONCLUSIVE" in capsys.readouterr().out

--- a/tests/test_byok_v1_precondition.py
+++ b/tests/test_byok_v1_precondition.py
@@ -597,8 +597,9 @@ def test_a_hand_written_pass_that_counted_v1_rows_is_reported_as_a_defect() -> N
 
 def test_an_attestation_that_does_not_name_the_database_it_read_is_a_defect() -> None:
     """Since a wrong-but-populated database passes, the one mitigation is that
-    the ledger says which database answered. An entry without it removes the
-    only thing a reviewer could have checked."""
+    the ledger says which database was read — the server's own answer on
+    Postgres, the CLI's own arguments echoed back on Spanner. An entry without
+    it removes the only thing a reviewer could have checked."""
     ledger = empty_ledger()
     ledger["attestations"]["gcp"] = _passing_attestation("gcp", census_source="  ").to_dict()
 

--- a/tests/test_byok_v1_precondition.py
+++ b/tests/test_byok_v1_precondition.py
@@ -2,12 +2,19 @@
 
 THE LAW
     For each standalone cloud deployment, `check_no_v1_envelopes` reports that
-    the deployment holds no v1 BYOK envelope only when the audit both (a) found
-    zero v1 envelopes and (b) is corroborated by an independently shaped census
-    of the same table showing the scan could have seen rows if any existed.
-    Every other shape — v1 rows found, rows it could not classify, a scan that
-    disagrees with the census, a scan with nothing behind it — is its own named
-    outcome and none of them may be written into the attestation ledger.
+    the deployment holds no v1 BYOK envelope only when the audit (a) found zero
+    v1 envelopes, (b) is corroborated by a census of the same table showing the
+    scan could have seen rows if any existed, and (c) is corroborated by a
+    search for the v1 algorithm literal that shares neither the scan's kind
+    filter nor its field-name map. Every other shape — v1 rows found, rows it
+    could not classify, a scan that disagrees with either census question, a
+    scan with nothing behind it — is its own named outcome and none of them may
+    be written into the attestation ledger.
+
+    And the ledger is read as one fleet-wide verdict, never per cloud: an AWS
+    or Azure enclave falls over to the home control plane when its own cannot
+    be dialled, so a v1 envelope in any database can reach any enclave. See
+    `trusted_router.byok_v1_attestations`, "WHY EVERY CLOUD".
 
 WHY THIS IS A PROOF AND NOT A TEST
     Step 4 of docs/design/byok-aad-v2-migration.md deletes `_aad` and
@@ -27,21 +34,34 @@ THE REAL NEAR-MISS
     a wrong table, a renamed entity kind, or a credential scoped to the wrong
     project produces — silently, with exit code 0. The audit cannot tell you
     whether it looked at anything, because from inside the audit those cases
-    are identical. That is the specific confusion these tests exist to make
-    impossible to commit.
+    are identical.
+
+    Of those four, this file makes three impossible to commit as a pass: a
+    wrong cursor and a wrong ordering (the per-kind census), a renamed kind or
+    a renamed body field (the v1 literal census). The fourth — a credential on
+    a wrong but populated database — is NOT caught, is not catchable from here,
+    and is named as a scope limit below rather than papered over. An earlier
+    revision of this docstring claimed all four.
 
 SCOPE LIMIT — what these tests do NOT establish
     * They exercise the classification and the ledger, against in-memory
       stores. They do not exercise Spanner or Postgres SQL. `census()` on
-      either real adapter is unproven here, and a census that always returned
-      an empty result would fail closed (zero_scan), not open — that is the
-      direction this gets wrong safely.
-    * A passing precondition is about one moment on one cloud. It says nothing
-      about the enclave side (`quill-cloud-proxy` has its own v1 branch), and
-      nothing about a surface no code path in this repo knows about.
+      either real adapter is unproven here — including the two new queries, the
+      `STRPOS`/`LIKE` literal count and the `source` lookup. A census that
+      always returned an empty result would fail closed (zero_scan), not open.
+    * **A wrong-but-populated database passes.** Point a read-only credential
+      at some other project's `tr_entities`: it is reachable, non-empty, and
+      holds no v1 envelope, which is exactly what success looks like. Nothing
+      offline distinguishes them. What the run does instead is record
+      `census_source` — the server's own answer to "which database am I?" — so
+      a reviewer can compare it against the cloud the entry claims.
+    * A passing precondition is about one moment on one cloud's database. It
+      says nothing about the enclave side (`quill-cloud-proxy` has its own v1
+      branch), and nothing about a surface no code path in this repo knows
+      about — though the literal census does see a v1 envelope stored under a
+      field name this repo has never heard of, which is most of that risk.
     * `empty_witnessed` rests on the census reaching the same table as the
-      scan through the same store object. It corroborates credentials,
-      reachability and the scan's cursor. It does NOT prove `tr_entities` is
+      scan through the same store object. It does NOT prove `tr_entities` is
       where envelopes live; nothing offline can.
 """
 
@@ -63,6 +83,8 @@ from trusted_router.byok_aad_backfill import (
 )
 from trusted_router.byok_v1_attestations import (
     DEFAULT_LEDGER_PATH,
+    ENCLAVE_CONTROL_PLANE_SOURCES,
+    MIGRATED_KINDS,
     OUTCOME_CLEAN,
     OUTCOME_DIRTY,
     OUTCOME_EMPTY_WITNESSED,
@@ -70,7 +92,9 @@ from trusted_router.byok_v1_attestations import (
     OUTCOME_V1_REMAINS,
     OUTCOME_ZERO_SCAN,
     STANDALONE_CLOUDS,
+    V1_ALGORITHM_LITERAL,
     Attestation,
+    clouds_that_must_attest,
     empty_ledger,
     ledger_defects,
     load_ledger,
@@ -97,10 +121,29 @@ def _envelope(algorithm: str) -> dict[str, str]:
     }
 
 
+SOURCE = "postgres:trustedrouter@10.0.0.7:5432 as auditor"
+
+
 class FakeCloudDatabase:
-    """One cloud's entity table, with the scan and the census as separate
-    answers so a test can make them disagree — which is exactly what a resume
-    cursor bug does in production."""
+    """One cloud's entity table, modelled the way the real adapters behave.
+
+    The important fidelity here is what the two halves SHARE, because that is
+    where an earlier version of these tests lied. Both `scan` and the per-kind
+    census filter on `MIGRATED_KINDS`, exactly as `SpannerEntityStore` and
+    `PostgresEntityStore` do, and the walk reads envelopes only out of the
+    field names in `MIGRATED_SURFACES`. So a test cannot make those two
+    disagree by renaming a kind — renaming it renames it in both — and any
+    fixture that pretends otherwise is testing a decoupling production cannot
+    exhibit. `scan_returns_nothing` is kept for the one class where they really
+    do diverge in production: a cursor, ordering or pagination bug in the paged
+    walk, where the count still sees rows the walk skipped.
+
+    `v1_literal_rows` is computed from the serialised bodies of ALL rows, of any
+    kind, which is what `STRPOS(body, …)` / `body::text LIKE` do. That is the
+    only question here whose answer does not pass through `MIGRATED_KINDS` or
+    `MIGRATED_SURFACES`, and it is why a renamed kind and a renamed body field
+    are now catchable at all.
+    """
 
     def __init__(
         self,
@@ -118,7 +161,9 @@ class FakeCloudDatabase:
     def scan(self, *, after: tuple[str, str] | None, limit: int) -> list[EntityRow]:
         if self.scan_returns_nothing:
             return []
-        keys = sorted(key for key in self.rows if after is None or key > after)[:limit]
+        keys = sorted(
+            key for key in self.rows if key[0] in MIGRATED_KINDS and (after is None or key > after)
+        )[:limit]
         return [
             EntityRow(
                 kind=kind,
@@ -139,10 +184,15 @@ class FakeCloudDatabase:
             return self._census
         counts: dict[str, int] = {}
         for kind, _entity_id in self.rows:
-            counts[kind] = counts.get(kind, 0) + 1
+            if kind in MIGRATED_KINDS:
+                counts[kind] = counts.get(kind, 0) + 1
         return EntityCensus(
             migrated_kind_counts=counts,
             sampled_kinds=tuple(sorted({kind for kind, _ in self.rows})),
+            v1_literal_rows=sum(
+                1 for body in self.rows.values() if V1_ALGORITHM_LITERAL in json.dumps(body)
+            ),
+            source=SOURCE,
         )
 
 
@@ -233,15 +283,11 @@ def test_an_empty_deployment_passes_only_with_a_census_witness() -> None:
     A deployment with no BYOK customers must still be able to reach step 4 or
     the gate becomes something people route around. What makes this a pass is
     not the empty scan — it is the census reaching the same table with the same
-    credentials, finding rows of other kinds, and counting zero rows of every
-    migrated kind.
+    credentials, finding rows of other kinds, and finding no row anywhere in
+    the table that carries the v1 algorithm literal.
     """
     store = FakeCloudDatabase(
-        {},
-        census=EntityCensus(
-            migrated_kind_counts={},
-            sampled_kinds=("api_key", "generation", "workspace"),
-        ),
+        {("workspace", "w"): {"name": "acme"}, ("generation", "g"): {"model": "gpt"}},
     )
 
     result = check_no_v1_envelopes(store, cloud="aws", reporter=lambda _m: None)
@@ -251,12 +297,39 @@ def test_an_empty_deployment_passes_only_with_a_census_witness() -> None:
     assert result.outcome != OUTCOME_CLEAN, "an absence is a weaker claim and is named as one"
 
 
-def test_a_broken_cursor_is_caught_by_the_census() -> None:
-    """The failure mode a self-reported audit cannot see.
+def test_rows_of_a_migrated_kind_that_hold_no_secret_are_not_a_failure() -> None:
+    """The false positive that would have made this check unusable.
 
-    The scan returns nothing — a bad `--after` cursor, an ordering bug, a
-    renamed kind in the WHERE clause — while the rows are sitting right there.
-    Without the census this is indistinguishable from a migrated deployment.
+    Both broadcast secret fields and the BYOK secret are optional
+    (`storage_models.py`), so a destination that posts to an unauthenticated
+    webhook is a row of a migrated kind carrying no envelope at all. Blocking
+    on that — "rows exist but I recognised no envelope" — would be fail-closed
+    and wrong, and a precondition nobody can ever satisfy is a precondition
+    somebody deletes. The literal census is what lets this pass safely: those
+    rows contain no v1 marker.
+    """
+    store = FakeCloudDatabase(
+        {
+            ("broadcast_destination", "d1"): {"workspace_id": "w", "endpoint": "https://x"},
+            ("workspace", "w"): {"name": "acme"},
+        }
+    )
+
+    result = check_no_v1_envelopes(store, cloud="aws", reporter=lambda _m: None)
+
+    assert result.outcome == OUTCOME_EMPTY_WITNESSED
+    assert result.stats.missing_envelopes == 2
+    assert result.census.migrated_kind_counts == {"broadcast_destination": 1}
+
+
+def test_a_broken_cursor_is_caught_by_the_per_kind_census() -> None:
+    """The one divergence the paged walk and the aggregate count really have.
+
+    The scan returns nothing — a bad cursor, an ordering bug, a page boundary
+    mishandled — while the rows are sitting right there. Note what this does
+    NOT cover: a renamed kind in the WHERE clause cannot be modelled this way,
+    because both queries build that clause from `MIGRATED_KINDS` and a rename
+    renames it in both. See the next two tests for the check that does cover it.
     """
     store = FakeCloudDatabase(
         {("byok", "a"): _byok_row(V1)},
@@ -268,6 +341,96 @@ def test_a_broken_cursor_is_caught_by_the_census() -> None:
     assert result.outcome == OUTCOME_SCAN_DISAGREES
     assert not result.passed
     assert "census counted 1 rows, the scan returned 0" in result.detail
+
+
+def test_a_v1_envelope_under_a_renamed_body_field_is_not_an_empty_deployment() -> None:
+    """The bug this file was written to prevent, one layer up, reproduced.
+
+    `encrypted_secret` renamed to `secret_envelope` — schema drift, a partial
+    refactor, a surface this repository never knew about. The walk reads only
+    the field names in `MIGRATED_SURFACES`, so it sees the rows and finds
+    nothing in them: `envelopes_seen=0`, and the per-kind census agrees with
+    the walk exactly because both were told the same thing. That combination
+    used to be reported as `empty_witnessed`, exit 0, recorded — over two live
+    v1 envelopes, with `missing_envelopes: 2` printed in the same output.
+
+    "I could not see" is not "there is nothing", and the only question here
+    that can tell them apart is the one that does not know any field names.
+    """
+    store = FakeCloudDatabase(
+        {
+            ("byok", "a"): {
+                "workspace_id": "w",
+                "provider": "anthropic",
+                "secret_envelope": _envelope(V1),
+            },
+            ("byok", "b"): {
+                "workspace_id": "w",
+                "provider": "openai",
+                "secret_envelope": _envelope(V1),
+            },
+            ("workspace", "w"): {"name": "acme"},
+        }
+    )
+
+    result = check_no_v1_envelopes(store, cloud="aws", reporter=lambda _m: None)
+
+    assert result.stats.envelopes_seen == 0  # the tempting half, again
+    assert result.stats.missing_envelopes == 2
+    assert result.census.migrated_kind_counts == {"byok": 2}  # and the census agreed
+    assert result.outcome == OUTCOME_SCAN_DISAGREES
+    assert not result.passed
+    assert "2 rows in the table carry the v1 algorithm literal" in result.detail
+
+    with pytest.raises(ValueError, match="does not attest zero v1"):
+        attestation_for(result, backend="postgres", operator="you@lorehex.co")
+
+
+def test_a_renamed_entity_kind_is_not_an_empty_deployment() -> None:
+    """The other half of the same blindness, and the one the docstrings claimed.
+
+    The rows are under `byok_provider_config` rather than `byok`. Both the walk
+    and the per-kind census filter on `MIGRATED_KINDS`, so BOTH miss them and
+    corroborate each other's silence — the exact shape a census is supposed to
+    break. It does not break it; the literal search does.
+    """
+    store = FakeCloudDatabase(
+        {
+            ("byok_provider_config", "a"): _byok_row(V1),
+            ("workspace", "w"): {"name": "acme"},
+        }
+    )
+
+    result = check_no_v1_envelopes(store, cloud="azure", reporter=lambda _m: None)
+
+    assert result.stats.rows_scanned == 0
+    assert result.census.migrated_kind_counts == {}
+    assert result.outcome == OUTCOME_SCAN_DISAGREES
+    assert not result.passed
+    assert "1 rows in the table carry the v1 algorithm literal" in result.detail
+
+
+def test_a_wrong_but_populated_database_still_passes_and_says_which_one_it_read() -> None:
+    """A negative result, stated rather than hidden.
+
+    Point the credential at another project's `tr_entities`. It is reachable,
+    non-empty, and holds no v1 envelope — indistinguishable from success, and
+    nothing offline can distinguish it. This test exists so that the limit is
+    executable documentation rather than a sentence someone can forget: if a
+    future change claims to close this, this test is what has to change.
+
+    What the run does instead is record where it read, so the mismatch is
+    visible to whoever reviews the ledger.
+    """
+    store = FakeCloudDatabase({("workspace", "someone-elses"): {"name": "not-ours"}})
+
+    result = check_no_v1_envelopes(store, cloud="aws", reporter=lambda _m: None)
+
+    assert result.outcome == OUTCOME_EMPTY_WITNESSED
+    assert result.passed, "this is the gap; it is named, not closed"
+    assert result.census.source == SOURCE
+    assert SOURCE in result.detail
+    assert "does not establish that this was the right database" in result.detail
 
 
 def test_a_credentials_failure_cannot_be_mistaken_for_an_empty_database() -> None:
@@ -298,8 +461,11 @@ def _passing_attestation(cloud: str, **overrides: Any) -> Attestation:
         "envelopes_seen": 7,
         "v1_envelopes": 0,
         "v2_envelopes": 7,
+        "missing_envelopes": 0,
         "census_migrated_kind_counts": {"byok": 7},
         "census_sampled_kinds": ["byok", "workspace"],
+        "census_v1_literal_rows": 0,
+        "census_source": SOURCE,
         "operator": "you@lorehex.co",
         "note": "",
     }
@@ -356,6 +522,92 @@ def test_a_hand_written_non_passing_entry_is_reported_as_a_defect() -> None:
 
     assert any("is not an attestation and must not be recorded" in defect for defect in defects)
     assert any("aws" in blocker for blocker in zero_v1_blockers(ledger))
+
+
+def test_a_hand_written_pass_that_counted_v1_rows_is_reported_as_a_defect() -> None:
+    """The structural half of the literal census.
+
+    `check_no_v1_envelopes` cannot produce this and `record_attestation`
+    refuses it, so an entry like this arrived by someone editing the JSON —
+    plausibly by copying a real run and trimming the outcome. The reader has to
+    catch it too, or the only enforcement lives in the writer.
+    """
+    ledger = empty_ledger()
+    ledger["attestations"]["gcp"] = _passing_attestation("gcp", census_v1_literal_rows=3).to_dict()
+
+    defects = ledger_defects(ledger)
+
+    assert any("census_v1_literal_rows=3" in defect for defect in defects)
+    assert zero_v1_blockers(ledger) != []
+
+
+def test_an_attestation_that_does_not_name_the_database_it_read_is_a_defect() -> None:
+    """Since a wrong-but-populated database passes, the one mitigation is that
+    the ledger says which database answered. An entry without it removes the
+    only thing a reviewer could have checked."""
+    ledger = empty_ledger()
+    ledger["attestations"]["gcp"] = _passing_attestation("gcp", census_source="  ").to_dict()
+
+    assert any("no census_source" in defect for defect in ledger_defects(ledger))
+
+    with pytest.raises(ValueError, match="does not name the database"):
+        record_attestation(_passing_attestation("gcp", census_source=""), ledger=empty_ledger())
+
+
+def test_counts_written_as_strings_do_not_read_as_zero() -> None:
+    """`not "0"` is False and `not 0` is True, so a hand edit that quotes the
+    numbers flips several of the checks below it. Cheap to reject, so rejected
+    before any of them run."""
+    ledger = empty_ledger()
+    ledger["attestations"]["aws"] = _passing_attestation("aws").to_dict()
+    ledger["attestations"]["aws"]["v1_envelopes"] = "0"
+    ledger["attestations"]["aws"]["census_v1_literal_rows"] = "0"
+
+    defects = ledger_defects(ledger)
+
+    assert any("are not integers" in defect for defect in defects)
+    assert any("v1_envelopes" in defect for defect in defects)
+
+
+# ------------------------------------------------ one fleet, not three clouds ---
+
+
+def test_the_required_clouds_are_derived_from_the_enclave_failover_topology() -> None:
+    """Why every cloud must attest, as code rather than as a claim.
+
+    §4.0 of the migration doc used to say a v2 envelope written by one cloud's
+    control plane "never reaches another cloud's enclave". It does: AWS and
+    Azure enclaves are deployed with an ordered control-plane list ending in
+    the home plane and fail over to it on a dial failure
+    (quill-cloud-proxy tools/deploy-aws-nitro.sh:888,
+    tools/deploy-azure-aci.sh:269,
+    enclave-go/internal/trustedrouter/client.go:41-44). So a v1 envelope in the
+    GCP database can be handed to an AWS enclave — during a control-plane
+    outage, which is when nobody wants a second incident.
+
+    The required set is therefore the union of every enclave's sources, and
+    that is what `zero_v1_blockers` iterates.
+    """
+    assert set(clouds_that_must_attest()) == set(STANDALONE_CLOUDS)
+    assert ENCLAVE_CONTROL_PLANE_SOURCES["aws"][-1] == "gcp"
+    assert ENCLAVE_CONTROL_PLANE_SOURCES["azure"][-1] == "gcp"
+    for cloud, sources in ENCLAVE_CONTROL_PLANE_SOURCES.items():
+        assert sources[0] == cloud, "index 0 is the cloud's own control plane"
+        assert set(sources) <= set(STANDALONE_CLOUDS)
+
+
+def test_no_proper_subset_of_the_ledger_clears_the_gate(tmp_path: Path) -> None:
+    """There is no per-cloud permission, however complete one cloud's evidence."""
+    for absent in STANDALONE_CLOUDS:
+        ledger_path = tmp_path / f"without-{absent}.json"
+        for cloud in STANDALONE_CLOUDS:
+            if cloud != absent:
+                record_attestation(_passing_attestation(cloud), path=ledger_path)
+
+        blockers = zero_v1_blockers(load_ledger(ledger_path))
+
+        assert blockers, f"the gate cleared with {absent} unattested"
+        assert all(absent in blocker for blocker in blockers)
 
 
 def test_an_empty_witnessed_entry_with_no_witness_is_a_zero_scan() -> None:
@@ -478,13 +730,54 @@ def test_the_script_records_a_pass_and_then_reports_what_is_still_missing(
     )
 
     out = capsys.readouterr().out
-    assert code == 0
+    assert code == 1, "exit 0 means the FLEET is clear; one cloud recorded is not that"
     assert "ATTESTS ZERO V1 [clean]" in out
     assert "step 4 is blocked" in out, "one cloud recorded is not the gate cleared"
+    assert "EXIT 1, NOT 0" in out
     recorded = json.loads(ledger_path.read_text())["attestations"]["gcp"]
     assert recorded["outcome"] == OUTCOME_CLEAN
     assert recorded["surface_fingerprint"] == surface_fingerprint()
     assert recorded["note"] == "post-backfill re-audit"
+    assert recorded["census_v1_literal_rows"] == 0
+    assert recorded["census_source"] == SOURCE
+
+
+def test_status_only_exits_nonzero_while_the_ledger_blocks(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`check_no_v1_envelopes.py --status-only && <proceed>` must not proceed.
+
+    It returned 0 unconditionally, including while printing three blockers, so
+    the shell form the migration doc itself suggests would have run the next
+    command on a fully blocked ledger. A refusal that only humans can read is
+    not a refusal.
+    """
+    ledger_path = tmp_path / "attestations.json"
+
+    blocked = check_script.main(["--status-only", "--ledger", str(ledger_path)])
+    assert blocked == 2
+    assert "step 4 is blocked" in capsys.readouterr().out
+
+    for cloud in STANDALONE_CLOUDS:
+        record_attestation(_passing_attestation(cloud), path=ledger_path)
+
+    cleared = check_script.main(["--status-only", "--ledger", str(ledger_path)])
+    assert cleared == 0
+    assert "every standalone cloud attests" in capsys.readouterr().out
+
+
+def test_the_pinned_v1_literal_is_the_one_the_module_writes() -> None:
+    """The census searches for `V1_ALGORITHM_LITERAL`, which is a copy.
+
+    It is pinned rather than imported so that the check survives step 4
+    deleting `byok_crypto.ALGORITHM` — but a copy that drifts would search for
+    a string no row contains and report zero forever, which is the quietest
+    possible way for this whole file to stop meaning anything. Held equal while
+    both exist; delete this assertion with v1, not before.
+    """
+    from trusted_router.byok_crypto import ALGORITHM
+
+    assert V1_ALGORITHM_LITERAL == ALGORITHM == V1
 
 
 def test_the_script_reports_a_failed_run_as_inconclusive(

--- a/tests/test_byok_v1_removal_gate.py
+++ b/tests/test_byok_v1_removal_gate.py
@@ -1,0 +1,423 @@
+"""The gate on step 4: v1 envelope support may not be deleted unattested.
+
+THE LAW
+    If `src/trusted_router/byok_crypto.py` no longer supports v1 envelopes —
+    the `ALGORITHM` constant holding the v1 literal, the `_aad` builder, and
+    the v1 branch of `_envelope_aad` must all be present, or v1 is gone — then
+    `docs/design/byok-aad-v2-attestations.json` must carry a passing zero-v1
+    attestation for **every** standalone cloud, covering the surfaces this
+    repository writes today. Otherwise CI fails and says what to run.
+
+    While v1 support is present, this gate asserts nothing about the ledger. It
+    is silent on every change except the one it exists for.
+
+WHY THIS IS A PROOF AND NOT A TEST
+    Step 4 of docs/design/byok-aad-v2-migration.md is the only irreversible
+    step in that plan. A v1 envelope that outlives the deletion is not a
+    revertable bug: the associated data that seals both the ciphertext and the
+    KMS-wrapped DEK cannot be reconstructed once no implementation of the v1
+    encoding exists, so the customer's provider key is gone. Everything else in
+    the migration has a rollback row in §5. This one has "do not attempt this
+    step until you are willing not to roll it back."
+
+    What made it worth writing as a proof is the shape of the evidence. Until
+    now the precondition for that irreversible step was a sentence in a
+    markdown table: "clean audit: no BYOK or Broadcast secret rows existed".
+    Nothing executes a sentence. Nothing dates it, re-runs it, or notices when
+    it stops being true. This gate does not verify the migration — it verifies
+    that somebody ran the precondition, on each cloud, and that the run
+    established something.
+
+THE REAL NEAR-MISS THIS ENCODES
+    On 2026-08-15 the migration doc shows step 3 green on all three clouds. On
+    AWS and Azure step 3 was a **read-only audit that found no rows to
+    rewrite**. That is not the same claim as GCP's "7 migrated, 0 v1 after an
+    independent audit", but the table renders them identically — and an audit
+    that returns nothing looks exactly the same whether the database is
+    migrated, empty, or unreachable behind a bad cursor or the wrong
+    credentials. See tests/test_byok_v1_precondition.py for the outcome split
+    that makes those cases distinguishable; this file is what refuses to let
+    the ambiguous one authorise a deletion.
+
+SCOPE LIMIT — what this gate does NOT establish
+    * It does not prove no v1 envelope exists. It proves that a precondition
+      run which could distinguish "none" from "did not look" was recorded for
+      each cloud. The truth of those runs rests on the databases they queried,
+      at the moment they queried them.
+    * It cannot see `quill-cloud-proxy`. The enclave has its own `Algorithm`
+      constant and its own v1 branch in `byokcache/cache.go`, and removing v1
+      there is a separate decision this repository has no visibility into.
+      Ordering across the two repos remains a human responsibility.
+    * It reads the source text of one module. A v1 branch moved into a
+      different module, or reimplemented inline, would leave this gate quiet.
+      The probe below is deliberately narrow so that it fires on the edit the
+      migration plan actually prescribes ("remove `_aad`, `ALGORITHM`, and the
+      v1 branches"), and it says so rather than pretending to be exhaustive.
+    * Nothing stops someone deleting this file along with v1. No in-repo guard
+      can prevent that; what it can do is make the deliberate version of the
+      edit cost a sentence in a pull request instead of nothing at all.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from trusted_router.byok_v1_attestations import (
+    OUTCOME_CLEAN,
+    STANDALONE_CLOUDS,
+    empty_ledger,
+    load_ledger,
+    surface_fingerprint,
+    zero_v1_blockers,
+)
+
+REPO = Path(__file__).resolve().parents[1]
+BYOK_CRYPTO = REPO / "src" / "trusted_router" / "byok_crypto.py"
+NAMESPACE_PROPERTY_TEST = REPO / "tests" / "test_byok_aad_namespace_property.py"
+CHECK_SCRIPT = "scripts/check_no_v1_envelopes.py"
+
+#: Pinned rather than imported. This module must still load — and still explain
+#: itself — in the tree where `ALGORITHM` has just been deleted, which is
+#: precisely the tree it is here to judge.
+V1_ALGORITHM = "TR-BYOK-ENVELOPE-AES-256-GCM-V1"
+
+#: The migration doc's step 4 says to delete this test along with v1. Until
+#: then it is the standing record of the v1 collision, and deleting it early
+#: would erase the reason any of this exists.
+V1_COLLISION_RECORD = "test_aad_encoding_is_not_injective_in_general"
+
+
+@dataclass(frozen=True)
+class V1Support:
+    """What `byok_crypto.py` still knows about the v1 envelope format."""
+
+    algorithm_constant: str | None
+    has_aad_builder: bool
+    dispatch_selects_v1: bool
+
+    @property
+    def present(self) -> bool:
+        return not self.missing
+
+    @property
+    def missing(self) -> tuple[str, ...]:
+        gaps: list[str] = []
+        if self.algorithm_constant != V1_ALGORITHM:
+            gaps.append(
+                f"the ALGORITHM constant (found {self.algorithm_constant!r}, "
+                f"expected {V1_ALGORITHM!r})"
+            )
+        if not self.has_aad_builder:
+            gaps.append("the _aad v1 associated-data builder")
+        if not self.dispatch_selects_v1:
+            gaps.append("the v1 branch of _envelope_aad")
+        return tuple(gaps)
+
+
+def probe_v1_support(source: str) -> V1Support:
+    """Read the module's AST for the three pieces step 4 removes.
+
+    An AST walk rather than a grep because the v1 algorithm string also appears
+    in this file's own prose, in the module docstring of `byok_crypto.py`, and
+    in comments — a grep would keep reporting v1 as present long after the code
+    implementing it was gone, which is the failure mode that makes a guard
+    worthless.
+    """
+    tree = ast.parse(source)
+    algorithm_constant: str | None = None
+    has_aad_builder = False
+    dispatcher: ast.FunctionDef | None = None
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "ALGORITHM":
+                    if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+                        algorithm_constant = node.value.value
+        elif isinstance(node, ast.FunctionDef):
+            if node.name == "_aad":
+                has_aad_builder = True
+            elif node.name == "_envelope_aad":
+                dispatcher = node
+
+    dispatch_selects_v1 = False
+    if dispatcher is not None:
+        compares_algorithm = any(
+            isinstance(node, ast.Compare)
+            and any(
+                isinstance(comparator, ast.Name) and comparator.id == "ALGORITHM"
+                for comparator in node.comparators
+            )
+            for node in ast.walk(dispatcher)
+        )
+        calls_v1_builder = any(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_aad"
+            for node in ast.walk(dispatcher)
+        )
+        dispatch_selects_v1 = compares_algorithm and calls_v1_builder
+
+    return V1Support(
+        algorithm_constant=algorithm_constant,
+        has_aad_builder=has_aad_builder,
+        dispatch_selects_v1=dispatch_selects_v1,
+    )
+
+
+def gate(source: str, ledger: dict[str, Any]) -> str | None:
+    """The CI verdict: a failure message, or None when there is nothing to say."""
+    support = probe_v1_support(source)
+    if support.present:
+        return None
+    blockers = zero_v1_blockers(ledger)
+    if not blockers:
+        return None
+    removed = "\n".join(f"  - {gap}" for gap in support.missing)
+    still_blocking = "\n".join(f"  - {blocker}" for blocker in blockers)
+    return (
+        "v1 BYOK envelope support is being removed from src/trusted_router/byok_crypto.py:\n"
+        f"{removed}\n"
+        "\n"
+        "but no zero-v1 attestation exists for every cloud. This is step 4 of\n"
+        "docs/design/byok-aad-v2-migration.md and it cannot be rolled back: a v1 envelope\n"
+        "that survives the deletion is a customer's BYOK provider key that nothing can\n"
+        "decrypt again, because the AAD sealing both the ciphertext and the wrapped DEK\n"
+        "cannot be rebuilt from a format no implementation carries.\n"
+        "\n"
+        "Each cloud is a standalone deployment with its own database, so each one needs\n"
+        "its own run:\n"
+        f"    uv run python {CHECK_SCRIPT} --backend <spanner|postgres> \\\n"
+        "        --cloud <" + "|".join(STANDALONE_CLOUDS) + "> --record --operator <you>\n"
+        "then commit docs/design/byok-aad-v2-attestations.json.\n"
+        "\n"
+        "Still blocking:\n"
+        f"{still_blocking}"
+    )
+
+
+# --------------------------------------------------------------- the gate ---
+
+
+def test_v1_support_is_not_removed_before_every_cloud_attests_zero_v1() -> None:
+    """The gate itself, against the tree as committed."""
+    verdict = gate(BYOK_CRYPTO.read_text(), load_ledger())
+
+    if verdict is not None:
+        # pytest.fail rather than assert: the verdict is a multi-line
+        # instruction sheet, and assertion rewriting would print it as one
+        # escaped string. The whole value of this failure is that it reads.
+        pytest.fail(verdict, pytrace=False)
+
+
+def test_the_probe_sees_v1_support_in_the_module_today() -> None:
+    """Anti-vacuity, first half.
+
+    The gate above is quiet today because v1 support is present. If the probe
+    had silently stopped recognising it — a renamed helper, a restructured
+    dispatch — the gate would be quiet for the opposite reason and would never
+    fire again. This asserts the reason.
+    """
+    support = probe_v1_support(BYOK_CRYPTO.read_text())
+
+    assert support.algorithm_constant == V1_ALGORITHM
+    assert support.has_aad_builder
+    assert support.dispatch_selects_v1
+    assert support.present
+
+
+# ------------------------------------------- the edits it must not permit ---
+
+
+@pytest.fixture(name="v1_source")
+def _v1_source() -> str:
+    """The module as committed, while it still has v1 support to remove.
+
+    The tests below work by performing step 4's edits on the real source. Once
+    step 4 has actually been performed there is nothing left to mutate, and the
+    two tests above are the ones that speak. Skipping here keeps that moment
+    legible: a failing gate plus a handful of "already removed" skips, rather
+    than four mutation helpers failing about text they cannot find.
+    """
+    source = BYOK_CRYPTO.read_text()
+    if not probe_v1_support(source).present:
+        pytest.skip("v1 support is already removed; the gate test above is the live one")
+    return source
+
+
+def _without_function(source: str, name: str) -> str:
+    tree = ast.parse(source)
+    target = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == name
+    )
+    return _without_lines(source, target)
+
+
+def _without_v1_dispatch(source: str) -> str:
+    """Delete the `if algorithm == ALGORITHM:` arm of `_envelope_aad`.
+
+    Located through the AST rather than by matching source text, so that
+    reformatting `byok_crypto.py` cannot turn this into a mutation that
+    silently stops mutating — a no-op mutation makes every test below pass for
+    the wrong reason.
+    """
+    tree = ast.parse(source)
+    dispatcher = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "_envelope_aad"
+    )
+    branch = next(
+        node
+        for node in dispatcher.body
+        if isinstance(node, ast.If)
+        and any(
+            isinstance(comparator, ast.Name) and comparator.id == "ALGORITHM"
+            for comparator in getattr(node.test, "comparators", [])
+        )
+    )
+    return _without_lines(source, branch)
+
+
+def _without_algorithm_constant(source: str) -> str:
+    tree = ast.parse(source)
+    assignment = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "ALGORITHM" for target in node.targets
+        )
+    )
+    return _without_lines(source, assignment)
+
+
+def _algorithm_constant_retargeted(source: str) -> str:
+    """The subtle one: the constant survives, pointing at the v2 literal.
+
+    A stored v1 row then dispatches to the v2 AAD builder and fails to open,
+    which surfaces as an InvalidTag that looks like corruption rather than like
+    a migration mistake.
+    """
+    return source.replace(
+        f'ALGORITHM = "{V1_ALGORITHM}"', 'ALGORITHM = "TR-BYOK-ENVELOPE-AES-256-GCM-V2"'
+    )
+
+
+def _without_lines(source: str, node: ast.stmt) -> str:
+    lines = source.splitlines(keepends=True)
+    assert node.end_lineno is not None
+    del lines[node.lineno - 1 : node.end_lineno]
+    return "".join(lines)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected_gap"),
+    [
+        (_without_v1_dispatch, "the v1 branch of _envelope_aad"),
+        (lambda source: _without_function(source, "_aad"), "the _aad v1 associated-data builder"),
+        (_without_algorithm_constant, "the ALGORITHM constant"),
+        (_algorithm_constant_retargeted, "the ALGORITHM constant"),
+    ],
+)
+def test_the_gate_fires_on_each_half_of_the_v1_deletion(
+    v1_source: str, mutate: Any, expected_gap: str
+) -> None:
+    """Every piece step 4 removes, removed one at a time, from the real module.
+
+    Partial removals matter as much as the whole edit: deleting the dispatch
+    branch alone already makes every stored v1 envelope unreadable, and it is
+    the smallest diff that does so.
+    """
+    mutated = mutate(v1_source)
+    assert mutated != v1_source, "the mutation did not apply"
+
+    support = probe_v1_support(mutated)
+    verdict = gate(mutated, load_ledger())
+
+    assert not support.present
+    assert any(expected_gap in gap for gap in support.missing), support.missing
+    assert verdict is not None, "v1 was removed with no attestation and the gate stayed quiet"
+    assert CHECK_SCRIPT in verdict
+    for cloud in STANDALONE_CLOUDS:
+        assert cloud in verdict, "the failure must name every cloud that still owes a run"
+
+
+def test_the_gate_permits_the_removal_once_every_cloud_attests(v1_source: str) -> None:
+    """Not a "never delete v1" test, which would simply be deleted.
+
+    The gate exists to sequence the work, not to forbid it. Given a ledger in
+    which all three deployments attest zero v1 envelopes, the same edit the
+    test above rejects is allowed through without further argument.
+    """
+    ledger = empty_ledger()
+    for cloud in STANDALONE_CLOUDS:
+        ledger["attestations"][cloud] = {
+            "cloud": cloud,
+            "outcome": OUTCOME_CLEAN,
+            "recorded_at": "2026-09-01T00:00:00+00:00",
+            "backend": "spanner",
+            "surface_fingerprint": surface_fingerprint(),
+            "rows_scanned": 12,
+            "rows_scanned_by_kind": {"byok": 12},
+            "envelopes_seen": 12,
+            "v1_envelopes": 0,
+            "v2_envelopes": 12,
+            "census_migrated_kind_counts": {"byok": 12},
+            "census_sampled_kinds": ["byok", "workspace"],
+            "operator": "release-engineer@lorehex.co",
+            "note": "step 4 precondition",
+        }
+    assert zero_v1_blockers(ledger) == []
+
+    assert gate(_without_v1_dispatch(v1_source), ledger) is None
+
+
+def test_an_unrelated_edit_to_byok_crypto_keeps_the_gate_quiet(v1_source: str) -> None:
+    """The annoyance check. Touching the file must not summon the gate."""
+    source = v1_source.replace(
+        "def _b64(value: bytes) -> str:",
+        "def _b64(value: bytes) -> str:\n    # an ordinary comment\n",
+    )
+    assert source != v1_source
+
+    assert gate(source, load_ledger()) is None
+
+
+# ---------------------------------------------- the record step 4 deletes ---
+
+
+def _defines(path: Path, name: str) -> bool:
+    return any(
+        isinstance(node, ast.FunctionDef) and node.name == name
+        for node in ast.walk(ast.parse(path.read_text()))
+    )
+
+
+def test_the_v1_collision_record_lives_exactly_as_long_as_v1_does() -> None:
+    """`test_aad_encoding_is_not_injective_in_general` and v1 go together.
+
+    The migration doc lists deleting that test as a step-4 item, and it is
+    correct to delete it then: it asserts `_aad("a:b", "c") == _aad("a", "b:c")`,
+    which cannot even be expressed once `_aad` is gone. Deleting it EARLIER is
+    the edit worth catching — it is the only standing record that the v1
+    encoding is not injective, and losing it while v1 envelopes are still
+    stored erases the reason the migration exists. Without this assertion that
+    early deletion shows up as nothing at all; with it, the collection error
+    that would otherwise appear becomes a sentence.
+    """
+    v1_supported = probe_v1_support(BYOK_CRYPTO.read_text()).present
+    record_kept = _defines(NAMESPACE_PROPERTY_TEST, V1_COLLISION_RECORD)
+
+    assert v1_supported == record_kept, (
+        f"{V1_COLLISION_RECORD} is "
+        f"{'present' if record_kept else 'absent'} in {NAMESPACE_PROPERTY_TEST.name} while v1 "
+        f"envelope support is {'present' if v1_supported else 'absent'} in byok_crypto.py. They "
+        "are removed together, in step 4, after every cloud attests zero v1 envelopes — never "
+        "before. If the test was renamed rather than deleted, update V1_COLLISION_RECORD here."
+    )

--- a/tests/test_byok_v1_removal_gate.py
+++ b/tests/test_byok_v1_removal_gate.py
@@ -1,15 +1,37 @@
 """The gate on step 4: v1 envelope support may not be deleted unattested.
 
 THE LAW
-    If `src/trusted_router/byok_crypto.py` no longer supports v1 envelopes —
-    the `ALGORITHM` constant holding the v1 literal, the `_aad` builder, and
-    the v1 branch of `_envelope_aad` must all be present, or v1 is gone — then
-    `docs/design/byok-aad-v2-attestations.json` must carry a passing zero-v1
-    attestation for **every** standalone cloud, covering the surfaces this
-    repository writes today. Otherwise CI fails and says what to run.
+    If a v1-shaped envelope — sealed exactly as the stored rows were sealed —
+    no longer opens through `decrypt_byok_secret` and `decrypt_control_secret`,
+    then `docs/design/byok-aad-v2-attestations.json` must carry a passing
+    zero-v1 attestation for **every** standalone cloud, covering the surfaces
+    this repository writes today. Otherwise CI fails and says what to run.
 
-    While v1 support is present, this gate asserts nothing about the ledger. It
-    is silent on every change except the one it exists for.
+    While a v1 envelope still opens, this gate asserts nothing about the
+    ledger.
+
+WHY THE TEST IS BEHAVIOURAL AND THE AST PROBE IS ONLY THE EXPLANATION
+    An earlier revision of this file decided by reading `byok_crypto.py`'s AST
+    for three named pieces: the `ALGORITHM` constant, the `_aad` builder, and
+    the v1 arm of `_envelope_aad`. That got it wrong in both directions.
+
+    It stayed **quiet** on the removal the migration doc's own step-4 bullet
+    invites — rejecting v1 at `decrypt_byok_secret`/`decrypt_control_secret`
+    while leaving all three pieces physically in place. Every stored v1
+    envelope is permanently unopenable after that edit, and the gate returned
+    no verdict at all.
+
+    It **fired** on edits that changed nothing: annotating the constant as
+    `ALGORITHM: Final[str]` (an `ast.AnnAssign`, which the probe did not match)
+    and extracting the v1 arm into a helper that `_envelope_aad` calls. Both
+    preserve v1 completely. A gate that cries wolf on a type annotation is a
+    gate somebody deletes, and deleting it is the whole failure.
+
+    So the verdict now comes from sealing a v1 envelope the way a stored row
+    was sealed and asking the public API to open it. Refactors are invisible to
+    that; anything that stops a stored row opening is not, wherever the change
+    lives. The AST probe survives only to name which pieces went missing in the
+    failure message, and it no longer decides anything on its own.
 
 WHY THIS IS A PROOF AND NOT A TEST
     Step 4 of docs/design/byok-aad-v2-migration.md is the only irreversible
@@ -48,11 +70,21 @@ SCOPE LIMIT — what this gate does NOT establish
       constant and its own v1 branch in `byokcache/cache.go`, and removing v1
       there is a separate decision this repository has no visibility into.
       Ordering across the two repos remains a human responsibility.
-    * It reads the source text of one module. A v1 branch moved into a
-      different module, or reimplemented inline, would leave this gate quiet.
-      The probe below is deliberately narrow so that it fires on the edit the
-      migration plan actually prescribes ("remove `_aad`, `ALGORITHM`, and the
-      v1 branches"), and it says so rather than pretending to be exhaustive.
+    * The behavioural probe opens a v1 envelope wrapped by the local/test key
+      wrapper (`KeyWrapperConfig(environment="test")`). It establishes that the
+      v1 AAD path and the algorithm dispatch still work; it does not exercise
+      the KMS wrapper, so a v1 regression that lives only in `GcpKmsKeyWrapper`
+      is out of scope here.
+    * It probes the two public decrypt entry points. A caller that reaches a v1
+      envelope by some other route is not covered, and neither is a v1 branch
+      that some *other* module reimplements privately — but note that a v1 row
+      which those two functions refuse is already unopenable in production,
+      which is the condition the gate cares about.
+    * The v1 wire format (`V1_ALGORITHM` and `_v1_aad` below) is pinned here
+      rather than imported, because it has to stay expressible in the tree
+      where step 4 has deleted the originals. A pin can drift; while `_aad`
+      still exists, `test_the_pinned_v1_format_is_the_one_the_module_seals`
+      holds them equal.
     * Nothing stops someone deleting this file along with v1. No in-repo guard
       can prevent that; what it can do is make the deliberate version of the
       edit cost a sentence in a pull request instead of nothing at all.
@@ -61,11 +93,16 @@ SCOPE LIMIT — what this gate does NOT establish
 from __future__ import annotations
 
 import ast
+import secrets as secrets_module
+import sys
+import types
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import pytest
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 from trusted_router.byok_v1_attestations import (
     OUTCOME_CLEAN,
@@ -75,6 +112,8 @@ from trusted_router.byok_v1_attestations import (
     surface_fingerprint,
     zero_v1_blockers,
 )
+from trusted_router.key_management import KeyWrapperConfig
+from trusted_router.storage_models import EncryptedSecretEnvelope
 
 REPO = Path(__file__).resolve().parents[1]
 BYOK_CRYPTO = REPO / "src" / "trusted_router" / "byok_crypto.py"
@@ -86,6 +125,22 @@ CHECK_SCRIPT = "scripts/check_no_v1_envelopes.py"
 #: precisely the tree it is here to judge.
 V1_ALGORITHM = "TR-BYOK-ENVELOPE-AES-256-GCM-V1"
 
+#: The local/test wrapping path, so the probe needs no KMS. See the scope limit.
+PROBE_SETTINGS = KeyWrapperConfig(environment="test")
+
+
+def _v1_aad(workspace_id: str, context: str) -> bytes:
+    """The v1 associated data, as it was sealed into the rows that exist.
+
+    Pinned, not imported, for the same reason as `V1_ALGORITHM`: a stored row
+    carries these bytes whatever the module later calls the function that
+    produced them, and the probe has to keep working after step 4 deletes
+    `_aad`. `test_the_pinned_v1_format_is_the_one_the_module_seals` holds this
+    equal to the real `_aad` while the real one exists.
+    """
+    return f"trustedrouter:byok:{workspace_id}:{context}".encode()
+
+
 #: The migration doc's step 4 says to delete this test along with v1. Until
 #: then it is the standing record of the v1 collision, and deleting it early
 #: would erase the reason any of this exists.
@@ -94,7 +149,13 @@ V1_COLLISION_RECORD = "test_aad_encoding_is_not_injective_in_general"
 
 @dataclass(frozen=True)
 class V1Support:
-    """What `byok_crypto.py` still knows about the v1 envelope format."""
+    """What `byok_crypto.py`'s SOURCE still mentions of the v1 envelope format.
+
+    Descriptive only. `present` here is not the gate's verdict — a refactor can
+    move any of these and keep v1 working perfectly, and an entry-point guard
+    can leave all three in place and break it. `v1_envelope_opens()` decides;
+    this explains.
+    """
 
     algorithm_constant: str | None
     has_aad_builder: bool
@@ -127,6 +188,10 @@ def probe_v1_support(source: str) -> V1Support:
     in comments — a grep would keep reporting v1 as present long after the code
     implementing it was gone, which is the failure mode that makes a guard
     worthless.
+
+    `ast.AnnAssign` is matched as well as `ast.Assign`: `ALGORITHM: Final[str] =
+    "…"` is the same constant, and reading it as an absence used to turn a type
+    annotation into a CI failure about permanently unreadable customer keys.
     """
     tree = ast.parse(source)
     algorithm_constant: str | None = None
@@ -134,8 +199,9 @@ def probe_v1_support(source: str) -> V1Support:
     dispatcher: ast.FunctionDef | None = None
 
     for node in ast.walk(tree):
-        if isinstance(node, ast.Assign):
-            for target in node.targets:
+        if isinstance(node, ast.Assign | ast.AnnAssign):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for target in targets:
                 if isinstance(target, ast.Name) and target.id == "ALGORITHM":
                     if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
                         algorithm_constant = node.value.value
@@ -170,15 +236,147 @@ def probe_v1_support(source: str) -> V1Support:
     )
 
 
+@dataclass(frozen=True)
+class V1Behaviour:
+    """Whether a stored v1 envelope still opens through the public API."""
+
+    #: True: it opened. False: it did not. None: the probe could not be built,
+    #: so this says nothing and the AST probe is all there is.
+    opens: bool | None
+    reason: str
+
+    @property
+    def removed(self) -> bool:
+        """True only for a definite refusal. `None` is never treated as removal.
+
+        An indeterminate probe must not fire the gate: the message it prints is
+        a multi-line warning about unrecoverable customer keys, and printing it
+        because an import failed is how a guard gets deleted.
+        """
+        return self.opens is False
+
+
+def load_module(source: str, name: str = "byok_crypto_under_probe") -> types.ModuleType:
+    """Execute `source` as a module, so the probe can run against a mutation.
+
+    The mutation tests below edit the real `byok_crypto.py` text and need the
+    edited version to be *callable*, not merely parseable. Registered in
+    `sys.modules` under a scratch name while it executes, because dataclass and
+    typing machinery resolves `__module__` through there.
+
+    The `exec` is the point rather than a shortcut: the input is always this
+    repository's own source file, read from disk, optionally with a mutation
+    this file wrote. Nothing external reaches it.
+    """
+    module = types.ModuleType(name)
+    module.__file__ = str(BYOK_CRYPTO)
+    sys.modules[name] = module
+    try:
+        exec(compile(source, str(BYOK_CRYPTO), "exec"), module.__dict__)  # noqa: S102
+    finally:
+        sys.modules.pop(name, None)
+    return module
+
+
+def seal_v1(module: types.ModuleType, secret: str, *, workspace_id: str, context: str) -> Any:
+    """Build the envelope a pre-migration row holds, using only v2-era helpers.
+
+    Deliberately does not touch `ALGORITHM` or `_aad`: the algorithm string and
+    the AAD bytes are pinned above, exactly as a stored row carries them. So
+    retargeting the constant, renaming the builder, or deleting either is
+    invisible to the sealing side and shows up only where it matters — in
+    whether the module can still open the result.
+    """
+    dek = secrets_module.token_bytes(32)
+    nonce = secrets_module.token_bytes(12)
+    dek_nonce = secrets_module.token_bytes(12)
+    aad = _v1_aad(workspace_id, context)
+    return EncryptedSecretEnvelope(
+        algorithm=V1_ALGORITHM,
+        key_ref=module._key_ref(PROBE_SETTINGS),
+        encrypted_dek=module._b64(module._wrap_dek(dek, dek_nonce, aad, PROBE_SETTINGS)),
+        dek_nonce=module._b64(dek_nonce),
+        ciphertext=module._b64(AESGCM(dek).encrypt(nonce, secret.encode(), aad)),
+        nonce=module._b64(nonce),
+    )
+
+
+def v1_envelope_opens(module: types.ModuleType) -> V1Behaviour:
+    """The gate's actual question: can a stored v1 row still be decrypted?
+
+    Both public entry points are tried, because they dispatch differently —
+    `decrypt_control_secret` picks the namespace from the algorithm — and
+    because rejecting v1 at either one is enough to make a stored row
+    unopenable in production.
+    """
+    workspace_id = str(uuid.uuid4())
+    try:
+        provider_envelope = seal_v1(
+            module, "v1-provider", workspace_id=workspace_id, context="openai"
+        )
+        control_envelope = seal_v1(
+            module, "v1-control", workspace_id=workspace_id, context="broadcast:bdst_1:api_key"
+        )
+    except Exception as exc:
+        return V1Behaviour(
+            opens=None,
+            reason=(
+                f"could not seal a v1 envelope with this module's own helpers "
+                f"({type(exc).__name__}: {exc}), so the behavioural probe says nothing"
+            ),
+        )
+
+    try:
+        opened_provider = module.decrypt_byok_secret(
+            provider_envelope, PROBE_SETTINGS, workspace_id=workspace_id, provider="openai"
+        )
+    except Exception as exc:
+        return V1Behaviour(
+            opens=False,
+            reason=(
+                f"decrypt_byok_secret refused a stored v1 envelope: {type(exc).__name__}: {exc}"
+            ),
+        )
+    try:
+        opened_control = module.decrypt_control_secret(
+            control_envelope,
+            PROBE_SETTINGS,
+            workspace_id=workspace_id,
+            purpose="broadcast:bdst_1:api_key",
+        )
+    except Exception as exc:
+        return V1Behaviour(
+            opens=False,
+            reason=(
+                f"decrypt_control_secret refused a stored v1 envelope: {type(exc).__name__}: {exc}"
+            ),
+        )
+    if (opened_provider, opened_control) != ("v1-provider", "v1-control"):
+        return V1Behaviour(
+            opens=False,
+            reason="a v1 envelope decrypted to the wrong plaintext, which is worse than a refusal",
+        )
+    return V1Behaviour(opens=True, reason="a v1 envelope still opens through both entry points")
+
+
 def gate(source: str, ledger: dict[str, Any]) -> str | None:
-    """The CI verdict: a failure message, or None when there is nothing to say."""
+    """The CI verdict: a failure message, or None when there is nothing to say.
+
+    Behaviour decides. The AST probe only supplies the "what changed" lines,
+    and is consulted for a verdict solely when the behavioural probe could not
+    run at all.
+    """
     support = probe_v1_support(source)
-    if support.present:
+    behaviour = v1_envelope_opens(load_module(source))
+    if behaviour.opens is True:
+        return None
+    if behaviour.opens is None and support.present:
         return None
     blockers = zero_v1_blockers(ledger)
     if not blockers:
         return None
-    removed = "\n".join(f"  - {gap}" for gap in support.missing)
+    gaps = list(support.missing) or ["nothing in the module's source text, but:"]
+    removed = "\n".join(f"  - {gap}" for gap in gaps + [behaviour.reason])
     still_blocking = "\n".join(f"  - {blocker}" for blocker in blockers)
     return (
         "v1 BYOK envelope support is being removed from src/trusted_router/byok_crypto.py:\n"
@@ -190,8 +388,10 @@ def gate(source: str, ledger: dict[str, Any]) -> str | None:
         "decrypt again, because the AAD sealing both the ciphertext and the wrapped DEK\n"
         "cannot be rebuilt from a format no implementation carries.\n"
         "\n"
-        "Each cloud is a standalone deployment with its own database, so each one needs\n"
-        "its own run:\n"
+        "Every cloud must attest, not just the one you are looking at. Each is a\n"
+        "standalone deployment with its own database, AND an AWS or Azure enclave falls\n"
+        "over to the home control plane when its own cannot be dialled — so a v1 envelope\n"
+        "left in any one database can be handed to any cloud's enclave, during an outage.\n"
         f"    uv run python {CHECK_SCRIPT} --backend <spanner|postgres> \\\n"
         "        --cloud <" + "|".join(STANDALONE_CLOUDS) + "> --record --operator <you>\n"
         "then commit docs/design/byok-aad-v2-attestations.json.\n"
@@ -218,17 +418,34 @@ def test_v1_support_is_not_removed_before_every_cloud_attests_zero_v1() -> None:
 def test_the_probe_sees_v1_support_in_the_module_today() -> None:
     """Anti-vacuity, first half.
 
-    The gate above is quiet today because v1 support is present. If the probe
-    had silently stopped recognising it — a renamed helper, a restructured
-    dispatch — the gate would be quiet for the opposite reason and would never
-    fire again. This asserts the reason.
+    The gate above is quiet today because a v1 envelope still opens. If the
+    probe had silently stopped being able to ask — an import that no longer
+    resolves, a helper it needs renamed — the gate would be quiet for the
+    opposite reason and would never fire again. This asserts the reason.
     """
-    support = probe_v1_support(BYOK_CRYPTO.read_text())
+    behaviour = v1_envelope_opens(load_module(BYOK_CRYPTO.read_text()))
+    assert behaviour.opens is True, behaviour.reason
 
+    support = probe_v1_support(BYOK_CRYPTO.read_text())
     assert support.algorithm_constant == V1_ALGORITHM
     assert support.has_aad_builder
     assert support.dispatch_selects_v1
     assert support.present
+
+
+def test_the_pinned_v1_format_is_the_one_the_module_seals() -> None:
+    """The pin above must be the real thing while the real thing exists.
+
+    `_v1_aad` and `V1_ALGORITHM` are copies of a wire format, kept so the probe
+    outlives step 4's deletions. A copy can drift, and a drifted copy makes the
+    behavioural probe report a refusal that never happened — a false CI failure
+    on the scariest message in the repository. Held equal here, and this test
+    is the one that becomes unrunnable (and should be deleted) at step 4.
+    """
+    from trusted_router import byok_crypto
+
+    assert byok_crypto.ALGORITHM == V1_ALGORITHM
+    assert byok_crypto._aad("ws", "ctx") == _v1_aad("ws", "ctx")
 
 
 # ------------------------------------------- the edits it must not permit ---
@@ -240,12 +457,12 @@ def _v1_source() -> str:
 
     The tests below work by performing step 4's edits on the real source. Once
     step 4 has actually been performed there is nothing left to mutate, and the
-    two tests above are the ones that speak. Skipping here keeps that moment
+    tests above are the ones that speak. Skipping here keeps that moment
     legible: a failing gate plus a handful of "already removed" skips, rather
-    than four mutation helpers failing about text they cannot find.
+    than mutation helpers failing about text they cannot find.
     """
     source = BYOK_CRYPTO.read_text()
-    if not probe_v1_support(source).present:
+    if v1_envelope_opens(load_module(source)).removed:
         pytest.skip("v1 support is already removed; the gate test above is the live one")
     return source
 
@@ -309,6 +526,46 @@ def _algorithm_constant_retargeted(source: str) -> str:
     )
 
 
+def _rejected_at_the_entry_points(source: str) -> str:
+    """The staged removal the migration doc's own step-4 bullet invites.
+
+    "Keep a v1-shaped envelope in a test fixture asserting it is now rejected"
+    describes exactly this edit: refuse v1 where callers arrive, leave
+    `ALGORITHM`, `_aad` and the dispatch arm physically in place for now. Every
+    stored v1 row is permanently unopenable the moment it ships, and the
+    source-reading version of this gate had nothing to say about it.
+    """
+    guard = (
+        "    if envelope.algorithm != ALGORITHM_V2:\n"
+        '        raise ValueError("v1 BYOK envelopes are no longer supported")\n'
+    )
+    mutated = source.replace(
+        "    aad = _envelope_aad(envelope.algorithm, NAMESPACE_PROVIDER, workspace_id, provider)",
+        guard
+        + "    aad = _envelope_aad(envelope.algorithm, NAMESPACE_PROVIDER, workspace_id, provider)",
+    )
+    return mutated.replace(
+        "    namespace = NAMESPACE_CONTROL if envelope.algorithm == ALGORITHM_V2 "
+        "else NAMESPACE_PROVIDER",
+        guard + "    namespace = NAMESPACE_CONTROL",
+    )
+
+
+def _rejected_only_for_control_secrets(source: str) -> str:
+    """Half of the above: BYOK keeps working, broadcast secrets stop opening.
+
+    A partial removal is the likelier accident, and it is just as unrecoverable
+    for the rows it touches.
+    """
+    return source.replace(
+        "    namespace = NAMESPACE_CONTROL if envelope.algorithm == ALGORITHM_V2 "
+        "else NAMESPACE_PROVIDER",
+        "    if envelope.algorithm != ALGORITHM_V2:\n"
+        '        raise ValueError("v1 control-plane envelopes are no longer supported")\n'
+        "    namespace = NAMESPACE_CONTROL",
+    )
+
+
 def _without_lines(source: str, node: ast.stmt) -> str:
     lines = source.splitlines(keepends=True)
     assert node.end_lineno is not None
@@ -323,25 +580,30 @@ def _without_lines(source: str, node: ast.stmt) -> str:
         (lambda source: _without_function(source, "_aad"), "the _aad v1 associated-data builder"),
         (_without_algorithm_constant, "the ALGORITHM constant"),
         (_algorithm_constant_retargeted, "the ALGORITHM constant"),
+        (_rejected_at_the_entry_points, "decrypt_byok_secret refused"),
+        (_rejected_only_for_control_secrets, "decrypt_control_secret refused"),
     ],
 )
 def test_the_gate_fires_on_each_half_of_the_v1_deletion(
     v1_source: str, mutate: Any, expected_gap: str
 ) -> None:
-    """Every piece step 4 removes, removed one at a time, from the real module.
+    """Every way v1 stops opening, one at a time, on the real module.
 
     Partial removals matter as much as the whole edit: deleting the dispatch
     branch alone already makes every stored v1 envelope unreadable, and it is
-    the smallest diff that does so.
+    the smallest diff that does so. The last two entries are the edits that
+    leave the source text looking untouched — the gate's previous shape passed
+    them both.
     """
     mutated = mutate(v1_source)
     assert mutated != v1_source, "the mutation did not apply"
 
-    support = probe_v1_support(mutated)
+    behaviour = v1_envelope_opens(load_module(mutated))
     verdict = gate(mutated, load_ledger())
 
-    assert not support.present
-    assert any(expected_gap in gap for gap in support.missing), support.missing
+    assert behaviour.removed, behaviour.reason
+    reported = list(probe_v1_support(mutated).missing) + [behaviour.reason]
+    assert any(expected_gap in line for line in reported), reported
     assert verdict is not None, "v1 was removed with no attestation and the gate stayed quiet"
     assert CHECK_SCRIPT in verdict
     for cloud in STANDALONE_CLOUDS:
@@ -355,6 +617,14 @@ def test_the_gate_permits_the_removal_once_every_cloud_attests(v1_source: str) -
     which all three deployments attest zero v1 envelopes, the same edit the
     test above rejects is allowed through without further argument.
     """
+    ledger = _full_ledger()
+    assert zero_v1_blockers(ledger) == []
+
+    assert gate(_without_v1_dispatch(v1_source), ledger) is None
+    assert gate(_rejected_at_the_entry_points(v1_source), ledger) is None
+
+
+def _full_ledger() -> dict[str, Any]:
     ledger = empty_ledger()
     for cloud in STANDALONE_CLOUDS:
         ledger["attestations"][cloud] = {
@@ -368,25 +638,81 @@ def test_the_gate_permits_the_removal_once_every_cloud_attests(v1_source: str) -
             "envelopes_seen": 12,
             "v1_envelopes": 0,
             "v2_envelopes": 12,
+            "missing_envelopes": 0,
             "census_migrated_kind_counts": {"byok": 12},
             "census_sampled_kinds": ["byok", "workspace"],
+            "census_v1_literal_rows": 0,
+            "census_source": f"spanner:projects/tr-{cloud}/instances/i/databases/d",
             "operator": "release-engineer@lorehex.co",
             "note": "step 4 precondition",
         }
-    assert zero_v1_blockers(ledger) == []
-
-    assert gate(_without_v1_dispatch(v1_source), ledger) is None
+    return ledger
 
 
-def test_an_unrelated_edit_to_byok_crypto_keeps_the_gate_quiet(v1_source: str) -> None:
-    """The annoyance check. Touching the file must not summon the gate."""
-    source = v1_source.replace(
-        "def _b64(value: bytes) -> str:",
-        "def _b64(value: bytes) -> str:\n    # an ordinary comment\n",
-    )
-    assert source != v1_source
+def test_one_cloud_short_of_a_full_ledger_still_refuses(v1_source: str) -> None:
+    """There is no per-cloud version of this permission.
 
-    assert gate(source, load_ledger()) is None
+    An AWS enclave that can no longer read v1 is broken by a v1 envelope in the
+    GCP database, because it falls over to the home control plane whenever its
+    own is undialable (byok_v1_attestations, "WHY EVERY CLOUD"). So dropping
+    every cloud but one from the ledger must still refuse the edit, whichever
+    cloud is the one left owing.
+    """
+    for absent in STANDALONE_CLOUDS:
+        ledger = _full_ledger()
+        del ledger["attestations"][absent]
+
+        verdict = gate(_without_v1_dispatch(v1_source), ledger)
+
+        assert verdict is not None, f"the gate cleared with {absent} unattested"
+        assert absent in verdict
+
+
+@pytest.mark.parametrize(
+    ("name", "mutate"),
+    [
+        (
+            "an ordinary comment",
+            lambda source: source.replace(
+                "def _b64(value: bytes) -> str:",
+                "def _b64(value: bytes) -> str:\n    # an ordinary comment\n",
+            ),
+        ),
+        (
+            "a Final[str] annotation on ALGORITHM",
+            lambda source: source.replace(
+                "import secrets\n", "import secrets\nfrom typing import Final\n", 1
+            ).replace(f'ALGORITHM = "{V1_ALGORITHM}"', f'ALGORITHM: Final[str] = "{V1_ALGORITHM}"'),
+        ),
+        (
+            "the v1 arm extracted into a helper",
+            lambda source: source.replace(
+                "    if algorithm == ALGORITHM:\n        return _aad(workspace_id, context)",
+                "    if algorithm == ALGORITHM:\n        return _legacy_aad(workspace_id, context)",
+            ).replace(
+                "def _aad_v2(",
+                "def _legacy_aad(workspace_id: str, context: str) -> bytes:\n"
+                "    return _aad(workspace_id, context)\n\n\ndef _aad_v2(",
+            ),
+        ),
+    ],
+)
+def test_an_unrelated_edit_to_byok_crypto_keeps_the_gate_quiet(
+    v1_source: str, name: str, mutate: Any
+) -> None:
+    """The annoyance check, which is a safety check.
+
+    The gate's failure message is a multi-line warning about customer keys
+    nothing will ever decrypt again. Printing it for a type annotation or a
+    helper extraction — both of which leave every stored v1 envelope opening
+    exactly as before — teaches the reader to ignore it, and the next reader
+    deletes it. The source-reading gate fired on the last two of these.
+    """
+    source = mutate(v1_source)
+    assert source != v1_source, f"the {name} mutation did not apply"
+    assert v1_envelope_opens(load_module(source)).opens is True
+
+    assert gate(source, load_ledger()) is None, name
 
 
 # ---------------------------------------------- the record step 4 deletes ---
@@ -411,7 +737,7 @@ def test_the_v1_collision_record_lives_exactly_as_long_as_v1_does() -> None:
     early deletion shows up as nothing at all; with it, the collection error
     that would otherwise appear becomes a sentence.
     """
-    v1_supported = probe_v1_support(BYOK_CRYPTO.read_text()).present
+    v1_supported = not v1_envelope_opens(load_module(BYOK_CRYPTO.read_text())).removed
     record_kept = _defines(NAMESPACE_PROPERTY_TEST, V1_COLLISION_RECORD)
 
     assert v1_supported == record_kept, (

--- a/tests/test_byok_v1_removal_gate.py
+++ b/tests/test_byok_v1_removal_gate.py
@@ -642,7 +642,10 @@ def _full_ledger() -> dict[str, Any]:
             "census_migrated_kind_counts": {"byok": 12},
             "census_sampled_kinds": ["byok", "workspace"],
             "census_v1_literal_rows": 0,
-            "census_source": f"spanner:projects/tr-{cloud}/instances/i/databases/d",
+            "census_source": (
+                f"spanner:projects/tr-{cloud}/instances/i/databases/d"
+                " (from CLI arguments, not asked of the server)"
+            ),
             "operator": "release-engineer@lorehex.co",
             "note": "step 4 precondition",
         }


### PR DESCRIPTION
## Why

Step 4 of the BYOK migration deletes v1 envelope support. The only thing standing between
that and permanently unreadable customer BYOK keys is currently a claim in a markdown
table. And note the shape of that claim: on AWS and Azure, step 3 was a **read-only audit
that found no rows**. "No rows existed" and "the backfill ran successfully" are different
sentences that render as the same green check.

This makes the precondition executable and refuses the deletion until every cloud attests.

## Corrects a false claim in the design doc that changes step 4's preconditions

§4.0 said a v2 envelope written by one cloud's control plane *"never reaches another
cloud's enclave"*. That is **false for both AWS and Azure**, and I verified it in the
enclave repo:

- `tools/deploy-aws-nitro.sh:888` — `...=https://aws.trustedrouter.com/v1,https://trustedrouter.com/v1`
- `tools/deploy-azure-aci.sh:269` — `...=https://azure.trustedrouter.com/v1,https://trustedrouter.com/v1`
- `enclave-go/internal/trustedrouter/client.go:41` — *"baseURLs is ordered: index 0 is this
  cloud's OWN control plane, later entries are fallbacks used only when an earlier one
  cannot be dialled."*

Consequence: **v1 support cannot be dropped per-cloud independently.** If cloud A drops v1
reads while cloud B still writes v1, then during a B-side control-plane outage A's enclave
fails over to B, is handed a v1 envelope, and BYOK breaks — during an outage. The gate
enforces an all-clouds condition, not a per-cloud one.

## The defect review found in the first version

The `empty_witnessed` verdict claimed a census proved the table was reachable and empty,
but the code never read the census counts in that branch and never read
`missing_envelopes` at all. Because AWS and Azure hold zero BYOK rows, `empty_witnessed`
is the **only** verdict those two clouds can produce — so the verdict that would authorise
an irreversible deletion on two of three clouds was the one whose stated justification was
never evaluated. Fixed, and a zero-scan is now a distinct loud outcome that is never a pass.

## What it does NOT establish

- A wrong-but-populated database still passes. The mitigation is that the run records
  `census_source` in the ledger so it can be checked against the cloud being attested.
- On the Spanner path that source is composed client-side from the CLI's own arguments —
  the server is not asked. Earlier drafts described it as "the server's own answer"; that
  was false and is corrected everywhere it appeared.
- Any row whose body merely mentions the v1 algorithm string in free text makes that cloud
  unattestable until removed. Named as a scope limit.

## Correction to an earlier commit message

`42ef9abf` says the `empty_witnessed` and `clean` detail strings are *"the two that go into
the ledger entry"*. That is false — `detail` is not a field of `Attestation` and
`attestation_for` never copies it, so it is printed for the operator and goes nowhere near
the ledger. Verified; recorded here since the branch history can't be rewritten cleanly.

## Merge order

Conflicts with #587 (t2-gate) on `docs/design/byok-aad-v2-migration.md`. **Merge this
before #587.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
