### PR TITLE
A cloud is not done until the gate says so, proven by running the scripts

### DIFF
--- a/.github/workflows/check-analytics-freshness.yml
+++ b/.github/workflows/check-analytics-freshness.yml
@@ -90,8 +90,11 @@ name: Check fleet analytics freshness
 #   1. Deploy all three control planes; verify with
 #        curl -s https://trustedrouter.com/status.json | jq .data.analytics
 #      (and the AWS/Azure URLs in ANALYTICS_FRESHNESS_FLEET) that each one
-#      returns an object rather than null. Verified 2026-08-17: all three
-#      returned null, i.e. NONE of them publishes the section yet.
+#      returns an object rather than null. Do not take this comment's word for
+#      where the fleet is -- it is a to-do list, and the fleet moves under it.
+#      `bash scripts/deploy/verify_cloud_complete.sh <cloud>` answers per cloud;
+#      exit 5 is the "still returns null" state. When this was written, all
+#      three returned null; the publisher ships in the same change.
 #   2. Run this workflow once with workflow_dispatch and read the result,
 #      including the `~` unchecked lines.
 #

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -771,3 +771,71 @@ jobs:
           SPANNER_INSTANCE_ID: trusted-router-nam6
           SPANNER_DATABASE_ID: trusted-router
         run: scripts/deploy/retire_settle_outbox_hot_index.sh
