### PR TITLE
User-provided models: earnings API + console, payout reconciliation sweep, re-probe, health, reverse-harness contract (Phase 7)

### DIFF
--- a/scripts/reconcile_custom_model_payouts.py
+++ b/scripts/reconcile_custom_model_payouts.py
@@ -1,0 +1,400 @@
+"""Reconcile user-model generations against their exactly-once payouts.
+
+The sweep is read-only by default and emits JSON Lines. Pass ``--apply`` to
+credit missing payouts through the existing event-claim primitive.
+
+Examples:
+  uv run python scripts/reconcile_custom_model_payouts.py
+  uv run python scripts/reconcile_custom_model_payouts.py --since 2026-08-15T00:00:00Z --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, TypeVar, cast
+
+os.environ.setdefault("TR_STORAGE_BACKEND", "spanner-bigtable")
+os.environ.setdefault("TR_GCP_PROJECT_ID", "quill-cloud-proxy")
+os.environ.setdefault("TR_SPANNER_INSTANCE_ID", "trusted-router-nam6")
+os.environ.setdefault("TR_SPANNER_DATABASE_ID", "trusted-router")
+os.environ.setdefault("TR_BIGTABLE_INSTANCE_ID", "trusted-router-logs")
+os.environ.setdefault("TR_BIGTABLE_GENERATION_TABLE", "trustedrouter-generations")
+
+from trusted_router.config import Settings
+from trusted_router.custom_model_billing import (
+    owner_share_microdollars,
+    user_model_payout_event_id,
+)
+from trusted_router.storage import create_store
+from trusted_router.storage_models import (
+    CreditMovement,
+    GatewayAuthorization,
+    Generation,
+)
+
+DEFAULT_SINCE_HOURS = 48
+_PAYOUT_KIND = "custom_model_payout"
+_PAYOUT_PREFIX = "custom_model_payout:"
+T = TypeVar("T")
+
+
+@dataclass
+class ReconciliationSummary:
+    authorizations_scanned: int = 0
+    generations_checked: int = 0
+    missing_payouts: int = 0
+    payouts_applied: int = 0
+    owner_unknown: int = 0
+    generation_missing: int = 0
+    attribution_mismatches: int = 0
+    orphan_payouts: int = 0
+
+
+def reconcile_custom_model_payouts(
+    store: Any,
+    *,
+    since: datetime,
+    apply: bool = False,
+    emit: Callable[[dict[str, Any]], None] | None = None,
+) -> ReconciliationSummary:
+    """Find missing and orphaned user-model payouts in one bounded window."""
+    output = emit or _emit_json
+    cutoff = _as_utc(since)
+    authorizations = _scan_authorizations(store, cutoff)
+    payouts = _scan_payout_movements(store, cutoff)
+    payout_by_account_and_event = {
+        (movement.account_id, movement.movement_id): movement for movement in payouts
+    }
+    summary = ReconciliationSummary(authorizations_scanned=len(authorizations))
+    generation_cache: dict[str, Generation | None] = {}
+
+    def generation(generation_id: str) -> Generation | None:
+        if generation_id not in generation_cache:
+            generation_cache[generation_id] = store.get_generation(generation_id)
+        return generation_cache[generation_id]
+
+    for authorization in authorizations:
+        if (
+            not authorization.user_provided_model_id
+            or authorization.finalization_outcome != "settled"
+            or not authorization.finalized_generation_id
+        ):
+            continue
+        stored_generation = generation(authorization.finalized_generation_id)
+        if stored_generation is None:
+            summary.generation_missing += 1
+            output(
+                {
+                    "type": "generation_missing",
+                    "authorization_id": authorization.id,
+                    "generation_id": authorization.finalized_generation_id,
+                }
+            )
+            continue
+        if (
+            stored_generation.custom_model_id is None
+            or stored_generation.custom_model_id
+            != authorization.user_provided_model_id
+        ):
+            summary.attribution_mismatches += 1
+            output(
+                {
+                    "type": "generation_attribution_mismatch",
+                    "authorization_id": authorization.id,
+                    "generation_id": stored_generation.id,
+                    "authorization_model_id": authorization.user_provided_model_id,
+                    "generation_model_id": stored_generation.custom_model_id,
+                }
+            )
+            continue
+        summary.generations_checked += 1
+        # The payee is whoever owned the model when the request was
+        # authorized — frozen on the authorization by Phase 5 — so a model
+        # deleted since then is still reconcilable. The live model is only a
+        # fallback for authorizations that predate the frozen field.
+        owner_user_id = authorization.user_model_owner_user_id
+        if not owner_user_id:
+            model = store.get_user_model(stored_generation.custom_model_id)
+            owner_user_id = model.owner_user_id if model is not None else None
+        if not owner_user_id:
+            summary.owner_unknown += 1
+            output(
+                {
+                    "type": "owner_unknown",
+                    "authorization_id": authorization.id,
+                    "generation_id": stored_generation.id,
+                    "model_id": stored_generation.custom_model_id,
+                }
+            )
+            continue
+        expected_amount = owner_share_microdollars(
+            stored_generation.total_cost_microdollars
+        )
+        if expected_amount <= 0:
+            continue
+        event_id = user_model_payout_event_id(authorization.id)
+        account_id = f"user:{owner_user_id}"
+        if (account_id, event_id) in payout_by_account_and_event:
+            continue
+        summary.missing_payouts += 1
+        applied = False
+        if apply:
+            applied = bool(
+                store.credit_user_earnings(
+                    owner_user_id,
+                    expected_amount,
+                    event_id,
+                    custom_model_id=stored_generation.custom_model_id,
+                    payer_workspace_id=stored_generation.workspace_id,
+                )
+            )
+            if applied:
+                summary.payouts_applied += 1
+        output(
+            {
+                "type": "missing_payout",
+                "authorization_id": authorization.id,
+                "generation_id": stored_generation.id,
+                "model_id": stored_generation.custom_model_id,
+                "owner_user_id": owner_user_id,
+                "payer_workspace_id": stored_generation.workspace_id,
+                "expected_amount_microdollars": expected_amount,
+                "applied": applied,
+            }
+        )
+
+    authorization_cache = {authorization.id: authorization for authorization in authorizations}
+    for movement in payouts:
+        authorization_id = _payout_authorization_id(movement)
+        authorization = (
+            authorization_cache.get(authorization_id)
+            if authorization_id is not None
+            else None
+        )
+        if authorization is None and authorization_id is not None:
+            authorization = store.get_gateway_authorization(authorization_id)
+        generation_id = (
+            authorization.finalized_generation_id if authorization is not None else None
+        )
+        if generation_id and generation(generation_id) is not None:
+            continue
+        summary.orphan_payouts += 1
+        output(
+            {
+                "type": "orphan_payout",
+                "movement_id": movement.movement_id,
+                "account_id": movement.account_id,
+                "authorization_id": authorization_id,
+                "generation_id": generation_id,
+                "amount_microdollars": movement.amount_microdollars,
+            }
+        )
+
+    output(
+        {
+            "type": "summary",
+            "since": cutoff.isoformat().replace("+00:00", "Z"),
+            "apply": apply,
+            **dataclasses.asdict(summary),
+        }
+    )
+    return summary
+
+
+def _scan_authorizations(store: Any, since: datetime) -> list[GatewayAuthorization]:
+    target = _store_target(store)
+    if hasattr(target, "api_keys") and hasattr(
+        target.api_keys, "gateway_authorizations"
+    ):
+        return sorted(
+            (
+                authorization
+                for authorization in target.api_keys.gateway_authorizations.values()
+                if authorization.settled
+                and _parse_iso(authorization.created_at) >= since
+            ),
+            key=lambda authorization: (authorization.created_at, authorization.id),
+        )
+    if hasattr(target, "_database") and hasattr(target, "_param_types"):
+        with target._database.snapshot() as snapshot:
+            rows = list(
+                snapshot.execute_sql(
+                    "SELECT payload FROM tr_gateway_authorization "
+                    "WHERE settled=true AND created_at>=@since "
+                    "ORDER BY created_at, authorization_id",
+                    params={"since": since},
+                    param_types={"since": target._param_types.TIMESTAMP},
+                )
+            )
+        return [
+            _dataclass_from_json(row[0], GatewayAuthorization)
+            for row in rows
+            if row[0]
+        ]
+    if hasattr(target, "_run_transaction"):
+        def read(conn: Any) -> list[GatewayAuthorization]:
+            rows = conn.execute(
+                "SELECT body FROM tr_entities "
+                "WHERE kind = %s AND updated_at >= %s ORDER BY updated_at, id",
+                ("gateway_authorization", since),
+            ).fetchall()
+            return [
+                authorization
+                for row in rows
+                if (
+                    (authorization := _dataclass_from_json(
+                        row[0], GatewayAuthorization
+                    )).settled
+                    and _parse_iso(authorization.created_at) >= since
+                )
+            ]
+
+        return cast(list[GatewayAuthorization], target._run_transaction(read))
+    raise TypeError(f"unsupported reconciliation store: {type(target).__name__}")
+
+
+def _scan_payout_movements(store: Any, since: datetime) -> list[CreditMovement]:
+    target = _store_target(store)
+    if hasattr(target, "credit_movements"):
+        return sorted(
+            (
+                movement
+                for movement in target.credit_movements.values()
+                if movement.kind == _PAYOUT_KIND
+                and _parse_iso(movement.created_at) >= since
+            ),
+            key=lambda movement: (movement.created_at, movement.movement_id),
+        )
+    if hasattr(target, "_database") and hasattr(target, "_param_types"):
+        with target._database.snapshot() as snapshot:
+            rows = list(
+                snapshot.execute_sql(
+                    "SELECT account_id, movement_id, kind, amount_microdollars, "
+                    "counterparty_account_id, custom_model_id, authorization_id, created_at "
+                    "FROM tr_credit_movement "
+                    "WHERE kind='custom_model_payout' AND created_at>=@since "
+                    "ORDER BY created_at, account_id, movement_id",
+                    params={"since": since},
+                    param_types={"since": target._param_types.TIMESTAMP},
+                )
+            )
+        return [_movement_from_row(row) for row in rows]
+    if hasattr(target, "_run_transaction"):
+        def read(conn: Any) -> list[CreditMovement]:
+            rows = conn.execute(
+                "SELECT account_id, movement_id, kind, amount_microdollars, "
+                "counterparty_account_id, custom_model_id, authorization_id, created_at "
+                "FROM tr_credit_movement "
+                "WHERE kind = %s AND created_at >= %s "
+                "ORDER BY created_at, account_id, movement_id",
+                (_PAYOUT_KIND, since),
+            ).fetchall()
+            return [_movement_from_row(row) for row in rows]
+
+        return cast(list[CreditMovement], target._run_transaction(read))
+    raise TypeError(f"unsupported reconciliation store: {type(target).__name__}")
+
+
+def _movement_from_row(row: Any) -> CreditMovement:
+    return CreditMovement(
+        account_id=str(row[0]),
+        movement_id=str(row[1]),
+        kind=str(row[2]),
+        amount_microdollars=int(row[3]),
+        counterparty_account_id=None if row[4] is None else str(row[4]),
+        custom_model_id=None if row[5] is None else str(row[5]),
+        authorization_id=None if row[6] is None else str(row[6]),
+        created_at=_timestamp_string(row[7]),
+    )
+
+
+def _payout_authorization_id(movement: CreditMovement) -> str | None:
+    if movement.authorization_id:
+        return movement.authorization_id
+    if movement.movement_id.startswith(_PAYOUT_PREFIX):
+        suffix = movement.movement_id.removeprefix(_PAYOUT_PREFIX)
+        return suffix or None
+    return None
+
+
+def _dataclass_from_json(raw: Any, cls: type[T]) -> T:
+    data = json.loads(raw) if isinstance(raw, str) else dict(raw)
+    known = {field.name for field in dataclasses.fields(cast(Any, cls))}
+    return cls(**{key: value for key, value in data.items() if key in known})
+
+
+def _store_target(store: Any) -> Any:
+    return getattr(store, "target", store)
+
+
+def _parse_iso(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return _as_utc(parsed)
+
+
+def _timestamp_string(value: Any) -> str:
+    if isinstance(value, str):
+        return _parse_iso(value).isoformat().replace("+00:00", "Z")
+    if isinstance(value, datetime):
+        return _as_utc(value).isoformat().replace("+00:00", "Z")
+    raise TypeError("movement timestamp is not a datetime")
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _since_argument(raw: str) -> datetime:
+    try:
+        return _parse_iso(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("since must be an ISO timestamp") from exc
+
+
+def _emit_json(record: dict[str, Any]) -> None:
+    print(json.dumps(record, separators=(",", ":"), sort_keys=True))
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--since",
+        type=_since_argument,
+        default=datetime.now(UTC) - timedelta(hours=DEFAULT_SINCE_HOURS),
+        help="ISO timestamp; defaults to 48 hours ago",
+    )
+    parser.add_argument("--apply", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    store = create_store(Settings())
+    summary = reconcile_custom_model_payouts(
+        store,
+        since=args.since,
+        apply=args.apply,
+    )
+    unresolved_missing = summary.missing_payouts - summary.payouts_applied
+    has_unresolved_findings = any(
+        (
+            unresolved_missing,
+            summary.owner_unknown,
+            summary.generation_missing,
+            summary.attribution_mismatches,
+            summary.orphan_payouts,
+        )
+    )
+    return 1 if has_unresolved_findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reprobe_user_models.py
+++ b/scripts/reprobe_user_models.py
@@ -1,0 +1,79 @@
+"""Periodically probe online user-provided models.
+
+Dry-run is the default and only prints the models that would be probed. Pass
+``--apply`` to send the signed canaries and persist their probe status.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import dataclasses
+import json
+import os
+
+os.environ.setdefault("TR_STORAGE_BACKEND", "spanner-bigtable")
+os.environ.setdefault("TR_GCP_PROJECT_ID", "quill-cloud-proxy")
+os.environ.setdefault("TR_SPANNER_INSTANCE_ID", "trusted-router-nam6")
+os.environ.setdefault("TR_SPANNER_DATABASE_ID", "trusted-router")
+os.environ.setdefault("TR_BIGTABLE_INSTANCE_ID", "trusted-router-logs")
+os.environ.setdefault("TR_BIGTABLE_GENERATION_TABLE", "trustedrouter-generations")
+
+from trusted_router.config import Settings
+from trusted_router.services.user_model_reprobe import reprobe_user_models
+from trusted_router.storage import create_store
+
+
+def _positive_limit(raw: str) -> int:
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("limit must be an integer") from exc
+    if value < 1:
+        raise argparse.ArgumentTypeError("limit must be at least 1")
+    return value
+
+
+def _emit(record: dict[str, object]) -> None:
+    print(json.dumps(record, separators=(",", ":"), sort_keys=True))
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--limit", type=_positive_limit, default=100)
+    parser.add_argument("--kind", choices=("machine", "agent", "human"))
+    parser.add_argument("--apply", action="store_true")
+    return parser
+
+
+async def _run(args: argparse.Namespace) -> int:
+    settings = Settings()
+    store = create_store(settings)
+    report = await reprobe_user_models(
+        settings,
+        store=store,
+        limit=args.limit,
+        kind=args.kind,
+        apply=args.apply,
+    )
+    for record in report.records:
+        _emit({"type": "model", **dataclasses.asdict(record)})
+    _emit(
+        {
+            "type": "summary",
+            "scanned": report.scanned,
+            "attempted": report.attempted,
+            "passed": report.passed,
+            "failed": report.failed,
+            "dry_run": report.dry_run,
+        }
+    )
+    return 1 if report.failed else 0
+
+
+def main() -> int:
+    return asyncio.run(_run(_parser().parse_args()))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trusted_router/custom_model_billing.py
+++ b/src/trusted_router/custom_model_billing.py
@@ -17,6 +17,14 @@ def user_model_payout_event_id(authorization_id: str) -> str:
     return f"custom_model_payout:{authorization_id}"
 
 
