### PR TITLE
Enforce a nonce-based CSP, plus the three headers that were missing

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -74,6 +74,7 @@ from trusted_router.content.legal import (
 from trusted_router.content_handling import CONTENT_HANDLING_CLAIM
 from trusted_router.domains import canonical_public_url
 from trusted_router.measured import measured_for_model, measured_for_provider
+from trusted_router.middleware import current_csp_nonce
 from trusted_router.model_regions import MODEL_REGION_SLUGS, model_region_evidence
 from trusted_router.money import MICRODOLLARS_PER_DOLLAR, format_money_precise
 from trusted_router.og import OG_DESCRIPTION, OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH, OG_TITLE
@@ -1756,6 +1757,9 @@ def _env() -> Environment:
     env.filters["seo_meta_description"] = seo_meta_description
     env.globals["provider_logo_url"] = provider_logo_url
     env.globals["content_handling_claim"] = CONTENT_HANDLING_CLAIM
+    # Callable, not a value: this env is lru_cached and shared across
+    # requests, so it must read the per-request ContextVar at render time.
+    env.globals["csp_nonce"] = current_csp_nonce
     return env
 
 

--- a/src/trusted_router/middleware.py
+++ b/src/trusted_router/middleware.py
@@ -24,10 +24,12 @@ it could be reused by other ASGI services in the same project.
 from __future__ import annotations
 
 import logging
+import secrets
 import threading
 import time
 import uuid
 from collections.abc import Awaitable, Callable
+from contextvars import ContextVar
 from hashlib import sha256
 from urllib.parse import parse_qs, urlsplit
 
@@ -294,7 +296,12 @@ def register_http_middleware(app: FastAPI, settings: Settings) -> None:
         `docs`...) inherit the guarantee. Set conservatively — no
         `preload` directive yet because submitting to the Chrome
         preload list is a one-way commitment."""
-        response = await call_next(request)
+        nonce = secrets.token_urlsafe(16)
+        token = _CSP_NONCE.set(nonce)
+        try:
+            response = await call_next(request)
+        finally:
+            _CSP_NONCE.reset(token)
         response.headers.setdefault(
             "strict-transport-security",
             "max-age=63072000; includeSubDomains",
@@ -319,10 +326,27 @@ def register_http_middleware(app: FastAPI, settings: Settings) -> None:
             # they appear in the browser console and nowhere else. That is a
             # deliberate first step, not a monitoring claim -- see the PR.
             response.headers.setdefault(
-                "content-security-policy-report-only",
-                CONTENT_SECURITY_POLICY_REPORT_ONLY,
+                "content-security-policy",
+                content_security_policy(nonce),
             )
         return response
+
+
+#: Per-request CSP nonce. A ContextVar rather than a template global because
+#: both Jinja environments are ``lru_cache``d and therefore shared across
+#: requests -- a nonce stored on the env would be reused, which is exactly as
+#: good as no nonce at all.
+_CSP_NONCE: ContextVar[str] = ContextVar("csp_nonce", default="")
+
+
+def current_csp_nonce() -> str:
+    """The nonce for the request being rendered, or "" outside a request.
+
+    Registered as the ``csp_nonce`` template global. Empty outside a request
+    so template rendering in tests and scripts does not explode; an empty
+    nonce attribute simply fails the policy rather than silently passing it.
+    """
+    return _CSP_NONCE.get()
 
 
 #: The policy the site would have to satisfy before CSP can be enforced.
@@ -330,22 +354,45 @@ def register_http_middleware(app: FastAPI, settings: Settings) -> None:
 #: couple of scripts, the trust and status subdomains, GitHub links), not from
 #: a generic template -- a policy nobody measured is one that gets switched to
 #: report-only forever.
-CONTENT_SECURITY_POLICY_REPORT_ONLY = "; ".join(
-    (
-        "default-src 'self'",
-        "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
-        "style-src 'self' 'unsafe-inline'",
-        "img-src 'self' data: https:",
-        "font-src 'self' data: https://cdn.jsdelivr.net",
-        "connect-src 'self' https://api.trustedrouter.com https://trust.trustedrouter.com "
-        "https://status.trustedrouter.com",
-        "frame-src 'self'",
-        "frame-ancestors 'self'",
-        "base-uri 'self'",
-        "form-action 'self'",
-        "object-src 'none'",
-    )
+#: Script origins the templates actually load today: our own static files,
+#: four jsdelivr libraries, and Adyen's checkout SDK on the credits page.
+CSP_SCRIPT_ORIGINS = (
+    "https://cdn.jsdelivr.net",
+    "https://checkoutshopper-live.cdn.adyen.com",
+    "https://checkoutshopper-test.cdn.adyen.com",
 )
+
+
+def content_security_policy(nonce: str) -> str:
+    """Build the policy for one request.
+
+    ``script-src`` carries a nonce, which makes browsers IGNORE any
+    ``'unsafe-inline'`` there -- that is the whole point, and why every inline
+    <script> in the templates now carries ``nonce="{{ csp_nonce() }}"``.
+
+    ``style-src`` keeps ``'unsafe-inline'`` and is not a mistake: a nonce
+    cannot authorise an inline ``style="..."`` ATTRIBUTE, only a <style>
+    block, and 27 templates use style attributes. Removing them is a real
+    change with no security payoff next to script-src, so it is not bundled
+    here. Said plainly rather than left looking like an oversight.
+    """
+    return "; ".join(
+        (
+            "default-src 'self'",
+            f"script-src 'self' 'nonce-{nonce}' " + " ".join(CSP_SCRIPT_ORIGINS),
+            "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
+            "img-src 'self' data: https:",
+            "font-src 'self' data: https://cdn.jsdelivr.net",
+            "connect-src 'self' https://api.trustedrouter.com "
+            "https://trust.trustedrouter.com https://status.trustedrouter.com",
+            "frame-src 'self' https://checkoutshopper-live.cdn.adyen.com "
+            "https://checkoutshopper-test.cdn.adyen.com",
+            "frame-ancestors 'self'",
+            "base-uri 'self'",
+            "form-action 'self'",
+            "object-src 'none'",
+        )
+    )
 
 
 def _status_host_path(path: str) -> bool:

--- a/src/trusted_router/middleware.py
+++ b/src/trusted_router/middleware.py
@@ -299,7 +299,53 @@ def register_http_middleware(app: FastAPI, settings: Settings) -> None:
             "strict-transport-security",
             "max-age=63072000; includeSubDomains",
         )
+        # Cheap, universal, and safe on every response including JSON.
+        response.headers.setdefault("x-content-type-options", "nosniff")
+        response.headers.setdefault("referrer-policy", "strict-origin-when-cross-origin")
+        # SAMEORIGIN, not DENY: /choose embeds /static/choose-app.html in a
+        # same-origin iframe, and DENY would blank it. SAMEORIGIN still blocks
+        # the clickjacking case, which is a THIRD party framing a page where
+        # somebody is creating an API key.
+        response.headers.setdefault("x-frame-options", "SAMEORIGIN")
+        if response.headers.get("content-type", "").startswith("text/html"):
+            # REPORT-ONLY on purpose. 14 templates carry inline <script> and 27
+            # carry inline style=, so an enforcing policy would have to ship
+            # with 'unsafe-inline' (which buys almost nothing) or with nonces
+            # threaded through every template (which is the real fix and a
+            # separate change). Report-only breaks nothing while the violation
+            # list is gathered.
+            #
+            # It has NO report-uri, so nothing collects these automatically:
+            # they appear in the browser console and nowhere else. That is a
+            # deliberate first step, not a monitoring claim -- see the PR.
+            response.headers.setdefault(
+                "content-security-policy-report-only",
+                CONTENT_SECURITY_POLICY_REPORT_ONLY,
+            )
         return response
+
+
+#: The policy the site would have to satisfy before CSP can be enforced.
+#: Derived from what the templates actually reference today (jsdelivr for a
+#: couple of scripts, the trust and status subdomains, GitHub links), not from
+#: a generic template -- a policy nobody measured is one that gets switched to
+#: report-only forever.
+CONTENT_SECURITY_POLICY_REPORT_ONLY = "; ".join(
+    (
+        "default-src 'self'",
+        "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
+        "style-src 'self' 'unsafe-inline'",
+        "img-src 'self' data: https:",
+        "font-src 'self' data: https://cdn.jsdelivr.net",
+        "connect-src 'self' https://api.trustedrouter.com https://trust.trustedrouter.com "
+        "https://status.trustedrouter.com",
+        "frame-src 'self'",
+        "frame-ancestors 'self'",
+        "base-uri 'self'",
+        "form-action 'self'",
+        "object-src 'none'",
+    )
+)
 
 
 def _status_host_path(path: str) -> bool:

--- a/src/trusted_router/templates/auth/_base.html
+++ b/src/trusted_router/templates/auth/_base.html
@@ -9,7 +9,7 @@
      flash-of-light). Dark is the default here too; these bare auth steps
      have no toggle of their own — they inherit whatever the user picked
      in the marketing chrome / console. #}
-  <script>
+  <script nonce="{{ csp_nonce() }}">
     (function () {
       try {
         if (localStorage.getItem("tr-theme") === "light") {

--- a/src/trusted_router/templates/console/_layout.html
+++ b/src/trusted_router/templates/console/_layout.html
@@ -10,7 +10,7 @@
      doesn't flash light. Dark is the default; only a stored "light"
      preference adds the attribute. See public/_base.html for the matching
      marketing-chrome script + the toggle that writes localStorage. #}
-  <script>
+  <script nonce="{{ csp_nonce() }}">
     (function () {
       try {
         if (localStorage.getItem("tr-theme") === "light") {

--- a/src/trusted_router/templates/console/activity.html
+++ b/src/trusted_router/templates/console/activity.html
@@ -1,6 +1,6 @@
 {% extends "console/_layout.html" %}
 {% block scripts %}
-<script>
+<script nonce="{{ csp_nonce() }}">
 (function () {
   "use strict";
 
@@ -441,7 +441,7 @@
   }
 })();
 </script>
-<script>
+<script nonce="{{ csp_nonce() }}">
 (function () {
   "use strict";
 

--- a/src/trusted_router/templates/console/adyen_checkout.html
+++ b/src/trusted_router/templates/console/adyen_checkout.html
@@ -4,8 +4,8 @@
 {% endblock %}
 {% block scripts %}
 <script src="{{ adyen_js_url }}" integrity="{{ adyen_js_sri }}" crossorigin="anonymous"></script>
-<script id="adyen-checkout-config" type="application/json">{{ checkout_config | tojson }}</script>
-<script>
+<script id="adyen-checkout-config" type="application/json" nonce="{{ csp_nonce() }}">{{ checkout_config | tojson }}</script>
+<script nonce="{{ csp_nonce() }}">
   document.addEventListener("DOMContentLoaded", async function () {
     const status = document.getElementById("adyen-checkout-status");
     const root = document.getElementById("adyen-dropin");

--- a/src/trusted_router/templates/console/user_models.html
+++ b/src/trusted_router/templates/console/user_models.html
@@ -125,7 +125,7 @@
     {% else %}<p class="empty">No user-provided models yet.</p>{% endif %}
   </div>
 </section>
-<script>
+<script nonce="{{ csp_nonce() }}">
   (function () {
     const CAPS = {
       machine: {{ price_cap_for_kind["machine"] }},

--- a/src/trusted_router/templates/dashboard.html
+++ b/src/trusted_router/templates/dashboard.html
@@ -5,7 +5,7 @@
   {% set meta_description = og_description|seo_meta_description %}
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <script>
+  <script nonce="{{ csp_nonce() }}">
     (function () {
       try {
         if (localStorage.getItem("tr-theme") === "light") {
@@ -39,7 +39,7 @@
   <link rel="preload" href="/static/fonts/spectral-300-latin.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/static/dashboard.css?v={{ static_version|default('local') }}">
   <link rel="stylesheet" href="/static/charter.css?v={{ static_version|default('local') }}">
-  <script>window.__TR__ = {{ tr_config | safe }};</script>
+  <script nonce="{{ csp_nonce() }}">window.__TR__ = {{ tr_config | safe }};</script>
   <script src="/static/dashboard.js?v={{ static_version|default('local') }}" defer></script>
 </head>
 <body>

--- a/src/trusted_router/templates/public/_base.html
+++ b/src/trusted_router/templates/public/_base.html
@@ -5,7 +5,7 @@
   {% set meta_description = description|seo_meta_description %}
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <script>
+  <script nonce="{{ csp_nonce() }}">
     (function () {
       try {
         if (localStorage.getItem("tr-theme") === "light") {
@@ -42,7 +42,7 @@
   <link rel="stylesheet" href="/static/dashboard.css?v={{ static_version|default('local') }}">
   <link rel="stylesheet" href="/static/charter.css?v={{ static_version|default('local') }}">
   {% block head_extra %}{% endblock %}
-  {% if json_ld_blob %}<script type="application/ld+json">{{ json_ld_blob|safe }}</script>{% endif %}
+  {% if json_ld_blob %}<script type="application/ld+json" nonce="{{ csp_nonce() }}">{{ json_ld_blob|safe }}</script>{% endif %}
 </head>
 <body>
   {% include "public/_nav.html" %}
@@ -83,7 +83,7 @@
   </main>
   {% include "public/_footer.html" %}
   {% include "public/_signin.html" %}
-  <script>window.__TR__ = {"apiBaseUrl": "{{ api_base_url }}"};</script>
+  <script nonce="{{ csp_nonce() }}">window.__TR__ = {"apiBaseUrl": "{{ api_base_url }}"};</script>
   <script src="/static/dashboard.js?v={{ static_version|default('local') }}"></script>
   {% block body_scripts %}{% endblock %}
 </body>

--- a/src/trusted_router/templates/public/blog_index.html
+++ b/src/trusted_router/templates/public/blog_index.html
@@ -4,7 +4,7 @@
 {% block hero %}{% endblock %}
 
 {% block body %}
-<style>
+<style nonce="{{ csp_nonce() }}">
   .blog-index { max-width: 980px; margin: 0 auto; padding: 6px 4px 56px; }
   .blog-index-head h1 { font-size: 40px; line-height: 1.12; letter-spacing: 0;
     margin: 4px 0 10px; max-width: none; color: var(--inkstrong); }

--- a/src/trusted_router/templates/public/blog_post.html
+++ b/src/trusted_router/templates/public/blog_post.html
@@ -5,7 +5,7 @@
 {% block hero %}{% endblock %}
 
 {% block body %}
-<style>
+<style nonce="{{ csp_nonce() }}">
   /* Medium-style reading column: narrow measure, serif body, generous
      line-height. Scoped to .blog-article so no other page is affected.
      Colors use the theme vars so dark (default) and light both work. */

--- a/src/trusted_router/templates/public/chat.html
+++ b/src/trusted_router/templates/public/chat.html
@@ -152,7 +152,7 @@
 
 {# Inline config so chat.js doesn't need a second roundtrip just to
    know which API base URL to call. Mirrors the dashboard.js pattern. #}
-<script>
+<script nonce="{{ csp_nonce() }}">
   window.__TR_CHAT__ = {
     apiBaseUrl: {{ api_base_url|tojson }},
     issueKeyPath: "/internal/chat/issue-browser-key",
@@ -165,7 +165,7 @@
 </script>
 {# Markdown + code highlighting + XSS sanitization loaded from CDN.
    marked turns the assistant's content into HTML; highlight.js paints
-   code blocks; DOMPurify strips any <script> a model might emit
+   code blocks; DOMPurify strips any <script nonce="{{ csp_nonce() }}"> a model might emit
    before insertion. chunk 4 may vendor these locally for offline +
    subresource-integrity guarantees. #}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlight.js@11/styles/github-dark.min.css">

--- a/src/trusted_router/templates/public/choose.html
+++ b/src/trusted_router/templates/public/choose.html
@@ -44,13 +44,13 @@ Estimate cost and speed before making billable calls.</code></pre>
           loading="eager"
           referrerpolicy="same-origin"></iframe>
 </section>
-<style>
+<style nonce="{{ csp_nonce() }}">
   .choose-embed{margin:6px 0 30px;border-radius:var(--r-panel);overflow:hidden;
     border:1px solid var(--border-default);background:var(--surface-card)}
   #tr-choose-frame{width:100%;border:0;display:block;min-height:1480px;background:var(--surface-card)}
   @media(max-width:980px){ #tr-choose-frame{min-height:2200px} }
 </style>
-<script>
+<script nonce="{{ csp_nonce() }}">
   /* Same-origin iframe: size it to its content. Prefer the height the app
      postMessages; fall back to reading the document directly. */
   (function(){

--- a/src/trusted_router/templates/public/fusion_playground.html
+++ b/src/trusted_router/templates/public/fusion_playground.html
@@ -123,7 +123,7 @@
   </main>
 </section>
 
-<script>
+<script nonce="{{ csp_nonce() }}">
   window.__TR_FUSION__ = {
     apiBaseUrl: "{{ api_base_url }}",
     issueKeyPath: "/internal/chat/issue-browser-key",

--- a/src/trusted_router/templates/public/support.html
+++ b/src/trusted_router/templates/public/support.html
@@ -90,7 +90,7 @@
   </div>
 </section>
 
-<style>
+<style nonce="{{ csp_nonce() }}">
   .support-layout {
     display: grid;
     grid-template-columns: minmax(0, 1.65fr) minmax(260px, .75fr);
@@ -170,7 +170,7 @@
 {% endblock %}
 
 {% block body_scripts %}
-<script>
+<script nonce="{{ csp_nonce() }}">
   (function () {
     var form = document.getElementById("support-inquiry");
     if (!form) return;

--- a/src/trusted_router/templates/public/trustedos.html
+++ b/src/trusted_router/templates/public/trustedos.html
@@ -183,7 +183,7 @@ curl -s "{{ api_base_url|replace('/v1', '') }}/attestation?nonce=$NONCE" \
   </div>
 </section>
 
-<style>
+<style nonce="{{ csp_nonce() }}">
   .inquiry-form { margin-top: 4px; }
   .inquiry-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 14px; }
   .inquiry-grid label { display: flex; flex-direction: column; gap: 6px; font-size: 13px; font-weight: 650; color: var(--muted); }
@@ -200,7 +200,7 @@ curl -s "{{ api_base_url|replace('/v1', '') }}/attestation?nonce=$NONCE" \
   .inquiry-status[data-tone="err"] { color: var(--bad, #ff6b6b); }
   @media (max-width: 640px) { .inquiry-grid { grid-template-columns: 1fr; } }
 </style>
-<script>
+<script nonce="{{ csp_nonce() }}">
   (function () {
     var form = document.getElementById("trustedos-inquiry");
     if (!form) return;

--- a/src/trusted_router/views.py
+++ b/src/trusted_router/views.py
@@ -16,6 +16,7 @@ from typing import Any
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from trusted_router.content_handling import CONTENT_HANDLING_CLAIM
+from trusted_router.middleware import current_csp_nonce
 from trusted_router.provider_branding import provider_logo_url
 from trusted_router.seo_meta import seo_meta_description, seo_title
 
@@ -72,6 +73,9 @@ def _env() -> Environment:
     env.filters["seo_meta_description"] = seo_meta_description
     env.globals["provider_logo_url"] = provider_logo_url
     env.globals["content_handling_claim"] = CONTENT_HANDLING_CLAIM
+    # Callable, not a value: this env is lru_cached and shared across
+    # requests, so it must read the per-request ContextVar at render time.
+    env.globals["csp_nonce"] = current_csp_nonce
     return env
 
 

--- a/tests/test_competitor_comparisons.py
+++ b/tests/test_competitor_comparisons.py
@@ -10,7 +10,7 @@ from trusted_router.competitor_comparisons import COMPETITOR_COMPARISONS
 
 def _json_ld(response_text: str) -> dict[str, object]:
     match = re.search(
-        r'<script type="application/ld\+json">(.*?)</script>',
+        r'<script type="application/ld\+json"[^>]*>(.*?)</script>',
         response_text,
         flags=re.DOTALL,
     )

--- a/tests/test_measured_pages.py
+++ b/tests/test_measured_pages.py
@@ -75,7 +75,7 @@ def test_provider_performance_page_indexes_with_enough_samples() -> None:
     assert "Cerebras performance" in resp.text
     assert "110 ms" in resp.text
     assert '<meta name="robots" content="noindex,follow">' not in resp.text
-    assert '<script type="application/ld+json">' in resp.text
+    assert '<script type="application/ld+json"' in resp.text
 
 
 def test_model_performance_page_without_data_still_renders() -> None:

--- a/tests/test_provider_branding.py
+++ b/tests/test_provider_branding.py
@@ -118,7 +118,7 @@ def test_provider_detail_structured_data_describes_visible_provider(
 ) -> None:
     response = client.get("/providers/minimax")
     match = re.search(
-        r'<script type="application/ld\+json">(.*?)</script>',
+        r'<script type="application/ld\+json"[^>]*>(.*?)</script>',
         response.text,
         re.DOTALL,
     )

--- a/tests/test_public_model_region_pages.py
+++ b/tests/test_public_model_region_pages.py
@@ -44,7 +44,7 @@ REGION_TEMPLATES = (
 
 def _json_ld(html: str) -> dict[str, object]:
     match = re.search(
-        r'<script type="application/ld\+json">(?P<payload>.*?)</script>',
+        r'<script type="application/ld\+json"[^>]*>(?P<payload>.*?)</script>',
         html,
     )
     assert match is not None

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -639,7 +639,7 @@ def test_public_model_detail_uses_service_structured_data(client: TestClient) ->
 
     assert response.status_code == 200
     match = re.search(
-        r'<script type="application/ld\+json">(?P<payload>.*?)</script>',
+        r'<script type="application/ld\+json"[^>]*>(?P<payload>.*?)</script>',
         response.text,
     )
     assert match is not None

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -642,7 +642,7 @@ def test_blog_page_views_emit_axiom_safe_metadata(client: TestClient, caplog) ->
 
 def _json_ld(html: str) -> dict[str, object]:
     match = re.search(
-        r'<script type="application/ld\+json">(?P<payload>.*?)</script>',
+        r'<script type="application/ld\+json"[^>]*>(?P<payload>.*?)</script>',
         html,
     )
     assert match is not None

--- a/tests/test_security_response_headers.py
+++ b/tests/test_security_response_headers.py
@@ -13,7 +13,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from trusted_router.main import create_app
-from trusted_router.middleware import CONTENT_SECURITY_POLICY_REPORT_ONLY
+from trusted_router.middleware import CSP_SCRIPT_ORIGINS, content_security_policy
 
 
 @pytest.fixture(scope="module")
@@ -58,42 +58,94 @@ def test_x_frame_options_is_sameorigin_not_deny() -> None:
     assert '"x-frame-options", "DENY"' not in source
 
 
-def test_csp_is_report_only_and_only_on_html(client: TestClient) -> None:
-    """Report-only, and NOT enforcing: the templates carry inline script and
-    style, so enforcing today would either need 'unsafe-inline' (pointless) or
-    nonces in every template (the real fix, and a separate change)."""
+def test_csp_is_enforcing_and_only_on_html(client: TestClient) -> None:
+    """Enforcing, not report-only. Verified in a real browser before flipping:
+    /, /choose, /docs and /chat all render with zero console violations, which
+    includes the four jsdelivr libraries /chat loads."""
     html = client.get("/")
-    assert html.headers.get("content-security-policy-report-only")
-    assert "content-security-policy" not in {k.lower() for k in html.headers} - {
-        "content-security-policy-report-only"
-    }
+    assert html.headers.get("content-security-policy")
+    assert html.headers.get("content-security-policy-report-only") is None
 
     api = client.get("/status.json")
     assert api.headers.get("content-type", "").startswith("application/json")
-    assert api.headers.get("content-security-policy-report-only") is None
+    assert api.headers.get("content-security-policy") is None
 
 
-def test_the_policy_allows_what_the_templates_actually_load() -> None:
-    """A policy copied from a blog post reports violations nobody acts on.
+def test_script_src_uses_a_nonce_and_not_unsafe_inline(client: TestClient) -> None:
+    """A nonce in script-src makes browsers ignore 'unsafe-inline'. Shipping
+    both would be the policy that looks strict and blocks nothing."""
+    policy = client.get("/").headers["content-security-policy"]
+    script_src = next(d for d in policy.split("; ") if d.startswith("script-src"))
+    assert "'nonce-" in script_src
+    assert "'unsafe-inline'" not in script_src
 
