### PR TITLE
Track Databricks Tier 2 quota requests

### DIFF
--- a/scripts/pricing/providers/databricks.py
+++ b/scripts/pricing/providers/databricks.py
@@ -135,6 +135,25 @@ EXPECTED_MODELS = [str(row["id"]) for row in MODEL_CONFIG.values()]
 UPSTREAM_ID_MAP = {
     str(row["id"]): str(row["upstream_id"]) for row in MODEL_CONFIG.values()
 }
+
+# Submitted to Databricks as Tier 2 account quota requests on 2026-08-19.
+# These values are deliberately metadata-only until Databricks confirms the
+# increase. Treating a submitted request as granted capacity would make the
+# router over-admit traffic and turn predictable fallback into avoidable 429s.
+_TIER_2_RATE_LIMIT_MODEL_IDS = frozenset(
+    {
+        "moonshotai/kimi-k3",
+        "thinkingmachines/inkling",
+        "z-ai/glm-5.2",
+    }
+)
+_TIER_2_RATE_LIMIT_REQUEST = {
+    "tier": 2,
+    "status": "submitted",
+    "submitted_on": "2026-08-19",
+    "input_tokens_per_minute": 1_000_000,
+    "output_tokens_per_minute": 100_000,
+}
 _DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
 _LIVE_CANARY_CHECKED_MODEL_IDS: set[str] = set()
 _LIVE_CANARY_HEALTHY_MODEL_IDS: set[str] = set()
@@ -249,6 +268,8 @@ def _parse_catalog(
         }
         if config.get("max_output_tokens") is not None:
             row["max_output_tokens"] = int(config["max_output_tokens"])
+        if model_id in _TIER_2_RATE_LIMIT_MODEL_IDS:
+            row["account_rate_limit_request"] = dict(_TIER_2_RATE_LIMIT_REQUEST)
         discovered[model_id] = row
     return prices, discovered
 

--- a/src/trusted_router/data/provider_models/databricks.json
+++ b/src/trusted_router/data/provider_models/databricks.json
@@ -131,6 +131,13 @@
         "prompt_caching"
       ],
       "routable": true,
+      "account_rate_limit_request": {
+        "tier": 2,
+        "status": "submitted",
+        "submitted_on": "2026-08-19",
+        "input_tokens_per_minute": 1000000,
+        "output_tokens_per_minute": 100000
+      },
       "input_token_price_per_m": 3000000,
       "output_token_price_per_m": 15000000,
       "cached_input_token_price_per_m": 300000
@@ -264,6 +271,13 @@
         "prompt_caching"
       ],
       "routable": true,
+      "account_rate_limit_request": {
+        "tier": 2,
+        "status": "submitted",
+        "submitted_on": "2026-08-19",
+        "input_tokens_per_minute": 1000000,
+        "output_tokens_per_minute": 100000
+      },
       "input_token_price_per_m": 1000000,
       "output_token_price_per_m": 4050000,
       "cached_input_token_price_per_m": 170000
@@ -292,6 +306,13 @@
         "prompt_caching"
       ],
       "routable": true,
+      "account_rate_limit_request": {
+        "tier": 2,
+        "status": "submitted",
+        "submitted_on": "2026-08-19",
+        "input_tokens_per_minute": 1000000,
+        "output_tokens_per_minute": 100000
+      },
       "input_token_price_per_m": 1400000,
       "output_token_price_per_m": 4400000,
       "cached_input_token_price_per_m": 260000

--- a/tests/test_databricks_provider.py
+++ b/tests/test_databricks_provider.py
@@ -61,6 +61,17 @@ def test_databricks_parser_converts_official_dbu_rates_exactly(
     assert discovered["z-ai/glm-5.2"]["upstream_id"] == "databricks-glm-5-2"
     assert discovered["moonshotai/kimi-k3"]["context_length"] == 1_048_576
     assert discovered["moonshotai/kimi-k3"]["input_modalities"] == ["text", "image"]
+    expected_request = {
+        "tier": 2,
+        "status": "submitted",
+        "submitted_on": "2026-08-19",
+        "input_tokens_per_minute": 1_000_000,
+        "output_tokens_per_minute": 100_000,
+    }
+    assert discovered["moonshotai/kimi-k3"]["account_rate_limit_request"] == expected_request
+    assert discovered["z-ai/glm-5.2"]["account_rate_limit_request"] == expected_request
+    assert discovered["thinkingmachines/inkling"]["account_rate_limit_request"] == expected_request
+    assert "account_rate_limit_request" not in discovered["openai/gpt-oss-120b"]
 
 
 def test_databricks_parser_prunes_route_when_documented_endpoint_disappears() -> None:
@@ -281,6 +292,18 @@ def test_databricks_manifest_activates_only_models_with_passing_canaries(
     for model_id in checked - healthy:
         assert by_id[model_id]["routable"] is False
         assert by_id[model_id]["routable_reason"] == "provider-canary-failed"
+    for model_id in (
+        "moonshotai/kimi-k3",
+        "thinkingmachines/inkling",
+        "z-ai/glm-5.2",
+    ):
+        assert by_id[model_id]["account_rate_limit_request"] == {
+            "tier": 2,
+            "status": "submitted",
+            "submitted_on": "2026-08-19",
+            "input_tokens_per_minute": 1_000_000,
+            "output_tokens_per_minute": 100_000,
+        }
 
 
 def test_databricks_is_prepaid_standard_privacy_and_not_byok() -> None:


### PR DESCRIPTION
Summary: record submitted Tier 2 quota requests for Databricks Kimi K3, GLM 5.2, and Inkling; preserve 1M ITPM / 100K OTPM metadata across hourly provider refreshes; keep the requests metadata-only until Databricks confirms approval. Verification: focused Databricks tests, Ruff, and mypy pass. All three Databricks prepaid endpoints are already present in production.