### PR TITLE
Give Azure a real analytics pipeline: two nodes, one drain, flag last

### DIFF
--- a/clickhouse/tr-clickhouse-operational-ingest-postgres.service
+++ b/clickhouse/tr-clickhouse-operational-ingest-postgres.service
@@ -35,6 +35,12 @@ Environment=HOME=/var/lib/tr-clickhouse-ingest
 # connection, and on plain Postgres libpq reads PGPASSWORD from this file
 # rather than from argv, where every local user could read it.
 #
+# AZURE uses that second path. Flexible Server has no IAM token, so the Azure
+# node's file omits TR_POSTGRES_IAM_AUTH entirely and supplies PGPASSWORD for a
+# role granted SELECT, DELETE on the outbox table and nothing else. The HOME
+# line above matters MORE there, not less: libpq looks for the client
+# certificate on every connect regardless of how the password arrives.
+#
 # SECOND DURABLE COPY (optional, additive). Setting
 # TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_REPLICA_HOST turns the drain into a
 # dual-write: it writes each batch to the local node AND to that host, and

--- a/docs/clickhouse-reliability.md
+++ b/docs/clickhouse-reliability.md
@@ -285,10 +285,11 @@ header spells out.
 
 Two states are neither pass nor fail, and are printed as `(unchecked)` on every
 run rather than skipped: a cloud with no public status page (`reason=`), and a
-cloud that legitimately runs no outbox (`expects_outbox=False` — Azure today,
-whose deploy script sets no `TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED`). The
-second one becomes a **failure** the day that cloud publishes a real lag, which
-is the day it needs watching.
+cloud that legitimately runs no outbox (`expects_outbox=False`). The second one
+becomes a **failure** the day that cloud publishes a real lag, which is the day
+it needs watching. Azure was its only user until 2026-08-18 and is not any more:
+it now has two ClickHouse nodes, a drain, and a control-plane script that states
+the flag, so all three clouds are measured and none is excused.
 
 To ask about one cloud during an incident:
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1134,8 +1134,11 @@ failure mode this exists to stop.
 starts answering when a control plane built from the publisher is deployed to
 it, and exits 5 until then. The last reading taken while editing this section
 was `gcp` VERIFIED with `aws` and `azure` both at 5, and it is a note about a
-moment rather than a claim about now. Azure additionally fails stage (e): it has
-no operational-analytics outbox at all. See
+moment rather than a claim about now. Azure used to fail stage (e) as well —
+its control-plane script set no outbox variable at all — and now passes it
+statically, which means only that the script CAN enable the outbox, not that any
+deployed revision has. Walking it from nodes to flag is
+`docs/storage-portability/azure-analytics-runbook.md`; see
 `docs/storage-portability/multi-cloud-separation.md` §7 for the full definition
 of done and the checklist for a new cloud.
 

--- a/docs/storage-portability/azure-analytics-runbook.md
+++ b/docs/storage-portability/azure-analytics-runbook.md
@@ -1,0 +1,336 @@
+# Azure operational analytics: the operator's runbook
+
+**Status:** written 2026-08-18, alongside the scripts. **Nothing in it has been
+executed.** Every command below is what the code does; the Azure ARM control
+plane was unreachable from the machine that wrote this (an expired session, not
+a permission), so no resource named here has been observed to exist. Read the
+"what working looks like" line at each stage and believe the output, not this
+page.
+
+This is the ordered procedure for giving the Azure cloud an
+operational-analytics pipeline: two ClickHouse nodes, a scoped database role, a
+drain that writes both copies before it deletes anything, and — LAST — the flag
+that starts producing rows.
+
+## Why the order is the whole document
+
+From 2026-08-02 to 2026-08-17 the AWS-EU cloud ran with the producer on and the
+consumer missing. 470,897 rows piled into the outbox, `SELECT count() FROM
+activity_generations` returned 0, and every status page was green. Nothing
+reported it, because the alarm that bounds outbox growth is emitted BY the drain
+that did not exist.
+
+Enabling `TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED` before stages 1–5 are done
+reproduces that on purpose. It is the last stage here for exactly that reason,
+and `azure_control_plane.sh` computes the flag from whether a ClickHouse target
+exists rather than taking it from you.
+
+## What the finished thing is
+
+| | |
+|---|---|
+| uaenorth (Dubai) | `tr-azure-clickhouse-uaenorth` in `vnet-prod`, and the drain runs here |
+| southeastasia (Singapore) | `tr-azure-clickhouse-southeastasia` in its own VNet, joined by global VNet peering |
+| What each holds | **The same rows.** This is a durability replica, not a residency split |
+| What crosses a cloud boundary | Nothing. Azure rows stay in Azure; no row goes to GCP or AWS, and none arrives from them |
+| Cost | ≈ $270/month: two `Standard_E2s_v5` ($113.15/mo each at uaenorth prices read 2026-08-18), two 128 GiB Premium SSDs ($21.50 each), two public IPs (~$3.65 each), plus $0.25/GB of peering traffic — one copy of each drained batch, both sides billed |
+
+One drain, not two. Two drains against one outbox would each DELETE rows the
+other had not yet written, and every row would land on exactly one node — which
+looks like replication and is the precise opposite of it.
+
+---
+
+## Stage 0 — before you start
+
+```bash
+az login --tenant 2abe2fae-5c28-491d-af5a-6255b33e534e
+az account show --query '{name:name, id:id}' -o json
+az group list -o table
+```
+
+**Working:** the subscription is `2fc83893-ca6c-48e4-b090-8860fba33d33` and
+`az group list` returns rows.
+
+**Not working:** `AADSTS50132: The session is not valid due the following
+reasons: password expiration or recent password change`. The cached profile
+answers `az account show` from disk and every ARM call fails. Re-run `az login`;
+there is no non-interactive path in this subscription — no service principal
+exists.
+
+While you are here, take the readings this plan was written without, because
+three of its defaults are inferences:
+
+```bash
+az network vnet show -g tr-azure -n vnet-prod \
+  --query '{cidrs:addressSpace.addressPrefixes, subnets:subnets[].{n:name,p:addressPrefix}}' -o json
+az containerapp show -g tr-azure -n tr-azure-vnet --query 'properties.template.containers[0].env' -o json
+az network private-dns zone list -o table
+az vm list-skus -l uaenorth --size Standard_E --all -o table
+az vm list-skus -l southeastasia --size Standard_E --all -o table
+```
+
+If `10.61.3.0/24` is taken, set `PRIMARY_SUBNET_CIDR` — the script checks and
+refuses rather than colliding. If `Standard_E2s_v5` is not offered in
+southeastasia, set `VM_SIZE` for that invocation; the two nodes do not have to
+match.
+
+---
+
+## Stage 1 — the uaenorth node
+
+```bash
+bash scripts/deploy/azure_clickhouse.sh uaenorth
+```
+
+Creates the subnet and its NSG, a user-assigned identity, a Key Vault with the
+ClickHouse password and the drain's future Postgres password, the VM, and then
+applies `clickhouse/006` + `clickhouse/009` and counts the tables.
+
+**Working:** the report block prints a private address and `tables the drain
+writes, present on this node: 8`, and the script then exits **5** with `NOT YET
+OBSERVABLE`. Exit 5 is the expected answer at this stage — no control plane
+publishes an `analytics` section yet — and the script is not permitted to
+pretend otherwise by exiting 0.
+
+**Not working:**
+
+* `FATAL: no VNet 'vnet-prod'` — wrong subscription or the network was renamed.
+  The script will not create production networking on a typo.
+* `subnet 10.61.3.0/24 overlaps existing subnets [...]` — pick a free range with
+  `PRIMARY_SUBNET_CIDR`.
+* `remote step did not complete: apply and verify the schema` — cloud-init has
+  not finished, or it failed. `az vm run-command invoke -g tr-azure -n
+  tr-azure-clickhouse-uaenorth --command-id RunShellScript --scripts "tail -50
+  /var/log/cloud-init-output.log"`. The usual causes are the identity not yet
+  having Key Vault read (it retries for five minutes, then gives up) and apt
+  being unable to reach `packages.clickhouse.com`, which means the node has no
+  egress.
+* ClickHouse is running but refuses the password — check ownership of
+  `/etc/clickhouse-server/users.d/default-password.xml`. It must be
+  `clickhouse:clickhouse`; a root-owned file is unreadable to the server after
+  it drops privileges and the process dies in `UsersConfigAccessStorage::load`
+  with a stack trace that never names the permission.
+
+## Stage 2 — the southeastasia node and the peering
+
+```bash
+bash scripts/deploy/azure_clickhouse.sh southeastasia
+```
+
+Same shape, plus: its own resource group, VNet and vault; global VNet peering
+created **from both ends**; and a grant letting the uaenorth node's identity
+read this region's ClickHouse password.
+
+**Working:** `peering peer-to-uaenorth: Connected` and `peering
+peer-to-southeastasia: Connected`, both printed. Then exit 5 again.
+
+**Not working:**
+
+* `peering ... is 'Initiated', not Connected` — only one half exists. A
+  one-sided peering drops every packet while both resources look healthy. Let
+  the script create the other half, or delete both and re-run.
+* `no identity 'tr-azure-analytics-uaenorth-id'` — you ran this before stage 1.
+  Order matters here and nowhere else.
+* `PEER_VNET_CIDR ... overlaps the primary VNet` — global peering cannot join
+  overlapping address spaces at all.
+
+## Stage 3 — the scoped Postgres role
+
+The drain must **not** log in as `tradmin`. `tradmin` can read `tr_entities`,
+which holds raw member emails and workspace ids — the identifiers
+`analytics_surrogate()` exists to keep off the analytics host. The role it uses
+gets `SELECT, DELETE` on one table and nothing else.
+
+The password already exists, in Key Vault, generated by stage 1 and never read
+by it. Pipe it into `psql`; do not paste it, do not put it in a file, and do not
+pass it as `-v drain_password=...` (that is argv, and argv is readable by every
+local user through `ps`).
+
+```bash
+MYIP=$(curl -fsS https://api.ipify.org)
+az postgres flexible-server firewall-rule create -g tr-azure -s tr-azure-pg \
+  --name tmp-drain-role --start-ip-address "$MYIP" --end-ip-address "$MYIP"
+
+{
+  printf "\\set drain_password '"
+  az keyvault secret show --vault-name tr-azure-analytics-kv \
+    -n drain-postgres-password --query value -o tsv | tr -d '\n'
+  printf "'\n"
+  cat scripts/deploy/sql/azure_operational_outbox_drain_role.sql
+} | psql "host=tr-azure-pg.postgres.database.azure.com port=5432 \
+          user=tradmin dbname=trustedrouter sslmode=require" \
+      -v ON_ERROR_STOP=1 -f -
+
+az postgres flexible-server firewall-rule delete -g tr-azure -s tr-azure-pg \
+  --name tmp-drain-role --yes
+```
+
+**Working:** the last statement prints one row with `can_select_outbox = t`,
+`can_delete_outbox = t`, `can_read_entities_MUST_BE_FALSE = f`, and the three
+role attributes false.
+
+**Not working:**
+
+* `psql: could not connect` — the temporary firewall rule takes a few seconds,
+  and `tr-azure-pg` has no other public rule. Wait, retry, and remember to
+  delete the rule afterwards whatever happens. A temporary widening that is
+  skipped on the failure path is how it becomes permanent.
+* `can_delete_outbox = f` — the quietest possible failure if you leave it:
+  every row is delivered, every metric reads healthy, and the outbox grows
+  forever because nothing removes anything. Stage 4 refuses to install for
+  exactly this.
+* `can_read_entities_MUST_BE_FALSE = t` — the role inherited a broad grant.
+  Find it (`\dp tr_entities`) and remove it; do not proceed.
+
+## Stage 4 — the drain
+
+```bash
+bash scripts/deploy/azure_clickhouse_drain_install.sh
+```
+
+Preflights the private DNS path and the second node, ships the repo's current
+code in ~15 chunks, builds a venv, imports it in staging before swapping,
+writes `/etc/tr-clickhouse-ingest-postgres.env` from secrets **the node
+fetches**, proves the role is scoped, installs the unit, and prints the journal
+and two row counts.
+
+**Working:** `copies=2 degraded_targets=-` in the metrics line, and both
+ClickHouse counts printed. They will be **0**, and that is correct — nothing is
+being enqueued yet. Then exit 5.
+
+**Not working:**
+
+* `no private DNS zone 'privatelink.postgres.database.azure.com'`, or a zone not
+  linked to `vnet-prod` — the node would resolve the *public* address of a
+  server with zero firewall rules and time out every connection while the unit
+  reported itself active. Create and link the zone; this is the single most
+  likely blocker in the whole runbook and the reason it is checked first.
+* `cannot find the southeastasia node` — stage 2 has not run. If one copy is
+  genuinely what you want, say so out loud: `REQUIRE_REPLICA=0`. A silent
+  single-target drain deletes rows the second node never received and logs
+  `copies=1`, identical to a deliberate one-node deployment.
+* `the drain role can read tr_entities` — go back to stage 3.
+* the unit is `failed` with status **78** — `CONFIG_EXIT_CODE`. The environment
+  file is wrong and `RestartPreventExitStatus` stopped it deliberately rather
+  than crash-loop every five seconds while the outbox grew.
+  `journalctl -u tr-clickhouse-operational-ingest-postgres | grep config_invalid`
+  names the variable. A `*_REPLICA*` name this drain does not recognise is
+  refused rather than ignored, because an ignored replica setting looks exactly
+  like a working two-copy deployment.
+* rollback: `systemctl disable --now tr-clickhouse-operational-ingest-postgres`
+  and `mv /opt/tr-clickhouse.previous /opt/tr-clickhouse`. Nothing is lost by
+  stopping the drain — undelivered rows stay in the outbox.
+
+## Stage 5 — watch it do nothing, on purpose
+
+Before turning the producer on, confirm the consumer is alive and idle:
+
+```bash
+az vm run-command invoke -g tr-azure -n tr-azure-clickhouse-uaenorth \
+  --command-id RunShellScript \
+  --scripts "journalctl -u tr-clickhouse-operational-ingest-postgres -n 30 --no-pager"
+```
+
+**Working:** a metrics line every couple of seconds with `rows=0`,
+`drain_lag_seconds=-1.000` or `0.000`, `copies=2`, `degraded_targets=-`.
+
+**Not working:** no metrics lines at all means the loop is not running; a
+`degraded_targets=southeastasia` before any traffic means the peering or that
+node's NSG is wrong, and it is far cheaper to fix now than under load.
+
+## Stage 6 — the flag, and only now
+
+```bash
+bash scripts/deploy/azure_control_plane.sh
+```
+
+There is nothing to edit. The script finds the node's private address and the
+vault secret, and sets `TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true` because
+they exist. If it prints `no ClickHouse target ... analytics disabled for this
+service`, stop: a stage above did not do what you think it did.
+
+**Working:** `analytics ON: outbox enabled, ClickHouse at http://10.61.x.x:8123`,
+the deploy completes, and the app comes up on a new revision **by digest** (a
+mutable tag would let Container Apps re-use the old image with the new
+environment).
+
+**Not working:** if the deploy succeeds and the outbox line said `false`, you
+have just deployed a control plane that enqueues nothing. That is safe, and it
+is not done.
+
+## Stage 7 — prove rows move
+
+Two numbers, ten minutes apart. No status page substitutes for this.
+
+```bash
+az vm run-command invoke -g tr-azure -n tr-azure-clickhouse-uaenorth \
+  --command-id RunShellScript --scripts \
+  'set -a; . /etc/tr-clickhouse-ingest-postgres.env; set +a;
+   CLICKHOUSE_PASSWORD="$CH_PASSWORD" clickhouse-client --user default --database default \
+     --query "SELECT count() FROM activity_generations";
+   CLICKHOUSE_PASSWORD="$CH_REPLICA_PASSWORD" clickhouse-client \
+     --host "$TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_REPLICA_HOST" \
+     --user default --database default \
+     --query "SELECT count() FROM activity_generations"'
+```
+
+**Working:** both numbers non-zero, both rising, and close to each other.
+
+**Not working:** uaenorth rising and southeastasia flat means the fan-out is
+failing and — importantly — nothing is being deleted, so the outbox is
+absorbing the backlog rather than losing it. Look for `degraded_targets=` and
+`backlog_alarm` in the journal. The two supported responses are to restore the
+second node, or to remove its `_REPLICA_` variables and restart, after which
+that node is permanently behind and needs an out-of-band backfill.
+
+## Stage 8 — from outside
+
+```bash
+bash scripts/deploy/verify_cloud_complete.sh azure
+curl -s https://azure.trustedrouter.com/status.json | jq .data.analytics
+```
+
+**Working:** `VERIFIED — azure passed every stage`, and the `analytics` object
+carries `available: true` with a `drain_lag_seconds` under the bound the drain
+itself alarms on.
+
+**Not working:**
+
+* exit **5**, `NOT YET OBSERVABLE` — the deployed revision predates stage 6, or
+  the deploy did not take. Check that the running revision is the digest that
+  was just pushed.
+* exit **1** with stage (c) failing — `analytics.available` is false. The
+  control plane could not read its own outbox; that is a database problem, not a
+  drain problem.
+* exit **1** with stage (d) failing — the lag is past the bound. The drain is
+  behind or dead. Go back to stage 5's journal.
+
+## Stage 9 — start watching it
+
+`src/trusted_router/operational_analytics_fleet.py` already carries
+`expects_outbox=True` for Azure: it landed in the commit that built this
+pipeline, which means the fleet check FAILS for Azure from that commit until
+stage 6 has actually run. That is deliberate — the alternative is an entry that
+records an expected absence while a pipeline sits half-built — but it does mean
+the failure is load-bearing information rather than noise, and it should be red
+for hours, not weeks.
+
+Once all three clouds publish a live lag, the last thing to do is give
+`.github/workflows/check-analytics-freshness.yml` a `schedule:` trigger. Today
+it ships with `workflow_dispatch` as its only trigger, deliberately and in its
+own header, so *nothing is watching any of this on a schedule* — including the
+cloud you just finished.
+
+## What this pipeline still cannot tell you
+
+* Nothing here proves a row is *correct*, only that it arrived.
+* The rollup and snapshot jobs (`synthetic_status_rollups`,
+  `client_availability_rollups`, `public_analytics_snapshots`) are GCP timers.
+  On Azure nothing writes them, so both nodes hold those tables empty and the
+  second node is a complete copy of what the drain writes — not of everything
+  the schema can hold.
+* Stage (e) of the gate is a static read of a file in your working tree.
+  Anybody who wants to beat it can. It is kept because the alternative needs
+  production credentials, and a check that needs those is a check that does not
+  get run.

