### PR TITLE
Fail scheduled-cutover tests on the PR that writes them, not at midnight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,48 @@ jobs:
       - name: Tests and coverage
         run: uv run pytest -q -n 4 --dist loadgroup --cov=trusted_router --cov-report=term-missing --cov-fail-under=70
 
+  # The same suite, run once with the provider-lifecycle clock pinned PAST every
+  # scheduled cutover.
+  #
+  # provider_lifecycle.py schedules effective-dated retirements and price
+  # changes. A test written on the near side of one passes right up to the
+  # announced minute and then turns main red for every open pull request with
+  # no code change -- Wafer's three routes at 2026-08-17 00:00 UTC did exactly
+  # that (CI run 31980690855), and the fix landed hours later in PR #628. This
+  # job moves that failure to the pull request that writes the test.
+  #
+  # Cheap: no service containers and no coverage, so the conformance backends
+  # skip and this is the plain suite once more. It is a separate job rather
+  # than a second step in `test` so the two clocks report separately -- a red
+  # here means "this will break on <date>", not "this is broken".
+  test-post-cutover:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+      - name: Sync
+        run: uv sync --frozen
+      # Computed from _RETIREMENTS rather than hard-coded, so adding a
+      # retirement moves this clock with it and no one has to remember. The
+      # max() with now() keeps the clock in the future once every announced
+      # cutover is in the past.
+      - name: Pin the lifecycle clock past the latest scheduled cutover
+        run: |
+          uv run python -c '
+          import os
+          from datetime import UTC, datetime, timedelta
+          from trusted_router.provider_lifecycle import latest_scheduled_cutover
+          clock = max(latest_scheduled_cutover(), datetime.now(UTC)) + timedelta(days=1)
+          stamp = clock.strftime("%Y-%m-%dT%H:%M:%SZ")
+          with open(os.environ["GITHUB_ENV"], "a") as env:
+              env.write(f"TR_LIFECYCLE_CLOCK_OVERRIDE={stamp}\n")
+          print(f"lifecycle clock pinned to {stamp}")
+          '
+      - name: Tests with every scheduled cutover already past
+        run: uv run pytest -q -n 4 --dist loadgroup
+
   browser:
     runs-on: ubuntu-latest
     steps:

--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -7,8 +7,21 @@ billing do not depend on an hourly refresh landing at exactly the right second.
 
 from __future__ import annotations
 
+import os
+import sys
 from dataclasses import dataclass
 from datetime import UTC, datetime
+
+# Test-only clock override, e.g. TR_LIFECYCLE_CLOCK_OVERRIDE=2027-01-01T00:00:00Z.
+# Every effective-dated cutover below is a scheduled change of behaviour: a
+# test that fixtures a soon-to-retire id passes right up to the announced
+# minute and then turns main red with no code change (Wafer, 2026-08-17 00:00
+# UTC, CI run 31980690855). CI runs the suite a second time with this clock
+# pinned past the latest cutover so that class of test fails on the pull
+# request that introduces it. The override is honoured ONLY under pytest or
+# with TR_ENVIRONMENT=test; anywhere else it is ignored so a stray variable
+# can never move routing or billing off the real clock.
+LIFECYCLE_CLOCK_OVERRIDE_ENV = "TR_LIFECYCLE_CLOCK_OVERRIDE"
 
 PHALA_JULY_2026_EFFECTIVE_AT = datetime(2026, 7, 29, 18, 0, tzinfo=UTC)
 TOGETHER_MINIMAX_M27_RETIREMENT_AT = datetime(2026, 7, 27, 0, 0, tzinfo=UTC)
@@ -344,8 +357,35 @@ _RETIREMENTS = (
 )
 
 
+def _clock_override_permitted() -> bool:
+    return (
+        os.environ.get("TR_ENVIRONMENT", "").lower() == "test"
+        or "pytest" in sys.modules
+        or bool(os.environ.get("PYTEST_CURRENT_TEST"))
+    )
+
+
 def _utc_now() -> datetime:
