### PR TITLE
Implement bounded regional quota leases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -257,6 +257,11 @@ jobs:
       - name: Sync shared public analytics snapshots
         run: scripts/deploy/sync_public_analytics_snapshots.sh --apply
 
+      - name: Provision bounded regional quota ledger
+        # Idempotent. The table and fixed single-cluster app profiles must
+        # exist before any serving revision can enable the workspace canary.
+        run: bash scripts/deploy/regional_quota_ledger.sh
+
   sync-runtime-secrets:
     # Validate the small set of runtime credentials while the image build and
     # schema verification run. SES credentials are rotated directly in GCP
@@ -634,6 +639,12 @@ jobs:
         # deploy leaves conversions durably queued, but this workflow stays red
         # so ad spend is never scaled under silently broken attribution.
         run: bash scripts/deploy/google_data_manager.sh
+
+      - name: Deploy regional quota reconciler
+        # Safe while the feature is disabled (the endpoint is a no-op) and
+        # mandatory once a workspace canary is enabled. Keep it in the normal
+        # rollout so scheduler drift cannot strand bounded escrow.
+        run: bash scripts/deploy/regional_quota_reconciler.sh
 
       # No cross-region "final watchdog" step. Each region's health is
       # gated by its own per-region canary above (us-central1 first,

--- a/README.md
+++ b/README.md
@@ -402,7 +402,10 @@ done carefully:
   not terminate TLS. Cloudflare orange-cloud proxying remains incompatible
   with the prompt-path trust claim.
 - Authorize through regional quota leases, not a synchronous global Spanner
-  transaction for every request.
+  counter mutation for every request. New workspaces and keys start with 16
+  exact billing shards; eligible allowlisted traffic can additionally use 16
+  independently fenced regional escrow rows whose combined grant is already
+  reserved in Spanner.
 - Write generation metadata to regional Bigtable clusters, then aggregate into
   global activity views asynchronously.
 - Keep provider routing regional, with provider-specific circuit breakers,

--- a/docs/design/regional-quota-leases.md
+++ b/docs/design/regional-quota-leases.md
@@ -1,11 +1,11 @@
 # Regional quota leases
 
-Status: **dark foundation, not production authority**
+Status: **canary-capable, off by default, workspace allowlisted**
 
-The current typed Spanner counter path remains TrustedRouter's only prepaid
-billing authority. Regional quota leases are the planned way to remove a
-cross-continent Spanner transaction from first-token latency without changing
-the invariant that a workspace cannot spend more credit than it owns.
+Global Spanner remains TrustedRouter's prepaid billing source of truth.
+Regional quota leases remove the hot global counter mutation from eligible
+authorizations without changing the invariant that a workspace cannot spend
+more credit than it owns.
 
 ## Safety model
 
@@ -18,7 +18,7 @@ balance.
 
 This is escrow, not an eventually consistent copy of account balance.
 
-Every lease has:
+Every lease shard has:
 
 - one workspace and one region;
 - a monotonically increasing fencing token;
@@ -26,6 +26,13 @@ Every lease has:
 - a short expiration;
 - durable reservation, settlement, and refund records;
 - `active`, `draining`, `closed`, or `quarantined` state.
+
+Each workspace-region pool is split across 16 independently fenced Bigtable
+rows. The configured dollar cap and available-balance percentage apply to the
+whole pool and are divided across those rows, so sharding does not multiply
+financial exposure. A Spanner fence permits only one globally escrowed grant
+per row until reconciliation closes it. The request idempotency fingerprint
+selects a stable row.
 
 The regional ledger rejects stale fencing tokens, expired leases, duplicate
 request IDs with changed fingerprints, settlement above the exact reservation,
@@ -60,55 +67,43 @@ The grant is the minimum of:
 
 All values are integer microdollars. No floating-point money enters this path.
 
-## Durable schema sketch
+## Durable storage
 
-The production implementation should use a regional strongly consistent store,
-not process memory. A representative schema is:
+Global grants, fences, and compact reconciliation totals are stored in Spanner.
+Each regional lease shard is one row in the
+`trustedrouter-regional-quota` Bigtable table. A single-cluster transactional
+app profile binds that row to exactly one physical regional writer, and every
+transition uses compare-and-swap on a random version value. The table retains
+only the latest cell version and expires rows after seven days.
 
-```sql
-CREATE TABLE tr_regional_quota_lease (
-  lease_id STRING(64) NOT NULL,
-  workspace_id STRING(64) NOT NULL,
-  region STRING(32) NOT NULL,
-  fencing_token INT64 NOT NULL,
-  granted_micro INT64 NOT NULL,
-  state STRING(16) NOT NULL,
-  expires_at TIMESTAMP NOT NULL,
-  updated_at TIMESTAMP OPTIONS (allow_commit_timestamp=true)
-) PRIMARY KEY (lease_id);
+The regional row stores authorization IDs, key hashes, integer amounts,
+expiry, and terminal state. It never stores raw keys, prompts, outputs, or
+request bodies. The normal typed Spanner authorization and reservation rows
+still provide global idempotent replay, but carry a zero global counter hold;
+the bounded regional escrow owns that hold until reconciliation.
 
-CREATE TABLE tr_regional_quota_hold (
-  lease_id STRING(64) NOT NULL,
-  hold_id STRING(64) NOT NULL,
-  fingerprint STRING(64) NOT NULL,
-  reserved_micro INT64 NOT NULL,
-  actual_micro INT64,
-  state STRING(16) NOT NULL,
-  updated_at TIMESTAMP OPTIONS (allow_commit_timestamp=true)
-) PRIMARY KEY (lease_id, hold_id),
-  INTERLEAVE IN PARENT tr_regional_quota_lease ON DELETE CASCADE;
-```
-
-The final regional store choice must preserve conditional writes and fencing.
-Redis without durable, strongly consistent persistence is not acceptable.
+Current fixed profiles exist for `us-central1` and `europe-west4`. A request
+served from a region without a fixed profile uses the exact Spanner path.
 
 ## Rollout gates
 
-`TR_REGIONAL_QUOTA_LEASES_ENABLED` defaults to false and production startup
-currently rejects true. Ordinary deploys explicitly set it false so stale
-configuration cannot activate a second billing authority.
+`TR_REGIONAL_QUOTA_LEASES_ENABLED` defaults to false. Production startup
+accepts true only with typed request records, the durable settle outbox, a
+non-empty workspace allowlist, a Bigtable instance, and fixed regional app
+profiles. Ordinary deploys preserve the serving revision's state rather than
+silently flipping it.
 
 Production activation requires all of the following:
 
-1. Durable regional schema and transactional adapter.
-2. Global grant and close transactions that escrow and release exact credit.
-3. Reconciliation worker with drift, orphan, and stuck-lease repair.
-4. Property tests proving aggregate spend never exceeds the escrowed grant.
-5. Crash tests at every boundary, including grant-write ambiguity and regional
-   settlement before reconciliation.
-6. Fencing tests for region replacement and split-brain workers.
-7. Shadow accounting with zero drift on a pilot workspace.
-8. A one-workspace rollout with a hard exposure cap and automatic rollback.
+Implemented gates include the transactional adapter, exact global grant and
+close transactions, a once-per-minute reconciler, integer-only property tests,
+ambiguous Bigtable commit replay, fencing, concurrent idempotency, exact key
+usage import, and 16-way local sharding. Production activation remains a
+one-workspace canary. Any local read, conditional write, missing profile, or
+initialization ambiguity falls back to exact Spanner authorization. Missing
+lease state is quarantined and its global escrow is not guessed back into the
+available balance.
 
-Until those gates pass, the latency work in this change improves connection,
-TLS, health, and region selection while billing remains exact in Spanner.
+Before expanding the allowlist, verify zero reconciliation errors, bounded
+lease-row size and CAS retries under the canary's real concurrency, no global
+counter drift, and successful failback when a Bigtable profile is disabled.

--- a/docs/design/regional-quota-leases.md
+++ b/docs/design/regional-quota-leases.md
@@ -82,8 +82,11 @@ request bodies. The normal typed Spanner authorization and reservation rows
 still provide global idempotent replay, but carry a zero global counter hold;
 the bounded regional escrow owns that hold until reconciliation.
 
-Current fixed profiles exist for `us-central1` and `europe-west4`. A request
-served from a region without a fixed profile uses the exact Spanner path.
+The initial fixed profile exists only for `us-central1`. Bigtable warns against
+transactional profiles that target separate clusters in one replicated
+instance because they could write the same row concurrently. TrustedRouter
+does not override that guard. A request served from Europe or another region
+uses the exact Spanner path until that region has an isolated local ledger.
 
 ## Rollout gates
 

--- a/docs/spanner-reliability.md
+++ b/docs/spanner-reliability.md
@@ -10,6 +10,11 @@ application bugs, quota exhaustion, or hot-row retries.
 - Source project: `quill-cloud-proxy`
 - Source instance/database: `trusted-router-nam6` / `trusted-router`
 - Configuration: `nam6`, Enterprise Plus, 300 processing units
+- Replica topology: two read-write locations (`us-central1`, `us-east1`), two
+  read-only locations (`us-west1`, `us-west2`), and one witness
+  (`us-central2`). This is five replica locations, not four application
+  regions. `nam6` cannot be edited down to three locations; a three-location
+  topology would require a separate migration to `nam7`.
 - Database deletion protection: enabled
 - Point-in-time recovery: 7 days
 - Backups: daily full plus incremental every 4 hours, retained for 7 days
@@ -54,6 +59,11 @@ incident remains open. Unauthenticated safe reads use a process-local
 rate-limit counter so a crawler cannot create a transactional Spanner hot row.
 The alerts use status, latency, path, and aggregate transaction metadata only;
 they never inspect or export prompts or outputs.
+
+New workspaces and their new API keys start with 16 exact billing shards.
+Existing workspaces retain their current shard count until the pause, drain,
+verify, reshard workflow completes; changing the default never rewrites a live
+ledger in place.
 
 ## Alert response
 

--- a/scripts/deploy-gcp.sh
+++ b/scripts/deploy-gcp.sh
@@ -12,7 +12,8 @@
 #   3. image.sh    — Artifact Registry repo + buildx push (linux/amd64)
 #   4. secrets.sh  — Secret Manager + runtime IAM bindings
 #   5. rollout.sh  — parallel multi-region Cloud Run deploy + LB wiring
-#   6. synthetic.sh — US/EU synthetic monitor jobs + schedules
+#   6. regional quota ledger + reconciler (idempotent, feature allowlisted)
+#   7. synthetic.sh — US/EU synthetic monitor jobs + schedules
 
 set -euo pipefail
 
@@ -31,5 +32,8 @@ bash "${SCRIPT_DIR}/deploy/migrate_analytics_outbox.sh"
 bash "${SCRIPT_DIR}/deploy/migrate_operational_analytics_outbox.sh"
 bash "${SCRIPT_DIR}/deploy/image.sh"
 bash "${SCRIPT_DIR}/deploy/secrets.sh"
+bash "${SCRIPT_DIR}/deploy/regional_quota_ledger.sh" \
+  </dev/null
 bash "${SCRIPT_DIR}/deploy/rollout.sh"
+bash "${SCRIPT_DIR}/deploy/regional_quota_reconciler.sh"
 bash "${SCRIPT_DIR}/deploy/synthetic.sh"

--- a/scripts/deploy/_lib.sh
+++ b/scripts/deploy/_lib.sh
@@ -69,6 +69,11 @@ BIGTABLE_CLUSTER_ID="${TR_BIGTABLE_CLUSTER_ID:-trusted-router-logs-c1}"
 BIGTABLE_APP_PROFILE_ID="${TR_BIGTABLE_APP_PROFILE_ID:-}"
 BIGTABLE_GENERATION_TABLE="${TR_BIGTABLE_GENERATION_TABLE:-trustedrouter-generations}"
 BIGTABLE_INSTANCE_TYPE="${TR_BIGTABLE_INSTANCE_TYPE:-PRODUCTION}"
+# Regional quota escrow currently has fixed single-cluster authority only in
+# the two Bigtable regions that physically exist. Other gateway regions fail
+# closed to the exact Spanner path until their own cluster is provisioned.
+TR_REGIONAL_QUOTA_CLUSTER_MAP="${TR_REGIONAL_QUOTA_CLUSTER_MAP:-us-central1=trusted-router-logs-c1,europe-west4=trusted-router-logs-eu}"
+TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES="${TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES:-us-central1=tr-quota-us-central1,europe-west4=tr-quota-europe-west4}"
 KMS_KEYRING_ID="${TR_KMS_KEYRING_ID:-trusted-router}"
 BYOK_KMS_KEY_ID="${TR_BYOK_KMS_KEY_ID:-byok-envelope}"
 BYOK_KMS_KEY_NAME="${TR_BYOK_KMS_KEY_NAME:-projects/${PROJECT_ID}/locations/${REGION}/keyRings/${KMS_KEYRING_ID}/cryptoKeys/${BYOK_KMS_KEY_ID}}"

--- a/scripts/deploy/_lib.sh
+++ b/scripts/deploy/_lib.sh
@@ -69,11 +69,12 @@ BIGTABLE_CLUSTER_ID="${TR_BIGTABLE_CLUSTER_ID:-trusted-router-logs-c1}"
 BIGTABLE_APP_PROFILE_ID="${TR_BIGTABLE_APP_PROFILE_ID:-}"
 BIGTABLE_GENERATION_TABLE="${TR_BIGTABLE_GENERATION_TABLE:-trustedrouter-generations}"
 BIGTABLE_INSTANCE_TYPE="${TR_BIGTABLE_INSTANCE_TYPE:-PRODUCTION}"
-# Regional quota escrow currently has fixed single-cluster authority only in
-# the two Bigtable regions that physically exist. Other gateway regions fail
-# closed to the exact Spanner path until their own cluster is provisioned.
-TR_REGIONAL_QUOTA_CLUSTER_MAP="${TR_REGIONAL_QUOTA_CLUSTER_MAP:-us-central1=trusted-router-logs-c1,europe-west4=trusted-router-logs-eu}"
-TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES="${TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES:-us-central1=tr-quota-us-central1,europe-west4=tr-quota-europe-west4}"
+# The first canary has one transactional writer. Bigtable rejects a second
+# transactional profile on another cluster unless its split-brain warning is
+# forcibly bypassed. EU and other gateways therefore use exact Spanner until
+# they receive isolated regional ledgers.
+TR_REGIONAL_QUOTA_CLUSTER_MAP="${TR_REGIONAL_QUOTA_CLUSTER_MAP:-us-central1=trusted-router-logs-c1}"
+TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES="${TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES:-us-central1=tr-quota-us-central1}"
 KMS_KEYRING_ID="${TR_KMS_KEYRING_ID:-trusted-router}"
 BYOK_KMS_KEY_ID="${TR_BYOK_KMS_KEY_ID:-byok-envelope}"
 BYOK_KMS_KEY_NAME="${TR_BYOK_KMS_KEY_NAME:-projects/${PROJECT_ID}/locations/${REGION}/keyRings/${KMS_KEYRING_ID}/cryptoKeys/${BYOK_KMS_KEY_ID}}"

--- a/scripts/deploy/regional_quota_ledger.sh
+++ b/scripts/deploy/regional_quota_ledger.sh
@@ -4,7 +4,7 @@
 # Usage:
 #   GCP_PROJECT_ID=quill-cloud-proxy \
 #   TR_BIGTABLE_INSTANCE_ID=trusted-router-logs \
-#   TR_REGIONAL_QUOTA_CLUSTER_MAP='us-central1=tr-us-central1,europe-west4=tr-eu' \
+#   TR_REGIONAL_QUOTA_CLUSTER_MAP='us-central1=tr-us-central1' \
 #     scripts/deploy/regional_quota_ledger.sh
 set -euo pipefail
 

--- a/scripts/deploy/regional_quota_ledger.sh
+++ b/scripts/deploy/regional_quota_ledger.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Provision the isolated Bigtable ledger used by bounded regional quota leases.
+#
+# Usage:
+#   GCP_PROJECT_ID=quill-cloud-proxy \
+#   TR_BIGTABLE_INSTANCE_ID=trusted-router-logs \
+#   TR_REGIONAL_QUOTA_CLUSTER_MAP='us-central1=tr-us-central1,europe-west4=tr-eu' \
+#     scripts/deploy/regional_quota_ledger.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+PROJECT="${GCP_PROJECT_ID:-$PROJECT_ID}"
+INSTANCE="${TR_BIGTABLE_INSTANCE_ID:-$BIGTABLE_INSTANCE_ID}"
+TABLE="${TR_REGIONAL_QUOTA_BIGTABLE_TABLE:-trustedrouter-regional-quota}"
+CLUSTER_MAP="$TR_REGIONAL_QUOTA_CLUSTER_MAP"
+
+log() { printf '%s %s\n' '[regional_quota_ledger]' "$*"; }
+
+if gcloud bigtable instances tables describe "$TABLE" \
+  --project="$PROJECT" --instance="$INSTANCE" >/dev/null 2>&1; then
+  log "table $TABLE exists"
+else
+  log "creating $TABLE with seven-day, latest-version-only lease state"
+  gcloud bigtable instances tables create "$TABLE" \
+    --project="$PROJECT" \
+    --instance="$INSTANCE" \
+    --column-families='lease:maxversions=1||maxage=7d'
+fi
+
+IFS=',' read -r -a entries <<< "$CLUSTER_MAP"
+profiles=()
+for entry in "${entries[@]}"; do
+  region="${entry%%=*}"
+  cluster="${entry#*=}"
+  if [ -z "$region" ] || [ -z "$cluster" ] || [ "$region" = "$cluster" ]; then
+    log "invalid cluster-map entry: $entry"
+    exit 2
+  fi
+  profile="tr-quota-${region}"
+  profiles+=("${region}=${profile}")
+  if gcloud bigtable app-profiles describe "$profile" \
+    --project="$PROJECT" --instance="$INSTANCE" >/dev/null 2>&1; then
+    log "app profile $profile exists"
+  else
+    log "creating transactional single-cluster profile $profile -> $cluster"
+    gcloud bigtable app-profiles create "$profile" \
+      --project="$PROJECT" \
+      --instance="$INSTANCE" \
+      --route-to="$cluster" \
+      --transactional-writes \
+      --description="TrustedRouter regional quota escrow for ${region}"
+  fi
+done
+
+profile_csv="$(IFS=','; printf '%s' "${profiles[*]}")"
+log "set TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES=${profile_csv}"

