### PR TITLE
Run synthetic inference probes through trusted-router-py so the SDK telemetry path is exercised every pass

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,12 @@ dependencies = [
   "python-multipart>=0.0.20",
   "sentry-sdk[fastapi]>=2.20.0",
   "stripe>=11.0.0",
+  # The synthetic monitor runs its inference probes through the official
+  # Python SDK so every pass exercises the SDK client-telemetry path
+  # (x-tr-client header + /v1/client-events beacon). It lives in the main
+  # dependencies because the Cloud Run jobs share the control-plane image,
+  # which installs with `uv sync --no-dev` and no extras (Dockerfile).
+  "trusted-router-py>=0.6.0",
   "uvicorn[standard]>=0.32.0",
 ]
 

--- a/src/trusted_router/synthetic/cli.py
+++ b/src/trusted_router/synthetic/cli.py
@@ -77,6 +77,8 @@ async def _one_probe_pass(
             monitor_region=monitor_region,
             api_key=api_key,
             billing_semaphore=limiter,
+            # The inference probes' SDK sessions beacon to this plane.
+            control_plane_base_url=control_plane,
         )
     )
     if not api_key:

--- a/src/trusted_router/synthetic/inference_sdk.py
+++ b/src/trusted_router/synthetic/inference_sdk.py
@@ -1,0 +1,151 @@
+"""The monitor's TrustedRouter Python SDK session for its inference probes.
+
+The pong probes (``openai_sdk_pong``, ``responses_pong``) are the monitor's
+only real model calls, and they used to go out as raw ``httpx`` POSTs. That
+left the SDK's client-telemetry path -- the per-attempt ``x-tr-client`` header
+the enclave forwards into settle context, and the beacon the SDK posts to
+``/v1/client-events`` -- with no traffic from our own monitor: not one
+``client_source='tr'`` row had ever settled in production, and the canary
+batch the monitor posts (``probes.client_telemetry_canary_probe``) is
+hand-built, so it proves ingest liveness and nothing about the SDK. Sending
+the probes through the official SDK makes every pass exercise that path end
+to end.
+
+The session is configured to preserve what the probe measures:
+
+* exactly one attempt per probe: ``max_retries=0``. ``regional_failover`` is
+  off as well, although a non-default base URL has a single candidate and
+  could not move anyway;
+* the monitor's own ``httpx.AsyncClient`` is injected, so a probe keeps its
+  configured timeout and its TLS context (attested targets trust the
+  TEE-minted certificate through the attestation probe, not through a CA);
+* ``regional_affinity=False``: the target IS the region; the SDK must never
+  race the regional health endpoints to pick one for us;
+* telemetry explicitly on, at a 1.0 sample rate. The monitor wants every
+  event, and the SDK's environment opt-outs (``TRUSTEDROUTER_TELEMETRY``,
+  ``DO_NOT_TRACK``) must not silence it; an explicit ``telemetry=True`` wins
+  over both.
+
+Synthetic marking keeps both server-recognized forms: the request body carries
+``metadata.trustedrouter_synthetic`` and ``app="TrustedRouter Synthetic"``.
+The beacon is sent with the monitor key, which ``/v1/client-events`` identifies
+server-side as synthetic regardless of the batch's client-supplied bit. No
+client honesty is required on either channel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+
+import httpx
+from trustedrouter import AsyncTrustedRouter, TrustedRouterError
+
+log = logging.getLogger(__name__)
+
+DEFAULT_CONTROL_PLANE_BASE_URL = "https://trustedrouter.com"
+# Every synthetic event is wanted. The SDK's default (0.01) keeps one success
+# in a hundred, which would leave the monitor's own beacons nearly empty.
+MONITOR_TELEMETRY_SAMPLE_RATE = 1.0
+# How long ``aclose()`` joins the reporter's final flush (one bounded POST).
+SDK_CLOSE_TIMEOUT_SECONDS = 2.0
+
+
+def build_inference_sdk(
+    api_base_url: str,
+    *,
+    api_key: str,
+    http_client: httpx.AsyncClient,
+    control_plane_base_url: str,
+) -> AsyncTrustedRouter:
+    """One SDK session for one probe target, on the monitor's own HTTP client."""
+    return AsyncTrustedRouter(
+        api_key,
+        base_url=api_base_url,
+        control_base_url=f"{control_plane_base_url.rstrip('/')}/v1",
+        client=http_client,
+        max_retries=0,
+        regional_failover=False,
+        regional_affinity=False,
+        telemetry=True,
+        telemetry_sample_rate=MONITOR_TELEMETRY_SAMPLE_RATE,
+    )
+
+
+async def close_inference_sdk(sdk: AsyncTrustedRouter) -> None:
+    """Flush the session's telemetry reporter without stalling the event loop.
+
+    ``aclose()`` joins the reporter's final flush for up to
+    :data:`SDK_CLOSE_TIMEOUT_SECONDS`. Other probes (ledger, rotation) may
+    still be timing requests on this loop, and a two-second stall would land
+    in their latencies, so the join runs in a worker thread. The session owns
+    no loop-bound resource (the HTTP client is the monitor's), which is what
+    makes running ``aclose()`` on a private loop in that thread safe.
+    Telemetry never fails a pass: an error here is logged and swallowed, and
+    the SDK's own atexit hook is the backstop for a reporter left unclosed.
+    """
+    try:
+        await asyncio.to_thread(asyncio.run, sdk.aclose())
+    except Exception:  # noqa: BLE001 - telemetry must never fail a probe pass
+        log.warning("synthetic.sdk_close_failed", exc_info=True)
+
+
+@dataclass(frozen=True)
+class SdkFailure:
+    """The monitor's reading of an SDK exception, in the pre-SDK vocabulary."""
+
+    error_type: str
+    http_status: int | None
+    # Whether a response reached the probe, i.e. whether a time-to-first-byte
+    # exists for the sample. False for transport failures.
+    response_received: bool
+
+
+def classify_sdk_failure(exc: BaseException) -> SdkFailure:
+    """Map an SDK exception back onto the raw-httpx probes' taxonomy.
+
+    Those probes had exactly three outcomes: a parsed response (``up``, or
+    ``pong_mismatch`` carrying the real HTTP status -- they never raised on a
+    status), an ``httpx.HTTPError`` (``error_type`` is its class name, no
+    status), or an exception escaping the pass. The SDK folds the first two
+    into typed errors, and this undoes the fold:
+
+    * a transport failure arrives as ``InternalError(503)`` raised ``from``
+      the httpx exception. The cause chain, not the status, tells it apart
+      from a real 503, and the httpx class name is kept;
+    * any other ``TrustedRouterError`` is a response the probe could not
+      accept: ``pong_mismatch`` with the status the SDK saw. A 2xx whose JSON
+      is not an object lands here too, status intact;
+    * a successful body that is not JSON surfaces as the bare ``ValueError``;
+      this path is only reached after ``response.is_success``, and these two
+      gateway endpoints' success contract is 200, so the old status is kept;
+    * anything else is an SDK-internal failure the old probes could not have
+      had. It becomes a down sample named after the exception rather than a
+      crashed pass, so the anomaly shows on the page instead of as a gap.
+    """
+    transport = _transport_cause(exc)
+    if transport is not None:
+        return SdkFailure(type(transport).__name__, None, False)
+    if isinstance(exc, TrustedRouterError):
+        return SdkFailure("pong_mismatch", exc.status_code, True)
+    if isinstance(exc, ValueError):
+        return SdkFailure("pong_mismatch", 200, True)
+    return SdkFailure(type(exc).__name__, None, False)
+
+
+def _transport_cause(exc: BaseException) -> httpx.HTTPError | None:
+    """The httpx error behind ``exc``, following explicit causes only.
+
+    ``__context__`` is deliberately not followed: a status error raised inside
+    the SDK's JSON handling has the decode error as implicit context, and the
+    response status, not a transport failure, is the truth there.
+    """
+    current: BaseException | None = exc
+    for _ in range(6):
+        if current is None:
+            return None
+        if isinstance(current, httpx.HTTPError):
+            return current
+        current = current.__cause__
+    return None

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -22,6 +22,7 @@ import cbor2
 import httpx
 from cryptography import x509
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from trustedrouter import AsyncTrustedRouter
 
 from trusted_router.config import Settings, parse_gateway_region_targets
 from trusted_router.provider_reliability import model_deadlines
