### PR TITLE
Fix live provider refresh gate

### DIFF
--- a/src/trusted_router/data/provider_models/tinfoil.json
+++ b/src/trusted_router/data/provider_models/tinfoil.json
@@ -2,7 +2,7 @@
   "_about": "Provider-native supplement for Tinfoil models whose live API is ahead of the snapshot. Tinfoil launched Kimi K3 and DeepSeek V4 Flash on 2026-08-20 and supports confidential prompt caching where published by its live feed. Deprecated Tinfoil routes are filtered in catalog.py.",
   "provider": "tinfoil",
   "source": "https://inference.tinfoil.sh/v1/models",
-  "generated_at": "2026-08-20T17:35:03Z",
+  "generated_at": "2026-08-21T03:36:43Z",
   "model_count": 4,
   "models": [
     {
@@ -11,9 +11,9 @@
       "display_name": "DeepSeek V4 Flash",
       "title": "deepseek/deepseek-v4-flash",
       "context_length": 1048576,
-      "input_token_price_per_m": 200000,
-      "cached_input_token_price_per_m": 20000,
-      "output_token_price_per_m": 400000,
+      "input_token_price_per_m": 300000,
+      "cached_input_token_price_per_m": 60000,
+      "output_token_price_per_m": 700000,
       "model_type": "chat",
       "features": [
         "reasoning",

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -592,7 +592,10 @@ def test_embeddings_and_model_endpoints(
         "Credits",
         "BYOK",
     ]
-    assert {item["provider"] for item in kimi.json()["data"]} >= {"kimi", "together"}
+    # The first-party Moonshot route is the stable contract. Secondary
+    # providers are discovered from their live serverless catalogs and may
+    # legitimately add or remove Kimi K2.6 without a code change.
+    assert "kimi" in {item["provider"] for item in kimi.json()["data"]}
 
     # gpt-5.5 is OpenAI's served flagship (Credits + BYOK on the openai
     # provider). NB: the GPT-5.4 line and the "-pro" tiers are dropped from

--- a/tests/test_gateway_fallback_billing.py
+++ b/tests/test_gateway_fallback_billing.py
@@ -851,7 +851,10 @@ def test_gateway_prepaid_route_does_not_return_byok_secret_even_if_configured() 
     assert data["route_candidates"][0]["byok_secret_ref"] is None
     assert data["route_candidates"][0]["byok_encrypted_secret"] is None
     assert [item["usage_type"] for item in data["route_candidates"]][:2] == ["Credits", "BYOK"]
-    assert {item["provider"] for item in data["route_candidates"]} >= {"kimi", "together"}
+    # Kimi direct is the stable prepaid route. Together and other secondary
+    # routes are live-discovered and must disappear when the provider stops
+    # advertising this model as started serverless capacity.
+    assert "kimi" in {item["provider"] for item in data["route_candidates"]}
 
 
 def test_gateway_can_prefer_byok_endpoint_for_dual_mode_model() -> None:

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
+from trusted_router.catalog import endpoints_for_model
 from trusted_router.dashboard import PUBLIC_PAGES
 from trusted_router.storage import STORE
 
@@ -480,14 +481,17 @@ def test_public_models_page_does_not_require_api_key(client: TestClient) -> None
 
 
 def test_public_model_detail_lists_distinct_serving_providers(client: TestClient) -> None:
-    response = client.get("/models/moonshotai/kimi-k2.6")
+    model_id = "moonshotai/kimi-k2.6"
+    response = client.get(f"/models/{model_id}")
 
     assert response.status_code == 200
     assert "Providers serving this model" in response.text
     assert "Endpoints</th>" in response.text
     assert 'href="https://aiiq.org/models/kimi-k2.6/"' in response.text
     assert "IQ 116" in response.text
-    for provider in ["kimi", "parasail", "together", "novita"]:
+    expected_providers = {endpoint.provider for endpoint in endpoints_for_model(model_id)}
+    assert "kimi" in expected_providers
+    for provider in expected_providers:
         assert f'title="{provider}"' in response.text
 
 

--- a/tests/test_tinfoil_pricing.py
+++ b/tests/test_tinfoil_pricing.py
@@ -141,9 +141,12 @@ def test_tinfoil_deepseek_route_is_confidential_and_uses_live_prices() -> None:
     provider = PROVIDERS["tinfoil"]
 
     assert endpoint.upstream_id == "deepseek-v4-flash"
-    assert endpoint.prompt_price_microdollars_per_million_tokens == 211_000
-    assert endpoint.completion_price_microdollars_per_million_tokens == 422_000
-    assert endpoint.price_tiers[0].prompt_cached_price_microdollars_per_million_tokens == 21_100
+    # Accepted against Tinfoil's authoritative /v1/models feed on
+    # 2026-08-21: $0.30 input, $0.06 cached input, and $0.70 output.
+    # Customer prices below include TrustedRouter's 5.5% markup.
+    assert endpoint.prompt_price_microdollars_per_million_tokens == 316_500
+    assert endpoint.completion_price_microdollars_per_million_tokens == 738_500
+    assert endpoint.price_tiers[0].prompt_cached_price_microdollars_per_million_tokens == 63_300
     assert provider.provider_zero_data_retention is True
     assert provider.provider_confidential_compute is True
     assert provider.provider_e2ee is True


### PR DESCRIPTION
Summary:
- Accept Tinfoil's authoritative DeepSeek V4 Flash price increase and update the provider manifest.
- Stop pinning Together as a permanent Kimi K2.6 route after its live serverless catalog removed that model.
- Make the public provider rendering test validate every currently routable provider dynamically.

Verification:
- Ruff clean.
- Mypy clean.
- Focused pricing and catalog tests: 8 passed.
- Full suite: 5057 passed, 301 skipped, 10 xfailed.

This unblocks the hourly provider price refresh without weakening the price spike guard.