### PR TITLE
Client telemetry R-PR4b: run the canary from the GCP monitor job and the watch from the samples ingest

### DIFF
--- a/src/trusted_router/routes/internal/synthetic.py
+++ b/src/trusted_router/routes/internal/synthetic.py
@@ -166,6 +166,14 @@ def register(router: APIRouter) -> None:
         await run_in_threadpool(_record_probe_samples, samples)
         await run_in_threadpool(report_image_generation_failures, samples)
         await run_in_threadpool(report_video_generation_failures, samples)
+        # The GCP monitor is a Cloud Run Job (synthetic.cli) that posts its
+        # samples here; it never runs _run_and_record. Evaluate the client
+        # watch on THIS side, where STORE and the ClickHouse reader live, so
+        # the invisible-outage / stale alerts fire on every cloud's pass.
+        try:
+            await run_in_threadpool(_client_watch_pass, settings, samples)
+        except Exception:
+            log.warning("client_watch.pass_failed", exc_info=True)
         return {"data": {"recorded": len(samples)}}
 
     @router.post("/internal/synthetic/benchmark")

--- a/src/trusted_router/synthetic/cli.py
+++ b/src/trusted_router/synthetic/cli.py
@@ -19,6 +19,7 @@ from trusted_router.synthetic.probes import (
     SyntheticTarget,
     _attested_ssl_context,
     choose_rotation_target,
+    client_telemetry_canary_probe,
     gateway_billing_probe,
     gateway_fallback_probe,
     provider_rotation_probe,
@@ -78,8 +79,25 @@ async def _one_probe_pass(
             billing_semaphore=limiter,
         )
     )
-    if not (api_key and internal_token):
+    if not api_key:
         return await synthetic_task
+    canary_samples: list[SyntheticProbeSample] = []
+    if not internal_token:
+        # No internal token means no ledger probes, but the client-telemetry
+        # canary needs only the monitor key: it is the positive control that
+        # proves the beacon path (route -> outbox -> ClickHouse) is alive on
+        # every cloud, and the GCP monitor is THIS job, not the in-process
+        # scheduler behind /internal/synthetic/run.
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            canary_samples.append(
+                await client_telemetry_canary_probe(
+                    client,
+                    control_plane_base_url=control_plane,
+                    monitor_region=monitor_region,
+                    api_key=api_key,
+                )
+            )
+        return [*(await synthetic_task), *canary_samples]
     # Keep ledger-style probes ordered. They reserve, settle, and refund
     # against the same synthetic key; running them concurrently turns the
     # monitor into a Spanner/key-row contention test and can create false
@@ -108,6 +126,17 @@ async def _one_probe_pass(
                     model=settings.synthetic_monitor_model,
                 )
             )
+        # Client-telemetry canary: one schema-valid synthetic batch per pass
+        # through the public beacon route with the monitor key. Not a ledger
+        # probe (no reserve/settle), so it needs no limiter slot.
+        gateway_samples.append(
+            await client_telemetry_canary_probe(
+                client,
+                control_plane_base_url=control_plane,
+                monitor_region=monitor_region,
+                api_key=api_key,
+            )
+        )
     synthetic_samples = await synthetic_task
     return [*synthetic_samples, *gateway_samples]
 

--- a/tests/test_synthetic_canary.py
+++ b/tests/test_synthetic_canary.py
@@ -113,3 +113,75 @@ def test_client_telemetry_canary_is_an_ops_only_sample() -> None:
     )
     assert snapshot["samples"] == []
     assert snapshot["recent_events"] == []
