### PR TITLE
Run the fleet analytics freshness check on a schedule

### DIFF
--- a/.github/workflows/check-analytics-freshness.yml
+++ b/.github/workflows/check-analytics-freshness.yml
@@ -63,29 +63,35 @@ name: Check fleet analytics freshness
 # stronger than a ClickHouse timestamp -- it cannot be satisfied by a drain that
 # is writing nowhere.
 #
-# OPERATOR STEPS BEFORE THE SCHEDULE IS ENABLED
-# ---------------------------------------------
-# The `schedule:` trigger is intentionally absent, exactly as it was in this
-# job's single-cloud predecessor and for the same reason one layer up. So is
-# `push:`, and that one is worth stating outright rather than leaving to be
-# rediscovered: a push trigger on these paths fires on the very merge that
-# lands them, at which point NO control plane publishes the `analytics` section
-# yet. The run fails -- correctly -- and the failure step below opens a
-# labelled public issue about a state we already know about and have written
-# down here. An automated issue filed against a known, documented, not-yet-true
-# precondition is the cry-wolf failure in miniature, one hour after merge
-# instead of one morning after.
+# WHY THE TRIGGERS ARE ON NOW
+# ---------------------------
+# `schedule:` and `push:` were both withheld until every cloud in
+# ANALYTICS_FRESHNESS_FLEET was actually SERVING code that publishes the
+# `analytics` section. Merging to main was never that: it auto-deploys the GCP
+# control plane only (deploy.yml), while AWS-EU and Azure are hand-run scripts
+# and were both behind. A schedule enabled before then would have filed an
+# issue every morning about two clouds nobody had redeployed, and a check that
+# cries wolf is a check people learn to close unread -- at which point it is
+# not watching the clouds it CAN read either.
 #
-# PRECONDITION: every cloud in ANALYTICS_FRESHNESS_FLEET must actually be
-# SERVING the code that publishes the `analytics` section. Merging to main is
-# not that. Merging auto-deploys the GCP control plane only (deploy.yml);
-# AWS-EU and Azure are deployed by hand-run scripts
-# (scripts/deploy/aws_eu_control_plane.sh, scripts/deploy/azure_control_plane.sh)
-# and are already behind main. A schedule turned on in the same commit as the
-# publisher would therefore file an issue every morning about two clouds that
-# were never redeployed -- a check that cries wolf is a check people learn to
-# ignore, which is the failure `CANARY_COUNT_GATE_FROM` in
-# clickhouse/check_client_telemetry_freshness.py was written to avoid.
+# That precondition was met on 2026-08-21:
+#
+#   aws    was publishing "unreachable" -- deployed 2026-08-18, two days
+#          before #672, so it still sent Aurora DSQL a SET LOCAL
+#          statement_timeout that DSQL rejects. Redeployed.
+#   azure  was publishing no analytics section at all -- the control plane had
+#          never been redeployed past revision 0000001. Redeployed; it now
+#          reports not_configured, which is the honest answer for a cloud with
+#          no outbox and is what expects_outbox=False asserts.
+#
+#   fleet analytics freshness: OK aws=0.0 azure=None gcp=0.287 unchecked=1
+#
+# The documented sequencing was deploy, dispatch once by hand, then enable the
+# triggers. Doing the hand dispatch is what found that this job could not run
+# AT ALL: it installed no dependencies, so the checker died on `import
+# pydantic` before reading a single status page. Its entire run history was
+# that one failure. The install step below is the fix, and it is the reason
+# the dispatch step was worth insisting on rather than treating as ceremony.
 #
 #   1. Deploy all three control planes; verify with
 #        curl -s https://trustedrouter.com/status.json | jq .data.analytics
@@ -121,6 +127,30 @@ name: Check fleet analytics freshness
 # of a late detection is freshness and storage, never data.
 
 on:
+  schedule:
+    # Every six hours. The cadence is set by what this check is FOR: the
+    # drain's own backlog_alarm is emitted by the drain process, so a drain
+    # that does not exist cannot alarm about not existing -- which is how
+    # AWS-EU went fifteen days and 470,370 rows unnoticed. This is the
+    # out-of-band backstop for exactly that.
+    #
+    # Not hourly: the drain tolerates an hour of lag by design
+    # (max_drain_lag_seconds defaults to 3600), so a sub-hourly run reports
+    # the same number more often without learning anything new, and a check
+    # that cries wolf is one people learn to skip. Not daily either: at that
+    # cadence a stopped drain is a day of silence, and the whole complaint
+    # about the original outage was the length of the silence.
+    - cron: "0 */6 * * *"
+  push:
+    branches: [main]
+    # Only when the check ITSELF changes. One run, on the merge, while somebody
+    # still holds the context -- which is what the withheld push trigger was
+    # always for. Not on every main push: the clouds it reads are deployed by
+    # hand, so an unrelated merge says nothing new about their drains.
+    paths:
+      - "clickhouse/check_fleet_analytics_freshness.py"
+      - "src/trusted_router/operational_analytics_fleet.py"
+      - ".github/workflows/check-analytics-freshness.yml"
   workflow_dispatch:
     inputs:
       cloud:
@@ -155,6 +185,24 @@ jobs:
         with:
           python-version: "3.12"
 
+      - uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+
+      # The checker imports trusted_router.operational_analytics_fleet, whose
+      # import chain reaches trusted_router.config and therefore pydantic. This
+      # job set PYTHONPATH=src and installed NOTHING, so it had never once
+      # completed: the only run in its entire history -- a hand dispatch on
+      # 2026-08-21 -- died with ModuleNotFoundError before reading a single
+      # status page.
+      #
+      # A check built to catch a fifteen-day silent outage was itself silently
+      # incapable of running. It is worth saying plainly, because the shape is
+      # the one this repository keeps finding: configured, documented, tested,
+      # and never executed.
+      - name: Install the package the checker imports
+        run: uv sync --frozen
+
       # No credentials, no cloud SDK, no VPC. The whole point of reading the
       # public status feeds is that this step is a handful of plain HTTPS GETs.
       - name: Check every cloud's drain lag
@@ -176,7 +224,7 @@ jobs:
           if [ -n "${MAX_LAG}" ]; then
             args+=(--max-drain-lag-seconds "${MAX_LAG}")
           fi
-          python3 -m clickhouse.check_fleet_analytics_freshness "${args[@]}"
+          uv run python -m clickhouse.check_fleet_analytics_freshness "${args[@]}"
 
       - name: Open or update the freshness issue
         if: failure()

--- a/tests/test_analytics_freshness_registry.py
+++ b/tests/test_analytics_freshness_registry.py
@@ -999,56 +999,6 @@ def _check_run_script(workflow: dict[str, object]) -> str:
     raise AssertionError("no step runs the fleet freshness module")
 
 
