### PR TITLE
Approve verified DeepSeek and GMI price transitions

### DIFF
--- a/scripts/check_price_spike.py
+++ b/scripts/check_price_spike.py
@@ -37,6 +37,38 @@ DEFAULT_SPIKE_RATIO = 2.0  # 100% increase = ≥2× the previous value
 # route, dimension, old value, or new value still fails closed.
 APPROVED_ENDPOINT_PRICE_TRANSITIONS = frozenset(
     {
+        # DeepSeek's first-party schedule effective 2026-08-16. The public
+        # pricing table is the source of truth for both off-peak baselines:
+        # https://api-docs.deepseek.com/quick_start/pricing/
+        (
+            "deepseek/deepseek-v4-flash [deepseek:deepseek:deepseek-v4-flash]",
+            "completion",
+            Decimal("0.00000028"),
+            Decimal("0.00000066"),
+        ),
+        (
+            "deepseek/deepseek-v4-pro [deepseek:deepseek:deepseek-v4-pro]",
+            "completion",
+            Decimal("0.00000087"),
+            Decimal("0.00000198"),
+        ),
+        # GMI's public billing API changed the V4 Pro discount from roughly
+        # 80% to 60%. Keep this approval pinned to the exact payable values:
+        # https://console.gmicloud.ai/api/v1/billing/model_prices
+        (
+            "deepseek/deepseek-v4-pro "
+            "[gmi:gmicloud/fp8:deepseek-ai/DeepSeek-V4-Pro]",
+            "prompt",
+            Decimal("0.000000347999"),
+            Decimal("0.000000696"),
+        ),
+        (
+            "deepseek/deepseek-v4-pro "
+            "[gmi:gmicloud/fp8:deepseek-ai/DeepSeek-V4-Pro]",
+            "completion",
+            Decimal("0.000000695999"),
+            Decimal("0.000001392"),
+        ),
         (
             "moonshotai/kimi-k3 [tinfoil:tinfoil:kimi-k3]",
             "prompt",

--- a/tests/test_check_price_spike.py
+++ b/tests/test_check_price_spike.py
@@ -236,6 +236,75 @@ def test_confirmed_tinfoil_kimi_k3_price_transition_is_allowed(
     assert "moonshotai/kimi-k3" in capsys.readouterr().out
 
 
+def test_confirmed_deepseek_and_gmi_price_transitions_are_allowed(
+    tmp_path: Path, capsys
+) -> None:
+    from scripts.check_price_spike import main
+
+    before_payload = _make_endpoint_snapshot(
+        ("0.000000347999", "0.000000695999"),
+        [
+            ("deepseek", "deepseek-v4-pro", "0.000000435", "0.00000087"),
+            (
+                "gmi",
+                "deepseek-ai/DeepSeek-V4-Pro",
+                "0.000000347999",
+                "0.000000695999",
+            ),
+        ],
+        model_id="deepseek/deepseek-v4-pro",
+    )
+    before_payload["models"][0]["endpoints"][1]["tag"] = "gmicloud/fp8"
+    before = _write(tmp_path, "before.json", before_payload)
+
+    after_payload = _make_endpoint_snapshot(
+        ("0.00000066", "0.000001392"),
+        [
+            ("deepseek", "deepseek-v4-pro", "0.00000066", "0.00000198"),
+            (
+                "gmi",
+                "deepseek-ai/DeepSeek-V4-Pro",
+                "0.000000696",
+                "0.000001392",
+            ),
+        ],
+        model_id="deepseek/deepseek-v4-pro",
+    )
+    after_payload["models"][0]["endpoints"][1]["tag"] = "gmicloud/fp8"
+    after = _write(tmp_path, "after.json", after_payload)
+
+    assert main([str(before), str(after), "--summary"]) == 0
+    assert "deepseek/deepseek-v4-pro" in capsys.readouterr().out
+
+
+def test_unapproved_deepseek_price_transition_still_blocks(
+    tmp_path: Path, capsys
+) -> None:
+    from scripts.check_price_spike import main
+
+    before = _write(
+        tmp_path,
+        "before.json",
+        _make_endpoint_snapshot(
+            ("0.00000014", "0.00000028"),
+            [("deepseek", "deepseek-v4-flash", "0.00000014", "0.00000028")],
+            model_id="deepseek/deepseek-v4-flash",
+        ),
+    )
+    after = _write(
+        tmp_path,
+        "after.json",
+        _make_endpoint_snapshot(
+            ("0.00000022", "0.00000067"),
+            [("deepseek", "deepseek-v4-flash", "0.00000022", "0.00000067")],
+            model_id="deepseek/deepseek-v4-flash",
+        ),
+    )
+
+    assert main([str(before), str(after), "--summary"]) == 1
+    assert "PRICE SPIKE FAILURES" in capsys.readouterr().out
+
+
 def test_unapproved_tinfoil_kimi_k3_price_transition_still_blocks(
     tmp_path: Path, capsys
 ) -> None:


### PR DESCRIPTION
## Summary
- accept the exact DeepSeek V4 Flash and V4 Pro completion-price transitions published by DeepSeek
- accept the exact GMI V4 Pro prompt and completion transitions from GMI's public billing API
- keep the global 2x spike guard unchanged and endpoint/value scoped
- add positive and fail-closed regression coverage

## Verification
- DeepSeek first-party pricing: https://api-docs.deepseek.com/quick_start/pricing/
- GMI billing feed: https://console.gmicloud.ai/api/v1/billing/model_prices
- `uv run pytest -q tests/test_check_price_spike.py tests/test_deepseek_time_pricing.py`
- `uv run ruff check scripts/check_price_spike.py tests/test_check_price_spike.py`
- `uv run mypy`