### PR TITLE
Capture the active rollback revision exactly

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -393,14 +393,19 @@ jobs:
       - name: Capture pre-deploy revisions (for rollback)
         id: prev
         run: |
+          set -euo pipefail
           for region in us-central1 europe-west4 us-east4 southamerica-east1; do
-            rev=$(gcloud run services describe "${SERVICE}" \
+            service_json=$(gcloud run services describe "${SERVICE}" \
               --region="$region" --project="${PROJECT_ID}" \
-              --format='value(status.traffic[0].revisionName)' \
-              2>/dev/null || true)
+              --format=json)
+            if ! rev=$(python3 scripts/deploy/resolve_active_revision.py \
+                <<<"${service_json}"); then
+              echo "::error::${region} has no unambiguous 100%-traffic rollback revision"
+              exit 1
+            fi
             key="${region//-/_}_revision"
             echo "${key}=${rev}" >> "$GITHUB_OUTPUT"
-            echo "  pre-deploy ${region}: ${rev:-<none>}"
+            echo "  pre-deploy ${region}: ${rev}"
           done
 
       - name: Detect optional deploy surfaces

--- a/scripts/deploy/resolve_active_revision.py
+++ b/scripts/deploy/resolve_active_revision.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Resolve the sole serving revision from a Cloud Run service document."""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Mapping
+from typing import Any
+
+
+def resolve_active_revision(service: Mapping[str, Any]) -> str:
+    """Return the exact revision receiving 100% of untagged service traffic."""
+    status = service.get("status")
+    if not isinstance(status, Mapping):
+        raise ValueError("service status is not an object")
+    raw_traffic = status.get("traffic", [])
+    if not isinstance(raw_traffic, list):
+        raise ValueError("service status traffic is not a list")
+
+    active: list[tuple[Mapping[str, Any], int]] = []
+    for item in raw_traffic:
+        if not isinstance(item, Mapping):
+            raise ValueError("service status traffic contains a non-object entry")
+        try:
+            percent = int(item.get("percent") or 0)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("service status traffic has an invalid percent") from exc
+        if percent > 0:
+            active.append((item, percent))
+
+    if len(active) != 1 or active[0][1] != 100:
+        raise ValueError("expected exactly one 100%-traffic revision")
+
+    revision = active[0][0].get("revisionName")
+    if not isinstance(revision, str) or not revision:
+        raise ValueError("100%-traffic entry has no revisionName")
+    return revision
+
+
+def main() -> int:
+    try:
+        service = json.load(sys.stdin)
+        if not isinstance(service, Mapping):
+            raise ValueError("Cloud Run service document is not an object")
+        print(resolve_active_revision(service))
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(f"cannot resolve active Cloud Run revision: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_deploy_workflow_regions.py
+++ b/tests/test_deploy_workflow_regions.py
@@ -122,6 +122,20 @@ def test_superseded_push_stops_before_production_mutation() -> None:
     assert "if: ${{ needs.confirm-current-main.outputs.proceed == 'true' }}" in workflow
 
 
+def test_rollback_capture_uses_the_sole_serving_revision() -> None:
+    workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
+    start = workflow.index("- name: Capture pre-deploy revisions")
+    end = workflow.index("- name: Detect optional deploy surfaces", start)
+    capture = workflow[start:end]
+
+    assert "set -euo pipefail" in capture
+    assert "--format=json" in capture
+    assert "scripts/deploy/resolve_active_revision.py" in capture
+    assert "status.traffic[0]" not in capture
+    assert "|| true" not in capture
+    assert "has no unambiguous 100%-traffic rollback revision" in capture
+
+
 def test_runtime_secret_validation_is_parallel_and_does_not_restore_stale_ses_keys() -> None:
     workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
     sync = workflow.index("sync-runtime-secrets:")

--- a/tests/test_resolve_active_revision.py
+++ b/tests/test_resolve_active_revision.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.deploy.resolve_active_revision import resolve_active_revision
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/deploy/resolve_active_revision.py"
+
+
+def _service(*traffic: dict[str, Any]) -> dict[str, Any]:
+    return {"status": {"traffic": list(traffic)}}
+
+
+def test_resolves_serving_revision_after_tag_only_entry() -> None:
+    service = _service(
+        {
+            "revisionName": "trusted-router-older-tagged",
+            "tag": "rq-lease-canary",
+        },
+        {"revisionName": "trusted-router-current", "percent": 100},
+    )
+
+    assert resolve_active_revision(service) == "trusted-router-current"
+
+
+@pytest.mark.parametrize(
+    "traffic",
+    [
+        (),
+        (
+            {"revisionName": "trusted-router-a", "percent": 50},
+            {"revisionName": "trusted-router-b", "percent": 50},
+        ),
+        (
+            {"revisionName": "trusted-router-a", "percent": 100},
+            {"revisionName": "trusted-router-b", "percent": 100},
+        ),
+        ({"revisionName": "trusted-router-a", "percent": "invalid"},),
+        ({"percent": 100},),
+        ({"revisionName": "trusted-router-a", "percent": -1},),
+    ],
+)
+def test_rejects_ambiguous_or_invalid_traffic(
+    traffic: tuple[dict[str, Any], ...],
+) -> None:
+    with pytest.raises(ValueError):
+        resolve_active_revision(_service(*traffic))
+
+
+@pytest.mark.parametrize(
+    "service",
+    [
+        {},
+        {"status": None},
+        {"status": {"traffic": {}}},
+        {"status": {"traffic": ["not-an-object"]}},
+    ],
+)
+def test_rejects_malformed_service_documents(service: dict[str, Any]) -> None:
+    with pytest.raises(ValueError):
+        resolve_active_revision(service)
+
+
+def test_cli_fails_closed_on_split_traffic() -> None:
+    result = subprocess.run(  # noqa: S603 - fixed interpreter and repo-owned script
+        [sys.executable, str(SCRIPT)],
+        input=json.dumps(
+            _service(
+                {"revisionName": "trusted-router-a", "percent": 90},
+                {"revisionName": "trusted-router-b", "percent": 10},
+            )
+        ),
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "expected exactly one 100%-traffic revision" in result.stderr
+    assert result.stdout == ""


### PR DESCRIPTION
## Incident

A tagged Cloud Run traffic entry appeared first in status.traffic, so the deploy workflow captured an older tag-only revision instead of the actual 100%-traffic revision. The staged rollout removed the verified baseline from traffic and would have rolled back to the wrong revision.

## Fix

- resolve the sole positive 100%-traffic revision from the full Cloud Run service JSON
- ignore tag-only zero-percent entries
- fail closed on split, missing, malformed, duplicate, or unreadable traffic state before any production mutation
- cover the exact tag-first incident and workflow wiring

## Verification

- focused deploy/rollout tests: 24 passed on current main
- full suite on the patch-identical prior base: 5,306 passed, 301 skipped, 10 xfailed
- Ruff: green
- Mypy: 297 files green
- independent P0-P2 review: approved