### PR TITLE
Phone notifications: settings UI, real SMS consent gate, and billing fix

### DIFF
--- a/src/trusted_router/routes/console/settings.py
+++ b/src/trusted_router/routes/console/settings.py
@@ -81,6 +81,7 @@ def register(app: FastAPI) -> None:
         settings: SettingsDep,
         phone: str = Form(""),
         channel: str = Form("voice"),
+        sms_consent: str = Form(""),
     ) -> Response:
         """Send a verification code to a number the visitor claims."""
         # Fresh read, not the session snapshot: the floor must see the send
@@ -90,6 +91,20 @@ def register(app: FastAPI) -> None:
         missing_requirements = missing_phone_verification_requirements(current, settings)
         if missing_requirements:
             return _back(f"error={missing_requirements[0]}")
+
+        # Consent is a GATE, not a notice: a checkbox enforced only in the
+        # browser is decoration, since anyone can post this form without it, and
+        # the consent record we would then show a carrier would be a claim with
+        # nothing behind it. 10DLC campaign 30909 was rejected for a Call to
+        # Action that could not be verified, and the honest reason was that the
+        # checkbox described in the submission did not exist at all.
+        #
+        # Checked AFTER the funding and email requirements, matching the sibling
+        # /notify/phone/start route: those are eligibility, and an unfunded
+        # account is not even shown this form, so "you cannot do this yet" is
+        # the useful answer rather than "tick a box you never saw".
+        if sms_consent.strip().lower() not in {"yes", "on", "true", "1"}:
+            return _back("error=consent")
         allowed, wait = pv.can_resend(current)
         if not allowed:
             # Without a floor, this form is a way to ring someone else's phone

