### PR TITLE
Fix regional quota settlement and reconciliation races

### DIFF
--- a/scripts/deploy/regional_quota_ledger.sh
+++ b/scripts/deploy/regional_quota_ledger.sh
@@ -43,7 +43,18 @@ for entry in "${entries[@]}"; do
   profiles+=("${region}=${profile}")
   if gcloud bigtable app-profiles describe "$profile" \
     --project="$PROJECT" --instance="$INSTANCE" >/dev/null 2>&1; then
-    log "app profile $profile exists"
+    profile_config="$(
+      gcloud bigtable app-profiles describe "$profile" \
+        --project="$PROJECT" \
+        --instance="$INSTANCE" \
+        --format='value(singleClusterRouting.clusterId,singleClusterRouting.allowTransactionalWrites)'
+    )"
+    read -r actual_cluster transactional_writes <<<"$profile_config"
+    if [ "$actual_cluster" != "$cluster" ] || [ "$transactional_writes" != "True" ]; then
+      log "refusing regional quota profile drift: ${profile} must route only to ${cluster} with transactional writes"
+      exit 1
+    fi
+    log "app profile $profile is transactionally pinned to $cluster"
   else
     log "creating transactional single-cluster profile $profile -> $cluster"
     gcloud bigtable app-profiles create "$profile" \

--- a/scripts/deploy/regional_quota_reconciler.sh
+++ b/scripts/deploy/regional_quota_reconciler.sh
@@ -16,6 +16,11 @@ RELEASE="$(git rev-parse --short HEAD 2>/dev/null || echo local)"
 JOB_PREFIX="${TR_REGIONAL_QUOTA_RECONCILER_JOB_PREFIX:-trusted-router-regional-quota-reconciler}"
 JOB_NAME="${TR_REGIONAL_QUOTA_RECONCILER_JOB:-${JOB_PREFIX}-${RELEASE}}"
 RECONCILE_LIMIT="${TR_REGIONAL_QUOTA_RECONCILE_LIMIT:-25}"
+scheduler_state="$(
+  gc scheduler jobs describe "$SCHEDULER_NAME" \
+    --location="$SCHEDULER_REGION" \
+    --format='value(state)' 2>/dev/null || true
+)"
 
 if ! gc artifacts docker images describe "$IMAGE" >/dev/null 2>&1; then
   log "refusing regional quota reconciler deploy: image ${IMAGE} does not exist"
@@ -64,13 +69,20 @@ gc run jobs add-iam-policy-binding "$JOB_NAME" \
   --role="roles/run.invoker" \
   --quiet >/dev/null
 