-def test_workflow_ships_without_a_schedule_or_a_push_trigger() -> None:
-    """No trigger may fire this job before a control plane publishes the section.
-
-    Merging main auto-deploys the GCP control plane ONLY (deploy.yml); AWS-EU
-    and Azure are hand-run scripts and are already behind. A `schedule:` landed
-    in the same commit as the publisher would file an issue every morning about
-    two clouds nobody has redeployed -- and the daily issue teaches people to
-    close this job unread, at which point it is not watching the clouds it CAN
-    read either. That is the same failure the client-telemetry check's
-    `CANARY_COUNT_GATE_FROM` ramp-up guard exists to avoid, and the same reason
-    this job's single-cloud predecessor shipped scheduleless.
-
-    `push:` was held to be different -- one run, on the merge, aimed at
-    somebody still holding the context. It is not. On that merge NO plane
-    publishes the section yet, so the run fails, and the failure step opens a
-    LABELLED PUBLIC ISSUE about a state this repository has already written
-    down as expected. Filing an automated issue against a known, documented,
-    not-yet-true precondition is the cry-wolf failure with a shorter fuse. The
-    honest sequencing is: deploy, dispatch once by hand, then enable both
-    triggers in one commit that also deletes this test.
-
-    `workflow_dispatch` is the whole trigger surface until then.
-    """
-    on_block = _on_block(_workflow())
-
-    assert "schedule" not in on_block
-    assert "push" not in on_block
-    assert set(on_block) == {"workflow_dispatch"}
-
-
-def test_workflow_header_states_the_precondition_and_the_follow_up() -> None:
-    """A withheld trigger is only honest if the note says how to un-withhold it.
-
-    Including the part that is only discoverable by breaking it: turning the
-    triggers on fails two tests, and the header names both, so nobody learns
-    what they changed from a red CI run.
-    """
-    workflow = WORKFLOW.read_text()
-
-    assert "OPERATOR STEPS BEFORE THE SCHEDULE IS ENABLED" in workflow
-    assert "PRECONDITION" in workflow
-    assert 'schedule: [{cron: "20 7 * * *"}]' in workflow
-    assert "cries wolf" in workflow
-    # Named, not described. A rename that does not update the header fails here.
-    assert "::test_workflow_ships_without_a_schedule_or_a_push_trigger" in workflow
-    assert "::test_workflow_still_does_not_page_before_the_field_is_deployed" in workflow
-    assert "tests/test_analytics_freshness_registry.py" in workflow
-    assert "tests/test_aws_analytics_drain_install.py" in workflow
-
-
 def test_the_scheduled_run_line_can_never_be_narrowed_to_one_cloud() -> None:
     """Structural, because the string version of this test proved nothing.
 
@@ -1084,7 +1034,10 @@ def test_the_scheduled_run_line_can_never_be_narrowed_to_one_cloud() -> None:
 def test_workflow_runs_the_fleet_module_not_the_single_cloud_alias() -> None:
     script = _check_run_script(_workflow())
 
-    assert "python3 -m clickhouse.check_fleet_analytics_freshness" in script
+    # Launcher-agnostic on purpose: the job runs this through `uv run` now
+    # that it installs the package it imports. What this test is about is WHICH
+    # module runs -- the fleet checker, not the single-cloud alias it replaced.
+    assert "-m clickhouse.check_fleet_analytics_freshness" in script
 
 
 def test_workflow_needs_no_cloud_credentials() -> None:

--- a/tests/test_aws_analytics_drain_install.py
+++ b/tests/test_aws_analytics_drain_install.py
@@ -353,36 +353,6 @@ def test_workflow_needs_no_cloud_credentials() -> None:
     assert "clickhouse.check_fleet_analytics_freshness" in workflow
 
 
-def test_workflow_still_does_not_page_before_the_field_is_deployed() -> None:
-    """Publishing the field in this repo is not the same as serving it.
-
-    The predecessor shipped without a `schedule:` because nothing published the
-    section. That is still true of the LIVE fleet: merging main auto-deploys
-    the GCP control plane only, while AWS-EU and Azure are hand-run scripts and
-    are already behind. A schedule enabled in the same commit as the publisher
-    would file an issue every morning about clouds nobody redeployed, and a
-    check that cries wolf is a check people learn to ignore.
-
-    The same goes for `push:`. It looked different -- one run, on the merge,
-    addressed to whoever is still holding the context -- but on that merge no
-    plane publishes the section yet, so the run fails and the failure step
-    opens a labelled PUBLIC issue about the precondition this header already
-    documents as unmet.
-
-    The structural version of this assertion, on parsed YAML, is in
-    `tests/test_analytics_freshness_registry.py`; this one keeps the
-    predecessor's own guard alive where the predecessor's tests live.
-    """
-    workflow = WORKFLOW.read_text()
-
-    # Matched at the two-space indent a real trigger sits at under `on:`, so
-    # the enabling instructions in the header do not satisfy it.
-    assert "\n  schedule:" not in workflow
-    assert "\n  push:" not in workflow
-    assert "\n  workflow_dispatch:" in workflow
-    assert "OPERATOR STEPS BEFORE THE SCHEDULE IS ENABLED" in workflow
-
-
 def test_workflow_issue_names_the_never_installed_case() -> None:
     """The failure that actually happened must be in the runbook, not inferred."""
     workflow = WORKFLOW.read_text()


### PR DESCRIPTION
The check has existed since the AWS-EU outage and has only ever run when somebody dispatched it by hand — an out-of-band backstop that is only out-of-band when someone is watching, which is the property the original failure already disproved.

## Why it wasn't scheduled before

Because it didn't pass. Two clouds published nothing usable:

| | |
|---|---|
| `aws` | `"unreachable"` — the plane was deployed 2026-08-18, two days before #672, so it still sent Aurora DSQL a `SET LOCAL statement_timeout` it rejects |
| `azure` | **no analytics section at all** — the control plane had never been redeployed past revision `0000001`, so it ran code predating #643 |

Both are now deployed. Current fleet:

```
~ azure: NOT CHECKED -- runs no operational-analytics outbox (expects_outbox=False,
  and the plane confirms not_configured). There is no drain here to be missing.
  This line becomes a FAILURE the day it publishes a real lag.
fleet analytics freshness: OK  aws=0.0  azure=None  gcp=0.287  unchecked=1
```

Scheduling a red check would have been worse than not scheduling one: an alarm that fires on its first run and every run after is an alarm people learn to skip — the same silence in a different costume.

## Cadence

Six-hourly. **Not hourly**, because the drain tolerates an hour of lag by design (`max_drain_lag_seconds` defaults to 3600), so a sub-hourly run reports the same number more often without learning anything new. **Not daily**, because at that cadence a stopped drain buys a day of silence, and the length of the silence was the whole complaint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)