### PR TITLE
Add measured Google Ads landing experiments

### DIFF
--- a/docs/marketing/first-party-attribution.md
+++ b/docs/marketing/first-party-attribution.md
@@ -125,12 +125,19 @@ uv run python scripts/marketing_funnel_report.py \
 ```
 
 Use `--format json` for analysis or dashboards. Add `--creative <utm_content>`
-to inspect one creative cell. Revenue remains integer microdollars until the
-final display conversion.
+to inspect one creative cell, or `--landing <path>` to inspect one exact
+destination. Reports retain the landing path as its own dimension and show
+signup, activation, and purchase rates against engaged visitors. Revenue
+remains integer microdollars until the final display conversion.
 
 One `utm_content` value is one measurable creative cell. Multiple headlines
 inside one responsive search ad share that cell, so create separately tagged
 ads when headline-level downstream measurement is required.
+
+For landing-page tests, keep campaign, keywords, bids, ad copy, geography, and
+device settings identical. Change only the destination and use one stable
+`utm_content` value per arm. This prevents a strong headline or a different
+search term from being mistaken for a landing-page improvement.
 
 ## Initial Optimization Policy
 

--- a/docs/marketing/google-landing-page-experiment-2026-08-20.md
+++ b/docs/marketing/google-landing-page-experiment-2026-08-20.md
@@ -1,0 +1,129 @@
+# Google Ads Landing Page Experiment
+
+## Objective
+
+Improve paid-search conversion through the complete first-party funnel:
+
+1. engaged visit
+2. signup
+3. first successful API call
+4. checkout
+5. settled credit purchase
+
+The experiment keeps the existing Google Ads budget. It reallocates traffic
+away from weak hot-model cells and compares two landing experiences under the
+same search intent.
+
+## Production Baseline
+
+The 30-day first-party report on August 20, 2026 shows:
+
+| Segment | Engaged | Signups | Activated | Buyers | Revenue |
+|---|---:|---:|---:|---:|---:|
+| OpenRouter migration | 185 | 23 | 3 | 0 | $0 |
+| OpenAI compatible | 19 | 2 | 1 | 1 | $5 |
+| OpenRouter privacy | 117 | 14 | 1 | 0 | $0 |
+| Kimi K3 | 216 | 6 | 0 | 0 | $0 |
+
+OpenRouter intent creates signup volume. The action-led OpenAI-compatible page
+produces materially better activation and the only observed purchase. Kimi K3
+traffic has high volume and weak downstream intent.
+
+## Experiment 1: OpenRouter Migration
+
+Use a Google Ads custom experiment with a 50/50 traffic split. Keep keywords,
+negative keywords, bids, geography, schedule, devices, and responsive-search-ad
+assets identical.
+
+### Control
+
+```text
+https://trustedrouter.com/openrouter-alternative
+  ?utm_source=google
+  &utm_medium=paid_search
+  &utm_campaign=openrouter_lp_20260820
+  &utm_content=or_lp_proof_v1
+```
+
+### Challenger
+
+```text
+https://trustedrouter.com/openrouter-alternative/quickstart
+  ?utm_source=google
+  &utm_medium=paid_search
+  &utm_campaign=openrouter_lp_20260820
+  &utm_content=or_lp_quickstart_v1
+```
+
+The challenger preserves the OpenRouter promise but puts key creation, working
+SDK code, and the three migration steps in the first screen. It is no-index and
+canonicalized to the permanent OpenRouter page.
+
+## Experiment 2: Private LLM API
+
+Start only after Experiment 1 has enough activation data. Use the same 50/50
+structure for high-intent privacy queries.
+
+### Control
+
+```text
+https://trustedrouter.com/private-llm-api
+  ?utm_source=google
+  &utm_medium=paid_search
+  &utm_campaign=private_lp_20260820
+  &utm_content=privacy_lp_proof_v1
+```
+
+### Challenger
+
+```text
+https://trustedrouter.com/private-llm-api/quickstart
+  ?utm_source=google
+  &utm_medium=paid_search
+  &utm_campaign=private_lp_20260820
+  &utm_content=privacy_lp_quickstart_v1
+```
+
+## Decision Rules
+
+- Primary early metric: activated users per engaged visitor.
+- Diagnostic metric: signups per engaged visitor.
+- Business metric: purchasers and settled revenue per engaged visitor.
+- Guardrail: the challenger must not reduce activation per engaged visitor.
+- Do not optimize toward click-through rate or signup volume alone.
+- Do not name a payment winner from one purchase.
+- Review after each arm has at least 20 activated users or after 30 days,
+  whichever comes first.
+- Pause an arm early only for a severe defect or when its 95% confidence
+  interval excludes a practically useful result.
+
+## Budget Reallocation
+
+- Keep total Google Ads daily spend unchanged for the first experiment.
+- Reduce or pause Kimi K3 acquisition traffic while it remains at zero
+  activations from 216 engaged visitors.
+- Move that budget into the OpenRouter experiment.
+- Keep the existing OpenAI-compatible creative live as a reference cell because
+  it produced the only observed paid conversion.
+
+## Reporting
+
+```bash
+uv run python scripts/marketing_funnel_report.py \
+  --source google \
+  --campaign openrouter_lp_20260820 \
+  --days 30
+```
+
+Inspect one destination directly:
+
+```bash
+uv run python scripts/marketing_funnel_report.py \
+  --source google \
+  --landing /openrouter-alternative/quickstart \
+  --days 30
+```
+
+Google receives no signup, activation, or payment event from TrustedRouter.
+This experiment is evaluated from TrustedRouter's metadata-only first-party
+events. Prompt and output content never enter the report.

--- a/scripts/marketing_funnel_report.py
+++ b/scripts/marketing_funnel_report.py
@@ -33,6 +33,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--source")
     parser.add_argument("--campaign")
     parser.add_argument("--creative")
+    parser.add_argument(
+        "--landing",
+        dest="landing_path",
+        help="Limit the report to one exact landing path, such as /openrouter-alternative.",
+    )
     parser.add_argument("--format", choices=("markdown", "json"), default="markdown")
     return parser.parse_args()
 
@@ -68,6 +73,7 @@ def main() -> int:
         source=args.source,
         campaign=args.campaign,
         creative=args.creative,
+        landing_path=args.landing_path,
     )
     if args.format == "json":
         print(json.dumps([row.as_dict() for row in rows], indent=2, sort_keys=True))

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -1256,6 +1256,22 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
             "Route to Claude, GPT, Gemini, DeepSeek through an attested gateway."
         ),
     ),
+    "openrouter-alternative/quickstart": PublicPage(
+        template="public/experiment_openrouter_quickstart.html",
+        title="Switch from OpenRouter in One Line",
+        description=(
+            "Keep your OpenAI SDK, create a TrustedRouter key, and make the first "
+            "request through a private, hardware-attested gateway."
+        ),
+    ),
+    "private-llm-api/quickstart": PublicPage(
+        template="public/experiment_private_llm_quickstart.html",
+        title="Private LLM API Quickstart",
+        description=(
+            "Make one OpenAI-compatible request through TrustedRouter's "
+            "zero-data-retention route and verify the live gateway."
+        ),
+    ),
     "latest-model-apis": PublicPage(
         template="public/seo_latest_model_apis.html",
         title="Latest AI Model APIs: Kimi K3, GLM 5.2, DeepSeek V4",
@@ -2060,6 +2076,7 @@ def public_page_html(
     page_key: str,
     *,
     site_url: str | None = None,
+    canonical_path: str | None = None,
     robots_meta: str | None = None,
 ) -> str:
     page = PUBLIC_PAGES[page_key]
@@ -2070,6 +2087,11 @@ def public_page_html(
         path=path,
         page_key=page_key,
         site_url=site_url,
+        canonical_url_override=(
+            canonical_public_url(settings, canonical_path)
+            if canonical_path is not None
+            else None
+        ),
         robots_meta=robots_meta,
     )
 
@@ -2247,11 +2269,12 @@ def _render_public_page(
     path: str,
     page_key: str | None = None,
     site_url: str | None = None,
+    canonical_url_override: str | None = None,
     robots_meta: str | None = None,
     extra_context: Mapping[str, object] | None = None,
     extra_json_ld: Sequence[dict[str, object]] = (),
 ) -> str:
-    canonical_url = canonical_public_url(settings, path)
+    canonical_url = canonical_url_override or canonical_public_url(settings, path)
     resolved_site_url = site_url or canonical_url
     catalog_evidence = (
         seo_catalog_evidence(page_key, test_mode=settings.environment == "test")

--- a/src/trusted_router/marketing_funnel.py
+++ b/src/trusted_router/marketing_funnel.py
@@ -47,6 +47,7 @@ class FunnelKey:
     medium: str
     campaign: str
     creative: str
+    landing_path: str
 
 
 @dataclass
@@ -55,6 +56,7 @@ class FunnelRow:
     medium: str
     campaign: str
     creative: str
+    landing_path: str
     engaged_visitors: int = 0
     sign_in_visitors: int = 0
     signups: int = 0
@@ -73,6 +75,7 @@ class FunnelRow:
             "medium": self.medium,
             "campaign": self.campaign,
             "creative": self.creative,
+            "landing_path": self.landing_path,
             "engaged_visitors": self.engaged_visitors,
             "sign_in_visitors": self.sign_in_visitors,
             "signups": self.signups,
@@ -88,12 +91,20 @@ class FunnelRow:
             "sign_in_rate": percentage(self.sign_in_visitors, self.engaged_visitors),
             "signup_rate": percentage(self.signups, self.engaged_visitors),
             "activation_rate": percentage(self.activated_users, self.signups),
+            "activation_per_engaged_rate": percentage(
+                self.activated_users,
+                self.engaged_visitors,
+            ),
             "checkout_rate": percentage(self.checkout_started_users, self.signups),
             "payment_method_rate": percentage(
                 self.payment_method_saved_users,
                 self.signups,
             ),
             "purchase_rate": percentage(self.purchasers, self.signups),
+            "purchase_per_engaged_rate": percentage(
+                self.purchasers,
+                self.engaged_visitors,
+            ),
             "retention_7d_rate": percentage(self.retained_users_7d, self.signups),
         }
 
@@ -108,8 +119,9 @@ def build_axiom_funnel_query(dataset: str) -> str:
         f"| where event in ({event_values}) "
         "| summarize people=dcount(anonymous_fingerprint), "
         "events=count(), revenue_microdollars=sum(amount_microdollars) "
-        "by event, utm_source, utm_medium, utm_campaign, utm_content "
-        "| sort by utm_source asc, utm_campaign asc, utm_content asc, event asc"
+        "by event, utm_source, utm_medium, utm_campaign, utm_content, landing_path "
+        "| sort by utm_source asc, utm_campaign asc, utm_content asc, "
+        "landing_path asc, event asc"
     )
 
 
@@ -134,6 +146,7 @@ def aggregate_funnel_rows(
     source: str | None = None,
     campaign: str | None = None,
     creative: str | None = None,
+    landing_path: str | None = None,
 ) -> list[FunnelRow]:
     rows: dict[FunnelKey, FunnelRow] = {}
     seen_event_rows: set[tuple[FunnelKey, str]] = set()
@@ -147,12 +160,15 @@ def aggregate_funnel_rows(
             medium=_dimension(record.get("utm_medium"), "(none)"),
             campaign=_dimension(record.get("utm_campaign"), "(none)"),
             creative=_dimension(record.get("utm_content"), "(none)"),
+            landing_path=_dimension(record.get("landing_path"), "(unknown)"),
         )
         if source is not None and key.source != source:
             continue
         if campaign is not None and key.campaign != campaign:
             continue
         if creative is not None and key.creative != creative:
+            continue
+        if landing_path is not None and key.landing_path != landing_path:
             continue
         event_key = (key, event)
         if event_key in seen_event_rows:
@@ -165,6 +181,7 @@ def aggregate_funnel_rows(
                 medium=key.medium,
                 campaign=key.campaign,
                 creative=key.creative,
+                landing_path=key.landing_path,
             ),
         )
         people = _nonnegative_int(record.get("people"))
@@ -184,16 +201,17 @@ def aggregate_funnel_rows(
             row.source,
             row.campaign,
             row.creative,
+            row.landing_path,
         ),
     )
 
 
 def render_markdown(rows: Iterable[FunnelRow]) -> str:
     header = (
-        "| Source | Campaign | Creative | Engaged | Sign in | Signups | "
+        "| Source | Campaign | Creative | Landing | Engaged | Sign in | Signups | "
         "Activated | Free used | Checkout | Card saved | Buyers | Revenue | "
-        "Signup / engaged | Activated / signup |\n"
-        "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|"
+        "Signup / engaged | Activated / engaged | Buyers / engaged |\n"
+        "|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|"
     )
     body = [
         "| "
@@ -202,6 +220,7 @@ def render_markdown(rows: Iterable[FunnelRow]) -> str:
                 _markdown_cell(row.source),
                 _markdown_cell(row.campaign),
                 _markdown_cell(row.creative),
+                _markdown_cell(row.landing_path),
                 str(row.engaged_visitors),
                 str(row.sign_in_visitors),
                 str(row.signups),
@@ -212,7 +231,8 @@ def render_markdown(rows: Iterable[FunnelRow]) -> str:
                 str(row.purchasers),
                 f"${microdollars_to_usd(row.revenue_microdollars)}",
                 percentage(row.signups, row.engaged_visitors),
-                percentage(row.activated_users, row.signups),
+                percentage(row.activated_users, row.engaged_visitors),
+                percentage(row.purchasers, row.engaged_visitors),
             )
         )
         + " |"

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -965,6 +965,24 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     async def seo_private_llm_api() -> str:
         return public_page_html(settings, "private-llm-api")
 
+    @public_html_route("/openrouter-alternative/quickstart")
+    async def experiment_openrouter_quickstart() -> str:
+        return public_page_html(
+            settings,
+            "openrouter-alternative/quickstart",
+            canonical_path="/openrouter-alternative",
+            robots_meta="noindex,follow",
+        )
+
+    @public_html_route("/private-llm-api/quickstart")
+    async def experiment_private_llm_quickstart() -> str:
+        return public_page_html(
+            settings,
+            "private-llm-api/quickstart",
+            canonical_path="/private-llm-api",
+            robots_meta="noindex,follow",
+        )
+
     @public_html_route("/hipaa-llm-api")
     async def seo_hipaa_llm_api() -> str:
         return public_page_html(settings, "hipaa-llm-api")

--- a/src/trusted_router/templates/public/experiment_openrouter_quickstart.html
+++ b/src/trusted_router/templates/public/experiment_openrouter_quickstart.html
@@ -1,0 +1,78 @@
+{% extends "public/_base.html" %}
+
+{% block hero %}
+<section class="public-hero marketing-hero" aria-label="OpenRouter migration quickstart">
+  <div>
+    <div class="kicker">OpenRouter migration</div>
+    <h1>Keep your SDK. Switch the base URL.</h1>
+    <p class="lead">Create a key and run your existing OpenAI client through TrustedRouter. The first request takes one changed URL.</p>
+    <div class="hero-actions">
+      <button class="btn primary" type="button" data-action="open-signin">Create my API key</button>
+      <a class="btn" href="/compare/openrouter">Compare the routers <span aria-hidden="true">→</span></a>
+    </div>
+    <p class="microcopy">No card required. Keep your current SDK and request format.</p>
+  </div>
+  <div class="copy-terminal">
+    <div class="code-head"><span>One-line migration</span><button class="code-copy" type="button" data-action="copy-code" data-copy-target="openrouter-migration-call">Copy</button></div>
+    <pre><code id="openrouter-migration-call">import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["TRUSTEDROUTER_API_KEY"],
+    base_url="{{ api_base_url }}",
+)
+
+response = client.chat.completions.create(
+    model="trustedrouter/cheap",
+    messages=[{
+        "role": "user",
+        "content": "Reply PONG",
+    }],
+)
+
+print(response.choices[0].message.content)</code></pre>
+  </div>
+</section>
+{% endblock %}
+
+{% block body %}
+<section class="public-proof-strip" aria-label="Migration facts">
+  <div><strong>One URL</strong><span>Keep the OpenAI client.</span></div>
+  <div><strong>Hundreds</strong><span>Models behind one API.</span></div>
+  <div><strong>5%</strong><span>Prepaid platform fee.</span></div>
+  <div><strong>Always</strong><span>No prompt or output logs.</span></div>
+</section>
+
+<section class="marketing-grid three" aria-label="Three migration steps">
+  <div class="marketing-card"><span class="card-label">Step 1</span><h3>Create one key.</h3><p>Sign in, create an API key, and export it as <code>TRUSTEDROUTER_API_KEY</code>.</p></div>
+  <div class="marketing-card"><span class="card-label">Step 2</span><h3>Change the URL.</h3><p>Point your existing OpenAI client to <code>{{ api_base_url }}</code>.</p></div>
+  <div class="marketing-card"><span class="card-label">Step 3</span><h3>Run the same request.</h3><p>Keep the SDK and message shape. Start with <code>trustedrouter/cheap</code> or your current model ID.</p></div>
+</section>
+
+<section class="marketing-split" aria-label="OpenRouter migration details">
+  <div class="marketing-copy">
+    <span class="eyebrow">What stays familiar</span>
+    <h2>Your application contract.</h2>
+    <ul class="check-list">
+      <li>The OpenAI Python or JavaScript SDK</li>
+      <li>Chat Completions and Responses API request shapes</li>
+      <li>Streaming, fallbacks, provider filters, and model lists</li>
+    </ul>
+  </div>
+  <div class="marketing-copy">
+    <span class="eyebrow">What changes</span>
+    <h2>The prompt path becomes verifiable.</h2>
+    <ul class="check-list">
+      <li>Open-source gateway code linked to the running image</li>
+      <li>Fresh hardware attestation for the live API endpoint</li>
+      <li>No prompt or output content in TrustedRouter logs</li>
+    </ul>
+  </div>
+</section>
+
+<section class="cta-band" aria-label="Create a TrustedRouter key">
+  <div><strong>Make the first request now.</strong><span>Create a key, copy the code, and keep building.</span></div>
+  <div class="cta-band-actions"><button class="btn primary" type="button" data-action="open-signin">Create my API key</button></div>
+  <span class="microcopy">No card required.</span>
+</section>
+{% endblock %}

--- a/src/trusted_router/templates/public/experiment_private_llm_quickstart.html
+++ b/src/trusted_router/templates/public/experiment_private_llm_quickstart.html
@@ -1,0 +1,72 @@
+{% extends "public/_base.html" %}
+
+{% block hero %}
+<section class="public-hero marketing-hero" aria-label="Private LLM API quickstart">
+  <div>
+    <div class="kicker">Private LLM API</div>
+    <h1>Make one private API call in 60 seconds.</h1>
+    <p class="lead">Use the OpenAI client you already know. The <code>trustedrouter/zdr</code> route selects an eligible zero-data-retention provider through the attested gateway.</p>
+    <div class="hero-actions">
+      <button class="btn primary" type="button" data-action="open-signin">Create my API key</button>
+      <a class="btn" href="https://trust.trustedrouter.com">Verify the gateway <span aria-hidden="true">→</span></a>
+    </div>
+    <p class="microcopy">No card required. TrustedRouter never logs or stores prompt or output content.</p>
+  </div>
+  <div class="copy-terminal">
+    <div class="code-head"><span>Private first call</span><button class="code-copy" type="button" data-action="copy-code" data-copy-target="private-first-call">Copy</button></div>
+    <pre><code id="private-first-call">import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["TRUSTEDROUTER_API_KEY"],
+    base_url="{{ api_base_url }}",
+)
+
+response = client.chat.completions.create(
+    model="trustedrouter/zdr",
+    messages=[{
+        "role": "user",
+        "content": "Reply PONG",
+    }],
+)
+
+print(response.choices[0].message.content)</code></pre>
+  </div>
+</section>
+{% endblock %}
+
+{% block body %}
+<section class="public-proof-strip" aria-label="Private API facts">
+  <div><strong>Always</strong><span>No prompt or output logs.</span></div>
+  <div><strong>ZDR</strong><span>Policy-filtered provider routes.</span></div>
+  <div><strong>Fresh</strong><span>Nonce-bound gateway evidence.</span></div>
+  <div><strong>OpenAI</strong><span>Compatible client interface.</span></div>
+</section>
+
+<section class="marketing-grid three" aria-label="Three private API steps">
+  <div class="marketing-card"><span class="card-label">Step 1</span><h3>Create one key.</h3><p>Sign in and export the new key as <code>TRUSTEDROUTER_API_KEY</code>.</p></div>
+  <div class="marketing-card"><span class="card-label">Step 2</span><h3>Choose the ZDR route.</h3><p>Use <code>trustedrouter/zdr</code> to restrict eligible downstream provider routes.</p></div>
+  <div class="marketing-card"><span class="card-label">Step 3</span><h3>Verify live evidence.</h3><p>Challenge the gateway with a fresh nonce and match the running image to the published source.</p></div>
+</section>
+
+<section class="marketing-split" aria-label="Privacy boundaries">
+  <div class="marketing-copy">
+    <span class="eyebrow">Gateway proof</span>
+    <h2>Verify what TrustedRouter runs.</h2>
+    <p>Hardware attestation binds the live gateway to a published workload image. The open-source prompt path contains no durable prompt or output logging.</p>
+    <p><a class="btn" href="/security">Read the security boundary</a></p>
+  </div>
+  <div class="marketing-copy">
+    <span class="eyebrow">Provider policy</span>
+    <h2>Route by downstream posture.</h2>
+    <p>The ZDR alias restricts routing to providers with a documented zero-data-retention posture. Provider policy and gateway attestation remain separate claims.</p>
+    <p><a class="btn" href="/providers">Compare provider policies</a></p>
+  </div>
+</section>
+
+<section class="cta-band" aria-label="Create a private LLM API key">
+  <div><strong>Run the private quickstart.</strong><span>Create a key and make the first ZDR request.</span></div>
+  <div class="cta-band-actions"><button class="btn primary" type="button" data-action="open-signin">Create my API key</button></div>
+  <span class="microcopy">No card required.</span>
+</section>
+{% endblock %}

--- a/tests/test_acquisition_attribution.py
+++ b/tests/test_acquisition_attribution.py
@@ -221,6 +221,23 @@ def test_first_touch_is_preserved_and_last_touch_updates(client: TestClient) -> 
     assert context.last_touch["landing_path"] == "/private-llm-api"
 
 
+def test_paid_experiment_preserves_exact_landing_path(client: TestClient) -> None:
+    response = client.get(
+        "/openrouter-alternative/quickstart"
+        "?utm_source=google&utm_medium=paid_search"
+        "&utm_campaign=openrouter_landing_test&utm_content=or_quickstart_v1"
+        "&gclid=experiment-click-123"
+    )
+
+    assert response.status_code == 200
+    context = decode_attribution_cookie(
+        client.cookies.get(ATTRIBUTION_COOKIE_NAME), client.app.state.settings
+    )
+    assert context is not None
+    assert context.last_touch["landing_path"] == "/openrouter-alternative/quickstart"
+    assert context.last_touch["utm_content"] == "or_quickstart_v1"
+
+
 @pytest.mark.parametrize("header", ["sec-gpc", "dnt"])
 def test_privacy_signals_suppress_attribution_cookie(client: TestClient, header: str) -> None:
     response = client.get(

--- a/tests/test_marketing_funnel_report.py
+++ b/tests/test_marketing_funnel_report.py
@@ -23,6 +23,7 @@ def _record(
     source: str = "google",
     campaign: str = "high_intent",
     creative: str = "privacy_a",
+    landing_path: str = "/openrouter-alternative",
 ) -> dict[str, object]:
     return {
         "event": event,
@@ -33,6 +34,7 @@ def _record(
         "utm_medium": "paid_search",
         "utm_campaign": campaign,
         "utm_content": creative,
+        "landing_path": landing_path,
     }
 
 
@@ -53,6 +55,7 @@ def test_funnel_query_is_metadata_only_and_covers_every_stage() -> None:
         assert event in query
     assert "dcount(anonymous_fingerprint)" in query
     assert "sum(amount_microdollars)" in query
+    assert "landing_path" in query
     for forbidden in (
         "prompt",
         "output",
@@ -106,11 +109,14 @@ def test_aggregate_funnel_rows_pivots_creative_and_preserves_integer_money() -> 
     assert row.purchase_events == 3
     assert row.retained_users_7d == 3
     assert row.revenue_microdollars == 12_345_678
+    assert row.landing_path == "/openrouter-alternative"
     assert row.as_dict()["revenue_usd"] == "12.345678"
     assert row.as_dict()["signup_rate"] == "17.5%"
     assert row.as_dict()["activation_rate"] == "57.1%"
+    assert row.as_dict()["activation_per_engaged_rate"] == "10.0%"
     assert row.as_dict()["checkout_rate"] == "42.9%"
     assert row.as_dict()["payment_method_rate"] == "28.6%"
+    assert row.as_dict()["purchase_per_engaged_rate"] == "5.0%"
 
 
 def test_aggregate_filters_without_placing_user_input_in_apl() -> None:
@@ -122,13 +128,19 @@ def test_aggregate_filters_without_placing_user_input_in_apl() -> None:
             source="x",
             campaign="openrouter_conquest",
             creative="reliability_b",
+            landing_path="/private-llm-api",
         ),
     ]
 
-    rows = aggregate_funnel_rows(records, source="x", creative="reliability_b")
+    rows = aggregate_funnel_rows(
+        records,
+        source="x",
+        creative="reliability_b",
+        landing_path="/private-llm-api",
+    )
 
-    assert [(row.source, row.creative) for row in rows] == [
-        ("x", "reliability_b")
+    assert [(row.source, row.creative, row.landing_path) for row in rows] == [
+        ("x", "reliability_b", "/private-llm-api")
     ]
 
 
@@ -194,6 +206,7 @@ def test_null_dimensions_are_explicit_and_unknown_events_are_ignored() -> None:
     assert rows[0].medium == "(none)"
     assert rows[0].campaign == "(none)"
     assert rows[0].creative == "(none)"
+    assert rows[0].landing_path == "(unknown)"
 
 
 def test_parse_axiom_json_lines_is_strict() -> None:
@@ -225,6 +238,7 @@ def test_report_rendering_escapes_markdown_and_handles_empty_denominators() -> N
     rendered = render_markdown([row])
 
     assert "campaign\\|unsafe" in rendered
+    assert "/openrouter-alternative" in rendered
     assert "n/a" in rendered
     assert percentage(1, 3) == "33.3%"
     assert microdollars_to_usd(1) == "0.000001"

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -171,6 +171,44 @@ def test_api_reference_declares_one_query_independent_canonical(
         assert f'href="{path}"' in response.text
 
 
+@pytest.mark.parametrize(
+    ("path", "canonical", "expected_copy"),
+    (
+        (
+            "/openrouter-alternative/quickstart",
+            "/openrouter-alternative",
+            "Keep your SDK. Switch the base URL.",
+        ),
+        (
+            "/private-llm-api/quickstart",
+            "/private-llm-api",
+            "Make one private API call in 60 seconds.",
+        ),
+    ),
+)
+def test_paid_landing_experiments_are_noindex_and_canonical(
+    client: TestClient,
+    path: str,
+    canonical: str,
+    expected_copy: str,
+) -> None:
+    response = client.get(f"{path}?utm_source=google&utm_content=landing_test")
+
+    assert response.status_code == 200
+    assert expected_copy in response.text
+    assert '<meta name="robots" content="noindex,follow">' in response.text
+    assert response.text.count('rel="canonical"') == 1
+    assert (
+        f'<link rel="canonical" href="https://trustedrouter.com{canonical}">'
+        in response.text
+    )
+    assert 'data-action="open-signin"' in response.text
+
+    sitemap = client.get("/sitemap.xml")
+    assert sitemap.status_code == 200
+    assert f"https://trustedrouter.com{path}" not in sitemap.text
+
+
 def test_public_footer_links_to_canonical_trust_page(client: TestClient) -> None:
     response = client.get("/")
 


### PR DESCRIPTION
Summary:
- Report the first-party acquisition funnel by exact landing path through signup, activation, and settled purchase.
- Add controlled, no-index quickstart challengers for OpenRouter migration and private LLM search intent.
- Document 50/50 experiment cells, decision rules, and budget reallocation based on the current 30-day baseline.

Verification:
- 114 focused tests passed.
- Ruff and mypy passed.
- Production Axiom query grouped and filtered by landing path.
- Both first screens and the signup modal were verified in a local browser.