### PR TITLE
Update homepage hero and live region footprint

### DIFF
--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -673,14 +673,14 @@ class Settings(BaseSettings):
         "asia-northeast1,asia-east2,asia-southeast1,"
         "southamerica-east1,"
         # Standalone deployments on other clouds (multi-cloud-separation.md).
-        "aws-eu-west-1,aws-eu-north-1,azure-australiaeast"
+        "aws-eu-west-1,aws-eu-west-3,aws-eu-north-1,azure-australiaeast"
     )
     # Non-GCP deployments that have PASSED their own end-to-end smoke
     # (verify_deployment.sh --expect-monitor). Listing here turns the map dot
     # from "staged" to "live", so an entry is a factual claim, not decoration.
     # Stockholm (aws-eu-north-1) is deliberately absent: it replicates the
     # AWS-EU database but has no compute yet.
-    external_live_regions: str = "aws-eu-west-1,azure-australiaeast"
+    external_live_regions: str = "aws-eu-west-1,aws-eu-west-3,azure-australiaeast"
     primary_region: str = "us-central1"
     regional_api_hostname_template: str = "api-{region}.quillrouter.com"
     synthetic_monitor_region: str | None = None

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -1752,6 +1752,9 @@ def dashboard_html(
         "githubEnabled": settings.github_oauth_enabled,
     }
     map_regions = region_map_payload(settings)
+    live_map_regions = [region for region in map_regions if region["serving"]]
+    live_region_count = len(live_map_regions)
+    live_cloud_count = len({region["cloud"] for region in live_map_regions})
     api_region_count = len(configured_regions(settings))
     return (
         _env()
@@ -1773,6 +1776,8 @@ def dashboard_html(
             paypal_enabled=settings.paypal_enabled,
             map_regions=map_regions,
             api_region_count=api_region_count,
+            live_region_count=live_region_count,
+            live_cloud_count=live_cloud_count,
             primary_region=settings.primary_region,
             static_version=_static_version(settings),
         )

--- a/src/trusted_router/regions.py
+++ b/src/trusted_router/regions.py
@@ -20,12 +20,22 @@ class RegionGeo:
     lat: float
     lng: float
     cloud: str = "gcp"
+    label_dx: float = 12.0
+    label_dy: float = -8.0
+    label_anchor: str = "start"
 
 
 # GCP region locations — the cities Cloud Run actually runs in. Keep in
 # sync with https://cloud.google.com/about/locations when adding rows.
 GCP_REGION_GEO: dict[str, RegionGeo] = {
-    "us-central1": RegionGeo("us-central1", "Iowa", 41.262, -95.860),
+    "us-central1": RegionGeo(
+        "us-central1",
+        "Iowa",
+        41.262,
+        -95.860,
+        label_dx=-12,
+        label_anchor="end",
+    ),
     "us-east1": RegionGeo("us-east1", "S. Carolina", 33.836, -81.163),
     "us-east4": RegionGeo("us-east4", "N. Virginia", 39.045, -77.487),
     "us-west1": RegionGeo("us-west1", "Oregon", 45.523, -122.676),
@@ -35,7 +45,9 @@ GCP_REGION_GEO: dict[str, RegionGeo] = {
     "europe-west1": RegionGeo("europe-west1", "Belgium", 50.503, 4.469),
     "europe-west2": RegionGeo("europe-west2", "London", 51.507, -0.128),
     "europe-west3": RegionGeo("europe-west3", "Frankfurt", 50.111, 8.682),
-    "europe-west4": RegionGeo("europe-west4", "Netherlands", 52.379, 4.900),
+    "europe-west4": RegionGeo(
+        "europe-west4", "Netherlands", 52.379, 4.900, label_dy=-14
+    ),
     "europe-west6": RegionGeo("europe-west6", "Zürich", 47.376, 8.541),
     "me-west1": RegionGeo("me-west1", "Tel Aviv", 32.085, 34.781),
     "africa-south1": RegionGeo("africa-south1", "Johannesburg", -26.204, 28.047),
@@ -63,13 +75,38 @@ def _lookup_region_geo(region: str) -> RegionGeo | None:
 # must correspond to a deployment that actually serves; the live/staged
 # split is settings.external_live_regions, not this table.
 MULTICLOUD_REGION_GEO: dict[str, RegionGeo] = {
-    "aws-eu-west-1": RegionGeo("aws-eu-west-1", "Dublin", 53.349, -6.260, cloud="aws"),
+    "aws-eu-west-1": RegionGeo(
+        "aws-eu-west-1",
+        "Dublin",
+        53.349,
+        -6.260,
+        cloud="aws",
+        label_dx=-12,
+        label_dy=4,
+        label_anchor="end",
+    ),
+    "aws-eu-west-3": RegionGeo(
+        "aws-eu-west-3",
+        "Paris",
+        48.857,
+        2.352,
+        cloud="aws",
+        label_dy=18,
+    ),
     # Stockholm is the DSQL replication peer of the AWS-EU deployment. It
     # holds live data but no compute yet, so it defaults to "staged" on the
     # map until compute lands there.
-    "aws-eu-north-1": RegionGeo("aws-eu-north-1", "Stockholm", 59.329, 18.068, cloud="aws"),
+    "aws-eu-north-1": RegionGeo(
+        "aws-eu-north-1", "Stockholm", 59.329, 18.068, cloud="aws", label_dy=-14
+    ),
     "azure-australiaeast": RegionGeo(
-        "azure-australiaeast", "Sydney", -33.868, 151.209, cloud="azure"
+        "azure-australiaeast",
+        "Sydney",
+        -33.868,
+        151.209,
+        cloud="azure",
+        label_dx=-12,
+        label_anchor="end",
     ),
 }
 
@@ -245,6 +282,9 @@ def region_map_payload(settings: Settings) -> list[dict[str, Any]]:
                 "cloud": geo.cloud,
                 "serving": serving,
                 "status_label": "live" if serving else "edge",
+                "label_dx": geo.label_dx,
+                "label_dy": geo.label_dy,
+                "label_anchor": geo.label_anchor,
             }
         )
     return out

--- a/src/trusted_router/static/charter.css
+++ b/src/trusted_router/static/charter.css
@@ -976,6 +976,16 @@ pre {
   line-height: 1.7;
 }
 
+.charter-home-hero .lead-claim {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--text-display);
+  font-family: var(--font-body);
+  font-size: 17px;
+  font-weight: 600;
+  line-height: 1.45;
+}
+
 .charter-home-hero .hero-actions {
   margin: 30px 0 0;
 }

