### PR TITLE
Read the Spanner lag in one round trip: 32 were 9.76s against a 3s budget

### DIFF
--- a/src/trusted_router/storage_gcp_operational_analytics_outbox.py
+++ b/src/trusted_router/storage_gcp_operational_analytics_outbox.py
@@ -15,7 +15,6 @@ unchanged.  What stays is the Spanner-specific writer.
 from __future__ import annotations
 
 import datetime as dt
-import time
 from typing import Any
 
 from trusted_router.storage_gcp_codec import json_body
@@ -127,44 +126,45 @@ class SpannerOperationalAnalyticsOutbox:
         them identical is what stops the published number and the drain's own
         ``backlog_alarm`` from meaning different things.
 
-        ``timeout`` is a budget for the WHOLE call, not per statement, and that
-        distinction is the point. This runs on the public /status.json path, in
-        an async handler, where a blocking wait stops the event loop rather
-        than one thread. 32 shard reads each given a 3s timeout is a 96s worst
-        case -- a per-statement bound that is not a bound. So the deadline is
-        set once and each statement gets whatever is LEFT of it, and running
-        out raises rather than returning a partial answer: a minimum taken over
-        the shards that happened to reply before the clock expired is not the
+        ``timeout`` bounds the one statement, which is the whole call. This
+        runs on the public /status.json path, in an async handler, where a
+        blocking wait stops the event loop rather than one thread. Running out
+        raises rather than returning a partial answer: a minimum over the
+        shards that happened to reply before the clock expired is not the
         oldest row, it is a smaller number that would publish as better health.
         """
-        deadline = None if timeout is None else time.monotonic() + timeout
-        oldest: dt.datetime | None = None
-        with self._database.snapshot(multi_use=True) as snapshot:
-            for shard in range(self._shard_count):
-                kwargs: dict[str, Any] = {}
-                if deadline is not None:
-                    remaining = deadline - time.monotonic()
-                    if remaining <= 0:
-                        raise TimeoutError(
-                            "operational analytics outbox lag read exceeded "
-                            f"{timeout}s after {shard} of {self._shard_count} shards"
-                        )
-                    kwargs["timeout"] = remaining
-                rows = list(
-                    snapshot.execute_sql(
-                        "SELECT commit_ts FROM tr_operational_analytics_outbox "
-                        "WHERE shard=@shard ORDER BY commit_ts LIMIT 1",
-                        params={"shard": shard},
-                        param_types={"shard": self._pt.INT64},
-                        **kwargs,
-                    )
-                )
-                if not rows or rows[0][0] is None:
-                    continue
-                candidate: dt.datetime = rows[0][0]
-                if candidate.tzinfo is None:
-                    candidate = candidate.replace(tzinfo=dt.UTC)
-                oldest = candidate if oldest is None else min(oldest, candidate)
+        # ONE round trip, not 32. Each arm is still a seek on the key prefix
+        # (the primary key leads with `shard`), so this keeps the cost the
+        # per-shard form was chosen for while paying the network once.
+        #
+        # Measured against production Spanner on 2026-08-17, the 32-statement
+        # loop this replaces took 9.76s -- 2.22s for the first shard, ~0.25s
+        # for each of the rest -- against a 3.0s budget. It therefore raised
+        # TimeoutError on every call, and /status.json published
+        # `{"available": false, "reason": "unreachable"}` for a cloud whose
+        # outbox was in fact EMPTY, i.e. whose drain was perfectly healthy. The
+        # same sweep as one statement: 2.93s cold, 1.01s warm.
+        #
+        # `MIN(commit_ts)` over the whole table would be one round trip too and
+        # is the wrong fix: no shard predicate means a scan, which gets slower
+        # exactly as the backlog it measures grows.
+        arms = " UNION ALL ".join(
+            "SELECT (SELECT commit_ts FROM tr_operational_analytics_outbox "  # noqa: S608
+            f"WHERE shard={shard} ORDER BY commit_ts LIMIT 1) AS commit_ts"
+            for shard in range(self._shard_count)
+        )
+        # Interpolation is safe and unavoidable here: shard numbers come from
+        # range(self._shard_count), never from a caller, and a query parameter
+        # cannot stand in for the literal each arm seeks on.
+        sql = f"SELECT MIN(commit_ts) FROM ({arms})"  # noqa: S608
+        kwargs: dict[str, Any] = {} if timeout is None else {"timeout": timeout}
+        with self._database.snapshot() as snapshot:
+            rows = list(snapshot.execute_sql(sql, **kwargs))
+        if not rows or rows[0][0] is None:
+            return None
+        oldest: dt.datetime = rows[0][0]
+        if oldest.tzinfo is None:
+            oldest = oldest.replace(tzinfo=dt.UTC)
         return oldest
 
     def _enqueue(

--- a/tests/test_operational_analytics.py
+++ b/tests/test_operational_analytics.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dataclasses
 import datetime as dt
 import json
+import re
 import threading
 from typing import Any
 
@@ -966,7 +967,15 @@ def test_synthetic_rollup_rebuild_never_overwrites_partial_ttl_boundary() -> Non
 
 
 class _SnapshotDatabase:
-    """A Spanner database whose snapshot answers per-shard oldest-row reads."""
+    """A Spanner database whose snapshot answers the one-statement lag read.
+
+    The read is a single `SELECT MIN(commit_ts) FROM (<32 per-shard seeks>)`,
+    so this fake parses the shard literals back out of the SQL and answers the
+    minimum over the shards it was asked about. Parsing rather than ignoring
+    them is deliberate: it is what lets the tests below assert that all 32
+    heads really were consulted, which is the property the old 32-round-trip
+    form made obvious and this one does not.
+    """
 
     def __init__(self, rows_by_shard: dict[int, list[dt.datetime]]) -> None:
         self._rows_by_shard = rows_by_shard
@@ -985,20 +994,22 @@ class _SnapshotDatabase:
             def __exit__(self, *_exc: Any) -> None:
                 return None
 
-            def execute_sql(
-                self,
-                sql: str,
-                *,
-                params: dict[str, Any],
-                param_types: dict[str, Any],
-                **kwargs: Any,
-            ) -> list[list[Any]]:
+            def execute_sql(self, sql: str, **kwargs: Any) -> list[list[Any]]:
                 outer.timeouts.append(kwargs.get("timeout"))
-                outer.queries.append((sql, params))
-                stamps = sorted(outer._rows_by_shard.get(int(params["shard"]), []))
-                return [[stamps[0]]] if stamps else []
+                outer.queries.append((sql, kwargs.get("params") or {}))
+                shards = [int(value) for value in re.findall(r"WHERE shard=(\d+)", sql)]
+                stamps = sorted(
+                    stamp
+                    for shard in shards
+                    for stamp in outer._rows_by_shard.get(shard, [])
+                )
+                return [[stamps[0]]] if stamps else [[None]]
 
         return _Snapshot()
+
+
+def _queried_shards(sql: str) -> set[int]:
+    return {int(value) for value in re.findall(r"WHERE shard=(\d+)", sql)}
 
 
 def test_spanner_oldest_enqueued_at_is_the_minimum_across_every_shard() -> None:
@@ -1019,9 +1030,49 @@ def test_spanner_oldest_enqueued_at_is_the_minimum_across_every_shard() -> None:
     outbox = SpannerOperationalAnalyticsOutbox(database, _ParamTypes())
 
     assert outbox.oldest_enqueued_at() == oldest
-    assert len(database.queries) == OPERATIONAL_ANALYTICS_OUTBOX_SHARDS
-    assert all("ORDER BY commit_ts LIMIT 1" in sql for sql, _ in database.queries)
-    assert all("count(" not in sql.lower() for sql, _ in database.queries)
+    [(sql, _)] = database.queries
+    assert _queried_shards(sql) == set(range(OPERATIONAL_ANALYTICS_OUTBOX_SHARDS))
+    assert sql.count("ORDER BY commit_ts LIMIT 1") == OPERATIONAL_ANALYTICS_OUTBOX_SHARDS
+    assert "count(" not in sql.lower()
+
+
+def test_spanner_lag_read_is_one_round_trip_not_one_per_shard() -> None:
+    """32 sequential round trips do not fit the budget that bounds this read.
+
+    Measured against production Spanner on 2026-08-17, the per-shard loop this
+    replaced took 9.76s (2.22s for the first shard, ~0.25s for each of the
+    rest) against a 3.0s budget, so it raised TimeoutError on EVERY call and
+    /status.json published `unreachable` for a cloud whose outbox was empty --
+    a healthy drain reported as a broken one, on the very page added to notice
+    broken drains. As one statement: 2.93s cold, 1.01s warm.
+
+    The count is the assertion. Anything that walks the shards in Python is
+    correct and unusably slow, and it would pass every other test here.
+    """
+    database = _SnapshotDatabase({5: [dt.datetime(2026, 8, 2, 3, 0, tzinfo=dt.UTC)]})
+    outbox = SpannerOperationalAnalyticsOutbox(database, _ParamTypes())
+
+    outbox.oldest_enqueued_at(timeout=3.0)
+
+    assert len(database.queries) == 1
+
+
+def test_spanner_lag_read_never_scans_the_whole_table() -> None:
+    """Every arm carries a shard predicate; a bare MIN() would scan.
+
+    One round trip is achievable the wrong way -- `SELECT MIN(commit_ts) FROM
+    tr_operational_analytics_outbox` is also one statement, and it degrades
+    precisely as the backlog grows, which is when this number matters most.
+    """
+    database = _SnapshotDatabase({0: [dt.datetime(2026, 8, 2, 3, 0, tzinfo=dt.UTC)]})
+    outbox = SpannerOperationalAnalyticsOutbox(database, _ParamTypes())
+
+    outbox.oldest_enqueued_at()
+
+    [(sql, _)] = database.queries
+    selects = sql.count("FROM tr_operational_analytics_outbox")
+    assert selects == OPERATIONAL_ANALYTICS_OUTBOX_SHARDS
+    assert selects == sql.count("WHERE shard=")
 
 
 def test_spanner_oldest_enqueued_at_is_none_when_every_shard_is_drained() -> None:
@@ -1048,23 +1099,13 @@ def test_spanner_oldest_enqueued_at_spends_one_budget_across_all_shards() -> Non
 
     This read runs on the public /status.json path inside an async handler, so
     the number that matters is how long the whole thing can hold the event
-    loop. Handing each shard a fresh copy of the timeout would make the real
-    ceiling 32x the number written down -- a bound in name only.
+    loop. With one statement the two are the same thing by construction, which
+    is the second reason to prefer it: the earlier form had to subtract
+    elapsed time from a deadline to keep the promise this now keeps for free.
     """
     database = _SnapshotDatabase({0: [dt.datetime(2026, 8, 2, 3, 0, tzinfo=dt.UTC)]})
     outbox = SpannerOperationalAnalyticsOutbox(database, _ParamTypes())
 
     outbox.oldest_enqueued_at(timeout=5.0)
 
