### PR TITLE
Bridge the legacy combined rollout until the service split

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -353,6 +353,9 @@ jobs:
       # Keep the workflow value raw. rollout.sh normalizes preserve/false/true
       # only after reading the actual 100%-traffic primary revision.
       TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED: ${{ inputs.regional_quota_lease_issuance }}
+      # Temporary explicit opt-in for the pre-split all-routes service. Remove
+      # with the six-service production cutover in #712.
+      TR_ALLOW_DEPLOYED_COMBINED_SURFACE: "true"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/operations/service-surfaces.md
+++ b/docs/operations/service-surfaces.md
@@ -1,7 +1,10 @@
 # Service-surface bulkheads
 
 The TrustedRouter FastAPI image runs as an explicit, fail-closed process role.
-Production must never use the local/test-only `combined` role.
+Deployed `combined` mode is rejected by default. The sole temporary exception
+is the guarded GCP compatibility bridge described under Integration status;
+it exists only because the #714 enforcement landed before the #712 production
+split and requires a second, explicit opt-in.
 
 | Surface | Internet ownership | Background ownership | Capacity contract |
 |---|---|---|---|
@@ -138,3 +141,33 @@ service to `control`. Until that reviewed rollout patch lands, the helper must
 not be imported manually against the production URL map. The same patch must
 create and verify the four least-privilege runtime identities; an
 environment-only secret allowlist is insufficient.
+
+Because #714's enforcement landed before #712's production topology, the
+legacy service would otherwise refuse to start before the companion services
+and URL map exist. Until the full cutover in #712 lands, the guarded GCP
+workflow therefore explicitly sets
+`TR_SERVICE_SURFACE=combined` together with the temporary
+`TR_ALLOW_DEPLOYED_COMBINED_SURFACE=true` bridge. The application and rollout
+both reject deployed combined mode without that second opt-in. The bridge also
+requires `TR_RATE_LIMIT_ENABLED=false`: the legacy backend does not yet receive
+the edge-overwritten client identity, so #714's process limiter would otherwise
+collapse all Internet traffic into one bucket. Its existing synthetic and
+Sentry callers continue using the legacy internal gateway token only on this
+explicit bridge; split `internal` and `observer` services remain restricted to
+their dedicated observer token. The bridge also preserves the legacy
+session-aware `/bedrock-group-buy` page and its form return URLs; split
+`public` remains anonymous/cache-safe and split `control` owns the private
+`/bedrock-group-buy/manage` page. The two bounded inquiry/support form limiters
+likewise retain their pre-#714 socket-client identity only on the bridge;
+split `actions` continues to require the edge-overwritten identity contract.
+Remove the flag, rate-limit exception, legacy credential, form-identity and
+group-buy selections, and workflow wiring when #712 installs the split edge
+identity, services, and callers together. This is not an alternative
+production topology.
+
+The regional-quota reconciler Cloud Run Job also declares an explicit
+`TR_SERVICE_SURFACE=control`. It is a one-shot `worker` CLI and mounts no HTTP
+routes; `control` is the narrow role compatible with its existing Sentry and
+account-ledger storage bindings without granting either an internal gateway or
+observer credential. Worker validation skips the interactive control
+service's Stripe, attribution-cookie, and OAuth requirements.

