### PR TITLE
Allow bounded remediator maintenance timeout

### DIFF
--- a/src/trusted_router/synthetic/cli.py
+++ b/src/trusted_router/synthetic/cli.py
@@ -49,6 +49,7 @@ _DEFAULT_THROUGHPUT_MINIMUM_OUTPUT_TOKENS = 128
 _DEFAULT_THROUGHPUT_TIMEOUT_SECONDS = 90.0
 _DEFAULT_THROUGHPUT_TIMEOUT_CEILING_SECONDS = 210.0
 _DEFAULT_THROUGHPUT_INTERVAL_SECONDS = THROUGHPUT_INTERVAL_SECONDS
+_DEFAULT_REMEDIATOR_TIMEOUT_SECONDS = 90.0
 
 
 def _env_flag(name: str, *, default: bool = False) -> bool:
@@ -362,12 +363,14 @@ async def _post_remediator(
     *,
     url: str,
     internal_token: str,
+    timeout_seconds: float = _DEFAULT_REMEDIATOR_TIMEOUT_SECONDS,
 ) -> bool:
     """Run the control-plane remediator and make scheduler failures visible."""
     try:
         response = await client.post(
             url,
             headers={"x-trustedrouter-internal-token": internal_token},
+            timeout=httpx.Timeout(timeout_seconds),
         )
         response.raise_for_status()
         payload = response.json()
@@ -377,7 +380,7 @@ async def _post_remediator(
         print(f"remediator decisions: {decisions}")
         return True
     except Exception as exc:
-        print(f"remediator check failed: {exc}", file=sys.stderr)
+        print(f"remediator check failed: {type(exc).__name__}: {exc}", file=sys.stderr)
         return False
 
 
@@ -595,11 +598,21 @@ async def run() -> int:
                 )
         remediator_url = os.environ.get("TR_SYNTHETIC_REMEDIATOR_URL")
         if remediator_url:
+            remediator_timeout_seconds = max(
+                30.0,
+                float(
+                    os.environ.get(
+                        "TR_SYNTHETIC_REMEDIATOR_TIMEOUT_SECONDS",
+                        str(_DEFAULT_REMEDIATOR_TIMEOUT_SECONDS),
+                    )
+                ),
+            )
             ok = (
                 await _post_remediator(
                     client,
                     url=remediator_url,
                     internal_token=internal_token,
+                    timeout_seconds=remediator_timeout_seconds,
                 )
                 and ok
             )

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -2691,6 +2691,7 @@ async def test_remediator_caller_reports_success_and_failure(
 
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.headers["x-trustedrouter-internal-token"] == "internal"
+        assert request.extensions["timeout"]["read"] == 90.0
         if request.url.path.endswith("/failure"):
             return httpx.Response(503, json={"error": "unavailable"})
         return httpx.Response(200, json={"data": {"decisions": 2}})
@@ -2711,7 +2712,7 @@ async def test_remediator_caller_reports_success_and_failure(
     assert succeeded is True
     assert failed is False
     assert "remediator decisions: 2" in output.out
-    assert "remediator check failed:" in output.err
+    assert "remediator check failed: HTTPStatusError:" in output.err
 
 
 @pytest.mark.asyncio
@@ -2747,6 +2748,7 @@ async def test_primary_synthetic_job_invokes_scheduled_remediator(
 
         async def post(self, url: str, **kwargs: Any) -> _Response:
             assert kwargs["headers"]["x-trustedrouter-internal-token"] == "internal"
+            assert kwargs["timeout"].read == 75.0
             seen_urls.append(url)
             return _Response()
 
@@ -2762,6 +2764,7 @@ async def test_primary_synthetic_job_invokes_scheduled_remediator(
         "TR_SYNTHETIC_REMEDIATOR_URL",
         "https://trustedrouter.com/v1/internal/synthetic/remediate",
     )
+    monkeypatch.setenv("TR_SYNTHETIC_REMEDIATOR_TIMEOUT_SECONDS", "75")
     monkeypatch.delenv("TR_SYNTHETIC_THROUGHPUT_ONLY", raising=False)
     monkeypatch.delenv("TR_SYNTHETIC_THROUGHPUT_ENABLED", raising=False)
 


### PR DESCRIPTION
## Summary
- give the scheduled remediator call its own configurable 90-second timeout
- preserve strict normal synthetic probe timeouts
- include the exception type in worker logs so empty-string `ReadTimeout` failures are diagnosable

## Production evidence
The first scheduled call began at 03:32:17 UTC. The worker timed out at 30 seconds, while Cloud Run completed the same request with HTTP 200 after 48.72 seconds.

## Verification
- 150 synthetic/fleet/ClickHouse tests passed
- focused timeout and endpoint tests passed
- ruff and mypy passed
- `git diff --check` passed