### PR TITLE
Gate regional quota leases by configured region

### DIFF
--- a/src/trusted_router/regional_quota_ledger.py
+++ b/src/trusted_router/regional_quota_ledger.py
@@ -43,6 +43,8 @@ class RegionalLeaseNotFound(RegionalLeaseLedgerError):
 
 
 class RegionalQuotaLedger(Protocol):
+    def supports_region(self, region: str) -> bool: ...
+
     def initialize(self, lease: RegionalQuotaLease) -> RegionalQuotaLease: ...
 
     def get(self, lease_id: str, *, region: str) -> RegionalQuotaLease | None: ...
@@ -104,6 +106,9 @@ class InMemoryRegionalQuotaLedger:
     def __init__(self) -> None:
         self._lock = threading.RLock()
         self._leases: dict[tuple[str, str], RegionalQuotaLease] = {}
+
+    def supports_region(self, region: str) -> bool:
+        return bool(region)
 
     def initialize(self, lease: RegionalQuotaLease) -> RegionalQuotaLease:
         key = (lease.region, lease.lease_id)
@@ -257,6 +262,9 @@ class BigtableRegionalQuotaLedger:
         self._family_filter = FamilyNameRegexFilter
         self._chain_filter = RowFilterChain
         self._value_filter = ValueRegexFilter
+
+    def supports_region(self, region: str) -> bool:
+        return region in self._tables
 
     def initialize(self, lease: RegionalQuotaLease) -> RegionalQuotaLease:
         table = self._table(lease.region)

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -2752,7 +2752,10 @@ class SpannerBigtableStore:
         """Authorize from bounded regional escrow without touching hot counters."""
 
         ledger = self._regional_quota_ledger
-        if ledger is None:
+        # Do not reserve global Spanner escrow for a region that has no fixed
+        # transactional Bigtable app profile. Unsupported regions remain on
+        # the exact Spanner path without creating a lease to quarantine later.
+        if ledger is None or not ledger.supports_region(region):
             return "unavailable", None
         from trusted_router.regional_quota_ledger import (
             RegionalLeaseLedgerError,

--- a/tests/test_regional_quota_ledger.py
+++ b/tests/test_regional_quota_ledger.py
@@ -115,6 +115,8 @@ def test_bigtable_round_trip_preserves_key_shard_expiry_and_settlement() -> None
 
 def test_bigtable_ledger_fails_closed_without_authoritative_region_profile() -> None:
     ledger = BigtableRegionalQuotaLedger({"us-central1": _FakeBigtableTable()})
+    assert ledger.supports_region("us-central1") is True
+    assert ledger.supports_region("europe-west4") is False
     with pytest.raises(RegionalLeaseLedgerError, match="no fixed Bigtable app profile"):
         ledger.get("rql-test", region="europe-west4")
 

--- a/tests/test_regional_quota_spanner.py
+++ b/tests/test_regional_quota_spanner.py
@@ -360,6 +360,56 @@ def test_store_regional_authorize_settle_replay_and_reconcile_end_to_end() -> No
     )
 
 
+def test_regional_authorize_does_not_escrow_for_unconfigured_region() -> None:
+    store, database, _ = make_fake_store(request_record_write_mode="typed")
+
+    class UsCentralOnlyLedger(InMemoryRegionalQuotaLedger):
+        def supports_region(self, region: str) -> bool:
+            return region == "us-central1"
+
+    store._regional_quota_ledger = UsCentralOnlyLedger()
+    workspace = store.create_workspace(
+        "owner",
+        "regional-unsupported-region",
+        trial_credit_microdollars=100_000_000,
+    )
+    _raw, key = store.create_api_key(
+        workspace_id=workspace.id,
+        name="uncapped",
+        creator_user_id="owner",
+    )
+    before = _credit_totals(database, workspace.id)
+
+    outcome, authorization = store.authorize_gateway_regional(
+        authorization_id="gwa-eu-exact-fallback",
+        workspace_id=workspace.id,
+        key_hash=key.hash,
+        key_usage_shards=key.usage_shard_count,
+        estimate=10_000,
+        model_id="model",
+        provider="provider",
+        requested_model_id="model",
+        candidate_model_ids=["model"],
+        region="europe-west4",
+        endpoint_id="provider/model",
+        candidate_endpoint_ids=["provider/model"],
+        idempotency_key="unsupported-region",
+        idempotency_fingerprint="c" * 64,
+        tags={},
+        expires_at=NOW + timedelta(hours=2),
+        lease_ttl_seconds=60,
+        lease_max_microdollars=10_000_000,
+        lease_max_available_basis_points=1_000,
+        lease_shard_count=16,
+    )
+
+    assert outcome == "unavailable"
+    assert authorization is None
+    assert store._list_entities("regional_quota_lease", cls=dict) == []
+    assert store._list_entities("regional_quota_lease_open", cls=dict) == []
+    assert _credit_totals(database, workspace.id) == before
+
+
 def test_regional_pool_spreads_hot_workspace_across_bounded_lease_shards() -> None:
     store, database, _ = make_fake_store(request_record_write_mode="typed")
     store._regional_quota_ledger = InMemoryRegionalQuotaLedger()


### PR DESCRIPTION
## Summary

- reject the regional lease path before any global escrow is granted when the serving region lacks a fixed transactional Bigtable app profile
- preserve exact Spanner authorization as the fallback in every unconfigured region
- add regression coverage proving no lease, open-index row, or balance reservation is created

## Verification

- 35 focused regional quota and gateway tests pass
- ruff passes
- mypy passes across 291 source files

Regional leases remain disabled in production until this follow-up and the reconciler rollout are verified.