### PR TITLE
Fix remediator heartbeat rollout race

### DIFF
--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -233,11 +233,21 @@ def create_app(
             async def loop() -> None:
                 await _asyncio.sleep(_random.uniform(5, min(60, interval)))  # noqa: S311
                 while True:
+                    # Publish liveness before reading the eventually
+                    # consistent analytics copy. During a rolling deploy a
+                    # fresh instance must not page on the retired instance's
+                    # heartbeat before announcing itself.
+                    await _asyncio.to_thread(
+                        record_heartbeat, "scheduler:remediator", settings=settings
+                    )
                     try:
                         await _asyncio.to_thread(run_remediator_pass, settings)
                     except Exception:
                         # The watcher must be the last thing to die quietly.
                         log.exception("remediator pass failed")
+                    # A pass can cross a five-minute heartbeat bucket. The
+                    # completion write records that progress without adding a
+                    # duplicate row when it stayed in the same bucket.
                     await _asyncio.to_thread(
                         record_heartbeat, "scheduler:remediator", settings=settings
                     )

--- a/src/trusted_router/synthetic/fleet.py
+++ b/src/trusted_router/synthetic/fleet.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import asyncio
 import datetime as dt
 import logging
+import threading
 import time
 import uuid
 from typing import Any
@@ -56,6 +57,19 @@ PEER_FETCH_TIMEOUT_SECONDS = 10.0
 # concerned. Two synthetic cadences plus scheduling allowance, mirroring
 # SILENT_PROBE_TTL_SECONDS in status.py.
 HEARTBEAT_STALE_SECONDS = 11 * 60
+
+# Heartbeat reads must use the target-leading analytics indexes. A broad
+# ``probe_type=heartbeat`` read scans the entire synthetic table in ClickHouse
+# because ``target`` is the first sort-key column. Keep every product heartbeat
+# name here; ``record_heartbeat`` also registers local extension names.
+BUILTIN_HEARTBEAT_TARGETS = frozenset(
+    {
+        "job:settle-outbox-drain",
+        "scheduler:home-settlement",
+        "scheduler:remediator",
+        "scheduler:synthetic",
+    }
+)
 
 
 def fleet_peers(settings: Settings) -> list[tuple[str, str]]:
@@ -204,6 +218,31 @@ HEARTBEAT_BUCKET_SECONDS = 5 * 60
 # (job name -> last bucket recorded by THIS process); purely a write saver,
 # the deterministic id is what keeps concurrent replicas to one row.
 _HEARTBEAT_MARKS: dict[str, int] = {}
+_REGISTERED_HEARTBEAT_TARGETS: set[str] = set()
+_HEARTBEAT_LOCK = threading.RLock()
+
+
+def register_heartbeat_target(name: str) -> None:
+    """Register a heartbeat name for indexed fleet reads.
+
+    Product heartbeat names belong in ``BUILTIN_HEARTBEAT_TARGETS``. This
+    registry preserves the helper's usefulness for local jobs and tests
+    without falling back to a full-table ``probe_type`` scan.
+    """
+    if name:
+        with _HEARTBEAT_LOCK:
+            _REGISTERED_HEARTBEAT_TARGETS.add(name)
+
+
+def _heartbeat_bucket_start(bucket: int) -> str:
+    return (
+        dt.datetime.fromtimestamp(
+            bucket * HEARTBEAT_BUCKET_SECONDS,
+            tz=dt.UTC,
+        )
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
 
 
 def record_heartbeat(name: str, *, settings: Settings) -> None:
@@ -211,36 +250,36 @@ def record_heartbeat(name: str, *, settings: Settings) -> None:
     heartbeat that can kill its own loop would be worse than no heartbeat."""
     try:
         bucket = int(time.time() // HEARTBEAT_BUCKET_SECONDS)
-        if _HEARTBEAT_MARKS.get(name) == bucket:
-            return
-        from trusted_router.storage import STORE
+        with _HEARTBEAT_LOCK:
+            _REGISTERED_HEARTBEAT_TARGETS.add(name)
+            if _HEARTBEAT_MARKS.get(name) == bucket:
+                return
+            from trusted_router.storage import STORE
 
-        bucket_start = (
-            dt.datetime.fromtimestamp(
-                bucket * HEARTBEAT_BUCKET_SECONDS,
-                tz=dt.UTC,
+            bucket_start = _heartbeat_bucket_start(bucket)
+            STORE.record_synthetic_probe_sample(
+                SyntheticProbeSample(
+                    id=f"syn_hb_{name.replace(':', '_')}_{bucket}",
+                    probe_type=HEARTBEAT_PROBE,
+                    target=name,
+                    target_url="",
+                    monitor_region=(settings.synthetic_monitor_region or settings.primary_region),
+                    status="up",
+                    created_at=bucket_start,
+                )
             )
-            .isoformat()
-            .replace("+00:00", "Z")
-        )
-        STORE.record_synthetic_probe_sample(
-            SyntheticProbeSample(
-                id=f"syn_hb_{name.replace(':', '_')}_{bucket}",
-                probe_type=HEARTBEAT_PROBE,
-                target=name,
-                target_url="",
-                monitor_region=settings.synthetic_monitor_region or settings.primary_region,
-                status="up",
-                created_at=bucket_start,
-            )
-        )
-        _HEARTBEAT_MARKS[name] = bucket
+            # Publish the read-your-write mark only after the store accepted
+            # the sample. The lock also collapses concurrent gateway calls
+            # into one heartbeat row for this five-minute bucket.
+            _HEARTBEAT_MARKS[name] = bucket
     except Exception:  # noqa: BLE001 - liveness reporting must not break the job
         logger.exception("heartbeat record failed for %s", name)
 
 
 def reset_for_tests() -> None:
-    _HEARTBEAT_MARKS.clear()
+    with _HEARTBEAT_LOCK:
+        _HEARTBEAT_MARKS.clear()
+        _REGISTERED_HEARTBEAT_TARGETS.clear()
 
 
 def _age_seconds(created_at: str) -> float | None:
@@ -256,20 +295,34 @@ def _age_seconds(created_at: str) -> float | None:
 def _heartbeat_rows() -> list[dict[str, Any]]:
     from trusted_router.storage import STORE
 
-    samples = STORE.synthetic_probe_samples(probe_type=HEARTBEAT_PROBE, limit=500)
-    latest: dict[str, SyntheticProbeSample] = {}
-    for sample in samples:
-        current = latest.get(sample.target)
-        if current is None or sample.created_at > current.created_at:
-            latest[sample.target] = sample
+    # The durable analytics pipeline is intentionally asynchronous. Merge the
+    # successful process-local write marks so a newly rolled instance cannot
+    # page on an old ClickHouse snapshot immediately after publishing its own
+    # heartbeat. Durable samples remain authoritative after process restart.
+    latest: dict[str, str] = {}
+    with _HEARTBEAT_LOCK:
+        targets = BUILTIN_HEARTBEAT_TARGETS | _REGISTERED_HEARTBEAT_TARGETS
+        local_marks = dict(_HEARTBEAT_MARKS)
+    for name in sorted(targets):
+        samples = STORE.synthetic_probe_samples(
+            target=name,
+            probe_type=HEARTBEAT_PROBE,
+            limit=1,
+        )
+        if samples:
+            latest[name] = samples[0].created_at
+    for name, bucket in local_marks.items():
+        local_created_at = _heartbeat_bucket_start(bucket)
+        if local_created_at > latest.get(name, ""):
+            latest[name] = local_created_at
+
     rows = []
-    for name in sorted(latest):
-        sample = latest[name]
-        age = _age_seconds(sample.created_at)
+    for name, created_at in sorted(latest.items()):
+        age = _age_seconds(created_at)
         rows.append(
             {
                 "name": name,
-                "last_beat_at": sample.created_at,
+                "last_beat_at": created_at,
                 "age_seconds": round(age) if age is not None else None,
                 "stale": age is None or age > HEARTBEAT_STALE_SECONDS,
             }

--- a/tests/test_fleet_command_center.py
+++ b/tests/test_fleet_command_center.py
@@ -11,8 +11,10 @@ Covers the two halves plus the alert plumbing they rely on:
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import datetime as dt
 import json
+import time
 
 import httpx
 import pytest
@@ -176,9 +178,73 @@ def test_record_heartbeat_and_liveness_rows() -> None:
             created_at=old,
         )
     )
+    fleet.register_heartbeat_target("scheduler:dead-loop")
     snapshot = asyncio.run(fleet_snapshot(settings))
     beats = {row["name"]: row for row in snapshot["heartbeats"]}
     assert beats["scheduler:dead-loop"]["stale"] is True
+
+
+def test_heartbeat_read_your_write_masks_stale_analytics_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rollout must not page between the durable write and CH ingestion."""
+    from trusted_router.storage_models import SyntheticProbeSample
+
+    settings = _settings()
+    target = "scheduler:rollout-race"
+    record_heartbeat(target, settings=settings)
+    stale = SyntheticProbeSample(
+        id="syn_hb_rollout_stale",
+        probe_type="heartbeat",
+        target=target,
+        target_url="",
+        monitor_region="test-1",
+        status="up",
+        created_at=(utcnow() - dt.timedelta(hours=1)).isoformat().replace("+00:00", "Z"),
+    )
+    reads: list[dict[str, object]] = []
+
+    def stale_analytics(self: object, **kwargs: object) -> list[SyntheticProbeSample]:
+        reads.append(kwargs)
+        return [stale] if kwargs.get("target") == target else []
+
+    monkeypatch.setattr(
+        type(STORE.target),
+        "synthetic_probe_samples",
+        stale_analytics,
+    )
+
+    beats = {row["name"]: row for row in fleet._heartbeat_rows()}
+
+    assert beats[target]["stale"] is False
+    assert beats[target]["last_beat_at"] != stale.created_at
+    assert reads
+    assert all(read["target"] and read["limit"] == 1 for read in reads)
+    assert all(read["probe_type"] == "heartbeat" for read in reads)
+
+
+def test_concurrent_heartbeat_calls_write_one_bucket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store_type = type(STORE.target)
+    original = store_type.record_synthetic_probe_sample
+
+    def slow_record(self: object, sample: object) -> None:
+        time.sleep(0.01)
+        original(self, sample)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(store_type, "record_synthetic_probe_sample", slow_record)
+    settings = _settings()
+    target = "job:concurrent-heartbeat"
+    with concurrent.futures.ThreadPoolExecutor(max_workers=12) as pool:
+        list(pool.map(lambda _: record_heartbeat(target, settings=settings), range(24)))
+
+    samples = STORE.synthetic_probe_samples(
+        target=target,
+        probe_type="heartbeat",
+        limit=100,
+    )
+    assert len(samples) == 1
 
 
 def test_fleet_snapshot_merges_peers_and_ranks_overall() -> None:

--- a/tests/test_remediator.py
+++ b/tests/test_remediator.py
@@ -54,6 +54,7 @@ def _record(sample: SyntheticProbeSample) -> None:
 
 
 def test_stale_heartbeat_produces_paged_decision(sentry_events: list[str]) -> None:
+    fleet.register_heartbeat_target("scheduler:dead")
     _record(
         SyntheticProbeSample(
             id="syn_hb_dead_sched_rem",
@@ -124,6 +125,7 @@ def test_fresh_probes_produce_no_monitor_decision(sentry_events: list[str]) -> N
 
 
 def test_decision_rows_bucket_and_dedupe(sentry_events: list[str]) -> None:
+    fleet.register_heartbeat_target("scheduler:bucketed")
     _record(
         SyntheticProbeSample(
             id="syn_hb_dead_bucket",
@@ -180,6 +182,7 @@ def test_remediation_samples_stay_out_of_public_surfaces() -> None:
 def test_fleet_snapshot_carries_remediator_section() -> None:
     import asyncio
 
+    fleet.register_heartbeat_target("scheduler:fleet-dead")
     _record(
         SyntheticProbeSample(
             id="syn_hb_dead_fleet_rem",


### PR DESCRIPTION
## Summary
- publish the remediator heartbeat before evaluating stale-heartbeat alerts
- merge successful process-local heartbeat writes with the asynchronous ClickHouse view
- replace broad heartbeat scans with target-indexed reads
- serialize concurrent heartbeat writes within each process

## Root cause
During the multi-region rollout, fresh Cloud Run instances evaluated the retired instance's last ClickHouse heartbeat before their own heartbeat reached analytics. Concurrent instances then emitted duplicate false alerts. The true maximum heartbeat gap was 600 seconds, below the 660-second stale threshold.

## Verification
- regression fails on the prior revision and passes with this change
- 22 focused fleet/remediator tests pass
- 242 broader synthetic/ClickHouse tests pass, 1 skipped
- full suite: 3,750 passed, 254 skipped, 10 expected failures
- ruff and mypy clean