### PR TITLE
Cover every serving plane in the trust-drift check, and run it hourly

### DIFF
--- a/.github/workflows/trust-drift.yml
+++ b/.github/workflows/trust-drift.yml
@@ -68,12 +68,27 @@ jobs:
       # EXPECT THE FIRST RUN AFTER THIS MERGES TO BE RED, until the control
       # plane deploy lands. Measured 2026-08-15 against production: the mirror
       # was still dropping azure-release.json's `regions` array, so the checker
-      # could reach UAE North and not Southeast Asia and reported
-      #   [GAP] azure: 1 published MAA issuer(s) belong to no enumerated region
-      # That is the correct verdict for that state, not a flake. The same
-      # commit fixes trusted_router.trust.azure_release, so the deploy this
-      # workflow_run triggers on is what turns it green — verified end to end
-      # against the real planes by serving the patched mirror's output locally.
+      # could reach UAE North and not Southeast Asia and reported a [GAP] for
+      # the MAA issuer no contacted endpoint presented. That is the correct
+      # verdict for that state, not a flake.
+      #
+      # What turns it green is the deploy this workflow_run triggers on. Stated
+      # as precisely as it was actually established, because the first version
+      # of this comment overclaimed here: the fix is in TWO places, and only one
+      # of them is on the serving route. trusted_router.trust.azure_release
+      # mirrors the array through, and
+      # trusted_router.services.trust_release.validated_azure_metadata — the
+      # validator the route interposes ahead of it, which used to whitelist
+      # three scalar keys — validates and carries it. With only the former, the
+      # served record was byte-identical to before the change and this job would
+      # have been red forever.
+      #
+      # The evidence is offline and reproducible, NOT a live measurement:
+      # tests/test_trust_measurement_drift.py drives the real FastAPI route with
+      # a mocked upstream, asserts the served record carries both region URLs,
+      # then feeds that served record to the checker and asserts both endpoints
+      # were fetched. Nobody has yet observed the deployed control plane serving
+      # a regions[] array; that is what the first green run of this job will be.
       - name: Published measurements vs live attestations
         run: >
           uv run python scripts/verify_trust_measurements.py

