### PR TITLE
Repair ClickHouse parity identity and schema rollout

### DIFF
--- a/clickhouse/reconcile_benchmark_samples.py
+++ b/clickhouse/reconcile_benchmark_samples.py
@@ -25,7 +25,7 @@ log = logging.getLogger("trusted_router.analytics_reconciler")
 
 CLICKHOUSE_COLUMNS = (
     "id, created_at, provider, model, provider_name, status, usage_type, source, "
-    "streamed, input_tokens, output_tokens, total_cost_microdollars, "
+    "workspace_id, streamed, input_tokens, output_tokens, total_cost_microdollars, "
     "speed_tokens_per_second, elapsed_milliseconds, first_token_milliseconds, "
     "ttfb_milliseconds, finish_reason, error_type, error_status, error_message, "
     "region, app"

--- a/scripts/deploy/clickhouse_cluster.sh
+++ b/scripts/deploy/clickhouse_cluster.sh
@@ -96,6 +96,22 @@ ensure_service_account() {
   done
   ensure_project_role "serviceAccount:${CLUSTER_SERVICE_ACCOUNT}" roles/monitoring.metricWriter
   ensure_project_role "serviceAccount:${CLUSTER_SERVICE_ACCOUNT}" roles/logging.logWriter
+  # The parity and bounded backfill workers compare ClickHouse with the one
+  # retained Bigtable instance. Keep this at the instance boundary: the
+  # dedicated VM identity must not inherit project-wide Bigtable access.
+  for attempt in {1..12}; do
+    if gc bigtable instances add-iam-policy-binding "$BIGTABLE_INSTANCE_ID" \
+        --member="serviceAccount:${CLUSTER_SERVICE_ACCOUNT}" \
+        --role=roles/bigtable.reader \
+        --quiet >/dev/null 2>&1; then
+      break
+    fi
+    if [ "$attempt" -eq 12 ]; then
+      echo "could not grant Bigtable read access to ${CLUSTER_SERVICE_ACCOUNT}" >&2
+      exit 1
+    fi
+    sleep 5
+  done
   # Node 1 drains the durable Spanner analytics outbox. Keep this grant at the
   # database boundary: changing the VM from the broad default Compute identity
   # must not silently stop ingestion with spanner.sessions.create 403s.

--- a/scripts/deploy/clickhouse_operational_analytics.sh
+++ b/scripts/deploy/clickhouse_operational_analytics.sh
@@ -11,6 +11,8 @@ source "${SCRIPT_DIR}/_lib.sh"
 NAMES=(tr-clickhouse-1 tr-clickhouse-2 tr-clickhouse-3)
 ZONES=(us-central1-a us-central1-b us-central1-c)
 SCHEMA="${ROOT}/clickhouse/004_operational_analytics_replicated.sql"
+BENCHMARK_WORKSPACE_SCHEMA="${ROOT}/clickhouse/007_benchmark_samples_workspace_id.sql"
+BENCHMARK_WORKSPACE_BACKFILL_LIMIT="${TR_CLICKHOUSE_BENCHMARK_WORKSPACE_BACKFILL_LIMIT:-200000}"
 CONTROL_SECRET="trustedrouter-clickhouse-control-read-password"
 APPLY=0
 
@@ -26,7 +28,13 @@ if [ "$APPLY" -eq 0 ]; then
   log "dry-run: would create three-replica activity and synthetic tables"
   log "dry-run: would backfill bounded Bigtable history and verify replica parity"
   log "dry-run: would install the ingester, rollup worker, and private reader"
+  log "dry-run: would migrate and replay bounded benchmark workspace attribution"
   exit 0
+fi
+
+if ! [[ "$BENCHMARK_WORKSPACE_BACKFILL_LIMIT" =~ ^[1-9][0-9]*$ ]]; then
+  echo "TR_CLICKHOUSE_BENCHMARK_WORKSPACE_BACKFILL_LIMIT must be a positive integer" >&2
+  exit 2
 fi
 
 node_ssh() {
@@ -123,6 +131,27 @@ node_ssh 0 --command="sudo sh -c '
     /etc/systemd/system/tr-clickhouse-spanner-delivery.timer
   systemctl daemon-reload
   systemctl stop tr-clickhouse-operational-ingest.service 2>/dev/null || true
+'"
+
+# Deploy the parser before the additive column. The ingester is stopped while
+# these two versions move together, so rows queue durably in Spanner instead
+# of being written with the column default during a version-skew window.
+log "adding workspace attribution to benchmark samples"
+benchmark_workspace_schema="$(cat "$BENCHMARK_WORKSPACE_SCHEMA")"
+for index in 0 1 2; do
+  node_query "$index" "$benchmark_workspace_schema"
+done
+
+log "replaying bounded benchmark history with workspace attribution"
+node_ssh 0 --command="sudo sh -c '
+  set -eu
+  set -a
+  . /etc/tr-clickhouse-ingest.env
+  set +a
+  cd /opt/tr-clickhouse
+  PYTHONPATH=/opt/tr-clickhouse/src \
+    /opt/tr-clickhouse/venv/bin/python -m clickhouse.backfill_benchmark_samples \
+      --limit ${BENCHMARK_WORKSPACE_BACKFILL_LIMIT} --batch 20000
 '"
 
 log "backfilling bounded Bigtable history"

--- a/tests/test_analytics_outbox.py
+++ b/tests/test_analytics_outbox.py
@@ -15,7 +15,11 @@ from clickhouse.ingest_outbox import (
     drain_once,
     normalise_outbox_payload,
 )
-from clickhouse.reconcile_benchmark_samples import _add_row, _reverse_time_key
+from clickhouse.reconcile_benchmark_samples import (
+    CLICKHOUSE_COLUMNS,
+    _add_row,
+    _reverse_time_key,
+)
 from trusted_router.config import Settings
 from trusted_router.storage_gcp_analytics_outbox import (
     SpannerAnalyticsOutbox,
@@ -35,6 +39,7 @@ def _sample() -> ProviderBenchmarkSample:
         status="error",
         usage_type=UsageType.CREDITS,
         streamed=True,
+        workspace_id="ws-analytics-test",
         input_tokens=12,
         output_tokens=3,
         speed_tokens_per_second=7.125,
@@ -137,6 +142,8 @@ def test_normalise_is_identical_for_backfill_and_outbox_payload() -> None:
     assert expected is not None
     assert expected["error_status"] == 429
     assert expected["elapsed_milliseconds"] == 210
+    assert expected["workspace_id"] == "ws-analytics-test"
+    assert "workspace_id" in CLICKHOUSE_COLUMNS
 
 
 class _Source:

--- a/tests/test_clickhouse_node_provisioning.py
+++ b/tests/test_clickhouse_node_provisioning.py
@@ -49,6 +49,10 @@ def test_cluster_migration_is_parity_gated_and_keeps_local_backup() -> None:
     assert "source and replicated fingerprints differ" in script
     assert "timedelta(minutes=5)" in script
     assert "service account did not become visible" in script
+    assert "bigtable instances add-iam-policy-binding" in script
+    assert '"$BIGTABLE_INSTANCE_ID"' in script
+    assert "roles/bigtable.reader" in script
+    assert "could not grant Bigtable read access" in script
     assert "roles/spanner.databaseUser" in script
     assert "spanner databases add-iam-policy-binding" in script
     assert "provider_benchmark_samples_local_backup" in script
@@ -72,6 +76,22 @@ def test_rollout_prefers_private_clickhouse_load_balancer() -> None:
 
     assert "compute addresses describe tr-clickhouse-ilb" in script
     assert 'TR_PROVIDER_ANALYTICS_CLICKHOUSE_URL=${PROVIDER_ANALYTICS_CLICKHOUSE_URL}' in script
+
+
+def test_operational_deploy_moves_benchmark_code_schema_and_replay_together() -> None:
+    script = (ROOT / "scripts/deploy/clickhouse_operational_analytics.sh").read_text()
+
+    upload = script.index("sudo tar -xzf - -C /opt/tr-clickhouse")
+    stop = script.index("systemctl stop tr-clickhouse-operational-ingest.service")
+    migration = script.index('log "adding workspace attribution to benchmark samples"')
+    replay = script.index("clickhouse.backfill_benchmark_samples")
+    restart = script.index(
+        "systemctl start tr-clickhouse-operational-ingest.service", replay
+    )
+
+    assert upload < stop < migration < replay < restart
+    assert "007_benchmark_samples_workspace_id.sql" in script
+    assert "TR_CLICKHOUSE_BENCHMARK_WORKSPACE_BACKFILL_LIMIT" in script
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- grant the dedicated ClickHouse identity read-only access at the retained Bigtable instance boundary
- deploy benchmark parser code, stop ingestion, apply workspace attribution schema, and replay bounded rows in one ordered operation
- include workspace attribution in benchmark reconciliation fingerprints

## Production repair
- applied `roles/bigtable.reader` only on `trusted-router-logs`
- deployed the corrected normalizer and restarted the outbox ingester
- replayed the latest 10,000 metadata-only benchmark rows
- exact parity passed at `2026-08-16T17:22:41.144432Z`: 5,000/5,000 on benchmark, activity, synthetic, and rollup

## Verification
- `uv run pytest -q tests/test_clickhouse*.py tests/test_analytics*.py` (100 passed, 1 skipped)
- focused deployment and workspace tests (49 passed)
- Ruff and `bash -n` pass
- shellcheck was unavailable locally