+    override = os.environ.get(LIFECYCLE_CLOCK_OVERRIDE_ENV)
+    if override and _clock_override_permitted():
+        # A malformed override raises rather than falling back to the wall
+        # clock: a run that silently used the real clock would report the
+        # very time-bomb coverage it failed to provide.
+        return _effective_time(override)
     return datetime.now(UTC)
+
+
+def latest_scheduled_cutover() -> datetime:
+    """The latest effective-dated change this module schedules.
+
+    CI pins the lifecycle clock one day past this so tests that only pass
+    before a scheduled cutover fail on the pull request, not at midnight.
+    """
+    return max(
+        DEEPSEEK_V4_PRICING_EFFECTIVE_AT,
+        PHALA_JULY_2026_EFFECTIVE_AT,
+        *(retirement.effective_at for retirement in _RETIREMENTS),
+    )
 
 
 def _effective_time(at: datetime | str | None) -> datetime:

--- a/tests/lifecycle_clock.py
+++ b/tests/lifecycle_clock.py
@@ -1,0 +1,35 @@
+"""Which side of a scheduled cutover this test process was started on.
+
+`trusted_router.catalog_registry` resolves retirements ONCE, at import: a
+retired endpoint is absent from `MODEL_ENDPOINTS`, and a model whose every
+route has retired is absent from `MODELS` entirely. Monkeypatching
+`provider_lifecycle._utc_now` inside a test cannot put those rows back, so a
+test that wants to assert the pre-cutover catalog has to ask which clock built
+it rather than assume the answer is "before".
+
+Assuming it is what turned main red for every PR at 2026-08-17 00:00 UTC (CI
+run 31980690855). The `test-post-cutover` job in ci.yml runs the suite with
+`TR_LIFECYCLE_CLOCK_OVERRIDE` pinned past the latest scheduled cutover so that
+assumption fails on the pull request that introduces it instead of at midnight.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+
+from trusted_router import provider_lifecycle
+
+# Read at import, before any test monkeypatches `_utc_now`. Under
+# TR_LIFECYCLE_CLOCK_OVERRIDE this is the pinned clock; otherwise it is the
+# real one, within milliseconds of when catalog_registry was imported.
+CATALOG_CLOCK: datetime = provider_lifecycle._utc_now()
+
+LIFECYCLE_CLOCK_OVERRIDDEN: bool = bool(
+    os.environ.get(provider_lifecycle.LIFECYCLE_CLOCK_OVERRIDE_ENV)
+)
+
+
+def catalog_predates(cutover: datetime) -> bool:
+    """True when the import-time catalog still carries `cutover`'s routes."""
+    return CATALOG_CLOCK < cutover

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -8,8 +8,31 @@ ROOT = Path(__file__).resolve().parents[1]
 def test_ci_runs_python_suite_once_with_coverage() -> None:
     workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
 
-    assert workflow.count("uv run pytest") == 1
     assert (
         "uv run pytest -q -n 4 --dist loadgroup --cov=trusted_router "
         "--cov-report=term-missing --cov-fail-under=70"
     ) in workflow
+    # Exactly one coverage pass. A second pass on the SAME clock doubles CI
+    # time and delays every guarded rollout without checking any additional
+    # behavior, which is why this file exists.
+    assert workflow.count("--cov=trusted_router") == 1
+
+
+def test_ci_runs_the_suite_again_past_every_scheduled_cutover() -> None:
+    """The only sanctioned second pass: same tests, different clock.
+
+    provider_lifecycle schedules effective-dated retirements, so a test written
+    on the near side of one goes red at the announced minute on a pull request
+    that did not touch it (CI run 31980690855, Wafer, 2026-08-17 00:00 UTC).
+    The post-cutover job moves that failure onto the pull request that writes
+    the test. It earns its runtime only if it actually moves the clock, so the
+    override has to be there.
+    """
+    workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+
+    assert workflow.count("uv run pytest") == 2
+    assert "test-post-cutover:" in workflow
+    assert "TR_LIFECYCLE_CLOCK_OVERRIDE=" in workflow
+    # Derived from _RETIREMENTS at run time, never a hard-coded date that would
+    # silently stop being in the future.
+    assert "latest_scheduled_cutover" in workflow

