### PR TITLE
Fix deployment ordering CI after sequential rollout

### DIFF
--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -25,7 +25,7 @@ def test_guarded_deploy_applies_clickhouse_delivery_schemas_before_rollout() -> 
     generation = "scripts/deploy/migrate_generation_records.sh --apply"
     provider_outbox = "scripts/deploy/migrate_analytics_outbox.sh"
     operational_outbox = "scripts/deploy/migrate_operational_analytics_outbox.sh"
-    rollout = "run: bash scripts/deploy/rollout.sh"
+    rollout = "bash scripts/deploy/rollout.sh"
     assert generation in workflow
     assert provider_outbox in workflow
     assert operational_outbox in workflow


### PR DESCRIPTION
Updates the deployment ordering assertion to recognize the staged multiline rollout command introduced by #695.\n\nValidation: `uv run pytest -q tests/test_deploy_secret_wiring.py tests/test_deploy_workflow_regions.py tests/test_deploy_watchdog.py` (32 passed).