### PR TITLE
Don't send Aurora DSQL a statement_timeout it answers with an error

### DIFF
--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -427,6 +427,17 @@ class PostgresStore:
         if transaction_attempts < 1:
             raise ValueError("transaction_attempts must be positive")
         self._transaction_attempts = transaction_attempts
+        # Aurora DSQL refuses the GUC outright -- `SET LOCAL statement_timeout`
+        # answers `ERROR: setting configuration parameter "statement_timeout"
+        # not supported` -- so issuing it does not merely fail to bound the
+        # query, it raises and takes the whole read with it. That is how the
+        # AWS-EU control plane published
+        # `analytics: {available: false, reason: "unreachable"}` for an outbox
+        # it could in fact read: the timeout added to make the read safe was
+        # the only reason it failed. What still bounds these reads on DSQL is
+        # the pool-acquire timeout below and, for the status page, the
+        # caller-side wait in routes/public.py.
+        self._supports_statement_timeout = postgres_iam_auth != _AWS_DSQL_IAM_AUTH
         if not postgres_iam_auth:
             self._pool = ConnectionPool(
                 conninfo=dsn,
@@ -477,12 +488,23 @@ class PostgresStore:
         """Close the connection pool."""
         self._pool.close()
 
+    def _bound_statement(self, conn: Any, seconds: float) -> None:
+        """Cap one statement server-side where the backend allows it.
+
+        Silent on DSQL by design, not by accident: see
+        `_supports_statement_timeout`. Callers must still hold their own bound
+        (a pool-acquire timeout, and a caller-side wait for anything on a
+        request path), because on DSQL this call does nothing.
+        """
+        if self._supports_statement_timeout:
+            conn.execute(f"SET LOCAL statement_timeout = '{seconds:g}s'")
+
     def readiness_check(self) -> None:
         """Verify the billing database without permitting an unbounded wait."""
 
         with self._pool.connection(timeout=3.0) as conn:
             with conn.transaction():
-                conn.execute("SET LOCAL statement_timeout = '3s'")
+                self._bound_statement(conn, 3.0)
                 conn.execute("SELECT 1 FROM tr_credit_balance LIMIT 1").fetchone()
 
     def apply_schema(self) -> None:
@@ -4500,9 +4522,7 @@ class PostgresStore:
         try:
             with self._pool.connection(timeout=OUTBOX_FRESHNESS_TIMEOUT_SECONDS) as conn:
                 with conn.transaction():
-                    conn.execute(
-                        f"SET LOCAL statement_timeout = '{OUTBOX_FRESHNESS_TIMEOUT_SECONDS:g}s'"
-                    )
+                    self._bound_statement(conn, OUTBOX_FRESHNESS_TIMEOUT_SECONDS)
                     oldest = outbox.oldest_enqueued_at_tx(conn)
         except Exception as exc:
             log.exception(

--- a/tests/test_operational_analytics_outbox_postgres.py
+++ b/tests/test_operational_analytics_outbox_postgres.py
@@ -1291,3 +1291,42 @@ def test_the_drain_and_the_status_page_run_the_identical_lag_statement() -> None
     )
 
     assert SELECT_OLDEST_SQL is SELECT_OLDEST_ENQUEUED_AT_SQL
+
+
+def test_dsql_is_not_sent_a_statement_timeout_it_rejects() -> None:
+    """Aurora DSQL answers `SET LOCAL statement_timeout` with an ERROR.
+
+    Not "ignores it" -- it raises, which aborts the transaction and takes the
+    read with it. The AWS-EU control plane published
+    `analytics: {available: false, reason: "unreachable"}` for an outbox it
+    could read perfectly well, because the bound added to make that read safe
+    was the only thing failing. Verified against the live cluster 2026-08-18:
+
+        ERROR:  setting configuration parameter "statement_timeout" not supported
+
+    So the statement bound is issued only where the backend accepts it, and the
+    caller keeps its own (pool-acquire timeout; a caller-side wait on the
+    status path). This test pins the decision, not the plumbing.
+    """
+    from trusted_router.storage_postgres import PostgresStore
+
+    executed: list[str] = []
+
+    class _Conn:
+        def execute(self, sql: str, *_a: object, **_k: object) -> object:
+            executed.append(sql)
+            return _Rows()
+
+    class _Rows:
+        def fetchone(self) -> tuple[int, ...]:
+            return (1,)
+
+    store = PostgresStore.__new__(PostgresStore)
+
+    store._supports_statement_timeout = False  # DSQL
+    store._bound_statement(_Conn(), 3.0)
+    assert executed == [], f"DSQL was sent {executed!r}, which it rejects"
+
+    store._supports_statement_timeout = True  # stock Postgres
+    store._bound_statement(_Conn(), 3.0)
+    assert executed == ["SET LOCAL statement_timeout = '3s'"], executed


### PR DESCRIPTION
Found by deploying the AWS-EU control plane and letting the new rollout gate check it — the gate exited 1 on its first production run, correctly.

The service published `analytics: {"available": false, "reason": "unreachable"}` for an outbox it can read fine. The bound added to make the read safe was the only thing failing:

```
postgres=> BEGIN; SET LOCAL statement_timeout = '3s';
ERROR:  setting configuration parameter "statement_timeout" not supported
```

DSQL rejects the GUC rather than ignoring it, and the error aborts the transaction. `readiness_check` carries the same call, so it has been raising on both Postgres clouds since it was written — fixed too.

The store already knows its backend (it mints DSQL tokens), so the statement bound is issued only where accepted. On DSQL the remaining bounds are the pool-acquire timeout and the caller-side wait on the status path — said in the helper's docstring so the silence isn't later read as an oversight.

Gates: ruff + mypy clean, full suite 4910 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)