### PR TITLE
Clarify Confidential Cowork model selection

### DIFF
--- a/src/trusted_router/templates/public/confidential_cowork.html
+++ b/src/trusted_router/templates/public/confidential_cowork.html
@@ -30,11 +30,11 @@
   <div class="marketing-copy">
     <div class="kicker">A product boundary users can see</div>
     <h2 id="boundary-heading">Confidentiality cannot be clicked away</h2>
-    <p>Confidential Cowork removes custom routing controls from the user interface and sends every inference request through <code>trustedrouter/confidential</code> with data collection denied and a minimum privacy tier of confidential.</p>
-    <p>Provider selection stays available only inside that eligible set. Choose the model your work needs without creating an accidental route around policy.</p>
+    <p>Confidential Cowork removes unsafe custom routing controls while keeping a searchable catalog of specific models and providers that meet the Confidential tier. <code>trustedrouter/confidential</code> is the default.</p>
+    <p>Every selection carries data collection denied and a minimum privacy tier of confidential. Choose the approved model your work needs without creating an accidental route around policy.</p>
   </div>
   <div class="cc-policy-ledger" aria-label="Enforced routing policy">
-    <span>Model route</span><strong>trustedrouter/confidential</strong>
+    <span>Default route</span><strong>trustedrouter/confidential</strong>
     <span>Data collection</span><strong>deny</strong>
     <span>Minimum privacy</span><strong>confidential</strong>
     <span>Jurisdiction</span><strong>United States or European Union</strong>

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -228,6 +228,8 @@ def test_confidential_cowork_is_self_serve_and_fail_closed(client: TestClient) -
     assert "Confidential Cowork by TrustedRouter" in response.text
     assert "Confidential-Cowork-macOS-universal.dmg" in response.text
     assert "trustedrouter/confidential" in response.text
+    assert "searchable catalog of specific models and providers" in response.text
+    assert "Default route</span><strong>trustedrouter/confidential" in response.text
     assert "Data collection</span><strong>deny" in response.text
     assert "United States or European Union" in response.text
     assert "No eligible confidential provider means no model request" in response.text


### PR DESCRIPTION
## Summary
- describe the searchable Confidential-tier model and provider catalog
- label trustedrouter/confidential as the default route rather than the only selectable route
- keep fail-closed privacy policy messaging explicit

## Validation
- uv run pytest tests/test_public_revenue_pages.py -q (33 passed)