### PR TITLE
Finish the registered-to-headquartered correction

### DIFF
--- a/src/trusted_router/templates/public/seo_china_ai_models.html
+++ b/src/trusted_router/templates/public/seo_china_ai_models.html
@@ -34,7 +34,7 @@ reply = client.chat.completions.create(
 <section class="compare-matrix" aria-label="Vendor endpoint compared with a US-operated route">
   <div class="matrix-row matrix-head"><span></span><strong>The lab's own API</strong><strong>A US-operated route for the same weights</strong></div>
   <div class="matrix-row"><span>Who built the model</span><span>The Chinese lab</span><span>The same Chinese lab. Routing does not change this.</span></div>
-  <div class="matrix-row"><span>Who operates the endpoint</span><span>A company whose operating home is China &mdash; named in its own policy where one is published, otherwise the group&rsquo;s own filing</span><span>A company registered in the United States, named in its own terms or filing</span></div>
+  <div class="matrix-row"><span>Who operates the endpoint</span><span>A company whose operating home is China &mdash; named in its own policy where one is published, otherwise the group&rsquo;s own filing</span><span>A company headquartered in the United States, named in its own terms or filing</span></div>
   <div class="matrix-row"><span>Where the request is sent</span><span>To the lab's operator</span><span>To that US provider. The request is not sent on to the originating lab.</span></div>
   <div class="matrix-row"><span>How you select it</span><span>Call the vendor route directly</span><span>Set <span class="mono">provider.jurisdiction</span> to <span class="mono">us</span>, or pin operators with <span class="mono">provider.only</span></span></div>
   <div class="matrix-row"><span>Retention posture</span><span>Whatever that vendor's policy says</span><span>A separate field per provider. Jurisdiction and retention are independent; the table below shows both.</span></div>

--- a/src/trusted_router/templates/public/seo_eu_ai_models.html
+++ b/src/trusted_router/templates/public/seo_eu_ai_models.html
@@ -4,7 +4,7 @@
   <div class="marketing-copy">
     <span class="eyebrow">European labs, European operators, and the gap between them</span>
     <h2>An EU-registered provider is not the same thing as EU data residency. This page keeps the two apart.</h2>
-    <p>Two facts get sold as one. The lab that trained a model has a country: {{ region.origin_model_count }} models in the catalog come from {{ region.lab_count }} lab{{ '' if region.lab_count == 1 else 's' }} registered in an EU member state. The company operating the endpoint a request reaches has its own country, and it is a different field: {{ region.provider_count }} of the {{ region.catalog_provider_count }} providers here are operated by a company registered in the EU.</p>
+    <p>Two facts get sold as one. The lab that trained a model has a country: {{ region.origin_model_count }} models in the catalog come from {{ region.lab_count }} lab{{ '' if region.lab_count == 1 else 's' }} based in an EU member state. The company operating the endpoint a request reaches has its own country, and it is a different field: {{ region.provider_count }} of the {{ region.catalog_provider_count }} providers here are operated by a company headquartered in the EU.</p>
     <p>Neither field is a residency guarantee. TrustedRouter records the operator's legal home, read from its own terms or filing. It does not record which datacentre answers a given request, so nothing on this page should be read as one. Where residency is contractual, it comes from an allowlist you pin and a contract you sign, not from a country code on a directory page.</p>
     <p><a class="btn primary" href="/eu">Read the EU routing guide</a> <a class="btn" href="/gdpr-compliant-llm-api">GDPR evidence</a></p>
   </div>


### PR DESCRIPTION
Follow-up to #661, which fixed the shared directory sentence but left two siblings asserting place of incorporation - a different fact from the one `provider_headquarters_country` records.

- The China page's comparison row still called the US side "a company **registered** in the United States" while the China side had already been corrected, so a single row applied two different standards.
- The EU page's intro said labs "registered in an EU member state" and providers "operated by a company registered in the EU".

Both now say based / headquartered. These pages now make no claim about place of incorporation anywhere, because none was researched. Xiaomi remains the standing counterexample: head office Beijing, registered office Cayman Islands.