### PR TITLE
Give every cloud a restore drill, and stop one dataset hiding the rest

### DIFF
--- a/clickhouse/archive_daily.py
+++ b/clickhouse/archive_daily.py
@@ -282,6 +282,10 @@ class ArchiveStore(Protocol):
 
     def put_json_pointer(self, key: str, value: dict[str, Any]) -> None: ...
 
+    # The restore drill reads the archive back through this same store, so a
+    # cloud that can be written but not read would only fail at drill time.
+    def download_file(self, key: str, destination: Path) -> None: ...
+
 
 class ClickHouseDailyExporter:
     def __init__(
@@ -428,6 +432,9 @@ class GCSArchiveStore:
             raise RuntimeError(f"archive object {key} is not a JSON object")
         return value
 
+    def download_file(self, key: str, destination: Path) -> None:
+        self._bucket.blob(key).download_to_filename(str(destination))
+
     def put_file_if_absent(
         self,
         key: str,
@@ -544,6 +551,9 @@ class S3ArchiveStore:
         metadata = {str(k).lower(): v for k, v in (head.get("Metadata") or {}).items()}
         return metadata.get("sha256")
 
+    def download_file(self, key: str, destination: Path) -> None:
+        self._client.download_file(self._bucket, key, str(destination))
+
     def put_file_if_absent(
         self,
         key: str,
@@ -650,6 +660,10 @@ class AzureBlobArchiveStore:
         if not isinstance(value, dict):
             raise RuntimeError(f"archive object {key} is not a JSON object")
         return value
+
+    def download_file(self, key: str, destination: Path) -> None:
+        with destination.open("wb") as stream:
+            self._container.get_blob_client(key).download_blob().readinto(stream)
 
     def put_file_if_absent(
         self,

--- a/clickhouse/check_archive_freshness.py
+++ b/clickhouse/check_archive_freshness.py
@@ -136,6 +136,10 @@ class DatasetStatus:
     revision: str | None
     updated_at: str | None
     problems: tuple[Problem, ...]
+    # True when the archive could not be READ, as opposed to read and found
+    # stale. The two need different exit codes: a stale archive is a real
+    # finding, an unreadable one means this check does not know.
+    unreadable: bool = False
 
     @property
     def fresh(self) -> bool:
@@ -225,7 +229,25 @@ def check_days(
     statuses: list[DatasetStatus] = []
     for day in days:
         for dataset in datasets:
-            statuses.append(check_dataset(store, dataset, day))
+            # A read failure is contained to its own dataset-day rather than
+            # unwinding the sweep. It used to propagate: one denied read aborted
+            # the run after reporting 1 of 4 datasets, so an unrelated
+            # permissions error could hide a dataset that had genuinely stopped
+            # archiving -- the same shape as the 2026-08-16 incident, where the
+            # thing that should have raised the alarm was the thing that broke.
+            try:
+                statuses.append(check_dataset(store, dataset, day))
+            except StoreError as error:
+                statuses.append(
+                    DatasetStatus(
+                        dataset,
+                        day,
+                        None,
+                        None,
+                        (Problem(dataset, day, f"could not read the archive: {error}"),),
+                        unreadable=True,
+                    )
+                )
     return statuses
 
 
@@ -297,22 +319,27 @@ def main(
     datasets: tuple[str, ...] = tuple(args.dataset) if args.dataset else tuple(DATASETS)
     active_store: FreshnessStore = store or GcloudStore(bucket=args.bucket)
 
-    try:
-        statuses = check_days(active_store, days, datasets)
-    except StoreError as exc:
-        out(f"::error::archive freshness could not be determined: {exc}")
-        if args.problems_file:
-            with open(args.problems_file, "w", encoding="utf-8") as handle:
-                handle.write(f"could not read the archive: {exc}\n")
-        return 2
+    # No try/except around the sweep: check_days contains a read failure to the
+    # dataset-day it happened on, so every dataset is still reported. Aborting
+    # here is what let one unreadable dataset hide the rest.
+    statuses = check_days(active_store, days, datasets)
 
     out(format_report(statuses))
     problems = [problem for status in statuses for problem in status.problems]
     if problems:
+        unreadable = [status for status in statuses if status.unreadable]
+        # Report the whole picture first, then distinguish "the archive is
+        # stale" (a finding) from "this check could not read it" (not knowing).
         out(f"::error::{len(problems)} archive freshness problem(s) in gs://{args.bucket}")
         if args.problems_file:
             with open(args.problems_file, "w", encoding="utf-8") as handle:
                 handle.write("\n".join(str(problem) for problem in problems) + "\n")
+        if unreadable:
+            out(
+                f"::error::{len(unreadable)} of {len(statuses)} dataset-day(s) could not be "
+                "read, so freshness is unknown for those"
+            )
+            return 2
         return 1
     checked = ", ".join(day.isoformat() for day in days)
     out(f"archive is fresh for {len(datasets)} dataset(s) on {checked}")

--- a/clickhouse/verify_archive_restore.py
+++ b/clickhouse/verify_archive_restore.py
@@ -31,6 +31,7 @@ from clickhouse.archive_daily import (
     _run_clickhouse_local,
     _sha256,
     _sql_string,
+    build_archive_store,
 )
 
 log = logging.getLogger("trusted_router.analytics_archive_restore")
@@ -40,25 +41,6 @@ class RestoreStore(Protocol):
     def read_json(self, key: str) -> dict[str, Any] | None: ...
 
     def download_file(self, key: str, destination: Path) -> None: ...
-
-
-class GCSRestoreStore:
-    def __init__(self, *, project: str, bucket: str) -> None:
-        from google.cloud import storage
-
-        self._bucket = storage.Client(project=project).bucket(bucket)
-
-    def read_json(self, key: str) -> dict[str, Any] | None:
-        blob = self._bucket.blob(key)
-        if not blob.exists():
-            return None
-        value = json.loads(blob.download_as_text())
-        if not isinstance(value, dict):
-            raise RuntimeError(f"archive object {key} is not a JSON object")
-        return value
-
-    def download_file(self, key: str, destination: Path) -> None:
-        self._bucket.blob(key).download_to_filename(str(destination))
 
 
 @dataclasses.dataclass(frozen=True)
@@ -199,6 +181,15 @@ def main() -> int:
     parser.add_argument("--project", default=os.environ.get("GCP_PROJECT_ID", PROJECT))
     parser.add_argument("--bucket", default=os.environ.get("ARCHIVE_BUCKET", ARCHIVE_BUCKET))
     parser.add_argument("--table", action="append", choices=tuple(DATASETS))
+    # Which cloud's archive to drill. A drill that can only reach GCS would
+    # leave the other clouds writing archives nobody has proven restorable.
+    parser.add_argument(
+        "--object-store",
+        choices=("gcs", "s3", "azure"),
+        default=os.environ.get("TR_ARCHIVE_OBJECT_STORE", "gcs"),
+    )
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION"))
+    parser.add_argument("--account-url", default=os.environ.get("AZURE_STORAGE_ACCOUNT_URL"))
     parser.add_argument("--date", type=dt.date.fromisoformat)
     parser.add_argument(
         "--result-file",
@@ -214,7 +205,13 @@ def main() -> int:
     day = args.date or (dt.datetime.now(dt.UTC).date() - dt.timedelta(days=1))
     if day >= dt.datetime.now(dt.UTC).date():
         raise SystemExit("restore verification only accepts closed UTC days")
-    store = GCSRestoreStore(project=args.project, bucket=args.bucket)
+    store = build_archive_store(
+        args.object_store,
+        project=args.project,
+        bucket=args.bucket,
+        region=args.region,
+        account_url=args.account_url,
+    )
     results = [
         verify_archived_day(store, dataset=dataset, day=day)
         for dataset in tuple(dict.fromkeys(args.table or tuple(DATASETS)))

--- a/tests/test_clickhouse_archive_freshness.py
+++ b/tests/test_clickhouse_archive_freshness.py
@@ -44,6 +44,9 @@ class FakeStore:
         self.present: set[str] = set()
         self.reads: list[str] = []
         self.fail_reads_with: str | None = None
+        # Fail only the keys containing one of these fragments, so a test can
+        # make ONE dataset unreadable while the others stay legible.
+        self.fail_only_keys_containing: tuple[str, ...] = ()
 
     def put(self, key: str, pointer: dict[str, Any], *, with_manifest: bool = True) -> None:
         self.objects[key] = pointer
@@ -52,7 +55,10 @@ class FakeStore:
 
     def read_json(self, key: str) -> dict[str, Any] | None:
         self.reads.append(key)
-        if self.fail_reads_with is not None:
+        if self.fail_reads_with is not None and (
+            not self.fail_only_keys_containing
+            or any(fragment in key for fragment in self.fail_only_keys_containing)
+        ):
             raise StoreError(self.fail_reads_with)
         return self.objects.get(key)
 
@@ -208,8 +214,13 @@ def test_main_exit_codes_and_problem_file(tmp_path: Any) -> None:
     lines.clear()
     code = main(["--problems-file", str(problems_file)], store=broken, now=now, out=lines.append)
     assert code == 2
-    assert "could not read the archive: 403 Forbidden" in problems_file.read_text()
-    assert any("could not be determined" in line for line in lines)
+    written = problems_file.read_text()
+    assert "could not read the archive: 403 Forbidden" in written
+    assert any("could not be read, so freshness is unknown" in line for line in lines)
+    # Every dataset is reported even though the very first read failed. The
+    # sweep used to abort on it, so 3 of 4 datasets went unreported.
+    for dataset in DATASETS:
+        assert dataset in written
 
 
 def test_main_day_and_dataset_overrides() -> None:
@@ -282,3 +293,42 @@ def test_gcloud_store_distinguishes_absent_from_forbidden() -> None:
     with pytest.raises(StoreError, match="403"):
         store.exists("denied")
     assert runner.calls[0][:3] == ["gcloud", "storage", "cat"]
+
+
+def test_one_unreadable_dataset_does_not_hide_another_that_is_stale(tmp_path: Any) -> None:
+    """The masking case, and the reason the sweep no longer aborts.
+
+    Before this, check_days let a StoreError propagate, so the first denied read
+    ended the run. A dataset that had genuinely stopped archiving could sit
+    behind an unrelated permissions error on a different dataset and never be
+    reported -- the 2026-08-16 shape, where the mechanism that should have
+    raised the alarm was itself the broken thing.
+    """
+
+    now = dt.datetime(2026, 8, 16, 7, 30, tzinfo=UTC)
+    store = _fresh_store()
+    # provider_benchmark_samples is unreadable ...
+    store.fail_reads_with = "403 Forbidden"
+    store.fail_only_keys_containing = ("provider_benchmark_samples",)
+    # ... and a DIFFERENT dataset was genuinely never archived.
+    del store.objects[pointer_key("activity_generations", DAY)]
+
+    problems_file = tmp_path / "problems.txt"
+    lines: list[str] = []
+    code = main(
+        ["--problems-file", str(problems_file)],
+        store=store,
+        now=now,
+        out=lines.append,
+    )
+
+    written = problems_file.read_text()
+    # The genuine staleness is reported even though another dataset errored.
+    assert "activity_generations day=2026-08-15" in written
+    assert "the day was never archived" in written
+    # And the unreadable one is reported as unreadable, not as fresh.
+    assert "could not read the archive: 403 Forbidden" in written
+    # Unknown outranks stale: exit 2 says this check could not see everything.
+    assert code == 2
+    # The datasets that were readable and fine are not dragged in as problems.
+    assert "synthetic_status_rollups" not in written

--- a/tests/test_clickhouse_archive_object_stores.py
+++ b/tests/test_clickhouse_archive_object_stores.py
@@ -83,6 +83,12 @@ class FakeS3:
             raise _client_error("NotFound", 404)
         return self.objects[Key]
 
+    def download_file(self, bucket: str, key: str, filename: str) -> None:
+        del bucket
+        if key not in self.objects:
+            raise _client_error("NoSuchKey", 404)
+        Path(filename).write_bytes(self.objects[key]["Body"])
+
 
 class _Reader:
     def __init__(self, payload: bytes) -> None:
@@ -210,7 +216,11 @@ class FakeBlob:
     def download_blob(self) -> Any:
         if self._key not in self._container.blobs:
             raise _AzureResourceNotFound(self._key)
-        return types.SimpleNamespace(readall=lambda: self._container.blobs[self._key]["data"])
+        payload = self._container.blobs[self._key]["data"]
+        return types.SimpleNamespace(
+            readall=lambda: payload,
+            readinto=lambda stream: stream.write(payload),
+        )
 
     def get_blob_properties(self) -> Any:
         if self._key not in self._container.blobs:
@@ -644,3 +654,58 @@ def test_completion_log_names_the_store_actually_written(
     # Every store must expose it, since the log reads it off whichever is live.
     for cls in (GCSArchiveStore, S3ArchiveStore, AzureBlobArchiveStore):
         assert isinstance(getattr(cls, "scheme", None), str)
+
+
+# --------------------------------------------------------------------------
+# Reading the archive back.
+#
+# verify_archive_restore.py had its own GCS-only store, so a cloud could be
+# written but never drilled -- an archive nobody has proven restorable. The
+# restore drill now shares these stores, so download_file is part of the same
+# per-cloud contract as the writes.
+# --------------------------------------------------------------------------
+
+
+def test_s3_download_file_round_trips(s3: FakeS3, tmp_path: Path) -> None:
+    store = _store(s3)
+    source = tmp_path / "part.parquet"
+    source.write_bytes(b"parquet-bytes")
+    store.put_file_if_absent("k", source, sha256="abc", metadata={})
+
+    destination = tmp_path / "restored.parquet"
+    store.download_file("k", destination)
+    assert destination.read_bytes() == b"parquet-bytes"
+
+
+def test_azure_download_file_round_trips(
+    azure_container: FakeContainer, tmp_path: Path
+) -> None:
+    store = _azure_store()
+    source = tmp_path / "part.parquet"
+    source.write_bytes(b"parquet-bytes")
+    store.put_file_if_absent("k", source, sha256="abc", metadata={})
+
+    destination = tmp_path / "restored.parquet"
+    store.download_file("k", destination)
+    assert destination.read_bytes() == b"parquet-bytes"
+
+
+def test_every_store_can_be_read_back_not_only_written() -> None:
+    from clickhouse.archive_daily import ArchiveStore, GCSArchiveStore
+
+    assert "download_file" in dir(ArchiveStore)
+    for cls in (GCSArchiveStore, S3ArchiveStore, AzureBlobArchiveStore):
+        assert callable(getattr(cls, "download_file", None)), f"{cls.__name__} cannot be read back"
+
+
+def test_restore_drill_selects_the_same_per_cloud_stores() -> None:
+    """The drill must not carry its own GCS-only store, or 'the archive is
+    restorable' would only ever be true of one cloud."""
+
+    from clickhouse import verify_archive_restore
+
+    source = Path(verify_archive_restore.__file__).read_text()
+    assert "build_archive_store" in source
+    assert "--object-store" in source
+    # The near-duplicate is gone rather than merely unused.
+    assert "class GCSRestoreStore" not in source


### PR DESCRIPTION
Two defects that both let a broken archive look fine. Follows #642 / #644 / #647.

## 1. The restore drill could only read GCS

#642 and #644 made the archive **writable** on three clouds. The drill that proves it is **restorable** could still only read one: `verify_archive_restore.py` carried its own `GCSRestoreStore`, constructed unconditionally with no `--object-store`.

So AWS and Azure would have been writing archives nobody had ever restored — which is the exact failure this archive exists to prevent, just moved one step along.

That store was a near-duplicate of `GCSArchiveStore`: same client, same `read_json`, plus a `download_file`. Rather than add two more copies, the three archive stores gain `download_file` and the drill selects among them via `build_archive_store`. `GCSRestoreStore` is **deleted**, not merely unused — so every cloud now gets a restore drill the moment it gets an archive, instead of that being a separate thing to remember.

`download_file` is on the `ArchiveStore` Protocol, so a backend that can be written but not read fails type checking rather than failing at drill time on a cloud nobody is watching. The tests already treated these as one seam — `MemoryStore` has implemented `download_file` alongside the archive methods all along — so this makes production match what the tests assumed.

One gap stated plainly: `download_file` is injected by boto3's transfer manager and is **not** in the botocore service model, so `Stubber` cannot validate it the way it validates the conditional writes. Verified directly instead that a real boto3 client exposes `download_file(Bucket, Key, Filename)`, matching this call.

## 2. One unreadable dataset hid every dataset after it

`check_days` let `StoreError` propagate and `main` caught it around the *whole sweep*. So the first denied read ended the run: with four datasets, an unrelated permissions error on the first reported **1 of 4** and returned — and a dataset that had genuinely stopped archiving sat behind it, unreported.

That is the 2026-08-16 shape again: the mechanism that should raise the alarm was itself the broken thing. And it gets worse per cloud, not better — pointing this check at three clouds would let **cloud A's 403 mask cloud B's missing pointer**.

A read failure is now contained to the dataset-day it happened on and recorded as that dataset's own problem, so every dataset is still swept.

**Unknown still outranks stale**, because they are different claims — a stale archive is a finding, an unreadable one means the check does not know. `DatasetStatus` carries `unreadable`; `main` reports every problem, then exits `2` if anything could not be read and `1` if the archive was read and found stale. The problems file gets the full picture either way, which is what the issue body is built from.

## Why the existing tests missed it

The old coverage used a store that failed **every** read — and with every read failing, the masking bug is invisible. So the fake grew `fail_only_keys_containing`, and the new test makes *one* dataset unreadable and a *different* one never-archived, then asserts the genuine staleness is still reported.

Restoring the propagating behaviour fails that test and the exit-code test — verified by mutation, 2 failures.

80 tests pass · `ruff check` clean · `mypy` clean (276 files)

## Still outstanding

The freshness workflow itself remains GCS-only at the cron level: pointing it at AWS/Azure needs a GitHub→AWS OIDC role and an Entra federated credential, which don't exist yet and are your call (creating identity providers). This PR makes the checker *capable* of it without changing what the schedule does today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)