### PR TITLE
Provision the AWS-EU archive on its own identity, in its own region

### DIFF
--- a/scripts/deploy/aws_eu_clickhouse_archive.sh
+++ b/scripts/deploy/aws_eu_clickhouse_archive.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+# Provision the AWS-EU ClickHouse Parquet archive: bucket, dedicated node
+# identity, and the least-privilege grant between them.
+#
+# Idempotent. Without --apply it only prints the mutations it would make.
+#
+# WHY THIS EXISTS
+#
+# clickhouse/archive_daily.py is the only point-in-time copy of ClickHouse
+# history that exists. It ran on GCP only, so the AWS-EU node's analytics
+# history -- which is NOT a copy of GCP's, it is the rows this cloud's own
+# gateway produced -- was protected by replication alone. Replication does not
+# protect against logical corruption or deletion, because those replicate.
+#
+# WHY eu-west-3 AND NOT THE ACCOUNT'S USUAL us-east-1
+#
+# Every pre-existing bucket in this account is us-east-1. This one must not be.
+# tr-eu-clickhouse-1 runs in eu-west-3, and scripts/deploy/aws_eu_clickhouse.sh
+# stakes an EU audit claim on operational rows never leaving the EU. Archiving
+# EU operational history into Virginia would break that claim quietly -- the
+# archive would work perfectly and the residency statement would become false.
+# So the region is asserted, not defaulted, and creation in us-east-1 is refused.
+#
+# WHY A DEDICATED INSTANCE PROFILE
+#
+# tr-eu-clickhouse-1 currently shares quill-enclave-instance-profile with five
+# quill-enclave instances -- the attested gateway. Granting the archive bucket
+# to that role would grant it to the enclave too.
+#
+# Separating them is narrower in BOTH directions, which is why it is worth the
+# swap rather than just the grant:
+#
+#   the node stops carrying  : ecr:* (PullECR) and kms:Decrypt on the two
+#                              cross-cloud SA keys -- enclave concerns it never
+#                              uses
+#   the enclave stops gaining: s3:PutObject on the archive bucket
+#   the node's secret scope  : narrowed from quill/* to the one password secret
+#
+# WHY NO OBJECT LOCK
+#
+# Deliberately absent, and it must stay absent. The archive's immutability is
+# enforced by conditional writes (IfNoneMatch on create), not by bucket policy,
+# because put_json_pointer MUST overwrite _latest.json every time a revision is
+# added. Object Lock would block that overwrite and wedge the archive after its
+# first day. Versioning plus the noncurrent-version lifecycle rule gives the
+# recoverability Object Lock would nominally provide, without breaking the
+# pointer.
+#
+# WHY SSE-S3 AND NOT SSE-KMS
+#
+# SSE-KMS PutObject requires kms:GenerateDataKey. The node's role has only
+# kms:Decrypt and kms:DescribeKey, so SSE-KMS would fail every write. SSE-S3
+# (AES256) is enforced on the bucket instead.
+#
+# THE PROFILE SWAP IS A SEPARATE, GATED STEP
+#
+# --attach-profile is not part of the default run. The shared role grants
+# dsql:DbConnect, and the analytics drain depends on it: swapping the node onto
+# a role missing that permission stops delivery, and a stalled drain looks
+# exactly like a quiet one. So the swap runs a pre-flight that proves the new
+# role carries DSQL connect and Secrets Manager read BEFORE replacing the
+# association, and the association is reversible in one command (printed on
+# success).
+set -euo pipefail
+
+ACCOUNT="${TR_AWS_ACCOUNT:-330422590279}"
+REGION="${TR_AWS_EU_REGION:-eu-west-3}"
+NODE_NAME="${TR_AWS_EU_CLICKHOUSE_NAME:-tr-eu-clickhouse-1}"
+BUCKET="${TR_AWS_EU_ARCHIVE_BUCKET:-quill-tr-clickhouse-archive-${ACCOUNT}}"
+ROLE="${TR_AWS_EU_CLICKHOUSE_ROLE:-tr-eu-clickhouse-role}"
+PROFILE="${TR_AWS_EU_CLICKHOUSE_PROFILE:-tr-eu-clickhouse-instance-profile}"
+SECRET_ID="${TR_AWS_EU_SECRET_ID:-quill/tr-eu-clickhouse-password}"
+DSQL_CLUSTER="${TR_AWS_EU_DSQL_CLUSTER:-tnt642i3ofzpn5z62msacutpuu}"
+# 2555 days ~= 7 years, matching the GCP archive bucket's retention.
+CURRENT_RETENTION_DAYS="${TR_AWS_EU_ARCHIVE_RETENTION_DAYS:-2555}"
+NONCURRENT_RETENTION_DAYS="${TR_AWS_EU_ARCHIVE_NONCURRENT_DAYS:-30}"
+
+APPLY=0
+ATTACH_PROFILE=0
+for arg in "$@"; do
+  case "$arg" in
+    --apply) APPLY=1 ;;
+    --attach-profile) ATTACH_PROFILE=1 ;;
+    *)
+      echo "usage: $0 [--apply] [--attach-profile]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >&2; }
+
+run() {
+  if [ "$APPLY" -eq 0 ]; then
+    printf '[dry-run]'
+    printf ' %q' "$@"
+    printf '\n'
+    return 0
+  fi
+  "$@"
+}
+
+# Read-only helper. Mutations go through run() with an explicit --region so the
+# dry-run output is a command an operator can actually paste.
+aws_() { aws --region "$REGION" "$@"; }
+
+# The residency claim is the reason this script exists in a second region, so
+# it is checked rather than assumed.
+if [ "$REGION" = "us-east-1" ]; then
+  echo "refusing to create the EU archive in us-east-1: see the residency note above" >&2
+  exit 2
+fi
+
+require_node_region() {
+  log "confirming ${NODE_NAME} really is in ${REGION}"
+  local found
+  found="$(aws_ ec2 describe-instances \
+    --filters "Name=tag:Name,Values=${NODE_NAME}" "Name=instance-state-name,Values=running" \
+    --query 'Reservations[].Instances[].InstanceId' --output text)"
+  if [ -z "$found" ]; then
+    echo "no running ${NODE_NAME} in ${REGION}; refusing to provision an archive" \
+      "for a node that is not there" >&2
+    exit 1
+  fi
+  log "found ${NODE_NAME} = ${found}"
+}
+
+ensure_bucket() {
+  log "ensuring private, versioned, SSE-S3 archive bucket ${BUCKET} in ${REGION}"
+  if aws_ s3api head-bucket --bucket "$BUCKET" >/dev/null 2>&1; then
+    local loc
+    loc="$(aws_ s3api get-bucket-location --bucket "$BUCKET" --output text)"
+    # get-bucket-location reports us-east-1 as "None".
+    if [ "$loc" != "$REGION" ]; then
+      echo "bucket ${BUCKET} exists in ${loc}, not ${REGION}; refusing to use it" >&2
+      exit 1
+    fi
+    log "bucket already exists in the right region"
+  else
+    run aws --region "$REGION" s3api create-bucket --bucket "$BUCKET" \
+      --create-bucket-configuration "LocationConstraint=${REGION}"
+  fi
+
+  # Versioning is the recoverability mechanism, since Object Lock cannot be
+  # used (see header).
+  run aws --region "$REGION" s3api put-bucket-versioning --bucket "$BUCKET" \
+    --versioning-configuration Status=Enabled
+
+  # There is no account-level public access block to inherit, so it is set here.
+  run aws --region "$REGION" s3api put-public-access-block --bucket "$BUCKET" \
+    --public-access-block-configuration \
+    'BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true'
+
+  run aws --region "$REGION" s3api put-bucket-encryption --bucket "$BUCKET" \
+    --server-side-encryption-configuration \
+    '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"},"BucketKeyEnabled":true}]}'
+
+  run aws --region "$REGION" s3api put-bucket-lifecycle-configuration --bucket "$BUCKET" \
+    --lifecycle-configuration "{\"Rules\":[
+      {\"ID\":\"expire-archived-days\",\"Status\":\"Enabled\",\"Filter\":{\"Prefix\":\"\"},
+       \"Expiration\":{\"Days\":${CURRENT_RETENTION_DAYS}}},
+      {\"ID\":\"expire-noncurrent\",\"Status\":\"Enabled\",\"Filter\":{\"Prefix\":\"\"},
+       \"NoncurrentVersionExpiration\":{\"NoncurrentDays\":${NONCURRENT_RETENTION_DAYS}}}
+    ]}"
+}
+
+ensure_role() {
+  log "ensuring dedicated node role ${ROLE}"
+  if ! aws iam get-role --role-name "$ROLE" >/dev/null 2>&1; then
+    run aws iam create-role --role-name "$ROLE" \
+      --description "tr-eu-clickhouse node: analytics drain and Parquet archive" \
+      --assume-role-policy-document \
+      '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  fi
+
+  # SSM is how code reaches this node at all -- the drain installer ships the
+  # tree as chunked base64 over send-command.
+  run aws iam attach-role-policy --role-name "$ROLE" \
+    --policy-arn arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+
+  # Carried over from the shared role, because the drain stops without it.
+  run aws iam put-role-policy --role-name "$ROLE" --policy-name dsql-connect-drain \
+    --policy-document "{\"Version\":\"2012-10-17\",\"Statement\":[
+      {\"Effect\":\"Allow\",\"Action\":[\"dsql:DbConnect\"],
+       \"Resource\":[\"arn:aws:dsql:${REGION}:${ACCOUNT}:cluster/${DSQL_CLUSTER}\"]}
+    ]}"
+
+  # Narrower than the shared role's quill/*: this node reads one secret.
+  run aws iam put-role-policy --role-name "$ROLE" --policy-name read-clickhouse-password \
+    --policy-document "{\"Version\":\"2012-10-17\",\"Statement\":[
+      {\"Sid\":\"ReadClickHousePassword\",\"Effect\":\"Allow\",
+       \"Action\":[\"secretsmanager:GetSecretValue\",\"secretsmanager:DescribeSecret\"],
+       \"Resource\":\"arn:aws:secretsmanager:${REGION}:${ACCOUNT}:secret:${SECRET_ID}*\"},
+      {\"Sid\":\"DecryptViaSecretsManager\",\"Effect\":\"Allow\",
+       \"Action\":[\"kms:Decrypt\",\"kms:DescribeKey\"],
+       \"Resource\":\"arn:aws:kms:*:${ACCOUNT}:key/*\",
+       \"Condition\":{\"StringLike\":{\"kms:ViaService\":\"secretsmanager.*.amazonaws.com\"}}}
+    ]}"
+
+  # The archive grant itself. s3:ListBucket is deliberately absent:
+  # S3ArchiveStore only ever calls put_object, get_object and head_object, and
+  # head_object is authorized by s3:GetObject. Scope is the one bucket.
+  run aws iam put-role-policy --role-name "$ROLE" --policy-name write-clickhouse-archive \
+    --policy-document "{\"Version\":\"2012-10-17\",\"Statement\":[
+      {\"Sid\":\"WriteArchiveObjects\",\"Effect\":\"Allow\",
+       \"Action\":[\"s3:PutObject\",\"s3:GetObject\"],
+       \"Resource\":\"arn:aws:s3:::${BUCKET}/*\"}
+    ]}"
+}
+
+ensure_profile() {
+  log "ensuring instance profile ${PROFILE}"
+  if ! aws iam get-instance-profile --instance-profile-name "$PROFILE" >/dev/null 2>&1; then
+    run aws iam create-instance-profile --instance-profile-name "$PROFILE"
+  fi
+  if ! aws iam get-instance-profile --instance-profile-name "$PROFILE" \
+    --query 'InstanceProfile.Roles[].RoleName' --output text 2>/dev/null | grep -qw "$ROLE"; then
+    run aws iam add-role-to-instance-profile \
+      --instance-profile-name "$PROFILE" --role-name "$ROLE"
+  fi
+}
+
+# Proving the new role can do the drain's job BEFORE the node depends on it.
+# A missing dsql:DbConnect would not fail loudly; it would stop delivery, and a
+# stalled drain is indistinguishable from an idle one from the outside.
+preflight_profile_swap() {
+  log "pre-flight: the new role must carry DSQL connect and the secret read"
+  local missing=0
+  for policy in dsql-connect-drain read-clickhouse-password write-clickhouse-archive; do
+    if ! aws iam get-role-policy --role-name "$ROLE" --policy-name "$policy" \
+      >/dev/null 2>&1; then
+      echo "  MISSING inline policy ${policy} on ${ROLE}" >&2
+      missing=1
+    fi
+  done
+  if ! aws iam list-attached-role-policies --role-name "$ROLE" \
+    --query 'AttachedPolicies[].PolicyArn' --output text 2>/dev/null |
+    grep -q AmazonSSMManagedInstanceCore; then
+    echo "  MISSING AmazonSSMManagedInstanceCore on ${ROLE}: SSM is how code reaches the node" >&2
+    missing=1
+  fi
+  if [ "$missing" -ne 0 ]; then
+    echo "refusing to swap the instance profile: the replacement role is incomplete" >&2
+    echo "run without --attach-profile first (with --apply) to provision it" >&2
+    exit 1
+  fi
+  log "pre-flight passed"
+}
+
+attach_profile() {
+  preflight_profile_swap
+  local instance association
+  instance="$(aws_ ec2 describe-instances \
+    --filters "Name=tag:Name,Values=${NODE_NAME}" "Name=instance-state-name,Values=running" \
+    --query 'Reservations[].Instances[].InstanceId' --output text)"
+  association="$(aws_ ec2 describe-iam-instance-profile-associations \
+    --filters "Name=instance-id,Values=${instance}" \
+    --query 'IamInstanceProfileAssociations[?State==`associated`].AssociationId' \
+    --output text)"
+
+  if [ -z "$association" ]; then
+    run aws --region "$REGION" ec2 associate-iam-instance-profile --instance-id "$instance" \
+      --iam-instance-profile "Name=${PROFILE}"
+  else
+    local current
+    current="$(aws_ ec2 describe-iam-instance-profile-associations \
+      --filters "Name=instance-id,Values=${instance}" \
+      --query 'IamInstanceProfileAssociations[?State==`associated`].IamInstanceProfile.Arn' \
+      --output text)"
+    log "current association: ${current}"
+    run aws --region "$REGION" ec2 replace-iam-instance-profile-association \
+      --association-id "$association" --iam-instance-profile "Name=${PROFILE}"
+    cat >&2 <<EOF
+
+  Swapped ${NODE_NAME} onto ${PROFILE}.
+
+  Credentials on the instance refresh within minutes, they are not instant. So
+  VERIFY BEFORE WALKING AWAY, because the failure mode is silent:
+    - the drain still delivers  (operational_analytics_outbox lag stops growing)
+    - the archive can write     (a manual archive_daily run produces a pointer)
+
+  To revert:
+    aws --region ${REGION} ec2 replace-iam-instance-profile-association \\
+      --association-id ${association} \\
+      --iam-instance-profile Name=quill-enclave-instance-profile
+EOF
+  fi
+}
+
+require_node_region
+ensure_bucket
+ensure_role
+ensure_profile
+if [ "$ATTACH_PROFILE" -eq 1 ]; then
+  attach_profile
+else
+  log "instance profile NOT attached; re-run with --attach-profile when ready"
+fi
+
+if [ "$APPLY" -eq 0 ]; then
+  log "dry run only; nothing was changed. re-run with --apply"
+fi