-    These origins are the ones the templates reference today; if a template
-    starts loading from somewhere else, the violation should be a real signal
-    rather than noise this policy was always going to produce.
+
+def test_the_nonce_is_per_request_and_matches_the_page(client: TestClient) -> None:
+    """The header nonce must authorise THIS page's inline scripts, and must
+    not repeat: a reused nonce is worth exactly as much as none."""
+    import re
+
+    seen = set()
+    for _ in range(3):
+        response = client.get("/")
+        header = re.search(r"'nonce-([A-Za-z0-9_-]+)'", response.headers["content-security-policy"])
+        assert header, response.headers["content-security-policy"]
+        body = set(re.findall(r'nonce="([A-Za-z0-9_-]+)"', response.text))
+        assert body, "page has no nonced inline blocks"
+        assert body == {header.group(1)}, "page nonce does not match the header"
+        seen.add(header.group(1))
+    assert len(seen) == 3, "nonce was reused across requests"
+
+
+def test_every_inline_script_in_every_template_carries_the_nonce() -> None:
+    """The guard that keeps enforcement survivable.
+
+    Under an enforcing policy an inline <script> without a nonce does not warn
+    -- it silently does not run, and the page looks fine until somebody clicks
+    the thing it powered. A new template must not be able to do that quietly.
     """
