### PR TITLE
Archive verified ClickHouse days on every cloud, not only GCP

### DIFF
--- a/clickhouse/archive_daily.py
+++ b/clickhouse/archive_daily.py
@@ -472,6 +472,275 @@ class GCSArchiveStore:
         )
 
 
+class S3ArchiveStore:
+    """The same immutable archive on S3, for the AWS deployment.
+
+    S3's conditional writes carry the same meaning as the GCS store's
+    generation preconditions: ``IfNoneMatch="*"`` is create-if-absent, and a
+    pointer move is a compare-and-set on the current ETag.  So a 412 here is
+    a concurrent writer or a genuine content difference -- never a transport
+    error -- and is resolved by re-reading and comparing, exactly as the GCS
+    store resolves ``PreconditionFailed``, rather than by retrying.
+
+    A retry would be the dangerous choice: retrying an unconditional write is
+    how an "immutable" archive quietly stops being immutable.
+    """
+
+    scheme = "s3"
+
+    def __init__(self, *, bucket: str, region: str | None = None) -> None:
+        import boto3
+
+        self._bucket = bucket
+        self._client = boto3.client("s3", region_name=region)
+
+    def _uri(self, key: str) -> str:
+        return f"s3://{self._bucket}/{key}"
+
+    @staticmethod
+    def _is_precondition_failure(error: Any) -> bool:
+        response = getattr(error, "response", {}) or {}
+        code = str(response.get("Error", {}).get("Code", ""))
+        status = response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+        # ConditionalRequestConflict is S3's 409 for two conditional writes
+        # racing on the same key; it means the same thing as a 412 here.
+        return code in {"PreconditionFailed", "ConditionalRequestConflict"} or status in {409, 412}
+
+    @staticmethod
+    def _is_missing(error: Any) -> bool:
+        response = getattr(error, "response", {}) or {}
+        code = str(response.get("Error", {}).get("Code", ""))
+        status = response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+        return code in {"NoSuchKey", "404", "NotFound"} or status == 404
+
+    def read_json(self, key: str) -> dict[str, Any] | None:
+        from botocore.exceptions import ClientError
+
+        try:
+            body = self._client.get_object(Bucket=self._bucket, Key=key)["Body"].read()
+        except ClientError as error:
+            if self._is_missing(error):
+                return None
+            raise
+        value = json.loads(body)
+        if not isinstance(value, dict):
+            raise RuntimeError(f"archive object {key} is not a JSON object")
+        return value
+
+    def _stored_sha256(self, key: str) -> str | None:
+        # S3 lowercases user metadata keys on the way out.
+        head = self._client.head_object(Bucket=self._bucket, Key=key)
+        metadata = {str(k).lower(): v for k, v in (head.get("Metadata") or {}).items()}
+        return metadata.get("sha256")
+
+    def put_file_if_absent(
+        self,
+        key: str,
+        path: Path,
+        *,
+        sha256: str,
+        metadata: dict[str, str],
+    ) -> None:
+        from botocore.exceptions import ClientError
+
+        with path.open("rb") as stream:
+            try:
+                self._client.put_object(
+                    Bucket=self._bucket,
+                    Key=key,
+                    Body=stream,
+                    ContentType="application/vnd.apache.parquet",
+                    Metadata={**metadata, "sha256": sha256},
+                    IfNoneMatch="*",
+                )
+            except ClientError as error:
+                if not self._is_precondition_failure(error):
+                    raise
+                if self._stored_sha256(key) != sha256:
+                    raise RuntimeError(
+                        f"immutable archive object differs: {self._uri(key)}"
+                    ) from None
+
+    def put_json_if_absent(self, key: str, value: dict[str, Any]) -> None:
+        from botocore.exceptions import ClientError
+
+        encoded = _json_bytes(value)
+        try:
+            self._client.put_object(
+                Bucket=self._bucket,
+                Key=key,
+                Body=encoded,
+                ContentType="application/json",
+                IfNoneMatch="*",
+            )
+        except ClientError as error:
+            if not self._is_precondition_failure(error):
+                raise
+            existing = self._client.get_object(Bucket=self._bucket, Key=key)["Body"].read()
+            if existing != encoded:
+                raise RuntimeError(
+                    f"immutable archive manifest differs: {self._uri(key)}"
+                ) from None
+
+    def put_json_pointer(self, key: str, value: dict[str, Any]) -> None:
+        from botocore.exceptions import ClientError
+
+        encoded = _json_bytes(value)
+        try:
+            head = self._client.head_object(Bucket=self._bucket, Key=key)
+        except ClientError as error:
+            if not self._is_missing(error):
+                raise
+            head = None
+        condition = {"IfNoneMatch": "*"} if head is None else {"IfMatch": head["ETag"]}
+        self._client.put_object(
+            Bucket=self._bucket,
+            Key=key,
+            Body=encoded,
+            ContentType="application/json",
+            **condition,
+        )
+
+
+class AzureBlobArchiveStore:
+    """The same immutable archive on Azure Blob Storage.
+
+    ``overwrite=False`` is Azure's create-if-absent, and a pointer move is an
+    ``If-Match`` on the current ETag, so the preconditions line up with the
+    other two stores.  ``ResourceExistsError`` and
+    ``ResourceModifiedError`` are the conflict signals, and both are resolved
+    by comparison rather than retry for the reason given on
+    :class:`S3ArchiveStore`.
+    """
+
+    scheme = "azure"
+
+    def __init__(self, *, account_url: str, container: str) -> None:
+        from azure.identity import DefaultAzureCredential
+        from azure.storage.blob import BlobServiceClient
+
+        self._container_name = container
+        self._container = BlobServiceClient(
+            account_url=account_url,
+            credential=DefaultAzureCredential(),
+        ).get_container_client(container)
+
+    def _uri(self, key: str) -> str:
+        return f"azure://{self._container_name}/{key}"
+
+    def read_json(self, key: str) -> dict[str, Any] | None:
+        from azure.core.exceptions import ResourceNotFoundError
+
+        try:
+            body = self._container.get_blob_client(key).download_blob().readall()
+        except ResourceNotFoundError:
+            return None
+        value = json.loads(body)
+        if not isinstance(value, dict):
+            raise RuntimeError(f"archive object {key} is not a JSON object")
+        return value
+
+    def put_file_if_absent(
+        self,
+        key: str,
+        path: Path,
+        *,
+        sha256: str,
+        metadata: dict[str, str],
+    ) -> None:
+        from azure.core.exceptions import ResourceExistsError
+        from azure.storage.blob import ContentSettings
+
+        blob = self._container.get_blob_client(key)
+        with path.open("rb") as stream:
+            try:
+                blob.upload_blob(
+                    stream,
+                    overwrite=False,
+                    metadata={**metadata, "sha256": sha256},
+                    content_settings=ContentSettings(
+                        content_type="application/vnd.apache.parquet"
+                    ),
+                )
+            except ResourceExistsError:
+                existing = blob.get_blob_properties().metadata or {}
+                if existing.get("sha256") != sha256:
+                    raise RuntimeError(
+                        f"immutable archive object differs: {self._uri(key)}"
+                    ) from None
+
+    def put_json_if_absent(self, key: str, value: dict[str, Any]) -> None:
+        from azure.core.exceptions import ResourceExistsError
+        from azure.storage.blob import ContentSettings
+
+        encoded = _json_bytes(value)
+        blob = self._container.get_blob_client(key)
+        try:
+            blob.upload_blob(
+                encoded,
+                overwrite=False,
+                content_settings=ContentSettings(content_type="application/json"),
+            )
+        except ResourceExistsError:
+            if blob.download_blob().readall() != encoded:
+                raise RuntimeError(
+                    f"immutable archive manifest differs: {self._uri(key)}"
+                ) from None
+
+    def put_json_pointer(self, key: str, value: dict[str, Any]) -> None:
+        from azure.core import MatchConditions
+        from azure.core.exceptions import ResourceNotFoundError
+        from azure.storage.blob import ContentSettings
+
+        encoded = _json_bytes(value)
+        blob = self._container.get_blob_client(key)
+        settings = ContentSettings(content_type="application/json")
+        try:
+            etag = blob.get_blob_properties().etag
+        except ResourceNotFoundError:
+            blob.upload_blob(encoded, overwrite=False, content_settings=settings)
+            return
+        blob.upload_blob(
+            encoded,
+            overwrite=True,
+            content_settings=settings,
+            etag=etag,
+            match_condition=MatchConditions.IfNotModified,
+        )
+
+
+def build_archive_store(
+    kind: str,
+    *,
+    project: str,
+    bucket: str,
+    region: str | None = None,
+    account_url: str | None = None,
+) -> ArchiveStore:
+    """Select this deployment's object store.
+
+    Each cloud archives to its own object store in its own account.  That is
+    the point rather than an accident: an archive written across a cloud
+    boundary would make the cloud it describes non-recoverable exactly when
+    the *other* cloud is the one that is unreachable.
+    """
+
+    if kind == "gcs":
+        return GCSArchiveStore(project=project, bucket=bucket)
+    # ARCHIVE_BUCKET names a GCP bucket. Reaching another cloud's store while
+    # still carrying it means --bucket was never set, and the useful failure
+    # is here rather than a 404 that reads like a permissions problem.
+    if bucket == ARCHIVE_BUCKET:
+        raise ValueError(f"--bucket must name this deployment's {kind} bucket, not {bucket!r}")
+    if kind == "s3":
+        return S3ArchiveStore(bucket=bucket, region=region)
+    if kind == "azure":
+        if not account_url:
+            raise ValueError("--account-url is required for the azure object store")
+        return AzureBlobArchiveStore(account_url=account_url, container=bucket)
+    raise ValueError(f"unsupported archive object store: {kind}")
+
+
 def _nullable_string(value: Any) -> str | None:
     if value is None or value == "":
         return None
