### PR TITLE
Shard exact API key spend caps

### DIFF
--- a/docs/design/key-usage-row-sharding.md
+++ b/docs/design/key-usage-row-sharding.md
@@ -11,14 +11,22 @@ shape: sharded authorization completed, then unsharded settlement exhausted the
 fake Spanner retry budget on the one API-key row.
 
 The table and reservation schema already support `(key_hash, shard)` and
-`key_shard`. We use those fields to spread usage writes for high-throughput,
-keys without an exact lifetime cap.
+`key_shard`. We use those fields to spread both usage writes and exact-cap
+reservations for high-throughput keys.
 
 ## Scope and hard safety boundary
 
-`ApiKey.usage_shard_count` defaults to 1. A value above 1 is invalid when an
-exact lifetime spend limit is configured. That cap reserves headroom inside the
-same transaction and therefore remains byte-identical on shard zero.
+`ApiKey.usage_shard_count` defaults to 1. An exact lifetime limit is partitioned
+into escrow sub-budgets: each row receives its consumed amount plus a share of
+the remaining allowance, and all row limits sum to the configured global cap.
+Authorize reserves from one sub-budget in its existing atomic transaction. No
+distribution of requests can spend more than the global limit.
+
+An unusually large request can exceed every individual sub-budget while still
+fitting within the global remaining allowance. Only after all shards reject,
+the cold path atomically reads every shard and moves enough escrow to the first
+randomized candidate, then retries authorize once. Genuine exhaustion does not
+write or retry. Normal requests never pay this global coordination cost.
 
 Daily, weekly, and monthly limits are already approximate, lock-free snapshot
 checks. For sharded keys, the check reads the configured shard set and sums the
@@ -33,8 +41,9 @@ partitioned lifetime budget.
    typed authorize path. There is no extra hot-path database read.
 2. TrustedRouter randomizes all key usage shards outside the Spanner retry
    callback.
-3. A row without a lifetime cap returns `KEY_NO_HOLD`; authorize records the
-   selected `key_shard` on `tr_reservation`.
+3. An uncapped row returns `KEY_NO_HOLD`; a capped row conditionally reserves
+   from its escrow sub-budget. Authorize records the selected `key_shard` on
+   `tr_reservation` in both cases.
 4. Settle/refund books against exactly that recorded row.
 5. Idempotent replay returns the originally committed key shard.
 
@@ -54,9 +63,10 @@ python scripts/shard_workspace.py finish --workspace WS --shards 16 --apply
 Prepare pauses the workspace, refuses open typed or legacy requests, atomically
 partitions each ledger, verifies it, runs the invariant audit, and leaves the
 workspace paused. Finish re-verifies credit and key row sets before unpausing.
-Keys with an exact lifetime cap stay at one row. Reverse with `--shards 1`
-before any typed-to-JSON rollback or shard-zero repair; those older tools now
-refuse sharded state.
+Exact lifetime limits are repartitioned in the same transaction as the usage
+rows, including when open typed holds are preserved during an online split.
+Reverse with `--shards 1` before any typed-to-JSON rollback or shard-zero
+repair; those older tools refuse sharded state.
 
 The operator retains legacy reservation rows for audit but does not let
 pre-cutover debris block typed-ledger maintenance forever. Unsettled legacy

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -791,10 +791,14 @@ regressed, not just contention.
    Also inspect the `tr_key_limit` / `tr_credit_balance` shard rows for
    reserved/usage on the named `<key_hash>` and `<workspace_id>`.
 
-4. Bursts self-resolve when the tenant's spike ends. Receipt: the 2026-07-04
-   22:26-22:33 UTC burst was a single tenant and ended with zero intervention.
-   Client impact is a handful of 500s the enclave retries. Do NOT restart
-   services or roll back deploys for this signature.
+4. Stop any in-progress rollout and measure the full customer-facing burst.
+   Do not assume the enclave absorbed it. Receipt: on 2026-08-20 one capped
+   key generated a shard-zero retry storm with 1,667 billing-path 503s across
+   four regions in 18 minutes even though Cloud Run readiness stayed green.
+   Restarting Cloud Run does not repair a hot Spanner row. Rollback only when
+   the regional billing gate ties failures to a new revision; otherwise move
+   directly to the guarded online split and verify the affected customer's
+   subsequent authorize/settle results.
 
 Structural fix if a tenant does this chronically: **shard spreading is now
 operable** (as of the 2026-07 credit/key row-sharding work). A hot workspace's
@@ -804,10 +808,12 @@ operator (`.github/workflows/reshard-billing-workspace.yml` →
 unpause; requires an explicit `--apply`). The authorize reject path also does a
 lock-free precheck + bounded repair so no-move verdicts no longer take
 whole-shard-set write locks. Do NOT hand-set shard columns; always go through
-the operator. Before activating spreading on any workspace, confirm the
-credit-shard rebalance fix is deployed (a negative per-shard headroom from an
-overage settle must return a clean 402, never a `_RebalanceInvariantError`
-500 — fixed 2026-07).
+the operator. Exact lifetime key caps are escrowed across those rows while
+retaining the precise global limit; a large fragmented hold uses one atomic
+cold-path rebalance. Before activating spreading on any workspace, confirm the
+credit-shard rebalance and exact-cap escrow fixes are deployed. A negative
+per-shard headroom from an overage settle must return a clean 402, never a
+`_RebalanceInvariantError` 500.
 
 ---
 
@@ -915,14 +921,13 @@ Dispatch `operation: status` for a read-only look via the workflow.
 verification that is the entire point of the two-phase design, and a workspace
 serving on an unverified shard set can under-count spend across sub-ledgers.
 
-Two things that look like this but are not: the workflow serializes on
+One thing that looks like this but is not: the workflow serializes on
 `concurrency: production-billing-workspace-reshard`, so a second dispatch waits
 rather than racing a half-finished workspace — a queued run is expected, not a
