### PR TITLE
Interlock regional quota issuance rollout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,14 @@ on:
         description: "Force redeploy synthetic monitor jobs"
         type: boolean
         default: false
+      regional_quota_lease_issuance:
+        description: "Regional quota issuance: preserve active state, force off, or enable after fleet compatibility preflight"
+        type: choice
+        default: preserve
+        options:
+          - preserve
+          - "false"
+          - "true"
 
 # Only one deploy at a time. Two pushes within seconds of each other
 # serialize instead of racing to be the running revision.
@@ -342,6 +350,9 @@ jobs:
       SERVICE: trusted-router
       SHA: ${{ needs.build-image.outputs.sha }}
       IMAGE: ${{ needs.build-image.outputs.image }}
+      # Keep the workflow value raw. rollout.sh normalizes preserve/false/true
+      # only after reading the actual 100%-traffic primary revision.
+      TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED: ${{ inputs.regional_quota_lease_issuance }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/design/regional-quota-leases.md
+++ b/docs/design/regional-quota-leases.md
@@ -94,11 +94,55 @@ uses the exact Spanner path until that region has an isolated local ledger.
 
 ## Rollout gates
 
-`TR_REGIONAL_QUOTA_LEASES_ENABLED` defaults to false. Production startup
-accepts true only with typed request records, the durable settle outbox, a
-non-empty workspace allowlist, a Bigtable instance, and fixed regional app
-profiles. Ordinary deploys preserve the serving revision's state rather than
-silently flipping it.
+Two independent flags make a rolling deploy safe:
+
+- `TR_REGIONAL_QUOTA_LEASES_ENABLED` is fleet capability. It keeps the fixed
+  regional ledger available for settlement, refund, and reconciliation.
+- `TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED` is the traffic mutation switch.
+  It defaults to false, requires capability, and is the only flag that lets an
+  allowlisted authorization create a new regional hold.
+
+Capability in production requires typed request records, the durable settle
+outbox, a Bigtable instance, and fixed regional app profiles. Issuance also
+requires a non-empty workspace allowlist. An issuance-off revision can still
+finish a regional hold created by an issuance-on peer, which is the required
+mixed-revision behavior during a ramp or rollback.
+
+The rollout reads preserved quota state from the revision receiving exactly
+100% of primary-region traffic. It never reads the service template, latest
+created revision, or latest ready revision, because all three can name a failed
+candidate after traffic has rolled back. An ambiguous traffic split or any
+control-plane read error aborts. Only an exact missing-service response is
+treated as a fresh environment, with issuance off.
+
+Activation is intentionally two separate full-fleet deployments:
+
+1. Compatibility phase — deploy every region with issuance explicitly false.
+   Wait for the normal staged traffic, billing-path, and production smoke gates
+   to complete everywhere.
+2. Issuance phase — dispatch the same workflow with issuance true. Before
+   creating any issuance-enabled revision, the rollout checks every active
+   control-plane region for `TR_REGIONAL_QUOTA_LEASES_ENABLED=true` and an
+   explicit boolean `TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED` marker. Missing,
+   split, unreadable, or incapable regions fail closed.
+
+Operator commands (run only from the reviewed `main` commit) are:
+
+```bash
+gh workflow run deploy.yml --repo Lore-Hex/quill-router --ref main \
+  -f regional_quota_lease_issuance=false
+```
+
+After that run is fully green in every region:
+
+```bash
+gh workflow run deploy.yml --repo Lore-Hex/quill-router --ref main \
+  -f regional_quota_lease_issuance=true
+```
+
+Routine workflow dispatches use `preserve`; push-triggered deploys normalize an
+empty input to the same behavior. The shell writes only a normalized boolean to
+the Cloud Run revision.
 
 Reconciliation is intentionally independent from traffic issuance. A
 versioned one-shot Cloud Run Job continues draining leases that were already

--- a/scripts/deploy/regional_quota_rollout.sh
+++ b/scripts/deploy/regional_quota_rollout.sh
@@ -1,0 +1,198 @@
+# shellcheck shell=bash
+# Regional-quota rollout interlock helpers.
+#
+# This file is sourced by rollout.sh and intentionally has no top-level cloud
+# calls.  Keeping the state-resolution and fleet-preflight logic here makes the
+# money-path switch executable under a recording fake rather than review-only.
+
+_regional_quota_exact_service_not_found() {
+  local message="$1"
+  local line
+  while IFS= read -r line; do
+    # Only the describe command saying that this exact service is absent means
+    # "fresh environment".  A missing revision, denied read, expired login, or
+    # any other error must not be converted into feature defaults.
+    if [[ "$line" == "ERROR: (gcloud.run.services.describe) NOT_FOUND: Service [${SERVICE}]"* ]] ||
+       [[ "$line" == "ERROR: (gcloud.run.services.describe) NOT_FOUND: Service '${SERVICE}'"* ]] ||
+       [[ "$line" == "ERROR: (gcloud.run.services.describe) Service [${SERVICE}] could not be found." ]]; then
+      return 0
+    fi
+  done <<<"$message"
+  return 1
+}
+
+regional_quota_active_revision_json() {
+  local region="$1"
+  local allow_fresh_environment="${2:-false}"
+  local service_json
+  local status=0
+
+  service_json="$(
+    gc run services describe "$SERVICE" \
+      --region="$region" \
+      --format=json 2>&1
+  )" || status=$?
+  if [ "$status" -ne 0 ]; then
+    if [ "$allow_fresh_environment" = "true" ] &&
+       _regional_quota_exact_service_not_found "$service_json"; then
+      return 3
+    fi
+    log "refusing regional quota rollout: cannot read service ${SERVICE} in ${region}: ${service_json}"
+    return 1
+  fi
+
+  local active_revision
+  if ! active_revision="$(python3 -c '
+import json
+import sys
+
+service = json.load(sys.stdin)
+traffic = [
+    item
+    for item in service.get("status", {}).get("traffic", [])
+    if int(item.get("percent") or 0) > 0
+]
+if len(traffic) != 1 or int(traffic[0].get("percent") or 0) != 100:
+    raise SystemExit("expected exactly one 100%-traffic revision")
+revision = traffic[0].get("revisionName")
+if not isinstance(revision, str) or not revision:
+    raise SystemExit("100%-traffic entry has no revisionName")
+print(revision)
+' <<<"$service_json")"; then
+    log "refusing regional quota rollout: ${SERVICE} in ${region} has ambiguous active traffic"
+    return 1
+  fi
+
+  # Deliberately describe the traffic revision, never latestCreatedRevisionName,
+  # latestReadyRevisionName, or the service template.  After a rollback those
+  # all can point at the rejected candidate while 100% traffic serves the safe
+  # predecessor.
+  local revision_json
+  status=0
+  revision_json="$(
+    gc run revisions describe "$active_revision" \
+      --region="$region" \
+      --format=json 2>&1
+  )" || status=$?
+  if [ "$status" -ne 0 ]; then
+    log "refusing regional quota rollout: cannot read active revision ${active_revision} in ${region}: ${revision_json}"
+    return 1
+  fi
+  printf '%s\n' "$revision_json"
+}
+
+regional_quota_revision_env() {
+  local revision_json="$1"
+  local name="$2"
+  local default_value="${3:-}"
+  python3 -c '
+import json
+import sys
+
+name = sys.argv[1]
+default = sys.argv[2]
+revision = json.load(sys.stdin)
+matches = [
+    item
+    for item in revision.get("spec", {}).get("containers", [{}])[0].get("env", [])
+    if item.get("name") == name
+]
+if len(matches) > 1:
+    raise SystemExit(f"duplicate environment variable: {name}")
+if not matches:
+    print(default)
+else:
+    value = matches[0].get("value")
+    if not isinstance(value, str):
+        raise SystemExit(f"environment variable is not a plain value: {name}")
+    print(value)
+' "$name" "$default_value" <<<"$revision_json"
+}
+
+regional_quota_normalize_issuance_control() {
+  local raw_control="$1"
+  local live_value="$2"
+  local effective_value=""
+
+  case "$raw_control" in
+    ""|preserve) effective_value="$live_value" ;;
+    true|false) effective_value="$raw_control" ;;
+    *)
+      log "refusing rollout: regional quota issuance input must be preserve, true, or false"
+      return 1
+      ;;
+  esac
+  case "$effective_value" in
+    true|false) printf '%s\n' "$effective_value" ;;
+    *)
+      log "refusing rollout: active TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED must be true or false"
+      return 1
+      ;;
+  esac
+}
+
+regional_quota_preflight_issuance_fleet() {
+  local raw_regions="${TR_CONTROL_PLANE_REGIONS:-}"
+  if [ -z "$raw_regions" ]; then
+    log "refusing regional quota issuance: TR_CONTROL_PLANE_REGIONS is empty"
+    return 1
+  fi
+
+  local previous_ifs="$IFS"
+  IFS=','
+  # Bash 3.2-compatible indexed array; do not use readarray/mapfile here.
+  local regions
+  read -ra regions <<<"$raw_regions"
+  IFS="$previous_ifs"
+
+  local region
+  for region in "${regions[@]}"; do
+    if [ -z "$region" ]; then
+      log "refusing regional quota issuance: control-plane region list has an empty entry"
+      return 1
+    fi
+
+    local revision_json
+    if ! revision_json="$(regional_quota_active_revision_json "$region" false)"; then
+      return 1
+    fi
+
+    local capability
+    if ! capability="$(
+      regional_quota_revision_env \
+        "$revision_json" \
+        "TR_REGIONAL_QUOTA_LEASES_ENABLED" \
+        "__missing__"
+    )"; then
+      log "refusing regional quota issuance: cannot read capability marker in ${region}"
+      return 1
+    fi
+    if [ "$capability" != "true" ]; then
+      log "refusing regional quota issuance: active ${region} revision does not declare TR_REGIONAL_QUOTA_LEASES_ENABLED=true"
+      return 1
+    fi
+
+    local issuance_marker
+    if ! issuance_marker="$(
+      regional_quota_revision_env \
+        "$revision_json" \
+        "TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED" \
+        "__missing__"
+    )"; then
+      log "refusing regional quota issuance: cannot read issuance marker in ${region}"
+      return 1
+    fi
+    case "$issuance_marker" in
+      true|false) ;;
+      __missing__)
+        log "refusing regional quota issuance: active ${region} revision lacks TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED"
+        return 1
+        ;;
+      *)
+        log "refusing regional quota issuance: active ${region} revision has a non-boolean TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED"
+        return 1
+        ;;
+    esac
+    log "regional quota issuance compatibility: ${region}=capable, marker=${issuance_marker}"
+  done
+}

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -7,6 +7,8 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/deploy/_lib.sh
 source "${SCRIPT_DIR}/_lib.sh"
