### PR TITLE
Serve user-provided models in production (TR_USER_MODELS_DISPATCH_ENABLED=true)

### DIFF
--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -358,6 +358,14 @@ ENV_VARS=(
   # back to false in one commit.
   "TR_VERIFF_ENABLED=true"
   "TR_CUSTOM_MODELS_REQUIRE_VERIFICATION=true"
+  # User-provided models serve from here. The half that made this unsafe —
+  # settle/refund of the synthetic user-model endpoint, and the exactly-once
+  # payout — shipped in #608, and the attested enclave that dispatches them
+  # shipped in quill-cloud-proxy 7925a4f. Registration, probing and the public
+  # section always worked; this is the switch that lets the gateway AUTHORIZE
+  # and route to one. Off again = the gateway 404s user-model ids; in-flight
+  # holds still settle, because settle does not read this flag.
+  "TR_USER_MODELS_DISPATCH_ENABLED=true"
   "TR_VERIFF_BASE_URL=https://stationapi.veriff.com"
   "TR_TELNYX_FROM_NUMBER=+17869471547"
   "TR_TELNYX_TEXML_ACCOUNT_ID=1eea716a-02e0-4d4f-96fa-36d1f556edca"

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -70,6 +70,19 @@ def test_deploy_wires_three_cloud_ops_chat_support_fanout() -> None:
     )
 
 
+def test_deploy_serves_user_provided_models() -> None:
+    """The switch that lets the gateway authorize a user-provided model.
+
+    It stayed off until BOTH halves existed: settle/refund of the synthetic
+    user-model endpoint with its exactly-once payout (#608), and the attested
+    enclave that dispatches to the owner's URL. Pinning it here means turning
+    it back off is a deliberate edit with a test to update, not a quiet drift.
+    """
+    rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
+
+    assert '"TR_USER_MODELS_DISPATCH_ENABLED=true"' in rollout
+
+
 def test_deploy_wires_veriff_config_and_secrets() -> None:
     rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
     secrets = (ROOT / "scripts/deploy/secrets.sh").read_text()


### PR DESCRIPTION
## Summary

Flips the last gate: the gateway will now **authorize and route** requests to user-provided models. Until this commit it 404'd every `trustedrouter/user-…` id that wasn't a prompt-wrapper — registration, probing, the public section, the earnings console and the payout ledger all worked, only serving was off.

Both halves that made serving unsafe are in production:

- **#608** — settle/refund recognise the frozen user-model authorization, bill at the owner's frozen prices, cap at the authorized hold, and pay the owner exactly once inside the claim-gated finalize transaction.
- **quill-cloud-proxy `7925a4f`** — the attested enclave dispatches to the owner's URL: allowlisted OpenAI body, `TR-Signature`, bearer key decrypted only in-enclave, IP-pinned egress with redirects refused, kind-derived budgets, and the honest refund taxonomy that decides strikes.

Off again is a one-line revert. `settle` does not read the flag, so any in-flight hold still resolves.

## Test

`tests/test_deploy_secret_wiring.py::test_deploy_serves_user_provided_models` pins the rollout value, so turning it back off is a deliberate edit with a test to update rather than quiet drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
