### PR TITLE
Fail closed on synthetic monitor secret sync

### DIFF
--- a/scripts/deploy/secrets.sh
+++ b/scripts/deploy/secrets.sh
@@ -8,6 +8,31 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/deploy/_lib.sh
 source "${SCRIPT_DIR}/_lib.sh"
 
+validate_synthetic_monitor_candidate() {
+  local value="$1"
+  local repo_root
+  local -a python_cmd
+  repo_root="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+  if [ -x "${repo_root}/.venv/bin/python" ]; then
+    python_cmd=("${repo_root}/.venv/bin/python")
+  elif command -v uv >/dev/null 2>&1; then
+    python_cmd=(uv run python)
+  else
+    echo "ERROR: synthetic monitor validation requires the project venv or uv." >&2
+    return 1
+  fi
+  log "validating synthetic monitor key against the dedicated production workspace"
+  printf '%s' "$value" | (
+    cd "$repo_root"
+    TR_STORAGE_BACKEND=spanner-bigtable \
+      TR_GCP_PROJECT_ID="$PROJECT_ID" \
+      TR_SPANNER_INSTANCE_ID="$SPANNER_INSTANCE_ID" \
+      TR_SPANNER_DATABASE_ID="$SPANNER_DATABASE_ID" \
+      PYTHONPATH=src:. \
+      "${python_cmd[@]}" scripts/validate_synthetic_monitor_key.py
+  ) >/dev/null
+}
+
 ensure_secret_from_env_file() {
   local env_name="$1"
   local secret_name="$2"
@@ -28,6 +53,9 @@ ensure_secret_from_env_file() {
   fi
   if [ -z "$value" ]; then
     return 0
+  fi
+  if [ "$secret_name" = "trustedrouter-synthetic-monitor-api-key" ]; then
+    validate_synthetic_monitor_candidate "$value"
   fi
   ensure_secret_value "$secret_name" "$value"
   log "uploaded secret ${secret_name}"

--- a/scripts/provision_synthetic_monitor.py
+++ b/scripts/provision_synthetic_monitor.py
@@ -33,6 +33,72 @@ DEFAULT_FUNDING_EVENT = "synthetic_monitor_workspace_funding_v1"
 DEFAULT_TARGET_SHARDS = 16
 
 
+def validate_synthetic_monitor_key(
+    store: Any,
+    raw_key: str,
+    *,
+    email: str = DEFAULT_EMAIL,
+    workspace_name: str = DEFAULT_WORKSPACE_NAME,
+    key_name: str = DEFAULT_KEY_NAME,
+    target_shards: int = DEFAULT_TARGET_SHARDS,
+) -> dict[str, Any]:
+    """Fail closed unless ``raw_key`` is the isolated production monitor key."""
+
+    if not raw_key or raw_key != raw_key.strip():
+        raise ValueError("synthetic monitor key is empty or contains whitespace")
+
+    api_key = store.get_key_by_raw(raw_key)
+    if api_key is None:
+        raise ValueError("synthetic monitor key is not registered")
+    if api_key.disabled:
+        raise ValueError("synthetic monitor key is disabled")
+    if api_key.name != key_name:
+        raise ValueError("synthetic monitor key has the wrong name")
+
+    user = store.find_user_by_email(email)
+    if user is None:
+        raise ValueError("synthetic monitoring user is missing")
+    workspace = store.get_workspace(api_key.workspace_id)
+    if workspace is None or workspace.deleted:
+        raise ValueError("synthetic monitoring workspace is missing")
+    if workspace.name != workspace_name:
+        raise ValueError("synthetic monitor key belongs to the wrong workspace")
+    if workspace.owner_user_id != user.id or api_key.creator_user_id != user.id:
+        raise ValueError("synthetic monitor key has the wrong owner")
+
+    if (
+        api_key.management
+        or api_key.limit_microdollars is not None
+        or api_key.limit_daily_microdollars is not None
+        or api_key.limit_weekly_microdollars is not None
+        or api_key.limit_monthly_microdollars is not None
+        or api_key.expires_at is not None
+        or api_key.tags.get("purpose") != "synthetic_monitoring"
+        or api_key.tags.get("analytics") != "excluded"
+        or api_key.tags.get("spend_control") != "workspace_funding_only"
+    ):
+        raise ValueError("synthetic monitor key has unsafe configuration")
+
+    account = store.get_credit_account(workspace.id)
+    if account is None:
+        raise ValueError("synthetic monitoring credit account is missing")
+    if account.auto_refill_enabled:
+        raise ValueError("synthetic monitoring workspace must not use auto-refill")
+    if account.shard_count != target_shards:
+        raise ValueError("synthetic monitoring credit account has the wrong shard count")
+    if api_key.usage_shard_count != target_shards:
+        raise ValueError("synthetic monitor key has the wrong usage shard count")
+
+    return {
+        "key_id": api_key.hash,
+        "workspace_id": workspace.id,
+        "workspace_name": workspace.name,
+        "credit_shards": account.shard_count,
+        "key_shards": api_key.usage_shard_count,
+        "valid": True,
+    }
+
+
 def provision(
     store: Any,
     *,

--- a/scripts/validate_synthetic_monitor_key.py
+++ b/scripts/validate_synthetic_monitor_key.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Validate a synthetic monitor key read from stdin against production state.
+
+The raw key is never accepted on the command line and is never printed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+os.environ.setdefault("TR_STORAGE_BACKEND", "spanner-bigtable")
+os.environ.setdefault("TR_GCP_PROJECT_ID", "quill-cloud-proxy")
+os.environ.setdefault("TR_SPANNER_INSTANCE_ID", "trusted-router-nam6")
+os.environ.setdefault("TR_SPANNER_DATABASE_ID", "trusted-router")
+os.environ.setdefault("TR_BIGTABLE_INSTANCE_ID", "trusted-router-logs")
+os.environ.setdefault("TR_BIGTABLE_GENERATION_TABLE", "trustedrouter-generations")
+
+from scripts.provision_synthetic_monitor import validate_synthetic_monitor_key
+from trusted_router.config import Settings
+from trusted_router.storage import create_store
+
+
+def main() -> int:
+    raw_key = sys.stdin.read()
+    try:
+        result = validate_synthetic_monitor_key(create_store(Settings()), raw_key)
+    except (RuntimeError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_provision_synthetic_monitor.py
+++ b/tests/test_provision_synthetic_monitor.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from scripts.provision_synthetic_monitor import provision
+from scripts.provision_synthetic_monitor import (
+    provision,
+    validate_synthetic_monitor_key,
+)
 from trusted_router.storage import InMemoryStore
 
 
@@ -77,6 +80,65 @@ def test_provision_synthetic_monitor_is_isolated_funding_limited_and_idempotent(
     snapshot = store.credit_money_snapshot(workspaces[0].id)
     assert snapshot is not None
     assert snapshot[0] == 1_000_000_000
+
+
+def test_validate_synthetic_monitor_key_accepts_only_dedicated_active_key(
+    tmp_path: Path,
+) -> None:
+    store = InMemoryStore()
+    key_file = tmp_path / "monitor.key"
+    provisioned = provision(
+        store,
+        email="synthetic-monitor@trustedrouter.internal",
+        workspace_name="TrustedRouter Synthetic Monitoring",
+        key_name="Synthetic monitor",
+        funding_microdollars=1_000_000_000,
+        funding_event_id="synthetic_monitor_workspace_funding_v1",
+        target_shards=16,
+        apply=True,
+        key_output_file=key_file,
+    )
+    account = store.get_credit_account(provisioned["workspace_id"])
+    key = store.get_key_by_hash(provisioned["key_id"])
+    assert account is not None
+    assert key is not None
+    account.shard_count = 16
+    key.usage_shard_count = 16
+
+    result = validate_synthetic_monitor_key(store, key_file.read_text())
+
+    assert result["valid"] is True
+    assert result["key_id"] == key.hash
+    assert result["credit_shards"] == 16
+    assert result["key_shards"] == 16
+
+
+def test_validate_synthetic_monitor_key_rejects_disabled_unrelated_key() -> None:
+    store = InMemoryStore()
+    user = store.ensure_user("other@example.com", email="other@example.com")
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    raw_key, key = store.create_api_key(
+        workspace_id=workspace.id,
+        name="Other key",
+        creator_user_id=user.id,
+    )
+    key.disabled = True
+
+    try:
+        validate_synthetic_monitor_key(store, raw_key)
+    except ValueError as exc:
+        assert str(exc) == "synthetic monitor key is disabled"
+    else:
+        raise AssertionError("disabled unrelated key was accepted")
+
+
+def test_secret_sync_validates_monitor_key_before_upload() -> None:
+    script = Path("scripts/deploy/secrets.sh").read_text(encoding="utf-8")
+
+    validation = 'validate_synthetic_monitor_candidate "$value"'
+    upload = 'ensure_secret_value "$secret_name" "$value"'
+    assert validation in script
+    assert script.index(validation) < script.index(upload)
 
 
 def test_provision_synthetic_monitor_rejects_reused_capped_key(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- validate synthetic monitor credentials against the dedicated production workspace before upload
- reject disabled, unrelated, unsafe, or incorrectly sharded monitor keys
- read the candidate from stdin so raw credentials never enter argv or logs
- add regression coverage for the exact disabled-key failure

## Verification
- uv run pytest -q tests/test_provision_synthetic_monitor.py tests/test_deploy_secret_wiring.py
- uv run ruff check scripts/provision_synthetic_monitor.py scripts/validate_synthetic_monitor_key.py tests/test_provision_synthetic_monitor.py
- uv run mypy
- bash -n scripts/deploy/secrets.sh
- production validator accepted restored secret v7
- immediate US and EU synthetic executions completed successfully