### PR TITLE
Client telemetry: defer the canary 24h-count gate during ramp-up; canary stops claiming an SDK version it isn't

### DIFF
--- a/clickhouse/check_client_telemetry_freshness.py
+++ b/clickhouse/check_client_telemetry_freshness.py
@@ -49,6 +49,13 @@ def _parse_time(value: Any) -> dt.datetime | None:
     return parsed if parsed.tzinfo else parsed.replace(tzinfo=dt.UTC)
 
 
+# The canary began posting at 2026-08-17 04:49 UTC (the first synthetic pass
+# after the beacon flag went live). A 24 h count gate cannot pass before this
+# instant; it is a start-up fact, not a threshold to tune, and it expires on
+# its own.
+CANARY_COUNT_GATE_FROM = dt.datetime(2026, 8, 18, 5, 0, tzinfo=dt.UTC)
+
+
 def evaluate(
     payload: dict[str, Any],
     *,
@@ -56,6 +63,7 @@ def evaluate(
     max_age_seconds: int,
     max_canary_age_seconds: int,
     min_canary_24h: int,
+    canary_count_from: dt.datetime = CANARY_COUNT_GATE_FROM,
 ) -> list[str]:
     """Return human-readable problems; an empty list means fresh."""
     section = payload.get("client_observed")
@@ -80,7 +88,12 @@ def evaluate(
     elif canary_age > max_canary_age_seconds:
         problems.append(f"canary last seen {canary_age}s ago (> {max_canary_age_seconds}s)")
     canary_24h = _int(canary.get("last_24h_count")) or 0
-    if canary_24h < min_canary_24h:
+    # Ramp-up: the 24 h count cannot be met until the canary has been posting
+    # for 24 h (it started 2026-08-17 04:49 UTC, the first pass after
+    # TR_CLIENT_EVENTS_ENABLED went live). Liveness is still enforced above by
+    # last_seen_age_seconds, so an outage during the ramp-up is still caught;
+    # only the count is deferred, and the guard expires by itself.
+    if now >= canary_count_from and canary_24h < min_canary_24h:
         problems.append(f"only {canary_24h} canary batches in the last 24h (< {min_canary_24h})")
     return problems
 

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -23,7 +23,6 @@ import httpx
 from cryptography import x509
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
-from trusted_router import __version__
 from trusted_router.config import Settings, parse_gateway_region_targets
 from trusted_router.provider_reliability import model_deadlines
 from trusted_router.regions import choose_region, region_payload
@@ -870,8 +869,15 @@ async def client_telemetry_canary_probe(
         "instance_id": secrets.token_hex(8),
         "seq": 0,
         "sdk": {
+            # 0.0.0 is the deliberate "not a real SDK release" sentinel. The
+            # schema requires a TR SDK name and a SEMVER, but this batch comes
+            # from the monitor, not from a customer's SDK: reporting the
+            # CONTROL PLANE's own package version here put a phantom
+            # "tr-py 0.1.0" into the per-SDK breakdowns the calibration report
+            # reads (harmless in fleet stats, which exclude synthetic rows,
+            # but a fact that is not true).
             "name": "tr-py",
-            "version": str(__version__ or "0.0.0"),
+            "version": "0.0.0",
             "lang": "python",
             "runtime": "cpython/0.0.0",
             "os": "other",

--- a/tests/test_check_client_telemetry_freshness.py
+++ b/tests/test_check_client_telemetry_freshness.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime as dt
 from pathlib import Path
 
-from clickhouse.check_client_telemetry_freshness import evaluate
+from clickhouse.check_client_telemetry_freshness import CANARY_COUNT_GATE_FROM, evaluate
 
 ROOT = Path(__file__).resolve().parents[1]
 NOW = dt.datetime(2026, 8, 17, 6, 45, tzinfo=dt.UTC)
@@ -21,10 +21,19 @@ def _section(**updates: object) -> dict[str, object]:
     return section
 
 
-def _evaluate(payload: dict[str, object]) -> list[str]:
+def _section_at(section: dict[str, object], now: dt.datetime) -> dict[str, object]:
+    """Same section, generated 30s before `now` (keeps the age gate satisfied)."""
+    stamped = dict(section)
+    stamped["generated_at"] = (
+        (now - dt.timedelta(seconds=30)).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+    )
+    return stamped
+
+
+def _evaluate(payload: dict[str, object], *, now: dt.datetime = NOW) -> list[str]:
     return evaluate(
         payload,
-        now=NOW,
+        now=now,
         max_age_seconds=3_600,
         max_canary_age_seconds=3_600,
         min_canary_24h=200,
@@ -51,13 +60,40 @@ def test_stale_snapshot_and_missing_or_old_canary_are_reported() -> None:
         "client_reliability snapshot is 9900s old (> 3600s)"
     ]
     never = _section(canary={"last_seen_age_seconds": None, "last_24h_count": 0})
+    # Before the ramp-up gate only liveness is enforced; after it, both.
     assert _evaluate({"client_observed": never}) == [
+        "canary never seen (last_seen_age_seconds is null)",
+    ]
+    after = dt.datetime(2026, 8, 19, 8, 0, tzinfo=dt.UTC)
+    assert _evaluate({"client_observed": _section_at(never, after)}, now=after) == [
         "canary never seen (last_seen_age_seconds is null)",
         "only 0 canary batches in the last 24h (< 200)",
     ]
     late = _section(canary={"last_seen_age_seconds": 7_200, "last_24h_count": 1400})
     assert _evaluate({"client_observed": late}) == [
         "canary last seen 7200s ago (> 3600s)",
+    ]
+
+
+def test_canary_count_gate_is_deferred_during_ramp_up_but_liveness_is_not() -> None:
+    """A brand-new check that cries wolf on its first run teaches people to
+    ignore it. The canary started 2026-08-17 04:49 UTC, so a 24 h count cannot
+    be met before CANARY_COUNT_GATE_FROM -- but staleness must still fire, or
+    the deferral would hide a real outage during the ramp-up."""
+    ramping = _section(canary={"last_seen_age_seconds": 45, "last_24h_count": 12})
+    before = dt.datetime(2026, 8, 17, 8, 0, tzinfo=dt.UTC)
+    after = dt.datetime(2026, 8, 19, 8, 0, tzinfo=dt.UTC)
+    assert before < CANARY_COUNT_GATE_FROM <= after
+
+    assert _evaluate({"client_observed": _section_at(ramping, before)}, now=before) == []
+    assert _evaluate({"client_observed": _section_at(ramping, after)}, now=after) == [
+        "only 12 canary batches in the last 24h (< 200)"
+    ]
+
+    # Liveness still fires during the ramp-up.
+    dead = _section(canary={"last_seen_age_seconds": 7_200, "last_24h_count": 12})
+    assert _evaluate({"client_observed": _section_at(dead, before)}, now=before) == [
+        "canary last seen 7200s ago (> 3600s)"
     ]
 
 


### PR DESCRIPTION
Two things the first real post-flip data showed (canary landed 04:49 UTC and flowed end to end: route → outbox → ingester → counters+events → rollup → snapshot → `/status.json` `canary.last_24h_count=1`).

1. **False alarm avoided.** `check-client-telemetry-freshness` requires ≥200 canary batches/24 h. The canary posts every 3 min (~480/day) but only started at 04:49 today, so today's 06:45 UTC run would have filed an issue about a working pipeline. The count gate now applies from `CANARY_COUNT_GATE_FROM` (2026-08-18 05:00 UTC); **liveness is not deferred**, so a real outage during ramp-up still fires. Self-expiring — no widening to close later.
2. **Canary sdk_version.** It reported the control plane's own package version (`0.1.0`), putting a phantom `tr-py 0.1.0` in per-SDK breakdowns; now the `0.0.0` sentinel.

Gates: ruff + mypy clean, full suite 4486 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)