### PR TITLE
Repair synthetic ClickHouse gaps automatically

### DIFF
--- a/clickhouse/reconcile_synthetic_samples.py
+++ b/clickhouse/reconcile_synthetic_samples.py
@@ -1,0 +1,283 @@
+"""Repair bounded Bigtable synthetic metadata gaps in ClickHouse.
+
+The Spanner outbox is the live delivery path. Bigtable remains a bounded
+shadow during the migration soak, so this worker uses it only as a repair
+source when an immutable synthetic sample ID is absent from ClickHouse.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from google.cloud import bigtable
+from google.cloud.bigtable.row_filters import CellsColumnLimitFilter
+
+from clickhouse.backfill_operational_analytics import ClickHouse
+from clickhouse.ingest_operational_outbox import (
+    CanonicalOperationalEvent,
+    ClickHouseOperationalWriter,
+)
+from clickhouse.operational_fingerprint import SAFE_ID
+from clickhouse.verify_operational_parity import _body, _parse, _stable_source_write
+from trusted_router.storage_gcp_operational_analytics_outbox import synthetic_payload
+from trusted_router.storage_models import SyntheticProbeSample
+
+PROJECT = "quill-cloud-proxy"
+INSTANCE = "trusted-router-logs"
+TABLE = "trustedrouter-generations"
+DATABASE = "tr"
+DEFAULT_DAYS = 3
+DEFAULT_PER_DAY_LIMIT = 100_000
+DEFAULT_GRACE_SECONDS = 10 * 60
+DEFAULT_BATCH_SIZE = 5_000
+
+
+class EventWriter(Protocol):
+    def insert(self, events: list[CanonicalOperationalEvent]) -> None: ...
+
+
+class ClickHouseQuery(Protocol):
+    def query(
+        self,
+        sql: str,
+        *,
+        input_bytes: bytes | None = None,
+        external_ids: bool = False,
+    ) -> str: ...
+
+
+@dataclass(frozen=True)
+class ReconcileResult:
+    scanned: int
+    present: int
+    missing_before: int
+    repaired: int
+    unresolved: int
+    missing_ids: tuple[str, ...]
+    unresolved_ids: tuple[str, ...]
+
+    @property
+    def ok(self) -> bool:
+        return self.unresolved == 0
+
+
+def _utc(value: dt.datetime) -> dt.datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=dt.UTC)
+    return value.astimezone(dt.UTC)
+
+
+def _day_prefix(day: dt.date) -> bytes:
+    return f"synthetic_day_recent#{day.isoformat()}#".encode()
+
+
+def source_samples(
+    table: Any,
+    *,
+    now: dt.datetime,
+    days: int,
+    per_day_limit: int,
+    grace_seconds: int,
+) -> dict[str, dict[str, Any]]:
+    """Read complete recent day indexes and return immutable canonical rows."""
+    if days < 1:
+        raise ValueError("days must be positive")
+    if per_day_limit < 1:
+        raise ValueError("per_day_limit must be positive")
+    if grace_seconds < 0:
+        raise ValueError("grace_seconds cannot be negative")
+
+    cutoff = _utc(now) - dt.timedelta(seconds=grace_seconds)
+    result: dict[str, dict[str, Any]] = {}
+    for offset in range(days):
+        day = cutoff.date() - dt.timedelta(days=offset)
+        prefix = _day_prefix(day)
+        rows = table.read_rows(
+            start_key=prefix,
+            end_key=prefix + b"~",
+            limit=per_day_limit + 1,
+            filter_=CellsColumnLimitFilter(1),
+        )
+        scanned_for_day = 0
+        for row in rows:
+            scanned_for_day += 1
+            if scanned_for_day > per_day_limit:
+                raise RuntimeError(
+                    f"synthetic source day {day.isoformat()} exceeded "
+                    f"the {per_day_limit} row safety limit"
+                )
+            if not _stable_source_write(
+                row,
+                families=("synthetic", "m"),
+                cutoff=cutoff,
+            ):
+                continue
+            sample = _parse(
+                SyntheticProbeSample,
+                _body(row, ("synthetic", "m")),
+            )
+            if sample is None:
+                continue
+            try:
+                created_at = dt.datetime.fromisoformat(
+                    sample.created_at.replace("Z", "+00:00")
+                )
+            except ValueError:
+                continue
+            if _utc(created_at) > cutoff:
+                continue
+            result.setdefault(sample.id, synthetic_payload(sample))
+    return result
+
+
+def clickhouse_ids(clickhouse: ClickHouseQuery, ids: Iterable[str]) -> set[str]:
+    wanted = list(ids)
+    if not wanted:
+        return set()
+    if any(SAFE_ID.fullmatch(item) is None for item in wanted):
+        raise ValueError("source contains an invalid record ID")
+    payload = ("\n".join(wanted) + "\n").encode()
+    output = clickhouse.query(
+        "SELECT id FROM synthetic_probe_samples FINAL "
+        "WHERE id IN (SELECT id FROM wanted) FORMAT TabSeparated",
+        input_bytes=payload,
+        external_ids=True,
+    )
+    return {line.strip() for line in output.splitlines() if line.strip()}
+
+
+def _batches(items: list[str], size: int) -> Iterator[list[str]]:
+    for index in range(0, len(items), size):
+        yield items[index : index + size]
+
+
+def reconcile(
+    *,
+    source: dict[str, dict[str, Any]],
+    clickhouse: ClickHouseQuery,
+    writer: EventWriter,
+    apply: bool,
+    batch_size: int,
+    now: dt.datetime,
+) -> ReconcileResult:
+    if batch_size < 1:
+        raise ValueError("batch_size must be positive")
+    present = clickhouse_ids(clickhouse, source)
+    missing = sorted(set(source) - present)
+    if apply:
+        ingest_version = _utc(now).isoformat()
+        for batch in _batches(missing, batch_size):
+            writer.insert(
+                [
+                    CanonicalOperationalEvent(
+                        event_kind="synthetic",
+                        row={**source[sample_id], "ingest_version": ingest_version},
+                    )
+                    for sample_id in batch
+                ]
+            )
+    unresolved = sorted(set(missing) - clickhouse_ids(clickhouse, missing))
+    repaired = len(missing) - len(unresolved) if apply else 0
+    return ReconcileResult(
+        scanned=len(source),
+        present=len(present),
+        missing_before=len(missing),
+        repaired=repaired,
+        unresolved=len(unresolved),
+        missing_ids=tuple(missing[:20]),
+        unresolved_ids=tuple(unresolved[:20]),
+    )
+
+
+def _write_history(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(days=16)
+    retained: list[dict[str, Any]] = []
+    if path.exists():
+        for line in path.read_text().splitlines():
+            try:
+                row = json.loads(line)
+                checked_at = dt.datetime.fromisoformat(
+                    str(row["checked_at"]).replace("Z", "+00:00")
+                )
+            except (KeyError, TypeError, ValueError):
+                continue
+            if _utc(checked_at) >= cutoff:
+                retained.append(row)
+    retained.append(payload)
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text(
+        "".join(json.dumps(item, sort_keys=True) + "\n" for item in retained)
+    )
+    os.replace(temporary, path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--days", type=int, default=DEFAULT_DAYS)
+    parser.add_argument("--per-day-limit", type=int, default=DEFAULT_PER_DAY_LIMIT)
+    parser.add_argument("--grace-seconds", type=int, default=DEFAULT_GRACE_SECONDS)
+    parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    parser.add_argument(
+        "--history-file",
+        default="/var/lib/tr-clickhouse-ingest/synthetic-reconcile.jsonl",
+    )
+    args = parser.parse_args()
+    password = os.environ.get("CH_PASSWORD", "")
+    if not password:
+        raise SystemExit("CH_PASSWORD is required")
+
+    now = dt.datetime.now(dt.UTC)
+    table = (
+        bigtable.Client(project=PROJECT, admin=False)
+        .instance(INSTANCE)
+        .table(TABLE)
+    )
+    clickhouse = ClickHouse(password=password)
+    writer = ClickHouseOperationalWriter(password=password, database=DATABASE)
+    source = source_samples(
+        table,
+        now=now,
+        days=args.days,
+        per_day_limit=args.per_day_limit,
+        grace_seconds=args.grace_seconds,
+    )
+    result = reconcile(
+        source=source,
+        clickhouse=clickhouse,
+        writer=writer,
+        apply=args.apply,
+        batch_size=args.batch_size,
+        now=now,
+    )
+    payload = {
+        "checked_at": dt.datetime.now(dt.UTC).isoformat().replace("+00:00", "Z"),
+        "mode": "apply" if args.apply else "dry-run",
+        "ok": result.ok,
+        "scanned": result.scanned,
+        "present": result.present,
+        "missing_before": result.missing_before,
+        "repaired": result.repaired,
+        "unresolved": result.unresolved,
+        "missing_ids": list(result.missing_ids),
+        "unresolved_ids": list(result.unresolved_ids),
+        # The five-minute rollup worker consumes repaired raw rows. Keeping
+        # repair and rollup as separate single-purpose services prevents two
+        # full 14-day rollup rebuilds from racing each other.
+        "rollup_rebuild_pending": bool(result.repaired),
+    }
+    _write_history(Path(args.history_file), payload)
+    print(json.dumps(payload, sort_keys=True))
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/clickhouse/tr-clickhouse-synthetic-reconcile.service
+++ b/clickhouse/tr-clickhouse-synthetic-reconcile.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=TrustedRouter Bigtable to ClickHouse synthetic gap repair
+After=network-online.target clickhouse-server.service tr-clickhouse-operational-ingest.service
+Wants=network-online.target
+Requires=clickhouse-server.service
+
+[Service]
+Type=oneshot
+User=tr-clickhouse-ingest
+Group=tr-clickhouse-ingest
+WorkingDirectory=/opt/tr-clickhouse
+Environment=PYTHONPATH=/opt/tr-clickhouse/src
+EnvironmentFile=/etc/tr-clickhouse-ingest.env
+ExecStart=/opt/tr-clickhouse/venv/bin/python -m clickhouse.reconcile_synthetic_samples --apply
+TimeoutStartSec=10m
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=/var/lib/tr-clickhouse-ingest

--- a/clickhouse/tr-clickhouse-synthetic-reconcile.timer
+++ b/clickhouse/tr-clickhouse-synthetic-reconcile.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Hourly TrustedRouter synthetic metadata gap repair
+
+[Timer]
+OnBootSec=10min
+OnUnitActiveSec=1h
+RandomizedDelaySec=5min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/deploy/clickhouse_operational_analytics.sh
+++ b/scripts/deploy/clickhouse_operational_analytics.sh
@@ -116,6 +116,10 @@ node_ssh 0 --command="sudo sh -c '
     /etc/systemd/system/tr-clickhouse-synthetic-rollup.service
   install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-synthetic-rollup.timer \
     /etc/systemd/system/tr-clickhouse-synthetic-rollup.timer
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-synthetic-reconcile.service \
+    /etc/systemd/system/tr-clickhouse-synthetic-reconcile.service
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-synthetic-reconcile.timer \
+    /etc/systemd/system/tr-clickhouse-synthetic-reconcile.timer
   install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-client-rollup.service \
     /etc/systemd/system/tr-clickhouse-client-rollup.service
   install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-client-rollup.timer \
@@ -195,7 +199,7 @@ node_ssh 0 --command="sudo sh -c '
     /opt/tr-clickhouse/venv/bin/python -m clickhouse.rollup_synthetic
 '"
 
-node_ssh 0 --command="sudo systemctl enable tr-clickhouse-operational-ingest.service tr-clickhouse-synthetic-rollup.timer tr-clickhouse-client-rollup.timer tr-clickhouse-operational-parity.timer tr-clickhouse-public-snapshots.timer tr-clickhouse-archive-restore.timer tr-clickhouse-spanner-delivery.timer"
+node_ssh 0 --command="sudo systemctl enable tr-clickhouse-operational-ingest.service tr-clickhouse-synthetic-rollup.timer tr-clickhouse-synthetic-reconcile.timer tr-clickhouse-client-rollup.timer tr-clickhouse-operational-parity.timer tr-clickhouse-public-snapshots.timer tr-clickhouse-archive-restore.timer tr-clickhouse-spanner-delivery.timer"
 
 log "verifying exact replica identity after synchronization"
 for table in activity_generations synthetic_probe_samples synthetic_status_rollups public_analytics_snapshots client_request_events client_minute_counters client_availability_rollups operational_outbox_quarantine; do
@@ -239,7 +243,7 @@ for index in 0 1 2; do
 done
 
 node_ssh 0 --command="sudo systemctl start tr-clickhouse-operational-ingest.service"
-node_ssh 0 --command="sudo systemctl start tr-clickhouse-client-rollup.timer tr-clickhouse-public-snapshots.timer tr-clickhouse-public-snapshots.service tr-clickhouse-archive-restore.timer tr-clickhouse-spanner-delivery.timer tr-clickhouse-spanner-delivery.service"
+node_ssh 0 --command="sudo systemctl start tr-clickhouse-synthetic-reconcile.timer tr-clickhouse-client-rollup.timer tr-clickhouse-public-snapshots.timer tr-clickhouse-public-snapshots.service tr-clickhouse-archive-restore.timer tr-clickhouse-spanner-delivery.timer tr-clickhouse-spanner-delivery.service"
 
 log "operational analytics infrastructure is ready; Bigtable is still authoritative"
 log "deploy the operational outbox producer, then run clickhouse_operational_analytics_finalize.sh --apply"

--- a/tests/test_clickhouse_operational_deploy.py
+++ b/tests/test_clickhouse_operational_deploy.py
@@ -72,6 +72,8 @@ def test_operational_deploy_backfills_before_starting_live_ingest() -> None:
     assert "008_client_events_replicated.sql" in script
     assert "tr-clickhouse-client-rollup.service" in script
     assert "tr-clickhouse-client-rollup.timer" in script
+    assert "tr-clickhouse-synthetic-reconcile.service" in script
+    assert "tr-clickhouse-synthetic-reconcile.timer" in script
     assert "systemctl enable" in script
     assert 'id_column="event_id"' in script
 

--- a/tests/test_clickhouse_synthetic_reconcile.py
+++ b/tests/test_clickhouse_synthetic_reconcile.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import dataclasses
+import datetime as dt
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from clickhouse.ingest_operational_outbox import CanonicalOperationalEvent
+from clickhouse.reconcile_synthetic_samples import reconcile, source_samples
+from trusted_router.storage_models import SyntheticProbeSample
+
+
+def _sample(sample_id: str, created_at: dt.datetime) -> SyntheticProbeSample:
+    return SyntheticProbeSample(
+        id=sample_id,
+        probe_type="remediation",
+        target="route-quarantine:test/model",
+        target_url="",
+        monitor_region="us-central1",
+        status="down",
+        error_type="would quarantine",
+        created_at=created_at.isoformat().replace("+00:00", "Z"),
+    )
+
+
+def _row(sample: SyntheticProbeSample, *, written_at: dt.datetime) -> object:
+    cell = SimpleNamespace(
+        value=json.dumps(dataclasses.asdict(sample)).encode(),
+        timestamp_micros=int(written_at.timestamp() * 1_000_000),
+    )
+    return SimpleNamespace(cells={"synthetic": {b"body": [cell]}})
+
+
+class _Table:
+    def __init__(self, rows_by_day: dict[str, list[object]]) -> None:
+        self.rows_by_day = rows_by_day
+        self.limits: list[int] = []
+
+    def read_rows(
+        self,
+        *,
+        start_key: bytes,
+        end_key: bytes,
+        limit: int,
+        filter_: object,
+    ) -> list[object]:
+        del end_key, filter_
+        self.limits.append(limit)
+        day = start_key.decode().split("#")[1]
+        return self.rows_by_day.get(day, [])[:limit]
+
+
+class _ClickHouse:
+    def __init__(self, ids: set[str]) -> None:
+        self.ids = ids
+        self.queries: list[str] = []
+
+    def query(
+        self,
+        sql: str,
+        *,
+        input_bytes: bytes | None = None,
+        external_ids: bool = False,
+    ) -> str:
+        assert external_ids
+        assert input_bytes is not None
+        self.queries.append(sql)
+        wanted = set(input_bytes.decode().splitlines())
+        return "".join(f"{sample_id}\n" for sample_id in sorted(wanted & self.ids))
+
+
+class _Writer:
+    def __init__(self, clickhouse: _ClickHouse) -> None:
+        self.clickhouse = clickhouse
+        self.batches: list[list[CanonicalOperationalEvent]] = []
+
+    def insert(self, events: list[CanonicalOperationalEvent]) -> None:
+        self.batches.append(events)
+        self.clickhouse.ids.update(str(event.row["id"]) for event in events)
+
+
+def test_source_samples_reads_complete_recent_day_indexes_and_applies_grace() -> None:
+    now = dt.datetime(2026, 8, 22, 12, tzinfo=dt.UTC)
+    stable = _sample("syn_stable", now - dt.timedelta(hours=2))
+    recent = _sample("syn_recent", now - dt.timedelta(minutes=1))
+    table = _Table(
+        {
+            "2026-08-22": [
+                _row(stable, written_at=now - dt.timedelta(hours=1)),
+                _row(recent, written_at=now - dt.timedelta(minutes=1)),
+            ],
+            "2026-08-21": [],
+            "2026-08-20": [],
+        }
+    )
+
+    rows = source_samples(
+        table,
+        now=now,
+        days=3,
+        per_day_limit=100,
+        grace_seconds=600,
+    )
+
+    assert set(rows) == {"syn_stable"}
+    assert table.limits == [101, 101, 101]
+
+
+def test_source_samples_fails_closed_when_a_day_exceeds_the_safety_limit() -> None:
+    now = dt.datetime(2026, 8, 22, 12, tzinfo=dt.UTC)
+    rows = [
+        _row(
+            _sample(f"syn_{index}", now - dt.timedelta(hours=2)),
+            written_at=now - dt.timedelta(hours=1),
+        )
+        for index in range(3)
+    ]
+    table = _Table({"2026-08-22": rows})
+
+    with pytest.raises(RuntimeError, match="exceeded the 2 row safety limit"):
+        source_samples(
+            table,
+            now=now,
+            days=1,
+            per_day_limit=2,
+            grace_seconds=600,
+        )
+
+
+def test_reconcile_inserts_only_missing_rows_and_verifies_the_repair() -> None:
+    now = dt.datetime(2026, 8, 22, 12, tzinfo=dt.UTC)
+    source = {
+        "syn_present": {"id": "syn_present", "created_at": now.isoformat()},
+        "syn_missing": {"id": "syn_missing", "created_at": now.isoformat()},
+    }
+    clickhouse = _ClickHouse({"syn_present"})
+    writer = _Writer(clickhouse)
+
+    result = reconcile(
+        source=source,
+        clickhouse=clickhouse,
+        writer=writer,
+        apply=True,
+        batch_size=10,
+        now=now,
+    )
+
+    assert result.ok
+    assert result.missing_before == 1
+    assert result.repaired == 1
+    assert result.unresolved == 0
+    assert len(writer.batches) == 1
+    [event] = writer.batches[0]
+    assert event.event_kind == "synthetic"
+    assert event.row["id"] == "syn_missing"
+    assert event.row["ingest_version"] == now.isoformat()
+
+
+def test_reconcile_dry_run_reports_missing_without_writing() -> None:
+    now = dt.datetime(2026, 8, 22, 12, tzinfo=dt.UTC)
+    source = {"syn_missing": {"id": "syn_missing"}}
+    clickhouse = _ClickHouse(set())
+    writer = _Writer(clickhouse)
+
+    result = reconcile(
+        source=source,
+        clickhouse=clickhouse,
+        writer=writer,
+        apply=False,
+        batch_size=10,
+        now=now,
+    )
+
+    assert not result.ok
+    assert result.missing_before == 1
+    assert result.repaired == 0
+    assert result.unresolved == 1
+    assert writer.batches == []
+
+
+def test_reconcile_rejects_invalid_source_ids_before_querying() -> None:
+    now = dt.datetime(2026, 8, 22, 12, tzinfo=dt.UTC)
+    clickhouse = _ClickHouse(set())
+
+    with pytest.raises(ValueError, match="invalid record ID"):
+        reconcile(
+            source={"bad id": {"id": "bad id"}},
+            clickhouse=clickhouse,
+            writer=_Writer(clickhouse),
+            apply=True,
+            batch_size=10,
+            now=now,
+        )


### PR DESCRIPTION
## Summary
- add a bounded hourly reconciler for recent Bigtable synthetic metadata missing from ClickHouse
- verify idempotent replay before reporting success and retain a 16-day repair audit history
- install and enable the worker with the operational analytics deployment

## Production incident
Eight metadata-only synthetic remediation rows written during the Aug 20 staged rollout were present in Bigtable but absent from all three ClickHouse replicas. They were replayed and rollups rebuilt. Exact operational parity passed at 2026-08-22T06:57:14.941205Z and exact Spanner delivery passed at 2026-08-22T06:57:54.947669Z.

## Verification
- uv run ruff check .
- uv run mypy
- focused pytest: 31 passed, 1 skipped
- production dry run: 93,595 scanned, 0 missing, 0 unresolved

Bigtable remains enabled as shadow and fallback. This does not retire or move any read path.