### PR TITLE
Show the real enrolment form on /sms for 10DLC vetting

### DIFF
--- a/src/trusted_router/templates/_sms_enrolment_fields.html
+++ b/src/trusted_router/templates/_sms_enrolment_fields.html
@@ -1,0 +1,48 @@
+{#- The number field, the Call to Action checkbox and the submit button, defined ONCE.
+
+  Rendered in two places that a 10DLC vetter will compare:
+
+    * the console at Settings -> Notifications, live and interactive, where a
+      number is actually collected;
+    * the public /sms page, as a non-interactive PREVIEW, because the console is
+      behind a login and a CTA a vetter cannot see is a CTA that does not count.
+
+  The consent SENTENCE was already shared via _sms_consent.html. The fields
+  around it were not, so the public page could still describe a form that did not
+  match — the same failure as campaign 30909, one level out. Sharing the markup
+  makes "the public page shows the real form" true by construction rather than by
+  someone remembering to update both.
+
+  Set `preview = true` to render the disabled copy. Nothing else changes: same
+  labels, same order, same default-unticked checkbox.
+-#}
+<label>Mobile number<input name="phone" placeholder="+15551234567" autocomplete="tel"
+  {% if preview %}disabled{% else %}required{% endif %}></label>
+{% if preview %}
+  <p><strong>Phone call</strong></p>
+{% elif notify_sms_available %}
+  <label>Send the code by
+    <select name="channel">
+      <option value="voice">Phone call</option>
+      <option value="sms">Text message</option>
+    </select>
+  </label>
+{% else %}
+  <input type="hidden" name="channel" value="voice">
+  <p><strong>Phone call</strong></p>
+  <p class="muted">We'll call this number and read you a 6-digit code. (Text messages are coming once carrier registration completes.)</p>
+{% endif %}
+{# Every element below is required by CTIA and is what a vetter looks for at the
+   point a number is collected: who is sending, what is sent, how often, cost,
+   how to stop, how to get help, and the two policy links. It is a real gate —
+   the server refuses a submission without `sms_consent`, so it cannot be
+   bypassed by posting the form directly. #}
+<label class="consent">
+  <input type="checkbox" name="sms_consent" value="yes"
+    {% if preview %}disabled{% else %}required{% endif %}>
+  <span>{% with consent_links_new_tab = true %}{% include "_sms_consent.html" %}{% endwith %}</span>
+</label>
+<button class="btn primary" type="submit"
+  {% if preview or resend_wait_seconds %}disabled{% endif %}>
+  {%- if not preview and resend_wait_seconds %}You can request a code in {{ resend_wait_seconds }}s{% else %}Send code{% endif -%}
+</button>

--- a/src/trusted_router/templates/console/settings.html
+++ b/src/trusted_router/templates/console/settings.html
@@ -82,36 +82,7 @@
     {% else %}
       <p>Add a mobile number so your agents can reach you when something breaks. Verifying it is what unlocks every notification channel, email included.</p>
       <form class="form" method="post" action="/console/settings/phone/start">
-        <label>Mobile number<input name="phone" placeholder="+15551234567" autocomplete="tel" required></label>
-        {% if notify_sms_available %}
-          <label>Send the code by
-            <select name="channel">
-              <option value="voice">Phone call</option>
-              <option value="sms">Text message</option>
-            </select>
-          </label>
-        {% else %}
-          <input type="hidden" name="channel" value="voice">
-          <p><strong>Phone call</strong></p>
-          <p class="muted">We'll call this number and read you a 6-digit code. (Text messages are coming once carrier registration completes.)</p>
-        {% endif %}
-        {# The Call to Action. Every element below is required by CTIA and is what a
-           10DLC campaign vetter looks for at the point a number is collected: who
-           is sending, what is sent, how often, cost, how to stop, how to get help,
-           and the two policy links. It is a real gate — the server refuses a
-           submission without `sms_consent`, so it cannot be bypassed by posting
-           the form directly.
-
-           The sentence comes from _sms_consent.html, the same partial the PUBLIC
-           /sms page renders, because the console is behind a login and a CTA a
-           vetter cannot see is a CTA that does not count. Campaign 30909 was
-           exactly that: the submission and /sms both described this checkbox
-           while it existed in neither. #}
-        <label class="consent">
-          <input type="checkbox" name="sms_consent" value="yes" required>
-          <span>{% with consent_links_new_tab = true %}{% include "_sms_consent.html" %}{% endwith %}</span>
-        </label>
-        <button class="btn primary" type="submit" {% if resend_wait_seconds %}disabled{% endif %}>{% if resend_wait_seconds %}You can request a code in {{ resend_wait_seconds }}s{% else %}Send code{% endif %}</button>
+        {% include "_sms_enrolment_fields.html" %}
       </form>
       <p class="muted">A phone call works on any number, including landlines and desk phones, and needs no carrier registration. <a href="/docs/notify">What we send</a>.</p>
     {% endif %}

--- a/src/trusted_router/templates/public/sms.html
+++ b/src/trusted_router/templates/public/sms.html
@@ -33,6 +33,20 @@
   </ol>
   <p>The checkbox is unticked by default, and the number is not reachable until the code is confirmed.</p>
 
+  {# The form itself, not a description of it. A campaign vetter cannot sign in,
+     so a CTA they cannot see is a CTA that does not count — which is precisely
+     why 30909 was raised. These are the SAME fields the console renders, from
+     _sms_enrolment_fields.html, so this cannot drift into showing a form that
+     does not exist. Inputs are disabled: it is evidence, not a second place to
+     collect numbers. #}
+  <h2>The form, exactly as it appears in your account</h2>
+  <p class="muted">A non-interactive copy of the live form at <strong>Settings &rarr; Notifications</strong>,
+    rendered from the same template. The checkbox below is unticked, which is its default state;
+    the server rejects any submission that does not include it.</p>
+  <form class="form" aria-label="Preview of the notification enrolment form. Disabled." onsubmit="return false">
+    {% with preview = true %}{% include "_sms_enrolment_fields.html" %}{% endwith %}
+  </form>
+
   <h2>How you opt out</h2>
   <p>Reply <strong>STOP</strong> to any message to stop all messages from that program, or remove the number in Settings &rarr; Notifications. Reply <strong>START</strong> to resubscribe. Reply <strong>HELP</strong>, or email <a href="mailto:{{ entity.security_contact_email }}">{{ entity.security_contact_email }}</a>, for help.</p>
 

--- a/tests/test_sms_form_preview.py
+++ b/tests/test_sms_form_preview.py
@@ -1,0 +1,80 @@
+"""The public /sms page must show the REAL enrolment form, not a description of it.
+
+Campaign 30909 was rejected because the submission and /sms both described a
+consent checkbox the console did not have. The sentence is now shared, but the
+fields around it were not, so the public page could still show a form that did
+not match the live one. These tests hold the two together.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from trusted_router.config import Settings
+from trusted_router.dashboard import public_sms_html
+
+
+@pytest.fixture
+def sms_html() -> str:
+    return public_sms_html(Settings())
+
+
+class TestThePublicPageShowsTheForm:
+    def test_it_renders_an_actual_consent_checkbox(self, sms_html: str) -> None:
+        # Not prose about a checkbox — the input itself, which is what a vetter
+        # who cannot sign in has to look at.
+        assert re.search(r'<input[^>]*type="checkbox"[^>]*name="sms_consent"', sms_html)
+
+    def test_the_preview_checkbox_is_not_pre_ticked(self, sms_html: str) -> None:
+        # Its default state is the claim being made to the carrier.
+        block = _consent_input(sms_html)
+        assert "checked" not in block, f"preview checkbox is pre-ticked: {block}"
+
+    def test_the_preview_cannot_collect_anything(self, sms_html: str) -> None:
+        # Evidence, not a second enrolment path: every input is disabled, and the
+        # form posts nowhere.
+        assert "disabled" in _consent_input(sms_html)
+        phone = re.search(r'<input[^>]*name="phone"[^>]*>', sms_html)
+        assert phone and "disabled" in phone.group(0)
+        assert not re.search(r'<form[^>]*action="[^"]*/console/', sms_html), (
+            "the public preview points at the real POST endpoint"
+        )
+
+    def test_it_shows_the_number_field_and_the_submit_button(self, sms_html: str) -> None:
+        assert 'name="phone"' in sms_html
+        assert "Send code" in sms_html
+
+
+class TestItCannotDriftFromTheConsole:
+    def test_both_render_the_same_partial(self) -> None:
+        # The guarantee is structural: one template, included twice. If someone
+        # inlines either copy, this fails and the drift is caught here rather
+        # than by a rejected campaign.
+        from pathlib import Path
+
+        root = Path("src/trusted_router/templates")
+        console = (root / "console" / "settings.html").read_text()
+        public = (root / "public" / "sms.html").read_text()
+
+        assert "_sms_enrolment_fields.html" in console
+        assert "_sms_enrolment_fields.html" in public
+        # The console must not carry its own copy of the fields any more.
+        assert 'name="sms_consent"' not in console, (
+            "the console re-inlined the consent checkbox; it can now drift from /sms"
+        )
+
+    def test_the_shared_partial_still_carries_the_full_cta(self) -> None:
+        from pathlib import Path
+
+        fields = Path("src/trusted_router/templates/_sms_enrolment_fields.html").read_text()
+        assert "_sms_consent.html" in fields, "the CTA sentence stopped being shared"
+        assert 'name="sms_consent"' in fields
+        assert "required" in fields, "the live form must still require consent"
+
+
+def _consent_input(html: str) -> str:
+    match = re.search(r'<input[^>]*name="sms_consent"[^>]*>', html)
+    assert match, "no sms_consent input rendered on the public page"
+    return match.group(0)


### PR DESCRIPTION
## Why

Campaign 30909 keeps coming back because the Call to Action a vetter is asked to
verify sits behind a login. They cannot see it, so it does not count.

**There are no test credentials to give them.** TrustedRouter has no password
authentication — sign-in is Google or GitHub OAuth only, and there is no
password hashing anywhere in `src/`. Adding a password login purely so a
reviewer can log in would be new attack surface for a paperwork problem.

## What

`/sms` now renders the **actual form**, disabled: number field, consent checkbox
in its default unticked state, submit button. Evidence, not a second enrolment
path — inputs are disabled and the form posts nowhere.

The fields moved into `_sms_enrolment_fields.html`, included by both the console
and the public page. The consent *sentence* was already shared; the fields
around it were not, so the public page could still show a form that did not
match the live one — 30909 one level out.

## Verification

- 88 tests pass across the new preview tests, legal/SMS clauses, console
  settings and public SEO pages
- `ruff format --check`, `ruff check`, `mypy` clean
- the anti-drift test is mutation-checked: re-inlining the checkbox in the
  console fails it
- rendered output confirmed: disabled unticked checkbox, full CTA with both
  policy links, button disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)