### PR TITLE
Allow confirmed Fireworks DeepSeek price transition

### DIFF
--- a/scripts/check_price_spike.py
+++ b/scripts/check_price_spike.py
@@ -86,6 +86,17 @@ APPROVED_ENDPOINT_PRICE_TRANSITIONS = frozenset(
             Decimal("0.00000028"),
             Decimal("0.00000132"),
         ),
+        # Fireworks' announced 2026-08-22 price change for DeepSeek V4 Flash
+        # 0731. The input increase remains below the generic 2x gate; pin the
+        # completion transition exactly so a parser error still fails closed:
+        # https://docs.fireworks.ai/serverless/pricing
+        (
+            "deepseek/deepseek-v4-flash-0731 "
+            "[fireworks:fireworks:accounts/fireworks/models/deepseek-v4-flash-0731]",
+            "completion",
+            Decimal("0.00000028"),
+            Decimal("0.00000066"),
+        ),
         (
             "moonshotai/kimi-k3 [tinfoil:tinfoil:kimi-k3]",
             "prompt",

--- a/tests/test_check_price_spike.py
+++ b/tests/test_check_price_spike.py
@@ -361,6 +361,90 @@ def test_different_atlas_v4_flash_0731_transition_still_blocks(
     assert "PRICE SPIKE FAILURES" in capsys.readouterr().out
 
 
+def test_confirmed_fireworks_v4_flash_0731_transition_is_allowed(
+    tmp_path: Path, capsys
+) -> None:
+    from scripts.check_price_spike import main
+
+    before = _write(
+        tmp_path,
+        "before.json",
+        _make_endpoint_snapshot(
+            ("0.00000014", "0.00000028"),
+            [
+                (
+                    "fireworks",
+                    "accounts/fireworks/models/deepseek-v4-flash-0731",
+                    "0.00000014",
+                    "0.00000028",
+                )
+            ],
+            model_id="deepseek/deepseek-v4-flash-0731",
+        ),
+    )
+    after = _write(
+        tmp_path,
+        "after.json",
+        _make_endpoint_snapshot(
+            ("0.00000022", "0.00000066"),
+            [
+                (
+                    "fireworks",
+                    "accounts/fireworks/models/deepseek-v4-flash-0731",
+                    "0.00000022",
+                    "0.00000066",
+                )
+            ],
+            model_id="deepseek/deepseek-v4-flash-0731",
+        ),
+    )
+
+    assert main([str(before), str(after), "--summary"]) == 0
+    assert "PRICE SPIKE FAILURES" not in capsys.readouterr().out
+
+
+def test_different_fireworks_v4_flash_0731_transition_still_blocks(
+    tmp_path: Path, capsys
+) -> None:
+    from scripts.check_price_spike import main
+
+    before = _write(
+        tmp_path,
+        "before.json",
+        _make_endpoint_snapshot(
+            ("0.00000014", "0.00000028"),
+            [
+                (
+                    "fireworks",
+                    "accounts/fireworks/models/deepseek-v4-flash-0731",
+                    "0.00000014",
+                    "0.00000028",
+                )
+            ],
+            model_id="deepseek/deepseek-v4-flash-0731",
+        ),
+    )
+    after = _write(
+        tmp_path,
+        "after.json",
+        _make_endpoint_snapshot(
+            ("0.00000022", "0.00000067"),
+            [
+                (
+                    "fireworks",
+                    "accounts/fireworks/models/deepseek-v4-flash-0731",
+                    "0.00000022",
+                    "0.00000067",
+                )
+            ],
+            model_id="deepseek/deepseek-v4-flash-0731",
+        ),
+    )
+
+    assert main([str(before), str(after), "--summary"]) == 1
+    assert "PRICE SPIKE FAILURES" in capsys.readouterr().out
+
+
 def test_unapproved_deepseek_price_transition_still_blocks(
     tmp_path: Path, capsys
 ) -> None:


### PR DESCRIPTION
## Summary
- approve only Fireworks DeepSeek V4 Flash 0731 completion pricing from 0.28 to 0.66 USD per million tokens
- keep the generic 2x price spike gate fail-closed for every other route and value
- add positive and near-miss regression coverage

## Verification
- uv run pytest -q tests/test_check_price_spike.py tests/test_fireworks_pricing.py
- uv run ruff check scripts/check_price_spike.py tests/test_check_price_spike.py
- git diff --check

Upstream source: https://docs.fireworks.ai/serverless/pricing