### PR TITLE
Tell people why their identity check failed

### DIFF
--- a/docs/runbooks/identity-verification-support.md
+++ b/docs/runbooks/identity-verification-support.md
@@ -1,0 +1,80 @@
+# Runbook — someone's identity check failed
+
+Every attempt costs the person $5, charged when the session is created and not
+refunded by Veriff. So a wrong decline is a real loss to them and a support
+case for us. This is how to work one.
+
+## What they see, and why it is vague
+
+`/console/account/verification` shows copy from
+`src/trusted_router/identity_guidance.py`, not Veriff's words:
+
+- **resubmission_requested** → the specific reason ("There was glare on the
+  document. Tilt it away from the light."). Veriff strongly advises telling
+  people this, and it saves the next attempt.
+- **declined** → one neutral message for every reason code, plus a checklist
+  ("hold the physical document — not a photo, a screen, or a printout").
+
+The decline text is deliberately identical for all codes. The granular reasons
+are fraud detectors — 503 tampering, 504 suspicious behaviour, 505 known fraud,
+515–518 the screen/printout family, 526 photos not genuine — and Veriff
+publishes no end-user guidance for them. Naming the one that fired tells
+whoever tripped it exactly what to change next time. The checklist still fixes
+the honest version of the failure, which is the common case: someone
+photographs a scan of their own passport, reads "use the physical document",
+and passes on the retry.
+
+**Do not paste the reason to the customer**, and do not tailor the message per
+code. `tests/test_identity_guidance.py` enforces sameness; that test failing is
+the signal that the leak has been reintroduced.
+
+## Where an operator reads the real reason
+
+1. **Our store, first.** `veriff_decision_code`, `veriff_decision_reason`, and
+   `veriff_decision_reason_code` on the `User` row, populated by the webhook.
+2. **Veriff Station** — <https://station.veriff.com>, Verifications, search the
+   session id (`user.veriff_session_id`). Shows the captured images, the
+   decision, and the reason. This is the console to open when the store row
+   looks wrong or empty.
+3. **The API**, when Station is not enough or the webhook never landed:
+
+   ```bash
+   uv run python scripts/reconcile_veriff_decisions.py --email them@example.com
+   ```
+
+   Dry run by default; prints `reason` and `reason_code` alongside the mapped
+   status. Add `--apply` to write the decision the webhook missed. Veriff does
+   not resend webhooks, so without this the person sits at `pending` forever
+   with the fee already charged.
+
+## Deciding
+
+Corroborate before you extend or refuse trust. Signals worth checking:
+
+- Does the ID name match the cardholder name on their top-up?
+- Is the payment country the same as the document country?
+- Is this their first attempt, or the fifth on a fresh account?
+- Which document type did they use — Israel, for example, has Passport, ID Card
+  and Driver's License enabled but not Resident Permit, and a person holding
+  only the un-enabled type gets declined for reasons unrelated to fraud.
+
+A single decline on an account with a consistent name, a real card, and no
+velocity is much more likely a bad photo than fraud.
+
+## Giving another try
+
+Resetting to `none` clears the block; the next attempt charges $5 again, so
+credit them if the decline was ours to own.
+
+```python
+STORE.set_user_identity_status(user.id, status="none")
+```
+
+Credit through the normal typed-counter path with a reason string that names
+the case, so the movement is legible in the ledger later.
+
+## What to say
+
+Plain, short, no forensics: the attempt did not pass, they can try again, and
+here is the checklist. If we reset and credited them, say so. Never say which
+detector fired — not in email either.

--- a/scripts/reconcile_veriff_decisions.py
+++ b/scripts/reconcile_veriff_decisions.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Apply Veriff decisions the webhook never delivered.
+
+The webhook is the normal path and this changes nothing about it. It exists
+for the window where the decision fires and the webhook cannot be delivered —
+the URL is unset in the Veriff dashboard, or wrong, or the endpoint was down.
+Veriff does not resend, so without this the person sits at ``pending`` forever
+with a $5 attempt already charged, and support has no honest remedy short of
+editing the database by hand.
+
+Dry run by default. ``--apply`` writes only through
+``Store.set_user_identity_status``, with exactly the mapping the webhook uses,
+so a reconciled decision and a delivered one are indistinguishable afterwards.
+
+  uv run python scripts/reconcile_veriff_decisions.py --email you@example.com
+  uv run python scripts/reconcile_veriff_decisions.py --email you@example.com --apply
+
+One person per run, named explicitly: there is no store index of pending
+identity sessions, and inventing one to sweep them all is a bigger change than
+this repair deserves. If stranded sessions ever stop being rare, that index is
+the thing to add.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+os.environ.setdefault("TR_STORAGE_BACKEND", "spanner-bigtable")
+os.environ.setdefault("TR_GCP_PROJECT_ID", "quill-cloud-proxy")
+os.environ.setdefault("TR_SPANNER_INSTANCE_ID", "trusted-router-nam6")
+os.environ.setdefault("TR_SPANNER_DATABASE_ID", "trusted-router")
+os.environ.setdefault("TR_BIGTABLE_INSTANCE_ID", "trusted-router-logs")
+
+from trusted_router.config import Settings
+from trusted_router.routes.internal.veriff import (
+    decision_reason,
+    mapped_status,
+    verified_name,
+)
+from trusted_router.services.veriff import VeriffError, fetch_veriff_decision
+from trusted_router.storage import create_store
+from trusted_router.storage_models import User
+
+
+def _candidates(store: Any, args: argparse.Namespace) -> list[User]:
+    if args.email:
+        user = store.find_user_by_email(args.email)
+        return [user] if user is not None else []
+    user = store.get_user(args.user_id)
+    return [user] if user is not None else []
+
+
+def main(argv: list[str] | None = None, *, store: Any | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument("--email")
+    target.add_argument("--user-id")
+    parser.add_argument("--apply", action="store_true")
+    args = parser.parse_args(argv)
+
+    settings = Settings()
+    active = create_store(settings) if store is None else store
+    users = _candidates(active, args)
+    if not users:
+        print("no such user")
+        return 0
+
+    changed = 0
+    for user in users:
+        session_id = getattr(user, "veriff_session_id", None)
+        record: dict[str, Any] = {
+            "user_id": user.id,
+            "email": user.email,
+            "session_id": session_id,
+            "before": getattr(user, "identity_status", None),
+        }
+        if not session_id:
+            record["outcome"] = "no_session"
+            print(json.dumps(record, sort_keys=True))
+            continue
+        try:
+            payload = fetch_veriff_decision(session_id, settings=settings)
+        except VeriffError as exc:
+            record["outcome"] = f"lookup_failed: {exc}"
+            print(json.dumps(record, sort_keys=True))
+            continue
+        verification = payload.get("verification")
+        if not isinstance(verification, dict):
+            record["outcome"] = "no_decision_yet"
+            print(json.dumps(record, sort_keys=True))
+            continue
+        code = verification.get("code")
+        status = mapped_status(verification.get("status"), int(code) if code is not None else 0)
+        reason, reason_code = decision_reason(verification)
+        record["decision_code"] = code
+        record["mapped"] = status
+        # Operator-visible on purpose. The end user never sees this string —
+        # see trusted_router.identity_guidance for why.
+        record["reason"] = reason
+        record["reason_code"] = reason_code
+        if status is None:
+            record["outcome"] = "unhandled_decision"
+        elif status == record["before"]:
+            record["outcome"] = "already_applied"
+        elif not args.apply:
+            record["outcome"] = "would_apply"
+        else:
+            active.set_user_identity_status(
+                user.id,
+                status=status,
+                decision_code=int(code) if code is not None else None,
+                decision_reason=reason,
+                decision_reason_code=reason_code,
+                verified_name=verified_name(verification) if status == "approved" else None,
+            )
+            changed += 1
+            record["outcome"] = "applied"
+        print(json.dumps(record, sort_keys=True))
+
+    print(json.dumps({"mode": "apply" if args.apply else "dry_run", "applied": changed}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/trusted_router/identity_guidance.py
+++ b/src/trusted_router/identity_guidance.py
@@ -1,0 +1,104 @@
+"""What to tell someone whose identity check did not pass.
+
+Veriff draws a line here and we follow it.
+
+For ``resubmission_requested`` they ask integrators to say what went wrong:
+"it is strongly advised that you inform the end-user about the reasons for the
+verification failure and provide suggestions on how to improve their next
+attempt." Those reasons are quality problems — glare, a cropped document, a
+face that is not visible — and telling someone costs nothing and saves the
+attempt.
+
+For ``declined`` they say to investigate the session and, if you choose to
+give the person another try, create a new one. They publish no end-user
+guidance for the granular reasons, and the fraud family is why: 503 attempted
+deceit, 504 device screen used, 505 printout used, 515-518 the screen-used
+variants, 526 photos streamed. Printing one of those verbatim tells whoever
+tripped it exactly which check fired and what to change next time.
+
+So a decline gets the SAME neutral text no matter which signal fired, plus the
+checklist that fixes the honest version of the failure — someone who
+photographed a scan of their own passport reads "use the physical document"
+and succeeds on the retry without ever learning which detector caught them.
+The specific reason is kept for operators.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+#: Reason codes whose text Veriff intends the end user to see. These arrive
+#: with `resubmission_requested`, where being specific is the whole point.
+_RESUBMISSION_ADVICE: dict[int, str] = {
+    201: "The document in the photo was not fully inside the frame. Fit all four corners in.",
+    202: "Your face was not clearly visible. Face a window or a lamp and remove hats or sunglasses.",
+    203: "The photo was too dark or too bright. Move somewhere evenly lit.",
+    204: "The document photo was blurry. Hold still and let the camera focus.",
+    205: "There was glare on the document. Tilt it away from the light.",
+    206: "Part of the document was covered. Keep fingers off the printed area.",
+    207: "The document has expired. Use a current one.",
+    208: "The back of the document is needed too. Photograph both sides.",
+    209: "The document photo was too small to read. Move closer.",
+    210: "The face photo and the document photo did not clearly match. Retake both in good light.",
+}
+
+_RESUBMISSION_FALLBACK = (
+    "Something in the photos was not clear enough to read. Retake them in good, "
+    "even light with the whole document in frame."
+)
+
+#: One neutral message for every decline, whatever the granular reason. The
+#: checklist repairs the common honest mistake without naming the signal.
+_DECLINED_MESSAGE = (
+    "We could not verify your identity from that attempt. If you try again, "
+    "hold the physical document in front of the camera — not a photo of it, "
+    "a phone or laptop screen, or a printout — in even light with no glare, "
+    "and make sure the document is current."
+)
+
+_EXPIRED_MESSAGE = (
+    "That verification session expired before it was finished. Starting a new "
+    "one takes a couple of minutes."
+)
+
+
+@dataclass(frozen=True)
+class IdentityGuidance:
+    """Copy for the verification page, and whether a retry is the next step."""
+
+    headline: str
+    detail: str
+    can_retry: bool
+    #: True only when the text came from Veriff's own resubmission advice.
+    reason_shown: bool = False
+
+
+def guidance_for(
+    status: str,
+    *,
+    reason_code: int | None = None,
+) -> IdentityGuidance | None:
+    """Return what to show, or None when there is nothing to say yet."""
+    normalized = (status or "").strip().lower()
+    if normalized == "resubmission_requested":
+        detail = _RESUBMISSION_ADVICE.get(int(reason_code)) if reason_code else None
+        return IdentityGuidance(
+            headline="Veriff needs another photo",
+            detail=detail or _RESUBMISSION_FALLBACK,
+            can_retry=True,
+            reason_shown=detail is not None,
+        )
+    if normalized == "declined":
+        # Deliberately ignores reason_code. See the module docstring.
+        return IdentityGuidance(
+            headline="That attempt did not pass",
+            detail=_DECLINED_MESSAGE,
+            can_retry=True,
+        )
+    if normalized == "expired":
+        return IdentityGuidance(
+            headline="The session expired",
+            detail=_EXPIRED_MESSAGE,
+            can_retry=True,
+        )
+    return None

--- a/src/trusted_router/routes/console/verification.py
+++ b/src/trusted_router/routes/console/verification.py
@@ -7,6 +7,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse, Response
 
 from trusted_router.auth import SettingsDep
 from trusted_router.config import Settings
+from trusted_router.identity_guidance import guidance_for
 from trusted_router.money import (
     VERIFF_ATTEMPT_FEE_MICRODOLLARS,
     VERIFICATION_MIN_LIFETIME_TOPUP_MICRODOLLARS,
@@ -31,6 +32,10 @@ def register(app: FastAPI) -> None:
         lifetime_topup = STORE.get_lifetime_topup_microdollars(user.id)
         required = VERIFICATION_MIN_LIFETIME_TOPUP_MICRODOLLARS
         missing = missing_identity_verification_requirements(user, settings)
+        guidance = guidance_for(
+            user.identity_status,
+            reason_code=user.veriff_decision_reason_code,
+        )
         identity_labels = {
             "none": "Not started",
             "pending": "Pending",
@@ -61,12 +66,16 @@ def register(app: FastAPI) -> None:
                     VERIFF_ATTEMPT_FEE_MICRODOLLARS
                 ),
                 identity_missing_requirements=missing,
+                identity_missing_labels=[
+                    _REQUIREMENT_LABELS.get(key, key) for key in missing
+                ],
                 identity_status=user.identity_status,
                 identity_status_label=identity_labels.get(
                     user.identity_status,
                     "Not started",
                 ),
                 identity_action_label=_identity_action_label(user.identity_status),
+                identity_guidance=guidance,
                 identity_action_enabled=(
                     not missing
                     and not user.identity_verified
@@ -99,6 +108,15 @@ def register(app: FastAPI) -> None:
                 error = "veriff_unavailable"
             return _back(f"error={error}")
         return RedirectResponse(url=result.url, status_code=303)
+
+
+#: The API keeps the machine-readable keys; the page shows words. A person
+#: reading "phone_verified" is reading our schema, not an instruction.
+_REQUIREMENT_LABELS = {
+    "email": "a verified email address",
+    "phone_verified": "a verified phone number",
+    "funding": "the minimum lifetime top-up",
+}
 
 
 def _identity_action_label(status: str) -> str:

--- a/src/trusted_router/routes/internal/veriff.py
+++ b/src/trusted_router/routes/internal/veriff.py
@@ -60,13 +60,13 @@ def register(router: APIRouter) -> None:
             code = int(raw_code)
         except (TypeError, ValueError):
             return {"data": {"ignored": True}}
-        mapped_status = _mapped_status(provider_status, code)
+        decision_status = mapped_status(provider_status, code)
         if (
             not isinstance(session_id, str)
             or not session_id
             or not isinstance(vendor_data, str)
             or not vendor_data
-            or mapped_status is None
+            or decision_status is None
         ):
             return {"data": {"ignored": True}}
 
@@ -82,17 +82,26 @@ def register(router: APIRouter) -> None:
             log.info("veriff_webhook.ignored reason=stale_session")
             return {"data": {"ignored": True}}
 
-        verified_name = _verified_name(verification) if mapped_status == "approved" else None
+        approved_name = verified_name(verification) if decision_status == "approved" else None
+        reason, reason_code = decision_reason(verification)
         STORE.set_user_identity_status(
             user.id,
-            status=mapped_status,
+            status=decision_status,
             decision_code=code,
-            verified_name=verified_name,
+            decision_reason=reason,
+            decision_reason_code=reason_code,
+            verified_name=approved_name,
         )
-        return {"data": {"status": mapped_status}}
+        log.info(
+            "veriff_webhook.decision status=%s code=%s reason_code=%s",
+            decision_status,
+            code,
+            reason_code,
+        )
+        return {"data": {"status": decision_status}}
 
 
-def _mapped_status(provider_status: Any, code: int) -> str | None:
+def mapped_status(provider_status: Any, code: int) -> str | None:
     status = str(provider_status or "").strip().lower()
     if status == "approved" and code == 9001:
         return "approved"
@@ -105,7 +114,34 @@ def _mapped_status(provider_status: Any, code: int) -> str | None:
     return None
 
 
-def _verified_name(verification: dict[str, Any]) -> str | None:
+#: Veriff's `reason` is free text they author, so it is bounded before storage
+#: and never rendered to the person being verified — only to operators.
+MAX_REASON_LENGTH = 200
+
+
+def decision_reason(verification: dict[str, Any]) -> tuple[str | None, int | None]:
+    """Pull Veriff's granular reason off a decision webhook.
+
+    Kept for operators. Whether any of it reaches the end user is decided by
+    :mod:`trusted_router.identity_guidance`, not here.
+    """
+    raw_reason = verification.get("reason")
+    reason = str(raw_reason).strip()[:MAX_REASON_LENGTH] if isinstance(raw_reason, str) else None
+    raw_code = verification.get("reasonCode")
+    reason_code: int | None
+    if isinstance(raw_code, bool):
+        reason_code = None
+    elif isinstance(raw_code, (int, str)):
+        try:
+            reason_code = int(raw_code)
+        except (TypeError, ValueError):
+            reason_code = None
+    else:
+        reason_code = None
+    return (reason or None), reason_code
+
+
+def verified_name(verification: dict[str, Any]) -> str | None:
     person = verification.get("person")
     if not isinstance(person, dict):
         return None

--- a/src/trusted_router/routes/verification_status.py
+++ b/src/trusted_router/routes/verification_status.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter
 
 from trusted_router.auth import ManagementPrincipal, SettingsDep
 from trusted_router.errors import api_error
+from trusted_router.identity_guidance import guidance_for
 from trusted_router.money import (
     VERIFF_ATTEMPT_FEE_MICRODOLLARS,
     VERIFICATION_MIN_LIFETIME_TOPUP_MICRODOLLARS,
@@ -25,6 +26,10 @@ def register_verification_status_routes(router: APIRouter) -> None:
     ) -> dict[str, dict[str, Any]]:
         user = _principal_user(principal)
         lifetime_topup = STORE.get_lifetime_topup_microdollars(user.id)
+        guidance = guidance_for(
+            user.identity_status,
+            reason_code=user.veriff_decision_reason_code,
+        )
         return {
             "data": {
                 "email": user.email,
@@ -35,6 +40,13 @@ def register_verification_status_routes(router: APIRouter) -> None:
                 "identity_status": user.identity_status,
                 "identity_verified_at": user.identity_verified_at,
                 "veriff_attempt_count": user.veriff_attempt_count,
+                # The same copy the console shows. Veriff's own decline reason
+                # is never in here: see trusted_router.identity_guidance.
+                "identity_message": (
+                    None
+                    if guidance is None
+                    else {"headline": guidance.headline, "detail": guidance.detail}
+                ),
                 **money_pair("verification_fee", VERIFF_ATTEMPT_FEE_MICRODOLLARS),
                 **money_pair(
                     "lifetime_topup_required",

--- a/src/trusted_router/services/veriff.py
+++ b/src/trusted_router/services/veriff.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import hmac
 from dataclasses import dataclass
 from typing import Any
 
@@ -51,3 +53,39 @@ def create_veriff_session(*, user: User, settings: Settings) -> VeriffSession:
         return VeriffSession(id=session_id, url=session_url)
     except (httpx.HTTPError, ValueError) as exc:
         raise VeriffError("Veriff session creation failed") from exc
+
+
+def fetch_veriff_decision(session_id: str, *, settings: Settings) -> dict[str, Any]:
+    """Read a session's decision straight from Veriff.
+
+    The webhook is the normal path. This exists because a decision that fires
+    while the webhook URL is missing or wrong is otherwise lost forever: Veriff
+    does not resend it, and the person is left `pending` with a $5 attempt
+    already charged. GET endpoints need an HMAC of the session id alongside the
+    API key — the same shared secret the webhook signature uses.
+    """
+    if not settings.veriff_api_key or not settings.veriff_shared_secret_key:
+        raise VeriffError("Veriff credentials are not configured")
+    if not session_id.strip():
+        raise VeriffError("session id is required")
+    signature = hmac.new(
+        settings.veriff_shared_secret_key.encode("utf-8"),
+        session_id.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    try:
+        with httpx.Client(timeout=20.0) as client:
+            response = client.get(
+                settings.veriff_base_url.rstrip("/") + f"/v1/sessions/{session_id}/decision",
+                headers={
+                    "X-AUTH-CLIENT": settings.veriff_api_key,
+                    "X-HMAC-SIGNATURE": signature,
+                },
+            )
+        response.raise_for_status()
+        payload: Any = response.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        raise VeriffError("Veriff decision lookup failed") from exc
+    if not isinstance(payload, dict):
+        raise VeriffError("Veriff decision response was not an object")
+    return payload

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -558,6 +558,8 @@ class InMemoryStore:
         session_id: str | None = None,
         session_url: str | None = None,
         decision_code: int | None = None,
+        decision_reason: str | None = None,
+        decision_reason_code: int | None = None,
         verified_name: str | None = None,
         increment_attempts: bool = False,
     ) -> User | None:
@@ -577,6 +579,10 @@ class InMemoryStore:
                 user.veriff_session_url = session_url
             if decision_code is not None:
                 user.veriff_decision_code = decision_code
+            if decision_reason is not None:
+                user.veriff_decision_reason = decision_reason
+            if decision_reason_code is not None:
+                user.veriff_decision_reason_code = decision_reason_code
             if verified_name is not None:
                 user.identity_verified_name = verified_name
             if increment_attempts:

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -900,6 +900,8 @@ class SpannerBigtableStore:
         session_id: str | None = None,
         session_url: str | None = None,
         decision_code: int | None = None,
+        decision_reason: str | None = None,
+        decision_reason_code: int | None = None,
         verified_name: str | None = None,
         increment_attempts: bool = False,
     ) -> User | None:
@@ -919,6 +921,10 @@ class SpannerBigtableStore:
                 user.veriff_session_url = session_url
             if decision_code is not None:
                 user.veriff_decision_code = decision_code
+            if decision_reason is not None:
+                user.veriff_decision_reason = decision_reason
+            if decision_reason_code is not None:
+                user.veriff_decision_reason_code = decision_reason_code
             if verified_name is not None:
                 user.identity_verified_name = verified_name
             if increment_attempts:

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -110,6 +110,13 @@ class User:
     veriff_session_url: str | None = None
     veriff_session_created_at: str | None = None
     veriff_decision_code: int | None = None
+    #: Veriff's granular reason for the last decision, kept for OPERATORS.
+    #: Never rendered to the person being verified when the decision is a
+    #: decline: codes 503/504/505/515-518/526 name the exact fraud signal that
+    #: fired, and Veriff publishes no end-user guidance for them. Resubmission
+    #: reasons are different — Veriff asks integrators to show those.
+    veriff_decision_reason: str | None = None
+    veriff_decision_reason_code: int | None = None
     veriff_attempt_count: int = 0
 
     @property

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -961,6 +961,8 @@ class PostgresStore:
         session_id: str | None = None,
         session_url: str | None = None,
         decision_code: int | None = None,
+        decision_reason: str | None = None,
+        decision_reason_code: int | None = None,
         verified_name: str | None = None,
         increment_attempts: bool = False,
     ) -> User | None:
@@ -980,6 +982,10 @@ class PostgresStore:
                 user.veriff_session_url = session_url
             if decision_code is not None:
                 user.veriff_decision_code = decision_code
+            if decision_reason is not None:
+                user.veriff_decision_reason = decision_reason
+            if decision_reason_code is not None:
+                user.veriff_decision_reason_code = decision_reason_code
             if verified_name is not None:
                 user.identity_verified_name = verified_name
             if increment_attempts:

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -80,6 +80,8 @@ class Store(Protocol):
         session_id: str | None = ...,
         session_url: str | None = ...,
         decision_code: int | None = ...,
+        decision_reason: str | None = ...,
+        decision_reason_code: int | None = ...,
         verified_name: str | None = ...,
         increment_attempts: bool = ...,
     ) -> User | None: ...

--- a/src/trusted_router/templates/console/account/verification.html
+++ b/src/trusted_router/templates/console/account/verification.html
@@ -51,13 +51,16 @@
     <div class="verification-step-content">
       <div class="verification-step-head">
         <div><span class="verification-kicker">Step 4</span><h2>Identity</h2></div>
-        <span class="pill {{ 'good' if current_user.identity_verified else 'warn' if identity_status in ['pending', 'resubmission_requested'] else '' }}">{{ identity_status_label }}</span>
+        <span class="pill {{ 'good' if current_user.identity_verified else 'danger' if identity_status == 'declined' else 'warn' if identity_status in ['pending', 'resubmission_requested', 'expired'] else '' }}">{{ identity_status_label }}</span>
       </div>
       {% if current_user.identity_verified %}
         <p>Identity approved{% if current_user.identity_verified_name %} for <strong>{{ current_user.identity_verified_name }}</strong>{% endif %}.</p>
       {% else %}
+        {% if identity_guidance %}
+        <p class="notice {{ 'bad' if identity_status == 'declined' else 'warn' }}"><strong>{{ identity_guidance.headline }}.</strong> {{ identity_guidance.detail }}</p>
+        {% endif %}
         <p>Each new verification attempt costs {{ identity_fee_display }}. The fee is charged only after a session is created.</p>
-        {% if identity_missing_requirements %}<p class="muted">Still needed: {{ identity_missing_requirements|join(', ') }}.</p>{% endif %}
+        {% if identity_missing_labels %}<p class="muted">Still needed: {{ identity_missing_labels|join(', ') }}.</p>{% endif %}
         {% if not veriff_available %}<p class="muted">Identity verification is currently unavailable.</p>{% endif %}
         <form method="post" action="/console/account/verification/identity/start">
           <button class="btn primary verification-start" type="submit" {{ '' if identity_action_enabled else 'disabled' }}>{{ identity_action_label }}</button>

--- a/tests/test_identity_guidance.py
+++ b/tests/test_identity_guidance.py
@@ -1,0 +1,264 @@
+"""The decline-reason boundary: operators see it, the applicant never does."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from typing import Any
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from trusted_router.config import Settings
+from trusted_router.identity_guidance import (
+    _DECLINED_MESSAGE,
+    _RESUBMISSION_ADVICE,
+    guidance_for,
+)
+from trusted_router.main import create_app
+from trusted_router.routes.internal.veriff import MAX_REASON_LENGTH, decision_reason
+from trusted_router.storage import STORE
+
+SHARED_SECRET = "veriff-guidance-test-secret"  # noqa: S105 - test fixture.
+
+#: Every granular decline reason Veriff documents, verbatim. None of these
+#: strings may ever appear in a response the applicant can read.
+FRAUD_REASONS: list[tuple[int, str]] = [
+    (503, "Suspected document tampering"),
+    (504, "Person showing suspicious behaviour"),
+    (505, "Known fraud"),
+    (506, "Velocity/abuse duplicated user"),
+    (515, "Suspected document tampering (screen)"),
+    (516, "Person is not present during the session"),
+    (517, "Presented a printout of the document"),
+    (518, "Presented a device screen"),
+    (526, "Photos are not genuine"),
+]
+
+
+def _payload(
+    *,
+    status: str,
+    code: int,
+    vendor_data: str,
+    reason: str | None = None,
+    reason_code: int | None = None,
+) -> bytes:
+    verification: dict[str, Any] = {
+        "id": "session-one",
+        "status": status,
+        "code": code,
+        "vendorData": vendor_data,
+        "person": {"firstName": "Ada", "lastName": "Lovelace"},
+    }
+    if reason is not None:
+        verification["reason"] = reason
+    if reason_code is not None:
+        verification["reasonCode"] = reason_code
+    return json.dumps({"verification": verification}, separators=(",", ":")).encode()
+
+
+def _signature(raw: bytes) -> str:
+    return hmac.new(SHARED_SECRET.encode(), raw, hashlib.sha256).hexdigest()
+
+
+def _client_and_user(email: str) -> tuple[TestClient, Any]:
+    settings = Settings(
+        environment="test",
+        veriff_enabled=True,
+        veriff_api_key="api-key",
+        veriff_shared_secret_key=SHARED_SECRET,
+    )
+    client = TestClient(create_app(settings, init_observability=False))
+    user = STORE.ensure_user(email)
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+    raw_session, _session = STORE.create_auth_session(
+        user_id=user.id,
+        provider="test",
+        label="identity guidance",
+        ttl_seconds=3600,
+        workspace_id=workspace.id,
+    )
+    client.cookies.set("tr_session", raw_session)
+    STORE.set_user_identity_status(
+        user.id,
+        status="pending",
+        session_id="session-one",
+        session_url="https://verify.example/session-one",
+        increment_attempts=True,
+    )
+    return client, user
+
+
+def _post(client: TestClient, raw: bytes) -> httpx.Response:
+    return client.post(
+        "/v1/internal/veriff/webhook",
+        content=raw,
+        headers={
+            "content-type": "application/json",
+            "x-hmac-signature": _signature(raw),
+        },
+    )
+
+
+@pytest.mark.parametrize(("reason_code", "reason"), FRAUD_REASONS)
+def test_decline_stores_the_reason_but_never_shows_it(
+    reason_code: int, reason: str
+) -> None:
+    """The webhook keeps the fraud signal; the page shows the neutral text.
+
+    This is the whole point of the split. Printing "Presented a device screen"
+    tells whoever did it exactly which detector fired and what to change on the
+    next attempt, which is a free lesson for the one population we least want
+    to teach. Operators still need the signal, so it is stored.
+    """
+    client, user = _client_and_user(f"decline-{reason_code}@example.com")
+    raw = _payload(
+        status="declined",
+        code=9102,
+        vendor_data=user.id,
+        reason=reason,
+        reason_code=reason_code,
+    )
+    assert _post(client, raw).status_code == 200
+
+    stored = STORE.get_user(user.id)
+    assert stored is not None
+    assert stored.identity_status == "declined"
+    assert stored.veriff_decision_reason == reason
+    assert stored.veriff_decision_reason_code == reason_code
+
+    guidance = guidance_for("declined", reason_code=reason_code)
+    assert guidance is not None
+    assert guidance.detail == _DECLINED_MESSAGE
+    assert guidance.reason_shown is False
+    # Veriff's own wording never appears verbatim.
+    assert reason.lower() not in guidance.detail.lower()
+
+
+def test_every_decline_reason_produces_identical_copy() -> None:
+    """No reason code may fork the decline text — that fork IS the leak.
+
+    This is the load-bearing test, not the verbatim check above. The checklist
+    does name printouts and phone screens, which is also how Veriff words 517
+    and 518 — and that is fine precisely because someone declined for 505
+    reads the identical sentence. Constant copy carries zero information about
+    which detector fired. The day someone tailors this message per code, the
+    signal leaks even if no Veriff wording is copied, so the invariant to hold
+    is sameness, not vocabulary.
+    """
+    messages = {
+        guidance_for("declined", reason_code=code).detail  # type: ignore[union-attr]
+        for code, _ in FRAUD_REASONS
+    }
+    assert messages == {_DECLINED_MESSAGE}
+    assert guidance_for("declined", reason_code=None).detail == _DECLINED_MESSAGE  # type: ignore[union-attr]
+
+
+def test_resubmission_shows_the_specific_reason() -> None:
+    """Veriff strongly advises telling people about resubmission reasons."""
+    guidance = guidance_for("resubmission_requested", reason_code=205)
+    assert guidance is not None
+    assert guidance.reason_shown is True
+    assert "glare" in guidance.detail.lower()
+
+    unknown = guidance_for("resubmission_requested", reason_code=999)
+    assert unknown is not None
+    assert unknown.reason_shown is False
+    assert unknown.detail  # falls back rather than showing nothing
+
+
+def test_resubmission_advice_is_actionable() -> None:
+    """Every canned line tells the person what to DO, not just what failed."""
+    for text in _RESUBMISSION_ADVICE.values():
+        assert text.endswith(".")
+        assert len(text.split(".")) >= 3, text  # a diagnosis AND an instruction
+
+
+def test_approved_and_unknown_statuses_say_nothing() -> None:
+    assert guidance_for("approved") is None
+    assert guidance_for("pending") is None
+    assert guidance_for("none") is None
+    assert guidance_for("") is None
+
+
+def test_expired_gets_its_own_copy() -> None:
+    guidance = guidance_for("expired")
+    assert guidance is not None
+    assert "expired" in guidance.detail.lower()
+    assert guidance.detail != _DECLINED_MESSAGE
+
+
+def test_console_page_shows_neutral_copy_for_a_declined_user() -> None:
+    """Render the actual page: the reason must not be in the HTML."""
+    client, user = _client_and_user("decline-console@example.com")
+    raw = _payload(
+        status="declined",
+        code=9102,
+        vendor_data=user.id,
+        reason="Presented a device screen",
+        reason_code=518,
+    )
+    assert _post(client, raw).status_code == 200
+
+    page = client.get("/console/account/verification")
+    assert page.status_code == 200
+    body = page.text
+    assert "device screen" not in body.lower()
+    assert "518" not in body
+    stored = STORE.get_user(user.id)
+    assert stored is not None and stored.veriff_decision_reason is not None
+    assert stored.veriff_decision_reason.lower() not in body.lower()
+    assert "hold the physical document" in body.lower()
+    assert "That attempt did not pass" in body
+
+
+def test_resubmission_page_shows_the_specific_advice() -> None:
+    client, user = _client_and_user("resub-console@example.com")
+    raw = _payload(
+        status="resubmission_requested",
+        code=9103,
+        vendor_data=user.id,
+        reason="Glare on the document",
+        reason_code=205,
+    )
+    assert _post(client, raw).status_code == 200
+
+    page = client.get("/console/account/verification")
+    assert page.status_code == 200
+    assert "tilt it away from the light" in page.text.lower()
+
+
+def test_reason_parsing_is_defensive() -> None:
+    """Veriff authors `reason` free-hand, so it is bounded and type-checked."""
+    assert decision_reason({}) == (None, None)
+    assert decision_reason({"reason": "   ", "reasonCode": None}) == (None, None)
+    assert decision_reason({"reason": "x" * 900})[0] == "x" * MAX_REASON_LENGTH
+    assert decision_reason({"reasonCode": "518"})[1] == 518
+    assert decision_reason({"reasonCode": "not-a-number"})[1] is None
+    assert decision_reason({"reasonCode": True})[1] is None
+    assert decision_reason({"reasonCode": {"nested": 1}})[1] is None
+
+
+def test_missing_reason_does_not_erase_a_stored_one() -> None:
+    """A later decision with no reason must not blank the operator's evidence."""
+    client, user = _client_and_user("reason-keep@example.com")
+    first = _payload(
+        status="declined",
+        code=9102,
+        vendor_data=user.id,
+        reason="Known fraud",
+        reason_code=505,
+    )
+    assert _post(client, first).status_code == 200
+
+    STORE.set_user_identity_status(user.id, status="pending", session_id="session-one")
+    second = _payload(status="declined", code=9102, vendor_data=user.id)
+    assert _post(client, second).status_code == 200
+
+    stored = STORE.get_user(user.id)
+    assert stored is not None
+    assert stored.veriff_decision_reason == "Known fraud"
+    assert stored.veriff_decision_reason_code == 505

--- a/tests/test_phone_funding_gate.py
+++ b/tests/test_phone_funding_gate.py
@@ -266,6 +266,8 @@ def test_verification_status_reports_shape_and_next_step_progression(
         "identity_status": "none",
         "identity_verified_at": None,
         "veriff_attempt_count": 0,
+        # Nothing to say at `none` — guidance appears only after a decision.
+        "identity_message": None,
         "verification_fee": 5.0,
         "verification_fee_microdollars": 5_000_000,
         "lifetime_topup_required": 25.0,


### PR DESCRIPTION
A declined identity check costs the person $5 and, until now, told them
nothing. That is the support case we worked by hand yesterday: a real
customer with a real document, declined, and nobody able to say what to
do differently on the retry.

## The split, which is Veriff's own

**`resubmission_requested` → say exactly what went wrong.** Veriff
strongly advises this, and the reasons are quality problems that a
sentence fixes: glare, a cropped document, a face not visible. Each
canned line carries an instruction, not just a diagnosis.

**`declined` → one neutral message for every reason code.** The granular
reasons are fraud detectors — 503 tampering, 504 suspicious behaviour,
505 known fraud, 515–518 the screen/printout family, 526 photos not
genuine — and Veriff publishes no end-user guidance for any of them.
Printing the one that fired tells whoever tripped it precisely which
check to beat next time. The message still carries the checklist that
repairs the *honest* version ("hold the physical document, not a photo
of it, a screen, or a printout"), which is the common case: someone
photographs a scan of their own passport and passes on the retry
without ever learning which detector caught them.

## The invariant is sameness, not vocabulary

The checklist does say "printout" and "screen", which is also how Veriff
words 517 and 518 — and that leaks nothing, because a 505 decline reads
the identical sentence. Constant copy carries zero information about
which detector fired. `test_every_decline_reason_produces_identical_copy`
pins that, so the day someone tailors the message per code, the suite
objects.

## What is where

| Surface | Sees |
|---|---|
| `/console/account/verification` | headline + guidance, `danger` pill on decline |
| `GET /auth/verification-status` | the same copy as `identity_message` |
| `User` row | `veriff_decision_reason`, `veriff_decision_reason_code` |
| `scripts/reconcile_veriff_decisions.py` | reason + code in the JSON line |
| `docs/runbooks/identity-verification-support.md` | which console (Veriff Station), how to decide, how to reset and credit |

The runbook exists because "in what console" had no written answer
anywhere, and the next person to work one of these should not have to
rediscover it.

## Also

`Still needed: phone_verified, funding` was our schema showing through
in the same panel. The API keeps the machine keys; the page says words.

## Verification

- `tests/test_identity_guidance.py` — 18 cases: every documented fraud
  code stored-but-not-shown, copy constancy, resubmission specificity,
  defensive reason parsing, and two tests that render the real console
  page and assert the stored reason is absent from the HTML.
- Full suite green on this tree: **4567 passed, 290 skipped, 10 xfailed**.
- `ruff check` and `mypy` clean.
- Rendered all three states (declined / resubmission / expired) in a
  browser and confirmed the palette resolves — clay `danger` for
  decline, gold `warn` for resubmission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)