### PR TITLE
User-provided models: settle/refund at frozen prices, exactly-once owner payout, slots, local billing (Phase 5)

### DIFF
--- a/docs/design/reverse-harness-contract.md
+++ b/docs/design/reverse-harness-contract.md
@@ -1,0 +1,166 @@
+# Reverse-harness contract — serving a user-provided model to TrustedRouter
+
+**Status:** v1 (2026-08-16). Implemented by the open-source `reverse-harness` (Apache 2,
+TypeScript/Node reference: `npx @trustedrouter/reverse-harness`) and by any agent or machine that
+wants to be a model. This document is the whole wire contract; the harness holds its own queue and
+UI, TrustedRouter never sees them.
+
+## 1. What you are
+
+A **user-provided model** is an OpenAI-compatible HTTP endpoint you operate, registered under
+`trustedrouter/user-<slug>` with a fixed price per million tokens. TrustedRouter's attested gateway
+**pushes** requests to it (there is no pull/inbox); you answer, and you are paid 70% of the charge
+in TrustedRouter credits into your earnings wallet (never cash). Three kinds share the contract:
+
+| kind | who answers | price bounds (µ$/Mtok) | budgets connect / first-byte / idle / total |
+|---|---|---|---|
+| `machine` | a program | ≤ 1,000,000,000 ($1,000/Mtok) | 10 / 30 / 60 / 300 s |
+| `agent` | an autonomous agent | ≤ 1,000,000,000 | 10 / 60 / 60 / 600 s |
+| `human` | a person at a keyboard | 100,000,000,000 – 1,000,000,000,000 ($0.10 – $1.00 per token) | 10 / **300** / 120 / **900** s |
+
+Your model is **not attested and not zero-data-retention**: TrustedRouter says so on your model's
+page and on its trust page. Prompts and outputs are sent to you; what you do with them is between
+you and your callers.
+
+## 2. Registration (owner API, `Authorization: Bearer <management key>`)
+
+Requires a verified account (email, phone, identity). `POST /v1/user-models`:
+
+```json
+{
+  "name": "Ada, live", "slug": "ada-live", "kind": "human",
+  "description": "A real person. Median first token ~40s.",
+  "display_identity": "handle", "display_name": "ada",
+  "endpoint_url": "https://ada.example.com/v1",
+  "upstream_model_id": "ada",
+  "endpoint_api_key": "optional-bearer-your-endpoint-checks",
+  "supports_streaming": true,
+  "heartbeat_interval_seconds": 30, "max_concurrency": 1,
+  "prompt_price_microdollars_per_million_tokens": 100000000000,
+  "completion_price_microdollars_per_million_tokens": 100000000000
+}
+```
+
+`endpoint_url` must be **https**, resolve only to public addresses, and must not be a TrustedRouter
+host. The response carries `signing_secret` **once** — store it; it is how you verify that a request
+really came from TrustedRouter. `POST …/rotate-secrets` mints a new one (old signatures stop
+verifying at the next request).
+
+## 3. Being on the clock
+
+| call | effect |
+|---|---|
+| `POST /v1/user-models/{id}/clock-in` | TrustedRouter **probes** your endpoint first (a signed canary request, §5) — 409 with the reason if it fails; then you are on the clock. Strikes from an earlier shift are cleared. |
+| `POST …/heartbeat` | Extends your presence by `2 × heartbeat_interval_seconds`. Miss two intervals and you are treated as off the clock (no strike). Send it on a timer whenever you are on the clock. |
+| `POST …/clock-out` | Off the clock immediately. Requests already in flight finish. |
+
+Off the clock, callers get `503 model_off_the_clock`. **Three consecutive owner faults** (§7) clock
+you out automatically; clock back in when you are ready.
+
+## 4. The request you receive
+
+`POST {endpoint_url}/chat/completions` (your `endpoint_url` with `/chat/completions` appended; no
+redirects are followed — answer at that URL).
+
+Headers:
+
+```
+Content-Type: application/json
+Accept: text/event-stream, application/json
+User-Agent: TrustedRouter/1.0
+TR-Signature: t=<unix seconds>,v1=<hex HMAC-SHA256(signing_secret, "<t>." + body_bytes)>
+Authorization: Bearer <endpoint_api_key>        (only if you registered one)
+```
+
+Body — the caller's OpenAI chat request, **allowlisted** to exactly these keys:
+`messages, temperature, top_p, n, stop, max_tokens, max_completion_tokens, presence_penalty,
+frequency_penalty, logit_bias, logprobs, top_logprobs, response_format, seed, tools, tool_choice,
+parallel_tool_calls, reasoning_effort, metadata, stream_options` — plus two set by TrustedRouter:
+`model` = your `upstream_model_id`, and `stream` = your registered `supports_streaming` (the
+**owner** decides the transport, regardless of what the caller asked; TrustedRouter adapts). When
+`stream` is `false`, `stream_options` is never sent. Nothing else about the caller (identity, keys,
+routing preferences, TrustedRouter internals) is ever sent to you.
+
+### Verify the signature
+
+```
+t, v1 = parse("TR-Signature")            # "t=1700000000,v1=a7597e2b…"
+reject if |now - t| > 300 s               # replay window
+expected = hex(HMAC_SHA256(signing_secret, str(t) + "." + raw_body_bytes))
+reject unless constant_time_equal(expected, v1)
+```
+
+Sign the **exact bytes** you received; do not re-serialize. Test vector (secret
+`test-signing-secret`, body `{"model":"demo","stream":false}`, t = 1700000000):
+`t=1700000000,v1=a7597e2bfa4bc480b058f31a24542b3ab0c99fe6231ae15aa0498fd5bd1d4304`.
+
+## 5. The canary (probe)
+
+At clock-in — and whenever an operator asks — TrustedRouter sends a real signed request:
+`messages: [{"role":"user","content":"Reply with the single word: pong"}], max_tokens: 16`. A
+harness for humans should **auto-answer** it (any valid completion, e.g. `pong`) without waking the
+person; the probe must complete within 20 s total and its body is capped at 64 KiB. A valid answer
+resets your strike count.
+
+## 6. What you answer
+
+Exactly the OpenAI shape, in the transport you registered:
+
+- **`supports_streaming: true`** — `Content-Type: text/event-stream`; `data: <chat.completion.chunk
+  JSON>\n\n` frames; a final usage-only chunk (`"choices": []` with `usage`) is welcome; end with
+  `data: [DONE]\n\n`. Type-as-you-go: each keystroke batch is a `delta.content` chunk. Lines are
+  capped at 1 MiB and the whole stream at 64 MiB.
+- **`supports_streaming: false`** — one `chat.completion` JSON body (`choices[0].message`,
+  optional `usage`).
+
+Include `usage` (`prompt_tokens`, `completion_tokens`) when you can; TrustedRouter estimates
+otherwise. The charge is your usage at your price, **capped at what the caller authorized** (their
+estimated prompt + `max_tokens` at your prices) — reporting more than that earns nothing extra.
+Your `model` field is rewritten to the TrustedRouter id before the caller sees it.
+
+**Declining is just an HTTP error.** There is no special decline protocol: return `4xx` (you
+judged the request unacceptable) or `5xx` (you cannot serve right now). The caller sees a
+TrustedRouter `502` naming the status; their hold is refunded.
+
+## 7. What counts as your fault (strikes)
+
+TrustedRouter records one **strike** per owner fault; three in a row clocks you out. Faults:
+your endpoint unreachable / TLS or DNS failure (`connection_error`), first-byte / idle / total
+budget exceeded (`user_model_timeout`), HTTP `5xx` (`provider_error`), unparsable body or stream
+(`malformed_response`). **Not** faults: any `4xx` you return, the caller disconnecting, or a
+TrustedRouter-side error. A successful answer resets the count; so do clock-in and a passing probe.
+
+## 8. Timing, keepalives, disconnects
+
+- While a streaming caller waits for your first byte, TrustedRouter sends them SSE comment
+  keepalives; that wait is bounded only by your kind's **first-byte** budget (300 s for humans).
+  After your first byte, the **idle** budget applies between bytes; **total** bounds everything.
+- If the caller disconnects **before** any of your bytes reached them, the request is cancelled
+  (your endpoint sees the connection close) and refunded; no strike. If they disconnect **after**
+  receiving part of your answer, the delivered part is settled and you are paid for it.
+- TrustedRouter measures your **time to first token** and total latency exactly as for any other
+  model; a human's median TTFT is public on the model page. That is the point.
+
+## 9. Concurrency
+
+`max_concurrency` (default 4, humans usually 1) is enforced by TrustedRouter: beyond it callers get
+`429` "at capacity" and are not dispatched to you. A slot is held from authorization to
+settle/refund, at most one dispatch budget.
+
+## 10. Getting paid
+
+Every settled request credits **70% of the charge** (integer microdollars; TrustedRouter keeps the
+rounding) to your earnings wallet, exactly once. Owners see the ledger and per-model earnings in
+the console and can transfer earnings into any of their workspaces as spendable credits. Calling
+your own model charges you full price and pays you 70% — it nets −30%.
+
+## Appendix — minimal harness loop
+
+```
+on start:  POST clock-in (auto-answer the canary)              → on the clock
+timer:     POST heartbeat every heartbeat_interval_seconds
+on POST /chat/completions:
+           verify TR-Signature; enqueue; show the human the messages
+           human types → stream chunks (or one JSON body); or human clicks Decline → 4xx
+on stop:   POST clock-out
+```

--- a/src/trusted_router/custom_model_billing.py
+++ b/src/trusted_router/custom_model_billing.py
@@ -8,6 +8,13 @@ CUSTOM_MODEL_OWNER_SHARE_BASIS_POINTS = 7_000
 HUMAN_PRICE_MIN_MICRODOLLARS_PER_M = 100_000_000_000
 HUMAN_PRICE_MAX_MICRODOLLARS_PER_M = 1_000_000_000_000
 MACHINE_PRICE_MAX_MICRODOLLARS_PER_M = 1_000_000_000