--- a/docs/storage-portability/multi-cloud-separation.md
+++ b/docs/storage-portability/multi-cloud-separation.md
@@ -276,7 +276,8 @@ for it.
 Bring-up is not a menu. Every cloud's bring-up and control-plane deploy scripts
 end by running the check and exit non-zero when it fails —
 `aws_eu_clickhouse.sh`, `aws_eu_north_clickhouse.sh`, `aws_eu_control_plane.sh`,
-`aws_eu_clickhouse_drain_install.sh`, `azure_control_plane.sh`, and for GCP the
+`aws_eu_clickhouse_drain_install.sh`, `azure_clickhouse.sh`,
+`azure_clickhouse_drain_install.sh`, `azure_control_plane.sh`, and for GCP the
 out-of-band `verify_gcp_complete.sh`. Where a remaining step genuinely needs a
 human (a cost decision, a password that only exists on a node), the script
 prints the exact command **and exits non-zero**. It never prints and returns 0;
@@ -336,6 +337,8 @@ and the second move is a diff a reviewer reads.
 - `scripts/deploy/aws_eu_clickhouse.sh`
 - `scripts/deploy/aws_eu_control_plane.sh`
 - `scripts/deploy/aws_eu_north_clickhouse.sh`
+- `scripts/deploy/azure_clickhouse.sh`
+- `scripts/deploy/azure_clickhouse_drain_install.sh`
 - `scripts/deploy/azure_control_plane.sh`
 - `scripts/deploy/verify_gcp_complete.sh`
 <!-- PROVEN_BY_EXECUTION:end -->
@@ -349,7 +352,20 @@ and the second move is a diff a reviewer reads.
 Its middle ships a tarball to the node in base64 chunks over SSM and then reads
 the drain's own journal back to establish that rows moved; a stub SSM that
 answers `Status=Success` to everything would make that verification an assertion
-about the stub. It is recorded as `NOT_PROVEN` in `ROLLOUT_REGISTRY` with that
+about the stub.
+
+**The Azure drain installer is in the proven list, and that difference is worth
+stating rather than glossing.** `azure_clickhouse_drain_install.sh` ships its
+payload the same way, over `az vm run-command` instead of SSM, and the harness
+answers that channel from a fixture too. What running it establishes is
+therefore exactly the two behavioural properties and no more: it CALLS the gate
+for `azure`, and every code the gate can return comes out of it unaltered — plus
+that it parses under this machine's bash, which is not nothing (a heredoc inside
+`$( )` once took a whole deploy script out on macOS while CI stayed green). What
+it does not establish is anything about the middle: the chunked transfer, the
+scoped-role check and the row counts all assert against the stub under the
+harness. The evidence that rows moved is in-cloud and unchanged — `SELECT
+count() FROM activity_generations`, twice, ten minutes apart. It is recorded as `NOT_PROVEN` in `ROLLOUT_REGISTRY` with that
 reason, and a `NOT_PROVEN` entry with a blank reason fails CI. What *is* proven
 about it is that the shared fragment it calls —
 `scripts/deploy/cloud_complete_gate.sh` — returns the gate's exit status
@@ -498,11 +514,24 @@ under it, and this paragraph has already been wrong once. Ask:
 The last reading taken while editing this section: `gcp` VERIFIED, `aws` and
 `azure` both 5. That is a note about a moment, not a claim about now.
 
-**Azure has no operational-analytics outbox.** `azure_control_plane.sh` sets no
-`TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED` at all, so the cloud enqueues nothing,
-has nothing to drain, and stage (e) fails. It is a canary
-(`aws-eu-and-azure-canary.md` §3) and it still counts: a canary whose operational
-history is unrecorded cannot answer the question canaries exist to answer.
+**Azure's analytics pipeline exists in this repository and not yet on the
+wire.** `azure_control_plane.sh` now STATES
+`TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED` instead of letting it default, and
+computes it from whether a ClickHouse node and its Key Vault secret exist — so
+the flag is off until the sink is real and on the moment it is.
+`azure_clickhouse.sh` builds two nodes (uaenorth and southeastasia, joined by
+global VNet peering) and `azure_clickhouse_drain_install.sh` installs the single
+drain that writes BOTH copies before deleting anything. Two regions here is
+DURABILITY, not residency: both nodes hold the same rows, and no row leaves
+Azure.
+
+None of that is deployed by writing it down. Until an operator has walked
+`azure-analytics-runbook.md`, Azure's stage (e) passes on the checkout and the
+cloud still publishes no `analytics` section, so the gate exits 5 — and
+`operational_analytics_fleet.py` now carries `expects_outbox=True` for Azure,
+which means the fleet check FAILS for it rather than recording an expected
+absence. That failure is the correct reading of this moment: the pipeline is
+written, and a written pipeline moves no rows.
 
 ### Checklist for the next cloud
 

