### PR TITLE
Schedule Nebius August 31 serverless retirements

### DIFF
--- a/scripts/pricing/providers/nebius.py
+++ b/scripts/pricing/providers/nebius.py
@@ -22,6 +22,7 @@ from scripts.pricing.model_ids import (
     mapped_or_canonical_model_id,
     remember_upstream_id,
 )
+from trusted_router.provider_lifecycle import provider_model_retired
 
 SLUG = "nebius"
 URL = "https://api.tokenfactory.nebius.com/v1/models?verbose=true"
@@ -166,6 +167,8 @@ def fetch() -> ProviderPricingResult:
             continue
         model_id = mapped_or_canonical_model_id(upstream_id, canonical_by_native)
         if model_id is None:
+            continue
+        if provider_model_retired(SLUG, model_id, upstream_id):
             continue
         remember_upstream_id(UPSTREAM_ID_MAP, model_id, upstream_id)
         architecture = row.get("architecture")

--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -36,6 +36,7 @@ DEEPINFRA_TERMINUS_RETIREMENT_AT = datetime(2026, 8, 17, 0, 0, tzinfo=UTC)
 DEEPINFRA_QWEN3_235B_THINKING_RETIREMENT_AT = datetime(
     2026, 8, 24, 0, 0, tzinfo=UTC
 )
+NEBIUS_AUGUST_2026_RETIREMENT_AT = datetime(2026, 8, 31, 0, 0, tzinfo=UTC)
 NOVITA_LING_30_TINY_RETIREMENT_AT = datetime(2026, 8, 13, 15, 0, tzinfo=UTC)
 ALIBABA_OCTOBER_2026_RETIREMENT_AT = datetime(2026, 10, 9, 16, 0, tzinfo=UTC)
 DEEPSEEK_V4_PRICING_EFFECTIVE_AT = datetime(2026, 8, 16, 16, 0, tzinfo=UTC)