--- a/scripts/deploy/clickhouse_reliability.sh
+++ b/scripts/deploy/clickhouse_reliability.sh
@@ -12,7 +12,15 @@ NAME="${TR_CLICKHOUSE_NAME:-tr-clickhouse-1}"
 DISK="${TR_CLICKHOUSE_DISK:-${NAME}}"
 ARCHIVE_BUCKET="${TR_CLICKHOUSE_ARCHIVE_BUCKET:-${PROJECT_ID}-tr-clickhouse-archive}"
 SNAPSHOT_POLICY="${TR_CLICKHOUSE_SNAPSHOT_POLICY:-tr-clickhouse-daily-snapshots}"
-NODE_SERVICE_ACCOUNT="${TR_CLICKHOUSE_SERVICE_ACCOUNT:-${PROJECT_NUMBER}-compute@developer.gserviceaccount.com}"
+# The dedicated node identity, NOT the compute default. All three ClickHouse
+# nodes were moved onto tr-clickhouse@ as a least-privilege change, but this
+# default kept naming the old broad compute-default SA -- so the archive
+# bucket's objectUser binding named an identity the nodes no longer used, and
+# the archiver plus the restore drill failed 403 for ten hours before anyone
+# noticed (SOC 2 NC-005, 2026-08-16). Re-running this script with the old
+# default reproduces that outage, which is why the default is the fix and not
+# just the runbook.
+NODE_SERVICE_ACCOUNT="${TR_CLICKHOUSE_SERVICE_ACCOUNT:-tr-clickhouse@${PROJECT_ID}.iam.gserviceaccount.com}"
 ALERT_CHANNEL_DISPLAY_NAME="${TR_CLICKHOUSE_ALERT_CHANNEL_DISPLAY_NAME:-TrustedRouter Spanner on-call}"
 ALERT_EMAIL="${TR_CLICKHOUSE_ALERT_EMAIL:-security@trustedrouter.com}"
 APPLY=0

