### PR TITLE
Add the explainer video to the homepage

### DIFF
--- a/frontend/src/dashboard.ts
+++ b/frontend/src/dashboard.ts
@@ -148,6 +148,35 @@ function trackEngagedLanding(): void {
   }, 1500);
 }
 
+// Swap a click-to-load video facade for the real player.
+//
+// The facade exists so the homepage makes NO third-party request until the
+// visitor asks for one. A page whose claim is "we cannot read your requests"
+// should not hand Google a pageview to render. We therefore load the
+// privacy-enhanced host (youtube-nocookie.com), and only on an explicit press.
+function loadVideoEmbed(facade: HTMLElement): void {
+  const videoId = facade.dataset.videoId;
+  if (!videoId || facade.classList.contains("is-loaded")) {
+    return;
+  }
+  const start = Number.parseInt(facade.dataset.videoStart ?? "", 10);
+  const params = new URLSearchParams({ autoplay: "1", rel: "0" });
+  if (Number.isFinite(start) && start > 0) {
+    params.set("start", String(start));
+  }
+  const iframe = document.createElement("iframe");
+  iframe.src = `https://www.youtube-nocookie.com/embed/${encodeURIComponent(videoId)}?${params}`;
+  iframe.title = facade.dataset.videoTitle || "TrustedRouter explainer video";
+  iframe.allow = "accelerometer; autoplay; encrypted-media; picture-in-picture";
+  iframe.referrerPolicy = "strict-origin-when-cross-origin";
+  iframe.setAttribute("allowfullscreen", "");
+  facade.classList.add("is-loaded");
+  facade.replaceChildren(iframe);
+  facade.removeAttribute("role");
+  facade.removeAttribute("tabindex");
+  facade.removeAttribute("aria-label");
+}
+
 async function copyCode(button: HTMLElement): Promise<void> {
   const targetId = button.dataset.copyTarget;
   const target = targetId ? document.getElementById(targetId) : null;
@@ -314,6 +343,12 @@ function init(): void {
       event.preventDefault();
       void startMetaMaskSignin();
     }
+    const videoFacade = target.closest('[data-action="load-video"]') as HTMLElement | null;
+    if (videoFacade) {
+      event.preventDefault();
+      loadVideoEmbed(videoFacade);
+      return;
+    }
     const regionLi = target.closest(".region-list li[data-region-id]") as HTMLElement | null;
     if (regionLi && regionLi.dataset.regionId) {
       selectRegion(regionLi.dataset.regionId);
@@ -329,6 +364,15 @@ function init(): void {
     if (regionLi && regionLi.dataset.regionId) {
       event.preventDefault();
       selectRegion(regionLi.dataset.regionId);
+      return;
+    }
+    // The video facade is a role="button", so it must answer Enter/Space too.
+    const videoFacade = target && target.closest
+      ? (target.closest('[data-action="load-video"]') as HTMLElement | null)
+      : null;
+    if (videoFacade) {
+      event.preventDefault();
+      loadVideoEmbed(videoFacade);
     }
   });
 

--- a/src/trusted_router/static/dashboard.css
+++ b/src/trusted_router/static/dashboard.css
@@ -894,3 +894,47 @@ input, select { width:100%; border:1px solid var(--line); border-radius:7px; pad
   .home-matrix .matrix-row { grid-template-columns:1.3fr 1fr; }
   .home-matrix .matrix-row > *:nth-child(3) { display:none; }
 }
+
+/* Explainer video — click-to-load facade.
+   No third-party request until the visitor presses play; only then is the
+   privacy-enhanced player injected. See dashboard.html for the rationale. */
+.video-embed {
+  position:relative;
+  aspect-ratio:16 / 9;
+  width:100%;
+  border:1px solid var(--line);
+  border-radius:14px;
+  background:var(--code-bg);
+  cursor:pointer;
+  overflow:hidden;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  transition:border-color .16s ease;
+}
+.video-embed:hover,
+.video-embed:focus-visible { border-color:var(--accent); }
+.video-embed:focus-visible { outline:2px solid var(--accent); outline-offset:3px; }
+.video-embed-play {
+  width:74px; height:74px; border-radius:50%;
+  border:1px solid var(--line);
+  background:var(--panel);
+  display:flex; align-items:center; justify-content:center;
+  transition:transform .16s ease, border-color .16s ease;
+}
+.video-embed-play::after {
+  content:""; margin-left:5px;
+  border-style:solid; border-width:13px 0 13px 21px;
+  border-color:transparent transparent transparent var(--text);
+}
+.video-embed:hover .video-embed-play { transform:scale(1.06); border-color:var(--accent); }
+.video-embed-note {
+  position:absolute; left:0; right:0; bottom:14px;
+  text-align:center; font-size:12px; color:var(--muted);
+}
+.video-embed.is-loaded { cursor:default; background:#000; }
+.video-embed iframe { position:absolute; inset:0; width:100%; height:100%; border:0; }
+@media (prefers-reduced-motion: reduce) {
+  .video-embed, .video-embed-play { transition:none; }
+  .video-embed:hover .video-embed-play { transform:none; }
+}

--- a/src/trusted_router/static/dashboard.css
+++ b/src/trusted_router/static/dashboard.css
@@ -934,6 +934,7 @@ input, select { width:100%; border:1px solid var(--line); border-radius:7px; pad
 }
 .video-embed.is-loaded { cursor:default; background:#000; }
 .video-embed iframe { position:absolute; inset:0; width:100%; height:100%; border:0; }
+
 @media (prefers-reduced-motion: reduce) {
   .video-embed, .video-embed-play { transition:none; }
   .video-embed:hover .video-embed-play { transform:none; }

--- a/src/trusted_router/static/dashboard.js
+++ b/src/trusted_router/static/dashboard.js
@@ -138,6 +138,34 @@ function trackEngagedLanding() {
         }
     }, 1500);
 }
+// Swap a click-to-load video facade for the real player.
+//
+// The facade exists so the homepage makes NO third-party request until the
+// visitor asks for one. A page whose claim is "we cannot read your requests"
+// should not hand Google a pageview to render. We therefore load the
+// privacy-enhanced host (youtube-nocookie.com), and only on an explicit press.
+function loadVideoEmbed(facade) {
+    const videoId = facade.dataset.videoId;
+    if (!videoId || facade.classList.contains("is-loaded")) {
+        return;
+    }
+    const start = Number.parseInt(facade.dataset.videoStart ?? "", 10);
+    const params = new URLSearchParams({ autoplay: "1", rel: "0" });
+    if (Number.isFinite(start) && start > 0) {
+        params.set("start", String(start));
+    }
+    const iframe = document.createElement("iframe");
+    iframe.src = `https://www.youtube-nocookie.com/embed/${encodeURIComponent(videoId)}?${params}`;
+    iframe.title = facade.dataset.videoTitle || "TrustedRouter explainer video";
+    iframe.allow = "accelerometer; autoplay; encrypted-media; picture-in-picture";
+    iframe.referrerPolicy = "strict-origin-when-cross-origin";
+    iframe.setAttribute("allowfullscreen", "");
+    facade.classList.add("is-loaded");
+    facade.replaceChildren(iframe);
+    facade.removeAttribute("role");
+    facade.removeAttribute("tabindex");
+    facade.removeAttribute("aria-label");
+}
 async function copyCode(button) {
     const targetId = button.dataset.copyTarget;
     const target = targetId ? document.getElementById(targetId) : null;
@@ -303,6 +331,12 @@ function init() {
             event.preventDefault();
             void startMetaMaskSignin();
         }
+        const videoFacade = target.closest('[data-action="load-video"]');
+        if (videoFacade) {
+            event.preventDefault();
+            loadVideoEmbed(videoFacade);
+            return;
+        }
         const regionLi = target.closest(".region-list li[data-region-id]");
         if (regionLi && regionLi.dataset.regionId) {
             selectRegion(regionLi.dataset.regionId);
@@ -318,6 +352,15 @@ function init() {
         if (regionLi && regionLi.dataset.regionId) {
             event.preventDefault();
             selectRegion(regionLi.dataset.regionId);
+            return;
+        }
+        // The video facade is a role="button", so it must answer Enter/Space too.
+        const videoFacade = target && target.closest
+            ? target.closest('[data-action="load-video"]')
+            : null;
+        if (videoFacade) {
+            event.preventDefault();
+            loadVideoEmbed(videoFacade);
         }
     });
     // Don't auto-pop the sign-in modal on `?reason=signin` if the user is

--- a/src/trusted_router/templates/dashboard.html
+++ b/src/trusted_router/templates/dashboard.html
@@ -92,6 +92,35 @@
       <div class="charter-stat"><strong>Public</strong><span>Source and status</span></div>
     </section>
 
+    <section class="home-section" aria-label="How {{ brand_name }} works">
+      <div class="home-wrap narrow">
+        <div class="section-lead center">
+          <div class="kicker">Watch</div>
+          <h2>How {{ brand_name }} works</h2>
+        </div>
+        {#
+          Click-to-load facade, deliberately. A standard YouTube embed contacts
+          Google and sets tracking cookies on page load — indefensible on a page
+          whose claim is that we cannot read your requests. Nothing leaves the
+          browser until the visitor presses play; only then do we load the
+          privacy-enhanced (youtube-nocookie) player. It is also faster: no
+          third-party iframe on first paint.
+        #}
+        <div
+          class="video-embed"
+          data-action="load-video"
+          data-video-id="UzLY4kvjklI"
+          data-video-start="128"
+          role="button"
+          tabindex="0"
+          aria-label="Play: how {{ brand_name }} works (loads YouTube)"
+        >
+          <span class="video-embed-play" aria-hidden="true"></span>
+          <span class="video-embed-note">Loads YouTube only when you press play</span>
+        </div>
+      </div>
+    </section>
+
     <nav class="home-topic-links" aria-label="TrustedRouter developer resources">
       <span>Explore</span>
       <a href="/compare/models">Model comparisons</a>

--- a/tests/browser/dashboard.spec.js
+++ b/tests/browser/dashboard.spec.js
@@ -582,3 +582,48 @@ test("model picker has no horizontal overflow at mobile width", async ({ page })
   );
   expect(overflow).toBeLessThanOrEqual(2);
 });
+
+test("homepage explainer video contacts YouTube only after an explicit press", async ({
+  page,
+}) => {
+  const thirdParty = [];
+  page.on("request", (request) => {
+    if (/youtube|ytimg|googlevideo/.test(request.url())) {
+      thirdParty.push(request.url());
+    }
+  });
+
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "How TrustedRouter works" })).toBeVisible();
+
+  const facade = page.locator('[data-action="load-video"]');
+  await expect(facade).toBeVisible();
+
+  // The point of the facade: a privacy-first homepage must not hand Google a
+  // pageview to render. Nothing may be requested before the visitor asks.
+  await expect(page.locator('[data-action="load-video"] iframe')).toHaveCount(0);
+  expect(thirdParty).toEqual([]);
+
+  await facade.click();
+
+  const frame = page.locator('[data-action="load-video"] iframe');
+  await expect(frame).toHaveCount(1);
+  const src = await frame.getAttribute("src");
+  // Privacy-enhanced host, and the timestamp the video actually explains from.
+  expect(src).toContain("youtube-nocookie.com/embed/UzLY4kvjklI");
+  expect(src).toContain("start=128");
+
+  // Once loaded it is a player, not a button.
+  await expect(facade).not.toHaveAttribute("role", "button");
+  await facade.click();
+  await expect(frame).toHaveCount(1);
+});
+
+test("homepage explainer video is keyboard operable", async ({ page }) => {
+  await page.goto("/");
+  const facade = page.locator('[data-action="load-video"]');
+  await expect(facade).toHaveAttribute("role", "button");
+  await facade.focus();
+  await page.keyboard.press("Enter");
+  await expect(page.locator('[data-action="load-video"] iframe')).toHaveCount(1);
+});