+# shellcheck source=scripts/deploy/regional_quota_rollout.sh
+source "${SCRIPT_DIR}/regional_quota_rollout.sh"
 
 TRUST_SOURCE_COMMIT=""
 TRUST_IMAGE_REFERENCE=""
@@ -307,26 +309,41 @@ if [ "$ANALYTICS_READ_MODE" = "clickhouse" ] && {
   ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 fi
 
-read_primary_env() {
+# Regional quota capability and traffic issuance are separate switches. Resolve
+# preserved values from the one revision receiving 100% of primary traffic,
+# never the latest candidate or service template: both still point at a rejected
+# revision after rollback. Only an exact missing-service response represents a
+# fresh environment; every other control-plane read error aborts the rollout.
+REGIONAL_QUOTA_PRIMARY_FRESH=false
+REGIONAL_QUOTA_PRIMARY_REVISION_JSON=""
+if REGIONAL_QUOTA_PRIMARY_REVISION_JSON="$(
+  regional_quota_active_revision_json "$TR_PRIMARY_REGION" true
+)"; then
+  :
+else
+  regional_quota_primary_status=$?
+  if [ "$regional_quota_primary_status" -eq 3 ]; then
+    REGIONAL_QUOTA_PRIMARY_FRESH=true
+  else
+    exit "$regional_quota_primary_status"
+  fi
+fi
+
+read_primary_regional_quota_env() {
   local name="$1"
   local default_value="${2:-}"
-  gc run services describe "$SERVICE" \
-    --region="$TR_PRIMARY_REGION" \
-    --format=json 2>/dev/null \
-    | jq -r --arg name "$name" --arg default_value "$default_value" '
-        [
-          .spec.template.spec.containers[0].env[]?
-          | select(.name == $name)
-          | .value
-        ][0] // $default_value
-      ' || true
+  if [ "$REGIONAL_QUOTA_PRIMARY_FRESH" = "true" ]; then
+    printf '%s\n' "$default_value"
+    return 0
+  fi
+  regional_quota_revision_env \
+    "$REGIONAL_QUOTA_PRIMARY_REVISION_JSON" \
+    "$name" \
+    "$default_value"
 }
 
-# Regional quota leases are opt-in and workspace allowlisted. Preserve the
-# serving revision's state during ordinary deploys so a routine release cannot
-# silently turn a canary on or off. A fresh environment remains fail-closed.
 LIVE_REGIONAL_QUOTA_LEASES_ENABLED="$(
-  read_primary_env "TR_REGIONAL_QUOTA_LEASES_ENABLED" "false"
+  read_primary_regional_quota_env "TR_REGIONAL_QUOTA_LEASES_ENABLED" "false"
 )"
 REGIONAL_QUOTA_LEASES_ENABLED="${TR_REGIONAL_QUOTA_LEASES_ENABLED:-${LIVE_REGIONAL_QUOTA_LEASES_ENABLED:-false}}"
 case "$REGIONAL_QUOTA_LEASES_ENABLED" in