+USER_MODEL_PAYOUT_SETTLE_FIELD = "_trustedrouter_user_model_payout_microdollars"
+USER_MODEL_OWNER_SETTLE_FIELD = "_trustedrouter_user_model_owner_user_id"
+USER_MODEL_ID_SETTLE_FIELD = "_trustedrouter_user_model_id"
+
+
+def user_model_payout_event_id(authorization_id: str) -> str:
+    return f"custom_model_payout:{authorization_id}"
 
 
 def validate_custom_model_price(

--- a/src/trusted_router/routes/inference.py
+++ b/src/trusted_router/routes/inference.py
@@ -16,6 +16,8 @@ this module owns the inference dispatch logic.
 """
 from __future__ import annotations
 
+import json
+import logging
 import time
 import uuid
 from collections.abc import AsyncIterator
@@ -35,9 +37,19 @@ from trusted_router.auth import (
     Principal,
     SettingsDep,
 )
-from trusted_router.catalog import AUTO_MODEL_ID, MODELS, MONITOR_MODEL_ID, Model
+from trusted_router.catalog import AUTO_MODEL_ID, MODELS, MONITOR_MODEL_ID, PROVIDERS, Model
 from trusted_router.config import Settings
+from trusted_router.custom_model_billing import (
+    custom_model_cost_microdollars,
+    owner_share_microdollars,
+    user_model_payout_event_id,
+)
 from trusted_router.errors import api_error
+from trusted_router.provider_types import (
+    ProviderResult,
+    estimate_tokens_from_messages,
+    estimate_tokens_from_text,
+)
 from trusted_router.routes.helpers import json_body
 from trusted_router.routing import (
     chat_route_candidates,
@@ -54,18 +66,21 @@ from trusted_router.services.inference import (
     run_embeddings,
     run_messages_stream,
 )
+from trusted_router.services.inference_quota import reserved_quota
 from trusted_router.services.user_model_dispatch import (
+    BufferedUserModelDispatch,
     dispatch_user_model,
     stream_user_model,
 )
-from trusted_router.storage import STORE
+from trusted_router.storage import STORE, Generation
 from trusted_router.storage_custom_models import is_custom_model_id, normalize_custom_model_id
 from trusted_router.storage_models import UserProvidedModel
 from trusted_router.types import ErrorType, UsageType
-from trusted_router.user_model_rules import user_model_is_on_the_clock
+from trusted_router.user_model_rules import user_model_gateway_pair, user_model_is_on_the_clock
 
 _VALID_ROLES = frozenset({"system", "user", "assistant", "tool", "developer"})
 _OUTPUT_TOKEN_FIELDS = ("max_tokens", "max_completion_tokens", "max_output_tokens")
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -94,11 +109,23 @@ def register_inference_routes(router: APIRouter) -> None:
         if user_model is not None:
             if body.get("stream") is True:
                 return StreamingResponse(
-                    stream_user_model(user_model, body, settings),
+                    _stream_local_user_model(
+                        user_model,
+                        body,
+                        principal,
+                        settings,
+                        app_name=_app_name(request),
+                    ),
                     media_type="text/event-stream",
                     headers={"cache-control": "no-cache", "x-accel-buffering": "no"},
                 )
-            result = await dispatch_user_model(user_model, body, settings)
+            result = await _dispatch_local_user_model(
+                user_model,
+                body,
+                principal,
+                settings,
+                app_name=_app_name(request),
+            )
             return JSONResponse(result.body)
         provider_prefs = provider_route_preferences(body)
         usage_type = (
@@ -442,6 +469,284 @@ def _responses_api_envelope(
         },
         "trustedrouter": {"generation_id": generation_id, "content_stored": False},
     }
+
+
+async def _dispatch_local_user_model(
+    model: UserProvidedModel,
+    body: dict[str, Any],
+    principal: InferencePrincipal,
+    settings: Settings,
+    *,
+    app_name: str,
+) -> BufferedUserModelDispatch:
+    assert principal.api_key is not None
+    sentinel, _endpoint = _local_user_model_pair(model)
+    prompt_price = int(model.prompt_price_microdollars_per_million_tokens)
+    completion_price = int(model.completion_price_microdollars_per_million_tokens)
+    input_estimate = estimate_tokens_from_messages(body.get("messages", []))
+    reserve_amount = custom_model_cost_microdollars(
+        input_tokens=input_estimate,
+        output_tokens=_local_max_output_tokens(body),
+        prompt_price=prompt_price,
+        completion_price=completion_price,
+    )
+    async with reserved_quota(
+        principal,
+        sentinel,
+        reserve_amount=reserve_amount,
+        input_tokens=input_estimate,
+        streamed=False,
+        region=settings.primary_region,
+        usage_type_override=UsageType.CREDITS,
+    ) as ticket:
+        dispatch = await dispatch_user_model(model, body, settings)
+        output_text = _owner_response_text(dispatch.body)
+        usage = _sane_owner_usage(dispatch.body.get("usage"))
+        input_tokens, output_tokens = (
+            usage
+            if usage is not None
+            else (input_estimate, estimate_tokens_from_text(output_text))
+        )
+        actual_cost = custom_model_cost_microdollars(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            prompt_price=prompt_price,
+            completion_price=completion_price,
+        )
+        ticket.settle(actual_cost)
+        choice = _owner_choice(dispatch.body)
+        provider_result = ProviderResult(
+            text=output_text,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            finish_reason=str(choice.get("finish_reason") or "stop"),
+            provider_name=PROVIDERS["trustedrouter"].name,
+            request_id=str(dispatch.body.get("id") or f"chatcmpl-{uuid.uuid4().hex}"),
+            usage_estimated=usage is None,
+            elapsed_seconds=dispatch.elapsed_seconds,
+            first_token_seconds=dispatch.first_token_seconds,
+        )
+        _record_local_user_model_generation(
+            model,
+            principal,
+            provider_result,
+            actual_cost=actual_cost,
+            streamed=False,
+            app_name=app_name,
+            region=settings.primary_region,
+        )
+        return dispatch
+
+
+async def _stream_local_user_model(
+    model: UserProvidedModel,
+    body: dict[str, Any],
+    principal: InferencePrincipal,
+    settings: Settings,
+    *,
+    app_name: str,
+) -> AsyncIterator[bytes]:
+    assert principal.api_key is not None
+    sentinel, _endpoint = _local_user_model_pair(model)
+    prompt_price = int(model.prompt_price_microdollars_per_million_tokens)
+    completion_price = int(model.completion_price_microdollars_per_million_tokens)
+    input_estimate = estimate_tokens_from_messages(body.get("messages", []))
+    reserve_amount = custom_model_cost_microdollars(
+        input_tokens=input_estimate,
+        output_tokens=_local_max_output_tokens(body),
+        prompt_price=prompt_price,
+        completion_price=completion_price,
+    )
+    async with reserved_quota(
+        principal,
+        sentinel,
+        reserve_amount=reserve_amount,
+        input_tokens=input_estimate,
+        streamed=True,
+        region=settings.primary_region,
+        usage_type_override=UsageType.CREDITS,
+    ) as ticket:
+        started_at = time.monotonic()
+        text_parts: list[str] = []
+        usage: tuple[int, int] | None = None
+        request_id = f"chatcmpl-{uuid.uuid4().hex}"
+        finish_reason = "stop"
+        first_token_seconds: float | None = None
+        owner_error = False
+        saw_done = False
+        async for chunk in stream_user_model(model, body, settings):
+            if chunk.lstrip().startswith(b"event: error"):
+                owner_error = True
+            for data in _stream_data_payloads(chunk):
+                if data == "[DONE]":
+                    saw_done = True
+                    continue
+                try:
+                    event = json.loads(data)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(event, dict):
+                    continue
+                request_id = str(event.get("id") or request_id)
+                event_usage = _sane_owner_usage(event.get("usage"))
+                if event_usage is not None:
+                    usage = event_usage
+                choices = event.get("choices")
+                if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+                    continue
+                choice = choices[0]
+                delta = choice.get("delta")
+                if isinstance(delta, dict) and isinstance(delta.get("content"), str):
+                    content = delta["content"]
+                    if content:
+                        if first_token_seconds is None:
+                            first_token_seconds = max(time.monotonic() - started_at, 0.001)
+                        text_parts.append(content)
+                if choice.get("finish_reason") is not None:
+                    finish_reason = str(choice["finish_reason"])
+            yield chunk
+        if owner_error or not saw_done:
+            return
+        output_text = "".join(text_parts)
+        input_tokens, output_tokens = (
+            usage
+            if usage is not None
+            else (input_estimate, estimate_tokens_from_text(output_text))
+        )
+        actual_cost = custom_model_cost_microdollars(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            prompt_price=prompt_price,
+            completion_price=completion_price,
+        )
+        ticket.settle(actual_cost)
+        provider_result = ProviderResult(
+            text=output_text,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            finish_reason=finish_reason,
+            provider_name=PROVIDERS["trustedrouter"].name,
+            request_id=request_id,
+            usage_estimated=usage is None,
+            elapsed_seconds=max(time.monotonic() - started_at, 0.001),
+            first_token_seconds=first_token_seconds,
+        )
+        _record_local_user_model_generation(
+            model,
+            principal,
+            provider_result,
+            actual_cost=actual_cost,
+            streamed=True,
+            app_name=app_name,
+            region=settings.primary_region,
+        )
+
+
+def _local_user_model_pair(model: UserProvidedModel) -> tuple[Model, Any]:
+    return user_model_gateway_pair(
+        model_id=model.id,
+        name=model.name,
+        revision=model.revision,
+        prompt_price_microdollars_per_m=(
+            model.prompt_price_microdollars_per_million_tokens
+        ),
+        completion_price_microdollars_per_m=(
+            model.completion_price_microdollars_per_million_tokens
+        ),
+        owner_user_id=model.owner_user_id,
+        upstream_model_id=model.upstream_model_id,
+    )
+
+
+def _local_max_output_tokens(body: dict[str, Any]) -> int:
+    value = resolve_max_output_tokens(body)
+    return 512 if value is None else int(value)
+
+
+def _sane_owner_usage(value: Any) -> tuple[int, int] | None:
+    if not isinstance(value, dict):
+        return None
+    prompt = value.get("prompt_tokens")
+    completion = value.get("completion_tokens")
+    if (
+        isinstance(prompt, bool)
+        or isinstance(completion, bool)
+        or not isinstance(prompt, int)
+        or not isinstance(completion, int)
+        or prompt < 0
+        or completion < 0
+    ):
+        return None
+    return prompt, completion
+
+
+def _owner_choice(body: dict[str, Any]) -> dict[str, Any]:
+    choices = body.get("choices")
+    if isinstance(choices, list) and choices and isinstance(choices[0], dict):
+        return choices[0]
+    return {}
+
+
+def _owner_response_text(body: dict[str, Any]) -> str:
+    message = _owner_choice(body).get("message")
+    if not isinstance(message, dict):
+        return ""
+    content = message.get("content")
+    return content if isinstance(content, str) else ""
+
+
+def _stream_data_payloads(chunk: bytes) -> list[str]:
+    return [
+        line.removeprefix(b"data:").strip().decode("utf-8", errors="ignore")
+        for line in chunk.splitlines()
+        if line.startswith(b"data:")
+    ]
+
+
+def _record_local_user_model_generation(
+    model: UserProvidedModel,
+    principal: InferencePrincipal,
+    result: ProviderResult,
+    *,
+    actual_cost: int,
+    streamed: bool,
+    app_name: str,
+    region: str | None,
+) -> Generation:
+    assert principal.api_key is not None
+    generation = Generation.from_chat_result(
+        result=result,
+        workspace_id=principal.workspace.id,
+        key_hash=principal.api_key.hash,
+        model_id=model.id,
+        app_name=app_name,
+        actual_cost_microdollars=actual_cost,
+        usage_type=UsageType.CREDITS,
+        streamed=streamed,
+        provider="trustedrouter",
+        region=region,
+    )
+    payout = owner_share_microdollars(actual_cost)
+    generation.custom_model_id = model.id
+    generation.operator_cost_microdollars = payout
+    STORE.add_generation(generation)
+    if payout > 0:
+        try:
+            STORE.credit_user_earnings(
+                model.owner_user_id,
+                payout,
+                user_model_payout_event_id(generation.id),
+                custom_model_id=model.id,
+                payer_workspace_id=principal.workspace.id,
+            )
+        except Exception:
+            logger.error(
+                "user_model_payout_failed authorization_id=%s owner=%s",
+                generation.id,
+                model.owner_user_id,
+                exc_info=True,
+            )
+    return generation
 
 
 # ---------------------------------------------------------------------------

--- a/src/trusted_router/routes/inference.py
+++ b/src/trusted_router/routes/inference.py
@@ -507,11 +507,13 @@ async def _dispatch_local_user_model(
             if usage is not None
             else (input_estimate, estimate_tokens_from_text(output_text))
         )
-        actual_cost = custom_model_cost_microdollars(
+        actual_cost = _capped_user_model_cost(
+            model,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             prompt_price=prompt_price,
             completion_price=completion_price,
+            hold=reserve_amount,
         )
         ticket.settle(actual_cost)
         choice = _owner_choice(dispatch.body)
@@ -613,11 +615,13 @@ async def _stream_local_user_model(
             if usage is not None
             else (input_estimate, estimate_tokens_from_text(output_text))
         )
-        actual_cost = custom_model_cost_microdollars(
+        actual_cost = _capped_user_model_cost(
+            model,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             prompt_price=prompt_price,
             completion_price=completion_price,
+            hold=reserve_amount,
         )
         ticket.settle(actual_cost)
         provider_result = ProviderResult(
@@ -661,6 +665,42 @@ def _local_user_model_pair(model: UserProvidedModel) -> tuple[Model, Any]:
 def _local_max_output_tokens(body: dict[str, Any]) -> int:
     value = resolve_max_output_tokens(body)
     return 512 if value is None else int(value)
+
+
+def _capped_user_model_cost(
+    model: UserProvidedModel,
+    *,
+    input_tokens: int,
+    output_tokens: int,
+    prompt_price: int,
+    completion_price: int,
+    hold: int,
+) -> int:
+    """Owner-priced cost, never above the hold the caller authorized.
+
+    Same rule as the gateway settle: the token counts are the PAYEE's own
+    meter, so the reservation (estimated prompt + max_output at frozen prices)
+    is the ceiling on what the caller can be charged and the owner paid.
+    """
+    cost = custom_model_cost_microdollars(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        prompt_price=prompt_price,
+        completion_price=completion_price,
+    )
+    if cost > hold:
+        logger.warning(
+            "billing.user_model_settle_capped_to_hold",
+            extra={
+                "user_provided_model_id": model.id,
+                "reported_microdollars": cost,
+                "hold_microdollars": hold,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            },
+        )
+        return hold
+    return cost
 
 
 def _sane_owner_usage(value: Any) -> tuple[int, int] | None:

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -529,17 +529,20 @@ def _authorize_gateway_sync(
                 ErrorType.CONFLICT,
             )
         return _replay_response(existing_authorization)
-    authorization_id = _new_gateway_authorization_id(
-        workspace.id,
-        api_key.hash,
-        request_idempotency_key,
-    )
+    # Minted up front so a user-model concurrency slot can be keyed by it
+    # before the reservation exists. It is a fresh uuid — never derived from
+    # the caller's Idempotency-Key: a deterministic id would outlive its
+    # 30-day authorization row inside the 400-day tr_credit_movement PK
+    # (silently dropping a later payout) and let a mismatching concurrent
+    # request release the winner's slot.
+    authorization_id = _new_gateway_authorization_id()
     user_model_slot_acquired = False
     if user_model is not None:
         user_model_slot_acquired = acquire_user_model_slot(
             user_model.id,
             authorization_id,
             limit=user_model.max_concurrency,
+            kind=user_model.kind,
         )
         if not user_model_slot_acquired:
             raise api_error(
@@ -676,7 +679,10 @@ def _authorize_gateway_sync(
             release_user_model_slot_after_error()
             raise api_error(500, "gateway authorize failed", ErrorType.INTERNAL_ERROR)
         if outcome == AuthorizeOutcome.REPLAY:
-            # concurrent-race replay: respond from the STORED authorization
+            # concurrent-race replay: respond from the STORED authorization.
+            # Our provisional slot belongs to the id that lost the race, not
+            # to the stored authorization — give it back.
+            release_user_model_slot_after_error()
             return _replay_response(authorization)
         credit_reservation_id = authorization.credit_reservation_id
     else:
@@ -1180,14 +1186,9 @@ def _gateway_authorize_fingerprint(
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
 
-def _new_gateway_authorization_id(
-    workspace_id: str,
-    key_hash: str,
-    idempotency_key: str,
-) -> str:
-    """Derive one opaque slot/authorization id per idempotent request."""
-    material = f"{workspace_id}\0{key_hash}\0{idempotency_key}".encode()
-    return f"gwa-{hashlib.sha256(material).hexdigest()[:32]}"
+def _new_gateway_authorization_id() -> str:
+    """One fresh authorization id (same shape the typed store mints)."""
+    return f"gwa-{uuid.uuid4().hex}"
 
 
 def _authorization_endpoint_candidates(
@@ -1619,15 +1620,17 @@ def _settle_gateway_authorization(
     service_tier = (
         None if user_model_pair is not None else _actual_service_tier_or_error(body.service_tier)
     )
+    # Owner endpoints speak the OpenAI chat dialect, whose prompt_tokens
+    # already INCLUDES any cached subset — the "trustedrouter" branch of
+    # normalized_prompt_accounting (also what the outbox repair path uses).
+    # Adding cache counts on top would double-bill the prompt and let an owner
+    # who reports cached_tokens == prompt_tokens double their revenue. Owner
+    # prices have no cache tier, so the whole prompt bills at the prompt price.
+    uncached_input, total_input, cache_read, cache_creation = normalized_prompt_accounting(
+        selected_endpoint.provider, body
+    )
     if user_model_pair is not None:
-        cache_read = body.cache_read_count
-        cache_creation = body.cache_creation_count
-        total_input = body.input_count + cache_read + cache_creation
         uncached_input = total_input
-    else:
-        uncached_input, total_input, cache_read, cache_creation = normalized_prompt_accounting(
-            selected_endpoint.provider, body
-        )
     partner_mode = _partner_billing_mode_or_error(
         requested_model_id=authorization.requested_model_id,
         route_type=body.route_type,
@@ -1676,7 +1679,27 @@ def _settle_gateway_authorization(
         # route marker from a generic abort path; the authorization id is the
         # durable authority and refusing a refund can strand funds for 26h.
         actual_cost = 0
-    elif user_model_pair is None:
+    elif user_model_pair is not None:
+        # The token counts come from the PAYEE's own meter (the owner endpoint
+        # reports usage; the enclave forwards it). Catalog providers are
+        # trusted to overrun a hold by a little; an owner who reports
+        # 10^7 tokens for a 10-token answer must not be able to drain the
+        # caller and pocket 70%. The hold the caller authorized — estimated
+        # prompt at frozen prices plus max_output — is the ceiling.
+        if actual_cost > authorization.estimated_microdollars:
+            logger.warning(
+                "billing.user_model_settle_capped_to_hold",
+                extra={
+                    "authorization_id": authorization.id,
+                    "user_provided_model_id": authorization.user_provided_model_id,
+                    "reported_microdollars": actual_cost,
+                    "hold_microdollars": authorization.estimated_microdollars,
+                    "input_tokens": total_input,
+                    "output_tokens": output_tokens,
+                },
+            )
+            actual_cost = authorization.estimated_microdollars
+    else:
         actual_cost = _native_batch_cost_or_error(
             actual_cost,
             route_type=body.route_type,
@@ -2380,7 +2403,15 @@ def _select_authorized_endpoint(
         frozen_model, frozen_endpoint = user_model_pair
         if body.selected_endpoint_id not in {None, frozen_endpoint.id}:
             return None
-        if body.selected_model_id not in {None, frozen_model.id}:
+        # The enclave may echo the caller's raw spelling of the id
+        # ("TrustedRouter/User-Foo", the short "user-foo" alias); authorize
+        # normalized it before freezing, so compare normalized. A refused
+        # settle here strands the hold, so be no stricter than the id grammar.
+        selected_model_id = body.selected_model_id
+        if (
+            selected_model_id is not None
+            and normalize_custom_model_id(selected_model_id) != frozen_model.id
+        ):
             return None
         return frozen_endpoint
     authorized_endpoint_ids = authorization.candidate_endpoint_ids or []

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -43,7 +43,14 @@ from trusted_router.catalog import (
     endpoint_zero_data_retention,
 )
 from trusted_router.config import Settings, get_settings
-from trusted_router.custom_model_billing import custom_model_cost_microdollars
+from trusted_router.custom_model_billing import (
+    USER_MODEL_ID_SETTLE_FIELD,
+    USER_MODEL_OWNER_SETTLE_FIELD,
+    USER_MODEL_PAYOUT_SETTLE_FIELD,
+    custom_model_cost_microdollars,
+    owner_share_microdollars,
+    user_model_payout_event_id,
+)
 from trusted_router.errors import api_error, assert_workspace_billing_active
 from trusted_router.money import money_pair, token_cost_microdollars
 from trusted_router.openai_service_tiers import (
@@ -96,10 +103,17 @@ from trusted_router.services.settle_outbox_drain import (
     drain_settle_outbox,
     spanner_settle_outbox,
 )
+from trusted_router.services.user_model_gateway_health import (
+    record_user_model_gateway_result,
+)
 from trusted_router.services.user_model_secrets import (
     USER_MODEL_ENDPOINT_KEY_PURPOSE,
     USER_MODEL_SECRET_NAMESPACE,
     USER_MODEL_SIGNING_PURPOSE,
+)
+from trusted_router.services.user_model_slots import (
+    acquire_user_model_slot,
+    release_user_model_slot,
 )
 from trusted_router.storage import (
     STORE,
@@ -117,12 +131,19 @@ from trusted_router.storage_gcp_io import spanner_rpc_budget
 from trusted_router.storage_models import (
     SettleOutboxRow,
     TypedFinalizeResult,
+    UserModelPayout,
     UserProvidedModel,
 )
 from trusted_router.synthetic.fleet import record_heartbeat
 from trusted_router.synthetic.funding import ensure_monitor_funding, monitor_lookup_hash
 from trusted_router.types import ErrorType, UsageType
-from trusted_router.user_model_rules import dispatch_budget, user_model_is_on_the_clock
+from trusted_router.user_model_rules import (
+    GATEWAY_RESERVATION_TTL_SECONDS,
+    dispatch_budget,
+    is_owner_fault,
+    user_model_gateway_pair,
+    user_model_is_on_the_clock,
+)
 
 logger = logging.getLogger(__name__)
 REQUEST_METADATA_VERSION = 1
@@ -508,6 +529,30 @@ def _authorize_gateway_sync(
                 ErrorType.CONFLICT,
             )
         return _replay_response(existing_authorization)
+    authorization_id = _new_gateway_authorization_id(
+        workspace.id,
+        api_key.hash,
+        request_idempotency_key,
+    )
+    user_model_slot_acquired = False
+    if user_model is not None:
+        user_model_slot_acquired = acquire_user_model_slot(
+            user_model.id,
+            authorization_id,
+            limit=user_model.max_concurrency,
+        )
+        if not user_model_slot_acquired:
+            raise api_error(
+                429,
+                f"User-provided model {user_model.id} is at capacity "
+                f"({user_model.max_concurrency} concurrent)",
+                ErrorType.RATE_LIMITED,
+            )
+
+    def release_user_model_slot_after_error() -> None:
+        if user_model is not None and user_model_slot_acquired:
+            release_user_model_slot(user_model.id, authorization_id)
+
     credit_reservation_id: str | None = None
     idempotent_replay = False
     # C1 removed the workspace cohort/denylist brake: GCP now always uses typed
@@ -544,6 +589,7 @@ def _authorize_gateway_sync(
             outcome, authorization = _typed_store.authorize_gateway_typed(
                 workspace_id=workspace.id,
                 key_hash=api_key.hash,
+                authorization_id=authorization_id,
                 estimate=estimate,
                 has_credit_candidate=has_credit_candidate,
                 reservation_usage_type=reservation_usage_type,
@@ -579,6 +625,7 @@ def _authorize_gateway_sync(
                 window_limits=window_limits or None,
             )
         except conflict_store_error_types() as exc:
+            release_user_model_slot_after_error()
             # The generic 503 request log cannot identify a tenant hot row.
             # Emit only safe billing metadata so an operator can reshard the
             # affected workspace without ever logging a key, prompt, or body.
@@ -595,10 +642,15 @@ def _authorize_gateway_sync(
                 },
             )
             raise
+        except BaseException:
+            release_user_model_slot_after_error()
+            raise
         if outcome == AuthorizeOutcome.INSUFFICIENT_CREDITS:
+            release_user_model_slot_after_error()
             record_free_credit_exhausted_safely(workspace.id)
             raise _insufficient_credits_error(workspace)
         if outcome.startswith(AuthorizeOutcome.KEY_WINDOW_LIMIT_EXCEEDED):
+            release_user_model_slot_after_error()
             _, _, window = outcome.partition(":")
             window = window or "daily"
             resets_at = window_resets_at(window, utcnow())
@@ -611,14 +663,17 @@ def _authorize_gateway_sync(
                 headers={"Retry-After": str(retry_after)},
             )
         if outcome in (AuthorizeOutcome.KEY_LIMIT_EXCEEDED, AuthorizeOutcome.KEY_MISSING):
+            release_user_model_slot_after_error()
             raise api_error(402, "API key spend limit exceeded", ErrorType.KEY_LIMIT_EXCEEDED)
         if outcome == AuthorizeOutcome.IDEMPOTENCY_MISMATCH:
+            release_user_model_slot_after_error()
             raise api_error(
                 409,
                 "Idempotency key was already used for a different gateway request",
                 ErrorType.CONFLICT,
             )
         if authorization is None:
+            release_user_model_slot_after_error()
             raise api_error(500, "gateway authorize failed", ErrorType.INTERNAL_ERROR)
         if outcome == AuthorizeOutcome.REPLAY:
             # concurrent-race replay: respond from the STORED authorization
@@ -634,6 +689,7 @@ def _authorize_gateway_sync(
         try:
             STORE.reserve_key_limit(api_key.hash, estimate, usage_type=reservation_usage_type)
         except KeyWindowLimitExceeded as exc:
+            release_user_model_slot_after_error()
             # InMemory twin of the typed window rejection (same 429 shape).
             resets_at = window_resets_at(exc.window, utcnow())
             retry_after = max(1, int((resets_at - utcnow()).total_seconds()))
@@ -645,6 +701,7 @@ def _authorize_gateway_sync(
                 headers={"Retry-After": str(retry_after)},
             ) from exc
         except ValueError as exc:
+            release_user_model_slot_after_error()
             raise api_error(
                 402, "API key spend limit exceeded", ErrorType.KEY_LIMIT_EXCEEDED
             ) from exc
@@ -680,6 +737,7 @@ def _authorize_gateway_sync(
                 # local settlement. Reversing the order would strand real
                 # money that was deliberately moved here.
                 if not _deferred_settlement_applies(settings, api_key):
+                    release_user_model_slot_after_error()
                     STORE.refund_key_limit(
                         api_key.hash, estimate, usage_type=reservation_usage_type
                     )
@@ -696,6 +754,7 @@ def _authorize_gateway_sync(
             usage_type=reservation_usage_type,
             estimated_microdollars=estimate,
             credit_reservation_id=credit_reservation_id,
+            authorization_id=authorization_id,
             requested_model_id=requested_model_id,
             candidate_model_ids=[
                 candidate_model.id for candidate_model, _endpoint in endpoint_candidates
@@ -742,6 +801,7 @@ def _authorize_gateway_sync(
         try:
             authorization = create_authorization()
         except DeferredSettlementCapReached as cap_exc:
+            release_user_model_slot_after_error()
             # The key-limit escrow taken above must come back: nothing on this
             # plane would ever release it for a request that never became an
             # authorization (the reaper only sees authorizations).
@@ -755,6 +815,7 @@ def _authorize_gateway_sync(
                 headers={"Retry-After": "30"},
             ) from cap_exc
         except StoreConflict as conflict_exc:
+            release_user_model_slot_after_error()
             # DSQL OCC exhausted its retries (a hot outstanding row under
             # burst load will do this). Same rule as the cap arm: the escrow
             # committed OUTSIDE this transaction, so nothing downstream will
@@ -767,6 +828,9 @@ def _authorize_gateway_sync(
                 ErrorType.SERVICE_UNAVAILABLE,
                 headers={"Retry-After": "1"},
             ) from conflict_exc
+        except BaseException:
+            release_user_model_slot_after_error()
+            raise
     byok_config = (
         _get_byok_provider(workspace.id, endpoint.provider) if model_usage_type.is_byok() else None
     )
@@ -1116,10 +1180,23 @@ def _gateway_authorize_fingerprint(
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
 
+def _new_gateway_authorization_id(
+    workspace_id: str,
+    key_hash: str,
+    idempotency_key: str,
+) -> str:
+    """Derive one opaque slot/authorization id per idempotent request."""
+    material = f"{workspace_id}\0{key_hash}\0{idempotency_key}".encode()
+    return f"gwa-{hashlib.sha256(material).hexdigest()[:32]}"
+
+
 def _authorization_endpoint_candidates(
     authorization: Any,
     fallback: list[tuple[Model, ModelEndpoint]],
 ) -> list[tuple[Model, ModelEndpoint]]:
+    user_model_pair = _authorized_user_model_pair(authorization)
+    if user_model_pair is not None:
+        return [user_model_pair]
     candidates: list[tuple[Model, ModelEndpoint]] = []
     endpoint_ids = authorization.candidate_endpoint_ids or []
     if not endpoint_ids and authorization.endpoint_id:
@@ -1491,6 +1568,7 @@ def _settle_gateway_authorization(
     if authorization is None:
         raise api_error(404, "Gateway authorization not found", ErrorType.NOT_FOUND)
     if authorization.settled:
+        _release_user_model_slot_safely(authorization)
         # No timing line for replays: they are ~one point-read and would dominate
         # the latency dataset with noise.
         return {"data": _already_settled_gateway_data(authorization)}
@@ -1518,7 +1596,11 @@ def _settle_gateway_authorization(
     # This field is control-plane-owned. Never trust a caller-supplied value;
     # only the selected endpoint and frozen price history may set operator COGS.
     settle_body.pop(PARTNER_OPERATOR_COST_SETTLE_FIELD, None)
+    settle_body.pop(USER_MODEL_PAYOUT_SETTLE_FIELD, None)
+    settle_body.pop(USER_MODEL_OWNER_SETTLE_FIELD, None)
+    settle_body.pop(USER_MODEL_ID_SETTLE_FIELD, None)
 
+    user_model_pair = _authorized_user_model_pair(authorization)
     selected_endpoint = _select_authorized_endpoint(authorization, body)
     if selected_endpoint is None:
         raise api_error(
@@ -1526,21 +1608,37 @@ def _settle_gateway_authorization(
             "selected endpoint was not authorized for this gateway request",
             ErrorType.BAD_REQUEST,
         )
-    model = MODELS.get(selected_endpoint.model_id)
+    model = user_model_pair[0] if user_model_pair is not None else MODELS.get(
+        selected_endpoint.model_id
+    )
     if model is None:
         raise api_error(500, "Authorized model is no longer configured", ErrorType.INTERNAL_ERROR)
     auth_ms = (perf_counter() - timing_start) * 1000
 
     output_tokens = body.output_count
-    service_tier = _actual_service_tier_or_error(body.service_tier)
-    uncached_input, total_input, cache_read, cache_creation = normalized_prompt_accounting(
-        selected_endpoint.provider, body
+    service_tier = (
+        None if user_model_pair is not None else _actual_service_tier_or_error(body.service_tier)
     )
+    if user_model_pair is not None:
+        cache_read = body.cache_read_count
+        cache_creation = body.cache_creation_count
+        total_input = body.input_count + cache_read + cache_creation
+        uncached_input = total_input
+    else:
+        uncached_input, total_input, cache_read, cache_creation = normalized_prompt_accounting(
+            selected_endpoint.provider, body
+        )
     partner_mode = _partner_billing_mode_or_error(
         requested_model_id=authorization.requested_model_id,
         route_type=body.route_type,
         idempotency_key=authorization.idempotency_key,
     )
+    if user_model_pair is not None and partner_mode is not None:
+        raise api_error(
+            400,
+            "User-provided models do not support partner billing",
+            ErrorType.BAD_REQUEST,
+        )
     if partner_mode is not None and UsageType.for_endpoint(selected_endpoint) != UsageType.CREDITS:
         raise api_error(
             400,
@@ -1548,7 +1646,16 @@ def _settle_gateway_authorization(
             ErrorType.MODEL_NOT_SUPPORTED,
         )
     actual_cost = (
-        partner_cost_microdollars(
+        custom_model_cost_microdollars(
+            input_tokens=total_input,
+            output_tokens=output_tokens,
+            prompt_price=int(authorization.user_model_prompt_price_microdollars_per_m or 0),
+            completion_price=int(
+                authorization.user_model_completion_price_microdollars_per_m or 0
+            ),
+        )
+        if user_model_pair is not None
+        else partner_cost_microdollars(
             partner_mode,
             input_tokens=total_input,
             output_tokens=output_tokens,
@@ -1564,7 +1671,12 @@ def _settle_gateway_authorization(
             service_tier=service_tier,
         )
     )
-    if success:
+    if not success:
+        # A refund books zero and releases the frozen hold. Never require a
+        # route marker from a generic abort path; the authorization id is the
+        # durable authority and refusing a refund can strand funds for 26h.
+        actual_cost = 0
+    elif user_model_pair is None:
         actual_cost = _native_batch_cost_or_error(
             actual_cost,
             route_type=body.route_type,
@@ -1573,12 +1685,10 @@ def _settle_gateway_authorization(
             native_batch_eligible=authorization.native_batch_eligible,
             selected_usage_type=UsageType.for_endpoint(selected_endpoint),
         )
-    else:
-        # A refund books zero and releases the frozen hold. Never require a
-        # route marker from a generic abort path; the authorization id is the
-        # durable authority and refusing a refund can strand funds for 26h.
-        actual_cost = 0
     operator_cost = (
+        owner_share_microdollars(actual_cost)
+        if user_model_pair is not None
+        else
         _endpoint_cost_microdollars(
             selected_endpoint,
             uncached_input,
@@ -1592,6 +1702,12 @@ def _settle_gateway_authorization(
         else None
     )
     additional_cost = body.additional_cost_microdollars
+    if user_model_pair is not None and additional_cost:
+        raise api_error(
+            400,
+            "User-provided models do not support additional settlement cost",
+            ErrorType.BAD_REQUEST,
+        )
     if additional_cost:
         if body.route_type not in {"responses.web_search.planner", "videos"}:
             raise api_error(
@@ -1658,6 +1774,19 @@ def _settle_gateway_authorization(
         )
         generation_id = generation.id
 
+    user_model_payout: UserModelPayout | None = None
+    if user_model_pair is not None:
+        owner_user_id = str(authorization.user_model_owner_user_id or "")
+        user_model_id = str(authorization.user_provided_model_id or "")
+        user_model_payout = UserModelPayout(
+            owner_user_id=owner_user_id,
+            model_id=user_model_id,
+            amount_microdollars=(
+                owner_share_microdollars(actual_cost) if success else 0
+            ),
+            payer_workspace_id=authorization.workspace_id,
+        )
+
     # C1 removed the GCP legacy finalize branch; Spanner finalizes through typed
     # billing unconditionally. The memory store still uses the single-book path.
     _typed_store = typed_billing_store(STORE)
@@ -1671,6 +1800,14 @@ def _settle_gateway_authorization(
             frozen_settle_body = _settle_repair_metadata(settle_body)
             if operator_cost is not None:
                 frozen_settle_body[PARTNER_OPERATOR_COST_SETTLE_FIELD] = operator_cost
+            if user_model_payout is not None:
+                frozen_settle_body[USER_MODEL_PAYOUT_SETTLE_FIELD] = (
+                    user_model_payout.amount_microdollars
+                )
+                frozen_settle_body[USER_MODEL_OWNER_SETTLE_FIELD] = (
+                    user_model_payout.owner_user_id
+                )
+                frozen_settle_body[USER_MODEL_ID_SETTLE_FIELD] = user_model_payout.model_id
             # §5.4 honest scope: durability starts only when this INSERT commits;
             # crashes before it still rely on enclave redelivery. MF4/MF5 freeze
             # the finalize path and exact resolved cost used by the inline attempt.
@@ -1735,6 +1872,7 @@ def _settle_gateway_authorization(
                     actual_microdollars=actual_cost,
                     selected_usage_type=selected_usage_type,
                     generation=generation,
+                    user_model_payout=user_model_payout,
                 ),
             )
         else:
@@ -1744,6 +1882,7 @@ def _settle_gateway_authorization(
                 actual_microdollars=actual_cost,
                 selected_usage_type=selected_usage_type,
                 generation=generation,
+                user_model_payout=user_model_payout,
             )
             finalize_result = TypedFinalizeResult(
                 finalized=finalized_legacy_contract,
@@ -1758,11 +1897,18 @@ def _settle_gateway_authorization(
             selected_usage_type=selected_usage_type,
             generation=generation,
         )
+        if finalized:
+            _credit_user_model_payout_safely(
+                authorization,
+                success=success,
+                payout=user_model_payout,
+            )
         finalize_result = TypedFinalizeResult(
             finalized=finalized,
             activity_indexed=finalized,
         )
     finalize_ms = (perf_counter() - finalize_start) * 1000
+    _release_user_model_slot_safely(authorization)
     if not finalized:
         # §3/§6/§7: leave the row pending on purpose. Inline's False only says
         # "claim lost"; it cannot distinguish a charged replay from reaper-free
@@ -1771,6 +1917,12 @@ def _settle_gateway_authorization(
         # No timing line for replays: they would dominate the latency dataset
         # with noise instead of measuring full settle/refund work.
         return {"data": _already_settled_gateway_data(authorization)}
+    _record_user_model_gateway_outcome_safely(
+        authorization,
+        success=success,
+        error_status=body.error_status,
+        error_type=body.error_type,
+    )
     mark_ms = 0.0
     if settings.settle_outbox_enabled and outbox_enqueued and finalize_result.activity_indexed:
         mark_start = perf_counter()
@@ -1894,6 +2046,76 @@ def _settle_gateway_authorization(
             "cache_read_input_tokens": int(body.cache_read_input_tokens or 0),
         }
     }
+
+
+def _credit_user_model_payout_safely(
+    authorization: Any,
+    *,
+    success: bool,
+    payout: UserModelPayout | None,
+) -> None:
+    if not success or payout is None or payout.amount_microdollars <= 0:
+        return
+    try:
+        STORE.credit_user_earnings(
+            payout.owner_user_id,
+            payout.amount_microdollars,
+            user_model_payout_event_id(authorization.id),
+            custom_model_id=payout.model_id,
+            payer_workspace_id=payout.payer_workspace_id,
+        )
+    except Exception:
+        logger.error(
+            "user_model_payout_failed authorization_id=%s owner=%s",
+            authorization.id,
+            payout.owner_user_id,
+            exc_info=True,
+        )
+
+
+def _release_user_model_slot_safely(authorization: Any) -> None:
+    model_id = authorization.user_provided_model_id
+    if not model_id:
+        return
+    try:
+        release_user_model_slot(model_id, authorization.id)
+    except Exception:
+        logger.warning(
+            "user_model_slot_release_failed authorization_id=%s model_id=%s",
+            authorization.id,
+            model_id,
+            exc_info=True,
+        )
+
+
+def _record_user_model_gateway_outcome_safely(
+    authorization: Any,
+    *,
+    success: bool,
+    error_status: int | None,
+    error_type: str | None,
+) -> None:
+    model_id = authorization.user_provided_model_id
+    if not model_id:
+        return
+    dispatch_success: bool | None = True if success else None
+    if not success and is_owner_fault(error_status, error_type):
+        dispatch_success = False
+    if dispatch_success is None:
+        return
+    try:
+        record_user_model_gateway_result(
+            model_id,
+            success=dispatch_success,
+        )
+    except Exception:
+        # Deleting or renaming the live model never invalidates frozen billing.
+        logger.warning(
+            "user_model_dispatch_result_failed authorization_id=%s model_id=%s",
+            authorization.id,
+            model_id,
+            exc_info=True,
+        )
 
 
 def _already_settled_gateway_data(authorization: Any) -> dict[str, Any]:
@@ -2070,35 +2292,63 @@ def _user_model_gateway_candidate(
     record, so this pair exists only inside the authorization response; the
     enclave resolves the actual owner dispatch block separately.
     """
-    model = Model(
-        id=user_model.id,
-        name=user_model.name,
-        provider="trustedrouter",
-        context_length=1_000_000,
-        upstream_id=user_model.upstream_model_id,
-        prepaid_available=True,
-        byok_available=False,
-        prompt_price_microdollars_per_million_tokens=(
-            user_model.prompt_price_microdollars_per_million_tokens
-        ),
-        completion_price_microdollars_per_million_tokens=(
-            user_model.completion_price_microdollars_per_million_tokens
-        ),
-    )
-    endpoint = ModelEndpoint(
-        id=f"{user_model.id}@trustedrouter/credits",
+    return user_model_gateway_pair(
         model_id=user_model.id,
-        provider="trustedrouter",
-        usage_type="Credits",
-        upstream_id=user_model.upstream_model_id,
-        prompt_price_microdollars_per_million_tokens=(
+        name=user_model.name,
+        revision=user_model.revision,
+        prompt_price_microdollars_per_m=(
             user_model.prompt_price_microdollars_per_million_tokens
         ),
-        completion_price_microdollars_per_million_tokens=(
+        completion_price_microdollars_per_m=(
             user_model.completion_price_microdollars_per_million_tokens
         ),
+        owner_user_id=user_model.owner_user_id,
+        upstream_model_id=user_model.upstream_model_id,
     )
-    return model, endpoint
+
+
+def _authorized_user_model_pair(
+    authorization: Any,
+) -> tuple[Model, ModelEndpoint] | None:
+    """Rebuild a user-model sentinel only from authorization-frozen money facts.
+
+    The live model is consulted solely for a display name. Its deletion,
+    revision, prices, owner, endpoint, and secret material have no authority
+    over settlement.
+    """
+    model_id = authorization.user_provided_model_id
+    if not model_id:
+        return None
+    name = model_id
+    try:
+        live_model = STORE.get_user_model(model_id)
+    except Exception:
+        live_model = None
+    if live_model is not None:
+        name = live_model.name
+    revision = authorization.user_provided_model_revision
+    prompt_price = authorization.user_model_prompt_price_microdollars_per_m
+    completion_price = authorization.user_model_completion_price_microdollars_per_m
+    owner_user_id = authorization.user_model_owner_user_id
+    if (
+        revision is None
+        or prompt_price is None
+        or completion_price is None
+        or not owner_user_id
+    ):
+        return None
+    try:
+        return user_model_gateway_pair(
+            model_id=model_id,
+            name=name,
+            revision=int(revision),
+            prompt_price_microdollars_per_m=int(prompt_price),
+            completion_price_microdollars_per_m=int(completion_price),
+            owner_user_id=owner_user_id,
+            upstream_model_id=model_id,
+        )
+    except (TypeError, ValueError):
+        return None
 
 
 def _eligible_gateway_endpoint_candidates(
@@ -2125,6 +2375,14 @@ def _get_byok_provider(workspace_id: str, provider: str) -> Any | None:
 def _select_authorized_endpoint(
     authorization: Any, body: GatewaySettleRequest
 ) -> ModelEndpoint | None:
+    user_model_pair = _authorized_user_model_pair(authorization)
+    if user_model_pair is not None:
+        frozen_model, frozen_endpoint = user_model_pair
+        if body.selected_endpoint_id not in {None, frozen_endpoint.id}:
+            return None
+        if body.selected_model_id not in {None, frozen_model.id}:
+            return None
+        return frozen_endpoint
     authorized_endpoint_ids = authorization.candidate_endpoint_ids or []
     if not authorized_endpoint_ids and authorization.endpoint_id:
         authorized_endpoint_ids = [authorization.endpoint_id]
@@ -2338,7 +2596,11 @@ def _require_native_batch_route_binding(
 
 
 def _authorization_ttl_seconds(route_type: str | None) -> int:
-    return 26 * 60 * 60 if _is_native_batch_route(route_type) else 7200
+    return (
+        26 * 60 * 60
+        if _is_native_batch_route(route_type)
+        else GATEWAY_RESERVATION_TTL_SECONDS
+    )
 
 
 def _native_batch_cost_or_error(

--- a/src/trusted_router/services/safe_egress.py
+++ b/src/trusted_router/services/safe_egress.py
@@ -23,7 +23,12 @@ def is_safe_public_ip(ip_str: str) -> bool:
         return False
     if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
         return is_safe_public_ip(str(ip.ipv4_mapped))
-    return not (
+    # `is_global` is the IANA special-purpose-registry-aware check: it is
+    # False for shared address space (CGNAT 100.64.0.0/10 — never
+    # internet-routable, used INSIDE clouds for internal services), which the
+    # explicit predicates below miss. Keep them anyway: they are the
+    # documented rule, and the enclave's Go guard enumerates the same ranges.
+    return ip.is_global and not (
         ip.is_loopback
         or ip.is_private
         or ip.is_link_local

--- a/src/trusted_router/services/settle_outbox_apply.py
+++ b/src/trusted_router/services/settle_outbox_apply.py
@@ -10,6 +10,12 @@ from pydantic import ValidationError
 
 from trusted_router.catalog import PROVIDERS, endpoint_for_id
 from trusted_router.catalog_data import PARASAIL_LIBERTY_2_0_MODEL_ID
+from trusted_router.custom_model_billing import (
+    USER_MODEL_ID_SETTLE_FIELD,
+    USER_MODEL_OWNER_SETTLE_FIELD,
+    USER_MODEL_PAYOUT_SETTLE_FIELD,
+    user_model_payout_event_id,
+)
 from trusted_router.partner_billing import PARTNER_OPERATOR_COST_SETTLE_FIELD
 from trusted_router.schemas import GatewaySettleRequest
 from trusted_router.storage import STORE, Generation, typed_billing_store
@@ -19,7 +25,11 @@ from trusted_router.storage_gcp_codec import (
     generation_workspace_id as _generation_workspace_id,
 )
 from trusted_router.storage_gcp_codec import json_body as _json_body
-from trusted_router.storage_models import GatewayAuthorization, SettleOutboxRow
+from trusted_router.storage_models import (
+    GatewayAuthorization,
+    SettleOutboxRow,
+    UserModelPayout,
+)
 from trusted_router.types import UsageType
 
 logger = logging.getLogger(__name__)
@@ -126,11 +136,20 @@ def apply_frozen_settle(row: SettleOutboxRow) -> str:
     # authority; this pre-read is only for body construction and is TOCTOU-prone.
     usage_type = UsageType.coerce(row.selected_usage_type)
     operator_cost_raw = body_dict.pop(PARTNER_OPERATOR_COST_SETTLE_FIELD, None)
+    payout_raw = body_dict.pop(USER_MODEL_PAYOUT_SETTLE_FIELD, None)
+    owner_raw = body_dict.pop(USER_MODEL_OWNER_SETTLE_FIELD, None)
+    model_raw = body_dict.pop(USER_MODEL_ID_SETTLE_FIELD, None)
     try:
         operator_cost = (
             _operator_cost_microdollars(operator_cost_raw)
             if operator_cost_raw is not None
             else None
+        )
+        user_model_payout = _frozen_user_model_payout(
+            auth,
+            amount=payout_raw,
+            owner_user_id=owner_raw,
+            model_id=model_raw,
         )
         generation = (
             _frozen_generation(
@@ -150,9 +169,22 @@ def apply_frozen_settle(row: SettleOutboxRow) -> str:
         return ApplyOutcome.INVALID_ROW
 
     if row.settle_origin == "typed":
-        return _apply_typed(row, auth, success, usage_type, generation)
+        return _apply_typed(
+            row,
+            auth,
+            success,
+            usage_type,
+            generation,
+            user_model_payout,
+        )
     if row.settle_origin == "legacy":
-        return _apply_legacy(row, success, usage_type, generation)
+        return _apply_legacy(
+            row,
+            success,
+            usage_type,
+            generation,
+            user_model_payout,
+        )
     return ApplyOutcome.INVALID_ROW
 
 
@@ -205,6 +237,32 @@ def _operator_cost_microdollars(value: Any) -> int:
     return value
 
 
+def _frozen_user_model_payout(
+    auth: GatewayAuthorization,
+    *,
+    amount: Any,
+    owner_user_id: Any,
+    model_id: Any,
+) -> UserModelPayout | None:
+    fields = (amount, owner_user_id, model_id)
+    if fields == (None, None, None):
+        return None
+    if isinstance(amount, bool) or not isinstance(amount, int) or amount < 0:
+        raise ValueError("invalid frozen user-model payout")
+    if not isinstance(owner_user_id, str) or not owner_user_id.strip():
+        raise ValueError("invalid frozen user-model owner")
+    if not isinstance(model_id, str) or not model_id.strip():
+        raise ValueError("invalid frozen user-model id")
+    if not auth.workspace_id:
+        raise ValueError("invalid payout workspace")
+    return UserModelPayout(
+        owner_user_id=owner_user_id,
+        model_id=model_id,
+        amount_microdollars=amount,
+        payer_workspace_id=auth.workspace_id,
+    )
+
+
 def _provider_slug(endpoint_id: str | None) -> str:
     endpoint = endpoint_for_id(endpoint_id)
     if endpoint is not None:
@@ -226,6 +284,7 @@ def _apply_typed(
     success: bool,
     usage_type: UsageType,
     generation: Generation | None,
+    user_model_payout: UserModelPayout | None,
 ) -> str:
     typed_store = typed_billing_store()
     if typed_store is None:
@@ -264,6 +323,7 @@ def _apply_typed(
             auth_body_settled=_json_body(auth_settled),
             generation_writes=generation_writes,
             generation=generation,
+            user_model_payout=user_model_payout,
         )
     except _TRANSIENT_STORE_EXCS:
         return ApplyOutcome.PARK_TYPED_UNAVAILABLE
@@ -333,6 +393,7 @@ def _apply_legacy(
     success: bool,
     usage_type: UsageType,
     generation: Generation | None,
+    user_model_payout: UserModelPayout | None,
 ) -> str:
     try:
         finalized = STORE.finalize_gateway_authorization(
@@ -347,6 +408,22 @@ def _apply_legacy(
     except _TRANSIENT_STORE_EXCS:
         return ApplyOutcome.ERROR
     if finalized:
+        if success and user_model_payout is not None and user_model_payout.amount_microdollars > 0:
+            try:
+                STORE.credit_user_earnings(
+                    user_model_payout.owner_user_id,
+                    user_model_payout.amount_microdollars,
+                    user_model_payout_event_id(row.authorization_id),
+                    custom_model_id=user_model_payout.model_id,
+                    payer_workspace_id=user_model_payout.payer_workspace_id,
+                )
+            except Exception:
+                logger.error(
+                    "user_model_payout_failed authorization_id=%s owner=%s",
+                    row.authorization_id,
+                    user_model_payout.owner_user_id,
+                    exc_info=True,
+                )
         return ApplyOutcome.SETTLED_NOW
     # Legacy free releases do exist (inline refund/failure-settle). Only the
     # typed origin can disambiguate via the reservation's actual_micro.

--- a/src/trusted_router/services/settle_outbox_apply.py
+++ b/src/trusted_router/services/settle_outbox_apply.py
@@ -169,7 +169,7 @@ def apply_frozen_settle(row: SettleOutboxRow) -> str:
         return ApplyOutcome.INVALID_ROW
 
     if row.settle_origin == "typed":
-        return _apply_typed(
+        outcome = _apply_typed(
             row,
             auth,
             success,
@@ -177,15 +177,39 @@ def apply_frozen_settle(row: SettleOutboxRow) -> str:
             generation,
             user_model_payout,
         )
-    if row.settle_origin == "legacy":
-        return _apply_legacy(
+    elif row.settle_origin == "legacy":
+        outcome = _apply_legacy(
             row,
             success,
             usage_type,
             generation,
             user_model_payout,
         )
-    return ApplyOutcome.INVALID_ROW
+    else:
+        return ApplyOutcome.INVALID_ROW
+    # The inline settle releases the user-model concurrency slot after it
+    # finalizes; when the inline attempt died before that (this row exists
+    # because it did), the repair is the only thing left that can. Releasing
+    # is idempotent and independent of the money outcome, so do it for every
+    # terminal-or-already-terminal result rather than leaving the model at
+    # capacity until the slot's ttl.
+    _release_user_model_slot_safely(auth)
+    return outcome
+
+
+def _release_user_model_slot_safely(auth: GatewayAuthorization) -> None:
+    model_id = auth.user_provided_model_id
+    if not model_id:
+        return
+    try:
+        STORE.release_user_model_slot(model_id, auth.id)
+    except Exception:
+        logger.warning(
+            "user_model_slot_release_failed authorization_id=%s model_id=%s",
+            auth.id,
+            model_id,
+            exc_info=True,
+        )
 
 
 def _parse_settle_body(raw: str | None) -> dict[str, Any] | None:

--- a/src/trusted_router/services/user_model_dispatch.py
+++ b/src/trusted_router/services/user_model_dispatch.py
@@ -23,7 +23,12 @@ from trusted_router.services.user_model_secrets import (
 from trusted_router.storage import STORE
 from trusted_router.storage_models import UserProvidedModel
 from trusted_router.types import ErrorType
-from trusted_router.user_model_rules import DispatchBudget, dispatch_budget, sign_request_body
+from trusted_router.user_model_rules import (
+    DispatchBudget,
+    dispatch_budget,
+    is_owner_fault,
+    sign_request_body,
+)
 
 _KEEPALIVE_SECONDS = 15.0
 
@@ -55,20 +60,36 @@ async def dispatch_user_model(
             transport=transport,
         )
     except (TimeoutError, httpx.TimeoutException) as exc:
-        STORE.record_user_model_dispatch_result(model.id, success=False)
+        _record_dispatch_evidence(
+            model,
+            error_status=504,
+            error_type=ErrorType.USER_MODEL_TIMEOUT,
+        )
         raise _timeout_error(model) from exc
     except _MalformedOwnerResponse as exc:
-        STORE.record_user_model_dispatch_result(model.id, success=False)
+        _record_dispatch_evidence(
+            model,
+            error_status=502,
+            error_type="malformed_response",
+        )
         raise _malformed_error(model) from exc
     except _OwnerFault as exc:
-        STORE.record_user_model_dispatch_result(model.id, success=False)
+        _record_dispatch_evidence(
+            model,
+            error_status=exc.error.status_code,
+            error_type=ErrorType.PROVIDER_ERROR,
+        )
         raise exc.error from exc
     except httpx.HTTPError as exc:
-        STORE.record_user_model_dispatch_result(model.id, success=False)
+        _record_dispatch_evidence(
+            model,
+            error_status=502,
+            error_type="connection_error",
+        )
         raise _upstream_error(model) from exc
     # Anything else (owner 4xx, TR-side errors, cancellation) is not evidence
     # about the endpoint's health: neither a strike nor a reset.
-    STORE.record_user_model_dispatch_result(model.id, success=True)
+    _record_dispatch_evidence(model, success=True)
     return result
 
 
@@ -87,6 +108,7 @@ async def stream_user_model(
     otherwise three impatient callers clock a healthy human out.
     """
     outcome: bool | None = None  # None = no evidence either way
+    owner_fault: tuple[int, str] | None = None
     try:
         async for chunk in _stream_user_model(
             model,
@@ -98,14 +120,17 @@ async def stream_user_model(
         outcome = True
     except (TimeoutError, httpx.TimeoutException):
         outcome = False
+        owner_fault = (504, str(ErrorType.USER_MODEL_TIMEOUT))
         yield _sse_error(_timeout_error(model))
         yield b"data: [DONE]\n\n"
     except _OwnerFault as exc:
         outcome = False
+        owner_fault = (exc.error.status_code, str(ErrorType.PROVIDER_ERROR))
         yield _sse_error(exc.error)
         yield b"data: [DONE]\n\n"
     except _MalformedOwnerResponse:
         outcome = False
+        owner_fault = (502, "malformed_response")
         yield _sse_error(_malformed_error(model))
         yield b"data: [DONE]\n\n"
     except HTTPException as exc:
@@ -114,6 +139,7 @@ async def stream_user_model(
         yield b"data: [DONE]\n\n"
     except httpx.HTTPError:
         outcome = False
+        owner_fault = (502, "connection_error")
         yield _sse_error(_upstream_error(model))
         yield b"data: [DONE]\n\n"
     except Exception:
@@ -122,8 +148,14 @@ async def stream_user_model(
         yield _sse_error(_malformed_error(model))
         yield b"data: [DONE]\n\n"
     finally:
-        if outcome is not None:
-            STORE.record_user_model_dispatch_result(model.id, success=outcome)
+        if outcome is True:
+            _record_dispatch_evidence(model, success=True)
+        elif owner_fault is not None:
+            _record_dispatch_evidence(
+                model,
+                error_status=owner_fault[0],
+                error_type=owner_fault[1],
+            )
 
 
 async def _dispatch_user_model(
@@ -601,9 +633,22 @@ def _require_success(response: httpx.Response, model: UserProvidedModel) -> None
         f" (HTTP {response.status_code})",
         ErrorType.PROVIDER_ERROR,
     )
-    if response.status_code >= 500:
+    if is_owner_fault(response.status_code, None):
         raise _OwnerFault(error)
     raise error
+
+
+def _record_dispatch_evidence(
+    model: UserProvidedModel,
+    *,
+    success: bool = False,
+    error_status: int | None = None,
+    error_type: str | ErrorType | None = None,
+) -> None:
+    if success:
+        STORE.record_user_model_dispatch_result(model.id, success=True)
+    elif is_owner_fault(error_status, str(error_type) if error_type is not None else None):
+        STORE.record_user_model_dispatch_result(model.id, success=False)
 
 
 def _timeout_error(model: UserProvidedModel) -> HTTPException:

--- a/src/trusted_router/services/user_model_dispatch.py
+++ b/src/trusted_router/services/user_model_dispatch.py
@@ -481,9 +481,14 @@ def _parse_stream_chunk(payload: bytes) -> dict[str, Any]:
         not isinstance(chunk, dict)
         or chunk.get("object") != "chat.completion.chunk"
         or not isinstance(choices, list)
-        or not choices
-        or not isinstance(choices[0], dict)
-        or not isinstance(choices[0].get("delta"), dict)
+    ):
+        raise _MalformedOwnerResponse("invalid owner SSE chunk")
+    # `choices: []` is the spec-conforming usage-only final chunk emitted when
+    # the caller asked for stream_options.include_usage (OpenAI, vLLM). It is
+    # not malformed — treating it so refunded a fully served answer and struck
+    # a healthy owner. Any non-empty choice must still carry a delta object.
+    if choices and (
+        not isinstance(choices[0], dict) or not isinstance(choices[0].get("delta"), dict)
     ):
         raise _MalformedOwnerResponse("invalid owner SSE chunk")
     return chunk
@@ -510,6 +515,10 @@ def _aggregate_owner_sse(raw: bytes, *, requested_model_id: str) -> dict[str, An
         saw_chunk = True
         request_id = str(chunk.get("id") or request_id)
         created = int(chunk.get("created") or created)
+        if isinstance(chunk.get("usage"), dict):
+            usage = chunk["usage"]
+        if not chunk["choices"]:
+            continue  # usage-only final chunk
         choice = chunk["choices"][0]
         delta = choice["delta"]
         if isinstance(delta.get("role"), str):
@@ -518,8 +527,6 @@ def _aggregate_owner_sse(raw: bytes, *, requested_model_id: str) -> dict[str, An
             content.append(delta["content"])
         if choice.get("finish_reason") is not None:
             finish_reason = str(choice["finish_reason"])
-        if isinstance(chunk.get("usage"), dict):
-            usage = chunk["usage"]
     if not saw_chunk or not saw_done:
         raise _MalformedOwnerResponse("owner stream was incomplete")
     result: dict[str, Any] = {

--- a/src/trusted_router/services/user_model_gateway_health.py
+++ b/src/trusted_router/services/user_model_gateway_health.py
@@ -1,0 +1,10 @@
+"""Gateway-side health evidence for gated user-model dispatch."""
+
+from __future__ import annotations
+
+from trusted_router.storage import STORE
+
+
+def record_user_model_gateway_result(model_id: str, *, success: bool) -> None:
+    """Persist one production dispatch result after a winning finalize."""
+    STORE.record_user_model_dispatch_result(model_id, success=success)

--- a/src/trusted_router/services/user_model_slots.py
+++ b/src/trusted_router/services/user_model_slots.py
@@ -1,0 +1,18 @@
+"""Control-plane concurrency slots for gated user-model dispatch."""
+
+from __future__ import annotations
+
+from trusted_router.storage import STORE
+
+
+def acquire_user_model_slot(
+    model_id: str,
+    authorization_id: str,
+    *,
+    limit: int,
+) -> bool:
+    return STORE.acquire_user_model_slot(model_id, authorization_id, limit=limit)
+
+
+def release_user_model_slot(model_id: str, authorization_id: str) -> None:
+    STORE.release_user_model_slot(model_id, authorization_id)

--- a/src/trusted_router/services/user_model_slots.py
+++ b/src/trusted_router/services/user_model_slots.py
@@ -3,6 +3,15 @@
 from __future__ import annotations
 
 from trusted_router.storage import STORE
+from trusted_router.user_model_rules import dispatch_budget
+
+# Grace on top of the kind's total dispatch budget before an unreleased slot
+# (enclave died between authorize and settle) stops counting.
+SLOT_GRACE_SECONDS = 120
+
+
+def slot_ttl_seconds(kind: str) -> int:
+    return dispatch_budget(kind).total + SLOT_GRACE_SECONDS
 
 
 def acquire_user_model_slot(
@@ -10,8 +19,14 @@ def acquire_user_model_slot(
     authorization_id: str,
     *,
     limit: int,
+    kind: str,
 ) -> bool:
-    return STORE.acquire_user_model_slot(model_id, authorization_id, limit=limit)
+    return STORE.acquire_user_model_slot(
+        model_id,
+        authorization_id,
+        limit=limit,
+        ttl_seconds=slot_ttl_seconds(kind),
+    )
 
 
 def release_user_model_slot(model_id: str, authorization_id: str) -> None:

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -958,11 +958,13 @@ class InMemoryStore:
         authorization_id: str,
         *,
         limit: int,
+        ttl_seconds: int,
     ) -> bool:
         return self.user_model_store.acquire_slot(
             model_id,
             authorization_id,
             limit=limit,
+            ttl_seconds=ttl_seconds,
         )
 
     def release_user_model_slot(self, model_id: str, authorization_id: str) -> None:

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -952,6 +952,22 @@ class InMemoryStore:
     ) -> UserProvidedModel:
         return self.user_model_store.record_dispatch_result(model_id, success=success)
 
+    def acquire_user_model_slot(
+        self,
+        model_id: str,
+        authorization_id: str,
+        *,
+        limit: int,
+    ) -> bool:
+        return self.user_model_store.acquire_slot(
+            model_id,
+            authorization_id,
+            limit=limit,
+        )
+
+    def release_user_model_slot(self, model_id: str, authorization_id: str) -> None:
+        self.user_model_store.release_slot(model_id, authorization_id)
+
     def list_public_user_models(
         self,
         *,
@@ -1647,6 +1663,7 @@ class InMemoryStore:
         usage_type: UsageType | str,
         estimated_microdollars: int,
         credit_reservation_id: str | None,
+        authorization_id: str | None = None,
         requested_model_id: str | None = None,
         candidate_model_ids: list[str] | None = None,
         region: str | None = None,
@@ -1676,6 +1693,7 @@ class InMemoryStore:
             usage_type=usage_type,
             estimated_microdollars=estimated_microdollars,
             credit_reservation_id=credit_reservation_id,
+            authorization_id=authorization_id,
             requested_model_id=requested_model_id,
             candidate_model_ids=candidate_model_ids,
             region=region,

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -133,6 +133,7 @@ from trusted_router.storage_models import (
     BedrockGroupBuyPublicMessage,
     CreditMovement,
     TypedFinalizeResult,
+    UserModelPayout,
 )
 from trusted_router.types import IdentityVerificationStatus, UsageType
 
@@ -344,6 +345,7 @@ class SpannerBigtableStore:
         io = SpannerIO(
             database=self._database,
             spanner_module=self._spanner,
+            param_types=self._param_types,
             write_entity_batch=self._write_entity_batch,
             read_entity_tx=self._read_entity_tx,
             write_entity_tx=self._write_entity_tx,
@@ -1382,6 +1384,22 @@ class SpannerBigtableStore:
     ) -> UserProvidedModel:
         return self.user_model_store.record_dispatch_result(model_id, success=success)
 
+    def acquire_user_model_slot(
+        self,
+        model_id: str,
+        authorization_id: str,
+        *,
+        limit: int,
+    ) -> bool:
+        return self.user_model_store.acquire_slot(
+            model_id,
+            authorization_id,
+            limit=limit,
+        )
+
+    def release_user_model_slot(self, model_id: str, authorization_id: str) -> None:
+        self.user_model_store.release_slot(model_id, authorization_id)
+
     def list_public_user_models(
         self,
         *,
@@ -2158,6 +2176,7 @@ class SpannerBigtableStore:
         usage_type: UsageType | str,
         estimated_microdollars: int,
         credit_reservation_id: str | None,
+        authorization_id: str | None = None,
         requested_model_id: str | None = None,
         candidate_model_ids: list[str] | None = None,
         region: str | None = None,
@@ -2187,6 +2206,7 @@ class SpannerBigtableStore:
             usage_type=usage_type,
             estimated_microdollars=estimated_microdollars,
             credit_reservation_id=credit_reservation_id,
+            authorization_id=authorization_id,
             requested_model_id=requested_model_id,
             candidate_model_ids=candidate_model_ids,
             region=region,
@@ -2274,6 +2294,7 @@ class SpannerBigtableStore:
         actual_microdollars: int,
         selected_usage_type: UsageType | str,
         generation: Generation | None = None,
+        user_model_payout: UserModelPayout | None = None,
     ) -> bool:
         return self.typed_finalize_gateway_authorization_result(
             authorization_id,
@@ -2281,6 +2302,7 @@ class SpannerBigtableStore:
             actual_microdollars=actual_microdollars,
             selected_usage_type=selected_usage_type,
             generation=generation,
+            user_model_payout=user_model_payout,
         ).finalized
 
     def typed_finalize_gateway_authorization_result(
@@ -2291,6 +2313,7 @@ class SpannerBigtableStore:
         actual_microdollars: int,
         selected_usage_type: UsageType | str,
         generation: Generation | None = None,
+        user_model_payout: UserModelPayout | None = None,
     ) -> TypedFinalizeResult:
         """Route-facing typed settle: same contract as
         finalize_gateway_authorization, with explicit activity-index status.
@@ -2345,6 +2368,7 @@ class SpannerBigtableStore:
                 "_operational_analytics_outbox",
                 None,
             ),
+            user_model_payout=user_model_payout,
         )
         spanner_ms = (time.perf_counter() - spanner_start) * 1000
         if result["outcome"] == SettleOutcome.ERROR:
@@ -2390,6 +2414,7 @@ class SpannerBigtableStore:
         *,
         workspace_id: str,
         key_hash: str,
+        authorization_id: str | None = None,
         estimate: int,
         has_credit_candidate: bool,
         reservation_usage_type: UsageType | str,
@@ -2519,6 +2544,7 @@ class SpannerBigtableStore:
                 request_record_write_mode=self.request_record_write_mode,
                 credit_shard_candidates=candidates,
                 key_shard_candidates=key_shard_candidates,
+                authorization_id=authorization_id,
             )
 
         result = run_authorize(credit_shard_candidates)

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -1390,11 +1390,13 @@ class SpannerBigtableStore:
         authorization_id: str,
         *,
         limit: int,
+        ttl_seconds: int,
     ) -> bool:
         return self.user_model_store.acquire_slot(
             model_id,
             authorization_id,
             limit=limit,
+            ttl_seconds=ttl_seconds,
         )
 
     def release_user_model_slot(self, model_id: str, authorization_id: str) -> None:

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -814,23 +814,22 @@ def typed_finalize_atomic(
                 raise _SettleError("credit release row-count != 1")
 
         if success and user_model_payout is not None and user_model_payout.amount_microdollars > 0:
-            try:
-                _apply_user_model_payout_tx(
-                    transaction,
-                    pt,
-                    authorization_id=authorization_id,
-                    payout=user_model_payout,
-                )
-            except Exception:
-                # The customer reservation claim remains authoritative. A
-                # missing owner payout is repairable from generation metadata;
-                # a rolled-back customer finalize would strand their hold.
-                log.error(
-                    "user_model_payout_failed authorization_id=%s owner=%s",
-                    authorization_id,
-                    user_model_payout.owner_user_id,
-                    exc_info=True,
-                )
+            # Deliberately NOT wrapped in a swallow. The payout is two DML
+            # statements in this same transaction; a failure between them
+            # would otherwise commit the movement row without the balance
+            # bump (or the reverse), and every later replay would read the
+            # row as "already paid" — a permanent, silent underpayment. An
+            # exception here aborts the whole finalize: transient errors are
+            # retried by run_in_transaction_with_retry, and a deterministic
+            # one (schema drift) fails the settle LOUDLY, which the outbox
+            # repair/drain surfaces, instead of quietly not paying owners.
+            _apply_user_model_payout_tx(
+                transaction,
+                pt,
+                authorization_id=authorization_id,
+                payout=user_model_payout,
+                now=now,
+            )
 
         marked = 0
         request_record_typed = False
@@ -906,15 +905,21 @@ def _apply_user_model_payout_tx(
     *,
     authorization_id: str,
     payout: UserModelPayout,
+    now: Any,
 ) -> None:
     """Credit one owner payout inside the customer finalize transaction.
 
     The reservation claim is the primary exactly-once guard; the movement PK
-    (`account_id`, deterministic payout event id) is the secondary guard. A
-    duplicate movement therefore skips the balance increment. Payout failure
-    must never abort the customer settle: Phase 7 reconciliation can recover a
-    missing payout from generations carrying ``custom_model_id``, while an
-    aborted customer finalize can strand the payer's reservation.
+    (`account_id`, deterministic payout event id) is the secondary guard, so
+    a duplicate movement skips the balance increment. Both statements live in
+    the caller's transaction and either both commit or neither does — see the
+    call site for why a failure here is allowed to abort the finalize.
+
+    ``created_at`` is a client timestamp on purpose: tr_credit_movement was
+    created WITHOUT ``allow_commit_timestamp`` (migrate_money_primitives.sh),
+    and Spanner rejects PENDING_COMMIT_TIMESTAMP() into such a column
+    (FAILED_PRECONDITION). Phase 1's credit_user_earnings writes it the same
+    way; only tr_earnings_balance.updated_at is a commit-timestamp column.
     """
     pt = param_types
     movement_id = user_model_payout_event_id(authorization_id)
@@ -922,24 +927,27 @@ def _apply_user_model_payout_tx(
         "INSERT OR IGNORE INTO tr_credit_movement "
         "(account_id, movement_id, kind, amount_microdollars, "
         "counterparty_account_id, custom_model_id, authorization_id, created_at) "
-        "VALUES (@account_id, @movement_id, 'custom_model_payout', @amount, "
-        "@payer_workspace_id, @custom_model_id, @authorization_id, "
-        "PENDING_COMMIT_TIMESTAMP())",
+        "VALUES (@account_id, @movement_id, @kind, @amount, "
+        "@counterparty, @custom_model_id, @authorization_id, @created_at)",
         params={
             "account_id": f"user:{payout.owner_user_id}",
             "movement_id": movement_id,
+            "kind": "custom_model_payout",
             "amount": payout.amount_microdollars,
-            "payer_workspace_id": payout.payer_workspace_id,
+            "counterparty": payout.payer_workspace_id,
             "custom_model_id": payout.model_id,
             "authorization_id": authorization_id,
+            "created_at": now,
         },
         param_types={
             "account_id": pt.STRING,
             "movement_id": pt.STRING,
+            "kind": pt.STRING,
             "amount": pt.INT64,
-            "payer_workspace_id": pt.STRING,
+            "counterparty": pt.STRING,
             "custom_model_id": pt.STRING,
             "authorization_id": pt.STRING,
+            "created_at": pt.TIMESTAMP,
         },
     )
     if inserted == 0:

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -29,6 +29,7 @@ from typing import Any
 
 from google.api_core.exceptions import AlreadyExists
 
+from trusted_router.custom_model_billing import user_model_payout_event_id
 from trusted_router.spend_windows import utcnow, window_floors
 from trusted_router.storage_gcp_counter_dml import (
     KEY_ACCEPTED,
@@ -50,7 +51,7 @@ from trusted_router.storage_gcp_request_records import (
     mark_gateway_authorization_settled,
 )
 from trusted_router.storage_gcp_settle_outbox import _GUARD_STATUS_SQL, GUARD_COUNT_SQL
-from trusted_router.storage_models import GatewayAuthorization, Generation
+from trusted_router.storage_models import GatewayAuthorization, Generation, UserModelPayout
 
 log = logging.getLogger(__name__)
 
@@ -173,6 +174,7 @@ def authorize_atomic(
     credit_shard: int = UNSHARDED,
     credit_shard_candidates: tuple[int, ...] | None = None,
     key_shard_candidates: tuple[int, ...] = (UNSHARDED,),
+    authorization_id: str | None = None,
 ) -> dict:
     """Run the atomic authorize. Returns {outcome, reservation_id?, authorization_id?}.
 
@@ -224,7 +226,7 @@ def authorize_atomic(
     is_byok = not has_credit_candidate
     # Stable ids across ABORTED retries (only the committed attempt persists).
     reservation_id = str(uuid.uuid4())
-    authorization_id = f"gwa-{uuid.uuid4().hex}"
+    authorization_id = authorization_id or f"gwa-{uuid.uuid4().hex}"
     created_at = utcnow()
     authorization = (
         build_authorization(authorization_id, reservation_id)
@@ -744,6 +746,7 @@ def typed_finalize_atomic(
     generation: Generation | None = None,
     persist_generation_record: bool = False,
     operational_analytics_outbox: Any | None = None,
+    user_model_payout: UserModelPayout | None = None,
 ) -> dict:
     """Full DML-only finalize for the typed path (codex 3e, Option B).
 
@@ -809,6 +812,25 @@ def typed_finalize_atomic(
             )
             if credit_count != 1:
                 raise _SettleError("credit release row-count != 1")
+
+        if success and user_model_payout is not None and user_model_payout.amount_microdollars > 0:
+            try:
+                _apply_user_model_payout_tx(
+                    transaction,
+                    pt,
+                    authorization_id=authorization_id,
+                    payout=user_model_payout,
+                )
+            except Exception:
+                # The customer reservation claim remains authoritative. A
+                # missing owner payout is repairable from generation metadata;
+                # a rolled-back customer finalize would strand their hold.
+                log.error(
+                    "user_model_payout_failed authorization_id=%s owner=%s",
+                    authorization_id,
+                    user_model_payout.owner_user_id,
+                    exc_info=True,
+                )
 
         marked = 0
         request_record_typed = False
@@ -876,3 +898,65 @@ def typed_finalize_atomic(
         return result
     except _SettleError:
         return {"outcome": SettleOutcome.ERROR}
+
+
+def _apply_user_model_payout_tx(
+    transaction: Any,
+    param_types: Any,
+    *,
+    authorization_id: str,
+    payout: UserModelPayout,
+) -> None:
+    """Credit one owner payout inside the customer finalize transaction.
+
+    The reservation claim is the primary exactly-once guard; the movement PK
+    (`account_id`, deterministic payout event id) is the secondary guard. A
+    duplicate movement therefore skips the balance increment. Payout failure
+    must never abort the customer settle: Phase 7 reconciliation can recover a
+    missing payout from generations carrying ``custom_model_id``, while an
+    aborted customer finalize can strand the payer's reservation.
+    """
+    pt = param_types
+    movement_id = user_model_payout_event_id(authorization_id)
+    inserted = transaction.execute_update(
+        "INSERT OR IGNORE INTO tr_credit_movement "
+        "(account_id, movement_id, kind, amount_microdollars, "
+        "counterparty_account_id, custom_model_id, authorization_id, created_at) "
+        "VALUES (@account_id, @movement_id, 'custom_model_payout', @amount, "
+        "@payer_workspace_id, @custom_model_id, @authorization_id, "
+        "PENDING_COMMIT_TIMESTAMP())",
+        params={
+            "account_id": f"user:{payout.owner_user_id}",
+            "movement_id": movement_id,
+            "amount": payout.amount_microdollars,
+            "payer_workspace_id": payout.payer_workspace_id,
+            "custom_model_id": payout.model_id,
+            "authorization_id": authorization_id,
+        },
+        param_types={
+            "account_id": pt.STRING,
+            "movement_id": pt.STRING,
+            "amount": pt.INT64,
+            "payer_workspace_id": pt.STRING,
+            "custom_model_id": pt.STRING,
+            "authorization_id": pt.STRING,
+        },
+    )
+    if inserted == 0:
+        return
+    updated = transaction.execute_update(
+        "UPDATE tr_earnings_balance "
+        "SET total_earned = total_earned + @amount, "
+        "updated_at = PENDING_COMMIT_TIMESTAMP() "
+        "WHERE user_id=@user_id AND shard=0",
+        params={"amount": payout.amount_microdollars, "user_id": payout.owner_user_id},
+        param_types={"amount": pt.INT64, "user_id": pt.STRING},
+    )
+    if updated == 0:
+        transaction.execute_update(
+            "INSERT INTO tr_earnings_balance "
+            "(user_id, shard, total_earned, total_transferred, updated_at) "
+            "VALUES (@user_id, 0, @amount, 0, PENDING_COMMIT_TIMESTAMP())",
+            params={"user_id": payout.owner_user_id, "amount": payout.amount_microdollars},
+            param_types={"user_id": pt.STRING, "amount": pt.INT64},
+        )

--- a/src/trusted_router/storage_gcp_io.py
+++ b/src/trusted_router/storage_gcp_io.py
@@ -271,3 +271,6 @@ class SpannerIO:
     list_entities: Callable[..., list[Any]]
     delete_entities: Callable[[str, list[str]], None]
     delete_entities_tx: Callable[[Any, str, list[str]], None]
+    # Optional for feature adapters that never issue typed SQL. Production and
+    # the user-model slot adapter always provide the real param-types module.
+    param_types: Any = None

--- a/src/trusted_router/storage_gcp_keys.py
+++ b/src/trusted_router/storage_gcp_keys.py
@@ -295,6 +295,7 @@ class SpannerApiKeys:
         usage_type: UsageType | str,
         estimated_microdollars: int,
         credit_reservation_id: str | None,
+        authorization_id: str | None = None,
         requested_model_id: str | None = None,
         candidate_model_ids: list[str] | None = None,
         region: str | None = None,
@@ -335,7 +336,7 @@ class SpannerApiKeys:
         if existing is not None:
             return existing
         auth = GatewayAuthorization(
-            id=f"gwa-{uuid.uuid4().hex}",
+            id=authorization_id or f"gwa-{uuid.uuid4().hex}",
             workspace_id=workspace_id,
             key_hash=key_hash,
             model_id=model_id,

--- a/src/trusted_router/storage_gcp_user_models.py
+++ b/src/trusted_router/storage_gcp_user_models.py
@@ -290,12 +290,23 @@ class SpannerUserProvidedModels:
         authorization_id: str,
         *,
         limit: int,
+        ttl_seconds: int,
     ) -> bool:
+        """Admit one in-flight authorization if the model has capacity.
+
+        Each row carries its own ``expires_at`` (now + the kind's total
+        dispatch budget + grace, chosen by the caller). Rows past it are
+        swept on the next acquire for that model, so an enclave crash between
+        authorize and settle blacks a model out for at most one dispatch
+        budget, not a fixed multi-hour window. Legacy rows without
+        ``expires_at`` fall back to ``created_at`` + the reservation TTL.
+        """
         canonical = normalize_custom_model_id(model_id)
         slot_id = _user_model_slot_id(canonical, authorization_id)
         prefix = f"{canonical}#"
         now = dt.datetime.now(dt.UTC)
-        cutoff = now - dt.timedelta(seconds=GATEWAY_RESERVATION_TTL_SECONDS)
+        legacy_cutoff = now - dt.timedelta(seconds=GATEWAY_RESERVATION_TTL_SECONDS)
+        expires_at = now + dt.timedelta(seconds=max(1, ttl_seconds))
 
         def txn(transaction: Any) -> bool:
             rows = list(
@@ -316,12 +327,18 @@ class SpannerUserProvidedModels:
                     payload = json.loads(str(raw_body))
                     stored_authorization_id = str(payload["authorization_id"])
                     created_at = _parse_slot_time(str(payload["created_at"]))
+                    raw_expires = payload.get("expires_at")
+                    row_expires_at = (
+                        _parse_slot_time(str(raw_expires))
+                        if raw_expires
+                        else created_at + dt.timedelta(seconds=GATEWAY_RESERVATION_TTL_SECONDS)
+                    )
                 except (KeyError, TypeError, ValueError, json.JSONDecodeError):
                     # Malformed rows fail closed toward capacity until an
                     # operator repairs them; silently ignoring one overbooks.
                     live_authorizations.add(f"malformed:{len(live_authorizations)}")
                     continue
-                if created_at < cutoff:
+                if row_expires_at <= now or created_at < legacy_cutoff:
                     expired_ids.append(
                         _user_model_slot_id(canonical, stored_authorization_id)
                     )
@@ -345,6 +362,7 @@ class SpannerUserProvidedModels:
                     "model_id": canonical,
                     "authorization_id": authorization_id,
                     "created_at": now.isoformat().replace("+00:00", "Z"),
+                    "expires_at": expires_at.isoformat().replace("+00:00", "Z"),
                 },
             )
             return True

--- a/src/trusted_router/storage_gcp_user_models.py
+++ b/src/trusted_router/storage_gcp_user_models.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import datetime as dt
+import json
 import secrets
 from collections.abc import Callable
 from typing import Any
@@ -19,9 +21,11 @@ from trusted_router.storage_models import (
     iso_now,
 )
 from trusted_router.storage_user_models import USER_PROVIDED_MODEL_LIMIT_PER_USER
+from trusted_router.user_model_rules import GATEWAY_RESERVATION_TTL_SECONDS
 
 _CUSTOM_MODEL_KIND = "custom_model"
 _USER_PROVIDED_MODEL_KIND = "user_provided_model"
+_USER_MODEL_SLOT_KIND = "user_model_slot"
 _EDITABLE_FIELDS = (
     "name",
     "kind",
@@ -280,6 +284,79 @@ class SpannerUserProvidedModels:
 
         return self._mutate(model_id, mutate)
 
+    def acquire_slot(
+        self,
+        model_id: str,
+        authorization_id: str,
+        *,
+        limit: int,
+    ) -> bool:
+        canonical = normalize_custom_model_id(model_id)
+        slot_id = _user_model_slot_id(canonical, authorization_id)
+        prefix = f"{canonical}#"
+        now = dt.datetime.now(dt.UTC)
+        cutoff = now - dt.timedelta(seconds=GATEWAY_RESERVATION_TTL_SECONDS)
+
+        def txn(transaction: Any) -> bool:
+            rows = list(
+                transaction.execute_sql(
+                    "SELECT body FROM tr_entities "
+                    "WHERE kind=@kind AND STARTS_WITH(id, @prefix) ORDER BY id",
+                    params={"kind": _USER_MODEL_SLOT_KIND, "prefix": prefix},
+                    param_types={
+                        "kind": self._io.param_types.STRING,
+                        "prefix": self._io.param_types.STRING,
+                    },
+                )
+            )
+            live_authorizations: set[str] = set()
+            expired_ids: list[str] = []
+            for (raw_body,) in rows:
+                try:
+                    payload = json.loads(str(raw_body))
+                    stored_authorization_id = str(payload["authorization_id"])
+                    created_at = _parse_slot_time(str(payload["created_at"]))
+                except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+                    # Malformed rows fail closed toward capacity until an
+                    # operator repairs them; silently ignoring one overbooks.
+                    live_authorizations.add(f"malformed:{len(live_authorizations)}")
+                    continue
+                if created_at < cutoff:
+                    expired_ids.append(
+                        _user_model_slot_id(canonical, stored_authorization_id)
+                    )
+                else:
+                    live_authorizations.add(stored_authorization_id)
+            if expired_ids:
+                self._io.delete_entities_tx(
+                    transaction,
+                    _USER_MODEL_SLOT_KIND,
+                    expired_ids,
+                )
+            if authorization_id in live_authorizations:
+                return True
+            if limit <= 0 or len(live_authorizations) >= limit:
+                return False
+            self._io.write_entity_tx(
+                transaction,
+                _USER_MODEL_SLOT_KIND,
+                slot_id,
+                {
+                    "model_id": canonical,
+                    "authorization_id": authorization_id,
+                    "created_at": now.isoformat().replace("+00:00", "Z"),
+                },
+            )
+            return True
+
+        return run_in_transaction_with_retry(self._io.database, txn)
+
+    def release_slot(self, model_id: str, authorization_id: str) -> None:
+        self._io.delete_entities(
+            _USER_MODEL_SLOT_KIND,
+            [_user_model_slot_id(normalize_custom_model_id(model_id), authorization_id)],
+        )
+
     def list_public(self, *, kind: str | None = None) -> list[UserProvidedModel]:
         rows = self._io.list_entities(
             _USER_PROVIDED_MODEL_KIND,
@@ -383,3 +460,14 @@ class SpannerUserProvidedModels:
 
 def _user_model_id(owner_user_id: str, model_id: str) -> str:
     return f"{owner_user_id}#{model_id}"
+
+
+def _user_model_slot_id(model_id: str, authorization_id: str) -> str:
+    return f"{model_id}#{authorization_id}"
+
+
+def _parse_slot_time(value: str) -> dt.datetime:
+    parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed.astimezone(dt.UTC)

--- a/src/trusted_router/storage_keys.py
+++ b/src/trusted_router/storage_keys.py
@@ -388,6 +388,7 @@ class InMemoryApiKeys:
         usage_type: UsageType | str,
         estimated_microdollars: int,
         credit_reservation_id: str | None,
+        authorization_id: str | None = None,
         requested_model_id: str | None = None,
         candidate_model_ids: list[str] | None = None,
         region: str | None = None,
@@ -430,7 +431,7 @@ class InMemoryApiKeys:
                     )
                 self.deferred_outstanding[workspace_id] = held + estimated_microdollars
             authorization = GatewayAuthorization(
-                id=f"gwa-{uuid.uuid4().hex}",
+                id=authorization_id or f"gwa-{uuid.uuid4().hex}",
                 workspace_id=workspace_id,
                 key_hash=key_hash,
                 model_id=model_id,

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -589,6 +589,14 @@ class TypedFinalizeResult:
     request_record_typed: bool = False
 
 
+@dataclass(frozen=True)
+class UserModelPayout:
+    owner_user_id: str
+    model_id: str
+    amount_microdollars: int
+    payer_workspace_id: str
+
+
 @dataclass
 class Generation:
     id: str
@@ -626,6 +634,7 @@ class Generation:
     # Internal provider COGS for fixed-price orchestration leaves. This is
     # intentionally omitted from public generation/activity response shapes.
     operator_cost_microdollars: int | None = None
+    custom_model_id: str | None = None
     route_type: str | None = None
     video_input_mode: str | None = None
     video_duration_seconds: int | None = None
@@ -811,6 +820,7 @@ class Generation:
             app_categories=[str(item) for item in body.get("app_categories") or []],
             tags=dict(authorization.tags),
             operator_cost_microdollars=operator_cost_microdollars,
+            custom_model_id=authorization.user_provided_model_id,
             route_type=(str(body["route_type"]) if body.get("route_type") else None),
             video_input_mode=(
                 str(body["video_input_mode"]) if body.get("video_input_mode") else None

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -2182,6 +2182,7 @@ class PostgresStore:
         authorization_id: str,
         *,
         limit: int,
+        ttl_seconds: int,
     ) -> bool:
         self._not_implemented("acquire_user_model_slot")
 

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -2176,6 +2176,18 @@ class PostgresStore:
     ) -> UserProvidedModel:
         self._not_implemented("record_user_model_dispatch_result")
 
+    def acquire_user_model_slot(
+        self,
+        model_id: str,
+        authorization_id: str,
+        *,
+        limit: int,
+    ) -> bool:
+        self._not_implemented("acquire_user_model_slot")
+
+    def release_user_model_slot(self, model_id: str, authorization_id: str) -> None:
+        self._not_implemented("release_user_model_slot")
+
     def list_public_user_models(
         self,
         *,
@@ -3405,6 +3417,7 @@ class PostgresStore:
         usage_type: UsageType | str,
         estimated_microdollars: int,
         credit_reservation_id: str | None,
+        authorization_id: str | None = None,
         requested_model_id: str | None = None,
         candidate_model_ids: list[str] | None = None,
         region: str | None = None,
@@ -3447,7 +3460,7 @@ class PostgresStore:
         admit.
         """
         authorization = GatewayAuthorization(
-            id=f"gwauth_{uuid.uuid4().hex}",
+            id=authorization_id or f"gwauth_{uuid.uuid4().hex}",
             workspace_id=workspace_id,
             key_hash=key_hash,
             model_id=model_id,

--- a/src/trusted_router/storage_user_models.py
+++ b/src/trusted_router/storage_user_models.py
@@ -47,9 +47,11 @@ class InMemoryUserProvidedModels:
     def __init__(self, *, lock: threading.RLock) -> None:
         self._lock = lock
         self.models: dict[str, UserProvidedModel] = {}
+        self.slots: dict[str, set[str]] = {}
 
     def reset(self) -> None:
         self.models.clear()
+        self.slots.clear()
 
     def create(
         self,
@@ -235,6 +237,32 @@ class InMemoryUserProvidedModels:
                 model.online = False
                 model.online_changed_at = iso_now()
             return model
+
+    def acquire_slot(
+        self,
+        model_id: str,
+        authorization_id: str,
+        *,
+        limit: int,
+    ) -> bool:
+        with self._lock:
+            slots = self.slots.setdefault(normalize_custom_model_id(model_id), set())
+            if authorization_id in slots:
+                return True
+            if limit <= 0 or len(slots) >= limit:
+                return False
+            slots.add(authorization_id)
+            return True
+
+    def release_slot(self, model_id: str, authorization_id: str) -> None:
+        with self._lock:
+            canonical = normalize_custom_model_id(model_id)
+            slots = self.slots.get(canonical)
+            if slots is None:
+                return
+            slots.discard(authorization_id)
+            if not slots:
+                self.slots.pop(canonical, None)
 
     def list_public(self, *, kind: str | None = None) -> list[UserProvidedModel]:
         with self._lock:

--- a/src/trusted_router/storage_user_models.py
+++ b/src/trusted_router/storage_user_models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import secrets
 import threading
+import time
 from collections.abc import Callable
 from typing import Any
 
@@ -47,7 +48,8 @@ class InMemoryUserProvidedModels:
     def __init__(self, *, lock: threading.RLock) -> None:
         self._lock = lock
         self.models: dict[str, UserProvidedModel] = {}
-        self.slots: dict[str, set[str]] = {}
+        # model_id -> {authorization_id: expires_at (monotonic seconds)}
+        self.slots: dict[str, dict[str, float]] = {}
 
     def reset(self) -> None:
         self.models.clear()
@@ -244,14 +246,25 @@ class InMemoryUserProvidedModels:
         authorization_id: str,
         *,
         limit: int,
+        ttl_seconds: int,
     ) -> bool:
+        """Admit one in-flight authorization if the model has capacity.
+
+        A slot expires after ``ttl_seconds`` (the caller passes the kind's
+        total dispatch budget plus grace) so an enclave that dies between
+        authorize and settle cannot black a model out for longer than one
+        dispatch could legitimately have taken.
+        """
         with self._lock:
-            slots = self.slots.setdefault(normalize_custom_model_id(model_id), set())
+            now = time.monotonic()
+            slots = self.slots.setdefault(normalize_custom_model_id(model_id), {})
+            for stale in [aid for aid, exp in slots.items() if exp <= now]:
+                slots.pop(stale, None)
             if authorization_id in slots:
                 return True
             if limit <= 0 or len(slots) >= limit:
                 return False
-            slots.add(authorization_id)
+            slots[authorization_id] = now + max(1, ttl_seconds)
             return True
 
     def release_slot(self, model_id: str, authorization_id: str) -> None:
@@ -260,7 +273,7 @@ class InMemoryUserProvidedModels:
             slots = self.slots.get(canonical)
             if slots is None:
                 return
-            slots.discard(authorization_id)
+            slots.pop(authorization_id, None)
             if not slots:
                 self.slots.pop(canonical, None)
 

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -469,6 +469,7 @@ class Store(Protocol):
         authorization_id: str,
         *,
         limit: int,
+        ttl_seconds: int,
     ) -> bool: ...
     def release_user_model_slot(self, model_id: str, authorization_id: str) -> None: ...
     def list_public_user_models(

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -41,6 +41,7 @@ from trusted_router.storage_models import (
     SyntheticProbeSample,
     SyntheticRollup,
     User,
+    UserModelPayout,
     UserProvidedModel,
     VerificationToken,
     VideoJob,
@@ -462,6 +463,14 @@ class Store(Protocol):
         *,
         success: bool,
     ) -> UserProvidedModel: ...
+    def acquire_user_model_slot(
+        self,
+        model_id: str,
+        authorization_id: str,
+        *,
+        limit: int,
+    ) -> bool: ...
+    def release_user_model_slot(self, model_id: str, authorization_id: str) -> None: ...
     def list_public_user_models(
         self,
         *,
@@ -659,6 +668,7 @@ class Store(Protocol):
         usage_type: UsageType | str,
         estimated_microdollars: int,
         credit_reservation_id: str | None,
+        authorization_id: str | None = ...,
         requested_model_id: str | None = ...,
         candidate_model_ids: list[str] | None = ...,
         region: str | None = ...,
@@ -822,6 +832,7 @@ class TypedBillingStore(Protocol):
         *,
         workspace_id: str,
         key_hash: str,
+        authorization_id: str | None = ...,
         estimate: int,
         has_credit_candidate: bool,
         reservation_usage_type: UsageType | str,
@@ -857,6 +868,7 @@ class TypedBillingStore(Protocol):
         actual_microdollars: int,
         selected_usage_type: UsageType | str,
         generation: Generation | None = ...,
+        user_model_payout: UserModelPayout | None = ...,
     ) -> bool: ...
 
     def typed_finalize_gateway(self, **kwargs: Any) -> dict[str, Any]: ...

--- a/src/trusted_router/user_model_rules.py
+++ b/src/trusted_router/user_model_rules.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime
 from trusted_router.catalog import MODELS, PROVIDERS, Model, ModelEndpoint
 from trusted_router.config import Settings
 from trusted_router.errors import api_error
-from trusted_router.services.safe_egress import aassert_public_url
+from trusted_router.services.safe_egress import aassert_public_url, validate_url_scheme
 from trusted_router.storage_custom_models import custom_model_id_from_slug, custom_model_slug
 from trusted_router.storage_models import UserProvidedModel
 from trusted_router.types import ErrorType
@@ -157,16 +157,46 @@ def validate_user_model_display_name(display_name: str) -> str:
     return display_name.strip()
 
 
+def _first_party_domains(settings: Settings) -> frozenset[str]:
+    domains = {settings.trusted_domain.strip().lower().rstrip(".")}
+    domains.update(
+        value.strip().lower().rstrip(".")
+        for value in settings.trusted_domain_aliases.split(",")
+        if value.strip()
+    )
+    return frozenset(d for d in domains if d)
+
+
+def _is_first_party_host(host: str, settings: Settings) -> bool:
+    candidate = host.strip().lower().rstrip(".")
+    return any(
+        candidate == domain or candidate.endswith("." + domain)
+        for domain in _first_party_domains(settings)
+    )
+
+
 async def validate_endpoint_url(url: str, settings: Settings) -> str:
     """Normalize and SSRF-check an owner endpoint URL.
 
     Async on purpose: the DNS lookup behind the check runs off the event loop.
     Every caller is a request handler, and a synchronous lookup against an
     attacker-chosen hostname would stall the whole worker.
+
+    A TrustedRouter host is refused outright: an owner model pointed back at
+    api.trustedrouter.com (or an alias) — directly, or A→B→A — turns one
+    request into a recursive chain of live enclave connections and credit
+    holds. The enclave keeps the same rule so a stale row cannot loop either.
     """
     normalized = url.strip().rstrip("/")
     if not normalized:
         raise api_error(400, "Endpoint URL is required", ErrorType.BAD_REQUEST)
+    _scheme, host = validate_url_scheme(normalized)
+    if _is_first_party_host(host, settings):
+        raise api_error(
+            400,
+            "Endpoint URL must not point at TrustedRouter itself",
+            ErrorType.BAD_REQUEST,
+        )
     await aassert_public_url(
         normalized,
         allow_http=settings.environment in {"local", "test"},

--- a/src/trusted_router/user_model_rules.py
+++ b/src/trusted_router/user_model_rules.py
@@ -15,14 +15,21 @@ from trusted_router.storage_models import UserProvidedModel
 from trusted_router.types import ErrorType
 
 GATEWAY_RESERVATION_TTL_SECONDS = 2 * 60 * 60
+# Transport/shape failures that indict the owner endpoint even when no HTTP
+# status exists (the connection never produced one).
 _OWNER_FAULT_ERROR_TYPES = frozenset(
     {
         "timeout",
         str(ErrorType.USER_MODEL_TIMEOUT),
         "connection_error",
-        str(ErrorType.PROVIDER_ERROR),
         "malformed_response",
     }
+)
+# Explicit "not the owner's fault" tokens: the caller hung up, TR itself
+# failed, or the owner judged the CALLER's request (4xx). These win over any
+# status, so an enclave that labels a caller disconnect 502 cannot strike.
+_NON_OWNER_FAULT_ERROR_TYPES = frozenset(
+    {"client_closed", "internal_error", "upstream_client_error", "cancelled"}
 )
 
 _STATIC_RESERVED_NAMES = {
@@ -104,13 +111,21 @@ def user_model_gateway_pair(
 def is_owner_fault(error_status: int | None, error_type: str | None) -> bool:
     """Match the owner-health rule used by local and attested dispatch.
 
-    An upstream 5xx or an explicit transport/timeout/malformed-response token
-    says the owner endpoint failed to serve. A 4xx, cancellation, or missing
-    error evidence says nothing about endpoint health and must not add a strike.
+    Order matters and is deliberate:
+    1. an explicit non-fault token (caller disconnect, TR-internal error,
+       owner 4xx relabelled) is never a strike, whatever status rides with it;
+    2. otherwise an HTTP status decides: 5xx says the owner failed to serve,
+       anything else (4xx, 499) says nothing about endpoint health;
+    3. with no status at all, only a transport/timeout/malformed token strikes.
+    A bare "provider_error" with no status is NOT a strike: it is the enclave's
+    default label for "something went wrong" and carries no evidence.
     """
-    return (error_status is not None and error_status >= 500) or (
-        str(error_type or "").strip().lower() in _OWNER_FAULT_ERROR_TYPES
-    )
+    token = str(error_type or "").strip().lower()
+    if token in _NON_OWNER_FAULT_ERROR_TYPES:
+        return False
+    if error_status is not None:
+        return 500 <= error_status <= 599
+    return token in _OWNER_FAULT_ERROR_TYPES
 
 
 def reserved_user_model_names() -> frozenset[str]:

--- a/src/trusted_router/user_model_rules.py
+++ b/src/trusted_router/user_model_rules.py
@@ -6,13 +6,24 @@ import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-from trusted_router.catalog import MODELS, PROVIDERS
+from trusted_router.catalog import MODELS, PROVIDERS, Model, ModelEndpoint
 from trusted_router.config import Settings
 from trusted_router.errors import api_error
 from trusted_router.services.safe_egress import aassert_public_url
 from trusted_router.storage_custom_models import custom_model_id_from_slug, custom_model_slug
 from trusted_router.storage_models import UserProvidedModel
 from trusted_router.types import ErrorType
+
+GATEWAY_RESERVATION_TTL_SECONDS = 2 * 60 * 60
+_OWNER_FAULT_ERROR_TYPES = frozenset(
+    {
+        "timeout",
+        str(ErrorType.USER_MODEL_TIMEOUT),
+        "connection_error",
+        str(ErrorType.PROVIDER_ERROR),
+        "malformed_response",
+    }
+)
 
 _STATIC_RESERVED_NAMES = {
     "openai",
@@ -48,6 +59,58 @@ _DISPATCH_BUDGETS = {
     "agent": DispatchBudget(connect=10, first_byte=60, idle=60, total=600),
     "human": DispatchBudget(connect=10, first_byte=300, idle=120, total=900),
 }
+
+
+def user_model_gateway_pair(
+    *,
+    model_id: str,
+    name: str,
+    revision: int,
+    prompt_price_microdollars_per_m: int,
+    completion_price_microdollars_per_m: int,
+    owner_user_id: str,
+    upstream_model_id: str | None = None,
+) -> tuple[Model, ModelEndpoint]:
+    """Build the Credits-only catalog sentinel from explicit frozen values."""
+    if not model_id or revision < 1 or not owner_user_id:
+        raise ValueError("invalid frozen user-model attribution")
+    model = Model(
+        id=model_id,
+        name=name or model_id,
+        provider="trustedrouter",
+        context_length=1_000_000,
+        upstream_id=upstream_model_id or model_id,
+        prepaid_available=True,
+        byok_available=False,
+        prompt_price_microdollars_per_million_tokens=prompt_price_microdollars_per_m,
+        completion_price_microdollars_per_million_tokens=(
+            completion_price_microdollars_per_m
+        ),
+    )
+    endpoint = ModelEndpoint(
+        id=f"{model_id}@trustedrouter/credits",
+        model_id=model_id,
+        provider="trustedrouter",
+        usage_type="Credits",
+        upstream_id=upstream_model_id or model_id,
+        prompt_price_microdollars_per_million_tokens=prompt_price_microdollars_per_m,
+        completion_price_microdollars_per_million_tokens=(
+            completion_price_microdollars_per_m
+        ),
+    )
+    return model, endpoint
+
+
+def is_owner_fault(error_status: int | None, error_type: str | None) -> bool:
+    """Match the owner-health rule used by local and attested dispatch.
+
+    An upstream 5xx or an explicit transport/timeout/malformed-response token
+    says the owner endpoint failed to serve. A 4xx, cancellation, or missing
+    error evidence says nothing about endpoint health and must not add a strike.
+    """
+    return (error_status is not None and error_status >= 500) or (
+        str(error_type or "").strip().lower() in _OWNER_FAULT_ERROR_TYPES
+    )
 
 
 def reserved_user_model_names() -> frozenset[str]:

--- a/tests/conformance/test_user_model_store.py
+++ b/tests/conformance/test_user_model_store.py
@@ -183,6 +183,21 @@ def test_gateway_authorization_round_trips_frozen_user_model_fields(
     assert loaded.user_model_owner_user_id == "owner"
 
 
+def test_user_model_slots_are_idempotent_and_release_capacity(
+    user_model_store: Store,
+) -> None:
+    store = user_model_store
+    model_id = "trustedrouter/user-slots"
+
+    assert store.acquire_user_model_slot(model_id, "gwa-first", limit=1)
+    assert store.acquire_user_model_slot(model_id, "gwa-first", limit=1)
+    assert not store.acquire_user_model_slot(model_id, "gwa-second", limit=1)
+
+    store.release_user_model_slot(model_id, "gwa-first")
+    store.release_user_model_slot(model_id, "gwa-first")
+    assert store.acquire_user_model_slot(model_id, "gwa-second", limit=1)
+
+
 def test_user_model_coerces_secret_envelope_dicts() -> None:
     raw = {
         "algorithm": "test",

--- a/tests/conformance/test_user_model_store.py
+++ b/tests/conformance/test_user_model_store.py
@@ -189,13 +189,44 @@ def test_user_model_slots_are_idempotent_and_release_capacity(
     store = user_model_store
     model_id = "trustedrouter/user-slots"
 
-    assert store.acquire_user_model_slot(model_id, "gwa-first", limit=1)
-    assert store.acquire_user_model_slot(model_id, "gwa-first", limit=1)
-    assert not store.acquire_user_model_slot(model_id, "gwa-second", limit=1)
+    assert store.acquire_user_model_slot(model_id, "gwa-first", limit=1, ttl_seconds=600)
+    assert store.acquire_user_model_slot(model_id, "gwa-first", limit=1, ttl_seconds=600)
+    assert not store.acquire_user_model_slot(model_id, "gwa-second", limit=1, ttl_seconds=600)
 
     store.release_user_model_slot(model_id, "gwa-first")
     store.release_user_model_slot(model_id, "gwa-first")
-    assert store.acquire_user_model_slot(model_id, "gwa-second", limit=1)
+    assert store.acquire_user_model_slot(model_id, "gwa-second", limit=1, ttl_seconds=600)
+
+
+def test_user_model_slot_expires_after_its_ttl(
+    user_model_store: Store,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An enclave that dies between authorize and settle must not black a
+    model out for longer than one dispatch budget: the unreleased slot stops
+    counting once its own ttl has passed."""
+    import datetime as dt
+    import time
+
+    store = user_model_store
+    model_id = "trustedrouter/user-slot-ttl"
+    assert store.acquire_user_model_slot(model_id, "gwa-stuck", limit=1, ttl_seconds=30)
+    assert not store.acquire_user_model_slot(model_id, "gwa-next", limit=1, ttl_seconds=30)
+
+    # Advance both clocks the two backends use by more than the ttl.
+    real_monotonic = time.monotonic
+    real_now = dt.datetime.now
+    monkeypatch.setattr(time, "monotonic", lambda: real_monotonic() + 31)
+
+    class _Shifted(dt.datetime):
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            return real_now(tz) + dt.timedelta(seconds=31)
+
+    monkeypatch.setattr(
+        "trusted_router.storage_gcp_user_models.dt.datetime", _Shifted, raising=False
+    )
+    assert store.acquire_user_model_slot(model_id, "gwa-next", limit=1, ttl_seconds=30)
 
 
 def test_user_model_coerces_secret_envelope_dicts() -> None:

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -644,7 +644,7 @@ class _FakeTransaction:
             new = dict(
                 rec,
                 total_earned=rec["total_earned"] + p["amount"],
-                updated_at=p["now"],
+                updated_at=p.get("now", dt.datetime.now(dt.UTC)),
             )
             self.pending_writes.append(("update_typed", "tr_earnings_balance", pk, new))
             return 1
@@ -674,7 +674,7 @@ class _FakeTransaction:
                 user_id=p["user_id"],
                 shard=0,
                 total_earned=p.get("amount", 0),
-                updated_at=p["now"],
+                updated_at=p.get("now", dt.datetime.now(dt.UTC)),
             )
             self.pending_writes.append(("insert_typed_dml", "tr_earnings_balance", pk, record))
             return 1
@@ -701,19 +701,23 @@ class _FakeTransaction:
             }
             self.pending_writes.append(("insert_typed_dml", "tr_user_lifetime_topup", pk, record))
             return 1
-        if sql.startswith("INSERT INTO tr_credit_movement"):
+        if sql.startswith(("INSERT INTO tr_credit_movement", "INSERT OR IGNORE INTO tr_credit_movement")):
             pk = (p["account_id"], p["movement_id"])
             if self._typed_current("tr_credit_movement", pk) is not None:
+                if sql.startswith("INSERT OR IGNORE"):
+                    return 0
                 raise FakeAlreadyExists(f"tr_credit_movement/{pk}")
             record = {
                 "account_id": p["account_id"],
                 "movement_id": p["movement_id"],
-                "kind": p["kind"],
+                "kind": p.get("kind", "custom_model_payout"),
                 "amount_microdollars": p["amount"],
-                "counterparty_account_id": p["counterparty"],
+                "counterparty_account_id": p.get(
+                    "counterparty", p.get("payer_workspace_id")
+                ),
                 "custom_model_id": p["custom_model_id"],
                 "authorization_id": p["authorization_id"],
-                "created_at": p["created_at"],
+                "created_at": p.get("created_at", dt.datetime.now(dt.UTC)),
             }
             self.pending_writes.append(("insert_typed_dml", "tr_credit_movement", pk, record))
             return 1
@@ -2158,6 +2162,7 @@ def make_fake_store(
     io = SpannerIO(
         database=db,
         spanner_module=_SpannerModule,
+        param_types=_ParamTypes,
         write_entity_batch=store._write_entity_batch,
         read_entity_tx=store._read_entity_tx,
         write_entity_tx=store._write_entity_tx,

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -102,6 +102,21 @@ except ImportError:  # pragma: no cover - google always present in the test venv
     _AlreadyExists = Exception  # type: ignore[assignment,misc]
 
 
+try:  # subclass the real exception so production handlers see the prod type
+    from google.api_core.exceptions import FailedPrecondition as _FailedPrecondition
+except ImportError:  # pragma: no cover - google always present in the test venv
+    _FailedPrecondition = Exception  # type: ignore[assignment,misc]
+
+
+class FakeFailedPrecondition(_FailedPrecondition):
+    """Non-retryable statement rejection (e.g. writing PENDING_COMMIT_TIMESTAMP()
+    into a column without allow_commit_timestamp). run_in_transaction does NOT
+    retry it; the callback either handles it or the whole transaction fails."""
+
+    def __init__(self, detail: str = "failed precondition") -> None:
+        super().__init__(detail)
+
+
 class FakeAlreadyExists(_AlreadyExists):
     """Unique-index / duplicate-PK violation (e.g. duplicate idempotency_scope or
     reservation_id). Unlike Aborted, run_in_transaction does NOT retry this — the
@@ -707,17 +722,23 @@ class _FakeTransaction:
                 if sql.startswith("INSERT OR IGNORE"):
                     return 0
                 raise FakeAlreadyExists(f"tr_credit_movement/{pk}")
+            # Strict on purpose: created_at is NOT a commit-timestamp column,
+            # so real Spanner requires a client TIMESTAMP param here. A writer
+            # that omits it (or writes PENDING_COMMIT_TIMESTAMP()) must fail
+            # in the fake exactly as it would in prod.
+            if "PENDING_COMMIT_TIMESTAMP" in sql:
+                raise FakeFailedPrecondition(
+                    "tr_credit_movement.created_at: allow_commit_timestamp is not set"
+                )
             record = {
                 "account_id": p["account_id"],
                 "movement_id": p["movement_id"],
-                "kind": p.get("kind", "custom_model_payout"),
+                "kind": p["kind"],
                 "amount_microdollars": p["amount"],
-                "counterparty_account_id": p.get(
-                    "counterparty", p.get("payer_workspace_id")
-                ),
+                "counterparty_account_id": p["counterparty"],
                 "custom_model_id": p["custom_model_id"],
                 "authorization_id": p["authorization_id"],
-                "created_at": p.get("created_at", dt.datetime.now(dt.UTC)),
+                "created_at": p["created_at"],
             }
             self.pending_writes.append(("insert_typed_dml", "tr_credit_movement", pk, record))
             return 1

--- a/tests/test_byok_envelope_registry_totality_property.py
+++ b/tests/test_byok_envelope_registry_totality_property.py
@@ -1194,6 +1194,9 @@ NON_ENVELOPE_KINDS = {
     "broadcast_destination_by_workspace": "pointer row, dict literal body",
     "custom_model": "prompt-wrapper row, no encrypted envelope fields",
     "custom_model_by_user": "pointer row, dict literal body",
+    "user_model_slot": (
+        "concurrency lease row containing only model/authorization ids and created_at"
+    ),
     "user_provided_model_by_user": "pointer row, dict literal body",
 }
 
@@ -1959,6 +1962,7 @@ def test_the_derivation_reproduces_todays_registry() -> None:
         "broadcast_destination_by_workspace",
         "custom_model",
         "custom_model_by_user",
+        "user_model_slot",
         "user_provided_model",
         "user_provided_model_by_user",
     }

--- a/tests/test_egress_projection_closure_property.py
+++ b/tests/test_egress_projection_closure_property.py
@@ -191,7 +191,7 @@ def test_every_generation_field_is_classified() -> None:
     }
     # Fields carried only on the system-of-record or video surfaces.
     other_metadata = {
-        "route_type", "video_input_mode", "video_duration_seconds",
+        "custom_model_id", "route_type", "video_input_mode", "video_duration_seconds",
         "video_resolution", "video_aspect_ratio", "video_generate_audio",
     }
 

--- a/tests/test_settle_outbox_apply.py
+++ b/tests/test_settle_outbox_apply.py
@@ -17,6 +17,12 @@ from google.api_core.exceptions import (
 
 from tests.fakes.spanner import make_fake_store
 from trusted_router.catalog_data import PARASAIL_LIBERTY_2_0_MODEL_ID
+from trusted_router.custom_model_billing import (
+    USER_MODEL_ID_SETTLE_FIELD,
+    USER_MODEL_OWNER_SETTLE_FIELD,
+    USER_MODEL_PAYOUT_SETTLE_FIELD,
+    user_model_payout_event_id,
+)
 from trusted_router.partner_billing import PARTNER_OPERATOR_COST_SETTLE_FIELD
 from trusted_router.services import settle_outbox_apply as apply_mod
 from trusted_router.services.settle_outbox_apply import ApplyOutcome, apply_frozen_settle
@@ -30,6 +36,8 @@ PROVIDER = "anthropic"
 ENDPOINT_ID = "anthropic/claude-haiku-4.5@anthropic/prepaid"
 ESTIMATE = 1_000_000
 TOTAL_CREDIT = 5_000_000
+USER_MODEL_ID = "trustedrouter/user-outbox-payout"
+USER_MODEL_ENDPOINT_ID = f"{USER_MODEL_ID}@trustedrouter/credits"
 
 
 @pytest.fixture
@@ -133,6 +141,39 @@ def _legacy_authorization(
         endpoint_id=ENDPOINT_ID,
         candidate_endpoint_ids=[ENDPOINT_ID],
     )
+
+
+def _typed_user_model_authorization(
+    store: Any,
+    *,
+    workspace_id: str,
+    key_hash: str,
+) -> GatewayAuthorization:
+    outcome, auth = store.authorize_gateway_typed(
+        workspace_id=workspace_id,
+        key_hash=key_hash,
+        estimate=ESTIMATE,
+        has_credit_candidate=True,
+        reservation_usage_type="Credits",
+        model_id=USER_MODEL_ID,
+        provider="trustedrouter",
+        requested_model_id=USER_MODEL_ID,
+        candidate_model_ids=[USER_MODEL_ID],
+        region="us",
+        endpoint_id=USER_MODEL_ENDPOINT_ID,
+        candidate_endpoint_ids=[USER_MODEL_ENDPOINT_ID],
+        idempotency_key="typed-user-model-payout",
+        idempotency_fingerprint="typed-user-model-payout-fingerprint",
+        user_provided_model_id=USER_MODEL_ID,
+        user_provided_model_revision=3,
+        user_model_prompt_price_microdollars_per_m=2_000_000,
+        user_model_completion_price_microdollars_per_m=3_000_000,
+        user_model_owner_user_id="owner-user-model-payout",
+        expires_at="2026-01-01T00:00:00Z",
+    )
+    assert outcome == AuthorizeOutcome.ACCEPTED
+    assert auth is not None
+    return auth
 
 
 def _settle_body(authorization_id: str, *, endpoint_id: str = ENDPOINT_ID) -> str:
@@ -289,6 +330,90 @@ def test_replay_reports_already_charged(fake_store: tuple[Any, Any, Any]) -> Non
     assert apply_frozen_settle(row) == ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE
     assert _typed_credit(db, ws)["total_usage"] == 777_777
     assert len(_generation_bodies(db)) == 1
+
+
+def test_user_model_outbox_repair_pays_owner_exactly_once(
+    fake_store: tuple[Any, Any, Any],
+) -> None:
+    store, db, _bt = fake_store
+    ws = "ws_apply_user_model_payout"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_user_model_authorization(store, workspace_id=ws, key_hash=key.hash)
+    payout = 5_600
+    body = {
+        "authorization_id": auth.id,
+        "actual_input_tokens": 1_000,
+        "actual_output_tokens": 2_000,
+        "request_id": f"req-{auth.id}",
+        "finish_reason": "stop",
+        "status": "success",
+        "elapsed_seconds": 0.2,
+        "selected_model": USER_MODEL_ID,
+        "selected_endpoint": USER_MODEL_ENDPOINT_ID,
+        USER_MODEL_PAYOUT_SETTLE_FIELD: payout,
+        USER_MODEL_OWNER_SETTLE_FIELD: "owner-user-model-payout",
+        USER_MODEL_ID_SETTLE_FIELD: USER_MODEL_ID,
+        PARTNER_OPERATOR_COST_SETTLE_FIELD: payout,
+    }
+    row = _row(
+        auth,
+        cost=8_000,
+        endpoint_id=USER_MODEL_ENDPOINT_ID,
+        model_id=USER_MODEL_ID,
+        settle_body=json.dumps(body),
+    )
+
+    assert apply_frozen_settle(row) == ApplyOutcome.SETTLED_NOW
+    assert apply_frozen_settle(row) == ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE
+    assert store.earnings_summary("owner-user-model-payout") == {
+        "total_earned": payout,
+        "total_transferred": 0,
+        "available": payout,
+    }
+    movements = store.list_credit_movements("user:owner-user-model-payout")
+    assert len(movements) == 1
+    assert movements[0].movement_id == user_model_payout_event_id(auth.id)
+    assert movements[0].amount_microdollars == payout
+    assert movements[0].counterparty_account_id == ws
+    assert movements[0].custom_model_id == USER_MODEL_ID
+    assert movements[0].authorization_id == auth.id
+    generations = _generation_bodies(db)
+    assert len(generations) == 1
+    assert generations[0]["custom_model_id"] == USER_MODEL_ID
+    assert generations[0]["operator_cost_microdollars"] == payout
+
+
+@pytest.mark.parametrize("bad_payout", [-1, "5600"], ids=("negative", "non-int"))
+def test_bad_frozen_user_model_payout_is_invalid_row(
+    fake_store: tuple[Any, Any, Any],
+    bad_payout: Any,
+) -> None:
+    store, db, _bt = fake_store
+    ws = f"ws_apply_bad_user_model_payout_{type(bad_payout).__name__}"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_user_model_authorization(store, workspace_id=ws, key_hash=key.hash)
+    body = {
+        "authorization_id": auth.id,
+        "actual_input_tokens": 1_000,
+        "actual_output_tokens": 2_000,
+        USER_MODEL_PAYOUT_SETTLE_FIELD: bad_payout,
+        USER_MODEL_OWNER_SETTLE_FIELD: "owner-user-model-payout",
+        USER_MODEL_ID_SETTLE_FIELD: USER_MODEL_ID,
+    }
+    row = _row(
+        auth,
+        cost=8_000,
+        endpoint_id=USER_MODEL_ENDPOINT_ID,
+        model_id=USER_MODEL_ID,
+        settle_body=json.dumps(body),
+    )
+
+    assert apply_frozen_settle(row) == ApplyOutcome.INVALID_ROW
+    assert store.get_gateway_authorization(auth.id).settled is False
+    assert _typed_credit(db, ws)["total_usage"] == 0
+    assert store.earnings_summary("owner-user-model-payout")["total_earned"] == 0
 
 
 def test_zero_cost_replay_is_benign(fake_store: tuple[Any, Any, Any]) -> None:

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -1957,6 +1957,10 @@ def test_user_model_inline_typed_finalize_pays_owner_once_and_replay_is_a_noop(
     movements = store.list_credit_movements("user:owner-outbox-repair")
     assert [m.movement_id for m in movements] == [user_model_payout_event_id(auth.id)]
     assert movements[0].created_at  # client timestamp landed (not a commit-ts write)
+    # Payer ledger: exactly the owner-priced charge booked, hold fully released.
+    payer = store._database.typed[CREDIT_BALANCE_TABLE][(ws, 0)]
+    assert payer["total_usage"] == 8_000
+    assert payer["reserved"] == 0
 
     replay = client.post("/v1/internal/gateway/settle", json=_typed_settle_body(auth))
     assert replay.status_code == 200, replay.text

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 
 from tests.fakes.spanner import _FakeTransaction, make_fake_store
 from trusted_router.config import Settings
+from trusted_router.custom_model_billing import user_model_payout_event_id
 from trusted_router.main import create_app
 from trusted_router.services import settle_outbox_apply as apply_mod
 from trusted_router.services import settle_outbox_drain as drain_mod
@@ -25,11 +26,18 @@ from trusted_router.storage_gcp_authorize import (
 )
 from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
 from trusted_router.storage_gcp_settle_outbox import SpannerSettleOutbox
-from trusted_router.storage_models import CreditAccount, GatewayAuthorization, SettleOutboxRow
+from trusted_router.storage_models import (
+    CreditAccount,
+    GatewayAuthorization,
+    SettleOutboxRow,
+    TypedFinalizeResult,
+)
 
 MODEL_ID = "anthropic/claude-haiku-4.5"
 PROVIDER = "anthropic"
 ENDPOINT_ID = "anthropic/claude-haiku-4.5@anthropic/prepaid"
+USER_MODEL_ID = "trustedrouter/user-outbox-repair"
+USER_MODEL_ENDPOINT_ID = f"{USER_MODEL_ID}@trustedrouter/credits"
 ESTIMATE = 1_000_000
 TOTAL_CREDIT = 5_000_000
 NOW = "2026-07-04T12:00:00Z"
@@ -122,6 +130,39 @@ def _typed_authorization(
         idempotency_key=None,
         idempotency_fingerprint=None,
         expires_at=expires_at,
+    )
+    assert outcome == AuthorizeOutcome.ACCEPTED
+    assert auth is not None
+    return auth
+
+
+def _typed_user_model_authorization(
+    store: Any,
+    *,
+    workspace_id: str,
+    key_hash: str,
+) -> GatewayAuthorization:
+    outcome, auth = store.authorize_gateway_typed(
+        workspace_id=workspace_id,
+        key_hash=key_hash,
+        estimate=ESTIMATE,
+        has_credit_candidate=True,
+        reservation_usage_type="Credits",
+        model_id=USER_MODEL_ID,
+        provider="trustedrouter",
+        requested_model_id=USER_MODEL_ID,
+        candidate_model_ids=[USER_MODEL_ID],
+        region="us",
+        endpoint_id=USER_MODEL_ENDPOINT_ID,
+        candidate_endpoint_ids=[USER_MODEL_ENDPOINT_ID],
+        idempotency_key="typed-user-model-outbox-repair",
+        idempotency_fingerprint="typed-user-model-outbox-repair-fingerprint",
+        user_provided_model_id=USER_MODEL_ID,
+        user_provided_model_revision=4,
+        user_model_prompt_price_microdollars_per_m=2_000_000,
+        user_model_completion_price_microdollars_per_m=3_000_000,
+        user_model_owner_user_id="owner-outbox-repair",
+        expires_at="2026-01-01T00:00:00Z",
     )
     assert outcome == AuthorizeOutcome.ACCEPTED
     assert auth is not None
@@ -1479,6 +1520,58 @@ def test_lost_charge_recovery_end_to_end(
     assert db.reservations[auth.credit_reservation_id]["actual_micro"] == row.actual_cost_micro
     assert _typed_credit(db, ws)["total_usage"] == row.actual_cost_micro
     assert reap_expired_reservations(store._database, store._param_types, now=NOW) == 0
+
+
+def test_user_model_inline_finalize_loss_repairs_one_payout_from_frozen_outbox(
+    fake_store: tuple[Any, Any, Any],
+) -> None:
+    store, _db, _bt = fake_store
+    ws = "ws-user-model-outbox-repair"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_user_model_authorization(store, workspace_id=ws, key_hash=key.hash)
+    original = store.typed_finalize_gateway_authorization_result
+
+    def lose_inline_finalize(*_args: Any, **_kwargs: Any) -> TypedFinalizeResult:
+        return TypedFinalizeResult(finalized=False, activity_indexed=False)
+
+    store.typed_finalize_gateway_authorization_result = lose_inline_finalize
+    client = _client(Settings(environment="test", settle_outbox_enabled=True))
+    response = client.post(
+        "/v1/internal/gateway/settle",
+        json={
+            "authorization_id": auth.id,
+            "actual_input_tokens": 1_000,
+            "actual_output_tokens": 2_000,
+            "request_id": "req-user-model-outbox-repair",
+            "finish_reason": "stop",
+            "status": "success",
+            "elapsed_seconds": 0.2,
+            "selected_model": USER_MODEL_ID,
+            "selected_endpoint": USER_MODEL_ENDPOINT_ID,
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["already_settled"] is True
+    row = _outbox(store).get(auth.id, "settle")
+    assert row is not None
+    assert row.status == "pending"
+    assert row.settle_body is not None
+
+    store.typed_finalize_gateway_authorization_result = original
+    assert apply_mod.apply_frozen_settle(row) == ApplyOutcome.SETTLED_NOW
+    assert (
+        apply_mod.apply_frozen_settle(row)
+        == ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE
+    )
+    payout = 5_600
+    assert store.earnings_summary("owner-outbox-repair")["total_earned"] == payout
+    movements = store.list_credit_movements("user:owner-outbox-repair")
+    assert len(movements) == 1
+    assert movements[0].movement_id == user_model_payout_event_id(auth.id)
+    assert movements[0].amount_microdollars == payout
+    assert movements[0].custom_model_id == USER_MODEL_ID
+    assert movements[0].counterparty_account_id == ws
 
 
 def test_charged_settle_then_sibling_refund_resolves_and_arms_retention(

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -1910,3 +1910,172 @@ def test_drain_endpoint_requires_internal_token(fake_store: tuple[Any, Any, Any]
     assert wrong.status_code == 401
     assert ok.status_code == 200
     assert ok.json() == {"claimed": 0, "outcomes": {}, "recovered_micro": 0, "purged": 0, "reaped": 0}
+
+
+# --- Review-round regressions: the primary prod payout path -----------------
+
+
+def _typed_settle_body(auth: GatewayAuthorization, **overrides: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "authorization_id": auth.id,
+        "actual_input_tokens": 1_000,
+        "actual_output_tokens": 2_000,
+        "request_id": "req-user-model-inline",
+        "finish_reason": "stop",
+        "status": "success",
+        "elapsed_seconds": 0.2,
+        "selected_model": USER_MODEL_ID,
+        "selected_endpoint": USER_MODEL_ENDPOINT_ID,
+    }
+    body.update(overrides)
+    return body
+
+
+def test_user_model_inline_typed_finalize_pays_owner_once_and_replay_is_a_noop(
+    fake_store: tuple[Any, Any, Any],
+) -> None:
+    """The path prod actually takes: inline typed finalize WINS on Spanner.
+
+    The earlier test only covered the inline-LOSS → outbox repair path; a
+    mutant dropping `user_model_payout` from the inline finalize passed the
+    whole suite. Here the inline settle must pay exactly once, and both a
+    duplicate HTTP settle and the outbox repair replay must leave the payout
+    at one movement / one increment.
+    """
+    store, _db, _bt = fake_store
+    ws = "ws-user-model-inline-win"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_user_model_authorization(store, workspace_id=ws, key_hash=key.hash)
+    client = _client(Settings(environment="test", settle_outbox_enabled=True))
+
+    response = client.post("/v1/internal/gateway/settle", json=_typed_settle_body(auth))
+    assert response.status_code == 200, response.text
+    assert response.json()["data"].get("already_settled") is not True
+    payout = 5_600  # 70% of 8_000 µ$ (1k×2µ$ + 2k×3µ$)
+    assert store.earnings_summary("owner-outbox-repair")["total_earned"] == payout
+    movements = store.list_credit_movements("user:owner-outbox-repair")
+    assert [m.movement_id for m in movements] == [user_model_payout_event_id(auth.id)]
+    assert movements[0].created_at  # client timestamp landed (not a commit-ts write)
+
+    replay = client.post("/v1/internal/gateway/settle", json=_typed_settle_body(auth))
+    assert replay.status_code == 200, replay.text
+    assert replay.json()["data"]["already_settled"] is True
+    # The inline win marks the outbox row done (terminal; frozen body dropped),
+    # so the drain never re-applies it — the replay surface is the HTTP one.
+    row = _outbox(store).get(auth.id, "settle")
+    assert row is not None and row.status == "done"
+    assert store.earnings_summary("owner-outbox-repair")["total_earned"] == payout
+    assert len(store.list_credit_movements("user:owner-outbox-repair")) == 1
+
+
+def test_user_model_payout_movement_pk_is_a_real_second_guard(
+    fake_store: tuple[Any, Any, Any],
+) -> None:
+    """If the movement row already exists (a prior path paid this
+    authorization), the finalize must NOT bump earnings again — the PK is
+    the guard behind the claim, and it has to be load-bearing on its own."""
+    store, _db, _bt = fake_store
+    ws = "ws-user-model-second-guard"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_user_model_authorization(store, workspace_id=ws, key_hash=key.hash)
+    # Pre-pay through the other writer of the same movement id.
+    assert store.credit_user_earnings(
+        "owner-outbox-repair",
+        5_600,
+        user_model_payout_event_id(auth.id),
+        custom_model_id=USER_MODEL_ID,
+        payer_workspace_id=ws,
+    )
+    client = _client(Settings(environment="test", settle_outbox_enabled=False))
+    response = client.post("/v1/internal/gateway/settle", json=_typed_settle_body(auth))
+    assert response.status_code == 200, response.text
+    assert store.earnings_summary("owner-outbox-repair")["total_earned"] == 5_600
+    assert len(store.list_credit_movements("user:owner-outbox-repair")) == 1
+
+
+def test_user_model_settle_does_not_double_bill_cached_prompt_tokens(
+    fake_store: tuple[Any, Any, Any],
+) -> None:
+    """Owner endpoints speak the OpenAI dialect: prompt_tokens already
+    includes the cached subset. Billing input + cache_read double-charged the
+    prompt and let an owner reporting cached==prompt double their revenue."""
+    store, _db, _bt = fake_store
+    ws = "ws-user-model-cache"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_user_model_authorization(store, workspace_id=ws, key_hash=key.hash)
+    client = _client(Settings(environment="test", settle_outbox_enabled=False))
+    response = client.post(
+        "/v1/internal/gateway/settle",
+        json=_typed_settle_body(
+            auth,
+            actual_input_tokens=1_000,
+            actual_output_tokens=10,
+            cache_read_input_tokens=800,
+        ),
+    )
+    assert response.status_code == 200, response.text
+    # 1_000 prompt tokens at 2 µ$ + 10 completion at 3 µ$ = 2_030, not 3_630.
+    assert response.json()["data"]["cost_microdollars"] == 2_030
+
+
+def test_user_model_settle_is_capped_at_the_authorized_hold(
+    fake_store: tuple[Any, Any, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The token counts are the payee's own meter; the caller's hold is the
+    ceiling on both the charge and the 70% payout."""
+    store, _db, _bt = fake_store
+    ws = "ws-user-model-cap"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_user_model_authorization(store, workspace_id=ws, key_hash=key.hash)
+    client = _client(Settings(environment="test", settle_outbox_enabled=False))
+    with caplog.at_level(logging.WARNING):
+        response = client.post(
+            "/v1/internal/gateway/settle",
+            json=_typed_settle_body(
+                auth, actual_input_tokens=10_000_000, actual_output_tokens=10_000_000
+            ),
+        )
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["cost_microdollars"] == ESTIMATE
+    assert store.earnings_summary("owner-outbox-repair")["total_earned"] == ESTIMATE * 7 // 10
+    assert any("user_model_settle_capped_to_hold" in r.getMessage() for r in caplog.records)
+
+
+def test_user_model_settle_accepts_the_callers_raw_model_spelling(
+    fake_store: tuple[Any, Any, Any],
+) -> None:
+    """The enclave may echo the caller's spelling as selected_model; a refused
+    settle here strands the hold, so it must compare normalized."""
+    store, _db, _bt = fake_store
+    ws = "ws-user-model-raw-spelling"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_user_model_authorization(store, workspace_id=ws, key_hash=key.hash)
+    client = _client(Settings(environment="test", settle_outbox_enabled=False))
+    response = client.post(
+        "/v1/internal/gateway/settle",
+        json=_typed_settle_body(auth, selected_model="TrustedRouter/User-Outbox-Repair"),
+    )
+    assert response.status_code == 200, response.text
+
+
+def test_user_model_settle_refuses_a_different_model_id(
+    fake_store: tuple[Any, Any, Any],
+) -> None:
+    store, _db, _bt = fake_store
+    ws = "ws-user-model-wrong-model"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_user_model_authorization(store, workspace_id=ws, key_hash=key.hash)
+    client = _client(Settings(environment="test", settle_outbox_enabled=False))
+    other = client.post(
+        "/v1/internal/gateway/settle",
+        json=_typed_settle_body(auth, selected_model="trustedrouter/user-someone-else"),
+    )
+    assert other.status_code == 400, other.text
+

--- a/tests/test_user_model_dispatch.py
+++ b/tests/test_user_model_dispatch.py
@@ -679,3 +679,42 @@ def test_clock_in_and_passing_probe_reset_strikes(test_settings: Settings) -> No
     STORE.record_user_model_probe(model.id, status="failed", checked_at="2026-08-16T00:00:01Z")
     stored = STORE.get_user_model(model.id)
     assert stored is not None and stored.consecutive_dispatch_failures == 1
+
+
+@pytest.mark.asyncio
+async def test_usage_only_final_chunk_is_not_malformed(test_settings: Settings) -> None:
+    """OpenAI/vLLM emit `{"choices": [], "usage": {...}}` before [DONE] when
+    stream_options.include_usage is set. It must pass through the streaming
+    quadrant, feed usage in the buffered quadrant, and never strike."""
+    model = _model(test_settings, supports_streaming=True)
+    usage_chunk = {
+        "id": "chatcmpl-owner-stream",
+        "object": "chat.completion.chunk",
+        "created": 1_700_000_000,
+        "model": "owner-upstream",
+        "choices": [],
+        "usage": {"prompt_tokens": 7, "completion_tokens": 3, "total_tokens": 10},
+    }
+    body = _sse_body().replace(
+        b"data: [DONE]\n\n",
+        b"data: " + json.dumps(usage_chunk, separators=(",", ":")).encode() + b"\n\ndata: [DONE]\n\n",
+    )
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, headers={"content-type": "text/event-stream"}, content=body)
+
+    frames = [
+        chunk
+        async for chunk in stream_user_model(
+            model, _request_body(stream=True), test_settings, transport=httpx.MockTransport(handler)
+        )
+    ]
+    assert b'"error"' not in b"".join(frames)
+    assert b'"usage":{"prompt_tokens":7' in b"".join(frames)
+    buffered = await dispatch_user_model(
+        model, _request_body(stream=False), test_settings, transport=httpx.MockTransport(handler)
+    )
+    assert buffered.body["usage"]["prompt_tokens"] == 7
+    stored = STORE.get_user_model(model.id)
+    assert stored is not None
+    assert stored.consecutive_dispatch_failures == 0

--- a/tests/test_user_model_rules.py
+++ b/tests/test_user_model_rules.py
@@ -275,3 +275,35 @@ async def test_async_resolve_is_bounded_by_a_timeout(
         assert time.monotonic() - started < 2.0
     finally:
         release.set()  # let the worker thread finish so the run stays clean
+
+
+@pytest.mark.parametrize(
+    ("status", "error_type", "expected"),
+    [
+        # explicit non-fault tokens win over any status
+        (502, "client_closed", False),
+        (500, "internal_error", False),
+        (422, "upstream_client_error", False),
+        (None, "cancelled", False),
+        # a status decides otherwise: 5xx strikes, everything else does not
+        (503, "provider_error", True),
+        (502, None, True),
+        (599, "anything", True),
+        (401, "provider_error", False),
+        (422, "provider_error", False),
+        (499, "provider_error", False),
+        (429, "timeout", False),
+        # no status: only transport/shape tokens strike; a bare provider_error
+        # is the enclave's default label and carries no evidence
+        (None, "timeout", True),
+        (None, "user_model_timeout", True),
+        (None, "connection_error", True),
+        (None, "malformed_response", True),
+        (None, "provider_error", False),
+        (None, None, False),
+    ],
+)
+def test_is_owner_fault_rule(status: int | None, error_type: str | None, expected: bool) -> None:
+    from trusted_router.user_model_rules import is_owner_fault
+
+    assert is_owner_fault(status, error_type) is expected

--- a/tests/test_user_model_rules.py
+++ b/tests/test_user_model_rules.py
@@ -55,6 +55,11 @@ def _model(**overrides: Any) -> UserProvidedModel:
         "::",
         "::ffff:127.0.0.1",
         "::ffff:10.0.0.1",
+        "100.64.0.1",  # shared address space (CGNAT): cloud-internal, never routable
+        "100.127.255.254",
+        "192.0.2.1",  # documentation range
+        "198.18.0.1",  # benchmarking range
+        "2001:db8::1",
         "not-an-ip",
     ),
 )

--- a/tests/test_user_model_rules.py
+++ b/tests/test_user_model_rules.py
@@ -312,3 +312,35 @@ def test_is_owner_fault_rule(status: int | None, error_type: str | None, expecte
     from trusted_router.user_model_rules import is_owner_fault
 
     assert is_owner_fault(status, error_type) is expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://api.trustedrouter.com/v1",
+        "https://TrustedRouter.com/v1",
+        "https://api.allyrouter.com/v1/",
+        "https://uptimerouter.com./v1",
+    ],
+)
+@pytest.mark.asyncio
+async def test_endpoint_url_refuses_trustedrouter_itself(
+    url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A→TR→A recursion: an owner model must never point back at us."""
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("8.8.8.8", 0))
+        ],
+    )
+    with pytest.raises(HTTPException) as captured:
+        await validate_endpoint_url(url, Settings(environment="test"))
+    assert captured.value.status_code == 400
+    assert "TrustedRouter" in str(captured.value.detail)
+    # a look-alike that is not a subdomain is fine
+    assert (
+        await validate_endpoint_url("https://nottrustedrouter.com/v1", Settings(environment="test"))
+        == "https://nottrustedrouter.com/v1"
+    )

--- a/tests/test_user_models.py
+++ b/tests/test_user_models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import socket
 from typing import Any
 
@@ -1086,3 +1087,99 @@ def test_console_verification_disables_user_model_forms() -> None:
     assert page.status_code == 200
     assert "Verification required" in page.text
     assert '<fieldset class="form-gate" disabled>' in page.text
+
+
+def test_local_user_model_streaming_bills_from_the_usage_chunk_and_pays_owner(
+    client: TestClient,
+    inference_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The streaming quadrant of local billing: the owner streams SSE with
+    the OpenAI usage-only final chunk; the caller is charged the owner-priced
+    usage (capped at the hold), the owner is paid 70%, and no strike lands."""
+    body = _body(slug="local-stream-billing")
+    body["supports_streaming"] = True
+    body["prompt_price_microdollars_per_million_tokens"] = 2_000_000
+    body["completion_price_microdollars_per_million_tokens"] = 3_000_000
+    created = _create(client, body=body)
+
+    async def passing_probe(*_args: Any, **_kwargs: Any) -> ProbeResult:
+        return ProbeResult(ok=True, detail="ok")
+
+    monkeypatch.setattr("trusted_router.routes.user_models.probe_user_model", passing_probe)
+    assert (
+        client.post(f"/v1/user-models/{created['id']}/clock-in", headers=HEADERS).status_code
+        == 200
+    )
+
+    def chunk(**payload: Any) -> bytes:
+        base = {
+            "id": "chatcmpl-local-stream",
+            "object": "chat.completion.chunk",
+            "created": 1_700_000_000,
+            "model": "owner-model",
+        }
+        base.update(payload)
+        return b"data: " + json.dumps(base, separators=(",", ":")).encode() + b"\n\n"
+
+    sse = (
+        chunk(choices=[{"index": 0, "delta": {"role": "assistant", "content": "streamed "}}])
+        + chunk(choices=[{"index": 0, "delta": {"content": "reply"}, "finish_reason": "stop"}])
+        + chunk(choices=[], usage={"prompt_tokens": 3, "completion_tokens": 20, "total_tokens": 23})
+        + b"data: [DONE]\n\n"
+    )
+
+    async def owner_stream(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, headers={"content-type": "text/event-stream"}, content=sse)
+
+    from trusted_router.services.user_model_dispatch import stream_user_model
+
+    def patched_stream(model: Any, request_body: dict[str, Any], settings: Settings) -> Any:
+        return stream_user_model(
+            model, request_body, settings, transport=httpx.MockTransport(owner_stream)
+        )
+
+    monkeypatch.setattr("trusted_router.routes.inference.stream_user_model", patched_stream)
+    payer = STORE.find_user_by_email("alice@example.com")
+    assert payer is not None
+    payer_workspace = STORE.list_workspaces_for_user(payer.id)[0]
+    payer_money = STORE.credit_money[payer_workspace.id]
+    usage_before = payer_money.total_usage_microdollars
+
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        headers=inference_headers,
+        json={
+            "model": created["id"],
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_tokens": 100,
+            "stream": True,
+        },
+    ) as response:
+        assert response.status_code == 200
+        raw = b"".join(response.iter_bytes())
+    assert b"streamed " in raw and b"reply" in raw and b'"error"' not in raw
+    assert raw.rstrip().endswith(b"data: [DONE]")
+
+    reported = custom_model_cost_microdollars(
+        input_tokens=3, output_tokens=20, prompt_price=2_000_000, completion_price=3_000_000
+    )
+    hold = custom_model_cost_microdollars(
+        input_tokens=estimate_tokens_from_messages([{"role": "user", "content": "hello"}]),
+        output_tokens=100,
+        prompt_price=2_000_000,
+        completion_price=3_000_000,
+    )
+    charged = min(reported, hold)
+    assert payer_money.total_usage_microdollars - usage_before == charged
+    assert payer_money.reserved_microdollars == 0
+    assert STORE.earnings_summary(created["owner_user_id"])["total_earned"] == (
+        owner_share_microdollars(charged)
+    )
+    stored = STORE.get_user_model(created["id"])
+    assert stored is not None
+    assert stored.consecutive_dispatch_failures == 0
+    generation = next(iter(STORE.target.generation_store.generations.values()))
+    assert generation.custom_model_id == created["id"]
+    assert generation.tokens_completion == 20

--- a/tests/test_user_models.py
+++ b/tests/test_user_models.py
@@ -3,12 +3,21 @@ from __future__ import annotations
 import socket
 from typing import Any
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
 from trusted_router.config import Settings
+from trusted_router.custom_model_billing import (
+    custom_model_cost_microdollars,
+    owner_share_microdollars,
+    user_model_payout_event_id,
+)
 from trusted_router.main import create_app
-from trusted_router.services.user_model_dispatch import BufferedUserModelDispatch
+from trusted_router.services.user_model_dispatch import (
+    BufferedUserModelDispatch,
+    dispatch_user_model,
+)
 from trusted_router.services.user_model_probe import ProbeResult
 from trusted_router.services.user_model_secrets import (
     USER_MODEL_ENDPOINT_KEY_PURPOSE,
@@ -16,6 +25,7 @@ from trusted_router.services.user_model_secrets import (
     USER_MODEL_SIGNING_PURPOSE,
 )
 from trusted_router.storage import STORE
+from trusted_router.storage_user_models import InMemoryUserProvidedModels
 
 HEADERS = {"x-trustedrouter-user": "user-model-owner@example.com"}
 
@@ -81,10 +91,79 @@ def _create(
     return response.json()["data"]
 
 
-def _create_key(client: TestClient) -> dict[str, Any]:
-    response = client.post("/v1/keys", headers=HEADERS, json={"name": "gateway"})
+def _create_key(
+    client: TestClient,
+    *,
+    headers: dict[str, str] = HEADERS,
+) -> dict[str, Any]:
+    response = client.post("/v1/keys", headers=headers, json={"name": "gateway"})
     assert response.status_code == 201, response.text
     return response.json()["data"]
+
+
+def _online(created: dict[str, Any]) -> None:
+    STORE.set_user_model_online(
+        created["id"],
+        owner_user_id=created["owner_user_id"],
+        online=True,
+    )
+
+
+def _authorize(
+    client: TestClient,
+    key: dict[str, Any],
+    model_id: str,
+    *,
+    idempotency_key: str,
+    input_tokens: int = 1_000,
+    output_tokens: int = 2_000,
+) -> dict[str, Any]:
+    response = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": key["hash"],
+            "model": model_id,
+            "estimated_input_tokens": input_tokens,
+            "max_output_tokens": output_tokens,
+            "idempotency_key": idempotency_key,
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["data"]
+
+
+def _settle(
+    client: TestClient,
+    authorization_id: str,
+    *,
+    input_tokens: int = 1_000,
+    output_tokens: int = 2_000,
+) -> Any:
+    return client.post(
+        "/v1/internal/gateway/settle",
+        json={
+            "authorization_id": authorization_id,
+            "actual_input_tokens": input_tokens,
+            "actual_output_tokens": output_tokens,
+            "elapsed_seconds": 0.2,
+            "first_token_seconds": 0.05,
+        },
+    )
+
+
+def _refund(
+    client: TestClient,
+    authorization_id: str,
+    *,
+    error_status: int | None = None,
+    error_type: str | None = None,
+) -> Any:
+    body: dict[str, Any] = {"authorization_id": authorization_id}
+    if error_status is not None:
+        body["error_status"] = error_status
+    if error_type is not None:
+        body["error_type"] = error_type
+    return client.post("/v1/internal/gateway/refund", json=body)
 
 
 def test_user_model_crud_ownership_and_one_time_secrets(client: TestClient) -> None:
@@ -303,6 +382,304 @@ def test_gateway_authorization_freezes_user_model_attribution(
     assert authorization.user_model_owner_user_id == created["owner_user_id"]
 
 
+def test_gateway_settle_uses_frozen_prices_and_pays_owner_once(
+    dispatch_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = dispatch_client
+    payer_headers = {"x-trustedrouter-user": "user-model-payer@example.com"}
+    key = _create_key(client, headers=payer_headers)
+    body = _body(slug="frozen-billing")
+    prompt_price = 2_000_000
+    completion_price = 3_000_000
+    body["prompt_price_microdollars_per_million_tokens"] = prompt_price
+    body["completion_price_microdollars_per_million_tokens"] = completion_price
+    created = _create(client, body=body)
+    _online(created)
+    authorization = _authorize(
+        client,
+        key,
+        created["id"],
+        idempotency_key="user-model-frozen-billing",
+    )
+
+    patched = client.patch(
+        f"/v1/user-models/{created['id']}",
+        headers=HEADERS,
+        json={
+            "prompt_price_microdollars_per_million_tokens": 10 * prompt_price,
+            "completion_price_microdollars_per_million_tokens": 10 * completion_price,
+        },
+    )
+    assert patched.status_code == 200, patched.text
+
+    result_calls = 0
+    original = InMemoryUserProvidedModels.record_dispatch_result
+
+    def counted_result(
+        self: InMemoryUserProvidedModels,
+        model_id: str,
+        *,
+        success: bool,
+    ) -> Any:
+        nonlocal result_calls
+        result_calls += 1
+        return original(self, model_id, success=success)
+
+    monkeypatch.setattr(
+        InMemoryUserProvidedModels,
+        "record_dispatch_result",
+        counted_result,
+    )
+
+    settled = _settle(client, authorization["authorization_id"])
+    assert settled.status_code == 200, settled.text
+    actual_cost = custom_model_cost_microdollars(
+        input_tokens=1_000,
+        output_tokens=2_000,
+        prompt_price=prompt_price,
+        completion_price=completion_price,
+    )
+    payout = owner_share_microdollars(actual_cost)
+    assert settled.json()["data"]["cost_microdollars"] == actual_cost
+
+    summary = STORE.earnings_summary(created["owner_user_id"])
+    assert summary == {
+        "total_earned": payout,
+        "total_transferred": 0,
+        "available": payout,
+    }
+    movements = STORE.list_credit_movements(f"user:{created['owner_user_id']}")
+    assert len(movements) == 1
+    movement = movements[0]
+    assert movement.movement_id == user_model_payout_event_id(
+        authorization["authorization_id"]
+    )
+    assert movement.kind == "custom_model_payout"
+    assert movement.amount_microdollars == payout
+    payer = STORE.find_user_by_email(payer_headers["x-trustedrouter-user"])
+    assert payer is not None
+    payer_workspace = STORE.list_workspaces_for_user(payer.id)[0]
+    assert movement.counterparty_account_id == payer_workspace.id
+    assert movement.custom_model_id == created["id"]
+
+    generation_id = settled.json()["data"]["generation_id"]
+    generation = STORE.get_generation(generation_id)
+    assert generation is not None
+    assert generation.custom_model_id == created["id"]
+    assert generation.operator_cost_microdollars == payout
+    assert generation.elapsed_milliseconds == 200
+    assert generation.first_token_milliseconds == 50
+
+    replay = _settle(client, authorization["authorization_id"])
+    assert replay.status_code == 200, replay.text
+    assert replay.json()["data"]["already_settled"] is True
+    assert STORE.earnings_summary(created["owner_user_id"])["total_earned"] == payout
+    assert len(STORE.list_credit_movements(f"user:{created['owner_user_id']}")) == 1
+    assert result_calls == 1
+
+
+def test_gateway_refund_releases_hold_without_payout(
+    dispatch_client: TestClient,
+) -> None:
+    client = dispatch_client
+    key = _create_key(client)
+    body = _body(slug="refund-billing")
+    body["prompt_price_microdollars_per_million_tokens"] = 2_000_000
+    body["completion_price_microdollars_per_million_tokens"] = 3_000_000
+    created = _create(client, body=body)
+    _online(created)
+    authorization = _authorize(
+        client,
+        key,
+        created["id"],
+        idempotency_key="user-model-refund-billing",
+    )
+    workspace_money = STORE.credit_money[created["owner_workspace_id"]]
+    assert workspace_money.reserved_microdollars > 0
+
+    refunded = _refund(client, authorization["authorization_id"])
+    assert refunded.status_code == 200, refunded.text
+    assert refunded.json()["data"]["cost_microdollars"] == 0
+    assert workspace_money.reserved_microdollars == 0
+    assert workspace_money.total_usage_microdollars == 0
+    assert STORE.earnings_summary(created["owner_user_id"])["total_earned"] == 0
+    assert STORE.list_credit_movements(f"user:{created['owner_user_id']}") == []
+
+
+def test_deleted_user_model_still_settles_from_frozen_authorization(
+    dispatch_client: TestClient,
+) -> None:
+    client = dispatch_client
+    payer_headers = {"x-trustedrouter-user": "deleted-model-payer@example.com"}
+    key = _create_key(client, headers=payer_headers)
+    body = _body(slug="deleted-before-settle")
+    body["prompt_price_microdollars_per_million_tokens"] = 2_000_000
+    body["completion_price_microdollars_per_million_tokens"] = 3_000_000
+    created = _create(client, body=body)
+    _online(created)
+    authorization = _authorize(
+        client,
+        key,
+        created["id"],
+        idempotency_key="user-model-deleted-before-settle",
+    )
+    deleted = client.delete(f"/v1/user-models/{created['id']}", headers=HEADERS)
+    assert deleted.status_code == 200, deleted.text
+
+    settled = _settle(client, authorization["authorization_id"])
+    assert settled.status_code == 200, settled.text
+    payout = owner_share_microdollars(settled.json()["data"]["cost_microdollars"])
+    assert payout > 0
+    assert STORE.earnings_summary(created["owner_user_id"])["total_earned"] == payout
+    movement = STORE.list_credit_movements(f"user:{created['owner_user_id']}")[0]
+    assert movement.custom_model_id == created["id"]
+
+
+def test_user_model_self_usage_nets_owner_to_thirty_percent(
+    dispatch_client: TestClient,
+) -> None:
+    client = dispatch_client
+    key = _create_key(client)
+    body = _body(slug="self-usage")
+    body["prompt_price_microdollars_per_million_tokens"] = 2_000_000
+    body["completion_price_microdollars_per_million_tokens"] = 3_000_000
+    created = _create(client, body=body)
+    _online(created)
+    authorization = _authorize(
+        client,
+        key,
+        created["id"],
+        idempotency_key="user-model-self-usage",
+    )
+    settled = _settle(client, authorization["authorization_id"])
+    assert settled.status_code == 200, settled.text
+    charge = settled.json()["data"]["cost_microdollars"]
+    earned = STORE.earnings_summary(created["owner_user_id"])["available"]
+    assert earned == owner_share_microdollars(charge)
+    assert charge - earned == charge * 3_000 // 10_000
+
+
+def test_gateway_refund_strikes_only_owner_faults_and_success_resets(
+    dispatch_client: TestClient,
+) -> None:
+    client = dispatch_client
+    key = _create_key(client)
+    created = _create(client, body=_body(slug="gateway-strikes"))
+    _online(created)
+    request_number = 0
+
+    def authorization() -> dict[str, Any]:
+        nonlocal request_number
+        request_number += 1
+        return _authorize(
+            client,
+            key,
+            created["id"],
+            idempotency_key=f"user-model-strike-{request_number}",
+        )
+
+    no_evidence = authorization()
+    response = _refund(client, no_evidence["authorization_id"])
+    assert response.status_code == 200, response.text
+    stored = STORE.get_user_model(created["id"])
+    assert stored is not None
+    assert stored.consecutive_dispatch_failures == 0
+
+    caller_fault = authorization()
+    response = _refund(
+        client,
+        caller_fault["authorization_id"],
+        error_status=422,
+        error_type="bad_request",
+    )
+    assert response.status_code == 200, response.text
+    assert STORE.get_user_model(created["id"]).consecutive_dispatch_failures == 0  # type: ignore[union-attr]
+
+    for _ in range(2):
+        owner_fault = authorization()
+        response = _refund(
+            client,
+            owner_fault["authorization_id"],
+            error_status=503,
+        )
+        assert response.status_code == 200, response.text
+    assert STORE.get_user_model(created["id"]).consecutive_dispatch_failures == 2  # type: ignore[union-attr]
+
+    success = authorization()
+    response = _settle(client, success["authorization_id"])
+    assert response.status_code == 200, response.text
+    stored = STORE.get_user_model(created["id"])
+    assert stored is not None
+    assert stored.consecutive_dispatch_failures == 0
+    assert stored.online is True
+
+    for _ in range(3):
+        owner_fault = authorization()
+        response = _refund(
+            client,
+            owner_fault["authorization_id"],
+            error_type="user_model_timeout",
+        )
+        assert response.status_code == 200, response.text
+    stored = STORE.get_user_model(created["id"])
+    assert stored is not None
+    assert stored.consecutive_dispatch_failures == 3
+    assert stored.online is False
+
+
+def test_gateway_user_model_concurrency_slot_releases_on_settle_and_refund(
+    dispatch_client: TestClient,
+) -> None:
+    client = dispatch_client
+    key = _create_key(client)
+    body = _body(slug="one-at-a-time")
+    body["max_concurrency"] = 1
+    created = _create(client, body=body)
+    _online(created)
+
+    first = _authorize(
+        client,
+        key,
+        created["id"],
+        idempotency_key="user-model-capacity-first",
+    )
+    at_capacity = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": key["hash"],
+            "model": created["id"],
+            "estimated_input_tokens": 1_000,
+            "max_output_tokens": 2_000,
+            "idempotency_key": "user-model-capacity-second",
+        },
+    )
+    assert at_capacity.status_code == 429, at_capacity.text
+    assert at_capacity.json()["error"]["type"] == "rate_limited"
+    assert at_capacity.json()["error"]["message"] == (
+        f"User-provided model {created['id']} is at capacity (1 concurrent)"
+    )
+
+    settled = _settle(client, first["authorization_id"])
+    assert settled.status_code == 200, settled.text
+    third = _authorize(
+        client,
+        key,
+        created["id"],
+        idempotency_key="user-model-capacity-third",
+    )
+    refunded = _refund(client, third["authorization_id"])
+    assert refunded.status_code == 200, refunded.text
+    fourth = _authorize(
+        client,
+        key,
+        created["id"],
+        idempotency_key="user-model-capacity-fourth",
+    )
+    cleanup = _refund(client, fourth["authorization_id"])
+    assert cleanup.status_code == 200, cleanup.text
+
+
 def test_gateway_resolves_user_model_dispatch_block(dispatch_client: TestClient) -> None:
     client = dispatch_client
     key = _create_key(client)
@@ -415,6 +792,137 @@ def test_local_inference_dispatches_user_model_before_frozen_catalog_routing(
     )
     assert response.status_code == 200, response.text
     assert response.json()["choices"][0]["message"]["content"] == "owner reply"
+
+
+def test_local_user_model_dispatch_bills_pays_and_refunds_owner_failure(
+    client: TestClient,
+    inference_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    body = _body(slug="local-billing")
+    body["supports_streaming"] = False
+    body["prompt_price_microdollars_per_million_tokens"] = 2_000_000
+    body["completion_price_microdollars_per_million_tokens"] = 3_000_000
+    created = _create(client, body=body)
+
+    async def passing_probe(*_args: Any, **_kwargs: Any) -> ProbeResult:
+        return ProbeResult(ok=True, detail="ok")
+
+    monkeypatch.setattr("trusted_router.routes.user_models.probe_user_model", passing_probe)
+    clocked_in = client.post(
+        f"/v1/user-models/{created['id']}/clock-in",
+        headers=HEADERS,
+    )
+    assert clocked_in.status_code == 200, clocked_in.text
+
+    async def owner_success(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-local-billing",
+                "object": "chat.completion",
+                "model": "owner-model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "owner billed reply"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 1_000,
+                    "completion_tokens": 2_000,
+                    "total_tokens": 3_000,
+                },
+            },
+        )
+
+    async def success_dispatch(
+        model: Any,
+        request_body: dict[str, Any],
+        settings: Settings,
+    ) -> BufferedUserModelDispatch:
+        return await dispatch_user_model(
+            model,
+            request_body,
+            settings,
+            transport=httpx.MockTransport(owner_success),
+        )
+
+    monkeypatch.setattr(
+        "trusted_router.routes.inference.dispatch_user_model",
+        success_dispatch,
+    )
+    payer = STORE.find_user_by_email("alice@example.com")
+    assert payer is not None
+    payer_workspace = STORE.list_workspaces_for_user(payer.id)[0]
+    payer_money = STORE.credit_money[payer_workspace.id]
+    usage_before = payer_money.total_usage_microdollars
+    response = client.post(
+        "/v1/chat/completions",
+        headers=inference_headers,
+        json={
+            "model": created["id"],
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_tokens": 2_000,
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["choices"][0]["message"]["content"] == "owner billed reply"
+    actual_cost = custom_model_cost_microdollars(
+        input_tokens=1_000,
+        output_tokens=2_000,
+        prompt_price=2_000_000,
+        completion_price=3_000_000,
+    )
+    payout = owner_share_microdollars(actual_cost)
+    assert payer_money.total_usage_microdollars - usage_before == actual_cost
+    assert payer_money.reserved_microdollars == 0
+    assert STORE.earnings_summary(created["owner_user_id"])["total_earned"] == payout
+    movement = STORE.list_credit_movements(f"user:{created['owner_user_id']}")[0]
+    assert movement.amount_microdollars == payout
+    assert movement.counterparty_account_id == payer_workspace.id
+    assert movement.custom_model_id == created["id"]
+    generation = next(iter(STORE.target.generation_store.generations.values()))
+    assert generation.custom_model_id == created["id"]
+    assert movement.movement_id == user_model_payout_event_id(generation.id)
+
+    async def owner_failure(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"error": "owner unavailable"})
+
+    async def failure_dispatch(
+        model: Any,
+        request_body: dict[str, Any],
+        settings: Settings,
+    ) -> BufferedUserModelDispatch:
+        return await dispatch_user_model(
+            model,
+            request_body,
+            settings,
+            transport=httpx.MockTransport(owner_failure),
+        )
+
+    monkeypatch.setattr(
+        "trusted_router.routes.inference.dispatch_user_model",
+        failure_dispatch,
+    )
+    usage_after_success = payer_money.total_usage_microdollars
+    failed = client.post(
+        "/v1/chat/completions",
+        headers=inference_headers,
+        json={
+            "model": created["id"],
+            "messages": [{"role": "user", "content": "try again"}],
+            "max_tokens": 2_000,
+        },
+    )
+    assert failed.status_code == 502, failed.text
+    assert payer_money.total_usage_microdollars == usage_after_success
+    assert payer_money.reserved_microdollars == 0
+    assert STORE.earnings_summary(created["owner_user_id"])["total_earned"] == payout
+    stored = STORE.get_user_model(created["id"])
+    assert stored is not None
+    assert stored.consecutive_dispatch_failures == 1
 
 
 def test_public_shape_is_secret_free_and_resolves_operator_identities(

--- a/tests/test_user_models.py
+++ b/tests/test_user_models.py
@@ -14,6 +14,7 @@ from trusted_router.custom_model_billing import (
     user_model_payout_event_id,
 )
 from trusted_router.main import create_app
+from trusted_router.provider_types import estimate_tokens_from_messages
 from trusted_router.services.user_model_dispatch import (
     BufferedUserModelDispatch,
     dispatch_user_model,
@@ -869,12 +870,24 @@ def test_local_user_model_dispatch_bills_pays_and_refunds_owner_failure(
     )
     assert response.status_code == 200, response.text
     assert response.json()["choices"][0]["message"]["content"] == "owner billed reply"
-    actual_cost = custom_model_cost_microdollars(
+    # The owner reported 1,000 prompt tokens for "hello": more than the caller
+    # authorized. The charge is the owner-priced usage capped at the hold the
+    # caller's request reserved (estimated prompt + max_tokens at frozen
+    # prices) — the payee's meter can never exceed the payer's authorization.
+    reported_cost = custom_model_cost_microdollars(
         input_tokens=1_000,
         output_tokens=2_000,
         prompt_price=2_000_000,
         completion_price=3_000_000,
     )
+    hold = custom_model_cost_microdollars(
+        input_tokens=estimate_tokens_from_messages([{"role": "user", "content": "hello"}]),
+        output_tokens=2_000,
+        prompt_price=2_000_000,
+        completion_price=3_000_000,
+    )
+    assert reported_cost > hold
+    actual_cost = hold
     payout = owner_share_microdollars(actual_cost)
     assert payer_money.total_usage_microdollars - usage_before == actual_cost
     assert payer_money.reserved_microdollars == 0


### PR DESCRIPTION
## Summary

Phase 5 of user-provided Custom Models (plan: peppy-herding-clover). **Stacked on #602** — the diff shows Phase 4 until that merges; Phase 5 proper is the last 5 commits.

Closes the defect that kept `user_models_dispatch_enabled` dark: settle/refund did not recognise the synthetic `…@trustedrouter/credits` endpoint, so a user-model authorization could be created but never settled or refunded (hold stranded until TTL).

- **Settle/refund recognise the frozen authorization** — the sentinel is rebuilt from the authorization's own frozen price/owner fields, never from the live model: price edits and deletion mid-flight change nothing; deletion cannot break settle/refund.
- **Billing at frozen owner prices** via `custom_model_cost_microdollars`: no markup, no catalog floor, no cache/tier/native-batch/partner paths; OpenAI-dialect prompt accounting (no cache double-bill); additional cost rejected. Operator COGS = owner share.
- **Charge capped at the authorized hold** on the gateway and the local route — the token counts are the *payee's* meter, so an owner reporting 10⁷ tokens for a 10-token answer can't drain a workspace or pocket 70% of it.
- **Exactly-once payout** into the owner's earnings wallet inside `typed_finalize_atomic` (claim-gated txn; movement PK `custom_model_payout:{authorization_id}` as the second guard, `INSERT OR IGNORE` → earnings bump). Frozen payout ints ride the settle outbox; `apply_frozen_settle` pops them without pricing imports. Legacy/memory path via `credit_user_earnings`. Payout errors are **loud** (abort the finalize → retried / surfaced), not swallowed — a partial commit would otherwise read as "already paid" forever.
- **Strikes from settle/refund** via a shared `is_owner_fault`: explicit non-fault tokens never strike; with a status only 5xx strikes; without one only transport/shape tokens do. Replays don't re-record.
- **Concurrency slots** (control plane owns them): acquired at authorize (429 at capacity), released on settle/refund/already-settled/authorize-error/**outbox repair**; per-row `expires_at` = kind budget + 120s so an enclave crash can't black a model out for hours.
- **Local billing parity**: `/v1/chat/completions` user-model branch reserves via `reserved_quota`, settles from owner usage (or estimate), records the Generation with `custom_model_id`, pays the owner — both quadrants tested end to end.
- **Owner secrets** sealed under a new AAD namespace `user_model` (in #602's last commit; needed by the enclave in Phase 6).
- Flag `user_models_dispatch_enabled` **stays OFF** in this PR.

## Review

Adversarial multi-lens review (7 finders → 2 skeptics per finding; the verify phase was cut short by a session limit so I triaged the remainder by hand). Closed in `6eea3f28`: the payout `PENDING_COMMIT_TIMESTAMP()` into a non-commit-ts column (would have paid **no** owner on 100% of prod settles, silently — the fake had been loosened to hide it; now strict), the deterministic authorization id (all traffic; 30-day auth row vs 400-day movement PK → dropped payouts, winner-slot release), the payout swallow, cache double-billing, unbounded owner-reported usage, `provider_error`+4xx strikes, OpenAI usage-only chunk treated as malformed, 2h slot TTL, outbox path never releasing slots, raw-spelling `selected_model` refusal. Mutation-checked: dropping the inline payout, the commit-timestamp mutant.

## Gates

`ruff check` ✅ · `mypy` ✅ (265 files) · `pytest -n 4 --dist loadgroup` ✅ 4063+ passed / 290 skipped / 10 xfailed.

## After merge

Rebase check vs main (stacked on #602). Phase 6 (enclave dispatch, quill-cloud-proxy) is being written in parallel; the flag flips only after both land and a prod canary model settles + pays end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
