### PR TITLE
Simplify homepage to cloud footprint

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -87,7 +87,6 @@ from trusted_router.provider_contract import (
     PROVIDER_CATALOG_V2_EXAMPLE,
 )
 from trusted_router.provider_lifecycle import provider_pricing_schedule
-from trusted_router.regions import configured_regions, region_map_payload
 from trusted_router.seo_catalog import seo_catalog_evidence
 from trusted_router.seo_meta import (
     SEO_TITLE_MAX_LENGTH,
@@ -1751,11 +1750,6 @@ def dashboard_html(
         "googleEnabled": settings.google_oauth_enabled,
         "githubEnabled": settings.github_oauth_enabled,
     }
-    map_regions = region_map_payload(settings)
-    live_map_regions = [region for region in map_regions if region["serving"]]
-    live_region_count = len(live_map_regions)
-    live_cloud_count = len({region["cloud"] for region in live_map_regions})
-    api_region_count = len(configured_regions(settings))
     return (
         _env()
         .get_template("dashboard.html")
@@ -1774,10 +1768,6 @@ def dashboard_html(
             google_enabled=settings.google_oauth_enabled,
             github_enabled=settings.github_oauth_enabled,
             paypal_enabled=settings.paypal_enabled,
-            map_regions=map_regions,
-            api_region_count=api_region_count,
-            live_region_count=live_region_count,
-            live_cloud_count=live_cloud_count,
             primary_region=settings.primary_region,
             static_version=_static_version(settings),
         )

--- a/src/trusted_router/static/charter.css
+++ b/src/trusted_router/static/charter.css
@@ -1095,7 +1095,7 @@ pre {
 
 .charter-stat-band {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   padding-top: 16px;
   padding-bottom: 16px;
   border-top: 1px solid var(--border-default);
@@ -1939,15 +1939,6 @@ body.auth.auth-shell {
 
   .charter-stat:nth-child(2) {
     border-right: 0;
-  }
-
-  .charter-stat:nth-child(-n + 2) {
-    padding-bottom: 14px;
-    border-bottom: 1px solid var(--border-hairline);
-  }
-
-  .charter-stat:nth-child(n + 3) {
-    padding-top: 14px;
   }
 
   .home-section {

--- a/src/trusted_router/templates/dashboard.html
+++ b/src/trusted_router/templates/dashboard.html
@@ -94,9 +94,7 @@
 
     <section class="charter-stat-band" aria-label="{{ brand_name }} facts">
       <div class="charter-stat"><strong>550+</strong><span>AI models</span></div>
-      <div class="charter-stat"><strong>{{ live_region_count }}</strong><span>Live regions</span></div>
-      <div class="charter-stat"><strong>{{ live_cloud_count }}</strong><span>Clouds</span></div>
-      <div class="charter-stat"><strong>4</strong><span>Continents</span></div>
+      <div class="charter-stat"><strong>3 clouds</strong><span>GCP · AWS · Azure</span></div>
     </section>
 
     <section class="home-section" aria-label="How {{ brand_name }} works">
@@ -275,36 +273,19 @@ response = client.chat.completions.create(
     </section>
 
     <section class="home-section">
-      <div class="home-wrap charter-map-grid">
-        <div>
-          <div class="kicker">Regional reliability</div>
-          <h2>Routing that does not depend on one provider or one region.</h2>
-          <p class="section-sub">Regional gateways, provider health measurements, and explicit fallback keep failures visible and contained. The public status page separates router-core health from upstream model health.</p>
-          <ul class="check-list">
-            <li>{{ api_region_count }} live API regions</li>
-            <li>Provider and model health measured continuously</li>
-            <li>Public latency and availability history</li>
-            <li>No silent fallback to a non-attested prompt path</li>
-          </ul>
-          <a class="btn" href="/status">View public status</a>
+      <div class="home-wrap narrow">
+        <div class="section-lead">
+          <div class="kicker">Multi-cloud reliability</div>
+          <h2>Routing that does not depend on one provider or one cloud.</h2>
+          <p>TrustedRouter runs across GCP, AWS, and Azure. Provider health measurements and explicit fallback keep failures visible and contained.</p>
         </div>
-        <div class="region-map-card" aria-label="{{ brand_name }} regional footprint">
-          <div class="region-map-visual">
-            <img src="/static/world-map.svg?v={{ static_version }}" alt="TrustedRouter regional routing map" loading="lazy">
-            <svg viewBox="0 0 1000 500" aria-hidden="true" preserveAspectRatio="xMidYMid meet">
-              {% for region in map_regions %}
-              <g class="region-dot {% if region.primary %}primary{% endif %} {% if region.serving %}live{% else %}edge{% endif %}" transform="translate({{ '%.1f'|format(region.x) }} {{ '%.1f'|format(region.y) }})">
-                <circle r="{% if region.primary %}9{% else %}7{% endif %}"></circle>
-                <text x="{{ region.label_dx }}" y="{{ region.label_dy }}" text-anchor="{{ region.label_anchor }}">{{ region.city }}{% if region.cloud == "aws" %} · AWS{% elif region.cloud == "azure" %} · Azure{% endif %}</text>
-              </g>
-              {% endfor %}
-            </svg>
-          </div>
-          <div class="region-map-copy">
-            <strong>{{ live_region_count }} live regions across {{ live_cloud_count }} clouds and 4 continents</strong>
-            <span>TrustedRouter runs across GCP, AWS, and Azure, serving North America, South America, Europe, and Australia today.</span>
-          </div>
-        </div>
+        <ul class="check-list">
+          <li>GCP, AWS, and Azure</li>
+          <li>Provider and model health measured continuously</li>
+          <li>Public latency and availability history</li>
+          <li>No silent fallback to a non-attested prompt path</li>
+        </ul>
+        <a class="btn" href="/status">View public status</a>
       </div>
     </section>
 

--- a/tests/browser/dashboard.spec.js
+++ b/tests/browser/dashboard.spec.js
@@ -13,10 +13,11 @@ test("homepage opens sign-in modal and handles missing MetaMask", async ({ page 
   await expect(page.locator(".charter-home-hero .lead-claim")).toHaveText(
     "Better privacy, better prices, better uptime, no subscriptions.",
   );
-  await expect(page.locator(".charter-stat-band")).toContainText("550+AI models");
-  await expect(page.locator(".charter-stat-band")).toContainText("7Live regions");
-  await expect(page.locator(".charter-stat-band")).toContainText("3Clouds");
-  await expect(page.locator(".charter-stat-band")).toContainText("4Continents");
+  const homepageStats = page.locator(".charter-stat-band .charter-stat");
+  await expect(homepageStats).toHaveCount(2);
+  await expect(homepageStats.first()).toContainText("550+AI models");
+  await expect(homepageStats.last()).toContainText("3 cloudsGCP · AWS · Azure");
+  await expect(page.locator(".region-map-card")).toHaveCount(0);
   await expect(page.locator("body")).toHaveCSS("font-size", "15.5px");
   await expect(page.locator(".charter-pillar p a").first()).toHaveCSS("text-decoration-line", "underline");
 

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -651,9 +651,8 @@ def test_dashboard_links_to_public_models_not_keyed_api_catalog(client: TestClie
     assert "One Unified Interface." in response.text
     assert "Privacy with proof." in response.text
     assert "Better privacy, better prices, better uptime, no subscriptions." in response.text
-    assert '<strong>7</strong><span>Live regions</span>' in response.text
-    assert '<strong>3</strong><span>Clouds</span>' in response.text
-    assert '<strong>4</strong><span>Continents</span>' in response.text
+    assert '<strong>3 clouds</strong><span>GCP · AWS · Azure</span>' in response.text
+    assert 'class="region-map-card"' not in response.text
     assert "Provable privacy." not in response.text
     assert "ATTESTED GATEWAY" in response.text  # attestation record
     assert "Get API key" in response.text  # primary CTA

--- a/tests/test_smoke_prod.py
+++ b/tests/test_smoke_prod.py
@@ -264,15 +264,15 @@ def test_regions_list_covers_all_ten_gcp_regions(client: httpx.Client) -> None:
 def test_marketing_page_advertises_production_not_alpha(client: httpx.Client) -> None:
     """Belt-and-suspenders for the alpha-removal: if a future deploy
     accidentally restores 'Public Alpha' framing, this test fails. The
-    regions copy is also the smoke check that the regions panel
-    rendered (Jinja didn't error out on map_regions)."""
+    cloud copy also verifies that the multi-cloud reliability section rendered."""
     response = client.get("/")
     assert response.status_code == 200
     body = response.text
     assert "Public Alpha" not in body
-    assert "Live regions" in body
-    assert "regional routing" in body or "multi-region" in body
-    assert "world-map.svg" in body or "<svg" in body  # map renders
+    assert "3 clouds" in body
+    assert "GCP · AWS · Azure" in body
+    assert "GCP, AWS, and Azure" in body
+    assert "world-map.svg" not in body
 
 
 def test_oauth_login_redirects_to_provider(client: httpx.Client) -> None:

--- a/tests/test_stubs_and_security.py
+++ b/tests/test_stubs_and_security.py
@@ -196,9 +196,10 @@ def test_dashboard_and_trust_pages_are_real_surfaces(client: TestClient) -> None
     assert "Get API key" in dashboard.text
     assert "End-to-End Encrypted AI gateway" in dashboard.text
     assert "ATTESTED GATEWAY" in dashboard.text  # routing-diagram hero
-    assert "Live regions" in dashboard.text  # reliability stats
-    assert "7 live regions across 3 clouds and 4 continents" in dashboard.text
-    assert "North America, South America, Europe, and Australia" in dashboard.text
+    assert "3 clouds" in dashboard.text
+    assert "GCP · AWS · Azure" in dashboard.text
+    assert "GCP, AWS, and Azure" in dashboard.text
+    assert "world-map.svg" not in dashboard.text
     assert "trustedrouter/auto" in dashboard.text  # routing model
     assert "$25 USDC" not in dashboard.text
     assert "Stripe Crypto" not in dashboard.text


### PR DESCRIPTION
## Summary
- remove the regional map from the homepage
- remove region and continent counts from homepage messaging
- show only the multi-cloud footprint: 3 clouds, GCP, AWS, Azure
- retain reliability copy without geographic advertising

## Verification
- 22 focused contracts passed
- 2 Playwright desktop/mobile tests passed
- ruff, mypy, ESLint, and Stylelint passed
- desktop and mobile screenshots visually reviewed