### PR TITLE
Client telemetry R-PR2: contract doc, ClickHouse DDL 008/009, tolerant ingester + quarantine, rollup, snapshot skeleton

### DIFF
--- a/clickhouse/008_client_events_replicated.sql
+++ b/clickhouse/008_client_events_replicated.sql
@@ -1,0 +1,200 @@
+-- Replicated client-observed reliability telemetry tables.
+--
+-- Retention is deliberate: sampled request events live for 90 days, exact
+-- minute counters for 180 days, published rollups for 24 months, and poison
+-- outbox rows for 30 days. The raw client event and counter tables are
+-- deliberately NOT archived to Parquet; rollups are the retained artefact.
+
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS gateway_request_id String DEFAULT '';
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS synthetic UInt8 DEFAULT 0;
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_source LowCardinality(String) DEFAULT 'none';
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_sdk LowCardinality(String) DEFAULT '';
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_sdk_version LowCardinality(String) DEFAULT '';
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_lang LowCardinality(String) DEFAULT '';
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_runtime LowCardinality(String) DEFAULT '';
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_os LowCardinality(String) DEFAULT '';
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_arch LowCardinality(String) DEFAULT '';
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_timeout_ms Nullable(UInt32) DEFAULT NULL;
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_attempt Nullable(UInt8) DEFAULT NULL;
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_prev_outcome LowCardinality(String) DEFAULT '';
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_prev_error_class LowCardinality(String) DEFAULT '';
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_prev_host LowCardinality(String) DEFAULT '';
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_prev_elapsed_ms Nullable(UInt32) DEFAULT NULL;
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_since_first_ms Nullable(UInt32) DEFAULT NULL;
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_stream Nullable(UInt8) DEFAULT NULL;
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_failover_used Nullable(UInt8) DEFAULT NULL;
+
+CREATE TABLE IF NOT EXISTS client_request_events
+(
+    event_id                      FixedString(64),
+    tenant_id                     FixedString(64),
+    key_id                        FixedString(64),
+    batch_id                      FixedString(32),
+    instance_id                   FixedString(16),
+    seq                           UInt32,
+    received_at                   DateTime64(3, 'UTC'),
+    created_at                    DateTime64(3, 'UTC'),
+    clock_skew_ms                 Int64,
+    synthetic                     UInt8,
+    sdk                           LowCardinality(String),
+    sdk_version                   LowCardinality(String),
+    lang                          LowCardinality(String),
+    runtime                       LowCardinality(String),
+    os                            LowCardinality(String),
+    arch                          LowCardinality(String),
+    plane                         LowCardinality(String),
+    endpoint                      LowCardinality(String),
+    method                        LowCardinality(String),
+    streaming                     UInt8,
+    provider_pinned               UInt8,
+    model                         LowCardinality(String),
+    final_outcome                 LowCardinality(String),
+    final_http_status             UInt16,
+    final_host                    LowCardinality(String),
+    first_error_class             LowCardinality(String),
+    error_source                  LowCardinality(String),
+    total_ms                      UInt32,
+    ttft_ms                       Nullable(UInt32),
+    timeout_phase                 LowCardinality(String),
+    configured_timeout_ms         Nullable(UInt32),
+    attempt_count                 UInt8,
+    failover_used                 UInt8,
+    attempt_host                  Array(LowCardinality(String)),
+    attempt_outcome               Array(LowCardinality(String)),
+    attempt_http_status           Array(UInt16),
+    attempt_error_class           Array(LowCardinality(String)),
+    attempt_error_source          Array(LowCardinality(String)),
+    attempt_should_retry          Array(LowCardinality(String)),
+    attempt_retry_after_ms        Array(UInt32),
+    attempt_elapsed_ms            Array(UInt32),
+    attempt_ttfb_ms               Array(UInt32),
+    attempt_request_id            Array(String),
+    attempt_moved                 Array(UInt8),
+    sample_rate                   Float32,
+    sample_reason                 LowCardinality(String),
+    tr_fault                      UInt8,
+    methodology_version           UInt8,
+    ingest_version                DateTime64(6, 'UTC')
+)
+ENGINE = ReplicatedReplacingMergeTree(
+    '/trustedrouter/tables/{shard}/client-request-events-v1',
+    '{replica}',
+    ingest_version
+)
+PARTITION BY toYYYYMM(created_at)
+ORDER BY (tenant_id, created_at, event_id)
+TTL toDateTime(created_at) + INTERVAL 90 DAY;
+
+CREATE TABLE IF NOT EXISTS client_minute_counters
+(
+    event_id                    FixedString(64),
+    tenant_id                   FixedString(64),
+    key_id                      FixedString(64),
+    instance_id                 FixedString(16),
+    bucket_start                DateTime('UTC'),
+    received_at                 DateTime64(3, 'UTC'),
+    synthetic                   UInt8,
+    sdk                         LowCardinality(String),
+    sdk_version                 LowCardinality(String),
+    level                       LowCardinality(String),
+    endpoint                    LowCardinality(String),
+    streaming                   UInt8,
+    host                        LowCardinality(String),
+    outcome                     LowCardinality(String),
+    error_class                 LowCardinality(String),
+    http_status_class           LowCardinality(String),
+    timeout_phase               LowCardinality(String),
+    timeout_floor_met           UInt8,
+    provider_pinned             UInt8,
+    requests                    UInt64,
+    attempts                    UInt64,
+    failover_used               UInt64,
+    first_attempt_success       UInt64,
+    total_ms_hist               Map(String, UInt64),
+    first_event_ms_hist         Map(String, UInt64),
+    tr_fault                    UInt8,
+    methodology_version         UInt8,
+    ingest_version              DateTime64(6, 'UTC')
+)
+ENGINE = ReplicatedReplacingMergeTree(
+    '/trustedrouter/tables/{shard}/client-minute-counters-v1',
+    '{replica}',
+    ingest_version
+)
+PARTITION BY toYYYYMM(bucket_start)
+ORDER BY (
+    tenant_id, bucket_start, level, host, endpoint, outcome, error_class,
+    event_id
+)
+TTL bucket_start + INTERVAL 180 DAY;
+
+CREATE TABLE IF NOT EXISTS client_availability_rollups
+(
+    id                         String,
+    period                     LowCardinality(String),
+    period_start               DateTime('UTC'),
+    scope                      LowCardinality(String),
+    tenant_id                  FixedString(64),
+    host                       LowCardinality(String),
+    endpoint                   LowCardinality(String),
+    sdk                        LowCardinality(String),
+    requests                   UInt64,
+    successes                  UInt64,
+    tr_fault_failures          UInt64,
+    excluded_failures          UInt64,
+    aborted                    UInt64,
+    attempts                   UInt64,
+    attempt_tr_fault           UInt64,
+    failover_used              UInt64,
+    first_attempt_success      UInt64,
+    distinct_tenants           UInt32,
+    capped_requests            UInt64,
+    coverage_requests          UInt64,
+    total_ms_hist              Map(String, UInt64),
+    first_event_ms_hist        Map(String, UInt64),
+    methodology_version        UInt8,
+    computed_at                DateTime64(3, 'UTC')
+)
+ENGINE = ReplicatedReplacingMergeTree(
+    '/trustedrouter/tables/{shard}/client-availability-rollups-v1',
+    '{replica}',
+    computed_at
+)
+PARTITION BY toYYYYMM(period_start)
+ORDER BY (period, period_start, scope, tenant_id, host, endpoint, sdk, id)
+TTL period_start + INTERVAL 24 MONTH;
+
+CREATE TABLE IF NOT EXISTS operational_outbox_quarantine
+(
+    shard            UInt8,
+    commit_ts        DateTime64(6, 'UTC'),
+    event_kind       String,
+    event_id         String,
+    payload          String CODEC(ZSTD(3)),
+    reason           String,
+    quarantined_at   DateTime64(3, 'UTC')
+)
+ENGINE = ReplicatedMergeTree(
+    '/trustedrouter/tables/{shard}/operational-outbox-quarantine-v1',
+    '{replica}'
+)
+ORDER BY (commit_ts, event_kind, event_id)
+TTL toDateTime(commit_ts) + INTERVAL 30 DAY;

--- a/clickhouse/009_client_events_single_node.sql
+++ b/clickhouse/009_client_events_single_node.sql
@@ -1,0 +1,185 @@
+-- Client-observed reliability telemetry for a STANDALONE ClickHouse node.
+--
+-- Column-for-column identical to 008_client_events_replicated.sql; only the
+-- engines differ. Sampled request events live for 90 days, exact minute
+-- counters for 180 days, rollups for 24 months, and quarantine rows for 30
+-- days. The raw client tables are deliberately NOT archived to Parquet.
+
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS gateway_request_id String DEFAULT '';
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS synthetic UInt8 DEFAULT 0;
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_source LowCardinality(String) DEFAULT 'none';
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_sdk LowCardinality(String) DEFAULT '';
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_sdk_version LowCardinality(String) DEFAULT '';
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_lang LowCardinality(String) DEFAULT '';
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_runtime LowCardinality(String) DEFAULT '';
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_os LowCardinality(String) DEFAULT '';
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_arch LowCardinality(String) DEFAULT '';
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_timeout_ms Nullable(UInt32) DEFAULT NULL;
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_attempt Nullable(UInt8) DEFAULT NULL;
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_prev_outcome LowCardinality(String) DEFAULT '';
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_prev_error_class LowCardinality(String) DEFAULT '';
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_prev_host LowCardinality(String) DEFAULT '';
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_prev_elapsed_ms Nullable(UInt32) DEFAULT NULL;
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_since_first_ms Nullable(UInt32) DEFAULT NULL;
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_stream Nullable(UInt8) DEFAULT NULL;
+ALTER TABLE activity_generations
+    ADD COLUMN IF NOT EXISTS client_failover_used Nullable(UInt8) DEFAULT NULL;
+
+CREATE TABLE IF NOT EXISTS client_request_events
+(
+    event_id                      FixedString(64),
+    tenant_id                     FixedString(64),
+    key_id                        FixedString(64),
+    batch_id                      FixedString(32),
+    instance_id                   FixedString(16),
+    seq                           UInt32,
+    received_at                   DateTime64(3, 'UTC'),
+    created_at                    DateTime64(3, 'UTC'),
+    clock_skew_ms                 Int64,
+    synthetic                     UInt8,
+    sdk                           LowCardinality(String),
+    sdk_version                   LowCardinality(String),
+    lang                          LowCardinality(String),
+    runtime                       LowCardinality(String),
+    os                            LowCardinality(String),
+    arch                          LowCardinality(String),
+    plane                         LowCardinality(String),
+    endpoint                      LowCardinality(String),
+    method                        LowCardinality(String),
+    streaming                     UInt8,
+    provider_pinned               UInt8,
+    model                         LowCardinality(String),
+    final_outcome                 LowCardinality(String),
+    final_http_status             UInt16,
+    final_host                    LowCardinality(String),
+    first_error_class             LowCardinality(String),
+    error_source                  LowCardinality(String),
+    total_ms                      UInt32,
+    ttft_ms                       Nullable(UInt32),
+    timeout_phase                 LowCardinality(String),
+    configured_timeout_ms         Nullable(UInt32),
+    attempt_count                 UInt8,
+    failover_used                 UInt8,
+    attempt_host                  Array(LowCardinality(String)),
+    attempt_outcome               Array(LowCardinality(String)),
+    attempt_http_status           Array(UInt16),
+    attempt_error_class           Array(LowCardinality(String)),
+    attempt_error_source          Array(LowCardinality(String)),
+    attempt_should_retry          Array(LowCardinality(String)),
+    attempt_retry_after_ms        Array(UInt32),
+    attempt_elapsed_ms            Array(UInt32),
+    attempt_ttfb_ms               Array(UInt32),
+    attempt_request_id            Array(String),
+    attempt_moved                 Array(UInt8),
+    sample_rate                   Float32,
+    sample_reason                 LowCardinality(String),
+    tr_fault                      UInt8,
+    methodology_version           UInt8,
+    ingest_version                DateTime64(6, 'UTC')
+)
+ENGINE = ReplacingMergeTree(ingest_version)
+PARTITION BY toYYYYMM(created_at)
+ORDER BY (tenant_id, created_at, event_id)
+TTL toDateTime(created_at) + INTERVAL 90 DAY;
+
+CREATE TABLE IF NOT EXISTS client_minute_counters
+(
+    event_id                    FixedString(64),
+    tenant_id                   FixedString(64),
+    key_id                      FixedString(64),
+    instance_id                 FixedString(16),
+    bucket_start                DateTime('UTC'),
+    received_at                 DateTime64(3, 'UTC'),
+    synthetic                   UInt8,
+    sdk                         LowCardinality(String),
+    sdk_version                 LowCardinality(String),
+    level                       LowCardinality(String),
+    endpoint                    LowCardinality(String),
+    streaming                   UInt8,
+    host                        LowCardinality(String),
+    outcome                     LowCardinality(String),
+    error_class                 LowCardinality(String),
+    http_status_class           LowCardinality(String),
+    timeout_phase               LowCardinality(String),
+    timeout_floor_met           UInt8,
+    provider_pinned             UInt8,
+    requests                    UInt64,
+    attempts                    UInt64,
+    failover_used               UInt64,
+    first_attempt_success       UInt64,
+    total_ms_hist               Map(String, UInt64),
+    first_event_ms_hist         Map(String, UInt64),
+    tr_fault                    UInt8,
+    methodology_version         UInt8,
+    ingest_version              DateTime64(6, 'UTC')
+)
+ENGINE = ReplacingMergeTree(ingest_version)
+PARTITION BY toYYYYMM(bucket_start)
+ORDER BY (
+    tenant_id, bucket_start, level, host, endpoint, outcome, error_class,
+    event_id
+)
+TTL bucket_start + INTERVAL 180 DAY;
+
+CREATE TABLE IF NOT EXISTS client_availability_rollups
+(
+    id                         String,
+    period                     LowCardinality(String),
+    period_start               DateTime('UTC'),
+    scope                      LowCardinality(String),
+    tenant_id                  FixedString(64),
+    host                       LowCardinality(String),
+    endpoint                   LowCardinality(String),
+    sdk                        LowCardinality(String),
+    requests                   UInt64,
+    successes                  UInt64,
+    tr_fault_failures          UInt64,
+    excluded_failures          UInt64,
+    aborted                    UInt64,
+    attempts                   UInt64,
+    attempt_tr_fault           UInt64,
+    failover_used              UInt64,
+    first_attempt_success      UInt64,
+    distinct_tenants           UInt32,
+    capped_requests            UInt64,
+    coverage_requests          UInt64,
+    total_ms_hist              Map(String, UInt64),
+    first_event_ms_hist        Map(String, UInt64),
+    methodology_version        UInt8,
+    computed_at                DateTime64(3, 'UTC')
+)
+ENGINE = ReplacingMergeTree(computed_at)
+PARTITION BY toYYYYMM(period_start)
+ORDER BY (period, period_start, scope, tenant_id, host, endpoint, sdk, id)
+TTL period_start + INTERVAL 24 MONTH;
+
+CREATE TABLE IF NOT EXISTS operational_outbox_quarantine
+(
+    shard            UInt8,
+    commit_ts        DateTime64(6, 'UTC'),
+    event_kind       String,
+    event_id         String,
+    payload          String CODEC(ZSTD(3)),
+    reason           String,
+    quarantined_at   DateTime64(3, 'UTC')
+)
+ENGINE = MergeTree
+ORDER BY (commit_ts, event_kind, event_id)
+TTL toDateTime(commit_ts) + INTERVAL 30 DAY;

--- a/clickhouse/archive_daily.py
+++ b/clickhouse/archive_daily.py
@@ -27,6 +27,8 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, Protocol
 
+from clickhouse.ingest_operational_outbox import ACTIVITY_COLUMNS
+
 PROJECT = "quill-cloud-proxy"
 DATABASE = "tr"
 TABLE = "provider_benchmark_samples"
@@ -83,6 +85,8 @@ class DatasetSpec:
     shard_column: str
 
 
