### PR TITLE
Schedule Fireworks DeepSeek 0731 price cutover

### DIFF
--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -41,6 +41,9 @@ CEREBRAS_GEMMA4_SHARED_RETIREMENT_AT = datetime(2026, 9, 3, 0, 0, tzinfo=UTC)
 NOVITA_LING_30_TINY_RETIREMENT_AT = datetime(2026, 8, 13, 15, 0, tzinfo=UTC)
 ALIBABA_OCTOBER_2026_RETIREMENT_AT = datetime(2026, 10, 9, 16, 0, tzinfo=UTC)
 DEEPSEEK_V4_PRICING_EFFECTIVE_AT = datetime(2026, 8, 16, 16, 0, tzinfo=UTC)
+FIREWORKS_DSV4_FLASH_0731_PRICING_EFFECTIVE_AT = datetime(
+    2026, 8, 22, 12, 0, tzinfo=UTC
+)
 
 # DeepSeek prices direct V4 traffic at twice the off-peak rate during these
 # half-open UTC windows. Keep them as seconds since midnight so boundary
@@ -77,6 +80,12 @@ _DEEPSEEK_V4_PRICES = {
         "off_peak": ProviderPrice(660_000, 1_980_000, 22_000),
         "peak": ProviderPrice(1_320_000, 3_960_000, 44_000),
     },
+}
+
+_FIREWORKS_DSV4_FLASH_0731_MODEL_ID = "deepseek/deepseek-v4-flash-0731"
+_FIREWORKS_DSV4_FLASH_0731_PRICES = {
+    "legacy": ProviderPrice(140_000, 280_000, 28_000),
+    "new": ProviderPrice(220_000, 660_000, 7_000),
 }
 
 
@@ -463,6 +472,7 @@ def latest_scheduled_cutover() -> datetime:
     """
     return max(
         DEEPSEEK_V4_PRICING_EFFECTIVE_AT,
+        FIREWORKS_DSV4_FLASH_0731_PRICING_EFFECTIVE_AT,
         PHALA_JULY_2026_EFFECTIVE_AT,
         *(retirement.effective_at for retirement in _RETIREMENTS),
     )
@@ -529,9 +539,30 @@ def provider_pricing_schedule(
     at: datetime | str | None = None,
 ) -> dict[str, object] | None:
     """Public timing metadata for a provider's variable token pricing."""
+    effective_at = _effective_time(at)
+
+    if (
+        provider_slug == "fireworks"
+        and model_id == _FIREWORKS_DSV4_FLASH_0731_MODEL_ID
+    ):
+        return {
+            "kind": "fixed_cutover",
+            "timezone": "UTC",
+            "effective_at": (
+                FIREWORKS_DSV4_FLASH_0731_PRICING_EFFECTIVE_AT.isoformat().replace(
+                    "+00:00", "Z"
+                )
+            ),
+            "current_period": (
+                "legacy"
+                if effective_at < FIREWORKS_DSV4_FLASH_0731_PRICING_EFFECTIVE_AT
+                else "new"
+            ),
+            "rate_locked_at": "authorization",
+        }
+
     if _deepseek_v4_family(provider_slug, model_id) is None:
         return None
-    effective_at = _effective_time(at)
 
     def clock(seconds: int) -> str:
         return f"{seconds // 3600:02d}:{seconds % 3600 // 60:02d}"
@@ -567,6 +598,17 @@ def provider_price_microdollars(
     family = _deepseek_v4_family(provider_slug, model_id)
     if family is not None:
         return _DEEPSEEK_V4_PRICES[family][_deepseek_v4_period(effective_at)]
+
+    if (
+        provider_slug == "fireworks"
+        and model_id == _FIREWORKS_DSV4_FLASH_0731_MODEL_ID
+    ):
+        period = (
+            "legacy"
+            if effective_at < FIREWORKS_DSV4_FLASH_0731_PRICING_EFFECTIVE_AT
+            else "new"
+        )
+        return _FIREWORKS_DSV4_FLASH_0731_PRICES[period]
 
     if provider_slug == "phala" and model_id == "qwen/qwen-2.5-7b-instruct":
         if effective_at < PHALA_JULY_2026_EFFECTIVE_AT:

--- a/tests/test_fireworks_pricing.py
+++ b/tests/test_fireworks_pricing.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from scripts.pricing.base import ModelPrice, ProviderPricingResult
 from scripts.pricing.parsers import fireworks as fireworks_parser
 from scripts.pricing.providers import fireworks
+from trusted_router.catalog import MODEL_ENDPOINTS, effective_endpoint
+from trusted_router.provider_lifecycle import (
+    FIREWORKS_DSV4_FLASH_0731_PRICING_EFFECTIVE_AT,
+    ProviderPrice,
+    provider_price_microdollars,
+    provider_pricing_schedule,
+)
 
 
 def _price() -> ModelPrice:
@@ -14,6 +22,57 @@ def _price() -> ModelPrice:
         completion_micro_per_m=2_000_000,
         prompt_cached_micro_per_m=100_000,
     )