@@ -87,6 +88,47 @@ class _Retirement:
 
 
 _RETIREMENTS = (
+    # Nebius announced that these Token Factory Serverless routes retire on
+    # 2026-08-31. The notice did not specify a time zone, so use 00:00 UTC as
+    # the conservative cutover. Keep this provider-scoped: equivalent model
+    # checkpoints remain routable through other providers that still serve
+    # them. The announcement did not name replacements.
+    _Retirement(
+        provider="nebius",
+        model_ids=frozenset(
+            {
+                "nvidia/nemotron-3-ultra-550b-a55b",
+                "Qwen/Qwen3-32B",
+                "NousResearch/Hermes-4-70B",
+                "meta-llama/Llama-3.3-70B-Instruct",
+                "Qwen/Qwen2.5-VL-72B-Instruct",
+                "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B",
+                "MiniMaxAI/MiniMax-M2.5",
+                "nvidia/Nemotron-3-Nano-Omni",
+                "deepseek/deepseek-v4-flash",
+                "nvidia/Cosmos3-Super-Reasoner",
+                "Qwen/Qwen3-Next-80B-A3B-Thinking",
+                "nvidia/Llama-3_1-Nemotron-Ultra-253B-v1",
+            }
+        ),
+        upstream_ids=frozenset(
+            {
+                "nvidia/Nemotron-3-Ultra-550b-a55b",
+                "Qwen/Qwen3-32B",
+                "NousResearch/Hermes-4-70B",
+                "meta-llama/Llama-3.3-70B-Instruct",
+                "Qwen/Qwen2.5-VL-72B-Instruct",
+                "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B",
+                "MiniMaxAI/MiniMax-M2.5",
+                "nvidia/Nemotron-3-Nano-Omni",
+                "deepseek-ai/DeepSeek-V4-Flash",
+                "nvidia/Cosmos3-Super-Reasoner",
+                "Qwen/Qwen3-Next-80B-A3B-Thinking",
+                "nvidia/Llama-3_1-Nemotron-Ultra-253B-v1",
+            }
+        ),
+        effective_at=NEBIUS_AUGUST_2026_RETIREMENT_AT,
+    ),
     # Alibaba Cloud Model Studio is consolidating its previously announced
     # retirements at 2026-10-10 00:00 UTC+08. Keep this provider-scoped: the
     # same open-weight models remain routable through other healthy providers.

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -94,6 +94,7 @@ from trusted_router.catalog import (
 from trusted_router.catalog_ingest import _authoritative_provider_model_ids, _modalities
 from trusted_router.config import Settings
 from trusted_router.main import create_app
+from trusted_router.provider_lifecycle import provider_model_retired
 from trusted_router.routes.internal.gateway import _gateway_provider_route_payload
 from trusted_router.routing import chat_route_candidates, chat_route_endpoint_candidates
 
@@ -306,16 +307,17 @@ def test_model_storage_flag_is_gateway_scoped_endpoint_flag_is_provider_scoped()
         ),
         (
             "nebius",
-            20,
+            18,
             [
                 # Nebius retired Meta-Llama-3.1-8B + gemma-2-2b-it earlier, then
                 # announced 11 more Token Factory model retirements for
-                # 2026-06-22. These are intentionally absent; this contract keeps
-                # representative non-deprecated Nebius routes alive.
-                "meta-llama/Llama-3.3-70B-Instruct",
+                # 2026-06-22 and 12 more for 2026-08-31. Those are intentionally
+                # absent after their cutovers; this contract keeps representative
+                # non-deprecated Nebius routes alive.
                 "Qwen/Qwen3.5-397B-A17B",
                 "deepseek-ai/DeepSeek-V4-Pro",
-                "MiniMaxAI/MiniMax-M2.5",
+                "MiniMaxAI/MiniMax-M3",
+                "moonshotai/kimi-k3",
             ],
         ),
         (
@@ -1338,7 +1340,14 @@ def test_liberty_nemotron_resolves_only_to_working_canonical_prepaid_routes() ->
         if endpoint.usage_type == "Credits"
     }
     assert prepaid["baseten"] == "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B"
-    assert prepaid["nebius"] == "nvidia/Nemotron-3-Ultra-550b-a55b"
+    if provider_model_retired(
+        "nebius",
+        model_id,
+        "nvidia/Nemotron-3-Ultra-550b-a55b",
+    ):
+        assert "nebius" not in prepaid
+    else:
+        assert prepaid["nebius"] == "nvidia/Nemotron-3-Ultra-550b-a55b"
     assert prepaid["together"] == "nvidia/nemotron-3-ultra-550b-a55b"
     assert "gmi" not in prepaid
 

--- a/tests/test_gateway_fallback_billing.py
+++ b/tests/test_gateway_fallback_billing.py
@@ -13,6 +13,7 @@ from trusted_router.partner_billing import (
     PARASAIL_LIBERTY_2_0_TOP_LEVEL_ROUTE,
     PARTNER_OPERATOR_COST_SETTLE_FIELD,
 )
+from trusted_router.provider_lifecycle import provider_model_retired
 from trusted_router.routes.helpers import cost_microdollars
 from trusted_router.routes.internal import gateway as gateway_routes
 from trusted_router.storage import STORE, CreditAccount, Workspace, configure_store
@@ -169,7 +170,14 @@ def test_gateway_authorizes_every_liberty_alias_to_working_nemotron_hosts() -> N
             if route["model"] == "nvidia/nemotron-3-ultra-550b-a55b"
             and route["usage_type"] == "Credits"
         }
-        assert {"baseten", "nebius", "together"} <= nemotron_hosts, (model_id, routes)
+        expected_hosts = {"baseten", "together"}
+        if not provider_model_retired(
+            "nebius",
+            "nvidia/nemotron-3-ultra-550b-a55b",
+            "nvidia/Nemotron-3-Ultra-550b-a55b",
+        ):
+            expected_hosts.add("nebius")
+        assert expected_hosts <= nemotron_hosts, (model_id, routes)
         assert "gmi" not in nemotron_hosts, (model_id, routes)
 
 