+# Raw client_request_events and client_minute_counters are deliberately absent:
+# the telemetry contract retains their rollups, not raw client tables, in Parquet.
 DATASETS: dict[str, DatasetSpec] = {
     "provider_benchmark_samples": DatasetSpec(
         columns=_BENCHMARK_COLUMNS,
@@ -90,37 +94,7 @@ DATASETS: dict[str, DatasetSpec] = {
         shard_column="id",
     ),
     "activity_generations": DatasetSpec(
-        columns=(
-            "generation_id",
-            "request_id",
-            "tenant_id",
-            "key_id",
-            "model",
-            "provider",
-            "provider_name",
-            "app",
-            "tokens_prompt",
-            "tokens_completion",
-            "cached_input_tokens",
-            "reasoning_tokens",
-            "total_cost_microdollars",
-            "usage_type",
-            "speed_tokens_per_second",
-            "finish_reason",
-            "status",
-            "streamed",
-            "usage_estimated",
-            "elapsed_milliseconds",
-            "first_token_milliseconds",
-            "ttfb_milliseconds",
-            "region",
-            "user",
-            "session_id",
-            "http_referer",
-            "app_categories",
-            "tags",
-            "created_at",
-        ),
+        columns=ACTIVITY_COLUMNS,
         time_column="created_at",
         shard_column="generation_id",
     ),
@@ -204,9 +178,7 @@ def _day_bounds(day: dt.date) -> tuple[str, str]:
     start = dt.datetime.combine(day, dt.time(), tzinfo=dt.UTC)
     return (
         start.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
-        (start + dt.timedelta(days=1))
-        .isoformat(timespec="milliseconds")
-        .replace("+00:00", "Z"),
+        (start + dt.timedelta(days=1)).isoformat(timespec="milliseconds").replace("+00:00", "Z"),
     )
 
 
@@ -215,10 +187,7 @@ def _row_hash_expression(columns: Sequence[str]) -> str:
         if column in _UNORDERED_MAP_COLUMNS:
             return f"mapSort({column})"
         if column in _DATETIME_MILLI_COLUMNS:
-            return (
-                "toUnixTimestamp64Milli("
-                f"toDateTime64({column}, 3, 'UTC'))"
-            )
+            return f"toUnixTimestamp64Milli(toDateTime64({column}, 3, 'UTC'))"
         return column
 
     canonical = (canonical_column(column) for column in columns)
@@ -235,10 +204,7 @@ class SourceFingerprint:
 
     @property
     def revision(self) -> str:
-        return (
-            f"v{ARCHIVE_SCHEMA_VERSION}-{self.rows}-"
-            f"{self.hash_sum:016x}-{self.hash_xor:016x}"
-        )
+        return f"v{ARCHIVE_SCHEMA_VERSION}-{self.rows}-{self.hash_sum:016x}-{self.hash_xor:016x}"
 
     def matches(self, other: SourceFingerprint) -> bool:
         return (
@@ -608,7 +574,9 @@ def archive_day(
     with tempfile.TemporaryDirectory(prefix=f"tr-archive-{day.isoformat()}-") as temporary:
         paths = exporter.export_parts(day, Path(temporary), part_count=part_count)
         if len(paths) != part_count:
-            raise RuntimeError(f"expected {part_count} Parquet parts, exporter returned {len(paths)}")
+            raise RuntimeError(
+                f"expected {part_count} Parquet parts, exporter returned {len(paths)}"
+            )
         verified = [exporter.verify_part(path) for path in paths]
         actual = _combine_parts(verified)
         if not source.matches(actual):
@@ -718,9 +686,7 @@ def main() -> int:
             database=args.database,
             table=table,
         )
-        backfill_start = (
-            exporter.earliest_day() if args.backfill and args.date is None else None
-        )
+        backfill_start = exporter.earliest_day() if args.backfill and args.date is None else None
         for day in _days_to_archive(
             date=args.date,
             lookback_days=args.lookback_days,

--- a/clickhouse/archive_daily.py
+++ b/clickhouse/archive_daily.py
@@ -178,7 +178,9 @@ def _day_bounds(day: dt.date) -> tuple[str, str]:
     start = dt.datetime.combine(day, dt.time(), tzinfo=dt.UTC)
     return (
         start.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
-        (start + dt.timedelta(days=1)).isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+        (start + dt.timedelta(days=1))
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z"),
     )
 
 
@@ -187,7 +189,10 @@ def _row_hash_expression(columns: Sequence[str]) -> str:
         if column in _UNORDERED_MAP_COLUMNS:
             return f"mapSort({column})"
         if column in _DATETIME_MILLI_COLUMNS:
-            return f"toUnixTimestamp64Milli(toDateTime64({column}, 3, 'UTC'))"
+            return (
+                "toUnixTimestamp64Milli("
+                f"toDateTime64({column}, 3, 'UTC'))"
+            )
         return column
 
     canonical = (canonical_column(column) for column in columns)
@@ -204,7 +209,10 @@ class SourceFingerprint:
 
     @property
     def revision(self) -> str:
-        return f"v{ARCHIVE_SCHEMA_VERSION}-{self.rows}-{self.hash_sum:016x}-{self.hash_xor:016x}"
+        return (
+            f"v{ARCHIVE_SCHEMA_VERSION}-{self.rows}-"
+            f"{self.hash_sum:016x}-{self.hash_xor:016x}"
+        )
 
     def matches(self, other: SourceFingerprint) -> bool:
         return (
@@ -574,9 +582,7 @@ def archive_day(
     with tempfile.TemporaryDirectory(prefix=f"tr-archive-{day.isoformat()}-") as temporary:
         paths = exporter.export_parts(day, Path(temporary), part_count=part_count)
         if len(paths) != part_count:
-            raise RuntimeError(
-                f"expected {part_count} Parquet parts, exporter returned {len(paths)}"
-            )
+            raise RuntimeError(f"expected {part_count} Parquet parts, exporter returned {len(paths)}")
         verified = [exporter.verify_part(path) for path in paths]
         actual = _combine_parts(verified)
         if not source.matches(actual):
@@ -617,6 +623,11 @@ def archive_day(
         "revision": revision,
         "exported_at": exported_at.isoformat().replace("+00:00", "Z"),
         "source_fingerprint": source.as_dict(),
+        # The exact column list the fingerprint was computed over. Column
+        # additions (activity_generations grew client_* columns) change the
+        # fingerprint expression, so a verifier must recompute against the
+        # columns of THIS revision, not whatever the current schema says.
+        "columns": list(DATASETS[dataset].columns),
         "parts": manifest_parts,
         "parquet_rows": sum(int(part["rows"]) for part in manifest_parts),
     }
@@ -686,7 +697,9 @@ def main() -> int:
             database=args.database,
             table=table,
         )
-        backfill_start = exporter.earliest_day() if args.backfill and args.date is None else None
+        backfill_start = (
+            exporter.earliest_day() if args.backfill and args.date is None else None
+        )
         for day in _days_to_archive(
             date=args.date,
             lookback_days=args.lookback_days,

--- a/clickhouse/backfill_operational_analytics.py
+++ b/clickhouse/backfill_operational_analytics.py
@@ -131,7 +131,7 @@ def iter_activity_events(
         generation = _parse(Generation, _body(row, FAMILIES["activity"]))
         if generation is None:
             continue
-        yield normalise_operational_event(
+        yield from normalise_operational_event(
             OperationalOutboxRow(
                 shard=0,
                 commit_ts=_created_at(generation.created_at),
@@ -157,7 +157,7 @@ def iter_synthetic_events(
         sample = _parse(SyntheticProbeSample, _body(row, FAMILIES["synthetic"]))
         if sample is None:
             continue
-        yield normalise_operational_event(
+        yield from normalise_operational_event(
             OperationalOutboxRow(
                 shard=0,
                 commit_ts=_created_at(sample.created_at),

--- a/clickhouse/build_public_snapshots.py
+++ b/clickhouse/build_public_snapshots.py
@@ -1,5 +1,9 @@
 """Precompute small public analytics payloads from bounded ClickHouse data."""
 
+# ruff: noqa: S608
+# Client rollup cutoffs are rendered only from typed UTC datetimes; every
+# table name and limit is a module constant.
+
 from __future__ import annotations
 
 import dataclasses
@@ -11,6 +15,7 @@ from typing import Any
 
 from trusted_router.apps import aggregate_apps
 from trusted_router.catalog import MODELS, endpoints_for_model
+from trusted_router.client_reliability import build_client_reliability
 from trusted_router.storage_models import (
     ProviderBenchmarkSample,
     SyntheticProbeSample,
@@ -24,6 +29,7 @@ PER_PROVIDER_LIMIT = 500
 STATUS_LIVE_SAMPLE_LIMIT = 500
 STATUS_HOUR_ROLLUP_LIMIT = 5_000
 VIDEO_SAMPLE_LIMIT = 5_000
+CLIENT_ROLLUP_LIMIT = 100_000
 
 
 def _query(
@@ -81,10 +87,11 @@ def _dataclass_rows(cls: type[Any], output: str) -> list[Any]:
 
 
 def _clickhouse_string_array(values: list[str]) -> str:
-    return "[" + ",".join(
-        "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
-        for value in values
-    ) + "]"
+    return (
+        "["
+        + ",".join("'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'" for value in values)
+        + "]"
+    )
 
 
 def _samples(password: str) -> list[ProviderBenchmarkSample]:
@@ -164,6 +171,53 @@ FORMAT JSONEachRow
     return samples, rollups
 
 
+def _client_reliability_rows(password: str, *, now: dt.datetime) -> list[dict[str, Any]]:
+    cutoff_48h = (now - dt.timedelta(hours=48)).strftime("%Y-%m-%d %H:%M:%S")
+    cutoff_7d = (now - dt.timedelta(days=7)).strftime("%Y-%m-%d %H:%M:%S")
+    cutoff_30d = (now - dt.timedelta(days=30)).strftime("%Y-%m-%d %H:%M:%S")
+    output = _query(
+        password,
+        f"""
+SELECT * EXCEPT computed_at
+FROM client_availability_rollups FINAL
+WHERE scope = 'fleet'
+  AND (
+    (period = '5m' AND period_start >= toDateTime('{cutoff_48h}', 'UTC'))
+    OR (period = 'hour' AND period_start >= toDateTime('{cutoff_7d}', 'UTC'))
+    OR (period = 'day' AND period_start >= toDateTime('{cutoff_30d}', 'UTC'))
+  )
+ORDER BY period_start DESC, period, id
+LIMIT {CLIENT_ROLLUP_LIMIT}
+FORMAT JSONEachRow
+""",
+    )
+    return [json.loads(line) for line in output.splitlines() if line.strip()]
+
+
+def _client_rows_by_window(
+    rows: list[dict[str, Any]],
+    *,
+    now: dt.datetime,
+) -> dict[str, list[dict[str, Any]]]:
+    def parsed(row: dict[str, Any]) -> dt.datetime:
+        value = dt.datetime.fromisoformat(
+            str(row["period_start"]).replace(" ", "T").replace("Z", "+00:00")
+        )
+        return value.replace(tzinfo=dt.UTC) if value.tzinfo is None else value.astimezone(dt.UTC)
+
+    definitions = {
+        "5m": ("5m", dt.timedelta(minutes=5)),
+        "1h": ("5m", dt.timedelta(hours=1)),
+        "24h": ("hour", dt.timedelta(hours=24)),
+        "7d": ("hour", dt.timedelta(days=7)),
+        "30d": ("day", dt.timedelta(days=30)),
+    }
+    return {
+        name: [row for row in rows if row.get("period") == period and parsed(row) >= now - lookback]
+        for name, (period, lookback) in definitions.items()
+    }
+
+
 def build_snapshots(
     samples: list[ProviderBenchmarkSample],
     *,
@@ -171,6 +225,7 @@ def build_snapshots(
     video_samples: list[ProviderBenchmarkSample] | None = None,
     status_samples: list[SyntheticProbeSample] | None = None,
     status_rollups: list[SyntheticRollup] | None = None,
+    client_reliability_rows: list[dict[str, Any]] | None = None,
 ) -> dict[str, dict[str, Any]]:
     leaderboard = aggregate_leaderboard(
         samples,
@@ -184,9 +239,7 @@ def build_snapshots(
             "generated_at": generated_at,
             "sample_window_count": len(samples),
             "sample_limit": SAMPLE_LIMIT,
-            "window_label": (
-                f"rolling benchmark set of up to {SAMPLE_LIMIT:,} samples"
-            ),
+            "window_label": (f"rolling benchmark set of up to {SAMPLE_LIMIT:,} samples"),
             "rank_minimums": {
                 "model_availability_samples": 10,
                 "provider_availability_samples": 30,
@@ -212,9 +265,7 @@ def build_snapshots(
             "generated_at": generated_at,
             "sample_window_count": len(video_rows),
             "sample_limit": VIDEO_SAMPLE_LIMIT,
-            "window_label": (
-                f"rolling video benchmark set of up to {VIDEO_SAMPLE_LIMIT:,} jobs"
-            ),
+            "window_label": (f"rolling video benchmark set of up to {VIDEO_SAMPLE_LIMIT:,} jobs"),
         }
     )
     status_inputs = {
@@ -222,11 +273,17 @@ def build_snapshots(
         "samples": [dataclasses.asdict(sample) for sample in status_samples or []],
         "rollups": [dataclasses.asdict(rollup) for rollup in status_rollups or []],
     }
+    snapshot_now = dt.datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+    client_reliability = build_client_reliability(
+        _client_rows_by_window(client_reliability_rows or [], now=snapshot_now),
+        snapshot_now,
+    )
     return {
         "leaderboard": leaderboard,
         "apps": apps,
         "video_leaderboard": video,
         "status_inputs": status_inputs,
+        "client_reliability": client_reliability,
     }
 
 
@@ -243,6 +300,7 @@ def main() -> int:
         video_samples=_video_samples(password),
         status_samples=status_samples,
         status_rollups=status_rollups,
+        client_reliability_rows=_client_reliability_rows(password, now=now),
     )
     rows = [
         {

--- a/clickhouse/build_public_snapshots.py
+++ b/clickhouse/build_public_snapshots.py
@@ -87,11 +87,10 @@ def _dataclass_rows(cls: type[Any], output: str) -> list[Any]:
 
 
 def _clickhouse_string_array(values: list[str]) -> str:
-    return (
-        "["
-        + ",".join("'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'" for value in values)
-        + "]"
-    )
+    return "[" + ",".join(
+        "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
+        for value in values
+    ) + "]"
 
 
 def _samples(password: str) -> list[ProviderBenchmarkSample]:
@@ -239,7 +238,9 @@ def build_snapshots(
             "generated_at": generated_at,
             "sample_window_count": len(samples),
             "sample_limit": SAMPLE_LIMIT,
-            "window_label": (f"rolling benchmark set of up to {SAMPLE_LIMIT:,} samples"),
+            "window_label": (
+                f"rolling benchmark set of up to {SAMPLE_LIMIT:,} samples"
+            ),
             "rank_minimums": {
                 "model_availability_samples": 10,
                 "provider_availability_samples": 30,
@@ -265,7 +266,9 @@ def build_snapshots(
             "generated_at": generated_at,
             "sample_window_count": len(video_rows),
             "sample_limit": VIDEO_SAMPLE_LIMIT,
-            "window_label": (f"rolling video benchmark set of up to {VIDEO_SAMPLE_LIMIT:,} jobs"),
+            "window_label": (
+                f"rolling video benchmark set of up to {VIDEO_SAMPLE_LIMIT:,} jobs"
+            ),
         }
     )
     status_inputs = {

--- a/clickhouse/ingest_operational_outbox.py
+++ b/clickhouse/ingest_operational_outbox.py
@@ -231,26 +231,6 @@ class CanonicalOperationalEvent:
     row: dict[str, Any]
 
 
-class CanonicalOperationalEvents(list[CanonicalOperationalEvent]):
-    """List result with a temporary 1:1 compatibility surface.
-
-    Historical backfill and parity readers consume only activity/synthetic
-    rows and still access ``event_kind``/``row`` directly. Keeping those
-    properties for singleton results lets this rollout change the normalizer
-    to the required 1:N shape without widening the tightly scoped node PR.
-    """
-
-    @property
-    def event_kind(self) -> str:
-        [event] = self
-        return event.event_kind
-
-    @property
-    def row(self) -> dict[str, Any]:
-        [event] = self
-        return event.row
-
-
 @dataclass(frozen=True)
 class DrainResult:
     fetched: int
@@ -648,14 +628,14 @@ def normalise_operational_event(
         raise ValueError(f"unsupported operational event kind: {row.event_kind}")
     missing = [column for column in required if column not in raw]
     if missing:
-        raise ValueError(f"{row.event_kind} payload missing required fields: {', '.join(missing)}")
+        raise ValueError(
+            f"{row.event_kind} payload missing required fields: {', '.join(missing)}"
+        )
     canonical = {
         column: raw.get(column, ACTIVITY_OPTIONAL_DEFAULTS.get(column)) for column in allowed
     }
     canonical["ingest_version"] = _utc(row.commit_ts).isoformat()
-    return CanonicalOperationalEvents(
-        [CanonicalOperationalEvent(event_kind=row.event_kind, row=canonical)]
-    )
+    return [CanonicalOperationalEvent(event_kind=row.event_kind, row=canonical)]
 
 
 def quarantine_event(

--- a/clickhouse/ingest_operational_outbox.py
+++ b/clickhouse/ingest_operational_outbox.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import hashlib
 import json
 import logging
 import math
@@ -50,7 +51,45 @@ ACTIVITY_COLUMNS = (
     "app_categories",
     "tags",
     "created_at",
+    "gateway_request_id",
+    "synthetic",
+    "client_source",
+    "client_sdk",
+    "client_sdk_version",
+    "client_lang",
+    "client_runtime",
+    "client_os",
+    "client_arch",
+    "client_timeout_ms",
+    "client_attempt",
+    "client_prev_outcome",
+    "client_prev_error_class",
+    "client_prev_host",
+    "client_prev_elapsed_ms",
+    "client_since_first_ms",
+    "client_stream",
+    "client_failover_used",
 )
+ACTIVITY_OPTIONAL_DEFAULTS: dict[str, Any] = {
+    "gateway_request_id": "",
+    "synthetic": 0,
+    "client_source": "none",
+    "client_sdk": "",
+    "client_sdk_version": "",
+    "client_lang": "",
+    "client_runtime": "",
+    "client_os": "",
+    "client_arch": "",
+    "client_timeout_ms": None,
+    "client_attempt": None,
+    "client_prev_outcome": "",
+    "client_prev_error_class": "",
+    "client_prev_host": "",
+    "client_prev_elapsed_ms": None,
+    "client_since_first_ms": None,
+    "client_stream": None,
+    "client_failover_used": None,
+}
 SYNTHETIC_COLUMNS = (
     "id",
     "probe_type",
@@ -81,9 +120,93 @@ SYNTHETIC_COLUMNS = (
     "created_at",
 )
 
+CLIENT_REQUEST_COLUMNS = (
+    "event_id",
+    "tenant_id",
+    "key_id",
+    "batch_id",
+    "instance_id",
+    "seq",
+    "received_at",
+    "created_at",
+    "clock_skew_ms",
+    "synthetic",
+    "sdk",
+    "sdk_version",
+    "lang",
+    "runtime",
+    "os",
+    "arch",
+    "plane",
+    "endpoint",
+    "method",
+    "streaming",
+    "provider_pinned",
+    "model",
+    "final_outcome",
+    "final_http_status",
+    "final_host",
+    "first_error_class",
+    "error_source",
+    "total_ms",
+    "ttft_ms",
+    "timeout_phase",
+    "configured_timeout_ms",
+    "attempt_count",
+    "failover_used",
+    "attempt_host",
+    "attempt_outcome",
+    "attempt_http_status",
+    "attempt_error_class",
+    "attempt_error_source",
+    "attempt_should_retry",
+    "attempt_retry_after_ms",
+    "attempt_elapsed_ms",
+    "attempt_ttfb_ms",
+    "attempt_request_id",
+    "attempt_moved",
+    "sample_rate",
+    "sample_reason",
+    "tr_fault",
+    "methodology_version",
+)
+CLIENT_COUNTER_COLUMNS = (
+    "event_id",
+    "tenant_id",
+    "key_id",
+    "instance_id",
+    "bucket_start",
+    "received_at",
+    "synthetic",
+    "sdk",
+    "sdk_version",
+    "level",
+    "endpoint",
+    "streaming",
+    "host",
+    "outcome",
+    "error_class",
+    "http_status_class",
+    "timeout_phase",
+    "timeout_floor_met",
+    "provider_pinned",
+    "requests",
+    "attempts",
+    "failover_used",
+    "first_attempt_success",
+    "total_ms_hist",
+    "first_event_ms_hist",
+    "tr_fault",
+    "methodology_version",
+)
+
 EVENT_TABLES = {
     "activity": "activity_generations",
     "synthetic": "synthetic_probe_samples",
+    "client_events": ("client_request_events", "client_minute_counters"),
+    "client_request": "client_request_events",
+    "client_counter": "client_minute_counters",
+    "quarantine": "operational_outbox_quarantine",
 }
 
 log = logging.getLogger("trusted_router.operational_analytics_ingest")
@@ -108,11 +231,32 @@ class CanonicalOperationalEvent:
     row: dict[str, Any]
 
 
+class CanonicalOperationalEvents(list[CanonicalOperationalEvent]):
+    """List result with a temporary 1:1 compatibility surface.
+
+    Historical backfill and parity readers consume only activity/synthetic
+    rows and still access ``event_kind``/``row`` directly. Keeping those
+    properties for singleton results lets this rollout change the normalizer
+    to the required 1:N shape without widening the tightly scoped node PR.
+    """
+
+    @property
+    def event_kind(self) -> str:
+        [event] = self
+        return event.event_kind
+
+    @property
+    def row(self) -> dict[str, Any]:
+        [event] = self
+        return event.row
+
+
 @dataclass(frozen=True)
 class DrainResult:
     fetched: int
     inserted: int
     rows_per_second: float
+    quarantined: int = 0
 
 
 class OutboxSource(Protocol):
@@ -264,6 +408,10 @@ class ClickHouseOperationalWriter:
             table = EVENT_TABLES.get(event_kind)
             if table is None:
                 raise ValueError(f"unsupported operational event kind: {event_kind}")
+            if not isinstance(table, str):
+                raise ValueError(
+                    f"operational event kind must be expanded before insert: {event_kind}"
+                )
             payload = "\n".join(
                 json.dumps(row, separators=(",", ":"), sort_keys=True) for row in rows
             ).encode("utf-8")
@@ -309,25 +457,225 @@ class ClickHouseOperationalWriter:
                 raise RuntimeError(f"ClickHouse {event_kind} insert failed: {detail}")
 
 
-def normalise_operational_event(row: OperationalOutboxRow) -> CanonicalOperationalEvent:
+def _event_id(tenant_id: str, batch_id: str, kind: str, index: int) -> str:
+    value = f"{tenant_id}:{batch_id}:{kind}:{index}"
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def _object(value: Any, *, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"client_events {field} is not a JSON object")
+    return value
+
+
+def _objects(value: Any, *, field: str) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        raise ValueError(f"client_events {field} is not a JSON array")
+    return [_object(item, field=f"{field}[{index}]") for index, item in enumerate(value)]
+
+
+def _required(payload: dict[str, Any], field: str) -> Any:
+    try:
+        return payload[field]
+    except KeyError:
+        raise ValueError(f"client_events payload missing required field: {field}") from None
+
+
+def _retry_value(value: Any) -> str:
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if value == "true" or value == "false":
+        return str(value)
+    return "absent"
+
+
+def expand_client_events_payload(
+    payload: dict[str, Any],
+    commit_ts: dt.datetime,
+) -> list[CanonicalOperationalEvent]:
+    """Expand one validated beacon POST into ClickHouse request/counter rows."""
+
+    if _required(payload, "schema_version") != 1:
+        raise ValueError("client_events schema_version must be 1")
+    tenant_id = str(_required(payload, "tenant_id"))
+    key_id = str(_required(payload, "key_id"))
+    batch_id = str(_required(payload, "batch_id"))
+    instance_id = str(_required(payload, "instance_id"))
+    received_at = _required(payload, "received_at")
+    clock_skew_ms = int(_required(payload, "clock_skew_ms"))
+    synthetic = int(bool(_required(payload, "synthetic")))
+    seq = int(_required(payload, "seq"))
+    sdk = _object(_required(payload, "sdk"), field="sdk")
+    sdk_name = str(_required(sdk, "name"))
+    sdk_version = str(_required(sdk, "version"))
+    ingest_version = _utc(commit_ts).isoformat()
+    common = {
+        "tenant_id": tenant_id,
+        "key_id": key_id,
+        "instance_id": instance_id,
+        "received_at": received_at,
+        "synthetic": synthetic,
+        "sdk": sdk_name,
+        "sdk_version": sdk_version,
+    }
+    result: list[CanonicalOperationalEvent] = []
+    for index, event in enumerate(_objects(_required(payload, "events"), field="events")):
+        attempts = _objects(_required(event, "attempts"), field=f"events[{index}].attempts")
+        if not attempts:
+            raise ValueError(f"client_events events[{index}].attempts is empty")
+        error_classes = [
+            "" if attempt.get("error_class") is None else str(attempt["error_class"])
+            for attempt in attempts
+        ]
+        error_sources = [
+            "" if attempt.get("error_source") is None else str(attempt["error_source"])
+            for attempt in attempts
+        ]
+        row = {
+            "event_id": _event_id(tenant_id, batch_id, "r", index),
+            **common,
+            "batch_id": batch_id,
+            "seq": seq,
+            "created_at": _required(event, "created_at"),
+            "clock_skew_ms": clock_skew_ms,
+            "lang": str(_required(sdk, "lang")),
+            "runtime": str(_required(sdk, "runtime")),
+            "os": str(_required(sdk, "os")),
+            "arch": str(_required(sdk, "arch")),
+            "plane": _required(event, "plane"),
+            "endpoint": _required(event, "endpoint"),
+            "method": _required(event, "method"),
+            "streaming": int(bool(_required(event, "streaming"))),
+            "provider_pinned": int(bool(_required(event, "provider_pinned"))),
+            "model": "" if event.get("model") is None else str(event["model"]),
+            "final_outcome": _required(event, "final_outcome"),
+            "final_http_status": int(event.get("final_http_status") or 0),
+            "final_host": str(_required(attempts[-1], "host")),
+            "first_error_class": next((value for value in error_classes if value), ""),
+            "error_source": next((value for value in error_sources if value), ""),
+            "total_ms": int(_required(event, "total_ms")),
+            "ttft_ms": event.get("ttft_ms"),
+            "timeout_phase": _required(event, "timeout_phase"),
+            "configured_timeout_ms": event.get("configured_timeout_ms"),
+            "attempt_count": len(attempts),
+            "failover_used": int(bool(_required(event, "failover_used"))),
+            "attempt_host": [str(_required(attempt, "host")) for attempt in attempts],
+            "attempt_outcome": [str(_required(attempt, "outcome")) for attempt in attempts],
+            "attempt_http_status": [int(attempt.get("http_status") or 0) for attempt in attempts],
+            "attempt_error_class": error_classes,
+            "attempt_error_source": error_sources,
+            "attempt_should_retry": [
+                _retry_value(attempt.get("should_retry")) for attempt in attempts
+            ],
+            "attempt_retry_after_ms": [
+                int(attempt.get("retry_after_ms") or 0) for attempt in attempts
+            ],
+            "attempt_elapsed_ms": [int(_required(attempt, "elapsed_ms")) for attempt in attempts],
+            "attempt_ttfb_ms": [int(attempt.get("ttfb_ms") or 0) for attempt in attempts],
+            "attempt_request_id": [
+                "" if attempt.get("request_id") is None else str(attempt["request_id"])
+                for attempt in attempts
+            ],
+            "attempt_moved": [int(bool(_required(attempt, "moved"))) for attempt in attempts],
+            "sample_rate": float(_required(event, "sample_rate")),
+            "sample_reason": _required(event, "sample_reason"),
+            "tr_fault": int(bool(_required(event, "tr_fault"))),
+            "methodology_version": int(_required(event, "methodology_version")),
+            "ingest_version": ingest_version,
+        }
+        result.append(CanonicalOperationalEvent(event_kind="client_request", row=row))
+    for index, counter in enumerate(_objects(_required(payload, "counters"), field="counters")):
+        row = {
+            "event_id": _event_id(tenant_id, batch_id, "c", index),
+            **common,
+            "bucket_start": _required(counter, "bucket_start"),
+            "level": _required(counter, "level"),
+            "endpoint": _required(counter, "endpoint"),
+            "streaming": int(bool(_required(counter, "streaming"))),
+            "host": _required(counter, "host"),
+            "outcome": _required(counter, "outcome"),
+            "error_class": ("" if counter.get("error_class") is None else counter["error_class"]),
+            "http_status_class": _required(counter, "http_status_class"),
+            "timeout_phase": _required(counter, "timeout_phase"),
+            "timeout_floor_met": int(bool(_required(counter, "timeout_floor_met"))),
+            "provider_pinned": int(bool(_required(counter, "provider_pinned"))),
+            "requests": int(_required(counter, "requests")),
+            "attempts": int(_required(counter, "attempts")),
+            "failover_used": int(_required(counter, "failover_used")),
+            "first_attempt_success": int(_required(counter, "first_attempt_success")),
+            "total_ms_hist": _object(
+                _required(counter, "total_ms_hist"),
+                field=f"counters[{index}].total_ms_hist",
+            ),
+            "first_event_ms_hist": _object(
+                _required(counter, "first_event_ms_hist"),
+                field=f"counters[{index}].first_event_ms_hist",
+            ),
+            "tr_fault": int(bool(_required(counter, "tr_fault"))),
+            "methodology_version": int(_required(counter, "methodology_version")),
+            "ingest_version": ingest_version,
+        }
+        result.append(CanonicalOperationalEvent(event_kind="client_counter", row=row))
+    if not result:
+        raise ValueError("client_events payload has no events or counters")
+    return result
+
+
+def normalise_operational_event(
+    row: OperationalOutboxRow,
+) -> list[CanonicalOperationalEvent]:
     raw = json.loads(row.payload)
     if not isinstance(raw, dict):
         raise ValueError("operational outbox payload is not a JSON object")
+    if row.event_kind == "client_events":
+        try:
+            return expand_client_events_payload(raw, row.commit_ts)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(str(exc)) from None
     allowed: tuple[str, ...]
+    required: tuple[str, ...]
     if row.event_kind == "activity":
         allowed = ACTIVITY_COLUMNS
+        required = tuple(
+            column for column in ACTIVITY_COLUMNS if column not in ACTIVITY_OPTIONAL_DEFAULTS
+        )
     elif row.event_kind == "synthetic":
         allowed = SYNTHETIC_COLUMNS
+        required = SYNTHETIC_COLUMNS
     else:
         raise ValueError(f"unsupported operational event kind: {row.event_kind}")
-    missing = [column for column in allowed if column not in raw]
+    missing = [column for column in required if column not in raw]
     if missing:
-        raise ValueError(
-            f"{row.event_kind} payload missing required fields: {', '.join(missing)}"
-        )
-    canonical = {column: raw[column] for column in allowed}
+        raise ValueError(f"{row.event_kind} payload missing required fields: {', '.join(missing)}")
+    canonical = {
+        column: raw.get(column, ACTIVITY_OPTIONAL_DEFAULTS.get(column)) for column in allowed
+    }
     canonical["ingest_version"] = _utc(row.commit_ts).isoformat()
-    return CanonicalOperationalEvent(event_kind=row.event_kind, row=canonical)
+    return CanonicalOperationalEvents(
+        [CanonicalOperationalEvent(event_kind=row.event_kind, row=canonical)]
+    )
+
+
+def quarantine_event(
+    row: OperationalOutboxRow,
+    exc: ValueError,
+    *,
+    now: dt.datetime | None = None,
+) -> CanonicalOperationalEvent:
+    return CanonicalOperationalEvent(
+        event_kind="quarantine",
+        row={
+            "shard": row.shard,
+            "commit_ts": _utc(row.commit_ts).isoformat(),
+            "event_kind": row.event_kind,
+            "event_id": row.event_id,
+            "payload": row.payload,
+            "reason": str(exc)[:500],
+            "quarantined_at": _utc(now or dt.datetime.now(dt.UTC)).isoformat(),
+        },
+    )
 
 
 def drain_once(
@@ -339,15 +687,23 @@ def drain_once(
     rows = source.fetch(limit=batch_size)
     if not rows:
         return DrainResult(fetched=0, inserted=0, rows_per_second=0.0)
-    events = [normalise_operational_event(row) for row in rows]
+    events: list[CanonicalOperationalEvent] = []
+    quarantined = 0
+    for row in rows:
+        try:
+            events.extend(normalise_operational_event(row))
+        except ValueError as exc:
+            events.append(quarantine_event(row, exc))
+            quarantined += 1
     started = time.monotonic()
     writer.insert(events)
     source.delete(rows)
     elapsed = max(time.monotonic() - started, 0.000_001)
     return DrainResult(
         fetched=len(rows),
-        inserted=len(events),
+        inserted=len(events) - quarantined,
         rows_per_second=len(events) / elapsed,
+        quarantined=quarantined,
     )
 
 
@@ -391,10 +747,11 @@ def main() -> int:
         result = drain_once(source, writer, batch_size=max(1, args.batch_size))
         log.info(
             "operational_analytics_outbox.metrics rows=%d rows_per_second=%.3f "
-            "drain_lag_seconds=%.3f",
+            "drain_lag_seconds=%.3f quarantined=%d",
             result.inserted,
             result.rows_per_second,
             _lag_seconds(source.oldest_commit_ts()),
+            result.quarantined,
         )
         if args.once:
             return 0

--- a/clickhouse/ingest_operational_outbox_postgres.py
+++ b/clickhouse/ingest_operational_outbox_postgres.py
@@ -581,7 +581,9 @@ def clickhouse_targets_from_env(
             database=database,
         )
     ]
-    is_local = (lambda host: host in local_hosts) if local_hosts is not None else _is_own_address
+    is_local = (
+        (lambda host: host in local_hosts) if local_hosts is not None else _is_own_address
+    )
     _refuse_orphaned_replica_settings(env)
     for suffix in REPLICA_ENV_SUFFIXES:
         prefix = f"{CLICKHOUSE_ENV_PREFIX}_{suffix}"

--- a/clickhouse/ingest_operational_outbox_postgres.py
+++ b/clickhouse/ingest_operational_outbox_postgres.py
@@ -149,12 +149,12 @@ than one whose edges are known:
   and nothing notices, because the drain has forgotten the rows and the two
   nodes are never compared to each other.  The fan-out makes *total* loss much
   less likely; it does not make a single node's just-acked writes durable.
-* **Two of the four tables.**  This drain writes ``activity_generations`` and
-  ``synthetic_probe_samples`` (``EVENT_TABLES``).  The single-node DDL also
-  creates ``synthetic_status_rollups`` and ``public_analytics_snapshots``, which
-  nothing on this cloud writes today — they are produced by GCP timers — so both
-  nodes hold them empty.  If such a job is ever pointed at Paris, its output is
-  NOT replicated by this drain and the second copy is not complete until it is.
+* **Only ingested tables.**  This drain writes ``activity_generations``,
+  ``synthetic_probe_samples``, both raw client telemetry tables, and quarantine
+  rows (``EVENT_TABLES``). It does not write synthetic/client rollups or public
+  snapshots. Nothing on this cloud produces those today — they are GCP timers —
+  so both nodes hold them empty. If such a job is ever pointed at Paris, its
+  output is NOT replicated by this drain and the second copy is not complete.
 * **The alarm needs this process alive.**  ``backlog_alarm`` is emitted from the
   sweep loop, so it says nothing while the drain is not running.  A
   configuration error therefore exits with ``CONFIG_EXIT_CODE``, which the unit
@@ -180,6 +180,7 @@ from clickhouse.ingest_operational_outbox import (
     _lag_seconds,
     _utc,
     normalise_operational_event,
+    quarantine_event,
 )
 from trusted_router.postgres_dsn import (
     aws_dsql_connection_details,
@@ -580,9 +581,7 @@ def clickhouse_targets_from_env(
             database=database,
         )
     ]
-    is_local = (
-        (lambda host: host in local_hosts) if local_hosts is not None else _is_own_address
-    )
+    is_local = (lambda host: host in local_hosts) if local_hosts is not None else _is_own_address
     _refuse_orphaned_replica_settings(env)
     for suffix in REPLICA_ENV_SUFFIXES:
         prefix = f"{CLICKHOUSE_ENV_PREFIX}_{suffix}"
@@ -635,6 +634,7 @@ class ShardDrainResult:
     fetched: int
     inserted: int
     deleted: int
+    quarantined: int = 0
 
 
 @dataclass(frozen=True)
@@ -655,6 +655,7 @@ class SweepResult:
     rows_per_second: float
     failed_shards: int = 0
     degraded_targets: tuple[str, ...] = ()
+    quarantined: int = 0
 
 
 def _is_retryable(exc: BaseException) -> bool:
@@ -911,7 +912,14 @@ def drain_shard_once(
     exhausted = len(rows) < batch_size
     last_key = (rows[-1].event_kind, rows[-1].event_id)
     try:
-        events = [normalise_operational_event(row) for row in rows]
+        events: list[Any] = []
+        quarantined = 0
+        for row in rows:
+            try:
+                events.extend(normalise_operational_event(row))
+            except ValueError as exc:
+                events.append(quarantine_event(row, exc))
+                quarantined += 1
         writer.insert(events)
     except BaseException:
         if cursors is not None:
@@ -926,8 +934,9 @@ def drain_shard_once(
     return ShardDrainResult(
         shard=shard,
         fetched=len(rows),
-        inserted=len(events),
+        inserted=len(events) - quarantined,
         deleted=int(deleted or 0),
+        quarantined=quarantined,
     )
 
 
@@ -951,6 +960,7 @@ def drain_once(
     """
     fetched = 0
     inserted = 0
+    quarantined = 0
     failed_shards = 0
     degraded: dict[str, None] = {}
     # Lets a fan-out stop re-dialling a target that has already failed several
@@ -982,6 +992,7 @@ def drain_once(
             continue
         fetched += result.fetched
         inserted += result.inserted
+        quarantined += result.quarantined
     elapsed = max(time.monotonic() - started, 0.000_001)
     return SweepResult(
         fetched=fetched,
@@ -989,6 +1000,7 @@ def drain_once(
         rows_per_second=inserted / elapsed,
         failed_shards=failed_shards,
         degraded_targets=tuple(degraded),
+        quarantined=quarantined,
     )
 
 
@@ -1087,13 +1099,14 @@ def main() -> int:
         log.info(
             "operational_analytics_outbox.metrics backend=postgres rows=%d "
             "rows_per_second=%.3f drain_lag_seconds=%.3f failed_shards=%d "
-            "copies=%d degraded_targets=%s",
+            "copies=%d degraded_targets=%s quarantined=%d",
             result.inserted,
             result.rows_per_second,
             lag_seconds,
             result.failed_shards,
             len(targets),
             ",".join(degraded) or "-",
+            result.quarantined,
         )
         # The bound on outbox growth is this line plus an operator. There is no
         # automatic one: the only automatic bounds available are "delete rows a

--- a/clickhouse/rollup_client_events.py
+++ b/clickhouse/rollup_client_events.py
@@ -1,0 +1,521 @@
+"""Recompute client-observed availability rollups from exact minute counters."""
+
+# ruff: noqa: S608
+# Every SQL timestamp is rendered from a typed datetime and table names are
+# module constants, so no request-controlled fragment reaches these queries.
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import logging
+import os
+import subprocess
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from trusted_router.client_reliability import (
+    METHODOLOGY_VERSION,
+    classify_tr_fault,
+    is_excluded,
+)
+
+COUNTER_TABLE = "client_minute_counters"
+ACTIVITY_TABLE = "activity_generations"
+ROLLUP_TABLE = "client_availability_rollups"
+
+log = logging.getLogger("trusted_router.client_reliability_rollup")
+
+
+class ClickHouseExecutor:
+    def __init__(self, *, password: str, database: str = "tr") -> None:
+        self._password = password
+        self._database = database
+
+    def query(self, sql: str, *, input_bytes: bytes | None = None) -> bytes:
+        result = subprocess.run(  # noqa: S603 - fixed executable and argv.
+            [
+                "/usr/bin/clickhouse-client",
+                "--user",
+                "tr",
+                "--password",
+                self._password,
+                "--database",
+                self._database,
+                "--query",
+                sql,
+            ],
+            input=input_bytes,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(result.stderr.decode(errors="replace")[:1000])
+        return result.stdout
+
+
+def _utc(value: dt.datetime) -> dt.datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=dt.UTC)
+    return value.astimezone(dt.UTC)
+
+
+def _ch_time(value: dt.datetime) -> str:
+    return _utc(value).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _parse_time(value: Any) -> dt.datetime:
+    parsed = dt.datetime.fromisoformat(str(value).replace(" ", "T").replace("Z", "+00:00"))
+    return _utc(parsed)
+
+
+def _floor(value: dt.datetime, period: str) -> dt.datetime:
+    value = _utc(value).replace(second=0, microsecond=0)
+    if period == "5m":
+        return value.replace(minute=value.minute - value.minute % 5)
+    if period == "hour":
+        return value.replace(minute=0)
+    if period == "day":
+        return value.replace(hour=0, minute=0)
+    raise ValueError(f"unsupported client rollup period: {period}")
+
+
+def _period_delta(period: str) -> dt.timedelta:
+    if period == "5m":
+        return dt.timedelta(minutes=5)
+    if period == "hour":
+        return dt.timedelta(hours=1)
+    if period == "day":
+        return dt.timedelta(days=1)
+    raise ValueError(f"unsupported client rollup period: {period}")
+
+
+def client_rollup_id(
+    *,
+    period: str,
+    period_start: dt.datetime,
+    scope: str,
+    tenant_id: str,
+    host: str,
+    endpoint: str,
+    sdk: str,
+) -> str:
+    key = (
+        period,
+        _utc(period_start).isoformat(),
+        scope,
+        tenant_id,
+        host,
+        endpoint,
+        sdk,
+    )
+    return hashlib.blake2b("\x1f".join(key).encode(), digest_size=16).hexdigest()
+
+
+def cap_tenant_requests(
+    requests_by_tenant: Mapping[str, int],
+) -> tuple[dict[str, int], int]:
+    """Cap each tenant at 25% of the uncapped fleet request count."""
+
+    normalized = {tenant: max(0, int(count)) for tenant, count in requests_by_tenant.items()}
+    total = sum(normalized.values())
+    if not total:
+        return normalized, 0
+    limit = max(1, total // 4)
+    allowed = {tenant: min(count, limit) for tenant, count in normalized.items()}
+    return allowed, total - sum(allowed.values())
+
+
+def _new_accumulator() -> dict[str, Any]:
+    return {
+        "requests": 0,
+        "successes": 0,
+        "tr_fault_failures": 0,
+        "excluded_failures": 0,
+        "aborted": 0,
+        "attempts": 0,
+        "attempt_tr_fault": 0,
+        "failover_used": 0,
+        "first_attempt_success": 0,
+        "total_ms_hist": {},
+        "first_event_ms_hist": {},
+    }
+
+
+def _merge_histogram(target: dict[str, int], source: Any) -> None:
+    if not isinstance(source, Mapping):
+        return
+    for bucket, count in source.items():
+        target[str(bucket)] = target.get(str(bucket), 0) + int(count)
+
+
+def _classification_args(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "level": str(row.get("level") or "request"),
+        "outcome": str(row.get("outcome") or ""),
+        "error_class": str(row.get("error_class") or "") or None,
+        "error_source": str(row.get("error_source") or "") or None,
+        "http_status_class_or_status": row.get("http_status_class"),
+        "host": str(row.get("host") or ""),
+        "provider_pinned": bool(row.get("provider_pinned")),
+        "timeout_phase": str(row.get("timeout_phase") or "none"),
+        "timeout_floor_met": bool(row.get("timeout_floor_met")),
+    }
+
+
+def _is_tr_fault(row: Mapping[str, Any]) -> bool:
+    if "tr_fault" in row:
+        return bool(row.get("tr_fault"))
+    return classify_tr_fault(**_classification_args(row))
+
+
+def _facets(row: Mapping[str, Any]) -> tuple[tuple[str, str, str], ...]:
+    values = [
+        ("", "", ""),
+        (str(row.get("host") or ""), "", ""),
+        ("", str(row.get("endpoint") or ""), ""),
+        ("", "", str(row.get("sdk") or "")),
+    ]
+    return tuple(dict.fromkeys(value for value in values if any(value) or value == values[0]))
+
+
+def _apply_counter(target: dict[str, Any], row: Mapping[str, Any]) -> None:
+    count = int(row.get("requests") or 0)
+    outcome = str(row.get("outcome") or "")
+    if row.get("level") == "request":
+        target["requests"] += count
+        if outcome == "ok":
+            target["successes"] += count
+        elif _is_tr_fault(row):
+            target["tr_fault_failures"] += count
+        else:
+            # Calling the pure exclusion policy here keeps the disclosed
+            # denominator policy centralized. A future non-fault category is
+            # conservatively disclosed as excluded too.
+            is_excluded(**_classification_args(row))
+            target["excluded_failures"] += count
+        if outcome == "aborted":
+            target["aborted"] += count
+        target["first_attempt_success"] += int(row.get("first_attempt_success") or 0)
+        _merge_histogram(target["total_ms_hist"], row.get("total_ms_hist"))
+        _merge_histogram(target["first_event_ms_hist"], row.get("first_event_ms_hist"))
+    elif row.get("level") == "attempt":
+        attempts = int(row.get("attempts") or 0)
+        target["attempts"] += attempts
+        if _is_tr_fault(row):
+            target["attempt_tr_fault"] += attempts
+        target["failover_used"] += int(row.get("failover_used") or 0)
+
+
+def _tenant_accumulators(
+    rows: Iterable[Mapping[str, Any]],
+) -> dict[str, dict[tuple[str, str, str], dict[str, Any]]]:
+    grouped: dict[str, dict[tuple[str, str, str], dict[str, Any]]] = {}
+    for row in rows:
+        tenant_id = str(row.get("tenant_id") or "")
+        tenant = grouped.setdefault(tenant_id, {})
+        for facet in _facets(row):
+            target = tenant.setdefault(facet, _new_accumulator())
+            _apply_counter(target, row)
+    return grouped
+
+
+def _scaled(value: int, allowed: int, requests: int) -> int:
+    return value if requests <= 0 else value * allowed // requests
+
+
+def _scaled_accumulator(
+    source: Mapping[str, Any],
+    *,
+    allowed: int,
+    requests: int,
+) -> dict[str, Any]:
+    result = _new_accumulator()
+    for field in (
+        "requests",
+        "successes",
+        "tr_fault_failures",
+        "excluded_failures",
+        "aborted",
+        "attempts",
+        "attempt_tr_fault",
+        "failover_used",
+        "first_attempt_success",
+    ):
+        result[field] = _scaled(int(source.get(field) or 0), allowed, requests)
+    for field in ("total_ms_hist", "first_event_ms_hist"):
+        histogram = source.get(field) or {}
+        if isinstance(histogram, Mapping):
+            result[field] = {
+                str(bucket): _scaled(int(count), allowed, requests)
+                for bucket, count in histogram.items()
+            }
+    return result
+
+
+def _merge_accumulator(target: dict[str, Any], source: Mapping[str, Any]) -> None:
+    for field in (
+        "requests",
+        "successes",
+        "tr_fault_failures",
+        "excluded_failures",
+        "aborted",
+        "attempts",
+        "attempt_tr_fault",
+        "failover_used",
+        "first_attempt_success",
+    ):
+        target[field] += int(source.get(field) or 0)
+    for field in ("total_ms_hist", "first_event_ms_hist"):
+        _merge_histogram(target[field], source.get(field))
+
+
+def _coverage_by_tenant(rows: Iterable[Mapping[str, Any]]) -> dict[str, int]:
+    result: dict[str, int] = {}
+    for row in rows:
+        if bool(row.get("synthetic")):
+            continue
+        tenant = str(row.get("tenant_id") or "")
+        result[tenant] = result.get(tenant, 0) + int(row.get("requests") or 0)
+    return result
+
+
+def _render_rollup(
+    accumulator: Mapping[str, Any],
+    *,
+    period: str,
+    period_start: dt.datetime,
+    scope: str,
+    tenant_id: str,
+    facet: tuple[str, str, str],
+    distinct_tenants: int,
+    capped_requests: int,
+    coverage_requests: int,
+    computed_at: dt.datetime,
+) -> dict[str, Any]:
+    host, endpoint, sdk = facet
+    return {
+        "id": client_rollup_id(
+            period=period,
+            period_start=period_start,
+            scope=scope,
+            tenant_id=tenant_id,
+            host=host,
+            endpoint=endpoint,
+            sdk=sdk,
+        ),
+        "period": period,
+        "period_start": _utc(period_start).isoformat(),
+        "scope": scope,
+        "tenant_id": tenant_id,
+        "host": host,
+        "endpoint": endpoint,
+        "sdk": sdk,
+        **accumulator,
+        "distinct_tenants": distinct_tenants,
+        "capped_requests": capped_requests,
+        "coverage_requests": coverage_requests,
+        "methodology_version": METHODOLOGY_VERSION,
+        "computed_at": _utc(computed_at).isoformat(),
+    }
+
+
+def aggregate_client_rollups(
+    counter_rows: Iterable[Mapping[str, Any]],
+    coverage_rows: Iterable[Mapping[str, Any]],
+    *,
+    period: str,
+    period_start: dt.datetime,
+    computed_at: dt.datetime,
+) -> list[dict[str, Any]]:
+    """Aggregate one period for tenant and capped, non-synthetic fleet scopes."""
+
+    period_start = _floor(period_start, period)
+    period_end = period_start + _period_delta(period)
+    counters = [
+        row for row in counter_rows if period_start <= _parse_time(row["bucket_start"]) < period_end
+    ]
+    coverage = [
+        row
+        for row in coverage_rows
+        if period_start <= _parse_time(row["bucket_start"]) < period_end
+    ]
+    tenant_groups = _tenant_accumulators(counters)
+    coverage_tenants = _coverage_by_tenant(coverage)
+    result: list[dict[str, Any]] = []
+    for tenant_id, facets in tenant_groups.items():
+        for facet, accumulator in facets.items():
+            result.append(
+                _render_rollup(
+                    accumulator,
+                    period=period,
+                    period_start=period_start,
+                    scope="tenant",
+                    tenant_id=tenant_id,
+                    facet=facet,
+                    distinct_tenants=1,
+                    capped_requests=0,
+                    coverage_requests=coverage_tenants.get(tenant_id, 0),
+                    computed_at=computed_at,
+                )
+            )
+
+    fleet_groups = _tenant_accumulators(row for row in counters if not bool(row.get("synthetic")))
+    requests_by_tenant = {
+        tenant: int(facets.get(("", "", ""), {}).get("requests") or 0)
+        for tenant, facets in fleet_groups.items()
+    }
+    allowed, total_capped = cap_tenant_requests(requests_by_tenant)
+    fleet_facets = {facet for facets in fleet_groups.values() for facet in facets}
+    for facet in sorted(fleet_facets):
+        accumulator = _new_accumulator()
+        contributors = 0
+        facet_capped = 0
+        for tenant, facets in fleet_groups.items():
+            source = facets.get(facet)
+            if source is None:
+                continue
+            requests = requests_by_tenant[tenant]
+            tenant_allowed = allowed[tenant]
+            scaled = _scaled_accumulator(
+                source,
+                allowed=tenant_allowed,
+                requests=requests,
+            )
+            _merge_accumulator(accumulator, scaled)
+            if int(source.get("requests") or 0):
+                contributors += 1
+            facet_capped += max(0, int(source.get("requests") or 0) - int(scaled["requests"]))
+        result.append(
+            _render_rollup(
+                accumulator,
+                period=period,
+                period_start=period_start,
+                scope="fleet",
+                tenant_id="",
+                facet=facet,
+                distinct_tenants=contributors,
+                capped_requests=(total_capped if facet == ("", "", "") else facet_capped),
+                coverage_requests=sum(coverage_tenants.values()),
+                computed_at=computed_at,
+            )
+        )
+    return result
+
+
+def fetch_inputs(
+    executor: ClickHouseExecutor,
+    *,
+    start: dt.datetime,
+    end: dt.datetime,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    counters = executor.query(
+        f"SELECT * EXCEPT ingest_version FROM {COUNTER_TABLE} FINAL "
+        f"WHERE bucket_start >= toDateTime('{_ch_time(start)}', 'UTC') "
+        f"AND bucket_start < toDateTime('{_ch_time(end)}', 'UTC') "
+        "AND received_at <= toDateTime64(bucket_start, 3, 'UTC') + INTERVAL 6 HOUR "
+        "ORDER BY bucket_start, event_id FORMAT JSONEachRow"
+    )
+    coverage = executor.query(
+        "SELECT toStartOfMinute(created_at) AS bucket_start, tenant_id, "
+        "synthetic, count() AS requests "
+        f"FROM {ACTIVITY_TABLE} FINAL "
+        f"WHERE created_at >= toDateTime64('{_ch_time(start)}', 3, 'UTC') "
+        f"AND created_at < toDateTime64('{_ch_time(end)}', 3, 'UTC') "
+        "GROUP BY bucket_start, tenant_id, synthetic "
+        "ORDER BY bucket_start, tenant_id FORMAT JSONEachRow"
+    )
+    return (
+        [json.loads(line) for line in counters.decode().splitlines() if line.strip()],
+        [json.loads(line) for line in coverage.decode().splitlines() if line.strip()],
+    )
+
+
+def _starts(now: dt.datetime, *, period: str, lookback: dt.timedelta) -> list[dt.datetime]:
+    end = _floor(now, period)
+    current = _floor(now - lookback, period)
+    result: list[dt.datetime] = []
+    while current <= end:
+        result.append(current)
+        current += _period_delta(period)
+    return result
+
+
+def recompute(
+    executor: ClickHouseExecutor,
+    *,
+    now: dt.datetime,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    now = _utc(now)
+    start = _floor(now - dt.timedelta(days=3), "day")
+    counters, coverage = fetch_inputs(executor, start=start, end=now)
+    computed_at = dt.datetime.now(dt.UTC)
+    rollups: list[dict[str, Any]] = []
+    for period, lookback in (
+        ("5m", dt.timedelta(hours=3)),
+        ("hour", dt.timedelta(hours=3)),
+        ("day", dt.timedelta(days=3)),
+    ):
+        for period_start in _starts(now, period=period, lookback=lookback):
+            rollups.extend(
+                aggregate_client_rollups(
+                    counters,
+                    coverage,
+                    period=period,
+                    period_start=period_start,
+                    computed_at=computed_at,
+                )
+            )
+    if rollups and not dry_run:
+        payload = b"\n".join(
+            json.dumps(row, separators=(",", ":"), sort_keys=True).encode() for row in rollups
+        )
+        executor.query(
+            f"INSERT INTO {ROLLUP_TABLE} FORMAT JSONEachRow",
+            input_bytes=payload,
+        )
+    return {
+        "counter_rows": len(counters),
+        "coverage_rows": len(coverage),
+        "rollups": len(rollups),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--at", help="UTC ISO timestamp; defaults to now")
+    parser.add_argument("--once", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    password = os.environ.get("CH_PASSWORD", "")
+    if not password:
+        raise SystemExit("CH_PASSWORD is required")
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    now = (
+        dt.datetime.fromisoformat(args.at.replace("Z", "+00:00"))
+        if args.at
+        else dt.datetime.now(dt.UTC)
+    )
+    result = recompute(
+        ClickHouseExecutor(password=password),
+        now=now,
+        dry_run=args.dry_run,
+    )
+    log.info(
+        "client_reliability_rollup.metrics counter_rows=%d coverage_rows=%d rollups=%d dry_run=%d",
+        result["counter_rows"],
+        result["coverage_rows"],
+        result["rollups"],
+        int(args.dry_run),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/clickhouse/rollup_client_events.py
+++ b/clickhouse/rollup_client_events.py
@@ -16,11 +16,7 @@ import subprocess
 from collections.abc import Iterable, Mapping
 from typing import Any
 
-from trusted_router.client_reliability import (
-    METHODOLOGY_VERSION,
-    classify_tr_fault,
-    is_excluded,
-)
+from trusted_router.client_reliability import METHODOLOGY_VERSION, classify_tr_fault
 
 COUNTER_TABLE = "client_minute_counters"
 ACTIVITY_TABLE = "activity_generations"
@@ -191,10 +187,9 @@ def _apply_counter(target: dict[str, Any], row: Mapping[str, Any]) -> None:
         elif _is_tr_fault(row):
             target["tr_fault_failures"] += count
         else:
-            # Calling the pure exclusion policy here keeps the disclosed
-            # denominator policy centralized. A future non-fault category is
-            # conservatively disclosed as excluded too.
-            is_excluded(**_classification_args(row))
+            # Methodology v1 partitions every non-ok request into tr_fault or
+            # a disclosed exclusion (unknown counts against us), so whatever is
+            # not our fault is, by construction, excluded from the denominator.
             target["excluded_failures"] += count
         if outcome == "aborted":
             target["aborted"] += count
@@ -433,6 +428,18 @@ def fetch_inputs(
     )
 
 
+def _group_by_period(
+    rows: Iterable[Mapping[str, Any]],
+    period: str,
+) -> dict[dt.datetime, list[Mapping[str, Any]]]:
+    """Bucket rows by the period they fall in, parsing each timestamp once."""
+
+    grouped: dict[dt.datetime, list[Mapping[str, Any]]] = {}
+    for row in rows:
+        grouped.setdefault(_floor(_parse_time(row["bucket_start"]), period), []).append(row)
+    return grouped
+
+
 def _starts(now: dt.datetime, *, period: str, lookback: dt.timedelta) -> list[dt.datetime]:
     end = _floor(now, period)
     current = _floor(now - lookback, period)
@@ -454,16 +461,21 @@ def recompute(
     counters, coverage = fetch_inputs(executor, start=start, end=now)
     computed_at = dt.datetime.now(dt.UTC)
     rollups: list[dict[str, Any]] = []
+    # The lookback matches the 6 h late-arrival cap in fetch_inputs: a batch
+    # that drains hours late (a control-plane outage, SDK backoff) lands in
+    # the right minute AND is still folded into that minute's rollup.
     for period, lookback in (
-        ("5m", dt.timedelta(hours=3)),
-        ("hour", dt.timedelta(hours=3)),
+        ("5m", dt.timedelta(hours=6)),
+        ("hour", dt.timedelta(hours=6)),
         ("day", dt.timedelta(days=3)),
     ):
+        counters_by_start = _group_by_period(counters, period)
+        coverage_by_start = _group_by_period(coverage, period)
         for period_start in _starts(now, period=period, lookback=lookback):
             rollups.extend(
                 aggregate_client_rollups(
-                    counters,
-                    coverage,
+                    counters_by_start.get(period_start, ()),
+                    coverage_by_start.get(period_start, ()),
                     period=period,
                     period_start=period_start,
                     computed_at=computed_at,

--- a/clickhouse/tr-clickhouse-client-rollup.service
+++ b/clickhouse/tr-clickhouse-client-rollup.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=TrustedRouter client reliability ClickHouse rollup rebuild
+After=network-online.target clickhouse-server.service
+
+[Service]
+Type=oneshot
+User=tr-clickhouse-ingest
+Group=tr-clickhouse-ingest
+WorkingDirectory=/opt/tr-clickhouse
+Environment=PYTHONPATH=/opt/tr-clickhouse/src
+EnvironmentFile=/etc/tr-clickhouse-ingest.env
+ExecStart=/opt/tr-clickhouse/venv/bin/python -m clickhouse.rollup_client_events --once
+TimeoutStartSec=5m
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict

--- a/clickhouse/tr-clickhouse-client-rollup.timer
+++ b/clickhouse/tr-clickhouse-client-rollup.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Rebuild TrustedRouter client reliability ClickHouse rollups
+
+[Timer]
+OnBootSec=3m
+OnUnitActiveSec=5m
+RandomizedDelaySec=20s
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/clickhouse/verify_archive_restore.py
+++ b/clickhouse/verify_archive_restore.py
@@ -14,7 +14,7 @@ import json
 import logging
 import os
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -70,16 +70,24 @@ class RestoreResult:
     revision: str
 
 
-def verify_parquet_part(path: Path, *, dataset: str) -> ExportedPart:
+def verify_parquet_part(
+    path: Path,
+    *,
+    dataset: str,
+    columns: Sequence[str] | None = None,
+) -> ExportedPart:
     try:
         spec = DATASETS[dataset]
     except KeyError:
         raise ValueError(f"unsupported archive dataset: {dataset}") from None
+    # A revision exported before a column was added must be fingerprinted
+    # over the columns it was exported with (recorded in its manifest), or
+    # the recomputation reads columns the Parquet file does not have.
     query = _fingerprint_query(
         f"file({_sql_string(str(path))}, Parquet)",
         where=None,
         final=False,
-        columns=spec.columns,
+        columns=tuple(columns) if columns else spec.columns,
         time_column=spec.time_column,
     )
     fingerprint = _parse_fingerprint(_run_clickhouse_local(query))
@@ -123,6 +131,14 @@ def verify_archived_day(
     if not isinstance(parts_value, list):
         raise RuntimeError("archive manifest parts must be a list")
 
+    manifest_columns = manifest.get("columns")
+    if manifest_columns is not None and not (
+        isinstance(manifest_columns, list)
+        and manifest_columns
+        and all(isinstance(column, str) for column in manifest_columns)
+    ):
+        raise RuntimeError("archive manifest columns must be a non-empty list of names")
+
     verified: list[ExportedPart] = []
     with tempfile.TemporaryDirectory(prefix=f"tr-restore-{dataset}-") as temporary:
         for index, raw_part in enumerate(parts_value):
@@ -135,9 +151,14 @@ def verify_archived_day(
             store.download_file(key, path)
             if _sha256(path) != str(raw_part.get("sha256") or ""):
                 raise RuntimeError(f"archive SHA-256 mismatch: {key}")
-            part = (verifier or (lambda value: verify_parquet_part(value, dataset=dataset)))(
-                path
-            )
+            part = (
+                verifier
+                or (
+                    lambda value: verify_parquet_part(
+                        value, dataset=dataset, columns=manifest_columns
+                    )
+                )
+            )(path)
             expected = (
                 int(raw_part.get("rows", -1)),
                 int(raw_part.get("hash_sum", -1)),

--- a/clickhouse/verify_operational_parity.py
+++ b/clickhouse/verify_operational_parity.py
@@ -154,7 +154,7 @@ def _source_rows(
             generation = _parse(Generation, raw)
             if generation is None:
                 continue
-            event = normalise_operational_event(
+            [event] = normalise_operational_event(
                 OperationalOutboxRow(
                     shard=0,
                     commit_ts=dt.datetime.now(dt.UTC),

--- a/docs/client-telemetry.md
+++ b/docs/client-telemetry.md
@@ -1,0 +1,315 @@
+# Client-observed reliability telemetry — the cross-repo contract
+
+**Status:** contract v1 (2026-08-17). Implemented in this order: enclave request ids → control-plane settle
+context → this repo's ClickHouse tables/ingester → enclave header channel → beacon ingest → Python SDK →
+surfaces. Other SDKs implement from THIS document; each SDK PR states the contract version it implements.
+The executable source of the enums is `src/trusted_router/client_context.py` (header/settle vocabulary) and
+`src/trusted_router/client_events_schema.py` (beacon schema). If this document and those modules disagree,
+the modules win and this document has a bug — fix the document.
+
+## 1. Why this exists
+
+Every reliability number TrustedRouter publishes is measured from the inside: synthetic probes and the
+enclave's own `elapsed_seconds` / `first_token_seconds`. A request that dies in DNS, TLS, or a connect
+timeout — or a stream that stalls after the enclave already settled — leaves **no record anywhere**: settle
+exists only on success, refund only for failures the enclave *saw*. Those invisible failures are what a
+customer means by "you were down". This contract lets clients report what they observed, so we can
+(a) verify our uptime claims from the customer's side and (b) improve.
+
+Prior art, checked from installed source: OpenAI and Anthropic SDKs send client telemetry **only as
+request headers** on the call the user already made (`X-Stainless-Lang/-Package-Version/-OS/-Arch/-Runtime`,
+per-request `x-stainless-retry-count`, timeouts; Anthropic also a closed `x-stainless-helper` vocabulary).
+No phone-home, no OTel, no client-side TTFT. Both read a request id off every response (`x-request-id`
+for OpenAI, `request-id` for Anthropic). Our design keeps that header channel (and captures the vendor
+headers our enclave was discarding) and adds a beacon channel, because a header can never describe a
+request that never arrived.
+
+## 2. Principles (non-negotiable)
+
+1. **Content-free by construction.** Every string on the wire is a closed enum or an anchored regex with a
+   hard length. `extra="forbid"` at every level. There is **no free-text field** anywhere in the beacon.
+   The trust page publishes cosign-signed binary claims (`prompt_output_storage:false`,
+   `control_plane_prompt_access:false`); nothing here may weaken them.
+2. **Never on the money path.** Telemetry never fails a request. The enclave drops invalid headers with a
+   stderr line, never a 4xx. The control plane soft-validates settle extras, never 400s. The beacon is
+   fire-and-forget outside the SDK retry engine, bounded, single-shot per flush, kill-switchable.
+   Client context is **never** sent on `/internal/gateway/authorize` (its idempotency fingerprint hashes every
+   body key; a per-attempt object would 409 SDK retries).
+3. **Honest numbers.** Availability is computed only from exact per-minute counters at logical-request
+   granularity — never from sampled records. The TR-fault classification is versioned in one module.
+   Exclusions are disclosed. `client_observed` has its own id and is never mixed into `router_core`.
+4. **Efficient.** Header ≈ 14 B on a first attempt, ≤ 160 B on retries; response ids ≈ 70 B; beacon O(1)
+   POSTs per process-minute regardless of RPS; one Spanner transaction per POST.
+
+## 3. Header channel (every client, zero extra requests)
+
+### 3.1 What the enclave reads (`enclave-go/cmd/enclave/http_io.go` `readRequest`)
+All optional; invalid ⇒ field dropped + `enclave.client_context_dropped reason=<enum> request_log_id=…`
+on stderr; never a 4xx.
+
+| header | who sends it | accepted | normalised field |
+|---|---|---|---|
+| `user-agent` (≤256 B read, never stored raw) | everyone | `trusted-router-(py\|js\|go\|rust\|java\|swift)/SEMVER( runtime/ver)?` or `(OpenAI\|Anthropic)/(Python\|JS\|Go\|Java\|…) SEMVER` | `sdk`, `sdk_version`, `runtime` |
+| `x-stainless-lang / -runtime / -runtime-version / -os / -arch` | vendor SDKs (already sent) | allowlists → enums else `other` | `lang`, `runtime`, `os`, `arch` |
+| `x-stainless-retry-count` | vendor SDKs (already sent) | int 0..99 | `attempt` |
+| `x-stainless-timeout` / `x-stainless-read-timeout` | vendor SDKs | float seconds → int ms 1..3 600 000 | `timeout_ms` |
+| `x-tr-client` | TrustedRouter SDKs, **every attempt** | grammar §3.2, ≤160 B | attempt, prev_*, since_first_ms, stream, failover_used |
+
+`source` = `tr` if `x-tr-client` parsed, else `stainless` if any x-stainless-* parsed, else `none`.
+
+### 3.2 `x-tr-client` v1 grammar (TrustedRouter SDKs)
+```
+x-tr-client = "v=1" *( ";" key "=" value )       ; keys unique; unknown key or bad value ⇒ whole header dropped
+value = [a-z0-9_]{1,24}                          ; total header ≤ 160 bytes
+a  = attempt index 0..99 (0 = first attempt; same semantics as x-stainless-retry-count)
+po = previous attempt outcome: none | http_error | transport_error | timeout | stream_broken
+pc = previous error class (ErrorClass, §5.3) or none
+ph = previous host: apex | ally | uptime | us_central1 | us_east4 | europe_west4 | control | custom | none
+pm = previous attempt elapsed ms 0..3600000
+sm = ms since the first attempt started 0..3600000
+s  = 0|1 streaming
+fo = 0|1 candidate index advanced at least once during this logical request
+```
+- First attempt: `v=1;a=0;s=1`. Retry after a connect timeout on the apex that moved to an alias:
+  `v=1;a=1;po=transport_error;pc=connect_timeout;ph=apex;pm=10012;sm=10530;s=1;fo=1`.
+- Static identity (SDK name/version/runtime/OS) rides the existing `User-Agent`, not this header.
+- **Not sent to custom base URLs** (a self-hosted gateway is not TrustedRouter's to measure) and **not sent
+  on control-plane calls**. Not sent when telemetry is opted out (§6.4).
+
+### 3.3 Response correlation (enclave → every client)
+Every response — success, error, stream head, 413/431, `/health` — carries **both**
+`x-request-id: rlog_<32hex>` and `request-id: rlog_<32hex>` (OpenAI SDKs read the first, Anthropic SDKs the
+second). The value is the enclave's per-request audit id (`enclave.request_start/request_end` lines). SDKs
+should read `x-request-id` and put it in `ClientAttempt.request_id` (§5.4). The enclave forwards the same id
+to the control plane on settle and refund as `gateway_request_id`, which lands on `activity_generations` —
+that is the client↔server join key. Do not ship idempotency keys in telemetry (they are the exactly-once
+settlement token and are not joinable in ClickHouse).
+
+### 3.4 What the enclave forwards (settle and refund bodies only)
+```json
+"gateway_request_id": "rlog_…",
+"client": {"v":1,"source":"tr","sdk":"tr-py","sdk_version":"0.6.0","lang":"python","runtime":"cpython/3.12.1",
+           "os":"macos","arch":"arm64","timeout_ms":120000,"attempt":1,"prev_outcome":"transport_error",
+           "prev_error_class":"connect_timeout","prev_host":"apex","prev_elapsed_ms":10012,"since_first_ms":10530,
+           "stream":true,"failover_used":true}
+```
+Control plane: `GatewayClientContext(_Strict)` soft-validates (drop + warning, never 4xx), stores on
+`Generation` → `activity_generations` `client_*` columns; keeps `client` OUT of customer broadcast bodies;
+refund path logs one bounded line. Canary traffic is detected server-side (`metadata.trustedrouter_synthetic`,
+app `TrustedRouter Synthetic`, monitor workspace) — no client honesty required.
+
+## 4. Beacon channel (TrustedRouter SDKs; Python first)
+
+`POST https://trustedrouter.com/v1/client-events` (also `/client-events`). Control plane, i.e. a *different
+deployment* from the inference plane — an inference-plane outage is reported in near real time. If the
+control plane itself is down, the SDK keeps counting locally (24 h of minute counters, byte-capped) and drains
+the backlog on recovery; the server assigns time from ages, so late data lands in the right minutes.
+
+- Auth: `Authorization: Bearer sk-tr-…` (an ordinary inference key; `InferencePrincipal`).
+- Body ≤ 65 536 bytes (413 above), ≤100 `events`, ≤200 `counters`; JSON per §5.
+- Response `202`:
+  `{"data":{"accepted_events":n,"accepted_counters":m,"dropped":k},"policy":{"success_sample_rate":0.01,"flush_seconds":30,"pause_seconds":0}}`.
+  The SDK applies `policy` **only when it reduces volume** (lower rate, longer flush, pause ∈ [0, 86400]).
+- Errors: 400 schema (drop the batch, keep going), 401/403/404/410 (disable telemetry for the process),
+  413 (drop the batch; the SDK's caps were violated — a bug), 429 (+Retry-After: back off), 503 (+Retry-After:
+  back off). Kill switch: `pause_seconds` in a 202, or `x-tr-telemetry: off` (disable for the process).
+- Never retry a flush; never send from inside the retry engine; never block a user request; bounded memory.
+- No CORS in v1 (server-side SDKs only). Browser JS is a later, separate decision.
+
+## 5. Beacon schema v1 (mirrors `src/trusted_router/client_events_schema.py`)
+
+### 5.1 Batch
+```
+ClientEventsBatch:
+  schema_version: 1
+  batch_id:       ^[0-9a-f]{32}$          # SDK-minted per POST
+  instance_id:    ^[0-9a-f]{16}$          # SDK-minted per process
+  seq:            int ≥ 0                 # per-process POST counter (gap = server-side loss detection)
+  sdk:            {name: tr-py|tr-js|tr-go|tr-rust|tr-java|tr-swift; version: SEMVER ≤32;
+                   lang: python|js|go|rust|java|swift; runtime: ^[a-z]{1,10}/[0-9A-Za-z.+-]{1,24}$;
+                   os: linux|macos|windows|ios|android|freebsd|other; arch: x64|x32|arm|arm64|wasm|other}
+  synthetic:      bool                    # true iff the requests carried metadata.trustedrouter_synthetic
+  dropped_since_last: int ≥ 0             # events/counters the SDK dropped since the previous POST
+  events:   [ClientRequestEvent] ≤100
+  counters: [ClientMinuteCounter] ≤200    # at least one of events/counters non-empty
+```
+Nothing else. No tenant/workspace/key/user/session ids (identity comes from the principal), no IPs, no
+hostnames (hosts are an enum), no idempotency keys, no message text, no timestamps (durations/ages only —
+the server assigns wall time).
+
+### 5.2 Enums (closed)
+```
+Host       = apex | ally | uptime | us_central1 | us_east4 | europe_west4 | control | custom
+Endpoint   = chat_completions | messages | responses | embeddings | images | videos | models | fusion
+           | control_other | inference_other
+Outcome    = ok | http_error | transport_error | timeout | stream_broken | aborted
+FinalOutcome = Outcome | exhausted
+ErrorClass = dns | tls | connect_refused | connect_timeout | connect_error | read_timeout | write_timeout
+           | pool_timeout | protocol_error | reset | io_error | proxy_error | stream_stalled | unknown
+ErrorSource = router | provider | unknown        # from the error body's "source" field
+TimeoutPhase = none | connect | first_byte | idle | total
+HttpStatusClass = none | 2xx | 4xx | 429 | 5xx
+LatencyBucket = lt100 | lt200 | lt400 | lt800 | lt1600 | lt3200 | lt6400 | lt12800 | lt25600 | lt51200
+              | lt102400 | ge102400                # ms; upper-bound-exclusive
+```
+Host mapping (SDK-side): `api.trustedrouter.com`→apex, `api.allyrouter.com`→ally, `api.uptimerouter.com`→uptime,
+`api-<region>.quillrouter.com`→region enum, `trustedrouter.com`→control, anything else→custom.
+
+### 5.3 Per-request event (sampled diagnostics)
+```
+ClientRequestEvent:
+  age_ms:            0..86 400 000        # request completion → flush; server: created_at = received_at − age_ms
+  plane:             inference | control
+  endpoint:          Endpoint
+  method:            GET | POST | PUT | PATCH | DELETE
+  streaming:         bool
+  provider_pinned:   bool                 # request pinned a provider/models list
+  model:             ^[A-Za-z0-9._:/~@-]{1,128}$ | null   # server maps to catalog id or "other"
+  attempts:          [ClientAttempt] 1..16
+  final_outcome:     FinalOutcome
+  final_http_status: 100..599 | null
+  total_ms:          0..3 600 000
+  ttft_ms:           0..3 600 000 | null  # first SSE event / first body byte for streams
+  failover_used:     bool
+  timeout_phase:     TimeoutPhase
+  configured_timeout_ms: 1..3 600 000 | null
+  sample_rate:       (0, 1]
+  sample_reason:     failure | retried | slow | random
+ClientAttempt:
+  index:        0..99
+  host:         Host
+  outcome:      Outcome
+  http_status:  100..599 | null
+  error_class:  ErrorClass | null
+  error_source: ErrorSource | null
+  should_retry: true | false | absent     # x-should-retry as observed
+  retry_after_ms: 0..3 600 000 | null
+  elapsed_ms:   0..3 600 000
+  ttfb_ms:      0..3 600 000 | null       # headers received
+  request_id:   ^rlog_[0-9a-f]{32}$ | null   # from x-request-id
+  moved:        bool                      # candidate index advanced after this attempt
+```
+Sampling: 100 % of events with `final_outcome ≠ ok`; 100 % of ok events with `len(attempts) > 1` or
+`failover_used`; 100 % of ok events with `total_ms > 30 000`; `success_sample_rate` (default 0.01) of the rest.
+
+### 5.4 Per-minute counters (exact; the only source of availability numbers)
+```
+ClientMinuteCounter:
+  window_start_age_ms: 0..86 400 000     # start of the client minute, as an offset before the flush
+  level:        attempt | request         # attempt-level: one row per (host, …) tried; request-level: final outcome
+  endpoint:     Endpoint
+  streaming:    bool
+  host:         Host                      # attempt: host tried; request: final host
+  outcome:      FinalOutcome
+  error_class:  ErrorClass | null
+  http_status_class: HttpStatusClass
+  timeout_phase: TimeoutPhase
+  timeout_floor_met: bool                 # configured connect ≥10 s / first-byte ≥60 s / idle ≥30 s
+  provider_pinned: bool
+  requests:     1..10 000 000
+  attempts:     ≥0
+  failover_used: ≥0
+  first_attempt_success: ≥0
+  total_ms_hist:      {LatencyBucket: count}
+  first_event_ms_hist: {LatencyBucket: count}
+```
+The counter key is exactly the fields above minus the counts and histograms (`model` is deliberately not
+part of it). A process keeps ≤256 keys per minute window; when a new key would exceed the cap it is folded —
+first `error_class → unknown`, then `endpoint → inference_other` — so the counts are still exact, only
+coarser. `dropped_since_last` is never incremented by folding.
+
+## 6. SDK implementation guide
+
+### 6.1 Where the facts live (one emit point per SDK; do not add a second)
+| SDK | policy kernel | single engine loop (emit here) | header assembly (add `x-tr-client` here) | out-of-engine single-shot precedent (attach the beacon sender here) |
+|---|---|---|---|---|
+| py | `_retry.py` `RetryController` | `_transport.py` four drivers | `_client_sync.py` buffered headers AND `_requests.py` `_build_stream_request` (two sites!) | raw `self._client.get` in `_client_sync.py` (status/attestation/trust) |
+| js | `internal/transport.js` kernel fns | `performRequest` (`transport.js`) | `buildHeaders` (`transport.js`) | `internal/trust.js fetchTrustRelease` |
+| go | `retry_policy.go` | `transport.go do()` | `newHTTPRequest` (`transport.go`) | `transport.go absoluteRequest` |
+| rust | `transport/policy.rs` | `transport/engine.rs Client::execute` | `transport/headers.rs request_headers` | `transport/mod.rs credential_free_json` |
+| java | `internal/RetryPolicy.java` (`AttemptFacts`) | `internal/Transport.java executeUrls` | `internal/RequestFactory.java buildRequest` | **none — add a bypass** (`executeAbsolute` rides the loop) |
+| swift | `Transport/RetryPolicy.swift` | `Transport/TransportEngine.swift withTransportRetries` | `Core/TrustedRouterClient.swift buildHeaders` | `rawRequest` (single-shot by contract) |
+
+Capture the transport error **class before** each SDK's flattening call (py `_errors.py _transport_retry_error`,
+js `transportError`, go `transportRetryError`, java `Transport.java` IOException catch, swift the bare `catch`) —
+after those lines only a message string remains. TTFT is only observable in the SSE decoder
+(py `_sse.py`, js `internal/sse.js`, go `sse.go`, rust `sse.rs`, java `EventStream.java`, swift `SSEParser.swift`).
+
+### 6.2 Reporter requirements (every SDK)
+- Own HTTP client, never the SDK's engine or the user's injected client; single background worker
+  (py daemon thread; js `setTimeout(...).unref()` + `beforeExit`; go goroutine + `Close()`; rust `tokio::spawn`;
+  java daemon single-thread executor; swift detached `Task`); lazily started on first record, never at import.
+- Bounded: events ≤1 000 (drop oldest success first, then oldest failure — count every drop); counter keys
+  ≤256 per minute window; closed windows retained ≤24 h under a byte cap (~512 KiB; oldest first);
+  flush at 30 s or ≥50 events or ≥60 KB or process exit (≤2 s, single attempt); backlog drains in successive
+  ≤100/≤200 batches spaced by the flush interval.
+- One POST per flush, no retries; 429/503 → exponential backoff 60 s → 10 min honouring Retry-After ≤ 600;
+  400/401/403/404/410 → disable for the process; `policy` applied only if it reduces volume;
+  `x-tr-telemetry: off` → disable.
+- Never send for control-plane calls; the beacon POST itself is never traced.
+- Fork safety where applicable (py `os.register_at_fork(after_in_child=reset)`).
+
+### 6.3 Config surface (every SDK)
+- Constructor/builder: `telemetry: bool | None` and `telemetry_sample_rate: float` beside `regional_failover`.
+- Env: `TRUSTEDROUTER_TELEMETRY` ∈ {`0`,`false`,`off`,`no`} disables; `DO_NOT_TRACK=1` disables;
+  `TRUSTEDROUTER_TELEMETRY_DEBUG=1` echoes each batch JSON to stderr before send (a trust feature).
+- Precedence: explicit arg > `TRUSTEDROUTER_TELEMETRY` > `DO_NOT_TRACK` > default.
+- **Default on only when** the control host is `trustedrouter.com` (or a subdomain) AND the inference base
+  is a known TrustedRouter host. Custom control planes / custom base URLs default off. No URL env var.
+- Opt-out disables **both** the `x-tr-client` header and the beacon (User-Agent stays).
+
+### 6.4 Tests every SDK must add (parity)
+- Header on attempt 0 (`v=1;a=0;…`); after a 503 the alias attempt carries `po=http_error;ph=apex;fo=1`
+  (extend the existing alias-failover test); custom base URL → no header, no beacon; control-plane calls →
+  no header, no beacon.
+- Transport-error classification for the common classes; stream first item → ttft; mid-body error →
+  `stream_broken`; caller abort → `aborted`.
+- Failures always recorded; successes sampled; counters exact.
+- Reporter: bounded drops; 24 h retention across a failed flush; 429 backs off; 400 disables; exit ≤ 2 s;
+  the SDK's own fake transport sees zero `/client-events` calls; opt-out precedence; no worker when off.
+- Privacy: serialised batch keys ⊆ schema; injected prompt text never appears; custom hostnames never appear.
+- Parity constants pinned in each SDK's parity test: beacon path `/client-events`, schema version 1, the
+  Host/Endpoint/Outcome/ErrorClass enums.
+
+## 7. Server-side data model and retention (ClickHouse, `clickhouse/008_client_events_replicated.sql`)
+- `activity_generations` gains `gateway_request_id`, `synthetic`, `client_*` columns (header channel).
+- `client_request_events` (raw sampled records) — TTL **90 days**; ORDER BY (tenant_id, created_at, event_id);
+  `event_id` = sha256(tenant_id, batch_id, "r", index) computed server-side.
+- `client_minute_counters` (exact) — TTL **180 days**.
+- `client_availability_rollups` (5m/hour/day; fleet + tenant scopes; `methodology_version`) — TTL **24 months**.
+- `operational_outbox_quarantine` — poison rows parked, never crash-loop the drainer — TTL 30 days.
+- Tenant/key ids are one-way surrogates (`analytics_surrogate`); raw ids never leave Spanner.
+- Raw client tables are **not** archived to Parquet (explicit decision); rollups are the retained artefact.
+
+## 8. Methodology v1 — how "client-observed availability" is computed (published on `/docs/telemetry`)
+- Unit = one logical SDK call. Source = `client_minute_counters` (exact). Retries never counted twice;
+  failover-rescued requests are successes, with `failover_used` and `first_attempt_success` published.
+- `tr_fault` (counts against us; `client_reliability.classify_tr_fault`, `METHODOLOGY_VERSION = 1`):
+  transport_error with class ∈ {dns, tls, connect_refused, connect_timeout, connect_error, reset, io_error,
+  protocol_error} on a non-custom host; http 5xx from any source **except** `provider_pinned` with
+  `error_source=provider`; timeout with phase ∈ {connect, first_byte} and `timeout_floor_met`; stream_broken;
+  stream_stalled with `timeout_floor_met`; unknown (conservative).
+- Excluded from the denominator (counted and disclosed): aborted; 4xx and 429; pool_timeout / proxy_error;
+  anything on `custom` hosts; timeouts below floor; `timeout_phase=total`.
+- `availability = successes / (successes + tr_fault)`. Per-host attempt-level `attempt_tr_fault/attempts` is
+  used for alerting only.
+- Fleet: exclude synthetic (server-side); per-tenant cap 25 % of the window; publish percentages only if
+  requests ≥ 1 000 and distinct tenants ≥ 3; coverage (telemetry successes ÷ `activity_generations`
+  non-synthetic rows) always shown. Time = server-assigned; late batches land in the right minute; rollups
+  recompute the trailing 2 h every 5 min; `age_ms > 6 h` excluded from rollups.
+- Own id `client_observed`; never inside `router_core` or `SLO_DEFINITIONS`. Calibration gate: 14 clean days
+  before any percentage is published.
+
+## 9. Rollout ordering (why it is not arbitrary)
+1. Enclave request ids (independent). 2. Control plane accepts settle context (extras reach customer broadcast
+webhooks otherwise). 3. ClickHouse node: DDL + tolerant ingester (poison-row crash loop otherwise) — before
+the control plane emits new outbox kinds or declares new activity columns. 4. Enclave header channel.
+5. Beacon ingest (flag default off → flip after smoke + load test). 6. Canary + alerts + freshness (same phase).
+7. Python SDK; header-only PRs in the other five SDKs. 8. Surfaces. 9. Calibration → publication.
+Enum vocabulary grows **server-first**; SDKs last. Enclave merges auto-deploy production.
+
+## 10. What NOT to do
+No OTel/metrics runtime in SDKs or enclave; no free-text fields; no beacon retries; no idempotency keys in
+telemetry; no forging `x-stainless-*`; no `client` on authorize; no client fields on `/v1/generation`;
+no `client_observed` inside `SLO_DEFINITIONS`; no beacons in a second SDK until the Python contract has been
+live and calibrated; no CORS in v1.

--- a/docs/client-telemetry.md
+++ b/docs/client-telemetry.md
@@ -296,7 +296,7 @@ after those lines only a message string remains. TTFT is only observable in the 
 - Fleet: exclude synthetic (server-side); per-tenant cap 25 % of the window; publish percentages only if
   requests ≥ 1 000 and distinct tenants ≥ 3; coverage (telemetry successes ÷ `activity_generations`
   non-synthetic rows) always shown. Time = server-assigned; late batches land in the right minute; rollups
-  recompute the trailing 3 h every 5 min; `age_ms > 6 h` excluded from rollups.
+  recompute the trailing 6 h every 5 min (matching the late-arrival cap); `age_ms > 6 h` excluded from rollups.
 - Own id `client_observed`; never inside `router_core` or `SLO_DEFINITIONS`. Calibration gate: 14 clean days
   before any percentage is published.
 

--- a/docs/client-telemetry.md
+++ b/docs/client-telemetry.md
@@ -296,7 +296,7 @@ after those lines only a message string remains. TTFT is only observable in the 
 - Fleet: exclude synthetic (server-side); per-tenant cap 25 % of the window; publish percentages only if
   requests ≥ 1 000 and distinct tenants ≥ 3; coverage (telemetry successes ÷ `activity_generations`
   non-synthetic rows) always shown. Time = server-assigned; late batches land in the right minute; rollups
-  recompute the trailing 2 h every 5 min; `age_ms > 6 h` excluded from rollups.
+  recompute the trailing 3 h every 5 min; `age_ms > 6 h` excluded from rollups.
 - Own id `client_observed`; never inside `router_core` or `SLO_DEFINITIONS`. Calibration gate: 14 clean days
   before any percentage is published.
 

--- a/scripts/deploy/aws_eu_north_clickhouse.sh
+++ b/scripts/deploy/aws_eu_north_clickhouse.sh
@@ -66,6 +66,7 @@ SECRET_ID="${SECRET_ID:-quill/tr-eu-north-clickhouse-password}"
 INSTANCE_PROFILE="${INSTANCE_PROFILE:-quill-enclave-instance-profile}"
 PEER_WITH_PARIS="${PEER_WITH_PARIS:-1}"            # 0 to bring your own path.
 SCHEMA_FILE="${SCHEMA_FILE:-$(dirname "$0")/../../clickhouse/006_operational_analytics_single_node.sql}"
+CLIENT_SCHEMA_FILE="${CLIENT_SCHEMA_FILE:-$(dirname "$0")/../../clickhouse/009_client_events_single_node.sql}"
 
 log(){ printf '\n=== %s\n' "$*" >&2; }
 
@@ -123,6 +124,7 @@ if [ "$REGION" = "$PARIS_REGION" ]; then
   exit 1
 fi
 [ -r "$SCHEMA_FILE" ] || { echo "schema file not readable: $SCHEMA_FILE" >&2; exit 1; }
+[ -r "$CLIENT_SCHEMA_FILE" ] || { echo "schema file not readable: $CLIENT_SCHEMA_FILE" >&2; exit 1; }
 
 PARIS_VPC_CIDR="$(aws ec2 describe-vpcs --region "$PARIS_REGION" --vpc-ids "$PARIS_VPC_ID" \
   --query 'Vpcs[0].CidrBlock' --output text)"
@@ -249,6 +251,7 @@ log "security group: $SG_ID"
 #    manual step that someone forgets.
 # ---------------------------------------------------------------------------
 OPERATIONAL_SCHEMA="$(cat "$SCHEMA_FILE")"
+CLIENT_SCHEMA="$(cat "$CLIENT_SCHEMA_FILE")"
 
 EXISTING="$(aws ec2 describe-instances --region "$REGION" \
   --filters "Name=tag:Name,Values=$NAME" "Name=instance-state-name,Values=running,pending" \
@@ -320,6 +323,7 @@ systemctl restart clickhouse-server
 # Keeper: this node does not replicate with Paris, the drain writes both.
 cat > /root/operational_schema.sql <<'SQLEOF'
 ${OPERATIONAL_SCHEMA}
+${CLIENT_SCHEMA}
 SQLEOF
 for attempt in \$(seq 1 60); do
   if CLICKHOUSE_PASSWORD='${CH_PASSWORD}' clickhouse-client --user default --database default --query 'SELECT 1' >/dev/null 2>&1; then
@@ -559,12 +563,15 @@ echo "  clickhouse-client --user default --database default --query \\"
 echo "    \"INSERT INTO FUNCTION remote('${PRIVATE_IP}:9000','default','activity_generations','default','<stockholm password>') \\"
 echo "     SELECT * FROM activity_generations\""
 echo
-echo "and again for synthetic_probe_samples. ingest_version is carried through,"
+echo "and again for synthetic_probe_samples, client_request_events, and"
+echo "client_minute_counters. ingest_version is carried through,"
 echo "so re-running it collapses instead of double-counting."
 echo
-echo "COVERAGE: the drain replicates the two tables it drains --"
-echo "activity_generations and synthetic_probe_samples. It does NOT write"
-echo "synthetic_status_rollups or public_analytics_snapshots; on this cloud"
-echo "nothing does today (those are GCP timers), so both nodes hold them empty."
+echo "COVERAGE: the drain replicates activity_generations,"
+echo "synthetic_probe_samples, client_request_events, client_minute_counters,"
+echo "and operational_outbox_quarantine. It does NOT write"
+echo "synthetic_status_rollups, client_availability_rollups, or"
+echo "public_analytics_snapshots; on this cloud nothing does today"
+echo "(those are GCP timers), so both nodes hold them empty."
 echo "If a rollup or snapshot job is ever run against Paris, its output is NOT"
 echo "on this node and this node is not a complete copy until it is."

--- a/scripts/deploy/clickhouse_operational_analytics.sh
+++ b/scripts/deploy/clickhouse_operational_analytics.sh
@@ -11,6 +11,7 @@ source "${SCRIPT_DIR}/_lib.sh"
 NAMES=(tr-clickhouse-1 tr-clickhouse-2 tr-clickhouse-3)
 ZONES=(us-central1-a us-central1-b us-central1-c)
 SCHEMA="${ROOT}/clickhouse/004_operational_analytics_replicated.sql"
+CLIENT_SCHEMA="${ROOT}/clickhouse/008_client_events_replicated.sql"
 BENCHMARK_WORKSPACE_SCHEMA="${ROOT}/clickhouse/007_benchmark_samples_workspace_id.sql"
 BENCHMARK_WORKSPACE_BACKFILL_LIMIT="${TR_CLICKHOUSE_BENCHMARK_WORKSPACE_BACKFILL_LIMIT:-200000}"
 CONTROL_SECRET="trustedrouter-clickhouse-control-read-password"
@@ -26,6 +27,7 @@ fi
 if [ "$APPLY" -eq 0 ]; then
   log "dry-run: would create the bounded Spanner operational analytics queue"
   log "dry-run: would create three-replica activity and synthetic tables"
+  log "dry-run: would create client telemetry, rollup, and quarantine tables"
   log "dry-run: would backfill bounded Bigtable history and verify replica parity"
   log "dry-run: would install the ingester, rollup worker, and private reader"
   log "dry-run: would migrate and replay bounded benchmark workspace attribution"
@@ -83,8 +85,9 @@ SPANNER_DATABASE_ID="$SPANNER_DATABASE_ID" \
 
 log "creating replicated operational tables"
 schema="$(cat "$SCHEMA")"
+client_schema="$(cat "$CLIENT_SCHEMA")"
 for index in 0 1 2; do
-  node_query "$index" "CREATE DATABASE IF NOT EXISTS tr; ${schema}"
+  node_query "$index" "CREATE DATABASE IF NOT EXISTS tr; ${schema} ${client_schema}"
 done
 
 archive="$(mktemp "${TMPDIR:-/tmp}/tr-clickhouse-operational.XXXXXX.tar.gz")"
@@ -113,6 +116,10 @@ node_ssh 0 --command="sudo sh -c '
     /etc/systemd/system/tr-clickhouse-synthetic-rollup.service
   install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-synthetic-rollup.timer \
     /etc/systemd/system/tr-clickhouse-synthetic-rollup.timer
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-client-rollup.service \
+    /etc/systemd/system/tr-clickhouse-client-rollup.service
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-client-rollup.timer \
+    /etc/systemd/system/tr-clickhouse-client-rollup.timer
   install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-operational-parity.service \
     /etc/systemd/system/tr-clickhouse-operational-parity.service
   install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-operational-parity.timer \
@@ -188,16 +195,18 @@ node_ssh 0 --command="sudo sh -c '
     /opt/tr-clickhouse/venv/bin/python -m clickhouse.rollup_synthetic
 '"
 
-node_ssh 0 --command="sudo systemctl enable tr-clickhouse-operational-ingest.service tr-clickhouse-synthetic-rollup.timer tr-clickhouse-operational-parity.timer tr-clickhouse-public-snapshots.timer tr-clickhouse-archive-restore.timer tr-clickhouse-spanner-delivery.timer"
+node_ssh 0 --command="sudo systemctl enable tr-clickhouse-operational-ingest.service tr-clickhouse-synthetic-rollup.timer tr-clickhouse-client-rollup.timer tr-clickhouse-operational-parity.timer tr-clickhouse-public-snapshots.timer tr-clickhouse-archive-restore.timer tr-clickhouse-spanner-delivery.timer"
 
 log "verifying exact replica identity after synchronization"
-for table in activity_generations synthetic_probe_samples synthetic_status_rollups public_analytics_snapshots; do
+for table in activity_generations synthetic_probe_samples synthetic_status_rollups public_analytics_snapshots client_request_events client_minute_counters client_availability_rollups operational_outbox_quarantine; do
   expected=""
   id_column="id"
   if [ "$table" = "activity_generations" ]; then
     id_column="generation_id"
   elif [ "$table" = "public_analytics_snapshots" ]; then
     id_column="name"
+  elif [ "$table" = "client_request_events" ] || [ "$table" = "client_minute_counters" ] || [ "$table" = "operational_outbox_quarantine" ]; then
+    id_column="event_id"
   fi
   for index in 0 1 2; do
     node_query "$index" "SYSTEM SYNC REPLICA ${table}"
@@ -230,7 +239,7 @@ for index in 0 1 2; do
 done
 
 node_ssh 0 --command="sudo systemctl start tr-clickhouse-operational-ingest.service"
-node_ssh 0 --command="sudo systemctl start tr-clickhouse-public-snapshots.timer tr-clickhouse-public-snapshots.service tr-clickhouse-archive-restore.timer tr-clickhouse-spanner-delivery.timer tr-clickhouse-spanner-delivery.service"
+node_ssh 0 --command="sudo systemctl start tr-clickhouse-client-rollup.timer tr-clickhouse-public-snapshots.timer tr-clickhouse-public-snapshots.service tr-clickhouse-archive-restore.timer tr-clickhouse-spanner-delivery.timer tr-clickhouse-spanner-delivery.service"
 
 log "operational analytics infrastructure is ready; Bigtable is still authoritative"
 log "deploy the operational outbox producer, then run clickhouse_operational_analytics_finalize.sh --apply"

--- a/src/trusted_router/client_reliability.py
+++ b/src/trusted_router/client_reliability.py
@@ -1,0 +1,314 @@
+"""Pure methodology for client-observed reliability telemetry."""
+
+from __future__ import annotations
+
+import datetime as dt
+import math
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+METHODOLOGY_VERSION = 1
+
+HOSTS = (
+    "apex",
+    "ally",
+    "uptime",
+    "us_central1",
+    "us_east4",
+    "europe_west4",
+    "control",
+    "custom",
+)
+ENDPOINTS = (
+    "chat_completions",
+    "messages",
+    "responses",
+    "embeddings",
+    "images",
+    "videos",
+    "models",
+    "fusion",
+    "control_other",
+    "inference_other",
+)
+OUTCOMES = (
+    "ok",
+    "http_error",
+    "transport_error",
+    "timeout",
+    "stream_broken",
+    "aborted",
+)
+FINAL_OUTCOMES = (*OUTCOMES, "exhausted")
+ERROR_CLASSES = (
+    "dns",
+    "tls",
+    "connect_refused",
+    "connect_timeout",
+    "connect_error",
+    "read_timeout",
+    "write_timeout",
+    "pool_timeout",
+    "protocol_error",
+    "reset",
+    "io_error",
+    "proxy_error",
+    "stream_stalled",
+    "unknown",
+)
+TIMEOUT_PHASES = ("none", "connect", "first_byte", "idle", "total")
+LATENCY_BUCKETS = (
+    "lt100",
+    "lt200",
+    "lt400",
+    "lt800",
+    "lt1600",
+    "lt3200",
+    "lt6400",
+    "lt12800",
+    "lt25600",
+    "lt51200",
+    "lt102400",
+    "ge102400",
+)
+
+# Singular aliases make the names in the cross-repo contract executable while
+# the plural forms remain convenient for parity tests in every SDK.
+Host = HOSTS
+Endpoint = ENDPOINTS
+Outcome = OUTCOMES
+FinalOutcome = FINAL_OUTCOMES
+ErrorClass = ERROR_CLASSES
+TimeoutPhase = TIMEOUT_PHASES
+LatencyBucket = LATENCY_BUCKETS
+
+TR_FAULT_TRANSPORT_CLASSES = (
+    "dns",
+    "tls",
+    "connect_refused",
+    "connect_timeout",
+    "connect_error",
+    "reset",
+    "io_error",
+    "protocol_error",
+)
+
+
+def _status_class(value: str | int | None) -> str:
+    if value is None:
+        return "none"
+    if isinstance(value, int):
+        if value == 429:
+            return "429"
+        if 200 <= value <= 299:
+            return "2xx"
+        if 400 <= value <= 499:
+            return "4xx"
+        if 500 <= value <= 599:
+            return "5xx"
+        return "none"
+    return value.casefold()
+
+
+def is_excluded(
+    *,
+    level: str,
+    outcome: str,
+    error_class: str | None,
+    error_source: str | None,
+    http_status_class_or_status: str | int | None,
+    host: str,
+    provider_pinned: bool,
+    timeout_phase: str,
+    timeout_floor_met: bool,
+) -> bool:
+    """Return whether the observation is disclosed outside the denominator."""
+
+    if level not in {"attempt", "request"}:
+        raise ValueError(f"unsupported client reliability level: {level}")
+    status_class = _status_class(http_status_class_or_status)
+    error_class = error_class or ""
+    if host == "custom" or outcome == "aborted":
+        return True
+    if status_class in {"4xx", "429"}:
+        return True
+    if error_class in {"pool_timeout", "proxy_error"}:
+        return True
+    if timeout_phase == "total":
+        return True
+    if outcome == "timeout" and not timeout_floor_met:
+        return True
+    return bool(
+        outcome == "http_error"
+        and status_class == "5xx"
+        and provider_pinned
+        and error_source == "provider"
+    )
+
+
+def classify_tr_fault(
+    *,
+    level: str,
+    outcome: str,
+    error_class: str | None,
+    error_source: str | None,
+    http_status_class_or_status: str | int | None,
+    host: str,
+    provider_pinned: bool,
+    timeout_phase: str,
+    timeout_floor_met: bool,
+) -> bool:
+    """Apply client-observed availability methodology version 1 exactly."""
+
+    if is_excluded(
+        level=level,
+        outcome=outcome,
+        error_class=error_class,
+        error_source=error_source,
+        http_status_class_or_status=http_status_class_or_status,
+        host=host,
+        provider_pinned=provider_pinned,
+        timeout_phase=timeout_phase,
+        timeout_floor_met=timeout_floor_met,
+    ):
+        return False
+    error_class = error_class or ""
+    status_class = _status_class(http_status_class_or_status)
+    if outcome == "transport_error" and error_class in TR_FAULT_TRANSPORT_CLASSES:
+        return True
+    if outcome == "http_error" and status_class == "5xx":
+        return True
+    if outcome == "timeout" and timeout_phase in {"connect", "first_byte"} and timeout_floor_met:
+        return True
+    if outcome == "stream_broken":
+        return True
+    if error_class == "stream_stalled" and timeout_floor_met:
+        return True
+    return error_class == "unknown"
+
+
+def availability(successes: int, tr_fault: int) -> float | None:
+    denominator = successes + tr_fault
+    return successes / denominator if denominator else None
+
+
+def _int(row: Mapping[str, Any], key: str) -> int:
+    return int(row.get(key) or 0)
+
+
+def _merge_histograms(
+    rows: Iterable[Mapping[str, Any]],
+    key: str,
+) -> dict[str, int]:
+    result: dict[str, int] = {}
+    for row in rows:
+        histogram = row.get(key) or {}
+        if not isinstance(histogram, Mapping):
+            continue
+        for bucket, count in histogram.items():
+            result[str(bucket)] = result.get(str(bucket), 0) + int(count)
+    return result
+
+
+def _histogram_percentile(histogram: Mapping[str, int], percentile: int) -> int | None:
+    total = sum(max(0, int(histogram.get(bucket, 0))) for bucket in LATENCY_BUCKETS)
+    if total <= 0:
+        return None
+    target = max(1, math.ceil(total * percentile / 100))
+    seen = 0
+    for bucket in LATENCY_BUCKETS:
+        seen += max(0, int(histogram.get(bucket, 0)))
+        if seen >= target:
+            return 102_400 if bucket == "ge102400" else int(bucket[2:])
+    return 102_400
+
+
+def _total_rows(rows: Sequence[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
+    totals = [
+        row
+        for row in rows
+        if not str(row.get("host") or "")
+        and not str(row.get("endpoint") or "")
+        and not str(row.get("sdk") or "")
+    ]
+    return totals or list(rows)
+
+
+def _window(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    rows = _total_rows(rows)
+    requests = sum(_int(row, "requests") for row in rows)
+    successes = sum(_int(row, "successes") for row in rows)
+    tr_fault = sum(_int(row, "tr_fault_failures") for row in rows)
+    distinct_tenants = max((_int(row, "distinct_tenants") for row in rows), default=0)
+    coverage_requests = sum(_int(row, "coverage_requests") for row in rows)
+    measured = availability(successes, tr_fault)
+    total_hist = _merge_histograms(rows, "total_ms_hist")
+    first_event_hist = _merge_histograms(rows, "first_event_ms_hist")
+    return {
+        "requests": requests,
+        "successes": successes,
+        "tr_fault": tr_fault,
+        "excluded": sum(_int(row, "excluded_failures") for row in rows),
+        "aborted": sum(_int(row, "aborted") for row in rows),
+        "availability_percent": (
+            round(measured * 100, 4)
+            if measured is not None and requests >= 1_000 and distinct_tenants >= 3
+            else None
+        ),
+        "distinct_tenants": distinct_tenants,
+        "coverage": (round(successes / coverage_requests, 4) if coverage_requests else None),
+        "p50_total_ms": _histogram_percentile(total_hist, 50),
+        "p95_total_ms": _histogram_percentile(total_hist, 95),
+        "p50_ttft_ms": _histogram_percentile(first_event_hist, 50),
+    }
+
+
+def _host_breakdown(rows: Sequence[Mapping[str, Any]]) -> dict[str, dict[str, Any]]:
+    result: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        host = str(row.get("host") or "")
+        if not host or row.get("endpoint") or row.get("sdk"):
+            continue
+        item = result.setdefault(host, {"attempts": 0, "attempt_tr_fault": 0})
+        item["attempts"] += _int(row, "attempts")
+        item["attempt_tr_fault"] += _int(row, "attempt_tr_fault")
+    for item in result.values():
+        attempts = int(item["attempts"])
+        item["rate"] = round(int(item["attempt_tr_fault"]) / attempts, 6) if attempts else None
+    return result
+
+
+def _sdk_breakdown(rows: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    result: dict[str, int] = {}
+    for row in rows:
+        sdk = str(row.get("sdk") or "")
+        if not sdk or row.get("host") or row.get("endpoint"):
+            continue
+        result[sdk] = result.get(sdk, 0) + _int(row, "requests")
+    return result
+
+
+def build_client_reliability(
+    rows_by_window: Mapping[str, Iterable[Mapping[str, Any]]],
+    now: dt.datetime,
+) -> dict[str, Any]:
+    """Build the content-free public snapshot from bounded fleet rollups."""
+
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=dt.UTC)
+    else:
+        now = now.astimezone(dt.UTC)
+    windows = {
+        name: [dict(row) for row in rows_by_window.get(name, ())]
+        for name in ("5m", "1h", "24h", "7d", "30d")
+    }
+    return {
+        "generated_at": now.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+        "methodology_version": METHODOLOGY_VERSION,
+        "published": False,
+        "windows": {name: _window(rows) for name, rows in windows.items()},
+        "by_host_24h": _host_breakdown(windows["24h"]),
+        "by_sdk_24h": _sdk_breakdown(windows["24h"]),
+        "canary": {"last_seen_age_seconds": None, "last_24h_count": 0},
+        "freshness": {"newest_received_at": None, "drain_lag_seconds": None},
+    }

--- a/src/trusted_router/operational_analytics.py
+++ b/src/trusted_router/operational_analytics.py
@@ -375,8 +375,14 @@ def _generation(row: dict[str, Any], *, tenant_id: str) -> Generation:
         ttfb_milliseconds=_optional_int(row.get("ttfb_milliseconds")),
         region=str(row["region"]) if row.get("region") is not None else None,
         user=str(row["user"]) if row.get("user") is not None else None,
-        session_id=(str(row["session_id"]) if row.get("session_id") is not None else None),
-        http_referer=(str(row["http_referer"]) if row.get("http_referer") is not None else None),
+        session_id=(
+            str(row["session_id"]) if row.get("session_id") is not None else None
+        ),
+        http_referer=(
+            str(row["http_referer"])
+            if row.get("http_referer") is not None
+            else None
+        ),
         app_categories=[str(item) for item in row.get("app_categories") or []],
         tags={str(key): str(value) for key, value in (row.get("tags") or {}).items()},
         created_at=_iso(row["created_at"]),
@@ -392,7 +398,11 @@ def stable_rows_fingerprint(rows: list[Any], *, grace_seconds: int = 30) -> tupl
     cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=max(0, grace_seconds))
     stable: list[dict[str, Any]] = []
     for row in rows:
-        payload = dataclasses.asdict(cast(Any, row)) if dataclasses.is_dataclass(row) else dict(row)
+        payload = (
+            dataclasses.asdict(cast(Any, row))
+            if dataclasses.is_dataclass(row)
+            else dict(row)
+        )
         # Rebuild timestamps are expected to differ across stores. Raw tenant
         # and key identifiers are intentionally replaced by opaque surrogates
         # in ClickHouse, so they are not parity fields either.
@@ -419,7 +429,8 @@ def stable_rows_fingerprint(rows: list[Any], *, grace_seconds: int = 30) -> tupl
                 continue
         stable.append(payload)
     canonical_rows = sorted(
-        json.dumps(row, sort_keys=True, separators=(",", ":"), default=str) for row in stable
+        json.dumps(row, sort_keys=True, separators=(",", ":"), default=str)
+        for row in stable
     )
     encoded = "\n".join(canonical_rows)
     return len(stable), hashlib.sha256(encoded.encode("utf-8")).hexdigest()

--- a/src/trusted_router/operational_analytics.py
+++ b/src/trusted_router/operational_analytics.py
@@ -306,6 +306,7 @@ FORMAT JSON
             "apps",
             "video_leaderboard",
             "status_inputs",
+            "client_reliability",
         }:
             raise ValueError("unsupported public analytics snapshot")
         rows = self._query(
@@ -374,14 +375,8 @@ def _generation(row: dict[str, Any], *, tenant_id: str) -> Generation:
         ttfb_milliseconds=_optional_int(row.get("ttfb_milliseconds")),
         region=str(row["region"]) if row.get("region") is not None else None,
         user=str(row["user"]) if row.get("user") is not None else None,
-        session_id=(
-            str(row["session_id"]) if row.get("session_id") is not None else None
-        ),
-        http_referer=(
-            str(row["http_referer"])
-            if row.get("http_referer") is not None
-            else None
-        ),
+        session_id=(str(row["session_id"]) if row.get("session_id") is not None else None),
+        http_referer=(str(row["http_referer"]) if row.get("http_referer") is not None else None),
         app_categories=[str(item) for item in row.get("app_categories") or []],
         tags={str(key): str(value) for key, value in (row.get("tags") or {}).items()},
         created_at=_iso(row["created_at"]),
@@ -397,11 +392,7 @@ def stable_rows_fingerprint(rows: list[Any], *, grace_seconds: int = 30) -> tupl
     cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=max(0, grace_seconds))
     stable: list[dict[str, Any]] = []
     for row in rows:
-        payload = (
-            dataclasses.asdict(cast(Any, row))
-            if dataclasses.is_dataclass(row)
-            else dict(row)
-        )
+        payload = dataclasses.asdict(cast(Any, row)) if dataclasses.is_dataclass(row) else dict(row)
         # Rebuild timestamps are expected to differ across stores. Raw tenant
         # and key identifiers are intentionally replaced by opaque surrogates
         # in ClickHouse, so they are not parity fields either.
@@ -428,8 +419,7 @@ def stable_rows_fingerprint(rows: list[Any], *, grace_seconds: int = 30) -> tupl
                 continue
         stable.append(payload)
     canonical_rows = sorted(
-        json.dumps(row, sort_keys=True, separators=(",", ":"), default=str)
-        for row in stable
+        json.dumps(row, sort_keys=True, separators=(",", ":"), default=str) for row in stable
     )
     encoded = "\n".join(canonical_rows)
     return len(stable), hashlib.sha256(encoded.encode("utf-8")).hexdigest()

--- a/tests/test_clickhouse_archive.py
+++ b/tests/test_clickhouse_archive.py
@@ -240,7 +240,10 @@ def test_rollup_archive_fingerprint_sorts_unordered_map_columns() -> None:
     assert "mapSort(latency_histogram)" in expression
     assert "mapSort(error_counts)" in expression
     assert "mapSort(id)" not in expression
-    assert "toUnixTimestamp64Milli(toDateTime64(period_start, 3, 'UTC'))" in expression
+    assert (
+        "toUnixTimestamp64Milli(toDateTime64(period_start, 3, 'UTC'))"
+        in expression
+    )
 
 
 def test_operational_dataset_archive_round_trips_through_restore_verifier() -> None:
@@ -269,6 +272,48 @@ def test_operational_dataset_archive_round_trips_through_restore_verifier() -> N
     assert restored.rows == 7
     assert restored.parts == 3
     assert restored.revision == result.revision
+
+
+def test_manifest_records_its_columns_and_the_verifier_fingerprints_over_them() -> None:
+    """A revision exported before a column was added stays verifiable.
+
+    activity_generations grew 18 client_* columns; the fingerprint expression
+    covers every column, so recomputing an OLD Parquet part against the CURRENT
+    column list reads columns the file does not have. The manifest therefore
+    records the exact columns it was exported with and the verifier uses them.
+    """
+    import clickhouse.verify_archive_restore as restore
+
+    exporter = FakeExporter(_fingerprint())
+    store = MemoryStore()
+    day = dt.date(2026, 7, 1)
+    result = archive_day(exporter, store, day, dataset="activity_generations")
+    manifest = store.json[result.manifest_key]
+    assert manifest["columns"] == list(ACTIVITY_COLUMNS)
+
+    # Simulate a manifest written by an older exporter (fewer columns) and pin
+    # that the default verifier passes THOSE columns to the Parquet fingerprint.
+    legacy_columns = list(ACTIVITY_COLUMNS[:29])
+    manifest["columns"] = legacy_columns
+    seen: list[tuple[str, tuple[str, ...] | None]] = []
+    original = restore.verify_parquet_part
+
+    def spy(path: Path, *, dataset: str, columns: Any = None) -> ExportedPart:
+        seen.append((dataset, tuple(columns) if columns else None))
+        return exporter.verify_part(path)
+
+    restore.verify_parquet_part = spy  # type: ignore[assignment]
+    try:
+        verify_archived_day(store, dataset="activity_generations", day=day)
+    finally:
+        restore.verify_parquet_part = original  # type: ignore[assignment]
+    assert seen and all(columns == tuple(legacy_columns) for _, columns in seen)
+
+    manifest["columns"] = []
+    with pytest.raises(RuntimeError, match="manifest columns"):
+        verify_archived_day(
+            store, dataset="activity_generations", day=day, verifier=exporter.verify_part
+        )
 
 
 def test_restore_drill_rejects_a_tampered_parquet_part() -> None:

--- a/tests/test_clickhouse_archive.py
+++ b/tests/test_clickhouse_archive.py
@@ -17,6 +17,7 @@ from clickhouse.archive_daily import (
     _row_hash_expression,
     archive_day,
 )
+from clickhouse.ingest_operational_outbox import ACTIVITY_COLUMNS
 from clickhouse.verify_archive_backfill import verify_archive_backfill
 from clickhouse.verify_archive_restore import verify_archived_day
 
@@ -228,6 +229,9 @@ def test_every_bounded_analytics_dataset_has_an_archive_schema() -> None:
         assert spec.shard_column in spec.columns
         assert "ingest_version" not in spec.columns
     assert "updated_at" not in DATASETS["synthetic_status_rollups"].columns
+    assert DATASETS["activity_generations"].columns == ACTIVITY_COLUMNS
+    assert "client_request_events" not in DATASETS
+    assert "client_minute_counters" not in DATASETS
 
 
 def test_rollup_archive_fingerprint_sorts_unordered_map_columns() -> None:
@@ -236,10 +240,7 @@ def test_rollup_archive_fingerprint_sorts_unordered_map_columns() -> None:
     assert "mapSort(latency_histogram)" in expression
     assert "mapSort(error_counts)" in expression
     assert "mapSort(id)" not in expression
-    assert (
-        "toUnixTimestamp64Milli(toDateTime64(period_start, 3, 'UTC'))"
-        in expression
-    )
+    assert "toUnixTimestamp64Milli(toDateTime64(period_start, 3, 'UTC'))" in expression
 
 
 def test_operational_dataset_archive_round_trips_through_restore_verifier() -> None:

--- a/tests/test_clickhouse_client_events.py
+++ b/tests/test_clickhouse_client_events.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+import dataclasses
+import datetime as dt
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from clickhouse.ingest_operational_outbox import (
+    ACTIVITY_COLUMNS,
+    ACTIVITY_OPTIONAL_DEFAULTS,
+    CLIENT_COUNTER_COLUMNS,
+    CLIENT_REQUEST_COLUMNS,
+    CanonicalOperationalEvent,
+    ClickHouseOperationalWriter,
+    OperationalOutboxRow,
+    drain_once,
+    expand_client_events_payload,
+    normalise_operational_event,
+)
+from clickhouse.ingest_operational_outbox_postgres import drain_shard_once
+from tests.test_operational_analytics import _generation
+from trusted_router.storage_gcp_operational_analytics_outbox import activity_payload
+
+ROOT = Path(__file__).parents[1]
+COMMIT_TS = dt.datetime(2026, 8, 17, 12, 1, 2, 345678, tzinfo=dt.UTC)
+
+
+def _attempt(index: int, **updates: Any) -> dict[str, Any]:
+    value = {
+        "index": index,
+        "host": "apex",
+        "outcome": "ok",
+        "http_status": 200,
+        "error_class": None,
+        "error_source": None,
+        "should_retry": None,
+        "retry_after_ms": None,
+        "elapsed_ms": 123,
+        "ttfb_ms": 50,
+        "request_id": None,
+        "moved": False,
+    }
+    value.update(updates)
+    return value
+
+
+def _event(attempts: list[dict[str, Any]], **updates: Any) -> dict[str, Any]:
+    value = {
+        "created_at": "2026-08-17T12:00:01.000Z",
+        "plane": "inference",
+        "endpoint": "responses",
+        "method": "POST",
+        "streaming": True,
+        "provider_pinned": False,
+        "model": None,
+        "attempts": attempts,
+        "final_outcome": attempts[-1]["outcome"],
+        "final_http_status": attempts[-1]["http_status"],
+        "total_ms": 456,
+        "ttft_ms": None,
+        "failover_used": len(attempts) > 1,
+        "timeout_phase": "none",
+        "configured_timeout_ms": None,
+        "sample_rate": 1.0,
+        "sample_reason": "failure",
+        "tr_fault": 0,
+        "methodology_version": 1,
+    }
+    value.update(updates)
+    return value
+
+
+def _counter(**updates: Any) -> dict[str, Any]:
+    value = {
+        "bucket_start": "2026-08-17T12:00:00Z",
+        "level": "request",
+        "endpoint": "responses",
+        "streaming": True,
+        "host": "apex",
+        "outcome": "ok",
+        "error_class": None,
+        "http_status_class": "2xx",
+        "timeout_phase": "none",
+        "timeout_floor_met": True,
+        "provider_pinned": False,
+        "requests": 1,
+        "attempts": 1,
+        "failover_used": 0,
+        "first_attempt_success": 1,
+        "total_ms_hist": {"lt800": 1},
+        "first_event_ms_hist": {},
+        "tr_fault": 0,
+        "methodology_version": 1,
+    }
+    value.update(updates)
+    return value
+
+
+def _client_payload() -> dict[str, Any]:
+    attempts = [
+        _attempt(
+            0,
+            outcome="transport_error",
+            http_status=None,
+            error_class="connect_timeout",
+            should_retry=True,
+            retry_after_ms=None,
+            ttfb_ms=None,
+            moved=True,
+        ),
+        _attempt(
+            1,
+            host="ally",
+            outcome="http_error",
+            http_status=503,
+            error_source="router",
+            should_retry=False,
+            request_id="rlog_" + "a" * 32,
+        ),
+        _attempt(2, host="uptime"),
+    ]
+    return {
+        "schema_version": 1,
+        "tenant_id": "a" * 64,
+        "key_id": "b" * 64,
+        "received_at": "2026-08-17T12:01:00.000Z",
+        "clock_skew_ms": -10,
+        "synthetic": False,
+        "batch_id": "c" * 32,
+        "instance_id": "d" * 16,
+        "seq": 7,
+        "sdk": {
+            "name": "tr-py",
+            "version": "0.6.0",
+            "lang": "python",
+            "runtime": "cpython/3.12.1",
+            "os": "linux",
+            "arch": "x64",
+        },
+        "events": [
+            _event(attempts),
+            _event([_attempt(0)], sample_reason="random", sample_rate=0.01),
+        ],
+        "counters": [
+            _counter(),
+            _counter(level="attempt", attempts=1, first_attempt_success=0),
+            _counter(host="ally", outcome="http_error", http_status_class="5xx"),
+        ],
+    }
+
+
+def test_old_activity_payload_gets_exact_optional_defaults() -> None:
+    payload = activity_payload(_generation())
+    for field in ACTIVITY_OPTIONAL_DEFAULTS:
+        payload.pop(field, None)
+    row = OperationalOutboxRow(1, COMMIT_TS, "activity", "gen-old", json.dumps(payload))
+
+    [event] = normalise_operational_event(row)
+
+    assert tuple(key for key in event.row if key != "ingest_version") == ACTIVITY_COLUMNS
+    assert {key: event.row[key] for key in ACTIVITY_OPTIONAL_DEFAULTS} == (
+        ACTIVITY_OPTIONAL_DEFAULTS
+    )
+
+
+def test_old_activity_payload_still_rejects_missing_required_field() -> None:
+    payload = activity_payload(_generation())
+    payload.pop("generation_id")
+    row = OperationalOutboxRow(1, COMMIT_TS, "activity", "gen-old", json.dumps(payload))
+
+    with pytest.raises(ValueError, match="generation_id"):
+        normalise_operational_event(row)
+
+
+def test_client_events_expand_to_complete_deterministic_rows() -> None:
+    payload = _client_payload()
+
+    rows = expand_client_events_payload(payload, COMMIT_TS)
+
+    assert len(rows) == 5
+    requests = [event for event in rows if event.event_kind == "client_request"]
+    counters = [event for event in rows if event.event_kind == "client_counter"]
+    assert len(requests) == 2
+    assert len(counters) == 3
+    expected_request_id = hashlib.sha256(f"{'a' * 64}:{'c' * 32}:r:0".encode()).hexdigest()
+    expected_counter_id = hashlib.sha256(f"{'a' * 64}:{'c' * 32}:c:2".encode()).hexdigest()
+    assert requests[0].row["event_id"] == expected_request_id
+    assert counters[2].row["event_id"] == expected_counter_id
+    assert requests[0].row["attempt_http_status"] == [0, 503, 200]
+    assert requests[0].row["attempt_error_class"] == ["connect_timeout", "", ""]
+    assert requests[0].row["attempt_error_source"] == ["", "router", ""]
+    assert requests[0].row["attempt_should_retry"] == ["true", "false", "absent"]
+    assert requests[0].row["attempt_retry_after_ms"] == [0, 0, 0]
+    assert requests[0].row["attempt_ttfb_ms"] == [0, 50, 50]
+    assert requests[0].row["attempt_request_id"] == [
+        "",
+        "rlog_" + "a" * 32,
+        "",
+    ]
+    assert requests[0].row["first_error_class"] == "connect_timeout"
+    assert requests[0].row["error_source"] == "router"
+    assert requests[0].row["final_host"] == "uptime"
+    assert set(requests[0].row) == {*CLIENT_REQUEST_COLUMNS, "ingest_version"}
+    assert set(counters[0].row) == {*CLIENT_COUNTER_COLUMNS, "ingest_version"}
+
+
+class _Source:
+    def __init__(self, rows: list[OperationalOutboxRow]) -> None:
+        self.rows = rows
+        self.deleted: list[OperationalOutboxRow] = []
+
+    def fetch(self, *, limit: int) -> list[OperationalOutboxRow]:
+        return self.rows[:limit]
+
+    def fetch_shard(self, shard: int, *, limit: int) -> list[OperationalOutboxRow]:
+        return [row for row in self.rows if row.shard == shard][:limit]
+
+    def delete(self, rows: list[OperationalOutboxRow]) -> int:
+        self.deleted.extend(rows)
+        self.rows = [row for row in self.rows if row not in rows]
+        return len(rows)
+
+    def oldest_commit_ts(self) -> dt.datetime | None:
+        return self.rows[0].commit_ts if self.rows else None
+
+
+class _Writer:
+    def __init__(self) -> None:
+        self.batches: list[list[CanonicalOperationalEvent]] = []
+
+    def insert(self, events: list[CanonicalOperationalEvent]) -> None:
+        self.batches.append(events)
+
+
+def _activity_row(*, shard: int = 1) -> OperationalOutboxRow:
+    return OperationalOutboxRow(
+        shard,
+        COMMIT_TS,
+        "activity",
+        "gen-good",
+        json.dumps(activity_payload(_generation())),
+    )
+
+
+def _poison_row(*, shard: int = 1) -> OperationalOutboxRow:
+    return OperationalOutboxRow(shard, COMMIT_TS, "unknown", "bad-1", '{"x":1}')
+
+
+def test_spanner_drain_quarantines_unknown_kind_and_continues() -> None:
+    source = _Source([_poison_row(), _activity_row()])
+    writer = _Writer()
+
+    result = drain_once(source, writer, batch_size=10)
+
+    assert result.inserted == 1
+    assert result.quarantined == 1
+    assert source.rows == []
+    assert [event.event_kind for event in writer.batches[0]] == [
+        "quarantine",
+        "activity",
+    ]
+    quarantine = writer.batches[0][0].row
+    assert quarantine["event_kind"] == "unknown"
+    assert "unsupported operational event kind" in quarantine["reason"]
+
+
+def test_postgres_drain_quarantines_unknown_kind_and_continues() -> None:
+    source = _Source([_poison_row(), _activity_row()])
+    writer = _Writer()
+
+    result = drain_shard_once(source, writer, shard=1, batch_size=10)
+
+    assert result.inserted == 1
+    assert result.quarantined == 1
+    assert result.deleted == 2
+    assert source.rows == []
+
+
+def test_writer_rejects_a_table_outside_its_allowlist() -> None:
+    event = CanonicalOperationalEvent(event_kind="secrets", row={"value": "no"})
+
+    with pytest.raises(ValueError, match="unsupported operational event kind"):
+        ClickHouseOperationalWriter(password="test").insert([event])  # noqa: S106
+
+
+def test_client_event_schemas_are_bounded_and_column_aligned() -> None:
+    replicated = (ROOT / "clickhouse/008_client_events_replicated.sql").read_text()
+    single = (ROOT / "clickhouse/009_client_events_single_node.sql").read_text()
+
+    assert "INTERVAL 90 DAY" in replicated
+    assert "INTERVAL 180 DAY" in replicated
+    assert "INTERVAL 24 MONTH" in replicated
+    assert "INTERVAL 30 DAY" in replicated
+    assert "deliberately NOT archived" in replicated
+    assert replicated.count("ENGINE = ReplicatedReplacingMergeTree") == 3
+    assert "ENGINE = ReplicatedMergeTree" in replicated
+    assert single.count("ENGINE = ReplacingMergeTree") == 3
+    assert "ENGINE = MergeTree" in single
+    for column in ACTIVITY_OPTIONAL_DEFAULTS:
+        assert f"ADD COLUMN IF NOT EXISTS {column}" in replicated
+
+
+def test_normalise_client_events_returns_the_expansion() -> None:
+    row = OperationalOutboxRow(
+        1,
+        COMMIT_TS,
+        "client_events",
+        "batch-1",
+        json.dumps(_client_payload()),
+    )
+
+    assert normalise_operational_event(row) == expand_client_events_payload(
+        _client_payload(), COMMIT_TS
+    )
+
+
+def test_quarantine_reason_is_bounded() -> None:
+    source = _Source([dataclasses.replace(_poison_row(), event_kind="x" * 600)])
+    writer = _Writer()
+
+    drain_once(source, writer, batch_size=1)
+
+    assert len(writer.batches[0][0].row["reason"]) == 500

--- a/tests/test_clickhouse_client_events.py
+++ b/tests/test_clickhouse_client_events.py
@@ -325,3 +325,54 @@ def test_quarantine_reason_is_bounded() -> None:
     drain_once(source, writer, batch_size=1)
 
     assert len(writer.batches[0][0].row["reason"]) == 500
+
+
+def _ddl_columns(ddl: str, table: str) -> tuple[str, ...]:
+    """Column names of one CREATE TABLE block, in declaration order."""
+    import re
+
+    start = ddl.index(f"CREATE TABLE IF NOT EXISTS {table}\n(")
+    body = ddl[start:].split("\n)\n", 1)[0].splitlines()[2:]
+    return tuple(
+        match.group(1)
+        for line in body
+        if (match := re.match(r"^\s+([a-z_]+)\s+\S", line)) is not None
+    )
+
+
+def test_ingester_column_tuples_match_the_ddl_in_order() -> None:
+    """The ingester projects rows by these tuples; the DDL must agree exactly.
+
+    A drifted or reordered column would still insert (JSONEachRow is by name)
+    until a NEW column lands in one place only -- then the drain fails on
+    every client_events row. Pin the two lists to each other, replicated and
+    single-node alike.
+    """
+    for ddl in (
+        (ROOT / "clickhouse/008_client_events_replicated.sql").read_text(),
+        (ROOT / "clickhouse/009_client_events_single_node.sql").read_text(),
+    ):
+        assert _ddl_columns(ddl, "client_request_events") == (
+            *CLIENT_REQUEST_COLUMNS,
+            "ingest_version",
+        )
+        assert _ddl_columns(ddl, "client_minute_counters") == (
+            *CLIENT_COUNTER_COLUMNS,
+            "ingest_version",
+        )
+        assert _ddl_columns(ddl, "operational_outbox_quarantine") == (
+            "shard",
+            "commit_ts",
+            "event_kind",
+            "event_id",
+            "payload",
+            "reason",
+            "quarantined_at",
+        )
+        activity_alters = [
+            line.split("ADD COLUMN IF NOT EXISTS ")[1].split()[0]
+            for line in ddl.splitlines()
+            if "ADD COLUMN IF NOT EXISTS" in line
+        ]
+        assert tuple(activity_alters) == tuple(ACTIVITY_OPTIONAL_DEFAULTS)
+        assert ACTIVITY_COLUMNS[-len(activity_alters) :] == tuple(activity_alters)

--- a/tests/test_clickhouse_client_rollup.py
+++ b/tests/test_clickhouse_client_rollup.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+from clickhouse.rollup_client_events import (
+    aggregate_client_rollups,
+    cap_tenant_requests,
+    client_rollup_id,
+)
+
+START = dt.datetime(2026, 8, 17, 12, tzinfo=dt.UTC)
+
+
+def _counter(tenant: str, **updates: Any) -> dict[str, Any]:
+    value = {
+        "tenant_id": tenant,
+        "bucket_start": START.isoformat(),
+        "synthetic": 0,
+        "sdk": "tr-py",
+        "level": "request",
+        "endpoint": "responses",
+        "host": "apex",
+        "outcome": "ok",
+        "error_class": "",
+        "http_status_class": "2xx",
+        "timeout_phase": "none",
+        "timeout_floor_met": 1,
+        "provider_pinned": 0,
+        "requests": 25,
+        "attempts": 0,
+        "failover_used": 0,
+        "first_attempt_success": 25,
+        "total_ms_hist": {"lt200": 25},
+        "first_event_ms_hist": {"lt100": 25},
+        "tr_fault": 0,
+    }
+    value.update(updates)
+    return value
+
+
+def _coverage(tenant: str, requests: int = 25, synthetic: int = 0) -> dict[str, Any]:
+    return {
+        "tenant_id": tenant,
+        "bucket_start": START.isoformat(),
+        "synthetic": synthetic,
+        "requests": requests,
+    }
+
+
+def test_tenant_cap_is_25_percent_and_reports_the_excess() -> None:
+    allowed, excess = cap_tenant_requests({"large": 80, "small": 20})
+
+    assert allowed == {"large": 25, "small": 20}
+    assert excess == 55
+
+
+def test_rollup_aggregates_distinct_tenants_facets_and_synthetic_policy() -> None:
+    rows = [_counter(f"t{index}") for index in range(4)]
+    rows.append(_counter("synthetic", synthetic=1, requests=50))
+    rows.extend(
+        _counter(
+            f"t{index}",
+            level="attempt",
+            requests=0,
+            attempts=25,
+            first_attempt_success=0,
+        )
+        for index in range(4)
+    )
+    coverage = [_coverage(f"t{index}") for index in range(4)]
+    coverage.append(_coverage("synthetic", requests=50, synthetic=1))
+
+    result = aggregate_client_rollups(
+        rows,
+        coverage,
+        period="5m",
+        period_start=START,
+        computed_at=START + dt.timedelta(minutes=1),
+    )
+
+    total = next(
+        row
+        for row in result
+        if row["scope"] == "fleet" and row["host"] == row["endpoint"] == row["sdk"] == ""
+    )
+    host = next(row for row in result if row["scope"] == "fleet" and row["host"] == "apex")
+    assert total["requests"] == 100
+    assert total["successes"] == 100
+    assert total["distinct_tenants"] == 4
+    assert total["coverage_requests"] == 100
+    assert total["capped_requests"] == 0
+    assert host["attempts"] == 100
+
+
+def test_rollup_id_is_deterministic_over_the_full_key() -> None:
+    arguments = {
+        "period": "hour",
+        "period_start": START,
+        "scope": "fleet",
+        "tenant_id": "",
+        "host": "apex",
+        "endpoint": "",
+        "sdk": "",
+    }
+
+    assert client_rollup_id(**arguments) == client_rollup_id(**arguments)
+    assert client_rollup_id(**arguments) != client_rollup_id(**{**arguments, "host": "ally"})

--- a/tests/test_clickhouse_client_rollup.py
+++ b/tests/test_clickhouse_client_rollup.py
@@ -106,3 +106,75 @@ def test_rollup_id_is_deterministic_over_the_full_key() -> None:
 
     assert client_rollup_id(**arguments) == client_rollup_id(**arguments)
     assert client_rollup_id(**arguments) != client_rollup_id(**{**arguments, "host": "ally"})
+
+
+class _Executor:
+    """Answers the two fetch queries from memory and records the INSERT."""
+
+    def __init__(self, counters: list[dict[str, Any]], coverage: list[dict[str, Any]]) -> None:
+        self._counters = counters
+        self._coverage = coverage
+        self.queries: list[str] = []
+        self.inserted: list[dict[str, Any]] = []
+
+    def query(self, sql: str, *, input_bytes: bytes | None = None) -> bytes:
+        import json
+
+        self.queries.append(sql)
+        if sql.startswith("INSERT INTO"):
+            assert input_bytes is not None
+            self.inserted.extend(json.loads(line) for line in input_bytes.decode().splitlines())
+            return b""
+        rows = self._counters if "client_minute_counters" in sql else self._coverage
+        return "\n".join(json.dumps(row) for row in rows).encode()
+
+
+def test_recompute_covers_six_hours_of_5m_windows_so_late_batches_still_land() -> None:
+    """The recompute lookback equals the 6 h late-arrival cap in fetch_inputs.
+
+    A batch that drains 4 h late (control-plane outage, SDK backoff) lands in
+    the right minute of client_minute_counters; a 3 h lookback would never
+    fold it into that minute's rollup, silently hiding exactly the outage the
+    telemetry exists to measure.
+    """
+    from clickhouse.rollup_client_events import recompute
+
+    now = START + dt.timedelta(hours=5, minutes=30)
+    late = _counter("t1", bucket_start=START.isoformat())  # 5.5 h before now
+    fresh = _counter("t2", bucket_start=(now - dt.timedelta(minutes=10)).isoformat())
+    executor = _Executor([late, fresh], [_coverage("t1"), _coverage("t2")])
+
+    summary = recompute(executor, now=now)  # type: ignore[arg-type]
+
+    assert summary["counter_rows"] == 2
+    fetch = executor.queries[0]
+    assert "INTERVAL 6 HOUR" in fetch  # late-arrival cap
+    five_minute = [row for row in executor.inserted if row["period"] == "5m"]
+    starts = {row["period_start"] for row in five_minute}
+    assert START.isoformat() in starts  # the 5.5 h-old minute was recomputed
+    assert all(row["methodology_version"] == 1 for row in executor.inserted)
+    tenant_late = [
+        row
+        for row in five_minute
+        if row["scope"] == "tenant"
+        and row["tenant_id"] == "t1"
+        and row["host"] == ""
+        and row["endpoint"] == ""
+        and row["sdk"] == ""
+    ]
+    assert tenant_late and tenant_late[0]["requests"] == 25
+    # Windows without counters are not written (ReplacingMergeTree cannot
+    # delete, and counters are append-only), so the empty windows in between
+    # produce no rows.
+    assert len(starts) == 2
+
+
+def test_recompute_dry_run_computes_but_never_inserts() -> None:
+    from clickhouse.rollup_client_events import recompute
+
+    executor = _Executor([_counter("t1")], [_coverage("t1")])
+    summary = recompute(executor, now=START + dt.timedelta(minutes=7), dry_run=True)  # type: ignore[arg-type]
+
+    assert summary["rollups"] > 0
+    assert executor.inserted == []
+    assert not any(sql.startswith("INSERT INTO") for sql in executor.queries)

--- a/tests/test_clickhouse_node_provisioning.py
+++ b/tests/test_clickhouse_node_provisioning.py
@@ -75,7 +75,7 @@ def test_rollout_prefers_private_clickhouse_load_balancer() -> None:
     script = (ROOT / "scripts/deploy/rollout.sh").read_text()
 
     assert "compute addresses describe tr-clickhouse-ilb" in script
-    assert "TR_PROVIDER_ANALYTICS_CLICKHOUSE_URL=${PROVIDER_ANALYTICS_CLICKHOUSE_URL}" in script
+    assert 'TR_PROVIDER_ANALYTICS_CLICKHOUSE_URL=${PROVIDER_ANALYTICS_CLICKHOUSE_URL}' in script
 
 
 def test_operational_deploy_moves_benchmark_code_schema_and_replay_together() -> None:
@@ -85,7 +85,9 @@ def test_operational_deploy_moves_benchmark_code_schema_and_replay_together() ->
     stop = script.index("systemctl stop tr-clickhouse-operational-ingest.service")
     migration = script.index('log "adding workspace attribution to benchmark samples"')
     replay = script.index("clickhouse.backfill_benchmark_samples")
-    restart = script.index("systemctl start tr-clickhouse-operational-ingest.service", replay)
+    restart = script.index(
+        "systemctl start tr-clickhouse-operational-ingest.service", replay
+    )
 
     assert upload < stop < migration < replay < restart
     assert "007_benchmark_samples_workspace_id.sql" in script
@@ -132,7 +134,7 @@ def test_stockholm_refuses_a_cidr_that_overlaps_paris() -> None:
 
     assert "import ipaddress" in script
     assert ".overlaps(" in script
-    assert 'aws ec2 describe-vpcs --region "$PARIS_REGION"' in script
+    assert "aws ec2 describe-vpcs --region \"$PARIS_REGION\"" in script
 
 
 def test_stockholm_security_group_admits_only_the_paris_vpc() -> None:
@@ -155,9 +157,7 @@ def test_stockholm_repeats_the_hard_won_details_from_the_paris_node() -> None:
 
     # The users.d ownership fix: the server drops privileges, so a root-owned
     # file is unreadable to it and it dies without naming the permission.
-    assert (
-        "chown clickhouse:clickhouse /etc/clickhouse-server/users.d/default-password.xml" in script
-    )
+    assert "chown clickhouse:clickhouse /etc/clickhouse-server/users.d/default-password.xml" in script
     # IMDSv2 required, not optional.
     assert "HttpTokens=required" in script
     assert "X-aws-ec2-metadata-token-ttl-seconds" in script
@@ -257,14 +257,14 @@ def test_stockholm_builds_the_path_against_the_subnet_the_drain_runs_in() -> Non
 
     # Derived from the instance that actually runs the drain, by tag.
     assert 'PARIS_NODE_NAME="${PARIS_NODE_NAME:-tr-eu-clickhouse-1}"' in script
-    assert "Name=tag:Name,Values=$PARIS_NODE_NAME" in script
+    assert 'Name=tag:Name,Values=$PARIS_NODE_NAME' in script
     assert "Reservations[0].Instances[0].SubnetId" in script
     # And never from an arbitrary subnet of the VPC. The one surviving
     # `Subnets[0].SubnetId` is the Stockholm lookup, which is deterministic
     # because it filters on this script's own Name tag rather than taking
     # whatever the API returns first.
     assert statements.count("Subnets[0].SubnetId") == 1
-    assert "Name=tag:Name,Values=$VPC_NAME-a" in statements
+    assert 'Name=tag:Name,Values=$VPC_NAME-a' in statements
     assert 'describe-subnets --region "$PARIS_REGION" \\\n      --filters' not in statements
     # A subnet that is not in the Paris VPC is refused rather than used.
     assert "$PARIS_SUBNET_VPC" in script
@@ -283,7 +283,9 @@ def test_stockholm_env_block_contains_no_shell_substitution() -> None:
     """
     lines = STOCKHOLM.read_text().splitlines()
     env_lines = [
-        line for line in lines if "CH_REPLICA_PASSWORD=" in line or "_CLICKHOUSE_REPLICA_" in line
+        line
+        for line in lines
+        if "CH_REPLICA_PASSWORD=" in line or "_CLICKHOUSE_REPLICA_" in line
     ]
     assert env_lines, "the runbook must still print the replica env block"
     for line in env_lines:

--- a/tests/test_clickhouse_node_provisioning.py
+++ b/tests/test_clickhouse_node_provisioning.py
@@ -75,7 +75,7 @@ def test_rollout_prefers_private_clickhouse_load_balancer() -> None:
     script = (ROOT / "scripts/deploy/rollout.sh").read_text()
 
     assert "compute addresses describe tr-clickhouse-ilb" in script
-    assert 'TR_PROVIDER_ANALYTICS_CLICKHOUSE_URL=${PROVIDER_ANALYTICS_CLICKHOUSE_URL}' in script
+    assert "TR_PROVIDER_ANALYTICS_CLICKHOUSE_URL=${PROVIDER_ANALYTICS_CLICKHOUSE_URL}" in script
 
 
 def test_operational_deploy_moves_benchmark_code_schema_and_replay_together() -> None:
@@ -85,9 +85,7 @@ def test_operational_deploy_moves_benchmark_code_schema_and_replay_together() ->
     stop = script.index("systemctl stop tr-clickhouse-operational-ingest.service")
     migration = script.index('log "adding workspace attribution to benchmark samples"')
     replay = script.index("clickhouse.backfill_benchmark_samples")
-    restart = script.index(
-        "systemctl start tr-clickhouse-operational-ingest.service", replay
-    )
+    restart = script.index("systemctl start tr-clickhouse-operational-ingest.service", replay)
 
     assert upload < stop < migration < replay < restart
     assert "007_benchmark_samples_workspace_id.sql" in script
@@ -134,7 +132,7 @@ def test_stockholm_refuses_a_cidr_that_overlaps_paris() -> None:
 
     assert "import ipaddress" in script
     assert ".overlaps(" in script
-    assert "aws ec2 describe-vpcs --region \"$PARIS_REGION\"" in script
+    assert 'aws ec2 describe-vpcs --region "$PARIS_REGION"' in script
 
 
 def test_stockholm_security_group_admits_only_the_paris_vpc() -> None:
@@ -157,7 +155,9 @@ def test_stockholm_repeats_the_hard_won_details_from_the_paris_node() -> None:
 
     # The users.d ownership fix: the server drops privileges, so a root-owned
     # file is unreadable to it and it dies without naming the permission.
-    assert "chown clickhouse:clickhouse /etc/clickhouse-server/users.d/default-password.xml" in script
+    assert (
+        "chown clickhouse:clickhouse /etc/clickhouse-server/users.d/default-password.xml" in script
+    )
     # IMDSv2 required, not optional.
     assert "HttpTokens=required" in script
     assert "X-aws-ec2-metadata-token-ttl-seconds" in script
@@ -257,14 +257,14 @@ def test_stockholm_builds_the_path_against_the_subnet_the_drain_runs_in() -> Non
 
     # Derived from the instance that actually runs the drain, by tag.
     assert 'PARIS_NODE_NAME="${PARIS_NODE_NAME:-tr-eu-clickhouse-1}"' in script
-    assert 'Name=tag:Name,Values=$PARIS_NODE_NAME' in script
+    assert "Name=tag:Name,Values=$PARIS_NODE_NAME" in script
     assert "Reservations[0].Instances[0].SubnetId" in script
     # And never from an arbitrary subnet of the VPC. The one surviving
     # `Subnets[0].SubnetId` is the Stockholm lookup, which is deterministic
     # because it filters on this script's own Name tag rather than taking
     # whatever the API returns first.
     assert statements.count("Subnets[0].SubnetId") == 1
-    assert 'Name=tag:Name,Values=$VPC_NAME-a' in statements
+    assert "Name=tag:Name,Values=$VPC_NAME-a" in statements
     assert 'describe-subnets --region "$PARIS_REGION" \\\n      --filters' not in statements
     # A subnet that is not in the Paris VPC is refused rather than used.
     assert "$PARIS_SUBNET_VPC" in script
@@ -283,9 +283,7 @@ def test_stockholm_env_block_contains_no_shell_substitution() -> None:
     """
     lines = STOCKHOLM.read_text().splitlines()
     env_lines = [
-        line
-        for line in lines
-        if "CH_REPLICA_PASSWORD=" in line or "_CLICKHOUSE_REPLICA_" in line
+        line for line in lines if "CH_REPLICA_PASSWORD=" in line or "_CLICKHOUSE_REPLICA_" in line
     ]
     assert env_lines, "the runbook must still print the replica env block"
     for line in env_lines:
@@ -320,23 +318,22 @@ def test_stockholm_backfill_runs_in_the_direction_that_is_actually_open() -> Non
 
 
 def test_stockholm_states_which_tables_the_second_copy_covers() -> None:
-    """The drain replicates the two tables it drains, not all four in the DDL.
-
-    006 creates activity_generations, synthetic_probe_samples,
-    synthetic_status_rollups and public_analytics_snapshots; EVENT_TABLES maps
-    only the first two. Nothing on this cloud writes the other two today, but
-    "a second, independent copy of that history" is a claim that has to name
-    its own edges rather than let a reader assume all four.
-    """
+    """The drain names every ingested table and excludes derived products."""
     from clickhouse.ingest_operational_outbox import EVENT_TABLES
 
     script = STOCKHOLM.read_text()
 
     assert "COVERAGE:" in script
-    for table in EVENT_TABLES.values():
+    tables = {
+        table
+        for value in EVENT_TABLES.values()
+        for table in ((value,) if isinstance(value, str) else value)
+    }
+    for table in tables:
         assert table in script
     assert "does NOT write" in script
     assert "synthetic_status_rollups" in script
+    assert "client_availability_rollups" in script
     assert "public_analytics_snapshots" in script
 
 

--- a/tests/test_clickhouse_operational_deploy.py
+++ b/tests/test_clickhouse_operational_deploy.py
@@ -41,12 +41,23 @@ def test_operational_deploy_backfills_before_starting_live_ingest() -> None:
     assert "clickhouse_replicate_rollups.sh" in script
     assert "clickhouse_operational_analytics_finalize.sh --apply" in script
     assert "systemctl start tr-clickhouse-operational-parity.service" not in script
+    assert "008_client_events_replicated.sql" in script
+    assert "tr-clickhouse-client-rollup.service" in script
+    assert "tr-clickhouse-client-rollup.timer" in script
+    assert "systemctl enable" in script
+    assert 'id_column="event_id"' in script
+
+
+def test_client_telemetry_single_node_schema_is_applied_with_operational_schema() -> None:
+    script = (ROOT / "scripts/deploy/aws_eu_north_clickhouse.sh").read_text()
+
+    assert "006_operational_analytics_single_node.sql" in script
+    assert "009_client_events_single_node.sql" in script
+    assert "${CLIENT_SCHEMA}" in script
 
 
 def test_operational_finalize_requires_live_outbox_before_closing_gap() -> None:
-    script = (
-        ROOT / "scripts/deploy/clickhouse_operational_analytics_finalize.sh"
-    ).read_text()
+    script = (ROOT / "scripts/deploy/clickhouse_operational_analytics_finalize.sh").read_text()
     assert "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED" in script
     assert "--skip-synthetic --skip-rollups" in script
     assert "--recent-limit 20000 --skip-activity --skip-rollups" in script
@@ -98,9 +109,7 @@ def test_cutover_requires_soak_logs_queue_replica_and_positive_parity() -> None:
 
 
 def test_operational_parity_worker_has_a_bounded_runtime() -> None:
-    service = (
-        ROOT / "clickhouse/tr-clickhouse-operational-parity.service"
-    ).read_text()
+    service = (ROOT / "clickhouse/tr-clickhouse-operational-parity.service").read_text()
     assert "TimeoutStartSec=5m" in service
 
 

--- a/tests/test_clickhouse_operational_deploy.py
+++ b/tests/test_clickhouse_operational_deploy.py
@@ -57,7 +57,9 @@ def test_client_telemetry_single_node_schema_is_applied_with_operational_schema(
 
 
 def test_operational_finalize_requires_live_outbox_before_closing_gap() -> None:
-    script = (ROOT / "scripts/deploy/clickhouse_operational_analytics_finalize.sh").read_text()
+    script = (
+        ROOT / "scripts/deploy/clickhouse_operational_analytics_finalize.sh"
+    ).read_text()
     assert "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED" in script
     assert "--skip-synthetic --skip-rollups" in script
     assert "--recent-limit 20000 --skip-activity --skip-rollups" in script
@@ -109,7 +111,9 @@ def test_cutover_requires_soak_logs_queue_replica_and_positive_parity() -> None:
 
 
 def test_operational_parity_worker_has_a_bounded_runtime() -> None:
-    service = (ROOT / "clickhouse/tr-clickhouse-operational-parity.service").read_text()
+    service = (
+        ROOT / "clickhouse/tr-clickhouse-operational-parity.service"
+    ).read_text()
     assert "TimeoutStartSec=5m" in service
 
 

--- a/tests/test_client_reliability.py
+++ b/tests/test_client_reliability.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+from typing import Any
+
+import pytest
+
+from trusted_router.client_reliability import (
+    METHODOLOGY_VERSION,
+    availability,
+    build_client_reliability,
+    classify_tr_fault,
+    is_excluded,
+)
+
+
+def _facts(**updates: Any) -> dict[str, Any]:
+    value = {
+        "level": "request",
+        "outcome": "transport_error",
+        "error_class": "dns",
+        "error_source": "unknown",
+        "http_status_class_or_status": "none",
+        "host": "apex",
+        "provider_pinned": False,
+        "timeout_phase": "none",
+        "timeout_floor_met": True,
+    }
+    value.update(updates)
+    return value
+
+
+@pytest.mark.parametrize(
+    ("updates", "expected"),
+    [
+        ({"error_class": "dns"}, True),
+        ({"error_class": "tls"}, True),
+        ({"error_class": "connect_refused"}, True),
+        ({"error_class": "connect_timeout"}, True),
+        ({"error_class": "connect_error"}, True),
+        ({"error_class": "reset"}, True),
+        ({"error_class": "io_error"}, True),
+        ({"error_class": "protocol_error"}, True),
+        ({"host": "custom"}, False),
+        ({"error_class": "pool_timeout"}, False),
+        ({"error_class": "proxy_error"}, False),
+        (
+            {
+                "outcome": "http_error",
+                "error_class": None,
+                "http_status_class_or_status": 503,
+            },
+            True,
+        ),
+        (
+            {
+                "outcome": "http_error",
+                "error_class": None,
+                "http_status_class_or_status": "5xx",
+                "provider_pinned": True,
+                "error_source": "provider",
+            },
+            False,
+        ),
+        (
+            {
+                "outcome": "timeout",
+                "error_class": "read_timeout",
+                "timeout_phase": "connect",
+                "timeout_floor_met": True,
+            },
+            True,
+        ),
+        (
+            {
+                "outcome": "timeout",
+                "error_class": "read_timeout",
+                "timeout_phase": "first_byte",
+                "timeout_floor_met": False,
+            },
+            False,
+        ),
+        (
+            {
+                "outcome": "timeout",
+                "error_class": "read_timeout",
+                "timeout_phase": "total",
+            },
+            False,
+        ),
+        ({"outcome": "stream_broken", "error_class": None}, True),
+        ({"error_class": "stream_stalled", "timeout_floor_met": True}, True),
+        ({"error_class": "stream_stalled", "timeout_floor_met": False}, False),
+        ({"error_class": "unknown"}, True),
+        ({"outcome": "aborted", "error_class": "unknown"}, False),
+        (
+            {
+                "outcome": "http_error",
+                "error_class": None,
+                "http_status_class_or_status": "4xx",
+            },
+            False,
+        ),
+        (
+            {
+                "outcome": "http_error",
+                "error_class": None,
+                "http_status_class_or_status": "429",
+            },
+            False,
+        ),
+    ],
+)
+def test_methodology_v1_golden_table(updates: dict[str, Any], expected: bool) -> None:
+    assert classify_tr_fault(**_facts(**updates)) is expected
+
+
+def test_disclosed_exclusions_cover_every_methodology_branch() -> None:
+    assert is_excluded(**_facts(host="custom"))
+    assert is_excluded(**_facts(outcome="aborted"))
+    assert is_excluded(
+        **_facts(
+            outcome="http_error",
+            error_class=None,
+            http_status_class_or_status="429",
+        )
+    )
+    assert is_excluded(**_facts(error_class="pool_timeout"))
+    assert is_excluded(
+        **_facts(
+            outcome="timeout",
+            timeout_phase="first_byte",
+            timeout_floor_met=False,
+        )
+    )
+
+
+def _rollup(**updates: Any) -> dict[str, Any]:
+    value = {
+        "host": "",
+        "endpoint": "",
+        "sdk": "",
+        "requests": 1_000,
+        "successes": 990,
+        "tr_fault_failures": 10,
+        "excluded_failures": 5,
+        "aborted": 1,
+        "attempts": 1_010,
+        "attempt_tr_fault": 4,
+        "distinct_tenants": 3,
+        "coverage_requests": 1_100,
+        "total_ms_hist": {"lt100": 500, "lt200": 450, "lt400": 50},
+        "first_event_ms_hist": {"lt100": 700, "lt200": 300},
+    }
+    value.update(updates)
+    return value
+
+
+def test_snapshot_gate_privacy_and_histogram_percentiles() -> None:
+    rows = {
+        "5m": [_rollup(requests=999)],
+        "1h": [_rollup(distinct_tenants=2)],
+        "24h": [
+            _rollup(tenant_id="private-tenant"),
+            _rollup(host="apex", attempts=100, attempt_tr_fault=2, requests=0),
+            _rollup(sdk="tr-py", requests=750),
+        ],
+        "7d": [],
+        "30d": [],
+    }
+
+    snapshot = build_client_reliability(
+        rows,
+        dt.datetime(2026, 8, 17, 12, tzinfo=dt.UTC),
+    )
+
+    assert snapshot["methodology_version"] == METHODOLOGY_VERSION
+    assert snapshot["published"] is False
+    assert snapshot["windows"]["5m"]["availability_percent"] is None
+    assert snapshot["windows"]["1h"]["availability_percent"] is None
+    assert snapshot["windows"]["24h"]["availability_percent"] == 99.0
+    assert snapshot["windows"]["24h"]["p50_total_ms"] == 100
+    assert snapshot["windows"]["24h"]["p95_total_ms"] == 200
+    assert snapshot["windows"]["24h"]["p50_ttft_ms"] == 100
+    assert snapshot["by_host_24h"]["apex"] == {
+        "attempts": 100,
+        "attempt_tr_fault": 2,
+        "rate": 0.02,
+    }
+    assert snapshot["by_sdk_24h"] == {"tr-py": 750}
+    assert "private-tenant" not in json.dumps(snapshot, sort_keys=True)
+
+
+def test_availability_has_an_empty_denominator_sentinel() -> None:
+    assert availability(99, 1) == 0.99
+    assert availability(0, 0) is None

--- a/tests/test_operational_analytics.py
+++ b/tests/test_operational_analytics.py
@@ -99,9 +99,7 @@ def test_activity_payload_uses_surrogates_and_omits_content_and_raw_ids() -> Non
     payload = activity_payload(generation)
     encoded = json.dumps(payload, sort_keys=True)
 
-    assert payload["tenant_id"] == analytics_surrogate(
-        "workspace", generation.workspace_id
-    )
+    assert payload["tenant_id"] == analytics_surrogate("workspace", generation.workspace_id)
     assert payload["key_id"] == analytics_surrogate("api-key", generation.key_hash)
     assert generation.workspace_id not in encoded
     assert generation.key_hash not in encoded
@@ -115,17 +113,13 @@ def test_activity_payload_uses_surrogates_and_omits_content_and_raw_ids() -> Non
 def test_operational_outbox_enqueue_is_sharded_and_commit_timestamped() -> None:
     database = _Database()
     generation = _generation()
-    SpannerOperationalAnalyticsOutbox(database, _ParamTypes()).enqueue_activity(
-        generation
-    )
+    SpannerOperationalAnalyticsOutbox(database, _ParamTypes()).enqueue_activity(generation)
 
     [(sql, params, param_types)] = database.transaction.calls
     assert "PENDING_COMMIT_TIMESTAMP()" in sql
     assert params["event_kind"] == "activity"
     assert params["event_id"] == generation.id
-    assert params["shard"] == operational_analytics_shard(
-        f"activity:{generation.id}"
-    )
+    assert params["shard"] == operational_analytics_shard(f"activity:{generation.id}")
     assert json.loads(params["payload"])["tenant_id"] != generation.workspace_id
     assert param_types == {
         "shard": "INT64",
@@ -220,7 +214,13 @@ def test_clickhouse_balanced_benchmark_reader_uses_one_window_query() -> None:
 
 @pytest.mark.parametrize(
     "snapshot_name",
-    ["leaderboard", "apps", "video_leaderboard", "status_inputs"],
+    [
+        "leaderboard",
+        "apps",
+        "video_leaderboard",
+        "status_inputs",
+        "client_reliability",
+    ],
 )
 def test_public_snapshot_reads_newest_revision_across_month_partitions(
     snapshot_name: str,
@@ -242,9 +242,7 @@ def test_public_snapshot_reads_newest_revision_across_month_partitions(
         transport=httpx.MockTransport(handler),
     )
 
-    assert client.public_snapshot(snapshot_name) == {
-        "generated_at": "2026-08-01T00:00:00Z"
-    }
+    assert client.public_snapshot(snapshot_name) == {"generated_at": "2026-08-01T00:00:00Z"}
 
 
 def test_public_snapshot_rejects_unknown_products_without_querying() -> None:
@@ -288,15 +286,13 @@ def _outbox_row() -> OperationalOutboxRow:
 
 
 def test_operational_normalizer_adds_commit_version_and_rejects_unknown_kind() -> None:
-    event = normalise_operational_event(_outbox_row())
+    [event] = normalise_operational_event(_outbox_row())
     assert event.event_kind == "activity"
     assert event.row["generation_id"] == _generation().id
     assert event.row["ingest_version"].startswith("2026-07-31T12:35:00")
 
     with pytest.raises(ValueError, match="unsupported operational event kind"):
-        normalise_operational_event(
-            dataclasses.replace(_outbox_row(), event_kind="prompt")
-        )
+        normalise_operational_event(dataclasses.replace(_outbox_row(), event_kind="prompt"))
 
 
 class _Source:

--- a/tests/test_operational_analytics.py
+++ b/tests/test_operational_analytics.py
@@ -99,7 +99,9 @@ def test_activity_payload_uses_surrogates_and_omits_content_and_raw_ids() -> Non
     payload = activity_payload(generation)
     encoded = json.dumps(payload, sort_keys=True)
 
-    assert payload["tenant_id"] == analytics_surrogate("workspace", generation.workspace_id)
+    assert payload["tenant_id"] == analytics_surrogate(
+        "workspace", generation.workspace_id
+    )
     assert payload["key_id"] == analytics_surrogate("api-key", generation.key_hash)
     assert generation.workspace_id not in encoded
     assert generation.key_hash not in encoded
@@ -113,13 +115,17 @@ def test_activity_payload_uses_surrogates_and_omits_content_and_raw_ids() -> Non
 def test_operational_outbox_enqueue_is_sharded_and_commit_timestamped() -> None:
     database = _Database()
     generation = _generation()
-    SpannerOperationalAnalyticsOutbox(database, _ParamTypes()).enqueue_activity(generation)
+    SpannerOperationalAnalyticsOutbox(database, _ParamTypes()).enqueue_activity(
+        generation
+    )
 
     [(sql, params, param_types)] = database.transaction.calls
     assert "PENDING_COMMIT_TIMESTAMP()" in sql
     assert params["event_kind"] == "activity"
     assert params["event_id"] == generation.id
-    assert params["shard"] == operational_analytics_shard(f"activity:{generation.id}")
+    assert params["shard"] == operational_analytics_shard(
+        f"activity:{generation.id}"
+    )
     assert json.loads(params["payload"])["tenant_id"] != generation.workspace_id
     assert param_types == {
         "shard": "INT64",
@@ -242,7 +248,9 @@ def test_public_snapshot_reads_newest_revision_across_month_partitions(
         transport=httpx.MockTransport(handler),
     )
 
-    assert client.public_snapshot(snapshot_name) == {"generated_at": "2026-08-01T00:00:00Z"}
+    assert client.public_snapshot(snapshot_name) == {
+        "generated_at": "2026-08-01T00:00:00Z"
+    }
 
 
 def test_public_snapshot_rejects_unknown_products_without_querying() -> None:

--- a/tests/test_operational_analytics_dual_write.py
+++ b/tests/test_operational_analytics_dual_write.py
@@ -144,6 +144,9 @@ class _Fleet:
     def stored(self, host: str) -> list[dict[str, Any]]:
         collapsed: dict[tuple[Any, ...], dict[str, Any]] = {}
         for call in self.accepted(host):
+            query = call.command[call.command.index("--query") + 1]
+            if "INSERT INTO activity_generations" not in query:
+                continue
             for row in call.rows:
                 # activity_generations ORDER BY (tenant_id, created_at, generation_id)
                 key = (row["tenant_id"], row["created_at"], row["generation_id"])
@@ -217,9 +220,7 @@ class _Source:
     ) -> list[OperationalOutboxRow]:
         candidates = [row for row in self.rows if row.shard == shard]
         if after is not None:
-            candidates = [
-                row for row in candidates if (row.event_kind, row.event_id) > after
-            ]
+            candidates = [row for row in candidates if (row.event_kind, row.event_id) > after]
         candidates.sort(key=lambda row: (row.event_kind, row.event_id))
         return candidates[:limit]
 
@@ -632,9 +633,7 @@ def test_the_cursor_never_lets_a_row_be_deleted_for_only_one_node(
         drain_once(source, _dual_writer(), batch_size=2, shard_count=1, cursors=cursors)
 
     assert source.delete_calls == []
-    assert {row.event_id for row in source.rows} == {
-        f"gen-keep-{index:04d}" for index in range(6)
-    }
+    assert {row.event_id for row in source.rows} == {f"gen-keep-{index:04d}" for index in range(6)}
 
 
 def test_the_backlog_is_delivered_and_deleted_once_the_node_returns(
@@ -666,16 +665,13 @@ def test_the_backlog_is_delivered_and_deleted_once_the_node_returns(
     assert len(fleet.stored("local")) == 6
 
 
-def test_a_poison_batch_no_longer_blocks_the_rest_of_its_shard(
+def test_a_poison_batch_is_quarantined_and_does_not_block_its_shard(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Same root cause, non-ClickHouse trigger.
 
-    A payload this build cannot normalise fails its batch, so the batch is
-    never deleted -- and with an unpaged read that one row blocked its shard's
-    window permanently, taking every well-formed row behind it with it. The
-    cursor steps over the bad batch; the bad rows stay queued for a build that
-    can read them.
+    A payload this build cannot normalise is written to the quarantine table
+    and deleted with the healthy rows, so it cannot crash-loop the drainer.
     """
     fleet = _Fleet()
     fleet.install(monkeypatch)
@@ -690,18 +686,19 @@ def test_a_poison_batch_no_longer_blocks_the_rest_of_its_shard(
     source = _Source([poison, *healthy])
     cursors: dict[int, tuple[str, str]] = {}
 
-    # Progress is not free: a delivered batch resets the cursor to the head, so
-    # the unreadable batch is re-attempted before each good one. That is the
-    # deliberate trade -- the healthy path must read from the head exactly as it
-    # always did -- and it is bounded work, not a block. Before the cursor, the
-    # good rows behind this one were delivered NEVER, at any sweep count.
     for _ in range(8):
         drain_once(source, _dual_writer(), batch_size=1, shard_count=1, cursors=cursors)
 
     delivered = {row["generation_id"] for row in fleet.stored("local")}
     assert delivered == {f"gen-{index:04d}" for index in range(1, 4)}
-    # The unreadable row is still queued -- not delivered, and not dropped.
-    assert [row.event_id for row in source.rows] == ["gen-0000-poison"]
+    assert source.rows == []
+    quarantine_calls = [
+        call
+        for call in fleet.accepted("local")
+        if "INSERT INTO operational_outbox_quarantine"
+        in call.command[call.command.index("--query") + 1]
+    ]
+    assert quarantine_calls[0].rows[0]["event_id"] == "gen-0000-poison"
 
 
 def test_a_hard_down_target_is_skipped_after_a_few_failures_in_one_sweep(
@@ -870,9 +867,7 @@ def test_the_replacing_engine_backing_this_fake_is_real() -> None:
     schema = (ROOT / "clickhouse/006_operational_analytics_single_node.sql").read_text()
     # Comments stripped: the header explains at length why Keeper is NOT used
     # here, and the assertions below are about the statements, not the prose.
-    ddl = "\n".join(
-        line for line in schema.splitlines() if not line.strip().startswith("--")
-    )
+    ddl = "\n".join(line for line in schema.splitlines() if not line.strip().startswith("--"))
 
     assert ddl.count("ENGINE = ReplacingMergeTree(ingest_version)") == 4
     # Explicitly NOT the Replicated variant: two regions cannot form a Keeper
@@ -1057,7 +1052,7 @@ def test_a_misconfigured_replica_stops_the_drain_before_it_reads_anything(
 def test_the_configured_copies_are_logged_at_startup(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """"How many copies is this actually keeping?" must be answerable from the
+    """ "How many copies is this actually keeping?" must be answerable from the
     log, not from reading the environment file over someone's shoulder."""
     caplog.set_level("INFO")
 
@@ -1100,9 +1095,7 @@ def test_an_alarm_threshold_that_disables_the_alarm_is_refused(
     """
     for value in ("0", "-1"):
         with pytest.raises(SystemExit) as exit_info:
-            _run_main(
-                monkeypatch, DUAL_ENV, oldest=None, argv=["--max-lag-seconds", value]
-            )
+            _run_main(monkeypatch, DUAL_ENV, oldest=None, argv=["--max-lag-seconds", value])
         assert exit_info.value.code == drain_module.CONFIG_EXIT_CODE
 
 

--- a/tests/test_operational_analytics_dual_write.py
+++ b/tests/test_operational_analytics_dual_write.py
@@ -220,7 +220,9 @@ class _Source:
     ) -> list[OperationalOutboxRow]:
         candidates = [row for row in self.rows if row.shard == shard]
         if after is not None:
-            candidates = [row for row in candidates if (row.event_kind, row.event_id) > after]
+            candidates = [
+                row for row in candidates if (row.event_kind, row.event_id) > after
+            ]
         candidates.sort(key=lambda row: (row.event_kind, row.event_id))
         return candidates[:limit]
 
@@ -239,7 +241,8 @@ def _dual_writer() -> Any:
 
 
 def _event(event_id: str = "gen-1") -> Any:
-    return normalise_operational_event(_row(event_id))
+    [event] = normalise_operational_event(_row(event_id))
+    return event
 
 
 # --------------------------------------------------------------------------
@@ -633,7 +636,9 @@ def test_the_cursor_never_lets_a_row_be_deleted_for_only_one_node(
         drain_once(source, _dual_writer(), batch_size=2, shard_count=1, cursors=cursors)
 
     assert source.delete_calls == []
-    assert {row.event_id for row in source.rows} == {f"gen-keep-{index:04d}" for index in range(6)}
+    assert {row.event_id for row in source.rows} == {
+        f"gen-keep-{index:04d}" for index in range(6)
+    }
 
 
 def test_the_backlog_is_delivered_and_deleted_once_the_node_returns(
@@ -867,7 +872,9 @@ def test_the_replacing_engine_backing_this_fake_is_real() -> None:
     schema = (ROOT / "clickhouse/006_operational_analytics_single_node.sql").read_text()
     # Comments stripped: the header explains at length why Keeper is NOT used
     # here, and the assertions below are about the statements, not the prose.
-    ddl = "\n".join(line for line in schema.splitlines() if not line.strip().startswith("--"))
+    ddl = "\n".join(
+        line for line in schema.splitlines() if not line.strip().startswith("--")
+    )
 
     assert ddl.count("ENGINE = ReplacingMergeTree(ingest_version)") == 4
     # Explicitly NOT the Replicated variant: two regions cannot form a Keeper
@@ -1052,7 +1059,7 @@ def test_a_misconfigured_replica_stops_the_drain_before_it_reads_anything(
 def test_the_configured_copies_are_logged_at_startup(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """ "How many copies is this actually keeping?" must be answerable from the
+    """"How many copies is this actually keeping?" must be answerable from the
     log, not from reading the environment file over someone's shoulder."""
     caplog.set_level("INFO")
 
@@ -1095,7 +1102,9 @@ def test_an_alarm_threshold_that_disables_the_alarm_is_refused(
     """
     for value in ("0", "-1"):
         with pytest.raises(SystemExit) as exit_info:
-            _run_main(monkeypatch, DUAL_ENV, oldest=None, argv=["--max-lag-seconds", value])
+            _run_main(
+                monkeypatch, DUAL_ENV, oldest=None, argv=["--max-lag-seconds", value]
+            )
         assert exit_info.value.code == drain_module.CONFIG_EXIT_CODE
 
 

--- a/tests/test_public_analytics_snapshots.py
+++ b/tests/test_public_analytics_snapshots.py
@@ -128,6 +128,7 @@ def test_snapshot_builder_precomputes_video_and_status_inputs() -> None:
 
     assert set(snapshots) == {
         "apps",
+        "client_reliability",
         "leaderboard",
         "status_inputs",
         "video_leaderboard",
@@ -135,6 +136,7 @@ def test_snapshot_builder_precomputes_video_and_status_inputs() -> None:
     assert snapshots["video_leaderboard"]["total_samples"] == 1
     assert snapshots["status_inputs"]["samples"][0]["id"] == "status-1"
     assert snapshots["status_inputs"]["rollups"][0]["id"] == "rollup-1"
+    assert snapshots["client_reliability"]["published"] is False
 
 
 def test_snapshot_builder_encodes_clickhouse_array_parameters() -> None:


### PR DESCRIPTION
## Why
Node-side landing zone for client-observed reliability telemetry (see `docs/client-telemetry.md`, the cross-repo contract every SDK PR cites). Must land **before** the control plane enqueues the new `client_events` outbox kind (R-PR3) or emits the new activity keys as declared columns — otherwise the ingester's hard-fail on unknown kinds crash-loops the drainer (poison-row class).

## What
- **`docs/client-telemetry.md`** — contract v1: `x-tr-client` grammar, response-id contract, beacon endpoint + schema + enums + bounds, methodology v1, per-SDK emit points / header sites / out-of-engine precedents, opt-out semantics, rollout ordering.
- **DDL** `clickhouse/008_client_events_replicated.sql` + `009_client_events_single_node.sql`: `activity_generations` += 18 additive columns with DEFAULTs; `client_request_events` (90 d), `client_minute_counters` (180 d), `client_availability_rollups` (24 mo), `operational_outbox_quarantine` (30 d). Raw client tables deliberately NOT archived (rollups are the retained artefact).
- **Ingester** (`ingest_operational_outbox.py` + Postgres twin): `ACTIVITY_OPTIONAL_DEFAULTS` so pre-deploy outbox rows still drain; `normalise_operational_event` → list (1:N fan-out for `client_events` via pure `expand_client_events_payload`, server-computed sha256 row ids); **hardening:** unknown kind / bad payload → `operational_outbox_quarantine` row + deleted with the batch + `quarantined=` metric, never a crash-loop.
- **Rollup** `rollup_client_events.py` + systemd unit/timer (5 min): fleet + tenant scopes from exact minute counters, per-tenant 25 % cap, `distinct_tenants`, coverage vs `activity_generations`, 6 h lookback matching the late-arrival cap.
- **Methodology** `src/trusted_router/client_reliability.py` (`METHODOLOGY_VERSION=1`, `classify_tr_fault`, `is_excluded`, `build_client_reliability`, publication gate ≥1000 requests & ≥3 tenants).
- **Snapshot skeleton** `client_reliability` in `build_public_snapshots.py` (+ read allowlist), `published: false`.
- **Archive**: `activity_generations` DATASET columns == `ACTIVITY_COLUMNS`; manifest now records its column list and the restore verifier fingerprints against it (old revisions stay verifiable). `ARCHIVE_SCHEMA_VERSION` unchanged (rationale in commit).
- Deploy scripts apply 008 (GCP) / 009 (Stockholm provisioning) and install/enable the rollup timer.

## Runbook after merge (not auto-deployed)
DDL first, then code, then restart drainers — on the GCP cluster (`scripts/deploy/clickhouse_operational_analytics.sh` path or targeted apply of 008 + `tr-clickhouse-client-rollup.timer`), Paris (`009`), Stockholm (`009`); then one-time `archive_daily --backfill` for `activity_generations` so every revision carries the full column set.

## Gates
`ruff check` clean · `mypy` clean · focused suite 247 passed · full suite 4385 passed (1 unrelated hypothesis-deadline flake under `-n 4`, passes alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