--- a/scripts/deploy/azure_clickhouse.sh
+++ b/scripts/deploy/azure_clickhouse.sh
@@ -1,0 +1,724 @@
+#!/usr/bin/env bash
+# ClickHouse for the AZURE cloud: analytics that belong to THIS cloud.
+#
+# Two nodes, two regions, ONE invocation each:
+#
+#     bash scripts/deploy/azure_clickhouse.sh uaenorth        # 1st: the drain host
+#     bash scripts/deploy/azure_clickhouse.sh southeastasia   # 2nd: the second copy
+#
+# The order is not a style preference. The southeastasia run grants the
+# uaenorth node's managed identity read access to the southeastasia vault (so
+# the drain can fetch CH_REPLICA_PASSWORD without the password passing through
+# an operator's shell) and it builds the peering from both ends. Run it first
+# and it stops, naming the identity it could not find.
+#
+# WHY THIS EXISTS
+# ---------------
+# Azure has no operational-analytics pipeline at all. azure_control_plane.sh
+# sets no TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED, so settle enqueues nothing,
+# there is nothing to drain and no drain — which is why stage (e) of
+# scripts/deploy/verify_cloud_complete.sh fails for this cloud. This is the
+# first of the four things that must exist before that flag may be turned on,
+# and it is deliberately FIRST: enabling the flag before a sink and a drain
+# exist reproduces the Paris outage on purpose (470,897 undelivered rows over
+# fifteen days, behind an entirely green status page, because the only backlog
+# alarm is emitted BY the drain that was missing).
+#
+# THIS IS A PORT OF THE SHAPE, NOT A REUSE
+# ----------------------------------------
+# scripts/deploy/aws_eu_clickhouse.sh (Paris) and
+# scripts/deploy/aws_eu_north_clickhouse.sh (Stockholm) are aws-CLI-coupled at
+# every provisioning step. What carries over is the design and the scars:
+#
+#   * ClickHouse binds the PRIVATE address only. Never 0.0.0.0.
+#   * The users.d password file is chown clickhouse:clickhouse — the server
+#     drops privileges, so a root-owned 0600 file is unreadable to it and the
+#     process dies in UsersConfigAccessStorage::load with a stack trace that
+#     never names the permission. That cost a debugging cycle on Paris; it is
+#     repeated here rather than rediscovered.
+#   * The second region is a DURABILITY replica and not a Keeper quorum:
+#     across exactly two members a quorum cannot form a majority when either
+#     dies, so losing a region would FREEZE WRITES on the survivor. Both nodes
+#     run plain ReplacingMergeTree and do not know about each other; the drain
+#     writes both and deletes the outbox rows only once both accepted.
+#
+# WHAT EACH REGION HOLDS, stated plainly because it is easy to misread: BOTH
+# nodes hold the SAME rows. uaenorth is where the drain runs and writes first;
+# southeastasia is a second, independent copy of the same operational history.
+# This is NOT a residency split — rows from either Azure enclave region land in
+# both nodes — and it is not an EU deployment: Dubai and Singapore are where
+# this cloud lives. Azure rows stay in Azure. Nothing here replicates to GCP or
+# AWS and nothing there replicates here.
+#
+# WHY GLOBAL VNET PEERING FOR THE INTER-REGION PATH
+# -------------------------------------------------
+# Priced live from the retail API on 2026-08-18: global peering bills BOTH
+# sides — $0.16/GB egress at uaenorth plus $0.09/GB ingress at southeastasia =
+# $0.25/GB — and the only traffic on the link is one copy of each drained
+# batch. At 20 GB/month that is $5. The alternatives are worse for this job: a
+# VPN gateway adds a per-hour appliance ($26/mo at Basic, considerably more
+# zone-redundant) and its own failure domain, and a public path would put an
+# analytics store on the internet behind a password.
+#
+# A peering must be created from BOTH ends. One side alone sits in state
+# "Initiated" and every packet is dropped — the Azure spelling of the Transit
+# Gateway trap the Stockholm script documents. This creates both and then
+# asserts Connected on both.
+#
+# WHY THE NODES HAVE A PUBLIC IP AND ARE STILL PRIVATE
+# ----------------------------------------------------
+# apt must reach packages.clickhouse.com to install ClickHouse at all, and
+# Azure retired default outbound access for new VMs, so a node with no public
+# address and no NAT gateway has no egress and cannot be built. A NAT gateway
+# is ~$33/month per region — $66 for two nodes that pull a few hundred MB once.
+# So each node gets a Standard public IP for EGRESS. Nothing is exposed by it,
+# and that rests on two independent controls rather than one:
+#
+#   (a) ClickHouse binds the node's PRIVATE address only (cloud-init below), so
+#       the public interface has nothing listening on 8123/9000; and
+#   (b) the subnet NSG admits 8123/9000 from ONE source — its own VNet for the
+#       uaenorth node, the uaenorth VNet for the southeastasia node — and no
+#       rule admits the internet to anything. Including no SSH: shells are
+#       `az vm run-command`, over the Azure control plane, which needs no
+#       inbound port at all.
+#
+# WHAT THIS SCRIPT DOES NOT DO
+# ----------------------------
+# It does not enable TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED, it does not
+# install the drain, and it does not create the scoped Postgres role. Those are
+# later stages of docs/storage-portability/azure-analytics-runbook.md, and the
+# flag is LAST. This prints what it did and what it did not, and then ends in
+# the completeness gate, which today says no.
+set -euo pipefail
+
+SUBSCRIPTION="${SUBSCRIPTION:-2fc83893-ca6c-48e4-b090-8860fba33d33}"
+
+PRIMARY_REGION="${PRIMARY_REGION:-uaenorth}"       # Dubai. The drain runs here.
+PEER_REGION="${PEER_REGION:-southeastasia}"        # Singapore. Second copy.
+
+# uaenorth joins the EXISTING production network: the drain must reach
+# tr-azure-pg over its private endpoint, and a private endpoint is reachable
+# from the VNet it lives in (and peers of it), not from a stranger.
+PRIMARY_RG="${PRIMARY_RG:-tr-azure}"
+PRIMARY_VNET="${PRIMARY_VNET:-vnet-prod}"
+PRIMARY_VNET_CIDR="${PRIMARY_VNET_CIDR:-10.61.0.0/16}"
+PRIMARY_SUBNET="${PRIMARY_SUBNET:-snet-clickhouse}"
+# Measured 2026-08-17: vnet-prod is 10.61.0.0/16 with snet-aca 10.61.0.0/23
+# (delegated to Microsoft.App/environments) and snet-pe 10.61.2.0/24, so
+# 10.61.3.0/24 is the next free /24. That reading could NOT be re-verified (ARM
+# auth was dead during recon), so this script checks rather than trusts it: it
+# reads the VNet's real prefixes and real subnet list and refuses on overlap.
+PRIMARY_SUBNET_CIDR="${PRIMARY_SUBNET_CIDR:-10.61.3.0/24}"
+PRIMARY_KV="${PRIMARY_KV:-tr-azure-analytics-kv}"
+
+# southeastasia gets its OWN resource group, VNet, NSG and vault. A second node
+# inside vnet-prod would share its route tables, its NSGs and its region, which
+# is the single failure domain the second copy exists to escape.
+PEER_RG="${PEER_RG:-tr-azure-analytics-sea}"
+PEER_VNET="${PEER_VNET:-vnet-analytics-sea}"
+PEER_VNET_CIDR="${PEER_VNET_CIDR:-10.62.0.0/16}"   # Must not overlap vnet-prod.
+PEER_SUBNET="${PEER_SUBNET:-snet-clickhouse}"
+PEER_SUBNET_CIDR="${PEER_SUBNET_CIDR:-10.62.1.0/24}"
+PEER_KV="${PEER_KV:-tr-azure-analytics-sea-kv}"
+
+# Standard_E2s_v5: 2 vCPU / 16 GiB. ClickHouse wants RAM more than cores and
+# the memory-optimised family is the cheapest way to buy it. Priced live for
+# uaenorth on 2026-08-18: $0.1550/hr = $113.15/month. 128 GiB Premium SSD (P10)
+# is $21.50/month.
+VM_SIZE="${VM_SIZE:-Standard_E2s_v5}"
+DISK_GB="${DISK_GB:-128}"
+DISK_SKU="${DISK_SKU:-Premium_LRS}"
+# 24.04 LTS, not 22.04: its system python is 3.12, and the drain's package
+# imports StrEnum (3.11+). On the AWS node that mismatch meant provisioning
+# deadsnakes by hand before the venv would import at all.
+IMAGE="${IMAGE:-Canonical:ubuntu-24_04-lts:server:latest}"
+ADMIN_USER="${ADMIN_USER:-azureuser}"
+PEER_WITH_PRIMARY="${PEER_WITH_PRIMARY:-1}"
+
+CLICKHOUSE_KEY_ID="${CLICKHOUSE_KEY_ID:-3a9ea1193a97b548be1457d48919f6bd2b48d754}"
+CH_SECRET_NAME="${CH_SECRET_NAME:-clickhouse-default-password}"
+DRAIN_PG_SECRET_NAME="${DRAIN_PG_SECRET_NAME:-drain-postgres-password}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCHEMA_FILE="${SCHEMA_FILE:-$ROOT/clickhouse/006_operational_analytics_single_node.sql}"
+CLIENT_SCHEMA_FILE="${CLIENT_SCHEMA_FILE:-$ROOT/clickhouse/009_client_events_single_node.sql}"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+log() { printf '\n=== %s\n' "$*" >&2; }
+die() { printf '\nFATAL: %s\n' "$*" >&2; exit 1; }
+
+# Every az call carries the subscription explicitly. `az account set` would
+# change the operator's default for every OTHER shell they have open, which is
+# a side effect a deploy script has no business having.
+az() { command az --subscription "$SUBSCRIPTION" "$@"; }
+exists() { az "$@" >/dev/null 2>&1; }
+
+# --- the remote channel ----------------------------------------------------
+#
+# `az vm run-command invoke` exits 0 even when the remote script FAILS: the
+# remote status is inside the returned JSON, not in the CLI's exit code. Same
+# shape as the SSM lesson in aws_eu_clickhouse_drain_install.sh (Status=Failed,
+# exit 0), and a deploy script that cannot tell success from failure is the
+# same class of bug as a drain that cannot tell delivery from silence. So every
+# remote script ends by echoing a marker and this refuses to continue without
+# it.
+#
+# The body is passed as @file and BUILT by concatenation rather than by
+# interpolating text into a shell string: the schema files contain backticks in
+# their comments, and a backtick inside a double-quoted argument is a command
+# substitution on THIS machine. Same family as the run-command shorthand trap —
+# a payload that is parsed by a layer that was not supposed to parse it.
+REMOTE="$WORK/remote.sh"
+begin_remote() {
+  # RunShellScript hands the body to /bin/sh, which on Ubuntu is dash — and
+  # `set -o pipefail` is a bash builtin that dash refuses with "Illegal option",
+  # exiting before the first real line. So every remote body re-execs under bash
+  # first, and only then assumes anything bash-shaped. Nothing below would fail
+  # LOUDLY without this: the step would come back with one error about line one
+  # and no marker, which reads as "the node is broken".
+  cat > "$REMOTE" <<'PRELUDE'
+[ -n "${BASH_VERSION:-}" ] || exec /bin/bash "$0" "$@"
+set -euo pipefail
+PRELUDE
+}
+add_remote() { cat >> "$REMOTE"; }            # body on stdin
+add_remote_file() { cat "$@" >> "$REMOTE"; }  # verbatim file contents
+run_remote() {  # description
+  local what="$1" out
+  printf '\necho TR_RUNCMD_OK\n' >> "$REMOTE"
+  out="$(az vm run-command invoke -g "$RG" -n "$NODE" --command-id RunShellScript \
+    --scripts "@$REMOTE" --query 'value[0].message' -o tsv)" \
+    || die "az vm run-command invoke failed: $what"
+  printf '%s\n' "$out"
+  case "$out" in
+    *TR_RUNCMD_OK*) return 0 ;;
+    *) die "remote step did not complete: $what (no completion marker in the output above)" ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# 0. Which region is this run, and what does that make it?
+# ---------------------------------------------------------------------------
+REGION="${1:-${REGION:-$PRIMARY_REGION}}"
+case "$REGION" in
+  "$PRIMARY_REGION")
+    ROLE="primary"
+    RG="$PRIMARY_RG"; VNET="$PRIMARY_VNET"; SUBNET="$PRIMARY_SUBNET"
+    SUBNET_CIDR="$PRIMARY_SUBNET_CIDR"; VAULT="$PRIMARY_KV"
+    CREATE_VNET=0                       # vnet-prod exists and is production.
+    ;;
+  "$PEER_REGION")
+    ROLE="replica"
+    RG="$PEER_RG"; VNET="$PEER_VNET"; SUBNET="$PEER_SUBNET"
+    SUBNET_CIDR="$PEER_SUBNET_CIDR"; VAULT="$PEER_KV"
+    CREATE_VNET=1
+    ;;
+  *)
+    die "unknown region '$REGION'. This script builds exactly two nodes:
+  bash scripts/deploy/azure_clickhouse.sh $PRIMARY_REGION       (drain host)
+  bash scripts/deploy/azure_clickhouse.sh $PEER_REGION    (second copy)
+To build somewhere else set PRIMARY_REGION/PEER_REGION and the CIDRs to match,
+and read the peering section of this file first."
+    ;;
+esac
+NODE="${NODE:-tr-azure-clickhouse-$REGION}"
+NSG="${NSG:-nsg-clickhouse-$REGION}"
+IDENTITY="${IDENTITY:-tr-azure-analytics-$REGION-id}"
+PIP="${PIP:-pip-clickhouse-$REGION}"
+
+[ -r "$SCHEMA_FILE" ] || die "schema file not readable: $SCHEMA_FILE"
+[ -r "$CLIENT_SCHEMA_FILE" ] || die "schema file not readable: $CLIENT_SCHEMA_FILE"
+
+log "region=$REGION role=$ROLE rg=$RG vnet=$VNET node=$NODE"
+
+# ---------------------------------------------------------------------------
+# 1. Resource group and network.
+#
+#    The primary run REFUSES to create vnet-prod. That is production networking
+#    which predates this script, holding the container app and the Postgres
+#    private endpoint; a deploy script that would create it on a typo'd name is
+#    one that builds a second, empty network and reports success from inside it.
+# ---------------------------------------------------------------------------
+if exists group show -n "$RG"; then
+  log "resource group $RG exists"
+else
+  [ "$ROLE" = "replica" ] || die "resource group $RG does not exist in this subscription.
+That is the production group for $PRIMARY_REGION and this script will not create
+it. Check SUBSCRIPTION and PRIMARY_RG."
+  log "creating resource group $RG in $REGION"
+  az group create -n "$RG" -l "$REGION" -o none
+fi
+
+if [ "$CREATE_VNET" = "1" ]; then
+  if exists network vnet show -g "$RG" -n "$VNET"; then
+    log "vnet $VNET exists"
+  else
+    log "creating vnet $VNET ($PEER_VNET_CIDR)"
+    az network vnet create -g "$RG" -n "$VNET" -l "$REGION" \
+      --address-prefixes "$PEER_VNET_CIDR" -o none
+  fi
+else
+  exists network vnet show -g "$RG" -n "$VNET" \
+    || die "no VNet '$VNET' in resource group '$RG'.
+This run expects the EXISTING production network — the one holding the
+container app in snet-aca and the Postgres private endpoint in snet-pe — and it
+will not create it. Confirm the name with: az network vnet list -o table"
+fi
+
+VNET_PREFIXES="$(az network vnet show -g "$RG" -n "$VNET" \
+  --query "join(' ', addressSpace.addressPrefixes)" -o tsv)"
+EXISTING_SUBNETS="$(az network vnet subnet list -g "$RG" --vnet-name "$VNET" \
+  --query "join(' ', [].addressPrefix)" -o tsv 2>/dev/null || true)"
+log "vnet $VNET is $VNET_PREFIXES; existing subnets: ${EXISTING_SUBNETS:-none}"
+
+# Overlap is refused NOW, while these are still variables. An overlapping
+# subnet cannot be created at all, and overlapping address space across a
+# global peering cannot be peered — both of which are cheap to discover here
+# and an afternoon to discover after two VMs exist.
+python3 - "$SUBNET_CIDR" "$VNET_PREFIXES" "$EXISTING_SUBNETS" <<'PY'
+import ipaddress
+import sys
+
+wanted = ipaddress.ip_network(sys.argv[1])
+prefixes = [ipaddress.ip_network(p) for p in sys.argv[2].split() if "/" in p]
+taken = [ipaddress.ip_network(p) for p in sys.argv[3].split() if "/" in p]
+if prefixes and not any(wanted.subnet_of(p) for p in prefixes):
+    sys.exit(
+        f"subnet {wanted} is not inside the VNet address space "
+        f"{[str(p) for p in prefixes]}; set the *_SUBNET_CIDR variable to a range "
+        "that is"
+    )
+clashes = [str(p) for p in taken if p.overlaps(wanted) and p != wanted]
+if clashes:
+    sys.exit(
+        f"subnet {wanted} overlaps existing subnets {clashes}. Pick a free range: "
+        "an overlapping subnet cannot be created, and address ranges that collide "
+        "across a peering blackhole instead of erroring."
+    )
+PY
+
+if [ "$ROLE" = "replica" ]; then
+  python3 - "$PEER_VNET_CIDR" "$PRIMARY_VNET_CIDR" <<'PY'
+import ipaddress
+import sys
+
+peer, primary = (ipaddress.ip_network(a) for a in sys.argv[1:3])
+if peer.overlaps(primary):
+    sys.exit(
+        f"PEER_VNET_CIDR {peer} overlaps the primary VNet {primary}. Global VNet "
+        "peering between overlapping address spaces cannot be established, and the "
+        "failure arrives after both nodes exist."
+    )
+PY
+fi
+
+# ---------------------------------------------------------------------------
+# 2. NSG, attached to the SUBNET — which is dedicated to these nodes, so the
+#    rule set is about ClickHouse and nothing else.
+#
+#    Azure's default rules already deny inbound from Internet; the explicit
+#    deny is belt-and-braces and, more usefully, legible: a reader sees the
+#    intent instead of having to know the defaults. There is no rule for 22,
+#    and `az vm create` is told --nsg "" below so it does not helpfully attach
+#    a NIC-level NSG that opens SSH to the world, which is its default.
+# ---------------------------------------------------------------------------
+if exists network nsg show -g "$RG" -n "$NSG"; then
+  log "nsg $NSG exists"
+else
+  log "creating nsg $NSG"
+  az network nsg create -g "$RG" -n "$NSG" -l "$REGION" -o none
+fi
+
+if [ "$ROLE" = "primary" ]; then
+  ALLOWED_SOURCE="$VNET_PREFIXES"
+  ALLOWED_WHY="its own VNet; the drain runs on this node and the control plane never touches ClickHouse"
+else
+  ALLOWED_SOURCE="$PRIMARY_VNET_CIDR"
+  ALLOWED_WHY="the $PRIMARY_REGION VNet only; the drain host is this node's single legitimate client"
+fi
+log "nsg allow 8123,9000 from $ALLOWED_SOURCE ($ALLOWED_WHY)"
+# Word splitting on purpose: a VNet may carry several prefixes.
+# shellcheck disable=SC2086
+az network nsg rule create -g "$RG" --nsg-name "$NSG" -n allow-clickhouse-from-peer \
+  --priority 100 --direction Inbound --access Allow --protocol Tcp \
+  --source-address-prefixes $ALLOWED_SOURCE --destination-port-ranges 8123 9000 -o none \
+  2>/dev/null \
+  || az network nsg rule update -g "$RG" --nsg-name "$NSG" -n allow-clickhouse-from-peer \
+       --priority 100 --direction Inbound --access Allow --protocol Tcp \
+       --source-address-prefixes $ALLOWED_SOURCE --destination-port-ranges 8123 9000 -o none
+az network nsg rule create -g "$RG" --nsg-name "$NSG" -n deny-clickhouse-from-internet \
+  --priority 4000 --direction Inbound --access Deny --protocol '*' \
+  --source-address-prefixes Internet --destination-port-ranges 8123 9000 -o none \
+  2>/dev/null || true
+
+if exists network vnet subnet show -g "$RG" --vnet-name "$VNET" -n "$SUBNET"; then
+  log "subnet $SUBNET exists"
+else
+  log "creating subnet $SUBNET ($SUBNET_CIDR)"
+  az network vnet subnet create -g "$RG" --vnet-name "$VNET" -n "$SUBNET" \
+    --address-prefixes "$SUBNET_CIDR" -o none
+fi
+az network vnet subnet update -g "$RG" --vnet-name "$VNET" -n "$SUBNET" \
+  --network-security-group "$NSG" -o none
+SUBNET_ID="$(az network vnet subnet show -g "$RG" --vnet-name "$VNET" -n "$SUBNET" \
+  --query id -o tsv)"
+[ -n "$SUBNET_ID" ] || die "could not resolve the subnet id for $SUBNET"
+
+# ---------------------------------------------------------------------------
+# 3. Identity, vault, password.
+#
+#    A USER-assigned identity, created BEFORE the VM, because a system-assigned
+#    one exists only after the VM does — and cloud-init needs to read the
+#    ClickHouse password from the vault on FIRST boot. Granting after the thing
+#    that needs the grant is how a node comes up with an empty password file
+#    and a ClickHouse that refuses every connection.
+#
+#    RBAC authorization rather than vault access policies, so the grant shows
+#    up in the same place as every other permission in the subscription.
+#
+#    The password is generated ONCE and never printed: not by this script, not
+#    into a terminal, not into a file anybody edits. The nodes read it
+#    themselves over IMDS.
+# ---------------------------------------------------------------------------
+if exists identity show -g "$RG" -n "$IDENTITY"; then
+  log "identity $IDENTITY exists"
+else
+  log "creating user-assigned identity $IDENTITY"
+  az identity create -g "$RG" -n "$IDENTITY" -l "$REGION" -o none
+fi
+IDENTITY_ID="$(az identity show -g "$RG" -n "$IDENTITY" --query id -o tsv)"
+IDENTITY_CLIENT_ID="$(az identity show -g "$RG" -n "$IDENTITY" --query clientId -o tsv)"
+IDENTITY_PRINCIPAL="$(az identity show -g "$RG" -n "$IDENTITY" --query principalId -o tsv)"
+
+if exists keyvault show -g "$RG" -n "$VAULT"; then
+  log "key vault $VAULT exists"
+else
+  log "creating key vault $VAULT"
+  # Soft delete is on by default and cannot be disabled. A create that fails
+  # with "already in use" usually means a deleted vault of that name is still
+  # in the graveyard:   az keyvault list-deleted -o table
+  az keyvault create -g "$RG" -n "$VAULT" -l "$REGION" \
+    --enable-rbac-authorization true -o none
+fi
+VAULT_ID="$(az keyvault show -g "$RG" -n "$VAULT" --query id -o tsv)"
+
+grant_secret_read() {  # principal-id, description
+  [ -n "$1" ] || die "no principal id to grant on $VAULT ($2)"
+  az role assignment create --assignee-object-id "$1" \
+    --assignee-principal-type ServicePrincipal \
+    --role "Key Vault Secrets User" --scope "$VAULT_ID" -o none 2>/dev/null \
+    || log "role assignment for $2 already present (or this caller may not create it)"
+}
+grant_secret_read "$IDENTITY_PRINCIPAL" "this region's node identity"
+
+ensure_secret() {  # name, what it is for
+  if exists keyvault secret show --vault-name "$VAULT" -n "$1" --query id; then
+    log "secret $1 exists in $VAULT (reused; $2)"
+    return 0
+  fi
+  log "generating secret $1 in $VAULT ($2)"
+  # Written through a 0600 file rather than --value, so it never appears in
+  # this process's argv where any local user could read it out of ps. `cut`
+  # rather than `head -c`, which closes the pipe early and turns into a
+  # SIGPIPE failure under `set -o pipefail`.
+  umask 077
+  openssl rand -base64 48 | tr -d '\n/+=' | cut -c1-40 > "$WORK/secret"
+  az keyvault secret set --vault-name "$VAULT" -n "$1" --file "$WORK/secret" -o none
+  rm -f "$WORK/secret"
+}
+ensure_secret "$CH_SECRET_NAME" "the ClickHouse default user on this node"
+if [ "$ROLE" = "primary" ]; then
+  # Generated here and used in the runbook's scoped-role stage: the operator
+  # pipes it out of the vault straight into psql, so it never lands in a file
+  # they edit and never appears in shell history.
+  ensure_secret "$DRAIN_PG_SECRET_NAME" "the scoped Postgres role the drain logs in as"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. The node.
+#
+#    cloud-init installs ClickHouse, fetches the password from the vault with
+#    the identity attached above, and binds the server to the PRIVATE address.
+#    The password is deliberately NOT in custom-data: custom-data stays on the
+#    node at /var/lib/waagent/ovf-env.xml long after the boot that consumed it.
+# ---------------------------------------------------------------------------
+if [ "$ROLE" = "primary" ]; then
+  CH_NETWORKS=""
+  for prefix in $VNET_PREFIXES; do CH_NETWORKS="${CH_NETWORKS}<ip>${prefix}</ip>"; done
+else
+  CH_NETWORKS="<ip>${PRIMARY_VNET_CIDR}</ip><ip>${PEER_VNET_CIDR}</ip>"
+fi
+
+cat > "$WORK/cloud-init.sh" <<CLOUDINIT
+#!/bin/bash
+set -eux
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y apt-transport-https ca-certificates dirmngr gnupg curl python3
+
+GNUPGHOME=\$(mktemp -d)
+GNUPGHOME=\$GNUPGHOME gpg --no-default-keyring --keyring /usr/share/keyrings/clickhouse-keyring.gpg \\
+  --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${CLICKHOUSE_KEY_ID}
+chmod +r /usr/share/keyrings/clickhouse-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg] https://packages.clickhouse.com/deb stable main" \\
+  > /etc/apt/sources.list.d/clickhouse.list
+apt-get update -qq
+echo "clickhouse-server clickhouse-server/default-password password" | debconf-set-selections
+apt-get install -y clickhouse-server clickhouse-client
+
+# The node reads its OWN password, with the identity attached to it. Nothing on
+# the path between the vault and this file holds it. Retried because an RBAC
+# role assignment takes up to a minute to propagate, and a node that gave up
+# after one 403 would come up with an empty password element — which ClickHouse
+# accepts as "no password required from these networks".
+kv_secret() {
+  local token
+  token="\$(curl -s -H Metadata:true \\
+    "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.azure.net&client_id=${IDENTITY_CLIENT_ID}" \\
+    | python3 -c 'import sys,json;print(json.load(sys.stdin)["access_token"])')"
+  curl -s -H "Authorization: Bearer \$token" \\
+    "https://${VAULT}.vault.azure.net/secrets/\$1?api-version=7.4" \\
+    | python3 -c 'import sys,json;print(json.load(sys.stdin)["value"])'
+}
+CH_PASSWORD=""
+for _ in \$(seq 1 30); do
+  CH_PASSWORD="\$(kv_secret ${CH_SECRET_NAME} || true)"
+  [ -n "\$CH_PASSWORD" ] && break
+  sleep 10
+done
+[ -n "\$CH_PASSWORD" ] || { echo "could not read ${CH_SECRET_NAME} from ${VAULT}"; exit 1; }
+
+PRIVATE_IP=\$(curl -s -H Metadata:true \\
+  "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/privateIpAddress?api-version=2021-02-01&format=text")
+
+# Private address only. This node HAS a public address (it needs egress to
+# install ClickHouse), so binding 0.0.0.0 would put an analytics store on the
+# public internet behind nothing but a password.
+cat > /etc/clickhouse-server/config.d/listen.xml <<XML
+<clickhouse>
+  <listen_host>\${PRIVATE_IP}</listen_host>
+  <listen_host>127.0.0.1</listen_host>
+</clickhouse>
+XML
+
+umask 077
+cat > /etc/clickhouse-server/users.d/default-password.xml <<XML
+<clickhouse>
+  <users>
+    <default>
+      <password>\${CH_PASSWORD}</password>
+      <networks>${CH_NETWORKS}<ip>127.0.0.1</ip></networks>
+    </default>
+  </users>
+</clickhouse>
+XML
+# Owned by clickhouse, not root: the server drops privileges to the clickhouse
+# user, so a root-owned 0600 file is unreadable to it and the process dies in
+# UsersConfigAccessStorage::load with a stack trace that never names the
+# permission. Cost one debugging cycle on the Paris node.
+chown clickhouse:clickhouse /etc/clickhouse-server/users.d/default-password.xml
+chmod 640 /etc/clickhouse-server/users.d/default-password.xml
+
+systemctl enable clickhouse-server
+systemctl restart clickhouse-server
+CLOUDINIT
+
+if exists vm show -g "$RG" -n "$NODE" --query id; then
+  log "vm $NODE exists; not recreated (cloud-init runs once, on first boot)"
+else
+  log "creating $NODE ($VM_SIZE, $IMAGE, ${DISK_GB}GiB $DISK_SKU)"
+  # --nsg "" so az does NOT attach its default NIC-level NSG, which opens SSH
+  # to the internet. The subnet NSG above is the only rule set.
+  # --os-disk-delete-option Detach so deleting the VM does not delete the copy
+  # of the history — the Azure spelling of Stockholm's DeleteOnTermination=false.
+  az vm create -g "$RG" -n "$NODE" -l "$REGION" \
+    --image "$IMAGE" --size "$VM_SIZE" \
+    --subnet "$SUBNET_ID" --nsg "" \
+    --public-ip-address "$PIP" --public-ip-sku Standard \
+    --os-disk-size-gb "$DISK_GB" --storage-sku "$DISK_SKU" \
+    --os-disk-delete-option Detach \
+    --assign-identity "$IDENTITY_ID" \
+    --admin-username "$ADMIN_USER" --generate-ssh-keys \
+    --custom-data "@$WORK/cloud-init.sh" \
+    --tags Project=tr-azure-analytics Role="$ROLE" -o none
+fi
+
+PRIVATE_IP="$(az vm list-ip-addresses -g "$RG" -n "$NODE" \
+  --query "[0].virtualMachine.network.privateIpAddresses[0]" -o tsv)"
+[ -n "$PRIVATE_IP" ] || die "could not resolve the private IP of $NODE"
+log "node $NODE at $PRIVATE_IP"
+
+# ---------------------------------------------------------------------------
+# 5. The inter-region path, built from BOTH ends.
+#
+#    Done on the southeastasia run, because that is the run that knows both
+#    sides exist. A peering created from one end only sits in "Initiated" and
+#    drops every packet — the most likely way this link ends up built, reported
+#    healthy, and unable to pass a byte. So the state is asserted, not assumed.
+# ---------------------------------------------------------------------------
+PEERING_REPORT=""
+if [ "$ROLE" = "replica" ] && [ "$PEER_WITH_PRIMARY" = "1" ]; then
+  PRIMARY_VNET_ID="$(az network vnet show -g "$PRIMARY_RG" -n "$PRIMARY_VNET" --query id -o tsv)"
+  PEER_VNET_ID="$(az network vnet show -g "$RG" -n "$VNET" --query id -o tsv)"
+  [ -n "$PRIMARY_VNET_ID" ] \
+    || die "cannot find $PRIMARY_VNET in $PRIMARY_RG — run the $PRIMARY_REGION invocation first"
+
+  for DIRECTION in out back; do
+    if [ "$DIRECTION" = "out" ]; then
+      P_RG="$RG"; P_VNET="$VNET"; P_NAME="peer-to-$PRIMARY_REGION"; P_REMOTE="$PRIMARY_VNET_ID"
+    else
+      P_RG="$PRIMARY_RG"; P_VNET="$PRIMARY_VNET"; P_NAME="peer-to-$PEER_REGION"; P_REMOTE="$PEER_VNET_ID"
+    fi
+    if exists network vnet peering show -g "$P_RG" --vnet-name "$P_VNET" -n "$P_NAME"; then
+      log "peering $P_NAME exists"
+    else
+      log "creating peering $P_NAME"
+      az network vnet peering create -g "$P_RG" --vnet-name "$P_VNET" -n "$P_NAME" \
+        --remote-vnet "$P_REMOTE" --allow-vnet-access -o none
+    fi
+    STATE="$(az network vnet peering show -g "$P_RG" --vnet-name "$P_VNET" -n "$P_NAME" \
+      --query peeringState -o tsv)"
+    [ "$STATE" = "Connected" ] || die "peering $P_NAME is '$STATE', not Connected.
+A peering that exists on one side only drops every packet while both resources
+look fine. Create the other half, or delete both and re-run this script."
+    log "peering $P_NAME: $STATE"
+  done
+  PEERING_REPORT="  peering             $PRIMARY_VNET <-> $VNET, both directions Connected"
+
+  # The drain host must be able to read THIS region's ClickHouse password, or
+  # it starts, fails every replica insert, and stops deleting — after which the
+  # outbox grows without bound. Granting it here, on the run that creates the
+  # vault, keeps the secret out of every human path.
+  PRIMARY_IDENTITY="${PRIMARY_IDENTITY:-tr-azure-analytics-$PRIMARY_REGION-id}"
+  DRAIN_PRINCIPAL="$(az identity show -g "$PRIMARY_RG" -n "$PRIMARY_IDENTITY" \
+    --query principalId -o tsv 2>/dev/null || true)"
+  [ -n "$DRAIN_PRINCIPAL" ] || die "no identity '$PRIMARY_IDENTITY' in '$PRIMARY_RG'.
+Run the $PRIMARY_REGION invocation FIRST: the drain host's identity must exist
+before this vault can grant it read access to this node's password."
+  grant_secret_read "$DRAIN_PRINCIPAL" "the $PRIMARY_REGION drain host"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Schema. Applied to THIS node, and then COUNTED.
+#
+#    Applied from here rather than from cloud-init so a failure lands in front
+#    of the operator running the script instead of in /var/log/cloud-init.log
+#    on a host with no SSH. Every statement is IF NOT EXISTS, so re-running is
+#    free.
+# ---------------------------------------------------------------------------
+log "applying clickhouse/006 + clickhouse/009 to $NODE"
+begin_remote
+add_remote <<'REMOTE_HEAD'
+CH_PW="$(sed -n 's:.*<password>\(.*\)</password>.*:\1:p' \
+  /etc/clickhouse-server/users.d/default-password.xml)"
+[ -n "$CH_PW" ] || { echo "no ClickHouse password on this node: cloud-init has not finished"; exit 1; }
+for _ in $(seq 1 60); do
+  if CLICKHOUSE_PASSWORD="$CH_PW" clickhouse-client --user default \
+      --query 'SELECT 1' >/dev/null 2>&1; then
+    break
+  fi
+  sleep 5
+done
+cat > /root/tr_schema.sql <<'SQLEOF'
+REMOTE_HEAD
+add_remote_file "$SCHEMA_FILE" "$CLIENT_SCHEMA_FILE"
+add_remote <<'REMOTE_TAIL'
+SQLEOF
+CLICKHOUSE_PASSWORD="$CH_PW" clickhouse-client --user default --database default \
+  --multiquery < /root/tr_schema.sql
+rm -f /root/tr_schema.sql
+TABLES=$(CLICKHOUSE_PASSWORD="$CH_PW" clickhouse-client --user default --database default \
+  --query "SELECT count() FROM system.tables WHERE database='default' AND name IN ('activity_generations','synthetic_probe_samples','client_request_events','client_minute_counters','operational_outbox_quarantine')")
+echo "tables the drain writes, present on this node: $TABLES"
+# Assert the COUNT, not the exit status: a clickhouse-client that connects and
+# applies nothing still exits 0.
+test "$TABLES" -ge 5
+REMOTE_TAIL
+run_remote "apply and verify the schema"
+
+# ---------------------------------------------------------------------------
+# 7. What this run did, and what it did NOT.
+# ---------------------------------------------------------------------------
+SECRETS_REPORT="$CH_SECRET_NAME"
+[ "$ROLE" = "primary" ] && SECRETS_REPORT="$CH_SECRET_NAME + $DRAIN_PG_SECRET_NAME"
+
+cat <<REPORT
+
+--- azure_clickhouse.sh: $REGION ($ROLE) ---
+
+DID:
+  resource group      $RG
+  network             $VNET / $SUBNET ($SUBNET_CIDR), nsg $NSG
+                      inbound 8123,9000 from $ALLOWED_SOURCE only; no SSH rule
+  identity            $IDENTITY (user-assigned) -> Key Vault Secrets User on $VAULT
+  vault               $VAULT, secrets: $SECRETS_REPORT
+  node                $NODE ($VM_SIZE, ${DISK_GB}GiB $DISK_SKU, OS disk Detach on delete)
+  private address     $PRIVATE_IP
+  schema              clickhouse/006 + clickhouse/009, verified by table count
+$PEERING_REPORT
+
+DID NOT:
+  * enable TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED. That is the LAST stage;
+    turning it on before the drain exists is the Paris outage on purpose.
+  * install the drain. That is scripts/deploy/azure_clickhouse_drain_install.sh
+    and it runs on the $PRIMARY_REGION node ONLY — one drain, writing both
+    copies. Two drains against one outbox would each delete rows the other had
+    not written, and every row would land on exactly one node.
+  * create the scoped Postgres role. Its password was generated into
+    $PRIMARY_KV/$DRAIN_PG_SECRET_NAME and this script never read it.
+  * establish that rows MOVE. Nothing here can: nothing is enqueued yet.
+
+NEXT: docs/storage-portability/azure-analytics-runbook.md, from the stage after
+this one. Do not skip ahead to the flag.
+
+COST, at prices read live from the retail API on 2026-08-18 (uaenorth):
+  $VM_SIZE  \$113.15/mo    ${DISK_GB}GiB Premium SSD  \$21.50/mo
+  public IP  ~\$3.65/mo      global peering  \$0.25/GB, both sides, drain traffic only
+  Two regions is roughly \$270/month plus egress.
+REPORT
+
+# ---------------------------------------------------------------------------
+# 8. The exit code, which is the only part of the above a pipeline can read.
+#
+# A node that exists and a cloud that works are different things, and the
+# distance between them is what fifteen days of undelivered rows was made of.
+# So this ends by asking the gate, and the gate's answer is this script's exit
+# status, unaltered. Today it says no, which is correct: no drain, no enabled
+# outbox, nothing published.
+#
+# NEXT_STEPS is built with `read -r -d ''` and NOT with "$(cat <<'NEXT' ...)".
+# A heredoc nested inside a command substitution is a syntax error in bash 3.2
+# — /bin/bash on every macOS — as soon as the body contains an apostrophe, and
+# that bomb took out a whole deploy script here once while CI stayed green.
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/cloud_complete_gate.sh
+. "${SCRIPT_DIR}/cloud_complete_gate.sh"
+
+read -r -d '' NEXT_STEPS <<NEXT || true
+The $REGION node is up. The Azure CLOUD is not complete and this script cannot
+make it so. In order:
+
+  1. build the other region, if this was the first:
+       bash scripts/deploy/azure_clickhouse.sh $PEER_REGION
+  2. create the scoped Postgres role — SELECT, DELETE on
+     tr_operational_analytics_outbox and nothing else (runbook stage 3);
+  3. install the drain on the $PRIMARY_REGION node:
+       bash scripts/deploy/azure_clickhouse_drain_install.sh
+  4. watch rows move BEFORE touching the flag;
+  5. only then redeploy the control plane. There is nothing to edit: it finds
+     this node and the vault secret and turns the outbox on because they exist.
+       bash scripts/deploy/azure_control_plane.sh
+  6. bash scripts/deploy/verify_cloud_complete.sh azure
+
+docs/storage-portability/azure-analytics-runbook.md says what "working" looks
+like at each stage, and what to do when it is not.
+NEXT
+
+require_cloud_complete azure "$NEXT_STEPS"
+echo
+echo "The node is up and the gate VERIFIED azure — read its banner above for what"
+echo "that does and does not establish. This script does not restate it in"
+echo "stronger words than it earned."

