### PR TITLE
Make synthetic rollup rebuilds deterministic with an injectable clock

### DIFF
--- a/clickhouse/rollup_synthetic.py
+++ b/clickhouse/rollup_synthetic.py
@@ -12,6 +12,7 @@ import datetime as dt
 import json
 import os
 import subprocess
+from collections.abc import Callable
 from typing import Any
 
 from trusted_router.storage_models import SyntheticProbeSample, SyntheticRollup, iso_now
@@ -76,7 +77,13 @@ def build_raw_rollups(
     samples: list[SyntheticProbeSample],
     *,
     periods: set[str],
+    now: Callable[[], str] = iso_now,
 ) -> list[SyntheticRollup]:
+    """Rebuild rollups from raw samples.
+
+    ``now`` supplies the ``updated_at`` stamp shared by every rollup in one
+    build, so the output is a pure function of the samples and the clock.
+    """
     rollups: dict[str, SyntheticRollup] = {}
     for sample in _deduplicate_samples(samples):
         for period, component in sample_rollup_ids(sample):
@@ -92,7 +99,11 @@ def build_raw_rollups(
                 rollups[update.id] = update
             else:
                 apply_sample_to_rollup(existing, sample)
-    return list(rollups.values())
+    built = list(rollups.values())
+    stamp = now()
+    for rollup in built:
+        rollup.updated_at = stamp
+    return built
 
 
 def _deduplicate_samples(

--- a/tests/test_operational_analytics.py
+++ b/tests/test_operational_analytics.py
@@ -851,8 +851,9 @@ def test_synthetic_rollups_preserve_exact_counts_histograms_and_costs() -> None:
         ),
     ]
 
-    first = build_raw_rollups(samples, periods={"hour", "day"})
-    second = build_raw_rollups(samples, periods={"hour", "day"})
+    fixed_now = "2026-07-31T12:03:00Z"
+    first = build_raw_rollups(samples, periods={"hour", "day"}, now=lambda: fixed_now)
+    second = build_raw_rollups(samples, periods={"hour", "day"}, now=lambda: fixed_now)
     assert [dataclasses.asdict(item) for item in first] == [
         dataclasses.asdict(item) for item in second
     ]


### PR DESCRIPTION
## Problem

`tests/test_operational_analytics.py::test_synthetic_rollups_preserve_exact_counts_histograms_and_costs` calls `build_raw_rollups(samples, periods={"hour", "day"})` twice and asserts the two dataclass dicts are equal. Each rollup carries `updated_at = iso_now()` at second resolution, so the assertion fails whenever the two calls straddle a second boundary.

Observed on CI in PR #623, run 31975664887: `updated_at` `22:23:23Z` vs `22:23:24Z`.

## Fix

`build_raw_rollups` gains a keyword-only `now: Callable[[], str] = iso_now`. It is called once per build and stamps every rollup produced by that build, so the return value is a pure function of the samples and the clock.

- Default is the current behaviour: a wall-clock `iso_now()` stamp.
- Production callers are unchanged — `recompute()` in `clickhouse/rollup_synthetic.py` and `clickhouse/verify_operational_parity.py` still get wall-clock stamps.
- One behaviour nuance: all rollups in a single build now share one stamp instead of each getting the `iso_now()` of its last applied sample. They were already within a second of each other and all mean "rebuilt now".

The test passes a fixed instant, so determinism is a property of the code rather than of the assertion.

## Gates

```
$ uv run ruff check .
All checks passed!

$ uv run mypy
Success: no issues found in 274 source files

$ uv run pytest -q tests/test_operational_analytics.py   # run 1
26 passed, 2 warnings in 0.77s
$ uv run pytest -q tests/test_operational_analytics.py   # run 2
26 passed, 2 warnings in 0.16s
$ uv run pytest -q tests/test_operational_analytics.py   # run 3
26 passed, 2 warnings in 0.17s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)