@@ -336,33 +353,63 @@ case "$REGIONAL_QUOTA_LEASES_ENABLED" in
     exit 1
     ;;
 esac
+
+# workflow_dispatch passes one of preserve/false/true through unchanged. The
+# deploy shell, not GitHub's expression coercion, turns that raw operator intent
+# into the boolean written on the Cloud Run revision. A missing marker on the
+# first compatibility deploy defaults OFF.
+LIVE_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED="$(
+  read_primary_regional_quota_env \
+    "TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED" \
+    "false"
+)"
+REGIONAL_QUOTA_LEASE_ISSUANCE_CONTROL="${TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED:-}"
+REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED="$(
+  regional_quota_normalize_issuance_control \
+    "$REGIONAL_QUOTA_LEASE_ISSUANCE_CONTROL" \
+    "$LIVE_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED"
+)"
+if [ "$REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED" = "true" ] &&
+   [ "$REGIONAL_QUOTA_LEASES_ENABLED" != "true" ]; then
+  log "refusing rollout: regional quota issuance requires lease capability"
+  exit 1
+fi
+
 REGIONAL_QUOTA_LEASE_PILOT_WORKSPACE_IDS="${TR_REGIONAL_QUOTA_LEASE_PILOT_WORKSPACE_IDS:-$(
-  read_primary_env "TR_REGIONAL_QUOTA_LEASE_PILOT_WORKSPACE_IDS"
+  read_primary_regional_quota_env "TR_REGIONAL_QUOTA_LEASE_PILOT_WORKSPACE_IDS"
 )}"
 REGIONAL_QUOTA_BIGTABLE_TABLE="${TR_REGIONAL_QUOTA_BIGTABLE_TABLE:-$(
-  read_primary_env "TR_REGIONAL_QUOTA_BIGTABLE_TABLE" "trustedrouter-regional-quota"
+  read_primary_regional_quota_env "TR_REGIONAL_QUOTA_BIGTABLE_TABLE" "trustedrouter-regional-quota"
 )}"
 REGIONAL_QUOTA_BIGTABLE_APP_PROFILES="${TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES:-$(
