### PR TITLE
Make the per-cloud archive actually runnable off GCP (blocker + real-transport tests)

### DIFF
--- a/clickhouse/archive_daily.py
+++ b/clickhouse/archive_daily.py
@@ -290,10 +290,19 @@ class ClickHouseDailyExporter:
         password: str,
         database: str = DATABASE,
         table: str = TABLE,
+        user: str = "tr",
     ) -> None:
         self._password = password
         self._database = _identifier(database, label="database")
         self._table = _identifier(table, label="table")
+        # The user was hardcoded to "tr" while the database was already a
+        # parameter, so this exporter silently only worked on the GCP cluster --
+        # the same latent bug ClickHouseOperationalWriter carried. The AWS-EU
+        # node authenticates as "default" into database "default" (its schema is
+        # applied unqualified), and an explicit --user beats CLICKHOUSE_USER in
+        # the environment, so this could not have been corrected from the unit
+        # file. Archiving another cloud requires it to be a parameter.
+        self._user = _identifier(user, label="user")
         try:
             self._spec = DATASETS[self._table]
         except KeyError:
@@ -314,7 +323,7 @@ class ClickHouseDailyExporter:
             [
                 "/usr/bin/clickhouse-client",
                 "--user",
-                "tr",
+                self._user,
                 "--database",
                 self._database,
                 "--query",
@@ -403,6 +412,8 @@ class ClickHouseDailyExporter:
 
 
 class GCSArchiveStore:
+    scheme = "gs"
+
     def __init__(self, *, project: str, bucket: str) -> None:
         import google.cloud.storage as gcs_storage
 
@@ -946,7 +957,9 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--project", default=os.environ.get("GCP_PROJECT_ID", PROJECT))
     parser.add_argument("--bucket", default=os.environ.get("ARCHIVE_BUCKET", ARCHIVE_BUCKET))
-    parser.add_argument("--database", default=DATABASE)
+    parser.add_argument("--database", default=os.environ.get("TR_CLICKHOUSE_DATABASE", DATABASE))
+    # The AWS-EU node authenticates as "default"; see ClickHouseDailyExporter.
+    parser.add_argument("--clickhouse-user", default=os.environ.get("TR_CLICKHOUSE_USER", "tr"))
     parser.add_argument("--table", action="append", choices=tuple(DATASETS))
     parser.add_argument("--date", type=dt.date.fromisoformat)
     parser.add_argument("--lookback-days", type=int, default=7)
@@ -980,6 +993,7 @@ def main() -> int:
             password=os.environ["CH_PASSWORD"],
             database=args.database,
             table=table,
+            user=args.clickhouse_user,
         )
         backfill_start = (
             exporter.earliest_day() if args.backfill and args.date is None else None
@@ -998,12 +1012,13 @@ def main() -> int:
             )
             log.info(
                 "analytics_archive.completed dataset=%s day=%s rows=%d "
-                "revision=%s skipped=%s manifest=gs://%s/%s",
+                "revision=%s skipped=%s manifest=%s://%s/%s",
                 table,
                 result.day,
                 result.rows,
                 result.revision,
                 result.skipped,
+                getattr(store, "scheme", "gs"),
                 args.bucket,
                 result.manifest_key,
             )

