### PR TITLE
Fix regional quota CAS and burst capacity

### DIFF
--- a/scripts/deploy/_lib.sh
+++ b/scripts/deploy/_lib.sh
@@ -21,13 +21,19 @@ TR_PRIMARY_REGION="${TR_PRIMARY_REGION:-us-central1}"
 # than TR_REGIONS because cold control-plane regions can serve cached public
 # pages without advertising non-existent regional attested gateway hostnames.
 TR_CONTROL_PLANE_REGIONS="${TR_CONTROL_PLANE_REGIONS:-us-central1,us-east4,europe-west4,southamerica-east1}"
-# Comma-separated subset of TR_REGIONS that should run with min_scale=1
-# (always-on warm capacity). Anything in TR_REGIONS but NOT in
-# TR_WARM_REGIONS gets min_scale=0 (scale-to-zero — ~$0/mo idle, cold-
-# start tax on first request). Defaults to the regions where we run an
-# attested enclave MIG. São Paulo is warm as well so its gateway does not pay
-# a control-plane cold-start penalty on authorization or settlement.
+# Comma-separated subset of TR_REGIONS that should run with always-on warm
+# capacity. Anything outside TR_WARM_REGIONS gets min_scale=0 unless the
+# per-region map below says otherwise.
 TR_WARM_REGIONS="${TR_WARM_REGIONS:-us-central1,europe-west4,us-east4,southamerica-east1}"
+# Service-level minimums stay allocated across staged revision traffic shifts.
+# US East is deliberately larger: a 2026-08-22 customer burst exhausted the
+# old one-instance / concurrency-two ceiling before Cloud Run could scale.
+TR_CLOUD_RUN_MIN_INSTANCES_BY_REGION="${TR_CLOUD_RUN_MIN_INSTANCES_BY_REGION:-us-central1=2,us-east4=8,europe-west4=2,southamerica-east1=2}"
+# Billing handlers are small, synchronous Spanner operations dispatched to a
+# worker thread. Eight concurrent requests fit comfortably in 2 GiB and avoid
+# cold-starting dozens of instances for a short burst.
+TR_CLOUD_RUN_CONCURRENCY="${TR_CLOUD_RUN_CONCURRENCY:-8}"
+TR_SPANNER_POOL_SIZE="${TR_SPANNER_POOL_SIZE:-8}"
 # Cloud Run memory limit. 2Gi as of 2026-05-10.
 #
 # History of the bloat profile (RSS at idle, then under load):
@@ -38,14 +44,14 @@ TR_WARM_REGIONS="${TR_WARM_REGIONS:-us-central1,europe-west4,us-east4,southameri
 #   ~85 MB    google-cloud SDK imports (Spanner gRPC stubs, Bigtable,
 #             KMS, protobuf descriptors) — unavoidable floor
 #   ~50 MB    Spanner FixedSizePool(size=10) (SDK default) at first
-#             use, ~5 MB per gRPC session × 10 sessions; reduced to
-#             FixedSizePool(size=4) in storage_gcp.py → ~30 MB saved
+#             use, ~5 MB per gRPC session × 10 sessions; production pins
+#             eight sessions to match request concurrency without using 10
 #   ~20 MB    FastAPI + Pydantic + Starlette + uvicorn
 #   ~25 MB    create_app() route registration (244 routes worth of
 #             Pydantic dataclass shape metadata + dependency graphs)
