### PR TITLE
Activate identity verification + custom-model verification gate (Veriff secrets are live)

### DIFF
--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -346,17 +346,18 @@ ENV_VARS=(
   # one is a 422 or a 403 on every call.
   "TR_NOTIFY_ENABLED=true"
   "TR_NOTIFY_SMS_AVAILABLE=false"
-  # Identity verification ships DARK and the custom-model gate ships OFF, as a
-  # pair. They must flip together: enabling the gate without a reachable
-  # Veriff would 403 every custom-model create/edit with an unsatisfiable
-  # "identity_verified" — a silent lockout, not a boot failure. Activation
-  # (once trustedrouter-veriff-{api-key,shared-secret-key} exist in Secret
-  # Manager — the deploy SA can read them but not create them):
-  #   TR_VERIFF_ENABLED=true and TR_CUSTOM_MODELS_REQUIRE_VERIFICATION=true.
-  # The config validator refuses TR_VERIFF_ENABLED=true without both secrets,
-  # so a premature flip fails loud at boot rather than serving broken.
-  "TR_VERIFF_ENABLED=false"
-  "TR_CUSTOM_MODELS_REQUIRE_VERIFICATION=false"
+  # Identity verification and the custom-model verification gate are a PAIR
+  # and must flip together: enabling the gate without a reachable Veriff
+  # would 403 every custom-model create/edit with an unsatisfiable
+  # "identity_verified" — a silent lockout, not a boot failure. Activated
+  # 2026-08-16 once trustedrouter-veriff-{api-key,shared-secret-key} existed
+  # in Secret Manager (the deploy SA reads them via add_secret_env_if_exists
+  # above; it cannot create them). The config validator refuses
+  # TR_VERIFF_ENABLED=true without both secrets, so a rollout that lost them
+  # fails loud at boot rather than serving broken. To go dark again, set BOTH
+  # back to false in one commit.
+  "TR_VERIFF_ENABLED=true"
+  "TR_CUSTOM_MODELS_REQUIRE_VERIFICATION=true"
   "TR_VERIFF_BASE_URL=https://stationapi.veriff.com"
   "TR_TELNYX_FROM_NUMBER=+17869471547"
   "TR_TELNYX_TEXML_ACCOUNT_ID=1eea716a-02e0-4d4f-96fa-36d1f556edca"

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -74,12 +74,16 @@ def test_deploy_wires_veriff_config_and_secrets() -> None:
     rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
     secrets = (ROOT / "scripts/deploy/secrets.sh").read_text()
 
-    # Ships dark, as a PAIR: enabling the custom-model gate without a reachable
-    # Veriff would 403 every create/edit with an unsatisfiable requirement.
-    # Both flip to true in one step once the secrets exist in Secret Manager.
-    assert '"TR_VERIFF_ENABLED=false"' in rollout
-    assert '"TR_CUSTOM_MODELS_REQUIRE_VERIFICATION=false"' in rollout
-    assert '"TR_VERIFF_ENABLED=true"' not in rollout
+    # A PAIR that must agree: enabling the custom-model gate without a
+    # reachable Veriff would 403 every create/edit with an unsatisfiable
+    # requirement. Activated together 2026-08-16 (secrets exist); if either
+    # ever flips back, the other must flip with it in the same commit.
+    veriff_enabled = '"TR_VERIFF_ENABLED=true"' in rollout
+    gate_enabled = '"TR_CUSTOM_MODELS_REQUIRE_VERIFICATION=true"' in rollout
+    assert veriff_enabled == gate_enabled, (
+        "TR_VERIFF_ENABLED and TR_CUSTOM_MODELS_REQUIRE_VERIFICATION must flip together"
+    )
+    assert veriff_enabled, "identity verification is meant to be live in prod"
     assert '"TR_VERIFF_BASE_URL=https://stationapi.veriff.com"' in rollout
     assert (
         'add_secret_env_if_exists "TR_VERIFF_API_KEY" "trustedrouter-veriff-api-key"'


### PR DESCRIPTION
## Summary

Both Veriff secrets now exist in Secret Manager (`trustedrouter-veriff-api-key`, `trustedrouter-veriff-shared-secret-key`; verified readable). This flips the dark pair from #601 **together**:

- `TR_VERIFF_ENABLED=true`
- `TR_CUSTOM_MODELS_REQUIRE_VERIFICATION=true`

From this rollout, creating or editing **any** Custom Model (prompt-wrapper or user-provided) requires email → funding → verified phone → Veriff identity ($5/attempt). Existing models keep serving. The console verification page's "Start identity verification" button becomes live.

## Fail-loud guard

`Settings` refuses `TR_VERIFF_ENABLED=true` without both secret env vars, so if the deploy SA cannot read them the new revision fails at boot instead of serving a locked-out console. If that happens: re-run `scripts/deploy/secrets.sh` (it grants `tr-deploy@` accessor on both secrets) and re-run the rollout. To go dark again, set **both** back to `false` in one commit.

## Test

`tests/test_deploy_secret_wiring.py` now asserts the two flags agree (and that verification is live) instead of pinning the dark state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