+
+
+def test_fireworks_dsv4_flash_announced_cutover_is_exact() -> None:
+    model_id = "deepseek/deepseek-v4-flash-0731"
+
+    assert provider_price_microdollars(
+        "fireworks",
+        model_id,
+        at=FIREWORKS_DSV4_FLASH_0731_PRICING_EFFECTIVE_AT - timedelta(seconds=1),
+    ) == ProviderPrice(140_000, 280_000, 28_000)
+    assert provider_price_microdollars(
+        "fireworks",
+        model_id,
+        at=FIREWORKS_DSV4_FLASH_0731_PRICING_EFFECTIVE_AT,
+    ) == ProviderPrice(220_000, 660_000, 7_000)
+
+
+def test_fireworks_dsv4_flash_cutover_applies_markup_and_cache_floor() -> None:
+    endpoint = MODEL_ENDPOINTS[
+        "deepseek/deepseek-v4-flash-0731@fireworks/prepaid"
+    ]
+
+    before = effective_endpoint(
+        endpoint,
+        at=datetime(2026, 8, 22, 11, 59, 59, tzinfo=UTC),
+    )
+    after = effective_endpoint(
+        endpoint,
+        at=datetime(2026, 8, 22, 12, 0, tzinfo=UTC),
+    )
+
+    assert before.prompt_price_microdollars_per_million_tokens == 147_700
+    assert before.completion_price_microdollars_per_million_tokens == 295_400
+    assert before.price_tiers[0].prompt_cached_price_microdollars_per_million_tokens == 29_540
+    assert after.prompt_price_microdollars_per_million_tokens == 232_100
+    assert after.completion_price_microdollars_per_million_tokens == 696_300
+    assert after.price_tiers[0].prompt_cached_price_microdollars_per_million_tokens == 10_000
+
+
+def test_fireworks_dsv4_flash_schedule_is_public_and_authorization_locked() -> None:
+    assert provider_pricing_schedule(
+        "fireworks",
+        "deepseek/deepseek-v4-flash-0731",
+        at=datetime(2026, 8, 22, 12, 0, tzinfo=UTC),
+    ) == {
+        "kind": "fixed_cutover",
+        "timezone": "UTC",
+        "effective_at": "2026-08-22T12:00:00Z",
+        "current_period": "new",
+        "rate_locked_at": "authorization",
+    }
 
 
 def test_fireworks_fetch_intersects_prices_with_operator_catalog(

--- a/tests/test_provider_lifecycle_clock.py
+++ b/tests/test_provider_lifecycle_clock.py
@@ -153,6 +153,7 @@ def test_latest_scheduled_cutover_covers_every_effective_date() -> None:
     for retirement in provider_lifecycle._RETIREMENTS:
         assert retirement.effective_at <= latest, retirement.provider
     assert provider_lifecycle.DEEPSEEK_V4_PRICING_EFFECTIVE_AT <= latest
+    assert provider_lifecycle.FIREWORKS_DSV4_FLASH_0731_PRICING_EFFECTIVE_AT <= latest
     assert provider_lifecycle.PHALA_JULY_2026_EFFECTIVE_AT <= latest
     # Past the latest cutover, no retirement is still pending, which is what
     # makes the post-cutover CI job's clock the strictest one available.


### PR DESCRIPTION
## Summary
- lock Fireworks DeepSeek V4 Flash 0731 to the announced rates through 2026-08-22 12:00 UTC
- atomically switch upstream rates at the announced cutoff
- expose fixed-cutover metadata and lock each request at authorization time
- preserve the TrustedRouter markup and cached-input floor

## Verification
- `uv run ruff check src/trusted_router/provider_lifecycle.py tests/test_fireworks_pricing.py tests/test_provider_lifecycle_clock.py`
- `uv run pytest -q tests/test_fireworks_pricing.py tests/test_provider_lifecycle_clock.py` (12 passed)

The exact rates come from Fireworks notice dated 2026-08-21: before $0.14/$0.028 cached/$0.28, after $0.22/$0.007 cached/$0.66 per million tokens.