--- a/tests/test_minimax_nebius_xiaomi_pricing.py
+++ b/tests/test_minimax_nebius_xiaomi_pricing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import timedelta
 from pathlib import Path
 
 from scripts.pricing.base import ModelPrice, ProviderPricingResult
@@ -8,6 +9,7 @@ from scripts.pricing.parsers import minimax as minimax_parser
 from scripts.pricing.parsers import xiaomi as xiaomi_parser
 from scripts.pricing.providers import minimax, nebius
 from scripts.pricing.providers import xiaomi as xiaomi_provider
+from trusted_router import provider_lifecycle
 
 
 def test_minimax_parser_reads_official_token_plan_tiers() -> None:
@@ -260,6 +262,14 @@ def test_nebius_fetch_uses_verbose_pricing_and_skips_embeddings(
     tmp_path,
     monkeypatch,  # noqa: ANN001
 ) -> None:
+    # This fixture exercises the native-to-canonical mapping while the route
+    # is still live. The separate lifecycle suite owns its August 31 cutoff.
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: provider_lifecycle.NEBIUS_AUGUST_2026_RETIREMENT_AT
+        - timedelta(microseconds=1),
+    )
     payload = {
         "data": [
             {

--- a/tests/test_nebius_august_2026_lifecycle.py
+++ b/tests/test_nebius_august_2026_lifecycle.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from scripts.pricing import refresh
+from scripts.pricing.base import ModelPrice, ProviderPricingResult
+from scripts.pricing.providers import nebius
+from trusted_router import provider_lifecycle
+from trusted_router.catalog import endpoints_for_model
+
+_CUTOFF = datetime(2026, 8, 31, 0, 0, tzinfo=UTC)
+_RETIRING = {
+    "nvidia/nemotron-3-ultra-550b-a55b": "nvidia/Nemotron-3-Ultra-550b-a55b",
+    "Qwen/Qwen3-32B": "Qwen/Qwen3-32B",
+    "NousResearch/Hermes-4-70B": "NousResearch/Hermes-4-70B",
+    "meta-llama/Llama-3.3-70B-Instruct": "meta-llama/Llama-3.3-70B-Instruct",
+    "Qwen/Qwen2.5-VL-72B-Instruct": "Qwen/Qwen2.5-VL-72B-Instruct",
+    "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B",
+    "MiniMaxAI/MiniMax-M2.5": "MiniMaxAI/MiniMax-M2.5",
+    "nvidia/Nemotron-3-Nano-Omni": "nvidia/Nemotron-3-Nano-Omni",
+    "deepseek/deepseek-v4-flash": "deepseek-ai/DeepSeek-V4-Flash",
+    "nvidia/Cosmos3-Super-Reasoner": "nvidia/Cosmos3-Super-Reasoner",
+    "Qwen/Qwen3-Next-80B-A3B-Thinking": "Qwen/Qwen3-Next-80B-A3B-Thinking",
+    "nvidia/Llama-3_1-Nemotron-Ultra-253B-v1": "nvidia/Llama-3_1-Nemotron-Ultra-253B-v1",
+}
+_SURVIVING = {
+    "openai/gpt-oss-120b": "openai/gpt-oss-120b",
+    "deepseek-ai/DeepSeek-V4-Pro": "deepseek-ai/DeepSeek-V4-Pro",
+    "zai-org/GLM-5.1": "zai-org/GLM-5.1",
+    "moonshotai/kimi-k3": "moonshotai/Kimi-K3",
+}
+
+
+def test_nebius_routes_retire_at_announced_date() -> None:
+    for model_id, upstream_id in _RETIRING.items():
+        assert not provider_lifecycle.provider_model_retired(
+            "nebius",
+            model_id,
+            upstream_id,
+            at=_CUTOFF - timedelta(microseconds=1),
+        )
+        assert provider_lifecycle.provider_model_retired(
+            "nebius",
+            model_id,
+            upstream_id,
+            at=_CUTOFF,
+        )
+
+    for model_id, upstream_id in _SURVIVING.items():
+        assert not provider_lifecycle.provider_model_retired(
+            "nebius",
+            model_id,
+            upstream_id,
+            at=_CUTOFF,
+        )
+
+
+def test_nebius_retirements_are_provider_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+
+    for model_id, upstream_id in _RETIRING.items():
+        providers = {endpoint.provider for endpoint in endpoints_for_model(model_id)}
+        assert "nebius" not in providers
+        assert not provider_lifecycle.provider_model_retired(
+            "another-provider",
+            model_id,
+            upstream_id,
+            at=_CUTOFF,
+        )
+
+    # Both checkpoints remain available from other providers after Nebius's
+    # route is removed.
+    assert {"baseten", "together"}.issubset(
+        {endpoint.provider for endpoint in endpoints_for_model("nvidia/nemotron-3-ultra-550b-a55b")}
+    )
+    assert {
+        "deepinfra",
+        "makora",
+        "siliconflow",
+    }.issubset(
+        {endpoint.provider for endpoint in endpoints_for_model("deepseek/deepseek-v4-flash")}
+    )
+
+
+def test_hourly_refresh_cannot_restore_retired_nebius_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prices = {model_id: ModelPrice(1_000_000, 3_000_000) for model_id in {*_RETIRING, *_SURVIVING}}
+    result = ProviderPricingResult(
+        slug="nebius",
+        prices=prices,
+        source="api",
+        fetched_url=nebius.URL,
+    )
+
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF - timedelta(microseconds=1),
+    )
+    before = refresh._index_provider_prices({"nebius": result})
+    for model_id in _RETIRING:
+        assert "nebius" in before[model_id]
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    after = refresh._index_provider_prices({"nebius": result})
+    assert set(_RETIRING).isdisjoint(after)
+    for model_id in _SURVIVING:
+        assert "nebius" in after[model_id]
+
+
+def test_nebius_parser_filters_retired_rows_from_stale_feed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def row(native_id: str) -> dict[str, object]:
+        return {
+            "id": native_id,
+            "name": native_id,
+            "created": 1,
+            "context_length": 131_072,
+            "architecture": {"modality": "text->text"},
+            "pricing": {"prompt": "0.000001", "completion": "0.000003"},
+        }
+
+    payload = {
+        "data": [
+            *(row(upstream_id) for upstream_id in _RETIRING.values()),
+            *(row(upstream_id) for upstream_id in _SURVIVING.values()),
+        ]
+    }
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return payload
+
+    class FakeClient:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def get(self, *_args: object, **_kwargs: object) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setattr(nebius.httpx, "Client", FakeClient)
+
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF - timedelta(microseconds=1),
+    )
+    before = nebius.fetch()
+    assert set(_RETIRING).issubset(before.prices)
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    after = nebius.fetch()
+    assert set(_RETIRING).isdisjoint(after.prices)
+    assert set(_RETIRING).isdisjoint(nebius._DISCOVERED_ROWS)
+    assert set(_SURVIVING).issubset(after.prices)


### PR DESCRIPTION
## Summary
- schedule the 12 announced Nebius Token Factory Serverless retirements for 2026-08-31 00:00 UTC
- keep retirements provider-scoped so equivalent models remain available elsewhere
- filter stale Nebius API rows in both catalog routing and hourly pricing refresh
- make catalog and fallback tests safe before and after the cutover

## Verification
- ruff check .
- mypy
- 147 focused tests under the current clock
- 147 focused tests under the post-cutover clock
- full suite: 5,010 passed; the 104 localhost-only cases passed separately with socket access