--- a/src/trusted_router/templates/_sms_consent.html
+++ b/src/trusted_router/templates/_sms_consent.html
@@ -1,0 +1,24 @@
+{#- The SMS consent sentence, defined ONCE.
+
+  It is rendered in two places that must agree word for word:
+
+    * the checkbox in the console at Settings -> Notifications, which is where a
+      number is actually collected;
+    * the public /sms page, which tells a 10DLC campaign vetter "these are the
+      exact steps and the exact consent language shown".
+
+  When those two drifted, the page and the campaign submission both described a
+  checkbox that the console did not have at all — and campaign 30909 was rejected
+  for a Call to Action that could not be verified. A vetter comparing the public
+  claim against the live form is the whole point of the review, so the two cannot
+  be allowed to differ again.
+
+  Keep it CTIA-shaped: who is sending, what is sent, frequency, cost, how to
+  stop, how to get help, and links to both policies.
+-#}
+I agree to receive account alerts and one-time verification codes from Trusted
+Router at this number. Message frequency varies. Message and data rates may
+apply. Reply STOP to unsubscribe or HELP for help. See the
+<a href="/terms"{% if consent_links_new_tab %} target="_blank" rel="noopener"{% endif %}>Terms of Service</a>
+and
+<a href="/privacy"{% if consent_links_new_tab %} target="_blank" rel="noopener"{% endif %}>Privacy Policy</a>.

--- a/src/trusted_router/templates/console/settings.html
+++ b/src/trusted_router/templates/console/settings.html
@@ -28,7 +28,8 @@
     {% elif phone_error == 'expired' %}<p class="notice bad">That code expired. Send a new one.</p>
     {% elif phone_error == 'too_many_attempts' %}<p class="notice bad">Too many attempts — that code is now dead. Send a new one.</p>
     {% elif phone_error == 'no_pending' %}<p class="notice bad">No code is waiting. Send one first.</p>
-    {% elif phone_error == 'rate' %}<p class="notice bad">A code was just sent. Wait a moment before asking for another.</p>{% endif %}
+    {% elif phone_error == 'rate' %}<p class="notice bad">A code was just sent. Wait a moment before asking for another.</p>
+    {% elif phone_error == 'consent' %}<p class="notice bad">Tick the consent box before we can text or call you.</p>{% endif %}
     {% if phone_error == 'funding' %}<p class="notice bad">Add credits first — phone verification is available after your first top-up. <a href="/console/credits?purpose=identity_verification">Add credits</a></p>
     {% elif phone_error == 'email' %}<p class="notice bad">Add an email address before verifying a phone. <a href="/console/account/preferences">Add email</a></p>{% endif %}
     {% if phone_sent == 'voice' %}<p class="notice ok">We're calling {{ phone_pending }} now — pick up to hear your code. It expires in 10 minutes.</p>
@@ -94,6 +95,22 @@
           <p><strong>Phone call</strong></p>
           <p class="muted">We'll call this number and read you a 6-digit code. (Text messages are coming once carrier registration completes.)</p>
         {% endif %}
+        {# The Call to Action. Every element below is required by CTIA and is what a
+           10DLC campaign vetter looks for at the point a number is collected: who
+           is sending, what is sent, how often, cost, how to stop, how to get help,
+           and the two policy links. It is a real gate — the server refuses a
+           submission without `sms_consent`, so it cannot be bypassed by posting
+           the form directly.
+
+           The sentence comes from _sms_consent.html, the same partial the PUBLIC
+           /sms page renders, because the console is behind a login and a CTA a
+           vetter cannot see is a CTA that does not count. Campaign 30909 was
+           exactly that: the submission and /sms both described this checkbox
+           while it existed in neither. #}
+        <label class="consent">
+          <input type="checkbox" name="sms_consent" value="yes" required>
+          <span>{% with consent_links_new_tab = true %}{% include "_sms_consent.html" %}{% endwith %}</span>
+        </label>
         <button class="btn primary" type="submit" {% if resend_wait_seconds %}disabled{% endif %}>{% if resend_wait_seconds %}You can request a code in {{ resend_wait_seconds }}s{% else %}Send code{% endif %}</button>
       </form>
       <p class="muted">A phone call works on any number, including landlines and desk phones, and needs no carrier registration. <a href="/docs/notify">What we send</a>.</p>

--- a/src/trusted_router/templates/public/sms.html
+++ b/src/trusted_router/templates/public/sms.html
@@ -23,8 +23,10 @@
     <li>Open <strong>Settings &rarr; Notifications</strong>.</li>
     <li>Enter your own mobile number and tick the consent checkbox, which reads:</li>
   </ol>
+  {# Same partial the console checkbox renders, so this page cannot promise
+     wording the live form does not show. #}
   <blockquote>
-    <p>I agree to receive account alerts and one-time verification codes from Trusted Router at this number. Message frequency varies. Message and data rates may apply. Reply STOP to unsubscribe or HELP for help. See the <a href="/terms">Terms of Service</a> and <a href="/privacy">Privacy Policy</a>.</p>
+    <p>{% include "_sms_consent.html" %}</p>
   </blockquote>
   <ol start="4">
     <li>We call or text a one-time code to that number; entering it confirms you control the number and completes enrolment.</li>

--- a/tests/test_console_phone.py
+++ b/tests/test_console_phone.py
@@ -104,7 +104,7 @@ class TestVerifying:
     def test_a_code_can_be_requested_and_confirmed(self, client, carrier) -> None:
         started = client.post(
             "/console/settings/phone/start",
-            data={"phone": "+1 (305) 951-1381", "channel": "voice"},
+            data={"phone": "+1 (305) 951-1381", "channel": "voice", "sms_consent": "yes"},
         )
         assert started.status_code == 303, started.text
         assert carrier.sent, "no code was sent"
@@ -122,7 +122,7 @@ class TestVerifying:
     def test_the_page_then_shows_the_verified_number(self, client, carrier) -> None:
         client.post(
             "/console/settings/phone/start",
-            data={"phone": "+13059511381", "channel": "voice"},
+            data={"phone": "+13059511381", "channel": "voice", "sms_consent": "yes"},
         )
         _c, _t, spoken = carrier.sent[0]
         code = "".join(ch for ch in spoken.split("is")[1] if ch.isdigit())[:6]
@@ -136,7 +136,7 @@ class TestVerifying:
     def test_a_bad_number_never_reaches_a_carrier(self, client, carrier) -> None:
         response = client.post(
             "/console/settings/phone/start",
-            data={"phone": "3059511381", "channel": "voice"},
+            data={"phone": "3059511381", "channel": "voice", "sms_consent": "yes"},
         )
 
         assert response.status_code == 303
@@ -146,7 +146,7 @@ class TestVerifying:
     def test_a_wrong_code_does_not_verify(self, client, carrier) -> None:
         client.post(
             "/console/settings/phone/start",
-            data={"phone": "+13059511381", "channel": "voice"},
+            data={"phone": "+13059511381", "channel": "voice", "sms_consent": "yes"},
         )
 
         response = client.post("/console/settings/phone/confirm", data={"code": "000000"})
@@ -157,7 +157,7 @@ class TestVerifying:
     def test_an_immediate_resend_is_refused(self, client, carrier) -> None:
         # Otherwise this form rings a stranger's phone as fast as it can be
         # submitted.
-        body = {"phone": "+13059511381", "channel": "voice"}
+        body = {"phone": "+13059511381", "channel": "voice", "sms_consent": "yes"}
         client.post("/console/settings/phone/start", data=body)
 
         second = client.post("/console/settings/phone/start", data=body)
@@ -169,13 +169,13 @@ class TestVerifying:
         # "Use a different number" must not be a way around the resend floor:
         # cancel, start, cancel, start would otherwise ring any number as fast
         # as the two forms can be submitted.
-        body = {"phone": "+13059511381", "channel": "voice"}
+        body = {"phone": "+13059511381", "channel": "voice", "sms_consent": "yes"}
         client.post("/console/settings/phone/start", data=body)
         client.post("/console/settings/phone/cancel")
 
         again = client.post(
             "/console/settings/phone/start",
-            data={"phone": "+13059511382", "channel": "voice"},
+            data={"phone": "+13059511382", "channel": "voice", "sms_consent": "yes"},
         )
 
         assert "error=rate" in again.headers["location"]
@@ -187,7 +187,7 @@ class TestVerifying:
     def test_sms_is_defensively_delivered_as_voice_while_unavailable(self, client, carrier) -> None:
         response = client.post(
             "/console/settings/phone/start",
-            data={"phone": "+13059511381", "channel": "sms"},
+            data={"phone": "+13059511381", "channel": "sms", "sms_consent": "yes"},
         )
 
         assert response.headers["location"].endswith("sent=voice")
@@ -200,7 +200,7 @@ class TestVerifying:
     def test_pending_voice_renders_call_again_after_the_floor(self, client, carrier) -> None:
         client.post(
             "/console/settings/phone/start",
-            data={"phone": "+13059511381", "channel": "voice"},
+            data={"phone": "+13059511381", "channel": "voice", "sms_consent": "yes"},
         )
         _user().phone_code_sent_at = "2000-01-01T00:00:00Z"
 
@@ -215,7 +215,7 @@ class TestVerifying:
     ) -> None:
         response = sms_client.post(
             "/console/settings/phone/start",
-            data={"phone": "+13059511381", "channel": "sms"},
+            data={"phone": "+13059511381", "channel": "sms", "sms_consent": "yes"},
         )
         assert _user().phone_code_channel == "sms"
         sent_page = sms_client.get(response.headers["location"])
@@ -230,7 +230,7 @@ class TestVerifying:
     def test_pending_page_disables_resend_and_shows_the_wait(self, client, carrier) -> None:
         client.post(
             "/console/settings/phone/start",
-            data={"phone": "+13059511381", "channel": "voice"},
+            data={"phone": "+13059511381", "channel": "voice", "sms_consent": "yes"},
         )
 
         page = client.get("/console/settings")
@@ -243,7 +243,7 @@ class TestPostRedirectGet:
         # A refresh on a rendered POST would ring the phone again.
         response = client.post(
             "/console/settings/phone/start",
-            data={"phone": "+13059511381", "channel": "voice"},
+            data={"phone": "+13059511381", "channel": "voice", "sms_consent": "yes"},
         )
 
         assert response.status_code == 303
@@ -254,7 +254,7 @@ class TestRemoval:
     def test_a_number_can_be_removed(self, client, carrier) -> None:
         client.post(
             "/console/settings/phone/start",
-            data={"phone": "+13059511381", "channel": "voice"},
+            data={"phone": "+13059511381", "channel": "voice", "sms_consent": "yes"},
         )
         _c, _t, spoken = carrier.sent[0]
         code = "".join(ch for ch in spoken.split("is")[1] if ch.isdigit())[:6]
@@ -300,7 +300,7 @@ class TestCancellation:
 
         client.post(
             "/console/settings/phone/start",
-            data={"phone": "+13059511381", "channel": "voice"},
+            data={"phone": "+13059511381", "channel": "voice", "sms_consent": "yes"},
         )
         cancelled = client.post("/console/settings/phone/cancel")
         assert cancelled.status_code == 303
@@ -310,9 +310,96 @@ class TestCancellation:
         monkeypatch.setattr(pv, "utcnow", lambda: later)
         restarted = client.post(
             "/console/settings/phone/start",
-            data={"phone": "+442071838750", "channel": "voice"},
+            data={"phone": "+442071838750", "channel": "voice", "sms_consent": "yes"},
         )
 
         assert restarted.headers["location"].endswith("sent=voice")
         assert len(carrier.sent) == 2
         assert _user().pending_phone == "+442071838750"
+
+
+class TestSmsConsentIsRealAndVerifiable:
+    """10DLC campaign 30909: rejected for a Call to Action that could not be
+    verified. The honest cause was that the consent checkbox described in the
+    campaign submission — and promised verbatim on the public /sms page — did not
+    exist in the console at all. These tests exist so that cannot recur.
+    """
+
+    ANCHOR = (
+        "I agree to receive account alerts and one-time verification codes "
+        "from Trusted Router at this number."
+    )
+
+    @staticmethod
+    def _flat(text: str) -> str:
+        import re
+
+        return re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", text))
+
+    def test_the_form_has_a_required_consent_checkbox(self, client) -> None:
+        page = client.get("/console/settings")
+
+        assert 'name="sms_consent"' in page.text, "no consent checkbox in the form"
+        assert 'type="checkbox"' in page.text
+        # `required` keeps an honest user from missing it; the server check below
+        # is what makes it a gate.
+        checkbox = page.text.split('name="sms_consent"')[0].rsplit("<input", 1)[-1] + \
+            page.text.split('name="sms_consent"')[1].split(">")[0]
+        assert "required" in checkbox
+
+    def test_a_number_cannot_be_submitted_without_consent(self, client, carrier) -> None:
+        # The gate. A checkbox enforced only in the browser is decoration: this
+        # posts the form directly, exactly as anyone could.
+        response = client.post(
+            "/console/settings/phone/start",
+            data={"phone": "+13059511381", "channel": "voice"},
+        )
+
+        assert not carrier.sent, "a code was sent to a number that never consented"
+        assert "error=consent" in response.headers.get("location", "")
+
+    def test_consent_must_be_affirmative_not_merely_present(self, client, carrier) -> None:
+        for value in ("", "no", "false", "0", "maybe"):
+            carrier.sent.clear()
+            client.post(
+                "/console/settings/phone/start",
+                data={"phone": "+13059511381", "channel": "voice", "sms_consent": value},
+            )
+            assert not carrier.sent, f"sms_consent={value!r} was treated as consent"
+
+    def test_with_consent_the_code_is_sent(self, client, carrier) -> None:
+        response = client.post(
+            "/console/settings/phone/start",
+            data={"phone": "+13059511381", "channel": "voice", "sms_consent": "yes"},
+        )
+
+        assert response.status_code == 303, response.text
+        assert carrier.sent, "consent given and still no code sent"
+
+    def test_the_console_and_the_public_page_show_THE_SAME_wording(self, client) -> None:
+        """The /sms page tells a campaign vetter these are "the exact steps and
+        the exact consent language shown". If the two ever differ, the public
+        claim is false and the CTA fails review again — which is what happened.
+        """
+        console = self._flat(client.get("/console/settings").text)
+        public = self._flat(client.get("/sms").text)
+
+        assert self.ANCHOR in console, "console checkbox lost the agreed wording"
+        assert self.ANCHOR in public, "public /sms page lost the agreed wording"
+
+    def test_both_places_carry_every_required_disclosure(self, client) -> None:
+        # CTIA wants sender, frequency, cost, stop, help, and both policies at
+        # the point of collection.
+        for path in ("/console/settings", "/sms"):
+            flat = self._flat(client.get(path).text)
+            for required in (
+                "Trusted Router",
+                "Message frequency varies",
+                "Message and data rates may apply",
+                "STOP",
+                "HELP",
+                "Terms of Service",
+                "Privacy Policy",
+            ):
+                assert required in flat, f"{path} is missing {required!r}"
+

--- a/tests/test_phone_funding_gate.py
+++ b/tests/test_phone_funding_gate.py
@@ -181,7 +181,7 @@ def test_console_start_works_after_any_funding(
 
     response = client.post(
         "/console/settings/phone/start",
-        data={"phone": "+13059511381", "channel": "voice"},
+        data={"phone": "+13059511381", "channel": "voice", "sms_consent": "yes"},
     )
 
     assert response.status_code == 303


### PR DESCRIPTION
Three commits, all on the path to a working phone-notification channel.

**`Add the settings UI for a phone number`** — Settings → Notifications, where an
account owner enters their own number and confirms it with a one-time code.

**`Stop /v1/notify 500ing on the production billing backend`** — `STORE.reserve`
no longer exists on the typed backend, and 3757 in-memory-store tests could not
reach it, so Sentry found the 500 before CI could.

**`Build the SMS consent checkbox the 10DLC campaign claimed we had`** — 10DLC
campaign 30909 was rejected for a Call to Action that could not be verified. The
cause was not the wording or the legal pages: the consent checkbox did not exist.
The submission said users "check a box consenting to receive SMS", and /sms
quoted the exact sentence that box supposedly showed, while the form had only a
number field and a button.

- the checkbox exists now, with every disclosure CTIA wants at the point of
  collection — sender, what is sent, frequency, cost, STOP, HELP, both policies;
- it is a gate, not a notice: the server refuses a non-affirmative `sms_consent`,
  because a browser-only checkbox is decoration and the consent record shown to a
  carrier would be a claim with nothing behind it;
- the sentence lives in one partial rendered in both places, since /sms tells
  vetters it is quoting "the exact consent language shown" and drift is how the
  page came to promise a control nobody built.

Gate is mutation-verified: stubbing it out fails exactly the two tests asserting
it. `ruff check` and `mypy` clean.