--- a/src/trusted_router/templates/dashboard.html
+++ b/src/trusted_router/templates/dashboard.html
@@ -49,8 +49,15 @@
     <section class="charter-home-hero">
       <div class="home-hero-copy">
         <div class="kicker">{% if alternate_brand %}Powered by TrustedRouter{% else %}Own your alpha{% endif %}</div>
-        <h1><span class="hero-line">Every model.</span><em class="hero-line">Privacy with proof.</em></h1>
-        <p class="lead">One OpenAI-compatible API for hundreds of open-weight and frontier models. Requests cross an attested gateway that does not log prompt or output content. Even our engineers cannot read your requests.</p>
+        <h1>
+          <span class="hero-line">550+ AI Models at your fingertips.</span>
+          <span class="hero-line">One Unified Interface.</span>
+          <em class="hero-line">Privacy with proof.</em>
+        </h1>
+        <p class="lead">
+          <strong class="lead-claim">Better privacy, better prices, better uptime, no subscriptions.</strong>
+          One OpenAI-compatible API for open-weight and frontier models. Requests cross an attested gateway that does not log prompt or output content. Even our engineers cannot read your requests.
+        </p>
         <div class="hero-actions">
           <button class="btn primary" type="button" data-action="open-signin">Get API key</button>
           <a class="btn" href="https://trust.trustedrouter.com">Verify trust <span aria-hidden="true">→</span></a>