-  read_primary_env "TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES"
+  read_primary_regional_quota_env "TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES"
 )}"
 REGIONAL_QUOTA_LEASE_TTL_SECONDS="${TR_REGIONAL_QUOTA_LEASE_TTL_SECONDS:-$(
-  read_primary_env "TR_REGIONAL_QUOTA_LEASE_TTL_SECONDS" "60"
+  read_primary_regional_quota_env "TR_REGIONAL_QUOTA_LEASE_TTL_SECONDS" "60"
 )}"
 REGIONAL_QUOTA_LEASE_MAX_MICRODOLLARS="${TR_REGIONAL_QUOTA_LEASE_MAX_MICRODOLLARS:-$(
-  read_primary_env "TR_REGIONAL_QUOTA_LEASE_MAX_MICRODOLLARS" "10000000"
+  read_primary_regional_quota_env "TR_REGIONAL_QUOTA_LEASE_MAX_MICRODOLLARS" "10000000"
 )}"
 REGIONAL_QUOTA_LEASE_MAX_AVAILABLE_BASIS_POINTS="${TR_REGIONAL_QUOTA_LEASE_MAX_AVAILABLE_BASIS_POINTS:-$(
-  read_primary_env "TR_REGIONAL_QUOTA_LEASE_MAX_AVAILABLE_BASIS_POINTS" "1000"
+  read_primary_regional_quota_env "TR_REGIONAL_QUOTA_LEASE_MAX_AVAILABLE_BASIS_POINTS" "1000"
 )}"
 REGIONAL_QUOTA_LEASE_SHARD_COUNT="${TR_REGIONAL_QUOTA_LEASE_SHARD_COUNT:-$(
-  read_primary_env "TR_REGIONAL_QUOTA_LEASE_SHARD_COUNT" "16"
+  read_primary_regional_quota_env "TR_REGIONAL_QUOTA_LEASE_SHARD_COUNT" "16"
 )}"
