### PR TITLE
Drop the `app` body key the gateway's Responses validator rejects (responses_pong 501 since 03:12 UTC)

### DIFF
--- a/src/trusted_router/synthetic/inference_sdk.py
+++ b/src/trusted_router/synthetic/inference_sdk.py
@@ -26,8 +26,9 @@ The session is configured to preserve what the probe measures:
   ``DO_NOT_TRACK``) must not silence it; an explicit ``telemetry=True`` wins
   over both.
 
-Synthetic marking keeps both server-recognized forms: the request body carries
-``metadata.trustedrouter_synthetic`` and ``app="TrustedRouter Synthetic"``.
+The request bodies are byte-for-byte what the raw-httpx probes sent: the
+gateway's Responses validator rejects unknown top-level keys with HTTP 501.
+Synthetic marking in the body uses ``metadata.trustedrouter_synthetic``.
 The beacon is sent with the monitor key, which ``/v1/client-events`` identifies
 server-side as synthetic regardless of the batch's client-supplied bit. No
 client honesty is required on either channel.

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -1183,7 +1183,6 @@ async def openai_chat_pong_probe(
         "max_tokens": 128,
         "temperature": 0,
         "metadata": {"trustedrouter_synthetic": "true"},
-        "app": "TrustedRouter Synthetic",
     }
     started = time.perf_counter()
     try:
@@ -1232,7 +1231,6 @@ async def responses_pong_probe(
         "max_output_tokens": 128,
         "temperature": 0,
         "metadata": {"trustedrouter_synthetic": "true"},
-        "app": "TrustedRouter Synthetic",
     }
     started = time.perf_counter()
     try:

--- a/tests/test_synthetic_sdk_probes.py
+++ b/tests/test_synthetic_sdk_probes.py
@@ -91,6 +91,10 @@ async def test_real_sdk_pong_probes_mark_requests_and_flush_valid_telemetry(
         "/v1/chat/completions",
         "/v1/responses",
     ]
+    expected_top_level_keys = {
+        "/v1/chat/completions": {"model", "messages", "max_tokens", "temperature", "metadata"},
+        "/v1/responses": {"model", "input", "max_output_tokens", "temperature", "metadata"},
+    }
     for request in gateway_requests:
         assert request.headers["x-tr-client"] == "v=1;a=0;s=0"
         assert request.headers["user-agent"].startswith("trusted-router-py/")
@@ -102,7 +106,9 @@ async def test_real_sdk_pong_probes_mark_requests_and_flush_valid_telemetry(
         }
         body = json.loads(request.content)
         assert body["metadata"] == {"trustedrouter_synthetic": "true"}
-        assert body["app"] == "TrustedRouter Synthetic"
+        # validateResponsesFields answers 501 not_supported_in_alpha for keys outside its
+        # allowlist; on 2026-08-22 an added "app" key took responses_pong down.
+        assert set(body) == expected_top_level_keys[request.url.path]
 
     assert [sample.probe_type for sample in samples] == ["openai_sdk_pong", "responses_pong"]
     for sample in samples:


### PR DESCRIPTION
## What broke

Since the #726 deploy landed at **03:12 UTC 2026-08-22**, every `responses_pong` synthetic sample has been **`down` / HTTP 501** (35/35 in the first ten minutes; up/200 for the 140 samples before it). `openai_sdk_pong` on the same SDK session stayed up.

Root cause, verified from both ends:

- #726 added a new top-level key to both pong bodies: `"app": "TrustedRouter Synthetic"`.
- The gateway's Responses validator (`quill-cloud-proxy` `enclave-go/internal/adapter/responses.go`, `validateResponsesFields`) allowlists the top-level keys of a `/v1/responses` body and answers **`501 not_supported_in_alpha`** for any non-null key outside it. `app` is not in the allowlist; `model`, `input`, `max_output_tokens`, `temperature`, `metadata` are.
- The enclave log for one failing probe: `enclave.request_end … route="/v1/responses" status=501 outcome="server_error" body_bytes=180 attribution="validation"`. 180 bytes is exactly the compact JSON size of the responses body **with** `app` (148 without).
- Chat tolerates the key only because its request type declares `App string \`json:"-"\`` — a body-level `app` is silently ignored there (attribution comes from `x-title` / `x-openrouter-title` headers). The key was inert on chat and fatal on responses.

## Fix

Remove `app` from both pong bodies so each is byte-for-byte what the pre-#726 raw-httpx probes sent. The `inference_sdk` docstring no longer advertises the key and says why the bodies are frozen. The test that asserted `body["app"]` now pins each body's **exact top-level key set** (chat: `{model, messages, max_tokens, temperature, metadata}`; responses: `{model, input, max_output_tokens, temperature, metadata}`) with a comment naming the validator, so adding a key to either body fails CI instead of the status page.

Not touched: the two other `"app"` literals in `probes.py` (settlement usage records, a different contract).

## Authorship and review

Authored by codex-cli from a written spec; reviewed by Claude (Fable). Reviewer re-ran the CI gates on the tree (`ruff check .`, `mypy`, `scripts.check_format_ordering`, the two synthetic test files) and an independent mutation — re-adding `"app": "x"` to the responses body — to confirm the new assertion fails on the bug and passes after restore. Results in the PR conversation.

## Deploy note

`deploy.yml` runs with `cancel-in-progress: false`, so this queues behind the in-flight #727 run; the probe recovers when this SHA's synthetic-job redeploy step runs. The first `client_source='tr'` rows (28 by 03:22 UTC, `tr-py 0.6.0`) and real-SDK beacons (`sdk_version=0.6.0` beside the canary's `0.0.0`) are unaffected by this change — the chat probe has been producing them since 03:14 UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