-symptom. And a key with an exact lifetime cap (`limit_microdollars` set) is
-pinned to `usage_shards=1` by design, so it correctly reports
-`current_shards=1 target_shards=1 at_target=True` even when the workspace target
-is 16 — that is not a failure. (`prepare` prints
-`exact lifetime cap; keeping usage_shards=1` for such a key; `status` does not.)
+symptom. Exact lifetime caps no longer pin a key to shard zero: the operator
+partitions the cap into escrow sub-budgets whose sum remains the configured
+limit. A capped key that still reports one shard after a 16-shard operation is
+therefore incomplete and must not be unpaused by hand.
 
 ---
 

--- a/scripts/shard_workspace.py
+++ b/scripts/shard_workspace.py
@@ -16,10 +16,10 @@ silently resume billing:
   python scripts/shard_workspace.py online-split --workspace WS --shards 16 \
     --preserve-open-holds --apply
 
-Eligible API-key usage rows are split to the same count; keys with an exact
-lifetime cap remain on one row. Approximate daily/weekly/monthly windows sum
-usage across the configured rows. Reverse with the same commands and
-``--shards 1``.
+Every API-key usage row is split to the same count. Exact lifetime caps are
+partitioned into escrow sub-budgets whose sum remains the configured cap;
+approximate daily/weekly/monthly windows sum usage across the configured rows.
+Reverse with the same commands and ``--shards 1``.
 Without ``--apply`` every command is read-only. A failed prepare/finish always
 leaves the workspace paused.
 """
@@ -117,7 +117,8 @@ def _print_key_status(status: KeyUsageReshardResult) -> None:
 
 
 def _key_target(key: ApiKey, requested_shards: int) -> int:
-    return 1 if key.limit_microdollars is not None else requested_shards
+    _ = key
+    return requested_shards
 
 
 def _prepare_keys(
@@ -130,10 +131,6 @@ def _prepare_keys(
     clean = True
     for key in store.api_keys.list_for_workspace(workspace_id):
         target = _key_target(key, requested_shards)
-        if target != requested_shards:
-            print(
-                f"  key {key.hash}: exact lifetime cap; keeping usage_shards=1"
-            )
         status = reshard_key_usage(
             store,
             key.hash,

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -1234,14 +1234,10 @@ class SpannerBigtableStore:
         budget_alert_only: bool = False,
         tags: dict[str, str] | None = None,
     ) -> tuple[str, ApiKey]:
-        # Keep new uncapped keys at the workspace's established write scale.
-        # Falling back to one usage row after a workspace has been resharded
-        # recreates a hot key-limit row under otherwise shard-safe traffic.
-        # Exact lifetime limits deliberately remain single-row so authorize
-        # can reserve against the cap atomically.
-        usage_shard_count = (
-            1 if limit_microdollars is not None else self._credit_shard_count(workspace_id)
-        )
+        # Keep every new key at the workspace's established write scale.
+        # Lifetime limits use escrowed per-shard sub-budgets, so retaining an
+        # exact cap no longer requires recreating a single hot key-limit row.
+        usage_shard_count = self._credit_shard_count(workspace_id)
         return self.api_keys.create(
             workspace_id=workspace_id,
             name=name,
@@ -2811,6 +2807,23 @@ class SpannerBigtableStore:
             )
 
         result = run_authorize(credit_shard_candidates)
+        if (
+            result["outcome"] == AuthorizeOutcome.KEY_LIMIT_EXCEEDED
+            and key_counter_shards > 1
+        ):
+            from trusted_router.storage_gcp_key_escrow import (
+                rebalance_key_limit_headroom,
+            )
+
+            if rebalance_key_limit_headroom(
+                self._database,
+                self._param_types,
+                key_hash=key_hash,
+                shard_count=key_counter_shards,
+                estimate=estimate,
+                preferred_shard=key_shard_candidates[0],
+            ):
+                result = run_authorize(credit_shard_candidates)
         if result["outcome"] == AuthorizeOutcome.INSUFFICIENT_CREDITS and has_credit_candidate:
             from trusted_router import storage_gcp_credit_rebalance as rebalance_mod
 

--- a/src/trusted_router/storage_gcp_counters.py
+++ b/src/trusted_router/storage_gcp_counters.py
@@ -1,14 +1,14 @@
 """Typed-counter table constants and creation-time row builders.
 
 The retired JSON-to-typed mirror used these builders for every credit/api_key
-entity write. C2a keeps the builders but makes seeding explicit: callers may use
-them only while creating a new credit/api_key entity, never while updating
-metadata on an existing entity. After creation, the typed conditional-DML paths
-own money/usage state.
+entity write. C2a keeps creation seeding explicit; API-key limit edits also use
+the config-only builder with strongly-read counters so escrowed lifetime limits
+can be repartitioned without touching money/usage state.
 """
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any
 
 CREDIT_BALANCE_TABLE = "tr_credit_balance"
@@ -73,10 +73,9 @@ def credit_shard_count(value: Any) -> int:
 def key_usage_shard_count(value: Any) -> int:
     """Return and validate an API key's usage-counter shard count.
 