--- a/scripts/deploy/azure_clickhouse_drain_install.sh
+++ b/scripts/deploy/azure_clickhouse_drain_install.sh
@@ -1,0 +1,675 @@
+#!/usr/bin/env bash
+# Install (or refresh) the operational-analytics drain on the AZURE ClickHouse
+# node in uaenorth — the process that actually MOVES rows.
+#
+# WHY THIS SCRIPT EXISTS
+# ----------------------
+# scripts/deploy/azure_clickhouse.sh builds the nodes and applies the schema.
+# Neither node moves a single row on its own. On AWS the gap between those two
+# facts ran for fifteen days: /opt/drain held a copy of the code and nothing
+# else — no unit, no environment file, no process — while 470,897 rows piled up
+# in the outbox and `SELECT count() FROM activity_generations` returned 0. It
+# was silent because the alarm that bounds outbox growth
+# (`operational_analytics_outbox.backlog_alarm`) is emitted BY the drain that
+# was missing.
+#
+# ONE DRAIN, TWO COPIES
+# ---------------------
+# This installs the drain on the uaenorth node ONLY, configured to fan out to
+# southeastasia:
+#
+#   SELECT batch -> write uaenorth -> write southeastasia -> DELETE outbox rows
+#
+# with the DELETE gated on BOTH writes. If either node is unreachable the rows
+# stay queued and redeliver; ReplacingMergeTree on ingest_version collapses the
+# duplicate. The failure mode is "the outbox grows", not "data is lost".
+#
+# DO NOT instead run a second drain on the southeastasia node against the same
+# outbox. Two drains would each DELETE rows the other had not yet written, and
+# every row would land on exactly one node — which looks like replication and
+# is the precise opposite of it.
+#
+# WHAT IS DIFFERENT FROM THE AWS INSTALLER, AND WHY
+# -------------------------------------------------
+#   * PASSWORD AUTH, NOT IAM. Azure Flexible Server has no DSQL-style token, so
+#     the environment file OMITS TR_POSTGRES_IAM_AUTH entirely and supplies
+#     PGPASSWORD. `PostgresOperationalOutboxSource._connect` takes its
+#     no-IAM branch and libpq reads the password from the environment, never
+#     from argv — the DSN is refused outright if it carries one.
+#   * A SCOPED ROLE, AND IT IS CHECKED. The drain logs in as a role with
+#     SELECT, DELETE on tr_operational_analytics_outbox and nothing else. This
+#     script REFUSES to install the unit unless that is measurably true: it
+#     proves the role can read and delete that table, and proves it CANNOT read
+#     tr_entities. The admin login would work and is the wrong answer — this
+#     node would then hold credentials that can read raw member emails and
+#     workspace ids, which analytics_surrogate() exists to keep off it.
+#   * `az vm run-command`, not SSM. Same trap in a different spelling: it exits
+#     0 whether the remote script succeeded or failed, so the remote status
+#     lives in the output and every step here ends in a marker that must come
+#     back. The body always travels as @file, never inline — az's own
+#     shorthand/escape handling mangles multi-line values, and a remote script
+#     that arrives as one line runs its first word as a command (the SSM
+#     version of this cost a debugging cycle: `nset: not found`, exit 127).
+#   * NO SSH. There is no inbound rule for 22 anywhere in this design, and
+#     run-command needs none.
+#
+# WHAT IT DOES NOT DO
+# -------------------
+# It does not enable TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED. That is the LAST
+# stage of the runbook, deliberately after this one: enabling the producer
+# before the consumer exists is how the outage happened. It also does not
+# create the scoped Postgres role — that needs the database admin password and
+# is an operator step, printed in full below when the check fails.
+set -euo pipefail
+
+SUBSCRIPTION="${SUBSCRIPTION:-2fc83893-ca6c-48e4-b090-8860fba33d33}"
+REGION="${REGION:-uaenorth}"
+RG="${RG:-tr-azure}"
+NODE="${NODE:-tr-azure-clickhouse-$REGION}"
+VNET="${VNET:-vnet-prod}"
+VAULT="${VAULT:-tr-azure-analytics-kv}"
+IDENTITY="${IDENTITY:-tr-azure-analytics-$REGION-id}"
+
+# The second copy. Required by default: a drain installed single-target against
+# a two-node design is a drain that deletes rows the second node never
+# received, and it logs `copies=1` in exactly the same words a deliberate
+# one-node deployment would.
+PEER_REGION="${PEER_REGION:-southeastasia}"
+PEER_RG="${PEER_RG:-tr-azure-analytics-sea}"
+PEER_NODE="${PEER_NODE:-tr-azure-clickhouse-$PEER_REGION}"
+PEER_VAULT="${PEER_VAULT:-tr-azure-analytics-sea-kv}"
+REQUIRE_REPLICA="${REQUIRE_REPLICA:-1}"
+
+# Postgres. The DSN carries NO password (see above) and no IAM setting.
+PG_NAME="${PG_NAME:-tr-azure-pg}"
+PG_DB="${PG_DB:-trustedrouter}"
+DRAIN_PG_USER="${DRAIN_PG_USER:-tr_drain}"
+DRAIN_PG_SECRET_NAME="${DRAIN_PG_SECRET_NAME:-drain-postgres-password}"
+CH_SECRET_NAME="${CH_SECRET_NAME:-clickhouse-default-password}"
+PG_PRIVATE_DNS_ZONE="${PG_PRIVATE_DNS_ZONE:-privatelink.postgres.database.azure.com}"
+
+# "default"/"default", NOT the "tr"/"tr" default the GCP cluster uses: these
+# nodes have the schema applied unqualified. Getting this wrong fails
+# authentication only AFTER a batch has been read out of the outbox.
+CH_USER="${CH_USER:-default}"
+CH_DATABASE="${CH_DATABASE:-default}"
+
+REMOTE_ROOT="${REMOTE_ROOT:-/opt/tr-clickhouse}"
+STAGE_DIR="${STAGE_DIR:-/opt/tr-clickhouse.staging}"
+ENV_FILE="${ENV_FILE:-/etc/tr-clickhouse-ingest-postgres.env}"
+SERVICE="tr-clickhouse-operational-ingest-postgres.service"
+SERVICE_USER="${SERVICE_USER:-tr-clickhouse-ingest}"
+STATE_DIR="${STATE_DIR:-/var/lib/tr-clickhouse-ingest}"
+# Ubuntu 24.04's system python is 3.12, which is what the package needs
+# (trusted_router.types imports StrEnum, 3.11+). That is why the nodes are
+# 24.04 and not 22.04, where this same line meant provisioning deadsnakes.
+PYTHON_BIN="${PYTHON_BIN:-/usr/bin/python3}"
+# No boto3: nothing on this node calls an AWS API. If a transitive import ever
+# needs a package that is not here, the staging import smoke test in step 5
+# fails BEFORE anything is swapped into place and names it.
+DRAIN_PIP_PACKAGES="${DRAIN_PIP_PACKAGES:-psycopg[binary]>=3.2.0 pydantic>=2 pydantic-settings>=2 structlog>=24 python-dateutil>=2.9}"
+# One run-command script must stay under Azure's ~256 KB limit, which is
+# enforced by silent truncation rather than by an error. 120 KB of base64 plus
+# the wrapper is comfortably inside it; the payload is ~1.3 MB, so this is
+# about fifteen round trips.
+CHUNK_BYTES="${CHUNK_BYTES:-120000}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+log() { printf '\n=== %s\n' "$*" >&2; }
+# ON_FAIL_HINT is the fix for the step currently running, printed by die. A
+# remote step can only report that it failed; what to DO about it is knowledge
+# this script has and the node does not.
+ON_FAIL_HINT=""
+die() {
+  printf '\nFATAL: %s\n' "$*" >&2
+  [ -z "$ON_FAIL_HINT" ] || printf '%s\n' "$ON_FAIL_HINT" >&2
+  exit 1
+}
+
+az() { command az --subscription "$SUBSCRIPTION" "$@"; }
+
+# --- the remote channel ----------------------------------------------------
+# Built by concatenation into a file and passed as @file. Never interpolated
+# into a double-quoted argument: the payload contains backticks and dollar
+# signs, and both are live in that position on THIS machine.
+REMOTE="$WORK/remote.sh"
+begin_remote() {
+  # RunShellScript hands the body to /bin/sh, which on Ubuntu is dash — and
+  # `set -o pipefail` is a bash builtin that dash refuses with "Illegal option",
+  # exiting before the first real line. So every remote body re-execs under bash
+  # first, and only then assumes anything bash-shaped. Nothing below would fail
+  # LOUDLY without this: the step would come back with one error about line one
+  # and no marker, which reads as "the node is broken".
+  cat > "$REMOTE" <<'PRELUDE'
+[ -n "${BASH_VERSION:-}" ] || exec /bin/bash "$0" "$@"
+set -euo pipefail
+PRELUDE
+}
+add_remote() { cat >> "$REMOTE"; }
+run_remote() {  # description [quiet]
+  local what="$1" quiet="${2:-}" out
+  printf '\necho TR_RUNCMD_OK\n' >> "$REMOTE"
+  out="$(az vm run-command invoke -g "${RUN_RG:-$RG}" -n "${RUN_NODE:-$NODE}" \
+    --command-id RunShellScript --scripts "@$REMOTE" \
+    --query 'value[0].message' -o tsv)" \
+    || die "az vm run-command invoke failed: $what"
+  [ -n "$quiet" ] || printf '%s\n' "$out"
+  case "$out" in
+    *TR_RUNCMD_OK*) return 0 ;;
+    *) printf '%s\n' "$out" >&2
+       die "remote step did not complete: $what (no completion marker; az vm run-command exits 0 either way, so this is the only signal)" ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# 1. Resolve the node, and refuse early on the things that make a running drain
+#    deliver nothing.
+# ---------------------------------------------------------------------------
+az vm show -g "$RG" -n "$NODE" --query id -o tsv >/dev/null 2>&1 \
+  || die "no VM '$NODE' in resource group '$RG'. Build it first:
+  bash scripts/deploy/azure_clickhouse.sh $REGION"
+log "drain host: $NODE ($RG, $REGION)"
+
+PG_HOST="$(az postgres flexible-server show -g "$RG" -n "$PG_NAME" \
+  --query fullyQualifiedDomainName -o tsv)"
+[ -n "$PG_HOST" ] || die "could not resolve the FQDN of $PG_NAME"
+
+# PREFLIGHT A: can the node RESOLVE that name to the private endpoint?
+#
+# tr-azure-pg has publicNetworkAccess=Enabled and ZERO firewall rules, so the
+# public path is closed to everything. The only way in is the private endpoint
+# in snet-pe — and a private endpoint is only reachable by name if the
+# privatelink zone exists AND is linked to this VNet. Without the link the node
+# resolves the public address, every connection times out, and the unit sits
+# `active` reporting failed_shards while the outbox grows. That is precisely
+# the "configured, healthy, and empty" shape this pipeline exists to make loud,
+# so it is checked before anything is installed.
+ZONE_RG="$(az network private-dns zone list \
+  --query "[?name=='${PG_PRIVATE_DNS_ZONE}'].resourceGroup | [0]" -o tsv 2>/dev/null || true)"
+[ -n "$ZONE_RG" ] && [ "$ZONE_RG" != "None" ] || die "no private DNS zone '${PG_PRIVATE_DNS_ZONE}' in this subscription.
+Without it the drain resolves ${PG_HOST} to the PUBLIC address, which has no
+firewall rule permitting anything, and every connection times out while the
+unit reports itself active. Create the zone, link it to ${VNET}, and add the
+A record for the private endpoint (az network private-endpoint dns-zone-group
+does all three), then re-run."
+ZONE_LINK="$(az network private-dns link vnet list -g "$ZONE_RG" -z "$PG_PRIVATE_DNS_ZONE" \
+  --query "[?contains(virtualNetwork.id, '/${VNET}')].name | [0]" -o tsv 2>/dev/null || true)"
+[ -n "$ZONE_LINK" ] && [ "$ZONE_LINK" != "None" ] || die "private DNS zone '${PG_PRIVATE_DNS_ZONE}' exists (in $ZONE_RG) but is NOT linked to ${VNET}.
+A zone nobody links resolves for nobody. Link it:
+  az network private-dns link vnet create -g $ZONE_RG -z $PG_PRIVATE_DNS_ZONE \\
+    -n ${VNET}-link -v ${VNET} -e false"
+log "private DNS: zone $PG_PRIVATE_DNS_ZONE in $ZONE_RG, linked to $VNET as $ZONE_LINK"
+
+# PREFLIGHT B: does the scoped role's password exist where the node can read it?
+az keyvault secret show --vault-name "$VAULT" -n "$DRAIN_PG_SECRET_NAME" --query id -o tsv \
+  >/dev/null 2>&1 \
+  || die "no secret '$DRAIN_PG_SECRET_NAME' in vault '$VAULT'.
+scripts/deploy/azure_clickhouse.sh generates it. If the vault was rebuilt, the
+scoped role's password and this secret have parted company and the role has to
+be re-created with the new one (runbook stage 3)."
+
+IDENTITY_CLIENT_ID="$(az identity show -g "$RG" -n "$IDENTITY" --query clientId -o tsv)"
+[ -n "$IDENTITY_CLIENT_ID" ] || die "no managed identity '$IDENTITY' in '$RG'"
+
+# PREFLIGHT C: the second copy.
+PEER_IP=""
+if [ "$REQUIRE_REPLICA" = "1" ]; then
+  PEER_IP="$(az vm list-ip-addresses -g "$PEER_RG" -n "$PEER_NODE" \
+    --query "[0].virtualMachine.network.privateIpAddresses[0]" -o tsv 2>/dev/null || true)"
+  [ -n "$PEER_IP" ] && [ "$PEER_IP" != "None" ] || die "cannot find the $PEER_REGION node ($PEER_NODE in $PEER_RG).
+This deployment is TWO copies. Installing a single-target drain here would
+delete rows the second node never received, and its log line would read
+copies=1 — identical to a deliberate one-node deployment. Build it:
+  bash scripts/deploy/azure_clickhouse.sh $PEER_REGION
+or, if one copy is genuinely what you want, say so: REQUIRE_REPLICA=0"
+  az keyvault secret show --vault-name "$PEER_VAULT" -n "$CH_SECRET_NAME" --query id -o tsv \
+    >/dev/null 2>&1 \
+    || die "no secret '$CH_SECRET_NAME' in the $PEER_REGION vault '$PEER_VAULT'"
+  log "second copy: $PEER_NODE at $PEER_IP (vault $PEER_VAULT)"
+else
+  log "REQUIRE_REPLICA=0: installing a ONE-COPY drain. The southeastasia node, if it exists, will not receive these rows and cannot be backfilled from the outbox later."
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Build the payload.
+#
+# COPYFILE_DISABLE=1 stops macOS tar emitting ._* AppleDouble sidecars, and the
+# extraction deletes any it finds anyway and then FAILS if one survives. Not
+# hypothetical: the AWS node's /opt/drain holds four of them, shipped by a
+# macOS tar without that variable, and the same sidecars once crashed a
+# snapshot builder that tried to parse them as JSON.
+#
+# static/, templates/ and content/ are ~10 MB of web assets the drain never
+# imports; excluding them is what keeps this shippable at all.
+# ---------------------------------------------------------------------------
+log "building payload from $ROOT"
+COPYFILE_DISABLE=1 tar -C "$ROOT" \
+  --exclude='__pycache__' --exclude='._*' \
+  --exclude='static' --exclude='templates' --exclude='content' \
+  -czf "$WORK/drain.tgz" clickhouse src/trusted_router
+if command -v shasum >/dev/null 2>&1; then
+  LOCAL_SHA="$(shasum -a 256 "$WORK/drain.tgz" | awk '{print $1}')"
+else
+  LOCAL_SHA="$(sha256sum "$WORK/drain.tgz" | awk '{print $1}')"
+fi
+base64 < "$WORK/drain.tgz" | tr -d '\n' > "$WORK/drain.b64"
+split -b "$CHUNK_BYTES" "$WORK/drain.b64" "$WORK/chunk."
+CHUNKS=("$WORK"/chunk.*)
+log "payload $(wc -c < "$WORK/drain.tgz") bytes, sha256 $LOCAL_SHA, ${#CHUNKS[@]} chunks"
+
+# ---------------------------------------------------------------------------
+# 3. Ship it into STAGING. Nothing in $REMOTE_ROOT is touched until the
+#    checksum matches and the code imports.
+# ---------------------------------------------------------------------------
+begin_remote
+add_remote <<REMOTE
+rm -rf '$STAGE_DIR' /tmp/tr-drain.b64
+mkdir -p '$STAGE_DIR'
+REMOTE
+run_remote "reset staging" quiet
+
+i=0
+for chunk in "${CHUNKS[@]}"; do
+  i=$((i + 1))
+  printf '\rshipping chunk %d/%d' "$i" "${#CHUNKS[@]}" >&2
+  begin_remote
+  { printf "printf '%%s' '"; cat "$chunk"; printf "' >> /tmp/tr-drain.b64\n"; } >> "$REMOTE"
+  run_remote "chunk $i/${#CHUNKS[@]}" quiet
+done
+printf '\n' >&2
+
+begin_remote
+add_remote <<REMOTE
+base64 -d /tmp/tr-drain.b64 > /tmp/tr-drain.tgz
+rm -f /tmp/tr-drain.b64
+echo '$LOCAL_SHA  /tmp/tr-drain.tgz' | sha256sum -c -
+tar -xzf /tmp/tr-drain.tgz -C '$STAGE_DIR'
+rm -f /tmp/tr-drain.tgz
+# Flatten src/trusted_router -> trusted_router. The unit has no PYTHONPATH, so
+# 'python -m' can only see packages directly under WorkingDirectory.
+mv '$STAGE_DIR/src/trusted_router' '$STAGE_DIR/trusted_router'
+rmdir '$STAGE_DIR/src'
+# Belt and braces: COPYFILE_DISABLE should have prevented these, so finding one
+# means the tarball was not built the way this script claims.
+find '$STAGE_DIR' -name '._*' -print -delete
+test -z "\$(find '$STAGE_DIR' -name '._*')"
+test -f '$STAGE_DIR/clickhouse/ingest_operational_outbox_postgres.py'
+test -f '$STAGE_DIR/trusted_router/postgres_dsn.py'
+REMOTE
+run_remote "verify checksum and extract"
+
+# ---------------------------------------------------------------------------
+# 4. Service account, state directory, virtualenv.
+#
+#    STATE_DIR must exist before the unit starts: ProtectSystem=strict makes
+#    the filesystem read-only except ReadWritePaths, and systemd refuses to
+#    start a unit whose ReadWritePaths does not resolve. It is also the unit's
+#    HOME — libpq resolves a client certificate at $HOME/.postgresql/ on every
+#    connect and treats "Permission denied" there as FATAL, so under
+#    ProtectHome=true a HOME pointing at /home fails EVERY connection while the
+#    unit sits active. Password auth reads that path too; this is not an
+#    AWS-only detail.
+# ---------------------------------------------------------------------------
+begin_remote
+add_remote <<REMOTE
+id -u '$SERVICE_USER' >/dev/null 2>&1 || useradd --system --no-create-home --shell /usr/sbin/nologin '$SERVICE_USER'
+install -d -o '$SERVICE_USER' -g '$SERVICE_USER' -m 0750 '$STATE_DIR'
+test -x '$PYTHON_BIN' || { echo 'missing $PYTHON_BIN'; exit 1; }
+'$PYTHON_BIN' -m venv '$STAGE_DIR/venv'
+'$STAGE_DIR/venv/bin/pip' install --quiet --upgrade pip
+'$STAGE_DIR/venv/bin/pip' install --quiet $DRAIN_PIP_PACKAGES
+'$STAGE_DIR/venv/bin/python' -V
+REMOTE
+run_remote "service user, state dir, venv"
+
+# ---------------------------------------------------------------------------
+# 5. The gate that makes the trimmed tarball safe. If excluding
+#    static/templates/content broke an import, or the venv is short a
+#    dependency, it fails HERE — against staging, before anything is swapped in
+#    and before the unit exists.
+# ---------------------------------------------------------------------------
+begin_remote
+add_remote <<REMOTE
+cd '$STAGE_DIR'
+./venv/bin/python -c 'import clickhouse.ingest_operational_outbox_postgres as m; print("CONFIG_EXIT_CODE", m.CONFIG_EXIT_CODE)'
+REMOTE
+run_remote "import smoke test (staging)"
+
+# ---------------------------------------------------------------------------
+# 6. Swap staging into place, keeping .previous for rollback.
+# ---------------------------------------------------------------------------
+begin_remote
+add_remote <<REMOTE
+rm -rf '${REMOTE_ROOT}.previous'
+if [ -d '$REMOTE_ROOT' ]; then mv '$REMOTE_ROOT' '${REMOTE_ROOT}.previous'; fi
+mv '$STAGE_DIR' '$REMOTE_ROOT'
+ls -la '$REMOTE_ROOT'
+REMOTE
+run_remote "activate $REMOTE_ROOT"
+
+# ---------------------------------------------------------------------------
+# 7. The environment file, written by RUNNING commands ON THE NODE.
+#
+# systemd's EnvironmentFile performs NO command or variable substitution: a
+# literal $(az ...) written into it BECOMES the password, is non-empty so every
+# startup check passes, and then fails authentication on every insert forever
+# while the outbox grows. So each secret is fetched on the node, by the node's
+# own managed identity, and never passes through this script's output, its
+# arguments, or a human's clipboard.
+#
+# There is no az CLI on the node; the IMDS token endpoint plus a plain HTTPS
+# GET to the vault is the whole mechanism.
+# ---------------------------------------------------------------------------
+log "writing $ENV_FILE on the node (secrets fetched there, never here)"
+begin_remote
+add_remote <<REMOTE
+umask 077
+kv_secret() {  # vault, name
+  local token
+  token="\$(curl -s -H Metadata:true \\
+    "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.azure.net&client_id=${IDENTITY_CLIENT_ID}" \\
+    | python3 -c 'import sys,json;print(json.load(sys.stdin)["access_token"])')"
+  curl -s -H "Authorization: Bearer \$token" \\
+    "https://\$1.vault.azure.net/secrets/\$2?api-version=7.4" \\
+    | python3 -c 'import sys,json;print(json.load(sys.stdin)["value"])'
+}
+PG_PW="\$(kv_secret '$VAULT' '$DRAIN_PG_SECRET_NAME')"
+CH_PW="\$(kv_secret '$VAULT' '$CH_SECRET_NAME')"
+[ -n "\$PG_PW" ] || { echo 'could not read the drain Postgres password from $VAULT'; exit 1; }
+[ -n "\$CH_PW" ] || { echo 'could not read the ClickHouse password from $VAULT'; exit 1; }
+
+# The DSN is QUOTED and the passwords are not, and that asymmetry is
+# deliberate. systemd's EnvironmentFile takes the rest of the line either way,
+# but this file is also SOURCED by a shell twice below (steps 8 and 10), and
+# \`. file\` parses \`TR_POSTGRES_DSN=host=x port=5432 user=y\` as FIVE separate
+# assignments — leaving the DSN silently truncated to its first word. systemd
+# strips the quotes, the shell honours them, and the value is the same in both.
+# The passwords contain no whitespace by construction, and leaving them bare
+# keeps the length check below exact rather than off by two.
+cat > '$ENV_FILE' <<ENVEOF
+TR_POSTGRES_DSN="host=${PG_HOST} port=5432 user=${DRAIN_PG_USER} dbname=${PG_DB} sslmode=require"
+PGPASSWORD=\$PG_PW
+TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_USER=${CH_USER}
+TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_DATABASE=${CH_DATABASE}
+CH_PASSWORD=\$CH_PW
+ENVEOF
+REMOTE
+
+if [ -n "$PEER_IP" ]; then
+  add_remote <<REMOTE
+CH_REPLICA_PW="\$(kv_secret '$PEER_VAULT' '$CH_SECRET_NAME')"
+[ -n "\$CH_REPLICA_PW" ] || { echo 'could not read the $PEER_REGION ClickHouse password from $PEER_VAULT'; exit 1; }
+cat >> '$ENV_FILE' <<ENVEOF
+TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_REPLICA_NAME=${PEER_REGION}
+TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_REPLICA_HOST=${PEER_IP}
+TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_REPLICA_PORT=9000
+TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_REPLICA_USER=${CH_USER}
+TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_REPLICA_DATABASE=${CH_DATABASE}
+CH_REPLICA_PASSWORD=\$CH_REPLICA_PW
+ENVEOF
+REMOTE
+fi
+
+add_remote <<REMOTE
+chmod 600 '$ENV_FILE'
+chown root:root '$ENV_FILE'
+# Prove the secrets landed as VALUES and not as unexpanded commands, and never
+# print them: lengths and key names only.
+awk -F= '/^PGPASSWORD=/ {print "PGPASSWORD length=" length(\$2)}
+         /^CH_PASSWORD=/ {print "CH_PASSWORD length=" length(\$2)}
+         /^CH_REPLICA_PASSWORD=/ {print "CH_REPLICA_PASSWORD length=" length(\$2)}' '$ENV_FILE'
+if grep -qE '^(PGPASSWORD|CH_PASSWORD|CH_REPLICA_PASSWORD)=\\\$\\(' '$ENV_FILE'; then
+  echo 'a secret in the environment file is a literal command substitution; refusing'
+  exit 1
+fi
+cut -d= -f1 '$ENV_FILE'
+REMOTE
+run_remote "environment file"
+
+# ---------------------------------------------------------------------------
+# 8. PROVE THE ROLE IS SCOPED, before the unit exists.
+#
+# Three questions, all of which have to be answered by the database rather than
+# by the person who wrote the GRANT:
+#
+#   * can it SELECT the outbox?   without this the drain reads nothing;
+#   * can it DELETE from it?      WITHOUT THIS the drain writes ClickHouse
+#                                 forever and never deletes, so the outbox
+#                                 grows without bound while every metric looks
+#                                 healthy — the quietest failure in the set;
+#   * can it read tr_entities?    it MUST NOT. That table holds raw member
+#                                 emails and workspace ids, and this host is
+#                                 not allowed to hold credentials that reach
+#                                 them.
+#
+# The last one is why the admin login is not an acceptable shortcut: it passes
+# the first two and fails the third silently, because nothing would ever ask.
+# ---------------------------------------------------------------------------
+log "checking the scoped Postgres role from the node"
+read -r -d '' ON_FAIL_HINT <<HINT || true
+
+The drain role is missing, wrong, or over-granted. Create it EXACTLY as scoped —
+the SQL is scripts/deploy/sql/azure_operational_outbox_drain_role.sql and the
+password comes out of the vault and into psql through a PIPE, so it never lands
+in a file you edit, in argv, or in shell history:
+
+  # a temporary firewall rule for your own address, removed afterwards
+  MYIP=\$(curl -fsS https://api.ipify.org)
+  az postgres flexible-server firewall-rule create -g $RG -s $PG_NAME \\
+    --name tmp-drain-role --start-ip-address \$MYIP --end-ip-address \$MYIP
+
+  {
+    printf "\\\\set drain_password '"
+    az keyvault secret show --vault-name $VAULT -n $DRAIN_PG_SECRET_NAME \\
+      --query value -o tsv | tr -d '\\n'
+    printf "'\\n"
+    cat scripts/deploy/sql/azure_operational_outbox_drain_role.sql
+  } | PGPASSWORD="\$(read -rs -p 'tradmin password: ' p; echo \$p)" psql \\
+        "host=$PG_HOST port=5432 user=tradmin dbname=$PG_DB sslmode=require" \\
+        -v ON_ERROR_STOP=1 -f -
+
+  az postgres flexible-server firewall-rule delete -g $RG -s $PG_NAME \\
+    --name tmp-drain-role --yes
+
+Then re-run this script. It is idempotent: the code is already staged and the
+environment file already written.
+HINT
+begin_remote
+add_remote <<REMOTE
+set -a
+. '$ENV_FILE'
+set +a
+cd '$REMOTE_ROOT'
+./venv/bin/python - <<'PYEOF'
+import os
+import sys
+
+import psycopg
+
+dsn = os.environ["TR_POSTGRES_DSN"]
+with psycopg.connect(dsn) as conn:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT has_table_privilege('tr_operational_analytics_outbox', 'SELECT'), "
+            "has_table_privilege('tr_operational_analytics_outbox', 'DELETE')"
+        )
+        can_select, can_delete = cur.fetchone()
+    if not can_select:
+        sys.exit("the drain role cannot SELECT tr_operational_analytics_outbox")
+    if not can_delete:
+        sys.exit(
+            "the drain role cannot DELETE from tr_operational_analytics_outbox. "
+            "It would write ClickHouse forever and never delete: the outbox grows "
+            "without bound while every metric reads healthy."
+        )
+    with conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM tr_operational_analytics_outbox")
+        print("outbox rows visible to the drain role:", cur.fetchone()[0])
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT 1 FROM tr_entities LIMIT 1")
+    except psycopg.errors.InsufficientPrivilege:
+        print("tr_entities: denied, as required")
+    else:
+        sys.exit(
+            "the drain role can read tr_entities. It is not scoped: this host would "
+            "hold credentials that reach raw member emails and workspace ids. Use a "
+            "role with SELECT, DELETE on tr_operational_analytics_outbox and nothing "
+            "else."
+        )
+PYEOF
+REMOTE
+run_remote "scoped Postgres role"
+ON_FAIL_HINT=""
+
+# ---------------------------------------------------------------------------
+# 9. The unit.
+# ---------------------------------------------------------------------------
+UNIT_B64="$(base64 < "$ROOT/clickhouse/$SERVICE" | tr -d '\n')"
+begin_remote
+add_remote <<REMOTE
+printf '%s' '$UNIT_B64' | base64 -d > /etc/systemd/system/$SERVICE
+chmod 644 /etc/systemd/system/$SERVICE
+chown -R '$SERVICE_USER':'$SERVICE_USER' '$REMOTE_ROOT'
+systemctl daemon-reload
+systemctl enable --now $SERVICE
+REMOTE
+run_remote "install and start the unit"
+
+# ---------------------------------------------------------------------------
+# 10. Verify. A unit that is 'active' proves only that execve succeeded.
+#
+#     The proof is the metrics line the sweep loop emits every poll and the row
+#     counts on BOTH nodes. This script PRINTS them and asserts on none of
+#     them: a human reads copies=, degraded_targets=, and the two counts.
+#     Saying so is the point — an earlier version of a paragraph like this one
+#     claimed the run had "established that rows moved", which is the same
+#     printing-is-doing mistake one level down.
+# ---------------------------------------------------------------------------
+log "waiting for the first sweeps"
+sleep 45
+begin_remote
+add_remote <<REMOTE
+systemctl is-active $SERVICE || true
+echo '--- metrics (operational_analytics_outbox.*) ---'
+journalctl -u $SERVICE --no-pager -n 200 \
+  | grep -E 'outbox\.(metrics|targets|config_invalid|backlog_alarm)' | tail -20 || true
+echo '--- clickhouse, this node ---'
+set -a
+. '$ENV_FILE'
+set +a
+CLICKHOUSE_PASSWORD="\$CH_PASSWORD" clickhouse-client --user '$CH_USER' --database '$CH_DATABASE' \
+  --query 'SELECT (SELECT count() FROM activity_generations) AS activity, (SELECT count() FROM synthetic_probe_samples) AS synthetic FORMAT TSVWithNames'
+if [ -n "\${TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_REPLICA_HOST:-}" ]; then
+  echo '--- clickhouse, second copy ---'
+  CLICKHOUSE_PASSWORD="\$CH_REPLICA_PASSWORD" clickhouse-client \
+    --host "\$TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_REPLICA_HOST" \
+    --user '$CH_USER' --database '$CH_DATABASE' \
+    --query 'SELECT count() FROM activity_generations FORMAT TSVWithNames'
+fi
+REMOTE
+run_remote "verify"
+
+cat <<REPORT
+
+Installed on $NODE. What "working" looks like, and what to do when it is not:
+
+  copies=2 degraded_targets=-        both nodes accepting; this is the target
+  copies=1                           single-target. If you did not pass
+                                     REQUIRE_REPLICA=0 that is a defect: rows
+                                     are being deleted after ONE copy.
+  degraded_targets=$PEER_REGION      the second node is refusing or unreachable.
+                                     NOTHING is lost: the drain stops deleting
+                                     and the outbox absorbs the backlog. Fix the
+                                     node or the peering; do not "fix" it by
+                                     removing the replica variables unless you
+                                     accept that node falling permanently behind.
+  drain_lag_seconds falling          the backlog is draining
+  rows=0 with a large backlog        NOT healthy; read failed_shards= and the
+                                     lines above it
+  backlog_alarm (ERROR)              the oldest undelivered row is past
+                                     --max-lag-seconds (default 3600). Expected
+                                     while a first backlog drains; it should
+                                     clear, not sit.
+  unit failed with status=78         CONFIG_EXIT_CODE. The environment file is
+                                     wrong and RestartPreventExitStatus stopped
+                                     it deliberately rather than crash-loop.
+                                     journalctl -u $SERVICE | grep config_invalid
+
+  Both counts are ZERO and stay zero: that is expected right now. The producer
+  is still off — TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED is not set on the
+  container app — so there is nothing to drain yet. Enabling it is the NEXT
+  stage, and it is next precisely because this one is done.
+
+Watch:  az vm run-command invoke -g $RG -n $NODE --command-id RunShellScript \\
+          --scripts "journalctl -u $SERVICE -n 50 --no-pager"
+
+Rollback: stop the unit and restore the previous tree —
+  systemctl disable --now $SERVICE
+  mv ${REMOTE_ROOT}.previous $REMOTE_ROOT
+Nothing is lost by stopping the drain: undelivered rows stay in the outbox.
+REPORT
+
+# ---------------------------------------------------------------------------
+# 11. The outside view.
+#
+# Step 10 ran systemctl, the journal and two ClickHouse counts and PRINTED
+# them. Be exact about what that is: this script asserts on none of the three,
+# so what step 10 establishes is that the commands ran.
+#
+# What the gate adds is the question a rollout has to answer and no in-VNet
+# command can: whether anyone WITHOUT a session on that node can tell. Ending
+# here means an install visible only from the installer's shell cannot be
+# mistaken for a finished cloud.
+#
+# Exit 5 (NOT YET OBSERVABLE) is today's expected answer and it is still
+# non-zero: no control plane on this cloud publishes the analytics section yet,
+# because the flag that makes it publish one is the next stage. The shared
+# fragment prints the right words for that code; the paragraph below is the
+# part specific to having just installed a drain.
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/cloud_complete_gate.sh
+. "${SCRIPT_DIR}/cloud_complete_gate.sh"
+
+read -r -d '' NEXT_STEPS <<'NEXT' || true
+The drain install itself did not fail. Read step 10 above before touching
+anything: copies=, degraded_targets=, drain_lag_seconds and the ClickHouse
+counts are printed there and asserted nowhere.
+NEXT
+
+VERIFY_RC=0
+require_cloud_complete azure "$NEXT_STEPS" || VERIFY_RC=$?
+
+if [ "$VERIFY_RC" -eq 5 ]; then
+  cat >&2 <<PREDEPLOY
+
+DRAIN INSTALLED; NOT YET OBSERVABLE FROM OUTSIDE.
+
+What this run did: shipped the code, wrote the environment file from secrets the
+NODE fetched, proved the Postgres role is scoped, installed and started the
+unit, and printed the drain's journal and two ClickHouse counts.
+
+What it could not do: tell whether anyone WITHOUT a session on that node can see
+the drain. The Azure control plane publishes no analytics section, because
+TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED is still unset — which is correct
+ordering, not an oversight. Turning it on is the next stage, and the drain
+existing is its precondition.
+
+To close it:
+
+  1. redeploy the control plane. It resolves this node and its Key Vault secret
+     and sets the flag from their existence, so there is nothing to edit:
+       bash scripts/deploy/azure_control_plane.sh
+  2. bash scripts/deploy/verify_cloud_complete.sh azure
+  3. flip expects_outbox for azure in
+     src/trusted_router/operational_analytics_fleet.py once it publishes a live
+     lag (this PR does it; the fleet check then requires the lag to stay live).
+
+PREDEPLOY
+fi
+
+exit "$VERIFY_RC"

