### PR TITLE
Attribute purchases per user and gate phone verification on a first funding

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -222,6 +222,16 @@ jobs:
           SPANNER_INSTANCE_ID: trusted-router-nam6
           SPANNER_DATABASE_ID: trusted-router
         run: scripts/deploy/migrate_typed_counters.sh
+      - name: Apply money primitives schema (earnings, movements, lifetime top-ups)
+        # tr_user_lifetime_topup is written INSIDE the credit-grant transaction
+        # by every purchase webhook, so a missing table would abort the grant
+        # and stop payments crediting. This job runs before `deploy`, so the
+        # table exists before any revision that needs it can serve.
+        env:
+          GCP_PROJECT_ID: quill-cloud-proxy
+          SPANNER_INSTANCE_ID: trusted-router-nam6
+          SPANNER_DATABASE_ID: trusted-router
+        run: scripts/deploy/migrate_money_primitives.sh
       - name: Apply bounded request-retention schema
         env:
           TR_GCP_PROJECT_ID: quill-cloud-proxy

--- a/scripts/grant_credit.py
+++ b/scripts/grant_credit.py
@@ -1,6 +1,8 @@
 """Grant prepaid credit through the authoritative typed ledger.
 
 Dry-run is the default. ``--event-id`` is required and makes retries idempotent.
+Support grants must not unlock identity verification unless the operator passes
+``--count-toward-lifetime-topup`` explicitly.
 
 Example:
   uv run python scripts/grant_credit.py \
@@ -27,7 +29,7 @@ from trusted_router.storage import create_store
 from trusted_router.typed_balance import LiveCreditSummary, live_credit_summary
 
 
-def _select_workspace(store: Any, email: str, workspace_id: str | None) -> Any:
+def _select_workspace(store: Any, email: str, workspace_id: str | None) -> tuple[Any, Any]:
     user = store.find_user_by_email(email)
     if user is None:
         raise ValueError(f"no user found for {email}")
@@ -36,12 +38,12 @@ def _select_workspace(store: Any, email: str, workspace_id: str | None) -> Any:
         matches = [workspace for workspace in workspaces if workspace.id == workspace_id]
         if len(matches) != 1:
             raise ValueError("workspace is not accessible to that user")
-        return matches[0]
+        return user, matches[0]
     if len(workspaces) == 1:
-        return workspaces[0]
+        return user, workspaces[0]
     personal = [workspace for workspace in workspaces if workspace.name == "Personal Workspace"]
     if len(personal) == 1:
-        return personal[0]
+        return user, personal[0]
     raise ValueError("user has multiple workspaces; pass --workspace-id explicitly")
 
 
@@ -60,6 +62,7 @@ def main(argv: list[str] | None = None, *, store: Any | None = None) -> int:
     parser.add_argument("--amount", required=True, help="positive USD amount")
     parser.add_argument("--event-id", required=True)
     parser.add_argument("--workspace-id")
+    parser.add_argument("--count-toward-lifetime-topup", action="store_true")
     parser.add_argument("--apply", action="store_true")
     args = parser.parse_args(argv)
 
@@ -71,7 +74,7 @@ def main(argv: list[str] | None = None, *, store: Any | None = None) -> int:
         if amount <= 0:
             raise ValueError("amount must be positive")
         active_store = create_store(Settings()) if store is None else store
-        workspace = _select_workspace(active_store, args.email, args.workspace_id)
+        user, workspace = _select_workspace(active_store, args.email, args.workspace_id)
         before = live_credit_summary(workspace.id, store=active_store)
         if before is None:
             raise ValueError("authoritative credit account not found")
@@ -86,7 +89,12 @@ def main(argv: list[str] | None = None, *, store: Any | None = None) -> int:
         print("DRY-RUN: no credit granted; pass --apply after reviewing the target")
         return 0
 
-    granted = active_store.credit_workspace_typed_direct(workspace.id, amount, args.event_id)
+    granted = active_store.credit_workspace_typed_direct(
+        workspace.id,
+        amount,
+        args.event_id,
+        lifetime_topup_user_id=(user.id if args.count_toward_lifetime_topup else None),
+    )
     after = live_credit_summary(workspace.id, store=active_store)
     if after is None:
         print("ERROR: authoritative credit account disappeared after grant", file=sys.stderr)

--- a/scripts/set_lifetime_topup.py
+++ b/scripts/set_lifetime_topup.py
@@ -1,0 +1,54 @@
+"""Apply an idempotent lifetime-top-up support override without granting credits.
+
+Example:
+  uv run python scripts/set_lifetime_topup.py \
+    --user-id USER_ID --amount-dollars 25 --event-id support_override_2026_08_16
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import Any
+
+os.environ.setdefault("TR_STORAGE_BACKEND", "spanner-bigtable")
+os.environ.setdefault("TR_GCP_PROJECT_ID", "quill-cloud-proxy")
+os.environ.setdefault("TR_SPANNER_INSTANCE_ID", "trusted-router-nam6")
+os.environ.setdefault("TR_SPANNER_DATABASE_ID", "trusted-router")
+os.environ.setdefault("TR_BIGTABLE_INSTANCE_ID", "trusted-router-logs")
+os.environ.setdefault("TR_BIGTABLE_GENERATION_TABLE", "trustedrouter-generations")
+
+from trusted_router.config import Settings
+from trusted_router.money import dollars_to_microdollars, format_money_precise
+from trusted_router.storage import create_store
+
+
+def main(argv: list[str] | None = None, *, store: Any | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--user-id", required=True)
+    parser.add_argument("--amount-dollars", required=True)
+    parser.add_argument("--event-id", required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        amount = dollars_to_microdollars(args.amount_dollars)
+        if amount <= 0:
+            raise ValueError("amount must be positive")
+        active_store = create_store(Settings()) if store is None else store
+        if active_store.get_user(args.user_id) is None:
+            raise ValueError(f"no user found for {args.user_id}")
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    applied = active_store.add_lifetime_topup(args.user_id, amount, args.event_id)
+    print(
+        f"result: {'applied' if applied else 'no-op (event already applied)'}; "
+        f"user={args.user_id} amount={format_money_precise(amount)} event_id={args.event_id}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -519,6 +519,7 @@ class Settings(BaseSettings):
     # never registers anything — and sender reputation becomes a shared asset,
     # which is why notify requires a verified phone and is metered.
     notify_enabled: bool = False
+    phone_verification_requires_funding: bool | None = None
     # Flip to True once A2P 10DLC is approved on the primary SMS carrier;
     # voice needs no registration.
     notify_sms_available: bool = False
@@ -1222,6 +1223,12 @@ class Settings(BaseSettings):
     @property
     def paypal_enabled(self) -> bool:
         return bool(self.paypal_client_id and self.paypal_client_secret)
+
+    @property
+    def phone_verification_funding_enforced(self) -> bool:
+        if self.phone_verification_requires_funding is not None:
+            return self.phone_verification_requires_funding
+        return self.environment.lower() not in {"local", "test"}
 
     @property
     def adyen_checkout_ready(self) -> bool:

--- a/src/trusted_router/errors.py
+++ b/src/trusted_router/errors.py
@@ -24,6 +24,7 @@ def error_body(
     type_: str,
     *,
     source: str | None = None,
+    extra: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     return {
         "error": {
@@ -31,6 +32,7 @@ def error_body(
             "message": message,
             "type": type_,
             "source": source or default_error_source(type_),
+            **(extra or {}),
         }
     }
 
@@ -42,10 +44,11 @@ def api_error(
     *,
     source: str | None = None,
     headers: dict[str, str] | None = None,
+    extra: dict[str, Any] | None = None,
 ) -> HTTPException:
     return HTTPException(
         status_code=code,
-        detail=error_body(code, message, type_, source=source),
+        detail=error_body(code, message, type_, source=source, extra=extra),
         headers=headers,
     )
 

--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -51,6 +51,7 @@ from trusted_router.routes.provider_portal import register_provider_portal_route
 from trusted_router.routes.public import register_public_routes
 from trusted_router.routes.ses_notifications import register_ses_notification_routes
 from trusted_router.routes.signup import register_signup_routes
+from trusted_router.routes.verification_status import register_verification_status_routes
 from trusted_router.routes.wallet_oauth import register_wallet_oauth_routes
 from trusted_router.routes.workspaces import register_workspace_routes
 from trusted_router.sentry_config import init_sentry
@@ -428,6 +429,7 @@ def _make_api_router(settings: Settings) -> APIRouter:
     register_compat_stub_routes(router)
     register_signup_routes(router)
     register_email_verify_routes(router)
+    register_verification_status_routes(router)
     register_notify_routes(router)
     register_wallet_oauth_routes(router)
     register_ses_notification_routes(router)

--- a/src/trusted_router/routes/billing.py
+++ b/src/trusted_router/routes/billing.py
@@ -16,7 +16,7 @@ from trusted_router.billing_policy import (
 from trusted_router.config import Settings
 from trusted_router.domains import request_control_origin
 from trusted_router.errors import api_error, deprecated
-from trusted_router.money import money_pair
+from trusted_router.money import VERIFICATION_MIN_LIFETIME_TOPUP_MICRODOLLARS, money_pair
 from trusted_router.routes.helpers import json_body
 from trusted_router.schemas import CheckoutRequest, X402FundingRequest, X402SettleRequest
 from trusted_router.services.adyen_billing import create_adyen_checkout_session
@@ -78,32 +78,42 @@ def register_billing_routes(router: APIRouter) -> None:
             )
         body = _checkout_body_with_first_party_returns(body, request, settings)
         account = STORE.get_credit_account(workspace_id)
-        return JSONResponse(
-            {
-                "data": (
-                    create_adyen_checkout_session(
-                        body=body,
-                        workspace_id=workspace_id,
-                        customer_email=_checkout_customer_email(principal),
-                        settings=settings,
-                    )
-                    if body.payment_method == "adyen"
-                    else create_paypal_checkout_session(
-                        body=body,
-                        workspace_id=workspace_id,
-                        customer_email=_checkout_customer_email(principal),
-                        settings=settings,
-                    )
-                    if body.payment_method == "paypal"
-                    else create_checkout_session(
-                        body=body,
-                        workspace_id=workspace_id,
-                        customer_email=_checkout_customer_email(principal),
-                        customer_id=account.stripe_customer_id if account else None,
-                        settings=settings,
-                    )
+        initiating_user_id = _principal_user_id(principal)
+        checkout_data = (
+            create_adyen_checkout_session(
+                body=body,
+                workspace_id=workspace_id,
+                customer_email=_checkout_customer_email(principal),
+                settings=settings,
+            )
+            if body.payment_method == "adyen"
+            else create_paypal_checkout_session(
+                body=body,
+                workspace_id=workspace_id,
+                initiating_user_id=initiating_user_id,
+                customer_email=_checkout_customer_email(principal),
+                settings=settings,
+            )
+            if body.payment_method == "paypal"
+            else create_checkout_session(
+                body=body,
+                workspace_id=workspace_id,
+                initiating_user_id=initiating_user_id,
+                customer_email=_checkout_customer_email(principal),
+                customer_id=account.stripe_customer_id if account else None,
+                settings=settings,
+            )
+        )
+        if body.purpose == "identity_verification":
+            lifetime_topup = STORE.get_lifetime_topup_microdollars(initiating_user_id)
+            checkout_data.update(
+                money_pair(
+                    "verification_topup_remaining",
+                    max(0, VERIFICATION_MIN_LIFETIME_TOPUP_MICRODOLLARS - lifetime_topup),
                 )
-            },
+            )
+        return JSONResponse(
+            {"data": checkout_data},
             status_code=201,
         )
 
@@ -159,6 +169,7 @@ def register_billing_routes(router: APIRouter) -> None:
         challenge = create_x402_funding_challenge(
             body=body,
             workspace_id=principal.workspace.id,
+            initiating_user_id=_principal_user_id(principal),
             settings=settings,
         )
         return JSONResponse(
@@ -251,6 +262,14 @@ def _checkout_customer_email(principal: Any) -> str | None:
         if user is not None and user.email and "@" in user.email:
             return user.email
     return None
+
+
+def _principal_user_id(principal: Any) -> str:
+    if principal.user is not None:
+        return str(principal.user.id)
+    if principal.api_key is not None and principal.api_key.creator_user_id:
+        return str(principal.api_key.creator_user_id)
+    return str(principal.workspace.owner_user_id)
 
 
 def _reject_wallet_only_traditional_billing(principal: Any) -> None:

--- a/src/trusted_router/routes/console/credits.py
+++ b/src/trusted_router/routes/console/credits.py
@@ -19,6 +19,7 @@ from trusted_router.billing_policy import (
     is_wallet_only_user,
 )
 from trusted_router.domains import request_control_origin
+from trusted_router.money import VERIFICATION_MIN_LIFETIME_TOPUP_MICRODOLLARS, money_pair
 from trusted_router.routes.console._shared import ConsoleDep, money, render
 from trusted_router.schemas import CheckoutRequest
 from trusted_router.services.adyen_billing import (
@@ -45,7 +46,11 @@ from trusted_router.typed_balance import live_credit_summary
 
 def register(app: FastAPI) -> None:
     @app.get("/console/credits")
-    async def console_credits(ctx: ConsoleDep, settings: SettingsDep) -> Response:
+    async def console_credits(
+        ctx: ConsoleDep,
+        settings: SettingsDep,
+        purpose: str = "",
+    ) -> Response:
         credit = STORE.get_credit_account(ctx.workspace.id)
         summary = live_credit_summary(ctx.workspace.id)
         wallet_only_billing = is_wallet_only_user(ctx.user)
@@ -65,6 +70,19 @@ def register(app: FastAPI) -> None:
         saved_payment_method = describe_saved_payment_method(
             payment_method_id=credit.stripe_payment_method_id if credit else None,
             settings=settings,
+        )
+        verification_remaining = max(
+            0,
+            VERIFICATION_MIN_LIFETIME_TOPUP_MICRODOLLARS
+            - STORE.get_lifetime_topup_microdollars(ctx.user.id),
+        )
+        verification_nudge = (
+            {
+                **money_pair("verification_topup_remaining", verification_remaining),
+                "verification_topup_remaining_display": money(verification_remaining),
+            }
+            if purpose == "identity_verification"
+            else {}
         )
         return HTMLResponse(render(
             "console/credits.html",
@@ -97,6 +115,8 @@ def register(app: FastAPI) -> None:
             payments=payments,
             saved_payment_method=saved_payment_method,
             api_base_url=ctx.api_base_url,
+            identity_verification_checkout=purpose == "identity_verification",
+            **verification_nudge,
         ))
 
     @app.get("/console/credits/checkout")
@@ -110,6 +130,7 @@ def register(app: FastAPI) -> None:
         settings: SettingsDep,
         amount: str = Form(...),
         payment_method: str = Form("auto"),
+        purpose: str = Form(""),
     ) -> Response:
         if is_wallet_only_user(ctx.user) and not is_stablecoin_checkout_method(
             payment_method
@@ -130,6 +151,7 @@ def register(app: FastAPI) -> None:
                 amount=amount,
                 workspace_id=ctx.workspace.id,
                 payment_method=cast(Any, payment_method),
+                purpose=cast(Any, purpose or None),
                 success_url=success_url,
                 cancel_url=f"{origin}/console/credits?checkout=cancel",
             )
@@ -150,6 +172,7 @@ def register(app: FastAPI) -> None:
                 else create_paypal_checkout_session(
                     body=body,
                     workspace_id=ctx.workspace.id,
+                    initiating_user_id=ctx.user.id,
                     customer_email=ctx.user.email if ctx.user.email and "@" in ctx.user.email else None,
                     settings=settings,
                 )
@@ -157,6 +180,7 @@ def register(app: FastAPI) -> None:
                 else create_checkout_session(
                     body=body,
                     workspace_id=ctx.workspace.id,
+                    initiating_user_id=ctx.user.id,
                     customer_email=ctx.user.email if ctx.user.email and "@" in ctx.user.email else None,
                     customer_id=credit.stripe_customer_id if credit else None,
                     settings=settings,
@@ -164,8 +188,20 @@ def register(app: FastAPI) -> None:
             )
         except HTTPException:
             return RedirectResponse(url="/console/credits?error=checkout_unavailable", status_code=303)
+        if body.purpose == "identity_verification":
+            data.update(
+                money_pair(
+                    "verification_topup_remaining",
+                    max(
+                        0,
+                        VERIFICATION_MIN_LIFETIME_TOPUP_MICRODOLLARS
+                        - STORE.get_lifetime_topup_microdollars(ctx.user.id),
+                    ),
+                )
+            )
         if str(data.get("mode", "")).startswith("mock"):
-            return RedirectResponse(url="/console/credits?checkout=mock", status_code=303)
+            suffix = "&purpose=identity_verification" if body.purpose else ""
+            return RedirectResponse(url=f"/console/credits?checkout=mock{suffix}", status_code=303)
         if data.get("mode") == "adyen":
             adyen_js_url, adyen_css_url = adyen_web_asset_urls(settings)
             checkout_config = {

--- a/src/trusted_router/routes/console/settings.py
+++ b/src/trusted_router/routes/console/settings.py
@@ -13,6 +13,7 @@ from trusted_router.auth import SettingsDep
 from trusted_router.routes.console._shared import ConsoleDep, render
 from trusted_router.services.notify import send_verification_code
 from trusted_router.storage import STORE
+from trusted_router.verification_gates import missing_phone_verification_requirements
 
 MAX_WORKSPACE_NAME = 120
 
@@ -44,6 +45,7 @@ def register(app: FastAPI) -> None:
         # verified moments ago on this same page would otherwise still render
         # as unverified and invite the visitor to start over.
         user = STORE.get_user(ctx.user.id) or ctx.user
+        phone_missing_requirements = missing_phone_verification_requirements(user, settings)
         _resend_allowed, resend_wait_seconds = pv.can_resend(user)
         return HTMLResponse(
             render(
@@ -69,6 +71,7 @@ def register(app: FastAPI) -> None:
                 phone_saved=bool(phone_saved),
                 phone_error=error,
                 phone_error_detail=detail,
+                phone_missing_requirements=phone_missing_requirements,
             )
         )
 
@@ -84,6 +87,9 @@ def register(app: FastAPI) -> None:
         # that happened seconds ago on this same page, or a fast retry loop
         # (or cancel-then-start) rings the number again before it applies.
         current = STORE.get_user(ctx.user.id) or ctx.user
+        missing_requirements = missing_phone_verification_requirements(current, settings)
+        if missing_requirements:
+            return _back(f"error={missing_requirements[0]}")
         allowed, wait = pv.can_resend(current)
         if not allowed:
             # Without a floor, this form is a way to ring someone else's phone

--- a/src/trusted_router/routes/internal/webhook.py
+++ b/src/trusted_router/routes/internal/webhook.py
@@ -130,7 +130,10 @@ def register(router: APIRouter) -> None:
                     payment_method=payment_method,
                 )
                 credited = STORE.credit_workspace_typed_direct(
-                    workspace_id, amount_microdollars, credit_event_id
+                    workspace_id,
+                    amount_microdollars,
+                    credit_event_id,
+                    lifetime_topup_user_id=_lifetime_topup_user_id(workspace_id, metadata),
                 )
                 if credited:
                     record_credit_purchase(
@@ -229,7 +232,10 @@ def register(router: APIRouter) -> None:
                     payment_intent_amount_cents=obj.get("amount"),
                 )
                 credited = STORE.credit_workspace_typed_direct(
-                    workspace_id, amount_microdollars, event_id
+                    workspace_id,
+                    amount_microdollars,
+                    event_id,
+                    lifetime_topup_user_id=_lifetime_topup_user_id(workspace_id, metadata),
                 )
                 if credited:
                     record_credit_purchase(
@@ -329,6 +335,14 @@ def register(router: APIRouter) -> None:
                 }
 
         return {"data": {"ignored": True, "event_id": event_id}}
+
+
+def _lifetime_topup_user_id(workspace_id: str, metadata: dict[str, Any]) -> str | None:
+    initiating_user_id = metadata.get("initiating_user_id")
+    if isinstance(initiating_user_id, str) and initiating_user_id:
+        return initiating_user_id
+    workspace = STORE.get_workspace(workspace_id)
+    return workspace.owner_user_id if workspace is not None else None
 
 
 def _checkout_credit_event_id(

--- a/src/trusted_router/routes/notify.py
+++ b/src/trusted_router/routes/notify.py
@@ -40,6 +40,7 @@ from trusted_router.services.telephony import branded, spoken_text
 from trusted_router.storage import STORE
 from trusted_router.storage_models import User
 from trusted_router.types import ErrorType, UsageType
+from trusted_router.verification_gates import missing_phone_verification_requirements
 
 log = logging.getLogger(__name__)
 
@@ -106,6 +107,18 @@ def register_notify_routes(router: APIRouter) -> None:
         user = principal.user
         if user is None:
             raise api_error(403, "sign in to manage your phone number", ErrorType.FORBIDDEN)
+
+        missing_requirements = missing_phone_verification_requirements(user, settings)
+        if missing_requirements:
+            raise api_error(
+                403,
+                "Phone verification requirements are not met",
+                ErrorType.VERIFICATION_REQUIRED,
+                extra={
+                    "missing_requirements": missing_requirements,
+                    "verification_url": "/console/settings",
+                },
+            )
 
         requested = str(payload.get("channel") or "sms").strip().lower()
         if requested not in {"sms", "voice"}:

--- a/src/trusted_router/routes/oauth_keys.py
+++ b/src/trusted_router/routes/oauth_keys.py
@@ -97,6 +97,7 @@ def register_oauth_key_routes(router: APIRouter) -> None:
         data = create_checkout_session(
             body=body,
             workspace_id=principal.workspace.id,
+            initiating_user_id=_principal_user_id(principal),
             customer_email=(
                 principal.user.email
                 if principal.user and principal.user.email and "@" in principal.user.email
@@ -415,6 +416,7 @@ def _identity_payload(user: Any) -> dict[str, Any] | None:
         "sub": user.id,
         "email": user.email,
         "email_verified": user.email_verified,
+        "phone_verified": user.phone_verified,
         "wallet_address": user.wallet_address,
     }
 

--- a/src/trusted_router/routes/verification_status.py
+++ b/src/trusted_router/routes/verification_status.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter
+
+from trusted_router.auth import ManagementPrincipal, SettingsDep
+from trusted_router.errors import api_error
+from trusted_router.money import money_pair
+from trusted_router.storage import STORE
+from trusted_router.storage_models import User
+from trusted_router.types import ErrorType
+from trusted_router.verification_gates import missing_phone_verification_requirements
+
+IDENTITY_STATUS = "none"
+
+
+def register_verification_status_routes(router: APIRouter) -> None:
+    @router.get("/auth/verification-status")
+    async def verification_status(
+        principal: ManagementPrincipal,
+        settings: SettingsDep,
+    ) -> dict[str, dict[str, Any]]:
+        user = _principal_user(principal)
+        if user is None:
+            raise api_error(404, "User not found", ErrorType.NOT_FOUND)
+        lifetime_topup = STORE.get_lifetime_topup_microdollars(user.id)
+        return {
+            "data": {
+                "email": user.email,
+                "email_verified": bool(user.email_verified),
+                **money_pair("lifetime_topup", lifetime_topup),
+                "phone_verified": bool(user.phone_verified),
+                "phone": user.phone,
+                "identity_status": IDENTITY_STATUS,
+                "missing_requirements": missing_phone_verification_requirements(user, settings),
+                "next_step": _next_step(user, lifetime_topup),
+            }
+        }
+
+
+def _principal_user(principal: Any) -> User | None:
+    if principal.user is not None:
+        return principal.user
+    if principal.api_key is not None and principal.api_key.creator_user_id:
+        user = STORE.get_user(principal.api_key.creator_user_id)
+        if user is not None:
+            return user
+    return STORE.get_user(principal.workspace.owner_user_id)
+
+
+def _next_step(user: User, lifetime_topup: int) -> str | None:
+    if not user.email or not user.email_verified:
+        return "email"
+    if lifetime_topup <= 0:
+        return "funding"
+    if not user.phone_verified:
+        return "phone"
+    if IDENTITY_STATUS == "none":
+        return "identity"
+    return None

--- a/src/trusted_router/routes/verification_status.py
+++ b/src/trusted_router/routes/verification_status.py
@@ -22,8 +22,6 @@ def register_verification_status_routes(router: APIRouter) -> None:
         settings: SettingsDep,
     ) -> dict[str, dict[str, Any]]:
         user = _principal_user(principal)
-        if user is None:
-            raise api_error(404, "User not found", ErrorType.NOT_FOUND)
         lifetime_topup = STORE.get_lifetime_topup_microdollars(user.id)
         return {
             "data": {
@@ -39,14 +37,25 @@ def register_verification_status_routes(router: APIRouter) -> None:
         }
 
 
-def _principal_user(principal: Any) -> User | None:
+def _principal_user(principal: Any) -> User:
+    """The person this status is ABOUT — and only ever the caller.
+
+    A key minted under another key has no creator, and it must not resolve to
+    the workspace owner: that would hand any non-owner admin the owner's phone
+    number and email. Same rule as custom_models._owner_user_id — a status
+    endpoint that cannot identify a person answers 403, not someone else's PII.
+    """
     if principal.user is not None:
         return principal.user
     if principal.api_key is not None and principal.api_key.creator_user_id:
         user = STORE.get_user(principal.api_key.creator_user_id)
         if user is not None:
             return user
-    return STORE.get_user(principal.workspace.owner_user_id)
+    raise api_error(
+        403,
+        "A user-owned management session or key is required",
+        ErrorType.FORBIDDEN,
+    )
 
 
 def _next_step(user: User, lifetime_topup: int) -> str | None:

--- a/src/trusted_router/schemas.py
+++ b/src/trusted_router/schemas.py
@@ -42,6 +42,7 @@ class SignupRequest(_Strict):
 class CheckoutRequest(_Lenient):
     amount: Decimal | str | int | float = Decimal("20")
     workspace_id: str | None = None
+    purpose: Literal["identity_verification"] | None = None
     success_url: str | None = None
     cancel_url: str | None = None
     payment_method: Literal[

--- a/src/trusted_router/services/adyen_billing.py
+++ b/src/trusted_router/services/adyen_billing.py
@@ -331,10 +331,17 @@ def apply_adyen_notification(
     if prepared.reference is None or prepared.merchant_reference is None:
         return result
 
+    # The signed merchant reference carries no initiating user (its shape is
+    # fixed by the HMAC scheme), so a real Adyen purchase accrues lifetime
+    # top-up to the workspace owner — the same fallback every other payment
+    # path uses when the initiator is unknown. Without this an Adyen payer
+    # would stay funding-gated for phone verification.
+    workspace = STORE.get_workspace(prepared.reference.workspace_id)
     credited = STORE.credit_workspace_typed_direct(
         prepared.reference.workspace_id,
         result.amount_microdollars,
         f"adyen_checkout:{prepared.merchant_reference}",
+        lifetime_topup_user_id=(workspace.owner_user_id if workspace is not None else None),
     )
     if credited:
         record_credit_purchase(

--- a/src/trusted_router/services/auto_refill.py
+++ b/src/trusted_router/services/auto_refill.py
@@ -110,6 +110,11 @@ def maybe_charge_after_settle(
     metadata = fee.metadata(
         workspace_id=workspace_id,
         payment_method="card",
+        initiating_user_id=(
+            workspace.owner_user_id
+            if (workspace := STORE.get_workspace(workspace_id)) is not None
+            else None
+        ),
     )
     metadata.update(
         {

--- a/src/trusted_router/services/paypal_billing.py
+++ b/src/trusted_router/services/paypal_billing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import threading
 import time
 import uuid
@@ -52,12 +53,14 @@ class _PayPalCreditReference:
     workspace_id: str
     credit_amount_cents: int | None = None
     charge_amount_cents: int | None = None
+    initiating_user_id: str | None = None
 
 
 def create_paypal_checkout_session(
     *,
     body: CheckoutRequest,
     workspace_id: str,
+    initiating_user_id: str,
     customer_email: str | None,
     settings: Settings,
 ) -> dict[str, Any]:
@@ -103,7 +106,11 @@ def create_paypal_checkout_session(
             "purchase_units": [
                 {
                     "reference_id": workspace_id,
-                    "custom_id": _paypal_checkout_reference(workspace_id, fee),
+                    "custom_id": _paypal_checkout_reference(
+                        workspace_id,
+                        fee,
+                        initiating_user_id=initiating_user_id,
+                    ),
                     "description": "TrustedRouter prepaid credits",
                     "amount": {
                         "currency_code": "USD",
@@ -190,6 +197,7 @@ def credit_paypal_capture(
         raise api_error(403, "PayPal order belongs to a different workspace", ErrorType.FORBIDDEN)
     if STORE.get_credit_account(workspace_id) is None:
         raise api_error(404, "Credit account not found", ErrorType.NOT_FOUND)
+    workspace = STORE.get_workspace(workspace_id)
     amount_microdollars = parsed["amount_microdollars"]
     processing_fee_microdollars = parsed["processing_fee_microdollars"]
     charge_amount_microdollars = parsed["charge_amount_microdollars"]
@@ -198,6 +206,10 @@ def credit_paypal_capture(
         workspace_id,
         amount_microdollars,
         f"paypal_capture:{capture_id}",
+        lifetime_topup_user_id=(
+            parsed["initiating_user_id"]
+            or (workspace.owner_user_id if workspace is not None else None)
+        ),
     )
     if credited:
         record_credit_purchase(
@@ -322,14 +334,21 @@ def _paypal_amount_value(cents: int) -> str:
     return f"{sign}{cents // 100}.{cents % 100:02d}"
 
 
-def _paypal_checkout_reference(workspace_id: str, fee: ProcessingFee) -> str:
-    return "|".join(
-        (
-            _CHECKOUT_REFERENCE_VERSION,
-            workspace_id,
-            str(fee.credit_amount_cents),
-            str(fee.charge_amount_cents),
-        )
+def _paypal_checkout_reference(
+    workspace_id: str,
+    fee: ProcessingFee,
+    *,
+    initiating_user_id: str,
+) -> str:
+    return json.dumps(
+        {
+            "w": workspace_id,
+            "u": initiating_user_id,
+            "c": fee.credit_amount_cents,
+            "t": fee.charge_amount_cents,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
     )
 
 
@@ -425,6 +444,7 @@ def _paypal_capture_payload(
         "order_id": order_id,
         "capture_id": capture_id,
         "workspace_id": reference.workspace_id,
+        "initiating_user_id": reference.initiating_user_id,
         "amount_microdollars": amount_microdollars,
         "processing_fee_microdollars": processing_fee_microdollars,
         "charge_amount_microdollars": charge_amount_microdollars,
@@ -442,10 +462,40 @@ def _paypal_credit_reference(
         raw_reference = fallback.get("custom_id") or fallback.get("reference_id")
     if not isinstance(raw_reference, str) or not raw_reference:
         raise api_error(400, "PayPal capture has no workspace reference", ErrorType.BAD_REQUEST)
+    if raw_reference.startswith("{"):
+        try:
+            payload = json.loads(raw_reference)
+        except json.JSONDecodeError as exc:
+            raise api_error(400, "PayPal capture reference is invalid", ErrorType.BAD_REQUEST) from exc
+        if not isinstance(payload, dict):
+            raise api_error(400, "PayPal capture reference is invalid", ErrorType.BAD_REQUEST)
+        workspace_id = payload.get("w")
+        initiating_user_id = payload.get("u")
+        credit_amount_cents = payload.get("c")
+        charge_amount_cents = payload.get("t")
+        if (
+            not isinstance(workspace_id, str)
+            or not workspace_id
+            or not isinstance(initiating_user_id, str)
+            or not initiating_user_id
+            or not isinstance(credit_amount_cents, int)
+            or isinstance(credit_amount_cents, bool)
+            or not isinstance(charge_amount_cents, int)
+            or isinstance(charge_amount_cents, bool)
+            or credit_amount_cents <= 0
+            or charge_amount_cents < credit_amount_cents
+        ):
+            raise api_error(400, "PayPal capture reference is invalid", ErrorType.BAD_REQUEST)
+        return _PayPalCreditReference(
+            workspace_id=workspace_id,
+            credit_amount_cents=credit_amount_cents,
+            charge_amount_cents=charge_amount_cents,
+            initiating_user_id=initiating_user_id,
+        )
     if not raw_reference.startswith(f"{_CHECKOUT_REFERENCE_VERSION}|"):
         return _PayPalCreditReference(workspace_id=raw_reference)
     parts = raw_reference.split("|")
-    if len(parts) != 4 or not parts[1]:
+    if len(parts) not in {4, 5} or not parts[1]:
         raise api_error(400, "PayPal capture reference is invalid", ErrorType.BAD_REQUEST)
     try:
         credit_amount_cents = int(parts[2])
@@ -458,6 +508,7 @@ def _paypal_credit_reference(
         workspace_id=parts[1],
         credit_amount_cents=credit_amount_cents,
         charge_amount_cents=charge_amount_cents,
+        initiating_user_id=parts[4] if len(parts) == 5 and parts[4] else None,
     )
 
 

--- a/src/trusted_router/services/stripe_billing.py
+++ b/src/trusted_router/services/stripe_billing.py
@@ -22,6 +22,7 @@ def create_checkout_session(
     *,
     body: CheckoutRequest,
     workspace_id: str,
+    initiating_user_id: str | None,
     customer_email: str | None,
     customer_id: str | None,
     settings: Settings,
@@ -66,6 +67,7 @@ def create_checkout_session(
     payment_metadata = fee.metadata(
         workspace_id=workspace_id,
         payment_method=payment_method,
+        initiating_user_id=initiating_user_id,
     )
     if settings.stripe_secret_key:
         stripe.api_key = settings.stripe_secret_key

--- a/src/trusted_router/services/stripe_fees.py
+++ b/src/trusted_router/services/stripe_fees.py
@@ -92,6 +92,7 @@ class ProcessingFee:
         *,
         workspace_id: str,
         payment_method: str,
+        initiating_user_id: str | None = None,
     ) -> dict[str, str]:
         metadata = {
             "workspace_id": workspace_id,
@@ -105,6 +106,8 @@ class ProcessingFee:
         }
         if self.max_fee_cents is not None:
             metadata["fee_max_cents"] = str(self.max_fee_cents)
+        if initiating_user_id is not None:
+            metadata["initiating_user_id"] = initiating_user_id
         return metadata
 
 

--- a/src/trusted_router/services/x402_billing.py
+++ b/src/trusted_router/services/x402_billing.py
@@ -32,6 +32,7 @@ def create_x402_funding_challenge(
     *,
     body: X402FundingRequest,
     workspace_id: str,
+    initiating_user_id: str,
     settings: Settings,
 ) -> dict[str, Any]:
     _require_x402_enabled(settings)
@@ -40,6 +41,7 @@ def create_x402_funding_challenge(
         amount=body.amount,
         amount_microdollars=amount_microdollars,
         workspace_id=workspace_id,
+        initiating_user_id=initiating_user_id,
         settings=settings,
     )
     payment_intent_id = str(payment_intent.get("id") or "")
@@ -168,6 +170,7 @@ def credit_x402_payment_intent(
         workspace_id,
         amount_microdollars,
         x402_event_id(payment_intent_id),
+        lifetime_topup_user_id=_lifetime_topup_user_id(workspace_id, metadata),
     )
     if credited:
         record_credit_purchase(
@@ -217,6 +220,7 @@ def _create_payment_intent(
     amount: Decimal | str | int,
     amount_microdollars: int,
     workspace_id: str,
+    initiating_user_id: str,
     settings: Settings,
 ) -> dict[str, Any]:
     amount_cents = dollars_to_cents(amount)
@@ -229,6 +233,7 @@ def _create_payment_intent(
             "amount": amount_cents,
             "metadata": {
                 "workspace_id": workspace_id,
+                "initiating_user_id": initiating_user_id,
                 "amount_microdollars": str(amount_microdollars),
                 "payment_method": X402_PAYMENT_METHOD,
                 "purpose": "trustedrouter_credits",
@@ -263,6 +268,7 @@ def _create_payment_intent(
         "confirm": True,
         "metadata": {
             "workspace_id": workspace_id,
+            "initiating_user_id": initiating_user_id,
             "amount_microdollars": str(amount_microdollars),
             "payment_method": X402_PAYMENT_METHOD,
             "purpose": "trustedrouter_credits",
@@ -435,6 +441,14 @@ def _stripe_object_to_dict(value: Any) -> dict[str, Any]:
 
 def _dict_value(value: Any) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
+
+
+def _lifetime_topup_user_id(workspace_id: str, metadata: dict[str, Any]) -> str | None:
+    initiating_user_id = metadata.get("initiating_user_id")
+    if isinstance(initiating_user_id, str) and initiating_user_id:
+        return initiating_user_id
+    workspace = STORE.get_workspace(workspace_id)
+    return workspace.owner_user_id if workspace is not None else None
 
 
 def _mock_payments_enabled(settings: Settings) -> bool:

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -1206,6 +1206,20 @@ class InMemoryStore:
         with self._lock:
             return self.lifetime_topups.get(user_id, 0)
 
+    def add_lifetime_topup(
+        self,
+        user_id: str,
+        amount_microdollars: int,
+        event_id: str,
+    ) -> bool:
+        amount = self._positive_money_amount(amount_microdollars)
+        with self._lock:
+            if event_id in self.stripe_events:
+                return False
+            self.stripe_events.add(event_id)
+            self.lifetime_topups[user_id] = self.lifetime_topups.get(user_id, 0) + amount
+            return True
+
     def update_auto_refill_settings(
         self,
         workspace_id: str,

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -1863,6 +1863,36 @@ class SpannerBigtableStore:
             )
         return 0 if not rows else int(rows[0][0])
 
+    def add_lifetime_topup(
+        self,
+        user_id: str,
+        amount_microdollars: int,
+        event_id: str,
+    ) -> bool:
+        amount = self._positive_money_amount(amount_microdollars)
+
+        def txn(transaction: Any) -> bool:
+            if self._read_entity_tx(transaction, "stripe_event", event_id, dict) is not None:
+                return False
+            now = dt.datetime.now(dt.UTC).replace(microsecond=0)
+            self._increment_lifetime_topup_tx(transaction, user_id, amount, now=now)
+            insert_entity_dml_at(
+                transaction,
+                self._param_types,
+                "stripe_event",
+                event_id,
+                _json_body(
+                    {
+                        "created_at": now.isoformat().replace("+00:00", "Z"),
+                        "lifetime_topup_user_id": user_id,
+                    }
+                ),
+                now,
+            )
+            return True
+
+        return self._run_in_transaction(txn)
+
     def update_auto_refill_settings(
         self,
         workspace_id: str,

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -2736,6 +2736,37 @@ class PostgresStore:
 
         return self._run_transaction(read)
 
+    def add_lifetime_topup(
+        self,
+        user_id: str,
+        amount_microdollars: int,
+        event_id: str,
+    ) -> bool:
+        amount = self._positive_money_amount(amount_microdollars)
+
+        def add(conn: Any) -> bool:
+            won = self._insert_entity_once_tx(
+                conn,
+                "stripe_event",
+                event_id,
+                {"created_at": iso_now(), "lifetime_topup_user_id": user_id},
+            )
+            if not won:
+                return False
+            conn.execute(
+                "INSERT INTO tr_user_lifetime_topup "
+                "(user_id, total_microdollars, updated_at) "
+                "VALUES (%s, %s, CURRENT_TIMESTAMP) "
+                "ON CONFLICT (user_id) DO UPDATE SET "
+                "total_microdollars = "
+                "tr_user_lifetime_topup.total_microdollars + EXCLUDED.total_microdollars, "
+                "updated_at = CURRENT_TIMESTAMP",
+                (user_id, amount),
+            )
+            return True
+
+        return self._run_transaction(add)
+
     def typed_credit_snapshot(self, workspace_id: str) -> tuple[int, int, int] | None:
         def read(conn: Any) -> tuple[int, int, int] | None:
             account = self._read_entity_tx(conn, "credit", workspace_id, CreditAccount)

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -529,6 +529,12 @@ class Store(Protocol):
         *,
         since: str,
     ) -> dict[str, int]: ...
+    def add_lifetime_topup(
+        self,
+        user_id: str,
+        amount_microdollars: int,
+        event_id: str,
+    ) -> bool: ...
     def get_lifetime_topup_microdollars(self, user_id: str) -> int: ...
 
     def reserve(

--- a/src/trusted_router/templates/console/credits.html
+++ b/src/trusted_router/templates/console/credits.html
@@ -16,7 +16,13 @@
       <a href="/console/account/preferences">Preferences</a> to use cards or other payment methods.
     </div>
     {% endif %}
+    {% if identity_verification_checkout %}
+    <div class="notice" style="margin-top:18px">
+      Identity verification requires {{ verification_topup_remaining_display }} more in lifetime top-ups. Any successful top-up also unlocks phone verification.
+    </div>
+    {% endif %}
     <form class="form" method="post" action="/console/credits/checkout" style="margin-top:18px">
+      {% if identity_verification_checkout %}<input type="hidden" name="purpose" value="identity_verification">{% endif %}
       <div class="row">
         <label>Amount (USD)<input name="amount" type="number" min="1" max="10000" step="1" value="25" required></label>
         <label>Payment method

--- a/src/trusted_router/templates/console/settings.html
+++ b/src/trusted_router/templates/console/settings.html
@@ -29,6 +29,8 @@
     {% elif phone_error == 'too_many_attempts' %}<p class="notice bad">Too many attempts — that code is now dead. Send a new one.</p>
     {% elif phone_error == 'no_pending' %}<p class="notice bad">No code is waiting. Send one first.</p>
     {% elif phone_error == 'rate' %}<p class="notice bad">A code was just sent. Wait a moment before asking for another.</p>{% endif %}
+    {% if phone_error == 'funding' %}<p class="notice bad">Add credits first — phone verification is available after your first top-up. <a href="/console/credits?purpose=identity_verification">Add credits</a></p>
+    {% elif phone_error == 'email' %}<p class="notice bad">Add an email address before verifying a phone. <a href="/console/account/preferences">Add email</a></p>{% endif %}
     {% if phone_sent == 'voice' %}<p class="notice ok">We're calling {{ phone_pending }} now — pick up to hear your code. It expires in 10 minutes.</p>
     {% elif phone_sent == 'sms' %}<p class="notice ok">Code texted to {{ phone_pending }}. It expires in 10 minutes.</p>{% endif %}
     {% if phone_saved %}<p class="notice ok">Number verified.</p>{% endif %}
@@ -73,6 +75,9 @@
       <form class="form" method="post" action="/console/settings/phone/cancel">
         <button class="btn" type="submit">Use a different number</button>
       </form>
+    {% elif phone_missing_requirements %}
+      {% if phone_missing_requirements[0] == 'email' and phone_error != 'email' %}<p class="notice bad">Add an email address before verifying a phone. <a href="/console/account/preferences">Add email</a></p>
+      {% elif phone_missing_requirements[0] == 'funding' and phone_error != 'funding' %}<p class="notice bad">Add credits first — phone verification is available after your first top-up. <a href="/console/credits?purpose=identity_verification">Add credits</a></p>{% endif %}
     {% else %}
       <p>Add a mobile number so your agents can reach you when something breaks. Verifying it is what unlocks every notification channel, email included.</p>
       <form class="form" method="post" action="/console/settings/phone/start">

--- a/src/trusted_router/types.py
+++ b/src/trusted_router/types.py
@@ -42,6 +42,7 @@ class ErrorType(StrEnum):
     BAD_REQUEST = "bad_request"
     UNAUTHORIZED = "unauthorized"
     FORBIDDEN = "forbidden"
+    VERIFICATION_REQUIRED = "verification_required"
     NOT_FOUND = "not_found"
     CONFLICT = "conflict"
     ALREADY_REGISTERED = "already_registered"

--- a/src/trusted_router/verification_gates.py
+++ b/src/trusted_router/verification_gates.py
@@ -1,0 +1,19 @@
+"""Account-level prerequisites for phone and identity verification."""
+
+from __future__ import annotations
+
+from trusted_router.config import Settings
+from trusted_router.storage import STORE
+from trusted_router.storage_models import User
+
+
+def missing_phone_verification_requirements(user: User, settings: Settings) -> list[str]:
+    missing: list[str] = []
+    if not user.email:
+        missing.append("email")
+    if (
+        settings.phone_verification_funding_enforced
+        and STORE.get_lifetime_topup_microdollars(user.id) <= 0
+    ):
+        missing.append("funding")
+    return missing

--- a/tests/conformance/test_store_semantics.py
+++ b/tests/conformance/test_store_semantics.py
@@ -316,6 +316,21 @@ def test_lifetime_topup_is_part_of_the_grant_claim(
     assert store.get_lifetime_topup_microdollars(user_id) == 35
 
 
+def test_lifetime_topup_support_override_is_idempotent_without_crediting(
+    store: Store,
+    workspace_id: str,
+    user_id: str,
+    unique: str,
+) -> None:
+    before = live_credit_summary(workspace_id, store=store)
+    event_id = f"evt-lifetime-override-{unique}"
+
+    assert store.add_lifetime_topup(user_id, 25, event_id)
+    assert not store.add_lifetime_topup(user_id, 25, event_id)
+    assert store.get_lifetime_topup_microdollars(user_id) == 25
+    assert live_credit_summary(workspace_id, store=store) == before
+
+
 def _credit_and_key(
     store: Store,
     workspace_id: str,

--- a/tests/test_adyen_billing.py
+++ b/tests/test_adyen_billing.py
@@ -329,6 +329,28 @@ def test_adyen_authorisation_credits_exactly_once() -> None:
     assert after - before == 5_000_000
 
 
+def test_adyen_authorisation_accrues_lifetime_topup_to_the_owner_exactly_once() -> None:
+    # Every real purchase must accrue lifetime top-up, or an Adyen payer stays
+    # funding-gated for phone verification. The signed reference carries no
+    # initiator, so it lands on the workspace owner; the replayed notification
+    # must not accrue twice.
+    app = create_app(_settings(adyen_enabled=False), init_observability=False)
+    with TestClient(app) as client:
+        workspace_id = _workspace_id(client)
+        owner_id = STORE.get_workspace(workspace_id).owner_user_id
+        assert STORE.get_lifetime_topup_microdollars(owner_id) == 0
+        item = _notification_item(workspace_id)
+        client.post("/v1/internal/adyen/webhook", json=_webhook_payload(item))
+        replay = _notification_item(
+            workspace_id,
+            psp_reference="PSP000000000002",
+            merchant_reference=str(item["merchantReference"]),
+        )
+        client.post("/v1/internal/adyen/webhook", json=_webhook_payload(replay))
+
+    assert STORE.get_lifetime_topup_microdollars(owner_id) == 5_000_000
+
+
 def test_adyen_webhook_remains_available_when_checkout_is_dark_but_needs_hmac() -> None:
     missing_hmac = _settings(
         adyen_enabled=False,

--- a/tests/test_auto_refill.py
+++ b/tests/test_auto_refill.py
@@ -155,6 +155,9 @@ def test_auto_refill_fires_below_threshold(
     assert kwargs["off_session"] is True
     assert kwargs["confirm"] is True
     assert kwargs["metadata"]["workspace_id"] == configured_workspace
+    workspace = STORE.get_workspace(configured_workspace)
+    assert workspace is not None
+    assert kwargs["metadata"]["initiating_user_id"] == workspace.owner_user_id
     assert kwargs["metadata"]["auto_refill"] == "true"
     assert kwargs["metadata"]["amount_microdollars"] == "20000000"
     assert kwargs["metadata"]["processing_fee_cents"] == "91"

--- a/tests/test_billing_typed_direct_topups.py
+++ b/tests/test_billing_typed_direct_topups.py
@@ -6,7 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from tests.fakes.spanner import make_fake_store
-from trusted_router.storage import CreditAccount, InMemoryStore
+from trusted_router.storage import STORE, CreditAccount, InMemoryStore
 from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
 
 
@@ -115,12 +115,19 @@ def test_stripe_checkout_webhook_routes_topup_through_typed_direct(
     monkeypatch,
 ) -> None:
     workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
-    calls: list[tuple[str, int, str]] = []
+    workspace = STORE.get_workspace(workspace_id)
+    assert workspace is not None
+    calls: list[tuple[str, int, str, str | None]] = []
 
     def typed_direct(
-        _store: InMemoryStore, workspace_id_arg: str, amount: int, event_id: str
+        _store: InMemoryStore,
+        workspace_id_arg: str,
+        amount: int,
+        event_id: str,
+        *,
+        lifetime_topup_user_id: str | None = None,
     ) -> bool:
-        calls.append((workspace_id_arg, amount, event_id))
+        calls.append((workspace_id_arg, amount, event_id, lifetime_topup_user_id))
         return True
 
     def old_path(_store: InMemoryStore, *_args, **_kwargs) -> bool:
@@ -148,7 +155,9 @@ def test_stripe_checkout_webhook_routes_topup_through_typed_direct(
     )
 
     assert resp.status_code == 200, resp.text
-    assert calls == [(workspace_id, 1_230_000, "evt_checkout_typed_direct")]
+    assert calls == [
+        (workspace_id, 1_230_000, "evt_checkout_typed_direct", workspace.owner_user_id)
+    ]
 
 
 def test_stripe_auto_refill_webhook_routes_topup_through_typed_direct(
@@ -157,12 +166,19 @@ def test_stripe_auto_refill_webhook_routes_topup_through_typed_direct(
     monkeypatch,
 ) -> None:
     workspace_id = client.get("/v1/workspaces", headers=user_headers).json()["data"][0]["id"]
-    calls: list[tuple[str, int, str]] = []
+    workspace = STORE.get_workspace(workspace_id)
+    assert workspace is not None
+    calls: list[tuple[str, int, str, str | None]] = []
 
     def typed_direct(
-        _store: InMemoryStore, workspace_id_arg: str, amount: int, event_id: str
+        _store: InMemoryStore,
+        workspace_id_arg: str,
+        amount: int,
+        event_id: str,
+        *,
+        lifetime_topup_user_id: str | None = None,
     ) -> bool:
-        calls.append((workspace_id_arg, amount, event_id))
+        calls.append((workspace_id_arg, amount, event_id, lifetime_topup_user_id))
         return True
 
     def old_path(_store: InMemoryStore, *_args, **_kwargs) -> bool:
@@ -191,4 +207,6 @@ def test_stripe_auto_refill_webhook_routes_topup_through_typed_direct(
     )
 
     assert resp.status_code == 200, resp.text
-    assert calls == [(workspace_id, 2_000_000, "evt_auto_refill_typed_direct")]
+    assert calls == [
+        (workspace_id, 2_000_000, "evt_auto_refill_typed_direct", workspace.owner_user_id)
+    ]

--- a/tests/test_lifetime_topup.py
+++ b/tests/test_lifetime_topup.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.services.paypal_billing import credit_paypal_capture
+from trusted_router.services.x402_billing import credit_x402_payment_intent
+from trusted_router.storage import STORE
+
+
+def _user_and_workspace(client: TestClient, headers: dict[str, str]) -> tuple[Any, Any]:
+    response = client.get("/v1/workspaces", headers=headers)
+    assert response.status_code == 200, response.text
+    workspace = STORE.get_workspace(response.json()["data"][0]["id"])
+    user = STORE.find_user_by_email(headers["x-trustedrouter-user"])
+    assert user is not None and workspace is not None
+    return user, workspace
+
+
+def _stripe_client() -> TestClient:
+    return TestClient(
+        create_app(
+            Settings(
+                environment="test",
+                stripe_secret_key="sk_test_lifetime",  # noqa: S106
+                stripe_webhook_secret=None,
+            ),
+            init_observability=False,
+        )
+    )
+
+
+def test_stripe_checkout_stamps_initiator_and_replay_accrues_once(
+    monkeypatch,
+    user_headers: dict[str, str],
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def create_session(**kwargs: Any) -> dict[str, str]:
+        captured.update(kwargs)
+        return {"id": "cs_lifetime", "url": "https://stripe.test/checkout"}
+
+    monkeypatch.setattr(
+        "trusted_router.services.stripe_billing.stripe.checkout.Session.create",
+        create_session,
+    )
+    with _stripe_client() as client:
+        checkout = client.post(
+            "/v1/billing/checkout",
+            headers=user_headers,
+            json={"amount": 25, "payment_method": "card"},
+        )
+        user, workspace = _user_and_workspace(client, user_headers)
+        metadata = captured["metadata"]
+        assert metadata["initiating_user_id"] == user.id
+        event = {
+            "id": "evt_lifetime_card",
+            "type": "checkout.session.completed",
+            "data": {
+                "object": {
+                    "mode": "payment",
+                    "payment_status": "paid",
+                    "amount_total": int(metadata["charge_amount_cents"]),
+                    "metadata": metadata,
+                }
+            },
+        }
+        first = client.post("/v1/internal/stripe/webhook", json=event)
+        replay = client.post("/v1/internal/stripe/webhook", json=event)
+
+    assert checkout.status_code == 201, checkout.text
+    assert first.json()["data"]["credited"] is True
+    assert replay.json()["data"]["credited"] is False
+    assert STORE.get_lifetime_topup_microdollars(user.id) == 25_000_000
+    assert STORE.get_workspace(workspace.id) is not None
+
+
+def test_legacy_stripe_ach_event_falls_back_to_workspace_owner(
+    client: TestClient,
+    user_headers: dict[str, str],
+) -> None:
+    owner, workspace = _user_and_workspace(client, user_headers)
+    event = {
+        "id": "evt_lifetime_ach",
+        "type": "checkout.session.async_payment_succeeded",
+        "data": {
+            "object": {
+                "id": "cs_legacy_ach",
+                "payment_intent": "pi_legacy_ach",
+                "amount_total": 300,
+                "metadata": {
+                    "workspace_id": workspace.id,
+                    "payment_method": "ach",
+                },
+            }
+        },
+    }
+
+    first = client.post("/v1/internal/stripe/webhook", json=event)
+    replay = client.post("/v1/internal/stripe/webhook", json=event)
+
+    assert first.status_code == 200, first.text
+    assert replay.json()["data"]["credited"] is False
+    assert STORE.get_lifetime_topup_microdollars(owner.id) == 3_000_000
+
+
+def test_auto_refill_webhook_accrues_to_workspace_owner_without_initiator(
+    client: TestClient,
+    user_headers: dict[str, str],
+) -> None:
+    owner, workspace = _user_and_workspace(client, user_headers)
+    event = {
+        "id": "evt_lifetime_auto_refill",
+        "type": "payment_intent.succeeded",
+        "data": {
+            "object": {
+                "id": "pi_lifetime_auto_refill",
+                "amount": 200,
+                "metadata": {
+                    "workspace_id": workspace.id,
+                    "auto_refill": "true",
+                    "amount_microdollars": "2000000",
+                },
+            }
+        },
+    }
+
+    response = client.post("/v1/internal/stripe/webhook", json=event)
+
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["credited"] is True
+    assert STORE.get_lifetime_topup_microdollars(owner.id) == 2_000_000
+
+
+def _paypal_order(
+    workspace_id: str,
+    custom_id: str,
+    *,
+    capture_id: str,
+    amount: str,
+) -> dict[str, Any]:
+    return {
+        "id": f"ORDER-{capture_id}",
+        "purchase_units": [
+            {
+                "custom_id": custom_id,
+                "payments": {
+                    "captures": [
+                        {
+                            "id": capture_id,
+                            "status": "COMPLETED",
+                            "amount": {"currency_code": "USD", "value": amount},
+                        }
+                    ]
+                },
+            }
+        ],
+    }
+
+
+def test_paypal_accrues_to_initiating_user_and_legacy_order_falls_back_to_owner(
+    client: TestClient,
+    user_headers: dict[str, str],
+) -> None:
+    owner, workspace = _user_and_workspace(client, user_headers)
+    initiator = STORE.ensure_user("paypal-initiator@example.com")
+    current = _paypal_order(
+        workspace.id,
+        json.dumps({"w": workspace.id, "u": initiator.id, "c": 2500, "t": 2500}),
+        capture_id="CAPTURE-INITIATOR",
+        amount="25.00",
+    )
+    legacy = _paypal_order(
+        workspace.id,
+        workspace.id,
+        capture_id="CAPTURE-LEGACY-OWNER",
+        amount="3.00",
+    )
+
+    first = credit_paypal_capture(current, expected_workspace_id=workspace.id)
+    replay = credit_paypal_capture(current, expected_workspace_id=workspace.id)
+    credit_paypal_capture(legacy, expected_workspace_id=workspace.id)
+
+    assert first.credited is True
+    assert replay.credited is False
+    assert STORE.get_lifetime_topup_microdollars(initiator.id) == 25_000_000
+    assert STORE.get_lifetime_topup_microdollars(owner.id) == 3_000_000
+
+
+def _x402_intent(
+    workspace_id: str,
+    payment_intent_id: str,
+    *,
+    initiating_user_id: str | None,
+) -> dict[str, Any]:
+    metadata = {
+        "workspace_id": workspace_id,
+        "amount_microdollars": "1000000",
+        "payment_method": "x402",
+        "purpose": "trustedrouter_credits",
+        "asset": "USDC",
+        "network": "base",
+    }
+    if initiating_user_id is not None:
+        metadata["initiating_user_id"] = initiating_user_id
+    return {
+        "id": payment_intent_id,
+        "status": "succeeded",
+        "currency": "usd",
+        "amount": 100,
+        "amount_received": 100,
+        "metadata": metadata,
+    }
+
+
+def test_x402_accrues_to_initiator_and_legacy_intent_falls_back_to_owner(
+    client: TestClient,
+    user_headers: dict[str, str],
+) -> None:
+    owner, workspace = _user_and_workspace(client, user_headers)
+    initiator = STORE.ensure_user("x402-initiator@example.com")
+    settings = Settings(environment="test", x402_enabled=True)
+    current = _x402_intent(
+        workspace.id,
+        "pi_x402_lifetime_initiator",
+        initiating_user_id=initiator.id,
+    )
+    legacy = _x402_intent(
+        workspace.id,
+        "pi_x402_lifetime_owner",
+        initiating_user_id=None,
+    )
+
+    first = credit_x402_payment_intent(
+        current,
+        expected_workspace_id=workspace.id,
+        settings=settings,
+    )
+    replay = credit_x402_payment_intent(
+        current,
+        expected_workspace_id=workspace.id,
+        settings=settings,
+    )
+    credit_x402_payment_intent(
+        legacy,
+        expected_workspace_id=workspace.id,
+        settings=settings,
+    )
+
+    assert first["credited"] is True
+    assert replay["credited"] is False
+    assert STORE.get_lifetime_topup_microdollars(initiator.id) == 1_000_000
+    assert STORE.get_lifetime_topup_microdollars(owner.id) == 1_000_000
+
+
+def test_signup_credit_never_counts_as_a_lifetime_topup(client: TestClient) -> None:
+    response = client.post(
+        "/v1/signup",
+        json={"email": "lifetime-signup@example.com"},
+    )
+
+    assert response.status_code == 201, response.text
+    user = STORE.find_user_by_email("lifetime-signup@example.com")
+    assert user is not None
+    assert response.json()["data"]["trial_credit_microdollars"] > 0
+    assert STORE.get_lifetime_topup_microdollars(user.id) == 0
+
+
+def test_identity_checkout_nudge_is_present_only_for_that_purpose(
+    client: TestClient,
+    user_headers: dict[str, str],
+) -> None:
+    user, workspace = _user_and_workspace(client, user_headers)
+    ordinary = client.post(
+        "/v1/billing/checkout",
+        headers=user_headers,
+        json={"amount": 1},
+    )
+    identity = client.post(
+        "/v1/billing/checkout",
+        headers=user_headers,
+        json={"amount": 1, "purpose": "identity_verification"},
+    )
+    STORE.credit_workspace_typed_direct(
+        workspace.id,
+        5_000_000,
+        "evt_nudge_existing_topup",
+        lifetime_topup_user_id=user.id,
+    )
+    progressed = client.post(
+        "/v1/billing/checkout",
+        headers=user_headers,
+        json={"amount": 1, "purpose": "identity_verification"},
+    )
+    too_small = client.post(
+        "/v1/billing/checkout",
+        headers=user_headers,
+        json={"amount": "0.99", "purpose": "identity_verification"},
+    )
+
+    assert ordinary.status_code == 201
+    assert "verification_topup_remaining" not in ordinary.json()["data"]
+    assert identity.json()["data"]["verification_topup_remaining"] == 25
+    assert identity.json()["data"]["verification_topup_remaining_microdollars"] == 25_000_000
+    assert progressed.json()["data"]["verification_topup_remaining"] == 20
+    assert too_small.status_code == 400

--- a/tests/test_oauth_key_delegation.py
+++ b/tests/test_oauth_key_delegation.py
@@ -87,6 +87,7 @@ def test_oauth_code_exchange_returns_signed_in_identity(
     assert identity["sub"] == alice.id
     assert identity["email"] == "alice@example.com"
     assert "email_verified" in identity
+    assert identity["phone_verified"] is False
 
 
 def test_userinfo_returns_identity_for_delegated_key(

--- a/tests/test_operator_credit_scripts.py
+++ b/tests/test_operator_credit_scripts.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 
-from scripts import grant_credit
+from scripts import grant_credit, set_lifetime_topup
 from tests.fakes.spanner import make_fake_store
 from trusted_router.typed_balance import live_credit_summary
 
@@ -59,6 +59,71 @@ def test_grant_credit_applies_once_and_reports_authoritative_balance(
     assert summary is not None
     assert summary["total_credits"] == 10_000_001
     assert summary["available"] == 10_000_001
+
+
+def test_grant_credit_does_not_count_as_a_lifetime_topup_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TR_STORAGE_BACKEND", "spanner-bigtable")
+    store, _db, _ = make_fake_store()
+    user, _workspace = _user_and_workspace(store, "operator@example.com")
+    base = [
+        "--email",
+        "operator@example.com",
+        "--amount",
+        "10",
+        "--event-id",
+        "evt_support_grant",
+        "--apply",
+    ]
+
+    assert grant_credit.main(base, store=store) == 0
+    assert store.get_lifetime_topup_microdollars(user.id) == 0
+
+
+def test_grant_credit_can_explicitly_count_as_a_lifetime_topup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TR_STORAGE_BACKEND", "spanner-bigtable")
+    store, _db, _ = make_fake_store()
+    user, _workspace = _user_and_workspace(store, "operator@example.com")
+
+    assert (
+        grant_credit.main(
+            [
+                "--email",
+                "operator@example.com",
+                "--amount",
+                "10",
+                "--event-id",
+                "evt_counted_support_grant",
+                "--count-toward-lifetime-topup",
+                "--apply",
+            ],
+            store=store,
+        )
+        == 0
+    )
+    assert store.get_lifetime_topup_microdollars(user.id) == 10_000_000
+
+
+def test_set_lifetime_topup_is_idempotent_and_does_not_grant_credit() -> None:
+    store, _db, _ = make_fake_store()
+    user, workspace = _user_and_workspace(store, "operator@example.com")
+    before = live_credit_summary(workspace.id, store=store)
+    argv = [
+        "--user-id",
+        user.id,
+        "--amount-dollars",
+        "25",
+        "--event-id",
+        "evt_lifetime_override",
+    ]
+
+    assert set_lifetime_topup.main(argv, store=store) == 0
+    assert set_lifetime_topup.main(argv, store=store) == 0
+    assert store.get_lifetime_topup_microdollars(user.id) == 25_000_000
+    assert live_credit_summary(workspace.id, store=store) == before
 
 
 def test_grant_credit_requires_workspace_when_selection_is_ambiguous() -> None:

--- a/tests/test_paypal_processing_fees.py
+++ b/tests/test_paypal_processing_fees.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -98,8 +99,17 @@ def test_paypal_checkout_uses_the_existing_stripe_card_fee_schedule(
         ("TrustedRouter credits", "25.00"),
         ("Payment processing fee", "1.06"),
     ]
-    assert unit["custom_id"].startswith("tr1|")
-    assert unit["custom_id"].endswith("|2500|2606")
+    reference = json.loads(unit["custom_id"])
+    assert reference["c"] == 2500
+    assert reference["t"] == 2606
+    initiating_user = STORE.find_user_by_email("alice@example.com")
+    assert initiating_user is not None
+    assert reference == {
+        "w": unit["reference_id"],
+        "u": initiating_user.id,
+        "c": 2500,
+        "t": 2606,
+    }
     data = response.json()["data"]
     assert data["amount_microdollars"] == 25_000_000
     assert data["processing_fee_microdollars"] == 1_060_000

--- a/tests/test_phone_funding_gate.py
+++ b/tests/test_phone_funding_gate.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.services import notify as notify_module
+from trusted_router.services.telephony import TelephonyResult
+from trusted_router.storage import STORE
+
+
+class _Telephony:
+    enabled = True
+
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, str, str]] = []
+
+    def send(
+        self,
+        channel: str,
+        to: str,
+        body: str,
+        preferred_carrier: str | None = None,
+    ) -> TelephonyResult:
+        self.sent.append((channel, to, body))
+        return TelephonyResult(True, "telnyx", "queued")
+
+
+def _settings() -> Settings:
+    return Settings(
+        environment="test",
+        phone_verification_requires_funding=True,
+    )
+
+
+def _fund_user(user: Any, *, event_id: str = "evt_phone_gate_funding") -> None:
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+    STORE.credit_workspace_typed_direct(
+        workspace.id,
+        1,
+        event_id,
+        lifetime_topup_user_id=user.id,
+    )
+
+
+def _console_client() -> tuple[TestClient, Any]:
+    client = TestClient(create_app(_settings(), init_observability=False))
+    client.follow_redirects = False
+    user = STORE.ensure_user("phone-gate-console@example.com")
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+    raw_session, _session = STORE.create_auth_session(
+        user_id=user.id,
+        provider="test",
+        label="phone gate",
+        ttl_seconds=3600,
+        workspace_id=workspace.id,
+        state="active",
+    )
+    client.cookies.set("tr_session", raw_session)
+    return client, user
+
+
+def test_phone_funding_default_is_off_in_test_and_local() -> None:
+    assert Settings(environment="test").phone_verification_funding_enforced is False
+    assert Settings(environment="local").phone_verification_funding_enforced is False
+    assert Settings(environment="staging").phone_verification_funding_enforced is True
+    assert (
+        Settings(
+            environment="test",
+            phone_verification_requires_funding=True,
+        ).phone_verification_funding_enforced
+        is True
+    )
+
+
+def test_api_start_requires_funding_then_allows_any_successful_topup(
+    monkeypatch: pytest.MonkeyPatch,
+    user_headers: dict[str, str],
+) -> None:
+    carrier = _Telephony()
+    monkeypatch.setattr(notify_module, "get_telephony_service", lambda _settings: carrier)
+    with TestClient(create_app(_settings(), init_observability=False)) as client:
+        blocked = client.post(
+            "/v1/notify/phone/start",
+            headers=user_headers,
+            json={"phone": "+13059511381", "channel": "voice"},
+        )
+        user = STORE.find_user_by_email("alice@example.com")
+        assert user is not None
+        _fund_user(user)
+        allowed = client.post(
+            "/v1/notify/phone/start",
+            headers=user_headers,
+            json={"phone": "+13059511381", "channel": "voice"},
+        )
+
+    assert blocked.status_code == 403
+    assert blocked.json()["error"]["type"] == "verification_required"
+    assert blocked.json()["error"]["missing_requirements"] == ["funding"]
+    assert blocked.json()["error"]["verification_url"] == "/console/settings"
+    assert carrier.sent and allowed.status_code == 200
+
+
+def test_api_gate_reports_email_before_funding() -> None:
+    settings = _settings()
+    with TestClient(create_app(settings, init_observability=False)) as client:
+        user = STORE.create_wallet_user("0x" + "4" * 40)
+        workspace = STORE.list_workspaces_for_user(user.id)[0]
+        raw_session, _session = STORE.create_auth_session(
+            user_id=user.id,
+            provider="wallet",
+            label=user.wallet_address or "",
+            ttl_seconds=3600,
+            workspace_id=workspace.id,
+            state="active",
+        )
+        response = client.post(
+            "/v1/notify/phone/start",
+            headers={"authorization": f"Bearer {raw_session}"},
+            json={"phone": "+13059511381"},
+        )
+
+    assert response.status_code == 403
+    assert response.json()["error"]["missing_requirements"] == ["email", "funding"]
+
+
+def test_console_hides_phone_form_and_redirects_to_funding_flash() -> None:
+    client, _user = _console_client()
+
+    page = client.get("/console/settings")
+    blocked = client.post(
+        "/console/settings/phone/start",
+        data={"phone": "+13059511381", "channel": "voice"},
+    )
+    flash = client.get(blocked.headers["location"])
+
+    assert page.status_code == 200
+    assert 'name="phone"' not in page.text
+    assert "phone verification is available after your first top-up" in page.text
+    assert "/console/credits?purpose=identity_verification" in page.text
+    assert blocked.status_code == 303
+    assert blocked.headers["location"].endswith("error=funding")
+    assert "Add credits first" in flash.text
+
+
+def test_console_identity_checkout_shows_and_preserves_the_nudge() -> None:
+    client, _user = _console_client()
+
+    page = client.get("/console/credits?purpose=identity_verification")
+    checkout = client.post(
+        "/console/credits/checkout",
+        data={
+            "amount": "1",
+            "payment_method": "card",
+            "purpose": "identity_verification",
+        },
+    )
+
+    assert page.status_code == 200
+    assert "requires $25.00 more in lifetime top-ups" in page.text
+    assert 'name="purpose" value="identity_verification"' in page.text
+    assert "purpose=identity_verification" in checkout.headers["location"]
+
+
+def test_console_start_works_after_any_funding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, user = _console_client()
+    carrier = _Telephony()
+    monkeypatch.setattr(notify_module, "get_telephony_service", lambda _settings: carrier)
+    _fund_user(user)
+
+    response = client.post(
+        "/console/settings/phone/start",
+        data={"phone": "+13059511381", "channel": "voice"},
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"].endswith("sent=voice")
+    assert len(carrier.sent) == 1
+
+
+def test_confirm_cancel_and_remove_remain_ungated() -> None:
+    client, user = _console_client()
+    started = STORE.begin_phone_verification(user.id, "+13059511381", "voice")
+    assert started is not None
+    code, _updated = started
+
+    confirmed = client.post("/console/settings/phone/confirm", data={"code": code})
+    removed = client.post("/console/settings/phone/remove")
+    pending = STORE.begin_phone_verification(user.id, "+442071838750", "voice")
+    assert pending is not None
+    cancelled = client.post("/console/settings/phone/cancel")
+
+    assert confirmed.headers["location"].endswith("phone_saved=1")
+    assert removed.status_code == 303
+    assert cancelled.status_code == 303
+    refreshed = STORE.get_user(user.id)
+    assert refreshed is not None
+    assert refreshed.phone is None
+    assert refreshed.pending_phone is None
+    assert STORE.get_lifetime_topup_microdollars(user.id) == 0
+
+
+def test_verification_status_reports_shape_and_next_step_progression(
+    user_headers: dict[str, str],
+) -> None:
+    with TestClient(create_app(_settings(), init_observability=False)) as client:
+        initial_response = client.get(
+            "/v1/auth/verification-status",
+            headers=user_headers,
+        )
+        user = STORE.find_user_by_email("alice@example.com")
+        assert user is not None
+        initial = initial_response.json()["data"]
+
+        STORE.mark_user_email_verified(user.id)
+        email_done = client.get(
+            "/v1/auth/verification-status",
+            headers=user_headers,
+        ).json()["data"]
+
+        _fund_user(user, event_id="evt_verification_status_funding")
+        funded = client.get(
+            "/v1/auth/verification-status",
+            headers=user_headers,
+        ).json()["data"]
+
+        started = STORE.begin_phone_verification(user.id, "+13059511381", "voice")
+        assert started is not None
+        code, _updated = started
+        status, _updated = STORE.confirm_phone_verification(user.id, code)
+        assert status == "ok"
+        phone_done = client.get(
+            "/v1/auth/verification-status",
+            headers=user_headers,
+        ).json()["data"]
+
+    assert initial_response.status_code == 200
+    assert initial == {
+        "email": "alice@example.com",
+        "email_verified": False,
+        "lifetime_topup": 0.0,
+        "lifetime_topup_microdollars": 0,
+        "phone_verified": False,
+        "phone": None,
+        "identity_status": "none",
+        "missing_requirements": ["funding"],
+        "next_step": "email",
+    }
+    assert email_done["next_step"] == "funding"
+    assert funded["lifetime_topup_microdollars"] == 1
+    assert funded["missing_requirements"] == []
+    assert funded["next_step"] == "phone"
+    assert phone_done["phone_verified"] is True
+    assert phone_done["phone"] == "+13059511381"
+    assert phone_done["next_step"] == "identity"

--- a/tests/test_phone_funding_gate.py
+++ b/tests/test_phone_funding_gate.py
@@ -258,3 +258,35 @@ def test_verification_status_reports_shape_and_next_step_progression(
     assert phone_done["phone_verified"] is True
     assert phone_done["phone"] == "+13059511381"
     assert phone_done["next_step"] == "identity"
+
+
+def test_verification_status_never_falls_back_to_the_workspace_owner(
+    user_headers: dict[str, str],
+) -> None:
+    # A management key minted under another key has no creator. If the status
+    # endpoint answered for the workspace OWNER in that case, any non-owner
+    # admin could read the owner's phone number and email through it.
+    with TestClient(create_app(_settings(), init_observability=False)) as client:
+        client.get("/v1/auth/verification-status", headers=user_headers)
+        owner = STORE.find_user_by_email("alice@example.com")
+        assert owner is not None
+        workspace = STORE.list_workspaces_for_user(owner.id)[0]
+        started = STORE.begin_phone_verification(owner.id, "+13059511381", "voice")
+        assert started is not None
+        code, _ = started
+        assert STORE.confirm_phone_verification(owner.id, code)[0] == "ok"
+
+        raw_key, _record = STORE.create_api_key(
+            workspace_id=workspace.id,
+            name="ownerless-management-key",
+            creator_user_id=None,
+            management=True,
+        )
+        response = client.get(
+            "/v1/auth/verification-status",
+            headers={"Authorization": f"Bearer {raw_key}"},
+        )
+
+    assert response.status_code == 403
+    assert "+13059511381" not in response.text
+    assert "alice@example.com" not in response.text

--- a/tests/test_x402_billing.py
+++ b/tests/test_x402_billing.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 
 from trusted_router.config import Settings
 from trusted_router.main import create_app
+from trusted_router.storage import STORE
 from trusted_router.typed_balance import live_credit_summary
 
 
@@ -173,8 +174,11 @@ def test_x402_fund_creates_stripe_crypto_payment_intent_and_returns_payment_requ
     assert captured["payment_method_data"] == {"type": "crypto"}
     assert captured["payment_method_options"]["crypto"]["mode"] == "deposit"
     assert captured["payment_method_options"]["crypto"]["deposit_options"]["networks"] == ["base"]
+    key = STORE.get_key_by_raw(headers["authorization"].split()[1])
+    assert key is not None
     assert captured["metadata"] == {
         "workspace_id": workspace_id,
+        "initiating_user_id": key.creator_user_id,
         "amount_microdollars": "10000000",
         "payment_method": "x402",
         "purpose": "trustedrouter_credits",


### PR DESCRIPTION
Phase 2 of the user-provided Custom Models plan (follows #596).

## Lifetime top-up attribution
Every real purchase now accrues to the **initiating user** — Stripe checkout + ACH (metadata), PayPal (`custom_id` as JSON; the legacy pipe-delimited reference is still parsed so in-flight orders capture correctly), x402 (intent metadata) — by passing `lifetime_topup_user_id` into the existing grant, so accrual rides the event claim and is exactly-once per payment (verified: a webhook replay accrues once; the property fails under mutation). Auto-refill and legacy events fall back to the workspace owner. The signup grant never accrues. `grant_credit.py` does not accrue unless `--count-toward-lifetime-topup` — support grants must not unlock identity verification. `scripts/set_lifetime_topup.py` is the idempotent support override.

Checkout accepts `purpose=identity_verification` and answers with `verification_topup_remaining` as a hint; the $1 minimum is untouched.

## Funding gates phone verification
Both start entry points (`POST /notify/phone/start`, console form) now require lifetime top-ups > 0 — every call or text we place is backed by a completed payment (kills SMS/voice pumping). Enforced by default outside local/test (`phone_verification_requires_funding` tri-state; test corpus unaffected). API → `403 verification_required` with `missing_requirements` + `verification_url`; console → form disabled with the reason and a link to add credits. Confirm/cancel/remove stay ungated. New `GET /auth/verification-status`; OAuth identity payload gains `phone_verified`.

## Verification
`ruff check`, `mypy`, full `pytest -n 4`: 3,873 passed / 284 skipped / 10 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)