-if [ "$REGIONAL_QUOTA_LEASES_ENABLED" = "true" ] && {
+if [ "$REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED" = "true" ] && {
   [ -z "$REGIONAL_QUOTA_LEASE_PILOT_WORKSPACE_IDS" ] ||
   [ -z "$REGIONAL_QUOTA_BIGTABLE_APP_PROFILES" ];
 }; then
-  log "refusing rollout: regional quota canary requires pilot workspaces and fixed Bigtable app profiles"
+  log "refusing rollout: regional quota issuance requires pilot workspaces and fixed Bigtable app profiles"
   exit 1
+fi
+
+# This executes before gcloud run deploy can create any issuance-enabled
+# revision. Every currently active fleet member must already be settlement-
+# capable and must explicitly carry the new boolean marker. That creates a
+# compatibility phase between landing the code and enabling issuance.
+if [ "$REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED" = "true" ]; then
+  regional_quota_preflight_issuance_fleet
 fi
 
 # Prefer the private three-replica ClickHouse load balancer once provisioned.
@@ -535,10 +582,10 @@ ENV_VARS=(
   # operator overrides it. This prevents routine rollouts from reopening the
   # unbounded generic write path.
   "TR_REQUEST_RECORD_WRITE_MODE=${REQUEST_RECORD_WRITE_MODE}"
-  # Bounded regional escrow. This stays off by default and can serve only the
-  # explicit workspace allowlist. Ordinary deploys preserve the serving
-  # revision's state; startup fails closed if a required fixed profile is gone.
+  # Bounded regional escrow. Capability keeps settlement/reconciliation ready;
+  # the independent issuance marker stays off through the compatibility phase.
   "TR_REGIONAL_QUOTA_LEASES_ENABLED=${REGIONAL_QUOTA_LEASES_ENABLED}"
+  "TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED=${REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED}"
   "TR_REGIONAL_QUOTA_LEASE_PILOT_WORKSPACE_IDS=${REGIONAL_QUOTA_LEASE_PILOT_WORKSPACE_IDS}"
   "TR_REGIONAL_QUOTA_LEASE_TTL_SECONDS=${REGIONAL_QUOTA_LEASE_TTL_SECONDS}"
   "TR_REGIONAL_QUOTA_LEASE_MAX_MICRODOLLARS=${REGIONAL_QUOTA_LEASE_MAX_MICRODOLLARS}"

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -638,7 +638,12 @@ class Settings(BaseSettings):
     notify_max_per_hour: int = 30
     notify_max_voice_per_hour: int = 4
 
+    # Fleet capability: initialize and retain the regional ledger so any
+    # revision can settle/refund/reconcile leases created elsewhere.
     regional_quota_leases_enabled: bool = False
+    # Traffic mutation: authorize new requests from bounded regional escrow.
+    # This is deliberately independent and default-off for two-phase rollouts.
+    regional_quota_lease_issuance_enabled: bool = False
     regional_quota_lease_pilot_workspace_ids: str = ""
     regional_quota_lease_ttl_seconds: int = 60
     regional_quota_lease_max_microdollars: int = 10_000_000
@@ -1003,20 +1008,21 @@ class Settings(BaseSettings):
             raise ValueError(
                 "TR_REGIONAL_QUOTA_RECONCILER_WORKER is valid only in worker processes"
             )
-        if self.regional_quota_leases_enabled:
-            # Serving processes must always be allowlisted. The one-shot
-            # reconciler worker scans only already-issued global leases and
-            # cannot authorize traffic, so duplicating the serving allowlist
-            # into that job would add configuration drift without narrowing
-            # its authority.
-            if (
-                not self.regional_quota_reconciler_worker
-                and not self.regional_quota_lease_pilot_workspace_ids.strip()
-            ):
+        if (
+            self.regional_quota_lease_issuance_enabled
+            and not self.regional_quota_leases_enabled
+        ):
+            raise ValueError(
+                "TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED requires "
+                "TR_REGIONAL_QUOTA_LEASES_ENABLED"
+            )
+        if self.regional_quota_lease_issuance_enabled:
+            if not self.regional_quota_lease_pilot_workspace_ids.strip():
                 raise ValueError(
-                    "TR_REGIONAL_QUOTA_LEASES_ENABLED requires "
+                    "TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED requires "
                     "TR_REGIONAL_QUOTA_LEASE_PILOT_WORKSPACE_IDS"
                 )
+        if self.regional_quota_leases_enabled:
             if environment not in {"local", "test"}:
                 if self.storage_backend not in {
                     "spanner-bigtable",

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -615,6 +615,7 @@ def _authorize_gateway_sync(
             )
             regional_eligible = (
                 settings.regional_quota_leases_enabled
+                and settings.regional_quota_lease_issuance_enabled
                 and workspace.id in settings.regional_quota_lease_pilot_workspaces
                 and callable(regional_authorize)
                 and estimate > 0

--- a/tests/shell/test_regional_quota_rollout.sh
+++ b/tests/shell/test_regional_quota_rollout.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=scripts/deploy/regional_quota_rollout.sh
+source "${ROOT}/scripts/deploy/regional_quota_rollout.sh"
+
+SERVICE="trusted-router"
+TR_CONTROL_PLANE_REGIONS="us-central1,us-east4,europe-west4,southamerica-east1"
+SCENARIO=""
+CALL_LOG="$(mktemp "${TMPDIR:-/tmp}/tr-regional-quota-rollout.XXXXXX")"
+trap 'rm -f "$CALL_LOG"' EXIT
+
+log() {
+  printf '%s\n' "$*" >&2
+}
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+active_service_json() {
+  local region="$1"
+  local revision="rev-${region}"
+  printf '{"status":{"latestCreatedRevisionName":"%s","latestReadyRevisionName":"%s","traffic":[{"revisionName":"%s","percent":100}]}}\n' \
+    "$revision" "$revision" "$revision"
+}
+
+revision_json() {
+  local capability="$1"
+  local marker="$2"
+  if [ "$marker" = "missing" ]; then
+    printf '{"spec":{"containers":[{"env":[{"name":"TR_REGIONAL_QUOTA_LEASES_ENABLED","value":"%s"}]}]}}\n' \
+      "$capability"
+  else
+    printf '{"spec":{"containers":[{"env":[{"name":"TR_REGIONAL_QUOTA_LEASES_ENABLED","value":"%s"},{"name":"TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED","value":"%s"}]}]}}\n' \
+      "$capability" "$marker"
+  fi
+}
+
+gc() {
+  printf '%s\n' "$*" >>"$CALL_LOG"
+  if [ "$1 $2 $3" = "run services describe" ]; then
+    local region=""
+    local arg
+    for arg in "$@"; do
+      case "$arg" in
+        --region=*) region="${arg#--region=}" ;;
+      esac
+    done
+    case "$SCENARIO" in
+      rollback)
+        printf '%s\n' '{"status":{"latestCreatedRevisionName":"rev-rejected-candidate","latestReadyRevisionName":"rev-rejected-candidate","traffic":[{"revisionName":"rev-rollback","percent":100}]}}'
+        ;;
+      ambiguous)
+        printf '%s\n' '{"status":{"latestCreatedRevisionName":"rev-new","traffic":[{"revisionName":"rev-old","percent":50},{"revisionName":"rev-new","percent":50}]}}'
+        ;;
+      read_error)
+        printf '%s\n' 'ERROR: (gcloud.run.services.describe) PERMISSION_DENIED: caller cannot read service' >&2
+        return 1
+        ;;
+      exact_not_found)
+        printf '%s\n' 'ERROR: (gcloud.run.services.describe) NOT_FOUND: Service [trusted-router] was not found' >&2
+        return 1
+        ;;
+      *)
+        active_service_json "$region"
+        ;;
+    esac
+    return 0
+  fi
+
+  if [ "$1 $2 $3" = "run revisions describe" ]; then
+    local revision="$4"
+    case "$SCENARIO" in
+      rollback)
+        [ "$revision" = "rev-rollback" ] || fail "described latest candidate instead of rollback"
+        revision_json true false
+        ;;
+      missing_marker) revision_json true missing ;;
+      capability_false) revision_json false false ;;
+      all_compatible)
+        case "$revision" in
+          rev-us-central1|rev-europe-west4) revision_json true false ;;
+          *) revision_json true true ;;
+        esac
+        ;;
+      *) revision_json true false ;;
+    esac
+    return 0
+  fi
+
+  fail "unexpected gc call: $*"
+}
+
+test_rollback_reads_the_traffic_revision_not_latest_candidate() {
+  SCENARIO=rollback
+  : >"$CALL_LOG"
+  local json
+  json="$(regional_quota_active_revision_json us-central1 false)"
+  local marker
+  marker="$(
+    regional_quota_revision_env \
+      "$json" \
+      TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED \
+      missing
+  )"
+  [ "$marker" = "false" ] || fail "rollback marker was ${marker}"
+  grep -q 'run revisions describe rev-rollback ' "$CALL_LOG" ||
+    fail "100%-traffic rollback revision was not described"
+  if grep -q 'run revisions describe rev-rejected-candidate ' "$CALL_LOG"; then
+    fail "latest rejected candidate was described"
+  fi
+}
+
+test_ambiguous_traffic_fails_closed() {
+  SCENARIO=ambiguous
+  if regional_quota_active_revision_json us-central1 false >/dev/null 2>&1; then
+    fail "50/50 traffic was accepted as one active revision"
+  fi
+}
+
+test_read_errors_are_not_fresh_environments() {
+  SCENARIO=read_error
+  local status=0
+  regional_quota_active_revision_json us-central1 true >/dev/null 2>&1 || status=$?
+  [ "$status" -eq 1 ] || fail "read error returned ${status}, expected fail-closed status 1"
+}
+
+test_only_exact_service_not_found_is_a_fresh_environment() {
+  SCENARIO=exact_not_found
+  local status=0
+  regional_quota_active_revision_json us-central1 true >/dev/null 2>&1 || status=$?
+  [ "$status" -eq 3 ] || fail "exact service NOT_FOUND returned ${status}, expected 3"
+}
+
+test_raw_issuance_input_is_normalized_in_shell() {
+  [ "$(regional_quota_normalize_issuance_control "" false)" = "false" ] ||
+    fail "empty push input did not preserve false"
+  [ "$(regional_quota_normalize_issuance_control preserve true)" = "true" ] ||
+    fail "preserve input did not keep true"
+  [ "$(regional_quota_normalize_issuance_control true false)" = "true" ] ||
+    fail "true input did not override false"
+  [ "$(regional_quota_normalize_issuance_control false true)" = "false" ] ||
+    fail "false input did not override true"
+  if regional_quota_normalize_issuance_control invalid false >/dev/null 2>&1; then
+    fail "invalid issuance input was accepted"
+  fi
+  if regional_quota_normalize_issuance_control preserve missing >/dev/null 2>&1; then
+    fail "non-boolean live issuance marker was accepted"
+  fi
+}
+
+test_missing_issuance_marker_blocks_enable() {
+  SCENARIO=missing_marker
+  if regional_quota_preflight_issuance_fleet >/dev/null 2>&1; then
+    fail "fleet with a missing issuance marker passed preflight"
+  fi
+}
+
+test_capability_false_blocks_enable() {
+  SCENARIO=capability_false
+  if regional_quota_preflight_issuance_fleet >/dev/null 2>&1; then
+    fail "fleet with capability=false passed preflight"
+  fi
+}
+
+test_all_compatible_active_revisions_pass() {
+  SCENARIO=all_compatible
+  : >"$CALL_LOG"
+  regional_quota_preflight_issuance_fleet >/dev/null
+  local revision_reads
+  revision_reads="$(grep -c '^run revisions describe ' "$CALL_LOG")"
+  [ "$revision_reads" -eq 4 ] || fail "preflight read ${revision_reads} revisions, expected 4"
+}
+
+test_rollback_reads_the_traffic_revision_not_latest_candidate
+test_ambiguous_traffic_fails_closed
+test_read_errors_are_not_fresh_environments
+test_only_exact_service_not_found_is_a_fresh_environment
+test_raw_issuance_input_is_normalized_in_shell
+test_missing_issuance_marker_blocks_enable
+test_capability_false_blocks_enable
+test_all_compatible_active_revisions_pass
+printf '%s\n' 'regional quota rollout shell tests: 8 passed'

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -128,16 +128,36 @@ def test_all_attested_control_plane_regions_remain_warm() -> None:
     assert '--min-instances "$min_instances"' in rollout
 
 