+def user_model_authorization_id_from_payout_event_id(event_id: str) -> str | None:
+    prefix = "custom_model_payout:"
+    if not event_id.startswith(prefix):
+        return None
+    authorization_id = event_id.removeprefix(prefix)
+    return authorization_id or None
+
+
 def validate_custom_model_price(
     prompt_price: int,
     completion_price: int,

--- a/src/trusted_router/routes/console/__init__.py
+++ b/src/trusted_router/routes/console/__init__.py
@@ -22,6 +22,7 @@ from trusted_router.routes.console import (
     byok,
     credits,
     custom_models,
+    earnings,
     preferences,
     root,
     routing_page,
@@ -44,6 +45,7 @@ def register_console_routes(app: FastAPI) -> None:
     credits.register(app)
     custom_models.register(app)
     user_models.register(app)
+    earnings.register(app)
     activity.register(app)
     broadcast.register(app)
     byok.register(app)

--- a/src/trusted_router/routes/console/_shared.py
+++ b/src/trusted_router/routes/console/_shared.py
@@ -115,6 +115,7 @@ def _console_path_for_active(active: str) -> str:
         "byok": "/console/byok",
         "custom-models": "/console/custom-models",
         "user-models": "/console/user-models",
+        "earnings": "/console/earnings",
         "routing": "/console/routing",
         "activity": "/console/activity",
         "broadcast": "/console/broadcast",

--- a/src/trusted_router/routes/console/earnings.py
+++ b/src/trusted_router/routes/console/earnings.py
@@ -1,0 +1,142 @@
+"""Owner earnings ledger and credit transfer console."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from fastapi import FastAPI, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
+
+from trusted_router.auth import SettingsDep
+from trusted_router.money import dollars_to_microdollars, format_money_display
+from trusted_router.routes.console._shared import ConsoleDep, render
+from trusted_router.storage import STORE
+
+
+def register(app: FastAPI) -> None:
+    @app.get("/console/earnings")
+    async def console_earnings(
+        request: Request,
+        ctx: ConsoleDep,
+        settings: SettingsDep,
+    ) -> Response:
+        return HTMLResponse(_render_page(request, ctx, settings))
+
+    @app.post("/console/earnings/transfer")
+    async def console_transfer_earnings(
+        ctx: ConsoleDep,
+        workspace_id: str = Form(...),
+        amount: str = Form(...),
+        idempotency_key: str | None = Form(default=None, max_length=64),
+    ) -> Response:
+        workspace = next(
+            (candidate for candidate in ctx.workspaces if candidate.id == workspace_id),
+            None,
+        )
+        if workspace is None:
+            return _redirect("error=workspace")
+        if workspace.federated_home:
+            return _redirect("error=federated")
+        try:
+            amount_microdollars = dollars_to_microdollars(amount)
+        except ValueError:
+            return _redirect("error=amount")
+        if amount_microdollars <= 0:
+            return _redirect("error=amount")
+        event_suffix = idempotency_key or str(uuid.uuid4())
+        outcome = STORE.transfer_earnings_to_workspace(
+            ctx.user.id,
+            workspace.id,
+            amount_microdollars,
+            f"earnings_transfer:{ctx.user.id}:{event_suffix}",
+        )
+        if outcome == "insufficient":
+            return _redirect("error=insufficient")
+        return _redirect("saved=duplicate" if outcome == "duplicate" else "saved=transferred")
+
+
+def _render_page(request: Request, ctx: ConsoleDep, settings: SettingsDep) -> str:
+    since = (datetime.now(UTC) - timedelta(days=30)).isoformat().replace("+00:00", "Z")
+    summary = STORE.earnings_summary(ctx.user.id)
+    model_totals = STORE.custom_model_earnings_by_model(ctx.user.id, since=since)
+    by_model: list[dict[str, Any]] = []
+    for model_id, amount in sorted(
+        model_totals.items(),
+        key=lambda item: (-item[1], item[0]),
+    ):
+        model = STORE.get_user_model(model_id)
+        by_model.append(
+            {
+                "model_id": model_id,
+                "model_name": model.name if model is not None else None,
+                "earned_microdollars": amount,
+                "earned_display": format_money_display(amount),
+            }
+        )
+    recent = [
+        {
+            "kind": movement.kind,
+            "amount_display": format_money_display(movement.amount_microdollars),
+            "custom_model_id": movement.custom_model_id,
+            "counterparty_account_id": movement.counterparty_account_id,
+            "created_at": movement.created_at,
+        }
+        for movement in STORE.list_credit_movements(f"user:{ctx.user.id}", limit=50)
+    ]
+    return render(
+        "console/earnings.html",
+        settings=settings,
+        ctx=ctx,
+        active="earnings",
+        page_title="Earnings",
+        page_subtitle="Credits earned by your user-provided models.",
+        summary={
+            **summary,
+            "total_earned_display": format_money_display(summary["total_earned"]),
+            "total_transferred_display": format_money_display(
+                summary["total_transferred"]
+            ),
+            "available_display": format_money_display(summary["available"]),
+        },
+        by_model_30d=by_model,
+        recent=recent,
+        transfer_workspaces=[
+            workspace for workspace in ctx.workspaces if not workspace.federated_home
+        ],
+        transfer_idempotency_key=str(uuid.uuid4()),
+        flash=_flash_message(
+            request.query_params.get("saved"),
+            request.query_params.get("error"),
+        ),
+    )
+
+
+def _redirect(query: str) -> RedirectResponse:
+    return RedirectResponse(url=f"/console/earnings?{query}", status_code=303)
+
+
+def _flash_message(saved: str | None, error: str | None) -> dict[str, str] | None:
+    if saved == "transferred":
+        return {
+            "type": "success",
+            "text": "Earnings transferred into the workspace.",
+        }
+    if saved == "duplicate":
+        return {
+            "type": "success",
+            "text": "That transfer was already completed; no credits moved twice.",
+        }
+    if error == "insufficient":
+        return {"type": "error", "text": "Available earnings are insufficient."}
+    if error == "federated":
+        return {
+            "type": "error",
+            "text": "Earnings cannot be transferred to a federated workspace.",
+        }
+    if error == "workspace":
+        return {"type": "error", "text": "Workspace not found."}
+    if error == "amount":
+        return {"type": "error", "text": "Enter a transfer amount greater than $0."}
+    return None

--- a/src/trusted_router/routes/user_models.py
+++ b/src/trusted_router/routes/user_models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import secrets
+import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any, NoReturn
 
@@ -11,7 +12,12 @@ from trusted_router.auth import ManagementPrincipal, Principal, SettingsDep
 from trusted_router.custom_model_billing import validate_custom_model_price
 from trusted_router.custom_model_rules import assert_user_can_create_custom_models
 from trusted_router.errors import api_error
-from trusted_router.schemas import UserModelCreateRequest, UserModelPatchRequest
+from trusted_router.money import format_money_display
+from trusted_router.schemas import (
+    EarningsTransferRequest,
+    UserModelCreateRequest,
+    UserModelPatchRequest,
+)
 from trusted_router.serialization import user_model_owner_shape
 from trusted_router.services.user_model_probe import probe_user_model
 from trusted_router.services.user_model_secrets import (
@@ -35,6 +41,65 @@ def register_user_model_routes(router: APIRouter) -> None:
     async def list_user_models(principal: ManagementPrincipal) -> dict[str, Any]:
         models = STORE.list_user_models_for_user(_owner_user_id(principal))
         return {"data": [user_model_owner_shape(model) for model in models]}
+
+    @router.get("/user-models/earnings")
+    async def get_user_model_earnings(
+        principal: ManagementPrincipal,
+        before: str | None = None,
+    ) -> dict[str, Any]:
+        return {"data": _earnings_data(_owner_user_id(principal), before=before)}
+
+    @router.post("/user-models/earnings/transfer")
+    async def transfer_user_model_earnings(
+        body: EarningsTransferRequest,
+        principal: ManagementPrincipal,
+    ) -> dict[str, Any]:
+        owner_user_id = _owner_user_id(principal)
+        if body.amount_microdollars <= 0:
+            raise api_error(
+                400,
+                "Transfer amount must be positive",
+                ErrorType.BAD_REQUEST,
+            )
+        workspace = next(
+            (
+                candidate
+                for candidate in STORE.list_workspaces_for_user(owner_user_id)
+                if candidate.id == body.workspace_id
+            ),
+            None,
+        )
+        if workspace is None:
+            # Membership and existence deliberately collapse to the same answer.
+            raise api_error(404, "Resource not found", ErrorType.NOT_FOUND)
+        if workspace.federated_home:
+            raise api_error(
+                400,
+                "Earnings cannot be transferred to a federated workspace",
+                ErrorType.BAD_REQUEST,
+            )
+        event_suffix = body.idempotency_key or str(uuid.uuid4())
+        outcome = STORE.transfer_earnings_to_workspace(
+            owner_user_id,
+            workspace.id,
+            body.amount_microdollars,
+            f"earnings_transfer:{owner_user_id}:{event_suffix}",
+        )
+        if outcome == "insufficient":
+            available = STORE.earnings_summary(owner_user_id)["available"]
+            raise api_error(
+                402,
+                "Insufficient earnings",
+                ErrorType.INSUFFICIENT_CREDITS,
+                extra={"available": available},
+            )
+        summary = _earnings_summary_shape(STORE.earnings_summary(owner_user_id))
+        return {
+            "data": {
+                "deduplicated": outcome == "duplicate",
+                "summary": summary,
+            }
+        }
 
     @router.post("/user-models")
     async def create_user_model(
@@ -288,6 +353,55 @@ def _owner_user_id(principal: Principal) -> str:
         "A user-owned management session or key is required",
         ErrorType.FORBIDDEN,
     )
+
+
+def _earnings_data(user_id: str, *, before: str | None = None) -> dict[str, Any]:
+    since = (datetime.now(UTC) - timedelta(days=30)).isoformat().replace("+00:00", "Z")
+    by_model = STORE.custom_model_earnings_by_model(user_id, since=since)
+    recent = STORE.list_credit_movements(
+        f"user:{user_id}",
+        limit=50,
+        before=before,
+    )
+    return {
+        "summary": _earnings_summary_shape(STORE.earnings_summary(user_id)),
+        "by_model_30d": [
+            {"model_id": model_id, "earned_microdollars": amount}
+            for model_id, amount in sorted(
+                by_model.items(),
+                key=lambda item: (-item[1], item[0]),
+            )
+        ],
+        "recent": [
+            {
+                "account_id": movement.account_id,
+                "movement_id": movement.movement_id,
+                "kind": movement.kind,
+                "amount_microdollars": movement.amount_microdollars,
+                "amount_display": format_money_display(
+                    movement.amount_microdollars
+                ),
+                "counterparty_account_id": movement.counterparty_account_id,
+                "custom_model_id": movement.custom_model_id,
+                "authorization_id": movement.authorization_id,
+                "created_at": movement.created_at,
+            }
+            for movement in recent
+        ],
+    }
+
+
+def _earnings_summary_shape(summary: dict[str, int]) -> dict[str, int | str]:
+    return {
+        "total_earned": summary["total_earned"],
+        "total_earned_display": format_money_display(summary["total_earned"]),
+        "total_transferred": summary["total_transferred"],
+        "total_transferred_display": format_money_display(
+            summary["total_transferred"]
+        ),
+        "available": summary["available"],
+        "available_display": format_money_display(summary["available"]),
+    }
 
 
 def _require_owner_user_model(

--- a/src/trusted_router/schemas.py
+++ b/src/trusted_router/schemas.py
@@ -236,6 +236,12 @@ class UserModelPatchRequest(_Strict):
     completion_price_microdollars_per_million_tokens: int | None = Field(default=None, ge=0)
 
 
+class EarningsTransferRequest(_Strict):
+    workspace_id: str = Field(min_length=1, max_length=80)
+    amount_microdollars: int
+    idempotency_key: str | None = Field(default=None, min_length=1, max_length=64)
+
+
 class GatewayAuthorizeRequest(_Lenient):
     api_key_hash: str | None = Field(default=None, min_length=1)
     api_key_lookup_hash: str | None = Field(default=None, min_length=1)

--- a/src/trusted_router/serialization.py
+++ b/src/trusted_router/serialization.py
@@ -200,6 +200,11 @@ def user_model_public_shape(
         "on_the_clock": user_model_is_on_the_clock(
             model, now or datetime.now(UTC)
         ),
+        "health": (
+            "degraded"
+            if model.consecutive_dispatch_failures > 0 or model.probe_status == "failed"
+            else "ok"
+        ),
         "pricing": {
             "prompt_microdollars_per_million_tokens": (
                 model.prompt_price_microdollars_per_million_tokens

--- a/src/trusted_router/services/user_model_probe.py
+++ b/src/trusted_router/services/user_model_probe.py
@@ -35,6 +35,8 @@ class ProbeResult:
 async def probe_user_model(
     model: UserProvidedModel,
     settings: Settings,
+    *,
+    store: Any = STORE,
 ) -> ProbeResult:
     checked_at = datetime.now(UTC)
     try:
@@ -53,6 +55,7 @@ async def probe_user_model(
                 ok=False,
                 detail="Endpoint response was not an OpenAI chat completion",
                 checked_at=checked_at,
+                store=store,
             )
         if model.supports_streaming:
             streamed = await _probe_once(
@@ -68,6 +71,7 @@ async def probe_user_model(
                     ok=False,
                     detail="Endpoint response was not a valid chat completion stream",
                     checked_at=checked_at,
+                    store=store,
                 )
     except httpx.TimeoutException:
         return _recorded_result(
@@ -75,6 +79,7 @@ async def probe_user_model(
             ok=False,
             detail="Endpoint probe timed out",
             checked_at=checked_at,
+            store=store,
         )
     except httpx.HTTPError:
         return _recorded_result(
@@ -82,6 +87,7 @@ async def probe_user_model(
             ok=False,
             detail="Endpoint probe failed",
             checked_at=checked_at,
+            store=store,
         )
     except Exception as exc:  # fail closed without echoing secret-bearing details
         return _recorded_result(
@@ -89,12 +95,14 @@ async def probe_user_model(
             ok=False,
             detail=f"Endpoint probe failed ({type(exc).__name__})",
             checked_at=checked_at,
+            store=store,
         )
     return _recorded_result(
         model,
         ok=True,
         detail="Probe succeeded",
         checked_at=checked_at,
+        store=store,
     )
 
 
@@ -240,8 +248,9 @@ def _recorded_result(
     ok: bool,
     detail: str,
     checked_at: datetime,
+    store: Any,
 ) -> ProbeResult:
-    STORE.record_user_model_probe(
+    store.record_user_model_probe(
         model.id,
         status="ok" if ok else "failed",
         checked_at=checked_at.isoformat().replace("+00:00", "Z"),

--- a/src/trusted_router/services/user_model_reprobe.py
+++ b/src/trusted_router/services/user_model_reprobe.py
@@ -1,0 +1,81 @@
+"""Bounded periodic probes for online user-provided models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from trusted_router.config import Settings
+from trusted_router.services.user_model_probe import probe_user_model
+from trusted_router.storage import STORE
+
+
+@dataclass(frozen=True)
+class ReprobeRecord:
+    model_id: str
+    kind: str
+    status: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class ReprobeReport:
+    scanned: int
+    attempted: int
+    passed: int
+    failed: int
+    dry_run: bool
+    records: list[ReprobeRecord]
+
+
+async def reprobe_user_models(
+    settings: Settings,
+    *,
+    store: Any = STORE,
+    limit: int = 100,
+    kind: Literal["machine", "agent", "human"] | None = None,
+    apply: bool = False,
+) -> ReprobeReport:
+    """Probe bounded online models, or list them without network I/O."""
+    if limit < 1:
+        raise ValueError("limit must be at least 1")
+    models = [
+        model
+        for model in store.list_public_user_models(kind=kind)
+        if model.online
+    ][:limit]
+    records: list[ReprobeRecord] = []
+    passed = 0
+    failed = 0
+    for model in models:
+        if not apply:
+            records.append(
+                ReprobeRecord(
+                    model_id=model.id,
+                    kind=model.kind,
+                    status="would_probe",
+                    detail="Dry run; probe not sent",
+                )
+            )
+            continue
+        result = await probe_user_model(model, settings, store=store)
+        if result.ok:
+            passed += 1
+        else:
+            failed += 1
+        records.append(
+            ReprobeRecord(
+                model_id=model.id,
+                kind=model.kind,
+                status="ok" if result.ok else "failed",
+                detail=result.detail,
+            )
+        )
+    return ReprobeReport(
+        scanned=len(models),
+        attempted=len(models) if apply else 0,
+        passed=passed,
+        failed=failed,
+        dry_run=not apply,
+        records=records,
+    )

--- a/src/trusted_router/static/console.css
+++ b/src/trusted_router/static/console.css
@@ -203,6 +203,24 @@ body.console {
   max-width: 100%;
 }
 
+.earnings-copy {
+  text-wrap: pretty;
+}
+
+.earnings-money {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.earnings-table-wrap {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.earnings-transfer-submit {
+  min-height: 40px;
+}
+
 .form-gate {
   min-inline-size: 0;
   margin: 0;

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -14,6 +14,9 @@ from trusted_router.credit_transfer import (
     validate_outcome,
     validate_transfer_id,
 )
+from trusted_router.custom_model_billing import (
+    user_model_authorization_id_from_payout_event_id,
+)
 from trusted_router.money import DEFAULT_SIGNUP_CREDIT_MICRODOLLARS
 from trusted_router.storage_attribution import InMemoryAcquisitionAttribution
 from trusted_router.storage_auth_sessions import InMemoryAuthSessions
@@ -1288,6 +1291,9 @@ class InMemoryStore:
                 amount_microdollars=amount,
                 counterparty_account_id=payer_workspace_id,
                 custom_model_id=custom_model_id,
+                authorization_id=(
+                    user_model_authorization_id_from_payout_event_id(event_id)
+                ),
             )
             return True
 

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -13,6 +13,9 @@ from typing import Any, TypeVar
 
 from trusted_router import phone_verification
 from trusted_router import storage_gcp_credit_transfer as spanner_credit_transfer
+from trusted_router.custom_model_billing import (
+    user_model_authorization_id_from_payout_event_id,
+)
 from trusted_router.money import DEFAULT_SIGNUP_CREDIT_MICRODOLLARS
 from trusted_router.operational_analytics import (
     OperationalAnalyticsClient,
@@ -1836,6 +1839,9 @@ class SpannerBigtableStore:
                 amount_microdollars=amount,
                 counterparty_account_id=payer_workspace_id,
                 custom_model_id=custom_model_id,
+                authorization_id=(
+                    user_model_authorization_id_from_payout_event_id(event_id)
+                ),
                 created_at=now,
             )
             insert_entity_dml_at(

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -27,6 +27,9 @@ from trusted_router.credit_transfer import (
     validate_outcome,
     validate_transfer_id,
 )
+from trusted_router.custom_model_billing import (
+    user_model_authorization_id_from_payout_event_id,
+)
 from trusted_router.money import DEFAULT_SIGNUP_CREDIT_MICRODOLLARS
 from trusted_router.postgres_dsn import (
     aws_dsql_connection_details,
@@ -2720,6 +2723,9 @@ class PostgresStore:
                     amount_microdollars=amount,
                     counterparty_account_id=payer_workspace_id,
                     custom_model_id=custom_model_id,
+                    authorization_id=(
+                        user_model_authorization_id_from_payout_event_id(event_id)
+                    ),
                 ),
             )
             return True

--- a/src/trusted_router/templates/console/_layout.html
+++ b/src/trusted_router/templates/console/_layout.html
@@ -78,6 +78,7 @@
         <a href="/console/byok" class="sidebar-link {{ 'active' if active == 'byok' else '' }}">BYOK</a>
         <a href="/console/custom-models" class="sidebar-link {{ 'active' if active == 'custom-models' else '' }}">Custom Models</a>
         <a href="/console/user-models" class="sidebar-link {{ 'active' if active == 'user-models' else '' }}">User-provided Models</a>
+        <a href="/console/earnings" class="sidebar-link {{ 'active' if active == 'earnings' else '' }}">Earnings</a>
         <a href="/console/routing" class="sidebar-link {{ 'active' if active == 'routing' else '' }}">Routing</a>
         <a href="/console/activity" class="sidebar-link {{ 'active' if active == 'activity' else '' }}">Observability</a>
         <a href="/console/broadcast" class="sidebar-link {{ 'active' if active == 'broadcast' else '' }}">Broadcast</a>

--- a/src/trusted_router/templates/console/earnings.html
+++ b/src/trusted_router/templates/console/earnings.html
@@ -1,0 +1,74 @@
+{% extends "console/_layout.html" %}
+{% block body %}
+{% if flash %}<div class="console-flash {{ flash.type }}">{{ flash.text }}</div>{% endif %}
+
+<section class="panel">
+  <div class="panel-head"><h2>Your earnings</h2><span class="pill">TrustedRouter credits</span></div>
+  <div class="panel-body">
+    <p class="earnings-copy">You earn 70% of every charge in TrustedRouter credits. Transfer earnings into a workspace to spend them.</p>
+    <div class="metrics">
+      <div class="metric"><div class="label">Earned</div><div class="value earnings-money">{{ summary.total_earned_display }}</div><div class="sub">lifetime</div></div>
+      <div class="metric"><div class="label">Transferred</div><div class="value earnings-money">{{ summary.total_transferred_display }}</div><div class="sub">lifetime</div></div>
+      <div class="metric"><div class="label">Available</div><div class="value earnings-money">{{ summary.available_display }}</div><div class="sub">ready to transfer</div></div>
+    </div>
+  </div>
+</section>
+
+<section class="panel">
+  <div class="panel-head"><h2>Transfer earnings</h2></div>
+  <div class="panel-body">
+    {% if transfer_workspaces %}
+    <form class="form" method="post" action="/console/earnings/transfer">
+      <input type="hidden" name="idempotency_key" value="{{ transfer_idempotency_key }}">
+      <div class="row">
+        <label>Workspace
+          <select name="workspace_id" required>
+            {% for target in transfer_workspaces %}<option value="{{ target.id }}">{{ target.name }}</option>{% endfor %}
+          </select>
+        </label>
+        <label>Amount (USD)<input name="amount" type="number" min="0.000001" step="0.000001" placeholder="10.00" required></label>
+      </div>
+      <button class="btn primary earnings-transfer-submit" type="submit">Transfer credits</button>
+    </form>
+    {% else %}<p class="empty">No local workspace is available for transfers.</p>{% endif %}
+  </div>
+</section>
+
+<section class="panel">
+  <div class="panel-head"><h2>Earnings by model</h2><span class="pill">last 30 days</span></div>
+  <div class="panel-body">
+    {% if by_model_30d %}
+    <div class="earnings-table-wrap"><table class="data-table" style="width:100%;border-collapse:collapse">
+      <thead><tr><th>Model</th><th>Earned</th></tr></thead>
+      <tbody>
+        {% for row in by_model_30d %}
+        <tr><td>{% if row.model_name %}<strong>{{ row.model_name }}</strong><br>{% endif %}<code>{{ row.model_id }}</code></td><td class="earnings-money">{{ row.earned_display }}</td></tr>
+        {% endfor %}
+      </tbody>
+    </table></div>
+    {% else %}<p class="empty">No model earnings in the last 30 days.</p>{% endif %}
+  </div>
+</section>
+
+<section class="panel">
+  <div class="panel-head"><h2>Recent movements</h2><span class="pill">{{ recent|length }} recent</span></div>
+  <div class="panel-body">
+    {% if recent %}
+    <div class="earnings-table-wrap"><table class="data-table" style="width:100%;border-collapse:collapse">
+      <thead><tr><th>Kind</th><th>Amount</th><th>Model</th><th>Counterparty</th><th>When</th></tr></thead>
+      <tbody>
+        {% for movement in recent %}
+        <tr>
+          <td>{{ movement.kind|replace('_', ' ') }}</td>
+          <td class="earnings-money">{{ movement.amount_display }}</td>
+          <td>{% if movement.custom_model_id %}<code>{{ movement.custom_model_id }}</code>{% else %}<span class="muted">none</span>{% endif %}</td>
+          <td>{% if movement.counterparty_account_id %}<code>{{ movement.counterparty_account_id }}</code>{% else %}<span class="muted">none</span>{% endif %}</td>
+          <td class="earnings-money">{{ movement.created_at|datetime_iso }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table></div>
+    {% else %}<p class="empty">No earnings movements yet.</p>{% endif %}
+  </div>
+</section>
+{% endblock %}

--- a/src/trusted_router/templates/public/user_model_detail.html
+++ b/src/trusted_router/templates/public/user_model_detail.html
@@ -13,6 +13,7 @@
   <div class="public-hero-metrics" aria-label="User-provided model facts">
     <div><strong>{{ model.kind }}</strong><span>operator kind</span></div>
     <div><strong>{{ 'On' if model.on_the_clock else 'Off' }}</strong><span>the clock</span></div>
+    <div><strong>{{ model.health|capitalize }}</strong><span>health</span></div>
     <div><strong>No</strong><span>attestation or ZDR</span></div>
   </div>
 </section>
@@ -25,6 +26,7 @@
       <span class="pill warn">user-provided</span>
       <span class="pill">{{ model.kind }}</span>
       <span class="pill {{ 'good' if model.on_the_clock else 'warn' }}">{{ 'on the clock' if model.on_the_clock else 'off the clock' }}</span>
+      <span class="pill {{ 'good' if model.health == 'ok' else 'warn' }}">{{ model.health }}</span>
       {% if model.kind == 'human' and model.operator.human_verified %}<span class="pill good">✓ verified human</span>{% endif %}
     </div>
   </div>

--- a/tests/conformance/test_store_semantics.py
+++ b/tests/conformance/test_store_semantics.py
@@ -139,7 +139,7 @@ def test_user_earnings_seed_and_payout_are_idempotent(
         "total_transferred": 0,
         "available": 0,
     }
-    event_id = f"evt-payout-{unique}"
+    event_id = f"custom_model_payout:auth-{unique}"
     assert store.credit_user_earnings(
         user_id,
         75,
@@ -158,6 +158,7 @@ def test_user_earnings_seed_and_payout_are_idempotent(
     assert movement.amount_microdollars == 75
     assert movement.counterparty_account_id == "ws-payer"
     assert movement.custom_model_id == "model-a"
+    assert movement.authorization_id == f"auth-{unique}"
 
 
 def test_user_earnings_credit_seeds_an_absent_account(

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -1481,6 +1481,28 @@ def _execute_sql(
     params: dict[str, Any],
 ) -> list[list[str]]:
     kind = params.get("kind", "")
+    if (
+        "FROM tr_credit_movement " in sql
+        and "WHERE kind='custom_model_payout' AND created_at>=@since" in sql
+    ):
+        movements = [
+            dict(rec)
+            for rec in db.typed.get("tr_credit_movement", {}).values()
+            if rec["kind"] == "custom_model_payout"
+            and rec["created_at"] >= params["since"]
+        ]
+        movements.sort(
+            key=lambda rec: (
+                rec["created_at"],
+                rec["account_id"],
+                rec["movement_id"],
+            )
+        )
+        columns = [
+            column.strip()
+            for column in sql.split("SELECT", 1)[1].split("FROM", 1)[0].split(",")
+        ]
+        return [[rec.get(column) for column in columns] for rec in movements]
     if "FROM tr_credit_movement@{FORCE_INDEX=tr_credit_movement_by_time}" in sql:
         records = list(db.typed.get("tr_credit_movement", {}).items())
         visible = [
@@ -1539,6 +1561,16 @@ def _execute_sql(
     if sql.startswith("SELECT payload FROM tr_generation"):
         generation = db.generation_records.get(str(params["generation_id"]))
         return [[str(generation["payload"])]] if generation is not None else []
+    if sql.startswith("SELECT payload FROM tr_gateway_authorization "):
+        rows = [
+            rec
+            for rec in db.gateway_authorizations.values()
+            if rec.get("settled")
+            and rec.get("created_at") >= params["since"]
+            and rec.get("payload")
+        ]
+        rows.sort(key=lambda rec: (rec["created_at"], rec["authorization_id"]))
+        return [[str(rec["payload"])] for rec in rows]
     # Guarded legacy terminal_at backfill. These narrow handlers intentionally
     # assert every real predicate they model (MF6); a production SQL regression
     # must fail tests instead of being repaired by the fake's Python filtering.

--- a/tests/test_reconcile_custom_model_payouts.py
+++ b/tests/test_reconcile_custom_model_payouts.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from scripts.reconcile_custom_model_payouts import reconcile_custom_model_payouts
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage import InMemoryStore
+from trusted_router.storage_codec import json_body
+from trusted_router.storage_models import GatewayAuthorization, Generation
+from trusted_router.types import UsageType
+
+
+def _model(store: Any, *, owner: str, workspace: str, slug: str) -> Any:
+    return store.create_user_model(
+        owner_user_id=owner,
+        owner_workspace_id=workspace,
+        name="Reconciliation model",
+        kind="machine",
+        display_name="reconciler",
+        endpoint_url="https://owner.example/v1",
+        slug=slug,
+    )
+
+
+def _generation(model_id: str, *, authorization_id: str, created_at: str) -> Generation:
+    return Generation(
+        id=f"gen-{authorization_id}",
+        request_id=f"req-{authorization_id}",
+        workspace_id="ws-payer",
+        key_hash="key-payer",
+        model=model_id,
+        provider_name="User-provided",
+        app="Reconciliation test",
+        tokens_prompt=100,
+        tokens_completion=200,
+        total_cost_microdollars=1_000_000,
+        usage_type=UsageType.CREDITS,
+        speed_tokens_per_second=10.0,
+        finish_reason="stop",
+        status="success",
+        streamed=False,
+        custom_model_id=model_id,
+        created_at=created_at,
+    )
+
+
+def _authorization(
+    model_id: str,
+    generation_id: str,
+    *,
+    authorization_id: str,
+    created_at: str,
+) -> GatewayAuthorization:
+    return GatewayAuthorization(
+        id=authorization_id,
+        workspace_id="ws-payer",
+        key_hash="key-payer",
+        model_id=model_id,
+        provider="user",
+        usage_type=UsageType.CREDITS,
+        estimated_microdollars=1_000_000,
+        settled=True,
+        created_at=created_at,
+        user_provided_model_id=model_id,
+        user_model_owner_user_id="owner-reconcile",
+        finalization_outcome="settled",
+        finalized_cost_microdollars=1_000_000,
+        finalized_generation_id=generation_id,
+    )
+
+
+def test_memory_reconciliation_applies_once_reports_orphan_and_dry_run_is_read_only() -> None:
+    store = InMemoryStore()
+    now = datetime.now(UTC)
+    created_at = now.isoformat().replace("+00:00", "Z")
+    model = _model(
+        store,
+        owner="owner-reconcile",
+        workspace="ws-owner",
+        slug="memory-reconcile",
+    )
+    generation = _generation(
+        model.id,
+        authorization_id="auth-memory",
+        created_at=created_at,
+    )
+    authorization = _authorization(
+        model.id,
+        generation.id,
+        authorization_id="auth-memory",
+        created_at=created_at,
+    )
+    store.add_generation(generation)
+    store.api_keys.gateway_authorizations[authorization.id] = authorization
+    assert store.credit_user_earnings(
+        "orphan-owner",
+        12,
+        "custom_model_payout:auth-orphan",
+        custom_model_id=model.id,
+        payer_workspace_id="ws-payer",
+    )
+    cutoff = now - timedelta(hours=1)
+
+    dry_records: list[dict[str, Any]] = []
+    dry = reconcile_custom_model_payouts(
+        store,
+        since=cutoff,
+        emit=dry_records.append,
+    )
+    assert dry.missing_payouts == 1
+    assert dry.payouts_applied == 0
+    assert dry.orphan_payouts == 1
+    assert store.earnings_summary("owner-reconcile")["available"] == 0
+    assert any(record["type"] == "missing_payout" for record in dry_records)
+    assert any(record["type"] == "orphan_payout" for record in dry_records)
+
+    applied = reconcile_custom_model_payouts(store, since=cutoff, apply=True)
+    assert applied.missing_payouts == 1
+    assert applied.payouts_applied == 1
+    assert store.earnings_summary("owner-reconcile")["available"] == 700_000
+
+    rerun = reconcile_custom_model_payouts(store, since=cutoff, apply=True)
+    assert rerun.missing_payouts == 0
+    assert rerun.payouts_applied == 0
+    assert store.earnings_summary("owner-reconcile")["available"] == 700_000
+
+
+def test_spanner_fake_reconciliation_scans_applies_once_and_reports_orphan() -> None:
+    store, database, _bigtable = make_fake_store(generation_records_enabled=True)
+    now = datetime.now(UTC)
+    created_at = now.isoformat().replace("+00:00", "Z")
+    model = _model(
+        store,
+        owner="owner-reconcile",
+        workspace="ws-owner",
+        slug="spanner-reconcile",
+    )
+    generation = _generation(
+        model.id,
+        authorization_id="auth-spanner",
+        created_at=created_at,
+    )
+    authorization = _authorization(
+        model.id,
+        generation.id,
+        authorization_id="auth-spanner",
+        created_at=created_at,
+    )
+    store.add_generation(generation)
+    database.gateway_authorizations[authorization.id] = {
+        "authorization_id": authorization.id,
+        "created_at": now,
+        "settled": True,
+        "terminal_at": None,
+        "payload": json_body(authorization),
+    }
+    assert store.credit_user_earnings(
+        "orphan-owner",
+        12,
+        "custom_model_payout:auth-spanner-orphan",
+        custom_model_id=model.id,
+        payer_workspace_id="ws-payer",
+    )
+    cutoff = now - timedelta(hours=1)
+
+    dry = reconcile_custom_model_payouts(store, since=cutoff)
+    assert dry.missing_payouts == 1
+    assert dry.orphan_payouts == 1
+    assert store.earnings_summary("owner-reconcile")["available"] == 0
+
+    first = reconcile_custom_model_payouts(store, since=cutoff, apply=True)
+    second = reconcile_custom_model_payouts(store, since=cutoff, apply=True)
+    assert first.payouts_applied == 1
+    assert second.missing_payouts == 0
+    assert second.payouts_applied == 0
+    assert store.earnings_summary("owner-reconcile")["available"] == 700_000
+
+
+def test_deleted_model_is_still_reconciled_to_the_frozen_owner() -> None:
+    """The payee is the owner frozen on the authorization; deleting the model
+    afterwards must not turn a missing payout into owner_unknown."""
+    store = InMemoryStore()
+    now = datetime.now(UTC)
+    created_at = now.isoformat().replace("+00:00", "Z")
+    model = _model(store, owner="owner-reconcile", workspace="ws-owner", slug="gone-soon")
+    generation = _generation(model.id, authorization_id="auth-gone", created_at=created_at)
+    authorization = _authorization(
+        model.id, generation.id, authorization_id="auth-gone", created_at=created_at
+    )
+    store.add_generation(generation)
+    store.api_keys.gateway_authorizations[authorization.id] = authorization
+    assert store.delete_user_model(model.id, owner_user_id="owner-reconcile")
+
+    applied = reconcile_custom_model_payouts(store, since=now - timedelta(hours=1), apply=True)
+    assert applied.owner_unknown == 0
+    assert applied.missing_payouts == 1 and applied.payouts_applied == 1
+    assert store.earnings_summary("owner-reconcile")["total_earned"] == 700_000

--- a/tests/test_user_model_reprobe.py
+++ b/tests/test_user_model_reprobe.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import socket
+from typing import Any
+
+import httpx
+import pytest
+
+from trusted_router.config import Settings
+from trusted_router.services import user_model_probe
+from trusted_router.services.user_model_reprobe import reprobe_user_models
+from trusted_router.services.user_model_secrets import (
+    encrypt_user_model_signing_secret,
+)
+from trusted_router.storage import InMemoryStore
+
+
+def _online_model(
+    store: InMemoryStore,
+    settings: Settings,
+    *,
+    slug: str,
+    kind: str = "machine",
+) -> Any:
+    workspace_id = f"ws-{slug}"
+    model = store.create_user_model(
+        owner_user_id=f"owner-{slug}",
+        owner_workspace_id=workspace_id,
+        name=f"Model {slug}",
+        kind=kind,
+        display_name=slug,
+        endpoint_url="https://owner.example/v1",
+        encrypted_signing_secret=encrypt_user_model_signing_secret(
+            "reprobe-signing-secret",
+            settings,
+            workspace_id=workspace_id,
+        ),
+        supports_streaming=False,
+        slug=slug,
+    )
+    return store.set_user_model_online(
+        model.id,
+        owner_user_id=model.owner_user_id,
+        online=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_reprobe_dry_run_filters_online_kind_and_sends_nothing(
+    test_settings: Settings,
+) -> None:
+    store = InMemoryStore()
+    machine = _online_model(store, test_settings, slug="reprobe-machine")
+    _online_model(store, test_settings, slug="reprobe-agent", kind="agent")
+    offline = store.create_user_model(
+        owner_user_id="offline-owner",
+        owner_workspace_id="offline-workspace",
+        name="Offline",
+        kind="machine",
+        display_name="offline",
+        endpoint_url="https://owner.example/v1",
+        slug="reprobe-offline",
+    )
+
+    report = await reprobe_user_models(
+        test_settings,
+        store=store,
+        kind="machine",
+        limit=1,
+    )
+
+    assert report.scanned == 1
+    assert report.attempted == 0
+    assert report.dry_run is True
+    assert report.records[0].model_id == machine.id
+    assert report.records[0].status == "would_probe"
+    assert store.get_user_model(machine.id).probe_status == "unprobed"  # type: ignore[union-attr]
+    assert store.get_user_model(offline.id).probe_status == "unprobed"  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio
+async def test_reprobe_records_success_and_failure_without_clocking_model_out(
+    test_settings: Settings,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = InMemoryStore()
+    model = _online_model(store, test_settings, slug="reprobe-owner")
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("8.8.8.8", 0))
+        ],
+    )
+    real_client = user_model_probe.httpx.AsyncClient
+
+    def install_transport(handler: Any) -> None:
+        def client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+            kwargs["transport"] = httpx.MockTransport(handler)
+            return real_client(*args, **kwargs)
+
+        monkeypatch.setattr(user_model_probe.httpx, "AsyncClient", client)
+
+    def success(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "object": "chat.completion",
+                "choices": [
+                    {"message": {"role": "assistant", "content": "pong"}}
+                ],
+            },
+        )
+
+    install_transport(success)
+    passed = await reprobe_user_models(test_settings, store=store, apply=True)
+    assert passed.attempted == 1
+    assert passed.passed == 1
+    assert passed.failed == 0
+    stored = store.get_user_model(model.id)
+    assert stored is not None
+    assert stored.probe_status == "ok"
+    assert stored.online is True
+
+    def malformed(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"choices": []})
+
+    install_transport(malformed)
+    failed = await reprobe_user_models(test_settings, store=store, apply=True)
+    assert failed.attempted == 1
+    assert failed.failed == 1
+    stored = store.get_user_model(model.id)
+    assert stored is not None
+    assert stored.probe_status == "failed"
+    assert stored.online is True

--- a/tests/test_user_models.py
+++ b/tests/test_user_models.py
@@ -978,6 +978,7 @@ def test_public_shape_is_secret_free_and_resolves_operator_identities(
     assert verified_public["attested"] is False
     assert verified_public["zero_data_retention"] is False
     assert verified_public["privacy_tier"] == "standard"
+    assert verified_public["health"] == "ok"
     assert "private-owner-key" not in response.text
     assert "endpoint_url" not in response.text
     assert "encrypted_" not in response.text
@@ -997,6 +998,195 @@ def test_public_shape_is_secret_free_and_resolves_operator_identities(
     chat = client.get(f"/user-chat?model={human['id']}")
     assert chat.status_code == 200
     assert "User-provided model" in chat.text
+
+
+def test_public_user_model_health_reports_dispatch_and_probe_degradation(
+    client: TestClient,
+) -> None:
+    created = _create(client, body=_body(slug="health-signal"))
+    STORE.record_user_model_dispatch_result(created["id"], success=False)
+
+    degraded = client.get(f"/v1/models/user-provided/{created['id']}")
+    assert degraded.status_code == 200
+    assert degraded.json()["data"]["health"] == "degraded"
+    page = client.get(f"/models/{created['id']}")
+    assert page.status_code == 200
+    assert "Degraded" in page.text
+
+    STORE.record_user_model_dispatch_result(created["id"], success=True)
+    STORE.record_user_model_probe(
+        created["id"],
+        status="failed",
+        checked_at="2026-08-16T00:00:00Z",
+    )
+    assert (
+        client.get(f"/v1/models/user-provided/{created['id']}").json()["data"][
+            "health"
+        ]
+        == "degraded"
+    )
+
+
+def test_owner_earnings_api_lists_summary_models_movements_and_transfers(
+    client: TestClient,
+) -> None:
+    created = _create(client, body=_body(slug="earnings-api"))
+    owner_user_id = created["owner_user_id"]
+    workspace = STORE.list_workspaces_for_user(owner_user_id)[0]
+    assert STORE.credit_user_earnings(
+        owner_user_id,
+        2_500_000,
+        "custom_model_payout:earnings-api-auth",
+        custom_model_id=created["id"],
+        payer_workspace_id=workspace.id,
+    )
+
+    response = client.get("/v1/user-models/earnings", headers=HEADERS)
+    assert response.status_code == 200, response.text
+    data = response.json()["data"]
+    assert data["summary"] == {
+        "total_earned": 2_500_000,
+        "total_earned_display": "$2.50",
+        "total_transferred": 0,
+        "total_transferred_display": "$0.00",
+        "available": 2_500_000,
+        "available_display": "$2.50",
+    }
+    assert data["by_model_30d"] == [
+        {"model_id": created["id"], "earned_microdollars": 2_500_000}
+    ]
+    assert data["recent"][0]["kind"] == "custom_model_payout"
+    assert data["recent"][0]["amount_display"] == "$2.50"
+
+    body = {
+        "workspace_id": workspace.id,
+        "amount_microdollars": 1_000_000,
+        "idempotency_key": "earnings-api-transfer",
+    }
+    accepted = client.post(
+        "/v1/user-models/earnings/transfer",
+        headers=HEADERS,
+        json=body,
+    )
+    assert accepted.status_code == 200, accepted.text
+    assert accepted.json()["data"] == {
+        "deduplicated": False,
+        "summary": {
+            "total_earned": 2_500_000,
+            "total_earned_display": "$2.50",
+            "total_transferred": 1_000_000,
+            "total_transferred_display": "$1.00",
+            "available": 1_500_000,
+            "available_display": "$1.50",
+        },
+    }
+    duplicate = client.post(
+        "/v1/user-models/earnings/transfer",
+        headers=HEADERS,
+        json=body,
+    )
+    assert duplicate.status_code == 200
+    assert duplicate.json()["data"]["deduplicated"] is True
+
+    insufficient = client.post(
+        "/v1/user-models/earnings/transfer",
+        headers=HEADERS,
+        json={"workspace_id": workspace.id, "amount_microdollars": 2_000_000},
+    )
+    assert insufficient.status_code == 402
+    assert insufficient.json()["error"]["type"] == "insufficient_credits"
+    assert insufficient.json()["error"]["available"] == 1_500_000
+
+
+def test_owner_earnings_transfer_hides_membership_and_refuses_invalid_targets(
+    client: TestClient,
+) -> None:
+    _create(client, body=_body(slug="earnings-targets"))
+    user = STORE.find_user_by_email(HEADERS["x-trustedrouter-user"])
+    assert user is not None
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+
+    for amount in (0, -1):
+        invalid = client.post(
+            "/v1/user-models/earnings/transfer",
+            headers=HEADERS,
+            json={"workspace_id": workspace.id, "amount_microdollars": amount},
+        )
+        assert invalid.status_code == 400
+
+    stranger = STORE.ensure_user("earnings-stranger@example.com")
+    stranger_workspace = STORE.list_workspaces_for_user(stranger.id)[0]
+    hidden = client.post(
+        "/v1/user-models/earnings/transfer",
+        headers=HEADERS,
+        json={"workspace_id": stranger_workspace.id, "amount_microdollars": 1},
+    )
+    assert hidden.status_code == 404
+
+    workspace.federated_home = "https://home.example"
+    federated = client.post(
+        "/v1/user-models/earnings/transfer",
+        headers=HEADERS,
+        json={"workspace_id": workspace.id, "amount_microdollars": 1},
+    )
+    assert federated.status_code == 400
+
+
+def test_earnings_console_renders_and_transfers_with_idempotent_flash(
+    client: TestClient,
+) -> None:
+    user = STORE.ensure_user("earnings-console@example.com")
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+    raw_session, _session = STORE.create_auth_session(
+        user_id=user.id,
+        provider="test",
+        label="earnings console",
+        ttl_seconds=3600,
+        workspace_id=workspace.id,
+    )
+    client.cookies.set("tr_session", raw_session)
+    model = STORE.create_user_model(
+        owner_user_id=user.id,
+        owner_workspace_id=workspace.id,
+        name="Earning model",
+        kind="machine",
+        display_name="earner",
+        endpoint_url="https://owner.example/v1",
+        slug="earnings-console",
+    )
+    assert STORE.credit_user_earnings(
+        user.id,
+        3_000_000,
+        "custom_model_payout:earnings-console-auth",
+        custom_model_id=model.id,
+        payer_workspace_id=workspace.id,
+    )
+
+    page = client.get("/console/earnings")
+    assert page.status_code == 200
+    assert "You earn 70% of every charge in TrustedRouter credits" in page.text
+    assert "Earning model" in page.text
+    assert 'href="/console/earnings" class="sidebar-link active"' in page.text
+
+    form = {
+        "workspace_id": workspace.id,
+        "amount": "1.25",
+        "idempotency_key": "console-transfer",
+    }
+    accepted = client.post(
+        "/console/earnings/transfer",
+        data=form,
+        follow_redirects=False,
+    )
+    assert accepted.status_code == 303
+    assert accepted.headers["location"] == "/console/earnings?saved=transferred"
+    duplicate = client.post(
+        "/console/earnings/transfer",
+        data=form,
+        follow_redirects=False,
+    )
+    assert duplicate.headers["location"] == "/console/earnings?saved=duplicate"
+    assert STORE.earnings_summary(user.id)["available"] == 1_750_000
 
 
 def test_https_is_required_outside_local_and_test() -> None:


### PR DESCRIPTION
## Summary

Phase 7 of user-provided Custom Models. **Stacked on #608 (which is stacked on #602)** — the diff shows all three until they merge; Phase 7 proper is the last 6 commits.

- **Reverse-harness contract v1** — `docs/design/reverse-harness-contract.md`: the whole wire contract (registration, clock-in/heartbeat/clock-out, the signed allowlisted request and how to verify `TR-Signature` with the documented vector, the canary, both answer transports, declines as ordinary HTTP errors, the strike rule, timing/keepalive/disconnect semantics, concurrency, payout). The Apache-2 TypeScript `npx` harness will be built against this.
- **Owner earnings API** — `GET /v1/user-models/earnings` (summary, 30-day per-model, recent movements + cursor); `POST /v1/user-models/earnings/transfer` (member/owner workspaces only — 404 collapses existence and membership; federated refused; idempotent; 402 with `available` on insufficient).
- **`/console/earnings`** — cards, per-model table, movements, transfer form with flashes; sidebar entry. Copy: 70% in TR credits, transfer to spend; nothing about cash.
- **Payout reconciliation sweep** — `scripts/reconcile_custom_model_payouts.py`: for every settled user-model authorization in the window (join via `finalized_generation_id`), assert a `custom_model_payout` movement exists for the **frozen** owner; missing → reported, applied only with `--apply` through the event-claim-idempotent `credit_user_earnings`; orphans reported; dry-run default, JSONL, non-zero exit when unresolved. This is the safety net behind Phase 5's exactly-once path.
- **Periodic re-probe** — `scripts/reprobe_user_models.py` + schedulable service; a failing probe marks `health: degraded`, never clocks out (strikes come from dispatch).
- **Public health signal** — `"health": "ok"|"degraded"` on the public shape/page.

## Gates

`ruff` ✅ · `mypy` ✅ (267 files) · `pytest -n 4 --dist loadgroup` ✅ 4082 passed / 290 skipped / 10 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
