### PR TITLE
Prove the full-queue drop structurally instead of by wall clock (flake held deploy gate-on-ci)

### DIFF
--- a/tests/test_axiom_nonblocking.py
+++ b/tests/test_axiom_nonblocking.py
@@ -37,6 +37,7 @@ import queue
 import threading
 import time
 from collections.abc import Iterator, Mapping
+from contextlib import suppress
 
 import pytest
 
@@ -405,14 +406,26 @@ def test_a_full_queue_drops_instead_of_blocking() -> None:
     """Backpressure must cost observability, never latency."""
     handler = _DroppingQueueHandler(queue.Queue(maxsize=1))
     handler.handle(_record("first"))
+    returned = threading.Event()
 
-    started = time.monotonic()
-    for index in range(50):
-        handler.handle(_record(f"overflow {index}"))
-    elapsed = time.monotonic() - started
+    def overflow() -> None:
+        handler.handle(_record("overflow"))
+        returned.set()
 
-    assert elapsed < 0.5, f"a full queue blocked for {elapsed:.3f}s"
-    assert handler._dropped >= 50, "drops were not counted"
+    caller = threading.Thread(target=overflow, daemon=True)
+    caller.start()
+    try:
+        assert returned.wait(timeout=5), "a full queue waited for capacity"
+        assert handler.queue.qsize() == 1, "overflow item was not dropped"
+        assert handler._dropped == 1, "drop was not counted"
+    finally:
+        # Release a deliberately blocking mutation without leaking its thread;
+        # an unexpectedly empty queue must not mask the assertion above.
+        with suppress(queue.Empty):
+            handler.queue.get_nowait()
+        caller.join(timeout=5)
+
+    assert not caller.is_alive()
 
 
 def test_the_idempotency_guard_knows_the_handler_that_is_actually_attached() -> None:


### PR DESCRIPTION
`tests/test_axiom_nonblocking.py::test_a_full_queue_drops_instead_of_blocking` asserted that fifty `handle()` calls against a full `maxsize=1` queue finish in under 0.5 s. Under `pytest -n 4` on a shared runner that mostly measures fifty `prepare()` scrub passes, not whether the put blocks, and it failed on main at `aa0b4fd` (CI run 32551919490: "a full queue blocked for 0.630s", 1 failed / 6040 passed) — nothing in that commit touched the queue. Because `deploy.yml`'s `gate-on-ci` requires same-commit CI green, the flake held a production deploy for a 25-minute re-run on 2026-08-22 at ~04:57Z.

## Change

The property is structural in `_DroppingQueueHandler.enqueue` (`put_nowait` → `queue.Full` → `_note_drop`), so the test now proves it structurally: the overflow `handle()` runs on a daemon thread; the test asserts the call **returned** (`Event.wait(timeout=5)` — the bound is only a hang guard), that the item was **dropped** (`qsize()` unchanged at 1) and **counted** (`_dropped == 1`), and releases queue capacity in `finally` so a deliberately blocking mutant's thread can be joined rather than leaked. One test file, +19/−6.

## Evidence

- Load loop, whole file, `-n 4`, 10 repetitions: **10/10 pass** (author) and **10/10 pass** (reviewer, independently).
- Mutation — `enqueue` changed to blocking `put`: **FAILED** in ~5 s (`AssertionError: a full queue waited for capacity`), not a hang; restored: pass (author: `1 failed in 5.29s` / `1 passed`; reviewer: fails at 8 s wall / `10 passed in 0.70s`).
- `ruff check .` clean; `mypy` clean (297 files); `git diff --check` clean.

## Authorship and review

Authored by codex-cli from a written spec; reviewed by Claude (Fable), who applied one hardening (`suppress(queue.Empty)` around the `finally` release so an unexpectedly empty queue cannot mask the assertion above it) and re-ran every check above on the final tree.

**Merge note:** hold until the #732 bridge deploy has passed `confirm-current-main` — a new main commit before that resets the bridge's same-commit CI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
