### PR TITLE
axiom: ship logs from a listener thread, not the request thread

### DIFF
--- a/src/trusted_router/axiom_config.py
+++ b/src/trusted_router/axiom_config.py
@@ -30,6 +30,7 @@ Design choices:
 from __future__ import annotations
 
 import atexit
+import copy
 import importlib
 import logging
 import logging.handlers
@@ -37,6 +38,7 @@ import os
 import queue
 import re
 import sys
+import threading
 import time
 from collections.abc import Callable
 from typing import Any
@@ -45,7 +47,7 @@ from urllib.parse import urlparse
 from urllib3.util.retry import Retry
 
 from trusted_router.config import Settings
-from trusted_router.sentry_config import _scrub, _scrub_string
+from trusted_router.sentry_config import _is_sensitive_key, _scrub, _scrub_string
 
 log = logging.getLogger(__name__)
 HTTPAdapter: Any = importlib.import_module("requests.adapters").HTTPAdapter
@@ -54,6 +56,48 @@ HTTPAdapter: Any = importlib.import_module("requests.adapters").HTTPAdapter
 # the args-safe complement (PR #124 review P2).
 _AXIOM_SECRET_VALUE_RE = re.compile(r"(?i)(token|secret|key|password|authorization)=([^&\s\"']+)")
 _AXIOM_EMAIL_VALUE_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+
+
+def _scrub_axiom_string(value: str) -> str:
+    """Apply Axiom's message redactions to any string in the payload."""
+    return _scrub_string(
+        _AXIOM_EMAIL_VALUE_RE.sub(
+            "[Filtered-email]",
+            _AXIOM_SECRET_VALUE_RE.sub(r"\1=[Filtered]", value),
+        )
+    )
+
+
+def _scrub_axiom_value(value: Any) -> Any:
+    """Run the shared safe-value scrubber, then redact Axiom-wide PII.
+
+    ``sentry_config._scrub`` makes arbitrary values finite and serializable,
+    but its string policy intentionally targets known secret formats. Axiom's
+    payload is a flattened ``LogRecord.__dict__``, so its e-mail and
+    ``key=value`` rules must also apply recursively to every custom extra.
+    """
+
+    def redact_strings(scrubbed: Any) -> Any:
+        if isinstance(scrubbed, str):
+            return _scrub_axiom_string(scrubbed)
+        if isinstance(scrubbed, dict):
+            out: dict[Any, Any] = {}
+            for key, item in scrubbed.items():
+                if isinstance(key, str):
+                    safe_key: Any = _scrub_axiom_string(key)
+                elif key is None or isinstance(key, (bool, int, float)):
+                    safe_key = key
+                else:
+                    safe_key = f"[Filtered-{type(key).__name__}-key]"
+                out[safe_key] = redact_strings(item)
+            return out
+        if isinstance(scrubbed, list):
+            return [redact_strings(item) for item in scrubbed]
+        if isinstance(scrubbed, tuple):
+            return tuple(redact_strings(item) for item in scrubbed)
+        return scrubbed
+
+    return redact_strings(_scrub(value))
 
 
 def init_axiom(settings: Settings) -> None:
@@ -94,27 +138,25 @@ def init_axiom(settings: Settings) -> None:
         return
 
     resolved_level = _resolve_level(settings.axiom_log_level)
+    raw_handler = AxiomHandler(client, dataset)
     handler, listener = build_axiom_pipeline(
-        AxiomHandler(client, dataset),
+        raw_handler,
         resolved_level=resolved_level,
     )
     listener.start()
 
-    # Flush what is still queued at shutdown. The Axiom client already runs
-    # before_shutdown hooks; stopping the listener there drains the queue
-    # through the shipper first. atexit is the backstop for paths that never
-    # reach the client's own shutdown.
-    def _stop_listener() -> None:
-        try:
-            listener.stop()
-        except Exception as exc:  # noqa: BLE001 - shutdown must not raise.
-            sys.stderr.write(f"axiom.listener_stop_failed err={exc!r}\n")
+    # The callback owns shutdown ordering: drain the queue into axiom-py's
+    # buffer, then flush that buffer. axiom-py registers its own flush before
+    # this callback, so relying on its FIFO callback order would strand records
+    # that the listener delivers afterward. The same idempotent callback is an
+    # atexit backstop for paths that never reach the client's shutdown hook.
+    shutdown_pipeline = _make_axiom_shutdown(listener, raw_handler)
 
     try:
-        client.before_shutdown(_stop_listener)
+        client.before_shutdown(shutdown_pipeline)
     except Exception as exc:  # noqa: BLE001 - hook registration is best effort.
         log.warning("axiom.listener_shutdown_hook_failed err=%s", exc)
-    atexit.register(_stop_listener)
+    atexit.register(shutdown_pipeline)
 
     root = logging.getLogger()
     root.addHandler(handler)
