### PR TITLE
Bridge synthetic.sh for the deployed combined surface (monitor jobs stuck on de2d15e)

### DIFF
--- a/scripts/deploy/synthetic.sh
+++ b/scripts/deploy/synthetic.sh
@@ -4,6 +4,13 @@
 # samples to internal ingest endpoints. Short uptime probes must never wait on
 # the longer throughput benchmark.
 
+if [ "${TR_ALLOW_DEPLOYED_COMBINED_SURFACE:-}" != "true" ]; then
+  [ -n "${TR_BILLING_SERVICE:-}" ] || {
+    echo "ERROR: TR_BILLING_SERVICE is required; refusing observer-token jobs against the legacy service" >&2
+    exit 1
+  }
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/deploy/_lib.sh
 source "${SCRIPT_DIR}/_lib.sh"
@@ -15,36 +22,50 @@ source "${SCRIPT_DIR}/_private_run_ingress.sh"
 # would deploy successfully and then silently 401 every ingest. Require the
 # independently named internal service explicitly and re-check its live
 # contract immediately before every job deployment below.
-[ -n "${TR_BILLING_SERVICE:-}" ] || {
-  echo "ERROR: TR_BILLING_SERVICE is required; refusing observer-token jobs against the legacy service" >&2
-  exit 1
-}
-[ "$TR_BILLING_SERVICE" != "$SERVICE" ] || {
-  echo "ERROR: TR_BILLING_SERVICE must be separate from legacy SERVICE" >&2
-  exit 1
-}
-case "$TR_BILLING_SERVICE" in
-  *[!a-zA-Z0-9-]*|'')
-    echo "ERROR: invalid TR_BILLING_SERVICE" >&2
-    exit 2
-    ;;
-esac
-SYNTHETIC_INGEST_SERVICE="$TR_BILLING_SERVICE"
+if [ "${TR_ALLOW_DEPLOYED_COMBINED_SURFACE:-}" = "true" ]; then
+  DEPLOYED_COMBINED_BRIDGE=true
+  SYNTHETIC_INGEST_SERVICE="$SERVICE"
+else
+  DEPLOYED_COMBINED_BRIDGE=false
+  [ "$TR_BILLING_SERVICE" != "$SERVICE" ] || {
+    echo "ERROR: TR_BILLING_SERVICE must be separate from legacy SERVICE" >&2
+    exit 1
+  }
+  case "$TR_BILLING_SERVICE" in
+    *[!a-zA-Z0-9-]*|'')
+      echo "ERROR: invalid TR_BILLING_SERVICE" >&2
+      exit 2
+      ;;
+  esac
+  SYNTHETIC_INGEST_SERVICE="$TR_BILLING_SERVICE"
+fi
 
 if ! gc secrets describe trustedrouter-synthetic-monitor-api-key >/dev/null 2>&1; then
   log "synthetic monitor key secret is missing; skipping synthetic monitor deploy"
   exit 0
 fi
-if ! gc secrets describe trustedrouter-observer-internal-token >/dev/null 2>&1; then
-  echo "ERROR: trustedrouter-observer-internal-token is required for synthetic ingest" >&2
-  exit 1
-fi
 
