### PR TITLE
Repair ClickHouse soak verifiers

### DIFF
--- a/clickhouse/ingest_operational_outbox.py
+++ b/clickhouse/ingest_operational_outbox.py
@@ -90,6 +90,13 @@ ACTIVITY_OPTIONAL_DEFAULTS: dict[str, Any] = {
     "client_stream": None,
     "client_failover_used": None,
 }
+ACTIVITY_BOOLEAN_COLUMNS = (
+    "streamed",
+    "usage_estimated",
+    "synthetic",
+    "client_stream",
+    "client_failover_used",
+)
 SYNTHETIC_COLUMNS = (
     "id",
     "probe_type",
@@ -631,9 +638,17 @@ def normalise_operational_event(
         raise ValueError(
             f"{row.event_kind} payload missing required fields: {', '.join(missing)}"
         )
-    canonical = {
-        column: raw.get(column, ACTIVITY_OPTIONAL_DEFAULTS.get(column)) for column in allowed
-    }
+    canonical: dict[str, Any] = {}
+    for column in allowed:
+        value = raw.get(column)
+        if row.event_kind == "activity" and value is None:
+            default = ACTIVITY_OPTIONAL_DEFAULTS.get(column)
+            if default is not None:
+                value = default
+        if row.event_kind == "activity" and column in ACTIVITY_BOOLEAN_COLUMNS:
+            if value is not None:
+                value = int(bool(value))
+        canonical[column] = value
     canonical["ingest_version"] = _utc(row.commit_ts).isoformat()
     return [CanonicalOperationalEvent(event_kind=row.event_kind, row=canonical)]
 

--- a/clickhouse/operational_fingerprint.py
+++ b/clickhouse/operational_fingerprint.py
@@ -9,6 +9,11 @@ import re
 import struct
 from typing import Any, Protocol
 
+from clickhouse.ingest_operational_outbox import (
+    ACTIVITY_BOOLEAN_COLUMNS,
+    ACTIVITY_OPTIONAL_DEFAULTS,
+)
+
 SAFE_ID = re.compile(r"^[A-Za-z0-9._:-]{1,160}$")
 
 
@@ -34,7 +39,10 @@ def canonical_fingerprint(payload: dict[str, Any], *, surface: str) -> str:
             if canonical.get(field) is not None:
                 canonical[field] = bool(canonical[field])
     if surface == "activity":
-        for field in ("streamed", "usage_estimated"):
+        for field, default in ACTIVITY_OPTIONAL_DEFAULTS.items():
+            if canonical.get(field) is None and default is not None:
+                canonical[field] = default
+        for field in ACTIVITY_BOOLEAN_COLUMNS:
             if canonical.get(field) is not None:
                 canonical[field] = bool(canonical[field])
         if canonical.get("speed_tokens_per_second") is not None:

--- a/clickhouse/verify_spanner_delivery.py
+++ b/clickhouse/verify_spanner_delivery.py
@@ -12,6 +12,10 @@ from pathlib import Path
 from typing import Any, Protocol
 
 from clickhouse.backfill_operational_analytics import ClickHouse
+from clickhouse.ingest_operational_outbox import (
+    OperationalOutboxRow,
+    normalise_operational_event,
+)
 from clickhouse.operational_fingerprint import canonical_fingerprint, clickhouse_rows
 from trusted_router.storage_gcp_operational_analytics_outbox import activity_payload
 from trusted_router.storage_models import Generation
@@ -83,7 +87,19 @@ def verify_delivery(
     limit: int,
 ) -> dict[str, Any]:
     generations = source.fetch(start=start, end=end, limit=limit)
-    expected = {generation.id: activity_payload(generation) for generation in generations}
+    expected: dict[str, dict[str, Any]] = {}
+    for generation in generations:
+        [event] = normalise_operational_event(
+            OperationalOutboxRow(
+                shard=0,
+                commit_ts=end,
+                event_kind="activity",
+                event_id=generation.id,
+                payload=json.dumps(activity_payload(generation)),
+            )
+        )
+        event.row.pop("ingest_version", None)
+        expected[generation.id] = event.row
     actual = clickhouse_rows(
         clickhouse,
         table="activity_generations",

--- a/src/trusted_router/storage_operational_analytics.py
+++ b/src/trusted_router/storage_operational_analytics.py
@@ -16,16 +16,18 @@ from __future__ import annotations
 
 import datetime as dt
 import hashlib
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from trusted_router.catalog import MODELS
-from trusted_router.client_events_schema import ClientEventsBatch
 from trusted_router.client_reliability import (
     METHODOLOGY_VERSION,
     classify_tr_fault,
     timeout_floor_met,
 )
 from trusted_router.storage_models import Generation, SyntheticProbeSample
+
+if TYPE_CHECKING:
+    from trusted_router.client_events_schema import ClientEventsBatch
 
 OPERATIONAL_ANALYTICS_OUTBOX_SHARDS = 32
 ACTIVITY_EVENT_KIND = "activity"

--- a/tests/test_clickhouse_client_events.py
+++ b/tests/test_clickhouse_client_events.py
@@ -167,6 +167,18 @@ def test_old_activity_payload_gets_exact_optional_defaults() -> None:
     )
 
 
+def test_activity_payload_explicit_nulls_get_clickhouse_string_defaults() -> None:
+    payload = activity_payload(_generation())
+    row = OperationalOutboxRow(1, COMMIT_TS, "activity", "gen-null", json.dumps(payload))
+
+    [event] = normalise_operational_event(row)
+
+    for field, default in ACTIVITY_OPTIONAL_DEFAULTS.items():
+        if default is not None:
+            assert event.row[field] == default
+            assert type(event.row[field]) is type(default)
+
+
 def test_old_activity_payload_still_rejects_missing_required_field() -> None:
     payload = activity_payload(_generation())
     payload.pop("generation_id")

--- a/tests/test_clickhouse_operational_deploy.py
+++ b/tests/test_clickhouse_operational_deploy.py
@@ -1,8 +1,35 @@
 from __future__ import annotations
 
+import subprocess
+import sys
 from pathlib import Path
 
 ROOT = Path(__file__).parents[1]
+
+
+def test_clickhouse_worker_projection_import_does_not_require_pydantic() -> None:
+    script = """
+import builtins
+
+real_import = builtins.__import__
+def guarded_import(name, *args, **kwargs):
+    if name == "pydantic" or name.startswith("pydantic."):
+        raise ModuleNotFoundError("pydantic is intentionally unavailable")
+    return real_import(name, *args, **kwargs)
+
+builtins.__import__ = guarded_import
+import trusted_router.storage_operational_analytics
+"""
+
+    result = subprocess.run(  # noqa: S603 - fixed interpreter and inert test script.
+        [sys.executable, "-c", script],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_operational_schema_is_replicated_bounded_and_content_free() -> None:

--- a/tests/test_spanner_delivery.py
+++ b/tests/test_spanner_delivery.py
@@ -114,6 +114,58 @@ def test_spanner_delivery_normalizes_integral_float_json_values() -> None:
     assert result["mismatch_fields"] == {}
 
 
+def test_spanner_delivery_matches_clickhouse_defaults_for_legacy_rows() -> None:
+    generation = _generation()
+    actual = activity_payload(generation)
+    actual.update(
+        {
+            "gateway_request_id": "",
+            "synthetic": 0,
+            "client_source": "none",
+            "client_sdk": "",
+            "client_sdk_version": "",
+            "client_lang": "",
+            "client_runtime": "",
+            "client_os": "",
+            "client_arch": "",
+            "client_prev_outcome": "",
+            "client_prev_error_class": "",
+            "client_prev_host": "",
+        }
+    )
+
+    result = verify_delivery(
+        FakeSource([generation]),
+        FakeClickHouse({generation.id: actual}),
+        start=dt.datetime(2026, 7, 31, tzinfo=dt.UTC),
+        end=dt.datetime(2026, 8, 1, tzinfo=dt.UTC),
+        limit=100,
+    )
+
+    assert result["ok"] is True
+    assert result["mismatch_fields"] == {}
+
+
+def test_spanner_delivery_normalizes_nullable_clickhouse_booleans() -> None:
+    generation = _generation()
+    generation.client_stream = False
+    generation.client_failover_used = True
+    actual = activity_payload(generation)
+    actual["client_stream"] = 0
+    actual["client_failover_used"] = 1
+
+    result = verify_delivery(
+        FakeSource([generation]),
+        FakeClickHouse({generation.id: actual}),
+        start=dt.datetime(2026, 7, 31, tzinfo=dt.UTC),
+        end=dt.datetime(2026, 8, 1, tzinfo=dt.UTC),
+        limit=100,
+    )
+
+    assert result["ok"] is True
+    assert result["mismatch_fields"] == {}
+
+
 def test_spanner_delivery_reports_missing_and_mismatched_rows() -> None:
     missing = _generation("gen-missing")
     mismatched = _generation("gen-mismatched")


### PR DESCRIPTION
## Summary
- canonicalize nullable activity fields exactly like ClickHouse ingestion
- compare Spanner delivery through the shared canonical projection
- remove the analytics worker's accidental runtime dependency on Pydantic

## Production evidence
- old parity worker mismatched 5,000/5,000 activity rows after client telemetry defaults landed
- old parity and delivery workers then failed with ModuleNotFoundError: pydantic

## Verification
- ruff clean
- mypy clean across 277 source files
- 4,746 passed, 290 skipped, 10 xfailed