-# Verify the versioned job before changing the stable scheduler. A failed
-# deployment therefore leaves the previous known-good job scheduled.
-log "verifying regional quota reconciliation job"
-gc run jobs execute "$JOB_NAME" \
-  --region "$JOB_REGION" \
-  --wait \
-  --quiet >/dev/null
+# Verify the versioned job before changing the stable scheduler. An operator
+# containment pause forbids even this one-shot mutation; the repair run is
+# executed manually after review instead.
+verification_complete=false
+if [ "$scheduler_state" = "PAUSED" ]; then
+  log "skipping automatic reconciler execution while containment pause is active"
+else
+  log "verifying regional quota reconciliation job"
+  gc run jobs execute "$JOB_NAME" \
+    --region "$JOB_REGION" \
+    --wait \
+    --quiet >/dev/null
+  verification_complete=true
+fi
 
 uri="https://${JOB_REGION}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${PROJECT_ID}/jobs/${JOB_NAME}:run"
 common_args=(
@@ -87,8 +99,7 @@ common_args=(
   --quiet
 )
 
-if gc scheduler jobs describe "$SCHEDULER_NAME" \
-  --location="$SCHEDULER_REGION" >/dev/null 2>&1; then
+if [ -n "$scheduler_state" ]; then
   log "updating regional quota reconciler schedule"
   # The legacy HTTP scheduler stored the internal gateway token in a custom
   # header. Clear every legacy header while moving to Google OAuth so that
@@ -100,30 +111,38 @@ else
   gc scheduler jobs create http "$SCHEDULER_NAME" "${common_args[@]}" >/dev/null
 fi
 
-# The new version has passed a real Spanner and Bigtable execution, so it is
-# now safe to make it the stable schedule target. Resume is idempotent.
-gc scheduler jobs resume "$SCHEDULER_NAME" \
-  --location="$SCHEDULER_REGION" --quiet >/dev/null 2>&1 || true
+# A containment pause is operator state, not deployment state. Preserve it
+# across releases instead of silently re-enabling a worker during an incident.
+if [ "$scheduler_state" = "PAUSED" ]; then
+  log "preserving intentional regional quota reconciler pause"
+else
+  gc scheduler jobs resume "$SCHEDULER_NAME" \
+    --location="$SCHEDULER_REGION" --quiet >/dev/null 2>&1 || true
+fi
 
 # Retain the current and one previous verified version for immediate rollback;
 # stale definitions cost no runtime money but eventually consume the regional
 # Cloud Run Job quota.
-previous_kept=0
-while IFS= read -r old_job; do
-  [[ "$old_job" == "${JOB_PREFIX}-"* ]] || continue
-  [ "$old_job" = "$JOB_NAME" ] && continue
-  if [ "$previous_kept" -eq 0 ]; then
-    previous_kept=1
-    continue
-  fi
-  if ! gc run jobs delete "$old_job" \
-      --region "$JOB_REGION" --quiet >/dev/null; then
-    log "WARN: unable to remove stale regional quota job ${old_job}"
-  fi
-done < <(
-  gc run jobs list \
-    --region "$JOB_REGION" \
-    --sort-by='~metadata.creationTimestamp' \
-    --format='value(metadata.name)'
-)
-log "regional quota reconciler is verified and scheduled once per minute"
+if [ "$verification_complete" = true ]; then
+  previous_kept=0
+  while IFS= read -r old_job; do
+    [[ "$old_job" == "${JOB_PREFIX}-"* ]] || continue
+    [ "$old_job" = "$JOB_NAME" ] && continue
+    if [ "$previous_kept" -eq 0 ]; then
+      previous_kept=1
+      continue
+    fi
+    if ! gc run jobs delete "$old_job" \
+        --region "$JOB_REGION" --quiet >/dev/null; then
+      log "WARN: unable to remove stale regional quota job ${old_job}"
+    fi
+  done < <(
+    gc run jobs list \
+      --region "$JOB_REGION" \
+      --sort-by='~metadata.creationTimestamp' \
+      --format='value(metadata.name)'
+  )
+  log "regional quota reconciler is verified and scheduled once per minute"
+else
+  log "regional quota reconciler deployed but remains paused and unexecuted"
+fi

--- a/src/trusted_router/regional_quota_reconcile_cli.py
+++ b/src/trusted_router/regional_quota_reconcile_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import uuid
 from collections.abc import Callable
 from typing import Any, cast
 
@@ -12,6 +13,7 @@ from trusted_router.storage import configure_store, create_store
 from trusted_router.synthetic.fleet import record_heartbeat
 
 logger = logging.getLogger(__name__)
+_LOCK_TTL_SECONDS = 90
 
 
 def main() -> int:
@@ -27,6 +29,47 @@ def main() -> int:
 
     store = create_store(settings)
     configure_store(store)
+    acquire = cast(
+        Callable[..., Any] | None,
+        getattr(store, "acquire_regional_quota_reconciler_lock", None),
+    )
+    release = cast(
+        Callable[..., bool] | None,
+        getattr(store, "release_regional_quota_reconciler_lock", None),
+    )
+    if acquire is None or release is None:
+        logger.error("regional_quota.reconciler_lock_unsupported")
+        return 1
+    owner = f"rqrec-{uuid.uuid4().hex}"
+    lock = acquire(owner=owner, ttl_seconds=_LOCK_TTL_SECONDS)
+    if lock is None:
+        logger.info("regional_quota.reconciler_lock_busy")
+        return 0
+
+    exit_code = 1
+    try:
+        exit_code = _run_reconcile(settings, store)
+    except Exception:
+        logger.exception("regional_quota.reconciler_failed")
+        exit_code = 1
+    finally:
+        try:
+            released = release(
+                owner=owner,
+                fencing_token=int(lock.fencing_token),
+            )
+        except Exception:
+            logger.exception("regional_quota.reconciler_lock_release_failed")
+            released = False
+        if not released:
+            logger.error("regional_quota.reconciler_lock_release_lost")
+            exit_code = 1
+    if exit_code == 0:
+        record_heartbeat("job:regional-quota-reconcile", settings=settings)
+    return exit_code
+
+
+def _run_reconcile(settings: Any, store: Any) -> int:
     verify = cast(
         Callable[[], tuple[str, ...]] | None,
         getattr(store, "verify_regional_quota_ledger", None),
@@ -57,7 +100,6 @@ def main() -> int:
     )
     if int(result.get("errors", 0)):
         return 1
-    record_heartbeat("job:regional-quota-reconcile", settings=settings)
     return 0
 
 

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -413,17 +413,25 @@ class SpannerBigtableStore:
         self._regional_quota_ledger = None
         self._regional_quota_lease_cache: dict[tuple[str, str, int], Any] = {}
         self._regional_quota_lease_cache_lock = threading.Lock()
+        profiles = dict(regional_quota_bigtable_app_profiles or {})
         if regional_quota_leases_enabled:
-            profiles = dict(regional_quota_bigtable_app_profiles or {})
             if not bigtable_instance_id or not profiles:
                 raise ValueError(
                     "regional quota leases require a Bigtable instance and fixed app profiles"
+                )
+        # Issuance is region-local, but settlement and refund callbacks may land
+        # on any control-plane region. Every serving process with the fixed
+        # profile map therefore opens the ledger even when local issuance is off.
+        if profiles:
+            if not bigtable_instance_id:
+                raise ValueError(
+                    "regional quota app profiles require a Bigtable instance"
                 )
             try:
                 from google.cloud import bigtable
             except ImportError as exc:  # pragma: no cover - production image.
                 raise RuntimeError(
-                    "Install google-cloud-bigtable when regional quota leases are enabled"
+                    "Install google-cloud-bigtable when regional quota access is configured"
                 ) from exc
             from trusted_router.regional_quota_ledger import (
                 BigtableRegionalQuotaLedger,
@@ -3019,6 +3027,8 @@ class SpannerBigtableStore:
         from trusted_router.storage_gcp_regional_quota import (
             GlobalRegionalQuotaLease,
             OpenRegionalQuotaLease,
+            close_expired_uninitialized_regional_quota_lease,
+            delete_closed_regional_quota_open_index,
             reconcile_regional_quota_lease,
         )
 
@@ -3041,10 +3051,34 @@ class SpannerBigtableStore:
                 if record is None:
                     raise RuntimeError("indexed global regional lease is missing")
                 if record.state == "closed":
-                    raise RuntimeError("closed regional lease retained an open index")
+                    if not delete_closed_regional_quota_open_index(
+                        self,
+                        record,
+                        open_lease,
+                    ):
+                        raise RuntimeError("closed regional lease index cleanup lost its fence")
+                    result["closed"] += 1
+                    continue
                 local = ledger.get(record.lease_id, region=record.region)
                 if local is None:
-                    raise RuntimeError("regional lease row is missing")
+                    closed = close_expired_uninitialized_regional_quota_lease(
+                        self,
+                        record,
+                        now=now,
+                    )
+                    result["reconciled"] += 1
+                    if closed.closed:
+                        with self._regional_quota_lease_cache_lock:
+                            self._regional_quota_lease_cache.pop(
+                                (
+                                    record.workspace_id,
+                                    record.region,
+                                    record.quota_shard,
+                                ),
+                                None,
+                            )
+                        result["closed"] += 1
+                    continue
                 for hold in local.holds:
                     if (
                         hold.state == HoldState.RESERVED
@@ -3097,6 +3131,42 @@ class SpannerBigtableStore:
                     exc_info=True,
                 )
         return result
+
+    def acquire_regional_quota_reconciler_lock(
+        self,
+        *,
+        owner: str,
+        ttl_seconds: int,
+        now: dt.datetime | None = None,
+    ) -> Any | None:
+        from trusted_router.storage_gcp_regional_quota import (
+            acquire_regional_quota_reconciler_lock,
+        )
+
+        return acquire_regional_quota_reconciler_lock(
+            self,
+            owner=owner,
+            ttl_seconds=ttl_seconds,
+            now=now,
+        )
+
+    def release_regional_quota_reconciler_lock(
+        self,
+        *,
+        owner: str,
+        fencing_token: int,
+        now: dt.datetime | None = None,
+    ) -> bool:
+        from trusted_router.storage_gcp_regional_quota import (
+            release_regional_quota_reconciler_lock,
+        )
+
+        return release_regional_quota_reconciler_lock(
+            self,
+            owner=owner,
+            fencing_token=fencing_token,
+            now=now,
+        )
 
     def verify_regional_quota_ledger(self) -> tuple[str, ...]:
         """Prove conditional writes and reads through every fixed app profile."""

--- a/src/trusted_router/storage_gcp_regional_quota.py
+++ b/src/trusted_router/storage_gcp_regional_quota.py
@@ -38,6 +38,8 @@ log = logging.getLogger(__name__)
 _LEASE_KIND = "regional_quota_lease"
 _OPEN_LEASE_KIND = "regional_quota_lease_open"
 _FENCE_KIND = "regional_quota_fence"
+_RECONCILER_LOCK_KIND = "regional_quota_reconciler_lock"
+_RECONCILER_LOCK_ID = "singleton"
 
 
 @dataclass
@@ -96,6 +98,106 @@ class RegionalReconcileResult:
     unused_released_microdollars: int
     closed: bool
     replayed: bool
+
+
+@dataclass(frozen=True)
+class RegionalQuotaReconcilerLock:
+    owner: str | None
+    fencing_token: int
+    expires_at: str
+    updated_at: str
+
+    @property
+    def expires_datetime(self) -> datetime:
+        return _parse_iso(self.expires_at)
+
+
+def acquire_regional_quota_reconciler_lock(
+    store: Any,
+    *,
+    owner: str,
+    ttl_seconds: int,
+    now: datetime | None = None,
+) -> RegionalQuotaReconcilerLock | None:
+    """Acquire the singleton worker lease with an expiry and fencing token."""
+
+    now = utcnow() if now is None else now
+    if now.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+    if not owner or len(owner) > 128:
+        raise ValueError("owner must contain between 1 and 128 characters")
+    if not 1 <= ttl_seconds <= 600:
+        raise ValueError("ttl_seconds must be between 1 and 600")
+
+    def txn(transaction: Any) -> RegionalQuotaReconcilerLock | None:
+        current = store._read_entity_tx(
+            transaction,
+            _RECONCILER_LOCK_KIND,
+            _RECONCILER_LOCK_ID,
+            RegionalQuotaReconcilerLock,
+        )
+        if current is not None and current.owner is not None and current.expires_datetime > now:
+            return None
+        lock = RegionalQuotaReconcilerLock(
+            owner=owner,
+            fencing_token=1 if current is None else current.fencing_token + 1,
+            expires_at=_iso(now + timedelta(seconds=ttl_seconds)),
+            updated_at=_iso(now),
+        )
+        _upsert_entity_dml(
+            transaction,
+            store._param_types,
+            _RECONCILER_LOCK_KIND,
+            _RECONCILER_LOCK_ID,
+            lock,
+        )
+        return lock
+
+    return store._run_in_transaction(txn)
+
+
+def release_regional_quota_reconciler_lock(
+    store: Any,
+    *,
+    owner: str,
+    fencing_token: int,
+    now: datetime | None = None,
+) -> bool:
+    """Release only the lock generation owned by this worker."""
+
+    now = utcnow() if now is None else now
+    if now.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+
+    def txn(transaction: Any) -> bool:
+        current = store._read_entity_tx(
+            transaction,
+            _RECONCILER_LOCK_KIND,
+            _RECONCILER_LOCK_ID,
+            RegionalQuotaReconcilerLock,
+        )
+        if (
+            current is None
+            or current.owner != owner
+            or current.fencing_token != fencing_token
+        ):
+            return False
+        released = dataclasses.replace(
+            current,
+            owner=None,
+            expires_at=_iso(now),
+            updated_at=_iso(now),
+        )
+        _upsert_entity_dml(
+            transaction,
+            store._param_types,
+            _RECONCILER_LOCK_KIND,
+            _RECONCILER_LOCK_ID,
+            released,
+        )
+        return True
+
+    return bool(store._run_in_transaction(txn))
 
 
 def grant_regional_quota_lease(
@@ -473,6 +575,71 @@ def reconcile_regional_quota_lease(
         )
 
     return store._run_in_transaction(txn)
+
+
+def close_expired_uninitialized_regional_quota_lease(
+    store: Any,
+    global_lease: GlobalRegionalQuotaLease,
+    *,
+    now: datetime | None = None,
+) -> RegionalReconcileResult:
+    """Release escrow after a failed Bigtable initialization left no row.
+
+    A missing row is recoverable only for an expired quarantined lease with no
+    previously imported spend. Bigtable reads through a single-cluster profile
+    are strongly consistent, so absence proves the grant was never usable.
+    """
+
+    now = utcnow() if now is None else now
+    if global_lease.state != "quarantined":
+        raise RuntimeError("regional lease row is missing")
+    if global_lease.expires_datetime > now:
+        raise RuntimeError("quarantined regional lease has not expired")
+    if (
+        global_lease.reconciled_spent_microdollars != 0
+        or global_lease.reconciled_key_microdollars
+    ):
+        raise RuntimeError("quarantined regional lease has imported usage")
+    empty = regional_lease_from_global(global_lease).begin_drain(
+        fencing_token=global_lease.fencing_token
+    )
+    return reconcile_regional_quota_lease(
+        store,
+        global_lease,
+        empty,
+        close=True,
+        now=now,
+    )
+
+
+def delete_closed_regional_quota_open_index(
+    store: Any,
+    global_lease: GlobalRegionalQuotaLease,
+    open_lease: OpenRegionalQuotaLease,
+) -> bool:
+    """Idempotently remove a stale derived index after canonical close."""
+
+    def txn(transaction: Any) -> bool:
+        current = store._read_entity_tx(
+            transaction,
+            _LEASE_KIND,
+            global_lease.entity_id,
+            GlobalRegionalQuotaLease,
+        )
+        if current is None:
+            raise RuntimeError("indexed global regional lease is missing")
+        _validate_same_global_lease(global_lease, current)
+        if current.state != "closed":
+            return False
+        delete_entity_dml(
+            transaction,
+            store._param_types,
+            _OPEN_LEASE_KIND,
+            open_lease.entity_id,
+        )
+        return True
+
+    return bool(store._run_in_transaction(txn))
 
 
 def record_regional_gateway_authorization(

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -177,6 +177,14 @@ def test_production_deploy_provisions_and_schedules_regional_quota_reconciliatio
     assert "--max-retries 0" in reconciler
     assert "--task-timeout 50s" in reconciler
     assert "--max-retry-attempts=0" in reconciler
+    assert "scheduler_state" in reconciler
+    assert '[ "$scheduler_state" = "PAUSED" ]' in reconciler
+    assert "skipping automatic reconciler execution while containment pause is active" in reconciler
+    assert "preserving intentional regional quota reconciler pause" in reconciler
+    assert '--route-to="$cluster"' in provisioner
+    assert "singleClusterRouting.clusterId" in provisioner
+    assert "singleClusterRouting.allowTransactionalWrites" in provisioner
+    assert "refusing regional quota profile drift" in provisioner
     assert "gc run jobs delete" in reconciler
 
 

--- a/tests/test_regional_quota_reconcile_cli.py
+++ b/tests/test_regional_quota_reconcile_cli.py
@@ -14,9 +14,11 @@ def _isolate_observability(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class _Store:
-    def __init__(self, result: dict[str, int]) -> None:
+    def __init__(self, result: dict[str, int], *, lock_available: bool = True) -> None:
         self.result = result
         self.limits: list[int] = []
+        self.lock_available = lock_available
+        self.released: list[tuple[str, int]] = []
 
     def reconcile_regional_quota_leases(self, *, limit: int) -> dict[str, int]:
         self.limits.append(limit)
@@ -24,6 +26,27 @@ class _Store:
 
     def verify_regional_quota_ledger(self) -> tuple[str, ...]:
         return ("us-central1",)
+
+    def acquire_regional_quota_reconciler_lock(
+        self,
+        *,
+        owner: str,
+        ttl_seconds: int,
+    ) -> SimpleNamespace | None:
+        assert owner.startswith("rqrec-")
+        assert ttl_seconds == 90
+        if not self.lock_available:
+            return None
+        return SimpleNamespace(fencing_token=7)
+
+    def release_regional_quota_reconciler_lock(
+        self,
+        *,
+        owner: str,
+        fencing_token: int,
+    ) -> bool:
+        self.released.append((owner, fencing_token))
+        return True
 
 
 def test_disabled_worker_does_not_open_storage(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -61,6 +84,8 @@ def test_worker_reconciles_with_bounded_limit(monkeypatch: pytest.MonkeyPatch) -
     )
     assert worker.main() == 0
     assert store.limits == [1000]
+    assert len(store.released) == 1
+    assert store.released[0][1] == 7
     assert heartbeats == ["job:regional-quota-reconcile"]
 
 
@@ -80,6 +105,7 @@ def test_worker_fails_execution_when_any_lease_fails(
     monkeypatch.setattr(worker, "create_store", lambda _settings: store)
 
     assert worker.main() == 1
+    assert len(store.released) == 1
 
 
 def test_worker_fails_closed_without_reconcile_capability(
@@ -99,6 +125,10 @@ def test_worker_fails_closed_without_reconcile_capability(
         "create_store",
         lambda _settings: SimpleNamespace(
             verify_regional_quota_ledger=lambda: ("us-central1",),
+            acquire_regional_quota_reconciler_lock=lambda **_kwargs: SimpleNamespace(
+                fencing_token=1
+            ),
+            release_regional_quota_reconciler_lock=lambda **_kwargs: True,
         ),
     )
 
@@ -123,10 +153,37 @@ def test_worker_fails_closed_when_no_ledger_region_is_verified(
         lambda _settings: SimpleNamespace(
             verify_regional_quota_ledger=lambda: (),
             reconcile_regional_quota_leases=lambda **_kwargs: {},
+            acquire_regional_quota_reconciler_lock=lambda **_kwargs: SimpleNamespace(
+                fencing_token=1
+            ),
+            release_regional_quota_reconciler_lock=lambda **_kwargs: True,
         ),
     )
 
     assert worker.main() == 1
+
+
+def test_worker_skips_when_another_reconciler_owns_the_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _Store(
+        {"inspected": 1, "reconciled": 1, "closed": 1, "errors": 0},
+        lock_available=False,
+    )
+    monkeypatch.setattr(
+        worker,
+        "get_settings",
+        lambda: SimpleNamespace(
+            regional_quota_reconciler_worker=True,
+            regional_quota_leases_enabled=True,
+            regional_quota_reconcile_limit=25,
+        ),
+    )
+    monkeypatch.setattr(worker, "create_store", lambda _settings: store)
+
+    assert worker.main() == 0
+    assert store.limits == []
+    assert store.released == []
 
 
 def test_worker_environment_does_not_require_serving_pilot_allowlist() -> None:

--- a/tests/test_regional_quota_spanner.py
+++ b/tests/test_regional_quota_spanner.py
@@ -4,6 +4,8 @@ import hashlib
 import json
 from datetime import UTC, datetime, timedelta
 
+import pytest
+
 from tests.fakes.spanner import make_fake_store
 from trusted_router.regional_quota_ledger import InMemoryRegionalQuotaLedger
 from trusted_router.services.settle_outbox_apply import ApplyOutcome, apply_frozen_settle
@@ -15,6 +17,7 @@ from trusted_router.storage_gcp_regional_quota import (
     OpenRegionalQuotaLease,
     activate_regional_quota_lease,
     grant_regional_quota_lease,
+    quarantine_regional_quota_lease,
     reconcile_regional_quota_lease,
     record_regional_gateway_authorization,
     regional_lease_from_global,
@@ -581,3 +584,152 @@ def test_settle_outbox_recovery_settles_regional_hold_before_spanner_terminal() 
     )
     assert reconciled["errors"] == 0
     assert _credit_totals(database, workspace.id) == (100_000_000, 7_500, 0)
+
+
+def test_reconciler_closes_expired_quarantine_when_local_initialization_is_absent() -> None:
+    store, database, _ = make_fake_store(request_record_write_mode="typed")
+    store._regional_quota_ledger = InMemoryRegionalQuotaLedger()
+    workspace = store.create_workspace(
+        "owner",
+        "regional-quarantine",
+        trial_credit_microdollars=10_000_000,
+    )
+    lease = grant_regional_quota_lease(
+        store,
+        workspace_id=workspace.id,
+        region="us-central1",
+        requested_microdollars=1_000_000,
+        per_lease_cap_microdollars=1_000_000,
+        max_available_basis_points=1_000,
+        ttl_seconds=60,
+        minimum_grant_microdollars=1_000,
+        now=NOW,
+    )
+    assert lease is not None
+    quarantine_regional_quota_lease(
+        store,
+        lease,
+        reason="regional initialization ambiguity",
+        now=NOW,
+    )
+    quarantined = store._read_entity(
+        "regional_quota_lease",
+        lease.entity_id,
+        GlobalRegionalQuotaLease,
+    )
+    assert quarantined is not None
+    with pytest.raises(RuntimeError, match="quarantined"):
+        activate_regional_quota_lease(store, quarantined, now=NOW + timedelta(seconds=1))
+    assert _credit_totals(database, workspace.id)[2] == lease.granted_microdollars
+
+    result = store.reconcile_regional_quota_leases(now=NOW + timedelta(minutes=2))
+
+    assert result == {
+        "inspected": 1,
+        "reconciled": 1,
+        "closed": 1,
+        "errors": 0,
+    }
+    assert _credit_totals(database, workspace.id) == (10_000_000, 0, 0)
+    closed = store._read_entity("regional_quota_lease", lease.entity_id, GlobalRegionalQuotaLease)
+    assert closed is not None and closed.state == "closed"
+    assert store._list_entities("regional_quota_lease_open", cls=OpenRegionalQuotaLease) == []
+
+
+def test_reconciler_cleans_stale_open_index_for_already_closed_lease() -> None:
+    store, database, _ = make_fake_store(request_record_write_mode="typed")
+    ledger = InMemoryRegionalQuotaLedger()
+    store._regional_quota_ledger = ledger
+    workspace = store.create_workspace(
+        "owner",
+        "regional-stale-index",
+        trial_credit_microdollars=10_000_000,
+    )
+    lease = grant_regional_quota_lease(
+        store,
+        workspace_id=workspace.id,
+        region="us-central1",
+        requested_microdollars=1_000_000,
+        per_lease_cap_microdollars=1_000_000,
+        max_available_basis_points=1_000,
+        ttl_seconds=60,
+        minimum_grant_microdollars=1_000,
+        now=NOW,
+    )
+    assert lease is not None
+    lease = activate_regional_quota_lease(store, lease, now=NOW)
+    local = ledger.initialize(regional_lease_from_global(lease))
+    local = ledger.begin_drain(
+        local.lease_id,
+        region=local.region,
+        fencing_token=local.fencing_token,
+    )
+    reconcile_regional_quota_lease(
+        store,
+        lease,
+        local,
+        close=True,
+        now=NOW + timedelta(minutes=2),
+    )
+    stale = OpenRegionalQuotaLease(
+        lease_entity_id=lease.entity_id,
+        workspace_id=lease.workspace_id,
+        region=lease.region,
+        lease_id=lease.lease_id,
+        expires_at=lease.expires_at,
+    )
+    store._write_entity("regional_quota_lease_open", stale.entity_id, stale)
+
+    result = store.reconcile_regional_quota_leases(now=NOW + timedelta(minutes=3))
+
+    assert result == {
+        "inspected": 1,
+        "reconciled": 0,
+        "closed": 1,
+        "errors": 0,
+    }
+    assert _credit_totals(database, workspace.id) == (10_000_000, 0, 0)
+    assert store._list_entities("regional_quota_lease_open", cls=OpenRegionalQuotaLease) == []
+
+
+def test_reconciler_lock_is_single_owner_and_fenced_after_expiry() -> None:
+    store, _database, _ = make_fake_store(request_record_write_mode="typed")
+
+    first = store.acquire_regional_quota_reconciler_lock(
+        owner="worker-a",
+        ttl_seconds=90,
+        now=NOW,
+    )
+    assert first is not None
+    assert (
+        store.acquire_regional_quota_reconciler_lock(
+            owner="worker-b",
+            ttl_seconds=90,
+            now=NOW + timedelta(seconds=30),
+        )
+        is None
+    )
+
+    replacement = store.acquire_regional_quota_reconciler_lock(
+        owner="worker-b",
+        ttl_seconds=90,
+        now=NOW + timedelta(seconds=91),
+    )
+    assert replacement is not None
+    assert replacement.fencing_token == first.fencing_token + 1
+    assert (
+        store.release_regional_quota_reconciler_lock(
+            owner="worker-a",
+            fencing_token=first.fencing_token,
+            now=NOW + timedelta(seconds=92),
+        )
+        is False
+    )
+    assert (
+        store.release_regional_quota_reconciler_lock(
+            owner="worker-b",
+            fencing_token=replacement.fencing_token,
+            now=NOW + timedelta(seconds=92),
+        )
+        is True
+    )

--- a/tests/test_storage_gcp.py
+++ b/tests/test_storage_gcp.py
@@ -154,6 +154,56 @@ def test_gcp_store_disables_spanner_builtin_metrics(monkeypatch: Any) -> None:
     ]
 
 
+def test_gcp_store_opens_regional_ledger_when_local_issuance_is_disabled(
+    monkeypatch: Any,
+) -> None:
+    """Every control-plane region must settle leases issued by another region."""
+    from google.cloud import bigtable, spanner
+
+    monkeypatch.setattr(
+        "trusted_router.storage_gcp.configure_spanner_rpc_deadlines",
+        lambda _database: None,
+    )
+
+    class FakeSpannerClient:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        def instance(self, _instance_id: str) -> FakeSpannerClient:
+            return self
+
+        def database(self, _database_id: str, **_kwargs: Any) -> object:
+            return object()
+
+    class FakeBigtableClient:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        def instance(self, _instance_id: str) -> FakeBigtableClient:
+            return self
+
+        def table(self, _table_id: str, *, app_profile_id: str) -> object:
+            assert app_profile_id == "quota-us"
+            return object()
+
+    monkeypatch.setattr(spanner, "Client", FakeSpannerClient)
+    monkeypatch.setattr(bigtable, "Client", FakeBigtableClient)
+
+    store = SpannerBigtableStore(
+        project_id="project",
+        spanner_instance_id="spanner",
+        spanner_database_id="database",
+        bigtable_instance_id="bigtable",
+        bigtable_enabled=False,
+        analytics_read_mode="clickhouse-only",
+        regional_quota_leases_enabled=False,
+        regional_quota_bigtable_app_profiles={"us-central1": "quota-us"},
+    )
+
+    assert store._regional_quota_ledger is not None
+    assert store._regional_quota_ledger.supports_region("us-central1") is True
+
+
 def test_gcp_api_key_lookup_uses_index_and_never_stores_raw_key() -> None:
     store, db, _ = make_fake_store()
     store._write_entity(


### PR DESCRIPTION
## Summary
- initialize the regional quota ledger in every control-plane region that may receive settlement or refund callbacks
- fence the reconciler with a durable singleton Spanner lock and make stale index cleanup idempotent
- safely close expired quarantined grants only when the strongly consistent regional ledger proves initialization never created a row
- preserve operator pauses across deploys and fail closed if the Bigtable profile is not single-cluster transactional

## Verification
- regression tests were added first and failed on the previous code
- ruff clean
- mypy clean
- 73 focused tests pass
- full suite: 5,087 passed; 19 sandbox-only localhost bind failures all pass when rerun with loopback access (64/64)
- independent Claude CLI review found no concrete defects; its two stated invariants are now pinned by tests and deployment validation