-def test_production_deploy_preserves_allowlisted_regional_quota_canary() -> None:
+def test_production_deploy_interlocks_regional_quota_issuance() -> None:
     rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
+    helper = (ROOT / "scripts/deploy/regional_quota_rollout.sh").read_text()
+    workflow = (ROOT / ".github/workflows/deploy.yml").read_text()
 
-    assert 'read_primary_env "TR_REGIONAL_QUOTA_LEASES_ENABLED" "false"' in rollout
+    assert 'source "${SCRIPT_DIR}/regional_quota_rollout.sh"' in rollout
+    assert (
+        'read_primary_regional_quota_env "TR_REGIONAL_QUOTA_LEASES_ENABLED" "false"'
+        in rollout
+    )
     assert (
         '"TR_REGIONAL_QUOTA_LEASES_ENABLED=${REGIONAL_QUOTA_LEASES_ENABLED}"'
         in rollout
     )
+    assert (
+        '"TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED='
+        '${REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED}"'
+        in rollout
+    )
     assert '"TR_REGIONAL_QUOTA_LEASES_ENABLED=false"' not in rollout
-    assert "regional quota canary requires pilot workspaces" in rollout
+    assert "regional_quota_preflight_issuance_fleet" in rollout
+    assert 'service.get("status", {}).get("traffic", [])' in helper
+    assert "latestCreatedRevisionName" in helper
+    assert "latestReadyRevisionName" in helper
+    assert 'regional_quota_lease_issuance:' in workflow
+    assert (
+        "TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED: "
+        "${{ inputs.regional_quota_lease_issuance }}"
+        in workflow
+    )
     assert (
         '"TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES=${REGIONAL_QUOTA_BIGTABLE_APP_PROFILES}"'
         in rollout

--- a/tests/test_gateway_fallback_billing.py
+++ b/tests/test_gateway_fallback_billing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from fastapi.testclient import TestClient
 
 from tests.fakes.spanner import make_fake_store
@@ -93,6 +94,7 @@ def test_allowlisted_uncapped_key_authorizes_from_bounded_regional_escrow() -> N
     settings = Settings(
         environment="test",
         regional_quota_leases_enabled=True,
+        regional_quota_lease_issuance_enabled=True,
         regional_quota_lease_pilot_workspace_ids=workspace.id,
     )
     client = TestClient(
@@ -125,6 +127,128 @@ def test_allowlisted_uncapped_key_authorizes_from_bounded_regional_escrow() -> N
     assert sum(row["reserved"] for row in db.typed[CREDIT_BALANCE_TABLE].values()) > 0
 
 
+def test_capability_only_revision_keeps_uncapped_key_on_exact_global_path() -> None:
+    store, _db, _ = make_fake_store(request_record_write_mode="typed")
+    store._regional_quota_ledger = InMemoryRegionalQuotaLedger()
+    workspace = store.create_workspace(
+        "owner",
+        "regional-capability-only",
+        trial_credit_microdollars=100_000_000,
+    )
+    _raw, api_key = store.create_api_key(
+        workspace_id=workspace.id,
+        name="capability-only",
+        creator_user_id="owner",
+    )
+    configure_store(store)
+    client = TestClient(
+        create_app(
+            Settings(
+                environment="test",
+                regional_quota_leases_enabled=True,
+                regional_quota_lease_issuance_enabled=False,
+                regional_quota_lease_pilot_workspace_ids=workspace.id,
+            ),
+            configure_store_arg=False,
+            init_observability=False,
+        )
+    )
+
+    response = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": api_key.hash,
+            "model": "anthropic/claude-opus-4.7",
+            "estimated_input_tokens": 1_000,
+            "max_output_tokens": 100,
+            "route_type": "chat.completions",
+            "idempotency_key": "regional-capability-only",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    authorization = store.get_gateway_authorization(response.json()["data"]["authorization_id"])
+    assert authorization is not None
+    assert authorization.settlement == "local"
+    assert store._list_entities("regional_quota_lease", cls=dict) == []
+
+
+@pytest.mark.parametrize("finalize_kind", ["settle", "refund"])
+def test_capability_only_peer_finalizes_lease_issued_by_enabled_peer(
+    finalize_kind: str,
+) -> None:
+    store, _db, _ = make_fake_store(request_record_write_mode="typed")
+    store._regional_quota_ledger = InMemoryRegionalQuotaLedger()
+    workspace = store.create_workspace(
+        "owner",
+        f"regional-mixed-revision-{finalize_kind}",
+        trial_credit_microdollars=100_000_000,
+    )
+    _raw, api_key = store.create_api_key(
+        workspace_id=workspace.id,
+        name="mixed-revision",
+        creator_user_id="owner",
+    )
+    configure_store(store)
+    issuing_peer = TestClient(
+        create_app(
+            Settings(
+                environment="test",
+                regional_quota_leases_enabled=True,
+                regional_quota_lease_issuance_enabled=True,
+                regional_quota_lease_pilot_workspace_ids=workspace.id,
+            ),
+            configure_store_arg=False,
+            init_observability=False,
+        )
+    )
+
+    authorize = issuing_peer.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": api_key.hash,
+            "model": "anthropic/claude-opus-4.7",
+            "estimated_input_tokens": 1_000,
+            "max_output_tokens": 100,
+            "route_type": "chat.completions",
+            "idempotency_key": f"regional-mixed-{finalize_kind}",
+        },
+    )
+    assert authorize.status_code == 200, authorize.text
+    authorization_id = authorize.json()["data"]["authorization_id"]
+    authorization = store.get_gateway_authorization(authorization_id)
+    assert authorization is not None
+    assert authorization.settlement == "regional_lease"
+
+    # This app represents a different active revision: it retains the ledger
+    # capability, but its traffic-issuance switch is intentionally off.
+    settlement_peer = TestClient(
+        create_app(
+            Settings(
+                environment="test",
+                regional_quota_leases_enabled=True,
+                regional_quota_lease_issuance_enabled=False,
+            ),
+            configure_store_arg=False,
+            init_observability=False,
+        )
+    )
+    finalized = settlement_peer.post(
+        f"/v1/internal/gateway/{finalize_kind}",
+        json={
+            "authorization_id": authorization_id,
+            "actual_input_tokens": 900,
+            "actual_output_tokens": 50,
+            "route_type": "chat.completions",
+            "elapsed_seconds": 0.2,
+        },
+    )
+
+    assert finalized.status_code == 200, finalized.text
+    expected = "settled" if finalize_kind == "settle" else "refunded"
+    assert finalized.json()["data"]["finalization_outcome"] == expected
+
+
 def test_capped_key_stays_on_exact_global_authorization_path() -> None:
     store, db, _ = make_fake_store(request_record_write_mode="typed")
     ledger = InMemoryRegionalQuotaLedger()
