### PR TITLE
Defer Stripe reads from console credits TTFB

### DIFF
--- a/src/trusted_router/routes/console/credits.py
+++ b/src/trusted_router/routes/console/credits.py
@@ -7,17 +7,20 @@ actual API calls so this module stays focused on form parsing + redirects."""
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any, cast
 
 from fastapi import FastAPI, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse, Response
 from pydantic import ValidationError
+from starlette.concurrency import run_in_threadpool
 
 from trusted_router.auth import SettingsDep
 from trusted_router.billing_policy import (
     is_stablecoin_checkout_method,
     is_wallet_only_user,
 )
+from trusted_router.config import Settings
 from trusted_router.domains import request_control_origin
 from trusted_router.money import (
     MIN_PAYPAL_CHECKOUT_DOLLARS,
@@ -46,6 +49,13 @@ from trusted_router.services.stripe_billing import (
 )
 from trusted_router.storage import STORE
 from trusted_router.typed_balance import live_credit_summary
+from trusted_router.views import render_template
+
+_PRIVATE_CREDITS_HEADERS = {
+    "Cache-Control": "private, no-store",
+    "Vary": "Cookie",
+    "X-Robots-Tag": "noindex, nofollow",
+}
 
 
 def register(app: FastAPI) -> None:
@@ -58,22 +68,12 @@ def register(app: FastAPI) -> None:
         credit = STORE.get_credit_account(ctx.workspace.id)
         summary = live_credit_summary(ctx.workspace.id)
         wallet_only_billing = is_wallet_only_user(ctx.user)
-        # Pull the last 20 Stripe checkout sessions tagged with this
-        # workspace_id from Stripe's Search API. Returns [] if Stripe is
-        # unreachable / not configured / there are no payments yet — all
-        # three collapse to the same "no payment history yet" copy on
-        # the template, so the rest of the page renders fine without
-        # being blocked on Stripe's API. See list_workspace_payments
-        # docstring for why we pull live instead of reading from a TR
-        # ledger (tr_entities doesn't store per-payment metadata today).
-        payments = list_workspace_payments(
-            workspace_id=ctx.workspace.id,
-            settings=settings,
-            limit=20,
-        )
-        saved_payment_method = describe_saved_payment_method(
-            payment_method_id=credit.stripe_payment_method_id if credit else None,
-            settings=settings,
+        # This local fallback uses only persisted billing metadata. Live
+        # PaymentMethod.retrieve + PaymentIntent.search calls are deferred to
+        # /stripe-details so Stripe latency cannot delay the authoritative
+        # balance above or any of the billing controls below.
+        saved_payment_method = _saved_payment_method_fallback(
+            credit.stripe_payment_method_id if credit else None
         )
         verification_remaining = max(
             0,
@@ -89,41 +89,94 @@ def register(app: FastAPI) -> None:
             if purpose == "identity_verification"
             else {}
         )
-        return HTMLResponse(render(
-            "console/credits.html",
-            settings=settings,
-            ctx=ctx,
-            active="credits",
-            page_title="Credits",
-            page_subtitle="Top up to keep prepaid routes flowing.",
-            credits_available=money(summary["available"] if summary else 0),
-            credits_usage=money(summary["total_usage"] if summary else 0),
-            auto_refill_enabled=credit.auto_refill_enabled if credit else False,
-            auto_refill_threshold_dollars=(
-                credit.auto_refill_threshold_microdollars // 1_000_000 if credit and credit.auto_refill_threshold_microdollars else 10
+        return HTMLResponse(
+            render(
+                "console/credits.html",
+                settings=settings,
+                ctx=ctx,
+                active="credits",
+                page_title="Credits",
+                page_subtitle="Top up to keep prepaid routes flowing.",
+                credits_available=money(summary["available"] if summary else 0),
+                credits_usage=money(summary["total_usage"] if summary else 0),
+                auto_refill_enabled=credit.auto_refill_enabled if credit else False,
+                auto_refill_threshold_dollars=(
+                    credit.auto_refill_threshold_microdollars // 1_000_000
+                    if credit and credit.auto_refill_threshold_microdollars
+                    else 10
+                ),
+                auto_refill_amount_dollars=(
+                    credit.auto_refill_amount_microdollars // 1_000_000
+                    if credit and credit.auto_refill_amount_microdollars
+                    else 25
+                ),
+                has_payment_method=bool(
+                    credit
+                    and credit.stripe_customer_id
+                    and credit.stripe_payment_method_id
+                ),
+                has_stripe_customer=bool(credit and credit.stripe_customer_id),
+                payment_method_pending=bool(
+                    credit
+                    and credit.stripe_customer_id
+                    and not credit.stripe_payment_method_id
+                ),
+                last_auto_refill_at=credit.last_auto_refill_at if credit else None,
+                last_auto_refill_status=(
+                    credit.last_auto_refill_status if credit else None
+                ),
+                paypal_enabled=settings.paypal_enabled
+                or settings.environment.lower() in {"local", "test"},
+                paypal_minimum_dollars=MIN_PAYPAL_CHECKOUT_DOLLARS,
+                adyen_enabled=settings.adyen_checkout_ready,
+                wallet_only_billing=wallet_only_billing,
+                saved_payment_method=saved_payment_method,
+                api_base_url=ctx.api_base_url,
+                identity_verification_checkout=purpose == "identity_verification",
+                **verification_nudge,
             ),
-            auto_refill_amount_dollars=(
-                credit.auto_refill_amount_microdollars // 1_000_000 if credit and credit.auto_refill_amount_microdollars else 25
+            headers=_PRIVATE_CREDITS_HEADERS,
+        )
+
+    @app.get("/console/credits/stripe-details")
+    async def console_credit_stripe_details(
+        ctx: ConsoleDep,
+        settings: SettingsDep,
+    ) -> Response:
+        """Hydrate Stripe-backed display data outside the page's TTFB.
+
+        Both synchronous Stripe calls run concurrently in worker threads, so
+        neither can block Uvicorn's event loop and hydration takes the slower
+        call's latency rather than their sum. The selected workspace comes
+        only from the authenticated console context; the client cannot request
+        another tenant's Stripe metadata by supplying an id.
+        """
+        credit = await run_in_threadpool(STORE.get_credit_account, ctx.workspace.id)
+        payment_method_id = credit.stripe_payment_method_id if credit else None
+        saved_payment_method, payment_result = await asyncio.gather(
+            run_in_threadpool(
+                _load_saved_payment_method,
+                payment_method_id,
+                settings,
             ),
-            has_payment_method=bool(
-                credit and credit.stripe_customer_id and credit.stripe_payment_method_id
+            run_in_threadpool(
+                _load_workspace_payments,
+                ctx.workspace.id,
+                settings,
             ),
-            has_stripe_customer=bool(credit and credit.stripe_customer_id),
-            payment_method_pending=bool(
-                credit and credit.stripe_customer_id and not credit.stripe_payment_method_id
+        )
+        payments, payments_available = payment_result
+
+        return HTMLResponse(
+            render_template(
+                "console/_credits_stripe_details.html",
+                saved_payment_method=saved_payment_method,
+                payments=payments,
+                payments_available=payments_available,
+                wallet_only_billing=is_wallet_only_user(ctx.user),
             ),
-            last_auto_refill_at=credit.last_auto_refill_at if credit else None,
-            last_auto_refill_status=credit.last_auto_refill_status if credit else None,
-            paypal_enabled=settings.paypal_enabled or settings.environment.lower() in {"local", "test"},
-            paypal_minimum_dollars=MIN_PAYPAL_CHECKOUT_DOLLARS,
-            adyen_enabled=settings.adyen_checkout_ready,
-            wallet_only_billing=wallet_only_billing,
-            payments=payments,
-            saved_payment_method=saved_payment_method,
-            api_base_url=ctx.api_base_url,
-            identity_verification_checkout=purpose == "identity_verification",
-            **verification_nudge,
-        ))
+            headers=_PRIVATE_CREDITS_HEADERS,
+        )
 
     @app.get("/console/credits/checkout")
     async def console_credit_checkout_get(_ctx: ConsoleDep) -> Response:
@@ -348,6 +401,53 @@ def register(app: FastAPI) -> None:
             amount_microdollars=amount * 1_000_000,
         )
         return RedirectResponse(url="/console/credits?saved=1", status_code=303)
+
+
+def _saved_payment_method_fallback(
+    payment_method_id: str | None,
+) -> dict[str, Any] | None:
+    if not payment_method_id:
+        return None
+    return {
+        "id_tail": payment_method_id[-6:],
+        "brand": None,
+        "last4": None,
+        "exp_month": None,
+        "exp_year": None,
+        "details_available": False,
+    }
+
+
+def _load_saved_payment_method(
+    payment_method_id: str | None,
+    settings: Settings,
+) -> dict[str, Any] | None:
+    try:
+        return describe_saved_payment_method(
+            payment_method_id=payment_method_id,
+            settings=settings,
+            raise_on_error=True,
+        )
+    except Exception:
+        return _saved_payment_method_fallback(payment_method_id)
+
+
+def _load_workspace_payments(
+    workspace_id: str,
+    settings: Settings,
+) -> tuple[list[dict[str, Any]], bool]:
+    try:
+        return (
+            list_workspace_payments(
+                workspace_id=workspace_id,
+                settings=settings,
+                limit=20,
+                raise_on_error=True,
+            ),
+            True,
+        )
+    except Exception:
+        return [], False
 
 
 def _wallet_only_redirect() -> RedirectResponse:

--- a/src/trusted_router/services/stripe_billing.py
+++ b/src/trusted_router/services/stripe_billing.py
@@ -235,7 +235,14 @@ def describe_saved_payment_method(
     *,
     payment_method_id: str | None,
     settings: Settings,
+    raise_on_error: bool = False,
 ) -> dict[str, Any] | None:
+    """Return masked card display fields for a saved payment method.
+
+    Callers rendering a best-effort inline view keep the default fallback on
+    Stripe errors. Deferred loaders can request ``raise_on_error`` so they can
+    distinguish an empty value from a temporarily unavailable Stripe read.
+    """
     if not payment_method_id:
         return None
     fallback = {
@@ -258,6 +265,8 @@ def describe_saved_payment_method(
     try:
         payment_method = stripe.PaymentMethod.retrieve(payment_method_id)
     except Exception:
+        if raise_on_error:
+            raise
         return fallback
 
     data = (
@@ -310,6 +319,7 @@ def list_workspace_payments(
     workspace_id: str,
     settings: Settings,
     limit: int = 20,
+    raise_on_error: bool = False,
 ) -> list[dict[str, Any]]:
     """Return the recent Stripe payments for this workspace.
 