--- a/scripts/deploy/regional_quota_reconciler.sh
+++ b/scripts/deploy/regional_quota_reconciler.sh
@@ -29,6 +29,11 @@ fi
 
 env_vars=(
   "TR_ENVIRONMENT=worker"
+  # The one-shot CLI initializes Sentry and reconciles account-ledger storage,
+  # but owns no gateway or observer token. control is the sole split surface
+  # compatible with that exact binding set; worker mode skips HTTP-only
+  # control credentials such as Stripe and the attribution-cookie secret.
+  "TR_SERVICE_SURFACE=control"
   "TR_RELEASE=${RELEASE}"
   "TR_STORAGE_BACKEND=spanner-bigtable"
   "TR_GCP_PROJECT_ID=${PROJECT_ID}"

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -4,6 +4,17 @@
 # trustedrouter.com routes to the nearest healthy region. Finally ensures the
 # HTTP -> HTTPS redirect on :80.
 
+# Temporary compatibility bridge for the legacy all-routes service.  Requiring
+# an explicit caller opt-in keeps a direct invocation fail-closed before it can
+# read or mutate cloud state; the guarded deploy workflow is the sole
+# production caller that supplies it.  Delete this block and both emitted env
+# vars when the six-service cutover in #712 lands.
+ALLOW_DEPLOYED_COMBINED_SURFACE="${TR_ALLOW_DEPLOYED_COMBINED_SURFACE:-false}"
+if [ "$ALLOW_DEPLOYED_COMBINED_SURFACE" != "true" ]; then
+  echo "refusing legacy combined rollout: set TR_ALLOW_DEPLOYED_COMBINED_SURFACE=true" >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/deploy/_lib.sh
 source "${SCRIPT_DIR}/_lib.sh"
@@ -428,6 +439,13 @@ fi
 
 ENV_VARS=(
   "TR_ENVIRONMENT=production"
+  "TR_SERVICE_SURFACE=combined"
+  "TR_ALLOW_DEPLOYED_COMBINED_SURFACE=${ALLOW_DEPLOYED_COMBINED_SURFACE}"
+  # The legacy backend does not yet receive a trusted, edge-overwritten client
+  # identity. The #714 process-local limiter would collapse all Internet users
+  # into one 240/min bucket. #712 removes this exception while installing each
+  # split service's edge identity and independent capacity policy.
+  "TR_RATE_LIMIT_ENABLED=false"
   "TR_RELEASE=$(git rev-parse --short HEAD 2>/dev/null || echo local)"
   # Request-based Cloud Run CPU can pause background coroutines. The scheduled
   # synthetic job invokes /internal/synthetic/remediate instead.

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -297,10 +297,10 @@ class Settings(BaseSettings):
     release: str = "local"
     service_name: str = "trusted-router"
     # One image serves several deliberately disjoint process roles. ``combined``
-    # preserves the local/test developer experience, but create_app refuses it
-    # in deployed environments so a missing env var cannot silently put the
-    # anonymous site, account control plane, and gateway billing authority back
-    # into one autoscaling/concurrency failure domain.
+    # preserves the local/test developer experience. Deployed use requires the
+    # separate, temporary migration opt-in below so a missing env var cannot
+    # silently put the anonymous site, account control plane, and gateway
+    # billing authority back into one autoscaling/concurrency failure domain.
     service_surface: Literal[
         "combined",
         "public",
@@ -309,6 +309,11 @@ class Settings(BaseSettings):
         "internal",
         "observer",
     ] = "combined"
+    # Temporary compatibility bridge for the pre-split GCP service.  This is
+    # deliberately separate from ``service_surface`` so a missing surface env
+    # var remains fail-closed.  Remove the flag and its sole production opt-in
+    # when the six-service rollout in #712 replaces the legacy service.
+    allow_deployed_combined_surface: bool = False
     api_base_url: str = "https://api.trustedrouter.com/v1"
     trusted_domain: str = "trustedrouter.com"
     # Additional first-party control-plane domains. They serve the same
@@ -1070,6 +1075,33 @@ class Settings(BaseSettings):
     @model_validator(mode="after")
     def production_is_fail_closed(self) -> Settings:
         environment = self.environment.lower()
+        surface = self.service_surface
+        deployed_combined_bridge = (
+            surface == "combined"
+            and environment not in {"local", "test"}
+            and self.allow_deployed_combined_surface
+        )
+        if self.allow_deployed_combined_surface and surface != "combined":
+            raise ValueError(
+                "TR_ALLOW_DEPLOYED_COMBINED_SURFACE may only be set with "
+                "TR_SERVICE_SURFACE=combined"
+            )
+        if (
+            surface == "combined"
+            and environment not in {"local", "test"}
+            and not deployed_combined_bridge
+        ):
+            raise ValueError(
+                "TR_SERVICE_SURFACE=combined is restricted to local/test unless the "
+                "temporary TR_ALLOW_DEPLOYED_COMBINED_SURFACE=true migration bridge "
+                "is explicitly enabled"
+            )
+        if deployed_combined_bridge and self.rate_limit_enabled:
+            raise ValueError(
+                "the temporary deployed combined bridge requires "
+                "TR_RATE_LIMIT_ENABLED=false until #712 installs trusted per-client "
+                "edge identity"
+            )
         if self.synthetic_control_plane_base_url:
             parsed_control_plane = urlsplit(self.synthetic_control_plane_base_url)
             if (
@@ -1384,7 +1416,6 @@ class Settings(BaseSettings):
             return self
         production = environment == "production"
         missing = []
-        surface = self.service_surface
         if environment != "worker" and surface in {"control", "public"}:
             if not self.attribution_cookie_secret:
                 missing.append("TR_ATTRIBUTION_COOKIE_SECRET")
@@ -1448,18 +1479,20 @@ class Settings(BaseSettings):
                 "TR_SYNTHETIC_MONITOR_API_KEY"
             )
 
-        # ``combined`` is a local/test compatibility surface.  create_app()
-        # rejects it before any deployed server starts, so do not let missing
-        # credentials mask that clearer ownership error here.
+        # #712 removes the temporary combined bridge.  Until then it retains
+        # the legacy service's complete authority and therefore its complete
+        # pre-split startup requirements.
         gateway_surfaces = {"internal"}
         sentry_surfaces = {"combined", "control", "internal", "observer"}
         account_surfaces = {"combined", "control"}
         email_surfaces = {"combined", "control", "actions"}
-        if surface in gateway_surfaces and not self.internal_gateway_token:
+        if (surface in gateway_surfaces or deployed_combined_bridge) and not (
+            self.internal_gateway_token
+        ):
             missing.append("TR_INTERNAL_GATEWAY_TOKEN")
         if surface in {"internal", "observer"} and not self.observer_internal_token:
             missing.append("TR_OBSERVER_INTERNAL_TOKEN")
-        if surface == "control" and environment != "worker":
+        if (surface == "control" or deployed_combined_bridge) and environment != "worker":
             if not self.stripe_webhook_secret:
                 missing.append("TR_STRIPE_WEBHOOK_SECRET")
             if not self.stripe_secret_key:
@@ -1486,8 +1519,10 @@ class Settings(BaseSettings):
 
         for field_name, owners in SERVICE_SURFACE_SECRET_OWNERS.items():
             configured_value = getattr(self, field_name)
-            if surface not in owners and _sensitive_setting_is_configured(
-                field_name, configured_value
+            if (
+                not deployed_combined_bridge
+                and surface not in owners
+                and _sensitive_setting_is_configured(field_name, configured_value)
             ):
                 environment_name = f"TR_{field_name.upper()}"
                 missing.append(

--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -99,10 +99,15 @@ def create_app(
 ) -> FastAPI:
     settings = settings or get_settings()
     surface = settings.service_surface
-    if surface == "combined" and settings.environment.lower() not in {"local", "test"}:
+    if (
+        surface == "combined"
+        and settings.environment.lower() not in {"local", "test"}
+        and not settings.allow_deployed_combined_surface
+    ):
         raise ValueError(
-            "TR_SERVICE_SURFACE=combined is restricted to local/test; deploy an explicit "
-            "public, actions, control, internal, or observer service surface"
+            "TR_SERVICE_SURFACE=combined is restricted to local/test unless the "
+            "temporary TR_ALLOW_DEPLOYED_COMBINED_SURFACE=true migration bridge is "
+            "explicitly enabled"
         )
     validate_auto_model_order(settings.auto_model_order)
     if configure_store_arg:

--- a/src/trusted_router/routes/bedrock_group_buy.py
+++ b/src/trusted_router/routes/bedrock_group_buy.py
@@ -52,10 +52,27 @@ def register_bedrock_group_buy_public_routes(app: FastAPI, settings: Settings) -
         response_class=HTMLResponse,
         include_in_schema=False,
     )
-    async def group_buy_page() -> HTMLResponse:
+    async def group_buy_page(request: Request) -> HTMLResponse:
+        if _legacy_combined_bridge(settings):
+            principal = _optional_user_principal(request, settings)
+            pledge = await _own_pledge(principal)
+            notice = ""
+            if request.query_params.get("saved") == "1":
+                notice = "Your commitment is saved. You can change or remove it at any time."
+            elif request.query_params.get("withdrawn") == "1":
+                notice = "Your commitment and anonymous message were removed."
+            return await _page_response(
+                settings,
+                principal=principal,
+                pledge=pledge,
+                notice=notice,
+                share_after_commit=request.query_params.get("saved") == "1",
+            )
         # This response is served by the anonymous/CDN-backed surface.  Never
         # inspect a session here: a signed-in visitor must receive the same
-        # cacheable document as everyone else.
+        # cacheable document as everyone else. The explicit legacy combined
+        # bridge above preserves the pre-#714 session-aware URL only until the
+        # split production cutover in #712.
         return await _page_response(settings, principal=None, pledge=None)
 
     @app.get("/v1/bedrock-group-buy")
@@ -80,8 +97,13 @@ def register_bedrock_group_buy_control_routes(app: FastAPI, settings: Settings) 
     async def manage_group_buy_page(request: Request) -> Response:
         principal = _optional_user_principal(request, settings)
         if principal is None:
+            next_path = (
+                "%2Fbedrock-group-buy"
+                if _legacy_combined_bridge(settings)
+                else "%2Fbedrock-group-buy%2Fmanage"
+            )
             return RedirectResponse(
-                "/bedrock-group-buy?reason=signin&next=%2Fbedrock-group-buy%2Fmanage",
+                f"/bedrock-group-buy?reason=signin&next={next_path}",
                 status_code=303,
             )
         pledge = await _own_pledge(principal)
@@ -103,8 +125,13 @@ def register_bedrock_group_buy_control_routes(app: FastAPI, settings: Settings) 
         _assert_same_origin(request, settings)
         principal = _optional_user_principal(request, settings)
         if principal is None:
+            next_path = (
+                "%2Fbedrock-group-buy"
+                if _legacy_combined_bridge(settings)
+                else "%2Fbedrock-group-buy%2Fmanage"
+            )
             return RedirectResponse(
-                "/bedrock-group-buy?reason=signin&next=%2Fbedrock-group-buy%2Fmanage",
+                f"/bedrock-group-buy?reason=signin&next={next_path}",
                 status_code=303,
             )
         payload: dict[str, object] = {}
@@ -123,6 +150,11 @@ def register_bedrock_group_buy_control_routes(app: FastAPI, settings: Settings) 
         _invalidate_public_snapshot()
         if saved is None:
             log.info("bedrock_group_buy.pledge_withdrawn")
+            if _legacy_combined_bridge(settings):
+                return RedirectResponse(
+                    "/bedrock-group-buy?withdrawn=1",
+                    status_code=303,
+                )
             return RedirectResponse(
                 "/bedrock-group-buy/manage?withdrawn=1",
                 status_code=303,
@@ -131,6 +163,11 @@ def register_bedrock_group_buy_control_routes(app: FastAPI, settings: Settings) 
             "bedrock_group_buy.pledge_saved public_message=%s",
             saved.publish_message,
         )
+        if _legacy_combined_bridge(settings):
+            return RedirectResponse(
+                "/bedrock-group-buy?saved=1#share",
+                status_code=303,
+            )
         return RedirectResponse("/bedrock-group-buy/manage?saved=1#share", status_code=303)
 
     @app.post("/bedrock-group-buy/withdraw")
@@ -138,14 +175,21 @@ def register_bedrock_group_buy_control_routes(app: FastAPI, settings: Settings) 
         _assert_same_origin(request, settings)
         principal = _optional_user_principal(request, settings)
         if principal is None:
+            next_path = (
+                "%2Fbedrock-group-buy"
+                if _legacy_combined_bridge(settings)
+                else "%2Fbedrock-group-buy%2Fmanage"
+            )
             return RedirectResponse(
-                "/bedrock-group-buy?reason=signin&next=%2Fbedrock-group-buy%2Fmanage",
+                f"/bedrock-group-buy?reason=signin&next={next_path}",
                 status_code=303,
             )
         assert principal.user is not None
         await run_in_threadpool(STORE.withdraw_bedrock_group_buy_pledge, principal.user.id)
         _invalidate_public_snapshot()
         log.info("bedrock_group_buy.pledge_withdrawn")
+        if _legacy_combined_bridge(settings):
+            return RedirectResponse("/bedrock-group-buy?withdrawn=1", status_code=303)
         return RedirectResponse("/bedrock-group-buy/manage?withdrawn=1", status_code=303)
 
     @app.get("/v1/bedrock-group-buy/me")
@@ -249,6 +293,13 @@ def _invalidate_public_snapshot() -> None:
     with _snapshot_lock:
         _snapshot_value = None
         _snapshot_expires_at = 0.0
+
+
+def _legacy_combined_bridge(settings: Settings) -> bool:
+    return (
+        settings.service_surface == "combined"
+        and settings.allow_deployed_combined_surface
+    )
 
 
 def _optional_user_principal(request: Request, settings: Settings) -> Principal | None:

--- a/src/trusted_router/routes/internal/_shared.py
+++ b/src/trusted_router/routes/internal/_shared.py
@@ -3,9 +3,10 @@
 `require_internal_gateway` selects the credential owned by the route, not just
 the process. Billing routes accept only TR_INTERNAL_GATEWAY_TOKEN, while
 synthetic/Sentry routes accept only TR_OBSERVER_INTERNAL_TOKEN even when they
-are mounted on the internal service. That lets provider-facing monitor jobs
-operate without holding the credential that authorizes billing mutations.
-The local/test escape hatch lets unit tests avoid wiring a token.
+are mounted on the internal service. The sole temporary exception is the
+explicit deployed-combined bridge: its pre-#714 monitor jobs still present the
+legacy gateway token until #712 completes the split. The local/test escape
+hatch lets unit tests avoid wiring a token.
 """
 
 from __future__ import annotations
@@ -31,7 +32,11 @@ def internal_service_credential(
     observer_path = normalized_path in _OBSERVER_INTERNAL_EXACT_PATHS or normalized_path.startswith(
         _OBSERVER_INTERNAL_PATH_PREFIXES
     )
-    if observer_path:
+    legacy_combined_bridge = (
+        settings.service_surface == "combined"
+        and settings.allow_deployed_combined_surface
+    )
+    if observer_path and not legacy_combined_bridge:
         return "observer", settings.observer_internal_token
     return "gateway", settings.internal_gateway_token
 

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -299,6 +299,23 @@ def _bound_inquiry_clients(cutoff: float) -> None:
         _INQUIRY_HITS.popitem(last=False)
 
 
+def _inquiry_client_identity(request: Request, settings: Settings) -> str:
+    """Select the bounded form limiter's client identity.
+
+    The explicit combined bridge preserves the pre-#714 socket identity until
+    #712 moves these actions behind an edge that overwrites the dedicated
+    client-IP header. Split surfaces retain the fail-closed edge identity
+    contract and never trust forwarding headers or an arbitrary socket peer.
+    """
+
+    if (
+        settings.service_surface == "combined"
+        and settings.allow_deployed_combined_surface
+    ):
+        return request.client.host if request.client else "unknown"
+    return normalized_client_identity(request, settings)
+
+
 async def _handle_trustedos_inquiry(settings: Settings, request: Request) -> JSONResponse:
     """Receive a TrustedOS partner-inquiry submission and email it to the
     configured recipient. Returns an opaque {"ok": true} on accept so the
@@ -325,7 +342,7 @@ async def _handle_trustedos_inquiry(settings: Settings, request: Request) -> JSO
     if not name or not message or not _EMAIL_RE.match(email):
         return JSONResponse({"ok": False, "error": "missing_fields"}, status_code=422)
 
-    client_ip = normalized_client_identity(request, settings)
+    client_ip = _inquiry_client_identity(request, settings)
     if not _inquiry_rate_ok(client_ip):
         return JSONResponse({"ok": False, "error": "rate_limited"}, status_code=429)
 
@@ -445,7 +462,7 @@ async def _handle_support_inquiry(settings: Settings, request: Request) -> JSONR
     ):
         return JSONResponse({"ok": False, "error": "missing_fields"}, status_code=422)
 
-    client_ip = normalized_client_identity(request, settings)
+    client_ip = _inquiry_client_identity(request, settings)
     if not _inquiry_rate_ok(f"support:{client_ip}"):
         return JSONResponse({"ok": False, "error": "rate_limited"}, status_code=429)
 

--- a/src/trusted_router/synthetic/internal_auth.py
+++ b/src/trusted_router/synthetic/internal_auth.py
@@ -9,6 +9,14 @@ def synthetic_observer_token(settings: Settings) -> str | None:
     There is deliberately no fallback to the billing gateway token. Synthetic
     jobs may post observer-owned samples and remediation requests, but must
     never inherit the credential that authorizes billing gateway mutations.
+    The explicit combined migration bridge is the one bounded exception: its
+    already-deployed pre-#714 jobs and server share that legacy credential
+    until the split rollout in #712 replaces both ends together.
     """
 
+    if (
+        settings.service_surface == "combined"
+        and settings.allow_deployed_combined_surface
+    ):
+        return settings.internal_gateway_token
     return settings.observer_internal_token

--- a/tests/test_bedrock_group_buy.py
+++ b/tests/test_bedrock_group_buy.py
@@ -17,6 +17,8 @@ from trusted_router.bedrock_group_buy import (
     pledge_from_mapping,
     public_snapshot,
 )
+from trusted_router.config import Settings
+from trusted_router.main import create_app
 from trusted_router.money import MICRODOLLARS_PER_DOLLAR
 from trusted_router.storage import STORE, InMemoryStore
 from trusted_router.storage_group_buy import bedrock_group_buy_shard
@@ -365,6 +367,53 @@ def test_post_commit_confirmation_prompts_sharing_and_deeper_group_discount(
     assert "Share on LinkedIn" in confirmation.text
     assert "Email a founder" in confirmation.text
     assert confirmation.headers["cache-control"] == "private, no-store"
+
+
+def test_combined_bridge_preserves_legacy_group_buy_page_and_return_urls(
+    test_settings: Settings,
+    user_headers: dict[str, str],
+) -> None:
+    bridge_settings = Settings(
+        **{
+            **test_settings.model_dump(),
+            "allow_deployed_combined_surface": True,
+        }
+    )
+    client = TestClient(create_app(bridge_settings, init_observability=False))
+
+    anonymous_signin = client.post(
+        "/bedrock-group-buy/pledge",
+        data=_payload(),
+        follow_redirects=False,
+    )
+    saved = client.post(
+        "/bedrock-group-buy/pledge",
+        headers=user_headers,
+        data=_payload(),
+        follow_redirects=False,
+    )
+    personalized = client.get(
+        "/bedrock-group-buy?saved=1",
+        headers=user_headers,
+    )
+    withdrawn = client.post(
+        "/bedrock-group-buy/withdraw",
+        headers=user_headers,
+        follow_redirects=False,
+    )
+
+    assert anonymous_signin.status_code == 303
+    assert anonymous_signin.headers["location"] == (
+        "/bedrock-group-buy?reason=signin&next=%2Fbedrock-group-buy"
+    )
+    assert saved.status_code == 303
+    assert saved.headers["location"] == "/bedrock-group-buy?saved=1#share"
+    assert personalized.status_code == 200
+    assert personalized.headers["cache-control"] == "private, no-store"
+    assert "Avery Private" in personalized.text
+    assert "You are in. Bring one more buyer." in personalized.text
+    assert withdrawn.status_code == 303
+    assert withdrawn.headers["location"] == "/bedrock-group-buy?withdrawn=1"
 
 
 def test_public_group_buy_page_never_reads_or_varies_on_session(

--- a/tests/test_custom_model_verification_gate.py
+++ b/tests/test_custom_model_verification_gate.py
@@ -51,7 +51,16 @@ def _direct_model(user: Any) -> Any:
 def test_custom_model_verification_default_is_off_in_test() -> None:
     assert Settings(environment="test").custom_models_verification_enforced is False
     assert Settings(environment="local").custom_models_verification_enforced is False
-    assert Settings(environment="staging").custom_models_verification_enforced is True
+    assert (
+        Settings(
+            environment="staging",
+            service_surface="control",
+            attribution_cookie_secret="staging-attribution-" + "a" * 32,
+            stripe_webhook_secret="whsec_" + "staging",
+            stripe_secret_key="sk_" + "staging",
+        ).custom_models_verification_enforced
+        is True
+    )
 
 
 def test_enforced_api_post_and_patch_return_exact_verification_error() -> None:

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -1,4 +1,6 @@
+import os
 import re
+import subprocess
 from pathlib import Path
 
 from scripts.check_price_coverage import (
@@ -32,6 +34,39 @@ def test_guarded_deploy_applies_clickhouse_delivery_schemas_before_rollout() -> 
     assert workflow.index(generation) < workflow.index(rollout)
     assert workflow.index(provider_outbox) < workflow.index(rollout)
     assert workflow.index(operational_outbox) < workflow.index(rollout)
+
+
+def test_legacy_combined_rollout_requires_and_emits_the_workflow_opt_in() -> None:
+    rollout_path = ROOT / "scripts/deploy/rollout.sh"
+    rollout = rollout_path.read_text(encoding="utf-8")
+    workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
+
+    env = os.environ.copy()
+    env.pop("TR_ALLOW_DEPLOYED_COMBINED_SURFACE", None)
+    rejected = subprocess.run(  # noqa: S603 - fixed repo-owned script
+        ["bash", str(rollout_path)],  # noqa: S607 - fixed interpreter
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert rejected.returncode != 0
+    assert (
+        "refusing legacy combined rollout: set "
+        "TR_ALLOW_DEPLOYED_COMBINED_SURFACE=true" in rejected.stderr
+    )
+
+    env_vars = rollout.split("ENV_VARS=(", 1)[1].split("\n)", 1)[0]
+    assert '"TR_SERVICE_SURFACE=combined"' in env_vars
+    assert (
+        '"TR_ALLOW_DEPLOYED_COMBINED_SURFACE=${ALLOW_DEPLOYED_COMBINED_SURFACE}"'
+        in env_vars
+    )
+    assert '"TR_RATE_LIMIT_ENABLED=false"' in env_vars
+    assert 'TR_ALLOW_DEPLOYED_COMBINED_SURFACE: "true"' in workflow
+    assert "#712" in rollout
+    assert "#712" in workflow
 
 
 def test_deploy_pins_thirty_cent_signup_credit_policy() -> None:
@@ -197,6 +232,8 @@ def test_production_deploy_provisions_and_schedules_regional_quota_reconciliatio
     assert "europe-west4=tr-quota-europe-west4" not in library
     assert 'SCHEDULE="${TR_REGIONAL_QUOTA_RECONCILER_SCHEDULE:-* * * * *}"' in reconciler
     assert "trusted_router.regional_quota_reconcile_cli" in reconciler
+    assert '"TR_ENVIRONMENT=worker"' in reconciler
+    assert '"TR_SERVICE_SURFACE=control"' in reconciler
     assert "--oauth-service-account-email=\"$RUN_SERVICE_ACCOUNT\"" in reconciler
     assert "--clear-headers" in reconciler
     assert "gc secrets" not in reconciler

--- a/tests/test_fleet_command_center.py
+++ b/tests/test_fleet_command_center.py
@@ -150,7 +150,11 @@ def test_run_synthetic_once_gates_peer_probes_off_in_test_env(
     assert called == []
 
     # any non-test environment with peers configured: the branch runs.
-    canary = Settings(environment="canary")
+    canary = Settings(
+        environment="canary",
+        service_surface="observer",
+        observer_internal_token="canary-observer-" + "o" * 32,
+    )
     assert canary.synthetic_fleet_peers  # default-on config
     asyncio.run(run_synthetic_once(canary))
     assert called == ["fleet"]

--- a/tests/test_google_data_manager.py
+++ b/tests/test_google_data_manager.py
@@ -301,7 +301,7 @@ def test_config_fails_closed_when_enabled_without_destination_ids() -> None:
 
 def test_worker_config_requires_dedicated_kms_outside_local_test() -> None:
     with pytest.raises(ValueError, match="TR_GOOGLE_DATA_MANAGER_KMS_KEY_NAME"):
-        _settings(environment="worker")
+        _settings(environment="worker", service_surface="control")
 
 
 def test_metadata_identity_token_is_scoped_and_cached() -> None:

--- a/tests/test_ops_chat.py
+++ b/tests/test_ops_chat.py
@@ -102,6 +102,7 @@ def test_production_ops_chat_requires_https_destinations() -> None:
     with pytest.raises(ValidationError, match="only HTTPS URLs"):
         Settings(
             environment="production",
+            service_surface="actions",
             ops_chat_webhook_urls="http://a.example",
             ops_chat_webhook_secret=hook_secret,
         )

--- a/tests/test_phone_funding_gate.py
+++ b/tests/test_phone_funding_gate.py
@@ -72,7 +72,16 @@ def _console_client() -> tuple[TestClient, Any]:
 def test_phone_funding_default_is_off_in_test_and_local() -> None:
     assert Settings(environment="test").phone_verification_funding_enforced is False
     assert Settings(environment="local").phone_verification_funding_enforced is False
-    assert Settings(environment="staging").phone_verification_funding_enforced is True
+    assert (
+        Settings(
+            environment="staging",
+            service_surface="control",
+            attribution_cookie_secret="staging-attribution-" + "a" * 32,
+            stripe_webhook_secret="whsec_" + "staging",
+            stripe_secret_key="sk_" + "staging",
+        ).phone_verification_funding_enforced
+        is True
+    )
     assert (
         Settings(
             environment="test",

--- a/tests/test_rate_limit_trust.py
+++ b/tests/test_rate_limit_trust.py
@@ -711,3 +711,107 @@ def test_public_inquiry_limiters_and_display_use_canonical_production_source(
     assert partner.status_code == 200, partner.text
     assert seen_rate_subjects == ["support:2001:db8::1", "2001:db8::1"]
     assert "IP:      2001:db8::1" in sent_messages[-1].text_body
+
+
+@pytest.mark.parametrize(
+    ("path", "payload", "subject_prefix"),
+    (
+        (
+            "/support/inquiry",
+            {
+                "name": "Ada",
+                "email": "ada@example.com",
+                "category": "api",
+                "subject": "Help",
+                "message": "Please help",
+                "website": "",
+            },
+            "support:",
+        ),
+        (
+            "/trustedos/inquiry",
+            {
+                "name": "Ada",
+                "email": "ada@example.com",
+                "company": "Analytical Engines",
+                "message": "Partnership request",
+                "website": "",
+            },
+            "",
+        ),
+    ),
+)
+def test_combined_bridge_forms_keep_legacy_client_identity_without_weakening_split(
+    path: str,
+    payload: dict[str, str],
+    subject_prefix: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen_rate_subjects: list[str] = []
+
+    class FakeEmailService:
+        def send(self, _message: EmailMessage) -> bool:
+            return True
+
+    async def fake_fanout(*_args: object, **_kwargs: object) -> OpsChatFanoutResult:
+        return OpsChatFanoutResult(configured=0, accepted=0)
+
+    monkeypatch.setattr(
+        public_routes,
+        "_inquiry_rate_ok",
+        lambda subject: seen_rate_subjects.append(subject) or True,
+    )
+    monkeypatch.setattr(
+        public_routes,
+        "get_email_service",
+        lambda _settings: FakeEmailService(),
+    )
+    monkeypatch.setattr(public_routes, "fanout_support_message", fake_fanout)
+
+    bridged = Settings.model_construct(
+        environment="production",
+        service_surface="combined",
+        allow_deployed_combined_surface=True,
+        rate_limit_enabled=False,
+        partner_inquiry_email="leads@example.com",
+    )
+    bridge_app = create_app(
+        bridged,
+        configure_store_arg=False,
+        init_observability=False,
+    )
+    for address in ("198.51.100.10", "203.0.113.20"):
+        response = TestClient(bridge_app, client=(address, 50000)).post(
+            path,
+            json=payload,
+        )
+        assert response.status_code == 200, response.text
+    assert seen_rate_subjects == [
+        f"{subject_prefix}198.51.100.10",
+        f"{subject_prefix}203.0.113.20",
+    ]
+
+    seen_rate_subjects.clear()
+    split = Settings.model_construct(
+        environment="production",
+        service_surface="actions",
+        allow_deployed_combined_surface=False,
+        rate_limit_enabled=False,
+        rate_limit_client_ip_mode="untrusted",
+        partner_inquiry_email="leads@example.com",
+    )
+    split_app = create_app(
+        split,
+        configure_store_arg=False,
+        init_observability=False,
+    )
+    for address in ("198.51.100.10", "203.0.113.20"):
+        response = TestClient(split_app, client=(address, 50000)).post(
+            path,
+            json=payload,
+        )
+        assert response.status_code == 200, response.text
+    assert seen_rate_subjects == [
+        f"{subject_prefix}untrusted_lb",
+        f"{subject_prefix}untrusted_lb",
+    ]

--- a/tests/test_regional_quota_leases.py
+++ b/tests/test_regional_quota_leases.py
@@ -323,12 +323,14 @@ def test_regional_leases_default_off_and_fail_closed_without_dependencies() -> N
     with pytest.raises(ValidationError, match="Spanner GCP backend"):
         Settings(
             environment="staging",
+            service_surface="internal",
             regional_quota_leases_enabled=True,
             regional_quota_lease_pilot_workspace_ids="workspace-1",
         )
     with pytest.raises(ValidationError, match="typed request records"):
         Settings(
             environment="staging",
+            service_surface="internal",
             storage_backend="spanner-bigtable",
             regional_quota_leases_enabled=True,
             regional_quota_lease_pilot_workspace_ids="workspace-1",
@@ -354,6 +356,9 @@ def test_regional_lease_shard_count_is_bounded(count: int) -> None:
 def test_regional_lease_production_config_requires_fixed_profiles_and_outbox() -> None:
     common = {
         "environment": "staging",
+        "service_surface": "internal",
+        "internal_gateway_token": "staging-gateway-" + "g" * 32,
+        "observer_internal_token": "staging-observer-" + "o" * 32,
         "storage_backend": "spanner-bigtable",
         "bigtable_instance_id": "trusted-router-logs",
         "request_record_write_mode": "typed",

--- a/tests/test_regional_quota_reconcile_cli.py
+++ b/tests/test_regional_quota_reconcile_cli.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import os
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from pydantic import ValidationError
 
+from trusted_router import config as config_module
 from trusted_router import regional_quota_reconcile_cli as worker
 
 
@@ -191,6 +195,7 @@ def test_worker_environment_does_not_require_serving_pilot_allowlist() -> None:
 
     settings = Settings(
         environment="worker",
+        service_surface="control",
         storage_backend="spanner-bigtable",
         gcp_project_id="project",
         spanner_instance_id="instance",
@@ -206,6 +211,58 @@ def test_worker_environment_does_not_require_serving_pilot_allowlist() -> None:
     assert settings.regional_quota_lease_pilot_workspaces == frozenset()
 
 
+def test_deployed_job_env_selects_only_surface_compatible_with_its_bindings(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    # Exercise the same zero-argument factory the Cloud Run Job CLI calls,
+    # isolated from an operator shell, repo .env, or local developer key file.
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(  # noqa: SLF001 - isolate the local-only Settings source.
+        config_module._LocalKeyFileSource,
+        "__call__",
+        lambda _self: {},
+    )
+    for name in tuple(os.environ):
+        if name.startswith("TR_"):
+            monkeypatch.delenv(name)
+    job_env = {
+        "TR_ENVIRONMENT": "worker",
+        "TR_STORAGE_BACKEND": "spanner-bigtable",
+        "TR_GCP_PROJECT_ID": "project",
+        "TR_SPANNER_INSTANCE_ID": "instance",
+        "TR_SPANNER_DATABASE_ID": "database",
+        "TR_BIGTABLE_INSTANCE_ID": "bigtable",
+        "TR_BIGTABLE_GENERATION_TABLE": "generations",
+        "TR_REQUEST_RECORD_WRITE_MODE": "typed",
+        "TR_SETTLE_OUTBOX_ENABLED": "true",
+        "TR_REGIONAL_QUOTA_LEASES_ENABLED": "true",
+        "TR_REGIONAL_QUOTA_RECONCILER_WORKER": "true",
+        "TR_REGIONAL_QUOTA_BIGTABLE_TABLE": "regional-quota",
+        "TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES": "us-central1=quota-us",
+        "TR_REGIONAL_QUOTA_RECONCILE_LIMIT": "25",
+        "TR_PRIMARY_REGION": "us-central1",
+        "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED": "true",
+        "TR_SENTRY_DSN": "https://example@example.ingest.sentry.io/1",
+    }
+    for name, value in job_env.items():
+        monkeypatch.setenv(name, value)
+
+    invalid_surfaces = ("combined", "public", "actions", "internal", "observer")
+    for surface in invalid_surfaces:
+        monkeypatch.setenv("TR_SERVICE_SURFACE", surface)
+        with pytest.raises(ValidationError):
+            worker.get_settings()
+
+    monkeypatch.setenv("TR_SERVICE_SURFACE", "control")
+    settings = worker.get_settings()
+
+    assert settings.environment == "worker"
+    assert settings.service_surface == "control"
+    assert settings.regional_quota_reconciler_worker is True
+    assert settings.sentry_dsn == job_env["TR_SENTRY_DSN"]
+
+
 def test_generic_worker_issuance_still_requires_serving_pilot_allowlist() -> None:
     from pydantic import ValidationError
 
@@ -214,6 +271,7 @@ def test_generic_worker_issuance_still_requires_serving_pilot_allowlist() -> Non
     with pytest.raises(ValidationError, match="PILOT_WORKSPACE_IDS"):
         Settings(
             environment="worker",
+            service_surface="control",
             storage_backend="spanner-bigtable",
             gcp_project_id="project",
             spanner_instance_id="instance",

--- a/tests/test_request_record_retention.py
+++ b/tests/test_request_record_retention.py
@@ -736,17 +736,15 @@ def test_bigtable_reads_prefer_bounded_family_and_fall_back_to_legacy(
 
 def test_typed_production_mode_requires_durable_outbox() -> None:
     internal_token = "internal-" + "token"
-    webhook_secret = "whsec_" + "test"
-    stripe_secret = "sk_" + "test"
     with pytest.raises(
         ValidationError,
         match="TR_SETTLE_OUTBOX_ENABLED=true",
     ):
         Settings(
             environment="production",
+            service_surface="internal",
             internal_gateway_token=internal_token,
-            stripe_webhook_secret=webhook_secret,
-            stripe_secret_key=stripe_secret,
+            observer_internal_token="observer-" + "token",
             sentry_dsn="https://example@example.ingest.sentry.io/1",
             storage_backend="spanner-bigtable",
             spanner_instance_id="trusted-router",

--- a/tests/test_service_surface_secret_isolation.py
+++ b/tests/test_service_surface_secret_isolation.py
@@ -11,6 +11,7 @@ from trusted_router.acquisition import (
     encode_attribution_cookie,
 )
 from trusted_router.config import SERVICE_SURFACE_SECRET_OWNERS, Settings
+from trusted_router.main import create_app
 
 _ATTRIBUTION_SECRET = "attribution-only-" + "a" * 32
 _GATEWAY_SECRET = "gateway-only-" + "g" * 32
@@ -286,6 +287,120 @@ def _production(surface: str, **overrides: object) -> Settings:
     values: dict[str, object] = {**_PRODUCTION_STORAGE, "service_surface": surface}
     values.update(overrides)
     return Settings(**values)
+
+
+def _full_combined_bridge_production() -> dict[str, object]:
+    """Legacy GCP bindings spanning every future split-service owner."""
+    return {
+        **_PRODUCTION_STORAGE,
+        **_SENSITIVE_TEST_VALUES,
+        "service_surface": "combined",
+        "allow_deployed_combined_surface": True,
+        "rate_limit_enabled": False,
+        "ses_from_email": "noreply@example.com",
+        "ops_chat_webhook_urls": "https://ops.example/hook",
+        "google_data_manager_account_id": "account",
+        "google_data_manager_signup_action_id": "signup",
+        "google_data_manager_activated_action_id": "activated",
+        "google_data_manager_purchase_action_id": "purchase",
+        "adyen_merchant_account": "merchant",
+        "federation_home_base_url": "https://home.example",
+        # The test credential fixtures contain exactly this alias.
+        "trusted_domain_aliases": "allyrouter.com",
+    }
+
+
+def test_production_combined_rejects_full_bindings_without_the_bridge() -> None:
+    values = _full_combined_bridge_production()
+    values.pop("allow_deployed_combined_surface")
+
+    with pytest.raises(
+        ValidationError,
+        match="TR_ALLOW_DEPLOYED_COMBINED_SURFACE",
+    ):
+        Settings(**values)
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    ("internal_gateway_token", "stripe_webhook_secret", "stripe_secret_key"),
+)
+def test_combined_bridge_preserves_legacy_required_credentials(field_name: str) -> None:
+    values = _full_combined_bridge_production()
+    values[field_name] = None
+
+    with pytest.raises(ValidationError, match=f"TR_{field_name.upper()}"):
+        Settings(**values)
+
+
+def test_combined_bridge_requires_the_legacy_rate_limiter_to_stay_off() -> None:
+    values = _full_combined_bridge_production()
+    values["rate_limit_enabled"] = True
+
+    with pytest.raises(ValidationError, match="TR_RATE_LIMIT_ENABLED=false"):
+        Settings(**values)
+
+
+@pytest.mark.parametrize(
+    ("surface", "overrides"),
+    (
+        (
+            "public",
+            {
+                "attribution_cookie_secret": _ATTRIBUTION_SECRET,
+                "google_oauth_login_available": False,
+                "github_oauth_login_available": False,
+            },
+        ),
+        ("actions", {}),
+        (
+            "control",
+            {
+                "attribution_cookie_secret": _ATTRIBUTION_SECRET,
+                "stripe_webhook_secret": "whsec-test",
+                "stripe_secret_key": "sk-test",
+            },
+        ),
+        (
+            "internal",
+            {
+                "internal_gateway_token": _GATEWAY_SECRET,
+                "observer_internal_token": _SENSITIVE_TEST_VALUES[
+                    "observer_internal_token"
+                ],
+            },
+        ),
+        (
+            "observer",
+            {
+                "observer_internal_token": _SENSITIVE_TEST_VALUES[
+                    "observer_internal_token"
+                ],
+            },
+        ),
+    ),
+)
+def test_split_deployed_surfaces_keep_their_rate_limiter_default(
+    surface: str,
+    overrides: dict[str, object],
+) -> None:
+    settings = Settings(environment="canary", service_surface=surface, **overrides)
+
+    assert settings.rate_limit_enabled is True
+
+
+def test_combined_bridge_accepts_full_legacy_bindings_and_mounts_all_routes() -> None:
+    settings = Settings(**_full_combined_bridge_production())
+
+    for field_name, expected in _SENSITIVE_TEST_VALUES.items():
+        assert getattr(settings, field_name) == expected
+    app = create_app(
+        settings,
+        configure_store_arg=False,
+        init_observability=False,
+    )
+    paths = {route.path for route in app.routes}
+    assert {"/", "/console", "/internal/gateway/authorize"} <= paths
 
 
 @pytest.mark.parametrize(("field_name", "surface"), _UNAUTHORIZED_SENSITIVE_CASES)
@@ -631,6 +746,8 @@ def test_attribution_and_gateway_credentials_cannot_be_reused() -> None:
             "combined",
             **{
                 **_CONTROL_SECRETS,
+                "allow_deployed_combined_surface": True,
+                "rate_limit_enabled": False,
                 "internal_gateway_token": _GATEWAY_SECRET,
                 "attribution_cookie_secret": _GATEWAY_SECRET,
             },

--- a/tests/test_service_surfaces.py
+++ b/tests/test_service_surfaces.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 import pytest
 from fastapi import FastAPI
 from fastapi.routing import APIRoute
+from pydantic import ValidationError
 
 from trusted_router.config import Settings
 from trusted_router.main import create_app
@@ -57,12 +58,31 @@ def _without_shared_health(routes: Iterable[tuple[str, str]]) -> set[tuple[str, 
     }
 
 
-def test_combined_surface_is_rejected_outside_local_and_test() -> None:
-    with pytest.raises(ValueError, match="TR_SERVICE_SURFACE"):
+def test_deployed_combined_surface_requires_the_explicit_migration_bridge() -> None:
+    with pytest.raises(ValidationError, match="TR_ALLOW_DEPLOYED_COMBINED_SURFACE"):
+        Settings(environment="canary", service_surface="combined")
+
+    # Defense in depth: even a Settings object constructed without validation
+    # cannot make create_app mount every authority in a deployed process.
+    unvalidated = Settings.model_construct(
+        environment="canary",
+        service_surface="combined",
+        allow_deployed_combined_surface=False,
+    )
+    with pytest.raises(ValueError, match="TR_ALLOW_DEPLOYED_COMBINED_SURFACE"):
         create_app(
-            Settings(environment="canary", service_surface="combined"),
+            unvalidated,
             configure_store_arg=False,
             init_observability=False,
+        )
+
+
+def test_combined_migration_bridge_cannot_be_enabled_on_a_split_surface() -> None:
+    with pytest.raises(ValidationError, match="may only be set"):
+        Settings(
+            environment="test",
+            service_surface="control",
+            allow_deployed_combined_surface=True,
         )
 
 
@@ -498,6 +518,102 @@ def test_observer_surface_accepts_only_its_own_internal_token() -> None:
 
     assert denied.status_code == 401
     assert admitted.status_code == 400
+
+
+@pytest.mark.parametrize("prefix", ["", "/v1"])
+def test_combined_bridge_preserves_gateway_auth_for_synthetic_and_sentry(
+    prefix: str,
+) -> None:
+    from fastapi.testclient import TestClient
+
+    gateway_token = "legacy-combined-gateway-token"  # noqa: S105 - test token.
+    observer_token = "future-split-observer-token"  # noqa: S105 - test token.
+    settings = Settings.model_construct(
+        environment="canary",
+        service_surface="combined",
+        allow_deployed_combined_surface=True,
+        rate_limit_enabled=False,
+        enable_sentry_test_route=True,
+        internal_gateway_token=gateway_token,
+        observer_internal_token=observer_token,
+    )
+    client = TestClient(
+        create_app(
+            settings,
+            configure_store_arg=False,
+            init_observability=False,
+        ),
+        raise_server_exceptions=False,
+    )
+    malformed = b'{"not": "finished"'
+
+    synthetic_denied = client.post(
+        f"{prefix}/internal/synthetic/run",
+        headers={
+            "x-trustedrouter-internal-token": observer_token,
+            "content-type": "application/json",
+        },
+        content=malformed,
+    )
+    synthetic_admitted = client.post(
+        f"{prefix}/internal/synthetic/run",
+        headers={
+            "x-trustedrouter-internal-token": gateway_token,
+            "content-type": "application/json",
+        },
+        content=malformed,
+    )
+    sentry_denied = client.get(
+        f"{prefix}/internal/sentry-test",
+        headers={"x-trustedrouter-internal-token": observer_token},
+    )
+    sentry_admitted = client.get(
+        f"{prefix}/internal/sentry-test",
+        headers={"x-trustedrouter-internal-token": gateway_token},
+    )
+
+    assert synthetic_denied.status_code == 401
+    assert synthetic_admitted.status_code == 400
+    assert sentry_denied.status_code == 401
+    assert sentry_admitted.status_code == 500
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        "/internal/synthetic/run",
+        "/v1/internal/synthetic/samples",
+        "/internal/sentry-test",
+        "/v1/internal/sentry-test",
+    ),
+)
+def test_observer_credential_selection_changes_only_for_the_combined_bridge(
+    path: str,
+) -> None:
+    from trusted_router.routes.internal._shared import internal_service_credential
+
+    gateway_token = "legacy-combined-gateway-token"  # noqa: S105 - test token.
+    observer_token = "future-split-observer-token"  # noqa: S105 - test token.
+    common = {
+        "environment": "test",
+        "internal_gateway_token": gateway_token,
+        "observer_internal_token": observer_token,
+    }
+    bridged = Settings(
+        **common,
+        service_surface="combined",
+        allow_deployed_combined_surface=True,
+    )
+    unbridged = Settings(**common, service_surface="combined")
+    internal = Settings(**common, service_surface="internal")
+    observer = Settings(**common, service_surface="observer")
+
+    assert internal_service_credential(bridged, path) == ("gateway", gateway_token)
+    for settings in (unbridged, internal, observer):
+        assert internal_service_credential(settings, path) == (
+            "observer",
+            observer_token,
+        )
 
 
 @pytest.mark.parametrize("prefix", ["", "/v1"])

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -2848,7 +2848,7 @@ async def test_primary_synthetic_job_invokes_scheduled_remediator(
     assert seen_urls == ["https://trustedrouter.com/v1/internal/synthetic/remediate"]
 
 
-def test_synthetic_credential_selection_never_falls_back_to_billing_gateway() -> None:
+def test_synthetic_credential_selection_uses_gateway_only_for_combined_bridge() -> None:
     from trusted_router.synthetic.internal_auth import synthetic_observer_token
 
     both = Settings(
@@ -2860,9 +2860,16 @@ def test_synthetic_credential_selection_never_falls_back_to_billing_gateway() ->
         environment="test",
         internal_gateway_token="billing-only",  # noqa: S106 - test placeholder.
     )
+    bridged = Settings(
+        environment="test",
+        service_surface="combined",
+        allow_deployed_combined_surface=True,
+        internal_gateway_token="billing-only",  # noqa: S106 - test placeholder.
+    )
 
     assert synthetic_observer_token(both) == "observer-only"
     assert synthetic_observer_token(billing_only) is None
+    assert synthetic_observer_token(bridged) == "billing-only"
 
 
 @pytest.mark.asyncio

--- a/tests/test_user_model_rules.py
+++ b/tests/test_user_model_rules.py
@@ -119,7 +119,14 @@ async def test_endpoint_url_requires_https_outside_local_test(
     )
     with pytest.raises(HTTPException, match="https"):
         await validate_endpoint_url(
-            "http://owner.example/base", Settings(environment="staging")
+            "http://owner.example/base",
+            Settings(
+                environment="staging",
+                service_surface="control",
+                attribution_cookie_secret="staging-attribution-" + "a" * 32,
+                stripe_webhook_secret="whsec_" + "staging",
+                stripe_secret_key="sk_" + "staging",
+            ),
         )
 
 

--- a/tests/test_x402_billing.py
+++ b/tests/test_x402_billing.py
@@ -95,10 +95,15 @@ def test_x402_disabled_returns_404_without_auth(client: TestClient) -> None:
 
 def test_x402_config_refuses_mock_or_missing_stripe_outside_local_test() -> None:
     with pytest.raises(ValueError, match="TR_X402_ALLOW_MOCK_PAYMENTS"):
-        Settings(environment="staging", x402_allow_mock_payments=True)
+        Settings(
+            environment="staging",
+            service_surface="control",
+            x402_allow_mock_payments=True,
+        )
     with pytest.raises(ValueError, match="TR_X402_ENABLED"):
         Settings(
             environment="staging",
+            service_surface="control",
             x402_enabled=True,
             stripe_secret_key=None,
             stripe_webhook_secret=None,


### PR DESCRIPTION
Fixes the production boot blocker caused by #714 landing before the six-service cutover in draft #712.

- keeps deployed combined mode fail-closed by default
- requires an explicit temporary migration opt-in in both Settings and create_app
- makes rollout.sh refuse before cloud setup unless the guarded workflow opts in
- preserves the pre-#714 gateway and Stripe startup requirements
- documents the exact removal condition when #712 lands

Validated locally: 326 focused tests, full Ruff, mypy (297 files), and Bash syntax are green. Full pytest and an independent P0-P2 review are running on the exact commit.