### PR TITLE
Grant tr_control_read SELECT on the client telemetry tables

### DIFF
--- a/scripts/deploy/clickhouse_control_reader.sh
+++ b/scripts/deploy/clickhouse_control_reader.sh
@@ -53,6 +53,9 @@ sed "s/__PASSWORD_SHA256__/${reader_hash}/g" >"$config" <<'XML'
         <query>GRANT SELECT ON tr.synthetic_probe_samples</query>
         <query>GRANT SELECT ON tr.synthetic_status_rollups</query>
         <query>GRANT SELECT ON tr.public_analytics_snapshots</query>
+        <query>GRANT SELECT ON tr.client_minute_counters</query>
+        <query>GRANT SELECT ON tr.client_request_events</query>
+        <query>GRANT SELECT ON tr.client_availability_rollups</query>
       </grants>
     </tr_control_read>
   </users>
@@ -77,7 +80,7 @@ printf 'CH_CONTROL_READ_PASSWORD=%s\n' "$reader_password" |
     --zone="$ZONE" \
     --tunnel-through-iap \
     --quiet \
-    --command="sudo sh -c 'umask 077; cat > /tmp/tr-control-reader.env; set -a; . /tmp/tr-control-reader.env; set +a; /usr/bin/clickhouse-client --user tr_control_read --password \"\$CH_CONTROL_READ_PASSWORD\" --multiquery --query \"SELECT count() FROM tr.activity_generations FINAL LIMIT 1; SELECT count() FROM tr.public_analytics_snapshots FINAL LIMIT 1\" >/dev/null; rm -f /tmp/tr-control-reader.env'"
+    --command="sudo sh -c 'umask 077; cat > /tmp/tr-control-reader.env; set -a; . /tmp/tr-control-reader.env; set +a; status=0; /usr/bin/clickhouse-client --user tr_control_read --password \"\$CH_CONTROL_READ_PASSWORD\" --multiquery --query \"SELECT count() FROM tr.activity_generations FINAL LIMIT 1; SELECT count() FROM tr.public_analytics_snapshots FINAL LIMIT 1; SELECT count() FROM tr.client_minute_counters FINAL LIMIT 1; SELECT count() FROM tr.client_request_events FINAL LIMIT 1; SELECT count() FROM tr.client_availability_rollups FINAL LIMIT 1\" >/dev/null || status=\$?; rm -f /tmp/tr-control-reader.env; exit \$status'"
 unset reader_password
 
 echo "configured private read-only ClickHouse control-plane account"

--- a/tests/test_clickhouse_operational_deploy.py
+++ b/tests/test_clickhouse_operational_deploy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -103,8 +104,46 @@ def test_control_reader_is_private_read_only_and_cannot_read_secrets() -> None:
     assert "GRANT SELECT ON tr.synthetic_probe_samples" in script
     assert "GRANT SELECT ON tr.synthetic_status_rollups" in script
     assert "GRANT SELECT ON tr.public_analytics_snapshots" in script
+    assert "GRANT SELECT ON tr.client_minute_counters" in script
+    assert "GRANT SELECT ON tr.client_request_events" in script
+    assert "GRANT SELECT ON tr.client_availability_rollups" in script
     assert "GRANT SELECT ON tr.tr_entities" not in script
     assert "GRANT ALL" not in script
+
+
+def test_control_reader_grants_cover_operational_queries_and_all_client_tables() -> None:
+    """Pin grants to control-plane reads plus all three tables introduced by 008."""
+
+    source = (ROOT / "src/trusted_router/operational_analytics.py").read_text()
+    script = (ROOT / "scripts/deploy/clickhouse_control_reader.sh").read_text()
+    # Every table source the reader issues is `FROM <table> FINAL`. A qualified,
+    # aliased, dynamic, or non-FINAL source must extend this discovery to pass.
+    sources = re.findall(r"\bFROM\s+[a-z_]", source)
+    queried = set(re.findall(r"\bFROM ([a-z_]+) FINAL", source))
+    assert len(sources) == len(re.findall(r"\bFROM ([a-z_]+) FINAL", source))
+    granted = set(re.findall(r"<query>GRANT SELECT ON tr\.(\w+)</query>", script))
+
+    client_tables = {
+        "client_minute_counters",
+        "client_request_events",
+        "client_availability_rollups",
+    }
+    assert client_tables <= granted
+    # The three provider rollups predate operational_analytics.py and remain
+    # intentionally available to the same private, read-only account.
+    legacy = {
+        "provider_analytics_hourly",
+        "provider_analytics_daily",
+        "provider_analytics_monthly",
+    }
+    assert granted == queried | legacy | {"client_minute_counters"}
+    assert "operational_outbox_quarantine" not in script
+    for table in sorted(client_tables):
+        assert f"SELECT count() FROM tr.{table} FINAL LIMIT 1" in script  # noqa: S608
+    # A failed self-check must survive the cleanup command and fail deployment.
+    assert (
+        r">/dev/null || status=\$?; rm -f /tmp/tr-control-reader.env; exit \$status" in script
+    )
 
 
 def test_rollout_preserves_dual_read_mode_and_uses_distinct_reader_secret() -> None:


### PR DESCRIPTION
Grants `tr_control_read` — the ClickHouse user the Cloud Run control plane uses (`TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_USER`) — `SELECT` on the three tables introduced by the 008/009 client-telemetry schemas: `tr.client_minute_counters`, `tr.client_request_events`, `tr.client_availability_rollups`.

## Why

Observed in production on 2026-08-21 (`SHOW GRANTS FOR tr_control_read`): SELECT on `activity_generations`, `provider_analytics_*`, `provider_benchmark_samples`, `public_analytics_snapshots`, `synthetic_*` — and nothing on the client tables. Querying one as that user fails:

```
Code: 497. DB::Exception: tr_control_read: Not enough privileges. To execute this query, it's necessary to have the grant SELECT ON tr.client_availability_rollups. (ACCESS_DENIED)
```

`operational_analytics.py` `client_reliability_summary` and `client_events_recent` query two of those tables with this user, so the console's per-tenant client-reliability view presumably fails in production today.

## What changes

- `scripts/deploy/clickhouse_control_reader.sh` — the user's grant list (where `tr_control_read` is defined; the 008/009 SQL files carry no user grants, and the grants are table-name based, so no replicated/single-node variants exist) gains the three tables; the installer's self-check now queries `client_availability_rollups` and `client_request_events` as the reader and preserves a failed query's exit status through cleanup.
- `tests/test_clickhouse_operational_deploy.py` — pins that the grant set covers every `FROM <table> FINAL` source in `operational_analytics.py` plus the three client tables (and the three legacy provider rollups), so a future query against an ungranted table fails in CI instead of in production.

## Applying

`deploy.yml` does not invoke the grant installer. Apply by re-running `scripts/deploy/clickhouse_operational_analytics.sh --apply` (which calls `clickhouse_control_reader.sh` for each of the three nodes), or `clickhouse_control_reader.sh` directly with `PROJECT`, `ZONE`, `NAME`, `READER_SECRET` per node.

Authored by codex-cli from a written spec; reviewed by Claude (Fable): diff read in full; `bash -n` clean; `test_clickhouse_operational_deploy.py` **16 passed** under the reviewer's run. Companion PR: the client_observed calibration view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