-    for directive in (
-        "default-src 'self'",
-        "frame-ancestors 'self'",
-        "object-src 'none'",
-        "base-uri 'self'",
-        "form-action 'self'",
-    ):
-        assert directive in CONTENT_SECURITY_POLICY_REPORT_ONLY
-    assert "https://cdn.jsdelivr.net" in CONTENT_SECURITY_POLICY_REPORT_ONLY
+    import re
+    from pathlib import Path
+
+    import trusted_router
+
+    root = Path(trusted_router.__file__).parent / "templates"
+    missing = []
+    for path in sorted(root.rglob("*.html")):
+        for match in re.finditer(r"<(script|style)\b[^>]*>", path.read_text()):
+            tag = match.group(0)
+            if re.search(r"\bsrc\s*=", tag) or "nonce=" in tag:
+                continue
+            missing.append(f"{path.relative_to(root)}: {tag[:60]}")
+    assert not missing, (
+        "inline blocks without nonce=\"{{ csp_nonce() }}\" -- these will not "
+        "execute under the enforcing policy:\n  " + "\n  ".join(missing)
+    )
 
 
-def test_report_only_collects_nothing_automatically() -> None:
-    """No report-uri/report-to, stated so the header is not mistaken for
-    monitoring. Violations land in the browser console and nowhere else until
-    somebody looks -- which is the point of shipping it before enforcing."""
-    assert "report-uri" not in CONTENT_SECURITY_POLICY_REPORT_ONLY
-    assert "report-to" not in CONTENT_SECURITY_POLICY_REPORT_ONLY
+def test_external_script_origins_are_allowlisted() -> None:
+    """Every https:// script the templates load must be in CSP_SCRIPT_ORIGINS."""
+    import re
+    from pathlib import Path
+
+    import trusted_router
+
+    root = Path(trusted_router.__file__).parent / "templates"
+    origins = set()
+    for path in root.rglob("*.html"):
+        for match in re.finditer(r'<script[^>]*src="(https://[^"/]+)', path.read_text()):
+            origins.add(match.group(1))
+    assert origins <= set(CSP_SCRIPT_ORIGINS), (
+        f"templates load scripts from {origins - set(CSP_SCRIPT_ORIGINS)}, "
+        "which the policy blocks"
+    )
+
+
+def test_the_policy_still_collects_nothing_automatically() -> None:
+    """No report-uri: violations surface as broken pages and console errors,
+    not as telemetry. Stated so the header is not mistaken for monitoring."""
+    policy = content_security_policy("abc")
+    assert "report-uri" not in policy
+    assert "report-to" not in policy
+    for directive in ("frame-ancestors 'self'", "object-src 'none'", "base-uri 'self'"):
+        assert directive in policy

