### PR TITLE
Run regional quota reconciliation as a Cloud Run Job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -641,9 +641,9 @@ jobs:
         run: bash scripts/deploy/google_data_manager.sh
 
       - name: Deploy regional quota reconciler
-        # Safe while the feature is disabled (the endpoint is a no-op) and
-        # mandatory once a workspace canary is enabled. Keep it in the normal
-        # rollout so scheduler drift cannot strand bounded escrow.
+        # The worker cannot authorize traffic. It continues draining already
+        # issued bounded escrow even when serving issuance is disabled, and is
+        # mandatory once a workspace canary has ever been enabled.
         run: bash scripts/deploy/regional_quota_reconciler.sh
 
       # No cross-region "final watchdog" step. Each region's health is

--- a/docs/design/regional-quota-leases.md
+++ b/docs/design/regional-quota-leases.md
@@ -10,6 +10,10 @@ more credit than it owns.
 ## Safety model
 
 The global ledger grants a region a bounded amount of already-reserved credit.
+Each active grant also has a transactionally maintained
+`regional_quota_lease_open` index row ordered by expiry. Reconciliation reads a
+bounded prefix of that index instead of scanning historical closed leases; the
+same Spanner transaction removes the index row when it closes the grant.
 Creating a lease and increasing the workspace's global `reserved` total happen
 in one exact Spanner transaction. A region can authorize only against its local
 durable lease. The maximum unreconciled exposure is therefore the sum of active
@@ -95,6 +99,18 @@ accepts true only with typed request records, the durable settle outbox, a
 non-empty workspace allowlist, a Bigtable instance, and fixed regional app
 profiles. Ordinary deploys preserve the serving revision's state rather than
 silently flipping it.
+
+Reconciliation is intentionally independent from traffic issuance. A
+versioned one-shot Cloud Run Job continues draining leases that were already
+issued even after operators disable the serving feature, so a kill switch
+cannot strand globally reserved credit. Cloud Scheduler invokes the job with
+Google OAuth; the deploy identity never reads the internal gateway token. A
+new version must complete a real Spanner read and a Bigtable data read through
+every fixed app profile before the stable schedule points to it. Executions
+have no task or scheduler retry and a 50-second deadline under the one-minute
+cadence, preventing retry-driven overlap. Clean runs publish the
+`job:regional-quota-reconcile` heartbeat; failures reach Cloud Logging and
+Sentry.
 
 Production activation requires all of the following:
 

--- a/scripts/deploy/regional_quota_reconciler.sh
+++ b/scripts/deploy/regional_quota_reconciler.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 # Keep bounded regional quota escrow synchronized with the exact Spanner
-# ledger. The public Cloud Run service already has the storage clients warm;
-# Cloud Scheduler invokes its token-protected, metadata-only endpoint once a
-# minute. The endpoint is idempotent and a disabled feature returns a no-op.
+# ledger. Cloud Scheduler invokes a one-shot Cloud Run Job with Google OAuth;
+# the deploy identity never reads or embeds the internal gateway token.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -12,35 +11,61 @@ source "${SCRIPT_DIR}/_lib.sh"
 SCHEDULER_NAME="${TR_REGIONAL_QUOTA_RECONCILER_SCHEDULER:-trusted-router-regional-quota-reconcile}"
 SCHEDULER_REGION="${TR_REGIONAL_QUOTA_RECONCILER_REGION:-${TR_PRIMARY_REGION}}"
 SCHEDULE="${TR_REGIONAL_QUOTA_RECONCILER_SCHEDULE:-* * * * *}"
+JOB_NAME="${TR_REGIONAL_QUOTA_RECONCILER_JOB:-trusted-router-regional-quota-reconciler}"
+RECONCILE_LIMIT="${TR_REGIONAL_QUOTA_RECONCILE_LIMIT:-250}"
 
-service_url="$(
-  gc run services describe "$SERVICE" \
-    --region="$TR_PRIMARY_REGION" \
-    --format='value(status.url)'
-)"
-if [ -z "$service_url" ]; then
-  log "refusing regional quota scheduler deploy: primary service URL is missing"
+if ! gc artifacts docker images describe "$IMAGE" >/dev/null 2>&1; then
+  log "refusing regional quota reconciler deploy: image ${IMAGE} does not exist"
   exit 1
 fi
 
-internal_token="$(
-  gc secrets versions access latest \
-    --secret=trustedrouter-internal-gateway-token
-)"
-if [ -z "$internal_token" ]; then
-  log "refusing regional quota scheduler deploy: internal token is missing"
-  exit 1
-fi
+env_vars=(
+  "TR_ENVIRONMENT=worker"
+  "TR_RELEASE=$(git rev-parse --short HEAD 2>/dev/null || echo local)"
+  "TR_STORAGE_BACKEND=spanner-bigtable"
+  "TR_GCP_PROJECT_ID=${PROJECT_ID}"
+  "TR_SPANNER_INSTANCE_ID=${SPANNER_INSTANCE_ID}"
+  "TR_SPANNER_DATABASE_ID=${SPANNER_DATABASE_ID}"
+  "TR_BIGTABLE_INSTANCE_ID=${BIGTABLE_INSTANCE_ID}"
+  "TR_BIGTABLE_GENERATION_TABLE=${BIGTABLE_GENERATION_TABLE}"
+  "TR_REQUEST_RECORD_WRITE_MODE=typed"
+  "TR_SETTLE_OUTBOX_ENABLED=true"
+  "TR_REGIONAL_QUOTA_LEASES_ENABLED=true"
+  "TR_REGIONAL_QUOTA_BIGTABLE_TABLE=${TR_REGIONAL_QUOTA_BIGTABLE_TABLE:-trustedrouter-regional-quota}"
+  "TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES=${TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES}"
+  "TR_REGIONAL_QUOTA_RECONCILE_LIMIT=${RECONCILE_LIMIT}"
+  "TR_PRIMARY_REGION=${TR_PRIMARY_REGION}"
+)
+set_env_vars="$(IFS='|'; echo "^|^${env_vars[*]}")"
 
