### PR TITLE
perf: collapse authentication store fan-out

### DIFF
--- a/src/trusted_router/auth.py
+++ b/src/trusted_router/auth.py
@@ -8,7 +8,14 @@ from fastapi import Depends, Request, Response
 
 from trusted_router.config import Settings
 from trusted_router.errors import api_error
-from trusted_router.storage import STORE, ApiKey, AuthSession, User, Workspace
+from trusted_router.storage import (
+    STORE,
+    ApiKey,
+    ApiKeyAuthContext,
+    SessionAuthContext,
+    User,
+    Workspace,
+)
 from trusted_router.types import ErrorType
 
 SESSION_COOKIE_NAME = "tr_session"
@@ -105,28 +112,34 @@ def principal_from_request(request: Request, settings: Settings) -> Principal:
         # Browser console only ever sends the cookie. Resolve as a session;
         # don't fall through to the API-key lookup since we don't have a
         # bearer to look up.
-        session = STORE.get_auth_session_by_raw(cookie_token)
-        if session is None or session.state != "active":
+        session_context = STORE.session_auth_context(
+            cookie_token,
+            requested_workspace_id=(request.headers.get("x-trustedrouter-workspace") or None),
+        )
+        if session_context is None:
             raise api_error(401, "Invalid session", "unauthorized")
-        return _principal_for_session(request, session)
+        return _principal_for_session(request, session_context)
     if not raw_bearer:
         raise api_error(401, "Missing Authentication header", "unauthorized")
 
     bootstrap_management_key(settings)
 
     if raw_bearer.startswith(_API_KEY_BEARER_PREFIX):
-        api_key = STORE.get_key_by_raw(raw_bearer)
-        if api_key is None:
+        api_key_context = STORE.api_key_auth_context(raw_bearer)
+        if api_key_context is None:
             raise api_error(401, "Invalid API key", "unauthorized")
-        return _principal_for_api_key(api_key)
+        return _principal_for_api_key(api_key_context)
 
     if raw_bearer.startswith(_SESSION_BEARER_PREFIX):
         # Bearer-shaped session token. Used by management programs that
         # prefer a bearer header over the browser session cookie.
-        session = STORE.get_auth_session_by_raw(raw_bearer)
-        if session is None:
+        session_context = STORE.session_auth_context(
+            raw_bearer,
+            requested_workspace_id=(request.headers.get("x-trustedrouter-workspace") or None),
+        )
+        if session_context is None:
             raise api_error(401, "Invalid session token", "unauthorized")
-        return _principal_for_session(request, session)
+        return _principal_for_session(request, session_context)
 
     # Neither shape matched. Don't claim "Invalid API key" — the token
     # was never API-key-shaped to begin with. Surface the actual issue
@@ -160,7 +173,10 @@ def _principal_from_dev_header(
     )
 
 
-def _principal_for_session(request: Request, session: AuthSession) -> Principal:
+def _principal_for_session(
+    request: Request,
+    context: SessionAuthContext,
+) -> Principal:
     # The state gate lives here rather than at each call site so that every
     # conversion from a session into an authenticated principal enforces one
     # invariant. It used to sit only on the cookie branch, so the same
@@ -169,30 +185,33 @@ def _principal_for_session(request: Request, session: AuthSession) -> Principal:
     # token hash only. Note this is deliberately not pushed down into
     # get_auth_session_by_raw: the pending-email attach flow needs to fetch a
     # pending session directly, it just must not get a principal from one.
+    session = context.session
     if session.state != "active":
         raise api_error(401, "Invalid session", "unauthorized")
-    user = STORE.get_user(session.user_id)
+    user = context.user
     if user is None:
         raise api_error(401, "Invalid session", "unauthorized")
-    workspace = _resolve_workspace_for_user(
-        request,
-        user.id,
-        suggested_workspace_id=session.workspace_id,
-    )
+    selected_workspace_id = request.headers.get("x-trustedrouter-workspace") or session.workspace_id
+    workspace = context.workspace
+    if workspace is None or not context.is_member:
+        if selected_workspace_id:
+            raise api_error(403, "Forbidden", "forbidden")
+        raise api_error(403, "Workspace is unavailable", "forbidden")
     return Principal(
         user=user,
         workspace=workspace,
         api_key=None,
-        is_management=STORE.user_can_manage(user.id, workspace.id),
+        is_management=context.is_management,
     )
 
 
-def _principal_for_api_key(api_key: ApiKey) -> Principal:
+def _principal_for_api_key(context: ApiKeyAuthContext) -> Principal:
+    api_key = context.api_key
     if api_key.disabled:
         raise api_error(401, "Invalid API key", "unauthorized")
     if is_api_key_expired(api_key.expires_at):
         raise api_error(401, "API key expired", "unauthorized")
