### PR TITLE
Put Liberty first on the US page; it is open weight throughout

### DIFF
--- a/src/trusted_router/templates/public/seo_us_ai_models.html
+++ b/src/trusted_router/templates/public/seo_us_ai_models.html
@@ -26,23 +26,10 @@ reply = client.chat.completions.create(
   </div>
 </section>
 
-<section class="panel" aria-label="US open-weight models">
-  <div class="panel-head"><h2>US open-weight models</h2><span class="pill">{{ region.open_weight_count }} routes</span></div>
-  <div class="panel-body">
-    <p>Weights you can download, run anywhere, and inspect &mdash; built by US labs.</p>
-    <ul class="link-list">
-      {% for lab in region.open_weight_labs %}
-      <li><a href="/models?filter={{ lab.prefix }}">{{ lab.lab_name }}</a><span>{{ lab.count }} open-weight model{{ '' if lab.count == 1 else 's' }} &middot; {{ lab.example }}</span></li>
-      {% endfor %}
-    </ul>
-    <p><a class="btn primary" href="/models?filter=open-weight">Browse all open-weight routes</a></p>
-  </div>
-</section>
-
 <section class="panel" aria-label="Liberty model family">
-  <div class="panel-head"><h2>Liberty: our own routes, built only from US-lab models</h2><span class="pill good">TrustedRouter</span></div>
+  <div class="panel-head"><h2>Liberty: US labs, open weights, one route</h2><span class="pill good">open weight</span></div>
   <div class="panel-body">
-    <p>Liberty is TrustedRouter's own family. Each Liberty id is a panel route: it calls several component models and returns one answer. What makes it belong on this page is checkable rather than asserted — every component model under every Liberty route resolves to a lab recorded as US-based in the catalog's model-origin table, and the counts below are computed from that table when this page renders. If a component were ever swapped for a model from elsewhere, the count would move and this claim would stop being made.</p>
+    <p>Our own family. Each Liberty id calls several component models and returns one answer &mdash; and every component is an open-weight model from a US lab. Both facts are computed from the catalog when this page renders, so if a component were ever swapped the counts would move and the claim would retire itself.</p>
     <div class="model-table-wrap">
       <table>
         <thead>
@@ -76,6 +63,19 @@ reply = client.chat.completions.create(
     </div>
     <p class="muted">Two limits worth stating plainly. First, the component models are open-weights models that many providers serve, and Liberty's default candidate pool includes operators outside the US; set <span class="mono">provider.jurisdiction</span> to <span class="mono">us</span> when the serving provider has to be US-operated. Second, operator jurisdiction is not datacentre location — a US-registered company can run inference on hardware elsewhere, and the catalog records the company, not the machine.</p>
     <p class="muted">Measurement for these routes is published rather than summarised here: our own DRACO run for Liberty 2.0 is written up in <a href="/blog/introducing-liberty">the Liberty 2.0 post</a>, and live route behaviour is on the <a href="/leaderboard">leaderboard</a>.</p>
+  </div>
+</section>
+
+<section class="panel" aria-label="US open-weight models">
+  <div class="panel-head"><h2>Open weights from US labs</h2><span class="pill">{{ region.open_weight_count }} routes</span></div>
+  <div class="panel-body">
+    <p>The labs themselves. Weights you can download, run anywhere, and inspect.</p>
+    <ul class="link-list">
+      {% for lab in region.open_weight_labs %}
+      <li><a href="/models?filter={{ lab.prefix }}">{{ lab.lab_name }}</a><span>{{ lab.count }} open-weight model{{ '' if lab.count == 1 else 's' }} &middot; {{ lab.example }}</span></li>
+      {% endfor %}
+    </ul>
+    <p><a class="btn primary" href="/models?filter=open-weight">Browse all open-weight routes</a></p>
   </div>
 </section>
 

--- a/tests/test_public_model_region_pages.py
+++ b/tests/test_public_model_region_pages.py
@@ -277,3 +277,38 @@ def test_liberty_routes_are_meta_routes_the_catalog_actually_defines() -> None:
     from the catalog must not keep a section on the page."""
     for model_id in LIBERTY_MODEL_IDS:
         assert model_id in MODELS, model_id
+
+
+def test_liberty_leads_the_us_page_and_is_framed_as_open_weight(client: TestClient) -> None:
+    """Liberty is the first thing on /us-ai-models, above the lab catalogue.
+
+    Every Liberty route is open weight -- `model_open_weights` is recursive and
+    every component under every Liberty id qualifies -- so it belongs at the
+    top of a page about US open-weight models rather than after them. Ordering
+    is asserted by position because a heading can be renamed without moving,
+    and the point here is which section a reader meets first.
+    """
+    body = client.get("/us-ai-models").text
+
+    liberty_at = body.find('aria-label="Liberty model family"')
+    open_weight_at = body.find('aria-label="US open-weight models"')
+    assert liberty_at != -1, "Liberty panel missing from /us-ai-models"
+    assert open_weight_at != -1, "open-weight panel missing from /us-ai-models"
+    assert liberty_at < open_weight_at, "Liberty must come before the lab open-weight list"
+    assert "open weight" in body[liberty_at : liberty_at + 400].lower()
+
+
+def test_every_liberty_route_really_is_open_weight() -> None:
+    """The claim the panel makes, checked against the catalog rather than the copy.
+
+    If a Liberty component were ever swapped for a closed-weights model this
+    fails, which is what lets the page state it without hedging.
+    """
+    from trusted_router.catalog import MODELS, model_open_weights
+
+    models = MODELS if isinstance(MODELS, (list, tuple)) else list(MODELS.values())
+    liberty = [model for model in models if "liberty" in model.id.lower()]
+
+    assert liberty, "no Liberty routes found in the catalog"
+    not_open = [model.id for model in liberty if not model_open_weights(model)]
+    assert not not_open, f"Liberty routes that are not open weight: {not_open}"

--- a/tests/test_public_model_region_pages.py
+++ b/tests/test_public_model_region_pages.py
@@ -182,9 +182,7 @@ def test_region_pages_report_operator_jurisdiction_per_model(client: TestClient)
     for lab in labs:
         for model in lab["models"]:
             operators = {str(operator["slug"]) for operator in model["operators"]}
-            configured = {
-                endpoint.provider for endpoint in endpoints_for_model(str(model["id"]))
-            }
+            configured = {endpoint.provider for endpoint in endpoints_for_model(str(model["id"]))}
             assert operators <= configured, model["id"]
             counted = sum(int(str(chip["operator_count"])) for chip in model["jurisdiction_chips"])
             assert counted == len(configured), model["id"]


### PR DESCRIPTION
Follow-up to #663 (which should merge first — this branches off main and touches the same template).

Every Liberty route **is** open weight. `model_open_weights` is recursive and every component under every Liberty id qualifies, so all five (`liberty-1.0`, `-1.0-1m`, `-2.0`, `-3.0`, `parasail/liberty-2.0`) return True. On a page that now leads with open weights, Liberty belonged above the lab catalogue rather than after it.

The panel says it in the heading — **"Liberty: US labs, open weights, one route"** — instead of burying it, and the intro drops from five clauses to two sentences. The lab list follows.

## Two tests

- **Order, asserted by position.** A heading can be renamed without moving, and the point is which section a reader meets first. Reverting the swap reddens it (verified).
- **The open-weight claim, checked against the catalog** rather than the copy — so a Liberty component swapped for a closed-weights model fails the build instead of silently making the page wrong.