### PR TITLE
Prove synthetic fan-out structurally instead of by wall clock

### DIFF
--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -2261,7 +2261,36 @@ async def test_run_synthetic_once_fans_out_targets_and_probes(monkeypatch: pytes
         ),
     ]
 
-    def fake_probe(probe_type: str) -> Any:
+    # Fan-out is proven STRUCTURALLY (mutual handshake), not by wall clock:
+    # the old `elapsed < 0.18` bound flaked on CI at 0.1802s. Every unmetered
+    # probe registers itself and then WAITS until all of them are in flight at
+    # once, so a serialized implementation parks the first probe forever and
+    # asyncio.wait_for fails the test deterministically, while a concurrent one
+    # releases every probe the instant the last one arrives. There is no timing
+    # margin left to erode.
+    #
+    # Ten unmetered coroutines: tls_health + attestation_nonce +
+    # gateway_latency_phase_probes on each of the 3 targets, plus the single
+    # control-plane probe on the one target that configures a control plane URL.
+    # The six credit-bearing probes are deliberately EXCLUDED from the
+    # handshake: DEFAULT_SYNTHETIC_BILLING_CONCURRENCY caps them at 2 in flight
+    # (pinned by test_run_synthetic_once_bounds_credit_bearing_probe_concurrency),
+    # so making them join a ten-way rendezvous would deadlock by design.
+    unmetered_probe_count = 10
+    in_flight = 0
+    peak_in_flight = 0
+    all_in_flight = asyncio.Event()
+
+    async def rendezvous() -> None:
+        nonlocal in_flight, peak_in_flight
+        in_flight += 1
+        peak_in_flight = max(peak_in_flight, in_flight)
+        if in_flight >= unmetered_probe_count:
+            all_in_flight.set()
+        await asyncio.wait_for(all_in_flight.wait(), timeout=5)
+        in_flight -= 1
+
+    def fake_probe(probe_type: str, *, unmetered: bool = True) -> Any:
         async def run(
             _client: httpx.AsyncClient,
             target: SyntheticTarget,
@@ -2269,7 +2298,8 @@ async def test_run_synthetic_once_fans_out_targets_and_probes(monkeypatch: pytes
             monitor_region: str,
             **_kwargs: Any,
         ) -> SyntheticProbeSample:
-            await asyncio.sleep(0.03)
+            if unmetered:
+                await rendezvous()
             return _sample(
                 id=f"{probe_type}-{target.name}",
                 probe_type=probe_type,
@@ -2291,6 +2321,7 @@ async def test_run_synthetic_once_fans_out_targets_and_probes(monkeypatch: pytes
         monitor_region: str,
         **_kwargs: Any,
     ) -> list[SyntheticProbeSample]:
+        await rendezvous()
         return [
             _sample(
                 id=f"{probe_type}-{target.name}",
@@ -2307,10 +2338,13 @@ async def test_run_synthetic_once_fans_out_targets_and_probes(monkeypatch: pytes
     monkeypatch.setattr(
         probe_module, "control_plane_health_probe", fake_probe("control_plane_health")
     )
-    monkeypatch.setattr(probe_module, "openai_chat_pong_probe", fake_probe("openai_sdk_pong"))
-    monkeypatch.setattr(probe_module, "responses_pong_probe", fake_probe("responses_pong"))
+    monkeypatch.setattr(
+        probe_module, "openai_chat_pong_probe", fake_probe("openai_sdk_pong", unmetered=False)
+    )
+    monkeypatch.setattr(
+        probe_module, "responses_pong_probe", fake_probe("responses_pong", unmetered=False)
+    )
 
-    started = time.perf_counter()
     samples = await run_synthetic_once(
         Settings(
             environment="test",
@@ -2320,13 +2354,14 @@ async def test_run_synthetic_once_fans_out_targets_and_probes(monkeypatch: pytes
         monitor_region="us-central1",
         api_key="sk-tr-test",
     )
-    elapsed = time.perf_counter() - started
 
     assert len(samples) == 19
     assert {sample.target for sample in samples} == {"canonical", "us-east4", "europe-west4"}
-    # Serial execution would take about 13 * 30ms. Keep enough slack for busy CI
-    # while still proving a single slow target no longer blocks the whole pass.
-    assert elapsed < 0.18
+    # Every unmetered probe across every target was in flight at the same
+    # instant. A pass that serialized targets, or serialized probes within a
+    # target, could never reach this count — it would have timed out in
+    # rendezvous() above rather than reaching this assertion.
+    assert peak_in_flight == unmetered_probe_count
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`tests/test_synthetic_monitoring.py::test_run_synthetic_once_fans_out_targets_and_probes` asserted `elapsed < 0.18` (wall clock) to prove probes run concurrently. That measures the CI machine, not the code: run [31983353289](https://github.com/Lore-Hex/quill-router/actions/runs/31983353289) failed at **0.1802 s**. Raising the bound only moves the flake.

## What replaces it

The mutual-handshake idiom this file already uses for concurrency proofs (`test_probe_and_rotation_pass_runs_independent_blocks_concurrently` for the `asyncio.Event` + `asyncio.wait_for` rendezvous, `test_run_synthetic_once_bounds_credit_bearing_probe_concurrency` and `test_rotation_pass_fans_out_model_samples` for the peak-in-flight counter). This change uses both together:

- Each unmetered fake probe calls `rendezvous()`: increments `in_flight`, records `peak_in_flight`, sets `all_in_flight` once the count reaches 10, then `await asyncio.wait_for(all_in_flight.wait(), timeout=5)`.
- A serialized implementation parks the first probe forever and `wait_for` fails the test deterministically. A concurrent one releases every probe the instant the last one arrives.
- Final assertion is `peak_in_flight == unmetered_probe_count` — reached only if all ten were in flight at the same instant.
- The `await asyncio.sleep(0.03)` per probe is deleted. Nothing is timed at all; there is no margin left to erode.

Ten unmetered coroutines = `tls_health` + `attestation_nonce` + `gateway_latency_phase_probes` on each of the 3 targets, plus the one `control_plane_health` probe on the only target configuring a control plane URL.

The six credit-bearing probes are **deliberately excluded** from the rendezvous: `DEFAULT_SYNTHETIC_BILLING_CONCURRENCY` caps them at 2 in flight, so making them join a ten-way barrier would deadlock by design. Their bound is already pinned by the neighbouring test.

The `len(samples) == 19` and target-set assertions are unchanged, byte for byte.

## Mutation-tested (the proof actually bites)

Both serializations were applied to `src/trusted_router/synthetic/probes.py` and reverted:

| Mutation | Result |
| --- | --- |
| `target_results = await asyncio.gather(*probe_tasks)` → `[await t for t in probe_tasks]` (serialize targets) | `1 failed in 5.29s` — `TimeoutError` |
| `results = await asyncio.gather(*probes)` → `[await p for p in probes]` (serialize probes within a target) | `1 failed in 5.29s` — `TimeoutError` |
| unmutated | `1 passed in 0.96s` |

## Other wall-clock assertions in the same file

Grepped `tests/test_synthetic_monitoring.py` for `elapsed <`, `time.perf_counter`, `time.monotonic`, `loop.time`, `assert ... < 0.`. **No other assertion in this file has the flaky shape.** The remaining `time.*` hits, for the record:

| Line | Code | Verdict |
| --- | --- | --- |
| 511 | `time.sleep(0.01)` inside a bounded `for _ in range(100)` poll loop in `test_status_cached_response_refresh_...` | **Not fixed — different shape.** It is a poll-until-condition with a generous 1 s ceiling, not an assertion that something finished *fast*. A slow machine makes it poll more, not fail. Leaving it alone. |
| 3167 | `_remaining_probe_seconds(time.perf_counter() - 2.0, 1.0)` in `test_gateway_latency_phase_probe_uses_one_total_deadline` | **Not a threshold.** `perf_counter()` is used to synthesize a start instant 2 s in the past so a 1.0 s budget is definitionally exhausted; the margin is 1 s of pure arithmetic. Deterministic on any machine. |
| 3389 | `assert sample.elapsed_milliseconds is not None` | Field presence, not wall clock. |
| 3700 | `"elapsed_milliseconds": 300` | Fixture data. |

## Gates

```
$ uv run ruff check .
All checks passed!

$ uv run mypy
Success: no issues found in 274 source files

$ uv run pytest -q tests/test_synthetic_monitoring.py   # run 1
113 passed in 5.92s
$ uv run pytest -q tests/test_synthetic_monitoring.py   # run 2
113 passed in 5.80s
$ uv run pytest -q tests/test_synthetic_monitoring.py   # run 3
113 passed in 5.81s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
