### PR TITLE
Mirror email feedback into SES suppression

### DIFF
--- a/docs/runbooks/ses-reputation.md
+++ b/docs/runbooks/ses-reputation.md
@@ -35,6 +35,9 @@ addresses and message content must never be added to logs or metric tags.
    enabled.
 3. Do not delete a suppression entry unless the recipient has independently
    confirmed control of the address and requested another send.
+   Permanent bounces and complaints are written to both Spanner and the SES
+   account-wide suppression list before the SNS notification is acknowledged.
+   A failed SES mirror write returns 503 so SNS retries it.
 4. Group `email_send.accepted` and `ses_feedback.received` by mail class and
    acquisition source in Axiom. Correlate on `ses_message_id` and count unique
    message IDs or feedback IDs, not raw webhook deliveries: SNS retries are

--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -440,7 +440,7 @@ def _make_api_router(settings: Settings) -> APIRouter:
     register_identity_verify_routes(router)
     register_notify_routes(router)
     register_wallet_oauth_routes(router)
-    register_ses_notification_routes(router)
+    register_ses_notification_routes(router, settings)
     register_internal_routes(router)
     return router
 

--- a/src/trusted_router/routes/ses_notifications.py
+++ b/src/trusted_router/routes/ses_notifications.py
@@ -29,7 +29,12 @@ import httpx
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
+from trusted_router.config import Settings
 from trusted_router.errors import api_error
+from trusted_router.services.ses_suppression import (
+    SesSuppressionService,
+    SesSuppressionSyncError,
+)
 from trusted_router.sns_verify import SnsVerificationError, verify_sns_message
 from trusted_router.storage import STORE
 from trusted_router.types import ErrorType
@@ -37,7 +42,9 @@ from trusted_router.types import ErrorType
 log = logging.getLogger(__name__)
 
 
-def register_ses_notification_routes(router: APIRouter) -> None:
+def register_ses_notification_routes(router: APIRouter, settings: Settings) -> None:
+    account_suppression = SesSuppressionService(settings)
+
     @router.post("/internal/ses/notifications")
     async def ses_notification(request: Request) -> JSONResponse:
         raw = await request.body()
@@ -103,7 +110,20 @@ def register_ses_notification_routes(router: APIRouter) -> None:
         # SNS message retryable. The message-id claim only controls reporting:
         # suppression writes are idempotent, while duplicate SNS deliveries
         # must not inflate bounce/complaint counts.
-        blocked_count = _apply_feedback(kind, feedback, emit_log=False)
+        try:
+            blocked_count = _apply_feedback(
+                kind,
+                feedback,
+                account_suppression,
+                emit_log=False,
+            )
+        except SesSuppressionSyncError as exc:
+            log.error("ses_notification.account_suppression_sync_failed")
+            raise api_error(
+                503,
+                "SES suppression synchronization failed",
+                ErrorType.INTERNAL_ERROR,
+            ) from exc
         replayed = bool(message_id and not STORE.record_sns_message_once(message_id))
         if replayed:
             blocked_count = 0
@@ -123,6 +143,7 @@ def register_ses_notification_routes(router: APIRouter) -> None:
 def _apply_feedback(
     kind: str,
     feedback: dict[str, Any],
+    account_suppression: SesSuppressionService,
     *,
     emit_log: bool = True,
 ) -> int:
@@ -158,6 +179,7 @@ def _apply_feedback(
                         feedback_id=str(feedback_id) if feedback_id else None,
                         **tags,
                     )
+                    account_suppression.suppress(email, "BOUNCE")
                     blocked_count += 1
     elif kind in {"Complaint", "complaint"}:
         raw_complaint = feedback.get("complaint")
@@ -174,6 +196,7 @@ def _apply_feedback(
                     feedback_id=str(feedback_id) if feedback_id else None,
                     **tags,
                 )
+                account_suppression.suppress(email, "COMPLAINT")
                 blocked_count += 1
     if emit_log:
         _log_feedback(kind, feedback, blocked_count)

