### PR TITLE
Add the settings UI for verifying a phone number

### DIFF
--- a/src/trusted_router/routes/console/settings.py
+++ b/src/trusted_router/routes/console/settings.py
@@ -2,14 +2,31 @@
 
 from __future__ import annotations
 
+from typing import Literal
+from urllib.parse import quote
+
 from fastapi import FastAPI, Form
 from fastapi.responses import HTMLResponse, RedirectResponse, Response
 
+from trusted_router import phone_verification as pv
 from trusted_router.auth import SettingsDep
 from trusted_router.routes.console._shared import ConsoleDep, render
+from trusted_router.services.notify import send_verification_code
 from trusted_router.storage import STORE
 
 MAX_WORKSPACE_NAME = 120
+
+
+def _back(query: str) -> RedirectResponse:
+    """Back to the settings page, POST-redirect-GET.
+
+    Without the redirect a refresh re-posts the form, which for the start
+    handler means ringing the visitor's phone again.
+    """
+    return RedirectResponse(
+        url=f"/console/settings?{query}" if query else "/console/settings",
+        status_code=303,
+    )
 
 
 def register(app: FastAPI) -> None:
@@ -19,7 +36,14 @@ def register(app: FastAPI) -> None:
         settings: SettingsDep,
         saved: str = "",
         error: str = "",
+        sent: str = "",
+        phone_saved: str = "",
+        detail: str = "",
     ) -> Response:
+        # Read the user fresh. ctx.user is the session's snapshot, so a number
+        # verified moments ago on this same page would otherwise still render
+        # as unverified and invite the visitor to start over.
+        user = STORE.get_user(ctx.user.id) or ctx.user
         return HTMLResponse(render(
             "console/settings.html",
             settings=settings,
@@ -30,7 +54,59 @@ def register(app: FastAPI) -> None:
             can_manage=STORE.user_can_manage(ctx.user.id, ctx.workspace.id),
             saved=bool(saved),
             error=error,
+            phone=user.phone,
+            phone_verified=bool(user.phone_verified),
+            phone_pending=user.pending_phone,
+            phone_sent=sent,
+            phone_saved=bool(phone_saved),
+            phone_error=error,
+            phone_error_detail=detail,
         ))
