### PR TITLE
Alert when the verified ClickHouse archive stops advancing

### DIFF
--- a/.github/workflows/check-archive-freshness.yml
+++ b/.github/workflows/check-archive-freshness.yml
@@ -1,0 +1,130 @@
+name: Check ClickHouse archive freshness
+
+# The verified daily archive (clickhouse/archive_daily.py) and its restore
+# drill (clickhouse/verify_archive_restore.py) run on tr-clickhouse-1 under
+# systemd timers at ~04:28 and 06:08 UTC. When they fail, nothing outside the
+# node notices: on 2026-08-16 a service-account swap left both units failing
+# for ten hours until a person looked at the bucket (NC-005). This job looks
+# at the bucket for them, from outside, after the timers should have fired.
+#
+# It fails, and files or updates ONE issue, if yesterday's _latest.json is
+# missing for any dataset or names a manifest that does not exist. Because it
+# reads the bucket rather than the node, it also catches "the archiver never
+# ran" (node down, timer disabled), which an OnFailure= hook on the unit
+# cannot.
+
+on:
+  schedule:
+    # 07:30 UTC daily: after the 04:28 archive and 06:08 drill, with slack for
+    # GitHub's scheduler drift. The archiver's own 7-day lookback means a day
+    # that is caught here still gets back-filled by the next successful run.
+    - cron: "30 7 * * *"
+  push:
+    branches: [main]
+    paths:
+      - "clickhouse/check_archive_freshness.py"
+      - ".github/workflows/check-archive-freshness.yml"
+  workflow_dispatch:
+    inputs:
+      day:
+        description: "Closed day to check (YYYY-MM-DD, UTC). Default: yesterday."
+        required: false
+        default: ""
+      lookback:
+        description: "How many closed days to check, ending yesterday (ignored if day is set)."
+        required: false
+        default: "1"
+
+permissions:
+  contents: read
+  issues: write
+  id-token: write
+
+concurrency:
+  group: check-archive-freshness
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # Read-only. The identity already holds storage.admin project-wide for
+      # deploys; this job uses only storage.objects.get/list on one bucket.
+      - name: Authenticate to GCP via WIF
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/44325983244/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Check yesterday's archive pointers
+        id: check
+        env:
+          DAY: ${{ github.event.inputs.day }}
+          LOOKBACK: ${{ github.event.inputs.lookback || '1' }}
+        run: |
+          set -euo pipefail
+          args=(--problems-file /tmp/problems.txt)
+          if [ -n "${DAY}" ]; then
+            args+=(--day "${DAY}")
+          else
+            args+=(--lookback "${LOOKBACK}")
+          fi
+          python3 -m clickhouse.check_archive_freshness "${args[@]}"
+
+      - name: Open or update the freshness issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ -f /tmp/problems.txt ]; then
+            cp /tmp/problems.txt /tmp/detail.txt
+          else
+            echo "the freshness check failed before it could report; see the run log" > /tmp/detail.txt
+          fi
+          {
+            echo "The scheduled check found the verified ClickHouse archive has not advanced."
+            echo
+            echo '```'
+            cat /tmp/detail.txt
+            echo '```'
+            echo
+            echo "What to look at, in order:"
+            echo
+            echo '```bash'
+            echo "gcloud compute ssh tr-clickhouse-1 --zone=us-central1-a --project=quill-cloud-proxy --tunnel-through-iap \\"
+            echo "  --command='systemctl status tr-clickhouse-archive.service tr-clickhouse-archive-restore.service --no-pager; \\"
+            echo "             sudo journalctl -u tr-clickhouse-archive.service -n 30 --no-pager'"
+            echo '```'
+            echo
+            echo "A 403 in that journal means the node identity lost its bucket grant (this is"
+            echo "how NC-005 happened after a service-account swap): fix the IAM binding, then"
+            echo "'sudo systemctl start tr-clickhouse-archive.service' and the restore drill;"
+            echo "the archiver's 7-day lookback back-fills the missing day. If the unit did not"
+            echo "run at all, check the timer and the node. Record the outcome in the SOC 2"
+            echo "evidence log."
+            echo
+            echo "Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          } > /tmp/issue-body.md
+          gh label create archive-freshness \
+            --description "The verified ClickHouse archive stopped advancing" \
+            --color D93F0B --force >/dev/null
+          # One open issue at a time: a daily duplicate trains people to ignore it.
+          existing="$(gh issue list --label archive-freshness --state open --json number --jq '.[0].number' 2>/dev/null || true)"
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" --body-file /tmp/issue-body.md
+          else
+            gh issue create \
+              --title "ClickHouse archive has not advanced" \
+              --label archive-freshness \
+              --body-file /tmp/issue-body.md
+          fi

--- a/clickhouse/check_archive_freshness.py
+++ b/clickhouse/check_archive_freshness.py
@@ -1,0 +1,323 @@
+"""Alert when the verified ClickHouse archive stops advancing.
+
+``archive_daily`` exports every closed day of each dataset and advances
+``raw/<dataset>/day=<day>/_latest.json`` only after the export has been read
+back and fingerprint-matched; ``verify_archive_restore`` then restores that
+day again as a drill. Both run on a ClickHouse node under systemd timers, so
+when they fail nothing outside the node notices — on 2026-08-16 a
+service-account swap left both units failing for ten hours before a person
+happened to look at the bucket (NC-005).
+
+This check runs from *outside* the node, after the timers should have fired,
+and asks the only question that matters: does yesterday's pointer exist, for
+every dataset, and does it name a manifest that exists? It therefore catches
+"the archiver never ran" (node down, timer disabled, unit masked) as well as
+"the archiver ran and failed", which an ``OnFailure=`` hook on the unit cannot.
+
+It reads the bucket through ``gcloud storage`` so it needs no Python
+dependencies beyond the standard library and whatever identity gcloud holds.
+A permission or transport error is reported as its own failure, never folded
+into "missing": a check that reads 403 as "not archived yet" would be wrong in
+the same way the incident was.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import json
+import subprocess
+import sys
+from collections.abc import Callable, Iterable
+from typing import Any, Protocol
+
+from clickhouse.archive_daily import ARCHIVE_BUCKET, ARCHIVE_SCHEMA_VERSION, DATASETS
+
+# Observed on 2026-08-16 against the real bucket:
+#   gcloud storage cat  -> "The following URLs matched no objects or files: ..."
+#   gcloud storage ls   -> "One or more URLs matched no objects."
+# The HTTP forms are kept for the API-error path. Nothing here matches a 403.
+_NOT_FOUND_MARKERS = (
+    "matched no objects",
+    "No URLs matched",
+    "HTTPError 404",
+    "NotFound",
+)
+
+
+class StoreError(RuntimeError):
+    """The archive could not be read for a reason other than absence."""
+
+
+class FreshnessStore(Protocol):
+    def read_json(self, key: str) -> dict[str, Any] | None: ...
+
+    def exists(self, key: str) -> bool: ...
+
+
+@dataclasses.dataclass(frozen=True)
+class CompletedCommand:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+Runner = Callable[[list[str]], CompletedCommand]
+
+
+def _run_gcloud(argv: list[str]) -> CompletedCommand:
+    result = subprocess.run(  # noqa: S603 - fixed executable and argv, no shell
+        argv,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    return CompletedCommand(result.returncode, result.stdout, result.stderr)
+
+
+class GcloudStore:
+    """Read the archive bucket through the gcloud CLI.
+
+    ``gcloud storage cat`` and ``gcloud storage ls`` exit non-zero both when
+    an object is absent and when it cannot be read; the two are told apart by
+    the error text, and only absence is reported as ``None``/``False``.
+    """
+
+    def __init__(self, *, bucket: str, runner: Runner = _run_gcloud) -> None:
+        self._bucket = bucket
+        self._run = runner
+
+    def _url(self, key: str) -> str:
+        return f"gs://{self._bucket}/{key}"
+
+    @staticmethod
+    def _is_not_found(stderr: str) -> bool:
+        return any(marker in stderr for marker in _NOT_FOUND_MARKERS)
+
+    def read_json(self, key: str) -> dict[str, Any] | None:
+        result = self._run(["gcloud", "storage", "cat", self._url(key)])
+        if result.returncode != 0:
+            if self._is_not_found(result.stderr):
+                return None
+            raise StoreError(f"cannot read {self._url(key)}: {result.stderr.strip()}")
+        try:
+            value = json.loads(result.stdout)
+        except ValueError as exc:
+            raise StoreError(f"{self._url(key)} is not valid JSON: {exc}") from exc
+        if not isinstance(value, dict):
+            raise StoreError(f"{self._url(key)} is not a JSON object")
+        return value
+
+    def exists(self, key: str) -> bool:
+        result = self._run(["gcloud", "storage", "ls", self._url(key)])
+        if result.returncode == 0:
+            return True
+        if self._is_not_found(result.stderr):
+            return False
+        raise StoreError(f"cannot list {self._url(key)}: {result.stderr.strip()}")
+
+
+@dataclasses.dataclass(frozen=True)
+class Problem:
+    dataset: str
+    day: dt.date
+    message: str
+
+    def __str__(self) -> str:
+        return f"{self.dataset} day={self.day.isoformat()}: {self.message}"
+
+
+@dataclasses.dataclass(frozen=True)
+class DatasetStatus:
+    dataset: str
+    day: dt.date
+    revision: str | None
+    updated_at: str | None
+    problems: tuple[Problem, ...]
+
+    @property
+    def fresh(self) -> bool:
+        return not self.problems
+
+
+def pointer_key(dataset: str, day: dt.date) -> str:
+    return f"raw/{dataset}/day={day.isoformat()}/_latest.json"
+
+
+def _parse_updated_at(value: object) -> dt.datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    text = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = dt.datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(dt.UTC)
+
+
+def check_dataset(
+    store: FreshnessStore,
+    dataset: str,
+    day: dt.date,
+) -> DatasetStatus:
+    """Judge one dataset-day. Every defect is a separate, specific problem."""
+    key = pointer_key(dataset, day)
+    problems: list[Problem] = []
+
+    def problem(message: str) -> None:
+        problems.append(Problem(dataset, day, message))
+
+    pointer = store.read_json(key)
+    if pointer is None:
+        problem(f"no pointer at {key}; the day was never archived")
+        return DatasetStatus(dataset, day, None, None, tuple(problems))
+
+    revision = pointer.get("revision")
+    if not isinstance(revision, str) or not revision:
+        problem("pointer has no revision")
+        revision = None
+
+    if pointer.get("day") != day.isoformat():
+        problem(f"pointer says day={pointer.get('day')!r}, expected {day.isoformat()}")
+
+    if pointer.get("schema_version") != ARCHIVE_SCHEMA_VERSION:
+        problem(
+            f"pointer schema_version={pointer.get('schema_version')!r}, "
+            f"expected {ARCHIVE_SCHEMA_VERSION}"
+        )
+
+    manifest_key = pointer.get("manifest")
+    if not isinstance(manifest_key, str) or not manifest_key:
+        problem("pointer names no manifest")
+    elif not store.exists(manifest_key):
+        problem(f"pointer names manifest {manifest_key}, which does not exist")
+
+    updated_raw = pointer.get("updated_at")
+    updated_at = _parse_updated_at(updated_raw)
+    if updated_at is None:
+        problem(f"pointer updated_at={updated_raw!r} is not a timezone-aware timestamp")
+    else:
+        day_closed = dt.datetime.combine(day + dt.timedelta(days=1), dt.time(), tzinfo=dt.UTC)
+        if updated_at < day_closed:
+            problem(
+                f"pointer was written at {updated_at.isoformat()}, before the day closed "
+                f"at {day_closed.isoformat()}; the archive would be of a partial day"
+            )
+
+    return DatasetStatus(
+        dataset,
+        day,
+        revision,
+        updated_raw if isinstance(updated_raw, str) else None,
+        tuple(problems),
+    )
+
+
+def check_days(
+    store: FreshnessStore,
+    days: Iterable[dt.date],
+    datasets: Iterable[str] = tuple(DATASETS),
+) -> list[DatasetStatus]:
+    statuses: list[DatasetStatus] = []
+    for day in days:
+        for dataset in datasets:
+            statuses.append(check_dataset(store, dataset, day))
+    return statuses
+
+
+def days_to_check(*, now: dt.datetime, lookback: int) -> list[dt.date]:
+    """The closed days that should be archived by ``now``: yesterday backwards.
+
+    ``lookback`` is how many closed days to check; 1 means yesterday only.
+    Today is never checked — the archiver only exports closed days.
+    """
+    if lookback < 1:
+        raise ValueError("lookback must be at least 1")
+    yesterday = now.astimezone(dt.UTC).date() - dt.timedelta(days=1)
+    return [yesterday - dt.timedelta(days=offset) for offset in range(lookback)]
+
+
+def format_report(statuses: Iterable[DatasetStatus]) -> str:
+    lines: list[str] = []
+    for status in statuses:
+        if status.fresh:
+            lines.append(
+                f"OK    {status.dataset} day={status.day.isoformat()} "
+                f"revision={status.revision} updated_at={status.updated_at}"
+            )
+        else:
+            for problem in status.problems:
+                lines.append(f"STALE {problem}")
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--bucket", default=ARCHIVE_BUCKET)
+    parser.add_argument(
+        "--day",
+        type=dt.date.fromisoformat,
+        help="check this closed day instead of yesterday (UTC)",
+    )
+    parser.add_argument(
+        "--lookback",
+        type=int,
+        default=1,
+        help="how many closed days to check, ending yesterday (default 1)",
+    )
+    parser.add_argument(
+        "--dataset",
+        action="append",
+        choices=sorted(DATASETS),
+        help="restrict to a dataset (repeatable; default all)",
+    )
+    parser.add_argument(
+        "--problems-file",
+        help="write one problem per line here on failure, for the alerting step",
+    )
+    return parser.parse_args(argv)
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    store: FreshnessStore | None = None,
+    now: dt.datetime | None = None,
+    out: Callable[[str], None] = print,
+) -> int:
+    args = _parse_args(argv)
+    if args.day is not None:
+        days = [args.day]
+    else:
+        days = days_to_check(now=now or dt.datetime.now(dt.UTC), lookback=args.lookback)
+    datasets: tuple[str, ...] = tuple(args.dataset) if args.dataset else tuple(DATASETS)
+    active_store: FreshnessStore = store or GcloudStore(bucket=args.bucket)
+
+    try:
+        statuses = check_days(active_store, days, datasets)
+    except StoreError as exc:
+        out(f"::error::archive freshness could not be determined: {exc}")
+        if args.problems_file:
+            with open(args.problems_file, "w", encoding="utf-8") as handle:
+                handle.write(f"could not read the archive: {exc}\n")
+        return 2
+
+    out(format_report(statuses))
+    problems = [problem for status in statuses for problem in status.problems]
+    if problems:
+        out(f"::error::{len(problems)} archive freshness problem(s) in gs://{args.bucket}")
+        if args.problems_file:
+            with open(args.problems_file, "w", encoding="utf-8") as handle:
+                handle.write("\n".join(str(problem) for problem in problems) + "\n")
+        return 1
+    checked = ", ".join(day.isoformat() for day in days)
+    out(f"archive is fresh for {len(datasets)} dataset(s) on {checked}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/test_clickhouse_archive_freshness.py
+++ b/tests/test_clickhouse_archive_freshness.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+from typing import Any
+
+import pytest
+
+from clickhouse.archive_daily import ARCHIVE_SCHEMA_VERSION, DATASETS
+from clickhouse.check_archive_freshness import (
+    CompletedCommand,
+    GcloudStore,
+    StoreError,
+    check_dataset,
+    check_days,
+    days_to_check,
+    main,
+    pointer_key,
+)
+
+DAY = dt.date(2026, 8, 15)
+UTC = dt.UTC
+
+
+def _pointer(day: dt.date = DAY, **overrides: Any) -> dict[str, Any]:
+    pointer: dict[str, Any] = {
+        "schema_version": ARCHIVE_SCHEMA_VERSION,
+        "day": day.isoformat(),
+        "revision": "v1-19060-11af19dec320bb40-5e74e8045922709a",
+        "manifest": (
+            f"raw/activity_generations/day={day.isoformat()}/revisions/"
+            "v1-19060-11af19dec320bb40-5e74e8045922709a/manifest.json"
+        ),
+        "source_fingerprint": {"rows": 19060, "hash_sum": 1, "hash_xor": 2},
+        "updated_at": "2026-08-16T14:40:48Z",
+    }
+    pointer.update(overrides)
+    return pointer
+
+
+class FakeStore:
+    def __init__(self) -> None:
+        self.objects: dict[str, dict[str, Any] | None] = {}
+        self.present: set[str] = set()
+        self.reads: list[str] = []
+        self.fail_reads_with: str | None = None
+
+    def put(self, key: str, pointer: dict[str, Any], *, with_manifest: bool = True) -> None:
+        self.objects[key] = pointer
+        if with_manifest and isinstance(pointer.get("manifest"), str):
+            self.present.add(pointer["manifest"])
+
+    def read_json(self, key: str) -> dict[str, Any] | None:
+        self.reads.append(key)
+        if self.fail_reads_with is not None:
+            raise StoreError(self.fail_reads_with)
+        return self.objects.get(key)
+
+    def exists(self, key: str) -> bool:
+        return key in self.present
+
+
+def _fresh_store(day: dt.date = DAY) -> FakeStore:
+    store = FakeStore()
+    for dataset in DATASETS:
+        pointer = _pointer(day)
+        pointer["manifest"] = pointer["manifest"].replace("activity_generations", dataset)
+        store.put(pointer_key(dataset, day), pointer)
+    return store
+
+
+def test_fresh_day_has_no_problems() -> None:
+    statuses = check_days(_fresh_store(), [DAY])
+    assert len(statuses) == len(DATASETS)
+    assert all(status.fresh for status in statuses)
+    assert {status.revision for status in statuses} == {
+        "v1-19060-11af19dec320bb40-5e74e8045922709a"
+    }
+
+
+def test_missing_pointer_is_a_problem_naming_the_key() -> None:
+    store = FakeStore()
+    status = check_dataset(store, "activity_generations", DAY)
+    assert not status.fresh
+    assert len(status.problems) == 1
+    assert "never archived" in status.problems[0].message
+    assert pointer_key("activity_generations", DAY) in status.problems[0].message
+
+
+def test_pointer_whose_manifest_is_absent_is_a_problem() -> None:
+    store = FakeStore()
+    store.put(pointer_key("activity_generations", DAY), _pointer(), with_manifest=False)
+    status = check_dataset(store, "activity_generations", DAY)
+    assert [p.message for p in status.problems] == [
+        f"pointer names manifest {_pointer()['manifest']}, which does not exist"
+    ]
+
+
+def test_pointer_for_the_wrong_day_is_a_problem() -> None:
+    store = FakeStore()
+    store.put(pointer_key("activity_generations", DAY), _pointer(day=DAY - dt.timedelta(days=1)))
+    status = check_dataset(store, "activity_generations", DAY)
+    assert any("expected 2026-08-15" in p.message for p in status.problems)
+
+
+def test_pointer_written_before_the_day_closed_is_a_problem() -> None:
+    store = FakeStore()
+    store.put(
+        pointer_key("activity_generations", DAY),
+        _pointer(updated_at="2026-08-15T23:59:59Z"),
+    )
+    status = check_dataset(store, "activity_generations", DAY)
+    assert any("before the day closed" in p.message for p in status.problems)
+
+
+def test_real_pointer_shape_with_microseconds_is_fresh() -> None:
+    # Copied from the live bucket on 2026-08-16: fromisoformat must accept the
+    # microsecond precision the archiver actually writes.
+    store = FakeStore()
+    store.put(
+        pointer_key("activity_generations", DAY),
+        _pointer(updated_at="2026-08-16T14:40:47.567030Z"),
+    )
+    status = check_dataset(store, "activity_generations", DAY)
+    assert status.fresh, [str(p) for p in status.problems]
+
+
+def test_pointer_written_exactly_at_day_close_is_fresh() -> None:
+    store = FakeStore()
+    store.put(
+        pointer_key("activity_generations", DAY),
+        _pointer(updated_at="2026-08-16T00:00:00Z"),
+    )
+    assert check_dataset(store, "activity_generations", DAY).fresh
+
+
+@pytest.mark.parametrize("bad", ["", "not-a-time", "2026-08-16T14:40:48", 42, None])
+def test_unusable_updated_at_is_a_problem(bad: object) -> None:
+    store = FakeStore()
+    store.put(pointer_key("activity_generations", DAY), _pointer(updated_at=bad))
+    status = check_dataset(store, "activity_generations", DAY)
+    assert any("timezone-aware" in p.message for p in status.problems)
+
+
+def test_schema_version_and_revision_are_checked() -> None:
+    store = FakeStore()
+    store.put(
+        pointer_key("activity_generations", DAY),
+        _pointer(schema_version=ARCHIVE_SCHEMA_VERSION + 1, revision=""),
+    )
+    status = check_dataset(store, "activity_generations", DAY)
+    messages = [p.message for p in status.problems]
+    assert any("schema_version" in m for m in messages)
+    assert "pointer has no revision" in messages
+    assert status.revision is None
+
+
+def test_read_error_is_not_reported_as_missing() -> None:
+    store = FakeStore()
+    store.fail_reads_with = "403 Forbidden: storage.objects.get denied"
+    with pytest.raises(StoreError, match="403"):
+        check_dataset(store, "activity_generations", DAY)
+
+
+def test_days_to_check_never_includes_today() -> None:
+    now = dt.datetime(2026, 8, 16, 7, 30, tzinfo=UTC)
+    assert days_to_check(now=now, lookback=1) == [dt.date(2026, 8, 15)]
+    assert days_to_check(now=now, lookback=3) == [
+        dt.date(2026, 8, 15),
+        dt.date(2026, 8, 14),
+        dt.date(2026, 8, 13),
+    ]
+    with pytest.raises(ValueError, match="at least 1"):
+        days_to_check(now=now, lookback=0)
+
+
+def test_days_to_check_uses_utc_not_local_offset() -> None:
+    # 01:30 on the 17th in UTC+3 is still the 16th in UTC: yesterday is the 15th.
+    now = dt.datetime(2026, 8, 17, 1, 30, tzinfo=dt.timezone(dt.timedelta(hours=3)))
+    assert days_to_check(now=now, lookback=1) == [dt.date(2026, 8, 15)]
+
+
+def test_main_exit_codes_and_problem_file(tmp_path: Any) -> None:
+    now = dt.datetime(2026, 8, 16, 7, 30, tzinfo=UTC)
+    lines: list[str] = []
+
+    assert main([], store=_fresh_store(), now=now, out=lines.append) == 0
+    assert any(line.startswith("archive is fresh for 4 dataset(s) on 2026-08-15") for line in lines)
+
+    problems_file = tmp_path / "problems.txt"
+    stale = _fresh_store()
+    del stale.objects[pointer_key("synthetic_probe_samples", DAY)]
+    lines.clear()
+    code = main(
+        ["--problems-file", str(problems_file)],
+        store=stale,
+        now=now,
+        out=lines.append,
+    )
+    assert code == 1
+    written = problems_file.read_text()
+    assert "synthetic_probe_samples day=2026-08-15" in written
+    assert "activity_generations" not in written
+    assert any(line.startswith("::error::1 archive freshness problem") for line in lines)
+
+    broken = _fresh_store()
+    broken.fail_reads_with = "403 Forbidden"
+    lines.clear()
+    code = main(["--problems-file", str(problems_file)], store=broken, now=now, out=lines.append)
+    assert code == 2
+    assert "could not read the archive: 403 Forbidden" in problems_file.read_text()
+    assert any("could not be determined" in line for line in lines)
+
+
+def test_main_day_and_dataset_overrides() -> None:
+    now = dt.datetime(2026, 8, 20, 7, 30, tzinfo=UTC)
+    store = _fresh_store(DAY)  # only 2026-08-15 is archived
+    lines: list[str] = []
+    assert main(["--day", "2026-08-15"], store=store, now=now, out=lines.append) == 0
+    lines.clear()
+    assert (
+        main(
+            ["--day", "2026-08-15", "--dataset", "activity_generations"],
+            store=store,
+            now=now,
+            out=lines.append,
+        )
+        == 0
+    )
+    assert any("fresh for 1 dataset(s)" in line for line in lines)
+    # Yesterday relative to `now` (08-19) is not archived, so the default is stale.
+    assert main([], store=store, now=now, out=lines.append) == 1
+
+
+class FakeRunner:
+    def __init__(self, responses: dict[str, CompletedCommand]) -> None:
+        self.responses = responses
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv: list[str]) -> CompletedCommand:
+        self.calls.append(argv)
+        return self.responses[argv[2] + " " + argv[3]]
+
+
+def test_gcloud_store_distinguishes_absent_from_forbidden() -> None:
+    bucket = "example-archive"
+    key = pointer_key("activity_generations", DAY)
+    url = f"gs://{bucket}/{key}"
+    runner = FakeRunner(
+        {
+            f"cat {url}": CompletedCommand(0, json.dumps(_pointer()), ""),
+            f"cat gs://{bucket}/absent.json": CompletedCommand(
+                1,
+                "",
+                "ERROR: (gcloud.storage.cat) The following URLs matched no objects"
+                " or files: gs://example-archive/absent.json",
+            ),
+            f"cat gs://{bucket}/denied.json": CompletedCommand(
+                1,
+                "",
+                "ERROR: (gcloud.storage.cat) HTTPError 403: tr-x@... does not have"
+                " storage.objects.get access",
+            ),
+            f"cat gs://{bucket}/garbage.json": CompletedCommand(0, "not json", ""),
+            f"ls gs://{bucket}/present": CompletedCommand(0, f"gs://{bucket}/present\n", ""),
+            f"ls gs://{bucket}/gone": CompletedCommand(
+                1, "", "ERROR: (gcloud.storage.ls) One or more URLs matched no objects."
+            ),
+            f"ls gs://{bucket}/denied": CompletedCommand(1, "", "HTTPError 403: forbidden"),
+        }
+    )
+    store = GcloudStore(bucket=bucket, runner=runner)
+
+    assert store.read_json(key) == _pointer()
+    assert store.read_json("absent.json") is None
+    with pytest.raises(StoreError, match="403"):
+        store.read_json("denied.json")
+    with pytest.raises(StoreError, match="not valid JSON"):
+        store.read_json("garbage.json")
+    assert store.exists("present") is True
+    assert store.exists("gone") is False
+    with pytest.raises(StoreError, match="403"):
+        store.exists("denied")
+    assert runner.calls[0][:3] == ["gcloud", "storage", "cat"]


### PR DESCRIPTION
## Why

The daily verified archive and its restore drill run on `tr-clickhouse-1` under systemd timers. On 2026-08-16 a service-account swap during hardening left both units failing with 403 for ten hours; nothing paged, a person found it by looking at the bucket (SOC 2 NC-005). A backup control that fails silently is a monitoring gap.

## What

- `clickhouse/check_archive_freshness.py` — reads `raw/<dataset>/day=<yesterday>/_latest.json` for all four datasets through `gcloud storage` and fails if a pointer is missing, names a manifest that does not exist, carries the wrong day/schema, or was written before the day closed. A 403/transport error is its own failure (exit 2), never "missing" — reading 403 as "not archived yet" would be wrong in the same way the incident was. Not-found markers are the strings gcloud printed against the real bucket today.
- `.github/workflows/check-archive-freshness.yml` — daily 07:30 UTC (after the 04:28 archive and 06:08 drill), `workflow_dispatch` with `day`/`lookback`, and on push to the two files. WIF as the existing deploy identity, read-only use. On failure files/updates ONE issue (`archive-freshness`) with the journal commands to run first — same pattern as `verify-trust-freshness`.

Because it reads the bucket rather than the unit, it also catches "the archiver never ran" (node down, timer disabled), which an `OnFailure=` hook cannot.

## Verification

- 19 unit tests with a fake store (fresh; missing pointer; absent manifest; wrong day; pre-close timestamp; unusable `updated_at` incl. naive; schema/revision; 403 propagates; UTC day arithmetic incl. a UTC+3 `now`; exit codes + problems file; `--day`/`--dataset`; `GcloudStore` absent-vs-forbidden and non-JSON).
- `ruff check`, `ruff format --check`, `mypy --strict` on the module: clean.
- **Live positive control** against the real bucket: 2026-08-15 fresh for all four datasets, exit 0.
- **Live negative control**: `--day 2026-08-16` (not a closed day) → four "never archived" problems, exit 1, problems file written.
- After merge the `push` trigger gives an in-Actions positive control (WIF path); a dispatched negative control will follow to prove the issue step end to end.

No deploy is triggered (paths outside `deploy.yml`'s filter). No new IAM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