@@ -146,6 +270,7 @@ def test_capped_key_stays_on_exact_global_authorization_path() -> None:
             Settings(
                 environment="test",
                 regional_quota_leases_enabled=True,
+                regional_quota_lease_issuance_enabled=True,
                 regional_quota_lease_pilot_workspace_ids=workspace.id,
             ),
             configure_store_arg=False,

--- a/tests/test_regional_quota_leases.py
+++ b/tests/test_regional_quota_leases.py
@@ -308,9 +308,18 @@ def test_invalid_construction_and_grant_inputs_fail_closed() -> None:
 def test_regional_leases_default_off_and_fail_closed_without_dependencies() -> None:
     defaults = Settings(environment="test")
     assert defaults.regional_quota_leases_enabled is False
+    assert defaults.regional_quota_lease_issuance_enabled is False
     assert defaults.regional_quota_lease_shard_count == 16
+    capability_only = Settings(environment="test", regional_quota_leases_enabled=True)
+    assert capability_only.regional_quota_lease_issuance_enabled is False
+    with pytest.raises(ValidationError, match="requires TR_REGIONAL_QUOTA_LEASES_ENABLED"):
+        Settings(environment="test", regional_quota_lease_issuance_enabled=True)
     with pytest.raises(ValidationError, match="PILOT_WORKSPACE_IDS"):