@@ -147,8 +189,8 @@ def build_axiom_pipeline(
     early under pytest by design, so a test that only exercised `init_axiom`
     could not assert on the wiring at all — and a test that builds its own
     handlers asserts a stdlib property rather than this function's choices. The
-    security-relevant choice here is WHICH handler carries the scrub filter,
-    and that is only checkable against the objects this returns.
+    security-relevant choice here is that the queue handler scrubs a private
+    copy during ``prepare()``, before that copy can enter the queue.
 
     Returns the handler to attach to the root logger and the not-yet-started
     listener; the caller starts it and registers shutdown.
@@ -167,11 +209,10 @@ def build_axiom_pipeline(
     # may never slow a response.
     handler = _DroppingQueueHandler(queue.Queue(maxsize=max_queued))
     handler.setLevel(resolved_level)
-    # SCRUB BEFORE THE QUEUE, NOT AT THE SHIPPER. Filters run inside
-    # `Handler.handle()` before `emit()`, so attaching here scrubs on the
-    # logging thread and no unscrubbed record ever sits in the queue. Reuses
-    # sentry_config's `_scrub` so the PII rules have one home.
-    handler.addFilter(_AxiomScrubFilter())
+    # Scrubbing is owned by `_DroppingQueueHandler.prepare()`, not a handler
+    # filter. A filter would mutate the caller's shared LogRecord before a
+    # sibling stdout or Sentry handler sees it. `prepare()` first copies, then
+    # sanitizes, and only its private copy may cross the queue boundary.
     # Drop third-party transport chatter before it ships. Measured 2026-07-04:
     # urllib3.connectionpool (Sentry's envelope uploads) was 235 of 238 events
     # in a 2h window — observability traffic generating observability traffic.
@@ -179,7 +220,7 @@ def build_axiom_pipeline(
 
     # respect_handler_level=True so the shipper's level still governs what is
     # sent if either level is changed later.
-    listener = logging.handlers.QueueListener(
+    listener = _IdempotentQueueListener(
         handler.queue,
         shipper,
         respect_handler_level=True,
@@ -187,6 +228,43 @@ def build_axiom_pipeline(
     # No daemon flag to set: QueueListener.start() creates its monitor thread
     # with daemon=True itself, so the process is never held open by shipping.
     return handler, listener
+
+
+def _make_axiom_shutdown(
+    listener: logging.handlers.QueueListener,
+    raw_handler: logging.Handler,
+) -> Callable[[], None]:
+    """Return a once-only queue-drain-then-buffer-flush callback."""
+    lock = threading.Lock()
+    complete = False
+
+    def shutdown() -> None:
+        nonlocal complete
+        with lock:
+            if complete:
+                return
+            try:
+                listener.stop()
+            except Exception as exc:  # noqa: BLE001 - shutdown must not raise.
+                # Leave `complete` false so the atexit backstop can retry.
+                sys.stderr.write(f"axiom.listener_stop_failed err={exc!r}\n")
+                return
+            try:
+                raw_handler.flush()
+            except Exception as exc:  # noqa: BLE001 - defensive for test/custom handlers.
+                sys.stderr.write(f"axiom.flush_failed dropped=true err={exc!r}\n")
+            # axiom-py's emit starts a new timer after adding each drained
+            # record. Its earlier FIFO shutdown callback canceled the old
+            # timer, so cancel the replacement created during this drain.
+            timer = getattr(raw_handler, "timer", None)
+            if timer is not None:
+                try:
+                    timer.cancel()
+                except Exception:  # noqa: BLE001 - shutdown remains best effort.
+                    sys.stderr.write("axiom.timer_cancel_failed dropped=true\n")
+            complete = True
+
+    return shutdown
 
 
 def _client_kwargs(*, token: str, org_id: str | None, axiom_url: str) -> dict[str, Any]:
@@ -268,48 +346,39 @@ def _running_under_pytest(settings: Settings) -> bool:
 
 
 class _AxiomScrubFilter(logging.Filter):
-    """Scrub PII fields out of LogRecord.__dict__ before it leaves the
-    process. The AxiomHandler reads `record.__dict__` to build the
-    event payload, so mutating it here is the right hook.
+    """Scrub PII fields out of a private ``LogRecord`` copy.
+
+    The AxiomHandler reads ``record.__dict__`` to build the event payload, so
+    every outgoing key and value must be covered. The production queue handler
+    invokes this only after copying the caller's record; using it directly as
+    a handler filter would mutate records seen by sibling handlers.
 
     Reuses `sentry_config._scrub`, which walks the value recursively
     and replaces keys matching SENSITIVE_KEYS (prompt, content, key,
     authorization, ...) with '[Filtered]'. Same rules that protect
     Sentry breadcrumbs apply here."""
 
-    # Standard LogRecord fields we don't want to scrub (their values
-    # are usually filename/line numbers/etc., never secrets, and
-    # passing them through `_scrub` would needlessly walk them).
+    # These fields require structural handling rather than the generic value
+    # scrub below. Exception and stack data are removed in ``prepare()`` before
+    # a formatter can fold their arbitrary free text into the Axiom message.
     _SKIP_FIELDS = frozenset(
         {
-            "name",
             "msg",
             "args",
-            "levelname",
-            "levelno",
-            "pathname",
-            "filename",
-            "module",
             "exc_info",
             "exc_text",
             "stack_info",
-            "lineno",
-            "funcName",
-            "created",
-            "msecs",
-            "relativeCreated",
-            "thread",
-            "threadName",
-            "processName",
-            "process",
-            "taskName",
-            "asctime",
         }
     )
     _MAX_MESSAGE_CHARS = 2_000
     _TRUNCATION_SUFFIX = "…[truncated]"
 
     def filter(self, record: logging.LogRecord) -> bool:
+        # Never invoke arbitrary ``__str__`` code from a custom message object.
+        # The shared scrubber reduces unknown objects to a safe type marker.
+        if type(record.msg) is not str:
+            record.msg = _scrub_axiom_value(record.msg)
+            record.args = None
         try:
             collapsed = record.getMessage()
         except Exception:  # noqa: BLE001 - logging filters must not break logging.
@@ -321,32 +390,27 @@ class _AxiomScrubFilter(logging.Filter):
             # Collapsing args means Axiom loses structured args fields and gets
             # the final formatted message only. That is the point: nothing
             # unscrubbed can leave the process.
-            # _scrub_string last: the two regexes above only catch secrets in
-            # `key=value` shape and e-mail addresses, so a bare `sk-tr-v1-…` in
-            # an ordinary message ("rotating sk-tr-v1-ABC…") passed straight
-            # through to the shipper. _scrub_string applies the same declared
-            # fragment/prefix blocklist the structured fields already get.
-            record.msg = _scrub_string(
-                _AXIOM_EMAIL_VALUE_RE.sub(
-                    "[Filtered-email]",
-                    _AXIOM_SECRET_VALUE_RE.sub(r"\1=[Filtered]", collapsed),
-                )
-            )
+            record.msg = _scrub_axiom_string(collapsed)
             if len(record.msg) > self._MAX_MESSAGE_CHARS:
                 record.msg = (
                     record.msg[: self._MAX_MESSAGE_CHARS - len(self._TRUNCATION_SUFFIX)]
                     + self._TRUNCATION_SUFFIX
                 )
             record.args = None
+            # QueueHandler.prepare() adds ``message`` alongside ``msg``. Keep
+            # both payload fields identical so a downstream handler cannot
+            # read the pre-scrub formatted value from the former.
+            if "message" in record.__dict__:
+                record.message = record.msg
 
         for key, value in list(record.__dict__.items()):
             if key in self._SKIP_FIELDS:
                 continue
-            if key.startswith("_"):
-                continue
-            scrubbed = _scrub(value)
-            if scrubbed is not value:
-                record.__dict__[key] = scrubbed
+            safe_key = _scrub_axiom_string(key)
+            scrubbed = "[Filtered]" if _is_sensitive_key(key) else _scrub_axiom_value(value)
+            if safe_key != key:
+                del record.__dict__[key]
+            record.__dict__[safe_key] = scrubbed
         return True
 
 
@@ -383,6 +447,29 @@ class _AxiomNoiseFilter(logging.Filter):
         return True
 
 
+class _IdempotentQueueListener(logging.handlers.QueueListener):
+    """QueueListener with stable start/stop semantics across Python 3.11+."""
+
+    def __init__(self, *handlers: Any, **kwargs: Any) -> None:
+        super().__init__(*handlers, **kwargs)
+        self._lifecycle_lock = threading.Lock()
+        self._running = False
+
+    def start(self) -> None:
+        with self._lifecycle_lock:
+            if self._running:
+                return
+            super().start()
+            self._running = True
+
+    def stop(self) -> None:
+        with self._lifecycle_lock:
+            if not self._running:
+                return
+            super().stop()
+            self._running = False
+
+
 class _DroppingQueueHandler(logging.handlers.QueueHandler):
     """Enqueue for the shipper thread, and drop rather than block when full.
 
@@ -401,30 +488,66 @@ class _DroppingQueueHandler(logging.handlers.QueueHandler):
     stderr breadcrumb is written. Dropping observability under backpressure is
     the correct trade; blocking a request on log shipping is not.
 
-    FILTERS RUN BEFORE THE QUEUE, DELIBERATELY. `logging.Handler.handle()`
-    applies filters and then calls `emit()`, so a filter attached to THIS
-    handler runs on the request thread before the record is enqueued. The PII
-    scrubbing filter is attached here rather than to the shipping handler for
-    exactly that reason: an unscrubbed record must never exist in the queue,
-    where a crash dump or a future queue implementation could expose it.
+    SCRUBBING RUNS BEFORE THE QUEUE, DELIBERATELY. ``prepare()`` copies the
+    caller's record, scrubs its ordinary message and all custom extras, removes
+    arbitrary exception/stack free text, then formats and scrubs the final
+    payload again. Thus neither the shared caller record nor anything that
+    reaches the queue contains a newly exposed traceback or unsanitized extra.
     """
 
     def __init__(self, queue: Any) -> None:
         super().__init__(queue)
         self._dropped = 0
         self._last_drop_log_at: float | None = None
+        self._queue_scrubber = _AxiomScrubFilter()
+
+    def prepare(self, record: logging.LogRecord) -> logging.LogRecord:
+        """Format, then scrub the exact copy that will cross the queue.
+
+        Axiom is the structured-event tier; Sentry owns exception detail.
+        ``QueueHandler.prepare`` would otherwise format arbitrary exception and
+        stack text into ``msg``. Remove it from the copied record before stdlib
+        formatting, then scrub the fully prepared payload a second time for
+        custom formatter output. The caller's record remains untouched for
+        sibling stdout and Sentry handlers.
+        """
+        prepared = copy.copy(record)
+        self._queue_scrubber.filter(prepared)
+        prepared.exc_info = None
+        prepared.exc_text = None
+        prepared.stack_info = None
+        prepared = super().prepare(prepared)
+        self._queue_scrubber.filter(prepared)
+        return prepared
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Prepare without letting stdlib print the raw record on failure.
+
+        ``QueueHandler.emit`` delegates preparation errors to
+        ``handleError(record)``. With ``logging.raiseExceptions`` enabled that
+        fallback writes the *original*, unsanitized message and arguments to
+        stderr. A pathological custom extra must cost one log record, never
+        create a second PII channel.
+        """
+        try:
+            prepared = self.prepare(record)
+        except Exception:  # noqa: BLE001 - malformed extras must fail closed.
+            self._note_drop(event="record_dropped", reason="scrub_failed")
+            return
+        self.enqueue(prepared)
 
     def enqueue(self, record: logging.LogRecord) -> None:
         try:
             self.queue.put_nowait(record)
         except Exception:  # noqa: BLE001 - a full queue must not break a request.
-            self._dropped += 1
-            now = time.monotonic()
-            if self._last_drop_log_at is None or now - self._last_drop_log_at > 60:
-                self._last_drop_log_at = now
-                sys.stderr.write(
-                    f"axiom.queue_full dropped_total={self._dropped} reason=shipper_thread_behind\n"
-                )
+            self._note_drop(event="queue_full", reason="shipper_thread_behind")
+
+    def _note_drop(self, *, event: str, reason: str) -> None:
+        self._dropped += 1
+        now = time.monotonic()
+        if self._last_drop_log_at is None or now - self._last_drop_log_at > 60:
+            self._last_drop_log_at = now
+            sys.stderr.write(f"axiom.{event} dropped_total={self._dropped} reason={reason}\n")
 
 
 class _SafeAxiomHandler(logging.Handler):

--- a/src/trusted_router/axiom_config.py
+++ b/src/trusted_router/axiom_config.py
@@ -29,9 +29,12 @@ Design choices:
 
 from __future__ import annotations
 
+import atexit
 import importlib
 import logging
+import logging.handlers
 import os
+import queue
 import re
 import sys
 import time
@@ -91,24 +94,27 @@ def init_axiom(settings: Settings) -> None:
         return
 
     resolved_level = _resolve_level(settings.axiom_log_level)
-    raw_handler: Any = AxiomHandler(client, dataset)
-    raw_handler.setLevel(logging.NOTSET)
-    # axiom-py's emit() recreates each threading.Timer with `self.flush` at
-    # Timer-creation time. Assigning the bound flush on this instance shadows
-    # the class method, so timer-thread flushes go through the safe wrapper too.
-    raw_handler.flush = _safe_flush_wrapper(raw_handler.flush)
-    handler: logging.Handler = _SafeAxiomHandler(raw_handler)
-    handler.setLevel(resolved_level)
-    # Attach a filter that scrubs PII before the handler ships the
-    # record. Reuses sentry_config's `_scrub` so the rules are defined
-    # in one place.
-    handler.addFilter(_AxiomScrubFilter())
-    # Drop third-party transport chatter before it ships. Measured
-    # 2026-07-04: urllib3.connectionpool (Sentry's envelope uploads)
-    # was 235 of 238 events in a 2h window — a feedback loop where
-    # observability traffic generates observability traffic. Name-based
-    # so it composes with any handler level.
-    handler.addFilter(_AxiomNoiseFilter())
+    handler, listener = build_axiom_pipeline(
+        AxiomHandler(client, dataset),
+        resolved_level=resolved_level,
+    )
+    listener.start()
+
+    # Flush what is still queued at shutdown. The Axiom client already runs
+    # before_shutdown hooks; stopping the listener there drains the queue
+    # through the shipper first. atexit is the backstop for paths that never
+    # reach the client's own shutdown.
+    def _stop_listener() -> None:
+        try:
+            listener.stop()
+        except Exception as exc:  # noqa: BLE001 - shutdown must not raise.
+            sys.stderr.write(f"axiom.listener_stop_failed err={exc!r}\n")
+
+    try:
+        client.before_shutdown(_stop_listener)
+    except Exception as exc:  # noqa: BLE001 - hook registration is best effort.
+        log.warning("axiom.listener_shutdown_hook_failed err=%s", exc)
+    atexit.register(_stop_listener)
 
     root = logging.getLogger()
     root.addHandler(handler)
@@ -127,6 +133,60 @@ def init_axiom(settings: Settings) -> None:
         settings.axiom_log_level,
         "<set>" if org_id else "<unset>",
     )
+
+
+def build_axiom_pipeline(
+    raw_handler: Any,
+    *,
+    resolved_level: int,
+    max_queued: int = 10_000,
+) -> tuple[_DroppingQueueHandler, logging.handlers.QueueListener]:
+    """Wire the record path: logging thread -> bounded queue -> shipper thread.
+
+    Extracted from `init_axiom` so the wiring is testable. `init_axiom` returns
+    early under pytest by design, so a test that only exercised `init_axiom`
+    could not assert on the wiring at all — and a test that builds its own
+    handlers asserts a stdlib property rather than this function's choices. The
+    security-relevant choice here is WHICH handler carries the scrub filter,
+    and that is only checkable against the objects this returns.
+
+    Returns the handler to attach to the root logger and the not-yet-started
+    listener; the caller starts it and registers shutdown.
+    """
+    raw_handler.setLevel(logging.NOTSET)
+    # axiom-py's emit() recreates each threading.Timer with `self.flush` at
+    # Timer-creation time. Assigning the bound flush on this instance shadows
+    # the class method, so timer-thread flushes go through the safe wrapper too.
+    raw_handler.flush = _safe_flush_wrapper(raw_handler.flush)
+    shipper: logging.Handler = _SafeAxiomHandler(raw_handler)
+    shipper.setLevel(resolved_level)
+
+    # The record crosses to the shipper thread here, so the blocking HTTPS POST
+    # inside axiom-py's emit() no longer happens on the request thread. The
+    # queue is bounded: log shipping may lose records under backpressure, and
+    # may never slow a response.
+    handler = _DroppingQueueHandler(queue.Queue(maxsize=max_queued))
+    handler.setLevel(resolved_level)
+    # SCRUB BEFORE THE QUEUE, NOT AT THE SHIPPER. Filters run inside
+    # `Handler.handle()` before `emit()`, so attaching here scrubs on the
+    # logging thread and no unscrubbed record ever sits in the queue. Reuses
+    # sentry_config's `_scrub` so the PII rules have one home.
+    handler.addFilter(_AxiomScrubFilter())
+    # Drop third-party transport chatter before it ships. Measured 2026-07-04:
+    # urllib3.connectionpool (Sentry's envelope uploads) was 235 of 238 events
+    # in a 2h window — observability traffic generating observability traffic.
+    handler.addFilter(_AxiomNoiseFilter())
+
+    # respect_handler_level=True so the shipper's level still governs what is
+    # sent if either level is changed later.
+    listener = logging.handlers.QueueListener(
+        handler.queue,
+        shipper,
+        respect_handler_level=True,
+    )
+    # No daemon flag to set: QueueListener.start() creates its monitor thread
+    # with daemon=True itself, so the process is never held open by shipping.
+    return handler, listener
 
 
 def _client_kwargs(*, token: str, org_id: str | None, axiom_url: str) -> dict[str, Any]:
@@ -188,8 +248,14 @@ def _handler_already_installed() -> bool:
     """Don't double-attach if init_axiom() is called twice in the same
     process (e.g. tests that re-create the FastAPI app)."""
     root = logging.getLogger()
+    # `_DroppingQueueHandler` is what actually lands on root now that shipping
+    # happens on a listener thread; the other two names are what earlier
+    # versions attached, and are kept so a mixed-version process still
+    # short-circuits. Missing a name here does not merely double-log: it
+    # starts a second listener thread and a second bounded queue.
     return any(
-        type(handler).__name__ in {"AxiomHandler", "_SafeAxiomHandler"} for handler in root.handlers
+        type(handler).__name__ in {"AxiomHandler", "_SafeAxiomHandler", "_DroppingQueueHandler"}
+        for handler in root.handlers
     )
 
 
@@ -315,6 +381,50 @@ class _AxiomNoiseFilter(logging.Filter):
             if name == prefix or name.startswith(prefix + "."):
                 return False
         return True
+
+
+class _DroppingQueueHandler(logging.handlers.QueueHandler):
+    """Enqueue for the shipper thread, and drop rather than block when full.
+
+    WHY THIS EXISTS. axiom-py's `AxiomHandler.emit()` flushes SYNCHRONOUSLY in
+    the calling thread whenever more than its interval (1s) has elapsed since
+    the last flush. At low request volume that is nearly every request, so a
+    request that logs pays a blocking HTTPS POST to Axiom before it can
+    respond. Measured 2026-08-17 from this machine: 551 ms for a cold POST to
+    api.axiom.co. Production console pages served from europe-west4 measured
+    p50 1540 ms; this was one of the summands.
+
+    `logging.handlers.QueueHandler.enqueue` uses `put_nowait`, which raises
+    `queue.Full` on a bounded queue. The base class routes that through
+    `handleError`, whose behaviour depends on `logging.raiseExceptions`. Being
+    explicit instead: on a full queue the record is dropped and a throttled
+    stderr breadcrumb is written. Dropping observability under backpressure is
+    the correct trade; blocking a request on log shipping is not.
+
+    FILTERS RUN BEFORE THE QUEUE, DELIBERATELY. `logging.Handler.handle()`
+    applies filters and then calls `emit()`, so a filter attached to THIS
+    handler runs on the request thread before the record is enqueued. The PII
+    scrubbing filter is attached here rather than to the shipping handler for
+    exactly that reason: an unscrubbed record must never exist in the queue,
+    where a crash dump or a future queue implementation could expose it.
+    """
+
+    def __init__(self, queue: Any) -> None:
+        super().__init__(queue)
+        self._dropped = 0
+        self._last_drop_log_at: float | None = None
+
+    def enqueue(self, record: logging.LogRecord) -> None:
+        try:
+            self.queue.put_nowait(record)
+        except Exception:  # noqa: BLE001 - a full queue must not break a request.
+            self._dropped += 1
+            now = time.monotonic()
+            if self._last_drop_log_at is None or now - self._last_drop_log_at > 60:
+                self._last_drop_log_at = now
+                sys.stderr.write(
+                    f"axiom.queue_full dropped_total={self._dropped} reason=shipper_thread_behind\n"
+                )
 
 
 class _SafeAxiomHandler(logging.Handler):

--- a/tests/test_axiom_config.py
+++ b/tests/test_axiom_config.py
@@ -286,6 +286,69 @@ def test_axiom_timer_flush_wrapper_success_delivers_buffer(capsys) -> None:
     assert raw_handler.buffer == []
 
 
+def test_real_axiom_handler_ingests_only_the_sanitized_queue_payload() -> None:
+    """Exercise axiom-py's actual ``record.__dict__`` serialization path."""
+    exception_canary = "AXIOM-SINK-ARBITRARY-NARRATIVE-41729"
+    email_canary = "axiom-sink-canary@example.com"
+    secret_canary = "sk-tr-v1-AXIOMSINKCANARY"  # noqa: S105 - redaction canary
+    authorization_canary = "Bearer opaque-axiom-sink-authorization"
+    try:
+        raise RuntimeError(exception_canary)
+    except RuntimeError as exc:
+        record = logging.LogRecord(
+            name="trusted_router.test",
+            level=logging.ERROR,
+            pathname=__file__,
+            lineno=1,
+            msg="provider request failed",
+            args=(),
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+    record.stack_info = f"raw stack {exception_canary}"
+    record.email = email_canary
+    record.authorization = authorization_canary
+    record._private = secret_canary
+    record.context = {"contacts": (email_canary,), "prompt": "patient narrative"}
+
+    client = _StubAxiomClient()
+    raw_handler = axiom_logging.AxiomHandler(client, "test-logs", interval=60)
+    queue_handler, listener = axiom_config.build_axiom_pipeline(
+        raw_handler,
+        resolved_level=logging.INFO,
+    )
+    shutdown = axiom_config._make_axiom_shutdown(listener, raw_handler)
+    client.before_shutdown(shutdown)
+    listener.start()
+    queue_handler.handle(record)
+
+    # axiom-py registered its own flush first. Execute the client's real FIFO
+    # callback order and require our later owner callback to drain then flush
+    # the record that the first callback could not yet see.
+    for callback in client.shutdown_callbacks:
+        callback()
+    shutdown()
+
+    assert len(client.ingested) == 1
+    dataset, events = client.ingested[0]
+    assert dataset == "test-logs"
+    assert len(events) == 1
+    payload = repr(events[0])
+    for canary in (
+        exception_canary,
+        email_canary,
+        secret_canary,
+        authorization_canary,
+    ):
+        assert canary not in payload
+    assert events[0]["email"] == "[Filtered-email]"
+    assert events[0]["authorization"] == "[Filtered]"
+    assert events[0]["_private"] == "[Filtered]"
+    assert events[0]["context"] == {
+        "contacts": ("[Filtered-email]",),
+        "prompt": "[Filtered]",
+    }
+
+
 def test_axiom_client_session_mounts_post_retry_adapter() -> None:
     client = _StubAxiomClient()
 

--- a/tests/test_axiom_config.py
+++ b/tests/test_axiom_config.py
@@ -69,6 +69,31 @@ def clean_axiom_logging_state() -> Iterator[None]:
         logging.disable(original_disable)
 
 
+@pytest.fixture
+def captured_axiom_listeners(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[logging.handlers.QueueListener]:
+    listeners: list[logging.handlers.QueueListener] = []
+    original_build_pipeline = axiom_config.build_axiom_pipeline
+
+    def capture_pipeline(
+        raw_handler: object,
+        *,
+        resolved_level: int,
+        max_queued: int = 10_000,
+    ) -> tuple[axiom_config._DroppingQueueHandler, logging.handlers.QueueListener]:
+        pipeline = original_build_pipeline(
+            raw_handler,
+            resolved_level=resolved_level,
+            max_queued=max_queued,
+        )
+        listeners.append(pipeline[1])
+        return pipeline
+
+    monkeypatch.setattr(axiom_config, "build_axiom_pipeline", capture_pipeline)
+    return listeners
+
+
 class _ExplodingHandler(logging.Handler):
     def emit(self, record: logging.LogRecord) -> None:
         raise RuntimeError("axiom dataset is not ingestible")
@@ -463,7 +488,9 @@ def test_trustedos_inquiry_delivery_failed_log_ships_lengths_not_free_text(
         def send(self, _message: EmailMessage) -> bool:
             return False
 
-    monkeypatch.setattr(public_routes, "get_email_service", lambda _settings: RefusingEmailService())
+    monkeypatch.setattr(
+        public_routes, "get_email_service", lambda _settings: RefusingEmailService()
+    )
     client = _trustedos_client(
         Settings(
             environment="test",
@@ -521,6 +548,7 @@ def test_axiom_client_kwargs_keep_standard_api_url_for_non_edge() -> None:
 def test_init_axiom_sets_package_logger_level_and_keeps_third_party_info_gated(
     monkeypatch: pytest.MonkeyPatch,
     clean_axiom_logging_state: None,
+    captured_axiom_listeners: list[logging.handlers.QueueListener],
 ) -> None:
     captured_records: list[logging.LogRecord] = []
 
@@ -558,9 +586,14 @@ def test_init_axiom_sets_package_logger_level_and_keeps_third_party_info_gated(
     logging.getLogger("trusted_router.anything").info("app info reaches axiom")
     logging.getLogger("thirdparty").info("third-party info stays gated")
 
+    assert len(captured_axiom_listeners) == 1
+    # QueueListener.stop() puts its sentinel behind every queued record and
+    # joins the monitor thread. That is a deterministic flush; sleeping here
+    # would merely make this assertion probabilistic on a busy CI worker.
+    captured_axiom_listeners[0].stop()
+
     assert any(
-        record.name == "trusted_router.anything"
-        and record.getMessage() == "app info reaches axiom"
+        record.name == "trusted_router.anything" and record.getMessage() == "app info reaches axiom"
         for record in captured_records
     )
     assert all(record.name != "thirdparty" for record in captured_records)
@@ -569,6 +602,7 @@ def test_init_axiom_sets_package_logger_level_and_keeps_third_party_info_gated(
 def test_init_axiom_caps_package_logger_level_at_warning_but_keeps_handler_level(
     monkeypatch: pytest.MonkeyPatch,
     clean_axiom_logging_state: None,
+    captured_axiom_listeners: list[logging.handlers.QueueListener],
 ) -> None:
     class FakeClient:
         def __init__(self, **kwargs: object) -> None:
@@ -598,9 +632,12 @@ def test_init_axiom_caps_package_logger_level_at_warning_but_keeps_handler_level
         )
     )
 
+    assert len(captured_axiom_listeners) == 1
+    listener = captured_axiom_listeners[0]
     installed_handlers = [
-        handler for handler in logging.getLogger().handlers if isinstance(handler, _SafeAxiomHandler)
+        handler for handler in listener.handlers if isinstance(handler, _SafeAxiomHandler)
     ]
+    listener.stop()
     assert len(installed_handlers) == 1
     assert logging.getLogger("trusted_router").level == logging.WARNING
     assert installed_handlers[0].level == logging.ERROR
@@ -608,8 +645,13 @@ def test_init_axiom_caps_package_logger_level_at_warning_but_keeps_handler_level
 
 def _record(logger_name: str) -> logging.LogRecord:
     return logging.LogRecord(
-        name=logger_name, level=logging.INFO, pathname=__file__,
-        lineno=1, msg="hello", args=(), exc_info=None,
+        name=logger_name,
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="hello",
+        args=(),
+        exc_info=None,
     )
 
 

--- a/tests/test_axiom_nonblocking.py
+++ b/tests/test_axiom_nonblocking.py
@@ -1,0 +1,152 @@
+"""Axiom log shipping must not block the thread that logs.
+
+THE DEFECT THIS GUARDS. `axiom_py.logging.AxiomHandler.emit()` flushes
+SYNCHRONOUSLY in the calling thread whenever more than its interval (1 second)
+has elapsed since the last flush:
+
+    if len(self.buffer) >= 1000 or time.monotonic() - self.last_flush > self.interval:
+        self.flush()
+
+At low request volume more than a second has almost always elapsed, so a
+request that emits one log line pays a blocking HTTPS POST to Axiom before it
+can respond. Measured 2026-08-17: 551 ms for a cold POST to api.axiom.co.
+Production console pages served from europe-west4 measured p50 1540 ms and this
+was one of the summands.
+
+The fix routes records through a bounded queue to a listener thread. These
+tests pin the two properties that make the fix correct rather than merely
+faster:
+
+  1. emitting returns promptly even when shipping is slow, AND the record
+     still arrives at the shipper (fast-and-lossy is not the goal);
+  2. the PII scrub filter runs BEFORE the record enters the queue, so an
+     unscrubbed record never exists in the queue.
+
+Scope limit: these tests exercise the handler wiring directly rather than
+`init_axiom`, because `init_axiom` returns early under pytest by design
+(`_running_under_pytest`). What they do not cover is the real axiom-py client;
+the blocking behaviour above is quoted from the vendored source, not asserted
+here.
+"""
+
+from __future__ import annotations
+
+import logging
+import logging.handlers
+import queue
+import threading
+import time
+
+from trusted_router.axiom_config import (
+    _DroppingQueueHandler,
+    build_axiom_pipeline,
+)
+
+CANARY = "sk-tr-v1-BLOCKINGCANARY"
+
+
+class _SlowShipper(logging.Handler):
+    """Stands in for axiom-py's synchronous flush."""
+
+    def __init__(self, delay: float) -> None:
+        super().__init__()
+        self.delay = delay
+        self.received: list[logging.LogRecord] = []
+        self.arrived = threading.Event()
+
+    def emit(self, record: logging.LogRecord) -> None:
+        time.sleep(self.delay)
+        self.received.append(record)
+        self.arrived.set()
+
+
+def _record(message: str, **extra: object) -> logging.LogRecord:
+    record = logging.LogRecord(
+        name="trusted_router.test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg=message,
+        args=(),
+        exc_info=None,
+    )
+    for key, value in extra.items():
+        setattr(record, key, value)
+    return record
+
+
+def test_emitting_does_not_wait_for_the_shipper() -> None:
+    """The property the whole change exists for."""
+    shipper = _SlowShipper(delay=0.5)
+    handler = _DroppingQueueHandler(queue.Queue(maxsize=100))
+    listener = logging.handlers.QueueListener(handler.queue, shipper)
+    listener.start()
+    try:
+        started = time.monotonic()
+        handler.handle(_record("event happened"))
+        elapsed = time.monotonic() - started
+
+        assert elapsed < 0.05, f"emit blocked for {elapsed:.3f}s; shipping must be off-thread"
+        assert shipper.arrived.wait(timeout=5), "record never reached the shipper"
+        assert len(shipper.received) == 1
+    finally:
+        listener.stop()
+
+
+def test_the_scrub_filter_runs_before_the_queue() -> None:
+    """An unscrubbed record must never exist in the queue.
+
+    This drives the REAL wiring via `build_axiom_pipeline`. An earlier version
+    of this test built its own handler and attached the filter itself, so it
+    passed even when the production wiring put the scrub filter on the shipper
+    — i.e. it asserted a stdlib property (filters run before emit) instead of
+    the security property (production scrubs before the queue). Moving the
+    filter in the source must redden this test, and now does.
+    """
+    handler, listener = build_axiom_pipeline(_SlowShipper(delay=0), resolved_level=logging.INFO)
+
+    handler.handle(_record("rotating a key", context={"api_key": CANARY}))
+
+    queued = handler.queue.get_nowait()
+    assert CANARY not in str(queued.__dict__), "unscrubbed record reached the queue"
+    assert not listener._thread, "build must return the listener unstarted"
+
+
+def test_the_pipeline_puts_the_scrub_filter_on_the_queue_handler() -> None:
+    """The placement, asserted directly, so the reason is legible in a failure."""
+    handler, _ = build_axiom_pipeline(_SlowShipper(delay=0), resolved_level=logging.INFO)
+
+    filter_names = {type(f).__name__ for f in handler.filters}
+    assert "_AxiomScrubFilter" in filter_names, (
+        "the scrub filter must sit on the queue handler; on the shipper it would "
+        "run after the record has already crossed into the queue"
+    )
+
+
+def test_a_full_queue_drops_instead_of_blocking() -> None:
+    """Backpressure must cost observability, never latency."""
+    handler = _DroppingQueueHandler(queue.Queue(maxsize=1))
+    handler.handle(_record("first"))
+
+    started = time.monotonic()
+    for index in range(50):
+        handler.handle(_record(f"overflow {index}"))
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.5, f"a full queue blocked for {elapsed:.3f}s"
+    assert handler._dropped >= 50, "drops were not counted"
+
+
+def test_the_idempotency_guard_knows_the_handler_that_is_actually_attached() -> None:
+    """`init_axiom` attaches `_DroppingQueueHandler` to root now. If the guard
+    does not recognise it, a second `init_axiom` call starts a second listener
+    thread and a second queue rather than short-circuiting."""
+    from trusted_router.axiom_config import _handler_already_installed
+
+    root = logging.getLogger()
+    handler = _DroppingQueueHandler(queue.Queue(maxsize=1))
+    root.addHandler(handler)
+    try:
+        assert _handler_already_installed() is True
+    finally:
+        root.removeHandler(handler)

--- a/tests/test_axiom_nonblocking.py
+++ b/tests/test_axiom_nonblocking.py
@@ -19,8 +19,8 @@ faster:
 
   1. emitting returns promptly even when shipping is slow, AND the record
      still arrives at the shipper (fast-and-lossy is not the goal);
-  2. the PII scrub filter runs BEFORE the record enters the queue, so an
-     unscrubbed record never exists in the queue.
+  2. queue preparation scrubs a private copy BEFORE it enters the queue, so an
+     unscrubbed record never exists there and sibling handlers stay unchanged.
 
 Scope limit: these tests exercise the handler wiring directly rather than
 `init_axiom`, because `init_axiom` returns early under pytest by design
@@ -36,9 +36,13 @@ import logging.handlers
 import queue
 import threading
 import time
+from collections.abc import Iterator, Mapping
+
+import pytest
 
 from trusted_router.axiom_config import (
     _DroppingQueueHandler,
+    _make_axiom_shutdown,
     build_axiom_pipeline,
 )
 
@@ -93,7 +97,7 @@ def test_emitting_does_not_wait_for_the_shipper() -> None:
         listener.stop()
 
 
-def test_the_scrub_filter_runs_before_the_queue() -> None:
+def test_scrubbing_runs_before_the_queue() -> None:
     """An unscrubbed record must never exist in the queue.
 
     This drives the REAL wiring via `build_axiom_pipeline`. An earlier version
@@ -103,24 +107,298 @@ def test_the_scrub_filter_runs_before_the_queue() -> None:
     the security property (production scrubs before the queue). Moving the
     filter in the source must redden this test, and now does.
     """
-    handler, listener = build_axiom_pipeline(_SlowShipper(delay=0), resolved_level=logging.INFO)
+    shipper = _SlowShipper(delay=0)
+    handler, _ = build_axiom_pipeline(shipper, resolved_level=logging.INFO)
 
     handler.handle(_record("rotating a key", context={"api_key": CANARY}))
 
     queued = handler.queue.get_nowait()
     assert CANARY not in str(queued.__dict__), "unscrubbed record reached the queue"
-    assert not listener._thread, "build must return the listener unstarted"
+    assert shipper.received == [], "build must return the listener unstarted"
 
 
-def test_the_pipeline_puts_the_scrub_filter_on_the_queue_handler() -> None:
-    """The placement, asserted directly, so the reason is legible in a failure."""
+def test_exception_and_stack_data_are_scrubbed_at_the_queue_boundary() -> None:
+    """No exception, stack, or extra PII may cross the queue boundary.
+
+    Axiom is the structured-log tier, while Sentry owns exception detail.
+    Pattern matching is insufficient for arbitrary exception text, so inspect
+    the exact queued copy and require the raw exception fields to be absent.
+    """
+    exception_canary = "sk-tr-v1-EXCEPTIONCANARY"
+    arbitrary_exception = "ARBITRARY-PATIENT-NARRATIVE-74291"
+    cached_exception = "CACHED-ARBITRARY-NARRATIVE-91357"
+    stack_canary = "queue-stack-canary@example.com"
+    top_level_email = "queue-extra-canary@example.com"
+    nested_email = "queue-nested-canary@example.com"
+    opaque_authorization = "Bearer opaque-authorization-canary"
+    private_canary = "sk-tr-v1-PRIVATECANARY"
+    opaque_api_key = "opaque-api-key-canary"
+    field_name_canary = "sk-tr-v1-FIELDNAMECANARY"
+    try:
+        raise RuntimeError(f"upstream rejected {exception_canary} {arbitrary_exception}")
+    except RuntimeError as exc:
+        record = logging.LogRecord(
+            name="trusted_router.test",
+            level=logging.ERROR,
+            pathname=__file__,
+            lineno=1,
+            msg="request failed",
+            args=(),
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+    record.stack_info = f"Stack (most recent call last):\n  account={stack_canary}"
+    record.exc_text = f"already formatted: {cached_exception}"
+    record.customer_email = top_level_email
+    record.error_message = nested_email
+    record.authorization = opaque_authorization
+    record.api_key = opaque_api_key
+    record._private = private_canary
+    record.context = {
+        "contact": nested_email,
+        "items": ("token=opaque-nested-token", {"prompt": "private narrative"}),
+    }
+    setattr(record, field_name_canary, "field-name value")
+
+    assert exception_canary in str(record.exc_info[1])
+    assert stack_canary in record.stack_info
+    original_payload = record.__dict__.copy()
+    shipper = _SlowShipper(delay=0)
+    handler, _ = build_axiom_pipeline(
+        shipper,
+        resolved_level=logging.INFO,
+    )
+
+    handler.handle(record)
+
+    queued = handler.queue.get_nowait()
+    queued_payload = repr(queued.__dict__)
+    assert queued is not record
+    for canary in (
+        exception_canary,
+        arbitrary_exception,
+        cached_exception,
+        stack_canary,
+        top_level_email,
+        nested_email,
+        opaque_authorization,
+        private_canary,
+        opaque_api_key,
+        field_name_canary,
+    ):
+        assert canary not in queued_payload
+    assert queued.msg == queued.message
+    assert queued.args is None
+    assert queued.exc_info is None
+    assert queued.exc_text is None
+    assert queued.stack_info is None
+    assert queued.customer_email == "[Filtered-email]"
+    assert queued.error_message == "[Filtered-email]"
+    assert queued.authorization == "[Filtered]"
+    assert queued.api_key == "[Filtered]"
+    assert queued._private == "[Filtered]"
+    assert queued.context == {
+        "contact": "[Filtered-email]",
+        "items": ("token=[Filtered]", {"prompt": "[Filtered]"}),
+    }
+    assert queued.__dict__["[Filtered]"] == "field-name value"
+    # The Axiom handler must sanitize its own copy. Other handlers attached to
+    # the same logger should still receive the caller's original record.
+    assert record.__dict__ == original_payload
+    assert record.args == ()
+    assert record.customer_email == top_level_email
+    assert record.error_message == nested_email
+    assert record.authorization == opaque_authorization
+    assert record.api_key == opaque_api_key
+    assert record._private == private_canary
+    assert record.context == {
+        "contact": nested_email,
+        "items": ("token=opaque-nested-token", {"prompt": "private narrative"}),
+    }
+    assert record.exc_text == f"already formatted: {cached_exception}"
+    assert record.stack_info == f"Stack (most recent call last):\n  account={stack_canary}"
+    assert getattr(record, field_name_canary) == "field-name value"
+    assert "message" not in record.__dict__
+    assert shipper.received == [], "build must return the listener unstarted"
+
+
+def test_the_pipeline_scrubs_a_copy_in_queue_prepare() -> None:
+    """Scrubbing must happen before enqueue without mutating sibling handlers."""
     handler, _ = build_axiom_pipeline(_SlowShipper(delay=0), resolved_level=logging.INFO)
 
     filter_names = {type(f).__name__ for f in handler.filters}
-    assert "_AxiomScrubFilter" in filter_names, (
-        "the scrub filter must sit on the queue handler; on the shipper it would "
-        "run after the record has already crossed into the queue"
+    assert "_AxiomScrubFilter" not in filter_names, (
+        "handler filters mutate the shared caller record; the queue handler "
+        "must copy and scrub inside prepare() instead"
     )
+    assert type(handler._queue_scrubber).__name__ == "_AxiomScrubFilter"
+
+
+def test_actual_shipper_never_receives_raw_exception_stack_or_extra_data() -> None:
+    """The sanitized queue record must stay sanitized at the final handler."""
+    exception_canary = "sk-tr-v1-SINKEXCEPTIONCANARY"
+    arbitrary_exception = "SINK-ARBITRARY-PATIENT-NARRATIVE-85109"
+    stack_canary = "sink-stack-canary@example.com"
+    extra_canary = "sink-extra-canary@example.com"
+    opaque_authorization = "Bearer sink-opaque-authorization"
+    formatter_canary = "sk-tr-v1-FORMATTERCANARY"
+    try:
+        raise RuntimeError(f"provider rejected {exception_canary} {arbitrary_exception}")
+    except RuntimeError as exc:
+        record = logging.LogRecord(
+            name="trusted_router.test",
+            level=logging.ERROR,
+            pathname=__file__,
+            lineno=1,
+            msg="request failed",
+            args=(),
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+    record.stack_info = f"Stack (most recent call last):\n  account={stack_canary}"
+    record.customer_email = extra_canary
+    record.authorization = opaque_authorization
+
+    shipper = _SlowShipper(delay=0)
+    handler, listener = build_axiom_pipeline(shipper, resolved_level=logging.INFO)
+    handler.setFormatter(
+        logging.Formatter(
+            "%(levelname)s %(message)s customer_email=%(customer_email)s "
+            f"authorization=%(authorization)s trailer={formatter_canary}"
+        )
+    )
+    listener.start()
+    try:
+        handler.handle(record)
+    finally:
+        listener.stop()
+
+    assert len(shipper.received) == 1
+    shipped_payload = repr(shipper.received[0].__dict__)
+    for canary in (
+        exception_canary,
+        arbitrary_exception,
+        stack_canary,
+        extra_canary,
+        opaque_authorization,
+        formatter_canary,
+    ):
+        assert canary not in shipped_payload
+
+
+def test_custom_message_and_bad_args_cannot_escape_or_break_logging() -> None:
+    class ExplodingMessage:
+        def __str__(self) -> str:
+            raise AssertionError("the scrubber must not invoke custom __str__")
+
+    handler, _ = build_axiom_pipeline(_SlowShipper(delay=0), resolved_level=logging.INFO)
+
+    custom = _record("placeholder")
+    custom.msg = ExplodingMessage()
+    custom.args = ("sk-tr-v1-CUSTOMARGCANARY",)
+    handler.handle(custom)
+    queued_custom = handler.queue.get_nowait()
+
+    malformed = _record("two values: %s %s")
+    malformed.args = ("sk-tr-v1-MALFORMEDARGCANARY",)
+    handler.handle(malformed)
+    queued_malformed = handler.queue.get_nowait()
+
+    assert queued_custom.msg == "[Filtered-ExplodingMessage]"
+    assert queued_custom.args is None
+    assert "CUSTOMARGCANARY" not in repr(queued_custom.__dict__)
+    assert queued_malformed.msg == "two values: %s %s"
+    assert queued_malformed.args is None
+    assert "MALFORMEDARGCANARY" not in repr(queued_malformed.__dict__)
+
+
+def test_pathological_extras_drop_without_printing_the_raw_record(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Scrubber failures must not reach QueueHandler.handleError(original)."""
+
+    class ExplodingItems(Mapping[object, object]):
+        def __getitem__(self, key: object) -> object:
+            raise KeyError(key)
+
+        def __iter__(self) -> Iterator[object]:
+            return iter(())
+
+        def __len__(self) -> int:
+            return 1
+
+        def items(self) -> object:
+            raise RuntimeError("mapping traversal failed")
+
+    class ExplodingKey:
+        def __str__(self) -> str:
+            raise RuntimeError("key conversion failed")
+
+    class ExplodingString(str):
+        def lower(self) -> str:
+            raise RuntimeError("string normalization failed")
+
+    hostile_extras = (
+        ExplodingItems(),
+        {ExplodingKey(): "value"},
+        ExplodingString("value"),
+    )
+    for index, hostile_extra in enumerate(hostile_extras):
+        raw_canary = f"stderr-raw-{index}@example.com"
+        handler, _ = build_axiom_pipeline(
+            _SlowShipper(delay=0),
+            resolved_level=logging.INFO,
+        )
+        record = _record("unsafe positional value: %s")
+        record.args = (raw_canary,)
+        record.context = hostile_extra
+
+        handler.handle(record)
+
+        captured = capsys.readouterr()
+        assert handler.queue.empty()
+        assert handler._dropped == 1
+        assert "axiom.record_dropped dropped_total=1 reason=scrub_failed" in captured.err
+        assert raw_canary not in captured.err
+        assert "Message:" not in captured.err
+        assert "Arguments:" not in captured.err
+
+
+def test_shutdown_drains_then_flushes_once_and_is_safe_to_repeat(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    order: list[str] = []
+
+    class BufferingShipper(logging.Handler):
+        def __init__(self) -> None:
+            super().__init__()
+            self.buffer: list[str] = []
+            self.flushed: list[str] = []
+            self.flush_calls = 0
+
+        def emit(self, record: logging.LogRecord) -> None:
+            order.append("emit")
+            self.buffer.append(record.getMessage())
+
+        def flush(self) -> None:
+            order.append("flush")
+            self.flush_calls += 1
+            self.flushed.extend(self.buffer)
+            self.buffer.clear()
+
+    shipper = BufferingShipper()
+    handler, listener = build_axiom_pipeline(shipper, resolved_level=logging.INFO)
+    shutdown = _make_axiom_shutdown(listener, shipper)
+    listener.start()
+    handler.handle(_record("queued before shutdown"))
+
+    shutdown()
+    shutdown()
+    listener.stop()
+
+    assert shipper.flushed == ["queued before shutdown"]
+    assert shipper.buffer == []
+    assert shipper.flush_calls == 1
+    assert order == ["emit", "flush"]
+    assert capsys.readouterr().err == ""
 
 
 def test_a_full_queue_drops_instead_of_blocking() -> None:

--- a/tests/test_scrub_totality_property.py
+++ b/tests/test_scrub_totality_property.py
@@ -1,7 +1,8 @@
 """Property tests for scrub totality.
 
-`_scrub` is the last barrier on the Axiom path: `_AxiomScrubFilter` runs every
-log-record attribute through it and hands the record straight to the shipper.
+`_scrub` is the shared safe-value barrier on the Axiom path: queue preparation
+copies the caller's record, runs every outgoing key and value through the
+Axiom scrubber, and only then hands that private copy to the shipper.
 The law:
 
     for every value v built from any Python container shape,
@@ -185,8 +186,7 @@ def test_bytes_are_redacted_wholesale() -> None:
 @given(value=values)
 @settings(max_examples=400)
 def test_the_axiom_filter_ships_no_canary_in_an_extra(value: Any) -> None:
-    """End to end at the boundary that actually ships: the filter mutates the
-    record in place and axiom-py serialises it immediately afterwards."""
+    """Every record attribute, including underscore extras, is covered."""
     record = logging.LogRecord(
         name="trusted_router.test",
         level=logging.INFO,
@@ -199,9 +199,7 @@ def test_the_axiom_filter_ships_no_canary_in_an_extra(value: Any) -> None:
     record.context = value  # type: ignore[attr-defined]
 
     assert _AxiomScrubFilter().filter(record) is True
-    assert not _leaked(
-        {k: v for k, v in record.__dict__.items() if not k.startswith("_")}
-    )
+    assert not _leaked(record.__dict__)
 
 
 @pytest.mark.parametrize("secret", SECRETS)


### PR DESCRIPTION
First console-latency fix. Cloud Run measurements for authenticated `/console` 200s (2026-08-14..16) showed p50/p90 of 84/539 ms in `us-central1`, 398/629 ms in `us-east4`, and 1540/4074 ms in `europe-west4`.

## Defect and performance fix

`axiom_py.logging.AxiomHandler.emit()` can synchronously flush from the caller whenever its one-second interval has elapsed. A cold POST to `api.axiom.co` measured 551 ms, so an ordinary request that logged could pay an observability-network round trip.

Records now cross a bounded 10,000-record queue to a `QueueListener` shipper thread. Enqueue is nonblocking; under backpressure, observability records are deliberately dropped with a throttled constant breadcrumb rather than delaying a request. The handler-install guard recognizes the queue handler, preventing duplicate queues/listeners on repeated initialization.

## Security boundary

The original draft put the scrubber on the queue handler as a normal filter. Review found that design unsafe: stdlib queue preparation subsequently formatted raw `exc_info` and `stack_info` into `msg`; top-level/underscore extras were incomplete; and the filter mutated the shared caller record.

The final design instead owns `_DroppingQueueHandler.prepare()`:

- shallow-copy the caller record before any formatting;
- scrub the ordinary message and every outgoing key/value recursively, including top-level sensitive keys, underscore extras, e-mail values, nested mappings/tuples, and secret field names;
- remove `exc_info`, cached `exc_text`, and `stack_info` before stdlib formatting (Sentry remains the exception-detail tier);
- scrub the exact prepared `msg`/`message` again after custom formatting;
- if any pathological value or formatter makes preparation fail, drop the record and emit only constant metadata—never `QueueHandler.handleError(original_record)`.

No unsanitized record enters the queue, the real `axiom-py` serializer receives only the sanitized copy, and sibling stdout/Sentry handlers retain the untouched original `LogRecord`.

## Shutdown correctness

Shutdown is idempotent across supported Python 3.11–3.14 behavior. The owner callback stops/drains the listener first, flushes the newly populated Axiom buffer second, and cancels the replacement timer created while draining. This fixes axiom-py's FIFO callback order, where its earlier flush cannot see records that are still queued.

## Red and adversarial proof

- On the vulnerable head, the new queue-boundary regression exposed raw API-key/e-mail canaries from exceptions and stacks.
- Before the widened fix, top-level e-mail/authorization/underscore extras and arbitrary exception narratives also survived.
- Pathological `Mapping.items`, mapping-key `__str__`, and string-subclass normalization failures reproduced raw original `msg`/`args` on stderr through stdlib `handleError`; the final regression now proves queue-empty, one deliberate drop, constant stderr, and no raw data.
- Three independent mutations—restoring inherited prepare, omitting exception clearing, and omitting the post-format scrub—each turn their regression red.
- An independently run 800-record blocked-shipper stress accounted for every record as shipped or deliberately dropped, with no raw canary at the sink.
- A real `axiom-py` FIFO shutdown stress delivered 250/250 unique records, emptied queue and buffer, and canceled the replacement timer.

## Validation

Final rebase is conflict-free on `3314f370` (#669), candidate head `fbc1e064`. #669 changes only SMS templates plus `test_sms_form_preview.py`; that intervening test is included in the exact-head affected run.

```text
exact-head Axiom/property + #669 SMS tests: 72 passed
full suite on the immediately preceding, code-disjoint base: 4914 passed, 296 skipped, 10 xfailed, 0 failed (11m39s)
ruff check .: passed
mypy: passed (280 source files)
changed-file ruff format --check: passed
git diff --check: passed
```

Fresh independent review approved the preceding exact candidate; another exact-head review and replacement GitHub CI are gating the final rebase. No merge will use checks from an older SHA.

The repository-wide `ruff format --check .` remains baseline-red on hundreds of untouched files; no unrelated tree-wide formatting was applied, per `AGENTS.md`.