-SECRET_ENVS=(
-  "TR_SENTRY_DSN=trustedrouter-sentry-dsn:latest"
-  "TR_OBSERVER_INTERNAL_TOKEN=trustedrouter-observer-internal-token:latest"
-  "TR_SYNTHETIC_MONITOR_API_KEY=trustedrouter-synthetic-monitor-api-key:latest"
-)
+if [ "$DEPLOYED_COMBINED_BRIDGE" = "true" ]; then
+  SECRET_ENVS=(
+    "TR_SENTRY_DSN=trustedrouter-sentry-dsn:latest"
+    "TR_STRIPE_SECRET_KEY=trustedrouter-stripe-secret-key:latest"
+    "TR_STRIPE_WEBHOOK_SECRET=trustedrouter-stripe-webhook-secret:latest"
+    "TR_INTERNAL_GATEWAY_TOKEN=trustedrouter-internal-gateway-token:latest"
+    "TR_SYNTHETIC_MONITOR_API_KEY=trustedrouter-synthetic-monitor-api-key:latest"
+  )
+  JOB_SECRET_FLAG="--update-secrets"
+else
+  if ! gc secrets describe trustedrouter-observer-internal-token >/dev/null 2>&1; then
+    echo "ERROR: trustedrouter-observer-internal-token is required for synthetic ingest" >&2
+    exit 1
+  fi
+  SECRET_ENVS=(
+    "TR_SENTRY_DSN=trustedrouter-sentry-dsn:latest"
+    "TR_OBSERVER_INTERNAL_TOKEN=trustedrouter-observer-internal-token:latest"
+    "TR_SYNTHETIC_MONITOR_API_KEY=trustedrouter-synthetic-monitor-api-key:latest"
+  )
+  JOB_SECRET_FLAG="--set-secrets"
+fi
 add_secret_env_if_exists() {
   local env_name="$1"
   local secret_name="$2"
@@ -60,9 +81,7 @@ add_secret_env_if_exists "DEEPSEEK_API_KEY" "trustedrouter-deepseek-api-key"
 add_secret_env_if_exists "MISTRAL_API_KEY" "trustedrouter-mistral-api-key"
 add_secret_env_if_exists "KIMI_API_KEY" "trustedrouter-kimi-api-key"
 add_secret_env_if_exists "ZAI_API_KEY" "trustedrouter-zai-api-key"
-# Complete allowlist: --set-secrets removes legacy gateway/payment bindings
-# from an existing job instead of preserving omitted secrets across updates.
-SET_SECRETS="$(IFS=,; echo "${SECRET_ENVS[*]}")"
+JOB_SECRETS="$(IFS=,; echo "${SECRET_ENVS[*]}")"
 
 BASE_ENV_VARS=(
   # These are one-shot workers, not the public control-plane process. Using
@@ -70,7 +89,11 @@ BASE_ENV_VARS=(
   # of the monitor containers while their actual storage and probe inputs
   # remain explicit below.
   "TR_ENVIRONMENT=worker"
-  "TR_SERVICE_SURFACE=observer"
+)
+if [ "$DEPLOYED_COMBINED_BRIDGE" != "true" ]; then
+  BASE_ENV_VARS+=("TR_SERVICE_SURFACE=observer")
+fi
+BASE_ENV_VARS+=(
   "TR_RELEASE=$(git rev-parse --short HEAD 2>/dev/null || echo local)"
   "TR_ENABLE_LIVE_PROVIDERS=false"
   "TR_API_BASE_URL=https://api.trustedrouter.com/v1"
@@ -81,6 +104,11 @@ BASE_ENV_VARS=(
   "TR_SPANNER_DATABASE_ID=${SPANNER_DATABASE_ID}"
   "TR_BIGTABLE_INSTANCE_ID=${BIGTABLE_INSTANCE_ID}"
   "TR_BIGTABLE_GENERATION_TABLE=${BIGTABLE_GENERATION_TABLE}"
+)
+if [ "$DEPLOYED_COMBINED_BRIDGE" = "true" ]; then
+  BASE_ENV_VARS+=("TR_BYOK_KMS_KEY_NAME=${BYOK_KMS_KEY_NAME}")
+fi
+BASE_ENV_VARS+=(
   "TR_REGIONS=${TR_REGIONS}"
   "TR_PRIMARY_REGION=${TR_PRIMARY_REGION}"
   "TR_SYNTHETIC_MONITOR_MODEL=trustedrouter/monitor"
@@ -156,6 +184,16 @@ if secret_name("TR_INTERNAL_GATEWAY_TOKEN") != expected_gateway_secret:
     echo "ERROR: internal synthetic ingest service contract failed in ${target_region}" >&2
     return 1
   fi
+}
+
+prepare_synthetic_ingest_target() {
+  local target_region="$1"
+
+  if [ "$DEPLOYED_COMBINED_BRIDGE" = "true" ]; then
+    return
+  fi
+  ensure_private_run_app_access "$target_region"
+  verify_synthetic_ingest_service_contract "$target_region"
 }
 
 if ! gc artifacts docker images describe "$IMAGE" >/dev/null 2>&1; then
@@ -240,8 +278,7 @@ for monitor_region in "${_REGION_LIST[@]}"; do
   fi
   set_env_vars="$(IFS='|'; echo "^|^${env_vars[*]}")"
 
-  ensure_private_run_app_access "$monitor_region"
-  verify_synthetic_ingest_service_contract "$monitor_region"
+  prepare_synthetic_ingest_target "$monitor_region"
   log "deploying synthetic Cloud Run job ${job_name} in ${monitor_region}"
   gc run jobs deploy "$job_name" \
     --region "$monitor_region" \
@@ -249,9 +286,9 @@ for monitor_region in "${_REGION_LIST[@]}"; do
     --command="/app/.venv/bin/python" \
     --args="-m,trusted_router.synthetic.cli" \
     --service-account "$RUN_SERVICE_ACCOUNT" \
-    "${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]}" \
+    "${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]+"${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]}"}" \
     --set-env-vars "$set_env_vars" \
-    --set-secrets "$SET_SECRETS" \
+    "$JOB_SECRET_FLAG" "$JOB_SECRETS" \
     --max-retries 0 \
     --task-timeout 300s \
     --cpu 2 \
@@ -314,8 +351,7 @@ throughput_env_vars=(
 )
 throughput_set_env_vars="$(IFS='|'; echo "^|^${throughput_env_vars[*]}")"
 
-ensure_private_run_app_access "$throughput_region"
-verify_synthetic_ingest_service_contract "$throughput_region"
+prepare_synthetic_ingest_target "$throughput_region"
 log "deploying isolated throughput Cloud Run job ${throughput_job_name}"
 gc run jobs deploy "$throughput_job_name" \
   --region "$throughput_region" \
@@ -323,9 +359,9 @@ gc run jobs deploy "$throughput_job_name" \
   --command="/app/.venv/bin/python" \
   --args="-m,trusted_router.synthetic.cli" \
   --service-account "$RUN_SERVICE_ACCOUNT" \
-  "${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]}" \
+  "${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]+"${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]}"}" \
   --set-env-vars "$throughput_set_env_vars" \
-  --set-secrets "$SET_SECRETS" \
+  "$JOB_SECRET_FLAG" "$JOB_SECRETS" \
   --max-retries 0 \
   --task-timeout 300s \
   --cpu 1 \
@@ -369,8 +405,7 @@ image_env_vars=(
 )
 image_set_env_vars="$(IFS='|'; echo "^|^${image_env_vars[*]}")"
 
-ensure_private_run_app_access "$image_region"
-verify_synthetic_ingest_service_contract "$image_region"
+prepare_synthetic_ingest_target "$image_region"
 log "deploying isolated image-generation Cloud Run job ${image_job_name}"
 gc run jobs deploy "$image_job_name" \
   --region "$image_region" \
@@ -378,9 +413,9 @@ gc run jobs deploy "$image_job_name" \
   --command="/app/.venv/bin/python" \
   --args="-m,trusted_router.synthetic.image_generation" \
   --service-account "$RUN_SERVICE_ACCOUNT" \
-  "${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]}" \
+  "${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]+"${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]}"}" \
   --set-env-vars "$image_set_env_vars" \