+
+  # ---------------------------------------------------------------------------
+  # Did the CLOUD end up working, or did only the deploy finish?
+  #
+  # scripts/deploy/rollout.sh is GCP's control-plane deploy and it is the one
+  # bring-up script in this repo deliberately NOT ending in the completeness
+  # gate: it is a STEP of the job above, and a public HTTPS fetch of
+  # trustedrouter.com/status.json in the middle of deploying the cloud that
+  # SERVES trustedrouter.com would abort the deploy that repairs an outage,
+  # partway, because of the outage it repairs.
+  #
+  # That exemption is recorded in code, in ROLLOUT_REGISTRY
+  # (src/trusted_router/cloud_rollout_completeness.py), and it used to cite "the
+  # scheduled analytics freshness workflow" as the thing that checks GCP
+  # instead. That workflow ships with no `schedule:` trigger, on purpose and in
+  # its own header, so the citation was to a control that does not run: the
+  # primary cloud had no automated completeness check at all, behind a sentence
+  # saying it did. THIS JOB is that control.
+  #
+  # THE BODY OF THIS JOB IS ONE LINE, AND THAT IS THE POINT.
+  # For one revision the retry loop lived here in YAML, and all that bound it to
+  # anything was a substring search over this job's `run:` blocks for
+  # "verify_cloud_complete.sh gcp". Replacing this entire body with
+  # `echo "Next: bash scripts/deploy/verify_cloud_complete.sh gcp"; exit 0` kept
+  # the suite green -- the primary cloud's only binding was satisfied by the
+  # three saboteur shapes this whole change exists to kill. So the body is
+  # scripts/deploy/verify_gcp_complete.sh, which is in GCP's deploy_scripts and
+  # is RUN by tests/test_deploy_script_execution.py like every other bound
+  # script. What remains a text read is this YAML, and CI requires the step
+  # below to be an exact invocation of a script the registry proves by
+  # execution -- not a mention of one.
+  #
+  # Out of band by construction: it runs after the deploy job, so it can make
+  # the run red and can never leave GCP half-deployed. Read-only -- one public
+  # GET, no credentials, no cloud SDK.
+  #
+  # `if: always()` is load-bearing and was missing. With a bare `needs:
+  # [deploy]`, GitHub SKIPS this job when deploy fails -- and a deploy that
+  # failed PARTWAY has already mutated production, which is exactly the state
+  # somebody needs to know the completeness of. The check would have been absent
+  # from every run where it mattered most.
+  #
+  # What it still does NOT cover, stated because a comment here once claimed it
+  # ran "after every production mutation" and that is false: `migrate-schema`
+  # and `sync-runtime-secrets` mutate production BEFORE `deploy`, and this job
+  # is skipped when `deploy` is skipped -- which is exactly what happens when
+  # `confirm-current-main` says do not proceed. A run can therefore migrate the
+  # schema, rotate runtime secrets, skip the deploy, and never reach this check.
+  # The coverage is: every run in which the deploy job ran, whatever its result.
+  # ---------------------------------------------------------------------------
+  verify-cloud-complete:
+    needs: [deploy]
+    if: ${{ always() && needs.deploy.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+      - name: Install runtime
+        run: uv sync --frozen
+
+      # Exactly this, on one line. tests/test_cloud_rollout_completeness.py
+      # requires a step whose `run` IS an invocation of a script GCP's registry
+      # entry proves by execution; an echo, a comment or a `|| true` is not one.
+      - name: Is the GCP cloud complete, or only deployed?
+        run: bash scripts/deploy/verify_gcp_complete.sh

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -27,6 +27,7 @@ Index:
 - [Sentry "Aborted ... deadlock/wounded" burst on gateway authorize](#authorize-deadlock-burst)
 - [One workspace 503s "Workspace billing is paused" (interrupted reshard)](#reshard-interrupted)
 - [DNS-vendor-split symptoms (Cloudflare vs Cloud DNS)](#dns-vendor-split)
+- [Adding a cloud (and when it is allowed to be called done)](#adding-a-cloud)
 
 ---
 
@@ -1039,6 +1040,114 @@ After deploys that add SEO pages:
    not contain secrets.
 4. Follow `docs/marketing/llm-seo-opportunities.md` for Ahrefs exports
    and new page prioritization.
+
+---
+
+## <a id="adding-a-cloud"></a>Adding a cloud (and when it is allowed to be called done)
+
+**Symptom this prevents:** a cloud that serves traffic, shows an all-green
+status page, and records none of its operational history — because the process
+that moves rows out of its outbox was never installed, and the only alarm for
+that is emitted by the missing process. AWS-EU ran that way from 2026-08-02 to
+2026-08-17: 470,897 undelivered rows, `activity_generations` empty, no page.
+
+**The rule: a cloud is not in service until rows are observed moving.**
+
+Check any cloud, from anywhere, with no credentials:
+
+```bash
+bash scripts/deploy/verify_cloud_complete.sh aws     # or azure, gcp
+```
+
+It exits non-zero until all five stages hold, each naming its own fix:
+
+| # | Stage | Fix when it fails |
+|---|---|---|
+| a | in the fleet freshness registry (registered, not watched — that workflow has no schedule trigger yet) | add a `FleetAnalyticsEndpoint` in `src/trusted_router/operational_analytics_fleet.py` |
+| b | `/status.json` has the `analytics` section | deploy a control plane whose status snapshot publishes `drain_lag_seconds` |
+| c | `analytics.available` is true | the control plane cannot read its outbox — check its database connection |
+| d | `drain_lag_seconds` under bound | the drain is stopped or behind: `bash scripts/deploy/aws_eu_clickhouse_drain_install.sh` |
+| e | control-plane outbox enabled | set `TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true` in that cloud's deploy script |
+
+Stage (e) is a static read of that deploy script **in your working tree**, not
+of the revision the cloud is running: it tells you what a deploy from this
+checkout would set, and stages (b)–(d) are the evidence about the running
+service.
+
+**There is no way to excuse a stage.** No waiver, no exemption field, no flag,
+no environment variable. A cloud that cannot be checked is NOT VERIFIED and the
+run exits non-zero with the reason printed. (An earlier revision had an
+`analytics_absent_reason` that waived "structural" blockers, plus the machinery
+to decide which failures counted as structural. Review found bugs inside that
+machinery twice, the second set introduced by the fix for the first, so it is
+gone.) `TR_MAX_DRAIN_LAG_SECONDS` and `TR_STATUS_URL` are read only so the
+script can tell you loudly that it is ignoring them.
+
+Exit codes (`scripts/deploy/cloud_complete_gate.sh` turns each into the same
+words for every bound script):
+
+| code | meaning |
+|---|---|
+| 0 | `VERIFIED` — every stage was measured and held. The banner then says what that does *not* establish, which is that rows were seen moving |
+| 5 | `NOT YET OBSERVABLE` — the page parses and carries no `analytics` section, so the question cannot be asked from outside yet. Its own code because it is the state a cloud is in before its control plane publishes the section, and the run that installs a drain hits it by construction |
+| 1 | `NOT VERIFIED`, for everything else, with the reason printed: a stage failed, the page did not answer 200, the body was not the status document, the cloud is unknown, the arguments were wrong |
+
+The AWS and Azure bring-up and control-plane scripts end by running this, so an
+exit of 0 from one of them means the check passed — which is a statement about
+what the check measures, not a certificate that the cloud works. Read the
+banner: it lists the five stages and then says, every time, that rows moving is
+not among them.
+
+That binding is not taken on trust. Those scripts — GCP's included — are
+executed end to end against a stub `PATH` in
+`tests/test_deploy_script_execution.py`, which asserts each one calls the gate,
+cannot exit 0 over a failing gate, runs no cloud CLI after the gate answered,
+and passes both exit codes through unchanged. The one exception is
+`aws_eu_clickhouse_drain_install.sh`, whose SSM-heavy middle cannot be stubbed
+honestly — its tail is claimed, not proven, and `ROLLOUT_REGISTRY` says so.
+Which scripts are in which list is checked for exact set equality against
+`docs/storage-portability/multi-cloud-separation.md`, so a script cannot quietly
+lose its behavioural coverage while the docs still call it proven.
+
+**GCP's exempt file is `rollout.sh`, not GCP:** `rollout.sh` runs inside
+`.github/workflows/deploy.yml`, and ending it here would put a fetch of
+`trustedrouter.com/status.json` in the middle of deploying the cloud that serves
+it — the deploy that repairs an outage would abort partway. GCP is instead
+checked out of band by `scripts/deploy/verify_gcp_complete.sh`, which the
+`verify-cloud-complete` job in that same workflow runs as its whole body, and
+which the behavioural harness executes like every other bound script. Coverage,
+exactly: every run in which the `deploy` job ran, whatever its result —
+including a deploy that failed partway having already mutated production. It
+does NOT cover a run that skipped `deploy`, and `migrate-schema` and
+`sync-runtime-secrets` mutate production before `deploy` gets there. You can
+always run it yourself, from anywhere, with no credentials:
+
+```bash
+bash scripts/deploy/verify_gcp_complete.sh
+```
+
+If a script exits non-zero it prints the exact next command; run it and re-run
+the script, which is idempotent. Do not work around the exit code — that is the
+failure mode this exists to stop.
+
+**Do not read the fleet's state out of this runbook — run the gate.** A cloud
+starts answering when a control plane built from the publisher is deployed to
+it, and exits 5 until then. The last reading taken while editing this section
+was `gcp` VERIFIED with `aws` and `azure` both at 5, and it is a note about a
+moment rather than a claim about now. Azure additionally fails stage (e): it has
+no operational-analytics outbox at all. See
+`docs/storage-portability/multi-cloud-separation.md` §7 for the full definition
+of done and the checklist for a new cloud.
+
+**Last check that cannot be automated from outside:** once a cloud passes, look
+at the count from inside it, twice, ten minutes apart:
+
+```bash
+clickhouse-client --query 'SELECT count() FROM activity_generations'
+```
+
+Two numbers, the second larger. A drained outbox and a disabled outbox both
+publish `drain_lag_seconds: 0.0`; only the count tells them apart.
 
 ---
 

--- a/docs/storage-portability/multi-cloud-separation.md
+++ b/docs/storage-portability/multi-cloud-separation.md
@@ -198,3 +198,361 @@ first thing the conformance suite should be pointed at once a cluster exists.
    region-style selector. Affects key scoping and the 402 message.
 4. **Signup credit per cloud?** Granting the trial credit once per cloud
    multiplies the giveaway by the number of clouds.
+
+---
+
+## 7. Adding a cloud: the definition of done
+
+> **A cloud is not in service until rows are observed moving through its
+> analytics pipeline.** Not provisioned, not deployed, not "green on the status
+> page" — moving.
+
+This section exists because the previous, unwritten definition was "the
+bring-up scripts finished", and on 2026-08-02 that definition was satisfied by
+an AWS-EU cloud with no analytics pipeline at all. `aws_eu_clickhouse.sh` built
+the Paris node and ended by printing
+
+    Next: apply clickhouse/*.sql, then redeploy tr-eu with ...
+
+A human ran it, read the echoes, and stopped. For fifteen days settle enqueued
+operational rows into the DSQL outbox that nothing collected — 470,897 of them
+by 2026-08-17, with `activity_generations` on the node still empty — and no
+alarm fired, because the backlog alarm is emitted BY the drain that was never
+installed. The pipeline is
+
+    settle -> tr_operational_analytics_outbox (this cloud's OLTP db)
+           -> drain -> this cloud's ClickHouse
+
+and every stage after the first is invisible from outside the VPC, so "the
+control plane is up" says nothing about any of them.
+
+### The stages, in order
+
+A cloud is done when `scripts/deploy/verify_cloud_complete.sh <cloud>` exits 0.
+It needs no credentials — one public HTTPS GET and a text read of a deploy
+script — so it can be run from a laptop, by a reviewer, at any time:
+
+| # | Stage | Fails when |
+|---|---|---|
+| a | in the fleet freshness registry | the cloud has no status endpoint, so nothing can read its drain lag and this gate has nothing to fetch |
+| b | `/status.json` carries the `analytics` section | the cloud publishes no answer to the question |
+| c | `analytics.available` is true | the control plane cannot read its own outbox (**not** the same as an empty one) |
+| d | `drain_lag_seconds` under the bound | rows are enqueued and nothing is deleting them — the AWS-EU shape exactly |
+| e | the control plane's outbox is ENABLED | nothing is enqueued at all, so (c) and (d) pass over an empty pipe |
+
+Stage (a) means REGISTERED, not WATCHED, and the difference is worth one
+sentence because the check used to print the stronger claim on every pass
+("somebody reads this cloud's drain lag on a schedule"). Nobody does:
+`.github/workflows/check-analytics-freshness.yml` ships with `workflow_dispatch`
+as its only trigger, deliberately and in its own header, until every cloud
+publishes the section — see "Enable the fleet freshness cron" in that file.
+What (a) establishes is that there is an endpoint to read, which is what the
+rest of the run fetches.
+
+Stage (e) is not redundant with (d) and this is the subtle part: **a drained
+outbox and a disabled outbox look identical from outside.** Both publish
+`drain_lag_seconds: 0.0`. Stage (d) proves nothing is stuck; only (e) plus an
+in-cloud count proves anything moves.
+
+Stage (e) is also the one stage that reads a FILE rather than the cloud: it
+parses that cloud's control-plane deploy script **in the working tree you run it
+from**, because a check that needs `aws`/`az` credentials is a check that does
+not get run. So it answers "would a deploy from this checkout enable the
+outbox?", not "did the running service have it enabled?" — a local edit reads as
+enabled, and a script that shipped a year ago reads the same as one deployed
+this morning. The runtime evidence is (b)–(d), and the verifier prints exactly
+what it read, and from which file, as a note under its outcome.
+
+When you finish a cloud, look once, from inside:
+
+    clickhouse-client --query 'SELECT count() FROM activity_generations'
+
+and then again ten minutes later. Two numbers, the second larger. That is the
+observation the rule above is named after; nothing in a status page substitutes
+for it.
+
+### The analytics stage is not optional (with one named exception)
+
+Bring-up is not a menu. Every cloud's bring-up and control-plane deploy scripts
+end by running the check and exit non-zero when it fails —
+`aws_eu_clickhouse.sh`, `aws_eu_north_clickhouse.sh`, `aws_eu_control_plane.sh`,
+`aws_eu_clickhouse_drain_install.sh`, `azure_control_plane.sh`, and for GCP the
+out-of-band `verify_gcp_complete.sh`. Where a remaining step genuinely needs a
+human (a cost decision, a password that only exists on a node), the script
+prints the exact command **and exits non-zero**. It never prints and returns 0;
+that behaviour is the outage.
+
+That list is not typed here twice: it is `deploy_scripts` on each `CloudRollout`
+in `src/trusted_router/cloud_rollout_completeness.py`.
+
+### How "this script runs the gate" is established — and where it is only claimed
+
+This is worth reading before trusting the paragraph above, because the first
+version of that binding was a lie of exactly the kind this whole section is
+about. It was a regex: *does the string `verify_cloud_complete.sh <cloud>`
+appear in the script's last N lines?* A heredoc body satisfies that. So does a
+printed instruction. So does a commented-out line. The check that was written to
+stop "printing the step counts as doing the step" was itself satisfied by
+printing the step.
+
+So the binding is now behavioural. `tests/test_deploy_script_execution.py` RUNS
+each bound script to completion in a harness (`tests/deploy_script_harness.py`)
+whose `PATH` is one directory: a recording stub for each cloud CLI, `curl`,
+`ssh`, `systemctl`, `sleep` and the rest of a named list, plus a symlink to
+every other entry of `/bin` and `/usr/bin`. `$HOME` and `$TMPDIR` are inside a
+temp directory and the repository the scripts see is a copy. The isolation is by
+NAME, and its boundary is that list — a script that reached the network through
+some tool nobody thought to stub would reach it. What the harness guarantees is
+what the assertions need: the gate is a recording stub that can be told to fail,
+and every cloud CLI is a stub. It asserts three things about what each script
+DID:
+
+1. it called the gate, for its own cloud;
+2. with the gate failing, the script exits non-zero;
+3. it issues no further cloud CLI calls after the gate answered (the measured
+   form of "the check has to be the last thing it does").
+
+It also asserts that both of the gate's exit codes come out the far end
+unchanged — and, for `aws_eu_north_clickhouse.sh`, that they do so for an
+operator who has NOT set `TR_STOCKHOLM_REPLICA_WIRED`. That script ends by
+refusing to claim the Stockholm replica is wired until somebody attests to it,
+and that refusal used to overwrite the gate's status: on a first run, when
+nobody has ever set the variable, a gate exit of 5 and a gate exit of 1 both
+came out as 3. The propagation held only for the harness fixture, which supplies
+the variable so the script can reach its own end.
+
+**The two lists below are checked against `ROLLOUT_REGISTRY` for exact set
+equality** by `tests/test_deploy_script_execution.py` — path by path, not by
+substring. That is the point of writing them as lists: flipping a script from
+`PROVEN_BY_EXECUTION` to `NOT_PROVEN` silently deletes five parametrised
+behavioural cases from the suite, and for one revision the only thing standing
+in the way was a minimum reason length. It cost 121 characters of filler to go
+from 76 passing tests to 71, still green, with this document still calling the
+script proven. Now the registry cannot say `NOT_PROVEN` while this page says
+proven: moving a script between these lists fails CI until both move together,
+and the second move is a diff a reviewer reads.
+
+<!-- PROVEN_BY_EXECUTION:begin -->
+- `scripts/deploy/aws_eu_clickhouse.sh`
+- `scripts/deploy/aws_eu_control_plane.sh`
+- `scripts/deploy/aws_eu_north_clickhouse.sh`
+- `scripts/deploy/azure_control_plane.sh`
+- `scripts/deploy/verify_gcp_complete.sh`
+<!-- PROVEN_BY_EXECUTION:end -->
+
+**Not proven, and therefore only CLAIMED:**
+
+<!-- NOT_PROVEN:begin -->
+- `scripts/deploy/aws_eu_clickhouse_drain_install.sh`
+<!-- NOT_PROVEN:end -->
+
+Its middle ships a tarball to the node in base64 chunks over SSM and then reads
+the drain's own journal back to establish that rows moved; a stub SSM that
+answers `Status=Success` to everything would make that verification an assertion
+about the stub. It is recorded as `NOT_PROVEN` in `ROLLOUT_REGISTRY` with that
+reason, and a `NOT_PROVEN` entry with a blank reason fails CI. What *is* proven
+about it is that the shared fragment it calls —
+`scripts/deploy/cloud_complete_gate.sh` — returns the gate's exit status
+unaltered for every code the gate can produce. What is not proven is that a real
+run reaches that call.
+
+A smaller true claim beats a larger false one; that is the whole thesis here, so
+it applies to this section too.
+
+**GCP: `rollout.sh` is exempt, and GCP is not.** `rollout.sh` is not a script a
+human runs; it is a step of the deploy job in `.github/workflows/deploy.yml`,
+which runs on every merge to `main`. Ending *it* in this check would put a public
+fetch of `trustedrouter.com/status.json` in the middle of deploying the cloud
+that *serves* `trustedrouter.com` — the deploy that repairs an outage would
+abort partway, because of the outage it repairs. So `rollout.sh` carries a
+`ScriptExemption` with that reason in `ROLLOUT_REGISTRY`. That is a statement
+about which FILE ends in the gate. It is not permission for GCP to skip a stage;
+no such permission exists.
+
+For one revision it was more than that, and the gap is worth recording because
+it was the thesis of this whole change turned inside out. The compensating
+control was twenty lines of YAML inside that job, and the only thing binding it
+was a substring: the tests concatenated the job's `run:` blocks and looked for
+`verify_cloud_complete.sh gcp`. A reviewer replaced the entire body with
+`echo "Next: bash scripts/deploy/verify_cloud_complete.sh gcp"` and `exit 0`,
+and the suite stayed green at 76 passed — as it did for a commented-out line and
+for `|| true`. All three of the saboteur shapes this section exists to kill
+satisfied the one binding covering the primary cloud.
+
+So the job's body moved into `scripts/deploy/verify_gcp_complete.sh`, which is
+in GCP's `deploy_scripts` and is executed by the behavioural harness exactly
+like the other four: it calls the gate for `gcp`, it cannot exit 0 over a
+failing gate, it runs no cloud CLI afterwards, and both exit codes come out
+unchanged. The workflow step is now one line invoking that file, and CI requires
+it to be an exact invocation of a script the registry proves by execution — an
+`echo` of the command is not one.
+
+What stayed in YAML, because a workflow cannot be executed from a test: that the
+job exists, that it depends on `deploy`, and that it runs `if: always()`. Those
+are read as text out of `.github/workflows/deploy.yml`.
+
+`if: always()` on `needs: [deploy]` is load-bearing and was missing: with a bare
+`needs:`, GitHub SKIPS a job when its dependency fails, and a deploy that failed
+PARTWAY has already mutated production. **Its coverage, stated exactly:** every
+run in which the `deploy` job ran, whatever the result. Not "after every
+production mutation" — `migrate-schema` and `sync-runtime-secrets` run *before*
+`deploy` and mutate production, and the job is skipped when `deploy` is skipped,
+which is what happens when `confirm-current-main` says do not proceed. A run can
+migrate the schema, rotate runtime secrets, skip the deploy and never reach this
+check.
+
+Honest caveat, because this is a control that has never fired: it lands with
+this change and has not yet run on a merge.
+
+### There is no exemption
+
+Earlier revisions of this design had one: `analytics_absent_reason` on a cloud's
+entry in `src/trusted_router/cloud_rollout_completeness.py` waived the
+"structural" blockers, a verdict taxonomy decided which failures counted as
+structural, and a waived run printed `NOT VERIFIED` and exited 6.
+
+It is gone, machinery and all. Two rounds of review found bugs inside it rather
+than around it — one where the waiver path could not produce its own verdict at
+all and failed as "the gate could not classify its own output", one where the
+green banner was reachable on evidence this document says can never earn it —
+and the second set were regressions introduced by the fixes for the first. A
+mechanism whose failures upgrade a verdict has to earn its keep. This one did
+not.
+
+So: a cloud that cannot be checked is NOT VERIFIED. The run exits non-zero and
+prints the reason. To run a cloud without an analytics pipeline, run it and let
+the check say so; nothing in this repository will call it done.
+
+### Exit codes
+
+`scripts/deploy/cloud_complete_gate.sh` maps these to the same words for every
+bound script, so an operator is never told to fix an install that did not fail:
+
+| code | meaning |
+|---|---|
+| 0 | `VERIFIED` — every stage was measured and held |
+| 5 | `NOT YET OBSERVABLE` — the page parses and carries no `analytics` section |
+| 1 | `NOT VERIFIED` — everything else, with the reason printed: a stage failed, the page did not answer 200, the body was not the status document, the cloud is unknown, the arguments were wrong |
+
+There were seven. The rest collapsed into 1, which says why in words rather than
+in a number nobody looks up. 5 survives because it is the one non-zero answer an
+operator must not read as "your install failed": it is the state every cloud is
+in until a control plane that publishes the section is deployed, and the run
+that INSTALLS a drain hits it by construction. All five bound scripts report it
+in the same words, which is the reason the mapping is one shared file.
+
+The verdict itself is the exit status of each stage's own process — nothing is
+parsed out of a stream. That replaces a tab-separated sentinel line carrying one
+of eight `kind` values, which replaced classification-by-first-word. Both
+earlier contracts existed so that a passing run could be graded; with one green
+outcome there is nothing to grade.
+
+### What the check cannot do
+
+Six limits, stated because a gate that is trusted past its reach is worse than
+one that is not trusted at all:
+
+* **It starts from the tables.** A cloud that is in none of the deployment
+  tables `operational_analytics_fleet.deployment_sources()` reads — provisioned
+  by hand, serving traffic, named nowhere in `src/` — is invisible to all of
+  this, exactly as it is invisible to `/v1/regions` and the marketing map. Step 1
+  of the checklist below is unavoidable *for a cloud somebody adds properly*; it
+  is not a law of physics.
+* **Stage (e) reads this checkout, not the deployed revision** (above). It is
+  also the one judgement still made by reading text, and it is the weakest thing
+  in the gate: somebody who wants to beat it can, exactly as the old script
+  binding was beatable. It is kept because the alternative needs cloud
+  credentials, and a check that needs production credentials is a check nobody
+  runs.
+* **It cannot see rows move.** No status page can: an empty outbox and a
+  switched-off one publish the same number. That evidence is the two in-cloud
+  counts, and every passing run says so in the banner — not as a downgrade
+  earned by a stage, just as a fact about what the five stages are.
+* **One bound script's tail is claimed, not proven** —
+  `aws_eu_clickhouse_drain_install.sh`, above.
+* **GCP's job is half declaration.** What the check DOES is executed like every
+  other cloud's (`verify_gcp_complete.sh`). That the `verify-cloud-complete` job
+  exists, depends on `deploy` and runs `if: always()` is read as text out of
+  `.github/workflows/deploy.yml`, because nothing here can run a workflow. Its
+  coverage is every run in which `deploy` ran — not every production mutation;
+  see above.
+* **`bash -n` covers this repo's scripts, not a future one.** The parse check in
+  `tests/test_deploy_script_execution.py` walks `scripts/**/*.sh` with the local
+  shell, which is how the bash 3.2 heredoc-in-`$( )` bomb was found. It cannot
+  see a script somebody writes from the checklist below and has not committed,
+  and it does not run on the reviewer's machine's bash unless the reviewer runs
+  it.
+
+### What is missing right now
+
+**A cloud publishes the `analytics` section once a control plane built from the
+publisher is deployed to it, and not before.** Until then the gate exits 5 (NOT
+YET OBSERVABLE) — honest and red, which is the true state of that cloud rather
+than a defect in the gate.
+
+Do not read the fleet's state off this page. It is a document; the fleet moves
+under it, and this paragraph has already been wrong once. Ask:
+
+    bash scripts/deploy/verify_cloud_complete.sh gcp    # or aws, azure
+
+The last reading taken while editing this section: `gcp` VERIFIED, `aws` and
+`azure` both 5. That is a note about a moment, not a claim about now.
+
+**Azure has no operational-analytics outbox.** `azure_control_plane.sh` sets no
+`TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED` at all, so the cloud enqueues nothing,
+has nothing to drain, and stage (e) fails. It is a canary
+(`aws-eu-and-azure-canary.md` §3) and it still counts: a canary whose operational
+history is unrecorded cannot answer the question canaries exist to answer.
+
+### Checklist for the next cloud
+
+1. Add it to the deployment tables (`byok_v1_attestations.STANDALONE_CLOUDS`,
+   `regions.MULTICLOUD_REGION_GEO`, …). CI now fails until steps 2 and 3 are
+   done.
+2. Add a `FleetAnalyticsEndpoint` for it in
+   `src/trusted_router/operational_analytics_fleet.py`, pointing at the public
+   `/status.json` of its **control plane** — the deployment that holds the
+   database connection, which is not always the friendliest hostname. (AWS's is
+   the tr-eu App Runner service, not `aws.trustedrouter.com`.)
+3. Add a `CloudRollout` entry in
+   `src/trusted_router/cloud_rollout_completeness.py` naming its control-plane
+   deploy script and its drain install command.
+4. List every deploy script for it in that entry's `deploy_scripts`, and end
+   each of those scripts with
+
+       SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+       . "${SCRIPT_DIR}/cloud_complete_gate.sh"
+
+       read -r -d '' NEXT_STEPS <<'NEXT' || true
+       ...what to do about it...
+       NEXT
+       require_cloud_complete <cloud> "$NEXT_STEPS"
+
+   letting its exit status stand.
+
+   **Keep the heredoc out of a command substitution entirely.** A heredoc nested
+   inside `$( )` is a *syntax error* in bash 3.2 — `/bin/bash` on every macOS —
+   as soon as the body contains an apostrophe, and assigning the result to a
+   variable does not help: `NEXT_STEPS=$(cat <<'NEXT' ... NEXT )` is the same
+   bomb, which is what this checklist prescribed until it was checked against a
+   real 3.2. Verified on bash 3.2.57: the `$( )` form fails with `unexpected EOF
+   while looking for matching`, the `read -r -d ''` form above parses. (`read`
+   returns non-zero at EOF, hence `|| true` under `set -e`.) `aws_eu_clickhouse_drain_install.sh` was written that way and did
+   not parse at all on a Mac: the whole file did nothing, gate included, while
+   CI on Linux bash 5 stayed green. `tests/test_deploy_script_execution.py` runs
+   `bash -n` over `scripts/**/*.sh` with the local shell, which catches this in
+   *this* repository — it cannot catch it in a script you have written from this
+   page and not yet committed, so read the paragraph rather than relying on the
+   test.
+
+   Then add a fixture for it in `tests/deploy_script_harness.py` so the
+   behavioural test can run it; if it cannot be run honestly under stubs, mark it
+   `NOT_PROVEN` with the reason and move it into the `NOT_PROVEN` list above. CI
+   compares both lists on this page against `ROLLOUT_REGISTRY` for exact set
+   equality, so a script that changes proof status here fails until this page
+   changes with it.
+5. Build the pipeline: an outbox (enabled in the control-plane script), a
+   ClickHouse the cloud owns, and a drain installed as a supervised unit.
+6. Run `bash scripts/deploy/verify_cloud_complete.sh <cloud>` until it exits 0
+   and prints `VERIFIED`, then do the thing the banner tells you it did not do:
+   watch two counts ten minutes apart from inside the cloud.

--- a/scripts/deploy/aws_eu_clickhouse.sh
+++ b/scripts/deploy/aws_eu_clickhouse.sh
@@ -169,7 +169,60 @@ echo
 echo "CLICKHOUSE_PRIVATE_URL=http://${PRIVATE_IP}:8123"
 echo "VPC_CONNECTOR_ARN=${CONNECTOR_ARN}"
 echo "INSTANCE_ID=${INSTANCE_ID}"
+
+# ---------------------------------------------------------------------------
+# 5. Does the CLOUD work, or did only this script finish?
+#
+# This block used to be three `echo "Next: ..."` lines and an exit 0. That is
+# the whole outage: on 2026-08-02 someone ran this script, read the echoes, and
+# stopped. The node existed, the connector existed, and no drain was ever
+# installed — so for fifteen days settle enqueued rows into DSQL that nothing
+# collected (470,897 of them) while every alarm stayed quiet, because the
+# backlog alarm is emitted BY the drain that was missing.
+#
+# The remaining steps are still human steps: they need the ClickHouse password
+# and a redeploy decision. What changes is the exit code. A finished script and
+# a working cloud are now the same thing, or this exits non-zero saying which
+# one you have.
+#
+# require_cloud_complete returns the gate's status unaltered, so this script's
+# exit status IS the gate's. tests/test_deploy_script_execution.py runs this
+# whole file under a stub PATH — isolation by name, not a sandbox — and asserts
+# both halves: the gate is called for aws, and a failing gate makes this script
+# exit non-zero.
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/cloud_complete_gate.sh
+. "${SCRIPT_DIR}/cloud_complete_gate.sh"
+
+NEXT_STEPS=$(cat <<NEXT
+
+The node is up but the AWS cloud is NOT complete. Run these, in order, and this
+script will exit 0 the next time it is run:
+
+  1. apply the schema to the node (from inside the VPC):
+       for f in clickhouse/00*.sql; do
+         clickhouse-client --host ${PRIVATE_IP} --user default --multiquery < "\$f"
+       done
+
+  2. redeploy the control plane so settle enqueues and the outbox is readable.
+     Its own knobs, not the TR_* names — it builds those:
+       CLICKHOUSE_URL=http://${PRIVATE_IP}:8123 \\
+       VPC_CONNECTOR_ARN=${CONNECTOR_ARN} \\
+       bash scripts/deploy/aws_eu_control_plane.sh
+     (EgressConfiguration=VPC follows from a non-empty VPC_CONNECTOR_ARN.)
+
+  3. install the process that actually MOVES rows — the step that was missed:
+       bash scripts/deploy/aws_eu_clickhouse_drain_install.sh
+
+  4. re-run this script, or just the check:
+       bash scripts/deploy/verify_cloud_complete.sh aws
+
+NEXT
+)
+
+require_cloud_complete aws "$NEXT_STEPS"
 echo
-echo "Next: apply clickhouse/*.sql, then redeploy tr-eu with"
-echo "  TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_URL=http://${PRIVATE_IP}:8123"
-echo "  EgressConfiguration=VPC + the connector above."
+echo "The node is up and the gate VERIFIED aws — read its banner above for what"
+echo "that does and does not establish. This script does not restate it in"
+echo "stronger words than it earned."

--- a/scripts/deploy/aws_eu_clickhouse_drain_install.sh
+++ b/scripts/deploy/aws_eu_clickhouse_drain_install.sh
@@ -419,3 +419,79 @@ Rollback: systemctl disable --now $SERVICE, then
   mv ${REMOTE_ROOT}.previous $REMOTE_ROOT   (kept from this run)
 Nothing is lost by stopping the drain: undelivered rows stay in the outbox.
 EOF
+
+# ---------------------------------------------------------------------------
+# 10. The outside view.
+#
+# Step 9 ran systemctl, the journal and a ClickHouse count on the node and
+# PRINTED them. Be exact about what that is: this script does not assert on any
+# of those three outputs, so what step 9 establishes is that the commands ran —
+# a human still has to read `copies=`, `rows=` and the two counts and decide.
+# An earlier version of the paragraph below said the run had established that
+# the unit "swept, and moved rows out of the outbox", which is the same
+# printing-is-doing mistake one level down, inside the file written to end it.
+#
+# What the gate below adds is the question a rollout has to answer and no
+# in-VPC command can: whether anyone WITHOUT a session on that node can tell.
+# Ending here means an install visible only from the installer's shell cannot
+# be mistaken for a finished cloud.
+#
+# Non-zero on failure on purpose: this script's whole reason for existing is
+# that the previous version of this step was a paragraph of prose and an exit 0.
+# require_cloud_complete returns the gate's status unaltered, including 5 (NOT
+# YET OBSERVABLE), which is today's expected state on the very run that fixes
+# the outage — no deployed control plane on this cloud publishes the `analytics`
+# section yet, so an unqualified failure would be a red banner the operator can
+# do nothing about, every time, by design. All five bound scripts report that
+# state in the same words now; the extra paragraph below is the part specific to
+# having just installed a drain.
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/cloud_complete_gate.sh
+. "${SCRIPT_DIR}/cloud_complete_gate.sh"
+
+# The next-steps text is built with a plain heredoc into a variable, NOT as
+# "$(cat <<'NEXT' ... )". Nesting a heredoc inside a command substitution is a
+# syntax error in bash 3.2 -- which is /bin/bash on every macOS -- as soon as
+# the BODY contains an apostrophe: the parser looks for a matching quote inside
+# the substitution and runs off the end of the file. This body said "step 9's
+# output", so on a Mac this entire script failed to parse and did nothing at
+# all, gate included, while CI (Linux, bash 5) stayed green. The script whose
+# absence caused the outage could not be run by the person most likely to run
+# it. tests/test_deploy_script_execution.py now parses every deploy script with
+# the local shell, so a repeat is caught wherever the old shell is.
+NEXT_STEPS='The drain install itself did not fail. Read step 9 output above before
+touching anything: copies=, drain_lag_seconds, and the two ClickHouse
+counts are printed there and asserted nowhere.'
+
+VERIFY_RC=0
+require_cloud_complete aws "$NEXT_STEPS" || VERIFY_RC=$?
+
+if [ "$VERIFY_RC" -eq 5 ]; then
+  cat >&2 <<'PREDEPLOY'
+
+DRAIN INSTALLED; NOT YET OBSERVABLE FROM OUTSIDE.
+
+What this run did: shipped the code, installed and enabled the unit, and then
+printed the drain's journal and a ClickHouse row count from the node (step 9).
+Read those. Nothing in this script asserts on them.
+
+What it could not do at all: tell whether anyone WITHOUT a session on this node
+can see the drain. The tr-eu App Runner control plane -- the deployment holding
+the Aurora DSQL connection, whose /status.json is the URL in
+src/trusted_router/operational_analytics_fleet.py -- publishes no `analytics`
+section, because no control plane deployed to this cloud is built from a commit
+that includes trusted_router.operational_analytics_freshness. Until then the
+drain's health is visible only to whoever is logged in, which is the property
+that let it be missing for fifteen days.
+
+To close it:
+
+  1. deploy a control plane built from a commit that publishes the section:
+       bash scripts/deploy/aws_eu_control_plane.sh
+  2. bash scripts/deploy/verify_cloud_complete.sh aws
+
+PREDEPLOY
+fi
+
+exit "$VERIFY_RC"

--- a/scripts/deploy/aws_eu_control_plane.sh
+++ b/scripts/deploy/aws_eu_control_plane.sh
@@ -364,3 +364,36 @@ PY
   aws events put-targets --region "$REGION" --rule tr-eu-synthetic-1min --targets "$TARGETS" >/dev/null
   log "rule aligned: rotation_count=8, full catalogue (unpinned)"
 fi
+
+# ---------------------------------------------------------------------------
+# The deploy is not done until the CLOUD is done.
+#
+# This script is the source of truth for the service env, and the env it sets
+# includes TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED — so from 2026-08-02 it was
+# faithfully enqueueing operational rows into DSQL while no drain existed to
+# collect them. Every part of this file succeeded. The cloud did not work.
+#
+# Ending here makes those the same claim. It is READ-ONLY (one public HTTPS GET
+# plus a text read of this file) and provisions nothing; if it fails, the
+# service that was just deployed stays deployed and the message names what is
+# still missing.
+#
+# require_cloud_complete returns the gate's status unaltered, and this is the
+# last statement in the file, so under `set -e` this script's exit status IS the
+# gate's — including 5 (NOT YET OBSERVABLE), which is not a plain failure and
+# which it reports in the same words as every other bound script.
+# tests/test_deploy_script_execution.py runs this whole file under a stub PATH
+# — isolation by name, not a sandbox — and asserts both halves.
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/cloud_complete_gate.sh
+. "${SCRIPT_DIR}/cloud_complete_gate.sh"
+
+require_cloud_complete aws "$(cat <<'NEXT'
+The service is deployed but the AWS cloud is not complete. Most often this is
+the drain — the step that has been missed before:
+
+  bash scripts/deploy/aws_eu_clickhouse_drain_install.sh
+  bash scripts/deploy/verify_cloud_complete.sh aws
+NEXT
+)"

--- a/scripts/deploy/aws_eu_north_clickhouse.sh
+++ b/scripts/deploy/aws_eu_north_clickhouse.sh
@@ -575,3 +575,56 @@ echo "public_analytics_snapshots; on this cloud nothing does today"
 echo "(those are GCP timers), so both nodes hold them empty."
 echo "If a rollup or snapshot job is ever run against Paris, its output is NOT"
 echo "on this node and this node is not a complete copy until it is."
+
+# ---------------------------------------------------------------------------
+# The exit code, which is the only part of the above a pipeline can read.
+#
+# Everything printed so far is a HUMAN step: it needs a shell on the Paris node
+# and the Stockholm password. Printing it and returning 0 is exactly how the
+# Paris drain came to not exist for fifteen days — a script said its piece,
+# exited successfully, and nothing anywhere disagreed. So this ends by
+# checking the cloud, and then by refusing to claim the replica is wired until
+# somebody says it is.
+#
+# TR_STOCKHOLM_REPLICA_WIRED=1 is that attestation. It is deliberately a
+# statement an operator makes AFTER watching the drain log 'copies=2
+# degraded_targets=-', not something this script can infer: from here, a
+# second node that is provisioned and a second node that is receiving rows
+# look identical.
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/cloud_complete_gate.sh
+. "${SCRIPT_DIR}/cloud_complete_gate.sh"
+
+COMPLETE=0
+require_cloud_complete aws || COMPLETE=$?
+
+# The gate's answer wins, and it wins FIRST. Written the other way round, this
+# script returned 3 for an unwired replica whatever the gate had said — and
+# since a first-run operator has never set TR_STOCKHOLM_REPLICA_WIRED, that was
+# every first run. The claim "this script's exit status is the gate's" then held
+# only for the fixture in tests/deploy_script_harness.py, which sets the
+# variable so the script can reach its own end. A claim that is true of the test
+# and false of the operator is the shape of defect this whole change is about.
+if [ "$COMPLETE" -ne 0 ]; then
+  exit "$COMPLETE"
+fi
+
+if [ "${TR_STOCKHOLM_REPLICA_WIRED:-0}" != "1" ]; then
+  cat >&2 <<NEXT
+
+STOCKHOLM NOT WIRED. The node exists; the drain does not know about it, so this
+is one copy of the history, not two. Do the steps printed above on the PARIS
+node, watch for 'copies=2 degraded_targets=-' in
+
+  journalctl -u tr-clickhouse-operational-ingest-postgres -f | grep outbox.metrics
+
+and then record it by re-running:
+
+  TR_STOCKHOLM_REPLICA_WIRED=1 bash scripts/deploy/aws_eu_north_clickhouse.sh
+
+NEXT
+  exit 3
+fi
+
+exit "$COMPLETE"

--- a/scripts/deploy/azure_control_plane.sh
+++ b/scripts/deploy/azure_control_plane.sh
@@ -326,3 +326,46 @@ cat >&2 <<NOTE
                 model — which is the whole point of measuring it here.
   verify        bash scripts/deploy/verify_deployment.sh (cloud-agnostic)
 NOTE
+
+# ---------------------------------------------------------------------------
+# ...and then the part that is NOT a note.
+#
+# Everything above provisions a control plane that serves, measures itself, and
+# publishes a status page. None of it gives this cloud an operational-analytics
+# pipeline: the ENV_VARS block sets no TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED,
+# so settle enqueues nothing, there is no outbox to drain, and no drain. On AWS
+# that same gap ran for fifteen days behind an entirely green status page
+# because the only alarm is emitted by the missing process.
+#
+# So this deploy now ends by asking whether the CLOUD works rather than whether
+# the script finished, and today, on Azure, it says no. That is the correct
+# answer, and no variable this script inherits changes it: the verifier's bound
+# is a constant in src/ and its URL comes from the fleet registry, and the two
+# variables it reads at all -- TR_MAX_DRAIN_LAG_SECONDS and TR_STATUS_URL -- it
+# reads only in order to print that they are being IGNORED. (An earlier version
+# of this comment said the verifier "reads no environment variable at all",
+# which was a tidier sentence and not true.) It takes no flags either.
+#
+# The only way to make this exit 0 is to build the pipeline. There is no
+# exemption, no waiver and no registry field that excuses a stage: a cloud that
+# cannot be checked is NOT VERIFIED and this script exits non-zero.
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/cloud_complete_gate.sh
+. "${SCRIPT_DIR}/cloud_complete_gate.sh"
+
+require_cloud_complete azure "$(cat <<'NEXT'
+The Azure app is deployed and serving. The Azure CLOUD is not complete: it has
+no operational-analytics pipeline at all. To finish it:
+
+  1. give it somewhere to drain TO (a ClickHouse this cloud owns, mirroring
+     scripts/deploy/aws_eu_clickhouse.sh) — this is a COST decision, so it is
+     not made by a deploy script;
+  2. add to the ENV_VARS block in this file:
+       TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true
+       TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_URL=...  (+ user/database/password)
+  3. install a drain against it, mirroring
+     scripts/deploy/aws_eu_clickhouse_drain_install.sh;
+  4. bash scripts/deploy/verify_cloud_complete.sh azure
+NEXT
+)"

--- a/scripts/deploy/cloud_complete_gate.sh
+++ b/scripts/deploy/cloud_complete_gate.sh
@@ -1,0 +1,97 @@
+# shellcheck shell=bash
+# The completeness gate, as ONE function every bound deploy script calls.
+#
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   . "${SCRIPT_DIR}/cloud_complete_gate.sh"
+#
+#   NEXT_STEPS=$(cat <<'NEXT'
+#   ...what to do about it, printed only if the gate says no...
+#   NEXT
+#   )
+#   require_cloud_complete aws "$NEXT_STEPS"
+#
+# WHY THIS IS SHARED AND NOT COPIED
+# ---------------------------------
+# verify_cloud_complete.sh has two non-zero answers, and they mean different
+# things to an operator:
+#
+#   5  NOT YET OBSERVABLE — the cloud answers, but publishes no `analytics`
+#      section, so nobody outside can see its drain at all. On the run that
+#      INSTALLS a drain, today, this is the expected state and the installer did
+#      nothing wrong.
+#   1  NOT VERIFIED, for every other reason, with the reason printed by the
+#      verifier itself.
+#
+# Exactly one of five bound scripts used to understand code 5, so the other four
+# reported today's real state as a flat install failure with a fix instruction
+# that would not have fixed it. That is how you teach someone to stop reading
+# exit codes, which is the habit this whole change exists to break. Either all
+# of them understand the codes or none of them do — so the mapping lives here,
+# once, and every bound script gets the same words.
+#
+# WHAT THIS FUNCTION GUARANTEES
+# -----------------------------
+# It returns the verifier's exit status, unaltered. It never converts a non-zero
+# answer into a zero one, and there is no argument, environment variable or
+# input that makes it do so. `tests/test_deploy_script_execution.py` runs this
+# file against a stub verifier that is told to fail, and asserts the caller
+# exits non-zero — that assertion is the reason this file exists.
+#
+# WHICH VERIFIER IT RUNS IS NOT AN INPUT
+# --------------------------------------
+# The path is the verifier sitting next to this file, resolved from
+# BASH_SOURCE, and there is no way to point it elsewhere. A previous revision
+# read CLOUD_COMPLETE_GATE_DIR from the environment "for the test harness",
+# which made every bound deploy script — each of which inherits its operator's
+# whole environment — redirectable to any script on the machine by one export.
+# The harness needs no such hook: it runs the scripts against a mirrored
+# checkout whose own verify_cloud_complete.sh is the recording stub, so
+# BASH_SOURCE resolution finds it.
+
+require_cloud_complete() {
+  local cloud="${1:?require_cloud_complete needs a cloud id}"
+  local next_steps="${2:-}"
+  local here rc=0
+
+  here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  bash "${here}/verify_cloud_complete.sh" "$cloud" </dev/null || rc=$?
+
+  if [ "$rc" -eq 0 ]; then
+    return 0
+  fi
+
+  if [ "$rc" -eq 5 ]; then
+    cat >&2 <<EOF
+
+NOT YET OBSERVABLE FROM OUTSIDE (${cloud}).
+
+Whatever this script just did is not what failed. ${cloud} answers its status
+URL and publishes no \`analytics\` section, so its drain's health is visible
+only to whoever is logged in to the node — which is the property that let the
+AWS-EU drain be missing for fifteen days.
+
+To close it, deploy a control plane built from a commit that includes
+trusted_router.operational_analytics_freshness, then re-run:
+
+  bash scripts/deploy/verify_cloud_complete.sh ${cloud}
+
+Exiting ${rc}, not 0: a pipeline nobody outside can see is not a finished cloud.
+EOF
+  else
+    cat >&2 <<EOF
+
+NOT VERIFIED (${cloud}).
+
+The completeness check did not pass, and it printed which stage and why above.
+Nothing here excuses a stage: this cloud is not finished until the check exits
+0 on its own.
+
+Exiting ${rc}, not 0.
+EOF
+  fi
+
+  if [ -n "$next_steps" ]; then
+    printf '%s\n' "$next_steps" >&2
+  fi
+  return "$rc"
+}

--- a/scripts/deploy/verify_cloud_complete.sh
+++ b/scripts/deploy/verify_cloud_complete.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+# Is this cloud's rollout COMPLETE? Executable definition of done.
+#
+#   bash scripts/deploy/verify_cloud_complete.sh aws
+#   bash scripts/deploy/verify_cloud_complete.sh azure
+#   bash scripts/deploy/verify_cloud_complete.sh gcp
+#
+# WHY THIS EXISTS
+# ---------------
+# From 2026-08-02 to 2026-08-17 the AWS-EU cloud served production traffic with
+# NO analytics pipeline: the drain that moves rows from the DSQL outbox into
+# ClickHouse had never been installed, 470,897 rows accumulated, and
+# `SELECT count() FROM activity_generations` returned 0. Nothing reported it,
+# because the only backlog alarm is emitted BY the drain that was missing.
+#
+# The proximate cause was not a missing monitor. It was
+# scripts/deploy/aws_eu_clickhouse.sh, which ends by PRINTING
+#
+#     echo "Next: apply clickhouse/*.sql, then redeploy tr-eu with"
+#
+# and exiting 0. A human ran it, read the echoes, and stopped. "The script
+# finished" and "the cloud works" were different things. This script is what
+# makes them the same thing: bring-up scripts for a cloud call
+# require_cloud_complete (scripts/deploy/cloud_complete_gate.sh), which runs
+# this and returns its exit status unaltered.
+#
+# WHAT IT COSTS TO RUN
+# --------------------
+# One HTTPS GET of a public status page, and a text read of a deploy script in
+# this repository. No credentials, no cloud CLI.
+#
+# What it writes: one mktemp file holding the fetched body, removed on exit. And
+# — worth saying plainly, because an earlier version of this paragraph claimed
+# the mktemp file was the only thing written anywhere and that was false — if
+# this checkout has no `.venv/bin/python`, the judgements run under `uv run`,
+# which creates and refreshes a virtualenv and a package cache like any other
+# uv invocation. That is a normal developer-machine side effect, not a cloud
+# mutation; nothing here writes to any cloud, and nothing writes into the
+# checkout except by way of uv's own venv. (It used to drop __pycache__ into
+# src/ as well, on the .venv branch; PYTHONDONTWRITEBYTECODE closes that.)
+#
+# It provisions nothing and repairs nothing; it refuses to agree that an
+# incomplete cloud is finished.
+#
+# NOTHING HERE IS CONFIGURABLE — NOT FROM THE ENVIRONMENT, NOT FROM A FLAG
+# ------------------------------------------------------------------------
+# Deploy scripts run this, and a deploy script inherits every variable the
+# operator's shell exported. So an env-tunable bound is not a knob, it is a
+# remote control for the gate: `export TR_MAX_DRAIN_LAG_SECONDS=99999999` once,
+# and a cloud with 470,897 rows rotting in its outbox reports success. An
+# earlier draft of this file read exactly that variable, and TR_STATUS_URL too,
+# which pointed the whole check at any page that answered the way you wanted.
+#
+# Both are gone, and so are the `--max-lag-seconds` / `--status-url` flags that
+# replaced them: a flag needs its own "this run is only a diagnosis" outcome to
+# be safe, and an outcome that exists to make another outcome safe is the kind
+# of machinery this file has now twice had bugs in. The bound is the constant
+# DEFAULT_MAX_DRAIN_LAG_SECONDS in
+# src/trusted_router/cloud_rollout_completeness.py and the URL comes from the
+# fleet registry in src/trusted_router/operational_analytics_fleet.py. To ask a
+# different question, fetch the URL with curl yourself.
+#
+# To be precise about the claim, because a sweeping one was printed here before
+# and was not true: this script reads PATH, HOME and the usual things any
+# process reads, and it reads TR_MAX_DRAIN_LAG_SECONDS and TR_STATUS_URL for the
+# sole purpose of telling you loudly that they are IGNORED. No environment
+# variable and no argument changes a verdict.
+#
+# HOW IT READS ITS OWN JUDGEMENTS
+# -------------------------------
+# Every judgement is made in Python, one subprocess per stage, and the contract
+# is the exit status: 0 means the stage held, anything else means it did not.
+# Nothing is parsed out of a stream, so no DeprecationWarning, pip notice or
+# library that writes to stdout on import can change an outcome. Each stage's
+# stdout is collected and reprinted verbatim under the outcome as NOTES; its
+# stderr is the operator's explanation and goes straight through.
+#
+# This replaces a tab-separated sentinel line carrying one of eight `kind`
+# values, which replaced classification-by-first-word. Two reviews found bugs in
+# the taxonomy itself. A smaller true claim beats a larger false one.
+#
+# EXIT CODES
+# ----------
+#   0  VERIFIED: every stage was measured and held.
+#   5  NOT YET OBSERVABLE: this cloud's status page parses and publishes no
+#      analytics section at all, so the question cannot be asked from outside
+#      yet. Its own code because it is the state EVERY cloud is in until a
+#      control plane that publishes the section is deployed, and because the run
+#      that installs a drain hits it by construction — reporting that as "your
+#      install failed" is how an operator learns to ignore exit codes. It is
+#      still a failure: a cloud nobody can see is not a finished cloud.
+#   1  NOT VERIFIED, for every other reason, with the reason printed: a stage
+#      measured and failed, the page did not answer 200, the body was not the
+#      status document, the cloud is unknown, the arguments were wrong.
+#
+# scripts/deploy/cloud_complete_gate.sh turns both non-zero codes into the same
+# words for every caller.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+EXIT_NOT_VERIFIED=1
+EXIT_NOT_OBSERVABLE=5
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: verify_cloud_complete.sh <cloud>
+
+  <cloud>   cloud id as the deployment tables spell it: aws | azure | gcp
+
+There are no options. The lag bound and the status URL are fixed in code, on
+purpose: a deploy script inherits its caller's environment and would inherit a
+knob with it. See the header of this file.
+USAGE
+}
+
+CLOUD=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    -*) echo "unknown option: $1 (this script takes none)" >&2; usage; exit "$EXIT_NOT_VERIFIED" ;;
+    *)
+      [ -z "$CLOUD" ] || { echo "only one cloud at a time" >&2; usage; exit "$EXIT_NOT_VERIFIED"; }
+      CLOUD="$1"; shift ;;
+  esac
+done
+[ -n "$CLOUD" ] || { usage; exit "$EXIT_NOT_VERIFIED"; }
+
+# A variable that USED to work must not fail silently: someone with it exported
+# would otherwise believe it still applies. Say plainly that it is ignored, and
+# do not offer a flag instead, because there is no longer one to offer.
+warn_ignored_env() {
+  [ -n "$2" ] || return 0
+  printf 'IGNORED: %s=%s is set in the environment. This gate takes no input from\n' "$1" "$2" >&2
+  printf '         the environment and has no flag for it either; %s.\n' "$3" >&2
+}
+warn_ignored_env TR_MAX_DRAIN_LAG_SECONDS "${TR_MAX_DRAIN_LAG_SECONDS:-}" \
+  "the bound is DEFAULT_MAX_DRAIN_LAG_SECONDS in src/trusted_router/cloud_rollout_completeness.py"
+warn_ignored_env TR_STATUS_URL "${TR_STATUS_URL:-}" \
+  "the URL is this cloud's entry in src/trusted_router/operational_analytics_fleet.py"
+
+log() { printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*" >&2; }
+
+# Non-zero and loud. The failure mode this whole file exists to prevent is a
+# script that says its piece and returns 0, so every exit path below that is
+# not a verified cloud goes through one of these two.
+die() {
+  printf '\n' >&2
+  printf 'NOT VERIFIED — %s is not VERIFIABLY in service\n' "$CLOUD" >&2
+  printf '%s\n' "$*" >&2
+  printf '\n' >&2
+  printf 'The stage output above says what failed and what to do about it. There is\n' >&2
+  printf 'no way to excuse a stage: a cloud that cannot be checked is not done. See\n' >&2
+  printf 'docs/storage-portability/multi-cloud-separation.md\n' >&2
+  printf '("Adding a cloud: the definition of done").\n' >&2
+  exit "$EXIT_NOT_VERIFIED"
+}
+
+# Stage (b) failing has its own exit because it has its own MEANING. Every other
+# failure says "this cloud is broken"; this one says "no deployed control plane
+# publishes the analytics section, so no one outside can ask". Reporting that as
+# a plain failure is how you teach an operator to ignore exit codes: the run
+# that INSTALLS the drain and watches rows move from inside the VPC would end in
+# a red "your install failed" it can do nothing about, every time, by design.
+# It is still non-zero: a cloud nobody can see is not done.
+not_observable() {
+  printf '\n' >&2
+  printf 'NOT YET OBSERVABLE — %s answers, but not about analytics\n' "$CLOUD" >&2
+  printf '%s\n' "$*" >&2
+  printf '\n' >&2
+  printf 'This is not a claim that the pipeline is broken, and not a failure of\n' >&2
+  printf 'whatever just ran: it is the absence of the published field the check\n' >&2
+  printf 'reads. Until a control plane built from a commit that publishes it is\n' >&2
+  printf 'deployed to %s, this cloud cannot be verified from outside at all.\n' "$CLOUD" >&2
+  exit "$EXIT_NOT_OBSERVABLE"
+}
+
+# The judgements all live in src/trusted_router/cloud_rollout_completeness.py so
+# they can be unit-tested without a network. This shell owns the ordering, the
+# single fetch, and the exit status.
+if [ -x "${REPO_ROOT}/.venv/bin/python" ]; then
+  PYTHON_CMD=("${REPO_ROOT}/.venv/bin/python")
+elif command -v uv >/dev/null 2>&1; then
+  PYTHON_CMD=(uv run --quiet python)
+else
+  PYTHON_CMD=(python3)
+fi
+
+# NOT `2>&1`. The stage's human text goes to this script's stderr, where an
+# operator reads it as it happens; stdout is collected as notes. Merging them is
+# what let one stray interpreter line rewrite a verdict, back when a verdict was
+# something read out of a stream rather than an exit status.
+#
+# PYTHONDONTWRITEBYTECODE because this runs from a checkout: without it the
+# .venv branch leaves __pycache__ directories inside src/trusted_router/, i.e. a
+# read-only check writing into the repository it is reading. The header above
+# says what this script writes, and that has to stay a short list.
+tr_py() {
+  (cd "$REPO_ROOT" && PYTHONPATH=src:. PYTHONDONTWRITEBYTECODE=1 "${PYTHON_CMD[@]}" \
+    -m trusted_router.cloud_rollout_completeness "$@")
+}
+
+# Everything each passing stage asked to have printed under the outcome,
+# verbatim and unclassified. These do not change what the run may claim; the
+# banner below is written so that it is true with or without them.
+NOTES=""
+
+# Every stage: run it, and act on its EXIT STATUS. 0 held, 5 is stage (b)'s
+# "nobody can see this cloud yet", anything else is a failure. There is nothing
+# to classify and nothing that can be misclassified.
+stage() {
+  local label="$1" claim="$2"; shift 2
+  local step="${label%%:*}"
+  local out rc=0
+  out="$(tr_py "$@")" || rc=$?
+  case "$rc" in
+    0)
+      log "(${step}) ${claim}"
+      if [ -n "$out" ]; then
+        while IFS= read -r line; do
+          [ -n "$line" ] || continue
+          log "(${step}) note: ${line}"
+          NOTES="${NOTES}  (${step}) ${line}
+"
+        done <<<"$out"
+      fi
+      ;;
+    "$EXIT_NOT_OBSERVABLE")
+      not_observable "$(printf '(%s) see the lines above' "$label")" ;;
+    *)
+      die "$(printf '(%s) failed — see the lines above' "$label")" ;;
+  esac
+}
+
+printf '\n=== cloud rollout completeness: %s\n\n' "$CLOUD" >&2
+
+# ---------------------------------------------------------------------------
+# (a) Is this cloud in the registry the fleet check reads?
+#
+# First because it is the only stage whose failure means the others cannot even
+# be asked: it is what supplies the URL the rest of the run fetches. The
+# registry is imported from src/ — this script never carries its own list of
+# clouds, so a cloud added to the deployment tables cannot be invisible here.
+#
+# The claim printed here used to be "somebody reads this cloud's drain lag on a
+# schedule", and nobody does: .github/workflows/check-analytics-freshness.yml
+# ships with `workflow_dispatch` as its ONLY trigger, deliberately and in its
+# own header, until every cloud publishes the section. So this stage passing
+# means the cloud is registered and reachable, not that anything is watching it.
+# ---------------------------------------------------------------------------
+stage "a: fleet freshness registry" \
+  "this cloud has a status endpoint in the registry the fleet check reads (that check has no schedule trigger today — it runs on manual dispatch)" \
+  registry --cloud "$CLOUD"
+
+# The one place a stage's stdout is CONSUMED rather than reprinted. It still
+# carries no authority to pass anything: a line that is not an https:// URL ends
+# the run, and the only thing a URL can do downstream is be fetched.
+URL_RC=0
+STATUS_URL="$(tr_py status-url --cloud "$CLOUD" | tail -n 1)" || URL_RC=$?
+[ "$URL_RC" -eq 0 ] || die "(a) could not resolve a status URL for ${CLOUD}"
+case "$STATUS_URL" in
+  https://*) ;;
+  *) die "(a) the registry answered '${STATUS_URL}', which is not an https:// URL" ;;
+esac
+log "(a) registry URL: ${STATUS_URL}"
+
+# ---------------------------------------------------------------------------
+# (b) Does the cloud publish an answer? The one network call.
+# ---------------------------------------------------------------------------
+BODY="$(mktemp)"
+trap 'rm -f "$BODY"' EXIT
+HTTP_CODE="$(curl -sS -o "$BODY" -w '%{http_code}' --max-time 30 "$STATUS_URL" 2>/dev/null || true)"
+if [ "$HTTP_CODE" != "200" ]; then
+  die "(b) GET ${STATUS_URL} returned '${HTTP_CODE}' — the control plane is not
+serving its public status page, so nothing downstream can be checked.
+Fix: deploy this cloud's control plane and confirm ${STATUS_URL} answers 200."
+fi
+stage "b: analytics section published" "/status.json carries the analytics section" \
+  section --cloud "$CLOUD" --status-file "$BODY"
+
+# ---------------------------------------------------------------------------
+# (c) Could the control plane actually read its outbox? "Unavailable" is NOT
+#     "empty": collapsing the two turns a broken database connection green.
+# ---------------------------------------------------------------------------
+stage "c: analytics available" "analytics.available is true" \
+  available --cloud "$CLOUD" --status-file "$BODY"
+
+# ---------------------------------------------------------------------------
+# (d) Are rows leaving the outbox, and is the number about NOW?
+#
+# No bound is passed, because there is no bound to pass: the number comes from
+# DEFAULT_MAX_DRAIN_LAG_SECONDS in the Python module, which is the bound the
+# drain itself alarms on.
+# ---------------------------------------------------------------------------
+stage "d: drain lag" "drain_lag_seconds within the bound the drain alarms on" \
+  lag --cloud "$CLOUD" --status-file "$BODY"
+
+# ---------------------------------------------------------------------------
+# (e) Producer side. With the outbox off, nothing is ever enqueued, the lag is
+#     0.0 forever, and every stage above passes over a pipeline that carries no
+#     rows. This is the stage Azure fails today.
+# ---------------------------------------------------------------------------
+stage "e: control-plane outbox enabled" \
+  "the control-plane script in this checkout does not switch the outbox off" \
+  outbox --cloud "$CLOUD"
+
+# ---------------------------------------------------------------------------
+# The outcome. One sentence, and it has to be true of every run that reaches it.
+#
+# It used to be "COMPLETE: <cloud> publishes a live analytics pipeline", printed
+# unless a stage came back with a "caveat" kind — and the only caveat that could
+# have downgraded it was read off a field (outbox_depth) that no storage backend
+# in this repository populates. So the strong sentence was what a passing run
+# always printed, including over an outbox nothing had ever been enqueued into.
+#
+# So there is no strong sentence and no downgrade to get wrong. What the stages
+# establish is stated once, with what they do not establish next to it, and the
+# notes each stage asked for are printed verbatim underneath.
+# ---------------------------------------------------------------------------
+printf '\nVERIFIED — %s passed every stage of the completeness check (%s)\n\n' \
+  "$CLOUD" "$STATUS_URL" >&2
+printf 'That means: this cloud has an endpoint in the fleet registry, publishes\n' >&2
+printf 'its analytics section, could read its own outbox, has a drain lag under\n' >&2
+printf 'the bound the drain itself alarms on, and its control-plane script in\n' >&2
+printf 'THIS CHECKOUT does not switch the outbox off. That last one is a static\n' >&2
+printf 'read: where the script computes the value at deploy time — AWS sets it\n' >&2
+printf 'from whether a ClickHouse secret exists in the region, and can set it\n' >&2
+printf 'FALSE — the stage proves only that the script can enable it. The note\n' >&2
+printf 'below says so whenever that is what happened.\n\n' >&2
+printf 'It does not mean rows were seen moving. No public status page can show\n' >&2
+printf 'that. The remaining evidence is in-cloud and it is two numbers ten\n' >&2
+printf 'minutes apart: SELECT count() FROM activity_generations.\n' >&2
+if [ -n "$NOTES" ]; then
+  printf '\nNotes from the stages, verbatim:\n%s' "$NOTES" >&2
+fi
+printf '\n' >&2

--- a/scripts/deploy/verify_gcp_complete.sh
+++ b/scripts/deploy/verify_gcp_complete.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# GCP's completeness check, as a SCRIPT — so that it is proven the same way as
+# every other cloud's, by being run.
+#
+#   bash scripts/deploy/verify_gcp_complete.sh
+#
+# WHY THIS FILE EXISTS AT ALL
+# ---------------------------
+# GCP is the primary cloud and the one whose deploy script (rollout.sh) is
+# deliberately NOT ended in the gate: rollout.sh is a STEP of the deploy job in
+# .github/workflows/deploy.yml, and a public HTTPS fetch of
+# trustedrouter.com/status.json in the middle of deploying the cloud that SERVES
+# trustedrouter.com would abort the deploy that repairs an outage, partway,
+# because of the outage it repairs. So the gate runs out of band, after the
+# deploy job.
+#
+# For one revision that out-of-band control lived as twenty lines of YAML inside
+# the workflow, and the only thing binding it to anything was a substring: the
+# tests concatenated the job's `run:` blocks and looked for
+# "verify_cloud_complete.sh gcp". A reviewer replaced the entire job body with
+#
+#     echo "Next: bash scripts/deploy/verify_cloud_complete.sh gcp"
+#     exit 0
+#
+# and the suite stayed green — the three saboteur shapes this change exists to
+# kill (a printed instruction, a commented-out call, a swallowed status) all
+# satisfied the one binding covering the primary cloud. The exception had become
+# the hole.
+#
+# So the body moved here, where tests/test_deploy_script_execution.py RUNS it
+# against a stub PATH and asserts what it DID: that it called the gate for gcp,
+# that a failing gate makes it exit non-zero, that it provisions nothing after
+# the gate answered, and that both of the gate's exit codes come out unchanged.
+# The workflow job is now one line that invokes this file, and
+# tests/test_cloud_rollout_completeness.py requires that line to be an exact
+# invocation rather than a mention.
+#
+# WHAT IS STILL ONLY DECLARED
+# ---------------------------
+# That the job exists, depends on `deploy`, and runs on `if: always()` is YAML.
+# A workflow cannot be executed here, so those remain a text read of
+# .github/workflows/deploy.yml — see the limits list in
+# docs/storage-portability/multi-cloud-separation.md. What is no longer a text
+# read is the part that used to be all of it: what the check itself does.
+#
+# WHAT IT COSTS TO RUN
+# --------------------
+# Whatever verify_cloud_complete.sh costs: one public HTTPS GET per attempt and
+# a text read of a deploy script in this checkout. No credentials, no cloud CLI,
+# nothing provisioned. Runnable from a laptop, and worth running from one.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/cloud_complete_gate.sh
+. "${SCRIPT_DIR}/cloud_complete_gate.sh"
+
+CLOUD=gcp
+
+# A Cloud Run revision takes traffic gradually and the status snapshot behind
+# the CDN is not instant, so a failure in the first seconds after a deploy is
+# not yet news. A failure that survives five minutes is.
+ATTEMPTS=5
+RETRY_SLEEP_SECONDS=60
+
+# GitHub Actions annotations, and nothing else. Guarded so this prints workflow
+# markup only where workflow markup means something: run from a laptop it is
+# silent rather than shouting "::error::" at somebody with no run to annotate.
+annotate() {
+  [ -n "${GITHUB_ACTIONS:-}" ] || return 0
+  printf '::%s::%s\n' "$1" "$2"
+}
+
+NEXT_STEPS=$(cat <<'NEXT'
+
+GCP is deployed and its rollout is not complete. The stage output above names
+which stage failed and what fixes it. Nothing here excuses a stage, and this
+job cannot leave GCP half-deployed: it runs after every mutation the deploy job
+makes, and all it can do is turn the run red.
+
+Re-run it from anywhere, with no credentials:
+
+  bash scripts/deploy/verify_gcp_complete.sh
+
+docs/storage-portability/multi-cloud-separation.md ("Adding a cloud: the
+definition of done") has the stage table and what the check cannot see.
+NEXT
+)
+
+# One call path, the shared one. require_cloud_complete returns the verifier's
+# exit status unaltered and gives every bound script the same words for each
+# code, so an operator is never told to fix an install that did not fail. The
+# next-steps text is passed on the LAST attempt only: printing it after each of
+# five tries teaches people to scroll past it.
+attempt=1
+rc=0
+while [ "$attempt" -le "$ATTEMPTS" ]; do
+  rc=0
+  if [ "$attempt" -eq "$ATTEMPTS" ]; then
+    require_cloud_complete "$CLOUD" "$NEXT_STEPS" || rc=$?
+  else
+    require_cloud_complete "$CLOUD" || rc=$?
+  fi
+  if [ "$rc" -eq 0 ]; then
+    break
+  fi
+  if [ "$attempt" -lt "$ATTEMPTS" ]; then
+    annotate notice "verify_cloud_complete.sh ${CLOUD} exited ${rc} on attempt ${attempt}/${ATTEMPTS}; the new revision may not be taking traffic yet"
+    sleep "$RETRY_SLEEP_SECONDS"
+  fi
+  attempt=$((attempt + 1))
+done
+
+if [ "$rc" -ne 0 ]; then
+  annotate error "GCP deployed but its rollout is not complete (exit ${rc}). See the banner above; docs/storage-portability/multi-cloud-separation.md has the stage table."
+fi
+
+# The gate's answer, unaltered, as this script's own. This is the last statement
+# in the file on purpose.
+exit "$rc"

--- a/src/trusted_router/cloud_rollout_completeness.py
+++ b/src/trusted_router/cloud_rollout_completeness.py
@@ -1,0 +1,1254 @@
+"""When is a cloud *done*? The stages, and the binding that cannot be skipped.
+
+On 2026-08-17 the AWS-EU cloud had been serving production traffic since
+2026-08-02 with no analytics pipeline at all: the drain that moves rows from
+``tr_operational_analytics_outbox`` into ClickHouse had never been installed,
+470,897 rows had piled up in DSQL, and ``activity_generations`` on the Paris
+node was empty. Nothing reported it for fifteen days, because the only backlog
+alarm is emitted BY the drain that was missing.
+
+:mod:`trusted_router.operational_analytics_fleet` and
+``clickhouse.check_fleet_analytics_freshness`` are the *detectors*: they tell
+you afterwards, on someone else's schedule. This module is about the ROLLOUT.
+The proximate cause was not a missing monitor — it was a bring-up script that
+ended by PRINTING next steps and exiting 0 (``scripts/deploy/aws_eu_clickhouse.sh``:
+``echo "Next: apply clickhouse/*.sql, then redeploy tr-eu with ..."``). A human
+ran it, read the echoes, and stopped. "The script finished" and "the cloud
+works" were different things, and nothing anywhere treated "cloud exists but has
+no drain" as an incomplete rollout.
+
+So this module answers one question, executably, for one cloud:
+
+    a. is the cloud in the fleet freshness registry — i.e. is there an endpoint
+       to read its drain lag from at all? (Registered, not watched: the fleet
+       workflow that reads that registry ships with ``workflow_dispatch`` as its
+       only trigger, deliberately, until every cloud publishes the section.)
+    b. does its public ``/status.json`` carry the ``analytics`` section?
+    c. is ``analytics.available`` true — the control plane could READ its outbox?
+    d. is ``drain_lag_seconds`` under the bound the drain itself alarms on?
+    e. does the control plane that feeds the outbox have the outbox ENABLED?
+
+The order is deliberate: each stage is meaningless until the one before it
+holds, and each returns a message naming the fix rather than a boolean. The
+shell entry point is ``scripts/deploy/verify_cloud_complete.sh``, which does the
+HTTPS fetch and calls back into the subcommands here; every judgement lives in
+Python so it can be unit-tested without a network.
+
+WHAT THIS MODULE PROVES, AND WHAT IT DOES NOT
+---------------------------------------------
+Round 2 of review killed the previous answer to "does this deploy script run
+the gate?", and it is worth keeping the corpse visible. It used to be a regex:
+does the string ``verify_cloud_complete.sh <cloud>`` appear in the script's last
+N lines? That is satisfied by a heredoc body, by a printed instruction, and by a
+commented-out line — which is *verbatim the bug this module exists to prevent*.
+Printing the step is not doing the step, and no amount of regex hardening fixes
+a proof-by-text: the next careless edit always wins.
+
+So the binding is now behavioural, and it lives in the test suite
+(``tests/test_deploy_script_execution.py``): each bound script is RUN to
+completion in a harness whose ``PATH`` holds a recording stub for every command
+that leaves the machine plus a symlink to everything else in ``/bin`` and
+``/usr/bin`` — isolation BY NAME, not a sandbox, and ``tests/deploy_script_harness.py``
+says so in its own header — with a stub ``verify_cloud_complete.sh``, and two
+properties are asserted: the verifier was CALLED with this cloud, and when the
+verifier FAILS the script exits non-zero. A printed instruction fails both by
+construction.
+
+Every cloud is in that harness, GCP included. It was not, for one revision: the
+primary cloud's only binding was a substring search over the ``run:`` blocks of
+a workflow job, which a printed instruction satisfies — the exception had become
+the hole. The job's body now lives in ``scripts/deploy/verify_gcp_complete.sh``,
+which is bound here and executed like the rest.
+
+:data:`ROLLOUT_REGISTRY` is therefore the list of what to EXECUTE, not the
+assertion itself. Each :class:`DeployScript` says how it is proven:
+
+* :data:`PROVEN_BY_EXECUTION` — the harness runs it end to end, both ways.
+* :data:`NOT_PROVEN` — it could not be run honestly under stubs, and the reason
+  is written down here. Nothing in this repository claims those scripts run the
+  gate; the docs and the PR say the same thing in the same words.
+
+The functions in this file still do static checks — that a claimed script
+exists, that no unclaimed script calls the verifier, that an exemption carries a
+reason — but none of them is the "does it run the gate?" assertion any more.
+
+Two further rules this module enforces in code rather than in prose:
+
+* **The cloud list is never re-typed.** :func:`declared_clouds` delegates to
+  :func:`operational_analytics_fleet.deployed_clouds`, which is the union of
+  every table in this repo that declares a deployment. A fourth cloud added to
+  any one of them shows up here whether or not anybody remembered this file.
+  :func:`registry_gaps` then FAILS for a declared cloud that has no entry.
+
+* **The status URL is never re-typed either.** It comes from
+  :data:`operational_analytics_fleet.ANALYTICS_FRESHNESS_FLEET`, which is the
+  registry the scheduled fleet check reads. That matters concretely: AWS's entry
+  there is the *App Runner* control plane that holds the Aurora DSQL connection
+  and whose drain was missing, NOT ``aws.trustedrouter.com``, which fronts the
+  Fargate plane through Global Accelerator. A gate pointed at the wrong AWS
+  front end answers a question nobody asked.
+
+THERE IS NO WAY TO EXCUSE A STAGE
+---------------------------------
+Earlier revisions of this module carried an exemption: a cloud could record
+``analytics_absent_reason`` and have some stages "waived" rather than measured,
+with a verdict taxonomy deciding which failures a waiver was allowed to touch.
+Two review rounds found bugs in that machinery, and the second set were
+regressions introduced by the fixes to the first. It is gone. A cloud that
+cannot be checked is simply NOT VERIFIED: the run exits non-zero and prints the
+reason. Nothing in this file can turn a failure into a pass.
+
+Nothing this module decides comes from the environment or from a flag, either.
+That is not an accident: the bound in stage (d) and the URL in stage (a) are
+what an attacker of the *process* — a tired operator with an ``export`` in their
+shell profile — would reach for, and a deploy script inherits every variable its
+caller had. The bound is a constant here; the URL comes from the fleet registry
+in ``src/``; and neither this module nor the shell entry point accepts an
+override for either.
+
+This module opens no socket and shells out to nothing. It reads two kinds of
+file: deploy scripts in this repository (as text, for stage (e)) and the
+``--status-file`` the shell has already fetched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from trusted_router.operational_analytics_fleet import (
+    ANALYTICS_FRESHNESS_FLEET,
+    deployed_clouds,
+    fleet_endpoint,
+)
+from trusted_router.operational_analytics_freshness import (
+    ANALYTICS_STATUS_KEY,
+    AVAILABLE_FIELD,
+    DEFAULT_MAX_DRAIN_LAG_SECONDS,
+    DRAIN_LAG_FIELD,
+    GENERATED_AT_FIELD,
+    REASON_FIELD,
+    REASON_NOT_CONFIGURED,
+)
+
+#: Repository root, so the outbox stage can read the deploy script that is the
+#: source of truth for a cloud's control-plane environment.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: The environment variable that decides whether settle enqueues operational
+#: rows at all. Config-level truth: with this false the outbox stays empty, the
+#: published ``drain_lag_seconds`` is 0.0 forever, and every stage above reads
+#: green while ZERO rows move. Stages (b)-(d) cannot tell "fully drained" from
+#: "never enqueued" — see :data:`DRAIN_LAG_LIMIT_NOTE`, which says so on every
+#: run that passes stage (d).
+OUTBOX_ENABLED_ENV = "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED"
+
+#: Values of :data:`OUTBOX_ENABLED_ENV` that mean "off". Anything else — a
+#: literal ``true`` or a shell expansion the script computes — is accepted at
+#: this stage, because the runtime truth is what stages (b)-(d) measure.
+_OUTBOX_DISABLED_LITERALS = frozenset({"", "false", "0", "no", "off", "none"})
+
+#: How a deploy script DECLARES the variable, as opposed to merely mentioning
+#: it. Precision on purpose, and learned the hard way: a first version matched
+#: the name anywhere in the file, so the paragraph in
+#: ``azure_control_plane.sh`` that TELLS an operator to set
+#: ``TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true`` counted as having set it —
+#: the check read its own instructions back as compliance and passed the one
+#: cloud it was written to fail.
+#:
+#: All three control-plane scripts declare env in one of these shapes: an App
+#: Runner JSON map, a quoted ``KEY=VALUE`` array element, or an export. Prose
+#: is none of them. A future script that assigns the variable some other way
+#: fails this stage rather than passing it silently, which is the safe
+#: direction: the message says exactly which file and which variable.
+#:
+#: Matched against the WHOLE file, heredocs included — AWS declares its map
+#: inside ``CONFIG=$(cat <<JSON``, so stripping heredocs here would blind the
+#: stage to the one cloud that passes it.
+#:
+#: Stage (e) is the one judgement in this module that is still made by reading
+#: text, and it is the weakest thing here. It is kept because the alternative
+#: needs cloud credentials, and a check that needs production credentials is a
+#: check that does not get run — but the docs say plainly that a determined
+#: edit beats it, exactly as one beat the old script binding.
+_OUTBOX_DECLARATION_PATTERNS = (
+    rf'"{OUTBOX_ENABLED_ENV}"\s*:\s*"([^"]*)"',
+    rf'"{OUTBOX_ENABLED_ENV}=([^"]*)"',
+    rf"^[ \t]*export[ \t]+{OUTBOX_ENABLED_ENV}=(\S*)",
+)
+
+#: The fourth shape, and the reason it needs its own pass: a plain
+#: ``TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true`` line is EXACTLY what the
+#: failure message tells an operator to write, and the patterns above rejected
+#: it — a gate that refuses the fix it prescribes teaches people the gate is
+#: wrong. It cannot be matched against the whole file, because the same text
+#: appears inside the heredoc where ``azure_control_plane.sh`` prints that
+#: advice; it is matched against :func:`_executable_text`, which is the script
+#: with heredoc bodies and whole-line comments removed. Instructions stay
+#: instructions, and an assignment counts.
+_OUTBOX_BARE_ASSIGNMENT_PATTERN = rf"^[ \t]*{OUTBOX_ENABLED_ENV}=(\S*)"
+
+#: Repo-relative path of the shell entry point every bound deploy script ends in.
+VERIFIER_SCRIPT = "scripts/deploy/verify_cloud_complete.sh"
+
+#: Repo-relative path of the sourced fragment that RUNS the verifier and turns
+#: its exit status into an outcome every bound script reports identically.
+#: Shared on purpose: exit 5 ("nobody outside can see this cloud yet") used to
+#: be understood by one of five scripts, so the other four reported today's real
+#: state as the wrong failure with the wrong fix.
+GATE_LIBRARY = "scripts/deploy/cloud_complete_gate.sh"
+
+#: Where deploy scripts live. Scanned RECURSIVELY by :func:`script_binding_gaps`
+#: for invocations of the verifier that no registry entry claims — the previous
+#: glob was ``scripts/deploy/*.sh``, so a script one directory down escaped it.
+DEPLOY_SCRIPT_DIR = "scripts"
+
+#: How stale the published section may be before it is a frozen control plane
+#: rather than a healthy one. Mirrors the default in the fleet freshness check.
+DEFAULT_MAX_SECTION_AGE_SECONDS = 3_600.0
+
+#: How far into the future a published ``generated_at`` may sit before the
+#: staleness check calls it broken rather than fresh. Two machines' clocks
+#: disagree by seconds; a timestamp minutes ahead is a wrong clock or a wrong
+#: timezone, and either one turns the staleness half of stage (d) OFF — a
+#: control plane frozen a week ago that stamps tomorrow's date reads as
+#: negative age and passes. Small on purpose: this is skew tolerance, not a
+#: grace period.
+MAX_SECTION_CLOCK_SKEW_SECONDS = 120.0
+
+#: This script is executed end to end by the behavioural harness in
+#: ``tests/test_deploy_script_execution.py``, which asserts that it calls the
+#: verifier for its cloud AND that a failing verifier makes it exit non-zero.
+PROVEN_BY_EXECUTION = "execution"
+
+#: This script is NOT proven. Nothing in this repository establishes that it
+#: runs the gate; :attr:`DeployScript.unproven_reason` says why not, and the
+#: docs repeat it. Kept in the registry so the omission is a sentence somebody
+#: wrote rather than a row missing from a list.
+NOT_PROVEN = "unproven"
+
+
+@dataclass(frozen=True)
+class CompensatingControl:
+    """A CI job that checks a cloud whose deploy script is exempt from the gate.
+
+    Exists because the first version of GCP's exemption cited "the scheduled
+    analytics freshness workflow" — a workflow that ships with no ``schedule:``
+    trigger, deliberately and in its own header. The primary cloud therefore had
+    no automated completeness check at all, behind a sentence saying it did.
+
+    So a claimed control is a structured reference, and
+    ``tests/test_cloud_rollout_completeness.py`` opens the workflow, finds the
+    job, and requires one of its steps to be an EXACT invocation of a script
+    this cloud's :attr:`CloudRollout.deploy_scripts` records as
+    :data:`PROVEN_BY_EXECUTION`.
+
+    Both halves of that sentence were learned. The check used to concatenate the
+    job's ``run:`` blocks and look for the substring
+    ``verify_cloud_complete.sh gcp``; a reviewer replaced the whole body with an
+    ``echo`` of that string plus ``exit 0`` and the suite stayed green, as it
+    did for a commented-out line and for ``|| true``. All three are the shapes
+    this module exists to kill, and they satisfied the only binding covering the
+    primary cloud. Requiring an exact invocation kills them here, and pointing
+    it at a proven script moves the interesting half — what the check does — out
+    of YAML and into the behavioural harness.
+
+    What remains a DECLARATION, because a workflow cannot be executed here: that
+    the job exists, what it depends on, and whether GitHub reaches it on a merge.
+    """
+
+    #: Repo-relative path of the workflow file.
+    workflow: str
+    #: Job id inside ``jobs:``.
+    job: str
+    #: What it does and when it runs, for the human reading the exemption.
+    description: str
+
+
+@dataclass(frozen=True)
+class ScriptExemption:
+    """A deploy script that deliberately does NOT run the completeness gate.
+
+    Both text fields are required, which is the entire design: the failure mode
+    this replaces was a cloud being absent from a hand-written list, and absence
+    carries no reason. An exemption is a sentence somebody wrote and a reviewer
+    read — and, since round 2, a control somebody can go and look at.
+    """
+
+    #: Repo-relative path, so the test can assert the file exists.
+    script: str
+    #: Why binding this one would be wrong. Nothing prints this: it is read by
+    #: whoever opens this file and by the reviewer of the diff that adds it. CI
+    #: only requires that it is not blank.
+    reason: str
+    #: What checks the cloud instead. ``None`` is legal and means UNCHECKED —
+    #: which must then be said out loud, here and in the docs, rather than
+    #: implied away.
+    compensating_control: CompensatingControl | None = None
+
+
+@dataclass(frozen=True)
+class DeployScript:
+    """One deploy script that must end in the completeness gate, and its proof."""
+
+    #: Repo-relative path.
+    path: str
+    #: :data:`PROVEN_BY_EXECUTION` or :data:`NOT_PROVEN`.
+    proof: str = PROVEN_BY_EXECUTION
+    #: Required when :attr:`proof` is :data:`NOT_PROVEN`: what stops the harness
+    #: from running this one honestly. A blank reason is a CI failure.
+    unproven_reason: str = ""
+
+
+@dataclass(frozen=True)
+class CloudRollout:
+    """What this repository knows about finishing ONE cloud's rollout.
+
+    Deliberately small. The status URL is not stored here: it comes from
+    :data:`operational_analytics_fleet.ANALYTICS_FRESHNESS_FLEET`, so this table
+    cannot drift into a second, disagreeing list of clouds and their endpoints.
+    """
+
+    #: Cloud id as the deployment-declaring tables spell it ("aws", "azure", "gcp").
+    cloud: str
+    #: Repo-relative deploy script that is the SOURCE OF TRUTH for that cloud's
+    #: control-plane environment — the file whose header says so.
+    control_plane_script: str
+    #: The command an operator runs to install/refresh this cloud's drain.
+    #: Printed by the stage that fails, so the message names the fix.
+    drain_install_command: str
+    #: The deploy scripts for this cloud that end in the completeness gate. This
+    #: is the list the behavioural harness EXECUTES; it is not itself the
+    #: assertion.
+    #:
+    #: What :func:`script_binding_gaps` actually enforces, stated exactly
+    #: because an earlier version of this comment described a stricter rule that
+    #: no code enforced and no cloud satisfied: the cloud must name at least one
+    #: script here or one exemption; its :attr:`control_plane_script` must be in
+    #: one of the two; and no script anywhere under ``scripts/`` may invoke the
+    #: gate without appearing in one of the two. It does NOT enumerate a cloud's
+    #: scripts and require each to be bound — nothing here knows which of the
+    #: sixty files in ``scripts/deploy/`` belong to which cloud. A cloud can
+    #: still ship a bring-up script that neither runs the gate nor is named
+    #: here, and the check that catches that is a reviewer.
+    deploy_scripts: tuple[DeployScript, ...] = ()
+    #: Deploy scripts deliberately left unbound, each with its reason. Named in
+    #: code so that "this cloud's script does not run the check" is a claim
+    #: somebody made and a reviewer saw, rather than a row missing from a list.
+    #:
+    #: This is about which SCRIPTS end in the gate. It is not, and cannot become,
+    #: permission for a cloud to skip a stage: there is no such permission.
+    exempt_deploy_scripts: tuple[ScriptExemption, ...] = ()
+
+
+#: Every cloud that must be finishable. Keys are checked against
+#: :func:`declared_clouds` by :func:`registry_gaps`, so adding a cloud to any
+#: deployment-declaring table without adding it here is a CI failure rather than
+#: a cloud nobody ever verifies.
+ROLLOUT_REGISTRY: dict[str, CloudRollout] = {
+    "gcp": CloudRollout(
+        cloud="gcp",
+        control_plane_script="scripts/deploy/rollout.sh",
+        drain_install_command=(
+            "bash scripts/deploy/clickhouse_operational_analytics.sh  "
+            "# GCP drain: systemd units on the ClickHouse cluster"
+        ),
+        deploy_scripts=(
+            DeployScript("scripts/deploy/verify_gcp_complete.sh", PROVEN_BY_EXECUTION),
+        ),
+        exempt_deploy_scripts=(
+            ScriptExemption(
+                script="scripts/deploy/rollout.sh",
+                reason=(
+                    "GCP has no bring-up script a human runs: rollout.sh is a step of the "
+                    "deploy JOB (.github/workflows/deploy.yml), which runs on every merge to "
+                    "main. Ending rollout.sh itself in this verifier would put a public HTTPS "
+                    "fetch of trustedrouter.com/status.json in the MIDDLE of the deploy of the "
+                    "cloud that SERVES trustedrouter.com — the deploy that repairs an outage "
+                    "would abort partway because of the outage it repairs. So the gate runs in "
+                    "the same workflow as its own job, out of band, where a failure is a red "
+                    "run and never a half-finished rollout. That job's body is "
+                    "scripts/deploy/verify_gcp_complete.sh, which is bound above and proven "
+                    "by execution: the exemption is now about WHICH FILE ends in the gate, "
+                    "not about GCP being checked differently from anyone else."
+                ),
+                compensating_control=CompensatingControl(
+                    workflow=".github/workflows/deploy.yml",
+                    job="verify-cloud-complete",
+                    description=(
+                        "Runs 'bash scripts/deploy/verify_gcp_complete.sh' — nothing else — "
+                        "after the deploy job has finished mutating production, retrying "
+                        "while the new revision takes traffic. Out of band by construction: "
+                        "it can only make the run red, never leave GCP half-deployed. Its "
+                        "COVERAGE is every run in which the deploy job ran, whatever the "
+                        "result; migrate-schema and sync-runtime-secrets mutate production "
+                        "before deploy, and a run that skips deploy skips this. It has never "
+                        "run on a merge as of this commit — it lands with this change."
+                    ),
+                ),
+            ),
+        ),
+    ),
+    "aws": CloudRollout(
+        cloud="aws",
+        control_plane_script="scripts/deploy/aws_eu_control_plane.sh",
+        drain_install_command="bash scripts/deploy/aws_eu_clickhouse_drain_install.sh",
+        deploy_scripts=(
+            DeployScript("scripts/deploy/aws_eu_clickhouse.sh", PROVEN_BY_EXECUTION),
+            DeployScript("scripts/deploy/aws_eu_control_plane.sh", PROVEN_BY_EXECUTION),
+            DeployScript("scripts/deploy/aws_eu_north_clickhouse.sh", PROVEN_BY_EXECUTION),
+            DeployScript(
+                "scripts/deploy/aws_eu_clickhouse_drain_install.sh",
+                NOT_PROVEN,
+                unproven_reason=(
+                    "Not runnable under stubs without lying about the thing it exists to "
+                    "prove. Its steps 4-9 ship a tarball to the node in base64 chunks over "
+                    "SSM and then read the drain's own journal back to establish that rows "
+                    "MOVED; a stub SSM that answers Status=Success to every command turns "
+                    "that verification into an assertion about the stub. The harness would be "
+                    "executing a script whose middle had been replaced by the answer it wants, "
+                    "which is the failure this whole change is about, one level up. Its tail "
+                    "is therefore CLAIMED, not proven: it sources "
+                    "scripts/deploy/cloud_complete_gate.sh (whose behaviour IS proven, both "
+                    "ways, by tests/test_deploy_script_execution.py) and calls "
+                    "require_cloud_complete aws. Nothing here establishes that the call is "
+                    "reached on a real run."
+                ),
+            ),
+        ),
+    ),
+    "azure": CloudRollout(
+        cloud="azure",
+        control_plane_script="scripts/deploy/azure_control_plane.sh",
+        # No such script exists yet: Azure has no operational-analytics outbox
+        # at all, which is the point. The stage that fails says so and names
+        # what has to be built, rather than pointing at a file that is not there.
+        drain_install_command=(
+            "write it — Azure has no operational-analytics drain yet; the outbox "
+            "must be enabled in scripts/deploy/azure_control_plane.sh and a drain "
+            "installed against its ClickHouse, mirroring "
+            "scripts/deploy/aws_eu_clickhouse_drain_install.sh"
+        ),
+        deploy_scripts=(
+            DeployScript("scripts/deploy/azure_control_plane.sh", PROVEN_BY_EXECUTION),
+        ),
+    ),
+}
+
+
+def scripts_proven_by_execution() -> tuple[tuple[str, str], ...]:
+    """``(script, cloud)`` for every script the behavioural harness runs."""
+    return tuple(
+        (script.path, cloud)
+        for cloud, entry in sorted(ROLLOUT_REGISTRY.items())
+        for script in entry.deploy_scripts
+        if script.proof == PROVEN_BY_EXECUTION
+    )
+
+
+def scripts_not_proven() -> tuple[tuple[str, str, str], ...]:
+    """``(script, cloud, reason)`` for every script nothing here proves."""
+    return tuple(
+        (script.path, cloud, script.unproven_reason)
+        for cloud, entry in sorted(ROLLOUT_REGISTRY.items())
+        for script in entry.deploy_scripts
+        if script.proof != PROVEN_BY_EXECUTION
+    )
+
+
+# ---------------------------------------------------------------------------
+# (a) The registry. Who is checked, and by whom.
+# ---------------------------------------------------------------------------
+
+
+def declared_clouds() -> tuple[str, ...]:
+    """Every cloud this repository DECLARES it deploys.
+
+    Delegated whole to :func:`operational_analytics_fleet.deployed_clouds`,
+    which is the union of every table in this repo that declares a deployment
+    (the BYOK attestation tables, ``MULTICLOUD_REGION_GEO``, the
+    ``external_live_regions``/``marketing_regions`` settings, and
+    ``synthetic_fleet_peers``) and which names its sources in its own failure
+    messages. Delegated rather than re-derived: a second union that reads three
+    of those five tables is a fourth copy of the fleet, and copies drift — the
+    thing this module exists to stop.
+
+    The residual gap, stated because the docs must not overstate this: a cloud
+    that enters NO table — provisioned by hand, serving traffic, named nowhere
+    in ``src/`` — is invisible to every check here, exactly as a cloud that
+    nobody declares is invisible to the marketing map and to ``/v1/regions``.
+    """
+    return deployed_clouds()
+
+
+def freshness_registry() -> dict[str, str]:
+    """Cloud -> public ``/status.json`` URL, from the fleet registry.
+
+    The URLs come from :data:`ANALYTICS_FRESHNESS_FLEET` and nowhere else. That
+    is load-bearing rather than tidy: AWS's entry there is the tr-eu App Runner
+    control plane, the deployment that holds the Aurora DSQL connection and
+    whose drain was missing for fifteen days. The obvious-looking
+    ``aws.trustedrouter.com`` is a different service — the Fargate plane behind
+    Global Accelerator — and a gate pointed at it would have been green
+    throughout the outage.
+
+    Entries with a ``reason`` and no URL are deliberately absent from this
+    mapping: they are clouds the registry declares cannot be checked over HTTP,
+    and :func:`registry_blockers` reports them with that reason rather than
+    letting them fall through as "unknown cloud".
+    """
+    return {
+        entry.cloud: entry.status_url
+        for entry in ANALYTICS_FRESHNESS_FLEET
+        if entry.status_url
+    }
+
+
+def registry_gaps() -> list[str]:
+    """Declared clouds that no completeness check can reach. Empty means bound.
+
+    This is the function CI asserts on. Two ways to be missing, both fatal:
+    nobody publishes a freshness endpoint for the cloud, or this module has no
+    rollout entry for it and therefore cannot say what "done" would mean.
+    """
+    gaps: list[str] = []
+    registry = freshness_registry()
+    for cloud in declared_clouds():
+        if cloud not in registry:
+            endpoint = fleet_endpoint(cloud)
+            if endpoint is not None and endpoint.reason:
+                gaps.append(
+                    f"{cloud}: the fleet registry records it as UNCHECKABLE over HTTP "
+                    f"({endpoint.reason!r}), so scripts/deploy/verify_cloud_complete.sh "
+                    "cannot reach it and no rollout of it can be verified from outside. "
+                    "Fix: give it a public control-plane /status.json in "
+                    "ANALYTICS_FRESHNESS_FLEET (src/trusted_router/"
+                    "operational_analytics_fleet.py), or stop deploying it."
+                )
+            else:
+                gaps.append(
+                    f"{cloud}: declared as a deployment (see "
+                    "operational_analytics_fleet.deployment_sources() for which table "
+                    "says so) but absent from ANALYTICS_FRESHNESS_FLEET, so no one ever "
+                    "reads its analytics freshness. Fix: add a FleetAnalyticsEndpoint for "
+                    "it in src/trusted_router/operational_analytics_fleet.py."
+                )
+        if cloud not in ROLLOUT_REGISTRY:
+            gaps.append(
+                f"{cloud}: declared as a deployment but absent from ROLLOUT_REGISTRY in "
+                "src/trusted_router/cloud_rollout_completeness.py, so "
+                "scripts/deploy/verify_cloud_complete.sh cannot check it and the cloud "
+                "can be called done with no analytics pipeline at all. Fix: add a "
+                "CloudRollout entry naming its control-plane deploy script and its drain "
+                "install command."
+            )
+    return gaps
+
+
+# ---------------------------------------------------------------------------
+# The other binding: which SCRIPTS must run the gate.
+#
+# What is checked HERE is structural — a claimed script exists, an exemption
+# carries a reason, no unclaimed script calls the verifier. Whether a script
+# ACTUALLY runs the gate is proven by executing it; see the module docstring
+# and tests/test_deploy_script_execution.py.
+# ---------------------------------------------------------------------------
+
+
+def _scripts_invoking_the_verifier(root: Path) -> list[str]:
+    """Every script under ``scripts/`` that mentions the verifier at all.
+
+    Recursive since round 2. The previous version globbed
+    ``scripts/deploy/*.sh`` and nothing else, so a bring-up script one directory
+    down — ``scripts/deploy/aws/bring_up.sh`` — could call the verifier while no
+    registry entry claimed it, which is the "wiring nobody would miss" shape
+    this check exists to catch.
+    """
+    directory = root / DEPLOY_SCRIPT_DIR
+    if not directory.is_dir():
+        return []
+    verifier_name = Path(VERIFIER_SCRIPT).name
+    gate_name = Path(GATE_LIBRARY).name
+    found: list[str] = []
+    for path in sorted(directory.rglob("*.sh")):
+        if path.name in (verifier_name, gate_name):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):  # pragma: no cover - unreadable file
+            continue
+        if verifier_name in text or "require_cloud_complete" in text:
+            found.append(str(path.relative_to(root)))
+    return found
+
+
+def script_binding_gaps(root: Path | None = None) -> list[str]:
+    """Structural defects in the script registry. Empty means well-formed.
+
+    Six ways to be wrong, all of them things a new cloud does by accident:
+
+    1. the cloud names no script at all and claims no exemption — the shape the
+       old hand-written list allowed silently, because a cloud that is simply
+       absent from a list looks the same as a cloud with nothing to bind;
+    2. a named script does not exist;
+    3. the cloud's own ``control_plane_script`` — the file that IS the source
+       of truth for its environment — is neither bound nor exempt;
+    4. some script under ``scripts/`` runs the verifier for a cloud that never
+       named it, so the wiring exists but no registry entry would notice it
+       disappearing;
+    5. a script recorded as :data:`NOT_PROVEN` gives no reason, which is the
+       missing row it replaced;
+    6. an exemption has no reason, names a file that is not there, or cites a
+       compensating control whose workflow file does not exist.
+
+    Every message names the file to edit, because the fix is a code change and
+    a CI failure that does not say where to go teaches nobody.
+    """
+    root = root or REPO_ROOT
+    gaps: list[str] = []
+    here = "src/trusted_router/cloud_rollout_completeness.py"
+    claimed: dict[str, str] = {}
+
+    for cloud, entry in sorted(ROLLOUT_REGISTRY.items()):
+        exempt = {item.script: item for item in entry.exempt_deploy_scripts}
+        for script in entry.deploy_scripts:
+            claimed[script.path] = cloud
+        for path, item in exempt.items():
+            claimed.setdefault(path, cloud)
+            if not item.reason.strip():
+                gaps.append(
+                    f"{cloud}: {path} is exempt from the completeness gate with an EMPTY "
+                    f"reason. An exemption with no reason is the missing row it replaced. "
+                    f"Fix: write why in ScriptExemption.reason in {here}."
+                )
+            if not (root / path).is_file():
+                gaps.append(
+                    f"{cloud}: exempt script {path} does not exist. Fix: correct or drop "
+                    f"the ScriptExemption in {here}."
+                )
+            control = item.compensating_control
+            if control is not None and not (root / control.workflow).is_file():
+                gaps.append(
+                    f"{cloud}: {path} is exempt and cites {control.workflow} "
+                    f"(job {control.job}) as the control that checks this cloud instead, "
+                    "but that workflow file does not exist. An exemption citing a control "
+                    "that is not there is worse than one admitting the cloud is unchecked. "
+                    f"Fix: correct or drop the CompensatingControl in {here}."
+                )
+
+        if not entry.deploy_scripts and not exempt:
+            gaps.append(
+                f"{cloud}: ROLLOUT_REGISTRY names no deploy script for this cloud, so "
+                f"nothing binds its bring-up to {VERIFIER_SCRIPT} and it can ship a script "
+                'that prints "Next: ..." and exits 0 with CI green — the AWS-EU outage '
+                f"exactly. Fix: in {here}, add every deploy script for {cloud} to "
+                "deploy_scripts=(...) on its CloudRollout, and end each of those scripts "
+                f'with: require_cloud_complete {cloud}. If one of them must NOT be bound, '
+                "say so in exempt_deploy_scripts=(ScriptExemption(script=..., reason=...),)."
+            )
+
+        bound_paths = {script.path for script in entry.deploy_scripts}
+        if entry.control_plane_script not in bound_paths and (
+            entry.control_plane_script not in exempt
+        ):
+            gaps.append(
+                f"{cloud}: {entry.control_plane_script} is this cloud's control-plane "
+                "script — the source of truth for its service environment — but it is "
+                "neither in deploy_scripts nor exempt, so deploying this cloud never asks "
+                f"whether the cloud works. Fix: add it to deploy_scripts in {here} and end "
+                f"it with: require_cloud_complete {cloud}"
+            )
+
+        for script in entry.deploy_scripts:
+            if not (root / script.path).is_file():
+                gaps.append(
+                    f"{cloud}: deploy_scripts names {script.path}, which does not exist. "
+                    f"Fix: correct the path in {here}."
+                )
+            if script.proof not in (PROVEN_BY_EXECUTION, NOT_PROVEN):
+                gaps.append(
+                    f"{cloud}: {script.path} has proof={script.proof!r}, which is neither "
+                    f"PROVEN_BY_EXECUTION nor NOT_PROVEN. Fix: pick one in {here}."
+                )
+            if script.proof == NOT_PROVEN and not script.unproven_reason.strip():
+                gaps.append(
+                    f"{cloud}: {script.path} is recorded as NOT_PROVEN with no reason, so "
+                    "the repository says nothing establishes that it runs the gate and "
+                    "also does not say why. That is the missing row again. Fix: write "
+                    f"unproven_reason in {here}, and say the same thing in the docs."
+                )
+
+    for found in _scripts_invoking_the_verifier(root):
+        if found not in claimed:
+            gaps.append(
+                f"{found} runs {VERIFIER_SCRIPT} but no CloudRollout claims it, so nothing "
+                "would notice if that call were deleted. Fix: add it to deploy_scripts (or "
+                f"exempt_deploy_scripts) of the cloud it belongs to in {here}."
+            )
+    return gaps
+
+
+def registry_blockers(cloud: str) -> list[str]:
+    """Stage (a) for ONE cloud."""
+    blockers: list[str] = []
+    if cloud not in ROLLOUT_REGISTRY:
+        known = ", ".join(sorted(ROLLOUT_REGISTRY)) or "(none)"
+        blockers.append(
+            f"{cloud}: no ROLLOUT_REGISTRY entry in "
+            "src/trusted_router/cloud_rollout_completeness.py (known: "
+            f"{known}). Fix: add a CloudRollout for it before calling the cloud done."
+        )
+    registry = freshness_registry()
+    if cloud not in registry:
+        endpoint = fleet_endpoint(cloud)
+        detail = (
+            f" The fleet registry has an entry but no URL: {endpoint.reason!r}."
+            if endpoint is not None and endpoint.reason
+            else ""
+        )
+        blockers.append(
+            f"{cloud}: no public status URL in ANALYTICS_FRESHNESS_FLEET, so nothing on "
+            f"any schedule reads its drain lag and this gate has nothing to fetch.{detail}"
+            " Fix: add a FleetAnalyticsEndpoint with the CONTROL plane's public "
+            "/status.json in src/trusted_router/operational_analytics_fleet.py."
+        )
+    return blockers
+
+
+# ---------------------------------------------------------------------------
+# (b)-(d) What the cloud publishes about itself.
+# ---------------------------------------------------------------------------
+
+
+class UnreadableStatusPage(ValueError):
+    """The body fetched from the status URL is not the JSON status document.
+
+    Its own type because it is its own finding, and round 2 caught the two being
+    collapsed: "this cloud publishes no analytics section" (a deployed control
+    plane that predates the publisher — nobody outside can see this cloud yet)
+    and "the body could not be parsed at all" (a CDN interstitial, a captive
+    portal, a truncated response) were both reported as NOT YET OBSERVABLE with
+    the same fix instruction. Only one of them is fixed by deploying a newer
+    control plane.
+    """
+
+
+def unwrap_status_payload(payload: Any) -> dict[str, Any]:
+    """``/status.json`` serves ``{"data": {...}}``; accept either shape."""
+    if isinstance(payload, dict) and isinstance(payload.get("data"), dict):
+        payload = payload["data"]
+    if not isinstance(payload, dict):
+        raise UnreadableStatusPage(
+            "the status URL answered, but the body is a "
+            f"{type(payload).__name__}, not the JSON object /status.json serves"
+        )
+    return payload
+
+
+def section_blockers(cloud: str, payload: dict[str, Any]) -> list[str]:
+    """Stage (b): the section exists at all."""
+    section = payload.get(ANALYTICS_STATUS_KEY)
+    if isinstance(section, dict):
+        return []
+    return [
+        f"{cloud}: /status.json parsed, and publishes no '{ANALYTICS_STATUS_KEY}' section, "
+        "so this cloud's drain lag is unobservable from outside. Fix: deploy a control "
+        "plane built from a commit whose status snapshot calls "
+        "trusted_router.operational_analytics_freshness.analytics_status_section() — "
+        "an older image serves a status page that simply omits the question."
+    ]
+
+
+def _published_as_true(value: Any) -> bool:
+    """``available`` is a JSON boolean, and only a JSON boolean counts.
+
+    Python truthiness is the wrong predicate for a field read off somebody
+    else's HTTP response: the strings ``"false"``, ``"0"`` and ``"no"`` are all
+    truthy, so a control plane that serialised the flag as text — or a proxy
+    that stringified the body — would publish ``available: "false"`` and read as
+    AVAILABLE here. The publisher in this repo emits a real bool
+    (``operational_analytics_freshness.analytics_status_section``), so requiring
+    one costs nothing and closes the case where something else does not.
+    """
+    return value is True
+
+
+def available_blockers(cloud: str, payload: dict[str, Any]) -> list[str]:
+    """Stage (c): the section says the outbox could actually be read."""
+    section = payload.get(ANALYTICS_STATUS_KEY)
+    if not isinstance(section, dict):
+        return section_blockers(cloud, payload)
+    if _published_as_true(section.get(AVAILABLE_FIELD)):
+        return []
+    raw = section.get(AVAILABLE_FIELD)
+    if raw is not None and not isinstance(raw, bool):
+        entry = ROLLOUT_REGISTRY.get(cloud)
+        install = entry.drain_install_command if entry else "install this cloud's drain"
+        return [
+            f"{cloud}: {ANALYTICS_STATUS_KEY}.{AVAILABLE_FIELD} is {raw!r}, a "
+            f"{type(raw).__name__} rather than the JSON boolean this field is. The string "
+            '"false" is TRUE to a truthiness test, so this stage refuses to guess. Fix: '
+            "publish it from operational_analytics_freshness.analytics_status_section(), "
+            f"which emits a bool, or find whatever is rewriting the body. Then: {install}"
+        ]
+    reason = section.get(REASON_FIELD)
+    entry = ROLLOUT_REGISTRY.get(cloud)
+    install = entry.drain_install_command if entry else "install this cloud's drain"
+    if reason == REASON_NOT_CONFIGURED:
+        return [
+            f"{cloud}: {ANALYTICS_STATUS_KEY}.{REASON_FIELD} is "
+            f"{REASON_NOT_CONFIGURED!r} — the deployed control plane reports that it "
+            "runs NO operational-analytics outbox, so nothing is enqueued, nothing is "
+            "drained, and every freshness number this cloud can publish is vacuously "
+            f"green. Fix: {install}. Nothing in this repository excuses this: a cloud "
+            "that runs no analytics pipeline is not a finished cloud, and there is no "
+            "flag, variable or registry field that makes this run exit 0."
+        ]
+    return [
+        f"{cloud}: {ANALYTICS_STATUS_KEY}.{AVAILABLE_FIELD} is false "
+        f"({REASON_FIELD}={reason!r}) — the control plane could not read its own "
+        "operational-analytics outbox, which is not the same as an empty one and not "
+        f"the same as not having one. Fix: {install}"
+    ]
+
+
+def drain_lag_blockers(
+    cloud: str,
+    payload: dict[str, Any],
+    *,
+    now: dt.datetime,
+    max_drain_lag_seconds: float = DEFAULT_MAX_DRAIN_LAG_SECONDS,
+    max_section_age_seconds: float = DEFAULT_MAX_SECTION_AGE_SECONDS,
+) -> list[str]:
+    """Stage (d): rows are leaving the outbox, and the number is not stale.
+
+    Both halves matter. ``drain_lag_seconds`` is the age of the oldest
+    undelivered row, and rows are deleted only after ClickHouse accepts them, so
+    a lag under the bound is an end-to-end statement about the pipeline. But a
+    control plane that froze would serve a healthy lag forever, so the section's
+    own ``generated_at`` is checked too.
+
+    Known limitation, stated here because it is the reason stage (e) exists: a
+    lag of 0 with an empty outbox is indistinguishable from a cloud that never
+    enqueues anything. "Drained" and "disabled" look identical from outside.
+    """
+    section = payload.get(ANALYTICS_STATUS_KEY)
+    if not isinstance(section, dict):
+        return section_blockers(cloud, payload)
+    entry = ROLLOUT_REGISTRY.get(cloud)
+    install = entry.drain_install_command if entry else "install this cloud's drain"
+
+    if not _published_as_true(section.get(AVAILABLE_FIELD)):
+        # Nothing to measure, and inventing a "missing field" failure here would
+        # report the same condition twice in different words. Defer to (c),
+        # which already said whether this is a configuration or a fault.
+        return [
+            f"{cloud}: {ANALYTICS_STATUS_KEY}.{AVAILABLE_FIELD} is not true "
+            f"({section.get(AVAILABLE_FIELD)!r}, {REASON_FIELD}="
+            f"{section.get(REASON_FIELD)!r}), so there is no lag to read. Stage (c) is "
+            "the one to fix; this stage cannot run until it passes."
+        ]
+
+    blockers: list[str] = []
+    lag = _as_float(section.get(DRAIN_LAG_FIELD))
+    if lag is None:
+        blockers.append(
+            f"{cloud}: {ANALYTICS_STATUS_KEY}.{DRAIN_LAG_FIELD} is missing or "
+            "unparseable while the section claims to be available, so the pipeline "
+            "reports nothing measurable. Fix: publish it from the outbox head "
+            "(operational_analytics_freshness.analytics_status_section)."
+        )
+    elif lag > max_drain_lag_seconds:
+        blockers.append(
+            f"{cloud}: oldest undelivered outbox row is {lag:.0f}s old "
+            f"(> {max_drain_lag_seconds:.0f}s) — the drain is stopped or behind. This is "
+            "the AWS-EU failure shape exactly: rows enqueued, nothing draining them. "
+            f"Fix: {install}"
+        )
+
+    generated_at = _parse_time(section.get(GENERATED_AT_FIELD))
+    if generated_at is None:
+        blockers.append(
+            f"{cloud}: {ANALYTICS_STATUS_KEY}.{GENERATED_AT_FIELD} is missing or "
+            "unparseable, so a frozen control plane would republish a healthy lag "
+            "forever. Fix: publish generated_at with the section."
+        )
+    else:
+        age = (now - generated_at).total_seconds()
+        if age < -MAX_SECTION_CLOCK_SKEW_SECONDS:
+            # A future timestamp does not just fail to be stale — it makes the
+            # staleness test unable to fire at all, however old the snapshot
+            # really is, because the age it computes is negative. Say that, and
+            # do not silently keep the half of this stage that still works.
+            blockers.append(
+                f"{cloud}: the {ANALYTICS_STATUS_KEY} section is stamped "
+                f"{-age:.0f}s in the FUTURE (skew allowance "
+                f"{MAX_SECTION_CLOCK_SKEW_SECONDS:.0f}s), so its age cannot be judged: a "
+                "control plane frozen a week ago that stamps tomorrow reads as fresh "
+                "forever. Fix: the publisher's clock or timezone — "
+                f"{GENERATED_AT_FIELD} must be UTC 'now' at the moment the snapshot is "
+                "built."
+            )
+        elif age > max_section_age_seconds:
+            blockers.append(
+                f"{cloud}: the {ANALYTICS_STATUS_KEY} section is {age:.0f}s old "
+                f"(> {max_section_age_seconds:.0f}s) — the number is stale, so it says "
+                "nothing about now. Fix: check the control plane is serving and its "
+                "status snapshot is refreshing."
+            )
+    return blockers
+
+
+#: Printed under every PASSING stage (d), unconditionally.
+#:
+#: It used to be conditional on ``outbox_depth == 0`` — "say this only when the
+#: outbox is empty" — and that was worse than useless: no storage backend in
+#: this repository populates ``outbox_depth`` (both build ``OutboxFreshness``
+#: with the field left ``None``), so the condition was never true against a real
+#: cloud and the sentence was never printed where it mattered. The limitation it
+#: describes does not depend on the depth anyway: a lag under the bound says
+#: nothing is STUCK, whatever the depth, and an outbox nobody enqueues into
+#: publishes the same number as one that is being drained perfectly.
+DRAIN_LAG_LIMIT_NOTE = (
+    "a lag under the bound proves nothing is STUCK; it does not prove rows are moving. "
+    "An empty outbox and a switched-off one publish the same number. Rows observed "
+    "moving is the bar — see stage (e) and, in-cloud, "
+    "SELECT count() FROM activity_generations twice, ten minutes apart."
+)
+
+
+# ---------------------------------------------------------------------------
+# (e) The producer side: is anything enqueued in the first place?
+# ---------------------------------------------------------------------------
+
+#: A heredoc opener, and NOT a here-string. The distinction cost a false claim
+#: in the docstring below: ``<<-?\s*(['"]?)(NAME)\1`` looks like it cannot match
+#: ``<<<WORD``, and it does — the engine simply starts one character later, so
+#: the ``<<`` of ``<<<`` plus ``WORD`` matched and everything after it was
+#: treated as a heredoc body until a line reading ``WORD`` turned up, which it
+#: never does. A here-string that happened to sit above the outbox assignment
+#: would have swallowed it and failed the cloud that passes.
+_HEREDOC_OPENER = re.compile(r"(?<!<)<<(?!<)-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
+
+
+def _executable_text(text: str) -> str:
+    """The script with heredoc BODIES and whole-line comments removed.
+
+    Just enough shell awareness to tell an assignment from a paragraph that
+    contains one. ``cat <<'NEXT' ... NEXT`` is how every one of these scripts
+    prints operator instructions, and those instructions quote the very
+    assignment the operator is being asked to add; a bare-assignment pattern
+    over the raw text would read that advice back as compliance, which is the
+    bug :data:`_OUTBOX_DECLARATION_PATTERNS` documents having already made once.
+
+    The line that OPENS a heredoc is kept — it is code. ``<<<`` here-strings are
+    not heredocs and are genuinely skipped now; see :data:`_HEREDOC_OPENER` for
+    what "now" is doing in that sentence.
+    """
+    kept: list[str] = []
+    terminator: str | None = None
+    for line in text.splitlines():
+        if terminator is not None:
+            if line.strip() == terminator:
+                terminator = None
+            continue
+        match = _HEREDOC_OPENER.search(line)
+        if match is not None:
+            terminator = match.group(2)
+            kept.append(line)
+            continue
+        if line.lstrip().startswith("#"):
+            continue
+        kept.append(line)
+    return "\n".join(kept)
+
+
+def declared_outbox_value(cloud: str, root: Path | None = None) -> str | None:
+    """The value the cloud's control-plane deploy script declares for the outbox.
+
+    ``None`` means the script never DECLARES it — mentioning the name in a
+    comment or in operator instructions does not count, see
+    :data:`_OUTBOX_DECLARATION_PATTERNS`. These scripts say in their own headers
+    that they are THE SOURCE OF TRUTH for the service environment, so the
+    absence of the variable is the absence of the setting — which is exactly
+    Azure's state: ``azure_control_plane.sh`` sets no outbox variable at all,
+    and Azure therefore enqueues nothing to drain.
+
+    Read as text on purpose. This must run from a laptop with no cloud
+    credentials, and a check that needs ``az``/``aws`` to run is a check that
+    does not run. It is also, therefore, the weakest judgement in this module —
+    a static read of a file in the working tree, beatable by anyone who wants to
+    beat it, and the docs say so.
+    """
+    entry = ROLLOUT_REGISTRY.get(cloud)
+    if entry is None:
+        return None
+    path = (root or REPO_ROOT) / entry.control_plane_script
+    if not path.is_file():
+        return None
+    text = path.read_text(encoding="utf-8")
+    for pattern in _OUTBOX_DECLARATION_PATTERNS:
+        match = re.search(pattern, text, re.MULTILINE)
+        if match is not None:
+            return match.group(1).strip().strip('"').strip("'")
+    bare = re.search(_OUTBOX_BARE_ASSIGNMENT_PATTERN, _executable_text(text), re.MULTILINE)
+    if bare is not None:
+        return bare.group(1).strip().strip('"').strip("'")
+    return None
+
+
+def outbox_enabled_blockers(cloud: str, root: Path | None = None) -> list[str]:
+    """Stage (e): the control plane that owns the outbox has it switched on."""
+    entry = ROLLOUT_REGISTRY.get(cloud)
+    if entry is None:
+        return registry_blockers(cloud)
+    script = entry.control_plane_script
+    if not ((root or REPO_ROOT) / script).is_file():
+        # Not the same finding as "the script does not set the variable", and
+        # the fix is not the same either. Saying "SCRIPT never sets X" about a
+        # file that is not there sends the reader to open it, and it teaches
+        # them the gate is confused — which is how a gate stops being read.
+        return [
+            f"{cloud}: {script} — named in ROLLOUT_REGISTRY as this cloud's control-plane "
+            "script, the source of truth for its service environment — DOES NOT EXIST in "
+            "this checkout, so nothing here can say whether the cloud enqueues anything "
+            "at all. Fix: correct control_plane_script on this cloud's CloudRollout in "
+            "src/trusted_router/cloud_rollout_completeness.py, or write the script."
+        ]
+    value = declared_outbox_value(cloud, root=root)
+    if value is None:
+        return [
+            f"{cloud}: {script} — the source of truth for this cloud's control-plane "
+            f"environment — never sets {OUTBOX_ENABLED_ENV}, so settle enqueues NOTHING "
+            "and the pipeline is empty by construction. A drain over an empty outbox "
+            f"publishes drain_lag_seconds=0.0 and looks perfectly healthy. Fix: set "
+            f"{OUTBOX_ENABLED_ENV}=true in {script} alongside the ClickHouse URL/"
+            f"password wiring, then {entry.drain_install_command}"
+        ]
+    if value.casefold() in _OUTBOX_DISABLED_LITERALS:
+        return [
+            f"{cloud}: {script} sets {OUTBOX_ENABLED_ENV}={value!r} — the outbox is "
+            "switched OFF, so no operational row is ever enqueued and every freshness "
+            f"signal above is vacuously green. Fix: set {OUTBOX_ENABLED_ENV}=true in "
+            f"{script} and redeploy."
+        ]
+    return []
+
+
+def outbox_fact(cloud: str, root: Path | None = None) -> str:
+    """What a PASSING stage (e) actually established, said precisely.
+
+    Printed verbatim under the outcome, and it changes nothing: the stage passed
+    or it did not. It exists because "control-plane outbox is enabled"
+    overstates what was done in a way worth one clause: this is a static read of
+    a file in the WORKING TREE, not
+    of the revision that is deployed. A local edit that has not shipped reads as
+    enabled here; so does a script that shipped six months ago. What the running
+    service does with the variable is stages (b)-(d)'s business.
+    """
+    entry = ROLLOUT_REGISTRY.get(cloud)
+    script = entry.control_plane_script if entry else "its control-plane script"
+    value = declared_outbox_value(cloud, root=root)
+    return (
+        f"{OUTBOX_ENABLED_ENV}={value!r} in the working tree's {script} "
+        "(static read of this checkout, not of the deployed revision)"
+    )
+
+
+def outbox_note(cloud: str, root: Path | None = None) -> str | None:
+    """The extra line a stage (e) that passes on a COMPUTED value needs.
+
+    ``aws_eu_control_plane.sh`` writes ``"${OUTBOX_ENABLED}"``, which it sets to
+    ``false`` when no ClickHouse secret exists in the region. Statically that is
+    "enabled"; at runtime it may not be. Say so rather than imply more than was
+    measured.
+    """
+    value = declared_outbox_value(cloud, root=root)
+    if value is None or not value.startswith("$"):
+        return None
+    entry = ROLLOUT_REGISTRY[cloud]
+    return (
+        f"{OUTBOX_ENABLED_ENV} is computed at deploy time ({value}) in "
+        f"{entry.control_plane_script}; this stage proves the script CAN enable it, not "
+        "that the running service did. The runtime evidence is stages (b)-(d)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Small parsing helpers. Duplicated from the freshness checker on purpose: this
+# module must import nothing that does IO, so an operator can run it offline.
+# ---------------------------------------------------------------------------
+
+
+def _as_float(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_time(value: Any) -> dt.datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=dt.UTC)
+
+
+# ---------------------------------------------------------------------------
+# CLI. One subcommand per stage; the shell script owns the ordering and the
+# single HTTPS fetch, this owns every judgement.
+#
+# THE OUTPUT CONTRACT, which is now as small as it can be.
+#
+# A stage HELD if this process exits 0. That is the whole contract. There is no
+# verdict word to parse, no kind, no sentinel, and nothing printed by anything
+# at all — an interpreter warning, a pip notice, a library writing to stdout on
+# import — can turn a non-zero exit into a pass.
+#
+# It used to be bigger. The shell captured this process with `2>&1` and
+# classified the result by its FIRST WORD; the fix for that was a tab-separated
+# sentinel line carrying one of eight `kind` values, each of which the shell
+# turned into a different outcome. Two review rounds then found bugs IN THE
+# TAXONOMY, including one where the exemption kind could not be produced at all
+# and one where the flat green banner was reachable on evidence the module says
+# can never earn it. Classification whose misclassification can upgrade a
+# verdict has to earn its keep, and this one did not.
+#
+# So:
+#
+#   exit status  0 = this stage held. Anything else = it did not.
+#   stderr       the human sentences: what failed and what to do about it.
+#   stdout       zero or more PLAIN lines the shell prints verbatim under the
+#                outcome, and one special case, `status-url`, whose single line
+#                IS the answer the shell asked for.
+#
+# Stdout carries no authority: an extra line is an extra note under the banner,
+# never a different verdict.
+# ---------------------------------------------------------------------------
+
+#: The one non-zero exit that means something other than "this cloud is broken":
+#: the status page parses and carries no ``analytics`` section at all, so the
+#: question cannot be asked from outside yet. Every cloud is in this state until
+#: a control plane built from a commit that publishes the section is deployed to
+#: it, and the run that INSTALLS a drain hits it by construction. Reporting that
+#: as "your install failed" is how an operator learns to stop reading exit
+#: codes. It is still a failure: a cloud nobody can see is not a finished cloud.
+EXIT_NOT_OBSERVABLE = 5
+
+
+def _fail(blockers: list[str]) -> int:
+    """Every blocker to stderr, verbatim; the process is the verdict."""
+    for line in blockers:
+        print(line, file=sys.stderr)
+    return 1
+
+
+def _pass(notes: list[str] | None = None) -> int:
+    """Notes to stdout for the shell to print under the outcome. Exit 0."""
+    for note in notes or []:
+        print(" ".join(note.split()))
+    return 0
+
+
+def _load(path: str) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as handle:
+        raw = handle.read()
+    try:
+        return unwrap_status_payload(json.loads(raw))
+    except json.JSONDecodeError as exc:
+        head = " ".join(raw[:160].split()) or "(empty body)"
+        raise UnreadableStatusPage(
+            f"the status URL answered 200 but the body is not JSON ({exc.msg} at line "
+            f"{exc.lineno}). First bytes: {head!r}"
+        ) from exc
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Is this cloud's rollout complete?")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    for name in ("registry", "status-url", "outbox"):
+        child = sub.add_parser(name)
+        child.add_argument("--cloud", required=True)
+    # No --max-lag-seconds and no --status-url. The bound is
+    # DEFAULT_MAX_DRAIN_LAG_SECONDS and the URL is the fleet registry's; a gate
+    # with a knob for either is a gate with a way to pass a cloud that failed.
+    for name in ("section", "available", "lag"):
+        child = sub.add_parser(name)
+        child.add_argument("--cloud", required=True)
+        child.add_argument("--status-file", required=True)
+    sub.add_parser("audit")
+    sub.add_parser("clouds")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "audit":
+        gaps = registry_gaps() + script_binding_gaps()
+        return _fail(gaps) if gaps else _pass()
+    if args.command == "clouds":
+        return _pass([",".join(declared_clouds())])
+    if args.command == "registry":
+        blockers = registry_blockers(args.cloud)
+        return _fail(blockers) if blockers else _pass()
+    if args.command == "status-url":
+        blockers = registry_blockers(args.cloud)
+        if blockers:
+            return _fail(blockers)
+        # The one subcommand whose stdout the shell CONSUMES rather than
+        # reprints. It still carries no authority: the shell refuses anything
+        # that is not an https:// URL, and a refusal is a failure.
+        return _pass([freshness_registry()[args.cloud]])
+    if args.command == "outbox":
+        blockers = outbox_enabled_blockers(args.cloud)
+        if blockers:
+            return _fail(blockers)
+        notes = [outbox_fact(args.cloud)]
+        note = outbox_note(args.cloud)
+        if note:
+            notes.append(note)
+        return _pass(notes)
+
+    try:
+        payload = _load(args.status_file)
+    except UnreadableStatusPage as exc:
+        # NOT the "publishes no analytics section" state, and deploying a newer
+        # control plane does nothing for it, so it does not get that state's
+        # exit code. It is a plain failure with its own sentence.
+        return _fail(
+            [
+                f"{args.cloud}: {exc}. This is not 'the cloud publishes no analytics "
+                "section' — a CDN interstitial, a captive portal or a truncated body is "
+                "not an older control plane, and redeploying will not change it. Fetch "
+                "the URL by hand and look at what came back."
+            ]
+        )
+
+    if args.command == "section":
+        blockers = section_blockers(args.cloud, payload)
+        if blockers:
+            for line in blockers:
+                print(line, file=sys.stderr)
+            return EXIT_NOT_OBSERVABLE
+        return _pass()
+
+    if args.command == "available":
+        blockers = available_blockers(args.cloud, payload)
+        return _fail(blockers) if blockers else _pass()
+
+    blockers = drain_lag_blockers(args.cloud, payload, now=dt.datetime.now(dt.UTC))
+    return _fail(blockers) if blockers else _pass([DRAIN_LAG_LIMIT_NOTE])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/src/trusted_router/operational_analytics_fleet.py
+++ b/src/trusted_router/operational_analytics_fleet.py
@@ -172,9 +172,11 @@ ANALYTICS_FRESHNESS_FLEET: tuple[FleetAnalyticsEndpoint, ...] = (
             "hold the same outbox shape as AWS -- but that deploy script sets no "
             "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED at all, the setting defaults "
             "to False (config.py), and PostgresStore therefore builds no outbox. "
-            "Verified 2026-08-17: no cloud published an `analytics` section yet, "
-            "so this is read off the deploy script and the default, not off the "
-            "wire. There is no drain here to be missing; expects_outbox=False "
+            "That is read off the deploy script and the default, not off the "
+            "wire -- Azure published no `analytics` section when this was "
+            "written, and the current answer is one command away: "
+            "curl -s https://azure.trustedrouter.com/status.json | jq .data.analytics . "
+            "There is no drain here to be missing; expects_outbox=False "
             "asserts that absence and fails the day it stops being true."
         ),
     ),

--- a/tests/deploy_script_harness.py
+++ b/tests/deploy_script_harness.py
@@ -1,0 +1,426 @@
+"""Run a real deploy script to completion without touching anything real.
+
+WHY THIS EXISTS
+---------------
+The question "does this bring-up script actually run the completeness gate?"
+was answered, for one commit, by a regex: does the string
+``verify_cloud_complete.sh <cloud>`` appear in the script's last N lines? Three
+reviewers killed it for the same reason, and it is the reason this whole change
+exists: that predicate is satisfied by a heredoc body, by a printed
+instruction, and by a commented-out line. Printing the step is not doing the
+step. No amount of hardening the regex fixes a proof-by-text — the next
+careless edit wins, and the check goes on reporting success.
+
+So the script is EXECUTED, and two properties are asserted about what it did:
+
+  1. the gate was CALLED, with this cloud;
+  2. when the gate FAILS, the script exits non-zero.
+
+A printed instruction fails both by construction. So does a commented-out call,
+a heredoc, and a call whose exit status is swallowed.
+
+HOW ISOLATED IT IS, EXACTLY
+---------------------------
+Stated precisely rather than flatteringly, because "hermetic" was claimed here
+before and overstated three separate things.
+
+``PATH`` is one directory, built here, containing:
+
+* a recording stub for each name in :data:`STUBBED_COMMANDS` — the commands
+  these scripts use to leave the machine or change something outside it
+  (``aws``, ``az``, ``gcloud``, ``docker``, ``curl``, ``ssh``, ``systemctl``,
+  ``journalctl``, ``clickhouse-client``, ``sleep``, ...). Each writes its argv
+  to a shared ordered log and exits 0;
+* a symlink to **every other entry of /bin and /usr/bin**. Not a curated list of
+  text utilities: all of them, so nothing has to be re-implemented.
+
+So the isolation is *by name*, and its boundary is :data:`STUBBED_COMMANDS`. A
+script that reached the network through some tool nobody listed — ``ftp``,
+``telnet``, a language runtime — would reach it. What the harness does
+guarantee is what the two assertions need: the scripts under test call the
+cloud CLIs and ``curl``, all of which are stubs, and the ``bash`` they run is
+this machine's.
+
+``$HOME`` and ``$TMPDIR`` point inside the temp directory, and the repository
+the scripts see is a COPY of ``clickhouse/``, ``src/`` and ``scripts/``: they
+read the SQL schemas and the package for real, and writes land in the copy
+rather than in the checkout the suite is running from. That is a copy, not a
+sandbox — an absolute path would still escape it — but no script here uses one.
+``verify_cloud_complete.sh`` in that copy is replaced by a stub that records the
+call and exits with ``HARNESS_VERIFIER_RC``; ``cloud_complete_gate.sh`` is the
+real one, because its behaviour is part of what is being proven, and it resolves
+its verifier relative to itself, which is how the stub gets found.
+
+WHAT THE STUB RESPONSES ARE, AND WHAT THEY ARE NOT
+--------------------------------------------------
+Some scripts check their own work — ``aws_eu_control_plane.sh`` refuses to
+continue unless App Runner reports it is serving the digest that was just
+pushed. A stub that answers ``stub-output`` to everything fails that check, and
+correctly. :data:`SCRIPT_FIXTURES` therefore gives a few argv patterns a
+plausible answer, so the script can reach its own end.
+
+That is a fixture, and it is worth being precise about what it can and cannot
+launder: the two properties above are about the script's CONTROL FLOW at the
+gate, and no answer a stub gives can make a swallowed exit status non-zero or
+conjure a call that is not there. What a wrong fixture does is stop the script
+early — a loud failure in this harness, never a false pass. A script whose
+middle cannot be answered without asserting the answer it wants is recorded as
+NOT_PROVEN instead; ``aws_eu_clickhouse_drain_install.sh`` is that script.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: Commands replaced by a recording stub: anything that reaches the network, a
+#: cloud API, another host, or this machine's state. ``sleep`` is here so a
+#: script's waiter loops do not make the suite take twenty minutes.
+STUBBED_COMMANDS: tuple[str, ...] = (
+    "aws",
+    "az",
+    "gcloud",
+    "gc",
+    "gsutil",
+    "bq",
+    "docker",
+    "podman",
+    "curl",
+    "wget",
+    "ssh",
+    "scp",
+    "rsync",
+    "systemctl",
+    "journalctl",
+    "clickhouse-client",
+    "psql",
+    "openssl",
+    "apt-get",
+    "useradd",
+    "terraform",
+    "gh",
+    "kubectl",
+    "helm",
+    "uv",
+    "sudo",
+    "nc",
+    "ping",
+    "dig",
+    "host",
+    "sleep",
+)
+
+#: Directories whose real contents the scripts read (SQL schemas, the package
+#: they tar up). Copied rather than symlinked so nothing a script does can
+#: reach the checkout the test suite is running from.
+MIRRORED = ("clickhouse", "src", "scripts")
+
+#: ~10MB of web assets no deploy script reads; the drain installer excludes the
+#: same three by name when it builds its payload.
+_IGNORED = shutil.ignore_patterns(
+    "__pycache__", "static", "templates", "content", ".git", "*.pyc", "node_modules"
+)
+
+_STUB = r"""#!/usr/bin/env bash
+# Recording stub. Writes one tab-separated line per invocation to the shared
+# ordered log, answers from the fixture table if anything matches, and exits 0.
+{ printf '%s' "${0##*/}"; for a in "$@"; do printf '\t%s' "$a"; done; printf '\n'; } \
+  >> "$HARNESS_ARGV_LOG"
+# Drain stdin before answering. A stub that exits without reading closes the
+# pipe under its upstream, and `aws ecr get-login-password | docker login
+# --password-stdin` then dies of SIGPIPE -- 141 through `set -o pipefail`, in
+# about one run in eighty. That is the harness inventing a failure in the
+# script it is measuring, which would be a flake in the one suite that must not
+# have any. The run's stdin is /dev/null, so this returns immediately when the
+# stub is not in a pipeline.
+cat >/dev/null 2>&1 || true
+if [ -n "${HARNESS_FIXTURES:-}" ] && [ -f "$HARNESS_FIXTURES" ]; then
+  joined="${0##*/} $*"
+  while IFS=$'\t' read -r pattern reply; do
+    [ -n "$pattern" ] || continue
+    if printf '%s' "$joined" | grep -Eq -- "$pattern"; then
+      printf '%s\n' "$reply"
+      exit 0
+    fi
+  done < "$HARNESS_FIXTURES"
+fi
+printf '%s\n' "stub-output"
+exit 0
+"""
+
+#: The stub that stands in for the gate. It records that it was CALLED and with
+#: what, and exits with whatever the test told it to. Both assertions read this.
+_VERIFIER_STUB = r"""#!/usr/bin/env bash
+{ printf 'verify_cloud_complete.sh'; for a in "$@"; do printf '\t%s' "$a"; done; printf '\n'; } \
+  >> "$HARNESS_ARGV_LOG"
+printf 'stub verifier: pretending to check %s (rc=%s)\n' "$*" "${HARNESS_VERIFIER_RC:-0}" >&2
+exit "${HARNESS_VERIFIER_RC:-0}"
+"""
+
+_ECR = "330422590279.dkr.ecr.eu-west-3.amazonaws.com/trusted-router"
+_DIGEST = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+
+
+@dataclass(frozen=True)
+class ScriptFixture:
+    """What one script needs in order to reach its own last line under stubs."""
+
+    #: Environment the script legitimately requires from its operator. These are
+    #: INPUTS a human types, not state the harness is inventing.
+    env: dict[str, str] = field(default_factory=dict)
+    #: ``(extended-regex over "<command> <argv...>", stdout)`` in priority order.
+    responses: tuple[tuple[str, str], ...] = ()
+    #: Files to create under ``$HOME`` before the run, path -> contents.
+    home_files: dict[str, str] = field(default_factory=dict)
+    #: Commands legitimately issued AFTER the gate has answered, as regexes over
+    #: the joined argv. Only cleanup belongs here — an EXIT trap tearing down
+    #: something the script created. Provisioning after the gate means the gate
+    #: checked a cloud that did not exist yet, which is what the old "must be in
+    #: the last N lines" rule was reaching for.
+    cleanup_after_gate: tuple[str, ...] = ()
+
+
+SCRIPT_FIXTURES: dict[str, ScriptFixture] = {
+    "scripts/deploy/aws_eu_clickhouse.sh": ScriptFixture(),
+    # GCP's out-of-band check needs nothing from an operator: it runs the gate,
+    # retries while a Cloud Run revision takes traffic, and returns the gate's
+    # status. Listed explicitly rather than falling through to the default so
+    # that "GCP is in the harness" is visible here and not only in the registry.
+    # `sleep` is stubbed, so its retry loop costs the suite nothing.
+    "scripts/deploy/verify_gcp_complete.sh": ScriptFixture(),
+    "scripts/deploy/aws_eu_control_plane.sh": ScriptFixture(
+        # PCR0 is a required operator input: the script refuses to run without
+        # the enclave measurement to pin, which is the point of the probe.
+        env={"ATTESTATION_PCR0": "0" * 96},
+        responses=(
+            # It deploys by DIGEST and then refuses to believe App Runner until
+            # the service reports it is serving that exact digest.
+            (r"ecr describe-images", _DIGEST),
+            (r"apprunner describe-service.*ImageIdentifier", f"{_ECR}@{_DIGEST}"),
+            (r"apprunner describe-service.*Service\.Status", "RUNNING"),
+            (r"apprunner list-services", "arn:aws:apprunner:eu-west-3:330422590279:service/tr-eu"),
+            # It waits for the EventBridge API-key connection to authorize.
+            (r"events describe-connection", "AUTHORIZED"),
+        ),
+    ),
+    "scripts/deploy/aws_eu_north_clickhouse.sh": ScriptFixture(
+        env={"TR_STOCKHOLM_REPLICA_WIRED": "1"},
+        responses=(
+            # It computes a non-overlapping CIDR for the second VPC from the
+            # first one's, in real ipaddress arithmetic.
+            (r"ec2 describe-vpcs.*CidrBlock", "10.50.0.0/16"),
+            (r"ec2 describe-vpcs", "vpc-05b829b9cae6a9cd8"),
+            # It refuses to build the inter-region path unless the Paris
+            # subnet it found really is in the Paris VPC.
+            (r"ec2 describe-subnets.*Subnets\[0\]\.VpcId", "vpc-05b829b9cae6a9cd8"),
+            (r"describe-transit-gateway", "available"),
+            (r"--query .?State", "available"),
+        ),
+    ),
+    "scripts/deploy/azure_control_plane.sh": ScriptFixture(
+        env={},
+        home_files={
+            # Credential-shaped inputs the script requires. Fake values in a
+            # temp $HOME; nothing here is or resembles a real token.
+            ".quill-secrets/trustedrouter-internal-gateway-token": "harness-fake-internal\n",
+            ".quill-secrets/trustedrouter-synthetic-monitor-api-key": "harness-fake-monitor\n",
+            ".quill-secrets/trustedrouter-federation-peer-token": "harness-fake-peer\n",
+        },
+        responses=(
+            (r"acr build|acr import", "harness"),
+            (r"--query .?loginServer", "trazureuaenorthacr.azurecr.io"),
+            (r"--query .?fullyQualifiedDomainName", "tr-azure-pg.postgres.database.azure.com"),
+            (r"--query .?properties\.configuration\.ingress\.fqdn", "tr-azure.example.net"),
+            # It asserts the COUNT of tr_* tables, not psql's exit code.
+            (r"information_schema\.tables", "9"),
+        ),
+        # The only thing this script does after the gate is the EXIT trap it
+        # armed to remove the temporary Postgres firewall rule it opened to
+        # apply the schema. Cleanup, not provisioning.
+        cleanup_after_gate=(r"firewall-rule delete",),
+    ),
+}
+
+
+@dataclass
+class HarnessRun:
+    """One execution: what it exited with, and every command it ran, in order."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+    calls: list[list[str]]
+
+    @property
+    def verifier_calls(self) -> list[list[str]]:
+        return [call for call in self.calls if call[0] == "verify_cloud_complete.sh"]
+
+    def gate_ran_for(self, cloud: str) -> bool:
+        return any(call[1:] == [cloud] for call in self.verifier_calls)
+
+    def cloud_cli_calls_after_the_gate(self, allowed: tuple[str, ...] = ()) -> list[list[str]]:
+        """Provisioning commands issued AFTER the gate answered.
+
+        The old text check enforced "the verifier is in the last N lines" as a
+        proxy for "it is the last thing the script does". This is that property
+        measured instead of guessed: a gate that passes and is then followed by
+        more cloud mutations checked a cloud that did not exist yet.
+
+        ``allowed`` is for EXIT-trap cleanup, which genuinely runs last and is
+        not provisioning.
+        """
+        cloud_clis = {"aws", "az", "gcloud", "gc", "docker", "ssh", "scp", "clickhouse-client"}
+        patterns = [re.compile(pattern) for pattern in allowed]
+        seen_gate = False
+        after: list[list[str]] = []
+        for call in self.calls:
+            if call[0] == "verify_cloud_complete.sh":
+                seen_gate = True
+                continue
+            if not seen_gate or call[0] not in cloud_clis:
+                continue
+            joined = " ".join(call)
+            if any(pattern.search(joined) for pattern in patterns):
+                continue
+            after.append(call)
+        return after
+
+
+class DeployScriptHarness:
+    """A throwaway checkout, a stub PATH, and one recorded run per invocation."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.mirror = root / "repo"
+        self.bin = root / "bin"
+        self._runs = 0
+        self._build_mirror()
+        self._build_bin()
+
+    def _build_mirror(self) -> None:
+        self.mirror.mkdir(parents=True)
+        for name in MIRRORED:
+            shutil.copytree(
+                REPO_ROOT / name, self.mirror / name, ignore=_IGNORED, symlinks=True
+            )
+        for name in ("pyproject.toml",):
+            if (REPO_ROOT / name).is_file():
+                shutil.copy(REPO_ROOT / name, self.mirror / name)
+        verifier = self.mirror / "scripts" / "deploy" / "verify_cloud_complete.sh"
+        verifier.write_text(_VERIFIER_STUB)
+        verifier.chmod(0o755)
+
+    def _build_bin(self) -> None:
+        self.bin.mkdir(parents=True)
+        for name in STUBBED_COMMANDS:
+            stub = self.bin / name
+            stub.write_text(_STUB)
+            stub.chmod(0o755)
+        for directory in ("/bin", "/usr/bin"):
+            source = Path(directory)
+            if not source.is_dir():
+                continue
+            for entry in source.iterdir():
+                if entry.name in STUBBED_COMMANDS or (self.bin / entry.name).exists():
+                    continue
+                try:
+                    (self.bin / entry.name).symlink_to(entry)
+                except OSError:  # pragma: no cover - unusual filesystems
+                    continue
+
+    def write_script(self, relative: str, text: str) -> str:
+        """Add a script to the mirrored checkout, for saboteur cases.
+
+        Used to demonstrate that the two assertions catch the shapes the old
+        text check let through — a printed instruction, a commented-out call, a
+        swallowed exit status — rather than only asserting they would.
+        """
+        target = self.mirror / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text)
+        target.chmod(0o755)
+        return relative
+
+    def run(
+        self,
+        script: str,
+        *,
+        verifier_rc: int = 0,
+        timeout: int = 120,
+        omit_env: tuple[str, ...] = (),
+    ) -> HarnessRun:
+        """Run one script. ``omit_env`` drops fixture variables for this run.
+
+        ``omit_env`` exists for one question, and it is a question worth being
+        able to ask: a fixture supplies the environment an operator would type,
+        so a property that holds only BECAUSE the fixture supplied something is
+        a property that does not hold on a first run. See
+        ``test_the_gate_status_survives_without_the_operator_attestation``.
+        """
+        fixture = SCRIPT_FIXTURES.get(script, ScriptFixture())
+        self._runs += 1
+        run_dir = self.root / f"run-{self._runs:03d}"
+        home = run_dir / "home"
+        tmp = run_dir / "tmp"
+        home.mkdir(parents=True)
+        tmp.mkdir(parents=True)
+        for relative, contents in fixture.home_files.items():
+            target = home / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(contents)
+
+        argv_log = run_dir / "argv.log"
+        argv_log.write_text("")
+        fixtures_file = run_dir / "fixtures.tsv"
+        fixtures_file.write_text(
+            "".join(f"{pattern}\t{reply}\n" for pattern, reply in fixture.responses)
+        )
+
+        env = {
+            "PATH": str(self.bin),
+            "HOME": str(home),
+            "TMPDIR": str(tmp),
+            "LANG": "C",
+            "HARNESS_ARGV_LOG": str(argv_log),
+            "HARNESS_FIXTURES": str(fixtures_file),
+            "HARNESS_VERIFIER_RC": str(verifier_rc),
+            **{k: v for k, v in fixture.env.items() if k not in omit_env},
+        }
+
+        proc = subprocess.run(  # noqa: S603 - fixed argv, stub PATH, repo-local script
+            ["bash", str(self.mirror / script)],  # noqa: S607
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=str(self.mirror),
+            timeout=timeout,
+            # So a stub draining stdin sees EOF at once unless it is genuinely
+            # downstream of a pipe.
+            stdin=subprocess.DEVNULL,
+        )
+        calls = [
+            line.split("\t")
+            for line in argv_log.read_text().splitlines()
+            if line.strip()
+        ]
+        return HarnessRun(proc.returncode, proc.stdout, proc.stderr, calls)
+
+
+def summarise(run: HarnessRun) -> str:
+    """A failure message that says where the script actually stopped."""
+    tail = "\n".join(run.stderr.splitlines()[-12:])
+    return (
+        f"exit={run.returncode}\n"
+        f"commands={json.dumps([c[0] for c in run.calls][-12:])}\n"
+        f"stderr tail:\n{tail}"
+    )
+
+
+assert os.name == "posix", "the deploy-script harness needs a POSIX shell"

--- a/tests/test_cloud_rollout_completeness.py
+++ b/tests/test_cloud_rollout_completeness.py
@@ -1,0 +1,1270 @@
+"""A cloud cannot be added without becoming checkable.
+
+The AWS-EU cloud served production traffic for fifteen days with no analytics
+pipeline: no drain, 470,897 rows stuck in the DSQL outbox, `activity_generations`
+empty, and total silence, because the only backlog alarm is emitted BY the drain
+that was missing. The bring-up script had ended by PRINTING next steps and
+exiting 0.
+
+Four things are pinned here.
+
+1. **The cloud binding.** `declared_clouds()` delegates to
+   `operational_analytics_fleet.deployed_clouds()` — the union of every table in
+   this repo that declares a deployment — so a cloud added to any one of them is
+   a cloud the completeness check immediately expects to know about, and
+   `registry_gaps()` fails until it does.
+   `test_a_new_cloud_fails_ci_until_it_is_checkable` adds a fake cloud and
+   asserts the failure, which is the whole mechanism: you cannot get a cloud
+   into this codebase quietly.
+
+2. **The script registry, and what it is FOR.** Which deploy scripts must end in
+   the gate is data on `CloudRollout`, not a list in this file. What is checked
+   here is structural — the file exists, an unbound script carries a reason,
+   nothing unclaimed calls the verifier. Whether a script really runs the gate
+   is proven by RUNNING it, in `tests/test_deploy_script_execution.py`; this
+   file deliberately makes no claim it cannot support, because the previous
+   version made exactly that mistake with a regex.
+
+3. **The gate takes no input from anywhere.** Deploy scripts inherit their
+   caller's environment, so an env-tunable bound or status URL is a remote
+   control for the gate; a flag needs an outcome of its own to be safe, and an
+   outcome that exists to make an override safe is more machinery to get wrong.
+   There is neither. The tests below run the real shell with those variables
+   exported and assert on what it FETCHED and what argv it PASSED, not on what
+   it printed.
+
+4. **The stages, and the one thing a passing run may claim.** Stage (e) is not
+   redundant with stage (d), because a drained outbox and a disabled outbox
+   publish the same `drain_lag_seconds: 0.0`. A run either VERIFIED the cloud or
+   it did not: there is no waiver, no exemption and no verdict taxonomy, because
+   two review rounds found bugs inside that machinery rather than around it. The
+   green sentence is written so that it is true of every run that reaches it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import datetime as dt
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from trusted_router import cloud_rollout_completeness as crc
+from trusted_router import operational_analytics_fleet as fleet
+from trusted_router import regions
+from trusted_router.operational_analytics_freshness import (
+    ANALYTICS_STATUS_KEY,
+    AVAILABLE_FIELD,
+    DEFAULT_MAX_DRAIN_LAG_SECONDS,
+    REASON_NOT_CONFIGURED,
+    REASON_UNREACHABLE,
+    analytics_status_section,
+    analytics_status_unavailable,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFIER = ROOT / "scripts" / "deploy" / "verify_cloud_complete.sh"
+
+NOW = dt.datetime(2026, 8, 17, 12, 0, tzinfo=dt.UTC)
+
+
+@dataclass(frozen=True)
+class _ModuleRun:
+    """What one CLI invocation exited with, and what it wrote to each stream."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def _verified(stderr: str) -> bool:
+    """Did the run print the ONE green outcome?
+
+    Spelled with the leading newline on purpose: "NOT VERIFIED" contains
+    "VERIFIED", so the naive check passes on the failure banner and every
+    assertion written with it is vacuous.
+    """
+    return "\nVERIFIED —" in stderr
+
+
+def _run_module(*argv: str) -> _ModuleRun:
+    """Call the module's CLI in process. The exit status IS the verdict.
+
+    Worth stating once, since it is the whole output contract: nothing is parsed
+    out of either stream to decide whether a stage held. stdout carries plain
+    notes the shell reprints under the outcome; stderr carries the blockers.
+    """
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        code = crc.main(list(argv))
+    return _ModuleRun(code, out.getvalue(), err.getvalue())
+
+
+def _payload(section: dict[str, Any] | None) -> dict[str, Any]:
+    body: dict[str, Any] = {"overall_status": "up"}
+    if section is not None:
+        body[ANALYTICS_STATUS_KEY] = section
+    return body
+
+
+def _healthy_section() -> dict[str, Any]:
+    return analytics_status_section(
+        oldest_enqueued_at=NOW - dt.timedelta(seconds=30),
+        now=NOW,
+        outbox_depth=12,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The binding: adding a cloud is adding an obligation.
+# ---------------------------------------------------------------------------
+
+
+def test_registry_is_bound_to_the_declared_clouds() -> None:
+    """Every declared cloud is reachable by the completeness check.
+
+    No list of clouds is written here on purpose — a test that hard-codes
+    {aws, azure, gcp} is another copy of the fleet, and the copies are what
+    drift. The assertion is the relation: whatever the deployment tables
+    declare, `verify_cloud_complete.sh` can check it.
+    """
+    gaps = crc.registry_gaps()
+    assert gaps == [], "\n".join(gaps)
+    registry = crc.freshness_registry()
+    for cloud in crc.declared_clouds():
+        assert registry[cloud].startswith("https://")
+        assert cloud in crc.ROLLOUT_REGISTRY
+
+
+def test_the_cloud_list_is_the_fleet_module_s_and_not_a_second_copy() -> None:
+    """One union, in one place, named by the module that owns the question.
+
+    An earlier revision re-derived the union here from three of the five tables
+    `operational_analytics_fleet.deployment_sources()` reads. Two unions that
+    disagree is the outage's shape with the halves swapped, so this asserts the
+    delegation rather than the answer.
+    """
+    assert crc.declared_clouds() == fleet.deployed_clouds()
+
+
+def test_the_gate_asks_the_front_end_that_holds_the_dsql_connection() -> None:
+    """The AWS URL is the App Runner plane, not the vanity hostname.
+
+    This is the concrete reason stage (a) reads the fleet registry instead of
+    anything else. `aws.trustedrouter.com` fronts the Fargate control plane
+    through Global Accelerator; the deployment that holds the Aurora DSQL
+    connection — and whose drain was missing for fifteen days — is the tr-eu App
+    Runner service. A gate pointed at the wrong AWS front end would have been
+    green throughout the outage.
+    """
+    aws = crc.freshness_registry()["aws"]
+    entry = fleet.fleet_endpoint("aws")
+    assert entry is not None and entry.status_url == aws
+    assert "aws.trustedrouter.com" not in aws
+    assert "awsapprunner.com" in aws
+
+
+def test_a_new_cloud_fails_ci_until_it_is_checkable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """THE test. A cloud added to a deployment table with nothing else is a defect.
+
+    This is the shape of the AWS-EU outage expressed as a unit test: a cloud
+    exists, and no part of the system treats "it has no analytics pipeline" as
+    an incomplete rollout. Adding the region below is all it takes to reproduce
+    it, and `registry_gaps()` is what refuses.
+    """
+    monkeypatch.setitem(
+        regions.MULTICLOUD_REGION_GEO,
+        "oracle-eu-frankfurt-1",
+        regions.RegionGeo("oracle-eu-frankfurt-1", "Frankfurt", 50.111, 8.682, cloud="oracle"),
+    )
+
+    assert "oracle" in crc.declared_clouds()
+    gaps = crc.registry_gaps()
+    assert gaps, "a cloud with no freshness endpoint and no rollout entry must fail"
+
+    joined = "\n".join(gaps)
+    # The message has to name the fix, not just the fact. A CI failure that says
+    # "oracle: missing" teaches nobody what a complete cloud is.
+    assert "oracle: declared as a deployment" in joined
+    assert "operational_analytics_fleet.py" in joined
+    assert "ROLLOUT_REGISTRY" in joined
+    assert "verify_cloud_complete.sh" in joined
+
+
+def test_registry_gap_survives_a_half_finished_addition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Wiring the status URL but not the rollout entry is still a gap.
+
+    The likelier real mistake: someone adds the endpoint so the fleet page looks
+    complete, and never adds what "done" means for that cloud.
+    """
+    monkeypatch.setitem(
+        regions.MULTICLOUD_REGION_GEO,
+        "oracle-eu-frankfurt-1",
+        regions.RegionGeo("oracle-eu-frankfurt-1", "Frankfurt", 50.111, 8.682, cloud="oracle"),
+    )
+    monkeypatch.setattr(
+        crc,
+        "freshness_registry",
+        lambda: {
+            **{c: "https://x/status.json" for c in ("aws", "azure", "gcp")},
+            "oracle": "https://oracle.trustedrouter.com/status.json",
+        },
+    )
+    gaps = crc.registry_gaps()
+    assert len(gaps) == 1
+    assert "absent from ROLLOUT_REGISTRY" in gaps[0]
+
+
+def test_a_cloud_the_fleet_declares_uncheckable_is_still_a_gap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`reason=` in the fleet registry is not a pass here.
+
+    The fleet checker treats a cloud with no public status URL as EXPLICITLY
+    UNCHECKED and does not fail — reasonably, since a daily job that fails
+    forever about something nobody can fix is a job people mute. A ROLLOUT is a
+    different question: a cloud nobody outside can measure cannot be declared
+    done, whatever the reason, so this reports it with the reason attached.
+    """
+    monkeypatch.setattr(
+        fleet,
+        "ANALYTICS_FRESHNESS_FLEET",
+        (
+            *[e for e in fleet.ANALYTICS_FRESHNESS_FLEET if e.cloud != "azure"],
+            fleet.FleetAnalyticsEndpoint(cloud="azure", reason="internal-only ALB, no public page"),
+        ),
+    )
+    monkeypatch.setattr(
+        crc, "ANALYTICS_FRESHNESS_FLEET", fleet.ANALYTICS_FRESHNESS_FLEET
+    )
+    gaps = crc.registry_gaps()
+    assert any("UNCHECKABLE over HTTP" in gap and "internal-only ALB" in gap for gap in gaps), gaps
+
+
+def test_every_registered_cloud_names_a_control_plane_script_that_exists() -> None:
+    """A fix instruction pointing at a file that is not there is not a fix."""
+    for cloud, entry in crc.ROLLOUT_REGISTRY.items():
+        assert (ROOT / entry.control_plane_script).is_file(), (
+            f"{cloud}: {entry.control_plane_script} does not exist"
+        )
+
+
+# ---------------------------------------------------------------------------
+# (a)-(d): what the cloud publishes about itself.
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_cloud_is_a_failure_not_a_skip() -> None:
+    blockers = crc.registry_blockers("oracle")
+    assert blockers
+    assert any("no ROLLOUT_REGISTRY entry" in b for b in blockers)
+
+
+def test_missing_analytics_section_fails() -> None:
+    blockers = crc.section_blockers("aws", _payload(None))
+    assert blockers
+    assert "publishes no 'analytics' section" in blockers[0]
+
+
+def test_the_absent_section_and_the_unreadable_body_get_different_exits(
+    tmp_path: Path,
+) -> None:
+    """The two states stage (b) can be in, and why only one of them keeps a code.
+
+    "This cloud publishes no analytics section" is the state every cloud is in
+    until a control plane that publishes it is deployed, and the run installing
+    a drain hits it by construction — so it keeps its own exit, 5, and its own
+    words. A body that is not the status document at all (a CDN interstitial, a
+    captive portal, a truncated response) is a plain failure: deploying a newer
+    control plane does nothing for it, and the message says so instead of
+    borrowing the other one's advice.
+    """
+    absent = tmp_path / "absent.json"
+    absent.write_text(json.dumps({"data": {"overall_status": "up"}}))
+    run = _run_module("section", "--cloud", "aws", "--status-file", str(absent))
+    assert run.returncode == crc.EXIT_NOT_OBSERVABLE
+    assert "publishes no 'analytics' section" in run.stderr
+
+    interstitial = tmp_path / "interstitial.html"
+    interstitial.write_text("<!DOCTYPE html><title>Just a moment...</title>")
+    run = _run_module("section", "--cloud", "aws", "--status-file", str(interstitial))
+    assert run.returncode == 1
+    assert "Just a moment" in run.stderr
+    assert "redeploying will not change it" in run.stderr
+
+
+def test_a_body_that_is_not_the_status_document_is_its_own_finding() -> None:
+    """"No analytics section" and "not the status page at all" are different.
+
+    Both used to end in NOT YET OBSERVABLE, whose fix instruction is "deploy a
+    control plane built from a newer commit". That does nothing about a
+    Cloudflare challenge page, a captive portal, or a body cut off mid-stream.
+    """
+    with pytest.raises(crc.UnreadableStatusPage):
+        crc.unwrap_status_payload(["not", "an", "object"])
+
+
+def test_unavailable_is_not_the_same_as_empty() -> None:
+    """"I could not look" must never collapse into "there was nothing to see"."""
+    blockers = crc.available_blockers(
+        "aws", _payload(analytics_status_unavailable(REASON_UNREACHABLE))
+    )
+    assert blockers
+    assert "available is false" in blockers[0]
+    # Names the actual command, from the registry.
+    assert "aws_eu_clickhouse_drain_install.sh" in blockers[0]
+
+
+def test_not_configured_is_not_the_same_as_unreachable() -> None:
+    """A cloud saying "I run no outbox" is a configuration, not a fault.
+
+    Both fail, and neither is excusable — there is no exemption any more — but
+    they send the reader to different places, so they get different sentences.
+    """
+    configured_off = crc.available_blockers(
+        "azure", _payload(analytics_status_unavailable(REASON_NOT_CONFIGURED))
+    )
+    broken = crc.available_blockers(
+        "azure", _payload(analytics_status_unavailable(REASON_UNREACHABLE))
+    )
+    assert "runs NO operational-analytics outbox" in configured_off[0]
+    assert "could not read its own" in broken[0]
+    assert configured_off != broken
+
+
+def test_healthy_section_passes_c_and_d() -> None:
+    payload = _payload(_healthy_section())
+    assert crc.available_blockers("aws", payload) == []
+    assert crc.drain_lag_blockers("aws", payload, now=NOW) == []
+
+
+def test_the_string_false_does_not_read_as_available() -> None:
+    """Stage (c) tested this field with Python truthiness, and `"false"` is true.
+
+    The value comes off somebody else's HTTP response. A control plane that
+    serialised the flag as text — or anything in the path that stringified the
+    body — would publish `available: "false"` and be read here as AVAILABLE,
+    which passes the stage whose entire job is to notice that the control plane
+    could not read its own outbox. Only a JSON boolean counts now, and a
+    non-boolean is its own finding rather than a silent pass.
+    """
+    for value in ("false", "0", "no"):
+        section = {**_healthy_section(), AVAILABLE_FIELD: value}
+        blockers = crc.available_blockers("aws", _payload(section))
+        assert blockers, f"{value!r} read as available"
+        assert "rather than the JSON boolean" in blockers[0]
+        # ...and stage (d) does not then read a lag off a section it cannot trust.
+        assert crc.drain_lag_blockers("aws", _payload(section), now=NOW)
+
+    assert crc.available_blockers("aws", _payload(_healthy_section())) == []
+
+
+def test_a_generated_at_in_the_future_fails_instead_of_disabling_the_check() -> None:
+    """A negative age passes every "is it too old?" test there is.
+
+    The staleness half of stage (d) exists because a frozen control plane
+    republishes a healthy lag forever. A publisher whose clock or timezone is
+    wrong stamps the section ahead of now, the computed age goes negative, and
+    the comparison can never fire again however stale the snapshot really is —
+    the check switches itself off and the run stays green.
+    """
+    stamped = NOW + dt.timedelta(hours=6)
+    section = analytics_status_section(
+        oldest_enqueued_at=stamped - dt.timedelta(seconds=5), now=stamped
+    )
+    blockers = crc.drain_lag_blockers("aws", _payload(section), now=NOW)
+    # Non-emptiness FIRST. `blockers == [b for b in blockers if ...]` is
+    # trivially true for the empty list, so the previous form passed with the
+    # guard deleted -- a test green for the reason it was written to catch.
+    assert blockers, "a generated_at 6h in the future produced no blocker at all"
+    assert all("in the FUTURE" in blocker for blocker in blockers), blockers
+
+    # Ordinary clock skew between two machines is not a finding.
+    skew = dt.timedelta(seconds=crc.MAX_SECTION_CLOCK_SKEW_SECONDS - 1)
+    skewed = analytics_status_section(
+        oldest_enqueued_at=NOW + skew - dt.timedelta(seconds=5), now=NOW + skew
+    )
+    assert crc.drain_lag_blockers("aws", _payload(skewed), now=NOW) == []
+
+
+def test_stage_d_defers_to_stage_c_rather_than_inventing_a_second_failure() -> None:
+    """An unavailable section has no lag to read, and must not pretend otherwise.
+
+    Reporting "drain_lag_seconds is missing" about a section that says
+    `available: false` is the same condition twice, in words that point at the
+    wrong fix.
+    """
+    blockers = crc.drain_lag_blockers(
+        "azure", _payload(analytics_status_unavailable(REASON_NOT_CONFIGURED)), now=NOW
+    )
+    assert len(blockers) == 1
+    assert "Stage (c) is the one to fix" in blockers[0]
+
+
+def test_the_aws_eu_backlog_would_have_failed_stage_d() -> None:
+    """The outage, replayed: fifteen days of undrained rows.
+
+    2026-08-02 -> 2026-08-17 is the real interval; 1,248,668s is the lag the
+    drain reported on the day it was finally installed.
+    """
+    section = analytics_status_section(
+        oldest_enqueued_at=dt.datetime(2026, 8, 2, 4, 15, tzinfo=dt.UTC),
+        now=NOW,
+        outbox_depth=470_897,
+    )
+    blockers = crc.drain_lag_blockers("aws", _payload(section), now=NOW)
+    assert blockers
+    assert "oldest undelivered outbox row is" in blockers[0]
+    assert "aws_eu_clickhouse_drain_install.sh" in blockers[0]
+
+
+def test_stale_section_fails_even_when_the_lag_reads_healthy() -> None:
+    """A frozen control plane republishes a healthy number forever."""
+    section = analytics_status_section(
+        oldest_enqueued_at=NOW - dt.timedelta(seconds=5),
+        now=NOW - dt.timedelta(hours=9),
+    )
+    blockers = crc.drain_lag_blockers("aws", _payload(section), now=NOW)
+    assert blockers
+    assert "section is" in blockers[0] and "old" in blockers[0]
+
+
+def test_lag_bound_matches_the_alarm_the_drain_itself_fires() -> None:
+    """A gate more tolerant than the process it gates is decorative."""
+    assert crc.DEFAULT_MAX_SECTION_AGE_SECONDS == 3_600.0
+    section = analytics_status_section(
+        oldest_enqueued_at=NOW - dt.timedelta(seconds=DEFAULT_MAX_DRAIN_LAG_SECONDS + 1),
+        now=NOW,
+    )
+    assert crc.drain_lag_blockers("aws", _payload(section), now=NOW)
+
+
+def test_the_limit_of_a_passing_lag_is_printed_on_every_passing_run(tmp_path: Path) -> None:
+    """What green means, said on the runs that are green — all of them.
+
+    This used to be conditional: the sentence was printed only when the section
+    reported `outbox_depth == 0`. No storage backend in this repository ever
+    populates that field (both build `OutboxFreshness` without it), so against a
+    real cloud the condition was never true and the sentence was never printed —
+    while the banner it was supposed to weaken printed every time. The
+    limitation does not depend on the depth, so neither does the sentence.
+    """
+    payload = _payload(
+        analytics_status_section(oldest_enqueued_at=None, now=NOW, outbox_depth=None)
+    )
+    assert crc.drain_lag_blockers("aws", payload, now=NOW) == []
+    assert "does not prove rows are moving" in crc.DRAIN_LAG_LIMIT_NOTE
+
+    # ...and it reaches the operator, on stdout, where the shell reprints it.
+    # Generated at the real clock: the CLI compares the section's age to now.
+    live = dt.datetime.now(dt.UTC)
+    status = tmp_path / "status.json"
+    status.write_text(
+        json.dumps(
+            _payload(analytics_status_section(oldest_enqueued_at=None, now=live))
+        )
+    )
+    captured = _run_module("lag", "--cloud", "aws", "--status-file", str(status))
+    assert captured.returncode == 0
+    assert crc.DRAIN_LAG_LIMIT_NOTE.split(";")[0] in captured.stdout
+
+
+# ---------------------------------------------------------------------------
+# (e): the producer side, which (b)-(d) cannot see.
+# ---------------------------------------------------------------------------
+
+
+def test_azure_fails_because_it_has_no_outbox_at_all() -> None:
+    """Pins the state found on 2026-08-17, and the reason it is not benign.
+
+    Azure's control-plane deploy script sets no outbox variable, so settle
+    enqueues nothing. Every published freshness signal for such a cloud is
+    vacuously green. This test flips to the other branch when the outbox is
+    added, which is the point at which it should.
+    """
+    assert crc.declared_outbox_value("azure") is None
+    blockers = crc.outbox_enabled_blockers("azure")
+    assert blockers
+    assert "never sets TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED" in blockers[0]
+    assert "looks perfectly healthy" in blockers[0]
+
+
+def test_gcp_and_aws_declare_the_outbox() -> None:
+    assert crc.declared_outbox_value("gcp") == "true"
+    assert crc.outbox_enabled_blockers("gcp") == []
+    # AWS computes it at deploy time; the stage passes and says what it did not prove.
+    assert crc.declared_outbox_value("aws") == "${OUTBOX_ENABLED}"
+    assert crc.outbox_enabled_blockers("aws") == []
+    note = crc.outbox_note("aws")
+    assert note is not None and "computed at deploy time" in note
+
+
+def test_instructions_to_set_the_variable_are_not_the_variable(tmp_path: Path) -> None:
+    """The check must not read its own advice back as compliance.
+
+    Found while writing this: `azure_control_plane.sh` now ends by printing the
+    exact line an operator should add — `TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED
+    =true` — and a name-anywhere match counted that as having set it. The one
+    cloud this stage exists to fail passed, because the fix instruction looked
+    like the fix.
+    """
+    script_dir = tmp_path / "scripts" / "deploy"
+    script_dir.mkdir(parents=True)
+    (script_dir / "azure_control_plane.sh").write_text(
+        'az containerapp update --set-env-vars "TR_ENVIRONMENT=canary"\n'
+        "cat >&2 <<'NEXT'\n"
+        "  2. add to the ENV_VARS block in this file:\n"
+        "       TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true\n"
+        "NEXT\n"
+        "# and see TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED in the runbook\n"
+    )
+    assert crc.declared_outbox_value("azure", root=tmp_path) is None
+    assert crc.outbox_enabled_blockers("azure", root=tmp_path)
+
+
+def test_a_here_string_is_not_a_heredoc(tmp_path: Path) -> None:
+    """The false claim in `_executable_text`, made checkable.
+
+    Its docstring said `<<<` here-strings "are left alone". They were not: the
+    opener pattern could start one character in, so `<<<WORD` matched as a
+    heredoc named WORD and everything after it was swallowed until a line
+    reading WORD turned up, which never happens. A here-string sitting above the
+    assignment therefore hid the assignment, and the cloud that PASSES this
+    stage would have failed it.
+    """
+    script_dir = tmp_path / "scripts" / "deploy"
+    script_dir.mkdir(parents=True)
+    (script_dir / "azure_control_plane.sh").write_text(
+        "#!/usr/bin/env bash\n"
+        "python3 -c 'import sys; print(sys.stdin.read())' <<<PAYLOAD\n"
+        f"{crc.OUTBOX_ENABLED_ENV}=true\n"
+    )
+    assert crc.declared_outbox_value("azure", root=tmp_path) == "true"
+
+    # ...and a real heredoc still hides its body, which is the behaviour the
+    # here-string case was wrongly getting.
+    (script_dir / "azure_control_plane.sh").write_text(
+        "#!/usr/bin/env bash\n"
+        "cat <<PAYLOAD\n"
+        f"{crc.OUTBOX_ENABLED_ENV}=true\n"
+        "PAYLOAD\n"
+    )
+    assert crc.declared_outbox_value("azure", root=tmp_path) is None
+
+
+def test_the_three_declaration_shapes_are_all_recognised(tmp_path: Path) -> None:
+    """App Runner JSON, a quoted array element, and an export — one per cloud."""
+    script_dir = tmp_path / "scripts" / "deploy"
+    script_dir.mkdir(parents=True)
+    (script_dir / "aws_eu_control_plane.sh").write_text(
+        '        "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED": "${OUTBOX_ENABLED}",\n'
+    )
+    (script_dir / "rollout.sh").write_text('  "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true"\n')
+    (script_dir / "azure_control_plane.sh").write_text(
+        "  export TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true\n"
+    )
+    assert crc.declared_outbox_value("aws", root=tmp_path) == "${OUTBOX_ENABLED}"
+    assert crc.declared_outbox_value("gcp", root=tmp_path) == "true"
+    assert crc.declared_outbox_value("azure", root=tmp_path) == "true"
+
+
+def test_the_form_the_failure_message_prescribes_is_accepted(tmp_path: Path) -> None:
+    """A gate that rejects the fix it prints is a gate people learn to route around.
+
+    Stage (e) failing says, in as many words, `set
+    TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true in <script>`. An operator who
+    does exactly that — a plain assignment, not a JSON map, not a quoted array
+    element, not an export — used to get the same failure back, which reads as
+    the check being broken rather than as the cloud being incomplete.
+
+    The heredoc case still does not count (see the test above): the difference
+    is between a line of shell and a line of advice, and both contain the same
+    characters.
+    """
+    prescription = f"{crc.OUTBOX_ENABLED_ENV}=true"
+    assert prescription in crc.outbox_enabled_blockers("azure")[0]
+
+    script_dir = tmp_path / "scripts" / "deploy"
+    script_dir.mkdir(parents=True)
+    (script_dir / "azure_control_plane.sh").write_text(
+        "#!/usr/bin/env bash\n"
+        f"# {prescription}   <- a comment is still not a setting\n"
+        f"{prescription}\n"
+        'az containerapp update --set-env-vars "TR_ENVIRONMENT=canary"\n'
+    )
+    assert crc.declared_outbox_value("azure", root=tmp_path) == "true"
+    assert crc.outbox_enabled_blockers("azure", root=tmp_path) == []
+
+
+def test_only_the_assignment_counts_not_the_comment_that_quotes_it(tmp_path: Path) -> None:
+    """The commented-out line above the fix is the likeliest near-miss of all."""
+    script_dir = tmp_path / "scripts" / "deploy"
+    script_dir.mkdir(parents=True)
+    (script_dir / "azure_control_plane.sh").write_text(
+        "#!/usr/bin/env bash\n"
+        f"#   {crc.OUTBOX_ENABLED_ENV}=true    # TODO once the ClickHouse exists\n"
+    )
+    assert crc.declared_outbox_value("azure", root=tmp_path) is None
+    assert crc.outbox_enabled_blockers("azure", root=tmp_path)
+
+
+def test_a_hard_disabled_outbox_fails(tmp_path: Path) -> None:
+    script_dir = tmp_path / "scripts" / "deploy"
+    script_dir.mkdir(parents=True)
+    (script_dir / "rollout.sh").write_text(
+        'ENV=(\n  "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=false"\n)\n'
+    )
+    blockers = crc.outbox_enabled_blockers("gcp", root=tmp_path)
+    assert blockers
+    assert "switched OFF" in blockers[0]
+    assert "vacuously green" in blockers[0]
+
+
+def test_a_control_plane_script_that_is_not_there_says_so(tmp_path: Path) -> None:
+    """A missing FILE is not "the file does not set the variable".
+
+    `declared_outbox_value` answers None for both, and stage (e) used to print
+    the same sentence either way: "<script> — the source of truth for this
+    cloud's control-plane environment — never sets TR_...", about a path that
+    does not exist. That sends the reader to open a file that is not there and
+    teaches them the gate is confused, which is how a gate stops being read.
+    """
+    (tmp_path / "scripts" / "deploy").mkdir(parents=True)
+    blockers = crc.outbox_enabled_blockers("azure", root=tmp_path)
+    assert blockers
+    assert "DOES NOT EXIST in this checkout" in blockers[0]
+    assert "never sets" not in blockers[0]
+    assert "control_plane_script" in blockers[0]
+
+
+# ---------------------------------------------------------------------------
+# The script registry: structure only. Behaviour is proven by execution in
+# tests/test_deploy_script_execution.py.
+# ---------------------------------------------------------------------------
+
+
+def test_the_script_registry_is_well_formed() -> None:
+    gaps = crc.script_binding_gaps()
+    assert gaps == [], "\n".join(gaps)
+    assert crc.scripts_proven_by_execution(), "nothing is proven by execution"
+
+
+def test_a_new_cloud_with_no_wired_script_fails_ci_naming_the_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The BLOCKING case: a fourth cloud ships a script nothing binds.
+
+    Registering the cloud is not enough — that only makes it checkABLE. This is
+    the step that makes it checkED, and it has to fail loudly enough to be
+    actionable: the message names the registry file, the field, and the line to
+    put at the end of the script.
+    """
+    monkeypatch.setitem(
+        crc.ROLLOUT_REGISTRY,
+        "oracle",
+        crc.CloudRollout(
+            cloud="oracle",
+            control_plane_script="scripts/deploy/rollout.sh",
+            drain_install_command="build it",
+        ),
+    )
+    gaps = crc.script_binding_gaps()
+    joined = "\n".join(gaps)
+    assert gaps
+    assert "src/trusted_router/cloud_rollout_completeness.py" in joined
+    assert "deploy_scripts" in joined
+    assert "verify_cloud_complete.sh" in joined
+    assert "oracle" in joined
+
+
+def test_a_script_that_runs_the_verifier_unclaimed_fails_ci(tmp_path: Path) -> None:
+    """Wiring nobody claims is wiring nobody would miss.
+
+    A script that verifies a cloud, with no registry entry naming it, is one
+    delete away from silence — and the deletion looks like a cleanup.
+    """
+    for cloud, entry in crc.ROLLOUT_REGISTRY.items():
+        for path in (entry.control_plane_script, *(s.path for s in entry.deploy_scripts)):
+            target = tmp_path / path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(f"require_cloud_complete {cloud}\n")
+    for item in crc.ROLLOUT_REGISTRY["gcp"].exempt_deploy_scripts:
+        (tmp_path / item.script).write_text("# exempt\n")
+    (tmp_path / ".github" / "workflows").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".github" / "workflows" / "deploy.yml").write_text("jobs: {}\n")
+    assert crc.script_binding_gaps(root=tmp_path) == []
+
+    (tmp_path / "scripts" / "deploy" / "oracle_bring_up.sh").write_text(
+        'bash "${SCRIPT_DIR}/verify_cloud_complete.sh" oracle\n'
+    )
+    gaps = crc.script_binding_gaps(root=tmp_path)
+    assert any("oracle_bring_up.sh" in gap and "no CloudRollout claims it" in gap for gap in gaps)
+
+
+def test_a_script_in_a_subdirectory_does_not_escape_the_scan(tmp_path: Path) -> None:
+    """The glob was `scripts/deploy/*.sh`, and one directory down was invisible.
+
+    A bring-up script at `scripts/deploy/aws/bring_up.sh` could call the
+    verifier with nothing claiming it — the "wiring nobody would miss" case,
+    hidden by a non-recursive pattern.
+    """
+    for cloud, entry in crc.ROLLOUT_REGISTRY.items():
+        for path in (entry.control_plane_script, *(s.path for s in entry.deploy_scripts)):
+            target = tmp_path / path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(f"require_cloud_complete {cloud}\n")
+    for item in crc.ROLLOUT_REGISTRY["gcp"].exempt_deploy_scripts:
+        (tmp_path / item.script).write_text("# exempt\n")
+    (tmp_path / ".github" / "workflows").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".github" / "workflows" / "deploy.yml").write_text("jobs: {}\n")
+
+    nested = tmp_path / "scripts" / "deploy" / "oracle" / "bring_up.sh"
+    nested.parent.mkdir(parents=True, exist_ok=True)
+    nested.write_text('bash "${SCRIPT_DIR}/../verify_cloud_complete.sh" oracle\n')
+    gaps = crc.script_binding_gaps(root=tmp_path)
+    assert any("oracle/bring_up.sh" in gap for gap in gaps), gaps
+
+
+def test_an_unbound_script_must_carry_a_named_reason_and_a_real_control() -> None:
+    """GCP is exempt, and the exemption is a sentence somebody signed.
+
+    `rollout.sh` runs inside the deploy workflow, so ending IT in a public fetch
+    of the page that same cloud serves would abort the deploy that repairs an
+    outage, partway through. That is a real reason.
+
+    What round 2 caught is the other half: the exemption cited "the scheduled
+    analytics freshness workflow" as the compensating control, and that workflow
+    ships with no `schedule:` trigger by design — so the primary cloud had no
+    automated completeness check at all, behind a sentence saying it did. A
+    claimed control is now a structured reference, and this resolves it.
+
+    What round 5 caught is the half after that, and it is the reason this test
+    reads the way it does. The resolution used to be a SUBSTRING: concatenate
+    the job's `run:` blocks and look for "verify_cloud_complete.sh gcp".
+    Replacing the whole job body with
+
+        echo "Next: bash scripts/deploy/verify_cloud_complete.sh gcp"
+        exit 0
+
+    satisfied it, and so did a commented-out line and a `|| true` — the three
+    saboteur shapes this change exists to kill, all of them passing the only
+    binding that covered the primary cloud. So: the job must contain a step
+    whose `run` IS an invocation of a script that this cloud's registry entry
+    proves BY EXECUTION. An echo of the command is not an invocation, and the
+    script on the other end is in the behavioural harness.
+    """
+    exemptions = [
+        (cloud, item)
+        for cloud, entry in crc.ROLLOUT_REGISTRY.items()
+        for item in entry.exempt_deploy_scripts
+    ]
+    assert exemptions, "if nothing is exempt, this test is stale — delete it"
+    for cloud, item in exemptions:
+        assert (ROOT / item.script).is_file(), f"{cloud}: {item.script} does not exist"
+        assert item.reason.strip(), f"{cloud}: {item.script} exemption has no reason"
+
+        control = item.compensating_control
+        if control is None:
+            continue
+        workflow = yaml.safe_load((ROOT / control.workflow).read_text())
+        assert control.job in workflow["jobs"], (
+            f"{cloud}: {item.script} cites {control.workflow} job {control.job!r}, which "
+            "does not exist in that workflow"
+        )
+        job = workflow["jobs"][control.job]
+        # Only scripts THIS cloud proves by execution count. A control pointing
+        # at an unproven script is a control whose behaviour nothing checks.
+        proven = {
+            script
+            for script, script_cloud in crc.scripts_proven_by_execution()
+            if script_cloud == cloud
+        }
+        assert proven, f"{cloud}: nothing is proven by execution, so no control can cite it"
+        invocations = {f"bash {script}" for script in proven}
+        # The invocation must be the LAST executable line of some step, not
+        # merely present in one. Presence alone still accepted two of the three
+        # saboteur shapes: the line followed by `exit 0`, and the line sealed
+        # inside `if false; then ... fi` (whose last line is `fi`). A workflow
+        # cannot be executed from a test, so this checks the SHAPE of the
+        # declaration -- said plainly in the docs' limits list.
+        run_lines = set()
+        for step in job.get("steps", []):
+            executable = [
+                line.strip()
+                for line in str(step.get("run", "")).splitlines()
+                if line.strip() and not line.strip().startswith("#")
+            ]
+            if executable:
+                run_lines.add(executable[-1])
+        assert run_lines & invocations, (
+            f"{cloud}: {control.workflow} job {control.job!r} has no step that RUNS a "
+            f"script proven by execution for this cloud. Expected one of {sorted(invocations)} "
+            f"as a step's whole `run` line; found {sorted(line for line in run_lines if line)}. "
+            "A printed instruction, a commented-out call, a `|| true`, a trailing "
+            "`exit 0` and a call sealed in `if false` all used to pass here, which is "
+            "the defect this shape closes."
+        )
+        # The prose in multi-cloud-separation.md and the runbook says this check
+        # reads the job's `needs` and its `if:`. It did not, until now.
+        assert "deploy" in str(job.get("needs", "")), (
+            f"{cloud}: {control.workflow} job {control.job!r} does not depend on `deploy`, "
+            "so it can run before the thing it is supposed to check"
+        )
+        assert "always()" in str(job.get("if", "")), (
+            f"{cloud}: {control.workflow} job {control.job!r} has no `if: always()`, so it "
+            "is skipped exactly when the deploy it follows failed"
+        )
+
+    gcp = crc.ROLLOUT_REGISTRY["gcp"]
+    assert [item.script for item in gcp.exempt_deploy_scripts] == ["scripts/deploy/rollout.sh"]
+    assert gcp.exempt_deploy_scripts[0].compensating_control is not None
+    # ...and the exempt file is not the cloud: GCP is bound like everyone else.
+    assert [script.path for script in gcp.deploy_scripts] == [
+        "scripts/deploy/verify_gcp_complete.sh"
+    ]
+    assert all(script.proof == crc.PROVEN_BY_EXECUTION for script in gcp.deploy_scripts)
+
+
+def test_an_exemption_citing_a_workflow_that_is_not_there_fails_ci(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The generalisation of the GCP finding: a phantom control is a defect."""
+    monkeypatch.setitem(
+        crc.ROLLOUT_REGISTRY,
+        "gcp",
+        crc.CloudRollout(
+            cloud="gcp",
+            control_plane_script="scripts/deploy/rollout.sh",
+            drain_install_command="build it",
+            exempt_deploy_scripts=(
+                crc.ScriptExemption(
+                    script="scripts/deploy/rollout.sh",
+                    reason="x" * 100,
+                    compensating_control=crc.CompensatingControl(
+                        workflow=".github/workflows/no-such-workflow.yml",
+                        job="imaginary",
+                        description="a control that does not exist",
+                    ),
+                ),
+            ),
+        ),
+    )
+    (tmp_path / "scripts" / "deploy").mkdir(parents=True)
+    (tmp_path / "scripts" / "deploy" / "rollout.sh").write_text("# exempt\n")
+    gaps = crc.script_binding_gaps(root=tmp_path)
+    assert any("no-such-workflow.yml" in gap and "does not exist" in gap for gap in gaps), gaps
+
+
+def test_a_not_proven_script_must_say_why(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """"The harness cannot run this one" is allowed. Silence is not."""
+    monkeypatch.setitem(
+        crc.ROLLOUT_REGISTRY,
+        "azure",
+        crc.CloudRollout(
+            cloud="azure",
+            control_plane_script="scripts/deploy/azure_control_plane.sh",
+            drain_install_command="build it",
+            deploy_scripts=(
+                crc.DeployScript("scripts/deploy/azure_control_plane.sh", crc.NOT_PROVEN),
+            ),
+        ),
+    )
+    (tmp_path / "scripts" / "deploy").mkdir(parents=True)
+    (tmp_path / "scripts" / "deploy" / "azure_control_plane.sh").write_text("# nothing\n")
+    gaps = crc.script_binding_gaps(root=tmp_path)
+    assert any("NOT_PROVEN with no reason" in gap for gap in gaps), gaps
+
+
+# ---------------------------------------------------------------------------
+# The shell entry point.
+# ---------------------------------------------------------------------------
+
+
+def test_verifier_refuses_an_unknown_cloud_without_touching_the_network() -> None:
+    result = subprocess.run(  # noqa: S603,S607 - fixed argv, no shell, repo-local script
+        ["bash", str(VERIFIER), "oracle"],  # noqa: S607
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    assert result.returncode == 1
+    assert "NOT VERIFIED" in result.stderr
+    assert "no ROLLOUT_REGISTRY entry" in result.stderr
+
+
+def test_verifier_is_read_only() -> None:
+    """No cloud CLI, no writes. It has to be runnable by anyone, from a laptop.
+
+    The first version of this test looked for `"\\naws "` — a cloud CLI call at
+    column zero and nowhere else — so an indented `  aws dsql ...` inside any
+    `if` passed it, which is where such a call would actually be. It now scans
+    every executable line for the CLI as a COMMAND word, comments excluded.
+    """
+    text = VERIFIER.read_text()
+    assert "set -euo pipefail" in text
+
+    forbidden = re.compile(r"(?:^|[;&|(]|\bthen\b|\bdo\b|\$\()\s*(aws|az|gcloud|gc)\s+\S")
+    executable = []
+    for number, line in enumerate(text.splitlines(), start=1):
+        if line.lstrip().startswith("#"):
+            continue
+        executable.append(line)
+        match = forbidden.search(line)
+        assert match is None, (
+            f"verifier line {number} shells out to {match.group(1) if match else ''}: {line!r}"
+        )
+
+    # Counted over CODE, not over the file: the header explains what the one
+    # curl and the one mktemp are for, and prose that describes a rule is not
+    # an instance of breaking it.
+    code = "\n".join(executable)
+    assert code.count("curl ") == 1
+    assert '-o "$BODY"' in code
+    # And nothing writes anywhere but the one temp file it cleans up.
+    assert code.count("mktemp") == 1
+    assert len(re.findall(r">\s*\"?\$\{?REPO_ROOT", code)) == 0
+
+
+# ---------------------------------------------------------------------------
+# The gate cannot be turned off from the environment, or from anywhere else.
+#
+# It could, for one commit: the bound came from TR_MAX_DRAIN_LAG_SECONDS and the
+# URL from TR_STATUS_URL, both `${VAR:-default}` at the top of the script. Every
+# wired deploy script inherits its caller's environment, so a single `export` in
+# a shell profile turned 470,897 undelivered rows into a green verdict. The
+# replacement was a pair of `--max-lag-seconds` / `--status-url` FLAGS plus a
+# fourth outcome ("this run is only a diagnosis") to keep them safe; both are
+# gone too, because an outcome that exists to make an override safe is one more
+# thing that can be got wrong, and this file has had two rounds of exactly that.
+#
+# These tests run the REAL shell script, with a fake `curl` on PATH so no test
+# touches the network, and a stub of the Python module that records the argv the
+# shell passed it. Recorded argv is the strong form of the assertion: not "the
+# output looked right" but "the shell never asked for the operator's number".
+# ---------------------------------------------------------------------------
+
+_STUB_MODULE = '''
+"""Stand-in for the judgement module: replays a scripted plan, records argv.
+
+Speaks the contract the real module speaks, which is now just the exit status
+plus plain lines: stderr is the operator's explanation, stdout is notes for the
+shell to reprint. STUB_STDERR_NOISE and STUB_STDOUT_NOISE exist so a test can
+fire the interpreter-warning shape that used to be able to rewrite a verdict.
+"""
+import json, os, sys
+
+with open(os.environ["STUB_ARGV_LOG"], "a", encoding="utf-8") as handle:
+    handle.write(json.dumps(sys.argv[1:]) + "\\n")
+
+plan = json.loads(os.environ["STUB_PLAN"])
+code, lines = plan.get(sys.argv[1], [0, []])
+noise = os.environ.get("STUB_STDERR_NOISE")
+if noise:
+    print(noise, file=sys.stderr)
+extra = os.environ.get("STUB_STDOUT_NOISE")
+if extra:
+    print(extra)
+for line in lines:
+    print(line)
+sys.exit(code)
+'''
+
+_FAKE_CURL = """#!/usr/bin/env bash
+# Records the URL it was asked for; serves a fixture; never leaves the machine.
+out=""
+url=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    -w|--max-time) shift 2 ;;
+    -*) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+printf '%s\\n' "$url" >> "$CURL_URL_LOG"
+[ -z "$out" ] || cat "$CURL_BODY" > "$out"
+printf '%s' "${CURL_HTTP_CODE:-200}"
+"""
+
+
+class _Harness:
+    """A throwaway checkout: the REAL verifier, a stub module, a fake curl.
+
+    The shell is the thing under test, so it is copied verbatim; everything it
+    talks to is replaced by something that records what it was asked. The
+    ``.venv/bin/python`` symlink is what keeps the run off the network — it is
+    the interpreter the verifier prefers, so no `uv` resolution happens. Like
+    the deploy-script harness, the isolation here is by NAME (`curl` is a stub
+    on PATH), not a sandbox.
+    """
+
+    def __init__(self, root: Path, plan: dict[str, Any], body: dict[str, Any]) -> None:
+        self.root = root
+        self.plan = plan
+        self.verifier = root / "scripts" / "deploy" / "verify_cloud_complete.sh"
+        self.curl_log = root / "curl-urls.txt"
+        self.argv_log = root / "stub-argv.txt"
+        self.body = root / "status.json"
+        self.curl_dir = root / "bin"
+
+        self.verifier.parent.mkdir(parents=True)
+        self.verifier.write_text(VERIFIER.read_text())
+        package = root / "src" / "trusted_router"
+        package.mkdir(parents=True)
+        (package / "__init__.py").write_text("")
+        (package / "cloud_rollout_completeness.py").write_text(_STUB_MODULE)
+        venv_bin = root / ".venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        (venv_bin / "python").symlink_to(sys.executable)
+        self.curl_dir.mkdir()
+        (self.curl_dir / "curl").write_text(_FAKE_CURL)
+        (self.curl_dir / "curl").chmod(0o755)
+        self.body.write_text(json.dumps(body))
+
+    @property
+    def fetched_urls(self) -> list[str]:
+        """Every URL that actually went to `curl`, in order."""
+        return self.curl_log.read_text().split() if self.curl_log.exists() else []
+
+    def argv_for(self, command: str) -> list[str]:
+        """The argv the shell passed to a subcommand — what it ASKED, not what it printed."""
+        for line in self.argv_log.read_text().splitlines():
+            argv: list[str] = json.loads(line)
+            if argv and argv[0] == command:
+                return argv
+        raise AssertionError(f"the shell never ran the {command!r} subcommand")
+
+    def run(
+        self, *args: str, env: dict[str, str] | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        environment = dict(os.environ)
+        environment.update(
+            {
+                "PATH": f"{self.curl_dir}{os.pathsep}{os.environ['PATH']}",
+                "STUB_PLAN": json.dumps(self.plan),
+                "STUB_ARGV_LOG": str(self.argv_log),
+                "CURL_URL_LOG": str(self.curl_log),
+                "CURL_BODY": str(self.body),
+            }
+        )
+        environment.update(env or {})
+        return subprocess.run(  # noqa: S603
+            ["bash", str(self.verifier), *args],  # noqa: S607
+            capture_output=True,
+            text=True,
+            env=environment,
+            cwd=self.root,
+        )
+
+
+def _harness(root: Path, *, plan: dict[str, Any], body: dict[str, Any] | None = None) -> _Harness:
+    root.mkdir(parents=True, exist_ok=True)
+    return _Harness(root, plan, body if body is not None else {"data": {}})
+
+
+REGISTRY_URL = "https://registry.example/status.json"
+
+#: ``subcommand -> [exit status, stdout lines]``. The exit status is the entire
+#: verdict; the lines are notes the shell reprints under the outcome.
+_ALL_PASS: dict[str, list[Any]] = {
+    "registry": [0, []],
+    "status-url": [0, [REGISTRY_URL]],
+    "section": [0, []],
+    "available": [0, []],
+    "lag": [0, ["a lag under the bound proves nothing is STUCK"]],
+    "outbox": [0, ["TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED='true' in the working tree"]],
+}
+
+
+def test_exported_status_url_cannot_redirect_the_check(tmp_path: Path) -> None:
+    """(i) TR_STATUS_URL, invoked exactly as a deploy script invokes this.
+
+    The fake curl records what was actually fetched, so this is not a test of
+    what the script printed: with the variable exported to a page that would
+    answer perfectly, the URL that goes over the wire is still the registry's.
+    """
+    harness = _harness(tmp_path, plan=_ALL_PASS)
+    result = harness.run("aws", env={"TR_STATUS_URL": "https://attacker.example/status.json"})
+
+    assert harness.fetched_urls == [REGISTRY_URL]
+    assert "attacker.example" not in "".join(harness.fetched_urls)
+    assert "IGNORED: TR_STATUS_URL" in result.stderr
+    assert result.returncode == 0
+
+
+def test_exported_lag_bound_cannot_widen_the_gate(tmp_path: Path) -> None:
+    """(i) TR_MAX_DRAIN_LAG_SECONDS, asserted on the argv the shell passed.
+
+    The old script read the variable into `MAX_LAG_SECONDS` and passed it
+    through on every run, so `export TR_MAX_DRAIN_LAG_SECONDS=99999999` made the
+    fifteen-day backlog pass stage (d). Now the shell asks for no bound at all —
+    there is no flag to ask with — and the number comes from the Python module.
+    """
+    harness = _harness(tmp_path, plan=_ALL_PASS)
+    result = harness.run("aws", env={"TR_MAX_DRAIN_LAG_SECONDS": "99999999"})
+
+    lag_argv = harness.argv_for("lag")
+    assert "--max-lag-seconds" not in lag_argv, lag_argv
+    assert "99999999" not in " ".join(lag_argv)
+    assert "IGNORED: TR_MAX_DRAIN_LAG_SECONDS" in result.stderr
+    assert result.returncode == 0
+
+
+def test_the_env_is_ignored_by_the_real_verifier_too() -> None:
+    """The same, against the real module: no fixture, no network, no verdict change.
+
+    `oracle` fails stage (a) before anything is fetched, so this exercises the
+    real script and the real registry — and the exported variables change
+    neither the outcome nor the fact that they are called out as ignored.
+    """
+    result = subprocess.run(  # noqa: S603
+        ["bash", str(VERIFIER), "oracle"],  # noqa: S607
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+        env={
+            **os.environ,
+            "TR_STATUS_URL": "https://attacker.example/status.json",
+            "TR_MAX_DRAIN_LAG_SECONDS": "99999999",
+        },
+    )
+    assert result.returncode == 1
+    assert "NOT VERIFIED" in result.stderr
+    assert "IGNORED: TR_STATUS_URL" in result.stderr
+    assert "IGNORED: TR_MAX_DRAIN_LAG_SECONDS" in result.stderr
+    assert not _verified(result.stderr)
+
+
+def test_there_is_no_override_flag_left_to_pass(tmp_path: Path) -> None:
+    """The flags are gone, and gone means REJECTED rather than quietly accepted.
+
+    `--max-lag-seconds` and `--status-url` were the sanctioned way to ask the
+    gate a different question, and they needed a whole fourth outcome
+    (DIAGNOSTIC, exit 4) to keep them from minting a green verdict. Deleting
+    them deletes that outcome; this pins that an unknown flag is a failure
+    rather than something the script quietly treats as a cloud id.
+    """
+    harness = _harness(tmp_path, plan=_ALL_PASS)
+    for flag in ("--max-lag-seconds", "--status-url"):
+        result = harness.run(flag, "99999999", "aws")
+        assert result.returncode == 1
+        assert "unknown option" in result.stderr
+        assert not _verified(result.stderr)
+        assert harness.fetched_urls == []
+
+
+# ---------------------------------------------------------------------------
+# The outcome says what was measured, and nothing more.
+# ---------------------------------------------------------------------------
+
+
+def test_a_passing_run_says_verified_and_says_what_it_did_not_show(tmp_path: Path) -> None:
+    """The one green sentence, and the limit printed next to it every time.
+
+    The banner used to read "COMPLETE: <cloud> publishes a live analytics
+    pipeline", downgraded to "COMPLETE WITH CAVEATS" when a stage came back
+    flagged. The only flag that could have downgraded it was raised off a field
+    (`outbox_depth`) that no storage backend in this repository populates — so
+    the strong sentence was what every passing run printed, including over an
+    outbox nothing had ever been enqueued into. There is one outcome now and it
+    is true of every run that reaches it.
+    """
+    harness = _harness(tmp_path, plan=_ALL_PASS)
+    result = harness.run("aws")
+
+    assert result.returncode == 0
+    assert _verified(result.stderr) and "aws passed every stage" in result.stderr
+    assert "publishes a live analytics pipeline" not in result.stderr
+    assert "It does not mean rows were seen moving" in result.stderr
+
+
+def test_stage_notes_are_reprinted_verbatim_under_the_outcome(tmp_path: Path) -> None:
+    """Notes are text, not a taxonomy. They inform; they never re-rank a run."""
+    note = "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED is computed at deploy time"
+    harness = _harness(tmp_path, plan={**_ALL_PASS, "outbox": [0, [note]]})
+    result = harness.run("aws")
+
+    assert result.returncode == 0
+    assert note in result.stderr
+    assert "Notes from the stages, verbatim:" in result.stderr
+
+
+def test_an_unpublished_analytics_section_is_its_own_exit_code(tmp_path: Path) -> None:
+    """Stage (b) failing means "nobody can see this cloud", not "you broke it".
+
+    Every bound script depends on the distinction through
+    scripts/deploy/cloud_complete_gate.sh: the run that INSTALLS a drain hits
+    this state by construction today, and reporting it as a flat failure is what
+    teaches operators to ignore exit codes. It is the ONE code kept beside 0 and
+    1, for that reason.
+    """
+    harness = _harness(tmp_path, plan={**_ALL_PASS, "section": [5, []]})
+    result = harness.run("aws")
+
+    assert result.returncode == 5
+    assert "NOT YET OBSERVABLE" in result.stderr
+    assert not _verified(result.stderr)
+
+
+def test_a_failing_stage_ends_the_run_non_zero(tmp_path: Path) -> None:
+    """Everything that is not stage (b)'s absence is one code, and it says why."""
+    harness = _harness(tmp_path, plan={**_ALL_PASS, "available": [1, []]})
+    result = harness.run("aws")
+
+    assert result.returncode == 1
+    assert "NOT VERIFIED" in result.stderr
+    assert "c: analytics available" in result.stderr
+    assert not _verified(result.stderr)
+
+
+def test_noise_on_either_stream_cannot_change_an_outcome(tmp_path: Path) -> None:
+    """The bug the old verdict contract existed to survive, now impossible.
+
+    The shell used to capture the module with `2>&1` and classify by the first
+    word; a DeprecationWarning at import time could therefore turn one outcome
+    into another, and the fall-through was the green banner. The successor
+    contract read a tab-separated sentinel out of stdout, which had its own ways
+    to go wrong. Nothing is read out of a stream now: a failing stage that also
+    prints noise still fails, and a passing run's stray stdout line is a note.
+    """
+    noise = {
+        "STUB_STDERR_NOISE": "DeprecationWarning: pkg_resources is deprecated as an API",
+        "STUB_STDOUT_NOISE": "warning: a library printed this to stdout",
+    }
+    failing = _harness(tmp_path, plan={**_ALL_PASS, "outbox": [1, []]})
+    result = failing.run("azure", env=noise)
+    assert result.returncode == 1
+    assert "NOT VERIFIED" in result.stderr
+    assert not _verified(result.stderr)
+
+    passing = _harness(tmp_path / "second", plan=_ALL_PASS)
+    result = passing.run("aws", env=noise)
+    assert result.returncode == 0
+    assert _verified(result.stderr) and "aws passed every stage" in result.stderr
+    assert "a library printed this to stdout" in result.stderr
+
+
+def test_a_status_url_that_is_not_a_url_stops_the_run(tmp_path: Path) -> None:
+    """The one stdout line the shell CONSUMES, and its guard.
+
+    Stage (a) answers with a URL, which is the only place the shell takes a
+    value rather than an exit status. A stray line there can only make the run
+    fail — never pass, and never fetch something that is not an https:// page.
+    """
+    harness = _harness(tmp_path, plan={**_ALL_PASS, "status-url": [0, ["not-a-url"]]})
+    result = harness.run("aws")
+
+    assert result.returncode == 1
+    assert "not an https:// URL" in result.stderr
+    assert harness.fetched_urls == []

--- a/tests/test_deploy_script_execution.py
+++ b/tests/test_deploy_script_execution.py
@@ -1,0 +1,452 @@
+"""Proof by EXECUTION that a bring-up script runs the completeness gate.
+
+This file replaces a regex. The regex asked whether the string
+``verify_cloud_complete.sh <cloud>`` appeared in a script's last N lines, and
+three independent reviews killed it for the same reason: a heredoc body, a
+printed instruction and a commented-out line all satisfy it. That is verbatim
+the bug the whole change exists to prevent — printing the step counted as doing
+the step — reproduced inside the check written to end it.
+
+So every bound script is RUN, in ``tests/deploy_script_harness.py``'s stub-PATH
+harness — isolation by NAME rather than a sandbox, which that module's own
+header spells out — and two things are asserted about what it did:
+
+  1. it CALLED the gate, for its own cloud;
+  2. when the gate FAILS, it exits non-zero.
+
+Both are properties of the process, not of the text. A printed instruction
+fails (1). A call whose status is swallowed — ``verify ... || true``, a call
+inside ``if`` with an empty else, a call followed by ``exit 0`` — fails (2).
+
+A third assertion covers what "must be in the last N lines" was really reaching
+for: no cloud CLI runs AFTER the gate answered, except cleanup a fixture names.
+A gate that passes and is then followed by more provisioning checked a cloud
+that did not exist yet.
+
+WHAT IS NOT PROVEN HERE, SAID PLAINLY
+-------------------------------------
+``scripts/deploy/aws_eu_clickhouse_drain_install.sh`` is recorded as
+``NOT_PROVEN`` and this file does not run it. Its reason lives next to it in
+``ROLLOUT_REGISTRY``; the short version is that its middle ships a payload over
+SSM and reads the drain's own journal back, so a stub that answers
+``Status=Success`` to everything would be the harness asserting its own answer.
+:func:`test_unproven_scripts_are_declared_and_not_silently_skipped` fails if
+that list ever grows without a reason, or if the docs stop saying so.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from trusted_router import cloud_rollout_completeness as crc
+
+from .deploy_script_harness import (
+    SCRIPT_FIXTURES,
+    DeployScriptHarness,
+    summarise,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+PROVEN = crc.scripts_proven_by_execution()
+UNPROVEN = crc.scripts_not_proven()
+
+
+@pytest.fixture(scope="module")
+def harness(tmp_path_factory: pytest.TempPathFactory) -> DeployScriptHarness:
+    """One mirrored checkout and one stub PATH for the whole module."""
+    return DeployScriptHarness(tmp_path_factory.mktemp("deploy-harness"))
+
+
+def test_every_deploy_script_parses_in_this_machine_s_shell() -> None:
+    """`bash -n` over every deploy script, with whatever bash is here.
+
+    Cheap, and it caught a real one: `aws_eu_clickhouse_drain_install.sh` built
+    its next-steps text as `"$(cat <<'NEXT' ... )"`, and a heredoc nested inside
+    a command substitution is a syntax error in bash 3.2 — /bin/bash on every
+    macOS — the moment the BODY contains an apostrophe. The body said "step 9's
+    output". So on a Mac the whole file failed to parse and did nothing at all,
+    gate included, while CI on Linux bash 5 parsed it happily.
+
+    What this proves is therefore shell-specific, and saying so is the point: on
+    a modern bash it proves the scripts are well-formed there, and on an old one
+    it proves they are runnable by the operator sitting in front of it. The
+    class of defect only shows up on the second kind of machine, which is why
+    the check runs the LOCAL shell rather than a pinned one.
+    """
+    for script in sorted((ROOT / "scripts").rglob("*.sh")):
+        result = subprocess.run(  # noqa: S603
+            ["bash", "-n", str(script)],  # noqa: S607
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"{script.relative_to(ROOT)} does not parse under "
+            f"{subprocess.run(['bash', '--version'], capture_output=True, text=True).stdout.splitlines()[0]}"  # noqa: E501,S603,S607
+            f":\n{result.stderr}"
+        )
+
+
+def test_the_registry_actually_binds_something() -> None:
+    """If nothing is proven by execution, this file is decorative."""
+    assert PROVEN, "no deploy script is proven by execution — the mechanism is disconnected"
+
+
+@pytest.mark.parametrize(("script", "cloud"), PROVEN, ids=[s for s, _ in PROVEN])
+def test_the_script_calls_the_gate_for_its_own_cloud(
+    harness: DeployScriptHarness, script: str, cloud: str
+) -> None:
+    """(1) It RAN the gate. Not "the file mentions it" — it ran it.
+
+    The script executes end to end against recording stubs, so this assertion
+    reads the gate's own call log. A `Next: ...` echo, a heredoc quoting the
+    command, and a commented-out invocation all produce an empty log.
+    """
+    run = harness.run(script, verifier_rc=0)
+    assert run.gate_ran_for(cloud), (
+        f"{script} ran to completion without ever calling verify_cloud_complete.sh "
+        f"for {cloud}.\n{summarise(run)}"
+    )
+    assert run.returncode == 0, (
+        f"{script} called the gate, the gate passed, and the script still failed.\n"
+        f"{summarise(run)}"
+    )
+
+
+@pytest.mark.parametrize(("script", "cloud"), PROVEN, ids=[s for s, _ in PROVEN])
+def test_a_failing_gate_makes_the_script_fail(
+    harness: DeployScriptHarness, script: str, cloud: str
+) -> None:
+    """(2) It cannot report success over a failing gate.
+
+    This is the assertion the old text check could not make at all, and the one
+    that catches the likelier regression: not deleting the call, but keeping it
+    and losing its exit status — `|| true`, a bare `if`, an `exit 0` after it.
+    """
+    run = harness.run(script, verifier_rc=1)
+    assert run.gate_ran_for(cloud), summarise(run)
+    assert run.returncode != 0, (
+        f"{script} exited 0 with the completeness gate FAILING. That is the outage's "
+        f"shape: a finished script and a working cloud are different things.\n"
+        f"{summarise(run)}"
+    )
+
+
+@pytest.mark.parametrize(("script", "cloud"), PROVEN, ids=[s for s, _ in PROVEN])
+def test_every_gate_exit_code_survives_the_script(
+    harness: DeployScriptHarness, script: str, cloud: str
+) -> None:
+    """All bound scripts understand the gate's two codes, or none of them do.
+
+    Exit 5 (NOT YET OBSERVABLE) used to be taught to exactly one of five: the
+    other four reported today's real state — no deployed control plane publishes
+    the `analytics` section — as a flat install failure with a fix that would not
+    have fixed it, which is how an operator learns to stop reading exit codes.
+    The mapping is one shared file now, and this asserts the consequence rather
+    than the mechanism: each code comes out the far end unchanged.
+
+    There are two codes because 5 is the only one that earns its own words. The
+    gate used to have seven; the rest are collapsed into 1, which prints why.
+    """
+    for rc in (1, 5):
+        run = harness.run(script, verifier_rc=rc)
+        assert run.returncode == rc, (
+            f"{script} turned gate exit {rc} into {run.returncode}. 5 and 1 mean "
+            f"different things to an operator; collapsing them is the defect.\n"
+            f"{summarise(run)}"
+        )
+
+
+def test_the_gate_status_survives_without_the_operator_attestation(
+    harness: DeployScriptHarness,
+) -> None:
+    """The propagation claim, asked the way a FIRST RUN asks it.
+
+    `aws_eu_north_clickhouse.sh` refuses to claim the Stockholm replica is wired
+    until an operator says so with TR_STOCKHOLM_REPLICA_WIRED=1, and exits 3
+    when they have not. That check used to run AFTER the gate and unconditionally
+    overwrite its status — so on a first run, when nobody has ever set the
+    variable, the gate's 5 and the gate's 1 both came out as 3. The only reason
+    the parametrised test above passed for this script is that the harness
+    fixture sets the variable; the operator does not have it.
+    """
+    script = "scripts/deploy/aws_eu_north_clickhouse.sh"
+    for rc in (1, 5):
+        run = harness.run(script, verifier_rc=rc, omit_env=("TR_STOCKHOLM_REPLICA_WIRED",))
+        assert run.returncode == rc, (
+            f"{script} turned gate exit {rc} into {run.returncode} for an operator who "
+            f"has not set TR_STOCKHOLM_REPLICA_WIRED, i.e. on every first run.\n"
+            f"{summarise(run)}"
+        )
+
+    # ...and with the gate passing, the unwired replica is still its own answer.
+    unwired = harness.run(script, verifier_rc=0, omit_env=("TR_STOCKHOLM_REPLICA_WIRED",))
+    assert unwired.returncode == 3, summarise(unwired)
+    assert "STOCKHOLM NOT WIRED" in unwired.stderr
+
+
+@pytest.mark.parametrize(("script", "cloud"), PROVEN, ids=[s for s, _ in PROVEN])
+def test_nothing_provisions_after_the_gate_has_answered(
+    harness: DeployScriptHarness, script: str, cloud: str
+) -> None:
+    """The measured form of "the check must be the LAST thing it does".
+
+    A gate in the middle, followed by twenty more steps that mutate the cloud,
+    is a check of a cloud that did not exist yet. The old rule approximated this
+    by counting lines from the end of the file; this counts commands from the
+    call in an execution trace.
+    """
+    fixture = SCRIPT_FIXTURES.get(script)
+    allowed = fixture.cleanup_after_gate if fixture else ()
+    run = harness.run(script, verifier_rc=0)
+    stragglers = run.cloud_cli_calls_after_the_gate(allowed)
+    assert stragglers == [], (
+        f"{script} runs the gate for {cloud} and then keeps provisioning: "
+        f"{[' '.join(call[:4]) for call in stragglers]}. Either move the gate to the end "
+        "or, if these are cleanup, name them in cleanup_after_gate in "
+        "tests/deploy_script_harness.py."
+    )
+
+
+def test_the_shared_gate_library_returns_the_verifier_status_unaltered(
+    harness: DeployScriptHarness, tmp_path: Path
+) -> None:
+    """The one function every bound script funnels through, exercised directly.
+
+    Every non-zero code the verifier can produce has to come back out. This is
+    what makes "all five scripts understand exit 5" a property of one file
+    rather than five copies of a `case` statement, one of which had it.
+
+    Note what is NOT set here: the gate library used to read
+    CLOUD_COMPLETE_GATE_DIR to decide which verifier to run, "for the test
+    harness". Every bound deploy script inherits its operator's environment, so
+    that variable was a redirect for the gate itself — the third appearance of
+    the class of defect the verifier spends a section of its header closing. It
+    is gone, and nothing was lost: the caller below sources the gate out of the
+    MIRRORED checkout, and the gate resolves the verifier next to itself, which
+    is the mirror's recording stub.
+    """
+    caller = tmp_path / "caller.sh"
+    caller.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f'. "{harness.mirror}/scripts/deploy/cloud_complete_gate.sh"\n'
+        'require_cloud_complete "$1" "next steps for the operator"\n'
+    )
+
+    def run_with(rc: int) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(  # noqa: S603
+            ["bash", str(caller), "aws"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            env={
+                "PATH": str(harness.bin),
+                "HOME": str(tmp_path),
+                "HARNESS_ARGV_LOG": str(tmp_path / "argv.log"),
+                "HARNESS_VERIFIER_RC": str(rc),
+            },
+        )
+
+    for rc in (0, 1, 5):
+        result = run_with(rc)
+        assert result.returncode == rc, (rc, result.returncode, result.stderr)
+        if rc != 0:
+            assert "next steps for the operator" in result.stderr
+
+    # ...and each non-zero code gets its own words, so an operator is not told
+    # to fix an install that did not fail.
+    assert "NOT YET OBSERVABLE" in run_with(5).stderr
+    assert "NOT VERIFIED" in run_with(1).stderr
+
+
+@pytest.mark.parametrize(("script", "cloud"), PROVEN, ids=[s for s, _ in PROVEN])
+def test_each_gate_outcome_gets_the_same_words_from_every_script(
+    harness: DeployScriptHarness, script: str, cloud: str
+) -> None:
+    """The consequence of sharing the library, read off the scripts' own output.
+
+    Exit 5 used to be taught to exactly one of five bound scripts: the other
+    four reported today's real state — no control plane publishes the analytics
+    section yet — as a flat install failure with a fix that would not have fixed
+    it. So this does not check that a file sources a file; it runs the script
+    under each outcome and reads what the operator would have been told.
+    """
+    expected = {
+        1: "NOT VERIFIED",
+        5: "NOT YET OBSERVABLE",
+    }
+    for rc, phrase in expected.items():
+        run = harness.run(script, verifier_rc=rc)
+        assert phrase in run.stderr, (
+            f"{script} exited {run.returncode} on gate code {rc} without telling the "
+            f"operator {phrase!r}, so it has its own idea of what that code means.\n"
+            f"{summarise(run)}"
+        )
+
+
+#: The three shapes the old text check accepted, written as scripts. Each one
+#: contains the exact string ``verify_cloud_complete.sh aws`` in its last lines
+#: and each one is a lie; the regex passed all three.
+_SABOTEURS = {
+    "printed_instruction": """#!/usr/bin/env bash
+set -euo pipefail
+echo "provisioned everything"
+cat <<'NEXT'
+Next: bash scripts/deploy/verify_cloud_complete.sh aws
+NEXT
+exit 0
+""",
+    "commented_out": """#!/usr/bin/env bash
+set -euo pipefail
+echo "provisioned everything"
+# bash "${SCRIPT_DIR}/verify_cloud_complete.sh" aws
+exit 0
+""",
+    "swallowed_status": """#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "${SCRIPT_DIR}/verify_cloud_complete.sh" aws || true
+exit 0
+""",
+}
+
+
+@pytest.mark.parametrize("shape", sorted(_SABOTEURS))
+def test_the_shapes_the_old_regex_accepted_now_fail(
+    harness: DeployScriptHarness, shape: str
+) -> None:
+    """Demonstrate the fix rather than assert it.
+
+    Each of these satisfies "the string `verify_cloud_complete.sh aws` appears
+    in the last N lines", which is what the previous binding checked. Under
+    execution the first two never call the gate at all and the third calls it
+    and throws its answer away — so each fails one of the two properties, which
+    is the whole point of moving from text to behaviour.
+    """
+    path = harness.write_script(f"scripts/deploy/_saboteur_{shape}.sh", _SABOTEURS[shape])
+    passing = harness.run(path, verifier_rc=0)
+    failing = harness.run(path, verifier_rc=1)
+
+    called = passing.gate_ran_for("aws")
+    survived_a_failing_gate = failing.returncode == 0
+    assert not called or survived_a_failing_gate, (
+        f"the {shape} saboteur should fail one of the two properties, and did not"
+    )
+    if shape == "swallowed_status":
+        assert called, "this one does call the gate; that was never the problem"
+        assert survived_a_failing_gate, "and it reports success over a failing gate"
+    else:
+        assert not called, f"the {shape} saboteur must never reach the gate"
+
+
+#: The page that states, for a human, which scripts are proven and which are
+#: only claimed. It is the other half of the registry, and CI holds the two to
+#: exact agreement.
+PROOF_DOC = ROOT / "docs" / "storage-portability" / "multi-cloud-separation.md"
+
+
+def _documented_scripts(marker: str) -> set[str]:
+    """The repo-relative paths listed between ``<!-- MARKER:begin/end -->``.
+
+    A parser rather than a substring search, and that is the whole fix. The
+    previous check asked whether each NOT_PROVEN script's BASENAME appeared
+    anywhere in this document — which it does, several times, in the prose
+    explaining why it is not proven. So the document could go on calling a
+    script proven while the registry called it unproven, and the check was happy
+    with both.
+    """
+    text = PROOF_DOC.read_text()
+    match = re.search(
+        rf"<!--\s*{marker}:begin\s*-->(.*?)<!--\s*{marker}:end\s*-->", text, re.DOTALL
+    )
+    assert match is not None, (
+        f"{PROOF_DOC.relative_to(ROOT)} has no <!-- {marker}:begin --> block. That block "
+        "is how the docs and ROLLOUT_REGISTRY are held to the same list; do not delete it "
+        "to make this test pass."
+    )
+    return set(re.findall(r"^\s*[-*]\s*`([^`]+)`\s*$", match.group(1), re.MULTILINE))
+
+
+def test_the_docs_and_the_registry_name_the_same_proven_scripts() -> None:
+    """Losing behavioural coverage has to be loud, and this is the noise.
+
+    Flipping one script from PROVEN_BY_EXECUTION to NOT_PROVEN takes five
+    parametrised cases out of this module — the suite goes from 76 passing to 71
+    and stays GREEN, because a test that is not collected cannot fail. For one
+    revision the only thing in the way was a minimum reason length, which is 121
+    characters of filler.
+
+    So the gate is not the reason's length: it is that the registry and the
+    human-readable page must name the SAME SET, exactly. A script cannot lose
+    its coverage without an edit to a document somebody reviews, and the failure
+    below says which script moved and in which direction.
+    """
+    registry_proven = {script for script, _cloud in PROVEN}
+    registry_unproven = {script for script, _cloud, _reason in UNPROVEN}
+    doc_proven = _documented_scripts("PROVEN_BY_EXECUTION")
+    doc_unproven = _documented_scripts("NOT_PROVEN")
+
+    assert registry_proven == doc_proven, (
+        "ROLLOUT_REGISTRY and the 'Proven by execution today' list disagree.\n"
+        f"  proven in the registry, absent from the docs: {sorted(registry_proven - doc_proven)}\n"
+        f"  listed in the docs, not proven in the registry: {sorted(doc_proven - registry_proven)}\n"
+        f"Fix both, in {PROOF_DOC.relative_to(ROOT)} and "
+        "src/trusted_router/cloud_rollout_completeness.py. A script that quietly stops "
+        "being executed here loses five behavioural cases and the suite stays green."
+    )
+    assert registry_unproven == doc_unproven, (
+        "ROLLOUT_REGISTRY and the 'Not proven, and therefore only CLAIMED' list "
+        "disagree.\n"
+        f"  NOT_PROVEN in the registry, absent from the docs: "
+        f"{sorted(registry_unproven - doc_unproven)}\n"
+        f"  listed in the docs, not NOT_PROVEN in the registry: "
+        f"{sorted(doc_unproven - registry_unproven)}"
+    )
+    assert not (registry_proven & registry_unproven)
+
+
+def test_unproven_scripts_are_declared_and_not_silently_skipped() -> None:
+    """A script this harness cannot run honestly must SAY so, in code and docs.
+
+    The permitted answer to "the harness cannot run this one" is a written
+    reason, not a quiet omission — an omission is exactly the shape of the
+    original defect.
+
+    Note what this no longer asserts: a minimum reason LENGTH. That was the only
+    thing standing between the registry and a silent loss of five behavioural
+    cases per script, and 121 characters of filler cleared it. The gate is
+    :func:`test_the_docs_and_the_registry_name_the_same_proven_scripts`; a blank
+    reason is separately a `script_binding_gaps` failure.
+    """
+    for script, cloud, reason in UNPROVEN:
+        assert reason.strip(), f"{cloud}: {script} is NOT_PROVEN with no reason"
+        assert (ROOT / script).is_file()
+
+
+def test_the_unprovable_script_really_is_unprovable(harness: DeployScriptHarness) -> None:
+    """Show the failure rather than asserting it in prose.
+
+    ``aws_eu_clickhouse_drain_install.sh`` is claimed to be unrunnable under
+    stubs. That claim is itself checkable: run it and watch it stop before the
+    gate. If somebody later makes it runnable, this fails and the registry entry
+    should become PROVEN_BY_EXECUTION — which is the right way round.
+    """
+    unproven_paths = [script for script, _cloud, _reason in UNPROVEN]
+    if "scripts/deploy/aws_eu_clickhouse_drain_install.sh" not in unproven_paths:
+        pytest.skip("the drain installer is no longer claimed to be unprovable")
+    run = harness.run("scripts/deploy/aws_eu_clickhouse_drain_install.sh", verifier_rc=0)
+    # It has to have RUN and stopped, not failed to parse. Those are the same
+    # two observations — non-zero, gate never reached — and for a while they
+    # were the same outcome here: this file did not parse under bash 3.2 at all
+    # (see test_every_deploy_script_parses_in_this_machine_s_shell), so this
+    # test was passing on a Mac without the script executing a single line.
+    assert run.calls, f"the script never ran a command at all.\n{summarise(run)}"
+    assert not run.gate_ran_for("aws"), (
+        "the drain installer now reaches the gate under stubs — promote it to "
+        "PROVEN_BY_EXECUTION in ROLLOUT_REGISTRY and delete this test's premise"
+    )
+    assert run.returncode != 0


### PR DESCRIPTION
Supersedes #649 (its branch carried #643's commits, which main now has squashed; this is the same diff replayed onto current main).

**Why.** The AWS-EU drain was never installed; its outbox reached 470,897 rows over 15 days and nothing reported it, because the bring-up script *printed* `Next: …` and exited 0.

**What.** `verify_cloud_complete.sh <cloud>` answers one question in five falsifiable stages (in the registry → status page served → analytics section published → available, under bound, not stale → control-plane script does not switch the outbox off). Every bound deploy script ends in it and lets its exit status stand.

**The binding is behavioural, not textual.** The harness runs each script against a stub PATH and asserts of the *process*: it called the gate for its cloud, a failing gate makes it exit non-zero, exit codes survive, nothing provisions after the gate answered. Three saboteurs (printed instruction / commented-out call / swallowed status) are in the suite because the first version of this PR was satisfied by all three — it grepped script text, which is the same mistake as printing `Next:`.

**Deliberately small.** Three outcomes, three exit codes, no exemption that can launder a measured failure, no env var that widens the bound, no green banner. An earlier draft had eight verdict kinds and seven exit codes, and nearly every defect six review rounds found lived in that machinery.

**Stated limit, printed on every passing run:** it cannot see rows move — an empty outbox and a switched-off one publish the same lag.

Gates: ruff + mypy clean, full suite 4830 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)