-#   ~50-200 MB peak per in-flight request × concurrency
-#             (httpx connection pool + JSON parsing + gRPC streams).
-#             Halved by `--concurrency=2` in rollout.sh.
+#   Billing calls are small metadata payloads and mostly wait on Spanner. The
+#   browser proxy and public routes remain bounded by the 2 GiB container
+#   limit and are covered by staged traffic checks.
 #   ~10 MB    Sentry SDK breadcrumb + transport buffers
 #
 # Lazy-imported only when their first route is hit (not in startup):

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -488,6 +488,7 @@ ENV_VARS=(
   "TR_GOOGLE_DATA_MANAGER_KMS_KEY_NAME=${GOOGLE_ADS_KMS_KEY_NAME}"
   "TR_REGIONS=${TR_REGIONS}"
   "TR_PRIMARY_REGION=${TR_PRIMARY_REGION}"
+  "TR_SPANNER_POOL_SIZE=${TR_SPANNER_POOL_SIZE}"
   "VERTEX_PROJECT_ID=${PROJECT_ID}"
   "VERTEX_LOCATION=${REGION}"
   "TR_TRUST_GCP_SOURCE_COMMIT=${TRUST_SOURCE_COMMIT}"
@@ -648,6 +649,28 @@ is_warm_region() {
   esac
 }
 
+cloud_run_min_instances_for_region() {
+  local target="$1"
+  local entry
+  local region
+  local count
+  local entries=()
+  IFS=',' read -ra entries <<<"$TR_CLOUD_RUN_MIN_INSTANCES_BY_REGION"
+  for entry in "${entries[@]}"; do
+    region="${entry%%=*}"
+    count="${entry#*=}"
+    if [ "$region" = "$target" ] && [[ "$count" =~ ^[0-9]+$ ]]; then
+      printf '%s\n' "$count"
+      return 0
+    fi
+  done
+  if is_warm_region "$target"; then
+    printf '1\n'
+  else
+    printf '0\n'
+  fi
+}
+
 deploy_one_region() {
   local target="$1"
   local logfile="${2:-/dev/null}"
@@ -665,17 +688,13 @@ deploy_one_region() {
     log "deploying Cloud Run service ${SERVICE} to ${target}"
   fi
   prune_failed_revisions "$target" >>"$logfile" 2>&1 || true
-  # Cold regions (not in TR_WARM_REGIONS) scale to zero. The first request
-  # pays a ~5-10s cold-start tax; subsequent requests within the
-  # keep-warm window are fast. Explicit override via
-  # TR_CLOUD_RUN_MIN_INSTANCES wins for either kind.
+  # A global override wins. Otherwise use the per-region service minimum;
+  # unknown warm regions retain one instance and unknown cold regions scale to
+  # zero. Service-level minimums remain allocated while staged revisions split
+  # traffic, unlike revision-level minimums which can double or disappear.
   local min_instances="${TR_CLOUD_RUN_MIN_INSTANCES:-}"
   if [ -z "$min_instances" ]; then
-    if is_warm_region "$target"; then
-      min_instances=1
-    else
-      min_instances=0
-    fi
+    min_instances="$(cloud_run_min_instances_for_region "$target")"
   fi
   # /chat and /synth stream through /chat-proxy/v1 for browser CORS.
   # Synth can legitimately take several model calls before final output, so
@@ -686,8 +705,9 @@ deploy_one_region() {
       --allow-unauthenticated \
       --port 8080 \
       --memory "${TR_CLOUD_RUN_MEMORY:-1Gi}" \
-      --concurrency "${TR_CLOUD_RUN_CONCURRENCY:-2}" \
-      --min-instances "$min_instances" \
+      --concurrency "$TR_CLOUD_RUN_CONCURRENCY" \
+      --min "$min_instances" \
+      --min-instances default \
       --timeout "${TR_CLOUD_RUN_TIMEOUT_SECONDS:-300}" \
       --network "${TR_CLOUD_RUN_NETWORK:-default}" \
       --subnet "${TR_CLOUD_RUN_SUBNET:-default}" \

--- a/src/trusted_router/regional_quota_ledger.py
+++ b/src/trusted_router/regional_quota_ledger.py
@@ -478,12 +478,15 @@ class BigtableRegionalQuotaLedger:
         )
 
     def _version_equals_filter(self, version: bytes) -> Any:
+        # Filter order is the CAS invariant. Bigtable GC is asynchronous, so a
+        # historical version cell can remain readable after maxversions=1.
+        # Select the newest version first; only that cell may satisfy the token.
         return self._chain_filter(
             [
                 self._family_filter(f"^{_FAMILY}$"),
                 self._column_filter(b"^version$"),
-                self._value_filter(b"^" + re.escape(version) + b"$"),
                 self._cells_limit_filter(1),
+                self._value_filter(b"^" + re.escape(version) + b"$"),
             ]
         )
 

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -70,6 +70,7 @@ from trusted_router.partner_billing import (
 from trusted_router.pricing import resolve_request_rates
 from trusted_router.provider_compat import byok_storage_provider_candidates
 from trusted_router.provider_types import estimate_tokens_from_text
+from trusted_router.regional_quota_ledger import RegionalLeaseLedgerError
 from trusted_router.regions import choose_region, region_payload
 from trusted_router.request_attribution import (
     InvalidAttribution,
@@ -100,6 +101,7 @@ from trusted_router.services.broadcast import (
     should_drain_inline,
 )
 from trusted_router.services.federation import FederationClient, FederationUnavailable
+from trusted_router.services.regional_quota_leases import LeaseSettlementError
 from trusted_router.services.settle_outbox_apply import normalized_prompt_accounting
 from trusted_router.services.settle_outbox_drain import (
     drain_settle_outbox,
@@ -2019,17 +2021,37 @@ def _settle_gateway_authorization(
             None,
         )
         if callable(result_method):
-            finalize_result = cast(
-                TypedFinalizeResult,
-                result_method(
+            try:
+                finalize_result = cast(
+                    TypedFinalizeResult,
+                    result_method(
+                        authorization.id,
+                        success=success,
+                        actual_microdollars=actual_cost,
+                        selected_usage_type=selected_usage_type,
+                        generation=generation,
+                        user_model_payout=user_model_payout,
+                    ),
+                )
+            except (RegionalLeaseLedgerError, LeaseSettlementError):
+                # The frozen outbox intent is already durable. A local ledger
+                # conflict must remain retryable so the enclave can replay and
+                # the drain can finish once the ledger is healthy; surfacing an
+                # unclassified 500 only turns a recoverable billing delay into
+                # a client-visible router failure.
+                logger.error(
+                    "regional quota settlement temporarily unavailable "
+                    "authorization_id=%s lease_id=%s",
                     authorization.id,
-                    success=success,
-                    actual_microdollars=actual_cost,
-                    selected_usage_type=selected_usage_type,
-                    generation=generation,
-                    user_model_payout=user_model_payout,
-                ),
-            )
+                    authorization.regional_lease_id,
+                    exc_info=True,
+                )
+                raise api_error(
+                    503,
+                    "Settlement is temporarily unavailable",
+                    ErrorType.SERVICE_UNAVAILABLE,
+                    headers={"Retry-After": "1"},
+                ) from None
         else:
             finalized_legacy_contract = _typed_store.typed_finalize_gateway_authorization(
                 authorization.id,

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -365,11 +365,12 @@ class SpannerBigtableStore:
         # Bounded session pool. The SDK default is FixedSizePool(size=10),
         # which preallocates ten gRPC sessions on first use — ~5-8 MB each
         # = 50-80 MB of resident memory per Cloud Run instance. Our
-        # workload is single-shot reads/writes per HTTP request with
-        # `--concurrency=2` (rollout.sh), so we'll never need more than
-        # 2-3 sessions in flight; size=4 gives a 2x headroom over the
-        # in-flight ceiling. Saves ~30 MB per instance.
-        pool_size = int(os.environ.get("TR_SPANNER_POOL_SIZE", "4"))
+        # The production service admits eight small billing calls per instance.
+        # Match that ceiling so a burst queues on Spanner itself only when the
+        # database is saturated, not because this process preallocated too few
+        # sessions. Deploys pin the value explicitly; eight remains a safe
+        # standalone default under the 2 GiB container limit.
+        pool_size = int(os.environ.get("TR_SPANNER_POOL_SIZE", "8"))
         self._database = (
             spanner.Client(
                 project=project_id,

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -125,7 +125,17 @@ def test_all_attested_control_plane_regions_remain_warm() -> None:
         'southamerica-east1}"'
         in library
     )
-    assert '--min-instances "$min_instances"' in rollout
+    assert (
+        'TR_CLOUD_RUN_MIN_INSTANCES_BY_REGION="${TR_CLOUD_RUN_MIN_INSTANCES_BY_REGION:-'
+        'us-central1=2,us-east4=8,europe-west4=2,southamerica-east1=2}"'
+        in library
+    )
+    assert 'TR_CLOUD_RUN_CONCURRENCY="${TR_CLOUD_RUN_CONCURRENCY:-8}"' in library
+    assert 'TR_SPANNER_POOL_SIZE="${TR_SPANNER_POOL_SIZE:-8}"' in library
+    assert '--concurrency "$TR_CLOUD_RUN_CONCURRENCY"' in rollout
+    assert '--min "$min_instances"' in rollout
+    assert '--min-instances default' in rollout
+    assert '"TR_SPANNER_POOL_SIZE=${TR_SPANNER_POOL_SIZE}"' in rollout
 
 
 def test_production_deploy_interlocks_regional_quota_issuance() -> None:

--- a/tests/test_regional_quota_ledger.py
+++ b/tests/test_regional_quota_ledger.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
-from google.cloud.bigtable.row_filters import ValueRegexFilter
+from google.cloud.bigtable.row_filters import CellsColumnLimitFilter, ValueRegexFilter
 
 from trusted_router.regional_quota_ledger import (
     BigtableRegionalQuotaLedger,
@@ -136,6 +136,20 @@ def test_bigtable_health_check_fails_when_transactional_writes_fail() -> None:
 
     with pytest.raises(RegionalLeaseLedgerError, match="transactional health check"):
         ledger.health_check()
+
+
+def test_bigtable_cas_matches_only_the_latest_version_cell() -> None:
+    ledger = BigtableRegionalQuotaLedger({"us-central1": _FakeBigtableTable()})
+
+    predicate = ledger._version_equals_filter(b"stale-version")
+    filter_types = [type(filter_) for filter_ in predicate.filters]
+
+    # Bigtable applies a RowFilterChain in order. Limit the version column to
+    # its newest cell before checking the expected value, otherwise a retained
+    # historical version can satisfy the CAS and let a stale writer win.
+    assert filter_types.index(CellsColumnLimitFilter) < filter_types.index(
+        ValueRegexFilter
+    )
 
 
 @dataclass

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -14,8 +14,10 @@ from tests.fakes.spanner import _FakeTransaction, make_fake_store
 from trusted_router.config import Settings
 from trusted_router.custom_model_billing import user_model_payout_event_id
 from trusted_router.main import create_app
+from trusted_router.regional_quota_ledger import RegionalLeaseLedgerError
 from trusted_router.services import settle_outbox_apply as apply_mod
 from trusted_router.services import settle_outbox_drain as drain_mod
+from trusted_router.services.regional_quota_leases import LeaseSettlementError
 from trusted_router.services.settle_outbox_apply import ApplyOutcome
 from trusted_router.storage import InMemoryStore, configure_store
 from trusted_router.storage_gcp_authorize import (
@@ -1522,6 +1524,42 @@ def test_lost_charge_recovery_end_to_end(
     assert reap_expired_reservations(store._database, store._param_types, now=NOW) == 0
 
 
+@pytest.mark.parametrize(
+    "failure",
+    [
+        LeaseSettlementError("unknown regional reservation"),
+        RegionalLeaseLedgerError("regional ledger unavailable"),
+    ],
+)
+def test_regional_settlement_failure_is_retryable_after_outbox_enqueue(
+    fake_store: tuple[Any, Any, Any],
+    failure: Exception,
+) -> None:
+    store, db, _bt = fake_store
+    ws = "ws-regional-settle-retry"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+
+    def fail_finalize(*_args: Any, **_kwargs: Any) -> TypedFinalizeResult:
+        raise failure
+
+    store.typed_finalize_gateway_authorization_result = fail_finalize
+    client = _client(Settings(environment="test", settle_outbox_enabled=True))
+
+    response = client.post(
+        "/v1/internal/gateway/settle",
+        json=_settle_json(auth.id),
+    )
+
+    assert response.status_code == 503
+    assert response.headers["retry-after"] == "1"
+    assert response.json()["error"]["type"] == "service_unavailable"
+    row = _outbox(store).get(auth.id, "settle")
+    assert row is not None and row.status == "pending"
+    assert db.reservations[auth.credit_reservation_id]["settled"] is False
+
+
 def test_user_model_inline_finalize_loss_repairs_one_payout_from_frozen_outbox(
     fake_store: tuple[Any, Any, Any],
 ) -> None:
@@ -2082,4 +2120,3 @@ def test_user_model_settle_refuses_a_different_model_id(
         json=_typed_settle_body(auth, selected_model="trustedrouter/user-someone-else"),
     )
     assert other.status_code == 400, other.text
-

--- a/tests/test_storage_gcp.py
+++ b/tests/test_storage_gcp.py
@@ -100,9 +100,10 @@ def test_gcp_list_keys_uses_workspace_index() -> None:
 
 
 def test_gcp_store_disables_spanner_builtin_metrics(monkeypatch: Any) -> None:
-    from google.cloud import bigtable, spanner
+    from google.cloud import bigtable, spanner, spanner_v1
 
     spanner_calls: list[dict[str, Any]] = []
+    pool_sizes: list[int] = []
     monkeypatch.setattr(
         "trusted_router.storage_gcp.configure_spanner_rpc_deadlines",
         lambda _database: None,
@@ -120,6 +121,10 @@ def test_gcp_store_disables_spanner_builtin_metrics(monkeypatch: Any) -> None:
             # bound resident memory; accept-and-ignore here.
             return object()
 
+    class FakePool:
+        def __init__(self, *, size: int) -> None:
+            pool_sizes.append(size)
+
     class FakeBigtableClient:
         def __init__(self, **_kwargs: Any) -> None:
             pass
@@ -131,7 +136,9 @@ def test_gcp_store_disables_spanner_builtin_metrics(monkeypatch: Any) -> None:
             return object()
 
     monkeypatch.setattr(spanner, "Client", FakeSpannerClient)
+    monkeypatch.setattr(spanner_v1, "FixedSizePool", FakePool)
     monkeypatch.setattr(bigtable, "Client", FakeBigtableClient)
+    monkeypatch.delenv("TR_SPANNER_POOL_SIZE", raising=False)
 
     SpannerBigtableStore(
         project_id="project",
@@ -152,6 +159,7 @@ def test_gcp_store_disables_spanner_builtin_metrics(monkeypatch: Any) -> None:
             "disable_builtin_metrics": True,
         }
     ]
+    assert pool_sizes == [8]
 
 
 def test_gcp_store_opens_regional_ledger_when_local_issuance_is_disabled(


### PR DESCRIPTION
## Summary
- fix Bigtable regional quota CAS so only the newest retained version can satisfy a write
- return a retryable 503 after a durable settle-outbox enqueue when regional settlement is temporarily unavailable
- raise Cloud Run service minima and concurrency, with eight warm US East instances and an eight-session Spanner pool

## Incident evidence
- retained Bigtable history proved three synthetic holds were written and then overwritten by stale writers
- all three affected outbox rows were synthetic-only and were moved to the documented release_approved recovery state
- no customer workspace was affected by the regional CAS incident

## Tests
- regression test failed before the CAS filter-order fix and passes afterward
- focused regional quota, settlement recovery, deploy wiring, and Spanner pool tests pass
- ruff and mypy pass
- full pytest is running locally and CI will repeat it