### PR TITLE
Move blocking console work off the event loop

### DIFF
--- a/src/trusted_router/middleware.py
+++ b/src/trusted_router/middleware.py
@@ -33,6 +33,7 @@ from urllib.parse import parse_qs, urlsplit
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, RedirectResponse, Response
+from starlette.concurrency import run_in_threadpool
 from starlette.middleware.gzip import GZipMiddleware
 
 from trusted_router.acquisition import (
@@ -271,7 +272,7 @@ def register_http_middleware(app: FastAPI, settings: Settings) -> None:
         # drops the flag.
         if settings.read_only:
             return await call_next(request)
-        limited = _rate_limit_request(
+        limited = await _rate_limit_request(
             request,
             settings,
             public_read_rate_limits=public_read_rate_limits,
@@ -316,7 +317,7 @@ def _apex_public_url(settings: Settings, request: Request, hostname: str) -> str
     return f"https://{domain}{request.url.path}{suffix}"
 
 
-def _rate_limit_request(
+async def _rate_limit_request(
     request: Request,
     settings: Settings,
     *,
@@ -351,6 +352,7 @@ def _rate_limit_request(
         subject = _fingerprint(ip)
         limit = settings.rate_limit_ip_per_window
         hit_rate_limit = public_read_rate_limits.hit
+        durable = False
     elif path.startswith(("/internal/", "/v1/internal/")):
         namespace = "internal"
         # Subject cardinality must be BOUNDED against unauthenticated input:
@@ -378,24 +380,36 @@ def _rate_limit_request(
         # bucket keeps the backstop off the money path; fleet capacity is limit
         # times the number of instances.
         hit_rate_limit = public_read_rate_limits.hit
+        durable = False
     elif bearer:
         namespace = "key"
         subject = _fingerprint(bearer)
         limit = settings.rate_limit_key_per_window
         hit_rate_limit = STORE.hit_rate_limit
+        durable = True
     else:
         namespace = "ip"
         subject = _fingerprint(user or ip)
         limit = settings.rate_limit_ip_per_window
         hit_rate_limit = STORE.hit_rate_limit
+        durable = True
 
     try:
-        hit = hit_rate_limit(
-            namespace=namespace,
-            subject=subject,
-            limit=limit,
-            window_seconds=settings.rate_limit_window_seconds,
-        )
+        if durable:
+            hit = await run_in_threadpool(
+                hit_rate_limit,
+                namespace=namespace,
+                subject=subject,
+                limit=limit,
+                window_seconds=settings.rate_limit_window_seconds,
+            )
+        else:
+            hit = hit_rate_limit(
+                namespace=namespace,
+                subject=subject,
+                limit=limit,
+                window_seconds=settings.rate_limit_window_seconds,
+            )
     except Exception as exc:  # noqa: BLE001 — best-effort guard, must not 500
         # Rate limiting is a best-effort guard, not core request logic. The
         # Spanner read-modify-write on the (namespace#subject#bucket) counter

--- a/src/trusted_router/routes/console/activity.py
+++ b/src/trusted_router/routes/console/activity.py
@@ -200,7 +200,7 @@ def _client_reliability_data(
 
 def register(app: FastAPI) -> None:
     @app.get("/console/activity")
-    async def console_activity(ctx: ConsoleDep, settings: SettingsDep) -> Response:
+    def console_activity(ctx: ConsoleDep, settings: SettingsDep) -> Response:
         events = STORE.activity_events(ctx.workspace.id, limit=50)
         for event in events:
             event["cost_display"] = format_money_precise(int(event.get("cost_microdollars") or 0))
@@ -215,7 +215,7 @@ def register(app: FastAPI) -> None:
         ))
 
     @app.get("/console/activity/usage.json")
-    async def console_activity_usage(
+    def console_activity_usage(
         ctx: ConsoleDep,
         range_: str = Query("30d", alias="range"),
         by_model: bool = False,
@@ -259,7 +259,7 @@ def register(app: FastAPI) -> None:
         return result
 
     @app.get("/console/activity/client-reliability.json")
-    async def console_activity_client_reliability(
+    def console_activity_client_reliability(
         ctx: ConsoleDep,
         settings: SettingsDep,
         range_: str = Query("24h", alias="range"),

--- a/src/trusted_router/routes/console/api_keys.py
+++ b/src/trusted_router/routes/console/api_keys.py
@@ -65,7 +65,7 @@ def register(app: FastAPI) -> None:
         ))
 
     @app.get("/console/api-keys")
-    async def console_api_keys(
+    def console_api_keys(
         ctx: ConsoleDep,
         settings: SettingsDep,
         saved: str | None = None,
@@ -74,7 +74,7 @@ def register(app: FastAPI) -> None:
         return _render_page(ctx, settings, saved=saved, error=error)
 
     @app.post("/console/api-keys")
-    async def console_create_api_key(
+    def console_create_api_key(
         ctx: ConsoleDep,
         settings: SettingsDep,
         name: str = Form("API key", min_length=1, max_length=120),
@@ -108,7 +108,7 @@ def register(app: FastAPI) -> None:
         return _render_page(ctx, settings, created_key=raw)
 
     @app.post("/console/api-keys/{key_hash}/limit")
-    async def console_update_api_key_limit(
+    def console_update_api_key_limit(
         ctx: ConsoleDep,
         key_hash: str,
         limit: str = Form(""),
@@ -140,19 +140,19 @@ def register(app: FastAPI) -> None:
         return RedirectResponse(url="/console/api-keys?saved=limit", status_code=303)
 
     @app.post("/console/api-keys/{key_hash}/disable")
-    async def console_disable_api_key(ctx: ConsoleDep, key_hash: str) -> Response:
+    def console_disable_api_key(ctx: ConsoleDep, key_hash: str) -> Response:
         _require_key(ctx, key_hash, manage=True)
         STORE.update_key(key_hash, {"disabled": True})
         return RedirectResponse(url="/console/api-keys?saved=disabled", status_code=303)
 
     @app.post("/console/api-keys/{key_hash}/enable")
-    async def console_enable_api_key(ctx: ConsoleDep, key_hash: str) -> Response:
+    def console_enable_api_key(ctx: ConsoleDep, key_hash: str) -> Response:
         _require_key(ctx, key_hash, manage=True)
         STORE.update_key(key_hash, {"disabled": False})
         return RedirectResponse(url="/console/api-keys?saved=enabled", status_code=303)
 
     @app.post("/console/api-keys/{key_hash}/delete")
-    async def console_delete_api_key(ctx: ConsoleDep, key_hash: str) -> Response:
+    def console_delete_api_key(ctx: ConsoleDep, key_hash: str) -> Response:
         key = _require_key(ctx, key_hash, manage=True)
         # Disable-first, then delete: an ACTIVE key may have in-flight typed
         # holds; deleting it mid-flight strands them (issue #29). Disabling

--- a/src/trusted_router/routes/console/broadcast.py
+++ b/src/trusted_router/routes/console/broadcast.py
@@ -26,7 +26,7 @@ from trusted_router.storage import STORE, BroadcastDestination
 
 def register(app: FastAPI) -> None:
     @app.get("/console/broadcast")
-    async def console_broadcast(ctx: ConsoleDep, settings: SettingsDep) -> Response:
+    def console_broadcast(ctx: ConsoleDep, settings: SettingsDep) -> Response:
         destinations = [
             public_destination_shape(destination)
             for destination in STORE.list_broadcast_destinations(ctx.workspace.id)
@@ -43,7 +43,7 @@ def register(app: FastAPI) -> None:
         ))
 
     @app.post("/console/broadcast")
-    async def console_create_broadcast(
+    def console_create_broadcast(
         ctx: ConsoleDep,
         settings: SettingsDep,
         name: str = Form(..., min_length=1, max_length=120),
@@ -87,7 +87,7 @@ def register(app: FastAPI) -> None:
         return RedirectResponse(url="/console/broadcast", status_code=303)
 
     @app.post("/console/broadcast/{destination_id}/delete")
-    async def console_delete_broadcast(ctx: ConsoleDep, destination_id: str) -> Response:
+    def console_delete_broadcast(ctx: ConsoleDep, destination_id: str) -> Response:
         STORE.delete_broadcast_destination(ctx.workspace.id, destination_id)
         return RedirectResponse(url="/console/broadcast", status_code=303)
 

--- a/src/trusted_router/routes/console/byok.py
+++ b/src/trusted_router/routes/console/byok.py
@@ -19,7 +19,7 @@ from trusted_router.storage import STORE
 
 def register(app: FastAPI) -> None:
     @app.get("/console/byok")
-    async def console_byok(ctx: ConsoleDep, settings: SettingsDep) -> Response:
+    def console_byok(ctx: ConsoleDep, settings: SettingsDep) -> Response:
         providers = [
             {
                 "provider": p.provider,
@@ -41,7 +41,7 @@ def register(app: FastAPI) -> None:
         ))
 
     @app.post("/console/byok")
-    async def console_save_byok(
+    def console_save_byok(
         ctx: ConsoleDep,
         settings: SettingsDep,
         provider: str = Form(..., min_length=1, max_length=64),

--- a/src/trusted_router/routes/console/credits.py
+++ b/src/trusted_router/routes/console/credits.py
@@ -167,14 +167,18 @@ def register(app: FastAPI) -> None:
         )
         payments, payments_available = payment_result
 
-        return HTMLResponse(
-            render_template(
+        def render_stripe_details() -> str:
+            return render_template(
                 "console/_credits_stripe_details.html",
                 saved_payment_method=saved_payment_method,
                 payments=payments,
                 payments_available=payments_available,
                 wallet_only_billing=is_wallet_only_user(ctx.user),
-            ),
+            )
+
+        stripe_details_html = await run_in_threadpool(render_stripe_details)
+        return HTMLResponse(
+            stripe_details_html,
             headers=_PRIVATE_CREDITS_HEADERS,
         )
 

--- a/src/trusted_router/routes/console/credits.py
+++ b/src/trusted_router/routes/console/credits.py
@@ -60,7 +60,7 @@ _PRIVATE_CREDITS_HEADERS = {
 
 def register(app: FastAPI) -> None:
     @app.get("/console/credits")
-    async def console_credits(
+    def console_credits(
         ctx: ConsoleDep,
         settings: SettingsDep,
         purpose: str = "",
@@ -179,11 +179,11 @@ def register(app: FastAPI) -> None:
         )
 
     @app.get("/console/credits/checkout")
-    async def console_credit_checkout_get(_ctx: ConsoleDep) -> Response:
+    def console_credit_checkout_get(_ctx: ConsoleDep) -> Response:
         return RedirectResponse(url="/console/credits", status_code=302)
 
     @app.post("/console/credits/checkout")
-    async def console_credit_checkout(
+    def console_credit_checkout(
         request: Request,
         ctx: ConsoleDep,
         settings: SettingsDep,
@@ -298,7 +298,7 @@ def register(app: FastAPI) -> None:
         return RedirectResponse(url=str(data["url"]), status_code=303)
 
     @app.get("/console/credits/paypal/capture")
-    async def console_paypal_capture(
+    def console_paypal_capture(
         ctx: ConsoleDep,
         settings: SettingsDep,
         token: str = "",
@@ -319,7 +319,7 @@ def register(app: FastAPI) -> None:
         return RedirectResponse(url=f"/console/credits?checkout=success&{suffix}", status_code=303)
 
     @app.post("/console/credits/payment-methods/add")
-    async def console_add_payment_method(
+    def console_add_payment_method(
         request: Request,
         ctx: ConsoleDep,
         settings: SettingsDep,
@@ -344,7 +344,7 @@ def register(app: FastAPI) -> None:
         return RedirectResponse(url=str(data["url"]), status_code=303)
 
     @app.post("/console/credits/payment-methods/manage")
-    async def console_manage_payment_methods(
+    def console_manage_payment_methods(
         request: Request,
         ctx: ConsoleDep,
         settings: SettingsDep,
@@ -364,7 +364,7 @@ def register(app: FastAPI) -> None:
         return RedirectResponse(url=data["url"], status_code=303)
 
     @app.post("/console/credits/payment-methods/remove")
-    async def console_remove_payment_method(
+    def console_remove_payment_method(
         ctx: ConsoleDep,
         settings: SettingsDep,
     ) -> Response:
@@ -379,7 +379,7 @@ def register(app: FastAPI) -> None:
         return RedirectResponse(url=f"/console/credits?payment_method={suffix}", status_code=303)
 
     @app.post("/console/credits/auto-refill")
-    async def console_save_auto_refill(
+    def console_save_auto_refill(
         ctx: ConsoleDep,
         settings: SettingsDep,
         enabled: str = Form(""),

--- a/src/trusted_router/routes/console/custom_models.py
+++ b/src/trusted_router/routes/console/custom_models.py
@@ -22,7 +22,7 @@ from trusted_router.storage_custom_models import (
 
 def register(app: FastAPI) -> None:
     @app.get("/console/custom-models")
-    async def console_custom_models(
+    def console_custom_models(
         request: Request,
         ctx: ConsoleDep,
         settings: SettingsDep,
@@ -30,7 +30,7 @@ def register(app: FastAPI) -> None:
         return HTMLResponse(_render_page(ctx, settings, request=request))
 
     @app.post("/console/custom-models")
-    async def console_create_custom_model(
+    def console_create_custom_model(
         ctx: ConsoleDep,
         settings: SettingsDep,
         name: str = Form(..., min_length=1, max_length=120),
@@ -64,7 +64,7 @@ def register(app: FastAPI) -> None:
         return RedirectResponse(url="/console/custom-models?saved=created", status_code=303)
 
     @app.post("/console/custom-models/{model_id:path}")
-    async def console_update_custom_model(
+    def console_update_custom_model(
         ctx: ConsoleDep,
         settings: SettingsDep,
         model_id: str,
@@ -100,7 +100,7 @@ def register(app: FastAPI) -> None:
         return RedirectResponse(url="/console/custom-models?saved=updated", status_code=303)
 
     @app.post("/console/custom-models/{model_id:path}/delete")
-    async def console_delete_custom_model(ctx: ConsoleDep, model_id: str) -> Response:
+    def console_delete_custom_model(ctx: ConsoleDep, model_id: str) -> Response:
         model = _require_owner_model(model_id, ctx.user.id)
         STORE.delete_custom_model(model.id, owner_user_id=ctx.user.id)
         return RedirectResponse(url="/console/custom-models?saved=deleted", status_code=303)

--- a/src/trusted_router/routes/console/earnings.py
+++ b/src/trusted_router/routes/console/earnings.py
@@ -17,7 +17,7 @@ from trusted_router.storage import STORE
 
 def register(app: FastAPI) -> None:
     @app.get("/console/earnings")
-    async def console_earnings(
+    def console_earnings(
         request: Request,
         ctx: ConsoleDep,
         settings: SettingsDep,
@@ -25,7 +25,7 @@ def register(app: FastAPI) -> None:
         return HTMLResponse(_render_page(request, ctx, settings))
 
     @app.post("/console/earnings/transfer")
-    async def console_transfer_earnings(
+    def console_transfer_earnings(
         ctx: ConsoleDep,
         workspace_id: str = Form(...),
         amount: str = Form(...),

--- a/src/trusted_router/routes/console/preferences.py
+++ b/src/trusted_router/routes/console/preferences.py
@@ -11,7 +11,7 @@ from trusted_router.routes.console._shared import ConsoleDep, render
 
 def register(app: FastAPI) -> None:
     @app.get("/console/account/preferences")
-    async def console_preferences(ctx: ConsoleDep, settings: SettingsDep) -> Response:
+    def console_preferences(ctx: ConsoleDep, settings: SettingsDep) -> Response:
         return HTMLResponse(render(
             "console/account/preferences.html",
             settings=settings,

--- a/src/trusted_router/routes/console/root.py
+++ b/src/trusted_router/routes/console/root.py
@@ -17,11 +17,11 @@ from trusted_router.storage import STORE
 
 def register(app: FastAPI) -> None:
     @app.get("/console")
-    async def console_root() -> Response:
+    def console_root() -> Response:
         return RedirectResponse(url="/console/api-keys", status_code=302)
 
     @app.post("/console/workspaces/select")
-    async def console_select_workspace(
+    def console_select_workspace(
         request: Request,
         ctx: ConsoleDep,
         workspace_id: str = Form(..., min_length=1, max_length=128),

--- a/src/trusted_router/routes/console/routing_page.py
+++ b/src/trusted_router/routes/console/routing_page.py
@@ -12,7 +12,7 @@ from trusted_router.routes.console._shared import ConsoleDep, render
 
 def register(app: FastAPI) -> None:
     @app.get("/console/routing")
-    async def console_routing(ctx: ConsoleDep, settings: SettingsDep) -> Response:
+    def console_routing(ctx: ConsoleDep, settings: SettingsDep) -> Response:
         regions = []
         for region in region_payload(settings):
             # Strip the scheme + /v1 from api_base_url so the routing

--- a/src/trusted_router/routes/console/settings.py
+++ b/src/trusted_router/routes/console/settings.py
@@ -32,7 +32,7 @@ def _back(query: str) -> RedirectResponse:
 
 def register(app: FastAPI) -> None:
     @app.get("/console/settings")
-    async def console_settings(
+    def console_settings(
         ctx: ConsoleDep,
         settings: SettingsDep,
         saved: str = "",
@@ -75,7 +75,7 @@ def register(app: FastAPI) -> None:
         )
 
     @app.post("/console/settings/phone/start")
-    async def console_phone_start(
+    def console_phone_start(
         ctx: ConsoleDep,
         settings: SettingsDep,
         phone: str = Form(""),
@@ -132,24 +132,24 @@ def register(app: FastAPI) -> None:
         return _back(f"sent={wanted}")
 
     @app.post("/console/settings/phone/confirm")
-    async def console_phone_confirm(ctx: ConsoleDep, code: str = Form("")) -> Response:
+    def console_phone_confirm(ctx: ConsoleDep, code: str = Form("")) -> Response:
         status, _user = STORE.confirm_phone_verification(ctx.user.id, code)
         if status == "ok":
             return _back("phone_saved=1")
         return _back(f"error={status}")
 
     @app.post("/console/settings/phone/cancel")
-    async def console_phone_cancel(ctx: ConsoleDep) -> Response:
+    def console_phone_cancel(ctx: ConsoleDep) -> Response:
         STORE.cancel_phone_verification(ctx.user.id)
         return _back("")
 
     @app.post("/console/settings/phone/remove")
-    async def console_phone_remove(ctx: ConsoleDep) -> Response:
+    def console_phone_remove(ctx: ConsoleDep) -> Response:
         STORE.clear_user_phone(ctx.user.id)
         return _back("")
 
     @app.post("/console/settings")
-    async def console_update_settings(
+    def console_update_settings(
         ctx: ConsoleDep,
         name: str = Form(""),
     ) -> Response:

--- a/src/trusted_router/routes/console/user_models.py
+++ b/src/trusted_router/routes/console/user_models.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from fastapi import FastAPI, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse, Response
+from starlette.concurrency import run_in_threadpool
 
 from trusted_router.auth import SettingsDep
 from trusted_router.custom_model_billing import (
@@ -33,7 +34,7 @@ from trusted_router.user_model_rules import (
 
 def register(app: FastAPI) -> None:
     @app.get("/console/user-models")
-    async def console_user_models(
+    def console_user_models(
         request: Request,
         ctx: ConsoleDep,
         settings: SettingsDep,
@@ -72,7 +73,8 @@ def register(app: FastAPI) -> None:
         normalized_display_name = validate_user_model_display_name(display_name)
         normalized_endpoint = await validate_endpoint_url(endpoint_url, settings)
         signing_secret = secrets.token_urlsafe(32)
-        try:
+
+        def create_and_render() -> Response:
             STORE.create_user_model(
                 owner_user_id=ctx.user.id,
                 owner_workspace_id=ctx.workspace.id,
@@ -110,18 +112,21 @@ def register(app: FastAPI) -> None:
                 human_verified=kind == "human",
                 slug=normalized_slug,
             )
+            return HTMLResponse(
+                _render_page(
+                    ctx,
+                    settings,
+                    request=request,
+                    one_time_secret=signing_secret,
+                    one_time_reason="created",
+                ),
+                status_code=201,
+            )
+
+        try:
+            return await run_in_threadpool(create_and_render)
         except ValueError as exc:
             return _store_error_redirect(exc)
-        return HTMLResponse(
-            _render_page(
-                ctx,
-                settings,
-                request=request,
-                one_time_secret=signing_secret,
-                one_time_reason="created",
-            ),
-            status_code=201,
-        )
 
     @app.post("/console/user-models/{model_id:path}/edit")
     async def console_update_user_model(
@@ -145,7 +150,7 @@ def register(app: FastAPI) -> None:
     ) -> Response:
         if missing_custom_model_requirements(ctx.user, settings):
             return _redirect("error=verification")
-        model = _require_owner_model(model_id, ctx.user.id)
+        model = await run_in_threadpool(_require_owner_model, model_id, ctx.user.id)
         _validate_form_values(
             kind=kind,
             display_identity=display_identity,
@@ -172,19 +177,23 @@ def register(app: FastAPI) -> None:
             ),
             "human_verified": kind == "human",
         }
-        if endpoint_api_key:
-            patch["encrypted_endpoint_api_key"] = encrypt_user_model_endpoint_key(
-                endpoint_api_key,
-                settings,
-                workspace_id=model.owner_workspace_id,
-            )
-            patch["endpoint_key_hint"] = _secret_hint(endpoint_api_key)
-        try:
+
+        def update_model() -> None:
+            if endpoint_api_key:
+                patch["encrypted_endpoint_api_key"] = encrypt_user_model_endpoint_key(
+                    endpoint_api_key,
+                    settings,
+                    workspace_id=model.owner_workspace_id,
+                )
+                patch["endpoint_key_hint"] = _secret_hint(endpoint_api_key)
             STORE.update_user_model(
                 model.id,
                 owner_user_id=ctx.user.id,
                 patch=patch,
             )
+
+        try:
+            await run_in_threadpool(update_model)
         except ValueError as exc:
             return _store_error_redirect(exc)
         return _redirect("saved=updated")
@@ -195,24 +204,32 @@ def register(app: FastAPI) -> None:
         settings: SettingsDep,
         model_id: str,
     ) -> Response:
-        model = _require_owner_model(model_id, ctx.user.id)
+        model = await run_in_threadpool(_require_owner_model, model_id, ctx.user.id)
         result = await probe_user_model(model, settings)
         if not result.ok:
-            STORE.set_user_model_online(
-                model.id, owner_user_id=ctx.user.id, online=False
+            await run_in_threadpool(
+                STORE.set_user_model_online,
+                model.id,
+                owner_user_id=ctx.user.id,
+                online=False,
             )
             return _redirect("error=probe")
-        STORE.set_user_model_online(model.id, owner_user_id=ctx.user.id, online=True)
+        await run_in_threadpool(
+            STORE.set_user_model_online,
+            model.id,
+            owner_user_id=ctx.user.id,
+            online=True,
+        )
         return _redirect("saved=clocked-in")
 
     @app.post("/console/user-models/{model_id:path}/clock-out")
-    async def console_clock_out_user_model(ctx: ConsoleDep, model_id: str) -> Response:
+    def console_clock_out_user_model(ctx: ConsoleDep, model_id: str) -> Response:
         model = _require_owner_model(model_id, ctx.user.id)
         STORE.set_user_model_online(model.id, owner_user_id=ctx.user.id, online=False)
         return _redirect("saved=clocked-out")
 
     @app.post("/console/user-models/{model_id:path}/rotate-secrets")
-    async def console_rotate_user_model_secret(
+    def console_rotate_user_model_secret(
         request: Request,
         ctx: ConsoleDep,
         settings: SettingsDep,
@@ -242,7 +259,7 @@ def register(app: FastAPI) -> None:
         )
 
     @app.post("/console/user-models/{model_id:path}/delete")
-    async def console_delete_user_model(ctx: ConsoleDep, model_id: str) -> Response:
+    def console_delete_user_model(ctx: ConsoleDep, model_id: str) -> Response:
         model = _require_owner_model(model_id, ctx.user.id)
         STORE.delete_user_model(model.id, owner_user_id=ctx.user.id)
         return _redirect("saved=deleted")

--- a/src/trusted_router/routes/console/verification.py
+++ b/src/trusted_router/routes/console/verification.py
@@ -21,7 +21,7 @@ from trusted_router.verification_gates import missing_identity_verification_requ
 
 def register(app: FastAPI) -> None:
     @app.get("/console/account/verification")
-    async def console_verification(
+    def console_verification(
         ctx: ConsoleDep,
         settings: SettingsDep,
         error: str = "",
@@ -98,7 +98,7 @@ def register(app: FastAPI) -> None:
         )
 
     @app.post("/console/account/verification/identity/start")
-    async def console_start_identity(
+    def console_start_identity(
         ctx: ConsoleDep,
         settings: SettingsDep,
     ) -> Response:

--- a/src/trusted_router/routes/console/welcome.py
+++ b/src/trusted_router/routes/console/welcome.py
@@ -13,7 +13,7 @@ from trusted_router.typed_balance import live_credit_summary
 
 def register(app: FastAPI) -> None:
     @app.get("/console/welcome")
-    async def console_welcome(
+    def console_welcome(
         request: Request,
         ctx: ConsoleDep,
         settings: SettingsDep,

--- a/src/trusted_router/services/user_model_probe.py
+++ b/src/trusted_router/services/user_model_probe.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 import httpx
+from starlette.concurrency import run_in_threadpool
 
 from trusted_router.byok_crypto import decrypt_user_model_secret
 from trusted_router.config import Settings
@@ -39,9 +40,21 @@ async def probe_user_model(
     store: Any = STORE,
 ) -> ProbeResult:
     checked_at = datetime.now(UTC)
+
+    async def recorded_result(*, ok: bool, detail: str) -> ProbeResult:
+        return await run_in_threadpool(
+            _recorded_result,
+            model,
+            ok=ok,
+            detail=detail,
+            checked_at=checked_at,
+            store=store,
+        )
+
     try:
-        signing_secret = _decrypt_signing_secret(model, settings)
-        endpoint_api_key = _decrypt_endpoint_key(model, settings)
+        signing_secret, endpoint_api_key = await run_in_threadpool(
+            _decrypt_probe_secrets, model, settings
+        )
         # Probe the transport DISPATCH will actually use, and only that one.
         # `_owner_request` sends `stream: model.supports_streaming` on every
         # real call, whatever the caller asked for, and adapts the answer at
@@ -59,51 +72,33 @@ async def probe_user_model(
         )
         if model.supports_streaming:
             if not _valid_stream(answer):
-                return _recorded_result(
-                    model,
+                return await recorded_result(
                     ok=False,
                     detail="Endpoint response was not a valid chat completion stream",
-                    checked_at=checked_at,
-                    store=store,
                 )
         elif not _valid_chat_completion(answer):
-            return _recorded_result(
-                model,
+            return await recorded_result(
                 ok=False,
                 detail="Endpoint response was not an OpenAI chat completion",
-                checked_at=checked_at,
-                store=store,
             )
     except httpx.TimeoutException:
-        return _recorded_result(
-            model,
+        return await recorded_result(
             ok=False,
             detail="Endpoint probe timed out",
-            checked_at=checked_at,
-            store=store,
         )
     except httpx.HTTPError:
-        return _recorded_result(
-            model,
+        return await recorded_result(
             ok=False,
             detail="Endpoint probe failed",
-            checked_at=checked_at,
-            store=store,
         )
     except Exception as exc:  # fail closed without echoing secret-bearing details
-        return _recorded_result(
-            model,
+        return await recorded_result(
             ok=False,
             detail=f"Endpoint probe failed ({type(exc).__name__})",
-            checked_at=checked_at,
-            store=store,
         )
-    return _recorded_result(
-        model,
+    return await recorded_result(
         ok=True,
         detail="Probe succeeded",
-        checked_at=checked_at,
-        store=store,
     )
 
 
@@ -240,6 +235,16 @@ def _decrypt_endpoint_key(
         settings,
         workspace_id=model.owner_workspace_id,
         purpose=USER_MODEL_ENDPOINT_KEY_PURPOSE,
+    )
+
+
+def _decrypt_probe_secrets(
+    model: UserProvidedModel,
+    settings: Settings,
+) -> tuple[str, str | None]:
+    return (
+        _decrypt_signing_secret(model, settings),
+        _decrypt_endpoint_key(model, settings),
     )
 
 

--- a/tests/test_console_event_loop_isolation.py
+++ b/tests/test_console_event_loop_isolation.py
@@ -2,11 +2,11 @@
 
 Console pages are dominated by synchronous storage, KMS, payment-provider, and
 template work.  FastAPI only moves that work to AnyIO's worker pool when the
-decorated endpoint is a plain ``def``.  The three console endpoints that really
-await network I/O keep ``async def`` and place each synchronous segment behind
-``run_in_threadpool`` explicitly.
+decorated endpoint is a plain ``def``.  The four console endpoints that really
+await network I/O or coordinate concurrent provider calls keep ``async def`` and
+place each synchronous segment behind ``run_in_threadpool`` explicitly.
 
-The AST checks make the 45/3 split non-vacuous; the thread-id and heartbeat
+The AST checks make the 45/4 split non-vacuous; the thread-id and heartbeat
 checks prove the framework/runtime behavior instead of merely matching source
 text.  Storage methods are patched on ``InMemoryStore`` rather than the global
 ``STORE`` proxy so pytest restores them without poisoning later tests.
@@ -34,6 +34,7 @@ from trusted_router.storage_rate_limits import InMemoryRateLimits
 _ROOT = Path(__file__).resolve().parents[1]
 _CONSOLE_DIR = _ROOT / "src" / "trusted_router" / "routes" / "console"
 _ASYNC_CONSOLE_HANDLERS = {
+    "console_credit_stripe_details",
     "console_create_user_model",
     "console_update_user_model",
     "console_clock_in_user_model",
@@ -91,6 +92,18 @@ def _offload_targets(function: ast.FunctionDef | ast.AsyncFunctionDef) -> list[s
     return targets
 
 
+def _threadpool_targets(function: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    """Include workers passed to an awaited ``asyncio.gather`` call."""
+    return [
+        ast.unparse(node.args[0])
+        for node in _walk_without_nested_functions(function)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "run_in_threadpool"
+        and node.args
+    ]
+
+
 def _nested_function(
     function: ast.FunctionDef | ast.AsyncFunctionDef, name: str
 ) -> ast.FunctionDef | ast.AsyncFunctionDef:
@@ -110,12 +123,18 @@ def _nested_function(
 
 def test_console_route_async_split_and_worker_boundaries_are_total() -> None:
     routes = _console_route_functions()
-    assert len(routes) == 48, "guard must inspect every decorated console route"
+    assert len(routes) == 49, "guard must inspect every decorated console route"
     async_routes = {node.name for node in routes if isinstance(node, ast.AsyncFunctionDef)}
     assert async_routes == _ASYNC_CONSOLE_HANDLERS
     assert sum(isinstance(node, ast.FunctionDef) for node in routes) == 45
 
     by_name = {node.name: node for node in routes}
+    assert set(_threadpool_targets(by_name["console_credit_stripe_details"])) == {
+        "STORE.get_credit_account",
+        "_load_saved_payment_method",
+        "_load_workspace_payments",
+        "render_stripe_details",
+    }
     assert _offload_targets(by_name["console_create_user_model"]) == ["create_and_render"]
     assert set(_offload_targets(by_name["console_update_user_model"])) == {
         "_require_owner_model",
@@ -147,6 +166,14 @@ def test_console_route_async_split_and_worker_boundaries_are_total() -> None:
     )
     assert "STORE.update_user_model" in update_callback
     assert "encrypt_user_model_endpoint_key" in update_callback
+
+    stripe_render_callback = ast.unparse(
+        _nested_function(
+            by_name["console_credit_stripe_details"], "render_stripe_details"
+        )
+    )
+    assert "render_template" in stripe_render_callback
+    assert "is_wallet_only_user" in stripe_render_callback
 
 
 def test_probe_and_durable_limiter_keep_explicit_worker_boundaries() -> None:
@@ -212,15 +239,21 @@ def test_sync_console_handler_runs_storage_off_loop_and_keeps_heartbeat_alive(
     started = threading.Event()
     release = threading.Event()
     storage_thread: dict[str, int] = {}
-    original = InMemoryStore.list_keys
+    original = InMemoryStore.list_api_keys_with_usage
 
-    def blocking_list_keys(self: InMemoryStore, workspace_id: str) -> Any:
+    def blocking_list_api_keys_with_usage(
+        self: InMemoryStore, workspace_id: str
+    ) -> Any:
         storage_thread["id"] = threading.get_ident()
         started.set()
         assert release.wait(timeout=2.0), "console storage ran on the blocked event loop"
         return original(self, workspace_id)
 
-    monkeypatch.setattr(InMemoryStore, "list_keys", blocking_list_keys)
+    monkeypatch.setattr(
+        InMemoryStore,
+        "list_api_keys_with_usage",
+        blocking_list_api_keys_with_usage,
+    )
 
     async def scenario() -> None:
         loop_thread = threading.get_ident()

--- a/tests/test_console_event_loop_isolation.py
+++ b/tests/test_console_event_loop_isolation.py
@@ -1,0 +1,453 @@
+"""Regression coverage for control-plane event-loop isolation.
+
+Console pages are dominated by synchronous storage, KMS, payment-provider, and
+template work.  FastAPI only moves that work to AnyIO's worker pool when the
+decorated endpoint is a plain ``def``.  The three console endpoints that really
+await network I/O keep ``async def`` and place each synchronous segment behind
+``run_in_threadpool`` explicitly.
+
+The AST checks make the 45/3 split non-vacuous; the thread-id and heartbeat
+checks prove the framework/runtime behavior instead of merely matching source
+text.  Storage methods are patched on ``InMemoryStore`` rather than the global
+``STORE`` proxy so pytest restores them without poisoning later tests.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import threading
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.routes.console import user_models as console_user_models
+from trusted_router.services import user_model_probe
+from trusted_router.storage import STORE, InMemoryStore
+from trusted_router.storage_models import UserProvidedModel
+from trusted_router.storage_rate_limits import InMemoryRateLimits
+
+_ROOT = Path(__file__).resolve().parents[1]
+_CONSOLE_DIR = _ROOT / "src" / "trusted_router" / "routes" / "console"
+_ASYNC_CONSOLE_HANDLERS = {
+    "console_create_user_model",
+    "console_update_user_model",
+    "console_clock_in_user_model",
+}
+
+
+def _console_route_functions() -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    functions: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
+    for path in sorted(_CONSOLE_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            for decorator in node.decorator_list:
+                if not (
+                    isinstance(decorator, ast.Call)
+                    and isinstance(decorator.func, ast.Attribute)
+                    and decorator.args
+                    and isinstance(decorator.args[0], ast.Constant)
+                    and isinstance(decorator.args[0].value, str)
+                    and decorator.args[0].value.startswith("/console")
+                ):
+                    continue
+                functions.append(node)
+                break
+    return functions
+
+
+def _walk_without_nested_functions(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> list[ast.AST]:
+    nodes: list[ast.AST] = []
+    stack: list[ast.AST] = list(function.body)
+    while stack:
+        node = stack.pop()
+        nodes.append(node)
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda):
+            continue
+        stack.extend(ast.iter_child_nodes(node))
+    return nodes
+
+
+def _offload_targets(function: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    targets: list[str] = []
+    for node in _walk_without_nested_functions(function):
+        if not (
+            isinstance(node, ast.Await)
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Name)
+            and node.value.func.id == "run_in_threadpool"
+            and node.value.args
+        ):
+            continue
+        targets.append(ast.unparse(node.value.args[0]))
+    return targets
+
+
+def _nested_function(
+    function: ast.FunctionDef | ast.AsyncFunctionDef, name: str
+) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    match = next(
+        (
+            node
+            for node in ast.walk(function)
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+            and node is not function
+            and node.name == name
+        ),
+        None,
+    )
+    assert match is not None, f"{function.name} lost its {name} worker callback"
+    return match
+
+
+def test_console_route_async_split_and_worker_boundaries_are_total() -> None:
+    routes = _console_route_functions()
+    assert len(routes) == 48, "guard must inspect every decorated console route"
+    async_routes = {node.name for node in routes if isinstance(node, ast.AsyncFunctionDef)}
+    assert async_routes == _ASYNC_CONSOLE_HANDLERS
+    assert sum(isinstance(node, ast.FunctionDef) for node in routes) == 45
+
+    by_name = {node.name: node for node in routes}
+    assert _offload_targets(by_name["console_create_user_model"]) == ["create_and_render"]
+    assert set(_offload_targets(by_name["console_update_user_model"])) == {
+        "_require_owner_model",
+        "update_model",
+    }
+    assert (
+        _offload_targets(by_name["console_clock_in_user_model"]).count("_require_owner_model") == 1
+    )
+    assert (
+        _offload_targets(by_name["console_clock_in_user_model"]).count(
+            "STORE.set_user_model_online"
+        )
+        == 2
+    )
+
+    create_callback = ast.unparse(
+        _nested_function(by_name["console_create_user_model"], "create_and_render")
+    )
+    for blocking_call in (
+        "STORE.create_user_model",
+        "encrypt_user_model_endpoint_key",
+        "encrypt_user_model_signing_secret",
+        "_render_page",
+    ):
+        assert blocking_call in create_callback
+
+    update_callback = ast.unparse(
+        _nested_function(by_name["console_update_user_model"], "update_model")
+    )
+    assert "STORE.update_user_model" in update_callback
+    assert "encrypt_user_model_endpoint_key" in update_callback
+
+
+def test_probe_and_durable_limiter_keep_explicit_worker_boundaries() -> None:
+    probe_path = _ROOT / "src" / "trusted_router" / "services" / "user_model_probe.py"
+    probe_tree = ast.parse(probe_path.read_text(encoding="utf-8"), filename=str(probe_path))
+    probe = next(
+        node
+        for node in ast.walk(probe_tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "probe_user_model"
+    )
+    assert "_decrypt_probe_secrets" in _offload_targets(probe)
+    recorded = _nested_function(probe, "recorded_result")
+    assert _offload_targets(recorded) == ["_recorded_result"]
+
+    middleware_path = _ROOT / "src" / "trusted_router" / "middleware.py"
+    middleware_tree = ast.parse(
+        middleware_path.read_text(encoding="utf-8"), filename=str(middleware_path)
+    )
+    limiter = next(
+        node
+        for node in ast.walk(middleware_tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "_rate_limit_request"
+    )
+    assert _offload_targets(limiter) == ["hit_rate_limit"]
+    source = ast.unparse(limiter)
+    assert "if durable:" in source
+    assert "else:\n            hit = hit_rate_limit" in source
+
+
+async def _wait_until_started(started: threading.Event) -> None:
+    for _ in range(400):
+        if started.is_set():
+            return
+        await asyncio.sleep(0.005)
+    raise AssertionError("blocked operation never started")
+
+
+async def _five_heartbeats() -> None:
+    for _ in range(5):
+        await asyncio.sleep(0.005)
+
+
+def _active_console_session(app: Any, email: str) -> str:
+    del app
+    user = STORE.ensure_user(email)
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+    raw_session, _ = STORE.create_auth_session(
+        user_id=user.id,
+        provider="test",
+        label=email,
+        ttl_seconds=3600,
+        state="active",
+        workspace_id=workspace.id,
+    )
+    return raw_session
+
+
+def test_sync_console_handler_runs_storage_off_loop_and_keeps_heartbeat_alive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = create_app(Settings(environment="test"), init_observability=False)
+    raw_session = _active_console_session(app, "console-loop@example.com")
+    started = threading.Event()
+    release = threading.Event()
+    storage_thread: dict[str, int] = {}
+    original = InMemoryStore.list_keys
+
+    def blocking_list_keys(self: InMemoryStore, workspace_id: str) -> Any:
+        storage_thread["id"] = threading.get_ident()
+        started.set()
+        assert release.wait(timeout=2.0), "console storage ran on the blocked event loop"
+        return original(self, workspace_id)
+
+    monkeypatch.setattr(InMemoryStore, "list_keys", blocking_list_keys)
+
+    async def scenario() -> None:
+        loop_thread = threading.get_ident()
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+            cookies={"tr_session": raw_session},
+        ) as client:
+            request = asyncio.create_task(client.get("/console/api-keys"))
+            try:
+                await _wait_until_started(started)
+                await _five_heartbeats()
+                assert storage_thread["id"] != loop_thread
+            finally:
+                release.set()
+            response = await asyncio.wait_for(request, timeout=5.0)
+            assert response.status_code == 200
+
+    asyncio.run(asyncio.wait_for(scenario(), timeout=10.0))
+
+
+def test_async_console_kms_store_and_template_segment_runs_off_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = Settings(
+        environment="test",
+        custom_models_require_verification=False,
+    )
+    app = create_app(settings, init_observability=False)
+    raw_session = _active_console_session(app, "async-console-loop@example.com")
+    started = threading.Event()
+    release = threading.Event()
+    threads: dict[str, list[int]] = {"kms": [], "store": [], "template": []}
+    original_create = InMemoryStore.create_user_model
+    original_endpoint_encrypt = console_user_models.encrypt_user_model_endpoint_key
+    original_signing_encrypt = console_user_models.encrypt_user_model_signing_secret
+    original_render = console_user_models.render
+
+    async def validated_endpoint(url: str, _settings: Settings) -> str:
+        await asyncio.sleep(0)
+        return url.rstrip("/")
+
+    def endpoint_encrypt(*args: Any, **kwargs: Any) -> Any:
+        threads["kms"].append(threading.get_ident())
+        return original_endpoint_encrypt(*args, **kwargs)
+
+    def signing_encrypt(*args: Any, **kwargs: Any) -> Any:
+        threads["kms"].append(threading.get_ident())
+        return original_signing_encrypt(*args, **kwargs)
+
+    def blocking_create(self: InMemoryStore, **kwargs: Any) -> UserProvidedModel:
+        threads["store"].append(threading.get_ident())
+        started.set()
+        assert release.wait(timeout=2.0), "async console storage blocked the event loop"
+        return original_create(self, **kwargs)
+
+    def render_in_worker(*args: Any, **kwargs: Any) -> str:
+        threads["template"].append(threading.get_ident())
+        return original_render(*args, **kwargs)
+
+    monkeypatch.setattr(console_user_models, "validate_endpoint_url", validated_endpoint)
+    monkeypatch.setattr(console_user_models, "encrypt_user_model_endpoint_key", endpoint_encrypt)
+    monkeypatch.setattr(console_user_models, "encrypt_user_model_signing_secret", signing_encrypt)
+    monkeypatch.setattr(console_user_models, "render", render_in_worker)
+    monkeypatch.setattr(InMemoryStore, "create_user_model", blocking_create)
+
+    async def scenario() -> None:
+        loop_thread = threading.get_ident()
+        transport = httpx.ASGITransport(app=app)
+        form = {
+            "name": "Worker model",
+            "slug": "worker-model",
+            "kind": "machine",
+            "display_name": "worker",
+            "endpoint_url": "https://owner.example/v1",
+            "endpoint_api_key": "owner-secret",
+            "max_concurrency": "4",
+            "prompt_price_microdollars_per_million_tokens": "100",
+            "completion_price_microdollars_per_million_tokens": "200",
+        }
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+            cookies={"tr_session": raw_session},
+        ) as client:
+            request = asyncio.create_task(client.post("/console/user-models", data=form))
+            try:
+                await _wait_until_started(started)
+                await _five_heartbeats()
+                assert threads["store"] == [threads["store"][0]]
+                assert threads["store"][0] != loop_thread
+                assert threads["kms"] and all(tid != loop_thread for tid in threads["kms"])
+            finally:
+                release.set()
+            response = await asyncio.wait_for(request, timeout=5.0)
+            assert response.status_code == 201, response.text
+            assert threads["template"] and all(tid != loop_thread for tid in threads["template"])
+
+    asyncio.run(asyncio.wait_for(scenario(), timeout=10.0))
+
+
+def test_durable_rate_limit_runs_off_loop_and_keeps_heartbeat_alive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = create_app(
+        Settings(environment="test", rate_limit_enabled=True),
+        init_observability=False,
+    )
+    started = threading.Event()
+    release = threading.Event()
+    storage_thread: dict[str, int] = {}
+    original = InMemoryStore.hit_rate_limit
+
+    def blocking_hit(self: InMemoryStore, **kwargs: Any) -> Any:
+        storage_thread["id"] = threading.get_ident()
+        started.set()
+        assert release.wait(timeout=2.0), "durable limiter blocked the event loop"
+        return original(self, **kwargs)
+
+    monkeypatch.setattr(InMemoryStore, "hit_rate_limit", blocking_hit)
+
+    async def scenario() -> None:
+        loop_thread = threading.get_ident()
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as client:
+            request = asyncio.create_task(
+                client.post(
+                    "/v1/signup",
+                    headers={"x-forwarded-for": "203.0.113.111"},
+                    json={},
+                )
+            )
+            try:
+                await _wait_until_started(started)
+                await _five_heartbeats()
+                assert storage_thread["id"] != loop_thread
+            finally:
+                release.set()
+            response = await asyncio.wait_for(request, timeout=5.0)
+            assert response.status_code == 400
+
+    asyncio.run(asyncio.wait_for(scenario(), timeout=10.0))
+
+
+def test_public_read_rate_limit_stays_inline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen_threads: list[int] = []
+    original = InMemoryRateLimits.hit
+
+    def spy_hit(self: InMemoryRateLimits, **kwargs: Any) -> Any:
+        seen_threads.append(threading.get_ident())
+        return original(self, **kwargs)
+
+    monkeypatch.setattr(InMemoryRateLimits, "hit", spy_hit)
+    app = create_app(
+        Settings(environment="test", rate_limit_enabled=True),
+        init_observability=False,
+    )
+
+    async def scenario() -> None:
+        loop_thread = threading.get_ident()
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as client:
+            response = await client.get("/v1/models")
+        assert response.status_code == 200
+        assert seen_threads == [loop_thread]
+
+    asyncio.run(scenario())
+
+
+def test_probe_kms_and_result_recording_run_off_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = Settings(environment="test")
+    user = STORE.ensure_user("probe-loop@example.com")
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+    model = STORE.create_user_model(
+        owner_user_id=user.id,
+        owner_workspace_id=workspace.id,
+        name="Probe worker",
+        slug="probe-worker",
+        kind="machine",
+        display_name="worker",
+        endpoint_url="https://owner.example/v1",
+        supports_streaming=False,
+    )
+    started = threading.Event()
+    release = threading.Event()
+    threads: dict[str, int] = {}
+    original_record = InMemoryStore.record_user_model_probe
+
+    def blocking_decrypt(_model: UserProvidedModel, _settings: Settings) -> Any:
+        threads["decrypt"] = threading.get_ident()
+        started.set()
+        assert release.wait(timeout=2.0), "probe KMS work blocked the event loop"
+        return "signing-secret", None
+
+    async def successful_probe(*_args: Any, **_kwargs: Any) -> bytes:
+        return b'{"choices":[{"message":{"content":"pong"}}]}'
+
+    def record_result(self: InMemoryStore, model_id: str, **kwargs: Any) -> Any:
+        threads["record"] = threading.get_ident()
+        return original_record(self, model_id, **kwargs)
+
+    monkeypatch.setattr(user_model_probe, "_decrypt_probe_secrets", blocking_decrypt)
+    monkeypatch.setattr(user_model_probe, "_probe_once", successful_probe)
+    monkeypatch.setattr(InMemoryStore, "record_user_model_probe", record_result)
+
+    async def scenario() -> None:
+        loop_thread = threading.get_ident()
+        task = asyncio.create_task(user_model_probe.probe_user_model(model, settings))
+        try:
+            await _wait_until_started(started)
+            await _five_heartbeats()
+            assert threads["decrypt"] != loop_thread
+        finally:
+            release.set()
+        result = await asyncio.wait_for(task, timeout=5.0)
+        assert result.ok is True
+        assert threads["record"] != loop_thread
+
+    asyncio.run(asyncio.wait_for(scenario(), timeout=10.0))

--- a/tests/test_console_event_loop_isolation.py
+++ b/tests/test_console_event_loop_isolation.py
@@ -25,6 +25,7 @@ import pytest
 
 from trusted_router.config import Settings
 from trusted_router.main import create_app
+from trusted_router.routes.console import credits as console_credits
 from trusted_router.routes.console import user_models as console_user_models
 from trusted_router.services import user_model_probe
 from trusted_router.storage import STORE, InMemoryStore
@@ -352,6 +353,58 @@ def test_async_console_kms_store_and_template_segment_runs_off_loop(
             response = await asyncio.wait_for(request, timeout=5.0)
             assert response.status_code == 201, response.text
             assert threads["template"] and all(tid != loop_thread for tid in threads["template"])
+
+    asyncio.run(asyncio.wait_for(scenario(), timeout=10.0))
+
+
+def test_stripe_fragment_template_render_runs_off_loop_and_keeps_heartbeat_alive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = create_app(Settings(environment="test"), init_observability=False)
+    raw_session = _active_console_session(app, "stripe-render-loop@example.com")
+    started = threading.Event()
+    release = threading.Event()
+    render_thread: dict[str, int] = {}
+    original_render = console_credits.render_template
+
+    monkeypatch.setattr(
+        console_credits,
+        "_load_saved_payment_method",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        console_credits,
+        "_load_workspace_payments",
+        lambda *_args, **_kwargs: ([], True),
+    )
+
+    def blocking_render(*args: Any, **kwargs: Any) -> str:
+        render_thread["id"] = threading.get_ident()
+        started.set()
+        assert release.wait(timeout=2.0), "Stripe template blocked the event loop"
+        return original_render(*args, **kwargs)
+
+    monkeypatch.setattr(console_credits, "render_template", blocking_render)
+
+    async def scenario() -> None:
+        loop_thread = threading.get_ident()
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+            cookies={"tr_session": raw_session},
+        ) as client:
+            request = asyncio.create_task(
+                client.get("/console/credits/stripe-details")
+            )
+            try:
+                await _wait_until_started(started)
+                await _five_heartbeats()
+                assert render_thread["id"] != loop_thread
+            finally:
+                release.set()
+            response = await asyncio.wait_for(request, timeout=5.0)
+            assert response.status_code == 200
 
     asyncio.run(asyncio.wait_for(scenario(), timeout=10.0))
 


### PR DESCRIPTION
## Summary

- dispatch all 45 no-await console handlers through FastAPI worker threads
- retain exactly four async console handlers and offload every blocking storage, KMS, Stripe, probe, and template segment
- offload durable Store-backed rate-limit checks while keeping process-local public/internal buckets inline
- preserve console auth, ownership, tenant isolation, limiter precedence, headers, bypass, and fail-open behavior
- integrate the already-merged API-key batching, Stripe deferral, read-model batching, and catalog cache paths

## Measured impact

Same-machine fixed 200 ms blockers, three runs:

- two concurrent console requests: median 435.8 ms to 254.6 ms
- console maximum event-loop gap: 427.7 ms to 13.5 ms
- durable limiter requests: median 433.8 ms to 226.7 ms
- limiter maximum event-loop gap: 413.5 ms to 8.5 ms

No AnyIO limiter or Cloud Run concurrency setting is changed.

## Verification

- exact inventory: 49 console routes, 45 sync and four async
- combined final feature/event-loop suite: 104 passed
- independent relevant review suite: 403 passed
- full exact-head suite: 5014 passed, 299 skipped, 10 expected xfails
- Ruff, mypy, and git diff checks pass
- adverse mutations for sync route dispatch, async storage, durable limiter, and Stripe template rendering each turn their regression red
- independent exact-SHA review approved with no blockers