### PR TITLE
Replace the Singapore enclave region with Sydney

### DIFF
--- a/docs/storage-portability/HANDOFF.md
+++ b/docs/storage-portability/HANDOFF.md
@@ -40,7 +40,7 @@ operational wide-column store and was never a columnar warehouse.
 | AWS deployment | **Serving and attesting** — Nitro enclave + Fargate control plane |
 | Azure deployment | **Serving and attesting** — SEV-SNP/MAA enclave + Container App control plane |
 | Per-cloud *control-plane* independence — AWS | **LIVE 2026-08-06.** All 4 enclaves rolled to `aws-release-20260806-ownplane`, PCR0 `aef48a4539…`, dialling `aws.trustedrouter.com` first with the canonical plane as a dial-failure fallback. Status `up`, single measurement, 0 errors (§4.5) |
-| Per-cloud *control-plane* independence — Azure | **LIVE 2026-08-06** (uaenorth). Enclave rebuilt from main, `TR_CONTROL_PLANE_BASE_URL=azure.trustedrouter.com/v1,trustedrouter.com/v1`, HOST_DATA `1936719d7398e9ad…`, attestation verified. Second region (southeastasia) pending (§4.5b) |
+| Per-cloud *control-plane* independence — Azure | **LIVE 2026-08-06** (uaenorth). Enclave rebuilt from main, `TR_CONTROL_PLANE_BASE_URL=azure.trustedrouter.com/v1,trustedrouter.com/v1`, HOST_DATA `1936719d7398e9ad…`, attestation verified. Second region (australiaeast) pending (§4.5b) |
 | Postgres can serve `authorize` | **Fixed**, router#452 — 11 gateway-reachable methods used to raise (§4.6) |
 
 ### The single most useful result
@@ -321,10 +321,10 @@ python3 tools/verify-attestation.py --api-host api-azure.trustedrouter.com \
   --expected-maa-issuer https://trquilluaen.uaen.attest.azure.net --expected-hostdata "$HD"
 ```
 
-**Second region.** Confidential ACI validates in **southeastasia**, northeurope,
+**Second region.** Confidential ACI validates in **australiaeast**, northeurope,
 eastus2, switzerlandnorth and swedencentral; **westeurope is blocked by policy**
-on this subscription. southeastasia is the chosen second region — with the
-gateway in UAE North and GCP/AWS in US/EU, Singapore adds real geographic spread
+on this subscription. australiaeast is the chosen second region — with the
+gateway in UAE North and GCP/AWS in US/EU, Sydney adds real geographic spread
 rather than a second European site. Confirm a region with an ARM
 `deployment group validate` of the real template (rename the resource, drop
 `outputs`) rather than trusting a docs list.
@@ -398,18 +398,27 @@ Two things to check before trusting any green:
 
 So AWS and Azure simply never schedule the throughput commands. No cross-cloud pipe.
 
-### 4.8 Azure region two (southeastasia) — BLOCKED on four IAM grants
+### 4.8 Azure region two (australiaeast) — BLOCKED on four IAM grants
 
 Everything except the grants is done and merged-or-in-review.
 
-**Provisioned and Ready:** resource group `TR-TEE-SEA` (southeastasia), MAA instance
-`trquillsea` → `https://trquillsea.sasia.attest.azure.net`, managed identity
-`tr-skr-identity` (principal `e8193e32-34ba-4a22-8159-7db7a0687874`).
+**Provisioned and Ready** (verified 2026-08-21): resource group `tr-tee-sydney`
+(australiaeast), MAA instance `trquillsyd` → `https://trquillsyd.eau.attest.azure.net`,
+managed identity `tr-skr-identity` (principal `f8879ad4-734b-4091-85f7-3d7e3e169016`,
+client `24bea69e-9f18-4f6e-9c1e-fd1206fbcace`). Confidential ACI was proved in this
+region by provisioning a real SEV-SNP group with a genuine CCE policy, not by reading
+a docs list — the capabilities API reports nothing about the Confidential SKU.
 
 **The block.** The identity has *no role assignments*. `az role assignment create` is refused
-by this session's permission classifier — correctly, it is an IAM grant — so a human must run
-the four commands in `tools/bootstrap-azure-region.sh`'s plan output. Until then the deploy
-dies at its prerequisite check, which is the intended behaviour.
+by this session's permission classifier — correctly, it is an IAM grant against the vault that
+holds every provider key — so a human applies them. They are now declared in
+quill-cloud-proxy `tools/azure-enclave/` (terraform): `bash import.sh` adopts what exists,
+then `terraform apply` creates exactly the four. Until then the deploy dies at its
+prerequisite check, which is the intended behaviour.
+
+Sydney is deliberately **not** granted `Key Vault Crypto Officer`, which uaenorth's identity
+holds: that role lets a workload rewrite the release policy constraining it, so the TEE
+becomes self-authorizing. `bind`/`narrow` run under the operator's credential instead.
 
 **Shared vs regional.** Vault `trquillkv`, wrapping key `tr-bootstrap-wrap` and registry
 `trquillacr` are **shared** across regions; the resource group, MAA instance, identity and
@@ -420,7 +429,7 @@ means per-region bundle re-sealing, and a bundle that drifts between regions is 
 that 401s *in one region only*. Wrong trade.
 
 **Region availability**, confirmed against ARM `deployment group validate` rather than docs:
-confidential ACI is supported in southeastasia, northeurope, eastus2, switzerlandnorth and
+confidential ACI is supported in australiaeast, northeurope, eastus2, switzerlandnorth and
 swedencentral on this subscription. **westeurope is blocked by policy.**
 
 **What region two exposed in one-region code** (qcp #120):
@@ -444,7 +453,7 @@ Four nines is 52 minutes a year *total*. Here is each term, honestly.
 
 | | status |
 |---|---|
-| two regions, each attesting to its own MAA | **done** — uaenorth + southeastasia |
+| two regions, each attesting to its own MAA | **done** — uaenorth + australiaeast |
 | auto-recovery from a container fault | **done** — `restartPolicy: OnFailure` |
 | automatic failover *between* the two regions | **MISSING** — this is the blocker |
 | auto-recovery from group-level loss | **MISSING** |
@@ -457,7 +466,7 @@ forever, serving nothing, until a human noticed. One such event spends the entir
 budget before anyone has read the page.
 
 **Why two regions do not currently compose.** Each has its own hostname
-(`api-azure` / `api-azure-sea`), so a client pointed at one gets nothing when that region dies.
+(`api-azure` / `api-azure-syd`), so a client pointed at one gets nothing when that region dies.
 Two regions with no failover is two independent single points of failure, not redundancy.
 
 **The mechanism to fix it already exists** and is how GCP runs many enclaves behind one name:
@@ -532,7 +541,8 @@ LOCATION=uaenorth RESOURCE_GROUP=tr-tee-dubai \
 ```
 
 **Do not redeploy uaenorth again before then** — each attempt burns the next issuance the
-moment the window reopens. southeastasia is unaffected and serving.
+moment the window reopens. southeastasia was unaffected and serving at the time
+(it has since been retired in favour of australiaeast).
 
 **Run `audit` against every region before believing a green dashboard.** It is read-only:
 

--- a/scripts/check_format_ordering.py
+++ b/scripts/check_format_ordering.py
@@ -265,7 +265,7 @@ records rather than fixtures, and both fixed here:
     instead of from the record it was mirroring, so trustedrouter.com reported
     `not-configured` for AWS and Azure no matter what quill-cloud-proxy
     published. Publishing the field upstream alone would have changed nothing.
-  * the mirror dropped `regions`, making api-azure-sea.trustedrouter.com
+  * the mirror dropped `regions`, making api-azure-syd.trustedrouter.com
     undiscoverable from the surface published as the place to verify us.
 """
 

--- a/scripts/deploy/azure_canary.sh
+++ b/scripts/deploy/azure_canary.sh
@@ -39,7 +39,7 @@ LOCATION="${LOCATION:-northeurope}"          # Postgres
 APP_LOCATION="${APP_LOCATION:-swedencentral}"  # ACR + Container Apps
 # CANARY drives every resource name, so a second canary in another geography is
 # one env var, not a forked script:
-#   CANARY=tr-canary-apac LOCATION=southeastasia APP_LOCATION=southeastasia \
+#   CANARY=tr-canary-apac LOCATION=australiaeast APP_LOCATION=australiaeast \
 #     bash scripts/deploy/azure_canary.sh
 #
 # See docs/storage-portability/coverage-map.md for which geographies are worth

--- a/scripts/deploy/azure_control_plane.sh
+++ b/scripts/deploy/azure_control_plane.sh
@@ -68,17 +68,17 @@ STATUS_HOST="${STATUS_HOST:-https://azure.trustedrouter.com}"
 # renaming one without the other silently unpublishes it.
 # Both Azure enclave regions. A region missing here is not probed at all, and
 # its component silently reports nothing rather than reporting down.
-# southeastasia carries an explicit @public_host. The two Azure regions serve
+# australiaeast carries an explicit @public_host. The two Azure regions serve
 # DIFFERENT public names, because the shared ACME cache is disabled on Azure
 # (no "tr-cross-cloud-sa-key" in the bundle), so each region completes ACME for
-# its own hostname only. Probing southeastasia with the canonical SNI
+# its own hostname only. Probing australiaeast with the canonical SNI
 # api-azure.trustedrouter.com asks it for a certificate it does not hold: the
 # handshake fails and a healthy region publishes as DOWN.
 #
 # uaenorth needs no override — it IS the canonical name. When the shared cache
 # lands and both regions serve one name, drop the @suffix and this returns to
 # the plain shared-name form that GCP and AWS use.
-GATEWAY_REGION_TARGETS="${GATEWAY_REGION_TARGETS:-uaenorth=quill-enclave-uaenorth.uaenorth.azurecontainer.io,southeastasia=quill-enclave-southeastasia.southeastasia.azurecontainer.io@api-azure-sea.trustedrouter.com}"
+GATEWAY_REGION_TARGETS="${GATEWAY_REGION_TARGETS:-uaenorth=quill-enclave-uaenorth.uaenorth.azurecontainer.io,australiaeast=quill-enclave-australiaeast.australiaeast.azurecontainer.io@api-azure-syd.trustedrouter.com}"
 
 # Secrets resolved from the operator's own files, exactly like every other
 # cloud (quill-cloud-proxy tools/quill_secret_sources.py). No cloud reads

--- a/scripts/verify_trust_measurements.py
+++ b/scripts/verify_trust_measurements.py
@@ -54,7 +54,7 @@ against a fixture plane and against production:
      published but compared against nothing. Both are fixed below.
   3. It contacted ONE Azure region. AZURE_ATTESTATION_URL was hardcoded to UAE
      North while the plane also serves Southeast Asia from
-     api-azure-sea.trustedrouter.com with its own CCE policy and therefore its
+     api-azure-syd.trustedrouter.com with its own CCE policy and therefore its
      own hostdata (f3a0b4ed…d712d81c). That region was never contacted, and its
      measurement was never compared to anything. Demonstrated: with Southeast
      Asia serving a hostdata published nowhere, the old file fetched only the

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -104,8 +104,8 @@ class GatewayRegionTarget(NamedTuple):
     ``api_base_url``.
 
     It exists because Azure is NOT built that way yet. Each Azure region serves
-    its own hostname (``api-azure`` / ``api-azure-sea``) because the shared
-    ACME cache is disabled there, so probing southeastasia with the canonical
+    its own hostname (``api-azure`` / ``api-azure-syd``) because the shared
+    ACME cache is disabled there, so probing australiaeast with the canonical
     SNI asks it for a certificate it does not hold: the handshake fails and a
     perfectly healthy region reports DOWN. A status page that cries wolf is not
     a safer failure than one that stays quiet — it is a page nobody reads.

--- a/src/trusted_router/synthetic/components.py
+++ b/src/trusted_router/synthetic/components.py
@@ -170,12 +170,12 @@ COMPONENT_DEFINITIONS: tuple[dict[str, str], ...] = (
         ),
     },
     {
-        "id": "southeastasia_gateway",
-        "name": "Southeast Asia Gateway (Singapore)",
+        "id": "australiaeast_gateway",
+        "name": "Australia East Gateway (Sydney)",
         "description": (
             "Azure confidential container addressed directly: publicly-trusted "
             "TLS minted inside the TEE and SEV-SNP attestation through MAA "
-            "from a healthy Southeast Asia enclave behind it."
+            "from a healthy Australia East enclave behind it."
         ),
     },
     {
@@ -227,7 +227,7 @@ COMPONENT_PROBE_TARGETS: dict[str, str] = {
     # (scripts/deploy/azure_control_plane.sh). Absent everywhere else, which is
     # what keeps this row off the AWS and GCP status pages.
     "uaenorth_gateway": "uaenorth",
-    "southeastasia_gateway": "southeastasia",
+    "australiaeast_gateway": "australiaeast",
     "attestation": "canonical",
     "billing_settlement": CONTROL_PLANE_TARGET,
     "provider_fallback": CONTROL_PLANE_TARGET,
@@ -253,7 +253,7 @@ GATEWAY_REGION_COMPONENT_IDS: frozenset[str] = frozenset(
         "eu_west_1_gateway",
         "eu_west_3_gateway",
         "uaenorth_gateway",
-        "southeastasia_gateway",
+        "australiaeast_gateway",
     }
 )
 # Regional API components also feed deploy automation through
@@ -383,8 +383,8 @@ def sample_component_ids(sample: SyntheticProbeSample) -> list[str]:
         ids.append("eu_west_3_gateway")
     if sample.target == "uaenorth" and sample.probe_type in REGIONAL_GATEWAY_PROBES:
         ids.append("uaenorth_gateway")
-    if sample.target == "southeastasia" and sample.probe_type in REGIONAL_GATEWAY_PROBES:
-        ids.append("southeastasia_gateway")
+    if sample.target == "australiaeast" and sample.probe_type in REGIONAL_GATEWAY_PROBES:
+        ids.append("australiaeast_gateway")
     # "Attestation" is a SHARED, service-wide row that predates the pinned
     # targets, and it is scoped to the addresses customers actually resolve.
     # Folding the pinned per-region probes in here averaged a public number

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -204,8 +204,8 @@ def _region_api_base_url(canonical_url: str, public_host: str) -> str:
     exactly as before.
 
     Azure needs the override because its two regions serve DIFFERENT public
-    names (``api-azure`` / ``api-azure-sea``); the shared ACME cache that would
-    let both hold one certificate is disabled there. Probing southeastasia with
+    names (``api-azure`` / ``api-azure-syd``); the shared ACME cache that would
+    let both hold one certificate is disabled there. Probing australiaeast with
     the canonical SNI asks it for a certificate it does not have, the handshake
     fails, and a healthy region is published as DOWN. That false alarm is not a
     safe failure — it is how a status page stops being believed.

--- a/tests/test_check_format_ordering.py
+++ b/tests/test_check_format_ordering.py
@@ -165,12 +165,12 @@ COMMIT_V1_AND_V2 = "2222222"
 GCP_DIGEST = "sha256:" + "fa" * 32
 AWS_PCR0 = "23" * 48
 AZURE_UAEN = "c5" * 32
-AZURE_SEA = "f3" * 32
+AZURE_SYD = "f3" * 32
 
 UAEN_ISSUER = "https://trquilluaen.uaen.attest.azure.net"
-SEA_ISSUER = "https://trquillsea.sasia.attest.azure.net"
+SYD_ISSUER = "https://trquillsyd.eau.attest.azure.net"
 UAEN_URL = "https://api-azure.trustedrouter.com/attestation"
-SEA_URL = "https://api-azure-sea.trustedrouter.com/attestation"
+SYD_URL = "https://api-azure-syd.trustedrouter.com/attestation"
 
 
 # --------------------------------------------------------------------------
@@ -350,8 +350,8 @@ def azure_record(**overrides: Any) -> dict[str, Any]:
         "platform": "azure-confidential-containers-sev-snp",
         "api_base_url": "https://api-azure.trustedrouter.com/v1",
         "hostdata": AZURE_UAEN,
-        "accepted_hostdata": [AZURE_UAEN, AZURE_SEA],
-        "attestation_issuers": [UAEN_ISSUER, SEA_ISSUER],
+        "accepted_hostdata": [AZURE_UAEN, AZURE_SYD],
+        "attestation_issuers": [UAEN_ISSUER, SYD_ISSUER],
         "source_commit": COMMIT_V1_AND_V2,
         "regions": [
             {
@@ -360,9 +360,9 @@ def azure_record(**overrides: Any) -> dict[str, Any]:
                 "attestation_issuer": UAEN_ISSUER,
             },
             {
-                "attestation_url": SEA_URL,
-                "hostdata": AZURE_SEA,
-                "attestation_issuer": SEA_ISSUER,
+                "attestation_url": SYD_URL,
+                "hostdata": AZURE_SYD,
+                "attestation_issuer": SYD_ISSUER,
             },
         ],
     }
@@ -374,7 +374,7 @@ LIVE: dict[str, bytes] = {
     "https://api.trustedrouter.com/attestation": gcp_attestation(),
     "https://api-aws.trustedrouter.com/attestation": aws_attestation(),
     UAEN_URL: azure_attestation(AZURE_UAEN, UAEN_ISSUER),
-    SEA_URL: azure_attestation(AZURE_SEA, SEA_ISSUER),
+    SYD_URL: azure_attestation(AZURE_SYD, SYD_ISSUER),
 }
 
 
@@ -450,7 +450,7 @@ def test_every_cloud_clears_when_every_enclave_reads_what_the_plane_writes() -> 
         "api.trustedrouter.com",
         "api-aws.trustedrouter.com",
         "api-azure.trustedrouter.com",
-        "api-azure-sea.trustedrouter.com",
+        "api-azure-syd.trustedrouter.com",
     ], "all four serving regions must be checked, and Azure's two come from the record"
     assert all(result.ok for result in results), problems(results)
     assert all(result.accepts == frozenset({V1, V2}) for result in results)
@@ -475,7 +475,7 @@ def test_azure_regions_are_enumerated_from_the_record_not_from_this_file() -> No
 
     assert hosts == [
         "api-azure.trustedrouter.com",
-        "api-azure-sea.trustedrouter.com",
+        "api-azure-syd.trustedrouter.com",
         "api-azure-nz.trustedrouter.com",
     ]
 
@@ -600,7 +600,7 @@ def test_an_accepted_measurement_no_region_served_blocks() -> None:
     """The live Azure mirror's exact shape: two accepted hostdata, no regions array.
 
     The check probes api-azure.trustedrouter.com, is never routed to the
-    Southeast Asia enclave, and used to print "Every enclave serving azure
+    Australia East enclave, and used to print "Every enclave serving azure
     accepts every format this build writes" over a sample of one. The second
     accepted measurement belongs to a build nothing here checked, so the run is
     a refusal, not a green with a footnote.
@@ -614,7 +614,7 @@ def test_an_accepted_measurement_no_region_served_blocks() -> None:
     assert results[0].ok, "the region that did answer is fine; the coverage is not"
     assert not results[-1].ok
     assert "never checked" in problems(results)
-    assert AZURE_SEA in problems(results)
+    assert AZURE_SYD in problems(results)
 
 
 def test_the_bind_window_refusal_does_not_depend_on_probe_routing() -> None:
@@ -649,7 +649,7 @@ def test_a_region_serving_outside_the_record_blocks() -> None:
     """
     surprise = "https://trquillnz.nz.attest.azure.net"
     live = dict(LIVE)
-    live[SEA_URL] = azure_attestation(AZURE_SEA, surprise)
+    live[SYD_URL] = azure_attestation(AZURE_SYD, surprise)
 
     results = run("azure", azure_record(), frozenset({V2}), transport=transport_from(live))
 

--- a/tests/test_per_enclave_probes.py
+++ b/tests/test_per_enclave_probes.py
@@ -1241,7 +1241,7 @@ def test_azure_deploy_probes_every_azure_gateway_component() -> None:
         for c in mod.COMPONENT_DEFINITIONS
         if c["id"].endswith("_gateway")
         and c["id"] in mod.COMPONENT_PROBE_TARGETS
-        and mod.COMPONENT_PROBE_TARGETS[c["id"]] in {"uaenorth", "southeastasia"}
+        and mod.COMPONENT_PROBE_TARGETS[c["id"]] in {"uaenorth", "australiaeast"}
     }
     unprobed = sorted(azure_regions - probed)
     assert not unprobed, (
@@ -1256,12 +1256,13 @@ def test_azure_deploy_probes_every_azure_gateway_component() -> None:
 # Every regional target used to inherit the canonical api_base_url, so SNI and
 # Host were always the shared public name. That is correct wherever every
 # replica serves one name (GCP, AWS) and WRONG on Azure, whose two regions
-# serve api-azure and api-azure-sea because the shared ACME cache is disabled
-# there. Probing southeastasia with the canonical SNI asks it for a certificate
+# serve api-azure and api-azure-syd because the shared ACME cache is disabled
+# there. Probing australiaeast with the canonical SNI asks it for a certificate
 # it does not hold: the handshake fails and a healthy region publishes as DOWN.
 #
-# Reproduced live 2026-08-07 — southeastasia was serving 200 on its own name
-# while the status page called it down.
+# Reproduced live 2026-08-07 in southeastasia, the region australiaeast
+# replaced: it was serving 200 on its own name while the status page called it
+# down. The region changed; the failure mode did not.
 
 
 def test_no_override_leaves_the_canonical_url_untouched() -> None:
@@ -1280,9 +1281,9 @@ def test_an_override_swaps_only_the_host() -> None:
     """
     assert (
         _region_api_base_url(
-            "https://api-azure.trustedrouter.com/v1", "api-azure-sea.trustedrouter.com"
+            "https://api-azure.trustedrouter.com/v1", "api-azure-syd.trustedrouter.com"
         )
-        == "https://api-azure-sea.trustedrouter.com/v1"
+        == "https://api-azure-syd.trustedrouter.com/v1"
     )
     assert (
         _region_api_base_url("https://api.example.com:8443/v1", "sea.example.com")
@@ -1290,7 +1291,7 @@ def test_an_override_swaps_only_the_host() -> None:
     )
 
 
-def test_azure_southeastasia_is_probed_at_its_own_public_name() -> None:
+def test_azure_australiaeast_is_probed_at_its_own_public_name() -> None:
     """The deploy script must carry the override, not just the connect host.
 
     Without it the probe is a false alarm generator, and a status page that
@@ -1301,8 +1302,8 @@ def test_azure_southeastasia_is_probed_at_its_own_public_name() -> None:
         _deploy_script_region_targets("scripts/deploy/azure_control_plane.sh")
     )
     by_name = {entry.name: entry for entry in entries}
-    assert "southeastasia" in by_name, "southeastasia is not configured at all"
-    assert by_name["southeastasia"].public_host == "api-azure-sea.trustedrouter.com"
+    assert "australiaeast" in by_name, "australiaeast is not configured at all"
+    assert by_name["australiaeast"].public_host == "api-azure-syd.trustedrouter.com"
     # uaenorth IS the canonical name, so it must NOT carry an override —
     # one would be a second place to keep the same hostname in sync.
     assert by_name["uaenorth"].public_host == ""
@@ -1322,7 +1323,7 @@ def test_every_azure_region_target_resolves_to_a_distinct_public_name() -> None:
 def test_an_empty_public_host_after_the_separator_is_rejected() -> None:
     """`region=host@` reads as an override and silently is not one."""
     with pytest.raises(ValueError, match="public host after '@' must not"):
-        parse_gateway_region_targets("southeastasia=host.example.com@")
+        parse_gateway_region_targets("australiaeast=host.example.com@")
 
 
 def test_the_probe_actually_uses_the_override() -> None:
@@ -1345,20 +1346,20 @@ def test_the_probe_actually_uses_the_override() -> None:
                 synthetic_regional_probes_enabled=False,
                 synthetic_gateway_region_targets=(
                     "uaenorth=quill-enclave-uaenorth.uaenorth.azurecontainer.io,"
-                    "southeastasia=quill-enclave-southeastasia.southeastasia.azurecontainer.io"
-                    "@api-azure-sea.trustedrouter.com"
+                    "australiaeast=quill-enclave-australiaeast.australiaeast.azurecontainer.io"
+                    "@api-azure-syd.trustedrouter.com"
                 ),
             )
         )
     }
 
-    assert targets["southeastasia"].api_base_url == (
-        "https://api-azure-sea.trustedrouter.com/v1"
-    ), "southeastasia is probed with a certificate name it does not hold"
+    assert targets["australiaeast"].api_base_url == (
+        "https://api-azure-syd.trustedrouter.com/v1"
+    ), "australiaeast is probed with a certificate name it does not hold"
     # ...while still DIALLING its own region, or one dead region could hide
     # behind whatever DNS happens to return for the shared name.
-    assert targets["southeastasia"].connect_host == (
-        "quill-enclave-southeastasia.southeastasia.azurecontainer.io"
+    assert targets["australiaeast"].connect_host == (
+        "quill-enclave-australiaeast.australiaeast.azurecontainer.io"
     )
     # uaenorth has no override and must keep the canonical name.
     assert targets["uaenorth"].api_base_url == "https://api-azure.trustedrouter.com/v1"

--- a/tests/test_trust_measurement_drift.py
+++ b/tests/test_trust_measurement_drift.py
@@ -46,7 +46,7 @@ THE REAL DEFECT
          comments naming it as the thing that would catch drift, in
          config.py:365 and trust.py:142.
       2. AZURE_ATTESTATION_URL was hardcoded to UAE North. Southeast Asia
-         serves api-azure-sea.trustedrouter.com under its own CCE policy and
+         serves api-azure-syd.trustedrouter.com under its own CCE policy and
          therefore its own hostdata, f3a0b4ed…d712d81c, which was published in
          accepted_hostdata and compared against nothing. Head to head on a
          fixture where Southeast Asia served a hostdata published nowhere, the
@@ -146,11 +146,11 @@ AWS_MODULE_B = "i-02e34e58761097671-enc01a004d7a9c3c307"
 AWS_CERT_DER = b"-----der-of-the-cert-this-connection-served-----"
 
 UAEN_HOSTDATA = "c55d492aaf98db95e60ac87c0d4a787e07d565b460380a6c16bfcc418d60b89e"
-SEA_HOSTDATA = "f3a0b4ed5b27c81ceded35a54ddeedf2795fb733b4ecc026f8597311d712d81c"
+SYD_HOSTDATA = "f3a0b4ed5b27c81ceded35a54ddeedf2795fb733b4ecc026f8597311d712d81c"
 UAEN_ISSUER = "https://trquilluaen.uaen.attest.azure.net"
-SEA_ISSUER = "https://trquillsea.sasia.attest.azure.net"
+SYD_ISSUER = "https://trquillsyd.eau.attest.azure.net"
 UAEN_URL = "https://api-azure.trustedrouter.com/attestation"
-SEA_URL = "https://api-azure-sea.trustedrouter.com/attestation"
+SYD_URL = "https://api-azure-syd.trustedrouter.com/attestation"
 
 
 # ---------------------------------------------------------------------------
@@ -240,8 +240,8 @@ def azure_record(**overrides: Any) -> dict[str, Any]:
     record = {
         "platform": "azure-confidential-containers-sev-snp",
         "hostdata": UAEN_HOSTDATA,
-        "accepted_hostdata": [UAEN_HOSTDATA, SEA_HOSTDATA],
-        "attestation_issuers": [UAEN_ISSUER, SEA_ISSUER],
+        "accepted_hostdata": [UAEN_HOSTDATA, SYD_HOSTDATA],
+        "attestation_issuers": [UAEN_ISSUER, SYD_ISSUER],
         "api_base_url": "https://api-azure.trustedrouter.com/v1",
         "regions": [
             {
@@ -250,9 +250,9 @@ def azure_record(**overrides: Any) -> dict[str, Any]:
                 "attestation_issuer": UAEN_ISSUER,
             },
             {
-                "attestation_url": SEA_URL,
-                "hostdata": SEA_HOSTDATA,
-                "attestation_issuer": SEA_ISSUER,
+                "attestation_url": SYD_URL,
+                "hostdata": SYD_HOSTDATA,
+                "attestation_issuer": SYD_ISSUER,
             },
         ],
     }
@@ -302,7 +302,7 @@ def whole_fleet(
     azure: dict[str, Any] | None = None,
     gcp_live: bytes | None = None,
     uaen_live: bytes | None = None,
-    sea_live: bytes | None = None,
+    syd_live: bytes | None = None,
     aws_live: Any = None,
 ) -> FakeTransport:
     """Every plane healthy and matching, unless a caller drifts one."""
@@ -318,7 +318,7 @@ def whole_fleet(
                 aws_live if aws_live is not None else aws_document()
             ),
             UAEN_URL: uaen_live or azure_token(UAEN_HOSTDATA, UAEN_ISSUER),
-            SEA_URL: sea_live or azure_token(SEA_HOSTDATA, SEA_ISSUER),
+            SYD_URL: syd_live or azure_token(SYD_HOSTDATA, SYD_ISSUER),
         }
     )
 
@@ -456,9 +456,9 @@ def test_every_enumerated_region_is_contacted() -> None:
     result = results_by_plane(transport)["azure"]
 
     assert UAEN_URL in transport.fetched
-    assert SEA_URL in transport.fetched, "the second region was never contacted"
+    assert SYD_URL in transport.fetched, "the second region was never contacted"
     assert result.ok
-    assert result.endpoints == (UAEN_URL, SEA_URL)
+    assert result.endpoints == (UAEN_URL, SYD_URL)
     # The success sentence is counted from the fetch list and the live tokens,
     # so it cannot describe more of the plane than answered.
     assert "2 endpoint(s) contacted, 2 distinct MAA issuer(s) presented" in result.detail
@@ -474,11 +474,11 @@ def test_second_region_drift_fails_even_though_the_first_is_clean() -> None:
     tampering.
     """
     drifted = "9c" * 32
-    transport = whole_fleet(sea_live=azure_token(drifted, SEA_ISSUER))
+    transport = whole_fleet(syd_live=azure_token(drifted, SYD_ISSUER))
     result = results_by_plane(transport)["azure"]
 
     assert not result.ok
-    assert SEA_URL in result.detail
+    assert SYD_URL in result.detail
     # ...and the region that is fine is not blamed for it.
     assert UAEN_URL not in result.detail
 
@@ -491,7 +491,7 @@ def test_a_region_serving_its_neighbours_policy_is_drift() -> None:
     CCE policy. The record attributes a hostdata to each region, so the check
     is per region.
     """
-    transport = whole_fleet(sea_live=azure_token(UAEN_HOSTDATA, SEA_ISSUER))
+    transport = whole_fleet(syd_live=azure_token(UAEN_HOSTDATA, SYD_ISSUER))
     result = results_by_plane(transport)["azure"]
 
     assert not result.ok
@@ -529,8 +529,8 @@ def test_a_serving_region_the_record_cannot_reach_is_a_gap_not_a_pass(
 
     assert code == 1
     assert "[GAP] azure" in out
-    assert SEA_ISSUER in out
-    assert SEA_URL not in transport.fetched, "the fixture must not accidentally cover the gap"
+    assert SYD_ISSUER in out
+    assert SYD_URL not in transport.fetched, "the fixture must not accidentally cover the gap"
 
 
 def test_a_mirror_that_drops_the_region_array_is_a_gap() -> None:
@@ -548,7 +548,7 @@ def test_a_mirror_that_drops_the_region_array_is_a_gap() -> None:
 
     assert result.gap
     assert result.endpoints == (UAEN_URL,)
-    assert result.unreached == (SEA_ISSUER,)
+    assert result.unreached == (SYD_ISSUER,)
 
 
 def test_a_single_region_record_without_a_region_array_is_not_a_gap() -> None:
@@ -578,7 +578,7 @@ def test_an_unlisted_live_issuer_is_still_reported() -> None:
     own bookkeeping.
     """
     transport = whole_fleet(
-        sea_live=azure_token(SEA_HOSTDATA, "https://trquillnew.westus.attest.azure.net")
+        syd_live=azure_token(SYD_HOSTDATA, "https://trquillnew.westus.attest.azure.net")
     )
     result = results_by_plane(transport)["azure"]
 
@@ -749,7 +749,7 @@ def test_one_unpublished_plane_does_not_stop_the_others_being_checked() -> None:
 
     assert results["aws"].skipped
     assert results["gcp"].ok and results["azure"].ok
-    assert UAEN_URL in transport.fetched and SEA_URL in transport.fetched
+    assert UAEN_URL in transport.fetched and SYD_URL in transport.fetched
 
 
 # ---------------------------------------------------------------------------
@@ -798,14 +798,14 @@ def test_an_unreached_issuer_is_named_by_evidence_not_by_list_position() -> None
     same class of output this file exists to remove. Coverage is now attributed
     from the issuers the contacted endpoints presented live.
     """
-    record = azure_record(attestation_issuers=[SEA_ISSUER, UAEN_ISSUER])
+    record = azure_record(attestation_issuers=[SYD_ISSUER, UAEN_ISSUER])
     record.pop("regions")
     transport = whole_fleet(azure=record)
     result = drift.check_azure(CONTROL_PLANE, transport)
 
     assert result.gap
     assert result.endpoints == (UAEN_URL,), "UAE North is the endpoint that answered"
-    assert result.unreached == (SEA_ISSUER,), "the issuer that answered must not be blamed"
+    assert result.unreached == (SYD_ISSUER,), "the issuer that answered must not be blamed"
     assert UAEN_ISSUER not in "".join(result.unreached)
     # And the sentence carrying that verdict counts what ANSWERED, not what the
     # record listed: two issuers are published here and one was presented. A
@@ -837,7 +837,7 @@ def test_coverage_does_not_hang_on_the_optional_issuer_list(
     assert code == 1
     assert "[GAP] azure" in out
     assert "no attestation_issuers" in out
-    assert SEA_URL not in transport.fetched, "the fixture must not accidentally cover the gap"
+    assert SYD_URL not in transport.fetched, "the fixture must not accidentally cover the gap"
     assert "Every published measurement" not in out
 
 
@@ -875,7 +875,7 @@ def test_two_region_entries_at_one_endpoint_are_not_two_regions_covered(
     assert "[GAP] azure" in out
     assert "more than once" in out
     assert "azure (1)" in out, "one endpoint answered, so the summary must count one"
-    assert SEA_URL not in transport.fetched
+    assert SYD_URL not in transport.fetched
 
 
 def test_a_record_with_one_issuer_and_two_policies_and_no_endpoints_is_a_gap() -> None:
@@ -917,7 +917,7 @@ def test_two_endpoints_differing_only_by_fragment_are_one_endpoint() -> None:
                 "attestation_issuer": UAEN_ISSUER,
             },
             {
-                "attestation_url": UAEN_URL + "?region=sea",
+                "attestation_url": UAEN_URL + "?region=syd",
                 "hostdata": UAEN_HOSTDATA,
                 "attestation_issuer": UAEN_ISSUER,
             },
@@ -964,8 +964,8 @@ def test_a_gap_alongside_drift_is_still_reported_under_the_drift_mark(
 
     assert code == 1
     assert "[DRIFT] azure" in out
-    assert SEA_ISSUER in out, "the coverage gap must survive the more serious verdict"
-    assert "Not reached: azure " + SEA_ISSUER in out
+    assert SYD_ISSUER in out, "the coverage gap must survive the more serious verdict"
+    assert "Not reached: azure " + SYD_ISSUER in out
 
 
 def test_an_explicit_null_regions_key_is_not_read_as_an_absent_one(httpx_mock: Any) -> None:
@@ -993,9 +993,9 @@ def test_a_region_entry_naming_no_hostdata_cannot_be_attributed_and_is_a_gap() -
         regions=[
             {"attestation_url": UAEN_URL, "attestation_issuer": UAEN_ISSUER},
             {
-                "attestation_url": SEA_URL,
-                "hostdata": SEA_HOSTDATA,
-                "attestation_issuer": SEA_ISSUER,
+                "attestation_url": SYD_URL,
+                "hostdata": SYD_HOSTDATA,
+                "attestation_issuer": SYD_ISSUER,
             },
         ]
     )
@@ -1003,7 +1003,7 @@ def test_a_region_entry_naming_no_hostdata_cannot_be_attributed_and_is_a_gap() -
 
     assert result.gap
     assert "names no hostdata" in result.detail
-    assert result.endpoints == (UAEN_URL, SEA_URL), "both were still contacted"
+    assert result.endpoints == (UAEN_URL, SYD_URL), "both were still contacted"
 
 
 def test_a_regions_entry_with_no_attestation_url_is_a_gap_on_its_own() -> None:
@@ -1046,7 +1046,7 @@ def test_a_regions_entry_that_names_no_reachable_place_is_a_gap_and_is_not_fetch
     FETCHING one would let whoever writes the record aim the hourly job. It is
     reported and skipped. Isolated like the rule above so nothing props it up.
     """
-    hostile = "https://someone@api-azure-sea.trustedrouter.com/attestation"
+    hostile = "https://someone@api-azure-syd.trustedrouter.com/attestation"
     record = azure_record(
         accepted_hostdata=[UAEN_HOSTDATA],
         attestation_issuers=[UAEN_ISSUER],
@@ -1087,13 +1087,13 @@ def test_the_endpoint_the_record_advertises_is_contacted_even_when_regions_omits
     endpoint is contacted and the drift is caught.
     """
     record = azure_record(
-        accepted_hostdata=[SEA_HOSTDATA],
-        attestation_issuers=[SEA_ISSUER],
+        accepted_hostdata=[SYD_HOSTDATA],
+        attestation_issuers=[SYD_ISSUER],
         regions=[
             {
-                "attestation_url": SEA_URL,
-                "hostdata": SEA_HOSTDATA,
-                "attestation_issuer": SEA_ISSUER,
+                "attestation_url": SYD_URL,
+                "hostdata": SYD_HOSTDATA,
+                "attestation_issuer": SYD_ISSUER,
             }
         ],
     )
@@ -1120,9 +1120,9 @@ def test_an_advertised_endpoint_missing_from_the_region_census_is_a_gap_even_whe
     record = azure_record(
         regions=[
             {
-                "attestation_url": SEA_URL,
-                "hostdata": SEA_HOSTDATA,
-                "attestation_issuer": SEA_ISSUER,
+                "attestation_url": SYD_URL,
+                "hostdata": SYD_HOSTDATA,
+                "attestation_issuer": SYD_ISSUER,
             }
         ],
     )
@@ -1131,7 +1131,7 @@ def test_an_advertised_endpoint_missing_from_the_region_census_is_a_gap_even_whe
     assert result.gap
     assert "1 coverage gap(s)" in result.detail
     assert "api_base_url advertises" in result.detail
-    assert set(result.endpoints) == {SEA_URL, UAEN_URL}
+    assert set(result.endpoints) == {SYD_URL, UAEN_URL}
     assert result.unreached == (), "both published issuers answered; this is the other rule"
 
 
@@ -1203,15 +1203,15 @@ def test_the_serving_route_carries_the_region_array_and_the_check_covers_both_re
     served = _served_azure_record(azure_record(), httpx_mock)
 
     assert served["status_code"] == 200
-    assert [region["attestation_url"] for region in served["regions"]] == [UAEN_URL, SEA_URL]
-    assert served["regions"][1]["hostdata"] == SEA_HOSTDATA
+    assert [region["attestation_url"] for region in served["regions"]] == [UAEN_URL, SYD_URL]
+    assert served["regions"][1]["hostdata"] == SYD_HOSTDATA
 
     transport = whole_fleet(azure=served)
     code = drift.main(["--control-plane", CONTROL_PLANE, "--strict"], transport=transport)
     out = capsys.readouterr().out
 
     assert code == 0
-    assert SEA_URL in transport.fetched, "the served record did not reach the second region"
+    assert SYD_URL in transport.fetched, "the served record did not reach the second region"
     assert "Checked 3 plane(s) at 4 endpoint(s): gcp (1), aws (1), azure (2)" in out
 
 
@@ -1470,7 +1470,7 @@ ENDPOINT_TWINS = [
 #: `port = None`, so that every port folds away, left this file green.
 ENDPOINT_DISTINCTS = [
     (UAEN_URL, "https://api-azure.trustedrouter.com:8443/attestation"),
-    (UAEN_URL, "https://api-azure-sea.trustedrouter.com/attestation"),
+    (UAEN_URL, "https://api-azure-syd.trustedrouter.com/attestation"),
     (UAEN_URL, "https://api-azure.trustedrouter.com/attestation/uaen"),
     (UAEN_URL, "https://api-azure.trustedrouter.com/Attestation"),
     (UAEN_URL, "http://api-azure.trustedrouter.com/attestation"),

--- a/tests/test_trust_release.py
+++ b/tests/test_trust_release.py
@@ -641,16 +641,16 @@ def test_a_poisoned_upstream_record_is_rejected_not_republished(
 def test_azure_mirror_requires_an_issuer_and_carries_every_region(
     httpx_mock: HTTPXMock,
 ) -> None:
-    uaen, sea = "44" * 32, "26" * 32
+    uaen, syd = "44" * 32, "26" * 32
     httpx_mock.add_response(
         url=re.compile(r"https://trust\.example/azure\.json\?tr_cache_bucket=\d+"),
         json={
             "platform": "azure-confidential-containers-sev-snp",
             "hostdata": uaen,
-            "accepted_hostdata": [uaen, sea],
+            "accepted_hostdata": [uaen, syd],
             "attestation_issuers": [
                 "https://trquilluaen.uaen.attest.azure.net",
-                "https://trquillsea.sasia.attest.azure.net",
+                "https://trquillsyd.eau.attest.azure.net",
             ],
             "regions": [
                 {
@@ -659,9 +659,9 @@ def test_azure_mirror_requires_an_issuer_and_carries_every_region(
                     "attestation_issuer": "https://trquilluaen.uaen.attest.azure.net",
                 },
                 {
-                    "attestation_url": "https://api-azure-sea.trustedrouter.com/attestation",
-                    "hostdata": sea,
-                    "attestation_issuer": "https://trquillsea.sasia.attest.azure.net",
+                    "attestation_url": "https://api-azure-syd.trustedrouter.com/attestation",
+                    "hostdata": syd,
+                    "attestation_issuer": "https://trquillsyd.eau.attest.azure.net",
                 },
             ],
         },
@@ -675,7 +675,7 @@ def test_azure_mirror_requires_an_issuer_and_carries_every_region(
     # Both regions run different CCE policies, so both hostdata values are
     # permanently correct. Dropping either makes a verifier routed to that
     # region conclude tampering.
-    assert record["accepted_hostdata"] == [uaen, sea]
+    assert record["accepted_hostdata"] == [uaen, syd]
     assert len(record["attestation_issuers"]) == 2
     # ...and WHERE each of them answers has to survive the trip too. This
     # assertion used to be absent while the test's name promised it: the
@@ -683,9 +683,9 @@ def test_azure_mirror_requires_an_issuer_and_carries_every_region(
     # trust.azure_release and the drift check had one endpoint to enumerate.
     assert [region["attestation_url"] for region in record["regions"]] == [
         "https://api-azure.trustedrouter.com/attestation",
-        "https://api-azure-sea.trustedrouter.com/attestation",
+        "https://api-azure-syd.trustedrouter.com/attestation",
     ]
-    assert record["regions"][1]["hostdata"] == sea
+    assert record["regions"][1]["hostdata"] == syd
 
 
 def test_azure_record_without_an_issuer_is_rejected(httpx_mock: HTTPXMock) -> None:


### PR DESCRIPTION
`australiaeast` becomes Azure's second enclave region, replacing `southeastasia`.

## Both blocking properties were proved by provisioning, not by reading a docs list

Neither is discoverable. The ContainerInstance capabilities API reports **nothing** about the Confidential SKU — it returns identical shapes for a region running one and a region that is not — so the check was to actually create a SEV-SNP container group in Sydney with a genuine CCE policy. It reached `Running`, and was deleted.

| | |
|---|---|
| Confidential ACI in `australiaeast` | provisioned `Running`, then torn down |
| MAA in `australiaeast` | `trquillsyd.eau.attest.azure.net`, Ready |
| Sydney CCE policy | hostdata `fa903243…`, pins `australiaeast`/`api-azure-syd`/`trquillsyd`, zero Dubai or Singapore values |

Sydney is also better on the merits: it already hosts a full second Azure control plane (`tr-canary-apac` + its Postgres flexible server), `Standard_E2bs_v5` is available where `southeastasia` returns `NotAvailableForSubscription`, and it is $130/mo against `southeastasia`'s only option at $234/mo.

Confidential-VM quota is a red herring in that comparison: these enclaves are **Confidential ACI**, a different service with different regional availability from the DCADSv5 VM family that governs confidential *VMs*.

## Two places this is deliberately *not* a mechanical rename

- The **2026-08-07 SNI reproduction** in `test_per_enclave_probes.py` keeps naming `southeastasia`. It records something that actually happened in that region; rewriting it to say `australiaeast` would assert a live observation of a region that had not been deployed. Same for the region that was unaffected during the `uaenorth` Let's Encrypt rate-limit window.
- **HANDOFF 4.8's provisioned values are Sydney's own**, measured 2026-08-21 — resource group, principal id, client id — not Singapore's carried across. A per-region managed identity has a different principal, so inheriting one would have pointed every future SKR investigation at the wrong object.

## Gates

```
ruff    All checks passed!
mypy    Success: no issues found in 287 source files
pytest  5044 passed, 301 skipped, 10 xfailed
        233 passed (the four affected test files, after the corrections above)
```

## Scope

This lands the **code only**. `southeastasia` is serving at the time of writing (enclave `Running`, `/health` 200), so its Azure resources and its SKR release-policy entry are retired **separately, after `australiaeast` is verified serving** — widen first, narrow only against a live attestation.

The four IAM grants Sydney needs are declared as terraform in quill-cloud-proxy `tools/azure-enclave/` (already on main there). They exclude **Key Vault Crypto Officer**, which `uaenorth`'s identity holds and which lets a workload rewrite the release policy that constrains it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)