### PR TITLE
Add an ungated all-traffic calibration view to client_observed (includes synthetic)

### DIFF
--- a/clickhouse/build_public_snapshots.py
+++ b/clickhouse/build_public_snapshots.py
@@ -30,6 +30,9 @@ STATUS_LIVE_SAMPLE_LIMIT = 500
 STATUS_HOUR_ROLLUP_LIMIT = 5_000
 VIDEO_SAMPLE_LIMIT = 5_000
 CLIENT_ROLLUP_LIMIT = 100_000
+# Published rows and calibration rows are fetched by separate queries, each
+# with its own CLIENT_ROLLUP_LIMIT, so neither scope can truncate the other.
+CLIENT_ROLLUP_SCOPES = ("fleet", "fleet_all")
 
 
 def _query(
@@ -170,7 +173,14 @@ FORMAT JSONEachRow
     return samples, rollups
 
 
-def _client_reliability_rows(password: str, *, now: dt.datetime) -> list[dict[str, Any]]:
+def _client_reliability_rows(
+    password: str,
+    *,
+    now: dt.datetime,
+    scope: str = "fleet",
+) -> list[dict[str, Any]]:
+    if scope not in CLIENT_ROLLUP_SCOPES:
+        raise ValueError(f"unsupported client rollup scope: {scope}")
     cutoff_48h = (now - dt.timedelta(hours=48)).strftime("%Y-%m-%d %H:%M:%S")
     cutoff_7d = (now - dt.timedelta(days=7)).strftime("%Y-%m-%d %H:%M:%S")
     cutoff_30d = (now - dt.timedelta(days=30)).strftime("%Y-%m-%d %H:%M:%S")
@@ -179,7 +189,7 @@ def _client_reliability_rows(password: str, *, now: dt.datetime) -> list[dict[st
         f"""
 SELECT * EXCEPT computed_at
 FROM client_availability_rollups FINAL
-WHERE scope = 'fleet'
+WHERE scope = '{scope}'
   AND (
     (period = '5m' AND period_start >= toDateTime('{cutoff_48h}', 'UTC'))
     OR (period = 'hour' AND period_start >= toDateTime('{cutoff_7d}', 'UTC'))
@@ -250,6 +260,7 @@ def build_snapshots(
     status_rollups: list[SyntheticRollup] | None = None,
     client_reliability_rows: list[dict[str, Any]] | None = None,
     client_reliability_signals: dict[str, Any] | None = None,
+    client_reliability_all_traffic_rows: list[dict[str, Any]] | None = None,
 ) -> dict[str, dict[str, Any]]:
     leaderboard = aggregate_leaderboard(
         samples,
@@ -306,6 +317,11 @@ def build_snapshots(
         _client_rows_by_window(client_reliability_rows or [], now=snapshot_now),
         snapshot_now,
         signals=client_reliability_signals,
+        all_traffic_rows_by_window=(
+            _client_rows_by_window(client_reliability_all_traffic_rows, now=snapshot_now)
+            if client_reliability_all_traffic_rows is not None
+            else None
+        ),
     )
     return {
         "leaderboard": leaderboard,
@@ -331,6 +347,9 @@ def main() -> int:
         status_rollups=status_rollups,
         client_reliability_rows=_client_reliability_rows(password, now=now),
         client_reliability_signals=_client_reliability_signals(password, now=now),
+        client_reliability_all_traffic_rows=_client_reliability_rows(
+            password, now=now, scope="fleet_all"
+        ),
     )
     rows = [
         {

--- a/clickhouse/rollup_client_events.py
+++ b/clickhouse/rollup_client_events.py
@@ -267,10 +267,14 @@ def _merge_accumulator(target: dict[str, Any], source: Mapping[str, Any]) -> Non
         _merge_histogram(target[field], source.get(field))
 
 
-def _coverage_by_tenant(rows: Iterable[Mapping[str, Any]]) -> dict[str, int]:
+def _coverage_by_tenant(
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    include_synthetic: bool = False,
+) -> dict[str, int]:
     result: dict[str, int] = {}
     for row in rows:
-        if bool(row.get("synthetic")):
+        if not include_synthetic and bool(row.get("synthetic")):
             continue
         tenant = str(row.get("tenant_id") or "")
         result[tenant] = result.get(tenant, 0) + int(row.get("requests") or 0)
@@ -325,7 +329,13 @@ def aggregate_client_rollups(
     period_start: dt.datetime,
     computed_at: dt.datetime,
 ) -> list[dict[str, Any]]:
-    """Aggregate one period for tenant and capped, non-synthetic fleet scopes."""
+    """Aggregate one period for the tenant, fleet, and fleet_all scopes.
+
+    ``fleet`` is the published methodology: synthetic traffic excluded, each
+    tenant capped at 25 % of the window. ``fleet_all`` is the calibration
+    view: every counter row including synthetic canary traffic, no cap, no
+    scaling. Adding it changes nothing about the tenant or fleet rows.
+    """
 
     period_start = _floor(period_start, period)
     period_end = period_start + _period_delta(period)
@@ -394,6 +404,37 @@ def aggregate_client_rollups(
                 distinct_tenants=contributors,
                 capped_requests=(total_capped if facet == ("", "", "") else facet_capped),
                 coverage_requests=sum(coverage_tenants.values()),
+                computed_at=computed_at,
+            )
+        )
+
+    # Calibration scope: the tenant accumulators already hold every counter
+    # row, synthetic included, so the all-traffic view is their plain sum.
+    # No per-tenant cap and no scaling, so capped_requests is 0 by
+    # construction, and coverage counts synthetic generations too.
+    all_traffic_coverage = sum(_coverage_by_tenant(coverage, include_synthetic=True).values())
+    all_traffic_facets = {facet for facets in tenant_groups.values() for facet in facets}
+    for facet in sorted(all_traffic_facets):
+        accumulator = _new_accumulator()
+        contributors = 0
+        for facets in tenant_groups.values():
+            source = facets.get(facet)
+            if source is None:
+                continue
+            _merge_accumulator(accumulator, source)
+            if int(source.get("requests") or 0):
+                contributors += 1
+        result.append(
+            _render_rollup(
+                accumulator,
+                period=period,
+                period_start=period_start,
+                scope="fleet_all",
+                tenant_id="",
+                facet=facet,
+                distinct_tenants=contributors,
+                capped_requests=0,
+                coverage_requests=all_traffic_coverage,
                 computed_at=computed_at,
             )
         )

--- a/docs/client-telemetry.md
+++ b/docs/client-telemetry.md
@@ -299,6 +299,13 @@ after those lines only a message string remains. TTFT is only observable in the 
   recompute the trailing 6 h every 5 min (matching the late-arrival cap); `age_ms > 6 h` excluded from rollups.
 - Own id `client_observed`; never inside `router_core` or `SLO_DEFINITIONS`. Calibration gate: 14 clean days
   before any percentage is published.
+- **Calibration view (`client_observed.all_traffic` on `/status.json`; labelled on `/status`).** Beside the
+  published windows, the status page carries an explicitly labelled all-traffic view built from the `fleet_all`
+  rollup scope: every counter row **including synthetic canary traffic**, **no** 25 % per-tenant cap, **no**
+  ≥ 1 000-request / ≥ 3-tenant gate, so its `availability_percent` is shown whenever the denominator is
+  non-empty. It exists so the pipeline can be read end to end while real SDK traffic is scarce. It is **not the
+  published number**: `windows`, `state`, `by_host_24h`, and `canary` are computed exactly as above and never
+  read `fleet_all` rows. It is kept or removed by an explicit decision after calibration.
 
 ## 9. Rollout ordering (why it is not arbitrary)
 1. Enclave request ids (independent). 2. Control plane accepts settle context (extras reach customer broadcast

--- a/src/trusted_router/client_reliability.py
+++ b/src/trusted_router/client_reliability.py
@@ -8,6 +8,12 @@ from collections.abc import Iterable, Mapping, Sequence
 from typing import Any
 
 METHODOLOGY_VERSION = 1
+WINDOW_NAMES = ("5m", "1h", "24h", "7d", "30d")
+#: Fixed public disclosure carried on ``client_observed.all_traffic``.
+ALL_TRAFFIC_NOTE = (
+    "Calibration view; includes synthetic canary traffic; uncapped; ungated; "
+    "not the published methodology."
+)
 
 HOSTS = (
     "apex",
@@ -19,6 +25,7 @@ HOSTS = (
     "control",
     "custom",
 )
+SDKS = ("tr-py", "tr-js", "tr-go", "tr-rust", "tr-java", "tr-swift")
 ENDPOINTS = (
     "chat_completions",
     "messages",
@@ -249,7 +256,9 @@ def _total_rows(rows: Sequence[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
     return totals or list(rows)
 
 
-def _window(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+def _window(rows: Sequence[Mapping[str, Any]], *, gated: bool = True) -> dict[str, Any]:
+    """Summarize one window; ``gated`` applies the publication thresholds."""
+
     rows = _total_rows(rows)
     requests = sum(_int(row, "requests") for row in rows)
     successes = sum(_int(row, "successes") for row in rows)
@@ -259,17 +268,16 @@ def _window(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     measured = availability(successes, tr_fault)
     total_hist = _merge_histograms(rows, "total_ms_hist")
     first_event_hist = _merge_histograms(rows, "first_event_ms_hist")
+    availability_percent: float | None = None
+    if measured is not None and (not gated or (requests >= 1_000 and distinct_tenants >= 3)):
+        availability_percent = round(measured * 100, 4)
     return {
         "requests": requests,
         "successes": successes,
         "tr_fault": tr_fault,
         "excluded": sum(_int(row, "excluded_failures") for row in rows),
         "aborted": sum(_int(row, "aborted") for row in rows),
-        "availability_percent": (
-            round(measured * 100, 4)
-            if measured is not None and requests >= 1_000 and distinct_tenants >= 3
-            else None
-        ),
+        "availability_percent": availability_percent,
         "distinct_tenants": distinct_tenants,
         "coverage": (round(successes / coverage_requests, 4) if coverage_requests else None),
         "p50_total_ms": histogram_percentile(total_hist, 50),
@@ -490,11 +498,37 @@ def _status_host_breakdown(value: Any) -> dict[str, dict[str, Any]]:
     return result
 
 
+def _status_sdk_breakdown(value: Any) -> dict[str, int]:
+    rows = value if isinstance(value, Mapping) else {}
+    return {sdk: max(0, _int(rows, sdk)) for sdk in SDKS if sdk in rows}
+
+
 def _status_canary(value: Any) -> dict[str, Any]:
     row = value if isinstance(value, Mapping) else {}
     return {
         "last_seen_age_seconds": _optional_float(row.get("last_seen_age_seconds")),
         "last_24h_count": max(0, _int(row, "last_24h_count")),
+    }
+
+
+def _status_all_traffic(value: Any) -> dict[str, Any] | None:
+    """Project the calibration view; ``None`` when the snapshot predates it."""
+
+    if not isinstance(value, Mapping):
+        return None
+    raw_windows = value.get("windows")
+    windows = raw_windows if isinstance(raw_windows, Mapping) else {}
+    return {
+        "includes_synthetic": True,
+        "gated": False,
+        "note": ALL_TRAFFIC_NOTE,
+        # Ungated by construction and labelled as such, so the percentage
+        # passes through regardless of the publication state.
+        "windows": {
+            name: _status_window(windows.get(name), published=True) for name in WINDOW_NAMES
+        },
+        "by_host_24h": _status_host_breakdown(value.get("by_host_24h")),
+        "by_sdk_24h": _status_sdk_breakdown(value.get("by_sdk_24h")),
     }
 
 
@@ -528,11 +562,36 @@ def client_observed_status_section(
         "methodology_version": _optional_int(snapshot.get("methodology_version")),
         "windows": {
             name: _status_window(windows.get(name), published=published)
-            for name in ("5m", "1h", "24h", "7d", "30d")
+            for name in WINDOW_NAMES
         },
         "by_host_24h": _status_host_breakdown(snapshot.get("by_host_24h")),
         "canary": _status_canary(snapshot.get("canary")),
+        # Tolerates a snapshot built by a worker that predates the calibration
+        # view: the control plane deploys before the ClickHouse node does.
+        "all_traffic": _status_all_traffic(snapshot.get("all_traffic")),
         "generated_at": generated_at if isinstance(generated_at, str) else None,
+    }
+
+
+def _all_traffic_section(
+    rows_by_window: Mapping[str, Iterable[Mapping[str, Any]]],
+) -> dict[str, Any]:
+    """Ungated, uncapped summary of fleet_all rollups, synthetic included.
+
+    A calibration aid while real SDK traffic is scarce: the pipeline can be
+    read end to end without touching the published methodology, which stays
+    gated, capped, and synthetic-free in ``windows``.
+    """
+
+    windows = {
+        name: [dict(row) for row in rows_by_window.get(name, ())] for name in WINDOW_NAMES
+    }
+    return {
+        "includes_synthetic": True,
+        "gated": False,
+        "windows": {name: _window(rows, gated=False) for name, rows in windows.items()},
+        "by_host_24h": _host_breakdown(windows["24h"]),
+        "by_sdk_24h": _sdk_breakdown(windows["24h"]),
     }
 
 
@@ -541,8 +600,14 @@ def build_client_reliability(
     now: dt.datetime,
     *,
     signals: Mapping[str, Any] | None = None,
+    all_traffic_rows_by_window: Mapping[str, Iterable[Mapping[str, Any]]] | None = None,
 ) -> dict[str, Any]:
-    """Build the content-free public snapshot from bounded fleet rollups."""
+    """Build the content-free public snapshot from bounded fleet rollups.
+
+    ``all_traffic_rows_by_window`` carries the ``fleet_all`` rollups; when it
+    is given the snapshot gains an ``all_traffic`` calibration section and
+    nothing else changes.
+    """
 
     if now.tzinfo is None:
         now = now.replace(tzinfo=dt.UTC)
@@ -550,7 +615,7 @@ def build_client_reliability(
         now = now.astimezone(dt.UTC)
     windows = {
         name: [dict(row) for row in rows_by_window.get(name, ())]
-        for name in ("5m", "1h", "24h", "7d", "30d")
+        for name in WINDOW_NAMES
     }
     watch_15m_rows = [
         dict(row)
@@ -559,7 +624,7 @@ def build_client_reliability(
     signal_row = signals or {}
     canary_last_received_at = _parse_timestamp(signal_row.get("canary_last_received_at"))
     newest_received_at = _parse_timestamp(signal_row.get("newest_received_at"))
-    return {
+    snapshot: dict[str, Any] = {
         "generated_at": now.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
         "methodology_version": METHODOLOGY_VERSION,
         "published": False,
@@ -584,3 +649,6 @@ def build_client_reliability(
             "by_host_7d": _watch_7d(windows["7d"]),
         },
     }
+    if all_traffic_rows_by_window is not None:
+        snapshot["all_traffic"] = _all_traffic_section(all_traffic_rows_by_window)
+    return snapshot

--- a/src/trusted_router/templates/public/status.html
+++ b/src/trusted_router/templates/public/status.html
@@ -96,6 +96,24 @@
           {% endfor %}
         </div>
       </div>
+      {% if client_observed.all_traffic %}
+      {% set all_traffic_24h = client_observed.all_traffic.windows["24h"] %}
+      <div class="component-row" data-calibration-view>
+        <div class="component-main">
+          <div>
+            <h3>24h all traffic</h3>
+            <p>calibration view — includes synthetic canary traffic; not the published number</p>
+          </div>
+          <span class="component-status status-unknown">calibration</span>
+        </div>
+        <div class="slo-metrics" aria-label="Client-observed all-traffic calibration view, 24h">
+          <span>Availability <strong>{% if all_traffic_24h.availability_percent is not none %}{{ '%.4f'|format(all_traffic_24h.availability_percent) }}%{% else %}n/a{% endif %}</strong></span>
+          <span>Requests <strong>{{ all_traffic_24h.requests }}</strong></span>
+          <span>p50 total <strong>{% if all_traffic_24h.p50_total_ms is not none %}{{ all_traffic_24h.p50_total_ms }} ms{% else %}n/a{% endif %}</strong></span>
+          <span>p95 total <strong>{% if all_traffic_24h.p95_total_ms is not none %}{{ all_traffic_24h.p95_total_ms }} ms{% else %}n/a{% endif %}</strong></span>
+        </div>
+      </div>
+      {% endif %}
       {% if client_observed.by_host_24h %}
       <div class="component-row">
         <div class="component-main">

--- a/tests/test_clickhouse_client_rollup.py
+++ b/tests/test_clickhouse_client_rollup.py
@@ -178,3 +178,107 @@ def test_recompute_dry_run_computes_but_never_inserts() -> None:
     assert summary["rollups"] > 0
     assert executor.inserted == []
     assert not any(sql.startswith("INSERT INTO") for sql in executor.queries)
+
+
+def _total_row(result: list[dict[str, Any]], scope: str) -> dict[str, Any]:
+    return next(
+        row
+        for row in result
+        if row["scope"] == scope and row["host"] == row["endpoint"] == row["sdk"] == ""
+    )
+
+
+def test_fleet_all_scope_is_uncapped_and_synthetic_inclusive_beside_unchanged_fleet_rows() -> None:
+    """fleet_all sums every counter row with no cap; the fleet rows do not see it.
+
+    t0 sends 80 of the 155 non-synthetic requests, so the published fleet row
+    caps it at 25 % (38) and reports the 42 capped requests; the canary tenant
+    is excluded there entirely. The calibration row keeps all 205 requests.
+    """
+    rows = [
+        _counter(
+            "t0",
+            requests=80,
+            first_attempt_success=80,
+            total_ms_hist={"lt200": 80},
+            first_event_ms_hist={"lt100": 80},
+        ),
+        *(_counter(f"t{index}") for index in range(1, 4)),
+        _counter(
+            "synthetic",
+            synthetic=1,
+            requests=50,
+            first_attempt_success=50,
+            total_ms_hist={"lt200": 50},
+            first_event_ms_hist={"lt100": 50},
+        ),
+    ]
+    coverage = [
+        _coverage("t0", requests=80),
+        *(_coverage(f"t{index}") for index in range(1, 4)),
+        _coverage("synthetic", requests=50, synthetic=1),
+    ]
+    arguments: dict[str, Any] = {
+        "period": "5m",
+        "period_start": START,
+        "computed_at": START + dt.timedelta(minutes=1),
+    }
+
+    with_synthetic = aggregate_client_rollups(rows, coverage, **arguments)
+    without_synthetic = aggregate_client_rollups(
+        [row for row in rows if not row["synthetic"]],
+        [row for row in coverage if not row["synthetic"]],
+        **arguments,
+    )
+
+    fleet = _total_row(with_synthetic, "fleet")
+    assert fleet["requests"] == 113
+    assert fleet["successes"] == 113
+    assert fleet["capped_requests"] == 42
+    assert fleet["distinct_tenants"] == 4
+    assert fleet["coverage_requests"] == 155
+
+    def fleet_rows(result: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return sorted((row for row in result if row["scope"] == "fleet"), key=lambda row: row["id"])
+
+    assert fleet_rows(with_synthetic) == fleet_rows(without_synthetic)
+
+    all_traffic = _total_row(with_synthetic, "fleet_all")
+    assert all_traffic["requests"] == 205
+    assert all_traffic["successes"] == 205
+    assert all_traffic["first_attempt_success"] == 205
+    assert all_traffic["capped_requests"] == 0
+    assert all_traffic["distinct_tenants"] == 5
+    assert all_traffic["coverage_requests"] == 205
+    assert all_traffic["total_ms_hist"] == {"lt200": 205}
+    assert all_traffic["first_event_ms_hist"] == {"lt100": 205}
+    assert all_traffic["tenant_id"] == ""
+    assert all_traffic["methodology_version"] == fleet["methodology_version"]
+    assert all_traffic["id"] != fleet["id"]
+    assert len({row["id"] for row in with_synthetic}) == len(with_synthetic)
+    assert {row["scope"] for row in with_synthetic} == {"tenant", "fleet", "fleet_all"}
+    assert sorted(
+        (row["host"], row["endpoint"], row["sdk"])
+        for row in with_synthetic
+        if row["scope"] == "fleet_all"
+    ) == sorted((row["host"], row["endpoint"], row["sdk"]) for row in fleet_rows(with_synthetic))
+
+
+def test_recompute_writes_fleet_all_rows_beside_the_published_rows() -> None:
+    from clickhouse.rollup_client_events import recompute
+
+    executor = _Executor(
+        [_counter("t1"), _counter("synthetic", synthetic=1, requests=50)],
+        [_coverage("t1"), _coverage("synthetic", requests=50, synthetic=1)],
+    )
+
+    recompute(executor, now=START + dt.timedelta(minutes=7))  # type: ignore[arg-type]
+
+    five_minute = [row for row in executor.inserted if row["period"] == "5m"]
+    # One real tenant is capped at 25 % of its own 25 requests; the canary is
+    # excluded. The calibration row is the plain sum of both.
+    fleet = _total_row(five_minute, "fleet")
+    assert (fleet["requests"], fleet["capped_requests"], fleet["distinct_tenants"]) == (6, 19, 1)
+    all_traffic = _total_row(five_minute, "fleet_all")
+    assert (all_traffic["requests"], all_traffic["capped_requests"]) == (75, 0)
+    assert all_traffic["distinct_tenants"] == 2

--- a/tests/test_client_reliability.py
+++ b/tests/test_client_reliability.py
@@ -464,3 +464,158 @@ def test_tenant_summary_uses_one_rollup_granularity_and_exact_counts() -> None:
         "attempt_tr_fault": 3,
         "rate": 0.027273,
     }
+
+
+def _below_gates(**updates: Any) -> dict[str, Any]:
+    value: dict[str, Any] = {
+        "requests": 50,
+        "successes": 49,
+        "tr_fault_failures": 1,
+        "excluded_failures": 0,
+        "aborted": 0,
+        "distinct_tenants": 1,
+        "coverage_requests": 60,
+        "total_ms_hist": {"lt800": 50},
+        "first_event_ms_hist": {"lt400": 50},
+    }
+    value.update(updates)
+    return _rollup(**value)
+
+
+def test_all_traffic_window_is_ungated_while_the_official_window_stays_gated() -> None:
+    now = dt.datetime(2026, 8, 21, 12, tzinfo=dt.UTC)
+    official_rows = {"24h": [_below_gates()]}
+    all_traffic_rows = {
+        "24h": [
+            _below_gates(),
+            _below_gates(host="apex", requests=0, attempts=60, attempt_tr_fault=3),
+            _below_gates(sdk="tr-py"),
+        ]
+    }
+
+    official_only = build_client_reliability(official_rows, now)
+    snapshot = build_client_reliability(
+        official_rows,
+        now,
+        all_traffic_rows_by_window=all_traffic_rows,
+    )
+
+    assert "all_traffic" not in official_only
+    assert {key: value for key, value in snapshot.items() if key != "all_traffic"} == official_only
+    assert snapshot["published"] is False
+    assert snapshot["windows"]["24h"]["requests"] == 50
+    assert snapshot["windows"]["24h"]["availability_percent"] is None
+    all_traffic = snapshot["all_traffic"]
+    assert all_traffic["includes_synthetic"] is True
+    assert all_traffic["gated"] is False
+    window = all_traffic["windows"]["24h"]
+    assert window["requests"] == 50
+    assert window["distinct_tenants"] == 1
+    assert window["availability_percent"] == 98.0
+    assert window["coverage"] == 0.8167
+    assert window["p50_total_ms"] == 800
+    assert window["p50_ttft_ms"] == 400
+    assert all_traffic["windows"]["5m"]["availability_percent"] is None
+    assert all_traffic["by_host_24h"]["apex"] == {
+        "attempts": 60,
+        "attempt_tr_fault": 3,
+        "rate": 0.05,
+    }
+    assert all_traffic["by_sdk_24h"] == {"tr-py": 50}
+
+
+def test_client_observed_status_exposes_all_traffic_and_leaves_official_fields_unchanged() -> None:
+    now = dt.datetime(2026, 8, 17, 12, tzinfo=dt.UTC)
+    all_traffic = {
+        "includes_synthetic": True,
+        "gated": False,
+        "windows": {
+            "24h": {
+                "requests": 8_956,
+                "successes": 8_956,
+                "tr_fault": 0,
+                "excluded": 0,
+                "aborted": 0,
+                "distinct_tenants": 1,
+                "coverage": 1.0,
+                "p50_total_ms": 800,
+                "p95_total_ms": 1_600,
+                "p50_ttft_ms": 400,
+                "availability_percent": 100.0,
+                "tenant_id": "private-all-traffic-tenant",
+            }
+        },
+        "by_host_24h": {
+            "apex": {"attempts": 9_000, "attempt_tr_fault": 4, "tenant_id": "private-host"},
+            "private-tenant": {"attempts": 1, "attempt_tr_fault": 1},
+        },
+        "by_sdk_24h": {"tr-py": 8_956},
+    }
+
+    official = client_observed_status_section(_public_snapshot(), now=now)
+    section = client_observed_status_section(
+        _public_snapshot(all_traffic=all_traffic),
+        now=now,
+    )
+
+    assert official["all_traffic"] is None
+    assert {key: value for key, value in section.items() if key != "all_traffic"} == {
+        key: value for key, value in official.items() if key != "all_traffic"
+    }
+    assert section["state"] == "calibrating"
+    assert section["windows"]["24h"]["availability_percent"] is None
+    view = section["all_traffic"]
+    assert set(view) == {
+        "includes_synthetic",
+        "gated",
+        "note",
+        "windows",
+        "by_host_24h",
+        "by_sdk_24h",
+    }
+    assert view["includes_synthetic"] is True
+    assert view["gated"] is False
+    assert view["note"] == (
+        "Calibration view; includes synthetic canary traffic; uncapped; ungated; "
+        "not the published methodology."
+    )
+    assert view["windows"]["24h"]["availability_percent"] == 100.0
+    assert view["windows"]["24h"]["requests"] == 8_956
+    assert view["windows"]["24h"]["p95_total_ms"] == 1_600
+    assert view["windows"]["5m"]["requests"] == 0
+    assert view["windows"]["5m"]["availability_percent"] is None
+    assert view["by_host_24h"] == {
+        "apex": {"attempts": 9_000, "attempt_tr_fault": 4, "rate": 0.000444}
+    }
+    assert view["by_sdk_24h"] == {"tr-py": 8_956}
+    encoded = json.dumps(section, sort_keys=True)
+    assert "tenant_id" not in encoded
+    assert "private-" not in encoded
+
+
+@pytest.mark.parametrize(
+    ("updates", "expected"),
+    [
+        ({}, None),
+        ({"all_traffic": None}, None),
+        ({"all_traffic": "junk"}, None),
+        ({"all_traffic": {"windows": "junk"}}, 0),
+    ],
+)
+def test_client_observed_status_tolerates_a_snapshot_without_all_traffic(
+    updates: dict[str, Any],
+    expected: int | None,
+) -> None:
+    section = client_observed_status_section(
+        _public_snapshot(**updates),
+        now=dt.datetime(2026, 8, 17, 12, tzinfo=dt.UTC),
+    )
+
+    assert section["available"] is True
+    assert section["state"] == "calibrating"
+    assert section["windows"]["24h"]["requests"] == 1_000
+    if expected is None:
+        assert section["all_traffic"] is None
+    else:
+        assert section["all_traffic"]["windows"]["24h"]["requests"] == expected
+        assert section["all_traffic"]["windows"]["24h"]["availability_percent"] is None

--- a/tests/test_public_analytics_snapshots.py
+++ b/tests/test_public_analytics_snapshots.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import datetime as dt
+import json
 import os
 import subprocess
 import sys
 import textwrap
 from pathlib import Path
+from typing import Any
+
+import pytest
 
 import clickhouse.build_public_snapshots as snapshot_builder
 from clickhouse.build_public_snapshots import _clickhouse_string_array, build_snapshots
@@ -231,3 +235,128 @@ def test_status_page_uses_shared_inputs_without_raw_scan(monkeypatch) -> None:
 
     assert snapshot["monitor_freshness"]["is_stale"] is False
     assert any(sample["id"] == "status-live" for sample in snapshot["samples"])
+
+
+def test_client_reliability_rows_are_fetched_per_scope_with_separate_limits(monkeypatch) -> None:
+    queries: list[str] = []
+
+    def fake_query(_password: str, sql: str, **_kwargs: object) -> str:
+        queries.append(sql)
+        return '{"scope":"x"}\n'
+
+    monkeypatch.setattr(snapshot_builder, "_query", fake_query)
+    now = dt.datetime(2026, 8, 21, 12, tzinfo=dt.UTC)
+
+    published = snapshot_builder._client_reliability_rows("test-password", now=now)
+    calibration = snapshot_builder._client_reliability_rows(
+        "test-password", now=now, scope="fleet_all"
+    )
+
+    assert published == calibration == [{"scope": "x"}]
+    published_sql, calibration_sql = queries
+    assert "WHERE scope = 'fleet'\n" in published_sql
+    assert "WHERE scope = 'fleet_all'\n" in calibration_sql
+    limit = f"LIMIT {snapshot_builder.CLIENT_ROLLUP_LIMIT}"
+    assert published_sql.count(limit) == 1
+    assert calibration_sql.count(limit) == 1
+    with pytest.raises(ValueError, match="scope"):
+        snapshot_builder._client_reliability_rows("test-password", now=now, scope="tenant")
+
+
+def _client_rollup(scope: str, **updates: Any) -> dict[str, Any]:
+    value: dict[str, Any] = {
+        "period": "hour",
+        "period_start": "2026-08-15T08:00:00Z",
+        "scope": scope,
+        "host": "",
+        "endpoint": "",
+        "sdk": "",
+        "requests": 50,
+        "successes": 49,
+        "tr_fault_failures": 1,
+        "excluded_failures": 0,
+        "aborted": 0,
+        "attempts": 50,
+        "attempt_tr_fault": 1,
+        "distinct_tenants": 1,
+        "capped_requests": 0,
+        "coverage_requests": 60,
+        "total_ms_hist": {"lt800": 50},
+        "first_event_ms_hist": {"lt400": 50},
+    }
+    value.update(updates)
+    return value
+
+
+def test_snapshot_builder_adds_all_traffic_without_touching_the_published_payload() -> None:
+    generated_at = "2026-08-15T09:00:00Z"
+    published = _client_rollup("fleet")
+    calibration = _client_rollup(
+        "fleet_all",
+        requests=5_000,
+        successes=4_990,
+        tr_fault_failures=10,
+        coverage_requests=5_100,
+    )
+
+    without = build_snapshots([], generated_at=generated_at, client_reliability_rows=[published])
+    with_all = build_snapshots(
+        [],
+        generated_at=generated_at,
+        client_reliability_rows=[published],
+        client_reliability_all_traffic_rows=[calibration],
+    )
+
+    assert "all_traffic" not in without["client_reliability"]
+    payload = with_all["client_reliability"]
+    assert {key: value for key, value in payload.items() if key != "all_traffic"} == (
+        without["client_reliability"]
+    )
+    assert payload["windows"]["24h"]["requests"] == 50
+    assert payload["windows"]["24h"]["availability_percent"] is None
+    assert payload["all_traffic"]["includes_synthetic"] is True
+    assert payload["all_traffic"]["gated"] is False
+    assert payload["all_traffic"]["windows"]["24h"]["requests"] == 5_000
+    assert payload["all_traffic"]["windows"]["24h"]["availability_percent"] == 99.8
+    assert payload["all_traffic"]["windows"]["24h"]["coverage"] == 0.9784
+
+
+def test_snapshot_worker_main_wires_both_rollup_scopes_into_one_insert(monkeypatch) -> None:
+    queries: list[str] = []
+    inserted: list[bytes] = []
+
+    def fake_query(
+        _password: str,
+        sql: str,
+        *,
+        input_bytes: bytes | None = None,
+        params: dict[str, str] | None = None,
+    ) -> str:
+        _ = params
+        queries.append(sql)
+        if sql.startswith("INSERT INTO public_analytics_snapshots"):
+            assert input_bytes is not None
+            inserted.append(input_bytes)
+        return ""
+
+    monkeypatch.setattr(snapshot_builder, "_query", fake_query)
+    monkeypatch.setenv("CH_PASSWORD", "test-password")
+
+    assert snapshot_builder.main() == 0
+
+    rollup_queries = [sql for sql in queries if "FROM client_availability_rollups FINAL" in sql]
+    assert sorted(sql.split("WHERE scope = ", 1)[1].split("\n", 1)[0] for sql in rollup_queries) == [
+        "'fleet'",
+        "'fleet_all'",
+    ]
+    [body] = inserted
+    payloads = {
+        json.loads(line)["name"]: json.loads(json.loads(line)["payload"])
+        for line in body.decode().splitlines()
+    }
+    client = payloads["client_reliability"]
+    assert client["published"] is False
+    assert client["all_traffic"]["includes_synthetic"] is True
+    assert client["all_traffic"]["gated"] is False
+    assert set(client["all_traffic"]["windows"]) == {"5m", "1h", "24h", "7d", "30d"}
+    assert set(client["windows"]) == {"5m", "1h", "24h", "7d", "30d"}

--- a/tests/test_public_client_reliability.py
+++ b/tests/test_public_client_reliability.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+from typing import Any
 
 from fastapi.testclient import TestClient
 
@@ -96,3 +97,81 @@ def test_telemetry_contract_is_public_and_registered_everywhere(client: TestClie
     assert 'href="/docs/telemetry"' in docs.text
     assert "https://trustedrouter.com/docs/telemetry" in sitemap.text
     assert "/docs/telemetry" in llms.text
+
+
+CALIBRATION_LABEL = (
+    "calibration view — includes synthetic canary traffic; not the published number"
+)
+
+
+def _client_snapshot(**updates: Any) -> dict[str, Any]:
+    value: dict[str, Any] = {
+        "generated_at": dt.datetime.now(dt.UTC).isoformat().replace("+00:00", "Z"),
+        "methodology_version": 1,
+        "published": False,
+        "freshness": {"age_seconds": 0},
+        "windows": {"24h": {"requests": 0, "successes": 0, "tr_fault": 0, "distinct_tenants": 0}},
+    }
+    value.update(updates)
+    return value
+
+
+def _status_snapshot_with_client(monkeypatch, client_payload: dict[str, Any]) -> dict[str, Any]:
+    monkeypatch.setattr(
+        public_routes,
+        "_precomputed_public_analytics_snapshot",
+        lambda name: client_payload if name == "client_reliability" else None,
+    )
+    monkeypatch.setattr(public_routes, "_status_samples", lambda **_kwargs: [])
+    monkeypatch.setattr(public_routes, "_status_rollups", lambda _window: [])
+    monkeypatch.setattr(public_routes, "_STATUS_CACHE", None)
+    return public_routes._status_snapshot(Settings(environment="local"))
+
+
+def test_status_html_labels_the_all_traffic_calibration_view(
+    client: TestClient,
+    monkeypatch,
+) -> None:
+    all_traffic = {
+        "windows": {
+            "24h": {
+                "requests": 8_956,
+                "successes": 8_956,
+                "tr_fault": 0,
+                "distinct_tenants": 1,
+                "availability_percent": 100.0,
+                "p50_total_ms": 800,
+                "p95_total_ms": 1_600,
+            }
+        }
+    }
+    snapshot = _status_snapshot_with_client(monkeypatch, _client_snapshot(all_traffic=all_traffic))
+    assert snapshot["client_observed"]["all_traffic"]["windows"]["24h"]["requests"] == 8_956
+    monkeypatch.setattr(public_routes, "_status_snapshot", lambda _settings: snapshot)
+
+    response = client.get("/status")
+
+    assert response.status_code == 200
+    assert CALIBRATION_LABEL in response.text
+    assert "100.0000%" in response.text
+    assert "<strong>8956</strong>" in response.text
+    assert "800 ms" in response.text
+    assert "1600 ms" in response.text
+    # The published window on the same page is still gated.
+    assert "insufficient data — 0 requests from 0 tenants" in response.text
+
+
+def test_status_html_tolerates_a_client_snapshot_without_all_traffic(
+    client: TestClient,
+    monkeypatch,
+) -> None:
+    snapshot = _status_snapshot_with_client(monkeypatch, _client_snapshot())
+    assert snapshot["client_observed"]["all_traffic"] is None
+    monkeypatch.setattr(public_routes, "_status_snapshot", lambda _settings: snapshot)
+
+    response = client.get("/status")
+
+    assert response.status_code == 200
+    assert CALIBRATION_LABEL not in response.text
+    assert "<h2>Client-observed availability</h2>" in response.text
+    assert "insufficient data — 0 requests from 0 tenants" in response.text


### PR DESCRIPTION
Adds an explicitly labelled **calibration view** of client-observed reliability beside the untouched published methodology. Owner decision (2026-08-21): with very few SDK users, all production beacon data is the synthetic canary, and the official `client_observed` windows are zero by construction (fleet excludes synthetic; 25 % per-tenant cap; ≥1 000 requests / ≥3 tenants; `published` false). Observed on tr-clickhouse-1 the same day: `client_minute_counters` holds only synthetic `tr-py` rows (8 956 requests, one tenant) and `client_availability_rollups` holds **no** `scope='fleet'` rows at all.

## Authorship and review

Authored by codex-cli from a written spec; reviewed by Claude (Fable): production hunks read in full; focused gates re-run by the reviewer (`ruff` clean; `test_client_reliability`, `test_public_client_reliability`, `test_clickhouse_client_rollup`, `test_public_analytics_snapshots`: **71 passed**). Author's full-repo gates: `ruff` clean, `mypy` clean (291 files), `pytest` **5 121 passed, 301 skipped, 10 xfailed**; every new test mutation-checked (scope rename, single-scope snapshot queries, suppressed all-traffic argument, re-enabled gates, dropped `by_sdk_24h`, raising on absent `all_traffic`, replaced disclosure label — each killed its test).

## What changes

- `clickhouse/rollup_client_events.py` — new scope `fleet_all`: the plain sum of every counter row **including synthetic**, no per-tenant cap, no scaling (`capped_requests=0` by construction), `distinct_tenants` counts synthetic contributors, `coverage_requests` includes synthetic. `tenant` and `fleet` rows are unchanged.
- `clickhouse/build_public_snapshots.py` — fetches `fleet` and `fleet_all` with **separate** bounded queries (each its own `CLIENT_ROLLUP_LIMIT`) so neither scope can truncate the other; passes the calibration rows as `all_traffic_rows_by_window`.
- `src/trusted_router/client_reliability.py` — `build_client_reliability(..., all_traffic_rows_by_window=None)` adds an `all_traffic` section (`_window(gated=False)`); the public projection exposes `client_observed.all_traffic` = `{includes_synthetic: true, gated: false, note: "Calibration view; includes synthetic canary traffic; uncapped; ungated; not the published methodology.", windows{5m,1h,24h,7d,30d}, by_host_24h, by_sdk_24h}` with `availability_percent` shown whenever the denominator is non-empty. Official `state`, `windows`, `by_host_24h`, `canary` are derived only from `fleet`, exactly as before. A snapshot that predates this feature yields `all_traffic: null` — the route never breaks.
- `templates/public/status.html` — a row labelled **"calibration view — includes synthetic canary traffic; not the published number"** (24 h availability, requests, p50/p95 total), omitted when `all_traffic` is null.
- `docs/client-telemetry.md` §8 — discloses the view in the methodology (kept or removed by explicit decision after calibration).

Public keys stay closed vocabularies (hosts from `HOSTS`; SDK keys from the six `tr-*` names); nothing tenant-identifying is added.

## Deploy ordering — read before merging

- Merging auto-deploys Cloud Run (`deploy.yml` `paths:` includes `src/**`). The deploy workflow also runs `scripts/deploy/sync_public_analytics_snapshots.sh --apply`, which copies `clickhouse/build_public_snapshots.py` and `src/trusted_router` to `/opt/tr-clickhouse` on `tr-clickhouse-1` — so the snapshot builder and the projection update automatically.
- That sync does **not** copy `clickhouse/rollup_client_events.py`, and no CI workflow deploys it. After merge an operator must run `scripts/deploy/clickhouse_operational_analytics.sh --apply` so the VM's `tr-clickhouse-client-rollup.timer` runs the new worker; `fleet_all` rows appear on its next run and the snapshot timer then publishes them. Until then `/status` shows the calibration row as absent (null), by design.

Companion PR: the `tr_control_read` grants fix (separate branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