@@ -33,6 +34,12 @@ from trusted_router.storage_models import (
     scrub_provider_error_message,
 )
 from trusted_router.synthetic.components import is_router_origin_error
+from trusted_router.synthetic.inference_sdk import (
+    DEFAULT_CONTROL_PLANE_BASE_URL,
+    build_inference_sdk,
+    classify_sdk_failure,
+    close_inference_sdk,
+)
 from trusted_router.types import UsageType
 
 DEFAULT_SYNTHETIC_BILLING_CONCURRENCY = 2
@@ -284,9 +291,20 @@ async def run_synthetic_once(
     monitor_region: str | None = None,
     api_key: str | None = None,
     billing_semaphore: asyncio.Semaphore | None = None,
+    control_plane_base_url: str | None = None,
 ) -> list[SyntheticProbeSample]:
     region = monitor_region or settings.synthetic_monitor_region or choose_region(settings)
     key = api_key or settings.synthetic_monitor_api_key
+    # Where the inference probes' SDK sessions beacon their client telemetry.
+    # Same precedence as /internal/synthetic/run: the caller's explicit value
+    # (the monitor CLI's TR_SYNTHETIC_CONTROL_PLANE_URL), then this
+    # deployment's own plane, then the canonical GCP plane. A standalone cloud
+    # must report to its own control plane, not another cloud's.
+    control_plane = (
+        control_plane_base_url
+        or settings.synthetic_control_plane_base_url
+        or DEFAULT_CONTROL_PLANE_BASE_URL
+    )
     timeout = httpx.Timeout(settings.synthetic_monitor_timeout_seconds)
     limiter = billing_semaphore or asyncio.Semaphore(DEFAULT_SYNTHETIC_BILLING_CONCURRENCY)
     samples: list[SyntheticProbeSample] = []