-  --set-secrets "$SET_SECRETS" \
+  "$JOB_SECRET_FLAG" "$JOB_SECRETS" \
   --max-retries 0 \
   --task-timeout 300s \
   --cpu 1 \
@@ -411,8 +446,7 @@ video_env_vars=(
 )
 video_set_env_vars="$(IFS='|'; echo "^|^${video_env_vars[*]}")"
 
-ensure_private_run_app_access "$video_region"
-verify_synthetic_ingest_service_contract "$video_region"
+prepare_synthetic_ingest_target "$video_region"
 log "deploying isolated daily video-generation Cloud Run job ${video_job_name}"
 gc run jobs deploy "$video_job_name" \
   --region "$video_region" \
@@ -420,9 +454,9 @@ gc run jobs deploy "$video_job_name" \
   --command="/app/.venv/bin/python" \
   --args="-m,trusted_router.synthetic.video_generation" \
   --service-account "$RUN_SERVICE_ACCOUNT" \
-  "${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]}" \
+  "${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]+"${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]}"}" \
   --set-env-vars "$video_set_env_vars" \
-  --set-secrets "$SET_SECRETS" \
+  "$JOB_SECRET_FLAG" "$JOB_SECRETS" \
   --max-retries 0 \
   --task-timeout 1200s \
   --cpu 1 \

