### PR TITLE
Cache and slim the public model catalog

### DIFF
--- a/src/trusted_router/routes/catalog.py
+++ b/src/trusted_router/routes/catalog.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+import gzip
+import hashlib
+import json
+from dataclasses import dataclass
+from functools import lru_cache
 from typing import Any
 
 from fastapi import APIRouter, Request
+from fastapi.responses import Response
 
 from trusted_router.auth import ManagementPrincipal, SettingsDep
 from trusted_router.catalog import (
@@ -32,6 +38,168 @@ from trusted_router.openai_service_tiers import (
 from trusted_router.provider_lifecycle import provider_pricing_schedule
 from trusted_router.regions import choose_region, region_payload
 from trusted_router.routing import catalog_endpoint_candidates, provider_route_preferences
+
+_PUBLIC_CATALOG_CACHE_CONTROL = (
+    "public, max-age=300, s-maxage=300, stale-while-revalidate=60"
+)
+
+
+@dataclass(frozen=True)
+class _PublicCatalogPayload:
+    shapes: tuple[dict[str, Any], ...]
+    body: bytes
+    etag: str
+    gzip_body: bytes
+    gzip_etag: str
+    picker_body: bytes
+    picker_etag: str
+    picker_gzip_body: bytes
+    picker_gzip_etag: str
+
+
+def _json_bytes(data: object) -> bytes:
+    return json.dumps(
+        data,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+    ).encode()
+
+
+def _content_etag(body: bytes) -> str:
+    return f'"{hashlib.sha256(body).hexdigest()}"'
+
+
+def _weak_etag_value(value: str) -> str:
+    value = value.strip()
+    return value[2:].lstrip() if value.startswith("W/") else value
+
+
+def _picker_model_shape(shape: dict[str, Any]) -> dict[str, Any]:
+    pricing = shape.get("pricing")
+    trustedrouter = shape.get("trustedrouter")
+    pricing = pricing if isinstance(pricing, dict) else {}
+    trustedrouter = trustedrouter if isinstance(trustedrouter, dict) else {}
+    return {
+        "id": shape.get("id"),
+        "name": shape.get("name"),
+        "description": shape.get("description"),
+        "context_length": shape.get("context_length"),
+        "pricing": {
+            "prompt": pricing.get("prompt"),
+            "completion": pricing.get("completion"),
+        },
+        "trustedrouter": {
+            "capabilities": trustedrouter.get("capabilities", []),
+            "uptime_pct": trustedrouter.get("uptime_pct"),
+            "open_weights": trustedrouter.get("open_weights", False),
+            "us_provider_available": trustedrouter.get("us_provider_available", False),
+            "eu_focused_provider_available": trustedrouter.get(
+                "eu_focused_provider_available", False
+            ),
+            "internal_only": trustedrouter.get("internal_only", False),
+            "route_kind": trustedrouter.get("route_kind", "model"),
+            "supports_chat": trustedrouter.get("supports_chat", True),
+        },
+    }
+
+
+@lru_cache(maxsize=1)
+def _public_catalog_payload() -> _PublicCatalogPayload:
+    shapes: list[dict[str, Any]] = []
+    for model in MODELS.values():
+        shape = model_to_openrouter_shape(model)
+        trustedrouter = shape.get("trustedrouter")
+        if isinstance(trustedrouter, dict) and trustedrouter.get("internal_only"):
+            continue
+        shapes.append(shape)
+    frozen_shapes = tuple(shapes)
+    body = _json_bytes({"data": frozen_shapes})
+    picker_body = _json_bytes(
+        {"data": [_picker_model_shape(shape) for shape in frozen_shapes]}
+    )
+    gzip_body = gzip.compress(body, compresslevel=6, mtime=0)
+    picker_gzip_body = gzip.compress(picker_body, compresslevel=6, mtime=0)
+    return _PublicCatalogPayload(
+        shapes=frozen_shapes,
+        body=body,
+        etag=_content_etag(body),
+        gzip_body=gzip_body,
+        gzip_etag=_content_etag(gzip_body),
+        picker_body=picker_body,
+        picker_etag=_content_etag(picker_body),
+        picker_gzip_body=picker_gzip_body,
+        picker_gzip_etag=_content_etag(picker_gzip_body),
+    )
+
+
+def _cached_json_response(
+    request: Request,
+    body: bytes,
+    etag: str,
+    *,
+    gzip_body: bytes | None = None,
+    gzip_etag: str | None = None,
+) -> Response:
+    accept_encoding = request.headers.get("accept-encoding", "")
+    accepted_encodings: dict[str, float] = {}
+    for entry in accept_encoding.split(","):
+        token, *parameters = entry.split(";")
+        quality = 1.0
+        for parameter in parameters:
+            name, separator, value = parameter.strip().partition("=")
+            if separator and name.strip().lower() == "q":
+                try:
+                    quality = float(value)
+                except ValueError:
+                    quality = 0.0
+                if not 0.0 <= quality <= 1.0:
+                    quality = 0.0
+        accepted_encodings[token.strip().lower()] = quality
+    explicit_gzip_qualities = [
+        accepted_encodings[coding]
+        for coding in ("gzip", "x-gzip")
+        if coding in accepted_encodings
+    ]
+    gzip_quality = (
+        max(explicit_gzip_qualities)
+        if explicit_gzip_qualities
+        else accepted_encodings.get("*", 0.0)
+    )
+    serve_gzip = gzip_body is not None and gzip_quality > 0
+    if serve_gzip:
+        assert gzip_body is not None
+        body = gzip_body
+        etag = gzip_etag or _content_etag(body)
+    headers = {
+        "Cache-Control": _PUBLIC_CATALOG_CACHE_CONTROL,
+        "ETag": etag,
+    }
+    if serve_gzip:
+        headers["Content-Encoding"] = "gzip"
+    elif "gzip" in accept_encoding:
+        # Starlette's outer GZipMiddleware only checks whether the token
+        # "gzip" occurs in Accept-Encoding, so values such as x-gzip or an
+        # explicit q=0 rejection can otherwise make it compress our identity
+        # bytes after we have assigned their strong ETag.
+        headers["Content-Encoding"] = "identity"
+    validators = {
+        _weak_etag_value(token)
+        for token in request.headers.get("if-none-match", "").split(",")
+    }
+    not_modified = "*" in validators or _weak_etag_value(etag) in validators
+    if serve_gzip or "Content-Encoding" in headers or not_modified:
+        # The outer compression middleware adds this for a normal identity
+        # response. Set it ourselves when the body already carries an encoding,
+        # and on 304 where the middleware has no body from which to infer it.
+        headers["Vary"] = "Accept-Encoding"
+    if not_modified:
+        return Response(status_code=304, headers=headers)
+    return Response(
+        content=body,
+        media_type="application/json",
+        headers=headers,
+    )
 
 
 def _set_provider_query(raw: dict[str, Any], key: str, value: str) -> None:
@@ -146,7 +314,26 @@ def _public_model_matches_filters(shape: dict[str, Any], request: Request) -> bo
     return True
 
 
+def _has_public_model_filters(request: Request) -> bool:
+    return any(
+        key in request.query_params
+        for key in (
+            "open_weights",
+            "provider[jurisdiction]",
+            "provider.jurisdiction",
+            "provider[region]",
+            "provider.region",
+            "region",
+        )
+    )
+
+
 def register_catalog_routes(router: APIRouter) -> None:
+    # Catalog inputs are immutable for the life of a release. Pay the expensive
+    # endpoint/policy projection once while the app is starting, rather than on
+    # the first request handled by a shared event loop.
+    catalog_payload = _public_catalog_payload()
+
     @router.get("/embeddings/models")
     async def embeddings_models() -> dict[str, list[dict[str, Any]]]:
         return {
@@ -159,20 +346,33 @@ def register_catalog_routes(router: APIRouter) -> None:
         # routing pools, not user-selectable. The shape itself carries
         # the flag; filter it BEFORE handing to callers so SDKs +
         # chat playground don't accidentally surface them.
-        shapes = []
-        for model in MODELS.values():
-            shape = model_to_openrouter_shape(model)
-            trustedrouter = shape.get("trustedrouter")
-            if isinstance(trustedrouter, dict) and trustedrouter.get("internal_only"):
-                continue
-            if request is not None and not _public_model_matches_filters(shape, request):
-                continue
-            shapes.append(shape)
-        return shapes
+        if request is None:
+            return list(catalog_payload.shapes)
+        return [
+            shape
+            for shape in catalog_payload.shapes
+            if _public_model_matches_filters(shape, request)
+        ]
 
-    @router.get("/models")
-    async def models(request: Request) -> dict[str, list[dict[str, Any]]]:
-        return {"data": _public_model_shapes(request)}
+    @router.get("/models", response_model=dict[str, list[dict[str, Any]]])
+    async def models(request: Request) -> Response:
+        if not _has_public_model_filters(request):
+            return _cached_json_response(
+                request,
+                catalog_payload.body,
+                catalog_payload.etag,
+                gzip_body=catalog_payload.gzip_body,
+                gzip_etag=catalog_payload.gzip_etag,
+            )
+        body = _json_bytes({"data": _public_model_shapes(request)})
+        compressed = gzip.compress(body, compresslevel=6, mtime=0)
+        return _cached_json_response(
+            request,
+            body,
+            _content_etag(body),
+            gzip_body=compressed,
+            gzip_etag=_content_etag(compressed),
+        )
 
     @router.get("/models/count")
     async def models_count(request: Request) -> dict[str, dict[str, int]]:
@@ -181,6 +381,16 @@ def register_catalog_routes(router: APIRouter) -> None:
     @router.get("/models/user")
     async def models_user(_principal: ManagementPrincipal) -> dict[str, list[dict[str, Any]]]:
         return {"data": _public_model_shapes()}
+
+    @router.get("/models/picker")
+    async def models_picker(request: Request) -> Response:
+        return _cached_json_response(
+            request,
+            catalog_payload.picker_body,
+            catalog_payload.picker_etag,
+            gzip_body=catalog_payload.picker_gzip_body,
+            gzip_etag=catalog_payload.picker_gzip_etag,
+        )
 
     @router.get("/models/{author}/{slug}/endpoints")
     async def model_endpoints(

--- a/src/trusted_router/static/custom_models.js
+++ b/src/trusted_router/static/custom_models.js
@@ -55,7 +55,10 @@
     const idEl = root.querySelector("[data-base-model-id]");
     if (!(input instanceof HTMLInputElement) || !(button instanceof HTMLButtonElement)) return;
     const value = input.value || root.dataset.currentModel || "";
-    if (nameEl) nameEl.textContent = displayName(value);
+    // The server already rendered the authoritative catalog name. Preserve it
+    // while the deferred projection has not been fetched; only synthesize a
+    // fallback for an otherwise-empty custom integration.
+    if (nameEl && !nameEl.textContent.trim()) nameEl.textContent = displayName(value);
     if (idEl) idEl.textContent = value;
     button.addEventListener("click", async () => {
       button.disabled = true;
@@ -80,5 +83,4 @@
   }
 
   hydrateAll();
-  load();
 })();

--- a/src/trusted_router/static/model_catalog.js
+++ b/src/trusted_router/static/model_catalog.js
@@ -61,7 +61,7 @@
 
   async function loadModels(catalogBase) {
     const base = catalogBase || "/v1";
-    const resp = await fetch(base + "/models");
+    const resp = await fetch(base + "/models/picker");
     if (!resp.ok) throw new Error("models fetch " + resp.status);
     const json = await resp.json();
     const data = Array.isArray(json.data) ? json.data : [];

--- a/tests/test_models_catalog_cache.py
+++ b/tests/test_models_catalog_cache.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from trusted_router.catalog import MODELS
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.routes import catalog as catalog_routes
+
+
+def test_v1_models_builds_expensive_shapes_once(monkeypatch) -> None:
+    catalog_routes._public_catalog_payload.cache_clear()
+    calls = 0
+    original = catalog_routes.model_to_openrouter_shape
+
+    def counted(model):
+        nonlocal calls
+        calls += 1
+        return original(model)
+
+    monkeypatch.setattr(catalog_routes, "model_to_openrouter_shape", counted)
+    client = TestClient(create_app(Settings(environment="test"), init_observability=False))
+
+    first = client.get("/v1/models")
+    second = client.get("/v1/models")
+
+    assert first.status_code == 200
+    assert second.content == first.content
+    assert calls == len(MODELS)
+
+
+def test_v1_models_is_publicly_cacheable_and_revalidates_with_etag(client: TestClient) -> None:
+    response = client.get("/v1/models")
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == (
+        "public, max-age=300, s-maxage=300, stale-while-revalidate=60"
+    )
+    etag = response.headers["etag"]
+    assert etag.startswith('"') and etag.endswith('"')
+
+    unchanged = client.get("/v1/models", headers={"if-none-match": etag})
+
+    assert unchanged.status_code == 304
+    assert unchanged.content == b""
+    assert unchanged.headers["etag"] == etag
+
+    weak_validator = client.get(
+        "/v1/models",
+        headers={"if-none-match": f"W/{etag}"},
+    )
+    assert weak_validator.status_code == 304
+    schema = client.get("/openapi.json").json()["paths"]["/v1/models"]["get"]
+    assert schema["responses"]["200"]["content"]["application/json"]["schema"] == {
+        "additionalProperties": {
+            "items": {"additionalProperties": True, "type": "object"},
+            "type": "array",
+        },
+        "type": "object",
+        "title": "Response Models V1 Models Get",
+    }
+
+
+def test_v1_models_varies_strong_etag_by_content_encoding(client: TestClient) -> None:
+    compressed = client.get("/v1/models")
+    identity = client.get("/v1/models", headers={"accept-encoding": "identity"})
+
+    assert compressed.content == identity.content
+    assert compressed.headers["content-encoding"] == "gzip"
+    assert "content-encoding" not in identity.headers
+    assert compressed.headers["etag"] != identity.headers["etag"]
+    assert compressed.headers["vary"] == "Accept-Encoding"
+    assert identity.headers["vary"] == "Accept-Encoding"
+
+    wrong_representation = client.get(
+        "/v1/models",
+        headers={
+            "accept-encoding": "identity",
+            "if-none-match": compressed.headers["etag"],
+        },
+    )
+    assert wrong_representation.status_code == 200
+
+    gzip_alias = client.get(
+        "/v1/models",
+        headers={"accept-encoding": "x-gzip, identity;q=0"},
+    )
+    assert gzip_alias.headers["content-encoding"] == "gzip"
+    assert gzip_alias.headers["etag"] == compressed.headers["etag"]
+
+
+def test_picker_projection_preserves_picker_contract_at_a_fraction_of_the_wire_size(
+    client: TestClient,
+) -> None:
+    full = client.get("/v1/models")
+    picker = client.get("/v1/models/picker")
+
+    assert picker.status_code == 200
+    assert picker.headers["cache-control"] == full.headers["cache-control"]
+    full_rows = full.json()["data"]
+    picker_rows = picker.json()["data"]
+    assert [row["id"] for row in picker_rows] == [row["id"] for row in full_rows]
+    assert len(picker.content) < len(full.content) // 4
+    assert int(picker.headers["content-length"]) < (
+        int(full.headers["content-length"]) // 4
+    )
+    for row in picker_rows:
+        assert set(row) == {
+            "id",
+            "name",
+            "description",
+            "context_length",
+            "pricing",
+            "trustedrouter",
+        }
+        assert set(row["pricing"]) == {"prompt", "completion"}
+        assert set(row["trustedrouter"]) == {
+            "capabilities",
+            "uptime_pct",
+            "open_weights",
+            "us_provider_available",
+            "eu_focused_provider_available",
+            "internal_only",
+            "route_kind",
+            "supports_chat",
+        }
+    unchanged = client.get(
+        "/v1/models/picker",
+        headers={"if-none-match": picker.headers["etag"]},
+    )
+    assert unchanged.status_code == 304
+
+
+def test_picker_projection_preserves_normalized_capability_metadata(
+    client: TestClient,
+) -> None:
+    full_rows = client.get("/v1/models").json()["data"]
+    picker_rows = client.get("/v1/models/picker").json()["data"]
+
+    for full, picker in zip(full_rows, picker_rows, strict=True):
+        assert picker == {
+            "id": full.get("id"),
+            "name": full.get("name"),
+            "description": full.get("description"),
+            "context_length": full.get("context_length"),
+            "pricing": {
+                "prompt": full.get("pricing", {}).get("prompt"),
+                "completion": full.get("pricing", {}).get("completion"),
+            },
+            "trustedrouter": {
+                "capabilities": full.get("trustedrouter", {}).get(
+                    "capabilities", []
+                ),
+                "uptime_pct": full.get("trustedrouter", {}).get("uptime_pct"),
+                "open_weights": full.get("trustedrouter", {}).get(
+                    "open_weights", False
+                ),
+                "us_provider_available": full.get("trustedrouter", {}).get(
+                    "us_provider_available", False
+                ),
+                "eu_focused_provider_available": full.get("trustedrouter", {}).get(
+                    "eu_focused_provider_available", False
+                ),
+                "internal_only": full.get("trustedrouter", {}).get(
+                    "internal_only", False
+                ),
+                "route_kind": full.get("trustedrouter", {}).get(
+                    "route_kind", "model"
+                ),
+                "supports_chat": full.get("trustedrouter", {}).get(
+                    "supports_chat", True
+                ),
+            },
+        }
+
+
+def test_v1_models_honors_an_explicit_gzip_rejection(client: TestClient) -> None:
+    response = client.get(
+        "/v1/models",
+        headers={"accept-encoding": "br, gzip ; q = 0, identity;q=1"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-encoding"] == "identity"
+
+
+def test_filtered_catalog_uses_cached_shapes_and_its_own_validator(client: TestClient) -> None:
+    full = client.get("/v1/models")
+    filtered = client.get("/v1/models?open_weights=true")
+
+    assert filtered.status_code == 200
+    rows = filtered.json()["data"]
+    assert rows
+    assert all(row["trustedrouter"]["open_weights"] for row in rows)
+    assert filtered.headers["etag"] != full.headers["etag"]
+    unchanged = client.get(
+        "/v1/models?open_weights=true",
+        headers={"if-none-match": filtered.headers["etag"]},
+    )
+    assert unchanged.status_code == 304
+
+
+def test_irrelevant_query_parameters_keep_the_prebuilt_full_payload(client: TestClient) -> None:
+    full = client.get("/v1/models")
+    tracked = client.get("/v1/models?utm_source=docs")
+
+    assert tracked.content == full.content
+    assert tracked.headers["etag"] == full.headers["etag"]
+
+
+def test_browser_pickers_use_projection_and_console_defers_fetch_until_open() -> None:
+    static = Path(__file__).parents[1] / "src" / "trusted_router" / "static"
+    shared = (static / "model_catalog.js").read_text()
+    custom = (static / "custom_models.js").read_text()
+
+    assert 'fetch(base + "/models/picker")' in shared
+    assert custom.count("load();") == 1
+    assert "if (nameEl && !nameEl.textContent.trim())" in custom


### PR DESCRIPTION
## Summary
- precompute immutable public model shapes and serialized identity/gzip representations once per release
- add strong representation-specific ETags and short shared-cache directives without changing filtered response semantics
- preserve the existing OpenAPI response contract and handle gzip aliases/middleware correctly
- add a lightweight picker projection and defer the custom-model catalog fetch until the picker opens

## Performance
On identical same-machine warm requests with PYTHONPATH=src and seven samples, /v1/models median fell from 218.365 ms to 2.603 ms. An independent rerun measured 232.485 ms to 2.773 ms. The picker is 15,121 bytes gzip versus 98,883 bytes for the full response.

## Verification
- exact full suite: 4,929 passed, 296 skipped, 10 expected xfails
- focused catalog/cache tests: 9 passed; every new test node is parent-red
- expanded catalog/custom-model suite: 231 passed
- exact body parity for full, filtered, region, jurisdiction, and irrelevant-query variants
- full Ruff, mypy, JavaScript syntax, and diff checks green
- independent exact-commit review approved

Internal models remain excluded, and cache inputs are release-static. No user-specific data is cached.