-    assert all(timeout is not None and timeout <= 5.0 for timeout in database.timeouts)
-    assert database.timeouts == sorted(database.timeouts, reverse=True)
-
-
-def test_spanner_oldest_enqueued_at_is_unbounded_only_when_asked_to_be() -> None:
-    """The drain has no deadline; only the status path does."""
-    database = _SnapshotDatabase({})
-    outbox = SpannerOperationalAnalyticsOutbox(database, _ParamTypes())
-
-    outbox.oldest_enqueued_at()
-
-    assert database.timeouts == [None] * OPERATIONAL_ANALYTICS_OUTBOX_SHARDS
+    assert database.timeouts == [5.0]

--- a/tests/test_public_analytics_freshness.py
+++ b/tests/test_public_analytics_freshness.py
@@ -429,7 +429,20 @@ def test_the_postgres_lag_read_bounds_the_pool_wait_and_the_statement() -> None:
 
 
 def test_the_spanner_lag_read_bounds_the_whole_shard_sweep() -> None:
-    """A per-statement timeout across 32 shards is a 32x bound, i.e. not one."""
+    """The budget bounds the CALL, and the call is now a single statement.
+
+    The previous shape handed each of 32 statements the REMAINING budget and
+    raised TimeoutError itself when it ran out. That arithmetic existed to stop
+    a per-statement bound from silently becoming a 32x one -- and it worked,
+    but the underlying read still cost 9.76s against a 3.0s budget in
+    production, so it timed out every time and published `unreachable` for a
+    healthy drain. One statement removes the arithmetic and the problem
+    together: what the client is given IS the ceiling on the whole call.
+
+    The remaining risk -- a client that ignores its own timeout -- is covered
+    not here but by the caller-side bound, proven behaviourally in
+    test_a_backend_that_answers_slowly_does_not_hold_the_status_build_open.
+    """
     from trusted_router.storage_gcp_operational_analytics_outbox import (
         SpannerOperationalAnalyticsOutbox,
     )