-uri="${service_url}/v1/internal/gateway/regional-quota/reconcile?limit=250"
-headers="x-trustedrouter-internal-token=${internal_token},Content-Type=application/json"
+log "deploying regional quota reconciliation job ${JOB_NAME}"
+gc run jobs deploy "$JOB_NAME" \
+  --region "$SCHEDULER_REGION" \
+  --image "$IMAGE" \
+  --command="/app/.venv/bin/python" \
+  --args="-m,trusted_router.regional_quota_reconcile_cli" \
+  --service-account "$RUN_SERVICE_ACCOUNT" \
+  --set-env-vars "$set_env_vars" \
+  --max-retries 1 \
+  --task-timeout 240s \
+  --cpu 1 \
+  --memory 512Mi \
+  --quiet >/dev/null
+
+gc run jobs add-iam-policy-binding "$JOB_NAME" \
+  --region "$SCHEDULER_REGION" \
+  --member="serviceAccount:${RUN_SERVICE_ACCOUNT}" \
+  --role="roles/run.invoker" \
+  --quiet >/dev/null
+
+uri="https://${SCHEDULER_REGION}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${PROJECT_ID}/jobs/${JOB_NAME}:run"
 common_args=(
   --location="$SCHEDULER_REGION"
   --schedule="$SCHEDULE"
   --time-zone=UTC
   --uri="$uri"
   --http-method=POST
-  --headers="$headers"
+  --oauth-service-account-email="$RUN_SERVICE_ACCOUNT"
   --attempt-deadline=30s
   --max-retry-attempts=3
   --min-backoff=5s
@@ -61,4 +86,13 @@ fi
 # accumulate expired escrow. Resume is idempotent.
 gc scheduler jobs resume "$SCHEDULER_NAME" \
   --location="$SCHEDULER_REGION" --quiet >/dev/null 2>&1 || true
-log "regional quota reconciler is scheduled once per minute"
+
+# A successful no-op execution proves image startup, settings validation,
+# Spanner access, and Bigtable app-profile routing before the deploy turns
+# green. Reconciliation is idempotent if an active pilot lease already exists.
+log "verifying regional quota reconciliation job"
+gc run jobs execute "$JOB_NAME" \
+  --region "$SCHEDULER_REGION" \
+  --wait \
+  --quiet >/dev/null
+log "regional quota reconciler is verified and scheduled once per minute"

--- a/scripts/deploy/regional_quota_reconciler.sh
+++ b/scripts/deploy/regional_quota_reconciler.sh
@@ -90,7 +90,11 @@ common_args=(
 if gc scheduler jobs describe "$SCHEDULER_NAME" \
   --location="$SCHEDULER_REGION" >/dev/null 2>&1; then
   log "updating regional quota reconciler schedule"
-  gc scheduler jobs update http "$SCHEDULER_NAME" "${common_args[@]}" >/dev/null
+  # The legacy HTTP scheduler stored the internal gateway token in a custom
+  # header. Clear every legacy header while moving to Google OAuth so that
+  # secret does not remain in the Scheduler resource after migration.
+  gc scheduler jobs update http "$SCHEDULER_NAME" \
+    "${common_args[@]}" --clear-headers >/dev/null
 else
   log "creating regional quota reconciler schedule"
   gc scheduler jobs create http "$SCHEDULER_NAME" "${common_args[@]}" >/dev/null

--- a/scripts/deploy/regional_quota_reconciler.sh
+++ b/scripts/deploy/regional_quota_reconciler.sh
@@ -9,10 +9,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/_lib.sh"
 
 SCHEDULER_NAME="${TR_REGIONAL_QUOTA_RECONCILER_SCHEDULER:-trusted-router-regional-quota-reconcile}"
-SCHEDULER_REGION="${TR_REGIONAL_QUOTA_RECONCILER_REGION:-${TR_PRIMARY_REGION}}"
+JOB_REGION="${TR_REGIONAL_QUOTA_RECONCILER_JOB_REGION:-${TR_PRIMARY_REGION}}"
+SCHEDULER_REGION="${TR_REGIONAL_QUOTA_RECONCILER_SCHEDULER_REGION:-${JOB_REGION}}"
 SCHEDULE="${TR_REGIONAL_QUOTA_RECONCILER_SCHEDULE:-* * * * *}"
-JOB_NAME="${TR_REGIONAL_QUOTA_RECONCILER_JOB:-trusted-router-regional-quota-reconciler}"
-RECONCILE_LIMIT="${TR_REGIONAL_QUOTA_RECONCILE_LIMIT:-250}"
+RELEASE="$(git rev-parse --short HEAD 2>/dev/null || echo local)"
+JOB_PREFIX="${TR_REGIONAL_QUOTA_RECONCILER_JOB_PREFIX:-trusted-router-regional-quota-reconciler}"
+JOB_NAME="${TR_REGIONAL_QUOTA_RECONCILER_JOB:-${JOB_PREFIX}-${RELEASE}}"
+RECONCILE_LIMIT="${TR_REGIONAL_QUOTA_RECONCILE_LIMIT:-25}"
 
 if ! gc artifacts docker images describe "$IMAGE" >/dev/null 2>&1; then
   log "refusing regional quota reconciler deploy: image ${IMAGE} does not exist"
@@ -21,7 +24,7 @@ fi
 
 env_vars=(
   "TR_ENVIRONMENT=worker"
-  "TR_RELEASE=$(git rev-parse --short HEAD 2>/dev/null || echo local)"
+  "TR_RELEASE=${RELEASE}"
   "TR_STORAGE_BACKEND=spanner-bigtable"
   "TR_GCP_PROJECT_ID=${PROJECT_ID}"
   "TR_SPANNER_INSTANCE_ID=${SPANNER_INSTANCE_ID}"
@@ -31,34 +34,45 @@ env_vars=(
   "TR_REQUEST_RECORD_WRITE_MODE=typed"
   "TR_SETTLE_OUTBOX_ENABLED=true"
   "TR_REGIONAL_QUOTA_LEASES_ENABLED=true"
+  "TR_REGIONAL_QUOTA_RECONCILER_WORKER=true"
   "TR_REGIONAL_QUOTA_BIGTABLE_TABLE=${TR_REGIONAL_QUOTA_BIGTABLE_TABLE:-trustedrouter-regional-quota}"
   "TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES=${TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES}"
   "TR_REGIONAL_QUOTA_RECONCILE_LIMIT=${RECONCILE_LIMIT}"
   "TR_PRIMARY_REGION=${TR_PRIMARY_REGION}"
+  "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true"
 )
 set_env_vars="$(IFS='|'; echo "^|^${env_vars[*]}")"
 
 log "deploying regional quota reconciliation job ${JOB_NAME}"
 gc run jobs deploy "$JOB_NAME" \
-  --region "$SCHEDULER_REGION" \
+  --region "$JOB_REGION" \
   --image "$IMAGE" \
   --command="/app/.venv/bin/python" \
   --args="-m,trusted_router.regional_quota_reconcile_cli" \
   --service-account "$RUN_SERVICE_ACCOUNT" \
   --set-env-vars "$set_env_vars" \
-  --max-retries 1 \
-  --task-timeout 240s \
+  --update-secrets "TR_SENTRY_DSN=trustedrouter-sentry-dsn:latest" \
+  --max-retries 0 \
+  --task-timeout 50s \
   --cpu 1 \
   --memory 512Mi \
   --quiet >/dev/null
 
 gc run jobs add-iam-policy-binding "$JOB_NAME" \
-  --region "$SCHEDULER_REGION" \
+  --region "$JOB_REGION" \
   --member="serviceAccount:${RUN_SERVICE_ACCOUNT}" \
   --role="roles/run.invoker" \
   --quiet >/dev/null
 
-uri="https://${SCHEDULER_REGION}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${PROJECT_ID}/jobs/${JOB_NAME}:run"
+# Verify the versioned job before changing the stable scheduler. A failed
+# deployment therefore leaves the previous known-good job scheduled.
+log "verifying regional quota reconciliation job"
+gc run jobs execute "$JOB_NAME" \
+  --region "$JOB_REGION" \
+  --wait \
+  --quiet >/dev/null
+
+uri="https://${JOB_REGION}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${PROJECT_ID}/jobs/${JOB_NAME}:run"
 common_args=(
   --location="$SCHEDULER_REGION"
   --schedule="$SCHEDULE"
@@ -67,7 +81,7 @@ common_args=(
   --http-method=POST
   --oauth-service-account-email="$RUN_SERVICE_ACCOUNT"
   --attempt-deadline=30s
-  --max-retry-attempts=3
+  --max-retry-attempts=0
   --min-backoff=5s
   --max-backoff=30s
   --quiet
@@ -82,17 +96,30 @@ else
   gc scheduler jobs create http "$SCHEDULER_NAME" "${common_args[@]}" >/dev/null
 fi
 
-# Do not let a previously paused scheduler make an enabled pilot silently
-# accumulate expired escrow. Resume is idempotent.
+# The new version has passed a real Spanner and Bigtable execution, so it is
+# now safe to make it the stable schedule target. Resume is idempotent.
 gc scheduler jobs resume "$SCHEDULER_NAME" \
   --location="$SCHEDULER_REGION" --quiet >/dev/null 2>&1 || true
 
-# A successful no-op execution proves image startup, settings validation,
-# Spanner access, and Bigtable app-profile routing before the deploy turns
-# green. Reconciliation is idempotent if an active pilot lease already exists.
-log "verifying regional quota reconciliation job"
-gc run jobs execute "$JOB_NAME" \
-  --region "$SCHEDULER_REGION" \
-  --wait \
-  --quiet >/dev/null
+# Retain the current and one previous verified version for immediate rollback;
+# stale definitions cost no runtime money but eventually consume the regional
+# Cloud Run Job quota.
+previous_kept=0
+while IFS= read -r old_job; do
+  [[ "$old_job" == "${JOB_PREFIX}-"* ]] || continue
+  [ "$old_job" = "$JOB_NAME" ] && continue
+  if [ "$previous_kept" -eq 0 ]; then
+    previous_kept=1
+    continue
+  fi
+  if ! gc run jobs delete "$old_job" \
+      --region "$JOB_REGION" --quiet >/dev/null; then
+    log "WARN: unable to remove stale regional quota job ${old_job}"
+  fi
+done < <(
+  gc run jobs list \
+    --region "$JOB_REGION" \
+    --sort-by='~metadata.creationTimestamp' \
+    --format='value(metadata.name)'
+)
 log "regional quota reconciler is verified and scheduled once per minute"

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -992,7 +992,15 @@ class Settings(BaseSettings):
         if not 1 <= self.regional_quota_lease_shard_count <= 64:
             raise ValueError("TR_REGIONAL_QUOTA_LEASE_SHARD_COUNT must be between 1 and 64")
         if self.regional_quota_leases_enabled:
-            if not self.regional_quota_lease_pilot_workspace_ids.strip():
+            # Serving processes must always be allowlisted. The one-shot
+            # reconciler worker scans only already-issued global leases and
+            # cannot authorize traffic, so duplicating the serving allowlist
+            # into that job would add configuration drift without narrowing
+            # its authority.
+            if (
+                environment != "worker"
+                and not self.regional_quota_lease_pilot_workspace_ids.strip()
+            ):
                 raise ValueError(
                     "TR_REGIONAL_QUOTA_LEASES_ENABLED requires "
                     "TR_REGIONAL_QUOTA_LEASE_PILOT_WORKSPACE_IDS"

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -645,6 +645,12 @@ class Settings(BaseSettings):
     regional_quota_lease_max_available_basis_points: int = 1_000
     regional_quota_lease_shard_count: int = 16
     regional_quota_bigtable_table: str = "trustedrouter-regional-quota"
+    # True only in the one-shot reconciliation Cloud Run Job. Serving
+    # processes must never set this: it exempts the worker from duplicating the
+    # traffic-issuance allowlist because the worker can only drain leases that
+    # already exist.
+    regional_quota_reconciler_worker: bool = False
+    regional_quota_reconcile_limit: int = 25
     # Comma-separated region=single-cluster-app-profile pairs. A fixed profile
     # is required because one lease has exactly one regional writer authority.
     regional_quota_bigtable_app_profiles: str = ""
@@ -991,6 +997,12 @@ class Settings(BaseSettings):
             )
         if not 1 <= self.regional_quota_lease_shard_count <= 64:
             raise ValueError("TR_REGIONAL_QUOTA_LEASE_SHARD_COUNT must be between 1 and 64")
+        if not 1 <= self.regional_quota_reconcile_limit <= 1_000:
+            raise ValueError("TR_REGIONAL_QUOTA_RECONCILE_LIMIT must be between 1 and 1000")
+        if self.regional_quota_reconciler_worker and environment != "worker":
+            raise ValueError(
+                "TR_REGIONAL_QUOTA_RECONCILER_WORKER is valid only in worker processes"
+            )
         if self.regional_quota_leases_enabled:
             # Serving processes must always be allowlisted. The one-shot
             # reconciler worker scans only already-issued global leases and
@@ -998,7 +1010,7 @@ class Settings(BaseSettings):
             # into that job would add configuration drift without narrowing
             # its authority.
             if (
-                environment != "worker"
+                not self.regional_quota_reconciler_worker
                 and not self.regional_quota_lease_pilot_workspace_ids.strip()
             ):
                 raise ValueError(

--- a/src/trusted_router/regional_quota_ledger.py
+++ b/src/trusted_router/regional_quota_ledger.py
@@ -294,6 +294,30 @@ class BigtableRegionalQuotaLedger:
         state, _version = _state_and_version(row)
         return _deserialize_lease(state)
 
+    def health_check(self) -> tuple[str, ...]:
+        """Prove conditional writes and reads through every fixed profile."""
+
+        for region in sorted(self._tables):
+            table = self._tables[region]
+            row_key = f"health#regional-quota#{region}".encode()
+            version = uuid.uuid4().hex.encode("ascii")
+            row = table.row(row_key, filter_=self._version_exists_filter())
+            for state in (False, True):
+                row.set_cell(_FAMILY, _STATE_COLUMN, b'{"status":"ok"}', state=state)
+                row.set_cell(_FAMILY, _VERSION_COLUMN, version, state=state)
+            try:
+                row.commit()
+                durable = table.read_row(row_key, filter_=self._state_filter())
+            except Exception as exc:  # pragma: no cover - remote transport
+                raise RegionalLeaseLedgerError(
+                    "regional ledger transactional health check failed"
+                ) from exc
+            if durable is None:
+                raise RegionalLeaseLedgerError(
+                    "regional ledger health check write was not durable"
+                )
+        return tuple(sorted(self._tables))
+
     def reserve(
         self,
         lease_id: str,

--- a/src/trusted_router/regional_quota_reconcile_cli.py
+++ b/src/trusted_router/regional_quota_reconcile_cli.py
@@ -1,0 +1,52 @@
+"""One-shot regional quota lease reconciler for Cloud Run Jobs."""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable
+from typing import Any, cast
+
+from trusted_router.config import get_settings
+from trusted_router.storage import create_store
+
+logger = logging.getLogger(__name__)
+
+
+def _reconcile_limit() -> int:
+    raw = os.environ.get("TR_REGIONAL_QUOTA_RECONCILE_LIMIT", "250")
+    try:
+        return max(1, min(int(raw), 1_000))
+    except ValueError as exc:
+        raise ValueError("TR_REGIONAL_QUOTA_RECONCILE_LIMIT must be an integer") from exc
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO)
+    settings = get_settings()
+    if not settings.regional_quota_leases_enabled:
+        logger.info("regional_quota.reconciler_disabled")
+        return 0
+
+    store = create_store(settings)
+    reconcile = cast(
+        Callable[..., dict[str, int]] | None,
+        getattr(store, "reconcile_regional_quota_leases", None),
+    )
+    if reconcile is None:
+        logger.error("regional_quota.reconciler_store_unsupported")
+        return 1
+
+    result: dict[str, Any] = reconcile(limit=_reconcile_limit())
+    logger.info(
+        "regional_quota.reconcile_complete inspected=%d reconciled=%d closed=%d errors=%d",
+        int(result.get("inspected", 0)),
+        int(result.get("reconciled", 0)),
+        int(result.get("closed", 0)),
+        int(result.get("errors", 0)),
+    )
+    return 1 if int(result.get("errors", 0)) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trusted_router/regional_quota_reconcile_cli.py
+++ b/src/trusted_router/regional_quota_reconcile_cli.py
@@ -3,32 +3,42 @@
 from __future__ import annotations
 
 import logging
-import os
 from collections.abc import Callable
 from typing import Any, cast
 
 from trusted_router.config import get_settings
-from trusted_router.storage import create_store
+from trusted_router.sentry_config import init_sentry
+from trusted_router.storage import configure_store, create_store
+from trusted_router.synthetic.fleet import record_heartbeat
 
 logger = logging.getLogger(__name__)
-
-
-def _reconcile_limit() -> int:
-    raw = os.environ.get("TR_REGIONAL_QUOTA_RECONCILE_LIMIT", "250")
-    try:
-        return max(1, min(int(raw), 1_000))
-    except ValueError as exc:
-        raise ValueError("TR_REGIONAL_QUOTA_RECONCILE_LIMIT must be an integer") from exc
 
 
 def main() -> int:
     logging.basicConfig(level=logging.INFO)
     settings = get_settings()
-    if not settings.regional_quota_leases_enabled:
+    init_sentry(settings)
+    if not settings.regional_quota_reconciler_worker:
         logger.info("regional_quota.reconciler_disabled")
         return 0
+    if not settings.regional_quota_leases_enabled:
+        logger.error("regional_quota.reconciler_ledger_disabled")
+        return 1
 
     store = create_store(settings)
+    configure_store(store)
+    verify = cast(
+        Callable[[], tuple[str, ...]] | None,
+        getattr(store, "verify_regional_quota_ledger", None),
+    )
+    if verify is None:
+        logger.error("regional_quota.reconciler_health_check_unsupported")
+        return 1
+    verified_regions = verify()
+    if not verified_regions:
+        logger.error("regional_quota.reconciler_has_no_regions")
+        return 1
+
     reconcile = cast(
         Callable[..., dict[str, int]] | None,
         getattr(store, "reconcile_regional_quota_leases", None),
@@ -37,7 +47,7 @@ def main() -> int:
         logger.error("regional_quota.reconciler_store_unsupported")
         return 1
 
-    result: dict[str, Any] = reconcile(limit=_reconcile_limit())
+    result: dict[str, Any] = reconcile(limit=settings.regional_quota_reconcile_limit)
     logger.info(
         "regional_quota.reconcile_complete inspected=%d reconciled=%d closed=%d errors=%d",
         int(result.get("inspected", 0)),
@@ -45,7 +55,10 @@ def main() -> int:
         int(result.get("closed", 0)),
         int(result.get("errors", 0)),
     )
-    return 1 if int(result.get("errors", 0)) else 0
+    if int(result.get("errors", 0)):
+        return 1
+    record_heartbeat("job:regional-quota-reconcile", settings=settings)
+    return 0
 
 
 if __name__ == "__main__":

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -3015,24 +3015,30 @@ class SpannerBigtableStore:
         from trusted_router.services.regional_quota_leases import HoldState
         from trusted_router.storage_gcp_regional_quota import (
             GlobalRegionalQuotaLease,
+            OpenRegionalQuotaLease,
             reconcile_regional_quota_lease,
         )
 
         now = dt.datetime.now(dt.UTC) if now is None else now
-        records = [
-            record
-            for record in self._list_entities(
-                "regional_quota_lease",
-                cls=GlobalRegionalQuotaLease,
-            )
-            if record.state != "closed"
-        ]
-        records.sort(key=lambda record: (record.expires_datetime, record.lease_id))
-        records = records[: max(1, min(limit, 1000))]
+        bounded_limit = max(1, min(limit, 1000))
+        open_leases = self._list_entities(
+            "regional_quota_lease_open",
+            cls=OpenRegionalQuotaLease,
+            limit=bounded_limit,
+        )
         result = {"inspected": 0, "reconciled": 0, "closed": 0, "errors": 0}
-        for record in records:
+        for open_lease in open_leases:
             result["inspected"] += 1
             try:
+                record = self._read_entity(
+                    "regional_quota_lease",
+                    open_lease.lease_entity_id,
+                    GlobalRegionalQuotaLease,
+                )
+                if record is None:
+                    raise RuntimeError("indexed global regional lease is missing")
+                if record.state == "closed":
+                    raise RuntimeError("closed regional lease retained an open index")
                 local = ledger.get(record.lease_id, region=record.region)
                 if local is None:
                     raise RuntimeError("regional lease row is missing")
@@ -3083,11 +3089,19 @@ class SpannerBigtableStore:
                 result["errors"] += 1
                 log.error(
                     "regional quota reconciliation failed lease_id=%s workspace_id=%s",
-                    record.lease_id,
-                    record.workspace_id,
+                    open_lease.lease_id,
+                    open_lease.workspace_id,
                     exc_info=True,
                 )
         return result
+
+    def verify_regional_quota_ledger(self) -> tuple[str, ...]:
+        """Prove conditional writes and reads through every fixed app profile."""
+
+        ledger = self._regional_quota_ledger
+        if ledger is None:
+            raise RuntimeError("regional quota ledger is disabled")
+        return ledger.health_check()
 
     def authorize_gateway_typed(
         self,

--- a/src/trusted_router/storage_gcp_regional_quota.py
+++ b/src/trusted_router/storage_gcp_regional_quota.py
@@ -20,6 +20,8 @@ from trusted_router.services.regional_quota_leases import (
 from trusted_router.spend_windows import utcnow, window_floors
 from trusted_router.storage_gcp_codec import json_body
 from trusted_router.storage_gcp_counter_dml import (
+    delete_entity_dml,
+    insert_entity_dml_at,
     insert_reservation,
     key_limit_exists,
     read_reservation_by_idempotency,
@@ -34,6 +36,7 @@ from trusted_router.storage_models import GatewayAuthorization
 log = logging.getLogger(__name__)
 
 _LEASE_KIND = "regional_quota_lease"
+_OPEN_LEASE_KIND = "regional_quota_lease_open"
 _FENCE_KIND = "regional_quota_fence"
 
 
@@ -71,6 +74,19 @@ class RegionalQuotaFence:
     quota_shard: int = 0
     active_lease_id: str | None = None
     updated_at: str = field(default_factory=lambda: _iso(utcnow()))
+
+
+@dataclass(frozen=True)
+class OpenRegionalQuotaLease:
+    lease_entity_id: str
+    workspace_id: str
+    region: str
+    lease_id: str
+    expires_at: str
+
+    @property
+    def entity_id(self) -> str:
+        return _open_lease_entity_id(self)
 
 
 @dataclass(frozen=True)
@@ -190,6 +206,24 @@ def grant_regional_quota_lease(
             entity_id,
             lease,
         )
+        open_lease = OpenRegionalQuotaLease(
+            lease_entity_id=entity_id,
+            workspace_id=workspace_id,
+            region=region,
+            lease_id=lease_id,
+            expires_at=_iso(expires_at),
+        )
+        # Use a client timestamp for this third tr_entities DML statement;
+        # Spanner permits only one pending commit timestamp write per table in
+        # a transaction.
+        insert_entity_dml_at(
+            transaction,
+            store._param_types,
+            _OPEN_LEASE_KIND,
+            open_lease.entity_id,
+            json_body(open_lease),
+            now,
+        )
         return lease
 
     return store._run_in_transaction(txn)
@@ -306,6 +340,12 @@ def reconcile_regional_quota_lease(
             raise RuntimeError("global regional lease is missing")
         _validate_same_global_lease(global_lease, current)
         if current.state == "closed":
+            delete_entity_dml(
+                transaction,
+                store._param_types,
+                _OPEN_LEASE_KIND,
+                _open_lease_entity_id(current),
+            )
             return RegionalReconcileResult(
                 lease_id=current.lease_id,
                 spent_delta_microdollars=0,
@@ -403,6 +443,12 @@ def reconcile_regional_quota_lease(
                     active_lease_id=None,
                     updated_at=_iso(now),
                 ),
+            )
+            delete_entity_dml(
+                transaction,
+                store._param_types,
+                _OPEN_LEASE_KIND,
+                _open_lease_entity_id(current),
             )
         updated = dataclasses.replace(
             current,
@@ -665,6 +711,10 @@ def _lease_entity_id(workspace_id: str, region: str, lease_id: str) -> str:
 
 def _fence_entity_id(workspace_id: str, region: str, quota_shard: int) -> str:
     return f"{workspace_id}#{region}#{quota_shard}"
+
+
+def _open_lease_entity_id(lease: GlobalRegionalQuotaLease | OpenRegionalQuotaLease) -> str:
+    return f"{lease.expires_at}#{lease.workspace_id}#{lease.region}#{lease.lease_id}"
 
 
 def _key_total_id(key_hash: str, shard: int) -> str:

--- a/src/trusted_router/synthetic/fleet.py
+++ b/src/trusted_router/synthetic/fleet.py
@@ -65,6 +65,7 @@ HEARTBEAT_STALE_SECONDS = 11 * 60
 BUILTIN_HEARTBEAT_TARGETS = frozenset(
     {
         "job:settle-outbox-drain",
+        "job:regional-quota-reconcile",
         "scheduler:home-settlement",
         "scheduler:remediator",
         "scheduler:synthetic",

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -168,6 +168,7 @@ def test_production_deploy_provisions_and_schedules_regional_quota_reconciliatio
     assert 'SCHEDULE="${TR_REGIONAL_QUOTA_RECONCILER_SCHEDULE:-* * * * *}"' in reconciler
     assert "trusted_router.regional_quota_reconcile_cli" in reconciler
     assert "--oauth-service-account-email=\"$RUN_SERVICE_ACCOUNT\"" in reconciler
+    assert "--clear-headers" in reconciler
     assert "gc secrets" not in reconciler
     assert "trustedrouter-internal-gateway-token" not in reconciler
     assert "gc run jobs execute" in reconciler

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -168,9 +168,15 @@ def test_production_deploy_provisions_and_schedules_regional_quota_reconciliatio
     assert 'SCHEDULE="${TR_REGIONAL_QUOTA_RECONCILER_SCHEDULE:-* * * * *}"' in reconciler
     assert "trusted_router.regional_quota_reconcile_cli" in reconciler
     assert "--oauth-service-account-email=\"$RUN_SERVICE_ACCOUNT\"" in reconciler
-    assert "gcloud.secrets" not in reconciler
-    assert "internal_gateway_token" not in reconciler
+    assert "gc secrets" not in reconciler
+    assert "trustedrouter-internal-gateway-token" not in reconciler
     assert "gc run jobs execute" in reconciler
+    assert reconciler.index("gc run jobs execute") < reconciler.index("gc scheduler jobs update")
+    assert reconciler.index("gc run jobs execute") < reconciler.index("gc scheduler jobs create")
+    assert "--max-retries 0" in reconciler
+    assert "--task-timeout 50s" in reconciler
+    assert "--max-retry-attempts=0" in reconciler
+    assert "gc run jobs delete" in reconciler
 
 
 def test_deploy_preserves_request_record_mode_without_silent_legacy_fallback() -> None:

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -166,9 +166,11 @@ def test_production_deploy_provisions_and_schedules_regional_quota_reconciliatio
     assert "us-central1=tr-quota-us-central1" in library
     assert "europe-west4=tr-quota-europe-west4" not in library
     assert 'SCHEDULE="${TR_REGIONAL_QUOTA_RECONCILER_SCHEDULE:-* * * * *}"' in reconciler
-    assert "/v1/internal/gateway/regional-quota/reconcile?limit=250" in reconciler
-    assert "x-trustedrouter-internal-token=${internal_token}" in reconciler
-    assert "echo \"$internal_token\"" not in reconciler
+    assert "trusted_router.regional_quota_reconcile_cli" in reconciler
+    assert "--oauth-service-account-email=\"$RUN_SERVICE_ACCOUNT\"" in reconciler
+    assert "gcloud.secrets" not in reconciler
+    assert "internal_gateway_token" not in reconciler
+    assert "gc run jobs execute" in reconciler
 
 
 def test_deploy_preserves_request_record_mode_without_silent_legacy_fallback() -> None:

--- a/tests/test_regional_quota_ledger.py
+++ b/tests/test_regional_quota_ledger.py
@@ -119,6 +119,23 @@ def test_bigtable_ledger_fails_closed_without_authoritative_region_profile() -> 
         ledger.get("rql-test", region="europe-west4")
 
 
+def test_bigtable_health_check_proves_conditional_write_and_read() -> None:
+    table = _FakeBigtableTable()
+    ledger = BigtableRegionalQuotaLedger({"us-central1": table})
+
+    assert ledger.health_check() == ("us-central1",)
+    assert b"health#regional-quota#us-central1" in table.rows
+
+
+def test_bigtable_health_check_fails_when_transactional_writes_fail() -> None:
+    table = _FakeBigtableTable()
+    table.reject_conditional_commits = True
+    ledger = BigtableRegionalQuotaLedger({"us-central1": table})
+
+    with pytest.raises(RegionalLeaseLedgerError, match="transactional health check"):
+        ledger.health_check()
+
+
 @dataclass
 class _Cell:
     value: bytes
@@ -147,6 +164,8 @@ class _FakeConditionalRow:
         self.mutations.append((state, column, value))
 
     def commit(self) -> bool:
+        if self.table.reject_conditional_commits:
+            raise RuntimeError("transactional writes disabled")
         current = self.table.rows.get(self.row_key)
         regex_filter = next(
             (
@@ -183,6 +202,7 @@ class _FakeBigtableTable:
     def __init__(self) -> None:
         self.rows: dict[bytes, dict[bytes, bytes]] = {}
         self.raise_after_next_applied_commit = False
+        self.reject_conditional_commits = False
 
     def row(self, row_key: bytes, *, filter_: Any) -> _FakeConditionalRow:
         return _FakeConditionalRow(self, row_key, filter_)

--- a/tests/test_regional_quota_reconcile_cli.py
+++ b/tests/test_regional_quota_reconcile_cli.py
@@ -7,6 +7,12 @@ import pytest
 from trusted_router import regional_quota_reconcile_cli as worker
 
 
+@pytest.fixture(autouse=True)
+def _isolate_observability(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(worker, "init_sentry", lambda _settings: None)
+    monkeypatch.setattr(worker, "record_heartbeat", lambda *_args, **_kwargs: None)
+
+
 class _Store:
     def __init__(self, result: dict[str, int]) -> None:
         self.result = result
@@ -16,12 +22,15 @@ class _Store:
         self.limits.append(limit)
         return self.result
 
+    def verify_regional_quota_ledger(self) -> tuple[str, ...]:
+        return ("us-central1",)
+
 
 def test_disabled_worker_does_not_open_storage(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         worker,
         "get_settings",
-        lambda: SimpleNamespace(regional_quota_leases_enabled=False),
+        lambda: SimpleNamespace(regional_quota_reconciler_worker=False),
     )
     monkeypatch.setattr(
         worker,
@@ -37,13 +46,22 @@ def test_worker_reconciles_with_bounded_limit(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(
         worker,
         "get_settings",
-        lambda: SimpleNamespace(regional_quota_leases_enabled=True),
+        lambda: SimpleNamespace(
+            regional_quota_reconciler_worker=True,
+            regional_quota_leases_enabled=True,
+            regional_quota_reconcile_limit=1_000,
+        ),
     )
+    heartbeats: list[str] = []
     monkeypatch.setattr(worker, "create_store", lambda _settings: store)
-    monkeypatch.setenv("TR_REGIONAL_QUOTA_RECONCILE_LIMIT", "5000")
-
+    monkeypatch.setattr(
+        worker,
+        "record_heartbeat",
+        lambda name, **_kwargs: heartbeats.append(name),
+    )
     assert worker.main() == 0
     assert store.limits == [1000]
+    assert heartbeats == ["job:regional-quota-reconcile"]
 
 
 def test_worker_fails_execution_when_any_lease_fails(
@@ -53,25 +71,15 @@ def test_worker_fails_execution_when_any_lease_fails(
     monkeypatch.setattr(
         worker,
         "get_settings",
-        lambda: SimpleNamespace(regional_quota_leases_enabled=True),
+        lambda: SimpleNamespace(
+            regional_quota_reconciler_worker=True,
+            regional_quota_leases_enabled=True,
+            regional_quota_reconcile_limit=25,
+        ),
     )
     monkeypatch.setattr(worker, "create_store", lambda _settings: store)
 
     assert worker.main() == 1
-
-
-def test_worker_rejects_non_integer_limit(monkeypatch: pytest.MonkeyPatch) -> None:
-    store = _Store({"inspected": 0, "reconciled": 0, "closed": 0, "errors": 0})
-    monkeypatch.setattr(
-        worker,
-        "get_settings",
-        lambda: SimpleNamespace(regional_quota_leases_enabled=True),
-    )
-    monkeypatch.setattr(worker, "create_store", lambda _settings: store)
-    monkeypatch.setenv("TR_REGIONAL_QUOTA_RECONCILE_LIMIT", "many")
-
-    with pytest.raises(ValueError, match="must be an integer"):
-        worker.main()
 
 
 def test_worker_fails_closed_without_reconcile_capability(
@@ -80,9 +88,43 @@ def test_worker_fails_closed_without_reconcile_capability(
     monkeypatch.setattr(
         worker,
         "get_settings",
-        lambda: SimpleNamespace(regional_quota_leases_enabled=True),
+        lambda: SimpleNamespace(
+            regional_quota_reconciler_worker=True,
+            regional_quota_leases_enabled=True,
+            regional_quota_reconcile_limit=25,
+        ),
     )
-    monkeypatch.setattr(worker, "create_store", lambda _settings: SimpleNamespace())
+    monkeypatch.setattr(
+        worker,
+        "create_store",
+        lambda _settings: SimpleNamespace(
+            verify_regional_quota_ledger=lambda: ("us-central1",),
+        ),
+    )
+
+    assert worker.main() == 1
+
+
+def test_worker_fails_closed_when_no_ledger_region_is_verified(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        worker,
+        "get_settings",
+        lambda: SimpleNamespace(
+            regional_quota_reconciler_worker=True,
+            regional_quota_leases_enabled=True,
+            regional_quota_reconcile_limit=25,
+        ),
+    )
+    monkeypatch.setattr(
+        worker,
+        "create_store",
+        lambda _settings: SimpleNamespace(
+            verify_regional_quota_ledger=lambda: (),
+            reconcile_regional_quota_leases=lambda **_kwargs: {},
+        ),
+    )
 
     assert worker.main() == 1
 
@@ -100,7 +142,28 @@ def test_worker_environment_does_not_require_serving_pilot_allowlist() -> None:
         request_record_write_mode="typed",
         settle_outbox_enabled=True,
         regional_quota_leases_enabled=True,
+        regional_quota_reconciler_worker=True,
         regional_quota_bigtable_app_profiles="us-central1=quota-us",
     )
 
     assert settings.regional_quota_lease_pilot_workspaces == frozenset()
+
+
+def test_generic_worker_still_requires_serving_pilot_allowlist() -> None:
+    from pydantic import ValidationError
+
+    from trusted_router.config import Settings
+
+    with pytest.raises(ValidationError, match="PILOT_WORKSPACE_IDS"):
+        Settings(
+            environment="worker",
+            storage_backend="spanner-bigtable",
+            gcp_project_id="project",
+            spanner_instance_id="instance",
+            spanner_database_id="database",
+            bigtable_instance_id="bigtable",
+            request_record_write_mode="typed",
+            settle_outbox_enabled=True,
+            regional_quota_leases_enabled=True,
+            regional_quota_bigtable_app_profiles="us-central1=quota-us",
+        )

--- a/tests/test_regional_quota_reconcile_cli.py
+++ b/tests/test_regional_quota_reconcile_cli.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from trusted_router import regional_quota_reconcile_cli as worker
+
+
+class _Store:
+    def __init__(self, result: dict[str, int]) -> None:
+        self.result = result
+        self.limits: list[int] = []
+
+    def reconcile_regional_quota_leases(self, *, limit: int) -> dict[str, int]:
+        self.limits.append(limit)
+        return self.result
+
+
+def test_disabled_worker_does_not_open_storage(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        worker,
+        "get_settings",
+        lambda: SimpleNamespace(regional_quota_leases_enabled=False),
+    )
+    monkeypatch.setattr(
+        worker,
+        "create_store",
+        lambda _settings: pytest.fail("disabled worker opened storage"),
+    )
+
+    assert worker.main() == 0
+
+
+def test_worker_reconciles_with_bounded_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = _Store({"inspected": 2, "reconciled": 2, "closed": 1, "errors": 0})
+    monkeypatch.setattr(
+        worker,
+        "get_settings",
+        lambda: SimpleNamespace(regional_quota_leases_enabled=True),
+    )
+    monkeypatch.setattr(worker, "create_store", lambda _settings: store)
+    monkeypatch.setenv("TR_REGIONAL_QUOTA_RECONCILE_LIMIT", "5000")
+
+    assert worker.main() == 0
+    assert store.limits == [1000]
+
+
+def test_worker_fails_execution_when_any_lease_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _Store({"inspected": 1, "reconciled": 0, "closed": 0, "errors": 1})
+    monkeypatch.setattr(
+        worker,
+        "get_settings",
+        lambda: SimpleNamespace(regional_quota_leases_enabled=True),
+    )
+    monkeypatch.setattr(worker, "create_store", lambda _settings: store)
+
+    assert worker.main() == 1
+
+
+def test_worker_rejects_non_integer_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = _Store({"inspected": 0, "reconciled": 0, "closed": 0, "errors": 0})
+    monkeypatch.setattr(
+        worker,
+        "get_settings",
+        lambda: SimpleNamespace(regional_quota_leases_enabled=True),
+    )
+    monkeypatch.setattr(worker, "create_store", lambda _settings: store)
+    monkeypatch.setenv("TR_REGIONAL_QUOTA_RECONCILE_LIMIT", "many")
+
+    with pytest.raises(ValueError, match="must be an integer"):
+        worker.main()
+
+
+def test_worker_fails_closed_without_reconcile_capability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        worker,
+        "get_settings",
+        lambda: SimpleNamespace(regional_quota_leases_enabled=True),
+    )
+    monkeypatch.setattr(worker, "create_store", lambda _settings: SimpleNamespace())
+
+    assert worker.main() == 1
+
+
+def test_worker_environment_does_not_require_serving_pilot_allowlist() -> None:
+    from trusted_router.config import Settings
+
+    settings = Settings(
+        environment="worker",
+        storage_backend="spanner-bigtable",
+        gcp_project_id="project",
+        spanner_instance_id="instance",
+        spanner_database_id="database",
+        bigtable_instance_id="bigtable",
+        request_record_write_mode="typed",
+        settle_outbox_enabled=True,
+        regional_quota_leases_enabled=True,
+        regional_quota_bigtable_app_profiles="us-central1=quota-us",
+    )
+
+    assert settings.regional_quota_lease_pilot_workspaces == frozenset()

--- a/tests/test_regional_quota_spanner.py
+++ b/tests/test_regional_quota_spanner.py
@@ -12,6 +12,7 @@ from trusted_router.storage_gcp_authorize import settle_atomic
 from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
 from trusted_router.storage_gcp_regional_quota import (
     GlobalRegionalQuotaLease,
+    OpenRegionalQuotaLease,
     activate_regional_quota_lease,
     grant_regional_quota_lease,
     reconcile_regional_quota_lease,
@@ -62,6 +63,11 @@ def test_global_grant_and_reconcile_preserve_exact_credit_and_key_totals() -> No
     )
     assert global_lease is not None
     assert global_lease.granted_microdollars == 6_250_000
+    open_leases = store._list_entities(
+        "regional_quota_lease_open",
+        cls=OpenRegionalQuotaLease,
+    )
+    assert [open_lease.lease_id for open_lease in open_leases] == [global_lease.lease_id]
     assert _credit_totals(database, workspace.id) == (
         100_000_000,
         0,
@@ -111,6 +117,13 @@ def test_global_grant_and_reconcile_preserve_exact_credit_and_key_totals() -> No
         0,
     )
     assert database.typed[KEY_LIMIT_TABLE][(key.hash, 7)]["usage"] == 3_250
+    assert (
+        store._list_entities(
+            "regional_quota_lease_open",
+            cls=OpenRegionalQuotaLease,
+        )
+        == []
+    )
 
     replay = reconcile_regional_quota_lease(
         store,


### PR DESCRIPTION
## Summary
- replace the Scheduler call carrying the internal gateway secret with a one-shot Cloud Run Job authenticated by Google OAuth
- fail the deployment unless a live reconciliation execution can reach Spanner and the regional Bigtable ledger
- keep serving-process workspace allowlisting strict while allowing the non-serving worker to scan already-issued leases

## Verification
- 138 focused regional quota, security, and configuration tests pass
- mypy clean across 291 source files
- ruff, shell syntax, and diff checks pass

## Production issue
The first regional-quota deployment failed only because the deploy service account correctly lacked Secret Manager access. This fixes the deployment without broadening that identity.