### PR TITLE
Schedule DeepInfra Qwen3 thinking retirement

### DIFF
--- a/scripts/pricing/providers/deepinfra.py
+++ b/scripts/pricing/providers/deepinfra.py
@@ -38,6 +38,7 @@ from scripts.pricing.base import (
 from scripts.pricing.manifest import write_discovered_chat_manifest
 from scripts.pricing.model_ids import mapped_or_canonical_model_id, remember_upstream_id
 from scripts.pricing.openai_catalog import positive_int
+from trusted_router.provider_lifecycle import provider_model_retired
 
 SLUG = "deepinfra"
 URL = "https://api.deepinfra.com/v1/openai/models"
@@ -107,6 +108,8 @@ def fetch() -> ProviderPricingResult:
             continue
         or_id = mapped_or_canonical_model_id(native_id, _NATIVE_TO_OR_ID)
         if or_id is None:
+            continue
+        if provider_model_retired(SLUG, or_id, native_id):
             continue
         remember_upstream_id(UPSTREAM_ID_MAP, or_id, native_id)
         meta = row.get("metadata") or {}

--- a/src/trusted_router/data/provider_models/deepinfra.json
+++ b/src/trusted_router/data/provider_models/deepinfra.json
@@ -1459,7 +1459,9 @@
       "context_length": 262144,
       "max_output_tokens": 262144,
       "input_token_price_per_m": 230000,
-      "output_token_price_per_m": 2300000
+      "output_token_price_per_m": 2300000,
+      "retirement_at": "2026-08-24T00:00:00Z",
+      "replacement_model_id": "qwen/qwen3.6-35b-a3b"
     },
     {
       "display_name": "Qwen/Qwen3-30B-A3B",

--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -33,6 +33,9 @@ FRIENDLI_K_EXAONE_236B_RETIREMENT_AT = datetime(2026, 8, 20, 0, 0, tzinfo=UTC)
 CRUSOE_NEMOTRON_3_ULTRA_RETIREMENT_AT = datetime(2026, 7, 28, 18, 0, tzinfo=UTC)
 WAFER_AUGUST_2026_RETIREMENT_AT = datetime(2026, 8, 17, 0, 0, tzinfo=UTC)
 DEEPINFRA_TERMINUS_RETIREMENT_AT = datetime(2026, 8, 17, 0, 0, tzinfo=UTC)
+DEEPINFRA_QWEN3_235B_THINKING_RETIREMENT_AT = datetime(
+    2026, 8, 24, 0, 0, tzinfo=UTC
+)
 NOVITA_LING_30_TINY_RETIREMENT_AT = datetime(2026, 8, 13, 15, 0, tzinfo=UTC)
 ALIBABA_OCTOBER_2026_RETIREMENT_AT = datetime(2026, 10, 9, 16, 0, tzinfo=UTC)
 DEEPSEEK_V4_PRICING_EFFECTIVE_AT = datetime(2026, 8, 16, 16, 0, tzinfo=UTC)
@@ -215,6 +218,18 @@ _RETIREMENTS = (
         model_ids=frozenset({"deepseek/deepseek-v3.1-terminus"}),
         upstream_ids=frozenset({"deepseek-ai/DeepSeek-V3.1-Terminus"}),
         effective_at=DEEPINFRA_TERMINUS_RETIREMENT_AT,
+    ),
+    # DeepInfra announced that Qwen3-235B-A22B-Thinking-2507 retires on
+    # 2026-08-24 and that requests will subsequently redirect to
+    # Qwen3.6-35B-A3B. Do not accept that silent model substitution: retire
+    # only DeepInfra's old route while preserving the requested checkpoint on
+    # other providers. The notice did not specify a time zone, so use 00:00 UTC
+    # conservatively. The replacement remains independently routable.
+    _Retirement(
+        provider="deepinfra",
+        model_ids=frozenset({"qwen/qwen3-235b-a22b-thinking-2507"}),
+        upstream_ids=frozenset({"Qwen/Qwen3-235B-A22B-Thinking-2507"}),
+        effective_at=DEEPINFRA_QWEN3_235B_THINKING_RETIREMENT_AT,
     ),
     # Wafer announced that GLM 5.1, GLM 5.2 Fast, and Kimi K3 Fast retire on
     # 2026-08-17. Standard GLM 5.2 replaces both GLM routes, while Kimi K3

--- a/tests/test_deepinfra_august_2026_lifecycle.py
+++ b/tests/test_deepinfra_august_2026_lifecycle.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime, timedelta
 
 import pytest
 
 from scripts.pricing import refresh
 from scripts.pricing.base import ModelPrice, ProviderPricingResult
+from scripts.pricing.providers import deepinfra
 from trusted_router import provider_lifecycle
 from trusted_router.catalog import MODEL_ENDPOINTS, endpoints_for_model
 from trusted_router.catalog_data import ModelEndpoint
@@ -15,6 +17,11 @@ _TERMINUS = "deepseek/deepseek-v3.1-terminus"
 _TERMINUS_UPSTREAM = "deepseek-ai/DeepSeek-V3.1-Terminus"
 _FLASH = "deepseek/deepseek-v4-flash-0731"
 _FLASH_UPSTREAM = "deepseek-ai/DeepSeek-V4-Flash-0731"
+_QWEN_CUTOFF = datetime(2026, 8, 24, 0, 0, tzinfo=UTC)
+_QWEN_THINKING = "qwen/qwen3-235b-a22b-thinking-2507"
+_QWEN_THINKING_UPSTREAM = "Qwen/Qwen3-235B-A22B-Thinking-2507"
+_QWEN_REPLACEMENT = "qwen/qwen3.6-35b-a3b"
+_QWEN_REPLACEMENT_UPSTREAM = "Qwen/Qwen3.6-35B-A3B"
 
 
 def test_deepinfra_terminus_retires_at_announced_date() -> None:
@@ -100,3 +107,124 @@ def test_hourly_refresh_cannot_restore_retired_deepinfra_terminus(
 
     assert _TERMINUS not in after
     assert "deepinfra" in after[_FLASH]
+
+
+def test_deepinfra_qwen_thinking_retires_at_announced_date() -> None:
+    assert not provider_lifecycle.provider_model_retired(
+        "deepinfra",
+        _QWEN_THINKING,
+        _QWEN_THINKING_UPSTREAM,
+        at=_QWEN_CUTOFF - timedelta(microseconds=1),
+    )
+    assert provider_lifecycle.provider_model_retired(
+        "deepinfra",
+        _QWEN_THINKING,
+        _QWEN_THINKING_UPSTREAM,
+        at=_QWEN_CUTOFF,
+    )
+    assert not provider_lifecycle.provider_model_retired(
+        "deepinfra",
+        _QWEN_REPLACEMENT,
+        _QWEN_REPLACEMENT_UPSTREAM,
+        at=_QWEN_CUTOFF,
+    )
+
+
+def test_deepinfra_qwen_thinking_retirement_is_provider_scoped() -> None:
+    assert provider_lifecycle.provider_model_retired(
+        "deepinfra",
+        _QWEN_THINKING,
+        _QWEN_THINKING_UPSTREAM,
+        at=_QWEN_CUTOFF,
+    )
+    for provider in ("alibaba", "chutes", "novita", "venice"):
+        assert not provider_lifecycle.provider_model_retired(
+            provider,
+            _QWEN_THINKING,
+            at=_QWEN_CUTOFF,
+        )
+
+
+def test_hourly_refresh_cannot_restore_retired_deepinfra_qwen_thinking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = ProviderPricingResult(
+        slug="deepinfra",
+        prices={
+            _QWEN_THINKING: ModelPrice(230_000, 2_300_000),
+            _QWEN_REPLACEMENT: ModelPrice(80_000, 240_000),
+        },
+        source="api",
+        fetched_url="https://api.deepinfra.com/v1/openai/models",
+    )
+
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _QWEN_CUTOFF - timedelta(microseconds=1),
+    )
+    before = refresh._index_provider_prices({"deepinfra": result})
+    assert "deepinfra" in before[_QWEN_THINKING]
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _QWEN_CUTOFF)
+    after = refresh._index_provider_prices({"deepinfra": result})
+
+    assert _QWEN_THINKING not in after
+    assert "deepinfra" in after[_QWEN_REPLACEMENT]
+
+
+def test_deepinfra_parser_filters_retired_qwen_from_stale_feed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def row(native_id: str) -> dict[str, object]:
+        return {
+            "id": native_id,
+            "metadata": {
+                "pricing": {"input_tokens": 0.23, "output_tokens": 2.3}
+            },
+        }
+
+    payload = {
+        "data": [row(_QWEN_THINKING_UPSTREAM), row(_QWEN_REPLACEMENT_UPSTREAM)]
+    }
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return payload
+
+    class FakeClient:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def get(self, *_args: object, **_kwargs: object) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setattr(deepinfra.httpx, "Client", FakeClient)
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _QWEN_CUTOFF)
+
+    result = deepinfra.fetch()
+
+    assert _QWEN_THINKING not in result.prices
+    assert _QWEN_THINKING not in deepinfra._DISCOVERED_MANIFEST_ROWS
+    assert _QWEN_REPLACEMENT in result.prices
+    assert _QWEN_REPLACEMENT in deepinfra._DISCOVERED_MANIFEST_ROWS
+
+
+def test_deepinfra_manifest_records_announced_qwen_replacement() -> None:
+    rows = {
+        row["id"]: row
+        for row in json.loads(deepinfra.MANIFEST_PATH.read_text())["models"]
+    }
+
+    retired = rows[_QWEN_THINKING]
+    assert retired["retirement_at"] == "2026-08-24T00:00:00Z"
+    assert retired["replacement_model_id"] == _QWEN_REPLACEMENT


### PR DESCRIPTION
## Summary
- retire only DeepInfra's `qwen/qwen3-235b-a22b-thinking-2507` route at 2026-08-24 00:00 UTC
- keep the same model available through other providers and keep `qwen/qwen3.6-35b-a3b` independently routable
- filter stale DeepInfra discovery rows before manifest generation and record the announced replacement

## Verification
- `uv run ruff check scripts/pricing/providers/deepinfra.py src/trusted_router/provider_lifecycle.py tests/test_deepinfra_august_2026_lifecycle.py`
- `uv run mypy`
- 122 focused pricing/catalog/lifecycle tests
- 120 post-cutover catalog tests with `TR_LIFECYCLE_CLOCK_OVERRIDE=2026-10-11T00:00:00Z`
- full suite: 4,848 passed; sandbox-blocked localhost tests rerun with socket access: 104 passed
