### PR TITLE
Schedule remediator outside request CPU

### DIFF
--- a/scripts/deploy/clickhouse_cluster.sh
+++ b/scripts/deploy/clickhouse_cluster.sh
@@ -96,6 +96,14 @@ ensure_service_account() {
   done
   ensure_project_role "serviceAccount:${CLUSTER_SERVICE_ACCOUNT}" roles/monitoring.metricWriter
   ensure_project_role "serviceAccount:${CLUSTER_SERVICE_ACCOUNT}" roles/logging.logWriter
+  # Node 1 drains the durable Spanner analytics outbox. Keep this grant at the
+  # database boundary: changing the VM from the broad default Compute identity
+  # must not silently stop ingestion with spanner.sessions.create 403s.
+  gc spanner databases add-iam-policy-binding "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID" \
+    --member="serviceAccount:${CLUSTER_SERVICE_ACCOUNT}" \
+    --role=roles/spanner.databaseUser \
+    --quiet >/dev/null
 }
 
 ensure_network() {

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -320,6 +320,9 @@ fi
 ENV_VARS=(
   "TR_ENVIRONMENT=production"
   "TR_RELEASE=$(git rev-parse --short HEAD 2>/dev/null || echo local)"
+  # Request-based Cloud Run CPU can pause background coroutines. The scheduled
+  # synthetic job invokes /internal/synthetic/remediate instead.
+  "TR_REMEDIATOR_IN_PROCESS_ENABLED=false"
   "TR_ENABLE_LIVE_PROVIDERS=false"
   "TR_API_BASE_URL=https://api.trustedrouter.com/v1"
   "TR_TRUSTED_DOMAIN=trustedrouter.com"

--- a/scripts/deploy/synthetic.sh
+++ b/scripts/deploy/synthetic.sh
@@ -146,6 +146,11 @@ for monitor_region in "${_REGION_LIST[@]}"; do
     "TR_SYNTHETIC_THROUGHPUT_ENABLED=false"
     "TR_SYNTHETIC_THROUGHPUT_ONLY=false"
   )
+  if [ "$monitor_region" = "$TR_PRIMARY_REGION" ]; then
+    env_vars+=(
+      "TR_SYNTHETIC_REMEDIATOR_URL=${regional_ingest_base}/v1/internal/synthetic/remediate"
+    )
+  fi
   set_env_vars="$(IFS='|'; echo "^|^${env_vars[*]}")"
 
   log "deploying synthetic Cloud Run job ${job_name} in ${monitor_region}"

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -828,6 +828,10 @@ class Settings(BaseSettings):
     # ship it behaves as observe.
     remediator_mode: str = "observe"
     remediator_interval_seconds: int = 120
+    # Cloud Run request-based CPU may pause background coroutines between
+    # requests. GCP therefore drives remediation from the scheduled synthetic
+    # worker and disables this loop; long-lived AWS/Azure processes retain it.
+    remediator_in_process_enabled: bool = True
     synthetic_fleet_peers: str = (
         "gcp=https://trustedrouter.com"
         ",aws=https://aws.trustedrouter.com"

--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -216,7 +216,7 @@ def create_app(
     # The standing remediator (command-center Inc 3): detect -> decide ->
     # record on a fixed cadence, on every control plane, outside deploy
     # windows. Observe mode by default; see synthetic/remediator.py.
-    if settings.remediator_mode != "off":
+    if settings.remediator_mode != "off" and settings.remediator_in_process_enabled:
 
         @app.on_event("startup")
         async def _start_remediator_loop() -> None:  # pragma: no cover - thread wiring

--- a/src/trusted_router/routes/internal/synthetic.py
+++ b/src/trusted_router/routes/internal/synthetic.py
@@ -19,11 +19,13 @@ from trusted_router.storage import STORE, ProviderBenchmarkSample, SyntheticProb
 from trusted_router.storage_models import FUTURE_SAMPLE_SKEW_SECONDS, scrub_provider_error_message
 from trusted_router.synthetic.alerts import alert_on_failure_streak
 from trusted_router.synthetic.cli import rotation_pass
+from trusted_router.synthetic.fleet import record_heartbeat
 from trusted_router.synthetic.probes import (
     gateway_billing_probe,
     gateway_fallback_probe,
     run_synthetic_once,
 )
+from trusted_router.synthetic.remediator import run_remediator_pass
 from trusted_router.synthetic.route_health import (
     evaluate_route_health,
     report_image_generation_failures,
@@ -165,6 +167,28 @@ def register(router: APIRouter) -> None:
         flags = await run_in_threadpool(evaluate_route_health, STORE)
         await run_in_threadpool(report_route_health, flags)
         return {"data": {"flagged": [asdict(flag) for flag in flags]}}
+
+    @router.post("/internal/synthetic/remediate")
+    async def synthetic_remediate(request: Request, settings: SettingsDep) -> dict[str, Any]:
+        """Run one remediation pass under request CPU.
+
+        GCP's scheduled synthetic worker calls this endpoint. Publishing the
+        heartbeat before detection gives the pass read-your-write liveness
+        even while the durable analytics copy catches up.
+        """
+        require_internal_gateway(request, settings)
+        await run_in_threadpool(
+            record_heartbeat,
+            "scheduler:remediator",
+            settings=settings,
+        )
+        decisions = await run_in_threadpool(run_remediator_pass, settings)
+        await run_in_threadpool(
+            record_heartbeat,
+            "scheduler:remediator",
+            settings=settings,
+        )
+        return {"data": {"decisions": len(decisions)}}
 
     @router.post("/internal/synthetic/run")
     async def synthetic_run(

--- a/src/trusted_router/synthetic/cli.py
+++ b/src/trusted_router/synthetic/cli.py
@@ -357,6 +357,30 @@ async def _post_route_health_if_due(
     await _post_route_health(client, url=url, internal_token=internal_token)
 
 
+async def _post_remediator(
+    client: httpx.AsyncClient,
+    *,
+    url: str,
+    internal_token: str,
+) -> bool:
+    """Run the control-plane remediator and make scheduler failures visible."""
+    try:
+        response = await client.post(
+            url,
+            headers={"x-trustedrouter-internal-token": internal_token},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        decisions = payload.get("data", {}).get("decisions") if isinstance(payload, dict) else None
+        if not isinstance(decisions, int):
+            raise ValueError("remediator response did not contain a decision count")
+        print(f"remediator decisions: {decisions}")
+        return True
+    except Exception as exc:
+        print(f"remediator check failed: {exc}", file=sys.stderr)
+        return False
+
+
 async def run() -> int:
     settings = get_settings()
     monitor_region = (
@@ -569,6 +593,16 @@ async def run() -> int:
                     url=route_health_url,
                     internal_token=internal_token,
                 )
+        remediator_url = os.environ.get("TR_SYNTHETIC_REMEDIATOR_URL")
+        if remediator_url:
+            ok = (
+                await _post_remediator(
+                    client,
+                    url=remediator_url,
+                    internal_token=internal_token,
+                )
+                and ok
+            )
     return 0 if ok else 1
 
 

--- a/tests/test_clickhouse_node_provisioning.py
+++ b/tests/test_clickhouse_node_provisioning.py
@@ -49,6 +49,8 @@ def test_cluster_migration_is_parity_gated_and_keeps_local_backup() -> None:
     assert "source and replicated fingerprints differ" in script
     assert "timedelta(minutes=5)" in script
     assert "service account did not become visible" in script
+    assert "roles/spanner.databaseUser" in script
+    assert "spanner databases add-iam-policy-binding" in script
     assert "provider_benchmark_samples_local_backup" in script
     assert "RENAME TABLE provider_benchmark_samples TO" in script
     assert "DROP TABLE provider_benchmark_samples_local_backup" not in script

--- a/tests/test_fleet_command_center.py
+++ b/tests/test_fleet_command_center.py
@@ -21,6 +21,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from trusted_router.config import Settings
+from trusted_router.main import create_app
 from trusted_router.storage import STORE
 from trusted_router.storage_models import iso_now, utcnow
 from trusted_router.synthetic import fleet
@@ -55,6 +56,19 @@ def _peer_transport(responses: dict[str, object]) -> httpx.MockTransport:
         return httpx.Response(200, json={"data": spec})
 
     return httpx.MockTransport(handler)
+
+
+def test_remediator_background_loop_can_be_disabled_for_request_cpu() -> None:
+    app = create_app(
+        _settings(
+            remediator_mode="observe",
+            remediator_in_process_enabled=False,
+            sentry_dsn=None,
+        ),
+        init_observability=False,
+    )
+
+    assert "_start_remediator_loop" not in {handler.__name__ for handler in app.router.on_startup}
 
 
 def test_fleet_peers_parsing_skips_junk() -> None:

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -2683,6 +2683,92 @@ async def test_route_health_caller_obeys_hourly_gate_and_override(
     assert posted == (expected if should_post else [])
 
 
+@pytest.mark.asyncio
+async def test_remediator_caller_reports_success_and_failure(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from trusted_router.synthetic import cli as cli_module
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["x-trustedrouter-internal-token"] == "internal"
+        if request.url.path.endswith("/failure"):
+            return httpx.Response(503, json={"error": "unavailable"})
+        return httpx.Response(200, json={"data": {"decisions": 2}})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        succeeded = await cli_module._post_remediator(
+            client,
+            url="https://trustedrouter.com/v1/internal/synthetic/remediate",
+            internal_token="internal",  # noqa: S106 - test placeholder.
+        )
+        failed = await cli_module._post_remediator(
+            client,
+            url="https://trustedrouter.com/failure",
+            internal_token="internal",  # noqa: S106 - test placeholder.
+        )
+
+    output = capsys.readouterr()
+    assert succeeded is True
+    assert failed is False
+    assert "remediator decisions: 2" in output.out
+    assert "remediator check failed:" in output.err
+
+
+@pytest.mark.asyncio
+async def test_primary_synthetic_job_invokes_scheduled_remediator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trusted_router.synthetic import cli as cli_module
+
+    seen_urls: list[str] = []
+
+    async def empty_pass(**_kwargs: Any) -> tuple[list[Any], list[Any]]:
+        return [], []
+
+    class _Response:
+        status_code = 200
+        text = '{"data":{"decisions":0}}'
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return {"data": {"decisions": 0}}
+
+    class _Client:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _Client:
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            return None
+
+        async def post(self, url: str, **kwargs: Any) -> _Response:
+            assert kwargs["headers"]["x-trustedrouter-internal-token"] == "internal"
+            seen_urls.append(url)
+            return _Response()
+
+    settings = Settings(
+        environment="test",
+        sentry_dsn=None,
+        internal_gateway_token="internal",  # noqa: S106 - test placeholder.
+    )
+    monkeypatch.setattr(cli_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(cli_module, "_probe_and_rotation_pass", empty_pass)
+    monkeypatch.setattr(cli_module.httpx, "AsyncClient", _Client)
+    monkeypatch.setenv(
+        "TR_SYNTHETIC_REMEDIATOR_URL",
+        "https://trustedrouter.com/v1/internal/synthetic/remediate",
+    )
+    monkeypatch.delenv("TR_SYNTHETIC_THROUGHPUT_ONLY", raising=False)
+    monkeypatch.delenv("TR_SYNTHETIC_THROUGHPUT_ENABLED", raising=False)
+
+    assert await cli_module.run() == 0
+    assert seen_urls == ["https://trustedrouter.com/v1/internal/synthetic/remediate"]
+
+
 def test_synthetic_deploy_targets_public_api_domain() -> None:
     deploy_script = Path(__file__).resolve().parents[1] / "scripts/deploy/synthetic.sh"
     body = deploy_script.read_text()
@@ -2726,6 +2812,13 @@ def test_synthetic_deploy_targets_public_api_domain() -> None:
         '"TR_SYNTHETIC_ROUTE_HEALTH_URL=${regional_ingest_base}/v1/internal/synthetic/route-health"'
         in body
     )
+    assert (
+        '"TR_SYNTHETIC_REMEDIATOR_URL=${regional_ingest_base}/v1/internal/synthetic/remediate"'
+        in body
+    )
+    assert 'if [ "$monitor_region" = "$TR_PRIMARY_REGION" ]' in body
+    rollout = (Path(__file__).resolve().parents[1] / "scripts/deploy/rollout.sh").read_text()
+    assert '"TR_REMEDIATOR_IN_PROCESS_ENABLED=false"' in rollout
     assert (
         '"TR_SYNTHETIC_INGEST_URL=${throughput_ingest_base}/v1/internal/synthetic/samples"'
         in body
@@ -4087,3 +4180,36 @@ def test_internal_route_health_reports_flags_and_requires_token(
     assert response.status_code == 200
     assert response.json() == {"data": {"flagged": [asdict(flag)]}}
     assert reported == [flag]
+
+
+def test_internal_remediator_runs_between_heartbeats_and_requires_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trusted_router.routes.internal import synthetic as synthetic_routes
+
+    events: list[str] = []
+
+    def fake_heartbeat(name: str, *, settings: Settings) -> None:
+        assert name == "scheduler:remediator"
+        assert settings.environment == "test"
+        events.append("heartbeat")
+
+    def fake_remediator(settings: Settings) -> list[object]:
+        assert settings.environment == "test"
+        events.append("remediate")
+        return [object(), object()]
+
+    monkeypatch.setattr(synthetic_routes, "record_heartbeat", fake_heartbeat)
+    monkeypatch.setattr(synthetic_routes, "run_remediator_pass", fake_remediator)
+    client = TestClient(create_app(_benchmark_ingest_settings(), init_observability=False))
+
+    unauthorized = client.post("/v1/internal/synthetic/remediate")
+    response = client.post(
+        "/v1/internal/synthetic/remediate",
+        headers={"x-trustedrouter-internal-token": "test-internal-secret"},
+    )
+
+    assert unauthorized.status_code in (401, 403)
+    assert response.status_code == 200
+    assert response.json() == {"data": {"decisions": 2}}
+    assert events == ["heartbeat", "remediate", "heartbeat"]


### PR DESCRIPTION
## Summary
- invoke the remediator from the primary scheduled synthetic job instead of relying on request-throttled Cloud Run background CPU
- keep process-local remediation available for long-lived non-GCP services
- preserve the ClickHouse service account Spanner database grant during node provisioning

## Incident
The ClickHouse node service-account change removed Spanner database access, briefly stalling operational analytics ingestion. After the live IAM repair, monitoring recovered, but the in-process remediator heartbeat could still pause between Cloud Run requests. This change removes that false-page source.

## Verification
- `uv run pytest -q` (3769 passed, 254 skipped, 10 xfailed)
- `uv run ruff check .`
- `uv run mypy`
- focused synthetic/fleet/ClickHouse tests (205 passed)
- shell syntax checks for rollout, synthetic, and ClickHouse deploy scripts