@@ -443,10 +456,9 @@ def test_the_spanner_lag_read_bounds_the_whole_shard_sweep() -> None:
         def __exit__(self, *_exc):
             return None
 
-        def execute_sql(self, _sql, *, params, param_types, **kwargs):
+        def execute_sql(self, _sql, **kwargs):
             calls.append(kwargs["timeout"])
-            time.sleep(0.02)
-            return []
+            return [[None]]
 
     class _Database:
         def snapshot(self, **_kwargs):
@@ -457,9 +469,6 @@ def test_the_spanner_lag_read_bounds_the_whole_shard_sweep() -> None:
 
     outbox = SpannerOperationalAnalyticsOutbox(_Database(), _ParamTypes())
 
-    with pytest.raises(TimeoutError):
-        outbox.oldest_enqueued_at(timeout=0.1)
+    outbox.oldest_enqueued_at(timeout=0.1)
 
-    # Each statement got the REMAINING budget, not a fresh copy of it.
-    assert calls == sorted(calls, reverse=True)
-    assert calls[-1] < calls[0]
+    assert calls == [0.1]


### PR DESCRIPTION
#643 shipped an hour ago and the field it added immediately reported the opposite of the truth — `trustedrouter.com/status.json` published `"analytics": {"available": false, "reason": "unreachable"}` for a cloud whose outbox was **empty**. A healthy drain, reported as broken, on the page added to notice broken drains.

**Measured against production Spanner** (ops SA, read-only): the 32-statement per-shard sweep takes **9.76 s** (2.22 s for the first shard, ~0.25 s each after) against the **3.0 s** budget. It timed out on every call and correctly degraded to `unreachable`. The bound and the degradation were fine — the read could never fit inside it.

The same 32 seeks as **one statement** (MIN over a UNION ALL of per-shard heads): **2.93 s cold, 1.01 s warm**, verified through the real method against production, now returning a live ~2 s lag.

`MIN(commit_ts)` over the whole table is *also* one round trip and is the wrong fix — no shard predicate means a scan, degrading exactly as the backlog grows. There's a separate test for that, because the round-trip-count test passes for the scan too.

Gates: ruff + mypy clean, full suite 4742 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)