### PR TITLE
aws-eu drain install: send SSM commands as JSON, not CLI shorthand

### DIFF
--- a/clickhouse/tr-clickhouse-operational-ingest-postgres.service
+++ b/clickhouse/tr-clickhouse-operational-ingest-postgres.service
@@ -8,6 +8,17 @@ Type=simple
 User=tr-clickhouse-ingest
 Group=tr-clickhouse-ingest
 WorkingDirectory=/opt/tr-clickhouse
+# libpq resolves a client certificate at $HOME/.postgresql/postgresql.crt on
+# every connect. ProtectHome=true (below) makes /home unreadable, and libpq
+# treats "Permission denied" on that path as FATAL -- unlike a missing file,
+# which it ignores. Without this line the drain authenticated fine and then
+# failed every single connection with
+#   could not open certificate file "/home/tr-clickhouse-ingest/.postgresql/postgresql.crt"
+# reporting failed_shards=32, rows=0 while the unit sat "active". HOME must
+# therefore point inside ReadWritePaths, which is also what the archive
+# sibling does. DSQL uses an IAM token, never a client cert, so the file is
+# expected to be absent -- it just must be absent READABLY.
+Environment=HOME=/var/lib/tr-clickhouse-ingest
 # The venv MUST be built on Python >= 3.11. trusted_router.types imports
 # StrEnum, which is 3.11+. The AWS-EU ClickHouse node runs Ubuntu 22.04 whose
 # system python is 3.10, so `python3 -m venv` there produces an interpreter

--- a/scripts/deploy/aws_eu_clickhouse_drain_install.sh
+++ b/scripts/deploy/aws_eu_clickhouse_drain_install.sh
@@ -110,10 +110,21 @@ die(){ printf '\nFATAL: %s\n' "$*" >&2; exit 1; }
 # same class of bug as a drain that cannot tell delivery from silence.
 ssm(){
   local comment="$1"; shift
-  local cid
+  local cid params
+  # --parameters MUST arrive as a file:// JSON document, never as
+  # "commands=[...]". The latter looks like JSON but the CLI parses key=[a,b]
+  # with its SHORTHAND parser, which does not decode JSON escapes: every \n
+  # stayed a literal backslash-n, the remote script arrived as ONE line, and
+  # the leading "\nset -eux" ran as the command `nset`:
+  #     _script.sh: 1: nset: not found   (exit 127)
+  # Shorthand also splits on commas, so any command containing one would be
+  # silently torn into separate list elements. JSON in, JSON parsed.
+  params="$WORK/ssm-params.json"
+  python3 -c 'import json,sys; json.dump({"commands": [sys.stdin.read()]}, sys.stdout)' \
+    <<<"$*" > "$params"
   cid="$(aws ssm send-command --region "$REGION" --instance-ids "$INSTANCE_ID" \
     --document-name AWS-RunShellScript --comment "$comment" \
-    --parameters "commands=$(python3 -c 'import json,sys; print(json.dumps([sys.stdin.read()]))' <<<"$*")" \
+    --parameters "file://$params" \
     --query 'Command.CommandId' --output text)"
   aws ssm wait command-executed --region "$REGION" --command-id "$cid" \
     --instance-id "$INSTANCE_ID" 2>/dev/null || true

--- a/scripts/deploy/aws_eu_clickhouse_drain_install.sh
+++ b/scripts/deploy/aws_eu_clickhouse_drain_install.sh
@@ -280,6 +280,9 @@ test -f '$STAGE_DIR/trusted_router/postgres_dsn.py'
 ssm "drain: user, state dir, venv" "
 set -eux
 id -u '$SERVICE_USER' >/dev/null 2>&1 || useradd --system --no-create-home --shell /usr/sbin/nologin '$SERVICE_USER'
+# The unit pins HOME here (see its comment: ProtectHome + libpq's cert lookup).
+# Create it whether or not the user already existed with a /home entry.
+install -d -o '$SERVICE_USER' -g '$SERVICE_USER' -m 0750 /var/lib/tr-clickhouse-ingest
 install -d -o '$SERVICE_USER' -g '$SERVICE_USER' -m 0750 '$STATE_DIR'
 test -x '$PYTHON_BIN' || { echo 'missing $PYTHON_BIN; provision 3.12 (deadsnakes on 22.04)'; exit 1; }
 '$PYTHON_BIN' -m venv '$STAGE_DIR/venv'


### PR DESCRIPTION
The installer's first SSM step died with `_script.sh: 1: nset: not found` (exit 127).

`nset` is `\nset` after the shell collapsed a literal backslash-n. `--parameters "commands=[<json>]"` *looks* like JSON but the AWS CLI parses `key=[a,b]` with its **shorthand** parser, which doesn't decode JSON escapes — the whole remote script arrived as one line beginning `\nset -eux`. Shorthand also splits on commas, so any command containing one would have been torn in half just as quietly.

`--parameters "file://<json>"` makes the CLI parse real JSON.

**Verified on the live node** with a read-only payload — Status=Success and `set -x` traced three separate lines (`+ echo LINE_ONE` / `+ echo LINE_TWO` / `+ uname -s`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)