### PR TITLE
Pin the clock in two rate-limit tests that could straddle a minute boundary

### DIFF
--- a/tests/test_client_events_route.py
+++ b/tests/test_client_events_route.py
@@ -10,6 +10,7 @@ import pytest
 from fastapi import Request
 from fastapi.testclient import TestClient
 
+from trusted_router import storage_rate_limits
 from trusted_router.config import Settings
 from trusted_router.main import create_app
 from trusted_router.routes.helpers import (
@@ -311,8 +312,21 @@ async def test_bounded_stream_stops_reading_as_soon_as_cap_is_crossed() -> None:
 
 def test_client_events_rate_limits_the_61st_post_per_key(
     test_settings: Settings,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client, headers, _ = _client_with_key(test_settings)
+
+    # The limiter buckets on a TUMBLING window aligned to wall-clock minutes
+    # (`epoch // window_seconds`), not a sliding one. So these 61 posts only
+    # share a bucket if none of them crosses a real minute boundary -- and when
+    # one does, the count restarts and the 61st post is allowed, which fails
+    # this test for a reason that has nothing to do with the limiter being
+    # wrong. Observed on CI 2026-08-17.
+    #
+    # Pinning the clock tests what the name claims (the 61st request *within a
+    # window* is refused) instead of also testing what time it happens to be.
+    fixed_now = dt.datetime(2026, 1, 1, 0, 0, 30, tzinfo=dt.UTC)
+    monkeypatch.setattr(storage_rate_limits, "utcnow", lambda: fixed_now)
 
     responses = [
         client.post("/v1/client-events", headers=headers, json=_batch()) for _ in range(61)

--- a/tests/test_stubs_and_security.py
+++ b/tests/test_stubs_and_security.py
@@ -1113,22 +1113,69 @@ def test_internal_rate_limit_precedence_matches_route_auth(
     assert mixed.status_code == 200, mixed.text
 
 
+def test_in_memory_rate_limit_window_is_tumbling_not_sliding() -> None:
+    """The window is a TUMBLING bucket keyed on `epoch // window_seconds`.
+
+    This is the documented behaviour, not a defect -- but it means a burst that
+    crosses a wall-clock boundary gets a fresh allowance, and it is why tests
+    that assert "the Nth request is refused" must pin the clock. Two of them did
+    not, and one failed on CI (2026-08-17) with 202 instead of 429 for exactly
+    this reason.
+
+    If someone later changes this to a sliding window, this test should fail and
+    the clock pins in those tests can then be removed.
+    """
+    import datetime as _dt
+    import threading as _threading
+
+    from trusted_router.storage_rate_limits import InMemoryRateLimits
+
+    limits = InMemoryRateLimits(lock=_threading.RLock())
+
+    def nth_request_allowed(start: _dt.datetime) -> bool:
+        limits.reset()
+        hit = None
+        for index in range(61):
+            hit = limits.hit(
+                namespace="ce",
+                subject="k",
+                limit=60,
+                window_seconds=60,
+                now=start + _dt.timedelta(milliseconds=20 * index),
+            )
+        assert hit is not None
+        return hit.allowed
+
+    # Entirely inside one bucket: the 61st request is over the limit of 60.
+    assert nth_request_allowed(_dt.datetime(2026, 1, 1, 0, 0, 10, tzinfo=_dt.UTC)) is False
+    # Straddling :00 starts a new bucket, so the count restarts and the same
+    # 61st request is allowed.
+    assert nth_request_allowed(_dt.datetime(2026, 1, 1, 0, 0, 59, tzinfo=_dt.UTC)) is True
+
+
 def test_in_memory_rate_limit_bucket_cardinality_is_capped() -> None:
     """Attacker-fabricated identities (rotated tokens, spoofed XFF) must not
     grow the process map without bound (review finding on #400, round 3).
     At the cap, new subjects fold into a shared per-namespace overflow bucket:
     memory stays bounded and fabricated identities throttle collectively."""
+    import datetime as _dt
     import threading as _threading
 
     from trusted_router.storage_rate_limits import InMemoryRateLimits
 
     limits = InMemoryRateLimits(lock=_threading.RLock(), max_buckets=50)
+    # The bucket key includes `epoch // window_seconds`, so a run that crosses a
+    # real minute boundary starts a SECOND generation of keys and can exceed the
+    # cap+1 bound below for a reason unrelated to cardinality. Pinning `now`
+    # keeps this a test of the cap.
+    fixed_now = _dt.datetime(2026, 1, 1, 0, 0, 30, tzinfo=_dt.UTC)
     for n in range(200):
         hit = limits.hit(
             namespace="internal",
             subject=f"fabricated-{n}",
             limit=3,
             window_seconds=60,
+            now=fixed_now,
         )
     assert len(limits.buckets) <= 51  # cap + at most the one overflow bucket
     # Identities past the cap share the overflow bucket, so a rotation attack


### PR DESCRIPTION
`test_client_events_rate_limits_the_61st_post_per_key` failed on CI today with `assert 202 == 429`, in code no PR had touched. It is not a limiter bug, and it is not a mystery.

## Root cause

`InMemoryRateLimits` buckets on a **tumbling** window aligned to wall-clock minutes, not a sliding one:

```python
epoch = int(now.timestamp())
bucket = epoch // window_seconds   # 60
key = (namespace, subject, bucket)
```

The test resets the limiter (an `autouse` fixture does), fires 61 posts, and asserts the 61st is refused. That only holds if none of the 61 crosses a real minute boundary. When one does, the bucket key changes, the count restarts, and the 61st post is **correctly** allowed.

I ruled out the alternatives before landing on this: the `autouse` reset excludes bucket pollution, and the `_MAX_BUCKETS` overflow fold would make it refuse *earlier*, not later — the opposite of the observed failure.

## Reproduced, not assumed

Driving the limiter directly with 61 hits spread over ~1.2s, as on a loaded runner:

```
well inside a window            61st allowed=False  -> 429
straddling a minute boundary    61st allowed=True   -> 202
```

The second line is the CI failure exactly.

## The fix

Both tests now pin `now`, so they test what their names claim rather than also testing what time it happens to be.

- **client-events test** patches `storage_rate_limits.utcnow`, because the route reaches the limiter through `enforce_rate_limit`, which takes no clock parameter.
- **cardinality test** passes `now=` directly. It had the same exposure by a different route: crossing a boundary starts a *second generation* of bucket keys, which can push the map past its cap-plus-one bound for a reason unrelated to cardinality. That one hadn't failed yet — it was waiting to.

## Plus a test that keeps the knowledge

`test_in_memory_rate_limit_window_is_tumbling_not_sliding` asserts both halves of the reproduction. It documents why the pins exist, and if the limiter is ever changed to a sliding window it fails — which is precisely the signal that the pins can be removed. Without it, the next person to hit this has to rediscover it, or "fixes" it by changing limiter semantics.

**No production code changes.** The limiter is correct in both cases; only the tests were time-dependent.

19 + 12 tests pass · `ruff check` clean · `mypy` clean (275 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)