--- a/tests/test_clickhouse_archive_object_stores.py
+++ b/tests/test_clickhouse_archive_object_stores.py
@@ -404,3 +404,142 @@ def test_pointer_json_is_byte_identical_across_stores(
     encoded = s3.objects["m.json"]["Body"]
     assert encoded == azure_container.blobs["m.json"]["data"]
     assert json.loads(encoded) == value
+
+
+# --------------------------------------------------------------------------
+# Real-transport validation.
+#
+# Everything above runs against fakes I wrote, and a fake validates my
+# understanding of S3 rather than S3 itself -- if botocore rejected the
+# precondition parameters, or named them differently, every test above would
+# still pass and the archiver would fail on the node with ParamValidationError.
+#
+# botocore's Stubber applies the real service model and the real parameter
+# validator, so these tests fail if the argv the store builds is not a call
+# boto3 will actually make. No network and no credentials are involved.
+# --------------------------------------------------------------------------
+
+
+def _stubbed_client(monkeypatch: pytest.MonkeyPatch) -> tuple[Any, Any]:
+    import boto3
+    from botocore.stub import Stubber
+
+    client = boto3.client(
+        "s3",
+        region_name="eu-west-1",
+        aws_access_key_id="testing",
+        aws_secret_access_key="testing",  # noqa: S106 - stubbed, never sent
+        aws_session_token="testing",  # noqa: S106 - stubbed, never sent
+    )
+    stubber = Stubber(client)
+    monkeypatch.setattr(boto3, "client", lambda *a, **k: client)
+    return client, stubber
+
+
+def test_real_botocore_accepts_the_immutable_file_write(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from botocore.stub import ANY
+
+    _, stubber = _stubbed_client(monkeypatch)
+    part = tmp_path / "part.parquet"
+    part.write_bytes(b"rows")
+
+    stubber.add_response(
+        "put_object",
+        {},
+        {
+            "Bucket": "tr-archive-eu",
+            "Key": "k",
+            "Body": ANY,
+            "ContentType": "application/vnd.apache.parquet",
+            "Metadata": {"day": "2026-08-16", "sha256": "abc"},
+            "IfNoneMatch": "*",
+        },
+    )
+    with stubber:
+        store = S3ArchiveStore(bucket="tr-archive-eu", region="eu-west-1")
+        store.put_file_if_absent("k", part, sha256="abc", metadata={"day": "2026-08-16"})
+    stubber.assert_no_pending_responses()
+
+
+def test_real_botocore_accepts_the_pointer_compare_and_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, stubber = _stubbed_client(monkeypatch)
+
+    stubber.add_response(
+        "head_object", {"ETag": '"abc123"'}, {"Bucket": "tr-archive-eu", "Key": "_latest.json"}
+    )
+    stubber.add_response(
+        "put_object",
+        {},
+        {
+            "Bucket": "tr-archive-eu",
+            "Key": "_latest.json",
+            "Body": _json_bytes_for_test({"day": "2026-08-16"}),
+            "ContentType": "application/json",
+            "IfMatch": '"abc123"',
+        },
+    )
+    with stubber:
+        store = S3ArchiveStore(bucket="tr-archive-eu", region="eu-west-1")
+        store.put_json_pointer("_latest.json", {"day": "2026-08-16"})
+    stubber.assert_no_pending_responses()
+
+
+def test_real_botocore_maps_a_missing_pointer_to_create_if_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """First run on a new cloud: no pointer exists yet, so the CAS degrades to
+    a create. A 404 here must not be mistaken for a precondition failure."""
+
+    _, stubber = _stubbed_client(monkeypatch)
+
+    stubber.add_client_error("head_object", service_error_code="404", http_status_code=404)
+    stubber.add_response(
+        "put_object",
+        {},
+        {
+            "Bucket": "tr-archive-eu",
+            "Key": "_latest.json",
+            "Body": _json_bytes_for_test({"day": "2026-08-16"}),
+            "ContentType": "application/json",
+            "IfNoneMatch": "*",
+        },
+    )
+    with stubber:
+        store = S3ArchiveStore(bucket="tr-archive-eu", region="eu-west-1")
+        store.put_json_pointer("_latest.json", {"day": "2026-08-16"})
+    stubber.assert_no_pending_responses()
+
+
+def test_real_botocore_412_is_classified_as_a_precondition_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The rerun path: a genuine S3 412 must route to the sha256 comparison,
+    not escape as an unhandled ClientError."""
+
+    _, stubber = _stubbed_client(monkeypatch)
+    part = tmp_path / "p"
+    part.write_bytes(b"rows")
+
+    stubber.add_client_error(
+        "put_object", service_error_code="PreconditionFailed", http_status_code=412
+    )
+    stubber.add_response(
+        "head_object",
+        {"Metadata": {"sha256": "abc"}},
+        {"Bucket": "tr-archive-eu", "Key": "k"},
+    )
+    with stubber:
+        store = S3ArchiveStore(bucket="tr-archive-eu", region="eu-west-1")
+        # Same content already archived -> silent no-op, not an error.
+        store.put_file_if_absent("k", part, sha256="abc", metadata={})
+    stubber.assert_no_pending_responses()
+
+
+def _json_bytes_for_test(value: dict[str, Any]) -> bytes:
+    from clickhouse.archive_daily import _json_bytes
+
+    return _json_bytes(value)

--- a/tests/test_clickhouse_archive_object_stores.py
+++ b/tests/test_clickhouse_archive_object_stores.py
@@ -589,7 +589,7 @@ def test_exporter_argv_carries_the_configured_user_and_database(
     # A leftover "tr" anywhere in argv means the AWS node authenticates as a
     # user that does not exist there.
     assert "tr" not in argv
-    assert seen["env"]["CLICKHOUSE_PASSWORD"] == "pw"
+    assert seen["env"]["CLICKHOUSE_PASSWORD"] == "pw"  # noqa: S105 - test literal
 
 
 def test_exporter_still_defaults_to_the_gcp_user(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_clickhouse_archive_object_stores.py
+++ b/tests/test_clickhouse_archive_object_stores.py
@@ -543,3 +543,104 @@ def _json_bytes_for_test(value: dict[str, Any]) -> bytes:
     from clickhouse.archive_daily import _json_bytes
 
     return _json_bytes(value)
+
+
+# --------------------------------------------------------------------------
+# Running the exporter on a non-GCP node.
+#
+# The archiver shells out to clickhouse-client with an explicit --user. That
+# user was hardcoded to "tr", which only exists on the GCP cluster; the AWS-EU
+# node authenticates as "default" into database "default". An explicit --user
+# beats CLICKHOUSE_USER in the environment, so this could not be corrected
+# from the systemd unit -- the per-cloud object stores were necessary but not
+# sufficient to archive another cloud.
+# --------------------------------------------------------------------------
+
+
+def test_exporter_argv_carries_the_configured_user_and_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from clickhouse import archive_daily
+
+    seen: dict[str, Any] = {}
+
+    class _Result:
+        returncode = 0
+        stdout = b"{}"
+        stderr = b""
+
+    def _fake_run(argv: Any, **kwargs: Any) -> Any:
+        seen["argv"] = list(argv)
+        seen["env"] = kwargs.get("env") or {}
+        return _Result()
+
+    monkeypatch.setattr(archive_daily.subprocess, "run", _fake_run)
+    exporter = archive_daily.ClickHouseDailyExporter(
+        password="pw",  # noqa: S106 - test literal
+        database="default",
+        table="activity_generations",
+        user="default",
+    )
+    exporter._client("SELECT 1")
+
+    argv = seen["argv"]
+    assert argv[argv.index("--user") + 1] == "default"
+    assert argv[argv.index("--database") + 1] == "default"
+    # A leftover "tr" anywhere in argv means the AWS node authenticates as a
+    # user that does not exist there.
+    assert "tr" not in argv
+    assert seen["env"]["CLICKHOUSE_PASSWORD"] == "pw"
+
+
+def test_exporter_still_defaults_to_the_gcp_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GCP's units pass no user, so the default must keep them byte-identical."""
+
+    from clickhouse import archive_daily
+
+    seen: dict[str, Any] = {}
+
+    class _Result:
+        returncode = 0
+        stdout = b"{}"
+        stderr = b""
+
+    monkeypatch.setattr(
+        archive_daily.subprocess,
+        "run",
+        lambda argv, **kw: (seen.__setitem__("argv", list(argv)), _Result())[1],
+    )
+    archive_daily.ClickHouseDailyExporter(
+        password="pw",  # noqa: S106 - test literal
+    )._client("SELECT 1")
+
+    argv = seen["argv"]
+    assert argv[argv.index("--user") + 1] == "tr"
+    assert argv[argv.index("--database") + 1] == "tr"
+
+
+def test_exporter_rejects_a_non_identifier_user() -> None:
+    """The user reaches an argv, so it gets the same allowlist as the database."""
+
+    from clickhouse import archive_daily
+
+    with pytest.raises(ValueError, match="user must be a ClickHouse identifier"):
+        archive_daily.ClickHouseDailyExporter(
+            password="pw",  # noqa: S106 - test literal
+            user="default; DROP",
+        )
+
+
+def test_completion_log_names_the_store_actually_written(
+    s3: FakeS3, azure_container: FakeContainer
+) -> None:
+    """The success line hardcoded gs:// for every store, so an operator reading
+    AWS logs would be told the object landed in GCS."""
+
+    from clickhouse.archive_daily import GCSArchiveStore
+
+    assert GCSArchiveStore.scheme == "gs"
+    assert S3ArchiveStore.scheme == "s3"
+    assert AzureBlobArchiveStore.scheme == "azure"
+    # Every store must expose it, since the log reads it off whichever is live.
+    for cls in (GCSArchiveStore, S3ArchiveStore, AzureBlobArchiveStore):
+        assert isinstance(getattr(cls, "scheme", None), str)


### PR DESCRIPTION
Follow-up to #642. Two things, the first of which is a hard blocker that #642 left standing.

## 1. The archiver could not run on any node but GCP's

`#642` gave the archiver per-cloud object stores. That turned out to be **necessary but not sufficient**: `_client()` shells out to `clickhouse-client` with an explicit `--user` hardcoded to `"tr"`.

```python
"/usr/bin/clickhouse-client", "--user", "tr", "--database", self._database, ...
```

`tr` exists only on the GCP cluster. The AWS-EU node authenticates as **`default` into database `default`** (its schema is applied unqualified). And an explicit `--user` **beats `CLICKHOUSE_USER` in the environment**, so this was not fixable from a systemd unit.

The failure mode is the bad one: the timer installs, `systemctl is-active` reports active, and the archiver fails authentication on its first query — on a unit with no `OnFailure=`, which is precisely how the 2026-08-16 archive outage went unnoticed for ten hours.

`ClickHouseOperationalWriter` carried the **identical** bug and already fixed it this way, with a comment saying so, so this mirrors that precedent instead of inventing one:

- `user` threaded through `ClickHouseDailyExporter`, defaulting to `"tr"` so GCP's units emit the byte-identical command they do today
- validated against the same identifier allowlist `database` already gets, since it reaches an argv
- `--database` gains a `TR_CLICKHOUSE_DATABASE` fallback so a unit can set it via `EnvironmentFile` like the other per-cloud settings

Tests pin the **argv**, not the constructor — reverting `--user` to the literal `"tr"` fails `test_exporter_argv_carries_the_configured_user_and_database`. Verified by mutation.

Also fixed: the completion log hardcoded `gs://` for every store, so an operator reading AWS logs would be told the object landed in Cloud Storage. Each store now declares its `scheme` and the log reads it off whichever store is live.

## 2. The store tests only ever validated my fake

Every per-cloud store test in #642 runs against a fake I wrote, and a fake validates *my understanding of S3*, not S3. If botocore rejected `IfNoneMatch` on `put_object`, all of them would still pass and the archiver would fail on the node with `ParamValidationError`.

`botocore.stub.Stubber` applies the real service model and parameter validator — no network, no credentials:

| Case | Why it matters |
|---|---|
| Immutable file write carries `IfNoneMatch="*"` | the whole immutability guarantee |
| Pointer CAS sends `IfMatch` with the ETag from `HeadObject` | prevents a lost update between two archivers |
| Missing pointer degrades to create-if-absent | **the first run on a new cloud** — a 404 must not read as a precondition failure |
| A genuine 412 routes to the sha256 comparison | the idempotent-rerun path |

Confirmed botocore 1.43.2 models `IfMatch`/`IfNoneMatch` on `PutObject`, `HeadObject`, `GetObject`.

## Stated limitations

- **Azure has no real-transport validation.** Its SDK is node-only, so it is covered by injected fakes only; its first real write will be its first real test.
- Two further gaps remain before any cloud can be rolled out, and are **not** in this PR: `verify_archive_restore.py` has only a GCS store (so there is no restore drill outside GCP), and `check_archive_freshness.py` has only a GCS store *and* treats a store error as run-fatal — in a 3-cloud check, one cloud's 403 would abort before another cloud is read, which is the same masking shape as the 2026-08-16 incident.

26 tests pass · `ruff check` clean · `mypy` clean (275 files) · mutations caught: 5/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)