### PR TITLE
Make control-plane rollouts Spanner-safe

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -354,8 +354,9 @@ jobs:
       # Staged regional deploy. Deploy us-central1 first, gate on a
       # 3-min single-region synthetic watch; only proceed to the
       # secondary warm regions if us-central1 stays up. Once the image has
-      # passed that primary-region gate, europe-west4 and us-east4 roll in
-      # parallel with independent staged traffic, canaries, and rollback.
+      # passed that primary-region gate, every secondary rolls sequentially.
+      # All regions share Spanner, so overlapping revision warmups and traffic
+      # ramps can amplify billing transaction contention.
       #
       # Hotfix mode (workflow_dispatch input `hotfix: true`): the
       # watchdogs skip baseline + use --skip-baseline so a sick prod
@@ -426,6 +427,7 @@ jobs:
           echo "deploy_google_data_manager=${deploy_google_data_manager}"
 
       - name: Deploy us-central1 (no-traffic)
+        id: deploy_us
         env:
           IMAGE_TAG: ${{ needs.build-image.outputs.sha }}
           TR_DEPLOY_TARGET_REGIONS: us-central1
@@ -433,7 +435,9 @@ jobs:
           # Global LB topology is shared by every region. Reconcile it exactly
           # once here; concurrent secondary rollouts must not race on it.
           TR_DEPLOY_RECONCILE_LB: "1"
-        run: bash scripts/deploy/rollout.sh
+        run: |
+          echo "started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+          bash scripts/deploy/rollout.sh
 
       - name: Resolve us-central1 new revision
         id: new_us
@@ -450,7 +454,7 @@ jobs:
         # is reverted to 100% on the old revision and the workflow
         # fails before ever shipping anything to europe-west4.
         env:
-          TR_WATCHDOG_SLO_CLASS: control_plane
+          TR_WATCHDOG_SLO_CLASS: router_core
         run: bash scripts/deploy/staged_traffic.sh us-central1 "${{ steps.new_us.outputs.revision }}" "${{ steps.prev.outputs.us_central1_revision }}"
 
       - name: Canary gate — watch us-central1 only (3 min)
@@ -459,7 +463,7 @@ jobs:
         # received the new image yet, so the bad change is contained.
         id: canary_us
         continue-on-error: true
-        run: python3 scripts/deploy/watchdog.py --regions us-central1 --duration-min 3 --rollback-after 2 --slo-class control_plane ${{ steps.wd_args.outputs.extra }}
+        run: python3 scripts/deploy/watchdog.py --regions us-central1 --duration-min 3 --rollback-after 2 --slo-class router_core ${{ steps.wd_args.outputs.extra }}
 
       - name: Rollback us-central1 + abort (canary tripped)
         if: ${{ steps.canary_us.outcome == 'failure' && steps.canary_us.outputs.rollback_regions != '' }}
@@ -478,15 +482,31 @@ jobs:
           echo "europe-west4 NEVER received the bad image; safe."
           exit 1
 
-      - name: Roll secondary warm regions in parallel
+      - name: Billing-path gate + rollback (us-central1)
+        env:
+          PREV_US: ${{ steps.prev.outputs.us_central1_revision }}
+          TR_BILLING_5XX_GATE_SKIP: ${{ inputs.hotfix == true && 'true' || 'false' }}
+        run: |
+          set -euo pipefail
+          if ! bash scripts/deploy/assert_no_billing_5xx.sh \
+              us-central1 "${{ steps.deploy_us.outputs.started_at }}"; then
+            echo "us-central1 emitted billing-path 5xx; rolling back to ${PREV_US}"
+            gcloud run services update-traffic "${SERVICE}" \
+              --region=us-central1 --project="${PROJECT_ID}" \
+              --to-revisions="${PREV_US}=100" --quiet
+            exit 1
+          fi
+
+      - name: Roll secondary warm regions sequentially
         env:
           IMAGE_TAG: ${{ needs.build-image.outputs.sha }}
           PREV_EU: ${{ steps.prev.outputs.europe_west4_revision }}
           PREV_US_EAST4: ${{ steps.prev.outputs.us_east4_revision }}
           PREV_SOUTHAMERICA_EAST1: ${{ steps.prev.outputs.southamerica_east1_revision }}
           WD_EXTRA: ${{ steps.wd_args.outputs.extra }}
-          TR_WATCHDOG_SLO_CLASS: control_plane
+          TR_WATCHDOG_SLO_CLASS: router_core
           TR_DEPLOY_RECONCILE_LB: "0"