@@ -683,13 +952,28 @@ def main() -> int:
     parser.add_argument("--lookback-days", type=int, default=7)
     parser.add_argument("--backfill", action="store_true")
     parser.add_argument("--rows-per-part", type=int, default=ROWS_PER_PART)
+    # Which cloud this node archives to. Defaults to gcs so the existing
+    # GCP units keep their current behaviour with no argv change.
+    parser.add_argument(
+        "--object-store",
+        choices=("gcs", "s3", "azure"),
+        default=os.environ.get("TR_ARCHIVE_OBJECT_STORE", "gcs"),
+    )
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION"))
+    parser.add_argument("--account-url", default=os.environ.get("AZURE_STORAGE_ACCOUNT_URL"))
     args = parser.parse_args()
 
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
-    store = GCSArchiveStore(project=args.project, bucket=args.bucket)
+    store = build_archive_store(
+        args.object_store,
+        project=args.project,
+        bucket=args.bucket,
+        region=args.region,
+        account_url=args.account_url,
+    )
     tables = tuple(dict.fromkeys(args.table or tuple(DATASETS)))
     for table in tables:
         exporter = ClickHouseDailyExporter(

--- a/clickhouse/requirements-live.txt
+++ b/clickhouse/requirements-live.txt
@@ -7,3 +7,8 @@ psycopg[binary]>=3.2.0
 # Imported only when --iam-auth aws-dsql is selected, to mint the DSQL
 # connect token. Unused by the Spanner-sourced drains.
 boto3>=1.35.0
+# archive_daily.py --object-store azure. Installed only on the Azure ClickHouse
+# nodes; the GCP and AWS nodes never import it, which is why this is a node
+# requirement rather than a package dependency.
+azure-storage-blob>=12.23.0
+azure-identity>=1.19.0

--- a/tests/test_clickhouse_archive_object_stores.py
+++ b/tests/test_clickhouse_archive_object_stores.py
@@ -1,0 +1,406 @@
+"""Per-cloud archive stores.
+
+Each cloud archives to its own object store, so the immutability guarantee is
+implemented three times against three different sets of preconditions.  These
+tests exist because that guarantee is *only* the precondition: an
+unconditional ``put_object`` would pass every functional test in the archive
+suite and silently make the archive mutable.
+
+So the fakes here enforce the conditional semantics rather than record them --
+``IfNoneMatch``/``overwrite`` actually reject a second write.  Deleting a
+precondition from the store under test fails these tests instead of quietly
+weakening the archive.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from clickhouse.archive_daily import (
+    ARCHIVE_BUCKET,
+    AzureBlobArchiveStore,
+    S3ArchiveStore,
+    build_archive_store,
+)
+
+
+def _client_error(code: str, status: int) -> Exception:
+    from botocore.exceptions import ClientError
+
+    return ClientError(
+        {"Error": {"Code": code}, "ResponseMetadata": {"HTTPStatusCode": status}},
+        "PutObject",
+    )
+
+
+class FakeS3:
+    """A fake that honours the conditional writes rather than logging them."""
+
+    def __init__(self) -> None:
+        self.objects: dict[str, dict[str, Any]] = {}
+        self.unconditional_writes: list[str] = []
+
+    def put_object(self, **kwargs: Any) -> dict[str, Any]:
+        key = kwargs["Key"]
+        body = kwargs["Body"]
+        payload = body.read() if hasattr(body, "read") else body
+        exists = key in self.objects
+        if "IfNoneMatch" in kwargs:
+            if kwargs["IfNoneMatch"] != "*":
+                raise AssertionError("IfNoneMatch must be '*'")
+            if exists:
+                raise _client_error("PreconditionFailed", 412)
+        elif "IfMatch" in kwargs:
+            if not exists:
+                raise _client_error("PreconditionFailed", 412)
+            if kwargs["IfMatch"] != self.objects[key]["ETag"]:
+                raise _client_error("PreconditionFailed", 412)
+        else:
+            # Nothing in this module may write without a precondition.
+            self.unconditional_writes.append(key)
+        self.objects[key] = {
+            "Body": payload,
+            "Metadata": {str(k).title(): v for k, v in (kwargs.get("Metadata") or {}).items()},
+            "ETag": f'"etag-{len(self.objects)}-{len(payload)}"',
+        }
+        return {}
+
+    def get_object(self, *, Bucket: str, Key: str) -> dict[str, Any]:  # noqa: N803
+        del Bucket
+        if Key not in self.objects:
+            raise _client_error("NoSuchKey", 404)
+        return {"Body": _Reader(self.objects[Key]["Body"])}
+
+    def head_object(self, *, Bucket: str, Key: str) -> dict[str, Any]:  # noqa: N803
+        del Bucket
+        if Key not in self.objects:
+            raise _client_error("NotFound", 404)
+        return self.objects[Key]
+
+
+class _Reader:
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+@pytest.fixture
+def s3(monkeypatch: pytest.MonkeyPatch) -> FakeS3:
+    import boto3
+
+    fake = FakeS3()
+    monkeypatch.setattr(boto3, "client", lambda *a, **k: fake)
+    return fake
+
+
+def _store(fake: FakeS3) -> S3ArchiveStore:
+    del fake
+    return S3ArchiveStore(bucket="tr-archive-eu", region="eu-west-1")
+
+
+def test_s3_file_write_is_conditional_and_idempotent(s3: FakeS3, tmp_path: Path) -> None:
+    store = _store(s3)
+    part = tmp_path / "part.parquet"
+    part.write_bytes(b"rows")
+
+    store.put_file_if_absent("day/part.parquet", part, sha256="abc", metadata={"day": "2026-08-16"})
+    # Re-running the archiver for an already-archived day must be a no-op,
+    # not a rewrite and not an error.
+    store.put_file_if_absent("day/part.parquet", part, sha256="abc", metadata={"day": "2026-08-16"})
+
+    assert s3.objects["day/part.parquet"]["Body"] == b"rows"
+    assert s3.unconditional_writes == []
+
+
+def test_s3_rejects_a_changed_object_under_an_archived_key(s3: FakeS3, tmp_path: Path) -> None:
+    store = _store(s3)
+    part = tmp_path / "part.parquet"
+    part.write_bytes(b"rows")
+    store.put_file_if_absent("k", part, sha256="abc", metadata={})
+
+    part.write_bytes(b"different")
+    with pytest.raises(RuntimeError, match="immutable archive object differs"):
+        store.put_file_if_absent("k", part, sha256="def", metadata={})
+
+
+def test_s3_manifest_conflict_compares_content(s3: FakeS3) -> None:
+    store = _store(s3)
+    store.put_json_if_absent("m.json", {"rows": 1})
+    store.put_json_if_absent("m.json", {"rows": 1})
+
+    with pytest.raises(RuntimeError, match="immutable archive manifest differs"):
+        store.put_json_if_absent("m.json", {"rows": 2})
+
+
+def test_s3_pointer_is_compare_and_set(s3: FakeS3) -> None:
+    store = _store(s3)
+    store.put_json_pointer("_latest.json", {"day": "2026-08-15"})
+    store.put_json_pointer("_latest.json", {"day": "2026-08-16"})
+
+    assert store.read_json("_latest.json") == {"day": "2026-08-16"}
+    # The pointer is the one mutable object, but it still moves under a
+    # precondition so two archivers cannot interleave a lost update.
+    assert s3.unconditional_writes == []
+
+
+def test_s3_read_json_absent_and_malformed(s3: FakeS3) -> None:
+    store = _store(s3)
+    assert store.read_json("missing.json") is None
+
+    s3.objects["bad.json"] = {"Body": b"[1, 2]", "Metadata": {}, "ETag": '"e"'}
+    with pytest.raises(RuntimeError, match="not a JSON object"):
+        store.read_json("bad.json")
+
+
+def test_s3_reads_metadata_case_insensitively(s3: FakeS3, tmp_path: Path) -> None:
+    """S3 lowercases user metadata; a case-sensitive lookup would read the
+    sha256 as absent and report every rerun as an immutability violation."""
+
+    store = _store(s3)
+    part = tmp_path / "p"
+    part.write_bytes(b"x")
+    store.put_file_if_absent("k", part, sha256="abc", metadata={})
+    assert "Sha256" in s3.objects["k"]["Metadata"]  # stored title-cased by the fake
+
+    store.put_file_if_absent("k", part, sha256="abc", metadata={})
+
+
+# --------------------------------------------------------------------------
+# Azure. The SDK is installed only on the Azure nodes (requirements-live.txt),
+# so the module is injected here. The store's own logic is still the code
+# under test -- only the transport is fake.
+# --------------------------------------------------------------------------
+
+
+class _AzureResourceExists(Exception):
+    pass
+
+
+class _AzureResourceNotFound(Exception):
+    pass
+
+
+class FakeBlob:
+    def __init__(self, container: FakeContainer, key: str) -> None:
+        self._container = container
+        self._key = key
+
+    def upload_blob(self, data: Any, **kwargs: Any) -> None:
+        payload = data.read() if hasattr(data, "read") else data
+        exists = self._key in self._container.blobs
+        if not kwargs.get("overwrite", False):
+            if exists:
+                raise _AzureResourceExists(self._key)
+        elif kwargs.get("match_condition") is None:
+            self._container.unconditional_writes.append(self._key)
+        self._container.blobs[self._key] = {
+            "data": payload,
+            "metadata": kwargs.get("metadata") or {},
+            "etag": f"etag-{len(self._container.blobs)}",
+        }
+
+    def download_blob(self) -> Any:
+        if self._key not in self._container.blobs:
+            raise _AzureResourceNotFound(self._key)
+        return types.SimpleNamespace(readall=lambda: self._container.blobs[self._key]["data"])
+
+    def get_blob_properties(self) -> Any:
+        if self._key not in self._container.blobs:
+            raise _AzureResourceNotFound(self._key)
+        record = self._container.blobs[self._key]
+        return types.SimpleNamespace(metadata=record["metadata"], etag=record["etag"])
+
+
+class FakeContainer:
+    def __init__(self) -> None:
+        self.blobs: dict[str, dict[str, Any]] = {}
+        self.unconditional_writes: list[str] = []
+
+    def get_blob_client(self, key: str) -> FakeBlob:
+        return FakeBlob(self, key)
+
+
+@pytest.fixture
+def azure_container(monkeypatch: pytest.MonkeyPatch) -> FakeContainer:
+    container = FakeContainer()
+
+    def _module(name: str, **attrs: Any) -> types.ModuleType:
+        module = types.ModuleType(name)
+        for key, value in attrs.items():
+            setattr(module, key, value)
+        # monkeypatch.setitem restores sys.modules after the test, so the
+        # fakes cannot leak into another test's imports.
+        monkeypatch.setitem(sys.modules, name, module)
+        return module
+
+    _module("azure")
+    _module("azure.core", MatchConditions=types.SimpleNamespace(IfNotModified="if-not-modified"))
+    _module(
+        "azure.core.exceptions",
+        ResourceExistsError=_AzureResourceExists,
+        ResourceNotFoundError=_AzureResourceNotFound,
+    )
+    _module("azure.identity", DefaultAzureCredential=lambda *a, **k: object())
+    _module(
+        "azure.storage",
+    )
+    _module(
+        "azure.storage.blob",
+        BlobServiceClient=lambda **kwargs: types.SimpleNamespace(
+            get_container_client=lambda name: container
+        ),
+        ContentSettings=lambda **kwargs: types.SimpleNamespace(**kwargs),
+    )
+    return container
+
+
+def _azure_store() -> AzureBlobArchiveStore:
+    return AzureBlobArchiveStore(
+        account_url="https://tracct.blob.core.windows.net",
+        container="tr-archive",
+    )
+
+
+def test_azure_file_write_is_conditional_and_idempotent(
+    azure_container: FakeContainer, tmp_path: Path
+) -> None:
+    store = _azure_store()
+    part = tmp_path / "part.parquet"
+    part.write_bytes(b"rows")
+
+    store.put_file_if_absent("k", part, sha256="abc", metadata={"day": "2026-08-16"})
+    store.put_file_if_absent("k", part, sha256="abc", metadata={"day": "2026-08-16"})
+
+    assert azure_container.blobs["k"]["data"] == b"rows"
+    assert azure_container.unconditional_writes == []
+
+
+def test_azure_rejects_a_changed_object_under_an_archived_key(
+    azure_container: FakeContainer, tmp_path: Path
+) -> None:
+    store = _azure_store()
+    part = tmp_path / "p"
+    part.write_bytes(b"rows")
+    store.put_file_if_absent("k", part, sha256="abc", metadata={})
+
+    with pytest.raises(RuntimeError, match="immutable archive object differs"):
+        store.put_file_if_absent("k", part, sha256="def", metadata={})
+
+
+def test_azure_manifest_conflict_compares_content(azure_container: FakeContainer) -> None:
+    store = _azure_store()
+    store.put_json_if_absent("m.json", {"rows": 1})
+    store.put_json_if_absent("m.json", {"rows": 1})
+
+    with pytest.raises(RuntimeError, match="immutable archive manifest differs"):
+        store.put_json_if_absent("m.json", {"rows": 2})
+
+
+def test_azure_pointer_moves_under_an_etag_precondition(azure_container: FakeContainer) -> None:
+    store = _azure_store()
+    store.put_json_pointer("_latest.json", {"day": "2026-08-15"})
+    store.put_json_pointer("_latest.json", {"day": "2026-08-16"})
+
+    assert store.read_json("_latest.json") == {"day": "2026-08-16"}
+    assert azure_container.unconditional_writes == []
+
+
+def test_azure_read_json_absent_and_malformed(azure_container: FakeContainer) -> None:
+    store = _azure_store()
+    assert store.read_json("missing.json") is None
+
+    azure_container.blobs["bad.json"] = {"data": b"[]", "metadata": {}, "etag": "e"}
+    with pytest.raises(RuntimeError, match="not a JSON object"):
+        store.read_json("bad.json")
+
+
+# --------------------------------------------------------------------------
+# Selection
+# --------------------------------------------------------------------------
+
+
+def test_build_archive_store_rejects_the_gcp_bucket_on_other_clouds() -> None:
+    """A unit that sets --object-store but forgets --bucket would otherwise
+    address a GCP bucket name in another cloud's namespace."""
+
+    for kind in ("s3", "azure"):
+        with pytest.raises(ValueError, match="must name this deployment"):
+            build_archive_store(
+                kind,
+                project="quill-cloud-proxy",
+                bucket=ARCHIVE_BUCKET,
+                region="eu-west-1",
+                account_url="https://tracct.blob.core.windows.net",
+            )
+
+
+def test_build_archive_store_requires_an_account_url_for_azure() -> None:
+    with pytest.raises(ValueError, match="account-url is required"):
+        build_archive_store("azure", project="p", bucket="tr-archive", account_url=None)
+
+
+def test_build_archive_store_rejects_an_unknown_kind() -> None:
+    with pytest.raises(ValueError, match="unsupported archive object store"):
+        build_archive_store("ceph", project="p", bucket="b")
+
+
+def test_build_archive_store_selects_s3(s3: FakeS3) -> None:
+    store = build_archive_store("s3", project="p", bucket="tr-archive-eu", region="eu-west-1")
+    assert isinstance(store, S3ArchiveStore)
+    assert store.scheme == "s3"
+
+
+def test_build_archive_store_selects_azure(azure_container: FakeContainer) -> None:
+    store = build_archive_store(
+        "azure",
+        project="p",
+        bucket="tr-archive",
+        account_url="https://tracct.blob.core.windows.net",
+    )
+    assert isinstance(store, AzureBlobArchiveStore)
+    assert store.scheme == "azure"
+
+
+def test_every_store_satisfies_the_archive_store_protocol(
+    s3: FakeS3, azure_container: FakeContainer
+) -> None:
+    """archive_day() is typed against ArchiveStore; a backend missing a method
+    would only fail at the end of a real export."""
+
+    from clickhouse.archive_daily import ArchiveStore, GCSArchiveStore
+
+    required = [name for name in dir(ArchiveStore) if not name.startswith("_")]
+    assert set(required) >= {
+        "read_json",
+        "put_file_if_absent",
+        "put_json_if_absent",
+        "put_json_pointer",
+    }
+    for cls in (GCSArchiveStore, S3ArchiveStore, AzureBlobArchiveStore):
+        for name in required:
+            assert callable(getattr(cls, name, None)), f"{cls.__name__} lacks {name}"
+
+
+def test_pointer_json_is_byte_identical_across_stores(
+    s3: FakeS3, azure_container: FakeContainer
+) -> None:
+    """The freshness checker compares manifests across clouds; divergent JSON
+    encoding would read as drift."""
+
+    s3_store = _store(s3)
+    azure_store = _azure_store()
+    value = {"day": "2026-08-16", "rows": 5}
+    s3_store.put_json_if_absent("m.json", value)
+    azure_store.put_json_if_absent("m.json", value)
+
+    encoded = s3.objects["m.json"]["Body"]
+    assert encoded == azure_container.blobs["m.json"]["data"]
+    assert json.loads(encoded) == value


### PR DESCRIPTION
## What this fixes

The verified Parquet archive (`archive_daily.py`) is the only point-in-time copy of ClickHouse history anywhere in the system — and it ran for **one of three deployments**.

AWS and Azure keep their analytics history on ClickHouse volumes protected by **replication alone**. `ingest_operational_outbox_postgres.py` says it about its own cloud:

> This cloud's analytics history lives on ClickHouse EBS volumes. With one node that is one volume holding every operational row the cloud has ever produced, and losing it loses the history.

Replication is not a backup — logical corruption and accidental deletion replicate to every replica. That is the same gap GCP closed with this archiver, still open on the other two.

**This history is not a duplicate of GCP's.** Each cloud's ClickHouse holds the rows its own gateway produced, so an unarchived cloud is an unrecoverable one.

## Why the change is small

`archive_daily.py` was already shaped for this: `ArchiveStore` is a `Protocol`, and `GCSArchiveStore` was its only implementation. This adds the two missing implementations plus a selector. The export, the read-back verification, the fingerprint, and the manifest are untouched.

- `S3ArchiveStore` — `IfNoneMatch: "*"` for create-if-absent, `IfMatch: <etag>` for the pointer CAS
- `AzureBlobArchiveStore` — `overwrite=False`, and `If-Match` via `MatchConditions.IfNotModified`
- `build_archive_store(kind, ...)` + `--object-store {gcs,s3,azure}`, defaulting to `gcs` so existing GCP units keep their exact current argv

Each cloud archives into **its own** object store in its own account. An archive written across a cloud boundary would make the cloud it describes non-recoverable precisely when the *other* cloud is the unreachable one.

## Why the tests are shaped the way they are

The immutability guarantee is *only* the write precondition. An unconditional `put_object` would pass every existing test in the archive suite and silently make the archive mutable.

So the fakes **enforce** the conditional semantics instead of recording them. Verified by mutation rather than by reading — each of these was removed in turn and the suite failed:

| Mutation | Result |
|---|---|
| S3 `IfNoneMatch="*"` removed | 2 failed |
| Azure `overwrite=False` → `True` | 2 failed |
| S3 pointer CAS removed | 1 failed |
| Azure `match_condition` removed | 1 failed |

Also covered: S3 lowercases user metadata on read (a case-sensitive lookup would read `sha256` as absent and report every idempotent rerun as an immutability violation), and pointer JSON is byte-identical across stores so the cross-cloud freshness comparison can't read encoding drift as real drift.

## Guard

`ARCHIVE_BUCKET` names a GCP bucket. A unit that sets `--object-store` but forgets `--bucket` now fails with a useful message instead of a 404 that reads like a permissions problem.

## Dependencies

`boto3` is already a package dependency. The Azure SDKs go in `clickhouse/requirements-live.txt` (installed on the ClickHouse nodes) rather than `pyproject.toml`, since only the Azure nodes import them — so the Azure store is exercised against injected modules.

## Not in this change

Installing the AWS and Azure timers, creating the buckets, and extending the freshness workflow to all three clouds. This lands the code path and its tests; the GCP archive behaviour is unchanged.

## Verification

`ruff check` clean · `mypy` clean (275 files) · 67 tests pass (`test_clickhouse_archive`, `_freshness`, `_object_stores`, `test_clickhouse_operational_deploy`) · 4/4 mutations caught

🤖 Generated with [Claude Code](https://claude.com/claude-code)