+
+    @app.post("/console/settings/phone/start")
+    async def console_phone_start(
+        ctx: ConsoleDep,
+        settings: SettingsDep,
+        phone: str = Form(""),
+        channel: str = Form("voice"),
+    ) -> Response:
+        """Send a verification code to a number the visitor claims."""
+        allowed, wait = pv.can_resend(ctx.user)
+        if not allowed:
+            # Without a floor, this form is a way to ring someone else's phone
+            # repeatedly by typing their number.
+            return _back(f"error=rate&detail={wait}s")
+
+        try:
+            normalized = pv.normalize_phone(phone)
+        except pv.PhoneNumberError as exc:
+            return _back(f"error=phone&detail={quote(str(exc))}")
+
+        started = STORE.begin_phone_verification(ctx.user.id, normalized)
+        if started is None:
+            return _back("error=phone&detail=account+not+found")
+        code, _updated = started
+
+        wanted: Literal["sms", "voice"] = "sms" if channel == "sms" else "voice"
+        delivered, detail = send_verification_code(settings, normalized, code, channel=wanted)
+        if not delivered:
+            # The pending code is left in place deliberately: a carrier blip is
+            # not a rejected number, and clearing it would send the visitor
+            # back to the start for nothing.
+            return _back(f"error=send&detail={quote(detail[:120])}")
+        return _back(f"sent={'a phone call' if wanted == 'voice' else 'text message'}")
+
+    @app.post("/console/settings/phone/confirm")
+    async def console_phone_confirm(ctx: ConsoleDep, code: str = Form("")) -> Response:
+        status, _user = STORE.confirm_phone_verification(ctx.user.id, code)
+        if status == "ok":
+            return _back("phone_saved=1")
+        return _back(f"error={status}")
+
+    @app.post("/console/settings/phone/remove")
+    async def console_phone_remove(ctx: ConsoleDep) -> Response:
+        STORE.clear_user_phone(ctx.user.id)
+        return _back("")
 
     @app.post("/console/settings")
     async def console_update_settings(

--- a/src/trusted_router/templates/console/settings.html
+++ b/src/trusted_router/templates/console/settings.html
@@ -17,6 +17,55 @@
   </div>
 </section>
 <section class="panel">
+  <div class="panel-head">
+    <h2>Notifications</h2>
+    {% if phone_verified %}<span class="pill good">verified</span>{% else %}<span class="pill">not set up</span>{% endif %}
+  </div>
+  <div class="panel-body">
+    {% if phone_error == 'phone' %}<p class="notice bad">{{ phone_error_detail or 'Enter a mobile number in international format, e.g. +15551234567.' }}</p>
+    {% elif phone_error == 'send' %}<p class="notice bad">Could not send the code: {{ phone_error_detail }}</p>
+    {% elif phone_error == 'mismatch' %}<p class="notice bad">That code is not right. Check the digits and try again.</p>
+    {% elif phone_error == 'expired' %}<p class="notice bad">That code expired. Send a new one.</p>
+    {% elif phone_error == 'too_many_attempts' %}<p class="notice bad">Too many attempts — that code is now dead. Send a new one.</p>
+    {% elif phone_error == 'no_pending' %}<p class="notice bad">No code is waiting. Send one first.</p>
+    {% elif phone_error == 'rate' %}<p class="notice bad">A code was just sent. Wait a moment before asking for another.</p>{% endif %}
+    {% if phone_sent %}<p class="notice ok">Code sent by {{ phone_sent }}. It expires in 10 minutes.</p>{% endif %}
+    {% if phone_saved %}<p class="notice ok">Number verified.</p>{% endif %}
+
+    {% if phone_verified %}
+      <p>Alerts go to <strong>{{ phone }}</strong>.</p>
+      <p class="muted">Your agents can reach you here with <code>POST /v1/notify</code> — push, email, SMS, or a phone call. They cannot send anywhere else: the destination is resolved from the API key to this account, never from the request. <a href="/docs/notify">How it works</a>.</p>
+      <form class="form" method="post" action="/console/settings/phone/remove">
+        <button class="btn" type="submit">Remove this number</button>
+      </form>
+    {% elif phone_pending %}
+      <p>A code is on its way to <strong>{{ phone_pending }}</strong>.</p>
+      <form class="form" method="post" action="/console/settings/phone/confirm">
+        <label>Code<input name="code" inputmode="numeric" autocomplete="one-time-code" maxlength="6" placeholder="123456" required></label>
+        <button class="btn primary" type="submit">Verify</button>
+      </form>
+      <form class="form" method="post" action="/console/settings/phone/start">
+        <input type="hidden" name="phone" value="{{ phone_pending }}">
+        <input type="hidden" name="channel" value="voice">
+        <button class="btn" type="submit">Call me the code instead</button>
+      </form>
+    {% else %}
+      <p>Add a mobile number so your agents can reach you when something breaks. Verifying it is what unlocks every notification channel, email included.</p>
+      <form class="form" method="post" action="/console/settings/phone/start">
+        <label>Mobile number<input name="phone" placeholder="+15551234567" autocomplete="tel" required></label>
+        <label>Send the code by
+          <select name="channel">
+            <option value="voice">Phone call</option>
+            <option value="sms">Text message</option>
+          </select>
+        </label>
+        <button class="btn primary" type="submit">Send code</button>
+      </form>
+      <p class="muted">A phone call works on any number, including landlines and desk phones, and needs no carrier registration. <a href="/docs/notify">What we send</a>.</p>
+    {% endif %}
+  </div>
+</section>
+<section class="panel">
   <div class="panel-head"><h2>Prompt and output handling</h2><span class="pill">never logged</span></div>
   <div class="panel-body">
     <p>{{ content_handling_claim }} A workspace can explicitly send content to its own Broadcast destination; that customer-directed export is not retained as a TrustedRouter log.</p>

--- a/tests/test_console_phone.py
+++ b/tests/test_console_phone.py
@@ -1,0 +1,173 @@
+"""The settings page that actually lets someone add a phone number.
+
+The API existed for a day before this did, which made the feature unreachable
+for anyone who was not willing to hand-craft a POST — including its owner, who
+went looking for it in the console and found nothing.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from trusted_router.services import notify as notify_module
+from trusted_router.services.telephony import TelephonyResult
+from trusted_router.storage import STORE
+
+
+class _Telephony:
+    def __init__(self, *, delivered: bool = True) -> None:
+        self.enabled = True
+        self._delivered = delivered
+        self.sent: list[tuple[str, str, str]] = []
+
+    def send(self, channel, to, body, preferred_carrier=None):
+        self.sent.append((channel, to, body))
+        if self._delivered:
+            return TelephonyResult(True, "telnyx", "queued")
+        return TelephonyResult(False, None, "telnyx=500; twilio=500")
+
+
+@pytest.fixture
+def client(client: TestClient) -> TestClient:
+    """A signed-in console session on conftest's app.
+
+    /console/* rejects API-key Bearer auth and wants the cookie sign-in mints;
+    standing up a second create_app would replace process-wide settings and
+    poison unrelated tests.
+    """
+    user = STORE.ensure_user("console-phone@example.com")
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+    raw_session, _ = STORE.create_auth_session(
+        user_id=user.id, provider="test", label="t", ttl_seconds=3600,
+        workspace_id=workspace.id, state="active",
+    )
+    client.cookies.set("tr_session", raw_session)
+    client.follow_redirects = False
+    return client
+
+
+@pytest.fixture
+def carrier(monkeypatch) -> _Telephony:
+    fake = _Telephony()
+    monkeypatch.setattr(notify_module, "get_telephony_service", lambda s: fake)
+    return fake
+
+
+def _user():
+    return STORE.find_user_by_email("console-phone@example.com")
+
+
+class TestThePageOffersIt:
+    def test_the_settings_page_invites_a_number(self, client) -> None:
+        page = client.get("/console/settings")
+
+        assert page.status_code == 200
+        assert "Mobile number" in page.text
+        assert "/console/settings/phone/start" in page.text
+
+    def test_it_offers_a_phone_call_as_well_as_a_text(self, client) -> None:
+        # A call needs no carrier registration and reaches landlines, so it must
+        # be offered rather than hidden behind SMS failing first.
+        page = client.get("/console/settings")
+
+        assert "Phone call" in page.text
+
+
+class TestVerifying:
+    def test_a_code_can_be_requested_and_confirmed(self, client, carrier) -> None:
+        started = client.post(
+            "/console/settings/phone/start",
+            data={"phone": "+1 (305) 951-1381", "channel": "voice"},
+        )
+        assert started.status_code == 303, started.text
+        assert carrier.sent, "no code was sent"
+
+        _channel, _to, spoken = carrier.sent[0]
+        code = "".join(ch for ch in spoken.split("is")[1] if ch.isdigit())[:6]
+
+        confirmed = client.post(
+            "/console/settings/phone/confirm", data={"code": code}
+        )
+        assert confirmed.status_code == 303
+
+        user = _user()
+        assert user.phone_verified
+        assert user.phone == "+13059511381"
+
+    def test_the_page_then_shows_the_verified_number(self, client, carrier) -> None:
+        client.post(
+            "/console/settings/phone/start",
+            data={"phone": "+13059511381", "channel": "voice"},
+        )
+        _c, _t, spoken = carrier.sent[0]
+        code = "".join(ch for ch in spoken.split("is")[1] if ch.isdigit())[:6]
+        client.post("/console/settings/phone/confirm", data={"code": code})
+
+        page = client.get("/console/settings")
+
+        assert "+13059511381" in page.text
+        assert "verified" in page.text
+
+    def test_a_bad_number_never_reaches_a_carrier(self, client, carrier) -> None:
+        response = client.post(
+            "/console/settings/phone/start",
+            data={"phone": "3059511381", "channel": "voice"},
+        )
+
+        assert response.status_code == 303
+        assert "error=phone" in response.headers["location"]
+        assert carrier.sent == []
+
+    def test_a_wrong_code_does_not_verify(self, client, carrier) -> None:
+        client.post(
+            "/console/settings/phone/start",
+            data={"phone": "+13059511381", "channel": "voice"},
+        )
+
+        response = client.post(
+            "/console/settings/phone/confirm", data={"code": "000000"}
+        )
+
+        assert "error=mismatch" in response.headers["location"]
+        assert not _user().phone_verified
+
+    def test_an_immediate_resend_is_refused(self, client, carrier) -> None:
+        # Otherwise this form rings a stranger's phone as fast as it can be
+        # submitted.
+        body = {"phone": "+13059511381", "channel": "voice"}
+        client.post("/console/settings/phone/start", data=body)
+
+        second = client.post("/console/settings/phone/start", data=body)
+
+        assert "error=rate" in second.headers["location"]
+        assert len(carrier.sent) == 1
+
+
+class TestPostRedirectGet:
+    def test_starting_redirects_rather_than_rendering(self, client, carrier) -> None:
+        # A refresh on a rendered POST would ring the phone again.
+        response = client.post(
+            "/console/settings/phone/start",
+            data={"phone": "+13059511381", "channel": "voice"},
+        )
+
+        assert response.status_code == 303
+        assert response.headers["location"].startswith("/console/settings")
+
+
+class TestRemoval:
+    def test_a_number_can_be_removed(self, client, carrier) -> None:
+        client.post(
+            "/console/settings/phone/start",
+            data={"phone": "+13059511381", "channel": "voice"},
+        )
+        _c, _t, spoken = carrier.sent[0]
+        code = "".join(ch for ch in spoken.split("is")[1] if ch.isdigit())[:6]
+        client.post("/console/settings/phone/confirm", data={"code": code})
+
+        client.post("/console/settings/phone/remove")
+
+        user = _user()
+        assert not user.phone_verified
+        assert user.phone is None


### PR DESCRIPTION
The notify API shipped a day before anything could reach it. Verification is session-authenticated, so the only way to use it was to hand-craft a POST with a session cookie — going to the console and looking for it, correctly, found nothing.

Plain form posts, no JavaScript. This page stands between someone and being reachable when their infrastructure breaks; a script that fails to load should not be what stops them.

- **Phone call offered first** — no carrier registration needed, works on landlines
- **POST/redirect/GET** — a refresh on a rendered POST would ring the phone again
- **Resend floor server-side** — without it the form rings any number as fast as it can be submitted
- **Re-reads the user** — a number verified seconds ago would otherwise render as unverified and invite starting over
- **A carrier blip keeps the pending code** — it is not a rejected number, and clearing it costs the visitor their resend allowance

3757 tests pass; ruff and mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)