### PR TITLE
Retry aborted Postgres transactions by SQLSTATE; the class-based clause never matched

### DIFF
--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -128,6 +128,34 @@ log = logging.getLogger(__name__)
 
 _AWS_DSQL_IAM_AUTH = "aws-dsql"
 
+# SQLSTATEs meaning "the server rolled your transaction back whole; replaying
+# it is the correct response". _run_transaction retries exactly these.
+#
+# Keyed on the SQLSTATE string rather than on a psycopg exception class, and
+# that is the entire point. psycopg generates ONE FLAT CLASS PER SQLSTATE, each
+# deriving straight from its DB-API base, so `SerializationFailure` (40001) and
+# `DeadlockDetected` (40P01) are SIBLINGS of `TransactionRollback` (40000), not
+# subclasses of it. `except psycopg.errors.TransactionRollback` therefore
+# caught only a bare 40000 -- which no server in this fleet emits -- and every
+# real abort fell through to the generic handler as a caller-visible
+# StoreUnavailable. That is how a routine concurrent reserve came back as
+# "Postgres could not service the storage operation" instead of retrying and
+# reporting "insufficient credits" (CI run 31996299784). SQLSTATE is the
+# DATABASE's contract; psycopg's class layout is not.
+#
+# The other two class-40 codes are deliberately absent:
+#   40002 transaction_integrity_constraint_violation -- deterministic, so a
+#         replay fails identically forever.
+#   40003 statement_completion_unknown -- the statement may in fact have
+#         COMMITTED, so replaying it could double-apply money.
+_RETRYABLE_ROLLBACK_SQLSTATES = frozenset(
+    {
+        "40000",  # transaction_rollback
+        "40001",  # serialization_failure -- Spanner ABORTED, DSQL OCC abort
+        "40P01",  # deadlock_detected -- ordinary Postgres lock ordering
+    }
+)
+
 
 class _IamTokenConnectionPool(ConnectionPool):
     """Connection pool that obtains a new password for every connection.
@@ -405,22 +433,20 @@ class PostgresStore:
                 with self._pool.connection() as conn:
                     with conn.transaction():
                         return operation(conn)
-            except psycopg.errors.TransactionRollback as exc:
-                # Covers SerializationFailure (40001) *and* DeadlockDetected
-                # (40P01). Both mean "the server rolled you back, try again",
-                # and both are routine: 40001 is how Aurora DSQL reports every
-                # optimistic-concurrency abort, and 40P01 is ordinary Postgres
-                # lock ordering. Retrying only the first would surface
-                # deadlocks to callers as hard failures.
+            except psycopg.Error as exc:
+                # Retry on SQLSTATE, NOT on psycopg's exception classes. See
+                # _RETRYABLE_ROLLBACK_SQLSTATES: psycopg gives every SQLSTATE
+                # its own flat class, so the obvious `except TransactionRollback`
+                # silently caught neither 40001 nor 40P01.
                 #
                 # Safe to retry because the transaction rolled back whole: an
                 # idempotency row inserted on the failed attempt is gone, so
                 # the retry re-inserts and credits exactly once.
-                last_serialization_error = exc
-                continue
-            except psycopg.IntegrityError as exc:
-                raise StoreConflict("Postgres write conflict") from exc
-            except psycopg.Error as exc:
+                if exc.sqlstate in _RETRYABLE_ROLLBACK_SQLSTATES:
+                    last_serialization_error = exc
+                    continue
+                if isinstance(exc, psycopg.IntegrityError):
+                    raise StoreConflict("Postgres write conflict") from exc
                 raise StoreUnavailable("Postgres could not service the storage operation") from exc
         raise StoreConflict(
             "Postgres transaction repeatedly rolled back (serialization failure or deadlock)"

--- a/tests/conformance/test_store_semantics.py
+++ b/tests/conformance/test_store_semantics.py
@@ -465,6 +465,13 @@ def test_concurrent_reserves_cannot_oversubscribe(
     assert all(not thread.is_alive() for thread in threads), "reserve threads hung"
     assert len(reservations) == 1
     assert len(errors) == 1
+    # The loser gets the DOMAIN's refusal, never an infrastructure error. On a
+    # backend that resolves the race by ABORTING the loser rather than by
+    # blocking it -- Spanner PG and Aurora DSQL both do -- the store owes the
+    # caller a replay, not a StoreUnavailable. This assertion is the contract,
+    # so if it ever goes flaky again the bug is in the retry policy
+    # (PostgresStore._RETRYABLE_ROLLBACK_SQLSTATES, covered by
+    # tests/test_postgres_transaction_retry.py), NOT in this line.
     assert isinstance(errors[0], ValueError)
     assert str(errors[0]) == "insufficient credits"
     with pytest.raises(ValueError, match="insufficient credits"):
@@ -1575,6 +1582,10 @@ def test_concurrent_transfers_cannot_overdraw(store: Store, workspace_id: str, u
         pytest.skip("backend does not implement cross-plane credit transfer")
 
     moved: list[bool] = []
+    # Anything that is neither "moved" nor the domain's refusal. Without this
+    # an escaping exception just left the tally SHORT, and the failure read
+    # `assert 0 == 1` with no hint that a store error had reached the caller.
+    escaped: list[BaseException] = []
     lock = threading.Lock()
 
     def attempt(index: int) -> None:
@@ -1588,6 +1599,10 @@ def test_concurrent_transfers_cannot_overdraw(store: Store, workspace_id: str, u
             outcome = True
         except ValueError:
             outcome = False
+        except BaseException as exc:  # noqa: BLE001 - reported, then re-asserted below
+            with lock:
+                escaped.append(exc)
+            return
         with lock:
             moved.append(outcome)
 
@@ -1597,4 +1612,9 @@ def test_concurrent_transfers_cannot_overdraw(store: Store, workspace_id: str, u
     for thread in threads:
         thread.join(timeout=30)
 
+    # Same contract as the concurrent-reserve race: a loser gets the domain's
+    # refusal, never an infrastructure error. A backend that resolves the race
+    # by ABORTING owes the caller a replay -- see
+    # PostgresStore._RETRYABLE_ROLLBACK_SQLSTATES.
+    assert not escaped, f"store errors reached the caller: {escaped}"
     assert moved.count(True) == 1, f"oversubscribed the balance: {moved}"

--- a/tests/test_postgres_transaction_retry.py
+++ b/tests/test_postgres_transaction_retry.py
@@ -1,0 +1,188 @@
+"""PostgresStore._run_transaction's retry policy, pinned by SQLSTATE.
+
+This is the one piece of the Postgres backend that every server-backed test
+runs THROUGH but none ran ON: `tests/fakes/postgres.py` replaces
+`_run_transaction` wholesale, so the retry loop had no coverage at all. It was
+broken the entire time.
+
+`except psycopg.errors.TransactionRollback` reads like it covers
+serialization failures and deadlocks -- its comment said so -- but psycopg
+generates one flat class per SQLSTATE, each deriving straight from its DB-API
+base. `SerializationFailure` (40001) and `DeadlockDetected` (40P01) are
+SIBLINGS of `TransactionRollback` (40000), not subclasses. The clause caught
+only a bare 40000, so every real abort fell through to the generic handler and
+reached the caller as `StoreUnavailable`.
+
+Concretely, that turned a routine contended reserve into "Postgres could not
+service the storage operation" instead of a retry that reports "insufficient
+credits" -- observed on the Spanner PG emulator in CI run 31996299784, and on
+Aurora DSQL it would be EVERY optimistic-concurrency abort, since 40001 is how
+DSQL reports all of them.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any
+
+import psycopg
+import pytest
+
+from trusted_router.storage_errors import StoreConflict, StoreUnavailable
+from trusted_router.storage_postgres import (
+    _RETRYABLE_ROLLBACK_SQLSTATES,
+    PostgresStore,
+)
+
+
+class _FakeTransaction:
+    def __enter__(self) -> _FakeTransaction:
+        return self
+
+    def __exit__(self, *_exc: object) -> bool:
+        return False
+
+
+class _FakeConnection:
+    def transaction(self) -> _FakeTransaction:
+        return _FakeTransaction()
+
+
+class _FakePool:
+    def __init__(self) -> None:
+        self.connections_handed_out = 0
+
+    @contextmanager
+    def connection(self) -> Any:
+        self.connections_handed_out += 1
+        yield _FakeConnection()
+
+
+def _store(attempts: int = 8) -> tuple[PostgresStore, _FakePool]:
+    """A PostgresStore with the real `_run_transaction` and no server.
+
+    Built with `object.__new__` on purpose: `__init__` opens a connection pool,
+    and the behaviour under test is the retry policy, not connection setup.
+    """
+    store = object.__new__(PostgresStore)
+    pool = _FakePool()
+    store._transaction_attempts = attempts
+    store._pool = pool  # type: ignore[assignment]
+    return store, pool
+
+
+def _raise_then_succeed(error: BaseException, failures: int) -> Any:
+    calls = {"n": 0}
+
+    def operation(_conn: Any) -> str:
+        calls["n"] += 1
+        if calls["n"] <= failures:
+            raise error
+        return "committed"
+
+    operation.calls = calls  # type: ignore[attr-defined]
+    return operation
+
+
+@pytest.mark.parametrize(
+    ("sqlstate", "error"),
+    [
+        ("40001", psycopg.errors.SerializationFailure("aborted by concurrent write")),
+        ("40P01", psycopg.errors.DeadlockDetected("deadlock detected")),
+        ("40000", psycopg.errors.TransactionRollback("rolled back")),
+    ],
+)
+def test_rolled_back_transactions_are_replayed(
+    sqlstate: str, error: psycopg.Error
+) -> None:
+    """The whole point: an abort is retried, not handed to the caller."""
+    assert error.sqlstate == sqlstate
+    store, pool = _store()
+    operation = _raise_then_succeed(error, failures=2)
+
+    assert store._run_transaction(operation) == "committed"
+    assert operation.calls["n"] == 3
+    # A fresh connection per attempt -- a retry on the same aborted connection
+    # would fail identically forever.
+    assert pool.connections_handed_out == 3
+
+
+@pytest.mark.parametrize(
+    ("label", "error"),
+    [
+        # Deterministic: replaying it fails identically forever.
+        ("40002", psycopg.errors.TransactionIntegrityConstraintViolation("bad")),
+        # The statement may in fact have COMMITTED; replaying could double-apply.
+        ("40003", psycopg.errors.StatementCompletionUnknown("unknown")),
+    ],
+)
+def test_unsafe_class_40_states_are_not_replayed(
+    label: str, error: psycopg.Error
+) -> None:
+    """Not every 40xxx is safe to replay, so the set is explicit, not a prefix."""
+    assert error.sqlstate == label
+    assert error.sqlstate not in _RETRYABLE_ROLLBACK_SQLSTATES
+    store, pool = _store()
+    operation = _raise_then_succeed(error, failures=1)
+
+    with pytest.raises(StoreUnavailable):
+        store._run_transaction(operation)
+    assert operation.calls["n"] == 1
+    assert pool.connections_handed_out == 1
+
+
+def test_duplicate_key_is_a_conflict_not_a_retry() -> None:
+    store, _pool = _store()
+    operation = _raise_then_succeed(psycopg.errors.UniqueViolation("dup"), failures=1)
+
+    with pytest.raises(StoreConflict):
+        store._run_transaction(operation)
+    assert operation.calls["n"] == 1
+
+
+def test_exhausting_the_retry_budget_raises_conflict() -> None:
+    store, _pool = _store(attempts=3)
+    operation = _raise_then_succeed(
+        psycopg.errors.SerializationFailure("aborted"), failures=99
+    )
+
+    with pytest.raises(StoreConflict) as exc:
+        store._run_transaction(operation)
+    assert operation.calls["n"] == 3
+    # The original abort is preserved for the operator reading the traceback.
+    assert isinstance(exc.value.__cause__, psycopg.errors.SerializationFailure)
+
+
+def test_a_clean_run_does_not_retry() -> None:
+    store, pool = _store()
+    operation = _raise_then_succeed(RuntimeError("unused"), failures=0)
+
+    assert store._run_transaction(operation) == "committed"
+    assert operation.calls["n"] == 1
+    assert pool.connections_handed_out == 1
+
+
+def test_non_psycopg_errors_propagate_untouched() -> None:
+    """A ValueError is the domain's own refusal (e.g. insufficient credits).
+
+    It must reach the caller unwrapped and unretried -- swallowing it into a
+    StoreError is what made a contended reserve look like an outage.
+    """
+    store, _pool = _store()
+    operation = _raise_then_succeed(ValueError("insufficient credits"), failures=99)
+
+    with pytest.raises(ValueError, match="insufficient credits"):
+        store._run_transaction(operation)
+    assert operation.calls["n"] == 1
+
+
+def test_retryable_set_matches_what_psycopg_maps_those_states_to() -> None:
+    """Pins the intent against a future psycopg reshuffling its class tree.
+
+    If psycopg ever makes these classes nest, this still passes -- the store
+    keys off SQLSTATE, which is the database's contract rather than the
+    driver's. What must never happen is 40001 or 40P01 dropping out of the set.
+    """
+    assert psycopg.errors.SerializationFailure("x").sqlstate in _RETRYABLE_ROLLBACK_SQLSTATES
+    assert psycopg.errors.DeadlockDetected("x").sqlstate in _RETRYABLE_ROLLBACK_SQLSTATES
+    assert psycopg.errors.UniqueViolation("x").sqlstate not in _RETRYABLE_ROLLBACK_SQLSTATES