--- a/scripts/deploy/azure_control_plane.sh
+++ b/scripts/deploy/azure_control_plane.sh
@@ -47,7 +47,13 @@ set -euo pipefail
 STACK="${STACK:-tr-azure}"
 RG="${RG:-$STACK}"
 LOCATION="${LOCATION:-uaenorth}"
-APP="${APP:-$STACK}"
+# tr-azure-VNET, not tr-azure. Production runs the container app `tr-azure-vnet`
+# and this file called itself the source of truth while defaulting to a
+# different app — so a deploy from a clean checkout would have created or
+# updated the wrong one, and every claim in this header would have been about a
+# service nobody was using. The drift was found by reading ARM, not by reading
+# this file; that is the direction it usually goes.
+APP="${APP:-$STACK-vnet}"
 APP_ENV="${APP_ENV:-$STACK-env}"
 PG_NAME="${PG_NAME:-$STACK-pg}"
 PG_ADMIN="${PG_ADMIN:-tradmin}"
@@ -97,6 +103,30 @@ DEFERRED_SETTLEMENT_ENABLED="${DEFERRED_SETTLEMENT_ENABLED:-false}"
 SYNTHETIC_INTERVAL_SECONDS="${SYNTHETIC_INTERVAL_SECONDS:-120}"
 SYNTHETIC_ROTATION_COUNT="${SYNTHETIC_ROTATION_COUNT:-8}"
 