--- a/scripts/deploy/regional_quota_reconciler.sh
+++ b/scripts/deploy/regional_quota_reconciler.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Keep bounded regional quota escrow synchronized with the exact Spanner
+# ledger. The public Cloud Run service already has the storage clients warm;
+# Cloud Scheduler invokes its token-protected, metadata-only endpoint once a
+# minute. The endpoint is idempotent and a disabled feature returns a no-op.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+SCHEDULER_NAME="${TR_REGIONAL_QUOTA_RECONCILER_SCHEDULER:-trusted-router-regional-quota-reconcile}"
+SCHEDULER_REGION="${TR_REGIONAL_QUOTA_RECONCILER_REGION:-${TR_PRIMARY_REGION}}"
+SCHEDULE="${TR_REGIONAL_QUOTA_RECONCILER_SCHEDULE:-* * * * *}"
+
+service_url="$(
+  gc run services describe "$SERVICE" \
+    --region="$TR_PRIMARY_REGION" \
+    --format='value(status.url)'
+)"
+if [ -z "$service_url" ]; then
+  log "refusing regional quota scheduler deploy: primary service URL is missing"
+  exit 1
+fi
+
+internal_token="$(
+  gc secrets versions access latest \
+    --secret=trustedrouter-internal-gateway-token
+)"
+if [ -z "$internal_token" ]; then
+  log "refusing regional quota scheduler deploy: internal token is missing"
+  exit 1
+fi
+
+uri="${service_url}/v1/internal/gateway/regional-quota/reconcile?limit=250"
+headers="x-trustedrouter-internal-token=${internal_token},Content-Type=application/json"
+common_args=(
+  --location="$SCHEDULER_REGION"
+  --schedule="$SCHEDULE"
+  --time-zone=UTC
+  --uri="$uri"
+  --http-method=POST
+  --headers="$headers"
+  --attempt-deadline=30s
+  --max-retry-attempts=3
+  --min-backoff=5s
+  --max-backoff=30s
+  --quiet
+)
+
+if gc scheduler jobs describe "$SCHEDULER_NAME" \
+  --location="$SCHEDULER_REGION" >/dev/null 2>&1; then
+  log "updating regional quota reconciler schedule"
+  gc scheduler jobs update http "$SCHEDULER_NAME" "${common_args[@]}" >/dev/null
+else
+  log "creating regional quota reconciler schedule"
+  gc scheduler jobs create http "$SCHEDULER_NAME" "${common_args[@]}" >/dev/null
+fi
+
+# Do not let a previously paused scheduler make an enabled pilot silently
+# accumulate expired escrow. Resume is idempotent.
+gc scheduler jobs resume "$SCHEDULER_NAME" \
+  --location="$SCHEDULER_REGION" --quiet >/dev/null 2>&1 || true
+log "regional quota reconciler is scheduled once per minute"

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -307,6 +307,64 @@ if [ "$ANALYTICS_READ_MODE" = "clickhouse" ] && {
   ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 fi
 
+read_primary_env() {
+  local name="$1"
+  local default_value="${2:-}"
+  gc run services describe "$SERVICE" \
+    --region="$TR_PRIMARY_REGION" \
+    --format=json 2>/dev/null \
+    | jq -r --arg name "$name" --arg default_value "$default_value" '
+        [
+          .spec.template.spec.containers[0].env[]?
+          | select(.name == $name)
+          | .value
+        ][0] // $default_value
+      ' || true
+}
+
+# Regional quota leases are opt-in and workspace allowlisted. Preserve the
+# serving revision's state during ordinary deploys so a routine release cannot
+# silently turn a canary on or off. A fresh environment remains fail-closed.
+LIVE_REGIONAL_QUOTA_LEASES_ENABLED="$(
+  read_primary_env "TR_REGIONAL_QUOTA_LEASES_ENABLED" "false"
+)"
+REGIONAL_QUOTA_LEASES_ENABLED="${TR_REGIONAL_QUOTA_LEASES_ENABLED:-${LIVE_REGIONAL_QUOTA_LEASES_ENABLED:-false}}"
+case "$REGIONAL_QUOTA_LEASES_ENABLED" in
+  true|false) ;;
+  *)
+    log "refusing rollout: TR_REGIONAL_QUOTA_LEASES_ENABLED must be true or false"
+    exit 1
+    ;;
+esac
+REGIONAL_QUOTA_LEASE_PILOT_WORKSPACE_IDS="${TR_REGIONAL_QUOTA_LEASE_PILOT_WORKSPACE_IDS:-$(
+  read_primary_env "TR_REGIONAL_QUOTA_LEASE_PILOT_WORKSPACE_IDS"
+)}"
+REGIONAL_QUOTA_BIGTABLE_TABLE="${TR_REGIONAL_QUOTA_BIGTABLE_TABLE:-$(
+  read_primary_env "TR_REGIONAL_QUOTA_BIGTABLE_TABLE" "trustedrouter-regional-quota"
+)}"
+REGIONAL_QUOTA_BIGTABLE_APP_PROFILES="${TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES:-$(
+  read_primary_env "TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES"
+)}"
+REGIONAL_QUOTA_LEASE_TTL_SECONDS="${TR_REGIONAL_QUOTA_LEASE_TTL_SECONDS:-$(
+  read_primary_env "TR_REGIONAL_QUOTA_LEASE_TTL_SECONDS" "60"
+)}"
+REGIONAL_QUOTA_LEASE_MAX_MICRODOLLARS="${TR_REGIONAL_QUOTA_LEASE_MAX_MICRODOLLARS:-$(
+  read_primary_env "TR_REGIONAL_QUOTA_LEASE_MAX_MICRODOLLARS" "10000000"
+)}"
+REGIONAL_QUOTA_LEASE_MAX_AVAILABLE_BASIS_POINTS="${TR_REGIONAL_QUOTA_LEASE_MAX_AVAILABLE_BASIS_POINTS:-$(
+  read_primary_env "TR_REGIONAL_QUOTA_LEASE_MAX_AVAILABLE_BASIS_POINTS" "1000"
+)}"
+REGIONAL_QUOTA_LEASE_SHARD_COUNT="${TR_REGIONAL_QUOTA_LEASE_SHARD_COUNT:-$(
+  read_primary_env "TR_REGIONAL_QUOTA_LEASE_SHARD_COUNT" "16"
+)}"
+if [ "$REGIONAL_QUOTA_LEASES_ENABLED" = "true" ] && {
+  [ -z "$REGIONAL_QUOTA_LEASE_PILOT_WORKSPACE_IDS" ] ||
+  [ -z "$REGIONAL_QUOTA_BIGTABLE_APP_PROFILES" ];
+}; then
+  log "refusing rollout: regional quota canary requires pilot workspaces and fixed Bigtable app profiles"
+  exit 1
+fi
+
 # Prefer the private three-replica ClickHouse load balancer once provisioned.
 # The direct node-1 address remains only as a migration fallback for projects
 # that have not run clickhouse_cluster.sh yet.
@@ -477,9 +535,17 @@ ENV_VARS=(
   # operator overrides it. This prevents routine rollouts from reopening the
   # unbounded generic write path.
   "TR_REQUEST_RECORD_WRITE_MODE=${REQUEST_RECORD_WRITE_MODE}"
-  # Dark foundation only. Do not let a stale service-level env var activate a
-  # second billing authority during an ordinary production rollout.
-  "TR_REGIONAL_QUOTA_LEASES_ENABLED=false"
+  # Bounded regional escrow. This stays off by default and can serve only the
+  # explicit workspace allowlist. Ordinary deploys preserve the serving
+  # revision's state; startup fails closed if a required fixed profile is gone.
+  "TR_REGIONAL_QUOTA_LEASES_ENABLED=${REGIONAL_QUOTA_LEASES_ENABLED}"
+  "TR_REGIONAL_QUOTA_LEASE_PILOT_WORKSPACE_IDS=${REGIONAL_QUOTA_LEASE_PILOT_WORKSPACE_IDS}"
+  "TR_REGIONAL_QUOTA_LEASE_TTL_SECONDS=${REGIONAL_QUOTA_LEASE_TTL_SECONDS}"
+  "TR_REGIONAL_QUOTA_LEASE_MAX_MICRODOLLARS=${REGIONAL_QUOTA_LEASE_MAX_MICRODOLLARS}"
+  "TR_REGIONAL_QUOTA_LEASE_MAX_AVAILABLE_BASIS_POINTS=${REGIONAL_QUOTA_LEASE_MAX_AVAILABLE_BASIS_POINTS}"
+  "TR_REGIONAL_QUOTA_LEASE_SHARD_COUNT=${REGIONAL_QUOTA_LEASE_SHARD_COUNT}"
+  "TR_REGIONAL_QUOTA_BIGTABLE_TABLE=${REGIONAL_QUOTA_BIGTABLE_TABLE}"
+  "TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES=${REGIONAL_QUOTA_BIGTABLE_APP_PROFILES}"
 )
 SET_ENV_VARS="$(IFS='|'; echo "^|^${ENV_VARS[*]}")"
 

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -545,11 +545,11 @@ class Settings(BaseSettings):
     x402_settle_rate_limit_per_window: int = 30
     x402_settle_workspace_per_window: int = 120
     multi_region_enabled: bool = True
-    # Regional quota leases are a future latency optimization for prepaid
-    # authorization. The state machine and design are intentionally dark: the
-    # exact typed Spanner counters remain the only production authority until
-    # a durable regional ledger and reconciliation worker have passed the
-    # rollout gates in docs/design/regional-quota-leases.md.
+    # Regional quota leases remove hot global counter mutations from eligible
+    # prepaid authorization. Global Spanner still reserves every bounded grant
+    # and remains the source of truth; a fixed-cluster Bigtable row is only the
+    # regional escrow ledger. Production activation is workspace-allowlisted
+    # and validated fail-closed below.
     # ---- notifications (email / sms / voice to the account owner) ----------
     # Delivery credentials. TrustedRouter is the registered A2P 10DLC brand and
     # every customer's notification sends from these numbers, so a customer
@@ -643,6 +643,11 @@ class Settings(BaseSettings):
     regional_quota_lease_ttl_seconds: int = 60
     regional_quota_lease_max_microdollars: int = 10_000_000
     regional_quota_lease_max_available_basis_points: int = 1_000
+    regional_quota_lease_shard_count: int = 16
+    regional_quota_bigtable_table: str = "trustedrouter-regional-quota"
+    # Comma-separated region=single-cluster-app-profile pairs. A fixed profile
+    # is required because one lease has exactly one regional writer authority.
+    regional_quota_bigtable_app_profiles: str = ""
     # Operational read-only flag. When set, write paths (credit
     # reservations, gateway authorize, signup, etc.) return 503 with
     # `Retry-After`; reads keep working. Used for the Spanner →
@@ -984,17 +989,39 @@ class Settings(BaseSettings):
             raise ValueError(
                 "TR_REGIONAL_QUOTA_LEASE_MAX_AVAILABLE_BASIS_POINTS must be between 1 and 5000"
             )
+        if not 1 <= self.regional_quota_lease_shard_count <= 64:
+            raise ValueError("TR_REGIONAL_QUOTA_LEASE_SHARD_COUNT must be between 1 and 64")
         if self.regional_quota_leases_enabled:
-            if environment not in {"local", "test"}:
-                raise ValueError(
-                    "TR_REGIONAL_QUOTA_LEASES_ENABLED is not production-ready; "
-                    "the durable regional ledger and reconciliation gates are incomplete"
-                )
             if not self.regional_quota_lease_pilot_workspace_ids.strip():
                 raise ValueError(
                     "TR_REGIONAL_QUOTA_LEASES_ENABLED requires "
                     "TR_REGIONAL_QUOTA_LEASE_PILOT_WORKSPACE_IDS"
                 )
+            if environment not in {"local", "test"}:
+                if self.storage_backend not in {
+                    "spanner-bigtable",
+                    "spanner-clickhouse",
+                }:
+                    raise ValueError(
+                        "TR_REGIONAL_QUOTA_LEASES_ENABLED requires a Spanner GCP backend"
+                    )
+                if self.request_record_write_mode != "typed":
+                    raise ValueError(
+                        "TR_REGIONAL_QUOTA_LEASES_ENABLED requires typed request records"
+                    )
+                if not self.settle_outbox_enabled:
+                    raise ValueError(
+                        "TR_REGIONAL_QUOTA_LEASES_ENABLED requires the settle outbox"
+                    )
+                if not self.bigtable_instance_id:
+                    raise ValueError(
+                        "TR_REGIONAL_QUOTA_LEASES_ENABLED requires a Bigtable instance"
+                    )
+                if not self.regional_quota_bigtable_app_profile_map:
+                    raise ValueError(
+                        "TR_REGIONAL_QUOTA_LEASES_ENABLED requires fixed regional "
+                        "Bigtable app profiles"
+                    )
         # Parse for effect: a malformed entry must fail the process at
         # construction, not degrade into "no extra targets" that nobody
         # notices until a dead enclave goes unreported.
@@ -1384,6 +1411,28 @@ class Settings(BaseSettings):
             for workspace_id in self.regional_quota_lease_pilot_workspace_ids.split(",")
             if workspace_id.strip()
         )
+
+    @property
+    def regional_quota_bigtable_app_profile_map(self) -> dict[str, str]:
+        profiles: dict[str, str] = {}
+        for raw_entry in self.regional_quota_bigtable_app_profiles.split(","):
+            entry = raw_entry.strip()
+            if not entry:
+                continue
+            region, separator, profile = entry.partition("=")
+            region = region.strip()
+            profile = profile.strip()
+            if not separator or not region or not profile:
+                raise ValueError(
+                    "TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES entries must be "
+                    "region=app-profile"
+                )
+            if region in profiles:
+                raise ValueError(
+                    "TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES contains a duplicate region"
+                )
+            profiles[region] = profile
+        return profiles
 
     @property
     def ses_enabled(self) -> bool:

--- a/src/trusted_router/regional_quota_ledger.py
+++ b/src/trusted_router/regional_quota_ledger.py
@@ -1,0 +1,558 @@
+"""Durable regional ledger adapters for bounded prepaid quota escrow.
+
+The gateway hot path mutates one lease row atomically. Global Spanner has
+already reserved the full grant, so this ledger can never authorize more money
+than the globally escrowed amount. The Bigtable adapter uses an explicit
+compare-and-swap version cell and a fixed regional app profile for every lease.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import threading
+import uuid
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any, Protocol
+
+from trusted_router.services.regional_quota_leases import (
+    HoldState,
+    LeaseState,
+    QuotaLeaseHold,
+    RegionalQuotaLease,
+)
+
+_FAMILY = "lease"
+_STATE_COLUMN = b"state"
+_VERSION_COLUMN = b"version"
+_MAX_CAS_ATTEMPTS = 16
+
+
+class RegionalLeaseLedgerError(RuntimeError):
+    """The durable regional ledger could not complete an operation."""
+
+
+class RegionalLeaseCasExhausted(RegionalLeaseLedgerError):
+    pass
+
+
+class RegionalLeaseNotFound(RegionalLeaseLedgerError):
+    pass
+
+
+class RegionalQuotaLedger(Protocol):
+    def initialize(self, lease: RegionalQuotaLease) -> RegionalQuotaLease: ...
+
+    def get(self, lease_id: str, *, region: str) -> RegionalQuotaLease | None: ...
+
+    def reserve(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        hold_id: str,
+        fingerprint: str,
+        amount_microdollars: int,
+        fencing_token: int,
+        key_hash: str,
+        key_shard: int,
+        hold_expires_at: datetime | None = None,
+        now: datetime | None = None,
+    ) -> RegionalQuotaLease: ...
+
+    def settle(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        hold_id: str,
+        actual_microdollars: int,
+        fencing_token: int,
+    ) -> RegionalQuotaLease: ...
+
+    def refund(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        hold_id: str,
+        fencing_token: int,
+    ) -> RegionalQuotaLease: ...
+
+    def begin_drain(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        fencing_token: int,
+    ) -> RegionalQuotaLease: ...
+
+    def close(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        fencing_token: int,
+    ) -> RegionalQuotaLease: ...
+
+
+class InMemoryRegionalQuotaLedger:
+    """Transactionally faithful test twin of the Bigtable row adapter."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._leases: dict[tuple[str, str], RegionalQuotaLease] = {}
+
+    def initialize(self, lease: RegionalQuotaLease) -> RegionalQuotaLease:
+        key = (lease.region, lease.lease_id)
+        with self._lock:
+            existing = self._leases.get(key)
+            if existing is not None:
+                if existing != lease:
+                    raise RegionalLeaseLedgerError(
+                        "lease ID already contains different durable state"
+                    )
+                return existing
+            self._leases[key] = lease
+            return lease
+
+    def get(self, lease_id: str, *, region: str) -> RegionalQuotaLease | None:
+        with self._lock:
+            return self._leases.get((region, lease_id))
+
+    def _apply(
+        self,
+        lease_id: str,
+        region: str,
+        transition: Callable[[RegionalQuotaLease], RegionalQuotaLease],
+    ) -> RegionalQuotaLease:
+        with self._lock:
+            key = (region, lease_id)
+            current = self._leases.get(key)
+            if current is None:
+                raise RegionalLeaseNotFound("regional lease was not found")
+            updated = transition(current)
+            self._leases[key] = updated
+            return updated
+
+    def reserve(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        hold_id: str,
+        fingerprint: str,
+        amount_microdollars: int,
+        fencing_token: int,
+        key_hash: str,
+        key_shard: int,
+        hold_expires_at: datetime | None = None,
+        now: datetime | None = None,
+    ) -> RegionalQuotaLease:
+        return self._apply(
+            lease_id,
+            region,
+            lambda lease: (
+                lease.reserve(
+                    hold_id=hold_id,
+                    fingerprint=fingerprint,
+                    amount_microdollars=amount_microdollars,
+                    fencing_token=fencing_token,
+                    key_hash=key_hash,
+                    key_shard=key_shard,
+                    hold_expires_at=hold_expires_at,
+                    now=now,
+                ).lease
+            ),
+        )
+
+    def settle(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        hold_id: str,
+        actual_microdollars: int,
+        fencing_token: int,
+    ) -> RegionalQuotaLease:
+        return self._apply(
+            lease_id,
+            region,
+            lambda lease: (
+                lease.settle(
+                    hold_id=hold_id,
+                    actual_microdollars=actual_microdollars,
+                    fencing_token=fencing_token,
+                ).lease
+            ),
+        )
+
+    def refund(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        hold_id: str,
+        fencing_token: int,
+    ) -> RegionalQuotaLease:
+        return self._apply(
+            lease_id,
+            region,
+            lambda lease: (
+                lease.refund(
+                    hold_id=hold_id,
+                    fencing_token=fencing_token,
+                ).lease
+            ),
+        )
+
+    def begin_drain(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        fencing_token: int,
+    ) -> RegionalQuotaLease:
+        return self._apply(
+            lease_id,
+            region,
+            lambda lease: lease.begin_drain(fencing_token=fencing_token),
+        )
+
+    def close(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        fencing_token: int,
+    ) -> RegionalQuotaLease:
+        return self._apply(
+            lease_id,
+            region,
+            lambda lease: lease.close(fencing_token=fencing_token),
+        )
+
+
+class BigtableRegionalQuotaLedger:
+    """Single-row CAS ledger routed through fixed regional app profiles."""
+
+    def __init__(self, tables_by_region: dict[str, Any]) -> None:
+        if not tables_by_region:
+            raise ValueError("at least one regional Bigtable table is required")
+        self._tables = dict(tables_by_region)
+        try:
+            from google.cloud.bigtable.row_filters import (
+                CellsColumnLimitFilter,
+                ColumnQualifierRegexFilter,
+                FamilyNameRegexFilter,
+                RowFilterChain,
+                ValueRegexFilter,
+            )
+        except ImportError as exc:  # pragma: no cover - production dependency
+            raise RuntimeError("google-cloud-bigtable is required") from exc
+        self._cells_limit_filter = CellsColumnLimitFilter
+        self._column_filter = ColumnQualifierRegexFilter
+        self._family_filter = FamilyNameRegexFilter
+        self._chain_filter = RowFilterChain
+        self._value_filter = ValueRegexFilter
+
+    def initialize(self, lease: RegionalQuotaLease) -> RegionalQuotaLease:
+        table = self._table(lease.region)
+        row_key = _row_key(lease)
+        state = _serialize_lease(lease)
+        version = uuid.uuid4().hex.encode("ascii")
+        predicate = self._version_exists_filter()
+        row = table.row(row_key, filter_=predicate)
+        row.set_cell(_FAMILY, _STATE_COLUMN, state, state=False)
+        row.set_cell(_FAMILY, _VERSION_COLUMN, version, state=False)
+        try:
+            matched = bool(row.commit())
+        except Exception as exc:  # pragma: no cover - remote transport
+            raise RegionalLeaseLedgerError("regional lease initialization failed") from exc
+        if not matched:
+            return lease
+        existing = self.get(lease.lease_id, region=lease.region)
+        if existing is None:
+            raise RegionalLeaseLedgerError("lease initialization was ambiguous")
+        if existing != lease:
+            raise RegionalLeaseLedgerError("lease ID already contains different durable state")
+        return existing
+
+    def get(self, lease_id: str, *, region: str) -> RegionalQuotaLease | None:
+        table = self._table(region)
+        try:
+            row = table.read_row(
+                _row_key_for(region, lease_id),
+                filter_=self._state_filter(),
+            )
+        except Exception as exc:  # pragma: no cover - remote transport
+            raise RegionalLeaseLedgerError("regional lease read failed") from exc
+        if row is None:
+            return None
+        state, _version = _state_and_version(row)
+        return _deserialize_lease(state)
+
+    def reserve(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        hold_id: str,
+        fingerprint: str,
+        amount_microdollars: int,
+        fencing_token: int,
+        key_hash: str,
+        key_shard: int,
+        hold_expires_at: datetime | None = None,
+        now: datetime | None = None,
+    ) -> RegionalQuotaLease:
+        return self._transition(
+            lease_id,
+            region=region,
+            transition=lambda lease: (
+                lease.reserve(
+                    hold_id=hold_id,
+                    fingerprint=fingerprint,
+                    amount_microdollars=amount_microdollars,
+                    fencing_token=fencing_token,
+                    key_hash=key_hash,
+                    key_shard=key_shard,
+                    hold_expires_at=hold_expires_at,
+                    now=now,
+                ).lease
+            ),
+        )
+
+    def settle(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        hold_id: str,
+        actual_microdollars: int,
+        fencing_token: int,
+    ) -> RegionalQuotaLease:
+        return self._transition(
+            lease_id,
+            region=region,
+            transition=lambda lease: (
+                lease.settle(
+                    hold_id=hold_id,
+                    actual_microdollars=actual_microdollars,
+                    fencing_token=fencing_token,
+                ).lease
+            ),
+        )
+
+    def refund(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        hold_id: str,
+        fencing_token: int,
+    ) -> RegionalQuotaLease:
+        return self._transition(
+            lease_id,
+            region=region,
+            transition=lambda lease: (
+                lease.refund(
+                    hold_id=hold_id,
+                    fencing_token=fencing_token,
+                ).lease
+            ),
+        )
+
+    def begin_drain(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        fencing_token: int,
+    ) -> RegionalQuotaLease:
+        return self._transition(
+            lease_id,
+            region=region,
+            transition=lambda lease: lease.begin_drain(fencing_token=fencing_token),
+        )
+
+    def close(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        fencing_token: int,
+    ) -> RegionalQuotaLease:
+        return self._transition(
+            lease_id,
+            region=region,
+            transition=lambda lease: lease.close(fencing_token=fencing_token),
+        )
+
+    def _transition(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        transition: Callable[[RegionalQuotaLease], RegionalQuotaLease],
+    ) -> RegionalQuotaLease:
+        table = self._table(region)
+        row_key = _row_key_for(region, lease_id)
+        last_error: Exception | None = None
+        for _attempt in range(_MAX_CAS_ATTEMPTS):
+            try:
+                row_data = table.read_row(row_key, filter_=self._state_filter())
+            except Exception as exc:  # pragma: no cover - remote transport
+                raise RegionalLeaseLedgerError("regional lease read failed") from exc
+            if row_data is None:
+                raise RegionalLeaseNotFound("regional lease was not found")
+            state, current_version = _state_and_version(row_data)
+            updated = transition(_deserialize_lease(state))
+            updated_state = _serialize_lease(updated)
+            next_version = uuid.uuid4().hex.encode("ascii")
+            predicate = self._version_equals_filter(current_version)
+            row = table.row(row_key, filter_=predicate)
+            row.set_cell(_FAMILY, _STATE_COLUMN, updated_state, state=True)
+            row.set_cell(_FAMILY, _VERSION_COLUMN, next_version, state=True)
+            try:
+                if row.commit():
+                    return updated
+            except Exception as exc:  # pragma: no cover - remote transport
+                # The commit may have reached Bigtable. Re-read on the next
+                # attempt; every transition is idempotent by hold ID/fence.
+                last_error = exc
+                continue
+        raise RegionalLeaseCasExhausted(
+            "regional lease compare-and-swap retries were exhausted"
+        ) from last_error
+
+    def _table(self, region: str) -> Any:
+        table = self._tables.get(region)
+        if table is None:
+            raise RegionalLeaseLedgerError(
+                f"no fixed Bigtable app profile is configured for region {region}"
+            )
+        return table
+
+    def _version_exists_filter(self) -> Any:
+        return self._chain_filter(
+            [
+                self._family_filter(f"^{_FAMILY}$"),
+                self._column_filter(b"^version$"),
+                self._cells_limit_filter(1),
+            ]
+        )
+
+    def _version_equals_filter(self, version: bytes) -> Any:
+        return self._chain_filter(
+            [
+                self._family_filter(f"^{_FAMILY}$"),
+                self._column_filter(b"^version$"),
+                self._value_filter(b"^" + re.escape(version) + b"$"),
+                self._cells_limit_filter(1),
+            ]
+        )
+
+    def _state_filter(self) -> Any:
+        return self._chain_filter(
+            [
+                self._family_filter(f"^{_FAMILY}$"),
+                self._column_filter(b"^(state|version)$"),
+                self._cells_limit_filter(1),
+            ]
+        )
+
+
+def settled_key_totals(lease: RegionalQuotaLease) -> dict[tuple[str, int], int]:
+    totals: dict[tuple[str, int], int] = {}
+    for hold in lease.holds:
+        if hold.state != HoldState.SETTLED or not hold.key_hash:
+            continue
+        key = (hold.key_hash, hold.key_shard)
+        totals[key] = totals.get(key, 0) + int(hold.actual_microdollars or 0)
+    return totals
+
+
+def _row_key(lease: RegionalQuotaLease) -> bytes:
+    return _row_key_for(lease.region, lease.lease_id)
+
+
+def _row_key_for(region: str, lease_id: str) -> bytes:
+    spread = hashlib.sha256(lease_id.encode("utf-8")).hexdigest()[:4]
+    return f"{spread}#lease#{region}#{lease_id}".encode()
+
+
+def _serialize_lease(lease: RegionalQuotaLease) -> bytes:
+    payload = {
+        "lease_id": lease.lease_id,
+        "workspace_id": lease.workspace_id,
+        "region": lease.region,
+        "fencing_token": lease.fencing_token,
+        "granted_microdollars": lease.granted_microdollars,
+        "expires_at": lease.expires_at.astimezone(UTC).isoformat(),
+        "state": lease.state.value,
+        "holds": [
+            {
+                "hold_id": hold.hold_id,
+                "fingerprint": hold.fingerprint,
+                "reserved_microdollars": hold.reserved_microdollars,
+                "key_hash": hold.key_hash,
+                "key_shard": hold.key_shard,
+                "expires_at": (
+                    hold.expires_at.astimezone(UTC).isoformat()
+                    if hold.expires_at is not None
+                    else None
+                ),
+                "state": hold.state.value,
+                "actual_microdollars": hold.actual_microdollars,
+            }
+            for hold in lease.holds
+        ],
+    }
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _deserialize_lease(value: bytes) -> RegionalQuotaLease:
+    payload = json.loads(value.decode("utf-8"))
+    return RegionalQuotaLease(
+        lease_id=str(payload["lease_id"]),
+        workspace_id=str(payload["workspace_id"]),
+        region=str(payload["region"]),
+        fencing_token=int(payload["fencing_token"]),
+        granted_microdollars=int(payload["granted_microdollars"]),
+        expires_at=datetime.fromisoformat(str(payload["expires_at"])),
+        state=LeaseState(str(payload["state"])),
+        holds=tuple(
+            QuotaLeaseHold(
+                hold_id=str(item["hold_id"]),
+                fingerprint=str(item["fingerprint"]),
+                reserved_microdollars=int(item["reserved_microdollars"]),
+                key_hash=str(item.get("key_hash") or ""),
+                key_shard=int(item.get("key_shard") or 0),
+                expires_at=(
+                    None
+                    if item.get("expires_at") is None
+                    else datetime.fromisoformat(str(item["expires_at"]))
+                ),
+                state=HoldState(str(item["state"])),
+                actual_microdollars=(
+                    None
+                    if item.get("actual_microdollars") is None
+                    else int(item["actual_microdollars"])
+                ),
+            )
+            for item in payload.get("holds", [])
+        ),
+    )
+
+
+def _state_and_version(row: Any) -> tuple[bytes, bytes]:
+    try:
+        family = row.cells[_FAMILY]
+        state = bytes(family[_STATE_COLUMN][0].value)
+        version = bytes(family[_VERSION_COLUMN][0].value)
+    except (KeyError, IndexError, TypeError, AttributeError) as exc:
+        raise RegionalLeaseLedgerError("regional lease row is incomplete") from exc
+    return state, version

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -608,44 +608,98 @@ def _authorize_gateway_sync(
         )
         key_usage_shards = key_usage_shard_count(api_key)
         try:
-            outcome, authorization = _typed_store.authorize_gateway_typed(
-                workspace_id=workspace.id,
-                key_hash=api_key.hash,
-                authorization_id=authorization_id,
-                estimate=estimate,
-                has_credit_candidate=has_credit_candidate,
-                reservation_usage_type=reservation_usage_type,
-                model_id=model.id,
-                provider=endpoint.provider,
-                requested_model_id=requested_model_id,
-                candidate_model_ids=[m.id for m, _e in endpoint_candidates],
-                region=region,
-                endpoint_id=endpoint.id,
-                candidate_endpoint_ids=[e.id for _m, e in endpoint_candidates],
-                idempotency_key=request_idempotency_key,
-                tags=effective_tags,
-                idempotency_fingerprint=request_fingerprint,
-                key_usage_shards=key_usage_shards,
-                custom_model_id=custom_model.id if custom_model else None,
-                custom_model_revision=custom_model.revision if custom_model else None,
-                user_provided_model_id=user_model.id if user_model else None,
-                user_provided_model_revision=user_model.revision if user_model else None,
-                user_model_prompt_price_microdollars_per_m=(
-                    user_model.prompt_price_microdollars_per_million_tokens
-                    if user_model
-                    else None
-                ),
-                user_model_completion_price_microdollars_per_m=(
-                    user_model.completion_price_microdollars_per_million_tokens
-                    if user_model
-                    else None
-                ),
-                user_model_owner_user_id=user_model.owner_user_id if user_model else None,
-                additional_cost_reservation_microdollars=additional_cost_reservation,
-                native_batch_eligible=native_batch_eligible,
-                expires_at=expires_at,
-                window_limits=window_limits or None,
+            regional_authorize = getattr(
+                _typed_store,
+                "authorize_gateway_regional",
+                None,
             )
+            regional_eligible = (
+                settings.regional_quota_leases_enabled
+                and workspace.id in settings.regional_quota_lease_pilot_workspaces
+                and callable(regional_authorize)
+                and estimate > 0
+                and body.route_type in {None, "chat.completions", "responses"}
+                and all(
+                    UsageType.for_endpoint(candidate_endpoint) == UsageType.CREDITS
+                    for _candidate_model, candidate_endpoint in endpoint_candidates
+                )
+                and api_key.limit_microdollars is None
+                and api_key.limit_daily_microdollars is None
+                and api_key.limit_weekly_microdollars is None
+                and api_key.limit_monthly_microdollars is None
+                and custom_model is None
+                and user_model is None
+                and partner_mode is None
+                and additional_cost_reservation == 0
+                and not native_batch_eligible
+            )
+            outcome = "unavailable"
+            authorization = None
+            if regional_eligible:
+                assert callable(regional_authorize)
+                outcome, authorization = regional_authorize(
+                    authorization_id=authorization_id,
+                    workspace_id=workspace.id,
+                    key_hash=api_key.hash,
+                    key_usage_shards=key_usage_shards,
+                    estimate=estimate,
+                    model_id=model.id,
+                    provider=endpoint.provider,
+                    requested_model_id=requested_model_id,
+                    candidate_model_ids=[m.id for m, _e in endpoint_candidates],
+                    region=region,
+                    endpoint_id=endpoint.id,
+                    candidate_endpoint_ids=[e.id for _m, e in endpoint_candidates],
+                    idempotency_key=request_idempotency_key,
+                    idempotency_fingerprint=request_fingerprint,
+                    tags=effective_tags,
+                    expires_at=expires_at,
+                    lease_ttl_seconds=settings.regional_quota_lease_ttl_seconds,
+                    lease_max_microdollars=settings.regional_quota_lease_max_microdollars,
+                    lease_max_available_basis_points=(
+                        settings.regional_quota_lease_max_available_basis_points
+                    ),
+                    lease_shard_count=settings.regional_quota_lease_shard_count,
+                )
+            if outcome == "unavailable":
+                outcome, authorization = _typed_store.authorize_gateway_typed(
+                    workspace_id=workspace.id,
+                    key_hash=api_key.hash,
+                    authorization_id=authorization_id,
+                    estimate=estimate,
+                    has_credit_candidate=has_credit_candidate,
+                    reservation_usage_type=reservation_usage_type,
+                    model_id=model.id,
+                    provider=endpoint.provider,
+                    requested_model_id=requested_model_id,
+                    candidate_model_ids=[m.id for m, _e in endpoint_candidates],
+                    region=region,
+                    endpoint_id=endpoint.id,
+                    candidate_endpoint_ids=[e.id for _m, e in endpoint_candidates],
+                    idempotency_key=request_idempotency_key,
+                    tags=effective_tags,
+                    idempotency_fingerprint=request_fingerprint,
+                    key_usage_shards=key_usage_shards,
+                    custom_model_id=custom_model.id if custom_model else None,
+                    custom_model_revision=custom_model.revision if custom_model else None,
+                    user_provided_model_id=user_model.id if user_model else None,
+                    user_provided_model_revision=user_model.revision if user_model else None,
+                    user_model_prompt_price_microdollars_per_m=(
+                        user_model.prompt_price_microdollars_per_million_tokens
+                        if user_model
+                        else None
+                    ),
+                    user_model_completion_price_microdollars_per_m=(
+                        user_model.completion_price_microdollars_per_million_tokens
+                        if user_model
+                        else None
+                    ),
+                    user_model_owner_user_id=user_model.owner_user_id if user_model else None,
+                    additional_cost_reservation_microdollars=additional_cost_reservation,
+                    native_batch_eligible=native_batch_eligible,
+                    expires_at=expires_at,
+                    window_limits=window_limits or None,
+                )
         except conflict_store_error_types() as exc:
             release_user_model_slot_after_error()
             # The generic 503 request log cannot identify a tenant hot row.
@@ -798,14 +852,10 @@ def _authorize_gateway_sync(
             user_provided_model_id=user_model.id if user_model else None,
             user_provided_model_revision=user_model.revision if user_model else None,
             user_model_prompt_price_microdollars_per_m=(
-                user_model.prompt_price_microdollars_per_million_tokens
-                if user_model
-                else None
+                user_model.prompt_price_microdollars_per_million_tokens if user_model else None
             ),
             user_model_completion_price_microdollars_per_m=(
-                user_model.completion_price_microdollars_per_million_tokens
-                if user_model
-                else None
+                user_model.completion_price_microdollars_per_million_tokens if user_model else None
             ),
             user_model_owner_user_id=user_model.owner_user_id if user_model else None,
             additional_cost_reservation_microdollars=additional_cost_reservation,
@@ -1104,6 +1154,39 @@ def register(router: APIRouter) -> None:
         # cadence visible on /fleet so a silently-dead scheduler is seen.
         await run_in_threadpool(record_heartbeat, "job:settle-outbox-drain", settings=settings)
         return result
+
+    @router.post("/internal/gateway/regional-quota/reconcile")
+    async def gateway_regional_quota_reconcile(
+        request: Request,
+        settings: SettingsDep,
+        limit: int = 100,
+    ) -> dict[str, int]:
+        require_internal_gateway(request, settings)
+        method = getattr(STORE, "reconcile_regional_quota_leases", None)
+        if not settings.regional_quota_leases_enabled or not callable(method):
+            return {"inspected": 0, "reconciled": 0, "closed": 0, "errors": 0}
+        result = await run_in_threadpool(method, limit=max(1, min(limit, 1000)))
+        if int(result.get("errors", 0)):
+            logger.error(
+                "regional_quota.reconcile_incomplete",
+                extra={
+                    "inspected": int(result.get("inspected", 0)),
+                    "reconciled": int(result.get("reconciled", 0)),
+                    "closed": int(result.get("closed", 0)),
+                    "errors": int(result.get("errors", 0)),
+                },
+            )
+            raise api_error(
+                503,
+                "Regional quota reconciliation is incomplete",
+                ErrorType.SERVICE_UNAVAILABLE,
+            )
+        await run_in_threadpool(
+            record_heartbeat,
+            "job:regional-quota-reconcile",
+            settings=settings,
+        )
+        return cast(dict[str, int], result)
 
     @router.post("/internal/gateway/home-settlement/drain")
     async def gateway_home_settlement_drain(
@@ -1646,8 +1729,10 @@ def _settle_gateway_authorization(
             "selected endpoint was not authorized for this gateway request",
             ErrorType.BAD_REQUEST,
         )
-    model = user_model_pair[0] if user_model_pair is not None else MODELS.get(
-        selected_endpoint.model_id
+    model = (
+        user_model_pair[0]
+        if user_model_pair is not None
+        else MODELS.get(selected_endpoint.model_id)
     )
     if model is None:
         raise api_error(500, "Authorized model is no longer configured", ErrorType.INTERNAL_ERROR)
@@ -1690,9 +1775,7 @@ def _settle_gateway_authorization(
             input_tokens=total_input,
             output_tokens=output_tokens,
             prompt_price=int(authorization.user_model_prompt_price_microdollars_per_m or 0),
-            completion_price=int(
-                authorization.user_model_completion_price_microdollars_per_m or 0
-            ),
+            completion_price=int(authorization.user_model_completion_price_microdollars_per_m or 0),
         )
         if user_model_pair is not None
         else partner_cost_microdollars(
@@ -1748,8 +1831,7 @@ def _settle_gateway_authorization(
     operator_cost = (
         owner_share_microdollars(actual_cost)
         if user_model_pair is not None
-        else
-        _endpoint_cost_microdollars(
+        else _endpoint_cost_microdollars(
             selected_endpoint,
             uncached_input,
             output_tokens,
@@ -1790,6 +1872,22 @@ def _settle_gateway_authorization(
         actual_cost += additional_cost
     input_tokens = total_input
     selected_usage_type = UsageType.for_endpoint(selected_endpoint)
+    if (
+        success
+        and authorization.settlement == "regional_lease"
+        and actual_cost > authorization.estimated_microdollars
+    ):
+        logger.warning(
+            "billing.regional_settle_capped_to_escrow",
+            extra={
+                "authorization_id": authorization.id,
+                "workspace_id": authorization.workspace_id,
+                "estimated_microdollars": authorization.estimated_microdollars,
+                "actual_microdollars": actual_cost,
+                "overrun_microdollars": (actual_cost - authorization.estimated_microdollars),
+            },
+        )
+        actual_cost = authorization.estimated_microdollars
     if (
         success
         and selected_usage_type == UsageType.CREDITS
@@ -1841,9 +1939,7 @@ def _settle_gateway_authorization(
         user_model_payout = UserModelPayout(
             owner_user_id=owner_user_id,
             model_id=user_model_id,
-            amount_microdollars=(
-                owner_share_microdollars(actual_cost) if success else 0
-            ),
+            amount_microdollars=(owner_share_microdollars(actual_cost) if success else 0),
             payer_workspace_id=authorization.workspace_id,
         )
 
@@ -1864,9 +1960,7 @@ def _settle_gateway_authorization(
                 frozen_settle_body[USER_MODEL_PAYOUT_SETTLE_FIELD] = (
                     user_model_payout.amount_microdollars
                 )
-                frozen_settle_body[USER_MODEL_OWNER_SETTLE_FIELD] = (
-                    user_model_payout.owner_user_id
-                )
+                frozen_settle_body[USER_MODEL_OWNER_SETTLE_FIELD] = user_model_payout.owner_user_id
                 frozen_settle_body[USER_MODEL_ID_SETTLE_FIELD] = user_model_payout.model_id
             # §5.4 honest scope: durability starts only when this INSERT commits;
             # crashes before it still rely on enclave redelivery. MF4/MF5 freeze
@@ -2391,9 +2485,7 @@ def _user_model_gateway_candidate(
         model_id=user_model.id,
         name=user_model.name,
         revision=user_model.revision,
-        prompt_price_microdollars_per_m=(
-            user_model.prompt_price_microdollars_per_million_tokens
-        ),
+        prompt_price_microdollars_per_m=(user_model.prompt_price_microdollars_per_million_tokens),
         completion_price_microdollars_per_m=(
             user_model.completion_price_microdollars_per_million_tokens
         ),
@@ -2425,12 +2517,7 @@ def _authorized_user_model_pair(
     prompt_price = authorization.user_model_prompt_price_microdollars_per_m
     completion_price = authorization.user_model_completion_price_microdollars_per_m
     owner_user_id = authorization.user_model_owner_user_id
-    if (
-        revision is None
-        or prompt_price is None
-        or completion_price is None
-        or not owner_user_id
-    ):
+    if revision is None or prompt_price is None or completion_price is None or not owner_user_id:
         return None
     try:
         return user_model_gateway_pair(
@@ -2699,11 +2786,7 @@ def _require_native_batch_route_binding(
 
 
 def _authorization_ttl_seconds(route_type: str | None) -> int:
-    return (
-        26 * 60 * 60
-        if _is_native_batch_route(route_type)
-        else GATEWAY_RESERVATION_TTL_SECONDS
-    )
+    return 26 * 60 * 60 if _is_native_batch_route(route_type) else GATEWAY_RESERVATION_TTL_SECONDS
 
 
 def _native_batch_cost_or_error(

--- a/src/trusted_router/services/regional_quota_leases.py
+++ b/src/trusted_router/services/regional_quota_leases.py
@@ -1,9 +1,4 @@
-"""Pure, dark state machine for future regional prepaid quota leases.
-
-This module is deliberately not connected to gateway authorization. It models
-the invariants that a durable regional ledger must enforce before the exact
-typed Spanner billing path can safely delegate bounded spend.
-"""
+"""Pure state machine for bounded regional prepaid quota escrow."""
 
 from __future__ import annotations
 
@@ -54,6 +49,9 @@ class QuotaLeaseHold:
     hold_id: str
     fingerprint: str
     reserved_microdollars: int
+    key_hash: str = ""
+    key_shard: int = 0
+    expires_at: datetime | None = None
     state: HoldState = HoldState.RESERVED
     actual_microdollars: int | None = None
 
@@ -62,6 +60,10 @@ class QuotaLeaseHold:
             raise RegionalQuotaLeaseError("hold_id and fingerprint are required")
         if self.reserved_microdollars <= 0:
             raise RegionalQuotaLeaseError("reserved_microdollars must be positive")
+        if self.key_shard < 0:
+            raise RegionalQuotaLeaseError("key_shard must not be negative")
+        if self.expires_at is not None and self.expires_at.tzinfo is None:
+            raise RegionalQuotaLeaseError("hold expires_at must be timezone-aware")
         if self.state == HoldState.RESERVED and self.actual_microdollars is not None:
             raise RegionalQuotaLeaseError("reserved hold cannot have an actual amount")
         if self.state == HoldState.SETTLED and not (
@@ -95,9 +97,7 @@ class RegionalQuotaLease:
 
     def __post_init__(self) -> None:
         if not self.lease_id or not self.workspace_id or not self.region:
-            raise RegionalQuotaLeaseError(
-                "lease_id, workspace_id, and region are required"
-            )
+            raise RegionalQuotaLeaseError("lease_id, workspace_id, and region are required")
         if self.fencing_token <= 0:
             raise RegionalQuotaLeaseError("fencing_token must be positive")
         if self.granted_microdollars <= 0:
@@ -112,17 +112,13 @@ class RegionalQuotaLease:
     @property
     def reserved_microdollars(self) -> int:
         return sum(
-            hold.reserved_microdollars
-            for hold in self.holds
-            if hold.state == HoldState.RESERVED
+            hold.reserved_microdollars for hold in self.holds if hold.state == HoldState.RESERVED
         )
 
     @property
     def spent_microdollars(self) -> int:
         return sum(
-            hold.actual_microdollars or 0
-            for hold in self.holds
-            if hold.state == HoldState.SETTLED
+            hold.actual_microdollars or 0 for hold in self.holds if hold.state == HoldState.SETTLED
         )
 
     @property
@@ -140,6 +136,9 @@ class RegionalQuotaLease:
         fingerprint: str,
         amount_microdollars: int,
         fencing_token: int,
+        key_hash: str = "",
+        key_shard: int = 0,
+        hold_expires_at: datetime | None = None,
         now: datetime | None = None,
     ) -> LeaseTransition:
         now = _utc_now() if now is None else now
@@ -150,6 +149,9 @@ class RegionalQuotaLease:
             if (
                 existing.fingerprint != fingerprint
                 or existing.reserved_microdollars != amount_microdollars
+                or existing.key_hash != key_hash
+                or existing.key_shard != key_shard
+                or existing.expires_at != hold_expires_at
             ):
                 raise LeaseIdempotencyConflictError(
                     "hold ID was reused with different reservation inputs"
@@ -167,6 +169,9 @@ class RegionalQuotaLease:
             hold_id=hold_id,
             fingerprint=fingerprint,
             reserved_microdollars=amount_microdollars,
+            key_hash=key_hash,
+            key_shard=key_shard,
+            expires_at=hold_expires_at,
         )
         lease = replace(self, holds=(*self.holds, hold))
         return LeaseTransition(lease, hold, False)
@@ -182,9 +187,7 @@ class RegionalQuotaLease:
         hold = self._required_hold(hold_id)
         if hold.state == HoldState.SETTLED:
             if hold.actual_microdollars != actual_microdollars:
-                raise LeaseIdempotencyConflictError(
-                    "settlement replay changed the actual amount"
-                )
+                raise LeaseIdempotencyConflictError("settlement replay changed the actual amount")
             return LeaseTransition(self, hold, True)
         if hold.state == HoldState.REFUNDED:
             raise LeaseSettlementError("refunded hold cannot be settled")
@@ -257,8 +260,7 @@ class RegionalQuotaLease:
         return replace(
             self,
             holds=tuple(
-                replacement if hold.hold_id == replacement.hold_id else hold
-                for hold in self.holds
+                replacement if hold.hold_id == replacement.hold_id else hold for hold in self.holds
             ),
         )
 
@@ -272,19 +274,18 @@ def bounded_lease_grant_microdollars(
 ) -> int:
     """Return a bounded grant; the global transaction must escrow this amount."""
 
-    if min(
-        available_microdollars,
-        requested_microdollars,
-        per_lease_cap_microdollars,
-    ) < 0:
+    if (
+        min(
+            available_microdollars,
+            requested_microdollars,
+            per_lease_cap_microdollars,
+        )
+        < 0
+    ):
         raise RegionalQuotaLeaseError("lease grant inputs cannot be negative")
     if not 1 <= max_available_basis_points <= 10_000:
-        raise RegionalQuotaLeaseError(
-            "max_available_basis_points must be between 1 and 10000"
-        )
-    fraction_cap = (
-        available_microdollars * max_available_basis_points // 10_000
-    )
+        raise RegionalQuotaLeaseError("max_available_basis_points must be between 1 and 10000")
+    fraction_cap = available_microdollars * max_available_basis_points // 10_000
     return min(requested_microdollars, per_lease_cap_microdollars, fraction_cap)
 
 

--- a/src/trusted_router/services/settle_outbox_apply.py
+++ b/src/trusted_router/services/settle_outbox_apply.py
@@ -17,7 +17,9 @@ from trusted_router.custom_model_billing import (
     user_model_payout_event_id,
 )
 from trusted_router.partner_billing import PARTNER_OPERATOR_COST_SETTLE_FIELD
+from trusted_router.regional_quota_ledger import RegionalLeaseLedgerError
 from trusted_router.schemas import GatewaySettleRequest
+from trusted_router.services.regional_quota_leases import LeaseSettlementError
 from trusted_router.storage import STORE, Generation, typed_billing_store
 from trusted_router.storage_errors import transient_store_error_types
 from trusted_router.storage_gcp_authorize import SettleOutcome
@@ -44,6 +46,11 @@ logger = logging.getLogger(__name__)
 # ResourceExhausted (session-pool and admission-control overload)/RetryError/
 # ServiceUnavailable, plus the backend-neutral StoreConflict/StoreUnavailable.
 _TRANSIENT_STORE_EXCS = transient_store_error_types()
+_REGIONAL_SETTLE_RETRY_EXCS: tuple[type[Exception], ...] = (
+    *_TRANSIENT_STORE_EXCS,
+    RegionalLeaseLedgerError,
+    LeaseSettlementError,
+)
 
 # Rolling legacy rows can still carry this historical marker. New typed rows
 # atomically enqueue ClickHouse delivery in the settlement transaction and do
@@ -318,6 +325,49 @@ def _apply_typed(
     if auth.credit_reservation_id is None:
         return ApplyOutcome.RESERVATION_MISSING
 
+    # A regional request must settle/refund its durable local hold before the
+    # typed Spanner request record becomes terminal. Calling the lower-level
+    # typed primitive directly would skip that step; the reconciler could then
+    # release the grant as unused and turn an outbox-recovered request into a
+    # free request. The wrapper is idempotent at both boundaries.
+    if auth.settlement == "regional_lease":
+        regional_finalize = getattr(
+            typed_store,
+            "typed_finalize_gateway_authorization_result",
+            None,
+        )
+        if not callable(regional_finalize):
+            return ApplyOutcome.PARK_TYPED_UNAVAILABLE
+        try:
+            existing_reservation = typed_store.read_typed_reservation(auth.credit_reservation_id)
+            if existing_reservation is not None and existing_reservation.get("settled"):
+                finalize_result = None
+            else:
+                finalize_result = regional_finalize(
+                    auth.id,
+                    success=success,
+                    actual_microdollars=row.actual_cost_micro,
+                    selected_usage_type=usage_type,
+                    generation=generation,
+                    user_model_payout=user_model_payout,
+                )
+        except _REGIONAL_SETTLE_RETRY_EXCS:
+            # An opposing settle/refund can win the local row just before its
+            # Spanner transaction. Park until that transaction commits, then
+            # the replay classifier below can report the exact terminal result.
+            return ApplyOutcome.PARK_TYPED_UNAVAILABLE
+        if finalize_result is not None and finalize_result.finalized:
+            return (
+                ApplyOutcome.SETTLED_NOW
+                if finalize_result.activity_indexed
+                else ApplyOutcome.ACTIVITY_PENDING
+            )
+        # The wrapper returns false for an already-terminal request. Continue
+        # through the existing exact replay classifier below.
+        result: dict[str, Any] = {"outcome": SettleOutcome.ALREADY_SETTLED}
+    else:
+        result = {}
+
     generation_writes: list[tuple[str, str, str]] = []
     if success and generation is not None:
         generation_writes = [
@@ -335,22 +385,23 @@ def _apply_typed(
         selected_usage_type=usage_type,
         generation=generation,
     )
-    try:
-        result = typed_store.typed_finalize_gateway(
-            reservation_id=auth.credit_reservation_id,
-            authorization_id=auth.id,
-            success=success,
-            actual_micro=row.actual_cost_micro,
-            settled_usage_type=str(usage_type),
-            now=dt.datetime.now(dt.UTC),
-            authorization=auth_settled,
-            auth_body_settled=_json_body(auth_settled),
-            generation_writes=generation_writes,
-            generation=generation,
-            user_model_payout=user_model_payout,
-        )
-    except _TRANSIENT_STORE_EXCS:
-        return ApplyOutcome.PARK_TYPED_UNAVAILABLE
+    if auth.settlement != "regional_lease":
+        try:
+            result = typed_store.typed_finalize_gateway(
+                reservation_id=auth.credit_reservation_id,
+                authorization_id=auth.id,
+                success=success,
+                actual_micro=row.actual_cost_micro,
+                settled_usage_type=str(usage_type),
+                now=dt.datetime.now(dt.UTC),
+                authorization=auth_settled,
+                auth_body_settled=_json_body(auth_settled),
+                generation_writes=generation_writes,
+                generation=generation,
+                user_model_payout=user_model_payout,
+            )
+        except _TRANSIENT_STORE_EXCS:
+            return ApplyOutcome.PARK_TYPED_UNAVAILABLE
     outcome = result.get("outcome")
     if outcome == SettleOutcome.SETTLED:
         # The typed transaction atomically persisted the bounded generation

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -2439,6 +2439,19 @@ def create_store(settings: Any) -> Store:
             analytics_dual_read_grace_seconds=getattr(
                 settings, "analytics_dual_read_grace_seconds", 30
             ),
+            regional_quota_leases_enabled=getattr(
+                settings, "regional_quota_leases_enabled", False
+            ),
+            regional_quota_bigtable_table=getattr(
+                settings,
+                "regional_quota_bigtable_table",
+                "trustedrouter-regional-quota",
+            ),
+            regional_quota_bigtable_app_profiles=getattr(
+                settings,
+                "regional_quota_bigtable_app_profile_map",
+                {},
+            ),
         )
     raise ValueError(f"unsupported storage backend: {backend}")
 

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import datetime as dt
+import hashlib
 import json
 import logging
 import os
@@ -99,8 +100,9 @@ from trusted_router.storage_gcp_counter_dml import (
 from trusted_router.storage_gcp_counters import (
     CREDIT_BALANCE_COLUMNS,
     CREDIT_BALANCE_TABLE,
+    DEFAULT_NEW_BILLING_SHARDS,
     UNSHARDED,
-    credit_balance_mirror_row,
+    credit_balance_seed_rows,
     credit_shard_count,
     distribute_credit_amount,
     key_usage_shard_count,
@@ -290,6 +292,9 @@ class SpannerBigtableStore:
         operational_analytics_clickhouse_database: str = "tr",
         analytics_read_mode: str = "bigtable",
         analytics_dual_read_grace_seconds: int = 30,
+        regional_quota_leases_enabled: bool = False,
+        regional_quota_bigtable_table: str = "trustedrouter-regional-quota",
+        regional_quota_bigtable_app_profiles: dict[str, str] | None = None,
     ) -> None:
         if not spanner_instance_id or not spanner_database_id:
             raise ValueError("Spanner instance and database IDs are required")
@@ -405,6 +410,39 @@ class SpannerBigtableStore:
             else:
                 self._bt_table = bt_instance.table(generation_table)
         self._bigtable_app_profile_id = bigtable_app_profile_id
+        self._regional_quota_ledger = None
+        self._regional_quota_lease_cache: dict[tuple[str, str, int], Any] = {}
+        self._regional_quota_lease_cache_lock = threading.Lock()
+        if regional_quota_leases_enabled:
+            profiles = dict(regional_quota_bigtable_app_profiles or {})
+            if not bigtable_instance_id or not profiles:
+                raise ValueError(
+                    "regional quota leases require a Bigtable instance and fixed app profiles"
+                )
+            try:
+                from google.cloud import bigtable
+            except ImportError as exc:  # pragma: no cover - production image.
+                raise RuntimeError(
+                    "Install google-cloud-bigtable when regional quota leases are enabled"
+                ) from exc
+            from trusted_router.regional_quota_ledger import (
+                BigtableRegionalQuotaLedger,
+            )
+
+            quota_instance = bigtable.Client(
+                project=project_id,
+                credentials=credentials,
+                admin=False,
+            ).instance(bigtable_instance_id)
+            self._regional_quota_ledger = BigtableRegionalQuotaLedger(
+                {
+                    region: quota_instance.table(
+                        regional_quota_bigtable_table,
+                        app_profile_id=profile,
+                    )
+                    for region, profile in profiles.items()
+                }
+            )
         # Composed feature stores. Each owns its own logic and is importable
         # on its own — keeps the core SpannerBigtableStore body focused on
         # identity + credit ledger. Mirrors the InMemoryStore pattern.
@@ -642,7 +680,10 @@ class SpannerBigtableStore:
             )
             member = Member(workspace_id=workspace.id, user_id=new_user.id, role="owner")
             initial_total = 0 if trial_credit_microdollars is None else trial_credit_microdollars
-            credit = CreditAccount(workspace_id=workspace.id)
+            credit = CreditAccount(
+                workspace_id=workspace.id,
+                shard_count=DEFAULT_NEW_BILLING_SHARDS,
+            )
             self._write_entity_tx(transaction, "user", new_user.id, new_user)
             self._write_entity_tx(
                 transaction, "email_user", normalized_email, {"user_id": new_user.id}
@@ -652,7 +693,12 @@ class SpannerBigtableStore:
                 transaction, "member", _member_id(workspace.id, new_user.id), member
             )
             self._write_entity_tx(transaction, "credit", workspace.id, credit)
-            self._seed_credit_balance_on_create(transaction, workspace.id, initial_total)
+            self._seed_credit_balance_on_create(
+                transaction,
+                workspace.id,
+                initial_total,
+                shard_count=credit.shard_count,
+            )
             return new_user
 
         return self._run_in_transaction(txn)
@@ -734,17 +780,18 @@ class SpannerBigtableStore:
         writer: Any,
         workspace_id: str,
         initial_total_micro: int,
+        *,
+        shard_count: int,
     ) -> None:
         writer.insert_or_update(
             table=CREDIT_BALANCE_TABLE,
             columns=CREDIT_BALANCE_COLUMNS,
-            values=[
-                credit_balance_mirror_row(
-                    workspace_id,
-                    initial_total_micro,
-                    self._spanner.COMMIT_TIMESTAMP,
-                )
-            ],
+            values=credit_balance_seed_rows(
+                workspace_id,
+                initial_total_micro,
+                self._spanner.COMMIT_TIMESTAMP,
+                shard_count=shard_count,
+            ),
         )
 
     # Auth sessions delegate to storage_gcp_auth_sessions.SpannerAuthSessions.
@@ -848,14 +895,22 @@ class SpannerBigtableStore:
         # Account creation passes the configured starter amount explicitly.
         # Secondary workspaces omit it and therefore start at zero.
         initial_total = 0 if trial_credit_microdollars is None else trial_credit_microdollars
-        credit = CreditAccount(workspace_id=workspace.id)
+        credit = CreditAccount(
+            workspace_id=workspace.id,
+            shard_count=DEFAULT_NEW_BILLING_SHARDS,
+        )
         with self._database.batch() as batch:
             self._write_entity_batch(batch, "workspace", workspace.id, workspace)
             self._write_entity_batch(
                 batch, "member", _member_id(workspace.id, owner_user_id), member
             )
             self._write_entity_batch(batch, "credit", workspace.id, credit)
-            self._seed_credit_balance_on_create(batch, workspace.id, initial_total)
+            self._seed_credit_balance_on_create(
+                batch,
+                workspace.id,
+                initial_total,
+                shard_count=credit.shard_count,
+            )
         return workspace
 
     def list_workspaces_for_user(self, user_id: str) -> list[Workspace]:
@@ -1024,7 +1079,10 @@ class SpannerBigtableStore:
                 owner_user_id=new_user.id,
             )
             member = Member(workspace_id=workspace.id, user_id=new_user.id, role="owner")
-            credit = CreditAccount(workspace_id=workspace.id)
+            credit = CreditAccount(
+                workspace_id=workspace.id,
+                shard_count=DEFAULT_NEW_BILLING_SHARDS,
+            )
             self._write_entity_tx(transaction, "user", new_user.id, new_user)
             self._write_entity_tx(transaction, "wallet_user", normalized, {"user_id": new_user.id})
             self._write_entity_tx(transaction, "workspace", workspace.id, workspace)
@@ -1036,6 +1094,7 @@ class SpannerBigtableStore:
                 transaction,
                 workspace.id,
                 0,
+                shard_count=credit.shard_count,
             )
             return new_user
 
@@ -1395,11 +1454,7 @@ class SpannerBigtableStore:
         api_key = _auth_record(str(rows[0][0]), ApiKey)
         if not verify_api_key(raw_key, api_key.salt, api_key.secret_hash):
             return None
-        workspace = (
-            _auth_record(str(rows[0][1]), Workspace)
-            if rows[0][1] is not None
-            else None
-        )
+        workspace = _auth_record(str(rows[0][1]), Workspace) if rows[0][1] is not None else None
         if workspace is not None and workspace.deleted:
             workspace = None
         return ApiKeyAuthContext(api_key=api_key, workspace=workspace)
@@ -2061,9 +2116,7 @@ class SpannerBigtableStore:
                 amount_microdollars=amount,
                 counterparty_account_id=payer_workspace_id,
                 custom_model_id=custom_model_id,
-                authorization_id=(
-                    user_model_authorization_id_from_payout_event_id(event_id)
-                ),
+                authorization_id=(user_model_authorization_id_from_payout_event_id(event_id)),
                 created_at=now,
             )
             insert_entity_dml_at(
@@ -2476,9 +2529,7 @@ class SpannerBigtableStore:
             custom_model_revision=custom_model_revision,
             user_provided_model_id=user_provided_model_id,
             user_provided_model_revision=user_provided_model_revision,
-            user_model_prompt_price_microdollars_per_m=(
-                user_model_prompt_price_microdollars_per_m
-            ),
+            user_model_prompt_price_microdollars_per_m=(user_model_prompt_price_microdollars_per_m),
             user_model_completion_price_microdollars_per_m=(
                 user_model_completion_price_microdollars_per_m
             ),
@@ -2586,6 +2637,12 @@ class SpannerBigtableStore:
         authorization = self.get_gateway_authorization(authorization_id)
         if authorization is None or authorization.credit_reservation_id is None:
             return TypedFinalizeResult(finalized=False, activity_indexed=False)
+        if authorization.settlement == "regional_lease":
+            self._finalize_regional_quota_hold(
+                authorization,
+                success=success,
+                actual_microdollars=actual_microdollars,
+            )
         actual_usage_type = UsageType.coerce(selected_usage_type)
         generation_writes: list[tuple[str, str, str]] = []
         if success and generation is not None:
@@ -2667,6 +2724,370 @@ class SpannerBigtableStore:
             finalized=False,
             activity_indexed=False,
         )  # already_settled / not_found
+
+    def authorize_gateway_regional(
+        self,
+        *,
+        authorization_id: str,
+        workspace_id: str,
+        key_hash: str,
+        key_usage_shards: int,
+        estimate: int,
+        model_id: str,
+        provider: str,
+        requested_model_id: str | None,
+        candidate_model_ids: list[str],
+        region: str,
+        endpoint_id: str | None,
+        candidate_endpoint_ids: list[str],
+        idempotency_key: str | None,
+        idempotency_fingerprint: str | None,
+        tags: dict[str, str] | None,
+        expires_at: dt.datetime,
+        lease_ttl_seconds: int,
+        lease_max_microdollars: int,
+        lease_max_available_basis_points: int,
+        lease_shard_count: int,
+    ) -> tuple[str, GatewayAuthorization | None]:
+        """Authorize from bounded regional escrow without touching hot counters."""
+
+        ledger = self._regional_quota_ledger
+        if ledger is None:
+            return "unavailable", None
+        from trusted_router.regional_quota_ledger import (
+            RegionalLeaseLedgerError,
+        )
+        from trusted_router.services.regional_quota_leases import (
+            LeaseExhaustedError,
+            LeaseUnavailableError,
+        )
+        from trusted_router.storage_gcp_keys import (
+            _gateway_authorization_idempotency_index_id,
+        )
+        from trusted_router.storage_gcp_regional_quota import (
+            activate_regional_quota_lease,
+            active_regional_quota_leases,
+            grant_regional_quota_lease,
+            quarantine_regional_quota_lease,
+            record_regional_gateway_authorization,
+            regional_lease_from_global,
+        )
+
+        scope = (
+            _gateway_authorization_idempotency_index_id(
+                workspace_id,
+                key_hash,
+                idempotency_key,
+            )
+            if idempotency_key is not None
+            else None
+        )
+        if lease_shard_count <= 0:
+            return "unavailable", None
+        shard_source = idempotency_fingerprint or authorization_id
+        quota_shard = (
+            int.from_bytes(
+                hashlib.sha256(shard_source.encode("utf-8")).digest()[:4],
+                "big",
+            )
+            % lease_shard_count
+        )
+        cache_key = (workspace_id, region, quota_shard)
+        with self._regional_quota_lease_cache_lock:
+            cached = self._regional_quota_lease_cache.get(cache_key)
+        candidates = []
+        if cached is not None and cached.expires_datetime > dt.datetime.now(dt.UTC):
+            candidates.append(cached)
+        else:
+            candidates.extend(
+                active_regional_quota_leases(
+                    self,
+                    workspace_id=workspace_id,
+                    region=region,
+                    quota_shard=quota_shard,
+                )
+            )
+
+        selected_global = None
+        selected_local = None
+        key_shard = randomized_credit_shards(
+            key_usage_shard_count({"usage_shard_count": key_usage_shards})
+        )[0]
+        for candidate in candidates:
+            try:
+                local = ledger.get(candidate.lease_id, region=region)
+                if local is None:
+                    quarantine_regional_quota_lease(
+                        self,
+                        candidate,
+                        reason="active global lease has no regional row",
+                    )
+                    continue
+                selected_local = ledger.reserve(
+                    candidate.lease_id,
+                    region=region,
+                    hold_id=authorization_id,
+                    fingerprint=idempotency_fingerprint or authorization_id,
+                    amount_microdollars=estimate,
+                    fencing_token=candidate.fencing_token,
+                    key_hash=key_hash,
+                    key_shard=key_shard,
+                    hold_expires_at=expires_at,
+                )
+                selected_global = candidate
+                break
+            except (LeaseExhaustedError, LeaseUnavailableError):
+                continue
+            except RegionalLeaseLedgerError:
+                log.warning(
+                    "regional quota lease read/reserve failed workspace_id=%s region=%s",
+                    workspace_id,
+                    region,
+                    exc_info=True,
+                )
+                return "unavailable", None
+
+        if selected_global is None:
+            # These caps describe the whole regional pool. Divide both across
+            # the independently fenced rows so sharding removes contention
+            # without multiplying the globally escrowed exposure.
+            per_shard_cap = max(1, lease_max_microdollars // lease_shard_count)
+            per_shard_basis_points = max(
+                1,
+                lease_max_available_basis_points // lease_shard_count,
+            )
+            global_lease = grant_regional_quota_lease(
+                self,
+                workspace_id=workspace_id,
+                region=region,
+                quota_shard=quota_shard,
+                requested_microdollars=per_shard_cap,
+                per_lease_cap_microdollars=per_shard_cap,
+                max_available_basis_points=per_shard_basis_points,
+                ttl_seconds=lease_ttl_seconds,
+                minimum_grant_microdollars=estimate,
+            )
+            if global_lease is None:
+                return "unavailable", None
+            try:
+                ledger.initialize(regional_lease_from_global(global_lease))
+                global_lease = activate_regional_quota_lease(self, global_lease)
+                selected_local = ledger.reserve(
+                    global_lease.lease_id,
+                    region=region,
+                    hold_id=authorization_id,
+                    fingerprint=idempotency_fingerprint or authorization_id,
+                    amount_microdollars=estimate,
+                    fencing_token=global_lease.fencing_token,
+                    key_hash=key_hash,
+                    key_shard=key_shard,
+                    hold_expires_at=expires_at,
+                )
+                selected_global = global_lease
+            except Exception as exc:
+                try:
+                    quarantine_regional_quota_lease(
+                        self,
+                        global_lease,
+                        reason=f"regional initialization ambiguity: {type(exc).__name__}",
+                    )
+                except Exception:
+                    log.error(
+                        "regional quota quarantine failed lease_id=%s",
+                        global_lease.lease_id,
+                        exc_info=True,
+                    )
+                log.warning(
+                    "regional quota lease initialization failed workspace_id=%s region=%s",
+                    workspace_id,
+                    region,
+                    exc_info=True,
+                )
+                return "unavailable", None
+
+        assert selected_global is not None and selected_local is not None
+        with self._regional_quota_lease_cache_lock:
+            self._regional_quota_lease_cache[cache_key] = selected_global
+        authorization = GatewayAuthorization(
+            id=authorization_id,
+            workspace_id=workspace_id,
+            key_hash=key_hash,
+            model_id=model_id,
+            provider=provider,
+            usage_type=UsageType.CREDITS,
+            estimated_microdollars=estimate,
+            requested_model_id=requested_model_id,
+            candidate_model_ids=list(candidate_model_ids),
+            region=region,
+            endpoint_id=endpoint_id,
+            candidate_endpoint_ids=list(candidate_endpoint_ids),
+            idempotency_key=idempotency_key,
+            tags=dict(tags or {}),
+            idempotency_fingerprint=idempotency_fingerprint,
+            settlement="regional_lease",
+            regional_lease_id=selected_global.lease_id,
+            regional_fencing_token=selected_global.fencing_token,
+            regional_hold_id=authorization_id,
+        )
+        try:
+            result = record_regional_gateway_authorization(
+                self,
+                authorization=authorization,
+                idempotency_scope=scope,
+                idempotency_fingerprint=idempotency_fingerprint,
+                expires_at=expires_at,
+            )
+        except Exception:
+            self._refund_regional_quota_hold_safely(authorization)
+            raise
+        if result["outcome"] == "accepted":
+            authorization.credit_reservation_id = str(result["reservation_id"])
+            return "accepted", authorization
+        self._refund_regional_quota_hold_safely(authorization)
+        if result["outcome"] == "idempotency_mismatch":
+            return "idempotency_mismatch", None
+        replay = self.get_gateway_authorization(str(result["authorization_id"]))
+        return "replay", replay
+
+    def _finalize_regional_quota_hold(
+        self,
+        authorization: GatewayAuthorization,
+        *,
+        success: bool,
+        actual_microdollars: int,
+    ) -> None:
+        ledger = self._regional_quota_ledger
+        if ledger is None:
+            raise RuntimeError("regional quota ledger is unavailable")
+        lease_id = authorization.regional_lease_id
+        fencing_token = authorization.regional_fencing_token
+        hold_id = authorization.regional_hold_id
+        region = authorization.region
+        if not lease_id or not fencing_token or not hold_id or not region:
+            raise RuntimeError("regional authorization is missing lease identity")
+        if actual_microdollars > authorization.estimated_microdollars:
+            raise RuntimeError("regional settlement exceeds its exact reservation")
+        if success:
+            ledger.settle(
+                lease_id,
+                region=region,
+                hold_id=hold_id,
+                actual_microdollars=actual_microdollars,
+                fencing_token=fencing_token,
+            )
+        else:
+            ledger.refund(
+                lease_id,
+                region=region,
+                hold_id=hold_id,
+                fencing_token=fencing_token,
+            )
+
+    def _refund_regional_quota_hold_safely(
+        self,
+        authorization: GatewayAuthorization,
+    ) -> None:
+        try:
+            self._finalize_regional_quota_hold(
+                authorization,
+                success=False,
+                actual_microdollars=0,
+            )
+        except Exception:
+            log.error(
+                "regional quota hold compensation failed authorization_id=%s lease_id=%s",
+                authorization.id,
+                authorization.regional_lease_id,
+                exc_info=True,
+            )
+
+    def reconcile_regional_quota_leases(
+        self,
+        *,
+        limit: int = 100,
+        now: dt.datetime | None = None,
+    ) -> dict[str, int]:
+        """Reconcile bounded local escrow; expired open holds refund first."""
+
+        ledger = self._regional_quota_ledger
+        if ledger is None:
+            return {"inspected": 0, "reconciled": 0, "closed": 0, "errors": 0}
+        from trusted_router.services.regional_quota_leases import HoldState
+        from trusted_router.storage_gcp_regional_quota import (
+            GlobalRegionalQuotaLease,
+            reconcile_regional_quota_lease,
+        )
+
+        now = dt.datetime.now(dt.UTC) if now is None else now
+        records = [
+            record
+            for record in self._list_entities(
+                "regional_quota_lease",
+                cls=GlobalRegionalQuotaLease,
+            )
+            if record.state != "closed"
+        ]
+        records.sort(key=lambda record: (record.expires_datetime, record.lease_id))
+        records = records[: max(1, min(limit, 1000))]
+        result = {"inspected": 0, "reconciled": 0, "closed": 0, "errors": 0}
+        for record in records:
+            result["inspected"] += 1
+            try:
+                local = ledger.get(record.lease_id, region=record.region)
+                if local is None:
+                    raise RuntimeError("regional lease row is missing")
+                for hold in local.holds:
+                    if (
+                        hold.state == HoldState.RESERVED
+                        and hold.expires_at is not None
+                        and hold.expires_at <= now
+                    ):
+                        local = ledger.refund(
+                            record.lease_id,
+                            region=record.region,
+                            hold_id=hold.hold_id,
+                            fencing_token=record.fencing_token,
+                        )
+                if local.expires_at <= now and local.state.value == "active":
+                    local = ledger.begin_drain(
+                        record.lease_id,
+                        region=record.region,
+                        fencing_token=record.fencing_token,
+                    )
+                should_close = local.state.value == "draining" and local.reserved_microdollars == 0
+                reconcile_regional_quota_lease(
+                    self,
+                    record,
+                    local,
+                    close=should_close,
+                    now=now,
+                )
+                result["reconciled"] += 1
+                if should_close:
+                    ledger.close(
+                        record.lease_id,
+                        region=record.region,
+                        fencing_token=record.fencing_token,
+                    )
+                    with self._regional_quota_lease_cache_lock:
+                        self._regional_quota_lease_cache.pop(
+                            (
+                                record.workspace_id,
+                                record.region,
+                                record.quota_shard,
+                            ),
+                            None,
+                        )
+                    result["closed"] += 1
+            except Exception:
+                result["errors"] += 1
+                log.error(
+                    "regional quota reconciliation failed lease_id=%s workspace_id=%s",
+                    record.lease_id,
+                    record.workspace_id,
+                    exc_info=True,
+                )
+        return result
 
     def authorize_gateway_typed(
         self,
@@ -2807,10 +3228,7 @@ class SpannerBigtableStore:
             )
 
         result = run_authorize(credit_shard_candidates)
-        if (
-            result["outcome"] == AuthorizeOutcome.KEY_LIMIT_EXCEEDED
-            and key_counter_shards > 1
-        ):
+        if result["outcome"] == AuthorizeOutcome.KEY_LIMIT_EXCEEDED and key_counter_shards > 1:
             from trusted_router.storage_gcp_key_escrow import (
                 rebalance_key_limit_headroom,
             )

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -486,6 +486,23 @@ def settle_atomic(
         if not won:
             return {"outcome": SettleOutcome.ALREADY_SETTLED}  # replay, no double-apply
 
+        # A regional authorization spent from an already escrowed lease. The
+        # regional ledger is settled/refunded before this transaction and the
+        # lease reconciler imports aggregate spend later. Releasing counters
+        # here would double-release the grant and recreate the hot global row.
+        if res.get("hold_usage_type") == "RegionalCredits":
+            if mark_authorization_terminal and res.get("authorization_id"):
+                close_reaped_gateway_authorization(
+                    transaction,
+                    pt,
+                    str(res["authorization_id"]),
+                    terminal_at=terminal_at,
+                )
+            return {
+                "outcome": SettleOutcome.SETTLED,
+                "missing_key_releases": [],
+            }
+
         # key first, then credit (single lock order everywhere — codex#2 #2).
         key_actual = book_actual  # key usage counts under both Credits and BYOK
         missing_key_releases = []

--- a/src/trusted_router/storage_gcp_counters.py
+++ b/src/trusted_router/storage_gcp_counters.py
@@ -18,6 +18,7 @@ KEY_LIMIT_TABLE = "tr_key_limit"
 UNSHARDED = 0
 MAX_CREDIT_SHARDS = 64
 MAX_KEY_USAGE_SHARDS = 64
+DEFAULT_NEW_BILLING_SHARDS = 16
 
 # Creation-time credit seed columns. `reserved` + `total_usage` are deliberately
 # omitted so a new row gets the Spanner defaults (0) and later typed DML owns
@@ -187,6 +188,29 @@ def credit_balance_mirror_row(workspace_id: str, total_micro: int, commit_ts: An
         commit_ts,  # source_updated_at — the JSON row's updated_at, same commit
         commit_ts,  # this mirror's updated_at
     )
+
+
+def credit_balance_seed_rows(
+    workspace_id: str,
+    total_micro: int,
+    commit_ts: Any,
+    *,
+    shard_count: int,
+) -> list[tuple]:
+    """Seed a new workspace's exact balance across independent sub-ledgers."""
+
+    count = credit_shard_count({"shard_count": shard_count})
+    parts = distribute_credit_amount(total_micro, count)
+    return [
+        (
+            workspace_id,
+            shard,
+            parts[shard],
+            commit_ts,
+            commit_ts,
+        )
+        for shard in range(count)
+    ]
 
 
 def key_limit_mirror_row(key_hash: str, value: Any, commit_ts: Any) -> tuple:

--- a/src/trusted_router/storage_gcp_regional_quota.py
+++ b/src/trusted_router/storage_gcp_regional_quota.py
@@ -1,0 +1,689 @@
+"""Global Spanner escrow and reconciliation for regional quota leases."""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import random
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from google.api_core.exceptions import AlreadyExists
+
+from trusted_router.regional_quota_ledger import settled_key_totals
+from trusted_router.services.regional_quota_leases import (
+    RegionalQuotaLease,
+    bounded_lease_grant_microdollars,
+)
+from trusted_router.spend_windows import utcnow, window_floors
+from trusted_router.storage_gcp_codec import json_body
+from trusted_router.storage_gcp_counter_dml import (
+    insert_reservation,
+    key_limit_exists,
+    read_reservation_by_idempotency,
+    release_credit,
+    release_key,
+    reserve_credit,
+)
+from trusted_router.storage_gcp_io import run_in_transaction_with_retry
+from trusted_router.storage_gcp_request_records import insert_gateway_authorization
+from trusted_router.storage_models import GatewayAuthorization
+
+log = logging.getLogger(__name__)
+
+_LEASE_KIND = "regional_quota_lease"
+_FENCE_KIND = "regional_quota_fence"
+
+
+@dataclass
+class GlobalRegionalQuotaLease:
+    lease_id: str
+    workspace_id: str
+    region: str
+    fencing_token: int
+    granted_microdollars: int
+    credit_shard: int
+    expires_at: str
+    quota_shard: int = 0
+    state: str = "pending"
+    reconciled_spent_microdollars: int = 0
+    reconciled_key_microdollars: dict[str, int] = field(default_factory=dict)
+    created_at: str = field(default_factory=lambda: _iso(utcnow()))
+    updated_at: str = field(default_factory=lambda: _iso(utcnow()))
+    last_error: str | None = None
+
+    @property
+    def entity_id(self) -> str:
+        return _lease_entity_id(self.workspace_id, self.region, self.lease_id)
+
+    @property
+    def expires_datetime(self) -> datetime:
+        return _parse_iso(self.expires_at)
+
+
+@dataclass
+class RegionalQuotaFence:
+    workspace_id: str
+    region: str
+    fencing_token: int
+    quota_shard: int = 0
+    active_lease_id: str | None = None
+    updated_at: str = field(default_factory=lambda: _iso(utcnow()))
+
+
+@dataclass(frozen=True)
+class RegionalReconcileResult:
+    lease_id: str
+    spent_delta_microdollars: int
+    unused_released_microdollars: int
+    closed: bool
+    replayed: bool
+
+
+def grant_regional_quota_lease(
+    store: Any,
+    *,
+    workspace_id: str,
+    region: str,
+    requested_microdollars: int,
+    per_lease_cap_microdollars: int,
+    max_available_basis_points: int,
+    ttl_seconds: int,
+    minimum_grant_microdollars: int,
+    quota_shard: int = 0,
+    now: datetime | None = None,
+) -> GlobalRegionalQuotaLease | None:
+    """Reserve a bounded exact grant and persist its fence in one transaction."""
+
+    now = utcnow() if now is None else now
+    if now.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+    if quota_shard < 0:
+        raise ValueError("quota_shard must not be negative")
+    rows = _credit_rows(store, workspace_id)
+    available_by_shard = {
+        int(shard): max(0, int(total) - int(usage) - int(reserved))
+        for shard, total, usage, reserved in rows
+    }
+    total_available = sum(available_by_shard.values())
+    bounded = bounded_lease_grant_microdollars(
+        available_microdollars=total_available,
+        requested_microdollars=requested_microdollars,
+        per_lease_cap_microdollars=per_lease_cap_microdollars,
+        max_available_basis_points=max_available_basis_points,
+    )
+    if bounded < minimum_grant_microdollars:
+        return None
+    candidates = list(available_by_shard)
+    random.SystemRandom().shuffle(candidates)
+    candidates.sort(key=lambda shard: available_by_shard[shard], reverse=True)
+    selected_shard = next(
+        (
+            shard
+            for shard in candidates
+            if min(bounded, available_by_shard[shard]) >= minimum_grant_microdollars
+        ),
+        None,
+    )
+    if selected_shard is None:
+        return None
+    grant = min(bounded, available_by_shard[selected_shard])
+    lease_id = f"rql-{uuid.uuid4().hex}"
+    expires_at = now + timedelta(seconds=ttl_seconds)
+    entity_id = _lease_entity_id(workspace_id, region, lease_id)
+    fence_id = _fence_entity_id(workspace_id, region, quota_shard)
+
+    def txn(transaction: Any) -> GlobalRegionalQuotaLease | None:
+        fence = store._read_entity_tx(
+            transaction,
+            _FENCE_KIND,
+            fence_id,
+            RegionalQuotaFence,
+        )
+        # Exactly one globally escrowed grant may own a local quota shard at a
+        # time. Without this guard, an exhausted row could mint another lease
+        # before reconciliation and multiply the configured regional exposure.
+        if fence is not None and fence.active_lease_id is not None:
+            return None
+        if not reserve_credit(
+            transaction,
+            store._param_types,
+            workspace_id,
+            grant,
+            shard=selected_shard,
+        ):
+            return None
+        fencing_token = 1 if fence is None else fence.fencing_token + 1
+        updated_fence = RegionalQuotaFence(
+            workspace_id=workspace_id,
+            region=region,
+            fencing_token=fencing_token,
+            quota_shard=quota_shard,
+            active_lease_id=lease_id,
+            updated_at=_iso(now),
+        )
+        lease = GlobalRegionalQuotaLease(
+            lease_id=lease_id,
+            workspace_id=workspace_id,
+            region=region,
+            fencing_token=fencing_token,
+            granted_microdollars=grant,
+            credit_shard=selected_shard,
+            expires_at=_iso(expires_at),
+            quota_shard=quota_shard,
+            created_at=_iso(now),
+            updated_at=_iso(now),
+        )
+        _upsert_entity_dml(
+            transaction,
+            store._param_types,
+            _FENCE_KIND,
+            fence_id,
+            updated_fence,
+        )
+        _insert_entity_dml(
+            transaction,
+            store._param_types,
+            _LEASE_KIND,
+            entity_id,
+            lease,
+        )
+        return lease
+
+    return store._run_in_transaction(txn)
+
+
+def activate_regional_quota_lease(
+    store: Any,
+    lease: GlobalRegionalQuotaLease,
+    *,
+    now: datetime | None = None,
+) -> GlobalRegionalQuotaLease:
+    return _transition_global_lease(
+        store,
+        lease,
+        expected_states={"pending", "active"},
+        state="active",
+        now=now,
+    )
+
+
+def quarantine_regional_quota_lease(
+    store: Any,
+    lease: GlobalRegionalQuotaLease,
+    *,
+    reason: str,
+    now: datetime | None = None,
+) -> GlobalRegionalQuotaLease:
+    return _transition_global_lease(
+        store,
+        lease,
+        expected_states={"pending", "active", "draining", "quarantined"},
+        state="quarantined",
+        last_error=reason[:500],
+        now=now,
+    )
+
+
+def active_regional_quota_leases(
+    store: Any,
+    *,
+    workspace_id: str,
+    region: str,
+    quota_shard: int | None = None,
+    now: datetime | None = None,
+) -> list[GlobalRegionalQuotaLease]:
+    now = utcnow() if now is None else now
+    if quota_shard is None:
+        raise ValueError("quota_shard is required for fenced regional lease lookup")
+    fence = store._read_entity(
+        _FENCE_KIND,
+        _fence_entity_id(workspace_id, region, quota_shard),
+        RegionalQuotaFence,
+    )
+    if fence is None or fence.active_lease_id is None:
+        return []
+    lease = get_global_regional_quota_lease(
+        store,
+        workspace_id=workspace_id,
+        region=region,
+        lease_id=fence.active_lease_id,
+    )
+    if (
+        lease is None
+        or lease.quota_shard != quota_shard
+        or lease.fencing_token != fence.fencing_token
+        or lease.state != "active"
+        or lease.expires_datetime <= now
+    ):
+        return []
+    return [lease]
+
+
+def get_global_regional_quota_lease(
+    store: Any,
+    *,
+    workspace_id: str,
+    region: str,
+    lease_id: str,
+) -> GlobalRegionalQuotaLease | None:
+    return store._read_entity(
+        _LEASE_KIND,
+        _lease_entity_id(workspace_id, region, lease_id),
+        GlobalRegionalQuotaLease,
+    )
+
+
+def reconcile_regional_quota_lease(
+    store: Any,
+    global_lease: GlobalRegionalQuotaLease,
+    local_lease: RegionalQuotaLease,
+    *,
+    close: bool,
+    now: datetime | None = None,
+) -> RegionalReconcileResult:
+    """Import settled spend and optionally release all unused escrow atomically."""
+
+    now = utcnow() if now is None else now
+    _validate_local_snapshot(global_lease, local_lease)
+    if close and local_lease.reserved_microdollars:
+        raise ValueError("cannot close a regional lease with open reservations")
+    current_key_totals = {
+        _key_total_id(key_hash, shard): amount
+        for (key_hash, shard), amount in settled_key_totals(local_lease).items()
+    }
+
+    def txn(transaction: Any) -> RegionalReconcileResult:
+        current = store._read_entity_tx(
+            transaction,
+            _LEASE_KIND,
+            global_lease.entity_id,
+            GlobalRegionalQuotaLease,
+        )
+        if current is None:
+            raise RuntimeError("global regional lease is missing")
+        _validate_same_global_lease(global_lease, current)
+        if current.state == "closed":
+            return RegionalReconcileResult(
+                lease_id=current.lease_id,
+                spent_delta_microdollars=0,
+                unused_released_microdollars=0,
+                closed=True,
+                replayed=True,
+            )
+        if local_lease.spent_microdollars < current.reconciled_spent_microdollars:
+            raise RuntimeError("regional settled total moved backwards")
+        spent_delta = local_lease.spent_microdollars - current.reconciled_spent_microdollars
+        key_deltas: dict[str, int] = {}
+        for key, total in current_key_totals.items():
+            previous = int(current.reconciled_key_microdollars.get(key, 0))
+            if total < previous:
+                raise RuntimeError("regional key usage moved backwards")
+            if total > previous:
+                key_deltas[key] = total - previous
+        if sum(key_deltas.values()) != spent_delta:
+            raise RuntimeError("regional workspace and key settlement totals differ")
+
+        if (
+            spent_delta
+            and release_credit(
+                transaction,
+                store._param_types,
+                current.workspace_id,
+                spent_delta,
+                spent_delta,
+                shard=current.credit_shard,
+            )
+            != 1
+        ):
+            raise RuntimeError("global regional credit escrow release failed")
+        floors = window_floors(now)
+        for key, amount in key_deltas.items():
+            key_hash, key_shard = _parse_key_total_id(key)
+            count = release_key(
+                transaction,
+                store._param_types,
+                key_hash,
+                0,
+                amount,
+                book_to_byok=False,
+                window_floors=floors,
+                shard=key_shard,
+            )
+            if count != 1 and key_limit_exists(
+                transaction,
+                store._param_types,
+                key_hash,
+                shard=key_shard,
+            ):
+                raise RuntimeError("regional API key usage reconciliation failed")
+
+        unused = 0
+        next_state = "active"
+        if close:
+            unused = current.granted_microdollars - local_lease.spent_microdollars
+            if unused < 0:
+                raise RuntimeError("regional lease spent more than its grant")
+            if (
+                unused
+                and release_credit(
+                    transaction,
+                    store._param_types,
+                    current.workspace_id,
+                    unused,
+                    0,
+                    shard=current.credit_shard,
+                )
+                != 1
+            ):
+                raise RuntimeError("unused regional credit escrow release failed")
+            next_state = "closed"
+            fence_id = _fence_entity_id(
+                current.workspace_id,
+                current.region,
+                current.quota_shard,
+            )
+            fence = store._read_entity_tx(
+                transaction,
+                _FENCE_KIND,
+                fence_id,
+                RegionalQuotaFence,
+            )
+            if fence is None or fence.active_lease_id != current.lease_id:
+                raise RuntimeError("regional lease no longer owns its global fence")
+            _upsert_entity_dml(
+                transaction,
+                store._param_types,
+                _FENCE_KIND,
+                fence_id,
+                dataclasses.replace(
+                    fence,
+                    active_lease_id=None,
+                    updated_at=_iso(now),
+                ),
+            )
+        updated = dataclasses.replace(
+            current,
+            state=next_state,
+            reconciled_spent_microdollars=local_lease.spent_microdollars,
+            reconciled_key_microdollars=current_key_totals,
+            updated_at=_iso(now),
+        )
+        _upsert_entity_dml(
+            transaction,
+            store._param_types,
+            _LEASE_KIND,
+            current.entity_id,
+            updated,
+        )
+        return RegionalReconcileResult(
+            lease_id=current.lease_id,
+            spent_delta_microdollars=spent_delta,
+            unused_released_microdollars=unused,
+            closed=close,
+            replayed=spent_delta == 0 and unused == 0,
+        )
+
+    return store._run_in_transaction(txn)
+
+
+def record_regional_gateway_authorization(
+    store: Any,
+    *,
+    authorization: GatewayAuthorization,
+    idempotency_scope: str | None,
+    idempotency_fingerprint: str | None,
+    expires_at: datetime,
+) -> dict[str, Any]:
+    """Persist replay state without touching the globally escrowed counters."""
+
+    if store.request_record_write_mode != "typed":
+        raise RuntimeError("regional quota leases require typed request records")
+    reservation_id = str(uuid.uuid4())
+    created_at = utcnow()
+    authorization.credit_reservation_id = reservation_id
+    authorization.created_at = _iso(created_at)
+
+    def replay(existing: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "outcome": "replay",
+            "reservation_id": existing["reservation_id"],
+            "authorization_id": existing["authorization_id"],
+        }
+
+    def txn(transaction: Any) -> dict[str, Any]:
+        if idempotency_scope is not None:
+            existing = read_reservation_by_idempotency(
+                transaction,
+                store._param_types,
+                idempotency_scope,
+            )
+            if existing is not None:
+                if existing["idempotency_fingerprint"] != idempotency_fingerprint:
+                    return {"outcome": "idempotency_mismatch"}
+                return replay(existing)
+        insert_reservation(
+            transaction,
+            store._param_types,
+            reservation_id=reservation_id,
+            workspace_id=authorization.workspace_id,
+            key_hash=authorization.key_hash,
+            ws_shard=0,
+            credit_shard=0,
+            key_shard=0,
+            credit_reserved_micro=0,
+            key_reserved_micro=0,
+            hold_usage_type="RegionalCredits",
+            authorization_id=authorization.id,
+            idempotency_scope=idempotency_scope,
+            idempotency_fingerprint=idempotency_fingerprint,
+            expires_at=expires_at,
+            created_at=created_at,
+        )
+        insert_gateway_authorization(
+            transaction,
+            store._param_types,
+            authorization,
+            created_at=created_at,
+        )
+        return {
+            "outcome": "accepted",
+            "reservation_id": reservation_id,
+            "authorization_id": authorization.id,
+        }
+
+    try:
+        return run_in_transaction_with_retry(store._database, txn)
+    except AlreadyExists:
+        if idempotency_scope is None:
+            raise
+
+        def replay_txn(transaction: Any) -> dict[str, Any]:
+            existing = read_reservation_by_idempotency(
+                transaction,
+                store._param_types,
+                idempotency_scope,
+            )
+            if existing is None:
+                return {"outcome": "idempotency_mismatch"}
+            if existing["idempotency_fingerprint"] != idempotency_fingerprint:
+                return {"outcome": "idempotency_mismatch"}
+            return replay(existing)
+
+        return run_in_transaction_with_retry(store._database, replay_txn)
+
+
+def regional_lease_from_global(record: GlobalRegionalQuotaLease) -> RegionalQuotaLease:
+    return RegionalQuotaLease(
+        lease_id=record.lease_id,
+        workspace_id=record.workspace_id,
+        region=record.region,
+        fencing_token=record.fencing_token,
+        granted_microdollars=record.granted_microdollars,
+        expires_at=record.expires_datetime,
+    )
+
+
+def _credit_rows(store: Any, workspace_id: str) -> list[list[Any]]:
+    with store._database.snapshot() as snapshot:
+        return list(
+            snapshot.execute_sql(
+                "SELECT shard, total_credits, total_usage, reserved "
+                "FROM tr_credit_balance WHERE workspace_id=@ws ORDER BY shard",
+                params={"ws": workspace_id},
+                param_types={"ws": store._param_types.STRING},
+            )
+        )
+
+
+def _transition_global_lease(
+    store: Any,
+    lease: GlobalRegionalQuotaLease,
+    *,
+    expected_states: set[str],
+    state: str,
+    last_error: str | None = None,
+    now: datetime | None = None,
+) -> GlobalRegionalQuotaLease:
+    now = utcnow() if now is None else now
+
+    def txn(transaction: Any) -> GlobalRegionalQuotaLease:
+        current = store._read_entity_tx(
+            transaction,
+            _LEASE_KIND,
+            lease.entity_id,
+            GlobalRegionalQuotaLease,
+        )
+        if current is None:
+            raise RuntimeError("global regional lease is missing")
+        _validate_same_global_lease(lease, current)
+        if current.state not in expected_states:
+            raise RuntimeError(f"regional lease is {current.state}")
+        updated = dataclasses.replace(
+            current,
+            state=state,
+            updated_at=_iso(now),
+            last_error=last_error,
+        )
+        _upsert_entity_dml(
+            transaction,
+            store._param_types,
+            _LEASE_KIND,
+            current.entity_id,
+            updated,
+        )
+        return updated
+
+    return store._run_in_transaction(txn)
+
+
+def _validate_same_global_lease(
+    expected: GlobalRegionalQuotaLease,
+    current: GlobalRegionalQuotaLease,
+) -> None:
+    identity = (
+        "lease_id",
+        "workspace_id",
+        "region",
+        "fencing_token",
+        "granted_microdollars",
+        "credit_shard",
+        "quota_shard",
+    )
+    if any(getattr(expected, field) != getattr(current, field) for field in identity):
+        raise RuntimeError("global regional lease identity changed")
+
+
+def _validate_local_snapshot(
+    global_lease: GlobalRegionalQuotaLease,
+    local_lease: RegionalQuotaLease,
+) -> None:
+    if (
+        global_lease.lease_id != local_lease.lease_id
+        or global_lease.workspace_id != local_lease.workspace_id
+        or global_lease.region != local_lease.region
+        or global_lease.fencing_token != local_lease.fencing_token
+        or global_lease.granted_microdollars != local_lease.granted_microdollars
+    ):
+        raise RuntimeError("regional lease snapshot does not match global escrow")
+    if local_lease.spent_microdollars > global_lease.granted_microdollars:
+        raise RuntimeError("regional lease snapshot exceeds global escrow")
+
+
+def _insert_entity_dml(
+    transaction: Any,
+    param_types: Any,
+    kind: str,
+    entity_id: str,
+    value: Any,
+) -> None:
+    transaction.execute_update(
+        "INSERT INTO tr_entities (kind, id, body, updated_at) "
+        "VALUES (@kind, @id, @body, PENDING_COMMIT_TIMESTAMP())",
+        params={"kind": kind, "id": entity_id, "body": json_body(value)},
+        param_types={
+            "kind": param_types.STRING,
+            "id": param_types.STRING,
+            "body": param_types.STRING,
+        },
+    )
+
+
+def _upsert_entity_dml(
+    transaction: Any,
+    param_types: Any,
+    kind: str,
+    entity_id: str,
+    value: Any,
+) -> None:
+    params = {"kind": kind, "id": entity_id, "body": json_body(value)}
+    types = {
+        "kind": param_types.STRING,
+        "id": param_types.STRING,
+        "body": param_types.STRING,
+    }
+    updated = transaction.execute_update(
+        "UPDATE tr_entities SET body=@body, updated_at=PENDING_COMMIT_TIMESTAMP() "
+        "WHERE kind=@kind AND id=@id",
+        params=params,
+        param_types=types,
+    )
+    if updated == 0:
+        transaction.execute_update(
+            "INSERT INTO tr_entities (kind, id, body, updated_at) "
+            "VALUES (@kind, @id, @body, PENDING_COMMIT_TIMESTAMP())",
+            params=params,
+            param_types=types,
+        )
+
+
+def _lease_entity_id(workspace_id: str, region: str, lease_id: str) -> str:
+    return f"{workspace_id}#{region}#{lease_id}"
+
+
+def _fence_entity_id(workspace_id: str, region: str, quota_shard: int) -> str:
+    return f"{workspace_id}#{region}#{quota_shard}"
+
+
+def _key_total_id(key_hash: str, shard: int) -> str:
+    return f"{key_hash}#{shard}"
+
+
+def _parse_key_total_id(value: str) -> tuple[str, int]:
+    key_hash, shard = value.rsplit("#", 1)
+    return key_hash, int(shard)
+
+
+def _iso(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _parse_iso(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -460,8 +460,9 @@ class SettleOutboxRow:
 class CreditAccount:
     workspace_id: str
     # Number of independent tr_credit_balance sub-ledgers owned by this
-    # workspace. The default preserves the original one-row behavior; only the
-    # pause/drain operator path may activate more shards for a hot workspace.
+    # workspace. The dataclass default must remain one so legacy JSON that
+    # predates this field keeps its original row interpretation. Production
+    # account creation explicitly chooses the current multi-shard default.
     shard_count: int = 1
     # Auto-refill: when available drops below threshold, charge the saved
     # Stripe payment method off-session for `auto_refill_amount_microdollars`.
@@ -558,6 +559,12 @@ class GatewayAuthorization:
     # authorization before this field existed); "deferred_home" records the
     # spend as debt to the home plane's ledger, forwarded asynchronously.
     settlement: str = "local"
+    # Present only when a bounded regional escrow authorized this request.
+    # These are content-free routing facts used to settle/refund the durable
+    # regional hold before the global request record becomes terminal.
+    regional_lease_id: str | None = None
+    regional_fencing_token: int | None = None
+    regional_hold_id: str | None = None
     # Only deferred authorizations carry an expiry: it is what lets the reaper
     # reclaim the outstanding-counter estimate when the enclave dies between
     # authorize and settle. Local authorizations keep their pre-existing

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -2517,6 +2517,9 @@ def make_fake_store(
     store._analytics_read_mode = "bigtable"
     store._analytics_dual_read_grace_seconds = 0
     store._operational_analytics = None
+    store._regional_quota_ledger = None
+    store._regional_quota_lease_cache = {}
+    store._regional_quota_lease_cache_lock = threading.Lock()
     from trusted_router.storage_gcp_credit_shards import CreditShardCountCache
 
     store._credit_shard_counts = CreditShardCountCache()

--- a/tests/test_billing_typed_counters.py
+++ b/tests/test_billing_typed_counters.py
@@ -4,7 +4,11 @@ import json
 
 from tests.fakes.spanner import make_fake_store
 from trusted_router.storage_gcp_authorize import AuthorizeOutcome
-from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
+from trusted_router.storage_gcp_counters import (
+    CREDIT_BALANCE_TABLE,
+    DEFAULT_NEW_BILLING_SHARDS,
+    KEY_LIMIT_TABLE,
+)
 
 
 def _json_credit(db, workspace_id: str) -> dict:
@@ -15,8 +19,26 @@ def _typed_credit(db, workspace_id: str) -> dict:
     return db.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)]
 
 
+def _typed_credit_rows(db, workspace_id: str) -> list[dict]:
+    return [
+        row
+        for (candidate_workspace_id, _shard), row in db.typed[
+            CREDIT_BALANCE_TABLE
+        ].items()
+        if candidate_workspace_id == workspace_id
+    ]
+
+
 def _typed_key(db, key_hash: str) -> dict:
     return db.typed[KEY_LIMIT_TABLE][(key_hash, 0)]
+
+
+def _typed_key_rows(db, key_hash: str) -> list[dict]:
+    return [
+        row
+        for (candidate_key_hash, _shard), row in db.typed[KEY_LIMIT_TABLE].items()
+        if candidate_key_hash == key_hash
+    ]
 
 
 def test_create_workspace_seeds_tr_credit_balance_row() -> None:
@@ -28,12 +50,15 @@ def test_create_workspace_seeds_tr_credit_balance_row() -> None:
         trial_credit_microdollars=7_000_000,
     )
 
-    row = _typed_credit(db, workspace.id)
-    assert row["workspace_id"] == workspace.id
-    assert row["shard"] == 0
-    assert row["total_credits"] == 7_000_000
-    assert row["total_usage"] == 0
-    assert row["reserved"] == 0
+    rows = _typed_credit_rows(db, workspace.id)
+    assert len(rows) == DEFAULT_NEW_BILLING_SHARDS
+    assert {row["workspace_id"] for row in rows} == {workspace.id}
+    assert {row["shard"] for row in rows} == set(
+        range(DEFAULT_NEW_BILLING_SHARDS)
+    )
+    assert sum(row["total_credits"] for row in rows) == 7_000_000
+    assert sum(row["total_usage"] for row in rows) == 0
+    assert sum(row["reserved"] for row in rows) == 0
 
 
 def test_create_api_key_seeds_tr_key_limit_row() -> None:
@@ -49,17 +74,20 @@ def test_create_api_key_seeds_tr_key_limit_row() -> None:
         include_byok_in_limit=False,
     )
 
-    row = _typed_key(db, key.hash)
-    assert row["key_hash"] == key.hash
-    assert row["shard"] == 0
-    assert row["limit_micro"] == 1_000_000
-    assert row["day_limit_micro"] == 250_000
-    assert row["week_limit_micro"] is None
-    assert row["month_limit_micro"] is None
-    assert row["include_byok"] is False
-    assert row["usage"] == 0
-    assert row["byok_usage"] == 0
-    assert row["reserved"] == 0
+    rows = _typed_key_rows(db, key.hash)
+    assert len(rows) == DEFAULT_NEW_BILLING_SHARDS
+    assert {row["key_hash"] for row in rows} == {key.hash}
+    assert {row["shard"] for row in rows} == set(
+        range(DEFAULT_NEW_BILLING_SHARDS)
+    )
+    assert sum(row["limit_micro"] for row in rows) == 1_000_000
+    assert {row["day_limit_micro"] for row in rows} == {250_000}
+    assert {row["week_limit_micro"] for row in rows} == {None}
+    assert {row["month_limit_micro"] for row in rows} == {None}
+    assert {row["include_byok"] for row in rows} == {False}
+    assert sum(row["usage"] for row in rows) == 0
+    assert sum(row["byok_usage"] for row in rows) == 0
+    assert sum(row["reserved"] for row in rows) == 0
 
 
 def test_metadata_writes_never_reseed_or_clobber_typed_topups() -> None:
@@ -71,17 +99,32 @@ def test_metadata_writes_never_reseed_or_clobber_typed_topups() -> None:
     )
 
     assert store.credit_workspace_once(workspace.id, 50_000_000, "evt-topup")
-    assert _typed_credit(db, workspace.id)["total_credits"] == 150_000_000
+    assert sum(
+        row["total_credits"] for row in _typed_credit_rows(db, workspace.id)
+    ) == 150_000_000
     assert "total_credits_microdollars" not in _json_credit(db, workspace.id)
-    typed_version = db.typed_versions[(CREDIT_BALANCE_TABLE, (workspace.id, 0))]
+    typed_versions = {
+        shard: db.typed_versions[(CREDIT_BALANCE_TABLE, (workspace.id, shard))]
+        for shard in range(DEFAULT_NEW_BILLING_SHARDS)
+    }
 
     assert store.record_auto_refill_outcome(workspace.id, status="succeeded") is not None
-    assert _typed_credit(db, workspace.id)["total_credits"] == 150_000_000
-    assert db.typed_versions[(CREDIT_BALANCE_TABLE, (workspace.id, 0))] == typed_version
+    assert sum(
+        row["total_credits"] for row in _typed_credit_rows(db, workspace.id)
+    ) == 150_000_000
+    assert {
+        shard: db.typed_versions[(CREDIT_BALANCE_TABLE, (workspace.id, shard))]
+        for shard in range(DEFAULT_NEW_BILLING_SHARDS)
+    } == typed_versions
 
     assert store.set_stripe_customer(workspace.id, customer_id="cus_c2a") is not None
-    assert _typed_credit(db, workspace.id)["total_credits"] == 150_000_000
-    assert db.typed_versions[(CREDIT_BALANCE_TABLE, (workspace.id, 0))] == typed_version
+    assert sum(
+        row["total_credits"] for row in _typed_credit_rows(db, workspace.id)
+    ) == 150_000_000
+    assert {
+        shard: db.typed_versions[(CREDIT_BALANCE_TABLE, (workspace.id, shard))]
+        for shard in range(DEFAULT_NEW_BILLING_SHARDS)
+    } == typed_versions
 
 
 def test_brand_new_workspace_authorizes_immediately_after_topup() -> None:
@@ -93,7 +136,9 @@ def test_brand_new_workspace_authorizes_immediately_after_topup() -> None:
         creator_user_id="owner",
     )
 
-    assert _typed_credit(db, workspace.id)["total_credits"] == 0
+    assert sum(
+        row["total_credits"] for row in _typed_credit_rows(db, workspace.id)
+    ) == 0
     assert _typed_key(db, key.hash)["limit_micro"] is None
     assert store.credit_workspace_typed_direct(workspace.id, 10_000_000, "evt-new") is True
 
@@ -116,4 +161,6 @@ def test_brand_new_workspace_authorizes_immediately_after_topup() -> None:
 
     assert outcome == AuthorizeOutcome.ACCEPTED
     assert authorization is not None
-    assert _typed_credit(db, workspace.id)["reserved"] == 1_000_000
+    assert sum(
+        row["reserved"] for row in _typed_credit_rows(db, workspace.id)
+    ) == 1_000_000

--- a/tests/test_billing_typed_direct_topups.py
+++ b/tests/test_billing_typed_direct_topups.py
@@ -35,6 +35,14 @@ def _typed_credit(db, workspace_id: str) -> dict:
     return db.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)]
 
 
+def _typed_credit_total(db, workspace_id: str) -> int:
+    return sum(
+        int(row["total_credits"])
+        for (candidate, _shard), row in db.typed[CREDIT_BALANCE_TABLE].items()
+        if candidate == workspace_id
+    )
+
+
 def test_credit_workspace_typed_direct_applies_once_in_one_transaction() -> None:
     store, db, _ = make_fake_store()
     ws = "ws_b2_apply"
@@ -101,12 +109,12 @@ def test_gcp_signup_seeds_typed_starter_credit() -> None:
     assert result is not None
     assert result.trial_credit_microdollars == grant_amount
     assert "total_credits_microdollars" not in _json_credit(db, result.workspace.id)
-    assert _typed_credit(db, result.workspace.id)["total_credits"] == grant_amount
+    assert _typed_credit_total(db, result.workspace.id) == grant_amount
     assert store.signup(
         email="typed-signup@example.com",
         trial_credit_microdollars=grant_amount,
     ) is None
-    assert _typed_credit(db, result.workspace.id)["total_credits"] == grant_amount
+    assert _typed_credit_total(db, result.workspace.id) == grant_amount
 
 
 def test_stripe_checkout_webhook_routes_topup_through_typed_direct(

--- a/tests/test_cloud_sdk_boundary.py
+++ b/tests/test_cloud_sdk_boundary.py
@@ -39,9 +39,12 @@ ALLOWED = {
     "storage_gcp_authorize.py",
     "storage_gcp_google_ads.py",
     "storage_gcp_io.py",
+    "storage_gcp_regional_quota.py",
     "storage_gcp_settle_outbox.py",
     "storage_gcp_synthetic_rollups.py",
     "storage_gcp_synthetic_index.py",
+    # Fixed-cluster Bigtable CAS implementation of the regional storage port.
+    "regional_quota_ledger.py",
     # The two explicit cloud ports. Both import lazily so a non-GCP deployment
     # need not install the Google libraries at all.
     "storage_errors.py",

--- a/tests/test_console_api_key_batch.py
+++ b/tests/test_console_api_key_batch.py
@@ -136,7 +136,9 @@ def test_spanner_bulk_key_usage_preserves_missing_row_fallback() -> None:
         name="legacy-json-counters",
         creator_user_id=user.id,
     )
-    database.typed["tr_key_limit"].pop((key.hash, 0))
+    for row_key in list(database.typed["tr_key_limit"]):
+        if row_key[0] == key.hash:
+            database.typed["tr_key_limit"].pop(row_key)
     key.usage_microdollars = 1234
     key.byok_usage_microdollars = 56
     key.reserved_microdollars = 7
@@ -170,7 +172,9 @@ def test_spanner_bulk_projection_matches_the_legacy_fanout_values() -> None:
     # One legacy JSON-only key, one ordinary typed key, and one three-shard
     # key exercise all of the old route's result branches.
     legacy = keys[0]
-    database.typed["tr_key_limit"].pop((legacy.hash, 0))
+    for row_key in list(database.typed["tr_key_limit"]):
+        if row_key[0] == legacy.hash:
+            database.typed["tr_key_limit"].pop(row_key)
     legacy.usage_microdollars = 17
     store._write_entity("api_key", legacy.hash, legacy)
 
@@ -227,12 +231,7 @@ def test_spanner_bulk_key_usage_fails_closed_on_incomplete_shards() -> None:
     )
     key.usage_shard_count = 3
     store._write_entity("api_key", key.hash, key)
-    base = database.typed["tr_key_limit"][(key.hash, 0)]
-    database.typed["tr_key_limit"][(key.hash, 2)] = {
-        **base,
-        "key_hash": key.hash,
-        "shard": 2,
-    }
+    database.typed["tr_key_limit"].pop((key.hash, 1))
 
     with pytest.raises(RuntimeError, match="usage shard set is incomplete"):
         store.list_api_keys_with_usage(workspace.id)

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -128,10 +128,46 @@ def test_all_attested_control_plane_regions_remain_warm() -> None:
     assert '--min-instances "$min_instances"' in rollout
 
 
-def test_production_deploy_keeps_regional_quota_leases_dark() -> None:
+def test_production_deploy_preserves_allowlisted_regional_quota_canary() -> None:
     rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
 
-    assert '"TR_REGIONAL_QUOTA_LEASES_ENABLED=false"' in rollout
+    assert 'read_primary_env "TR_REGIONAL_QUOTA_LEASES_ENABLED" "false"' in rollout
+    assert (
+        '"TR_REGIONAL_QUOTA_LEASES_ENABLED=${REGIONAL_QUOTA_LEASES_ENABLED}"'
+        in rollout
+    )
+    assert '"TR_REGIONAL_QUOTA_LEASES_ENABLED=false"' not in rollout
+    assert "regional quota canary requires pilot workspaces" in rollout
+    assert (
+        '"TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES=${REGIONAL_QUOTA_BIGTABLE_APP_PROFILES}"'
+        in rollout
+    )
+
+
+def test_production_deploy_provisions_and_schedules_regional_quota_reconciliation() -> None:
+    orchestrator = (ROOT / "scripts/deploy-gcp.sh").read_text()
+    workflow = (ROOT / ".github/workflows/deploy.yml").read_text()
+    library = (ROOT / "scripts/deploy/_lib.sh").read_text()
+    provisioner = (ROOT / "scripts/deploy/regional_quota_ledger.sh").read_text()
+    reconciler = (ROOT / "scripts/deploy/regional_quota_reconciler.sh").read_text()
+
+    assert 'deploy/regional_quota_ledger.sh' in orchestrator
+    assert 'deploy/regional_quota_reconciler.sh' in orchestrator
+    assert "bash scripts/deploy/regional_quota_ledger.sh" in workflow
+    assert "bash scripts/deploy/regional_quota_reconciler.sh" in workflow
+    assert workflow.index("bash scripts/deploy/regional_quota_ledger.sh") < workflow.index(
+        "bash scripts/deploy/rollout.sh"
+    )
+    assert workflow.index("bash scripts/deploy/regional_quota_reconciler.sh") > workflow.index(
+        "- name: Roll secondary warm regions sequentially"
+    )
+    assert "--transactional-writes" in provisioner
+    assert "trusted-router-logs-c1" in library
+    assert "trusted-router-logs-eu" in library
+    assert 'SCHEDULE="${TR_REGIONAL_QUOTA_RECONCILER_SCHEDULE:-* * * * *}"' in reconciler
+    assert "/v1/internal/gateway/regional-quota/reconcile?limit=250" in reconciler
+    assert "x-trustedrouter-internal-token=${internal_token}" in reconciler
+    assert "echo \"$internal_token\"" not in reconciler
 
 
 def test_deploy_preserves_request_record_mode_without_silent_legacy_fallback() -> None:

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -163,7 +163,8 @@ def test_production_deploy_provisions_and_schedules_regional_quota_reconciliatio
     )
     assert "--transactional-writes" in provisioner
     assert "trusted-router-logs-c1" in library
-    assert "trusted-router-logs-eu" in library
+    assert "us-central1=tr-quota-us-central1" in library
+    assert "europe-west4=tr-quota-europe-west4" not in library
     assert 'SCHEDULE="${TR_REGIONAL_QUOTA_RECONCILER_SCHEDULE:-* * * * *}"' in reconciler
     assert "/v1/internal/gateway/regional-quota/reconcile?limit=250" in reconciler
     assert "x-trustedrouter-internal-token=${internal_token}" in reconciler

--- a/tests/test_gateway_fallback_billing.py
+++ b/tests/test_gateway_fallback_billing.py
@@ -14,6 +14,7 @@ from trusted_router.partner_billing import (
     PARTNER_OPERATOR_COST_SETTLE_FIELD,
 )
 from trusted_router.provider_lifecycle import provider_model_retired
+from trusted_router.regional_quota_ledger import InMemoryRegionalQuotaLedger
 from trusted_router.routes.helpers import cost_microdollars
 from trusted_router.routes.internal import gateway as gateway_routes
 from trusted_router.storage import STORE, CreditAccount, Workspace, configure_store
@@ -73,6 +74,125 @@ def test_gateway_authorize_fake_spanner_uses_typed_without_allowlist_settings() 
     data = authorize.json()["data"]
     assert data["credit_reservation_id"] in db.reservations
     assert ("reservation", data["credit_reservation_id"]) not in db.rows
+
+
+def test_allowlisted_uncapped_key_authorizes_from_bounded_regional_escrow() -> None:
+    store, db, _ = make_fake_store(request_record_write_mode="typed")
+    store._regional_quota_ledger = InMemoryRegionalQuotaLedger()
+    workspace = store.create_workspace(
+        "owner",
+        "regional-pilot",
+        trial_credit_microdollars=100_000_000,
+    )
+    _raw, api_key = store.create_api_key(
+        workspace_id=workspace.id,
+        name="regional",
+        creator_user_id="owner",
+    )
+    configure_store(store)
+    settings = Settings(
+        environment="test",
+        regional_quota_leases_enabled=True,
+        regional_quota_lease_pilot_workspace_ids=workspace.id,
+    )
+    client = TestClient(
+        create_app(
+            settings,
+            configure_store_arg=False,
+            init_observability=False,
+        )
+    )
+
+    response = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": api_key.hash,
+            "model": "anthropic/claude-opus-4.7",
+            "estimated_input_tokens": 1_000,
+            "max_output_tokens": 100,
+            "route_type": "chat.completions",
+            "idempotency_key": "regional-pilot-request",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    authorization = store.get_gateway_authorization(response.json()["data"]["authorization_id"])
+    assert authorization is not None
+    assert authorization.settlement == "regional_lease"
+    reservation = db.reservations[str(authorization.credit_reservation_id)]
+    assert reservation["hold_usage_type"] == "RegionalCredits"
+    assert reservation["credit_reserved_micro"] == 0
+    assert sum(row["reserved"] for row in db.typed[CREDIT_BALANCE_TABLE].values()) > 0
+
+
+def test_capped_key_stays_on_exact_global_authorization_path() -> None:
+    store, db, _ = make_fake_store(request_record_write_mode="typed")
+    ledger = InMemoryRegionalQuotaLedger()
+    store._regional_quota_ledger = ledger
+    workspace = store.create_workspace(
+        "owner",
+        "regional-ineligible",
+        trial_credit_microdollars=100_000_000,
+    )
+    _raw, api_key = store.create_api_key(
+        workspace_id=workspace.id,
+        name="capped",
+        creator_user_id="owner",
+        limit_microdollars=1_000_000,
+    )
+    configure_store(store)
+    client = TestClient(
+        create_app(
+            Settings(
+                environment="test",
+                regional_quota_leases_enabled=True,
+                regional_quota_lease_pilot_workspace_ids=workspace.id,
+            ),
+            configure_store_arg=False,
+            init_observability=False,
+        )
+    )
+
+    response = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": api_key.hash,
+            "model": "anthropic/claude-opus-4.7",
+            "estimated_input_tokens": 1_000,
+            "max_output_tokens": 100,
+            "route_type": "chat.completions",
+            "idempotency_key": "regional-capped-key",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    authorization = store.get_gateway_authorization(response.json()["data"]["authorization_id"])
+    assert authorization is not None
+    assert authorization.settlement == "local"
+    assert store._list_entities("regional_quota_lease", cls=dict) == []
+
+
+def test_regional_reconciler_fails_scheduler_tick_when_any_lease_errors() -> None:
+    store, _db, _ = make_fake_store(request_record_write_mode="typed")
+    store._regional_quota_ledger = InMemoryRegionalQuotaLedger()
+    store.reconcile_regional_quota_leases = lambda **_kwargs: {
+        "inspected": 2,
+        "reconciled": 1,
+        "closed": 0,
+        "errors": 1,
+    }
+    configure_store(store)
+    settings = Settings(
+        environment="test",
+        regional_quota_leases_enabled=True,
+        regional_quota_lease_pilot_workspace_ids="pilot",
+    )
+    client = TestClient(create_app(settings, configure_store_arg=False, init_observability=False))
+
+    response = client.post("/v1/internal/gateway/regional-quota/reconcile")
+
+    assert response.status_code == 503
+    assert response.json()["error"]["type"] == "service_unavailable"
 
 
 def test_gateway_web_search_cost_uses_typed_reservation_and_finalize() -> None:

--- a/tests/test_regional_quota_leases.py
+++ b/tests/test_regional_quota_leases.py
@@ -37,13 +37,17 @@ def _lease(*, grant: int = 1_000, expires_in: int = 60) -> RegionalQuotaLease:
 
 
 def test_reserve_settle_and_refund_preserve_exact_integer_accounting() -> None:
-    first = _lease().reserve(
-        hold_id="a",
-        fingerprint="fp-a",
-        amount_microdollars=400,
-        fencing_token=7,
-        now=NOW,
-    ).lease
+    first = (
+        _lease()
+        .reserve(
+            hold_id="a",
+            fingerprint="fp-a",
+            amount_microdollars=400,
+            fencing_token=7,
+            now=NOW,
+        )
+        .lease
+    )
     second = first.reserve(
         hold_id="b",
         fingerprint="fp-b",
@@ -52,9 +56,7 @@ def test_reserve_settle_and_refund_preserve_exact_integer_accounting() -> None:
         now=NOW,
     ).lease
 
-    settled = second.settle(
-        hold_id="a", actual_microdollars=275, fencing_token=7
-    ).lease
+    settled = second.settle(hold_id="a", actual_microdollars=275, fencing_token=7).lease
     refunded = settled.refund(hold_id="b", fencing_token=7).lease
 
     assert refunded.spent_microdollars == 275
@@ -82,12 +84,8 @@ def test_reservation_and_terminal_transitions_are_idempotent() -> None:
     assert replay.replayed is True
     assert replay.lease is transition.lease
 
-    settled = replay.lease.settle(
-        hold_id="a", actual_microdollars=250, fencing_token=7
-    )
-    settled_replay = settled.lease.settle(
-        hold_id="a", actual_microdollars=250, fencing_token=7
-    )
+    settled = replay.lease.settle(hold_id="a", actual_microdollars=250, fencing_token=7)
+    settled_replay = settled.lease.settle(hold_id="a", actual_microdollars=250, fencing_token=7)
     assert settled_replay.replayed is True
     assert settled_replay.lease is settled.lease
 
@@ -96,16 +94,18 @@ def test_reservation_and_terminal_transitions_are_idempotent() -> None:
     ("fingerprint", "amount"),
     [("different", 400), ("fp", 401)],
 )
-def test_idempotency_reuse_with_changed_inputs_fails(
-    fingerprint: str, amount: int
-) -> None:
-    lease = _lease().reserve(
-        hold_id="a",
-        fingerprint="fp",
-        amount_microdollars=400,
-        fencing_token=7,
-        now=NOW,
-    ).lease
+def test_idempotency_reuse_with_changed_inputs_fails(fingerprint: str, amount: int) -> None:
+    lease = (
+        _lease()
+        .reserve(
+            hold_id="a",
+            fingerprint="fp",
+            amount_microdollars=400,
+            fencing_token=7,
+            now=NOW,
+        )
+        .lease
+    )
     with pytest.raises(LeaseIdempotencyConflictError):
         lease.reserve(
             hold_id="a",
@@ -144,13 +144,17 @@ def test_lease_fails_closed_on_expiry_exhaustion_and_stale_fence() -> None:
 
 
 def test_settlement_cannot_exceed_hold_or_cross_refund_boundary() -> None:
-    lease = _lease().reserve(
-        hold_id="a",
-        fingerprint="fp",
-        amount_microdollars=100,
-        fencing_token=7,
-        now=NOW,
-    ).lease
+    lease = (
+        _lease()
+        .reserve(
+            hold_id="a",
+            fingerprint="fp",
+            amount_microdollars=100,
+            fencing_token=7,
+            now=NOW,
+        )
+        .lease
+    )
     with pytest.raises(LeaseSettlementError, match="fit inside"):
         lease.settle(hold_id="a", actual_microdollars=101, fencing_token=7)
     refunded = lease.refund(hold_id="a", fencing_token=7).lease
@@ -159,13 +163,17 @@ def test_settlement_cannot_exceed_hold_or_cross_refund_boundary() -> None:
 
 
 def test_drain_blocks_new_work_and_close_waits_for_open_holds() -> None:
-    lease = _lease().reserve(
-        hold_id="a",
-        fingerprint="fp",
-        amount_microdollars=100,
-        fencing_token=7,
-        now=NOW,
-    ).lease
+    lease = (
+        _lease()
+        .reserve(
+            hold_id="a",
+            fingerprint="fp",
+            amount_microdollars=100,
+            fencing_token=7,
+            now=NOW,
+        )
+        .lease
+    )
     draining = lease.begin_drain(fencing_token=7)
     assert draining.state == LeaseState.DRAINING
     with pytest.raises(LeaseUnavailableError, match="draining"):
@@ -178,9 +186,7 @@ def test_drain_blocks_new_work_and_close_waits_for_open_holds() -> None:
         )
     with pytest.raises(LeaseUnavailableError, match="open reservations"):
         draining.close(fencing_token=7)
-    closed = draining.refund(hold_id="a", fencing_token=7).lease.close(
-        fencing_token=7
-    )
+    closed = draining.refund(hold_id="a", fencing_token=7).lease.close(fencing_token=7)
     assert closed.state == LeaseState.CLOSED
 
 
@@ -299,13 +305,22 @@ def test_invalid_construction_and_grant_inputs_fail_closed() -> None:
         )
 
 
-def test_regional_leases_are_dark_and_fail_closed_outside_tests() -> None:
-    assert Settings(environment="test").regional_quota_leases_enabled is False
+def test_regional_leases_default_off_and_fail_closed_without_dependencies() -> None:
+    defaults = Settings(environment="test")
+    assert defaults.regional_quota_leases_enabled is False
+    assert defaults.regional_quota_lease_shard_count == 16
     with pytest.raises(ValidationError, match="PILOT_WORKSPACE_IDS"):
         Settings(environment="test", regional_quota_leases_enabled=True)
-    with pytest.raises(ValidationError, match="not production-ready"):
+    with pytest.raises(ValidationError, match="Spanner GCP backend"):
         Settings(
             environment="staging",
+            regional_quota_leases_enabled=True,
+            regional_quota_lease_pilot_workspace_ids="workspace-1",
+        )
+    with pytest.raises(ValidationError, match="typed request records"):
+        Settings(
+            environment="staging",
+            storage_backend="spanner-bigtable",
             regional_quota_leases_enabled=True,
             regional_quota_lease_pilot_workspace_ids="workspace-1",
         )
@@ -318,3 +333,46 @@ def test_regional_leases_are_dark_and_fail_closed_outside_tests() -> None:
         "workspace-1",
         "workspace-2",
     }
+
+
+@pytest.mark.parametrize("count", [0, 65])
+def test_regional_lease_shard_count_is_bounded(count: int) -> None:
+    with pytest.raises(ValidationError, match="LEASE_SHARD_COUNT"):
+        Settings(environment="test", regional_quota_lease_shard_count=count)
+
+
+def test_regional_lease_production_config_requires_fixed_profiles_and_outbox() -> None:
+    common = {
+        "environment": "staging",
+        "storage_backend": "spanner-bigtable",
+        "request_record_write_mode": "typed",
+        "regional_quota_leases_enabled": True,
+        "regional_quota_lease_pilot_workspace_ids": "workspace-1",
+    }
+    with pytest.raises(ValidationError, match="settle outbox"):
+        Settings(**common)
+    with pytest.raises(ValidationError, match="fixed regional Bigtable app profiles"):
+        Settings(**common, settle_outbox_enabled=True)
+    settings = Settings(
+        **common,
+        settle_outbox_enabled=True,
+        regional_quota_bigtable_app_profiles=(
+            "us-central1=tr-quota-us-central1,europe-west4=tr-quota-europe-west4"
+        ),
+    )
+    assert settings.regional_quota_bigtable_app_profile_map == {
+        "us-central1": "tr-quota-us-central1",
+        "europe-west4": "tr-quota-europe-west4",
+    }
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["missing-separator", "=profile", "region=", "region=a,region=b"],
+)
+def test_regional_profile_map_rejects_ambiguous_entries(value: str) -> None:
+    with pytest.raises(ValueError):
+        _ = Settings(
+            environment="test",
+            regional_quota_bigtable_app_profiles=value,
+        ).regional_quota_bigtable_app_profile_map

--- a/tests/test_regional_quota_ledger.py
+++ b/tests/test_regional_quota_ledger.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import re
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from google.cloud.bigtable.row_filters import ValueRegexFilter
+
+from trusted_router.regional_quota_ledger import (
+    BigtableRegionalQuotaLedger,
+    InMemoryRegionalQuotaLedger,
+    RegionalLeaseLedgerError,
+    settled_key_totals,
+)
+from trusted_router.services.regional_quota_leases import RegionalQuotaLease
+
+NOW = datetime(2026, 8, 21, tzinfo=UTC)
+
+
+def _lease(*, grant: int = 10_000) -> RegionalQuotaLease:
+    return RegionalQuotaLease(
+        lease_id="rql-test",
+        workspace_id="workspace-test",
+        region="us-central1",
+        fencing_token=9,
+        granted_microdollars=grant,
+        expires_at=NOW + timedelta(minutes=1),
+    )
+
+
+def test_in_memory_ledger_serializes_concurrent_reservations_exactly() -> None:
+    ledger = InMemoryRegionalQuotaLedger()
+    ledger.initialize(_lease(grant=10_000))
+
+    def reserve(index: int) -> None:
+        ledger.reserve(
+            "rql-test",
+            region="us-central1",
+            hold_id=f"hold-{index}",
+            fingerprint=f"fingerprint-{index}",
+            amount_microdollars=100,
+            fencing_token=9,
+            key_hash="key-1",
+            key_shard=index % 16,
+            hold_expires_at=NOW + timedelta(hours=2),
+            now=NOW,
+        )
+
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        list(pool.map(reserve, range(100)))
+
+    current = ledger.get("rql-test", region="us-central1")
+    assert current is not None
+    assert current.reserved_microdollars == 10_000
+    assert current.available_microdollars == 0
+    assert len(current.holds) == 100
+
+
+def test_ledger_replays_ambiguous_commit_without_duplicate_hold() -> None:
+    table = _FakeBigtableTable()
+    ledger = BigtableRegionalQuotaLedger({"us-central1": table})
+    ledger.initialize(_lease())
+    table.raise_after_next_applied_commit = True
+
+    current = ledger.reserve(
+        "rql-test",
+        region="us-central1",
+        hold_id="hold-1",
+        fingerprint="same",
+        amount_microdollars=500,
+        fencing_token=9,
+        key_hash="key-1",
+        key_shard=3,
+        hold_expires_at=NOW + timedelta(hours=2),
+        now=NOW,
+    )
+
+    assert current.reserved_microdollars == 500
+    assert len(current.holds) == 1
+    durable = ledger.get("rql-test", region="us-central1")
+    assert durable == current
+
+
+def test_bigtable_round_trip_preserves_key_shard_expiry_and_settlement() -> None:
+    table = _FakeBigtableTable()
+    ledger = BigtableRegionalQuotaLedger({"us-central1": table})
+    ledger.initialize(_lease())
+    ledger.reserve(
+        "rql-test",
+        region="us-central1",
+        hold_id="hold-1",
+        fingerprint="same",
+        amount_microdollars=500,
+        fencing_token=9,
+        key_hash="key-1",
+        key_shard=7,
+        hold_expires_at=NOW + timedelta(hours=2),
+        now=NOW,
+    )
+    settled = ledger.settle(
+        "rql-test",
+        region="us-central1",
+        hold_id="hold-1",
+        actual_microdollars=275,
+        fencing_token=9,
+    )
+
+    assert settled.spent_microdollars == 275
+    assert settled.holds[0].expires_at == NOW + timedelta(hours=2)
+    assert settled_key_totals(settled) == {("key-1", 7): 275}
+
+
+def test_bigtable_ledger_fails_closed_without_authoritative_region_profile() -> None:
+    ledger = BigtableRegionalQuotaLedger({"us-central1": _FakeBigtableTable()})
+    with pytest.raises(RegionalLeaseLedgerError, match="no fixed Bigtable app profile"):
+        ledger.get("rql-test", region="europe-west4")
+
+
+@dataclass
+class _Cell:
+    value: bytes
+
+
+class _ReadRow:
+    def __init__(self, values: dict[bytes, bytes]) -> None:
+        self.cells = {"lease": {qualifier: [_Cell(value)] for qualifier, value in values.items()}}
+
+
+class _FakeConditionalRow:
+    def __init__(self, table: _FakeBigtableTable, row_key: bytes, filter_: Any) -> None:
+        self.table = table
+        self.row_key = row_key
+        self.filter = filter_
+        self.mutations: list[tuple[bool, bytes, bytes]] = []
+
+    def set_cell(
+        self,
+        _family: str,
+        column: bytes,
+        value: bytes,
+        *,
+        state: bool,
+    ) -> None:
+        self.mutations.append((state, column, value))
+
+    def commit(self) -> bool:
+        current = self.table.rows.get(self.row_key)
+        regex_filter = next(
+            (
+                candidate
+                for candidate in self.filter.filters
+                if isinstance(candidate, ValueRegexFilter)
+            ),
+            None,
+        )
+        if regex_filter is None:
+            matched = current is not None and b"version" in current
+        else:
+            expected = regex_filter.regex.removeprefix(b"^").removesuffix(b"$")
+            matched = (
+                current is not None
+                and re.fullmatch(
+                    expected,
+                    current.get(b"version", b""),
+                )
+                is not None
+            )
+        selected = [mutation for mutation in self.mutations if mutation[0] == matched]
+        if selected:
+            values = self.table.rows.setdefault(self.row_key, {})
+            for _state, column, value in selected:
+                values[column] = value
+        if self.table.raise_after_next_applied_commit and selected:
+            self.table.raise_after_next_applied_commit = False
+            raise TimeoutError("reply lost after durable apply")
+        return matched
+
+
+class _FakeBigtableTable:
+    def __init__(self) -> None:
+        self.rows: dict[bytes, dict[bytes, bytes]] = {}
+        self.raise_after_next_applied_commit = False
+
+    def row(self, row_key: bytes, *, filter_: Any) -> _FakeConditionalRow:
+        return _FakeConditionalRow(self, row_key, filter_)
+
+    def read_row(self, row_key: bytes, *, filter_: Any) -> _ReadRow | None:
+        del filter_
+        values = self.rows.get(row_key)
+        return None if values is None else _ReadRow(values)

--- a/tests/test_regional_quota_spanner.py
+++ b/tests/test_regional_quota_spanner.py
@@ -1,0 +1,520 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime, timedelta
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.regional_quota_ledger import InMemoryRegionalQuotaLedger
+from trusted_router.services.settle_outbox_apply import ApplyOutcome, apply_frozen_settle
+from trusted_router.storage import configure_store
+from trusted_router.storage_gcp_authorize import settle_atomic
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
+from trusted_router.storage_gcp_regional_quota import (
+    GlobalRegionalQuotaLease,
+    activate_regional_quota_lease,
+    grant_regional_quota_lease,
+    reconcile_regional_quota_lease,
+    record_regional_gateway_authorization,
+    regional_lease_from_global,
+)
+from trusted_router.storage_models import GatewayAuthorization, SettleOutboxRow
+from trusted_router.types import UsageType
+
+NOW = datetime(2026, 8, 21, tzinfo=UTC)
+
+
+def _credit_totals(database: object, workspace_id: str) -> tuple[int, int, int]:
+    rows = [
+        row
+        for (candidate, _shard), row in database.typed[CREDIT_BALANCE_TABLE].items()
+        if candidate == workspace_id
+    ]
+    return (
+        sum(row["total_credits"] for row in rows),
+        sum(row["total_usage"] for row in rows),
+        sum(row["reserved"] for row in rows),
+    )
+
+
+def test_global_grant_and_reconcile_preserve_exact_credit_and_key_totals() -> None:
+    store, database, _ = make_fake_store(request_record_write_mode="typed")
+    workspace = store.create_workspace(
+        "owner",
+        "regional",
+        trial_credit_microdollars=100_000_000,
+    )
+    _raw, key = store.create_api_key(
+        workspace_id=workspace.id,
+        name="uncapped",
+        creator_user_id="owner",
+    )
+    global_lease = grant_regional_quota_lease(
+        store,
+        workspace_id=workspace.id,
+        region="us-central1",
+        requested_microdollars=10_000_000,
+        per_lease_cap_microdollars=10_000_000,
+        max_available_basis_points=1_000,
+        ttl_seconds=60,
+        minimum_grant_microdollars=1_000,
+        now=NOW,
+    )
+    assert global_lease is not None
+    assert global_lease.granted_microdollars == 6_250_000
+    assert _credit_totals(database, workspace.id) == (
+        100_000_000,
+        0,
+        6_250_000,
+    )
+
+    global_lease = activate_regional_quota_lease(store, global_lease, now=NOW)
+    ledger = InMemoryRegionalQuotaLedger()
+    local = ledger.initialize(regional_lease_from_global(global_lease))
+    local = ledger.reserve(
+        local.lease_id,
+        region=local.region,
+        hold_id="auth-1",
+        fingerprint="fp-1",
+        amount_microdollars=5_000,
+        fencing_token=local.fencing_token,
+        key_hash=key.hash,
+        key_shard=7,
+        hold_expires_at=NOW + timedelta(hours=2),
+        now=NOW,
+    )
+    local = ledger.settle(
+        local.lease_id,
+        region=local.region,
+        hold_id="auth-1",
+        actual_microdollars=3_250,
+        fencing_token=local.fencing_token,
+    )
+    local = ledger.begin_drain(
+        local.lease_id,
+        region=local.region,
+        fencing_token=local.fencing_token,
+    )
+
+    result = reconcile_regional_quota_lease(
+        store,
+        global_lease,
+        local,
+        close=True,
+        now=NOW + timedelta(minutes=2),
+    )
+    assert result.spent_delta_microdollars == 3_250
+    assert result.unused_released_microdollars == 6_246_750
+    assert _credit_totals(database, workspace.id) == (
+        100_000_000,
+        3_250,
+        0,
+    )
+    assert database.typed[KEY_LIMIT_TABLE][(key.hash, 7)]["usage"] == 3_250
+
+    replay = reconcile_regional_quota_lease(
+        store,
+        global_lease,
+        local,
+        close=True,
+        now=NOW + timedelta(minutes=3),
+    )
+    assert replay.replayed is True
+    assert _credit_totals(database, workspace.id) == (
+        100_000_000,
+        3_250,
+        0,
+    )
+
+
+def test_global_fence_allows_only_one_active_grant_per_quota_shard() -> None:
+    store, database, _ = make_fake_store(request_record_write_mode="typed")
+    workspace = store.create_workspace(
+        "owner",
+        "regional-fence",
+        trial_credit_microdollars=100_000_000,
+    )
+    first = grant_regional_quota_lease(
+        store,
+        workspace_id=workspace.id,
+        region="us-central1",
+        quota_shard=3,
+        requested_microdollars=1_000_000,
+        per_lease_cap_microdollars=1_000_000,
+        max_available_basis_points=1_000,
+        ttl_seconds=60,
+        minimum_grant_microdollars=1_000,
+        now=NOW,
+    )
+    assert first is not None
+    first = activate_regional_quota_lease(store, first, now=NOW)
+    reserved_after_first = _credit_totals(database, workspace.id)[2]
+
+    blocked = grant_regional_quota_lease(
+        store,
+        workspace_id=workspace.id,
+        region="us-central1",
+        quota_shard=3,
+        requested_microdollars=1_000_000,
+        per_lease_cap_microdollars=1_000_000,
+        max_available_basis_points=1_000,
+        ttl_seconds=60,
+        minimum_grant_microdollars=1_000,
+        now=NOW,
+    )
+    assert blocked is None
+    assert _credit_totals(database, workspace.id)[2] == reserved_after_first
+
+    local = regional_lease_from_global(first).begin_drain(fencing_token=first.fencing_token)
+    reconcile_regional_quota_lease(
+        store,
+        first,
+        local,
+        close=True,
+        now=NOW + timedelta(minutes=2),
+    )
+    replacement = grant_regional_quota_lease(
+        store,
+        workspace_id=workspace.id,
+        region="us-central1",
+        quota_shard=3,
+        requested_microdollars=1_000_000,
+        per_lease_cap_microdollars=1_000_000,
+        max_available_basis_points=1_000,
+        ttl_seconds=60,
+        minimum_grant_microdollars=1_000,
+        now=NOW + timedelta(minutes=2),
+    )
+    assert replacement is not None
+    assert replacement.fencing_token == first.fencing_token + 1
+
+
+def test_regional_request_record_replays_without_reserving_global_rows() -> None:
+    store, database, _ = make_fake_store(request_record_write_mode="typed")
+    workspace = store.create_workspace(
+        "owner",
+        "regional-auth",
+        trial_credit_microdollars=10_000_000,
+    )
+    _raw, key = store.create_api_key(
+        workspace_id=workspace.id,
+        name="uncapped",
+        creator_user_id="owner",
+    )
+    authorization = GatewayAuthorization(
+        id="gwa-regional",
+        workspace_id=workspace.id,
+        key_hash=key.hash,
+        model_id="model",
+        provider="provider",
+        usage_type=UsageType.CREDITS,
+        estimated_microdollars=10_000,
+        idempotency_key="retry-key",
+        idempotency_fingerprint="f" * 64,
+        settlement="regional_lease",
+        regional_lease_id="rql-1",
+        regional_fencing_token=4,
+        regional_hold_id="gwa-regional",
+        region="us-central1",
+    )
+    before = _credit_totals(database, workspace.id)
+    first = record_regional_gateway_authorization(
+        store,
+        authorization=authorization,
+        idempotency_scope="scope-1",
+        idempotency_fingerprint="f" * 64,
+        expires_at=NOW + timedelta(hours=2),
+    )
+    second = record_regional_gateway_authorization(
+        store,
+        authorization=authorization,
+        idempotency_scope="scope-1",
+        idempotency_fingerprint="f" * 64,
+        expires_at=NOW + timedelta(hours=2),
+    )
+
+    assert first["outcome"] == "accepted"
+    assert second["outcome"] == "replay"
+    assert second["authorization_id"] == authorization.id
+    assert _credit_totals(database, workspace.id) == before
+
+    settle = settle_atomic(
+        database,
+        store._param_types,
+        reservation_id=str(first["reservation_id"]),
+        actual_micro=5_000,
+        settled_usage_type="Credits",
+        success=True,
+        outbox_available=False,
+    )
+    assert settle["outcome"] == "settled"
+    assert _credit_totals(database, workspace.id) == before
+    assert (
+        sum(
+            row["usage"]
+            for (candidate, _shard), row in database.typed[KEY_LIMIT_TABLE].items()
+            if candidate == key.hash
+        )
+        == 0
+    )
+
+
+def test_store_regional_authorize_settle_replay_and_reconcile_end_to_end() -> None:
+    store, database, _ = make_fake_store(request_record_write_mode="typed")
+    ledger = InMemoryRegionalQuotaLedger()
+    store._regional_quota_ledger = ledger
+    workspace = store.create_workspace(
+        "owner",
+        "regional-e2e",
+        trial_credit_microdollars=100_000_000,
+    )
+    _raw, key = store.create_api_key(
+        workspace_id=workspace.id,
+        name="uncapped",
+        creator_user_id="owner",
+    )
+    common = {
+        "workspace_id": workspace.id,
+        "key_hash": key.hash,
+        "key_usage_shards": key.usage_shard_count,
+        "estimate": 10_000,
+        "model_id": "model",
+        "provider": "provider",
+        "requested_model_id": "model",
+        "candidate_model_ids": ["model"],
+        "region": "us-central1",
+        "endpoint_id": "provider/model",
+        "candidate_endpoint_ids": ["provider/model"],
+        "idempotency_key": "same-request",
+        "idempotency_fingerprint": "a" * 64,
+        "tags": {"test": "regional"},
+        "expires_at": NOW + timedelta(hours=2),
+        "lease_ttl_seconds": 60,
+        "lease_max_microdollars": 10_000_000,
+        "lease_max_available_basis_points": 1_000,
+        "lease_shard_count": 16,
+    }
+
+    outcome, authorization = store.authorize_gateway_regional(
+        authorization_id="gwa-first",
+        **common,
+    )
+    replay_outcome, replay = store.authorize_gateway_regional(
+        authorization_id="gwa-concurrent-loser",
+        **common,
+    )
+
+    assert outcome == "accepted"
+    assert authorization is not None
+    assert authorization.settlement == "regional_lease"
+    assert replay_outcome == "replay"
+    assert replay is not None and replay.id == authorization.id
+    local = ledger.get(
+        str(authorization.regional_lease_id),
+        region="us-central1",
+    )
+    assert local is not None
+    assert [hold.hold_id for hold in local.holds if hold.state.value == "reserved"] == [
+        authorization.id
+    ]
+
+    finalized = store.typed_finalize_gateway_authorization_result(
+        authorization.id,
+        success=True,
+        actual_microdollars=7_500,
+        selected_usage_type=UsageType.CREDITS,
+    )
+    assert finalized.finalized is True
+    local = ledger.get(
+        str(authorization.regional_lease_id),
+        region="us-central1",
+    )
+    assert local is not None and local.spent_microdollars == 7_500
+
+    reconciled = store.reconcile_regional_quota_leases(
+        now=datetime.now(UTC) + timedelta(minutes=2),
+    )
+    assert reconciled == {
+        "inspected": 1,
+        "reconciled": 1,
+        "closed": 1,
+        "errors": 0,
+    }
+    assert _credit_totals(database, workspace.id) == (
+        100_000_000,
+        7_500,
+        0,
+    )
+
+
+def test_regional_pool_spreads_hot_workspace_across_bounded_lease_shards() -> None:
+    store, database, _ = make_fake_store(request_record_write_mode="typed")
+    store._regional_quota_ledger = InMemoryRegionalQuotaLedger()
+    workspace = store.create_workspace(
+        "owner",
+        "regional-shards",
+        trial_credit_microdollars=100_000_000,
+    )
+    _raw, key = store.create_api_key(
+        workspace_id=workspace.id,
+        name="uncapped",
+        creator_user_id="owner",
+    )
+
+    def fingerprint_for_shard(target: int) -> str:
+        for index in range(10_000):
+            candidate = hashlib.sha256(f"fp-{index}".encode()).hexdigest()
+            selected = (
+                int.from_bytes(
+                    hashlib.sha256(candidate.encode()).digest()[:4],
+                    "big",
+                )
+                % 4
+            )
+            if selected == target:
+                return candidate
+        raise AssertionError("could not produce shard fingerprint")
+
+    authorizations = []
+    for shard in range(4):
+        outcome, authorization = store.authorize_gateway_regional(
+            authorization_id=f"gwa-shard-{shard}",
+            workspace_id=workspace.id,
+            key_hash=key.hash,
+            key_usage_shards=key.usage_shard_count,
+            estimate=10_000,
+            model_id="model",
+            provider="provider",
+            requested_model_id="model",
+            candidate_model_ids=["model"],
+            region="us-central1",
+            endpoint_id="provider/model",
+            candidate_endpoint_ids=["provider/model"],
+            idempotency_key=f"request-{shard}",
+            idempotency_fingerprint=fingerprint_for_shard(shard),
+            tags={},
+            expires_at=datetime.now(UTC) + timedelta(hours=2),
+            lease_ttl_seconds=60,
+            lease_max_microdollars=10_000_000,
+            lease_max_available_basis_points=1_000,
+            lease_shard_count=4,
+        )
+        assert outcome == "accepted"
+        assert authorization is not None
+        authorizations.append(authorization)
+
+    leases = store._list_entities(
+        "regional_quota_lease",
+        cls=GlobalRegionalQuotaLease,
+    )
+    assert {lease.quota_shard for lease in leases} == {0, 1, 2, 3}
+    _total, _usage, reserved = _credit_totals(database, workspace.id)
+    assert 0 < reserved <= 10_000_000
+
+    for authorization in authorizations:
+        result = store.typed_finalize_gateway_authorization_result(
+            authorization.id,
+            success=False,
+            actual_microdollars=0,
+            selected_usage_type=UsageType.CREDITS,
+        )
+        assert result.finalized is True
+    reconciled = store.reconcile_regional_quota_leases(
+        now=datetime.now(UTC) + timedelta(minutes=2),
+    )
+    assert reconciled["closed"] == 4
+    assert reconciled["errors"] == 0
+    assert _credit_totals(database, workspace.id) == (100_000_000, 0, 0)
+
+
+def test_settle_outbox_recovery_settles_regional_hold_before_spanner_terminal() -> None:
+    store, database, _ = make_fake_store(request_record_write_mode="typed")
+    ledger = InMemoryRegionalQuotaLedger()
+    store._regional_quota_ledger = ledger
+    workspace = store.create_workspace(
+        "owner",
+        "regional-outbox",
+        trial_credit_microdollars=100_000_000,
+    )
+    _raw, key = store.create_api_key(
+        workspace_id=workspace.id,
+        name="uncapped",
+        creator_user_id="owner",
+    )
+    outcome, authorization = store.authorize_gateway_regional(
+        authorization_id="gwa-outbox-regional",
+        workspace_id=workspace.id,
+        key_hash=key.hash,
+        key_usage_shards=key.usage_shard_count,
+        estimate=10_000,
+        model_id="model",
+        provider="provider",
+        requested_model_id="model",
+        candidate_model_ids=["model"],
+        region="us-central1",
+        endpoint_id="provider/model",
+        candidate_endpoint_ids=["provider/model"],
+        idempotency_key="regional-outbox-request",
+        idempotency_fingerprint="b" * 64,
+        tags={},
+        expires_at=datetime.now(UTC) + timedelta(hours=2),
+        lease_ttl_seconds=60,
+        lease_max_microdollars=10_000_000,
+        lease_max_available_basis_points=1_000,
+        lease_shard_count=16,
+    )
+    assert outcome == "accepted"
+    assert authorization is not None
+    configure_store(store)
+    row = SettleOutboxRow(
+        authorization_id=authorization.id,
+        intent_kind="settle",
+        settle_origin="typed",
+        actual_cost_micro=7_500,
+        reservation_id=authorization.credit_reservation_id,
+        selected_endpoint_id="provider/model",
+        model_id="model",
+        selected_usage_type="Credits",
+        settle_body=json.dumps(
+            {
+                "authorization_id": authorization.id,
+                "actual_input_tokens": 10,
+                "actual_output_tokens": 5,
+                "request_id": "provider-request",
+                "finish_reason": "stop",
+                "status": "success",
+            }
+        ),
+    )
+
+    assert apply_frozen_settle(row) == ApplyOutcome.SETTLED_NOW
+    local = ledger.get(
+        str(authorization.regional_lease_id),
+        region="us-central1",
+    )
+    assert local is not None
+    assert local.spent_microdollars == 7_500
+
+    opposing_refund = SettleOutboxRow(
+        authorization_id=authorization.id,
+        intent_kind="refund",
+        settle_origin="typed",
+        actual_cost_micro=0,
+        reservation_id=authorization.credit_reservation_id,
+        selected_endpoint_id="provider/model",
+        model_id="model",
+        selected_usage_type="Credits",
+        settle_body=json.dumps({"authorization_id": authorization.id}),
+    )
+    assert apply_frozen_settle(opposing_refund) == ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE
+    replayed_local = ledger.get(
+        str(authorization.regional_lease_id),
+        region="us-central1",
+    )
+    assert replayed_local == local
+
+    reconciled = store.reconcile_regional_quota_leases(
+        now=datetime.now(UTC) + timedelta(minutes=2),
+    )
+    assert reconciled["errors"] == 0
+    assert _credit_totals(database, workspace.id) == (100_000_000, 7_500, 0)


### PR DESCRIPTION
## Summary
- default new workspaces and keys to 16 billing shards
- add bounded, fenced regional Bigtable quota escrow with exact Spanner reconciliation
- add a one-workspace production canary, crash-safe settlement recovery, and fail-closed exact fallback
- provision the ledger and reconciler through the normal staged deployment workflow

## Validation
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (5,078 passed, 301 skipped, 10 xfailed)
- deployment-focused suite (58 passed)
- post-rebase regional/deploy suite (79 passed)