--- a/scripts/deploy/synthetic.sh
+++ b/scripts/deploy/synthetic.sh
@@ -4,6 +4,7 @@
 # samples to internal ingest endpoints. Short uptime probes must never wait on
 # the longer throughput benchmark.
 
+# Intentionally refuse before sourcing _lib.sh so this fail-fast path makes zero gcloud calls.
 if [ "${TR_ALLOW_DEPLOYED_COMBINED_SURFACE:-}" != "true" ]; then
   [ -n "${TR_BILLING_SERVICE:-}" ] || {
     echo "ERROR: TR_BILLING_SERVICE is required; refusing observer-token jobs against the legacy service" >&2
@@ -90,7 +91,13 @@ BASE_ENV_VARS=(
   # remain explicit below.
   "TR_ENVIRONMENT=worker"
 )
-if [ "$DEPLOYED_COMBINED_BRIDGE" != "true" ]; then
+if [ "$DEPLOYED_COMBINED_BRIDGE" = "true" ]; then
+  BASE_ENV_VARS+=(
+    "TR_SERVICE_SURFACE=combined"
+    "TR_ALLOW_DEPLOYED_COMBINED_SURFACE=true"
+    "TR_RATE_LIMIT_ENABLED=false"
+  )
+else
   BASE_ENV_VARS+=("TR_SERVICE_SURFACE=observer")
 fi
 BASE_ENV_VARS+=(
@@ -190,6 +197,8 @@ prepare_synthetic_ingest_target() {
   local target_region="$1"
 
   if [ "$DEPLOYED_COMBINED_BRIDGE" = "true" ]; then
+    # The combined service uses ingress=all in every region, matching the pre-#714
+    # jobs' public run.app path; VPC/private-ingress setup belongs to the split path.
     return
   fi
   ensure_private_run_app_access "$target_region"

--- a/tests/test_ddos_edge_deploy.py
+++ b/tests/test_ddos_edge_deploy.py
@@ -702,20 +702,27 @@ def test_every_synthetic_job_uses_private_run_app_ingress() -> None:
         '"TR_OBSERVER_INTERNAL_TOKEN=trustedrouter-observer-internal-token:latest"'
         in deploy
     )
-    assert '"TR_INTERNAL_GATEWAY_TOKEN=' not in deploy
-    assert "TR_INTERNAL_GATEWAY_TOKEN=trustedrouter" not in deploy
+    assert (
+        '"TR_INTERNAL_GATEWAY_TOKEN=trustedrouter-internal-gateway-token:latest"'
+        in deploy
+    )
     assert (
         'SYNTHETIC_INGEST_SERVICE="$TR_BILLING_SERVICE"'
     ) in deploy
+    assert 'SYNTHETIC_INGEST_SERVICE="$SERVICE"' in deploy
     assert "TR_SYNTHETIC_INGEST_SERVICE" not in deploy
     assert deploy.count("${SYNTHETIC_INGEST_SERVICE}-${PROJECT_NUMBER}") == 4
-    assert "https://${SERVICE}-${PROJECT_NUMBER}" not in deploy
     assert deploy.count("gc run jobs deploy") == 4
-    assert deploy.count('--set-secrets "$SET_SECRETS"') == 4
-    assert "--update-secrets" not in deploy
-    assert deploy.count("ensure_private_run_app_access") == 4
-    assert deploy.count("verify_synthetic_ingest_service_contract") == 5
-    assert deploy.count('"${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]}"') == 4
+    assert deploy.count('"$JOB_SECRET_FLAG" "$JOB_SECRETS"') == 4
+    assert 'JOB_SECRET_FLAG="--set-secrets"' in deploy
+    assert 'JOB_SECRET_FLAG="--update-secrets"' in deploy
+    assert deploy.count("ensure_private_run_app_access") == 1
+    assert deploy.count("verify_synthetic_ingest_service_contract") == 2
+    guarded_network_args = (
+        '"${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]+'
+        '"${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]}"}"'
+    )
+    assert deploy.count(guarded_network_args) == 4
 
 
 def test_secret_bootstrap_provisions_a_distinct_observer_credential() -> None:

--- a/tests/test_deploy_script_execution.py
+++ b/tests/test_deploy_script_execution.py
@@ -103,8 +103,15 @@ def _settings_kwargs_from_cloud_run_job(call: list[str]) -> dict[str, object]:
         for name, value in _cloud_run_job_env(call).items()
         if name.startswith("TR_")
     }
-    # Cloud Run resolves this --update-secrets binding before process startup.
-    kwargs["internal_gateway_token"] = "harness-gateway-token"  # noqa: S105
+    secret_flag = next(
+        flag for flag in ("--update-secrets", "--set-secrets") if flag in call
+    )
+    for binding in call[call.index(secret_flag) + 1].split(","):
+        name, separator, reference = binding.partition("=")
+        if not separator or not name.startswith("TR_"):
+            continue
+        secret_name = reference.partition(":")[0]
+        kwargs[name.removeprefix("TR_").lower()] = f"harness-{secret_name}"
     return kwargs
 
 
@@ -1194,23 +1201,34 @@ def test_synthetic_combined_bridge_job_environment_constructs_settings(
     run = isolated.run(script, verifier_rc=0, omit_env=("TR_BILLING_SERVICE",))
 
     assert run.returncode == 0, summarise(run)
-    deploy = next(
+    deploys = [
         call
         for call in run.calls
         if call[:4] == ["gcloud", "--project", "quill-cloud-proxy", "run"]
         and call[4:6] == ["jobs", "deploy"]
-    )
-    settings_kwargs = _settings_kwargs_from_cloud_run_job(deploy)
-    settings = Settings(**settings_kwargs)
-    assert settings.environment == "worker"
-    assert settings.service_surface == "combined"
+    ]
+    assert len(deploys) == 5
+    for deploy in deploys:
+        settings_kwargs = _settings_kwargs_from_cloud_run_job(deploy)
+        settings = Settings(**settings_kwargs)
+        assert settings.environment == "worker"
+        assert settings.service_surface == "combined"
 
-    settings_kwargs.pop("allow_deployed_combined_surface")
-    with pytest.raises(
-        ValidationError,
-        match="TR_ALLOW_DEPLOYED_COMBINED_SURFACE",
-    ):
-        Settings(**settings_kwargs)
+        without_combined_opt_in = dict(settings_kwargs)
+        without_combined_opt_in.pop("allow_deployed_combined_surface")
+        with pytest.raises(
+            ValidationError,
+            match="TR_ALLOW_DEPLOYED_COMBINED_SURFACE",
+        ):
+            Settings(**without_combined_opt_in)
+
+        without_gateway_token = dict(settings_kwargs)
+        without_gateway_token.pop("internal_gateway_token")
+        with pytest.raises(
+            ValidationError,
+            match="not fail-closed.*TR_INTERNAL_GATEWAY_TOKEN",
+        ):
+            Settings(**without_gateway_token)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_deploy_script_execution.py
+++ b/tests/test_deploy_script_execution.py
@@ -1050,7 +1050,7 @@ def test_synthetic_jobs_execute_private_ingress_preflight_in_their_own_region(
         previous_deploy_index = deploy_index
 
 
-def test_synthetic_deploy_requires_explicit_split_billing_service_before_any_job(
+def test_synthetic_deploy_requires_explicit_split_billing_service_before_any_gcloud_call(
     tmp_path: Path,
 ) -> None:
     isolated = DeployScriptHarness(tmp_path / "synthetic-no-split-service")
@@ -1063,11 +1063,41 @@ def test_synthetic_deploy_requires_explicit_split_billing_service_before_any_job
 
     assert run.returncode != 0
     assert "TR_BILLING_SERVICE is required" in run.stderr
-    assert not any(
-        call[:4] == ["gcloud", "--project", "quill-cloud-proxy", "run"]
-        and call[4:6] == ["jobs", "deploy"]
-        for call in run.calls
+    assert run.calls == []
+
+
+def test_synthetic_combined_bridge_restores_legacy_job_deploys(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    script = "scripts/deploy/synthetic.sh"
+    fixture = SCRIPT_FIXTURES[script]
+    monkeypatch.setitem(
+        SCRIPT_FIXTURES,
+        script,
+        replace(
+            fixture,
+            env={**fixture.env, "TR_ALLOW_DEPLOYED_COMBINED_SURFACE": "true"},
+        ),
     )
+    isolated = DeployScriptHarness(tmp_path / "synthetic-combined-bridge")
+
+    run = isolated.run(script, verifier_rc=0, omit_env=("TR_BILLING_SERVICE",))
+
+    assert run.returncode == 0, summarise(run)
+    deploys = [
+        call
+        for call in run.calls
+        if call[:4] == ["gcloud", "--project", "quill-cloud-proxy", "run"]
+        and call[4:6] == ["jobs", "deploy"]
+    ]
+    assert [(call[6], call[call.index("--region") + 1]) for call in deploys] == [
+        ("trusted-router-synthetic-us-central1", "us-central1"),
+        ("trusted-router-synthetic-europe-west4", "europe-west4"),
+        ("trusted-router-throughput-us-central1", "us-central1"),
+        ("trusted-router-image-generation-us-central1", "us-central1"),
+        ("trusted-router-video-generation-us-central1", "us-central1"),
+    ]
     assert not any(
         call[:6]
         == [
@@ -1080,6 +1110,34 @@ def test_synthetic_deploy_requires_explicit_split_billing_service_before_any_job
         ]
         for call in run.calls
     )
+    assert not any(
+        call[:5]
+        == [
+            "gcloud",
+            "--project",
+            "quill-cloud-proxy",
+            "secrets",
+            "describe",
+        ]
+        and call[5] == "trustedrouter-observer-internal-token"
+        for call in run.calls
+    )
+    for deploy in deploys:
+        deploy_text = " ".join(deploy)
+        region = deploy[deploy.index("--region") + 1]
+        assert f"https://trusted-router-stub-output.{region}.run.app" in deploy_text
+        assert (
+            "TR_INTERNAL_GATEWAY_TOKEN=trustedrouter-internal-gateway-token:latest"
+            in deploy_text
+        )
+        assert "TR_OBSERVER_INTERNAL_TOKEN" not in deploy_text
+        assert "TR_SERVICE_SURFACE=observer" not in deploy_text
+        assert "TR_BYOK_KMS_KEY_NAME=" in deploy_text
+        assert "--update-secrets" in deploy
+        assert "--set-secrets" not in deploy
+        assert "--network" not in deploy
+        assert "--subnet" not in deploy
+        assert "--vpc-egress" not in deploy
 
 
 @pytest.mark.parametrize(

--- a/tests/test_deploy_script_execution.py
+++ b/tests/test_deploy_script_execution.py
@@ -43,6 +43,7 @@ from dataclasses import replace
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from trusted_router import cloud_rollout_completeness as crc
 from trusted_router.config import Settings
@@ -85,6 +86,26 @@ def _settings_from_containerapp_mutation(call: list[str]) -> Settings:
     kwargs["attribution_cookie_secret"] = "a" * 64
     kwargs["postgres_dsn"] = "postgresql://canary.invalid/trustedrouter"
     return Settings(**kwargs)
+
+
+def _cloud_run_job_env(call: list[str]) -> dict[str, str]:
+    serialized = call[call.index("--set-env-vars") + 1]
+    assert serialized.startswith("^|^")
+    return {
+        assignment.partition("=")[0]: assignment.partition("=")[2]
+        for assignment in serialized.removeprefix("^|^").split("|")
+    }
+
+
+def _settings_kwargs_from_cloud_run_job(call: list[str]) -> dict[str, object]:
+    kwargs: dict[str, object] = {
+        name.removeprefix("TR_").lower(): value
+        for name, value in _cloud_run_job_env(call).items()
+        if name.startswith("TR_")
+    }
+    # Cloud Run resolves this --update-secrets binding before process startup.
+    kwargs["internal_gateway_token"] = "harness-gateway-token"  # noqa: S105
+    return kwargs
 
 
 def test_every_deploy_script_parses_in_this_machine_s_shell() -> None:
@@ -991,7 +1012,10 @@ def test_synthetic_jobs_execute_private_ingress_preflight_in_their_own_region(
     for deploy_index, deploy in deploys:
         region = deploy[deploy.index("--region") + 1]
         deploy_text = " ".join(deploy)
-        assert "TR_SERVICE_SURFACE=observer" in deploy_text
+        deployed_env = _cloud_run_job_env(deploy)
+        assert deployed_env["TR_SERVICE_SURFACE"] == "observer"
+        assert "TR_ALLOW_DEPLOYED_COMBINED_SURFACE" not in deployed_env
+        assert "TR_RATE_LIMIT_ENABLED" not in deployed_env
         assert (
             "TR_OBSERVER_INTERNAL_TOKEN=trustedrouter-observer-internal-token:latest"
             in deploy_text
@@ -1124,6 +1148,7 @@ def test_synthetic_combined_bridge_restores_legacy_job_deploys(
     )
     for deploy in deploys:
         deploy_text = " ".join(deploy)
+        deployed_env = _cloud_run_job_env(deploy)
         region = deploy[deploy.index("--region") + 1]
         assert f"https://trusted-router-stub-output.{region}.run.app" in deploy_text
         assert (
@@ -1131,13 +1156,61 @@ def test_synthetic_combined_bridge_restores_legacy_job_deploys(
             in deploy_text
         )
         assert "TR_OBSERVER_INTERNAL_TOKEN" not in deploy_text
-        assert "TR_SERVICE_SURFACE=observer" not in deploy_text
+        assert deployed_env["TR_SERVICE_SURFACE"] == "combined"
+        assert deployed_env["TR_ALLOW_DEPLOYED_COMBINED_SURFACE"] == "true"
+        assert deployed_env["TR_RATE_LIMIT_ENABLED"] == "false"
         assert "TR_BYOK_KMS_KEY_NAME=" in deploy_text
         assert "--update-secrets" in deploy
         assert "--set-secrets" not in deploy
         assert "--network" not in deploy
         assert "--subnet" not in deploy
         assert "--vpc-egress" not in deploy
+        # The combined service keeps ingress=all and the pre-#714 jobs reached it over
+        # the public run.app URL with no VPC; bridge mode must not grow a private path
+        # before the split actually restricts ingress.
+        assert not any(
+            arg == flag or arg.startswith(f"{flag}=")
+            for arg in deploy
+            for flag in ("--network", "--subnet", "--vpc-egress", "--vpc-connector")
+        ), " ".join(deploy)
+
+
+def test_synthetic_combined_bridge_job_environment_constructs_settings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    script = "scripts/deploy/synthetic.sh"
+    fixture = SCRIPT_FIXTURES[script]
+    monkeypatch.setitem(
+        SCRIPT_FIXTURES,
+        script,
+        replace(
+            fixture,
+            env={**fixture.env, "TR_ALLOW_DEPLOYED_COMBINED_SURFACE": "true"},
+        ),
+    )
+    isolated = DeployScriptHarness(tmp_path / "synthetic-combined-settings")
+
+    run = isolated.run(script, verifier_rc=0, omit_env=("TR_BILLING_SERVICE",))
+
+    assert run.returncode == 0, summarise(run)
+    deploy = next(
+        call
+        for call in run.calls
+        if call[:4] == ["gcloud", "--project", "quill-cloud-proxy", "run"]
+        and call[4:6] == ["jobs", "deploy"]
+    )
+    settings_kwargs = _settings_kwargs_from_cloud_run_job(deploy)
+    settings = Settings(**settings_kwargs)
+    assert settings.environment == "worker"
+    assert settings.service_surface == "combined"
+
+    settings_kwargs.pop("allow_deployed_combined_surface")
+    with pytest.raises(
+        ValidationError,
+        match="TR_ALLOW_DEPLOYED_COMBINED_SURFACE",
+    ):
+        Settings(**settings_kwargs)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -2953,8 +2953,10 @@ def test_synthetic_deploy_targets_public_api_and_private_internal_ingest() -> No
         '"TR_OBSERVER_INTERNAL_TOKEN=trustedrouter-observer-internal-token:latest"'
         in body
     )
-    assert '"TR_INTERNAL_GATEWAY_TOKEN=' not in body
-    assert "TR_INTERNAL_GATEWAY_TOKEN=trustedrouter" not in body
+    assert (
+        '"TR_INTERNAL_GATEWAY_TOKEN=trustedrouter-internal-gateway-token:latest"'
+        in body
+    )
     assert "TR_API_BASE_URL=https://api.trustedrouter.com/v1" in body
     assert "TR_API_BASE_URL=https://api.quillrouter.com/v1" not in body
     assert 'throughput_job_name="trusted-router-throughput-${throughput_region}"' in body


### PR DESCRIPTION
#714 rewrote `scripts/deploy/synthetic.sh` for the six-service split: it refuses unless `TR_BILLING_SERVICE` names a separate billing service (lines 18–28 on main) and requires the Secret Manager secret `trustedrouter-observer-internal-token` (lines 38–39), which `scripts/deploy/secrets.sh` has never created. #732 bridged the *service* for the deployed combined surface but not this script, so the workflow's "Deploy synthetic monitor Cloud Run Job" step — `continue-on-error: true` — keeps failing closed and the monitor jobs stay on their old image (`de2d15e`), which is why the `responses_pong` 501 fix (#728) never reaches the monitor and the status page keeps false-alarming.

## Change

Under the same `TR_ALLOW_DEPLOYED_COMBINED_SURFACE=true` that #732 sets in the `deploy` job's `env:` (inherited by the synthetic step), `synthetic.sh` deploys the jobs exactly as the pre-#714 script did: ingest target `$SERVICE`, the legacy five-secret binding (`sentry-dsn`, `stripe-secret-key`, `stripe-webhook-secret`, `internal-gateway-token`, `synthetic-monitor-api-key`) via `--update-secrets`, the BYOK KMS env, no observer-token requirement, no `TR_SERVICE_SURFACE=observer`, and the split-only private-ingress/contract preflight skipped. Without the flag, the split path and every refusal are unchanged. The empty-array expansion of `PRIVATE_RUN_APP_JOB_NETWORK_ARGS` is guarded for `set -u`.

Tests (real script under the deploy-script harness with a stubbed `gcloud`): flag absent → exits with the `TR_BILLING_SERVICE` refusal before **any** gcloud call; flag present and no `TR_BILLING_SERVICE` → exit 0 with the five expected job deploys (synthetic us-central1/europe-west4, throughput, image, video), their regions, ingest URLs and secret bindings, and no observer-token lookup. `test_ddos_edge_deploy.py`'s text pins are updated to the two-branch script.

## Evidence

- Bridge branch vs the pre-#714 script (`6e3e89f:scripts/deploy/synthetic.sh`): identical secret bindings, `--update-secrets`, BYOK env, ingest target.
- `bash -n` clean; `shellcheck` (warning+) clean; `ruff check .` clean; `mypy` clean (297 files).
- `tests/test_deploy_script_execution.py tests/test_ddos_edge_deploy.py tests/test_synthetic_monitoring.py`: **212 passed** (reviewer), 32 focused (author).
- Mutation — refusal disabled and bridge forced unconditionally: **3 failed** (the refusal test and two split-path tests); restored: 71 passed. Author's mutation: refusal test failed, restored passed.

## Authorship, review, sequencing

Authored by codex-cli from a written spec (the pre-#714 script supplied as reference); reviewed by Claude (Fable), who re-ran every check above. Merging this triggers a deploy (it touches `scripts/deploy/**`): merge only after the #732 bridge rollout (run 32556287154) reaches terminal success, so its `confirm-current-main` is not tripped. Expected effect of the next rollout: the monitor jobs move to the current image, `responses_pong` returns to up/200, and the status page stops false-alarming. Remove with the six-service cutover (#712), together with the rest of the bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