+          TR_BILLING_5XX_GATE_SKIP: ${{ inputs.hotfix == true && 'true' || 'false' }}
         run: |
           set -euo pipefail
 
@@ -516,7 +536,9 @@ jobs:
           deploy_secondary() {
             local region="$1"
             local previous
+            local rollout_started_at
             previous="$(previous_revision "${region}")"
+            rollout_started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
             echo "deploying ${region} no-traffic"
             if ! TR_DEPLOY_TARGET_REGIONS="${region}" \
                 TR_DEPLOY_NO_TRAFFIC="1" \
@@ -562,43 +584,31 @@ jobs:
               --regions "${region}" \
               --duration-min 3 \
               --rollback-after 2 \
-              --slo-class control_plane \
+              --slo-class router_core \
               ${WD_EXTRA}; then
+              rollback_region "${region}"
+              return 1
+            fi
+
+            if ! bash scripts/deploy/assert_no_billing_5xx.sh \
+                "${region}" "${rollout_started_at}"; then
               rollback_region "${region}"
               return 1
             fi
           }
 
           # The image has already passed the full us-central1 ramp and canary.
-          # These regions share no mutable Cloud Run resources; each child
-          # retains its own traffic ramp, watchdog, and region-local rollback.
+          # Roll one region at a time because every control-plane region shares
+          # Spanner and its billing indexes. Each region retains its own traffic
+          # ramp, router-core watchdog, billing-path gate, and local rollback.
           regions=(europe-west4 us-east4 southamerica-east1)
-          log_dir="$(mktemp -d)"
-          pids=()
           for region in "${regions[@]}"; do
-            echo "starting independent rollout for ${region}"
-            (deploy_secondary "${region}") >"${log_dir}/${region}.log" 2>&1 &
-            pids+=("$!")
-          done
-
-          failed=0
-          for idx in "${!regions[@]}"; do
-            region="${regions[$idx]}"
-            if wait "${pids[$idx]}"; then
-              echo "::group::${region} rollout"
-              cat "${log_dir}/${region}.log"
-              echo "::endgroup::"
-            else
-              failed=1
-              echo "::group::${region} failed rollout"
-              cat "${log_dir}/${region}.log"
-              echo "::endgroup::"
-              echo "::error::${region} rollout failed and was rolled back independently."
+            echo "starting sequential rollout for ${region}"
+            if ! deploy_secondary "${region}"; then
+              echo "::error::${region} rollout failed and was rolled back. Later regions were not touched."
+              exit 1
             fi
           done
-          if [ "${failed}" -ne 0 ]; then
-            exit 1
-          fi
 
       - name: Deploy synthetic monitor Cloud Run Job
         if: ${{ steps.optional.outputs.deploy_synthetic_monitor == 'true' }}
@@ -627,7 +637,7 @@ jobs:
 
       # No cross-region "final watchdog" step. Each region's health is
       # gated by its own per-region canary above (us-central1 first,
-      # then europe-west4 and us-east4 in parallel, each with its own 3-min
+      # then each secondary sequentially, each with its own 3-min
       # watchdog AFTER the staged_traffic 10/50/100 ramp). The prior cross-
       # region watchdog at this point caused recurring spurious
       # rollbacks: by the time it ran, earlier regions had finished

--- a/scripts/deploy/assert_no_billing_5xx.sh
+++ b/scripts/deploy/assert_no_billing_5xx.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Fail a rollout when its region emitted a billing-path 5xx after the supplied
+# timestamp. Cloud Run readiness alone cannot detect exhausted Spanner retries.
+set -euo pipefail
+
+REGION="${1:?usage: assert_no_billing_5xx.sh REGION SINCE_TIMESTAMP}"
+SINCE="${2:?usage: assert_no_billing_5xx.sh REGION SINCE_TIMESTAMP}"
+PROJECT_ID="${PROJECT_ID:-quill-cloud-proxy}"
+SERVICE="${SERVICE:-trusted-router}"
+
+if [ "${TR_BILLING_5XX_GATE_SKIP:-false}" = "true" ]; then
+  echo "hotfix mode: skipping historical billing-path 5xx gate for ${REGION}"
+  exit 0
+fi
+
+# Give request logs time to become queryable before deciding the rollout is clean.
+sleep "${TR_BILLING_5XX_LOG_GRACE_SECONDS:-20}"
+
+query="resource.type=\"cloud_run_revision\"
+resource.labels.service_name=\"${SERVICE}\"
+resource.labels.location=\"${REGION}\"
+timestamp>=\"${SINCE}\"
+httpRequest.status>=500
+httpRequest.requestUrl:\"/internal/gateway/\""
+
+failure="$(gcloud logging read "${query}" \
+  --project="${PROJECT_ID}" \
+  --limit=1 \
+  --order=desc \
+  --format='value(timestamp,httpRequest.requestUrl,httpRequest.status,httpRequest.latency)')"
+
+if [ -n "${failure}" ]; then
+  echo "billing-path 5xx detected in ${REGION} after ${SINCE}: ${failure}"
+  exit 1
+fi
+
+echo "billing-path 5xx gate passed for ${REGION}"