@@ -311,6 +329,7 @@ async def run_synthetic_once(
                     api_key=key,
                     model=settings.synthetic_monitor_model,
                     billing_semaphore=limiter,
+                    control_plane_base_url=control_plane,
                 )
             )
         # Peer policing rides the same pass: every deployment fetches every
@@ -339,6 +358,7 @@ async def _run_target_synthetic_probes(
     api_key: str | None,
     model: str,
     billing_semaphore: asyncio.Semaphore,
+    control_plane_base_url: str = DEFAULT_CONTROL_PLANE_BASE_URL,
 ) -> list[SyntheticProbeSample]:
     probes = [
         tls_health_probe(client, target, monitor_region=monitor_region),
@@ -361,27 +381,16 @@ async def _run_target_synthetic_probes(
     # can influence that env var, would otherwise harvest a billable key
     # once a minute with no certificate check standing in the way.
     if api_key and target.paid_probes and not target.connect_host:
-        probes.extend(
-            [
-                _run_billing_probe(
-                    billing_semaphore,
-                    openai_chat_pong_probe,
-                    client,
-                    target,
-                    monitor_region=monitor_region,
-                    api_key=api_key,
-                    model=model,
-                ),
-                _run_billing_probe(
-                    billing_semaphore,
-                    responses_pong_probe,
-                    client,
-                    target,
-                    monitor_region=monitor_region,
-                    api_key=api_key,
-                    model=model,
-                ),
-            ]
+        probes.append(
+            _run_inference_sdk_probes(
+                client,
+                target,
+                monitor_region=monitor_region,
+                api_key=api_key,
+                model=model,
+                billing_semaphore=billing_semaphore,
+                control_plane_base_url=control_plane_base_url,
+            )
         )
     results = await asyncio.gather(*probes)
     samples: list[SyntheticProbeSample] = []
@@ -393,6 +402,49 @@ async def _run_target_synthetic_probes(
         else:
             raise TypeError(f"unexpected synthetic probe result: {type(result).__name__}")
     return samples
+
+
+async def _run_inference_sdk_probes(
+    client: httpx.AsyncClient,
+    target: SyntheticTarget,
+    *,
+    monitor_region: str,
+    api_key: str,
+    model: str,
+    billing_semaphore: asyncio.Semaphore,
+    control_plane_base_url: str,
+) -> list[SyntheticProbeSample]:
+    """Run this target's inference pair and flush its SDK beacon before returning."""
+    sdk = build_inference_sdk(
+        target.api_base_url,
+        api_key=api_key,
+        http_client=client,
+        control_plane_base_url=control_plane_base_url,
+    )
+    try:
+        results = await asyncio.gather(
+            _run_billing_probe(
+                billing_semaphore,
+                openai_chat_pong_probe,
+                sdk,
+                target,
+                monitor_region=monitor_region,
+                model=model,
+            ),
+            _run_billing_probe(
+                billing_semaphore,
+                responses_pong_probe,
+                sdk,
+                target,
+                monitor_region=monitor_region,
+                model=model,
+            ),
+        )
+        return list(results)
+    finally:
+        # Telemetry is best-effort and close_inference_sdk swallows reporter
+        # failures, so a broken beacon can never rewrite either probe sample.
+        await close_inference_sdk(sdk)
 
 
 async def _run_billing_probe(
@@ -1107,13 +1159,20 @@ def _response_peer_cert_der(response: httpx.Response) -> bytes | None:
 
 
 async def openai_chat_pong_probe(
-    client: httpx.AsyncClient,
+    sdk: AsyncTrustedRouter,
     target: SyntheticTarget,
     *,
     monitor_region: str,
-    api_key: str,
     model: str,
 ) -> SyntheticProbeSample:
+    """A real chat completion through the official Python SDK.
+
+    ``sdk`` is the target's session from ``inference_sdk.build_inference_sdk``:
+    the monitor's own client underneath, one attempt, telemetry on. The
+    buffered ``request`` path keeps the request non-streaming and adds the
+    SDK's user-agent and per-attempt ``x-tr-client`` header; the timing stays
+    the monitor's own, measured around the call.
+    """
     url = _api_url(target.api_base_url, "/chat/completions")
     body = {
         "model": model,
@@ -1124,54 +1183,43 @@ async def openai_chat_pong_probe(
         "max_tokens": 128,
         "temperature": 0,
         "metadata": {"trustedrouter_synthetic": "true"},
+        "app": "TrustedRouter Synthetic",
     }
-    request_url, connect_headers, extensions = _connect_host_request(target, url)
     started = time.perf_counter()
     try:
-        response = await client.post(
-            request_url,
-            json=body,
-            headers={**_auth_headers(api_key), **connect_headers},
-            extensions=extensions,
-        )
-        latency_ms = _elapsed_ms(started)
-        text = _chat_text(response)
-        ok = response.status_code == 200 and _pong_matches(text)
-        return _sample(
-            "openai_sdk_pong",
-            target,
-            monitor_region,
-            url,
-            status="up" if ok else "down",
-            latency_milliseconds=latency_ms,
-            ttfb_milliseconds=latency_ms,
-            http_status=response.status_code,
-            error_type=None if ok else "pong_mismatch",
-            model=model,
-            output_match=ok,
-        )
-    except httpx.HTTPError as exc:
-        return _sample(
-            "openai_sdk_pong",
-            target,
-            monitor_region,
-            url,
-            status="down",
-            latency_milliseconds=_elapsed_ms(started),
-            error_type=exc.__class__.__name__,
-            model=model,
-            output_match=False,
-        )
+        payload = await sdk.request("POST", "/chat/completions", json=body)
+    except Exception as exc:  # noqa: BLE001 - every SDK failure is a classified sample
+        return _sdk_failure_sample("openai_sdk_pong", target, monitor_region, url, exc, started, model)
+    latency_ms = _elapsed_ms(started)
+    ok = _pong_matches(_chat_text(httpx.Response(200, json=payload)))
+    return _sample(
+        "openai_sdk_pong",
+        target,
+        monitor_region,
+        url,
+        status="up" if ok else "down",
+        latency_milliseconds=latency_ms,
+        ttfb_milliseconds=latency_ms,
+        # The SDK only returns a payload for a non-error status, and the
+        # gateway's success status on this route is 200.
+        http_status=200,
+        error_type=None if ok else "pong_mismatch",
+        model=model,
+        output_match=ok,
+    )
 
 
 async def responses_pong_probe(
-    client: httpx.AsyncClient,
+    sdk: AsyncTrustedRouter,
     target: SyntheticTarget,
     *,
     monitor_region: str,
-    api_key: str,
     model: str,
 ) -> SyntheticProbeSample:
+    """A real Responses round-trip through the official Python SDK.
+
+    Same session and same contract as ``openai_chat_pong_probe``.
+    """
     url = _api_url(target.api_base_url, "/responses")
     body = {
         "model": model,
@@ -1184,44 +1232,61 @@ async def responses_pong_probe(
         "max_output_tokens": 128,
         "temperature": 0,
         "metadata": {"trustedrouter_synthetic": "true"},
+        "app": "TrustedRouter Synthetic",
     }
-    request_url, connect_headers, extensions = _connect_host_request(target, url)
     started = time.perf_counter()
     try:
-        response = await client.post(
-            request_url,
-            json=body,
-            headers={**_auth_headers(api_key), **connect_headers},
-            extensions=extensions,
-        )
-        latency_ms = _elapsed_ms(started)
-        text = _responses_text(response)
-        ok = response.status_code == 200 and _pong_matches(text)
-        return _sample(
-            "responses_pong",
-            target,
-            monitor_region,
-            url,
-            status="up" if ok else "down",
-            latency_milliseconds=latency_ms,
-            ttfb_milliseconds=latency_ms,
-            http_status=response.status_code,
-            error_type=None if ok else "pong_mismatch",
-            model=model,
-            output_match=ok,
-        )
-    except httpx.HTTPError as exc:
-        return _sample(
-            "responses_pong",
-            target,
-            monitor_region,
-            url,
-            status="down",
-            latency_milliseconds=_elapsed_ms(started),
-            error_type=exc.__class__.__name__,
-            model=model,
-            output_match=False,
-        )
+        payload = await sdk.request("POST", "/responses", json=body)
+    except Exception as exc:  # noqa: BLE001 - every SDK failure is a classified sample
+        return _sdk_failure_sample("responses_pong", target, monitor_region, url, exc, started, model)
+    latency_ms = _elapsed_ms(started)
+    ok = _pong_matches(_responses_text(httpx.Response(200, json=payload)))
+    return _sample(
+        "responses_pong",
+        target,
+        monitor_region,
+        url,
+        status="up" if ok else "down",
+        latency_milliseconds=latency_ms,
+        ttfb_milliseconds=latency_ms,
+        # See openai_chat_pong_probe: a returned payload means a 200.
+        http_status=200,
+        error_type=None if ok else "pong_mismatch",
+        model=model,
+        output_match=ok,
+    )
+
+
+def _sdk_failure_sample(
+    probe_type: str,
+    target: SyntheticTarget,
+    monitor_region: str,
+    url: str,
+    exc: BaseException,
+    started: float,
+    model: str,
+) -> SyntheticProbeSample:
+    """The down sample for an SDK exception, in the pre-SDK taxonomy.
+
+    ``classify_sdk_failure`` owns the mapping; this keeps the sample fields
+    exactly as the raw-httpx probes set them: a latency always, a
+    time-to-first-byte only when a response was received.
+    """
+    latency_ms = _elapsed_ms(started)
+    failure = classify_sdk_failure(exc)
+    return _sample(
+        probe_type,
+        target,
+        monitor_region,
+        url,
+        status="down",
+        latency_milliseconds=latency_ms,
+        ttfb_milliseconds=latency_ms if failure.response_received else None,
+        http_status=failure.http_status,
+        error_type=failure.error_type,
+        model=model,
+        output_match=False,
+    )
 
 
 async def image_generation_probe(

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import datetime as dt
 import json
 import random
+import socket
 import threading
 import time
+from collections.abc import AsyncIterator
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any
@@ -15,6 +18,7 @@ import httpx
 import pytest
 from fastapi import BackgroundTasks
 from fastapi.testclient import TestClient
+from trustedrouter import AsyncTrustedRouter
 
 from trusted_router.catalog import (
     CHEAP_MODEL_ID,
@@ -47,6 +51,7 @@ from trusted_router.storage_gcp_synthetic_rollups import (
 )
 from trusted_router.storage_models import ProviderBenchmarkSample, iso_now, utcnow
 from trusted_router.synthetic.components import sample_slo_class_ids
+from trusted_router.synthetic.inference_sdk import build_inference_sdk, close_inference_sdk
 from trusted_router.synthetic.probes import (
     IMAGE_GENERATION_MODEL,
     IMAGE_GENERATION_PROVIDER,
@@ -83,6 +88,35 @@ from trusted_router.synthetic.route_health import (
     report_route_health,
 )
 from trusted_router.synthetic.status import history_payload, status_snapshot
+
+
+def _closed_local_port() -> int:
+    """A localhost port nothing listens on: connections are refused at once."""
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+
+
+# The SDK sessions' beacon destination in these tests. A refused port keeps
+# the reporter's close-time flush instant and off the network.
+_NO_CONTROL_PLANE = f"http://127.0.0.1:{_closed_local_port()}"
+
+
+@contextlib.asynccontextmanager
+async def _monitor_sdk(
+    client: httpx.AsyncClient, target: SyntheticTarget
+) -> AsyncIterator[AsyncTrustedRouter]:
+    """The production SDK session around a fake-gateway client, closed after use."""
+    sdk = build_inference_sdk(
+        target.api_base_url,
+        api_key="sk-test",
+        http_client=client,
+        control_plane_base_url=_NO_CONTROL_PLANE,
+    )
+    try:
+        yield sdk
+    finally:
+        await close_inference_sdk(sdk)
 
 
 def test_catalog_exposes_free_cheap_and_monitor_meta_models() -> None:
@@ -1607,20 +1641,13 @@ async def test_synthetic_http_probes_parse_success_shapes() -> None:
     async with httpx.AsyncClient(transport=transport) as client:
         health = await tls_health_probe(client, target, monitor_region="us-central1")
         attestation = await attestation_nonce_probe(client, target, monitor_region="us-central1")
-        chat = await openai_chat_pong_probe(
-            client,
-            target,
-            monitor_region="us-central1",
-            api_key="sk-test",  # noqa: S106 - test placeholder.
-            model=MONITOR_MODEL_ID,
-        )
-        responses = await responses_pong_probe(
-            client,
-            target,
-            monitor_region="us-central1",
-            api_key="sk-test",  # noqa: S106 - test placeholder.
-            model=MONITOR_MODEL_ID,
-        )
+        async with _monitor_sdk(client, target) as sdk:
+            chat = await openai_chat_pong_probe(
+                sdk, target, monitor_region="us-central1", model=MONITOR_MODEL_ID
+            )
+            responses = await responses_pong_probe(
+                sdk, target, monitor_region="us-central1", model=MONITOR_MODEL_ID
+            )
 
     assert health.status == "up"
     assert attestation.status == "up"
@@ -1849,35 +1876,26 @@ async def test_pong_probe_accepts_reasoning_model_shapes() -> None:
 
     target = SyntheticTarget("canonical", "https://api.trustedrouter.com/v1", "us-central1")
     async with httpx.AsyncClient(transport=httpx.MockTransport(chat_handler)) as client:
-        chat = await openai_chat_pong_probe(
-            client,
-            target,
-            monitor_region="us-central1",
-            api_key="sk-test",  # noqa: S106 - test placeholder.
-            model=MONITOR_MODEL_ID,
-        )
+        async with _monitor_sdk(client, target) as sdk:
+            chat = await openai_chat_pong_probe(
+                sdk, target, monitor_region="us-central1", model=MONITOR_MODEL_ID
+            )
     assert chat.status == "up", chat.error_type
     assert chat.output_match is True
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(chat_list_handler)) as client:
-        chat_list = await openai_chat_pong_probe(
-            client,
-            target,
-            monitor_region="us-central1",
-            api_key="sk-test",  # noqa: S106 - test placeholder.
-            model=MONITOR_MODEL_ID,
-        )
+        async with _monitor_sdk(client, target) as sdk:
+            chat_list = await openai_chat_pong_probe(
+                sdk, target, monitor_region="us-central1", model=MONITOR_MODEL_ID
+            )
     assert chat_list.status == "up", chat_list.error_type
     assert chat_list.output_match is True
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(responses_handler)) as client:
-        responses = await responses_pong_probe(
-            client,
-            target,
-            monitor_region="us-central1",
-            api_key="sk-test",  # noqa: S106 - test placeholder.
-            model=MONITOR_MODEL_ID,
-        )
+        async with _monitor_sdk(client, target) as sdk:
+            responses = await responses_pong_probe(
+                sdk, target, monitor_region="us-central1", model=MONITOR_MODEL_ID
+            )
     assert responses.status == "up", responses.error_type
     assert responses.output_match is True
 
@@ -1901,13 +1919,10 @@ async def test_pong_probe_still_catches_real_mismatches() -> None:
 
     target = SyntheticTarget("canonical", "https://api.trustedrouter.com/v1", "us-central1")
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
-        chat = await openai_chat_pong_probe(
-            client,
-            target,
-            monitor_region="us-central1",
-            api_key="sk-test",  # noqa: S106 - test placeholder.
-            model=MONITOR_MODEL_ID,
-        )
+        async with _monitor_sdk(client, target) as sdk:
+            chat = await openai_chat_pong_probe(
+                sdk, target, monitor_region="us-central1", model=MONITOR_MODEL_ID
+            )
 
     assert chat.status == "down"
     assert chat.output_match is False

--- a/tests/test_synthetic_sdk_probes.py
+++ b/tests/test_synthetic_sdk_probes.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import httpx
+import pytest
+import trustedrouter._telemetry as sdk_telemetry
+
+from trusted_router.client_events_schema import ClientEventsBatch
+from trusted_router.storage_models import SyntheticProbeSample
+from trusted_router.synthetic.probes import (
+    SyntheticTarget,
+    _run_inference_sdk_probes,
+)
+
+_API_KEY = "sk-test-monitor"
+_MODEL = "trustedrouter/monitor"
+_REGIONAL_API = "https://api-us-east4.quillrouter.com/v1"
+
+
+@pytest.fixture
+def telemetry_requests(monkeypatch: pytest.MonkeyPatch) -> Iterator[list[httpx.Request]]:
+    """Capture the SDK reporter's synchronous close-time POST."""
+    requests: list[httpx.Request] = []
+    real_client = httpx.Client
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            202,
+            json={
+                "data": {"accepted_events": 2, "accepted_counters": 4, "dropped": 0},
+                "policy": {
+                    "success_sample_rate": 1.0,
+                    "flush_seconds": 30,
+                    "pause_seconds": 0,
+                },
+            },
+        )
+
+    def client_factory(*args: Any, **kwargs: Any) -> httpx.Client:
+        return real_client(*args, transport=httpx.MockTransport(handler), **kwargs)
+
+    monkeypatch.setattr(sdk_telemetry.httpx, "Client", client_factory)
+    yield requests
+
+
+async def _run_pair(
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> list[SyntheticProbeSample]:
+    target = SyntheticTarget("us-east4", _REGIONAL_API, "us-east4")
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        timeout=httpx.Timeout(7.0),
+    ) as client:
+        return await _run_inference_sdk_probes(
+            client,
+            target,
+            monitor_region="europe-west4",
+            api_key=_API_KEY,
+            model=_MODEL,
+            billing_semaphore=asyncio.Semaphore(2),
+            control_plane_base_url="https://control.example",
+        )
+
+
+@pytest.mark.asyncio
+async def test_real_sdk_pong_probes_mark_requests_and_flush_valid_telemetry(
+    telemetry_requests: list[httpx.Request],
+) -> None:
+    gateway_requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        gateway_requests.append(request)
+        if request.url.path.endswith("/chat/completions"):
+            return httpx.Response(
+                200,
+                json={"choices": [{"message": {"content": "PONG"}}]},
+            )
+        return httpx.Response(
+            200,
+            json={"output": [{"type": "message", "content": [{"text": "PONG"}]}]},
+        )
+
+    samples = await _run_pair(handler)
+
+    assert [request.url.path for request in gateway_requests] == [
+        "/v1/chat/completions",
+        "/v1/responses",
+    ]
+    for request in gateway_requests:
+        assert request.headers["x-tr-client"] == "v=1;a=0;s=0"
+        assert request.headers["user-agent"].startswith("trusted-router-py/")
+        assert request.extensions["timeout"] == {
+            "connect": 7.0,
+            "read": 7.0,
+            "write": 7.0,
+            "pool": 7.0,
+        }
+        body = json.loads(request.content)
+        assert body["metadata"] == {"trustedrouter_synthetic": "true"}
+        assert body["app"] == "TrustedRouter Synthetic"
+
+    assert [sample.probe_type for sample in samples] == ["openai_sdk_pong", "responses_pong"]
+    for sample in samples:
+        assert sample.status == "up"
+        assert sample.http_status == 200
+        assert sample.error_type is None
+        assert sample.output_match is True
+        assert sample.latency_milliseconds is not None
+        assert sample.latency_milliseconds >= 0
+        assert sample.ttfb_milliseconds == sample.latency_milliseconds
+
+    # _run_inference_sdk_probes does not return until close() has attempted
+    # the reporter's final flush, so the request must already be observable.
+    [telemetry_request] = telemetry_requests
+    assert str(telemetry_request.url) == "https://control.example/v1/client-events"
+    assert telemetry_request.headers["authorization"] == f"Bearer {_API_KEY}"
+    batch = ClientEventsBatch.model_validate(json.loads(telemetry_request.content))
+    assert batch.sdk.name == "tr-py"
+    assert batch.sdk.version != "0.0.0"
+    assert {event.endpoint for event in batch.events} == {"chat_completions", "responses"}
+    assert all(event.attempts[0].host == "us_east4" for event in batch.events)
+    assert all(event.sample_rate == 1.0 for event in batch.events)
+
+
+@pytest.mark.asyncio
+async def test_real_sdk_pong_probes_make_one_attempt_each_on_503(
+    telemetry_requests: list[httpx.Request],
+) -> None:
+    attempts: dict[str, int] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts[request.url.path] = attempts.get(request.url.path, 0) + 1
+        # This explicitly authorizes a replay in SDKs configured to retry.
+        # The monitor's max_retries=0 must still make exactly one attempt.
+        return httpx.Response(
+            503,
+            headers={"x-should-retry": "true"},
+            json={"error": {"message": "unavailable"}},
+        )
+
+    samples = await _run_pair(handler)
+
+    assert attempts == {"/v1/chat/completions": 1, "/v1/responses": 1}
+    assert len(telemetry_requests) == 1
+    for sample in samples:
+        assert sample.status == "down"
+        assert sample.http_status == 503
+        assert sample.error_type == "pong_mismatch"
+        assert sample.output_match is False
+        assert sample.latency_milliseconds is not None
+        assert sample.ttfb_milliseconds == sample.latency_milliseconds
+
+
+@pytest.mark.asyncio
+async def test_real_sdk_pong_probes_restore_httpx_transport_error_taxonomy(
+    telemetry_requests: list[httpx.Request],
+) -> None:
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        raise httpx.ConnectError("gateway unavailable", request=request)
+
+    samples = await _run_pair(handler)
+
+    assert attempts == 2
+    assert len(telemetry_requests) == 1
+    for sample in samples:
+        assert sample.status == "down"
+        assert sample.http_status is None
+        assert sample.error_type == "ConnectError"
+        assert sample.output_match is False
+        assert sample.latency_milliseconds is not None
+        assert sample.ttfb_milliseconds is None
+
+
+@pytest.mark.asyncio
+async def test_sdk_telemetry_delivery_failure_cannot_change_probe_outcomes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_client = httpx.Client
+
+    def telemetry_handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("telemetry unavailable", request=request)
+
+    def client_factory(*args: Any, **kwargs: Any) -> httpx.Client:
+        return real_client(
+            *args,
+            transport=httpx.MockTransport(telemetry_handler),
+            **kwargs,
+        )
+
+    monkeypatch.setattr(sdk_telemetry.httpx, "Client", client_factory)
+
+    def gateway_handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/chat/completions"):
+            return httpx.Response(200, json={"choices": [{"message": {"content": "PONG"}}]})
+        return httpx.Response(200, json={"output": [{"content": [{"text": "PONG"}]}]})
+
+    samples = await _run_pair(gateway_handler)
+
+    assert [sample.status for sample in samples] == ["up", "up"]
+    assert [sample.output_match for sample in samples] == [True, True]

--- a/uv.lock
+++ b/uv.lock
@@ -4570,6 +4570,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "stripe" },
+    { name = "trusted-router-py" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -4608,6 +4609,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.20.0" },
     { name = "stripe", specifier = ">=11.0.0" },
+    { name = "trusted-router-py", specifier = ">=0.6.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
 ]
 
@@ -4625,6 +4627,19 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.8.0" },
     { name = "sec-parser", specifier = ">=0.58.0" },
+]
+
+[[package]]
+name = "trusted-router-py"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/3e/e01a5aefef2244b6bd23bb20eeaf7fd06d461ffc7fd43c461950a280c70e/trusted_router_py-0.6.0.tar.gz", hash = "sha256:7fe711906f339289062ca7d4054375babb72be074a9d83ec4bd061f51b37e7ce", size = 229523, upload-time = "2026-08-17T03:40:28.388Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/05/98679b53b4b2624b47809b2795b60c04b5a8f5e6258f143c037badceac6d/trusted_router_py-0.6.0-py3-none-any.whl", hash = "sha256:010a73ae2b12f39892225408a555e744af1265a9b132d745dc55405e2a7237a9", size = 86234, upload-time = "2026-08-17T03:40:26.782Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Routes the synthetic monitor's two inference probes (`openai_sdk_pong`, `responses_pong`) through the official Python SDK (`trusted-router-py` ≥ 0.6.0) instead of raw `httpx`, so every synthetic pass exercises the SDK's client-telemetry path end to end: the per-attempt `x-tr-client` header (enclave → settle context) and the SDK's beacon to `/v1/client-events`.

Owner decision (2026-08-21): "the synthetics should use the SDKs; we're trying to test the SDKs and client analytics." Motivation measured the same day: **no TR-SDK request had ever settled in production** (zero `client_source='tr'` rows) because the probes were raw `httpx` (UA `python-httpx`, no header) and the canary batch is hand-built. Synthetic package only; no analytics, rollup, methodology, status, or `/v1/client-events` route changes.

## Authorship and review

Authored by codex-cli from a written spec; reviewed by Claude (Fable): the new adapter read in full; `ruff` and `mypy` clean on the changed modules; focused suites (`test_synthetic_sdk_probes`, `test_synthetic_monitoring`) **117 passed** under the reviewer's run; reviewer mutation (`telemetry=True` → `False` in the adapter) failed **3 of 4** SDK-probe tests. Author's full-repo gates: `ruff` clean, `mypy` clean (292 files), `pytest` **5 111 passed, 301 skipped, 10 xfailed**; every new test mutation-checked.

## What the monitor measures is preserved

- Exactly one attempt per probe: `max_retries=0`, `regional_failover=False`, `regional_affinity=False` (the target *is* the region); a 503 carrying `x-should-retry: true` still yields one request (tested).
- The monitor's own `httpx.AsyncClient` is injected, keeping its timeouts and TLS context (attested targets trust the TEE-minted certificate via the attestation probe, not a CA); all four 7 s timeout phases are captured on the outbound SDK request (tested).
- The per-region `api-<region>.quillrouter.com/v1` base stays the SDK `base_url`; captured requests carry exactly `x-tr-client: v=1;a=0;s=0` and a `trusted-router-py/…` User-Agent (tested).
- Synthetic marking keeps both server-recognised forms (`metadata.trustedrouter_synthetic` and `app="TrustedRouter Synthetic"`); the beacon is sent with the monitor key, which `/v1/client-events` identifies as synthetic server-side regardless of the batch's client bit.
- Telemetry explicitly on at sample rate 1.0 (overriding env opt-outs — the monitor wants every event); the reporter is flushed after each target's inference pair, **off the event loop** (`asyncio.to_thread`) so the ≤ 2 s join never lands in another probe's latency; close failures are logged and swallowed, the SDK's atexit hook is the backstop.
- `_chat_text` / `_responses_text` (hashed by the provider-check contract) are byte-for-byte unchanged; SDK payloads are wrapped in an in-memory 200 response after the monitor's timer stops.

## Outcome mapping (typed SDK errors → the monitor's existing taxonomy)

| raw-httpx observation | SDK surface | recorded sample |
|---|---|---|
| 200, JSON object with PONG | dict | `up`, 200, `output_match=true` |
| 200 without PONG | dict or `TrustedRouterError(200)` | `down`, 200, `pong_mismatch` |
| 4xx/5xx | typed `TrustedRouterError` | `down`, original status, `pong_mismatch` |
| `httpx.HTTPError` before a response | `InternalError(503)` **caused by** the httpx error (explicit `__cause__` only) | `down`, httpx class name, no status/TTFB |
| 200 non-JSON | bare `ValueError` | `down`, 200, `pong_mismatch` |
| unexpected exception | — | `down`, exception class name (the anomaly shows on the page instead of as a gap) |

One unavoidable timing difference: SDK JSON decoding now happens before the monitor's timer stops (the old code decoded after capturing latency), so measured latency includes the first JSON decode.

## Deploy

`Dockerfile` runs `uv sync --frozen --no-dev`, so the runtime SDK dependency ships in the control-plane image. The deploy workflow's optional-surface detector enables the synthetic-job step for any `src/trusted_router/` change and runs `scripts/deploy/synthetic.sh`, redeploying both `trusted-router-synthetic-*` jobs with the same image — but that step is `continue-on-error: true`, so verify the job redeploy succeeded rather than assuming it. The control plane now depends on its own SDK (`pyproject.toml`, `uv.lock`).

After the first pass on the new image, the decisive check is `activity_generations` rows with `client_source='tr'` and `client_sdk='tr-py'`, and `client_minute_counters` rows with `sdk='tr-py'` from the monitor workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