--- a/src/trusted_router/services/ses_suppression.py
+++ b/src/trusted_router/services/ses_suppression.py
@@ -1,0 +1,46 @@
+"""Mirror permanent SES feedback into the account-wide suppression list."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from trusted_router.config import Settings
+
+SuppressionReason = Literal["BOUNCE", "COMPLAINT"]
+
+
+class SesSuppressionSyncError(RuntimeError):
+    """Raised when an SES account suppression write cannot be completed."""
+
+
+class SesSuppressionService:
+    """Lazily writes durable account-wide SES suppression entries."""
+
+    def __init__(self, settings: Settings) -> None:
+        self._settings = settings
+        self._client: Any | None = None
+
+    def suppress(self, email: str, reason: SuppressionReason) -> None:
+        client = self._get_client()
+        if client is None:
+            return
+        try:
+            client.put_suppressed_destination(EmailAddress=email, Reason=reason)
+        except Exception:
+            # Do not include the recipient or the provider exception. SNS will
+            # retry the privacy-safe webhook after the route returns a 503.
+            raise SesSuppressionSyncError("SES account suppression write failed") from None
+
+    def _get_client(self) -> Any | None:
+        if not self._settings.aws_access_key_id or not self._settings.aws_secret_access_key:
+            return None
+        if self._client is None:
+            import boto3
+
+            self._client = boto3.client(
+                "sesv2",
+                region_name=self._settings.aws_region,
+                aws_access_key_id=self._settings.aws_access_key_id,
+                aws_secret_access_key=self._settings.aws_secret_access_key,
+            )
+        return self._client

--- a/tests/test_cloud_sdk_boundary.py
+++ b/tests/test_cloud_sdk_boundary.py
@@ -57,6 +57,9 @@ ALLOWED = {
     # boto3 talks to Amazon SES to send transactional mail. SES is reachable
     # from any cloud; this is a vendor choice, not a deployment coupling.
     "services/email.py",
+    # SES account suppression is the matching vendor-side feedback adapter.
+    # It keeps hard bounces and complaints blocked across every sender.
+    "services/ses_suppression.py",
 }
 
 CLOUD_SDK_ROOTS = {"google", "boto3", "botocore", "azure"}

--- a/tests/test_ses_notifications.py
+++ b/tests/test_ses_notifications.py
@@ -24,6 +24,10 @@ from fastapi.testclient import TestClient
 
 from trusted_router.config import Settings
 from trusted_router.services.email import EmailMessage, EmailService, build_verification_email
+from trusted_router.services.ses_suppression import (
+    SesSuppressionService,
+    SesSuppressionSyncError,
+)
 from trusted_router.sns_verify import SnsVerificationError, verify_sns_message
 from trusted_router.storage import STORE
 
@@ -82,7 +86,10 @@ def verified_client() -> TestClient:
 
 def test_permanent_bounce_blocks_email(verified_client: TestClient) -> None:
     envelope = _envelope(MessageId="msg-bounce-1", Message=_bounce_message(["bounce@example.com"]))
-    with patch("trusted_router.routes.ses_notifications.verify_sns_message"):
+    with (
+        patch("trusted_router.routes.ses_notifications.verify_sns_message"),
+        patch("trusted_router.routes.ses_notifications.SesSuppressionService.suppress") as suppress,
+    ):
         resp = verified_client.post(
             "/internal/ses/notifications",
             json=envelope,
@@ -95,6 +102,7 @@ def test_permanent_bounce_blocks_email(verified_client: TestClient) -> None:
     assert block is not None
     assert block.reason == "bounce"
     assert block.bounce_type == "Permanent"
+    suppress.assert_called_once_with("bounce@example.com", "BOUNCE")
 
 
 def test_transient_bounce_does_not_block(verified_client: TestClient) -> None:
@@ -102,19 +110,101 @@ def test_transient_bounce_does_not_block(verified_client: TestClient) -> None:
         MessageId="msg-bounce-2",
         Message=_bounce_message(["soft@example.com"], bounce_type="Transient"),
     )
-    with patch("trusted_router.routes.ses_notifications.verify_sns_message"):
+    with (
+        patch("trusted_router.routes.ses_notifications.verify_sns_message"),
+        patch("trusted_router.routes.ses_notifications.SesSuppressionService.suppress") as suppress,
+    ):
         verified_client.post("/internal/ses/notifications", json=envelope)
     assert not STORE.is_email_blocked("soft@example.com")
+    suppress.assert_not_called()
 
 
 def test_complaint_blocks_email(verified_client: TestClient) -> None:
     envelope = _envelope(MessageId="msg-complaint-1", Message=_complaint_message(["mad@example.com"]))
-    with patch("trusted_router.routes.ses_notifications.verify_sns_message"):
+    with (
+        patch("trusted_router.routes.ses_notifications.verify_sns_message"),
+        patch("trusted_router.routes.ses_notifications.SesSuppressionService.suppress") as suppress,
+    ):
         resp = verified_client.post("/internal/ses/notifications", json=envelope)
     assert resp.status_code == 200
     assert resp.json()["data"]["blocked_count"] == 1
     block = STORE.get_email_block("mad@example.com")
     assert block is not None and block.reason == "complaint"
+    suppress.assert_called_once_with("mad@example.com", "COMPLAINT")
+
+
+def test_suppression_sync_failure_keeps_sns_notification_retryable(
+    verified_client: TestClient,
+) -> None:
+    envelope = _envelope(
+        MessageId="msg-sync-failure",
+        Message=_bounce_message(["retry@example.com"]),
+    )
+    with (
+        patch("trusted_router.routes.ses_notifications.verify_sns_message"),
+        patch(
+            "trusted_router.routes.ses_notifications.SesSuppressionService.suppress",
+            side_effect=SesSuppressionSyncError("sanitized"),
+        ),
+    ):
+        response = verified_client.post("/internal/ses/notifications", json=envelope)
+
+    assert response.status_code == 503
+    assert STORE.is_email_blocked("retry@example.com")
+    assert STORE.record_sns_message_once("msg-sync-failure") is True
+    assert "retry@example.com" not in response.text
+
+
+def test_account_suppression_service_writes_with_configured_region(monkeypatch) -> None:
+    calls: list[dict[str, str]] = []
+
+    class FakeSesV2Client:
+        def put_suppressed_destination(self, **kwargs: str) -> None:
+            calls.append(kwargs)
+
+    def fake_client(service: str, **kwargs: str) -> FakeSesV2Client:
+        assert service == "sesv2"
+        assert kwargs == {
+            "region_name": "us-west-2",
+            "aws_access_key_id": "AKIA_TEST",
+            "aws_secret_access_key": "secret",
+        }
+        return FakeSesV2Client()
+
+    monkeypatch.setattr("boto3.client", fake_client)
+    service = SesSuppressionService(
+        Settings(
+            environment="test",
+            aws_access_key_id="AKIA_TEST",
+            aws_secret_access_key="secret",  # noqa: S106 - test fixture secret.
+            aws_region="us-west-2",
+        )
+    )
+
+    service.suppress("blocked@example.com", "BOUNCE")
+
+    assert calls == [{"EmailAddress": "blocked@example.com", "Reason": "BOUNCE"}]
+
+
+def test_account_suppression_service_sanitizes_provider_errors(monkeypatch) -> None:
+    class FakeSesV2Client:
+        def put_suppressed_destination(self, **_kwargs: str) -> None:
+            raise RuntimeError("provider leaked private@example.com")
+
+    monkeypatch.setattr("boto3.client", lambda *_args, **_kwargs: FakeSesV2Client())
+    service = SesSuppressionService(
+        Settings(
+            environment="test",
+            aws_access_key_id="AKIA_TEST",
+            aws_secret_access_key="secret",  # noqa: S106 - test fixture secret.
+        )
+    )
+
+    with pytest.raises(SesSuppressionSyncError) as exc_info:
+        service.suppress("private@example.com", "COMPLAINT")
+
+    assert str(exc_info.value) == "SES account suppression write failed"
+    assert exc_info.value.__cause__ is None
 
 
 def test_replayed_message_id_is_idempotent(


### PR DESCRIPTION
## Summary
- mirror permanent bounces and complaints into the SES account-wide suppression list
- return a retryable 503 when the SES mirror write fails, without exposing recipient data
- cover permanent, transient, complaint, retry, privacy, and vendor adapter behavior

## Verification
- uv run ruff check .
- uv run mypy
- uv run pytest -q tests/test_ses_notifications.py tests/test_cloud_sdk_boundary.py
- full suite before the final fixes: 5,018 passed; all three identified failures were fixed and rerun locally