### PR TITLE
docs: client-telemetry — connect timeout is outcome timeout in both examples

### DIFF
--- a/docs/client-telemetry.md
+++ b/docs/client-telemetry.md
@@ -71,7 +71,7 @@ s  = 0|1 streaming
 fo = 0|1 candidate index advanced at least once during this logical request
 ```
 - First attempt: `v=1;a=0;s=1`. Retry after a connect timeout on the apex that moved to an alias:
-  `v=1;a=1;po=transport_error;pc=connect_timeout;ph=apex;pm=10012;sm=10530;s=1;fo=1`.
+  `v=1;a=1;po=timeout;pc=connect_timeout;ph=apex;pm=10012;sm=10530;s=1;fo=1`.
 - Static identity (SDK name/version/runtime/OS) rides the existing `User-Agent`, not this header.
 - **Not sent to custom base URLs** (a self-hosted gateway is not TrustedRouter's to measure) and **not sent
   on control-plane calls**. Not sent when telemetry is opted out (§6.4).
@@ -89,7 +89,7 @@ settlement token and are not joinable in ClickHouse).
 ```json
 "gateway_request_id": "rlog_…",
 "client": {"v":1,"source":"tr","sdk":"tr-py","sdk_version":"0.6.0","lang":"python","runtime":"cpython/3.12.1",
-           "os":"macos","arch":"arm64","timeout_ms":120000,"attempt":1,"prev_outcome":"transport_error",
+           "os":"macos","arch":"arm64","timeout_ms":120000,"attempt":1,"prev_outcome":"timeout",
            "prev_error_class":"connect_timeout","prev_host":"apex","prev_elapsed_ms":10012,"since_first_ms":10530,
            "stream":true,"failover_used":true}
 ```


### PR DESCRIPTION
Contract v1 doc fix, no behavior change.

The §3.2 retry example read `po=transport_error;pc=connect_timeout`, and the §3.4 forwarded-body example mirrored it as `"prev_outcome":"transport_error"`. The reference implementation (trusted-router-py 0.6.0, `_telemetry.py` `on_transport_error`) classifies every `httpx.TimeoutException` — `ConnectTimeout` included — as outcome `timeout`, so the wire value is `po=timeout` (normalised `prev_outcome=timeout`). Per the document's own header rule ("if this document and those modules disagree, the modules win and this document has a bug — fix the document"), this fixes both examples. The §3.2 `po` enum line already lists `transport_error` and `timeout` as distinct outcomes and is untouched.

Found while pinning byte-for-byte parity vectors for the header-only telemetry PRs (trusted-router-js#14, -go#10, -rust#19, -java#17, -swift#12); their engine-path tests assert `po=timeout` for timeout-class previous attempts, matching py. Enclave-side validation of the SDK headers was verified in production logs (falsification probe drew `client_context_dropped reason=x_tr_client_grammar`; the five SDK smoke ids drew none).

Related, tracked separately: trusted-router-py#15 (py emits `a=100` past the grammar range; sibling SDKs suppress — py fix PR incoming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)