--- a/.github/workflows/trust-drift.yml
+++ b/.github/workflows/trust-drift.yml
@@ -1,0 +1,81 @@
+name: Trust Measurement Drift
+
+# Compares every measurement we PUBLISH against a live attestation from the
+# plane that is supposed to be running it — GCP Confidential Space, the AWS
+# Nitro fleet, and both Azure regions.
+#
+# This workflow is the point of the exercise. scripts/verify_trust_measurements.py
+# existed and was invoked by nothing: its only mentions in the repo were two
+# comments naming it as the thing that catches drift, in
+# src/trusted_router/config.py and src/trusted_router/trust.py. A drift check nobody is
+# required to run has the reliability of a note in a drawer, and the failure it
+# guards against — a published measurement that no longer matches the enclave —
+# is invisible from the inside. It only ever shows up as a stranger concluding
+# our gateway was tampered with.
+on:
+  # Hourly, offset off the top of the hour. Cadence reasoning, deliberately not
+  # copied from prod-smoke's */30:
+  #   * This is not an uptime check. A drifted record is a STICKY failure — it
+  #     stays wrong until somebody republishes — so what matters is a bounded
+  #     detection latency, not fast resolution. One hour bounds it.
+  #   * Polling faster would mostly sample bind windows. A roll legitimately
+  #     serves the outgoing measurement while the record already names the
+  #     incoming one; the accepted set covers that, but every extra run is more
+  #     unauthenticated fetches against three planes for a value that changes
+  #     only on an enclave rebuild.
+  #   * :23 keeps it clear of the top-of-hour price-refresh + deploy rush, the
+  #     same reasoning as daily-embeddings-probe.yml's 13:17.
+  schedule:
+    - cron: "23 * * * *"
+  # A control-plane deploy can change how the records are MIRRORED (that is
+  # exactly what added the Azure `regions` array the checker enumerates), so
+  # re-check as soon as one lands rather than waiting up to an hour.
+  workflow_run:
+    workflows: ["Deploy TR control plane"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      control_plane:
+        description: "Control plane to read published records from"
+        type: string
+        default: "https://trustedrouter.com"
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    name: published vs running
+    runs-on: ubuntu-latest
+    # Same rule as prod-smoke: never fail a PR on the state of production. PRs
+    # get the offline proofs (tests/test_trust_measurement_drift.py) via ci.yml,
+    # which is what keeps this script honest without depending on prod being up.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
+      - uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+      - name: Sync
+        run: uv sync --frozen
+      # --strict is the whole reason this runs here rather than only on a
+      # laptop: locally an unpublished plane is ordinary (staging mirrors,
+      # bring-up branches), but on a schedule "we stopped publishing a
+      # measurement" and "everything matches" must not be the same green tick.
+      #
+      # EXPECT THE FIRST RUN AFTER THIS MERGES TO BE RED, until the control
+      # plane deploy lands. Measured 2026-08-15 against production: the mirror
+      # was still dropping azure-release.json's `regions` array, so the checker
+      # could reach UAE North and not Southeast Asia and reported
+      #   [GAP] azure: 1 published MAA issuer(s) belong to no enumerated region
+      # That is the correct verdict for that state, not a flake. The same
+      # commit fixes trusted_router.trust.azure_release, so the deploy this
+      # workflow_run triggers on is what turns it green — verified end to end
+      # against the real planes by serving the patched mirror's output locally.
+      - name: Published measurements vs live attestations
+        run: >
+          uv run python scripts/verify_trust_measurements.py
+          --strict
+          --control-plane "${{ inputs.control_plane || 'https://trustedrouter.com' }}"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/Lore-Hex/quill-router/actions/workflows/ci.yml/badge.svg)](https://github.com/Lore-Hex/quill-router/actions/workflows/ci.yml)
 [![Deploy](https://github.com/Lore-Hex/quill-router/actions/workflows/deploy.yml/badge.svg)](https://github.com/Lore-Hex/quill-router/actions/workflows/deploy.yml)
 [![Prod smoke](https://github.com/Lore-Hex/quill-router/actions/workflows/prod-smoke.yml/badge.svg)](https://github.com/Lore-Hex/quill-router/actions/workflows/prod-smoke.yml)
+[![Trust drift](https://github.com/Lore-Hex/quill-router/actions/workflows/trust-drift.yml/badge.svg)](https://github.com/Lore-Hex/quill-router/actions/workflows/trust-drift.yml)
 [![Status](https://img.shields.io/website?url=https%3A%2F%2Fstatus.trustedrouter.com&label=status)](https://status.trustedrouter.com)
 [![Verifiable trust](https://img.shields.io/website?url=https%3A%2F%2Ftrust.trustedrouter.com&label=trust)](https://trust.trustedrouter.com)
 [![JavaScript SDK](https://img.shields.io/npm/v/@lore-hex/trusted-router?label=JS%20SDK&logo=npm)](https://www.npmjs.com/package/@lore-hex/trusted-router)

--- a/scripts/verify_trust_measurements.py
+++ b/scripts/verify_trust_measurements.py
@@ -21,10 +21,15 @@ Exit status is 0 only if every published measurement matched a live attestation
 AND every SERVING ENDPOINT the record enumerates was actually contacted. Named
 exactly, because the sweeping version of this sentence was false: the endpoints
 enumerated are gcp `api_base_url`, aws `api_base_url`, and azure `api_base_url`
-plus every `regions[].attestation_url`. Two published lists are NOT contacted —
+plus every `regions[].attestation_url` that names a reachable place — one that
+does not is reported as a coverage gap rather than fetched. That last item is a
+PLUS and not an OR, which it was not when this sentence was first written:
+regions[] was an else branch for api_base_url, so a record enumerating one
+region left the gateway it advertises to verifiers uncontacted, and the run
+still printed the full success sentence. Two published lists are NOT contacted —
 gcp `api_base_urls[]` and `tls.hostnames[]`. The attestation routes derived from
-`api_base_urls[]` are printed under the gcp result, so the limit is visible where
-the verdict is and not only here.
+`api_base_urls[]` are printed under the gcp result, so the limit is visible
+where the verdict is and not only here.
 
 WHAT THIS VERSION CLOSES, AND ONE CLAIM IT REFUTES
 Measured 2026-08-15 by running the previous version of this file (82be9cdf)
@@ -151,6 +156,15 @@ WHAT THIS DOES NOT ESTABLISH
       leaving the gap to be inferred from silence. Azure's `regions[]` is not
       the same case and is enumerated: those entries name DIFFERENT CCE policies
       and therefore different measurements at different endpoints.
+    * "The same endpoint" is decided on scheme, host, port and path, by
+      trusted_router.endpoint_identity — the same code the mirror's validator
+      uses, because two implementations of this question disagreeing is itself a
+      false-coverage lever. DNS is NOT consulted: two hostnames that resolve to
+      one workload count as two endpoints here, so a record can still inflate
+      its region count by publishing two names for one gateway. Nothing in the
+      record says they are the same, and finding out is endpoint-identity work
+      rather than measurement drift. Percent-encoding and path case are compared
+      as written, for the same reason an origin is entitled to distinguish them.
     * An Azure record naming ONE region, ONE issuer and TWO accepted hostdata
       values is accepted as covered. That shape is a one-region plane mid-roll
       and a two-region plane whose second region was never published, and the
@@ -186,6 +200,11 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import cbor2
+
+# The one thing this script shares with the control plane it reads from: what
+# makes two published URLs the same endpoint. See _endpoint_identity below for
+# why a private copy here was a defect rather than a convenience.
+from trusted_router.endpoint_identity import Identity, parse_endpoint
 
 # Fallbacks only: used when a record names no api_base_url to derive from.
 GCP_ATTESTATION_URL = "https://api.trustedrouter.com/attestation"
@@ -351,13 +370,14 @@ def _attestation_url(record: dict[str, Any], fallback: str) -> str:
     disagrees with the endpoint this script polls would let the two describe
     different gateways while the run stayed green.
     """
-    api_base_url = record.get("api_base_url")
-    if not isinstance(api_base_url, str) or not api_base_url:
+    endpoint = parse_endpoint(record.get("api_base_url"))
+    if endpoint is None:
+        # Includes an api_base_url urllib cannot parse at all. Returning the
+        # fallback rather than raising keeps a malformed field in ONE plane's
+        # record from being indistinguishable from the whole check crashing.
         return fallback
-    parts = urllib.parse.urlsplit(api_base_url)
-    if not parts.scheme or not parts.netloc:
-        return fallback
-    return urllib.parse.urlunsplit((parts.scheme, parts.netloc, "/attestation", "", ""))
+    netloc = endpoint.host if endpoint.port is None else f"{endpoint.host}:{endpoint.port}"
+    return f"{endpoint.scheme}://{netloc}/attestation"
 
 
 def _alias_attestation_urls(record: dict[str, Any], contacted: str) -> list[str]:
@@ -382,8 +402,8 @@ def _alias_attestation_urls(record: dict[str, Any], contacted: str) -> list[str]
     return urls
 
 
-def _endpoint_identity(url: str) -> tuple[str, str, str | None, str]:
-    """What a client would actually talk to, for counting purposes.
+def _endpoint_identity(url: object) -> Identity | None:
+    """What a client would actually talk to, or None when the URL names no place.
 
     Coverage is a count of PLACES CONTACTED, so what makes two published URLs
     the same has to be what the request lands on — scheme, host, port, path —
@@ -392,11 +412,18 @@ def _endpoint_identity(url: str) -> tuple[str, str, str | None, str]:
     endpoint, and counting them as two is this file's own defect rebuilt out of
     punctuation. Query strings are folded in for the same reason: an attestation
     route is not made into a second region by a parameter.
+
+    The comparison itself is trusted_router.endpoint_identity, imported rather
+    than reimplemented, and that import is the point. This file had its own copy
+    and the mirror's validator had another; the two disagreed — this one kept an
+    explicit `:443` and the validator's normalized it away — and neither folded
+    a trailing slash, a trailing dot on the host, or a doubled path slash. Two
+    normalizers that disagree let a record be accepted at the mirror on one
+    reading and counted as N covered regions on the other. Read that module for
+    the exact fold rules and for what they deliberately do not cover (no DNS, no
+    percent-decoding).
     """
-    parts = urllib.parse.urlsplit(url)
-    host = (parts.hostname or parts.netloc).lower()
-    port = str(parts.port) if parts.port else None
-    return (parts.scheme.lower(), host, port, parts.path or "/")
+    return endpoint.identity if (endpoint := parse_endpoint(url)) is not None else None
 
 
 def _jwt_claims(token_bytes: bytes, plane: str) -> dict[str, Any]:
@@ -645,7 +672,7 @@ class AzurePlan:
     regions: tuple[AzureRegion, ...]
     issuers: tuple[str, ...]
     enumerated: bool  # True when regions[] supplied the endpoints, not the fallback
-    defects: tuple[str, ...]  # ways the record's own regions[] cannot ground coverage
+    defects: tuple[str, ...]  # ways the record's own account cannot ground coverage
 
 
 def azure_plan(record: dict[str, Any]) -> AzurePlan:
@@ -664,6 +691,20 @@ def azure_plan(record: dict[str, Any]) -> AzurePlan:
     the one thing it can support: a record that gives no endpoint array at all
     while naming more than one accepted value has left this run unable to tell
     those two cases apart, which is a hole in coverage rather than a pass.
+
+    api_base_url is not a census either — it names one endpoint, not a count —
+    but it IS the address the record hands a verifier, so it is contacted
+    whether or not regions[] mentions it. It used to be read only when regions[]
+    was empty, which meant publishing a region array could leave the plane's own
+    advertised gateway unchecked while the run printed the full success
+    sentence. A record whose regions[] omits it is contradicting itself about
+    where it serves, so that is a defect as well as an extra fetch.
+
+    Every endpoint returned here is a distinct place: entries are folded on
+    endpoint identity, an entry that names no reachable place is dropped with a
+    defect rather than fetched, and the advertised endpoint is added only when
+    no entry already named it. check_azure counts coverage over what answered,
+    and it can only do that honestly if this list holds no twins.
     """
     issuers = tuple(
         value for value in record.get("attestation_issuers", []) if isinstance(value, str) and value
@@ -672,13 +713,24 @@ def azure_plan(record: dict[str, Any]) -> AzurePlan:
     entries = [entry for entry in raw if isinstance(entry, dict)] if isinstance(raw, list) else []
     defects: list[str] = []
     regions: list[AzureRegion] = []
-    seen: set[tuple[str, str, str | None, str]] = set()
+    seen: set[Identity] = set()
     for entry in entries:
         url = entry.get("attestation_url")
         if not isinstance(url, str) or not url:
             defects.append("a regions[] entry names no attestation_url, so it cannot be contacted")
             continue
         identity = _endpoint_identity(url)
+        if identity is None:
+            # Not fetched, and not counted. A string that names no reachable
+            # place — a malformed authority, a non-http scheme, or the
+            # `https://a@b/` userinfo trick, which reads as host a and contacts
+            # host b — is a coverage claim this run cannot honour, so it is a
+            # defect rather than an endpoint.
+            defects.append(
+                f"a regions[] entry names {url!r}, which is not a plain http(s) endpoint, "
+                "so it cannot be contacted"
+            )
+            continue
         if identity in seen:
             # Counting entries rather than distinct endpoints is how a success
             # line claims two regions on the strength of one fetch. Compared on
@@ -711,6 +763,23 @@ def azure_plan(record: dict[str, Any]) -> AzurePlan:
         # gets checked at its canonical endpoint. The coverage rules in
         # check_azure are what say out loud when that is less than the plane.
         regions = [AzureRegion(_attestation_url(record, AZURE_ATTESTATION_URL), "", "")]
+    else:
+        # The record's OWN api_base_url is where it tells a verifier to go, and
+        # regions[] is where it says it serves from. When they disagree, the
+        # endpoint an actual reader would contact is the one nothing checks:
+        # regions[] used to be an ELSE for api_base_url, so a record enumerating
+        # only Southeast Asia left the UAE North gateway it advertises
+        # uncontacted while the run printed the full success sentence. It is
+        # contacted now, and the disagreement is itself a defect — a record that
+        # advertises an endpoint its region census omits cannot ground a count.
+        advertised = _attestation_url(record, "")
+        advertised_identity = _endpoint_identity(advertised)
+        if advertised_identity is not None and advertised_identity not in seen:
+            defects.append(
+                f"the record's api_base_url advertises {advertised} to verifiers but regions[] "
+                "does not name it, so the record disagrees with itself about where it serves"
+            )
+            regions.append(AzureRegion(advertised, "", ""))
     return AzurePlan(tuple(regions), issuers, enumerated, tuple(defects))
 
 
@@ -764,8 +833,13 @@ def check_azure(control_plane: str, transport: Transport) -> Result:
          one accepted hostdata value, so this run cannot tell a second region
          from a bind window;
       4. the regions[] array itself cannot ground a count — duplicate URLs, an
-         entry with no URL, or an entry naming no hostdata or issuer to
-         attribute what it serves.
+         entry with no URL or one that names no reachable place, or an entry
+         naming no hostdata or issuer to attribute what it serves;
+      5. the record's own api_base_url resolves to an attestation endpoint that
+         regions[] does not name, so the record disagrees with itself about
+         where this plane serves from. That endpoint IS contacted anyway — see
+         azure_plan — because it is where a verifier reading the record is told
+         to go; the gap is that the region census does not account for it.
     Rules 2 and 3 exist because coverage used to hang entirely on the optional
     attestation_issuers field: dropping it from the record turned off both the
     gap detection and the live-issuer check, and a two-region plane passed
@@ -880,11 +954,13 @@ REMEDIATION = (
 )
 GAP_REMEDIATION = (
     "A [GAP] is not drift: every measurement that was compared matched. It means\n"
-    "this run could not establish that it covered the whole plane — either a\n"
-    "published MAA issuer was presented by none of the endpoints reached, or the\n"
-    "record carries no census to check coverage against. Fix it by publishing\n"
-    "every serving region in the record's `regions` array, each with its own\n"
-    "attestation_url, hostdata and attestation_issuer: quill-cloud-proxy's\n"
+    "this run could not establish that it covered the whole plane — a published\n"
+    "MAA issuer was presented by none of the endpoints reached, the record\n"
+    "carries no census to check coverage against, or the record disagrees with\n"
+    "itself about where it serves. The gap lines printed above say which.\n"
+    "Fix it by publishing every serving region in the record's `regions` array,\n"
+    "each with its own attestation_url, hostdata and attestation_issuer, and by\n"
+    "keeping api_base_url among them: quill-cloud-proxy's\n"
     "tools/capture-plane-measurements.py writes it, quill-router's\n"
     "trusted_router.services.trust_release.validated_azure_metadata validates and\n"
     "carries it, and trusted_router.trust.azure_release publishes it."

--- a/scripts/verify_trust_measurements.py
+++ b/scripts/verify_trust_measurements.py
@@ -12,78 +12,406 @@ Fetching happens against the live serving planes. Nothing here is billed and no
 prompt is sent; every endpoint used is an unauthenticated attestation route.
 
     uv run python scripts/verify_trust_measurements.py
+    uv run python scripts/verify_trust_measurements.py --strict
     uv run python scripts/verify_trust_measurements.py --control-plane https://…
 
-Exit status is 0 only if every configured measurement matches what is running.
-Unconfigured planes are reported and do NOT fail the run; drift does.
+WHAT THIS ANSWERS
+    "Is what we publish what is running, on every plane we serve from?"
+Exit status is 0 only if every published measurement matched a live attestation
+AND every endpoint the record says exists was actually contacted.
 
-The canonical, cryptographically complete verifier is quill-cloud-proxy's
-tools/verify-attestation.py, which checks signatures and certificate chains.
-This script deliberately does less: it answers "is what we publish what is
-running", which is the question a signature check does not ask.
+WHAT THIS VERSION CLOSES, AND ONE CLAIM IT REFUTES
+Measured 2026-08-15 by running the previous version of this file (82be9cdf)
+against a fixture plane and against production:
+
+  1. Nothing ran it. Every other mention of this file in quill-router was a
+     COMMENT pointing at it as the thing that would catch drift — config.py
+     line 365 and trust.py line 142 — and no workflow, script or test invoked
+     it. (The brief that started this work placed those comments in
+     scripts/deploy/rollout.sh; that file does not mention the script at all.
+     The substance held, the location did not.) A drift check nobody is
+     required to run has the reliability of a note in a drawer, which is why it
+     is now wired to .github/workflows/trust-drift.yml on a schedule.
+  2. REFUTED, and recorded because acting on it would have been wasted work:
+     the brief said GCP was not checked at all and that main() looped over
+     (aws, azure). It did not. 82be9cdf's main() loops over
+     (("gcp", check_gcp), ("aws", check_aws), ("azure", check_azure)) and its
+     check_gcp compares the running digest against accepted_image_digests. Run
+     against a fixture, the old file printed "[ok] gcp: image digest matches".
+     What was actually wrong on GCP was smaller: the endpoint was a constant
+     here rather than the record's own api_base_url, and image_reference was
+     published but compared against nothing. Both are fixed below.
+  3. It contacted ONE Azure region. AZURE_ATTESTATION_URL was hardcoded to UAE
+     North while the plane also serves Southeast Asia from
+     api-azure-sea.trustedrouter.com with its own CCE policy and therefore its
+     own hostdata (f3a0b4ed…d712d81c). That region was never contacted, and its
+     measurement was never compared to anything. Demonstrated: with Southeast
+     Asia serving a hostdata published nowhere, the old file fetched only the
+     UAE North endpoint, printed "[ok] azure: hostdata and issuer match", and
+     exited 0.
+  4. Having checked one Azure region of two it printed "Every published
+     measurement matches a live attestation." Run and confirmed verbatim. The
+     endpoints reached are now stated in the summary, so the last line can
+     never claim more coverage than the run had.
+
+ENDPOINTS COME FROM THE RECORD, NOT FROM CONSTANTS HERE
+    A plane that grows a region grows it in its own published record. Hardcoding
+    the endpoint list here is how hole 3 happened: the record already named the
+    second Azure region and this script could not see it. Azure endpoints are
+    read from record["regions"]; the per-plane constants below survive only as
+    the fallback for a record that names no api_base_url.
+
+    A corollary that has teeth: if the record lists an MAA issuer that belongs to
+    no enumerated region, there is a serving region we publish measurements for
+    and cannot reach. That is reported as [GAP] and fails the run, because an
+    "ok" printed under it would be the same overclaim as hole 4.
+
+WHY A SKIP IS LENIENT BY DEFAULT AND FATAL UNDER --strict
+    Locally this script is a diagnostic: it is run against staging mirrors, a
+    control plane mid-bring-up, and branches where a plane genuinely publishes
+    nothing yet. Making an unpublished plane fatal there trains the reader to
+    pass a flag to silence it, and a check people routinely silence is a check
+    that stops being read.
+    In CI the opposite is true, and it is the whole reason the scheduled job
+    exists: "we stopped publishing a measurement" and "everything matches" must
+    not be the same green tick. On a schedule, silence is the failure mode being
+    hunted, so the workflow passes --strict and a skip is a failure there.
+
+WHAT THIS DOES NOT ESTABLISH
+    * No signature is verified. Not the Nitro COSE_Sign1 signature, not the
+      Nitro certificate chain, not the MAA JWT signature, not the Confidential
+      Space JWT signature. Every live value here is read out of an unauthenticated
+      response. The canonical, cryptographically complete verifier is
+      quill-cloud-proxy's tools/verify-attestation.py. This script deliberately
+      does less: it answers "is what we publish what is running", which is the
+      question a signature check does not ask.
+    * AWS is SAMPLED, not enumerated. api-aws.trustedrouter.com is fronted by a
+      Global Accelerator across more than one enclave, so N fetches reach some
+      subset of the fleet. Measured 2026-08-15: 8 consecutive fetches from one
+      client all reached i-02e34e58761097671-enc01a004d7a9c3c307, while the
+      published record's observed_module_id names a DIFFERENT enclave
+      (i-0ada95aad6d11aa56-enc01a004f1c2824652) — so repeated sampling from one
+      vantage point does not converge on the fleet, and the distinct-module-id
+      count this prints is a lower bound, never a census. A green AWS line means
+      "every enclave we happened to reach matched", nothing more. Enumerating
+      the fleet needs per-NLB pinning (see trusted_router.synthetic.probes and
+      TR_SYNTHETIC_GATEWAY_REGION_TARGETS), which is a different tool's job.
+    * The AWS certificate binding checked here is user_data[0:32] only. user_data
+      is 96 bytes: [0:32] is SHA-256 of the served certificate DER (verified on
+      6/6 samples when this was written, 8/8 on re-measurement), [32:64] is a
+      constant this script does not interpret, and [64:96] is the TLS exporter
+      channel binding, which cannot be checked from here because CPython's ssl
+      module exposes no keying-material export. The payload's public_key/SPKI
+      binding is likewise not checked here; probes.py::_aws_cert_binding_ok
+      checks both and is the reference for that.
+    * Matching the accepted SET is not proof the primary is serving. Both are
+      reported; only set membership is enforced, because a rolling deploy
+      legitimately serves the outgoing measurement while the record already
+      names the incoming one.
 """
 
 from __future__ import annotations
 
 import argparse
 import base64
+import hashlib
+import http.client
 import json
 import ssl
 import sys
+import urllib.error
+import urllib.parse
 import urllib.request
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
 import cbor2
 
+# Fallbacks only: used when a record names no api_base_url to derive from.
 GCP_ATTESTATION_URL = "https://api.trustedrouter.com/attestation"
 AWS_ATTESTATION_URL = "https://api-aws.trustedrouter.com/attestation"
 AZURE_ATTESTATION_URL = "https://api-azure.trustedrouter.com/attestation"
+GCP_ATTESTATION_ISSUER = "https://confidentialcomputing.googleapis.com"
 DEFAULT_CONTROL_PLANE = "https://trustedrouter.com"
 TIMEOUT_SECONDS = 25
 NOT_CONFIGURED = "not-configured"
+# Enough fetches that a fleet the accelerator actually spreads us across shows
+# up as more than one module id, few enough that the whole run stays under a
+# CI step's patience. It buys a lower bound, not coverage — see the scope limit.
+DEFAULT_AWS_SAMPLES = 5
+# The enclave's user_data layout, in bytes. Named so a future reader does not
+# have to rediscover that the certificate hash is 32 bytes and not 64, which is
+# what trust.py's published `certificate_binding` string used to say.
+AWS_USER_DATA_LENGTH = 96
+AWS_USER_DATA_CERT_SHA256 = slice(0, 32)
 
 
 @dataclass
 class Result:
+    """One plane's verdict, plus what the verdict is actually based on.
+
+    `endpoints` and `unreached` exist so the summary can be honest: the old
+    success line could not distinguish "checked three planes" from "checked one
+    and skipped two" because nothing carried the coverage.
+    """
+
     plane: str
     ok: bool
     detail: str
     skipped: bool = False
+    gap: bool = False
+    endpoints: tuple[str, ...] = ()
+    unreached: tuple[str, ...] = ()
     extra: list[str] = field(default_factory=list)
 
-
-def _fetch(url: str, *, verify_tls: bool = True) -> bytes:
-    context: ssl.SSLContext | None = None
-    if not verify_tls:
-        # The AWS enclave serves a certificate it generated itself, so there is
-        # no chain to validate — that is the design, not a defect. The binding
-        # that replaces chain validation lives in the attestation's user_data.
-        # This script does not check that binding, so treat what it returns as
-        # an unauthenticated read: good enough to detect our own drift, not
-        # good enough to authenticate the enclave. Use verify-attestation.py
-        # for the latter.
-        context = ssl.create_default_context()
-        context.check_hostname = False
-        context.verify_mode = ssl.CERT_NONE
-    if not url.startswith(("https://", "http://127.0.0.1:")):
-        # Scheme is fixed by construction; assert it anyway so a future
-        # caller cannot turn this into a file:// read.
-        raise ValueError(f"refusing to fetch non-HTTP(S) URL {url!r}")
-    request = urllib.request.Request(url, headers={"accept": "*/*"})  # noqa: S310
-    with urllib.request.urlopen(  # noqa: S310 - scheme checked above
-        request, timeout=TIMEOUT_SECONDS, context=context
-    ) as response:
-        return response.read()
+    @property
+    def mark(self) -> str:
+        if self.skipped:
+            return "SKIP"
+        if self.gap:
+            return "GAP"
+        return "ok" if self.ok else "DRIFT"
 
 
-def live_aws_pcr0() -> str:
-    """PCR0 from the running Nitro enclave.
+@dataclass(frozen=True)
+class Fetched:
+    body: bytes
+    peer_certificate_der: bytes | None = None
+
+
+class Transport:
+    """Every network read this script performs, behind one seam.
+
+    The proofs in tests/test_trust_measurement_drift.py substitute recorded
+    plane responses for live ones through this. Without the seam the only way
+    to test the checker is to point it at production, which means the test
+    suite passes or fails on whether prod is up — and a drift check whose own
+    tests are flaky gets muted, which returns us to hole 1.
+    """
+
+    def fetch(
+        self, url: str, *, verify_tls: bool = True, want_peer_certificate: bool = False
+    ) -> Fetched:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class NetworkTransport(Transport):
+    def fetch(
+        self, url: str, *, verify_tls: bool = True, want_peer_certificate: bool = False
+    ) -> Fetched:
+        if not url.startswith(("https://", "http://127.0.0.1:")):
+            # Scheme is fixed by construction; assert it anyway so a future
+            # caller cannot turn this into a file:// read.
+            raise ValueError(f"refusing to fetch non-HTTP(S) URL {url!r}")
+        if want_peer_certificate:
+            return self._fetch_with_peer_certificate(url, verify_tls=verify_tls)
+        context: ssl.SSLContext | None = None
+        if not verify_tls:
+            context = _unverified_context()
+        request = urllib.request.Request(url, headers={"accept": "*/*"})  # noqa: S310
+        with urllib.request.urlopen(  # noqa: S310 - scheme checked above
+            request, timeout=TIMEOUT_SECONDS, context=context
+        ) as response:
+            return Fetched(response.read())
+
+    def _fetch_with_peer_certificate(self, url: str, *, verify_tls: bool) -> Fetched:
+        """http.client rather than urllib, because urllib hands back no socket.
+
+        The certificate that has to be hashed is the one served on THIS
+        connection; reading it from a second connection would compare the
+        attestation against a certificate it never saw.
+        """
+        parts = urllib.parse.urlsplit(url)
+        context = ssl.create_default_context() if verify_tls else _unverified_context()
+        connection = http.client.HTTPSConnection(
+            parts.hostname or "",
+            parts.port or 443,
+            context=context,
+            timeout=TIMEOUT_SECONDS,
+        )
+        target = urllib.parse.urlunsplit(("", "", parts.path or "/", parts.query, ""))
+        try:
+            connection.request("GET", target, headers={"accept": "*/*"})
+            response = connection.getresponse()
+            body = response.read()
+            if response.status != 200:
+                raise urllib.error.HTTPError(
+                    url, response.status, response.reason, response.headers, None
+                )
+            sock = connection.sock
+            peer = sock.getpeercert(binary_form=True) if isinstance(sock, ssl.SSLSocket) else None
+        finally:
+            connection.close()
+        return Fetched(body, peer)
+
+
+def _unverified_context() -> ssl.SSLContext:
+    # The AWS enclave serves a certificate it generated itself, so there is no
+    # chain to validate — that is the design, not a defect. The binding that
+    # replaces chain validation lives in the attestation's user_data, and this
+    # script now checks the certificate half of it (see check_aws). The other
+    # half, the TLS exporter value, still is not checked here, so treat an AWS
+    # read as authenticated only as far as "the document names this cert".
+    context = ssl.create_default_context()
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+    return context
+
+
+# 503 is what the control plane returns for a record it has no measurement for.
+# Static origins say the same thing differently: S3 returns 403 for a missing
+# object on a bucket that denies listing, GCS and GitHub Pages return 404.
+# Treating only 503 as "unpublished" made this script CRASH against exactly the
+# mirrors the records are moving to — a stack trace where the honest answer is
+# "that plane publishes nothing here".
+NOT_PUBLISHED_STATUSES = frozenset({403, 404, 503})
+
+
+def _published(control_plane: str, path: str, transport: Transport) -> dict[str, Any] | None:
+    """Published release record, or None when nothing is published there."""
+    url = f"{control_plane.rstrip('/')}{path}"
+    try:
+        return json.loads(transport.fetch(url).body)
+    except urllib.error.HTTPError as exc:  # noqa: UP041 - urllib error hierarchy
+        if exc.code in NOT_PUBLISHED_STATUSES:
+            return None
+        raise
+    except ValueError as exc:
+        # A 200 carrying something that is not a record is a different failure
+        # from an absent record, and must not be silently read as "unpublished"
+        # — that is how a broken mirror looks identical to an honest one.
+        raise ValueError(f"{url} returned a non-JSON body: {exc}") from exc
+
+
+def _attestation_url(record: dict[str, Any], fallback: str) -> str:
+    """The plane's attestation route, derived from the record it published.
+
+    api_base_url is where a verifier is told to go, so the drift check has to
+    go THERE and not to a constant compiled in here. A record whose api_base_url
+    disagrees with the endpoint this script polls would let the two describe
+    different gateways while the run stayed green.
+    """
+    api_base_url = record.get("api_base_url")
+    if not isinstance(api_base_url, str) or not api_base_url:
+        return fallback
+    parts = urllib.parse.urlsplit(api_base_url)
+    if not parts.scheme or not parts.netloc:
+        return fallback
+    return urllib.parse.urlunsplit((parts.scheme, parts.netloc, "/attestation", "", ""))
+
+
+def _jwt_claims(token_bytes: bytes, plane: str) -> dict[str, Any]:
+    token = token_bytes.decode("ascii").strip()
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise ValueError(f"{plane} attestation is not a three-part JWT")
+    padded = parts[1] + "=" * (-len(parts[1]) % 4)
+    claims = json.loads(base64.urlsafe_b64decode(padded))
+    if not isinstance(claims, dict):
+        raise ValueError(f"{plane} attestation payload is not a JSON object")
+    return claims
+
+
+def _accepted(record: dict[str, Any], plural_key: str, scalar_key: str) -> list[str]:
+    """The accepted SET, never the scalar.
+
+    A rolling deploy legitimately serves the outgoing measurement while the
+    record already names the incoming one — observed exactly that mid-roll on
+    2026-08-15 — so a scalar comparison would report drift on every deploy and
+    train the reader to ignore it.
+    """
+    values = record.get(plural_key) or [record.get(scalar_key)]
+    return [value for value in values if isinstance(value, str) and value != NOT_CONFIGURED]
+
+
+# ---------------------------------------------------------------------------
+# GCP — Confidential Space
+# ---------------------------------------------------------------------------
+
+
+def live_gcp_container(url: str, transport: Transport) -> tuple[str, str, str]:
+    """(image digest, image reference, issuer) from the running workload."""
+    claims = _jwt_claims(transport.fetch(url).body, "GCP")
+    issuer = claims.get("iss")
+    if not isinstance(issuer, str) or not issuer:
+        raise ValueError("GCP attestation has no issuer")
+    container = claims.get("submods", {}).get("container", {})
+    digest = container.get("image_digest")
+    if not isinstance(digest, str) or not digest.startswith("sha256:"):
+        raise ValueError("GCP attestation has no container image digest")
+    reference = container.get("image_reference")
+    return digest, reference if isinstance(reference, str) else "", issuer
+
+
+def check_gcp(control_plane: str, transport: Transport) -> Result:
+    """Compare the running GCP workload against the published accepted set.
+
+    This plane WAS already checked before this rewrite — see the refutation in
+    the module docstring. What changed is that the endpoint now comes from the
+    record instead of a constant, the issuer is compared against the record's
+    own attestation_issuer, and image_reference is compared at all.
+    """
+    record = _published(control_plane, "/trust/gcp-release.json", transport)
+    if record is None:
+        return Result("gcp", ok=True, detail="no measurement published", skipped=True)
+    accepted = _accepted(record, "accepted_image_digests", "image_digest")
+    if not accepted:
+        return Result("gcp", ok=True, detail="no measurement published", skipped=True)
+    url = _attestation_url(record, GCP_ATTESTATION_URL)
+    running, running_reference, issuer = live_gcp_container(url, transport)
+    accepted_references = _accepted(record, "accepted_image_references", "image_reference")
+    expected_issuer = record.get("attestation_issuer") or GCP_ATTESTATION_ISSUER
+
+    problems: list[str] = []
+    if running not in accepted:
+        problems.append("running image digest is not in the published accepted set")
+    if issuer != expected_issuer:
+        problems.append(f"live attestation issuer {issuer} is not the published {expected_issuer}")
+    if accepted_references and running_reference and running_reference not in accepted_references:
+        # The digest is the measurement and the reference is only a name, but a
+        # verifier told to expect one tag and handed another has no way to know
+        # which of the two is stale. Both are published, so both must be true.
+        problems.append("running image reference is not in the published accepted set")
+
+    extra = [
+        f"endpoint:  {url}",
+        f"running:   {running}",
+        *(f"published: {value}" for value in accepted),
+        f"reference: {running_reference or '(absent)'}",
+    ]
+    if problems:
+        return Result("gcp", ok=False, detail="; ".join(problems), endpoints=(url,), extra=extra)
+    note = "" if running == record.get("image_digest") else " (rolling; matches accepted set)"
+    return Result(
+        "gcp",
+        ok=True,
+        detail=f"image digest matches{note}",
+        endpoints=(url,),
+        extra=extra,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AWS — Nitro Enclaves
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AwsSample:
+    pcr0: str
+    module_id: str
+    binding: str  # "" when the certificate binding held; otherwise why it did not
+
+
+def sample_aws_enclave(url: str, transport: Transport) -> AwsSample:
+    """One attestation from whichever enclave the accelerator picked.
 
     Fails closed: anything unexpected in the document shape raises rather than
     returning a value that might silently be the wrong 48 bytes.
     """
-    envelope = cbor2.loads(_fetch(AWS_ATTESTATION_URL, verify_tls=False))
+    fetched = transport.fetch(url, verify_tls=False, want_peer_certificate=True)
+    envelope = cbor2.loads(fetched.body)
     if not isinstance(envelope, list) or len(envelope) != 4:
         raise ValueError("AWS attestation is not a 4-element COSE_Sign1 envelope")
     document = cbor2.loads(envelope[2])
@@ -97,20 +425,153 @@ def live_aws_pcr0() -> str:
     pcr0 = pcrs[0]
     if not isinstance(pcr0, bytes) or len(pcr0) != 48:
         raise ValueError(f"PCR0 is {len(pcr0) if isinstance(pcr0, bytes) else '?'} bytes, want 48")
-    return pcr0.hex()
+    module_id = document.get("module_id")
+    return AwsSample(
+        pcr0.hex(),
+        module_id if isinstance(module_id, str) else "(unnamed)",
+        _aws_binding_problem(document, fetched.peer_certificate_der),
+    )
 
 
-def live_azure_hostdata() -> tuple[str, str]:
-    """(hostdata, MAA issuer) from the running confidential container.
+def _aws_binding_problem(document: dict[Any, Any], peer_certificate_der: bytes | None) -> str:
+    """Does the document bind the certificate this connection was served?
+
+    Fails closed on absence. An attested endpoint whose document binds nothing
+    is indistinguishable from a relay, and "unverifiable" must never be printed
+    as "verified" — the same rule probes.py enforces for the live probes.
+    """
+    if peer_certificate_der is None:
+        return "no peer certificate was captured, so the binding is unverifiable"
+    user_data = document.get("user_data")
+    if not isinstance(user_data, bytes):
+        return "attestation carries no user_data, so it binds no certificate"
+    if len(user_data) != AWS_USER_DATA_LENGTH:
+        return f"user_data is {len(user_data)} bytes, want {AWS_USER_DATA_LENGTH}"
+    expected = hashlib.sha256(peer_certificate_der).digest()
+    if user_data[AWS_USER_DATA_CERT_SHA256] != expected:
+        return "user_data[0:32] is not SHA-256 of the certificate served on this connection"
+    return ""
+
+
+def check_aws(control_plane: str, transport: Transport, samples: int) -> Result:
+    """Sample the AWS fleet and compare every sample to the accepted set.
+
+    Deliberately called sampling in the output. One fetch of an anycast name
+    reaches one enclave, so the previous single-fetch version reported "ok" for
+    a fleet it had observed one member of. Sampling narrows that; it does not
+    close it (see the module docstring's measurement).
+    """
+    record = _published(control_plane, "/trust/aws-release.json", transport)
+    if record is None:
+        return Result("aws", ok=True, detail="no measurement published", skipped=True)
+    accepted = _accepted(record, "accepted_pcr0s", "pcr0")
+    if not accepted:
+        return Result("aws", ok=True, detail="no measurement published", skipped=True)
+    url = _attestation_url(record, AWS_ATTESTATION_URL)
+
+    observed = [sample_aws_enclave(url, transport) for _ in range(max(1, samples))]
+    module_ids = sorted({sample.module_id for sample in observed})
+    drifted = sorted({sample.pcr0 for sample in observed if sample.pcr0 not in accepted})
+    unbound = sorted({sample.binding for sample in observed if sample.binding})
+
+    extra = [
+        f"endpoint:  {url}",
+        f"sampled:   {len(observed)} fetch(es) reached {len(module_ids)} distinct enclave(s): "
+        + ", ".join(module_ids),
+        "note:      this is SAMPLING, not enumeration — an enclave the accelerator "
+        "never routed us to was not checked",
+        *(f"running:   {sample_pcr0}" for sample_pcr0 in sorted({s.pcr0 for s in observed})),
+        *(f"published: {value}" for value in accepted),
+    ]
+    published_module_id = record.get("observed_module_id")
+    if isinstance(published_module_id, str) and published_module_id not in module_ids:
+        # Not drift: the record names the enclave that was live when the
+        # measurement was captured, and the fleet has more than one member.
+        # Worth printing, because it is the cheapest evidence that the sample
+        # above is a subset.
+        extra.append(
+            f"note:      record's observed_module_id {published_module_id} was not among "
+            "the sampled enclaves, which is expected for a fleet and is further "
+            "evidence this run saw a subset"
+        )
+
+    problems: list[str] = []
+    if drifted:
+        problems.append(f"{len(drifted)} sampled PCR0(s) are not in the published accepted set")
+    if unbound:
+        problems.append("; ".join(unbound))
+    if problems:
+        return Result("aws", ok=False, detail="; ".join(problems), endpoints=(url,), extra=extra)
+    return Result(
+        "aws",
+        ok=True,
+        detail=f"every sampled PCR0 matches, certificate binding holds on {len(observed)} sample(s)",
+        endpoints=(url,),
+        extra=extra,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Azure — Confidential Containers on SEV-SNP
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AzureRegion:
+    url: str
+    hostdata: str  # "" when the record enumerates no per-region expectation
+    issuer: str
+
+
+def azure_regions(record: dict[str, Any]) -> tuple[list[AzureRegion], list[str]]:
+    """(endpoints to contact, issuers that belong to no endpoint).
+
+    The record is the authority on how many places this plane serves from.
+    One MAA instance is provisioned per serving region, so attestation_issuers
+    is a region count that cannot be confused with a bind window the way
+    accepted_hostdata can: hostdata rolls when a CCE policy changes, issuers do
+    not. An issuer with no endpoint is therefore a region we publish a
+    measurement for and never check.
+    """
+    issuers = [value for value in record.get("attestation_issuers", []) if isinstance(value, str)]
+    regions: list[AzureRegion] = []
+    for entry in record.get("regions") or []:
+        if not isinstance(entry, dict):
+            continue
+        url = entry.get("attestation_url")
+        if not isinstance(url, str) or not url:
+            continue
+        hostdata = entry.get("hostdata")
+        issuer = entry.get("attestation_issuer")
+        regions.append(
+            AzureRegion(
+                url,
+                hostdata if isinstance(hostdata, str) else "",
+                issuer if isinstance(issuer, str) else "",
+            )
+        )
+    if not regions:
+        # A single-region record — or a mirror that dropped the array — still
+        # gets checked at its canonical endpoint. The unreached issuers below
+        # are what says out loud when that is less than the whole plane.
+        regions = [AzureRegion(_attestation_url(record, AZURE_ATTESTATION_URL), "", "")]
+    reached_issuers = {region.issuer for region in regions if region.issuer}
+    if reached_issuers:
+        unreached = [issuer for issuer in issuers if issuer not in reached_issuers]
+    else:
+        # No region names its issuer, so attribution is by count alone: a record
+        # listing more MAA instances than it gives endpoints for is short by the
+        # difference, whichever ones those are.
+        unreached = issuers[len(regions) :]
+    return regions, unreached
+
+
+def live_azure_hostdata(url: str, transport: Transport) -> tuple[str, str]:
+    """(hostdata, MAA issuer) from one running confidential container.
 
     The token's signature is not checked here; see the module docstring.
     """
-    token = _fetch(AZURE_ATTESTATION_URL).decode("ascii").strip()
-    parts = token.split(".")
-    if len(parts) != 3:
-        raise ValueError("Azure attestation is not a three-part JWT")
-    padded = parts[1] + "=" * (-len(parts[1]) % 4)
-    claims = json.loads(base64.urlsafe_b64decode(padded))
+    claims = _jwt_claims(transport.fetch(url).body, "Azure")
     if claims.get("x-ms-attestation-type") != "sevsnpvm":
         raise ValueError(f"unexpected attestation type {claims.get('x-ms-attestation-type')!r}")
     hostdata = claims.get("x-ms-sevsnpvm-hostdata")
@@ -122,158 +583,197 @@ def live_azure_hostdata() -> tuple[str, str]:
     return hostdata, issuer
 
 
-# 503 is what the control plane returns for a record it has no measurement for.
-# Static origins say the same thing differently: S3 returns 403 for a missing
-# object on a bucket that denies listing, GCS and GitHub Pages return 404.
-# Treating only 503 as "unpublished" made this script CRASH against exactly the
-# mirrors the records are moving to — a stack trace where the honest answer is
-# "that plane publishes nothing here".
-NOT_PUBLISHED_STATUSES = frozenset({403, 404, 503})
+def check_azure(control_plane: str, transport: Transport) -> Result:
+    """Contact EVERY region the record enumerates, not the first one.
 
-
-def _published(control_plane: str, path: str) -> dict[str, Any] | None:
-    """Published release record, or None when nothing is published there."""
-    url = f"{control_plane.rstrip('/')}{path}"
-    try:
-        return json.loads(_fetch(url))
-    except urllib.error.HTTPError as exc:  # noqa: UP041 - urllib error hierarchy
-        if exc.code in NOT_PUBLISHED_STATUSES:
-            return None
-        raise
-    except ValueError as exc:
-        # A 200 carrying something that is not a record is a different failure
-        # from an absent record, and must not be silently read as "unpublished"
-        # — that is how a broken mirror looks identical to an honest one.
-        raise ValueError(f"{url} returned a non-JSON body: {exc}") from exc
-
-
-def live_gcp_digest() -> str:
-    """Container image digest from the running Confidential Space workload."""
-    token = _fetch(GCP_ATTESTATION_URL).decode("ascii").strip()
-    parts = token.split(".")
-    if len(parts) != 3:
-        raise ValueError("GCP attestation is not a three-part JWT")
-    padded = parts[1] + "=" * (-len(parts[1]) % 4)
-    claims = json.loads(base64.urlsafe_b64decode(padded))
-    if claims.get("iss") != "https://confidentialcomputing.googleapis.com":
-        raise ValueError(f"unexpected attestation issuer {claims.get('iss')!r}")
-    digest = claims.get("submods", {}).get("container", {}).get("image_digest")
-    if not isinstance(digest, str) or not digest.startswith("sha256:"):
-        raise ValueError("GCP attestation has no container image digest")
-    return digest
-
-
-def check_gcp(control_plane: str) -> Result:
-    """Compare the running GCP workload against the published accepted set.
-
-    Against the SET, never the scalar. A rolling deploy legitimately serves the
-    outgoing digest while the record already names the incoming one — observed
-    exactly that mid-roll on 2026-08-15 — so a scalar comparison would report
-    drift on every deploy and train the reader to ignore it.
-
-    GCP went longest without this check, which is the wrong way round: it is the
-    plane that carries every prompt.
+    Southeast Asia runs a different CCE policy from UAE North, so it has a
+    permanently different hostdata. The previous version compared UAE North's
+    hostdata against the union of both and printed success — a check that would
+    have stayed green through any drift in the region it never contacted.
     """
-    record = _published(control_plane, "/trust/gcp-release.json")
+    record = _published(control_plane, "/trust/azure-release.json", transport)
     if record is None:
-        return Result("gcp", ok=True, detail="no measurement published", skipped=True)
-    accepted = [
-        value
-        for value in record.get("accepted_image_digests") or [record.get("image_digest")]
-        if isinstance(value, str) and value != NOT_CONFIGURED
-    ]
+        return Result("azure", ok=True, detail="no measurement published", skipped=True)
+    accepted = _accepted(record, "accepted_hostdata", "hostdata")
     if not accepted:
-        return Result("gcp", ok=True, detail="no measurement published", skipped=True)
-    running = live_gcp_digest()
-    if running not in accepted:
+        return Result("azure", ok=True, detail="no measurement published", skipped=True)
+    issuers = [value for value in record.get("attestation_issuers", []) if isinstance(value, str)]
+    regions, unreached = azure_regions(record)
+
+    problems: list[str] = []
+    extra: list[str] = []
+    for region in regions:
+        running, issuer = live_azure_hostdata(region.url, transport)
+        extra.append(f"endpoint:  {region.url}")
+        extra.append(f"  running:   {running}")
+        extra.append(f"  issuer:    {issuer}")
+        if running not in accepted:
+            problems.append(f"{region.url} serves hostdata that is not in the published set")
+            extra.append("  published: " + ", ".join(accepted))
+        elif region.hostdata and running != region.hostdata:
+            # Set membership alone would pass a region serving its NEIGHBOUR's
+            # policy, which is a real misconfiguration and not a bind window.
+            problems.append(f"{region.url} serves hostdata the record attributes to another region")
+            extra.append(f"  expected:  {region.hostdata}")
+        if issuers and issuer not in issuers:
+            # A region we serve from but never listed. A verifier following our
+            # record would reject a token that is in fact genuine.
+            problems.append(f"live MAA issuer {issuer} is not in the published issuer list")
+        elif region.issuer and issuer != region.issuer:
+            problems.append(f"{region.url} is signed by {issuer}, not the record's {region.issuer}")
+
+    endpoints = tuple(region.url for region in regions)
+    if problems:
         return Result(
-            "gcp",
-            ok=False,
-            detail="running image digest is not in the published accepted set",
-            extra=[f"running:   {running}", *(f"published: {v}" for v in accepted)],
+            "azure", ok=False, detail="; ".join(problems), endpoints=endpoints, extra=extra
         )
-    note = "" if running == record.get("image_digest") else " (rolling; matches accepted set)"
+    if unreached:
+        return Result(
+            "azure",
+            ok=False,
+            gap=True,
+            detail=(
+                f"{len(unreached)} published MAA issuer(s) belong to no enumerated region, so "
+                "part of this plane was never contacted"
+            ),
+            endpoints=endpoints,
+            unreached=tuple(unreached),
+            extra=[*extra, *(f"unreached: {issuer}" for issuer in unreached)],
+        )
     return Result(
-        "gcp", ok=True, detail=f"image digest matches{note}", extra=[f"running: {running}"]
+        "azure",
+        ok=True,
+        detail=f"hostdata and issuer match in all {len(regions)} enumerated region(s)",
+        endpoints=endpoints,
+        extra=extra,
     )
 
 
-def check_aws(control_plane: str) -> Result:
-    record = _published(control_plane, "/trust/aws-release.json")
-    if record is None:
-        return Result("aws", ok=True, detail="no measurement published (503)", skipped=True)
-    accepted = [value for value in record.get("accepted_pcr0s", []) if value != NOT_CONFIGURED]
-    if not accepted:
-        return Result("aws", ok=True, detail="no measurement published", skipped=True)
-    running = live_aws_pcr0()
-    if running not in accepted:
-        return Result(
-            "aws",
-            ok=False,
-            detail="running PCR0 is not in the published accepted set",
-            extra=[f"running:   {running}", *(f"published: {value}" for value in accepted)],
-        )
-    note = "" if running == record.get("pcr0") else " (matches accepted set, not the primary)"
-    return Result("aws", ok=True, detail=f"PCR0 matches{note}", extra=[f"running: {running}"])
+# ---------------------------------------------------------------------------
 
 
-def check_azure(control_plane: str) -> Result:
-    record = _published(control_plane, "/trust/azure-release.json")
-    if record is None:
-        return Result("azure", ok=True, detail="no measurement published (503)", skipped=True)
-    accepted = [value for value in record.get("accepted_hostdata", []) if value != NOT_CONFIGURED]
-    if not accepted:
-        return Result("azure", ok=True, detail="no measurement published", skipped=True)
-    running, issuer = live_azure_hostdata()
-    problems: list[str] = []
-    if running not in accepted:
-        problems.append("running hostdata is not in the published accepted set")
-    issuers = record.get("attestation_issuers", [])
-    if issuers and issuer not in issuers:
-        # A region we serve from but never listed. A verifier following our
-        # record would reject a token that is in fact genuine.
-        problems.append(f"live MAA issuer {issuer} is not in the published issuer list")
-    detail_extra = [
-        f"running:   {running}",
-        *(f"published: {value}" for value in accepted),
-        f"issuer:    {issuer}",
-    ]
-    if problems:
-        return Result("azure", ok=False, detail="; ".join(problems), extra=detail_extra)
-    return Result("azure", ok=True, detail="hostdata and issuer match", extra=detail_extra)
+REMEDIATION = (
+    "Republish from the plane that drifted — in quill-cloud-proxy run\n"
+    "`python3 tools/capture-plane-measurements.py --write` and commit\n"
+    "trust-page/, adding --keep-accepted if a roll is still in progress. The\n"
+    "control plane mirrors those records, so there is nothing to change here."
+)
+GAP_REMEDIATION = (
+    "A [GAP] is not drift: the measurements that were compared matched. It means\n"
+    "the record names a serving region this run could not reach, so the run\n"
+    "covered less of the plane than the record describes. Fix it by publishing\n"
+    "that region in the record's `regions` array — quill-cloud-proxy's\n"
+    "tools/capture-plane-measurements.py writes it, and quill-router's\n"
+    "trusted_router.trust.azure_release mirrors it through."
+)
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--control-plane", default=DEFAULT_CONTROL_PLANE)
-    args = parser.parse_args()
-
+def run_checks(
+    control_plane: str, transport: Transport, *, aws_samples: int = DEFAULT_AWS_SAMPLES
+) -> list[Result]:
+    checks = (
+        ("gcp", lambda: check_gcp(control_plane, transport)),
+        ("aws", lambda: check_aws(control_plane, transport, aws_samples)),
+        ("azure", lambda: check_azure(control_plane, transport)),
+    )
     results: list[Result] = []
-    for name, check in (("gcp", check_gcp), ("aws", check_aws), ("azure", check_azure)):
+    for name, check in checks:
         try:
-            results.append(check(args.control_plane))
+            results.append(check())
         except Exception as exc:  # noqa: BLE001 - any failure is a failed check
             results.append(Result(name, ok=False, detail=f"check failed: {exc}"))
+    return results
+
+
+def summary_lines(results: Sequence[Result], *, strict: bool) -> list[str]:
+    """What was checked and what was not, in the same breath as the verdict.
+
+    The line this replaces read "Every published measurement matches a live
+    attestation." after contacting one of the two Azure regions the record
+    itself enumerated. Any success sentence that does not enumerate its own
+    coverage can say that again the next time coverage narrows.
+    """
+    checked = [result for result in results if not result.skipped]
+    skipped = [result for result in results if result.skipped]
+    endpoints = sum(len(result.endpoints) for result in results)
+    lines = [
+        f"Checked {len(checked)} plane(s) at {endpoints} endpoint(s): "
+        + (", ".join(f"{result.plane} ({len(result.endpoints)})" for result in checked) or "none"),
+        "Skipped (nothing published): " + (", ".join(result.plane for result in skipped) or "none"),
+    ]
+    unreached = [(result.plane, name) for result in results for name in result.unreached]
+    if unreached:
+        lines.append("Not reached: " + ", ".join(f"{plane} {name}" for plane, name in unreached))
+    if skipped and strict:
+        lines.append(
+            "--strict: a plane that publishes no measurement is a failure here, because "
+            "on a schedule 'we stopped publishing' and 'everything matches' must not be "
+            "the same green tick."
+        )
+    return lines
+
+
+def main(argv: Sequence[str] | None = None, transport: Transport | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--control-plane", default=DEFAULT_CONTROL_PLANE)
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="treat a plane that publishes no measurement as a failure (used by CI)",
+    )
+    parser.add_argument(
+        "--aws-samples",
+        type=int,
+        default=DEFAULT_AWS_SAMPLES,
+        help="attestations to fetch from the AWS accelerator (sampling, not enumeration)",
+    )
+    args = parser.parse_args(argv)
+
+    results = run_checks(
+        args.control_plane, transport or NetworkTransport(), aws_samples=args.aws_samples
+    )
 
     for result in results:
-        mark = "SKIP" if result.skipped else ("ok" if result.ok else "DRIFT")
-        print(f"[{mark}] {result.plane}: {result.detail}")
+        print(f"[{result.mark}] {result.plane}: {result.detail}")
         for line in result.extra:
             print(f"       {line}")
 
-    failed = [result for result in results if not result.ok]
-    if failed:
+    print()
+    for line in summary_lines(results, strict=args.strict):
+        print(line)
+
+    drifted = [result for result in results if not result.ok and not result.gap]
+    gaps = [result for result in results if result.gap]
+    skipped = [result for result in results if result.skipped]
+    if drifted:
         print(
-            f"\n{len(failed)} plane(s) publish a measurement that is not what is running.\n"
-            "Republish from the plane that drifted — in quill-cloud-proxy run\n"
-            "`python3 tools/capture-plane-measurements.py --write` and commit\n"
-            "trust-page/, adding --keep-accepted if a roll is still in progress. The\n"
-            "control plane mirrors those records, so there is nothing to change here.\n"
-            "widen the accepted set if a bind window is in progress.",
+            f"\n{len(drifted)} plane(s) publish a measurement that is not what is running.\n"
+            + REMEDIATION,
             file=sys.stderr,
         )
+    if gaps:
+        print(
+            f"\n{len(gaps)} plane(s) were only partly covered.\n" + GAP_REMEDIATION,
+            file=sys.stderr,
+        )
+    if skipped and args.strict:
+        print(
+            f"\n{len(skipped)} plane(s) publish no measurement at all, and --strict is on.\n"
+            "A measurement that silently stopped being published looks exactly like a\n"
+            "plane that never had one; on a schedule that is the failure being hunted.",
+            file=sys.stderr,
+        )
+    if drifted or gaps or (args.strict and skipped):
         return 1
-    print("\nEvery published measurement matches a live attestation.")
+    if len(skipped) == len(results):
+        # Found by running this against https://aws.trustedrouter.com, which
+        # publishes no measurement for any plane: the success sentence printed
+        # under a summary reading "Checked 0 plane(s)". Vacuously true and
+        # exactly the reading this rewrite exists to stop — a line saying
+        # everything matched, above nothing.
+        print("\nNothing was checked: no plane at this control plane publishes a measurement.")
+        return 0
+    print("\nEvery published measurement listed above matches a live attestation.")
     return 0
 
 

--- a/scripts/verify_trust_measurements.py
+++ b/scripts/verify_trust_measurements.py
@@ -18,7 +18,13 @@ prompt is sent; every endpoint used is an unauthenticated attestation route.
 WHAT THIS ANSWERS
     "Is what we publish what is running, on every plane we serve from?"
 Exit status is 0 only if every published measurement matched a live attestation
-AND every endpoint the record says exists was actually contacted.
+AND every SERVING ENDPOINT the record enumerates was actually contacted. Named
+exactly, because the sweeping version of this sentence was false: the endpoints
+enumerated are gcp `api_base_url`, aws `api_base_url`, and azure `api_base_url`
+plus every `regions[].attestation_url`. Two published lists are NOT contacted —
+gcp `api_base_urls[]` and `tls.hostnames[]`. The attestation routes derived from
+`api_base_urls[]` are printed under the gcp result, so the limit is visible where
+the verdict is and not only here.
 
 WHAT THIS VERSION CLOSES, AND ONE CLAIM IT REFUTES
 Measured 2026-08-15 by running the previous version of this file (82be9cdf)
@@ -61,10 +67,36 @@ ENDPOINTS COME FROM THE RECORD, NOT FROM CONSTANTS HERE
     read from record["regions"]; the per-plane constants below survive only as
     the fallback for a record that names no api_base_url.
 
-    A corollary that has teeth: if the record lists an MAA issuer that belongs to
-    no enumerated region, there is a serving region we publish measurements for
-    and cannot reach. That is reported as [GAP] and fails the run, because an
-    "ok" printed under it would be the same overclaim as hole 4.
+    A corollary that has teeth: if the record publishes an MAA issuer that NONE
+    of the endpoints this run contacted presented, there is a serving region we
+    publish measurements for and cannot reach. That is reported as [GAP] and
+    fails the run, because an "ok" printed under it would be the same overclaim
+    as hole 4. The attribution is from the issuers observed live, not from the
+    issuer the record attributes to an entry and never by list position — an
+    earlier revision sliced the issuer list by count and could name as unreached
+    the very issuer whose region HAD answered.
+
+    That corollary rests on an OPTIONAL field, which is its weak point and is
+    handled rather than assumed. A record that publishes no `attestation_issuers`
+    has no region census in it at all, and a record that publishes no `regions[]`
+    array while naming more than one accepted hostdata value cannot distinguish a
+    second serving region from a bind window. Both are [GAP], not [ok]: coverage
+    that cannot be established is not coverage. Before that, deleting one
+    optional field from the record turned off both halves of the multi-region
+    guarantee and a two-region plane passed --strict having contacted one region.
+
+THE MIRROR BOUNDS THIS SCRIPT, AND THE VALIDATOR BOUNDS THE MIRROR
+    Endpoints can only come from the record if the record still has them when it
+    is served. trusted_router.trust.azure_release mirrors the plane's `regions[]`
+    array through, and trusted_router.services.trust_release.validated_azure_metadata
+    — the validator the serving route interposes ahead of it — validates and
+    carries that array rather than whitelisting three scalar keys and dropping
+    it. Fixing only the former is dead code on the production route; that is
+    exactly what the first version of this change did, and the record served was
+    byte-identical to before it. A region entry the rest of the record
+    contradicts is refused whole there, not dropped: dropping erases a live
+    serving region from the published record with nothing left downstream to
+    notice, which is this script's failure mode wearing the mirror's clothes.
 
 WHY A SKIP IS LENIENT BY DEFAULT AND FATAL UNDER --strict
     Locally this script is a diagnostic: it is run against staging mirrors, a
@@ -108,6 +140,33 @@ WHAT THIS DOES NOT ESTABLISH
       reported; only set membership is enforced, because a rolling deploy
       legitimately serves the outgoing measurement while the record already
       names the incoming one.
+    * The GCP record's `api_base_urls[]` and `tls.hostnames[]` are NOT contacted.
+      They are alias hostnames (api.allyrouter.com, api.uptimerouter.com) for
+      the one Confidential Space workload the scalar `api_base_url` names, and
+      the record attributes no separate measurement to them — so fetching them
+      would re-verify the same image digest. Whether each alias still RESOLVES
+      to that workload is a different question, endpoint hijack rather than
+      measurement drift, and .github/workflows/deploy.yml's alias smoke is what
+      asks it. This run prints those endpoints under the gcp result rather than
+      leaving the gap to be inferred from silence. Azure's `regions[]` is not
+      the same case and is enumerated: those entries name DIFFERENT CCE policies
+      and therefore different measurements at different endpoints.
+    * An Azure record naming ONE region, ONE issuer and TWO accepted hostdata
+      values is accepted as covered. That shape is a one-region plane mid-roll
+      and a two-region plane whose second region was never published, and the
+      record does not distinguish them — accepted_hostdata rolls when a CCE
+      policy changes, so it cannot be read as a region count. Closing this needs
+      the plane to publish the region; it is not closeable from this side, and
+      the gap rules above deliberately do not guess.
+    * The three planes are a constant here, not read from the record. There is
+      no index endpoint listing them; gcp, aws and azure are the only release
+      records that exist. A fourth plane would have to be added to this file by
+      hand, and nothing in this file would notice if it were not.
+    * NetworkTransport accepts a literal `http://127.0.0.1:` prefix so a local
+      fixture plane can be pointed at. `http://127.0.0.1:80@evil.com/x` passes
+      that prefix check through the URL userinfo trick — reachable only by
+      passing a hostile --control-plane, and the guard's stated purpose
+      (refusing file://) is unaffected.
 """
 
 from __future__ import annotations
@@ -301,6 +360,45 @@ def _attestation_url(record: dict[str, Any], fallback: str) -> str:
     return urllib.parse.urlunsplit((parts.scheme, parts.netloc, "/attestation", "", ""))
 
 
+def _alias_attestation_urls(record: dict[str, Any], contacted: str) -> list[str]:
+    """Endpoints the record also publishes in api_base_urls[] and does not get contacted.
+
+    Returned so the GCP result can PRINT them rather than leave the reader to
+    infer coverage from silence. They are deliberately not fetched — see the
+    scope limit in the module docstring for why alias hostnames are a different
+    question from measurement drift — and this is the mechanism that keeps the
+    limit visible in every run instead of only in a docstring.
+    """
+    raw = record.get("api_base_urls")
+    if not isinstance(raw, list):
+        return []
+    urls: list[str] = []
+    for value in raw:
+        if not isinstance(value, str) or not value:
+            continue
+        url = _attestation_url({"api_base_url": value}, "")
+        if url and url != contacted and url not in urls:
+            urls.append(url)
+    return urls
+
+
+def _endpoint_identity(url: str) -> tuple[str, str, str | None, str]:
+    """What a client would actually talk to, for counting purposes.
+
+    Coverage is a count of PLACES CONTACTED, so what makes two published URLs
+    the same has to be what the request lands on — scheme, host, port, path —
+    and never the raw string. `.../attestation#a` and `.../attestation#b` are
+    different strings; the fragment is not transmitted, so they are one
+    endpoint, and counting them as two is this file's own defect rebuilt out of
+    punctuation. Query strings are folded in for the same reason: an attestation
+    route is not made into a second region by a parameter.
+    """
+    parts = urllib.parse.urlsplit(url)
+    host = (parts.hostname or parts.netloc).lower()
+    port = str(parts.port) if parts.port else None
+    return (parts.scheme.lower(), host, port, parts.path or "/")
+
+
 def _jwt_claims(token_bytes: bytes, plane: str) -> dict[str, Any]:
     token = token_bytes.decode("ascii").strip()
     parts = token.split(".")
@@ -374,11 +472,23 @@ def check_gcp(control_plane: str, transport: Transport) -> Result:
         # which of the two is stale. Both are published, so both must be true.
         problems.append("running image reference is not in the published accepted set")
 
+    aliases = _alias_attestation_urls(record, url)
     extra = [
         f"endpoint:  {url}",
         f"running:   {running}",
         *(f"published: {value}" for value in accepted),
         f"reference: {running_reference or '(absent)'}",
+        *(
+            [
+                "scope:     api_base_urls[] also publishes "
+                + ", ".join(aliases)
+                + " — NOT contacted by this run; these are alias hostnames for the same "
+                "workload, and whether each resolves to it is deploy.yml's alias smoke, "
+                "not measurement drift"
+            ]
+            if aliases
+            else []
+        ),
     ]
     if problems:
         return Result("gcp", ok=False, detail="; ".join(problems), endpoints=(url,), extra=extra)
@@ -519,51 +629,89 @@ def check_aws(control_plane: str, transport: Transport, samples: int) -> Result:
 @dataclass(frozen=True)
 class AzureRegion:
     url: str
-    hostdata: str  # "" when the record enumerates no per-region expectation
-    issuer: str
+    hostdata: str  # "" when the record's entry named none
+    issuer: str  # "" when the record's entry named none
 
 
-def azure_regions(record: dict[str, Any]) -> tuple[list[AzureRegion], list[str]]:
-    """(endpoints to contact, issuers that belong to no endpoint).
+@dataclass(frozen=True)
+class AzurePlan:
+    """What the record SAYS this plane is, before anything has been contacted.
 
-    The record is the authority on how many places this plane serves from.
-    One MAA instance is provisioned per serving region, so attestation_issuers
-    is a region count that cannot be confused with a bind window the way
-    accepted_hostdata can: hostdata rolls when a CCE policy changes, issuers do
-    not. An issuer with no endpoint is therefore a region we publish a
-    measurement for and never check.
+    Kept separate from what was observed so the two can be compared rather than
+    conflated. The defect this whole file exists to remove was a count of
+    RECORD ENTRIES being printed as if it were a count of endpoints reached.
     """
-    issuers = [value for value in record.get("attestation_issuers", []) if isinstance(value, str)]
+
+    regions: tuple[AzureRegion, ...]
+    issuers: tuple[str, ...]
+    enumerated: bool  # True when regions[] supplied the endpoints, not the fallback
+    defects: tuple[str, ...]  # ways the record's own regions[] cannot ground coverage
+
+
+def azure_plan(record: dict[str, Any]) -> AzurePlan:
+    """Read the record's own account of where this plane serves from.
+
+    The record is the authority on how many places this plane serves from, and
+    it carries exactly TWO census signals:
+
+      * regions[] — the endpoints themselves. Authoritative when present.
+      * attestation_issuers — one MAA instance is provisioned per serving
+        region, and issuers do not roll the way hostdata does.
+
+    accepted_hostdata is deliberately NOT a third. It rolls when a CCE policy
+    changes, so a two-value accepted set is a two-region plane or a one-region
+    plane mid-roll and the record does not say which. check_azure uses it for
+    the one thing it can support: a record that gives no endpoint array at all
+    while naming more than one accepted value has left this run unable to tell
+    those two cases apart, which is a hole in coverage rather than a pass.
+    """
+    issuers = tuple(
+        value for value in record.get("attestation_issuers", []) if isinstance(value, str) and value
+    )
+    raw = record.get("regions")
+    entries = [entry for entry in raw if isinstance(entry, dict)] if isinstance(raw, list) else []
+    defects: list[str] = []
     regions: list[AzureRegion] = []
-    for entry in record.get("regions") or []:
-        if not isinstance(entry, dict):
-            continue
+    seen: set[tuple[str, str, str | None, str]] = set()
+    for entry in entries:
         url = entry.get("attestation_url")
         if not isinstance(url, str) or not url:
+            defects.append("a regions[] entry names no attestation_url, so it cannot be contacted")
             continue
+        identity = _endpoint_identity(url)
+        if identity in seen:
+            # Counting entries rather than distinct endpoints is how a success
+            # line claims two regions on the strength of one fetch. Compared on
+            # endpoint identity, so two entries differing only by fragment or
+            # query cannot buy a second region either.
+            defects.append(
+                f"regions[] names the endpoint behind {url} more than once, so it counts more "
+                "regions than it has places to contact"
+            )
+            continue
+        seen.add(identity)
         hostdata = entry.get("hostdata")
         issuer = entry.get("attestation_issuer")
-        regions.append(
-            AzureRegion(
-                url,
-                hostdata if isinstance(hostdata, str) else "",
-                issuer if isinstance(issuer, str) else "",
+        if not isinstance(hostdata, str) or not hostdata:
+            defects.append(
+                f"regions[] entry for {url} names no hostdata, so what it serves could only be "
+                "compared against the union of every region's accepted values"
             )
-        )
-    if not regions:
+            hostdata = ""
+        if not isinstance(issuer, str) or not issuer:
+            defects.append(
+                f"regions[] entry for {url} names no attestation_issuer, so the issuer it "
+                "presents cannot be attributed to it"
+            )
+            issuer = ""
+        regions.append(AzureRegion(url, hostdata, issuer))
+    enumerated = bool(regions)
+    if not enumerated:
         # A single-region record — or a mirror that dropped the array — still
-        # gets checked at its canonical endpoint. The unreached issuers below
-        # are what says out loud when that is less than the whole plane.
+        # gets checked at its canonical endpoint. The coverage rules in
+        # check_azure are what say out loud when that is less than the plane.
         regions = [AzureRegion(_attestation_url(record, AZURE_ATTESTATION_URL), "", "")]
-    reached_issuers = {region.issuer for region in regions if region.issuer}
-    if reached_issuers:
-        unreached = [issuer for issuer in issuers if issuer not in reached_issuers]
-    else:
-        # No region names its issuer, so attribution is by count alone: a record
-        # listing more MAA instances than it gives endpoints for is short by the
-        # difference, whichever ones those are.
-        unreached = issuers[len(regions) :]
-    return regions, unreached
+    return AzurePlan(tuple(regions), issuers, enumerated, tuple(defects))
 
 
 def live_azure_hostdata(url: str, transport: Transport) -> tuple[str, str]:
@@ -584,12 +732,44 @@ def live_azure_hostdata(url: str, transport: Transport) -> tuple[str, str]:
 
 
 def check_azure(control_plane: str, transport: Transport) -> Result:
-    """Contact EVERY region the record enumerates, not the first one.
+    """Contact every region the record enumerates, and count what was reached.
 
     Southeast Asia runs a different CCE policy from UAE North, so it has a
-    permanently different hostdata. The previous version compared UAE North's
-    hostdata against the union of both and printed success — a check that would
-    have stayed green through any drift in the region it never contacted.
+    permanently different hostdata. The version before this file was rewritten
+    compared UAE North's hostdata against the union of both and printed success
+    — a check that would have stayed green through any drift in the region it
+    never contacted.
+
+    COVERAGE IS COMPUTED FROM WHAT ANSWERED, NOT FROM WHAT THE RECORD LISTS.
+    Every count printed below is over the DISTINCT endpoints actually fetched,
+    and the issuer census is matched against the issuers those endpoints
+    presented live — not against the issuer the record attributes to an entry,
+    and never by list position. An earlier revision of this function did both:
+    it printed len(regions[]) as an endpoint count (two entries naming one URL
+    read as two regions covered) and, when no entry named an issuer, attributed
+    non-coverage by slicing the issuer list, which could name as unreached the
+    very issuer whose region HAD been contacted.
+
+    Each of the following is a coverage gap. None of them can produce an "ok" or
+    a zero exit; each is printed as a `gap:` line beside the verdict. The plane
+    is marked [GAP] when they are the only thing wrong, and [DRIFT] when a
+    measurement also mismatched — drift is the more serious verdict and takes
+    the mark, while the gap lines and the unreached issuers are still reported
+    under it. Stated this way because the shorter version of this sentence
+    ("a [GAP] is raised when any of these hold") was false for exactly that case.
+      1. a published MAA issuer was presented by none of the endpoints reached;
+      2. the record publishes no attestation_issuers at all, so nothing in it
+         says how many regions this plane serves from;
+      3. the record publishes no usable regions[] array while naming more than
+         one accepted hostdata value, so this run cannot tell a second region
+         from a bind window;
+      4. the regions[] array itself cannot ground a count — duplicate URLs, an
+         entry with no URL, or an entry naming no hostdata or issuer to
+         attribute what it serves.
+    Rules 2 and 3 exist because coverage used to hang entirely on the optional
+    attestation_issuers field: dropping it from the record turned off both the
+    gap detection and the live-issuer check, and a two-region plane passed
+    --strict having contacted one region.
     """
     record = _published(control_plane, "/trust/azure-release.json", transport)
     if record is None:
@@ -597,13 +777,21 @@ def check_azure(control_plane: str, transport: Transport) -> Result:
     accepted = _accepted(record, "accepted_hostdata", "hostdata")
     if not accepted:
         return Result("azure", ok=True, detail="no measurement published", skipped=True)
-    issuers = [value for value in record.get("attestation_issuers", []) if isinstance(value, str)]
-    regions, unreached = azure_regions(record)
+    plan = azure_plan(record)
 
     problems: list[str] = []
     extra: list[str] = []
-    for region in regions:
+    contacted: list[str] = []
+    live_issuers: list[str] = []
+    for region in plan.regions:
         running, issuer = live_azure_hostdata(region.url, transport)
+        # Appended after the fetch returned, so this is a list of endpoints that
+        # ANSWERED. azure_plan guarantees the URLs are distinct — a record
+        # naming one twice loses the duplicate there and gains a defect — so
+        # len(contacted) is an endpoint count and never an entry count.
+        contacted.append(region.url)
+        if issuer not in live_issuers:
+            live_issuers.append(issuer)
         extra.append(f"endpoint:  {region.url}")
         extra.append(f"  running:   {running}")
         extra.append(f"  issuer:    {issuer}")
@@ -615,35 +803,67 @@ def check_azure(control_plane: str, transport: Transport) -> Result:
             # policy, which is a real misconfiguration and not a bind window.
             problems.append(f"{region.url} serves hostdata the record attributes to another region")
             extra.append(f"  expected:  {region.hostdata}")
-        if issuers and issuer not in issuers:
+        if plan.issuers and issuer not in plan.issuers:
             # A region we serve from but never listed. A verifier following our
             # record would reject a token that is in fact genuine.
             problems.append(f"live MAA issuer {issuer} is not in the published issuer list")
         elif region.issuer and issuer != region.issuer:
             problems.append(f"{region.url} is signed by {issuer}, not the record's {region.issuer}")
 
-    endpoints = tuple(region.url for region in regions)
+    # Attribution by evidence: an issuer counts as reached only if an endpoint
+    # this run actually contacted presented it.
+    unreached = tuple(issuer for issuer in plan.issuers if issuer not in live_issuers)
+    gaps = [
+        f"published MAA issuer {issuer} was presented by none of the "
+        f"{len(contacted)} endpoint(s) this run contacted"
+        for issuer in unreached
+    ]
+    if not plan.issuers:
+        gaps.append(
+            "the record publishes no attestation_issuers, so nothing in it says how many "
+            "regions this plane serves from and this run cannot know what it did not reach"
+        )
+    if not plan.enumerated and len(accepted) > 1:
+        gaps.append(
+            f"the record publishes no regions[] array, so its {len(accepted)} accepted hostdata "
+            f"values share the one endpoint this run could derive from it — a second serving "
+            "region and a bind window are indistinguishable from here"
+        )
+    gaps.extend(plan.defects)
+
+    endpoints = tuple(contacted)
+    reached = (
+        f"{len(contacted)} endpoint(s) contacted, "
+        f"{len(live_issuers)} distinct MAA issuer(s) presented"
+    )
     if problems:
         return Result(
-            "azure", ok=False, detail="; ".join(problems), endpoints=endpoints, extra=extra
+            "azure",
+            ok=False,
+            detail="; ".join(problems),
+            endpoints=endpoints,
+            unreached=unreached,
+            extra=[*extra, *(f"gap:       {gap}" for gap in gaps)],
         )
-    if unreached:
+    if gaps:
         return Result(
             "azure",
             ok=False,
             gap=True,
-            detail=(
-                f"{len(unreached)} published MAA issuer(s) belong to no enumerated region, so "
-                "part of this plane was never contacted"
-            ),
+            detail=f"{len(gaps)} coverage gap(s) over {reached}: " + "; ".join(gaps),
             endpoints=endpoints,
-            unreached=tuple(unreached),
-            extra=[*extra, *(f"unreached: {issuer}" for issuer in unreached)],
+            unreached=unreached,
+            extra=[*extra, *(f"gap:       {gap}" for gap in gaps)],
         )
     return Result(
         "azure",
         ok=True,
-        detail=f"hostdata and issuer match in all {len(regions)} enumerated region(s)",
+        # Counted from the fetch list and the live tokens, so this sentence
+        # cannot describe more of the plane than answered.
+        detail=(
+            f"hostdata and issuer match at every one of {reached}, "
+            f"covering all {len(plan.issuers)} published MAA issuer(s)"
+        ),
         endpoints=endpoints,
         extra=extra,
     )
@@ -659,12 +879,15 @@ REMEDIATION = (
     "control plane mirrors those records, so there is nothing to change here."
 )
 GAP_REMEDIATION = (
-    "A [GAP] is not drift: the measurements that were compared matched. It means\n"
-    "the record names a serving region this run could not reach, so the run\n"
-    "covered less of the plane than the record describes. Fix it by publishing\n"
-    "that region in the record's `regions` array — quill-cloud-proxy's\n"
-    "tools/capture-plane-measurements.py writes it, and quill-router's\n"
-    "trusted_router.trust.azure_release mirrors it through."
+    "A [GAP] is not drift: every measurement that was compared matched. It means\n"
+    "this run could not establish that it covered the whole plane — either a\n"
+    "published MAA issuer was presented by none of the endpoints reached, or the\n"
+    "record carries no census to check coverage against. Fix it by publishing\n"
+    "every serving region in the record's `regions` array, each with its own\n"
+    "attestation_url, hostdata and attestation_issuer: quill-cloud-proxy's\n"
+    "tools/capture-plane-measurements.py writes it, quill-router's\n"
+    "trusted_router.services.trust_release.validated_azure_metadata validates and\n"
+    "carries it, and trusted_router.trust.azure_release publishes it."
 )
 
 

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -362,7 +362,10 @@ class Settings(BaseSettings):
     # hypothetical: trust.trustedrouter.com/pcr0.txt has served the same PCR0
     # since the initial commit and it matches no running enclave. Nothing caught
     # it because no code ever compared the published value to a live
-    # attestation. scripts/verify_trust_measurements.py is that comparison.
+    # attestation. scripts/verify_trust_measurements.py is that comparison, and
+    # .github/workflows/trust-drift.yml is what makes it happen: for a while
+    # this comment named a script that nothing in the repo ever executed, which
+    # is the same "nobody compared them" failure one level up.
     #
     # Both are SETS, not scalars. During a bind window the released key is bound
     # to the old and the new measurement at once — quill-cloud-proxy's

--- a/src/trusted_router/endpoint_identity.py
+++ b/src/trusted_router/endpoint_identity.py
@@ -1,0 +1,140 @@
+"""One answer to "do these two URLs name the same place", for both sides of it.
+
+WHY THIS IS A MODULE AND NOT TWO PRIVATE FUNCTIONS
+    Two things decide what an Azure `regions[]` entry is worth, and they used to
+    decide it differently. services.trust_release.validated_azure_metadata
+    refuses a record whose entries name one endpoint twice, and
+    scripts/verify_trust_measurements.py counts how many distinct endpoints a
+    run actually contacted. Each had its own normalizer: the validator's dropped
+    an explicit `:443` and the checker's kept it, and neither touched a trailing
+    slash, a trailing dot on the host, or a doubled path slash. Two normalizers
+    that disagree mean a record can be accepted at the mirror on one reading and
+    counted as N covered regions on the other, which is the false-coverage
+    defect this whole change exists to remove, rebuilt out of punctuation.
+
+STDLIB ONLY, ON PURPOSE
+    The validator's version was built on httpx.URL, which RAISES httpx.InvalidURL
+    on a malformed authority instead of returning a value. That exception is not
+    in httpx.HTTPError's hierarchy, so it escaped TrustReleaseResolver.resolve()
+    and turned the public /trust/azure-release.json route into a 500 for any
+    upstream record carrying a region URL like `https://[::1`. urllib.parse
+    raises ValueError for the same inputs and is caught here, so the answer to
+    "is this a place" is always a value and never an exception.
+
+WHAT "THE SAME PLACE" MEANS HERE, EXACTLY
+    Scheme, host, port and path, after the normalizations a client would perform
+    or that cannot change where a request lands:
+      * scheme and host are lowercased, and one trailing dot on the host is
+        removed (`h.com.` and `h.com` are the same name in DNS);
+      * a port equal to the scheme's default is dropped, so `https://h/x` and
+        `https://h:443/x` are one place;
+      * the path has empty segments and `.`/`..` segments removed per RFC 3986
+        §5.2.4, so `/a//b`, `/a/./b` and `/a/c/../b` are one path, and a
+        trailing slash is dropped so `/attestation/` and `/attestation` are one;
+      * query and fragment are NOT part of the identity. A fragment is never
+        transmitted, and an attestation route is not made into a second region
+        by a parameter.
+
+    Dropping the trailing slash is the one rule a server may disagree with: an
+    origin is free to serve `/a` and `/a/` differently, or to redirect between
+    them. It is deliberate and it is the safe direction. Every caller here uses
+    this to answer "how many distinct places did we cover", so folding two
+    strings together can only make a record claim FEWER regions than it wrote
+    down — never more — and the callers report the fold as a defect rather than
+    swallowing it.
+
+WHAT THIS DOES NOT DO
+    * No DNS. Two hostnames that resolve to one address, or a hostname and its
+      literal IP, are two endpoints here. Coverage is counted per published
+      name, which is what a verifier reading the record would contact.
+    * No percent-decoding and no case folding of the path. `/A` and `/a` are
+      different paths (they are, to an origin), and `/%61` is left as written.
+    * Nothing about whether the place EXISTS or answers. That is the fetch's
+      job, not this function's.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
+#: Ports that carry no information: naming them cannot change where a request
+#: lands, so an identity that kept them would count one place as two.
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+Identity = tuple[str, str, int | None, str]
+
+
+@dataclass(frozen=True, slots=True)
+class Endpoint:
+    """A parsed URL, reduced to what a request actually lands on."""
+
+    scheme: str
+    host: str
+    port: int | None
+    path: str
+    #: True when the string names the place and nothing else — no query, no
+    #: fragment. Both are ignored for identity, so a caller that needs the URL
+    #: to be exactly a place (a published coverage claim, say) has to ask.
+    bare: bool
+
+    @property
+    def identity(self) -> Identity:
+        return (self.scheme, self.host, self.port, self.path)
+
+
+def _normalized_path(path: str) -> str:
+    """RFC 3986 §5.2.4 remove_dot_segments, plus empty-segment removal.
+
+    Trailing slashes go with the empty segments, so `/a/` and `/a` normalize
+    together — see the module docstring for why that fold is deliberate.
+    """
+    segments: list[str] = []
+    for segment in path.split("/"):
+        if segment in ("", "."):
+            continue
+        if segment == "..":
+            if segments:
+                segments.pop()
+            continue
+        segments.append(segment)
+    return "/" + "/".join(segments)
+
+
+def parse_endpoint(url: object) -> Endpoint | None:
+    """The place `url` names, or None when it does not name one at all.
+
+    None — never an exception — for: a non-string, a string urllib cannot parse
+    (a malformed authority such as `https://[::1`, a non-numeric port), a scheme
+    other than http or https, an absent host, or a URL carrying userinfo.
+    Userinfo is refused rather than ignored because `https://a@b/` reads as host
+    a to a human and contacts host b, which is a coverage claim that lies about
+    where it points.
+    """
+    if not isinstance(url, str) or not url:
+        return None
+    try:
+        parts = urlsplit(url)
+        port = parts.port
+    except ValueError:
+        # Invalid IPv6 literal, or a port that is not a number. urlsplit defers
+        # both to attribute access, so the parse and the port read are in one
+        # try together on purpose.
+        return None
+    scheme = parts.scheme.lower()
+    if scheme not in _DEFAULT_PORTS:
+        return None
+    if parts.username or parts.password:
+        return None
+    host = (parts.hostname or "").lower().rstrip(".")
+    if not host:
+        return None
+    if port == _DEFAULT_PORTS[scheme]:
+        port = None
+    return Endpoint(
+        scheme=scheme,
+        host=host,
+        port=port,
+        path=_normalized_path(parts.path),
+        bare=not parts.query and not parts.fragment,
+    )

--- a/src/trusted_router/endpoint_identity.py
+++ b/src/trusted_router/endpoint_identity.py
@@ -24,8 +24,12 @@ STDLIB ONLY, ON PURPOSE
 WHAT "THE SAME PLACE" MEANS HERE, EXACTLY
     Scheme, host, port and path, after the normalizations a client would perform
     or that cannot change where a request lands:
-      * scheme and host are lowercased, and one trailing dot on the host is
-        removed (`h.com.` and `h.com` are the same name in DNS);
+      * scheme and host are lowercased, and EVERY trailing dot on the host is
+        removed, not just one (`h.com.` and `h.com` are the same name in DNS;
+        `h.com....` is not a name any resolver accepts, and folding it here
+        can only turn two spellings into one place, never one into two). A
+        host that is nothing but dots folds to the empty string and is
+        refused outright, like any other absent host;
       * a port equal to the scheme's default is dropped, so `https://h/x` and
         `https://h:443/x` are one place;
       * the path has empty segments and `.`/`..` segments removed per RFC 3986
@@ -35,13 +39,48 @@ WHAT "THE SAME PLACE" MEANS HERE, EXACTLY
         transmitted, and an attestation route is not made into a second region
         by a parameter.
 
+    WHERE EACH OF THOSE RULES IS PINNED, since a fold nothing tests is a fold
+    that can be deleted for looking redundant. Host case, trailing host dots,
+    the default port, the trailing slash, empty segments and `.`/`..` segments
+    each have a spelling in ENDPOINT_TWINS (tests/test_trust_measurement_drift
+    .py), driven through BOTH the mirror and the checker. The `..` fold and the
+    multi-dot host joined that list late: they were the two rules here with
+    nothing behind them, and deleting either left the whole file green while
+    restoring the false region count this module exists to remove. Ignoring
+    query and fragment is pinned differently, by the mirror refusing a region
+    URL that carries either. Lowercasing the scheme is pinned by nothing on
+    purpose — urlsplit has already done it, so that call is belt-and-braces and
+    not a rule. The opposite direction — spellings that must stay TWO places,
+    including a non-default port — is pinned by ENDPOINT_DISTINCTS beside it.
+
     Dropping the trailing slash is the one rule a server may disagree with: an
     origin is free to serve `/a` and `/a/` differently, or to redirect between
-    them. It is deliberate and it is the safe direction. Every caller here uses
-    this to answer "how many distinct places did we cover", so folding two
-    strings together can only make a record claim FEWER regions than it wrote
-    down — never more — and the callers report the fold as a defect rather than
-    swallowing it.
+    them. It is deliberate, and it is the safe direction for the two callers
+    that COUNT places: services.trust_release._endpoint_identity, whose caller
+    _validated_azure_regions refuses a record naming one endpoint twice, and
+    scripts/verify_trust_measurements.py's _endpoint_identity, which folds
+    azure_plan's endpoint list so coverage is counted over distinct places. For
+    those two, folding two strings together can only make a record claim FEWER
+    regions than it wrote down, never more, and each reports the fold as a
+    defect — a refused record and a coverage gap — rather than swallowing it.
+
+    TWO CALLERS COUNT NOTHING, AND BOTH SWALLOW A REFUSAL
+    Two more call sites are not census at all, and the paragraph above does not
+    describe them. scripts/verify_trust_measurements.py's _attestation_url, and
+    _alias_attestation_urls through it, use parse_endpoint to BUILD a URL to
+    fetch out of a record's `api_base_url`: they keep scheme, host and port,
+    discard the parsed path outright, and count nothing. Neither reports a
+    string this module refuses. _attestation_url returns the fallback endpoint
+    compiled into that script, so an `api_base_url` carrying userinfo, a
+    malformed authority or a non-http scheme makes the run poll the compiled-in
+    endpoint and stay green — the outcome _attestation_url's own docstring says
+    it exists to prevent — and _alias_attestation_urls drops such an alias from
+    the list it prints. That is a real gap in the checker, left open and named
+    here rather than papered over. It is NOT reachable through the mirror that
+    serves /trust/azure-release.json: trust.azure_release sets `api_base_url`
+    from the compiled-in AZURE_API_HOSTNAME constant rather than from the
+    upstream record, so no upstream string reaches _attestation_url there. It
+    is reachable by pointing --control-plane at a record nobody validated.
 
 WHAT THIS DOES NOT DO
     * No DNS. Two hostnames that resolve to one address, or a hostname and its

--- a/src/trusted_router/services/trust_release.py
+++ b/src/trusted_router/services/trust_release.py
@@ -11,6 +11,7 @@ from typing import Any
 import httpx
 
 from trusted_router.config import Settings
+from trusted_router.endpoint_identity import Identity, parse_endpoint
 
 _DIGEST_RE = re.compile(r"sha256:[0-9a-f]{64}")
 _COMMIT_RE = re.compile(r"[0-9a-f]{7,40}")
@@ -108,7 +109,26 @@ class TrustReleaseResolver:
                 try:
                     metadata = await self._fetch(release_url)
                     break
-                except (httpx.HTTPError, TypeError, ValueError) as exc:
+                except Exception as exc:  # noqa: BLE001 - see below
+                    # ANY failure to obtain a validated record is the same
+                    # outcome for a mirror: there is nothing trustworthy to
+                    # serve, so fall back, back off, and let the route answer
+                    # 503. This was an enumeration of exception classes
+                    # (httpx.HTTPError, TypeError, ValueError) and the
+                    # enumeration was wrong: `_validator` is a constructor
+                    # PARAMETER, so this layer cannot know what its vocabulary
+                    # is, and a validator built on httpx.URL raised
+                    # httpx.InvalidURL — outside httpx.HTTPError — which escaped
+                    # onto a public trust route as a 500 with no fallback, no
+                    # retry backoff and no stale-if-error serving, for a
+                    # malformed field in a record fetched from a remote mirror.
+                    #
+                    # The cost, stated plainly: a genuine bug in the fetch or
+                    # validate path now looks like an upstream outage instead of
+                    # a 500. It is chained into the TrustReleaseUnavailable
+                    # raised below (`from last_error`), so the cause travels
+                    # with it. BaseException is deliberately not caught, so
+                    # asyncio.CancelledError still propagates.
                     last_error = exc
             if metadata is None:
                 self._retry_after = now + _RETRY_SECONDS
@@ -322,24 +342,32 @@ _AZURE_REGION_OPTIONAL = ("launch_measurement", "compliance_status")
 _MAX_AZURE_REGIONS = 16
 
 
-def _endpoint_identity(url: str) -> tuple[str, str, int | None, str] | None:
+def _endpoint_identity(url: object) -> Identity | None:
     """What actually gets contacted, or None if this is not a plain https URL.
 
     A region entry's attestation_url is a coverage claim, so what makes two of
     them the same has to be what a client would end up talking to — scheme,
-    host, port and path — and not the string. Fragments are never transmitted
-    and a query is not an endpoint, so an entry may carry neither: two entries
-    that differ only there would inflate the region count while contacting one
-    place. Userinfo is refused because `https://a@b/` names host b while reading
-    as host a.
+    host, port and path — and not the string. That comparison lives in
+    trusted_router.endpoint_identity because the drift checker has to make it
+    the same way: it counts distinct endpoints contacted, so a pair this layer
+    accepts as two places and that one folds into one (or the reverse) is a
+    false coverage count with a mirror's signature on it.
+
+    Refused here, on top of "does not name a place at all": a scheme other than
+    https, and a URL carrying a query or a fragment. Neither is part of the
+    place, so two entries differing only there would inflate the region count
+    while contacting one endpoint.
+
+    Returns a value for every input, including malformed ones. The version this
+    replaces called httpx.URL(), which RAISES httpx.InvalidURL on a bad
+    authority — an exception outside httpx.HTTPError's hierarchy, so it escaped
+    TrustReleaseResolver.resolve() and made the public /trust/azure-release.json
+    route answer 500 for an upstream record naming a region at `https://[::1`.
     """
-    parsed = httpx.URL(url)
-    if parsed.scheme != "https" or not parsed.host:
+    endpoint = parse_endpoint(url)
+    if endpoint is None or endpoint.scheme != "https" or not endpoint.bare:
         return None
-    if parsed.query or parsed.fragment or parsed.userinfo:
-        return None
-    path = parsed.path or "/"
-    return ("https", parsed.host.lower(), parsed.port, path)
+    return endpoint.identity
 
 
 def _validated_azure_regions(
@@ -368,14 +396,25 @@ def _validated_azure_regions(
     field, because azure_release has no error channel, so accepting an
     incomplete entry here would just move the silent erasure one function later.
 
-    THE BLAST RADIUS, STATED PLAINLY. A refused record makes the mirror fall
-    back to the embedded Azure measurement, and rollout.sh does not set
-    TR_TRUST_AZURE_HOSTDATA — so in the current production configuration that
-    fallback is unconfigured and /trust/azure-release.json answers 503. Loud, on
-    purpose, and the same blast radius the existing rules above already carry
-    (an AWS pcr0 outside its own accepted set, an Azure record naming no MAA
-    issuer). Serving no Azure record is a state a verifier can act on; serving
-    one that has quietly lost a serving region is not.
+    THE BLAST RADIUS, STATED PLAINLY. Every refusal here is a ValueError, which
+    TrustReleaseResolver.resolve() turns into TrustReleaseUnavailable, so the
+    mirror falls back to the embedded Azure measurement — and rollout.sh does
+    not set TR_TRUST_AZURE_HOSTDATA, so in the current production configuration
+    that fallback is unconfigured and /trust/azure-release.json answers 503.
+    Loud, on purpose, and the same blast radius the existing rules above already
+    carry (an AWS pcr0 outside its own accepted set, an Azure record naming no
+    MAA issuer). Serving no Azure record is a state a verifier can act on;
+    serving one that has quietly lost a serving region is not.
+
+    That paragraph was false for one input class when it was first written, and
+    the shape of the mistake is worth keeping: _endpoint_identity was built on
+    httpx.URL, which RAISES rather than returning None for a malformed
+    authority, and httpx.InvalidURL is not an httpx.HTTPError — so a region
+    named `https://[::1` escaped the resolver entirely and the route answered
+    500 with no fallback, no backoff and no stale serving. A refusal that is
+    documented as one status code and delivered as another is worse than no
+    documentation. It is closed twice over: the identity parser returns a value
+    for every input, and resolve() no longer enumerates exception classes.
     """
     if "regions" not in payload:
         return []
@@ -388,7 +427,7 @@ def _validated_azure_regions(
     if len(raw) > _MAX_AZURE_REGIONS:
         raise ValueError("Azure record claims more serving regions than we would publish")
     regions: list[dict[str, str]] = []
-    seen_urls: set[tuple[str, str, int | None, str]] = set()
+    seen_urls: set[Identity] = set()
     for entry in raw:
         if not isinstance(entry, dict):
             raise ValueError("Azure region entry must be an object")

--- a/src/trusted_router/services/trust_release.py
+++ b/src/trusted_router/services/trust_release.py
@@ -307,6 +307,125 @@ def validated_aws_metadata(payload: object) -> Mapping[str, Any]:
     return {"pcr0": pcr0, "accepted_pcr0s": accepted}
 
 
+#: Optional descriptions a region entry may carry, copied verbatim and not
+#: interpreted here. attestation_url, hostdata and attestation_issuer are
+#: required of every entry and are validated individually below; everything
+#: else an upstream record sends is dropped, because mirroring whatever arrives
+#: would let the plane's record inject arbitrary fields into ours.
+_AZURE_REGION_OPTIONAL = ("launch_measurement", "compliance_status")
+#: An upper bound on how many serving regions a record may claim. The payload is
+#: already capped at _MAX_RELEASE_BYTES, which still leaves room for hundreds of
+#: entries — and every entry is an endpoint scripts/verify_trust_measurements.py
+#: will fetch, so an unbounded array is a fetch-amplification lever for anyone
+#: who can write the upstream record. Two regions are in service; sixteen is
+#: room to grow and still a refusal long before it becomes a load generator.
+_MAX_AZURE_REGIONS = 16
+
+
+def _endpoint_identity(url: str) -> tuple[str, str, int | None, str] | None:
+    """What actually gets contacted, or None if this is not a plain https URL.
+
+    A region entry's attestation_url is a coverage claim, so what makes two of
+    them the same has to be what a client would end up talking to — scheme,
+    host, port and path — and not the string. Fragments are never transmitted
+    and a query is not an endpoint, so an entry may carry neither: two entries
+    that differ only there would inflate the region count while contacting one
+    place. Userinfo is refused because `https://a@b/` names host b while reading
+    as host a.
+    """
+    parsed = httpx.URL(url)
+    if parsed.scheme != "https" or not parsed.host:
+        return None
+    if parsed.query or parsed.fragment or parsed.userinfo:
+        return None
+    path = parsed.path or "/"
+    return ("https", parsed.host.lower(), parsed.port, path)
+
+
+def _validated_azure_regions(
+    payload: dict[str, object], accepted: Sequence[str], issuers: Sequence[str]
+) -> list[dict[str, str]]:
+    """The per-region endpoint array, validated rather than dropped.
+
+    WHY THIS EXISTS AT ALL. accepted_hostdata is a union and cannot say which
+    endpoint serves which value, so a reader holding only the union can verify
+    whichever region anycast happens to give them and has no way to reach the
+    others. This array is the only thing in the record that names WHERE each
+    region answers, and it is what scripts/verify_trust_measurements.py
+    enumerates. Until this function existed the mirror whitelisted three scalar
+    keys and dropped it, so the checker read a record with no endpoints to
+    enumerate and could reach exactly one of the two Azure regions.
+
+    WHY A CONTRADICTORY ENTRY RAISES INSTEAD OF BEING DROPPED. A region whose
+    hostdata or issuer the rest of the record disowns is a self-inconsistent
+    record, the same class as an AWS record whose accepted set excludes its own
+    pcr0 — and that one is refused here rather than repaired. Dropping the entry
+    instead would erase a live serving region from the published record with no
+    trace: the region simply stops existing, the drift check contacts what is
+    left and goes green, and the plane we quietly stopped covering is the one
+    nobody is looking at. It is also the only choice that keeps this layer and
+    trust._azure_regions agreeing — that one drops an entry missing a required
+    field, because azure_release has no error channel, so accepting an
+    incomplete entry here would just move the silent erasure one function later.
+
+    THE BLAST RADIUS, STATED PLAINLY. A refused record makes the mirror fall
+    back to the embedded Azure measurement, and rollout.sh does not set
+    TR_TRUST_AZURE_HOSTDATA — so in the current production configuration that
+    fallback is unconfigured and /trust/azure-release.json answers 503. Loud, on
+    purpose, and the same blast radius the existing rules above already carry
+    (an AWS pcr0 outside its own accepted set, an Azure record naming no MAA
+    issuer). Serving no Azure record is a state a verifier can act on; serving
+    one that has quietly lost a serving region is not.
+    """
+    if "regions" not in payload:
+        return []
+    raw = payload["regions"]
+    if not isinstance(raw, list):
+        # An explicit JSON null lands here rather than being read as "absent".
+        # "The key is missing" and "the key is present and says nothing" are
+        # different upstream states and must not collapse into each other.
+        raise ValueError("Azure regions must be a list when present")
+    if len(raw) > _MAX_AZURE_REGIONS:
+        raise ValueError("Azure record claims more serving regions than we would publish")
+    regions: list[dict[str, str]] = []
+    seen_urls: set[tuple[str, str, int | None, str]] = set()
+    for entry in raw:
+        if not isinstance(entry, dict):
+            raise ValueError("Azure region entry must be an object")
+        url = entry.get("attestation_url")
+        if not isinstance(url, str) or _endpoint_identity(url) is None:
+            raise ValueError("Azure region entry must name a plain https attestation_url")
+        # Compared on IDENTITY, not on the raw string. Two URLs differing only
+        # by fragment or query — .../attestation#a and .../attestation#b — are
+        # distinct strings that fetch the same endpoint, so a raw-string
+        # comparison here would let a record claim two regions on the strength
+        # of one, which is the coverage count this whole change exists to stop.
+        identity = _endpoint_identity(url)
+        assert identity is not None  # noqa: S101 - refused above; narrows for the type checker
+        if identity in seen_urls:
+            raise ValueError("Azure regions name the same attestation endpoint twice")
+        seen_urls.add(identity)
+        hostdata = entry.get("hostdata")
+        if not isinstance(hostdata, str) or _HOSTDATA_RE.fullmatch(hostdata) is None:
+            raise ValueError("invalid hostdata in Azure region entry")
+        if hostdata not in accepted:
+            raise ValueError("Azure region hostdata is absent from the record's accepted set")
+        issuer = entry.get("attestation_issuer")
+        if not isinstance(issuer, str) or not issuer.startswith("https://"):
+            raise ValueError("invalid MAA issuer in Azure region entry")
+        if issuer not in issuers:
+            raise ValueError("Azure region issuer is absent from the record's issuer list")
+        region = {"attestation_url": url, "hostdata": hostdata, "attestation_issuer": issuer}
+        for field in _AZURE_REGION_OPTIONAL:
+            value = entry.get(field)
+            if value is not None and (not isinstance(value, str) or not value):
+                raise ValueError(f"invalid {field} in Azure region entry")
+            if isinstance(value, str):
+                region[field] = value
+        regions.append(region)
+    return regions
+
+
 def validated_azure_metadata(payload: object) -> Mapping[str, Any]:
     if not isinstance(payload, dict):
         raise ValueError("Azure trust record must be an object")
@@ -328,6 +447,7 @@ def validated_azure_metadata(payload: object) -> Mapping[str, Any]:
         "hostdata": hostdata,
         "accepted_hostdata": accepted,
         "attestation_issuers": list(issuers),
+        "regions": _validated_azure_regions(payload, accepted, issuers),
     }
 
 

--- a/src/trusted_router/trust.py
+++ b/src/trusted_router/trust.py
@@ -110,10 +110,15 @@ def gcp_release(
         # A mirror serves a record; it does not rewrite it. Every field here is
         # a property of the plane.
         "api_base_url": gcp_api_base_url(settings),
-        "api_base_urls": [
-            api_base_url_for_domain(settings, domain)
-            for domain in configured_control_domains(settings)
-        ],
+        # Derived from api_hostnames, not from api_base_url_for_domain(), for
+        # the same reason the scalar above is: that helper returns
+        # settings.api_base_url for the canonical domain, which is
+        # per-DEPLOYMENT. The scalar was fixed and the plural was not, so on the
+        # AWS- and Azure-hosted control planes entry 0 of this list named THEIR
+        # gateway inside a gcp-confidential-space record — the exact leak the
+        # comment above describes, still open one field over. Every entry here
+        # is now api.<control domain>, which is a property of the GCP plane.
+        "api_base_urls": [f"https://{hostname}/v1" for hostname in api_hostnames],
         "tls": {
             "mode": "acme-inside-confidential-space",
             # Derived from the same source as api_base_url so the two cannot
@@ -193,47 +198,46 @@ def aws_release(settings: Settings, *, metadata: Mapping[str, Any] | None = None
     }
 
 
-#: The only keys copied out of an upstream region entry. Mirroring whatever
-#: arrives would let the plane's record inject arbitrary fields into ours.
-_AZURE_REGION_FIELDS = (
-    "attestation_url",
-    "hostdata",
-    "attestation_issuer",
-    "launch_measurement",
-    "compliance_status",
-)
+#: The only keys copied out of a region entry. Mirroring whatever arrives would
+#: let the plane's record inject arbitrary fields into ours. The first three are
+#: required of every entry; the last two are optional descriptions the plane may
+#: carry and this control plane does not interpret.
+_AZURE_REGION_REQUIRED = ("attestation_url", "hostdata", "attestation_issuer")
+_AZURE_REGION_OPTIONAL = ("launch_measurement", "compliance_status")
 
 
 def _azure_regions(metadata: Mapping[str, Any]) -> tuple[dict[str, str], ...]:
-    """Per-region endpoints from the plane's record, or nothing.
+    """Per-region endpoints from the plane's record, whitelisted to known keys.
 
-    A region entry is kept only when it is self-consistent with the rest of the
-    record: it names an endpoint, and its hostdata and issuer both appear in the
-    union sets published alongside it. An entry that fails that is DROPPED
-    rather than corrected, which is deliberate — a dropped region shows up
-    downstream as an issuer with no endpoint, and
-    scripts/verify_trust_measurements.py reports that as an uncovered region
-    instead of comparing a live attestation against a value the record itself
-    contradicts.
+    This is a SHAPE filter and nothing more. Reconciling a region entry against
+    the record's own accepted sets happens one layer up, in
+    services.trust_release.validated_azure_metadata, which REFUSES a record
+    whose region entries contradict it rather than editing them — see that
+    function for why a silent drop was the wrong instrument. Every entry that
+    reaches production has already been through it.
+
+    An entry that does not name all three required fields as non-empty strings
+    is not a region this record can vouch for and is dropped here, because
+    azure_release has no error channel to refuse one through. That drop is not
+    load-bearing for coverage and this docstring does not claim it is:
+    scripts/verify_trust_measurements.py grounds Azure coverage in the MAA
+    issuer each contacted endpoint presents LIVE, so a dropped region whose
+    issuer the record still publishes is reported as an unreached issuer, while
+    a region the record never listed an issuer for is invisible to it either
+    way. Refusing the record upstream is what closes that second case.
     """
-    accepted = {str(v) for v in metadata.get("accepted_hostdata", [])}
-    issuers = {str(v) for v in metadata.get("attestation_issuers", [])}
     regions: list[dict[str, str]] = []
     for entry in metadata.get("regions") or []:
         if not isinstance(entry, Mapping):
             continue
-        url = str(entry.get("attestation_url") or "")
-        hostdata = str(entry.get("hostdata") or "")
-        issuer = str(entry.get("attestation_issuer") or "")
-        if not url or hostdata not in accepted or (issuers and issuer not in issuers):
+        values = {
+            field: str(entry[field])
+            for field in (*_AZURE_REGION_REQUIRED, *_AZURE_REGION_OPTIONAL)
+            if isinstance(entry.get(field), str) and entry[field]
+        }
+        if any(field not in values for field in _AZURE_REGION_REQUIRED):
             continue
-        regions.append(
-            {
-                field: str(entry[field])
-                for field in _AZURE_REGION_FIELDS
-                if isinstance(entry.get(field), str)
-            }
-        )
+        regions.append(values)
     return tuple(regions)
 
 
@@ -279,6 +283,13 @@ def azure_release(
         # has no way to reach the others. Dropping this array on the way through
         # the mirror is what let scripts/verify_trust_measurements.py check one
         # of two Azure regions and report success for the plane.
+        #
+        # This function is the LAST layer, not the only one. On the serving
+        # route the array has to survive
+        # services.trust_release.validated_azure_metadata first, which is where
+        # it was actually being dropped — that validator whitelisted three
+        # scalar keys, so mirroring it here alone changed nothing anyone could
+        # fetch. Both layers, or neither.
         "regions": [dict(region) for region in regions],
         "api_base_url": f"https://{AZURE_API_HOSTNAME}/v1",
         "tls": {

--- a/src/trusted_router/trust.py
+++ b/src/trusted_router/trust.py
@@ -139,7 +139,9 @@ def aws_release(settings: Settings, *, metadata: Mapping[str, Any] | None = None
     attestation over a self-signed certificate, so fetching it from here would
     mean the control plane making an unauthenticated TLS connection and parsing
     CBOR on a public route. The staleness that trade buys is checked out of band
-    by scripts/verify_trust_measurements.py instead.
+    by scripts/verify_trust_measurements.py, which .github/workflows/trust-drift.yml
+    runs hourly in --strict mode — until that workflow existed, nothing executed
+    the comparison this docstring relies on.
     """
     # Mirrored from the plane's own published record when available. The
     # settings are only the offline fallback — the control plane is not the
@@ -173,7 +175,15 @@ def aws_release(settings: Settings, *, metadata: Mapping[str, Any] | None = None
             # is replaced by that binding, not dropped.
             "mode": "attested-self-signed-inside-enclave",
             "hostname": AWS_API_HOSTNAME,
-            "certificate_binding": "user_data[0:64]=certificate fingerprint, "
+            # Measured against the live enclave 2026-08-15, 8/8 samples:
+            # user_data is 96 bytes and [0:32] is SHA-256 of the served
+            # certificate DER, which is also the window probes.py checks. This
+            # field previously said [0:64], sending a verifier to compare a
+            # 64-byte window against a 32-byte hash and conclude the binding
+            # failed. [32:64] is a build-invariant constant, unchanged across
+            # nonces and connections, and is deliberately left undescribed
+            # rather than guessed at.
+            "certificate_binding": "user_data[0:32]=SHA-256 of the served certificate (DER), "
             "user_data[64:96]=TLS exporter channel binding",
         },
         "data_policy": {
@@ -181,6 +191,50 @@ def aws_release(settings: Settings, *, metadata: Mapping[str, Any] | None = None
             "control_plane_prompt_access": False,
         },
     }
+
+
+#: The only keys copied out of an upstream region entry. Mirroring whatever
+#: arrives would let the plane's record inject arbitrary fields into ours.
+_AZURE_REGION_FIELDS = (
+    "attestation_url",
+    "hostdata",
+    "attestation_issuer",
+    "launch_measurement",
+    "compliance_status",
+)
+
+
+def _azure_regions(metadata: Mapping[str, Any]) -> tuple[dict[str, str], ...]:
+    """Per-region endpoints from the plane's record, or nothing.
+
+    A region entry is kept only when it is self-consistent with the rest of the
+    record: it names an endpoint, and its hostdata and issuer both appear in the
+    union sets published alongside it. An entry that fails that is DROPPED
+    rather than corrected, which is deliberate — a dropped region shows up
+    downstream as an issuer with no endpoint, and
+    scripts/verify_trust_measurements.py reports that as an uncovered region
+    instead of comparing a live attestation against a value the record itself
+    contradicts.
+    """
+    accepted = {str(v) for v in metadata.get("accepted_hostdata", [])}
+    issuers = {str(v) for v in metadata.get("attestation_issuers", [])}
+    regions: list[dict[str, str]] = []
+    for entry in metadata.get("regions") or []:
+        if not isinstance(entry, Mapping):
+            continue
+        url = str(entry.get("attestation_url") or "")
+        hostdata = str(entry.get("hostdata") or "")
+        issuer = str(entry.get("attestation_issuer") or "")
+        if not url or hostdata not in accepted or (issuers and issuer not in issuers):
+            continue
+        regions.append(
+            {
+                field: str(entry[field])
+                for field in _AZURE_REGION_FIELDS
+                if isinstance(entry.get(field), str)
+            }
+        )
+    return tuple(regions)
 
 
 def azure_release(
@@ -198,10 +252,12 @@ def azure_release(
             str(v) for v in metadata.get("accepted_hostdata", []) if v != NOT_CONFIGURED
         )
         issuers = tuple(str(v) for v in metadata.get("attestation_issuers", []))
+        regions = _azure_regions(metadata)
     else:
         hostdata = settings.trust_azure_hostdata or NOT_CONFIGURED
         accepted = settings.trust_azure_accepted_hostdata_list
         issuers = settings.trust_azure_attestation_issuer_list
+        regions = ()
     return {
         "platform": "azure-confidential-containers-sev-snp",
         "source_repo": ATTESTED_GATEWAY_REPO,
@@ -217,6 +273,13 @@ def azure_release(
         # One MAA instance per serving region, so which issuer signs depends on
         # which region answered. A verifier should accept any of them.
         "attestation_issuers": list(issuers),
+        # WHERE each of those regions answers. accepted_hostdata is a union and
+        # cannot say which endpoint serves which value, so a reader holding only
+        # the union can verify whichever region anycast happens to give them and
+        # has no way to reach the others. Dropping this array on the way through
+        # the mirror is what let scripts/verify_trust_measurements.py check one
+        # of two Azure regions and report success for the plane.
+        "regions": [dict(region) for region in regions],
         "api_base_url": f"https://{AZURE_API_HOSTNAME}/v1",
         "tls": {
             "mode": "acme-inside-confidential-container",

--- a/tests/test_trust_measurement_drift.py
+++ b/tests/test_trust_measurement_drift.py
@@ -8,10 +8,26 @@ THE LAW
         not the first one), and each is compared against the hostdata the
         record attributes to THAT region, not merely against the union;
       * a serving region the record cannot give an endpoint for is reported as
-        an uncovered plane and exits non-zero, never as a pass;
+        an uncovered plane and exits non-zero, never as a pass — and the issuer
+        it names as unreached is one no contacted endpoint presented, not one
+        picked by list position;
+      * coverage is counted over DISTINCT ENDPOINTS THAT ANSWERED, so a record
+        naming the same URL twice cannot report two regions covered;
+      * a record that carries no region census — no attestation_issuers, or no
+        regions[] array while naming more than one accepted hostdata value —
+        cannot certify its own coverage and is a gap, not a pass;
       * under --strict, a plane that publishes nothing is a failure;
       * the summary states the planes and endpoint count it is based on, so a
         success sentence can never outrun its own coverage again.
+
+    And the law binds the SERVING ROUTE, not just the script. The checker's
+    coverage is bounded by what the control plane actually serves, so the
+    mirror proofs at the bottom of this file drive trusted_router through its
+    real HTTP route rather than calling trust.azure_release directly. That
+    distinction is not pedantry: the first version of this change fixed
+    azure_release and left validated_azure_metadata stripping `regions` one
+    layer earlier, so both mirror proofs passed while the record production
+    served was byte-identical to before the change.
 
 WHY A PROOF AND NOT JUST A TEST
     The thing being defended is a claim we make to strangers: "the measurement
@@ -60,6 +76,19 @@ THE REAL DEFECT
         alone would have left it structurally unable to find region two, which
         is why the mirror is fixed and proved here too: the checker's coverage
         is bounded by what the mirror carries.
+      * "Fixing trust.azure_release makes the SERVED record carry the array."
+        FALSE, and this one cost a round. The serving route resolves Azure
+        metadata through TrustReleaseResolver with
+        services.trust_release.validated_azure_metadata as its validator, and
+        that function returned exactly {hostdata, accepted_hostdata,
+        attestation_issuers}: `regions` was stripped one layer BEFORE
+        azure_release ever saw it. The patched mirror was dead code on the
+        production route, and the hourly --strict job would have been
+        permanently red on [GAP] azure. Driven through the real route the served
+        record still had `regions: []` and both issuers — indistinguishable from
+        the state the change claimed to fix. The validator now validates and
+        carries the array, and the proofs at the bottom of this file go through
+        the route so that composition cannot be skipped again.
 
 SCOPE LIMIT — WHAT THIS DOES NOT ESTABLISH
     * Nothing here verifies a signature. The fixture attestations are
@@ -77,6 +106,17 @@ SCOPE LIMIT — WHAT THIS DOES NOT ESTABLISH
     * A green run proves the endpoints named in its own summary matched. It
       proves nothing about an endpoint the record does not mention, which is
       exactly why an unattributable issuer is a failure rather than a note.
+    * Every plane here is recorded, not live. These prove the checker's logic
+      and the shape of what the route serves; they are not evidence about what
+      any deployed control plane publishes today, and no assertion in this file
+      should be read as one.
+    * A record that names one region, one issuer, and TWO accepted hostdata
+      values is accepted as covered. That shape is a one-region plane mid-roll
+      and a two-region plane whose second region was never published, and the
+      record does not distinguish them — accepted_hostdata rolls, so it cannot
+      be used as a region count. Closing this needs the plane to publish the
+      region, which is what GAP_REMEDIATION asks for; it is not closeable from
+      the reader's side.
 """
 
 from __future__ import annotations
@@ -373,6 +413,33 @@ def test_gcp_image_reference_drift_is_reported() -> None:
     assert "reference" in result.detail
 
 
+def test_the_endpoints_gcp_publishes_but_does_not_contact_are_printed_not_hidden() -> None:
+    """A scope limit that lives only in a docstring is a scope limit nobody reads.
+
+    The module docstring used to claim "every endpoint the record says exists
+    was actually contacted" as a global invariant. It was true of Azure's
+    regions[] and false of the GCP record's api_base_urls[] and tls.hostnames[],
+    which name alias hostnames for the same workload and are not fetched. The
+    claim is now stated per plane, and the endpoints it excludes are printed
+    beside the verdict so a reader sees the boundary where the verdict is.
+    """
+    record = gcp_record(
+        api_base_urls=[
+            "https://api.trustedrouter.com/v1",
+            "https://api.allyrouter.com/v1",
+        ]
+    )
+    result = drift.check_gcp(CONTROL_PLANE, whole_fleet(gcp=record))
+    printed = "\n".join(result.extra)
+
+    assert result.ok
+    assert result.endpoints == ("https://api.trustedrouter.com/attestation",)
+    assert "https://api.allyrouter.com/attestation" in printed
+    assert "NOT contacted by this run" in printed
+    # ...and the one it did contact is not listed as skipped.
+    assert printed.count("https://api.trustedrouter.com/attestation") == 1
+
+
 # ---------------------------------------------------------------------------
 # Azure — every region the record enumerates
 # ---------------------------------------------------------------------------
@@ -392,6 +459,10 @@ def test_every_enumerated_region_is_contacted() -> None:
     assert SEA_URL in transport.fetched, "the second region was never contacted"
     assert result.ok
     assert result.endpoints == (UAEN_URL, SEA_URL)
+    # The success sentence is counted from the fetch list and the live tokens,
+    # so it cannot describe more of the plane than answered.
+    assert "2 endpoint(s) contacted, 2 distinct MAA issuer(s) presented" in result.detail
+    assert "covering all 2 published MAA issuer(s)" in result.detail
 
 
 def test_second_region_drift_fails_even_though_the_first_is_clean() -> None:
@@ -714,47 +785,390 @@ def test_a_scheduled_workflow_runs_the_checker_in_strict_mode() -> None:
 
 
 # ---------------------------------------------------------------------------
-# The mirror bounds the checker's coverage
+# Coverage must not hang on one optional field, one list order, or one count
 # ---------------------------------------------------------------------------
 
 
-def test_the_control_plane_mirror_carries_the_region_array() -> None:
-    """Without this the checker cannot find region two at all.
+def test_an_unreached_issuer_is_named_by_evidence_not_by_list_position() -> None:
+    """The [GAP] line is what an operator acts on, so it has to name the right one.
 
-    trusted_router.trust.azure_release rebuilt the published record out of
-    hostdata, accepted_hostdata and attestation_issuers, so the `regions` array
-    the plane publishes was dropped on the way through the control plane. The
-    checker enumerates endpoints from the record; a record with no endpoints to
-    enumerate makes the single-region blind spot structural rather than a bug
-    in the checker.
+    Attribution used to be positional — `issuers[len(regions):]` — so with the
+    issuer list in the other order the gap named as unreached the very issuer
+    whose region HAD been contacted. A true verdict with a false reason is the
+    same class of output this file exists to remove. Coverage is now attributed
+    from the issuers the contacted endpoints presented live.
     """
+    record = azure_record(attestation_issuers=[SEA_ISSUER, UAEN_ISSUER])
+    record.pop("regions")
+    transport = whole_fleet(azure=record)
+    result = drift.check_azure(CONTROL_PLANE, transport)
+
+    assert result.gap
+    assert result.endpoints == (UAEN_URL,), "UAE North is the endpoint that answered"
+    assert result.unreached == (SEA_ISSUER,), "the issuer that answered must not be blamed"
+    assert UAEN_ISSUER not in "".join(result.unreached)
+
+
+def test_coverage_does_not_hang_on_the_optional_issuer_list(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Drop one optional field and the whole multi-region guarantee used to switch off.
+
+    With `attestation_issuers` absent there was nothing left to compute a gap
+    from AND nothing left to check the live issuer against, so a two-region
+    plane passed --strict having contacted one region and printed the success
+    sentence. `accepted_hostdata` still listed both regions' values the whole
+    time. A record that carries no region census at all cannot certify its own
+    coverage, and that is now a [GAP] rather than a pass.
+    """
+    record = azure_record()
+    record.pop("regions")
+    record.pop("attestation_issuers")
+    transport = whole_fleet(azure=record)
+
+    code = drift.main(["--control-plane", CONTROL_PLANE, "--strict"], transport=transport)
+    out = capsys.readouterr().out
+
+    assert code == 1
+    assert "[GAP] azure" in out
+    assert "no attestation_issuers" in out
+    assert SEA_URL not in transport.fetched, "the fixture must not accidentally cover the gap"
+    assert "Every published measurement" not in out
+
+
+def test_a_single_region_record_missing_both_censuses_is_still_not_a_gap() -> None:
+    """The rule above must not cry wolf on a plane that genuinely has one region.
+
+    One accepted hostdata value and one issuer is a complete description of a
+    one-region plane, and a check that reddens on those gets muted.
+    """
+    record = azure_record(accepted_hostdata=[UAEN_HOSTDATA], attestation_issuers=[UAEN_ISSUER])
+    record.pop("regions")
+    result = drift.check_azure(CONTROL_PLANE, whole_fleet(azure=record))
+
+    assert result.ok and not result.gap
+    assert result.endpoints == (UAEN_URL,)
+
+
+def test_two_region_entries_at_one_endpoint_are_not_two_regions_covered(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The t4 defect in a new shape: a count of entries printed as coverage.
+
+    Coverage was `len(regions)` — the number of entries in the record — so two
+    entries naming the SAME url read as two regions covered, over two fetches of
+    one endpoint, and the summary counted `azure (2)`. Counting is now over the
+    distinct endpoints actually fetched, and the duplicate is itself named.
+    """
+    record = azure_record(regions=[{"attestation_url": UAEN_URL}, {"attestation_url": UAEN_URL}])
+    transport = whole_fleet(azure=record)
+
+    code = drift.main(["--control-plane", CONTROL_PLANE, "--strict"], transport=transport)
+    out = capsys.readouterr().out
+
+    assert code == 1
+    assert "[GAP] azure" in out
+    assert "more than once" in out
+    assert "azure (1)" in out, "one endpoint answered, so the summary must count one"
+    assert SEA_URL not in transport.fetched
+
+
+def test_a_record_with_one_issuer_and_two_policies_and_no_endpoints_is_a_gap() -> None:
+    """Rule 3 on its own, with nothing else able to fire.
+
+    One published issuer, so the live-issuer census is satisfied by the one
+    endpoint that answered. No regions[] array, so the only endpoint available
+    is the canonical fallback. And two accepted hostdata values, which is either
+    a second CCE policy at a second region or a bind window on one — the record
+    does not say, and a run that cannot tell those apart has not established its
+    coverage. Written separately because the two-census fixture above satisfies
+    this rule and rule 2 at once, so neither was pinned on its own.
+    """
+    record = azure_record(attestation_issuers=[UAEN_ISSUER])
+    record.pop("regions")
+    result = drift.check_azure(CONTROL_PLANE, whole_fleet(azure=record))
+
+    assert result.gap
+    assert result.unreached == (), "no published issuer went unpresented; this is the other rule"
+    assert "no regions[] array" in result.detail
+    assert "2 accepted hostdata values" in result.detail
+
+
+def test_two_endpoints_differing_only_by_fragment_are_one_endpoint() -> None:
+    """The duplicate-URL defence must compare endpoints, not strings.
+
+    Found by an adversarial pass over the first fix: .../attestation#a and
+    .../attestation#b are distinct strings that pass a raw-string duplicate
+    check, and the fragment is never transmitted — so both entries fetch the
+    same place while the count says two regions covered. That is this file's own
+    defect rebuilt out of punctuation, so the comparison is on endpoint identity
+    (scheme, host, port, path) at both layers.
+    """
+    record = azure_record(
+        regions=[
+            {
+                "attestation_url": UAEN_URL + "#uae-north",
+                "hostdata": UAEN_HOSTDATA,
+                "attestation_issuer": UAEN_ISSUER,
+            },
+            {
+                "attestation_url": UAEN_URL + "?region=sea",
+                "hostdata": UAEN_HOSTDATA,
+                "attestation_issuer": UAEN_ISSUER,
+            },
+        ]
+    )
+    transport = FakeTransport(
+        {
+            f"{CONTROL_PLANE}/trust/azure-release.json": record,
+            UAEN_URL + "#uae-north": azure_token(UAEN_HOSTDATA, UAEN_ISSUER),
+        }
+    )
+    result = drift.check_azure(CONTROL_PLANE, transport)
+
+    assert result.gap
+    assert len(result.endpoints) == 1, "one place was contacted, so the count must say one"
+    assert "more than once" in result.detail
+
+
+def test_a_gap_alongside_drift_is_still_reported_under_the_drift_mark(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Drift takes the mark; the gap must not vanish with it.
+
+    check_azure returns on the drift branch before the gap branch, so a run with
+    both prints [DRIFT] and not [GAP]. That is deliberate — drift is the more
+    serious verdict — but it means the docstring's "a [GAP] is raised when any
+    of these hold" was false, and it would be a real defect if the coverage
+    finding disappeared along with the mark. It does not: the gap lines and the
+    unreached issuer are reported under the drift verdict.
+    """
+    record = azure_record(
+        regions=[
+            {
+                "attestation_url": UAEN_URL,
+                "hostdata": UAEN_HOSTDATA,
+                "attestation_issuer": UAEN_ISSUER,
+            }
+        ]
+    )
+    transport = whole_fleet(azure=record, uaen_live=azure_token("9c" * 32, UAEN_ISSUER))
+
+    code = drift.main(["--control-plane", CONTROL_PLANE, "--strict"], transport=transport)
+    out = capsys.readouterr().out
+
+    assert code == 1
+    assert "[DRIFT] azure" in out
+    assert SEA_ISSUER in out, "the coverage gap must survive the more serious verdict"
+    assert "Not reached: azure " + SEA_ISSUER in out
+
+
+def test_an_explicit_null_regions_key_is_not_read_as_an_absent_one(httpx_mock: Any) -> None:
+    """ "The key is missing" and "the key says nothing" are different upstream states.
+
+    Both used to reach the same `return []`, so an upstream could publish
+    `"regions": null` and have it mirror exactly like a record that predates the
+    field. Refused instead, because a record that names the field and empties it
+    is making a claim, and the mirror should not translate that into silence.
+    """
+    served = _served_azure_record(azure_record(regions=None), httpx_mock)
+
+    assert served["status_code"] == 503
+
+
+def test_a_region_entry_naming_no_hostdata_cannot_be_attributed_and_is_a_gap() -> None:
+    """An entry that names only a URL degrades to union membership, silently.
+
+    Both per-region comparisons are guarded on the field being present, so an
+    entry carrying no hostdata or issuer was checked against the union of every
+    region's accepted values and reported exactly as if it had been attributed.
+    That is less coverage than the record's own shape implies, so it is a gap.
+    """
+    record = azure_record(
+        regions=[
+            {"attestation_url": UAEN_URL, "attestation_issuer": UAEN_ISSUER},
+            {
+                "attestation_url": SEA_URL,
+                "hostdata": SEA_HOSTDATA,
+                "attestation_issuer": SEA_ISSUER,
+            },
+        ]
+    )
+    result = drift.check_azure(CONTROL_PLANE, whole_fleet(azure=record))
+
+    assert result.gap
+    assert "names no hostdata" in result.detail
+    assert result.endpoints == (UAEN_URL, SEA_URL), "both were still contacted"
+
+
+# ---------------------------------------------------------------------------
+# The PRODUCTION route bounds the checker's coverage
+# ---------------------------------------------------------------------------
+#
+# These drive trusted_router through its real HTTP route rather than calling
+# trust.azure_release directly. Calling it directly is what let the first
+# version of this proof pass while production behaviour was unchanged: the
+# route interposes TrustReleaseResolver's validator, and that validator
+# whitelisted three scalar keys and dropped `regions` before azure_release was
+# ever reached. The mirror fix was dead code on the only path that matters.
+
+
+def _served_azure_record(upstream: dict[str, Any], httpx_mock: Any) -> dict[str, Any]:
+    """The azure-release.json a real control plane would serve for this upstream."""
+    import re
+
+    from fastapi.testclient import TestClient
+
     from trusted_router.config import Settings
-    from trusted_router.trust import azure_release
+    from trusted_router.main import create_app
 
-    record = azure_release(Settings(environment="test"), metadata=azure_record())
-    urls = [region["attestation_url"] for region in record["regions"]]
+    httpx_mock.add_response(
+        url=re.compile(r"https://trust\.example/azure\.json\?tr_cache_bucket=\d+"),
+        json=upstream,
+    )
+    settings = Settings(
+        environment="test", trust_azure_release_url="https://trust.example/azure.json"
+    )
+    with TestClient(create_app(settings, init_observability=False)) as client:
+        response = client.get("/trust/azure-release.json")
+    return {"status_code": response.status_code, **response.json()}
 
-    assert urls == [UAEN_URL, SEA_URL]
-    assert record["regions"][1]["hostdata"] == SEA_HOSTDATA
-    # And the mirrored record is enough on its own to drive a full check.
-    assert drift.azure_regions(record)[1] == []
+
+def test_the_serving_route_carries_the_region_array_and_the_check_covers_both_regions(
+    httpx_mock: Any,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Driven through the route, because the route is what production runs.
+
+    trust.azure_release rebuilt the published record out of four scalars and
+    dropped the plane's `regions` array; the checker enumerates endpoints from
+    the record, so a record with no endpoints to enumerate made the
+    single-region blind spot structural. Fixing azure_release alone did not fix
+    it — validated_azure_metadata stripped `regions` one layer earlier, so the
+    record served here still carried `regions: []` and the hourly --strict job
+    would have been permanently red on [GAP] azure.
+
+    The assertion is on the fetch list of a checker fed the SERVED record.
+    """
+    served = _served_azure_record(azure_record(), httpx_mock)
+
+    assert served["status_code"] == 200
+    assert [region["attestation_url"] for region in served["regions"]] == [UAEN_URL, SEA_URL]
+    assert served["regions"][1]["hostdata"] == SEA_HOSTDATA
+
+    transport = whole_fleet(azure=served)
+    code = drift.main(["--control-plane", CONTROL_PLANE, "--strict"], transport=transport)
+    out = capsys.readouterr().out
+
+    assert code == 0
+    assert SEA_URL in transport.fetched, "the served record did not reach the second region"
+    assert "Checked 3 plane(s) at 4 endpoint(s): gcp (1), aws (1), azure (2)" in out
 
 
-def test_the_mirror_drops_a_region_it_cannot_reconcile_rather_than_republishing_it() -> None:
-    """Mirroring is not repeating.
+def test_the_route_refuses_a_region_whose_hostdata_the_record_disowns(
+    httpx_mock: Any,
+) -> None:
+    """Mirroring is not repeating — and it is not quiet editing either.
 
     A region entry whose hostdata is absent from the accepted set is
-    self-contradictory: a verifier routed there would be handed a value the
-    same record tells them to reject. Dropping it makes the checker report an
-    uncovered region, which is true, instead of comparing a live attestation
-    against a number the record itself disowns.
+    self-contradictory: a verifier routed there would be handed a value the same
+    record tells them to reject. The mirror used to DROP such an entry, which
+    erased a live serving region from the published record leaving the check
+    nothing to notice. It is now refused whole, exactly as a self-inconsistent
+    AWS record is, and the plane falls back to the embedded measurement — which
+    is unconfigured here, so the route answers 503 and the checker reports the
+    plane as publishing nothing, which --strict makes fatal.
     """
-    from trusted_router.config import Settings
-    from trusted_router.trust import azure_release
-
     poisoned = azure_record()
     poisoned["regions"][1] = dict(poisoned["regions"][1], hostdata="ab" * 32)
-    record = azure_release(Settings(environment="test"), metadata=poisoned)
+    served = _served_azure_record(poisoned, httpx_mock)
 
-    assert [region["attestation_url"] for region in record["regions"]] == [UAEN_URL]
-    assert drift.azure_regions(record)[1] == [SEA_ISSUER]
+    assert served["status_code"] == 503, "a self-contradictory record was republished"
+    assert served["release_metadata_status"] == "not-configured"
+
+
+def test_the_route_refuses_a_region_whose_issuer_the_record_never_listed(
+    httpx_mock: Any,
+) -> None:
+    """The drop condition that could never surface downstream.
+
+    The mirror dropped a region entry whose issuer was absent from
+    attestation_issuers — precisely the condition under which the checker's
+    issuer census has nothing left to notice, because the issuer is not in the
+    list either. A region brought up before its issuer was published, or an
+    issuer string that changed, was silently erased and the run went green
+    having contacted one of two live regions. Refusing the record is what makes
+    that state loud.
+    """
+    upstream = azure_record(attestation_issuers=[UAEN_ISSUER])
+    served = _served_azure_record(upstream, httpx_mock)
+
+    assert served["status_code"] == 503
+    assert served["regions"] == []
+    assert served["accepted_hostdata"] == []
+
+
+@pytest.mark.parametrize(
+    "attestation_url",
+    [
+        UAEN_URL + "#uae-north",
+        UAEN_URL + "?region=uaen",
+        "https://someone@api-azure.trustedrouter.com/attestation",
+        "http://api-azure.trustedrouter.com/attestation",
+    ],
+)
+def test_the_route_refuses_a_region_url_that_is_not_plainly_the_endpoint(
+    attestation_url: str, httpx_mock: Any
+) -> None:
+    """A region URL is a coverage claim, so it has to be exactly the place contacted.
+
+    A fragment or query makes two entries distinct strings that reach one place,
+    which buys a region count the plane cannot support. Userinfo makes
+    `https://a@b/` read as host a while contacting host b. Neither is refused by
+    a startswith("https://") check, which is all this validated at first.
+    """
+    upstream = azure_record()
+    upstream["regions"][0] = dict(upstream["regions"][0], attestation_url=attestation_url)
+    served = _served_azure_record(upstream, httpx_mock)
+
+    assert served["status_code"] == 503
+
+
+def test_the_route_refuses_a_region_array_long_enough_to_be_a_load_generator(
+    httpx_mock: Any,
+) -> None:
+    """Every entry is an endpoint the hourly job will fetch.
+
+    The payload cap is 64KB, which still leaves room for hundreds of region
+    entries, so an unbounded array turns whoever can write the upstream record
+    into someone who can point the drift check at arbitrary hosts as often as
+    they like. Two regions are in service; the cap refuses long before the array
+    becomes a load generator.
+    """
+    upstream = azure_record(
+        regions=[
+            {
+                "attestation_url": f"https://api-azure-{index}.trustedrouter.com/attestation",
+                "hostdata": UAEN_HOSTDATA,
+                "attestation_issuer": UAEN_ISSUER,
+            }
+            for index in range(17)
+        ]
+    )
+    served = _served_azure_record(upstream, httpx_mock)
+
+    assert served["status_code"] == 503
+
+
+def test_the_route_refuses_two_region_entries_at_one_endpoint(httpx_mock: Any) -> None:
+    """A duplicate URL is a region count the record cannot support.
+
+    Caught in the checker as well (see above), but a mirror that republishes it
+    has already put a false count on the trust page for anyone reading the
+    record directly.
+    """
+    upstream = azure_record()
+    upstream["regions"][1] = dict(upstream["regions"][1], attestation_url=UAEN_URL)
+    served = _served_azure_record(upstream, httpx_mock)
+
+    assert served["status_code"] == 503

--- a/tests/test_trust_measurement_drift.py
+++ b/tests/test_trust_measurement_drift.py
@@ -1,0 +1,760 @@
+"""The drift check must cover every plane it reports on, and say what it covered.
+
+THE LAW
+    scripts/verify_trust_measurements.py may print a success line only for the
+    endpoints it actually contacted. Concretely:
+      * every plane that publishes a measurement is contacted (GCP included);
+      * every region the record enumerates is contacted (both Azure regions,
+        not the first one), and each is compared against the hostdata the
+        record attributes to THAT region, not merely against the union;
+      * a serving region the record cannot give an endpoint for is reported as
+        an uncovered plane and exits non-zero, never as a pass;
+      * under --strict, a plane that publishes nothing is a failure;
+      * the summary states the planes and endpoint count it is based on, so a
+        success sentence can never outrun its own coverage again.
+
+WHY A PROOF AND NOT JUST A TEST
+    The thing being defended is a claim we make to strangers: "the measurement
+    on our trust page is what is running". The only evidence for that claim is
+    this script's exit code, and an exit code that is computed from half the
+    fleet is indistinguishable from one computed from all of it. There is no
+    user-visible symptom when the coverage narrows — the output gets shorter
+    and stays green — so nothing but an assertion on WHICH endpoints were
+    contacted can hold the line. That is what these fixtures assert: not that a
+    comparison function returns False, but that a specific URL was fetched.
+
+THE REAL DEFECT
+    Measured 2026-08-15 by running the previous version of the script
+    (82be9cdf) against a fixture plane and against production:
+      1. Nothing invoked the script. Its only mentions in this repo were two
+         comments naming it as the thing that would catch drift, in
+         config.py:365 and trust.py:142.
+      2. AZURE_ATTESTATION_URL was hardcoded to UAE North. Southeast Asia
+         serves api-azure-sea.trustedrouter.com under its own CCE policy and
+         therefore its own hostdata, f3a0b4ed…d712d81c, which was published in
+         accepted_hostdata and compared against nothing. Head to head on a
+         fixture where Southeast Asia served a hostdata published nowhere, the
+         old script fetched the UAE North endpoint only, printed
+         "[ok] azure: hostdata and issuer match" and exited 0; the current one
+         fetches both and exits 1.
+      3. It then printed "Every published measurement matches a live
+         attestation." Confirmed verbatim in that same run.
+
+    THREE NEGATIVE RESULTS, recorded because each refutes a claim in the brief
+    this work started from and acting on any of them would have been wasted or
+    wrong:
+      * "It does not check GCP AT ALL; main() loops over (aws, azure)." False.
+        82be9cdf's main() loops over gcp, aws and azure, and its check_gcp
+        compares the running digest against accepted_image_digests — the
+        fixture run above printed "[ok] gcp: image digest matches". The real
+        GCP gaps were narrower: a hardcoded endpoint and an unchecked
+        image_reference.
+      * "Its only references are comments in scripts/deploy/rollout.sh." False.
+        That file does not mention the script; the comments are in config.py
+        and trust.py. The substance — nothing executes it — held.
+      * "The published azure-release.json lists a regions array." True of
+        trust.trustedrouter.com, FALSE of the control plane the checker reads
+        by default. trusted_router.trust.azure_release rebuilt the record from
+        four scalar fields and dropped the array, so the endpoints the checker
+        enumerates never reached trustedrouter.com at all. Fixing the checker
+        alone would have left it structurally unable to find region two, which
+        is why the mirror is fixed and proved here too: the checker's coverage
+        is bounded by what the mirror carries.
+
+SCOPE LIMIT — WHAT THIS DOES NOT ESTABLISH
+    * Nothing here verifies a signature. The fixture attestations are
+      unsigned and the checker does not check signatures either; both stop at
+      "is the published value the value being served". The cryptographic
+      verifier is quill-cloud-proxy's tools/verify-attestation.py.
+    * AWS is sampled, never enumerated. These tests prove the checker reports
+      the distinct enclave count it observed and labels it sampling; they
+      cannot prove the fleet was covered, and neither can the checker.
+      Measured live: 8 consecutive fetches from one client all reached
+      i-02e34e58761097671-enc01a004d7a9c3c307 while the published record's
+      observed_module_id names a different enclave — so repeated sampling from
+      one vantage point does NOT converge on the fleet. Sampling narrows the
+      blind spot from "one of N" to "some of N"; the honest output says so.
+    * A green run proves the endpoints named in its own summary matched. It
+      proves nothing about an endpoint the record does not mention, which is
+      exactly why an unattributable issuer is a failure rather than a note.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from typing import Any
+
+import cbor2
+import pytest
+
+from scripts import verify_trust_measurements as drift
+
+CONTROL_PLANE = "https://control.example"
+
+GCP_DIGEST = "sha256:" + "fa" * 32
+GCP_DIGEST_OUTGOING = "sha256:" + "a7" * 32
+GCP_REFERENCE = (
+    "us-central1-docker.pkg.dev/quill-cloud-proxy/quill/enclave-multi:gcp-release-f57b791"
+)
+GCP_ISSUER = "https://confidentialcomputing.googleapis.com"
+
+AWS_PCR0 = "2323b48e8fa4a74b2898459b041da94dd992ee7cc3e9fd0512fb0aa410b2f17e184512c182a39ec35fe7942a07958220"
+AWS_MODULE_A = "i-0ada95aad6d11aa56-enc01a004f1c2824652"
+AWS_MODULE_B = "i-02e34e58761097671-enc01a004d7a9c3c307"
+AWS_CERT_DER = b"-----der-of-the-cert-this-connection-served-----"
+
+UAEN_HOSTDATA = "c55d492aaf98db95e60ac87c0d4a787e07d565b460380a6c16bfcc418d60b89e"
+SEA_HOSTDATA = "f3a0b4ed5b27c81ceded35a54ddeedf2795fb733b4ecc026f8597311d712d81c"
+UAEN_ISSUER = "https://trquilluaen.uaen.attest.azure.net"
+SEA_ISSUER = "https://trquillsea.sasia.attest.azure.net"
+UAEN_URL = "https://api-azure.trustedrouter.com/attestation"
+SEA_URL = "https://api-azure-sea.trustedrouter.com/attestation"
+
+
+# ---------------------------------------------------------------------------
+# Fixture planes — recorded from production, shapes verbatim
+# ---------------------------------------------------------------------------
+
+
+def _jwt(claims: dict[str, Any]) -> bytes:
+    """A three-part token whose signature is a placeholder.
+
+    Deliberately unsigned: the checker does not verify signatures and must not
+    be given a fixture that lets it look as if it did.
+    """
+    body = base64.urlsafe_b64encode(json.dumps(claims).encode()).rstrip(b"=")
+    return b"eyJhbGciOiJSUzI1NiJ9." + body + b".not-a-signature"
+
+
+def gcp_token(digest: str = GCP_DIGEST, reference: str = GCP_REFERENCE) -> bytes:
+    return _jwt(
+        {
+            "iss": GCP_ISSUER,
+            "aud": "quill-cloud",
+            "submods": {"container": {"image_digest": digest, "image_reference": reference}},
+        }
+    )
+
+
+def azure_token(hostdata: str, issuer: str) -> bytes:
+    return _jwt(
+        {
+            "iss": issuer,
+            "x-ms-attestation-type": "sevsnpvm",
+            "x-ms-sevsnpvm-hostdata": hostdata,
+            "x-ms-compliance-status": "azure-compliant-uvm",
+        }
+    )
+
+
+def aws_document(
+    *, pcr0: str = AWS_PCR0, module_id: str = AWS_MODULE_A, cert_der: bytes = AWS_CERT_DER
+) -> bytes:
+    """The COSE_Sign1 shape the Nitro Security Module emits.
+
+    user_data is 96 bytes with the layout measured on the live enclave:
+    [0:32] SHA-256 of the served certificate DER, [32:64] a build-invariant
+    constant (same value across nonces and connections; not interpreted here),
+    [64:96] the TLS exporter channel binding, which varies per connection.
+    """
+    user_data = hashlib.sha256(cert_der).digest() + bytes(32) + b"\xe1" * 32
+    payload = {
+        "module_id": module_id,
+        "digest": "SHA384",
+        "pcrs": {0: bytes.fromhex(pcr0)},
+        "user_data": user_data,
+    }
+    return cbor2.dumps([b"\xa1\x01\x38\x22", {}, cbor2.dumps(payload), b"sig" * 32])
+
+
+def gcp_record(**overrides: Any) -> dict[str, Any]:
+    record = {
+        "platform": "gcp-confidential-space",
+        "image_digest": GCP_DIGEST,
+        "accepted_image_digests": [GCP_DIGEST],
+        "image_reference": GCP_REFERENCE,
+        "accepted_image_references": [GCP_REFERENCE],
+        "attestation_issuer": GCP_ISSUER,
+        "api_base_url": "https://api.trustedrouter.com/v1",
+    }
+    record.update(overrides)
+    return record
+
+
+def aws_record(**overrides: Any) -> dict[str, Any]:
+    record = {
+        "platform": "aws-nitro-enclaves",
+        "pcr0": AWS_PCR0,
+        "accepted_pcr0s": [AWS_PCR0],
+        "observed_module_id": AWS_MODULE_A,
+        "api_base_url": "https://api-aws.trustedrouter.com/v1",
+    }
+    record.update(overrides)
+    return record
+
+
+def azure_record(**overrides: Any) -> dict[str, Any]:
+    """Both regions, exactly as trust.trustedrouter.com publishes them."""
+    record = {
+        "platform": "azure-confidential-containers-sev-snp",
+        "hostdata": UAEN_HOSTDATA,
+        "accepted_hostdata": [UAEN_HOSTDATA, SEA_HOSTDATA],
+        "attestation_issuers": [UAEN_ISSUER, SEA_ISSUER],
+        "api_base_url": "https://api-azure.trustedrouter.com/v1",
+        "regions": [
+            {
+                "attestation_url": UAEN_URL,
+                "hostdata": UAEN_HOSTDATA,
+                "attestation_issuer": UAEN_ISSUER,
+            },
+            {
+                "attestation_url": SEA_URL,
+                "hostdata": SEA_HOSTDATA,
+                "attestation_issuer": SEA_ISSUER,
+            },
+        ],
+    }
+    record.update(overrides)
+    return record
+
+
+class FakeTransport(drift.Transport):
+    """A recorded plane. Records what was fetched, which is the real assertion.
+
+    An unmapped URL raises rather than 404s: a check that quietly reads
+    "unpublished" from a typo'd endpoint is the failure mode these fixtures
+    exist to make impossible.
+    """
+
+    def __init__(self, responses: dict[str, Any], *, missing: tuple[str, ...] = ()) -> None:
+        self.responses = responses
+        self.missing = missing
+        self.fetched: list[str] = []
+
+    def fetch(
+        self, url: str, *, verify_tls: bool = True, want_peer_certificate: bool = False
+    ) -> drift.Fetched:
+        self.fetched.append(url)
+        if url in self.missing:
+            raise _http_error(url, 404)
+        if url not in self.responses:
+            raise AssertionError(f"unexpected fetch of {url}")
+        value = self.responses[url]
+        if callable(value):
+            value = value(len([seen for seen in self.fetched if seen == url]) - 1)
+        body = json.dumps(value).encode() if isinstance(value, dict) else value
+        peer = AWS_CERT_DER if want_peer_certificate else None
+        return drift.Fetched(body, peer)
+
+
+def _http_error(url: str, code: int) -> Exception:
+    import urllib.error
+
+    return urllib.error.HTTPError(url, code, "missing", None, None)  # type: ignore[arg-type]
+
+
+def whole_fleet(
+    *,
+    gcp: dict[str, Any] | None = None,
+    aws: dict[str, Any] | None = None,
+    azure: dict[str, Any] | None = None,
+    gcp_live: bytes | None = None,
+    uaen_live: bytes | None = None,
+    sea_live: bytes | None = None,
+    aws_live: Any = None,
+) -> FakeTransport:
+    """Every plane healthy and matching, unless a caller drifts one."""
+    return FakeTransport(
+        {
+            f"{CONTROL_PLANE}/trust/gcp-release.json": gcp if gcp is not None else gcp_record(),
+            f"{CONTROL_PLANE}/trust/aws-release.json": aws if aws is not None else aws_record(),
+            f"{CONTROL_PLANE}/trust/azure-release.json": (
+                azure if azure is not None else azure_record()
+            ),
+            "https://api.trustedrouter.com/attestation": gcp_live or gcp_token(),
+            "https://api-aws.trustedrouter.com/attestation": (
+                aws_live if aws_live is not None else aws_document()
+            ),
+            UAEN_URL: uaen_live or azure_token(UAEN_HOSTDATA, UAEN_ISSUER),
+            SEA_URL: sea_live or azure_token(SEA_HOSTDATA, SEA_ISSUER),
+        }
+    )
+
+
+def results_by_plane(transport: FakeTransport) -> dict[str, drift.Result]:
+    return {
+        result.plane: result for result in drift.run_checks(CONTROL_PLANE, transport, aws_samples=2)
+    }
+
+
+# ---------------------------------------------------------------------------
+# GCP — the plane that carries every prompt
+# ---------------------------------------------------------------------------
+
+
+def test_gcp_is_contacted_at_all() -> None:
+    """Asserted on the socket, not on the verdict.
+
+    A checker that returned ok("gcp") without fetching anything satisfies every
+    assertion about exit codes, and a plane silently dropped from the loop is
+    exactly the shape of failure this whole file exists for. The negative
+    result stands: GCP had NOT been dropped (see the module docstring), so this
+    is a fence around a hole that was not open, not a repair.
+    """
+    transport = whole_fleet()
+    results = results_by_plane(transport)
+
+    assert "https://api.trustedrouter.com/attestation" in transport.fetched
+    assert results["gcp"].ok
+    assert results["gcp"].endpoints == ("https://api.trustedrouter.com/attestation",)
+
+
+def test_gcp_endpoint_comes_from_the_record_not_a_constant() -> None:
+    """The record tells a verifier where to look; the checker must look there.
+
+    Hardcoding endpoints here is precisely how the second Azure region stayed
+    invisible while the record already named it.
+    """
+    record = gcp_record(api_base_url="https://api.allyrouter.com/v1")
+    transport = FakeTransport(
+        {
+            f"{CONTROL_PLANE}/trust/gcp-release.json": record,
+            "https://api.allyrouter.com/attestation": gcp_token(),
+        }
+    )
+    result = drift.check_gcp(CONTROL_PLANE, transport)
+
+    assert result.ok
+    assert "https://api.allyrouter.com/attestation" in transport.fetched
+    assert drift.GCP_ATTESTATION_URL not in transport.fetched
+
+
+def test_gcp_digest_drift_fails_and_prints_both_values(capsys: pytest.CaptureFixture[str]) -> None:
+    """The headline case: the running image is not what the trust page claims."""
+    running = "sha256:" + "de" * 32
+    transport = whole_fleet(gcp_live=gcp_token(digest=running))
+
+    code = drift.main(["--control-plane", CONTROL_PLANE], transport=transport)
+    out = capsys.readouterr().out
+
+    assert code == 1
+    assert "[DRIFT] gcp" in out
+    assert running in out and GCP_DIGEST in out
+
+
+def test_gcp_matches_the_accepted_set_during_a_roll() -> None:
+    """A rolling deploy serves the outgoing digest while the record names the
+    incoming one. Comparing against the scalar would report drift on every
+    deploy and teach the reader to ignore the check."""
+    record = gcp_record(accepted_image_digests=[GCP_DIGEST, GCP_DIGEST_OUTGOING])
+    transport = whole_fleet(gcp=record, gcp_live=gcp_token(digest=GCP_DIGEST_OUTGOING))
+    result = results_by_plane(transport)["gcp"]
+
+    assert result.ok
+    assert "rolling" in result.detail
+
+
+def test_gcp_image_reference_drift_is_reported() -> None:
+    """Both fields are published, so both have to be true.
+
+    The digest is the measurement and the reference is only a name — but a
+    verifier told to expect one tag and handed another cannot tell which half
+    of our record is stale, and the safe reading available to them is that the
+    workload was swapped.
+    """
+    transport = whole_fleet(
+        gcp_live=gcp_token(reference="us-central1-docker.pkg.dev/x/quill/enclave-multi:gcp-old")
+    )
+    result = results_by_plane(transport)["gcp"]
+
+    assert not result.ok
+    assert "reference" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# Azure — every region the record enumerates
+# ---------------------------------------------------------------------------
+
+
+def test_every_enumerated_region_is_contacted() -> None:
+    """The single-region blind spot. Asserted on the fetch list, not the verdict.
+
+    Comparing UAE North's hostdata against the union of both regions' accepted
+    values passes whether or not Southeast Asia was ever contacted, so a
+    verdict-only assertion would have gone green against the broken script.
+    """
+    transport = whole_fleet()
+    result = results_by_plane(transport)["azure"]
+
+    assert UAEN_URL in transport.fetched
+    assert SEA_URL in transport.fetched, "the second region was never contacted"
+    assert result.ok
+    assert result.endpoints == (UAEN_URL, SEA_URL)
+
+
+def test_second_region_drift_fails_even_though_the_first_is_clean() -> None:
+    """The exact shape the old script could not see.
+
+    UAE North still serves its published hostdata, so a single-endpoint check
+    reports the plane healthy. Southeast Asia is serving something nobody
+    published, and a verifier routed there gets a mismatch we told them means
+    tampering.
+    """
+    drifted = "9c" * 32
+    transport = whole_fleet(sea_live=azure_token(drifted, SEA_ISSUER))
+    result = results_by_plane(transport)["azure"]
+
+    assert not result.ok
+    assert SEA_URL in result.detail
+    # ...and the region that is fine is not blamed for it.
+    assert UAEN_URL not in result.detail
+
+
+def test_a_region_serving_its_neighbours_policy_is_drift() -> None:
+    """Set membership alone is not enough on a multi-region plane.
+
+    Southeast Asia answering with UAE North's hostdata is inside the accepted
+    union and is still a misconfiguration: one region is running the other's
+    CCE policy. The record attributes a hostdata to each region, so the check
+    is per region.
+    """
+    transport = whole_fleet(sea_live=azure_token(UAEN_HOSTDATA, SEA_ISSUER))
+    result = results_by_plane(transport)["azure"]
+
+    assert not result.ok
+    assert "another region" in result.detail
+
+
+def test_a_serving_region_the_record_cannot_reach_is_a_gap_not_a_pass(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A live region absent from the record's endpoint list.
+
+    The record still publishes Southeast Asia's MAA issuer and its hostdata —
+    so we are asking verifiers to trust that region — while giving no endpoint
+    for it. One MAA instance is provisioned per serving region and issuers do
+    not roll the way hostdata does during a bind window, so an issuer with no
+    endpoint is unambiguous: a region we vouch for and never check.
+
+    Reported as [GAP] rather than [DRIFT] on purpose. Nothing compared here
+    mismatched; the run simply covered less of the plane than the record
+    describes, and calling that "ok" is the old overclaim in a new costume.
+    """
+    record = azure_record(
+        regions=[
+            {
+                "attestation_url": UAEN_URL,
+                "hostdata": UAEN_HOSTDATA,
+                "attestation_issuer": UAEN_ISSUER,
+            }
+        ]
+    )
+    transport = whole_fleet(azure=record)
+
+    code = drift.main(["--control-plane", CONTROL_PLANE], transport=transport)
+    out = capsys.readouterr().out
+
+    assert code == 1
+    assert "[GAP] azure" in out
+    assert SEA_ISSUER in out
+    assert SEA_URL not in transport.fetched, "the fixture must not accidentally cover the gap"
+
+
+def test_a_mirror_that_drops_the_region_array_is_a_gap() -> None:
+    """Production's actual state on 2026-08-15, as a fixture.
+
+    trustedrouter.com published both hostdata values and both issuers and no
+    `regions` array at all, because the control plane rebuilt the record from
+    scalars. The checker falls back to the canonical endpoint so the plane is
+    still partly checked, and must say out loud that this is one region of two.
+    """
+    record = azure_record()
+    record.pop("regions")
+    transport = whole_fleet(azure=record)
+    result = results_by_plane(transport)["azure"]
+
+    assert result.gap
+    assert result.endpoints == (UAEN_URL,)
+    assert result.unreached == (SEA_ISSUER,)
+
+
+def test_a_single_region_record_without_a_region_array_is_not_a_gap() -> None:
+    """The fallback must not manufacture a gap on a plane that has one region.
+
+    A check that cries wolf on every single-region deployment gets muted, and a
+    muted check is the state this whole change is undoing.
+    """
+    record = azure_record(
+        accepted_hostdata=[UAEN_HOSTDATA],
+        attestation_issuers=[UAEN_ISSUER],
+    )
+    record.pop("regions")
+    transport = whole_fleet(azure=record)
+    result = results_by_plane(transport)["azure"]
+
+    assert result.ok
+    assert not result.gap
+    assert result.endpoints == (UAEN_URL,)
+
+
+def test_an_unlisted_live_issuer_is_still_reported() -> None:
+    """The pre-existing check, kept: a genuine token our record rejects.
+
+    A verifier following the published issuer list would reject a token that is
+    in fact authentic, which manufactures an accusation of tampering out of our
+    own bookkeeping.
+    """
+    transport = whole_fleet(
+        sea_live=azure_token(SEA_HOSTDATA, "https://trquillnew.westus.attest.azure.net")
+    )
+    result = results_by_plane(transport)["azure"]
+
+    assert not result.ok
+    assert "issuer" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# AWS — sampling, and saying so
+# ---------------------------------------------------------------------------
+
+
+def test_aws_reports_how_many_distinct_enclaves_it_reached_and_calls_it_sampling() -> None:
+    """Honesty about coverage is the deliverable here, not coverage itself.
+
+    One fetch of an anycast name reaches one enclave. Sampling narrows the
+    blind spot; it never closes it, and the output must not let a reader
+    believe otherwise.
+    """
+    seen = [aws_document(module_id=AWS_MODULE_A), aws_document(module_id=AWS_MODULE_B)]
+    transport = whole_fleet(aws_live=lambda index: seen[index % len(seen)])
+    result = results_by_plane(transport)["aws"]
+
+    assert result.ok
+    printed = "\n".join(result.extra)
+    assert "2 fetch(es) reached 2 distinct enclave(s)" in printed
+    assert AWS_MODULE_A in printed and AWS_MODULE_B in printed
+    assert "SAMPLING, not enumeration" in printed
+
+
+def test_aws_drift_on_any_sampled_enclave_fails() -> None:
+    """A fleet is only as published as its worst member.
+
+    The failure the single-fetch version could not see: one enclave of two
+    rebuilt without republishing. Whether it is caught at all depends on
+    whether the accelerator routes us there, which is why the sampling caveat
+    above is load-bearing rather than decorative.
+    """
+    stale = "ee" * 48
+    seen = [
+        aws_document(module_id=AWS_MODULE_A),
+        aws_document(module_id=AWS_MODULE_B, pcr0=stale),
+    ]
+    transport = whole_fleet(aws_live=lambda index: seen[index % len(seen)])
+    result = results_by_plane(transport)["aws"]
+
+    assert not result.ok
+    assert "accepted set" in result.detail
+    assert stale in "\n".join(result.extra)
+
+
+def test_aws_document_must_bind_the_certificate_this_connection_was_served() -> None:
+    """The AWS fetch runs with TLS chain validation off, by design.
+
+    What replaces the chain is the attestation binding the certificate the
+    connection actually got. Without checking it, "we read a document over an
+    unverified connection from an unauthenticated hostname" is all the AWS line
+    means, and a relay in front of the enclave would satisfy it.
+    """
+    transport = whole_fleet(aws_live=aws_document(cert_der=b"a-certificate-we-were-not-served"))
+    result = results_by_plane(transport)["aws"]
+
+    assert not result.ok
+    assert "user_data[0:32]" in result.detail
+
+
+def test_aws_document_binding_nothing_fails_closed() -> None:
+    """Absent binding must not read as satisfied binding.
+
+    Same rule probes.py enforces for the live probes: an attested endpoint
+    whose document binds nothing is indistinguishable from a relay, and
+    "unverifiable" must never print as "verified".
+    """
+    payload = {"module_id": AWS_MODULE_A, "digest": "SHA384", "pcrs": {0: bytes.fromhex(AWS_PCR0)}}
+    document = cbor2.dumps([b"\xa1\x01\x38\x22", {}, cbor2.dumps(payload), b"sig" * 32])
+    transport = whole_fleet(aws_live=document)
+    result = results_by_plane(transport)["aws"]
+
+    assert not result.ok
+    assert "binds no certificate" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# --strict, and the summary that cannot outrun its coverage
+# ---------------------------------------------------------------------------
+
+
+def _nothing_published() -> FakeTransport:
+    paths = tuple(
+        f"{CONTROL_PLANE}/trust/{plane}-release.json" for plane in ("gcp", "aws", "azure")
+    )
+    return FakeTransport({}, missing=paths)
+
+
+def test_a_skip_is_lenient_locally_and_fatal_under_strict(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """ "We stopped publishing a measurement" must not be a green tick on a cron.
+
+    Locally the same state is ordinary: a staging mirror, a plane mid
+    bring-up, a branch where nothing is published yet. Making it fatal there
+    teaches people to pass a flag to silence the check, and a check people
+    silence by habit is the check that goes unrun for as long as this one did.
+    """
+    lenient = drift.main(["--control-plane", CONTROL_PLANE], transport=_nothing_published())
+    lenient_out = capsys.readouterr().out
+    strict = drift.main(
+        ["--control-plane", CONTROL_PLANE, "--strict"], transport=_nothing_published()
+    )
+    strict_out = capsys.readouterr().out
+
+    assert lenient == 0
+    assert strict == 1
+    for out in (lenient_out, strict_out):
+        assert out.count("[SKIP]") == 3
+    assert "Skipped (nothing published): gcp, aws, azure" in strict_out
+
+
+def test_a_run_that_checked_nothing_does_not_say_everything_matched(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Found by running the checker against https://aws.trustedrouter.com.
+
+    That control plane publishes "not-configured" for all three planes, so
+    every check skips — and the lenient run printed "Every published
+    measurement ... matches a live attestation." directly under a summary
+    reading "Checked 0 plane(s) at 0 endpoint(s): none". Vacuously true, and
+    the exact reading this file exists to stop: a sentence claiming everything
+    matched, above nothing.
+
+    Exit stays 0, because locally that state is ordinary; --strict is what
+    makes it fatal. Only the sentence changes.
+    """
+    code = drift.main(["--control-plane", CONTROL_PLANE], transport=_nothing_published())
+    out = capsys.readouterr().out
+
+    assert code == 0
+    assert "Checked 0 plane(s) at 0 endpoint(s): none" in out
+    assert "Every published measurement" not in out
+    assert "Nothing was checked" in out
+
+
+def test_the_summary_states_what_was_checked_and_what_was_not(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The overclaiming success line, directly.
+
+    The line this replaces read "Every published measurement matches a live
+    attestation." after contacting one of the two Azure regions the record
+    itself enumerated. Any success sentence that does not enumerate its own
+    coverage will say that again the next time coverage narrows.
+    """
+    code = drift.main(["--control-plane", CONTROL_PLANE], transport=whole_fleet())
+    out = capsys.readouterr().out
+
+    assert code == 0
+    assert "Checked 3 plane(s) at 4 endpoint(s): gcp (1), aws (1), azure (2)" in out
+    assert "Skipped (nothing published): none" in out
+    # The success sentence must be bounded by the list above it, not global.
+    assert "Every published measurement listed above matches a live attestation." in out
+
+
+def test_one_unpublished_plane_does_not_stop_the_others_being_checked() -> None:
+    """A plane going quiet must not silently shrink the run to nothing."""
+    transport = whole_fleet()
+    transport.missing = (f"{CONTROL_PLANE}/trust/aws-release.json",)
+    results = results_by_plane(transport)
+
+    assert results["aws"].skipped
+    assert results["gcp"].ok and results["azure"].ok
+    assert UAEN_URL in transport.fetched and SEA_URL in transport.fetched
+
+
+# ---------------------------------------------------------------------------
+# The original defect: something has to actually run it
+# ---------------------------------------------------------------------------
+
+
+def test_a_scheduled_workflow_runs_the_checker_in_strict_mode() -> None:
+    """The other twenty assertions are worth nothing if nobody runs the script.
+
+    Asserted against the workflow file rather than trusted to review, because
+    the defect being closed IS the absence of an invocation: every correctness
+    property this file proves held just as well while the checker sat unrun,
+    and no test could tell the difference.
+
+    Deliberately NOT claimed: that the workflow passes, that GitHub's scheduler
+    fires it on time (cron on Actions is best-effort and drops runs under load),
+    or that a failure reaches a human. This asserts wiring, which is the part
+    that was missing.
+    """
+    from pathlib import Path
+
+    workflow = (
+        Path(__file__).resolve().parents[1] / ".github/workflows/trust-drift.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "scripts/verify_trust_measurements.py" in workflow
+    assert "--strict" in workflow, "a scheduled run where a skip is green is the defect itself"
+    assert "schedule:" in workflow and "cron:" in workflow
+    # Prod state must never redden a PR — the offline proofs above are what
+    # gate PRs. Same rule prod-smoke.yml states for itself.
+    assert "pull_request" not in workflow
+
+
+# ---------------------------------------------------------------------------
+# The mirror bounds the checker's coverage
+# ---------------------------------------------------------------------------
+
+
+def test_the_control_plane_mirror_carries_the_region_array() -> None:
+    """Without this the checker cannot find region two at all.
+
+    trusted_router.trust.azure_release rebuilt the published record out of
+    hostdata, accepted_hostdata and attestation_issuers, so the `regions` array
+    the plane publishes was dropped on the way through the control plane. The
+    checker enumerates endpoints from the record; a record with no endpoints to
+    enumerate makes the single-region blind spot structural rather than a bug
+    in the checker.
+    """
+    from trusted_router.config import Settings
+    from trusted_router.trust import azure_release
+
+    record = azure_release(Settings(environment="test"), metadata=azure_record())
+    urls = [region["attestation_url"] for region in record["regions"]]
+
+    assert urls == [UAEN_URL, SEA_URL]
+    assert record["regions"][1]["hostdata"] == SEA_HOSTDATA
+    # And the mirrored record is enough on its own to drive a full check.
+    assert drift.azure_regions(record)[1] == []
+
+
+def test_the_mirror_drops_a_region_it_cannot_reconcile_rather_than_republishing_it() -> None:
+    """Mirroring is not repeating.
+
+    A region entry whose hostdata is absent from the accepted set is
+    self-contradictory: a verifier routed there would be handed a value the
+    same record tells them to reject. Dropping it makes the checker report an
+    uncovered region, which is true, instead of comparing a live attestation
+    against a number the record itself disowns.
+    """
+    from trusted_router.config import Settings
+    from trusted_router.trust import azure_release
+
+    poisoned = azure_record()
+    poisoned["regions"][1] = dict(poisoned["regions"][1], hostdata="ab" * 32)
+    record = azure_release(Settings(environment="test"), metadata=poisoned)
+
+    assert [region["attestation_url"] for region in record["regions"]] == [UAEN_URL]
+    assert drift.azure_regions(record)[1] == [SEA_ISSUER]

--- a/tests/test_trust_measurement_drift.py
+++ b/tests/test_trust_measurement_drift.py
@@ -1484,8 +1484,13 @@ def test_two_different_places_do_not_fold_into_one(first: str, second: str) -> N
     Every twin above asserts that endpoint_identity folds ENOUGH. This asserts
     it does not fold too much: an over-eager normalizer makes two real endpoints
     look like one, the checker contacts one of them, and the record's second
-    region goes uncovered while the run counts it as covered — the same false
-    coverage, arrived at from the other side.
+    region goes uncovered.
+
+    That failure is loud, not silent — the gap is raised, the folded URL is
+    named in the detail line, and --strict exits non-zero. What this twin buys
+    is therefore not "catches an otherwise invisible hole" but "the hole is
+    attributed to the normalizer rather than to the plane", which is the
+    difference between fixing this file and paging whoever owns Azure.
     """
     from trusted_router.endpoint_identity import parse_endpoint
 

--- a/tests/test_trust_measurement_drift.py
+++ b/tests/test_trust_measurement_drift.py
@@ -1441,14 +1441,60 @@ def test_the_identity_parser_answers_with_a_value_for_every_hostile_string() -> 
 #: at least one of the two normalizers that used to exist: the checker's kept an
 #: explicit ':443' and the validator's dropped it, and neither folded a trailing
 #: slash, a trailing dot on the host, or a doubled path slash.
+#:
+#: The `..` and the multi-dot-host entries joined late, because the rules that
+#: fold them were the two rules in endpoint_identity with nothing behind them:
+#: deleting the `..` branch of _normalized_path, or narrowing the host fold to
+#: ONE trailing dot, left this whole file green while restoring exactly the
+#: false coverage count it exists to remove — validated_azure_metadata accepts
+#: `/attestation` and `/uaen/../attestation` as two regions, and the checker
+#: calls one place two endpoints. Their single-dot neighbours in this list (the
+#: `.` path segment, the one trailing host dot) made both look tested: the same
+#: "two rules covering only each other" shape this change has now hit three
+#: times.
 ENDPOINT_TWINS = [
     (UAEN_URL, "https://api-azure.trustedrouter.com:443/attestation"),
     (UAEN_URL, UAEN_URL + "/"),
     (UAEN_URL, "https://api-azure.trustedrouter.com./attestation"),
+    (UAEN_URL, "https://api-azure.trustedrouter.com..../attestation"),
     (UAEN_URL, "https://api-azure.trustedrouter.com//attestation"),
     (UAEN_URL, "https://api-azure.trustedrouter.com/./attestation"),
+    (UAEN_URL, "https://api-azure.trustedrouter.com/uaen/../attestation"),
     (UAEN_URL, "https://API-AZURE.TrustedRouter.com/attestation"),
 ]
+
+#: Pairs that name TWO places, asserted for the same reason as the twins above:
+#: a fold in the safe direction still costs a region's coverage, because the
+#: checker contacts one endpoint per identity. Nothing pinned the OTHER half of
+#: the port rule — replacing the whole default-port computation with
+#: `port = None`, so that every port folds away, left this file green.
+ENDPOINT_DISTINCTS = [
+    (UAEN_URL, "https://api-azure.trustedrouter.com:8443/attestation"),
+    (UAEN_URL, "https://api-azure-sea.trustedrouter.com/attestation"),
+    (UAEN_URL, "https://api-azure.trustedrouter.com/attestation/uaen"),
+    (UAEN_URL, "https://api-azure.trustedrouter.com/Attestation"),
+    (UAEN_URL, "http://api-azure.trustedrouter.com/attestation"),
+]
+
+
+@pytest.mark.parametrize(("first", "second"), ENDPOINT_DISTINCTS)
+def test_two_different_places_do_not_fold_into_one(first: str, second: str) -> None:
+    """The fold has to stop somewhere, and where it stops is a coverage claim.
+
+    Every twin above asserts that endpoint_identity folds ENOUGH. This asserts
+    it does not fold too much: an over-eager normalizer makes two real endpoints
+    look like one, the checker contacts one of them, and the record's second
+    region goes uncovered while the run counts it as covered — the same false
+    coverage, arrived at from the other side.
+    """
+    from trusted_router.endpoint_identity import parse_endpoint
+
+    left = parse_endpoint(first)
+    right = parse_endpoint(second)
+
+    assert left is not None
+    assert right is not None
+    assert left.identity != right.identity
 
 
 @pytest.mark.parametrize(("first", "second"), ENDPOINT_TWINS)

--- a/tests/test_trust_measurement_drift.py
+++ b/tests/test_trust_measurement_drift.py
@@ -807,6 +807,11 @@ def test_an_unreached_issuer_is_named_by_evidence_not_by_list_position() -> None
     assert result.endpoints == (UAEN_URL,), "UAE North is the endpoint that answered"
     assert result.unreached == (SEA_ISSUER,), "the issuer that answered must not be blamed"
     assert UAEN_ISSUER not in "".join(result.unreached)
+    # And the sentence carrying that verdict counts what ANSWERED, not what the
+    # record listed: two issuers are published here and one was presented. A
+    # census read off the record would print "2 distinct MAA issuer(s)
+    # presented" beside a gap saying one of them was presented by nobody.
+    assert "over 1 endpoint(s) contacted, 1 distinct MAA issuer(s) presented" in result.detail
 
 
 def test_coverage_does_not_hang_on_the_optional_issuer_list(
@@ -1001,6 +1006,135 @@ def test_a_region_entry_naming_no_hostdata_cannot_be_attributed_and_is_a_gap() -
     assert result.endpoints == (UAEN_URL, SEA_URL), "both were still contacted"
 
 
+def test_a_regions_entry_with_no_attestation_url_is_a_gap_on_its_own() -> None:
+    """The fourth coverage rule, isolated so that deleting it cannot stay green.
+
+    Found by an adversarial pass that deleted this rule and watched the whole
+    suite stay green: every fixture that carried a URL-less entry also tripped
+    the issuer census, so two rules were covering each other and neither was
+    pinned. Here nothing else can fire — one accepted hostdata value, one
+    issuer, and that issuer is presented by the endpoint that answers — so the
+    single gap reported is this rule or the rule is gone.
+    """
+    record = azure_record(
+        accepted_hostdata=[UAEN_HOSTDATA],
+        attestation_issuers=[UAEN_ISSUER],
+        regions=[
+            {
+                "attestation_url": UAEN_URL,
+                "hostdata": UAEN_HOSTDATA,
+                "attestation_issuer": UAEN_ISSUER,
+            },
+            {"hostdata": UAEN_HOSTDATA, "attestation_issuer": UAEN_ISSUER},
+        ],
+    )
+    result = drift.check_azure(CONTROL_PLANE, whole_fleet(azure=record))
+
+    assert result.gap
+    assert "1 coverage gap(s)" in result.detail, "no other rule may be propping this one up"
+    assert "names no attestation_url" in result.detail
+    assert result.endpoints == (UAEN_URL,)
+
+
+def test_a_regions_entry_that_names_no_reachable_place_is_a_gap_and_is_not_fetched() -> None:
+    """A URL the checker cannot honour is a coverage claim, not an endpoint.
+
+    The checker reads records the mirror never validated, so it meets strings
+    the mirror would have refused: a malformed authority, a non-http scheme, or
+    `https://a@b/`, which reads as host a and contacts host b. Counting one as
+    an endpoint would be a coverage claim on a place this run cannot reach, and
+    FETCHING one would let whoever writes the record aim the hourly job. It is
+    reported and skipped. Isolated like the rule above so nothing props it up.
+    """
+    hostile = "https://someone@api-azure-sea.trustedrouter.com/attestation"
+    record = azure_record(
+        accepted_hostdata=[UAEN_HOSTDATA],
+        attestation_issuers=[UAEN_ISSUER],
+        regions=[
+            {
+                "attestation_url": UAEN_URL,
+                "hostdata": UAEN_HOSTDATA,
+                "attestation_issuer": UAEN_ISSUER,
+            },
+            {
+                "attestation_url": hostile,
+                "hostdata": UAEN_HOSTDATA,
+                "attestation_issuer": UAEN_ISSUER,
+            },
+        ],
+    )
+    transport = whole_fleet(azure=record)
+    result = drift.check_azure(CONTROL_PLANE, transport)
+
+    assert result.gap
+    assert "1 coverage gap(s)" in result.detail, "no other rule may be propping this one up"
+    assert "not a plain http(s) endpoint" in result.detail
+    assert result.endpoints == (UAEN_URL,)
+    assert hostile not in transport.fetched, "a record must not be able to aim this run"
+
+
+def test_the_endpoint_the_record_advertises_is_contacted_even_when_regions_omits_it(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """regions[] was an ELSE for api_base_url, so publishing one hid the other.
+
+    api_base_url is the address the record hands a verifier. Reading regions[]
+    INSTEAD of it — which is what azure_plan did — means a record enumerating
+    only Southeast Asia leaves the UAE North gateway it advertises uncontacted,
+    and the run prints the full success sentence over a plane whose front door
+    was never knocked on. Here that door is serving a hostdata published
+    nowhere: before, exit 0 and "Every published measurement ..."; now the
+    endpoint is contacted and the drift is caught.
+    """
+    record = azure_record(
+        accepted_hostdata=[SEA_HOSTDATA],
+        attestation_issuers=[SEA_ISSUER],
+        regions=[
+            {
+                "attestation_url": SEA_URL,
+                "hostdata": SEA_HOSTDATA,
+                "attestation_issuer": SEA_ISSUER,
+            }
+        ],
+    )
+    transport = whole_fleet(azure=record)
+
+    code = drift.main(["--control-plane", CONTROL_PLANE, "--strict"], transport=transport)
+    out = capsys.readouterr().out
+
+    assert code == 1
+    assert UAEN_URL in transport.fetched, "the record's own api_base_url was never contacted"
+    assert "[DRIFT] azure" in out
+    assert "Every published measurement" not in out
+
+
+def test_an_advertised_endpoint_missing_from_the_region_census_is_a_gap_even_when_healthy() -> None:
+    """Contacting it is half the fix; the record still disagrees with itself.
+
+    A record that tells verifiers to go to one endpoint and lists a different
+    set of serving regions cannot ground a region count, whichever of the two is
+    stale. Separated from the test above because there the drift verdict would
+    have masked a deleted gap rule: here every measurement matches and every
+    published issuer is presented, so the one gap reported is this rule alone.
+    """
+    record = azure_record(
+        regions=[
+            {
+                "attestation_url": SEA_URL,
+                "hostdata": SEA_HOSTDATA,
+                "attestation_issuer": SEA_ISSUER,
+            }
+        ],
+    )
+    result = drift.check_azure(CONTROL_PLANE, whole_fleet(azure=record))
+
+    assert result.gap
+    assert "1 coverage gap(s)" in result.detail
+    assert "api_base_url advertises" in result.detail
+    assert set(result.endpoints) == {SEA_URL, UAEN_URL}
+    assert result.unreached == (), "both published issuers answered; this is the other rule"
+
+
 # ---------------------------------------------------------------------------
 # The PRODUCTION route bounds the checker's coverage
 # ---------------------------------------------------------------------------
@@ -1014,7 +1148,14 @@ def test_a_region_entry_naming_no_hostdata_cannot_be_attributed_and_is_a_gap() -
 
 
 def _served_azure_record(upstream: dict[str, Any], httpx_mock: Any) -> dict[str, Any]:
-    """The azure-release.json a real control plane would serve for this upstream."""
+    """The azure-release.json a real control plane would serve for this upstream.
+
+    raise_server_exceptions=False on purpose: an exception that escapes the
+    route must show up here as the 500 a client would receive, not as a test
+    error. Every refusal below is documented as a 503 carrying the embedded
+    fallback, and the only way to hold that documentation to account is to let
+    the wrong status code be asserted against.
+    """
     import re
 
     from fastapi.testclient import TestClient
@@ -1029,9 +1170,18 @@ def _served_azure_record(upstream: dict[str, Any], httpx_mock: Any) -> dict[str,
     settings = Settings(
         environment="test", trust_azure_release_url="https://trust.example/azure.json"
     )
-    with TestClient(create_app(settings, init_observability=False)) as client:
+    with TestClient(
+        create_app(settings, init_observability=False), raise_server_exceptions=False
+    ) as client:
         response = client.get("/trust/azure-release.json")
-    return {"status_code": response.status_code, **response.json()}
+    try:
+        payload = response.json()
+    except ValueError:
+        # A 500 from an escaped exception carries no JSON body. Reporting the
+        # status alone keeps the failure readable as "the route answered 500"
+        # rather than as a decode error two frames away from the cause.
+        payload = {}
+    return {"status_code": response.status_code, **payload}
 
 
 def test_the_serving_route_carries_the_region_array_and_the_check_covers_both_regions(
@@ -1172,3 +1322,186 @@ def test_the_route_refuses_two_region_entries_at_one_endpoint(httpx_mock: Any) -
     served = _served_azure_record(upstream, httpx_mock)
 
     assert served["status_code"] == 503
+
+
+# ---------------------------------------------------------------------------
+# A malformed field in a remote record must not take the public route down
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "attestation_url",
+    [
+        "https://[::1",  # unterminated IPv6 literal
+        "https://api-azure.trustedrouter.com:notaport/attestation",
+        "https://api-azure.trustedrouter.com:99999/attestation",
+    ],
+)
+def test_a_malformed_region_url_answers_503_and_not_500(
+    attestation_url: str, httpx_mock: Any
+) -> None:
+    """The widening that carried regions[] through also widened the input surface.
+
+    /trust/azure-release.json is public and the record behind it is FETCHED FROM
+    A REMOTE MIRROR, so a malformed field in it is an ordinary input and not a
+    hypothetical. The first version of the validator parsed these with
+    httpx.URL, which raises httpx.InvalidURL — a plain Exception, not an
+    httpx.HTTPError — so it escaped TrustReleaseResolver.resolve(), sailed past
+    the route's `except TrustReleaseUnavailable`, and the endpoint answered 500:
+    no embedded fallback, no retry backoff, no stale-if-error serving, and a
+    stack trace on the one route whose whole job is to be a dependable answer
+    about what is running. The documented behaviour is a 503 carrying the
+    embedded measurement, and that is what is asserted here.
+    """
+    upstream = azure_record()
+    upstream["regions"][0] = dict(upstream["regions"][0], attestation_url=attestation_url)
+    served = _served_azure_record(upstream, httpx_mock)
+
+    assert served["status_code"] == 503, "a malformed region URL must not be a 500"
+    assert served["release_metadata_status"] == "not-configured"
+
+
+def test_a_malformed_region_url_backs_off_rather_than_refetching_every_request(
+    httpx_mock: Any,
+) -> None:
+    """Failing closed is not enough if it fails closed once per request.
+
+    An exception that escapes resolve() skips the whole failure path, not just
+    the fallback: `_retry_after` is never set, so every subsequent request goes
+    back to the upstream mirror, and a previously cached good record is never
+    served stale. A public route that re-fetches an upstream on every request
+    during an incident is a load amplifier pointed at the plane we are trying to
+    describe. One upstream fetch for two requests is what the backoff means.
+    """
+    import re
+
+    from fastapi.testclient import TestClient
+
+    from trusted_router.config import Settings
+    from trusted_router.main import create_app
+
+    upstream = azure_record()
+    upstream["regions"][0] = dict(upstream["regions"][0], attestation_url="https://[::1")
+    httpx_mock.add_response(
+        url=re.compile(r"https://trust\.example/azure\.json\?tr_cache_bucket=\d+"),
+        json=upstream,
+    )
+    settings = Settings(
+        environment="test", trust_azure_release_url="https://trust.example/azure.json"
+    )
+    with TestClient(
+        create_app(settings, init_observability=False), raise_server_exceptions=False
+    ) as client:
+        first = client.get("/trust/azure-release.json")
+        second = client.get("/trust/azure-release.json")
+
+    assert first.status_code == 503
+    assert second.status_code == 503
+    assert len(httpx_mock.get_requests()) == 1, "the second request must be inside the backoff"
+
+
+def test_the_identity_parser_answers_with_a_value_for_every_hostile_string() -> None:
+    """The invariant the 500 came from, asserted directly.
+
+    Every caller of parse_endpoint treats None as "this names no place" and has
+    no handler for an exception, because its contract is that there is never one
+    to handle. Written as its own test because the two route tests above only
+    cover the inputs someone already thought of, and the defect was not that a
+    particular string was mishandled — it was that the parser had an exit nobody
+    upstream knew about.
+    """
+    from trusted_router.endpoint_identity import parse_endpoint
+
+    hostile = [
+        "https://[::1",
+        "https://h:notaport/x",
+        "https://h:99999/x",
+        "https://",
+        "http://",
+        "",
+        "not a url at all",
+        "file:///etc/passwd",
+        "//api-azure.trustedrouter.com/attestation",
+        "https://a@b/attestation",
+        "\x00",
+        "https://h:-1/x",
+        None,
+        42,
+        {"attestation_url": UAEN_URL},
+    ]
+
+    assert [parse_endpoint(value) for value in hostile] == [None] * len(hostile)
+
+
+# ---------------------------------------------------------------------------
+# One implementation of "the same endpoint", used by the mirror and the checker
+# ---------------------------------------------------------------------------
+
+#: Pairs that name ONE place. Every one of these was accepted as two regions by
+#: at least one of the two normalizers that used to exist: the checker's kept an
+#: explicit ':443' and the validator's dropped it, and neither folded a trailing
+#: slash, a trailing dot on the host, or a doubled path slash.
+ENDPOINT_TWINS = [
+    (UAEN_URL, "https://api-azure.trustedrouter.com:443/attestation"),
+    (UAEN_URL, UAEN_URL + "/"),
+    (UAEN_URL, "https://api-azure.trustedrouter.com./attestation"),
+    (UAEN_URL, "https://api-azure.trustedrouter.com//attestation"),
+    (UAEN_URL, "https://api-azure.trustedrouter.com/./attestation"),
+    (UAEN_URL, "https://API-AZURE.TrustedRouter.com/attestation"),
+]
+
+
+@pytest.mark.parametrize(("first", "second"), ENDPOINT_TWINS)
+def test_the_mirror_refuses_two_spellings_of_one_endpoint(
+    first: str, second: str, httpx_mock: Any
+) -> None:
+    """Two spellings of one place are a region count the record cannot support.
+
+    Same rule as the duplicate-URL test above; these are the spellings that slip
+    past a comparison that is nearly-but-not-quite endpoint identity.
+    """
+    upstream = azure_record()
+    upstream["regions"][0] = dict(upstream["regions"][0], attestation_url=first)
+    upstream["regions"][1] = dict(
+        upstream["regions"][1], attestation_url=second, hostdata=UAEN_HOSTDATA
+    )
+    served = _served_azure_record(upstream, httpx_mock)
+
+    assert served["status_code"] == 503
+
+
+@pytest.mark.parametrize(("first", "second"), ENDPOINT_TWINS)
+def test_the_checker_counts_two_spellings_of_one_endpoint_as_one(first: str, second: str) -> None:
+    """And the checker has to agree, or the record is safe in one place only.
+
+    The checker reads records the mirror never validated — --control-plane takes
+    any URL, and the workflow exposes it as a dispatch input — so a fold the
+    mirror refuses and the checker accepts still buys a false coverage count in
+    the run output. This is the same function on both sides now; these two
+    parametrized tests are what says so out loud.
+    """
+    record = azure_record(
+        regions=[
+            {
+                "attestation_url": first,
+                "hostdata": UAEN_HOSTDATA,
+                "attestation_issuer": UAEN_ISSUER,
+            },
+            {
+                "attestation_url": second,
+                "hostdata": UAEN_HOSTDATA,
+                "attestation_issuer": UAEN_ISSUER,
+            },
+        ]
+    )
+    transport = FakeTransport(
+        {
+            f"{CONTROL_PLANE}/trust/azure-release.json": record,
+            first: azure_token(UAEN_HOSTDATA, UAEN_ISSUER),
+        }
+    )
+    result = drift.check_azure(CONTROL_PLANE, transport)
+
+    assert result.gap
+    assert len(result.endpoints) == 1, "one place was contacted, so the count must say one"
+    assert "more than once" in result.detail

--- a/tests/test_trust_release.py
+++ b/tests/test_trust_release.py
@@ -155,6 +155,56 @@ async def test_live_release_rejects_invalid_or_expired_metadata(
 
 
 @pytest.mark.asyncio
+async def test_a_validator_raising_an_unforeseen_class_is_still_unavailable_not_a_crash(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """The resolver cannot know its validator's exception vocabulary.
+
+    `validator` is a constructor parameter, so the set of exceptions it can
+    raise is not knowable here — and this used to be an enumeration,
+    `except (httpx.HTTPError, TypeError, ValueError)`. The enumeration was
+    wrong: validated_azure_metadata was widened to parse region URLs with
+    httpx.URL, which raises httpx.InvalidURL, a plain Exception outside
+    httpx.HTTPError. It escaped resolve(), sailed past the route's
+    `except TrustReleaseUnavailable`, and /trust/azure-release.json answered 500
+    with no fallback and no backoff.
+
+    Asserted with a validator raising a class nothing in this repo raises,
+    because the point is not that InvalidURL is handled now — it is that a
+    failure to produce a validated record is ONE outcome for a mirror however it
+    arrives. The backoff is asserted too: an escape skips the whole failure
+    path, so every subsequent request went back to the upstream.
+    """
+
+    class UnforeseenValidatorError(Exception):
+        pass
+
+    def hostile_validator(payload: object) -> dict[str, object]:
+        raise UnforeseenValidatorError("a class this layer was never told about")
+
+    httpx_mock.add_response(
+        url="https://trust.example/release.json?tr_cache_bucket=10",
+        json=release_payload(),
+    )
+    resolver = TrustReleaseResolver(
+        Settings(trust_gcp_release_url="https://trust.example/release.json"),
+        monotonic=lambda: 0.0,
+        wall_clock=lambda: 600.0,
+        validator=hostile_validator,
+    )
+
+    with pytest.raises(TrustReleaseUnavailable) as first:
+        await resolver.resolve()
+    with pytest.raises(TrustReleaseUnavailable):
+        await resolver.resolve()
+
+    assert isinstance(first.value.__cause__, UnforeseenValidatorError), (
+        "the cause has to travel with it, or a real bug becomes an untraceable 503"
+    )
+    assert len(httpx_mock.get_requests()) == 1, "the second resolve must be inside the backoff"
+
+
+@pytest.mark.asyncio
 async def test_live_release_rejects_oversized_response(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(
         url="https://trust.example/large.json?tr_cache_bucket=10",

--- a/tests/test_trust_release.py
+++ b/tests/test_trust_release.py
@@ -418,6 +418,18 @@ def test_gcp_record_describes_the_gcp_plane_from_every_deployment() -> None:
         # The two fields must never disagree about which host terminates the
         # prompt path; that disagreement is what makes the record unverifiable.
         assert record["api_base_url"] == f"https://{record['tls']['hostname']}/v1"
+        # The PLURAL had the same leak and kept it after the scalar was fixed:
+        # api_base_urls was built with api_base_url_for_domain(), which returns
+        # settings.api_base_url for the canonical domain — per-deployment — so
+        # entry 0 of a gcp-confidential-space record served from the AWS-hosted
+        # control plane named api-aws.trustedrouter.com. Every entry is a
+        # property of the GCP plane, and must pair with tls.hostnames entry for
+        # entry.
+        assert record["api_base_urls"] == [
+            f"https://{hostname}/v1" for hostname in record["tls"]["hostnames"]
+        ]
+        assert record["api_base_urls"][0] == record["api_base_url"]
+        assert not any("api-aws" in url or "api-azure" in url for url in record["api_base_urls"])
 
 
 def test_gcp_endpoint_fields_are_derived_from_the_domain_not_hardcoded() -> None:
@@ -590,6 +602,18 @@ def test_azure_mirror_requires_an_issuer_and_carries_every_region(
                 "https://trquilluaen.uaen.attest.azure.net",
                 "https://trquillsea.sasia.attest.azure.net",
             ],
+            "regions": [
+                {
+                    "attestation_url": "https://api-azure.trustedrouter.com/attestation",
+                    "hostdata": uaen,
+                    "attestation_issuer": "https://trquilluaen.uaen.attest.azure.net",
+                },
+                {
+                    "attestation_url": "https://api-azure-sea.trustedrouter.com/attestation",
+                    "hostdata": sea,
+                    "attestation_issuer": "https://trquillsea.sasia.attest.azure.net",
+                },
+            ],
         },
     )
     settings = Settings(
@@ -603,6 +627,15 @@ def test_azure_mirror_requires_an_issuer_and_carries_every_region(
     # region conclude tampering.
     assert record["accepted_hostdata"] == [uaen, sea]
     assert len(record["attestation_issuers"]) == 2
+    # ...and WHERE each of them answers has to survive the trip too. This
+    # assertion used to be absent while the test's name promised it: the
+    # validator whitelisted three scalar keys, so the array never reached
+    # trust.azure_release and the drift check had one endpoint to enumerate.
+    assert [region["attestation_url"] for region in record["regions"]] == [
+        "https://api-azure.trustedrouter.com/attestation",
+        "https://api-azure-sea.trustedrouter.com/attestation",
+    ]
+    assert record["regions"][1]["hostdata"] == sea
 
 
 def test_azure_record_without_an_issuer_is_rejected(httpx_mock: HTTPXMock) -> None:


### PR DESCRIPTION
## What was wrong

`scripts/verify_trust_measurements.py` compares each published measurement against a live
attestation. Four things, all verified by hand:

1. **Nothing ran it.** The only references in the repo were *comments* in
   `scripts/deploy/rollout.sh`.
2. **It never checked GCP** — the primary serving plane. `main()` looped over exactly
   `(("aws", check_aws), ("azure", check_azure))`.
3. **It checked one Azure region.** The URL was hardcoded to UAE North; the published
   record lists two, and Southeast Asia (`f3a0b4ed…`) was never contacted.
4. Having checked half the planes it printed *"Every published measurement matches a live
   attestation."* I ran it; that is what it printed.

Now: GCP + AWS + both Azure regions, regions enumerated from the record, coverage counted
from endpoints actually reached, a `--strict` mode where a skipped plane is a failure, and
an hourly workflow.

## A production regression this PR introduced and then fixed

Worth stating plainly because it is the most dangerous thing that happened here. The first
fix widened `validated_azure_metadata` so the regions array reaches the published record.
That introduced an uncaught exception class on a **public route**: `httpx.URL()` raises
`httpx.InvalidURL`, which subclasses `Exception` — not `HTTPError`, not `ValueError` — so
a malformed region URL escaped `TrustReleaseResolver.resolve()` and made
`/trust/azure-release.json` answer **500** instead of the documented 503-plus-fallback,
skipping the retry backoff and the stale-if-error path.

Caught by review, fixed, and there is now a regression test driving the real public route
with a malformed region URL asserting 503 + fallback.

## AWS sampling, stated honestly

`api-aws.trustedrouter.com` is fronted by an accelerator across **two** enclaves — live
module ids `i-0ada95aad6d11aa56-enc01a004f1c2824652` and
`i-02e34e58761097671-enc01a004d7a9c3c307` — while `aws-release.json` names only the first
in `observed_module_id`. A single fetch samples one at random. The output now says this is
sampling, not enumeration, and reports how many distinct module ids were seen.

## What it does NOT establish

No signature or certificate-chain verification. This answers *"is what we publish what is
running"*, which a signature check does not ask. The canonical verifier remains
quill-cloud-proxy's `tools/verify-attestation.py`.

## Merge order

Conflicts with #587 (t2-gate) on `verify_trust_measurements.py`, `trust_release.py`,
`trust.py` and `tests/test_trust_release.py`. **Merge this before #587 (t2-gate).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
