### PR TITLE
Schedule Cerebras Qwen 3.8 Shared Tier cutover

### DIFF
--- a/scripts/check_price_coverage.py
+++ b/scripts/check_price_coverage.py
@@ -69,6 +69,8 @@ def _cerebras_model_id(native_id: str) -> str | None:
         "gpt-oss-120b": "openai/gpt-oss-120b",
         "zai-glm-4.7": "z-ai/glm-4.7",
         "gemma-4-31b": "google/gemma-4-31b-it",
+        "qwen-3.8-27b": "qwen/qwen3.8-27b",
+        "qwen3.8-27b": "qwen/qwen3.8-27b",
     }.get(value) or canonicalize_unqualified_model_id(value)
 
 

--- a/scripts/pricing/providers/cerebras.py
+++ b/scripts/pricing/providers/cerebras.py
@@ -28,6 +28,7 @@ from scripts.pricing.model_ids import (
     remember_upstream_id,
 )
 from scripts.pricing.openai_catalog import openai_model_price, positive_int
+from trusted_router.provider_lifecycle import provider_model_retired
 
 SLUG = "cerebras"
 URL = "https://api.cerebras.ai/public/v1/models"
@@ -44,13 +45,24 @@ _CANONICAL_BY_NATIVE = {
     "gpt-oss-120b": "openai/gpt-oss-120b",
     "zai-glm-4.7": "z-ai/glm-4.7",
     "gemma-4-31b": "google/gemma-4-31b-it",
+    # Cerebras has announced Qwen 3.8 27B for Shared Tier on 2026-09-03 but
+    # has not yet published the callable native ID. Accept both spellings the
+    # provider commonly uses, while still requiring the live feed to expose
+    # the route and exact price before it is written to the runtime manifest.
+    "qwen-3.8-27b": "qwen/qwen3.8-27b",
+    "qwen3.8-27b": "qwen/qwen3.8-27b",
 }
 _ALIASES_BY_NATIVE = {
     "gpt-oss-120b": ("cerebras/gpt-oss-120b",),
     "zai-glm-4.7": ("cerebras/zai-glm-4.7",),
     "gemma-4-31b": ("cerebras/gemma-4-31b",),
+    "qwen-3.8-27b": ("cerebras/qwen-3.8-27b",),
+    "qwen3.8-27b": ("cerebras/qwen-3.8-27b",),
 }
-EXPECTED_MODELS = list(_CANONICAL_BY_NATIVE.values())
+# Keep one stable Shared Tier anchor as the hard feed-health gate. GLM 4.7 is
+# already absent from the public catalog, and Gemma 4 is scheduled to leave;
+# requiring either would deadlock hourly refreshes on a legitimate delisting.
+EXPECTED_MODELS = ["openai/gpt-oss-120b"]
 UPSTREAM_ID_MAP: dict[str, str] = {}
 _DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
 
@@ -133,6 +145,8 @@ def fetch() -> ProviderPricingResult:
             native_id
         )
         if canonical_id is None:
+            continue
+        if provider_model_retired(SLUG, canonical_id, native_id):
             continue
         price = openai_model_price(source)
         if price is None:

--- a/src/trusted_router/data/provider_models/cerebras.json
+++ b/src/trusted_router/data/provider_models/cerebras.json
@@ -154,6 +154,8 @@
       "status": 1,
       "id": "cerebras/gemma-4-31b",
       "upstream_id": "gemma-4-31b",