-    An exact lifetime spend limit must remain on one row because authorize
-    reserves against that row atomically. Daily/weekly/monthly limits are
-    intentionally approximate snapshot checks; their usage can be summed over
-    shards without changing that contract.
+    Exact lifetime limits use escrowed per-shard sub-budgets whose sum is the
+    configured limit. Daily/weekly/monthly limits remain approximate snapshot
+    checks whose usage is summed over every shard.
     """
     raw = _field(value, "usage_shard_count", 1)
     if isinstance(raw, bool):
@@ -87,10 +86,6 @@ def key_usage_shard_count(value: Any) -> int:
     if count > MAX_KEY_USAGE_SHARDS:
         raise ValueError(
             f"key usage_shard_count must not exceed {MAX_KEY_USAGE_SHARDS}"
-        )
-    if count > 1 and _field(value, "limit_microdollars", None) is not None:
-        raise ValueError(
-            "API keys with an exact lifetime limit must use one usage shard"
         )
     return count
 
@@ -104,6 +99,74 @@ def distribute_credit_amount(amount: int, shard_count: int) -> tuple[int, ...]:
     values = [sign * per_shard for _ in range(shard_count)]
     values[UNSHARDED] += sign * remainder
     return tuple(values)
+
+
+def partition_key_limit(
+    limit_micro: int | None,
+    *,
+    usage_parts: Sequence[int],
+    byok_usage_parts: Sequence[int],
+    reserved_parts: Sequence[int],
+    include_byok: bool,
+) -> tuple[int | None, ...]:
+    """Partition an exact key cap into independent escrow sub-budgets.
+
+    Every shard receives its already-consumed amount plus a share of remaining
+    headroom. Therefore the row limits always sum to ``limit_micro`` and no
+    distribution of future reservations can exceed the global cap. When a cap
+    is lowered below current consumption, every shard is left with non-positive
+    headroom so new reservations fail closed while existing holds can settle.
+    """
+    shard_count = len(usage_parts)
+    if shard_count < 1:
+        raise ValueError("key limit partition requires at least one shard")
+    if len(byok_usage_parts) != shard_count or len(reserved_parts) != shard_count:
+        raise ValueError("key limit partition inputs must have equal lengths")
+    if limit_micro is None:
+        return (None,) * shard_count
+    limit = int(limit_micro)
+    if limit < 0:
+        raise ValueError("key lifetime limit must not be negative")
+
+    consumed: list[int] = []
+    for usage, byok_usage, reserved in zip(
+        usage_parts,
+        byok_usage_parts,
+        reserved_parts,
+        strict=True,
+    ):
+        values = (int(usage), int(byok_usage), int(reserved))
+        if any(value < 0 for value in values):
+            raise ValueError("key limit partition counters must not be negative")
+        consumed.append(values[0] + (values[1] if include_byok else 0) + values[2])
+
+    remaining = limit - sum(consumed)
+    if remaining >= 0:
+        headroom = distribute_credit_amount(remaining, shard_count)
+        return tuple(
+            current + extra
+            for current, extra in zip(consumed, headroom, strict=True)
+        )
+
+    # The cap was reduced below spend already booked or held. Subtract the
+    # deficit from consumed allocations without creating headroom on any row.
+    # Settlement does not require limit >= consumption, so existing holds can
+    # still close while every new reserve is rejected.
+    allocations = list(consumed)
+    deficit = -remaining
+    for shard in sorted(
+        range(shard_count),
+        key=lambda index: (allocations[index], -index),
+        reverse=True,
+    ):
+        reduction = min(allocations[shard], deficit)
+        allocations[shard] -= reduction
+        deficit -= reduction
+        if deficit == 0:
+            break
+    if deficit != 0:  # pragma: no cover - limit>=0 makes this unreachable
+        raise AssertionError("key limit partition deficit was not exhausted")
+    return tuple(allocations)
 
 
 def credit_balance_mirror_row(workspace_id: str, total_micro: int, commit_ts: Any) -> tuple:
@@ -148,8 +211,40 @@ def key_limit_mirror_row(key_hash: str, value: Any, commit_ts: Any) -> tuple:
     )
 
 
-def key_limit_mirror_rows(key_hash: str, value: Any, commit_ts: Any) -> list[tuple]:
-    """Build initial config rows for every active usage shard."""
+def key_limit_mirror_rows(
+    key_hash: str,
+    value: Any,
+    commit_ts: Any,
+    *,
+    usage_rows: Sequence[Sequence[int]] | None = None,
+) -> list[tuple]:
+    """Build config rows for every active usage shard.
+
+    Creation supplies no usage rows and starts every counter at zero. A config
+    update supplies the strongly-read ``(shard, usage, byok_usage, reserved)``
+    rows so an exact cap can be repartitioned without minting headroom.
+    """
     shard_count = key_usage_shard_count(value)
     base = key_limit_mirror_row(key_hash, value, commit_ts)
-    return [base[:1] + (shard,) + base[2:] for shard in range(shard_count)]
+    if usage_rows is None:
+        usage_parts = [0] * shard_count
+        byok_usage_parts = [0] * shard_count
+        reserved_parts = [0] * shard_count
+    else:
+        ordered = sorted(usage_rows, key=lambda row: int(row[0]))
+        if [int(row[0]) for row in ordered] != list(range(shard_count)):
+            raise RuntimeError("configured tr_key_limit usage shard set is incomplete")
+        usage_parts = [int(row[1]) for row in ordered]
+        byok_usage_parts = [int(row[2]) for row in ordered]
+        reserved_parts = [int(row[3]) for row in ordered]
+    limits = partition_key_limit(
+        _field(value, "limit_microdollars", None),
+        usage_parts=usage_parts,
+        byok_usage_parts=byok_usage_parts,
+        reserved_parts=reserved_parts,
+        include_byok=bool(_field(value, "include_byok_in_limit", True)),
+    )
+    return [
+        base[:1] + (shard, limits[shard]) + base[3:]
+        for shard in range(shard_count)
+    ]

--- a/src/trusted_router/storage_gcp_key_escrow.py
+++ b/src/trusted_router/storage_gcp_key_escrow.py
@@ -1,0 +1,89 @@
+"""Cold-path escrow maintenance for exact API-key lifetime limits."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from trusted_router.storage_gcp_counters import (
+    KEY_LIMIT_TABLE,
+    distribute_credit_amount,
+)
+from trusted_router.storage_gcp_io import run_in_transaction_with_retry
+
+
+def rebalance_key_limit_headroom(
+    database: Any,
+    param_types: Any,
+    *,
+    key_hash: str,
+    shard_count: int,
+    estimate: int,
+    preferred_shard: int,
+) -> bool:
+    """Give one shard enough escrow for a large otherwise-affordable hold.
+
+    The accepted hot path never calls this function. It runs only after every
+    shard rejected an exact-cap reservation, which can mean either genuine
+    exhaustion or harmless escrow fragmentation. One transaction strongly
+    reads every shard, proves the global remaining allowance, and moves that
+    allowance without changing the sum of row limits.
+    """
+    if shard_count < 2:
+        return False
+    if preferred_shard < 0 or preferred_shard >= shard_count:
+        raise ValueError("preferred key escrow shard is outside the configured set")
+    required = int(estimate)
+    if required <= 0:
+        return False
+    pt = param_types
+
+    def txn(transaction: Any) -> bool:
+        rows = list(
+            transaction.execute_sql(
+                "SELECT shard, limit_micro, usage, byok_usage, reserved, include_byok "
+                "FROM tr_key_limit WHERE key_hash=@kh AND shard>=0 "
+                "AND shard<@shard_count ORDER BY shard",
+                params={"kh": key_hash, "shard_count": shard_count},
+                param_types={"kh": pt.STRING, "shard_count": pt.INT64},
+            )
+        )
+        if [int(row[0]) for row in rows] != list(range(shard_count)):
+            raise RuntimeError("configured tr_key_limit usage shard set is incomplete")
+        if any(row[1] is None for row in rows):
+            return False  # uncapped or inconsistent config; no exact escrow to move
+        include_values = {bool(row[5]) for row in rows}
+        if len(include_values) != 1:
+            raise RuntimeError("configured tr_key_limit include_byok values are inconsistent")
+        include_byok = include_values.pop()
+        counters = [
+            (int(row[2]), int(row[3]), int(row[4]))
+            for row in rows
+        ]
+        if any(value < 0 for current in counters for value in current):
+            raise RuntimeError("key escrow counters must not be negative")
+        consumed = [
+            usage + (byok_usage if include_byok else 0) + reserved
+            for usage, byok_usage, reserved in counters
+        ]
+        global_limit = sum(int(row[1]) for row in rows)
+        remaining = global_limit - sum(consumed)
+        if remaining < required:
+            return False
+
+        headroom = list(distribute_credit_amount(remaining - required, shard_count))
+        headroom[preferred_shard] += required
+        limits = [
+            current + extra
+            for current, extra in zip(consumed, headroom, strict=True)
+        ]
+        transaction.insert_or_update(
+            table=KEY_LIMIT_TABLE,
+            columns=("key_hash", "shard", "limit_micro"),
+            values=[
+                (key_hash, shard, limits[shard])
+                for shard in range(shard_count)
+            ],
+        )
+        return True
+
+    return bool(run_in_transaction_with_retry(database, txn))