### PR DESCRIPTION
Places the TrustedRouter explainer video between the stat band and the customer story, starting at **2:08 (`t=128`)** — the timestamp where the explanation begins.

## Why a facade instead of a plain embed

A standard YouTube iframe contacts Google and sets tracking cookies **on page load**. That is hard to defend on a page whose headline claim is *"Even our engineers cannot read your requests."* A visitor who opens devtools on our homepage should not find a third-party tracker there.

So the section renders a lightweight click-to-load facade. Nothing leaves the browser until the visitor presses play; only then is the privacy-enhanced `youtube-nocookie.com` player injected. Bonus: no third-party iframe on the critical path to first paint.

## Accessibility

The facade is a `role="button"` with an `aria-label`, answers **Enter/Space** as well as click, has a visible `:focus-visible` outline, and **sheds its button semantics** (`role`, `tabindex`, `aria-label`) once it becomes a player. Re-clicking is idempotent — no stacked iframes. Honours `prefers-reduced-motion`.

## Note on the build

Behaviour is edited in `frontend/src/dashboard.ts` and compiled to the checked-in bundle via `npm run build` (`tsconfig` outputs to `src/trusted_router/static`). Both are in the diff — editing `dashboard.js` directly would have been overwritten by the next build.

## Tests

Two new Playwright tests assert the property that actually matters:

- **zero** `youtube` / `ytimg` / `googlevideo` requests before the press, then exactly one iframe whose src contains `youtube-nocookie.com/embed/UzLY4kvjklI` and `start=128`
- keyboard operation via Enter

Both pass in a real browser. Also verified live against a local server: 0 iframes and 0 Google resources before click; after click, `https://www.youtube-nocookie.com/embed/UzLY4kvjklI?autoplay=1&rel=0&start=128`.

`ruff` clean, `tsc --noEmit` clean, 84 existing public-page tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)