### PR TITLE
Attribute deploy billing errors to candidate revision

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -494,7 +494,9 @@ jobs:
         run: |
           set -euo pipefail
           if ! bash scripts/deploy/assert_no_billing_5xx.sh \
-              us-central1 "${{ steps.deploy_us.outputs.started_at }}"; then
+              us-central1 \
+              "${{ steps.deploy_us.outputs.started_at }}" \
+              "${{ steps.new_us.outputs.revision }}"; then
             echo "us-central1 emitted billing-path 5xx; rolling back to ${PREV_US}"
             gcloud run services update-traffic "${SERVICE}" \
               --region=us-central1 --project="${PROJECT_ID}" \
@@ -596,7 +598,7 @@ jobs:
             fi
 
             if ! bash scripts/deploy/assert_no_billing_5xx.sh \
-                "${region}" "${rollout_started_at}"; then
+                "${region}" "${rollout_started_at}" "${revision}"; then
               rollback_region "${region}"
               return 1
             fi

--- a/scripts/deploy/assert_no_billing_5xx.sh
+++ b/scripts/deploy/assert_no_billing_5xx.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
-# Fail a rollout when its region emitted a billing-path 5xx after the supplied
-# timestamp. Cloud Run readiness alone cannot detect exhausted Spanner retries.
+# Fail a rollout when its candidate revision emitted a billing-path 5xx after
+# the supplied timestamp. Cloud Run readiness cannot detect exhausted retries.
 set -euo pipefail
 
-REGION="${1:?usage: assert_no_billing_5xx.sh REGION SINCE_TIMESTAMP}"
-SINCE="${2:?usage: assert_no_billing_5xx.sh REGION SINCE_TIMESTAMP}"
+REGION="${1:?usage: assert_no_billing_5xx.sh REGION SINCE_TIMESTAMP REVISION}"
+SINCE="${2:?usage: assert_no_billing_5xx.sh REGION SINCE_TIMESTAMP REVISION}"
+REVISION="${3:?usage: assert_no_billing_5xx.sh REGION SINCE_TIMESTAMP REVISION}"
 PROJECT_ID="${PROJECT_ID:-quill-cloud-proxy}"
 SERVICE="${SERVICE:-trusted-router}"
 
@@ -19,6 +20,7 @@ sleep "${TR_BILLING_5XX_LOG_GRACE_SECONDS:-20}"
 query="resource.type=\"cloud_run_revision\"
 resource.labels.service_name=\"${SERVICE}\"
 resource.labels.location=\"${REGION}\"
+resource.labels.revision_name=\"${REVISION}\"
 timestamp>=\"${SINCE}\"
 httpRequest.status>=500
 httpRequest.requestUrl:\"/internal/gateway/\""
@@ -30,8 +32,8 @@ failure="$(gcloud logging read "${query}" \
   --format='value(timestamp,httpRequest.requestUrl,httpRequest.status,httpRequest.latency)')"
 
 if [ -n "${failure}" ]; then
-  echo "billing-path 5xx detected in ${REGION} after ${SINCE}: ${failure}"
+  echo "billing-path 5xx detected in ${REGION} revision ${REVISION} after ${SINCE}: ${failure}"
   exit 1
 fi
 
-echo "billing-path 5xx gate passed for ${REGION}"
+echo "billing-path 5xx gate passed for ${REGION} revision ${REVISION}"

--- a/tests/test_deploy_workflow_regions.py
+++ b/tests/test_deploy_workflow_regions.py
@@ -95,7 +95,19 @@ def test_primary_rollout_gates_on_router_core_and_billing_path_errors() -> None:
     assert "--slo-class router_core" in rollout
     assert "- name: Billing-path gate + rollback (us-central1)" in rollout
     assert "scripts/deploy/assert_no_billing_5xx.sh" in rollout
+    assert '"${{ steps.new_us.outputs.revision }}"' in rollout
     assert '--to-revisions="${PREV_US}=100"' in rollout
+
+
+def test_billing_path_gate_only_attributes_errors_to_candidate_revision() -> None:
+    workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
+    script = (ROOT / "scripts/deploy/assert_no_billing_5xx.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'REVISION="${3:?usage:' in script
+    assert 'resource.labels.revision_name=\\"${REVISION}\\"' in script
+    assert '"${region}" "${rollout_started_at}" "${revision}"' in workflow
 
 
 def test_superseded_push_stops_before_production_mutation() -> None:


### PR DESCRIPTION
## Root cause
Two Europe rollouts were rolled back because the billing gate queried every revision in the region. In both cases the single settlement 500 came from the old revision receiving staged traffic; the candidate revisions emitted zero billing-path 5xxs.

## Fix
- require the candidate Cloud Run revision in the billing gate
- filter Cloud Logging by that exact revision
- pass the resolved primary and secondary revision through the workflow
- retain rollback on any candidate-revision billing 5xx

## Verification
- candidate-revision log audit: 0 billing-path 5xxs across both failed canaries
- deploy workflow region tests: 10 passed
- shell syntax and Ruff pass