--- a/tests/test_friendli_august_2026_lifecycle.py
+++ b/tests/test_friendli_august_2026_lifecycle.py
@@ -7,6 +7,7 @@ import pytest
 from scripts.pricing import refresh
 from scripts.pricing.base import ModelPrice, ProviderPricingResult
 from scripts.pricing.providers import friendli
+from tests.lifecycle_clock import catalog_predates
 from trusted_router import provider_lifecycle
 from trusted_router.catalog import endpoints_for_model
 
@@ -75,14 +76,19 @@ def test_friendli_qwen_retirement_is_provider_scoped(
 def test_friendli_exaone_catalog_route_retires_on_schedule(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(
-        provider_lifecycle,
-        "_utc_now",
-        lambda: _EXAONE_CUTOFF - timedelta(microseconds=1),
-    )
-    assert "friendli" in {
-        endpoint.provider for endpoint in endpoints_for_model(_EXAONE)
-    }
+    # The catalog registry applies retirements at IMPORT, so the live route is
+    # only observable while the process itself was started before the cutover.
+    # `provider_model_retired` is asserted at both instants regardless, by
+    # test_friendli_exaone_retires_at_announced_instant above.
+    if catalog_predates(_EXAONE_CUTOFF):
+        monkeypatch.setattr(
+            provider_lifecycle,
+            "_utc_now",
+            lambda: _EXAONE_CUTOFF - timedelta(microseconds=1),
+        )
+        assert "friendli" in {
+            endpoint.provider for endpoint in endpoints_for_model(_EXAONE)
+        }
 
     monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _EXAONE_CUTOFF)
     assert "friendli" not in {

--- a/tests/test_manifest_discovery_hooks.py
+++ b/tests/test_manifest_discovery_hooks.py
@@ -15,6 +15,12 @@ from trusted_router import catalog_ingest, provider_lifecycle
 # discovery MECHANICS with fixture rows that include those ids, so they pin the
 # lifecycle clock just before the cutover instead of drifting with the wall clock.
 _BEFORE_WAFER_AUGUST_RETIREMENT = provider_lifecycle.WAFER_AUGUST_2026_RETIREMENT_AT - timedelta(seconds=1)
+# Same for Friendli's K-EXAONE-236B-A23B at 2026-08-20 00:00 UTC: the tombstone
+# mechanics below re-list that id from a fixture feed, which the retirement
+# would otherwise filter out.
+_BEFORE_FRIENDLI_EXAONE_RETIREMENT = (
+    provider_lifecycle.FRIENDLI_K_EXAONE_236B_RETIREMENT_AT - timedelta(seconds=1)
+)
 
 
 def _manifest_row(model_id: str, upstream_id: str, **metadata: object) -> dict[str, object]:
@@ -51,6 +57,9 @@ def _write_manifest(path: Path, provider: str, rows: list[dict[str, object]]) ->
 def test_friendli_tombstones_second_miss_then_restores_annotations(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    monkeypatch.setattr(
+        provider_lifecycle, "_utc_now", lambda: _BEFORE_FRIENDLI_EXAONE_RETIREMENT
+    )
     manifest_path = tmp_path / "friendli.json"
     _write_manifest(
         manifest_path,

--- a/tests/test_phala_july_2026_lifecycle.py
+++ b/tests/test_phala_july_2026_lifecycle.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 
 from scripts.pricing.base import ModelPrice
 from scripts.pricing.providers import phala
+from tests.lifecycle_clock import catalog_predates
 from trusted_router import provider_lifecycle
 from trusted_router.catalog import (
     MODELS,
@@ -50,8 +51,10 @@ def test_phala_retirement_is_provider_scoped(monkeypatch: pytest.MonkeyPatch) ->
     assert glm_providers
     assert "phala" not in qwen_providers
     # Retirement is provider-scoped: Alibaba still serves this exact Qwen
-    # revision after Phala's route is removed.
-    assert qwen_providers == {"alibaba"}
+    # revision after Phala's route is removed -- until Alibaba retires it too,
+    # at which point no provider serves it and the model leaves the catalog.
+    if catalog_predates(provider_lifecycle.ALIBABA_OCTOBER_2026_RETIREMENT_AT):
+        assert qwen_providers == {"alibaba"}
 
 
 def test_non_confidential_phala_qwen_route_is_not_published() -> None:
@@ -75,10 +78,17 @@ def test_public_catalog_uses_effective_price_and_active_routes(
         endpoint.prompt_price_microdollars_per_million_tokens for endpoint in qwen_endpoints
     )
 
-    retired_qwen = model_to_openrouter_shape(MODELS["qwen/qwen3-30b-a3b-instruct-2507"])
-    assert all(
-        endpoint["provider"] != "phala" for endpoint in retired_qwen["trustedrouter"]["endpoints"]
-    )
+    # Alibaba retires this same Qwen revision on 2026-10-09; after that no
+    # provider serves it and the model is absent from MODELS altogether, which
+    # is a stronger form of the same assertion.
+    if catalog_predates(provider_lifecycle.ALIBABA_OCTOBER_2026_RETIREMENT_AT):
+        retired_qwen = model_to_openrouter_shape(MODELS["qwen/qwen3-30b-a3b-instruct-2507"])
+        assert all(
+            endpoint["provider"] != "phala"
+            for endpoint in retired_qwen["trustedrouter"]["endpoints"]
+        )
+    else:
+        assert "qwen/qwen3-30b-a3b-instruct-2507" not in MODELS
 
 
 def test_phala_hourly_parser_applies_announced_policy() -> None:

--- a/tests/test_provider_branding.py
+++ b/tests/test_provider_branding.py
@@ -4,10 +4,12 @@ import json
 import re
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 from PIL import Image
 
 from scripts.generate_provider_og import CARD_VERSION, generate
+from tests.lifecycle_clock import LIFECYCLE_CLOCK_OVERRIDDEN
 from trusted_router.catalog import PROVIDERS
 from trusted_router.provider_branding import (
     PROVIDER_BRANDS,
@@ -19,6 +21,19 @@ from trusted_router.provider_og import all_provider_og_facts
 from trusted_router.storage import STORE, ProviderBenchmarkSample
 
 STATIC_DIR = Path(__file__).parents[1] / "src" / "trusted_router" / "static"
+
+# Provider social cards embed live model and route COUNTS, so the committed
+# cards match exactly one catalog: the one the real clock produces. Under a
+# pinned future lifecycle clock they are stale by construction and `generate()`
+# would rewrite the committed PNGs, so these two are the one thing the
+# post-cutover job cannot assert. Cards are regenerated after a real cutover by
+# the hourly refresh workflow -- see
+# test_hourly_catalog_refresh_keeps_provider_cards_current below, which runs on
+# both clocks because it reads the workflow rather than the catalog.
+_needs_real_clock = pytest.mark.skipif(
+    LIFECYCLE_CLOCK_OVERRIDDEN,
+    reason="social cards embed live route counts; only the real clock's catalog matches",
+)
 
 
 def test_every_catalog_provider_has_local_branding() -> None:
@@ -38,6 +53,7 @@ def test_unknown_provider_logo_falls_back_locally() -> None:
     assert provider_homepage_url("future-provider") is None
 
 
+@_needs_real_clock
 def test_every_provider_has_current_social_card() -> None:
     manifest_path = STATIC_DIR / "og" / "providers" / "manifest.json"
     manifest = json.loads(manifest_path.read_text())
@@ -67,6 +83,7 @@ def test_provider_social_cards_use_current_trustedrouter_mark() -> None:
     assert (169, 205, 185) in colors  # mint attested route
 
 
+@_needs_real_clock
 def test_provider_social_card_generation_is_idempotent() -> None:
     generated, unchanged = generate()
 

--- a/tests/test_provider_lifecycle_clock.py
+++ b/tests/test_provider_lifecycle_clock.py
@@ -1,0 +1,197 @@
+"""The guard against scheduled cutovers turning main red at midnight.
+
+At 2026-08-17 00:00 UTC main went red for every open pull request with no code
+change (CI run 31980690855): `provider_lifecycle` retired three Wafer routes at
+that instant, four tests fixtured the retired ids, and one routing-contract
+param named the retired endpoint. Nothing had regressed -- the tests had simply
+been written on the near side of a cutover the module itself schedules.
+
+Two halves of the guard live here: the clock override the post-cutover CI job
+uses, and the standing check that no test names a route that has ALREADY
+retired. The third half is the `test-post-cutover` job in ci.yml, which runs
+the whole suite with the clock pinned past the latest scheduled cutover.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from trusted_router import provider_lifecycle
+
+_REPO_ROOT = Path(__file__).parents[1]
+_TESTS_DIR = Path(__file__).parent
+
+# "moonshotai/kimi-k3-fast@wafer/prepaid" -> ("moonshotai/kimi-k3-fast", "wafer")
+_ENDPOINT_ID = re.compile(r"([a-z0-9][\w.-]*/[\w.-]+)@([a-z0-9-]+)/[a-z]+")
+
+
+def _code_string_literals(path: Path) -> Iterator[tuple[int, str]]:
+    """Every string literal a test actually evaluates.
+
+    Comments and docstrings are deliberately excluded: naming a retired
+    endpoint in prose is how a retirement gets DOCUMENTED (PR #628 left exactly
+    such a comment where the param used to be), and prose cannot break a test.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    docstrings: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(
+            node, ast.Module | ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef
+        ):
+            continue
+        first = node.body[0] if node.body else None
+        if (
+            isinstance(first, ast.Expr)
+            and isinstance(first.value, ast.Constant)
+            and isinstance(first.value.value, str)
+        ):
+            docstrings.add(id(first.value))
+
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and id(node) not in docstrings
+        ):
+            yield node.lineno, node.value
+
+
+def _retirement_date(provider_slug: str, model_id: str) -> str:
+    for retirement in provider_lifecycle._RETIREMENTS:
+        if retirement.provider == provider_slug and model_id in retirement.model_ids:
+            return retirement.effective_at.isoformat()
+    return "unknown"
+
+
+def test_override_moves_the_clock_only_under_test(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pinned = datetime(2027, 1, 1, tzinfo=UTC)
+    monkeypatch.setenv(
+        provider_lifecycle.LIFECYCLE_CLOCK_OVERRIDE_ENV, "2027-01-01T00:00:00Z"
+    )
+
+    assert provider_lifecycle._utc_now() == pinned
+    # Naive and offset strings both land on UTC, like every other `at=` here.
+    monkeypatch.setenv(provider_lifecycle.LIFECYCLE_CLOCK_OVERRIDE_ENV, "2027-01-01T02:00:00+02:00")
+    assert provider_lifecycle._utc_now() == pinned
+
+    # A typo must not silently degrade to the wall clock: a run that quietly
+    # used the real clock would report the coverage it did not provide.
+    monkeypatch.setenv(provider_lifecycle.LIFECYCLE_CLOCK_OVERRIDE_ENV, "not-a-timestamp")
+    with pytest.raises(ValueError):
+        provider_lifecycle._utc_now()
+
+    monkeypatch.delenv(provider_lifecycle.LIFECYCLE_CLOCK_OVERRIDE_ENV)
+    assert provider_lifecycle._utc_now() - datetime.now(UTC) < timedelta(minutes=1)
+
+
+def test_override_is_ignored_outside_test_environments() -> None:
+    """Production must reach the real clock even with the variable exported.
+
+    Driven in a SUBPROCESS on purpose: in-process, `"pytest" in sys.modules` is
+    unconditionally true, so the permission check cannot be exercised from
+    inside the suite that trips it.
+    """
+    env = {
+        **os.environ,
+        provider_lifecycle.LIFECYCLE_CLOCK_OVERRIDE_ENV: "2027-01-01T00:00:00Z",
+        "TR_ENVIRONMENT": "production",
+        "PYTHONPATH": str(_REPO_ROOT / "src"),
+    }
+    env.pop("PYTEST_CURRENT_TEST", None)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from datetime import UTC, datetime\n"
+            "from trusted_router import provider_lifecycle\n"
+            "drift = abs(provider_lifecycle._utc_now() - datetime.now(UTC)).total_seconds()\n"
+            "print(drift < 60)\n",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=_REPO_ROOT,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "True"
+
+    # Negative control: the same subprocess DOES honour the override under
+    # TR_ENVIRONMENT=test, so the assertion above is about the guard and not
+    # about the variable failing to reach the child at all.
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from trusted_router import provider_lifecycle\n"
+            "print(provider_lifecycle._utc_now().year)\n",
+        ],
+        capture_output=True,
+        text=True,
+        env={**env, "TR_ENVIRONMENT": "test"},
+        cwd=_REPO_ROOT,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "2027"
+
+
+def test_latest_scheduled_cutover_covers_every_effective_date() -> None:
+    latest = provider_lifecycle.latest_scheduled_cutover()
+
+    for retirement in provider_lifecycle._RETIREMENTS:
+        assert retirement.effective_at <= latest, retirement.provider
+    assert provider_lifecycle.DEEPSEEK_V4_PRICING_EFFECTIVE_AT <= latest
+    assert provider_lifecycle.PHALA_JULY_2026_EFFECTIVE_AT <= latest
+    # Past the latest cutover, no retirement is still pending, which is what
+    # makes the post-cutover CI job's clock the strictest one available.
+    day_after = latest + timedelta(days=1)
+    for retirement in provider_lifecycle._RETIREMENTS:
+        for model_id in retirement.model_ids:
+            assert provider_lifecycle.provider_model_retired(
+                retirement.provider, model_id, at=day_after
+            )
+
+
+def test_no_test_names_an_already_retired_endpoint() -> None:
+    """No `provider/model@provider/tier` id in tests/ has already retired.
+
+    This is the specific defect PR #628 patched by hand: a
+    `test_catalog_routing_contracts` param named
+    `moonshotai/kimi-k3-fast@wafer/prepaid`, and the endpoint stopped existing
+    at the announced minute. Endpoint ids appear in parametrize lists and
+    `MODEL_ENDPOINTS[...]` lookups, so scanning the source catches both.
+
+    The `*_lifecycle.py` files are exempt: proving a route retires is their
+    subject, and they pass explicit `at=` instants rather than relying on the
+    catalog the run happened to build.
+    """
+    offenders: list[str] = []
+    scanned = 0
+    for path in sorted(_TESTS_DIR.rglob("test_*.py")):
+        if path.name.endswith("_lifecycle.py"):
+            continue
+        for line_number, literal in _code_string_literals(path):
+            for model_id, provider_slug in _ENDPOINT_ID.findall(literal):
+                scanned += 1
+                if provider_lifecycle.provider_model_retired(provider_slug, model_id):
+                    offenders.append(
+                        f"{path.relative_to(_REPO_ROOT)}:{line_number}: "
+                        f"{model_id}@{provider_slug} retired "
+                        f"{_retirement_date(provider_slug, model_id)}"
+                    )
+
+    assert not offenders, "\n".join(offenders)
+    # A scan that matched nothing would pass for the wrong reason.
+    assert scanned > 100, scanned


### PR DESCRIPTION
## Why

`provider_lifecycle` schedules effective-dated retirements, so a test written on the near side of one passes until the announced minute and then turns main red for **every open pull request with no code change**. Wafer's three routes did that at 2026-08-17 00:00 UTC ([CI run 31980690855](https://github.com/Lore-Hex/quill-router/actions/runs/31980690855)) and #628 patched the four symptoms hours later.

The defect is not those four tests. It is that nothing runs the suite on the far side of a cutover.

## What

**1. A test-only clock override.** `provider_lifecycle._utc_now()` honours `TR_LIFECYCLE_CLOCK_OVERRIDE`, but only under pytest or `TR_ENVIRONMENT=test` — a stray variable can never move production routing or billing off the real clock — and a malformed value raises rather than silently reverting to the wall clock, because a run that quietly used the real clock would report coverage it never provided. The permission check is driven in a **subprocess** (in-process, `"pytest" in sys.modules` is unconditionally true, so the guard cannot be exercised from inside the suite that trips it), with a negative control proving the variable does reach the child. `latest_scheduled_cutover()` derives the clock from `_RETIREMENTS`, so adding a retirement moves it and nobody has to remember.

**2. A CI job.** `test-post-cutover` runs the same suite with the clock pinned one day past the latest scheduled cutover. No coverage and no service containers, so it is the plain suite once more; a separate job rather than a second step so a red reads *"this breaks on `<date>`"*, not *"this is broken"*.

**3. A standing check.** `tests/test_provider_lifecycle_clock.py` asserts no test names an **already-retired** `provider/model@provider/tier` endpoint — the specific thing #628 patched by hand. It scans string literals via AST, so comments and docstrings that *document* a retirement (as #628's does) are exempt while `parametrize` lists and `MODEL_ENDPOINTS[...]` lookups are not. Re-adding the `kimi-k3-fast@wafer/prepaid` param reproduces the failure, reported with its retirement date.

## The job immediately found six live time bombs

| Test | Fires |
|---|---|
| `test_friendli_exaone_catalog_route_retires_on_schedule` | **2026-08-20** (3 days) |
| `test_friendli_tombstones_second_miss_then_restores_annotations` | **2026-08-20** |
| `test_phala_retirement_is_provider_scoped` | 2026-10-09 |
| `test_public_catalog_uses_effective_price_and_active_routes` | 2026-10-09 |
| `test_every_provider_has_current_social_card` | every cutover |
| `test_provider_social_card_generation_is_idempotent` | every cutover |

Friendli's K-EXAONE pair is exactly Wafer's shape and would have broken main this Thursday. Phala's two assumed Alibaba still serves `qwen/qwen3-30b-a3b-instruct-2507`, which Alibaba retires 2026-10-09 — after which no provider serves it and the model leaves `MODELS` entirely.

The two social-card tests embed live model/route counts, so under a hypothetical clock they are stale by construction **and** `generate()` rewrote the committed PNGs in the working tree. They skip when the clock is overridden; `test_hourly_catalog_refresh_keeps_provider_cards_current` still asserts on both clocks that the refresh workflow regenerates them after a real cutover.

## One thing worth knowing

The catalog registry applies retirements at **import**, so monkeypatching `_utc_now` inside a test cannot restore a route the process never built. `tests/lifecycle_clock.py` captures the import-time clock so those tests ask which side of a cutover they are on instead of assuming "before".

## Gates

- `uv run ruff check .` — clean
- `uv run mypy` — clean, 274 files
- `uv run pytest -q -n 4 --dist loadgroup` on **both** clocks:
  - real clock: 4490 passed, 290 skipped, 10 xfailed
  - `TR_LIFECYCLE_CLOCK_OVERRIDE=2026-10-10T16:00:00Z`: 4488 passed, 292 skipped, 10 xfailed
- Clean working tree after each run (no OG card churn).
- The workflow step's inline Python was executed against a real `GITHUB_ENV` file and the YAML parses with the new job present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)