+      "retirement_at": "2026-09-03T00:00:00Z",
+      "replacement_model_id": "qwen/qwen3.8-27b",
       "features": [
         "function-calling",
         "high-throughput",
@@ -187,6 +189,8 @@
       "status": 1,
       "id": "google/gemma-4-31b-it",
       "upstream_id": "gemma-4-31b",
+      "retirement_at": "2026-09-03T00:00:00Z",
+      "replacement_model_id": "qwen/qwen3.8-27b",
       "features": [
         "function-calling",
         "high-throughput",

--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -37,6 +37,7 @@ DEEPINFRA_QWEN3_235B_THINKING_RETIREMENT_AT = datetime(
     2026, 8, 24, 0, 0, tzinfo=UTC
 )
 NEBIUS_AUGUST_2026_RETIREMENT_AT = datetime(2026, 8, 31, 0, 0, tzinfo=UTC)
+CEREBRAS_GEMMA4_SHARED_RETIREMENT_AT = datetime(2026, 9, 3, 0, 0, tzinfo=UTC)
 NOVITA_LING_30_TINY_RETIREMENT_AT = datetime(2026, 8, 13, 15, 0, tzinfo=UTC)
 ALIBABA_OCTOBER_2026_RETIREMENT_AT = datetime(2026, 10, 9, 16, 0, tzinfo=UTC)
 DEEPSEEK_V4_PRICING_EFFECTIVE_AT = datetime(2026, 8, 16, 16, 0, tzinfo=UTC)
@@ -88,6 +89,22 @@ class _Retirement:
 
 
 _RETIREMENTS = (
+    # Cerebras announced that Qwen 3.8 27B replaces Gemma 4 31B on its
+    # Shared Tier on 2026-09-03. The notice did not specify a time zone, so
+    # retire the shared route conservatively at 00:00 UTC. Gemma remains
+    # available through separately provisioned Cerebras dedicated endpoints;
+    # TrustedRouter's prepaid Cerebras route uses the Shared Tier.
+    _Retirement(
+        provider="cerebras",
+        model_ids=frozenset(
+            {
+                "google/gemma-4-31b-it",
+                "cerebras/gemma-4-31b",
+            }
+        ),
+        upstream_ids=frozenset({"gemma-4-31b"}),
+        effective_at=CEREBRAS_GEMMA4_SHARED_RETIREMENT_AT,
+    ),
     # Nebius announced that these Token Factory Serverless routes retire on
     # 2026-08-31. The notice did not specify a time zone, so use 00:00 UTC as
     # the conservative cutover. Keep this provider-scoped: equivalent model

--- a/tests/test_catalog_prepaid_display.py
+++ b/tests/test_catalog_prepaid_display.py
@@ -17,6 +17,7 @@ from trusted_router.catalog_ingest import (
     _provider_manifest_dark_model_ids,
 )
 from trusted_router.dashboard import _model_detail_view
+from trusted_router.provider_lifecycle import provider_model_retired
 
 
 def _a_supplemental_priced_model() -> str:
@@ -171,6 +172,11 @@ def test_cerebras_native_routes_use_verified_upstream_ids() -> None:
         if isinstance(row, dict)
         and isinstance(row.get("id"), str)
         and row.get("routable") is not False
+        and not provider_model_retired(
+            "cerebras",
+            row["id"],
+            row.get("upstream_id"),
+        )
     ]
 
     assert live_rows

--- a/tests/test_cerebras_pricing.py
+++ b/tests/test_cerebras_pricing.py
@@ -1,13 +1,24 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import TracebackType
 from typing import Any
 
 from pytest import MonkeyPatch
 
+from scripts.pricing import refresh
+from scripts.pricing.base import ModelPrice, ProviderPricingResult
 from scripts.pricing.providers import cerebras
+from trusted_router import provider_lifecycle
+from trusted_router.catalog import endpoints_for_model
+
+_CUTOFF = datetime(2026, 9, 3, 0, 0, tzinfo=UTC)
+_GEMMA = "google/gemma-4-31b-it"
+_GEMMA_ALIAS = "cerebras/gemma-4-31b"
+_GEMMA_UPSTREAM = "gemma-4-31b"
+_QWEN = "qwen/qwen3.8-27b"
 
 
 class _FakeCerebrasResponse:
@@ -102,6 +113,11 @@ def test_cerebras_public_api_discovers_models_prices_and_capabilities(
     monkeypatch: MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(cerebras.httpx, "Client", _FakeCerebrasClient)
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF - timedelta(microseconds=1),
+    )
 
     result = cerebras.fetch()
 
@@ -126,6 +142,11 @@ def test_cerebras_refresh_writes_new_models_and_aliases(
     tmp_path: Path,
 ) -> None:
     monkeypatch.setattr(cerebras.httpx, "Client", _FakeCerebrasClient)
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF - timedelta(microseconds=1),
+    )
     manifest_path = tmp_path / "cerebras.json"
     manifest_path.write_text(
         json.dumps({"provider": "cerebras", "models": []}) + "\n",
@@ -150,3 +171,145 @@ def test_cerebras_refresh_writes_new_models_and_aliases(
     } == set(rows)
     assert rows["google/gemma-4-31b-it"]["input_token_price_per_m"] == 990_000
     assert rows["google/gemma-4-31b-it"]["upstream_id"] == "gemma-4-31b"
+
+
+def test_cerebras_qwen38_is_discovered_only_from_a_live_priced_feed(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    payload = _FakeCerebrasResponse().json()
+    payload["data"].append(
+        {
+            "id": "qwen-3.8-27b",
+            "name": "Qwen 3.8 27B",
+            "pricing": {
+                "prompt": "0.00000040",
+                "completion": "0.00000120",
+            },
+            "capabilities": {
+                "function_calling": True,
+                "structured_outputs": True,
+                "vision": True,
+            },
+            "limits": {
+                "max_context_length": 131_072,
+                "max_completion_tokens": 32_768,
+            },
+            "deprecated": False,
+        }
+    )
+    monkeypatch.setattr(_FakeCerebrasResponse, "json", lambda _self: payload)
+    monkeypatch.setattr(cerebras.httpx, "Client", _FakeCerebrasClient)
+
+    result = cerebras.fetch()
+
+    assert result.prices[_QWEN] == ModelPrice(400_000, 1_200_000)
+    assert result.prices["cerebras/qwen-3.8-27b"] == result.prices[_QWEN]
+    assert cerebras.UPSTREAM_ID_MAP[_QWEN] == "qwen-3.8-27b"
+    row = cerebras._DISCOVERED_MANIFEST_ROWS[_QWEN]
+    assert row["input_modalities"] == ["text", "image"]
+    assert row["upstream_id"] == "qwen-3.8-27b"
+
+
+def test_cerebras_gemma_shared_route_retires_at_announced_cutover() -> None:
+    assert not provider_lifecycle.provider_model_retired(
+        "cerebras",
+        _GEMMA,
+        _GEMMA_UPSTREAM,
+        at=_CUTOFF - timedelta(microseconds=1),
+    )
+    assert provider_lifecycle.provider_model_retired(
+        "cerebras",
+        _GEMMA,
+        _GEMMA_UPSTREAM,
+        at=_CUTOFF,
+    )
+    assert provider_lifecycle.provider_model_retired(
+        "cerebras",
+        _GEMMA_ALIAS,
+        _GEMMA_UPSTREAM,
+        at=_CUTOFF,
+    )
+    assert not provider_lifecycle.provider_model_retired(
+        "another-provider",
+        _GEMMA,
+        _GEMMA_UPSTREAM,
+        at=_CUTOFF,
+    )
+    assert not provider_lifecycle.provider_model_retired(
+        "cerebras",
+        _QWEN,
+        "qwen-3.8-27b",
+        at=_CUTOFF,
+    )
+
+
+def test_cerebras_parser_filters_retired_gemma_from_a_stale_feed(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cerebras.httpx, "Client", _FakeCerebrasClient)
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF - timedelta(microseconds=1),
+    )
+    before = cerebras.fetch()
+    assert _GEMMA in before.prices
+    assert _GEMMA_ALIAS in before.prices
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    after = cerebras.fetch()
+    assert _GEMMA not in after.prices
+    assert _GEMMA_ALIAS not in after.prices
+    assert _GEMMA not in cerebras._DISCOVERED_MANIFEST_ROWS
+    assert "openai/gpt-oss-120b" in after.prices
+
+
+def test_hourly_refresh_cannot_restore_retired_cerebras_gemma(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    result = ProviderPricingResult(
+        slug="cerebras",
+        prices={
+            _GEMMA: ModelPrice(990_000, 1_490_000),
+            _QWEN: ModelPrice(400_000, 1_200_000),
+        },
+        source="api",
+        fetched_url=cerebras.URL,
+    )
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF - timedelta(microseconds=1),
+    )
+    before = refresh._index_provider_prices({"cerebras": result})
+    assert "cerebras" in before[_GEMMA]
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    after = refresh._index_provider_prices({"cerebras": result})
+    assert _GEMMA not in after
+    assert "cerebras" in after[_QWEN]
+
+
+def test_cerebras_gemma_retirement_is_visible_and_provider_scoped(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+
+    providers = {endpoint.provider for endpoint in endpoints_for_model(_GEMMA)}
+
+    assert "cerebras" not in providers
+    assert providers
+
+
+def test_cerebras_manifest_records_shared_tier_replacement() -> None:
+    rows = {
+        row["id"]: row
+        for row in json.loads(cerebras.MANIFEST_PATH.read_text(encoding="utf-8"))["models"]
+    }
+    for model_id in (_GEMMA, _GEMMA_ALIAS):
+        assert rows[model_id]["retirement_at"] == "2026-09-03T00:00:00Z"
+        assert rows[model_id]["replacement_model_id"] == _QWEN
+
+
+def test_cerebras_feed_gate_uses_a_non_retiring_anchor() -> None:
+    assert cerebras.EXPECTED_MODELS == ["openai/gpt-oss-120b"]

--- a/tests/test_check_price_coverage.py
+++ b/tests/test_check_price_coverage.py
@@ -135,6 +135,8 @@ def test_cerebras_discovery_uses_canonical_ids_and_ignores_unknown_models() -> N
     assert check_price_coverage._cerebras_model_id("gpt-oss-120b") == ("openai/gpt-oss-120b")
     assert check_price_coverage._cerebras_model_id("zai-glm-4.7") == "z-ai/glm-4.7"
     assert check_price_coverage._cerebras_model_id("gemma-4-31b") == ("google/gemma-4-31b-it")
+    assert check_price_coverage._cerebras_model_id("qwen-3.8-27b") == "qwen/qwen3.8-27b"
+    assert check_price_coverage._cerebras_model_id("qwen3.8-27b") == "qwen/qwen3.8-27b"
     assert check_price_coverage._cerebras_model_id("unknown") is None
 
 


### PR DESCRIPTION
## Summary
- retire Cerebras Shared Tier Gemma 4 31B on 2026-09-03 without affecting other providers or dedicated endpoints
- auto-discover Qwen 3.8 27B only after Cerebras publishes a priced live-feed row
- replace the stale GLM/Gemma feed gate with the stable GPT OSS anchor
- add current-clock and post-cutover regression coverage

## Verification
- live Cerebras public catalog fetch
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q` (5,085 passed)
- focused current/post-cutover suites (56 passed each)

The complete post-cutover CI job remains the authoritative Linux socket-probe gate.