@@ -342,11 +352,12 @@ def list_workspace_payments(
           "bank_last4": "6789" | None,
         }
 
-    Failures (Stripe API down, missing key) return an empty list rather
-    than raising — the credits page falls back to "no payment history
+    Failures (Stripe API down, missing key) return an empty list by default
+    rather than raising — the credits page falls back to "no payment history
     yet" copy, which is the right UX in both legitimate-empty and
     transient-failure cases. The page still renders the balance section
-    so the page isn't blocked on Stripe API uptime.
+    so the page isn't blocked on Stripe API uptime. Deferred loaders can set
+    ``raise_on_error`` to distinguish an outage from a legitimate empty list.
     """
     if not settings.stripe_secret_key:
         return []
@@ -363,6 +374,8 @@ def list_workspace_payments(
             expand=["data.latest_charge"],
         )
     except Exception:
+        if raise_on_error:
+            raise
         # Stripe down, search quota exceeded, or the workspace has
         # never paid yet — all collapse to "no payments to show right
         # now." Page still renders the rest of credits view.

--- a/src/trusted_router/static/console.js
+++ b/src/trusted_router/static/console.js
@@ -346,9 +346,73 @@ function updateCheckoutMinimum() {
   }
 }
 
+function replaceCreditsStripeFragment(documentFragment, sourceSelector, targetSelector) {
+  const source = documentFragment.querySelector(sourceSelector);
+  const target = document.querySelector(targetSelector);
+  if (!source || !target)
+    return;
+  target.replaceChildren(
+    ...Array.from(source.childNodes, (node) => node.cloneNode(true)),
+  );
+}
+
+async function loadCreditsStripeDetails() {
+  const panel = document.querySelector("[data-credits-stripe-details-url]");
+  if (!panel)
+    return;
+  const history = document.querySelector("[data-credits-payment-history]");
+  const count = document.querySelector("[data-credits-payment-history-count]");
+  try {
+    const response = await fetch(panel.dataset.creditsStripeDetailsUrl, {
+      credentials: "same-origin",
+      cache: "no-store",
+      headers: { Accept: "text/html" },
+    });
+    if (!response.ok || response.redirected)
+      throw new Error("credits_stripe_details_unavailable");
+    const fragment = new DOMParser().parseFromString(await response.text(), "text/html");
+    const fragmentHistory = fragment.querySelector(
+      "[data-credits-payment-history-fragment]",
+    );
+    if (!fragmentHistory)
+      throw new Error("credits_stripe_details_invalid");
+    replaceCreditsStripeFragment(
+      fragment,
+      "[data-credits-saved-payment-method-fragment]",
+      "[data-credits-saved-payment-method]",
+    );
+    replaceCreditsStripeFragment(
+      fragment,
+      "[data-credits-payment-history-count-fragment]",
+      "[data-credits-payment-history-count]",
+    );
+    replaceCreditsStripeFragment(
+      fragment,
+      "[data-credits-payment-history-fragment]",
+      "[data-credits-payment-history]",
+    );
+  } catch {
+    if (count)
+      count.textContent = "unavailable";
+    if (history) {
+      history.replaceChildren();
+      const message = document.createElement("p");
+      message.style.cssText = "color:var(--muted);font-size:14px;margin:0";
+      message.textContent = (
+        "Payment history is temporarily unavailable. "
+        + "Your balance and billing controls are unaffected."
+      );
+      history.append(message);
+    }
+  } finally {
+    history?.setAttribute("aria-busy", "false");
+  }
+}
+
 function initConsole() {
   applyStoredTheme();
   updateCheckoutMinimum();
+  loadCreditsStripeDetails();
   const checkoutMethod = document.querySelector("[data-checkout-payment-method]");
   if (checkoutMethod) {
     checkoutMethod.addEventListener("change", updateCheckoutMinimum);

--- a/src/trusted_router/templates/console/_credits_payment_history.html
+++ b/src/trusted_router/templates/console/_credits_payment_history.html
@@ -1,0 +1,81 @@
+{% if not payments_available %}
+<p style="color:var(--muted);font-size:14px;margin:0">
+  Payment history is temporarily unavailable. Your balance and billing controls are unaffected.
+</p>
+{% elif payments %}
+<table class="data-table" style="width:100%;border-collapse:collapse">
+  <thead>
+    <tr style="text-align:left;border-bottom:1px solid var(--border)">
+      <th style="padding:8px 6px;font-weight:600;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em">Date</th>
+      <th style="padding:8px 6px;font-weight:600;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em">Amount</th>
+      <th style="padding:8px 6px;font-weight:600;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em">Payment</th>
+      <th style="padding:8px 6px;font-weight:600;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em">Status</th>
+      <th style="padding:8px 6px;font-weight:600;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em">Receipt</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for p in payments %}
+    <tr style="border-bottom:1px solid var(--border)">
+      <td style="padding:10px 6px;color:var(--muted);font-variant-numeric:tabular-nums">
+        {{ p.created_at | datetime_iso if p.created_at else 'none' }}
+      </td>
+      <td style="padding:10px 6px;font-variant-numeric:tabular-nums">
+        ${{ '%.2f'|format((p.amount_cents or 0) / 100) }}
+        <span style="color:var(--muted);font-size:11px">{{ (p.currency or 'usd')|upper }}</span>
+        {% if p.get('credit_amount_cents') is not none and p.get('processing_fee_cents') is not none %}
+        <span style="display:block;color:var(--muted);font-size:11px">
+          ${{ '%.2f'|format(p.credit_amount_cents / 100) }} credits
+          + ${{ '%.2f'|format(p.processing_fee_cents / 100) }} fee
+        </span>
+        {% endif %}
+      </td>
+      <td style="padding:10px 6px">
+        {% if p.bank_last4 %}
+          <span>{{ p.bank_name or 'Bank account' }}</span> ····{{ p.bank_last4 }}
+        {% elif p.card_brand and p.card_last4 %}
+          <span style="text-transform:capitalize">{{ p.card_brand }}</span> ····{{ p.card_last4 }}
+        {% elif p.payment_method_type == 'ach' %}
+          <span>Bank account (ACH)</span>
+        {% elif p.payment_method_type == 'stablecoin' %}
+          <span>Stablecoin</span>
+        {% else %}
+          <span style="color:var(--muted)">none</span>
+        {% endif %}
+      </td>
+      <td style="padding:10px 6px">
+        {% if p.payment_status == 'paid' %}
+          <span class="pill good">paid</span>
+        {% elif p.payment_status == 'processing' %}
+          <span class="pill warn">processing</span>
+        {% elif p.payment_status == 'unpaid' %}
+          <span class="pill warn">unpaid</span>
+        {% elif p.status == 'expired' %}
+          <span class="pill">expired</span>
+        {% else %}
+          <span class="pill">{{ p.payment_status or p.status or 'none' }}</span>
+        {% endif %}
+      </td>
+      <td style="padding:10px 6px">
+        {% if p.receipt_url %}
+          <a href="{{ p.receipt_url }}" target="_blank" rel="noopener">Receipt ↗</a>
+        {% else %}
+          <span style="color:var(--muted)">none</span>
+        {% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<p style="color:var(--muted);font-size:12px;margin-top:12px">
+  Source: Stripe. Showing up to the 20 most recent checkout sessions tagged with this workspace. Hosted receipts open in Stripe.
+</p>
+{% else %}
+<p style="color:var(--muted);font-size:14px;margin:0">
+  {% if wallet_only_billing %}
+  No payments yet. Stablecoin payments appear after confirmation.
+  {% else %}
+  No payments yet. Card payments appear after completion; ACH credits appear
+  after Stripe confirms bank settlement.
+  {% endif %}
+</p>
+{% endif %}

--- a/src/trusted_router/templates/console/_credits_saved_payment_method.html
+++ b/src/trusted_router/templates/console/_credits_saved_payment_method.html
@@ -1,0 +1,30 @@
+{% if saved_payment_method %}
+<div class="payment-method-card">
+  <div>
+    <strong>
+      {% if saved_payment_method.brand %}
+        {{ saved_payment_method.brand|capitalize }} card
+      {% else %}
+        Stripe card
+      {% endif %}
+    </strong>
+    <span>
+      {% if saved_payment_method.last4 %}
+        ending in {{ saved_payment_method.last4 }}
+      {% else %}
+        saved payment method
+      {% endif %}
+      {% if saved_payment_method.exp_month and saved_payment_method.exp_year %}
+        · expires {{ saved_payment_method.exp_month }}/{{ saved_payment_method.exp_year }}
+      {% endif %}
+      · id ...{{ saved_payment_method.id_tail }}
+    </span>
+    {% if not saved_payment_method.details_available %}
+    <span>Stripe card details are temporarily unavailable. Removal still uses the saved Stripe id.</span>
+    {% endif %}
+  </div>
+  <form method="post" action="/console/credits/payment-methods/remove">
+    <button class="btn danger" type="submit">Remove</button>
+  </form>
+</div>
+{% endif %}

--- a/src/trusted_router/templates/console/_credits_stripe_details.html
+++ b/src/trusted_router/templates/console/_credits_stripe_details.html
@@ -1,0 +1,9 @@
+<div data-credits-saved-payment-method-fragment>
+  {% include "console/_credits_saved_payment_method.html" %}
+</div>
+<span data-credits-payment-history-count-fragment>
+  {{ payments|length ~ ' recent' if payments_available else 'unavailable' }}
+</span>
+<div data-credits-payment-history-fragment>
+  {% include "console/_credits_payment_history.html" %}
+</div>

--- a/src/trusted_router/templates/console/credits.html
+++ b/src/trusted_router/templates/console/credits.html
@@ -84,36 +84,9 @@
       {% endif %}
       {% endif %}
     </p>
-    {% if saved_payment_method %}
-    <div class="payment-method-card">
-      <div>
-        <strong>
-          {% if saved_payment_method.brand %}
-            {{ saved_payment_method.brand|capitalize }} card
-          {% else %}
-            Stripe card
-          {% endif %}
-        </strong>
-        <span>
-          {% if saved_payment_method.last4 %}
-            ending in {{ saved_payment_method.last4 }}
-          {% else %}
-            saved payment method
-          {% endif %}
-          {% if saved_payment_method.exp_month and saved_payment_method.exp_year %}
-            · expires {{ saved_payment_method.exp_month }}/{{ saved_payment_method.exp_year }}
-          {% endif %}
-          · id ...{{ saved_payment_method.id_tail }}
-        </span>
-        {% if not saved_payment_method.details_available %}
-        <span>Stripe card details are temporarily unavailable. Removal still uses the saved Stripe id.</span>
-        {% endif %}
-      </div>
-      <form method="post" action="/console/credits/payment-methods/remove">
-        <button class="btn danger" type="submit">Remove</button>
-      </form>
+    <div data-credits-saved-payment-method aria-live="polite">
+      {% include "console/_credits_saved_payment_method.html" %}
     </div>
-    {% endif %}
     {% if not wallet_only_billing %}
     <div class="button-row">
       <form method="post" action="/console/credits/payment-methods/add">
@@ -174,89 +147,29 @@
 </section>
 {% endif %}
 
-<section class="panel">
+<section
+  class="panel"
+  data-credits-stripe-details-url="/console/credits/stripe-details"
+>
   <div class="panel-head">
     <h2>Payment history</h2>
-    <span class="pill">{{ payments|length }} recent</span>
+    <span class="pill" data-credits-payment-history-count>loading</span>
   </div>
-  <div class="panel-body">
-    {% if payments %}
-    <table class="data-table" style="width:100%;border-collapse:collapse">
-      <thead>
-        <tr style="text-align:left;border-bottom:1px solid var(--border)">
-          <th style="padding:8px 6px;font-weight:600;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em">Date</th>
-          <th style="padding:8px 6px;font-weight:600;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em">Amount</th>
-          <th style="padding:8px 6px;font-weight:600;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em">Payment</th>
-          <th style="padding:8px 6px;font-weight:600;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em">Status</th>
-          <th style="padding:8px 6px;font-weight:600;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em">Receipt</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for p in payments %}
-        <tr style="border-bottom:1px solid var(--border)">
-          <td style="padding:10px 6px;color:var(--muted);font-variant-numeric:tabular-nums">
-            {{ p.created_at | datetime_iso if p.created_at else 'none' }}
-          </td>
-          <td style="padding:10px 6px;font-variant-numeric:tabular-nums">
-            ${{ '%.2f'|format((p.amount_cents or 0) / 100) }}
-            <span style="color:var(--muted);font-size:11px">{{ (p.currency or 'usd')|upper }}</span>
-            {% if p.get('credit_amount_cents') is not none and p.get('processing_fee_cents') is not none %}
-            <span style="display:block;color:var(--muted);font-size:11px">
-              ${{ '%.2f'|format(p.credit_amount_cents / 100) }} credits
-              + ${{ '%.2f'|format(p.processing_fee_cents / 100) }} fee
-            </span>
-            {% endif %}
-          </td>
-          <td style="padding:10px 6px">
-            {% if p.bank_last4 %}
-              <span>{{ p.bank_name or 'Bank account' }}</span> ····{{ p.bank_last4 }}
-            {% elif p.card_brand and p.card_last4 %}
-              <span style="text-transform:capitalize">{{ p.card_brand }}</span> ····{{ p.card_last4 }}
-            {% elif p.payment_method_type == 'ach' %}
-              <span>Bank account (ACH)</span>
-            {% elif p.payment_method_type == 'stablecoin' %}
-              <span>Stablecoin</span>
-            {% else %}
-              <span style="color:var(--muted)">none</span>
-            {% endif %}
-          </td>
-          <td style="padding:10px 6px">
-            {% if p.payment_status == 'paid' %}
-              <span class="pill good">paid</span>
-            {% elif p.payment_status == 'processing' %}
-              <span class="pill warn">processing</span>
-            {% elif p.payment_status == 'unpaid' %}
-              <span class="pill warn">unpaid</span>
-            {% elif p.status == 'expired' %}
-              <span class="pill">expired</span>
-            {% else %}
-              <span class="pill">{{ p.payment_status or p.status or 'none' }}</span>
-            {% endif %}
-          </td>
-          <td style="padding:10px 6px">
-            {% if p.receipt_url %}
-              <a href="{{ p.receipt_url }}" target="_blank" rel="noopener">Receipt ↗</a>
-            {% else %}
-              <span style="color:var(--muted)">none</span>
-            {% endif %}
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-    <p style="color:var(--muted);font-size:12px;margin-top:12px">
-      Source: Stripe. Showing up to the 20 most recent checkout sessions tagged with this workspace. Hosted receipts open in Stripe.
-    </p>
-    {% else %}
+  <div
+    class="panel-body"
+    data-credits-payment-history
+    aria-busy="true"
+    aria-live="polite"
+  >
     <p style="color:var(--muted);font-size:14px;margin:0">
-      {% if wallet_only_billing %}
-      No payments yet. Stablecoin payments appear after confirmation.
-      {% else %}
-      No payments yet. Card payments appear after completion; ACH credits appear
-      after Stripe confirms bank settlement.
-      {% endif %}
+      Loading recent payments…
     </p>
-    {% endif %}
+    <noscript>
+      <p style="color:var(--muted);font-size:14px;margin-top:12px">
+        <a href="/console/credits/stripe-details">Open Stripe payment details</a>.
+        Your live balance above is unaffected.
+      </p>
+    </noscript>
   </div>
 </section>
 {% endblock %}

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -1062,11 +1062,13 @@ def test_credits_page_renders_payment_history_section(monkeypatch) -> None:
     )
     client, _ = _console_client_for_test()
     resp = client.get("/console/credits")
+    details = client.get("/console/credits/stripe-details")
     assert resp.status_code == 200, resp.text[:300]
+    assert details.status_code == 200, details.text[:300]
     assert "Payment history" in resp.text
-    assert "No payments yet" in resp.text
+    assert "No payments yet" in details.text
     assert "Bank account (ACH)" in resp.text
-    assert "credits appear" in resp.text
+    assert "credits appear" in details.text
 
 
 def test_credits_page_renders_payment_rows_when_present(monkeypatch) -> None:
@@ -1129,27 +1131,29 @@ def test_credits_page_renders_payment_rows_when_present(monkeypatch) -> None:
 
     client, _ = _console_client_for_test()
     resp = client.get("/console/credits")
+    details = client.get("/console/credits/stripe-details")
     assert resp.status_code == 200, resp.text[:300]
+    assert details.status_code == 200, details.text[:300]
     assert "Payment history" in resp.text
     # Amount formatted as dollars
-    assert "$1.00" in resp.text
-    assert "$0.34 fee" in resp.text
-    assert "$1.34" in resp.text
-    assert "$5.00" in resp.text
+    assert "$1.00" in details.text
+    assert "$0.34 fee" in details.text
+    assert "$1.34" in details.text
+    assert "$5.00" in details.text
     # Card brand + last4 displayed
-    assert "visa" in resp.text.lower()
-    assert "4242" in resp.text
-    assert "mastercard" in resp.text.lower()
-    assert "8888" in resp.text
-    assert "Test Bank" in resp.text
-    assert "6789" in resp.text
-    assert ">processing<" in resp.text or 'pill warn">processing' in resp.text
+    assert "visa" in details.text.lower()
+    assert "4242" in details.text
+    assert "mastercard" in details.text.lower()
+    assert "8888" in details.text
+    assert "Test Bank" in details.text
+    assert "6789" in details.text
+    assert ">processing<" in details.text or 'pill warn">processing' in details.text
     # Receipt links rendered
-    assert "https://pay.stripe.com/receipts/test-receipt" in resp.text
+    assert "https://pay.stripe.com/receipts/test-receipt" in details.text
     # `paid` status pill
-    assert ">paid<" in resp.text or 'pill good">paid' in resp.text
+    assert ">paid<" in details.text or 'pill good">paid' in details.text
     # Date formatted (UTC)
-    assert "2026-05-24" in resp.text
-    assert "2026-05-23" in resp.text
+    assert "2026-05-24" in details.text
+    assert "2026-05-23" in details.text
     # Empty-state copy NOT shown when payments exist
-    assert "No payments yet" not in resp.text
+    assert "No payments yet" not in details.text

--- a/tests/test_console_credits_stripe_deferred.py
+++ b/tests/test_console_credits_stripe_deferred.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.routes.console import credits as credits_module
+from trusted_router.storage import STORE, Workspace
+
+
+def _signed_in_client(
+    *,
+    email: str = "deferred-stripe@example.com",
+    settings: Settings | None = None,
+) -> tuple[TestClient, Workspace]:
+    app = create_app(
+        settings
+        or Settings(
+            environment="local",
+            stripe_secret_key="sk_test_deferred",  # noqa: S106 - test fixture.
+        ),
+        init_observability=False,
+    )
+    client = TestClient(app)
+    user = STORE.ensure_user(email)
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+    raw_token, _ = STORE.create_auth_session(
+        user_id=user.id,
+        provider="email",
+        label=email,
+        workspace_id=workspace.id,
+        ttl_seconds=3600,
+        state="active",
+    )
+    client.cookies.set("tr_session", raw_token)
+    return client, workspace
+
+
+def test_credits_html_finishes_before_stripe_starts_and_keeps_live_money_read(
+    monkeypatch,
+) -> None:
+    client, workspace = _signed_in_client()
+    stripe_started = Event()
+    release_stripe = Event()
+    money_reads: list[str] = []
+
+    def blocking_stripe(**_: Any) -> list[dict[str, Any]]:
+        stripe_started.set()
+        assert release_stripe.wait(timeout=5)
+        return []
+
+    def live_money(workspace_id: str) -> dict[str, int]:
+        money_reads.append(workspace_id)
+        return {
+            "total_credits": 12_340_000,
+            "total_usage": 2_340_000,
+            "reserved": 0,
+            "available": 10_000_000,
+        }
+
+    monkeypatch.setattr(credits_module, "list_workspace_payments", blocking_stripe)
+    monkeypatch.setattr(credits_module, "describe_saved_payment_method", blocking_stripe)
+    monkeypatch.setattr(credits_module, "live_credit_summary", live_money)
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        request = pool.submit(client.get, "/console/credits")
+        try:
+            response = request.result(timeout=2)
+        finally:
+            release_stripe.set()
+
+    assert response.status_code == 200
+    assert not stripe_started.is_set()
+    assert money_reads == [workspace.id]
+    assert "$10.00" in response.text
+    assert "$2.34" in response.text
+    assert response.headers["cache-control"] == "private, no-store"
+    assert "Cookie" in response.headers["vary"].split(", ")
+    assert 'data-credits-stripe-details-url="/console/credits/stripe-details"' in response.text
+
+
+def test_stripe_fragment_populates_masked_card_and_payment_history(monkeypatch) -> None:
+    client, workspace = _signed_in_client()
+    STORE.set_stripe_customer(
+        workspace.id,
+        customer_id="cus_deferred",
+        payment_method_id="pm_deferred_card",
+    )
+    seen_workspaces: list[str] = []
+
+    def list_payments(*, workspace_id: str, **_: Any) -> list[dict[str, Any]]:
+        seen_workspaces.append(workspace_id)
+        return [
+            {
+                "payment_intent": "pi_deferred",
+                "created_at": 1779582083,
+                "amount_cents": 1_134,
+                "credit_amount_cents": 1_000,
+                "processing_fee_cents": 134,
+                "currency": "usd",
+                "status": "succeeded",
+                "payment_status": "paid",
+                "receipt_url": "https://pay.stripe.com/receipts/deferred",
+                "payment_method_type": "card",
+                "card_brand": "visa",
+                "card_last4": "4242",
+                "bank_name": None,
+                "bank_last4": None,
+            }
+        ]
+
+    monkeypatch.setattr(credits_module, "list_workspace_payments", list_payments)
+    monkeypatch.setattr(
+        credits_module,
+        "describe_saved_payment_method",
+        lambda **_: {
+            "id_tail": "d_card",
+            "brand": "visa",
+            "last4": "4242",
+            "exp_month": 12,
+            "exp_year": 2031,
+            "details_available": True,
+        },
+    )
+
+    response = client.get("/console/credits/stripe-details")
+
+    assert response.status_code == 200
+    assert seen_workspaces == [workspace.id]
+    assert "Visa card" in response.text
+    assert "ending in 4242" in response.text
+    assert "expires 12/2031" in response.text
+    assert "$10.00" in response.text
+    assert "$1.34 fee" in response.text
+    assert "2026-05-24" in response.text
+    assert "https://pay.stripe.com/receipts/deferred" in response.text
+    assert response.headers["cache-control"] == "private, no-store"
+    assert "Cookie" in response.headers["vary"].split(", ")
+
+
+def test_stripe_fragment_falls_back_when_each_stripe_read_fails(monkeypatch) -> None:
+    from trusted_router.services import stripe_billing
+
+    client, workspace = _signed_in_client()
+    STORE.set_stripe_customer(
+        workspace.id,
+        customer_id="cus_fallback",
+        payment_method_id="pm_secret_full_identifier",
+    )
+
+    def unavailable(**_: Any) -> Any:
+        raise RuntimeError("Stripe unavailable")
+
+    monkeypatch.setattr(stripe_billing.stripe.PaymentIntent, "search", unavailable)
+    monkeypatch.setattr(stripe_billing.stripe.PaymentMethod, "retrieve", unavailable)
+
+    response = client.get("/console/credits/stripe-details")
+
+    assert response.status_code == 200
+    assert "Stripe card details are temporarily unavailable" in response.text
+    assert "id ...tifier" in response.text
+    assert "pm_secret_full_identifier" not in response.text
+    assert "Payment history is temporarily unavailable" in response.text
+
+
+def test_stripe_fragment_loads_card_and_history_concurrently(monkeypatch) -> None:
+    client, workspace = _signed_in_client()
+    STORE.set_stripe_customer(
+        workspace.id,
+        customer_id="cus_parallel",
+        payment_method_id="pm_parallel",
+    )
+    history_started = Event()
+    card_started = Event()
+
+    def list_payments(**_: Any) -> list[dict[str, Any]]:
+        history_started.set()
+        assert card_started.wait(timeout=3)
+        return [
+            {
+                "amount_cents": 100,
+                "currency": "usd",
+                "payment_status": "paid",
+                "status": "succeeded",
+                "card_brand": "parallel-history",
+                "card_last4": "0001",
+            }
+        ]
+
+    def describe_method(**_: Any) -> dict[str, Any]:
+        card_started.set()
+        assert history_started.wait(timeout=3)
+        return {
+            "id_tail": "rallel",
+            "brand": "parallel-card",
+            "last4": "0002",
+            "exp_month": 1,
+            "exp_year": 2032,
+            "details_available": True,
+        }
+
+    monkeypatch.setattr(credits_module, "list_workspace_payments", list_payments)
+    monkeypatch.setattr(
+        credits_module,
+        "describe_saved_payment_method",
+        describe_method,
+    )
+
+    response = client.get("/console/credits/stripe-details")
+
+    assert response.status_code == 200
+    assert "Parallel-card card" in response.text
+    assert "parallel-history" in response.text
+
+
+def test_stripe_fragment_requires_session_before_any_stripe_work(monkeypatch) -> None:
+    app = create_app(
+        Settings(
+            environment="local",
+            stripe_secret_key="sk_test_deferred",  # noqa: S106 - test fixture.
+        ),
+        init_observability=False,
+    )
+    client = TestClient(app)
+    stripe_started = Event()
+
+    def should_not_run(**_: Any) -> Any:
+        stripe_started.set()
+        raise AssertionError("Stripe ran before console authentication")
+
+    monkeypatch.setattr(credits_module, "list_workspace_payments", should_not_run)
+    monkeypatch.setattr(credits_module, "describe_saved_payment_method", should_not_run)
+
+    response = client.get(
+        "/console/credits/stripe-details",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == "/?reason=signin"
+    assert not stripe_started.is_set()
+
+
+def test_stripe_fragment_is_scoped_to_workspace_from_each_session(monkeypatch) -> None:
+    settings = Settings(
+        environment="local",
+        stripe_secret_key="sk_test_deferred",  # noqa: S106 - test fixture.
+    )
+    app = create_app(settings, init_observability=False)
+
+    def client_for(email: str) -> tuple[TestClient, Workspace]:
+        client = TestClient(app)
+        user = STORE.ensure_user(email)
+        workspace = STORE.list_workspaces_for_user(user.id)[0]
+        STORE.set_stripe_customer(
+            workspace.id,
+            customer_id=f"cus_{workspace.id}",
+            payment_method_id=f"pm_{workspace.id}",
+        )
+        raw_token, _ = STORE.create_auth_session(
+            user_id=user.id,
+            provider="email",
+            label=email,
+            workspace_id=workspace.id,
+            ttl_seconds=3600,
+            state="active",
+        )
+        client.cookies.set("tr_session", raw_token)
+        return client, workspace
+
+    alice, alice_workspace = client_for("alice-deferred@example.com")
+    bob, bob_workspace = client_for("bob-deferred@example.com")
+    markers = {
+        alice_workspace.id: "alice-only-marker",
+        bob_workspace.id: "bob-only-marker",
+    }
+
+    def scoped_payments(*, workspace_id: str, **_: Any) -> list[dict[str, Any]]:
+        return [
+            {
+                "amount_cents": 100,
+                "currency": "usd",
+                "payment_status": "paid",
+                "status": "succeeded",
+                "card_brand": markers[workspace_id],
+                "card_last4": "0001",
+            }
+        ]
+
+    monkeypatch.setattr(credits_module, "list_workspace_payments", scoped_payments)
+    monkeypatch.setattr(
+        credits_module,
+        "describe_saved_payment_method",
+        lambda **_: None,
+    )
+
+    alice_response = alice.get("/console/credits/stripe-details")
+    bob_response = bob.get("/console/credits/stripe-details")
+
+    assert markers[alice_workspace.id] in alice_response.text
+    assert markers[bob_workspace.id] not in alice_response.text
+    assert markers[bob_workspace.id] in bob_response.text
+    assert markers[alice_workspace.id] not in bob_response.text
+
+
+def test_blocked_stripe_fragment_does_not_stall_event_loop(monkeypatch) -> None:
+    client, _workspace = _signed_in_client()
+    stripe_started = Event()
+    release_stripe = Event()
+
+    def blocking_list(**_: Any) -> list[dict[str, Any]]:
+        stripe_started.set()
+        assert release_stripe.wait(timeout=5)
+        return []
+
+    monkeypatch.setattr(credits_module, "list_workspace_payments", blocking_list)
+    monkeypatch.setattr(
+        credits_module,
+        "describe_saved_payment_method",
+        lambda **_: None,
+    )
+
+    with TestClient(client.app) as concurrent_client:
+        concurrent_client.cookies.update(client.cookies)
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            fragment = pool.submit(
+                concurrent_client.get,
+                "/console/credits/stripe-details",
+            )
+            assert stripe_started.wait(timeout=3)
+            started = time.perf_counter()
+            try:
+                health = concurrent_client.get("/health")
+                elapsed = time.perf_counter() - started
+            finally:
+                release_stripe.set()
+            fragment_response = fragment.result(timeout=3)
+
+    assert health.status_code == 200
+    assert fragment_response.status_code == 200
+    assert elapsed < 0.75

--- a/tests/test_oauth_and_console.py
+++ b/tests/test_oauth_and_console.py
@@ -1455,9 +1455,10 @@ def test_console_add_payment_method_mock_saves_method(
     assert account.stripe_customer_id
     assert account.stripe_payment_method_id
     page = client.get("/console/credits")
+    details = client.get("/console/credits/stripe-details")
     assert "Replace card" in page.text
     assert "Manage in Stripe" in page.text
-    assert "Test card" in page.text
+    assert "Test card" in details.text
     assert "Remove" in page.text
 
 
@@ -1600,12 +1601,15 @@ def test_console_credits_lists_saved_stripe_card(monkeypatch) -> None:
     )
 
     page = client.get("/console/credits")
+    details = client.get("/console/credits/stripe-details")
 
     assert page.status_code == 200
-    assert "Visa card" in page.text
-    assert "ending in 4242" in page.text
-    assert "expires 12/2031" in page.text
-    assert "id ...e_card" in page.text
+    assert details.status_code == 200
+    assert "Stripe card details are temporarily unavailable" in page.text
+    assert "Visa card" in details.text
+    assert "ending in 4242" in details.text
+    assert "expires 12/2031" in details.text
+    assert "id ...e_card" in details.text
     assert "Remove" in page.text
 
 


### PR DESCRIPTION
## Summary
- remove Stripe network calls from the initial authenticated credits HTML response
- load payment history and card detail through a private, no-store, tenant-derived fragment
- run PaymentMethod and PaymentIntent reads concurrently in worker threads
- preserve live balance, billing controls, masking, failure fallback, and a no-JavaScript path

## Performance
With two deterministic 200 ms Stripe calls, initial credits median fell from 421.6 ms to 23.1 ms. The deferred fragment completed in 236.0 ms because the calls run concurrently and off the event loop. This is a same-machine injected-delay comparison, not production Stripe latency.

## Verification
- exact full suite: 4,927 passed, 296 skipped, 10 expected xfails
- seven new regressions green; all seven parent-red
- broader billing/console/wallet review suite: 215 passed, 32 environment skips
- Ruff, mypy, JavaScript syntax, and diff checks green
- independent exact-commit security/correctness review approved

No cross-request cache is introduced; both responses remain private/no-store, and the fragment accepts no tenant identifier from the caller.