-        Settings(environment="test", regional_quota_leases_enabled=True)
+        Settings(
+            environment="test",
+            regional_quota_leases_enabled=True,
+            regional_quota_lease_issuance_enabled=True,
+        )
     with pytest.raises(ValidationError, match="Spanner GCP backend"):
         Settings(
             environment="staging",
@@ -327,6 +336,7 @@ def test_regional_leases_default_off_and_fail_closed_without_dependencies() -> N
     settings = Settings(
         environment="test",
         regional_quota_leases_enabled=True,
+        regional_quota_lease_issuance_enabled=True,
         regional_quota_lease_pilot_workspace_ids=" workspace-1,workspace-2 ",
     )
     assert settings.regional_quota_lease_pilot_workspaces == {
@@ -345,8 +355,10 @@ def test_regional_lease_production_config_requires_fixed_profiles_and_outbox() -
     common = {
         "environment": "staging",
         "storage_backend": "spanner-bigtable",
+        "bigtable_instance_id": "trusted-router-logs",
         "request_record_write_mode": "typed",
         "regional_quota_leases_enabled": True,
+        "regional_quota_lease_issuance_enabled": True,
         "regional_quota_lease_pilot_workspace_ids": "workspace-1",
     }
     with pytest.raises(ValidationError, match="settle outbox"):

--- a/tests/test_regional_quota_reconcile_cli.py
+++ b/tests/test_regional_quota_reconcile_cli.py
@@ -206,7 +206,7 @@ def test_worker_environment_does_not_require_serving_pilot_allowlist() -> None:
     assert settings.regional_quota_lease_pilot_workspaces == frozenset()
 
 
-def test_generic_worker_still_requires_serving_pilot_allowlist() -> None:
+def test_generic_worker_issuance_still_requires_serving_pilot_allowlist() -> None:
     from pydantic import ValidationError
 
     from trusted_router.config import Settings
@@ -222,5 +222,6 @@ def test_generic_worker_still_requires_serving_pilot_allowlist() -> None:
             request_record_write_mode="typed",
             settle_outbox_enabled=True,
             regional_quota_leases_enabled=True,
+            regional_quota_lease_issuance_enabled=True,
             regional_quota_bigtable_app_profiles="us-central1=quota-us",
         )

--- a/tests/test_regional_quota_rollout_shell.py
+++ b/tests/test_regional_quota_rollout_shell.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SHELL_TEST = ROOT / "tests" / "shell" / "test_regional_quota_rollout.sh"
+
+
+def test_regional_quota_rollout_shell_contract() -> None:
+    assert os.access(SHELL_TEST, os.X_OK), "regional quota shell contract must be executable"
+    result = subprocess.run(  # noqa: S603 - fixed repository-owned executable
+        [str(SHELL_TEST)],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "8 passed" in result.stdout


### PR DESCRIPTION
## Why

Two Europe rollouts reproduced a cross-revision settlement failure: a new revision issued a regional quota hold while the old 50% traffic peer had no regional ledger and returned HTTP 500 on settlement.

## What

- split ledger/settlement capability from new-hold issuance
- default issuance off and require capability when enabled
- preserve state from the single 100%-traffic revision, never a rejected latest candidate
- fail closed on ambiguous traffic or control-plane read errors
- preflight every active region before any issuance-enabled revision is created
- add executable rollback, ambiguity, read-error, input-normalization, marker, capability, and mixed-fleet tests
- prove an issuance-off capability peer can settle and refund holds issued by an enabled peer

## Validation

- shell rollout contract: 8/8
- focused quota/gateway/deploy tests: 72/72
- Ruff: pass
- mypy: 291 source files pass
- full pytest: 5,090 passed, 301 skipped, 10 xfailed; all environment-restricted nodes passed in the permitted reruns
- independent review: no P0/P1/P2

## Rollout

After merge, first dispatch with `regional_quota_lease_issuance=false` and require a fully green four-region deploy. Only then dispatch a second full rollout with `regional_quota_lease_issuance=true`; the fleet preflight runs before any mutation.
