### PR TITLE
Enforce exact edge and runtime IAM contracts (stack 3/4)

### DIFF
--- a/scripts/deploy/_edge_security.sh
+++ b/scripts/deploy/_edge_security.sh
@@ -3,98 +3,357 @@
 # Application Load Balancer backends. This file defines functions only; the
 # caller owns authentication, PROJECT_ID, gc(), and log().
 
-_edge_require_positive_integer() {
-  local name="$1"
-  local value="$2"
-  case "$value" in
-    ''|*[!0-9]*|0)
-      echo "ERROR: ${name} must be a positive integer; got ${value:-<empty>}" >&2
-      return 2
-      ;;
-  esac
+_TR_EDGE_ALLOWED_HOST_REGEX="^(trustedrouter[.]com|www[.]trustedrouter[.]com|status[.]trustedrouter[.]com|trust[.]trustedrouter[.]com|eu[.]trustedrouter[.]com|status-us[.]trustedrouter[.]com|status-eu[.]trustedrouter[.]com|allyrouter[.]com|www[.]allyrouter[.]com|status[.]allyrouter[.]com|trust[.]allyrouter[.]com|uptimerouter[.]com|www[.]uptimerouter[.]com|status[.]uptimerouter[.]com|trust[.]uptimerouter[.]com)(:[0-9]+)?$"
+
+# Pure, read-only postcondition verifier shared by reconciliation, staging, and
+# promotion/rollback.  Passing JSON as an argument keeps the function usable by
+# callers that already captured a provider response without making another
+# cloud request.
+verify_cloud_armor_policy_contract_json() {
+  [ "$#" -eq 1 ] || {
+    echo "ERROR: verify_cloud_armor_policy_contract_json expects POLICY_JSON" >&2
+    return 2
+  }
+  python3 - "$_TR_EDGE_ALLOWED_HOST_REGEX" "$1" <<'PY'
+import json
+import sys
+
+allowed, raw = sys.argv[1:]
+try:
+    data = json.loads(raw)
+except json.JSONDecodeError:
+    raise SystemExit("Cloud Armor policy response is not valid JSON") from None
+if not isinstance(data, dict):
+    raise SystemExit("Cloud Armor policy response is malformed")
+if data.get("type") != "CLOUD_ARMOR":
+    raise SystemExit("Cloud Armor policy type drifted")
+if data.get("description") != (
+    "TrustedRouter exact edge controls; host and all-path gates enforced, "
+    "route-shape rules previewed"
+):
+    raise SystemExit("Cloud Armor policy description drifted")
+for field in ("recaptchaOptionsConfig", "userIpRequestHeaders"):
+    if data.get(field) not in (None, {}, []):
+        raise SystemExit(f"Cloud Armor policy retains forbidden {field}")
+
+raw_rules = data.get("rules")
+if not isinstance(raw_rules, list) or any(not isinstance(item, dict) for item in raw_rules):
+    raise SystemExit("Cloud Armor rule inventory is malformed")
+try:
+    rules = {int(item.get("priority")): item for item in raw_rules}
+except (TypeError, ValueError):
+    raise SystemExit("Cloud Armor rule priority is malformed") from None
+host_expression = (
+    "!has(request.headers['host']) || "
+    f"!request.headers['host'].lower().matches('{allowed}')"
+)
+expected = {
+    900: (
+        "deny(403)", False, host_expression, None, None,
+        "Reject hosts outside canonical and marketing aliases",
+    ),
+    1000: (
+        "throttle", True, "request.path.startsWith('/chat-proxy/')", 120, None,
+        "Browser inference proxy per-client throttle",
+    ),
+    1100: (
+        "throttle",
+        True,
+        "request.method != 'GET' && request.method != 'HEAD' && request.method != 'OPTIONS'",
+        300,
+        None,
+        "State-changing request per-client throttle",
+    ),
+    1200: (
+        "throttle", False, None, 2400, ["*"],
+        "All-path per-source safety ceiling",
+    ),
+    2147483647: (
+        "allow", False, None, None, ["*"],
+        "Default allow; bounded route classes are evaluated first",
+    ),
+}
+if set(rules) != set(expected) or len(raw_rules) != len(expected):
+    raise SystemExit("unexpected Cloud Armor priority set")
+allowed_rule_fields = {
+    "action",
+    "description",
+    "kind",
+    "match",
+    "preview",
+    "priority",
+    "rateLimitOptions",
+}
+for priority, (action, preview, expression, count, ranges, description) in expected.items():
+    rule = rules[priority]
+    if set(rule) - allowed_rule_fields:
+        raise SystemExit(f"rule {priority} retains forbidden fields")
+    if rule.get("action") != action or rule.get("preview") is not preview:
+        raise SystemExit(f"rule {priority} action/preview differs")
+    if rule.get("description") != description:
+        raise SystemExit(f"rule {priority} description differs")
+    match = rule.get("match") or {}
+    if not isinstance(match, dict):
+        raise SystemExit(f"rule {priority} match is malformed")
+    if expression is not None:
+        if set(match) != {"expr"}:
+            raise SystemExit(f"rule {priority} retains match extras")
+        expr = match.get("expr") or {}
+        if not isinstance(expr, dict) or set(expr) != {"expression"} or expr.get("expression") != expression:
+            raise SystemExit(f"rule {priority} expression differs")
+    if ranges is not None:
+        if set(match) != {"config", "versionedExpr"}:
+            raise SystemExit(f"rule {priority} retains source-match extras")
+        config = match.get("config") or {}
+        if not isinstance(config, dict) or set(config) != {"srcIpRanges"} or config.get("srcIpRanges") != ranges:
+            raise SystemExit(f"rule {priority} source ranges differ")
+        if match.get("versionedExpr") != "SRC_IPS_V1":
+            raise SystemExit(f"rule {priority} versioned source expression differs")
+    options = rule.get("rateLimitOptions") or {}
+    if count is None:
+        if "rateLimitOptions" in rule:
+            raise SystemExit(f"rule {priority} retains rate-limit options")
+        continue
+    if not isinstance(options, dict):
+        raise SystemExit(f"rule {priority} rate-limit contract differs")
+    threshold = options.get("rateLimitThreshold") or {}
+    if not isinstance(threshold, dict) or (
+        set(options) != {
+            "conformAction",
+            "enforceOnKey",
+            "exceedAction",
+            "rateLimitThreshold",
+        }
+        or set(threshold) != {"count", "intervalSec"}
+        or int(threshold.get("count", -1)) != count
+        or int(threshold.get("intervalSec", -1)) != 60
+        or options.get("conformAction") != "allow"
+        or options.get("exceedAction") != "deny(429)"
+        or options.get("enforceOnKey") != "IP"
+    ):
+        raise SystemExit(f"rule {priority} rate-limit contract differs")
+PY
 }
 
-_edge_require_log_sample_rate() {
-  local value="$1"
-  local fraction=""
+_verify_edge_backend_security_contract_json() {
+  [ "$#" -eq 2 ] || {
+    echo "ERROR: internal edge backend verifier expects PUBLIC_FLAG BACKEND_JSON" >&2
+    return 2
+  }
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
 
-  case "$value" in
-    0|1|1.0) return 0 ;;
-    0.*)
-      fraction="${value#0.}"
-      ;;
-    *)
-      echo "ERROR: TR_CLOUD_ARMOR_LOG_SAMPLE_RATE must be between 0 and 1" >&2
-      return 2
-      ;;
-  esac
-  case "$fraction" in
-    ''|*[!0-9]*)
-      echo "ERROR: TR_CLOUD_ARMOR_LOG_SAMPLE_RATE must be between 0 and 1" >&2
-      return 2
-      ;;
-  esac
+public_raw, raw = sys.argv[1:]
+if public_raw not in {"0", "1"}:
+    raise SystemExit("edge backend public flag is invalid")
+try:
+    data = json.loads(raw)
+except json.JSONDecodeError:
+    raise SystemExit("edge backend response is not valid JSON") from None
+if not isinstance(data, dict):
+    raise SystemExit("edge backend response is malformed")
+
+expected_header = ["X-TrustedRouter-Client-IP:{client_ip_address}"]
+if data.get("customRequestHeaders", []) != expected_header:
+    raise SystemExit("backend request-header allowlist drifted")
+if data.get("customResponseHeaders", []) not in (None, []):
+    raise SystemExit("backend retains custom response headers")
+if data.get("edgeSecurityPolicy") not in (None, ""):
+    raise SystemExit("backend retains an unexpected edge security policy")
+iap = data.get("iap") or {}
+if not isinstance(iap, dict):
+    raise SystemExit("backend IAP contract is malformed")
+if iap:
+    if iap.get("enabled") is not False:
+        raise SystemExit("backend IAP contract is not disabled")
+    if set(iap) - {"enabled", "oauth2ClientId"}:
+        raise SystemExit("backend IAP retains an OAuth secret or unknown state")
+    if iap.get("oauth2ClientId") not in (None, " "):
+        raise SystemExit("backend IAP retains an OAuth client ID")
+
+logging = data.get("logConfig") or {}
+if not isinstance(logging, dict) or (
+    set(logging) - {"enable", "sampleRate", "optionalMode", "optionalFields"}
+    or logging.get("enable") is not True
+    or float(logging.get("sampleRate", -1)) != 0.1
+    or logging.get("optionalMode", "EXCLUDE_ALL_OPTIONAL") != "EXCLUDE_ALL_OPTIONAL"
+    or logging.get("optionalFields", []) not in (None, [])
+):
+    raise SystemExit("backend logging contract drifted")
+
+public = public_raw == "1"
+if bool(data.get("enableCDN", False)) != public:
+    raise SystemExit("backend CDN state drifted")
+cdn_policy = data.get("cdnPolicy") or {}
+if not isinstance(cdn_policy, dict):
+    raise SystemExit("backend CDN policy is malformed")
+if public:
+    cache_key = cdn_policy.get("cacheKeyPolicy") or {}
+    if not isinstance(cache_key, dict):
+        raise SystemExit("public backend cache-key policy is malformed")
+    allowed_cdn_fields = {
+        "bypassCacheOnRequestHeaders",
+        "cacheKeyPolicy",
+        "cacheMode",
+        "clientTtl",
+        "defaultTtl",
+        "maxTtl",
+        "negativeCaching",
+        "negativeCachingPolicy",
+        "requestCoalescing",
+        "serveWhileStale",
+        "signedUrlCacheMaxAgeSec",
+        "signedUrlKeyNames",
+    }
+    allowed_cache_key_fields = {
+        "includeHost",
+        "includeHttpHeaders",
+        "includeNamedCookies",
+        "includeProtocol",
+        "includeQueryString",
+        "queryStringBlacklist",
+        "queryStringWhitelist",
+    }
+    if (
+        set(cdn_policy) - allowed_cdn_fields
+        or set(cache_key) - allowed_cache_key_fields
+        or cdn_policy.get("cacheMode") != "USE_ORIGIN_HEADERS"
+        or cdn_policy.get("negativeCaching", False) is not False
+        or cdn_policy.get("negativeCachingPolicy", []) not in (None, [])
+        or int(cdn_policy.get("serveWhileStale", -1)) != 600
+        or cdn_policy.get("clientTtl") is not None
+        or cdn_policy.get("defaultTtl") is not None
+        or cdn_policy.get("maxTtl") is not None
+        or cdn_policy.get("bypassCacheOnRequestHeaders", []) not in (None, [])
+        or cdn_policy.get("requestCoalescing", True) is not True
+        or cdn_policy.get("signedUrlCacheMaxAgeSec") is not None
+        or cdn_policy.get("signedUrlKeyNames", []) not in (None, [])
+        or cache_key.get("includeHost") is not True
+        or cache_key.get("includeProtocol") is not True
+        or cache_key.get("includeQueryString") is not True
+        or cache_key.get("queryStringBlacklist", []) not in (None, [])
+        or cache_key.get("queryStringWhitelist", []) not in (None, [])
+        or cache_key.get("includeHttpHeaders", []) not in (None, [])
+        or cache_key.get("includeNamedCookies", []) not in (None, [])
+        or data.get("compressionMode") != "AUTOMATIC"
+    ):
+        raise SystemExit("public backend CDN/cache-key contract drifted")
+elif cdn_policy:
+    raise SystemExit("non-public backend retains a CDN policy")
+PY
 }
 
-_edge_upsert_rule() {
-  local policy="$1"
-  local priority="$2"
-  shift 2
-  local preview="${TR_CLOUD_ARMOR_PREVIEW:-1}"
+verify_edge_backend_contract_json() {
+  [ "$#" -eq 8 ] || {
+    echo "ERROR: verify_edge_backend_contract_json expects SURFACE BACKEND_JSON PROJECT REGIONS_CSV SERVICE NEG POLICY TIMEOUT" >&2
+    return 2
+  }
+  local surface="$1"
+  local backend_json="$2"
+  local project="$3"
+  local regions_csv="$4"
+  local service="$5"
+  local neg="$6"
+  local policy="$7"
+  local timeout="$8"
+  local public_flag=0
+  [ "$surface" = public ] && public_flag=1
+  _verify_edge_backend_security_contract_json "$public_flag" "$backend_json" || return 1
+  python3 - "$surface" "$backend_json" "$project" "$regions_csv" \
+    "$service" "$neg" "$policy" "$timeout" <<'PY'
+import json
+import re
+import sys
 
-  case "$preview" in
-    1|0) ;;
-    *)
-      echo "ERROR: TR_CLOUD_ARMOR_PREVIEW must be 0 or 1" >&2
-      return 2
-      ;;
-  esac
+surface, raw, project, raw_regions, service, neg, policy, timeout = sys.argv[1:]
+services = {
+    "public": "trusted-router-public",
+    "actions": "trusted-router-actions",
+    "console": "trusted-router-console",
+    "chat": "trusted-router-chat",
+    "webhooks": "trusted-router-webhooks",
+    "internal": "trusted-router-billing",
+}
+backends = {
+    "public": "trusted-router-public-backend",
+    "actions": "trusted-router-actions-backend",
+    "console": "trusted-router-console-backend",
+    "chat": "trusted-router-chat-backend",
+    "webhooks": "trusted-router-webhooks-backend",
+    "internal": "trusted-router-billing-backend",
+}
+if surface not in services or service != services[surface]:
+    raise SystemExit("edge backend surface/service identity is noncanonical")
+if not re.fullmatch(r"[a-z][a-z0-9-]{4,28}[a-z0-9]", project):
+    raise SystemExit("edge backend project identity is noncanonical")
+if any(not re.fullmatch(r"[a-z][a-z0-9-]{0,61}[a-z0-9]", item) for item in (neg, policy)):
+    raise SystemExit("edge backend NEG or policy identity is noncanonical")
+regions = raw_regions.split(",")
+if not regions or len(regions) != len(set(regions)) or any(
+    not re.fullmatch(r"[a-z]+-[a-z0-9]+[0-9]", region) for region in regions
+):
+    raise SystemExit("edge backend region inventory is noncanonical")
+if not re.fullmatch(r"[1-9][0-9]{0,4}", timeout) or int(timeout) > 86400:
+    raise SystemExit("edge backend timeout is noncanonical")
+data = json.loads(raw)
+name = str(data.get("name") or "").rstrip("/").rsplit("/", 1)[-1]
+if name != backends[surface]:
+    raise SystemExit("edge backend resource identity is noncanonical")
 
-  if gc compute security-policies rules describe "$priority" \
-      --security-policy="$policy" >/dev/null 2>&1; then
-    # Create treats absence of --preview as enforcement. Update needs the
-    # explicit inverse or a previously-previewed rule would remain previewed.
-    if [ "$preview" = "0" ]; then
-      gc compute security-policies rules update "$priority" \
-        --security-policy="$policy" \
-        "$@" \
-        --no-preview \
-        --quiet >/dev/null
-    else
-      gc compute security-policies rules update "$priority" \
-        --security-policy="$policy" \
-        "$@" \
-        --preview \
-        --quiet >/dev/null
-    fi
-  else
-    if [ "$preview" = "0" ]; then
-      gc compute security-policies rules create "$priority" \
-        --security-policy="$policy" \
-        "$@" \
-        --quiet >/dev/null
-    else
-      gc compute security-policies rules create "$priority" \
-        --security-policy="$policy" \
-        "$@" \
-        --preview \
-        --quiet >/dev/null
-    fi
-  fi
+def resource_path(value: object) -> str:
+    text = str(value or "").rstrip("/")
+    match = re.search(
+        r"(?:^|/)(projects/[^/]+/(?:regions/[^/]+/networkEndpointGroups|"
+        r"global/securityPolicies)/[^/]+)$",
+        text,
+    )
+    if not match:
+        raise SystemExit(f"{name} has a noncanonical edge-resource reference: {text!r}")
+    return match.group(1)
+
+raw_backends = data.get("backends")
+if not isinstance(raw_backends, list) or any(not isinstance(item, dict) for item in raw_backends):
+    raise SystemExit(f"{name} has a malformed NEG inventory")
+expected_groups = sorted(
+    f"projects/{project}/regions/{region}/networkEndpointGroups/{neg}"
+    for region in regions
+)
+actual_groups = sorted(resource_path(item.get("group")) for item in raw_backends)
+if actual_groups != expected_groups or len(raw_backends) != len(expected_groups):
+    raise SystemExit(f"{name} NEG membership is not the exact same-project regional inventory")
+if data.get("loadBalancingScheme") != "EXTERNAL_MANAGED" or data.get("protocol") != "HTTP":
+    raise SystemExit(f"{name} has the wrong load-balancer scheme/protocol")
+if int(data.get("timeoutSec", 0)) != int(timeout):
+    raise SystemExit(f"{name} timeout differs from the exact surface contract")
+attached = resource_path(data.get("securityPolicy"))
+if attached != f"projects/{project}/global/securityPolicies/{policy}":
+    raise SystemExit(f"{name} has the wrong Cloud Armor policy")
+PY
 }
 
 _reconcile_cloud_armor_policy() {
   local policy="$1"
-  local interval="${TR_CLOUD_ARMOR_RATE_INTERVAL_SECONDS:-60}"
-  local browser_count="${TR_CLOUD_ARMOR_BROWSER_RATE_COUNT:-120}"
-  local write_count="${TR_CLOUD_ARMOR_WRITE_RATE_COUNT:-300}"
-  local global_count="${TR_CLOUD_ARMOR_GLOBAL_RATE_COUNT:-2400}"
-  local allowed_host_regex="${TR_EDGE_ALLOWED_HOST_REGEX:-^(trustedrouter[.]com|www[.]trustedrouter[.]com|status[.]trustedrouter[.]com|trust[.]trustedrouter[.]com|eu[.]trustedrouter[.]com|status-us[.]trustedrouter[.]com|status-eu[.]trustedrouter[.]com|allyrouter[.]com|www[.]allyrouter[.]com|status[.]allyrouter[.]com|trust[.]allyrouter[.]com|uptimerouter[.]com|www[.]uptimerouter[.]com|status[.]uptimerouter[.]com|trust[.]uptimerouter[.]com)(:[0-9]+)?$}"
+  local allowed_host_regex="$_TR_EDGE_ALLOWED_HOST_REGEX"
+  local policy_file=""
+  local policy_json=""
+  local setting=""
 
-  _edge_require_positive_integer TR_CLOUD_ARMOR_RATE_INTERVAL_SECONDS "$interval"
-  _edge_require_positive_integer TR_CLOUD_ARMOR_BROWSER_RATE_COUNT "$browser_count"
-  _edge_require_positive_integer TR_CLOUD_ARMOR_WRITE_RATE_COUNT "$write_count"
-  _edge_require_positive_integer TR_CLOUD_ARMOR_GLOBAL_RATE_COUNT "$global_count"
+  # These values are a reviewed production contract, not tuning inputs. A
+  # per-invocation override could silently weaken one backend while the other
+  # five retained the audited policy.
+  for setting in \
+    TR_EDGE_ALLOWED_HOST_REGEX \
+    TR_CLOUD_ARMOR_RATE_INTERVAL_SECONDS \
+    TR_CLOUD_ARMOR_BROWSER_RATE_COUNT \
+    TR_CLOUD_ARMOR_WRITE_RATE_COUNT \
+    TR_CLOUD_ARMOR_GLOBAL_RATE_COUNT \
+    TR_CLOUD_ARMOR_PREVIEW; do
+    if [ -n "${!setting:-}" ]; then
+      echo "ERROR: ${setting} is not an operator override; edit and review the exact edge contract" >&2
+      return 2
+    fi
+  done
 
   if ! gc compute security-policies describe "$policy" --global >/dev/null 2>&1; then
     log "creating Cloud Armor backend policy ${policy}"
@@ -105,76 +364,121 @@ _reconcile_cloud_armor_policy() {
       --quiet >/dev/null
   fi
 
-  # Repair the immutable catch-all contract on every deploy. Custom rules all
-  # have a lower priority; a typo must never turn policy creation into an
-  # accidental default deny.
-  gc compute security-policies rules update 2147483647 \
-    --security-policy="$policy" \
-    --action=allow \
-    --src-ip-ranges='*' \
-    --no-preview \
-    --description="Default allow; bounded route classes are evaluated first" \
-    --quiet >/dev/null
+  policy_file="$(mktemp "${TMPDIR:-/tmp}/tr-edge-policy-XXXXXX.json")"
+  chmod 600 "$policy_file"
+  if ! python3 - "$allowed_host_regex" "$policy_file" <<'PY'
+import json
+import sys
+from pathlib import Path
 
-  # Host ownership is a routing boundary, not a tuning signal.  Keep it
-  # enforced even while the narrower traffic-shape rules are in preview: an
-  # allowed TLS SNI with an attacker-chosen Host must never fall through to an
-  # unrelated/legacy URL-map default.
-  TR_CLOUD_ARMOR_PREVIEW=0 _edge_upsert_rule "$policy" 900 \
-    --action=deny-403 \
-    --expression="!has(request.headers['host']) || !request.headers['host'].lower().matches('${allowed_host_regex}')" \
-    --description="Reject hosts outside canonical and marketing aliases"
+allowed, destination = sys.argv[1:]
+host_expression = (
+    "!has(request.headers['host']) || "
+    f"!request.headers['host'].lower().matches('{allowed}')"
+)
 
-  _edge_upsert_rule "$policy" 1000 \
-    --action=throttle \
-    --expression="request.path.startsWith('/chat-proxy/')" \
-    --description="Browser inference proxy per-client throttle" \
-    --rate-limit-threshold-count="$browser_count" \
-    --rate-limit-threshold-interval-sec="$interval" \
-    --conform-action=allow \
-    --exceed-action=deny-429 \
-    --enforce-on-key=IP
+def source_match():
+    return {"config": {"srcIpRanges": ["*"]}, "versionedExpr": "SRC_IPS_V1"}
 
-  _edge_upsert_rule "$policy" 1100 \
-    --action=throttle \
-    --expression="request.method != 'GET' && request.method != 'HEAD' && request.method != 'OPTIONS'" \
-    --description="State-changing request per-client throttle" \
-    --rate-limit-threshold-count="$write_count" \
-    --rate-limit-threshold-interval-sec="$interval" \
-    --conform-action=allow \
-    --exceed-action=deny-429 \
-    --enforce-on-key=IP
+def rate_limit(count):
+    return {
+        "conformAction": "allow",
+        "enforceOnKey": "IP",
+        "exceedAction": "deny(429)",
+        "rateLimitThreshold": {"count": count, "intervalSec": 60},
+    }
 
-  # Keep one generous all-path per-source ceiling enforced from the first
-  # attach. The independent Cloud Run max-instance caps, not this IP-keyed
-  # rule, bound a distributed botnet and the fleet-wide serverless bill. The
-  # tighter browser/write rules can spend a canary period in preview, but
-  # preview-only policy would leave health and every other cheap path entirely
-  # unbounded at the edge during the exact launch window this policy protects.
-  TR_CLOUD_ARMOR_PREVIEW=0 _edge_upsert_rule "$policy" 1200 \
-    --action=throttle \
-    --src-ip-ranges='*' \
-    --description="All-path per-source safety ceiling" \
-    --rate-limit-threshold-count="$global_count" \
-    --rate-limit-threshold-interval-sec="$interval" \
-    --conform-action=allow \
-    --exceed-action=deny-429 \
-    --enforce-on-key=IP
+policy = {
+    "description": (
+        "TrustedRouter exact edge controls; host and all-path gates enforced, "
+        "route-shape rules previewed"
+    ),
+    "type": "CLOUD_ARMOR",
+    "rules": [
+        {
+            "action": "deny(403)",
+            "description": "Reject hosts outside canonical and marketing aliases",
+            "match": {"expr": {"expression": host_expression}},
+            "preview": False,
+            "priority": 900,
+        },
+        {
+            "action": "throttle",
+            "description": "Browser inference proxy per-client throttle",
+            "match": {"expr": {"expression": "request.path.startsWith('/chat-proxy/')"}},
+            "preview": True,
+            "priority": 1000,
+            "rateLimitOptions": rate_limit(120),
+        },
+        {
+            "action": "throttle",
+            "description": "State-changing request per-client throttle",
+            "match": {
+                "expr": {
+                    "expression": (
+                        "request.method != 'GET' && request.method != 'HEAD' && "
+                        "request.method != 'OPTIONS'"
+                    )
+                }
+            },
+            "preview": True,
+            "priority": 1100,
+            "rateLimitOptions": rate_limit(300),
+        },
+        {
+            "action": "throttle",
+            "description": "All-path per-source safety ceiling",
+            "match": source_match(),
+            "preview": False,
+            "priority": 1200,
+            "rateLimitOptions": rate_limit(2400),
+        },
+        {
+            "action": "allow",
+            "description": "Default allow; bounded route classes are evaluated first",
+            "match": source_match(),
+            "preview": False,
+            "priority": 2147483647,
+        },
+    ],
+}
+Path(destination).write_text(json.dumps(policy, separators=(",", ":")) + "\n")
+PY
+  then
+    rm -f "$policy_file"
+    return 1
+  fi
+
+  # Import is a single policy replacement. It removes unknown priorities and
+  # stale headerAction/redirect/WAF fields instead of trying to update an
+  # attacker-controlled rule in place and accidentally retaining its extras.
+  if ! gc compute security-policies import "$policy" \
+      --file-name="$policy_file" \
+      --file-format=json \
+      --global \
+      --quiet >/dev/null; then
+    rm -f "$policy_file"
+    return 1
+  fi
+  rm -f "$policy_file"
+
+  policy_json="$(gc compute security-policies describe "$policy" \
+    --global --format=json)" || return 1
+  if ! verify_cloud_armor_policy_contract_json "$policy_json"; then
+    echo "ERROR: ${policy} did not retain the exact Cloud Armor contract" >&2
+    return 1
+  fi
 }
 
 reconcile_edge_backend() {
   local backend="$1"
   local policy="$2"
   # Full request logging can turn the attack itself into a Cloud Logging bill.
-  # Ten percent is enough for preview sizing; operators can temporarily raise
-  # it during a bounded investigation.
-  local log_sample_rate="${TR_CLOUD_ARMOR_LOG_SAMPLE_RATE:-0.1}"
-  local backend_json=""
-  local preserved_headers=""
+  # The reviewed contract is always a ten-percent sample.
+  local log_sample_rate="0.1"
   local final_json=""
   local attached_policy=""
-  local header=""
-  local header_args=()
+  local public_backend="${TR_PUBLIC_BACKEND:-trusted-router-public-backend}"
 
   case "$backend" in
     ''|*[!a-zA-Z0-9_-]*)
@@ -188,7 +492,10 @@ reconcile_edge_backend() {
       return 2
       ;;
   esac
-  _edge_require_log_sample_rate "$log_sample_rate"
+  if [ -n "${TR_CLOUD_ARMOR_LOG_SAMPLE_RATE:-}" ]; then
+    echo "ERROR: TR_CLOUD_ARMOR_LOG_SAMPLE_RATE is fixed at 0.1 for production reconciliation" >&2
+    return 2
+  fi
 
   if ! gc compute backend-services describe "$backend" --global >/dev/null 2>&1; then
     echo "ERROR: required public load-balancer backend ${backend} does not exist" >&2
@@ -196,35 +503,57 @@ reconcile_edge_backend() {
   fi
 
   _reconcile_cloud_armor_policy "$policy"
-  backend_json="$(gc compute backend-services describe "$backend" \
-    --global --format=json)"
-  preserved_headers="$(printf '%s' "$backend_json" | python3 -c '
-import json
-import sys
 
-data = json.load(sys.stdin)
-for header in data.get("customRequestHeaders", []) or []:
-    name = str(header).split(":", 1)[0].strip().casefold()
-    if name != "x-trustedrouter-client-ip":
-        print(header)
-')"
-  while IFS= read -r header; do
-    [ -n "$header" ] || continue
-    header_args+=("--custom-request-header=${header}")
-  done <<<"$preserved_headers"
-  # Google adds this after receiving the client request and overwrites any
-  # same-name client header case-insensitively. Never derive limiter identity
-  # from X-Forwarded-For or a header that survives client input unchanged.
-  header_args+=("--custom-request-header=X-TrustedRouter-Client-IP:{client_ip_address}")
-
-  log "attaching ${policy} and trusted client identity to ${backend}"
+  log "clearing stale edge state and attaching ${policy} to ${backend}"
+  # Clear response/request injection before installing the sole trusted header.
+  # The IAP single-space values are the documented API sentinel for clearing a
+  # retained OAuth client while leaving IAP disabled.
   gc compute backend-services update "$backend" \
     --global \
     --security-policy="$policy" \
+    --edge-security-policy="" \
+    '--iap=disabled,oauth2-client-id= ,oauth2-client-secret= ' \
+    --no-custom-request-headers \
+    --no-custom-response-headers \
     --enable-logging \
     --logging-sample-rate="$log_sample_rate" \
-    "${header_args[@]}" \
     --quiet >/dev/null
+
+  # Google adds this value after receiving the client request. Replacing the
+  # whole request-header list prevents an old Authorization/internal-token
+  # injection from surviving a service split.
+  if [ "$backend" = "$public_backend" ]; then
+    gc compute backend-services update "$backend" \
+      --global \
+      --custom-request-header='X-TrustedRouter-Client-IP:{client_ip_address}' \
+      --enable-cdn \
+      --cache-mode=USE_ORIGIN_HEADERS \
+      --cache-key-include-host \
+      --cache-key-include-protocol \
+      --cache-key-include-query-string \
+      --cache-key-query-string-blacklist= \
+      --cache-key-include-http-header= \
+      --cache-key-include-named-cookie= \
+      --no-bypass-cache-on-request-headers \
+      --no-negative-caching-policies \
+      --serve-while-stale=600 \
+      --request-coalescing \
+      --no-client-ttl \
+      --no-default-ttl \
+      --no-max-ttl \
+      --compression-mode=AUTOMATIC \
+      --quiet >/dev/null
+    gc compute backend-services update "$backend" \
+      --global \
+      --no-negative-caching \
+      --quiet >/dev/null
+  else
+    gc compute backend-services update "$backend" \
+      --global \
+      --custom-request-header='X-TrustedRouter-Client-IP:{client_ip_address}' \
+      --no-enable-cdn \
+      --quiet >/dev/null
+  fi
 
   attached_policy="$(gc compute backend-services describe "$backend" --global \
     --format='value(securityPolicy.basename())')"
@@ -232,22 +561,10 @@ for header in data.get("customRequestHeaders", []) or []:
     echo "ERROR: ${backend} has Cloud Armor policy ${attached_policy:-<none>}, expected ${policy}" >&2
     return 1
   fi
-  final_json="$(gc compute backend-services describe "$backend" --global \
-    --format='json(customRequestHeaders,securityPolicy)')"
-  if ! printf '%s' "$final_json" | python3 -c '
-import json
-import sys
-
-data = json.load(sys.stdin)
-matches = []
-for header in data.get("customRequestHeaders", []) or []:
-    name, separator, value = str(header).partition(":")
-    if separator and name.strip().casefold() == "x-trustedrouter-client-ip":
-        matches.append(value.strip())
-if matches != ["{client_ip_address}"]:
-    raise SystemExit(f"trusted client header drift: {matches!r}")
-'; then
-    echo "ERROR: ${backend} did not retain the trusted client-IP overwrite" >&2
+  final_json="$(gc compute backend-services describe "$backend" --global --format=json)"
+  if ! _verify_edge_backend_security_contract_json \
+      "$([ "$backend" = "$public_backend" ] && echo 1 || echo 0)" "$final_json"; then
+    echo "ERROR: ${backend} did not retain the exact edge backend contract" >&2
     return 1
   fi
 }

--- a/scripts/deploy/_lib.sh
+++ b/scripts/deploy/_lib.sh
@@ -21,6 +21,13 @@ TR_PRIMARY_REGION="${TR_PRIMARY_REGION:-us-central1}"
 # than TR_REGIONS because cold control-plane regions can serve cached public
 # pages without advertising non-existent regional attested gateway hostnames.
 TR_CONTROL_PLANE_REGIONS="${TR_CONTROL_PLANE_REGIONS:-us-central1,us-east4,europe-west4,southamerica-east1}"
+# Canonical regions for the four synthetic job families. infra.sh consumes
+# the same inventory before retiring the legacy job identity, so changing a
+# job region cannot silently leave the retirement preflight behind.
+TR_SYNTHETIC_MONITOR_REGIONS="${TR_SYNTHETIC_MONITOR_REGIONS:-us-central1,europe-west4}"
+TR_SYNTHETIC_THROUGHPUT_REGION="${TR_SYNTHETIC_THROUGHPUT_REGION:-us-central1}"
+TR_SYNTHETIC_IMAGE_REGION="${TR_SYNTHETIC_IMAGE_REGION:-us-central1}"
+TR_SYNTHETIC_VIDEO_REGION="${TR_SYNTHETIC_VIDEO_REGION:-us-central1}"
 # Comma-separated subset of TR_REGIONS that should run with always-on warm
 # capacity. Anything outside TR_WARM_REGIONS gets min_scale=0 unless the
 # per-region map below says otherwise.
@@ -76,7 +83,57 @@ TR_CLOUD_RUN_DISABLE_DEFAULT_URL="${TR_CLOUD_RUN_DISABLE_DEFAULT_URL:-0}"
 # service. rollout.sh uses Cloud Run's mutable --max service cap, not the
 # per-revision --max-instances setting, so staged traffic cannot double it.
 TR_CLOUD_RUN_MAX_INSTANCES="${TR_CLOUD_RUN_MAX_INSTANCES:-20}"
+TR_RETIRE_LEGACY_RUN_SERVICE_ACCOUNT_IAM="${TR_RETIRE_LEGACY_RUN_SERVICE_ACCOUNT_IAM:-0}"
 SERVICE="${SERVICE:-trusted-router}"
+# The split console is a companion service. Keep the old combined monolith
+# under an explicit name so initial-migration discovery and rollback cannot
+# accidentally treat it as the console-only target.
+CONSOLE_SERVICE="${TR_CONSOLE_SERVICE:-${SERVICE}-console}"
+LEGACY_CONSOLE_SERVICE="${TR_LEGACY_CONSOLE_SERVICE:-$SERVICE}"
+PUBLIC_SERVICE="${TR_PUBLIC_SERVICE:-${SERVICE}-public}"
+ACTIONS_SERVICE="${TR_ACTIONS_SERVICE:-${SERVICE}-actions}"
+CHAT_SERVICE="${TR_CHAT_SERVICE:-${SERVICE}-chat}"
+WEBHOOKS_SERVICE="${TR_WEBHOOKS_SERVICE:-${SERVICE}-webhooks}"
+# TR_BILLING_SERVICE predates the process-role name `internal` and is also
+# consumed by synthetic.sh. Keep it as a compatibility/input alias while the
+# application revision itself remains TR_SERVICE_SURFACE=internal.
+INTERNAL_SERVICE="${TR_INTERNAL_SERVICE:-${TR_BILLING_SERVICE:-${SERVICE}-billing}}"
+TR_BILLING_SERVICE="${TR_BILLING_SERVICE:-$INTERNAL_SERVICE}"
+
+# Each process role names a dedicated, pre-provisioned runtime identity.
+# Provisioning and verification remain explicit operator prerequisites.
+PUBLIC_RUN_SERVICE_ACCOUNT="${TR_PUBLIC_RUN_SERVICE_ACCOUNT:-tr-public@${PROJECT_ID}.iam.gserviceaccount.com}"
+ACTIONS_RUN_SERVICE_ACCOUNT="${TR_ACTIONS_RUN_SERVICE_ACCOUNT:-tr-actions@${PROJECT_ID}.iam.gserviceaccount.com}"
+CONSOLE_RUN_SERVICE_ACCOUNT="${TR_CONSOLE_RUN_SERVICE_ACCOUNT:-tr-console@${PROJECT_ID}.iam.gserviceaccount.com}"
+CHAT_RUN_SERVICE_ACCOUNT="${TR_CHAT_RUN_SERVICE_ACCOUNT:-tr-chat@${PROJECT_ID}.iam.gserviceaccount.com}"
+WEBHOOKS_RUN_SERVICE_ACCOUNT="${TR_WEBHOOKS_RUN_SERVICE_ACCOUNT:-tr-webhooks@${PROJECT_ID}.iam.gserviceaccount.com}"
+INTERNAL_RUN_SERVICE_ACCOUNT="${TR_INTERNAL_RUN_SERVICE_ACCOUNT:-tr-internal@${PROJECT_ID}.iam.gserviceaccount.com}"
+SYNTHETIC_RUN_SERVICE_ACCOUNT="${TR_SYNTHETIC_RUN_SERVICE_ACCOUNT:-tr-synthetic@${PROJECT_ID}.iam.gserviceaccount.com}"
+DEPLOY_SERVICE_ACCOUNT="${TR_DEPLOY_SERVICE_ACCOUNT:-tr-deploy@${PROJECT_ID}.iam.gserviceaccount.com}"
+# Exact direct principals, managed outside this deploy, that may impersonate a
+# split runtime. Each listed member may hold only one unconditional
+# roles/iam.serviceAccountUser binding. Runtime identities, the deploy identity,
+# wildcard principals, TokenCreator, and arbitrary roles are never admitted by
+# this escape hatch. Promotion can feed its already-fetched policy JSON into
+# verify_runtime_service_account_policy_json below.
+TR_RUNTIME_SERVICE_ACCOUNT_OPERATOR_MEMBERS="${TR_RUNTIME_SERVICE_ACCOUNT_OPERATOR_MEMBERS:-}"
+# Exact non-runtime accessors that an owner has explicitly reviewed and wants
+# to preserve while secrets.sh replaces resource policies. The value is JSON:
+# {"secret-name":["serviceAccount:consumer@project.iam.gserviceaccount.com"]}.
+# Conditions, public principals, runtime/synthetic/deploy identities, arbitrary
+# roles, and wildcard secret names are deliberately unsupported.
+TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON="${TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON:-}"
+if [ -z "$TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON" ]; then
+  TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON='{}'
+fi
+RUNTIME_SERVICE_ACCOUNTS=(
+  "$PUBLIC_RUN_SERVICE_ACCOUNT"
+  "$ACTIONS_RUN_SERVICE_ACCOUNT"
+  "$CONSOLE_RUN_SERVICE_ACCOUNT"
+  "$CHAT_RUN_SERVICE_ACCOUNT"
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT"
+  "$INTERNAL_RUN_SERVICE_ACCOUNT"
+)
 REPO="${REPO:-trusted-router}"
 IMAGE="${IMAGE:-${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/${SERVICE}:$(git rev-parse --short HEAD 2>/dev/null || echo local)}"
 KEY_FILE="${TR_LOCAL_KEYS_FILE:-${HOME}/.quill_cloud_keys.private}"
@@ -108,7 +165,559 @@ log() { echo "[$(date +%H:%M:%S)] $*" >&2; }
 gc() { gcloud --project "$PROJECT_ID" "$@"; }
 
 PROJECT_NUMBER="$(gc projects describe "$PROJECT_ID" --format='value(projectNumber)')"
+# Compatibility for GCP synthetic jobs only. Cloud Run services must use one
+# of the six RUNTIME_SERVICE_ACCOUNTS above. infra.sh references this legacy
+# identity only in the guarded post-cutover retirement path; secrets.sh never
+# grants it split-service access. Synthetic Scheduler jobs still name it
+# directly and are verified separately.
 RUN_SERVICE_ACCOUNT="${RUN_SERVICE_ACCOUNT:-${PROJECT_NUMBER}-compute@developer.gserviceaccount.com}"
+
+# Canonical Secret Manager ownership for the six FastAPI surfaces. Unknown
+# resources intentionally return nonzero and therefore have zero runtime
+# owners. Keep this single table shared by owner reconciliation and every
+# read-only rollout gate.
+secret_expected_surfaces() {
+  case "$1" in
+    trustedrouter-attribution-cookie-secret) echo "public console" ;;
+    trustedrouter-sentry-dsn) echo "console chat webhooks internal" ;;
+    trustedrouter-stripe-secret-key) echo "console" ;;
+    trustedrouter-internal-stripe-payment-intents-key) echo "internal" ;;
+    trustedrouter-stripe-webhook-secret) echo "webhooks" ;;
+    trustedrouter-internal-gateway-token|trustedrouter-observer-internal-token|trustedrouter-synthetic-monitor-api-key|trustedrouter-federation-peer-token|trustedrouter-federation-home-token|trustedrouter-federation-credit-inbound-token|trustedrouter-federation-credit-peer-token|trustedrouter-federation-settlement-inbound-tokens|trustedrouter-federation-settlement-home-token) echo "internal" ;;
+    trustedrouter-aws-access-key-id|trustedrouter-aws-secret-access-key) echo "actions console" ;;
+    trustedrouter-internal-ses-access-key-id|trustedrouter-internal-ses-secret-access-key) echo "internal" ;;
+    trustedrouter-ops-chat-webhook-secret) echo "actions" ;;
+    trustedrouter-google-client-id|trustedrouter-google-client-secret|trustedrouter-google-alias-credentials-json|trustedrouter-github-client-id|trustedrouter-github-client-secret|trustedrouter-github-alias-credentials-json) echo "console" ;;
+    trustedrouter-paypal-client-id|trustedrouter-paypal-client-secret) echo "console webhooks" ;;
+    trustedrouter-paypal-webhook-id) echo "webhooks" ;;
+    trustedrouter-adyen-test-api-key|trustedrouter-adyen-test-client-key) echo "console" ;;
+    trustedrouter-adyen-test-hmac-key) echo "webhooks" ;;
+    trustedrouter-adyen-test-reference-key) echo "console webhooks" ;;
+    trustedrouter-veriff-api-key) echo "console" ;;
+    trustedrouter-veriff-shared-secret-key) echo "webhooks" ;;
+    trustedrouter-telnyx-api-key|trustedrouter-twilio-account-sid|trustedrouter-twilio-api-key-sid|trustedrouter-twilio-api-key-secret|trustedrouter-twilio-auth-token) echo "console" ;;
+    trustedrouter-clickhouse-provider-read-password) echo "console" ;;
+    trustedrouter-clickhouse-control-read-password) echo "public console internal" ;;
+    trustedrouter-clickhouse-password) echo "console internal" ;;
+    trustedrouter-axiom-api-token) echo "" ;;
+    trustedrouter-anthropic-api-key|trustedrouter-openai-api-key|trustedrouter-openai-video-api-key|trustedrouter-gemini-api-key|trustedrouter-cerebras-api-key|trustedrouter-deepseek-api-key|trustedrouter-mistral-api-key|trustedrouter-kimi-api-key|trustedrouter-zai-api-key|trustedrouter-together-api-key|trustedrouter-fireworks-api-key|trustedrouter-deepinfra-api-key|trustedrouter-cohere-api-key|trustedrouter-voyage-api-key|trustedrouter-xiaomi-api-key|trustedrouter-grok-api-key|trustedrouter-novita-api-key|trustedrouter-phala-api-key|trustedrouter-phala-confidential-api-key|trustedrouter-siliconflow-api-key|trustedrouter-tinfoil-api-key|trustedrouter-venice-api-key|trustedrouter-nebius-api-key|trustedrouter-minimax-api-key|trustedrouter-friendli-api-key|trustedrouter-baseten-api-key|trustedrouter-thinking-machines-api-key|trustedrouter-wafer-api-key|trustedrouter-crusoe-api-key|trustedrouter-makora-api-key|trustedrouter-alibaba-api-key|trustedrouter-ltx-api-key|trustedrouter-runway-api-key|trustedrouter-kling-api-key|trustedrouter-chutes-api-key|trustedrouter-digitalocean-api-key|trustedrouter-cloudflare-workers-ai-api-token|trustedrouter-inceptron-api-key|trustedrouter-morph-api-key|trustedrouter-atlas-cloud-api-key|trustedrouter-streamlake-api-key|trustedrouter-neurometric-api-key|trustedrouter-engy-api-key|trustedrouter-pearl-api-key|trustedrouter-zero-g-api-key|trustedrouter-athena-worker-prompt-v1|trustedrouter-gcp-service-account-key-json) echo "" ;;
+    *) return 1 ;;
+  esac
+}
+
+# The deploy identity reads only the exact secrets consumed by the checked-in
+# price refresh workflow. Historic operational/Veriff/Adyen/ClickHouse grants
+# are intentionally absent and are removed by owner reconciliation.
+deploy_service_account_owns_secret() {
+  case "$1" in
+    trustedrouter-tr-api-key-for-self-heal|trustedrouter-together-api-key|trustedrouter-parasail-api-key|trustedrouter-lightning-api-key|trustedrouter-gmi-api-key|trustedrouter-deepinfra-api-key|trustedrouter-phala-confidential-api-key|trustedrouter-siliconflow-api-key|trustedrouter-venice-api-key|trustedrouter-openai-api-key|trustedrouter-grok-api-key|trustedrouter-deepseek-api-key|trustedrouter-mistral-api-key|trustedrouter-zai-api-key|trustedrouter-cerebras-api-key|trustedrouter-kimi-api-key|trustedrouter-fireworks-api-key|trustedrouter-gemini-api-key|trustedrouter-novita-api-key|trustedrouter-nebius-api-key|trustedrouter-minimax-api-key|trustedrouter-crusoe-api-key|trustedrouter-friendli-api-key|trustedrouter-baseten-api-key|trustedrouter-telnyx-api-key|trustedrouter-wafer-api-key|trustedrouter-alibaba-api-key|trustedrouter-makora-api-key|trustedrouter-chutes-api-key|trustedrouter-digitalocean-api-key|trustedrouter-cloudflare-workers-ai-api-token|trustedrouter-inceptron-api-key|trustedrouter-morph-api-key|trustedrouter-atlas-cloud-api-key|trustedrouter-streamlake-api-key|trustedrouter-neurometric-api-key|trustedrouter-engy-api-key|trustedrouter-pearl-api-key|trustedrouter-zero-g-api-key) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+synthetic_service_account_owns_secret() {
+  case "$1" in
+    trustedrouter-observer-internal-token|trustedrouter-synthetic-monitor-api-key) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Read a Secret Manager policy on stdin. `verify` requires the canonical owners
+# and permits only explicitly allowlisted unrelated accessors. `plan` emits
+# narrowly targeted add/remove operations for the six runtimes, deploy,
+# synthetic, and public principals. It never rewrites or removes an unrelated
+# non-public principal; unallowlisted drift fails before mutation.
+secret_iam_policy_contract_json() {
+  local mode="$1"
+  local secret_name="$2"
+  local expected_surfaces="${3:-}"
+  local deploy_expected=0
+  local synthetic_expected=0
+  local runtime_csv
+  case "$mode" in
+    verify|plan) ;;
+    *) echo "ERROR: invalid secret IAM policy contract mode ${mode}" >&2; return 2 ;;
+  esac
+  deploy_service_account_owns_secret "$secret_name" && deploy_expected=1
+  synthetic_service_account_owns_secret "$secret_name" && synthetic_expected=1
+  runtime_csv="$(IFS=,; echo "${RUNTIME_SERVICE_ACCOUNTS[*]}")"
+  python3 -c '
+import json
+import re
+import sys
+
+(
+    mode,
+    secret,
+    expected_surfaces,
+    accounts_csv,
+    deploy_account,
+    synthetic_account,
+    deploy_expected,
+    synthetic_expected,
+    preserved_raw,
+) = sys.argv[1:]
+surfaces = ("public", "actions", "console", "chat", "webhooks", "internal")
+accounts = accounts_csv.split(",")
+if len(accounts) != 6 or len(set(accounts)) != 6:
+    raise SystemExit("runtime identity inventory is not exactly six")
+wanted_surfaces = expected_surfaces.split()
+if len(set(wanted_surfaces)) != len(wanted_surfaces) or not set(wanted_surfaces).issubset(surfaces):
+    raise SystemExit("secret runtime owner set is invalid")
+if not re.fullmatch(r"[A-Za-z0-9_-]{1,255}", secret):
+    raise SystemExit("secret resource identifier is invalid")
+
+try:
+    preserved = json.loads(preserved_raw)
+except json.JSONDecodeError:
+    raise SystemExit("TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON is invalid JSON") from None
+if not isinstance(preserved, dict):
+    raise SystemExit("TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON must be an object")
+
+canonical_accounts = set(accounts) | {deploy_account, synthetic_account}
+preserved_for_secret = []
+valid_member_prefixes = (
+    "user:",
+    "group:",
+    "serviceAccount:",
+    "domain:",
+    "principal://",
+    "principalSet://",
+)
+for name, members in preserved.items():
+    if not isinstance(name, str) or not re.fullmatch(r"[A-Za-z0-9_-]{1,255}", name):
+        raise SystemExit("preserved secret accessor map has an invalid resource name")
+    if not isinstance(members, list) or any(not isinstance(member, str) for member in members):
+        raise SystemExit(f"preserved secret accessor list for {name} is malformed")
+    if len(members) != len(set(members)):
+        raise SystemExit(f"preserved secret accessor list for {name} has duplicates")
+    for member in members:
+        if member in {"allUsers", "allAuthenticatedUsers"}:
+            raise SystemExit("public principals cannot be preserved on secrets")
+        if (
+            member.startswith("deleted:")
+            or not member.startswith(valid_member_prefixes)
+            or member != member.strip()
+            or any(character.isspace() for character in member)
+        ):
+            raise SystemExit(f"preserved secret accessor {member!r} is noncanonical")
+        raw_account = member.removeprefix("serviceAccount:")
+        if raw_account in canonical_accounts:
+            raise SystemExit("canonical runtime/deploy/synthetic owners cannot be overridden")
+    if name == secret:
+        preserved_for_secret = members
+
+canonical_wanted = {
+    "serviceAccount:" + account
+    for surface, account in zip(surfaces, accounts)
+    if surface in wanted_surfaces
+}
+if deploy_expected == "1":
+    canonical_wanted.add("serviceAccount:" + deploy_account)
+if synthetic_expected == "1":
+    canonical_wanted.add("serviceAccount:" + synthetic_account)
+managed_members = {"serviceAccount:" + account for account in canonical_accounts}
+preserved_members = set(preserved_for_secret)
+
+policy = json.load(sys.stdin)
+if not isinstance(policy, dict) or not isinstance(policy.get("bindings", []), list):
+    raise SystemExit("Secret Manager IAM policy is malformed")
+observed = []
+for binding in policy.get("bindings", []):
+    if not isinstance(binding, dict):
+        raise SystemExit("Secret Manager IAM binding is malformed")
+    role = binding.get("role")
+    members = binding.get("members")
+    condition = binding.get("condition") if "condition" in binding else None
+    if not isinstance(role, str) or not isinstance(members, list) or not members:
+        raise SystemExit("Secret Manager IAM binding is malformed")
+    if len(members) != len(set(members)) or any(not isinstance(member, str) for member in members):
+        raise SystemExit("Secret Manager IAM member inventory is malformed")
+    for member in members:
+        observed.append((role, member, condition))
+
+present_managed = set()
+present_preserved = set()
+present_public = set()
+operations = []
+for role, member, condition in observed:
+    if member in {"allUsers", "allAuthenticatedUsers"}:
+        if condition is not None:
+            raise SystemExit("conditional public secret IAM must be removed manually")
+        public_entry = (role, member)
+        if public_entry in present_public:
+            raise SystemExit("public secret principal has duplicate bindings")
+        present_public.add(public_entry)
+        if mode == "plan":
+            operations.append(("remove", role, member))
+        else:
+            raise SystemExit("public principal is forbidden on Secret Manager")
+        continue
+    if member in managed_members:
+        if role != "roles/secretmanager.secretAccessor" or condition is not None:
+            raise SystemExit("managed secret principal has a noncanonical role or condition")
+        if member in present_managed:
+            raise SystemExit("managed secret principal has duplicate bindings")
+        present_managed.add(member)
+        if member not in canonical_wanted:
+            if mode == "plan":
+                operations.append(("remove", role, member))
+            else:
+                raise SystemExit("managed non-owner retains secret access")
+        continue
+    if member not in preserved_members:
+        raise SystemExit("unapproved unrelated secret principal must be explicitly allowlisted")
+    if role != "roles/secretmanager.secretAccessor" or condition is not None:
+        raise SystemExit("preserved unrelated secret principal must be an unconditional accessor")
+    if member in present_preserved:
+        raise SystemExit("preserved unrelated secret principal has duplicate bindings")
+    present_preserved.add(member)
+
+missing = sorted(canonical_wanted - present_managed)
+if mode == "verify" and missing:
+    raise SystemExit("canonical secret owner is missing")
+if mode == "plan":
+    operations.extend(
+        ("add", "roles/secretmanager.secretAccessor", member)
+        for member in missing
+    )
+    for action, role, member in sorted(operations):
+        print(action, role, member, sep="\t")
+' "$mode" "$secret_name" "$expected_surfaces" "$runtime_csv" \
+    "$DEPLOY_SERVICE_ACCOUNT" "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
+    "$deploy_expected" "$synthetic_expected" \
+    "$TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON"
+}
+
+validate_nonempty_region_list() {
+  local variable_name="$1"
+  local value="$2"
+  local seen="|"
+  local -a regions
+  local region
+  case "$value" in
+    ''|,*|*,|*,,*)
+      echo "ERROR: ${variable_name} must be a nonempty comma-separated region list" >&2
+      return 1
+      ;;
+  esac
+  IFS=',' read -ra regions <<<"$value"
+  for region in "${regions[@]}"; do
+    if ! [[ "$region" =~ ^[a-z][a-z0-9-]*[a-z0-9]$ ]]; then
+      echo "ERROR: ${variable_name} contains invalid region '${region}'" >&2
+      return 1
+    fi
+    case "$seen" in
+      *"|${region}|"*)
+        echo "ERROR: ${variable_name} contains duplicate region ${region}" >&2
+        return 1
+        ;;
+    esac
+    seen="${seen}${region}|"
+  done
+}
+
+# Emit every direct binding for an exact principal as a stable token. IAM
+# conditions are deliberately preserved: flatten/value queries discard that
+# distinction and can make a time- or resource-conditioned grant look like the
+# unconditional binding a runtime contract requires.
+iam_direct_binding_tokens_for_member() {
+  local member="$1"
+  shift
+  local policy_json
+  policy_json="$("$@" --format=json)" || return 1
+  printf '%s' "$policy_json" | python3 -c '
+import json
+import sys
+
+member = sys.argv[1]
+policy = json.load(sys.stdin)
+tokens = []
+for binding in policy.get("bindings", []) or []:
+    if member not in (binding.get("members", []) or []):
+        continue
+    role = binding.get("role")
+    if not isinstance(role, str) or not role:
+        raise SystemExit("direct IAM binding has no role")
+    prefix = "conditional:" if "condition" in binding and binding["condition"] is not None else ""
+    tokens.append(prefix + role)
+for token in sorted(tokens):
+    print(token)
+' "$member"
+}
+
+iam_member_has_unconditional_role() {
+  local member="$1"
+  local role="$2"
+  shift 2
+  local tokens
+  tokens="$(iam_direct_binding_tokens_for_member "$member" "$@")" || return 1
+  grep -Fxq "$role" <<<"$tokens"
+}
+
+verify_exact_unconditional_roles() {
+  local label="$1"
+  local member="$2"
+  local expected_csv="$3"
+  shift 3
+  local actual
+  local expected
+  actual="$(iam_direct_binding_tokens_for_member "$member" "$@")" || {
+    echo "ERROR: cannot read ${label} IAM policy for ${member}" >&2
+    return 1
+  }
+  expected="$(printf '%s' "$expected_csv" | tr ',' '\n' | sed '/^$/d' | LC_ALL=C sort)"
+  if [ "$actual" != "$expected" ]; then
+    echo "ERROR: ${member} has ${label} bindings '${actual:-<none>}', expected unconditional '${expected:-<none>}'" >&2
+    return 1
+  fi
+}
+
+# Before a removal pass, prove that every direct binding is both
+# unconditional and in the finite set that the pass knows how to reconcile.
+# Unknown/custom/conditional grants stop the run before its first mutation.
+preflight_reconcilable_direct_roles() {
+  local label="$1"
+  local member="$2"
+  local allowed_csv="$3"
+  shift 3
+  local tokens
+  local token
+  local role
+  tokens="$(iam_direct_binding_tokens_for_member "$member" "$@")" || {
+    echo "ERROR: cannot inventory ${label} IAM policy for ${member}" >&2
+    return 1
+  }
+  while IFS= read -r token; do
+    [ -n "$token" ] || continue
+    case "$token" in
+      conditional:*)
+        echo "ERROR: ${member} has unsupported conditional ${label} binding ${token#conditional:}" >&2
+        return 1
+        ;;
+    esac
+    role="$token"
+    case ",${allowed_csv}," in
+      *",${role},"*) ;;
+      *)
+        echo "ERROR: ${member} has unreconcilable ${label} binding ${role}" >&2
+        return 1
+        ;;
+    esac
+  done <<<"$tokens"
+}
+
+verify_no_direct_roles() {
+  local label="$1"
+  local member="$2"
+  local forbidden_csv="$3"
+  shift 3
+  local tokens
+  local token
+  local role
+  tokens="$(iam_direct_binding_tokens_for_member "$member" "$@")" || {
+    echo "ERROR: cannot inspect ${label} IAM policy for ${member}" >&2
+    return 1
+  }
+  while IFS= read -r token; do
+    [ -n "$token" ] || continue
+    role="${token#conditional:}"
+    case ",${forbidden_csv}," in
+      *",${role},"*)
+        echo "ERROR: ${member} retains forbidden ${label} binding ${token}" >&2
+        return 1
+        ;;
+    esac
+  done <<<"$tokens"
+}
+
+is_runtime_service_account() {
+  local candidate="$1"
+  local runtime_account
+  for runtime_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do
+    if [ "$candidate" = "$runtime_account" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Validate the complete direct IAM policy on one of the six runtime service
+# accounts. This pure JSON contract is shared so provisioning and promotion can
+# apply identical semantics without flattening away conditions.
+verify_runtime_service_account_policy_json() {
+  local target_account="$1"
+  local phase="$2"
+  local operator_members_csv="${3:-$TR_RUNTIME_SERVICE_ACCOUNT_OPERATOR_MEMBERS}"
+  python3 -c '
+import json
+import sys
+
+target, phase, deploy_account, runtime_csv, operator_csv = sys.argv[1:6]
+if phase not in {"preflight", "post"}:
+    raise SystemExit(f"unknown runtime service-account policy phase {phase!r}")
+
+deploy_member = "serviceAccount:" + deploy_account
+runtime_members = {"serviceAccount:" + item for item in runtime_csv.split(",") if item}
+if "serviceAccount:" + target not in runtime_members:
+    raise SystemExit(f"policy target {target!r} is not one of the six runtimes")
+
+operators = operator_csv.split(",") if operator_csv else []
+if any(not item or item != item.strip() for item in operators):
+    raise SystemExit("operator member allowlist contains an empty or padded item")
+if len(set(operators)) != len(operators):
+    raise SystemExit("operator member allowlist contains duplicates")
+valid_prefixes = ("user:", "group:", "serviceAccount:", "domain:", "principal://", "principalSet://")
+for operator in operators:
+    if not operator.startswith(valid_prefixes):
+        raise SystemExit(f"invalid operator IAM member {operator!r}")
+    if operator == deploy_member or operator in runtime_members:
+        raise SystemExit(f"operator allowlist must not contain deploy/runtime member {operator}")
+
+policy = json.load(sys.stdin)
+deploy_bindings = []
+operator_bindings = []
+for binding in policy.get("bindings", []) or []:
+    role = binding.get("role")
+    members = binding.get("members", []) or []
+    if not isinstance(role, str) or not role:
+        raise SystemExit("runtime service-account policy binding has no role")
+    if not isinstance(members, list):
+        raise SystemExit("runtime service-account policy binding members are not a list")
+    condition = binding.get("condition") if "condition" in binding else None
+    for member in members:
+        if not isinstance(member, str) or not member:
+            raise SystemExit("runtime service-account policy has an invalid member")
+        entry = (role, condition)
+        if member in runtime_members:
+            raise SystemExit(
+                f"split runtime principal {member} has a direct binding on {target}"
+            )
+        if member == deploy_member:
+            deploy_bindings.append(entry)
+            continue
+        if member in operators:
+            operator_bindings.append((member, role, condition))
+            continue
+        raise SystemExit(f"unapproved principal {member} has a direct binding on {target}")
+
+expected = [("roles/iam.serviceAccountUser", None)]
+if phase == "post" and deploy_bindings != expected:
+    raise SystemExit(
+        f"deploy principal bindings are {deploy_bindings!r}, expected {expected!r}"
+    )
+if phase == "preflight" and deploy_bindings not in ([], expected):
+    raise SystemExit(f"unsafe preexisting deploy bindings {deploy_bindings!r}")
+seen_operators = set()
+for member, role, condition in operator_bindings:
+    if member in seen_operators:
+        raise SystemExit(f"operator {member} has duplicate direct bindings on {target}")
+    seen_operators.add(member)
+    if role != "roles/iam.serviceAccountUser" or condition is not None:
+        raise SystemExit(
+            f"operator {member} must have only unconditional serviceAccountUser"
+        )
+' "$target_account" "$phase" "$DEPLOY_SERVICE_ACCOUNT" \
+    "$(IFS=,; echo "${RUNTIME_SERVICE_ACCOUNTS[*]}")" \
+    "$operator_members_csv"
+}
+
+validate_runtime_service_accounts() {
+  local expected_suffix="@${PROJECT_ID}.iam.gserviceaccount.com"
+  local seen="|"
+  local service_account
+  local account_id
+  for service_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do
+    if [ "$service_account" = "$RUN_SERVICE_ACCOUNT" ]; then
+      echo "ERROR: Cloud Run surface must not reuse legacy RUN_SERVICE_ACCOUNT" >&2
+      return 1
+    fi
+    case "$service_account" in
+      *"$expected_suffix") ;;
+      *)
+        echo "ERROR: runtime service account must belong to ${PROJECT_ID}: ${service_account}" >&2
+        return 1
+        ;;
+    esac
+    account_id="${service_account%@*}"
+    if ! [[ "$account_id" =~ ^[a-z][a-z0-9-]{4,28}[a-z0-9]$ ]]; then
+      echo "ERROR: invalid runtime service account id: ${account_id}" >&2
+      return 1
+    fi
+    case "$seen" in
+      *"|${service_account}|"*)
+        echo "ERROR: runtime service accounts must be distinct: ${service_account}" >&2
+        return 1
+        ;;
+    esac
+    seen="${seen}${service_account}|"
+  done
+  if [ "$DEPLOY_SERVICE_ACCOUNT" = "$PUBLIC_RUN_SERVICE_ACCOUNT" ] ||
+     [ "$DEPLOY_SERVICE_ACCOUNT" = "$ACTIONS_RUN_SERVICE_ACCOUNT" ] ||
+     [ "$DEPLOY_SERVICE_ACCOUNT" = "$CONSOLE_RUN_SERVICE_ACCOUNT" ] ||
+     [ "$DEPLOY_SERVICE_ACCOUNT" = "$CHAT_RUN_SERVICE_ACCOUNT" ] ||
+     [ "$DEPLOY_SERVICE_ACCOUNT" = "$WEBHOOKS_RUN_SERVICE_ACCOUNT" ] ||
+     [ "$DEPLOY_SERVICE_ACCOUNT" = "$INTERNAL_RUN_SERVICE_ACCOUNT" ]; then
+    echo "ERROR: deploy service account must not be a runtime identity" >&2
+    return 1
+  fi
+  case "$DEPLOY_SERVICE_ACCOUNT" in
+    *"$expected_suffix") ;;
+    *)
+      echo "ERROR: deploy service account must belong to ${PROJECT_ID}" >&2
+      return 1
+      ;;
+  esac
+  account_id="${DEPLOY_SERVICE_ACCOUNT%@*}"
+  if ! [[ "$account_id" =~ ^[a-z][a-z0-9-]{4,28}[a-z0-9]$ ]]; then
+    echo "ERROR: invalid deploy service account id: ${account_id}" >&2
+    return 1
+  fi
+  if [ "$DEPLOY_SERVICE_ACCOUNT" = "$RUN_SERVICE_ACCOUNT" ]; then
+    echo "ERROR: deploy service account must not reuse legacy RUN_SERVICE_ACCOUNT" >&2
+    return 1
+  fi
+  if [ "$SYNTHETIC_RUN_SERVICE_ACCOUNT" != "tr-synthetic@${PROJECT_ID}.iam.gserviceaccount.com" ]; then
+    echo "ERROR: synthetic jobs require canonical tr-synthetic identity in ${PROJECT_ID}" >&2
+    return 1
+  fi
+  if [ "$SYNTHETIC_RUN_SERVICE_ACCOUNT" = "$RUN_SERVICE_ACCOUNT" ] ||
+     [ "$SYNTHETIC_RUN_SERVICE_ACCOUNT" = "$DEPLOY_SERVICE_ACCOUNT" ] ||
+     is_runtime_service_account "$SYNTHETIC_RUN_SERVICE_ACCOUNT"; then
+    echo "ERROR: synthetic job identity must be distinct from deploy, legacy, and six runtimes" >&2
+    return 1
+  fi
+  if ! printf '%s' "$TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON" | python3 -c '
+import json
+import sys
+
+try:
+    value = json.load(sys.stdin)
+except json.JSONDecodeError:
+    raise SystemExit(1) from None
+if not isinstance(value, dict):
+    raise SystemExit(1)
+'; then
+    echo "ERROR: TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON must be a JSON object" >&2
+    return 1
+  fi
+  case "$TR_RETIRE_LEGACY_RUN_SERVICE_ACCOUNT_IAM" in
+    0|1) ;;
+    *)
+      echo "ERROR: TR_RETIRE_LEGACY_RUN_SERVICE_ACCOUNT_IAM must be 0 or 1" >&2
+      return 1
+      ;;
+  esac
+  if [ "$TR_BILLING_SERVICE" != "$INTERNAL_SERVICE" ]; then
+    echo "ERROR: TR_BILLING_SERVICE and TR_INTERNAL_SERVICE must resolve to the same Cloud Run service" >&2
+    return 1
+  fi
+  validate_nonempty_region_list TR_CONTROL_PLANE_REGIONS "$TR_CONTROL_PLANE_REGIONS"
+  validate_nonempty_region_list TR_SYNTHETIC_MONITOR_REGIONS "$TR_SYNTHETIC_MONITOR_REGIONS"
+  validate_nonempty_region_list TR_SYNTHETIC_THROUGHPUT_REGION "$TR_SYNTHETIC_THROUGHPUT_REGION"
+  validate_nonempty_region_list TR_SYNTHETIC_IMAGE_REGION "$TR_SYNTHETIC_IMAGE_REGION"
+  validate_nonempty_region_list TR_SYNTHETIC_VIDEO_REGION "$TR_SYNTHETIC_VIDEO_REGION"
+}
 
 read_key_file_var() {
   local env_name="$1"
@@ -154,14 +763,9 @@ ensure_secret_value() {
 ensure_project_role() {
   local member="$1"
   local role="$2"
-  local bound_roles=""
-  if bound_roles="$(gc projects get-iam-policy "$PROJECT_ID" \
-      --flatten='bindings[].members' \
-      --filter="bindings.role=${role} AND bindings.members=${member}" \
-      --format='value(bindings.role)' 2>/dev/null)"; then
-    if grep -Fxq "$role" <<<"$bound_roles"; then
-      return 0
-    fi
+  if iam_member_has_unconditional_role \
+      "$member" "$role" gc projects get-iam-policy "$PROJECT_ID" 2>/dev/null; then
+    return 0
   fi
 
   # Retry only etag conflicts. Retrying an authorization failure creates a
@@ -173,6 +777,7 @@ ensure_project_role() {
     if last_stderr="$(gc projects add-iam-policy-binding "$PROJECT_ID" \
         --member="$member" \
         --role="$role" \
+        --condition=None \
         --quiet 2>&1 >/dev/null)"; then
       return 0
     fi

--- a/scripts/deploy/infra.sh
+++ b/scripts/deploy/infra.sh
@@ -6,9 +6,1103 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/deploy/_lib.sh
 source "${SCRIPT_DIR}/_lib.sh"
 
+validate_runtime_service_accounts
+
+GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT_ID="${TR_GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT_ID:-tr-google-data-manager}"
+GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT="${GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT_ID}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+ensure_runtime_service_account() {
+  local service_account="$1"
+  local display_name="$2"
+  local account_id="${service_account%@*}"
+  local describe_error=""
+  if ! describe_error="$(gc iam service-accounts describe "$service_account" \
+      --format='value(email)' 2>&1)"; then
+    if [[ "$describe_error" != *"NOT_FOUND"* ]] &&
+       [[ "$describe_error" != *"not found"* ]]; then
+      echo "ERROR: cannot determine whether ${service_account} exists: ${describe_error}" >&2
+      return 1
+    fi
+    gc iam service-accounts create "$account_id" \
+      --display-name="$display_name" \
+      --description="Dedicated Cloud Run runtime identity for ${display_name}" \
+      --quiet
+  fi
+
+  local actual_email
+  local disabled
+  actual_email="$(gc iam service-accounts describe "$service_account" \
+    --format='value(email)')"
+  disabled="$(gc iam service-accounts describe "$service_account" \
+    --format='value(disabled)')"
+  if [ "$actual_email" != "$service_account" ]; then
+    echo "ERROR: runtime service account post-verification failed: ${service_account}" >&2
+    return 1
+  fi
+  case "$disabled" in
+    ""|False|false|0) ;;
+    *)
+      echo "ERROR: runtime service account is disabled: ${service_account}" >&2
+      return 1
+      ;;
+  esac
+}
+
+policy_roles_for_member() {
+  local member="$1"
+  shift
+  iam_direct_binding_tokens_for_member "$member" "$@"
+}
+
+verify_only_resource_role() {
+  local label="$1"
+  local member="$2"
+  local expected_role="$3"
+  shift 3
+  verify_exact_unconditional_roles "$label" "$member" "$expected_role" "$@"
+}
+
+verify_resource_role_present() {
+  local label="$1"
+  local member="$2"
+  local role="$3"
+  shift 3
+  if ! iam_member_has_unconditional_role "$member" "$role" "$@"; then
+    echo "ERROR: ${member} is missing desired ${label} binding ${role}" >&2
+    return 1
+  fi
+}
+
+remove_project_role_if_present() {
+  local member="$1"
+  local role="$2"
+  local roles
+  roles="$(policy_roles_for_member "$member" gc projects get-iam-policy "$PROJECT_ID")" || {
+    echo "ERROR: cannot read project IAM while checking ${member}" >&2
+    return 1
+  }
+  if grep -Fxq "$role" <<<"$roles"; then
+    gc projects remove-iam-policy-binding "$PROJECT_ID" \
+      --member="$member" \
+      --role="$role" \
+      --quiet >/dev/null
+  fi
+  roles="$(policy_roles_for_member "$member" gc projects get-iam-policy "$PROJECT_ID")" || {
+    echo "ERROR: cannot post-verify project IAM for ${member}" >&2
+    return 1
+  }
+  if grep -Fxq "$role" <<<"$roles"; then
+    echo "ERROR: ${member} retains forbidden project-wide ${role}" >&2
+    return 1
+  fi
+}
+
+remove_spanner_role_if_present() {
+  local member="$1"
+  local role="$2"
+  local roles
+  roles="$(policy_roles_for_member "$member" gc spanner databases get-iam-policy \
+    "$SPANNER_DATABASE_ID" --instance="$SPANNER_INSTANCE_ID")" || {
+    echo "ERROR: cannot read Spanner database IAM for ${member}" >&2
+    return 1
+  }
+  if grep -Fxq "$role" <<<"$roles"; then
+    gc spanner databases remove-iam-policy-binding "$SPANNER_DATABASE_ID" \
+      --instance="$SPANNER_INSTANCE_ID" \
+      --member="$member" \
+      --role="$role" \
+      --quiet >/dev/null
+  fi
+}
+
+remove_bigtable_role_if_present() {
+  local member="$1"
+  local role="$2"
+  local roles
+  roles="$(policy_roles_for_member "$member" gc bigtable instances get-iam-policy \
+    "$BIGTABLE_INSTANCE_ID")" || {
+    echo "ERROR: cannot read Bigtable instance IAM for ${member}" >&2
+    return 1
+  }
+  if grep -Fxq "$role" <<<"$roles"; then
+    gc bigtable instances remove-iam-policy-binding "$BIGTABLE_INSTANCE_ID" \
+      --member="$member" \
+      --role="$role" \
+      --quiet >/dev/null
+  fi
+}
+
+remove_kms_role_if_present() {
+  local member="$1"
+  local role="$2"
+  local key_id="${3:-$BYOK_KMS_KEY_ID}"
+  local roles
+  roles="$(policy_roles_for_member "$member" gc kms keys get-iam-policy \
+    "$key_id" --keyring="$KMS_KEYRING_ID" --location="$REGION")" || {
+    echo "ERROR: cannot read ${key_id} KMS IAM for ${member}" >&2
+    return 1
+  }
+  if grep -Fxq "$role" <<<"$roles"; then
+    gc kms keys remove-iam-policy-binding "$key_id" \
+      --keyring="$KMS_KEYRING_ID" \
+      --location="$REGION" \
+      --member="$member" \
+      --role="$role" \
+      --quiet >/dev/null
+  fi
+}
+
+verify_synthetic_service_account_policy() {
+  local phase="$1"
+  local policy_json=""
+  case "$phase" in
+    preflight|post) ;;
+    *) echo "ERROR: invalid synthetic service-account IAM phase ${phase}" >&2; return 2 ;;
+  esac
+  policy_json="$(gc iam service-accounts get-iam-policy \
+    "$SYNTHETIC_RUN_SERVICE_ACCOUNT" --format=json)" || return 1
+  if ! printf '%s' "$policy_json" | python3 -c '
+import json
+import sys
+
+phase, deploy_member = sys.argv[1:3]
+policy = json.load(sys.stdin)
+bindings = policy.get("bindings") or []
+expected = [{"role": "roles/iam.serviceAccountUser", "members": [deploy_member]}]
+if phase == "preflight" and bindings not in ([], expected):
+    raise SystemExit("synthetic service-account IAM has unsafe preexisting bindings")
+if phase == "post" and bindings != expected:
+    raise SystemExit("synthetic service-account IAM differs from exact deploy-only actAs")
+' "$phase" "serviceAccount:${DEPLOY_SERVICE_ACCOUNT}"; then
+    echo "ERROR: dedicated synthetic identity IAM is not the exact deploy-only actAs policy" >&2
+    return 1
+  fi
+}
+
+verify_synthetic_data_iam_empty() {
+  local member="serviceAccount:${SYNTHETIC_RUN_SERVICE_ACCOUNT}"
+  local key_id=""
+  verify_exact_unconditional_roles \
+    "synthetic identity project" "$member" "" \
+    gc projects get-iam-policy "$PROJECT_ID" || return 1
+  verify_identity_resource_manager_ancestors_empty \
+    "synthetic identity" "$SYNTHETIC_RUN_SERVICE_ACCOUNT" || return 1
+  verify_exact_unconditional_roles \
+    "synthetic identity Spanner instance" "$member" "" \
+    gc spanner instances get-iam-policy "$SPANNER_INSTANCE_ID" || return 1
+  verify_exact_unconditional_roles \
+    "synthetic identity Spanner database" "$member" "" \
+    gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID" || return 1
+  verify_exact_unconditional_roles \
+    "synthetic identity Bigtable instance" "$member" "" \
+    gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID" || return 1
+  verify_exact_unconditional_roles \
+    "synthetic identity Bigtable generation table" "$member" "" \
+    gc bigtable tables get-iam-policy "$BIGTABLE_GENERATION_TABLE" \
+    --instance="$BIGTABLE_INSTANCE_ID" || return 1
+  verify_exact_unconditional_roles \
+    "synthetic identity KMS key ring" "$member" "" \
+    gc kms keyrings get-iam-policy "$KMS_KEYRING_ID" \
+    --location="$REGION" || return 1
+  for key_id in "$BYOK_KMS_KEY_ID" "$GOOGLE_ADS_KMS_KEY_ID"; do
+    verify_exact_unconditional_roles \
+      "synthetic identity KMS key ${key_id}" "$member" "" \
+      gc kms keys get-iam-policy "$key_id" \
+      --keyring="$KMS_KEYRING_ID" --location="$REGION" || return 1
+  done
+}
+
+verify_legacy_runtime_retirement_ready() {
+  if [ "$CONSOLE_SERVICE" = "$LEGACY_CONSOLE_SERVICE" ]; then
+    echo "ERROR: cannot retire legacy IAM; split console ${CONSOLE_SERVICE} aliases the legacy monolith" >&2
+    return 1
+  fi
+  local -a services=(
+    "$PUBLIC_SERVICE"
+    "$ACTIONS_SERVICE"
+    "$CONSOLE_SERVICE"
+    "$CHAT_SERVICE"
+    "$WEBHOOKS_SERVICE"
+    "$INTERNAL_SERVICE"
+  )
+  local -a surfaces=(public actions console chat webhooks internal)
+  local -a identities=(
+    "$PUBLIC_RUN_SERVICE_ACCOUNT"
+    "$ACTIONS_RUN_SERVICE_ACCOUNT"
+    "$CONSOLE_RUN_SERVICE_ACCOUNT"
+    "$CHAT_RUN_SERVICE_ACCOUNT"
+    "$WEBHOOKS_RUN_SERVICE_ACCOUNT"
+    "$INTERNAL_RUN_SERVICE_ACCOUNT"
+  )
+  local -a regions
+  local region
+  local index
+  local service_json
+  local revisions
+  local revision
+  local revision_json
+  IFS=',' read -ra regions <<<"$TR_CONTROL_PLANE_REGIONS"
+  for region in "${regions[@]}"; do
+    [ -n "$region" ] || continue
+    for index in 0 1 2 3 4 5; do
+      service_json="$(gc run services describe "${services[$index]}" \
+        --region="$region" --format=json)" || {
+        echo "ERROR: cannot retire legacy IAM; ${services[$index]} is absent in ${region}" >&2
+        return 1
+      }
+      revisions="$(printf '%s' "$service_json" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+conditions = data.get("status", {}).get("conditions", [])
+if not any(
+    item.get("type") == "Ready"
+    and str(item.get("status", "")).casefold() == "true"
+    for item in conditions
+):
+    raise SystemExit("service is not Ready")
+traffic = [
+    item
+    for item in data.get("status", {}).get("traffic", [])
+    if int(item.get("percent", 0) or 0) > 0
+]
+if not traffic or sum(int(item.get("percent", 0) or 0) for item in traffic) != 100:
+    raise SystemExit("serving traffic is absent or does not total 100 percent")
+for item in traffic:
+    revision = item.get("revisionName")
+    if not revision:
+        raise SystemExit("serving traffic does not name an immutable revision")
+    print(revision)
+')" || {
+        echo "ERROR: cannot retire legacy IAM; ${services[$index]} traffic is unsafe in ${region}" >&2
+        return 1
+      }
+      for revision in $revisions; do
+        revision_json="$(gc run revisions describe "$revision" \
+          --region="$region" --format=json)" || {
+          echo "ERROR: cannot inspect serving revision ${revision} in ${region}" >&2
+          return 1
+        }
+        if ! printf '%s' "$revision_json" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+expected_surface, expected_identity = sys.argv[1:3]
+spec = data.get("spec", {})
+actual_identity = spec.get("serviceAccountName")
+if actual_identity != expected_identity:
+    raise SystemExit(
+        f"service account is {actual_identity!r}, expected {expected_identity!r}"
+    )
+containers = spec.get("containers", [])
+if len(containers) != 1:
+    raise SystemExit("revision must have exactly one container")
+surface = next(
+    (
+        item.get("value")
+        for item in containers[0].get("env", [])
+        if item.get("name") == "TR_SERVICE_SURFACE"
+    ),
+    None,
+)
+if surface != expected_surface:
+    raise SystemExit(f"surface is {surface!r}, expected {expected_surface!r}")
+' "${surfaces[$index]}" "${identities[$index]}"; then
+          echo "ERROR: cannot retire legacy IAM; serving revision ${revision} is not isolated" >&2
+          return 1
+        fi
+      done
+    done
+  done
+}
+
+verify_identity_resource_manager_ancestors_empty() {
+  local label="$1"
+  local service_account="$2"
+  local member="serviceAccount:${service_account}"
+  local ancestors_json
+  local ancestors
+  local ancestor_type
+  local ancestor_id
+
+  ancestors_json="$(gc projects get-ancestors "$PROJECT_ID" --format=json)" || {
+    echo "ERROR: cannot inventory Resource Manager ancestors for ${label}" >&2
+    return 1
+  }
+  ancestors="$(printf '%s' "$ancestors_json" | python3 -c '
+import json
+import sys
+
+items = json.load(sys.stdin)
+if not isinstance(items, list):
+    raise SystemExit("project ancestor inventory is not a list")
+seen = set()
+projects = []
+organizations = []
+for item in items:
+    if not isinstance(item, dict):
+        raise SystemExit("project ancestor entry is not an object")
+    kind = str(item.get("type") or "").casefold()
+    identifier = str(item.get("id") or "")
+    if kind not in {"project", "folder", "organization"} or not identifier:
+        raise SystemExit("project ancestor entry has an invalid type or id")
+    key = (kind, identifier)
+    if key in seen:
+        raise SystemExit("project ancestor inventory contains a duplicate")
+    seen.add(key)
+    if kind == "project":
+        projects.append(identifier)
+    elif kind == "organization":
+        organizations.append(identifier)
+    print(kind, identifier, sep="\t")
+if len(projects) != 1 or projects[0] not in set(sys.argv[1:3]):
+    raise SystemExit("project ancestor inventory does not identify this project")
+if len(organizations) > 1:
+    raise SystemExit("project ancestor inventory has multiple organizations")
+' "$PROJECT_ID" "$PROJECT_NUMBER")" || {
+    echo "ERROR: malformed Resource Manager ancestor inventory for ${label}" >&2
+    return 1
+  }
+
+  while IFS=$'\t' read -r ancestor_type ancestor_id; do
+    [ -n "$ancestor_id" ] || continue
+    case "$ancestor_type" in
+      project) ;;
+      folder)
+        verify_exact_unconditional_roles \
+          "${label} inherited folder ${ancestor_id}" "$member" "" \
+          gc resource-manager folders get-iam-policy "$ancestor_id" \
+          --format=json || return 1
+        ;;
+      organization)
+        verify_exact_unconditional_roles \
+          "${label} inherited organization ${ancestor_id}" "$member" "" \
+          gc organizations get-iam-policy "$ancestor_id" \
+          --format=json || return 1
+        ;;
+      *)
+        echo "ERROR: unsupported Resource Manager ancestor ${ancestor_type}/${ancestor_id}" >&2
+        return 1
+        ;;
+    esac
+  done <<<"$ancestors"
+}
+
+verify_synthetic_retirement_identity_ready() {
+  local expected_identity="tr-synthetic@${PROJECT_ID}.iam.gserviceaccount.com"
+  local member="serviceAccount:${SYNTHETIC_RUN_SERVICE_ACCOUNT}"
+  local account_json
+  local account_policy
+  local key_id
+
+  if [ "$SYNTHETIC_RUN_SERVICE_ACCOUNT" != "$expected_identity" ]; then
+    echo "ERROR: legacy IAM retirement requires the canonical dedicated synthetic identity ${expected_identity}" >&2
+    return 1
+  fi
+  if [ "$SYNTHETIC_RUN_SERVICE_ACCOUNT" = "$RUN_SERVICE_ACCOUNT" ]; then
+    echo "ERROR: legacy IAM retirement cannot reuse RUN_SERVICE_ACCOUNT for synthetic Jobs" >&2
+    return 1
+  fi
+
+  account_json="$(gc iam service-accounts describe \
+    "$SYNTHETIC_RUN_SERVICE_ACCOUNT" --format=json)" || {
+    echo "ERROR: dedicated synthetic identity is not provisioned; separate narrow IAM approval is required" >&2
+    return 1
+  }
+  if ! printf '%s' "$account_json" | python3 -c '
+import json
+import sys
+
+account = json.load(sys.stdin)
+if account.get("email") != sys.argv[1] or account.get("disabled", False) is not False:
+    raise SystemExit("synthetic identity is missing, disabled, or renamed")
+' "$SYNTHETIC_RUN_SERVICE_ACCOUNT"; then
+    echo "ERROR: dedicated synthetic identity is missing, disabled, or renamed" >&2
+    return 1
+  fi
+
+  account_policy="$(gc iam service-accounts get-iam-policy \
+    "$SYNTHETIC_RUN_SERVICE_ACCOUNT" --format=json)" || {
+    echo "ERROR: cannot read dedicated synthetic identity IAM" >&2
+    return 1
+  }
+  if ! printf '%s' "$account_policy" | python3 -c '
+import json
+import sys
+
+policy = json.load(sys.stdin)
+bindings = policy.get("bindings") or []
+if len(bindings) != 1:
+    raise SystemExit("synthetic identity IAM binding inventory differs")
+binding = bindings[0]
+if binding.get("role") != "roles/iam.serviceAccountUser":
+    raise SystemExit("synthetic identity actAs role differs")
+if binding.get("condition") is not None:
+    raise SystemExit("synthetic identity actAs grant is conditional")
+if (binding.get("members") or []) != [sys.argv[1]]:
+    raise SystemExit("synthetic identity actAs member inventory differs")
+' "serviceAccount:${DEPLOY_SERVICE_ACCOUNT}"; then
+    echo "ERROR: dedicated synthetic identity IAM is not the narrow reviewed policy" >&2
+    return 1
+  fi
+
+  verify_exact_unconditional_roles \
+    "synthetic identity project" "$member" "" \
+    gc projects get-iam-policy "$PROJECT_ID" || return 1
+  verify_identity_resource_manager_ancestors_empty \
+    "synthetic identity" "$SYNTHETIC_RUN_SERVICE_ACCOUNT" || return 1
+  verify_exact_unconditional_roles \
+    "synthetic identity Spanner instance" "$member" "" \
+    gc spanner instances get-iam-policy "$SPANNER_INSTANCE_ID" || return 1
+  verify_exact_unconditional_roles \
+    "synthetic identity Spanner database" "$member" "" \
+    gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID" || return 1
+  verify_exact_unconditional_roles \
+    "synthetic identity Bigtable instance" "$member" "" \
+    gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID" || return 1
+  verify_exact_unconditional_roles \
+    "synthetic identity Bigtable generation table" "$member" "" \
+    gc bigtable tables get-iam-policy "$BIGTABLE_GENERATION_TABLE" \
+    --instance="$BIGTABLE_INSTANCE_ID" || return 1
+  verify_exact_unconditional_roles \
+    "synthetic identity KMS key ring" "$member" "" \
+    gc kms keyrings get-iam-policy "$KMS_KEYRING_ID" \
+    --location="$REGION" || return 1
+  for key_id in "$BYOK_KMS_KEY_ID" "$GOOGLE_ADS_KMS_KEY_ID"; do
+    verify_exact_unconditional_roles \
+      "synthetic identity KMS key ${key_id}" "$member" "" \
+      gc kms keys get-iam-policy "$key_id" \
+      --keyring="$KMS_KEYRING_ID" --location="$REGION" || return 1
+  done
+}
+
+verify_legacy_synthetic_secret_access_ready() {
+  local expected_names="|trustedrouter-observer-internal-token|trustedrouter-synthetic-monitor-api-key|"
+  local seen_names="|"
+  local inventory_json
+  local inventory
+  local secret_name
+  local policy_json
+  local member="serviceAccount:${SYNTHETIC_RUN_SERVICE_ACCOUNT}"
+
+  inventory_json="$(gc secrets list --format=json)" || {
+    echo "ERROR: cannot inventory every Secret Manager resource before legacy IAM retirement" >&2
+    return 1
+  }
+  inventory="$(printf '%s' "$inventory_json" | python3 -c '
+import json
+import sys
+
+items = json.load(sys.stdin)
+if not isinstance(items, list):
+    raise SystemExit("secret inventory is not a list")
+names = []
+for item in items:
+    if not isinstance(item, dict):
+        raise SystemExit("secret inventory entry is not an object")
+    raw_name = item.get("name")
+    if not isinstance(raw_name, str) or not raw_name:
+        raise SystemExit("secret inventory entry has no name")
+    name = raw_name.rstrip("/").rsplit("/", 1)[-1]
+    if not name:
+        raise SystemExit("secret inventory entry has an invalid name")
+    names.append(name)
+if len(names) != len(set(names)):
+    raise SystemExit("secret inventory contains duplicate names")
+print("\n".join(sorted(names)))
+')" || {
+    echo "ERROR: malformed Secret Manager inventory before legacy IAM retirement" >&2
+    return 1
+  }
+
+  while IFS= read -r secret_name; do
+    [ -n "$secret_name" ] || continue
+    case "$expected_names" in
+      *"|${secret_name}|"*)
+        seen_names="${seen_names}${secret_name}|"
+        ;;
+      *)
+        verify_exact_unconditional_roles \
+          "non-synthetic secret ${secret_name}" "$member" "" \
+          gc secrets get-iam-policy "$secret_name" || return 1
+        continue
+        ;;
+    esac
+    policy_json="$(gc secrets get-iam-policy "$secret_name" --format=json)" || {
+      echo "ERROR: cannot read synthetic secret IAM for ${secret_name}" >&2
+      return 1
+    }
+    if ! printf '%s' "$policy_json" | python3 -c '
+import json
+import sys
+
+policy = json.load(sys.stdin)
+expected = sorted(sys.argv[1:])
+bindings = policy.get("bindings") or []
+if len(bindings) != 1:
+    raise SystemExit("synthetic secret IAM binding inventory differs")
+binding = bindings[0]
+if binding.get("role") != "roles/secretmanager.secretAccessor":
+    raise SystemExit("synthetic secret IAM role differs")
+if binding.get("condition") is not None:
+    raise SystemExit("synthetic secret IAM grant is conditional")
+members = binding.get("members") or []
+if len(members) != len(set(members)) or sorted(members) != expected:
+    raise SystemExit("synthetic secret IAM consumer inventory differs")
+' "serviceAccount:${INTERNAL_RUN_SERVICE_ACCOUNT}" \
+      "serviceAccount:${SYNTHETIC_RUN_SERVICE_ACCOUNT}"; then
+      echo "ERROR: ${secret_name} must have exactly the internal and dedicated synthetic consumers" >&2
+      return 1
+    fi
+  done <<<"$inventory"
+
+  for secret_name in \
+    trustedrouter-observer-internal-token \
+    trustedrouter-synthetic-monitor-api-key; do
+    case "$seen_names" in
+      *"|${secret_name}|"*) ;;
+      *)
+        echo "ERROR: required synthetic secret ${secret_name} is absent from the project inventory" >&2
+        return 1
+        ;;
+    esac
+  done
+}
+
+synthetic_job_inventory_lines() {
+  local -a monitor_regions
+  local monitor_region
+  IFS=',' read -ra monitor_regions <<<"$TR_SYNTHETIC_MONITOR_REGIONS"
+  for monitor_region in "${monitor_regions[@]}"; do
+    printf '%s\t%s\t%s\n' \
+      "$monitor_region" \
+      "trusted-router-synthetic-${monitor_region//[^a-zA-Z0-9-]/-}" \
+      "trusted-router-synthetic-${monitor_region//[^a-zA-Z0-9-]/-}-every-three-minutes"
+  done
+  printf '%s\t%s\t%s\n' \
+    "$TR_SYNTHETIC_THROUGHPUT_REGION" \
+    "trusted-router-throughput-${TR_SYNTHETIC_THROUGHPUT_REGION}" \
+    "trusted-router-throughput-${TR_SYNTHETIC_THROUGHPUT_REGION}-every-five-minutes"
+  printf '%s\t%s\t%s\n' \
+    "$TR_SYNTHETIC_IMAGE_REGION" \
+    "trusted-router-image-generation-${TR_SYNTHETIC_IMAGE_REGION}" \
+    "trusted-router-image-generation-${TR_SYNTHETIC_IMAGE_REGION}-every-six-hours"
+  printf '%s\t%s\t%s\n' \
+    "$TR_SYNTHETIC_VIDEO_REGION" \
+    "trusted-router-video-generation-${TR_SYNTHETIC_VIDEO_REGION}" \
+    "trusted-router-video-generation-${TR_SYNTHETIC_VIDEO_REGION}-daily"
+}
+
+cloud_run_inventory_lines() {
+  local kind="$1"
+  local resources_json
+  resources_json="$(gc run "$kind" list --format=json)" || {
+    echo "ERROR: cannot list Cloud Run ${kind} in all regions" >&2
+    return 1
+  }
+  printf '%s' "$resources_json" | python3 -c '
+import json
+import sys
+
+kind = sys.argv[1]
+items = json.load(sys.stdin)
+if not isinstance(items, list):
+    raise SystemExit(f"Cloud Run {kind} inventory is not a list")
+seen = set()
+for item in items:
+    metadata = item.get("metadata", {}) or {}
+    raw_name = metadata.get("name") or item.get("name")
+    if not isinstance(raw_name, str) or not raw_name:
+        raise SystemExit(f"Cloud Run {kind} inventory entry has no name")
+    name = raw_name.rsplit("/", 1)[-1]
+    labels = metadata.get("labels", {}) or {}
+    annotations = metadata.get("annotations", {}) or {}
+    region = (
+        labels.get("cloud.googleapis.com/location")
+        or annotations.get("run.googleapis.com/region")
+        or item.get("location")
+    )
+    if not region and "/locations/" in raw_name:
+        region = raw_name.split("/locations/", 1)[1].split("/", 1)[0]
+    if not isinstance(region, str) or not region:
+        raise SystemExit(f"Cloud Run {kind} inventory cannot resolve region for {name}")
+    key = (region, name)
+    if key in seen:
+        raise SystemExit(f"Cloud Run {kind} inventory repeats {region}/{name}")
+    seen.add(key)
+    print(region, name, sep="\t")
+' "$kind"
+}
+
+cloud_run_job_service_account() {
+  local job_name="$1"
+  local region="$2"
+  local job_json
+  job_json="$(gc run jobs describe "$job_name" --region="$region" --format=json)" || {
+    echo "ERROR: cannot inspect Cloud Run job ${region}/${job_name}" >&2
+    return 1
+  }
+  printf '%s' "$job_json" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+root = data.get("spec", {}).get("template", {})
+values = []
+def visit(value):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key in {"serviceAccount", "serviceAccountName"} and isinstance(child, str):
+                values.append(child)
+            elif isinstance(child, (dict, list)):
+                visit(child)
+    elif isinstance(value, list):
+        for child in value:
+            visit(child)
+visit(root)
+values = sorted(set(values))
+if len(values) != 1:
+    raise SystemExit(f"job execution template exposes {len(values)} service accounts")
+print(values[0])
+'
+}
+
+verify_legacy_cloud_run_service_inventory() {
+  local inventory
+  local region
+  local service_name
+  local service_json
+  local revisions
+  local revision
+  local revision_json
+  inventory="$(cloud_run_inventory_lines services)" || return 1
+  while IFS=$'\t' read -r region service_name; do
+    [ -n "$service_name" ] || continue
+    service_json="$(gc run services describe "$service_name" \
+      --region="$region" --format=json)" || {
+      echo "ERROR: cannot inspect inventoried Cloud Run service ${region}/${service_name}" >&2
+      return 1
+    }
+    revisions="$(printf '%s' "$service_json" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+legacy = sys.argv[1]
+template = data.get("spec", {}).get("template", {})
+pod_spec = template.get("spec", template)
+if pod_spec.get("serviceAccountName") == legacy or pod_spec.get("serviceAccount") == legacy:
+    raise SystemExit("service template still names the legacy runtime identity")
+for item in data.get("status", {}).get("traffic", []) or []:
+    if int(item.get("percent", 0) or 0) <= 0:
+        continue
+    revision = item.get("revisionName")
+    if not revision:
+        raise SystemExit("serving traffic does not name an immutable revision")
+    print(revision)
+' "$RUN_SERVICE_ACCOUNT")" || {
+      echo "ERROR: legacy IAM retirement inventory rejected ${region}/${service_name}" >&2
+      return 1
+    }
+    while IFS= read -r revision; do
+      [ -n "$revision" ] || continue
+      revision_json="$(gc run revisions describe "$revision" \
+        --region="$region" --format=json)" || {
+        echo "ERROR: cannot inspect serving revision ${region}/${revision}" >&2
+        return 1
+      }
+      if ! printf '%s' "$revision_json" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+spec = data.get("spec", {})
+identity = spec.get("serviceAccountName") or spec.get("serviceAccount")
+if identity == sys.argv[1]:
+    raise SystemExit("serving revision still names the legacy runtime identity")
+' "$RUN_SERVICE_ACCOUNT"; then
+        echo "ERROR: cannot retire legacy IAM while ${region}/${revision} still serves" >&2
+        return 1
+      fi
+    done <<<"$revisions"
+  done <<<"$inventory"
+}
+
+verify_legacy_synthetic_jobs_ready() {
+  local expected_inventory
+  local actual_inventory
+  local expected_keys="|"
+  local seen_keys="|"
+  local region
+  local job_name
+  local scheduler_name
+  local key
+  local identity
+  local job_policy_json
+  local scheduler_json
+  local member="serviceAccount:${SYNTHETIC_RUN_SERVICE_ACCOUNT}"
+  expected_inventory="$(synthetic_job_inventory_lines)" || return 1
+  while IFS=$'\t' read -r region job_name scheduler_name; do
+    [ -n "$job_name" ] || continue
+    key="${region}/${job_name}"
+    case "$expected_keys" in
+      *"|${key}|"*)
+        echo "ERROR: synthetic job inventory repeats ${key}" >&2
+        return 1
+        ;;
+    esac
+    expected_keys="${expected_keys}${key}|"
+  done <<<"$expected_inventory"
+
+  actual_inventory="$(cloud_run_inventory_lines jobs)" || return 1
+  while IFS=$'\t' read -r region job_name; do
+    [ -n "$job_name" ] || continue
+    key="${region}/${job_name}"
+    identity="$(cloud_run_job_service_account "$job_name" "$region")" || return 1
+    if [ "$identity" = "$RUN_SERVICE_ACCOUNT" ]; then
+      echo "ERROR: Cloud Run job ${key} still uses legacy identity ${RUN_SERVICE_ACCOUNT}" >&2
+      return 1
+    fi
+    case "$expected_keys" in
+      *"|${key}|"*)
+        if [ "$identity" != "$SYNTHETIC_RUN_SERVICE_ACCOUNT" ]; then
+          echo "ERROR: canonical synthetic job ${key} uses ${identity}, expected ${SYNTHETIC_RUN_SERVICE_ACCOUNT}" >&2
+          return 1
+        fi
+        seen_keys="${seen_keys}${key}|"
+        ;;
+    esac
+  done <<<"$actual_inventory"
+
+  while IFS=$'\t' read -r region job_name scheduler_name; do
+    [ -n "$job_name" ] || continue
+    key="${region}/${job_name}"
+    case "$seen_keys" in
+      *"|${key}|"*) ;;
+      *)
+        echo "ERROR: canonical synthetic job ${key} is absent from the all-region inventory" >&2
+        return 1
+        ;;
+    esac
+    job_policy_json="$(gc run jobs get-iam-policy "$job_name" \
+      --region="$region" --format=json)" || {
+      echo "ERROR: cannot read canonical synthetic job IAM for ${key}" >&2
+      return 1
+    }
+    if ! printf '%s' "$job_policy_json" | python3 -c '
+import json
+import sys
+
+policy = json.load(sys.stdin)
+bindings = policy.get("bindings") or []
+if len(bindings) != 1:
+    raise SystemExit("synthetic job IAM binding inventory differs")
+binding = bindings[0]
+if binding.get("role") != "roles/run.invoker":
+    raise SystemExit("synthetic job IAM role differs")
+if binding.get("condition") is not None:
+    raise SystemExit("synthetic job invoker grant is conditional")
+members = binding.get("members") or []
+if members != [sys.argv[1]]:
+    raise SystemExit("synthetic job invoker inventory differs")
+' "$member"; then
+      echo "ERROR: canonical synthetic job ${key} must have only the dedicated synthetic invoker" >&2
+      return 1
+    fi
+    scheduler_json="$(gc scheduler jobs describe "$scheduler_name" \
+      --location="$region" --format=json)" || {
+      echo "ERROR: canonical synthetic scheduler ${region}/${scheduler_name} is absent" >&2
+      return 1
+    }
+    if ! printf '%s' "$scheduler_json" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+expected_identity, expected_uri = sys.argv[1:3]
+target = data.get("httpTarget", {}) or {}
+oauth = target.get("oauthToken", {}) or {}
+if oauth.get("serviceAccountEmail") != expected_identity:
+    raise SystemExit("scheduler OAuth identity is wrong")
+if target.get("uri") != expected_uri:
+    raise SystemExit("scheduler run URI is wrong")
+if str(target.get("httpMethod", "")).upper() != "POST":
+    raise SystemExit("scheduler HTTP method is not POST")
+if str(data.get("state", "")).upper() != "ENABLED":
+    raise SystemExit("scheduler is not enabled")
+' "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
+      "https://${region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${PROJECT_ID}/jobs/${job_name}:run"; then
+      echo "ERROR: canonical synthetic scheduler ${region}/${scheduler_name} is unsafe" >&2
+      return 1
+    fi
+  done <<<"$expected_inventory"
+}
+
+describe_iam_role_definition() {
+  local role="$1"
+  local scope
+  local role_id
+  case "$role" in
+    roles/*)
+      gc iam roles describe "$role" --format=json
+      ;;
+    projects/*/roles/*)
+      scope="${role#projects/}"
+      scope="${scope%%/roles/*}"
+      role_id="${role##*/}"
+      if [ "$scope" != "$PROJECT_ID" ]; then
+        echo "ERROR: project policy references custom role from unexpected project ${scope}" >&2
+        return 1
+      fi
+      gc iam roles describe "$role_id" --format=json
+      ;;
+    organizations/*/roles/*)
+      scope="${role#organizations/}"
+      scope="${scope%%/roles/*}"
+      role_id="${role##*/}"
+      gcloud --billing-project "$PROJECT_ID" iam roles describe "$role_id" \
+        --organization="$scope" --format=json
+      ;;
+    *)
+      echo "ERROR: cannot resolve IAM role definition ${role}" >&2
+      return 1
+      ;;
+  esac
+}
+
+verify_deploy_identity_has_no_project_data_roles() {
+  local member="serviceAccount:${DEPLOY_SERVICE_ACCOUNT}"
+  local tokens
+  local token
+  local role
+  local role_json
+  verify_no_direct_roles \
+    "project" \
+    "$member" \
+    "roles/secretmanager.secretAccessor,roles/secretmanager.admin,roles/spanner.databaseReader,roles/spanner.databaseUser,roles/bigtable.reader,roles/bigtable.user,roles/aiplatform.user,roles/cloudkms.cryptoKeyEncrypter,roles/cloudkms.cryptoKeyDecrypter,roles/cloudkms.cryptoKeyEncrypterDecrypter,roles/iam.serviceAccountUser,roles/iam.serviceAccountTokenCreator,roles/editor,roles/owner" \
+    gc projects get-iam-policy "$PROJECT_ID"
+  tokens="$(iam_direct_binding_tokens_for_member "$member" \
+    gc projects get-iam-policy "$PROJECT_ID")" || {
+    echo "ERROR: cannot inventory deploy identity project roles" >&2
+    return 1
+  }
+  while IFS= read -r token; do
+    [ -n "$token" ] || continue
+    role="${token#conditional:}"
+    role_json="$(describe_iam_role_definition "$role")" || {
+      echo "ERROR: cannot audit permissions in deploy identity role ${role}" >&2
+      return 1
+    }
+    if ! printf '%s' "$role_json" | python3 -c '
+import json
+import sys
+
+role = json.load(sys.stdin)
+forbidden = {
+    "iam.serviceAccounts.actAs",
+    "iam.serviceAccounts.getAccessToken",
+    "secretmanager.versions.access",
+    "spanner.databases.read",
+    "spanner.databases.write",
+    "spanner.sessions.create",
+    "bigtable.tables.readRows",
+    "bigtable.tables.mutateRows",
+    "cloudkms.cryptoKeyVersions.useToDecrypt",
+    "cloudkms.cryptoKeyVersions.useToEncrypt",
+    "aiplatform.endpoints.predict",
+}
+present = sorted(forbidden.intersection(role.get("includedPermissions", []) or []))
+if present:
+    raise SystemExit("forbidden permissions: " + ",".join(present))
+'; then
+      echo "ERROR: deploy identity role ${role} contains actAs, token-minting, or runtime data permissions" >&2
+      return 1
+    fi
+  done <<<"$tokens"
+}
+
+preflight_identity_iam_removal_targets() {
+  local label="$1"
+  local service_account="$2"
+  local member="serviceAccount:${service_account}"
+  local project_roles="roles/secretmanager.secretAccessor,roles/spanner.databaseReader,roles/spanner.databaseUser,roles/bigtable.reader,roles/bigtable.user,roles/aiplatform.user,roles/run.developer,roles/serviceusage.serviceUsageConsumer,roles/editor,roles/owner"
+  local database_roles="roles/spanner.databaseReader,roles/spanner.databaseUser"
+  local bigtable_roles="roles/bigtable.reader,roles/bigtable.user"
+  local kms_roles="roles/cloudkms.cryptoKeyEncrypter,roles/cloudkms.cryptoKeyDecrypter,roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  local key_id
+
+  preflight_reconcilable_direct_roles \
+    "${label} project" "$member" "$project_roles" \
+    gc projects get-iam-policy "$PROJECT_ID"
+  verify_exact_unconditional_roles \
+    "${label} Spanner instance" "$member" "" \
+    gc spanner instances get-iam-policy "$SPANNER_INSTANCE_ID"
+  preflight_reconcilable_direct_roles \
+    "${label} Spanner database" "$member" "$database_roles" \
+    gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID"
+  preflight_reconcilable_direct_roles \
+    "${label} Bigtable instance" "$member" "$bigtable_roles" \
+    gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID"
+  verify_exact_unconditional_roles \
+    "${label} Bigtable generation table" "$member" "" \
+    gc bigtable tables get-iam-policy "$BIGTABLE_GENERATION_TABLE" \
+    --instance="$BIGTABLE_INSTANCE_ID"
+  verify_exact_unconditional_roles \
+    "${label} KMS key ring" "$member" "" \
+    gc kms keyrings get-iam-policy "$KMS_KEYRING_ID" --location="$REGION"
+  for key_id in "$BYOK_KMS_KEY_ID" "$GOOGLE_ADS_KMS_KEY_ID"; do
+    preflight_reconcilable_direct_roles \
+      "${label} KMS key ${key_id}" "$member" "$kms_roles" \
+      gc kms keys get-iam-policy "$key_id" \
+      --keyring="$KMS_KEYRING_ID" --location="$REGION"
+  done
+}
+
+verify_identity_ancestor_scopes_empty() {
+  local label="$1"
+  local service_account="$2"
+  local member="serviceAccount:${service_account}"
+  verify_exact_unconditional_roles \
+    "${label} Spanner instance" "$member" "" \
+    gc spanner instances get-iam-policy "$SPANNER_INSTANCE_ID"
+  verify_exact_unconditional_roles \
+    "${label} Bigtable generation table" "$member" "" \
+    gc bigtable tables get-iam-policy "$BIGTABLE_GENERATION_TABLE" \
+    --instance="$BIGTABLE_INSTANCE_ID"
+  verify_exact_unconditional_roles \
+    "${label} KMS key ring" "$member" "" \
+    gc kms keyrings get-iam-policy "$KMS_KEYRING_ID" --location="$REGION"
+}
+
+verify_deploy_actas_inventory() {
+  local google_data_manager_service_account="$1"
+  local phase="${2:-post}"
+  local deploy_member="serviceAccount:${DEPLOY_SERVICE_ACCOUNT}"
+  local allowed="|"
+  local seen="|"
+  local accounts_json
+  local accounts
+  local service_account
+  local expected
+  local bindings
+  local runtime_policy
+
+  case "$phase" in
+    preflight|post) ;;
+    *)
+      echo "ERROR: unknown deploy actAs audit phase ${phase}" >&2
+      return 1
+      ;;
+  esac
+
+  for service_account in \
+    "${RUNTIME_SERVICE_ACCOUNTS[@]}" \
+    "$google_data_manager_service_account" \
+    "$SYNTHETIC_RUN_SERVICE_ACCOUNT"; do
+    allowed="${allowed}${service_account}|"
+  done
+  accounts_json="$(gc iam service-accounts list --format=json)" || {
+    echo "ERROR: cannot inventory project service accounts for deploy actAs audit" >&2
+    return 1
+  }
+  accounts="$(printf '%s' "$accounts_json" | python3 -c '
+import json
+import sys
+
+items = json.load(sys.stdin)
+if not isinstance(items, list):
+    raise SystemExit("service-account inventory is not a list")
+emails = []
+for item in items:
+    email = item.get("email")
+    if not isinstance(email, str) or not email:
+        raise SystemExit("service-account inventory entry has no email")
+    emails.append(email)
+if len(set(emails)) != len(emails):
+    raise SystemExit("service-account inventory contains duplicate emails")
+print("\n".join(sorted(emails)))
+')" || {
+    echo "ERROR: malformed project service-account inventory" >&2
+    return 1
+  }
+  while IFS= read -r service_account; do
+    [ -n "$service_account" ] || continue
+    case "$allowed" in
+      *"|${service_account}|"*)
+        expected="roles/iam.serviceAccountUser"
+        seen="${seen}${service_account}|"
+        ;;
+      *) expected="" ;;
+    esac
+    if is_runtime_service_account "$service_account"; then
+      runtime_policy="$(gc iam service-accounts get-iam-policy \
+        "$service_account" --format=json)" || {
+        echo "ERROR: cannot read complete runtime service-account policy ${service_account}" >&2
+        return 1
+      }
+      if ! printf '%s' "$runtime_policy" | \
+          verify_runtime_service_account_policy_json \
+            "$service_account" "$phase"; then
+        echo "ERROR: unsafe direct IAM policy on runtime service account ${service_account}" >&2
+        return 1
+      fi
+      continue
+    fi
+    if [ "$phase" = "preflight" ] && [ -n "$expected" ]; then
+      bindings="$(iam_direct_binding_tokens_for_member "$deploy_member" \
+        gc iam service-accounts get-iam-policy "$service_account")" || {
+        echo "ERROR: cannot preflight deploy identity access on ${service_account}" >&2
+        return 1
+      }
+      if [ -n "$bindings" ] && [ "$bindings" != "$expected" ]; then
+        echo "ERROR: deploy identity has unsafe preexisting bindings on ${service_account}: ${bindings}" >&2
+        return 1
+      fi
+    else
+      verify_exact_unconditional_roles \
+        "deploy identity access on service account ${service_account}" \
+        "$deploy_member" "$expected" \
+        gc iam service-accounts get-iam-policy "$service_account"
+    fi
+  done <<<"$accounts"
+  for service_account in \
+    "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do
+    case "$seen" in
+      *"|${service_account}|"*) ;;
+      *)
+        echo "ERROR: actAs target ${service_account} is absent from service-account inventory" >&2
+        return 1
+        ;;
+    esac
+  done
+  case "$seen" in
+    *"|${SYNTHETIC_RUN_SERVICE_ACCOUNT}|"*) ;;
+    *)
+      echo "ERROR: approved synthetic actAs target ${SYNTHETIC_RUN_SERVICE_ACCOUNT} is absent from service-account inventory" >&2
+      return 1
+      ;;
+  esac
+  if [ "$phase" = "post" ]; then
+    case "$seen" in
+      *"|${google_data_manager_service_account}|"*) ;;
+      *)
+        echo "ERROR: actAs target ${google_data_manager_service_account} is absent from service-account inventory" >&2
+        return 1
+        ;;
+    esac
+  fi
+  verify_deploy_identity_has_no_project_data_roles
+}
+
 log "enabling required GCP APIs"
 gc services enable \
   artifactregistry.googleapis.com \
+  iam.googleapis.com \
   run.googleapis.com \
   secretmanager.googleapis.com \
   cloudscheduler.googleapis.com \
@@ -17,6 +1111,15 @@ gc services enable \
   spanner.googleapis.com \
   bigtableadmin.googleapis.com \
   cloudbuild.googleapis.com
+
+log "ensuring six dedicated Cloud Run runtime identities and synthetic Job identity"
+ensure_runtime_service_account "$PUBLIC_RUN_SERVICE_ACCOUNT" "TrustedRouter public web"
+ensure_runtime_service_account "$ACTIONS_RUN_SERVICE_ACCOUNT" "TrustedRouter anonymous actions"
+ensure_runtime_service_account "$CONSOLE_RUN_SERVICE_ACCOUNT" "TrustedRouter console"
+ensure_runtime_service_account "$CHAT_RUN_SERVICE_ACCOUNT" "TrustedRouter chat proxy"
+ensure_runtime_service_account "$WEBHOOKS_RUN_SERVICE_ACCOUNT" "TrustedRouter webhooks"
+ensure_runtime_service_account "$INTERNAL_RUN_SERVICE_ACCOUNT" "TrustedRouter internal billing"
+ensure_runtime_service_account "$SYNTHETIC_RUN_SERVICE_ACCOUNT" "TrustedRouter synthetic jobs"
 
 log "ensuring Spanner instance/database"
 if ! gc spanner instances describe "$SPANNER_INSTANCE_ID" >/dev/null 2>&1; then
@@ -65,7 +1168,6 @@ fi
 # Keep that capability table-scoped and separate from row-data access.
 BIGTABLE_SCHEMA_ROLE_ID="${TR_BIGTABLE_SCHEMA_ROLE_ID:-trustedRouterBigtableSchemaManager}"
 BIGTABLE_SCHEMA_ROLE="projects/${PROJECT_ID}/roles/${BIGTABLE_SCHEMA_ROLE_ID}"
-DEPLOY_SERVICE_ACCOUNT="${TR_DEPLOY_SERVICE_ACCOUNT:-tr-deploy@${PROJECT_ID}.iam.gserviceaccount.com}"
 OPS_SERVICE_ACCOUNT="${TR_OPS_SERVICE_ACCOUNT:-tr-ops-local@${PROJECT_ID}.iam.gserviceaccount.com}"
 if ! gc iam roles describe "$BIGTABLE_SCHEMA_ROLE_ID" >/dev/null 2>&1; then
   gc iam roles create "$BIGTABLE_SCHEMA_ROLE_ID" \
@@ -94,12 +1196,6 @@ if ! gc kms keys describe "$BYOK_KMS_KEY_ID" \
     --location "$REGION" \
     --purpose=encryption
 fi
-gc kms keys add-iam-policy-binding "$BYOK_KMS_KEY_ID" \
-  --keyring "$KMS_KEYRING_ID" \
-  --location "$REGION" \
-  --member="serviceAccount:${RUN_SERVICE_ACCOUNT}" \
-  --role="roles/cloudkms.cryptoKeyEncrypter" \
-  --quiet >/dev/null
 
 # Google Ads click identifiers use a separate envelope key. The conversion
 # worker can unwrap this key but never receives permission to unwrap BYOK keys.
@@ -110,28 +1206,406 @@ if ! gc kms keys describe "$GOOGLE_ADS_KMS_KEY_ID" \
     --location "$REGION" \
     --purpose=encryption
 fi
+
+# Inventory every direct binding that the reconciliation code can touch before
+# its first removal. This makes drift a no-mutation failure instead of leaving
+# the first few identities partially stripped when a later target surprises us.
+log "preflighting all runtime IAM removal targets and direct ancestor policies"
+if [ "$TR_RETIRE_LEGACY_RUN_SERVICE_ACCOUNT_IAM" = "1" ]; then
+  verify_synthetic_retirement_identity_ready
+fi
+verify_deploy_actas_inventory "$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT" preflight
+verify_synthetic_service_account_policy preflight
+verify_synthetic_data_iam_empty
+for service_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do
+  preflight_identity_iam_removal_targets "split runtime" "$service_account"
+done
+if [ "$TR_RETIRE_LEGACY_RUN_SERVICE_ACCOUNT_IAM" = "1" ]; then
+  log "preflighting complete Cloud Run inventory before legacy IAM retirement"
+  verify_legacy_runtime_retirement_ready
+  verify_legacy_cloud_run_service_inventory
+  verify_legacy_synthetic_secret_access_ready
+  verify_legacy_synthetic_jobs_ready
+  preflight_identity_iam_removal_targets "legacy runtime" "$RUN_SERVICE_ACCOUNT"
+fi
+
+# Install and verify every desired six-runtime grant before removing a live
+# obsolete grant on the same resource. IAM propagation can lag a successful
+# setIamPolicy response, so a remove-then-add transition creates a real serving
+# outage even when the final matrix is correct.
+log "granting and verifying desired runtime IAM before obsolete-role cleanup"
 gc kms keys add-iam-policy-binding "$GOOGLE_ADS_KMS_KEY_ID" \
   --keyring "$KMS_KEYRING_ID" \
   --location "$REGION" \
-  --member="serviceAccount:${RUN_SERVICE_ACCOUNT}" \
+  --member="serviceAccount:${CONSOLE_RUN_SERVICE_ACCOUNT}" \
   --role="roles/cloudkms.cryptoKeyEncrypter" \
   --quiet >/dev/null
+verify_resource_role_present \
+  "Google Ads KMS key" "serviceAccount:${CONSOLE_RUN_SERVICE_ACCOUNT}" \
+  "roles/cloudkms.cryptoKeyEncrypter" \
+  gc kms keys get-iam-policy "$GOOGLE_ADS_KMS_KEY_ID" \
+  --keyring="$KMS_KEYRING_ID" --location="$REGION"
 
-# Runtime-SA project-level role grants. These call projects.setIamPolicy
-# and need roles/resourcemanager.projectIamAdmin on the caller, so they
-# must run as a project Owner — not as tr-deploy@ (which secrets.sh and
-# rollout.sh use). Idempotent: gcloud no-ops if the binding already exists.
-log "ensuring runtime IAM for ${RUN_SERVICE_ACCOUNT}"
-ensure_project_role "serviceAccount:${RUN_SERVICE_ACCOUNT}" "roles/secretmanager.secretAccessor"
-ensure_project_role "serviceAccount:${RUN_SERVICE_ACCOUNT}" "roles/spanner.databaseUser"
-ensure_project_role "serviceAccount:${RUN_SERVICE_ACCOUNT}" "roles/bigtable.user"
-ensure_project_role "serviceAccount:${RUN_SERVICE_ACCOUNT}" "roles/aiplatform.user"
+for service_account in \
+  "$PUBLIC_RUN_SERVICE_ACCOUNT" \
+  "$CONSOLE_RUN_SERVICE_ACCOUNT" \
+  "$CHAT_RUN_SERVICE_ACCOUNT" \
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT" \
+  "$INTERNAL_RUN_SERVICE_ACCOUNT"; do
+  member="serviceAccount:${service_account}"
+  ensure_project_role "$member" "roles/serviceusage.serviceUsageConsumer"
+  verify_resource_role_present \
+    "project" "$member" "roles/serviceusage.serviceUsageConsumer" \
+    gc projects get-iam-policy "$PROJECT_ID"
+done
+
+for service_account in "$PUBLIC_RUN_SERVICE_ACCOUNT" "$CHAT_RUN_SERVICE_ACCOUNT"; do
+  member="serviceAccount:${service_account}"
+  gc spanner databases add-iam-policy-binding "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID" \
+    --member="$member" \
+    --role="roles/spanner.databaseReader" \
+    --quiet >/dev/null
+  verify_resource_role_present \
+    "Spanner database" "$member" "roles/spanner.databaseReader" \
+    gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID"
+done
+for service_account in \
+  "$CONSOLE_RUN_SERVICE_ACCOUNT" \
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT" \
+  "$INTERNAL_RUN_SERVICE_ACCOUNT"; do
+  member="serviceAccount:${service_account}"
+  gc spanner databases add-iam-policy-binding "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID" \
+    --member="$member" \
+    --role="roles/spanner.databaseUser" \
+    --quiet >/dev/null
+  verify_resource_role_present \
+    "Spanner database" "$member" "roles/spanner.databaseUser" \
+    gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID"
+done
+
+for service_account in "$PUBLIC_RUN_SERVICE_ACCOUNT" "$CONSOLE_RUN_SERVICE_ACCOUNT"; do
+  member="serviceAccount:${service_account}"
+  gc bigtable instances add-iam-policy-binding "$BIGTABLE_INSTANCE_ID" \
+    --member="$member" \
+    --role="roles/bigtable.reader" \
+    --quiet >/dev/null
+  verify_resource_role_present \
+    "Bigtable instance" "$member" "roles/bigtable.reader" \
+    gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID"
+done
+member="serviceAccount:${INTERNAL_RUN_SERVICE_ACCOUNT}"
+gc bigtable instances add-iam-policy-binding "$BIGTABLE_INSTANCE_ID" \
+  --member="$member" \
+  --role="roles/bigtable.user" \
+  --quiet >/dev/null
+verify_resource_role_present \
+  "Bigtable instance" "$member" "roles/bigtable.user" \
+  gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID"
+
+gc kms keys add-iam-policy-binding "$BYOK_KMS_KEY_ID" \
+  --keyring="$KMS_KEYRING_ID" \
+  --location="$REGION" \
+  --member="serviceAccount:${CONSOLE_RUN_SERVICE_ACCOUNT}" \
+  --role="roles/cloudkms.cryptoKeyEncrypterDecrypter" \
+  --quiet >/dev/null
+verify_resource_role_present \
+  "BYOK KMS key" "serviceAccount:${CONSOLE_RUN_SERVICE_ACCOUNT}" \
+  "roles/cloudkms.cryptoKeyEncrypterDecrypter" \
+  gc kms keys get-iam-policy "$BYOK_KMS_KEY_ID" \
+  --keyring="$KMS_KEYRING_ID" --location="$REGION"
+gc kms keys add-iam-policy-binding "$BYOK_KMS_KEY_ID" \
+  --keyring="$KMS_KEYRING_ID" \
+  --location="$REGION" \
+  --member="serviceAccount:${INTERNAL_RUN_SERVICE_ACCOUNT}" \
+  --role="roles/cloudkms.cryptoKeyDecrypter" \
+  --quiet >/dev/null
+verify_resource_role_present \
+  "BYOK KMS key" "serviceAccount:${INTERNAL_RUN_SERVICE_ACCOUNT}" \
+  "roles/cloudkms.cryptoKeyDecrypter" \
+  gc kms keys get-iam-policy "$BYOK_KMS_KEY_ID" \
+  --keyring="$KMS_KEYRING_ID" --location="$REGION"
+
+for service_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do
+  member="serviceAccount:${service_account}"
+  for role in \
+    roles/cloudkms.cryptoKeyEncrypter \
+    roles/cloudkms.cryptoKeyDecrypter \
+    roles/cloudkms.cryptoKeyEncrypterDecrypter; do
+    if [ "$service_account" = "$CONSOLE_RUN_SERVICE_ACCOUNT" ] && \
+       [ "$role" = "roles/cloudkms.cryptoKeyEncrypter" ]; then
+      continue
+    fi
+    remove_kms_role_if_present "$member" "$role" "$GOOGLE_ADS_KMS_KEY_ID"
+  done
+done
+verify_only_resource_role \
+  "Google Ads KMS key" "serviceAccount:${CONSOLE_RUN_SERVICE_ACCOUNT}" \
+  "roles/cloudkms.cryptoKeyEncrypter" \
+  gc kms keys get-iam-policy "$GOOGLE_ADS_KMS_KEY_ID" \
+  --keyring="$KMS_KEYRING_ID" --location="$REGION"
+for service_account in \
+  "$PUBLIC_RUN_SERVICE_ACCOUNT" \
+  "$ACTIONS_RUN_SERVICE_ACCOUNT" \
+  "$CHAT_RUN_SERVICE_ACCOUNT" \
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT" \
+  "$INTERNAL_RUN_SERVICE_ACCOUNT"; do
+  verify_only_resource_role \
+    "Google Ads KMS key" "serviceAccount:${service_account}" "" \
+    gc kms keys get-iam-policy "$GOOGLE_ADS_KMS_KEY_ID" \
+    --keyring="$KMS_KEYRING_ID" --location="$REGION"
+done
+
+# Cloud Run role isolation. Data roles bind directly to the one database,
+# Bigtable instance, or KMS key. Owner-provisioned direct secret access is
+# verified per resource by secrets.sh. The only project-level runtime role
+# retained here is the non-data service-usage permission required to call
+# enabled Google APIs.
+log "removing broad legacy and split-runtime project data roles"
+for service_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do
+  member="serviceAccount:${service_account}"
+  remove_project_role_if_present "$member" "roles/secretmanager.secretAccessor"
+  remove_project_role_if_present "$member" "roles/spanner.databaseReader"
+  remove_project_role_if_present "$member" "roles/spanner.databaseUser"
+  remove_project_role_if_present "$member" "roles/bigtable.reader"
+  remove_project_role_if_present "$member" "roles/bigtable.user"
+  remove_project_role_if_present "$member" "roles/aiplatform.user"
+  remove_project_role_if_present "$member" "roles/run.developer"
+  if [ "$service_account" = "$ACTIONS_RUN_SERVICE_ACCOUNT" ]; then
+    remove_project_role_if_present "$member" "roles/serviceusage.serviceUsageConsumer"
+  fi
+  remove_project_role_if_present "$member" "roles/editor"
+  remove_project_role_if_present "$member" "roles/owner"
+  expected_spanner_role=""
+  case "$service_account" in
+    "$PUBLIC_RUN_SERVICE_ACCOUNT"|"$CHAT_RUN_SERVICE_ACCOUNT")
+      expected_spanner_role="roles/spanner.databaseReader"
+      remove_spanner_role_if_present "$member" "roles/spanner.databaseUser"
+      ;;
+    "$CONSOLE_RUN_SERVICE_ACCOUNT"|"$WEBHOOKS_RUN_SERVICE_ACCOUNT"|"$INTERNAL_RUN_SERVICE_ACCOUNT")
+      expected_spanner_role="roles/spanner.databaseUser"
+      remove_spanner_role_if_present "$member" "roles/spanner.databaseReader"
+      ;;
+    "$ACTIONS_RUN_SERVICE_ACCOUNT")
+      remove_spanner_role_if_present "$member" "roles/spanner.databaseReader"
+      remove_spanner_role_if_present "$member" "roles/spanner.databaseUser"
+      ;;
+  esac
+  verify_only_resource_role \
+    "Spanner database" "$member" "$expected_spanner_role" \
+    gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID"
+  expected_bigtable_role=""
+  case "$service_account" in
+    "$PUBLIC_RUN_SERVICE_ACCOUNT"|"$CONSOLE_RUN_SERVICE_ACCOUNT")
+      expected_bigtable_role="roles/bigtable.reader"
+      remove_bigtable_role_if_present "$member" "roles/bigtable.user"
+      ;;
+    "$INTERNAL_RUN_SERVICE_ACCOUNT")
+      expected_bigtable_role="roles/bigtable.user"
+      remove_bigtable_role_if_present "$member" "roles/bigtable.reader"
+      ;;
+    "$ACTIONS_RUN_SERVICE_ACCOUNT"|"$CHAT_RUN_SERVICE_ACCOUNT"|"$WEBHOOKS_RUN_SERVICE_ACCOUNT")
+      remove_bigtable_role_if_present "$member" "roles/bigtable.reader"
+      remove_bigtable_role_if_present "$member" "roles/bigtable.user"
+      ;;
+  esac
+  verify_only_resource_role \
+    "Bigtable instance" "$member" "$expected_bigtable_role" \
+    gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID"
+  expected_project_role="roles/serviceusage.serviceUsageConsumer"
+  if [ "$service_account" = "$ACTIONS_RUN_SERVICE_ACCOUNT" ]; then
+    expected_project_role=""
+  fi
+  verify_only_resource_role \
+    "project" "$member" "$expected_project_role" \
+    gc projects get-iam-policy "$PROJECT_ID"
+done
+if [ "$TR_RETIRE_LEGACY_RUN_SERVICE_ACCOUNT_IAM" = "1" ]; then
+  member="serviceAccount:${RUN_SERVICE_ACCOUNT}"
+  remove_project_role_if_present "$member" "roles/secretmanager.secretAccessor"
+  remove_project_role_if_present "$member" "roles/spanner.databaseReader"
+  remove_project_role_if_present "$member" "roles/spanner.databaseUser"
+  remove_project_role_if_present "$member" "roles/bigtable.reader"
+  remove_project_role_if_present "$member" "roles/bigtable.user"
+  remove_project_role_if_present "$member" "roles/aiplatform.user"
+  remove_project_role_if_present "$member" "roles/run.developer"
+  remove_project_role_if_present "$member" "roles/serviceusage.serviceUsageConsumer"
+  remove_project_role_if_present "$member" "roles/editor"
+  remove_project_role_if_present "$member" "roles/owner"
+  remove_spanner_role_if_present "$member" "roles/spanner.databaseReader"
+  remove_spanner_role_if_present "$member" "roles/spanner.databaseUser"
+  verify_only_resource_role \
+    "retired Spanner database" "$member" "" \
+    gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID"
+  remove_bigtable_role_if_present "$member" "roles/bigtable.reader"
+  remove_bigtable_role_if_present "$member" "roles/bigtable.user"
+  verify_only_resource_role \
+    "retired Bigtable instance" "$member" "" \
+    gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID"
+  for key_id in "$BYOK_KMS_KEY_ID" "$GOOGLE_ADS_KMS_KEY_ID"; do
+    for role in \
+      roles/cloudkms.cryptoKeyEncrypter \
+      roles/cloudkms.cryptoKeyDecrypter \
+      roles/cloudkms.cryptoKeyEncrypterDecrypter; do
+      remove_kms_role_if_present "$member" "$role" "$key_id"
+    done
+    verify_only_resource_role \
+      "retired ${key_id} KMS key" "$member" "" \
+      gc kms keys get-iam-policy "$key_id" \
+      --keyring="$KMS_KEYRING_ID" --location="$REGION"
+  done
+  verify_identity_ancestor_scopes_empty "retired legacy runtime" "$RUN_SERVICE_ACCOUNT"
+  verify_only_resource_role \
+    "retired project" "$member" "" \
+    gc projects get-iam-policy "$PROJECT_ID"
+else
+  log "legacy runtime IAM retirement deferred until combined traffic is zero"
+fi
+
+for service_account in \
+  "$PUBLIC_RUN_SERVICE_ACCOUNT" \
+  "$CONSOLE_RUN_SERVICE_ACCOUNT" \
+  "$CHAT_RUN_SERVICE_ACCOUNT" \
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT" \
+  "$INTERNAL_RUN_SERVICE_ACCOUNT"; do
+  ensure_project_role \
+    "serviceAccount:${service_account}" \
+    "roles/serviceusage.serviceUsageConsumer"
+done
+for service_account in \
+  "$PUBLIC_RUN_SERVICE_ACCOUNT" \
+  "$CONSOLE_RUN_SERVICE_ACCOUNT" \
+  "$CHAT_RUN_SERVICE_ACCOUNT" \
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT" \
+  "$INTERNAL_RUN_SERVICE_ACCOUNT"; do
+  verify_only_resource_role \
+    "project" \
+    "serviceAccount:${service_account}" \
+    "roles/serviceusage.serviceUsageConsumer" \
+    gc projects get-iam-policy "$PROJECT_ID"
+done
+verify_only_resource_role \
+  "project" \
+  "serviceAccount:${ACTIONS_RUN_SERVICE_ACCOUNT}" \
+  "" \
+  gc projects get-iam-policy "$PROJECT_ID"
+
+log "granting deploy identity actAs on exactly six runtime identities"
+for service_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do
+  gc iam service-accounts add-iam-policy-binding "$service_account" \
+    --member="serviceAccount:${DEPLOY_SERVICE_ACCOUNT}" \
+    --role="roles/iam.serviceAccountUser" \
+    --quiet >/dev/null
+  verify_only_resource_role \
+    "runtime service-account actAs" \
+    "serviceAccount:${DEPLOY_SERVICE_ACCOUNT}" \
+    "roles/iam.serviceAccountUser" \
+    gc iam service-accounts get-iam-policy "$service_account"
+done
+gc iam service-accounts add-iam-policy-binding "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
+  --member="serviceAccount:${DEPLOY_SERVICE_ACCOUNT}" \
+  --role="roles/iam.serviceAccountUser" \
+  --condition=None \
+  --quiet >/dev/null
+verify_synthetic_service_account_policy post
+verify_synthetic_data_iam_empty
+
+log "post-verifying database-scoped Spanner access"
+
+verify_only_resource_role \
+  "Spanner database" "serviceAccount:${PUBLIC_RUN_SERVICE_ACCOUNT}" \
+  "roles/spanner.databaseReader" \
+  gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+  --instance="$SPANNER_INSTANCE_ID"
+verify_only_resource_role \
+  "Spanner database" "serviceAccount:${CHAT_RUN_SERVICE_ACCOUNT}" \
+  "roles/spanner.databaseReader" \
+  gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+  --instance="$SPANNER_INSTANCE_ID"
+for service_account in \
+  "$CONSOLE_RUN_SERVICE_ACCOUNT" \
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT" \
+  "$INTERNAL_RUN_SERVICE_ACCOUNT"; do
+  verify_only_resource_role \
+    "Spanner database" "serviceAccount:${service_account}" \
+    "roles/spanner.databaseUser" \
+    gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID"
+done
+verify_only_resource_role \
+  "Spanner database" "serviceAccount:${ACTIONS_RUN_SERVICE_ACCOUNT}" "" \
+  gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+  --instance="$SPANNER_INSTANCE_ID"
+
+log "post-verifying instance-scoped Bigtable access"
+verify_only_resource_role \
+  "Bigtable instance" "serviceAccount:${PUBLIC_RUN_SERVICE_ACCOUNT}" \
+  "roles/bigtable.reader" \
+  gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID"
+verify_only_resource_role \
+  "Bigtable instance" "serviceAccount:${CONSOLE_RUN_SERVICE_ACCOUNT}" \
+  "roles/bigtable.reader" \
+  gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID"
+verify_only_resource_role \
+  "Bigtable instance" "serviceAccount:${INTERNAL_RUN_SERVICE_ACCOUNT}" \
+  "roles/bigtable.user" \
+  gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID"
+for service_account in \
+  "$ACTIONS_RUN_SERVICE_ACCOUNT" \
+  "$CHAT_RUN_SERVICE_ACCOUNT" \
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT"; do
+  verify_only_resource_role \
+    "Bigtable instance" "serviceAccount:${service_account}" "" \
+    gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID"
+done
+
+log "reconciling key-scoped BYOK KMS access"
+for service_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do
+  member="serviceAccount:${service_account}"
+  for role in \
+    roles/cloudkms.cryptoKeyEncrypter \
+    roles/cloudkms.cryptoKeyDecrypter \
+    roles/cloudkms.cryptoKeyEncrypterDecrypter; do
+    if [ "$service_account" = "$CONSOLE_RUN_SERVICE_ACCOUNT" ] && \
+       [ "$role" = "roles/cloudkms.cryptoKeyEncrypterDecrypter" ]; then
+      continue
+    fi
+    if [ "$service_account" = "$INTERNAL_RUN_SERVICE_ACCOUNT" ] && \
+       [ "$role" = "roles/cloudkms.cryptoKeyDecrypter" ]; then
+      continue
+    fi
+    remove_kms_role_if_present "$member" "$role"
+  done
+done
+verify_only_resource_role \
+  "BYOK KMS key" "serviceAccount:${CONSOLE_RUN_SERVICE_ACCOUNT}" \
+  "roles/cloudkms.cryptoKeyEncrypterDecrypter" \
+  gc kms keys get-iam-policy "$BYOK_KMS_KEY_ID" \
+  --keyring="$KMS_KEYRING_ID" --location="$REGION"
+verify_only_resource_role \
+  "BYOK KMS key" "serviceAccount:${INTERNAL_RUN_SERVICE_ACCOUNT}" \
+  "roles/cloudkms.cryptoKeyDecrypter" \
+  gc kms keys get-iam-policy "$BYOK_KMS_KEY_ID" \
+  --keyring="$KMS_KEYRING_ID" --location="$REGION"
+for service_account in \
+  "$PUBLIC_RUN_SERVICE_ACCOUNT" \
+  "$ACTIONS_RUN_SERVICE_ACCOUNT" \
+  "$CHAT_RUN_SERVICE_ACCOUNT" \
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT"; do
+  verify_only_resource_role \
+    "BYOK KMS key" "serviceAccount:${service_account}" "" \
+    gc kms keys get-iam-policy "$BYOK_KMS_KEY_ID" \
+    --keyring="$KMS_KEYRING_ID" --location="$REGION"
+done
 
 # Metadata-only Google Ads conversion worker. It can read the durable Spanner
 # outbox and unwrap only the dedicated Google-click envelope key. It has no
 # Bigtable, Secret Manager, provider-key, or BYOK-key decrypt permission.
-GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT_ID="${TR_GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT_ID:-tr-google-data-manager}"
-GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT="${GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT_ID}@${PROJECT_ID}.iam.gserviceaccount.com"
 if ! gc iam service-accounts describe \
   "$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT" >/dev/null 2>&1; then
   gc iam service-accounts create "$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT_ID" \
@@ -139,9 +1613,20 @@ if ! gc iam service-accounts describe \
     --description="Uploads encrypted-click signup, activation, and purchase conversions to Google Ads" \
     --quiet
 fi
-ensure_project_role \
+remove_project_role_if_present \
   "serviceAccount:${GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT}" \
   "roles/spanner.databaseUser"
+gc spanner databases add-iam-policy-binding "$SPANNER_DATABASE_ID" \
+  --instance="$SPANNER_INSTANCE_ID" \
+  --member="serviceAccount:${GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT}" \
+  --role="roles/spanner.databaseUser" \
+  --quiet >/dev/null
+verify_only_resource_role \
+  "Spanner database" \
+  "serviceAccount:${GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT}" \
+  "roles/spanner.databaseUser" \
+  gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+  --instance="$SPANNER_INSTANCE_ID"
 ensure_project_role \
   "serviceAccount:${GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT}" \
   "roles/serviceusage.serviceUsageConsumer"
@@ -151,6 +1636,32 @@ gc kms keys add-iam-policy-binding "$GOOGLE_ADS_KMS_KEY_ID" \
   --member="serviceAccount:${GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT}" \
   --role="roles/cloudkms.cryptoKeyDecrypter" \
   --quiet >/dev/null
+verify_only_resource_role \
+  "Google Ads KMS key" \
+  "serviceAccount:${CONSOLE_RUN_SERVICE_ACCOUNT}" \
+  "roles/cloudkms.cryptoKeyEncrypter" \
+  gc kms keys get-iam-policy "$GOOGLE_ADS_KMS_KEY_ID" \
+  --keyring="$KMS_KEYRING_ID" --location="$REGION"
+verify_only_resource_role \
+  "Google Ads KMS key" \
+  "serviceAccount:${GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT}" \
+  "roles/cloudkms.cryptoKeyDecrypter" \
+  gc kms keys get-iam-policy "$GOOGLE_ADS_KMS_KEY_ID" \
+  --keyring="$KMS_KEYRING_ID" --location="$REGION"
+for service_account in \
+  "$PUBLIC_RUN_SERVICE_ACCOUNT" \
+  "$ACTIONS_RUN_SERVICE_ACCOUNT" \
+  "$CHAT_RUN_SERVICE_ACCOUNT" \
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT" \
+  "$INTERNAL_RUN_SERVICE_ACCOUNT"; do
+  verify_only_resource_role \
+    "Google Ads KMS key" "serviceAccount:${service_account}" "" \
+    gc kms keys get-iam-policy "$GOOGLE_ADS_KMS_KEY_ID" \
+    --keyring="$KMS_KEYRING_ID" --location="$REGION"
+done
+for service_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do
+  verify_identity_ancestor_scopes_empty "split runtime" "$service_account"
+done
 gc iam service-accounts add-iam-policy-binding \
   "$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT" \
   --member="serviceAccount:${DEPLOY_SERVICE_ACCOUNT}" \
@@ -161,3 +1672,6 @@ gc iam service-accounts add-iam-policy-binding \
   --member="serviceAccount:service-${PROJECT_NUMBER}@gcp-sa-cloudscheduler.iam.gserviceaccount.com" \
   --role="roles/iam.serviceAccountTokenCreator" \
   --quiet >/dev/null
+
+log "auditing deploy actAs bindings without removing operator-managed grants"
+verify_deploy_actas_inventory "$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT" post

--- a/scripts/deploy/rollout_iam_verify.sh
+++ b/scripts/deploy/rollout_iam_verify.sh
@@ -1,0 +1,1285 @@
+#!/usr/bin/env bash
+# Read-only IAM and mounted-secret verification for the six-surface rollout.
+#
+# This gate intentionally owns no reconciliation path.  Every gcloud command
+# below is a describe, list, or get-iam-policy operation so it is safe to run
+# both before staging and before every promotion step.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 --project PROJECT [--manifest PATH]" >&2
+}
+
+PROJECT_ARGUMENT=""
+MANIFEST_PATH=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --project)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      [ -z "$PROJECT_ARGUMENT" ] || { echo "ERROR: --project may be specified only once" >&2; exit 2; }
+      PROJECT_ARGUMENT="$2"
+      shift 2
+      ;;
+    --manifest)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      [ -z "$MANIFEST_PATH" ] || { echo "ERROR: --manifest may be specified only once" >&2; exit 2; }
+      MANIFEST_PATH="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+[[ "$PROJECT_ARGUMENT" =~ ^[a-z][a-z0-9-]{4,28}[a-z0-9]$ ]] || {
+  echo "ERROR: --project must be a canonical GCP project identifier" >&2
+  exit 2
+}
+if [ -n "$MANIFEST_PATH" ] && [ ! -f "$MANIFEST_PATH" ]; then
+  echo "ERROR: --manifest must name a readable regular file" >&2
+  exit 2
+fi
+
+PROJECT_ID="$PROJECT_ARGUMENT"
+export PROJECT_ID
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+SURFACES=(public actions console chat webhooks internal)
+
+surface_account() {
+  case "$1" in
+    public) echo "$PUBLIC_RUN_SERVICE_ACCOUNT" ;;
+    actions) echo "$ACTIONS_RUN_SERVICE_ACCOUNT" ;;
+    console) echo "$CONSOLE_RUN_SERVICE_ACCOUNT" ;;
+    chat) echo "$CHAT_RUN_SERVICE_ACCOUNT" ;;
+    webhooks) echo "$WEBHOOKS_RUN_SERVICE_ACCOUNT" ;;
+    internal) echo "$INTERNAL_RUN_SERVICE_ACCOUNT" ;;
+    *) return 2 ;;
+  esac
+}
+
+for surface in "${SURFACES[@]}"; do
+  expected_account="tr-${surface}@${PROJECT_ID}.iam.gserviceaccount.com"
+  [ "$(surface_account "$surface")" = "$expected_account" ] || {
+    echo "ERROR: six-surface IAM verification requires canonical runtime identities" >&2
+    exit 1
+  }
+done
+if [ "${#RUNTIME_SERVICE_ACCOUNTS[@]}" -ne 6 ]; then
+  echo "ERROR: runtime service-account inventory is not the canonical six-account set" >&2
+  exit 1
+fi
+
+RUNTIME_CSV="$(IFS=,; echo "${RUNTIME_SERVICE_ACCOUNTS[*]}")"
+
+ROLLOUT_REQUIRE_RECOVERY_BUNDLE="${TR_ROLLOUT_REQUIRE_RECOVERY_BUNDLE:-false}"
+ROLLOUT_RECOVERY_GCS_PREFIX="${TR_ROLLOUT_RECOVERY_GCS_PREFIX:-}"
+ROLLOUT_RECOVERY_GCS_ROLE="${TR_ROLLOUT_RECOVERY_GCS_ROLE:-}"
+ROLLOUT_BUNDLE_GCS_URI="${TR_ROLLOUT_BUNDLE_GCS_URI:-}"
+ROLLOUT_AUTHORITY_GCS_URI="${TR_ROLLOUT_AUTHORITY_GCS_URI:-}"
+ROLLOUT_STATE_GCS_URI="${TR_ROLLOUT_STATE_GCS_URI:-}"
+ROLLOUT_STATE_GCS_ROLE="${TR_ROLLOUT_STATE_GCS_ROLE:-}"
+case "$ROLLOUT_REQUIRE_RECOVERY_BUNDLE" in
+  true|false) ;;
+  *)
+    echo "ERROR: TR_ROLLOUT_REQUIRE_RECOVERY_BUNDLE must be true or false" >&2
+    exit 2
+    ;;
+esac
+ROLLOUT_RECOVERY_ACTIVE=false
+if [ "$ROLLOUT_REQUIRE_RECOVERY_BUNDLE" = true ] ||
+   [ -n "$ROLLOUT_RECOVERY_GCS_PREFIX$ROLLOUT_RECOVERY_GCS_ROLE$ROLLOUT_BUNDLE_GCS_URI$ROLLOUT_AUTHORITY_GCS_URI" ]; then
+  ROLLOUT_RECOVERY_ACTIVE=true
+fi
+ROLLOUT_STATE_BUCKET=""
+ROLLOUT_STATE_OBJECT=""
+if [ "$ROLLOUT_RECOVERY_ACTIVE" = false ]; then
+  if { [ -n "$ROLLOUT_STATE_GCS_URI" ] && [ -z "$ROLLOUT_STATE_GCS_ROLE" ]; } ||
+     { [ -z "$ROLLOUT_STATE_GCS_URI" ] && [ -n "$ROLLOUT_STATE_GCS_ROLE" ]; }; then
+    echo "ERROR: rollout journal URI and custom role must be configured together" >&2
+    exit 1
+  fi
+fi
+if [ "$ROLLOUT_RECOVERY_ACTIVE" = false ] && [ -n "$ROLLOUT_STATE_GCS_URI" ]; then
+  if ! ROLLOUT_STATE_PARTS="$(python3 -c '
+import re
+import sys
+
+uri, project, role = sys.argv[1:4]
+match = re.fullmatch(
+    r"gs://([a-z0-9][a-z0-9._-]{1,220}[a-z0-9])/"
+    r"([A-Za-z0-9][A-Za-z0-9._/-]{0,1023})",
+    uri,
+)
+if not match or "//" in match.group(2):
+    raise SystemExit("invalid rollout journal URI")
+if not re.fullmatch(
+    rf"projects/{re.escape(project)}/roles/[A-Za-z0-9_.]{{3,64}}", role
+):
+    raise SystemExit("invalid rollout journal custom role")
+print(match.group(1) + "\t" + match.group(2))
+' "$ROLLOUT_STATE_GCS_URI" "$PROJECT_ID" "$ROLLOUT_STATE_GCS_ROLE" 2>/dev/null)"; then
+    echo "ERROR: rollout journal URI or custom role is noncanonical" >&2
+    exit 1
+  fi
+  IFS=$'\t' read -r ROLLOUT_STATE_BUCKET ROLLOUT_STATE_OBJECT <<<"$ROLLOUT_STATE_PARTS"
+fi
+
+ROLLOUT_RECOVERY_BUCKET=""
+ROLLOUT_RECOVERY_OBJECT_PREFIX=""
+ROLLOUT_RECOVERY_EPOCH=""
+if [ "$ROLLOUT_RECOVERY_ACTIVE" = true ]; then
+  if [ -z "$ROLLOUT_RECOVERY_GCS_PREFIX" ] ||
+     [ -z "$ROLLOUT_RECOVERY_GCS_ROLE" ] ||
+     [ -z "$ROLLOUT_BUNDLE_GCS_URI" ] ||
+     [ -z "$ROLLOUT_AUTHORITY_GCS_URI" ] ||
+     [ -z "$ROLLOUT_STATE_GCS_URI" ]; then
+    echo "ERROR: recovery IAM verification requires prefix, role, bundle, authority, and state URIs" >&2
+    exit 1
+  fi
+  if [ -n "$ROLLOUT_STATE_GCS_ROLE" ] &&
+     [ "$ROLLOUT_STATE_GCS_ROLE" != "$ROLLOUT_RECOVERY_GCS_ROLE" ]; then
+    echo "ERROR: legacy journal and recovery custom-role inputs disagree" >&2
+    exit 1
+  fi
+  if ! ROLLOUT_RECOVERY_PARTS="$(python3 -c '
+import re
+import sys
+
+prefix, bundle, authority, state, project, role = sys.argv[1:]
+bucket_pattern = r"[a-z0-9][a-z0-9._-]{1,220}[a-z0-9]"
+prefix_match = re.fullmatch(
+    rf"gs://({bucket_pattern})/(trusted-router-rollouts/{re.escape(project)})",
+    prefix,
+)
+if not prefix_match:
+    raise SystemExit("noncanonical recovery prefix")
+bucket, object_prefix = prefix_match.groups()
+release_prefix = f"{prefix}/releases/"
+if not bundle.startswith(release_prefix):
+    raise SystemExit("bundle is outside the recovery releases prefix")
+epoch = bundle[len(release_prefix):]
+if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{7,159}", epoch):
+    raise SystemExit("bundle epoch is not unique and canonical")
+if authority != f"{prefix}/authority.json":
+    raise SystemExit("authority is outside the exact recovery object")
+if state != f"{bundle}/promotion-state.json":
+    raise SystemExit("state is outside the exact recovery bundle")
+if not re.fullmatch(
+    rf"projects/{re.escape(project)}/roles/[A-Za-z][A-Za-z0-9_.]{{2,63}}",
+    role,
+):
+    raise SystemExit("recovery role is not project-local and canonical")
+print("\t".join((bucket, object_prefix, epoch)))
+' "$ROLLOUT_RECOVERY_GCS_PREFIX" "$ROLLOUT_BUNDLE_GCS_URI" \
+    "$ROLLOUT_AUTHORITY_GCS_URI" "$ROLLOUT_STATE_GCS_URI" \
+    "$PROJECT_ID" "$ROLLOUT_RECOVERY_GCS_ROLE" 2>/dev/null)"; then
+    echo "ERROR: rollout recovery prefix, bundle, authority, state, or role is noncanonical" >&2
+    exit 1
+  fi
+  IFS=$'\t' read -r ROLLOUT_RECOVERY_BUCKET \
+    ROLLOUT_RECOVERY_OBJECT_PREFIX ROLLOUT_RECOVERY_EPOCH \
+    <<<"$ROLLOUT_RECOVERY_PARTS"
+fi
+
+read_cloud_json() {
+  local label="$1"
+  shift
+  local output
+  if ! output="$("$@" 2>/dev/null)"; then
+    echo "ERROR: cannot read ${label}" >&2
+    return 1
+  fi
+  if ! printf '%s' "$output" | python3 -c '
+import json
+import sys
+
+label = sys.argv[1]
+try:
+    value = json.load(sys.stdin)
+except json.JSONDecodeError:
+    raise SystemExit(f"{label}: response is not valid JSON") from None
+if isinstance(value, dict):
+    for binding in value.get("bindings") or []:
+        members = binding.get("members") or []
+        if any(member in {"allUsers", "allAuthenticatedUsers"} for member in members):
+            raise SystemExit(f"{label}: public IAM principal is forbidden")
+' "$label"
+  then
+    echo "ERROR: ${label} contains a public or malformed IAM policy" >&2
+    return 1
+  fi
+  printf '%s' "$output"
+}
+
+describe_iam_role_definition_readonly() {
+  local role="$1"
+  local scope role_id
+  case "$role" in
+    roles/*)
+      gc iam roles describe "$role" --format=json
+      ;;
+    projects/*/roles/*)
+      scope="${role#projects/}"
+      scope="${scope%%/roles/*}"
+      role_id="${role##*/}"
+      [ "$scope" = "$PROJECT_ID" ] || return 1
+      gc iam roles describe "$role_id" --format=json
+      ;;
+    organizations/*/roles/*)
+      scope="${role#organizations/}"
+      scope="${scope%%/roles/*}"
+      role_id="${role##*/}"
+      [[ "$scope" =~ ^[0-9]+$ ]] || return 1
+      gcloud --billing-project "$PROJECT_ID" iam roles describe "$role_id" \
+        --organization="$scope" --format=json
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+# Verify all and only the expected direct bindings for the six runtime
+# principals, plus no binding for the dedicated synthetic identity, on one
+# resource policy. Bindings for unrelated administrators or service agents
+# remain outside this verifier's ownership boundary.
+verify_six_runtime_matrix_json() {
+  local label="$1"
+  local expected_csv="$2"
+  python3 -c '
+import json
+import sys
+
+label, accounts_csv, expected_csv, project = sys.argv[1:5]
+accounts = accounts_csv.split(",")
+if len(accounts) != 6 or len(set(accounts)) != 6:
+    raise SystemExit(f"{label}: runtime identity inventory is not exactly six")
+
+expected = {}
+for item in expected_csv.split(","):
+    surface, separator, role = item.partition("=")
+    if not separator or surface in expected:
+        raise SystemExit(f"{label}: invalid expected IAM matrix")
+    expected[surface] = role
+surfaces = ("public", "actions", "console", "chat", "webhooks", "internal")
+if set(expected) != set(surfaces):
+    raise SystemExit(f"{label}: expected IAM matrix does not cover six surfaces")
+
+members = {
+    "serviceAccount:" + account: expected[surface]
+    for surface, account in zip(surfaces, accounts)
+}
+members[f"serviceAccount:tr-synthetic@{project}.iam.gserviceaccount.com"] = ""
+policy = json.load(sys.stdin)
+if not isinstance(policy, dict) or not isinstance(policy.get("bindings", []), list):
+    raise SystemExit(f"{label}: malformed IAM policy")
+found = {member: [] for member in members}
+for binding in policy.get("bindings", []):
+    if not isinstance(binding, dict):
+        raise SystemExit(f"{label}: malformed IAM binding")
+    role = binding.get("role")
+    binding_members = binding.get("members", [])
+    if not isinstance(role, str) or not isinstance(binding_members, list):
+        raise SystemExit(f"{label}: malformed IAM binding")
+    condition = binding.get("condition") if "condition" in binding else None
+    for member in binding_members:
+        if member in found:
+            found[member].append((role, condition))
+
+for member, wanted_role in members.items():
+    wanted = [] if not wanted_role else [(wanted_role, None)]
+    if found[member] != wanted:
+        raise SystemExit(f"{label}: six-runtime IAM matrix drift")
+' "$label" "$RUNTIME_CSV" "$expected_csv" "$PROJECT_ID"
+}
+
+verify_policy_from_cloud() {
+  local label="$1"
+  local expected_csv="$2"
+  shift 2
+  local policy
+  policy="$(read_cloud_json "${label} IAM policy" "$@")" || return 1
+  if ! printf '%s' "$policy" | verify_six_runtime_matrix_json "$label" "$expected_csv"; then
+    echo "ERROR: ${label} has unsafe six-runtime IAM" >&2
+    return 1
+  fi
+}
+
+# Normalize a provider list response to one resource identifier per line.  The
+# command that produced the response is already scoped to PROJECT_ID; full
+# resource names are nevertheless checked again so a malformed/cross-project
+# inventory cannot cause the verifier to audit the wrong object and miss the
+# actual one.
+normalize_project_inventory_json() {
+  local label="$1"
+  local kind="$2"
+  local parent="$3"
+  python3 -c '
+import json
+import re
+import sys
+
+label, kind, project, parent = sys.argv[1:5]
+items = json.load(sys.stdin)
+if not isinstance(items, list):
+    raise SystemExit(f"{label}: inventory is not a list")
+identifier = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}")
+location_identifier = re.compile(r"[a-z0-9][a-z0-9-]{0,62}")
+service_account_email = re.compile(
+    r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}@"
+    r"[A-Za-z0-9](?:[A-Za-z0-9.-]{0,250}[A-Za-z0-9])?[.]gserviceaccount[.]com"
+)
+
+def resource_id(item):
+    if not isinstance(item, dict):
+        raise SystemExit(f"{label}: malformed inventory entry")
+    value = item.get("name")
+    if kind == "kms-location":
+        value = item.get("locationId", value)
+        prefix = f"projects/{project}/locations/"
+    elif kind == "spanner-instance":
+        prefix = f"projects/{project}/instances/"
+    elif kind == "spanner-database":
+        prefix = f"projects/{project}/instances/{parent}/databases/"
+    elif kind == "bigtable-instance":
+        prefix = f"projects/{project}/instances/"
+    elif kind == "bigtable-table":
+        prefix = f"projects/{project}/instances/{parent}/tables/"
+    elif kind == "kms-keyring":
+        prefix = f"projects/{project}/locations/{parent}/keyRings/"
+    elif kind == "kms-key":
+        location, separator, keyring = parent.partition("/")
+        if not separator:
+            raise SystemExit(f"{label}: malformed key parent")
+        prefix = f"projects/{project}/locations/{location}/keyRings/{keyring}/cryptoKeys/"
+    elif kind == "service-account":
+        email = item.get("email")
+        if not isinstance(email, str) or not service_account_email.fullmatch(email):
+            raise SystemExit(f"{label}: malformed service-account email")
+        name = item.get("name")
+        unique_id = item.get("uniqueId")
+        allowed_accounts = {email}
+        if unique_id is not None:
+            unique_id = str(unique_id)
+            if not re.fullmatch(r"[0-9]{6,32}", unique_id):
+                raise SystemExit(f"{label}: malformed service-account unique id")
+            allowed_accounts.add(unique_id)
+        if name is not None:
+            prefixes = (
+                f"projects/{project}/serviceAccounts/",
+                "projects/-/serviceAccounts/",
+            )
+            matching_prefix = next(
+                (prefix for prefix in prefixes if name.startswith(prefix)), None
+            ) if isinstance(name, str) else None
+            if matching_prefix is None or name[len(matching_prefix):] not in allowed_accounts:
+                raise SystemExit(f"{label}: cross-project service-account entry")
+        return email
+    else:
+        raise SystemExit(f"{label}: unknown inventory kind")
+    if not isinstance(value, str):
+        raise SystemExit(f"{label}: malformed resource name")
+    if value.startswith("projects/"):
+        if not value.startswith(prefix):
+            raise SystemExit(f"{label}: cross-project or wrong-parent entry")
+        value = value[len(prefix):]
+    validator = location_identifier if kind == "kms-location" else identifier
+    if not validator.fullmatch(value):
+        raise SystemExit(f"{label}: invalid resource identifier")
+    return value
+
+values = [resource_id(item) for item in items]
+if len(values) != len(set(values)):
+    raise SystemExit(f"{label}: duplicate inventory entry")
+print("\n".join(sorted(values)))
+' "$label" "$kind" "$PROJECT_ID" "$parent"
+}
+
+# Project- and ancestor-level grants cannot be safely constrained to one
+# runtime, secret, key, or recovery object. Resolve every role directly bound
+# to the deploy principal and reject broad data access, token minting, or
+# project-wide actAs. Narrow resource bindings are audited separately.
+verify_deploy_broad_permissions_absent_json() {
+  local label="$1"
+  local policy="$2"
+  local deploy_member="serviceAccount:${DEPLOY_SERVICE_ACCOUNT}"
+  local roles role role_json
+  if ! roles="$(printf '%s' "$policy" | python3 -c '
+import json
+import sys
+
+member = sys.argv[1]
+policy = json.load(sys.stdin)
+if not isinstance(policy, dict) or not isinstance(policy.get("bindings", []), list):
+    raise SystemExit("malformed IAM policy")
+roles = []
+for binding in policy.get("bindings", []):
+    if not isinstance(binding, dict):
+        raise SystemExit("malformed IAM binding")
+    role = binding.get("role")
+    members = binding.get("members", [])
+    if not isinstance(role, str) or not role or not isinstance(members, list):
+        raise SystemExit("malformed IAM binding")
+    if member in members:
+        roles.append(role)
+if len(set(roles)) != len(roles):
+    raise SystemExit("deploy principal has duplicate role bindings")
+print("\n".join(sorted(roles)))
+' "$deploy_member")"; then
+    echo "ERROR: cannot inspect deploy identity bindings at ${label}" >&2
+    return 1
+  fi
+  while IFS= read -r role; do
+    [ -n "$role" ] || continue
+    role_json="$(read_cloud_json "deploy identity role definition" \
+      describe_iam_role_definition_readonly "$role")" || return 1
+    if ! printf '%s' "$role_json" | python3 -c '
+import json
+import sys
+
+value = json.load(sys.stdin)
+permissions = value.get("includedPermissions")
+if not isinstance(permissions, list) or any(not isinstance(item, str) for item in permissions):
+    raise SystemExit("role permission inventory is malformed")
+forbidden = {
+    "aiplatform.endpoints.predict",
+    "bigtable.tables.mutateRows",
+    "bigtable.tables.readRows",
+    "cloudkms.cryptoKeyVersions.useToDecrypt",
+    "cloudkms.cryptoKeyVersions.useToEncrypt",
+    "iam.serviceAccounts.actAs",
+    "iam.serviceAccounts.getAccessToken",
+    "secretmanager.versions.access",
+    "spanner.databases.read",
+    "spanner.databases.write",
+    "spanner.sessions.create",
+}
+if forbidden.intersection(permissions) or any(
+    permission.startswith("storage.objects.") for permission in permissions
+):
+    raise SystemExit("deploy role contains project/ancestor data or impersonation permission")
+'; then
+      echo "ERROR: deploy identity has a broad data or impersonation permission at ${label}" >&2
+      return 1
+    fi
+  done <<<"$roles"
+}
+
+verify_journal_role_and_bucket_policy() {
+  [ -n "$ROLLOUT_STATE_GCS_URI" ] || return 0
+  local role_json bucket_policy expected_expression
+  role_json="$(read_cloud_json "rollout journal custom-role definition" \
+    describe_iam_role_definition_readonly "$ROLLOUT_STATE_GCS_ROLE")" || return 1
+  if ! printf '%s' "$role_json" | python3 -c '
+import json
+import sys
+
+expected_name = sys.argv[1]
+value = json.load(sys.stdin)
+if value.get("name") != expected_name:
+    raise SystemExit("rollout journal custom role identity mismatch")
+if value.get("deleted", False) is not False:
+    raise SystemExit("rollout journal custom role is deleted")
+permissions = value.get("includedPermissions")
+expected = {
+    "storage.objects.get",
+    "storage.objects.create",
+    "storage.objects.delete",
+}
+if not isinstance(permissions, list) or len(permissions) != len(set(permissions)):
+    raise SystemExit("rollout journal custom role permission inventory is malformed")
+if set(permissions) != expected:
+    raise SystemExit("rollout journal custom role permissions drifted")
+' "$ROLLOUT_STATE_GCS_ROLE"; then
+    echo "ERROR: rollout journal custom role is not the exact three-permission role" >&2
+    return 1
+  fi
+
+  bucket_policy="$(read_cloud_json "rollout journal bucket IAM policy" \
+    gc storage buckets get-iam-policy "gs://${ROLLOUT_STATE_BUCKET}" --format=json)" || return 1
+  expected_expression="resource.name == \"projects/_/buckets/${ROLLOUT_STATE_BUCKET}/objects/${ROLLOUT_STATE_OBJECT}\""
+  if ! printf '%s' "$bucket_policy" | python3 -c '
+import json
+import sys
+
+role, member, title, expression = sys.argv[1:5]
+policy = json.load(sys.stdin)
+if not isinstance(policy, dict) or not isinstance(policy.get("bindings", []), list):
+    raise SystemExit("rollout journal bucket IAM policy is malformed")
+role_bindings = []
+member_bindings = []
+for binding in policy.get("bindings", []):
+    if not isinstance(binding, dict):
+        raise SystemExit("rollout journal bucket IAM binding is malformed")
+    binding_role = binding.get("role")
+    members = binding.get("members", [])
+    if not isinstance(binding_role, str) or not isinstance(members, list):
+        raise SystemExit("rollout journal bucket IAM binding is malformed")
+    if binding_role == role:
+        role_bindings.append(binding)
+    if member in members:
+        member_bindings.append(binding)
+if len(role_bindings) != 1 or len(member_bindings) != 1 or role_bindings[0] is not member_bindings[0]:
+    raise SystemExit("rollout journal bucket binding is not unique")
+binding = role_bindings[0]
+if binding.get("members") != [member]:
+    raise SystemExit("rollout journal bucket role has noncanonical members")
+condition = binding.get("condition")
+if not isinstance(condition, dict):
+    raise SystemExit("rollout journal bucket role lacks its object condition")
+if condition.get("title") != title or condition.get("expression") != expression:
+    raise SystemExit("rollout journal bucket object condition drifted")
+if set(condition) - {"title", "expression", "description"}:
+    raise SystemExit("rollout journal bucket condition has unknown fields")
+' "$ROLLOUT_STATE_GCS_ROLE" "serviceAccount:${DEPLOY_SERVICE_ACCOUNT}" \
+    "trusted-router-rollout-journal" "$expected_expression"; then
+    echo "ERROR: rollout journal bucket IAM is not the exact object-scoped binding" >&2
+    return 1
+  fi
+}
+
+verify_recovery_role_and_bucket_policy() {
+  [ "$ROLLOUT_RECOVERY_ACTIVE" = true ] || return 0
+  local role_json bucket_json bucket_policy
+  local authority_resource bundle_resource_prefix expected_expression
+
+  role_json="$(read_cloud_json "rollout recovery custom-role definition" \
+    describe_iam_role_definition_readonly "$ROLLOUT_RECOVERY_GCS_ROLE")" || return 1
+  if ! printf '%s' "$role_json" | python3 -c '
+import json
+import sys
+
+expected_name = sys.argv[1]
+value = json.load(sys.stdin)
+if value.get("name") != expected_name:
+    raise SystemExit("rollout recovery custom role identity mismatch")
+if value.get("deleted", False) is not False:
+    raise SystemExit("rollout recovery custom role is deleted")
+permissions = value.get("includedPermissions")
+expected = {
+    "storage.objects.create",
+    "storage.objects.delete",
+    "storage.objects.get",
+}
+if not isinstance(permissions, list) or len(permissions) != len(set(permissions)):
+    raise SystemExit("rollout recovery custom role permission inventory is malformed")
+if set(permissions) != expected:
+    raise SystemExit("rollout recovery custom role permissions drifted")
+' "$ROLLOUT_RECOVERY_GCS_ROLE"; then
+    echo "ERROR: rollout recovery custom role is not the exact three-permission role" >&2
+    return 1
+  fi
+
+  bucket_json="$(read_cloud_json "rollout recovery bucket metadata" \
+    gc storage buckets describe "gs://${ROLLOUT_RECOVERY_BUCKET}" \
+      --format=json)" || return 1
+  if ! printf '%s' "$bucket_json" | python3 -c '
+import json
+import sys
+
+expected_name = sys.argv[1]
+value = json.load(sys.stdin)
+if value.get("name") != expected_name:
+    raise SystemExit("rollout recovery bucket identity mismatch")
+iam = value.get("iamConfiguration") or {}
+uniform = iam.get("uniformBucketLevelAccess") or {}
+if uniform.get("enabled") is not True:
+    raise SystemExit("rollout recovery bucket lacks uniform access")
+if str(iam.get("publicAccessPrevention", "")).lower() != "enforced":
+    raise SystemExit("rollout recovery bucket lacks public-access prevention")
+if (value.get("versioning") or {}).get("enabled") is not True:
+    raise SystemExit("rollout recovery bucket lacks versioning")
+retention = (value.get("retentionPolicy") or {}).get("retentionPeriod")
+try:
+    retention_seconds = int(retention)
+except (TypeError, ValueError):
+    raise SystemExit("rollout recovery bucket retention is malformed") from None
+if retention_seconds < 7 * 24 * 60 * 60:
+    raise SystemExit("rollout recovery bucket retention is shorter than seven days")
+' "$ROLLOUT_RECOVERY_BUCKET"; then
+    echo "ERROR: rollout recovery bucket protection contract drifted" >&2
+    return 1
+  fi
+
+  authority_resource="projects/_/buckets/${ROLLOUT_RECOVERY_BUCKET}/objects/${ROLLOUT_RECOVERY_OBJECT_PREFIX}/authority.json"
+  bundle_resource_prefix="projects/_/buckets/${ROLLOUT_RECOVERY_BUCKET}/objects/${ROLLOUT_RECOVERY_OBJECT_PREFIX}/releases/${ROLLOUT_RECOVERY_EPOCH}/"
+  expected_expression="resource.name == \"${authority_resource}\" || resource.name.startsWith(\"${bundle_resource_prefix}\")"
+  bucket_policy="$(read_cloud_json "rollout recovery bucket IAM policy" \
+    gc storage buckets get-iam-policy "gs://${ROLLOUT_RECOVERY_BUCKET}" \
+      --format=json)" || return 1
+  if ! printf '%s' "$bucket_policy" | python3 -c '
+import json
+import sys
+
+role, member, title, expression = sys.argv[1:5]
+policy = json.load(sys.stdin)
+bindings = policy.get("bindings")
+if not isinstance(bindings, list) or len(bindings) != 1:
+    raise SystemExit("recovery bucket must have one exact binding")
+binding = bindings[0]
+if not isinstance(binding, dict) or set(binding) != {"role", "members", "condition"}:
+    raise SystemExit("recovery bucket binding shape drifted")
+if binding.get("role") != role or binding.get("members") != [member]:
+    raise SystemExit("recovery bucket role or principal drifted")
+condition = binding.get("condition")
+if not isinstance(condition, dict) or set(condition) != {"title", "expression"}:
+    raise SystemExit("recovery bucket condition shape drifted")
+if condition.get("title") != title or condition.get("expression") != expression:
+    raise SystemExit("recovery bucket condition scope drifted")
+' "$ROLLOUT_RECOVERY_GCS_ROLE" "serviceAccount:${DEPLOY_SERVICE_ACCOUNT}" \
+    "trusted-router-rollout-recovery" "$expected_expression"; then
+    echo "ERROR: rollout recovery bucket IAM is not the exact authority-and-bundle binding" >&2
+    return 1
+  fi
+}
+
+EMPTY_MATRIX="public=,actions=,console=,chat=,webhooks=,internal="
+PROJECT_MATRIX="public=roles/serviceusage.serviceUsageConsumer,actions=,console=roles/serviceusage.serviceUsageConsumer,chat=roles/serviceusage.serviceUsageConsumer,webhooks=roles/serviceusage.serviceUsageConsumer,internal=roles/serviceusage.serviceUsageConsumer"
+SPANNER_MATRIX="public=roles/spanner.databaseReader,actions=,console=roles/spanner.databaseUser,chat=roles/spanner.databaseReader,webhooks=roles/spanner.databaseUser,internal=roles/spanner.databaseUser"
+BIGTABLE_MATRIX="public=roles/bigtable.reader,actions=,console=roles/bigtable.reader,chat=,webhooks=,internal=roles/bigtable.user"
+BYOK_MATRIX="public=,actions=,console=roles/cloudkms.cryptoKeyEncrypterDecrypter,chat=,webhooks=,internal=roles/cloudkms.cryptoKeyDecrypter"
+GOOGLE_ADS_MATRIX="public=,actions=,console=roles/cloudkms.cryptoKeyEncrypter,chat=,webhooks=,internal="
+
+PROJECT_POLICY_JSON="$(read_cloud_json "project IAM policy" \
+  gc projects get-iam-policy "$PROJECT_ID" --format=json)" || exit 1
+if ! printf '%s' "$PROJECT_POLICY_JSON" | \
+    verify_six_runtime_matrix_json "project" "$PROJECT_MATRIX"; then
+  echo "ERROR: project has unsafe six-runtime IAM" >&2
+  exit 1
+fi
+verify_deploy_broad_permissions_absent_json "project" "$PROJECT_POLICY_JSON"
+
+# A named-resource audit is insufficient: a stale grant on an older database,
+# table, key, or service account remains live.  Inventory every resource in the
+# project and require the exact configured matrix only at the canonical target;
+# all other resources must have zero six-runtime/synthetic bindings.  This is a
+# read-only gate and deliberately owns no automatic cleanup path.
+SPANNER_INSTANCES_JSON="$(read_cloud_json "Spanner instance inventory" \
+  gc spanner instances list --format=json)" || exit 1
+if ! SPANNER_INSTANCE_IDS="$(printf '%s' "$SPANNER_INSTANCES_JSON" | \
+    normalize_project_inventory_json "Spanner instance" spanner-instance "")"; then
+  echo "ERROR: Spanner instance inventory is malformed" >&2
+  exit 1
+fi
+SPANNER_INSTANCE_FOUND=0
+SPANNER_DATABASE_FOUND=0
+while IFS= read -r spanner_instance; do
+  [ -n "$spanner_instance" ] || continue
+  [ "$spanner_instance" != "$SPANNER_INSTANCE_ID" ] || SPANNER_INSTANCE_FOUND=1
+  verify_policy_from_cloud "Spanner inventory instance" "$EMPTY_MATRIX" \
+    gc spanner instances get-iam-policy "$spanner_instance" --format=json
+
+  spanner_databases_json="$(read_cloud_json "Spanner database inventory" \
+    gc spanner databases list --instance="$spanner_instance" --format=json)" || exit 1
+  if ! spanner_database_ids="$(printf '%s' "$spanner_databases_json" | \
+      normalize_project_inventory_json "Spanner database" spanner-database \
+        "$spanner_instance")"; then
+    echo "ERROR: Spanner database inventory is malformed" >&2
+    exit 1
+  fi
+  while IFS= read -r spanner_database; do
+    [ -n "$spanner_database" ] || continue
+    spanner_matrix="$EMPTY_MATRIX"
+    if [ "$spanner_instance" = "$SPANNER_INSTANCE_ID" ] && \
+       [ "$spanner_database" = "$SPANNER_DATABASE_ID" ]; then
+      SPANNER_DATABASE_FOUND=1
+      spanner_matrix="$SPANNER_MATRIX"
+    fi
+    verify_policy_from_cloud "Spanner inventory database" "$spanner_matrix" \
+      gc spanner databases get-iam-policy "$spanner_database" \
+        --instance="$spanner_instance" --format=json
+  done <<<"$spanner_database_ids"
+done <<<"$SPANNER_INSTANCE_IDS"
+[ "$SPANNER_INSTANCE_FOUND" = 1 ] && [ "$SPANNER_DATABASE_FOUND" = 1 ] || {
+  echo "ERROR: canonical Spanner instance/database is absent from the project inventory" >&2
+  exit 1
+}
+
+BIGTABLE_INSTANCES_JSON="$(read_cloud_json "Bigtable instance inventory" \
+  gc bigtable instances list --format=json)" || exit 1
+if ! BIGTABLE_INSTANCE_IDS="$(printf '%s' "$BIGTABLE_INSTANCES_JSON" | \
+    normalize_project_inventory_json "Bigtable instance" bigtable-instance "")"; then
+  echo "ERROR: Bigtable instance inventory is malformed" >&2
+  exit 1
+fi
+BIGTABLE_INSTANCE_FOUND=0
+BIGTABLE_TABLE_FOUND=0
+while IFS= read -r bigtable_instance; do
+  [ -n "$bigtable_instance" ] || continue
+  bigtable_matrix="$EMPTY_MATRIX"
+  if [ "$bigtable_instance" = "$BIGTABLE_INSTANCE_ID" ]; then
+    BIGTABLE_INSTANCE_FOUND=1
+    bigtable_matrix="$BIGTABLE_MATRIX"
+  fi
+  verify_policy_from_cloud "Bigtable inventory instance" "$bigtable_matrix" \
+    gc bigtable instances get-iam-policy "$bigtable_instance" --format=json
+
+  bigtable_tables_json="$(read_cloud_json "Bigtable table inventory" \
+    gc bigtable tables list --instances="$bigtable_instance" --format=json)" || exit 1
+  if ! bigtable_table_ids="$(printf '%s' "$bigtable_tables_json" | \
+      normalize_project_inventory_json "Bigtable table" bigtable-table \
+        "$bigtable_instance")"; then
+    echo "ERROR: Bigtable table inventory is malformed" >&2
+    exit 1
+  fi
+  while IFS= read -r bigtable_table; do
+    [ -n "$bigtable_table" ] || continue
+    if [ "$bigtable_instance" = "$BIGTABLE_INSTANCE_ID" ] && \
+       [ "$bigtable_table" = "$BIGTABLE_GENERATION_TABLE" ]; then
+      BIGTABLE_TABLE_FOUND=1
+    fi
+    verify_policy_from_cloud "Bigtable inventory table" "$EMPTY_MATRIX" \
+      gc bigtable tables get-iam-policy "$bigtable_table" \
+        --instance="$bigtable_instance" --format=json
+  done <<<"$bigtable_table_ids"
+done <<<"$BIGTABLE_INSTANCE_IDS"
+[ "$BIGTABLE_INSTANCE_FOUND" = 1 ] && [ "$BIGTABLE_TABLE_FOUND" = 1 ] || {
+  echo "ERROR: canonical Bigtable instance/table is absent from the project inventory" >&2
+  exit 1
+}
+
+KMS_LOCATIONS_JSON="$(read_cloud_json "KMS location inventory" \
+  gc kms locations list --format=json)" || exit 1
+if ! KMS_LOCATION_IDS="$(printf '%s' "$KMS_LOCATIONS_JSON" | \
+    normalize_project_inventory_json "KMS location" kms-location "")"; then
+  echo "ERROR: KMS location inventory is malformed" >&2
+  exit 1
+fi
+KMS_LOCATION_FOUND=0
+KMS_KEYRING_FOUND=0
+BYOK_KEY_FOUND=0
+GOOGLE_ADS_KEY_FOUND=0
+while IFS= read -r kms_location; do
+  [ -n "$kms_location" ] || continue
+  [ "$kms_location" != "$REGION" ] || KMS_LOCATION_FOUND=1
+  kms_keyrings_json="$(read_cloud_json "KMS keyring inventory" \
+    gc kms keyrings list --location="$kms_location" --format=json)" || exit 1
+  if ! kms_keyring_ids="$(printf '%s' "$kms_keyrings_json" | \
+      normalize_project_inventory_json "KMS keyring" kms-keyring \
+        "$kms_location")"; then
+    echo "ERROR: KMS keyring inventory is malformed" >&2
+    exit 1
+  fi
+  while IFS= read -r kms_keyring; do
+    [ -n "$kms_keyring" ] || continue
+    if [ "$kms_location" = "$REGION" ] && \
+       [ "$kms_keyring" = "$KMS_KEYRING_ID" ]; then
+      KMS_KEYRING_FOUND=1
+    fi
+    verify_policy_from_cloud "KMS inventory keyring" "$EMPTY_MATRIX" \
+      gc kms keyrings get-iam-policy "$kms_keyring" \
+        --location="$kms_location" --format=json
+
+    kms_keys_json="$(read_cloud_json "KMS key inventory" \
+      gc kms keys list --keyring="$kms_keyring" \
+        --location="$kms_location" --format=json)" || exit 1
+    if ! kms_key_ids="$(printf '%s' "$kms_keys_json" | \
+        normalize_project_inventory_json "KMS key" kms-key \
+          "${kms_location}/${kms_keyring}")"; then
+      echo "ERROR: KMS key inventory is malformed" >&2
+      exit 1
+    fi
+    while IFS= read -r kms_key; do
+      [ -n "$kms_key" ] || continue
+      kms_matrix="$EMPTY_MATRIX"
+      if [ "$kms_location" = "$REGION" ] && \
+         [ "$kms_keyring" = "$KMS_KEYRING_ID" ] && \
+         [ "$kms_key" = "$BYOK_KMS_KEY_ID" ]; then
+        BYOK_KEY_FOUND=1
+        kms_matrix="$BYOK_MATRIX"
+      elif [ "$kms_location" = "$REGION" ] && \
+           [ "$kms_keyring" = "$KMS_KEYRING_ID" ] && \
+           [ "$kms_key" = "$GOOGLE_ADS_KMS_KEY_ID" ]; then
+        GOOGLE_ADS_KEY_FOUND=1
+        kms_matrix="$GOOGLE_ADS_MATRIX"
+      fi
+      verify_policy_from_cloud "KMS inventory key" "$kms_matrix" \
+        gc kms keys get-iam-policy "$kms_key" --keyring="$kms_keyring" \
+          --location="$kms_location" --format=json
+    done <<<"$kms_key_ids"
+  done <<<"$kms_keyring_ids"
+done <<<"$KMS_LOCATION_IDS"
+[ "$KMS_LOCATION_FOUND" = 1 ] && [ "$KMS_KEYRING_FOUND" = 1 ] && \
+  [ "$BYOK_KEY_FOUND" = 1 ] && [ "$GOOGLE_ADS_KEY_FOUND" = 1 ] || {
+  echo "ERROR: canonical KMS location/keyring/keys are absent from the project inventory" >&2
+  exit 1
+}
+
+SERVICE_ACCOUNTS_JSON="$(read_cloud_json "service-account inventory" \
+  gc iam service-accounts list --format=json)" || exit 1
+if ! SERVICE_ACCOUNT_EMAILS="$(printf '%s' "$SERVICE_ACCOUNTS_JSON" | \
+    normalize_project_inventory_json "service account" service-account "")"; then
+  echo "ERROR: project service-account inventory is malformed" >&2
+  exit 1
+fi
+CANONICAL_SERVICE_ACCOUNT_INVENTORY="|"
+for runtime_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}" \
+  "$SYNTHETIC_RUN_SERVICE_ACCOUNT"; do
+  CANONICAL_SERVICE_ACCOUNT_INVENTORY="${CANONICAL_SERVICE_ACCOUNT_INVENTORY}${runtime_account}|"
+  case $'\n'"$SERVICE_ACCOUNT_EMAILS"$'\n' in
+    *$'\n'"${runtime_account}"$'\n'*) ;;
+    *)
+      echo "ERROR: a canonical split/synthetic identity is absent from the project inventory" >&2
+      exit 1
+      ;;
+  esac
+done
+while IFS= read -r service_account; do
+  [ -n "$service_account" ] || continue
+  case "$CANONICAL_SERVICE_ACCOUNT_INVENTORY" in
+    *"|${service_account}|"*) continue ;;
+  esac
+  verify_policy_from_cloud "other project service account" "$EMPTY_MATRIX" \
+    gc iam service-accounts get-iam-policy "$service_account" --format=json
+done <<<"$SERVICE_ACCOUNT_EMAILS"
+
+# Project ancestors are an inherited privilege boundary.  A read failure is a
+# hard failure because absence cannot otherwise be proven.
+ANCESTORS_JSON="$(read_cloud_json "project ancestor inventory" \
+  gc projects get-ancestors "$PROJECT_ID" --format=json)" || exit 1
+if ! ANCESTOR_ROWS="$(printf '%s' "$ANCESTORS_JSON" | python3 -c '
+import json
+import re
+import sys
+
+items = json.load(sys.stdin)
+expected_project = sys.argv[1]
+if not isinstance(items, list):
+    raise SystemExit("malformed ancestor inventory")
+seen = set()
+rows = []
+for item in items:
+    if not isinstance(item, dict):
+        raise SystemExit("malformed ancestor inventory")
+    kind = item.get("type")
+    identifier = str(item.get("id", ""))
+    if kind not in {"project", "folder", "organization"}:
+        raise SystemExit("unknown ancestor type")
+    if not re.fullmatch(r"[A-Za-z0-9-]+", identifier):
+        raise SystemExit("invalid ancestor identifier")
+    key = (kind, identifier)
+    if key in seen:
+        raise SystemExit("duplicate ancestor")
+    seen.add(key)
+    if kind != "project":
+        rows.append(key)
+project_rows = [key for key in seen if key[0] == "project"]
+if project_rows != [("project", expected_project)]:
+    raise SystemExit("project ancestor inventory does not identify the audited project")
+print("\n".join("\t".join(row) for row in rows))
+' "$PROJECT_ID")"; then
+  echo "ERROR: project ancestor inventory is malformed" >&2
+  exit 1
+fi
+while IFS=$'\t' read -r ancestor_type ancestor_id; do
+  [ -n "$ancestor_type" ] || continue
+  case "$ancestor_type" in
+    folder)
+      ancestor_policy="$(read_cloud_json "folder ancestor IAM policy" \
+        gc resource-manager folders get-iam-policy "$ancestor_id" --format=json)" || exit 1
+      if ! printf '%s' "$ancestor_policy" | \
+          verify_six_runtime_matrix_json "folder ancestor" "$EMPTY_MATRIX"; then
+        echo "ERROR: folder ancestor has unsafe six-runtime IAM" >&2
+        exit 1
+      fi
+      verify_deploy_broad_permissions_absent_json "folder ancestor" "$ancestor_policy"
+      ;;
+    organization)
+      ancestor_policy="$(read_cloud_json "organization ancestor IAM policy" \
+        gc organizations get-iam-policy "$ancestor_id" --format=json)" || exit 1
+      if ! printf '%s' "$ancestor_policy" | \
+          verify_six_runtime_matrix_json "organization ancestor" "$EMPTY_MATRIX"; then
+        echo "ERROR: organization ancestor has unsafe six-runtime IAM" >&2
+        exit 1
+      fi
+      verify_deploy_broad_permissions_absent_json "organization ancestor" "$ancestor_policy"
+      ;;
+    *)
+      echo "ERROR: project ancestor inventory is malformed" >&2
+      exit 1
+      ;;
+  esac
+done <<<"$ANCESTOR_ROWS"
+
+if [ "$ROLLOUT_RECOVERY_ACTIVE" = true ]; then
+  verify_recovery_role_and_bucket_policy
+else
+  verify_journal_role_and_bucket_policy
+fi
+
+synthetic_description="$(read_cloud_json "synthetic service-account description" \
+  gc iam service-accounts describe "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
+    --format=json)" || exit 1
+if ! printf '%s' "$synthetic_description" | python3 -c '
+import json
+import sys
+
+expected = sys.argv[1]
+value = json.load(sys.stdin)
+if value.get("email") != expected or value.get("disabled", False) is not False:
+    raise SystemExit("synthetic identity is absent, renamed, or disabled")
+' "$SYNTHETIC_RUN_SERVICE_ACCOUNT"; then
+  echo "ERROR: canonical synthetic service account is absent, renamed, or disabled" >&2
+  exit 1
+fi
+synthetic_policy="$(read_cloud_json "synthetic service-account IAM policy" \
+  gc iam service-accounts get-iam-policy "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
+    --format=json)" || exit 1
+if ! printf '%s' "$synthetic_policy" | python3 -c '
+import json
+import sys
+
+policy = json.load(sys.stdin)
+expected = [{
+    "role": "roles/iam.serviceAccountUser",
+    "members": [sys.argv[1]],
+}]
+bindings = policy.get("bindings") or []
+if bindings != expected:
+    raise SystemExit("synthetic identity actAs policy differs")
+' "serviceAccount:${DEPLOY_SERVICE_ACCOUNT}"; then
+  echo "ERROR: synthetic identity does not have the exact deploy-only actAs policy" >&2
+  exit 1
+fi
+
+# The shared helper is the canonical complete-policy contract for runtime
+# service accounts.  `post` requires exactly one unconditional deploy
+# serviceAccountUser grant, permits only explicitly configured operators, and
+# rejects every cross-runtime or otherwise unapproved direct principal.
+for runtime_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do
+  runtime_description="$(read_cloud_json "runtime service-account description" \
+    gc iam service-accounts describe "$runtime_account" --format=json)" || exit 1
+  if ! printf '%s' "$runtime_description" | python3 -c '
+import json
+import sys
+
+expected = sys.argv[1]
+value = json.load(sys.stdin)
+if value.get("email") != expected or value.get("disabled", False) is not False:
+    raise SystemExit("runtime identity is absent, renamed, or disabled")
+' "$runtime_account"; then
+    echo "ERROR: a canonical runtime service account is absent, renamed, or disabled" >&2
+    exit 1
+  fi
+  runtime_policy="$(read_cloud_json "runtime service-account IAM policy" \
+    gc iam service-accounts get-iam-policy "$runtime_account" --format=json)" || exit 1
+  if ! printf '%s' "$runtime_policy" | \
+      verify_runtime_service_account_policy_json "$runtime_account" post; then
+    echo "ERROR: a runtime service account has unsafe direct IAM" >&2
+    exit 1
+  fi
+  if ! printf '%s' "$runtime_policy" | python3 -c '
+import json
+import sys
+
+member = sys.argv[1]
+policy = json.load(sys.stdin)
+matches = [
+    (binding.get("role"), binding.get("condition") if "condition" in binding else None)
+    for binding in policy.get("bindings", [])
+    if member in (binding.get("members") or [])
+]
+if matches:
+    raise SystemExit("synthetic identity may not impersonate a split runtime")
+' "serviceAccount:tr-synthetic@${PROJECT_ID}.iam.gserviceaccount.com"; then
+    echo "ERROR: synthetic identity has a direct binding on a runtime service account" >&2
+    exit 1
+  fi
+done
+
+SECRETS_JSON="$(read_cloud_json "Secret Manager inventory" \
+  gc secrets list --format=json)" || exit 1
+if ! SECRET_NAMES="$(printf '%s' "$SECRETS_JSON" | python3 -c '
+import json
+import re
+import sys
+
+project = sys.argv[1]
+items = json.load(sys.stdin)
+if not isinstance(items, list):
+    raise SystemExit("malformed secret inventory")
+names = []
+prefix = f"projects/{project}/secrets/"
+for item in items:
+    if not isinstance(item, dict) or not isinstance(item.get("name"), str):
+        raise SystemExit("malformed secret inventory")
+    name = item["name"]
+    if name.startswith("projects/"):
+        if not name.startswith(prefix):
+            raise SystemExit("cross-project secret inventory entry")
+        name = name[len(prefix):]
+    if not re.fullmatch(r"[A-Za-z0-9_-]{1,255}", name):
+        raise SystemExit("invalid secret resource identifier")
+    names.append(name)
+if len(set(names)) != len(names):
+    raise SystemExit("duplicate secret inventory entry")
+print("\n".join(sorted(names)))
+' "$PROJECT_ID")"; then
+  echo "ERROR: Secret Manager inventory is malformed" >&2
+  exit 1
+fi
+
+if ! printf '%s' "$TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON" | python3 -c '
+import json
+import sys
+
+inventory = set(sys.argv[1].splitlines())
+value = json.load(sys.stdin)
+missing = sorted(set(value) - inventory)
+if missing:
+    raise SystemExit("preserved secret accessor allowlist references absent resources")
+' "$SECRET_NAMES"; then
+  echo "ERROR: explicit preserved secret accessor inventory is invalid" >&2
+  exit 1
+fi
+
+SECRET_INVENTORY="|"
+while IFS= read -r secret_name; do
+  [ -n "$secret_name" ] || continue
+  SECRET_INVENTORY="${SECRET_INVENTORY}${secret_name}|"
+  if expected_surfaces="$(secret_expected_surfaces "$secret_name")"; then
+    :
+  else
+    expected_surfaces=""
+  fi
+  secret_policy="$(read_cloud_json "Secret Manager inventory-item IAM policy" \
+    gc secrets get-iam-policy "$secret_name" --format=json)" || exit 1
+  if ! printf '%s' "$secret_policy" | \
+      secret_iam_policy_contract_json verify "$secret_name" "$expected_surfaces"; then
+    echo "ERROR: a Secret Manager resource has unsafe exact accessor IAM" >&2
+    exit 1
+  fi
+done <<<"$SECRET_NAMES"
+
+if [ -n "$MANIFEST_PATH" ]; then
+  # The recovery manifest is intentionally non-secret.  Reject any injected
+  # secret-like field before emitting the small, fixed candidate inventory.
+  if ! MANIFEST_ROWS="$(python3 -c '
+import json
+import re
+import sys
+
+path, expected_project = sys.argv[1:3]
+try:
+    with open(path, encoding="utf-8") as source:
+        manifest = json.load(source)
+except (OSError, json.JSONDecodeError):
+    raise SystemExit("manifest is unreadable")
+
+forbidden = re.compile(r"(?:^|_)(?:secret|token|password|credential|private_key)(?:_|$)", re.I)
+def reject_sensitive_keys(value):
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if forbidden.search(str(key)):
+                raise SystemExit("manifest contains a sensitive field")
+            reject_sensitive_keys(item)
+    elif isinstance(value, list):
+        for item in value:
+            reject_sensitive_keys(item)
+reject_sensitive_keys(manifest)
+
+if not isinstance(manifest, dict) or manifest.get("project_id") != expected_project:
+    raise SystemExit("manifest project mismatch")
+regions = manifest.get("regions")
+internal_regions = manifest.get("internal_regions")
+services = manifest.get("services")
+if (
+    not isinstance(regions, list)
+    or not regions
+    or not isinstance(internal_regions, list)
+    or not internal_regions
+    or not isinstance(services, list)
+):
+    raise SystemExit("manifest candidate inventory is malformed")
+if len(set(regions)) != len(regions) or any(
+    not isinstance(region, str) or not re.fullmatch(r"[a-z]+-[a-z0-9]+[0-9]", region)
+    for region in regions
+):
+    raise SystemExit("manifest region inventory is malformed")
+if (
+    len(set(internal_regions)) != len(internal_regions)
+    or not set(regions).issubset(internal_regions)
+    or any(
+        not isinstance(region, str)
+        or not re.fullmatch(r"[a-z]+-[a-z0-9]+[0-9]", region)
+        for region in internal_regions
+    )
+):
+    raise SystemExit("manifest internal region inventory is malformed")
+
+names = {
+    "public": "trusted-router-public",
+    "actions": "trusted-router-actions",
+    "console": "trusted-router-console",
+    "chat": "trusted-router-chat",
+    "webhooks": "trusted-router-webhooks",
+    "internal": "trusted-router-billing",
+}
+rows = []
+seen = set()
+for entry in services:
+    if not isinstance(entry, dict):
+        raise SystemExit("manifest candidate entry is malformed")
+    surface = entry.get("surface")
+    region = entry.get("region")
+    name = entry.get("name")
+    candidate = entry.get("candidate_revision")
+    account = entry.get("runtime_service_account")
+    allowed_regions = internal_regions if surface == "internal" else regions
+    if surface not in names or region not in allowed_regions or name != names[surface]:
+        raise SystemExit("manifest candidate entry is noncanonical")
+    if account != f"tr-{surface}@{expected_project}.iam.gserviceaccount.com":
+        raise SystemExit("manifest candidate identity is noncanonical")
+    if not isinstance(candidate, str) or not re.fullmatch(r"[a-z][a-z0-9-]{0,61}", candidate):
+        raise SystemExit("manifest candidate revision is malformed")
+    if not candidate.startswith(name + "-"):
+        raise SystemExit("manifest candidate revision does not belong to its service")
+    key = (surface, region)
+    if key in seen:
+        raise SystemExit("manifest candidate inventory contains duplicates")
+    seen.add(key)
+    rows.append((surface, name, region, candidate, account))
+expected = {
+    (surface, region)
+    for surface in names
+    for region in (internal_regions if surface == "internal" else regions)
+}
+if seen != expected:
+    raise SystemExit("manifest candidate inventory is not the complete surface-region matrix")
+print("\n".join("\t".join(row) for row in sorted(rows)))
+' "$MANIFEST_PATH" "$PROJECT_ID" 2>/dev/null)"; then
+    echo "ERROR: rollout manifest candidate inventory is invalid" >&2
+    exit 1
+  fi
+
+  while IFS=$'\t' read -r surface service_name region candidate account; do
+    [ -n "$surface" ] || continue
+    revision_json="$(read_cloud_json "candidate Cloud Run revision" \
+      gc run revisions describe "$candidate" --region="$region" --format=json)" || exit 1
+    if ! MOUNTED_REFS="$(printf '%s' "$revision_json" | python3 -c '
+import json
+import re
+import sys
+
+project, candidate, account = sys.argv[1:4]
+revision = json.load(sys.stdin)
+if not isinstance(revision, dict):
+    raise SystemExit("candidate revision is malformed")
+metadata = revision.get("metadata") or {}
+spec = revision.get("spec") or {}
+if metadata.get("name") != candidate or spec.get("serviceAccountName") != account:
+    raise SystemExit("candidate revision identity mismatch")
+
+prefix = f"projects/{project}/secrets/"
+def normalize_name(value):
+    if not isinstance(value, str):
+        raise SystemExit("candidate secret reference is malformed")
+    if value.startswith("projects/"):
+        if not value.startswith(prefix):
+            raise SystemExit("candidate has a cross-project secret reference")
+        value = value[len(prefix):]
+    if not re.fullmatch(r"[A-Za-z0-9_-]{1,255}", value):
+        raise SystemExit("candidate secret reference is malformed")
+    return value
+
+def normalize_version(value):
+    if isinstance(value, bool):
+        raise SystemExit("candidate secret version is not numeric")
+    value = str(value)
+    if not re.fullmatch(r"[1-9][0-9]*", value):
+        raise SystemExit("candidate secret version is not numeric")
+    return value
+
+refs = []
+containers = spec.get("containers") or []
+if not isinstance(containers, list) or not containers:
+    raise SystemExit("candidate revision has no container inventory")
+for container in containers:
+    if not isinstance(container, dict):
+        raise SystemExit("candidate container is malformed")
+    for env in container.get("env") or []:
+        if not isinstance(env, dict):
+            raise SystemExit("candidate environment is malformed")
+        reference = ((env.get("valueFrom") or {}).get("secretKeyRef"))
+        if reference is None:
+            continue
+        if not isinstance(reference, dict):
+            raise SystemExit("candidate secret reference is malformed")
+        refs.append((normalize_name(reference.get("name")), normalize_version(
+            reference.get("key", reference.get("version"))
+        )))
+for volume in spec.get("volumes") or []:
+    if not isinstance(volume, dict):
+        raise SystemExit("candidate volume is malformed")
+    secret = volume.get("secret")
+    if secret is None:
+        continue
+    if not isinstance(secret, dict):
+        raise SystemExit("candidate secret volume is malformed")
+    name = normalize_name(secret.get("secretName", secret.get("name")))
+    items = secret.get("items")
+    if not isinstance(items, list) or not items:
+        raise SystemExit("candidate secret volume has an implicit version")
+    for item in items:
+        if not isinstance(item, dict):
+            raise SystemExit("candidate secret volume item is malformed")
+        refs.append((name, normalize_version(item.get("key", item.get("version")))))
+print("\n".join("\t".join(ref) for ref in sorted(set(refs))))
+' "$PROJECT_ID" "$candidate" "$account" 2>/dev/null)"; then
+      echo "ERROR: a candidate revision has malformed or unpinned mounted-secret metadata" >&2
+      exit 1
+    fi
+
+    while IFS=$'\t' read -r mounted_secret mounted_version; do
+      [ -n "$mounted_secret" ] || continue
+      case "$SECRET_INVENTORY" in
+        *"|${mounted_secret}|"*) ;;
+        *)
+          echo "ERROR: a candidate revision references a secret outside the verified project inventory" >&2
+          exit 1
+          ;;
+      esac
+      if mounted_owners="$(secret_expected_surfaces "$mounted_secret")"; then
+        case " ${mounted_owners} " in
+          *" ${surface} "*) ;;
+          *)
+            echo "ERROR: a candidate revision mounts a secret outside its declared surface ownership" >&2
+            exit 1
+            ;;
+        esac
+      else
+        echo "ERROR: a candidate revision mounts a secret with no declared static owner set" >&2
+        exit 1
+      fi
+      version_json="$(read_cloud_json "mounted secret-version status" \
+        gc secrets versions describe "$mounted_version" \
+          --secret="$mounted_secret" --format=json)" || exit 1
+      if ! printf '%s' "$version_json" | python3 -c '
+import json
+import sys
+
+project, secret, version = sys.argv[1:4]
+value = json.load(sys.stdin)
+if value.get("state") != "ENABLED":
+    raise SystemExit("mounted secret version is not enabled")
+name = value.get("name")
+expected = f"projects/{project}/secrets/{secret}/versions/{version}"
+if name is not None and name != expected:
+    raise SystemExit("mounted secret version identity mismatch")
+' "$PROJECT_ID" "$mounted_secret" "$mounted_version"; then
+        echo "ERROR: a candidate revision has a disabled or mismatched mounted secret version" >&2
+        exit 1
+      fi
+    done <<<"$MOUNTED_REFS"
+  done <<<"$MANIFEST_ROWS"
+fi
+
+echo "six-surface rollout IAM verification passed"

--- a/scripts/deploy/secrets.sh
+++ b/scripts/deploy/secrets.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 # Phase 3: push provider/OAuth/SES/Stripe secrets to Secret Manager and
-# grant the Cloud Run runtime service account access to them. Reads
+# verify exact per-resource split-runtime access. Reads
 # values from $TR_LOCAL_KEYS_FILE (~/.quill_cloud_keys.private by default)
 # or from the current shell environment.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/deploy/_lib.sh
 source "${SCRIPT_DIR}/_lib.sh"
+
+validate_runtime_service_accounts
 
 validate_synthetic_monitor_candidate() {
   local value="$1"
@@ -83,6 +85,205 @@ require_secret_from_env_file() {
   log "uploaded secret ${secret_name}"
 }
 
+secret_exists_or_error() {
+  local secret_name="$1"
+  local describe_error=""
+  if describe_error="$(gc secrets describe "$secret_name" --format='value(name)' 2>&1)"; then
+    return 0
+  fi
+  if [[ "$describe_error" == *"NOT_FOUND"* ]] ||
+     [[ "$describe_error" == *"not found"* ]]; then
+    return 1
+  fi
+  echo "ERROR: cannot determine whether secret ${secret_name} exists: ${describe_error}" >&2
+  return 2
+}
+
+ensure_generated_secret_resource() {
+  local secret_name="$1"
+  local existence_rc=0
+  if secret_exists_or_error "$secret_name"; then
+    return 0
+  else
+    existence_rc=$?
+  fi
+  if [ "$existence_rc" -ne 1 ]; then
+    return 1
+  fi
+  ensure_secret_value "$secret_name" "$(python3 - <<'PY'
+import secrets
+print(secrets.token_urlsafe(48))
+PY
+)"
+  log "generated secret ${secret_name}"
+}
+
+reconcile_declared_secret_iam() {
+  local inventory_json=""
+  local secret_names=""
+  local plans_file=""
+  local secret_name=""
+  local expected_surfaces=""
+  local policy_json=""
+  local plan=""
+  local action=""
+  local role=""
+  local member=""
+  local declared=0
+
+  inventory_json="$(gc secrets list --format=json)" || {
+    echo "ERROR: cannot inventory Secret Manager before exact IAM reconciliation" >&2
+    return 1
+  }
+  secret_names="$(printf '%s' "$inventory_json" | python3 -c '
+import json
+import re
+import sys
+
+project = sys.argv[1]
+items = json.load(sys.stdin)
+if not isinstance(items, list):
+    raise SystemExit("Secret Manager inventory is not a list")
+prefix = f"projects/{project}/secrets/"
+names = []
+for item in items:
+    if not isinstance(item, dict) or not isinstance(item.get("name"), str):
+        raise SystemExit("Secret Manager inventory entry is malformed")
+    name = item["name"]
+    if name.startswith("projects/"):
+        if not name.startswith(prefix):
+            raise SystemExit("Secret Manager inventory contains a cross-project resource")
+        name = name[len(prefix):]
+    if not re.fullmatch(r"[A-Za-z0-9_-]{1,255}", name):
+        raise SystemExit("Secret Manager inventory contains an invalid resource name")
+    names.append(name)
+if len(names) != len(set(names)):
+    raise SystemExit("Secret Manager inventory contains duplicate resources")
+print("\n".join(sorted(names)))
+' "$PROJECT_ID")" || return 1
+  if ! printf '%s' "$TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON" | python3 -c '
+import json
+import sys
+
+inventory = set(sys.argv[1].splitlines())
+value = json.load(sys.stdin)
+if set(value) - inventory:
+    raise SystemExit("preserved accessor allowlist references an absent secret")
+' "$secret_names"; then
+    echo "ERROR: preserved secret accessor allowlist references absent resources" >&2
+    return 1
+  fi
+
+  plans_file="$(mktemp "${TMPDIR:-/tmp}/tr-secret-iam-plans-XXXXXX")"
+  chmod 600 "$plans_file"
+  # Inventory and validate the complete project before the first mutation.
+  # Unrelated non-public bindings are never removed: they must be explicitly
+  # listed in TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON or this preflight fails.
+  while IFS= read -r secret_name; do
+    [ -n "$secret_name" ] || continue
+    policy_json="$(gc secrets get-iam-policy "$secret_name" --format=json)" || {
+      echo "ERROR: cannot read Secret Manager IAM for ${secret_name}" >&2
+      return 1
+    }
+    if expected_surfaces="$(secret_expected_surfaces "$secret_name")"; then
+      declared=1
+    else
+      expected_surfaces=""
+      declared=0
+      if deploy_service_account_owns_secret "$secret_name" ||
+         synthetic_service_account_owns_secret "$secret_name"; then
+        declared=1
+      fi
+    fi
+    plan="$(printf '%s' "$policy_json" | secret_iam_policy_contract_json plan \
+      "$secret_name" "$expected_surfaces")" || {
+      echo "ERROR: unsafe Secret Manager IAM preflight for ${secret_name}" >&2
+      return 1
+    }
+    if [ "$declared" = "0" ] && [ -n "$plan" ]; then
+      echo "ERROR: unknown secret ${secret_name} has runtime, deploy, synthetic, or public IAM; remove it in a separately reviewed owner change" >&2
+      return 1
+    fi
+    while IFS=$'\t' read -r action role member; do
+      [ -n "$action" ] || continue
+      [ "$declared" = "1" ] || continue
+      printf '%s\t%s\t%s\t%s\n' \
+        "$secret_name" "$action" "$role" "$member" >>"$plans_file"
+    done <<<"$plan"
+  done <<<"$secret_names"
+
+  while IFS=$'\t' read -r secret_name action role member; do
+    [ -n "$secret_name" ] || continue
+    case "$action" in
+      add)
+        gc secrets add-iam-policy-binding "$secret_name" \
+          --member="$member" \
+          --role="$role" \
+          --condition=None \
+          --quiet >/dev/null
+        ;;
+      remove)
+        gc secrets remove-iam-policy-binding "$secret_name" \
+          --member="$member" \
+          --role="$role" \
+          --condition=None \
+          --quiet >/dev/null
+        ;;
+      *)
+        echo "ERROR: invalid preflighted secret IAM action ${action}" >&2
+        return 1
+        ;;
+    esac
+  done <"$plans_file"
+
+  while IFS= read -r secret_name; do
+    [ -n "$secret_name" ] || continue
+    if expected_surfaces="$(secret_expected_surfaces "$secret_name")"; then
+      :
+    else
+      expected_surfaces=""
+    fi
+    policy_json="$(gc secrets get-iam-policy "$secret_name" --format=json)" || return 1
+    if ! printf '%s' "$policy_json" | secret_iam_policy_contract_json verify \
+        "$secret_name" "$expected_surfaces"; then
+      echo "ERROR: exact Secret Manager IAM postcondition failed for ${secret_name}" >&2
+      return 1
+    fi
+  done <<<"$secret_names"
+  rm -f "$plans_file"
+}
+
+verify_runtime_secret_access() {
+  local requirement="$1"
+  local secret_name="$2"
+  local expected_surfaces=""
+  local existence_rc=0
+  local policy_json=""
+  if secret_exists_or_error "$secret_name"; then
+    :
+  else
+    existence_rc=$?
+    if [ "$existence_rc" -eq 1 ] && [ "$requirement" = "optional" ]; then
+      return 0
+    fi
+    if [ "$existence_rc" -eq 1 ]; then
+      echo "ERROR: required runtime secret ${secret_name} does not exist" >&2
+    fi
+    return 1
+  fi
+  if expected_surfaces="$(secret_expected_surfaces "$secret_name")"; then
+    :
+  else
+    expected_surfaces=""
+  fi
+  policy_json="$(gc secrets get-iam-policy "$secret_name" --format=json)" || return 1
+  if ! printf '%s' "$policy_json" | secret_iam_policy_contract_json verify \
+      "$secret_name" "$expected_surfaces"; then
+    echo "ERROR: exact Secret Manager accessor contract failed for ${secret_name}" >&2
+    return 1
+  fi
+}
+
 ensure_secret_from_prompt_file() {
   local secret_name="$1"
   local prompt_file="$2"
@@ -139,13 +340,11 @@ ensure_secret_from_env_file "TOGETHER_API_KEY" "trustedrouter-together-api-key" 
 ensure_secret_from_env_file "FIREWORKS_API_KEY" "trustedrouter-fireworks-api-key" "FIREWORKS_AI_API_KEY"
 ensure_secret_from_env_file "DEEPINFRA_API_KEY" "trustedrouter-deepinfra-api-key"
 # Cohere — embeddings only (native /v2/embed in the enclave). Reads
-# COHERE_API_KEY from ~/.quill_cloud_keys.private. Runtime read access comes
-# from the project-level secretAccessor binding (infra.sh), like every other
-# provider secret.
+# COHERE_API_KEY from ~/.quill_cloud_keys.private. The chat-only resource
+# binding is verified below with every other provider secret.
 ensure_secret_from_env_file "COHERE_API_KEY" "trustedrouter-cohere-api-key"
 # Voyage AI — embeddings only (OpenAI-shaped /v1/embeddings in the enclave).
-# Reads VOYAGE_API_KEY from ~/.quill_cloud_keys.private. Same project-level
-# secretAccessor binding as every other provider secret.
+# Reads VOYAGE_API_KEY from ~/.quill_cloud_keys.private. It is also chat-only.
 ensure_secret_from_env_file "VOYAGE_API_KEY" "trustedrouter-voyage-api-key"
 # Xiaomi MiMo — OpenAI-compatible chat (api.xiaomimimo.com/v1). Reads
 # XIAOMI_API_KEY from ~/.quill_cloud_keys.private.
@@ -228,7 +427,7 @@ ensure_secret_from_prompt_file "trustedrouter-socrates-advisor-prompt-v1" "$SOCR
 ensure_secret_from_prompt_file "trustedrouter-athena-worker-prompt-v1" "$ATHENA_PROMPTS_FILE" "Worker Prompt V1"
 
 ensure_secret_from_env_file "TR_SYNTHETIC_MONITOR_API_KEY" "trustedrouter-synthetic-monitor-api-key" "SYNTHETIC_MONITOR_API_KEY"
-ensure_secret_from_env_file "SENTRY_DSN" "trustedrouter-sentry-dsn"
+require_secret_from_env_file "SENTRY_DSN" "trustedrouter-sentry-dsn"
 ensure_secret_from_env_file \
   "TR_OPS_CHAT_WEBHOOK_SECRET" \
   "trustedrouter-ops-chat-webhook-secret" \
@@ -238,68 +437,11 @@ ensure_secret_from_env_file \
 # pushed to Secret Manager like every other TR secret. The GHA WIF service
 # account receives access only to the individual secrets it needs.
 ensure_secret_from_env_file "TR_API_KEY_FOR_SELF_HEAL" "trustedrouter-tr-api-key-for-self-heal"
-TR_DEPLOY_SA="${TR_DEPLOY_SA:-tr-deploy@${PROJECT_ID}.iam.gserviceaccount.com}"
-
-grant_tr_deploy_secret_access() {
-  local secret_name="$1"
-  if ! gc secrets describe "$secret_name" >/dev/null 2>&1; then
-    return
-  fi
-  log "granting ${TR_DEPLOY_SA} accessor on ${secret_name}"
-  gc secrets add-iam-policy-binding "$secret_name" \
-    --member="serviceAccount:${TR_DEPLOY_SA}" \
-    --role="roles/secretmanager.secretAccessor" \
-    --quiet >/dev/null \
-    || log "WARN: per-secret binding for ${secret_name} returned non-zero"
-}
-
-grant_tr_deploy_secret_access "trustedrouter-tr-api-key-for-self-heal"
-grant_tr_deploy_secret_access "trustedrouter-ops-chat-webhook-secret"
-grant_tr_deploy_secret_access "trustedrouter-together-api-key"
-grant_tr_deploy_secret_access "trustedrouter-parasail-api-key"
-grant_tr_deploy_secret_access "trustedrouter-lightning-api-key"
-grant_tr_deploy_secret_access "trustedrouter-gmi-api-key"
-grant_tr_deploy_secret_access "trustedrouter-deepinfra-api-key"
-grant_tr_deploy_secret_access "trustedrouter-phala-confidential-api-key"
-grant_tr_deploy_secret_access "trustedrouter-siliconflow-api-key"
-grant_tr_deploy_secret_access "trustedrouter-venice-api-key"
-grant_tr_deploy_secret_access "trustedrouter-openai-api-key"
-grant_tr_deploy_secret_access "trustedrouter-grok-api-key"
-grant_tr_deploy_secret_access "trustedrouter-deepseek-api-key"
-grant_tr_deploy_secret_access "trustedrouter-mistral-api-key"
-grant_tr_deploy_secret_access "trustedrouter-zai-api-key"
-grant_tr_deploy_secret_access "trustedrouter-cerebras-api-key"
-grant_tr_deploy_secret_access "trustedrouter-kimi-api-key"
-grant_tr_deploy_secret_access "trustedrouter-fireworks-api-key"
-grant_tr_deploy_secret_access "trustedrouter-gemini-api-key"
-grant_tr_deploy_secret_access "trustedrouter-novita-api-key"
-grant_tr_deploy_secret_access "trustedrouter-nebius-api-key"
-grant_tr_deploy_secret_access "trustedrouter-minimax-api-key"
-grant_tr_deploy_secret_access "trustedrouter-crusoe-api-key"
-grant_tr_deploy_secret_access "trustedrouter-friendli-api-key"
-grant_tr_deploy_secret_access "trustedrouter-baseten-api-key"
-grant_tr_deploy_secret_access "trustedrouter-telnyx-api-key"
-grant_tr_deploy_secret_access "trustedrouter-veriff-api-key"
-grant_tr_deploy_secret_access "trustedrouter-veriff-shared-secret-key"
-grant_tr_deploy_secret_access "trustedrouter-wafer-api-key"
-grant_tr_deploy_secret_access "trustedrouter-alibaba-api-key"
-grant_tr_deploy_secret_access "trustedrouter-makora-api-key"
-grant_tr_deploy_secret_access "trustedrouter-chutes-api-key"
-grant_tr_deploy_secret_access "trustedrouter-digitalocean-api-key"
-grant_tr_deploy_secret_access "trustedrouter-cloudflare-workers-ai-api-token"
-grant_tr_deploy_secret_access "trustedrouter-inceptron-api-key"
-grant_tr_deploy_secret_access "trustedrouter-morph-api-key"
-grant_tr_deploy_secret_access "trustedrouter-atlas-cloud-api-key"
-grant_tr_deploy_secret_access "trustedrouter-streamlake-api-key"
-grant_tr_deploy_secret_access "trustedrouter-neurometric-api-key"
-grant_tr_deploy_secret_access "trustedrouter-engy-api-key"
-grant_tr_deploy_secret_access "trustedrouter-pearl-api-key"
-grant_tr_deploy_secret_access "trustedrouter-zero-g-api-key"
-grant_tr_deploy_secret_access "trustedrouter-clickhouse-control-read-password"
-grant_tr_deploy_secret_access "trustedrouter-adyen-test-api-key"
-grant_tr_deploy_secret_access "trustedrouter-adyen-test-client-key"
-grant_tr_deploy_secret_access "trustedrouter-adyen-test-hmac-key"
-grant_tr_deploy_secret_access "trustedrouter-adyen-test-reference-key"
+if [ -n "${TR_DEPLOY_SA:-}" ] && [ "$TR_DEPLOY_SA" != "$DEPLOY_SERVICE_ACCOUNT" ]; then
+  echo "ERROR: TR_DEPLOY_SA must match TR_DEPLOY_SERVICE_ACCOUNT" >&2
+  exit 1
+fi
+TR_DEPLOY_SA="$DEPLOY_SERVICE_ACCOUNT"
 
 # Axiom logging — ship structured logs to a dedicated dataset for
 # slice-and-dice analysis (request_id correlation, rate-limit hits,
@@ -309,6 +451,57 @@ grant_tr_deploy_secret_access "trustedrouter-adyen-test-reference-key"
 ensure_secret_from_env_file "AXIOM_API_TOKEN" "trustedrouter-axiom-api-token" "AXIOM_TOKEN" "AXIOM_API_KEY"
 require_secret_from_env_file "STRIPE_SECRET_KEY" "trustedrouter-stripe-secret-key" "STRIPE_KEY"
 require_secret_from_env_file "STRIPE_WEBHOOK_SECRET" "trustedrouter-stripe-webhook-secret"
+require_secret_from_env_file \
+  "TR_INTERNAL_STRIPE_PAYMENT_INTENTS_KEY" \
+  "trustedrouter-internal-stripe-payment-intents-key"
+
+# The internal billing process creates off-session PaymentIntents but must not
+# inherit the console's full Stripe key. Stripe restricted live keys carry the
+# rk_live_ prefix; the exact dashboard permission contract is documented and
+# must be verified provider-side because Secret Manager can only attest to the
+# stored bytes and IAM, not Stripe's permission switches.
+_internal_stripe_key="$(gc secrets versions access latest \
+  --secret=trustedrouter-internal-stripe-payment-intents-key)"
+_console_stripe_key="$(gc secrets versions access latest \
+  --secret=trustedrouter-stripe-secret-key)"
+case "$_internal_stripe_key" in
+  rk_live_?*) ;;
+  *)
+    echo "ERROR: internal Stripe key must be a live restricted rk_live_ key" >&2
+    exit 1
+    ;;
+esac
+if [ "$_internal_stripe_key" = "$_console_stripe_key" ]; then
+  echo "ERROR: internal Stripe key must differ from the console Stripe key" >&2
+  exit 1
+fi
+unset _internal_stripe_key _console_stripe_key
+
+ensure_secret_from_env_file \
+  "TR_ATTRIBUTION_COOKIE_SECRET" \
+  "trustedrouter-attribution-cookie-secret"
+_attribution_exists_rc=0
+if secret_exists_or_error trustedrouter-attribution-cookie-secret; then
+  :
+else
+  _attribution_exists_rc=$?
+  if [ "$_attribution_exists_rc" -ne 1 ]; then
+    exit 1
+  fi
+  ensure_secret_value trustedrouter-attribution-cookie-secret "$(python3 - <<'PY'
+import secrets
+print(secrets.token_hex(32))
+PY
+)"
+  log "generated secret trustedrouter-attribution-cookie-secret"
+fi
+_attribution_cookie_secret="$(gc secrets versions access latest \
+  --secret=trustedrouter-attribution-cookie-secret)"
+if [ "${#_attribution_cookie_secret}" -lt 32 ]; then
+  echo "ERROR: attribution cookie secret must contain at least 32 characters" >&2
+  exit 1
+fi
+unset _attribution_exists_rc _attribution_cookie_secret
 
 # OAuth + SES secrets — independently optional. Push to Secret Manager only
 # when the local keys file (or env) supplies a value; production fail-closed
@@ -323,9 +516,36 @@ ensure_secret_from_env_file "GITHUB_CLIENT_SECRET" "trustedrouter-github-client-
 ensure_secret_from_env_file \
   "GITHUB_ALIAS_CREDENTIALS_JSON" \
   "trustedrouter-github-alias-credentials-json"
-# SES email credentials only; not used for AWS hosting or failover.
-ensure_secret_from_env_file "AWS_ACCESS_KEY_ID" "trustedrouter-aws-access-key-id"
-ensure_secret_from_env_file "AWS_SECRET_ACCESS_KEY" "trustedrouter-aws-secret-access-key"
+# SES email credentials only; not used for AWS hosting or failover. Internal
+# billing gets an independent AWS principal whose provider-side policy allows
+# ses:SendEmail and nothing else; sharing the console/actions key would undo
+# the service-account split even if Secret Manager resource names differed.
+require_secret_from_env_file "AWS_ACCESS_KEY_ID" "trustedrouter-aws-access-key-id"
+require_secret_from_env_file "AWS_SECRET_ACCESS_KEY" "trustedrouter-aws-secret-access-key"
+require_secret_from_env_file \
+  "TR_INTERNAL_SES_ACCESS_KEY_ID" \
+  "trustedrouter-internal-ses-access-key-id"
+require_secret_from_env_file \
+  "TR_INTERNAL_SES_SECRET_ACCESS_KEY" \
+  "trustedrouter-internal-ses-secret-access-key"
+_internal_ses_access_key_id="$(gc secrets versions access latest \
+  --secret=trustedrouter-internal-ses-access-key-id)"
+_internal_ses_secret_access_key="$(gc secrets versions access latest \
+  --secret=trustedrouter-internal-ses-secret-access-key)"
+_shared_ses_access_key_id="$(gc secrets versions access latest \
+  --secret=trustedrouter-aws-access-key-id)"
+_shared_ses_secret_access_key="$(gc secrets versions access latest \
+  --secret=trustedrouter-aws-secret-access-key)"
+if [ "$_internal_ses_access_key_id" = "$_shared_ses_access_key_id" ] ||
+   [ "$_internal_ses_secret_access_key" = "$_shared_ses_secret_access_key" ]; then
+  echo "ERROR: internal SES credentials must differ from console/actions SES credentials" >&2
+  exit 1
+fi
+unset \
+  _internal_ses_access_key_id \
+  _internal_ses_secret_access_key \
+  _shared_ses_access_key_id \
+  _shared_ses_secret_access_key
 ensure_secret_from_env_file "PAYPAL_CLIENT_ID" "trustedrouter-paypal-client-id"
 ensure_secret_from_env_file "PAYPAL_CLIENT_SECRET" "trustedrouter-paypal-client-secret"
 ensure_secret_from_env_file "PAYPAL_WEBHOOK_ID" "trustedrouter-paypal-webhook-id"
@@ -334,33 +554,214 @@ ensure_secret_from_env_file "ADYEN_CLIENT_KEY" "trustedrouter-adyen-test-client-
 ensure_secret_from_env_file "ADYEN_HMAC_KEY" "trustedrouter-adyen-test-hmac-key"
 ensure_secret_from_env_file \
   "ADYEN_REFERENCE_KEY" "trustedrouter-adyen-test-reference-key"
-if ! gc secrets describe trustedrouter-internal-gateway-token >/dev/null 2>&1; then
-  ensure_secret_value trustedrouter-internal-gateway-token "$(python3 - <<'PY'
-import secrets
-print(secrets.token_urlsafe(48))
-PY
-)"
-  log "generated secret trustedrouter-internal-gateway-token"
-fi
-if ! gc secrets describe trustedrouter-observer-internal-token >/dev/null 2>&1; then
-  ensure_secret_value trustedrouter-observer-internal-token "$(python3 - <<'PY'
-import secrets
-print(secrets.token_urlsafe(48))
-PY
-)"
-  log "generated secret trustedrouter-observer-internal-token"
-fi
+ensure_generated_secret_resource trustedrouter-internal-gateway-token
+ensure_generated_secret_resource trustedrouter-observer-internal-token
 # A copied billing token would silently undo the surface split. Compare values
 # without logging either secret and fail before the rollout can consume them.
 _observer_token_check="$(gc secrets versions access latest \
   --secret=trustedrouter-observer-internal-token)"
 _gateway_token_check="$(gc secrets versions access latest \
   --secret=trustedrouter-internal-gateway-token)"
+_attribution_token_check="$(gc secrets versions access latest \
+  --secret=trustedrouter-attribution-cookie-secret)"
 if [ "$_observer_token_check" = "$_gateway_token_check" ]; then
   echo "ERROR: observer internal token must differ from billing gateway token" >&2
   exit 1
 fi
-unset _observer_token_check _gateway_token_check
+if [ "$_attribution_token_check" = "$_gateway_token_check" ] ||
+   [ "$_attribution_token_check" = "$_observer_token_check" ]; then
+  echo "ERROR: attribution cookie secret must differ from internal credentials" >&2
+  exit 1
+fi
+if secret_exists_or_error trustedrouter-synthetic-monitor-api-key; then
+  _monitor_token_check="$(gc secrets versions access latest \
+    --secret=trustedrouter-synthetic-monitor-api-key)"
+  if [ "$_monitor_token_check" = "$_observer_token_check" ] ||
+     [ "$_monitor_token_check" = "$_gateway_token_check" ] ||
+     [ "$_monitor_token_check" = "$_attribution_token_check" ]; then
+    echo "ERROR: synthetic monitor key must differ from browser and internal credentials" >&2
+    exit 1
+  fi
+  unset _monitor_token_check
+else
+  _monitor_exists_rc=$?
+  if [ "$_monitor_exists_rc" -ne 1 ]; then
+    exit 1
+  fi
+  unset _monitor_exists_rc
+fi
+unset _observer_token_check _gateway_token_check _attribution_token_check
+
+# Reconcile only the declared six-surface, synthetic, and checked-in deploy
+# resources. The complete project inventory is still read before the first
+# mutation: an unknown secret with runtime, deploy, synthetic, or public access
+# fails closed for a separate owner review instead of being rewritten here.
+log "reconciling declared Secret Manager accessor ownership"
+reconcile_declared_secret_iam
+
+# Repeat the named capability checks as readable postconditions. Optional
+# means the resource may be absent, never that an existing resource may have a
+# broader owner set.
+log "verifying required split-runtime Secret Manager ownership"
+verify_runtime_secret_access required \
+  trustedrouter-attribution-cookie-secret \
+  "$PUBLIC_RUN_SERVICE_ACCOUNT" "$CONSOLE_RUN_SERVICE_ACCOUNT"
+verify_runtime_secret_access required \
+  trustedrouter-sentry-dsn \
+  "$CONSOLE_RUN_SERVICE_ACCOUNT" \
+  "$CHAT_RUN_SERVICE_ACCOUNT" \
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT" \
+  "$INTERNAL_RUN_SERVICE_ACCOUNT"
+verify_runtime_secret_access required \
+  trustedrouter-stripe-secret-key \
+  "$CONSOLE_RUN_SERVICE_ACCOUNT"
+verify_runtime_secret_access required \
+  trustedrouter-stripe-webhook-secret \
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT"
+verify_runtime_secret_access required \
+  trustedrouter-internal-stripe-payment-intents-key \
+  "$INTERNAL_RUN_SERVICE_ACCOUNT"
+for secret_name in \
+  trustedrouter-aws-access-key-id \
+  trustedrouter-aws-secret-access-key; do
+  verify_runtime_secret_access required "$secret_name" \
+    "$ACTIONS_RUN_SERVICE_ACCOUNT" "$CONSOLE_RUN_SERVICE_ACCOUNT"
+done
+for secret_name in \
+  trustedrouter-internal-ses-access-key-id \
+  trustedrouter-internal-ses-secret-access-key \
+  trustedrouter-internal-gateway-token \
+  trustedrouter-observer-internal-token \
+  trustedrouter-synthetic-monitor-api-key; do
+  verify_runtime_secret_access required "$secret_name" \
+    "$INTERNAL_RUN_SERVICE_ACCOUNT"
+done
+
+log "verifying optional split-runtime Secret Manager ownership"
+verify_runtime_secret_access optional \
+  trustedrouter-ops-chat-webhook-secret \
+  "$ACTIONS_RUN_SERVICE_ACCOUNT"
+for secret_name in \
+  trustedrouter-google-client-id \
+  trustedrouter-google-client-secret \
+  trustedrouter-google-alias-credentials-json \
+  trustedrouter-github-client-id \
+  trustedrouter-github-client-secret \
+  trustedrouter-github-alias-credentials-json \
+  trustedrouter-clickhouse-provider-read-password \
+  trustedrouter-twilio-account-sid \
+  trustedrouter-twilio-api-key-sid \
+  trustedrouter-twilio-api-key-secret \
+  trustedrouter-twilio-auth-token; do
+  verify_runtime_secret_access optional "$secret_name" \
+    "$CONSOLE_RUN_SERVICE_ACCOUNT"
+done
+for secret_name in \
+  trustedrouter-paypal-client-id \
+  trustedrouter-paypal-client-secret \
+  trustedrouter-adyen-test-reference-key; do
+  verify_runtime_secret_access optional "$secret_name" \
+    "$CONSOLE_RUN_SERVICE_ACCOUNT" "$WEBHOOKS_RUN_SERVICE_ACCOUNT"
+done
+for secret_name in \
+  trustedrouter-paypal-webhook-id \
+  trustedrouter-adyen-test-hmac-key \
+  trustedrouter-veriff-shared-secret-key; do
+  verify_runtime_secret_access optional "$secret_name" \
+    "$WEBHOOKS_RUN_SERVICE_ACCOUNT"
+done
+for secret_name in \
+  trustedrouter-adyen-test-api-key \
+  trustedrouter-adyen-test-client-key \
+  trustedrouter-veriff-api-key; do
+  verify_runtime_secret_access optional "$secret_name" \
+    "$CONSOLE_RUN_SERVICE_ACCOUNT"
+done
+verify_runtime_secret_access optional \
+  trustedrouter-clickhouse-password \
+  "$CONSOLE_RUN_SERVICE_ACCOUNT" "$INTERNAL_RUN_SERVICE_ACCOUNT"
+verify_runtime_secret_access optional \
+  trustedrouter-clickhouse-control-read-password \
+  "$PUBLIC_RUN_SERVICE_ACCOUNT" \
+  "$CONSOLE_RUN_SERVICE_ACCOUNT" \
+  "$INTERNAL_RUN_SERVICE_ACCOUNT"
+# None of the six split runtimes reads AXIOM_API_TOKEN. Keep the secret
+# detached instead of granting a logging credential by habit; an explicitly
+# approved external shipper can own it separately.
+verify_runtime_secret_access optional trustedrouter-axiom-api-token
+for secret_name in \
+  trustedrouter-federation-peer-token \
+  trustedrouter-federation-home-token \
+  trustedrouter-federation-credit-inbound-token \
+  trustedrouter-federation-credit-peer-token \
+  trustedrouter-federation-settlement-inbound-tokens \
+  trustedrouter-federation-settlement-home-token; do
+  verify_runtime_secret_access optional "$secret_name" \
+    "$INTERNAL_RUN_SERVICE_ACCOUNT"
+done
+
+# The chat surface validates the caller and forwards to the separately attested
+# API service; it never calls inference providers directly.  Keep every
+# upstream provider credential and inference prompt detached from all six
+# split runtimes.  Telnyx is the sole exception because console owns the voice
+# operation routes; it is still forbidden on chat.
+DETACHED_PROVIDER_SECRET_NAMES=(
+  trustedrouter-anthropic-api-key
+  trustedrouter-openai-api-key
+  trustedrouter-openai-video-api-key
+  trustedrouter-gemini-api-key
+  trustedrouter-cerebras-api-key
+  trustedrouter-deepseek-api-key
+  trustedrouter-mistral-api-key
+  trustedrouter-kimi-api-key
+  trustedrouter-zai-api-key
+  trustedrouter-together-api-key
+  trustedrouter-fireworks-api-key
+  trustedrouter-deepinfra-api-key
+  trustedrouter-cohere-api-key
+  trustedrouter-voyage-api-key
+  trustedrouter-xiaomi-api-key
+  trustedrouter-grok-api-key
+  trustedrouter-novita-api-key
+  trustedrouter-phala-api-key
+  trustedrouter-phala-confidential-api-key
+  trustedrouter-siliconflow-api-key
+  trustedrouter-tinfoil-api-key
+  trustedrouter-venice-api-key
+  trustedrouter-nebius-api-key
+  trustedrouter-minimax-api-key
+  trustedrouter-friendli-api-key
+  trustedrouter-baseten-api-key
+  trustedrouter-telnyx-api-key
+  trustedrouter-thinking-machines-api-key
+  trustedrouter-wafer-api-key
+  trustedrouter-crusoe-api-key
+  trustedrouter-makora-api-key
+  trustedrouter-alibaba-api-key
+  trustedrouter-ltx-api-key
+  trustedrouter-runway-api-key
+  trustedrouter-kling-api-key
+  trustedrouter-chutes-api-key
+  trustedrouter-digitalocean-api-key
+  trustedrouter-cloudflare-workers-ai-api-token
+  trustedrouter-inceptron-api-key
+  trustedrouter-morph-api-key
+  trustedrouter-atlas-cloud-api-key
+  trustedrouter-streamlake-api-key
+  trustedrouter-neurometric-api-key
+  trustedrouter-engy-api-key
+  trustedrouter-pearl-api-key
+  trustedrouter-zero-g-api-key
+  trustedrouter-athena-worker-prompt-v1
+)
+for secret_name in "${DETACHED_PROVIDER_SECRET_NAMES[@]}"; do
+  if [ "$secret_name" = "trustedrouter-telnyx-api-key" ]; then
+    verify_runtime_secret_access optional "$secret_name" \
+      "$CONSOLE_RUN_SERVICE_ACCOUNT"
+  else
+    verify_runtime_secret_access optional "$secret_name"
+  fi
+done
 
 # Runtime-SA project-level IAM bindings live in infra.sh (Phase 1
 # bootstrap, run as a project Owner). Calling projects.setIamPolicy

--- a/scripts/deploy/synthetic.sh
+++ b/scripts/deploy/synthetic.sh
@@ -10,15 +10,13 @@ source "${SCRIPT_DIR}/_lib.sh"
 # shellcheck source=scripts/deploy/_private_run_ingress.sh
 source "${SCRIPT_DIR}/_private_run_ingress.sh"
 
+validate_runtime_service_accounts
+
 # Observer-token jobs cannot safely target the legacy combined service: before
 # the split that service accepts only the billing gateway token, so the jobs
 # would deploy successfully and then silently 401 every ingest. Require the
-# independently named internal service explicitly and re-check its live
+# independently named internal service and re-check its live
 # contract immediately before every job deployment below.
-[ -n "${TR_BILLING_SERVICE:-}" ] || {
-  echo "ERROR: TR_BILLING_SERVICE is required; refusing observer-token jobs against the legacy service" >&2
-  exit 1
-}
 [ "$TR_BILLING_SERVICE" != "$SERVICE" ] || {
   echo "ERROR: TR_BILLING_SERVICE must be separate from legacy SERVICE" >&2
   exit 1
@@ -30,6 +28,52 @@ case "$TR_BILLING_SERVICE" in
     ;;
 esac
 SYNTHETIC_INGEST_SERVICE="$TR_BILLING_SERVICE"
+[ "$SYNTHETIC_RUN_SERVICE_ACCOUNT" = "tr-synthetic@${PROJECT_ID}.iam.gserviceaccount.com" ] || {
+  echo "ERROR: synthetic Jobs require the canonical dedicated tr-synthetic identity" >&2
+  exit 1
+}
+synthetic_account_json="$(gc iam service-accounts describe \
+  "$SYNTHETIC_RUN_SERVICE_ACCOUNT" --format=json)" || {
+    echo "ERROR: dedicated synthetic identity is not provisioned; separate narrow IAM approval is required" >&2
+    exit 1
+  }
+if ! printf '%s' "$synthetic_account_json" | python3 -c '
+import json
+import sys
+
+account = json.load(sys.stdin)
+if account.get("email") != sys.argv[1] or account.get("disabled", False) is not False:
+    raise SystemExit("synthetic identity is missing, disabled, or renamed")
+' "$SYNTHETIC_RUN_SERVICE_ACCOUNT"; then
+  echo "ERROR: dedicated synthetic identity is missing, disabled, or renamed" >&2
+  exit 1
+fi
+synthetic_account_policy="$(gc iam service-accounts get-iam-policy \
+  "$SYNTHETIC_RUN_SERVICE_ACCOUNT" --format=json)" || exit 1
+if ! printf '%s' "$synthetic_account_policy" | python3 -c '
+import json
+import sys
+
+policy = json.load(sys.stdin)
+bindings = policy.get("bindings") or []
+if len(bindings) != 1:
+    raise SystemExit("synthetic identity IAM binding inventory differs")
+binding = bindings[0]
+if binding.get("role") != "roles/iam.serviceAccountUser":
+    raise SystemExit("synthetic identity actAs role differs")
+if binding.get("condition") is not None:
+    raise SystemExit("synthetic identity actAs grant is conditional")
+if (binding.get("members") or []) != [sys.argv[1]]:
+    raise SystemExit("synthetic identity actAs member inventory differs")
+' "serviceAccount:${DEPLOY_SERVICE_ACCOUNT}"; then
+  echo "ERROR: dedicated synthetic identity IAM is not the narrow reviewed policy" >&2
+  exit 1
+fi
+verify_exact_unconditional_roles \
+  "project IAM roles on the synthetic Job identity" \
+  "serviceAccount:${SYNTHETIC_RUN_SERVICE_ACCOUNT}" \
+  "" \
+  gc projects get-iam-policy "$PROJECT_ID"
 
 if ! gc secrets describe trustedrouter-synthetic-monitor-api-key >/dev/null 2>&1; then
   log "synthetic monitor key secret is missing; skipping synthetic monitor deploy"
@@ -40,30 +84,132 @@ if ! gc secrets describe trustedrouter-observer-internal-token >/dev/null 2>&1; 
   exit 1
 fi
 
-SECRET_ENVS=(
-  "TR_SENTRY_DSN=trustedrouter-sentry-dsn:latest"
-  "TR_OBSERVER_INTERNAL_TOKEN=trustedrouter-observer-internal-token:latest"
-  "TR_SYNTHETIC_MONITOR_API_KEY=trustedrouter-synthetic-monitor-api-key:latest"
-)
-add_secret_env_if_exists() {
-  local env_name="$1"
-  local secret_name="$2"
-  if gc secrets describe "$secret_name" >/dev/null 2>&1; then
-    SECRET_ENVS+=("${env_name}=${secret_name}:latest")
-  fi
+verify_synthetic_secret_access() {
+  local secret_name policy_json expected_surfaces
+  for secret_name in \
+    trustedrouter-observer-internal-token \
+    trustedrouter-synthetic-monitor-api-key; do
+    expected_surfaces="$(secret_expected_surfaces "$secret_name")" || return 1
+    policy_json="$(gc secrets get-iam-policy "$secret_name" --format=json)" || return 1
+    if ! printf '%s' "$policy_json" | secret_iam_policy_contract_json verify \
+        "$secret_name" "$expected_surfaces"; then
+      echo "ERROR: ${secret_name} does not have the exact reviewed accessor policy" >&2
+      return 1
+    fi
+  done
 }
-add_secret_env_if_exists "ANTHROPIC_API_KEY" "trustedrouter-anthropic-api-key"
-add_secret_env_if_exists "OPENAI_API_KEY" "trustedrouter-openai-api-key"
-add_secret_env_if_exists "GEMINI_API_KEY" "trustedrouter-gemini-api-key"
-add_secret_env_if_exists "CEREBRAS_API_KEY" "trustedrouter-cerebras-api-key"
-add_secret_env_if_exists "DEEPSEEK_API_KEY" "trustedrouter-deepseek-api-key"
-add_secret_env_if_exists "MISTRAL_API_KEY" "trustedrouter-mistral-api-key"
-add_secret_env_if_exists "KIMI_API_KEY" "trustedrouter-kimi-api-key"
-add_secret_env_if_exists "ZAI_API_KEY" "trustedrouter-zai-api-key"
+
+resolve_newest_enabled_secret_version() {
+  local secret_name="$1" versions_json
+  versions_json="$(gc secrets versions list "$secret_name" \
+    --filter='state=ENABLED' --format=json)" || return 1
+  printf '%s' "$versions_json" | python3 -c '
+import json
+import sys
+
+items = json.load(sys.stdin)
+versions = []
+for item in items:
+    if item.get("state") != "ENABLED":
+        continue
+    version = str(item.get("name") or "").rstrip("/").split("/")[-1]
+    if not version.isdigit() or version.startswith("0"):
+        raise SystemExit("enabled secret version name is not numeric")
+    versions.append(int(version))
+if not versions:
+    raise SystemExit("secret has no enabled numeric version")
+print(max(versions))
+'
+}
+
+OBSERVER_SECRET_VERSION="$(resolve_newest_enabled_secret_version \
+  trustedrouter-observer-internal-token)" || {
+    echo "ERROR: cannot resolve an enabled observer-token version" >&2
+    exit 1
+  }
+MONITOR_SECRET_VERSION="$(resolve_newest_enabled_secret_version \
+  trustedrouter-synthetic-monitor-api-key)" || {
+    echo "ERROR: cannot resolve an enabled synthetic-monitor version" >&2
+    exit 1
+  }
+SECRET_ENVS=(
+  "TR_OBSERVER_INTERNAL_TOKEN=trustedrouter-observer-internal-token:${OBSERVER_SECRET_VERSION}"
+  "TR_SYNTHETIC_MONITOR_API_KEY=trustedrouter-synthetic-monitor-api-key:${MONITOR_SECRET_VERSION}"
+)
 # Complete allowlist: --set-secrets removes legacy gateway/payment bindings
 # from an existing job instead of preserving omitted secrets across updates.
 SET_SECRETS="$(IFS=,; echo "${SECRET_ENVS[*]}")"
 
+verify_synthetic_job_secret_contract() {
+  local job_name="$1" region="$2" job_json
+  job_json="$(gc run jobs describe "$job_name" --region="$region" --format=json)" || {
+    echo "ERROR: cannot read deployed synthetic Job ${region}/${job_name}" >&2
+    return 1
+  }
+  printf '%s' "$job_json" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+expected_identity, observer_version, monitor_version = sys.argv[1:]
+containers = []
+identities = []
+
+def visit(value):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key in {"serviceAccount", "serviceAccountName"} and isinstance(child, str):
+                identities.append(child)
+            if key == "containers" and isinstance(child, list):
+                containers.extend(child)
+            visit(child)
+    elif isinstance(value, list):
+        for child in value:
+            visit(child)
+
+visit(data.get("spec") or {})
+if sorted(set(identities)) != [expected_identity]:
+    raise SystemExit("synthetic Job runtime identity differs")
+if len(containers) != 1:
+    raise SystemExit("synthetic Job container inventory differs")
+env = {
+    item.get("name"): item
+    for item in containers[0].get("env", [])
+    if item.get("name")
+}
+actual = {}
+for name, item in env.items():
+    if "valueFrom" not in item:
+        continue
+    reference = (item.get("valueFrom") or {}).get("secretKeyRef") or {}
+    actual[name] = {
+        "resource": str(reference.get("name") or reference.get("secret") or "").split("/")[-1],
+        "version": str(reference.get("key") or reference.get("version") or ""),
+    }
+expected = {
+    "TR_OBSERVER_INTERNAL_TOKEN": {
+        "resource": "trustedrouter-observer-internal-token",
+        "version": observer_version,
+    },
+    "TR_SYNTHETIC_MONITOR_API_KEY": {
+        "resource": "trustedrouter-synthetic-monitor-api-key",
+        "version": monitor_version,
+    },
+}
+if actual != expected:
+    raise SystemExit("synthetic Job exact numeric secret map differs")
+' "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
+    "$OBSERVER_SECRET_VERSION" "$MONITOR_SECRET_VERSION" || {
+      echo "ERROR: deployed synthetic Job ${region}/${job_name} secret contract failed" >&2
+      return 1
+    }
+}
+
+SYNTHETIC_RELEASE="${TR_RELEASE:-$(git rev-parse --short HEAD 2>/dev/null || echo local)}"
+[[ "$SYNTHETIC_RELEASE" =~ ^[A-Za-z0-9._-]{1,128}$ ]] || {
+  echo "ERROR: synthetic release is invalid" >&2
+  exit 1
+}
 BASE_ENV_VARS=(
   # These are one-shot workers, not the public control-plane process. Using
   # the worker runtime keeps control-plane-only dependencies such as SES out
@@ -71,7 +217,7 @@ BASE_ENV_VARS=(
   # remain explicit below.
   "TR_ENVIRONMENT=worker"
   "TR_SERVICE_SURFACE=observer"
-  "TR_RELEASE=$(git rev-parse --short HEAD 2>/dev/null || echo local)"
+  "TR_RELEASE=${SYNTHETIC_RELEASE}"
   "TR_ENABLE_LIVE_PROVIDERS=false"
   "TR_API_BASE_URL=https://api.trustedrouter.com/v1"
   "TR_TRUSTED_DOMAIN=trustedrouter.com"
@@ -101,6 +247,8 @@ BASE_ENV_VARS=(
 verify_synthetic_ingest_service_contract() {
   local target_region="$1"
   local service_json=""
+  local revision_name=""
+  local revision_json=""
 
   service_json="$(gc run services describe "$SYNTHETIC_INGEST_SERVICE" \
     --region "$target_region" \
@@ -108,12 +256,12 @@ verify_synthetic_ingest_service_contract() {
       echo "ERROR: internal synthetic ingest service is absent in ${target_region}" >&2
       return 1
     }
-  if ! printf '%s' "$service_json" | python3 -c '
+  revision_name="$(printf '%s' "$service_json" | python3 -c '
 import json
 import sys
 
 data = json.load(sys.stdin)
-expected_name, expected_observer_secret, expected_gateway_secret = sys.argv[1:4]
+expected_name = sys.argv[1]
 metadata = data.get("metadata", {})
 reported_name = metadata.get("name")
 if reported_name and reported_name != expected_name:
@@ -129,11 +277,41 @@ if not ready:
 annotations = metadata.get("annotations", {}) or {}
 if annotations.get("run.googleapis.com/ingress") != "internal-and-cloud-load-balancing":
     raise SystemExit("service ingress is not internal-and-cloud-load-balancing")
-template = data.get("spec", {}).get("template", {})
-pod_spec = template.get("spec", template)
-containers = pod_spec.get("containers", [])
+traffic = [
+    item
+    for item in data.get("status", {}).get("traffic", []) or []
+    if int(item.get("percent", 0) or 0) > 0
+]
+if len(traffic) != 1 or int(traffic[0].get("percent", 0) or 0) != 100:
+    raise SystemExit("service must have exactly one revision serving 100 percent")
+revision = traffic[0].get("revisionName")
+if not revision:
+    raise SystemExit("serving traffic does not name an immutable revision")
+print(revision)
+' "$SYNTHETIC_INGEST_SERVICE")" || {
+    echo "ERROR: internal synthetic ingest service contract failed in ${target_region}" >&2
+    return 1
+  }
+  revision_json="$(gc run revisions describe "$revision_name" \
+    --region "$target_region" --format=json)" || {
+    echo "ERROR: serving internal revision ${revision_name} is absent in ${target_region}" >&2
+    return 1
+  }
+  if ! printf '%s' "$revision_json" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+expected_identity, expected_observer_secret, expected_gateway_secret = sys.argv[1:4]
+spec = data.get("spec", {})
+actual_identity = spec.get("serviceAccountName") or spec.get("serviceAccount")
+if actual_identity != expected_identity:
+    raise SystemExit(
+        f"serving revision identity is {actual_identity!r}, expected {expected_identity!r}"
+    )
+containers = spec.get("containers", [])
 if len(containers) != 1:
-    raise SystemExit("service must have exactly one container")
+    raise SystemExit("serving revision must have exactly one container")
 env = {
     item.get("name"): item
     for item in containers[0].get("env", [])
@@ -150,21 +328,99 @@ if secret_name("TR_OBSERVER_INTERNAL_TOKEN") != expected_observer_secret:
     raise SystemExit("observer token is not bound to the dedicated secret")
 if secret_name("TR_INTERNAL_GATEWAY_TOKEN") != expected_gateway_secret:
     raise SystemExit("billing gateway token is not bound to the dedicated secret")
-' "$SYNTHETIC_INGEST_SERVICE" \
+' "$INTERNAL_RUN_SERVICE_ACCOUNT" \
       trustedrouter-observer-internal-token \
       trustedrouter-internal-gateway-token; then
-    echo "ERROR: internal synthetic ingest service contract failed in ${target_region}" >&2
+    echo "ERROR: serving internal revision contract failed in ${target_region}" >&2
     return 1
   fi
 }
 
-if ! gc artifacts docker images describe "$IMAGE" >/dev/null 2>&1; then
+IMAGE_METADATA="$(gc artifacts docker images describe "$IMAGE" --format=json)" || {
   echo "ERROR: image ${IMAGE} does not exist. Run scripts/deploy/image.sh before synthetic.sh." >&2
   exit 1
-fi
+}
+IMAGE="$(printf '%s' "$IMAGE_METADATA" | python3 -c '
+import json
+import sys
 
-ensure_project_role "serviceAccount:${RUN_SERVICE_ACCOUNT}" "roles/run.developer"
-ensure_project_role "serviceAccount:${RUN_SERVICE_ACCOUNT}" "roles/secretmanager.secretAccessor"
+data = json.load(sys.stdin)
+summary = data.get("image_summary") or data.get("imageSummary") or {}
+value = (
+    summary.get("fully_qualified_digest")
+    or summary.get("fullyQualifiedDigest")
+    or data.get("fully_qualified_digest")
+    or data.get("fullyQualifiedDigest")
+)
+if not isinstance(value, str):
+    raise SystemExit("image metadata omits fully qualified digest")
+print(value)
+')" || {
+  echo "ERROR: synthetic image did not resolve to an immutable digest" >&2
+  exit 1
+}
+[[ "$IMAGE" =~ ^[^,|[:space:]@]+@sha256:[0-9a-f]{64}$ ]] || {
+  echo "ERROR: synthetic image digest is invalid" >&2
+  exit 1
+}
+
+verify_exact_synthetic_job_invoker_policy() {
+  local job_name="$1"
+  local region="$2"
+  local policy_json
+  policy_json="$(gc run jobs get-iam-policy "$job_name" \
+    --region="$region" --format=json)" || return 1
+  if ! printf '%s' "$policy_json" | python3 -c '
+import json
+import sys
+
+policy = json.load(sys.stdin)
+bindings = policy.get("bindings") or []
+if len(bindings) != 1:
+    raise SystemExit("synthetic Job IAM binding inventory differs")
+binding = bindings[0]
+if binding.get("role") != "roles/run.invoker" or binding.get("condition") is not None:
+    raise SystemExit("synthetic Job invoker binding differs")
+if (binding.get("members") or []) != [sys.argv[1]]:
+    raise SystemExit("synthetic Job invoker member inventory differs")
+' "serviceAccount:${SYNTHETIC_RUN_SERVICE_ACCOUNT}"; then
+    echo "ERROR: Cloud Run Job ${region}/${job_name} IAM is not the exact singleton invoker policy" >&2
+    return 1
+  fi
+}
+
+ensure_synthetic_job_invoker() {
+  local job_name="$1"
+  local region="$2"
+  local member="serviceAccount:${SYNTHETIC_RUN_SERVICE_ACCOUNT}"
+  gc run jobs add-iam-policy-binding "$job_name" \
+    --region="$region" \
+    --member="$member" \
+    --role="roles/run.invoker" \
+    --condition=None \
+    --quiet >/dev/null
+  verify_exact_synthetic_job_invoker_policy "$job_name" "$region"
+}
+
+verify_existing_synthetic_job_invoker_or_absent() {
+  local job_name="$1"
+  local region="$2"
+  local describe_error=""
+  if describe_error="$(gc run jobs describe "$job_name" \
+      --region="$region" --format='value(metadata.name)' 2>&1)"; then
+    verify_exact_synthetic_job_invoker_policy "$job_name" "$region"
+    return
+  fi
+  case "$describe_error" in
+    *NOT_FOUND*|*not\ found*|*Not\ Found*|*Cannot\ find*|*could\ not\ be\ found*|*was\ not\ found*)
+      return 0
+      ;;
+    *)
+      echo "ERROR: cannot determine whether Cloud Run job ${region}/${job_name} exists: ${describe_error}" >&2
+      return 1
+      ;;
+  esac
+}
 
 upsert_scheduler() {
   local scheduler_name="$1"
@@ -178,9 +434,18 @@ upsert_scheduler() {
     if ! gc scheduler jobs update http "$scheduler_name" \
       --location "$region" \
       --schedule "$schedule" \
+      --time-zone Etc/UTC \
       --uri "$run_uri" \
       --http-method POST \
-      --oauth-service-account-email "$RUN_SERVICE_ACCOUNT" \
+      --oauth-service-account-email "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
+      --clear-headers \
+      --clear-message-body \
+      --attempt-deadline=300s \
+      --max-retry-attempts=0 \
+      --max-retry-duration=0s \
+      --min-backoff=5s \
+      --max-backoff=60s \
+      --max-doublings=3 \
       --quiet >/dev/null; then
       log "WARN: failed to update synthetic scheduler ${scheduler_name}; leaving existing schedule in place"
       return 1
@@ -190,9 +455,16 @@ upsert_scheduler() {
     if ! gc scheduler jobs create http "$scheduler_name" \
       --location "$region" \
       --schedule "$schedule" \
+      --time-zone Etc/UTC \
       --uri "$run_uri" \
       --http-method POST \
-      --oauth-service-account-email "$RUN_SERVICE_ACCOUNT" \
+      --oauth-service-account-email "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
+      --attempt-deadline=300s \
+      --max-retry-attempts=0 \
+      --max-retry-duration=0s \
+      --min-backoff=5s \
+      --max-backoff=60s \
+      --max-doublings=3 \
       --quiet >/dev/null; then
       log "WARN: failed to create synthetic scheduler ${scheduler_name}; deploy the job exists but is not scheduled"
       return 1
@@ -200,8 +472,7 @@ upsert_scheduler() {
   fi
 }
 
-SYNTHETIC_MONITOR_REGIONS="${TR_SYNTHETIC_MONITOR_REGIONS:-us-central1,europe-west4}"
-IFS=',' read -ra _REGION_LIST <<<"$SYNTHETIC_MONITOR_REGIONS"
+IFS=',' read -ra _REGION_LIST <<<"$TR_SYNTHETIC_MONITOR_REGIONS"
 monitor_index=0
 for monitor_region in "${_REGION_LIST[@]}"; do
   [ -n "$monitor_region" ] || continue
@@ -219,6 +490,7 @@ for monitor_region in "${_REGION_LIST[@]}"; do
     # Cloud Run URL. Otherwise an apex TLS/DNS incident prevents the monitor
     # from recording the very failure it observed.
     "TR_SYNTHETIC_INGEST_URL=${regional_ingest_base}/v1/internal/synthetic/samples"
+    "TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL=${regional_ingest_base}"
     "TR_SYNTHETIC_BENCHMARK_INGEST_URL=${regional_ingest_base}/v1/internal/synthetic/benchmark"
     "TR_SYNTHETIC_ROUTE_HEALTH_URL=${regional_ingest_base}/v1/internal/synthetic/route-health"
     "TR_SYNTHETIC_BILLING_CONCURRENCY=2"
@@ -242,21 +514,27 @@ for monitor_region in "${_REGION_LIST[@]}"; do
 
   ensure_private_run_app_access "$monitor_region"
   verify_synthetic_ingest_service_contract "$monitor_region"
+  verify_synthetic_secret_access
+  verify_existing_synthetic_job_invoker_or_absent "$job_name" "$monitor_region"
   log "deploying synthetic Cloud Run job ${job_name} in ${monitor_region}"
   gc run jobs deploy "$job_name" \
     --region "$monitor_region" \
     --image "$IMAGE" \
     --command="/app/.venv/bin/python" \
     --args="-m,trusted_router.synthetic.cli" \
-    --service-account "$RUN_SERVICE_ACCOUNT" \
+    --service-account "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
     "${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]}" \
     --set-env-vars "$set_env_vars" \
     --set-secrets "$SET_SECRETS" \
+    --tasks 1 \
+    --parallelism 1 \
     --max-retries 0 \
     --task-timeout 300s \
     --cpu 2 \
     --memory 1Gi \
     --quiet >/dev/null
+  verify_synthetic_job_secret_contract "$job_name" "$monitor_region"
+  ensure_synthetic_job_invoker "$job_name" "$monitor_region"
   # CPU 2 + 1Gi mem: the synthetic CLI fans out N probes per pass
   # concurrently via asyncio.gather + httpx. On 1 CPU / 512Mi (the
   # Cloud Run default) the parallel TLS handshakes serialize and
@@ -281,7 +559,7 @@ done
 # Sustained-output benchmark: one deterministic top-200 route per tick. This
 # has a separate Cloud Run Job so a slow 512-token stream cannot delay or
 # overlap TLS, attestation, billing, fallback, or short provider probes.
-throughput_region="us-central1"
+throughput_region="$TR_SYNTHETIC_THROUGHPUT_REGION"
 throughput_ingest_base="https://${SYNTHETIC_INGEST_SERVICE}-${PROJECT_NUMBER}.${throughput_region}.run.app"
 throughput_job_name="trusted-router-throughput-${throughput_region}"
 throughput_scheduler_name="${throughput_job_name}-every-five-minutes"
@@ -293,6 +571,7 @@ throughput_env_vars=(
   "${BASE_ENV_VARS[@]}"
   "TR_SYNTHETIC_MONITOR_REGION=${throughput_region}"
   "TR_SYNTHETIC_INGEST_URL=${throughput_ingest_base}/v1/internal/synthetic/samples"
+  "TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL=${throughput_ingest_base}"
   "TR_SYNTHETIC_BENCHMARK_INGEST_URL=${throughput_ingest_base}/v1/internal/synthetic/benchmark"
   "TR_SYNTHETIC_ROUTE_HEALTH_URL=${throughput_ingest_base}/v1/internal/synthetic/route-health"
   "TR_SYNTHETIC_BILLING_CONCURRENCY=1"
@@ -316,21 +595,28 @@ throughput_set_env_vars="$(IFS='|'; echo "^|^${throughput_env_vars[*]}")"
 
 ensure_private_run_app_access "$throughput_region"
 verify_synthetic_ingest_service_contract "$throughput_region"
+verify_synthetic_secret_access
+verify_existing_synthetic_job_invoker_or_absent \
+  "$throughput_job_name" "$throughput_region"
 log "deploying isolated throughput Cloud Run job ${throughput_job_name}"
 gc run jobs deploy "$throughput_job_name" \
   --region "$throughput_region" \
   --image "$IMAGE" \
   --command="/app/.venv/bin/python" \
   --args="-m,trusted_router.synthetic.cli" \
-  --service-account "$RUN_SERVICE_ACCOUNT" \
+  --service-account "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
   "${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]}" \
   --set-env-vars "$throughput_set_env_vars" \
   --set-secrets "$SET_SECRETS" \
+  --tasks 1 \
+  --parallelism 1 \
   --max-retries 0 \
   --task-timeout 300s \
   --cpu 1 \
   --memory 1Gi \
   --quiet >/dev/null
+verify_synthetic_job_secret_contract "$throughput_job_name" "$throughput_region"
+ensure_synthetic_job_invoker "$throughput_job_name" "$throughput_region"
 
 upsert_scheduler \
   "$throughput_scheduler_name" \
@@ -354,7 +640,7 @@ done
 
 # Image generation is materially more expensive than text PONG probes. Keep it
 # isolated and run one canonical end-to-end request every six hours.
-image_region="us-central1"
+image_region="$TR_SYNTHETIC_IMAGE_REGION"
 image_ingest_base="https://${SYNTHETIC_INGEST_SERVICE}-${PROJECT_NUMBER}.${image_region}.run.app"
 image_job_name="trusted-router-image-generation-${image_region}"
 image_scheduler_name="${image_job_name}-every-six-hours"
@@ -362,6 +648,7 @@ image_env_vars=(
   "${BASE_ENV_VARS[@]}"
   "TR_SYNTHETIC_MONITOR_REGION=${image_region}"
   "TR_SYNTHETIC_INGEST_URL=${image_ingest_base}/v1/internal/synthetic/samples"
+  "TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL=${image_ingest_base}"
   "TR_SYNTHETIC_IMAGE_MODEL=google/gemini-3.1-flash-image-preview"
   "TR_SYNTHETIC_IMAGE_PROVIDER=google-ai-studio"
   "TR_SYNTHETIC_IMAGE_TIMEOUT_SECONDS=120"
@@ -371,21 +658,27 @@ image_set_env_vars="$(IFS='|'; echo "^|^${image_env_vars[*]}")"
 
 ensure_private_run_app_access "$image_region"
 verify_synthetic_ingest_service_contract "$image_region"
+verify_synthetic_secret_access
+verify_existing_synthetic_job_invoker_or_absent "$image_job_name" "$image_region"
 log "deploying isolated image-generation Cloud Run job ${image_job_name}"
 gc run jobs deploy "$image_job_name" \
   --region "$image_region" \
   --image "$IMAGE" \
   --command="/app/.venv/bin/python" \
   --args="-m,trusted_router.synthetic.image_generation" \
-  --service-account "$RUN_SERVICE_ACCOUNT" \
+  --service-account "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
   "${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]}" \
   --set-env-vars "$image_set_env_vars" \
   --set-secrets "$SET_SECRETS" \
+  --tasks 1 \
+  --parallelism 1 \
   --max-retries 0 \
   --task-timeout 300s \
   --cpu 1 \
   --memory 512Mi \
   --quiet >/dev/null
+verify_synthetic_job_secret_contract "$image_job_name" "$image_region"
+ensure_synthetic_job_invoker "$image_job_name" "$image_region"
 
 upsert_scheduler \
   "$image_scheduler_name" \
@@ -398,7 +691,7 @@ upsert_scheduler \
 # The current seven-day total is $2.499276 including TrustedRouter's 20% fee,
 # or about $10.71 per 30 days. max-retries=0 plus a date-scoped idempotency key
 # prevents duplicate billing.
-video_region="us-central1"
+video_region="$TR_SYNTHETIC_VIDEO_REGION"
 video_ingest_base="https://${SYNTHETIC_INGEST_SERVICE}-${PROJECT_NUMBER}.${video_region}.run.app"
 video_job_name="trusted-router-video-generation-${video_region}"
 video_scheduler_name="${video_job_name}-daily"
@@ -406,6 +699,7 @@ video_env_vars=(
   "${BASE_ENV_VARS[@]}"
   "TR_SYNTHETIC_MONITOR_REGION=${video_region}"
   "TR_SYNTHETIC_INGEST_URL=${video_ingest_base}/v1/internal/synthetic/samples"
+  "TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL=${video_ingest_base}"
   "TR_SYNTHETIC_VIDEO_TIMEOUT_SECONDS=900"
   "TR_SYNTHETIC_VIDEO_POLL_INTERVAL_SECONDS=5"
 )
@@ -413,21 +707,27 @@ video_set_env_vars="$(IFS='|'; echo "^|^${video_env_vars[*]}")"
 
 ensure_private_run_app_access "$video_region"
 verify_synthetic_ingest_service_contract "$video_region"
+verify_synthetic_secret_access
+verify_existing_synthetic_job_invoker_or_absent "$video_job_name" "$video_region"
 log "deploying isolated daily video-generation Cloud Run job ${video_job_name}"
 gc run jobs deploy "$video_job_name" \
   --region "$video_region" \
   --image "$IMAGE" \
   --command="/app/.venv/bin/python" \
   --args="-m,trusted_router.synthetic.video_generation" \
-  --service-account "$RUN_SERVICE_ACCOUNT" \
+  --service-account "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
   "${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]}" \
   --set-env-vars "$video_set_env_vars" \
   --set-secrets "$SET_SECRETS" \
+  --tasks 1 \
+  --parallelism 1 \
   --max-retries 0 \
   --task-timeout 1200s \
   --cpu 1 \
   --memory 512Mi \
   --quiet >/dev/null
+verify_synthetic_job_secret_contract "$video_job_name" "$video_region"
+ensure_synthetic_job_invoker "$video_job_name" "$video_region"
 
 upsert_scheduler \
   "$video_scheduler_name" \

--- a/tests/deploy_script_harness.py
+++ b/tests/deploy_script_harness.py
@@ -148,6 +148,29 @@ _STUB = r"""#!/usr/bin/env bash
 # have any. The run's stdin is /dev/null, so this returns immediately when the
 # stub is not in a pipeline.
 cat >/dev/null 2>&1 || true
+if [ -n "${HARNESS_SEQUENCE_FIXTURES:-}" ] && [ -f "$HARNESS_SEQUENCE_FIXTURES" ]; then
+  joined="${0##*/} $*"
+  while IFS=$'\t' read -r sequence_id pattern; do
+    [ -n "$pattern" ] || continue
+    if printf '%s' "$joined" | grep -Eq -- "$pattern"; then
+      count_file="$HARNESS_STATE_DIR/sequence-${sequence_id}.count"
+      response_file="$HARNESS_STATE_DIR/sequence-${sequence_id}.responses"
+      count=0
+      if [ -f "$count_file" ]; then
+        IFS= read -r count < "$count_file"
+      fi
+      count=$((count + 1))
+      printf '%s\n' "$count" > "$count_file"
+      encoded_reply="$(sed -n "${count}p" "$response_file")"
+      if [ -z "$encoded_reply" ]; then
+        encoded_reply="$(tail -n 1 "$response_file")"
+      fi
+      printf '%s' "$encoded_reply" | base64 --decode
+      printf '\n'
+      exit 0
+    fi
+  done < "$HARNESS_SEQUENCE_FIXTURES"
+fi
 if [ -n "${HARNESS_FIXTURES:-}" ] && [ -f "$HARNESS_FIXTURES" ]; then
   joined="${0##*/} $*"
   while IFS=$'\t' read -r pattern encoded_reply; do
@@ -194,7 +217,12 @@ _SYNTHETIC_INGEST_SERVICE_JSON = json.dumps(
                 "run.googleapis.com/ingress": "internal-and-cloud-load-balancing"
             },
         },
-        "status": {"conditions": [{"type": "Ready", "status": "True"}]},
+        "status": {
+            "conditions": [{"type": "Ready", "status": "True"}],
+            "traffic": [
+                {"revisionName": "trusted-router-billing-harness", "percent": 100}
+            ],
+        },
         "spec": {
             "template": {
                 "spec": {
@@ -229,6 +257,142 @@ _SYNTHETIC_INGEST_SERVICE_JSON = json.dumps(
     },
     separators=(",", ":"),
 )
+_SYNTHETIC_INGEST_REVISION_JSON = json.dumps(
+    {
+        "metadata": {"name": "trusted-router-billing-harness"},
+        "spec": {
+            "serviceAccountName": "tr-internal@quill-cloud-proxy.iam.gserviceaccount.com",
+            "containers": [
+                {
+                    "env": [
+                        {"name": "TR_SERVICE_SURFACE", "value": "internal"},
+                        {
+                            "name": "TR_OBSERVER_INTERNAL_TOKEN",
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "trustedrouter-observer-internal-token",
+                                    "key": "latest",
+                                }
+                            },
+                        },
+                        {
+                            "name": "TR_INTERNAL_GATEWAY_TOKEN",
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "trustedrouter-internal-gateway-token",
+                                    "key": "latest",
+                                }
+                            },
+                        },
+                    ]
+                }
+            ],
+        },
+    },
+    separators=(",", ":"),
+)
+_SYNTHETIC_SECRET_POLICY_JSON = json.dumps(
+    {
+        "bindings": [
+            {
+                "role": "roles/secretmanager.secretAccessor",
+                "members": [
+                    "serviceAccount:tr-internal@quill-cloud-proxy.iam.gserviceaccount.com",
+                    "serviceAccount:tr-synthetic@quill-cloud-proxy.iam.gserviceaccount.com",
+                ],
+            }
+        ]
+    },
+    separators=(",", ":"),
+)
+_SYNTHETIC_ACCOUNT_JSON = json.dumps(
+    {
+        "email": "tr-synthetic@quill-cloud-proxy.iam.gserviceaccount.com",
+        "disabled": False,
+    },
+    separators=(",", ":"),
+)
+_SYNTHETIC_ACCOUNT_POLICY_JSON = json.dumps(
+    {
+        "bindings": [
+            {
+                "role": "roles/iam.serviceAccountUser",
+                "members": [
+                    "serviceAccount:tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com"
+                ],
+            }
+        ]
+    },
+    separators=(",", ":"),
+)
+_SYNTHETIC_VERSION_LIST_JSON = json.dumps(
+    [
+        {
+            "name": "projects/quill-cloud-proxy/secrets/fixture/versions/7",
+            "state": "ENABLED",
+        }
+    ],
+    separators=(",", ":"),
+)
+_SYNTHETIC_JOB_POLICY_JSON = json.dumps(
+    {
+        "bindings": [
+            {
+                "role": "roles/run.invoker",
+                "members": [
+                    "serviceAccount:tr-synthetic@quill-cloud-proxy.iam.gserviceaccount.com"
+                ],
+            }
+        ]
+    },
+    separators=(",", ":"),
+)
+_SYNTHETIC_JOB_JSON = json.dumps(
+    {
+        "spec": {
+            "template": {
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "serviceAccountName": (
+                                "tr-synthetic@quill-cloud-proxy.iam.gserviceaccount.com"
+                            ),
+                            "containers": [
+                                {
+                                    "env": [
+                                        {
+                                            "name": "TR_OBSERVER_INTERNAL_TOKEN",
+                                            "valueFrom": {
+                                                "secretKeyRef": {
+                                                    "name": (
+                                                        "trustedrouter-observer-internal-token"
+                                                    ),
+                                                    "key": "7",
+                                                }
+                                            },
+                                        },
+                                        {
+                                            "name": "TR_SYNTHETIC_MONITOR_API_KEY",
+                                            "valueFrom": {
+                                                "secretKeyRef": {
+                                                    "name": (
+                                                        "trustedrouter-synthetic-monitor-api-key"
+                                                    ),
+                                                    "key": "7",
+                                                }
+                                            },
+                                        },
+                                    ]
+                                }
+                            ],
+                        }
+                    }
+                }
+            }
+        }
+    },
+    separators=(",", ":"),
+)
 
 
 @dataclass(frozen=True)
@@ -240,6 +404,11 @@ class ScriptFixture:
     env: dict[str, str] = field(default_factory=dict)
     #: ``(extended-regex over "<command> <argv...>", stdout)`` in priority order.
     responses: tuple[tuple[str, str], ...] = ()
+    #: Like ``responses``, but each matching call consumes the next reply and
+    #: then repeats the last one. This lets tests model an IAM policy changing
+    #: between two preflight reads instead of proving ordering against a
+    #: forever-static fake control plane.
+    sequential_responses: tuple[tuple[str, tuple[str, ...]], ...] = ()
     #: Extended regexes whose matching command must exit 1 instead of succeeding.
     failures: tuple[str, ...] = ()
     #: Files to create under ``$HOME`` before the run, path -> contents.
@@ -375,9 +544,42 @@ SCRIPT_FIXTURES: dict[str, ScriptFixture] = {
     "scripts/deploy/synthetic.sh": ScriptFixture(
         env={"TR_BILLING_SERVICE": "trusted-router-billing"},
         responses=(
+            (r"projects describe .*--format=value\(projectNumber\)", "123456789"),
+            (r"projects get-iam-policy .*--format=json", '{"bindings":[]}'),
+            (
+                r"iam service-accounts describe tr-synthetic@.*--format=json",
+                _SYNTHETIC_ACCOUNT_JSON,
+            ),
+            (
+                r"iam service-accounts get-iam-policy tr-synthetic@.*--format=json",
+                _SYNTHETIC_ACCOUNT_POLICY_JSON,
+            ),
+            (
+                r"secrets versions list .*--filter=state=ENABLED.*--format=json",
+                _SYNTHETIC_VERSION_LIST_JSON,
+            ),
+            (
+                r"secrets get-iam-policy .*--format=json",
+                _SYNTHETIC_SECRET_POLICY_JSON,
+            ),
+            (
+                r"run jobs get-iam-policy .*--format=json",
+                _SYNTHETIC_JOB_POLICY_JSON,
+            ),
+            (r"run jobs describe .*--format=json", _SYNTHETIC_JOB_JSON),
+            (
+                r"artifacts docker images describe .*--format=json",
+                '{"image_summary":{"fully_qualified_digest":'
+                '"us-central1-docker.pkg.dev/quill-cloud-proxy/trusted-router/'
+                'trusted-router@sha256:' + "a" * 64 + '"}}',
+            ),
             (
                 r"run services describe trusted-router-billing.*--format=json",
                 _SYNTHETIC_INGEST_SERVICE_JSON,
+            ),
+            (
+                r"run revisions describe trusted-router-billing-harness.*--format=json",
+                _SYNTHETIC_INGEST_REVISION_JSON,
             ),
             (
                 r"dns managed-zones describe trusted-router-private-run-app --format=json",
@@ -526,6 +728,24 @@ class DeployScriptHarness:
                 for pattern, reply in fixture.responses
             )
         )
+        state_dir = run_dir / "state"
+        state_dir.mkdir()
+        sequence_fixtures_file = run_dir / "sequence-fixtures.tsv"
+        sequence_fixtures_file.write_text(
+            "".join(
+                f"{index}\t{pattern}\n"
+                for index, (pattern, _) in enumerate(fixture.sequential_responses)
+            )
+        )
+        for index, (_, replies) in enumerate(fixture.sequential_responses):
+            if not replies:
+                raise ValueError("sequential response fixtures must not be empty")
+            (state_dir / f"sequence-{index}.responses").write_text(
+                "".join(
+                    f"{base64.b64encode(reply.encode()).decode('ascii')}\n"
+                    for reply in replies
+                )
+            )
         failures_file = run_dir / "failures.txt"
         failures_file.write_text("".join(f"{pattern}\n" for pattern in fixture.failures))
 
@@ -536,6 +756,8 @@ class DeployScriptHarness:
             "LANG": "C",
             "HARNESS_ARGV_LOG": str(argv_log),
             "HARNESS_FIXTURES": str(fixtures_file),
+            "HARNESS_SEQUENCE_FIXTURES": str(sequence_fixtures_file),
+            "HARNESS_STATE_DIR": str(state_dir),
             "HARNESS_FAILURES": str(failures_file),
             "HARNESS_VERIFIER_RC": str(verifier_rc),
             **{k: v for k, v in fixture.env.items() if k not in omit_env},

--- a/tests/test_ddos_edge_deploy.py
+++ b/tests/test_ddos_edge_deploy.py
@@ -33,29 +33,279 @@ def test_cloud_run_security_defaults_are_per_service_and_cost_bounded() -> None:
     assert 'TR_CLOUD_RUN_MAX_INSTANCES="${TR_CLOUD_RUN_MAX_INSTANCES:-20}"' in shared
 
 
-def test_gcp_edge_reconciler_preserves_headers_and_repairs_every_security_control(
+def _exact_policy() -> dict[str, object]:
+    allowed = (
+        r"^(trustedrouter[.]com|www[.]trustedrouter[.]com|status[.]trustedrouter[.]com|"
+        r"trust[.]trustedrouter[.]com|eu[.]trustedrouter[.]com|status-us[.]trustedrouter[.]com|"
+        r"status-eu[.]trustedrouter[.]com|allyrouter[.]com|www[.]allyrouter[.]com|"
+        r"status[.]allyrouter[.]com|trust[.]allyrouter[.]com|uptimerouter[.]com|"
+        r"www[.]uptimerouter[.]com|status[.]uptimerouter[.]com|trust[.]uptimerouter[.]com)"
+        r"(:[0-9]+)?$"
+    )
+
+    def rate(count: int) -> dict[str, object]:
+        return {
+            "rateLimitThreshold": {"count": count, "intervalSec": 60},
+            "conformAction": "allow",
+            "exceedAction": "deny(429)",
+            "enforceOnKey": "IP",
+        }
+
+    source = {"config": {"srcIpRanges": ["*"]}, "versionedExpr": "SRC_IPS_V1"}
+    return {
+        "type": "CLOUD_ARMOR",
+        "description": (
+            "TrustedRouter exact edge controls; host and all-path gates enforced, "
+            "route-shape rules previewed"
+        ),
+        "rules": [
+            {
+                "priority": 900,
+                "action": "deny(403)",
+                "description": "Reject hosts outside canonical and marketing aliases",
+                "preview": False,
+                "match": {
+                    "expr": {
+                        "expression": (
+                            "!has(request.headers['host']) || "
+                            f"!request.headers['host'].lower().matches('{allowed}')"
+                        )
+                    }
+                },
+            },
+            {
+                "priority": 1000,
+                "action": "throttle",
+                "description": "Browser inference proxy per-client throttle",
+                "preview": True,
+                "match": {
+                    "expr": {"expression": "request.path.startsWith('/chat-proxy/')"}
+                },
+                "rateLimitOptions": rate(120),
+            },
+            {
+                "priority": 1100,
+                "action": "throttle",
+                "description": "State-changing request per-client throttle",
+                "preview": True,
+                "match": {
+                    "expr": {
+                        "expression": (
+                            "request.method != 'GET' && request.method != 'HEAD' && "
+                            "request.method != 'OPTIONS'"
+                        )
+                    }
+                },
+                "rateLimitOptions": rate(300),
+            },
+            {
+                "priority": 1200,
+                "action": "throttle",
+                "description": "All-path per-source safety ceiling",
+                "preview": False,
+                "match": source,
+                "rateLimitOptions": rate(2400),
+            },
+            {
+                "priority": 2_147_483_647,
+                "action": "allow",
+                "description": (
+                    "Default allow; bounded route classes are evaluated first"
+                ),
+                "preview": False,
+                "match": source,
+            },
+        ]
+    }
+
+
+def _exact_public_backend() -> dict[str, object]:
+    return {
+        "customRequestHeaders": ["X-TrustedRouter-Client-IP:{client_ip_address}"],
+        "customResponseHeaders": [],
+        "edgeSecurityPolicy": "",
+        "iap": {"enabled": False, "oauth2ClientId": " "},
+        "logConfig": {
+            "enable": True,
+            "sampleRate": 0.1,
+        },
+        "enableCDN": True,
+        "compressionMode": "AUTOMATIC",
+        "cdnPolicy": {
+            "cacheMode": "USE_ORIGIN_HEADERS",
+            "negativeCaching": False,
+            "negativeCachingPolicy": [],
+            "serveWhileStale": 600,
+            "cacheKeyPolicy": {
+                "includeHost": True,
+                "includeProtocol": True,
+                "includeQueryString": True,
+                "queryStringBlacklist": [],
+                "queryStringWhitelist": [],
+                "includeHttpHeaders": [],
+                "includeNamedCookies": [],
+            },
+        },
+    }
+
+
+def _exact_rollout_public_backend() -> dict[str, object]:
+    backend = _exact_public_backend()
+    backend.update(
+        {
+            "name": "trusted-router-public-backend",
+            "loadBalancingScheme": "EXTERNAL_MANAGED",
+            "protocol": "HTTP",
+            "timeoutSec": 60,
+            "securityPolicy": (
+                "https://www.googleapis.com/compute/v1/projects/quill-cloud-proxy/"
+                "global/securityPolicies/trusted-router-public-edge"
+            ),
+            "backends": [
+                {
+                    "group": (
+                        "https://www.googleapis.com/compute/v1/projects/"
+                        "quill-cloud-proxy/regions/us-central1/networkEndpointGroups/"
+                        "trusted-router-public-neg"
+                    )
+                },
+                {
+                    "group": (
+                        "https://www.googleapis.com/compute/v1/projects/"
+                        "quill-cloud-proxy/regions/europe-west4/networkEndpointGroups/"
+                        "trusted-router-public-neg"
+                    )
+                },
+            ],
+        }
+    )
+    return backend
+
+
+def _set_nested(value: dict[str, object], path: tuple[object, ...], replacement: object) -> None:
+    current: object = value
+    for component in path[:-1]:
+        if isinstance(component, int):
+            assert isinstance(current, list)
+            current = current[component]
+        else:
+            assert isinstance(current, dict)
+            current = current[component]
+    last = path[-1]
+    if isinstance(last, int):
+        assert isinstance(current, list)
+        current[last] = replacement
+    else:
+        assert isinstance(current, dict)
+        current[last] = replacement
+
+
+def test_shared_edge_verifiers_accept_only_the_exact_rollout_contract(
+    tmp_path: Path,
+) -> None:
+    driver = tmp_path / "driver.sh"
+    driver.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+source {ROOT / 'scripts/deploy/_edge_security.sh'}
+verify_edge_backend_contract_json public "$BACKEND_JSON" quill-cloud-proxy \
+  us-central1,europe-west4 trusted-router-public trusted-router-public-neg \
+  trusted-router-public-edge 60
+verify_cloud_armor_policy_contract_json "$POLICY_JSON"
+""",
+        encoding="utf-8",
+    )
+    exact_env = {
+        "BACKEND_JSON": json.dumps(_exact_rollout_public_backend(), separators=(",", ":")),
+        "POLICY_JSON": json.dumps(_exact_policy(), separators=(",", ":")),
+    }
+    exact = _run_bash(driver, env=exact_env)
+    assert exact.returncode == 0, exact.stderr
+
+    armor_drifts: tuple[tuple[tuple[object, ...], object], ...] = (
+        (("userIpRequestHeaders",), ["X-Forwarded-For"]),
+        (("recaptchaOptionsConfig",), {"redirectSiteKey": "injected"}),
+        (("rules", 0, "headerAction"), {"requestHeadersToAdds": []}),
+        (("rules", 1, "rateLimitOptions", "banDurationSec"), 600),
+    )
+    for path, replacement in armor_drifts:
+        policy = json.loads(json.dumps(_exact_policy()))
+        _set_nested(policy, path, replacement)
+        drift = _run_bash(
+            driver,
+            env={**exact_env, "POLICY_JSON": json.dumps(policy, separators=(",", ":"))},
+        )
+        assert drift.returncode != 0, path
+
+    backend_drifts: tuple[tuple[tuple[object, ...], object], ...] = (
+        (("cdnPolicy", "requestCoalescing"), False),
+        (("cdnPolicy", "signedUrlCacheMaxAgeSec"), 3600),
+        (("cdnPolicy", "signedUrlKeyNames"), ["legacy-key"]),
+        (("cdnPolicy", "clientTtl"), 60),
+        (("cdnPolicy", "defaultTtl"), 60),
+        (("cdnPolicy", "maxTtl"), 60),
+        (("cdnPolicy", "bypassCacheOnRequestHeaders"), [{"headerName": "Authorization"}]),
+        (("cdnPolicy", "cacheKeyPolicy", "includeHttpHeaders"), ["Authorization"]),
+        (("cdnPolicy", "cacheKeyPolicy", "includeNamedCookies"), ["session"]),
+        (("cdnPolicy", "cacheKeyPolicy", "includeUserAgent"), True),
+        (("cdnPolicy", "unknownProviderField"), True),
+    )
+    for path, replacement in backend_drifts:
+        backend = json.loads(json.dumps(_exact_rollout_public_backend()))
+        _set_nested(backend, path, replacement)
+        drift = _run_bash(
+            driver,
+            env={**exact_env, "BACKEND_JSON": json.dumps(backend, separators=(",", ":"))},
+        )
+        assert drift.returncode != 0, path
+
+
+def test_gcp_edge_reconciler_clears_stale_backend_and_armor_state(
     tmp_path: Path,
 ) -> None:
     calls = tmp_path / "calls.log"
+    imported_policy = tmp_path / "imported-policy.json"
     driver = tmp_path / "driver.sh"
     driver.write_text(
         f"""#!/usr/bin/env bash
 set -euo pipefail
 source {ROOT / 'scripts/deploy/_edge_security.sh'}
 CALLS={calls}
+IMPORTED_POLICY={imported_policy}
+POLICY_IMPORTED=0
+BACKEND_UPDATES=0
 gc() {{
   printf '%s\\n' "$*" >> "$CALLS"
   case "$*" in
-    "compute security-policies describe tr-public-policy --global") return 1 ;;
-    "compute security-policies rules describe "*) return 1 ;;
+    "compute security-policies import tr-public-policy "*)
+      for value in "$@"; do
+        case "$value" in
+          --file-name=*) cp "${{value#--file-name=}}" "$IMPORTED_POLICY" ;;
+        esac
+      done
+      [ -s "$IMPORTED_POLICY" ] || return 92
+      POLICY_IMPORTED=1
+      ;;
+    "compute security-policies describe tr-public-policy --global --format=json")
+      [ "$POLICY_IMPORTED" = 1 ] || return 91
+      if [ "${{FAKE_ARMOR_EXTRA:-0}}" = 1 ]; then
+        python3 -c 'import json,sys; value=json.load(open(sys.argv[1], encoding="utf-8")); value["rules"][0]["headerAction"]={{"requestHeadersToAdds":[{{"headerName":"X-Injected","headerValue":"unsafe"}}]}}; print(json.dumps(value))' "$IMPORTED_POLICY"
+      else
+        command cat "$IMPORTED_POLICY"
+      fi
+      ;;
+    "compute backend-services update tr-public-backend "*)
+      BACKEND_UPDATES=$((BACKEND_UPDATES + 1))
+      ;;
     "compute backend-services describe tr-public-backend --global --format=json")
-      printf '%s\\n' '{{"customRequestHeaders":["X-Existing:keep","x-trustedrouter-client-ip:spoof"]}}'
+      if [ "$BACKEND_UPDATES" -eq 0 ]; then
+        printf '%s\\n' '{{"customRequestHeaders":["Authorization: stale"],"customResponseHeaders":["X-Internal: stale"],"edgeSecurityPolicy":"stale","iap":{{"enabled":true}},"enableCDN":false}}'
+      else
+        printf '%s\\n' "$FAKE_BACKEND_JSON"
+      fi
       ;;
     "compute backend-services describe tr-public-backend --global --format=value(securityPolicy.basename())")
       printf '%s\\n' tr-public-policy
-      ;;
-    "compute backend-services describe tr-public-backend --global --format=json(customRequestHeaders,securityPolicy)")
-      printf '%s\\n' '{{"customRequestHeaders":["X-Existing:keep","X-TrustedRouter-Client-IP:{{client_ip_address}}"],"securityPolicy":"/global/securityPolicies/tr-public-policy"}}'
       ;;
   esac
 }}
@@ -65,84 +315,117 @@ reconcile_edge_backend tr-public-backend tr-public-policy
         encoding="utf-8",
     )
 
-    result = _run_bash(driver)
+    result = _run_bash(
+        driver,
+        env={
+            "TR_PUBLIC_BACKEND": "tr-public-backend",
+            "FAKE_BACKEND_JSON": json.dumps(
+                _exact_public_backend(), separators=(",", ":")
+            ),
+        },
+    )
     assert result.returncode == 0, result.stderr
     invoked = calls.read_text(encoding="utf-8")
-    assert "security-policies create tr-public-policy" in invoked
-    assert "security-policies rules update 2147483647" in invoked
-    assert invoked.count("security-policies rules create") == 4
-    assert invoked.count("--action=throttle") == 3
-    assert invoked.count("--preview") == 2
-    host_rule = next(
-        line
-        for line in invoked.splitlines()
-        if "security-policies rules create 900" in line
-    )
-    assert "--preview" not in host_rule
-    assert "--action=deny-403" in host_rule
-    global_rule = next(
-        line
-        for line in invoked.splitlines()
-        if "security-policies rules create 1200" in line
-    )
-    assert "--preview" not in global_rule
-    assert "--action=throttle" in global_rule
-    assert "--exceed-action=deny-429" in global_rule
-    assert "--enforce-on-key=IP" in global_rule
+    assert "security-policies import tr-public-policy" in invoked
     assert "--security-policy=tr-public-policy" in invoked
+    assert "--edge-security-policy=" in invoked
+    assert "--iap=disabled,oauth2-client-id= ,oauth2-client-secret= " in invoked
+    assert "--no-custom-request-headers" in invoked
+    assert "--no-custom-response-headers" in invoked
     assert "--enable-logging" in invoked
-    assert "--custom-request-header=X-Existing:keep" in invoked
-    assert (
-        "--custom-request-header=X-TrustedRouter-Client-IP:{client_ip_address}" in invoked
+    assert "--logging-sample-rate=0.1" in invoked
+    assert "--logging-optional=" not in invoked
+    assert "--custom-request-header=X-TrustedRouter-Client-IP:{client_ip_address}" in invoked
+    assert "--enable-cdn" in invoked
+    assert "--cache-mode=USE_ORIGIN_HEADERS" in invoked
+    assert "--no-negative-caching" in invoked
+    assert "--request-coalescing" in invoked
+    assert "--compression-mode=AUTOMATIC" in invoked
+    imported = json.loads(imported_policy.read_text(encoding="utf-8"))
+    contract_fields = ("priority", "action", "preview", "match", "rateLimitOptions")
+    assert [
+        {field: rule[field] for field in contract_fields if field in rule}
+        for rule in imported["rules"]
+    ] == [
+        {field: rule[field] for field in contract_fields if field in rule}
+        for rule in _exact_policy()["rules"]
+    ]
+    assert all(
+        field not in rule
+        for rule in imported["rules"]
+        for field in ("headerAction", "redirectOptions", "preconfiguredWafConfig")
     )
-    assert "--custom-request-header=x-trustedrouter-client-ip:spoof" not in invoked
+
+    drift_result = _run_bash(
+        driver,
+        env={
+            "TR_PUBLIC_BACKEND": "tr-public-backend",
+            "FAKE_ARMOR_EXTRA": "1",
+            "FAKE_BACKEND_JSON": json.dumps(
+                _exact_public_backend(), separators=(",", ":")
+            ),
+        },
+    )
+    assert drift_result.returncode != 0
+    assert "retains forbidden fields" in drift_result.stderr
+
+    for field, value in (
+        ("requestCoalescing", False),
+        ("signedUrlCacheMaxAgeSec", "3600"),
+    ):
+        stale_backend = _exact_public_backend()
+        assert isinstance(stale_backend["cdnPolicy"], dict)
+        stale_backend["cdnPolicy"][field] = value
+        drift_result = _run_bash(
+            driver,
+            env={
+                "TR_PUBLIC_BACKEND": "tr-public-backend",
+                "FAKE_BACKEND_JSON": json.dumps(stale_backend, separators=(",", ":")),
+            },
+        )
+        assert drift_result.returncode != 0
+        assert "CDN/cache-key contract drifted" in drift_result.stderr
+
+    stale_backend = _exact_public_backend()
+    assert isinstance(stale_backend["cdnPolicy"], dict)
+    cache_key = stale_backend["cdnPolicy"]["cacheKeyPolicy"]
+    assert isinstance(cache_key, dict)
+    cache_key["includeUserAgent"] = True
+    drift_result = _run_bash(
+        driver,
+        env={
+            "TR_PUBLIC_BACKEND": "tr-public-backend",
+            "FAKE_BACKEND_JSON": json.dumps(stale_backend, separators=(",", ":")),
+        },
+    )
+    assert drift_result.returncode != 0
+    assert "CDN/cache-key contract drifted" in drift_result.stderr
 
 
-def test_gcp_existing_host_gate_and_all_path_ceiling_are_forced_out_of_preview(
+@pytest.mark.parametrize(
+    "setting",
+    ("TR_CLOUD_ARMOR_PREVIEW", "TR_EDGE_ALLOWED_HOST_REGEX"),
+)
+def test_gcp_edge_contract_rejects_runtime_tuning_overrides(
     tmp_path: Path,
+    setting: str,
 ) -> None:
-    calls = tmp_path / "calls.log"
     driver = tmp_path / "driver.sh"
     driver.write_text(
         f"""#!/usr/bin/env bash
 set -euo pipefail
 source {ROOT / 'scripts/deploy/_edge_security.sh'}
-CALLS={calls}
-gc() {{
-  printf '%s\\n' "$*" >> "$CALLS"
-}}
+gc() {{ :; }}
 log() {{ :; }}
-TR_CLOUD_ARMOR_PREVIEW=1 _reconcile_cloud_armor_policy tr-existing-policy
+{setting}=unsafe _reconcile_cloud_armor_policy tr-existing-policy
 """,
         encoding="utf-8",
     )
 
     result = _run_bash(driver)
 
-    assert result.returncode == 0, result.stderr
-    updates = calls.read_text(encoding="utf-8").splitlines()
-    host_updates = [
-        line
-        for line in updates
-        if "security-policies rules update 900" in line
-    ]
-    assert len(host_updates) == 1
-    assert "--no-preview" in host_updates[0]
-    assert "--preview" not in host_updates[0]
-    assert "--action=deny-403" in host_updates[0]
-
-    global_updates = [
-        line
-        for line in updates
-        if "security-policies rules update 1200" in line
-    ]
-    assert len(global_updates) == 1
-    global_update = global_updates[0]
-    assert "--no-preview" in global_update
-    assert "--preview" not in global_update
-    assert "--enforce-on-key=IP" in global_update
-    assert "--action=throttle" in global_update
-    assert "--exceed-action=deny-429" in global_update
+    assert result.returncode == 2
+    assert "not an operator override" in result.stderr
 
 
 def test_gcp_edge_reconciler_is_parameterized_for_multiple_backends(tmp_path: Path) -> None:
@@ -182,7 +465,7 @@ TR_CLOUD_ARMOR_LOG_SAMPLE_RATE=0.not-a-number \
 
     result = _run_bash(driver)
     assert result.returncode == 2
-    assert "must be between 0 and 1" in result.stderr
+    assert "fixed at 0.1" in result.stderr
 
 
 def test_private_run_app_reconciler_uses_private_google_access(tmp_path: Path) -> None:
@@ -698,10 +981,18 @@ def test_every_synthetic_job_uses_private_run_app_ingress() -> None:
 
     assert 'source "${SCRIPT_DIR}/_private_run_ingress.sh"' in deploy
     assert '"TR_SERVICE_SURFACE=observer"' in deploy
+    assert "resolve_newest_enabled_secret_version" in deploy
+    assert "enabled secret version name is not numeric" in deploy
     assert (
-        '"TR_OBSERVER_INTERNAL_TOKEN=trustedrouter-observer-internal-token:latest"'
-        in deploy
+        '"TR_OBSERVER_INTERNAL_TOKEN=trustedrouter-observer-internal-token:'
+        '${OBSERVER_SECRET_VERSION}"' in deploy
     )
+    assert (
+        '"TR_SYNTHETIC_MONITOR_API_KEY=trustedrouter-synthetic-monitor-api-key:'
+        '${MONITOR_SECRET_VERSION}"' in deploy
+    )
+    assert "trustedrouter-observer-internal-token:latest" not in deploy
+    assert "trustedrouter-synthetic-monitor-api-key:latest" not in deploy
     assert '"TR_INTERNAL_GATEWAY_TOKEN=' not in deploy
     assert "TR_INTERNAL_GATEWAY_TOKEN=trustedrouter" not in deploy
     assert (
@@ -721,7 +1012,11 @@ def test_every_synthetic_job_uses_private_run_app_ingress() -> None:
 def test_secret_bootstrap_provisions_a_distinct_observer_credential() -> None:
     deploy = (ROOT / "scripts/deploy/secrets.sh").read_text(encoding="utf-8")
 
-    assert "generated secret trustedrouter-observer-internal-token" in deploy
+    assert (
+        "ensure_generated_secret_resource trustedrouter-observer-internal-token"
+        in deploy
+    )
+    assert 'log "generated secret ${secret_name}"' in deploy
     assert "secrets.token_urlsafe(48)" in deploy
     assert "--secret=trustedrouter-observer-internal-token" in deploy
     assert "--secret=trustedrouter-internal-gateway-token" in deploy
@@ -761,14 +1056,16 @@ def test_edge_surface_inventory_is_total_and_never_claims_live_completion() -> N
 def test_runbook_has_emergency_promotion_and_independent_cost_caps() -> None:
     runbook = (ROOT / "docs/runbooks/ddos-edge-hardening.md").read_text(encoding="utf-8")
 
-    assert "TR_CLOUD_ARMOR_PREVIEW=0" in runbook
+    assert "preview-only until a separately approved" in runbook
     assert "TR_AWS_WAF_PREVIEW=0" in runbook
     assert "HighRatePerIpBlock" in runbook
-    assert "actions-backend=actions-edge" in runbook
+    assert "public, actions, console, chat, webhooks, and" in runbook
     for row in (
         "| Public/static | 4 | 10 |",
         "| Anonymous actions | 4 | 2 |",
-        "| Control | 4 | 20 |",
+        "| Console | 4 | 20 |",
+        "| Chat proxy | 2 | 20 |",
+        "| Webhooks | 4 | 10 |",
         "| Billing/internal gateway | 8 | 50 |",
         "| Observer/status worker | 4 | 4 |",
     ):

--- a/tests/test_deploy_iam_helpers.py
+++ b/tests/test_deploy_iam_helpers.py
@@ -20,7 +20,13 @@ case "$*" in
     ;;
   *"projects get-iam-policy"*)
     if [ "${FAKE_BINDING_PRESENT:-0}" = "1" ]; then
-      printf '%s\\n' "${FAKE_ROLE}"
+      if [ "${FAKE_BINDING_CONDITIONAL:-0}" = "1" ]; then
+        printf '{"bindings":[{"role":"%s","members":["%s"],"condition":{"title":"temporary","expression":"true"}}]}\\n' "${FAKE_ROLE}" "${FAKE_MEMBER}"
+      else
+        printf '{"bindings":[{"role":"%s","members":["%s"]}]}\\n' "${FAKE_ROLE}" "${FAKE_MEMBER}"
+      fi
+    else
+      printf '{"bindings":[]}\\n'
     fi
     ;;
   *"projects add-iam-policy-binding"*)
@@ -45,6 +51,7 @@ def _run_ensure_project_role(
     tmp_path: Path,
     *,
     binding_present: bool,
+    binding_conditional: bool = False,
     add_denied: bool = False,
 ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
     _, calls = _fake_gcloud(tmp_path)
@@ -55,8 +62,10 @@ def _run_ensure_project_role(
         "PROJECT_ID": "test-project",
         "FAKE_GCLOUD_CALLS": str(calls),
         "FAKE_BINDING_PRESENT": "1" if binding_present else "0",
+        "FAKE_BINDING_CONDITIONAL": "1" if binding_conditional else "0",
         "FAKE_ADD_DENIED": "1" if add_denied else "0",
         "FAKE_ROLE": role,
+        "FAKE_MEMBER": "serviceAccount:runtime@test-project.iam.gserviceaccount.com",
     }
     result = subprocess.run(  # noqa: S603 - fixed local test command
         [
@@ -96,3 +105,18 @@ def test_missing_project_role_fails_after_one_denied_write(tmp_path: Path) -> No
     assert result.returncode != 0
     assert sum("add-iam-policy-binding" in call for call in calls) == 1
     assert "Policy update access denied" in result.stderr
+
+
+def test_conditional_project_role_does_not_satisfy_unconditional_grant(
+    tmp_path: Path,
+) -> None:
+    result, calls = _run_ensure_project_role(
+        tmp_path,
+        binding_present=True,
+        binding_conditional=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    writes = [call for call in calls if "add-iam-policy-binding" in call]
+    assert len(writes) == 1
+    assert "--condition=None" in writes[0]

--- a/tests/test_deploy_service_names.py
+++ b/tests/test_deploy_service_names.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+INFRA = (ROOT / "scripts/deploy/infra.sh").read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("env_update", "expected_console", "expected_legacy"),
+    (
+        ({}, "trusted-router-console", "trusted-router"),
+        ({"SERVICE": "router-canary"}, "router-canary-console", "router-canary"),
+        (
+            {
+                "TR_CONSOLE_SERVICE": "reviewed-console",
+                "TR_LEGACY_CONSOLE_SERVICE": "reviewed-monolith",
+            },
+            "reviewed-console",
+            "reviewed-monolith",
+        ),
+    ),
+)
+def test_console_and_legacy_monolith_names_resolve_independently(
+    tmp_path: Path,
+    env_update: dict[str, str],
+    expected_console: str,
+    expected_legacy: str,
+) -> None:
+    fake_gcloud = tmp_path / "gcloud"
+    fake_gcloud.write_text(
+        "#!/usr/bin/env bash\nprintf '123456789\\n'\n",
+        encoding="utf-8",
+    )
+    fake_gcloud.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{tmp_path}:{os.environ['PATH']}",
+        "PROJECT_ID": "test-project",
+    }
+    for variable in (
+        "SERVICE",
+        "TR_CONSOLE_SERVICE",
+        "TR_LEGACY_CONSOLE_SERVICE",
+    ):
+        env.pop(variable, None)
+    env.update(env_update)
+
+    result = subprocess.run(  # noqa: S603 - fixed local shell and repository script
+        [
+            "/bin/bash",
+            "-c",
+            (
+                "source scripts/deploy/_lib.sh; "
+                "printf '%s\\t%s\\n' \"$CONSOLE_SERVICE\" \"$LEGACY_CONSOLE_SERVICE\""
+            ),
+        ],
+        cwd=ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == f"{expected_console}\t{expected_legacy}"
+
+
+def test_legacy_iam_retirement_rejects_a_console_monolith_alias() -> None:
+    start = INFRA.index("verify_legacy_runtime_retirement_ready() {")
+    end = INFRA.index("verify_identity_resource_manager_ancestors_empty() {", start)
+    helper = INFRA[start:end]
+
+    assert 'if [ "$CONSOLE_SERVICE" = "$LEGACY_CONSOLE_SERVICE" ]; then' in helper
+    assert "split console ${CONSOLE_SERVICE} aliases the legacy monolith" in helper
+    assert helper.index('"$CONSOLE_SERVICE"') < helper.index("local -a services=(")

--- a/tests/test_gcp_runtime_iam_contract.py
+++ b/tests/test_gcp_runtime_iam_contract.py
@@ -1,0 +1,1298 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+LIB = (ROOT / "scripts/deploy/_lib.sh").read_text(encoding="utf-8")
+INFRA = (ROOT / "scripts/deploy/infra.sh").read_text(encoding="utf-8")
+SECRETS = (ROOT / "scripts/deploy/secrets.sh").read_text(encoding="utf-8")
+SYNTHETIC = (ROOT / "scripts/deploy/synthetic.sh").read_text(encoding="utf-8")
+RUNBOOK = (ROOT / "docs/runbooks/ddos-edge-hardening.md").read_text(encoding="utf-8")
+PRICE_REFRESH = (ROOT / ".github/workflows/refresh-prices.yml").read_text(
+    encoding="utf-8"
+)
+
+RUNTIME_VARIABLES = (
+    "PUBLIC_RUN_SERVICE_ACCOUNT",
+    "ACTIONS_RUN_SERVICE_ACCOUNT",
+    "CONSOLE_RUN_SERVICE_ACCOUNT",
+    "CHAT_RUN_SERVICE_ACCOUNT",
+    "WEBHOOKS_RUN_SERVICE_ACCOUNT",
+    "INTERNAL_RUN_SERVICE_ACCOUNT",
+)
+
+
+def _shell_words(source: str) -> str:
+    return " ".join(source.replace("\\\n", " ").split())
+
+
+def _function_body(source: str, name: str, next_name: str) -> str:
+    start = source.index(f"{name}() {{")
+    end = source.index(f"{next_name}() {{", start)
+    return source[start:end]
+
+
+def _infra_is_resource_scoped(source: str) -> bool:
+    words = _shell_words(source)
+    required = (
+        'gc spanner databases add-iam-policy-binding "$SPANNER_DATABASE_ID"',
+        'gc bigtable instances add-iam-policy-binding "$BIGTABLE_INSTANCE_ID"',
+        'gc kms keys add-iam-policy-binding "$BYOK_KMS_KEY_ID"',
+        'gc kms keys add-iam-policy-binding "$GOOGLE_ADS_KMS_KEY_ID"',
+        '"$PUBLIC_RUN_SERVICE_ACCOUNT" "$CHAT_RUN_SERVICE_ACCOUNT"; do '
+        'member="serviceAccount:${service_account}"',
+        '"$CONSOLE_RUN_SERVICE_ACCOUNT" "$WEBHOOKS_RUN_SERVICE_ACCOUNT" '
+        '"$INTERNAL_RUN_SERVICE_ACCOUNT"; do',
+        '"roles/spanner.databaseReader"',
+        '"roles/spanner.databaseUser"',
+        '"roles/bigtable.reader"',
+        '"roles/bigtable.user"',
+        '--member="serviceAccount:${CONSOLE_RUN_SERVICE_ACCOUNT}" '
+        '--role="roles/cloudkms.cryptoKeyEncrypterDecrypter"',
+        '--member="serviceAccount:${INTERNAL_RUN_SERVICE_ACCOUNT}" '
+        '--role="roles/cloudkms.cryptoKeyDecrypter"',
+    )
+    forbidden = (
+        'ensure_project_role "$member" "roles/spanner.',
+        'ensure_project_role "$member" "roles/bigtable.',
+        'ensure_project_role "$member" "roles/cloudkms.',
+        'ensure_project_role "$member" "roles/secretmanager.secretAccessor"',
+        'gc projects add-iam-policy-binding "$PROJECT_ID" --member="$member" '
+        '--role="roles/spanner.',
+        'gc projects add-iam-policy-binding "$PROJECT_ID" --member="$member" '
+        '--role="roles/bigtable.',
+    )
+    return all(item in words for item in required) and not any(
+        item in words for item in forbidden
+    )
+
+
+def _anti_reuse_contract_is_complete(source: str) -> bool:
+    words = _shell_words(source)
+    checks = (
+        'case "$_internal_stripe_key" in rk_live_?*)',
+        '[ "$_internal_stripe_key" = "$_console_stripe_key" ]',
+        '[ "$_internal_ses_access_key_id" = "$_shared_ses_access_key_id" ]',
+        '[ "$_internal_ses_secret_access_key" = "$_shared_ses_secret_access_key" ]',
+        '[ "$_observer_token_check" = "$_gateway_token_check" ]',
+        '[ "$_attribution_token_check" = "$_gateway_token_check" ]',
+        '[ "$_attribution_token_check" = "$_observer_token_check" ]',
+        '[ "$_monitor_token_check" = "$_observer_token_check" ]',
+        '[ "$_monitor_token_check" = "$_gateway_token_check" ]',
+        '[ "$_monitor_token_check" = "$_attribution_token_check" ]',
+    )
+    secret_values = (
+        "$_internal_stripe_key",
+        "$_console_stripe_key",
+        "$_internal_ses_access_key_id",
+        "$_internal_ses_secret_access_key",
+        "$_shared_ses_access_key_id",
+        "$_shared_ses_secret_access_key",
+        "$_observer_token_check",
+        "$_gateway_token_check",
+        "$_attribution_token_check",
+        "$_monitor_token_check",
+    )
+    logged_lines = "\n".join(
+        line for line in source.splitlines() if "echo " in line or "log " in line
+    )
+    return all(check in words for check in checks) and not any(
+        value in logged_lines for value in secret_values
+    )
+
+
+def _desired_runtime_grants_precede_obsolete_removals(source: str) -> bool:
+    words = _shell_words(source)
+    marker = "granting and verifying desired runtime IAM before obsolete-role cleanup"
+    if marker not in words:
+        return False
+    tail = words[words.index(marker) :]
+    contracts = (
+        (
+            (
+                'gc kms keys add-iam-policy-binding "$GOOGLE_ADS_KMS_KEY_ID"',
+            ),
+            'verify_resource_role_present "Google Ads KMS key"',
+            'remove_kms_role_if_present "$member" "$role" "$GOOGLE_ADS_KMS_KEY_ID"',
+            'verify_only_resource_role "Google Ads KMS key"',
+        ),
+        (
+            (
+                'ensure_project_role "$member" "roles/serviceusage.serviceUsageConsumer"',
+            ),
+            'verify_resource_role_present "project" "$member" '
+            '"roles/serviceusage.serviceUsageConsumer"',
+            'remove_project_role_if_present "$member" '
+            '"roles/serviceusage.serviceUsageConsumer"',
+            'verify_only_resource_role "project" "$member" "$expected_project_role"',
+        ),
+        (
+            (
+                'gc spanner databases add-iam-policy-binding "$SPANNER_DATABASE_ID" '
+                '--instance="$SPANNER_INSTANCE_ID" --member="$member" '
+                '--role="roles/spanner.databaseReader"',
+                'gc spanner databases add-iam-policy-binding "$SPANNER_DATABASE_ID" '
+                '--instance="$SPANNER_INSTANCE_ID" --member="$member" '
+                '--role="roles/spanner.databaseUser"',
+            ),
+            'verify_resource_role_present "Spanner database"',
+            'remove_spanner_role_if_present "$member"',
+            'verify_only_resource_role "Spanner database" "$member" '
+            '"$expected_spanner_role"',
+        ),
+        (
+            (
+                'gc bigtable instances add-iam-policy-binding "$BIGTABLE_INSTANCE_ID" '
+                '--member="$member" --role="roles/bigtable.reader"',
+                'gc bigtable instances add-iam-policy-binding "$BIGTABLE_INSTANCE_ID" '
+                '--member="$member" --role="roles/bigtable.user"',
+            ),
+            'verify_resource_role_present "Bigtable instance"',
+            'remove_bigtable_role_if_present "$member"',
+            'verify_only_resource_role "Bigtable instance" "$member" '
+            '"$expected_bigtable_role"',
+        ),
+        (
+            (
+                'gc kms keys add-iam-policy-binding "$BYOK_KMS_KEY_ID" '
+                '--keyring="$KMS_KEYRING_ID" --location="$REGION" '
+                '--member="serviceAccount:${CONSOLE_RUN_SERVICE_ACCOUNT}" '
+                '--role="roles/cloudkms.cryptoKeyEncrypterDecrypter"',
+                'gc kms keys add-iam-policy-binding "$BYOK_KMS_KEY_ID" '
+                '--keyring="$KMS_KEYRING_ID" --location="$REGION" '
+                '--member="serviceAccount:${INTERNAL_RUN_SERVICE_ACCOUNT}" '
+                '--role="roles/cloudkms.cryptoKeyDecrypter"',
+            ),
+            'verify_resource_role_present "BYOK KMS key"',
+            'remove_kms_role_if_present "$member" "$role"',
+            'verify_only_resource_role "BYOK KMS key"',
+        ),
+    )
+    for grants, presence, removal, postverify in contracts:
+        if any(grant not in tail for grant in grants):
+            return False
+        if presence not in tail or removal not in tail or postverify not in tail:
+            return False
+        removal_position = tail.index(removal)
+        if any(tail.index(grant) >= removal_position for grant in grants):
+            return False
+        presence_position = tail.index(presence)
+        if presence_position >= removal_position:
+            return False
+        if tail.index(postverify, removal_position) <= removal_position:
+            return False
+    return True
+
+
+def test_six_runtime_service_accounts_are_distinct_and_never_legacy() -> None:
+    array = re.search(r"RUNTIME_SERVICE_ACCOUNTS=\(\n(?P<body>.*?)\n\)", LIB, re.S)
+    assert array is not None
+    assert tuple(re.findall(r'"\$(\w+_RUN_SERVICE_ACCOUNT)"', array["body"])) == (
+        RUNTIME_VARIABLES
+    )
+    assert "validate_runtime_service_accounts" in INFRA
+    assert "validate_runtime_service_accounts" in SECRETS
+    assert 'if [ "$service_account" = "$RUN_SERVICE_ACCOUNT" ]' in LIB
+    assert "runtime service accounts must be distinct" in LIB
+    assert "deploy service account must not be a runtime identity" in LIB
+    expected_ids = {
+        "PUBLIC": "tr-public",
+        "ACTIONS": "tr-actions",
+        "CONSOLE": "tr-console",
+        "CHAT": "tr-chat",
+        "WEBHOOKS": "tr-webhooks",
+        "INTERNAL": "tr-internal",
+    }
+    for surface, account_id in expected_ids.items():
+        assignment = (
+            f'{surface}_RUN_SERVICE_ACCOUNT="'
+            + "${TR_"
+            + surface
+            + "_RUN_SERVICE_ACCOUNT:-"
+            + account_id
+            + "@${PROJECT_ID}.iam.gserviceaccount.com}"
+            + '"'
+        )
+        assert assignment in LIB
+    assert (
+        'DEPLOY_SERVICE_ACCOUNT="${TR_DEPLOY_SERVICE_ACCOUNT:-'
+        'tr-deploy@${PROJECT_ID}.iam.gserviceaccount.com}"' in LIB
+    )
+    assert "deploy service account must belong to ${PROJECT_ID}" in LIB
+
+
+def test_deploy_actas_is_bound_to_the_six_runtime_accounts() -> None:
+    words = _shell_words(INFRA)
+    assert (
+        'for service_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do gc iam '
+        in words
+    )
+    assert (
+        'service-accounts add-iam-policy-binding "$service_account" '
+        '--member="serviceAccount:${DEPLOY_SERVICE_ACCOUNT}" '
+        '--role="roles/iam.serviceAccountUser"' in words
+    )
+    assert (
+        'verify_only_resource_role "runtime service-account actAs" '
+        '"serviceAccount:${DEPLOY_SERVICE_ACCOUNT}" '
+        '"roles/iam.serviceAccountUser"' in words
+    )
+    # Non-surface actAs targets are the conversion job and dedicated synthetic Job.
+    assert words.count('--role="roles/iam.serviceAccountUser"') == 3
+    assert '"$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT"' in words
+    assert '"$SYNTHETIC_RUN_SERVICE_ACCOUNT"' in words
+
+
+def test_runtime_data_and_kms_roles_are_resource_scoped() -> None:
+    assert _infra_is_resource_scoped(INFRA)
+
+
+def test_desired_runtime_iam_is_granted_and_verified_before_cleanup() -> None:
+    assert _desired_runtime_grants_precede_obsolete_removals(INFRA)
+
+
+@pytest.mark.parametrize(
+    "premature_removal",
+    (
+        'remove_kms_role_if_present "$member" "$role" "$GOOGLE_ADS_KMS_KEY_ID"',
+        'remove_project_role_if_present "$member" '
+        '"roles/serviceusage.serviceUsageConsumer"',
+        'remove_spanner_role_if_present "$member" "roles/spanner.databaseReader"',
+        'remove_bigtable_role_if_present "$member" "roles/bigtable.reader"',
+        'remove_kms_role_if_present "$member" "$role"',
+    ),
+)
+def test_remove_before_add_mutations_break_the_runtime_iam_contract(
+    premature_removal: str,
+) -> None:
+    marker = 'log "granting and verifying desired runtime IAM before obsolete-role cleanup"'
+    assert marker in INFRA
+    mutated = INFRA.replace(marker, f"{marker}\n{premature_removal}", 1)
+    assert not _desired_runtime_grants_precede_obsolete_removals(mutated)
+
+
+@pytest.mark.parametrize(
+    ("old", "new"),
+    (
+        (
+            'gc spanner databases add-iam-policy-binding "$SPANNER_DATABASE_ID"',
+            'gc projects add-iam-policy-binding "$PROJECT_ID"',
+        ),
+        (
+            'gc bigtable instances add-iam-policy-binding "$BIGTABLE_INSTANCE_ID"',
+            'gc projects add-iam-policy-binding "$PROJECT_ID"',
+        ),
+        (
+            'gc kms keys add-iam-policy-binding "$BYOK_KMS_KEY_ID"',
+            'gc projects add-iam-policy-binding "$PROJECT_ID"',
+        ),
+        (
+            '"$PUBLIC_RUN_SERVICE_ACCOUNT" "$CHAT_RUN_SERVICE_ACCOUNT"',
+            '"$PUBLIC_RUN_SERVICE_ACCOUNT" "$ACTIONS_RUN_SERVICE_ACCOUNT"',
+        ),
+    ),
+)
+def test_resource_scope_mutations_break_the_contract(old: str, new: str) -> None:
+    assert old in INFRA
+    assert not _infra_is_resource_scoped(INFRA.replace(old, new))
+
+
+def test_project_roles_are_complete_and_actions_has_none() -> None:
+    words = _shell_words(INFRA)
+    assert (
+        '"$PUBLIC_RUN_SERVICE_ACCOUNT" "$CONSOLE_RUN_SERVICE_ACCOUNT" '
+        '"$CHAT_RUN_SERVICE_ACCOUNT" "$WEBHOOKS_RUN_SERVICE_ACCOUNT" '
+        '"$INTERNAL_RUN_SERVICE_ACCOUNT"; do ensure_project_role '
+        '"serviceAccount:${service_account}" '
+        '"roles/serviceusage.serviceUsageConsumer"' in words
+    )
+    assert (
+        '"project" "serviceAccount:${ACTIONS_RUN_SERVICE_ACCOUNT}" "" '
+        'gc projects get-iam-policy "$PROJECT_ID"' in words
+    )
+    for role in ("roles/editor", "roles/owner", "roles/run.developer"):
+        assert f'remove_project_role_if_present "$member" "{role}"' in INFRA
+    deploy_preflight = _function_body(
+        INFRA,
+        "verify_deploy_identity_has_no_project_data_roles",
+        "preflight_identity_iam_removal_targets",
+    )
+    for role in (
+        "roles/secretmanager.secretAccessor",
+        "roles/secretmanager.admin",
+        "roles/spanner.databaseReader",
+        "roles/spanner.databaseUser",
+        "roles/bigtable.reader",
+        "roles/bigtable.user",
+        "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+        "roles/iam.serviceAccountUser",
+        "roles/iam.serviceAccountTokenCreator",
+        "roles/editor",
+        "roles/owner",
+    ):
+        assert role in deploy_preflight
+    assert "remove-iam-policy-binding" not in deploy_preflight
+    assert "describe_iam_role_definition" in deploy_preflight
+    for permission in (
+        "iam.serviceAccounts.actAs",
+        "iam.serviceAccounts.getAccessToken",
+        "secretmanager.versions.access",
+        "cloudkms.cryptoKeyVersions.useToDecrypt",
+    ):
+        assert permission in deploy_preflight
+
+
+def test_runtime_secret_reconciler_is_preflighted_targeted_and_exact() -> None:
+    helper = _function_body(
+        LIB,
+        "secret_iam_policy_contract_json",
+        "validate_nonempty_region_list",
+    )
+    body = _function_body(
+        SECRETS,
+        "reconcile_declared_secret_iam",
+        "verify_runtime_secret_access",
+    )
+    assert "roles/secretmanager.secretAccessor" in helper
+    assert "allUsers" in helper and "allAuthenticatedUsers" in helper
+    assert "unapproved unrelated secret principal" in helper
+    assert "TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON" in helper
+    assert "secret_iam_policy_contract_json plan" in body
+    assert "unknown secret ${secret_name}" in body
+    assert "add-iam-policy-binding" in body
+    assert "remove-iam-policy-binding" in body
+    assert "set-iam-policy" not in body
+    first_mutation = min(
+        body.index("gc secrets add-iam-policy-binding"),
+        body.index("gc secrets remove-iam-policy-binding"),
+    )
+    assert body.index('done <<<"$secret_names"') < first_mutation
+
+    required_bindings = (
+        "trustedrouter-attribution-cookie-secret",
+        "trustedrouter-sentry-dsn",
+        "trustedrouter-stripe-secret-key",
+        "trustedrouter-stripe-webhook-secret",
+        "trustedrouter-internal-stripe-payment-intents-key",
+        "trustedrouter-aws-access-key-id",
+        "trustedrouter-aws-secret-access-key",
+        "trustedrouter-internal-ses-access-key-id",
+        "trustedrouter-internal-ses-secret-access-key",
+        "trustedrouter-internal-gateway-token",
+        "trustedrouter-observer-internal-token",
+        "trustedrouter-synthetic-monitor-api-key",
+    )
+    verification_tail = LIB[LIB.index("secret_expected_surfaces()") :]
+    for secret_name in required_bindings:
+        assert secret_name in verification_tail
+
+
+@pytest.mark.parametrize(
+    ("bindings", "error_fragment"),
+    (
+        (
+            [
+                {
+                    "role": "roles/secretmanager.secretAccessor",
+                    "members": [
+                        "serviceAccount:tr-public@quill-cloud-proxy.iam.gserviceaccount.com"
+                    ],
+                    "condition": {"title": "expired", "expression": "false"},
+                }
+            ],
+            "noncanonical role or condition",
+        ),
+        (
+            [
+                {
+                    "role": "roles/secretmanager.secretAccessor",
+                    "members": [
+                        "serviceAccount:tr-public@quill-cloud-proxy.iam.gserviceaccount.com"
+                    ],
+                },
+                {
+                    "role": "roles/secretmanager.secretAccessor",
+                    "members": [
+                        "serviceAccount:tr-actions@quill-cloud-proxy.iam.gserviceaccount.com"
+                    ],
+                    "condition": {"title": "temporary", "expression": "true"},
+                },
+            ],
+            "noncanonical role or condition",
+        ),
+    ),
+    ids=("conditional-owner", "conditional-non-owner"),
+)
+def test_runtime_secret_verifier_rejects_conditional_owner_and_nonowner_bindings(
+    tmp_path: Path,
+    bindings: list[dict[str, object]],
+    error_fragment: str,
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_gcloud = fake_bin / "gcloud"
+    fake_gcloud.write_text(
+        "#!/usr/bin/env bash\n"
+        "if [[ \"$*\" == *\"projects describe\"* ]]; then\n"
+        "  printf '123456789\\n'\n"
+        "else\n"
+        "  exit 2\n"
+        "fi\n"
+    )
+    fake_gcloud.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "HOME": str(tmp_path),
+        "FAKE_SECRET_POLICY": json.dumps(
+            {"bindings": bindings}, separators=(",", ":")
+        ),
+    }
+    run = subprocess.run(  # noqa: S603 - fixed shell and repo-local helpers
+        [
+            "/bin/bash",
+            "-c",
+            'source "$1"; printf "%s" "$FAKE_SECRET_POLICY" | '
+            'secret_iam_policy_contract_json plan test-secret "public"',
+            "bash",
+            str(ROOT / "scripts/deploy/_lib.sh"),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=ROOT,
+        check=False,
+    )
+
+    assert run.returncode != 0
+    assert error_fragment in run.stderr
+
+
+def _run_secret_iam_reconciler(
+    tmp_path: Path,
+    secrets: dict[str, dict[str, object]],
+    *,
+    preserved: dict[str, list[str]] | None = None,
+) -> tuple[subprocess.CompletedProcess[str], dict[str, object], list[str]]:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    state_path = tmp_path / "secret-state.json"
+    events_path = tmp_path / "events.log"
+    state_path.write_text(json.dumps(secrets, sort_keys=True), encoding="utf-8")
+    events_path.write_text("", encoding="utf-8")
+    fake_gcloud = fake_bin / "gcloud"
+    fake_gcloud.write_text(
+        r'''#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+if args[:1] == ["--project"]:
+    args = args[2:]
+state_path = Path(os.environ["FAKE_SECRET_STATE"])
+events_path = Path(os.environ["FAKE_SECRET_EVENTS"])
+with events_path.open("a", encoding="utf-8") as output:
+    output.write(" ".join(args) + "\n")
+
+def option(name):
+    for index, value in enumerate(args):
+        if value.startswith(name + "="):
+            return value.split("=", 1)[1]
+        if value == name and index + 1 < len(args):
+            return args[index + 1]
+    return ""
+
+if args[:2] == ["projects", "describe"]:
+    print("123456789")
+    raise SystemExit(0)
+state = json.loads(state_path.read_text(encoding="utf-8"))
+if args[:2] == ["secrets", "list"]:
+    print(json.dumps([
+        {"name": f"projects/quill-cloud-proxy/secrets/{name}"}
+        for name in sorted(state)
+    ], separators=(",", ":")))
+    raise SystemExit(0)
+if args[:2] == ["secrets", "get-iam-policy"]:
+    print(json.dumps(state[args[2]], separators=(",", ":")))
+    raise SystemExit(0)
+if args[:2] in (
+    ["secrets", "add-iam-policy-binding"],
+    ["secrets", "remove-iam-policy-binding"],
+):
+    action = args[1].split("-", 1)[0]
+    secret = args[2]
+    member = option("--member")
+    role = option("--role")
+    if option("--condition") != "None":
+        raise SystemExit(88)
+    bindings = state[secret].setdefault("bindings", [])
+    matches = [
+        binding for binding in bindings
+        if binding.get("role") == role and binding.get("condition") is None
+    ]
+    if action == "add":
+        binding = matches[0] if matches else {"role": role, "members": []}
+        if not matches:
+            bindings.append(binding)
+        if member in binding["members"]:
+            raise SystemExit(89)
+        binding["members"].append(member)
+    else:
+        found = False
+        for binding in matches:
+            if member in binding.get("members", []):
+                binding["members"].remove(member)
+                found = True
+        if not found:
+            raise SystemExit(90)
+        state[secret]["bindings"] = [
+            binding for binding in bindings if binding.get("members")
+        ]
+    state_path.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
+    raise SystemExit(0)
+print("unexpected fake gcloud call: " + " ".join(args), file=sys.stderr)
+raise SystemExit(87)
+''',
+        encoding="utf-8",
+    )
+    fake_gcloud.chmod(0o755)
+    helper = tmp_path / "secret-reconciler.sh"
+    helper.write_text(
+        _function_body(
+            SECRETS,
+            "reconcile_declared_secret_iam",
+            "verify_runtime_secret_access",
+        ),
+        encoding="utf-8",
+    )
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "HOME": str(tmp_path),
+        "FAKE_SECRET_STATE": str(state_path),
+        "FAKE_SECRET_EVENTS": str(events_path),
+        "TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON": json.dumps(preserved or {}),
+    }
+    run = subprocess.run(  # noqa: S603 - isolated fake gcloud and repo helper
+        [
+            "/bin/bash",
+            "-c",
+            'source "$1"; source "$2"; reconcile_declared_secret_iam',
+            "bash",
+            str(ROOT / "scripts/deploy/_lib.sh"),
+            str(helper),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=ROOT,
+        check=False,
+    )
+    final_state = json.loads(state_path.read_text(encoding="utf-8"))
+    events = events_path.read_text(encoding="utf-8").splitlines()
+    return run, final_state, events
+
+
+def _secret_accessor_members(policy: dict[str, object]) -> set[str]:
+    return {
+        member
+        for binding in policy.get("bindings", [])
+        if binding.get("role") == "roles/secretmanager.secretAccessor"
+        and binding.get("condition") is None
+        for member in binding.get("members", [])
+    }
+
+
+def test_secret_iam_reconciler_mutates_only_declared_owner_bindings(
+    tmp_path: Path,
+) -> None:
+    preserved_member = "group:billing-auditors@example.com"
+    secrets = {
+        "trustedrouter-attribution-cookie-secret": {
+            "bindings": [
+                {
+                    "role": "roles/secretmanager.secretAccessor",
+                    "members": [
+                        "serviceAccount:tr-actions@quill-cloud-proxy.iam.gserviceaccount.com",
+                        preserved_member,
+                    ],
+                },
+                {
+                    "role": "roles/secretmanager.secretAccessor",
+                    "members": ["allUsers"],
+                },
+            ]
+        },
+        "trustedrouter-openai-api-key": {
+            "bindings": [
+                {
+                    "role": "roles/secretmanager.secretAccessor",
+                    "members": [
+                        "serviceAccount:tr-chat@quill-cloud-proxy.iam.gserviceaccount.com"
+                    ],
+                }
+            ]
+        },
+        "trustedrouter-observer-internal-token": {
+            "bindings": [
+                {
+                    "role": "roles/secretmanager.secretAccessor",
+                    "members": [
+                        "serviceAccount:tr-internal@quill-cloud-proxy.iam.gserviceaccount.com"
+                    ],
+                }
+            ]
+        },
+        "owner-managed-existing-secret": {"bindings": []},
+    }
+
+    run, final_state, events = _run_secret_iam_reconciler(
+        tmp_path,
+        secrets,
+        preserved={
+            "trustedrouter-attribution-cookie-secret": [preserved_member]
+        },
+    )
+
+    assert run.returncode == 0, run.stderr
+    assert _secret_accessor_members(
+        final_state["trustedrouter-attribution-cookie-secret"]
+    ) == {
+        "serviceAccount:tr-public@quill-cloud-proxy.iam.gserviceaccount.com",
+        "serviceAccount:tr-console@quill-cloud-proxy.iam.gserviceaccount.com",
+        preserved_member,
+    }
+    assert _secret_accessor_members(final_state["trustedrouter-openai-api-key"]) == {
+        "serviceAccount:tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com"
+    }
+    assert _secret_accessor_members(
+        final_state["trustedrouter-observer-internal-token"]
+    ) == {
+        "serviceAccount:tr-internal@quill-cloud-proxy.iam.gserviceaccount.com",
+        "serviceAccount:tr-synthetic@quill-cloud-proxy.iam.gserviceaccount.com",
+    }
+    assert final_state["owner-managed-existing-secret"] == {"bindings": []}
+    mutations = [
+        event
+        for event in events
+        if "add-iam-policy-binding" in event or "remove-iam-policy-binding" in event
+    ]
+    assert mutations
+    assert all("set-iam-policy" not in event for event in events)
+    assert not any("owner-managed-existing-secret" in event for event in mutations)
+
+
+def test_secret_iam_reconciler_fails_before_mutation_on_unknown_managed_grant(
+    tmp_path: Path,
+) -> None:
+    secrets = {
+        "trustedrouter-attribution-cookie-secret": {"bindings": []},
+        "owner-managed-existing-secret": {
+            "bindings": [
+                {
+                    "role": "roles/secretmanager.secretAccessor",
+                    "members": [
+                        "serviceAccount:tr-public@quill-cloud-proxy.iam.gserviceaccount.com"
+                    ],
+                }
+            ]
+        },
+    }
+
+    run, final_state, events = _run_secret_iam_reconciler(tmp_path, secrets)
+
+    assert run.returncode != 0
+    assert final_state == secrets
+    assert not any("iam-policy-binding" in event for event in events)
+
+
+def test_deploy_secret_accessor_residual_is_exact_and_never_project_wide() -> None:
+    allowlist = _function_body(
+        LIB,
+        "deploy_service_account_owns_secret",
+        "synthetic_service_account_owns_secret",
+    )
+    grants = set(re.findall(r"trustedrouter-[a-z0-9-]+", allowlist))
+    workflow_reads = set(re.findall(r"trustedrouter-[a-z0-9-]+", PRICE_REFRESH))
+    workflow_reads.discard("trustedrouter-pricing-bot")
+    assert grants == workflow_reads
+    assert "grant_tr_deploy_secret_access" not in SECRETS
+    assert (
+        'ensure_project_role "$member" "roles/secretmanager.secretAccessor"'
+        not in INFRA
+    )
+    assert 'TR_DEPLOY_SA="$DEPLOY_SERVICE_ACCOUNT"' in SECRETS
+    assert "TR_DEPLOY_SA must match TR_DEPLOY_SERVICE_ACCOUNT" in SECRETS
+
+
+def test_split_runtimes_cannot_read_upstream_model_provider_secrets() -> None:
+    provider_creation_block = SECRETS[
+        SECRETS.index('ensure_secret_from_env_file "ANTHROPIC_API_KEY"') :
+        SECRETS.index("# Dedicated read-only ClickHouse credential")
+    ]
+    provisioned = set(
+        re.findall(r"trustedrouter-[a-z0-9-]+", provider_creation_block)
+    )
+    provisioned -= {
+        "trustedrouter-veriff-api-key",
+        "trustedrouter-veriff-shared-secret-key",
+    }
+    manifest = re.search(
+        r"DETACHED_PROVIDER_SECRET_NAMES=\(\n(?P<body>.*?)\n\)",
+        SECRETS,
+        re.S,
+    )
+    assert manifest is not None
+    detached_secrets = set(
+        re.findall(r"trustedrouter-[a-z0-9-]+", manifest["body"])
+    )
+    assert detached_secrets - {"trustedrouter-athena-worker-prompt-v1"} == provisioned
+    ownership_loop = SECRETS[
+        manifest.end() : SECRETS.index(
+            "# Runtime-SA project-level IAM bindings", manifest.end()
+        )
+    ]
+    assert '"$CHAT_RUN_SERVICE_ACCOUNT"' not in ownership_loop
+    assert (
+        'verify_runtime_secret_access optional "$secret_name"\n'
+        '  fi' in ownership_loop
+    )
+    assert (
+        'verify_runtime_secret_access optional "$secret_name" \\\n'
+        '      "$CONSOLE_RUN_SERVICE_ACCOUNT"' in ownership_loop
+    )
+
+
+def test_axiom_token_is_detached_from_every_split_runtime() -> None:
+    axiom_call = SECRETS[
+        SECRETS.index(
+            "verify_runtime_secret_access optional trustedrouter-axiom-api-token"
+        ) :
+        SECRETS.index("for secret_name in \\\n  trustedrouter-federation-peer-token")
+    ]
+    assert "RUN_SERVICE_ACCOUNT" not in axiom_call
+
+
+def test_actions_has_no_data_or_kms_capability() -> None:
+    words = _shell_words(INFRA)
+    assert (
+        '"Spanner database" "serviceAccount:${ACTIONS_RUN_SERVICE_ACCOUNT}" ""'
+        in words
+    )
+    assert (
+        '"$ACTIONS_RUN_SERVICE_ACCOUNT" "$CHAT_RUN_SERVICE_ACCOUNT" '
+        '"$WEBHOOKS_RUN_SERVICE_ACCOUNT"; do verify_only_resource_role '
+        '"Bigtable instance"' in words
+    )
+    assert (
+        '"$PUBLIC_RUN_SERVICE_ACCOUNT" "$ACTIONS_RUN_SERVICE_ACCOUNT" '
+        '"$CHAT_RUN_SERVICE_ACCOUNT" "$WEBHOOKS_RUN_SERVICE_ACCOUNT"; do '
+        'verify_only_resource_role "BYOK KMS key"' in words
+    )
+    assert (
+        '"$PUBLIC_RUN_SERVICE_ACCOUNT" "$ACTIONS_RUN_SERVICE_ACCOUNT" '
+        '"$CHAT_RUN_SERVICE_ACCOUNT" "$WEBHOOKS_RUN_SERVICE_ACCOUNT" '
+        '"$INTERNAL_RUN_SERVICE_ACCOUNT"; do verify_only_resource_role '
+        '"Google Ads KMS key"' in words
+    )
+
+
+def test_restricted_provider_credentials_have_mutation_sensitive_anti_reuse_checks() -> None:
+    assert _anti_reuse_contract_is_complete(SECRETS)
+
+
+@pytest.mark.parametrize(
+    "needle",
+    (
+        '[ "$_internal_stripe_key" = "$_console_stripe_key" ]',
+        '[ "$_internal_ses_access_key_id" = "$_shared_ses_access_key_id" ]',
+        '[ "$_internal_ses_secret_access_key" = "$_shared_ses_secret_access_key" ]',
+        '[ "$_attribution_token_check" = "$_observer_token_check" ]',
+        '[ "$_monitor_token_check" = "$_gateway_token_check" ]',
+    ),
+)
+def test_removing_a_reuse_guard_breaks_the_contract(needle: str) -> None:
+    assert needle in SECRETS
+    assert not _anti_reuse_contract_is_complete(SECRETS.replace(needle, "[ 1 = 2 ]", 1))
+
+
+def test_synthetic_job_identity_has_only_direct_job_and_secret_contracts() -> None:
+    words = _shell_words(SYNTHETIC)
+    secret_envs = re.search(r"SECRET_ENVS=\(\n(?P<body>.*?)\n\)", SYNTHETIC, re.S)
+    assert secret_envs is not None
+    assert set(re.findall(r"trustedrouter-[a-z0-9-]+", secret_envs["body"])) == {
+        "trustedrouter-observer-internal-token",
+        "trustedrouter-synthetic-monitor-api-key",
+    }
+    assert "roles/run.developer" not in SYNTHETIC
+    assert "ensure_project_role" not in SYNTHETIC
+    assert 'gc run jobs add-iam-policy-binding "$job_name"' in words
+    assert '--role="roles/run.invoker"' in words
+    assert "--condition=None" in words
+    assert "verify_synthetic_secret_access" in SYNTHETIC
+    assert "verify_existing_synthetic_job_invoker_or_absent" in SYNTHETIC
+    assert "verify_exact_unconditional_roles" in SYNTHETIC
+    assert "--flatten='bindings[].members'" not in SYNTHETIC
+    assert words.count('ensure_synthetic_job_invoker "$') == 4
+
+
+def test_legacy_retirement_is_guarded_and_covers_data_and_both_kms_keys() -> None:
+    words = _shell_words(INFRA)
+    assert 'if [ "$TR_RETIRE_LEGACY_RUN_SERVICE_ACCOUNT_IAM" = "1" ]; then' in INFRA
+    assert "verify_legacy_runtime_retirement_ready" in INFRA
+    assert "verify_legacy_synthetic_secret_access_ready" in INFRA
+    assert "verify_legacy_cloud_run_service_inventory" in INFRA
+    assert "verify_legacy_synthetic_jobs_ready" in INFRA
+    assert "cloud_run_inventory_lines services" in INFRA
+    assert "cloud_run_inventory_lines jobs" in INFRA
+    assert '"roles/run.invoker"' in INFRA
+    assert 'oauth.get("serviceAccountEmail") != expected_identity' in INFRA
+    assert 'for key_id in "$BYOK_KMS_KEY_ID" "$GOOGLE_ADS_KMS_KEY_ID"' in words
+    assert '"retired project" "$member" "" gc projects get-iam-policy' in words
+    assert "sole-revision 100%" in RUNBOOK
+    assert "TR_RETIRE_LEGACY_RUN_SERVICE_ACCOUNT_IAM=1" in RUNBOOK
+
+
+def test_provider_side_restrictions_are_explicitly_outside_secret_manager() -> None:
+    assert "Payment Intents" in RUNBOOK
+    assert "ses:SendEmail" in RUNBOOK
+    assert "ses:SendRawEmail" in RUNBOOK
+    assert "Secret Manager" in RUNBOOK
+    assert "cannot prove Stripe dashboard permissions or an AWS IAM policy" in RUNBOOK
+
+
+def test_iam_queries_preserve_conditions_and_cover_direct_resource_ancestors() -> None:
+    helper = _function_body(
+        LIB,
+        "iam_direct_binding_tokens_for_member",
+        "iam_member_has_unconditional_role",
+    )
+    assert "--format=json" in helper
+    assert '"condition" in binding' in helper
+    assert 'prefix = "conditional:"' in helper
+    assert "--flatten" not in helper
+
+    preflight = _function_body(
+        INFRA,
+        "preflight_identity_iam_removal_targets",
+        "verify_identity_ancestor_scopes_empty",
+    )
+    for command in (
+        'gc projects get-iam-policy "$PROJECT_ID"',
+        'gc spanner instances get-iam-policy "$SPANNER_INSTANCE_ID"',
+        'gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID"',
+        'gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID"',
+        'gc bigtable tables get-iam-policy "$BIGTABLE_GENERATION_TABLE"',
+        'gc kms keyrings get-iam-policy "$KMS_KEYRING_ID"',
+        'gc kms keys get-iam-policy "$key_id"',
+    ):
+        assert command in preflight
+    for roles in ("project_roles", "database_roles", "bigtable_roles", "kms_roles"):
+        assert f'"${roles}"' in preflight
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        'gc spanner instances get-iam-policy "$SPANNER_INSTANCE_ID"',
+        'gc bigtable tables get-iam-policy "$BIGTABLE_GENERATION_TABLE"',
+        'gc kms keyrings get-iam-policy "$KMS_KEYRING_ID"',
+    ),
+)
+def test_removing_an_ancestor_read_breaks_the_preflight_contract(command: str) -> None:
+    preflight = _function_body(
+        INFRA,
+        "preflight_identity_iam_removal_targets",
+        "verify_identity_ancestor_scopes_empty",
+    )
+    assert command in preflight
+    assert command not in preflight.replace(command, "gc false", 1)
+
+
+def test_every_removal_target_is_preflighted_before_the_first_runtime_removal() -> None:
+    preflight_call = INFRA.index(
+        'log "preflighting all runtime IAM removal targets and direct ancestor policies"'
+    )
+    first_runtime_removal = INFRA.index(
+        'remove_kms_role_if_present "$member" "$role" "$GOOGLE_ADS_KMS_KEY_ID"',
+        preflight_call,
+    )
+    assert preflight_call < first_runtime_removal
+    for call in (
+        'preflight_identity_iam_removal_targets "split runtime" "$service_account"',
+        "verify_legacy_runtime_retirement_ready",
+        "verify_legacy_cloud_run_service_inventory",
+        "verify_legacy_synthetic_secret_access_ready",
+        "verify_legacy_synthetic_jobs_ready",
+        'preflight_identity_iam_removal_targets "legacy runtime" "$RUN_SERVICE_ACCOUNT"',
+    ):
+        assert preflight_call < INFRA.index(call, preflight_call) < first_runtime_removal
+
+
+def test_deploy_actas_audit_is_exact_read_only_and_project_aware() -> None:
+    start = INFRA.index("verify_deploy_actas_inventory() {")
+    end = INFRA.index('\n}\n\nlog "enabling required GCP APIs"', start) + 3
+    body = INFRA[start:end]
+    assert "service-accounts list --format=json" in body
+    assert "verify_exact_unconditional_roles" in body
+    assert "roles/iam.serviceAccountUser" in body
+    assert "verify_deploy_identity_has_no_project_data_roles" in body
+    assert "remove-iam-policy-binding" not in body
+    preflight = (
+        'verify_deploy_actas_inventory '
+        '"$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT" preflight'
+    )
+    postverify = (
+        'verify_deploy_actas_inventory '
+        '"$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT" post'
+    )
+    assert preflight in INFRA
+    assert postverify in INFRA
+    assert INFRA.index(preflight) < INFRA.index(
+        'remove_kms_role_if_present "$member" "$role" "$GOOGLE_ADS_KMS_KEY_ID"',
+        INFRA.index(preflight),
+    )
+    assert INFRA.index(postverify) > INFRA.index(
+        'gc iam service-accounts add-iam-policy-binding \\\n  "$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT"'
+    )
+
+
+def test_regions_and_internal_billing_alias_are_validated_fail_closed() -> None:
+    body = _function_body(LIB, "validate_runtime_service_accounts", "read_key_file_var")
+    assert 'if [ "$TR_BILLING_SERVICE" != "$INTERNAL_SERVICE" ]' in body
+    assert "validate_nonempty_region_list TR_CONTROL_PLANE_REGIONS" in body
+    for variable in (
+        "TR_SYNTHETIC_MONITOR_REGIONS",
+        "TR_SYNTHETIC_THROUGHPUT_REGION",
+        "TR_SYNTHETIC_IMAGE_REGION",
+        "TR_SYNTHETIC_VIDEO_REGION",
+    ):
+        assert f"validate_nonempty_region_list {variable}" in body
+
+
+def test_synthetic_live_contract_checks_one_full_traffic_revision_and_runtime_sa() -> None:
+    body = _function_body(
+        SYNTHETIC,
+        "verify_synthetic_ingest_service_contract",
+        "ensure_synthetic_job_invoker",
+    )
+    assert "len(traffic) != 1" in body
+    assert "!= 100" in body
+    assert 'gc run revisions describe "$revision_name"' in body
+    assert '"$INTERNAL_RUN_SERVICE_ACCOUNT"' in body
+    assert "serving revision identity" in body
+
+
+def test_condition_aware_iam_helper_rejects_state_change_between_reads(
+    tmp_path: Path,
+) -> None:
+    member = "serviceAccount:test@quill-cloud-proxy.iam.gserviceaccount.com"
+    valid = json.dumps(
+        {
+            "bindings": [
+                {"role": "roles/run.invoker", "members": [member]}
+            ]
+        },
+        separators=(",", ":"),
+    )
+    conditional = json.dumps(
+        {
+            "bindings": [
+                {
+                    "role": "roles/run.invoker",
+                    "members": [member],
+                    "condition": {"title": "temporary", "expression": "true"},
+                }
+            ]
+        },
+        separators=(",", ":"),
+    )
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_gcloud = fake_bin / "gcloud"
+    fake_gcloud.write_text(
+        "#!/usr/bin/env bash\n"
+        "if [[ \"$*\" == *\"projects describe\"* ]]; then\n"
+        "  printf '123456789\\n'\n"
+        "  exit 0\n"
+        "fi\n"
+        "if [ ! -f \"$FAKE_IAM_STATE\" ]; then\n"
+        "  : > \"$FAKE_IAM_STATE\"\n"
+        f"  printf '%s\\n' '{valid}'\n"
+        "else\n"
+        f"  printf '%s\\n' '{conditional}'\n"
+        "fi\n"
+    )
+    fake_gcloud.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "HOME": str(tmp_path),
+        "FAKE_IAM_STATE": str(tmp_path / "iam-state"),
+    }
+    run = subprocess.run(  # noqa: S603 - fixed shell and repo-local helper
+        [
+            "/bin/bash",
+            "-c",
+            'source "$1"; '
+            'verify_exact_unconditional_roles first "$2" roles/run.invoker '
+            'gc projects get-iam-policy "$PROJECT_ID"; '
+            'if verify_exact_unconditional_roles second "$2" roles/run.invoker '
+            'gc projects get-iam-policy "$PROJECT_ID"; then exit 91; fi',
+            "bash",
+            str(ROOT / "scripts/deploy/_lib.sh"),
+            member,
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=ROOT,
+        check=False,
+    )
+
+    assert run.returncode == 0
+    assert "conditional:roles/run.invoker" in run.stderr
+
+
+def _run_runtime_service_account_policy_contract(
+    tmp_path: Path,
+    policy: dict[str, object],
+    *,
+    phase: str = "post",
+    operator_members: str = "",
+) -> subprocess.CompletedProcess[str]:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_gcloud = fake_bin / "gcloud"
+    fake_gcloud.write_text(
+        "#!/usr/bin/env bash\n"
+        "if [[ \"$*\" == *\"projects describe\"* ]]; then\n"
+        "  printf '123456789\\n'\n"
+        "else\n"
+        "  printf 'unexpected gcloud call: %s\\n' \"$*\" >&2\n"
+        "  exit 2\n"
+        "fi\n"
+    )
+    fake_gcloud.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "HOME": str(tmp_path),
+        "RUNTIME_POLICY": json.dumps(policy, separators=(",", ":")),
+        "POLICY_PHASE": phase,
+        "TR_RUNTIME_SERVICE_ACCOUNT_OPERATOR_MEMBERS": operator_members,
+    }
+    return subprocess.run(  # noqa: S603 - fixed shell and repo-local helper
+        [
+            "/bin/bash",
+            "-c",
+            'source "$1"; printf "%s" "$RUNTIME_POLICY" | '
+            "verify_runtime_service_account_policy_json "
+            '"$PUBLIC_RUN_SERVICE_ACCOUNT" "$POLICY_PHASE"',
+            "bash",
+            str(ROOT / "scripts/deploy/_lib.sh"),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=ROOT,
+        check=False,
+    )
+
+
+def test_runtime_service_account_policy_allows_deploy_and_explicit_operator(
+    tmp_path: Path,
+) -> None:
+    deploy = "serviceAccount:tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com"
+    operator = "user:operator@example.com"
+    run = _run_runtime_service_account_policy_contract(
+        tmp_path,
+        {
+            "bindings": [
+                {"role": "roles/iam.serviceAccountUser", "members": [deploy]},
+                {"role": "roles/iam.serviceAccountUser", "members": [operator]},
+            ]
+        },
+        operator_members=operator,
+    )
+
+    assert run.returncode == 0, run.stderr
+
+
+@pytest.mark.parametrize(
+    "role",
+    (
+        "roles/iam.serviceAccountUser",
+        "roles/iam.serviceAccountTokenCreator",
+        "roles/viewer",
+    ),
+)
+def test_runtime_service_account_policy_rejects_every_cross_runtime_role(
+    tmp_path: Path,
+    role: str,
+) -> None:
+    deploy = "serviceAccount:tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com"
+    other_runtime = (
+        "serviceAccount:tr-actions@quill-cloud-proxy.iam.gserviceaccount.com"
+    )
+    run = _run_runtime_service_account_policy_contract(
+        tmp_path,
+        {
+            "bindings": [
+                {"role": "roles/iam.serviceAccountUser", "members": [deploy]},
+                {"role": role, "members": [other_runtime]},
+            ]
+        },
+    )
+
+    assert run.returncode != 0
+    assert "split runtime principal" in run.stderr
+
+
+@pytest.mark.parametrize(
+    ("binding", "operator_members", "error_fragment"),
+    (
+        (
+            {
+                "role": "roles/iam.serviceAccountUser",
+                "members": [
+                    "serviceAccount:tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com"
+                ],
+                "condition": {"title": "temporary", "expression": "true"},
+            },
+            "",
+            "deploy principal bindings",
+        ),
+        (
+            {
+                "role": "roles/iam.serviceAccountTokenCreator",
+                "members": [
+                    "serviceAccount:tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com"
+                ],
+            },
+            "",
+            "deploy principal bindings",
+        ),
+        (
+            {
+                "role": "roles/iam.serviceAccountUser",
+                "members": ["user:unlisted@example.com"],
+            },
+            "",
+            "unapproved principal",
+        ),
+        (
+            {
+                "role": "roles/iam.serviceAccountTokenCreator",
+                "members": ["user:operator@example.com"],
+            },
+            "user:operator@example.com",
+            "must have only unconditional serviceAccountUser",
+        ),
+    ),
+    ids=(
+        "conditional-deploy",
+        "deploy-token-creator",
+        "unknown-principal",
+        "operator-token-creator",
+    ),
+)
+def test_runtime_service_account_policy_rejects_noncanonical_direct_bindings(
+    tmp_path: Path,
+    binding: dict[str, object],
+    operator_members: str,
+    error_fragment: str,
+) -> None:
+    deploy = "serviceAccount:tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com"
+    bindings: list[dict[str, object]] = []
+    if deploy not in binding.get("members", []):
+        bindings.append(
+            {"role": "roles/iam.serviceAccountUser", "members": [deploy]}
+        )
+    bindings.append(binding)
+    run = _run_runtime_service_account_policy_contract(
+        tmp_path,
+        {"bindings": bindings},
+        operator_members=operator_members,
+    )
+
+    assert run.returncode != 0
+    assert error_fragment in run.stderr
+
+
+def test_runtime_policy_contract_is_mutation_sensitive_to_cross_runtime_drift(
+    tmp_path: Path,
+) -> None:
+    deploy = "serviceAccount:tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com"
+    valid = {"bindings": [{"role": "roles/iam.serviceAccountUser", "members": [deploy]}]}
+    mutated = json.loads(json.dumps(valid))
+    mutated["bindings"].append(
+        {
+            "role": "roles/iam.serviceAccountUser",
+            "members": [
+                "serviceAccount:tr-chat@quill-cloud-proxy.iam.gserviceaccount.com"
+            ],
+        }
+    )
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_gcloud = fake_bin / "gcloud"
+    fake_gcloud.write_text(
+        "#!/usr/bin/env bash\n"
+        "printf '123456789\\n'\n"
+    )
+    fake_gcloud.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "HOME": str(tmp_path),
+        "VALID_POLICY": json.dumps(valid, separators=(",", ":")),
+        "MUTATED_POLICY": json.dumps(mutated, separators=(",", ":")),
+    }
+    run = subprocess.run(  # noqa: S603 - fixed shell and repo-local helper
+        [
+            "/bin/bash",
+            "-c",
+            'source "$1"; '
+            'printf "%s" "$VALID_POLICY" | '
+            'verify_runtime_service_account_policy_json "$PUBLIC_RUN_SERVICE_ACCOUNT" post; '
+            'if printf "%s" "$MUTATED_POLICY" | '
+            'verify_runtime_service_account_policy_json "$PUBLIC_RUN_SERVICE_ACCOUNT" post; '
+            "then exit 91; fi",
+            "bash",
+            str(ROOT / "scripts/deploy/_lib.sh"),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=ROOT,
+        check=False,
+    )
+
+    assert run.returncode == 0
+    assert "split runtime principal" in run.stderr
+
+
+def test_runtime_policy_shared_contract_is_used_by_infra_pre_and_post_audits() -> None:
+    helper = _function_body(
+        LIB,
+        "verify_runtime_service_account_policy_json",
+        "validate_runtime_service_accounts",
+    )
+    assert "roles/iam.serviceAccountTokenCreator" not in helper
+    assert "split runtime principal" in helper
+    assert "unapproved principal" in helper
+    assert "operator" in helper
+    audit_start = INFRA.index("verify_deploy_actas_inventory() {")
+    audit_end = INFRA.index('\n}\n\nlog "enabling required GCP APIs"', audit_start)
+    audit = INFRA[audit_start:audit_end]
+    assert "verify_runtime_service_account_policy_json" in audit
+    assert '"$service_account" "$phase"' in audit

--- a/tests/test_infra_synthetic_retirement.py
+++ b/tests/test_infra_synthetic_retirement.py
@@ -1,0 +1,614 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+INFRA = (ROOT / "scripts/deploy/infra.sh").read_text(encoding="utf-8")
+LIB = (ROOT / "scripts/deploy/_lib.sh").read_text(encoding="utf-8")
+PROJECT_ID = "quill-cloud-proxy"
+LEGACY_IDENTITY = "123456789-compute@developer.gserviceaccount.com"
+SYNTHETIC_IDENTITY = f"tr-synthetic@{PROJECT_ID}.iam.gserviceaccount.com"
+INTERNAL_IDENTITY = f"tr-internal@{PROJECT_ID}.iam.gserviceaccount.com"
+DEPLOY_IDENTITY = f"tr-deploy@{PROJECT_ID}.iam.gserviceaccount.com"
+
+CANONICAL_JOBS = (
+    (
+        "us-central1",
+        "trusted-router-synthetic-us-central1",
+        "trusted-router-synthetic-us-central1-every-three-minutes",
+    ),
+    (
+        "europe-west1",
+        "trusted-router-throughput-europe-west1",
+        "trusted-router-throughput-europe-west1-every-five-minutes",
+    ),
+    (
+        "asia-northeast1",
+        "trusted-router-image-generation-asia-northeast1",
+        "trusted-router-image-generation-asia-northeast1-every-six-hours",
+    ),
+    (
+        "us-east1",
+        "trusted-router-video-generation-us-east1",
+        "trusted-router-video-generation-us-east1-daily",
+    ),
+)
+
+
+def _function_body(source: str, name: str, next_name: str) -> str:
+    start = source.index(f"{name}() {{")
+    end = source.index(f"{next_name}() {{", start)
+    return source[start:end]
+
+
+RETIREMENT_HELPERS = "\n".join(
+    (
+        _function_body(
+            INFRA,
+            "verify_identity_resource_manager_ancestors_empty",
+            "verify_synthetic_retirement_identity_ready",
+        ),
+        _function_body(
+            INFRA,
+            "verify_synthetic_retirement_identity_ready",
+            "verify_legacy_synthetic_secret_access_ready",
+        ),
+        _function_body(
+            INFRA,
+            "verify_legacy_synthetic_secret_access_ready",
+            "synthetic_job_inventory_lines",
+        ),
+        _function_body(
+            INFRA,
+            "synthetic_job_inventory_lines",
+            "cloud_run_inventory_lines",
+        ),
+        _function_body(
+            INFRA,
+            "cloud_run_inventory_lines",
+            "cloud_run_job_service_account",
+        ),
+        _function_body(
+            INFRA,
+            "cloud_run_job_service_account",
+            "verify_legacy_cloud_run_service_inventory",
+        ),
+        _function_body(
+            INFRA,
+            "verify_legacy_synthetic_jobs_ready",
+            "describe_iam_role_definition",
+        ),
+    )
+)
+
+FAKE_GCLOUD = r'''#!/usr/bin/env python3
+import json
+import os
+import sys
+
+args = sys.argv[1:]
+
+
+def option(name):
+    prefix = name + "="
+    for index, value in enumerate(args):
+        if value.startswith(prefix):
+            return value[len(prefix):]
+        if value == name and index + 1 < len(args):
+            return args[index + 1]
+    return ""
+
+
+def emit(value):
+    print(json.dumps(value, separators=(",", ":")))
+    raise SystemExit(0)
+
+
+if args[:3] == ["iam", "service-accounts", "describe"]:
+    emit(json.loads(os.environ["FAKE_ACCOUNT_JSON"]))
+if args[:3] == ["iam", "service-accounts", "get-iam-policy"]:
+    emit(json.loads(os.environ["FAKE_ACCOUNT_POLICY"]))
+if args[:2] == ["projects", "get-ancestors"]:
+    emit(json.loads(os.environ["FAKE_ANCESTORS"]))
+if args[:3] == ["resource-manager", "folders", "get-iam-policy"]:
+    emit(json.loads(os.environ["FAKE_FOLDER_POLICY"]))
+if args[:2] == ["organizations", "get-iam-policy"]:
+    emit(json.loads(os.environ["FAKE_ORGANIZATION_POLICY"]))
+if args[:3] == ["run", "jobs", "list"]:
+    emit(json.loads(os.environ["FAKE_JOB_INVENTORY"]))
+if args[:3] == ["run", "jobs", "describe"]:
+    key = option("--region") + "/" + args[3]
+    identities = json.loads(os.environ["FAKE_JOB_IDENTITIES"])
+    if key not in identities:
+        raise SystemExit(3)
+    emit(
+        {
+            "spec": {
+                "template": {
+                    "template": {"serviceAccount": identities[key]}
+                }
+            }
+        }
+    )
+if args[:3] == ["run", "jobs", "get-iam-policy"]:
+    emit(json.loads(os.environ["FAKE_JOB_POLICY"]))
+if args[:3] == ["scheduler", "jobs", "describe"]:
+    region = option("--location")
+    scheduler_name = args[3]
+    scheduler_identities = json.loads(os.environ["FAKE_SCHEDULER_IDENTITIES"])
+    key = region + "/" + scheduler_name
+    if key not in scheduler_identities:
+        raise SystemExit(3)
+    job_name = scheduler_name.rsplit("-every-", 1)[0]
+    if scheduler_name.endswith("-daily"):
+        job_name = scheduler_name[:-len("-daily")]
+    uri = (
+        f"https://{region}-run.googleapis.com/apis/run.googleapis.com/v1/"
+        f"namespaces/{os.environ['FAKE_PROJECT_ID']}/jobs/{job_name}:run"
+    )
+    emit(
+        {
+            "state": "ENABLED",
+            "httpTarget": {
+                "uri": uri,
+                "httpMethod": "POST",
+                "oauthToken": {
+                    "serviceAccountEmail": scheduler_identities[key]
+                },
+            },
+        }
+    )
+if args[:2] == ["secrets", "list"]:
+    emit(json.loads(os.environ["FAKE_SECRET_INVENTORY"]))
+if args[:2] == ["secrets", "get-iam-policy"]:
+    policies = json.loads(os.environ["FAKE_SECRET_POLICIES"])
+    if args[2] not in policies:
+        raise SystemExit(3)
+    emit(policies[args[2]])
+if "get-iam-policy" in args:
+    emit(json.loads(os.environ["FAKE_RESOURCE_POLICY"]))
+
+print("unexpected fake gc invocation: " + " ".join(args), file=sys.stderr)
+raise SystemExit(2)
+'''
+
+SHELL_HARNESS = r'''
+gc() {
+  "$FAKE_GCLOUD" "$@"
+}
+
+verify_exact_unconditional_roles() {
+  local label="$1"
+  local member="$2"
+  local expected="$3"
+  local policy
+  local actual
+  shift 3
+  policy="$("$@")" || return 1
+  actual="$(printf '%s' "$policy" | python3 -c '
+import json
+import sys
+
+policy = json.load(sys.stdin)
+member = sys.argv[1]
+tokens = []
+for binding in policy.get("bindings") or []:
+    if member not in (binding.get("members") or []):
+        continue
+    prefix = "conditional:" if binding.get("condition") is not None else ""
+    tokens.append(prefix + str(binding.get("role") or ""))
+print("\n".join(sorted(tokens)))
+' "$member")" || return 1
+  if [ "$actual" != "$expected" ]; then
+    echo "ERROR: ${label} roles are ${actual}, expected ${expected}" >&2
+    return 1
+  fi
+}
+
+verify_all_synthetic_retirement_contracts() {
+  verify_synthetic_retirement_identity_ready || return 1
+  verify_legacy_synthetic_secret_access_ready || return 1
+  verify_legacy_synthetic_jobs_ready
+}
+'''
+
+
+def _valid_secret_policy() -> dict[str, object]:
+    return {
+        "bindings": [
+            {
+                "role": "roles/secretmanager.secretAccessor",
+                "members": [
+                    f"serviceAccount:{INTERNAL_IDENTITY}",
+                    f"serviceAccount:{SYNTHETIC_IDENTITY}",
+                ],
+            }
+        ]
+    }
+
+
+def _base_state() -> dict[str, str]:
+    inventory = [
+        {
+            "metadata": {
+                "name": job_name,
+                "labels": {"cloud.googleapis.com/location": region},
+            }
+        }
+        for region, job_name, _ in CANONICAL_JOBS
+    ]
+    job_identities = {
+        f"{region}/{job_name}": SYNTHETIC_IDENTITY
+        for region, job_name, _ in CANONICAL_JOBS
+    }
+    scheduler_identities = {
+        f"{region}/{scheduler_name}": SYNTHETIC_IDENTITY
+        for region, _, scheduler_name in CANONICAL_JOBS
+    }
+    return {
+        "FAKE_ACCOUNT_JSON": json.dumps(
+            {"email": SYNTHETIC_IDENTITY, "disabled": False}
+        ),
+        "FAKE_ACCOUNT_POLICY": json.dumps(
+            {
+                "bindings": [
+                    {
+                        "role": "roles/iam.serviceAccountUser",
+                        "members": [f"serviceAccount:{DEPLOY_IDENTITY}"],
+                    }
+                ]
+            }
+        ),
+        "FAKE_ANCESTORS": json.dumps(
+            [
+                {"type": "project", "id": PROJECT_ID},
+                {"type": "folder", "id": "456789"},
+                {"type": "organization", "id": "987654"},
+            ]
+        ),
+        "FAKE_FOLDER_POLICY": json.dumps({"bindings": []}),
+        "FAKE_ORGANIZATION_POLICY": json.dumps({"bindings": []}),
+        "FAKE_JOB_INVENTORY": json.dumps(inventory),
+        "FAKE_JOB_IDENTITIES": json.dumps(job_identities),
+        "FAKE_JOB_POLICY": json.dumps(
+            {
+                "bindings": [
+                    {
+                        "role": "roles/run.invoker",
+                        "members": [f"serviceAccount:{SYNTHETIC_IDENTITY}"],
+                    }
+                ]
+            }
+        ),
+        "FAKE_SCHEDULER_IDENTITIES": json.dumps(scheduler_identities),
+        "FAKE_SECRET_INVENTORY": json.dumps(
+            [
+                {"name": "trustedrouter-observer-internal-token"},
+                {"name": "trustedrouter-synthetic-monitor-api-key"},
+                {"name": "owner-managed-existing-secret"},
+            ]
+        ),
+        "FAKE_SECRET_POLICIES": json.dumps(
+            {
+                "trustedrouter-observer-internal-token": _valid_secret_policy(),
+                "trustedrouter-synthetic-monitor-api-key": _valid_secret_policy(),
+                "owner-managed-existing-secret": {
+                    "bindings": [
+                        {
+                            "role": "roles/secretmanager.viewer",
+                            "members": ["group:unrelated-owners@example.com"],
+                        }
+                    ]
+                },
+            }
+        ),
+        "FAKE_RESOURCE_POLICY": json.dumps({"bindings": []}),
+    }
+
+
+def _run_retirement_helper(
+    tmp_path: Path,
+    function_name: str,
+    *,
+    state_updates: dict[str, str] | None = None,
+    synthetic_identity: str = SYNTHETIC_IDENTITY,
+) -> subprocess.CompletedProcess[str]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    fake_gcloud = tmp_path / "fake-gc"
+    fake_gcloud.write_text(FAKE_GCLOUD, encoding="utf-8")
+    fake_gcloud.chmod(0o755)
+    helpers = tmp_path / "retirement-helpers.sh"
+    helpers.write_text(RETIREMENT_HELPERS + SHELL_HARNESS, encoding="utf-8")
+
+    env = {
+        **os.environ,
+        **_base_state(),
+        "FAKE_GCLOUD": str(fake_gcloud),
+        "FAKE_PROJECT_ID": PROJECT_ID,
+        "PROJECT_ID": PROJECT_ID,
+        "PROJECT_NUMBER": "123456789",
+        "RUN_SERVICE_ACCOUNT": LEGACY_IDENTITY,
+        "SYNTHETIC_RUN_SERVICE_ACCOUNT": synthetic_identity,
+        "INTERNAL_RUN_SERVICE_ACCOUNT": INTERNAL_IDENTITY,
+        "DEPLOY_SERVICE_ACCOUNT": DEPLOY_IDENTITY,
+        "SPANNER_INSTANCE_ID": "trusted-router",
+        "SPANNER_DATABASE_ID": "trusted-router",
+        "BIGTABLE_INSTANCE_ID": "trusted-router",
+        "BIGTABLE_GENERATION_TABLE": "generations",
+        "KMS_KEYRING_ID": "trusted-router",
+        "BYOK_KMS_KEY_ID": "byok",
+        "GOOGLE_ADS_KMS_KEY_ID": "google-ads",
+        "REGION": "us-central1",
+        "TR_SYNTHETIC_MONITOR_REGIONS": "us-central1",
+        "TR_SYNTHETIC_THROUGHPUT_REGION": "europe-west1",
+        "TR_SYNTHETIC_IMAGE_REGION": "asia-northeast1",
+        "TR_SYNTHETIC_VIDEO_REGION": "us-east1",
+    }
+    env.update(state_updates or {})
+    return subprocess.run(  # noqa: S603 - fixed shell and test-owned helper
+        [
+            "/bin/bash",
+            "-c",
+            'set -uo pipefail; source "$1"; "$2"',
+            "bash",
+            str(helpers),
+            function_name,
+        ],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_legacy_retirement_requires_a_separate_canonical_synthetic_identity() -> None:
+    assert (
+        'SYNTHETIC_RUN_SERVICE_ACCOUNT="${TR_SYNTHETIC_RUN_SERVICE_ACCOUNT:-'
+        'tr-synthetic@${PROJECT_ID}.iam.gserviceaccount.com}"' in LIB
+    )
+    assert (
+        'ensure_runtime_service_account "$SYNTHETIC_RUN_SERVICE_ACCOUNT" '
+        '"TrustedRouter synthetic jobs"' in INFRA
+    )
+    assert "verify_synthetic_service_account_policy preflight" in INFRA
+    assert "verify_synthetic_service_account_policy post" in INFRA
+    assert INFRA.count("verify_synthetic_data_iam_empty") >= 3
+    preflight_section = INFRA.index(
+        'log "preflighting all runtime IAM removal targets and direct ancestor policies"'
+    )
+    preflight = INFRA.index(
+        "  verify_synthetic_retirement_identity_ready", preflight_section
+    )
+    first_legacy_removal = INFRA.index(
+        'remove_project_role_if_present "$member" "roles/secretmanager.secretAccessor"',
+        INFRA.index(
+            'if [ "$TR_RETIRE_LEGACY_RUN_SERVICE_ACCOUNT_IAM" = "1" ]; then',
+            INFRA.index('log "removing broad legacy'),
+        ),
+    )
+    assert preflight < first_legacy_removal
+    jobs = _function_body(
+        INFRA,
+        "verify_legacy_synthetic_jobs_ready",
+        "describe_iam_role_definition",
+    )
+    assert 'local member="serviceAccount:${SYNTHETIC_RUN_SERVICE_ACCOUNT}"' in jobs
+    assert 'if [ "$identity" = "$RUN_SERVICE_ACCOUNT" ]' in jobs
+    assert '"$SYNTHETIC_RUN_SERVICE_ACCOUNT" \\' in jobs
+
+
+def test_synthetic_retirement_contract_accepts_only_the_narrow_migrated_state(
+    tmp_path: Path,
+) -> None:
+    run = _run_retirement_helper(
+        tmp_path, "verify_all_synthetic_retirement_contracts"
+    )
+
+    assert run.returncode == 0, run.stderr
+
+
+@pytest.mark.parametrize("canonical_index", range(len(CANONICAL_JOBS)))
+def test_each_canonical_job_still_using_legacy_blocks_retirement(
+    tmp_path: Path,
+    canonical_index: int,
+) -> None:
+    region, job_name, _ = CANONICAL_JOBS[canonical_index]
+    identities = json.loads(_base_state()["FAKE_JOB_IDENTITIES"])
+    identities[f"{region}/{job_name}"] = LEGACY_IDENTITY
+
+    run = _run_retirement_helper(
+        tmp_path,
+        "verify_legacy_synthetic_jobs_ready",
+        state_updates={"FAKE_JOB_IDENTITIES": json.dumps(identities)},
+    )
+
+    assert run.returncode != 0
+    assert "still uses legacy identity" in run.stderr
+
+
+def test_unaccounted_job_using_legacy_also_blocks_retirement(tmp_path: Path) -> None:
+    state = _base_state()
+    inventory = json.loads(state["FAKE_JOB_INVENTORY"])
+    inventory.append(
+        {
+            "metadata": {
+                "name": "forgotten-synthetic",
+                "labels": {"cloud.googleapis.com/location": "australia-southeast1"},
+            }
+        }
+    )
+    identities = json.loads(state["FAKE_JOB_IDENTITIES"])
+    identities["australia-southeast1/forgotten-synthetic"] = LEGACY_IDENTITY
+
+    run = _run_retirement_helper(
+        tmp_path,
+        "verify_legacy_synthetic_jobs_ready",
+        state_updates={
+            "FAKE_JOB_INVENTORY": json.dumps(inventory),
+            "FAKE_JOB_IDENTITIES": json.dumps(identities),
+        },
+    )
+
+    assert run.returncode != 0
+    assert "forgotten-synthetic still uses legacy identity" in run.stderr
+
+
+def test_canonical_scheduler_using_legacy_blocks_retirement(tmp_path: Path) -> None:
+    region, _, scheduler_name = CANONICAL_JOBS[0]
+    schedulers = json.loads(_base_state()["FAKE_SCHEDULER_IDENTITIES"])
+    schedulers[f"{region}/{scheduler_name}"] = LEGACY_IDENTITY
+
+    run = _run_retirement_helper(
+        tmp_path,
+        "verify_legacy_synthetic_jobs_ready",
+        state_updates={"FAKE_SCHEDULER_IDENTITIES": json.dumps(schedulers)},
+    )
+
+    assert run.returncode != 0
+    assert "canonical synthetic scheduler" in run.stderr
+    assert "is unsafe" in run.stderr
+
+
+def test_legacy_job_invoker_binding_blocks_retirement(tmp_path: Path) -> None:
+    policy = {
+        "bindings": [
+            {
+                "role": "roles/run.invoker",
+                "members": [
+                    f"serviceAccount:{SYNTHETIC_IDENTITY}",
+                    f"serviceAccount:{LEGACY_IDENTITY}",
+                ],
+            }
+        ]
+    }
+
+    run = _run_retirement_helper(
+        tmp_path,
+        "verify_legacy_synthetic_jobs_ready",
+        state_updates={"FAKE_JOB_POLICY": json.dumps(policy)},
+    )
+
+    assert run.returncode != 0
+    assert "must have only the dedicated synthetic invoker" in run.stderr
+
+
+def test_legacy_secret_consumer_blocks_retirement(tmp_path: Path) -> None:
+    policy = _valid_secret_policy()
+    members = policy["bindings"][0]["members"]  # type: ignore[index]
+    assert isinstance(members, list)
+    members[1] = f"serviceAccount:{LEGACY_IDENTITY}"
+    policies = json.loads(_base_state()["FAKE_SECRET_POLICIES"])
+    policies["trustedrouter-observer-internal-token"] = policy
+
+    run = _run_retirement_helper(
+        tmp_path,
+        "verify_legacy_synthetic_secret_access_ready",
+        state_updates={"FAKE_SECRET_POLICIES": json.dumps(policies)},
+    )
+
+    assert run.returncode != 0
+    assert "exactly the internal and dedicated synthetic consumers" in run.stderr
+
+
+def test_unknown_secret_with_synthetic_accessor_blocks_retirement(
+    tmp_path: Path,
+) -> None:
+    inventory = json.loads(_base_state()["FAKE_SECRET_INVENTORY"])
+    inventory.append({"name": "owner-managed-future-secret"})
+    policies = json.loads(_base_state()["FAKE_SECRET_POLICIES"])
+    policies["owner-managed-future-secret"] = {
+        "bindings": [
+            {
+                "role": "roles/secretmanager.secretAccessor",
+                "members": [f"serviceAccount:{SYNTHETIC_IDENTITY}"],
+            },
+            {
+                "role": "roles/secretmanager.viewer",
+                "members": ["group:unrelated-owners@example.com"],
+            },
+        ]
+    }
+
+    run = _run_retirement_helper(
+        tmp_path,
+        "verify_legacy_synthetic_secret_access_ready",
+        state_updates={
+            "FAKE_SECRET_INVENTORY": json.dumps(inventory),
+            "FAKE_SECRET_POLICIES": json.dumps(policies),
+        },
+    )
+
+    assert run.returncode != 0
+    assert "non-synthetic secret owner-managed-future-secret roles are" in run.stderr
+    assert "roles/secretmanager.secretAccessor" in run.stderr
+
+
+def test_unapproved_or_broad_synthetic_identity_blocks_retirement(
+    tmp_path: Path,
+) -> None:
+    unapproved = _run_retirement_helper(
+        tmp_path / "unapproved",
+        "verify_synthetic_retirement_identity_ready",
+        synthetic_identity=f"custom-monitor@{PROJECT_ID}.iam.gserviceaccount.com",
+    )
+    assert unapproved.returncode != 0
+    assert "canonical dedicated synthetic identity" in unapproved.stderr
+
+    broad_policy = {
+        "bindings": [
+            {
+                "role": "roles/editor",
+                "members": [f"serviceAccount:{SYNTHETIC_IDENTITY}"],
+            }
+        ]
+    }
+    broad = _run_retirement_helper(
+        tmp_path / "broad",
+        "verify_synthetic_retirement_identity_ready",
+        state_updates={"FAKE_RESOURCE_POLICY": json.dumps(broad_policy)},
+    )
+    assert broad.returncode != 0
+    assert "synthetic identity project roles are roles/editor" in broad.stderr
+
+
+@pytest.mark.parametrize(
+    ("policy_variable", "error_fragment"),
+    (
+        (
+            "FAKE_FOLDER_POLICY",
+            "synthetic identity inherited folder 456789 roles are roles/editor",
+        ),
+        (
+            "FAKE_ORGANIZATION_POLICY",
+            "synthetic identity inherited organization 987654 roles are roles/editor",
+        ),
+    ),
+)
+def test_direct_folder_or_organization_binding_blocks_retirement(
+    tmp_path: Path,
+    policy_variable: str,
+    error_fragment: str,
+) -> None:
+    ancestor_policy = {
+        "bindings": [
+            {
+                "role": "roles/editor",
+                "members": [f"serviceAccount:{SYNTHETIC_IDENTITY}"],
+            }
+        ]
+    }
+
+    run = _run_retirement_helper(
+        tmp_path,
+        "verify_synthetic_retirement_identity_ready",
+        state_updates={policy_variable: json.dumps(ancestor_policy)},
+    )
+
+    assert run.returncode != 0
+    assert error_fragment in run.stderr

--- a/tests/test_rollout_iam_verify.py
+++ b/tests/test_rollout_iam_verify.py
@@ -1,0 +1,1152 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFIER = ROOT / "scripts/deploy/rollout_iam_verify.sh"
+PROJECT = "quill-cloud-proxy"
+SURFACES = ("public", "actions", "console", "chat", "webhooks", "internal")
+SERVICES = {
+    "public": "trusted-router-public",
+    "actions": "trusted-router-actions",
+    "console": "trusted-router-console",
+    "chat": "trusted-router-chat",
+    "webhooks": "trusted-router-webhooks",
+    "internal": "trusted-router-billing",
+}
+
+
+def _account(surface: str) -> str:
+    return f"tr-{surface}@{PROJECT}.iam.gserviceaccount.com"
+
+
+def _member(surface: str) -> str:
+    return f"serviceAccount:{_account(surface)}"
+
+
+def _synthetic_member() -> str:
+    return f"serviceAccount:tr-synthetic@{PROJECT}.iam.gserviceaccount.com"
+
+
+def _binding(
+    role: str,
+    surfaces: tuple[str, ...],
+    *,
+    condition: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    value: dict[str, Any] = {
+        "role": role,
+        "members": [_member(surface) for surface in surfaces],
+    }
+    if condition is not None:
+        value["condition"] = condition
+    return value
+
+
+def _policy(*bindings: dict[str, Any]) -> dict[str, Any]:
+    return {"bindings": list(bindings)}
+
+
+def _candidate(surface: str) -> str:
+    return f"{SERVICES[surface]}-iamverify"
+
+
+def _revision(surface: str) -> dict[str, Any]:
+    env: list[dict[str, Any]] = []
+    if surface in {"public", "console"}:
+        env.append(
+            {
+                "name": "TR_ATTRIBUTION_COOKIE_SECRET",
+                "valueFrom": {
+                    "secretKeyRef": {
+                        "name": "trustedrouter-attribution-cookie-secret",
+                        "key": "7",
+                    }
+                },
+            }
+        )
+    return {
+        "metadata": {"name": _candidate(surface)},
+        "spec": {
+            "serviceAccountName": _account(surface),
+            "containers": [{"env": env}],
+        },
+    }
+
+
+def _valid_state() -> dict[str, Any]:
+    deploy_member = f"serviceAccount:tr-deploy@{PROJECT}.iam.gserviceaccount.com"
+    return {
+        "policies": {
+            "project": _policy(
+                _binding(
+                    "roles/serviceusage.serviceUsageConsumer",
+                    ("public", "console", "chat", "webhooks", "internal"),
+                )
+            ),
+            "spanner_instance": _policy(),
+            "spanner_database": _policy(
+                _binding("roles/spanner.databaseReader", ("public", "chat")),
+                _binding(
+                    "roles/spanner.databaseUser",
+                    ("console", "webhooks", "internal"),
+                ),
+            ),
+            "bigtable_instance": _policy(
+                _binding("roles/bigtable.reader", ("public", "console")),
+                _binding("roles/bigtable.user", ("internal",)),
+            ),
+            "bigtable_table": _policy(),
+            "keyring": _policy(),
+            "byok": _policy(
+                _binding(
+                    "roles/cloudkms.cryptoKeyEncrypterDecrypter", ("console",)
+                ),
+                _binding("roles/cloudkms.cryptoKeyDecrypter", ("internal",)),
+            ),
+            "ads": _policy(
+                _binding("roles/cloudkms.cryptoKeyEncrypter", ("console",))
+            ),
+            "folder": _policy(),
+            "organization": _policy(),
+        },
+        "service_account_policies": {
+            _account(surface): _policy(
+                {
+                    "role": "roles/iam.serviceAccountUser",
+                    "members": [deploy_member],
+                }
+            )
+            for surface in SURFACES
+        }
+        | {
+            f"tr-synthetic@{PROJECT}.iam.gserviceaccount.com": _policy(
+                {
+                    "role": "roles/iam.serviceAccountUser",
+                    "members": [deploy_member],
+                }
+            ),
+            f"unrelated-build@{PROJECT}.iam.gserviceaccount.com": _policy(),
+        },
+        "inventories": {
+            "spanner_instances": ["trusted-router-nam6"],
+            "spanner_databases": {"trusted-router-nam6": ["trusted-router"]},
+            "bigtable_instances": ["trusted-router-logs"],
+            "bigtable_tables": {
+                "trusted-router-logs": ["trustedrouter-generations"]
+            },
+            "kms_locations": ["us-central1"],
+            "kms_keyrings": {"us-central1": ["trusted-router"]},
+            "kms_keys": {
+                "us-central1/trusted-router": [
+                    "byok-envelope",
+                    "google-ads-click-envelope",
+                ]
+            },
+            "service_accounts": [
+                *[_account(surface) for surface in SURFACES],
+                f"tr-synthetic@{PROJECT}.iam.gserviceaccount.com",
+                f"unrelated-build@{PROJECT}.iam.gserviceaccount.com",
+            ],
+        },
+        "inventory_policies": {},
+        "secrets": {
+            "trustedrouter-attribution-cookie-secret": _policy(
+                _binding(
+                    "roles/secretmanager.secretAccessor", ("public", "console")
+                )
+            ),
+            "unrelated-build-secret": _policy(),
+        },
+        "versions": {
+            "trustedrouter-attribution-cookie-secret|7": "ENABLED",
+        },
+        "revisions": {
+            _candidate(surface): _revision(surface) for surface in SURFACES
+        },
+        "roles": {},
+        "bucket_metadata": {
+            "name": "trusted-router-rollout-recovery",
+            "iamConfiguration": {
+                "uniformBucketLevelAccess": {"enabled": True},
+                "publicAccessPrevention": "enforced",
+            },
+            "versioning": {"enabled": True},
+            "retentionPolicy": {"retentionPeriod": "604800"},
+        },
+        "bucket_policy": _policy(),
+    }
+
+
+def _write_manifest(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "project_id": PROJECT,
+                "regions": ["us-central1"],
+                "internal_regions": ["us-central1"],
+                "services": [
+                    {
+                        "surface": surface,
+                        "name": SERVICES[surface],
+                        "region": "us-central1",
+                        "candidate_revision": _candidate(surface),
+                        "runtime_service_account": _account(surface),
+                    }
+                    for surface in SURFACES
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+FAKE_GCLOUD = r'''#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+state = json.loads(Path(os.environ["FAKE_GCLOUD_STATE"]).read_text(encoding="utf-8"))
+events = Path(os.environ["FAKE_GCLOUD_EVENTS"])
+args = sys.argv[1:]
+if args[:1] == ["--project"]:
+    if len(args) < 2 or args[1] != "quill-cloud-proxy":
+        raise SystemExit(81)
+    args = args[2:]
+with events.open("a", encoding="utf-8") as output:
+    output.write("gcloud " + " ".join(args) + "\n")
+
+mutating = {
+    "add-iam-policy-binding", "remove-iam-policy-binding", "set-iam-policy",
+    "create", "delete", "deploy", "import", "update", "update-traffic",
+}
+if any(item in mutating for item in args):
+    print("mutation rejected", file=sys.stderr)
+    raise SystemExit(90)
+
+def option(name):
+    for index, value in enumerate(args):
+        if value.startswith(name + "="):
+            return value.split("=", 1)[1]
+        if value == name and index + 1 < len(args):
+            return args[index + 1]
+    return None
+
+def finish(value):
+    if isinstance(value, str):
+        print(value)
+    else:
+        print(json.dumps(value, separators=(",", ":")))
+    raise SystemExit(0)
+
+def inventory_policy(key, fallback=None):
+    if key in state["inventory_policies"]:
+        return state["inventory_policies"][key]
+    return {"bindings": []} if fallback is None else fallback
+
+if args[:2] == ["projects", "describe"]:
+    finish("123456789")
+if args[:2] == ["projects", "get-iam-policy"]:
+    finish(state["policies"]["project"])
+if args[:2] == ["projects", "get-ancestors"]:
+    finish([
+        {"type": "project", "id": "quill-cloud-proxy"},
+        {"type": "folder", "id": "1234"},
+        {"type": "organization", "id": "5678"},
+    ])
+if args[:3] == ["resource-manager", "folders", "get-iam-policy"]:
+    finish(state["policies"]["folder"])
+if args[:2] == ["organizations", "get-iam-policy"]:
+    finish(state["policies"]["organization"])
+if args[:3] == ["spanner", "instances", "list"]:
+    finish([
+        {"name": f"projects/quill-cloud-proxy/instances/{name}"}
+        for name in state["inventories"]["spanner_instances"]
+    ])
+if args[:3] == ["spanner", "instances", "get-iam-policy"]:
+    name = args[3]
+    fallback = state["policies"]["spanner_instance"] if name == "trusted-router-nam6" else None
+    finish(inventory_policy(f"spanner_instance|{name}", fallback))
+if args[:3] == ["spanner", "databases", "list"]:
+    instance = option("--instance")
+    finish([
+        {"name": f"projects/quill-cloud-proxy/instances/{instance}/databases/{name}"}
+        for name in state["inventories"]["spanner_databases"].get(instance, [])
+    ])
+if args[:3] == ["spanner", "databases", "get-iam-policy"]:
+    name = args[3]
+    instance = option("--instance")
+    fallback = (
+        state["policies"]["spanner_database"]
+        if instance == "trusted-router-nam6" and name == "trusted-router"
+        else None
+    )
+    finish(inventory_policy(f"spanner_database|{instance}|{name}", fallback))
+if args[:3] == ["bigtable", "instances", "list"]:
+    finish([
+        {"name": f"projects/quill-cloud-proxy/instances/{name}"}
+        for name in state["inventories"]["bigtable_instances"]
+    ])
+if args[:3] == ["bigtable", "instances", "get-iam-policy"]:
+    name = args[3]
+    fallback = state["policies"]["bigtable_instance"] if name == "trusted-router-logs" else None
+    finish(inventory_policy(f"bigtable_instance|{name}", fallback))
+if args[:3] == ["bigtable", "tables", "list"]:
+    instance = option("--instances")
+    finish([
+        {"name": f"projects/quill-cloud-proxy/instances/{instance}/tables/{name}"}
+        for name in state["inventories"]["bigtable_tables"].get(instance, [])
+    ])
+if args[:3] == ["bigtable", "tables", "get-iam-policy"]:
+    name = args[3]
+    instance = option("--instance")
+    fallback = (
+        state["policies"]["bigtable_table"]
+        if instance == "trusted-router-logs" and name == "trustedrouter-generations"
+        else None
+    )
+    finish(inventory_policy(f"bigtable_table|{instance}|{name}", fallback))
+if args[:3] == ["kms", "locations", "list"]:
+    finish([{"locationId": name} for name in state["inventories"]["kms_locations"]])
+if args[:3] == ["kms", "keyrings", "list"]:
+    location = option("--location")
+    finish([
+        {
+            "name": (
+                f"projects/quill-cloud-proxy/locations/{location}/keyRings/{name}"
+            )
+        }
+        for name in state["inventories"]["kms_keyrings"].get(location, [])
+    ])
+if args[:3] == ["kms", "keyrings", "get-iam-policy"]:
+    name = args[3]
+    location = option("--location")
+    fallback = (
+        state["policies"]["keyring"]
+        if location == "us-central1" and name == "trusted-router"
+        else None
+    )
+    finish(inventory_policy(f"kms_keyring|{location}|{name}", fallback))
+if args[:3] == ["kms", "keys", "list"]:
+    location = option("--location")
+    keyring = option("--keyring")
+    finish([
+        {
+            "name": (
+                f"projects/quill-cloud-proxy/locations/{location}/keyRings/"
+                f"{keyring}/cryptoKeys/{name}"
+            )
+        }
+        for name in state["inventories"]["kms_keys"].get(f"{location}/{keyring}", [])
+    ])
+if args[:3] == ["kms", "keys", "get-iam-policy"]:
+    name = args[3]
+    location = option("--location")
+    keyring = option("--keyring")
+    fallback = None
+    if location == "us-central1" and keyring == "trusted-router":
+        if name == "byok-envelope":
+            fallback = state["policies"]["byok"]
+        elif name == "google-ads-click-envelope":
+            fallback = state["policies"]["ads"]
+    finish(inventory_policy(f"kms_key|{location}|{keyring}|{name}", fallback))
+if args[:3] == ["iam", "service-accounts", "list"]:
+    finish([
+        {
+            "name": f"projects/quill-cloud-proxy/serviceAccounts/{100000000000000000000 + index}",
+            "email": email,
+            "uniqueId": str(100000000000000000000 + index),
+        }
+        for index, email in enumerate(state["inventories"]["service_accounts"])
+    ])
+if args[:3] == ["iam", "service-accounts", "describe"]:
+    finish({"email": args[3], "disabled": False})
+if args[:3] == ["iam", "service-accounts", "get-iam-policy"]:
+    finish(state["service_account_policies"][args[3]])
+if args[:3] == ["iam", "roles", "describe"]:
+    role = args[3]
+    if role not in state["roles"]:
+        matches = [value for name, value in state["roles"].items() if name.endswith("/roles/" + role)]
+        if len(matches) != 1:
+            raise SystemExit(83)
+        finish(matches[0])
+    finish(state["roles"][role])
+if args[:3] == ["storage", "buckets", "get-iam-policy"]:
+    finish(state["bucket_policy"])
+if args[:3] == ["storage", "buckets", "describe"]:
+    finish(state["bucket_metadata"])
+if args[:2] == ["secrets", "list"]:
+    finish([
+        {"name": f"projects/quill-cloud-proxy/secrets/{name}"}
+        for name in state["secrets"]
+    ])
+if args[:2] == ["secrets", "get-iam-policy"]:
+    finish(state["secrets"][args[2]])
+if args[:3] == ["secrets", "versions", "describe"]:
+    secret = option("--secret")
+    version = args[3]
+    finish({
+        "name": f"projects/quill-cloud-proxy/secrets/{secret}/versions/{version}",
+        "state": state["versions"].get(f"{secret}|{version}", "MISSING"),
+    })
+if args[:3] == ["run", "revisions", "describe"]:
+    finish(state["revisions"][args[3]])
+
+print("unexpected fake gcloud command", file=sys.stderr)
+raise SystemExit(82)
+'''
+
+
+def _run(
+    tmp_path: Path,
+    state: dict[str, Any],
+    *,
+    with_manifest: bool = True,
+    extra_env: dict[str, str] | None = None,
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake = fake_bin / "gcloud"
+    fake.write_text(FAKE_GCLOUD, encoding="utf-8")
+    fake.chmod(0o755)
+    state_path = tmp_path / "state.json"
+    original_state = json.dumps(state, sort_keys=True)
+    state_path.write_text(original_state, encoding="utf-8")
+    events_path = tmp_path / "events.log"
+    events_path.write_text("", encoding="utf-8")
+    command = [str(VERIFIER), "--project", PROJECT]
+    if with_manifest:
+        manifest_path = tmp_path / "manifest.json"
+        _write_manifest(manifest_path)
+        command.extend(("--manifest", str(manifest_path)))
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "HOME": str(tmp_path),
+        "FAKE_GCLOUD_STATE": str(state_path),
+        "FAKE_GCLOUD_EVENTS": str(events_path),
+        "REGION": "us-central1",
+    }
+    env.pop("TR_ROLLOUT_STATE_GCS_URI", None)
+    env.pop("TR_ROLLOUT_STATE_GCS_ROLE", None)
+    env.pop("TR_ROLLOUT_REQUIRE_RECOVERY_BUNDLE", None)
+    env.pop("TR_ROLLOUT_RECOVERY_GCS_PREFIX", None)
+    env.pop("TR_ROLLOUT_RECOVERY_GCS_ROLE", None)
+    env.pop("TR_ROLLOUT_BUNDLE_GCS_URI", None)
+    env.pop("TR_ROLLOUT_AUTHORITY_GCS_URI", None)
+    env.update(extra_env or {})
+    run = subprocess.run(  # noqa: S603 - repo-local script and isolated fake PATH
+        command,
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert state_path.read_text(encoding="utf-8") == original_state
+    events = events_path.read_text(encoding="utf-8").splitlines()
+    forbidden = (
+        " add-iam-policy-binding",
+        " remove-iam-policy-binding",
+        " set-iam-policy",
+        " create ",
+        " delete ",
+        " deploy ",
+        " import ",
+        " update ",
+        " update-traffic",
+    )
+    assert all(not any(token in event for token in forbidden) for event in events)
+    return run, events
+
+
+RECOVERY_BUCKET = "trusted-router-rollout-recovery"
+RECOVERY_EPOCH = "manifest-20260821T120000Z-deadbeef"
+RECOVERY_ROLE = f"projects/{PROJECT}/roles/trustedRouterRolloutRecovery"
+
+
+def _recovery_env() -> dict[str, str]:
+    prefix = f"gs://{RECOVERY_BUCKET}/trusted-router-rollouts/{PROJECT}"
+    bundle = f"{prefix}/releases/{RECOVERY_EPOCH}"
+    return {
+        "TR_ROLLOUT_REQUIRE_RECOVERY_BUNDLE": "true",
+        "TR_ROLLOUT_RECOVERY_GCS_PREFIX": prefix,
+        "TR_ROLLOUT_RECOVERY_GCS_ROLE": RECOVERY_ROLE,
+        "TR_ROLLOUT_BUNDLE_GCS_URI": bundle,
+        "TR_ROLLOUT_AUTHORITY_GCS_URI": f"{prefix}/authority.json",
+        "TR_ROLLOUT_STATE_GCS_URI": f"{bundle}/promotion-state.json",
+        "TR_ROLLOUT_STATE_GCS_ROLE": RECOVERY_ROLE,
+    }
+
+
+def _state_with_exact_recovery() -> dict[str, Any]:
+    state = _valid_state()
+    state["roles"][RECOVERY_ROLE] = {
+        "name": RECOVERY_ROLE,
+        "deleted": False,
+        "includedPermissions": [
+            "storage.objects.create",
+            "storage.objects.delete",
+            "storage.objects.get",
+        ],
+    }
+    authority_resource = (
+        f"projects/_/buckets/{RECOVERY_BUCKET}/objects/"
+        f"trusted-router-rollouts/{PROJECT}/authority.json"
+    )
+    bundle_resource_prefix = (
+        f"projects/_/buckets/{RECOVERY_BUCKET}/objects/"
+        f"trusted-router-rollouts/{PROJECT}/releases/{RECOVERY_EPOCH}/"
+    )
+    state["bucket_policy"] = _policy(
+        {
+            "role": RECOVERY_ROLE,
+            "members": [
+                f"serviceAccount:tr-deploy@{PROJECT}.iam.gserviceaccount.com"
+            ],
+            "condition": {
+                "title": "trusted-router-rollout-recovery",
+                "expression": (
+                    f'resource.name == "{authority_resource}" || '
+                    f'resource.name.startsWith("{bundle_resource_prefix}")'
+                ),
+            },
+        }
+    )
+    return state
+
+
+def test_happy_manifest_audits_every_scope_candidate_and_pinned_version(
+    tmp_path: Path,
+) -> None:
+    run, events = _run(tmp_path, _valid_state())
+
+    assert run.returncode == 0, run.stderr
+    assert run.stdout.strip() == "six-surface rollout IAM verification passed"
+    joined = "\n".join(events)
+    for command in (
+        "projects get-iam-policy",
+        "projects get-ancestors",
+        "resource-manager folders get-iam-policy",
+        "organizations get-iam-policy",
+        "spanner instances get-iam-policy",
+        "spanner databases get-iam-policy",
+        "bigtable instances get-iam-policy",
+        "bigtable tables get-iam-policy",
+        "kms keyrings get-iam-policy",
+        "kms keys get-iam-policy",
+        "iam service-accounts get-iam-policy",
+        "secrets list",
+        "secrets get-iam-policy",
+        "run revisions describe",
+        "secrets versions describe 7",
+    ):
+        assert command in joined
+    assert joined.count("run revisions describe") == 6
+
+
+def test_stage_mode_never_reads_candidate_revisions_or_secret_versions(
+    tmp_path: Path,
+) -> None:
+    run, events = _run(tmp_path, _valid_state(), with_manifest=False)
+
+    assert run.returncode == 0, run.stderr
+    assert not any("run revisions describe" in event for event in events)
+    assert not any("secrets versions describe" in event for event in events)
+
+
+@pytest.mark.parametrize(
+    ("target", "principal"),
+    (
+        ("spanner_instance", "runtime"),
+        ("spanner_database", "synthetic"),
+        ("bigtable_instance", "synthetic"),
+        ("bigtable_table", "runtime"),
+        ("kms_keyring", "runtime"),
+        ("kms_key", "synthetic"),
+        ("service_account", "runtime"),
+    ),
+)
+def test_full_project_inventory_rejects_grant_on_any_other_resource(
+    tmp_path: Path,
+    target: str,
+    principal: str,
+) -> None:
+    state = _valid_state()
+    member = _member("public") if principal == "runtime" else _synthetic_member()
+    binding = {"role": "roles/viewer", "members": [member]}
+
+    if target == "spanner_instance":
+        state["inventories"]["spanner_instances"].append("archive-spanner")
+        state["inventories"]["spanner_databases"]["archive-spanner"] = []
+        state["inventory_policies"]["spanner_instance|archive-spanner"] = _policy(
+            binding
+        )
+    elif target == "spanner_database":
+        state["inventories"]["spanner_databases"]["trusted-router-nam6"].append(
+            "archive-database"
+        )
+        state["inventory_policies"][
+            "spanner_database|trusted-router-nam6|archive-database"
+        ] = _policy(binding)
+    elif target == "bigtable_instance":
+        state["inventories"]["bigtable_instances"].append("archive-bigtable")
+        state["inventories"]["bigtable_tables"]["archive-bigtable"] = []
+        state["inventory_policies"]["bigtable_instance|archive-bigtable"] = _policy(
+            binding
+        )
+    elif target == "bigtable_table":
+        state["inventories"]["bigtable_tables"]["trusted-router-logs"].append(
+            "archive-table"
+        )
+        state["inventory_policies"][
+            "bigtable_table|trusted-router-logs|archive-table"
+        ] = _policy(binding)
+    elif target == "kms_keyring":
+        state["inventories"]["kms_keyrings"]["us-central1"].append(
+            "archive-keyring"
+        )
+        state["inventories"]["kms_keys"]["us-central1/archive-keyring"] = []
+        state["inventory_policies"][
+            "kms_keyring|us-central1|archive-keyring"
+        ] = _policy(binding)
+    elif target == "kms_key":
+        state["inventories"]["kms_keys"]["us-central1/trusted-router"].append(
+            "archive-key"
+        )
+        state["inventory_policies"][
+            "kms_key|us-central1|trusted-router|archive-key"
+        ] = _policy(binding)
+    else:
+        email = f"legacy-runtime@{PROJECT}.iam.gserviceaccount.com"
+        state["inventories"]["service_accounts"].append(email)
+        state["service_account_policies"][email] = _policy(
+            {
+                "role": "roles/iam.serviceAccountTokenCreator",
+                "members": [member],
+            }
+        )
+
+    run, events = _run(tmp_path, state, with_manifest=False)
+
+    assert run.returncode != 0
+    assert "unsafe six-runtime IAM" in run.stderr
+    assert any(" list " in f" {event} " for event in events)
+
+
+@pytest.mark.parametrize(
+    "inventory",
+    (
+        "spanner_instances",
+        "spanner_databases",
+        "bigtable_instances",
+        "bigtable_tables",
+        "kms_locations",
+        "kms_keyrings",
+        "kms_keys",
+        "service_accounts",
+    ),
+)
+def test_full_project_inventory_requires_every_canonical_resource(
+    tmp_path: Path,
+    inventory: str,
+) -> None:
+    state = _valid_state()
+    values = state["inventories"][inventory]
+    if isinstance(values, list):
+        values.clear()
+    else:
+        for resources in values.values():
+            resources.clear()
+
+    run, _ = _run(tmp_path, state, with_manifest=False)
+
+    assert run.returncode != 0
+    assert "absent from the project inventory" in run.stderr
+
+
+def test_unknown_secret_with_direct_runtime_grant_is_rejected(tmp_path: Path) -> None:
+    state = _valid_state()
+    state["secrets"]["unrelated-build-secret"] = _policy(
+        _binding("roles/secretmanager.secretAccessor", ("public",))
+    )
+
+    run, _ = _run(tmp_path, state)
+
+    assert run.returncode != 0
+    assert "unsafe exact accessor IAM" in run.stderr
+    assert "unrelated-build-secret" not in run.stdout + run.stderr
+
+
+def test_unknown_secret_with_direct_synthetic_grant_is_rejected(tmp_path: Path) -> None:
+    state = _valid_state()
+    state["secrets"]["unrelated-build-secret"] = _policy(
+        {
+            "role": "roles/secretmanager.secretAccessor",
+            "members": [_synthetic_member()],
+        }
+    )
+
+    run, _ = _run(tmp_path, state)
+
+    assert run.returncode != 0
+    assert "unsafe exact accessor IAM" in run.stderr
+    assert "unrelated-build-secret" not in run.stdout + run.stderr
+
+
+def test_observer_secret_requires_exact_internal_and_synthetic_owners(
+    tmp_path: Path,
+) -> None:
+    state = _valid_state()
+    state["secrets"]["trustedrouter-observer-internal-token"] = _policy(
+        {
+            "role": "roles/secretmanager.secretAccessor",
+            "members": [_member("internal"), _synthetic_member()],
+        }
+    )
+
+    run, _ = _run(tmp_path, state, with_manifest=False)
+
+    assert run.returncode == 0, run.stderr
+
+
+@pytest.mark.parametrize(
+    "target",
+    (
+        "project",
+        "spanner_instance",
+        "spanner_database",
+        "bigtable_instance",
+        "bigtable_table",
+        "keyring",
+        "byok",
+        "ads",
+        "folder",
+        "organization",
+    ),
+)
+def test_synthetic_identity_has_no_data_or_ancestor_role(
+    tmp_path: Path,
+    target: str,
+) -> None:
+    state = _valid_state()
+    state["policies"][target]["bindings"].append(
+        {
+            "role": "roles/viewer",
+            "members": [_synthetic_member()],
+        }
+    )
+
+    run, _ = _run(tmp_path, state, with_manifest=False)
+
+    assert run.returncode != 0
+    assert "unsafe six-runtime IAM" in run.stderr
+
+
+def test_synthetic_identity_cannot_impersonate_runtime_account(tmp_path: Path) -> None:
+    state = _valid_state()
+    state["service_account_policies"][_account("internal")]["bindings"].append(
+        {
+            "role": "roles/iam.serviceAccountTokenCreator",
+            "members": [_synthetic_member()],
+        }
+    )
+
+    run, _ = _run(tmp_path, state, with_manifest=False)
+
+    assert run.returncode != 0
+    assert "runtime service account has unsafe direct IAM" in run.stderr
+
+
+def test_known_secret_rejects_non_owner_accessor_principal(tmp_path: Path) -> None:
+    state = _valid_state()
+    state["secrets"]["trustedrouter-attribution-cookie-secret"]["bindings"].append(
+        {
+            "role": "roles/secretmanager.secretAccessor",
+            "members": ["serviceAccount:unrelated-build@quill-cloud-proxy.iam.gserviceaccount.com"],
+        }
+    )
+
+    run, _ = _run(tmp_path, state)
+
+    assert run.returncode != 0
+    assert "unsafe exact accessor IAM" in run.stderr
+
+
+@pytest.mark.parametrize(
+    "target",
+    ("project", "spanner_database", "runtime_account", "secret"),
+)
+def test_public_principal_is_rejected_on_every_policy_class(
+    tmp_path: Path,
+    target: str,
+) -> None:
+    state = _valid_state()
+    binding = {"role": "roles/viewer", "members": ["allUsers"]}
+    if target == "runtime_account":
+        state["service_account_policies"][_account("public")]["bindings"].append(
+            binding
+        )
+    elif target == "secret":
+        state["secrets"]["unrelated-build-secret"]["bindings"].append(
+            {
+                "role": "roles/secretmanager.secretAccessor",
+                "members": ["allAuthenticatedUsers"],
+            }
+        )
+    else:
+        state["policies"][target]["bindings"].append(binding)
+
+    run, _ = _run(tmp_path, state)
+
+    assert run.returncode != 0
+    assert "public or malformed IAM policy" in run.stderr
+
+
+@pytest.mark.parametrize("parent", ("spanner_instance", "folder"))
+def test_parent_scope_runtime_role_is_rejected(tmp_path: Path, parent: str) -> None:
+    state = _valid_state()
+    state["policies"][parent] = _policy(
+        _binding("roles/viewer", ("public",))
+    )
+
+    run, _ = _run(tmp_path, state)
+
+    assert run.returncode != 0
+    assert "IAM matrix drift" in run.stderr
+
+
+def test_cross_runtime_service_account_binding_is_rejected(tmp_path: Path) -> None:
+    state = _valid_state()
+    state["service_account_policies"][_account("public")]["bindings"].append(
+        {
+            "role": "roles/iam.serviceAccountTokenCreator",
+            "members": [_member("chat")],
+        }
+    )
+
+    run, _ = _run(tmp_path, state)
+
+    assert run.returncode != 0
+    assert "split runtime principal" in run.stderr
+
+
+@pytest.mark.parametrize("drift", ("conditional", "extra"))
+def test_conditional_or_extra_deploy_binding_is_rejected(
+    tmp_path: Path,
+    drift: str,
+) -> None:
+    state = _valid_state()
+    bindings = state["service_account_policies"][_account("public")]["bindings"]
+    if drift == "conditional":
+        bindings[0]["condition"] = {
+            "title": "temporary",
+            "expression": "request.time < timestamp('2030-01-01T00:00:00Z')",
+        }
+    else:
+        bindings.append(
+            {
+                "role": "roles/iam.serviceAccountTokenCreator",
+                "members": [f"serviceAccount:tr-deploy@{PROJECT}.iam.gserviceaccount.com"],
+            }
+        )
+
+    run, _ = _run(tmp_path, state)
+
+    assert run.returncode != 0
+    assert "deploy principal" in run.stderr
+
+
+@pytest.mark.parametrize("drift", ("disabled", "latest"))
+def test_disabled_or_latest_mounted_secret_version_is_rejected(
+    tmp_path: Path,
+    drift: str,
+) -> None:
+    state = _valid_state()
+    if drift == "disabled":
+        state["versions"]["trustedrouter-attribution-cookie-secret|7"] = "DISABLED"
+    else:
+        reference = state["revisions"][_candidate("public")]["spec"]["containers"][0][
+            "env"
+        ][0]["valueFrom"]["secretKeyRef"]
+        reference["key"] = "latest"
+
+    run, _ = _run(tmp_path, state)
+
+    assert run.returncode != 0
+    assert "secret" in run.stderr.lower()
+    assert "trustedrouter-attribution-cookie-secret" not in run.stdout + run.stderr
+
+
+@pytest.mark.parametrize(
+    "permission",
+    (
+        "storage.objects.get",
+        "storage.objects.getIamPolicy",
+        "secretmanager.versions.access",
+        "cloudkms.cryptoKeyVersions.useToDecrypt",
+        "iam.serviceAccounts.actAs",
+    ),
+)
+def test_project_broad_data_or_impersonation_permission_on_deploy_is_rejected(
+    tmp_path: Path,
+    permission: str,
+) -> None:
+    state = _valid_state()
+    deploy_member = f"serviceAccount:tr-deploy@{PROJECT}.iam.gserviceaccount.com"
+    state["policies"]["project"]["bindings"].append(
+        {"role": "roles/storage.objectAdmin", "members": [deploy_member]}
+    )
+    state["roles"]["roles/storage.objectAdmin"] = {
+        "name": "roles/storage.objectAdmin",
+        "includedPermissions": [permission],
+    }
+
+    run, events = _run(tmp_path, state)
+
+    assert run.returncode != 0
+    assert "broad data or impersonation permission at project" in run.stderr
+    assert any(
+        "iam roles describe roles/storage.objectAdmin" in event for event in events
+    )
+
+
+def test_exact_object_scoped_rollout_journal_role_and_bucket_binding_are_allowed(
+    tmp_path: Path,
+) -> None:
+    state = _valid_state()
+    role = f"projects/{PROJECT}/roles/trustedRouterRolloutJournal"
+    uri = "gs://trusted-router-rollout-state/releases/state.json"
+    deploy_member = f"serviceAccount:tr-deploy@{PROJECT}.iam.gserviceaccount.com"
+    state["roles"][role] = {
+        "name": role,
+        "deleted": False,
+        "includedPermissions": [
+            "storage.objects.get",
+            "storage.objects.create",
+            "storage.objects.delete",
+        ],
+    }
+    state["bucket_policy"] = _policy(
+        {
+            "role": role,
+            "members": [deploy_member],
+            "condition": {
+                "title": "trusted-router-rollout-journal",
+                "description": "forward-only rollout recovery journal",
+                "expression": (
+                    'resource.name == "projects/_/buckets/'
+                    'trusted-router-rollout-state/objects/releases/state.json"'
+                ),
+            },
+        }
+    )
+
+    run, events = _run(
+        tmp_path,
+        state,
+        extra_env={
+            "TR_ROLLOUT_STATE_GCS_URI": uri,
+            "TR_ROLLOUT_STATE_GCS_ROLE": role,
+        },
+    )
+
+    assert run.returncode == 0, run.stderr
+    assert any("storage buckets get-iam-policy" in event for event in events)
+    assert any(
+        "iam roles describe trustedRouterRolloutJournal" in event for event in events
+    )
+
+
+def test_rollout_journal_bucket_condition_drift_is_rejected(tmp_path: Path) -> None:
+    state = _valid_state()
+    role = f"projects/{PROJECT}/roles/trustedRouterRolloutJournal"
+    state["roles"][role] = {
+        "name": role,
+        "includedPermissions": [
+            "storage.objects.get",
+            "storage.objects.create",
+            "storage.objects.delete",
+        ],
+    }
+    state["bucket_policy"] = _policy(
+        {
+            "role": role,
+            "members": [
+                f"serviceAccount:tr-deploy@{PROJECT}.iam.gserviceaccount.com"
+            ],
+            "condition": {
+                "title": "trusted-router-rollout-journal",
+                "expression": (
+                    'resource.name.startsWith("projects/_/buckets/'
+                    'trusted-router-rollout-state/objects/")'
+                ),
+            },
+        }
+    )
+
+    run, _ = _run(
+        tmp_path,
+        state,
+        extra_env={
+            "TR_ROLLOUT_STATE_GCS_URI": (
+                "gs://trusted-router-rollout-state/releases/state.json"
+            ),
+            "TR_ROLLOUT_STATE_GCS_ROLE": role,
+        },
+    )
+
+    assert run.returncode != 0
+    assert "exact object-scoped binding" in run.stderr
+
+
+def test_recovery_bundle_iam_is_read_only_and_exactly_object_scoped(
+    tmp_path: Path,
+) -> None:
+    run, events = _run(
+        tmp_path,
+        _state_with_exact_recovery(),
+        extra_env=_recovery_env(),
+    )
+
+    assert run.returncode == 0, run.stderr
+    joined = "\n".join(events)
+    assert "storage buckets describe" in joined
+    assert "storage buckets get-iam-policy" in joined
+    assert "iam roles describe trustedRouterRolloutRecovery" in joined
+
+
+def test_recovery_bundle_uses_recovery_role_without_legacy_state_role(
+    tmp_path: Path,
+) -> None:
+    env = _recovery_env()
+    env.pop("TR_ROLLOUT_STATE_GCS_ROLE")
+
+    run, _ = _run(
+        tmp_path,
+        _state_with_exact_recovery(),
+        extra_env=env,
+    )
+
+    assert run.returncode == 0, run.stderr
+
+
+def test_recovery_bundle_rejects_broad_project_prefix_binding(tmp_path: Path) -> None:
+    state = _state_with_exact_recovery()
+    state["bucket_policy"]["bindings"][0]["condition"]["expression"] = (
+        'resource.name.startsWith("projects/_/buckets/'
+        f'{RECOVERY_BUCKET}/objects/trusted-router-rollouts/{PROJECT}/")'
+    )
+
+    run, _ = _run(tmp_path, state, extra_env=_recovery_env())
+
+    assert run.returncode != 0
+    assert "exact authority-and-bundle binding" in run.stderr
+
+
+@pytest.mark.parametrize("principal", ("allUsers", "group:unknown@example.com"))
+def test_recovery_bundle_rejects_public_and_unknown_principals(
+    tmp_path: Path,
+    principal: str,
+) -> None:
+    state = _state_with_exact_recovery()
+    state["bucket_policy"]["bindings"].append(
+        {"role": "roles/storage.objectViewer", "members": [principal]}
+    )
+
+    run, _ = _run(tmp_path, state, extra_env=_recovery_env())
+
+    assert run.returncode != 0
+    if principal == "allUsers":
+        assert "public or malformed IAM policy" in run.stderr
+    else:
+        assert "exact authority-and-bundle binding" in run.stderr
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("uniform", False),
+        ("public_prevention", "inherited"),
+        ("versioning", False),
+        ("retention", "604799"),
+    ),
+)
+def test_recovery_bundle_rejects_weakened_bucket_protection(
+    tmp_path: Path,
+    field: str,
+    value: object,
+) -> None:
+    state = _state_with_exact_recovery()
+    metadata = state["bucket_metadata"]
+    if field == "uniform":
+        metadata["iamConfiguration"]["uniformBucketLevelAccess"]["enabled"] = value
+    elif field == "public_prevention":
+        metadata["iamConfiguration"]["publicAccessPrevention"] = value
+    elif field == "versioning":
+        metadata["versioning"]["enabled"] = value
+    else:
+        metadata["retentionPolicy"]["retentionPeriod"] = value
+
+    run, _ = _run(tmp_path, state, extra_env=_recovery_env())
+
+    assert run.returncode != 0
+    assert "bucket protection contract drifted" in run.stderr
+
+
+def test_recovery_bundle_rejects_role_permission_expansion(tmp_path: Path) -> None:
+    state = _state_with_exact_recovery()
+    state["roles"][RECOVERY_ROLE]["includedPermissions"].append(
+        "storage.objects.list"
+    )
+
+    run, _ = _run(tmp_path, state, extra_env=_recovery_env())
+
+    assert run.returncode != 0
+    assert "exact three-permission role" in run.stderr
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    (
+        (
+            "TR_ROLLOUT_AUTHORITY_GCS_URI",
+            f"gs://{RECOVERY_BUCKET}/trusted-router-rollouts/{PROJECT}/other.json",
+        ),
+        (
+            "TR_ROLLOUT_BUNDLE_GCS_URI",
+            f"gs://{RECOVERY_BUCKET}/trusted-router-rollouts/{PROJECT}/releases/short",
+        ),
+        (
+            "TR_ROLLOUT_STATE_GCS_URI",
+            f"gs://{RECOVERY_BUCKET}/trusted-router-rollouts/{PROJECT}/promotion-state.json",
+        ),
+        (
+            "TR_ROLLOUT_STATE_GCS_ROLE",
+            f"projects/{PROJECT}/roles/aDifferentRolloutRole",
+        ),
+    ),
+)
+def test_recovery_bundle_rejects_noncanonical_authority_bundle_state_or_role(
+    tmp_path: Path,
+    name: str,
+    value: str,
+) -> None:
+    env = _recovery_env()
+    env[name] = value
+
+    run, events = _run(
+        tmp_path,
+        _state_with_exact_recovery(),
+        extra_env=env,
+    )
+
+    assert run.returncode != 0
+    assert not any("storage buckets" in event for event in events)


### PR DESCRIPTION
Six-surface split, part 3/4: exact edge and runtime IAM contracts. Authored by codex; reviewed, rebased, and gated by Fable. Base: `fable/six-surface-app-oauth`.

- **Cloud Armor as a reviewed artifact**: per-surface security policies (host-deny + per-source ceilings enforced; two route-shaped throttles in preview) are rendered and imported as full-policy replacements — a rule added by hand in the console does not survive reconciliation, and the verifier rejects supersets.
- **Runtime IAM as an exact contract**: six runtime service accounts with per-secret accessor grants and per-role storage grants; the read-only verifier (`rollout_iam_verify.sh`) fails closed on any grant on an unconfigured resource, cross-service-account impersonation, or direct folder/org bindings.
- Per-resource SecretAccessor owner matrix replaces blanket deploy-account access.

Gate: covered by the stack-tip full suite (see PR 4); all 64 IAM-verify tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
