### PR TITLE
Carry workspace_id on analytics samples for durable usage history

### DIFF
--- a/clickhouse/007_benchmark_samples_workspace_id.sql
+++ b/clickhouse/007_benchmark_samples_workspace_id.sql
@@ -1,0 +1,27 @@
+-- Add `workspace_id` to the benchmark/usage sample table.
+--
+-- WHY: Spanner's `tr_generation` carries a
+-- `ROW DELETION POLICY (OLDER_THAN(terminal_at, INTERVAL 30 DAY))`, so
+-- per-workspace usage history there is a rolling 30-day window — a customer's
+-- lifetime totals silently shrink as their traffic ages out. ClickHouse keeps
+-- these rows for 400 days but had no tenant column, so it could not answer
+-- "how much has this customer used" at all. This column is what makes durable
+-- per-customer usage history possible.
+--
+-- PRIVACY NOTE: this table also feeds PUBLIC surfaces (leaderboard, provider
+-- and model rankings, the /apps directory). Those consumers aggregate samples
+-- into their own explicit dicts and must never project `workspace_id` into a
+-- response; `tests/test_analytics_workspace_id.py` pins that boundary. The
+-- node itself is VPC-internal with no public IP, which is why carrying a
+-- tenant id here is acceptable where it would not be in a public export.
+--
+-- Backfill is deliberately NOT attempted: rows written before this change
+-- have no tenant attribution anywhere recoverable (Spanner has already
+-- deleted anything older than 30 days), so historical rows keep the DEFAULT
+-- ''. Treat `workspace_id = ''` as "unattributed", not "no workspace".
+--
+-- Idempotent: `IF NOT EXISTS` makes re-running safe.
+
+ALTER TABLE provider_benchmark_samples
+    ADD COLUMN IF NOT EXISTS workspace_id LowCardinality(String) DEFAULT ''
+    AFTER source;

--- a/clickhouse/backfill_benchmark_samples.py
+++ b/clickhouse/backfill_benchmark_samples.py
@@ -116,6 +116,7 @@ def normalise(raw: dict[str, Any]) -> dict[str, Any] | None:
         "status": str(raw.get("status") or ""),
         "usage_type": str(raw.get("usage_type") or ""),
         "source": str(raw.get("source") or ""),
+        "workspace_id": str(raw.get("workspace_id") or ""),
         "streamed": 1 if raw.get("streamed") else 0,
         "input_tokens": int(raw.get("input_tokens") or 0),
         "output_tokens": int(raw.get("output_tokens") or 0),

--- a/src/trusted_router/analytics_sink.py
+++ b/src/trusted_router/analytics_sink.py
@@ -228,6 +228,7 @@ def _row_from_sample(sample: Any) -> dict[str, Any]:
         "status": str(raw.get("status") or ""),
         "usage_type": str(raw.get("usage_type") or ""),
         "source": str(raw.get("source") or ""),
+        "workspace_id": str(raw.get("workspace_id") or ""),
         "streamed": 1 if raw.get("streamed") else 0,
         "input_tokens": int(raw.get("input_tokens") or 0),
         "output_tokens": int(raw.get("output_tokens") or 0),

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -1732,6 +1732,7 @@ def _settle_gateway_authorization(
                 error_type=body.error_type or "provider_error",
                 region=authorization.region,
                 provider=selected_endpoint.provider,
+                workspace_id=authorization.workspace_id,
             )
         )
 

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -815,10 +815,18 @@ def scrub_provider_error_message(value: str) -> str:
 
 @dataclass
 class ProviderBenchmarkSample:
-    """Privacy-safe provider performance sample for future public rankings.
+    """Provider performance sample, and the durable per-workspace usage record.
 