--- a/tests/test_deploy_workflow_regions.py
+++ b/tests/test_deploy_workflow_regions.py
@@ -5,7 +5,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def test_every_load_balanced_control_plane_region_is_staged() -> None:
     workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
-    start = workflow.index("- name: Roll secondary warm regions in parallel")
+    start = workflow.index("- name: Roll secondary warm regions sequentially")
     end = workflow.index("- name: Deploy synthetic monitor Cloud Run Job", start)
     rollout = workflow[start:end]
 
@@ -59,10 +59,10 @@ def test_public_snapshot_worker_swap_is_verified_and_rollbackable() -> None:
     assert r'mv \"\$previous_builder\" \"\$builder\"' in script
 
 
-def test_warm_secondary_regions_roll_in_parallel_after_primary_canary() -> None:
+def test_warm_secondary_regions_roll_sequentially_after_primary_canary() -> None:
     workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
     primary_canary = workflow.index("- name: Canary gate — watch us-central1 only")
-    start = workflow.index("- name: Roll secondary warm regions in parallel")
+    start = workflow.index("- name: Roll secondary warm regions sequentially")
     end = workflow.index("- name: Deploy synthetic monitor Cloud Run Job", start)
     rollout = workflow[start:end]
 
@@ -71,16 +71,31 @@ def test_warm_secondary_regions_roll_in_parallel_after_primary_canary() -> None:
     assert "PREV_SOUTHAMERICA_EAST1" in rollout
     assert "southamerica-east1)" in rollout
     assert 'for region in "${regions[@]}"; do' in rollout
-    assert '(deploy_secondary "${region}")' in rollout
+    assert 'if ! deploy_secondary "${region}"; then' in rollout
     assert 'if ! TR_DEPLOY_TARGET_REGIONS="${region}"' in rollout
     assert 'if ! bash scripts/deploy/staged_traffic.sh \\' in rollout
     assert 'active_traffic="$(gcloud run services describe' in rollout
     assert '[ "${active_traffic}" != "1" ]' in rollout
-    assert "pids=()" in rollout
-    assert 'pids+=("$!")' in rollout
-    assert 'if wait "${pids[$idx]}"; then' in rollout
+    assert "pids=()" not in rollout
+    assert 'pids+=("$!")' not in rollout
+    assert 'if wait "${pids[$idx]}"; then' not in rollout
     assert 'rollback_region "${region}"' in rollout
     assert 'TR_DEPLOY_RECONCILE_LB: "0"' in rollout
+    assert "assert_no_billing_5xx.sh" in rollout
+    assert "--slo-class router_core" in rollout
+
+
+def test_primary_rollout_gates_on_router_core_and_billing_path_errors() -> None:
+    workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
+    primary = workflow.index("- name: Deploy us-central1 (no-traffic)")
+    secondary = workflow.index("- name: Roll secondary warm regions sequentially")
+    rollout = workflow[primary:secondary]
+
+    assert "TR_WATCHDOG_SLO_CLASS: router_core" in rollout
+    assert "--slo-class router_core" in rollout
+    assert "- name: Billing-path gate + rollback (us-central1)" in rollout
+    assert "scripts/deploy/assert_no_billing_5xx.sh" in rollout
+    assert '--to-revisions="${PREV_US}=100"' in rollout
 
 
 def test_superseded_push_stops_before_production_mutation() -> None:


### PR DESCRIPTION
Incident containment: roll every secondary region sequentially, gate canaries on router-core health, and query Cloud Logging for billing-path 5xx during each regional rollout. A failed gate rolls back that region and stops before later regions are touched. The gate was validated against production: it passes the recovered window and fails on the known 2026-08-20 22:08-22:09 UTC incident window. Focused deploy and watchdog tests pass; shell syntax and diff checks pass.