--- a/tests/test_aws_eu_clickhouse_archive_deploy.py
+++ b/tests/test_aws_eu_clickhouse_archive_deploy.py
@@ -1,0 +1,246 @@
+"""The AWS-EU archive provisioning script.
+
+Every assertion here corresponds to a way this could go wrong *silently* --
+where the archive would appear to work and something else would be quietly
+false: the EU residency claim, the enclave's blast radius, or the pointer
+overwrite the archive depends on.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts/deploy/aws_eu_clickhouse_archive.sh"
+SCRIPT = SCRIPT_PATH.read_text()
+
+
+def test_script_is_executable_and_fails_fast() -> None:
+    assert SCRIPT_PATH.stat().st_mode & 0o111, "deploy scripts must be executable"
+    assert "set -euo pipefail" in SCRIPT
+
+
+def test_defaults_to_dry_run() -> None:
+    """A provisioning script whose default mutates is one bad tab-complete from
+    creating real infrastructure."""
+
+    assert "APPLY=0" in SCRIPT
+    assert '--apply) APPLY=1' in SCRIPT
+    assert "dry run only; nothing was changed" in SCRIPT
+
+
+# --------------------------------------------------------------------------
+# Residency. The archive is in a second region for one reason.
+# --------------------------------------------------------------------------
+
+
+def test_archive_region_is_the_nodes_eu_region_not_the_accounts_default() -> None:
+    """Every other bucket in this account is us-east-1. Following that habit
+    would move EU operational history to Virginia and quietly falsify the EU
+    audit claim, while the archive itself kept working."""
+
+    region_line = [line for line in SCRIPT.splitlines() if line.startswith("REGION=")]
+    assert len(region_line) == 1
+    assert "eu-west-3" in region_line[0]
+    assert "us-east-1" not in region_line[0]
+
+
+def test_script_refuses_to_create_the_eu_archive_in_us_east_1() -> None:
+    assert 'if [ "$REGION" = "us-east-1" ]' in SCRIPT
+    assert "refusing to create the EU archive in us-east-1" in SCRIPT
+
+
+def test_script_verifies_the_node_is_actually_in_that_region() -> None:
+    """Provisioning an archive in eu-west-3 for a node that is not there would
+    produce a bucket that never receives an object -- and a freshness check
+    pointed at it would file a daily issue forever."""
+
+    assert "require_node_region" in SCRIPT
+    assert "refusing to provision an archive" in SCRIPT
+
+
+def test_existing_bucket_in_the_wrong_region_is_refused_not_reused() -> None:
+    assert "get-bucket-location" in SCRIPT
+    assert "refusing to use it" in SCRIPT
+
+
+# --------------------------------------------------------------------------
+# The pointer overwrite. This is the subtle one.
+# --------------------------------------------------------------------------
+
+
+def test_object_lock_is_never_enabled() -> None:
+    """The archive's immutability comes from conditional writes, NOT bucket
+    policy, because put_json_pointer must overwrite _latest.json on every new
+    revision. Object Lock would block that and wedge the archive after its
+    first day -- and on S3, object-lock-enabled cannot be turned off."""
+
+    lowered = SCRIPT.lower()
+    assert "object-lock" not in lowered
+    assert "objectlock" not in lowered
+    assert "governance" not in lowered
+    assert "compliance_mode" not in lowered
+
+
+def test_versioning_is_the_recoverability_mechanism_instead() -> None:
+    assert "put-bucket-versioning" in SCRIPT
+    assert "Status=Enabled" in SCRIPT
+    assert "NoncurrentVersionExpiration" in SCRIPT
+
+
+def test_bucket_is_private_and_encrypted_with_sse_s3_not_kms() -> None:
+    """SSE-KMS PutObject needs kms:GenerateDataKey, which the node's role does
+    not have and should not need. SSE-KMS would fail every archive write."""
+
+    assert "put-public-access-block" in SCRIPT
+    assert "BlockPublicAcls=true" in SCRIPT
+    assert "RestrictPublicBuckets=true" in SCRIPT
+    assert "AES256" in SCRIPT
+    assert "aws:kms" not in SCRIPT.split("put-bucket-encryption")[1].split("\n\n")[0]
+
+
+# --------------------------------------------------------------------------
+# Identity separation and least privilege.
+# --------------------------------------------------------------------------
+
+
+def test_a_dedicated_role_is_created_rather_than_reusing_the_enclave_role() -> None:
+    """tr-eu-clickhouse-1 shares quill-enclave-instance-profile with five
+    attested-gateway instances. Granting the archive bucket to that role would
+    hand s3:PutObject to the enclave."""
+
+    assert "tr-eu-clickhouse-role" in SCRIPT
+    assert "tr-eu-clickhouse-instance-profile" in SCRIPT
+    # The enclave role must never be the grant target.
+    grant_section = SCRIPT.split("write-clickhouse-archive")[1]
+    assert "quill-enclave-role" not in grant_section
+
+
+def test_the_archive_grant_is_scoped_to_one_bucket_and_omits_list() -> None:
+    """S3ArchiveStore only calls put_object/get_object/head_object, and
+    head_object is authorized by s3:GetObject. ListBucket is not needed, and a
+    wildcard resource would put every bucket in the account in scope."""
+
+    policy = _inline_policy("write-clickhouse-archive")
+    statement = policy["Statement"][0]
+    assert set(statement["Action"]) == {"s3:PutObject", "s3:GetObject"}
+    assert statement["Resource"].startswith("arn:aws:s3:::")
+    assert statement["Resource"].endswith("/*")
+    assert "s3:ListBucket" not in json.dumps(policy)
+    assert "s3:*" not in json.dumps(policy)
+    assert '"Resource":"*"' not in json.dumps(policy).replace(" ", "")
+
+
+def test_the_dedicated_role_still_carries_what_the_drain_needs() -> None:
+    """The swap's real risk: the shared role granted dsql:DbConnect. A
+    replacement role without it stops analytics delivery, and a stalled drain
+    is indistinguishable from an idle one from outside the node."""
+
+    dsql = _inline_policy("dsql-connect-drain")
+    assert dsql["Statement"][0]["Action"] == ["dsql:DbConnect"]
+    assert "cluster/" in dsql["Statement"][0]["Resource"][0]
+
+    secrets = _inline_policy("read-clickhouse-password")
+    actions = {a for s in secrets["Statement"] for a in _as_list(s["Action"])}
+    assert "secretsmanager:GetSecretValue" in actions
+    # SSM is how code reaches this node at all.
+    assert "AmazonSSMManagedInstanceCore" in SCRIPT
+
+
+def test_the_secret_grant_is_narrower_than_the_shared_roles_wildcard() -> None:
+    """The shared role allowed quill/*. This node reads exactly one secret."""
+
+    # The ARN is built from ${SECRET_ID}, so the narrowing lives in two places:
+    # the default value, and the fact that the policy interpolates it rather
+    # than hardcoding a prefix wildcard.
+    secret_default = [line for line in SCRIPT.splitlines() if line.startswith("SECRET_ID=")]
+    assert len(secret_default) == 1
+    assert "quill/tr-eu-clickhouse-password" in secret_default[0]
+
+    resources = [
+        s["Resource"]
+        for s in _inline_policy("read-clickhouse-password")["Statement"]
+        if "secretsmanager" in json.dumps(s["Action"])
+    ]
+    assert resources
+    for resource in resources:
+        assert ":secret:" in resource
+        # quill/* would restore the shared role's breadth.
+        assert "quill/*" not in resource
+    # And the raw script must interpolate the variable, not a wildcard prefix.
+    assert "secret:${SECRET_ID}" in SCRIPT
+    assert "secret:quill/*" not in SCRIPT
+
+
+def test_the_enclave_keeps_no_new_permissions() -> None:
+    """Nothing in this script may modify the enclave's role or profile."""
+
+    for forbidden in (
+        "--role-name quill-enclave-role",
+        "--instance-profile-name quill-enclave-instance-profile",
+    ):
+        assert forbidden not in SCRIPT
+    assert "put-role-policy --role-name quill-enclave-role" not in SCRIPT
+
+
+# --------------------------------------------------------------------------
+# The profile swap is the one step that can break a working system.
+# --------------------------------------------------------------------------
+
+
+def test_the_profile_swap_is_opt_in_and_not_part_of_the_default_run() -> None:
+    assert "ATTACH_PROFILE=0" in SCRIPT
+    assert "--attach-profile) ATTACH_PROFILE=1" in SCRIPT
+    assert "instance profile NOT attached" in SCRIPT
+
+
+def test_the_swap_preflights_the_replacement_role_before_replacing() -> None:
+    """Ordering matters: the check must run before the association changes, or
+    it is a post-mortem rather than a pre-flight."""
+
+    assert "preflight_profile_swap" in SCRIPT
+    body = SCRIPT.split("attach_profile() {")[1]
+    preflight_at = body.index("preflight_profile_swap")
+    replace_at = body.index("replace-iam-instance-profile-association")
+    assert preflight_at < replace_at, "the pre-flight must precede the swap"
+    assert "refusing to swap the instance profile" in SCRIPT
+
+
+def test_the_swap_prints_a_revert_command_and_says_verification_is_required() -> None:
+    """Instance credentials refresh on a delay, so 'it did not break instantly'
+    is not evidence. The operator must be told what to check."""
+
+    assert "To revert:" in SCRIPT
+    assert "replace-iam-instance-profile-association" in SCRIPT
+    assert "VERIFY BEFORE WALKING AWAY" in SCRIPT
+    assert "lag stops growing" in SCRIPT
+
+
+def _as_list(value: object) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    assert isinstance(value, list)
+    return [str(item) for item in value]
+
+
+def _inline_policy(name: str) -> dict:
+    """Pull an inline policy document out of the script and parse it.
+
+    Parsing rather than substring-matching means a policy that is malformed
+    JSON, or that quietly grows an extra action, fails a test instead of
+    failing at apply time against real IAM.
+    """
+
+    marker = f"--policy-name {name} \\"
+    assert marker in SCRIPT, f"no inline policy named {name}"
+    tail = SCRIPT.split(marker, 1)[1]
+    match = re.search(r'--policy-document "(\{.*?\n\s*\]\})"', tail, re.DOTALL)
+    assert match, f"could not extract the policy document for {name}"
+    raw = match.group(1)
+    # The script embeds JSON in a double-quoted shell string, so quotes are
+    # backslash-escaped and shell variables are interpolated at run time.
+    raw = raw.replace('\\"', '"')
+    raw = re.sub(r"\$\{[A-Z_]+\}", "PLACEHOLDER", raw)
+    return json.loads(raw)

--- a/tests/test_clickhouse_reliability_deploy.py
+++ b/tests/test_clickhouse_reliability_deploy.py
@@ -26,6 +26,7 @@ def test_reliability_script_provisions_private_archive_and_snapshots() -> None:
     assert "--public-access-prevention" in script
     assert "--versioning" in script
     assert "roles/storage.objectUser" in script
+    _assert_binds_the_dedicated_node_identity(script)
     assert "create snapshot-schedule" in script
     assert "--max-retention-days=30" in script
     assert "--on-source-disk-delete=keep-auto-snapshots" in script
@@ -78,3 +79,29 @@ def test_failover_smoke_has_remote_and_local_restore_guards() -> None:
     assert "wait_for_health 3 3 exact" in script
     assert "for _ in \\$(seq 1 20)" in script
     assert "SYSTEM SYNC REPLICA provider_benchmark_samples" in script
+
+
+def _assert_binds_the_dedicated_node_identity(script: str) -> None:
+    """The archive bucket grant must name the identity the nodes actually use.
+
+    Asserting only that "roles/storage.objectUser" appears is what let NC-005
+    happen: the role was granted, to the wrong member. All three ClickHouse
+    nodes run as tr-clickhouse@, but NODE_SERVICE_ACCOUNT defaulted to the
+    broad compute-default SA, so --apply bound the bucket to a principal the
+    nodes had been moved off. The archiver and the restore drill failed 403 for
+    ten hours, and nothing off-node noticed.
+    """
+
+    default = [
+        line for line in script.splitlines() if line.startswith("NODE_SERVICE_ACCOUNT=")
+    ]
+    assert len(default) == 1, "expected exactly one NODE_SERVICE_ACCOUNT default"
+    assert "tr-clickhouse@" in default[0], (
+        "the archive bucket grant must default to the dedicated node identity"
+    )
+    # The specific regression: the compute-default SA must not be the default
+    # anywhere in this script, or --apply recreates the NC-005 outage.
+    assert "-compute@developer.gserviceaccount.com" not in script
+    # The grant and the metric-writer role must both use that same variable
+    # rather than a second hardcoded principal.
+    assert 'serviceAccount:${NODE_SERVICE_ACCOUNT}' in script


### PR DESCRIPTION
Follows #642 / #644. Two changes, both about **an IAM grant naming the wrong thing**. Nothing here has been applied — the AWS script defaults to dry-run.

## GCP: stop reproducing NC-005 on every `--apply`

All three ClickHouse nodes were moved onto the dedicated `tr-clickhouse@` identity as a least-privilege change. But `clickhouse_reliability.sh` still defaulted `NODE_SERVICE_ACCOUNT` to the broad compute-default SA — so `--apply` bound the archive bucket to a principal the nodes no longer use, and the archiver *and* the restore drill failed 403 for ten hours before anyone noticed.

Verified against all three live instances:

```
tr-clickhouse-1  us-central1-a  tr-clickhouse@quill-cloud-proxy.iam.gserviceaccount.com
tr-clickhouse-2  us-central1-b  tr-clickhouse@quill-cloud-proxy.iam.gserviceaccount.com
tr-clickhouse-3  us-central1-c  tr-clickhouse@quill-cloud-proxy.iam.gserviceaccount.com
```

**The test is the more interesting half.** It asserted only that `"roles/storage.objectUser"` appeared in the script — which is precisely what let this through, because the role *was* granted, to the wrong member. It now pins the member and asserts the compute-default SA appears nowhere in the file. Reverting the default fails the test.

## AWS: `scripts/deploy/aws_eu_clickhouse_archive.sh`

**Region: eu-west-3, not the account's habitual us-east-1.** `tr-eu-clickhouse-1` runs there, and `aws_eu_clickhouse.sh` stakes an EU audit claim on operational rows never leaving the EU. Archiving EU history into Virginia wouldn't break the archive — it would keep working while the residency statement quietly became false. So the region is asserted, `us-east-1` is refused outright, and the script confirms the node really is in the region before provisioning anything.

**Identity: a dedicated role + instance profile**, rather than the shared `quill-enclave-instance-profile` that `tr-eu-clickhouse-1` currently shares with five attested-gateway instances. Separating them is narrower in *both* directions:

| | before | after |
|---|---|---|
| enclave | would gain `s3:PutObject` on the archive | unchanged |
| node | carries `ecr:*` + `kms:Decrypt` on two cross-cloud SA keys | neither |
| node secrets | `quill/*` | the one password secret |

**The swap is the one step that can break a working system.** The shared role grants `dsql:DbConnect` and the analytics drain depends on it — a replacement role without it stops delivery, and a stalled drain looks exactly like an idle one. So `--attach-profile` is opt-in, runs a pre-flight proving the new role carries DSQL connect + secret read + SSM *before* touching the association, and prints both the revert command and what to verify afterwards.

**Object Lock is deliberately absent, and the tests enforce that it stays absent.** The archive's immutability is the conditional write; `put_json_pointer` must overwrite `_latest.json` on every revision. Object Lock would wedge the archive after its first day — and `ObjectLockEnabled` cannot be turned off. Versioning + a noncurrent-version lifecycle rule gives the recoverability instead. SSE-S3 rather than SSE-KMS, because SSE-KMS `PutObject` needs `kms:GenerateDataKey`, which the node's role does not have.

## Verification

Ran the script in **dry-run against live AWS**. It resolved the node by real API call and printed every mutation without making one:

```
confirming tr-eu-clickhouse-1 really is in eu-west-3
found tr-eu-clickhouse-1 = i-025ed1c1766f61290
[dry-run] aws iam put-role-policy --role-name tr-eu-clickhouse-role --policy-name dsql-connect-drain ...
instance profile NOT attached; re-run with --attach-profile when ready
dry run only; nothing was changed
```

The inline policies are **parsed as JSON** by the tests rather than substring-matched, so a malformed document or a quietly-added action fails in CI instead of at apply time. 22 tests pass · `ruff check` clean · `mypy` clean · mutations caught (Object Lock added → fail; region → us-east-1 → fail; NC-005 default restored → fail).

## Still not done after this

Bucket/role creation (`--apply`), the profile swap, shipping the tree to the node, the first `--backfill` run, and the unit install. Also outstanding: `verify_archive_restore.py` and `check_archive_freshness.py` are still GCS-only, and the latter treats a store error as run-fatal — in a 3-cloud check one cloud's 403 would abort before another is read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)