### PR TITLE
perf: use bounded staleness for display reads

### DIFF
--- a/src/trusted_router/routes/billing.py
+++ b/src/trusted_router/routes/billing.py
@@ -105,7 +105,11 @@ def register_billing_routes(router: APIRouter) -> None:
             )
         )
         if body.purpose == "identity_verification":
-            lifetime_topup = STORE.get_lifetime_topup_microdollars(initiating_user_id)
+            # Checkout response metadata only; verification gates read strongly.
+            lifetime_topup = STORE.get_lifetime_topup_microdollars(
+                initiating_user_id,
+                allow_stale=True,
+            )
             checkout_data.update(
                 money_pair(
                     "verification_topup_remaining",

--- a/src/trusted_router/routes/console/api_keys.py
+++ b/src/trusted_router/routes/console/api_keys.py
@@ -198,9 +198,10 @@ def _checkbox(value: str) -> bool:
 def _key_view(key: ApiKey) -> dict[str, Any]:
     limit_display = "none" if key.limit_microdollars is None else money(key.limit_microdollars)
     # One typed point-read for live usage + current window spend (falls back to
-    # the JSON values when typed is off / row missing).
+    # the JSON values when typed is off / row missing). This only renders the
+    # key card; authorize uses a separate strong read for hard limits.
     typed = getattr(STORE, "typed_key_usage", None)
-    usage = typed(key.hash) if typed is not None else None
+    usage = typed(key.hash, allow_stale=True) if typed is not None else None
     windows_used = (usage or {}).get("windows", {})
     lifetime_used = usage["usage"] if usage is not None else key.usage_microdollars
     window_views = []

--- a/src/trusted_router/routes/console/credits.py
+++ b/src/trusted_router/routes/console/credits.py
@@ -78,7 +78,8 @@ def register(app: FastAPI) -> None:
         verification_remaining = max(
             0,
             VERIFICATION_MIN_LIFETIME_TOPUP_MICRODOLLARS
-            - STORE.get_lifetime_topup_microdollars(ctx.user.id),
+            # Display-only nudge; verification enforcement reads strongly.
+            - STORE.get_lifetime_topup_microdollars(ctx.user.id, allow_stale=True),
         )
         verification_nudge = (
             {
@@ -200,7 +201,11 @@ def register(app: FastAPI) -> None:
                     max(
                         0,
                         VERIFICATION_MIN_LIFETIME_TOPUP_MICRODOLLARS
-                        - STORE.get_lifetime_topup_microdollars(ctx.user.id),
+                        # Response metadata only; it does not approve checkout.
+                        - STORE.get_lifetime_topup_microdollars(
+                            ctx.user.id,
+                            allow_stale=True,
+                        ),
                     ),
                 )
             )

--- a/src/trusted_router/routes/console/earnings.py
+++ b/src/trusted_router/routes/console/earnings.py
@@ -59,7 +59,9 @@ def register(app: FastAPI) -> None:
 
 def _render_page(request: Request, ctx: ConsoleDep, settings: SettingsDep) -> str:
     since = (datetime.now(UTC) - timedelta(days=30)).isoformat().replace("+00:00", "Z")
-    summary = STORE.earnings_summary(ctx.user.id)
+    # Page rendering only; transfer POSTs use the strong default for their
+    # operation result.
+    summary = STORE.earnings_summary(ctx.user.id, allow_stale=True)
     model_totals = STORE.custom_model_earnings_by_model(ctx.user.id, since=since)
     by_model: list[dict[str, Any]] = []
     for model_id, amount in sorted(

--- a/src/trusted_router/routes/console/verification.py
+++ b/src/trusted_router/routes/console/verification.py
@@ -29,7 +29,12 @@ def register(app: FastAPI) -> None:
         dev: str = "",
     ) -> Response:
         user = STORE.get_user(ctx.user.id) or ctx.user
-        lifetime_topup = STORE.get_lifetime_topup_microdollars(user.id)
+        # Page progress only; `missing_identity_verification_requirements`
+        # below performs the actual gate with the strong default.
+        lifetime_topup = STORE.get_lifetime_topup_microdollars(
+            user.id,
+            allow_stale=True,
+        )
         required = VERIFICATION_MIN_LIFETIME_TOPUP_MICRODOLLARS
         missing = missing_identity_verification_requirements(user, settings)
         guidance = guidance_for(

--- a/src/trusted_router/routes/keys.py
+++ b/src/trusted_router/routes/keys.py
@@ -20,7 +20,9 @@ def _enriched_key_shape(key: ApiKey) -> dict[str, Any]:
     """key_shape backed by the typed counters when available: live lifetime
     usage/reserved (the JSON copies froze at the typed flip) + real current-
     window spend. Falls back to the JSON values (typed off / row missing)."""
-    usage = STORE.typed_key_usage(key.hash)  # on the base Store protocol; None when typed off
+    # This GET shape cannot authorize spend; hard budget enforcement has its
+    # own strong authorize-path read.
+    usage = STORE.typed_key_usage(key.hash, allow_stale=True)
     if usage is None:
         return key_shape(key)
     key = replace(

--- a/src/trusted_router/routes/user_models.py
+++ b/src/trusted_router/routes/user_models.py
@@ -379,7 +379,8 @@ def _earnings_data(user_id: str, *, before: str | None = None) -> dict[str, Any]
         before=before,
     )
     return {
-        "summary": _earnings_summary_shape(STORE.earnings_summary(user_id)),
+        # GET response only; transfer POSTs keep the strong default.
+        "summary": _earnings_summary_shape(STORE.earnings_summary(user_id, allow_stale=True)),
         "by_model_30d": [
             {"model_id": model_id, "earned_microdollars": amount}
             for model_id, amount in sorted(

--- a/src/trusted_router/routes/verification_status.py
+++ b/src/trusted_router/routes/verification_status.py
@@ -25,7 +25,12 @@ def register_verification_status_routes(router: APIRouter) -> None:
         settings: SettingsDep,
     ) -> dict[str, dict[str, Any]]:
         user = _principal_user(principal)
-        lifetime_topup = STORE.get_lifetime_topup_microdollars(user.id)
+        # Response progress only; `missing_identity_verification_requirements`
+        # below evaluates the gate with the strong default.
+        lifetime_topup = STORE.get_lifetime_topup_microdollars(
+            user.id,
+            allow_stale=True,
+        )
         guidance = guidance_for(
             user.identity_status,
             reason_code=user.veriff_decision_reason_code,

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -674,7 +674,12 @@ class InMemoryStore:
     def get_key_by_hash(self, key_hash: str) -> ApiKey | None:
         return self.api_keys.get_by_hash(key_hash)
 
-    def typed_key_usage(self, key_hash: str) -> dict[str, Any] | None:
+    def typed_key_usage(
+        self,
+        key_hash: str,
+        *,
+        allow_stale: bool = False,
+    ) -> dict[str, Any] | None:
         """InMemory twin of the Spanner typed point-read: lifetime counters are
         already live on the ApiKey; windows come from the lazy snapshot."""
         key = self.api_keys.get_by_hash(key_hash)
@@ -1356,7 +1361,12 @@ class InMemoryStore:
         with self._lock:
             self.earnings_money.setdefault(user_id, (0, 0))
 
-    def earnings_summary(self, user_id: str) -> dict[str, int]:
+    def earnings_summary(
+        self,
+        user_id: str,
+        *,
+        allow_stale: bool = False,
+    ) -> dict[str, int]:
         with self._lock:
             earned, transferred = self.earnings_money.get(user_id, (0, 0))
             return {
@@ -1414,7 +1424,12 @@ class InMemoryStore:
                     )
         return totals
 
-    def get_lifetime_topup_microdollars(self, user_id: str) -> int:
+    def get_lifetime_topup_microdollars(
+        self,
+        user_id: str,
+        *,
+        allow_stale: bool = False,
+    ) -> int:
         with self._lock:
             return self.lifetime_topups.get(user_id, 0)
 

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -415,6 +415,8 @@ class SpannerBigtableStore:
     def readiness_check(self) -> None:
         """Verify the strongly consistent billing store within a hard deadline."""
 
+        # This is the billing-store health signal, not a display value: keep it
+        # strong so readiness cannot be certified from an older database view.
         with self._database.snapshot() as snapshot:
             list(
                 snapshot.execute_sql(
@@ -1962,9 +1964,20 @@ class SpannerBigtableStore:
 
         self._run_in_transaction(txn)
 
-    def earnings_summary(self, user_id: str) -> dict[str, int]:
+    def earnings_summary(
+        self,
+        user_id: str,
+        *,
+        allow_stale: bool = False,
+    ) -> dict[str, int]:
         pt = self._param_types
-        with self._database.snapshot() as snapshot:
+        # Display callers may accept five seconds of staleness. The default is
+        # strong because transfer POSTs return the just-committed balance (or
+        # current insufficient-funds detail) from this same method.
+        snapshot_options: dict[str, Any] = {}
+        if allow_stale:
+            snapshot_options["exact_staleness"] = dt.timedelta(seconds=5)
+        with self._database.snapshot(**snapshot_options) as snapshot:
             rows = list(
                 snapshot.execute_sql(
                     "SELECT total_earned, total_transferred "
@@ -2008,7 +2021,10 @@ class SpannerBigtableStore:
             where += " AND created_at < @before"
             params["before"] = _parse_iso_timestamp(before)
             param_types["before"] = pt.TIMESTAMP
-        with self._database.snapshot() as snapshot:
+        # This is paginated ledger history and never authorizes a transfer.
+        # Thirty seconds is imperceptible for history while keeping the read
+        # local to a nearby Spanner replica.
+        with self._database.snapshot(exact_staleness=dt.timedelta(seconds=30)) as snapshot:
             rows = list(
                 snapshot.execute_sql(
                     "SELECT account_id, movement_id, kind, amount_microdollars, "  # noqa: S608 -- fixed clauses only.
@@ -2041,7 +2057,9 @@ class SpannerBigtableStore:
         since: str,
     ) -> dict[str, int]:
         pt = self._param_types
-        with self._database.snapshot() as snapshot:
+        # A 30-day display aggregate does not gate payout or transfer logic.
+        # One minute of staleness is small relative to its reporting window.
+        with self._database.snapshot(exact_staleness=dt.timedelta(seconds=60)) as snapshot:
             rows = list(
                 snapshot.execute_sql(
                     "SELECT custom_model_id, SUM(amount_microdollars) "
@@ -2058,9 +2076,20 @@ class SpannerBigtableStore:
             )
         return {str(row[0]): int(row[1]) for row in rows}
 
-    def get_lifetime_topup_microdollars(self, user_id: str) -> int:
+    def get_lifetime_topup_microdollars(
+        self,
+        user_id: str,
+        *,
+        allow_stale: bool = False,
+    ) -> int:
         pt = self._param_types
-        with self._database.snapshot() as snapshot:
+        # Display callers may accept five seconds of staleness. The default is
+        # strong because verification gates and the lifetime-top-up backfill
+        # read immediately before/after a durable increment.
+        snapshot_options: dict[str, Any] = {}
+        if allow_stale:
+            snapshot_options["exact_staleness"] = dt.timedelta(seconds=5)
+        with self._database.snapshot(**snapshot_options) as snapshot:
             rows = list(
                 snapshot.execute_sql(
                     "SELECT total_microdollars FROM tr_user_lifetime_topup WHERE user_id=@user_id",
@@ -2260,6 +2289,8 @@ class SpannerBigtableStore:
         )
 
     def get_gateway_authorization(self, authorization_id: str) -> GatewayAuthorization | None:
+        # Settlement and durable-outbox recovery consume this state. A stale
+        # authorization could replay terminal work, so this point read is strong.
         with self._database.snapshot() as snapshot:
             typed = read_gateway_authorization(
                 snapshot,
@@ -2697,7 +2728,12 @@ class SpannerBigtableStore:
 
         return _reap(self._database, self._param_types, now=now, limit=limit)
 
-    def typed_key_usage(self, key_hash: str) -> dict[str, Any] | None:
+    def typed_key_usage(
+        self,
+        key_hash: str,
+        *,
+        allow_stale: bool = False,
+    ) -> dict[str, Any] | None:
         """One point-read of the typed tr_key_limit row: live lifetime counters
         (post-flip the JSON api_key copies are frozen/stale) + the lazy window
         usage (stale windows read as zero). None when the row is missing —
@@ -2705,7 +2741,13 @@ class SpannerBigtableStore:
         from trusted_router.spend_windows import utcnow, window_floors
 
         pt = self._param_types
-        with self._database.snapshot(multi_use=True) as snapshot:
+        # Display callers opt into five-second staleness. The default remains
+        # strong because the same method decides whether to emit a one-shot
+        # budget alert; a stale below-threshold read could suppress that email.
+        snapshot_options: dict[str, Any] = {"multi_use": True}
+        if allow_stale:
+            snapshot_options["exact_staleness"] = dt.timedelta(seconds=5)
+        with self._database.snapshot(**snapshot_options) as snapshot:
             key = self._read_entity_from(snapshot, "api_key", key_hash, ApiKey)
             if key is None:
                 return None
@@ -2796,6 +2838,8 @@ class SpannerBigtableStore:
         """
         from trusted_router.storage_gcp_counter_dml import read_reservation
 
+        # Lost-claim recovery decides whether money was already booked; keep its
+        # reservation read strong.
         with self._database.snapshot() as snapshot:
             return read_reservation(snapshot, self._param_types, reservation_id)
 
@@ -2810,6 +2854,8 @@ class SpannerBigtableStore:
             return False
         from trusted_router.storage_gcp_counter_dml import read_reservation
 
+        # This selects the settle/refund implementation, so an old answer could
+        # route money through the wrong ledger. Keep it strong.
         with self._database.snapshot() as snapshot:
             res = read_reservation(snapshot, self._param_types, reservation_id)
         return res is not None and res.get("authorization_id") == authorization_id
@@ -2826,6 +2872,7 @@ class SpannerBigtableStore:
         )
 
         scope = _gateway_authorization_idempotency_index_id(workspace_id, key_hash, idempotency_key)
+        # This is the authorize replay/double-hold guard, not display state.
         with self._database.snapshot() as snapshot:
             existing = read_reservation_by_idempotency(snapshot, self._param_types, scope)
         if existing is None:
@@ -3570,6 +3617,8 @@ class SpannerBigtableStore:
         return None
 
     def _read_entity(self, kind: str, entity_id: str, cls: type[T]) -> T | None:
+        # This generic helper serves membership, key, and workspace authorization
+        # reads as well as display reads, so weakening it globally is unsafe.
         with self._database.snapshot() as snapshot:
             return self._read_entity_from(snapshot, kind, entity_id, cls)
 
@@ -3638,6 +3687,8 @@ class SpannerBigtableStore:
             suffix_sql += " LIMIT @limit"
             params["limit"] = int(limit)
             param_types["limit"] = self._param_types.INT64
+        # Membership and provider-access checks share this generic list helper;
+        # a blanket stale policy here could preserve revoked authorization.
         with self._database.snapshot() as snapshot:
             rows = snapshot.execute_sql(
                 f"SELECT body FROM tr_entities WHERE {where}{suffix_sql}",  # noqa: S608 - where/suffix are built from fixed predicates; values are bound params.

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -1440,7 +1440,12 @@ class PostgresStore:
     def get_key_by_hash(self, key_hash: str) -> ApiKey | None:
         return self._read_entity("api_key", key_hash, ApiKey)
 
-    def typed_key_usage(self, key_hash: str) -> dict[str, Any] | None:
+    def typed_key_usage(
+        self,
+        key_hash: str,
+        *,
+        allow_stale: bool = False,
+    ) -> dict[str, Any] | None:
         self._not_implemented("typed_key_usage")
 
     def upsert_federated_api_key(self, record: dict[str, Any]) -> ApiKey:
@@ -2850,7 +2855,12 @@ class PostgresStore:
 
         self._run_transaction(ensure)
 
-    def earnings_summary(self, user_id: str) -> dict[str, int]:
+    def earnings_summary(
+        self,
+        user_id: str,
+        *,
+        allow_stale: bool = False,
+    ) -> dict[str, int]:
         def read(conn: Any) -> dict[str, int]:
             row = conn.execute(
                 "SELECT total_earned, total_transferred "
@@ -2928,7 +2938,12 @@ class PostgresStore:
 
         return self._run_transaction(read)
 
-    def get_lifetime_topup_microdollars(self, user_id: str) -> int:
+    def get_lifetime_topup_microdollars(
+        self,
+        user_id: str,
+        *,
+        allow_stale: bool = False,
+    ) -> int:
         def read(conn: Any) -> int:
             row = conn.execute(
                 "SELECT total_microdollars FROM tr_user_lifetime_topup WHERE user_id = %s",

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -273,7 +273,12 @@ class Store(Protocol):
         tags: dict[str, str] | None = ...,
     ) -> tuple[str, ApiKey]: ...
     def get_key_by_hash(self, key_hash: str) -> ApiKey | None: ...
-    def typed_key_usage(self, key_hash: str) -> dict[str, Any] | None: ...
+    def typed_key_usage(
+        self,
+        key_hash: str,
+        *,
+        allow_stale: bool = ...,
+    ) -> dict[str, Any] | None: ...
     def get_key_by_lookup_hash(self, lookup_hash: str) -> ApiKey | None: ...
 
     def upsert_federated_api_key(self, record: dict[str, Any]) -> ApiKey:
@@ -608,7 +613,12 @@ class Store(Protocol):
         event_id: str,
     ) -> str: ...
     def ensure_earnings_account(self, user_id: str) -> None: ...
-    def earnings_summary(self, user_id: str) -> dict[str, int]: ...
+    def earnings_summary(
+        self,
+        user_id: str,
+        *,
+        allow_stale: bool = ...,
+    ) -> dict[str, int]: ...
     def list_credit_movements(
         self,
         account_id: str,
@@ -629,7 +639,12 @@ class Store(Protocol):
         amount_microdollars: int,
         event_id: str,
     ) -> bool: ...
-    def get_lifetime_topup_microdollars(self, user_id: str) -> int: ...
+    def get_lifetime_topup_microdollars(
+        self,
+        user_id: str,
+        *,
+        allow_stale: bool = ...,
+    ) -> int: ...
 
     def reserve(
         self,

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -188,6 +188,11 @@ class FakeSpannerDatabase:
         self.aborts = 0
         self.commits = 0
         self.last_timeout_secs: float | None = None
+        # Preserve the exact consistency options passed by production code so
+        # tests can distinguish a deliberate stale display read from a strong
+        # money / authorization read.  The fake does not model historical row
+        # versions; this records the contract without pretending that it does.
+        self.snapshot_calls: list[dict[str, Any]] = []
 
     def run_in_transaction(self, fn: Any, *, timeout_secs: float | None = None) -> Any:
         # timeout_secs mirrors google-cloud-spanner's Database.run_in_transaction
@@ -328,6 +333,10 @@ class FakeSpannerDatabase:
         # ONE read; a second read on it raises. Only multi_use=True allows many.
         # Prod bug fa9f5d4 was a single-use snapshot that grew a second read and
         # faulted live — the old fake "allowed repeated reads regardless" and hid it.
+        call = dict(_kwargs)
+        if multi_use:
+            call["multi_use"] = True
+        self.snapshot_calls.append(call)
         return _FakeSnapshot(self, multi_use=multi_use)
 
     def batch(self) -> _FakeBatch:

--- a/tests/test_storage_gcp_staleness.py
+++ b/tests/test_storage_gcp_staleness.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from tests.fakes.spanner import make_fake_store
+
+
+@pytest.mark.parametrize(
+    ("read", "expected"),
+    [
+        (
+            lambda store: store.earnings_summary(
+                "user-display",
+                allow_stale=True,
+            ),
+            {"exact_staleness": dt.timedelta(seconds=5)},
+        ),
+        (
+            lambda store: store.list_credit_movements("user:user-display"),
+            {"exact_staleness": dt.timedelta(seconds=30)},
+        ),
+        (
+            lambda store: store.custom_model_earnings_by_model(
+                "user-display",
+                since="2026-01-01T00:00:00Z",
+            ),
+            {"exact_staleness": dt.timedelta(seconds=60)},
+        ),
+        (
+            lambda store: store.get_lifetime_topup_microdollars(
+                "user-display",
+                allow_stale=True,
+            ),
+            {"exact_staleness": dt.timedelta(seconds=5)},
+        ),
+        (
+            lambda store: store.typed_key_usage("key-display", allow_stale=True),
+            {
+                "exact_staleness": dt.timedelta(seconds=5),
+                "multi_use": True,
+            },
+        ),
+    ],
+    ids=[
+        "earnings-summary",
+        "credit-movement-history",
+        "earnings-by-model-aggregate",
+        "lifetime-topup-total",
+        "api-key-usage-display",
+    ],
+)
+def test_read_only_views_request_their_exact_bounded_staleness(
+    read: Callable[[Any], Any],
+    expected: dict[str, Any],
+) -> None:
+    store, database, _ = make_fake_store()
+
+    read(store)
+
+    assert database.snapshot_calls == [expected]
+
+
+def test_earnings_summary_defaults_to_strong_for_transfer_results() -> None:
+    store, database, _ = make_fake_store()
+
+    store.earnings_summary("user-transfer")
+
+    assert database.snapshot_calls == [{}]
+
+
+def test_lifetime_topup_defaults_to_strong_for_write_verification() -> None:
+    store, database, _ = make_fake_store()
+
+    store.get_lifetime_topup_microdollars("user-backfill")
+
+    assert database.snapshot_calls == [{}]
+
+
+def test_non_display_and_correctness_sensitive_reads_remain_strong() -> None:
+    store, database, _ = make_fake_store()
+
+    cases: list[tuple[Callable[[], Any], list[dict[str, Any]]]] = [
+        # The missing typed authorization falls back to the legacy entity row;
+        # both point reads must stay strong because settlement consumes it.
+        (lambda: store.get_gateway_authorization("gwa-missing"), [{}, {}]),
+        (lambda: store.typed_credit_snapshot("ws-missing"), [{"multi_use": True}]),
+        (lambda: store.read_typed_reservation("res-missing"), [{}]),
+        (lambda: store.is_typed_reservation("res-missing", "gwa-missing"), [{}]),
+        (
+            lambda: store.get_typed_authorization_by_idempotency(
+                "ws-missing",
+                "key-missing",
+                "idem-missing",
+            ),
+            [{}],
+        ),
+        # Budget alerts use the default and must observe the just-settled usage;
+        # an old below-threshold value could suppress their one-shot email.
+        (lambda: store.typed_key_usage("key-alert"), [{"multi_use": True}]),
+        (lambda: store._read_entity("user", "user-missing", dict), [{}]),
+        (lambda: store._list_entities("member", cls=dict), [{}]),
+    ]
+
+    for read, expected in cases:
+        database.snapshot_calls.clear()
+        read()
+        assert database.snapshot_calls == expected

--- a/tests/test_user_models.py
+++ b/tests/test_user_models.py
@@ -28,7 +28,7 @@ from trusted_router.services.user_model_secrets import (
     USER_MODEL_SECRET_NAMESPACE,
     USER_MODEL_SIGNING_PURPOSE,
 )
-from trusted_router.storage import STORE
+from trusted_router.storage import STORE, InMemoryStore
 from trusted_router.storage_user_models import InMemoryUserProvidedModels
 
 HEADERS = {"x-trustedrouter-user": "user-model-owner@example.com"}
@@ -1031,6 +1031,7 @@ def test_public_user_model_health_reports_dispatch_and_probe_degradation(
 
 def test_owner_earnings_api_lists_summary_models_movements_and_transfers(
     client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     created = _create(client, body=_body(slug="earnings-api"))
     owner_user_id = created["owner_user_id"]
@@ -1060,6 +1061,21 @@ def test_owner_earnings_api_lists_summary_models_movements_and_transfers(
     assert data["recent"][0]["kind"] == "custom_model_payout"
     assert data["recent"][0]["amount_display"] == "$2.50"
 
+    summary_staleness: list[bool] = []
+    original_summary = InMemoryStore.earnings_summary
+
+    def recording_summary(
+        store: InMemoryStore,
+        user_id: str,
+        *,
+        allow_stale: bool = False,
+    ) -> dict[str, int]:
+        summary_staleness.append(allow_stale)
+        return original_summary(store, user_id, allow_stale=allow_stale)
+
+    # Patch the backend class, never the module-global STORE proxy.
+    monkeypatch.setattr(InMemoryStore, "earnings_summary", recording_summary)
+
     body = {
         "workspace_id": workspace.id,
         "amount_microdollars": 1_000_000,
@@ -1071,6 +1087,7 @@ def test_owner_earnings_api_lists_summary_models_movements_and_transfers(
         json=body,
     )
     assert accepted.status_code == 200, accepted.text
+    assert summary_staleness == [False]
     assert accepted.json()["data"] == {
         "deduplicated": False,
         "summary": {
@@ -1089,6 +1106,7 @@ def test_owner_earnings_api_lists_summary_models_movements_and_transfers(
     )
     assert duplicate.status_code == 200
     assert duplicate.json()["data"]["deduplicated"] is True
+    assert summary_staleness == [False, False]
 
     insufficient = client.post(
         "/v1/user-models/earnings/transfer",
@@ -1098,6 +1116,7 @@ def test_owner_earnings_api_lists_summary_models_movements_and_transfers(
     assert insufficient.status_code == 402
     assert insufficient.json()["error"]["type"] == "insufficient_credits"
     assert insufficient.json()["error"]["available"] == 1_500_000
+    assert summary_staleness == [False, False, False]
 
 
 def test_owner_earnings_transfer_hides_membership_and_refuses_invalid_targets(


### PR DESCRIPTION
## Outcome

Move only read-only/display Spanner reads onto bounded-staleness snapshots. Money, authorization, settlement, claim, replay, readiness, and generic entity reads remain strong. `storage_gcp_authorize.py` and all documented MF2 interlocks are untouched.

| Read | Bound | Why stale is safe |
|---|---:|---|
| earnings summary GET/page | 5s exact | display only; transfer results and insufficient-funds detail use the strong default |
| credit movement history | 30s exact | paginated ledger display, never an authorization input |
| 30-day model earnings | 60s exact | reporting aggregate over a 30-day window |
| lifetime top-up UI/status metadata | 5s exact | display only; verification gates and backfill checks use the strong default |
| key usage GET/card | 5s exact | display only; authorize uses separate strong counters |

`earnings_summary`, `get_lifetime_topup_microdollars`, and `typed_key_usage` are all strong by default. Only audited GET/UI/status-response callers opt in with `allow_stale=True`. Transfer POSTs, lifetime-top-up backfill checks, verification gates, and one-shot budget alerts therefore retain read-after-write/correctness semantics.

## Measurement

I could not measure a real Spanner latency delta: the service-account credential is absent and local `gcloud` user auth requires interactive reauthentication. I am not presenting emulator/fake timings as production latency.

What the same `/console/earnings` storage slice proves:

```text
before: 3 statements, 3 strong snapshots
after:  3 statements, 0 strong snapshots, 3 bounded snapshots (5s / 60s / 30s)
delta:  3 leader-coordinated reads removed; statement count unchanged
```

## Red proof

The initial parameterized regression was run against pre-fix code. All five bounded-read cases failed because the observed snapshot options were `{}` (or only `multi_use=True`).

A first exact-head review then found that earnings and lifetime top-up had mixed display/correctness callers. Before the strong-default split, each pair of new regressions failed: the display opt-in was unsupported and the default incorrectly requested five-second staleness. The replacement head adds exact-argument tests for both modes, plus a route regression proving accepted, duplicate, and insufficient transfer outcomes all use `allow_stale=False`.

The fake records exact snapshot options but does not pretend to model historical row versions.

## Verification

```text
focused replacement-head suite       55 passed
affected key/budget/console/core set   81 passed
broader affected storage/console set  130 passed
uv run ruff check .                    pass
uv run mypy                            pass (279 files)
git diff --check                       pass
```

The first full-suite run produced `4858 passed` plus 11 failures / 8 errors caused by the sandbox denying loopback binds. A detached `origin/main` worktree produced the identical failing set under the same sandbox; with loopback allowed, branch and baseline were both 64/64 green. CI is the authoritative unrestricted full-suite run.

Repository-wide `ruff format --check .` is already red on current `main` under locked Ruff 0.15.12 (438 files). The new test and added hunks are formatter-clean; the tree was not reformatted because `AGENTS.md` explicitly forbids that unrelated rewrite.