### PR DESCRIPTION
Fixes the recurring `test_concurrent_reserves_cannot_oversubscribe[backend=spanner-pg]` flake ([CI run 31996299784](https://github.com/Lore-Hex/quill-router/actions/runs/31996299784), and again on main in [31997649749](https://github.com/Lore-Hex/quill-router/actions/runs/31997649749)) — but the flake was a symptom. **`PostgresStore` has never retried a single aborted transaction.**

## Root cause

`_run_transaction` caught `psycopg.errors.TransactionRollback`, with a comment claiming that covered SerializationFailure (40001) and DeadlockDetected (40P01). It does not:

```
SerializationFailure  bases=['OperationalError']
DeadlockDetected      bases=['OperationalError']
TransactionRollback   bases=['OperationalError']
issubclass(SerializationFailure, TransactionRollback) -> False
```

psycopg generates **one flat class per SQLSTATE**, each deriving straight from its DB-API base. `TransactionRollback` is simply the class for code `40000`, a *sibling* of the two we meant to catch. So the clause matched only a bare 40000 — which no server in this fleet emits — and every real abort fell through to `except psycopg.Error` and reached the caller as `StoreUnavailable`. `transaction_attempts=8` was dead code for its stated purpose.

**Blast radius is not just the flake:**
- **Spanner PG** aborts the loser of a write-write conflict → a routine contended reserve returned "Postgres could not service the storage operation" instead of retrying to "insufficient credits".
- **Aurora DSQL** — per this module's own comment, 40001 is how DSQL reports *every* optimistic-concurrency abort, so the EU deployment has been turning ordinary contention into 503s.
- **Stock Postgres** deadlocks (40P01) were never retried either.

**Why no test caught it:** `tests/fakes/postgres.py` replaces `_run_transaction` wholesale, so every server-backed test ran *through* the retry loop and none ran *on* it.

## The fix

Retry on `exc.sqlstate` — the database's contract — rather than on psycopg's class layout. The set is explicit, not a `40` prefix match:

| code | retried | why |
|---|---|---|
| 40000 transaction_rollback | ✅ | rolled back whole |
| 40001 serialization_failure | ✅ | Spanner ABORTED, DSQL OCC abort |
| 40P01 deadlock_detected | ✅ | ordinary lock ordering |
| 40002 integrity constraint | ❌ | deterministic — replay fails identically forever |
| 40003 completion unknown | ❌ | **may have COMMITTED** — replay could double-apply money |

## Evidence (PGAdapter/Spanner emulator)

- **Mechanism confirmed directly:** a forced write-write conflict raises `psycopg.errors.SerializationFailure`, `sqlstate='40001'`, `isinstance(..., TransactionRollback)` → `False`.
- **Before:** 4 of 72 concurrent reserves surfaced `StoreUnavailable` to the caller.
- **After:** **0 of 240** at 8-way contention, with exactly one winner per round (no oversubscription).
- **A/B on the 4-way transfer race** (`attempts=1` reproduces the pre-fix "no retry" profile): 2 of 16 escaped as `StoreConflict` vs **0 of 16** after — at identical wall-clock, 0.2–0.3s/round, so the retry loop introduces no storm.
- **Mutation test:** reverting only the `except` clause fails 3 of the new tests, exactly on 40001/40P01.
- **25 consecutive runs** of both concurrent tests across all 5 backends: 0 failures.

## Tests

`tests/test_postgres_transaction_retry.py` drives the **real** `_run_transaction` against a fake pool (no server, so it runs everywhere): replay on 40000/40001/40P01 with a fresh connection per attempt, refusal to replay 40002/40003, duplicate key → `StoreConflict`, budget exhaustion → `StoreConflict` preserving the original abort as `__cause__`, and non-psycopg errors (the domain's own `ValueError`) propagating unwrapped and unretried.

I did **not** loosen the conformance assertion — it was correct all along, and it now carries a comment saying so, pointing at the retry policy as the thing to fix if it ever flakes again. `test_concurrent_transfers_cannot_overdraw` only tallied `True`/`ValueError`, so an escaping store error left the tally short and failed as a bare `assert 0 == 1`; it now names what escaped.

## Note, not changed here

`storage_errors._postgres_error_types()` lists `SerializationFailure` as a conflict type but omits `DeadlockDetected`. After this fix both are retried inside the store and only surface as `StoreConflict` (already a conflict type), so there is no live exposure — and changing it would shift deadlock responses from 503 to the abort handler, which deserves its own decision.

## Gates

- `uv run ruff check .` — clean (no `ruff format`)
- `uv run mypy` — clean, 275 files
- `uv run pytest -q tests/conformance/` — **281 passed** against both postgres:17 and Spanner PG
- `uv run pytest -q -n 4 --dist loadgroup` — **4685 passed**, 139 skipped, 10 xfailed, with BOTH conformance backends live (139 skips rather than the usual 290 is how you can tell the server-backed backends actually ran).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