+
+
+@pytest.mark.asyncio
+async def test_monitor_cli_pass_posts_the_canary_on_every_cloud(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The GCP monitor is `trusted_router.synthetic.cli` (a Cloud Run Job), not
+    the in-process scheduler. Its probe pass must include the client-telemetry
+    canary -- with the ledger probes when an internal token is present, and on
+    its own when only the monitor key is -- or the positive control that proves
+    the beacon path is alive would run everywhere except production's monitor."""
+    from trusted_router.synthetic import cli
+
+    calls: list[dict[str, object]] = []
+
+    async def fake_run_synthetic_once(
+        *_args: object, **_kwargs: object
+    ) -> list[SyntheticProbeSample]:
+        return []
+
+    async def fake_canary(_client: object, **kwargs: object) -> SyntheticProbeSample:
+        calls.append(kwargs)
+        return SyntheticProbeSample(
+            id="syn_canary",
+            probe_type="client_telemetry_ingest",
+            target="control_plane",
+            target_url="https://control.example/v1/client-events",
+            monitor_region=str(kwargs["monitor_region"]),
+            status="up",
+            created_at="2026-08-17T03:00:00Z",
+        )
+
+    async def fake_ledger_probe(_client: object, **_kwargs: object) -> list[SyntheticProbeSample]:
+        return []
+
+    monkeypatch.setattr(cli, "run_synthetic_once", fake_run_synthetic_once)
+    monkeypatch.setattr(cli, "client_telemetry_canary_probe", fake_canary)
+    monkeypatch.setattr(cli, "gateway_billing_probe", fake_ledger_probe)
+    monkeypatch.setattr(cli, "gateway_fallback_probe", fake_ledger_probe)
+    settings = Settings(environment="test")
+
+    with_token = await cli._one_probe_pass(
+        settings=settings,
+        monitor_region="us-central1",
+        control_plane="https://control.example",
+        internal_token="internal",  # noqa: S106 - test fixture
+        api_key="sk-monitor",
+        timeout=httpx.Timeout(1.0),
+    )
+    without_token = await cli._one_probe_pass(
+        settings=settings,
+        monitor_region="europe-west4",
+        control_plane="https://control.example",
+        internal_token=None,
+        api_key="sk-monitor",
+        timeout=httpx.Timeout(1.0),
+    )
+    no_key = await cli._one_probe_pass(
+        settings=settings,
+        monitor_region="us-east4",
+        control_plane="https://control.example",
+        internal_token=None,
+        api_key=None,
+        timeout=httpx.Timeout(1.0),
+    )
+
+    assert [sample.probe_type for sample in with_token] == ["client_telemetry_ingest"]
+    assert [sample.probe_type for sample in without_token] == ["client_telemetry_ingest"]
+    assert no_key == []
+    assert [call["monitor_region"] for call in calls] == ["us-central1", "europe-west4"]
+    assert all(call["api_key"] == "sk-monitor" for call in calls)
+    assert all(call["control_plane_base_url"] == "https://control.example" for call in calls)

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -2582,9 +2582,22 @@ async def test_one_probe_pass_keeps_gateway_accounting_probes_ordered(
         events.append("fallback-end")
         return [_sample(id="fallback", probe_type="provider_fallback", status="up")]
 
+    async def fake_canary_probe(_client: object, **kwargs: object) -> SyntheticProbeSample:
+        events.append("canary")
+        return SyntheticProbeSample(
+            id="syn_canary",
+            probe_type="client_telemetry_ingest",
+            target="control_plane",
+            target_url="https://control.example/v1/client-events",
+            monitor_region=str(kwargs["monitor_region"]),
+            status="up",
+            created_at="2026-08-17T03:00:00Z",
+        )
+
     monkeypatch.setattr(cli_module, "run_synthetic_once", fake_run_synthetic_once)
     monkeypatch.setattr(cli_module, "gateway_billing_probe", fake_billing_probe)
     monkeypatch.setattr(cli_module, "gateway_fallback_probe", fake_fallback_probe)
+    monkeypatch.setattr(cli_module, "client_telemetry_canary_probe", fake_canary_probe)
 
     samples = await cli_module._one_probe_pass(
         settings=Settings(environment="test", api_base_url="https://api.trustedrouter.com/v1"),
@@ -2599,8 +2612,11 @@ async def test_one_probe_pass_keeps_gateway_accounting_probes_ordered(
         "tls_health",
         "gateway_authorize_settle",
         "provider_fallback",
+        "client_telemetry_ingest",
     ]
     assert events.index("billing-end") < events.index("fallback-start")
+    # The canary is not a ledger probe; it runs after the ordered pair.
+    assert events.index("fallback-start") < events.index("canary")
 
 
 @pytest.mark.asyncio

--- a/tests/test_synthetic_run_rotation.py
+++ b/tests/test_synthetic_run_rotation.py
@@ -232,3 +232,43 @@ def test_run_calls_client_watch_and_swallows_its_exception(
     assert response.status_code == 200
     assert calls == [1]
     assert [record.message for record in caplog.records].count("client_watch.pass_failed") == 1
+
+
+def test_samples_ingest_runs_client_watch_and_swallows_its_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The GCP monitor is a Cloud Run Job (synthetic.cli) that POSTs its samples
+    to /internal/synthetic/samples and never runs _run_and_record. The client
+    watch must therefore evaluate on the ingest side too, or the invisible-
+    outage / stale alerts would only ever fire on the clouds with an in-process
+    scheduler -- configured everywhere, working nowhere that matters."""
+    calls: list[int] = []
+
+    def broken_watch(_settings: Settings, samples: list[SyntheticProbeSample]) -> None:
+        calls.append(len(samples))
+        raise RuntimeError("watch exploded")
+
+    monkeypatch.setattr(synthetic_route, "_client_watch_pass", broken_watch)
+    monkeypatch.setattr(synthetic_route, "_record_probe_samples", lambda _s: None)
+    client = TestClient(create_app(_settings(), init_observability=False))
+    sample = SyntheticProbeSample(
+        id="syn_ingest_watch",
+        probe_type="tls_health",
+        target="canonical",
+        target_url="https://api.trustedrouter.com/health",
+        monitor_region="us-central1",
+        status="up",
+        created_at="2026-08-17T03:00:00Z",
+    )
+    with caplog.at_level("WARNING"):
+        response = client.post(
+            "/v1/internal/synthetic/samples",
+            json={"samples": [sample.public_dict()]},
+            headers={"x-trustedrouter-internal-token": INTERNAL_TOKEN},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"data": {"recorded": 1}}
+    assert calls == [1]
+    assert [record.message for record in caplog.records].count("client_watch.pass_failed") == 1


### PR DESCRIPTION
After #629 flipped the flag, no canary batch was posted from GCP: R-PR4 wired the canary probe + client_watch into `_run_and_record` (in-process scheduler / `/internal/synthetic/run`), but production's GCP monitor is the Cloud Run Job `trusted_router.synthetic.cli`, which POSTs its samples to `/internal/synthetic/samples`. This adds the canary to the CLI pass (both guard branches; not a ledger probe, no limiter slot) and evaluates the watch on the samples-ingest side (exception-isolated). Tests pin both. Full suite 4485 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)