--- a/tests/test_security_response_headers.py
+++ b/tests/test_security_response_headers.py
@@ -1,0 +1,99 @@
+"""The headers an outside reviewer checks first, and one they cannot yet.
+
+Prompted by a public comment claiming "basic security holes" with no
+specifics. What was actually missing, verified against production on
+2026-08-20: HSTS and the cookie flags were correct; CSP, X-Frame-Options,
+X-Content-Type-Options and Referrer-Policy were absent on every path,
+including /docs and the /console flow where people paste API keys.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from trusted_router.main import create_app
+from trusted_router.middleware import CONTENT_SECURITY_POLICY_REPORT_ONLY
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    return TestClient(create_app(), raise_server_exceptions=False)
+
+
+@pytest.mark.parametrize(
+    "header,value",
+    [
+        ("strict-transport-security", "max-age=63072000; includeSubDomains"),
+        ("x-content-type-options", "nosniff"),
+        ("referrer-policy", "strict-origin-when-cross-origin"),
+        ("x-frame-options", "SAMEORIGIN"),
+    ],
+)
+def test_every_response_carries_the_baseline_headers(
+    client: TestClient, header: str, value: str
+) -> None:
+    """Including JSON: nosniff on an API error costs nothing and a missing
+    header is judged on whichever path the reviewer happened to fetch."""
+    for path in ("/", "/docs", "/status.json"):
+        response = client.get(path)
+        assert response.headers.get(header) == value, f"{path} missing {header}"
+
+
+def test_x_frame_options_is_sameorigin_not_deny() -> None:
+    """DENY would blank the model picker.
+
+    /choose embeds /static/choose-app.html in a SAME-ORIGIN iframe, so DENY
+    breaks a live page while buying nothing: the clickjacking risk is a THIRD
+    party framing a page where somebody is creating an API key, and SAMEORIGIN
+    already blocks that. This test exists because DENY is the reflexive choice
+    and it is wrong here.
+    """
+    from trusted_router import middleware
+
+    source = (
+        __import__("pathlib").Path(middleware.__file__).read_text()
+    )
+    assert '"x-frame-options", "SAMEORIGIN"' in source
+    assert '"x-frame-options", "DENY"' not in source
+
+
+def test_csp_is_report_only_and_only_on_html(client: TestClient) -> None:
+    """Report-only, and NOT enforcing: the templates carry inline script and
+    style, so enforcing today would either need 'unsafe-inline' (pointless) or
+    nonces in every template (the real fix, and a separate change)."""
+    html = client.get("/")
+    assert html.headers.get("content-security-policy-report-only")
+    assert "content-security-policy" not in {k.lower() for k in html.headers} - {
+        "content-security-policy-report-only"
+    }
+
+    api = client.get("/status.json")
+    assert api.headers.get("content-type", "").startswith("application/json")
+    assert api.headers.get("content-security-policy-report-only") is None
+
+
+def test_the_policy_allows_what_the_templates_actually_load() -> None:
+    """A policy copied from a blog post reports violations nobody acts on.
+
+    These origins are the ones the templates reference today; if a template
+    starts loading from somewhere else, the violation should be a real signal
+    rather than noise this policy was always going to produce.
+    """
+    for directive in (
+        "default-src 'self'",
+        "frame-ancestors 'self'",
+        "object-src 'none'",
+        "base-uri 'self'",
+        "form-action 'self'",
+    ):
+        assert directive in CONTENT_SECURITY_POLICY_REPORT_ONLY
+    assert "https://cdn.jsdelivr.net" in CONTENT_SECURITY_POLICY_REPORT_ONLY
+
+
+def test_report_only_collects_nothing_automatically() -> None:
+    """No report-uri/report-to, stated so the header is not mistaken for
+    monitoring. Violations land in the browser console and nowhere else until
+    somebody looks -- which is the point of shipping it before enforcing."""
+    assert "report-uri" not in CONTENT_SECURITY_POLICY_REPORT_ONLY
+    assert "report-to" not in CONTENT_SECURITY_POLICY_REPORT_ONLY

--- a/tests/test_seo_catalog_evidence.py
+++ b/tests/test_seo_catalog_evidence.py
@@ -55,7 +55,7 @@ def test_visible_featured_models_match_item_list_structured_data(
 ) -> None:
     response = client.get("/kimi-k2-api")
     match = re.search(
-        r'<script type="application/ld\+json">(.*?)</script>',
+        r'<script type="application/ld\+json"[^>]*>(.*?)</script>',
         response.text,
         re.DOTALL,
     )


### PR DESCRIPTION
Prompted by a public claim of "basic security holes" with no specifics. Measured production first (2026-08-20): HSTS and cookie flags were already correct; `X-Content-Type-Options`, `Referrer-Policy`, `X-Frame-Options` and CSP were absent on every path, including `/docs` and the `/console` flow where people paste API keys.

**Baseline headers**, every response: `nosniff`, `referrer-policy: strict-origin-when-cross-origin`, `x-frame-options: SAMEORIGIN`.

**`SAMEORIGIN`, not `DENY`** — `/choose` embeds `/static/choose-app.html` in a same-origin iframe; `DENY` would blank the model picker while buying nothing, since the clickjacking risk is a *third party* framing a key-creation page. Pinned by a test.

**CSP is enforcing, with per-request nonces.** All 23 inline `<script>`/`<style>` blocks across 14 templates carry `nonce="{{ csp_nonce() }}"`. The nonce is a `ContextVar` exposed as a Jinja global *callable* — both Jinja envs are `lru_cache`d and shared across requests, so a stored nonce would be reused and worth nothing. A nonce in `script-src` also makes browsers ignore `'unsafe-inline'`, so that directive is gone rather than decorative.

**`style-src` keeps `'unsafe-inline'`, deliberately** — a nonce cannot authorise an inline `style=` *attribute*, only a `<style>` block, and 27 templates use attributes. Removing them is real work with no payoff next to script-src; the docstring says so rather than leaving it looking accidental.

**Verified in a browser under enforcement**, not by reading code: `/`, `/choose`, `/docs` and `/chat` render with **zero console violations** — including the four jsdelivr libraries `/chat` loads. Header nonce matches the page within a request and differs between requests.

**Guard:** a test walks every template and fails on an unnonced inline block, because under enforcement such a block doesn't warn — it silently doesn't run. Proven by adding one and watching it fail.

Also relaxed JSON-LD matchers in 7 SEO test files that pinned the exact tag string.

Gates: ruff + mypy clean, full suite 5033 passed.