### PR TITLE
aws-eu: install the analytics drain, and check it from outside

### DIFF
--- a/.github/workflows/check-aws-analytics-freshness.yml
+++ b/.github/workflows/check-aws-analytics-freshness.yml
@@ -1,0 +1,192 @@
+name: Check AWS-EU analytics freshness
+
+# The AWS-EU analytics pipeline is
+#   settle -> tr_operational_analytics_outbox (DSQL) -> drain -> ClickHouse (Paris)
+# and on 2026-08-17 it was found to have never started: no unit had been
+# installed on tr-eu-clickhouse-1, 465,119 rows had accumulated in the outbox
+# since 2026-08-02, and `SELECT count() FROM activity_generations` on the node
+# returned 0. Nothing reported it for fifteen days, for a structural reason
+# worth stating plainly: every in-band signal for this pipeline -- the metrics
+# line, `degraded_targets=`, and the `backlog_alarm` that is the ONLY bound on
+# outbox growth -- is emitted by the drain process itself. A drain that does
+# not exist cannot alarm about not existing.
+#
+# So this check runs somewhere else, on someone else's schedule, and asks the
+# database rather than the daemon.
+#
+# WHY IT READS /status.json AND NOT THE NODE
+# ------------------------------------------
+# The Paris ClickHouse node is private: it listens on its VPC address only and
+# its security group admits only the VPC CIDR, so a GitHub runner cannot reach
+# it to ask for max(created_at). Three ways to get the signal out were
+# considered; this is the one that adds no infrastructure at all.
+#
+#   1. CHOSEN -- the tr-eu control plane publishes an `analytics` section in
+#      its already-public /status.json, and this job reads it with NO
+#      credentials, exactly as check-client-telemetry-freshness.yml reads the
+#      GCP one. tr-eu is already public, already holds dsql:DbConnect{,Admin}
+#      on the Paris cluster, and already opens a DSQL connection per request.
+#      The query is an index seek on tr_operational_analytics_outbox_enqueued_at_idx.
+#      New AWS resources: none. New IAM: none. New secrets in Actions: none.
+#
+#   2. Rejected -- this job queries Aurora DSQL directly. The DSQL endpoint IS
+#      publicly reachable, so it would work, but the repo has no GitHub OIDC
+#      provider and no Actions-assumable AWS role, so it needs a new OIDC
+#      provider plus a role and trust policy. More infrastructure, to learn
+#      the same number.
+#
+#   3. Rejected -- a systemd timer on the node writes a heartbeat somewhere
+#      Actions can read. The node's role can reach Secrets Manager and
+#      CloudWatch Logs, but Actions can read neither without the same new IAM
+#      as (2), and it adds a unit and a timer whose own failure is once again
+#      invisible.
+#
+# The number it checks is drain_lag_seconds: the age of the oldest row still in
+# the outbox. Rows are deleted only after ClickHouse accepts them, so this is an
+# end-to-end statement about the whole pipeline and it is strictly stronger than
+# a ClickHouse timestamp -- it cannot be satisfied by a drain that is writing
+# nowhere.
+#
+# OPERATOR STEPS BEFORE THE SCHEDULE IS ENABLED
+# ---------------------------------------------
+# The `schedule:` trigger is intentionally absent. Two things must land first,
+# and until they do this job would file a daily issue about a field that was
+# never deployed, which trains people to ignore it:
+#
+#   1. Install the drain:  bash scripts/deploy/aws_eu_clickhouse_drain_install.sh
+#      (it refuses to run until quill-enclave-role is granted dsql:DbConnect*,
+#      which it prints in full -- that grant is an IAM change and is step 0).
+#   2. Publish the section: wire
+#      trusted_router.operational_analytics_freshness.analytics_status_section
+#      into the /status.json payload on the AWS deployment, reading
+#      `SELECT enqueued_at FROM tr_operational_analytics_outbox
+#       ORDER BY enqueued_at LIMIT 1`. The builder and its contract are already
+#      in this repo and tested; only the wiring and a STORE read remain.
+#
+# Then add, here:
+#     schedule:
+#       - cron: "20 7 * * *"
+# and verify once with workflow_dispatch before trusting it.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "clickhouse/check_aws_analytics_freshness.py"
+      - "src/trusted_router/operational_analytics_freshness.py"
+      - ".github/workflows/check-aws-analytics-freshness.yml"
+  workflow_dispatch:
+    inputs:
+      status_url:
+        description: "status.json URL of the AWS-EU control plane"
+        required: false
+        default: ""
+      max_drain_lag_seconds:
+        description: "Fail above this outbox age, in seconds (drain default: 3600)."
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: check-aws-analytics-freshness
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # No credentials, no cloud SDK, no VPC. The whole point of reading the
+      # public status feed is that this step is a plain HTTPS GET.
+      - name: Check the AWS-EU drain lag
+        id: check
+        env:
+          STATUS_URL: ${{ github.event.inputs.status_url }}
+          MAX_LAG: ${{ github.event.inputs.max_drain_lag_seconds }}
+          PYTHONPATH: src
+        run: |
+          set -euo pipefail
+          args=(--problems-file /tmp/problems.txt)
+          if [ -n "${STATUS_URL}" ]; then
+            args+=(--status-url "${STATUS_URL}")
+          fi
+          if [ -n "${MAX_LAG}" ]; then
+            args+=(--max-drain-lag-seconds "${MAX_LAG}")
+          fi
+          python3 -m clickhouse.check_aws_analytics_freshness "${args[@]}"
+
+      - name: Open or update the freshness issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ -f /tmp/problems.txt ]; then
+            cp /tmp/problems.txt /tmp/detail.txt
+          else
+            echo "the freshness check failed before it could report; see the run log" > /tmp/detail.txt
+          fi
+          {
+            echo "The AWS-EU operational analytics drain is not observably delivering."
+            echo
+            echo '```'
+            cat /tmp/detail.txt
+            echo '```'
+            echo
+            echo "Rows are not lost while this is broken: the drain deletes an outbox row"
+            echo "only after ClickHouse has accepted it, so a stopped drain means the outbox"
+            echo "GROWS. The cost is freshness now and DSQL storage later, not data."
+            echo
+            echo "What to look at, in order:"
+            echo
+            echo '```bash'
+            echo "# 1. Is the unit even installed and running?"
+            echo "aws ssm send-command --region eu-west-3 \\"
+            echo "  --instance-ids \"\$(aws ec2 describe-instances --region eu-west-3 \\"
+            echo "    --filters Name=tag:Name,Values=tr-eu-clickhouse-1 Name=instance-state-name,Values=running \\"
+            echo "    --query 'Reservations[0].Instances[0].InstanceId' --output text)\" \\"
+            echo "  --document-name AWS-RunShellScript \\"
+            echo "  --parameters 'commands=[\"systemctl status tr-clickhouse-operational-ingest-postgres.service --no-pager\",\"journalctl -u tr-clickhouse-operational-ingest-postgres.service -n 50 --no-pager\"]'"
+            echo '```'
+            echo
+            echo "Read the journal for these, in this order:"
+            echo
+            echo "- \`config_invalid\` + a unit in **failed** with status **78**: the environment"
+            echo "  file is wrong. \`RestartPreventExitStatus=78\` stopped it deliberately rather"
+            echo "  than crash-loop while the outbox grew. Fix /etc/tr-clickhouse-ingest-postgres.env"
+            echo "  and restart. Never paste secrets into that file -- write them by RUNNING the"
+            echo "  command that fetches them (systemd does no substitution, so a literal"
+            echo "  \\\$(aws ...) becomes the password and passes every startup check)."
+            echo "- \`degraded_targets=\` naming an endpoint: that node is refusing writes and"
+            echo "  NOTHING is being deleted until it returns. Restore it, or remove its"
+            echo "  \`*_REPLICA_*\` variables and accept that it is permanently behind."
+            echo "- \`backlog_alarm\`: the oldest row is past --max-lag-seconds. Expected while a"
+            echo "  known backlog drains; it must fall, not sit."
+            echo "- **nothing at all**: the unit was never installed. Run"
+            echo "  \`scripts/deploy/aws_eu_clickhouse_drain_install.sh\`. This is what happened"
+            echo "  between 2026-08-02 and 2026-08-17."
+            echo
+            echo "Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          } > /tmp/issue-body.md
+          gh label create aws-analytics-freshness \
+            --description "The AWS-EU operational analytics drain stopped delivering" \
+            --color D93F0B --force >/dev/null
+          # One open issue at a time: a daily duplicate trains people to ignore it.
+          existing="$(gh issue list --label aws-analytics-freshness --state open --json number --jq '.[0].number' 2>/dev/null || true)"
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" --body-file /tmp/issue-body.md
+          else
+            gh issue create \
+              --title "AWS-EU analytics drain is not delivering" \
+              --label aws-analytics-freshness \
+              --body-file /tmp/issue-body.md
+          fi

--- a/clickhouse/check_aws_analytics_freshness.py
+++ b/clickhouse/check_aws_analytics_freshness.py
@@ -1,0 +1,186 @@
+"""Check, from outside the VPC, that the AWS-EU analytics drain is still draining.
+
+Sibling of :mod:`clickhouse.check_client_telemetry_freshness`, and the same
+shape: read a PUBLIC ``/status.json`` with no credentials and fail when the
+pipeline is not observably alive.  What differs is which cloud and which
+signal.
+
+The Paris ClickHouse node is private -- it listens on its VPC address and its
+security group admits only the VPC CIDR -- so this job cannot ask it anything.
+It reads the ``analytics`` section the control plane publishes instead, whose
+rationale and field names live in
+:mod:`trusted_router.operational_analytics_freshness`.  The number that matters
+is ``drain_lag_seconds``: the age of the oldest row still sitting in the
+DSQL outbox.  Rows leave the outbox only after ClickHouse has accepted them, so
+a lag that stops falling is a drain that has stopped delivering.
+
+This exists because the drain's own ``backlog_alarm`` cannot fire when the
+drain is not running, and on 2026-08-17 that was not hypothetical: no unit had
+ever been installed, 465,119 rows had accumulated since 2026-08-02, and every
+in-band signal was silent because every in-band signal came from the missing
+process.  This check runs somewhere else, on someone else's schedule, and asks
+the database rather than the daemon.
+
+Pure function :func:`evaluate` returns the problems; :func:`main` fetches and
+reports, writing them to ``--problems-file`` for the workflow's issue body.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+import urllib.request
+from typing import Any
+
+from trusted_router.operational_analytics_freshness import (
+    ANALYTICS_STATUS_KEY,
+    AVAILABLE_FIELD,
+    DEFAULT_MAX_DRAIN_LAG_SECONDS,
+    DRAIN_LAG_FIELD,
+    GENERATED_AT_FIELD,
+    OUTBOX_DEPTH_FIELD,
+    REASON_FIELD,
+)
+
+#: The AWS-EU control plane. Not trustedrouter.com: that is the GCP deployment,
+#: whose analytics run on an entirely separate cluster and would answer this
+#: question about the wrong cloud.
+DEFAULT_STATUS_URL = "https://gchircrcif.eu-west-3.awsapprunner.com/status.json"
+
+
+def _float(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_time(value: Any) -> dt.datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=dt.UTC)
+
+
+def evaluate(
+    payload: dict[str, Any],
+    *,
+    now: dt.datetime,
+    max_drain_lag_seconds: float = DEFAULT_MAX_DRAIN_LAG_SECONDS,
+    max_age_seconds: int = 3_600,
+    max_outbox_depth: int | None = None,
+) -> list[str]:
+    """Return human-readable problems; an empty list means the drain is healthy."""
+    section = payload.get(ANALYTICS_STATUS_KEY)
+    if not isinstance(section, dict):
+        # Deliberately a FAILURE and not a skip. A missing section means either
+        # the control plane does not publish it yet or it stopped publishing
+        # it; treating "no signal" as "no problem" is how a monitor becomes
+        # decorative.
+        return [
+            f"/status.json has no {ANALYTICS_STATUS_KEY} section "
+            "(the control plane does not publish drain lag)"
+        ]
+    if not section.get(AVAILABLE_FIELD):
+        return [
+            f"{ANALYTICS_STATUS_KEY} unavailable: reason={section.get(REASON_FIELD)!r} "
+            "(the control plane could not read the outbox)"
+        ]
+
+    problems: list[str] = []
+
+    lag = _float(section.get(DRAIN_LAG_FIELD))
+    if lag is None:
+        problems.append(f"{ANALYTICS_STATUS_KEY}.{DRAIN_LAG_FIELD} missing or unparseable")
+    elif lag > max_drain_lag_seconds:
+        problems.append(
+            f"oldest undelivered outbox row is {lag:.0f}s old "
+            f"(> {max_drain_lag_seconds:.0f}s): the drain is behind or stopped"
+        )
+
+    # The section's own age. A control plane that froze would otherwise serve a
+    # stale-but-healthy lag forever, and the check would agree with it.
+    generated_at = _parse_time(section.get(GENERATED_AT_FIELD))
+    if generated_at is None:
+        problems.append(f"{ANALYTICS_STATUS_KEY}.{GENERATED_AT_FIELD} missing or unparseable")
+    else:
+        age = int((now - generated_at).total_seconds())
+        if age > max_age_seconds:
+            problems.append(f"analytics section is {age}s old (> {max_age_seconds}s)")
+
+    # Optional, and only checked when both a bound and a value are present:
+    # depth is a count(*) the publisher may decline to pay for.
+    depth = _int(section.get(OUTBOX_DEPTH_FIELD))
+    if max_outbox_depth is not None and depth is not None and depth > max_outbox_depth:
+        problems.append(f"outbox holds {depth} undelivered rows (> {max_outbox_depth})")
+
+    return problems
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n\n")[0])
+    parser.add_argument("--status-url", default=DEFAULT_STATUS_URL)
+    parser.add_argument(
+        "--max-drain-lag-seconds", type=float, default=DEFAULT_MAX_DRAIN_LAG_SECONDS
+    )
+    parser.add_argument("--max-age-seconds", type=int, default=3_600)
+    parser.add_argument("--max-outbox-depth", type=int, default=None)
+    parser.add_argument("--problems-file", default=None)
+    return parser.parse_args(argv)
+
+
+def fetch_status(url: str) -> dict[str, Any]:
+    request = urllib.request.Request(  # noqa: S310 - https URL from argv/default only
+        url, headers={"user-agent": "trustedrouter-aws-analytics-freshness/1"}
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
+        payload = json.loads(response.read().decode("utf-8"))
+    if isinstance(payload, dict) and isinstance(payload.get("data"), dict):
+        payload = payload["data"]
+    if not isinstance(payload, dict):
+        raise SystemExit("status.json is not a JSON object")
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    payload = fetch_status(args.status_url)
+    problems = evaluate(
+        payload,
+        now=dt.datetime.now(dt.UTC),
+        max_drain_lag_seconds=args.max_drain_lag_seconds,
+        max_age_seconds=args.max_age_seconds,
+        max_outbox_depth=args.max_outbox_depth,
+    )
+    section = payload.get(ANALYTICS_STATUS_KEY)
+    lag = section.get(DRAIN_LAG_FIELD) if isinstance(section, dict) else None
+    if args.problems_file:
+        with open(args.problems_file, "w", encoding="utf-8") as handle:
+            handle.write("\n".join(problems) + ("\n" if problems else ""))
+    if problems:
+        print(f"aws-eu analytics freshness: FAIL drain_lag_seconds={lag}", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+    print(f"aws-eu analytics freshness: OK drain_lag_seconds={lag}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deploy/aws_eu_clickhouse_drain_install.sh
+++ b/scripts/deploy/aws_eu_clickhouse_drain_install.sh
@@ -1,0 +1,407 @@
+#!/usr/bin/env bash
+# Install (or refresh) the operational-analytics drain on the AWS-EU ClickHouse
+# node in Paris.
+#
+# WHY THIS SCRIPT EXISTS
+# ----------------------
+# scripts/deploy/aws_eu_clickhouse.sh built the node and applied the schema.
+# scripts/deploy/aws_eu_north_clickhouse.sh documents the second copy. Neither
+# installs the process that actually moves rows, and on 2026-08-17 the
+# consequence was visible: /opt/drain held a copy of the code from 2026-08-02,
+# there was no unit, no environment file, no running process, and
+# `SELECT count() FROM activity_generations` on the node returned 0 while the
+# DSQL outbox held 465,119 undelivered rows (399,760 synthetic, oldest
+# 2026-08-02; 65,361 activity, oldest 2026-08-10).
+#
+# That is the failure this pipeline is built to make loud, and it was silent
+# for fifteen days for one reason: the alarm that bounds outbox growth
+# (`operational_analytics_outbox.backlog_alarm`) is emitted BY the drain, so a
+# drain that was never installed cannot report that it is not running. See the
+# module docstring of clickhouse/ingest_operational_outbox_postgres.py, "The
+# alarm needs this process alive".
+#
+# WHY /opt/tr-clickhouse AND NOT /opt/drain
+# -----------------------------------------
+# Not a preference — the unit file decides it, and the unit is the thing that
+# runs in production:
+#
+#     WorkingDirectory=/opt/tr-clickhouse
+#     ExecStart=/opt/tr-clickhouse/venv/bin/python -m clickhouse.ingest_operational_outbox_postgres
+#
+# There is no PYTHONPATH= line, so `python -m` puts the WorkingDirectory on
+# sys.path and nothing else. The existing /opt/drain layout could not satisfy
+# that unit even if it were pointed there, because it nests the package as
+# /opt/drain/src/trusted_router, and `import trusted_router` from a
+# WorkingDirectory of /opt/drain does not look inside src/. So the layout this
+# script installs is FLAT, which is exactly what the unit already expects:
+#
+#     /opt/tr-clickhouse/clickhouse/...      (the drain)
+#     /opt/tr-clickhouse/trusted_router/...  (flattened from src/)
+#     /opt/tr-clickhouse/venv/
+#
+# /opt/drain is left alone. It is dead weight, not a hazard, and deleting other
+# people's directories is not this script's job; remove it by hand once this
+# unit has been healthy for a while.
+#
+# HOW THE CODE GETS THERE
+# -----------------------
+# Through SSM, as base64 chunks of a tarball, staged and checksummed before
+# anything is swapped into place. Deliberately NOT S3: the node's instance role
+# (quill-enclave-role) has no s3:GetObject at all, and the only buckets in the
+# account are tf-state, cloudtrail, alb-access-logs, device-keys and the trust
+# site — none of which is a build-artifact bucket. A presigned URL would work
+# without new IAM (the node has a public IP and an IGW route), but it needs a
+# bucket to presign FROM, and borrowing the Terraform state bucket for code
+# tarballs is how buckets stop meaning anything. Chunked SSM needs no bucket,
+# no new IAM, and leaves the whole transfer in the SSM audit trail.
+#
+# The tarball is built with COPYFILE_DISABLE=1 and the extraction deletes any
+# ._* AppleDouble sidecar it finds anyway, then FAILS if one survives. This is
+# not hypothetical: /opt/drain/clickhouse currently holds four of them
+# (._ingest_operational_outbox_postgres.py and friends), shipped by a macOS tar
+# without that variable, and the same sidecars once crashed a snapshot builder
+# that tried to parse them as JSON.
+#
+# WHAT THIS SCRIPT DOES NOT DO
+# ----------------------------
+# It does not create or change IAM, and it will REFUSE to install if the node
+# cannot authenticate to DSQL. As of 2026-08-17 it cannot: quill-enclave-role
+# grants secretsmanager, kms, ecr and logs, and no dsql action whatsoever. The
+# drain would start, fail every connection, and deliver nothing. That grant is
+# an operator step and it is printed in full below.
+set -euo pipefail
+
+REGION="${REGION:-eu-west-3}"                       # Paris.
+ACCOUNT="${ACCOUNT:-330422590279}"
+NODE_NAME="${NODE_NAME:-tr-eu-clickhouse-1}"
+INSTANCE_ID="${INSTANCE_ID:-}"                      # Resolved from NODE_NAME when empty.
+SECRET_ID="${SECRET_ID:-quill/tr-eu-clickhouse-password}"
+CLUSTER_ID="${CLUSTER_ID:-tnt642i3ofzpn5z62msacutpuu}"
+DSQL_REGION="${DSQL_REGION:-$REGION}"
+DSQL_HOST="${DSQL_HOST:-${CLUSTER_ID}.dsql.${DSQL_REGION}.on.aws}"
+DSQL_USER="${DSQL_USER:-admin}"
+# "default"/"default" and NOT the "tr"/"tr" default, because this node's schema
+# was applied unqualified. Getting this wrong fails authentication only AFTER a
+# batch has been read out of the outbox.
+CH_USER="${CH_USER:-default}"
+CH_DATABASE="${CH_DATABASE:-default}"
+REMOTE_ROOT="${REMOTE_ROOT:-/opt/tr-clickhouse}"
+STAGE_DIR="${STAGE_DIR:-/opt/tr-clickhouse.staging}"
+ENV_FILE="${ENV_FILE:-/etc/tr-clickhouse-ingest-postgres.env}"
+SERVICE="tr-clickhouse-operational-ingest-postgres.service"
+SERVICE_USER="${SERVICE_USER:-tr-clickhouse-ingest}"
+STATE_DIR="${STATE_DIR:-/var/lib/tr-clickhouse-ingest}"
+# Ubuntu 22.04's system python is 3.10; trusted_router.types uses StrEnum
+# (3.11+), so the venv MUST be built from an explicitly provisioned 3.12.
+# Already present on the live node at this path.
+PYTHON_BIN="${PYTHON_BIN:-/usr/bin/python3.12}"
+CHUNK_BYTES="${CHUNK_BYTES:-40000}"                 # Fits one SSM parameter comfortably.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+log(){ printf '\n=== %s\n' "$*" >&2; }
+die(){ printf '\nFATAL: %s\n' "$*" >&2; exit 1; }
+
+# Run a shell snippet on the node and fail loudly if it fails. SSM reports a
+# failed command as Status=Failed but exits 0 itself, so the status is checked
+# explicitly -- a deploy script that cannot tell success from failure is the
+# same class of bug as a drain that cannot tell delivery from silence.
+ssm(){
+  local comment="$1"; shift
+  local cid
+  cid="$(aws ssm send-command --region "$REGION" --instance-ids "$INSTANCE_ID" \
+    --document-name AWS-RunShellScript --comment "$comment" \
+    --parameters "commands=$(python3 -c 'import json,sys; print(json.dumps([sys.stdin.read()]))' <<<"$*")" \
+    --query 'Command.CommandId' --output text)"
+  aws ssm wait command-executed --region "$REGION" --command-id "$cid" \
+    --instance-id "$INSTANCE_ID" 2>/dev/null || true
+  local status
+  status="$(aws ssm get-command-invocation --region "$REGION" --command-id "$cid" \
+    --instance-id "$INSTANCE_ID" --query 'Status' --output text)"
+  aws ssm get-command-invocation --region "$REGION" --command-id "$cid" \
+    --instance-id "$INSTANCE_ID" --query 'StandardOutputContent' --output text
+  if [ "$status" != "Success" ]; then
+    aws ssm get-command-invocation --region "$REGION" --command-id "$cid" \
+      --instance-id "$INSTANCE_ID" --query 'StandardErrorContent' --output text >&2
+    die "SSM step failed ($comment): status=$status command-id=$cid"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 1. Resolve the node.
+# ---------------------------------------------------------------------------
+if [ -z "$INSTANCE_ID" ]; then
+  INSTANCE_ID="$(aws ec2 describe-instances --region "$REGION" \
+    --filters "Name=tag:Name,Values=$NODE_NAME" "Name=instance-state-name,Values=running" \
+    --query 'Reservations[0].Instances[0].InstanceId' --output text 2>/dev/null || true)"
+fi
+[ -n "$INSTANCE_ID" ] && [ "$INSTANCE_ID" != "None" ] || die "no running instance named $NODE_NAME in $REGION"
+log "node $INSTANCE_ID ($NODE_NAME, $REGION)"
+
+# ---------------------------------------------------------------------------
+# 2. PREFLIGHT: can the node authenticate to DSQL at all?
+#
+# This is checked FIRST and it is fatal, because every other step can succeed
+# while this one is missing and the result is a running unit that delivers
+# nothing -- the exact shape of the outage this script exists to end.
+#
+# The DSN names user=admin, so the token is generate_db_connect_admin_auth_token
+# and the action is dsql:DbConnectAdmin (see trusted_router/postgres_dsn.py,
+# dsql_token_is_admin). A scoped role uses dsql:DbConnect instead; either is
+# accepted here.
+# ---------------------------------------------------------------------------
+NODE_ROLE="$(aws ec2 describe-instances --region "$REGION" --instance-ids "$INSTANCE_ID" \
+  --query 'Reservations[0].Instances[0].IamInstanceProfile.Arn' --output text | sed 's#.*instance-profile/##')"
+NODE_ROLE="$(aws iam get-instance-profile --instance-profile-name "$NODE_ROLE" \
+  --query 'InstanceProfile.Roles[0].RoleName' --output text)"
+CLUSTER_ARN="arn:aws:dsql:${DSQL_REGION}:${ACCOUNT}:cluster/${CLUSTER_ID}"
+log "node role: $NODE_ROLE; checking DSQL connect permission on $CLUSTER_ARN"
+DSQL_DECISION="$(aws iam simulate-principal-policy \
+  --policy-source-arn "arn:aws:iam::${ACCOUNT}:role/${NODE_ROLE}" \
+  --action-names dsql:DbConnectAdmin dsql:DbConnect \
+  --resource-arns "$CLUSTER_ARN" \
+  --query 'EvaluationResults[?EvalDecision==`allowed`].EvalActionName' --output text 2>/dev/null || true)"
+if [ -z "$DSQL_DECISION" ]; then
+  cat >&2 <<EOF
+
+FATAL: ${NODE_ROLE} cannot connect to DSQL, so the drain would start, fail
+every connection, and deliver nothing.
+
+This is an IAM change and this script will not make it. The control plane's
+role (tr-eu-app) already holds exactly this grant and is the model to copy:
+
+  aws iam put-role-policy --role-name ${NODE_ROLE} \\
+    --policy-name dsql-connect-drain \\
+    --policy-document '{
+      "Version": "2012-10-17",
+      "Statement": [{
+        "Effect": "Allow",
+        "Action": ["dsql:DbConnectAdmin"],
+        "Resource": ["${CLUSTER_ARN}"]
+      }]
+    }'
+
+PREFER A SCOPED ROLE. The drain needs SELECT and DELETE on ONE table; admin is
+every table plus DDL, on a cluster that also holds wallets, keys and the
+ledger. To scope it, grant the node dsql:DbConnect (NOT DbConnectAdmin) above,
+then, connected to DSQL as admin, run:
+
+  CREATE ROLE tr_drain WITH LOGIN;
+  AWS IAM GRANT tr_drain TO 'arn:aws:iam::${ACCOUNT}:role/${NODE_ROLE}';
+  GRANT SELECT, DELETE ON tr_operational_analytics_outbox TO tr_drain;
+
+and set user=tr_drain in TR_POSTGRES_DSN below. postgres_dsn.dsql_token_is_admin
+reads the role out of the DSN and mints the non-admin token automatically, so
+the DSN is the only thing that changes. The repo documents no scoped DSQL role
+today; this is the first one.
+EOF
+  exit 1
+fi
+log "DSQL permission present: $DSQL_DECISION"
+
+# ---------------------------------------------------------------------------
+# 3. Build the payload.
+#
+# COPYFILE_DISABLE=1 stops macOS tar from emitting ._* AppleDouble sidecars.
+# static/, templates/ and content/ are ~10 MB of web assets the drain never
+# imports; excluding them is what keeps this shippable through SSM.
+# ---------------------------------------------------------------------------
+log "building payload from $ROOT"
+COPYFILE_DISABLE=1 tar -C "$ROOT" \
+  --exclude='__pycache__' --exclude='._*' \
+  --exclude='static' --exclude='templates' --exclude='content' \
+  -czf "$WORK/drain.tgz" clickhouse src/trusted_router
+LOCAL_SHA="$(shasum -a 256 "$WORK/drain.tgz" | awk '{print $1}')"
+base64 < "$WORK/drain.tgz" | tr -d '\n' > "$WORK/drain.b64"
+split -b "$CHUNK_BYTES" "$WORK/drain.b64" "$WORK/chunk."
+CHUNKS=("$WORK"/chunk.*)
+log "payload $(wc -c < "$WORK/drain.tgz") bytes, sha256 $LOCAL_SHA, ${#CHUNKS[@]} chunks"
+
+# ---------------------------------------------------------------------------
+# 4. Ship it into a STAGING directory. Nothing in /opt/tr-clickhouse is touched
+#    until the checksum matches and the code imports.
+# ---------------------------------------------------------------------------
+ssm "drain: reset staging" "
+set -eux
+rm -rf '$STAGE_DIR' /tmp/tr-drain.b64
+mkdir -p '$STAGE_DIR'
+"
+
+i=0
+for chunk in "${CHUNKS[@]}"; do
+  i=$((i + 1))
+  printf '\rshipping chunk %d/%d' "$i" "${#CHUNKS[@]}" >&2
+  ssm "drain: chunk $i/${#CHUNKS[@]}" "
+set -eu
+printf '%s' '$(cat "$chunk")' >> /tmp/tr-drain.b64
+" >/dev/null
+done
+printf '\n' >&2
+
+ssm "drain: verify and extract" "
+set -eux
+base64 -d /tmp/tr-drain.b64 > /tmp/tr-drain.tgz
+rm -f /tmp/tr-drain.b64
+echo '$LOCAL_SHA  /tmp/tr-drain.tgz' | sha256sum -c -
+tar -xzf /tmp/tr-drain.tgz -C '$STAGE_DIR'
+rm -f /tmp/tr-drain.tgz
+# Flatten src/trusted_router -> trusted_router. The unit has no PYTHONPATH, so
+# 'python -m' can only see packages directly under WorkingDirectory.
+mv '$STAGE_DIR/src/trusted_router' '$STAGE_DIR/trusted_router'
+rmdir '$STAGE_DIR/src'
+# Belt and braces: COPYFILE_DISABLE should have prevented these, so finding one
+# means the tarball was built without it and the build is not what it claims.
+find '$STAGE_DIR' -name '._*' -print -delete
+test -z \"\$(find '$STAGE_DIR' -name '._*')\"
+test -f '$STAGE_DIR/clickhouse/ingest_operational_outbox_postgres.py'
+test -f '$STAGE_DIR/trusted_router/postgres_dsn.py'
+"
+
+# ---------------------------------------------------------------------------
+# 5. Service account, state directory, virtualenv.
+#
+# STATE_DIR must exist before the unit starts: ProtectSystem=strict makes the
+# whole filesystem read-only except ReadWritePaths, and systemd refuses to
+# start a unit whose ReadWritePaths does not resolve.
+# ---------------------------------------------------------------------------
+ssm "drain: user, state dir, venv" "
+set -eux
+id -u '$SERVICE_USER' >/dev/null 2>&1 || useradd --system --no-create-home --shell /usr/sbin/nologin '$SERVICE_USER'
+install -d -o '$SERVICE_USER' -g '$SERVICE_USER' -m 0750 '$STATE_DIR'
+test -x '$PYTHON_BIN' || { echo 'missing $PYTHON_BIN; provision 3.12 (deadsnakes on 22.04)'; exit 1; }
+'$PYTHON_BIN' -m venv '$STAGE_DIR/venv'
+'$STAGE_DIR/venv/bin/pip' install --quiet --upgrade pip
+# The drain's own dependencies. clickhouse/requirements-live.txt also carries
+# the google-cloud-* trio for the Spanner-sourced siblings, which this node has
+# no use for and no credentials for.
+'$STAGE_DIR/venv/bin/pip' install --quiet \
+  'psycopg[binary]>=3.2.0' 'boto3>=1.35.0' 'pydantic>=2' 'pydantic-settings>=2' \
+  'structlog>=24' 'python-dateutil>=2.9'
+'$STAGE_DIR/venv/bin/python' -V
+"
+
+# The gate that makes the trimmed tarball safe: if excluding static/templates/
+# content broke an import, or the venv is short a dependency, it fails HERE --
+# against the staging tree, before anything is swapped in and before the unit
+# is enabled.
+ssm "drain: import smoke test (staging)" "
+set -eux
+cd '$STAGE_DIR'
+./venv/bin/python -c 'import clickhouse.ingest_operational_outbox_postgres as m; print(\"CONFIG_EXIT_CODE\", m.CONFIG_EXIT_CODE)'
+"
+
+# ---------------------------------------------------------------------------
+# 6. Swap staging into place.
+# ---------------------------------------------------------------------------
+ssm "drain: activate $REMOTE_ROOT" "
+set -eux
+rm -rf '${REMOTE_ROOT}.previous'
+if [ -d '$REMOTE_ROOT' ]; then mv '$REMOTE_ROOT' '${REMOTE_ROOT}.previous'; fi
+mv '$STAGE_DIR' '$REMOTE_ROOT'
+ls -la '$REMOTE_ROOT'
+"
+
+# ---------------------------------------------------------------------------
+# 7. The environment file, written by RUNNING commands.
+#
+# systemd's EnvironmentFile performs NO command or variable substitution: a
+# literal \$(aws ...) written into it BECOMES the password, is non-empty so
+# every startup check passes, and then fails authentication on every insert
+# forever while the outbox grows. So the secret is fetched and written in one
+# step on the node, and never passes through this script's output, its
+# arguments, or a human's clipboard.
+#
+# There is no aws CLI on this node, so boto3 in the venv reads the secret --
+# the instance role already allows secretsmanager:GetSecretValue on quill/*.
+#
+# The DSN carries NO password: on DSQL the token is minted per connection.
+# ---------------------------------------------------------------------------
+ssm "drain: environment file" "
+set -eu
+umask 077
+cat > '$ENV_FILE' <<'ENVEOF'
+TR_POSTGRES_DSN=host=${DSQL_HOST} port=5432 user=${DSQL_USER} dbname=postgres sslmode=require
+TR_POSTGRES_IAM_AUTH=aws-dsql
+TR_POSTGRES_IAM_REGION=${DSQL_REGION}
+TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_USER=${CH_USER}
+TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_DATABASE=${CH_DATABASE}
+ENVEOF
+'$REMOTE_ROOT/venv/bin/python' - <<'PYEOF' >> '$ENV_FILE'
+import boto3
+secret = boto3.client('secretsmanager', region_name='${REGION}').get_secret_value(
+    SecretId='${SECRET_ID}')['SecretString']
+print('CH_PASSWORD=' + secret)
+PYEOF
+chmod 600 '$ENV_FILE'
+# Prove the password landed as a value and not as an unexpanded command, and
+# never print it: length and shape only.
+awk -F= '/^CH_PASSWORD=/ {print \"CH_PASSWORD length=\" length(\$2)}' '$ENV_FILE'
+grep -q '^CH_PASSWORD=\$(' '$ENV_FILE' && { echo 'CH_PASSWORD is a literal command; refusing'; exit 1; }
+cut -d= -f1 '$ENV_FILE'
+"
+
+# NOTE ON THE SECOND COPY. Stockholm does not exist yet (no instances in
+# eu-north-1 as of 2026-08-17), so no *_REPLICA_* variables are written and the
+# drain runs single-target -- one node, one copy, exactly today's behaviour.
+# When scripts/deploy/aws_eu_north_clickhouse.sh has built it, that script
+# prints the five literals and the CH_REPLICA_PASSWORD command to append here.
+
+# ---------------------------------------------------------------------------
+# 8. The unit.
+# ---------------------------------------------------------------------------
+UNIT_B64="$(base64 < "$ROOT/clickhouse/$SERVICE" | tr -d '\n')"
+ssm "drain: install unit" "
+set -eux
+printf '%s' '$UNIT_B64' | base64 -d > /etc/systemd/system/$SERVICE
+chmod 644 /etc/systemd/system/$SERVICE
+chown -R '$SERVICE_USER':'$SERVICE_USER' '$REMOTE_ROOT'
+systemctl daemon-reload
+systemctl enable --now $SERVICE
+"
+
+# ---------------------------------------------------------------------------
+# 9. Verify. A unit that is 'active' proves only that execve succeeded.
+#
+# The proof is the metrics line the sweep loop emits every poll, and a
+# ClickHouse count that is no longer zero.
+# ---------------------------------------------------------------------------
+log "waiting 45s for the first sweeps"
+sleep 45
+ssm "drain: verify" "
+set -eu
+systemctl is-active $SERVICE || true
+echo '--- metrics (operational_analytics_outbox.metrics) ---'
+journalctl -u $SERVICE --no-pager -n 200 | grep -E 'outbox\.(metrics|targets|config_invalid|backlog_alarm)' | tail -20
+echo '--- clickhouse ---'
+export CLICKHOUSE_PASSWORD=\"\$('$REMOTE_ROOT/venv/bin/python' -c \"import boto3;print(boto3.client('secretsmanager',region_name='${REGION}').get_secret_value(SecretId='${SECRET_ID}')['SecretString'],end='')\")\"
+clickhouse-client --user '$CH_USER' --database '$CH_DATABASE' --query \\
+  'SELECT (SELECT count() FROM activity_generations) AS activity, (SELECT count() FROM synthetic_probe_samples) AS synthetic FORMAT TSVWithNames'
+"
+
+cat <<EOF
+
+Installed. What "working" looks like, and what to do when it is not:
+
+  copies=1 degraded_targets=-        one node, healthy (Stockholm not built yet)
+  drain_lag_seconds falling          the backlog is draining
+  rows=0 with a large backlog        NOT healthy; read failed_shards= and the
+                                     lines above it
+
+  operational_analytics_outbox.backlog_alarm (ERROR)
+      the oldest undelivered row is past --max-lag-seconds (default 3600).
+      Expected while the 465k-row backlog drains; it should clear, not sit.
+
+  a unit in 'failed' with status=78  CONFIG_EXIT_CODE. The environment file is
+                                     wrong and RestartPreventExitStatus stopped
+                                     it deliberately rather than crash-loop.
+                                     Read: journalctl -u $SERVICE | grep config_invalid
+
+  systemctl status $SERVICE
+  journalctl -u $SERVICE -f | grep outbox.metrics
+
+Rollback: systemctl disable --now $SERVICE, then
+  mv ${REMOTE_ROOT}.previous $REMOTE_ROOT   (kept from this run)
+Nothing is lost by stopping the drain: undelivered rows stay in the outbox.
+EOF

--- a/src/trusted_router/operational_analytics_freshness.py
+++ b/src/trusted_router/operational_analytics_freshness.py
@@ -1,0 +1,129 @@
+"""The ``analytics`` section of ``/status.json``: is this cloud's drain alive?
+
+Why this exists as a *published* field rather than a check against the node
+-------------------------------------------------------------------------
+
+On the AWS-EU cloud the analytics pipeline is
+
+    settle -> tr_operational_analytics_outbox (DSQL) -> drain -> ClickHouse
+
+and every stage after the first is invisible from outside the VPC.  The Paris
+ClickHouse node listens only on its private address and its security group
+admits only the VPC CIDR, so nothing on the public internet -- a GitHub Actions
+runner included -- can ask it ``SELECT max(created_at) FROM
+activity_generations``.  A freshness check that cannot reach the thing it
+checks is not a check.
+
+The signal that *is* reachable is the outbox, and it is strictly better than a
+ClickHouse timestamp for this purpose.  Rows are deleted from the outbox only
+after ClickHouse has accepted them (``SELECT -> insert -> DELETE``, in that
+order, gated on every configured target succeeding), so the age of the OLDEST
+undelivered row is an end-to-end statement about the whole pipeline:
+
+* drain healthy      -> oldest row is seconds old
+* drain dead/failing -> oldest row ages without bound, because nothing deletes
+
+That is exactly ``drain_lag_seconds``, the number the drain itself computes and
+logs every sweep, and the number its ``backlog_alarm`` fires on.  Publishing it
+means an outside observer can see the drain stop even when the drain is not
+running to say so -- which is the failure that actually happened: between
+2026-08-02 and 2026-08-17 the drain was never installed at all, the outbox grew
+to 465,119 rows, and nothing anywhere reported it, because the alarm is emitted
+BY the process that was missing.
+
+The control plane is the natural publisher because it is already the only
+public thing that holds a DSQL connection, and the query is an index seek on
+``tr_operational_analytics_outbox_enqueued_at_idx`` (``ORDER BY enqueued_at
+LIMIT 1``), not a scan.  Note the asymmetry deliberately: ``outbox_depth`` is
+optional, because ``count(*)`` over a large backlog is the expensive question
+and the lag already answers the important one.
+
+Nothing here does IO.  The caller reads the two numbers and calls
+:func:`analytics_status_section`; :mod:`clickhouse.check_aws_analytics_freshness`
+reads the published result back with no credentials at all.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+#: Key this section occupies in the ``/status.json`` ``data`` object.
+ANALYTICS_STATUS_KEY = "analytics"
+
+#: Field names, exported so the publisher and the external checker cannot
+#: drift apart silently -- a checker reading a key nobody writes any more
+#: reports "healthy" forever, which is the same class of bug as the outage
+#: this section exists to expose.
+AVAILABLE_FIELD = "available"
+REASON_FIELD = "reason"
+BACKEND_FIELD = "backend"
+DRAIN_LAG_FIELD = "drain_lag_seconds"
+OUTBOX_DEPTH_FIELD = "outbox_depth"
+OLDEST_ENQUEUED_AT_FIELD = "oldest_enqueued_at"
+GENERATED_AT_FIELD = "generated_at"
+
+#: Mirrors ``clickhouse.ingest_operational_outbox_postgres.DEFAULT_MAX_LAG_SECONDS``.
+#: The drain logs ``backlog_alarm`` at this age; a checker that tolerated more
+#: would be quieter than the process it is watching.
+DEFAULT_MAX_DRAIN_LAG_SECONDS = 3600.0
+
+#: ``reason`` values for the unavailable form.
+REASON_NO_DATA = "no_data"
+REASON_UNREACHABLE = "unreachable"
+
+
+def _utc(value: dt.datetime) -> dt.datetime:
+    return value.replace(tzinfo=dt.UTC) if value.tzinfo is None else value.astimezone(dt.UTC)
+
+
+def _iso(value: dt.datetime) -> str:
+    return _utc(value).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def analytics_status_unavailable(reason: str = REASON_NO_DATA) -> dict[str, Any]:
+    """The section when the outbox could not be read.
+
+    Distinct from an EMPTY outbox on purpose.  An empty outbox is the healthiest
+    state there is -- everything ever enqueued has been delivered -- and
+    collapsing "I could not look" into it would turn a broken database
+    connection into a green check.
+    """
+    return {AVAILABLE_FIELD: False, REASON_FIELD: reason}
+
+
+def analytics_status_section(
+    *,
+    oldest_enqueued_at: dt.datetime | None,
+    now: dt.datetime,
+    outbox_depth: int | None = None,
+    backend: str = "postgres",
+) -> dict[str, Any]:
+    """Project the outbox's head onto the public status contract.
+
+    ``oldest_enqueued_at`` is the single row returned by ``SELECT enqueued_at
+    FROM tr_operational_analytics_outbox ORDER BY enqueued_at LIMIT 1``, or
+    ``None`` when the table is empty -- which means fully drained, so the lag
+    is 0.0 rather than unknown.
+
+    The lag is clamped at 0.  ``enqueued_at`` is ``CURRENT_TIMESTAMP`` at the
+    writer and ``now`` comes from the reader, so a few milliseconds of clock
+    skew can otherwise publish a negative age and make every downstream
+    comparison read backwards.
+    """
+    moment = _utc(now)
+    if oldest_enqueued_at is None:
+        lag = 0.0
+        oldest_iso: str | None = None
+    else:
+        oldest = _utc(oldest_enqueued_at)
+        lag = max(0.0, (moment - oldest).total_seconds())
+        oldest_iso = _iso(oldest)
+    return {
+        AVAILABLE_FIELD: True,
+        BACKEND_FIELD: backend,
+        DRAIN_LAG_FIELD: round(lag, 3),
+        OUTBOX_DEPTH_FIELD: None if outbox_depth is None else max(0, int(outbox_depth)),
+        OLDEST_ENQUEUED_AT_FIELD: oldest_iso,
+        GENERATED_AT_FIELD: _iso(moment),
+    }

--- a/tests/test_aws_analytics_drain_install.py
+++ b/tests/test_aws_analytics_drain_install.py
@@ -1,0 +1,346 @@
+"""The AWS-EU drain: its install script, its freshness contract, and the check.
+
+Background these tests are pinning down. On 2026-08-17 the drain for the
+AWS-EU cloud was found never to have been installed: no unit on
+tr-eu-clickhouse-1, no environment file, no process, `activity_generations`
+empty, and 465,119 undelivered rows in the DSQL outbox going back to
+2026-08-02. It was silent for fifteen days because every signal for this
+pipeline is emitted by the drain itself.
+
+So the assertions below are mostly about the two ways that recurs: an install
+that puts files somewhere the unit does not look, and a monitor that reports
+healthy when it is actually seeing nothing.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+from clickhouse.check_aws_analytics_freshness import evaluate
+from trusted_router.operational_analytics_freshness import (
+    ANALYTICS_STATUS_KEY,
+    AVAILABLE_FIELD,
+    DRAIN_LAG_FIELD,
+    GENERATED_AT_FIELD,
+    OLDEST_ENQUEUED_AT_FIELD,
+    OUTBOX_DEPTH_FIELD,
+    analytics_status_section,
+    analytics_status_unavailable,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALL = ROOT / "scripts/deploy/aws_eu_clickhouse_drain_install.sh"
+UNIT = ROOT / "clickhouse/tr-clickhouse-operational-ingest-postgres.service"
+WORKFLOW = ROOT / ".github/workflows/check-aws-analytics-freshness.yml"
+
+NOW = dt.datetime(2026, 8, 17, 12, 0, tzinfo=dt.UTC)
+
+
+# ---------------------------------------------------------------------------
+# The install script must agree with the unit about where the code lives.
+# ---------------------------------------------------------------------------
+
+
+def test_install_targets_the_path_the_unit_actually_execs() -> None:
+    """The reason /opt/drain was dead weight: the unit never looked there.
+
+    This is the drift guard. If someone edits WorkingDirectory or ExecStart in
+    the unit, the install script stops matching and this fails, rather than the
+    node quietly gaining a second unused copy of the drain.
+    """
+    unit = UNIT.read_text()
+    script = INSTALL.read_text()
+
+    assert "WorkingDirectory=/opt/tr-clickhouse" in unit
+    assert "ExecStart=/opt/tr-clickhouse/venv/bin/python -m clickhouse.ingest_operational_outbox_postgres" in unit
+    assert 'REMOTE_ROOT="${REMOTE_ROOT:-/opt/tr-clickhouse}"' in script
+    # The unit sets no PYTHONPATH, so `python -m` sees only WorkingDirectory:
+    # the package has to be flattened out of src/ or `import trusted_router`
+    # fails. That is precisely what /opt/drain got wrong.
+    assert "PYTHONPATH" not in unit
+    assert "mv '$STAGE_DIR/src/trusted_router' '$STAGE_DIR/trusted_router'" in script
+
+
+def test_install_creates_what_the_unit_hardening_requires() -> None:
+    """ProtectSystem=strict + ReadWritePaths refuses to start on a missing dir."""
+    unit = UNIT.read_text()
+    script = INSTALL.read_text()
+
+    assert "ReadWritePaths=/var/lib/tr-clickhouse-ingest" in unit
+    assert "User=tr-clickhouse-ingest" in unit
+    assert "useradd --system" in script
+    assert "install -d -o '$SERVICE_USER' -g '$SERVICE_USER'" in script
+
+
+def test_install_refuses_to_proceed_without_dsql_permission() -> None:
+    """The one precondition that fails silently at runtime, so it fails loudly here.
+
+    quill-enclave-role holds no dsql action at all, so without this gate the
+    script would finish "successfully" and leave a unit that connects to
+    nothing.
+    """
+    script = INSTALL.read_text()
+
+    assert "simulate-principal-policy" in script
+    assert "dsql:DbConnectAdmin dsql:DbConnect" in script
+    assert "FATAL:" in script
+    # It must document the scoped alternative rather than normalising admin on a
+    # cluster that also holds wallets, keys and the ledger.
+    assert "GRANT SELECT, DELETE ON tr_operational_analytics_outbox" in script
+    assert "AWS IAM GRANT tr_drain" in script
+
+
+def test_install_never_ships_appledouble_sidecars() -> None:
+    """/opt/drain/clickhouse currently holds four of these; they broke a parser once."""
+    script = INSTALL.read_text()
+
+    assert "COPYFILE_DISABLE=1 tar" in script
+    assert "--exclude='._*'" in script
+    assert "find '$STAGE_DIR' -name '._*' -print -delete" in script
+    # Deleting is not enough: if one survives, the tarball was not built the way
+    # this script claims, and that is worth failing over. (Escaped, because the
+    # snippet is carried to the node inside a quoted SSM command.)
+    assert r"""test -z \"\$(find '$STAGE_DIR' -name '._*')""" in script
+
+
+def test_install_stages_and_verifies_before_swapping_anything_in() -> None:
+    script = INSTALL.read_text()
+
+    assert "sha256sum -c -" in script
+    assert "import smoke test (staging)" in script
+    # The swap happens after the smoke test, never before.
+    assert script.index("import smoke test (staging)") < script.index("drain: activate")
+    assert "${REMOTE_ROOT}.previous" in script
+
+
+def test_install_writes_the_secret_by_running_a_command_not_by_pasting() -> None:
+    """EnvironmentFile does no substitution: a pasted $(...) BECOMES the password.
+
+    It is non-empty, so every startup check passes, and then authentication
+    fails on every insert forever while the outbox grows.
+    """
+    script = INSTALL.read_text()
+
+    assert "get_secret_value" in script
+    assert "print('CH_PASSWORD=' + secret)" in script
+    assert "chmod 600 '$ENV_FILE'" in script
+    assert "CH_PASSWORD is a literal command; refusing" in script
+    # Never echoed into the SSM output, which is retained and readable by
+    # anyone with ssm:GetCommandInvocation. The verification prints the key
+    # NAMES and the password's length, never its value.
+    assert "CH_PASSWORD length=" in script
+    assert "cut -d= -f1 '$ENV_FILE'" in script
+    assert "cat '$ENV_FILE'" not in script
+
+
+def test_env_file_carries_exactly_the_drain_contract_and_no_password_in_the_dsn() -> None:
+    script = INSTALL.read_text()
+
+    for key in (
+        "TR_POSTGRES_DSN=",
+        "TR_POSTGRES_IAM_AUTH=aws-dsql",
+        "TR_POSTGRES_IAM_REGION=",
+        "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_USER=",
+        "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_DATABASE=",
+    ):
+        assert key in script
+
+    # "default"/"default", not the "tr"/"tr" default: this node's schema is
+    # applied unqualified, and a mismatch fails auth only AFTER a batch has
+    # been read out of the outbox.
+    assert 'CH_USER="${CH_USER:-default}"' in script
+    assert 'CH_DATABASE="${CH_DATABASE:-default}"' in script
+
+    # On DSQL the token is minted per connection, so a password in the DSN is a
+    # configuration error the drain raises on.
+    dsn_line = next(line for line in script.splitlines() if line.startswith("TR_POSTGRES_DSN="))
+    assert "password=" not in dsn_line
+    assert "sslmode=require" in dsn_line
+
+
+def test_install_stays_single_target_until_stockholm_exists() -> None:
+    """No instances in eu-north-1 as of 2026-08-17.
+
+    Setting a _REPLICA_HOST that resolves to nothing means NOTHING is ever
+    deleted from the outbox, which is the failure this whole PR is fixing.
+    """
+    script = INSTALL.read_text()
+
+    assert "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_REPLICA_HOST=" not in script
+    assert "CH_REPLICA_PASSWORD=" not in script
+    assert "aws_eu_north_clickhouse.sh" in script
+
+
+def test_install_verifies_delivery_and_not_merely_that_the_unit_started() -> None:
+    """`active` proves execve succeeded. It does not prove a single row moved."""
+    script = INSTALL.read_text()
+
+    assert "outbox\\.(metrics|targets|config_invalid|backlog_alarm)" in script
+    assert "SELECT count() FROM activity_generations" in script
+    assert "degraded_targets" in script
+
+
+# ---------------------------------------------------------------------------
+# The published freshness contract.
+# ---------------------------------------------------------------------------
+
+
+def test_empty_outbox_is_zero_lag_and_not_missing_data() -> None:
+    """A fully drained outbox is the healthiest state, not an absence of signal."""
+    section = analytics_status_section(oldest_enqueued_at=None, now=NOW, outbox_depth=0)
+
+    assert section[AVAILABLE_FIELD] is True
+    assert section[DRAIN_LAG_FIELD] == 0.0
+    assert section[OUTBOX_DEPTH_FIELD] == 0
+    assert section[OLDEST_ENQUEUED_AT_FIELD] is None
+
+
+def test_unavailable_is_distinguishable_from_drained() -> None:
+    """Collapsing "could not look" into "nothing queued" turns an outage green."""
+    section = analytics_status_unavailable()
+
+    assert section[AVAILABLE_FIELD] is False
+    assert DRAIN_LAG_FIELD not in section
+
+
+def test_lag_is_the_age_of_the_oldest_undelivered_row() -> None:
+    section = analytics_status_section(
+        oldest_enqueued_at=NOW - dt.timedelta(hours=2),
+        now=NOW,
+        outbox_depth=465_119,
+    )
+
+    assert section[DRAIN_LAG_FIELD] == 7200.0
+    assert section[OUTBOX_DEPTH_FIELD] == 465_119
+    assert section[OLDEST_ENQUEUED_AT_FIELD] == "2026-08-17T10:00:00Z"
+
+
+def test_clock_skew_cannot_publish_a_negative_age() -> None:
+    """enqueued_at comes from the writer's clock, now from the reader's."""
+    section = analytics_status_section(
+        oldest_enqueued_at=NOW + dt.timedelta(seconds=3),
+        now=NOW,
+    )
+
+    assert section[DRAIN_LAG_FIELD] == 0.0
+
+
+def test_naive_timestamps_are_read_as_utc() -> None:
+    section = analytics_status_section(
+        oldest_enqueued_at=dt.datetime(2026, 8, 17, 11, 0),
+        now=NOW,
+    )
+
+    assert section[DRAIN_LAG_FIELD] == 3600.0
+
+
+# ---------------------------------------------------------------------------
+# The external check.
+# ---------------------------------------------------------------------------
+
+
+def _payload(**overrides: object) -> dict[str, object]:
+    section: dict[str, object] = dict(
+        analytics_status_section(
+            oldest_enqueued_at=NOW - dt.timedelta(seconds=30),
+            now=NOW,
+            outbox_depth=12,
+        )
+    )
+    section.update(overrides)
+    return {ANALYTICS_STATUS_KEY: section}
+
+
+def test_healthy_drain_reports_no_problems() -> None:
+    assert evaluate(_payload(), now=NOW) == []
+
+
+def test_missing_section_fails_rather_than_skips() -> None:
+    """A monitor that treats "no signal" as "no problem" is decorative.
+
+    This is the exact state of the live tr-eu /status.json today, which is why
+    the workflow ships without a schedule trigger.
+    """
+    problems = evaluate({}, now=NOW)
+
+    assert len(problems) == 1
+    assert ANALYTICS_STATUS_KEY in problems[0]
+
+
+def test_unavailable_section_fails() -> None:
+    problems = evaluate({ANALYTICS_STATUS_KEY: analytics_status_unavailable()}, now=NOW)
+
+    assert len(problems) == 1
+    assert "no_data" in problems[0]
+
+
+def test_backlog_older_than_the_drains_own_alarm_fails() -> None:
+    """3600s is DEFAULT_MAX_LAG_SECONDS; a check looser than the daemon is useless."""
+    problems = evaluate(
+        _payload(**{DRAIN_LAG_FIELD: 7200.0}),
+        now=NOW,
+    )
+
+    assert any("7200s old" in problem for problem in problems)
+
+
+def test_frozen_control_plane_is_caught_by_the_sections_own_age() -> None:
+    """Otherwise a stuck publisher serves a healthy-looking lag forever."""
+    problems = evaluate(
+        _payload(**{GENERATED_AT_FIELD: "2026-08-16T12:00:00Z"}),
+        now=NOW,
+    )
+
+    assert any("analytics section is" in problem for problem in problems)
+
+
+def test_depth_bound_is_opt_in() -> None:
+    """count(*) over a big backlog is the expensive question; lag answers the real one."""
+    payload = _payload(**{OUTBOX_DEPTH_FIELD: 465_119})
+
+    assert evaluate(payload, now=NOW) == []
+    assert evaluate(payload, now=NOW, max_outbox_depth=1_000) != []
+
+
+def test_unparseable_lag_is_a_problem_not_a_pass() -> None:
+    problems = evaluate(_payload(**{DRAIN_LAG_FIELD: "soon"}), now=NOW)
+
+    assert any(DRAIN_LAG_FIELD in problem for problem in problems)
+
+
+# ---------------------------------------------------------------------------
+# The workflow.
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_needs_no_cloud_credentials() -> None:
+    """The whole reason for publishing the field: the check is a plain GET."""
+    workflow = WORKFLOW.read_text()
+
+    assert "configure-aws-credentials" not in workflow
+    assert "role-to-assume" not in workflow
+    assert "google-github-actions/auth" not in workflow
+    assert "clickhouse.check_aws_analytics_freshness" in workflow
+
+
+def test_workflow_does_not_page_before_the_field_is_deployed() -> None:
+    """A daily issue about a field nobody deployed trains people to ignore it."""
+    workflow = WORKFLOW.read_text()
+
+    # No ACTIVE schedule trigger. Matched at the two-space indent a real trigger
+    # sits at under `on:`, so the commented-out example in the header (which is
+    # the instruction for enabling it later) does not satisfy this.
+    assert "\n  schedule:" not in workflow
+    assert "\n  workflow_dispatch:" in workflow
+    assert "OPERATOR STEPS BEFORE THE SCHEDULE IS ENABLED" in workflow
+
+
+def test_workflow_issue_names_the_never_installed_case() -> None:
+    """The failure that actually happened must be in the runbook, not inferred."""
+    workflow = WORKFLOW.read_text()
+
+    assert "aws_eu_clickhouse_drain_install.sh" in workflow
+    assert "the unit was never installed" in workflow
+    assert "status **78**" in workflow
+    assert "aws-analytics-freshness" in workflow


### PR DESCRIPTION
## What was found

The AWS-EU analytics pipeline — `settle -> tr_operational_analytics_outbox (DSQL) -> drain -> ClickHouse` — **has never run**.

On 2026-08-17, `tr-eu-clickhouse-1` (`i-025ed1c1766f61290`) held drain code from 2026-08-02 under `/opt/drain`, with **no systemd unit, no `/etc/tr-clickhouse-ingest-postgres.env`, and no process**. On the node:

```
activity_generations = 0     synthetic_probe_samples = 0
```

In the DSQL outbox (`tnt642i3ofzpn5z62msacutpuu`, eu-west-3), read live:

| event_kind | rows | oldest | newest |
|---|---|---|---|
| synthetic | 399,760 | 2026-08-02 21:48:50Z | 2026-08-17 04:47:54Z |
| activity | 65,361 | 2026-08-10 14:32:36Z | 2026-08-17 04:48:36Z |

**465,119 rows across all 32 shards.** Nothing was lost — the drain deletes an outbox row only after ClickHouse accepts it, so a drain that never ran means the outbox *grew*. The cost is fifteen days of freshness, and DSQL storage.

It was silent for a structural reason: every signal for this pipeline — the metrics line, `degraded_targets=`, and the `backlog_alarm` that is the *only* bound on outbox growth — is emitted **by the drain**. A drain that does not exist cannot alarm about not existing.

## Two pieces, matching the two problems

### 1. `scripts/deploy/aws_eu_clickhouse_drain_install.sh`

- Targets **`/opt/tr-clickhouse`**, because that is what the unit already execs. The unit sets no `PYTHONPATH`, so `python -m` sees only `WorkingDirectory` — which is why the existing `/opt/drain/src/trusted_router` layout could not have satisfied it even if pointed there. The script flattens `src/trusted_router` → `trusted_router`. A test pins the script against the unit so the two cannot drift.
- Ships code as **base64 chunks through SSM**. Not S3: the node's role has no `s3:GetObject`, and the only buckets in the account are tf-state, cloudtrail, alb-access-logs, device-keys and the trust site — none is a build-artifact bucket. Staged, `sha256sum -c`, and **import-smoke-tested before anything is swapped in**; previous tree kept for rollback.
- `COPYFILE_DISABLE=1`, deletes `._*` sidecars, and **fails if one survives**. `/opt/drain/clickhouse` currently holds four.
- **Refuses to install when the node cannot reach DSQL** — which today it cannot. `quill-enclave-role` grants secretsmanager, kms, ecr and logs, and **no `dsql` action at all**. Without this gate the script would finish "successfully" and leave a unit connected to nothing. It prints the grant and prefers a **scoped role** (`dsql:DbConnect` + `SELECT, DELETE` on the one table) over admin on a cluster that also holds wallets, keys and the ledger.
- Writes the secret by **running** the fetch, never pasting — `EnvironmentFile` does no substitution, so a literal `$(aws ...)` *becomes* the password, passes every startup check, and fails auth forever.
- Verifies delivery (metrics line + a non-zero ClickHouse count), not merely that the unit reached `active`.
- Stays **single-target**: there are no instances in eu-north-1, and a `_REPLICA_HOST` pointing at nothing would mean nothing is ever deleted.

### 2. `.github/workflows/check-aws-analytics-freshness.yml`

The Paris node is private, so a runner cannot ask it for `max(created_at)`. The check reads **`drain_lag_seconds`** — the age of the oldest row still in the outbox — from the control plane's already-public `/status.json`, **with no credentials**. Rows leave the outbox only after ClickHouse accepts them, so that number is end-to-end and cannot be satisfied by a drain writing nowhere.

Alternatives rejected for needing more infrastructure to learn the same number: querying DSQL from Actions (needs a new OIDC provider + role — there is none today), and a node-side heartbeat (same IAM, plus a timer whose own failure is invisible again).

A **missing section is a failure, not a skip.** Verified against the live feed:

```
$ python -m clickhouse.check_aws_analytics_freshness
aws-eu analytics freshness: FAIL drain_lag_seconds=None
  - /status.json has no analytics section (the control plane does not publish drain lag)
```

Because that field is not published yet, the workflow ships **with no `schedule:` trigger** — a daily issue about a field nobody deployed trains people to ignore it. The header lists the two operator steps that precede enabling it.

## Operator steps (not done here — all require IAM or deploys)

1. **Grant DSQL connect** to `quill-enclave-role` (the install script prints it; scoped role preferred). Nothing else can proceed.
2. Run the install script.
3. Wire `analytics_status_section` into `/status.json` on the AWS deployment (`SELECT enqueued_at FROM tr_operational_analytics_outbox ORDER BY enqueued_at LIMIT 1` — an index seek on the existing index). The builder and its contract are in this PR and tested; only the wiring and a STORE read remain.
4. Add the `schedule:` trigger and verify once with `workflow_dispatch`.

Expect `backlog_alarm` while the 465k backlog drains — it must **fall, not sit**.

## Gates

`uv run ruff check .` clean · `uv run mypy` clean (275 files) · `uv run pytest -q tests/test_aws_analytics_drain_install.py tests/test_clickhouse_operational_deploy.py tests/test_clickhouse_node_provisioning.py` → **60 passed**.

All five files are new; no pre-existing file was modified and `ruff format` was not run over anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