--- a/src/trusted_router/storage_gcp_key_shard_admin.py
+++ b/src/trusted_router/storage_gcp_key_shard_admin.py
@@ -16,6 +16,7 @@ from trusted_router.storage_gcp_counters import (
     KEY_LIMIT_TABLE,
     distribute_credit_amount,
     key_usage_shard_count,
+    partition_key_limit,
 )
 from trusted_router.storage_gcp_legacy_reservations import (
     legacy_reservation_snapshot,
@@ -152,11 +153,6 @@ def inspect_key_usage_reshard(
         result.reasons.append("workspace not found")
     elif not workspace.billing_paused:
         result.reasons.append("workspace not billing-paused")
-    if target_count > 1 and key.limit_microdollars is not None:
-        result.reasons.append(
-            "API key with an exact lifetime limit must remain on one usage shard"
-        )
-
     try:
         current_count = key_usage_shard_count(key)
     except ValueError as exc:
@@ -237,8 +233,6 @@ def reshard_key_usage(
             Workspace,
         )
         if workspace is None or not workspace.billing_paused:
-            return None
-        if target_count > 1 and key.limit_microdollars is not None:
             return None
         current_count = key_usage_shard_count(key)
         rows = list(
@@ -321,6 +315,13 @@ def reshard_key_usage(
             day_parts = list(distribute_credit_amount(day_usage, target_count))
             week_parts = list(distribute_credit_amount(week_usage, target_count))
             month_parts = list(distribute_credit_amount(month_usage, target_count))
+        limit_parts = partition_key_limit(
+            key.limit_microdollars,
+            usage_parts=usage_parts,
+            byok_usage_parts=byok_parts,
+            reserved_parts=reserved_parts,
+            include_byok=key.include_byok_in_limit,
+        )
         commit_timestamp = store._spanner.COMMIT_TIMESTAMP
         transaction.insert_or_update(
             table=KEY_LIMIT_TABLE,
@@ -329,7 +330,7 @@ def reshard_key_usage(
                 (
                     key_hash,
                     shard,
-                    key.limit_microdollars,
+                    limit_parts[shard],
                     usage_parts[shard],
                     byok_parts[shard],
                     reserved_parts[shard],

--- a/src/trusted_router/storage_gcp_keys.py
+++ b/src/trusted_router/storage_gcp_keys.py
@@ -29,6 +29,7 @@ from trusted_router.storage_gcp_counters import (
     KEY_LIMIT_COLUMNS,
     KEY_LIMIT_TABLE,
     key_limit_mirror_rows,
+    key_usage_shard_count,
 )
 from trusted_router.storage_gcp_io import SpannerIO, run_in_transaction_with_retry
 from trusted_router.storage_key_usage import api_key_from_json, api_key_usage_snapshot
@@ -75,6 +76,46 @@ _CONSOLE_API_KEYS_SQL = """
              key_record.id,
              key_limit.shard
 """
+
+_TYPED_LIMIT_PATCH_FIELDS = frozenset(
+    {
+        "limit",
+        "limit_microdollars",
+        "limit_daily_microdollars",
+        "limit_weekly_microdollars",
+        "limit_monthly_microdollars",
+        "include_byok_in_limit",
+    }
+)
+
+
+def _apply_key_patch(key: ApiKey, patch: dict[str, Any]) -> None:
+    if "name" in patch and patch["name"]:
+        key.name = str(patch["name"])
+    if "disabled" in patch:
+        key.disabled = bool(patch["disabled"])
+    if "limit" in patch:
+        value = patch["limit"]
+        key.limit_microdollars = (
+            None if value is None else dollars_to_microdollars(value)
+        )
+    if "limit_microdollars" in patch:
+        key.limit_microdollars = patch["limit_microdollars"]
+    if "limit_reset" in patch:
+        key.limit_reset = patch["limit_reset"]
+    for window in ("daily", "weekly", "monthly"):
+        field = f"limit_{window}_microdollars"
+        if field in patch:
+            setattr(key, field, patch[field])
+    if "include_byok_in_limit" in patch:
+        key.include_byok_in_limit = bool(patch["include_byok_in_limit"])
+    if patch.get("budget_alert_only") is not None:
+        key.budget_alert_only = bool(patch["budget_alert_only"])
+    if "budget_alerted" in patch:
+        key.budget_alerted = dict(patch["budget_alerted"] or {})
+    if "tags" in patch:
+        key.tags = dict(patch["tags"] or {})
+    key.updated_at = iso_now()
 
 
 class SpannerApiKeys:
@@ -231,57 +272,54 @@ class SpannerApiKeys:
         key = self.get_by_hash(key_hash)
         if key is None:
             return None
-        if key.usage_shard_count > 1:
-            if patch.get("limit") is not None or patch.get(
-                "limit_microdollars"
-            ) is not None:
-                raise ValueError(
-                    "consolidate API-key usage to one shard before adding "
-                    "an exact lifetime spend limit"
+        if not (_TYPED_LIMIT_PATCH_FIELDS & patch.keys()):
+            # Metadata edits do not touch typed counter configuration. Besides
+            # avoiding unnecessary hot-row writes, this preserves an existing
+            # escrow partition exactly.
+            _apply_key_patch(key, patch)
+            self._io.write_entity("api_key", key.hash, key)
+            return key
+
+        # A cap edit must repartition against strongly-read usage and holds in
+        # the same transaction. A snapshot followed by a batch could race an
+        # authorize and accidentally mint headroom on another shard.
+        pt = self._io.param_types
+
+        def txn(transaction: Any) -> ApiKey | None:
+            current = self._io.read_entity_tx(
+                transaction,
+                "api_key",
+                key_hash,
+                ApiKey,
+            )
+            if current is None:
+                return None
+            _apply_key_patch(current, patch)
+            shard_count = key_usage_shard_count(current)
+            usage_rows = list(
+                transaction.execute_sql(
+                    "SELECT shard, usage, byok_usage, reserved "
+                    "FROM tr_key_limit WHERE key_hash=@kh AND shard>=0 "
+                    "AND shard<@shard_count ORDER BY shard",
+                    params={"kh": key_hash, "shard_count": shard_count},
+                    param_types={"kh": pt.STRING, "shard_count": pt.INT64},
                 )
-        if "name" in patch and patch["name"]:
-            key.name = str(patch["name"])
-        if "disabled" in patch:
-            key.disabled = bool(patch["disabled"])
-        if "limit" in patch:
-            value = patch["limit"]
-            key.limit_microdollars = None if value is None else dollars_to_microdollars(value)
-        if "limit_microdollars" in patch:
-            key.limit_microdollars = patch["limit_microdollars"]
-        if "limit_reset" in patch:
-            key.limit_reset = patch["limit_reset"]
-        for window in ("daily", "weekly", "monthly"):
-            field = f"limit_{window}_microdollars"
-            if field in patch:
-                setattr(key, field, patch[field])
-        if "include_byok_in_limit" in patch:
-            key.include_byok_in_limit = bool(patch["include_byok_in_limit"])
-        if patch.get("budget_alert_only") is not None:
-            key.budget_alert_only = bool(patch["budget_alert_only"])
-        if "budget_alerted" in patch:
-            key.budget_alerted = dict(patch["budget_alerted"] or {})
-        if "tags" in patch:
-            key.tags = dict(patch["tags"] or {})
-        key.updated_at = iso_now()
-        # Re-sync the CONFIG columns to tr_key_limit in the same atomic batch.
-        # The generic mirror (deleted in C2a) used to do this on every api_key
-        # write; the typed authorize path reads the overall per-key cap
-        # (limit_micro) from tr_key_limit, so a limit edit that only wrote
-        # tr_entities would never reach enforcement (stale cap = spend bypass).
-        # KEY_LIMIT_COLUMNS is config-only (no usage/reserved/byok_usage), so
-        # this upsert on the existing row cannot clobber typed-owned counters.
-        with self._io.database.batch() as batch:
-            self._io.write_entity_batch(batch, "api_key", key.hash, key)
-            batch.insert_or_update(
+            )
+            config_rows = key_limit_mirror_rows(
+                current.hash,
+                current,
+                self._io.spanner_module.COMMIT_TIMESTAMP,
+                usage_rows=usage_rows,
+            )
+            self._io.write_entity_tx(transaction, "api_key", current.hash, current)
+            transaction.insert_or_update(
                 table=KEY_LIMIT_TABLE,
                 columns=KEY_LIMIT_COLUMNS,
-                values=key_limit_mirror_rows(
-                    key.hash,
-                    key,
-                    self._io.spanner_module.COMMIT_TIMESTAMP,
-                ),
+                values=config_rows,
             )
-        return key
+            return current
+
+        return run_in_transaction_with_retry(self._io.database, txn)
 
     # ── Per-key spend-cap lifecycle ─────────────────────────────────────
     def reserve_limit(

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -216,9 +216,9 @@ class ApiKey:
     created_at: str = field(default_factory=iso_now)
     updated_at: str | None = None
     reserved_microdollars: int = 0
-    # Independent usage-counter rows for a high-throughput key. Keys with an
-    # exact lifetime spend limit remain at one shard. Fixed-window limits are
-    # approximate snapshot checks and may sum usage across shards.
+    # Independent usage-counter rows for a high-throughput key. Exact lifetime
+    # caps use escrowed per-shard sub-budgets; fixed-window limits are
+    # approximate snapshot checks and sum usage across shards.
     usage_shard_count: int = 1
     tags: dict[str, str] = field(default_factory=dict)
     # Non-empty marks a key learned from a home plane via federation. Such a

--- a/tests/test_key_usage_row_sharding.py
+++ b/tests/test_key_usage_row_sharding.py
@@ -5,6 +5,8 @@ import json
 from typing import Any
 
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 from tests.fakes.spanner import make_fake_store
 from trusted_router.spend_windows import utcnow, window_floors
@@ -22,6 +24,7 @@ from trusted_router.storage_gcp_counters import (
     CREDIT_BALANCE_TABLE,
     KEY_LIMIT_TABLE,
     key_usage_shard_count,
+    partition_key_limit,
 )
 from trusted_router.storage_gcp_credit_shard_admin import reshard_credit_account
 from trusted_router.storage_gcp_key_shard_admin import (
@@ -100,17 +103,86 @@ def _auth_body(authorization_id: str, reservation_id: str) -> str:
     )
 
 
-def test_key_usage_shards_default_and_fail_closed_for_lifetime_caps() -> None:
+@st.composite
+def _key_limit_partition_cases(
+    draw: Any,
+) -> tuple[int, list[int], list[int], list[int], bool]:
+    shard_count = draw(st.integers(min_value=1, max_value=16))
+    counters = st.lists(
+        st.integers(min_value=0, max_value=1_000_000),
+        min_size=shard_count,
+        max_size=shard_count,
+    )
+    usage = draw(counters)
+    byok_usage = draw(counters)
+    reserved = draw(counters)
+    include_byok = draw(st.booleans())
+    consumed = sum(usage) + sum(reserved)
+    if include_byok:
+        consumed += sum(byok_usage)
+    limit = draw(st.integers(min_value=0, max_value=consumed + 1_000_000))
+    return limit, usage, byok_usage, reserved, include_byok
+
+
+@given(case=_key_limit_partition_cases())
+def test_key_limit_partition_preserves_global_cap_for_all_counter_shapes(
+    case: tuple[int, list[int], list[int], list[int], bool],
+) -> None:
+    limit, usage, byok_usage, reserved, include_byok = case
+    limits = partition_key_limit(
+        limit,
+        usage_parts=usage,
+        byok_usage_parts=byok_usage,
+        reserved_parts=reserved,
+        include_byok=include_byok,
+    )
+    consumed = [
+        current_usage
+        + (current_byok if include_byok else 0)
+        + current_reserved
+        for current_usage, current_byok, current_reserved in zip(
+            usage,
+            byok_usage,
+            reserved,
+            strict=True,
+        )
+    ]
+
+    assert len(limits) == len(usage)
+    assert all(value is not None and value >= 0 for value in limits)
+    assert sum(value for value in limits if value is not None) == limit
+    if limit >= sum(consumed):
+        assert all(
+            value >= current
+            for value, current in zip(limits, consumed, strict=True)
+            if value is not None
+        )
+        assert sum(
+            value - current
+            for value, current in zip(limits, consumed, strict=True)
+            if value is not None
+        ) == limit - sum(consumed)
+    else:
+        assert all(
+            value <= current
+            for value, current in zip(limits, consumed, strict=True)
+            if value is not None
+        )
+
+
+def test_key_usage_shards_default_and_accept_escrowed_lifetime_caps() -> None:
     assert key_usage_shard_count({}) == 1
     assert key_usage_shard_count({"usage_shard_count": 16}) == 16
     with pytest.raises(ValueError, match="positive integer"):
         key_usage_shard_count({"usage_shard_count": 0})
     with pytest.raises(ValueError, match="must not exceed"):
         key_usage_shard_count({"usage_shard_count": 65})
-    with pytest.raises(ValueError, match="exact lifetime limit"):
+    assert (
         key_usage_shard_count(
             {"usage_shard_count": 2, "limit_microdollars": 1_000_000}
         )
+        == 2
+    )
     assert (
         key_usage_shard_count(
             {"usage_shard_count": 2, "limit_daily_microdollars": 1_000_000}
@@ -142,7 +214,7 @@ def test_new_uncapped_key_inherits_workspace_credit_shards() -> None:
     } == set(range(16))
 
 
-def test_new_lifetime_capped_key_remains_single_shard() -> None:
+def test_new_lifetime_capped_key_inherits_workspace_shards_with_exact_escrow() -> None:
     store, database, _ = make_fake_store()
     workspace_id = "ws-new-capped-key"
     store._write_entity(
@@ -158,12 +230,50 @@ def test_new_lifetime_capped_key_remains_single_shard() -> None:
         limit_microdollars=1_000_000,
     )
 
-    assert key.usage_shard_count == 1
-    assert {
-        shard
-        for key_hash, shard in database.typed[KEY_LIMIT_TABLE]
+    assert key.usage_shard_count == 16
+    rows = [
+        row
+        for (key_hash, _shard), row in database.typed[KEY_LIMIT_TABLE].items()
         if key_hash == key.hash
-    } == {0}
+    ]
+    assert len(rows) == 16
+    assert sum(row["limit_micro"] for row in rows) == 1_000_000
+    assert {row["limit_micro"] for row in rows} == {62_500}
+
+
+def test_key_limit_partition_preserves_only_real_remaining_headroom() -> None:
+    limits = partition_key_limit(
+        20_000,
+        usage_parts=[10_000, 0, 0, 0],
+        byok_usage_parts=[0, 0, 0, 0],
+        reserved_parts=[2_000, 0, 0, 0],
+        include_byok=True,
+    )
+
+    assert sum(limit for limit in limits if limit is not None) == 20_000
+    assert limits == (14_000, 2_000, 2_000, 2_000)
+    assert sum(
+        limit - consumed
+        for limit, consumed in zip(limits, (12_000, 0, 0, 0), strict=True)
+        if limit is not None
+    ) == 8_000
+
+
+def test_key_limit_partition_below_current_spend_creates_no_headroom() -> None:
+    limits = partition_key_limit(
+        5_000,
+        usage_parts=[4_000, 3_000],
+        byok_usage_parts=[0, 0],
+        reserved_parts=[1_000, 0],
+        include_byok=True,
+    )
+
+    assert sum(limit for limit in limits if limit is not None) == 5_000
+    assert all(
+        limit <= consumed
+        for limit, consumed in zip(limits, (5_000, 3_000), strict=True)
+        if limit is not None
+    )
 
 
 def test_sharded_key_metadata_update_does_not_clobber_typed_counters() -> None:
@@ -179,9 +289,16 @@ def test_sharded_key_metadata_update_does_not_clobber_typed_counters() -> None:
         assert row["reserved"] == 0
 
     rows[(key.hash, 2)]["usage"] = 123
-    key.name = "renamed"
-    store._write_entity("api_key", key.hash, key)
+    capped = store.api_keys.update(key.hash, {"limit_microdollars": 1_000_000})
+    assert capped is not None
+    escrow_before = [rows[(key.hash, shard)]["limit_micro"] for shard in range(4)]
+
+    renamed = store.api_keys.update(key.hash, {"name": "renamed"})
+
+    assert renamed is not None
+    assert renamed.name == "renamed"
     assert rows[(key.hash, 2)]["usage"] == 123
+    assert [rows[(key.hash, shard)]["limit_micro"] for shard in range(4)] == escrow_before
 
 
 def test_authorize_records_key_shard_and_settle_spreads_exact_usage() -> None:
@@ -224,6 +341,96 @@ def test_authorize_records_key_shard_and_settle_spreads_exact_usage() -> None:
     assert [rows[(key.hash, shard)]["usage"] for shard in range(4)] == [9_000] * 4
     assert [rows[(key.hash, shard)]["reserved"] for shard in range(4)] == [0] * 4
     assert sum(row["total_usage"] for row in database.typed[CREDIT_BALANCE_TABLE].values()) == 36_000
+
+
+def test_sharded_lifetime_cap_cannot_be_overspent_across_candidates() -> None:
+    store, database, key = _seed(key_shards=4)
+    updated = store.api_keys.update(key.hash, {"limit_microdollars": 12_000})
+    assert updated is not None
+
+    outcomes: list[str] = []
+    for index in range(13):
+        first = index % 4
+        candidates = tuple((first + offset) % 4 for offset in range(4))
+        result = authorize_atomic(
+            store._database,
+            store._param_types,
+            workspace_id=key.workspace_id,
+            key_hash=key.hash,
+            estimate=1_000,
+            has_credit_candidate=True,
+            reservation_usage_type="Credits",
+            idempotency_scope=f"exact-cap-{index}",
+            idempotency_fingerprint="same-body",
+            expires_at="2026-12-01T00:00:00Z",
+            build_auth_body=_auth_body,
+            key_shard_candidates=candidates,
+        )
+        outcomes.append(result["outcome"])
+
+    assert outcomes == [AuthorizeOutcome.ACCEPTED] * 12 + [
+        AuthorizeOutcome.KEY_LIMIT_EXCEEDED
+    ]
+    rows = database.typed[KEY_LIMIT_TABLE]
+    assert sum(rows[(key.hash, shard)]["reserved"] for shard in range(4)) == 12_000
+    assert sum(rows[(key.hash, shard)]["limit_micro"] for shard in range(4)) == 12_000
+
+
+def test_large_affordable_hold_rebalances_fragmented_key_escrow_once() -> None:
+    store, database, key = _seed(key_shards=4)
+    updated = store.api_keys.update(key.hash, {"limit_microdollars": 20_000})
+    assert updated is not None
+    assert {
+        database.typed[KEY_LIMIT_TABLE][(key.hash, shard)]["limit_micro"]
+        for shard in range(4)
+    } == {5_000}
+
+    outcome, authorization = store.authorize_gateway_typed(
+        workspace_id=key.workspace_id,
+        key_hash=key.hash,
+        estimate=10_000,
+        has_credit_candidate=True,
+        reservation_usage_type="Credits",
+        model_id="test/model",
+        provider="test",
+        requested_model_id="test/model",
+        candidate_model_ids=["test/model"],
+        region="test",
+        endpoint_id="test-endpoint",
+        candidate_endpoint_ids=["test-endpoint"],
+        idempotency_key="large-escrow-hold",
+        idempotency_fingerprint="same-body",
+        key_usage_shards=4,
+    )
+
+    assert outcome == AuthorizeOutcome.ACCEPTED
+    assert authorization is not None
+    rows = database.typed[KEY_LIMIT_TABLE]
+    assert sum(rows[(key.hash, shard)]["limit_micro"] for shard in range(4)) == 20_000
+    assert sum(rows[(key.hash, shard)]["reserved"] for shard in range(4)) == 10_000
+
+    rejected, second_authorization = store.authorize_gateway_typed(
+        workspace_id=key.workspace_id,
+        key_hash=key.hash,
+        estimate=10_001,
+        has_credit_candidate=True,
+        reservation_usage_type="Credits",
+        model_id="test/model",
+        provider="test",
+        requested_model_id="test/model",
+        candidate_model_ids=["test/model"],
+        region="test",
+        endpoint_id="test-endpoint",
+        candidate_endpoint_ids=["test-endpoint"],
+        idempotency_key="too-large-after-escrow-hold",
+        idempotency_fingerprint="same-body",
+        key_usage_shards=4,
+    )
+
+    assert rejected == AuthorizeOutcome.KEY_LIMIT_EXCEEDED
+    assert second_authorization is None
+    assert sum(rows[(key.hash, shard)]["limit_micro"] for shard in range(4)) == 20_000
+    assert sum(rows[(key.hash, shard)]["reserved"] for shard in range(4)) == 10_000
 
 
 def test_idempotent_replay_keeps_original_key_shard() -> None:
@@ -295,16 +502,27 @@ def test_deleting_sharded_key_leaves_typed_usage_rows() -> None:
     assert {(key.hash, shard) for shard in range(4)} <= set(database.typed[KEY_LIMIT_TABLE])
 
 
-def test_adding_a_limit_to_sharded_key_is_rejected_atomically() -> None:
-    store, _database, key = _seed(key_shards=4)
+def test_adding_a_limit_to_sharded_key_partitions_exact_headroom_atomically() -> None:
+    store, database, key = _seed(key_shards=4)
+    rows = database.typed[KEY_LIMIT_TABLE]
+    rows[(key.hash, 0)]["usage"] = 100_000
+    rows[(key.hash, 1)]["reserved"] = 20_000
 
-    with pytest.raises(ValueError, match="consolidate API-key usage"):
-        store.api_keys.update(key.hash, {"limit_microdollars": 1_000_000})
+    updated = store.api_keys.update(key.hash, {"limit_microdollars": 1_000_000})
 
     persisted = store.api_keys.get_by_hash(key.hash)
     assert persisted is not None
-    assert persisted.limit_microdollars is None
+    assert updated is not None
+    assert persisted.limit_microdollars == 1_000_000
     assert persisted.usage_shard_count == 4
+    limits = [rows[(key.hash, shard)]["limit_micro"] for shard in range(4)]
+    assert sum(limits) == 1_000_000
+    assert sum(
+        limits[shard]
+        - rows[(key.hash, shard)]["usage"]
+        - rows[(key.hash, shard)]["reserved"]
+        for shard in range(4)
+    ) == 880_000
 
 
 def test_adding_window_limits_to_sharded_key_preserves_usage_rows() -> None:
@@ -537,6 +755,65 @@ def test_online_credit_and_key_split_preserve_then_settle_live_request() -> None
     assert database.reservations[reservation_id]["settled"] is True
 
 
+def test_online_capped_key_split_preserves_hold_without_minting_headroom() -> None:
+    store, database, key = _seed(key_shards=1)
+    key.limit_microdollars = 20_000
+    store._write_entity("api_key", key.hash, key)
+    row = database.typed[KEY_LIMIT_TABLE][(key.hash, 0)]
+    row["limit_micro"] = 20_000
+    row["usage"] = 8_000
+    authorized = authorize_atomic(
+        store._database,
+        store._param_types,
+        workspace_id=key.workspace_id,
+        key_hash=key.hash,
+        estimate=2_000,
+        has_credit_candidate=True,
+        reservation_usage_type="Credits",
+        idempotency_scope="online-capped-split",
+        idempotency_fingerprint="same-body",
+        expires_at="2026-12-01T00:00:00Z",
+        build_auth_body=_auth_body,
+        key_shard_candidates=(0,),
+    )
+    assert authorized["outcome"] == AuthorizeOutcome.ACCEPTED
+
+    split = reshard_key_usage(
+        store,
+        key.hash,
+        4,
+        apply=True,
+        preserve_open_holds=True,
+    )
+
+    assert split.ready and split.applied
+    rows = [database.typed[KEY_LIMIT_TABLE][(key.hash, shard)] for shard in range(4)]
+    assert [current["usage"] for current in rows] == [8_000, 0, 0, 0]
+    assert [current["reserved"] for current in rows] == [2_000, 0, 0, 0]
+    assert sum(current["limit_micro"] for current in rows) == 20_000
+    assert sum(
+        current["limit_micro"] - current["usage"] - current["reserved"]
+        for current in rows
+    ) == 10_000
+
+    settled = settle_atomic(
+        store._database,
+        store._param_types,
+        reservation_id=authorized["reservation_id"],
+        actual_micro=1_500,
+        settled_usage_type="Credits",
+        success=True,
+    )
+    assert settled["outcome"] == SettleOutcome.SETTLED
+    rows = [database.typed[KEY_LIMIT_TABLE][(key.hash, shard)] for shard in range(4)]
+    assert sum(current["reserved"] for current in rows) == 0
+    assert sum(current["usage"] for current in rows) == 9_500
+    assert sum(
+        current["limit_micro"] - current["usage"] - current["reserved"]
+        for current in rows
+    ) == 10_500
+
+
 def test_online_key_split_keeps_history_and_windows_on_existing_shard() -> None:
     store, database, key = _seed(key_shards=1)
     floors = window_floors(utcnow())
@@ -629,27 +906,30 @@ def test_key_reshard_derives_window_floors_inside_transaction(
     )
 
 
-def test_key_usage_operator_refuses_lifetime_capped_or_undrained_key() -> None:
+def test_key_usage_operator_escrows_lifetime_cap_and_refuses_undrained_key() -> None:
     store, database, key = _seed(key_shards=1)
     key.limit_microdollars = 1_000_000
     store._write_entity("api_key", key.hash, key)
 
+    row = database.typed[KEY_LIMIT_TABLE][(key.hash, 0)]
+    row["limit_micro"] = 1_000_000
+    row["usage"] = 100_000
     capped = reshard_key_usage(store, key.hash, 4, apply=True)
-    assert not capped.ready
-    assert (
-        "API key with an exact lifetime limit must remain on one usage shard"
-        in capped.reasons
-    )
+    assert capped.ready and capped.applied
+    rows = [database.typed[KEY_LIMIT_TABLE][(key.hash, shard)] for shard in range(4)]
+    assert sum(current["limit_micro"] for current in rows) == 1_000_000
+    assert sum(
+        current["limit_micro"] - current["usage"] - current["reserved"]
+        for current in rows
+    ) == 900_000
 
-    key.limit_microdollars = None
-    store._write_entity("api_key", key.hash, key)
     database.reservations["open-key-request"] = {
         "reservation_id": "open-key-request",
         "workspace_id": key.workspace_id,
         "key_hash": key.hash,
         "settled": False,
     }
-    undrained = reshard_key_usage(store, key.hash, 4, apply=True)
+    undrained = reshard_key_usage(store, key.hash, 8, apply=True)
     assert not undrained.ready
     assert any("open typed reservations" in reason for reason in undrained.reasons)
 


### PR DESCRIPTION
## Incident fix\n\nReplaces the single Spanner row used by exact API-key lifetime caps with escrowed per-shard sub-budgets. Their sum remains the exact configured cap, so concurrency is distributed without weakening billing enforcement.\n\n- preserves settled usage, BYOK usage, and open holds during online migration\n- atomically repartitions limit edits against strongly-read counters\n- cold-path rebalances fragmented escrow for a large otherwise-affordable request\n- keeps metadata-only key edits away from typed money rows\n- makes new capped keys inherit workspace shard scale\n- updates the guarded workspace sharding operator and runbook\n\n## Validation\n\n- 132 focused billing, sharding, gateway, and reliability tests passed\n- Hypothesis property coverage proves shard limits always sum to the global cap and never mint headroom\n- ruff clean\n- mypy clean