@@ -86,10 +93,10 @@
     </section>
 
     <section class="charter-stat-band" aria-label="{{ brand_name }} facts">
-      <div class="charter-stat"><strong>{{ api_region_count }}</strong><span>Live regions</span></div>
-      <div class="charter-stat"><strong>Hundreds</strong><span>Models through one API</span></div>
-      <div class="charter-stat"><strong class="accent">Never</strong><span>Prompt logs</span></div>
-      <div class="charter-stat"><strong>Public</strong><span>Source and status</span></div>
+      <div class="charter-stat"><strong>550+</strong><span>AI models</span></div>
+      <div class="charter-stat"><strong>{{ live_region_count }}</strong><span>Live regions</span></div>
+      <div class="charter-stat"><strong>{{ live_cloud_count }}</strong><span>Clouds</span></div>
+      <div class="charter-stat"><strong>4</strong><span>Continents</span></div>
     </section>
 
     <section class="home-section" aria-label="How {{ brand_name }} works">
@@ -288,14 +295,14 @@ response = client.chat.completions.create(
               {% for region in map_regions %}
               <g class="region-dot {% if region.primary %}primary{% endif %} {% if region.serving %}live{% else %}edge{% endif %}" transform="translate({{ '%.1f'|format(region.x) }} {{ '%.1f'|format(region.y) }})">
                 <circle r="{% if region.primary %}9{% else %}7{% endif %}"></circle>
-                <text x="12" y="-8">{{ region.city }}{% if region.cloud == "aws" %} · AWS{% elif region.cloud == "azure" %} · Azure{% endif %}</text>
+                <text x="{{ region.label_dx }}" y="{{ region.label_dy }}" text-anchor="{{ region.label_anchor }}">{{ region.city }}{% if region.cloud == "aws" %} · AWS{% elif region.cloud == "azure" %} · Azure{% endif %}</text>
               </g>
               {% endfor %}
             </svg>
           </div>
           <div class="region-map-copy">
-            <strong>Live routing on four continents</strong>
-            <span>{{ api_region_count }} live GCP regions, plus independent AWS and Azure deployments. Serving North America, South America, Europe, and Australia today.</span>
+            <strong>{{ live_region_count }} live regions across {{ live_cloud_count }} clouds and 4 continents</strong>
+            <span>TrustedRouter runs across GCP, AWS, and Azure, serving North America, South America, Europe, and Australia today.</span>
           </div>
         </div>
       </div>

--- a/tests/browser/dashboard.spec.js
+++ b/tests/browser/dashboard.spec.js
@@ -3,11 +3,20 @@ const { expect, test } = require("@playwright/test");
 test("homepage opens sign-in modal and handles missing MetaMask", async ({ page }) => {
   await page.goto("/");
 
-  await expect(page.getByRole("heading", { name: "Every model. Privacy with proof." })).toBeVisible();
+  await expect(page.getByRole("heading", {
+    name: "550+ AI Models at your fingertips. One Unified Interface. Privacy with proof.",
+  })).toBeVisible();
   const headlineLines = page.locator(".charter-home-hero h1 .hero-line");
-  await expect(headlineLines).toHaveCount(2);
+  await expect(headlineLines).toHaveCount(3);
   await expect(headlineLines.first()).toHaveCSS("display", "block");
   await expect(headlineLines.last()).toHaveCSS("display", "block");
+  await expect(page.locator(".charter-home-hero .lead-claim")).toHaveText(
+    "Better privacy, better prices, better uptime, no subscriptions.",
+  );
+  await expect(page.locator(".charter-stat-band")).toContainText("550+AI models");
+  await expect(page.locator(".charter-stat-band")).toContainText("7Live regions");
+  await expect(page.locator(".charter-stat-band")).toContainText("3Clouds");
+  await expect(page.locator(".charter-stat-band")).toContainText("4Continents");
   await expect(page.locator("body")).toHaveCSS("font-size", "15.5px");
   await expect(page.locator(".charter-pillar p a").first()).toHaveCSS("text-decoration-line", "underline");
 
@@ -395,7 +404,9 @@ test("homepage and console redirect are usable on mobile width", async ({ page }
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto("/");
 
-  await expect(page.getByRole("heading", { name: "Every model. Privacy with proof." })).toBeVisible();
+  await expect(page.getByRole("heading", {
+    name: "550+ AI Models at your fingertips. One Unified Interface. Privacy with proof.",
+  })).toBeVisible();
   let overflow = await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth);
   expect(overflow).toBeLessThanOrEqual(2);
 

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -647,8 +647,13 @@ def test_dashboard_links_to_public_models_not_keyed_api_catalog(client: TestClie
     # Redesigned homepage (2026-06): a static routing-diagram hero replaces the
     # animated orbital scene, on the friend-provided modern layout. Assert the
     # new conversion surface rather than the old orbital-scene markup.
-    assert "Every model." in response.text  # homepage tagline
+    assert "550+ AI Models at your fingertips." in response.text
+    assert "One Unified Interface." in response.text
     assert "Privacy with proof." in response.text
+    assert "Better privacy, better prices, better uptime, no subscriptions." in response.text
+    assert '<strong>7</strong><span>Live regions</span>' in response.text
+    assert '<strong>3</strong><span>Clouds</span>' in response.text
+    assert '<strong>4</strong><span>Continents</span>' in response.text
     assert "Provable privacy." not in response.text
     assert "ATTESTED GATEWAY" in response.text  # attestation record
     assert "Get API key" in response.text  # primary CTA

--- a/tests/test_region_map_projection.py
+++ b/tests/test_region_map_projection.py
@@ -155,7 +155,7 @@ def test_map_shows_multicloud_deployments_with_honest_serving_flags() -> None:
 
     The serving flag is a factual claim — external_live_regions must only list
     deployments whose own smoke passes — so this pins the shipped default:
-    Dublin and Sydney live, Stockholm (database peer, no compute) staged.
+    Dublin, Paris, and Sydney live; Stockholm (database peer, no compute) staged.
     """
     settings = Settings(environment="local")
     rows = {row["id"]: row for row in region_map_payload(settings)}
@@ -164,13 +164,26 @@ def test_map_shows_multicloud_deployments_with_honest_serving_flags() -> None:
     assert rows["aws-eu-west-1"]["cloud"] == "aws"
     assert rows["aws-eu-west-1"]["serving"] is True
 
+    assert rows["aws-eu-west-3"]["city"] == "Paris"
+    assert rows["aws-eu-west-3"]["cloud"] == "aws"
+    assert rows["aws-eu-west-3"]["serving"] is True
+    assert rows["aws-eu-west-3"]["label_dy"] > 0
+
     assert rows["azure-australiaeast"]["cloud"] == "azure"
     assert rows["azure-australiaeast"]["serving"] is True
+    assert rows["azure-australiaeast"]["label_anchor"] == "end"
 
     # Stockholm replicates the AWS-EU database but has no compute yet. If this
     # assertion starts failing because someone flipped it live, that flip must
     # come with compute actually serving there.
     assert rows["aws-eu-north-1"]["serving"] is False
+
+    assert sum(row["serving"] for row in rows.values()) == 7
+    assert {row["cloud"] for row in rows.values() if row["serving"]} == {
+        "gcp",
+        "aws",
+        "azure",
+    }
 
     # No duplicate cities on the map (Joseph's rule): the Azure Sydney entry
     # must not coexist with GCP's australia-southeast1 Sydney dot.


### PR DESCRIPTION
## Summary
- replace the homepage hero with the new 550+ models and privacy-with-proof message
- surface the 7-region, 3-cloud, 4-continent footprint
- derive region and cloud counts from serving region metadata
- add the live AWS Paris region and improve crowded map label placement

## Verification
- focused pytest suite: 21 passed
- Playwright desktop/mobile homepage smoke: 2 passed
- ruff, mypy, ESLint, and Stylelint passed
- visual QA completed at desktop and mobile viewports