+# Operational analytics. The outbox flag is now STATED by this file rather than
+# defaulted by config.py, which is the whole point of the change: it was off
+# because nobody had written it down, not because anybody decided it. Mirrors
+# aws_eu_control_plane.sh, where the presence of a ClickHouse secret in the
+# region is what decides.
+#
+# The rule, and the order it enforces: with no ClickHouse target the outbox
+# stays OFF rather than enqueuing rows nothing will ever drain. That is not
+# caution, it is the Paris outage stated as a conditional — 470,897 rows
+# accumulated in fifteen days behind a green status page because the producer
+# was on and the consumer did not exist.
+#
+# The target is the uaenorth node built by scripts/deploy/azure_clickhouse.sh.
+# The container app lives in snet-aca inside vnet-prod and the node lives in
+# snet-clickhouse inside the same VNet, so this is a private address over
+# internal routing — there is no public path to it, by design.
+CLICKHOUSE_NODE="${CLICKHOUSE_NODE:-tr-azure-clickhouse-$LOCATION}"
+CLICKHOUSE_VAULT="${CLICKHOUSE_VAULT:-tr-azure-analytics-kv}"
+CLICKHOUSE_SECRET_NAME="${CLICKHOUSE_SECRET_NAME:-clickhouse-default-password}"
+# "default"/"default": the node's schema is applied unqualified, unlike the GCP
+# cluster's "tr"/"tr".
+CLICKHOUSE_USER="${CLICKHOUSE_USER:-default}"
+CLICKHOUSE_DATABASE="${CLICKHOUSE_DATABASE:-default}"
+
 log() { printf '\n=== %s\n' "$*" >&2; }
 exists() { "$@" >/dev/null 2>&1; }
 die() { echo "[FAIL] $*" >&2; exit 1; }
@@ -139,6 +169,26 @@ SETTLEMENT_TOKEN="$(read_secret trustedrouter-federation-settlement-token-azure-
 # The monitor key is what makes the leaderboard green: rotation calls the
 # gateway as a CUSTOMER of itself. Without it there is a status page with no
 # model rows, which reads as "no data" rather than "not measured".
+
+# Resolve the analytics target. BOTH halves must be there: an address with no
+# password, or a password with no address, is a config that starts and then
+# fails on first use — so a half-answer is treated as no answer.
+CLICKHOUSE_HOST="${CLICKHOUSE_HOST:-$(az vm list-ip-addresses -g "$RG" -n "$CLICKHOUSE_NODE" \
+  --query "[0].virtualMachine.network.privateIpAddresses[0]" -o tsv 2>/dev/null || true)}"
+CLICKHOUSE_PASSWORD="${CLICKHOUSE_PASSWORD:-$(az keyvault secret show --vault-name "$CLICKHOUSE_VAULT" \
+  -n "$CLICKHOUSE_SECRET_NAME" --query value -o tsv 2>/dev/null || true)}"
+if [ -n "$CLICKHOUSE_HOST" ] && [ "$CLICKHOUSE_HOST" != "None" ] && [ -n "$CLICKHOUSE_PASSWORD" ]; then
+  OUTBOX_ENABLED="true"
+  CLICKHOUSE_URL_EFFECTIVE="${CLICKHOUSE_URL:-http://${CLICKHOUSE_HOST}:8123}"
+  log "analytics ON: outbox enabled, ClickHouse at ${CLICKHOUSE_URL_EFFECTIVE}"
+  log "  a drain must ALREADY be installed against it. If it is not, this deploy
+  starts filling an outbox nothing empties. Check first:
+    bash scripts/deploy/azure_clickhouse_drain_install.sh"
+else
+  log "no ClickHouse target in ${LOCATION} (node ${CLICKHOUSE_NODE}, vault ${CLICKHOUSE_VAULT}): analytics disabled for this service"
+  OUTBOX_ENABLED="false"
+  CLICKHOUSE_URL_EFFECTIVE=""
+fi
 
 if [ -z "$SETTLEMENT_TOKEN" ] || [ "$DEFERRED_SETTLEMENT_ENABLED" != "true" ]; then
   log "deferred settlement OFF (token present: $([ -n "$SETTLEMENT_TOKEN" ] && echo yes || echo no))"