-    This intentionally omits workspace_id, key_hash, app, prompt, and output.
-    Public ranking pages can aggregate these rows without exposing tenants.
+    Prompts, outputs, and key material are never carried here. `workspace_id`
+    IS carried: this row is the only usage record that outlives Spanner's
+    30-day `tr_generation` deletion policy, so without it there is no way to
+    answer "how much has this customer used" beyond a month.
+
+    That places a hard requirement on every consumer: these rows feed PUBLIC
+    surfaces (the leaderboard, provider/model rankings, the /apps directory).
+    Those aggregate samples into their own explicit dicts and must never
+    project `workspace_id` into a response. `tests/test_analytics_workspace_id.py`
+    pins that boundary — if you add a public consumer, extend that test.
     """
 
     id: str
@@ -828,6 +836,9 @@ class ProviderBenchmarkSample:
     status: str
     usage_type: UsageType
     streamed: bool
+    # Tenant that generated the sample. Empty only for rows predating this
+    # field and for error paths without an authorization in scope.
+    workspace_id: str = ""
     input_tokens: int = 0
     output_tokens: int = 0
     total_cost_microdollars: int = 0
@@ -876,6 +887,7 @@ class ProviderBenchmarkSample:
             status=generation.status,
             usage_type=generation.usage_type,
             streamed=generation.streamed,
+            workspace_id=generation.workspace_id,
             input_tokens=generation.tokens_prompt,
             output_tokens=generation.tokens_completion,
             total_cost_microdollars=generation.total_cost_microdollars,
@@ -941,6 +953,7 @@ class ProviderBenchmarkSample:
         error_type: str,
         region: str | None,
         provider: str | None = None,
+        workspace_id: str = "",
     ) -> ProviderBenchmarkSample:
         return cls(
             id=f"bench-{uuid.uuid4().hex}",
@@ -950,6 +963,7 @@ class ProviderBenchmarkSample:
             status="error",
             usage_type=UsageType.coerce(usage_type),
             streamed=streamed,
+            workspace_id=workspace_id,
             input_tokens=input_tokens,
             output_tokens=0,
             total_cost_microdollars=0,

--- a/tests/test_analytics_workspace_id.py
+++ b/tests/test_analytics_workspace_id.py
@@ -1,0 +1,106 @@
+"""`workspace_id` reaches analytics storage but never a public surface.
+
+`ProviderBenchmarkSample` carries a tenant id so per-customer usage history
+survives Spanner's 30-day `tr_generation` deletion policy. The same rows feed
+public pages (leaderboard, model/provider rankings, /apps), so the boundary
+these tests pin is: the field flows into the ClickHouse row shape, and does
+NOT appear in any public response.
+
+If you add a public consumer of benchmark samples, add it to
+`test_public_surfaces_never_expose_workspace_id`.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from trusted_router.analytics_sink import _row_from_sample
+from trusted_router.apps import aggregate_apps
+from trusted_router.storage_models import Generation, ProviderBenchmarkSample
+from trusted_router.synthetic.leaderboard import aggregate_leaderboard
+
+WORKSPACE = "ws-secret-tenant-id"
+
+
+def _generation() -> Generation:
+    return Generation(
+        id="gen-abc",
+        request_id="req-abc",
+        workspace_id=WORKSPACE,
+        key_hash="key-hash",
+        model="deepseek/deepseek-v4-flash-0731",
+        provider_name="DeepSeek",
+        app="attested-gateway",
+        tokens_prompt=1_000,
+        tokens_completion=50,
+        total_cost_microdollars=120,
+        usage_type="Credits",
+        speed_tokens_per_second=40.0,
+        finish_reason="stop",
+        status="success",
+        streamed=True,
+        usage_estimated=False,
+        provider="deepseek",
+    )
+
+
+def _sample() -> ProviderBenchmarkSample:
+    return ProviderBenchmarkSample.from_generation(_generation())
+
+
+def test_sample_carries_workspace_id_from_generation() -> None:
+    assert _sample().workspace_id == WORKSPACE
+
+
+def test_clickhouse_row_includes_workspace_id() -> None:
+    """The durable analytics row must carry the tenant, or ClickHouse cannot
+    answer per-customer usage beyond Spanner's 30-day window."""
+    row = _row_from_sample(_sample())
+    assert row["workspace_id"] == WORKSPACE
+
+
+def test_error_samples_default_to_unattributed() -> None:
+    """Error paths without an authorization in scope produce '' — treated as
+    unattributed, never as a real workspace."""
+
+    class _Model:
+        id = "deepseek/deepseek-v4-flash-0731"
+        provider = "deepseek"
+
+    sample = ProviderBenchmarkSample.from_provider_error(
+        model=_Model(),
+        provider_name="DeepSeek",
+        input_tokens=10,
+        elapsed_seconds=0.5,
+        streamed=False,
+        usage_type="Credits",
+        error_status=502,
+        error_type="provider_error",
+        region=None,
+    )
+    assert sample.workspace_id == ""
+    assert _row_from_sample(sample)["workspace_id"] == ""
+
+
+def test_aggregators_never_emit_workspace_id() -> None:
+    """The two aggregators that public pages render must not project the
+    tenant id, no matter what the samples carry."""
+    samples = [_sample()]
+    assert WORKSPACE not in repr(aggregate_leaderboard(samples, min_samples=1))
+    assert WORKSPACE not in repr(aggregate_apps(samples))
+
+
+def test_public_surfaces_never_expose_workspace_id(client: TestClient) -> None:
+    """End-to-end: no public page or feed may contain a workspace id."""
+    for path in (
+        "/leaderboard",
+        "/apps",
+        "/rankings",
+        "/benchmarks",
+        "/status.json",
+        "/models",
+        "/providers",
+    ):
+        response = client.get(path)
+        assert response.status_code == 200, f"{path} -> {response.status_code}"
+        assert "workspace_id" not in response.text, f"{path} leaked the workspace_id field"
+        assert WORKSPACE not in response.text, f"{path} leaked a workspace id value"

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -141,12 +141,17 @@ def test_chat_activity_generation_and_no_content_storage(
     assert sample.provider_name == "Cerebras"
     assert sample.elapsed_milliseconds is not None
     assert sample.total_cost_microdollars == generation_data["total_cost_microdollars"]
-    assert "workspace_id" not in safe_sample
+    # `workspace_id` IS carried, deliberately. ClickHouse keeps these rows for
+    # 400 days while Spanner's tr_generation deletes after 30, so this is the
+    # only durable per-customer usage record. The table is VPC-internal; the
+    # public surfaces that read these samples aggregate them and must never
+    # project the tenant id — pinned by tests/test_analytics_workspace_id.py.
+    assert safe_sample["workspace_id"], "sample must carry tenant attribution"
+    # Credential material and prompt bodies remain excluded — those guarantees
+    # are unchanged and are the ones that actually matter here.
     assert "key_hash" not in safe_sample
     # `app` is the caller's public, opt-in self-reported title (X-Title): it
-    # powers the /apps directory and is NOT tenant / credential / prompt data.
-    # It is intentionally carried on the benchmark sample; the real privacy
-    # guarantees below (no workspace, no key, no prompt body) still hold.
+    # powers the /apps directory and is NOT credential / prompt data.
     assert isinstance(safe_sample["app"], str)
     assert prompt not in str(safe_sample)
 


### PR DESCRIPTION
## Problem
`tr_generation` in Spanner has:

```sql
ROW DELETION POLICY (OLDER_THAN(terminal_at, INTERVAL 30 DAY))
```

So per-customer usage history is a **rolling 30-day window**. A customer's lifetime totals silently shrink as their traffic ages out, and their peak-day figures vanish. Observed live: one account's reported total went 2B → 1.4B → 754M across three days, and its peak/day dropped 639M → 254M — not churn, just rows expiring.

ClickHouse retains the same events for **400 days** but carried no tenant column, so "how much has this customer used" was unanswerable beyond a month. That matters for case studies, renewals, and any cohort analysis.

## Change
Carry `workspace_id` on `ProviderBenchmarkSample` and write it through to the ClickHouse row shape — the live sink, the backfill normaliser, and the outbox ingester (which imports that normaliser). Migration `007` adds the column as `LowCardinality(String) DEFAULT ''`, positioned after `source`.

**The migration is already applied to prod** (additive, idempotent, backward-compatible — `ADD COLUMN IF NOT EXISTS` with a DEFAULT, so inserts that omit it still succeed). Verified live:

```
┌─name─────────┬─type───────────────────┬─default_expression─┐
│ workspace_id │ LowCardinality(String) │ ''                 │
└──────────────┴────────────────────────┴────────────────────┘
```

## Privacy boundary — now pinned, not incidental
These rows also feed **public** surfaces: the leaderboard, provider/model rankings, and the `/apps` directory. Those consumers aggregate samples into their own explicit dicts, so nothing leaks by construction — but that was an accident of implementation, not a stated contract.

`tests/test_analytics_workspace_id.py` now pins it: the field reaches the ClickHouse row, and neither the field name nor a workspace value appears in any of **seven** public responses. **The guard was verified to fail** against a deliberately injected leak in `aggregate_apps` — it is not a decorative test.

The node itself is VPC-internal with no public IP, which is why carrying a tenant id here is acceptable where it would not be in a public export.

## One test changed intentionally
`test_chat_activity_generation_and_no_content_storage` asserted `"workspace_id" not in safe_sample` — the codified form of the decision being reversed here. It now asserts the tenant **is** attributed (a positive assertion, not a deletion), while keeping the guarantees that still hold: no `key_hash`, no prompt body, `app` unchanged. The stale comment claiming "no workspace" as a privacy guarantee was corrected.

## No backfill
Rows predating this change have no recoverable tenant attribution — Spanner has already deleted anything older than 30 days — so they keep `DEFAULT ''`. **Treat `''` as unattributed, not as "no workspace".** Per-customer history accumulates from deploy forward, not retroactively.

## Tests
Full suite green: **3799 passed, 254 skipped, 10 xfailed**. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)