### PR TITLE
Stabilize ClickHouse parity write grace

### DIFF
--- a/clickhouse/verify_operational_parity.py
+++ b/clickhouse/verify_operational_parity.py
@@ -66,6 +66,26 @@ def _parse(cls: type[T], payload: dict[str, Any] | None) -> T | None:
         return None
 
 
+def _stable_source_write(
+    row: Any,
+    *,
+    families: tuple[str, ...],
+    cutoff: dt.datetime,
+) -> bool:
+    """Exclude rows whose Bigtable write may still be in flight to ClickHouse."""
+    for family in families:
+        cells = row.cells.get(family, {}).get(b"body", [])
+        if not cells:
+            continue
+        timestamp_micros = getattr(cells[0], "timestamp_micros", None)
+        if not isinstance(timestamp_micros, int):
+            # Lightweight test and operator fakes may not carry cell metadata.
+            return True
+        written_at = dt.datetime.fromtimestamp(timestamp_micros / 1_000_000, tz=dt.UTC)
+        return written_at <= cutoff
+    return False
+
+
 def _stable_source_row(
     payload: dict[str, Any],
     *,
@@ -139,6 +159,8 @@ def _source_rows(
     cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=max(0, grace_seconds))
     for row in rows:
         raw = _body(row, families)
+        if not _stable_source_write(row, families=families, cutoff=cutoff):
+            continue
         if surface == "benchmark":
             benchmark_sample = _parse(ProviderBenchmarkSample, raw)
             if benchmark_sample is None:
@@ -195,6 +217,12 @@ def _source_rollups_from_raw(
     )
     samples: list[SyntheticProbeSample] = []
     for row in rows:
+        if not _stable_source_write(
+            row,
+            families=("synthetic", "m"),
+            cutoff=cutoff,
+        ):
+            continue
         sample = _parse(SyntheticProbeSample, _body(row, ("synthetic", "m")))
         if sample is not None:
             samples.append(sample)

--- a/tests/test_clickhouse_operational_parity.py
+++ b/tests/test_clickhouse_operational_parity.py
@@ -10,6 +10,7 @@ from clickhouse.verify_operational_parity import (
     _source_rollups_from_raw,
     _source_rows,
     _stable_source_row,
+    _stable_source_write,
 )
 from trusted_router.storage_models import SyntheticProbeSample
 
@@ -83,6 +84,65 @@ def test_parity_grace_excludes_recent_raw_rows() -> None:
         surface="synthetic",
         cutoff=cutoff,
     )
+
+
+def test_parity_grace_excludes_rows_written_recently_even_with_old_event_time() -> None:
+    cutoff = dt.datetime(2026, 7, 31, 17, 0, tzinfo=dt.UTC)
+
+    def row(write_time: dt.datetime) -> object:
+        cell = SimpleNamespace(
+            value=b"{}",
+            timestamp_micros=int(write_time.timestamp() * 1_000_000),
+        )
+        return SimpleNamespace(cells={"benchmark": {b"body": [cell]}})
+
+    assert _stable_source_write(
+        row(cutoff - dt.timedelta(seconds=1)),
+        families=("benchmark", "m"),
+        cutoff=cutoff,
+    )
+    assert not _stable_source_write(
+        row(cutoff + dt.timedelta(seconds=1)),
+        families=("benchmark", "m"),
+        cutoff=cutoff,
+    )
+
+
+def test_benchmark_parity_applies_grace_to_bigtable_write_time() -> None:
+    now = dt.datetime.now(dt.UTC)
+
+    def row(sample_id: str, write_time: dt.datetime) -> object:
+        payload = {
+            "id": sample_id,
+            "model": "test/model",
+            "provider": "test",
+            "provider_name": "Test",
+            "status": "completed",
+            "usage_type": "credits",
+            "streamed": False,
+            "created_at": (now - dt.timedelta(hours=1)).isoformat(),
+        }
+        cell = SimpleNamespace(
+            value=json.dumps(payload).encode("utf-8"),
+            timestamp_micros=int(write_time.timestamp() * 1_000_000),
+        )
+        return SimpleNamespace(cells={"benchmark": {b"body": [cell]}})
+
+    class Table:
+        def read_rows(self, **_: object) -> list[object]:
+            return [
+                row("recent-write", now),
+                row("stable-write", now - dt.timedelta(minutes=10)),
+            ]
+
+    samples = _source_rows(
+        Table(),
+        surface="benchmark",
+        limit=2,
+        grace_seconds=120,
+    )
+
+    assert set(samples) == {"stable-write"}
 
 
 def test_parity_waits_for_shared_heartbeat_bucket_to_close() -> None:


### PR DESCRIPTION
## Summary
- gate Bigtable parity samples on cell write time in addition to event time
- prevent long-running probes from being sampled before their ClickHouse outbox delivery can complete
- add regression coverage for old event timestamps written inside the grace window

## Production evidence
- the 2026-08-18T02:05:00Z parity run sampled one benchmark row written immediately before verification and reported a transient missing row
- provider outbox drain lag and insert errors remained zero; every later run passed

## Verification
- `uv run pytest -q tests/test_clickhouse_operational_parity.py tests/test_clickhouse_cutover_parity_gate.py tests/test_clickhouse_operational_deploy.py` (31 passed)
- `uv run ruff check clickhouse/verify_operational_parity.py tests/test_clickhouse_operational_parity.py`
- `uv run mypy`