@@ -212,6 +262,13 @@ ENV_VARS=(
   "TR_SYNTHETIC_SCHEDULER_INTERVAL_SECONDS=${SYNTHETIC_INTERVAL_SECONDS}"
   "TR_SYNTHETIC_SCHEDULER_ROTATION_COUNT=${SYNTHETIC_ROTATION_COUNT}"
 
+  # Operational analytics. STATED, both ways: "false" here is a decision this
+  # file makes and a reader can see, not a default nobody wrote down.
+  "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=${OUTBOX_ENABLED}"
+  "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_URL=${CLICKHOUSE_URL_EFFECTIVE}"
+  "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_USER=${CLICKHOUSE_USER}"
+  "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_DATABASE=${CLICKHOUSE_DATABASE}"
+
   "TR_INTERNAL_GATEWAY_TOKEN=secretref:internal-token"
   "TR_SYNTHETIC_MONITOR_API_KEY=secretref:monitor-key"
   "TR_FEDERATION_HOME_TOKEN=secretref:federation-token"
@@ -226,6 +283,10 @@ SECRET_ARGS=(
 if [ "$DEFERRED_SETTLEMENT_ENABLED" = "true" ]; then
   ENV_VARS+=("TR_FEDERATION_SETTLEMENT_HOME_TOKEN=secretref:settlement-token")
   SECRET_ARGS+=("settlement-token=${SETTLEMENT_TOKEN}")
+fi
+if [ "$OUTBOX_ENABLED" = "true" ]; then
+  ENV_VARS+=("TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_PASSWORD=secretref:clickhouse-password")
+  SECRET_ARGS+=("clickhouse-password=${CLICKHOUSE_PASSWORD}")
 fi
 
 if exists az containerapp show -g "$RG" -n "$APP"; then
@@ -331,15 +392,16 @@ NOTE
 # ...and then the part that is NOT a note.
 #
 # Everything above provisions a control plane that serves, measures itself, and
-# publishes a status page. None of it gives this cloud an operational-analytics
-# pipeline: the ENV_VARS block sets no TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED,
-# so settle enqueues nothing, there is no outbox to drain, and no drain. On AWS
-# that same gap ran for fifteen days behind an entirely green status page
-# because the only alarm is emitted by the missing process.
+# publishes a status page. Whether it also gives this cloud an
+# operational-analytics pipeline now depends on one thing this script MEASURES
+# rather than assumes: whether a ClickHouse node and its password exist. With
+# them, the outbox is on and the plane publishes an `analytics` section. Without
+# them the outbox is explicitly off, because a producer with no consumer is the
+# outage rather than a smaller version of working.
 #
-# So this deploy now ends by asking whether the CLOUD works rather than whether
-# the script finished, and today, on Azure, it says no. That is the correct
-# answer, and no variable this script inherits changes it: the verifier's bound
+# So this deploy ends by asking whether the CLOUD works rather than whether the
+# script finished, and no variable this script inherits changes the answer: the
+# verifier's bound
 # is a constant in src/ and its URL comes from the fleet registry, and the two
 # variables it reads at all -- TR_MAX_DRAIN_LAG_SECONDS and TR_STATUS_URL -- it
 # reads only in order to print that they are being IGNORED. (An earlier version
@@ -354,18 +416,26 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/deploy/cloud_complete_gate.sh
 . "${SCRIPT_DIR}/cloud_complete_gate.sh"
 
-require_cloud_complete azure "$(cat <<'NEXT'
-The Azure app is deployed and serving. The Azure CLOUD is not complete: it has
-no operational-analytics pipeline at all. To finish it:
+read -r -d '' NEXT_STEPS <<NEXT || true
+The Azure app is deployed and serving. Whether the Azure CLOUD is complete
+depends on the stage this run reported above.
 
-  1. give it somewhere to drain TO (a ClickHouse this cloud owns, mirroring
-     scripts/deploy/aws_eu_clickhouse.sh) — this is a COST decision, so it is
-     not made by a deploy script;
-  2. add to the ENV_VARS block in this file:
-       TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true
-       TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_URL=...  (+ user/database/password)
-  3. install a drain against it, mirroring
-     scripts/deploy/aws_eu_clickhouse_drain_install.sh;
-  4. bash scripts/deploy/verify_cloud_complete.sh azure
+Analytics for this deploy: outbox=${OUTBOX_ENABLED}, clickhouse=${CLICKHOUSE_URL_EFFECTIVE:-none}
+
+If the outbox is FALSE, this cloud enqueues nothing and stage (e) fails. Build
+the pipeline, in this order and no other:
+
+  1. bash scripts/deploy/azure_clickhouse.sh uaenorth
+     bash scripts/deploy/azure_clickhouse.sh southeastasia
+  2. create the scoped Postgres role (runbook stage 3)
+  3. bash scripts/deploy/azure_clickhouse_drain_install.sh
+  4. re-run THIS script: it finds the node and the vault secret, and the outbox
+     turns itself on. There is nothing to edit here.
+  5. bash scripts/deploy/verify_cloud_complete.sh azure
+
+If the outbox is TRUE and a stage still failed, read which one: a published
+section that is stale, unavailable, or lagging is a drain problem, not a deploy
+problem, and docs/storage-portability/azure-analytics-runbook.md says which.
 NEXT
-)"
+
+require_cloud_complete azure "$NEXT_STEPS"

--- a/scripts/deploy/sql/azure_operational_outbox_drain_role.sql
+++ b/scripts/deploy/sql/azure_operational_outbox_drain_role.sql
@@ -1,0 +1,97 @@
+-- The Azure drain's login: SELECT and DELETE on ONE table, and nothing else.
+--
+-- WHY NOT THE ADMIN
+-- -----------------
+-- tradmin can read every table in this database, including tr_entities, which
+-- holds raw member emails and workspace ids — the identifiers
+-- analytics_surrogate() exists to keep OFF the analytics host. The drain runs
+-- on the ClickHouse node. A node holding admin credentials for the operational
+-- database is a node that can read the customer list, and it would work
+-- perfectly, which is the problem: nothing would ever ask.
+--
+-- scripts/deploy/azure_clickhouse_drain_install.sh refuses to install the unit
+-- unless the role it is given can SELECT and DELETE this table and CANNOT read
+-- tr_entities. All three are measured against the database, not against the
+-- intention of whoever ran this file.
+--
+-- WHY DELETE IS NOT OPTIONAL
+-- --------------------------
+-- The drain writes ClickHouse and only then deletes. A role with SELECT and no
+-- DELETE produces the quietest possible failure: every row is delivered, every
+-- metric reads healthy, rows_per_second is positive — and the outbox grows
+-- forever because nothing is ever removed. The installer checks for it by name.
+--
+-- HOW THE PASSWORD GETS IN HERE
+-- -----------------------------
+-- It is NOT in this file and must never be. `:'drain_password'` is a psql
+-- variable, set by the caller through a pipe:
+--
+--   {
+--     printf "\\set drain_password '"
+--     az keyvault secret show --vault-name tr-azure-analytics-kv \
+--       -n drain-postgres-password --query value -o tsv | tr -d '\n'
+--     printf "'\n"
+--     cat scripts/deploy/sql/azure_operational_outbox_drain_role.sql
+--   } | psql "host=tr-azure-pg.postgres.database.azure.com port=5432 \
+--             user=tradmin dbname=trustedrouter sslmode=require" \
+--         -v ON_ERROR_STOP=1 -f -
+--
+-- Through a PIPE and not `-v drain_password=...`, because a psql -v value is
+-- argv and every local user can read argv out of ps. Not through a temporary
+-- file either: the file is what gets committed by accident.
+--
+-- The value itself is generated once, into Key Vault, by
+-- scripts/deploy/azure_clickhouse.sh — which never reads it back. Nobody has to
+-- invent a password and nobody has to know one.
+--
+-- Azure Flexible Server is PASSWORD auth: there is no DSQL-style IAM token
+-- here, so the drain's environment file supplies PGPASSWORD and its DSN
+-- carries no password at all (a DSN that carries one is refused outright by
+-- PostgresOperationalOutboxSource, because argv is readable).
+--
+-- Re-runnable: CREATE ROLE on an existing role is an error, so creation is
+-- conditional (via \gexec) and the password is then set unconditionally. Every
+-- GRANT below is idempotent on its own.
+--
+-- NOT written as a DO $$ ... $$ block: psql does NOT expand :'variables'
+-- inside a dollar-quoted string, so a DO block would try to set the password to
+-- the literal text `:'drain_password'` — and would succeed, leaving a role
+-- whose password is a nine-character string nobody knows they know.
+
+\set ON_ERROR_STOP on
+
+SELECT 'CREATE ROLE tr_drain WITH LOGIN'
+ WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'tr_drain')
+\gexec
+
+ALTER ROLE tr_drain WITH LOGIN PASSWORD :'drain_password';
+
+-- The role attributes are ASSERTED at the bottom rather than set here.
+-- CREATE ROLE already defaults to NOSUPERUSER / NOCREATEDB / NOCREATEROLE, and
+-- on Azure Flexible Server `tradmin` is not a superuser: an
+-- `ALTER ROLE ... NOSUPERUSER NOBYPASSRLS` line would abort this whole file
+-- with a permission error while looking like extra safety.
+
+GRANT CONNECT ON DATABASE trustedrouter TO tr_drain;
+GRANT USAGE ON SCHEMA public TO tr_drain;
+GRANT SELECT, DELETE ON TABLE tr_operational_analytics_outbox TO tr_drain;
+
+-- Deliberately NOT granted, and each omission is load-bearing:
+--   * no GRANT on any other table. The drain reads one queue;
+--   * no ALTER DEFAULT PRIVILEGES. A future table must not become readable
+--     here by existing;
+--   * no CREATE on the schema. The drain never writes DDL;
+--   * no sequence grants. It inserts nothing.
+
+-- Say what was actually granted, so the operator reads the database's answer
+-- rather than this file's intention.
+SELECT
+    r.rolname AS role,
+    r.rolsuper AS is_superuser_MUST_BE_FALSE,
+    r.rolcreatedb AS can_create_db_MUST_BE_FALSE,
+    r.rolcreaterole AS can_create_role_MUST_BE_FALSE,
+    has_table_privilege('tr_drain', 'tr_operational_analytics_outbox', 'SELECT') AS can_select_outbox,
+    has_table_privilege('tr_drain', 'tr_operational_analytics_outbox', 'DELETE') AS can_delete_outbox,
+    has_table_privilege('tr_drain', 'tr_entities', 'SELECT') AS can_read_entities_MUST_BE_FALSE
+FROM pg_roles r
+WHERE r.rolname = 'tr_drain';

--- a/src/trusted_router/cloud_rollout_completeness.py
+++ b/src/trusted_router/cloud_rollout_completeness.py
@@ -426,17 +426,32 @@ ROLLOUT_REGISTRY: dict[str, CloudRollout] = {
     "azure": CloudRollout(
         cloud="azure",
         control_plane_script="scripts/deploy/azure_control_plane.sh",
-        # No such script exists yet: Azure has no operational-analytics outbox
-        # at all, which is the point. The stage that fails says so and names
-        # what has to be built, rather than pointing at a file that is not there.
-        drain_install_command=(
-            "write it — Azure has no operational-analytics drain yet; the outbox "
-            "must be enabled in scripts/deploy/azure_control_plane.sh and a drain "
-            "installed against its ClickHouse, mirroring "
-            "scripts/deploy/aws_eu_clickhouse_drain_install.sh"
-        ),
+        # This field used to be a paragraph explaining that no such script
+        # existed. It exists now, and it runs on the uaenorth node only: ONE
+        # drain writes both regions' copies, because two drains against one
+        # outbox would each delete rows the other had not yet written.
+        drain_install_command="bash scripts/deploy/azure_clickhouse_drain_install.sh",
         deploy_scripts=(
+            DeployScript("scripts/deploy/azure_clickhouse.sh", PROVEN_BY_EXECUTION),
             DeployScript("scripts/deploy/azure_control_plane.sh", PROVEN_BY_EXECUTION),
+            # Runnable under stubs, unlike its AWS sibling, and it is worth
+            # being exact about what that buys and what it does not. What the
+            # harness proves is CONTROL FLOW: the gate is called for azure, and
+            # every code the gate can return comes out of this script
+            # unaltered. What it cannot prove is the middle — the chunked
+            # payload, the scoped-role check and the row counts all travel
+            # through `az vm run-command`, which the harness answers from a
+            # fixture, so under stubs those steps assert against the stub. That
+            # is exactly the objection recorded against
+            # aws_eu_clickhouse_drain_install.sh; the difference here is only
+            # that the script can REACH its own end without the fixture having
+            # to fake a success signal the script then reads as evidence, so
+            # the two behavioural properties are measurable. The evidence that
+            # rows moved is still in-cloud, and still two numbers ten minutes
+            # apart.
+            DeployScript(
+                "scripts/deploy/azure_clickhouse_drain_install.sh", PROVEN_BY_EXECUTION
+            ),
         ),
     ),
 }

--- a/src/trusted_router/operational_analytics_fleet.py
+++ b/src/trusted_router/operational_analytics_fleet.py
@@ -49,17 +49,26 @@ WHY A ``reason`` FIELD AND NOT AN OMISSION
     can fix is a check people learn to ignore.
 
 WHY ``expects_outbox`` AND NOT A SECOND ``reason``
-    Azure is reachable, publishes a status page, and has no operational-analytics
-    outbox at all: ``scripts/deploy/azure_control_plane.sh`` never sets
-    ``TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED``, so the flag defaults off and
-    ``PostgresStore`` holds no outbox to read. Its section says
-    ``not_configured`` and would say so forever. Retiring it behind ``reason=``
-    would work, and would also throw away the ability to notice the day it
-    changes: an outbox that gets enabled on Azure would go unwatched exactly as
-    AWS-EU's was. ``expects_outbox=False`` instead keeps fetching the page and
-    asserts the ABSENCE -- unchecked while it publishes ``not_configured``, a
-    FAILURE the moment it publishes a real lag, which is the moment somebody
-    needs to come back here and start watching it.
+    Azure was this field's only user, and is not any more -- which is the field
+    working rather than the field becoming redundant. It was reachable,
+    publishing a status page, and running no operational-analytics outbox at
+    all, because ``scripts/deploy/azure_control_plane.sh`` never set
+    ``TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED`` and the flag defaults off. Its
+    section said ``not_configured`` and would have said so forever. Retiring it
+    behind ``reason=`` would have worked, and would also have thrown away the
+    ability to notice the day it changed: an outbox enabled on Azure would then
+    have gone unwatched for exactly the reason AWS-EU's was.
+    ``expects_outbox=False`` asserted the ABSENCE instead -- unchecked while
+    ``not_configured``, a FAILURE the moment a real lag appeared, which is the
+    moment somebody had to come back here and start watching it.
+
+    That day was 2026-08-18: Azure got two ClickHouse nodes, a drain that
+    writes both before deleting, and a control plane that STATES the flag. So
+    its entry is now ``expects_outbox=True`` and the cloud is measured like any
+    other. No live entry sets the field False today; the mechanism keeps its
+    tests (``tests/test_analytics_freshness_registry.py`` builds its own
+    registry for them) so that the next cloud declared outbox-free lands on
+    tested code rather than on a trapdoor nobody has opened in a year.
 
 NOTHING HERE DOES IO. :mod:`clickhouse.check_fleet_analytics_freshness` fetches.
 """
@@ -164,20 +173,33 @@ ANALYTICS_FRESHNESS_FLEET: tuple[FleetAnalyticsEndpoint, ...] = (
         cloud="azure",
         status_url="https://azure.trustedrouter.com/status.json",
         expected_backend=BACKEND_POSTGRES,
-        expects_outbox=False,
+        # TRUE as of the commit that built the pipeline, and only that commit.
+        # It was False for a reason that has now stopped being true: Azure had
+        # no outbox at all, so the honest assertion was the ABSENCE of one --
+        # `not_configured` reported as explicitly unchecked, a live lag reported
+        # as a FAILURE saying somebody should come back here and start watching.
+        # This is that somebody. Azure now owns two ClickHouse nodes
+        # (scripts/deploy/azure_clickhouse.sh), a drain that writes both before
+        # deleting (scripts/deploy/azure_clickhouse_drain_install.sh), and a
+        # control plane whose analytics flag is STATED rather than defaulted.
+        # So the assertion flips with the thing it asserts about: from here on a
+        # missing lag is a failure, which is the whole point of publishing one.
+        expects_outbox=True,
         note=(
             "The Azure control plane's own hostname, set as STATUS_HOST by "
             "scripts/deploy/azure_control_plane.sh and pointed at the container app "
-            "by that script's Cloud DNS step. It runs PostgresStore, so it COULD "
-            "hold the same outbox shape as AWS -- but that deploy script sets no "
-            "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED at all, the setting defaults "
-            "to False (config.py), and PostgresStore therefore builds no outbox. "
-            "That is read off the deploy script and the default, not off the "
-            "wire -- Azure published no `analytics` section when this was "
-            "written, and the current answer is one command away: "
-            "curl -s https://azure.trustedrouter.com/status.json | jq .data.analytics . "
-            "There is no drain here to be missing; expects_outbox=False "
-            "asserts that absence and fails the day it stops being true."
+            "by that script's Cloud DNS step. It runs PostgresStore and now holds "
+            "the same outbox shape as AWS: that deploy script sets "
+            "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED from whether a ClickHouse node "
+            "and its Key Vault secret exist, and the drain runs on the uaenorth "
+            "node writing a second copy in southeastasia before it deletes "
+            "anything. Two regions here is DURABILITY, not residency: both nodes "
+            "hold the same rows, and no row leaves Azure. Until the flag-flipping "
+            "deploy has actually run, this entry FAILS -- deliberately, and it is "
+            "the correct reading of a cloud whose pipeline exists in the "
+            "repository and not yet on the wire. The current answer is one command "
+            "away: "
+            "curl -s https://azure.trustedrouter.com/status.json | jq .data.analytics"
         ),
     ),
     FleetAnalyticsEndpoint(

--- a/tests/deploy_script_harness.py
+++ b/tests/deploy_script_harness.py
@@ -238,6 +238,13 @@ SCRIPT_FIXTURES: dict[str, ScriptFixture] = {
             (r"--query .?loginServer", "trazureuaenorthacr.azurecr.io"),
             (r"--query .?fullyQualifiedDomainName", "tr-azure-pg.postgres.database.azure.com"),
             (r"--query .?properties\.configuration\.ingress\.fqdn", "tr-azure.example.net"),
+            # The analytics conditional: with a ClickHouse node and a vault
+            # secret present, this script turns the outbox ON and points the
+            # plane at the node's PRIVATE address. Answering with a plausible
+            # address keeps the URL it builds readable in the run log; the
+            # branch is taken either way, because the fixture's default answer
+            # is also non-empty.
+            (r"privateIpAddresses", "10.61.3.4"),
             # It asserts the COUNT of tr_* tables, not psql's exit code.
             (r"information_schema\.tables", "9"),
         ),
@@ -245,6 +252,42 @@ SCRIPT_FIXTURES: dict[str, ScriptFixture] = {
         # armed to remove the temporary Postgres firewall rule it opened to
         # apply the schema. Cleanup, not provisioning.
         cleanup_after_gate=(r"firewall-rule delete",),
+    ),
+    "scripts/deploy/azure_clickhouse.sh": ScriptFixture(
+        responses=(
+            # It refuses a subnet that is not inside the VNet, and one that
+            # overlaps an existing subnet — in real ipaddress arithmetic, over
+            # the ranges it read back. Answering these two with the measured
+            # values is what makes that check run rather than skip.
+            (r"addressSpace\.addressPrefixes", "10.61.0.0/16"),
+            (r"\[\]\.addressPrefix", "10.61.0.0/23 10.61.2.0/24"),
+            (r"privateIpAddresses", "10.61.3.4"),
+            # `az vm run-command invoke` exits 0 whether the remote script
+            # succeeded or failed, so the script's only signal is the marker the
+            # remote body echoes. This fixture supplies it, and what that means
+            # is exactly what the module header says: a fixture cannot make a
+            # missing gate call appear or a swallowed exit status non-zero, but
+            # it does mean the SCHEMA step here asserts against this stub rather
+            # than against a node. The row-count evidence is in-cloud.
+            # One LINE, because the fixture table is tab-separated and
+            # newline-delimited: a reply containing a newline silently becomes
+            # a second, malformed row.
+            (r"vm run-command invoke", "tables the drain writes: 8 ... TR_RUNCMD_OK"),
+        ),
+    ),
+    "scripts/deploy/azure_clickhouse_drain_install.sh": ScriptFixture(
+        responses=(
+            (r"fullyQualifiedDomainName", "tr-azure-pg.postgres.database.azure.com"),
+            # The private-DNS preflight: a zone that exists, linked to vnet-prod.
+            # Without both the drain resolves the PUBLIC address of a server with
+            # zero firewall rules and times out every connection while the unit
+            # reports itself active.
+            (r"private-dns zone list", "tr-azure"),
+            (r"private-dns link vnet list", "vnet-prod-link"),
+            (r"privateIpAddresses", "10.62.1.4"),
+            (r"identity show", "11111111-2222-3333-4444-555555555555"),
+            (r"vm run-command invoke", "TR_RUNCMD_OK"),
+        ),
     ),
 }
 

--- a/tests/test_analytics_freshness_registry.py
+++ b/tests/test_analytics_freshness_registry.py
@@ -559,60 +559,120 @@ def test_a_cloud_with_a_reason_is_reported_as_unchecked_and_does_not_fail() -> N
     assert result.unchecked[0].startswith("aws: NOT CHECKED")
 
 
-def test_a_cloud_declared_outbox_free_is_unchecked_rather_than_failing() -> None:
-    """Azure today: no TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED, so no outbox.
+#: A registry with an outbox-free entry, written out instead of borrowed.
+#:
+#: These three tests used to read `expects_outbox=False` off the live registry,
+#: where Azure was its only user. Azure now runs a real pipeline
+#: (scripts/deploy/azure_clickhouse.sh + azure_clickhouse_drain_install.sh) and
+#: its entry says `expects_outbox=True`, so OUTBOX_FREE_CLOUDS is empty and
+#: every one of these tests would have quietly become a loop over nothing --
+#: passing, collecting zero cases, and testing the mechanism not at all. That is
+#: the precise shape this file exists to prevent one level up, so the mechanism
+#: keeps its coverage and gets its own fixture.
+_OUTBOX_FREE_REGISTRY = (
+    FleetAnalyticsEndpoint(
+        cloud="gcp",
+        status_url="https://trustedrouter.com/status.json",
+        expected_backend=BACKEND_SPANNER,
+    ),
+    FleetAnalyticsEndpoint(
+        cloud="aws",
+        status_url="https://tr-eu.example.com/status.json",
+        expected_backend=BACKEND_POSTGRES,
+        expects_outbox=False,
+        note="a deployment declared to have no operational-analytics outbox at all",
+    ),
+)
+_OUTBOX_FREE_CLOUD = "aws"
+_OUTBOX_FREE_DEPLOYED = ["aws", "gcp"]
 
