### PR TITLE
Correct Atlas DeepSeek V4 Flash 0731 pricing

### DIFF
--- a/scripts/check_price_spike.py
+++ b/scripts/check_price_spike.py
@@ -69,6 +69,23 @@ APPROVED_ENDPOINT_PRICE_TRANSITIONS = frozenset(
             Decimal("0.000000695999"),
             Decimal("0.000001392"),
         ),
+        # Atlas's authenticated /v1/models feed distinguishes the cheap
+        # unversioned route from the newer 0731 weights. The old snapshot had
+        # inherited the unversioned rate; approve only the exact correction.
+        (
+            "deepseek/deepseek-v4-flash-0731 "
+            "[atlas-cloud:atlas-cloud:deepseek/deepseek-v4-flash-0731]",
+            "prompt",
+            Decimal("0.00000014"),
+            Decimal("0.00000044"),
+        ),
+        (
+            "deepseek/deepseek-v4-flash-0731 "
+            "[atlas-cloud:atlas-cloud:deepseek/deepseek-v4-flash-0731]",
+            "completion",
+            Decimal("0.00000028"),
+            Decimal("0.00000132"),
+        ),
         (
             "moonshotai/kimi-k3 [tinfoil:tinfoil:kimi-k3]",
             "prompt",

--- a/src/trusted_router/data/openrouter_snapshot.json
+++ b/src/trusted_router/data/openrouter_snapshot.json
@@ -3160,8 +3160,8 @@
           "tr_provider_slug": "atlas-cloud",
           "context_length": 1310720,
           "pricing": {
-            "prompt": "0.00000014",
-            "completion": "0.00000028",
+            "prompt": "0.00000044",
+            "completion": "0.00000132",
             "input_cache_read": "0.000000028"
           },
           "pricing_source": "provider_direct",

--- a/src/trusted_router/data/provider_models/atlas-cloud.json
+++ b/src/trusted_router/data/provider_models/atlas-cloud.json
@@ -3416,8 +3416,8 @@
         "max_tokens",
         "logit_bias"
       ],
-      "input_token_price_per_m": 140000,
-      "output_token_price_per_m": 280000,
+      "input_token_price_per_m": 440000,
+      "output_token_price_per_m": 1320000,
       "cached_input_token_price_per_m": 28000
     },
     {

--- a/tests/test_check_price_spike.py
+++ b/tests/test_check_price_spike.py
@@ -277,6 +277,90 @@ def test_confirmed_deepseek_and_gmi_price_transitions_are_allowed(
     assert "deepseek/deepseek-v4-pro" in capsys.readouterr().out
 
 
+def test_confirmed_atlas_v4_flash_0731_transition_is_allowed(
+    tmp_path: Path, capsys
+) -> None:
+    from scripts.check_price_spike import main
+
+    before = _write(
+        tmp_path,
+        "before.json",
+        _make_endpoint_snapshot(
+            ("0.00000008", "0.00000018"),
+            [
+                (
+                    "atlas-cloud",
+                    "deepseek/deepseek-v4-flash-0731",
+                    "0.00000014",
+                    "0.00000028",
+                )
+            ],
+            model_id="deepseek/deepseek-v4-flash-0731",
+        ),
+    )
+    after = _write(
+        tmp_path,
+        "after.json",
+        _make_endpoint_snapshot(
+            ("0.00000008", "0.00000018"),
+            [
+                (
+                    "atlas-cloud",
+                    "deepseek/deepseek-v4-flash-0731",
+                    "0.00000044",
+                    "0.00000132",
+                )
+            ],
+            model_id="deepseek/deepseek-v4-flash-0731",
+        ),
+    )
+
+    assert main([str(before), str(after), "--summary"]) == 0
+    assert "PRICE SPIKE FAILURES" not in capsys.readouterr().out
+
+
+def test_different_atlas_v4_flash_0731_transition_still_blocks(
+    tmp_path: Path, capsys
+) -> None:
+    from scripts.check_price_spike import main
+
+    before = _write(
+        tmp_path,
+        "before.json",
+        _make_endpoint_snapshot(
+            ("0.00000008", "0.00000018"),
+            [
+                (
+                    "atlas-cloud",
+                    "deepseek/deepseek-v4-flash-0731",
+                    "0.00000014",
+                    "0.00000028",
+                )
+            ],
+            model_id="deepseek/deepseek-v4-flash-0731",
+        ),
+    )
+    after = _write(
+        tmp_path,
+        "after.json",
+        _make_endpoint_snapshot(
+            ("0.00000008", "0.00000018"),
+            [
+                (
+                    "atlas-cloud",
+                    "deepseek/deepseek-v4-flash-0731",
+                    "0.00000045",
+                    "0.00000132",
+                )
+            ],
+            model_id="deepseek/deepseek-v4-flash-0731",
+        ),
+    )
+
+    assert main([str(before), str(after), "--summary"]) == 1
+    assert "PRICE SPIKE FAILURES" in capsys.readouterr().out
+
+
 def test_unapproved_deepseek_price_transition_still_blocks(
     tmp_path: Path, capsys
 ) -> None:


### PR DESCRIPTION
## Summary

- Correct Atlas Cloud DeepSeek V4 Flash 0731 from the unversioned $0.14/$0.28 rate to its authenticated $0.44/$1.32 rate.
- Approve only that exact provider, model, dimension, and value transition in the price-spike gate.
- Keep every other Atlas transition fail-closed.

## Verification

- Authenticated Atlas `/v1/models` check confirms unversioned $0.14/$0.28 and 0731 $0.44/$1.32.
- `uv run ruff check scripts/check_price_spike.py tests/test_check_price_spike.py`
- `uv run mypy`
- `uv run pytest -q` (5,057 passed, 301 skipped, 10 xfailed)