-    workspace = STORE.get_workspace(api_key.workspace_id)
+    workspace = context.workspace
     if workspace is None:
         raise api_error(403, "Workspace is unavailable", "forbidden")
     return Principal(

--- a/src/trusted_router/routes/console/_shared.py
+++ b/src/trusted_router/routes/console/_shared.py
@@ -46,13 +46,18 @@ def require_console_context(request: Request, settings: SettingsDep) -> ConsoleC
     """FastAPI dependency. Resolves the active console session or raises a
     302 redirect to the marketing page so it can pop the sign-in modal."""
     cookie_token = request.cookies.get(SESSION_COOKIE_NAME)
-    session = STORE.get_auth_session_by_raw(cookie_token) if cookie_token else None
-    if session is None or session.state != "active":
+    context = (
+        STORE.session_auth_context(cookie_token, requested_workspace_id=None)
+        if cookie_token
+        else None
+    )
+    if context is None or context.session.state != "active":
         raise HTTPException(status_code=302, headers={"Location": "/?reason=signin"})
-    user = STORE.get_user(session.user_id)
+    session = context.session
+    user = context.user
     if user is None:
         raise HTTPException(status_code=302, headers={"Location": "/?reason=signin"})
-    workspaces = STORE.list_workspaces_for_user(user.id)
+    workspaces = list(context.workspaces)
     if not workspaces:
         raise HTTPException(status_code=302, headers={"Location": "/?reason=signin"})
     workspace = _selected_console_workspace(session, workspaces)

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -24,6 +24,7 @@ from trusted_router.operational_analytics_freshness import (
     OutboxFreshness,
 )
 from trusted_router.storage_attribution import InMemoryAcquisitionAttribution
+from trusted_router.storage_auth_context import build_session_auth_context
 from trusted_router.storage_auth_sessions import InMemoryAuthSessions
 from trusted_router.storage_broadcast import InMemoryBroadcastDestinations
 from trusted_router.storage_byok import InMemoryByok
@@ -37,6 +38,7 @@ from trusted_router.storage_models import (
     AcquisitionAttribution,
     ActivationReminderTask,
     ApiKey,
+    ApiKeyAuthContext,
     AuthSession,
     BedrockGroupBuyAggregate,
     BedrockGroupBuyPledge,
@@ -59,6 +61,7 @@ from trusted_router.storage_models import (
     ProviderBenchmarkSample,
     RateLimitHit,
     Reservation,
+    SessionAuthContext,
     SignupResult,
     SyntheticProbeSample,
     SyntheticRollup,
@@ -387,6 +390,39 @@ class InMemoryStore:
 
     def delete_auth_session_by_raw(self, raw_token: str) -> bool:
         return self.auth_session_store.delete_by_raw(raw_token)
+
+    def session_auth_context(
+        self,
+        raw_token: str,
+        *,
+        requested_workspace_id: str | None = None,
+    ) -> SessionAuthContext | None:
+        """Resolve a session principal under one lock.
+
+        Production backends implement the same contract with one strong SQL
+        statement.  Keeping the in-memory implementation atomic makes tests
+        model the same point-in-time membership decision instead of a sequence
+        of independently locked lookups.
+        """
+        with self._lock:
+            session = self.auth_session_store.get_by_raw(raw_token)
+            if session is None:
+                return None
+            user = self.users.get(session.user_id)
+            memberships: list[tuple[Member, Workspace]] = []
+            for (workspace_id, user_id), candidate_member in self.members.items():
+                if user_id != session.user_id:
+                    continue
+                candidate = self.workspaces.get(workspace_id)
+                if candidate is None:
+                    continue
+                memberships.append((candidate_member, candidate))
+            return build_session_auth_context(
+                session=session,
+                user=user,
+                memberships=memberships,
+                requested_workspace_id=requested_workspace_id,
+            )
 
     def create_workspace(
         self,
@@ -738,6 +774,17 @@ class InMemoryStore:
 
     def get_key_by_raw(self, raw_key: str) -> ApiKey | None:
         return self.api_keys.get_by_raw(raw_key)
+
+    def api_key_auth_context(self, raw_key: str) -> ApiKeyAuthContext | None:
+        """Resolve the key and its workspace atomically, without a cache."""
+        with self._lock:
+            api_key = self.api_keys.get_by_raw(raw_key)
+            if api_key is None:
+                return None
+            workspace = self.workspaces.get(api_key.workspace_id)
+            if workspace is not None and workspace.deleted:
+                workspace = None
+            return ApiKeyAuthContext(api_key=api_key, workspace=workspace)
 
     def list_keys(self, workspace_id: str) -> list[ApiKey]:
         return self.api_keys.list_for_workspace(workspace_id)

--- a/src/trusted_router/storage_auth_context.py
+++ b/src/trusted_router/storage_auth_context.py
@@ -1,0 +1,56 @@
+"""Backend-neutral assembly for the single-read authentication records."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from trusted_router.storage_models import (
+    AuthSession,
+    Member,
+    SessionAuthContext,
+    User,
+    Workspace,
+)
+
+
+def build_session_auth_context(
+    *,
+    session: AuthSession,
+    user: User | None,
+    memberships: Iterable[tuple[Member, Workspace]],
+    requested_workspace_id: str | None,
+) -> SessionAuthContext:
+    """Apply one workspace-selection contract to every storage backend.
+
+    An explicit request or session binding must match exactly.  With neither,
+    the first visible membership is the fallback.  Empty-role memberships are
+    still memberships for an explicit selection (matching ``user_is_member``)
+    but are omitted from the workspace list (matching
+    ``list_workspaces_for_user``).  Deleted workspaces are never visible.
+    """
+    current_memberships = [
+        (member, workspace) for member, workspace in memberships if not workspace.deleted
+    ]
+    visible_workspaces = tuple(
+        workspace for member, workspace in current_memberships if member.role
+    )
+    selected_workspace_id = requested_workspace_id or session.workspace_id
+    selected: tuple[Member, Workspace] | None = None
+    if selected_workspace_id:
+        selected = next(
+            (pair for pair in current_memberships if pair[1].id == selected_workspace_id),
+            None,
+        )
+    elif visible_workspaces:
+        fallback_id = visible_workspaces[0].id
+        selected = next(pair for pair in current_memberships if pair[1].id == fallback_id)
+    member = selected[0] if selected is not None else None
+    workspace = selected[1] if selected is not None else None
+    return SessionAuthContext(
+        session=session,
+        user=user,
+        workspace=workspace,
+        workspaces=visible_workspaces,
+        is_member=member is not None,
+        is_management=(member is not None and member.role in {"owner", "admin"}),
+    )

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -9,7 +9,7 @@ import threading
 import time
 import uuid
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from trusted_router import phone_verification
 from trusted_router import storage_gcp_credit_transfer as spanner_credit_transfer
@@ -27,6 +27,7 @@ from trusted_router.operational_analytics_freshness import (
     REASON_UNREACHABLE,
     OutboxFreshness,
 )
+from trusted_router.security import lookup_hash_api_key, verify_api_key
 from trusted_router.storage import (
     AcquisitionAttribution,
     ActivationReminderTask,
@@ -69,6 +70,7 @@ from trusted_router.storage_activity import (
     summarize_activity_result,
     usage_bucket_key,
 )
+from trusted_router.storage_auth_context import build_session_auth_context
 from trusted_router.storage_errors import is_duplicate_key_error
 from trusted_router.storage_gcp_analytics_outbox import SpannerAnalyticsOutbox
 from trusted_router.storage_gcp_attribution import SpannerAcquisitionAttribution
@@ -138,12 +140,15 @@ from trusted_router.storage_gcp_verification_tokens import SpannerVerificationTo
 from trusted_router.storage_gcp_video_jobs import SpannerVideoJobs
 from trusted_router.storage_gcp_wallet_challenges import SpannerWalletChallenges
 from trusted_router.storage_models import (
+    ApiKeyAuthContext,
     BedrockGroupBuyAggregate,
     BedrockGroupBuyPledge,
     BedrockGroupBuyPublicMessage,
     CreditMovement,
+    SessionAuthContext,
     TypedFinalizeResult,
     UserModelPayout,
+    _is_expired,
 )
 from trusted_router.types import IdentityVerificationStatus, UsageType
 
@@ -154,6 +159,57 @@ log = logging.getLogger(__name__)
 #: `readiness_check`, and the same rule: a public page degrades rather than
 #: waits. See `SpannerBigtableStore.operational_analytics_outbox_freshness`.
 OUTBOX_FRESHNESS_TIMEOUT_SECONDS = 3.0
+
+_SESSION_AUTH_CONTEXT_SQL = """
+    /* auth_session_context */
+    WITH resolved_session AS (
+      SELECT
+        session_record.body AS session_body,
+        JSON_VALUE(session_record.body, '$.user_id') AS user_id
+      FROM tr_entities AS lookup_record
+      JOIN tr_entities AS session_record
+        ON session_record.kind='auth_session'
+       AND session_record.id=JSON_VALUE(lookup_record.body, '$.session_id')
+      WHERE lookup_record.kind='auth_session_lookup'
+        AND lookup_record.id=@lookup_hash
+    )
+    SELECT
+      resolved.session_body,
+      user_record.body,
+      workspace_record.body,
+      member_record.body
+    FROM resolved_session AS resolved
+    LEFT JOIN tr_entities AS user_record
+      ON user_record.kind='user' AND user_record.id=resolved.user_id
+    LEFT JOIN tr_entities AS member_record
+      ON member_record.kind='member'
+     AND JSON_VALUE(member_record.body, '$.user_id')=resolved.user_id
+     AND member_record.id=CONCAT(JSON_VALUE(member_record.body, '$.workspace_id'), '#', resolved.user_id)
+    LEFT JOIN tr_entities AS workspace_record
+      ON workspace_record.kind='workspace'
+     AND workspace_record.id=JSON_VALUE(member_record.body, '$.workspace_id')
+    ORDER BY member_record.id
+"""
+
+_API_KEY_AUTH_CONTEXT_SQL = """
+    /* api_key_auth_context */
+    SELECT key_record.body, workspace_record.body
+    FROM tr_entities AS lookup_record
+    JOIN tr_entities AS key_record
+      ON key_record.kind='api_key'
+     AND key_record.id=JSON_VALUE(lookup_record.body, '$.key_id')
+    LEFT JOIN tr_entities AS workspace_record
+      ON workspace_record.kind='workspace'
+     AND workspace_record.id=JSON_VALUE(key_record.body, '$.workspace_id')
+    WHERE lookup_record.kind='api_key_lookup'
+      AND lookup_record.id=@lookup_hash
+"""
+
+
+def _auth_record(raw: str, cls: type[T]) -> T:
+    data = json.loads(raw)
+    known = {field.name for field in dataclasses.fields(cast(Any, cls))}
+    return cls(**{key: value for key, value in data.items() if key in known})
 
 
 def _empty_usage_bucket(bucket: str) -> dict[str, Any]:
@@ -663,6 +719,63 @@ class SpannerBigtableStore:
 
     def delete_auth_session_by_raw(self, raw_token: str) -> bool:
         return self.auth_session_store.delete_by_raw(raw_token)
+
+    def session_auth_context(
+        self,
+        raw_token: str,
+        *,
+        requested_workspace_id: str | None = None,
+    ) -> SessionAuthContext | None:
+        """Resolve session, user, workspaces, and selected role in one RPC.
+
+        This is deliberately a strong read: session invalidation and membership
+        removal are authorization changes and must be visible on the next
+        request.  A cache or bounded-staleness read would extend access.
+        """
+        lookup_hash = lookup_hash_api_key(raw_token)
+        with self._database.snapshot() as snapshot:
+            rows = list(
+                snapshot.execute_sql(
+                    _SESSION_AUTH_CONTEXT_SQL,
+                    params={"lookup_hash": lookup_hash},
+                    param_types={"lookup_hash": self._param_types.STRING},
+                )
+            )
+        if not rows:
+            return None
+
+        session = _auth_record(str(rows[0][0]), AuthSession)
+        if _is_expired(session.expires_at):
+            # Preserve get_auth_session_by_raw's expired-record cleanup.  The
+            # valid-request path above remains exactly one read RPC.
+            with self._database.batch() as batch:
+                batch.delete(
+                    self.entity_table,
+                    self._spanner.KeySet(
+                        keys=[
+                            ("auth_session", session.hash),
+                            ("auth_session_lookup", lookup_hash),
+                        ]
+                    ),
+                )
+            return None
+        if not verify_api_key(raw_token, session.salt, session.secret_hash):
+            return None
+
+        user = _auth_record(str(rows[0][1]), User) if rows[0][1] is not None else None
+        memberships: list[tuple[Member, Workspace]] = []
+        for _session_body, _user_body, workspace_body, member_body in rows:
+            if workspace_body is None or member_body is None:
+                continue
+            member = _auth_record(str(member_body), Member)
+            workspace = _auth_record(str(workspace_body), Workspace)
+            memberships.append((member, workspace))
+        return build_session_auth_context(
+            session=session,
+            user=user,
+            memberships=memberships,
+            requested_workspace_id=requested_workspace_id,
+        )
 
     def create_workspace(
         self,
@@ -1210,6 +1323,31 @@ class SpannerBigtableStore:
 
     def get_key_by_raw(self, raw_key: str) -> ApiKey | None:
         return self.api_keys.get_by_raw(raw_key)
+
+    def api_key_auth_context(self, raw_key: str) -> ApiKeyAuthContext | None:
+        """Resolve and verify an API key with its workspace in one strong RPC."""
+        lookup_hash = lookup_hash_api_key(raw_key)
+        with self._database.snapshot() as snapshot:
+            rows = list(
+                snapshot.execute_sql(
+                    _API_KEY_AUTH_CONTEXT_SQL,
+                    params={"lookup_hash": lookup_hash},
+                    param_types={"lookup_hash": self._param_types.STRING},
+                )
+            )
+        if not rows:
+            return None
+        api_key = _auth_record(str(rows[0][0]), ApiKey)
+        if not verify_api_key(raw_key, api_key.salt, api_key.secret_hash):
+            return None
+        workspace = (
+            _auth_record(str(rows[0][1]), Workspace)
+            if rows[0][1] is not None
+            else None
+        )
+        if workspace is not None and workspace.deleted:
+            workspace = None
+        return ApiKeyAuthContext(api_key=api_key, workspace=workspace)
 
     def list_keys(self, workspace_id: str) -> list[ApiKey]:
         return self.api_keys.list_for_workspace(workspace_id)

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -1432,6 +1432,26 @@ class AuthSession:
     state: str = "active"  # "active" | "pending_email" (legacy wallet email attach)
 
 
+@dataclass(frozen=True)
+class SessionAuthContext:
+    """Strong, point-in-time view used to authenticate a browser session."""
+
+    session: AuthSession
+    user: User | None
+    workspace: Workspace | None
+    workspaces: tuple[Workspace, ...]
+    is_member: bool
+    is_management: bool
+
+
+@dataclass(frozen=True)
+class ApiKeyAuthContext:
+    """Strong, point-in-time view used to authenticate an API key."""
+
+    api_key: ApiKey
+    workspace: Workspace | None
+
+
 @dataclass
 class EmailSendBlock:
     """Record of an email address that should not receive further sends.

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -51,6 +51,7 @@ from trusted_router.security import (
     verify_api_key,
 )
 from trusted_router.spend_windows import KeyWindowLimitExceeded, window_floors
+from trusted_router.storage_auth_context import build_session_auth_context
 from trusted_router.storage_codec import json_body
 from trusted_router.storage_errors import (
     DeferredSettlementCapReached,
@@ -70,6 +71,7 @@ from trusted_router.storage_models import (
     AcquisitionAttribution,
     ActivationReminderTask,
     ApiKey,
+    ApiKeyAuthContext,
     AuthSession,
     BedrockGroupBuyAggregate,
     BedrockGroupBuyPledge,
@@ -91,6 +93,7 @@ from trusted_router.storage_models import (
     ProviderBenchmarkSample,
     RateLimitHit,
     Reservation,
+    SessionAuthContext,
     SignupResult,
     SyntheticProbeSample,
     SyntheticRollup,
@@ -273,6 +276,51 @@ _CREDIT_TRANSFER_CLAIM_KIND = "credit_transfer_claim"
 # transition in this design that was not guarded by an insert-once row, and the
 # only place the module's own conservation claim was false.
 _CREDIT_TRANSFER_RESOLUTION_KIND = "credit_transfer_resolution"
+
+_SESSION_AUTH_CONTEXT_SQL = """
+    /* auth_session_context */
+    WITH resolved_session AS (
+      SELECT
+        session_record.body AS session_body,
+        session_record.body ->> 'user_id' AS user_id
+      FROM tr_entities AS lookup_record
+      JOIN tr_entities AS session_record
+        ON session_record.kind = 'auth_session'
+       AND session_record.id = lookup_record.body ->> 'session_id'
+      WHERE lookup_record.kind = 'auth_session_lookup'
+        AND lookup_record.id = %s
+    )
+    SELECT
+      resolved.session_body,
+      user_record.body,
+      workspace_record.body,
+      member_record.body
+    FROM resolved_session AS resolved
+    LEFT JOIN tr_entities AS user_record
+      ON user_record.kind = 'user' AND user_record.id = resolved.user_id
+    LEFT JOIN tr_entities AS member_record
+      ON member_record.kind = 'member'
+     AND member_record.body ->> 'user_id' = resolved.user_id
+     AND member_record.id = ((member_record.body ->> 'workspace_id') || '#' || resolved.user_id)
+    LEFT JOIN tr_entities AS workspace_record
+      ON workspace_record.kind = 'workspace'
+     AND workspace_record.id = member_record.body ->> 'workspace_id'
+    ORDER BY member_record.id
+"""
+
+_API_KEY_AUTH_CONTEXT_SQL = """
+    /* api_key_auth_context */
+    SELECT key_record.body, workspace_record.body
+    FROM tr_entities AS lookup_record
+    JOIN tr_entities AS key_record
+      ON key_record.kind = 'api_key'
+     AND key_record.id = lookup_record.body ->> 'key_id'
+    LEFT JOIN tr_entities AS workspace_record
+      ON workspace_record.kind = 'workspace'
+     AND workspace_record.id = key_record.body ->> 'workspace_id'
+    WHERE lookup_record.kind = 'api_key_lookup'
+      AND lookup_record.id = %s
+"""
 
 
 def _split_sql_statements(schema: str) -> list[str]:
@@ -1154,6 +1202,51 @@ class PostgresStore:
 
         return self._run_transaction(delete)
 
+    def session_auth_context(
+        self,
+        raw_token: str,
+        *,
+        requested_workspace_id: str | None = None,
+    ) -> SessionAuthContext | None:
+        """Resolve session principal state in one portable SQL statement."""
+        lookup_hash = lookup_hash_api_key(raw_token)
+
+        def resolve(conn: Any) -> SessionAuthContext | None:
+            rows = conn.execute(
+                _SESSION_AUTH_CONTEXT_SQL,
+                (lookup_hash,),
+            ).fetchall()
+            if not rows:
+                return None
+            session = _dataclass_from_json(rows[0][0], AuthSession)
+            if _is_expired(session.expires_at):
+                self._delete_entity_tx(conn, "auth_session", session.hash)
+                self._delete_entity_tx(conn, "auth_session_lookup", lookup_hash)
+                return None
+            if not verify_api_key(raw_token, session.salt, session.secret_hash):
+                return None
+
+            user = (
+                _dataclass_from_json(rows[0][1], User)
+                if rows[0][1] is not None
+                else None
+            )
+            memberships: list[tuple[Member, Workspace]] = []
+            for _session_body, _user_body, workspace_body, member_body in rows:
+                if workspace_body is None or member_body is None:
+                    continue
+                member = _dataclass_from_json(member_body, Member)
+                workspace = _dataclass_from_json(workspace_body, Workspace)
+                memberships.append((member, workspace))
+            return build_session_auth_context(
+                session=session,
+                user=user,
+                memberships=memberships,
+                requested_workspace_id=requested_workspace_id,
+            )
+
+        return self._run_transaction(resolve)
+
     # Wallet, verification, and OAuth one-shot secrets ----------------------
 
     def create_wallet_challenge(
@@ -1555,6 +1648,31 @@ class PostgresStore:
         ):
             return key
         return None
+
+    def api_key_auth_context(self, raw_key: str) -> ApiKeyAuthContext | None:
+        """Resolve and verify an API key with its workspace in one query."""
+        lookup_hash = lookup_hash_api_key(raw_key)
+
+        def resolve(conn: Any) -> ApiKeyAuthContext | None:
+            row = conn.execute(
+                _API_KEY_AUTH_CONTEXT_SQL,
+                (lookup_hash,),
+            ).fetchone()
+            if row is None:
+                return None
+            api_key = _dataclass_from_json(row[0], ApiKey)
+            if not verify_api_key(raw_key, api_key.salt, api_key.secret_hash):
+                return None
+            workspace = (
+                _dataclass_from_json(row[1], Workspace)
+                if row[1] is not None
+                else None
+            )
+            if workspace is not None and workspace.deleted:
+                workspace = None
+            return ApiKeyAuthContext(api_key=api_key, workspace=workspace)
+
+        return self._run_transaction(resolve)
 
     def list_keys(self, workspace_id: str) -> list[ApiKey]:
         self._not_implemented("list_keys")

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -17,6 +17,7 @@ from trusted_router.storage_models import (
     AcquisitionAttribution,
     ActivationReminderTask,
     ApiKey,
+    ApiKeyAuthContext,
     AuthSession,
     BedrockGroupBuyAggregate,
     BedrockGroupBuyPledge,
@@ -38,6 +39,7 @@ from trusted_router.storage_models import (
     ProviderBenchmarkSample,
     RateLimitHit,
     Reservation,
+    SessionAuthContext,
     SignupResult,
     SyntheticProbeSample,
     SyntheticRollup,
@@ -188,6 +190,12 @@ class Store(Protocol):
     ) -> tuple[str, AuthSession]: ...
     def get_auth_session_by_raw(self, raw_token: str) -> AuthSession | None: ...
     def delete_auth_session_by_raw(self, raw_token: str) -> bool: ...
+    def session_auth_context(
+        self,
+        raw_token: str,
+        *,
+        requested_workspace_id: str | None = ...,
+    ) -> SessionAuthContext | None: ...
     def upgrade_auth_session(self, raw_token: str, *, state: str) -> AuthSession | None: ...
     def set_auth_session_workspace(
         self, raw_token: str, workspace_id: str
@@ -346,6 +354,7 @@ class Store(Protocol):
         ...
 
     def get_key_by_raw(self, raw_key: str) -> ApiKey | None: ...
+    def api_key_auth_context(self, raw_key: str) -> ApiKeyAuthContext | None: ...
     def list_keys(self, workspace_id: str) -> list[ApiKey]: ...
     def delete_key(self, key_hash: str) -> bool: ...
     def update_key(self, key_hash: str, patch: dict[str, Any]) -> ApiKey | None: ...

--- a/tests/conformance/test_auth_context_semantics.py
+++ b/tests/conformance/test_auth_context_semantics.py
@@ -1,0 +1,61 @@
+"""Backend-neutral laws for the collapsed authentication reads."""
+
+from __future__ import annotations
+
+from trusted_router.store_protocol import Store
+
+
+def test_session_auth_context_is_complete_and_keeps_state_for_the_auth_gate(
+    store: Store,
+    user_id: str,
+    workspace_id: str,
+    unique: str,
+) -> None:
+    raw_token, session = store.create_auth_session(
+        user_id=user_id,
+        provider="email",
+        label=f"auth-context-{unique}",
+        ttl_seconds=3600,
+        workspace_id=workspace_id,
+        # Storage must return this state.  The security boundary that refuses
+        # it remains _principal_for_session, because pending-email flows need
+        # to retrieve their session without authenticating it.
+        state="pending_email",
+    )
+
+    context = store.session_auth_context(
+        raw_token,
+        requested_workspace_id=None,
+    )
+
+    assert context is not None
+    assert context.session.hash == session.hash
+    assert context.session.state == "pending_email"
+    assert context.user is not None and context.user.id == user_id
+    assert context.workspace is not None and context.workspace.id == workspace_id
+    assert workspace_id in {workspace.id for workspace in context.workspaces}
+    assert context.is_member is True
+    assert context.is_management is True
+
+
+def test_api_key_auth_context_returns_workspace_and_rejects_unknown_lookup(
+    store: Store,
+    user_id: str,
+    workspace_id: str,
+    unique: str,
+) -> None:
+    raw_key, api_key = store.create_api_key(
+        workspace_id=workspace_id,
+        name=f"auth-context-{unique}",
+        creator_user_id=user_id,
+    )
+
+    context = store.api_key_auth_context(raw_key)
+
+    assert context is not None
+    assert context.api_key.hash == api_key.hash
+    assert context.workspace is not None
+    assert context.workspace.id == workspace_id
+    # This is the backend-neutral unknown-lookup law.  The forced-collision
+    # tests exercise the distinct, security-critical secret-verification step.
+    assert store.api_key_auth_context(f"{raw_key}-tampered") is None

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -193,6 +193,11 @@ class FakeSpannerDatabase:
         # money / authorization read.  The fake does not model historical row
         # versions; this records the contract without pretending that it does.
         self.snapshot_calls: list[dict[str, Any]] = []
+        # Read-RPC instrumentation for fan-out tests.  Count the statement
+        # handed to a snapshot, not helper calls, so a hidden fallback lookup
+        # cannot masquerade as one logical Store operation.
+        self.snapshot_execute_sql_calls = 0
+        self.snapshot_sql: list[str] = []
 
     def run_in_transaction(self, fn: Any, *, timeout_secs: float | None = None) -> Any:
         # timeout_secs mirrors google-cloud-spanner's Database.run_in_transaction
@@ -328,12 +333,12 @@ class FakeSpannerDatabase:
                     self.entity_kind_versions[kind] = new_version
             return True
 
-    def snapshot(self, *, multi_use: bool = False, **_kwargs: Any) -> _FakeSnapshot:
+    def snapshot(self, *, multi_use: bool = False, **kwargs: Any) -> _FakeSnapshot:
         # Models real Spanner: a single-use snapshot (the default) permits exactly
         # ONE read; a second read on it raises. Only multi_use=True allows many.
         # Prod bug fa9f5d4 was a single-use snapshot that grew a second read and
         # faulted live — the old fake "allowed repeated reads regardless" and hid it.
-        call = dict(_kwargs)
+        call = dict(kwargs)
         if multi_use:
             call["multi_use"] = True
         self.snapshot_calls.append(call)
@@ -1272,6 +1277,8 @@ class _FakeSnapshot:
                 "database.snapshot(multi_use=True) for multiple reads "
                 "(models real Spanner — see prod fix fa9f5d4)"
             )
+        self.db.snapshot_execute_sql_calls += 1
+        self.db.snapshot_sql.append(sql)
         return _execute_sql(self.db, None, sql, params or {})
 
 
@@ -1490,6 +1497,118 @@ def _execute_sql(
     params: dict[str, Any],
 ) -> list[list[str]]:
     kind = params.get("kind", "")
+    if "/* auth_session_context */" in sql:
+        _require_pred(
+            sql,
+            "lookup_record.kind='auth_session_lookup'",
+            "session-auth-context lookup kind",
+        )
+        _require_pred(
+            sql,
+            "session_record.id=JSON_VALUE(lookup_record.body, '$.session_id')",
+            "session-auth-context lookup join",
+        )
+        _require_pred(
+            sql,
+            "user_record.kind='user' AND user_record.id=resolved.user_id",
+            "session-auth-context user join",
+        )
+        _require_pred(
+            sql,
+            "member_record.kind='member'",
+            "session-auth-context membership kind",
+        )
+        _require_pred(
+            sql,
+            "JSON_VALUE(member_record.body, '$.user_id')=resolved.user_id",
+            "session-auth-context membership boundary",
+        )
+        _require_pred(
+            sql,
+            "member_record.id=CONCAT(JSON_VALUE(member_record.body, '$.workspace_id'), '#', resolved.user_id)",
+            "session-auth-context canonical membership key",
+        )
+        _require_pred(
+            sql,
+            "workspace_record.id=JSON_VALUE(member_record.body, '$.workspace_id')",
+            "session-auth-context workspace join",
+        )
+        _require_pred(
+            sql,
+            "ORDER BY member_record.id",
+            "session-auth-context deterministic workspace order",
+        )
+        lookup = db.rows.get(("auth_session_lookup", str(params["lookup_hash"])))
+        if lookup is None:
+            return []
+        session_id = str(json.loads(lookup.body)["session_id"])
+        session = db.rows.get(("auth_session", session_id))
+        if session is None:
+            return []
+        user_id = str(json.loads(session.body)["user_id"])
+        user = db.rows.get(("user", user_id))
+        members = sorted(
+            (
+                (entity_id, row)
+                for (row_kind, entity_id), row in db.rows.items()
+                if row_kind == "member"
+                and str(json.loads(row.body).get("user_id")) == user_id
+                and entity_id
+                == f"{json.loads(row.body).get('workspace_id')}#{user_id}"
+            ),
+            key=lambda item: item[0],
+        )
+        if not members:
+            return [[session.body, user.body if user is not None else None, None, None]]
+        rows: list[list[Any]] = []
+        for _member_id, member in members:
+            workspace_id = str(json.loads(member.body)["workspace_id"])
+            workspace = db.rows.get(("workspace", workspace_id))
+            rows.append(
+                [
+                    session.body,
+                    user.body if user is not None else None,
+                    workspace.body if workspace is not None else None,
+                    member.body,
+                ]
+            )
+        return rows
+    if "/* api_key_auth_context */" in sql:
+        _require_pred(
+            sql,
+            "lookup_record.kind='api_key_lookup'",
+            "API-key-auth-context lookup kind",
+        )
+        _require_pred(
+            sql,
+            "key_record.kind='api_key'",
+            "API-key-auth-context key kind",
+        )
+        _require_pred(
+            sql,
+            "key_record.id=JSON_VALUE(lookup_record.body, '$.key_id')",
+            "API-key-auth-context lookup join",
+        )
+        _require_pred(
+            sql,
+            "workspace_record.id=JSON_VALUE(key_record.body, '$.workspace_id')",
+            "API-key-auth-context workspace join",
+        )
+        lookup = db.rows.get(("api_key_lookup", str(params["lookup_hash"])))
+        if lookup is None:
+            return []
+        key_id = str(json.loads(lookup.body)["key_id"])
+        api_key = db.rows.get(("api_key", key_id))
+        if api_key is None:
+            return []
+        workspace_id = str(json.loads(api_key.body)["workspace_id"])
+        workspace = db.rows.get(("workspace", workspace_id))
+        return [
+            [
+                api_key.body,
+                workspace.body if workspace is not None else None,
+            ]
+        ]
     if (
         "FROM tr_credit_movement " in sql
         and "WHERE kind='custom_model_payout' AND created_at>=@since" in sql

--- a/tests/test_auth_store_collapse.py
+++ b/tests/test_auth_store_collapse.py
@@ -1,0 +1,724 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import HTTPException, Request
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.auth import principal_from_request
+from trusted_router.config import Settings
+from trusted_router.routes.console._shared import require_console_context
+from trusted_router.storage import InMemoryStore, configure_store
+from trusted_router.storage_codec import json_body
+from trusted_router.storage_models import Member
+from trusted_router.storage_postgres import PostgresStore
+
+
+def test_session_auth_context_is_one_store_operation() -> None:
+    store = InMemoryStore()
+    user = store.ensure_user("fanout-session@example.com")
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    raw, _session = store.create_auth_session(
+        user_id=user.id,
+        provider="email",
+        label="fanout-session@example.com",
+        ttl_seconds=3600,
+        workspace_id=workspace.id,
+    )
+
+    context = store.session_auth_context(raw, requested_workspace_id=None)
+
+    assert context is not None
+    assert context.session.user_id == user.id
+    assert context.user == user
+    assert context.workspace == workspace
+    assert context.workspaces == (workspace,)
+    assert context.is_member is True
+    assert context.is_management is True
+
+
+def test_api_key_auth_context_resolves_key_and_workspace_together() -> None:
+    store = InMemoryStore()
+    user = store.ensure_user("fanout-key@example.com")
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    raw, api_key = store.create_api_key(
+        workspace_id=workspace.id,
+        name="fanout",
+        creator_user_id=user.id,
+    )
+
+    context = store.api_key_auth_context(raw)
+
+    assert context is not None
+    assert context.api_key == api_key
+    assert context.workspace == workspace
+
+
+def test_session_principal_does_not_fall_back_to_legacy_store_reads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = InMemoryStore()
+    configure_store(store)
+    user = store.ensure_user("collapsed-session@example.com")
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    raw, _session = store.create_auth_session(
+        user_id=user.id,
+        provider="email",
+        label="collapsed-session@example.com",
+        ttl_seconds=3600,
+        workspace_id=workspace.id,
+    )
+    _reject_legacy_auth_reads(monkeypatch)
+
+    principal = principal_from_request(
+        _request(cookie=raw),
+        Settings(environment="test"),
+    )
+
+    assert principal.user == user
+    assert principal.workspace == workspace
+    assert principal.is_management is True
+
+
+def test_api_key_principal_does_not_fall_back_to_legacy_store_reads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = InMemoryStore()
+    configure_store(store)
+    user = store.ensure_user("collapsed-key@example.com")
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    raw, api_key = store.create_api_key(
+        workspace_id=workspace.id,
+        name="collapsed key",
+        creator_user_id=user.id,
+        management=True,
+    )
+    _reject_legacy_auth_reads(monkeypatch)
+
+    principal = principal_from_request(
+        _request(authorization=f"Bearer {raw}"),
+        Settings(environment="test"),
+    )
+
+    assert principal.api_key == api_key
+    assert principal.workspace == workspace
+    assert principal.is_management is True
+
+
+def test_console_context_uses_collapsed_read_and_keeps_stale_selection_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = InMemoryStore()
+    configure_store(store)
+    user = store.ensure_user("console-collapse@example.com")
+    first_workspace = store.list_workspaces_for_user(user.id)[0]
+    second_workspace = store.create_workspace(user.id, "Second")
+    raw, _session = store.create_auth_session(
+        user_id=user.id,
+        provider="email",
+        label="console-collapse@example.com",
+        ttl_seconds=3600,
+        # Console treats this binding as a preference and falls back to the
+        # first current workspace when the saved selection is stale.
+        workspace_id="workspace-that-no-longer-exists",
+    )
+    _reject_legacy_auth_reads(monkeypatch)
+
+    context = require_console_context(
+        _request(cookie=raw),
+        Settings(environment="test"),
+    )
+
+    assert context.user == user
+    assert context.workspace == first_workspace
+    assert context.workspaces == [first_workspace, second_workspace]
+
+
+@pytest.mark.parametrize("state", ["pending_email", "revoked"])
+def test_console_collapsed_read_preserves_inactive_session_redirect(
+    state: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = InMemoryStore()
+    configure_store(store)
+    user = store.ensure_user(f"console-{state}@example.com")
+    raw, _session = store.create_auth_session(
+        user_id=user.id,
+        provider="email",
+        label=user.email or user.id,
+        ttl_seconds=3600,
+        state=state,
+    )
+    _reject_legacy_auth_reads(monkeypatch)
+
+    with pytest.raises(HTTPException) as exc_info:
+        require_console_context(
+            _request(cookie=raw),
+            Settings(environment="test"),
+        )
+
+    assert exc_info.value.status_code == 302
+    assert exc_info.value.headers == {"Location": "/?reason=signin"}
+
+
+def test_membership_removal_is_visible_on_the_next_session_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = InMemoryStore()
+    configure_store(store)
+    user = store.ensure_user("removed-member@example.com")
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    raw, _session = store.create_auth_session(
+        user_id=user.id,
+        provider="email",
+        label="removed-member@example.com",
+        ttl_seconds=3600,
+        workspace_id=workspace.id,
+    )
+    request = _request(cookie=raw)
+    settings = Settings(environment="test")
+    _reject_legacy_auth_reads(monkeypatch)
+    assert principal_from_request(request, settings).workspace == workspace
+
+    store.remove_members(workspace.id, [user.id])
+
+    with pytest.raises(HTTPException) as exc_info:
+        principal_from_request(request, settings)
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail["error"]["message"] == "Forbidden"
+
+
+def test_session_revocation_is_visible_on_the_next_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = InMemoryStore()
+    configure_store(store)
+    user = store.ensure_user("revoked-session@example.com")
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    raw, _session = store.create_auth_session(
+        user_id=user.id,
+        provider="email",
+        label="revoked-session@example.com",
+        ttl_seconds=3600,
+        workspace_id=workspace.id,
+    )
+    request = _request(cookie=raw)
+    settings = Settings(environment="test")
+    _reject_legacy_auth_reads(monkeypatch)
+    assert principal_from_request(request, settings).workspace == workspace
+
+    assert store.delete_auth_session_by_raw(raw) is True
+
+    with pytest.raises(HTTPException) as exc_info:
+        principal_from_request(request, settings)
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail["error"]["message"] == "Invalid session"
+
+
+def test_unbound_session_without_memberships_keeps_workspace_unavailable_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = InMemoryStore()
+    configure_store(store)
+    user = store.ensure_user("no-workspace@example.com")
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    raw, _session = store.create_auth_session(
+        user_id=user.id,
+        provider="email",
+        label="no-workspace@example.com",
+        ttl_seconds=3600,
+        workspace_id=None,
+    )
+    store.remove_members(workspace.id, [user.id])
+    _reject_legacy_auth_reads(monkeypatch)
+
+    with pytest.raises(HTTPException) as exc_info:
+        principal_from_request(
+            _request(cookie=raw),
+            Settings(environment="test"),
+        )
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail["error"]["message"] == "Workspace is unavailable"
+
+
+def test_key_revocation_is_visible_on_the_next_api_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = InMemoryStore()
+    configure_store(store)
+    user = store.ensure_user("revoked-key@example.com")
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    raw, api_key = store.create_api_key(
+        workspace_id=workspace.id,
+        name="revocable",
+        creator_user_id=user.id,
+    )
+    request = _request(authorization=f"Bearer {raw}")
+    settings = Settings(environment="test")
+    _reject_legacy_auth_reads(monkeypatch)
+    assert principal_from_request(request, settings).api_key == api_key
+
+    assert store.delete_key(api_key.hash) is True
+
+    with pytest.raises(HTTPException) as exc_info:
+        principal_from_request(request, settings)
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail["error"]["message"] == "Invalid API key"
+
+
+def test_spanner_session_context_uses_one_read_rpc() -> None:
+    store, database, _bigtable = make_fake_store()
+    user = store.ensure_user("spanner-session-fanout@example.com")
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    raw, _session = store.create_auth_session(
+        user_id=user.id,
+        provider="email",
+        label="spanner-session-fanout@example.com",
+        ttl_seconds=3600,
+        workspace_id=workspace.id,
+    )
+    before = database.snapshot_execute_sql_calls
+    snapshot_before = len(database.snapshot_calls)
+
+    context = store.session_auth_context(raw, requested_workspace_id=None)
+
+    assert context is not None and context.workspace == workspace
+    assert database.snapshot_execute_sql_calls - before == 1
+    assert database.snapshot_calls[snapshot_before:] == [{}]
+    assert "/* auth_session_context */" in database.snapshot_sql[-1]
+
+
+def test_spanner_api_key_context_uses_one_read_rpc() -> None:
+    store, database, _bigtable = make_fake_store()
+    user = store.ensure_user("spanner-key-fanout@example.com")
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    raw, api_key = store.create_api_key(
+        workspace_id=workspace.id,
+        name="spanner fanout",
+        creator_user_id=user.id,
+    )
+    before = database.snapshot_execute_sql_calls
+    snapshot_before = len(database.snapshot_calls)
+
+    context = store.api_key_auth_context(raw)
+
+    assert context is not None and context.api_key == api_key
+    assert context.workspace == workspace
+    assert database.snapshot_execute_sql_calls - before == 1
+    assert database.snapshot_calls[snapshot_before:] == [{}]
+    assert "/* api_key_auth_context */" in database.snapshot_sql[-1]
+
+
+def test_spanner_session_context_excludes_noncanonical_member_row() -> None:
+    store, _database, _bigtable = make_fake_store()
+    user = store.ensure_user("spanner-rogue-member@example.com")
+    fallback_workspace = store.list_workspaces_for_user(user.id)[0]
+    other_user = store.ensure_user("spanner-rogue-target@example.com")
+    target_workspace = store.list_workspaces_for_user(other_user.id)[0]
+    raw, _session = store.create_auth_session(
+        user_id=user.id,
+        provider="email",
+        label="spanner-rogue-member@example.com",
+        ttl_seconds=3600,
+        workspace_id=None,
+    )
+    rogue_member = Member(
+        workspace_id=target_workspace.id,
+        user_id=user.id,
+        role="owner",
+    )
+    # The body claims membership, but both legacy accessors reject this row:
+    # its entity id is neither the exact workspace#user key nor a #user suffix.
+    store._write_entity("member", "rogue-noncanonical-member-row", rogue_member)
+    assert store.user_is_member(user.id, target_workspace.id) is False
+    assert target_workspace not in store.list_workspaces_for_user(user.id)
+
+    requested = store.session_auth_context(
+        raw,
+        requested_workspace_id=target_workspace.id,
+    )
+    fallback = store.session_auth_context(raw, requested_workspace_id=None)
+
+    assert requested is not None
+    assert requested.workspace is None
+    assert requested.is_member is False
+    assert requested.is_management is False
+    assert target_workspace not in requested.workspaces
+    assert fallback is not None
+    assert fallback.workspace == fallback_workspace
+    assert fallback.workspaces == (fallback_workspace,)
+
+
+def test_postgres_session_context_excludes_noncanonical_member_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    memory = InMemoryStore()
+    user = memory.ensure_user("postgres-rogue-member@example.com")
+    fallback_workspace = memory.list_workspaces_for_user(user.id)[0]
+    fallback_member = memory.members[(fallback_workspace.id, user.id)]
+    other_user = memory.ensure_user("postgres-rogue-target@example.com")
+    target_workspace = memory.list_workspaces_for_user(other_user.id)[0]
+    raw_session, session = memory.create_auth_session(
+        user_id=user.id,
+        provider="email",
+        label="postgres-rogue-member@example.com",
+        ttl_seconds=3600,
+        workspace_id=None,
+    )
+    _raw_key, api_key = memory.create_api_key(
+        workspace_id=fallback_workspace.id,
+        name="postgres rogue member",
+        creator_user_id=user.id,
+    )
+    rogue_member = Member(
+        workspace_id=target_workspace.id,
+        user_id=user.id,
+        role="owner",
+    )
+    connection = _FakePostgresConnection(
+        session_rows=[
+            (
+                json_body(session),
+                json_body(user),
+                json_body(fallback_workspace),
+                json_body(fallback_member),
+            ),
+            (
+                json_body(session),
+                json_body(user),
+                json_body(target_workspace),
+                json_body(rogue_member),
+            ),
+        ],
+        session_member_ids=[
+            f"{fallback_workspace.id}#{user.id}",
+            "rogue-noncanonical-member-row",
+        ],
+        api_key_row=(json_body(api_key), json_body(fallback_workspace)),
+        session_lookup_hash=session.lookup_hash,
+        api_key_lookup_hash=api_key.lookup_hash,
+    )
+    monkeypatch.setattr(
+        PostgresStore,
+        "_run_transaction",
+        lambda _self, operation: operation(connection),
+    )
+    store = PostgresStore.__new__(PostgresStore)
+
+    requested = store.session_auth_context(
+        raw_session,
+        requested_workspace_id=target_workspace.id,
+    )
+    fallback = store.session_auth_context(
+        raw_session,
+        requested_workspace_id=None,
+    )
+
+    assert requested is not None
+    assert requested.workspace is None
+    assert requested.is_member is False
+    assert requested.is_management is False
+    assert target_workspace not in requested.workspaces
+    assert fallback is not None
+    assert fallback.workspace == fallback_workspace
+    assert fallback.workspaces == (fallback_workspace,)
+
+
+@pytest.mark.parametrize("backend", ["spanner", "postgres"])
+def test_session_auth_context_verifies_secret_after_forced_lookup_collision(
+    backend: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, session_lookup_hash, _api_key_lookup_hash = _collision_store(
+        backend,
+        monkeypatch,
+    )
+    _force_lookup_hash(monkeypatch, backend, session_lookup_hash)
+
+    context = store.session_auth_context(
+        "trsess-v1-forced-lookup-collision",
+        requested_workspace_id=None,
+    )
+
+    # The lookup intentionally resolves somebody else's valid row.  Only the
+    # salted secret verification prevents that row from authenticating.
+    assert context is None
+
+
+@pytest.mark.parametrize("backend", ["spanner", "postgres"])
+def test_api_key_auth_context_verifies_secret_after_forced_lookup_collision(
+    backend: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, _session_lookup_hash, api_key_lookup_hash = _collision_store(
+        backend,
+        monkeypatch,
+    )
+    _force_lookup_hash(monkeypatch, backend, api_key_lookup_hash)
+
+    context = store.api_key_auth_context("sk-tr-v1-forced-lookup-collision")
+
+    # A lookup hit is not authentication: the supplied secret must still
+    # verify against the returned key before the context can be trusted.
+    assert context is None
+
+
+def test_postgres_auth_contexts_each_issue_one_statement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    memory = InMemoryStore()
+    user = memory.ensure_user("postgres-fanout@example.com")
+    workspace = memory.list_workspaces_for_user(user.id)[0]
+    member = memory.members[(workspace.id, user.id)]
+    raw_session, session = memory.create_auth_session(
+        user_id=user.id,
+        provider="email",
+        label="postgres-fanout@example.com",
+        ttl_seconds=3600,
+        workspace_id=workspace.id,
+    )
+    raw_key, api_key = memory.create_api_key(
+        workspace_id=workspace.id,
+        name="postgres fanout",
+        creator_user_id=user.id,
+    )
+    connection = _FakePostgresConnection(
+        session_rows=[
+            (
+                json_body(session),
+                json_body(user),
+                json_body(workspace),
+                json_body(member),
+            )
+        ],
+        session_member_ids=[f"{workspace.id}#{user.id}"],
+        api_key_row=(json_body(api_key), json_body(workspace)),
+        session_lookup_hash=session.lookup_hash,
+        api_key_lookup_hash=api_key.lookup_hash,
+    )
+    monkeypatch.setattr(
+        PostgresStore,
+        "_run_transaction",
+        lambda _self, operation: operation(connection),
+    )
+    store = PostgresStore.__new__(PostgresStore)
+
+    session_context = store.session_auth_context(
+        raw_session,
+        requested_workspace_id=None,
+    )
+    assert session_context is not None and session_context.workspace == workspace
+    assert len(connection.calls) == 1
+    assert "/* auth_session_context */" in connection.calls[-1][0]
+
+    key_context = store.api_key_auth_context(raw_key)
+    assert key_context is not None and key_context.api_key == api_key
+    assert key_context.workspace == workspace
+    assert len(connection.calls) == 2
+    assert "/* api_key_auth_context */" in connection.calls[-1][0]
+
+
+def _collision_store(
+    backend: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Any, str, str]:
+    if backend == "spanner":
+        store, _database, _bigtable = make_fake_store()
+        user = store.ensure_user("spanner-collision@example.com")
+        workspace = store.list_workspaces_for_user(user.id)[0]
+        _raw_session, session = store.create_auth_session(
+            user_id=user.id,
+            provider="email",
+            label="spanner-collision@example.com",
+            ttl_seconds=3600,
+            workspace_id=workspace.id,
+        )
+        _raw_key, api_key = store.create_api_key(
+            workspace_id=workspace.id,
+            name="spanner collision",
+            creator_user_id=user.id,
+        )
+        return store, session.lookup_hash, api_key.lookup_hash
+
+    memory = InMemoryStore()
+    user = memory.ensure_user("postgres-collision@example.com")
+    workspace = memory.list_workspaces_for_user(user.id)[0]
+    member = memory.members[(workspace.id, user.id)]
+    _raw_session, session = memory.create_auth_session(
+        user_id=user.id,
+        provider="email",
+        label="postgres-collision@example.com",
+        ttl_seconds=3600,
+        workspace_id=workspace.id,
+    )
+    _raw_key, api_key = memory.create_api_key(
+        workspace_id=workspace.id,
+        name="postgres collision",
+        creator_user_id=user.id,
+    )
+    connection = _FakePostgresConnection(
+        session_rows=[
+            (
+                json_body(session),
+                json_body(user),
+                json_body(workspace),
+                json_body(member),
+            )
+        ],
+        session_member_ids=[f"{workspace.id}#{user.id}"],
+        api_key_row=(json_body(api_key), json_body(workspace)),
+        session_lookup_hash=session.lookup_hash,
+        api_key_lookup_hash=api_key.lookup_hash,
+    )
+    monkeypatch.setattr(
+        PostgresStore,
+        "_run_transaction",
+        lambda _self, operation: operation(connection),
+    )
+    return PostgresStore.__new__(PostgresStore), session.lookup_hash, api_key.lookup_hash
+
+
+def _force_lookup_hash(
+    monkeypatch: pytest.MonkeyPatch,
+    backend: str,
+    lookup_hash: str,
+) -> None:
+    module = (
+        "trusted_router.storage_gcp"
+        if backend == "spanner"
+        else "trusted_router.storage_postgres"
+    )
+    monkeypatch.setattr(f"{module}.lookup_hash_api_key", lambda _raw: lookup_hash)
+
+
+def _request(
+    *,
+    cookie: str | None = None,
+    authorization: str | None = None,
+) -> Request:
+    headers = [(b"host", b"trustedrouter.com")]
+    if cookie is not None:
+        headers.append((b"cookie", f"tr_session={cookie}".encode()))
+    if authorization is not None:
+        headers.append((b"authorization", authorization.encode()))
+    return Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "https",
+            "path": "/",
+            "raw_path": b"/",
+            "query_string": b"",
+            "headers": headers,
+            "client": ("testclient", 50000),
+            "server": ("trustedrouter.com", 443),
+            "app": SimpleNamespace(state=SimpleNamespace()),
+        }
+    )
+
+
+def _reject_legacy_auth_reads(monkeypatch: pytest.MonkeyPatch) -> None:
+    def unexpected(_self: InMemoryStore, *_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("auth fell back to a legacy Store round trip")
+
+    for method_name in (
+        "get_auth_session_by_raw",
+        "get_key_by_raw",
+        "get_user",
+        "get_workspace",
+        "list_workspaces_for_user",
+        "user_can_manage",
+        "user_is_member",
+    ):
+        monkeypatch.setattr(InMemoryStore, method_name, unexpected)
+
+
+class _FakePostgresCursor:
+    def __init__(self, rows: list[tuple[Any, ...]]) -> None:
+        self._rows = rows
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        return self._rows
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        return self._rows[0] if self._rows else None
+
+
+class _FakePostgresConnection:
+    def __init__(
+        self,
+        *,
+        session_rows: list[tuple[Any, ...]],
+        session_member_ids: list[str | None],
+        api_key_row: tuple[Any, ...],
+        session_lookup_hash: str,
+        api_key_lookup_hash: str,
+    ) -> None:
+        self._session_rows = session_rows
+        self._session_member_ids = session_member_ids
+        self._api_key_row = api_key_row
+        self._session_lookup_hash = session_lookup_hash
+        self._api_key_lookup_hash = api_key_lookup_hash
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+        if len(self._session_rows) != len(self._session_member_ids):
+            raise ValueError("each fake Postgres session row needs its member entity id")
+
+    def execute(
+        self,
+        sql: str,
+        params: tuple[Any, ...],
+    ) -> _FakePostgresCursor:
+        self.calls.append((sql, params))
+        if "/* auth_session_context */" in sql:
+            assert params == (self._session_lookup_hash,)
+            assert "lookup_record.id = %s" in sql
+            assert "session_record.id = lookup_record.body ->> 'session_id'" in sql
+            assert "user_record.id = resolved.user_id" in sql
+            assert "member_record.body ->> 'user_id' = resolved.user_id" in sql
+            assert (
+                "member_record.id = ((member_record.body ->> 'workspace_id') || '#' || resolved.user_id)"
+                in sql
+            )
+            assert "workspace_record.id = member_record.body ->> 'workspace_id'" in sql
+            rows = self._canonical_session_rows()
+        else:
+            assert params == (self._api_key_lookup_hash,)
+            assert "/* api_key_auth_context */" in sql
+            assert "lookup_record.id = %s" in sql
+            assert "key_record.id = lookup_record.body ->> 'key_id'" in sql
+            assert "workspace_record.id = key_record.body ->> 'workspace_id'" in sql
+            rows = [self._api_key_row]
+        return _FakePostgresCursor(rows)
+
+    def _canonical_session_rows(self) -> list[tuple[Any, ...]]:
+        rows: list[tuple[Any, ...]] = []
+        for member_id, row in zip(
+            self._session_member_ids,
+            self._session_rows,
+            strict=True,
+        ):
+            session_body, _user_body, _workspace_body, member_body = row
+            if member_body is None:
+                rows.append(row)
+                continue
+            session = _json_record(session_body)
+            member = _json_record(member_body)
+            user_id = str(session["user_id"])
+            if member.get("user_id") != user_id:
+                continue
+            if member_id != f"{member.get('workspace_id')}#{user_id}":
+                continue
+            rows.append(row)
+        if rows or not self._session_rows:
+            return rows
+        session_body, user_body, _workspace_body, _member_body = self._session_rows[0]
+        return [(session_body, user_body, None, None)]
+
+
+def _json_record(raw: Any) -> dict[str, Any]:
+    return json.loads(raw) if isinstance(raw, str) else dict(raw)


### PR DESCRIPTION
## Summary

- collapse session authentication, console authentication, and API-key authentication to one strong Store read each
- use one backend-native SQL statement for Spanner and Postgres, and one lock-scoped read in memory
- share workspace selection semantics across backends without adding a cache or invalidation window
- require canonical `workspace#user` member entity IDs as well as matching JSON fields, preserving the legacy authorization boundary under malformed/orphan rows
- preserve console redirect/fallback behavior and all existing 401/403 distinctions

## Safety

- session state remains gated in `_principal_for_session`
- disabled/expired API-key checks remain in `_principal_for_api_key`
- session/key revocation and membership removal are visible on the next request
- authorization reads remain strongly consistent

## Before / after

Same-machine A/B, 20 identical iterations with a controlled 10 ms delay per Store/network hop (synthetic latency, not real Spanner timing):

| Path | Store calls | Mean before | Mean after |
| --- | ---: | ---: | ---: |
| Session principal | 5 -> 1 | 67.90 ms | 13.10 ms |
| Console context | 3 -> 1 | 41.79 ms | 14.78 ms |
| API-key principal | 2 -> 1 | 27.10 ms | 15.93 ms |

Native Spanner statement counts from the actual old/new paths are session 6 -> 1, console 4+N -> 1 (5 -> 1 with one workspace), and API key 3 -> 1. New tests assert one snapshot `execute_sql` call and prohibit hidden legacy fallback reads.

The two measurements used the same candidate-worktree interpreter/dependencies and the same temporary harness command; only the import source root changed:

```sh
env PYTHONDONTWRITEBYTECODE=1 .venv/bin/python .tmp_measure_auth_fanout.py /Users/jperla/josh/repos/tr/quill-router
env PYTHONDONTWRITEBYTECODE=1 .venv/bin/python .tmp_measure_auth_fanout.py /private/tmp/claude-501/-Users-jperla-josh/b5eaa6c2-19b0-49e3-a322-ae405378fa3c/scratchpad/perf-wt/handlers
```

Baseline was clean `main` at `52fbd37d9c34e88e8c482903f15b3c777a4f8867`; candidate was the implementation diff based on that same commit which became this PR. The harness ran 20 iterations per path and inserted 10 ms before each watched Store call. It was deleted after measurement rather than committed as a benchmark, so the deterministic proof here is the counted call reduction; the wall-clock means also contain local hashing/request and scheduler overhead.

## Red proof

The complete two-file new test set was run against isolated clean parent source at `52fbd37d`: all 24 runnable cases failed and the six unconfigured real-backend fixture variants skipped. Production imports in the tracebacks resolved under the clean parent tree. On the candidate, the focused set is `48 passed, 6 skipped`.

A separate removal mutation forced both Spanner and Postgres `verify_api_key` calls to accept any secret. All four forced-lookup-collision cases then failed (session/API key x Spanner/Postgres), proving those tests exercise the post-lookup secret check rather than merely missing on a changed lookup hash. Auth snapshot tests also assert exact strong options (`{}`) and one SQL RPC.

The exact-head review also found that filtering member rows only by JSON body would widen access versus the legacy canonical entity-key lookup. New Spanner and Postgres differential tests inject a body-valid owner row under a noncanonical ID and prove explicit selection and fallback both exclude it. Removing the canonical-ID predicate from either SQL query makes the corresponding regression fail.

## Verification

- pre-rebase `uv run pytest -q`: 4,889 passed, 296 skipped, 10 xfailed
- rebased combined Task 2/3 safety suite before the final two security regressions: 66 passed, 6 backend-environment skips
- final focused auth/context suite: 48 passed, 6 backend-environment skips
- `uv run ruff check .`: passed
- `uv run mypy`: passed (280 source files)
- `git diff --check`: passed

Real Postgres/Spanner services were unavailable locally, so no real-database latency is claimed. The repository's Spanner fake validates the load-bearing join predicates and RPC count; a Postgres connection fake validates one statement. Repository-wide `ruff format --check` remains baseline-red on the same 438 pre-existing files; no tree-wide formatting was performed.