-    It would publish `not_configured` forever. Failing on it daily is the
-    cry-wolf shape the repo already fixed once, in the client-telemetry
-    freshness check's `CANARY_COUNT_GATE_FROM` ramp-up guard.
+
+def _outbox_free_payloads() -> dict[str, dict[str, object] | None]:
+    """Every entry answering exactly what `_OUTBOX_FREE_REGISTRY` declares."""
+    return {
+        "gcp": _healthy("gcp"),
+        _OUTBOX_FREE_CLOUD: {
+            ANALYTICS_STATUS_KEY: analytics_status_unavailable(REASON_NOT_CONFIGURED)
+        },
+    }
+
+
+def test_a_cloud_declared_outbox_free_is_unchecked_rather_than_failing() -> None:
+    """A cloud with no outbox publishes `not_configured` forever.
+
+    Failing on it daily is the cry-wolf shape the repo already fixed once, in
+    the client-telemetry freshness check's `CANARY_COUNT_GATE_FROM` ramp-up
+    guard. So it is reported as UNCHECKED: printed, counted, never silent, and
+    never a daily red.
     """
-    result = evaluate_fleet(_as_declared(), now=NOW)
+    assert registry_defects(_OUTBOX_FREE_DEPLOYED, registry=_OUTBOX_FREE_REGISTRY) == []
+
+    result = evaluate_fleet(
+        _outbox_free_payloads(),
+        now=NOW,
+        registry=_OUTBOX_FREE_REGISTRY,
+        deployed=_OUTBOX_FREE_DEPLOYED,
+    )
 
     assert result.problems == []
-    for cloud in OUTBOX_FREE_CLOUDS:
-        assert any(note.startswith(f"{cloud}: NOT CHECKED") for note in result.unchecked)
+    assert any(
+        note.startswith(f"{_OUTBOX_FREE_CLOUD}: NOT CHECKED") for note in result.unchecked
+    )
     assert any("expects_outbox=False" in note for note in result.unchecked)
 
 
-def test_the_azure_entry_is_the_one_declared_outbox_free() -> None:
-    """Read off the deploy script, and pinned so a silent flip is visible.
+def test_every_live_entry_now_expects_an_outbox() -> None:
+    """The state this commit puts the fleet in, pinned so a silent flip is loud.
 
-    `scripts/deploy/azure_control_plane.sh` sets no
-    TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED at all, and the setting defaults to
-    False, so PostgresStore builds no outbox there.
+    This test used to assert the opposite about Azure, and read the reason off
+    `azure_control_plane.sh` setting no outbox variable at all. It sets one now,
+    computed from whether a ClickHouse node and its Key Vault secret exist, and
+    Azure owns two nodes and a drain. So all three clouds are MEASURED, and a
+    cloud that stops publishing a live lag is a failure rather than an expected
+    absence -- including Azure, from the moment this lands and before the
+    flag-flipping deploy has run. That failure is information, not noise.
     """
-    azure = fleet_endpoint("azure")
-    assert azure is not None and azure.expects_outbox is False
-
-    for cloud in ("aws", "gcp"):
+    for cloud in ("aws", "azure", "gcp"):
         entry = fleet_endpoint(cloud)
-        assert entry is not None and entry.expects_outbox is True
+        assert entry is not None and entry.expects_outbox is True, cloud
+    assert OUTBOX_FREE_CLOUDS == []
 
 
 def test_a_cloud_declared_outbox_free_that_grows_one_FAILS() -> None:
-    """The trapdoor this closes, and the reason it is not just `reason=`.
+    """The trapdoor, and the reason `expects_outbox=False` is not just `reason=`.
 
-    Retiring Azure behind a bare reason would also retire the ability to notice
-    the day it gets a pipeline -- which would then be unwatched for exactly the
-    reason AWS-EU's was.
+    Retiring such a cloud behind a bare reason would also retire the ability to
+    notice the day it gets a pipeline -- which would then be unwatched for
+    exactly the reason AWS-EU's was. Asserting the ABSENCE means the day it
+    stops being absent, somebody is told to come back and start watching.
     """
-    payloads = _all_healthy()
+    payloads = _outbox_free_payloads()
+    payloads[_OUTBOX_FREE_CLOUD] = _healthy("aws")
 
-    result = evaluate_fleet(payloads, now=NOW)
+    result = evaluate_fleet(
+        payloads, now=NOW, registry=_OUTBOX_FREE_REGISTRY, deployed=_OUTBOX_FREE_DEPLOYED
+    )
 
-    assert [problem for problem in result.problems if problem.startswith("azure:")]
+    assert [
+        problem for problem in result.problems if problem.startswith(f"{_OUTBOX_FREE_CLOUD}:")
+    ]
     assert any("expects_outbox=True" in problem for problem in result.problems)
 
 
-@pytest.mark.parametrize("cloud", OUTBOX_FREE_CLOUDS)
-def test_a_cloud_declared_outbox_free_still_fails_when_its_database_is_broken(cloud: str) -> None:
+def test_a_cloud_declared_outbox_free_still_fails_when_its_database_is_broken() -> None:
     """`expects_outbox=False` excuses `not_configured`, and nothing else."""
-    payloads = _as_declared()
-    payloads[cloud] = {ANALYTICS_STATUS_KEY: analytics_status_unavailable(REASON_UNREACHABLE)}
+    payloads = _outbox_free_payloads()
+    payloads[_OUTBOX_FREE_CLOUD] = {
+        ANALYTICS_STATUS_KEY: analytics_status_unavailable(REASON_UNREACHABLE)
+    }
 
-    result = evaluate_fleet(payloads, now=NOW)
+    result = evaluate_fleet(
+        payloads, now=NOW, registry=_OUTBOX_FREE_REGISTRY, deployed=_OUTBOX_FREE_DEPLOYED
+    )
 
-    assert [problem for problem in result.problems if problem.startswith(f"{cloud}:")]
+    assert [
+        problem for problem in result.problems if problem.startswith(f"{_OUTBOX_FREE_CLOUD}:")
+    ]
 
 
 def test_unavailable_explanations_differ_per_reason() -> None:

--- a/tests/test_cloud_rollout_completeness.py
+++ b/tests/test_cloud_rollout_completeness.py
@@ -485,19 +485,26 @@ def test_the_limit_of_a_passing_lag_is_printed_on_every_passing_run(tmp_path: Pa
 # ---------------------------------------------------------------------------
 
 
-def test_azure_fails_because_it_has_no_outbox_at_all() -> None:
-    """Pins the state found on 2026-08-17, and the reason it is not benign.
+def test_azure_now_declares_the_outbox_and_says_it_is_computed() -> None:
+    """This test used to assert the opposite, and the flip is the change.
 
-    Azure's control-plane deploy script sets no outbox variable, so settle
-    enqueues nothing. Every published freshness signal for such a cloud is
-    vacuously green. This test flips to the other branch when the outbox is
-    added, which is the point at which it should.
+    Until 2026-08-18 `azure_control_plane.sh` set no outbox variable at all, so
+    settle enqueued nothing and every published freshness signal for the cloud
+    was vacuously green. The previous version of this test pinned that state and
+    said in its own docstring that it should flip when the outbox was added.
+    This is the other branch.
+
+    What it asserts is deliberately narrow, and stage (e) says the same thing in
+    its note: the script can now ENABLE the outbox, computing the value at
+    deploy time from whether a ClickHouse node and its Key Vault secret exist.
+    It does not assert that any deployed Azure revision has it on — nothing
+    readable from a checkout can, which is why stages (b)-(d) exist and why they
+    are still 5 for this cloud until the flag-flipping deploy has run.
     """
-    assert crc.declared_outbox_value("azure") is None
-    blockers = crc.outbox_enabled_blockers("azure")
-    assert blockers
-    assert "never sets TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED" in blockers[0]
-    assert "looks perfectly healthy" in blockers[0]
+    assert crc.declared_outbox_value("azure") == "${OUTBOX_ENABLED}"
+    assert crc.outbox_enabled_blockers("azure") == []
+    note = crc.outbox_note("azure")
+    assert note is not None and "computed at deploy time" in note
 
 
 def test_gcp_and_aws_declare_the_outbox() -> None:
@@ -593,10 +600,15 @@ def test_the_form_the_failure_message_prescribes_is_accepted(tmp_path: Path) -> 
     characters.
     """
     prescription = f"{crc.OUTBOX_ENABLED_ENV}=true"
-    assert prescription in crc.outbox_enabled_blockers("azure")[0]
-
+    # Read off a cloud that is actually failing the stage. This used to read the
+    # real Azure blocker, and Azure now declares the variable — so the assertion
+    # was silently about to become an IndexError on a passing cloud rather than
+    # a statement about the message.
     script_dir = tmp_path / "scripts" / "deploy"
     script_dir.mkdir(parents=True)
+    (script_dir / "azure_control_plane.sh").write_text("#!/usr/bin/env bash\necho hello\n")
+    assert prescription in crc.outbox_enabled_blockers("azure", root=tmp_path)[0]
+
     (script_dir / "azure_control_plane.sh").write_text(
         "#!/usr/bin/env bash\n"
         f"# {prescription}   <- a comment is still not a setting\n"


### PR DESCRIPTION
Azure enqueued nothing and drained nothing. `azure_control_plane.sh` set no
`TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED`, so the flag fell back to `config.py`'s
`False` — off by omission rather than by decision — and stage (e) of the
completeness gate failed for exactly that reason.

This builds the cloud-local pipeline, in the order that makes the flag safe.

## What is here

**`scripts/deploy/azure_clickhouse.sh`** — the nodes, one region per invocation
(`uaenorth` first, then `southeastasia`; the order is enforced, not suggested).
uaenorth joins `vnet-prod`, because the drain must reach `tr-azure-pg` over its
private endpoint. southeastasia gets its own resource group, VNet, NSG and Key
Vault, joined by **global VNet peering created from both ends and asserted
`Connected`** — a one-sided peering drops every packet while both resources look
healthy. Nodes bind their PRIVATE address; the subnet NSG admits 8123/9000 from
one CIDR and admits the internet to nothing, including no SSH rule anywhere
(shells are `az vm run-command`). `clickhouse/006` + `clickhouse/009` are applied
to each node and the table **count** is asserted, not the exit status.

**`scripts/deploy/azure_clickhouse_drain_install.sh`** — ONE drain, on the
uaenorth node, fanning out to southeastasia so both copies are written before any
outbox row is deleted. Two drains against one outbox would each DELETE rows the
other had not yet written. It refuses to install until it has measured three
things:

* the private DNS zone for the Postgres private endpoint is linked to `vnet-prod`
  — without it the drain resolves the PUBLIC address of a server with zero
  firewall rules and times out on every connection while the unit sits `active`;
* the second node exists (a silent single-target drain logs `copies=1`,
  indistinguishable from a deliberate one-node deployment);
* the login it was given can `SELECT` **and `DELETE`** the outbox and **cannot**
  read `tr_entities`. A role without DELETE is the quietest failure available:
  every row delivered, every metric healthy, outbox growing forever.

**`scripts/deploy/sql/azure_operational_outbox_drain_role.sql`** — the scoped
role. Its password is generated once into Key Vault by the provisioning script,
which never reads it back, and reaches `psql` through a **pipe** — not argv, not
a file. The nodes fetch their own secrets over IMDS; no secret passes through an
operator's terminal at any stage.

**`azure_control_plane.sh`** — the analytics conditional, mirroring
`aws_eu_control_plane.sh`: the flag is now STATED and computed from whether a
ClickHouse node and its vault secret exist. Also fixes the `APP` default from
`tr-azure` to **`tr-azure-vnet`**, which is what production runs; the file called
itself the source of truth while pointing at a different container app.

## Two regions is durability, not residency

Both nodes hold the **same** rows. This is the Paris+Stockholm pattern: the drain
writes both and deletes only when both accepted, so the failure mode is "the
outbox grows", never "data is lost". No row leaves Azure, and nothing here
replicates to or from GCP or AWS.

## Gate compliance

Both new scripts are bound in `ROLLOUT_REGISTRY['azure']`, both are executed end
to end by `tests/test_deploy_script_execution.py`, and the docs'
`PROVEN_BY_EXECUTION` block names them. **What that proves is control flow** —
the gate is called for `azure`, and every gate exit code comes out unaltered —
and both the registry comment and the docs say plainly what it does not prove:
the remote channel is a fixture under stubs, so the middle asserts against the
stub. Evidence that rows moved is still two counts, ten minutes apart, from
inside the VNet.

`expects_outbox` for azure flips to `True` **in this commit**, which means the
fleet check FAILS for Azure until the runbook has actually been walked. That is
the correct reading of a pipeline that exists in the repository and not yet on
the wire, and the failure should be red for hours, not weeks.

## The runbook

`docs/storage-portability/azure-analytics-runbook.md`: nodes → peering → scoped
role → drain → watch it idle → **then** the flag → redeploy → verify from
outside → start watching. Each stage says what "working" looks like and what to
do when it is not.

**Nothing in it has been executed.** Azure ARM auth was dead on the machine that
wrote this (`AADSTS50132`, an expired session — the cached profile answers
`az account show` from disk while every ARM call fails), so no resource named
here has been observed to exist and three defaults are inferences the scripts
CHECK rather than trust: the free `/24` in `vnet-prod`, the private DNS zone, and
the `Standard_E2s_v5` SKU in southeastasia. The runbook says so at the top and
lists the readings to take first.

## Cost

≈ $270/month: two `Standard_E2s_v5` ($113.15/mo each at uaenorth prices read live
2026-08-18), two 128 GiB Premium SSDs ($21.50 each), two Standard public IPs
(~$3.65 each, egress-only — nothing listens on them), plus $0.25/GB of peering
traffic, both sides billed, carrying one copy of each drained batch.

## Gates

`uv run ruff check .` clean; `uv run mypy` clean (280 files); full suite
**4925 passed, 296 skipped, 10 xfailed** in 7m57s. Every deploy script parses
under `/bin/bash` 3.2 (macOS), which is why no next-steps text in this PR is
built as a heredoc inside `$( )`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
