### PR TITLE
Six-surface split: surfaces, exact edge/IAM contracts, journaled cutover

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -401,19 +401,22 @@ jobs:
       TR_WEBHOOKS_SERVICE: trusted-router-webhooks
       TR_INTERNAL_SERVICE: trusted-router-billing
       TR_BILLING_SERVICE: trusted-router-billing
-      TR_ROLLOUT_MANIFEST: ${{ runner.temp }}/tr-rollout/manifest.json
       # The frontend identities are a reviewed contract (like the service
       # inventory above): capture verifies the live LB against them and
       # rollout.sh refuses to run without the resulting artifact.
       TR_FORWARDING_RULE: trusted-router-control-https
       TR_HTTPS_PROXY: trusted-router-control-https-proxy
-      TR_ROLLOUT_FRONTEND_ATTESTATION: ${{ runner.temp }}/tr-rollout/frontend-attestation.json
       SHA: ${{ needs.build-image.outputs.sha }}
       IMAGE: ${{ needs.build-image.outputs.image }}
       # Keep the workflow value raw. rollout.sh normalizes preserve/false/true
       # only after reading the actual 100%-traffic primary revision.
       TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED: ${{ inputs.regional_quota_lease_issuance }}
     steps:
+      - name: Initialize rollout artifact paths
+        run: |
+          echo "TR_ROLLOUT_MANIFEST=${RUNNER_TEMP}/tr-rollout/manifest.json" >> "$GITHUB_ENV"
+          echo "TR_ROLLOUT_FRONTEND_ATTESTATION=${RUNNER_TEMP}/tr-rollout/frontend-attestation.json" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -396,12 +396,18 @@ jobs:
       SERVICE: trusted-router
       TR_PUBLIC_SERVICE: trusted-router-public
       TR_ACTIONS_SERVICE: trusted-router-actions
-      TR_CONSOLE_SERVICE: trusted-router
+      TR_CONSOLE_SERVICE: trusted-router-console
       TR_CHAT_SERVICE: trusted-router-chat
       TR_WEBHOOKS_SERVICE: trusted-router-webhooks
       TR_INTERNAL_SERVICE: trusted-router-billing
       TR_BILLING_SERVICE: trusted-router-billing
       TR_ROLLOUT_MANIFEST: ${{ runner.temp }}/tr-rollout/manifest.json
+      # The frontend identities are a reviewed contract (like the service
+      # inventory above): capture verifies the live LB against them and
+      # rollout.sh refuses to run without the resulting artifact.
+      TR_FORWARDING_RULE: trusted-router-control-https
+      TR_HTTPS_PROXY: trusted-router-control-https-proxy
+      TR_ROLLOUT_FRONTEND_ATTESTATION: ${{ runner.temp }}/tr-rollout/frontend-attestation.json
       SHA: ${{ needs.build-image.outputs.sha }}
       IMAGE: ${{ needs.build-image.outputs.image }}
       # Keep the workflow value raw. rollout.sh normalizes preserve/false/true
@@ -420,6 +426,31 @@ jobs:
 
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v2
+
+      - name: Capture frontend attestation
+        # rollout.sh requires TR_ROLLOUT_FRONTEND_ATTESTATION unconditionally:
+        # the artifact binds the forwarding rule and VIP, HTTPS proxy, URL map,
+        # ACTIVE certificate SAN coverage, exact DNS answers, and the smoke
+        # hash, and every region's rollout re-verifies it before mutating
+        # anything. CI captures against the reviewed host inventory in
+        # docs/security/edge-surfaces.json, so a hijacked or drifted frontend
+        # fails the deploy here rather than serving traffic behind it.
+        run: |
+          set -euo pipefail
+          mkdir -p "$(dirname "$TR_ROLLOUT_FRONTEND_ATTESTATION")"
+          url_map=$(gcloud compute target-https-proxies describe \
+            "$TR_HTTPS_PROXY" --project="$PROJECT_ID" --format='value(urlMap)')
+          url_map=${url_map##*/}
+          hosts=$(python3 -c 'import json; rows = [s for s in json.load(open("docs/security/edge-surfaces.json"))["surfaces"] if s["id"] == "gcp-control-domains"]; print(",".join(rows[0]["hosts"]))')
+          python3 scripts/deploy/rollout_frontend_attest.py capture \
+            --project "$PROJECT_ID" \
+            --forwarding-rule "$TR_FORWARDING_RULE" \
+            --https-proxy "$TR_HTTPS_PROXY" \
+            --url-map "$url_map" \
+            --hosts "$hosts" \
+            --artifact "$TR_ROLLOUT_FRONTEND_ATTESTATION"
+          python3 scripts/deploy/rollout_frontend_attest.py \
+            verify-artifact "$TR_ROLLOUT_FRONTEND_ATTESTATION"
 
       # Staged regional deploy. Deploy us-central1 first, gate on a
       # 3-min single-region synthetic watch; only proceed to the

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -271,10 +271,13 @@ jobs:
         run: bash scripts/deploy/regional_quota_ledger.sh
 
   sync-runtime-secrets:
-    # Validate the small set of runtime credentials while the image build and
-    # schema verification run. SES credentials are rotated directly in GCP
-    # Secret Manager; deploys must never copy a stale long-lived key back from
-    # GitHub Actions and silently undo an incident-response rotation.
+    # Validate the six process surfaces' credential contract while the image
+    # build and schema verification run. Credentials are rotated directly in
+    # GCP Secret Manager; deploys must never copy a stale long-lived key back
+    # from GitHub Actions and silently undo an incident-response rotation.
+    # This job needs only per-resource Secret Manager Viewer bindings. It
+    # verifies that an ENABLED version exists without reading or logging any
+    # secret value.
     needs: [gate-on-ci]
     runs-on: ubuntu-latest
     steps:
@@ -285,15 +288,58 @@ jobs:
           workload_identity_provider: projects/44325983244/locations/global/workloadIdentityPools/github-actions/providers/github
           service_account: tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com
       - uses: google-github-actions/setup-gcloud@v2
-      - name: Validate required SES credentials
+      - name: Validate six-surface credential metadata
         run: |
           set -euo pipefail
-          for secret in \
-            trustedrouter-aws-access-key-id \
-            trustedrouter-aws-secret-access-key; do
-            gcloud secrets versions access latest \
+          # surface|Secret Manager resource. Repeated resources document the
+          # intentional sharing contract while `checked` avoids duplicate API
+          # reads. Internal billing has distinct Stripe and SES credentials.
+          surface_secret_contract=(
+            "public|trustedrouter-attribution-cookie-secret"
+            "actions|trustedrouter-aws-access-key-id"
+            "actions|trustedrouter-aws-secret-access-key"
+            "console|trustedrouter-attribution-cookie-secret"
+            "console|trustedrouter-aws-access-key-id"
+            "console|trustedrouter-aws-secret-access-key"
+            "console|trustedrouter-stripe-secret-key"
+            "console|trustedrouter-sentry-dsn"
+            "chat|trustedrouter-sentry-dsn"
+            "webhooks|trustedrouter-sentry-dsn"
+            "webhooks|trustedrouter-stripe-webhook-secret"
+            "internal|trustedrouter-sentry-dsn"
+            "internal|trustedrouter-internal-stripe-payment-intents-key"
+            "internal|trustedrouter-internal-ses-access-key-id"
+            "internal|trustedrouter-internal-ses-secret-access-key"
+            "internal|trustedrouter-internal-gateway-token"
+            "internal|trustedrouter-observer-internal-token"
+            "internal|trustedrouter-synthetic-monitor-api-key"
+          )
+          declare -A checked=()
+          declare -A represented=()
+          for binding in "${surface_secret_contract[@]}"; do
+            surface="${binding%%|*}"
+            secret="${binding#*|}"
+            represented["${surface}"]=1
+            if [ -n "${checked[${secret}]:-}" ]; then
+              continue
+            fi
+            enabled_version="$(gcloud secrets versions list "${secret}" \
               --project=quill-cloud-proxy \
-              --secret="${secret}" >/dev/null
+              --filter='state=ENABLED' \
+              --limit=1 \
+              --format='value(name)')"
+            if [ -z "${enabled_version}" ]; then
+              echo "required secret has no ENABLED version: ${secret}" >&2
+              exit 1
+            fi
+            checked["${secret}"]=1
+            echo "validated enabled-version metadata for ${secret}"
+          done
+          for surface in public actions console chat webhooks internal; do
+            if [ -z "${represented[${surface}]:-}" ]; then
+              echo "credential contract omitted surface: ${surface}" >&2
+              exit 1
+            fi
           done
       - name: Push provider analytics reader credential
         env:
@@ -348,6 +394,14 @@ jobs:
       REGION: us-central1
       REPO: trusted-router
       SERVICE: trusted-router
+      TR_PUBLIC_SERVICE: trusted-router-public
+      TR_ACTIONS_SERVICE: trusted-router-actions
+      TR_CONSOLE_SERVICE: trusted-router
+      TR_CHAT_SERVICE: trusted-router-chat
+      TR_WEBHOOKS_SERVICE: trusted-router-webhooks
+      TR_INTERNAL_SERVICE: trusted-router-billing
+      TR_BILLING_SERVICE: trusted-router-billing
+      TR_ROLLOUT_MANIFEST: ${{ runner.temp }}/tr-rollout/manifest.json
       SHA: ${{ needs.build-image.outputs.sha }}
       IMAGE: ${{ needs.build-image.outputs.image }}
       # Keep the workflow value raw. rollout.sh normalizes preserve/false/true
@@ -638,13 +692,16 @@ jobs:
         # 06:00Z 2026-06-02 pong surge to persist after PR #14 + #15
         # "deployed".
         #
-        # The script is idempotent and gracefully no-ops if the
-        # synthetic monitor secret isn't present in this environment
-        # (test, staging). Failure here does NOT block the API rollout
-        # (continue-on-error) because synthetic monitoring is observability,
-        # not user-serving traffic.
-        continue-on-error: true
-        run: bash scripts/deploy/synthetic.sh
+        # The script is idempotent and gracefully no-ops if the synthetic
+        # monitor secret isn't present in a non-production environment. A real
+        # deploy failure is release-critical: silently leaving stale probes
+        # would make the canary evidence untrustworthy for the next rollout.
+        env:
+          TR_BILLING_SERVICE: trusted-router-billing
+        run: |
+          set -euo pipefail
+          : "${TR_BILLING_SERVICE:?TR_BILLING_SERVICE must name the internal billing service}"
+          bash scripts/deploy/synthetic.sh
 
       - name: Deploy Google Ads conversion uploader
         if: ${{ steps.optional.outputs.deploy_google_data_manager == 'true' }}

--- a/docs/operations/service-surfaces.md
+++ b/docs/operations/service-surfaces.md
@@ -5,11 +5,19 @@ Production must never use the local/test-only `combined` role.
 
 | Surface | Internet ownership | Background ownership | Capacity contract |
 |---|---|---|---|
-| `public` | Marketing, static pages, status, public catalog | None | concurrency 4, max 10, min 0, Spanner pool 1 |
-| `actions` | Exact anonymous `POST /support/inquiry` and `POST /trustedos/inquiry` handlers | None | concurrency 4, max 2, min 0, 30s timeout, no shared Store |
-| `control` | Login, existing-user console, account management, checkout, signed external webhooks, MCP and the authenticated browser proxy | Activation reminders | concurrency 4, max 20, warm min 1, Spanner pool 2 |
-| `internal` | Gateway authorize/settle/refund, federation, drains and synthetic callbacks | Deferred settlement, synthetic monitor and remediator | concurrency 8, max 50, warm min 2, Spanner pool 8 |
+| `public` | Marketing, static pages, status, public catalog | None | concurrency 4, max 10, min 0, 60s timeout, 1 MiB request cap |
+| `actions` | Exact anonymous `POST /support/inquiry` and `POST /trustedos/inquiry` handlers | None | concurrency 4, max 2, min 0, 30s timeout, 256 KiB request cap, no shared Store |
+| `console` | Login, existing-user console, account management, checkout, MCP and browser-key issuance | None | concurrency 4, max 20, warm min 1, 300s timeout, 4 MiB request cap |
+| `chat` | Authenticated `/chat-proxy/*` browser streaming and attachments | None; forwards caller authentication to the attested gateway | concurrency 2, max 20, warm min 1, 300s timeout, 32 MiB request cap |
+| `webhooks` | Exact signed Stripe, PayPal, Adyen, Veriff, and SES callback routes | None | concurrency 4, max 10, warm min 1, 60s timeout, 1 MiB request cap |
+| `internal` | Gateway authorize/settle/refund, federation, drains and synthetic callbacks | Deferred settlement only; scheduled synthetic/remediator passes remain external jobs | concurrency 8, max 50, warm min 2, 300s timeout, 32 MiB request cap |
 | `observer` | AWS/Azure status, public catalog, and authenticated synthetic ingest | AWS: existing EventBridge rule; Azure: in-process synthetic monitor and remediator, with exactly one replica | AWS max 4; Azure max 1 while either loop is enabled |
+
+The canonical GCP console companion is `trusted-router-console`.
+`trusted-router` remains the explicitly named legacy combined monolith
+(`LEGACY_CONSOLE_SERVICE`, overridden only with
+`TR_LEGACY_CONSOLE_SERVICE`) for initial-migration discovery and rollback; it
+is not the split `console` target.
 
 The GCP global load balancer applies the same path contract only to the exact
 managed apex, `www`, `status`, and `trust` hosts for `trustedrouter.com`,
@@ -19,8 +27,9 @@ regional/status hosts. The transformer refuses a first-party wildcard rule:
 remain on their existing front doors.
 The public service is the first-party default. The two exact inquiry POST paths
 select the low-capacity actions service, explicit account paths select the
-control service, and `/internal/*` selects billing except for the enumerated
-signed-webhook and browser-key control exceptions. Both unprefixed and `/v1`
+console service, `/chat-proxy/*` selects chat, the exact signed callback routes
+select webhooks, and `/internal/*` selects internal except for the enumerated
+signed-webhook and browser-key console exceptions. Both unprefixed and `/v1`
 API forms are tested against the actual FastAPI route inventory. This preserves
 the `https://trustedrouter.com(/v1)` URL measured into attested gateway images.
 
@@ -33,7 +42,7 @@ provider signature. Authentication must run before request-body or Store work.
 ## Secrets and shared storage
 
 The public process receives no gateway, payment, email, Sentry, or BYOK secret.
-Public and control share only a dedicated attribution-cookie secret so a
+Public and console share only a dedicated attribution-cookie secret so a
 campaign cookie issued on a marketing page can be consumed at signup. Reusing
 the internal gateway token for that purpose is rejected at startup. The actions
 process receives only the SES sender credentials and operations-chat credential
@@ -43,10 +52,10 @@ payment, Sentry, or BYOK credential.
 The rollout also sets the non-secret
 `TR_GOOGLE_OAUTH_LOGIN_AVAILABLE` and
 `TR_GITHUB_OAUTH_LOGIN_AVAILABLE` flags with identical values on `public` and
-`control`. They let marketing pages
-render the control-owned login links without copying either OAuth client secret
+`console`. They let marketing pages
+render the console-owned login links without copying either OAuth client secret
 into the public process; a deployed public process rejects an omitted flag and
-control rejects any supplied value that disagrees with its credentials.
+console rejects any supplied value that disagrees with its credentials.
 The public `/openapi.json` is a deterministic, pre-serialized build asset made
 from a credential-free combined route inventory, with all `/internal/*` RPCs
 and unreachable components removed. Its drift test runs the generator in an
@@ -92,26 +101,136 @@ bash scripts/deploy/set_new_signups.sh disable
 bash scripts/deploy/set_new_signups.sh enable
 ```
 
-The command preflights every region as a `control` service, creates a
-no-traffic revision, explicitly moves 100% traffic to it, and verifies the
-value on the serving revision. Normal rollouts read and preserve that live
-value, so deploying code cannot accidentally reopen registration. AWS/Azure
-observer deployments pin signups off and do not register account routes.
+The command preflights `trusted-router-console` in every region as a `console`
+service, creates a no-traffic revision, explicitly moves 100% traffic to it,
+and verifies the value on the serving revision. It never mutates the legacy
+`trusted-router` monolith. Normal rollouts read and preserve that live value,
+so deploying code cannot accidentally reopen registration. AWS/Azure observer
+deployments pin signups off and do not register account routes.
 
 ## Deployment and failure behavior
 
-The initial split is ordered to avoid a compatibility outage:
+Initial staging requires the legacy fallback to be hardened before the split
+transaction begins. Every legacy service must already be Ready, use both
+desired and effective `internal-and-cloud-load-balancing` ingress, have exact
+invoker IAM, carry named sole-revision 100% traffic with no `LATEST` target,
+and mount only numeric pinned secret versions whose access policy matches the
+reviewed legacy identity. Default/all ingress, `:latest` or other floating
+secret references, or any other mismatch fails closed. Run the checked
+`rollout_legacy_harden.sh` prerequisite before the bootstrap. It writes a
+mode-0600 artifact and retained sibling `.state` journal before provider
+mutations, pins the serving secret versions, deploys an immutable LB-only
+revision, ramps named traffic through 10/50/100, and restores the captured
+named baseline traffic if a verified ramp fails. Ingress hardening is
+forward-only; do not discard either file.
 
-1. Deploy public, actions, and billing companions successfully in every intended region.
-2. Create and attach their independent NEGs/backends and capacity policies.
-3. Import the tested four-service URL map while the old combined control
-   revision can still serve every control path.
-4. Deploy the new control-only revision and use the existing staged traffic
-   workflow.
+The initial split has a forward-only private bootstrap before the
+manifest-bound web transaction:
 
-The URL map is never changed after a partial companion deployment. Public CDN
-is enabled only on the public backend; actions, authenticated control, and
-billing have independent non-CDN backends and autoscaling budgets. Exhausting
+1. Run the approved `infra.sh` and `secrets.sh` reconciliation to provision the
+   dedicated `tr-synthetic@PROJECT.iam.gserviceaccount.com` identity, its exact
+   deploy-only actAs policy, and its exact two Secret Manager accessor
+   bindings. It has no project, Spanner, Bigtable, KMS, or cross-service
+   impersonation role. This seventh Job identity is not one of the six FastAPI
+   runtime identities. The checked verifier rejects direct folder and
+   organization bindings, but it cannot prove membership hidden behind an
+   external Google Group; the cloud owner must audit those memberships as
+   separate production-execution evidence.
+2. Harden and verify the legacy fallback, retaining both files:
+
+   ```bash
+   bash scripts/deploy/rollout_legacy_harden.sh \
+     --artifact "$TR_LEGACY_HARDENING_ARTIFACT"
+   bash scripts/deploy/rollout_legacy_harden.sh \
+     --verify-artifact "$TR_LEGACY_HARDENING_ARTIFACT"
+   ```
+
+3. Bootstrap `internal` in the union of control-plane and synthetic-job regions
+   and retain both the private mode-0600 artifact and its sibling `.state`
+   journal:
+
+   ```bash
+   bash scripts/deploy/rollout_bootstrap_internal.sh \
+     --artifact "$TR_INTERNAL_BOOTSTRAP_ARTIFACT"
+   ```
+
+   A fresh bootstrap requires the complete internal service cohort to be
+   absent. Before each provider call the helper records a region-bound
+   deploy/traffic intent in `${TR_INTERNAL_BOOTSTRAP_ARTIFACT}.state`; an
+   interrupted run may resume only that exact project, digest, release,
+   revision suffix, and region cohort. Never discard or overwrite either file
+   during the initial migration.
+
+4. Run `synthetic.sh` to repoint every canonical Job/Scheduler to the private
+   regional internal origin, then run the bootstrap artifact verifier. The
+   required order is bootstrap `internal`, repoint Jobs/Schedulers, and only
+   then verify the artifact and live synthetic configuration. The verifier
+   must prove the exact job image/spec, dedicated identity, Direct VPC settings,
+   numeric enabled observer/monitor secret versions, exact nonsecret
+   environment, and Scheduler target. The legacy combined monolith
+   (`trusted-router`) URL and control backend remain untouched throughout this
+   prerequisite.
+5. Capture the repository-owned frontend attestation with the exact managed
+   host inventory. The read-only tool binds TCP/443 forwarding rule and VIP,
+   HTTPS proxy and URL map, ACTIVE certificate coverage, exact DNS A/AAAA, and
+   the checked smoke-script hash. Retain its mode-0600 artifact and set
+   `TR_ROLLOUT_FRONTEND_ATTESTATION` to it.
+6. Read-only preflight the complete six-account IAM/data/secret-owner matrix,
+   preserved host rules, immutable image digest, existing traffic, and any
+   already-live backend. A floating `LATEST` traffic or tag target aborts before
+   the first mutation because it cannot be restored exactly after a deploy.
+7. Run `rollout.sh --manifest PATH` with
+   `TR_INTERNAL_BOOTSTRAP_ARTIFACT`, `TR_LEGACY_HARDENING_ARTIFACT`, and
+   `TR_ROLLOUT_FRONTEND_ATTESTATION` set.
+   It verifies the artifact and live jobs, reconciles only previously
+   unreachable edge resources, then stages and post-verifies all six surfaces
+   in every control region plus private `internal` in every synthetic-only
+   region. Existing reachable
+   backends must already match their exact NEG, timeout, header, CDN, and Cloud
+   Armor contracts. The stage places each of the six split services at 100% on
+   its sole revision; `internal` adopts the already verified bootstrap rather
+   than creating a second cutover path. All six companions stay off-map and
+   unreachable through LB-only ingress, no default URL (except the preflighted
+   private internal synthetic path), and no URL-map route.
+
+   Legacy hardening, bootstrap, and initial staging require the same canonical
+   `TR_ROLLOUT_OPERATION_ID` and serialize through the same mode-0600 local
+   operation lock. This prevents two commands on one retained runner from
+   snapshotting or creating the cohort concurrently. It is not a cross-runner
+   lease. The shared online authority/CAS extension for these pre-promotion
+   mutations was not approved, so do not start them from a hosted or second
+   runner; cross-host initial staging remains a production blocker rather than
+   an inferred ownership guarantee.
+8. Write the versioned manifest plus separate prior/candidate URL-map snapshots.
+   The manifest contains only names, immutable image/revision metadata, traffic,
+   capacity, and postcondition hashes—never environment values, secret refs,
+   versions, or tokens.
+9. Run `rollout_rollback.sh promote MANIFEST` with the exact repository-owned
+   `scripts/deploy/rollout_smoke.sh` callback, mode-0600 authorization-header
+   and Firefox storage-state inputs, and explicit production-smoke approval.
+   Because every split service is already at its sole
+   revision's 100%, initial cutover consists only of atomically importing the
+   candidate three-domain URL map away from the untouched legacy
+   monolith/control backend. Initial rollback consists only of restoring the
+   prior URL map to that untouched legacy backend; it does not change Cloud Run
+   service traffic. Web rollback deliberately leaves the forward-only internal
+   bootstrap and repointed synthetic jobs in place; it never sends those jobs
+   back to the legacy console origin.
+
+Subsequent releases leave the URL map unchanged and move candidate revisions
+through 10%, 50%, and 100%, first in the primary region and then all secondary
+regions. These traffic ramps apply only after the initial split is already
+serving; they are not part of the initial cutover. Every step verifies Cloud
+Run Admin state, the full edge contract, and the mandatory LB/browser callback;
+a rerun resumes monotonically and never demotes a more advanced cohort.
+Provider mutations run under a durable operation lease and an explicit
+mutation fence. Each `gcloud` mutator is process-group terminated before its
+configured deadline, which must end at least fifteen seconds before lease
+expiry. A timed-out or otherwise ambiguous call deliberately leaves the fence
+unresolved: release and expired-lease takeover then fail closed for cloud-owner
+reconciliation instead of allowing a late provider apply to race recovery.
+Public CDN is enabled only on the public backend; actions, console, chat, webhooks, and
+internal have independent non-CDN backends and autoscaling budgets. Exhausting
 the anonymous rendering or form-submission budget therefore does not consume
 their protected Cloud Run concurrency or instance quota. Spanner remains a
 shared managed dependency, so sustained anonymous read pressure can still
@@ -127,14 +246,64 @@ are deliberately changed together.
 
 ## Integration status
 
-This change supplies the fail-closed application roles, four-backend URL-map
-transformer, route-totality tests, signup operator switch, and regional
-observer configuration. The production `scripts/deploy/rollout.sh` cutover is
-intentionally a separate integration patch: it must deploy the `-public`,
-`-actions`, and `-billing` companions in every region, apply the independent
-capacity and secret allowlists above, preserve the serving control revision's
-signup flag, and invoke `service_surface_url_map.py` before moving the legacy
-service to `control`. Until that reviewed rollout patch lands, the helper must
-not be imported manually against the production URL map. The same patch must
-create and verify the four least-privilege runtime identities; an
-environment-only secret allowlist is insufficient.
+The repository now contains the fail-closed six-surface application roles,
+six-backend URL-map transformer, manifest builder, staged rollout, phased
+promotion, attempt-scoped rollback, route-totality tests, signup operator
+switch, and regional observer configuration. This is implemented code, not a
+claim about live state: no production `gcloud` rollout was executed as part of
+this change, and the checked-in security inventory remains
+`live_state_verified: false`.
+
+Before an approved rollout, a cloud/IAM owner must run the separately reviewed
+`infra.sh` reconciliation for the six runtime accounts plus their exact actAs,
+Spanner, Bigtable, and KMS bindings and the dedicated synthetic account.
+`secrets.sh` then uses targeted member-level mutations to reconcile the exact
+runtime/deploy/synthetic SecretAccessor matrix and unconditional public
+denials on declared resources; it never replaces a whole secret policy.
+Unknown secrets with managed or public drift fail before mutation, and an
+unrelated non-public accessor is admitted only through the exact per-secret
+preservation allowlist. `rollout.sh` only verifies these IAM contracts. Do not
+import either URL-map snapshot or run the promotion helper independently of
+the manifest-producing stage.
+
+The read-only rollout gate also enumerates every project Spanner
+instance/database, Bigtable instance/table, KMS location/keyring/key, and
+service account. An unconfigured resource must have no split-runtime or
+synthetic binding, and an unconfigured service account must not be directly
+impersonable by either. Provisioning adds and verifies the desired six-runtime
+grant before selectively removing obsolete roles, then post-verifies the exact
+matrix so IAM propagation cannot create a remove-before-add outage.
+
+The production workflow is intentionally not ready to invoke this transaction.
+The checked `.github/workflows/deploy.yml` still invokes the legacy
+single-service commands and does not supply the required manifest, bootstrap,
+legacy-hardening, frontend-attestation, recovery, or repository-owned Firefox
+smoke inputs. A safety review rejected changing or even indirectly guarding
+that shared production workflow in this change. Do not use it for the
+six-surface rollout; run no production mutation until that workflow change is
+separately approved and reviewed.
+
+The durable recovery contract uses
+`gs://BUCKET/trusted-router-rollouts/PROJECT`, an exact `authority.json`, and a
+unique `releases/MANIFEST_EPOCH/` bundle containing the manifest, private map
+snapshots, and journal. The read-only IAM gate requires uniform bucket access,
+public-access prevention, versioning, retention of at least seven days, an
+exact create/delete/get custom role, and one deploy binding scoped only to the
+authority object plus the current unique bundle. No code here provisions that
+persistent access: a narrow approval for those exact object scopes is still
+required, and a broad project-prefix binding is rejected. The edge reconciler
+now clears stale request/response headers, IAP, and edge-security policy state
+and replaces Cloud Armor with the exact audited rule set, but it has not been
+run in production. Existing Cloud CDN signed-URL keys fail closed because
+deleting those credential-like keys still requires exact backend/key approval.
+`rollout_frontend_attest.py` now verifies forwarding-rule/VIP identity, ACTIVE
+certificate coverage, exact DNS for every managed host, and the repository
+smoke hash; `rollout_smoke.sh` runs the API checks and Playwright Firefox suite.
+However, safety review rejected uploading the persisted frontend and legacy
+artifacts into the online recovery bundle, so a fresh runner cannot recover
+from that bundle alone. Retain and securely transfer both mode-0600 artifacts;
+if either is unavailable, or GCS/IAM/network access prevents live CAS, recovery
+fails closed and requires a cloud-owner incident procedure. Offline rollback
+and cross-manifest authority supersession were also rejected. Do not claim
+production readiness until those approvals and the workflow integration are
+resolved.

--- a/docs/runbooks/ddos-edge-hardening.md
+++ b/docs/runbooks/ddos-edge-hardening.md
@@ -10,7 +10,12 @@ false until every provider-side verification has been captured after rollout.
 - The exact managed apex, `www`, `status`, and `trust` hosts for
   `trustedrouter.com`, `allyrouter.com`, and `uptimerouter.com` share the GCP
   public load balancer, along with the enumerated TrustedRouter regional/status
-  hosts. First-party wildcard rules are forbidden so attested `api*`, AWS,
+  hosts -- with one exclusion: `trust.trustedrouter.com` is the enclave
+  repository's static site (GitHub Pages; DNS pinned by
+  `quill-cloud-proxy/tools/fix-trustedrouter-dns.sh`) and is not an LB host.
+  `www.trustedrouter.com` is a CNAME to the apex by that same policy; the
+  attestation accepts a CNAME only when it chains through another managed host
+  to the attested VIP. First-party wildcard rules are forbidden so attested `api*`, AWS,
   Azure, alerting, and operational subdomains cannot be stolen during import.
   Every selected backend needs its own attached Cloud Armor policy.
 - The load balancer overwrites `X-TrustedRouter-Client-IP` from

--- a/docs/runbooks/ddos-edge-hardening.md
+++ b/docs/runbooks/ddos-edge-hardening.md
@@ -57,61 +57,315 @@ before that job is deployed.
 
 ## GCP rollout order
 
-1. Confirm every expected hostname resolves to the protected global HTTPS load
-   balancer and both brand certificates are ACTIVE.
-2. Reconcile each `backend=policy` pair with
-   `TR_CLOUD_ARMOR_BACKEND_POLICIES`. The generous all-path per-source ceiling
-   and unexpected-Host deny are enforced from the first attach; browser
-   inference proxy and state-changing-method rules start in preview. Backend logging is enabled
-   at a 10% sample by default so the tighter preview matches can be sized from
-   evidence without turning a flood into full-volume log-ingestion cost. Set
-   `TR_CLOUD_ARMOR_LOG_SAMPLE_RATE` explicitly for a short investigation and
-   lower it again before sustained high traffic.
-3. Verify each backend reports the expected `securityPolicy` and exactly one
-   `X-TrustedRouter-Client-IP:{client_ip_address}` custom request header.
-   Unrelated custom headers must survive reconciliation.
-4. Verify public LB requests for all apex, `www`, `status`, and `trust` names.
-5. Configure private run.app DNS and Private Google Access for every synthetic
-   job region, then run one bounded synthetic execution and verify its regional
-   ingest succeeds.
-6. Set Cloud Run ingress to `internal-and-cloud-load-balancing`. From an
-   external runner, each retained run.app `/health` request must return 403 or
-   404; a 2xx/3xx response is a failed deployment. Services with no named
-   private consumer additionally use `--no-default-url` and must expose no
-   `.status.url`.
-7. The final smoke uses public LB hostnames for HTTP behavior and the Cloud Run
-   Admin API for each region's Ready/traffic/release/ingress/scaling state. It
-   never reopens or treats a successful origin request as healthy.
+The repository implements a six-service, manifest-bound stage/promote/rollback
+transaction. It has not been executed against production by this code change;
+runtime IAM provisioning and every live mutation remain explicitly
+approval-gated.
 
-The current `rollout.sh` does **not** yet source this reconciler or create the
-four service backends. Do not run the command below on the current branch and
-do not source `_edge_security.sh` manually against production. It is the target
-operator command only after the separately reviewed four-service rollout patch
-has landed and its first-cutover ordering tests are green.
+Before this order begins, the legacy fallback must already be hardened. Each
+legacy service must be Ready, report both desired and effective
+`internal-and-cloud-load-balancing` ingress, have exact invoker IAM, route 100%
+to one named revision with no `LATEST` target, and use only numeric pinned
+secret versions with exact access for the reviewed legacy identity. Default or
+all ingress, `:latest` or other floating secret refs, or any mismatch is a
+fail-closed
+pre-migration error; staging does not repair it. Run
+`rollout_legacy_harden.sh --artifact "$TR_LEGACY_HARDENING_ARTIFACT"` first.
+The helper retains a mode-0600 journal, pins the serving secret versions,
+deploys an immutable LB-only revision, ramps named traffic through 10/50/100,
+and restores the exact named baseline traffic after a verified failure.
+Ingress hardening is forward-only. Re-run the same command to resume only the
+recorded suffix and cohort, then use `--verify-artifact` before bootstrap.
 
-After that integration, and after at least one representative peak window of
-preview logs has been reviewed, promote the GCP rules explicitly:
+1. Confirm every managed apex, `www`, `status`, and `trust` hostname for all
+   three domains resolves to the protected global HTTPS load balancer and the
+   certificates are ACTIVE. Confirm explicit existing host rules for every API,
+   AWS, Azure, and Quill regional alias; none may depend on the URL-map default.
+2. As a cloud owner, run the separately reviewed `infra.sh` reconciliation for
+   the six runtime accounts, the dedicated synthetic account, and their exact
+   actAs, Spanner, Bigtable, and KMS bindings. Run `secrets.sh` to reconcile the
+   declared per-resource SecretAccessor owner matrix with targeted add/remove
+   operations. Both scripts preflight the complete owned inventory before the
+   first IAM mutation and post-verify it. Unknown secrets with a managed or
+   public principal fail closed for a separately reviewed owner change;
+   unrelated accessors are preserved only when named exactly in
+   `TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON`. `rollout.sh` then performs a
+   read-only verification of the complete project, ancestor, data, KMS, and
+   Secret Manager matrix. That gate lists every in-project Spanner instance
+   and database, Bigtable instance and table, KMS location/keyring/key, and
+   service account; any split-runtime or synthetic grant on an unconfigured
+   resource, including cross-service-account impersonation, fails closed.
+3. Verify the provisioned
+   `tr-synthetic@PROJECT.iam.gserviceaccount.com` Job identity. It may have no
+   project, Spanner, Bigtable, KMS, or runtime-impersonation role; its only
+   payload access is the observer token and monitor key, and only the deploy
+   identity may act as it. The verifier also rejects direct folder and
+   organization bindings. It cannot prove transitive membership in an
+   externally managed Google Group, so capture a group-membership audit as
+   separate release evidence before approving the production execution.
+4. Harden and read-only verify the legacy fallback, retaining the artifact and
+   its sibling `.state` journal. Then bootstrap the private internal service,
+   retain its mode-0600 artifact and
+   sibling `.state` journal, repoint the Jobs, and then verify the artifact and
+   live Jobs in exactly that order. Keep the legacy combined monolith
+   (`trusted-router`) origin and control backend untouched:
 
-```bash
-TR_CLOUD_ARMOR_PREVIEW=0 \
-TR_CLOUD_ARMOR_BACKEND_POLICIES='public-backend=public-edge,actions-backend=actions-edge,control-backend=control-edge,billing-backend=billing-edge' \
-bash scripts/deploy/rollout.sh
-```
+   ```bash
+   bash scripts/deploy/rollout_bootstrap_internal.sh \
+     --artifact "$TR_INTERNAL_BOOTSTRAP_ARTIFACT"
+   bash scripts/deploy/synthetic.sh
+   bash scripts/deploy/rollout_bootstrap_internal.sh \
+     --verify-artifact "$TR_INTERNAL_BOOTSTRAP_ARTIFACT" \
+     --expected-image "$IMAGE"
+   ```
 
-Promotion of the three tighter rules is reversible by reconciling with
-`TR_CLOUD_ARMOR_PREVIEW=1`; the generous per-source ceiling remains enforced. This
-does not detach the policy or reopen the origin.
+   The verifier covers every control/synthetic region, exact private internal
+   revision, exact Job/Scheduler inventory, numeric enabled secret refs,
+   Direct VPC/PGA/private DNS, and the dedicated identity. Do not stage the
+   remaining split services before this bootstrap/repoint/verify prerequisite
+   completes. Web rollback leaves this forward-only internal bootstrap and Job
+   repointing in place. A fresh
+   bootstrap is allowed only when the entire reviewed internal cohort is
+   absent. The journal is written mode 0600 before each deploy/traffic call;
+   after interruption, rerun with the same artifact path to resume only the
+   recorded project, digest, release, suffix, and regions. Preserve both files
+   until the migration and recovery window have closed.
+5. Resolve every explicit release input before staging. In particular, an
+   initial legacy monolith revision without preserved capability flags requires
+   explicit `true` or `false` values for `TR_PAYPAL_CHECKOUT_ENABLED`,
+   `TR_ADYEN_ENABLED`, and `TR_VERIFF_ENABLED`; secret existence never enables
+   those capabilities. Also review `IMAGE`, `TR_CONTROL_PLANE_REGIONS`,
+   `TR_RELEASE`, `TR_ROLLOUT_REVISION_SUFFIX`, network/subnet and private
+   synthetic DNS inputs, and the nonsecret OAuth, telephony, storage, request
+   record, and analytics values. Omitted values may be preserved only from one
+   unambiguous 100%-serving console revision with identical state in every
+   region. A partial provider-verifier secret group always aborts.
+6. Capture the frontend contract with `rollout_frontend_attest.py capture`.
+   Supply the exact checked managed-host inventory; the artifact binds the
+   global TCP/443 forwarding rule and VIP, HTTPS proxy and URL map, ACTIVE
+   certificate SAN coverage, exact A/AAAA answers, and the repository smoke
+   hash. Run the approved stage command with a new manifest path and the
+   verified artifacts in `TR_INTERNAL_BOOTSTRAP_ARTIFACT`,
+   `TR_LEGACY_HARDENING_ARTIFACT`, and
+   `TR_ROLLOUT_FRONTEND_ATTESTATION`:
+
+   ```bash
+   bash scripts/deploy/rollout.sh --manifest "$ROLLOUT_MANIFEST"
+   ```
+
+   Staging first resolves an immutable image digest and numeric secret
+   versions. It verifies any reachable backend without mutating it, reconciles
+   only unreachable edge resources, deploys all six services in every region,
+   and checks observed generation, `/ready`, invoker IAM, exact environment and
+   secret names, capacity, ingress, and default-URL policy. This includes
+   adopting the verified `internal` bootstrap into the six-service split. Each
+   split service is staged at 100% on its sole revision, but remains off-map;
+   it is unreachable because it has LB-only ingress, no public default URL
+   (apart from the private internal synthetic path), and no URL-map/backend
+   route.
+7. Review the manifest and its separate prior/candidate URL-map snapshots
+   without printing or uploading them. The manifest contains no environment
+   values, secret resource/version references, rendered credentials, or
+   tokens. Do not hand-edit it.
+8. Promotion requires the private durable recovery bundle when
+   `TR_ROLLOUT_REQUIRE_RECOVERY_BUNDLE=true`. Set the canonical no-slash prefix
+   to `gs://BUCKET/trusted-router-rollouts/PROJECT`; the authority object is
+   `${PREFIX}/authority.json`, the unique bundle is
+   `${PREFIX}/releases/MANIFEST_EPOCH`, and its journal is
+   `${BUNDLE}/promotion-state.json`. `TR_ROLLOUT_RECOVERY_GCS_ROLE` is the
+   production role input; if the legacy `TR_ROLLOUT_STATE_GCS_ROLE` is also
+   supplied, it must be identical. Never disable durable state in production.
+   The IAM verifier is read-only and accepts only a protected, versioned bucket,
+   an exact create/delete/get custom role, and one deploy binding scoped to the
+   authority object plus that current unique bundle. It rejects a broader
+   project prefix, public or unknown principals, and retention under seven
+   days. This change does not provision that persistent binding: obtain narrow
+   production approval for those two object scopes before executing rollout.
+   The one binding is titled `trusted-router-rollout-recovery` and uses exactly:
+
+   ```text
+   resource.name == "projects/_/buckets/BUCKET/objects/trusted-router-rollouts/PROJECT/authority.json" || resource.name.startsWith("projects/_/buckets/BUCKET/objects/trusted-router-rollouts/PROJECT/releases/MANIFEST_EPOCH/")
+   ```
+9. Promote only with the mandatory repository-owned authenticated LB/browser
+   smoke callback. Its authorization header and Playwright storage-state files
+   must be regular mode-0600 files, and the callback runs Playwright Firefox:
+
+   ```bash
+   TR_ROLLOUT_SMOKE_COMMAND="$(pwd)/scripts/deploy/rollout_smoke.sh" \
+   TR_ROLLOUT_SMOKE_PRODUCTION_APPROVED=true \
+     bash scripts/deploy/rollout_rollback.sh promote "$ROLLOUT_MANIFEST"
+   ```
+
+   All six split services are already staged off-map at sole-revision 100%, so
+   the initial cutover only atomically imports the candidate three-domain URL
+   map away from the untouched legacy monolith/control backend. It does not
+   select or ramp Cloud Run traffic. Existing-split releases keep the map fixed
+   and, only then, ramp all six revisions 10/50/100 in the primary cohort and
+   then the secondary cohort, with Admin/edge checks and a smoke after every
+   step.
+10. On any failed or ambiguous command, inspect the provider postcondition and
+   roll back only attempts recorded for this exact manifest. Initial rollback
+   only restores the prior URL map to the untouched legacy monolith/control
+   backend; it does not alter the split services' sole-revision 100% traffic.
+   Operators may invoke the same idempotent recovery explicitly:
+
+   ```bash
+   bash scripts/deploy/rollout_rollback.sh rollback "$ROLLOUT_MANIFEST"
+   ```
+
+11. From an external runner, verify public LB behavior for all three domains and
+   rejection of every non-internal run.app origin. Verify the internal private
+   synthetic/billing path through Direct VPC egress, Private Google Access, and
+   private `run.app.` DNS. A retained external origin 2xx/3xx is a failed
+   rollout.
+
+The checked frontend attestation now proves forwarding-rule/VIP identity,
+ACTIVE certificate coverage, exact DNS-to-VIP for every managed host, and the
+repository smoke hash. The callback path is bound to the checked script and
+runs the Firefox project after the API probes. The approved edge reconciler
+clears all stale request/response headers and edge-security policy state,
+disables and clears IAP, installs the sole trusted client-IP header, and
+post-verifies exact logging/CDN behavior. It atomically imports each exact
+Cloud Armor policy so unknown priorities, header actions, redirects, and other
+rule extras cannot survive. Those mutations are implemented and tested here,
+but were not executed against production. A backend with any Cloud CDN signed
+URL key fails closed: deleting those credential-like keys was not authorized
+by this change. If read-only inventory finds one, obtain explicit approval for
+the exact backend and key name before removal and rerun reconciliation.
+
+Do not invoke the checked production `deploy.yml` for this transaction. It
+still contains the legacy single-service rollout and does not supply the
+manifest/bootstrap/hardening/frontend/recovery/Firefox contract. Safety review
+rejected changing or indirectly guarding that workflow here. The online
+recovery bundle also does not contain the mode-0600 frontend and legacy
+artifacts because uploading them was rejected; retain and securely transfer
+them separately. A fresh runner without both files, or a GCS/IAM/network
+outage that prevents live CAS, must fail closed for cloud-owner intervention.
+Offline rollback and cross-manifest authority supersession were not approved.
+
+The synthetic Scheduler contract rejects an explicit OAuth scope or OIDC
+audience and clears any stored request body or custom header before accepting
+an updated schedule. Adding an explicit broad OAuth scope was not authorized.
+If provider-side evidence shows that Cloud Scheduler requires or materializes
+such a scope, stop and obtain a separate IAM review instead of weakening the
+exact verifier.
+
+The six exact edge pairs are public, actions, console, chat, webhooks, and
+internal. Public alone enables CDN. Every backend must have exactly one
+service-bound NEG per configured region, the one trusted client-IP overwrite,
+its surface timeout, and its own Cloud Armor policy. The unexpected-Host deny
+and generous all-path IP ceiling are enforced; chat-proxy and state-changing
+rules remain preview-only until a separately approved, evidence-backed policy
+promotion. Do not source `_edge_security.sh` manually against production.
 
 ## Runtime identity and data-plane isolation
 
 Environment allowlists are not a security boundary if every service retains a
 shared cloud identity or database administrator credential. Before the surface
-URL map is imported:
+URL map is imported, provision and post-verify these six identities:
 
-- assign distinct Cloud Run runtime service accounts to public, actions,
-  control, and internal; grant Secret Manager access per named secret and
-  storage permissions per role, and post-verify the serving revision's service
-  account;
+| Surface | Runtime service account | Spanner database | Bigtable instance | BYOK KMS key |
+| --- | --- | --- | --- | --- |
+| Public | `tr-public@PROJECT.iam.gserviceaccount.com` | `roles/spanner.databaseReader` | `roles/bigtable.reader` | none |
+| Actions | `tr-actions@PROJECT.iam.gserviceaccount.com` | none | none | none |
+| Console | `tr-console@PROJECT.iam.gserviceaccount.com` | `roles/spanner.databaseUser` | `roles/bigtable.reader` | `roles/cloudkms.cryptoKeyEncrypterDecrypter` |
+| Chat proxy | `tr-chat@PROJECT.iam.gserviceaccount.com` | `roles/spanner.databaseReader` | none | none |
+| Webhooks | `tr-webhooks@PROJECT.iam.gserviceaccount.com` | `roles/spanner.databaseUser` | none | none |
+| Internal billing | `tr-internal@PROJECT.iam.gserviceaccount.com` | `roles/spanner.databaseUser` | `roles/bigtable.user` | `roles/cloudkms.cryptoKeyDecrypter` |
+
+The data roles bind to the named database, instance, and key, never the
+project. Store-using surfaces may additionally hold only
+`roles/serviceusage.serviceUsageConsumer` at project scope; actions holds no
+project role. The deploy identity has `roles/iam.serviceAccountUser` on the six
+runtime accounts, not on a shared runtime identity. Treat any other direct or
+inherited project role as unsafe drift.
+
+`infra.sh` installs and read-after-write verifies every desired project,
+Spanner, Bigtable, and KMS grant before removing an obsolete role on that
+resource, then verifies the exact final matrix. This ordering is mandatory:
+remove-then-add reconciliation can interrupt serving traffic while IAM changes
+propagate even when the eventual policy is correct. The rollout verifier is a
+separate read-only backstop; it inventories all resources rather than trusting
+only the configured names and never attempts broad automatic cleanup.
+
+Required Secret Manager ownership is similarly resource-specific:
+
+| Secret resource | Only allowed split runtime owner(s) |
+| --- | --- |
+| `trustedrouter-attribution-cookie-secret` | public, console |
+| `trustedrouter-sentry-dsn` | console, chat, webhooks, internal |
+| `trustedrouter-stripe-secret-key` | console |
+| `trustedrouter-stripe-webhook-secret` | webhooks |
+| `trustedrouter-internal-stripe-payment-intents-key` | internal |
+| `trustedrouter-aws-access-key-id`, `trustedrouter-aws-secret-access-key` | actions, console |
+| `trustedrouter-internal-ses-access-key-id`, `trustedrouter-internal-ses-secret-access-key` | internal |
+| `trustedrouter-internal-gateway-token`, `trustedrouter-observer-internal-token`, `trustedrouter-synthetic-monitor-api-key` | internal |
+
+`secrets.sh` actively reconciles these declared resources using only targeted,
+unconditional `add-iam-policy-binding` and `remove-iam-policy-binding` calls;
+it never replaces a whole policy. It inventories and validates every project
+secret before its first IAM mutation, then post-verifies every policy. For each
+listed resource, every owner has exactly
+`roles/secretmanager.secretAccessor` and each of the other five runtime
+identities has no role on that resource. It also removes unconditional public
+principals from declared resources. An unknown secret must have zero direct
+runtime, deploy, synthetic, or public access; drift on an unknown resource
+stops before mutation so its owner can approve a narrow repair. Unrelated
+non-public accessors are never removed and must be explicitly preserved in the
+per-secret `TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON` allowlist.
+
+Optional capabilities do not weaken the rule. If present, their exact owner
+map is: ops-chat webhook → actions; Google/GitHub client credentials and alias
+JSON → console; PayPal client id/secret → console plus webhooks, PayPal webhook
+id → webhooks; Adyen API/client key → console, HMAC key → webhooks, reference
+key → console plus webhooks; Veriff API key → console, Veriff shared callback
+secret → webhooks; Twilio credentials → console; Telnyx credential → console
+only; provider-analytics ClickHouse reader → console; the primary ClickHouse
+password → console plus internal; operational-analytics ClickHouse reader →
+public plus console plus internal; and federation tokens → internal. Axiom,
+every raw model-provider API key, the Athena worker prompt, and
+`GCP_SERVICE_ACCOUNT_KEY_JSON` are deliberately detached from all six FastAPI
+services. Chat forwards caller authentication to the attested gateway and owns
+no upstream provider credential.
+
+The declared secret-owner inventory in `rollout.sh` is checked one resource at a time even
+when a capability is disabled and its secret is not mounted. A configured
+optional secret with any other split-runtime owner—or any direct role other
+than exactly `roles/secretmanager.secretAccessor` for its declared owner—is a
+pre-deploy failure, not a reason to widen the role. For PayPal, Adyen, and
+Veriff, explicit capability booleans gate new console activity; a complete
+existing verifier group remains on webhooks for late signed callbacks when the
+bit is false, while a partial group always aborts. Existing OAuth, telephony,
+and ClickHouse resources can be operationally required even though some
+application capabilities may be disabled, so verify their production flags
+and nonsecret configuration before cutover.
+
+GCP synthetic jobs are separate from the six Cloud Run services. Their
+dedicated `tr-synthetic` identity may directly read only
+`trustedrouter-observer-internal-token` and
+`trustedrouter-synthetic-monitor-api-key`. It needs `roles/run.invoker` on each
+exact job for Scheduler execution; it must not have project-wide
+`roles/run.developer`, Secret Accessor, Spanner, Bigtable, or KMS access.
+`infra.sh` provisions the identity and exact deploy-only actAs policy, while
+`synthetic.sh` requires each existing Job policy to be exact before updating it
+and post-verifies the sole invoker. The legacy Job identity remains a release
+blocker until the approved production execution has completed and every Job
+and Scheduler is verified on the dedicated identity.
+
+The first cutover must not revoke the legacy combined revision's identity or
+mutate its service traffic. The split console is `trusted-router-console`; the
+legacy monolith is kept separately as `trusted-router` through
+`LEGACY_CONSOLE_SERVICE` as the rollback target. Having all six split services
+at 100%—whether staged off-map or serving after cutover—is not authorization to
+retire that identity or decommission the fallback. Those actions remain
+blocked until a separately approved durable rollback window is closed and the
+legacy fallback is explicitly decommissioned. That closure/decommission
+workflow is not implemented, so do not run `infra.sh` with
+`TR_RETIRE_LEGACY_RUN_SERVICE_ACCOUNT_IAM=1` or remove the legacy project,
+Spanner, Bigtable, or KMS-key bindings under this runbook.
+
+Before the surface URL map is imported, also:
+
 - give the AWS observer a dedicated instance role and least-privilege database
   principal; it must not retain `dsql:DbConnectAdmin` or wildcard read access to
   `quill/*` secrets;
@@ -125,6 +379,30 @@ These are release prerequisites for claiming compromise isolation. Omitting an
 environment reference while the runtime identity can fetch the same secret or
 mutate the same database does not satisfy the public/private bulkhead.
 
+### Internal provider credential contract
+
+The internal Stripe credential must be a distinct live restricted key (prefix
+`rk_live_`). In the Stripe restricted-key editor, grant **Write** only for
+Payment Intents and set every other resource to **None**. In particular it must
+not create Customers, Checkout Sessions, Billing Portal Sessions, Payment
+Methods, refunds, payouts, or account keys. `secrets.sh` rejects a non-restricted
+prefix and rejects byte-for-byte reuse of the console key without printing
+either value.
+
+The internal AWS access-key pair must belong to a dedicated IAM principal. Its
+only allow statement is `ses:SendEmail`, restricted to the verified
+`trustedrouter.com` and `alerts.trustedrouter.com` SES identity ARNs and the
+approved `noreply@trustedrouter.com` / `alerts@alerts.trustedrouter.com` From
+addresses. Do not grant `ses:SendRawEmail`, SES read/list operations, SNS, IAM,
+Secrets Manager, S3, or any hosting permission. `secrets.sh` rejects reuse of
+either existing console/actions SES credential component.
+
+Secret Manager can verify key shape, distinct values, versions, and Google IAM;
+it cannot prove Stripe dashboard permissions or an AWS IAM policy. Capture the
+Stripe restricted-key permission export and AWS attached-policy document as
+provider-side release evidence before promotion. A secret name or `rk_live_`
+prefix alone is not that evidence.
+
 ## Cloud Run cost bulkheads
 
 Cloud Armor per-IP throttles do not bound a distributed botnet or the Cloud Run
@@ -136,7 +414,9 @@ bill. Each split service must set an independent concurrency and service-level
 | Legacy combined (migration only) | 2 | 20 |
 | Public/static | 4 | 10 |
 | Anonymous actions | 4 | 2 |
-| Control | 4 | 20 |
+| Console | 4 | 20 |
+| Chat proxy | 2 | 20 |
+| Webhooks | 4 | 10 |
 | Billing/internal gateway | 8 | 50 |
 | Observer/status worker | 4 | 4 |
 

--- a/docs/runbooks/ddos-edge-hardening.md
+++ b/docs/runbooks/ddos-edge-hardening.md
@@ -187,17 +187,19 @@ recorded suffix and cohort, then use `--verify-artifact` before bootstrap.
    resource.name == "projects/_/buckets/BUCKET/objects/trusted-router-rollouts/PROJECT/authority.json" || resource.name.startsWith("projects/_/buckets/BUCKET/objects/trusted-router-rollouts/PROJECT/releases/MANIFEST_EPOCH/")
    ```
    Provisioning commands for that approval window. These create exactly what
-   the read-only IAM verifier accepts — a versioned bucket with seven-day
-   retention, one three-permission custom role shared by the journal and
-   recovery bindings, and object-scoped conditional bindings for the deploy
-   identity — so a value drifting from these commands fails
-   `rollout_iam_verify.sh` rather than passing loosely:
+   the read-only IAM verifier accepts. In recovery mode the verifier requires
+   EXACTLY ONE deploy binding on the bucket -- the recovery condition, which
+   covers the authority object and the release bundle (the durable journal is
+   `${BUNDLE}/promotion-state.json`, inside the bundle, so no separate journal
+   binding may exist). The epoch is assigned, not implied: use the reviewed
+   manifest's sha256 so it is unique and canonical per release.
 
    ```bash
    PROJECT=quill-cloud-proxy
    BUCKET="${PROJECT}-tr-rollout-state"
    DEPLOY_SA="tr-deploy@${PROJECT}.iam.gserviceaccount.com"
    PREFIX="trusted-router-rollouts/${PROJECT}"
+   MANIFEST_EPOCH="$(shasum -a 256 "$ROLLOUT_MANIFEST" | cut -c1-64)"
 
    gcloud storage buckets create "gs://${BUCKET}" --project="$PROJECT" \
      --location=us-central1 --uniform-bucket-level-access \
@@ -207,13 +209,10 @@ recorded suffix and cohort, then use `--verify-artifact` before bootstrap.
    gcloud iam roles create trRolloutJournal --project="$PROJECT" \
      --title="TrustedRouter rollout journal" --stage=GA \
      --permissions=storage.objects.get,storage.objects.create,storage.objects.delete
-   # Journal binding: exactly one object.
-   gcloud storage buckets add-iam-policy-binding "gs://${BUCKET}" \
-     --member="serviceAccount:${DEPLOY_SA}" \
-     --role="projects/${PROJECT}/roles/trRolloutJournal" \
-     --condition="title=trusted-router-rollout-journal,expression=resource.name == \"projects/_/buckets/${BUCKET}/objects/${PREFIX}/state.json\""
-   # Recovery binding: the authority object plus this manifest epoch's bundle.
-   # MANIFEST_EPOCH comes from the reviewed manifest; re-run per release.
+   # THE one binding. Per release, remove the previous epoch's binding first --
+   # the verifier rejects accumulated stale bindings, and remove-then-add is
+   # the reviewed rotation:
+   #   gcloud storage buckets remove-iam-policy-binding ... --condition=<prior>
    gcloud storage buckets add-iam-policy-binding "gs://${BUCKET}" \
      --member="serviceAccount:${DEPLOY_SA}" \
      --role="projects/${PROJECT}/roles/trRolloutJournal" \
@@ -221,14 +220,15 @@ recorded suffix and cohort, then use `--verify-artifact` before bootstrap.
    ```
 
    Then export, for both the operator stage/promote commands and
-   `rollout_iam_verify.sh`:
+   `rollout_iam_verify.sh`. The state URI is the promotion journal INSIDE the
+   bundle; a standalone state object fails recovery verification:
 
    ```bash
-   export TR_ROLLOUT_STATE_GCS_URI="gs://${BUCKET}/${PREFIX}/state.json"
    export TR_ROLLOUT_RECOVERY_GCS_PREFIX="gs://${BUCKET}/${PREFIX}"
    export TR_ROLLOUT_RECOVERY_GCS_ROLE="projects/${PROJECT}/roles/trRolloutJournal"
    export TR_ROLLOUT_BUNDLE_GCS_URI="gs://${BUCKET}/${PREFIX}/releases/${MANIFEST_EPOCH}"
    export TR_ROLLOUT_AUTHORITY_GCS_URI="gs://${BUCKET}/${PREFIX}/authority.json"
+   export TR_ROLLOUT_STATE_GCS_URI="${TR_ROLLOUT_BUNDLE_GCS_URI}/promotion-state.json"
    export TR_ROLLOUT_REQUIRE_RECOVERY_BUNDLE=true
    ```
 

--- a/docs/runbooks/ddos-edge-hardening.md
+++ b/docs/runbooks/ddos-edge-hardening.md
@@ -186,6 +186,52 @@ recorded suffix and cohort, then use `--verify-artifact` before bootstrap.
    ```text
    resource.name == "projects/_/buckets/BUCKET/objects/trusted-router-rollouts/PROJECT/authority.json" || resource.name.startsWith("projects/_/buckets/BUCKET/objects/trusted-router-rollouts/PROJECT/releases/MANIFEST_EPOCH/")
    ```
+   Provisioning commands for that approval window. These create exactly what
+   the read-only IAM verifier accepts — a versioned bucket with seven-day
+   retention, one three-permission custom role shared by the journal and
+   recovery bindings, and object-scoped conditional bindings for the deploy
+   identity — so a value drifting from these commands fails
+   `rollout_iam_verify.sh` rather than passing loosely:
+
+   ```bash
+   PROJECT=quill-cloud-proxy
+   BUCKET="${PROJECT}-tr-rollout-state"
+   DEPLOY_SA="tr-deploy@${PROJECT}.iam.gserviceaccount.com"
+   PREFIX="trusted-router-rollouts/${PROJECT}"
+
+   gcloud storage buckets create "gs://${BUCKET}" --project="$PROJECT" \
+     --location=us-central1 --uniform-bucket-level-access \
+     --public-access-prevention
+   gcloud storage buckets update "gs://${BUCKET}" --versioning \
+     --retention-period=7d
+   gcloud iam roles create trRolloutJournal --project="$PROJECT" \
+     --title="TrustedRouter rollout journal" --stage=GA \
+     --permissions=storage.objects.get,storage.objects.create,storage.objects.delete
+   # Journal binding: exactly one object.
+   gcloud storage buckets add-iam-policy-binding "gs://${BUCKET}" \
+     --member="serviceAccount:${DEPLOY_SA}" \
+     --role="projects/${PROJECT}/roles/trRolloutJournal" \
+     --condition="title=trusted-router-rollout-journal,expression=resource.name == \"projects/_/buckets/${BUCKET}/objects/${PREFIX}/state.json\""
+   # Recovery binding: the authority object plus this manifest epoch's bundle.
+   # MANIFEST_EPOCH comes from the reviewed manifest; re-run per release.
+   gcloud storage buckets add-iam-policy-binding "gs://${BUCKET}" \
+     --member="serviceAccount:${DEPLOY_SA}" \
+     --role="projects/${PROJECT}/roles/trRolloutJournal" \
+     --condition="title=trusted-router-rollout-recovery,expression=resource.name == \"projects/_/buckets/${BUCKET}/objects/${PREFIX}/authority.json\" || resource.name.startsWith(\"projects/_/buckets/${BUCKET}/objects/${PREFIX}/releases/${MANIFEST_EPOCH}/\")"
+   ```
+
+   Then export, for both the operator stage/promote commands and
+   `rollout_iam_verify.sh`:
+
+   ```bash
+   export TR_ROLLOUT_STATE_GCS_URI="gs://${BUCKET}/${PREFIX}/state.json"
+   export TR_ROLLOUT_RECOVERY_GCS_PREFIX="gs://${BUCKET}/${PREFIX}"
+   export TR_ROLLOUT_RECOVERY_GCS_ROLE="projects/${PROJECT}/roles/trRolloutJournal"
+   export TR_ROLLOUT_BUNDLE_GCS_URI="gs://${BUCKET}/${PREFIX}/releases/${MANIFEST_EPOCH}"
+   export TR_ROLLOUT_AUTHORITY_GCS_URI="gs://${BUCKET}/${PREFIX}/authority.json"
+   export TR_ROLLOUT_REQUIRE_RECOVERY_BUNDLE=true
+   ```
+
 9. Promote only with the mandatory repository-owned authenticated LB/browser
    smoke callback. Its authorization header and Playwright storage-state files
    must be regular mode-0600 files, and the callback runs Playwright Firefox:

--- a/docs/security/edge-surfaces.json
+++ b/docs/security/edge-surfaces.json
@@ -11,7 +11,6 @@
         "trustedrouter.com",
         "www.trustedrouter.com",
         "status.trustedrouter.com",
-        "trust.trustedrouter.com",
         "eu.trustedrouter.com",
         "status-us.trustedrouter.com",
         "status-eu.trustedrouter.com",

--- a/docs/security/edge-surfaces.json
+++ b/docs/security/edge-surfaces.json
@@ -6,7 +6,7 @@
     {
       "id": "gcp-control-domains",
       "cloud": "gcp",
-      "plane": "public-actions-control-internal",
+      "plane": "public-actions-console-chat-webhooks-internal",
       "hosts": [
         "trustedrouter.com",
         "www.trustedrouter.com",
@@ -26,12 +26,12 @@
       ],
       "front_door": "Google global external Application Load Balancer with serverless NEGs",
       "tls_termination": "Google load balancer",
-      "required_protection": "Cloud Armor policies on public, actions, control, and internal backends; LB-only Cloud Run ingress; private run.app access to the internal service only for regional synthetic jobs; independent Cloud Run max caps",
+      "required_protection": "Independent Cloud Armor policies and exact regional serverless NEGs on public, actions, console, chat, webhooks, and internal backends; LB-only Cloud Run ingress; no default URL except the preflighted private internal synthetic path; independent service and revision max caps",
       "trusted_client_identity": "X-TrustedRouter-Client-IP overwritten by the load balancer from {client_ip_address}",
-      "code_status": "helpers_ready_rollout_integration_pending_explicit_approval",
+      "code_status": "implemented-but-not-live",
       "protection_state": "p0_integration",
       "owner": "Lore-Hex/quill-router",
-      "verification": "scripts/deploy/rollout.sh reconciliation plus exact-host URL-map totality, .github/workflows/deploy.yml LB smoke, Admin API drift checks, and rejected external run.app probes"
+      "verification": "manifest-bound scripts/deploy/rollout.sh staging and rollout_rollback.sh phased promotion/attempt-scoped rollback; exact-host three-domain URL-map totality preserving explicit API/AWS/Azure/Quill aliases; six backend/NEG/Cloud Armor/header postconditions; six direct Admin API checks; authenticated LB/browser smoke; private internal billing synthetic; rejected external run.app probes"
     },
     {
       "id": "gcp-attested-api-aliases",
@@ -40,7 +40,8 @@
       "hosts": [
         "api.trustedrouter.com",
         "api.allyrouter.com",
-        "api.uptimerouter.com"
+        "api.uptimerouter.com",
+        "api.quillrouter.com"
       ],
       "host_patterns": [
         "api-<region>.quillrouter.com"
@@ -92,7 +93,8 @@
       "cloud": "aws",
       "plane": "attested-inference",
       "hosts": [
-        "api-aws.trustedrouter.com"
+        "api-aws.trustedrouter.com",
+        "api-eu-west-1.trustedrouter.com"
       ],
       "front_door": "AWS Global Accelerator to NLB to Nitro Enclaves",
       "tls_termination": "inside Nitro Enclave",
@@ -125,6 +127,7 @@
       "plane": "attested-inference",
       "hosts": [
         "api-azure.trustedrouter.com",
+        "api-azure-nz.trustedrouter.com",
         "api-azure-sea.trustedrouter.com"
       ],
       "front_door": "Azure regional public endpoints to SEV-SNP confidential workloads",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,23 +1,42 @@
-// Local-only smoke coverage for the marketing page and server-rendered console.
+// Local-only smoke coverage for the six service surfaces behind the tested
+// production URL-map contract. The server is an in-memory test dispatcher: it
+// never contacts Cloud Run, payment providers, email providers, or inference
+// providers.
 const { defineConfig, devices } = require("@playwright/test");
 
 module.exports = defineConfig({
   testDir: "tests/browser",
   timeout: 30_000,
+  // All six apps deliberately share one in-memory Store. A single worker keeps
+  // stateful browser journeys deterministic and mirrors one user's sequence.
+  workers: 1,
   use: {
+    // Keep APIRequestContext-compatible loopback as the default for the
+    // existing suite. The split matrix navigates the three explicit
+    // *.localhost hostnames in Chromium.
     baseURL: "http://127.0.0.1:18081",
     trace: "retain-on-failure",
   },
   webServer: {
-    // Every browser worker and subresource shares 127.0.0.1. Leaving source
-    // admission enabled makes the suite race its 240-request/minute production
-    // bucket; dedicated Python tests cover that middleware deterministically.
-    command: "TR_ENVIRONMENT=test TR_STORAGE_BACKEND=memory TR_RATE_LIMIT_ENABLED=false TR_SENTRY_DSN= TR_STRIPE_SECRET_KEY= TR_STRIPE_WEBHOOK_SECRET= TR_GOOGLE_CLIENT_ID=browser-test-client TR_GOOGLE_CLIENT_SECRET=not-a-real-secret TR_GITHUB_CLIENT_ID= TR_GITHUB_CLIENT_SECRET= uv run uvicorn trusted_router.main:app --host 127.0.0.1 --port 18081",
+    command: "uv run --frozen --offline uvicorn tests.browser.six_surface_server:app --host 127.0.0.1 --port 18081 --lifespan off",
     url: "http://127.0.0.1:18081/health",
-    reuseExistingServer: true,
+    // Reusing an arbitrary process on this port can make a split regression
+    // look green against a stale combined app.
+    reuseExistingServer: false,
     timeout: 30_000,
   },
   projects: [
-    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        launchOptions: {
+          // macOS does not consistently resolve subdomains of localhost via
+          // getaddrinfo. Keep the browser-domain matrix deterministic and
+          // entirely on loopback.
+          args: ["--host-resolver-rules=MAP *.localhost 127.0.0.1"],
+        },
+      },
+    },
   ],
 });

--- a/playwright.rollout.config.js
+++ b/playwright.rollout.config.js
@@ -1,0 +1,35 @@
+const fs = require("node:fs");
+const { defineConfig, devices } = require("@playwright/test");
+
+function authorizationHeader() {
+  const path = process.env.TR_ROLLOUT_SMOKE_AUTH_HEADER_FILE;
+  if (!path) throw new Error("TR_ROLLOUT_SMOKE_AUTH_HEADER_FILE is required");
+  const line = fs.readFileSync(path, "utf8").trim();
+  const prefix = "Authorization: ";
+  if (!line.startsWith(prefix)) throw new Error("authorization header file is malformed");
+  return line.slice(prefix.length);
+}
+
+const storageState = process.env.TR_ROLLOUT_SMOKE_PLAYWRIGHT_STORAGE_STATE;
+if (!storageState) throw new Error("TR_ROLLOUT_SMOKE_PLAYWRIGHT_STORAGE_STATE is required");
+const outputDir = process.env.TR_ROLLOUT_SMOKE_PLAYWRIGHT_OUTPUT_DIR;
+if (!outputDir) throw new Error("TR_ROLLOUT_SMOKE_PLAYWRIGHT_OUTPUT_DIR is required");
+
+module.exports = defineConfig({
+  testDir: "tests/browser",
+  testMatch: "production_rollout_smoke.spec.js",
+  outputDir,
+  timeout: 60_000,
+  workers: 1,
+  retries: 0,
+  reporter: "line",
+  use: {
+    storageState,
+    extraHTTPHeaders: { Authorization: authorizationHeader() },
+    // Production credentials must not be serialized into a failure trace.
+    screenshot: "off",
+    trace: "off",
+    video: "off",
+  },
+  projects: [{ name: "firefox", use: { ...devices["Desktop Firefox"] } }],
+});

--- a/scripts/deploy/_edge_security.sh
+++ b/scripts/deploy/_edge_security.sh
@@ -3,98 +3,357 @@
 # Application Load Balancer backends. This file defines functions only; the
 # caller owns authentication, PROJECT_ID, gc(), and log().
 
-_edge_require_positive_integer() {
-  local name="$1"
-  local value="$2"
-  case "$value" in
-    ''|*[!0-9]*|0)
-      echo "ERROR: ${name} must be a positive integer; got ${value:-<empty>}" >&2
-      return 2
-      ;;
-  esac
+_TR_EDGE_ALLOWED_HOST_REGEX="^(trustedrouter[.]com|www[.]trustedrouter[.]com|status[.]trustedrouter[.]com|trust[.]trustedrouter[.]com|eu[.]trustedrouter[.]com|status-us[.]trustedrouter[.]com|status-eu[.]trustedrouter[.]com|allyrouter[.]com|www[.]allyrouter[.]com|status[.]allyrouter[.]com|trust[.]allyrouter[.]com|uptimerouter[.]com|www[.]uptimerouter[.]com|status[.]uptimerouter[.]com|trust[.]uptimerouter[.]com)(:[0-9]+)?$"
+
+# Pure, read-only postcondition verifier shared by reconciliation, staging, and
+# promotion/rollback.  Passing JSON as an argument keeps the function usable by
+# callers that already captured a provider response without making another
+# cloud request.
+verify_cloud_armor_policy_contract_json() {
+  [ "$#" -eq 1 ] || {
+    echo "ERROR: verify_cloud_armor_policy_contract_json expects POLICY_JSON" >&2
+    return 2
+  }
+  python3 - "$_TR_EDGE_ALLOWED_HOST_REGEX" "$1" <<'PY'
+import json
+import sys
+
+allowed, raw = sys.argv[1:]
+try:
+    data = json.loads(raw)
+except json.JSONDecodeError:
+    raise SystemExit("Cloud Armor policy response is not valid JSON") from None
+if not isinstance(data, dict):
+    raise SystemExit("Cloud Armor policy response is malformed")
+if data.get("type") != "CLOUD_ARMOR":
+    raise SystemExit("Cloud Armor policy type drifted")
+if data.get("description") != (
+    "TrustedRouter exact edge controls; host and all-path gates enforced, "
+    "route-shape rules previewed"
+):
+    raise SystemExit("Cloud Armor policy description drifted")
+for field in ("recaptchaOptionsConfig", "userIpRequestHeaders"):
+    if data.get(field) not in (None, {}, []):
+        raise SystemExit(f"Cloud Armor policy retains forbidden {field}")
+
+raw_rules = data.get("rules")
+if not isinstance(raw_rules, list) or any(not isinstance(item, dict) for item in raw_rules):
+    raise SystemExit("Cloud Armor rule inventory is malformed")
+try:
+    rules = {int(item.get("priority")): item for item in raw_rules}
+except (TypeError, ValueError):
+    raise SystemExit("Cloud Armor rule priority is malformed") from None
+host_expression = (
+    "!has(request.headers['host']) || "
+    f"!request.headers['host'].lower().matches('{allowed}')"
+)
+expected = {
+    900: (
+        "deny(403)", False, host_expression, None, None,
+        "Reject hosts outside canonical and marketing aliases",
+    ),
+    1000: (
+        "throttle", True, "request.path.startsWith('/chat-proxy/')", 120, None,
+        "Browser inference proxy per-client throttle",
+    ),
+    1100: (
+        "throttle",
+        True,
+        "request.method != 'GET' && request.method != 'HEAD' && request.method != 'OPTIONS'",
+        300,
+        None,
+        "State-changing request per-client throttle",
+    ),
+    1200: (
+        "throttle", False, None, 2400, ["*"],
+        "All-path per-source safety ceiling",
+    ),
+    2147483647: (
+        "allow", False, None, None, ["*"],
+        "Default allow; bounded route classes are evaluated first",
+    ),
+}
+if set(rules) != set(expected) or len(raw_rules) != len(expected):
+    raise SystemExit("unexpected Cloud Armor priority set")
+allowed_rule_fields = {
+    "action",
+    "description",
+    "kind",
+    "match",
+    "preview",
+    "priority",
+    "rateLimitOptions",
+}
+for priority, (action, preview, expression, count, ranges, description) in expected.items():
+    rule = rules[priority]
+    if set(rule) - allowed_rule_fields:
+        raise SystemExit(f"rule {priority} retains forbidden fields")
+    if rule.get("action") != action or rule.get("preview") is not preview:
+        raise SystemExit(f"rule {priority} action/preview differs")
+    if rule.get("description") != description:
+        raise SystemExit(f"rule {priority} description differs")
+    match = rule.get("match") or {}
+    if not isinstance(match, dict):
+        raise SystemExit(f"rule {priority} match is malformed")
+    if expression is not None:
+        if set(match) != {"expr"}:
+            raise SystemExit(f"rule {priority} retains match extras")
+        expr = match.get("expr") or {}
+        if not isinstance(expr, dict) or set(expr) != {"expression"} or expr.get("expression") != expression:
+            raise SystemExit(f"rule {priority} expression differs")
+    if ranges is not None:
+        if set(match) != {"config", "versionedExpr"}:
+            raise SystemExit(f"rule {priority} retains source-match extras")
+        config = match.get("config") or {}
+        if not isinstance(config, dict) or set(config) != {"srcIpRanges"} or config.get("srcIpRanges") != ranges:
+            raise SystemExit(f"rule {priority} source ranges differ")
+        if match.get("versionedExpr") != "SRC_IPS_V1":
+            raise SystemExit(f"rule {priority} versioned source expression differs")
+    options = rule.get("rateLimitOptions") or {}
+    if count is None:
+        if "rateLimitOptions" in rule:
+            raise SystemExit(f"rule {priority} retains rate-limit options")
+        continue
+    if not isinstance(options, dict):
+        raise SystemExit(f"rule {priority} rate-limit contract differs")
+    threshold = options.get("rateLimitThreshold") or {}
+    if not isinstance(threshold, dict) or (
+        set(options) != {
+            "conformAction",
+            "enforceOnKey",
+            "exceedAction",
+            "rateLimitThreshold",
+        }
+        or set(threshold) != {"count", "intervalSec"}
+        or int(threshold.get("count", -1)) != count
+        or int(threshold.get("intervalSec", -1)) != 60
+        or options.get("conformAction") != "allow"
+        or options.get("exceedAction") != "deny(429)"
+        or options.get("enforceOnKey") != "IP"
+    ):
+        raise SystemExit(f"rule {priority} rate-limit contract differs")
+PY
 }
 
-_edge_require_log_sample_rate() {
-  local value="$1"
-  local fraction=""
+_verify_edge_backend_security_contract_json() {
+  [ "$#" -eq 2 ] || {
+    echo "ERROR: internal edge backend verifier expects PUBLIC_FLAG BACKEND_JSON" >&2
+    return 2
+  }
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
 
-  case "$value" in
-    0|1|1.0) return 0 ;;
-    0.*)
-      fraction="${value#0.}"
-      ;;
-    *)
-      echo "ERROR: TR_CLOUD_ARMOR_LOG_SAMPLE_RATE must be between 0 and 1" >&2
-      return 2
-      ;;
-  esac
-  case "$fraction" in
-    ''|*[!0-9]*)
-      echo "ERROR: TR_CLOUD_ARMOR_LOG_SAMPLE_RATE must be between 0 and 1" >&2
-      return 2
-      ;;
-  esac
+public_raw, raw = sys.argv[1:]
+if public_raw not in {"0", "1"}:
+    raise SystemExit("edge backend public flag is invalid")
+try:
+    data = json.loads(raw)
+except json.JSONDecodeError:
+    raise SystemExit("edge backend response is not valid JSON") from None
+if not isinstance(data, dict):
+    raise SystemExit("edge backend response is malformed")
+
+expected_header = ["X-TrustedRouter-Client-IP:{client_ip_address}"]
+if data.get("customRequestHeaders", []) != expected_header:
+    raise SystemExit("backend request-header allowlist drifted")
+if data.get("customResponseHeaders", []) not in (None, []):
+    raise SystemExit("backend retains custom response headers")
+if data.get("edgeSecurityPolicy") not in (None, ""):
+    raise SystemExit("backend retains an unexpected edge security policy")
+iap = data.get("iap") or {}
+if not isinstance(iap, dict):
+    raise SystemExit("backend IAP contract is malformed")
+if iap:
+    if iap.get("enabled") is not False:
+        raise SystemExit("backend IAP contract is not disabled")
+    if set(iap) - {"enabled", "oauth2ClientId"}:
+        raise SystemExit("backend IAP retains an OAuth secret or unknown state")
+    if iap.get("oauth2ClientId") not in (None, " "):
+        raise SystemExit("backend IAP retains an OAuth client ID")
+
+logging = data.get("logConfig") or {}
+if not isinstance(logging, dict) or (
+    set(logging) - {"enable", "sampleRate", "optionalMode", "optionalFields"}
+    or logging.get("enable") is not True
+    or float(logging.get("sampleRate", -1)) != 0.1
+    or logging.get("optionalMode", "EXCLUDE_ALL_OPTIONAL") != "EXCLUDE_ALL_OPTIONAL"
+    or logging.get("optionalFields", []) not in (None, [])
+):
+    raise SystemExit("backend logging contract drifted")
+
+public = public_raw == "1"
+if bool(data.get("enableCDN", False)) != public:
+    raise SystemExit("backend CDN state drifted")
+cdn_policy = data.get("cdnPolicy") or {}
+if not isinstance(cdn_policy, dict):
+    raise SystemExit("backend CDN policy is malformed")
+if public:
+    cache_key = cdn_policy.get("cacheKeyPolicy") or {}
+    if not isinstance(cache_key, dict):
+        raise SystemExit("public backend cache-key policy is malformed")
+    allowed_cdn_fields = {
+        "bypassCacheOnRequestHeaders",
+        "cacheKeyPolicy",
+        "cacheMode",
+        "clientTtl",
+        "defaultTtl",
+        "maxTtl",
+        "negativeCaching",
+        "negativeCachingPolicy",
+        "requestCoalescing",
+        "serveWhileStale",
+        "signedUrlCacheMaxAgeSec",
+        "signedUrlKeyNames",
+    }
+    allowed_cache_key_fields = {
+        "includeHost",
+        "includeHttpHeaders",
+        "includeNamedCookies",
+        "includeProtocol",
+        "includeQueryString",
+        "queryStringBlacklist",
+        "queryStringWhitelist",
+    }
+    if (
+        set(cdn_policy) - allowed_cdn_fields
+        or set(cache_key) - allowed_cache_key_fields
+        or cdn_policy.get("cacheMode") != "USE_ORIGIN_HEADERS"
+        or cdn_policy.get("negativeCaching", False) is not False
+        or cdn_policy.get("negativeCachingPolicy", []) not in (None, [])
+        or int(cdn_policy.get("serveWhileStale", -1)) != 600
+        or cdn_policy.get("clientTtl") is not None
+        or cdn_policy.get("defaultTtl") is not None
+        or cdn_policy.get("maxTtl") is not None
+        or cdn_policy.get("bypassCacheOnRequestHeaders", []) not in (None, [])
+        or cdn_policy.get("requestCoalescing", True) is not True
+        or cdn_policy.get("signedUrlCacheMaxAgeSec") is not None
+        or cdn_policy.get("signedUrlKeyNames", []) not in (None, [])
+        or cache_key.get("includeHost") is not True
+        or cache_key.get("includeProtocol") is not True
+        or cache_key.get("includeQueryString") is not True
+        or cache_key.get("queryStringBlacklist", []) not in (None, [])
+        or cache_key.get("queryStringWhitelist", []) not in (None, [])
+        or cache_key.get("includeHttpHeaders", []) not in (None, [])
+        or cache_key.get("includeNamedCookies", []) not in (None, [])
+        or data.get("compressionMode") != "AUTOMATIC"
+    ):
+        raise SystemExit("public backend CDN/cache-key contract drifted")
+elif cdn_policy:
+    raise SystemExit("non-public backend retains a CDN policy")
+PY
 }
 
-_edge_upsert_rule() {
-  local policy="$1"
-  local priority="$2"
-  shift 2
-  local preview="${TR_CLOUD_ARMOR_PREVIEW:-1}"
+verify_edge_backend_contract_json() {
+  [ "$#" -eq 8 ] || {
+    echo "ERROR: verify_edge_backend_contract_json expects SURFACE BACKEND_JSON PROJECT REGIONS_CSV SERVICE NEG POLICY TIMEOUT" >&2
+    return 2
+  }
+  local surface="$1"
+  local backend_json="$2"
+  local project="$3"
+  local regions_csv="$4"
+  local service="$5"
+  local neg="$6"
+  local policy="$7"
+  local timeout="$8"
+  local public_flag=0
+  [ "$surface" = public ] && public_flag=1
+  _verify_edge_backend_security_contract_json "$public_flag" "$backend_json" || return 1
+  python3 - "$surface" "$backend_json" "$project" "$regions_csv" \
+    "$service" "$neg" "$policy" "$timeout" <<'PY'
+import json
+import re
+import sys
 
-  case "$preview" in
-    1|0) ;;
-    *)
-      echo "ERROR: TR_CLOUD_ARMOR_PREVIEW must be 0 or 1" >&2
-      return 2
-      ;;
-  esac
+surface, raw, project, raw_regions, service, neg, policy, timeout = sys.argv[1:]
+services = {
+    "public": "trusted-router-public",
+    "actions": "trusted-router-actions",
+    "console": "trusted-router-console",
+    "chat": "trusted-router-chat",
+    "webhooks": "trusted-router-webhooks",
+    "internal": "trusted-router-billing",
+}
+backends = {
+    "public": "trusted-router-public-backend",
+    "actions": "trusted-router-actions-backend",
+    "console": "trusted-router-console-backend",
+    "chat": "trusted-router-chat-backend",
+    "webhooks": "trusted-router-webhooks-backend",
+    "internal": "trusted-router-billing-backend",
+}
+if surface not in services or service != services[surface]:
+    raise SystemExit("edge backend surface/service identity is noncanonical")
+if not re.fullmatch(r"[a-z][a-z0-9-]{4,28}[a-z0-9]", project):
+    raise SystemExit("edge backend project identity is noncanonical")
+if any(not re.fullmatch(r"[a-z][a-z0-9-]{0,61}[a-z0-9]", item) for item in (neg, policy)):
+    raise SystemExit("edge backend NEG or policy identity is noncanonical")
+regions = raw_regions.split(",")
+if not regions or len(regions) != len(set(regions)) or any(
+    not re.fullmatch(r"[a-z]+-[a-z0-9]+[0-9]", region) for region in regions
+):
+    raise SystemExit("edge backend region inventory is noncanonical")
+if not re.fullmatch(r"[1-9][0-9]{0,4}", timeout) or int(timeout) > 86400:
+    raise SystemExit("edge backend timeout is noncanonical")
+data = json.loads(raw)
+name = str(data.get("name") or "").rstrip("/").rsplit("/", 1)[-1]
+if name != backends[surface]:
+    raise SystemExit("edge backend resource identity is noncanonical")
 
-  if gc compute security-policies rules describe "$priority" \
-      --security-policy="$policy" >/dev/null 2>&1; then
-    # Create treats absence of --preview as enforcement. Update needs the
-    # explicit inverse or a previously-previewed rule would remain previewed.
-    if [ "$preview" = "0" ]; then
-      gc compute security-policies rules update "$priority" \
-        --security-policy="$policy" \
-        "$@" \
-        --no-preview \
-        --quiet >/dev/null
-    else
-      gc compute security-policies rules update "$priority" \
-        --security-policy="$policy" \
-        "$@" \
-        --preview \
-        --quiet >/dev/null
-    fi
-  else
-    if [ "$preview" = "0" ]; then
-      gc compute security-policies rules create "$priority" \
-        --security-policy="$policy" \
-        "$@" \
-        --quiet >/dev/null
-    else
-      gc compute security-policies rules create "$priority" \
-        --security-policy="$policy" \
-        "$@" \
-        --preview \
-        --quiet >/dev/null
-    fi
-  fi
+def resource_path(value: object) -> str:
+    text = str(value or "").rstrip("/")
+    match = re.search(
+        r"(?:^|/)(projects/[^/]+/(?:regions/[^/]+/networkEndpointGroups|"
+        r"global/securityPolicies)/[^/]+)$",
+        text,
+    )
+    if not match:
+        raise SystemExit(f"{name} has a noncanonical edge-resource reference: {text!r}")
+    return match.group(1)
+
+raw_backends = data.get("backends")
+if not isinstance(raw_backends, list) or any(not isinstance(item, dict) for item in raw_backends):
+    raise SystemExit(f"{name} has a malformed NEG inventory")
+expected_groups = sorted(
+    f"projects/{project}/regions/{region}/networkEndpointGroups/{neg}"
+    for region in regions
+)
+actual_groups = sorted(resource_path(item.get("group")) for item in raw_backends)
+if actual_groups != expected_groups or len(raw_backends) != len(expected_groups):
+    raise SystemExit(f"{name} NEG membership is not the exact same-project regional inventory")
+if data.get("loadBalancingScheme") != "EXTERNAL_MANAGED" or data.get("protocol") != "HTTP":
+    raise SystemExit(f"{name} has the wrong load-balancer scheme/protocol")
+if int(data.get("timeoutSec", 0)) != int(timeout):
+    raise SystemExit(f"{name} timeout differs from the exact surface contract")
+attached = resource_path(data.get("securityPolicy"))
+if attached != f"projects/{project}/global/securityPolicies/{policy}":
+    raise SystemExit(f"{name} has the wrong Cloud Armor policy")
+PY
 }
 
 _reconcile_cloud_armor_policy() {
   local policy="$1"
-  local interval="${TR_CLOUD_ARMOR_RATE_INTERVAL_SECONDS:-60}"
-  local browser_count="${TR_CLOUD_ARMOR_BROWSER_RATE_COUNT:-120}"
-  local write_count="${TR_CLOUD_ARMOR_WRITE_RATE_COUNT:-300}"
-  local global_count="${TR_CLOUD_ARMOR_GLOBAL_RATE_COUNT:-2400}"
-  local allowed_host_regex="${TR_EDGE_ALLOWED_HOST_REGEX:-^(trustedrouter[.]com|www[.]trustedrouter[.]com|status[.]trustedrouter[.]com|trust[.]trustedrouter[.]com|eu[.]trustedrouter[.]com|status-us[.]trustedrouter[.]com|status-eu[.]trustedrouter[.]com|allyrouter[.]com|www[.]allyrouter[.]com|status[.]allyrouter[.]com|trust[.]allyrouter[.]com|uptimerouter[.]com|www[.]uptimerouter[.]com|status[.]uptimerouter[.]com|trust[.]uptimerouter[.]com)(:[0-9]+)?$}"
+  local allowed_host_regex="$_TR_EDGE_ALLOWED_HOST_REGEX"
+  local policy_file=""
+  local policy_json=""
+  local setting=""
 
-  _edge_require_positive_integer TR_CLOUD_ARMOR_RATE_INTERVAL_SECONDS "$interval"
-  _edge_require_positive_integer TR_CLOUD_ARMOR_BROWSER_RATE_COUNT "$browser_count"
-  _edge_require_positive_integer TR_CLOUD_ARMOR_WRITE_RATE_COUNT "$write_count"
-  _edge_require_positive_integer TR_CLOUD_ARMOR_GLOBAL_RATE_COUNT "$global_count"
+  # These values are a reviewed production contract, not tuning inputs. A
+  # per-invocation override could silently weaken one backend while the other
+  # five retained the audited policy.
+  for setting in \
+    TR_EDGE_ALLOWED_HOST_REGEX \
+    TR_CLOUD_ARMOR_RATE_INTERVAL_SECONDS \
+    TR_CLOUD_ARMOR_BROWSER_RATE_COUNT \
+    TR_CLOUD_ARMOR_WRITE_RATE_COUNT \
+    TR_CLOUD_ARMOR_GLOBAL_RATE_COUNT \
+    TR_CLOUD_ARMOR_PREVIEW; do
+    if [ -n "${!setting:-}" ]; then
+      echo "ERROR: ${setting} is not an operator override; edit and review the exact edge contract" >&2
+      return 2
+    fi
+  done
 
   if ! gc compute security-policies describe "$policy" --global >/dev/null 2>&1; then
     log "creating Cloud Armor backend policy ${policy}"
@@ -105,76 +364,121 @@ _reconcile_cloud_armor_policy() {
       --quiet >/dev/null
   fi
 
-  # Repair the immutable catch-all contract on every deploy. Custom rules all
-  # have a lower priority; a typo must never turn policy creation into an
-  # accidental default deny.
-  gc compute security-policies rules update 2147483647 \
-    --security-policy="$policy" \
-    --action=allow \
-    --src-ip-ranges='*' \
-    --no-preview \
-    --description="Default allow; bounded route classes are evaluated first" \
-    --quiet >/dev/null
+  policy_file="$(mktemp "${TMPDIR:-/tmp}/tr-edge-policy-XXXXXX.json")"
+  chmod 600 "$policy_file"
+  if ! python3 - "$allowed_host_regex" "$policy_file" <<'PY'
+import json
+import sys
+from pathlib import Path
 
-  # Host ownership is a routing boundary, not a tuning signal.  Keep it
-  # enforced even while the narrower traffic-shape rules are in preview: an
-  # allowed TLS SNI with an attacker-chosen Host must never fall through to an
-  # unrelated/legacy URL-map default.
-  TR_CLOUD_ARMOR_PREVIEW=0 _edge_upsert_rule "$policy" 900 \
-    --action=deny-403 \
-    --expression="!has(request.headers['host']) || !request.headers['host'].lower().matches('${allowed_host_regex}')" \
-    --description="Reject hosts outside canonical and marketing aliases"
+allowed, destination = sys.argv[1:]
+host_expression = (
+    "!has(request.headers['host']) || "
+    f"!request.headers['host'].lower().matches('{allowed}')"
+)
 
-  _edge_upsert_rule "$policy" 1000 \
-    --action=throttle \
-    --expression="request.path.startsWith('/chat-proxy/')" \
-    --description="Browser inference proxy per-client throttle" \
-    --rate-limit-threshold-count="$browser_count" \
-    --rate-limit-threshold-interval-sec="$interval" \
-    --conform-action=allow \
-    --exceed-action=deny-429 \
-    --enforce-on-key=IP
+def source_match():
+    return {"config": {"srcIpRanges": ["*"]}, "versionedExpr": "SRC_IPS_V1"}
 
-  _edge_upsert_rule "$policy" 1100 \
-    --action=throttle \
-    --expression="request.method != 'GET' && request.method != 'HEAD' && request.method != 'OPTIONS'" \
-    --description="State-changing request per-client throttle" \
-    --rate-limit-threshold-count="$write_count" \
-    --rate-limit-threshold-interval-sec="$interval" \
-    --conform-action=allow \
-    --exceed-action=deny-429 \
-    --enforce-on-key=IP
+def rate_limit(count):
+    return {
+        "conformAction": "allow",
+        "enforceOnKey": "IP",
+        "exceedAction": "deny(429)",
+        "rateLimitThreshold": {"count": count, "intervalSec": 60},
+    }
 
-  # Keep one generous all-path per-source ceiling enforced from the first
-  # attach. The independent Cloud Run max-instance caps, not this IP-keyed
-  # rule, bound a distributed botnet and the fleet-wide serverless bill. The
-  # tighter browser/write rules can spend a canary period in preview, but
-  # preview-only policy would leave health and every other cheap path entirely
-  # unbounded at the edge during the exact launch window this policy protects.
-  TR_CLOUD_ARMOR_PREVIEW=0 _edge_upsert_rule "$policy" 1200 \
-    --action=throttle \
-    --src-ip-ranges='*' \
-    --description="All-path per-source safety ceiling" \
-    --rate-limit-threshold-count="$global_count" \
-    --rate-limit-threshold-interval-sec="$interval" \
-    --conform-action=allow \
-    --exceed-action=deny-429 \
-    --enforce-on-key=IP
+policy = {
+    "description": (
+        "TrustedRouter exact edge controls; host and all-path gates enforced, "
+        "route-shape rules previewed"
+    ),
+    "type": "CLOUD_ARMOR",
+    "rules": [
+        {
+            "action": "deny(403)",
+            "description": "Reject hosts outside canonical and marketing aliases",
+            "match": {"expr": {"expression": host_expression}},
+            "preview": False,
+            "priority": 900,
+        },
+        {
+            "action": "throttle",
+            "description": "Browser inference proxy per-client throttle",
+            "match": {"expr": {"expression": "request.path.startsWith('/chat-proxy/')"}},
+            "preview": True,
+            "priority": 1000,
+            "rateLimitOptions": rate_limit(120),
+        },
+        {
+            "action": "throttle",
+            "description": "State-changing request per-client throttle",
+            "match": {
+                "expr": {
+                    "expression": (
+                        "request.method != 'GET' && request.method != 'HEAD' && "
+                        "request.method != 'OPTIONS'"
+                    )
+                }
+            },
+            "preview": True,
+            "priority": 1100,
+            "rateLimitOptions": rate_limit(300),
+        },
+        {
+            "action": "throttle",
+            "description": "All-path per-source safety ceiling",
+            "match": source_match(),
+            "preview": False,
+            "priority": 1200,
+            "rateLimitOptions": rate_limit(2400),
+        },
+        {
+            "action": "allow",
+            "description": "Default allow; bounded route classes are evaluated first",
+            "match": source_match(),
+            "preview": False,
+            "priority": 2147483647,
+        },
+    ],
+}
+Path(destination).write_text(json.dumps(policy, separators=(",", ":")) + "\n")
+PY
+  then
+    rm -f "$policy_file"
+    return 1
+  fi
+
+  # Import is a single policy replacement. It removes unknown priorities and
+  # stale headerAction/redirect/WAF fields instead of trying to update an
+  # attacker-controlled rule in place and accidentally retaining its extras.
+  if ! gc compute security-policies import "$policy" \
+      --file-name="$policy_file" \
+      --file-format=json \
+      --global \
+      --quiet >/dev/null; then
+    rm -f "$policy_file"
+    return 1
+  fi
+  rm -f "$policy_file"
+
+  policy_json="$(gc compute security-policies describe "$policy" \
+    --global --format=json)" || return 1
+  if ! verify_cloud_armor_policy_contract_json "$policy_json"; then
+    echo "ERROR: ${policy} did not retain the exact Cloud Armor contract" >&2
+    return 1
+  fi
 }
 
 reconcile_edge_backend() {
   local backend="$1"
   local policy="$2"
   # Full request logging can turn the attack itself into a Cloud Logging bill.
-  # Ten percent is enough for preview sizing; operators can temporarily raise
-  # it during a bounded investigation.
-  local log_sample_rate="${TR_CLOUD_ARMOR_LOG_SAMPLE_RATE:-0.1}"
-  local backend_json=""
-  local preserved_headers=""
+  # The reviewed contract is always a ten-percent sample.
+  local log_sample_rate="0.1"
   local final_json=""
   local attached_policy=""
-  local header=""
-  local header_args=()
+  local public_backend="${TR_PUBLIC_BACKEND:-trusted-router-public-backend}"
 
   case "$backend" in
     ''|*[!a-zA-Z0-9_-]*)
@@ -188,7 +492,10 @@ reconcile_edge_backend() {
       return 2
       ;;
   esac
-  _edge_require_log_sample_rate "$log_sample_rate"
+  if [ -n "${TR_CLOUD_ARMOR_LOG_SAMPLE_RATE:-}" ]; then
+    echo "ERROR: TR_CLOUD_ARMOR_LOG_SAMPLE_RATE is fixed at 0.1 for production reconciliation" >&2
+    return 2
+  fi
 
   if ! gc compute backend-services describe "$backend" --global >/dev/null 2>&1; then
     echo "ERROR: required public load-balancer backend ${backend} does not exist" >&2
@@ -196,35 +503,57 @@ reconcile_edge_backend() {
   fi
 
   _reconcile_cloud_armor_policy "$policy"
-  backend_json="$(gc compute backend-services describe "$backend" \
-    --global --format=json)"
-  preserved_headers="$(printf '%s' "$backend_json" | python3 -c '
-import json
-import sys
 
-data = json.load(sys.stdin)
-for header in data.get("customRequestHeaders", []) or []:
-    name = str(header).split(":", 1)[0].strip().casefold()
-    if name != "x-trustedrouter-client-ip":
-        print(header)
-')"
-  while IFS= read -r header; do
-    [ -n "$header" ] || continue
-    header_args+=("--custom-request-header=${header}")
-  done <<<"$preserved_headers"
-  # Google adds this after receiving the client request and overwrites any
-  # same-name client header case-insensitively. Never derive limiter identity
-  # from X-Forwarded-For or a header that survives client input unchanged.
-  header_args+=("--custom-request-header=X-TrustedRouter-Client-IP:{client_ip_address}")
-
-  log "attaching ${policy} and trusted client identity to ${backend}"
+  log "clearing stale edge state and attaching ${policy} to ${backend}"
+  # Clear response/request injection before installing the sole trusted header.
+  # The IAP single-space values are the documented API sentinel for clearing a
+  # retained OAuth client while leaving IAP disabled.
   gc compute backend-services update "$backend" \
     --global \
     --security-policy="$policy" \
+    --edge-security-policy="" \
+    '--iap=disabled,oauth2-client-id= ,oauth2-client-secret= ' \
+    --no-custom-request-headers \
+    --no-custom-response-headers \
     --enable-logging \
     --logging-sample-rate="$log_sample_rate" \
-    "${header_args[@]}" \
     --quiet >/dev/null
+
+  # Google adds this value after receiving the client request. Replacing the
+  # whole request-header list prevents an old Authorization/internal-token
+  # injection from surviving a service split.
+  if [ "$backend" = "$public_backend" ]; then
+    gc compute backend-services update "$backend" \
+      --global \
+      --custom-request-header='X-TrustedRouter-Client-IP:{client_ip_address}' \
+      --enable-cdn \
+      --cache-mode=USE_ORIGIN_HEADERS \
+      --cache-key-include-host \
+      --cache-key-include-protocol \
+      --cache-key-include-query-string \
+      --cache-key-query-string-blacklist= \
+      --cache-key-include-http-header= \
+      --cache-key-include-named-cookie= \
+      --no-bypass-cache-on-request-headers \
+      --no-negative-caching-policies \
+      --serve-while-stale=600 \
+      --request-coalescing \
+      --no-client-ttl \
+      --no-default-ttl \
+      --no-max-ttl \
+      --compression-mode=AUTOMATIC \
+      --quiet >/dev/null
+    gc compute backend-services update "$backend" \
+      --global \
+      --no-negative-caching \
+      --quiet >/dev/null
+  else
+    gc compute backend-services update "$backend" \
+      --global \
+      --custom-request-header='X-TrustedRouter-Client-IP:{client_ip_address}' \
+      --no-enable-cdn \
+      --quiet >/dev/null
+  fi
 
   attached_policy="$(gc compute backend-services describe "$backend" --global \
     --format='value(securityPolicy.basename())')"
@@ -232,22 +561,10 @@ for header in data.get("customRequestHeaders", []) or []:
     echo "ERROR: ${backend} has Cloud Armor policy ${attached_policy:-<none>}, expected ${policy}" >&2
     return 1
   fi
-  final_json="$(gc compute backend-services describe "$backend" --global \
-    --format='json(customRequestHeaders,securityPolicy)')"
-  if ! printf '%s' "$final_json" | python3 -c '
-import json
-import sys
-
-data = json.load(sys.stdin)
-matches = []
-for header in data.get("customRequestHeaders", []) or []:
-    name, separator, value = str(header).partition(":")
-    if separator and name.strip().casefold() == "x-trustedrouter-client-ip":
-        matches.append(value.strip())
-if matches != ["{client_ip_address}"]:
-    raise SystemExit(f"trusted client header drift: {matches!r}")
-'; then
-    echo "ERROR: ${backend} did not retain the trusted client-IP overwrite" >&2
+  final_json="$(gc compute backend-services describe "$backend" --global --format=json)"
+  if ! _verify_edge_backend_security_contract_json \
+      "$([ "$backend" = "$public_backend" ] && echo 1 || echo 0)" "$final_json"; then
+    echo "ERROR: ${backend} did not retain the exact edge backend contract" >&2
     return 1
   fi
 }

--- a/scripts/deploy/_lib.sh
+++ b/scripts/deploy/_lib.sh
@@ -21,6 +21,13 @@ TR_PRIMARY_REGION="${TR_PRIMARY_REGION:-us-central1}"
 # than TR_REGIONS because cold control-plane regions can serve cached public
 # pages without advertising non-existent regional attested gateway hostnames.
 TR_CONTROL_PLANE_REGIONS="${TR_CONTROL_PLANE_REGIONS:-us-central1,us-east4,europe-west4,southamerica-east1}"
+# Canonical regions for the four synthetic job families. infra.sh consumes
+# the same inventory before retiring the legacy job identity, so changing a
+# job region cannot silently leave the retirement preflight behind.
+TR_SYNTHETIC_MONITOR_REGIONS="${TR_SYNTHETIC_MONITOR_REGIONS:-us-central1,europe-west4}"
+TR_SYNTHETIC_THROUGHPUT_REGION="${TR_SYNTHETIC_THROUGHPUT_REGION:-us-central1}"
+TR_SYNTHETIC_IMAGE_REGION="${TR_SYNTHETIC_IMAGE_REGION:-us-central1}"
+TR_SYNTHETIC_VIDEO_REGION="${TR_SYNTHETIC_VIDEO_REGION:-us-central1}"
 # Comma-separated subset of TR_REGIONS that should run with always-on warm
 # capacity. Anything outside TR_WARM_REGIONS gets min_scale=0 unless the
 # per-region map below says otherwise.
@@ -76,7 +83,57 @@ TR_CLOUD_RUN_DISABLE_DEFAULT_URL="${TR_CLOUD_RUN_DISABLE_DEFAULT_URL:-0}"
 # service. rollout.sh uses Cloud Run's mutable --max service cap, not the
 # per-revision --max-instances setting, so staged traffic cannot double it.
 TR_CLOUD_RUN_MAX_INSTANCES="${TR_CLOUD_RUN_MAX_INSTANCES:-20}"
+TR_RETIRE_LEGACY_RUN_SERVICE_ACCOUNT_IAM="${TR_RETIRE_LEGACY_RUN_SERVICE_ACCOUNT_IAM:-0}"
 SERVICE="${SERVICE:-trusted-router}"
+# The split console is a companion service. Keep the old combined monolith
+# under an explicit name so initial-migration discovery and rollback cannot
+# accidentally treat it as the console-only target.
+CONSOLE_SERVICE="${TR_CONSOLE_SERVICE:-${SERVICE}-console}"
+LEGACY_CONSOLE_SERVICE="${TR_LEGACY_CONSOLE_SERVICE:-$SERVICE}"
+PUBLIC_SERVICE="${TR_PUBLIC_SERVICE:-${SERVICE}-public}"
+ACTIONS_SERVICE="${TR_ACTIONS_SERVICE:-${SERVICE}-actions}"
+CHAT_SERVICE="${TR_CHAT_SERVICE:-${SERVICE}-chat}"
+WEBHOOKS_SERVICE="${TR_WEBHOOKS_SERVICE:-${SERVICE}-webhooks}"
+# TR_BILLING_SERVICE predates the process-role name `internal` and is also
+# consumed by synthetic.sh. Keep it as a compatibility/input alias while the
+# application revision itself remains TR_SERVICE_SURFACE=internal.
+INTERNAL_SERVICE="${TR_INTERNAL_SERVICE:-${TR_BILLING_SERVICE:-${SERVICE}-billing}}"
+TR_BILLING_SERVICE="${TR_BILLING_SERVICE:-$INTERNAL_SERVICE}"
+
+# Each process role names a dedicated, pre-provisioned runtime identity.
+# Provisioning and verification remain explicit operator prerequisites.
+PUBLIC_RUN_SERVICE_ACCOUNT="${TR_PUBLIC_RUN_SERVICE_ACCOUNT:-tr-public@${PROJECT_ID}.iam.gserviceaccount.com}"
+ACTIONS_RUN_SERVICE_ACCOUNT="${TR_ACTIONS_RUN_SERVICE_ACCOUNT:-tr-actions@${PROJECT_ID}.iam.gserviceaccount.com}"
+CONSOLE_RUN_SERVICE_ACCOUNT="${TR_CONSOLE_RUN_SERVICE_ACCOUNT:-tr-console@${PROJECT_ID}.iam.gserviceaccount.com}"
+CHAT_RUN_SERVICE_ACCOUNT="${TR_CHAT_RUN_SERVICE_ACCOUNT:-tr-chat@${PROJECT_ID}.iam.gserviceaccount.com}"
+WEBHOOKS_RUN_SERVICE_ACCOUNT="${TR_WEBHOOKS_RUN_SERVICE_ACCOUNT:-tr-webhooks@${PROJECT_ID}.iam.gserviceaccount.com}"
+INTERNAL_RUN_SERVICE_ACCOUNT="${TR_INTERNAL_RUN_SERVICE_ACCOUNT:-tr-internal@${PROJECT_ID}.iam.gserviceaccount.com}"
+SYNTHETIC_RUN_SERVICE_ACCOUNT="${TR_SYNTHETIC_RUN_SERVICE_ACCOUNT:-tr-synthetic@${PROJECT_ID}.iam.gserviceaccount.com}"
+DEPLOY_SERVICE_ACCOUNT="${TR_DEPLOY_SERVICE_ACCOUNT:-tr-deploy@${PROJECT_ID}.iam.gserviceaccount.com}"
+# Exact direct principals, managed outside this deploy, that may impersonate a
+# split runtime. Each listed member may hold only one unconditional
+# roles/iam.serviceAccountUser binding. Runtime identities, the deploy identity,
+# wildcard principals, TokenCreator, and arbitrary roles are never admitted by
+# this escape hatch. Promotion can feed its already-fetched policy JSON into
+# verify_runtime_service_account_policy_json below.
+TR_RUNTIME_SERVICE_ACCOUNT_OPERATOR_MEMBERS="${TR_RUNTIME_SERVICE_ACCOUNT_OPERATOR_MEMBERS:-}"
+# Exact non-runtime accessors that an owner has explicitly reviewed and wants
+# to preserve while secrets.sh replaces resource policies. The value is JSON:
+# {"secret-name":["serviceAccount:consumer@project.iam.gserviceaccount.com"]}.
+# Conditions, public principals, runtime/synthetic/deploy identities, arbitrary
+# roles, and wildcard secret names are deliberately unsupported.
+TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON="${TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON:-}"
+if [ -z "$TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON" ]; then
+  TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON='{}'
+fi
+RUNTIME_SERVICE_ACCOUNTS=(
+  "$PUBLIC_RUN_SERVICE_ACCOUNT"
+  "$ACTIONS_RUN_SERVICE_ACCOUNT"
+  "$CONSOLE_RUN_SERVICE_ACCOUNT"
+  "$CHAT_RUN_SERVICE_ACCOUNT"
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT"
+  "$INTERNAL_RUN_SERVICE_ACCOUNT"
+)
 REPO="${REPO:-trusted-router}"
 IMAGE="${IMAGE:-${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/${SERVICE}:$(git rev-parse --short HEAD 2>/dev/null || echo local)}"
 KEY_FILE="${TR_LOCAL_KEYS_FILE:-${HOME}/.quill_cloud_keys.private}"
@@ -108,7 +165,559 @@ log() { echo "[$(date +%H:%M:%S)] $*" >&2; }
 gc() { gcloud --project "$PROJECT_ID" "$@"; }
 
 PROJECT_NUMBER="$(gc projects describe "$PROJECT_ID" --format='value(projectNumber)')"
+# Compatibility for GCP synthetic jobs only. Cloud Run services must use one
+# of the six RUNTIME_SERVICE_ACCOUNTS above. infra.sh references this legacy
+# identity only in the guarded post-cutover retirement path; secrets.sh never
+# grants it split-service access. Synthetic Scheduler jobs still name it
+# directly and are verified separately.
 RUN_SERVICE_ACCOUNT="${RUN_SERVICE_ACCOUNT:-${PROJECT_NUMBER}-compute@developer.gserviceaccount.com}"
+
+# Canonical Secret Manager ownership for the six FastAPI surfaces. Unknown
+# resources intentionally return nonzero and therefore have zero runtime
+# owners. Keep this single table shared by owner reconciliation and every
+# read-only rollout gate.
+secret_expected_surfaces() {
+  case "$1" in
+    trustedrouter-attribution-cookie-secret) echo "public console" ;;
+    trustedrouter-sentry-dsn) echo "console chat webhooks internal" ;;
+    trustedrouter-stripe-secret-key) echo "console" ;;
+    trustedrouter-internal-stripe-payment-intents-key) echo "internal" ;;
+    trustedrouter-stripe-webhook-secret) echo "webhooks" ;;
+    trustedrouter-internal-gateway-token|trustedrouter-observer-internal-token|trustedrouter-synthetic-monitor-api-key|trustedrouter-federation-peer-token|trustedrouter-federation-home-token|trustedrouter-federation-credit-inbound-token|trustedrouter-federation-credit-peer-token|trustedrouter-federation-settlement-inbound-tokens|trustedrouter-federation-settlement-home-token) echo "internal" ;;
+    trustedrouter-aws-access-key-id|trustedrouter-aws-secret-access-key) echo "actions console" ;;
+    trustedrouter-internal-ses-access-key-id|trustedrouter-internal-ses-secret-access-key) echo "internal" ;;
+    trustedrouter-ops-chat-webhook-secret) echo "actions" ;;
+    trustedrouter-google-client-id|trustedrouter-google-client-secret|trustedrouter-google-alias-credentials-json|trustedrouter-github-client-id|trustedrouter-github-client-secret|trustedrouter-github-alias-credentials-json) echo "console" ;;
+    trustedrouter-paypal-client-id|trustedrouter-paypal-client-secret) echo "console webhooks" ;;
+    trustedrouter-paypal-webhook-id) echo "webhooks" ;;
+    trustedrouter-adyen-test-api-key|trustedrouter-adyen-test-client-key) echo "console" ;;
+    trustedrouter-adyen-test-hmac-key) echo "webhooks" ;;
+    trustedrouter-adyen-test-reference-key) echo "console webhooks" ;;
+    trustedrouter-veriff-api-key) echo "console" ;;
+    trustedrouter-veriff-shared-secret-key) echo "webhooks" ;;
+    trustedrouter-telnyx-api-key|trustedrouter-twilio-account-sid|trustedrouter-twilio-api-key-sid|trustedrouter-twilio-api-key-secret|trustedrouter-twilio-auth-token) echo "console" ;;
+    trustedrouter-clickhouse-provider-read-password) echo "console" ;;
+    trustedrouter-clickhouse-control-read-password) echo "public console internal" ;;
+    trustedrouter-clickhouse-password) echo "console internal" ;;
+    trustedrouter-axiom-api-token) echo "" ;;
+    trustedrouter-anthropic-api-key|trustedrouter-openai-api-key|trustedrouter-openai-video-api-key|trustedrouter-gemini-api-key|trustedrouter-cerebras-api-key|trustedrouter-deepseek-api-key|trustedrouter-mistral-api-key|trustedrouter-kimi-api-key|trustedrouter-zai-api-key|trustedrouter-together-api-key|trustedrouter-fireworks-api-key|trustedrouter-deepinfra-api-key|trustedrouter-cohere-api-key|trustedrouter-voyage-api-key|trustedrouter-xiaomi-api-key|trustedrouter-grok-api-key|trustedrouter-novita-api-key|trustedrouter-phala-api-key|trustedrouter-phala-confidential-api-key|trustedrouter-siliconflow-api-key|trustedrouter-tinfoil-api-key|trustedrouter-venice-api-key|trustedrouter-nebius-api-key|trustedrouter-minimax-api-key|trustedrouter-friendli-api-key|trustedrouter-baseten-api-key|trustedrouter-thinking-machines-api-key|trustedrouter-wafer-api-key|trustedrouter-crusoe-api-key|trustedrouter-makora-api-key|trustedrouter-alibaba-api-key|trustedrouter-ltx-api-key|trustedrouter-runway-api-key|trustedrouter-kling-api-key|trustedrouter-chutes-api-key|trustedrouter-digitalocean-api-key|trustedrouter-cloudflare-workers-ai-api-token|trustedrouter-inceptron-api-key|trustedrouter-morph-api-key|trustedrouter-atlas-cloud-api-key|trustedrouter-streamlake-api-key|trustedrouter-neurometric-api-key|trustedrouter-engy-api-key|trustedrouter-pearl-api-key|trustedrouter-zero-g-api-key|trustedrouter-athena-worker-prompt-v1|trustedrouter-gcp-service-account-key-json) echo "" ;;
+    *) return 1 ;;
+  esac
+}
+
+# The deploy identity reads only the exact secrets consumed by the checked-in
+# price refresh workflow. Historic operational/Veriff/Adyen/ClickHouse grants
+# are intentionally absent and are removed by owner reconciliation.
+deploy_service_account_owns_secret() {
+  case "$1" in
+    trustedrouter-tr-api-key-for-self-heal|trustedrouter-together-api-key|trustedrouter-parasail-api-key|trustedrouter-lightning-api-key|trustedrouter-gmi-api-key|trustedrouter-deepinfra-api-key|trustedrouter-phala-confidential-api-key|trustedrouter-siliconflow-api-key|trustedrouter-venice-api-key|trustedrouter-openai-api-key|trustedrouter-grok-api-key|trustedrouter-deepseek-api-key|trustedrouter-mistral-api-key|trustedrouter-zai-api-key|trustedrouter-cerebras-api-key|trustedrouter-kimi-api-key|trustedrouter-fireworks-api-key|trustedrouter-gemini-api-key|trustedrouter-novita-api-key|trustedrouter-nebius-api-key|trustedrouter-minimax-api-key|trustedrouter-crusoe-api-key|trustedrouter-friendli-api-key|trustedrouter-baseten-api-key|trustedrouter-telnyx-api-key|trustedrouter-wafer-api-key|trustedrouter-alibaba-api-key|trustedrouter-makora-api-key|trustedrouter-chutes-api-key|trustedrouter-digitalocean-api-key|trustedrouter-cloudflare-workers-ai-api-token|trustedrouter-inceptron-api-key|trustedrouter-morph-api-key|trustedrouter-atlas-cloud-api-key|trustedrouter-streamlake-api-key|trustedrouter-neurometric-api-key|trustedrouter-engy-api-key|trustedrouter-pearl-api-key|trustedrouter-zero-g-api-key) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+synthetic_service_account_owns_secret() {
+  case "$1" in
+    trustedrouter-observer-internal-token|trustedrouter-synthetic-monitor-api-key) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Read a Secret Manager policy on stdin. `verify` requires the canonical owners
+# and permits only explicitly allowlisted unrelated accessors. `plan` emits
+# narrowly targeted add/remove operations for the six runtimes, deploy,
+# synthetic, and public principals. It never rewrites or removes an unrelated
+# non-public principal; unallowlisted drift fails before mutation.
+secret_iam_policy_contract_json() {
+  local mode="$1"
+  local secret_name="$2"
+  local expected_surfaces="${3:-}"
+  local deploy_expected=0
+  local synthetic_expected=0
+  local runtime_csv
+  case "$mode" in
+    verify|plan) ;;
+    *) echo "ERROR: invalid secret IAM policy contract mode ${mode}" >&2; return 2 ;;
+  esac
+  deploy_service_account_owns_secret "$secret_name" && deploy_expected=1
+  synthetic_service_account_owns_secret "$secret_name" && synthetic_expected=1
+  runtime_csv="$(IFS=,; echo "${RUNTIME_SERVICE_ACCOUNTS[*]}")"
+  python3 -c '
+import json
+import re
+import sys
+
+(
+    mode,
+    secret,
+    expected_surfaces,
+    accounts_csv,
+    deploy_account,
+    synthetic_account,
+    deploy_expected,
+    synthetic_expected,
+    preserved_raw,
+) = sys.argv[1:]
+surfaces = ("public", "actions", "console", "chat", "webhooks", "internal")
+accounts = accounts_csv.split(",")
+if len(accounts) != 6 or len(set(accounts)) != 6:
+    raise SystemExit("runtime identity inventory is not exactly six")
+wanted_surfaces = expected_surfaces.split()
+if len(set(wanted_surfaces)) != len(wanted_surfaces) or not set(wanted_surfaces).issubset(surfaces):
+    raise SystemExit("secret runtime owner set is invalid")
+if not re.fullmatch(r"[A-Za-z0-9_-]{1,255}", secret):
+    raise SystemExit("secret resource identifier is invalid")
+
+try:
+    preserved = json.loads(preserved_raw)
+except json.JSONDecodeError:
+    raise SystemExit("TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON is invalid JSON") from None
+if not isinstance(preserved, dict):
+    raise SystemExit("TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON must be an object")
+
+canonical_accounts = set(accounts) | {deploy_account, synthetic_account}
+preserved_for_secret = []
+valid_member_prefixes = (
+    "user:",
+    "group:",
+    "serviceAccount:",
+    "domain:",
+    "principal://",
+    "principalSet://",
+)
+for name, members in preserved.items():
+    if not isinstance(name, str) or not re.fullmatch(r"[A-Za-z0-9_-]{1,255}", name):
+        raise SystemExit("preserved secret accessor map has an invalid resource name")
+    if not isinstance(members, list) or any(not isinstance(member, str) for member in members):
+        raise SystemExit(f"preserved secret accessor list for {name} is malformed")
+    if len(members) != len(set(members)):
+        raise SystemExit(f"preserved secret accessor list for {name} has duplicates")
+    for member in members:
+        if member in {"allUsers", "allAuthenticatedUsers"}:
+            raise SystemExit("public principals cannot be preserved on secrets")
+        if (
+            member.startswith("deleted:")
+            or not member.startswith(valid_member_prefixes)
+            or member != member.strip()
+            or any(character.isspace() for character in member)
+        ):
+            raise SystemExit(f"preserved secret accessor {member!r} is noncanonical")
+        raw_account = member.removeprefix("serviceAccount:")
+        if raw_account in canonical_accounts:
+            raise SystemExit("canonical runtime/deploy/synthetic owners cannot be overridden")
+    if name == secret:
+        preserved_for_secret = members
+
+canonical_wanted = {
+    "serviceAccount:" + account
+    for surface, account in zip(surfaces, accounts)
+    if surface in wanted_surfaces
+}
+if deploy_expected == "1":
+    canonical_wanted.add("serviceAccount:" + deploy_account)
+if synthetic_expected == "1":
+    canonical_wanted.add("serviceAccount:" + synthetic_account)
+managed_members = {"serviceAccount:" + account for account in canonical_accounts}
+preserved_members = set(preserved_for_secret)
+
+policy = json.load(sys.stdin)
+if not isinstance(policy, dict) or not isinstance(policy.get("bindings", []), list):
+    raise SystemExit("Secret Manager IAM policy is malformed")
+observed = []
+for binding in policy.get("bindings", []):
+    if not isinstance(binding, dict):
+        raise SystemExit("Secret Manager IAM binding is malformed")
+    role = binding.get("role")
+    members = binding.get("members")
+    condition = binding.get("condition") if "condition" in binding else None
+    if not isinstance(role, str) or not isinstance(members, list) or not members:
+        raise SystemExit("Secret Manager IAM binding is malformed")
+    if len(members) != len(set(members)) or any(not isinstance(member, str) for member in members):
+        raise SystemExit("Secret Manager IAM member inventory is malformed")
+    for member in members:
+        observed.append((role, member, condition))
+
+present_managed = set()
+present_preserved = set()
+present_public = set()
+operations = []
+for role, member, condition in observed:
+    if member in {"allUsers", "allAuthenticatedUsers"}:
+        if condition is not None:
+            raise SystemExit("conditional public secret IAM must be removed manually")
+        public_entry = (role, member)
+        if public_entry in present_public:
+            raise SystemExit("public secret principal has duplicate bindings")
+        present_public.add(public_entry)
+        if mode == "plan":
+            operations.append(("remove", role, member))
+        else:
+            raise SystemExit("public principal is forbidden on Secret Manager")
+        continue
+    if member in managed_members:
+        if role != "roles/secretmanager.secretAccessor" or condition is not None:
+            raise SystemExit("managed secret principal has a noncanonical role or condition")
+        if member in present_managed:
+            raise SystemExit("managed secret principal has duplicate bindings")
+        present_managed.add(member)
+        if member not in canonical_wanted:
+            if mode == "plan":
+                operations.append(("remove", role, member))
+            else:
+                raise SystemExit("managed non-owner retains secret access")
+        continue
+    if member not in preserved_members:
+        raise SystemExit("unapproved unrelated secret principal must be explicitly allowlisted")
+    if role != "roles/secretmanager.secretAccessor" or condition is not None:
+        raise SystemExit("preserved unrelated secret principal must be an unconditional accessor")
+    if member in present_preserved:
+        raise SystemExit("preserved unrelated secret principal has duplicate bindings")
+    present_preserved.add(member)
+
+missing = sorted(canonical_wanted - present_managed)
+if mode == "verify" and missing:
+    raise SystemExit("canonical secret owner is missing")
+if mode == "plan":
+    operations.extend(
+        ("add", "roles/secretmanager.secretAccessor", member)
+        for member in missing
+    )
+    for action, role, member in sorted(operations):
+        print(action, role, member, sep="\t")
+' "$mode" "$secret_name" "$expected_surfaces" "$runtime_csv" \
+    "$DEPLOY_SERVICE_ACCOUNT" "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
+    "$deploy_expected" "$synthetic_expected" \
+    "$TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON"
+}
+
+validate_nonempty_region_list() {
+  local variable_name="$1"
+  local value="$2"
+  local seen="|"
+  local -a regions
+  local region
+  case "$value" in
+    ''|,*|*,|*,,*)
+      echo "ERROR: ${variable_name} must be a nonempty comma-separated region list" >&2
+      return 1
+      ;;
+  esac
+  IFS=',' read -ra regions <<<"$value"
+  for region in "${regions[@]}"; do
+    if ! [[ "$region" =~ ^[a-z][a-z0-9-]*[a-z0-9]$ ]]; then
+      echo "ERROR: ${variable_name} contains invalid region '${region}'" >&2
+      return 1
+    fi
+    case "$seen" in
+      *"|${region}|"*)
+        echo "ERROR: ${variable_name} contains duplicate region ${region}" >&2
+        return 1
+        ;;
+    esac
+    seen="${seen}${region}|"
+  done
+}
+
+# Emit every direct binding for an exact principal as a stable token. IAM
+# conditions are deliberately preserved: flatten/value queries discard that
+# distinction and can make a time- or resource-conditioned grant look like the
+# unconditional binding a runtime contract requires.
+iam_direct_binding_tokens_for_member() {
+  local member="$1"
+  shift
+  local policy_json
+  policy_json="$("$@" --format=json)" || return 1
+  printf '%s' "$policy_json" | python3 -c '
+import json
+import sys
+
+member = sys.argv[1]
+policy = json.load(sys.stdin)
+tokens = []
+for binding in policy.get("bindings", []) or []:
+    if member not in (binding.get("members", []) or []):
+        continue
+    role = binding.get("role")
+    if not isinstance(role, str) or not role:
+        raise SystemExit("direct IAM binding has no role")
+    prefix = "conditional:" if "condition" in binding and binding["condition"] is not None else ""
+    tokens.append(prefix + role)
+for token in sorted(tokens):
+    print(token)
+' "$member"
+}
+
+iam_member_has_unconditional_role() {
+  local member="$1"
+  local role="$2"
+  shift 2
+  local tokens
+  tokens="$(iam_direct_binding_tokens_for_member "$member" "$@")" || return 1
+  grep -Fxq "$role" <<<"$tokens"
+}
+
+verify_exact_unconditional_roles() {
+  local label="$1"
+  local member="$2"
+  local expected_csv="$3"
+  shift 3
+  local actual
+  local expected
+  actual="$(iam_direct_binding_tokens_for_member "$member" "$@")" || {
+    echo "ERROR: cannot read ${label} IAM policy for ${member}" >&2
+    return 1
+  }
+  expected="$(printf '%s' "$expected_csv" | tr ',' '\n' | sed '/^$/d' | LC_ALL=C sort)"
+  if [ "$actual" != "$expected" ]; then
+    echo "ERROR: ${member} has ${label} bindings '${actual:-<none>}', expected unconditional '${expected:-<none>}'" >&2
+    return 1
+  fi
+}
+
+# Before a removal pass, prove that every direct binding is both
+# unconditional and in the finite set that the pass knows how to reconcile.
+# Unknown/custom/conditional grants stop the run before its first mutation.
+preflight_reconcilable_direct_roles() {
+  local label="$1"
+  local member="$2"
+  local allowed_csv="$3"
+  shift 3
+  local tokens
+  local token
+  local role
+  tokens="$(iam_direct_binding_tokens_for_member "$member" "$@")" || {
+    echo "ERROR: cannot inventory ${label} IAM policy for ${member}" >&2
+    return 1
+  }
+  while IFS= read -r token; do
+    [ -n "$token" ] || continue
+    case "$token" in
+      conditional:*)
+        echo "ERROR: ${member} has unsupported conditional ${label} binding ${token#conditional:}" >&2
+        return 1
+        ;;
+    esac
+    role="$token"
+    case ",${allowed_csv}," in
+      *",${role},"*) ;;
+      *)
+        echo "ERROR: ${member} has unreconcilable ${label} binding ${role}" >&2
+        return 1
+        ;;
+    esac
+  done <<<"$tokens"
+}
+
+verify_no_direct_roles() {
+  local label="$1"
+  local member="$2"
+  local forbidden_csv="$3"
+  shift 3
+  local tokens
+  local token
+  local role
+  tokens="$(iam_direct_binding_tokens_for_member "$member" "$@")" || {
+    echo "ERROR: cannot inspect ${label} IAM policy for ${member}" >&2
+    return 1
+  }
+  while IFS= read -r token; do
+    [ -n "$token" ] || continue
+    role="${token#conditional:}"
+    case ",${forbidden_csv}," in
+      *",${role},"*)
+        echo "ERROR: ${member} retains forbidden ${label} binding ${token}" >&2
+        return 1
+        ;;
+    esac
+  done <<<"$tokens"
+}
+
+is_runtime_service_account() {
+  local candidate="$1"
+  local runtime_account
+  for runtime_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do
+    if [ "$candidate" = "$runtime_account" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Validate the complete direct IAM policy on one of the six runtime service
+# accounts. This pure JSON contract is shared so provisioning and promotion can
+# apply identical semantics without flattening away conditions.
+verify_runtime_service_account_policy_json() {
+  local target_account="$1"
+  local phase="$2"
+  local operator_members_csv="${3:-$TR_RUNTIME_SERVICE_ACCOUNT_OPERATOR_MEMBERS}"
+  python3 -c '
+import json
+import sys
+
+target, phase, deploy_account, runtime_csv, operator_csv = sys.argv[1:6]
+if phase not in {"preflight", "post"}:
+    raise SystemExit(f"unknown runtime service-account policy phase {phase!r}")
+
+deploy_member = "serviceAccount:" + deploy_account
+runtime_members = {"serviceAccount:" + item for item in runtime_csv.split(",") if item}
+if "serviceAccount:" + target not in runtime_members:
+    raise SystemExit(f"policy target {target!r} is not one of the six runtimes")
+
+operators = operator_csv.split(",") if operator_csv else []
+if any(not item or item != item.strip() for item in operators):
+    raise SystemExit("operator member allowlist contains an empty or padded item")
+if len(set(operators)) != len(operators):
+    raise SystemExit("operator member allowlist contains duplicates")
+valid_prefixes = ("user:", "group:", "serviceAccount:", "domain:", "principal://", "principalSet://")
+for operator in operators:
+    if not operator.startswith(valid_prefixes):
+        raise SystemExit(f"invalid operator IAM member {operator!r}")
+    if operator == deploy_member or operator in runtime_members:
+        raise SystemExit(f"operator allowlist must not contain deploy/runtime member {operator}")
+
+policy = json.load(sys.stdin)
+deploy_bindings = []
+operator_bindings = []
+for binding in policy.get("bindings", []) or []:
+    role = binding.get("role")
+    members = binding.get("members", []) or []
+    if not isinstance(role, str) or not role:
+        raise SystemExit("runtime service-account policy binding has no role")
+    if not isinstance(members, list):
+        raise SystemExit("runtime service-account policy binding members are not a list")
+    condition = binding.get("condition") if "condition" in binding else None
+    for member in members:
+        if not isinstance(member, str) or not member:
+            raise SystemExit("runtime service-account policy has an invalid member")
+        entry = (role, condition)
+        if member in runtime_members:
+            raise SystemExit(
+                f"split runtime principal {member} has a direct binding on {target}"
+            )
+        if member == deploy_member:
+            deploy_bindings.append(entry)
+            continue
+        if member in operators:
+            operator_bindings.append((member, role, condition))
+            continue
+        raise SystemExit(f"unapproved principal {member} has a direct binding on {target}")
+
+expected = [("roles/iam.serviceAccountUser", None)]
+if phase == "post" and deploy_bindings != expected:
+    raise SystemExit(
+        f"deploy principal bindings are {deploy_bindings!r}, expected {expected!r}"
+    )
+if phase == "preflight" and deploy_bindings not in ([], expected):
+    raise SystemExit(f"unsafe preexisting deploy bindings {deploy_bindings!r}")
+seen_operators = set()
+for member, role, condition in operator_bindings:
+    if member in seen_operators:
+        raise SystemExit(f"operator {member} has duplicate direct bindings on {target}")
+    seen_operators.add(member)
+    if role != "roles/iam.serviceAccountUser" or condition is not None:
+        raise SystemExit(
+            f"operator {member} must have only unconditional serviceAccountUser"
+        )
+' "$target_account" "$phase" "$DEPLOY_SERVICE_ACCOUNT" \
+    "$(IFS=,; echo "${RUNTIME_SERVICE_ACCOUNTS[*]}")" \
+    "$operator_members_csv"
+}
+
+validate_runtime_service_accounts() {
+  local expected_suffix="@${PROJECT_ID}.iam.gserviceaccount.com"
+  local seen="|"
+  local service_account
+  local account_id
+  for service_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do
+    if [ "$service_account" = "$RUN_SERVICE_ACCOUNT" ]; then
+      echo "ERROR: Cloud Run surface must not reuse legacy RUN_SERVICE_ACCOUNT" >&2
+      return 1
+    fi
+    case "$service_account" in
+      *"$expected_suffix") ;;
+      *)
+        echo "ERROR: runtime service account must belong to ${PROJECT_ID}: ${service_account}" >&2
+        return 1
+        ;;
+    esac
+    account_id="${service_account%@*}"
+    if ! [[ "$account_id" =~ ^[a-z][a-z0-9-]{4,28}[a-z0-9]$ ]]; then
+      echo "ERROR: invalid runtime service account id: ${account_id}" >&2
+      return 1
+    fi
+    case "$seen" in
+      *"|${service_account}|"*)
+        echo "ERROR: runtime service accounts must be distinct: ${service_account}" >&2
+        return 1
+        ;;
+    esac
+    seen="${seen}${service_account}|"
+  done
+  if [ "$DEPLOY_SERVICE_ACCOUNT" = "$PUBLIC_RUN_SERVICE_ACCOUNT" ] ||
+     [ "$DEPLOY_SERVICE_ACCOUNT" = "$ACTIONS_RUN_SERVICE_ACCOUNT" ] ||
+     [ "$DEPLOY_SERVICE_ACCOUNT" = "$CONSOLE_RUN_SERVICE_ACCOUNT" ] ||
+     [ "$DEPLOY_SERVICE_ACCOUNT" = "$CHAT_RUN_SERVICE_ACCOUNT" ] ||
+     [ "$DEPLOY_SERVICE_ACCOUNT" = "$WEBHOOKS_RUN_SERVICE_ACCOUNT" ] ||
+     [ "$DEPLOY_SERVICE_ACCOUNT" = "$INTERNAL_RUN_SERVICE_ACCOUNT" ]; then
+    echo "ERROR: deploy service account must not be a runtime identity" >&2
+    return 1
+  fi
+  case "$DEPLOY_SERVICE_ACCOUNT" in
+    *"$expected_suffix") ;;
+    *)
+      echo "ERROR: deploy service account must belong to ${PROJECT_ID}" >&2
+      return 1
+      ;;
+  esac
+  account_id="${DEPLOY_SERVICE_ACCOUNT%@*}"
+  if ! [[ "$account_id" =~ ^[a-z][a-z0-9-]{4,28}[a-z0-9]$ ]]; then
+    echo "ERROR: invalid deploy service account id: ${account_id}" >&2
+    return 1
+  fi
+  if [ "$DEPLOY_SERVICE_ACCOUNT" = "$RUN_SERVICE_ACCOUNT" ]; then
+    echo "ERROR: deploy service account must not reuse legacy RUN_SERVICE_ACCOUNT" >&2
+    return 1
+  fi
+  if [ "$SYNTHETIC_RUN_SERVICE_ACCOUNT" != "tr-synthetic@${PROJECT_ID}.iam.gserviceaccount.com" ]; then
+    echo "ERROR: synthetic jobs require canonical tr-synthetic identity in ${PROJECT_ID}" >&2
+    return 1
+  fi
+  if [ "$SYNTHETIC_RUN_SERVICE_ACCOUNT" = "$RUN_SERVICE_ACCOUNT" ] ||
+     [ "$SYNTHETIC_RUN_SERVICE_ACCOUNT" = "$DEPLOY_SERVICE_ACCOUNT" ] ||
+     is_runtime_service_account "$SYNTHETIC_RUN_SERVICE_ACCOUNT"; then
+    echo "ERROR: synthetic job identity must be distinct from deploy, legacy, and six runtimes" >&2
+    return 1
+  fi
+  if ! printf '%s' "$TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON" | python3 -c '
+import json
+import sys
+
+try:
+    value = json.load(sys.stdin)
+except json.JSONDecodeError:
+    raise SystemExit(1) from None
+if not isinstance(value, dict):
+    raise SystemExit(1)
+'; then
+    echo "ERROR: TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON must be a JSON object" >&2
+    return 1
+  fi
+  case "$TR_RETIRE_LEGACY_RUN_SERVICE_ACCOUNT_IAM" in
+    0|1) ;;
+    *)
+      echo "ERROR: TR_RETIRE_LEGACY_RUN_SERVICE_ACCOUNT_IAM must be 0 or 1" >&2
+      return 1
+      ;;
+  esac
+  if [ "$TR_BILLING_SERVICE" != "$INTERNAL_SERVICE" ]; then
+    echo "ERROR: TR_BILLING_SERVICE and TR_INTERNAL_SERVICE must resolve to the same Cloud Run service" >&2
+    return 1
+  fi
+  validate_nonempty_region_list TR_CONTROL_PLANE_REGIONS "$TR_CONTROL_PLANE_REGIONS"
+  validate_nonempty_region_list TR_SYNTHETIC_MONITOR_REGIONS "$TR_SYNTHETIC_MONITOR_REGIONS"
+  validate_nonempty_region_list TR_SYNTHETIC_THROUGHPUT_REGION "$TR_SYNTHETIC_THROUGHPUT_REGION"
+  validate_nonempty_region_list TR_SYNTHETIC_IMAGE_REGION "$TR_SYNTHETIC_IMAGE_REGION"
+  validate_nonempty_region_list TR_SYNTHETIC_VIDEO_REGION "$TR_SYNTHETIC_VIDEO_REGION"
+}
 
 read_key_file_var() {
   local env_name="$1"
@@ -154,14 +763,9 @@ ensure_secret_value() {
 ensure_project_role() {
   local member="$1"
   local role="$2"
-  local bound_roles=""
-  if bound_roles="$(gc projects get-iam-policy "$PROJECT_ID" \
-      --flatten='bindings[].members' \
-      --filter="bindings.role=${role} AND bindings.members=${member}" \
-      --format='value(bindings.role)' 2>/dev/null)"; then
-    if grep -Fxq "$role" <<<"$bound_roles"; then
-      return 0
-    fi
+  if iam_member_has_unconditional_role \
+      "$member" "$role" gc projects get-iam-policy "$PROJECT_ID" 2>/dev/null; then
+    return 0
   fi
 
   # Retry only etag conflicts. Retrying an authorization failure creates a
@@ -173,6 +777,7 @@ ensure_project_role() {
     if last_stderr="$(gc projects add-iam-policy-binding "$PROJECT_ID" \
         --member="$member" \
         --role="$role" \
+        --condition=None \
         --quiet 2>&1 >/dev/null)"; then
       return 0
     fi

--- a/scripts/deploy/google_data_manager.sh
+++ b/scripts/deploy/google_data_manager.sh
@@ -31,7 +31,7 @@ fi
 ENV_VARS=(
   # One-shot worker: no Stripe, Sentry, gateway, provider, or BYOK secrets.
   "TR_ENVIRONMENT=worker"
-  "TR_SERVICE_SURFACE=control"
+  "TR_SERVICE_SURFACE=console"
   "TR_RELEASE=$(git rev-parse --short HEAD 2>/dev/null || echo local)"
   "TR_GCP_PROJECT_ID=${PROJECT_ID}"
   "TR_SPANNER_INSTANCE_ID=${SPANNER_INSTANCE_ID}"

--- a/scripts/deploy/infra.sh
+++ b/scripts/deploy/infra.sh
@@ -6,9 +6,1103 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/deploy/_lib.sh
 source "${SCRIPT_DIR}/_lib.sh"
 
+validate_runtime_service_accounts
+
+GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT_ID="${TR_GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT_ID:-tr-google-data-manager}"
+GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT="${GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT_ID}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+ensure_runtime_service_account() {
+  local service_account="$1"
+  local display_name="$2"
+  local account_id="${service_account%@*}"
+  local describe_error=""
+  if ! describe_error="$(gc iam service-accounts describe "$service_account" \
+      --format='value(email)' 2>&1)"; then
+    if [[ "$describe_error" != *"NOT_FOUND"* ]] &&
+       [[ "$describe_error" != *"not found"* ]]; then
+      echo "ERROR: cannot determine whether ${service_account} exists: ${describe_error}" >&2
+      return 1
+    fi
+    gc iam service-accounts create "$account_id" \
+      --display-name="$display_name" \
+      --description="Dedicated Cloud Run runtime identity for ${display_name}" \
+      --quiet
+  fi
+
+  local actual_email
+  local disabled
+  actual_email="$(gc iam service-accounts describe "$service_account" \
+    --format='value(email)')"
+  disabled="$(gc iam service-accounts describe "$service_account" \
+    --format='value(disabled)')"
+  if [ "$actual_email" != "$service_account" ]; then
+    echo "ERROR: runtime service account post-verification failed: ${service_account}" >&2
+    return 1
+  fi
+  case "$disabled" in
+    ""|False|false|0) ;;
+    *)
+      echo "ERROR: runtime service account is disabled: ${service_account}" >&2
+      return 1
+      ;;
+  esac
+}
+
+policy_roles_for_member() {
+  local member="$1"
+  shift
+  iam_direct_binding_tokens_for_member "$member" "$@"
+}
+
+verify_only_resource_role() {
+  local label="$1"
+  local member="$2"
+  local expected_role="$3"
+  shift 3
+  verify_exact_unconditional_roles "$label" "$member" "$expected_role" "$@"
+}
+
+verify_resource_role_present() {
+  local label="$1"
+  local member="$2"
+  local role="$3"
+  shift 3
+  if ! iam_member_has_unconditional_role "$member" "$role" "$@"; then
+    echo "ERROR: ${member} is missing desired ${label} binding ${role}" >&2
+    return 1
+  fi
+}
+
+remove_project_role_if_present() {
+  local member="$1"
+  local role="$2"
+  local roles
+  roles="$(policy_roles_for_member "$member" gc projects get-iam-policy "$PROJECT_ID")" || {
+    echo "ERROR: cannot read project IAM while checking ${member}" >&2
+    return 1
+  }
+  if grep -Fxq "$role" <<<"$roles"; then
+    gc projects remove-iam-policy-binding "$PROJECT_ID" \
+      --member="$member" \
+      --role="$role" \
+      --quiet >/dev/null
+  fi
+  roles="$(policy_roles_for_member "$member" gc projects get-iam-policy "$PROJECT_ID")" || {
+    echo "ERROR: cannot post-verify project IAM for ${member}" >&2
+    return 1
+  }
+  if grep -Fxq "$role" <<<"$roles"; then
+    echo "ERROR: ${member} retains forbidden project-wide ${role}" >&2
+    return 1
+  fi
+}
+
+remove_spanner_role_if_present() {
+  local member="$1"
+  local role="$2"
+  local roles
+  roles="$(policy_roles_for_member "$member" gc spanner databases get-iam-policy \
+    "$SPANNER_DATABASE_ID" --instance="$SPANNER_INSTANCE_ID")" || {
+    echo "ERROR: cannot read Spanner database IAM for ${member}" >&2
+    return 1
+  }
+  if grep -Fxq "$role" <<<"$roles"; then
+    gc spanner databases remove-iam-policy-binding "$SPANNER_DATABASE_ID" \
+      --instance="$SPANNER_INSTANCE_ID" \
+      --member="$member" \
+      --role="$role" \
+      --quiet >/dev/null
+  fi
+}
+
+remove_bigtable_role_if_present() {
+  local member="$1"
+  local role="$2"
+  local roles
+  roles="$(policy_roles_for_member "$member" gc bigtable instances get-iam-policy \
+    "$BIGTABLE_INSTANCE_ID")" || {
+    echo "ERROR: cannot read Bigtable instance IAM for ${member}" >&2
+    return 1
+  }
+  if grep -Fxq "$role" <<<"$roles"; then
+    gc bigtable instances remove-iam-policy-binding "$BIGTABLE_INSTANCE_ID" \
+      --member="$member" \
+      --role="$role" \
+      --quiet >/dev/null
+  fi
+}
+
+remove_kms_role_if_present() {
+  local member="$1"
+  local role="$2"
+  local key_id="${3:-$BYOK_KMS_KEY_ID}"
+  local roles
+  roles="$(policy_roles_for_member "$member" gc kms keys get-iam-policy \
+    "$key_id" --keyring="$KMS_KEYRING_ID" --location="$REGION")" || {
+    echo "ERROR: cannot read ${key_id} KMS IAM for ${member}" >&2
+    return 1
+  }
+  if grep -Fxq "$role" <<<"$roles"; then
+    gc kms keys remove-iam-policy-binding "$key_id" \
+      --keyring="$KMS_KEYRING_ID" \
+      --location="$REGION" \
+      --member="$member" \
+      --role="$role" \
+      --quiet >/dev/null
+  fi
+}
+
+verify_synthetic_service_account_policy() {
+  local phase="$1"
+  local policy_json=""
+  case "$phase" in
+    preflight|post) ;;
+    *) echo "ERROR: invalid synthetic service-account IAM phase ${phase}" >&2; return 2 ;;
+  esac
+  policy_json="$(gc iam service-accounts get-iam-policy \
+    "$SYNTHETIC_RUN_SERVICE_ACCOUNT" --format=json)" || return 1
+  if ! printf '%s' "$policy_json" | python3 -c '
+import json
+import sys
+
+phase, deploy_member = sys.argv[1:3]
+policy = json.load(sys.stdin)
+bindings = policy.get("bindings") or []
+expected = [{"role": "roles/iam.serviceAccountUser", "members": [deploy_member]}]
+if phase == "preflight" and bindings not in ([], expected):
+    raise SystemExit("synthetic service-account IAM has unsafe preexisting bindings")
+if phase == "post" and bindings != expected:
+    raise SystemExit("synthetic service-account IAM differs from exact deploy-only actAs")
+' "$phase" "serviceAccount:${DEPLOY_SERVICE_ACCOUNT}"; then
+    echo "ERROR: dedicated synthetic identity IAM is not the exact deploy-only actAs policy" >&2
+    return 1
+  fi
+}
+
+verify_synthetic_data_iam_empty() {
+  local member="serviceAccount:${SYNTHETIC_RUN_SERVICE_ACCOUNT}"
+  local key_id=""
+  verify_exact_unconditional_roles \
+    "synthetic identity project" "$member" "" \
+    gc projects get-iam-policy "$PROJECT_ID" || return 1
+  verify_identity_resource_manager_ancestors_empty \
+    "synthetic identity" "$SYNTHETIC_RUN_SERVICE_ACCOUNT" || return 1
+  verify_exact_unconditional_roles \
+    "synthetic identity Spanner instance" "$member" "" \
+    gc spanner instances get-iam-policy "$SPANNER_INSTANCE_ID" || return 1
+  verify_exact_unconditional_roles \
+    "synthetic identity Spanner database" "$member" "" \
+    gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID" || return 1
+  verify_exact_unconditional_roles \
+    "synthetic identity Bigtable instance" "$member" "" \
+    gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID" || return 1
+  verify_exact_unconditional_roles \
+    "synthetic identity Bigtable generation table" "$member" "" \
+    gc bigtable tables get-iam-policy "$BIGTABLE_GENERATION_TABLE" \
+    --instance="$BIGTABLE_INSTANCE_ID" || return 1
+  verify_exact_unconditional_roles \
+    "synthetic identity KMS key ring" "$member" "" \
+    gc kms keyrings get-iam-policy "$KMS_KEYRING_ID" \
+    --location="$REGION" || return 1
+  for key_id in "$BYOK_KMS_KEY_ID" "$GOOGLE_ADS_KMS_KEY_ID"; do
+    verify_exact_unconditional_roles \
+      "synthetic identity KMS key ${key_id}" "$member" "" \
+      gc kms keys get-iam-policy "$key_id" \
+      --keyring="$KMS_KEYRING_ID" --location="$REGION" || return 1
+  done
+}
+
+verify_legacy_runtime_retirement_ready() {
+  if [ "$CONSOLE_SERVICE" = "$LEGACY_CONSOLE_SERVICE" ]; then
+    echo "ERROR: cannot retire legacy IAM; split console ${CONSOLE_SERVICE} aliases the legacy monolith" >&2
+    return 1
+  fi
+  local -a services=(
+    "$PUBLIC_SERVICE"
+    "$ACTIONS_SERVICE"
+    "$CONSOLE_SERVICE"
+    "$CHAT_SERVICE"
+    "$WEBHOOKS_SERVICE"
+    "$INTERNAL_SERVICE"
+  )
+  local -a surfaces=(public actions console chat webhooks internal)
+  local -a identities=(
+    "$PUBLIC_RUN_SERVICE_ACCOUNT"
+    "$ACTIONS_RUN_SERVICE_ACCOUNT"
+    "$CONSOLE_RUN_SERVICE_ACCOUNT"
+    "$CHAT_RUN_SERVICE_ACCOUNT"
+    "$WEBHOOKS_RUN_SERVICE_ACCOUNT"
+    "$INTERNAL_RUN_SERVICE_ACCOUNT"
+  )
+  local -a regions
+  local region
+  local index
+  local service_json
+  local revisions
+  local revision
+  local revision_json
+  IFS=',' read -ra regions <<<"$TR_CONTROL_PLANE_REGIONS"
+  for region in "${regions[@]}"; do
+    [ -n "$region" ] || continue
+    for index in 0 1 2 3 4 5; do
+      service_json="$(gc run services describe "${services[$index]}" \
+        --region="$region" --format=json)" || {
+        echo "ERROR: cannot retire legacy IAM; ${services[$index]} is absent in ${region}" >&2
+        return 1
+      }
+      revisions="$(printf '%s' "$service_json" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+conditions = data.get("status", {}).get("conditions", [])
+if not any(
+    item.get("type") == "Ready"
+    and str(item.get("status", "")).casefold() == "true"
+    for item in conditions
+):
+    raise SystemExit("service is not Ready")
+traffic = [
+    item
+    for item in data.get("status", {}).get("traffic", [])
+    if int(item.get("percent", 0) or 0) > 0
+]
+if not traffic or sum(int(item.get("percent", 0) or 0) for item in traffic) != 100:
+    raise SystemExit("serving traffic is absent or does not total 100 percent")
+for item in traffic:
+    revision = item.get("revisionName")
+    if not revision:
+        raise SystemExit("serving traffic does not name an immutable revision")
+    print(revision)
+')" || {
+        echo "ERROR: cannot retire legacy IAM; ${services[$index]} traffic is unsafe in ${region}" >&2
+        return 1
+      }
+      for revision in $revisions; do
+        revision_json="$(gc run revisions describe "$revision" \
+          --region="$region" --format=json)" || {
+          echo "ERROR: cannot inspect serving revision ${revision} in ${region}" >&2
+          return 1
+        }
+        if ! printf '%s' "$revision_json" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+expected_surface, expected_identity = sys.argv[1:3]
+spec = data.get("spec", {})
+actual_identity = spec.get("serviceAccountName")
+if actual_identity != expected_identity:
+    raise SystemExit(
+        f"service account is {actual_identity!r}, expected {expected_identity!r}"
+    )
+containers = spec.get("containers", [])
+if len(containers) != 1:
+    raise SystemExit("revision must have exactly one container")
+surface = next(
+    (
+        item.get("value")
+        for item in containers[0].get("env", [])
+        if item.get("name") == "TR_SERVICE_SURFACE"
+    ),
+    None,
+)
+if surface != expected_surface:
+    raise SystemExit(f"surface is {surface!r}, expected {expected_surface!r}")
+' "${surfaces[$index]}" "${identities[$index]}"; then
+          echo "ERROR: cannot retire legacy IAM; serving revision ${revision} is not isolated" >&2
+          return 1
+        fi
+      done
+    done
+  done
+}
+
+verify_identity_resource_manager_ancestors_empty() {
+  local label="$1"
+  local service_account="$2"
+  local member="serviceAccount:${service_account}"
+  local ancestors_json
+  local ancestors
+  local ancestor_type
+  local ancestor_id
+
+  ancestors_json="$(gc projects get-ancestors "$PROJECT_ID" --format=json)" || {
+    echo "ERROR: cannot inventory Resource Manager ancestors for ${label}" >&2
+    return 1
+  }
+  ancestors="$(printf '%s' "$ancestors_json" | python3 -c '
+import json
+import sys
+
+items = json.load(sys.stdin)
+if not isinstance(items, list):
+    raise SystemExit("project ancestor inventory is not a list")
+seen = set()
+projects = []
+organizations = []
+for item in items:
+    if not isinstance(item, dict):
+        raise SystemExit("project ancestor entry is not an object")
+    kind = str(item.get("type") or "").casefold()
+    identifier = str(item.get("id") or "")
+    if kind not in {"project", "folder", "organization"} or not identifier:
+        raise SystemExit("project ancestor entry has an invalid type or id")
+    key = (kind, identifier)
+    if key in seen:
+        raise SystemExit("project ancestor inventory contains a duplicate")
+    seen.add(key)
+    if kind == "project":
+        projects.append(identifier)
+    elif kind == "organization":
+        organizations.append(identifier)
+    print(kind, identifier, sep="\t")
+if len(projects) != 1 or projects[0] not in set(sys.argv[1:3]):
+    raise SystemExit("project ancestor inventory does not identify this project")
+if len(organizations) > 1:
+    raise SystemExit("project ancestor inventory has multiple organizations")
+' "$PROJECT_ID" "$PROJECT_NUMBER")" || {
+    echo "ERROR: malformed Resource Manager ancestor inventory for ${label}" >&2
+    return 1
+  }
+
+  while IFS=$'\t' read -r ancestor_type ancestor_id; do
+    [ -n "$ancestor_id" ] || continue
+    case "$ancestor_type" in
+      project) ;;
+      folder)
+        verify_exact_unconditional_roles \
+          "${label} inherited folder ${ancestor_id}" "$member" "" \
+          gc resource-manager folders get-iam-policy "$ancestor_id" \
+          --format=json || return 1
+        ;;
+      organization)
+        verify_exact_unconditional_roles \
+          "${label} inherited organization ${ancestor_id}" "$member" "" \
+          gc organizations get-iam-policy "$ancestor_id" \
+          --format=json || return 1
+        ;;
+      *)
+        echo "ERROR: unsupported Resource Manager ancestor ${ancestor_type}/${ancestor_id}" >&2
+        return 1
+        ;;
+    esac
+  done <<<"$ancestors"
+}
+
+verify_synthetic_retirement_identity_ready() {
+  local expected_identity="tr-synthetic@${PROJECT_ID}.iam.gserviceaccount.com"
+  local member="serviceAccount:${SYNTHETIC_RUN_SERVICE_ACCOUNT}"
+  local account_json
+  local account_policy
+  local key_id
+
+  if [ "$SYNTHETIC_RUN_SERVICE_ACCOUNT" != "$expected_identity" ]; then
+    echo "ERROR: legacy IAM retirement requires the canonical dedicated synthetic identity ${expected_identity}" >&2
+    return 1
+  fi
+  if [ "$SYNTHETIC_RUN_SERVICE_ACCOUNT" = "$RUN_SERVICE_ACCOUNT" ]; then
+    echo "ERROR: legacy IAM retirement cannot reuse RUN_SERVICE_ACCOUNT for synthetic Jobs" >&2
+    return 1
+  fi
+
+  account_json="$(gc iam service-accounts describe \
+    "$SYNTHETIC_RUN_SERVICE_ACCOUNT" --format=json)" || {
+    echo "ERROR: dedicated synthetic identity is not provisioned; separate narrow IAM approval is required" >&2
+    return 1
+  }
+  if ! printf '%s' "$account_json" | python3 -c '
+import json
+import sys
+
+account = json.load(sys.stdin)
+if account.get("email") != sys.argv[1] or account.get("disabled", False) is not False:
+    raise SystemExit("synthetic identity is missing, disabled, or renamed")
+' "$SYNTHETIC_RUN_SERVICE_ACCOUNT"; then
+    echo "ERROR: dedicated synthetic identity is missing, disabled, or renamed" >&2
+    return 1
+  fi
+
+  account_policy="$(gc iam service-accounts get-iam-policy \
+    "$SYNTHETIC_RUN_SERVICE_ACCOUNT" --format=json)" || {
+    echo "ERROR: cannot read dedicated synthetic identity IAM" >&2
+    return 1
+  }
+  if ! printf '%s' "$account_policy" | python3 -c '
+import json
+import sys
+
+policy = json.load(sys.stdin)
+bindings = policy.get("bindings") or []
+if len(bindings) != 1:
+    raise SystemExit("synthetic identity IAM binding inventory differs")
+binding = bindings[0]
+if binding.get("role") != "roles/iam.serviceAccountUser":
+    raise SystemExit("synthetic identity actAs role differs")
+if binding.get("condition") is not None:
+    raise SystemExit("synthetic identity actAs grant is conditional")
+if (binding.get("members") or []) != [sys.argv[1]]:
+    raise SystemExit("synthetic identity actAs member inventory differs")
+' "serviceAccount:${DEPLOY_SERVICE_ACCOUNT}"; then
+    echo "ERROR: dedicated synthetic identity IAM is not the narrow reviewed policy" >&2
+    return 1
+  fi
+
+  verify_exact_unconditional_roles \
+    "synthetic identity project" "$member" "" \
+    gc projects get-iam-policy "$PROJECT_ID" || return 1
+  verify_identity_resource_manager_ancestors_empty \
+    "synthetic identity" "$SYNTHETIC_RUN_SERVICE_ACCOUNT" || return 1
+  verify_exact_unconditional_roles \
+    "synthetic identity Spanner instance" "$member" "" \
+    gc spanner instances get-iam-policy "$SPANNER_INSTANCE_ID" || return 1
+  verify_exact_unconditional_roles \
+    "synthetic identity Spanner database" "$member" "" \
+    gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID" || return 1
+  verify_exact_unconditional_roles \
+    "synthetic identity Bigtable instance" "$member" "" \
+    gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID" || return 1
+  verify_exact_unconditional_roles \
+    "synthetic identity Bigtable generation table" "$member" "" \
+    gc bigtable tables get-iam-policy "$BIGTABLE_GENERATION_TABLE" \
+    --instance="$BIGTABLE_INSTANCE_ID" || return 1
+  verify_exact_unconditional_roles \
+    "synthetic identity KMS key ring" "$member" "" \
+    gc kms keyrings get-iam-policy "$KMS_KEYRING_ID" \
+    --location="$REGION" || return 1
+  for key_id in "$BYOK_KMS_KEY_ID" "$GOOGLE_ADS_KMS_KEY_ID"; do
+    verify_exact_unconditional_roles \
+      "synthetic identity KMS key ${key_id}" "$member" "" \
+      gc kms keys get-iam-policy "$key_id" \
+      --keyring="$KMS_KEYRING_ID" --location="$REGION" || return 1
+  done
+}
+
+verify_legacy_synthetic_secret_access_ready() {
+  local expected_names="|trustedrouter-observer-internal-token|trustedrouter-synthetic-monitor-api-key|"
+  local seen_names="|"
+  local inventory_json
+  local inventory
+  local secret_name
+  local policy_json
+  local member="serviceAccount:${SYNTHETIC_RUN_SERVICE_ACCOUNT}"
+
+  inventory_json="$(gc secrets list --format=json)" || {
+    echo "ERROR: cannot inventory every Secret Manager resource before legacy IAM retirement" >&2
+    return 1
+  }
+  inventory="$(printf '%s' "$inventory_json" | python3 -c '
+import json
+import sys
+
+items = json.load(sys.stdin)
+if not isinstance(items, list):
+    raise SystemExit("secret inventory is not a list")
+names = []
+for item in items:
+    if not isinstance(item, dict):
+        raise SystemExit("secret inventory entry is not an object")
+    raw_name = item.get("name")
+    if not isinstance(raw_name, str) or not raw_name:
+        raise SystemExit("secret inventory entry has no name")
+    name = raw_name.rstrip("/").rsplit("/", 1)[-1]
+    if not name:
+        raise SystemExit("secret inventory entry has an invalid name")
+    names.append(name)
+if len(names) != len(set(names)):
+    raise SystemExit("secret inventory contains duplicate names")
+print("\n".join(sorted(names)))
+')" || {
+    echo "ERROR: malformed Secret Manager inventory before legacy IAM retirement" >&2
+    return 1
+  }
+
+  while IFS= read -r secret_name; do
+    [ -n "$secret_name" ] || continue
+    case "$expected_names" in
+      *"|${secret_name}|"*)
+        seen_names="${seen_names}${secret_name}|"
+        ;;
+      *)
+        verify_exact_unconditional_roles \
+          "non-synthetic secret ${secret_name}" "$member" "" \
+          gc secrets get-iam-policy "$secret_name" || return 1
+        continue
+        ;;
+    esac
+    policy_json="$(gc secrets get-iam-policy "$secret_name" --format=json)" || {
+      echo "ERROR: cannot read synthetic secret IAM for ${secret_name}" >&2
+      return 1
+    }
+    if ! printf '%s' "$policy_json" | python3 -c '
+import json
+import sys
+
+policy = json.load(sys.stdin)
+expected = sorted(sys.argv[1:])
+bindings = policy.get("bindings") or []
+if len(bindings) != 1:
+    raise SystemExit("synthetic secret IAM binding inventory differs")
+binding = bindings[0]
+if binding.get("role") != "roles/secretmanager.secretAccessor":
+    raise SystemExit("synthetic secret IAM role differs")
+if binding.get("condition") is not None:
+    raise SystemExit("synthetic secret IAM grant is conditional")
+members = binding.get("members") or []
+if len(members) != len(set(members)) or sorted(members) != expected:
+    raise SystemExit("synthetic secret IAM consumer inventory differs")
+' "serviceAccount:${INTERNAL_RUN_SERVICE_ACCOUNT}" \
+      "serviceAccount:${SYNTHETIC_RUN_SERVICE_ACCOUNT}"; then
+      echo "ERROR: ${secret_name} must have exactly the internal and dedicated synthetic consumers" >&2
+      return 1
+    fi
+  done <<<"$inventory"
+
+  for secret_name in \
+    trustedrouter-observer-internal-token \
+    trustedrouter-synthetic-monitor-api-key; do
+    case "$seen_names" in
+      *"|${secret_name}|"*) ;;
+      *)
+        echo "ERROR: required synthetic secret ${secret_name} is absent from the project inventory" >&2
+        return 1
+        ;;
+    esac
+  done
+}
+
+synthetic_job_inventory_lines() {
+  local -a monitor_regions
+  local monitor_region
+  IFS=',' read -ra monitor_regions <<<"$TR_SYNTHETIC_MONITOR_REGIONS"
+  for monitor_region in "${monitor_regions[@]}"; do
+    printf '%s\t%s\t%s\n' \
+      "$monitor_region" \
+      "trusted-router-synthetic-${monitor_region//[^a-zA-Z0-9-]/-}" \
+      "trusted-router-synthetic-${monitor_region//[^a-zA-Z0-9-]/-}-every-three-minutes"
+  done
+  printf '%s\t%s\t%s\n' \
+    "$TR_SYNTHETIC_THROUGHPUT_REGION" \
+    "trusted-router-throughput-${TR_SYNTHETIC_THROUGHPUT_REGION}" \
+    "trusted-router-throughput-${TR_SYNTHETIC_THROUGHPUT_REGION}-every-five-minutes"
+  printf '%s\t%s\t%s\n' \
+    "$TR_SYNTHETIC_IMAGE_REGION" \
+    "trusted-router-image-generation-${TR_SYNTHETIC_IMAGE_REGION}" \
+    "trusted-router-image-generation-${TR_SYNTHETIC_IMAGE_REGION}-every-six-hours"
+  printf '%s\t%s\t%s\n' \
+    "$TR_SYNTHETIC_VIDEO_REGION" \
+    "trusted-router-video-generation-${TR_SYNTHETIC_VIDEO_REGION}" \
+    "trusted-router-video-generation-${TR_SYNTHETIC_VIDEO_REGION}-daily"
+}
+
+cloud_run_inventory_lines() {
+  local kind="$1"
+  local resources_json
+  resources_json="$(gc run "$kind" list --format=json)" || {
+    echo "ERROR: cannot list Cloud Run ${kind} in all regions" >&2
+    return 1
+  }
+  printf '%s' "$resources_json" | python3 -c '
+import json
+import sys
+
+kind = sys.argv[1]
+items = json.load(sys.stdin)
+if not isinstance(items, list):
+    raise SystemExit(f"Cloud Run {kind} inventory is not a list")
+seen = set()
+for item in items:
+    metadata = item.get("metadata", {}) or {}
+    raw_name = metadata.get("name") or item.get("name")
+    if not isinstance(raw_name, str) or not raw_name:
+        raise SystemExit(f"Cloud Run {kind} inventory entry has no name")
+    name = raw_name.rsplit("/", 1)[-1]
+    labels = metadata.get("labels", {}) or {}
+    annotations = metadata.get("annotations", {}) or {}
+    region = (
+        labels.get("cloud.googleapis.com/location")
+        or annotations.get("run.googleapis.com/region")
+        or item.get("location")
+    )
+    if not region and "/locations/" in raw_name:
+        region = raw_name.split("/locations/", 1)[1].split("/", 1)[0]
+    if not isinstance(region, str) or not region:
+        raise SystemExit(f"Cloud Run {kind} inventory cannot resolve region for {name}")
+    key = (region, name)
+    if key in seen:
+        raise SystemExit(f"Cloud Run {kind} inventory repeats {region}/{name}")
+    seen.add(key)
+    print(region, name, sep="\t")
+' "$kind"
+}
+
+cloud_run_job_service_account() {
+  local job_name="$1"
+  local region="$2"
+  local job_json
+  job_json="$(gc run jobs describe "$job_name" --region="$region" --format=json)" || {
+    echo "ERROR: cannot inspect Cloud Run job ${region}/${job_name}" >&2
+    return 1
+  }
+  printf '%s' "$job_json" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+root = data.get("spec", {}).get("template", {})
+values = []
+def visit(value):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key in {"serviceAccount", "serviceAccountName"} and isinstance(child, str):
+                values.append(child)
+            elif isinstance(child, (dict, list)):
+                visit(child)
+    elif isinstance(value, list):
+        for child in value:
+            visit(child)
+visit(root)
+values = sorted(set(values))
+if len(values) != 1:
+    raise SystemExit(f"job execution template exposes {len(values)} service accounts")
+print(values[0])
+'
+}
+
+verify_legacy_cloud_run_service_inventory() {
+  local inventory
+  local region
+  local service_name
+  local service_json
+  local revisions
+  local revision
+  local revision_json
+  inventory="$(cloud_run_inventory_lines services)" || return 1
+  while IFS=$'\t' read -r region service_name; do
+    [ -n "$service_name" ] || continue
+    service_json="$(gc run services describe "$service_name" \
+      --region="$region" --format=json)" || {
+      echo "ERROR: cannot inspect inventoried Cloud Run service ${region}/${service_name}" >&2
+      return 1
+    }
+    revisions="$(printf '%s' "$service_json" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+legacy = sys.argv[1]
+template = data.get("spec", {}).get("template", {})
+pod_spec = template.get("spec", template)
+if pod_spec.get("serviceAccountName") == legacy or pod_spec.get("serviceAccount") == legacy:
+    raise SystemExit("service template still names the legacy runtime identity")
+for item in data.get("status", {}).get("traffic", []) or []:
+    if int(item.get("percent", 0) or 0) <= 0:
+        continue
+    revision = item.get("revisionName")
+    if not revision:
+        raise SystemExit("serving traffic does not name an immutable revision")
+    print(revision)
+' "$RUN_SERVICE_ACCOUNT")" || {
+      echo "ERROR: legacy IAM retirement inventory rejected ${region}/${service_name}" >&2
+      return 1
+    }
+    while IFS= read -r revision; do
+      [ -n "$revision" ] || continue
+      revision_json="$(gc run revisions describe "$revision" \
+        --region="$region" --format=json)" || {
+        echo "ERROR: cannot inspect serving revision ${region}/${revision}" >&2
+        return 1
+      }
+      if ! printf '%s' "$revision_json" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+spec = data.get("spec", {})
+identity = spec.get("serviceAccountName") or spec.get("serviceAccount")
+if identity == sys.argv[1]:
+    raise SystemExit("serving revision still names the legacy runtime identity")
+' "$RUN_SERVICE_ACCOUNT"; then
+        echo "ERROR: cannot retire legacy IAM while ${region}/${revision} still serves" >&2
+        return 1
+      fi
+    done <<<"$revisions"
+  done <<<"$inventory"
+}
+
+verify_legacy_synthetic_jobs_ready() {
+  local expected_inventory
+  local actual_inventory
+  local expected_keys="|"
+  local seen_keys="|"
+  local region
+  local job_name
+  local scheduler_name
+  local key
+  local identity
+  local job_policy_json
+  local scheduler_json
+  local member="serviceAccount:${SYNTHETIC_RUN_SERVICE_ACCOUNT}"
+  expected_inventory="$(synthetic_job_inventory_lines)" || return 1
+  while IFS=$'\t' read -r region job_name scheduler_name; do
+    [ -n "$job_name" ] || continue
+    key="${region}/${job_name}"
+    case "$expected_keys" in
+      *"|${key}|"*)
+        echo "ERROR: synthetic job inventory repeats ${key}" >&2
+        return 1
+        ;;
+    esac
+    expected_keys="${expected_keys}${key}|"
+  done <<<"$expected_inventory"
+
+  actual_inventory="$(cloud_run_inventory_lines jobs)" || return 1
+  while IFS=$'\t' read -r region job_name; do
+    [ -n "$job_name" ] || continue
+    key="${region}/${job_name}"
+    identity="$(cloud_run_job_service_account "$job_name" "$region")" || return 1
+    if [ "$identity" = "$RUN_SERVICE_ACCOUNT" ]; then
+      echo "ERROR: Cloud Run job ${key} still uses legacy identity ${RUN_SERVICE_ACCOUNT}" >&2
+      return 1
+    fi
+    case "$expected_keys" in
+      *"|${key}|"*)
+        if [ "$identity" != "$SYNTHETIC_RUN_SERVICE_ACCOUNT" ]; then
+          echo "ERROR: canonical synthetic job ${key} uses ${identity}, expected ${SYNTHETIC_RUN_SERVICE_ACCOUNT}" >&2
+          return 1
+        fi
+        seen_keys="${seen_keys}${key}|"
+        ;;
+    esac
+  done <<<"$actual_inventory"
+
+  while IFS=$'\t' read -r region job_name scheduler_name; do
+    [ -n "$job_name" ] || continue
+    key="${region}/${job_name}"
+    case "$seen_keys" in
+      *"|${key}|"*) ;;
+      *)
+        echo "ERROR: canonical synthetic job ${key} is absent from the all-region inventory" >&2
+        return 1
+        ;;
+    esac
+    job_policy_json="$(gc run jobs get-iam-policy "$job_name" \
+      --region="$region" --format=json)" || {
+      echo "ERROR: cannot read canonical synthetic job IAM for ${key}" >&2
+      return 1
+    }
+    if ! printf '%s' "$job_policy_json" | python3 -c '
+import json
+import sys
+
+policy = json.load(sys.stdin)
+bindings = policy.get("bindings") or []
+if len(bindings) != 1:
+    raise SystemExit("synthetic job IAM binding inventory differs")
+binding = bindings[0]
+if binding.get("role") != "roles/run.invoker":
+    raise SystemExit("synthetic job IAM role differs")
+if binding.get("condition") is not None:
+    raise SystemExit("synthetic job invoker grant is conditional")
+members = binding.get("members") or []
+if members != [sys.argv[1]]:
+    raise SystemExit("synthetic job invoker inventory differs")
+' "$member"; then
+      echo "ERROR: canonical synthetic job ${key} must have only the dedicated synthetic invoker" >&2
+      return 1
+    fi
+    scheduler_json="$(gc scheduler jobs describe "$scheduler_name" \
+      --location="$region" --format=json)" || {
+      echo "ERROR: canonical synthetic scheduler ${region}/${scheduler_name} is absent" >&2
+      return 1
+    }
+    if ! printf '%s' "$scheduler_json" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+expected_identity, expected_uri = sys.argv[1:3]
+target = data.get("httpTarget", {}) or {}
+oauth = target.get("oauthToken", {}) or {}
+if oauth.get("serviceAccountEmail") != expected_identity:
+    raise SystemExit("scheduler OAuth identity is wrong")
+if target.get("uri") != expected_uri:
+    raise SystemExit("scheduler run URI is wrong")
+if str(target.get("httpMethod", "")).upper() != "POST":
+    raise SystemExit("scheduler HTTP method is not POST")
+if str(data.get("state", "")).upper() != "ENABLED":
+    raise SystemExit("scheduler is not enabled")
+' "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
+      "https://${region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${PROJECT_ID}/jobs/${job_name}:run"; then
+      echo "ERROR: canonical synthetic scheduler ${region}/${scheduler_name} is unsafe" >&2
+      return 1
+    fi
+  done <<<"$expected_inventory"
+}
+
+describe_iam_role_definition() {
+  local role="$1"
+  local scope
+  local role_id
+  case "$role" in
+    roles/*)
+      gc iam roles describe "$role" --format=json
+      ;;
+    projects/*/roles/*)
+      scope="${role#projects/}"
+      scope="${scope%%/roles/*}"
+      role_id="${role##*/}"
+      if [ "$scope" != "$PROJECT_ID" ]; then
+        echo "ERROR: project policy references custom role from unexpected project ${scope}" >&2
+        return 1
+      fi
+      gc iam roles describe "$role_id" --format=json
+      ;;
+    organizations/*/roles/*)
+      scope="${role#organizations/}"
+      scope="${scope%%/roles/*}"
+      role_id="${role##*/}"
+      gcloud --billing-project "$PROJECT_ID" iam roles describe "$role_id" \
+        --organization="$scope" --format=json
+      ;;
+    *)
+      echo "ERROR: cannot resolve IAM role definition ${role}" >&2
+      return 1
+      ;;
+  esac
+}
+
+verify_deploy_identity_has_no_project_data_roles() {
+  local member="serviceAccount:${DEPLOY_SERVICE_ACCOUNT}"
+  local tokens
+  local token
+  local role
+  local role_json
+  verify_no_direct_roles \
+    "project" \
+    "$member" \
+    "roles/secretmanager.secretAccessor,roles/secretmanager.admin,roles/spanner.databaseReader,roles/spanner.databaseUser,roles/bigtable.reader,roles/bigtable.user,roles/aiplatform.user,roles/cloudkms.cryptoKeyEncrypter,roles/cloudkms.cryptoKeyDecrypter,roles/cloudkms.cryptoKeyEncrypterDecrypter,roles/iam.serviceAccountUser,roles/iam.serviceAccountTokenCreator,roles/editor,roles/owner" \
+    gc projects get-iam-policy "$PROJECT_ID"
+  tokens="$(iam_direct_binding_tokens_for_member "$member" \
+    gc projects get-iam-policy "$PROJECT_ID")" || {
+    echo "ERROR: cannot inventory deploy identity project roles" >&2
+    return 1
+  }
+  while IFS= read -r token; do
+    [ -n "$token" ] || continue
+    role="${token#conditional:}"
+    role_json="$(describe_iam_role_definition "$role")" || {
+      echo "ERROR: cannot audit permissions in deploy identity role ${role}" >&2
+      return 1
+    }
+    if ! printf '%s' "$role_json" | python3 -c '
+import json
+import sys
+
+role = json.load(sys.stdin)
+forbidden = {
+    "iam.serviceAccounts.actAs",
+    "iam.serviceAccounts.getAccessToken",
+    "secretmanager.versions.access",
+    "spanner.databases.read",
+    "spanner.databases.write",
+    "spanner.sessions.create",
+    "bigtable.tables.readRows",
+    "bigtable.tables.mutateRows",
+    "cloudkms.cryptoKeyVersions.useToDecrypt",
+    "cloudkms.cryptoKeyVersions.useToEncrypt",
+    "aiplatform.endpoints.predict",
+}
+present = sorted(forbidden.intersection(role.get("includedPermissions", []) or []))
+if present:
+    raise SystemExit("forbidden permissions: " + ",".join(present))
+'; then
+      echo "ERROR: deploy identity role ${role} contains actAs, token-minting, or runtime data permissions" >&2
+      return 1
+    fi
+  done <<<"$tokens"
+}
+
+preflight_identity_iam_removal_targets() {
+  local label="$1"
+  local service_account="$2"
+  local member="serviceAccount:${service_account}"
+  local project_roles="roles/secretmanager.secretAccessor,roles/spanner.databaseReader,roles/spanner.databaseUser,roles/bigtable.reader,roles/bigtable.user,roles/aiplatform.user,roles/run.developer,roles/serviceusage.serviceUsageConsumer,roles/editor,roles/owner"
+  local database_roles="roles/spanner.databaseReader,roles/spanner.databaseUser"
+  local bigtable_roles="roles/bigtable.reader,roles/bigtable.user"
+  local kms_roles="roles/cloudkms.cryptoKeyEncrypter,roles/cloudkms.cryptoKeyDecrypter,roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  local key_id
+
+  preflight_reconcilable_direct_roles \
+    "${label} project" "$member" "$project_roles" \
+    gc projects get-iam-policy "$PROJECT_ID"
+  verify_exact_unconditional_roles \
+    "${label} Spanner instance" "$member" "" \
+    gc spanner instances get-iam-policy "$SPANNER_INSTANCE_ID"
+  preflight_reconcilable_direct_roles \
+    "${label} Spanner database" "$member" "$database_roles" \
+    gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID"
+  preflight_reconcilable_direct_roles \
+    "${label} Bigtable instance" "$member" "$bigtable_roles" \
+    gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID"
+  verify_exact_unconditional_roles \
+    "${label} Bigtable generation table" "$member" "" \
+    gc bigtable tables get-iam-policy "$BIGTABLE_GENERATION_TABLE" \
+    --instance="$BIGTABLE_INSTANCE_ID"
+  verify_exact_unconditional_roles \
+    "${label} KMS key ring" "$member" "" \
+    gc kms keyrings get-iam-policy "$KMS_KEYRING_ID" --location="$REGION"
+  for key_id in "$BYOK_KMS_KEY_ID" "$GOOGLE_ADS_KMS_KEY_ID"; do
+    preflight_reconcilable_direct_roles \
+      "${label} KMS key ${key_id}" "$member" "$kms_roles" \
+      gc kms keys get-iam-policy "$key_id" \
+      --keyring="$KMS_KEYRING_ID" --location="$REGION"
+  done
+}
+
+verify_identity_ancestor_scopes_empty() {
+  local label="$1"
+  local service_account="$2"
+  local member="serviceAccount:${service_account}"
+  verify_exact_unconditional_roles \
+    "${label} Spanner instance" "$member" "" \
+    gc spanner instances get-iam-policy "$SPANNER_INSTANCE_ID"
+  verify_exact_unconditional_roles \
+    "${label} Bigtable generation table" "$member" "" \
+    gc bigtable tables get-iam-policy "$BIGTABLE_GENERATION_TABLE" \
+    --instance="$BIGTABLE_INSTANCE_ID"
+  verify_exact_unconditional_roles \
+    "${label} KMS key ring" "$member" "" \
+    gc kms keyrings get-iam-policy "$KMS_KEYRING_ID" --location="$REGION"
+}
+
+verify_deploy_actas_inventory() {
+  local google_data_manager_service_account="$1"
+  local phase="${2:-post}"
+  local deploy_member="serviceAccount:${DEPLOY_SERVICE_ACCOUNT}"
+  local allowed="|"
+  local seen="|"
+  local accounts_json
+  local accounts
+  local service_account
+  local expected
+  local bindings
+  local runtime_policy
+
+  case "$phase" in
+    preflight|post) ;;
+    *)
+      echo "ERROR: unknown deploy actAs audit phase ${phase}" >&2
+      return 1
+      ;;
+  esac
+
+  for service_account in \
+    "${RUNTIME_SERVICE_ACCOUNTS[@]}" \
+    "$google_data_manager_service_account" \
+    "$SYNTHETIC_RUN_SERVICE_ACCOUNT"; do
+    allowed="${allowed}${service_account}|"
+  done
+  accounts_json="$(gc iam service-accounts list --format=json)" || {
+    echo "ERROR: cannot inventory project service accounts for deploy actAs audit" >&2
+    return 1
+  }
+  accounts="$(printf '%s' "$accounts_json" | python3 -c '
+import json
+import sys
+
+items = json.load(sys.stdin)
+if not isinstance(items, list):
+    raise SystemExit("service-account inventory is not a list")
+emails = []
+for item in items:
+    email = item.get("email")
+    if not isinstance(email, str) or not email:
+        raise SystemExit("service-account inventory entry has no email")
+    emails.append(email)
+if len(set(emails)) != len(emails):
+    raise SystemExit("service-account inventory contains duplicate emails")
+print("\n".join(sorted(emails)))
+')" || {
+    echo "ERROR: malformed project service-account inventory" >&2
+    return 1
+  }
+  while IFS= read -r service_account; do
+    [ -n "$service_account" ] || continue
+    case "$allowed" in
+      *"|${service_account}|"*)
+        expected="roles/iam.serviceAccountUser"
+        seen="${seen}${service_account}|"
+        ;;
+      *) expected="" ;;
+    esac
+    if is_runtime_service_account "$service_account"; then
+      runtime_policy="$(gc iam service-accounts get-iam-policy \
+        "$service_account" --format=json)" || {
+        echo "ERROR: cannot read complete runtime service-account policy ${service_account}" >&2
+        return 1
+      }
+      if ! printf '%s' "$runtime_policy" | \
+          verify_runtime_service_account_policy_json \
+            "$service_account" "$phase"; then
+        echo "ERROR: unsafe direct IAM policy on runtime service account ${service_account}" >&2
+        return 1
+      fi
+      continue
+    fi
+    if [ "$phase" = "preflight" ] && [ -n "$expected" ]; then
+      bindings="$(iam_direct_binding_tokens_for_member "$deploy_member" \
+        gc iam service-accounts get-iam-policy "$service_account")" || {
+        echo "ERROR: cannot preflight deploy identity access on ${service_account}" >&2
+        return 1
+      }
+      if [ -n "$bindings" ] && [ "$bindings" != "$expected" ]; then
+        echo "ERROR: deploy identity has unsafe preexisting bindings on ${service_account}: ${bindings}" >&2
+        return 1
+      fi
+    else
+      verify_exact_unconditional_roles \
+        "deploy identity access on service account ${service_account}" \
+        "$deploy_member" "$expected" \
+        gc iam service-accounts get-iam-policy "$service_account"
+    fi
+  done <<<"$accounts"
+  for service_account in \
+    "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do
+    case "$seen" in
+      *"|${service_account}|"*) ;;
+      *)
+        echo "ERROR: actAs target ${service_account} is absent from service-account inventory" >&2
+        return 1
+        ;;
+    esac
+  done
+  case "$seen" in
+    *"|${SYNTHETIC_RUN_SERVICE_ACCOUNT}|"*) ;;
+    *)
+      echo "ERROR: approved synthetic actAs target ${SYNTHETIC_RUN_SERVICE_ACCOUNT} is absent from service-account inventory" >&2
+      return 1
+      ;;
+  esac
+  if [ "$phase" = "post" ]; then
+    case "$seen" in
+      *"|${google_data_manager_service_account}|"*) ;;
+      *)
+        echo "ERROR: actAs target ${google_data_manager_service_account} is absent from service-account inventory" >&2
+        return 1
+        ;;
+    esac
+  fi
+  verify_deploy_identity_has_no_project_data_roles
+}
+
 log "enabling required GCP APIs"
 gc services enable \
   artifactregistry.googleapis.com \
+  iam.googleapis.com \
   run.googleapis.com \
   secretmanager.googleapis.com \
   cloudscheduler.googleapis.com \
@@ -17,6 +1111,15 @@ gc services enable \
   spanner.googleapis.com \
   bigtableadmin.googleapis.com \
   cloudbuild.googleapis.com
+
+log "ensuring six dedicated Cloud Run runtime identities and synthetic Job identity"
+ensure_runtime_service_account "$PUBLIC_RUN_SERVICE_ACCOUNT" "TrustedRouter public web"
+ensure_runtime_service_account "$ACTIONS_RUN_SERVICE_ACCOUNT" "TrustedRouter anonymous actions"
+ensure_runtime_service_account "$CONSOLE_RUN_SERVICE_ACCOUNT" "TrustedRouter console"
+ensure_runtime_service_account "$CHAT_RUN_SERVICE_ACCOUNT" "TrustedRouter chat proxy"
+ensure_runtime_service_account "$WEBHOOKS_RUN_SERVICE_ACCOUNT" "TrustedRouter webhooks"
+ensure_runtime_service_account "$INTERNAL_RUN_SERVICE_ACCOUNT" "TrustedRouter internal billing"
+ensure_runtime_service_account "$SYNTHETIC_RUN_SERVICE_ACCOUNT" "TrustedRouter synthetic jobs"
 
 log "ensuring Spanner instance/database"
 if ! gc spanner instances describe "$SPANNER_INSTANCE_ID" >/dev/null 2>&1; then
@@ -65,7 +1168,6 @@ fi
 # Keep that capability table-scoped and separate from row-data access.
 BIGTABLE_SCHEMA_ROLE_ID="${TR_BIGTABLE_SCHEMA_ROLE_ID:-trustedRouterBigtableSchemaManager}"
 BIGTABLE_SCHEMA_ROLE="projects/${PROJECT_ID}/roles/${BIGTABLE_SCHEMA_ROLE_ID}"
-DEPLOY_SERVICE_ACCOUNT="${TR_DEPLOY_SERVICE_ACCOUNT:-tr-deploy@${PROJECT_ID}.iam.gserviceaccount.com}"
 OPS_SERVICE_ACCOUNT="${TR_OPS_SERVICE_ACCOUNT:-tr-ops-local@${PROJECT_ID}.iam.gserviceaccount.com}"
 if ! gc iam roles describe "$BIGTABLE_SCHEMA_ROLE_ID" >/dev/null 2>&1; then
   gc iam roles create "$BIGTABLE_SCHEMA_ROLE_ID" \
@@ -94,12 +1196,6 @@ if ! gc kms keys describe "$BYOK_KMS_KEY_ID" \
     --location "$REGION" \
     --purpose=encryption
 fi
-gc kms keys add-iam-policy-binding "$BYOK_KMS_KEY_ID" \
-  --keyring "$KMS_KEYRING_ID" \
-  --location "$REGION" \
-  --member="serviceAccount:${RUN_SERVICE_ACCOUNT}" \
-  --role="roles/cloudkms.cryptoKeyEncrypter" \
-  --quiet >/dev/null
 
 # Google Ads click identifiers use a separate envelope key. The conversion
 # worker can unwrap this key but never receives permission to unwrap BYOK keys.
@@ -110,28 +1206,406 @@ if ! gc kms keys describe "$GOOGLE_ADS_KMS_KEY_ID" \
     --location "$REGION" \
     --purpose=encryption
 fi
+
+# Inventory every direct binding that the reconciliation code can touch before
+# its first removal. This makes drift a no-mutation failure instead of leaving
+# the first few identities partially stripped when a later target surprises us.
+log "preflighting all runtime IAM removal targets and direct ancestor policies"
+if [ "$TR_RETIRE_LEGACY_RUN_SERVICE_ACCOUNT_IAM" = "1" ]; then
+  verify_synthetic_retirement_identity_ready
+fi
+verify_deploy_actas_inventory "$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT" preflight
+verify_synthetic_service_account_policy preflight
+verify_synthetic_data_iam_empty
+for service_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do
+  preflight_identity_iam_removal_targets "split runtime" "$service_account"
+done
+if [ "$TR_RETIRE_LEGACY_RUN_SERVICE_ACCOUNT_IAM" = "1" ]; then
+  log "preflighting complete Cloud Run inventory before legacy IAM retirement"
+  verify_legacy_runtime_retirement_ready
+  verify_legacy_cloud_run_service_inventory
+  verify_legacy_synthetic_secret_access_ready
+  verify_legacy_synthetic_jobs_ready
+  preflight_identity_iam_removal_targets "legacy runtime" "$RUN_SERVICE_ACCOUNT"
+fi
+
+# Install and verify every desired six-runtime grant before removing a live
+# obsolete grant on the same resource. IAM propagation can lag a successful
+# setIamPolicy response, so a remove-then-add transition creates a real serving
+# outage even when the final matrix is correct.
+log "granting and verifying desired runtime IAM before obsolete-role cleanup"
 gc kms keys add-iam-policy-binding "$GOOGLE_ADS_KMS_KEY_ID" \
   --keyring "$KMS_KEYRING_ID" \
   --location "$REGION" \
-  --member="serviceAccount:${RUN_SERVICE_ACCOUNT}" \
+  --member="serviceAccount:${CONSOLE_RUN_SERVICE_ACCOUNT}" \
   --role="roles/cloudkms.cryptoKeyEncrypter" \
   --quiet >/dev/null
+verify_resource_role_present \
+  "Google Ads KMS key" "serviceAccount:${CONSOLE_RUN_SERVICE_ACCOUNT}" \
+  "roles/cloudkms.cryptoKeyEncrypter" \
+  gc kms keys get-iam-policy "$GOOGLE_ADS_KMS_KEY_ID" \
+  --keyring="$KMS_KEYRING_ID" --location="$REGION"
 
-# Runtime-SA project-level role grants. These call projects.setIamPolicy
-# and need roles/resourcemanager.projectIamAdmin on the caller, so they
-# must run as a project Owner — not as tr-deploy@ (which secrets.sh and
-# rollout.sh use). Idempotent: gcloud no-ops if the binding already exists.
-log "ensuring runtime IAM for ${RUN_SERVICE_ACCOUNT}"
-ensure_project_role "serviceAccount:${RUN_SERVICE_ACCOUNT}" "roles/secretmanager.secretAccessor"
-ensure_project_role "serviceAccount:${RUN_SERVICE_ACCOUNT}" "roles/spanner.databaseUser"
-ensure_project_role "serviceAccount:${RUN_SERVICE_ACCOUNT}" "roles/bigtable.user"
-ensure_project_role "serviceAccount:${RUN_SERVICE_ACCOUNT}" "roles/aiplatform.user"
+for service_account in \
+  "$PUBLIC_RUN_SERVICE_ACCOUNT" \
+  "$CONSOLE_RUN_SERVICE_ACCOUNT" \
+  "$CHAT_RUN_SERVICE_ACCOUNT" \
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT" \
+  "$INTERNAL_RUN_SERVICE_ACCOUNT"; do
+  member="serviceAccount:${service_account}"
+  ensure_project_role "$member" "roles/serviceusage.serviceUsageConsumer"
+  verify_resource_role_present \
+    "project" "$member" "roles/serviceusage.serviceUsageConsumer" \
+    gc projects get-iam-policy "$PROJECT_ID"
+done
+
+for service_account in "$PUBLIC_RUN_SERVICE_ACCOUNT" "$CHAT_RUN_SERVICE_ACCOUNT"; do
+  member="serviceAccount:${service_account}"
+  gc spanner databases add-iam-policy-binding "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID" \
+    --member="$member" \
+    --role="roles/spanner.databaseReader" \
+    --quiet >/dev/null
+  verify_resource_role_present \
+    "Spanner database" "$member" "roles/spanner.databaseReader" \
+    gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID"
+done
+for service_account in \
+  "$CONSOLE_RUN_SERVICE_ACCOUNT" \
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT" \
+  "$INTERNAL_RUN_SERVICE_ACCOUNT"; do
+  member="serviceAccount:${service_account}"
+  gc spanner databases add-iam-policy-binding "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID" \
+    --member="$member" \
+    --role="roles/spanner.databaseUser" \
+    --quiet >/dev/null
+  verify_resource_role_present \
+    "Spanner database" "$member" "roles/spanner.databaseUser" \
+    gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID"
+done
+
+for service_account in "$PUBLIC_RUN_SERVICE_ACCOUNT" "$CONSOLE_RUN_SERVICE_ACCOUNT"; do
+  member="serviceAccount:${service_account}"
+  gc bigtable instances add-iam-policy-binding "$BIGTABLE_INSTANCE_ID" \
+    --member="$member" \
+    --role="roles/bigtable.reader" \
+    --quiet >/dev/null
+  verify_resource_role_present \
+    "Bigtable instance" "$member" "roles/bigtable.reader" \
+    gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID"
+done
+member="serviceAccount:${INTERNAL_RUN_SERVICE_ACCOUNT}"
+gc bigtable instances add-iam-policy-binding "$BIGTABLE_INSTANCE_ID" \
+  --member="$member" \
+  --role="roles/bigtable.user" \
+  --quiet >/dev/null
+verify_resource_role_present \
+  "Bigtable instance" "$member" "roles/bigtable.user" \
+  gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID"
+
+gc kms keys add-iam-policy-binding "$BYOK_KMS_KEY_ID" \
+  --keyring="$KMS_KEYRING_ID" \
+  --location="$REGION" \
+  --member="serviceAccount:${CONSOLE_RUN_SERVICE_ACCOUNT}" \
+  --role="roles/cloudkms.cryptoKeyEncrypterDecrypter" \
+  --quiet >/dev/null
+verify_resource_role_present \
+  "BYOK KMS key" "serviceAccount:${CONSOLE_RUN_SERVICE_ACCOUNT}" \
+  "roles/cloudkms.cryptoKeyEncrypterDecrypter" \
+  gc kms keys get-iam-policy "$BYOK_KMS_KEY_ID" \
+  --keyring="$KMS_KEYRING_ID" --location="$REGION"
+gc kms keys add-iam-policy-binding "$BYOK_KMS_KEY_ID" \
+  --keyring="$KMS_KEYRING_ID" \
+  --location="$REGION" \
+  --member="serviceAccount:${INTERNAL_RUN_SERVICE_ACCOUNT}" \
+  --role="roles/cloudkms.cryptoKeyDecrypter" \
+  --quiet >/dev/null
+verify_resource_role_present \
+  "BYOK KMS key" "serviceAccount:${INTERNAL_RUN_SERVICE_ACCOUNT}" \
+  "roles/cloudkms.cryptoKeyDecrypter" \
+  gc kms keys get-iam-policy "$BYOK_KMS_KEY_ID" \
+  --keyring="$KMS_KEYRING_ID" --location="$REGION"
+
+for service_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do
+  member="serviceAccount:${service_account}"
+  for role in \
+    roles/cloudkms.cryptoKeyEncrypter \
+    roles/cloudkms.cryptoKeyDecrypter \
+    roles/cloudkms.cryptoKeyEncrypterDecrypter; do
+    if [ "$service_account" = "$CONSOLE_RUN_SERVICE_ACCOUNT" ] && \
+       [ "$role" = "roles/cloudkms.cryptoKeyEncrypter" ]; then
+      continue
+    fi
+    remove_kms_role_if_present "$member" "$role" "$GOOGLE_ADS_KMS_KEY_ID"
+  done
+done
+verify_only_resource_role \
+  "Google Ads KMS key" "serviceAccount:${CONSOLE_RUN_SERVICE_ACCOUNT}" \
+  "roles/cloudkms.cryptoKeyEncrypter" \
+  gc kms keys get-iam-policy "$GOOGLE_ADS_KMS_KEY_ID" \
+  --keyring="$KMS_KEYRING_ID" --location="$REGION"
+for service_account in \
+  "$PUBLIC_RUN_SERVICE_ACCOUNT" \
+  "$ACTIONS_RUN_SERVICE_ACCOUNT" \
+  "$CHAT_RUN_SERVICE_ACCOUNT" \
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT" \
+  "$INTERNAL_RUN_SERVICE_ACCOUNT"; do
+  verify_only_resource_role \
+    "Google Ads KMS key" "serviceAccount:${service_account}" "" \
+    gc kms keys get-iam-policy "$GOOGLE_ADS_KMS_KEY_ID" \
+    --keyring="$KMS_KEYRING_ID" --location="$REGION"
+done
+
+# Cloud Run role isolation. Data roles bind directly to the one database,
+# Bigtable instance, or KMS key. Owner-provisioned direct secret access is
+# verified per resource by secrets.sh. The only project-level runtime role
+# retained here is the non-data service-usage permission required to call
+# enabled Google APIs.
+log "removing broad legacy and split-runtime project data roles"
+for service_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do
+  member="serviceAccount:${service_account}"
+  remove_project_role_if_present "$member" "roles/secretmanager.secretAccessor"
+  remove_project_role_if_present "$member" "roles/spanner.databaseReader"
+  remove_project_role_if_present "$member" "roles/spanner.databaseUser"
+  remove_project_role_if_present "$member" "roles/bigtable.reader"
+  remove_project_role_if_present "$member" "roles/bigtable.user"
+  remove_project_role_if_present "$member" "roles/aiplatform.user"
+  remove_project_role_if_present "$member" "roles/run.developer"
+  if [ "$service_account" = "$ACTIONS_RUN_SERVICE_ACCOUNT" ]; then
+    remove_project_role_if_present "$member" "roles/serviceusage.serviceUsageConsumer"
+  fi
+  remove_project_role_if_present "$member" "roles/editor"
+  remove_project_role_if_present "$member" "roles/owner"
+  expected_spanner_role=""
+  case "$service_account" in
+    "$PUBLIC_RUN_SERVICE_ACCOUNT"|"$CHAT_RUN_SERVICE_ACCOUNT")
+      expected_spanner_role="roles/spanner.databaseReader"
+      remove_spanner_role_if_present "$member" "roles/spanner.databaseUser"
+      ;;
+    "$CONSOLE_RUN_SERVICE_ACCOUNT"|"$WEBHOOKS_RUN_SERVICE_ACCOUNT"|"$INTERNAL_RUN_SERVICE_ACCOUNT")
+      expected_spanner_role="roles/spanner.databaseUser"
+      remove_spanner_role_if_present "$member" "roles/spanner.databaseReader"
+      ;;
+    "$ACTIONS_RUN_SERVICE_ACCOUNT")
+      remove_spanner_role_if_present "$member" "roles/spanner.databaseReader"
+      remove_spanner_role_if_present "$member" "roles/spanner.databaseUser"
+      ;;
+  esac
+  verify_only_resource_role \
+    "Spanner database" "$member" "$expected_spanner_role" \
+    gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID"
+  expected_bigtable_role=""
+  case "$service_account" in
+    "$PUBLIC_RUN_SERVICE_ACCOUNT"|"$CONSOLE_RUN_SERVICE_ACCOUNT")
+      expected_bigtable_role="roles/bigtable.reader"
+      remove_bigtable_role_if_present "$member" "roles/bigtable.user"
+      ;;
+    "$INTERNAL_RUN_SERVICE_ACCOUNT")
+      expected_bigtable_role="roles/bigtable.user"
+      remove_bigtable_role_if_present "$member" "roles/bigtable.reader"
+      ;;
+    "$ACTIONS_RUN_SERVICE_ACCOUNT"|"$CHAT_RUN_SERVICE_ACCOUNT"|"$WEBHOOKS_RUN_SERVICE_ACCOUNT")
+      remove_bigtable_role_if_present "$member" "roles/bigtable.reader"
+      remove_bigtable_role_if_present "$member" "roles/bigtable.user"
+      ;;
+  esac
+  verify_only_resource_role \
+    "Bigtable instance" "$member" "$expected_bigtable_role" \
+    gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID"
+  expected_project_role="roles/serviceusage.serviceUsageConsumer"
+  if [ "$service_account" = "$ACTIONS_RUN_SERVICE_ACCOUNT" ]; then
+    expected_project_role=""
+  fi
+  verify_only_resource_role \
+    "project" "$member" "$expected_project_role" \
+    gc projects get-iam-policy "$PROJECT_ID"
+done
+if [ "$TR_RETIRE_LEGACY_RUN_SERVICE_ACCOUNT_IAM" = "1" ]; then
+  member="serviceAccount:${RUN_SERVICE_ACCOUNT}"
+  remove_project_role_if_present "$member" "roles/secretmanager.secretAccessor"
+  remove_project_role_if_present "$member" "roles/spanner.databaseReader"
+  remove_project_role_if_present "$member" "roles/spanner.databaseUser"
+  remove_project_role_if_present "$member" "roles/bigtable.reader"
+  remove_project_role_if_present "$member" "roles/bigtable.user"
+  remove_project_role_if_present "$member" "roles/aiplatform.user"
+  remove_project_role_if_present "$member" "roles/run.developer"
+  remove_project_role_if_present "$member" "roles/serviceusage.serviceUsageConsumer"
+  remove_project_role_if_present "$member" "roles/editor"
+  remove_project_role_if_present "$member" "roles/owner"
+  remove_spanner_role_if_present "$member" "roles/spanner.databaseReader"
+  remove_spanner_role_if_present "$member" "roles/spanner.databaseUser"
+  verify_only_resource_role \
+    "retired Spanner database" "$member" "" \
+    gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID"
+  remove_bigtable_role_if_present "$member" "roles/bigtable.reader"
+  remove_bigtable_role_if_present "$member" "roles/bigtable.user"
+  verify_only_resource_role \
+    "retired Bigtable instance" "$member" "" \
+    gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID"
+  for key_id in "$BYOK_KMS_KEY_ID" "$GOOGLE_ADS_KMS_KEY_ID"; do
+    for role in \
+      roles/cloudkms.cryptoKeyEncrypter \
+      roles/cloudkms.cryptoKeyDecrypter \
+      roles/cloudkms.cryptoKeyEncrypterDecrypter; do
+      remove_kms_role_if_present "$member" "$role" "$key_id"
+    done
+    verify_only_resource_role \
+      "retired ${key_id} KMS key" "$member" "" \
+      gc kms keys get-iam-policy "$key_id" \
+      --keyring="$KMS_KEYRING_ID" --location="$REGION"
+  done
+  verify_identity_ancestor_scopes_empty "retired legacy runtime" "$RUN_SERVICE_ACCOUNT"
+  verify_only_resource_role \
+    "retired project" "$member" "" \
+    gc projects get-iam-policy "$PROJECT_ID"
+else
+  log "legacy runtime IAM retirement deferred until combined traffic is zero"
+fi
+
+for service_account in \
+  "$PUBLIC_RUN_SERVICE_ACCOUNT" \
+  "$CONSOLE_RUN_SERVICE_ACCOUNT" \
+  "$CHAT_RUN_SERVICE_ACCOUNT" \
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT" \
+  "$INTERNAL_RUN_SERVICE_ACCOUNT"; do
+  ensure_project_role \
+    "serviceAccount:${service_account}" \
+    "roles/serviceusage.serviceUsageConsumer"
+done
+for service_account in \
+  "$PUBLIC_RUN_SERVICE_ACCOUNT" \
+  "$CONSOLE_RUN_SERVICE_ACCOUNT" \
+  "$CHAT_RUN_SERVICE_ACCOUNT" \
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT" \
+  "$INTERNAL_RUN_SERVICE_ACCOUNT"; do
+  verify_only_resource_role \
+    "project" \
+    "serviceAccount:${service_account}" \
+    "roles/serviceusage.serviceUsageConsumer" \
+    gc projects get-iam-policy "$PROJECT_ID"
+done
+verify_only_resource_role \
+  "project" \
+  "serviceAccount:${ACTIONS_RUN_SERVICE_ACCOUNT}" \
+  "" \
+  gc projects get-iam-policy "$PROJECT_ID"
+
+log "granting deploy identity actAs on exactly six runtime identities"
+for service_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do
+  gc iam service-accounts add-iam-policy-binding "$service_account" \
+    --member="serviceAccount:${DEPLOY_SERVICE_ACCOUNT}" \
+    --role="roles/iam.serviceAccountUser" \
+    --quiet >/dev/null
+  verify_only_resource_role \
+    "runtime service-account actAs" \
+    "serviceAccount:${DEPLOY_SERVICE_ACCOUNT}" \
+    "roles/iam.serviceAccountUser" \
+    gc iam service-accounts get-iam-policy "$service_account"
+done
+gc iam service-accounts add-iam-policy-binding "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
+  --member="serviceAccount:${DEPLOY_SERVICE_ACCOUNT}" \
+  --role="roles/iam.serviceAccountUser" \
+  --condition=None \
+  --quiet >/dev/null
+verify_synthetic_service_account_policy post
+verify_synthetic_data_iam_empty
+
+log "post-verifying database-scoped Spanner access"
+
+verify_only_resource_role \
+  "Spanner database" "serviceAccount:${PUBLIC_RUN_SERVICE_ACCOUNT}" \
+  "roles/spanner.databaseReader" \
+  gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+  --instance="$SPANNER_INSTANCE_ID"
+verify_only_resource_role \
+  "Spanner database" "serviceAccount:${CHAT_RUN_SERVICE_ACCOUNT}" \
+  "roles/spanner.databaseReader" \
+  gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+  --instance="$SPANNER_INSTANCE_ID"
+for service_account in \
+  "$CONSOLE_RUN_SERVICE_ACCOUNT" \
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT" \
+  "$INTERNAL_RUN_SERVICE_ACCOUNT"; do
+  verify_only_resource_role \
+    "Spanner database" "serviceAccount:${service_account}" \
+    "roles/spanner.databaseUser" \
+    gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+    --instance="$SPANNER_INSTANCE_ID"
+done
+verify_only_resource_role \
+  "Spanner database" "serviceAccount:${ACTIONS_RUN_SERVICE_ACCOUNT}" "" \
+  gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+  --instance="$SPANNER_INSTANCE_ID"
+
+log "post-verifying instance-scoped Bigtable access"
+verify_only_resource_role \
+  "Bigtable instance" "serviceAccount:${PUBLIC_RUN_SERVICE_ACCOUNT}" \
+  "roles/bigtable.reader" \
+  gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID"
+verify_only_resource_role \
+  "Bigtable instance" "serviceAccount:${CONSOLE_RUN_SERVICE_ACCOUNT}" \
+  "roles/bigtable.reader" \
+  gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID"
+verify_only_resource_role \
+  "Bigtable instance" "serviceAccount:${INTERNAL_RUN_SERVICE_ACCOUNT}" \
+  "roles/bigtable.user" \
+  gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID"
+for service_account in \
+  "$ACTIONS_RUN_SERVICE_ACCOUNT" \
+  "$CHAT_RUN_SERVICE_ACCOUNT" \
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT"; do
+  verify_only_resource_role \
+    "Bigtable instance" "serviceAccount:${service_account}" "" \
+    gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID"
+done
+
+log "reconciling key-scoped BYOK KMS access"
+for service_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do
+  member="serviceAccount:${service_account}"
+  for role in \
+    roles/cloudkms.cryptoKeyEncrypter \
+    roles/cloudkms.cryptoKeyDecrypter \
+    roles/cloudkms.cryptoKeyEncrypterDecrypter; do
+    if [ "$service_account" = "$CONSOLE_RUN_SERVICE_ACCOUNT" ] && \
+       [ "$role" = "roles/cloudkms.cryptoKeyEncrypterDecrypter" ]; then
+      continue
+    fi
+    if [ "$service_account" = "$INTERNAL_RUN_SERVICE_ACCOUNT" ] && \
+       [ "$role" = "roles/cloudkms.cryptoKeyDecrypter" ]; then
+      continue
+    fi
+    remove_kms_role_if_present "$member" "$role"
+  done
+done
+verify_only_resource_role \
+  "BYOK KMS key" "serviceAccount:${CONSOLE_RUN_SERVICE_ACCOUNT}" \
+  "roles/cloudkms.cryptoKeyEncrypterDecrypter" \
+  gc kms keys get-iam-policy "$BYOK_KMS_KEY_ID" \
+  --keyring="$KMS_KEYRING_ID" --location="$REGION"
+verify_only_resource_role \
+  "BYOK KMS key" "serviceAccount:${INTERNAL_RUN_SERVICE_ACCOUNT}" \
+  "roles/cloudkms.cryptoKeyDecrypter" \
+  gc kms keys get-iam-policy "$BYOK_KMS_KEY_ID" \
+  --keyring="$KMS_KEYRING_ID" --location="$REGION"
+for service_account in \
+  "$PUBLIC_RUN_SERVICE_ACCOUNT" \
+  "$ACTIONS_RUN_SERVICE_ACCOUNT" \
+  "$CHAT_RUN_SERVICE_ACCOUNT" \
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT"; do
+  verify_only_resource_role \
+    "BYOK KMS key" "serviceAccount:${service_account}" "" \
+    gc kms keys get-iam-policy "$BYOK_KMS_KEY_ID" \
+    --keyring="$KMS_KEYRING_ID" --location="$REGION"
+done
 
 # Metadata-only Google Ads conversion worker. It can read the durable Spanner
 # outbox and unwrap only the dedicated Google-click envelope key. It has no
 # Bigtable, Secret Manager, provider-key, or BYOK-key decrypt permission.
-GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT_ID="${TR_GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT_ID:-tr-google-data-manager}"
-GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT="${GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT_ID}@${PROJECT_ID}.iam.gserviceaccount.com"
 if ! gc iam service-accounts describe \
   "$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT" >/dev/null 2>&1; then
   gc iam service-accounts create "$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT_ID" \
@@ -139,9 +1613,20 @@ if ! gc iam service-accounts describe \
     --description="Uploads encrypted-click signup, activation, and purchase conversions to Google Ads" \
     --quiet
 fi
-ensure_project_role \
+remove_project_role_if_present \
   "serviceAccount:${GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT}" \
   "roles/spanner.databaseUser"
+gc spanner databases add-iam-policy-binding "$SPANNER_DATABASE_ID" \
+  --instance="$SPANNER_INSTANCE_ID" \
+  --member="serviceAccount:${GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT}" \
+  --role="roles/spanner.databaseUser" \
+  --quiet >/dev/null
+verify_only_resource_role \
+  "Spanner database" \
+  "serviceAccount:${GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT}" \
+  "roles/spanner.databaseUser" \
+  gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+  --instance="$SPANNER_INSTANCE_ID"
 ensure_project_role \
   "serviceAccount:${GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT}" \
   "roles/serviceusage.serviceUsageConsumer"
@@ -151,6 +1636,32 @@ gc kms keys add-iam-policy-binding "$GOOGLE_ADS_KMS_KEY_ID" \
   --member="serviceAccount:${GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT}" \
   --role="roles/cloudkms.cryptoKeyDecrypter" \
   --quiet >/dev/null
+verify_only_resource_role \
+  "Google Ads KMS key" \
+  "serviceAccount:${CONSOLE_RUN_SERVICE_ACCOUNT}" \
+  "roles/cloudkms.cryptoKeyEncrypter" \
+  gc kms keys get-iam-policy "$GOOGLE_ADS_KMS_KEY_ID" \
+  --keyring="$KMS_KEYRING_ID" --location="$REGION"
+verify_only_resource_role \
+  "Google Ads KMS key" \
+  "serviceAccount:${GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT}" \
+  "roles/cloudkms.cryptoKeyDecrypter" \
+  gc kms keys get-iam-policy "$GOOGLE_ADS_KMS_KEY_ID" \
+  --keyring="$KMS_KEYRING_ID" --location="$REGION"
+for service_account in \
+  "$PUBLIC_RUN_SERVICE_ACCOUNT" \
+  "$ACTIONS_RUN_SERVICE_ACCOUNT" \
+  "$CHAT_RUN_SERVICE_ACCOUNT" \
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT" \
+  "$INTERNAL_RUN_SERVICE_ACCOUNT"; do
+  verify_only_resource_role \
+    "Google Ads KMS key" "serviceAccount:${service_account}" "" \
+    gc kms keys get-iam-policy "$GOOGLE_ADS_KMS_KEY_ID" \
+    --keyring="$KMS_KEYRING_ID" --location="$REGION"
+done
+for service_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do
+  verify_identity_ancestor_scopes_empty "split runtime" "$service_account"
+done
 gc iam service-accounts add-iam-policy-binding \
   "$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT" \
   --member="serviceAccount:${DEPLOY_SERVICE_ACCOUNT}" \
@@ -161,3 +1672,6 @@ gc iam service-accounts add-iam-policy-binding \
   --member="serviceAccount:service-${PROJECT_NUMBER}@gcp-sa-cloudscheduler.iam.gserviceaccount.com" \
   --role="roles/iam.serviceAccountTokenCreator" \
   --quiet >/dev/null
+
+log "auditing deploy actAs bindings without removing operator-managed grants"
+verify_deploy_actas_inventory "$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT" post

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -1,319 +1,1010 @@
 #!/usr/bin/env bash
-# Phase 4: parallel Cloud Run rollout across every control-plane region, then
-# attach a Serverless NEG per region to the global LB backend service so
-# trustedrouter.com routes to the nearest healthy region. Finally ensures the
-# HTTP -> HTTPS redirect on :80.
+# Stage the six GCP web surfaces without changing production traffic.
+#
+# This command reconciles the six LB backends/NEGs/Armor policies, deploys an
+# exact fail-closed revision for every surface and region without changing a
+# preexisting service's traffic,
+# verifies Cloud Run and application startup postconditions, and writes a
+# non-secret recovery manifest plus prior/candidate URL-map snapshots.  It does
+# not import the candidate URL map or promote a revision.  Promotion and
+# rollback are owned by rollout_rollback.sh.
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: bash scripts/deploy/rollout.sh --manifest PATH" >&2
+  exit 2
+}
+
+[ "$#" -eq 2 ] || usage
+[ "$1" = "--manifest" ] || usage
+MANIFEST="$2"
+[ -n "$MANIFEST" ] || usage
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/deploy/_lib.sh
 source "${SCRIPT_DIR}/_lib.sh"
 # shellcheck source=scripts/deploy/regional_quota_rollout.sh
 source "${SCRIPT_DIR}/regional_quota_rollout.sh"
+# shellcheck source=scripts/deploy/_edge_security.sh
+source "${SCRIPT_DIR}/_edge_security.sh"
 
-TRUST_SOURCE_COMMIT=""
-TRUST_IMAGE_REFERENCE=""
-TRUST_IMAGE_DIGEST=""
-TRUST_JSON=""
-if [ -f "$TRUST_FILE" ]; then
-  TRUST_JSON="$(cat "$TRUST_FILE")"
-elif [ -n "${TRUST_FILE_URL:-}" ]; then
-  TRUST_JSON="$(curl -fsSL --max-time 10 "$TRUST_FILE_URL" 2>/dev/null || true)"
+STATE_TOOL="${SCRIPT_DIR}/rollout_state.py"
+URL_MAP_TOOL="${SCRIPT_DIR}/service_surface_url_map.py"
+IAM_VERIFY="${SCRIPT_DIR}/rollout_iam_verify.sh"
+STAGE_OPERATION_ID="${TR_ROLLOUT_OPERATION_ID:-}"
+if ! [[ "$STAGE_OPERATION_ID" =~ ^[A-Za-z0-9._:-]{8,160}$ ]]; then
+  echo "ERROR: staging requires a canonical TR_ROLLOUT_OPERATION_ID" >&2
+  exit 2
 fi
-if [ -n "$TRUST_JSON" ]; then
-  TRUST_SOURCE_COMMIT="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("source_commit", ""))' <<<"$TRUST_JSON")"
-  TRUST_IMAGE_REFERENCE="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("image_reference", ""))' <<<"$TRUST_JSON")"
-  TRUST_IMAGE_DIGEST="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("image_digest", ""))' <<<"$TRUST_JSON")"
+MANIFEST_DIR="$(mkdir -p "$(dirname "$MANIFEST")" && cd "$(dirname "$MANIFEST")" && pwd)"
+MANIFEST="${MANIFEST_DIR}/$(basename "$MANIFEST")"
+STAGE_OPERATION_LOCK="${TR_ROLLOUT_LOCAL_LOCK_PATH:-${TMPDIR:-/tmp}/trusted-router-${PROJECT_ID}.stage.lock}"
+if [ "${TR_ROLLOUT_LOCAL_LOCK_HELD:-}" != "$STAGE_OPERATION_LOCK" ]; then
+  export TR_ROLLOUT_LOCAL_LOCK_HELD="$STAGE_OPERATION_LOCK"
+  exec python3 "${SCRIPT_DIR}/rollout_local_lock.py" "$STAGE_OPERATION_LOCK" -- \
+    /bin/bash "$0" --manifest "$MANIFEST"
+fi
+STAGE_JOURNAL="${MANIFEST}.stage.state"
+LEGACY_HARDENING_ARTIFACT_NAME="$(basename "$MANIFEST").legacy-hardening.json"
+FRONTEND_ATTESTATION_NAME="$(basename "$MANIFEST").frontend-attestation.json"
+LEGACY_HARDENING_ARTIFACT="${MANIFEST_DIR}/${LEGACY_HARDENING_ARTIFACT_NAME}"
+FRONTEND_ATTESTATION="${MANIFEST_DIR}/${FRONTEND_ATTESTATION_NAME}"
+PRIOR_URL_MAP_NAME="url-map.prior.json"
+CANDIDATE_URL_MAP_NAME="url-map.candidate.json"
+PRIOR_URL_MAP="${MANIFEST_DIR}/${PRIOR_URL_MAP_NAME}"
+CANDIDATE_URL_MAP="${MANIFEST_DIR}/${CANDIDATE_URL_MAP_NAME}"
+
+RESUMING_INITIAL_STAGE=false
+if [ -e "$STAGE_JOURNAL" ] || [ -L "$STAGE_JOURNAL" ]; then
+  RESUMING_INITIAL_STAGE=true
+fi
+if [ -e "$MANIFEST" ] && [ "$RESUMING_INITIAL_STAGE" != true ]; then
+  echo "ERROR: refusing to overwrite existing rollout manifest ${MANIFEST}" >&2
+  exit 1
+fi
+for recovery_artifact in \
+  "$PRIOR_URL_MAP" "$CANDIDATE_URL_MAP" \
+  "$LEGACY_HARDENING_ARTIFACT" "$FRONTEND_ATTESTATION"; do
+  if [ -e "$recovery_artifact" ]; then
+    if [ "$RESUMING_INITIAL_STAGE" != true ]; then
+      echo "ERROR: refusing to overwrite existing rollout recovery artifact ${recovery_artifact}" >&2
+      exit 1
+    fi
+  fi
+done
+[ ! -e "${MANIFEST_DIR}/promotion-state.json" ] || {
+  echo "ERROR: staging cannot resume after a promotion state exists" >&2
+  exit 1
+}
+for command_name in gcloud jq python3; do
+  command -v "$command_name" >/dev/null || {
+    echo "ERROR: required command is missing: ${command_name}" >&2
+    exit 1
+  }
+done
+[ -x "$IAM_VERIFY" ] || {
+  echo "ERROR: six-runtime IAM verifier is missing or not executable: ${IAM_VERIFY}" >&2
+  exit 1
+}
+
+DOMAINS="trustedrouter.com,allyrouter.com,uptimerouter.com"
+# Every host below must already have an explicit hostRule. The transformer
+# preserves its matcher/backend byte-for-byte and refuses a wildcard/default
+# dependency, so the six web services can never steal an API, AWS, or Azure
+# hostname during the atomic URL-map import.
+REQUIRED_PRESERVED_HOSTS="api.trustedrouter.com,api.allyrouter.com,api.uptimerouter.com,api.quillrouter.com,api-aws.trustedrouter.com,api-azure.trustedrouter.com,api-azure-nz.trustedrouter.com,api-azure-sea.trustedrouter.com,api-eu-west-1.trustedrouter.com,aws.trustedrouter.com,azure.trustedrouter.com"
+
+HTTPS_PROXY="${TR_HTTPS_PROXY:-trusted-router-control-https-proxy}"
+[[ "$HTTPS_PROXY" =~ ^[a-z][a-z0-9-]{0,61}[a-z0-9]$ ]] || {
+  echo "ERROR: TR_HTTPS_PROXY is not a canonical resource name" >&2
+  exit 1
+}
+URL_MAP_NAME="$(gc compute target-https-proxies describe "$HTTPS_PROXY" \
+  --global --format='value(urlMap.basename())')"
+[ -n "$URL_MAP_NAME" ] || {
+  echo "ERROR: HTTPS proxy ${HTTPS_PROXY} has no URL map" >&2
+  exit 1
+}
+[[ "$URL_MAP_NAME" =~ ^[a-z][a-z0-9-]{0,61}[a-z0-9]$ ]] || {
+  echo "ERROR: HTTPS proxy returned an invalid URL-map name" >&2
+  exit 1
+}
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tr-six-surface-stage-XXXXXX")"
+trap 'rm -rf "$WORK_DIR"' EXIT
+ENTRIES_FILE="${WORK_DIR}/services.jsonl"
+: >"$ENTRIES_FILE"
+LEGACY_FALLBACK_FILE="${WORK_DIR}/legacy-fallback.jsonl"
+: >"$LEGACY_FALLBACK_FILE"
+SECRET_VERSIONS_FILE="${WORK_DIR}/secret-versions.tsv"
+: >"$SECRET_VERSIONS_FILE"
+chmod 600 "$SECRET_VERSIONS_FILE"
+
+RELEASE="${TR_RELEASE:-$(git rev-parse --short HEAD 2>/dev/null || echo local)}"
+read_stage_journal_suffix() {
+  python3 - "$STAGE_JOURNAL" <<'PY'
+import json
+import os
+import re
+import stat
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+metadata = os.lstat(path)
+if not stat.S_ISREG(metadata.st_mode) or stat.S_IMODE(metadata.st_mode) != 0o600:
+    raise SystemExit("initial-stage journal must be a regular mode-0600 file")
+value = json.loads(path.read_text(encoding="utf-8"))
+suffix = value.get("revision_suffix")
+if not isinstance(suffix, str) or not re.fullmatch(r"[a-z][a-z0-9-]{0,34}[a-z0-9]", suffix):
+    raise SystemExit("initial-stage journal revision suffix is invalid")
+print(suffix)
+PY
+}
+if [ -n "${TR_ROLLOUT_REVISION_SUFFIX:-}" ]; then
+  REVISION_SUFFIX="$TR_ROLLOUT_REVISION_SUFFIX"
+elif [ "$RESUMING_INITIAL_STAGE" = true ]; then
+  REVISION_SUFFIX="$(read_stage_journal_suffix)"
+else
+  REVISION_SUFFIX="r$(date -u +%Y%m%d%H%M%S)-${GITHUB_RUN_ATTEMPT:-0}"
+fi
+if ! [[ "$REVISION_SUFFIX" =~ ^[a-z][a-z0-9-]{0,34}[a-z0-9]$ ]]; then
+  echo "ERROR: TR_ROLLOUT_REVISION_SUFFIX must be a canonical revision suffix" >&2
+  exit 1
+fi
+if [ "${#REVISION_SUFFIX}" -gt 36 ]; then
+  echo "ERROR: rollout revision suffix is too long" >&2
+  exit 1
 fi
 
+IFS=',' read -r -a REGIONS <<<"$TR_CONTROL_PLANE_REGIONS"
+[ "${#REGIONS[@]}" -gt 0 ] || { echo "ERROR: no control-plane regions configured" >&2; exit 1; }
+SEEN_REGIONS="|"
+for region in "${REGIONS[@]}"; do
+  [[ "$region" =~ ^[a-z]+-[a-z0-9]+[0-9]$ ]] || {
+    echo "ERROR: invalid control-plane region: ${region:-<empty>}" >&2
+    exit 1
+  }
+  case "$SEEN_REGIONS" in *"|${region}|"*)
+    echo "ERROR: duplicate control-plane region: ${region}" >&2; exit 1 ;;
+  esac
+  SEEN_REGIONS="${SEEN_REGIONS}${region}|"
+done
+REGION_CSV="$(IFS=,; echo "${REGIONS[*]}")"
+if [ -n "${TR_DEPLOY_TARGET_REGIONS:-}" ] && [ "$TR_DEPLOY_TARGET_REGIONS" != "$REGION_CSV" ]; then
+  echo "ERROR: six-surface staging requires the complete configured regional inventory" >&2
+  exit 1
+fi
+IFS=',' read -r -a GATEWAY_REGIONS <<<"$TR_REGIONS"
+[ "${#GATEWAY_REGIONS[@]}" -gt 0 ] || { echo "ERROR: no gateway regions configured" >&2; exit 1; }
+SEEN_GATEWAY_REGIONS="|"
+for gateway_region in "${GATEWAY_REGIONS[@]}"; do
+  [[ "$gateway_region" =~ ^[a-z]+-[a-z0-9]+[0-9]$ ]] || {
+    echo "ERROR: invalid gateway region: ${gateway_region:-<empty>}" >&2
+    exit 1
+  }
+  case "$SEEN_GATEWAY_REGIONS" in *"|${gateway_region}|"*)
+    echo "ERROR: duplicate gateway region: ${gateway_region}" >&2; exit 1 ;;
+  esac
+  SEEN_GATEWAY_REGIONS="${SEEN_GATEWAY_REGIONS}${gateway_region}|"
+done
+GATEWAY_REGION_CSV="$(IFS=,; echo "${GATEWAY_REGIONS[*]}")"
+[ -n "${TR_PRIMARY_REGION:-}" ] || {
+  echo "ERROR: TR_PRIMARY_REGION must be explicitly configured" >&2
+  exit 1
+}
+[[ "$TR_PRIMARY_REGION" =~ ^[a-z]+-[a-z0-9]+[0-9]$ ]] || {
+  echo "ERROR: TR_PRIMARY_REGION is not a canonical region" >&2
+  exit 1
+}
+[ "$TR_PRIMARY_REGION" = "${REGIONS[0]}" ] || {
+  echo "ERROR: TR_PRIMARY_REGION must be the first control-plane region" >&2
+  exit 1
+}
+case ",$GATEWAY_REGION_CSV," in
+  *",${TR_PRIMARY_REGION},"*) ;;
+  *) echo "ERROR: TR_PRIMARY_REGION must also belong to the gateway inventory" >&2; exit 1 ;;
+esac
+CLOUD_RUN_NETWORK="${TR_CLOUD_RUN_NETWORK:-default}"
+CLOUD_RUN_SUBNET="${TR_CLOUD_RUN_SUBNET:-default}"
+[ "$CLOUD_RUN_NETWORK" = default ] && [ "$CLOUD_RUN_SUBNET" = default ] || {
+  echo "ERROR: six-surface rollout pins the reviewed default VPC network/subnet" >&2
+  exit 1
+}
+INTERNAL_ALLOWED_REGIONS=("${REGIONS[@]}")
+for internal_region in \
+  ${TR_SYNTHETIC_MONITOR_REGIONS//,/ } \
+  "$TR_SYNTHETIC_THROUGHPUT_REGION" \
+  "$TR_SYNTHETIC_IMAGE_REGION" \
+  "$TR_SYNTHETIC_VIDEO_REGION"; do
+  [[ "$internal_region" =~ ^[a-z]+-[a-z0-9]+[0-9]$ ]] || {
+    echo "ERROR: invalid internal/synthetic region: ${internal_region:-<empty>}" >&2
+    exit 1
+  }
+  case " ${INTERNAL_ALLOWED_REGIONS[*]} " in
+    *" ${internal_region} "*) ;;
+    *) INTERNAL_ALLOWED_REGIONS+=("$internal_region") ;;
+  esac
+done
+INTERNAL_ALLOWED_REGION_CSV="$(IFS=,; echo "${INTERNAL_ALLOWED_REGIONS[*]}")"
+REGIONAL_QUILL_HOSTS="$(printf 'api-%s.quillrouter.com,' "${REGIONS[@]}" "${GATEWAY_REGIONS[@]}")"
+REGIONAL_QUILL_HOSTS="${REGIONAL_QUILL_HOSTS%,}"
+PRESERVED_HOSTS="$(python3 - "$REQUIRED_PRESERVED_HOSTS" "$REGIONAL_QUILL_HOSTS" \
+  "${TR_ROLLOUT_PRESERVED_HOSTS:-}" <<'PY'
+import re
+import sys
 
-SECRET_ENVS=(
-  "TR_SENTRY_DSN=trustedrouter-sentry-dsn:latest"
-  "TR_STRIPE_SECRET_KEY=trustedrouter-stripe-secret-key:latest"
-  "TR_STRIPE_WEBHOOK_SECRET=trustedrouter-stripe-webhook-secret:latest"
-  "TR_INTERNAL_GATEWAY_TOKEN=trustedrouter-internal-gateway-token:latest"
-)
-# Retired environment bindings remain on Cloud Run until explicitly removed.
-REMOVE_SECRET_ENVS=("TR_GOOGLE_ADS_CONVERSION_FEED_PASSWORD")
-add_secret_env_if_exists() {
-  local env_name="$1"
-  local secret_name="$2"
-  local describe_error=""
-  if describe_error="$(gc secrets describe "$secret_name" 2>&1)"; then
-    SECRET_ENVS+=("${env_name}=${secret_name}:latest")
-  elif [[ "$describe_error" == *"NOT_FOUND"* ]] || \
-       [[ "$describe_error" == *"not found"* ]]; then
-    # gcloud --update-secrets preserves old bindings. Explicit removal keeps
-    # a deleted optional secret from making an otherwise healthy revision
-    # unroutable in regions that still carry the stale environment entry.
-    REMOVE_SECRET_ENVS+=("${env_name}")
+hosts = []
+for raw in sys.argv[1:]:
+    hosts.extend(
+        item.strip().lower().rstrip(".")
+        for item in raw.split(",")
+        if item.strip()
+    )
+hosts = list(dict.fromkeys(hosts))
+if any(
+    not re.fullmatch(
+        r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:[.][a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+",
+        host,
+    )
+    for host in hosts
+):
+    raise SystemExit("invalid preserved hostname")
+print(",".join(hosts))
+PY
+)" || exit 1
+
+SURFACES=(public actions console chat webhooks internal)
+surface_service() {
+  case "$1" in
+    public) echo "$PUBLIC_SERVICE" ;;
+    actions) echo "$ACTIONS_SERVICE" ;;
+    console) echo "$CONSOLE_SERVICE" ;;
+    chat) echo "$CHAT_SERVICE" ;;
+    webhooks) echo "$WEBHOOKS_SERVICE" ;;
+    internal) echo "$INTERNAL_SERVICE" ;;
+    *) return 2 ;;
+  esac
+}
+surface_account() {
+  case "$1" in
+    public) echo "$PUBLIC_RUN_SERVICE_ACCOUNT" ;;
+    actions) echo "$ACTIONS_RUN_SERVICE_ACCOUNT" ;;
+    console) echo "$CONSOLE_RUN_SERVICE_ACCOUNT" ;;
+    chat) echo "$CHAT_RUN_SERVICE_ACCOUNT" ;;
+    webhooks) echo "$WEBHOOKS_RUN_SERVICE_ACCOUNT" ;;
+    internal) echo "$INTERNAL_RUN_SERVICE_ACCOUNT" ;;
+    *) return 2 ;;
+  esac
+}
+surface_backend() {
+  case "$1" in
+    public) echo "${TR_PUBLIC_BACKEND:-trusted-router-public-backend}" ;;
+    actions) echo "${TR_ACTIONS_BACKEND:-trusted-router-actions-backend}" ;;
+    console) echo "${TR_CONSOLE_BACKEND:-trusted-router-console-backend}" ;;
+    chat) echo "${TR_CHAT_BACKEND:-trusted-router-chat-backend}" ;;
+    webhooks) echo "${TR_WEBHOOKS_BACKEND:-trusted-router-webhooks-backend}" ;;
+    internal) echo "${TR_INTERNAL_BACKEND:-trusted-router-billing-backend}" ;;
+    *) return 2 ;;
+  esac
+}
+surface_neg() {
+  case "$1" in
+    public) echo "${TR_PUBLIC_NEG:-trusted-router-public-neg}" ;;
+    actions) echo "${TR_ACTIONS_NEG:-trusted-router-actions-neg}" ;;
+    console) echo "${TR_CONSOLE_NEG:-trusted-router-console-neg}" ;;
+    chat) echo "${TR_CHAT_NEG:-trusted-router-chat-neg}" ;;
+    webhooks) echo "${TR_WEBHOOKS_NEG:-trusted-router-webhooks-neg}" ;;
+    internal) echo "${TR_INTERNAL_NEG:-trusted-router-billing-neg}" ;;
+    *) return 2 ;;
+  esac
+}
+surface_policy() {
+  case "$1" in
+    public) echo "${TR_PUBLIC_EDGE_POLICY:-trusted-router-public-edge}" ;;
+    actions) echo "${TR_ACTIONS_EDGE_POLICY:-trusted-router-actions-edge}" ;;
+    console) echo "${TR_CONSOLE_EDGE_POLICY:-trusted-router-console-edge}" ;;
+    chat) echo "${TR_CHAT_EDGE_POLICY:-trusted-router-chat-edge}" ;;
+    webhooks) echo "${TR_WEBHOOKS_EDGE_POLICY:-trusted-router-webhooks-edge}" ;;
+    internal) echo "${TR_INTERNAL_EDGE_POLICY:-trusted-router-billing-edge}" ;;
+    *) return 2 ;;
+  esac
+}
+surface_region_lines() {
+  if [ "$1" = internal ]; then
+    printf '%s\n' "${INTERNAL_ALLOWED_REGIONS[@]}"
   else
-    log "cannot determine whether optional secret ${secret_name} exists"
-    return 1
+    printf '%s\n' "${REGIONS[@]}"
   fi
 }
-# Carrier credentials for /v1/notify. Optional bindings: if the secrets are
-# absent the notify channels report themselves unconfigured rather than the
-# revision failing to start, which is the right failure for a feature nobody
-# has enabled yet.
-add_secret_env_if_exists "TR_TELNYX_API_KEY" "trustedrouter-telnyx-api-key"
-add_secret_env_if_exists "TR_VERIFF_API_KEY" "trustedrouter-veriff-api-key"
-add_secret_env_if_exists \
-  "TR_VERIFF_SHARED_SECRET_KEY" \
-  "trustedrouter-veriff-shared-secret-key"
-add_secret_env_if_exists "TR_TWILIO_ACCOUNT_SID" "trustedrouter-twilio-account-sid"
-add_secret_env_if_exists "TR_TWILIO_API_KEY_SID" "trustedrouter-twilio-api-key-sid"
-add_secret_env_if_exists "TR_TWILIO_API_KEY_SECRET" "trustedrouter-twilio-api-key-secret"
-add_secret_env_if_exists "TR_TWILIO_AUTH_TOKEN" "trustedrouter-twilio-auth-token"
-add_secret_env_if_exists "ANTHROPIC_API_KEY" "trustedrouter-anthropic-api-key"
-add_secret_env_if_exists "OPENAI_API_KEY" "trustedrouter-openai-api-key"
-add_secret_env_if_exists "GEMINI_API_KEY" "trustedrouter-gemini-api-key"
-add_secret_env_if_exists "CEREBRAS_API_KEY" "trustedrouter-cerebras-api-key"
-add_secret_env_if_exists "DEEPSEEK_API_KEY" "trustedrouter-deepseek-api-key"
-add_secret_env_if_exists "MISTRAL_API_KEY" "trustedrouter-mistral-api-key"
-add_secret_env_if_exists "KIMI_API_KEY" "trustedrouter-kimi-api-key"
-add_secret_env_if_exists "ZAI_API_KEY" "trustedrouter-zai-api-key"
-add_secret_env_if_exists "TOGETHER_API_KEY" "trustedrouter-together-api-key"
-add_secret_env_if_exists "FIREWORKS_API_KEY" "trustedrouter-fireworks-api-key"
-add_secret_env_if_exists "DEEPINFRA_API_KEY" "trustedrouter-deepinfra-api-key"
-# 2026-05 — six new backends.
-add_secret_env_if_exists "GROK_API_KEY" "trustedrouter-grok-api-key"
-add_secret_env_if_exists "NOVITA_API_KEY" "trustedrouter-novita-api-key"
-add_secret_env_if_exists "PHALA_API_KEY" "trustedrouter-phala-api-key"
-add_secret_env_if_exists "SILICON_FLOW_API_KEY" "trustedrouter-siliconflow-api-key"
-add_secret_env_if_exists "TINFOIL_API_KEY" "trustedrouter-tinfoil-api-key"
-add_secret_env_if_exists "VENICE_API_KEY" "trustedrouter-venice-api-key"
-add_secret_env_if_exists "NEBIUS_API_KEY" "trustedrouter-nebius-api-key"
-add_secret_env_if_exists "MINIMAX_API_KEY" "trustedrouter-minimax-api-key"
-add_secret_env_if_exists "BASETEN_API_KEY" "trustedrouter-baseten-api-key"
-add_secret_env_if_exists "TELNYX_API_KEY" "trustedrouter-telnyx-api-key"
-add_secret_env_if_exists "THINKING_MACHINES_API_KEY" "trustedrouter-thinking-machines-api-key"
-add_secret_env_if_exists "WAFER_API_KEY" "trustedrouter-wafer-api-key"
-add_secret_env_if_exists "CRUSOE_API_KEY" "trustedrouter-crusoe-api-key"
-add_secret_env_if_exists "MAKORA_API_KEY" "trustedrouter-makora-api-key"
-add_secret_env_if_exists "ALIBABA_API_KEY" "trustedrouter-alibaba-api-key"
-add_secret_env_if_exists "ENGY_API_KEY" "trustedrouter-engy-api-key"
-add_secret_env_if_exists "ZERO_G_API_KEY" "trustedrouter-zero-g-api-key"
-add_secret_env_if_exists "TR_SYNTHETIC_MONITOR_API_KEY" "trustedrouter-synthetic-monitor-api-key"
-# HOME side of lazy key federation: peers present this token to
-# /v1/internal/federation/resolve-key and get identity + limits, never
-# credits and never key material. Setting it is what turns federation
-# serving ON for this plane (unset = 403 for every peer).
-add_secret_env_if_exists "TR_FEDERATION_PEER_TOKEN" "trustedrouter-federation-peer-token"
-# HOME side of deferred settlement: the per-peer token map
-# ("plane=token,plane=token"). Which token authenticated IS the source
-# plane's identity; the request body never carries it. Setting this is what
-# turns /v1/internal/federation/apply-usage serving ON (unset = 403).
-add_secret_env_if_exists \
-  "TR_FEDERATION_SETTLEMENT_INBOUND_TOKENS" \
-  "trustedrouter-federation-settlement-inbound-tokens"
-add_secret_env_if_exists "TR_GOOGLE_CLIENT_ID" "trustedrouter-google-client-id"
-add_secret_env_if_exists "TR_GOOGLE_CLIENT_SECRET" "trustedrouter-google-client-secret"
-add_secret_env_if_exists \
-  "TR_GOOGLE_ALIAS_CREDENTIALS_JSON" \
-  "trustedrouter-google-alias-credentials-json"
-add_secret_env_if_exists "TR_GITHUB_CLIENT_ID" "trustedrouter-github-client-id"
-add_secret_env_if_exists "TR_GITHUB_CLIENT_SECRET" "trustedrouter-github-client-secret"
-add_secret_env_if_exists \
-  "TR_GITHUB_ALIAS_CREDENTIALS_JSON" \
-  "trustedrouter-github-alias-credentials-json"
-# SES email credentials only; not used for AWS hosting or failover.
-add_secret_env_if_exists "TR_AWS_ACCESS_KEY_ID" "trustedrouter-aws-access-key-id"
-add_secret_env_if_exists "TR_AWS_SECRET_ACCESS_KEY" "trustedrouter-aws-secret-access-key"
-add_secret_env_if_exists \
-  "TR_OPS_CHAT_WEBHOOK_SECRET" \
-  "trustedrouter-ops-chat-webhook-secret"
-add_secret_env_if_exists "TR_PAYPAL_CLIENT_ID" "trustedrouter-paypal-client-id"
-add_secret_env_if_exists "TR_PAYPAL_CLIENT_SECRET" "trustedrouter-paypal-client-secret"
-add_secret_env_if_exists "TR_PAYPAL_WEBHOOK_ID" "trustedrouter-paypal-webhook-id"
-add_secret_env_if_exists "TR_ADYEN_API_KEY" "trustedrouter-adyen-test-api-key"
-add_secret_env_if_exists "TR_ADYEN_CLIENT_KEY" "trustedrouter-adyen-test-client-key"
-add_secret_env_if_exists "TR_ADYEN_HMAC_KEY" "trustedrouter-adyen-test-hmac-key"
-add_secret_env_if_exists \
-  "TR_ADYEN_REFERENCE_KEY" "trustedrouter-adyen-test-reference-key"
-add_secret_env_if_exists "AXIOM_API_TOKEN" "trustedrouter-axiom-api-token"
-add_secret_env_if_exists "TR_ATHENA_WORKER_PROMPT" "trustedrouter-athena-worker-prompt-v1"
-add_secret_env_if_exists \
-  "TR_PROVIDER_ANALYTICS_CLICKHOUSE_PASSWORD" \
-  "trustedrouter-clickhouse-provider-read-password"
-add_secret_env_if_exists \
-  "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_PASSWORD" \
-  "trustedrouter-clickhouse-control-read-password"
-UPDATE_SECRETS="$(IFS=,; echo "${SECRET_ENVS[*]}")"
-REMOVE_SECRETS_ARGS=()
-if [ "${#REMOVE_SECRET_ENVS[@]}" -gt 0 ]; then
-  REMOVE_SECRETS_ARGS=(--remove-secrets "$(IFS=,; echo "${REMOVE_SECRET_ENVS[*]}")")
-fi
 
-REQUEST_RECORD_WRITE_MODE="${TR_REQUEST_RECORD_WRITE_MODE:-}"
-if [ -z "$REQUEST_RECORD_WRITE_MODE" ]; then
-  REQUEST_RECORD_WRITE_MODE="$(
-    gc run services describe "$SERVICE" \
-      --region="$TR_PRIMARY_REGION" \
-      --format=json 2>/dev/null \
-      | jq -r '
-          [
-            .spec.template.spec.containers[0].env[]?
-            | select(.name == "TR_REQUEST_RECORD_WRITE_MODE")
-            | .value
-          ][0] // empty
-        ' || true
-  )"
-fi
-case "$REQUEST_RECORD_WRITE_MODE" in
-  legacy|typed) ;;
-  *)
-    log "refusing rollout: cannot determine TR_REQUEST_RECORD_WRITE_MODE; set it explicitly"
-    exit 1
-    ;;
-esac
-
-LIVE_STORAGE_BACKEND="$(
-  gc run services describe "$SERVICE" \
-    --region="$TR_PRIMARY_REGION" \
-    --format=json 2>/dev/null \
-    | jq -r '
-        [
-          .spec.template.spec.containers[0].env[]?
-          | select(.name == "TR_STORAGE_BACKEND")
-          | .value
-        ][0] // "spanner-bigtable"
-      ' || true
-)"
-STORAGE_BACKEND="${TR_STORAGE_BACKEND:-${LIVE_STORAGE_BACKEND:-spanner-bigtable}}"
-case "$STORAGE_BACKEND" in
-  spanner-bigtable|spanner-clickhouse) ;;
-  *)
-    log "refusing rollout: TR_STORAGE_BACKEND must be spanner-bigtable or spanner-clickhouse"
-    exit 1
-    ;;
-esac
-
-LIVE_GENERATION_RECORDS_ENABLED="$(
-  gc run services describe "$SERVICE" \
-    --region="$TR_PRIMARY_REGION" \
-    --format=json 2>/dev/null \
-    | jq -r '
-        [
-          .spec.template.spec.containers[0].env[]?
-          | select(.name == "TR_GENERATION_RECORDS_ENABLED")
-          | .value
-        ][0] // empty
-      ' || true
-)"
-LIVE_BIGTABLE_MIRROR_WRITES_ENABLED="$(
-  gc run services describe "$SERVICE" \
-    --region="$TR_PRIMARY_REGION" \
-    --format=json 2>/dev/null \
-    | jq -r '
-        [
-          .spec.template.spec.containers[0].env[]?
-          | select(.name == "TR_BIGTABLE_MIRROR_WRITES_ENABLED")
-          | .value
-        ][0] // empty
-      ' || true
-)"
-GENERATION_RECORDS_ENABLED="${TR_GENERATION_RECORDS_ENABLED:-${LIVE_GENERATION_RECORDS_ENABLED:-true}}"
-BIGTABLE_MIRROR_WRITES_ENABLED="${TR_BIGTABLE_MIRROR_WRITES_ENABLED:-${LIVE_BIGTABLE_MIRROR_WRITES_ENABLED:-true}}"
-case "$GENERATION_RECORDS_ENABLED:$BIGTABLE_MIRROR_WRITES_ENABLED" in
-  true:true|true:false|false:true|false:false) ;;
-  *)
-    log "refusing rollout: generation-record and Bigtable-mirror flags must be true or false"
-    exit 1
-    ;;
-esac
-
-LIVE_ANALYTICS_READ_MODE="$(
-  gc run services describe "$SERVICE" \
-    --region="$TR_PRIMARY_REGION" \
-    --format=json 2>/dev/null \
-    | jq -r '
-        [
-          .spec.template.spec.containers[0].env[]?
-          | select(.name == "TR_ANALYTICS_READ_MODE")
-          | .value
-        ][0] // "bigtable"
-      ' || true
-)"
-ANALYTICS_READ_MODE="${TR_ANALYTICS_READ_MODE:-$LIVE_ANALYTICS_READ_MODE}"
-case "$ANALYTICS_READ_MODE" in
-  bigtable|dual|clickhouse|clickhouse-only) ;;
-  *)
-    log "refusing rollout: invalid TR_ANALYTICS_READ_MODE"
-    exit 1
-    ;;
-esac
-if [ "$STORAGE_BACKEND" = "spanner-clickhouse" ] && \
-   [ "$ANALYTICS_READ_MODE" != "clickhouse-only" ]; then
-  log "refusing rollout: spanner-clickhouse requires clickhouse-only reads"
+validate_resource_name() {
+  local kind="$1" value="$2"
+  [[ "$value" =~ ^[a-z][a-z0-9-]{0,61}[a-z0-9]$ ]] || {
+    echo "ERROR: invalid ${kind}: ${value}" >&2
+    return 1
+  }
+}
+[[ "$RELEASE" =~ ^[A-Za-z0-9._-]{1,128}$ ]] || {
+  echo "ERROR: TR_RELEASE contains an unsafe delimiter or character" >&2
   exit 1
-fi
-if [ "$STORAGE_BACKEND" = "spanner-clickhouse" ] && \
-   { [ "$BIGTABLE_MIRROR_WRITES_ENABLED" != "false" ] ||
-     [ "$GENERATION_RECORDS_ENABLED" != "true" ] ||
-     [ "$REQUEST_RECORD_WRITE_MODE" != "typed" ]; }; then
-  log "refusing rollout: spanner-clickhouse requires typed generation records and no Bigtable mirror"
+}
+[[ "$IMAGE" =~ ^[^,|[:space:]]+$ ]] || {
+  echo "ERROR: IMAGE contains an unsafe delimiter or whitespace" >&2
   exit 1
-fi
-if [ "$GENERATION_RECORDS_ENABLED" = "true" ]; then
-  generation_table_count="$(gc spanner databases execute-sql "$SPANNER_DATABASE_ID" \
-    --instance="$SPANNER_INSTANCE_ID" \
-    --sql="SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE table_name='tr_generation'" \
-    --format='value(rows[0])')"
-  if [ "${generation_table_count:-0}" != "1" ]; then
-    log "refusing rollout: tr_generation is missing; run migrate_generation_records.sh --apply"
+}
+[[ "$PROJECT_ID" =~ ^[a-z][a-z0-9-]{4,28}[a-z0-9]$ ]] || {
+  echo "ERROR: PROJECT_ID is not a canonical GCP project identifier" >&2
+  exit 1
+}
+[ "$TR_CLOUD_RUN_INGRESS" = internal-and-cloud-load-balancing ] || {
+  echo "ERROR: six-surface rollout requires LB-only Cloud Run ingress" >&2
+  exit 1
+}
+for surface in "${SURFACES[@]}"; do
+  validate_resource_name "Cloud Run service" "$(surface_service "$surface")"
+  validate_resource_name "backend" "$(surface_backend "$surface")"
+  validate_resource_name "NEG" "$(surface_neg "$surface")"
+  validate_resource_name "Cloud Armor policy" "$(surface_policy "$surface")"
+done
+for surface in "${SURFACES[@]}"; do
+  validate_resource_name "candidate revision" "$(surface_service "$surface")-${REVISION_SUFFIX}"
+done
+for surface in "${SURFACES[@]}"; do
+  case "$surface" in
+    public) expected_backend=trusted-router-public-backend; expected_neg=trusted-router-public-neg; expected_policy=trusted-router-public-edge ;;
+    actions) expected_backend=trusted-router-actions-backend; expected_neg=trusted-router-actions-neg; expected_policy=trusted-router-actions-edge ;;
+    console) expected_backend=trusted-router-console-backend; expected_neg=trusted-router-console-neg; expected_policy=trusted-router-console-edge ;;
+    chat) expected_backend=trusted-router-chat-backend; expected_neg=trusted-router-chat-neg; expected_policy=trusted-router-chat-edge ;;
+    webhooks) expected_backend=trusted-router-webhooks-backend; expected_neg=trusted-router-webhooks-neg; expected_policy=trusted-router-webhooks-edge ;;
+    internal) expected_backend=trusted-router-billing-backend; expected_neg=trusted-router-billing-neg; expected_policy=trusted-router-billing-edge ;;
+  esac
+  [ "$(surface_backend "$surface")" = "$expected_backend" ] &&
+  [ "$(surface_neg "$surface")" = "$expected_neg" ] &&
+  [ "$(surface_policy "$surface")" = "$expected_policy" ] || {
+    echo "ERROR: ${surface} must use its canonical backend, NEG, and Cloud Armor policy" >&2
+    exit 1
+  }
+done
+[ "$PUBLIC_SERVICE" = trusted-router-public ] &&
+[ "$ACTIONS_SERVICE" = trusted-router-actions ] &&
+[ "$CONSOLE_SERVICE" = trusted-router-console ] &&
+[ "$CHAT_SERVICE" = trusted-router-chat ] &&
+[ "$WEBHOOKS_SERVICE" = trusted-router-webhooks ] &&
+[ "$INTERNAL_SERVICE" = trusted-router-billing ] || {
+  echo "ERROR: production six-surface service names must use the canonical inventory" >&2
+  exit 1
+}
+[ "${LEGACY_CONSOLE_SERVICE:-}" = trusted-router ] || {
+  echo "ERROR: initial migration must preserve trusted-router as the legacy monolith" >&2
+  exit 1
+}
+for surface in "${SURFACES[@]}"; do
+  [ "$(surface_account "$surface")" = "tr-${surface}@${PROJECT_ID}.iam.gserviceaccount.com" ] || {
+    echo "ERROR: ${surface} must use its canonical dedicated runtime identity" >&2
+    exit 1
+  }
+done
+
+validate_runtime_service_accounts
+for runtime_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do
+  runtime_description="$(gc iam service-accounts describe "$runtime_account" --format=json)"
+  if ! jq -e --arg email "$runtime_account" '
+      .email == $email and ((.disabled // false) == false)
+    ' <<<"$runtime_description" >/dev/null; then
+    echo "ERROR: runtime service account is missing, disabled, or renamed: ${runtime_account}" >&2
     exit 1
   fi
+  runtime_policy="$(gc iam service-accounts get-iam-policy "$runtime_account" --format=json)"
+  if ! jq -e --arg member "serviceAccount:${DEPLOY_SERVICE_ACCOUNT}" '
+      ([.bindings[]? | select(any(.members[]?; . == $member))
+        | {role, condition: (.condition // null)}] | unique)
+      == [{role:"roles/iam.serviceAccountUser",condition:null}]
+    ' <<<"$runtime_policy" >/dev/null; then
+    echo "ERROR: ${DEPLOY_SERVICE_ACCOUNT} must have exactly unconditional actAs on ${runtime_account}" >&2
+    exit 1
+  fi
+done
+
+RAW_URL_MAP="${WORK_DIR}/url-map.raw.json"
+gc compute url-maps describe "$URL_MAP_NAME" --global --format=json >"$RAW_URL_MAP"
+CAPTURED_PRIOR_URL_MAP="${WORK_DIR}/url-map.prior.current.json"
+python3 "$STATE_TOOL" sanitize-url-map "$RAW_URL_MAP" "$CAPTURED_PRIOR_URL_MAP"
+if [ "$RESUMING_INITIAL_STAGE" = true ]; then
+  python3 - "$PRIOR_URL_MAP" <<'PY'
+import os
+import stat
+import sys
+metadata = os.lstat(sys.argv[1])
+if not stat.S_ISREG(metadata.st_mode) or stat.S_IMODE(metadata.st_mode) != 0o600:
+    raise SystemExit("resumed prior URL-map snapshot must be a regular mode-0600 file")
+PY
+  [ "$(python3 "$STATE_TOOL" hash-url-map "$CAPTURED_PRIOR_URL_MAP")" = \
+    "$(python3 "$STATE_TOOL" hash-url-map "$PRIOR_URL_MAP")" ] || {
+    echo "ERROR: live URL map changed since the initial-stage journal was created" >&2
+    exit 1
+  }
+else
+  python3 - "$CAPTURED_PRIOR_URL_MAP" "$PRIOR_URL_MAP" <<'PY'
+import os
+import stat
+import sys
+from pathlib import Path
+source = Path(sys.argv[1])
+destination = Path(sys.argv[2])
+descriptor = os.open(destination, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+with os.fdopen(descriptor, "wb") as output:
+    output.write(source.read_bytes())
+    output.flush()
+    os.fsync(output.fileno())
+directory = os.open(destination.parent, os.O_RDONLY)
+try:
+    os.fsync(directory)
+finally:
+    os.close(directory)
+if stat.S_IMODE(os.stat(destination).st_mode) != 0o600:
+    raise SystemExit("prior URL-map snapshot mode differs")
+PY
+fi
+if jq -e 'any(.pathMatchers[]?; .name == "trusted-router-service-surfaces")' \
+    "$PRIOR_URL_MAP" >/dev/null; then
+  ROLLOUT_MODE="existing_split"
+else
+  ROLLOUT_MODE="initial_split"
 fi
 
-ANALYTICS_DUAL_READ_STARTED_AT="${TR_ANALYTICS_DUAL_READ_STARTED_AT:-}"
-if [ -z "$ANALYTICS_DUAL_READ_STARTED_AT" ]; then
-  ANALYTICS_DUAL_READ_STARTED_AT="$(
-    gc run services describe "$SERVICE" \
-      --region="$TR_PRIMARY_REGION" \
-      --format=json 2>/dev/null \
-      | jq -r '
-          [
-            .spec.template.spec.containers[0].env[]?
-            | select(.name == "TR_ANALYTICS_DUAL_READ_STARTED_AT")
-            | .value
-          ][0] // empty
-        ' || true
-  )"
-fi
-if [ "$ANALYTICS_READ_MODE" = "dual" ] && {
-  [ "$LIVE_ANALYTICS_READ_MODE" != "dual" ] ||
-  [ -z "$ANALYTICS_DUAL_READ_STARTED_AT" ];
-}; then
-  ANALYTICS_DUAL_READ_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+persist_attested_artifact() {
+  local source="$1" destination="$2"
+  python3 - "$source" "$destination" "$RESUMING_INITIAL_STAGE" <<'PY'
+import hashlib
+import os
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+source = Path(sys.argv[1])
+destination = Path(sys.argv[2])
+resuming = sys.argv[3] == "true"
+source_metadata = os.lstat(source)
+if (
+    not stat.S_ISREG(source_metadata.st_mode)
+    or stat.S_IMODE(source_metadata.st_mode) != 0o600
+):
+    raise SystemExit("rollout prerequisite artifact must be a regular mode-0600 file")
+payload = source.read_bytes()
+if destination.exists() or destination.is_symlink():
+    destination_metadata = os.lstat(destination)
+    if (
+        not resuming
+        or not stat.S_ISREG(destination_metadata.st_mode)
+        or stat.S_IMODE(destination_metadata.st_mode) != 0o600
+        or destination.read_bytes() != payload
+    ):
+        raise SystemExit("persisted rollout prerequisite artifact differs")
+else:
+    descriptor, temporary = tempfile.mkstemp(
+        dir=destination.parent, prefix=f".{destination.name}.", suffix=".tmp"
+    )
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "wb") as output:
+            output.write(payload)
+            output.flush()
+            os.fsync(output.fileno())
+        os.link(temporary, destination)
+        os.unlink(temporary)
+        directory = os.open(destination.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    finally:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+print(hashlib.sha256(payload).hexdigest())
+PY
+}
+
+[ -n "${TR_ROLLOUT_FRONTEND_ATTESTATION:-}" ] || {
+  echo "ERROR: rollout requires TR_ROLLOUT_FRONTEND_ATTESTATION" >&2
+  exit 1
+}
+FRONTEND_ATTESTATION_SHA256="$(persist_attested_artifact \
+  "$TR_ROLLOUT_FRONTEND_ATTESTATION" "$FRONTEND_ATTESTATION")" || exit 1
+python3 "${SCRIPT_DIR}/rollout_frontend_attest.py" \
+  verify-artifact "$FRONTEND_ATTESTATION" || exit 1
+
+LEGACY_HARDENING_ARTIFACT_SHA256=""
+if [ "$ROLLOUT_MODE" = initial_split ]; then
+  [ -n "${TR_LEGACY_HARDENING_ARTIFACT:-}" ] || {
+    echo "ERROR: initial split requires TR_LEGACY_HARDENING_ARTIFACT" >&2
+    exit 1
+  }
+  LEGACY_HARDENING_ARTIFACT_SHA256="$(persist_attested_artifact \
+    "$TR_LEGACY_HARDENING_ARTIFACT" "$LEGACY_HARDENING_ARTIFACT")" || exit 1
+  bash "${SCRIPT_DIR}/rollout_legacy_harden.sh" \
+    --verify-artifact "$LEGACY_HARDENING_ARTIFACT" || exit 1
 fi
 
-ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT="${TR_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT:-}"
-if [ -z "$ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT" ]; then
-  ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT="$(
-    gc run services describe "$SERVICE" \
-      --region="$TR_PRIMARY_REGION" \
-      --format=json 2>/dev/null \
-      | jq -r '
-          [
-            .spec.template.spec.containers[0].env[]?
-            | select(.name == "TR_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT")
-            | .value
-          ][0] // empty
-        ' || true
-  )"
+# Validate the preserved-host and three-domain transformation before the first
+# provider mutation. Placeholder self-links are deliberately canonical but do
+# not need to exist; the real candidate is rendered and provider-validated
+# after inactive backends are reconciled and before any active service deploy.
+EARLY_CANDIDATE_URL_MAP="${WORK_DIR}/url-map.candidate.preflight.json"
+python3 "$URL_MAP_TOOL" \
+  --input "$PRIOR_URL_MAP" \
+  --output "$EARLY_CANDIDATE_URL_MAP" \
+  --public-backend "projects/${PROJECT_ID}/global/backendServices/$(surface_backend public)" \
+  --actions-backend "projects/${PROJECT_ID}/global/backendServices/$(surface_backend actions)" \
+  --console-backend "projects/${PROJECT_ID}/global/backendServices/$(surface_backend console)" \
+  --chat-backend "projects/${PROJECT_ID}/global/backendServices/$(surface_backend chat)" \
+  --webhooks-backend "projects/${PROJECT_ID}/global/backendServices/$(surface_backend webhooks)" \
+  --internal-backend "projects/${PROJECT_ID}/global/backendServices/$(surface_backend internal)" \
+  --domains "$DOMAINS" \
+  --preserved-hosts "$PRESERVED_HOSTS"
+
+prior_json_path() {
+  echo "${WORK_DIR}/prior-$1-$2.json"
+}
+legacy_console_json_path() {
+  echo "${WORK_DIR}/legacy-console-$1.json"
+}
+service_exists() {
+  local surface="$1" region="$2" service output describe_output
+  service="$(surface_service "$surface")"
+  output="$(prior_json_path "$surface" "$region")"
+  if describe_output="$(gc run services describe "$service" --region="$region" --format=json 2>&1)"; then
+    printf '%s\n' "$describe_output" >"$output"
+    return 0
+  fi
+  case "$describe_output" in
+    *NOT_FOUND*|*"not found"*) return 1 ;;
+    *) echo "ERROR: cannot determine whether ${service}/${region} exists" >&2; return 2 ;;
+  esac
+}
+
+# Capture the complete pre-mutation inventory. Partial service families are a
+# failed precondition, not something a rollout silently fills in.
+for surface in "${SURFACES[@]}"; do
+  family_count=0
+  while IFS= read -r region; do
+    service_rc=0
+    service_exists "$surface" "$region" || service_rc=$?
+    if [ "$service_rc" = 0 ]; then
+      family_count=$((family_count + 1))
+    elif [ "$service_rc" != 1 ]; then
+      exit 1
+    fi
+  done < <(surface_region_lines "$surface")
+  expected_family_count="${#REGIONS[@]}"
+  [ "$surface" = internal ] && expected_family_count="${#INTERNAL_ALLOWED_REGIONS[@]}"
+  if [ "$ROLLOUT_MODE" = "existing_split" ] && [ "$family_count" -ne "$expected_family_count" ]; then
+    echo "ERROR: existing split has incomplete ${surface} regional inventory" >&2
+    exit 1
+  fi
+  if [ "$ROLLOUT_MODE" = "initial_split" ]; then
+    if [ "$surface" = internal ] && [ "$family_count" -ne "$expected_family_count" ]; then
+      echo "ERROR: initial split requires bootstrap internal in every control/synthetic region" >&2
+      exit 1
+    fi
+    if [ "$surface" != internal ] && [ "$family_count" -ne 0 ] && \
+        [ "$RESUMING_INITIAL_STAGE" != true ]; then
+      echo "ERROR: initial split requires the new ${surface} companion to be absent in every region" >&2
+      exit 1
+    fi
+  fi
+done
+
+# The legacy monolith is deliberately outside the six new service names.  It
+# remains the prior URL map's rollback target and is never deployed or assigned
+# traffic by this transaction.  Initial capability/storage discovery reads it
+# explicitly; subsequent split releases read the serving console companion.
+if [ "$ROLLOUT_MODE" = initial_split ]; then
+  LEGACY_BACKEND_PATH="${WORK_DIR}/legacy-control-backend.json"
+  gc compute backend-services describe trusted-router-control-backend \
+    --global --format=json >"$LEGACY_BACKEND_PATH" || {
+    echo "ERROR: initial split cannot capture the legacy control backend" >&2
+    exit 1
+  }
+  LEGACY_BACKEND_HASH="$(python3 "$STATE_TOOL" hash-resource "$LEGACY_BACKEND_PATH")" || exit 1
+  python3 - "$LEGACY_BACKEND_PATH" "$PROJECT_ID" "$REGION_CSV" <<'PY' || exit 1
+import json
+import sys
+from pathlib import Path
+
+backend = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+project = sys.argv[2]
+regions = sys.argv[3].split(",")
+expected = {
+    (
+        f"https://www.googleapis.com/compute/v1/projects/{project}/regions/"
+        f"{region}/networkEndpointGroups/trusted-router-control-neg"
+    )
+    for region in regions
+}
+actual = {item.get("group") for item in backend.get("backends") or []}
+if actual != expected:
+    raise SystemExit("legacy control backend has inexact regional NEG membership")
+PY
+  for region in "${REGIONS[@]}"; do
+    legacy_neg_path="${WORK_DIR}/legacy-control-neg-${region}.json"
+    gc compute network-endpoint-groups describe trusted-router-control-neg \
+      --region="$region" --format=json >"$legacy_neg_path" || exit 1
+    python3 - "$legacy_neg_path" "$LEGACY_CONSOLE_SERVICE" <<'PY' || exit 1
+import json
+import sys
+from pathlib import Path
+
+neg = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+cloud_run = (neg.get("cloudRun") or {})
+if neg.get("networkEndpointType") not in {None, "SERVERLESS"}:
+    raise SystemExit("legacy control NEG is not serverless")
+if cloud_run != {"service": sys.argv[2]}:
+    raise SystemExit("legacy control NEG does not target only the legacy monolith")
+PY
+  done
+  python3 - "$PRIOR_URL_MAP" <<'PY' || exit 1
+import json
+import sys
+from pathlib import Path
+
+value = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+
+def strings(item):
+    if isinstance(item, dict):
+        for nested in item.values():
+            yield from strings(nested)
+    elif isinstance(item, list):
+        for nested in item:
+            yield from strings(nested)
+    elif isinstance(item, str):
+        yield item
+
+references = {
+    item.rstrip("/").rsplit("/", 1)[-1]
+    for item in strings(value)
+    if "backendServices" in item or item.endswith("-backend")
+}
+if "trusted-router-control-backend" not in references:
+    raise SystemExit("prior URL map does not bind the legacy control backend")
+managed = {
+    "trusted-router-public-backend",
+    "trusted-router-actions-backend",
+    "trusted-router-console-backend",
+    "trusted-router-chat-backend",
+    "trusted-router-webhooks-backend",
+    "trusted-router-billing-backend",
+}
+unexpected = references & managed
+if unexpected:
+    raise SystemExit(
+        "initial prior URL map already references split backend(s): "
+        + ",".join(sorted(unexpected))
+    )
+PY
+  for region in "${REGIONS[@]}"; do
+    legacy_path="$(legacy_console_json_path "$region")"
+    if ! gc run services describe "$LEGACY_CONSOLE_SERVICE" \
+        --region="$region" --format=json >"$legacy_path"; then
+      echo "ERROR: initial split requires legacy monolith ${LEGACY_CONSOLE_SERVICE}/${region}" >&2
+      exit 1
+    fi
+    python3 "$STATE_TOOL" validate-prior-traffic "$legacy_path" || {
+      echo "ERROR: legacy fallback ${LEGACY_CONSOLE_SERVICE}/${region} traffic is not exactly restorable" >&2
+      exit 1
+    }
+    legacy_traffic="$(python3 "$STATE_TOOL" traffic-state "$legacy_path")" || exit 1
+    legacy_revision="$(jq -er '
+      if (.status.traffic | length) == 1 and
+         (.status.traffic[0].percent == 100) and
+         (.status.traffic[0].tag // null) == null and
+         (.status.traffic[0].revisionName != null)
+      then .status.traffic[0].revisionName
+      else error("legacy fallback is not one named untagged 100% target") end
+    ' "$legacy_path")" || exit 1
+    legacy_generation="$(jq -er '
+      if (.metadata.generation | type) == "number" and
+         (.metadata.generation == .status.observedGeneration)
+      then .metadata.generation
+      else error("legacy fallback generation is not observed") end
+    ' "$legacy_path")" || exit 1
+    legacy_hash="$(python3 "$STATE_TOOL" hash-service "$legacy_path")" || exit 1
+    legacy_revision_path="${WORK_DIR}/legacy-revision-${region}.json"
+    legacy_iam_path="${WORK_DIR}/legacy-service-iam-${region}.json"
+    legacy_secret_refs="${WORK_DIR}/legacy-secret-refs-${region}.tsv"
+    gc run revisions describe "$legacy_revision" --region="$region" --format=json \
+      >"$legacy_revision_path" || exit 1
+    gc run services get-iam-policy "$LEGACY_CONSOLE_SERVICE" \
+      --region="$region" --format=json >"$legacy_iam_path" || exit 1
+    python3 - "$legacy_path" "$legacy_revision_path" "$legacy_iam_path" \
+      "$legacy_revision" "$RUN_SERVICE_ACCOUNT" "$legacy_secret_refs" <<'PY' || exit 1
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+service = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+revision = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+policy = json.loads(Path(sys.argv[3]).read_text(encoding="utf-8"))
+expected_revision = sys.argv[4]
+expected_account = sys.argv[5]
+refs_path = Path(sys.argv[6])
+
+status = service.get("status") or {}
+annotations = (service.get("metadata") or {}).get("annotations") or {}
+ready = any(
+    item.get("type") == "Ready" and item.get("status") == "True"
+    for item in status.get("conditions") or []
+)
+if not ready or status.get("latestReadyRevisionName") != expected_revision:
+    raise SystemExit("legacy fallback service is not Ready on its serving revision")
+if annotations.get("run.googleapis.com/ingress") != "internal-and-cloud-load-balancing":
+    raise SystemExit("legacy fallback desired ingress is not LB-only")
+if annotations.get("run.googleapis.com/ingress-status") != "internal-and-cloud-load-balancing":
+    raise SystemExit("legacy fallback effective ingress is not LB-only")
+
+revision_status = revision.get("status") or {}
+revision_ready = any(
+    item.get("type") == "Ready" and item.get("status") == "True"
+    for item in revision_status.get("conditions") or []
+)
+if (revision.get("metadata") or {}).get("name") != expected_revision or not revision_ready:
+    raise SystemExit("legacy fallback serving revision is not Ready")
+revision_spec = revision.get("spec") or {}
+containers = revision_spec.get("containers") or []
+if len(containers) != 1 or revision_spec.get("serviceAccountName") != expected_account:
+    raise SystemExit("legacy fallback revision identity/container shape is inexact")
+
+all_users = []
+for binding in policy.get("bindings") or []:
+    members = binding.get("members") or []
+    if "allUsers" in members:
+        all_users.append(
+            (binding.get("role"), binding.get("condition"), members.count("allUsers"))
+        )
+if all_users != [("roles/run.invoker", None, 1)]:
+    raise SystemExit("legacy fallback service IAM lacks exact unconditional allUsers invoker")
+
+resource_re = re.compile(
+    r"(?:projects/[a-z][a-z0-9-]{4,28}[a-z0-9]/secrets/)?"
+    r"[a-z][a-z0-9-]{0,253}[a-z0-9]$"
+)
+refs = []
+for item in containers[0].get("env") or []:
+    secret_ref = ((item.get("valueFrom") or {}).get("secretKeyRef") or {})
+    if not secret_ref:
+        continue
+    resource = secret_ref.get("name")
+    version = str(secret_ref.get("key") or "")
+    if not isinstance(resource, str) or not resource_re.fullmatch(resource):
+        raise SystemExit("legacy fallback has a malformed mounted secret resource")
+    if not re.fullmatch(r"[1-9][0-9]*", version):
+        raise SystemExit("legacy fallback mounted secret versions must be numeric")
+    refs.append((resource, version))
+if len(refs) != len(set(refs)):
+    raise SystemExit("legacy fallback has duplicate mounted secret references")
+descriptor = os.open(refs_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+    for resource, version in sorted(refs):
+        output.write(f"{resource}\t{version}\n")
+PY
+    while IFS=$'\t' read -r legacy_secret legacy_version; do
+      [ -n "$legacy_secret" ] || continue
+      legacy_version_path="${WORK_DIR}/legacy-secret-version-${region}-${legacy_version}.json"
+      legacy_policy_path="${WORK_DIR}/legacy-secret-policy-${region}-${legacy_version}.json"
+      gc secrets versions describe "$legacy_version" --secret="$legacy_secret" \
+        --format=json >"$legacy_version_path" || exit 1
+      gc secrets get-iam-policy "$legacy_secret" --format=json \
+        >"$legacy_policy_path" || exit 1
+      python3 - "$legacy_version_path" "$legacy_policy_path" \
+        "serviceAccount:${RUN_SERVICE_ACCOUNT}" <<'PY' || exit 1
+import json
+import sys
+from pathlib import Path
+
+version = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+policy = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+member = sys.argv[3]
+if version.get("state") != "ENABLED":
+    raise SystemExit("legacy fallback mounted secret version is not ENABLED")
+direct = sorted(
+    (binding.get("role"), binding.get("condition"))
+    for binding in policy.get("bindings") or []
+    if member in (binding.get("members") or [])
+)
+if direct != [("roles/secretmanager.secretAccessor", None)]:
+    raise SystemExit("legacy fallback runtime lacks exact mounted-secret access")
+PY
+    done <"$legacy_secret_refs"
+    legacy_revision_hash="$(python3 "$STATE_TOOL" hash-revision "$legacy_revision_path")" || exit 1
+    legacy_invoker_iam_hash="$(python3 "$STATE_TOOL" hash-iam-policy "$legacy_iam_path")" || exit 1
+    jq -cn \
+      --arg service "$LEGACY_CONSOLE_SERVICE" \
+      --arg backend trusted-router-control-backend \
+      --arg region "$region" \
+      --argjson generation "$legacy_generation" \
+      --arg serving_revision "$legacy_revision" \
+      --arg serving_revision_sha256 "$legacy_revision_hash" \
+      --argjson traffic "$legacy_traffic" \
+      --arg postcondition_sha256 "$legacy_hash" \
+      --arg backend_postcondition_sha256 "$LEGACY_BACKEND_HASH" \
+      --arg invoker_iam_sha256 "$legacy_invoker_iam_hash" \
+      '{service:$service,backend:$backend,region:$region,generation:$generation,
+        serving_revision:$serving_revision,
+        serving_revision_sha256:$serving_revision_sha256,traffic:$traffic,
+        postcondition_sha256:$postcondition_sha256,
+        backend_postcondition_sha256:$backend_postcondition_sha256,
+        invoker_iam_sha256:$invoker_iam_sha256}' >>"$LEGACY_FALLBACK_FILE"
+  done
 fi
-if [ "$ANALYTICS_READ_MODE" = "clickhouse" ] && {
-  [ "$LIVE_ANALYTICS_READ_MODE" != "clickhouse" ] ||
-  [ -z "$ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT" ];
-}; then
-  ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# A removed control-plane region must not leave a canonical split service (and
+# especially a default run.app origin) outside this transaction. Cloud Run's
+# project-wide inventory is therefore exact for the six canonical names.
+ALL_RUN_SERVICES="${WORK_DIR}/all-run-services.json"
+gc run services list --platform=managed --format=json >"$ALL_RUN_SERVICES"
+python3 - "$ALL_RUN_SERVICES" "$REGION_CSV" "$INTERNAL_ALLOWED_REGION_CSV" \
+  "$PUBLIC_SERVICE" "$ACTIONS_SERVICE" "$CONSOLE_SERVICE" "$CHAT_SERVICE" \
+  "$WEBHOOKS_SERVICE" "$INTERNAL_SERVICE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+items = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+regions = set(sys.argv[2].split(","))
+internal_regions = set(sys.argv[3].split(","))
+canonical = set(sys.argv[4:])
+if not isinstance(items, list):
+    raise SystemExit("Cloud Run service inventory is not a list")
+for item in items:
+    metadata = item.get("metadata") or {}
+    name = metadata.get("name") or item.get("name")
+    if name not in canonical:
+        continue
+    labels = metadata.get("labels") or {}
+    annotations = metadata.get("annotations") or {}
+    region = (
+        item.get("location")
+        or labels.get("cloud.googleapis.com/location")
+        or labels.get("run.googleapis.com/location")
+        or annotations.get("run.googleapis.com/location")
+    )
+    allowed = internal_regions if name == "trusted-router-billing" else regions
+    if region not in allowed:
+        raise SystemExit(
+            f"canonical Cloud Run service {name} exists outside configured regions: {region!r}"
+        )
+PY
+
+# `gcloud run deploy --no-traffic` deliberately converts floating LATEST
+# traffic to its currently resolved revision before it creates a candidate.
+# That conversion cannot be reversed safely: setting LATEST during rollback
+# would select the candidate, and Cloud Run does not permit deleting the latest
+# revision. Require operators to make that semantic change explicit by pinning
+# every floating traffic/tag target before this all-surface transaction.
+for surface in "${SURFACES[@]}"; do
+  while IFS= read -r region; do
+    prior_path="$(prior_json_path "$surface" "$region")"
+    [ -f "$prior_path" ] || continue
+    if ! python3 "$STATE_TOOL" validate-prior-traffic "$prior_path"; then
+      echo "ERROR: ${surface}/${region} prior traffic is not exactly restorable" >&2
+      exit 1
+    fi
+    captured_traffic="$(python3 "$STATE_TOOL" traffic-state "$prior_path")" || exit 1
+    if jq -e 'any(.[]; .latest_revision)' <<<"$captured_traffic" >/dev/null; then
+      echo "ERROR: ${surface}/${region} has floating LATEST traffic or tags; pin it to named revisions before staging" >&2
+      exit 1
+    fi
+  done < <(surface_region_lines "$surface")
+done
+
+if [ "$ROLLOUT_MODE" = initial_split ]; then
+  PRIMARY_PRIOR="$(legacy_console_json_path "${REGIONS[0]}")"
+else
+  PRIMARY_PRIOR="$(prior_json_path console "${REGIONS[0]}")"
 fi
+PRIMARY_CAPABILITY_STATE=""
+SERVING_CONSOLE_JSON="${WORK_DIR}/serving-console-${REGIONS[0]}.json"
+for region in "${REGIONS[@]}"; do
+  if [ "$ROLLOUT_MODE" = initial_split ]; then
+    region_prior="$(legacy_console_json_path "$region")"
+  else
+    region_prior="$(prior_json_path console "$region")"
+  fi
+  serving_revision="$(jq -er '
+    [.status.traffic[]? | select((.percent // 0) > 0)] as $live
+    | if ($live | length) == 1 and ($live[0].percent == 100) and ($live[0].revisionName != null)
+      then $live[0].revisionName else error("console traffic is not one unambiguous 100% revision") end
+  ' "$region_prior")"
+  serving_json="${WORK_DIR}/serving-console-${region}.json"
+  gc run revisions describe "$serving_revision" --region="$region" --format=json >"$serving_json"
+  capability_state="$(python3 - "$serving_json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+revision = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+items = ((revision.get("spec") or {}).get("containers") or [{}])[0].get("env") or []
+values = {item.get("name"): str(item.get("value", "")) for item in items if "valueFrom" not in item}
+secrets = {
+    item.get("name"): (((item.get("valueFrom") or {}).get("secretKeyRef") or {}).get("name") or "").split("/")[-1]
+    for item in items
+    if "valueFrom" in item
+}
+def boolean_or_missing(name: str) -> str:
+    value = values.get(name, "__missing__")
+    if value not in {"true", "false", "__missing__"}:
+        raise SystemExit(f"invalid serving capability {name}")
+    return value
+def oauth(name: str, fields: tuple[str, str]) -> str:
+    explicit = boolean_or_missing(name)
+    if explicit != "__missing__":
+        return explicit
+    present = [bool(secrets.get(field)) for field in fields]
+    if any(present) and not all(present):
+        raise SystemExit(f"partial serving OAuth capability {name}")
+    return "true" if all(present) else "false"
+state = {
+    "new_signups": values.get("TR_NEW_SIGNUPS_ENABLED", "true"),
+    "google_oauth": oauth("TR_GOOGLE_OAUTH_LOGIN_AVAILABLE", ("TR_GOOGLE_CLIENT_ID", "TR_GOOGLE_CLIENT_SECRET")),
+    "github_oauth": oauth("TR_GITHUB_OAUTH_LOGIN_AVAILABLE", ("TR_GITHUB_CLIENT_ID", "TR_GITHUB_CLIENT_SECRET")),
+    "paypal": boolean_or_missing("TR_PAYPAL_CHECKOUT_ENABLED"),
+    "paypal_console_credentials": all(
+        bool(secrets.get(name))
+        for name in ("TR_PAYPAL_CLIENT_ID", "TR_PAYPAL_CLIENT_SECRET")
+    ),
+    "adyen": boolean_or_missing("TR_ADYEN_ENABLED"),
+    "adyen_console_credentials": all(
+        bool(secrets.get(name))
+        for name in ("TR_ADYEN_API_KEY", "TR_ADYEN_CLIENT_KEY", "TR_ADYEN_REFERENCE_KEY")
+    ),
+    "veriff": boolean_or_missing("TR_VERIFF_ENABLED"),
+    "veriff_console_credentials": bool(secrets.get("TR_VERIFF_API_KEY")),
+    "storage": values.get("TR_STORAGE_BACKEND", "spanner-bigtable"),
+    "request_records": values.get("TR_REQUEST_RECORD_WRITE_MODE", "__missing__"),
+    "analytics_reads": values.get("TR_ANALYTICS_READ_MODE", "bigtable"),
+    "generation_records": values.get("TR_GENERATION_RECORDS_ENABLED", "false"),
+    "bigtable_mirror": values.get("TR_BIGTABLE_MIRROR_WRITES_ENABLED", "true"),
+    "provider_clickhouse_url": values.get("TR_PROVIDER_ANALYTICS_CLICKHOUSE_URL", ""),
+    "telnyx_from": values.get("TR_TELNYX_FROM_NUMBER", ""),
+    "telnyx_account": values.get("TR_TELNYX_TEXML_ACCOUNT_ID", ""),
+    "telnyx_application": values.get("TR_TELNYX_TEXML_APPLICATION_ID", ""),
+    "twilio_from": values.get("TR_TWILIO_FROM_NUMBER", ""),
+}
+print(json.dumps(state, sort_keys=True, separators=(",", ":")))
+PY
+)"
+  if [ -z "$PRIMARY_CAPABILITY_STATE" ]; then
+    PRIMARY_CAPABILITY_STATE="$capability_state"
+  elif [ "$capability_state" != "$PRIMARY_CAPABILITY_STATE" ]; then
+    echo "ERROR: serving console capability/storage state differs across regions" >&2
+    exit 1
+  fi
+done
+
+serving_env_value() {
+  local name="$1" default_value="${2:-}"
+  jq -r --arg name "$name" --arg default "$default_value" '
+    [.spec.containers[0].env[]? | select(.name == $name) | .value][0] // $default
+  ' "$SERVING_CONSOLE_JSON"
+}
 
 # Regional quota capability and traffic issuance are separate switches. Resolve
 # preserved values from the one revision receiving 100% of primary traffic,
 # never the latest candidate or service template: both still point at a rejected
-# revision after rollback. Only an exact missing-service response represents a
-# fresh environment; every other control-plane read error aborts the rollout.
+# revision after rollback. During the initial split that authority is the legacy
+# service; after the split it is the internal/billing service.
+ROLLOUT_SERVICE="$SERVICE"
+REGIONAL_QUOTA_SERVICE="$SERVICE"
+if [ "$ROLLOUT_MODE" = existing_split ]; then
+  REGIONAL_QUOTA_SERVICE="$INTERNAL_SERVICE"
+fi
+SERVICE="$REGIONAL_QUOTA_SERVICE"
 REGIONAL_QUOTA_PRIMARY_FRESH=false
 REGIONAL_QUOTA_PRIMARY_REVISION_JSON=""
 if REGIONAL_QUOTA_PRIMARY_REVISION_JSON="$(
@@ -332,7 +1023,7 @@ fi
 read_primary_regional_quota_env() {
   local name="$1"
   local default_value="${2:-}"
-  if [ "$REGIONAL_QUOTA_PRIMARY_FRESH" = "true" ]; then
+  if [ "$REGIONAL_QUOTA_PRIMARY_FRESH" = true ]; then
     printf '%s\n' "$default_value"
     return 0
   fi
@@ -369,8 +1060,8 @@ REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED="$(
     "$REGIONAL_QUOTA_LEASE_ISSUANCE_CONTROL" \
     "$LIVE_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED"
 )"
-if [ "$REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED" = "true" ] &&
-   [ "$REGIONAL_QUOTA_LEASES_ENABLED" != "true" ]; then
+if [ "$REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED" = true ] &&
+   [ "$REGIONAL_QUOTA_LEASES_ENABLED" != true ]; then
   log "refusing rollout: regional quota issuance requires lease capability"
   exit 1
 fi
@@ -396,7 +1087,7 @@ REGIONAL_QUOTA_LEASE_MAX_AVAILABLE_BASIS_POINTS="${TR_REGIONAL_QUOTA_LEASE_MAX_A
 REGIONAL_QUOTA_LEASE_SHARD_COUNT="${TR_REGIONAL_QUOTA_LEASE_SHARD_COUNT:-$(
   read_primary_regional_quota_env "TR_REGIONAL_QUOTA_LEASE_SHARD_COUNT" "16"
 )}"
-if [ "$REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED" = "true" ] && {
+if [ "$REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED" = true ] && {
   [ -z "$REGIONAL_QUOTA_LEASE_PILOT_WORKSPACE_IDS" ] ||
   [ -z "$REGIONAL_QUOTA_BIGTABLE_APP_PROFILES" ];
 }; then
@@ -405,249 +1096,1571 @@ if [ "$REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED" = "true" ] && {
 fi
 
 # This executes before gcloud run deploy can create any issuance-enabled
-# revision. Every currently active fleet member must already be settlement-
-# capable and must explicitly carry the new boolean marker. That creates a
-# compatibility phase between landing the code and enabling issuance.
-if [ "$REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED" = "true" ]; then
+# revision. Every currently active internal/billing fleet member must already
+# be settlement-capable and explicitly carry the independent issuance marker.
+if [ "$REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED" = true ]; then
   regional_quota_preflight_issuance_fleet
 fi
-
-# Prefer the private three-replica ClickHouse load balancer once provisioned.
-# The direct node-1 address remains only as a migration fallback for projects
-# that have not run clickhouse_cluster.sh yet.
-PROVIDER_ANALYTICS_CLICKHOUSE_URL="${TR_PROVIDER_ANALYTICS_CLICKHOUSE_URL:-}"
-if [ -z "$PROVIDER_ANALYTICS_CLICKHOUSE_URL" ]; then
-  clickhouse_ilb_ip="$(gc compute addresses describe tr-clickhouse-ilb \
-    --region=us-central1 --format='value(address)' 2>/dev/null || true)"
-  if [ -n "$clickhouse_ilb_ip" ]; then
-    PROVIDER_ANALYTICS_CLICKHOUSE_URL="http://${clickhouse_ilb_ip}:8123"
-  else
-    PROVIDER_ANALYTICS_CLICKHOUSE_URL="http://10.128.15.214:8123"
-  fi
+SERVICE="$ROLLOUT_SERVICE"
+if [ "$ROLLOUT_MODE" = initial_split ] && {
+  [ "$REGIONAL_QUOTA_LEASES_ENABLED" != false ] ||
+  [ "$REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED" != false ];
+}; then
+  echo "ERROR: initial six-surface split requires regional quota capability and issuance disabled until the bootstrapped internal cohort is replaced" >&2
+  exit 1
 fi
 
-ENV_VARS=(
-  "TR_ENVIRONMENT=production"
-  "TR_RELEASE=$(git rev-parse --short HEAD 2>/dev/null || echo local)"
-  # Request-based Cloud Run CPU can pause background coroutines. The scheduled
-  # synthetic job invokes /internal/synthetic/remediate instead.
-  "TR_REMEDIATOR_IN_PROCESS_ENABLED=false"
-  "TR_ENABLE_LIVE_PROVIDERS=false"
-  "TR_API_BASE_URL=https://api.trustedrouter.com/v1"
-  "TR_TRUSTED_DOMAIN=trustedrouter.com"
-  "TR_TRUSTED_DOMAIN_ALIASES=allyrouter.com,uptimerouter.com"
-  "TR_STORAGE_BACKEND=${STORAGE_BACKEND}"
-  # Exactly $0.30 once per newly created email/social OAuth account. Wallet-only
-  # accounts stay at $0. Keep this explicit so stale env cannot change policy.
-  "TR_SIGNUP_TRIAL_CREDIT_MICRODOLLARS=300000"
-  "TR_GCP_PROJECT_ID=${PROJECT_ID}"
-  # Owner notifications. The identifiers here are not secrets — the numbers are
-  # public and the ids name resources, not authorise them — so they live in
-  # plain env alongside the credentials in Secret Manager.
-  #
-  # Telnyx voice needs BOTH ids: the account id is the ORGANISATION id from
-  # /v2/whoami (the connection id and application id both 404 there), and the
-  # application id is what carries the outbound voice profile. Missing either
-  # one is a 422 or a 403 on every call.
-  "TR_NOTIFY_ENABLED=true"
-  "TR_NOTIFY_SMS_AVAILABLE=false"
-  # Identity verification and the custom-model verification gate are a PAIR
-  # and must flip together: enabling the gate without a reachable Veriff
-  # would 403 every custom-model create/edit with an unsatisfiable
-  # "identity_verified" — a silent lockout, not a boot failure. Activated
-  # 2026-08-16 once trustedrouter-veriff-{api-key,shared-secret-key} existed
-  # in Secret Manager (the deploy SA reads them via add_secret_env_if_exists
-  # above; it cannot create them). The config validator refuses
-  # TR_VERIFF_ENABLED=true without both secrets, so a rollout that lost them
-  # fails loud at boot rather than serving broken. To go dark again, set BOTH
-  # back to false in one commit.
-  "TR_VERIFF_ENABLED=true"
-  "TR_CUSTOM_MODELS_REQUIRE_VERIFICATION=true"
-  # User-provided models serve from here. The half that made this unsafe —
-  # settle/refund of the synthetic user-model endpoint, and the exactly-once
-  # payout — shipped in #608, and the attested enclave that dispatches them
-  # shipped in quill-cloud-proxy 7925a4f. Registration, probing and the public
-  # section always worked; this is the switch that lets the gateway AUTHORIZE
-  # and route to one. Off again = the gateway 404s user-model ids; in-flight
-  # holds still settle, because settle does not read this flag.
-  "TR_USER_MODELS_DISPATCH_ENABLED=true"
-  "TR_VERIFF_BASE_URL=https://stationapi.veriff.com"
-  "TR_TELNYX_FROM_NUMBER=+17869471547"
-  "TR_TELNYX_TEXML_ACCOUNT_ID=1eea716a-02e0-4d4f-96fa-36d1f556edca"
-  "TR_TELNYX_TEXML_APPLICATION_ID=3026758434193146987"
-  # The 10DLC-registered sender. SMS defaults to Twilio because registration is
-  # per carrier and Telnyx is not registered — it rejects US SMS outright.
-  "TR_TWILIO_FROM_NUMBER=+15055313623"
-  "TR_SPANNER_INSTANCE_ID=${SPANNER_INSTANCE_ID}"
-  "TR_SPANNER_DATABASE_ID=${SPANNER_DATABASE_ID}"
-  "TR_BIGTABLE_INSTANCE_ID=${BIGTABLE_INSTANCE_ID}"
-  "TR_BIGTABLE_GENERATION_TABLE=${BIGTABLE_GENERATION_TABLE}"
-  "TR_BIGTABLE_MIRROR_WRITES_ENABLED=${BIGTABLE_MIRROR_WRITES_ENABLED}"
-  "TR_GENERATION_RECORDS_ENABLED=${GENERATION_RECORDS_ENABLED}"
-  "TR_BYOK_KMS_KEY_NAME=${BYOK_KMS_KEY_NAME}"
-  "TR_GOOGLE_DATA_MANAGER_KMS_KEY_NAME=${GOOGLE_ADS_KMS_KEY_NAME}"
-  "TR_REGIONS=${TR_REGIONS}"
-  "TR_PRIMARY_REGION=${TR_PRIMARY_REGION}"
-  "TR_SPANNER_POOL_SIZE=${TR_SPANNER_POOL_SIZE}"
-  "VERTEX_PROJECT_ID=${PROJECT_ID}"
-  "VERTEX_LOCATION=${REGION}"
-  "TR_TRUST_GCP_SOURCE_COMMIT=${TRUST_SOURCE_COMMIT}"
-  "TR_TRUST_GCP_IMAGE_REFERENCE=${TRUST_IMAGE_REFERENCE}"
-  "TR_TRUST_GCP_IMAGE_DIGEST=${TRUST_IMAGE_DIGEST}"
-  "TR_TRUST_GCP_RELEASE_URL=${TRUST_FILE_URL}"
-  "TR_TRUST_GCP_RELEASE_FALLBACK_URLS=https://raw.githubusercontent.com/Lore-Hex/quill-cloud-proxy/main/trust-page/gcp-release.json"
-  # AWS and Azure measurements are NOT injected here any more. Each plane
-  # publishes its own record, produced from a live attestation by
-  # quill-cloud-proxy's tools/capture-plane-measurements.py, and the control
-  # plane mirrors it from the URL below. Pinning them here made this one
-  # GCP-region rollout script the authority for what three independent planes
-  # were running — one place to falsify, one place to fail, and one more value
-  # to remember to update on every enclave rebuild.
-  "TR_TRUST_AWS_RELEASE_URL=https://trust.trustedrouter.com/trust/aws-release.json"
-  "TR_TRUST_AZURE_RELEASE_URL=https://trust.trustedrouter.com/trust/azure-release.json"
-  "TR_GOOGLE_OAUTH_REDIRECT_URL=https://trustedrouter.com/google_oauth_callback"
-  "TR_GITHUB_OAUTH_REDIRECT_URL=https://trustedrouter.com/github_oauth_callback"
-  "TR_SIWE_DOMAIN=trustedrouter.com"
-  "TR_AWS_REGION=us-east-1" # SES region only; hosted compute is GCP-only.
-  "TR_SES_FROM_EMAIL=noreply@trustedrouter.com"
-  "TR_SES_FROM_NAME=TrustedRouter"
-  "TR_SES_ALERT_FROM_EMAIL=alerts@alerts.trustedrouter.com"
-  "TR_SES_ALERT_FROM_NAME=TrustedRouter Alerts"
-  "TR_SES_ALERT_CONFIGURATION_SET=trustedrouter-alerts"
-  # Reputation brake: keep optional activation nudges off until SES class-level
-  # telemetry has a clean observation window. Login and verification email are
-  # unaffected because they are sent synchronously by their auth routes.
-  "TR_ACTIVATION_REMINDER_INTERVAL_SECONDS=0"
-  "TR_SUPPORT_EMAIL=help@trustedrouter.com"
-  # Adyen ships dark. Activating checkout is an intentional one-line release
-  # after the merchant, HMAC webhook, and test-payment canary are green.
-  "TR_ADYEN_ENABLED=false"
-  "TR_ADYEN_ENVIRONMENT=test"
-  "TR_ADYEN_MERCHANT_ACCOUNT=TrustedRouterUS"
-  "TR_ADYEN_CHECKOUT_API_VERSION=72"
-  "TR_ADYEN_WEB_VERSION=6.41.0"
-  # Replace these zeros with the signed Adyen commercial terms before launch.
-  "TR_ADYEN_CARD_FEE_BASIS_POINTS=0"
-  "TR_ADYEN_CARD_FEE_FIXED_CENTS=0"
-  "TR_CHECKOUT_CARD_FEE_MINIMUM_CENTS=80"
-  "TR_OPS_CHAT_WEBHOOK_URLS=https://a.uptimerouter.com,https://b.trustedrouter.com,https://c.allyrouter.com"
-  # /trustedos partner-inquiry form leads. Plain env (an address, not a
-  # secret); without it the handler falls back to TR_SES_FROM_EMAIL, which
-  # is send-only and effectively a black hole.
-  "TR_PARTNER_INQUIRY_EMAIL=joseph@jperla.com"
-  # Axiom log shipping. Token comes from Secret Manager via the
-  # add_secret_env_if_exists block above; dataset name is plain config.
-  # Empty AXIOM_API_TOKEN at runtime → handler is not registered (graceful no-op).
-  "TR_AXIOM_DATASET=trusted-router-logs"
-  "TR_AXIOM_URL=https://eu-central-1.aws.edge.axiom.co"
-  # Durable settle outbox (docs/design/durable-settle-outbox.md §5.4, §8):
-  # every gateway settle/refund durably records its frozen intent BEFORE the
-  # inline finalize, and /internal/gateway/settle-outbox/drain recovers any
-  # that were lost so the reaper never free-releases a completed request.
-  # DDL applied 2026-07-04 (migrate_typed_counters.sh); reaper guard armed.
-  # Flipped 2026-07-04 with Joseph's authorization. Remove to revert — the
-  # flag-off settle path is byte-identical.
-  "TR_SETTLE_OUTBOX_ENABLED=true"
-  # Provider benchmark events use their own best-effort durable queue. Tenant
-  # activity is different: its operational outbox insert is part of the typed
-  # settlement transaction, so a charge and its delivery intent cannot split.
-  # ClickHouse remains asynchronous and never participates in inference.
-  "TR_ANALYTICS_OUTBOX_ENABLED=true"
-  "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true"
-  # Client-observed reliability beacons (docs/client-telemetry.md §4): SDKs
-  # POST content-free per-request outcomes + exact minute counters to
-  # /v1/client-events; one operational-outbox row per batch; the ClickHouse
-  # node fans it out (DDL 008 applied on all replicas 2026-08-16, ingester
-  # quarantines poison rows, rollup timer live). Flipped 2026-08-17 per the
-  # approved plan after the local 200 POST/s x 64 KB smoke (all 202, p99 134
-  # ms) and R-PR4's canary probe + corroborated alerts landed. Off = the route
-  # answers 202 + `x-tr-telemetry: off` + pause 86400 before reading a body,
-  # so removing this line stops every SDK within one flush.
-  "TR_CLIENT_EVENTS_ENABLED=true"
-  # Private provider operations portal. Direct VPC egress below reaches this
-  # RFC1918 address; ClickHouse has no public IP and the credential is a
-  # SELECT-only account scoped to the benchmark table.
-  "TR_PROVIDER_ANALYTICS_CLICKHOUSE_URL=${PROVIDER_ANALYTICS_CLICKHOUSE_URL}"
-  "TR_PROVIDER_ANALYTICS_CLICKHOUSE_USER=tr_provider_read"
-  "TR_PROVIDER_ANALYTICS_CLICKHOUSE_DATABASE=tr"
-  "TR_PROVIDER_ANALYTICS_CLICKHOUSE_TABLE=provider_benchmark_samples"
-  "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_URL=${PROVIDER_ANALYTICS_CLICKHOUSE_URL}"
-  "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_USER=tr_control_read"
-  "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_DATABASE=tr"
-  "TR_ANALYTICS_READ_MODE=${ANALYTICS_READ_MODE}"
-  "TR_ANALYTICS_DUAL_READ_GRACE_SECONDS=30"
-  "TR_ANALYTICS_DUAL_READ_STARTED_AT=${ANALYTICS_DUAL_READ_STARTED_AT}"
-  "TR_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT=${ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT}"
-  # The first expand deployment defaults to legacy. After an explicit typed
-  # cutover, preserve the primary region's live mode on later deploys unless an
-  # operator overrides it. This prevents routine rollouts from reopening the
-  # unbounded generic write path.
-  "TR_REQUEST_RECORD_WRITE_MODE=${REQUEST_RECORD_WRITE_MODE}"
-  # Bounded regional escrow. Capability keeps settlement/reconciliation ready;
-  # the independent issuance marker stays off through the compatibility phase.
-  "TR_REGIONAL_QUOTA_LEASES_ENABLED=${REGIONAL_QUOTA_LEASES_ENABLED}"
-  "TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED=${REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED}"
-  "TR_REGIONAL_QUOTA_LEASE_PILOT_WORKSPACE_IDS=${REGIONAL_QUOTA_LEASE_PILOT_WORKSPACE_IDS}"
-  "TR_REGIONAL_QUOTA_LEASE_TTL_SECONDS=${REGIONAL_QUOTA_LEASE_TTL_SECONDS}"
-  "TR_REGIONAL_QUOTA_LEASE_MAX_MICRODOLLARS=${REGIONAL_QUOTA_LEASE_MAX_MICRODOLLARS}"
-  "TR_REGIONAL_QUOTA_LEASE_MAX_AVAILABLE_BASIS_POINTS=${REGIONAL_QUOTA_LEASE_MAX_AVAILABLE_BASIS_POINTS}"
-  "TR_REGIONAL_QUOTA_LEASE_SHARD_COUNT=${REGIONAL_QUOTA_LEASE_SHARD_COUNT}"
-  "TR_REGIONAL_QUOTA_BIGTABLE_TABLE=${REGIONAL_QUOTA_BIGTABLE_TABLE}"
-  "TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES=${REGIONAL_QUOTA_BIGTABLE_APP_PROFILES}"
-)
-SET_ENV_VARS="$(IFS='|'; echo "^|^${ENV_VARS[*]}")"
+serving_secret_name() {
+  local name="$1"
+  jq -r --arg name "$name" '
+    [.spec.containers[0].env[]? | select(.name == $name)
+      | .valueFrom.secretKeyRef.name][0] // ""
+    | split("/")[-1]
+  ' "$SERVING_CONSOLE_JSON"
+}
+require_bool() {
+  local name="$1" value="$2"
+  case "$value" in true|false) echo "$value" ;; *) echo "ERROR: ${name} must be true or false" >&2; return 1 ;; esac
+}
+resolve_credential_capability() {
+  local input_name="$1" field="$2" missing_default="$3"
+  shift 3
+  local explicit="${!input_name:-}" live any=0 all=1 credential
+  if [ -n "$explicit" ]; then require_bool "$input_name" "$explicit"; return; fi
+  live="$(serving_env_value "$field")"
+  if [ -n "$live" ]; then require_bool "$field on serving console" "$live"; return; fi
+  for credential in "$@"; do
+    if [ -n "$(serving_secret_name "$credential")" ]; then any=1; else all=0; fi
+  done
+  if [ "$any" = 1 ] && [ "$all" = 0 ]; then
+    echo "ERROR: serving console has a partial ${field} credential set" >&2
+    return 1
+  fi
+  if [ "$all" = 1 ] && [ "$#" -gt 0 ]; then echo true; else echo "$missing_default"; fi
+}
+resolve_explicit_or_serving_flag() {
+  local input_name="$1" field="$2"
+  local explicit="${!input_name:-}" live
+  if [ -n "$explicit" ]; then require_bool "$input_name" "$explicit"; return; fi
+  live="$(serving_env_value "$field")"
+  if [ -z "$live" ]; then
+    echo "ERROR: ${input_name} must be explicit because the unambiguous serving console revision has no capability flag" >&2
+    return 1
+  fi
+  require_bool "$field on serving console" "$live"
+}
 
-prune_failed_revisions() {
-  # `gcloud run deploy --no-traffic` waits for the LATEST revision on the
-  # service to be Ready before returning success. If a previous deploy
-  # left a NotReady revision (container failed to start, OOM during
-  # startup probe, missing env, etc.) AND the latest revision is that
-  # NotReady one, the new deploy gets misreported as failed even when
-  # it successfully created a fresh revision behind the latest tag.
-  #
-  # Caught the hard way during the 2026-05-10 cutover: paypal.py was
-  # uncommitted, an earlier deploy created revision 00131-zkk (Failed),
-  # and every subsequent deploy returned "Revision 00131-zkk is not
-  # ready" instead of failing-clean — leaving the operator to
-  # manually `update-traffic` to the actually-healthy fresh revision.
-  #
-  # Fix: before deploying, find revisions whose Ready condition is
-  # neither True nor pending and which currently have no traffic
-  # routed (so they're safe to delete) and remove them. Idempotent;
-  # no-op when everything is healthy.
-  local target="$1"
-  local serving
-  serving=$(gc run services describe "$SERVICE" --region "$target" \
-    --format='value(status.traffic[].revisionName)' 2>/dev/null \
-    | tr ';' ' ')
-  local failed_revs
-  failed_revs=$(gc run revisions list --service "$SERVICE" --region "$target" \
-    --format='value(metadata.name,status.conditions[0].status)' 2>/dev/null \
-    | awk '$2 == "False" { print $1 }')
-  for rev in $failed_revs; do
-    # Skip if this NotReady revision is somehow still in the traffic
-    # split — better to leave it and let the operator decide than risk
-    # hitting a revision we deleted while live.
-    case " $serving " in
-      *" $rev "*) continue ;;
+GOOGLE_OAUTH_AVAILABLE="$(resolve_credential_capability \
+  TR_GOOGLE_OAUTH_LOGIN_AVAILABLE TR_GOOGLE_OAUTH_LOGIN_AVAILABLE false \
+  TR_GOOGLE_CLIENT_ID TR_GOOGLE_CLIENT_SECRET)"
+GITHUB_OAUTH_AVAILABLE="$(resolve_credential_capability \
+  TR_GITHUB_OAUTH_LOGIN_AVAILABLE TR_GITHUB_OAUTH_LOGIN_AVAILABLE false \
+  TR_GITHUB_CLIENT_ID TR_GITHUB_CLIENT_SECRET)"
+PAYPAL_CHECKOUT_ENABLED="$(resolve_explicit_or_serving_flag \
+  TR_PAYPAL_CHECKOUT_ENABLED TR_PAYPAL_CHECKOUT_ENABLED)"
+ADYEN_ENABLED="$(resolve_explicit_or_serving_flag \
+  TR_ADYEN_ENABLED TR_ADYEN_ENABLED)"
+VERIFF_ENABLED="$(resolve_explicit_or_serving_flag \
+  TR_VERIFF_ENABLED TR_VERIFF_ENABLED)"
+NEW_SIGNUPS_ENABLED="$(require_bool TR_NEW_SIGNUPS_ENABLED \
+  "${TR_NEW_SIGNUPS_ENABLED:-$(serving_env_value TR_NEW_SIGNUPS_ENABLED true)}")"
+
+REQUEST_RECORD_WRITE_MODE="${TR_REQUEST_RECORD_WRITE_MODE:-$(serving_env_value TR_REQUEST_RECORD_WRITE_MODE)}"
+case "$REQUEST_RECORD_WRITE_MODE" in legacy|typed) ;; *)
+  echo "ERROR: cannot determine TR_REQUEST_RECORD_WRITE_MODE from the serving console" >&2; exit 1 ;;
+esac
+STORAGE_BACKEND="${TR_STORAGE_BACKEND:-$(serving_env_value TR_STORAGE_BACKEND spanner-bigtable)}"
+case "$STORAGE_BACKEND" in spanner-bigtable|spanner-clickhouse) ;; *)
+  echo "ERROR: invalid TR_STORAGE_BACKEND" >&2; exit 1 ;;
+esac
+ANALYTICS_READ_MODE="${TR_ANALYTICS_READ_MODE:-$(serving_env_value TR_ANALYTICS_READ_MODE bigtable)}"
+case "$ANALYTICS_READ_MODE" in bigtable|dual|clickhouse|clickhouse-only) ;; *)
+  echo "ERROR: invalid TR_ANALYTICS_READ_MODE" >&2; exit 1 ;;
+esac
+GENERATION_RECORDS_ENABLED="$(require_bool TR_GENERATION_RECORDS_ENABLED \
+  "${TR_GENERATION_RECORDS_ENABLED:-$(serving_env_value TR_GENERATION_RECORDS_ENABLED true)}")"
+BIGTABLE_MIRROR_WRITES_ENABLED="$(require_bool TR_BIGTABLE_MIRROR_WRITES_ENABLED \
+  "${TR_BIGTABLE_MIRROR_WRITES_ENABLED:-$(serving_env_value TR_BIGTABLE_MIRROR_WRITES_ENABLED true)}")"
+if [ "$STORAGE_BACKEND" = spanner-clickhouse ] && {
+  [ "$ANALYTICS_READ_MODE" != clickhouse-only ] ||
+  [ "$GENERATION_RECORDS_ENABLED" != true ] ||
+  [ "$BIGTABLE_MIRROR_WRITES_ENABLED" != false ] ||
+  [ "$REQUEST_RECORD_WRITE_MODE" != typed ];
+}; then
+  echo "ERROR: spanner-clickhouse requires clickhouse-only, typed records, generation records, and no Bigtable mirror" >&2
+  exit 1
+fi
+
+verify_policy_roles() {
+  local label="$1" member="$2" expected_role="$3"
+  shift 3
+  local policy actual expected
+  policy="$("$@")" || { echo "ERROR: cannot read ${label} IAM" >&2; return 1; }
+  actual="$(jq -c --arg member "$member" '[
+    .bindings[]? | select(any(.members[]?; . == $member))
+    | {role, condition: (.condition // null)}
+  ] | unique' <<<"$policy")" || return 1
+  if [ -n "$expected_role" ]; then
+    expected="$(jq -cn --arg role "$expected_role" '[{role:$role,condition:null}]')"
+  else
+    expected='[]'
+  fi
+  [ "$actual" = "$expected" ] || {
+    echo "ERROR: ${member} has ${label} IAM ${actual}, expected ${expected}" >&2
+    return 1
+  }
+}
+
+PROJECT_POLICY_JSON="$(gc projects get-iam-policy "$PROJECT_ID" --format=json)"
+SPANNER_POLICY_JSON="$(gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID" \
+  --instance="$SPANNER_INSTANCE_ID" --format=json)"
+BIGTABLE_POLICY_JSON="$(gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID" --format=json)"
+BYOK_POLICY_JSON="$(gc kms keys get-iam-policy "$BYOK_KMS_KEY_ID" \
+  --keyring="$KMS_KEYRING_ID" --location="$REGION" --format=json)"
+GOOGLE_ADS_POLICY_JSON="$(gc kms keys get-iam-policy "$GOOGLE_ADS_KMS_KEY_ID" \
+  --keyring="$KMS_KEYRING_ID" --location="$REGION" --format=json)"
+
+for surface in "${SURFACES[@]}"; do
+  account="$(surface_account "$surface")"
+  member="serviceAccount:${account}"
+  case "$surface" in actions) project_role="" ;; *) project_role="roles/serviceusage.serviceUsageConsumer" ;; esac
+  verify_policy_roles "project" "$member" "$project_role" printf '%s' "$PROJECT_POLICY_JSON"
+  case "$surface" in
+    public|chat) spanner_role="roles/spanner.databaseReader" ;;
+    console|webhooks|internal) spanner_role="roles/spanner.databaseUser" ;;
+    actions) spanner_role="" ;;
+  esac
+  verify_policy_roles "Spanner database" "$member" "$spanner_role" printf '%s' "$SPANNER_POLICY_JSON"
+  case "$surface" in
+    public|console) bigtable_role="roles/bigtable.reader" ;;
+    internal) bigtable_role="roles/bigtable.user" ;;
+    *) bigtable_role="" ;;
+  esac
+  verify_policy_roles "Bigtable instance" "$member" "$bigtable_role" printf '%s' "$BIGTABLE_POLICY_JSON"
+  case "$surface" in
+    console) byok_role="roles/cloudkms.cryptoKeyEncrypterDecrypter" ;;
+    internal) byok_role="roles/cloudkms.cryptoKeyDecrypter" ;;
+    *) byok_role="" ;;
+  esac
+  verify_policy_roles "BYOK KMS key" "$member" "$byok_role" printf '%s' "$BYOK_POLICY_JSON"
+  case "$surface" in console) ads_role="roles/cloudkms.cryptoKeyEncrypter" ;; *) ads_role="" ;; esac
+  verify_policy_roles "Google Ads KMS key" "$member" "$ads_role" printf '%s' "$GOOGLE_ADS_POLICY_JSON"
+done
+
+# Direct org/folder grants are inherited project power and must not silently
+# defeat the resource-level matrix above. This audit intentionally fails if
+# the deploy identity cannot read an ancestor policy.
+ANCESTORS_JSON="$(gc projects get-ancestors "$PROJECT_ID" --format=json)"
+ANCESTOR_ROWS="$(jq -r '.[] | [.type, (.id|tostring)] | @tsv' <<<"$ANCESTORS_JSON")" || exit 1
+while IFS=$'\t' read -r ancestor_type ancestor_id; do
+  [ -n "$ancestor_type" ] || continue
+  case "$ancestor_type" in
+    folder) ancestor_policy="$(gc resource-manager folders get-iam-policy "$ancestor_id" --format=json)" ;;
+    organization) ancestor_policy="$(gc organizations get-iam-policy "$ancestor_id" --format=json)" ;;
+    project) continue ;;
+    *) echo "ERROR: unknown project ancestor type ${ancestor_type}" >&2; exit 1 ;;
+  esac
+  for runtime_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do
+    verify_policy_roles "${ancestor_type}/${ancestor_id}" \
+      "serviceAccount:${runtime_account}" "" printf '%s' "$ancestor_policy"
+  done
+done <<<"$ANCESTOR_ROWS"
+
+OPERATIONAL_CLICKHOUSE_URL="${TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_URL:-$(serving_env_value TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_URL)}"
+PROVIDER_CLICKHOUSE_URL="${TR_PROVIDER_ANALYTICS_CLICKHOUSE_URL:-$(serving_env_value TR_PROVIDER_ANALYTICS_CLICKHOUSE_URL)}"
+if [ "$ANALYTICS_READ_MODE" != bigtable ] && [ -z "$OPERATIONAL_CLICKHOUSE_URL" ]; then
+  echo "ERROR: non-Bigtable analytics mode requires the serving operational ClickHouse URL" >&2
+  exit 1
+fi
+if [ -z "$PROVIDER_CLICKHOUSE_URL" ]; then
+  clickhouse_address_output=""
+  if clickhouse_address_output="$(gc compute addresses describe tr-clickhouse-ilb \
+      --region=us-central1 --format='value(address)' 2>&1)"; then
+    PROVIDER_CLICKHOUSE_URL="http://${clickhouse_address_output}:8123"
+  else
+    echo "ERROR: provider analytics needs an explicit private URL or the tr-clickhouse-ilb address" >&2
+    exit 1
+  fi
+fi
+python3 - "$PROVIDER_CLICKHOUSE_URL" <<'PY'
+import ipaddress
+import sys
+from urllib.parse import urlsplit
+
+value = sys.argv[1]
+parsed = urlsplit(value)
+if (
+    parsed.scheme not in {"http", "https"}
+    or not parsed.hostname
+    or parsed.username
+    or parsed.password
+    or parsed.query
+    or parsed.fragment
+):
+    raise SystemExit("provider ClickHouse URL is malformed")
+try:
+    private_host = ipaddress.ip_address(parsed.hostname).is_private
+except ValueError:
+    private_host = parsed.hostname.endswith((".internal", ".svc"))
+if not private_host:
+    raise SystemExit("provider ClickHouse URL must resolve through a private VPC address")
+PY
+
+secret_state() {
+  local secret="$1" describe_output version_json version_state version_name version
+  if ! describe_output="$(gc secrets describe "$secret" 2>&1)"; then
+    case "$describe_output" in
+      *NOT_FOUND*|*"not found"*) echo absent; return 0 ;;
+      *) echo "ERROR: cannot determine Secret Manager state for ${secret}" >&2; return 1 ;;
     esac
-    log "  pruning failed revision ${rev} in ${target}"
-    gc run revisions delete "$rev" --region "$target" --quiet >/dev/null 2>&1 \
-      || log "  WARN: failed to prune ${rev}; will let gcloud's deploy step error if it cares"
+  fi
+  if ! version_json="$(gc secrets versions describe latest --secret="$secret" --format=json 2>&1)"; then
+    echo "ERROR: cannot determine latest-version state for ${secret}" >&2
+    return 1
+  fi
+  version_state="$(jq -er '.state' <<<"$version_json")" || {
+    echo "ERROR: latest version metadata for ${secret} has no state" >&2
+    return 1
+  }
+  if [ "$version_state" = ENABLED ]; then
+    version_name="$(jq -er '.name' <<<"$version_json")" || return 1
+    version="${version_name##*/}"
+    [[ "$version" =~ ^[1-9][0-9]*$ ]] || {
+      echo "ERROR: latest enabled version for ${secret} is not a numeric immutable version" >&2
+      return 1
+    }
+    if ! awk -F '\t' -v secret="$secret" '$1 == secret {found=1} END {exit !found}' \
+        "$SECRET_VERSIONS_FILE"; then
+      printf '%s\t%s\n' "$secret" "$version" >>"$SECRET_VERSIONS_FILE"
+    elif [ "$(awk -F '\t' -v secret="$secret" '$1 == secret {print $2}' "$SECRET_VERSIONS_FILE")" != "$version" ]; then
+      echo "ERROR: latest version for ${secret} changed during rollout preflight" >&2
+      return 1
+    fi
+    echo present
+  else
+    echo "ERROR: latest version for ${secret} is not ENABLED" >&2
+    return 1
+  fi
+}
+pinned_secret_version() {
+  local secret="$1" version state
+  version="$(awk -F '\t' -v secret="$secret" '$1 == secret {print $2}' "$SECRET_VERSIONS_FILE")"
+  if [ -z "$version" ]; then
+    state="$(secret_state "$secret")" || return 1
+    [ "$state" = present ] || {
+      echo "ERROR: cannot pin absent secret ${secret}" >&2
+      return 1
+    }
+    version="$(awk -F '\t' -v secret="$secret" '$1 == secret {print $2}' "$SECRET_VERSIONS_FILE")"
+  fi
+  [[ "$version" =~ ^[1-9][0-9]*$ ]] || return 1
+  echo "$version"
+}
+pin_surface_secret_versions() {
+  local binding env_name resource version
+  local pinned=()
+  for binding in "${SURFACE_SECRETS[@]}"; do
+    env_name="${binding%%=*}"
+    resource="${binding#*=}"
+    version="$(pinned_secret_version "$resource")" || return 1
+    pinned+=("${env_name}=${resource}:${version}")
+  done
+  SURFACE_SECRETS=("${pinned[@]}")
+}
+runtime_account_for_member() {
+  surface_account "$1"
+}
+allowed_surfaces_for_secret() {
+  case "$1" in
+    trustedrouter-attribution-cookie-secret) echo "public console" ;;
+    trustedrouter-sentry-dsn) echo "console chat webhooks internal" ;;
+    trustedrouter-stripe-secret-key) echo "console" ;;
+    trustedrouter-internal-stripe-payment-intents-key) echo "internal" ;;
+    trustedrouter-stripe-webhook-secret) echo "webhooks" ;;
+    trustedrouter-internal-gateway-token|trustedrouter-observer-internal-token|trustedrouter-synthetic-monitor-api-key|trustedrouter-federation-peer-token|trustedrouter-federation-home-token|trustedrouter-federation-credit-inbound-token|trustedrouter-federation-credit-peer-token|trustedrouter-federation-settlement-inbound-tokens|trustedrouter-federation-settlement-home-token) echo "internal" ;;
+    trustedrouter-aws-access-key-id|trustedrouter-aws-secret-access-key) echo "actions console" ;;
+    trustedrouter-internal-ses-access-key-id|trustedrouter-internal-ses-secret-access-key) echo "internal" ;;
+    trustedrouter-ops-chat-webhook-secret) echo "actions" ;;
+    trustedrouter-google-client-id|trustedrouter-google-client-secret|trustedrouter-google-alias-credentials-json|trustedrouter-github-client-id|trustedrouter-github-client-secret|trustedrouter-github-alias-credentials-json) echo "console" ;;
+    trustedrouter-paypal-client-id|trustedrouter-paypal-client-secret) echo "console webhooks" ;;
+    trustedrouter-paypal-webhook-id) echo "webhooks" ;;
+    trustedrouter-adyen-test-api-key|trustedrouter-adyen-test-client-key) echo "console" ;;
+    trustedrouter-adyen-test-hmac-key) echo "webhooks" ;;
+    trustedrouter-adyen-test-reference-key) echo "console webhooks" ;;
+    trustedrouter-veriff-api-key) echo "console" ;;
+    trustedrouter-veriff-shared-secret-key) echo "webhooks" ;;
+    trustedrouter-telnyx-api-key|trustedrouter-twilio-account-sid|trustedrouter-twilio-api-key-sid|trustedrouter-twilio-api-key-secret|trustedrouter-twilio-auth-token) echo "console" ;;
+    trustedrouter-clickhouse-provider-read-password) echo "console" ;;
+    trustedrouter-clickhouse-control-read-password) echo "public console internal" ;;
+    trustedrouter-clickhouse-password) echo "console internal" ;;
+    trustedrouter-axiom-api-token) echo "" ;;
+    trustedrouter-anthropic-api-key|trustedrouter-openai-api-key|trustedrouter-openai-video-api-key|trustedrouter-gemini-api-key|trustedrouter-cerebras-api-key|trustedrouter-deepseek-api-key|trustedrouter-mistral-api-key|trustedrouter-kimi-api-key|trustedrouter-zai-api-key|trustedrouter-together-api-key|trustedrouter-fireworks-api-key|trustedrouter-deepinfra-api-key|trustedrouter-cohere-api-key|trustedrouter-voyage-api-key|trustedrouter-xiaomi-api-key|trustedrouter-grok-api-key|trustedrouter-novita-api-key|trustedrouter-phala-api-key|trustedrouter-phala-confidential-api-key|trustedrouter-siliconflow-api-key|trustedrouter-tinfoil-api-key|trustedrouter-venice-api-key|trustedrouter-nebius-api-key|trustedrouter-minimax-api-key|trustedrouter-friendli-api-key|trustedrouter-baseten-api-key|trustedrouter-thinking-machines-api-key|trustedrouter-wafer-api-key|trustedrouter-crusoe-api-key|trustedrouter-makora-api-key|trustedrouter-alibaba-api-key|trustedrouter-ltx-api-key|trustedrouter-runway-api-key|trustedrouter-kling-api-key|trustedrouter-chutes-api-key|trustedrouter-digitalocean-api-key|trustedrouter-cloudflare-workers-ai-api-token|trustedrouter-inceptron-api-key|trustedrouter-morph-api-key|trustedrouter-atlas-cloud-api-key|trustedrouter-streamlake-api-key|trustedrouter-neurometric-api-key|trustedrouter-engy-api-key|trustedrouter-pearl-api-key|trustedrouter-zero-g-api-key|trustedrouter-athena-worker-prompt-v1|trustedrouter-gcp-service-account-key-json) echo "" ;;
+    *) echo "ERROR: secret ${1} has no declared six-surface owner set" >&2; return 1 ;;
+  esac
+}
+preflight_secret_iam() {
+  local secret="$1" requirement="${2:-required}" allowed policy surface account member should_have state direct_bindings
+  state="$(secret_state "$secret")" || return 1
+  if [ "$state" = absent ]; then
+    [ "$requirement" = optional ] && return 0
+    echo "ERROR: required enabled secret is missing: ${secret}" >&2
+    return 1
+  fi
+  allowed="$(allowed_surfaces_for_secret "$secret")"
+  policy="$(gc secrets get-iam-policy "$secret" --format=json)"
+  for surface in "${SURFACES[@]}"; do
+    account="$(runtime_account_for_member "$surface")"
+    member="serviceAccount:${account}"
+    should_have=0
+    case " ${allowed} " in *" ${surface} "*) should_have=1 ;; esac
+    direct_bindings="$(jq -c --arg member "$member" '[
+      .bindings[]?
+      | select(any(.members[]?; . == $member))
+      | {role, condition: (.condition // null)}
+    ] | unique' <<<"$policy")" || return 1
+    if [ "$should_have" = 1 ]; then
+      [ "$direct_bindings" = '[{"role":"roles/secretmanager.secretAccessor","condition":null}]' ] || {
+        echo "ERROR: ${secret} must grant ${account} exactly one unconditional secretAccessor role" >&2
+        return 1
+      }
+    elif [ "$direct_bindings" != '[]' ]; then
+      echo "ERROR: ${secret} grants an unauthorized direct role to ${account}" >&2
+      return 1
+    fi
   done
 }
 
-is_warm_region() {
-  # Returns 0 if $1 is in TR_WARM_REGIONS, 1 otherwise. Cold regions
-  # (not in TR_WARM_REGIONS) deploy with --min-instances=0 so they don't
-  # pay for always-on capacity at idle. They serve local users with a
-  # ~5-10s cold-start tax on the first request, but ~$0/mo when idle.
-  local r="$1"
-  case ",${TR_WARM_REGIONS}," in
-    *",${r},"*) return 0 ;;
-    *) return 1 ;;
+OPTIONAL_CONSOLE_SECRET_GROUPS=()
+TELNYX_STATE="$(secret_state trustedrouter-telnyx-api-key)" || exit 1
+if [ "$TELNYX_STATE" = present ]; then
+  OPTIONAL_CONSOLE_SECRET_GROUPS+=("TR_TELNYX_API_KEY=trustedrouter-telnyx-api-key")
+fi
+TWILIO_COUNT=0
+for twilio_secret in trustedrouter-twilio-account-sid trustedrouter-twilio-api-key-sid trustedrouter-twilio-api-key-secret trustedrouter-twilio-auth-token; do
+  TWILIO_STATE="$(secret_state "$twilio_secret")" || exit 1
+  [ "$TWILIO_STATE" = present ] && TWILIO_COUNT=$((TWILIO_COUNT + 1))
+done
+if [ "$TWILIO_COUNT" -ne 0 ] && [ "$TWILIO_COUNT" -ne 4 ]; then
+  echo "ERROR: Twilio secret group is partially provisioned" >&2
+  exit 1
+fi
+if [ "$TWILIO_COUNT" -eq 4 ]; then
+  OPTIONAL_CONSOLE_SECRET_GROUPS+=(
+    "TR_TWILIO_ACCOUNT_SID=trustedrouter-twilio-account-sid"
+    "TR_TWILIO_API_KEY_SID=trustedrouter-twilio-api-key-sid"
+    "TR_TWILIO_API_KEY_SECRET=trustedrouter-twilio-api-key-secret"
+    "TR_TWILIO_AUTH_TOKEN=trustedrouter-twilio-auth-token"
+  )
+fi
+
+provider_secret_group_state() {
+  local provider="$1" enabled="$2"
+  shift 2
+  local resource state present=0 total="$#"
+  for resource in "$@"; do
+    state="$(secret_state "$resource")" || return 1
+    [ "$state" = present ] && present=$((present + 1))
+  done
+  if [ "$present" -eq "$total" ]; then
+    echo present
+    return 0
+  fi
+  if [ "$present" -eq 0 ] && [ "$enabled" = false ]; then
+    echo absent
+    return 0
+  fi
+  echo "ERROR: ${provider} credentials must be complete when enabled and may only be fully absent when disabled" >&2
+  return 1
+}
+
+PAYPAL_SECRET_GROUP_STATE="$(provider_secret_group_state PayPal "$PAYPAL_CHECKOUT_ENABLED" \
+  trustedrouter-paypal-client-id trustedrouter-paypal-client-secret \
+  trustedrouter-paypal-webhook-id)" || exit 1
+ADYEN_SECRET_GROUP_STATE="$(provider_secret_group_state Adyen "$ADYEN_ENABLED" \
+  trustedrouter-adyen-test-api-key trustedrouter-adyen-test-client-key \
+  trustedrouter-adyen-test-hmac-key trustedrouter-adyen-test-reference-key)" || exit 1
+VERIFF_SECRET_GROUP_STATE="$(provider_secret_group_state Veriff "$VERIFF_ENABLED" \
+  trustedrouter-veriff-api-key trustedrouter-veriff-shared-secret-key)" || exit 1
+
+TELNYX_FROM_NUMBER="${TR_TELNYX_FROM_NUMBER:-$(serving_env_value TR_TELNYX_FROM_NUMBER +17869471547)}"
+TELNYX_TEXML_ACCOUNT_ID="${TR_TELNYX_TEXML_ACCOUNT_ID:-$(serving_env_value TR_TELNYX_TEXML_ACCOUNT_ID 1eea716a-02e0-4d4f-96fa-36d1f556edca)}"
+TELNYX_TEXML_APPLICATION_ID="${TR_TELNYX_TEXML_APPLICATION_ID:-$(serving_env_value TR_TELNYX_TEXML_APPLICATION_ID 3026758434193146987)}"
+TWILIO_FROM_NUMBER="${TR_TWILIO_FROM_NUMBER:-$(serving_env_value TR_TWILIO_FROM_NUMBER +15055313623)}"
+if [ "$TELNYX_STATE" = present ] && {
+  [ -z "$TELNYX_FROM_NUMBER" ] || [ -z "$TELNYX_TEXML_ACCOUNT_ID" ] || [ -z "$TELNYX_TEXML_APPLICATION_ID" ];
+}; then
+  echo "ERROR: Telnyx credential exists but nonsecret telephony identifiers are incomplete" >&2
+  exit 1
+fi
+if [ "$TWILIO_COUNT" -eq 4 ] && [ -z "$TWILIO_FROM_NUMBER" ]; then
+  echo "ERROR: Twilio credentials exist but TR_TWILIO_FROM_NUMBER is empty" >&2
+  exit 1
+fi
+
+surface_secret_bindings() {
+  local surface="$1"
+  SURFACE_SECRETS=()
+  case "$surface" in
+    public)
+      SURFACE_SECRETS+=("TR_ATTRIBUTION_COOKIE_SECRET=trustedrouter-attribution-cookie-secret")
+      ;;
+    actions)
+      SURFACE_SECRETS+=(
+        "TR_AWS_ACCESS_KEY_ID=trustedrouter-aws-access-key-id"
+        "TR_AWS_SECRET_ACCESS_KEY=trustedrouter-aws-secret-access-key"
+        "TR_OPS_CHAT_WEBHOOK_SECRET=trustedrouter-ops-chat-webhook-secret"
+      )
+      ;;
+    console)
+      SURFACE_SECRETS+=(
+        "TR_SENTRY_DSN=trustedrouter-sentry-dsn"
+        "TR_STRIPE_SECRET_KEY=trustedrouter-stripe-secret-key"
+        "TR_ATTRIBUTION_COOKIE_SECRET=trustedrouter-attribution-cookie-secret"
+        "TR_AWS_ACCESS_KEY_ID=trustedrouter-aws-access-key-id"
+        "TR_AWS_SECRET_ACCESS_KEY=trustedrouter-aws-secret-access-key"
+        "TR_PROVIDER_ANALYTICS_CLICKHOUSE_PASSWORD=trustedrouter-clickhouse-provider-read-password"
+      )
+      if [ "${#OPTIONAL_CONSOLE_SECRET_GROUPS[@]}" -gt 0 ]; then
+        SURFACE_SECRETS+=("${OPTIONAL_CONSOLE_SECRET_GROUPS[@]}")
+      fi
+      if [ "$GOOGLE_OAUTH_AVAILABLE" = true ]; then
+        SURFACE_SECRETS+=(
+          "TR_GOOGLE_CLIENT_ID=trustedrouter-google-client-id"
+          "TR_GOOGLE_CLIENT_SECRET=trustedrouter-google-client-secret"
+          "TR_GOOGLE_ALIAS_CREDENTIALS_JSON=trustedrouter-google-alias-credentials-json"
+        )
+      fi
+      if [ "$GITHUB_OAUTH_AVAILABLE" = true ]; then
+        SURFACE_SECRETS+=(
+          "TR_GITHUB_CLIENT_ID=trustedrouter-github-client-id"
+          "TR_GITHUB_CLIENT_SECRET=trustedrouter-github-client-secret"
+          "TR_GITHUB_ALIAS_CREDENTIALS_JSON=trustedrouter-github-alias-credentials-json"
+        )
+      fi
+      # A false provider gate prevents new sessions. A complete preexisting
+      # group remains mounted for in-flight work and late signed callbacks;
+      # a never-configured disabled group stays absent.
+      if [ "$PAYPAL_SECRET_GROUP_STATE" = present ]; then
+        SURFACE_SECRETS+=(
+          "TR_PAYPAL_CLIENT_ID=trustedrouter-paypal-client-id"
+          "TR_PAYPAL_CLIENT_SECRET=trustedrouter-paypal-client-secret"
+        )
+      fi
+      if [ "$ADYEN_SECRET_GROUP_STATE" = present ]; then
+        SURFACE_SECRETS+=(
+          "TR_ADYEN_API_KEY=trustedrouter-adyen-test-api-key"
+          "TR_ADYEN_CLIENT_KEY=trustedrouter-adyen-test-client-key"
+          "TR_ADYEN_REFERENCE_KEY=trustedrouter-adyen-test-reference-key"
+        )
+      fi
+      if [ "$VERIFF_SECRET_GROUP_STATE" = present ]; then
+        SURFACE_SECRETS+=("TR_VERIFF_API_KEY=trustedrouter-veriff-api-key")
+      fi
+      ;;
+    chat)
+      SURFACE_SECRETS+=("TR_SENTRY_DSN=trustedrouter-sentry-dsn")
+      ;;
+    webhooks)
+      SURFACE_SECRETS+=(
+        "TR_SENTRY_DSN=trustedrouter-sentry-dsn"
+        "TR_STRIPE_WEBHOOK_SECRET=trustedrouter-stripe-webhook-secret"
+      )
+      if [ "$PAYPAL_SECRET_GROUP_STATE" = present ]; then
+        SURFACE_SECRETS+=(
+          "TR_PAYPAL_CLIENT_ID=trustedrouter-paypal-client-id"
+          "TR_PAYPAL_CLIENT_SECRET=trustedrouter-paypal-client-secret"
+          "TR_PAYPAL_WEBHOOK_ID=trustedrouter-paypal-webhook-id"
+        )
+      fi
+      if [ "$ADYEN_SECRET_GROUP_STATE" = present ]; then
+        SURFACE_SECRETS+=(
+          "TR_ADYEN_HMAC_KEY=trustedrouter-adyen-test-hmac-key"
+          "TR_ADYEN_REFERENCE_KEY=trustedrouter-adyen-test-reference-key"
+        )
+      fi
+      if [ "$VERIFF_SECRET_GROUP_STATE" = present ]; then
+        SURFACE_SECRETS+=("TR_VERIFF_SHARED_SECRET_KEY=trustedrouter-veriff-shared-secret-key")
+      fi
+      ;;
+    internal)
+      SURFACE_SECRETS+=(
+        "TR_SENTRY_DSN=trustedrouter-sentry-dsn"
+        "TR_INTERNAL_GATEWAY_TOKEN=trustedrouter-internal-gateway-token"
+        "TR_OBSERVER_INTERNAL_TOKEN=trustedrouter-observer-internal-token"
+        "TR_SYNTHETIC_MONITOR_API_KEY=trustedrouter-synthetic-monitor-api-key"
+        "TR_STRIPE_SECRET_KEY=trustedrouter-internal-stripe-payment-intents-key"
+        "TR_AWS_ACCESS_KEY_ID=trustedrouter-internal-ses-access-key-id"
+        "TR_AWS_SECRET_ACCESS_KEY=trustedrouter-internal-ses-secret-access-key"
+      )
+      for optional_pair in \
+        "TR_FEDERATION_PEER_TOKEN=trustedrouter-federation-peer-token" \
+        "TR_FEDERATION_SETTLEMENT_INBOUND_TOKENS=trustedrouter-federation-settlement-inbound-tokens"; do
+        optional_resource="${optional_pair#*=}"
+        OPTIONAL_STATE="$(secret_state "$optional_resource")" || return 1
+        [ "$OPTIONAL_STATE" = present ] && SURFACE_SECRETS+=("$optional_pair")
+      done
+      ;;
+  esac
+  if [ "$ANALYTICS_READ_MODE" != bigtable ]; then
+    case "$surface" in public|console|internal)
+      SURFACE_SECRETS+=("TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_PASSWORD=trustedrouter-clickhouse-control-read-password") ;;
+    esac
+  fi
+  pin_surface_secret_versions || return 1
+}
+
+# Read-only Secret Manager + IAM checks finish before any backend or revision
+# mutation. Complete --set-secrets later strips every stale binding.
+SECRETS_TO_PREFLIGHT=()
+for surface in "${SURFACES[@]}"; do
+  surface_secret_bindings "$surface"
+  for binding in "${SURFACE_SECRETS[@]}"; do
+    resource="${binding#*=}"; resource="${resource%:*}"
+    case " ${SECRETS_TO_PREFLIGHT[*]-} " in *" ${resource} "*) ;; *) SECRETS_TO_PREFLIGHT+=("$resource") ;; esac
+  done
+done
+for resource in "${SECRETS_TO_PREFLIGHT[@]}"; do preflight_secret_iam "$resource" required; done
+
+# Omission from a container environment is not an isolation boundary if the
+# runtime identity can still fetch the resource. Existing but unmounted
+# provider/logging/legacy resources therefore receive the same exact-owner IAM
+# audit; all upstream inference keys deliberately have an empty six-service
+# owner set because chat forwards caller authorization to the attested gateway.
+KNOWN_OPTIONAL_RUNTIME_SECRETS=(
+  trustedrouter-google-client-id trustedrouter-google-client-secret
+  trustedrouter-google-alias-credentials-json trustedrouter-github-client-id
+  trustedrouter-github-client-secret trustedrouter-github-alias-credentials-json
+  trustedrouter-paypal-client-id trustedrouter-paypal-client-secret
+  trustedrouter-paypal-webhook-id trustedrouter-adyen-test-api-key
+  trustedrouter-adyen-test-client-key trustedrouter-adyen-test-hmac-key
+  trustedrouter-adyen-test-reference-key trustedrouter-veriff-api-key
+  trustedrouter-veriff-shared-secret-key trustedrouter-telnyx-api-key
+  trustedrouter-twilio-account-sid trustedrouter-twilio-api-key-sid
+  trustedrouter-twilio-api-key-secret trustedrouter-twilio-auth-token
+  trustedrouter-clickhouse-password trustedrouter-axiom-api-token
+  trustedrouter-federation-home-token trustedrouter-federation-credit-inbound-token
+  trustedrouter-federation-credit-peer-token trustedrouter-federation-settlement-home-token
+  trustedrouter-anthropic-api-key trustedrouter-openai-api-key
+  trustedrouter-openai-video-api-key trustedrouter-gemini-api-key
+  trustedrouter-cerebras-api-key trustedrouter-deepseek-api-key
+  trustedrouter-mistral-api-key trustedrouter-kimi-api-key trustedrouter-zai-api-key
+  trustedrouter-together-api-key trustedrouter-fireworks-api-key
+  trustedrouter-deepinfra-api-key trustedrouter-cohere-api-key
+  trustedrouter-voyage-api-key trustedrouter-xiaomi-api-key trustedrouter-grok-api-key
+  trustedrouter-novita-api-key trustedrouter-phala-api-key
+  trustedrouter-phala-confidential-api-key trustedrouter-siliconflow-api-key
+  trustedrouter-tinfoil-api-key trustedrouter-venice-api-key trustedrouter-nebius-api-key
+  trustedrouter-minimax-api-key trustedrouter-friendli-api-key trustedrouter-baseten-api-key
+  trustedrouter-thinking-machines-api-key trustedrouter-wafer-api-key
+  trustedrouter-crusoe-api-key trustedrouter-makora-api-key trustedrouter-alibaba-api-key
+  trustedrouter-ltx-api-key trustedrouter-runway-api-key trustedrouter-kling-api-key
+  trustedrouter-chutes-api-key trustedrouter-digitalocean-api-key
+  trustedrouter-cloudflare-workers-ai-api-token trustedrouter-inceptron-api-key
+  trustedrouter-morph-api-key trustedrouter-atlas-cloud-api-key
+  trustedrouter-streamlake-api-key trustedrouter-neurometric-api-key
+  trustedrouter-engy-api-key trustedrouter-pearl-api-key trustedrouter-zero-g-api-key
+  trustedrouter-athena-worker-prompt-v1 trustedrouter-gcp-service-account-key-json
+)
+for resource in "${KNOWN_OPTIONAL_RUNTIME_SECRETS[@]}"; do
+  case " ${SECRETS_TO_PREFLIGHT[*]-} " in *" ${resource} "*) ;; *)
+    preflight_secret_iam "$resource" optional ;;
+  esac
+done
+
+# Re-run the shared complete isolation audit immediately before staging.  This
+# covers parent scopes, cross-runtime impersonation, and unknown project
+# secrets that the surface-specific environment builder cannot enumerate.
+bash "$IAM_VERIFY" --project "$PROJECT_ID"
+
+if ! IMAGE_METADATA="$(gc artifacts docker images describe "$IMAGE" --format=json 2>&1)"; then
+  echo "ERROR: image does not exist: ${IMAGE}" >&2
+  exit 1
+fi
+RESOLVED_IMAGE="$(jq -er '
+  .image_summary.fully_qualified_digest //
+  .imageSummary.fullyQualifiedDigest //
+  .fully_qualified_digest //
+  .fullyQualifiedDigest
+' <<<"$IMAGE_METADATA")" || {
+  echo "ERROR: Artifact Registry did not return a fully qualified image digest" >&2
+  exit 1
+}
+[[ "$RESOLVED_IMAGE" =~ ^[^,\|[:space:]@]+@sha256:[0-9a-f]{64}$ ]] || {
+  echo "ERROR: Artifact Registry returned an invalid immutable image digest" >&2
+  exit 1
+}
+if [[ "$IMAGE" == *@* ]] && [ "$IMAGE" != "$RESOLVED_IMAGE" ]; then
+  echo "ERROR: requested image digest differs from the Artifact Registry resolution" >&2
+  exit 1
+fi
+IMAGE="$RESOLVED_IMAGE"
+
+preflight_private_internal_origin() {
+  local network="${TR_SYNTHETIC_NETWORK:-default}"
+  local subnet="${TR_SYNTHETIC_SUBNET:-default}"
+  local zone="${TR_PRIVATE_RUN_APP_DNS_ZONE:-trusted-router-private-run-app}"
+  local region subnet_json zone_json apex_json wildcard_json
+  validate_resource_name "synthetic VPC network" "$network"
+  validate_resource_name "synthetic VPC subnet" "$subnet"
+  validate_resource_name "private run.app DNS zone" "$zone"
+  while IFS= read -r region; do
+    subnet_json="$(gc compute networks subnets describe "$subnet" \
+      --region="$region" --format=json)" || return 1
+    jq -e --arg network "$network" '
+      .privateIpGoogleAccess == true and
+      ((.network // "") | rtrimstr("/") | endswith("/networks/" + $network))
+    ' <<<"$subnet_json" >/dev/null || {
+      echo "ERROR: ${subnet}/${region} lacks Private Google Access on ${network}" >&2
+      return 1
+    }
+  done
+  zone_json="$(gc dns managed-zones describe "$zone" --format=json)" || return 1
+  jq -e --arg network "$network" '
+    .dnsName == "run.app." and .visibility == "private" and
+    any(.privateVisibilityConfig.networks[]?;
+      (.networkUrl // "") | rtrimstr("/") | endswith("/networks/" + $network))
+  ' <<<"$zone_json" >/dev/null || {
+    echo "ERROR: private run.app DNS zone does not match the synthetic VPC" >&2
+    return 1
+  }
+  apex_json="$(gc dns record-sets describe run.app. --zone="$zone" --type=A --format=json)" || return 1
+  jq -e '
+    (.rrdatas | sort) == [
+      "199.36.153.8", "199.36.153.9", "199.36.153.10", "199.36.153.11"
+    ]
+  ' <<<"$apex_json" >/dev/null || {
+    echo "ERROR: private run.app A record does not use the restricted Google VIP" >&2
+    return 1
+  }
+  wildcard_json="$(gc dns record-sets describe '*.run.app.' \
+    --zone="$zone" --type=CNAME --format=json)" || return 1
+  jq -e '.rrdatas == ["run.app."]' <<<"$wildcard_json" >/dev/null || {
+    echo "ERROR: private wildcard run.app record is absent or drifted" >&2
+    return 1
+  }
+}
+preflight_private_internal_origin
+
+# The first split adopts an already promoted private internal service and
+# verifies that every canonical synthetic Job/Scheduler pair uses it. The
+# legacy monolith remains untouched and keeps its run.app URL throughout this
+# transaction; existing splits have already crossed this one-way boundary and
+# do not depend on a historical bootstrap artifact.
+BOOTSTRAP_ARTIFACT_SHA256=""
+if [ "$ROLLOUT_MODE" = initial_split ]; then
+  [ -n "${TR_INTERNAL_BOOTSTRAP_ARTIFACT:-}" ] || {
+    echo "ERROR: initial split requires TR_INTERNAL_BOOTSTRAP_ARTIFACT" >&2
+    exit 1
+  }
+  bash "${SCRIPT_DIR}/rollout_bootstrap_internal.sh" \
+    --verify-artifact "$TR_INTERNAL_BOOTSTRAP_ARTIFACT" \
+    --expected-image "$IMAGE"
+  BOOTSTRAP_ARTIFACT_SHA256="$(python3 - "$TR_INTERNAL_BOOTSTRAP_ARTIFACT" <<'PY'
+import hashlib
+import sys
+from pathlib import Path
+
+print(hashlib.sha256(Path(sys.argv[1]).read_bytes()).hexdigest())
+PY
+)" || exit 1
+fi
+
+bootstrap_internal_revision() {
+  local region="$1"
+  [ "$ROLLOUT_MODE" = initial_split ] || return 2
+  jq -er --arg region "$region" '
+    [.services[] | select(.region == $region) | .revision] as $matches
+    | if ($matches | length) == 1 then $matches[0]
+      else error("bootstrap artifact has inexact regional service inventory") end
+  ' "$TR_INTERNAL_BOOTSTRAP_ARTIFACT"
+}
+
+surface_service_max_preflight() {
+  case "$1" in
+    public) echo 10 ;; actions) echo 2 ;; console|chat) echo 20 ;;
+    webhooks) echo 10 ;; internal) echo 50 ;; *) return 2 ;;
   esac
 }
+
+verify_existing_service_metadata_is_safe() {
+  local surface="$1" region="$2" prior="$3" service maximum allow_legacy_url iam
+  service="$(surface_service "$surface")"
+  maximum="$(surface_service_max_preflight "$surface")"
+  allow_legacy_url=false
+  python3 - "$prior" "$surface" "$TR_CLOUD_RUN_INGRESS" "$maximum" \
+    "$allow_legacy_url" <<'PY' || return 1
+import json
+import sys
+from pathlib import Path
+
+path, surface, ingress, maximum, allow_legacy_url = sys.argv[1:]
+service = json.loads(Path(path).read_text(encoding="utf-8"))
+metadata = service.get("metadata") or {}
+annotations = metadata.get("annotations") or {}
+spec = service.get("spec") or {}
+status = service.get("status") or {}
+if metadata.get("generation") is None or status.get("observedGeneration") is None:
+    raise SystemExit(f"{surface}: existing service generation metadata is absent")
+if str(metadata.get("generation")) != str(status.get("observedGeneration")):
+    raise SystemExit(f"{surface}: existing service has an unobserved metadata change")
+if annotations.get("run.googleapis.com/ingress") != ingress:
+    raise SystemExit(f"{surface}: existing ingress would be changed by staging")
+if annotations.get("run.googleapis.com/ingress-status") != ingress:
+    raise SystemExit(f"{surface}: existing effective ingress differs from desired ingress")
+service_max = (spec.get("scaling") or {}).get("maxInstanceCount")
+if service_max is None:
+    service_max = annotations.get("run.googleapis.com/maxScale")
+if str(service_max) != maximum:
+    raise SystemExit(f"{surface}: existing service-level max would be changed by staging")
+disabled = str(annotations.get("run.googleapis.com/default-url-disabled") or "").lower() == "true"
+url = status.get("url") or ""
+if surface == "internal":
+    if disabled or not url:
+        raise SystemExit("internal: private run.app origin must remain enabled")
+elif allow_legacy_url == "true":
+    if disabled != (not url):
+        raise SystemExit("console: default URL annotation/status are inconsistent")
+else:
+    if not disabled or url:
+        raise SystemExit(f"{surface}: default URL would be changed by staging")
+PY
+  iam="$(gc run services get-iam-policy "$service" --region="$region" --format=json)" || return 1
+  jq -e '
+    [.bindings[]? | select(any(.members[]?; . == "allUsers"))
+      | {role, condition: (.condition // null),
+         allUsersCount: ([.members[]? | select(. == "allUsers")] | length)}]
+    == [{role:"roles/run.invoker",condition:null,allUsersCount:1}]
+  ' <<<"$iam" >/dev/null || {
+    echo "ERROR: ${service}/${region} service IAM would be changed by staging" >&2
+    return 1
+  }
+}
+
+stage_configuration_sha256() {
+  python3 - "$0" "$SECRET_VERSIONS_FILE" "$PROJECT_ID" "$IMAGE" "$RELEASE" \
+    "$REGION_CSV" "$GATEWAY_REGION_CSV" "$INTERNAL_ALLOWED_REGION_CSV" \
+    "$STORAGE_BACKEND" "$REQUEST_RECORD_WRITE_MODE" "$ANALYTICS_READ_MODE" \
+    "$GENERATION_RECORDS_ENABLED" "$BIGTABLE_MIRROR_WRITES_ENABLED" \
+    "$NEW_SIGNUPS_ENABLED" "$GOOGLE_OAUTH_AVAILABLE" "$GITHUB_OAUTH_AVAILABLE" \
+    "$PAYPAL_CHECKOUT_ENABLED" "$ADYEN_ENABLED" "$VERIFF_ENABLED" \
+    "$TELNYX_FROM_NUMBER" "$TELNYX_TEXML_ACCOUNT_ID" \
+    "$TELNYX_TEXML_APPLICATION_ID" "$TWILIO_FROM_NUMBER" <<'PY'
+import hashlib
+import sys
+from pathlib import Path
+pins = sorted(
+    line for line in Path(sys.argv[2]).read_text(encoding="utf-8").splitlines()
+    if line
+)
+payload = Path(sys.argv[1]).read_bytes() + b"\0" + "\n".join(pins).encode()
+payload += b"\0" + b"\0".join(item.encode() for item in sys.argv[3:])
+print(hashlib.sha256(payload).hexdigest())
+PY
+}
+
+restore_stage_journal_secret_pins() {
+  local restored="${WORK_DIR}/journal-secret-versions.tsv"
+  python3 - "$STAGE_JOURNAL" "$restored" <<'PY'
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+value = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+descriptor = os.open(sys.argv[2], os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+    for item in value.get("pinned_secrets") or []:
+        output.write(f"{item['resource']}\t{item['version']}\n")
+PY
+  mv "$restored" "$SECRET_VERSIONS_FILE"
+  chmod 600 "$SECRET_VERSIONS_FILE"
+  while IFS=$'\t' read -r resource version; do
+    [ -n "$resource" ] || continue
+    version_json="$(gc secrets versions describe "$version" \
+      --secret="$resource" --format=json)" || return 1
+    [ "$(jq -er 'select(.state == "ENABLED") | .name | split("/")[-1]' \
+      <<<"$version_json")" = "$version" ] || {
+      echo "ERROR: journaled secret version is no longer ENABLED: ${resource}:${version}" >&2
+      return 1
+    }
+  done <"$SECRET_VERSIONS_FILE"
+}
+
+create_initial_stage_journal() {
+  local config_sha="$1" plan_file="${WORK_DIR}/stage-services.tsv"
+  local surface service region candidate prior_exists adopted
+  : >"$plan_file"
+  chmod 600 "$plan_file"
+  for surface in "${SURFACES[@]}"; do
+    service="$(surface_service "$surface")"
+    while IFS= read -r region; do
+      prior_exists=false
+      [ -f "$(prior_json_path "$surface" "$region")" ] && prior_exists=true
+      adopted=false
+      if [ "$surface" = internal ]; then
+        candidate="$(bootstrap_internal_revision "$region")" || return 1
+        adopted=true
+      else
+        candidate="${service}-${REVISION_SUFFIX}"
+      fi
+      printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$surface" "$service" "$region" "$candidate" "$prior_exists" "$adopted" \
+        >>"$plan_file"
+    done < <(surface_region_lines "$surface")
+  done
+  python3 - "$STAGE_JOURNAL" "$MANIFEST" "$PROJECT_ID" "$IMAGE" "$RELEASE" \
+    "$REVISION_SUFFIX" "$REGION_CSV" "$TR_PRIMARY_REGION" "$GATEWAY_REGION_CSV" \
+    "$INTERNAL_ALLOWED_REGION_CSV" "$HTTPS_PROXY" "$URL_MAP_NAME" \
+    "$PRIOR_URL_MAP_NAME" "$(python3 "$STATE_TOOL" hash-url-map "$PRIOR_URL_MAP")" \
+    "$BOOTSTRAP_ARTIFACT_SHA256" "$LEGACY_HARDENING_ARTIFACT_SHA256" \
+    "$FRONTEND_ATTESTATION_SHA256" "$config_sha" "$SECRET_VERSIONS_FILE" \
+    "$plan_file" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    "$STAGE_OPERATION_ID" <<'PY'
+import json
+import os
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+path = Path(sys.argv[1])
+pins = []
+for line in Path(sys.argv[19]).read_text(encoding="utf-8").splitlines():
+    if line:
+        resource, version = line.split("\t")
+        pins.append({"resource": resource, "version": version})
+services = []
+for line in Path(sys.argv[20]).read_text(encoding="utf-8").splitlines():
+    surface, name, region, candidate, prior_exists, adopted = line.split("\t")
+    services.append({
+        "surface": surface,
+        "name": name,
+        "region": region,
+        "candidate_revision": candidate,
+        "prior_exists": prior_exists == "true",
+        "adopted_bootstrap": adopted == "true",
+        "state": "pending",
+        "postcondition_sha256": None,
+    })
+value = {
+    "schema_version": 1,
+    "kind": "trusted-router-six-surface-initial-stage-state",
+    "manifest_path": str(Path(sys.argv[2]).resolve()),
+    "project_id": sys.argv[3],
+    "image": sys.argv[4],
+    "release": sys.argv[5],
+    "revision_suffix": sys.argv[6],
+    "rollout_mode": "initial_split",
+    "regions": sys.argv[7].split(","),
+    "primary_region": sys.argv[8],
+    "gateway_regions": sys.argv[9].split(","),
+    "internal_regions": sys.argv[10].split(","),
+    "https_proxy": sys.argv[11],
+    "url_map_name": sys.argv[12],
+    "prior_snapshot": sys.argv[13],
+    "prior_sha256": sys.argv[14],
+    "bootstrap_artifact_sha256": sys.argv[15],
+    "legacy_hardening_artifact_sha256": sys.argv[16],
+    "frontend_attestation_sha256": sys.argv[17],
+    "configuration_sha256": sys.argv[18],
+    "pinned_secrets": sorted(pins, key=lambda item: item["resource"]),
+    "created_at": sys.argv[21],
+    "operation_id": sys.argv[22],
+    "phase": "edge",
+    "edge_states": [
+        {"surface": surface, "state": "pending", "postcondition_sha256": None}
+        for surface in ("public", "actions", "console", "chat", "webhooks", "internal")
+    ],
+    "service_states": services,
+    "candidate_snapshot_sha256": None,
+    "manifest_sha256": None,
+}
+payload = (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+descriptor, temporary = tempfile.mkstemp(
+    dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+)
+try:
+    os.fchmod(descriptor, 0o600)
+    with os.fdopen(descriptor, "wb") as output:
+        output.write(payload)
+        output.flush()
+        os.fsync(output.fileno())
+    os.link(temporary, path)
+finally:
+    try:
+        os.unlink(temporary)
+    except FileNotFoundError:
+        pass
+directory = os.open(path.parent, os.O_RDONLY)
+try:
+    os.fsync(directory)
+finally:
+    os.close(directory)
+if stat.S_IMODE(os.stat(path).st_mode) != 0o600:
+    raise SystemExit("initial-stage journal mode differs")
+PY
+}
+
+validate_initial_stage_journal() {
+  local config_sha="$1"
+  python3 - "$STAGE_JOURNAL" "$MANIFEST" "$PROJECT_ID" "$IMAGE" "$RELEASE" \
+    "$REVISION_SUFFIX" "$REGION_CSV" "$TR_PRIMARY_REGION" "$GATEWAY_REGION_CSV" \
+    "$INTERNAL_ALLOWED_REGION_CSV" "$HTTPS_PROXY" "$URL_MAP_NAME" \
+    "$PRIOR_URL_MAP_NAME" "$(python3 "$STATE_TOOL" hash-url-map "$PRIOR_URL_MAP")" \
+    "$BOOTSTRAP_ARTIFACT_SHA256" "$LEGACY_HARDENING_ARTIFACT_SHA256" \
+    "$FRONTEND_ATTESTATION_SHA256" "$config_sha" "$STAGE_OPERATION_ID" <<'PY'
+import json
+import os
+import re
+import stat
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+metadata = os.lstat(path)
+if not stat.S_ISREG(metadata.st_mode) or stat.S_IMODE(metadata.st_mode) != 0o600:
+    raise SystemExit("initial-stage journal must be a regular mode-0600 file")
+value = json.loads(path.read_text(encoding="utf-8"))
+required = {
+    "schema_version", "kind", "manifest_path", "project_id", "image", "release",
+    "revision_suffix", "rollout_mode", "regions", "primary_region",
+    "gateway_regions", "internal_regions", "https_proxy", "url_map_name",
+    "prior_snapshot", "prior_sha256", "bootstrap_artifact_sha256",
+    "legacy_hardening_artifact_sha256", "frontend_attestation_sha256",
+    "configuration_sha256", "pinned_secrets", "created_at", "operation_id", "phase",
+    "edge_states", "service_states", "candidate_snapshot_sha256", "manifest_sha256",
+}
+if not isinstance(value, dict) or set(value) != required:
+    raise SystemExit("initial-stage journal fields differ")
+if value["schema_version"] != 1 or value["kind"] != "trusted-router-six-surface-initial-stage-state":
+    raise SystemExit("initial-stage journal schema differs")
+expected = {
+    "manifest_path": str(Path(sys.argv[2]).resolve()),
+    "project_id": sys.argv[3], "image": sys.argv[4], "release": sys.argv[5],
+    "revision_suffix": sys.argv[6], "rollout_mode": "initial_split",
+    "regions": sys.argv[7].split(","), "primary_region": sys.argv[8],
+    "gateway_regions": sys.argv[9].split(","),
+    "internal_regions": sys.argv[10].split(","), "https_proxy": sys.argv[11],
+    "url_map_name": sys.argv[12], "prior_snapshot": sys.argv[13],
+    "prior_sha256": sys.argv[14], "bootstrap_artifact_sha256": sys.argv[15],
+    "legacy_hardening_artifact_sha256": sys.argv[16],
+    "frontend_attestation_sha256": sys.argv[17],
+    "configuration_sha256": sys.argv[18],
+    "operation_id": sys.argv[19],
+}
+for field, wanted in expected.items():
+    if value[field] != wanted:
+        raise SystemExit(f"initial-stage journal binding differs: {field}")
+if value["phase"] not in {"edge", "services", "manifest_intent", "complete"}:
+    raise SystemExit("initial-stage journal phase differs")
+if not isinstance(value["pinned_secrets"], list) or any(
+    not isinstance(item, dict)
+    or set(item) != {"resource", "version"}
+    or not re.fullmatch(r"[1-9][0-9]*", str(item["version"]))
+    for item in value["pinned_secrets"]
+):
+    raise SystemExit("initial-stage journal secret pins differ")
+surfaces = ["public", "actions", "console", "chat", "webhooks", "internal"]
+edges = value["edge_states"]
+if [item.get("surface") for item in edges] != surfaces or any(
+    set(item) != {"surface", "state", "postcondition_sha256"}
+    or item["state"] not in {"pending", "reconcile_intent", "reconciled"}
+    for item in edges
+):
+    raise SystemExit("initial-stage edge state inventory differs")
+expected_services = []
+for surface in surfaces:
+    regions = value["internal_regions"] if surface == "internal" else value["regions"]
+    expected_services.extend((surface, region) for region in regions)
+services = value["service_states"]
+if [(item.get("surface"), item.get("region")) for item in services] != expected_services:
+    raise SystemExit("initial-stage service state inventory differs")
+for item in services:
+    if set(item) != {"surface", "name", "region", "candidate_revision", "prior_exists", "adopted_bootstrap", "state", "postcondition_sha256"}:
+        raise SystemExit("initial-stage service state fields differ")
+    if item["state"] not in {"pending", "deploy_intent", "staged"}:
+        raise SystemExit("initial-stage service transition differs")
+PY
+}
+
+stage_journal_read() {
+  local kind="$1" first="$2" second="${3:-}"
+  python3 - "$STAGE_JOURNAL" "$kind" "$first" "$second" <<'PY'
+import json
+import sys
+from pathlib import Path
+value = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+items = value["edge_states"] if sys.argv[2] == "edge" else value["service_states"]
+matches = [item for item in items if item["surface"] == sys.argv[3] and (sys.argv[2] == "edge" or item["region"] == sys.argv[4])]
+if len(matches) != 1:
+    raise SystemExit("initial-stage journal lookup differs")
+print(json.dumps(matches[0], sort_keys=True, separators=(",", ":")))
+PY
+}
+
+stage_journal_transition() {
+  local kind="$1" first="$2" second="$3" old_state="$4" new_state="$5" digest="${6:-}"
+  validate_initial_stage_journal "$STAGE_CONFIGURATION_SHA256"
+  python3 - "$STAGE_JOURNAL" "$kind" "$first" "$second" "$old_state" "$new_state" "$digest" <<'PY'
+import json
+import os
+import stat
+import sys
+import tempfile
+from pathlib import Path
+path = Path(sys.argv[1])
+value = json.loads(path.read_text(encoding="utf-8"))
+items = value["edge_states"] if sys.argv[2] == "edge" else value["service_states"]
+matches = [item for item in items if item["surface"] == sys.argv[3] and (sys.argv[2] == "edge" or item["region"] == sys.argv[4])]
+if len(matches) != 1 or matches[0]["state"] != sys.argv[5]:
+    raise SystemExit("initial-stage journal transition precondition differs")
+matches[0]["state"] = sys.argv[6]
+if sys.argv[7]:
+    matches[0]["postcondition_sha256"] = sys.argv[7]
+payload = (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+try:
+    os.fchmod(descriptor, stat.S_IRUSR | stat.S_IWUSR)
+    with os.fdopen(descriptor, "wb") as output:
+        output.write(payload); output.flush(); os.fsync(output.fileno())
+    os.replace(temporary, path)
+    directory = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory)
+    finally:
+        os.close(directory)
+finally:
+    try:
+        os.unlink(temporary)
+    except FileNotFoundError:
+        pass
+PY
+}
+
+stage_journal_set_phase() {
+  local old_phase="$1" new_phase="$2" candidate_sha="${3:-}" manifest_sha="${4:-}"
+  python3 - "$STAGE_JOURNAL" "$old_phase" "$new_phase" "$candidate_sha" "$manifest_sha" <<'PY'
+import json
+import os
+import stat
+import sys
+import tempfile
+from pathlib import Path
+path = Path(sys.argv[1])
+value = json.loads(path.read_text(encoding="utf-8"))
+if value["phase"] != sys.argv[2]:
+    raise SystemExit("initial-stage phase transition precondition differs")
+value["phase"] = sys.argv[3]
+if sys.argv[4]:
+    value["candidate_snapshot_sha256"] = sys.argv[4]
+if sys.argv[5]:
+    value["manifest_sha256"] = sys.argv[5]
+payload = (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+try:
+    os.fchmod(descriptor, stat.S_IRUSR | stat.S_IWUSR)
+    with os.fdopen(descriptor, "wb") as output:
+        output.write(payload); output.flush(); os.fsync(output.fileno())
+    os.replace(temporary, path)
+    directory = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory)
+    finally:
+        os.close(directory)
+finally:
+    try:
+        os.unlink(temporary)
+    except FileNotFoundError:
+        pass
+PY
+}
+
+if [ "$ROLLOUT_MODE" = initial_split ]; then
+  if [ "$RESUMING_INITIAL_STAGE" = true ]; then
+    restore_stage_journal_secret_pins
+  fi
+  STAGE_CONFIGURATION_SHA256="$(stage_configuration_sha256)" || exit 1
+  if [ "$RESUMING_INITIAL_STAGE" = true ]; then
+    validate_initial_stage_journal "$STAGE_CONFIGURATION_SHA256"
+  else
+    create_initial_stage_journal "$STAGE_CONFIGURATION_SHA256"
+    RESUMING_INITIAL_STAGE=true
+    validate_initial_stage_journal "$STAGE_CONFIGURATION_SHA256"
+  fi
+else
+  [ "$RESUMING_INITIAL_STAGE" != true ] || {
+    echo "ERROR: initial-stage journal cannot be resumed after the split URL map is active" >&2
+    exit 1
+  }
+  STAGE_CONFIGURATION_SHA256=""
+fi
+
+# A revision suffix is transaction ownership, not merely a label. A fresh
+# artifact directory may never adopt an existing immutable revision created by
+# another run after an ambiguous deploy response.
+for surface in "${SURFACES[@]}"; do
+  service="$(surface_service "$surface")"
+  while IFS= read -r region; do
+    if [ "$ROLLOUT_MODE" = initial_split ] && [ "$surface" = internal ]; then
+      candidate="$(bootstrap_internal_revision "$region")" || exit 1
+      prior_path="$(prior_json_path "$surface" "$region")"
+      verify_existing_service_metadata_is_safe "$surface" "$region" "$prior_path" || exit 1
+      continue
+    fi
+    candidate="${service}-${REVISION_SUFFIX}"
+    revision_rc=0
+    revision_description="$(gc run revisions describe "$candidate" \
+      --region="$region" --format=json 2>&1)" || revision_rc=$?
+    if [ "$revision_rc" = 0 ]; then
+      if [ "$ROLLOUT_MODE" = initial_split ]; then
+        recorded_service="$(stage_journal_read service "$surface" "$region")" || exit 1
+        recorded_candidate="$(jq -er .candidate_revision <<<"$recorded_service")" || exit 1
+        recorded_state="$(jq -er .state <<<"$recorded_service")" || exit 1
+        [ "$recorded_candidate" = "$candidate" ] || {
+          echo "ERROR: existing candidate differs from the journal: ${candidate}/${region}" >&2
+          exit 1
+        }
+        case "$recorded_state" in
+          deploy_intent|staged) ;;
+          *)
+            echo "ERROR: candidate exists without a recorded deploy intent: ${candidate}/${region}" >&2
+            exit 1
+            ;;
+        esac
+      else
+        echo "ERROR: candidate revision already exists outside this rollout: ${candidate}/${region}" >&2
+        exit 1
+      fi
+    fi
+    if [ "$revision_rc" != 0 ]; then
+      case "$revision_description" in
+        *NOT_FOUND*|*"not found"*) ;;
+        *) echo "ERROR: cannot prove candidate revision absence: ${candidate}/${region}" >&2; exit 1 ;;
+      esac
+      if [ "$ROLLOUT_MODE" = initial_split ]; then
+        recorded_state="$(stage_journal_read service "$surface" "$region" | jq -er .state)" || exit 1
+        [ "$recorded_state" != staged ] || {
+          echo "ERROR: journaled staged candidate is absent: ${candidate}/${region}" >&2
+          exit 1
+        }
+      fi
+    fi
+    prior_path="$(prior_json_path "$surface" "$region")"
+    if [ "$ROLLOUT_MODE" = initial_split ]; then
+      recorded_prior_exists="$(stage_journal_read service "$surface" "$region" | jq -r .prior_exists)" || exit 1
+      [ "$recorded_prior_exists" = true ] || continue
+    else
+      [ -f "$prior_path" ] || continue
+    fi
+    verify_existing_service_metadata_is_safe "$surface" "$region" "$prior_path" || exit 1
+  done < <(surface_region_lines "$surface")
+done
+
+surface_backend_timeout() {
+  case "$1" in
+    public) echo 60 ;; actions) echo 30 ;; console|chat|internal) echo 300 ;;
+    webhooks) echo 60 ;; *) return 2 ;;
+  esac
+}
+
+EXPECTED_EDGE_ALLOWED_HOST_REGEX='^(trustedrouter[.]com|www[.]trustedrouter[.]com|status[.]trustedrouter[.]com|trust[.]trustedrouter[.]com|eu[.]trustedrouter[.]com|status-us[.]trustedrouter[.]com|status-eu[.]trustedrouter[.]com|allyrouter[.]com|www[.]allyrouter[.]com|status[.]allyrouter[.]com|trust[.]allyrouter[.]com|uptimerouter[.]com|www[.]uptimerouter[.]com|status[.]uptimerouter[.]com|trust[.]uptimerouter[.]com)(:[0-9]+)?$'
+[ "${TR_EDGE_ALLOWED_HOST_REGEX:-$EXPECTED_EDGE_ALLOWED_HOST_REGEX}" = "$EXPECTED_EDGE_ALLOWED_HOST_REGEX" ] &&
+[ "${TR_CLOUD_ARMOR_RATE_INTERVAL_SECONDS:-60}" = 60 ] &&
+[ "${TR_CLOUD_ARMOR_BROWSER_RATE_COUNT:-120}" = 120 ] &&
+[ "${TR_CLOUD_ARMOR_WRITE_RATE_COUNT:-300}" = 300 ] &&
+[ "${TR_CLOUD_ARMOR_GLOBAL_RATE_COUNT:-2400}" = 2400 ] &&
+[ "${TR_CLOUD_ARMOR_PREVIEW:-1}" = 1 ] || {
+  echo "ERROR: six-surface rollout requires the reviewed exact Cloud Armor rule constants" >&2
+  exit 1
+}
+
+backend_reference_maps() {
+  local backend="$1" self_link="$2"
+  python3 - "$backend" "$self_link" "$URL_MAP_INVENTORY" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+backend, self_link, inventory_path = sys.argv[1:]
+
+def values(value):
+    if isinstance(value, dict):
+        for item in value.values():
+            yield from values(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from values(item)
+    elif isinstance(value, str):
+        yield value
+
+for line in Path(inventory_path).read_text(encoding="utf-8").splitlines():
+    item = json.loads(line)
+    references = any(
+        value == backend
+        or value == self_link
+        or value.rstrip("/").endswith(f"/backendServices/{backend}")
+        for value in values(item)
+    )
+    if references:
+        print(item.get("name", ""))
+PY
+}
+
+ensure_inactive_backend() {
+  local surface="$1" backend timeout describe_output describe_rc=0
+  backend="$(surface_backend "$surface")"
+  timeout="$(surface_backend_timeout "$surface")"
+  describe_output="$(gc compute backend-services describe "$backend" --global 2>&1)" || describe_rc=$?
+  if [ "$describe_rc" != 0 ]; then
+    if [[ "$describe_output" != *NOT_FOUND* && "$describe_output" != *"not found"* ]]; then
+      echo "ERROR: cannot determine whether inactive backend ${backend} exists" >&2
+      return 1
+    fi
+    gc compute backend-services create "$backend" --global \
+      --load-balancing-scheme=EXTERNAL_MANAGED --protocol=HTTP --port-name=http \
+      --timeout="${timeout}s" --quiet >/dev/null
+  else
+    gc compute backend-services update "$backend" --global \
+      --timeout="${timeout}s" --quiet >/dev/null
+  fi
+  if [ "$surface" = public ]; then
+    gc compute backend-services update "$backend" --global \
+      --enable-cdn \
+      --cache-mode=USE_ORIGIN_HEADERS \
+      --cache-key-include-host \
+      --cache-key-include-protocol \
+      --cache-key-include-query-string \
+      --cache-key-query-string-blacklist= \
+      --compression-mode=AUTOMATIC \
+      --serve-while-stale=600 \
+      --no-negative-caching \
+      --quiet >/dev/null
+  else
+    gc compute backend-services update "$backend" --global --no-enable-cdn --quiet >/dev/null
+  fi
+}
+
+verify_exact_neg_target() {
+  local service="$1" neg="$2" region="$3" neg_json="$4"
+  python3 - "$service" "$neg" "$region" "$neg_json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+service, neg, region, path = sys.argv[1:]
+target = (json.loads(Path(path).read_text(encoding="utf-8")).get("cloudRun") or {})
+if target != {"service": service}:
+    raise SystemExit(
+        f"{neg}/{region} must target exactly Cloud Run service {service} without tag/urlMask"
+    )
+PY
+}
+
+ensure_neg() {
+  local surface="$1" region="$2" service backend neg neg_json attached conflicting group_counts
+  local describe_output describe_rc=0
+  service="$(surface_service "$surface")"
+  backend="$(surface_backend "$surface")"
+  neg="$(surface_neg "$surface")"
+  neg_json="${WORK_DIR}/neg-${surface}-${region}.json"
+  describe_output="$(gc compute network-endpoint-groups describe "$neg" --region="$region" --format=json 2>&1)" || describe_rc=$?
+  if [ "$describe_rc" = 0 ]; then
+    printf '%s\n' "$describe_output" >"$neg_json"
+    verify_exact_neg_target "$service" "$neg" "$region" "$neg_json" || return 1
+  else
+    if [[ "$describe_output" != *NOT_FOUND* && "$describe_output" != *"not found"* ]]; then
+      echo "ERROR: cannot determine whether ${neg}/${region} exists" >&2
+      return 1
+    fi
+    gc compute network-endpoint-groups create "$neg" --region="$region" \
+      --network-endpoint-type=serverless --cloud-run-service="$service" --quiet >/dev/null
+  fi
+  group_counts="$(gc compute backend-services describe "$backend" --global --format=json \
+    | jq -r --arg project "$PROJECT_ID" --arg region "$region" --arg neg "$neg" '
+      ("/projects/" + $project + "/regions/" + $region + "/networkEndpointGroups/" + $neg) as $expected
+      | ("/regions/" + $region + "/networkEndpointGroups/" + $neg) as $suffix
+      | [
+          [.backends[]?.group | select(. == ($expected | ltrimstr("/")) or endswith($expected))] | length,
+          [.backends[]?.group | select(endswith($suffix) and
+            (. != ($expected | ltrimstr("/")) and (endswith($expected) | not)))] | length
+        ] | @tsv
+    ')" || return 1
+  read -r attached conflicting <<<"$group_counts" || return 1
+  [ "$conflicting" = 0 ] || {
+    echo "ERROR: ${backend} references same-named ${neg}/${region} outside project ${PROJECT_ID}" >&2
+    return 1
+  }
+  if [ "$attached" = 0 ]; then
+    gc compute backend-services add-backend "$backend" --global \
+      --network-endpoint-group="$neg" --network-endpoint-group-region="$region" --quiet >/dev/null
+  elif [ "$attached" != 1 ]; then
+    echo "ERROR: ${backend} has duplicate ${neg}/${region} attachments" >&2
+    return 1
+  fi
+}
+
+remove_extra_inactive_backend_groups() {
+  local surface="$1" backend neg backend_json groups group project region group_name keep
+  backend="$(surface_backend "$surface")"
+  neg="$(surface_neg "$surface")"
+  backend_json="$(gc compute backend-services describe "$backend" --global --format=json)"
+  groups="$(jq -r '.backends[]?.group' <<<"$backend_json")" || return 1
+  while IFS= read -r group; do
+    project="$(sed -n 's#.*projects/\([^/]*\)/regions/.*#\1#p' <<<"$group")"
+    region="$(sed -n 's#.*regions/\([^/]*\)/networkEndpointGroups/.*#\1#p' <<<"$group")"
+    group_name="${group##*/}"
+    [ -n "$project" ] && [ -n "$region" ] || {
+      echo "ERROR: inactive managed backend has a noncanonical group reference: ${group}" >&2
+      return 1
+    }
+    [ "$project" = "$PROJECT_ID" ] || {
+      echo "ERROR: inactive managed backend references a NEG outside project ${PROJECT_ID}: ${group}" >&2
+      return 1
+    }
+    keep=0
+    for expected_region in "${REGIONS[@]}"; do
+      [ "$region" = "$expected_region" ] && [ "$group_name" = "$neg" ] && keep=1
+    done
+    if [ "$keep" = 0 ]; then
+      gc compute backend-services remove-backend "$backend" --global \
+        --network-endpoint-group="$group_name" --network-endpoint-group-region="$region" --quiet >/dev/null
+    fi
+  done <<<"$groups"
+}
+
+verify_backend_contract() {
+  local surface="$1" backend neg service policy timeout backend_json policy_json
+  local backend_payload policy_payload regions_csv
+  backend="$(surface_backend "$surface")"
+  neg="$(surface_neg "$surface")"
+  service="$(surface_service "$surface")"
+  policy="$(surface_policy "$surface")"
+  timeout="$(surface_backend_timeout "$surface")"
+  backend_json="${WORK_DIR}/backend-${surface}.json"
+  gc compute backend-services describe "$backend" --global --format=json >"$backend_json"
+  backend_payload="$(<"$backend_json")"
+  regions_csv="$(IFS=,; echo "${REGIONS[*]}")"
+  verify_edge_backend_contract_json "$surface" "$backend_payload" \
+    "$PROJECT_ID" "$regions_csv" "$service" "$neg" "$policy" "$timeout" || return 1
+  policy_json="${WORK_DIR}/policy-${surface}.json"
+  gc compute security-policies describe "$policy" --global --format=json >"$policy_json"
+  policy_payload="$(<"$policy_json")"
+  verify_cloud_armor_policy_contract_json "$policy_payload" || return 1
+  for region in "${REGIONS[@]}"; do
+    neg_json="${WORK_DIR}/verify-neg-${surface}-${region}.json"
+    gc compute network-endpoint-groups describe "$neg" --region="$region" --format=json >"$neg_json"
+    verify_exact_neg_target "$service" "$neg" "$region" "$neg_json" || return 1
+  done
+}
+
+# TR_DEPLOY_RECONCILE_LB gates only the MUTATING edge work below. The
+# read-only inventory and backend verification always run: edge_header source
+# trust requires every deploy to verify the LB contract, and the workflow's
+# reconcile-exactly-once design (primary region reconciles, secondaries pass
+# TR_DEPLOY_RECONCILE_LB=0 so concurrent rollouts never race on the shared
+# global LB) only ever skips mutation, never verification. Skipping is legal
+# only when nothing needed reconciling; that is asserted after classification.
+
+# Inventory every global URL map, not only the selected HTTPS proxy map. A
+# canonical backend referenced by another proxy is live even when absent from
+# the selected map and therefore must never be reconciled as an inactive
+# rollout companion.
+URL_MAP_INVENTORY="${WORK_DIR}/all-url-maps.jsonl"
+: >"$URL_MAP_INVENTORY"
+URL_MAP_NAMES="$(gc compute url-maps list --format='value(name)')" || exit 1
+[ -n "$URL_MAP_NAMES" ] || {
+  echo "ERROR: no global URL maps are visible for backend reachability preflight" >&2
+  exit 1
+}
+while IFS= read -r inventory_map; do
+  [ -n "$inventory_map" ] || continue
+  validate_resource_name "global URL map" "$inventory_map"
+  gc compute url-maps describe "$inventory_map" --global --format=json \
+    | jq -c . >>"$URL_MAP_INVENTORY"
+done <<<"$URL_MAP_NAMES"
+jq -se --arg name "$URL_MAP_NAME" 'any(.[]; .name == $name)' \
+  "$URL_MAP_INVENTORY" >/dev/null || {
+  echo "ERROR: selected URL map is absent from the global inventory" >&2
+  exit 1
+}
+
+# Verify every currently reachable backend before any LB mutation. Active
+# backends are never reconciled in-place by staging because that would require
+# a much larger rollback manifest for cache, policy, headers, and membership.
+# Inactive companion backends may be reconciled because the captured URL map
+# proves they receive no production request.
+INACTIVE_SURFACES=()
+for surface in "${SURFACES[@]}"; do
+  backend="$(surface_backend "$surface")"
+  backend_describe_rc=0
+  backend_json="$(gc compute backend-services describe "$backend" --global --format=json 2>&1)" || backend_describe_rc=$?
+  if [ "$backend_describe_rc" = 0 ]; then
+    self_link="$(jq -er '.selfLink' <<<"$backend_json")"
+    reference_maps="$(backend_reference_maps "$backend" "$self_link")" || exit 1
+    if grep -Fxq "$URL_MAP_NAME" <<<"$reference_maps"; then
+      if [ "$ROLLOUT_MODE" = initial_split ]; then
+        echo "ERROR: initial URL map unexpectedly references the ${surface} backend" >&2
+        exit 1
+      fi
+      verify_backend_contract "$surface"
+      continue
+    fi
+    if [ -n "$reference_maps" ]; then
+      echo "ERROR: ${backend} is reachable from another global URL map: ${reference_maps//$'\n'/,}" >&2
+      exit 1
+    fi
+  elif [[ "$backend_json" != *NOT_FOUND* && "$backend_json" != *"not found"* ]]; then
+    echo "ERROR: cannot determine whether backend ${backend} exists" >&2
+    exit 1
+  fi
+  [ "$ROLLOUT_MODE" = existing_split ] && {
+    echo "ERROR: existing split does not route the ${surface} backend" >&2
+    exit 1
+  }
+  INACTIVE_SURFACES+=("$surface")
+done
+
+edge_contract_digest() {
+  local surface="$1" backend policy region path hashes=""
+  backend="$(surface_backend "$surface")"
+  policy="$(surface_policy "$surface")"
+  path="${WORK_DIR}/journal-backend-${surface}.json"
+  gc compute backend-services describe "$backend" --global --format=json >"$path" || return 1
+  hashes="$(python3 "$STATE_TOOL" hash-resource "$path")"
+  path="${WORK_DIR}/journal-policy-${surface}.json"
+  gc compute security-policies describe "$policy" --global --format=json >"$path" || return 1
+  hashes="${hashes}$(python3 "$STATE_TOOL" hash-resource "$path")"
+  for region in "${REGIONS[@]}"; do
+    path="${WORK_DIR}/journal-neg-${surface}-${region}.json"
+    gc compute network-endpoint-groups describe "$(surface_neg "$surface")" \
+      --region="$region" --format=json >"$path" || return 1
+    hashes="${hashes}$(python3 "$STATE_TOOL" hash-resource "$path")"
+  done
+  python3 - "$hashes" <<'PY'
+import hashlib
+import sys
+print(hashlib.sha256(sys.argv[1].encode()).hexdigest())
+PY
+}
+
+if [ "${TR_DEPLOY_RECONCILE_LB:-1}" = "1" ]; then
+for surface in "${INACTIVE_SURFACES[@]}"; do
+  policy="$(surface_policy "$surface")"
+  backend="$(surface_backend "$surface")"
+  # A supposedly inactive policy may still protect another live backend.
+  policy_describe_rc=0
+  policy_describe_output="$(gc compute security-policies describe "$policy" --global 2>&1)" || policy_describe_rc=$?
+  if [ "$policy_describe_rc" = 0 ]; then
+    policy_consumers="$(gc compute backend-services list --global --format=json \
+      | jq -r --arg policy "$policy" '[.[] | select((.securityPolicy // "" | split("/")[-1]) == $policy) | .name] | unique | join(",")')"
+    [ -z "$policy_consumers" ] || [ "$policy_consumers" = "$backend" ] || {
+      echo "ERROR: inactive policy ${policy} is attached to other backend(s): ${policy_consumers}" >&2
+      exit 1
+    }
+  elif [[ "$policy_describe_output" != *NOT_FOUND* && "$policy_describe_output" != *"not found"* ]]; then
+    echo "ERROR: cannot determine whether inactive policy ${policy} exists" >&2
+    exit 1
+  fi
+  edge_state=pending
+  if [ "$ROLLOUT_MODE" = initial_split ]; then
+    edge_record="$(stage_journal_read edge "$surface")" || exit 1
+    edge_state="$(jq -er .state <<<"$edge_record")" || exit 1
+    if [ "$edge_state" = pending ]; then
+      stage_journal_transition edge "$surface" "" pending reconcile_intent
+      edge_state=reconcile_intent
+    fi
+  fi
+  if [ "$edge_state" = reconciled ]; then
+    verify_backend_contract "$surface"
+    edge_digest="$(edge_contract_digest "$surface")" || exit 1
+    [ "$edge_digest" = "$(jq -er .postcondition_sha256 <<<"$edge_record")" ] || {
+      echo "ERROR: reconciled edge state drifted for ${surface}" >&2
+      exit 1
+    }
+    continue
+  fi
+  ensure_inactive_backend "$surface"
+  for region in "${REGIONS[@]}"; do ensure_neg "$surface" "$region"; done
+  remove_extra_inactive_backend_groups "$surface"
+  reconcile_edge_backend_mappings "${backend}=${policy}"
+  verify_backend_contract "$surface"
+  if [ "$ROLLOUT_MODE" = initial_split ]; then
+    edge_digest="$(edge_contract_digest "$surface")" || exit 1
+    stage_journal_transition edge "$surface" "" reconcile_intent reconciled "$edge_digest"
+  fi
+done
+else
+  log "skipping shared load-balancer reconciliation"
+  # Mutation was skipped, so it must not have been needed: every backend had
+  # to be classified active (routed by the selected map) above. An inactive
+  # backend here means the primary region's reconcile-once pass has not run.
+  [ "${#INACTIVE_SURFACES[@]}" = 0 ] || {
+    echo "ERROR: unreconciled inactive backends require TR_DEPLOY_RECONCILE_LB=1: ${INACTIVE_SURFACES[*]}" >&2
+    exit 1
+  }
+fi
+for surface in "${SURFACES[@]}"; do verify_backend_contract "$surface"; done
+if [ "$ROLLOUT_MODE" = initial_split ]; then
+  stage_phase="$(jq -er .phase "$STAGE_JOURNAL")" || exit 1
+  if [ "$stage_phase" = edge ]; then
+    stage_journal_set_phase edge services
+  elif [ "$stage_phase" != services ] && [ "$stage_phase" != manifest_intent ] && \
+      [ "$stage_phase" != complete ]; then
+    echo "ERROR: initial-stage journal phase differs after edge reconciliation" >&2
+    exit 1
+  fi
+fi
+
+backend_self_link() {
+  gc compute backend-services describe "$(surface_backend "$1")" \
+    --global --format='value(selfLink)'
+}
+
+# All inactive edge resources now exist and are exact, so build and ask GCP to
+# validate the real atomic map before any deploy can alter the active console
+# service. The helper later imports these exact private snapshot bytes.
+RENDERED_CANDIDATE_URL_MAP="$CANDIDATE_URL_MAP"
+if [ -e "$CANDIDATE_URL_MAP" ]; then
+  [ "$ROLLOUT_MODE" = initial_split ] && [ "$RESUMING_INITIAL_STAGE" = true ] || {
+    echo "ERROR: refusing to overwrite candidate URL-map snapshot" >&2
+    exit 1
+  }
+  RENDERED_CANDIDATE_URL_MAP="${WORK_DIR}/url-map.candidate.current.json"
+fi
+python3 "$URL_MAP_TOOL" \
+  --input "$PRIOR_URL_MAP" \
+  --output "$RENDERED_CANDIDATE_URL_MAP" \
+  --public-backend "$(backend_self_link public)" \
+  --actions-backend "$(backend_self_link actions)" \
+  --console-backend "$(backend_self_link console)" \
+  --chat-backend "$(backend_self_link chat)" \
+  --webhooks-backend "$(backend_self_link webhooks)" \
+  --internal-backend "$(backend_self_link internal)" \
+  --domains "$DOMAINS" \
+  --preserved-hosts "$PRESERVED_HOSTS"
+if [ "$RENDERED_CANDIDATE_URL_MAP" != "$CANDIDATE_URL_MAP" ]; then
+  [ "$(python3 "$STATE_TOOL" hash-url-map "$RENDERED_CANDIDATE_URL_MAP")" = \
+    "$(python3 "$STATE_TOOL" hash-url-map "$CANDIDATE_URL_MAP")" ] || {
+    echo "ERROR: resumed candidate URL-map snapshot differs from the journaled plan" >&2
+    exit 1
+  }
+else
+  chmod 600 "$CANDIDATE_URL_MAP"
+fi
+chmod 600 "$PRIOR_URL_MAP" "$CANDIDATE_URL_MAP"
+gc compute url-maps validate --global --source="$CANDIDATE_URL_MAP" >/dev/null
+if [ "$ROLLOUT_MODE" = initial_split ]; then
+  candidate_snapshot_sha="$(python3 "$STATE_TOOL" hash-url-map "$CANDIDATE_URL_MAP")"
+  recorded_candidate_sha="$(jq -r '.candidate_snapshot_sha256 // ""' "$STAGE_JOURNAL")"
+  if [ -n "$recorded_candidate_sha" ] && [ "$recorded_candidate_sha" != "$candidate_snapshot_sha" ]; then
+    echo "ERROR: candidate URL-map snapshot hash differs from the initial-stage journal" >&2
+    exit 1
+  fi
+  if [ -z "$recorded_candidate_sha" ]; then
+    stage_phase="$(jq -er .phase "$STAGE_JOURNAL")" || exit 1
+    stage_journal_set_phase "$stage_phase" "$stage_phase" "$candidate_snapshot_sha"
+  fi
+fi
 
 cloud_run_min_instances_for_region() {
   local target="$1"
@@ -664,315 +2677,675 @@ cloud_run_min_instances_for_region() {
       return 0
     fi
   done
-  if is_warm_region "$target"; then
-    printf '1\n'
-  else
-    printf '0\n'
-  fi
+  case ",${TR_WARM_REGIONS}," in
+    *",${target},"*) printf '1\n' ;;
+    *) printf '0\n' ;;
+  esac
 }
 
-deploy_one_region() {
-  local target="$1"
-  local logfile="${2:-/dev/null}"
-  # When TR_DEPLOY_NO_TRAFFIC=1 is set (the staged-traffic flow in the
-  # GHA workflow), the new revision is created with 0% traffic. The
-  # workflow then ramps it up via `gcloud run services update-traffic`
-  # in 10% / 50% / 100% stages with synthetic checks between, so a bug
-  # that breaks the new revision under real load is caught while most
-  # traffic is still on the old revision.
-  local traffic_arg=""
-  if [ "${TR_DEPLOY_NO_TRAFFIC:-0}" = "1" ]; then
-    traffic_arg="--no-traffic"
-    log "deploying Cloud Run service ${SERVICE} to ${target} with --no-traffic (staged shift to follow)"
-  else
-    log "deploying Cloud Run service ${SERVICE} to ${target}"
-  fi
-  prune_failed_revisions "$target" >>"$logfile" 2>&1 || true
-  # A global override wins. Otherwise use the per-region service minimum;
-  # unknown warm regions retain one instance and unknown cold regions scale to
-  # zero. Service-level minimums remain allocated while staged revisions split
-  # traffic, unlike revision-level minimums which can double or disappear.
-  local min_instances="${TR_CLOUD_RUN_MIN_INSTANCES:-}"
-  if [ -z "$min_instances" ]; then
-    min_instances="$(cloud_run_min_instances_for_region "$target")"
-  fi
-  # /chat and /synth stream through /chat-proxy/v1 for browser CORS.
-  # Synth can legitimately take several model calls before final output, so
-  # match the proxy's 300s upstream read timeout unless explicitly overridden.
-  if gc run deploy "$SERVICE" \
-      --region "$target" \
-      --image "$IMAGE" \
-      --allow-unauthenticated \
-      --port 8080 \
-      --memory "${TR_CLOUD_RUN_MEMORY:-1Gi}" \
-      --concurrency "$TR_CLOUD_RUN_CONCURRENCY" \
-      --min "$min_instances" \
-      --min-instances default \
-      --timeout "${TR_CLOUD_RUN_TIMEOUT_SECONDS:-300}" \
-      --network "${TR_CLOUD_RUN_NETWORK:-default}" \
-      --subnet "${TR_CLOUD_RUN_SUBNET:-default}" \
-      --vpc-egress private-ranges-only \
-      --set-env-vars "$SET_ENV_VARS" \
-      --update-secrets "$UPDATE_SECRETS" \
-      "${REMOVE_SECRETS_ARGS[@]}" \
-      ${traffic_arg} \
-      --quiet >>"$logfile" 2>&1; then
-    log "deploy succeeded: ${target}"
-    return 0
-  fi
-  log "deploy FAILED: ${target} (see ${logfile})"
-  return 1
+surface_runtime_contract() {
+  local surface="$1"
+  local region="$2"
+  case "$surface" in
+    public)
+      CONCURRENCY=4; MIN_INSTANCES=0; MAX_INSTANCES=10; TIMEOUT_SECONDS=60
+      MEMORY=1Gi; SPANNER_POOL_SIZE=1; MAX_REQUEST_BODY_BYTES=1048576
+      MAX_IN_FLIGHT_REQUEST_BODY_BYTES=4194304; MAX_CONCURRENT_REQUEST_BODIES=2
+      REQUEST_BODY_READ_TIMEOUT_SECONDS=10; DEFAULT_URL_DISABLED=true ;;
+    actions)
+      CONCURRENCY=4; MIN_INSTANCES=0; MAX_INSTANCES=2; TIMEOUT_SECONDS=30
+      MEMORY=512Mi; SPANNER_POOL_SIZE=0; MAX_REQUEST_BODY_BYTES=262144
+      MAX_IN_FLIGHT_REQUEST_BODY_BYTES=1048576; MAX_CONCURRENT_REQUEST_BODIES=2
+      REQUEST_BODY_READ_TIMEOUT_SECONDS=10; DEFAULT_URL_DISABLED=true ;;
+    console)
+      CONCURRENCY=4; MIN_INSTANCES=1; MAX_INSTANCES=20; TIMEOUT_SECONDS=300
+      MEMORY=2Gi; SPANNER_POOL_SIZE=2; MAX_REQUEST_BODY_BYTES=4194304
+      MAX_IN_FLIGHT_REQUEST_BODY_BYTES=16777216; MAX_CONCURRENT_REQUEST_BODIES=2
+      REQUEST_BODY_READ_TIMEOUT_SECONDS=30; DEFAULT_URL_DISABLED=true ;;
+    chat)
+      CONCURRENCY=2; MIN_INSTANCES=1; MAX_INSTANCES=20; TIMEOUT_SECONDS=300
+      MEMORY=2Gi; SPANNER_POOL_SIZE=2; MAX_REQUEST_BODY_BYTES=33554432
+      MAX_IN_FLIGHT_REQUEST_BODY_BYTES=67108864; MAX_CONCURRENT_REQUEST_BODIES=2
+      REQUEST_BODY_READ_TIMEOUT_SECONDS=30; DEFAULT_URL_DISABLED=true ;;
+    webhooks)
+      CONCURRENCY=4; MIN_INSTANCES=1; MAX_INSTANCES=10; TIMEOUT_SECONDS=60
+      MEMORY=1Gi; SPANNER_POOL_SIZE=2; MAX_REQUEST_BODY_BYTES=1048576
+      MAX_IN_FLIGHT_REQUEST_BODY_BYTES=4194304; MAX_CONCURRENT_REQUEST_BODIES=2
+      REQUEST_BODY_READ_TIMEOUT_SECONDS=10; DEFAULT_URL_DISABLED=true ;;
+    internal)
+      CONCURRENCY="$TR_CLOUD_RUN_CONCURRENCY"; MAX_INSTANCES=50; TIMEOUT_SECONDS=300
+      MIN_INSTANCES="${TR_CLOUD_RUN_MIN_INSTANCES:-$(cloud_run_min_instances_for_region "$region")}"
+      MEMORY=2Gi; SPANNER_POOL_SIZE="$TR_SPANNER_POOL_SIZE"; MAX_REQUEST_BODY_BYTES=33554432
+      MAX_IN_FLIGHT_REQUEST_BODY_BYTES=67108864; MAX_CONCURRENT_REQUEST_BODIES=4
+      REQUEST_BODY_READ_TIMEOUT_SECONDS=30; DEFAULT_URL_DISABLED=false ;;
+    *) return 2 ;;
+  esac
 }
 
-# Fan deploys out in parallel across every TR_REGIONS entry. Each
-# region's gcloud invocation runs in its own subshell so a slow image
-# pull in one cold region doesn't block the warm regions. Cloud Run scales to zero in
-# unused regions so the bill stays the same as a single-region deploy
-# at idle.
-log_dir="$(mktemp -d "${TMPDIR:-/tmp}/tr-deploy-XXXXXX")"
-log "parallel deploy logs in ${log_dir}"
-
-if ! gc artifacts docker images describe "$IMAGE" >/dev/null 2>&1; then
-  echo "ERROR: image ${IMAGE} does not exist. Run scripts/deploy/image.sh before rollout." >&2
-  exit 1
-fi
-
-DEPLOY_TARGET_REGIONS="${TR_DEPLOY_TARGET_REGIONS:-$TR_CONTROL_PLANE_REGIONS}"
-IFS=',' read -ra _REGION_LIST <<<"$DEPLOY_TARGET_REGIONS"
-TARGETS=()
-for r in "${_REGION_LIST[@]}"; do
-  [ -n "$r" ] && TARGETS+=("$r")
-done
-if [ "${TR_DEPLOY_ALL_REGIONS:-1}" != "1" ]; then
-  TARGETS=("$REGION")
-fi
-
-# Full set of control-plane regions that SHOULD be in the LB (independent of
-# what this deploy run targets). The detach-stale-NEG step below compares
-# attached regions against this — NOT against TARGETS — so a narrow-target
-# deploy (e.g. TR_DEPLOY_TARGET_REGIONS=us-central1) doesn't accidentally rip
-# cold public-site regions out of the LB.
-#
-# Lost ~30s of trustedrouter.com 504s on 2026-05-10 from exactly this:
-# a cold-region-only deploy detached all three warm-region NEGs from
-# trusted-router-control-backend because the original loop compared
-# against TARGETS (the cold subset) instead of the full control-plane region
-# set. TR_REGIONS remains the attested API region set exposed to SDK callers.
-IFS=',' read -ra _ALL_REGION_LIST <<<"$TR_CONTROL_PLANE_REGIONS"
-ALL_REGIONS=()
-for r in "${_ALL_REGION_LIST[@]}"; do
-  [ -n "$r" ] && ALL_REGIONS+=("$r")
-done
-
-REGION_PIDS=()
-REGION_LOGS=()
-for fanout_region in "${TARGETS[@]}"; do
-  region_log="${log_dir}/${fanout_region}.log"
-  REGION_LOGS+=("$region_log")
-  deploy_one_region "$fanout_region" "$region_log" &
-  REGION_PIDS+=("$!")
-done
-
-deploy_failed=0
-for idx in "${!TARGETS[@]}"; do
-  fanout_region="${TARGETS[$idx]}"
-  pid="${REGION_PIDS[$idx]}"
-  if ! wait "$pid"; then
-    deploy_failed=1
-    log "deploy log for failed region ${fanout_region}:"
-    tail -20 "${REGION_LOGS[$idx]}" >&2 || true
+surface_env_vars() {
+  local surface="$1"
+  local region="$2"
+  surface_runtime_contract "$surface" "$region"
+  SURFACE_ENV=(
+    "TR_ENVIRONMENT=production"
+    "TR_RELEASE=${RELEASE}"
+    "TR_SERVICE_SURFACE=${surface}"
+    "TR_API_BASE_URL=https://api.trustedrouter.com/v1"
+    "TR_TRUSTED_DOMAIN=trustedrouter.com"
+    "TR_TRUSTED_DOMAIN_ALIASES=allyrouter.com,uptimerouter.com"
+    "TR_GCP_PROJECT_ID=${PROJECT_ID}"
+    "TR_REGIONS=${TR_REGIONS}"
+    "TR_PRIMARY_REGION=${TR_PRIMARY_REGION}"
+    "TR_ENABLE_LIVE_PROVIDERS=false"
+    "TR_RATE_LIMIT_CLIENT_IP_MODE=edge_header"
+    "TR_MAX_REQUEST_BODY_BYTES=${MAX_REQUEST_BODY_BYTES}"
+    "TR_MAX_IN_FLIGHT_REQUEST_BODY_BYTES=${MAX_IN_FLIGHT_REQUEST_BODY_BYTES}"
+    "TR_MAX_CONCURRENT_REQUEST_BODIES=${MAX_CONCURRENT_REQUEST_BODIES}"
+    "TR_REQUEST_BODY_READ_TIMEOUT_SECONDS=${REQUEST_BODY_READ_TIMEOUT_SECONDS}"
+    "TR_REMEDIATOR_IN_PROCESS_ENABLED=false"
+    "TR_SYNTHETIC_SCHEDULER_INTERVAL_SECONDS=0"
+    "TR_ACTIVATION_REMINDER_INTERVAL_SECONDS=0"
+  )
+  if [ "$surface" = actions ]; then
+    SURFACE_ENV+=(
+      "TR_STORAGE_BACKEND=memory"
+      "TR_AWS_REGION=us-east-1"
+      "TR_SES_FROM_EMAIL=noreply@trustedrouter.com"
+      "TR_SES_FROM_NAME=TrustedRouter"
+      "TR_OPS_CHAT_WEBHOOK_URLS=https://a.uptimerouter.com,https://b.trustedrouter.com,https://c.allyrouter.com"
+      "TR_PARTNER_INQUIRY_EMAIL=joseph@jperla.com"
+    )
+    return
   fi
-done
-
-if [ "$deploy_failed" -ne 0 ]; then
-  echo "ERROR: at least one region's deploy failed; see logs in ${log_dir}" >&2
-  exit 1
-fi
-
-latest_ready_revision_for_region() {
-  local target="$1"
-  # `status.latestReadyRevisionName` can lag behind when a deploy reuses a
-  # mutable tag or when we immediately force a nonce-only redeploy. Prefer the
-  # newest revision from the revision list whose Ready condition is True.
-  gc run revisions list --service "$SERVICE" --region "$target" \
-    --limit=10 \
-    --sort-by='~metadata.creationTimestamp' \
-    --format='value(metadata.name,status.conditions[0].status)' 2>/dev/null \
-    | awk '$2 == "True" { print $1; exit }'
-}
-
-if [ "${TR_DEPLOY_NO_TRAFFIC:-0}" != "1" ]; then
-  # Defense against a real 2026-06-05 rollout bug: Cloud Run created Ready
-  # revisions in us-east4/europe-west4, but service traffic remained pinned
-  # to older revisions, so prod served a mixed catalog. Make the intended
-  # no-staging path explicit: after every successful regional deploy, route
-  # 100% to the newest Ready revision in that region.
-  for traffic_region in "${TARGETS[@]}"; do
-    latest_rev="$(latest_ready_revision_for_region "$traffic_region")"
-    if [ -z "$latest_rev" ]; then
-      echo "ERROR: could not find newest Ready revision for ${traffic_region}" >&2
-      exit 1
-    fi
-    log "routing ${traffic_region} traffic to newest Ready revision ${latest_rev}"
-    gc run services update-traffic "$SERVICE" \
-      --region="$traffic_region" \
-      --to-revisions="${latest_rev}=100" \
-      --quiet >/dev/null
-  done
-fi
-
-log "Cloud Run URLs:"
-for url_region in "${TARGETS[@]}"; do
-  url="$(gc run services describe "$SERVICE" --region "$url_region" --format='value(status.url)' 2>/dev/null || true)"
-  if [ -n "$url" ]; then
-    printf '  %-28s %s\n' "$url_region" "$url"
-  fi
-done
-
-# ---------------------------------------------------------------------------
-# Attach a Serverless NEG per region to the global LB backend service so
-# trustedrouter.com routes to the nearest healthy region instead of always
-# us-central1. The backend service was created out-of-band when the LB
-# was first set up; this block discovers + reuses its existing config so
-# we don't have to know LB topology upfront.
-#
-# Idempotent: skip-if-exists on every step (NEG create, backend add).
-# Safe to re-run on every deploy.
-# ---------------------------------------------------------------------------
-LB_BACKEND_SERVICE="${LB_BACKEND_SERVICE:-trusted-router-control-backend}"
-LB_NEG_NAME="${LB_NEG_NAME:-trusted-router-control-neg}"
-
-attach_region_to_lb() {
-  local target="$1"
-  if ! gc compute network-endpoint-groups describe "$LB_NEG_NAME" \
-      --region "$target" >/dev/null 2>&1; then
-    log "creating Serverless NEG ${LB_NEG_NAME} in ${target}"
-    gc compute network-endpoint-groups create "$LB_NEG_NAME" \
-      --region "$target" \
-      --network-endpoint-type=serverless \
-      --cloud-run-service="$SERVICE" \
-      --quiet >/dev/null
-  fi
-
-  local already_attached
-  already_attached="$(gc compute backend-services describe "$LB_BACKEND_SERVICE" \
-    --global --format='value(backends[].group)' 2>/dev/null \
-    | tr ';' '\n' \
-    | grep -c "/regions/${target}/networkEndpointGroups/${LB_NEG_NAME}\$" || true)"
-  if [ "$already_attached" = "0" ]; then
-    log "attaching NEG ${LB_NEG_NAME} (${target}) to ${LB_BACKEND_SERVICE}"
-    gc compute backend-services add-backend "$LB_BACKEND_SERVICE" \
-      --global \
-      --network-endpoint-group="$LB_NEG_NAME" \
-      --network-endpoint-group-region="$target" \
-      --quiet >/dev/null
-  fi
-}
-
-if [ "${TR_DEPLOY_RECONCILE_LB:-1}" != "1" ]; then
-  log "skipping shared load-balancer reconciliation for this regional rollout"
-elif gc compute backend-services describe "$LB_BACKEND_SERVICE" --global >/dev/null 2>&1; then
-  log "wiring Serverless NEGs to ${LB_BACKEND_SERVICE}"
-  # Attach every control-plane region, not just this deploy's TARGETS, so the
-  # LB always reflects the full intended public-site region set. Idempotent:
-  # attach_region_to_lb no-ops on regions that are already attached. Without
-  # this, a narrow-target deploy could leave a Cloud Run region outside LB
-  # rotation.
-  for fanout_region in "${ALL_REGIONS[@]}"; do
-    attach_region_to_lb "$fanout_region" || log "WARN: NEG attach failed for ${fanout_region}"
-  done
-  existing_backend_regions="$(gc compute backend-services describe "$LB_BACKEND_SERVICE" \
-    --global --format='value(backends[].group)' 2>/dev/null \
-    | tr ';' '\n' \
-    | sed -n 's#.*regions/\([^/]*\)/networkEndpointGroups/.*#\1#p' \
-    | sort -u)"
-  for attached_region in $existing_backend_regions; do
-    # Compare against ALL_REGIONS (= TR_CONTROL_PLANE_REGIONS), not TARGETS.
-    # TARGETS is just this deploy run's subset; detaching anything outside of
-    # it would rip cold regions out of the LB when running a warm-only or
-    # narrow-target deploy. We only want to detach regions that fell out of
-    # TR_CONTROL_PLANE_REGIONS entirely.
-    keep_region=0
-    for full_region in "${ALL_REGIONS[@]}"; do
-      if [ "$attached_region" = "$full_region" ]; then
-        keep_region=1
-        break
+  SURFACE_ENV+=(
+    "TR_STORAGE_BACKEND=${STORAGE_BACKEND}"
+    "TR_SPANNER_INSTANCE_ID=${SPANNER_INSTANCE_ID}"
+    "TR_SPANNER_DATABASE_ID=${SPANNER_DATABASE_ID}"
+    "TR_BIGTABLE_INSTANCE_ID=${BIGTABLE_INSTANCE_ID}"
+    "TR_BIGTABLE_GENERATION_TABLE=${BIGTABLE_GENERATION_TABLE}"
+    "TR_SPANNER_POOL_SIZE=${SPANNER_POOL_SIZE}"
+    "TR_BIGTABLE_MIRROR_WRITES_ENABLED=${BIGTABLE_MIRROR_WRITES_ENABLED}"
+    "TR_GENERATION_RECORDS_ENABLED=${GENERATION_RECORDS_ENABLED}"
+    "TR_ANALYTICS_READ_MODE=${ANALYTICS_READ_MODE}"
+    "TR_ANALYTICS_DUAL_READ_STARTED_AT=${TR_ANALYTICS_DUAL_READ_STARTED_AT:-$(serving_env_value TR_ANALYTICS_DUAL_READ_STARTED_AT)}"
+    "TR_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT=${TR_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT:-$(serving_env_value TR_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT)}"
+    "TR_REQUEST_RECORD_WRITE_MODE=${REQUEST_RECORD_WRITE_MODE}"
+    "TR_SETTLE_OUTBOX_ENABLED=true"
+    "TR_ANALYTICS_OUTBOX_ENABLED=true"
+    "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true"
+  )
+  case "$surface" in public|console|internal)
+    if [ "$ANALYTICS_READ_MODE" != bigtable ]; then
+      SURFACE_ENV+=(
+        "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_URL=${OPERATIONAL_CLICKHOUSE_URL}"
+        "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_USER=tr_control_read"
+        "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_DATABASE=tr"
+      )
+    fi ;;
+  esac
+  case "$surface" in
+    public)
+      SURFACE_ENV+=(
+        "TR_GOOGLE_OAUTH_LOGIN_AVAILABLE=${GOOGLE_OAUTH_AVAILABLE}"
+        "TR_GITHUB_OAUTH_LOGIN_AVAILABLE=${GITHUB_OAUTH_AVAILABLE}"
+        "TR_TRUST_GCP_RELEASE_URL=https://trust.trustedrouter.com/trust/gcp-release.json"
+        "TR_TRUST_GCP_RELEASE_FALLBACK_URLS=https://raw.githubusercontent.com/Lore-Hex/quill-cloud-proxy/main/trust-page/gcp-release.json"
+        "TR_TRUST_AWS_RELEASE_URL=https://trust.trustedrouter.com/trust/aws-release.json"
+        "TR_TRUST_AZURE_RELEASE_URL=https://trust.trustedrouter.com/trust/azure-release.json"
+      ) ;;
+    console)
+      SURFACE_ENV+=(
+        "TR_SIGNUP_TRIAL_CREDIT_MICRODOLLARS=300000"
+        "TR_NEW_SIGNUPS_ENABLED=${NEW_SIGNUPS_ENABLED}"
+        "TR_USER_MODELS_DISPATCH_ENABLED=true"
+        # Emergency telemetry disablement is an explicit rollout edit: with
+        # this flag false the route returns 202 plus x-tr-telemetry: off before
+        # it reads a request body.
+        "TR_CLIENT_EVENTS_ENABLED=true"
+        "TR_BYOK_KMS_KEY_NAME=${BYOK_KMS_KEY_NAME}"
+        "TR_GOOGLE_OAUTH_LOGIN_AVAILABLE=${GOOGLE_OAUTH_AVAILABLE}"
+        "TR_GITHUB_OAUTH_LOGIN_AVAILABLE=${GITHUB_OAUTH_AVAILABLE}"
+        "TR_GOOGLE_OAUTH_REDIRECT_URL=https://trustedrouter.com/google_oauth_callback"
+        "TR_GITHUB_OAUTH_REDIRECT_URL=https://trustedrouter.com/github_oauth_callback"
+        "TR_PAYPAL_CHECKOUT_ENABLED=${PAYPAL_CHECKOUT_ENABLED}"
+        "TR_ADYEN_ENABLED=${ADYEN_ENABLED}"
+        "TR_ADYEN_ENVIRONMENT=test"
+        "TR_ADYEN_MERCHANT_ACCOUNT=TrustedRouterUS"
+        "TR_ADYEN_CHECKOUT_API_VERSION=72"
+        "TR_ADYEN_WEB_VERSION=6.41.0"
+        "TR_ADYEN_CARD_FEE_BASIS_POINTS=0"
+        "TR_ADYEN_CARD_FEE_FIXED_CENTS=0"
+        "TR_CHECKOUT_CARD_FEE_MINIMUM_CENTS=80"
+        "TR_VERIFF_ENABLED=${VERIFF_ENABLED}"
+        "TR_CUSTOM_MODELS_REQUIRE_VERIFICATION=${VERIFF_ENABLED}"
+        "TR_VERIFF_BASE_URL=https://stationapi.veriff.com"
+        "TR_NOTIFY_ENABLED=true"
+        "TR_NOTIFY_SMS_AVAILABLE=false"
+        "TR_TELNYX_FROM_NUMBER=${TELNYX_FROM_NUMBER}"
+        "TR_TELNYX_TEXML_ACCOUNT_ID=${TELNYX_TEXML_ACCOUNT_ID}"
+        "TR_TELNYX_TEXML_APPLICATION_ID=${TELNYX_TEXML_APPLICATION_ID}"
+        "TR_TWILIO_FROM_NUMBER=${TWILIO_FROM_NUMBER}"
+        "TR_AWS_REGION=us-east-1"
+        "TR_SES_FROM_EMAIL=noreply@trustedrouter.com"
+        "TR_SES_FROM_NAME=TrustedRouter"
+        "TR_PROVIDER_ANALYTICS_CLICKHOUSE_URL=${PROVIDER_CLICKHOUSE_URL}"
+        "TR_PROVIDER_ANALYTICS_CLICKHOUSE_USER=tr_provider_read"
+        "TR_PROVIDER_ANALYTICS_CLICKHOUSE_DATABASE=tr"
+        "TR_PROVIDER_ANALYTICS_CLICKHOUSE_TABLE=provider_benchmark_samples"
+      ) ;;
+    webhooks)
+      SURFACE_ENV+=(
+        "TR_PAYPAL_CHECKOUT_ENABLED=${PAYPAL_CHECKOUT_ENABLED}"
+        "TR_ADYEN_ENABLED=${ADYEN_ENABLED}"
+        "TR_ADYEN_ENVIRONMENT=test"
+        "TR_ADYEN_MERCHANT_ACCOUNT=TrustedRouterUS"
+        "TR_VERIFF_ENABLED=${VERIFF_ENABLED}"
+      ) ;;
+    internal)
+      # The immutable bootstrap cohort predates the quota compatibility marker;
+      # an initial split may adopt it only while both switches are off. Every
+      # subsequent internal candidate carries the complete main-side contract.
+      if [ "$ROLLOUT_MODE" = initial_split ]; then
+        SURFACE_ENV+=(
+          "TR_REGIONAL_QUOTA_LEASES_ENABLED=${REGIONAL_QUOTA_LEASES_ENABLED}"
+        )
+      else
+        SURFACE_ENV+=(
+          "TR_REGIONAL_QUOTA_LEASES_ENABLED=${REGIONAL_QUOTA_LEASES_ENABLED}"
+          "TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED=${REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED}"
+          "TR_REGIONAL_QUOTA_LEASE_PILOT_WORKSPACE_IDS=${REGIONAL_QUOTA_LEASE_PILOT_WORKSPACE_IDS}"
+          "TR_REGIONAL_QUOTA_LEASE_TTL_SECONDS=${REGIONAL_QUOTA_LEASE_TTL_SECONDS}"
+          "TR_REGIONAL_QUOTA_LEASE_MAX_MICRODOLLARS=${REGIONAL_QUOTA_LEASE_MAX_MICRODOLLARS}"
+          "TR_REGIONAL_QUOTA_LEASE_MAX_AVAILABLE_BASIS_POINTS=${REGIONAL_QUOTA_LEASE_MAX_AVAILABLE_BASIS_POINTS}"
+          "TR_REGIONAL_QUOTA_LEASE_SHARD_COUNT=${REGIONAL_QUOTA_LEASE_SHARD_COUNT}"
+          "TR_REGIONAL_QUOTA_BIGTABLE_TABLE=${REGIONAL_QUOTA_BIGTABLE_TABLE}"
+          "TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES=${REGIONAL_QUOTA_BIGTABLE_APP_PROFILES}"
+        )
       fi
-    done
-    if [ "$keep_region" = "0" ]; then
-      log "detaching stale NEG ${LB_NEG_NAME} (${attached_region}) from ${LB_BACKEND_SERVICE}"
-      gc compute backend-services remove-backend "$LB_BACKEND_SERVICE" \
-        --global \
-        --network-endpoint-group="$LB_NEG_NAME" \
-        --network-endpoint-group-region="$attached_region" \
-        --quiet >/dev/null || log "WARN: stale NEG detach failed for ${attached_region}"
-    fi
-  done
-  log "enabling origin-controlled Cloud CDN on ${LB_BACKEND_SERVICE}"
-  gc compute backend-services update "$LB_BACKEND_SERVICE" \
-    --global \
-    --enable-cdn \
-    --cache-mode=USE_ORIGIN_HEADERS \
-    --cache-key-include-host \
-    --cache-key-include-protocol \
-    --cache-key-include-query-string \
-    --cache-key-query-string-blacklist= \
-    --compression-mode=AUTOMATIC \
-    --serve-while-stale=600 \
-    --no-negative-caching \
-    --quiet >/dev/null
-else
-  log "WARN: ${LB_BACKEND_SERVICE} not found; skipping NEG wiring"
-fi
-
-# ---------------------------------------------------------------------------
-# HTTP -> HTTPS redirect on the public load balancer
-# ---------------------------------------------------------------------------
-# The HTTPS forwarding rule was created out-of-band when the LB was first
-# set up. We add a parallel :80 stack here that 301-redirects every HTTP
-# request to HTTPS, so visitors who type `http://trustedrouter.com` don't
-# get a connection-reset blank page. Three resources, all idempotent:
-# skip-if-exists guards make it safe to re-run on every deploy.
-LB_HTTP_URL_MAP="${LB_HTTP_URL_MAP:-trusted-router-control-http-redirect}"
-LB_HTTP_PROXY="${LB_HTTP_PROXY:-trusted-router-control-http-proxy}"
-LB_HTTP_FORWARDING_RULE="${LB_HTTP_FORWARDING_RULE:-trusted-router-control-http}"
-LB_HTTPS_FORWARDING_RULE="${LB_HTTPS_FORWARDING_RULE:-trusted-router-control-https}"
-
-ensure_http_redirect_lb() {
-  if ! gc compute url-maps describe "$LB_HTTP_URL_MAP" --global >/dev/null 2>&1; then
-    log "creating HTTP-redirect URL map ${LB_HTTP_URL_MAP}"
-    gc compute url-maps import "$LB_HTTP_URL_MAP" --global \
-      --source=/dev/stdin --quiet <<YAML
-name: ${LB_HTTP_URL_MAP}
-defaultUrlRedirect:
-  httpsRedirect: true
-  redirectResponseCode: MOVED_PERMANENTLY_DEFAULT
-  stripQuery: false
-YAML
-  fi
-
-  if ! gc compute target-http-proxies describe "$LB_HTTP_PROXY" --global >/dev/null 2>&1; then
-    log "creating HTTP target proxy ${LB_HTTP_PROXY}"
-    gc compute target-http-proxies create "$LB_HTTP_PROXY" \
-      --url-map="$LB_HTTP_URL_MAP" --global --quiet
-  fi
-
-  if ! gc compute forwarding-rules describe "$LB_HTTP_FORWARDING_RULE" --global >/dev/null 2>&1; then
-    local lb_ip
-    lb_ip="$(gc compute forwarding-rules describe "$LB_HTTPS_FORWARDING_RULE" \
-      --global --format='value(IPAddress)' 2>/dev/null || true)"
-    if [ -z "$lb_ip" ]; then
-      log "WARN: HTTPS forwarding rule ${LB_HTTPS_FORWARDING_RULE} not found; skipping HTTP rule"
-      return 0
-    fi
-    log "creating HTTP forwarding rule ${LB_HTTP_FORWARDING_RULE} on ${lb_ip}:80"
-    gc compute forwarding-rules create "$LB_HTTP_FORWARDING_RULE" \
-      --address="$lb_ip" \
-      --target-http-proxy="$LB_HTTP_PROXY" \
-      --ports=80 --global --quiet
-  fi
+      SURFACE_ENV+=(
+        "TR_BYOK_KMS_KEY_NAME=${BYOK_KMS_KEY_NAME}"
+        "TR_AWS_REGION=us-east-1"
+        "TR_SES_FROM_EMAIL=alerts@alerts.trustedrouter.com"
+        "TR_SES_FROM_NAME=TrustedRouter Alerts"
+        "TR_SES_ALERT_FROM_EMAIL=alerts@alerts.trustedrouter.com"
+        "TR_SES_ALERT_FROM_NAME=TrustedRouter Alerts"
+        "TR_SES_ALERT_CONFIGURATION_SET=trustedrouter-alerts"
+      ) ;;
+  esac
 }
 
-if [ "${TR_DEPLOY_RECONCILE_LB:-1}" = "1" ]; then
-  ensure_http_redirect_lb
+prior_traffic_json() {
+  local prior="$1"
+  python3 "$STATE_TOOL" traffic-state "$prior"
+}
+
+expected_maps() {
+  local env_file="$1" secret_file="$2"
+  printf '%s\n' "${SURFACE_ENV[@]}" | jq -Rn '
+    [inputs | capture("^(?<name>[^=]+)=(?<value>.*)$")] | from_entries
+  ' >"$env_file"
+  printf '%s\n' "${SURFACE_SECRETS[@]}" | jq -Rn '
+    [inputs | capture("^(?<name>[^=]+)=(?<resource>.*):(?<version>[1-9][0-9]*)$")
+      | {key: .name, value: {resource: .resource, version: .version}}] | from_entries
+  ' >"$secret_file"
+  chmod 600 "$env_file" "$secret_file"
+}
+
+verify_service_postcondition() {
+  local surface="$1" service="$2" region="$3" candidate="$4" prior_exists="$5" prior="$6" adopted="$7"
+  local service_json expected_env expected_secrets service_iam actual_traffic expected_traffic
+  service_json="${WORK_DIR}/candidate-${surface}-${region}.json"
+  expected_env="${WORK_DIR}/expected-env-${surface}-${region}.json"
+  expected_secrets="${WORK_DIR}/expected-secret-${surface}-${region}.json"
+  service_iam="${WORK_DIR}/candidate-iam-${surface}-${region}.json"
+  gc run services describe "$service" --region="$region" --format=json >"$service_json"
+  gc run services get-iam-policy "$service" --region="$region" --format=json >"$service_iam"
+  if ! jq -e '
+      [.bindings[]? | select(any(.members[]?; . == "allUsers"))
+        | {role, condition: (.condition // null),
+           allUsersCount: ([.members[]? | select(. == "allUsers")] | length)}]
+      == [{role:"roles/run.invoker",condition:null,allUsersCount:1}]
+    ' "$service_iam" >/dev/null; then
+    echo "ERROR: ${service}/${region} lacks the exact unauthenticated LB invocation grant" >&2
+    return 1
+  fi
+  expected_maps "$expected_env" "$expected_secrets"
+  python3 - "$service_json" "$expected_env" "$expected_secrets" \
+    "$surface" "$candidate" "$(surface_account "$surface")" \
+    "$TR_CLOUD_RUN_INGRESS" "$CONCURRENCY" "$MIN_INSTANCES" "$MAX_INSTANCES" \
+    "$TIMEOUT_SECONDS" "$DEFAULT_URL_DISABLED" "$prior_exists" "$adopted" "$IMAGE" "$MEMORY" \
+    1 8080 "$CLOUD_RUN_NETWORK" "$CLOUD_RUN_SUBNET" private-ranges-only \
+    /ready 0 10 10 18 "$PROJECT_ID" <<'PY' || return 1
+from __future__ import annotations
+import json
+import sys
+from pathlib import Path
+
+(
+    service_path, env_path, secret_path, surface, candidate, expected_account,
+    expected_ingress, concurrency, minimum, maximum, timeout, default_disabled,
+    prior_exists, adopted, expected_image, memory, cpu, port, network, subnet, vpc_egress,
+    probe_path, probe_initial_delay, probe_timeout, probe_period,
+    probe_failures, project,
+) = sys.argv[1:]
+service = json.loads(Path(service_path).read_text())
+expected_env = json.loads(Path(env_path).read_text())
+expected_secrets = json.loads(Path(secret_path).read_text())
+metadata = service.get("metadata") or {}
+annotations = metadata.get("annotations") or {}
+spec = service.get("spec") or {}
+template = spec.get("template") or {}
+template_metadata = template.get("metadata") or {}
+template_annotations = template_metadata.get("annotations") or {}
+template_spec = template.get("spec") or {}
+status = service.get("status") or {}
+if status.get("latestCreatedRevisionName") != candidate:
+    raise SystemExit(f"{surface}: latest created revision is not {candidate}")
+if status.get("latestReadyRevisionName") != candidate:
+    raise SystemExit(f"{surface}: candidate is not latest Ready")
+if not any(item.get("type") == "Ready" and item.get("status") == "True" for item in status.get("conditions", [])):
+    raise SystemExit(f"{surface}: Cloud Run Ready condition failed")
+if metadata.get("generation") is None or status.get("observedGeneration") is None:
+    raise SystemExit(f"{surface}: Cloud Run generation metadata is absent")
+if str(status.get("observedGeneration")) != str(metadata.get("generation")):
+    raise SystemExit(f"{surface}: Cloud Run has not observed the desired generation")
+if annotations.get("run.googleapis.com/ingress") != expected_ingress:
+    raise SystemExit(f"{surface}: ingress postcondition failed")
+ingress_status = annotations.get("run.googleapis.com/ingress-status")
+if ingress_status != expected_ingress:
+    raise SystemExit(f"{surface}: effective ingress differs from desired ingress")
+default_annotation = annotations.get("run.googleapis.com/default-url-disabled")
+if default_disabled == "true" and str(default_annotation).lower() != "true":
+    raise SystemExit(f"{surface}: default URL disablement annotation drifted")
+if default_disabled == "false" and str(default_annotation or "").lower() not in {"", "false"}:
+    raise SystemExit(f"{surface}: internal default URL annotation drifted")
+if template_spec.get("serviceAccountName") != expected_account:
+    raise SystemExit(f"{surface}: runtime service account postcondition failed")
+if int(template_spec.get("containerConcurrency", -1)) != int(concurrency):
+    raise SystemExit(f"{surface}: concurrency postcondition failed")
+actual_timeout = str(template_spec.get("timeoutSeconds", "")).removesuffix("s")
+if actual_timeout != timeout:
+    raise SystemExit(f"{surface}: timeout postcondition failed")
+actual_min = template_annotations.get("autoscaling.knative.dev/minScale")
+actual_max = template_annotations.get("autoscaling.knative.dev/maxScale")
+if str(actual_min) != minimum or str(actual_max) != maximum:
+    raise SystemExit(f"{surface}: revision scaling postcondition failed")
+service_max = (spec.get("scaling") or {}).get("maxInstanceCount")
+if service_max is None:
+    service_max = annotations.get("run.googleapis.com/maxScale")
+if str(service_max) != maximum:
+    raise SystemExit(f"{surface}: service-level max postcondition failed")
+containers = template_spec.get("containers") or []
+if len(containers) != 1:
+    raise SystemExit(f"{surface}: service must contain exactly one application container")
+if template_spec.get("volumes") not in (None, []):
+    raise SystemExit(f"{surface}: unexpected service volumes are forbidden")
+if template_spec.get("initContainers") not in (None, []):
+    raise SystemExit(f"{surface}: init containers are forbidden")
+container = containers[0]
+if container.get("volumeMounts") not in (None, []):
+    raise SystemExit(f"{surface}: unexpected volume mounts are forbidden")
+if container.get("command") not in (None, []) or container.get("args") not in (None, []):
+    raise SystemExit(f"{surface}: container command/args override is forbidden")
+if container.get("image") != expected_image:
+    raise SystemExit(f"{surface}: immutable image digest postcondition failed")
+ports = container.get("ports") or []
+if len(ports) != 1 or int(ports[0].get("containerPort", -1)) != int(port):
+    raise SystemExit(f"{surface}: container port postcondition failed")
+limits = (container.get("resources") or {}).get("limits") or {}
+if str(limits.get("memory")) != memory:
+    raise SystemExit(f"{surface}: memory postcondition failed")
+actual_cpu = str(limits.get("cpu") or "")
+if actual_cpu not in {cpu, f"{int(cpu) * 1000}m"}:
+    raise SystemExit(f"{surface}: CPU postcondition failed")
+network_interfaces_raw = template_annotations.get("run.googleapis.com/network-interfaces")
+try:
+    network_interfaces = json.loads(network_interfaces_raw)
+except (TypeError, ValueError):
+    raise SystemExit(f"{surface}: VPC network annotation is invalid") from None
+if not isinstance(network_interfaces, list) or len(network_interfaces) != 1:
+    raise SystemExit(f"{surface}: VPC network interface count differs")
+
+def exact_resource(value: object, kind: str, expected: str) -> bool:
+    text = str(value or "").rstrip("/")
+    if text == expected:
+        return True
+    if f"/projects/{project}/" not in f"/{text}":
+        return False
+    suffix = f"/{kind}/{expected}"
+    return text.endswith(suffix)
+
+interface = network_interfaces[0]
+if not exact_resource(interface.get("network"), "networks", network):
+    raise SystemExit(f"{surface}: VPC network postcondition failed")
+if not exact_resource(interface.get("subnetwork"), "subnetworks", subnet):
+    raise SystemExit(f"{surface}: VPC subnet postcondition failed")
+if template_annotations.get("run.googleapis.com/vpc-access-egress") != vpc_egress:
+    raise SystemExit(f"{surface}: VPC egress postcondition failed")
+probe = container.get("startupProbe") or {}
+http_get = probe.get("httpGet") or {}
+if http_get.get("path") != probe_path:
+    raise SystemExit(f"{surface}: /ready startup probe is missing")
+if http_get.get("port") is not None and int(http_get["port"]) != int(port):
+    raise SystemExit(f"{surface}: startup probe port differs")
+expected_probe = {
+    "initialDelaySeconds": int(probe_initial_delay),
+    "timeoutSeconds": int(probe_timeout),
+    "periodSeconds": int(probe_period),
+    "failureThreshold": int(probe_failures),
+}
+for name, expected in expected_probe.items():
+    if int(probe.get(name, -1)) != expected:
+        raise SystemExit(f"{surface}: startup probe {name} differs")
+actual_values = {}
+actual_secrets = {}
+for item in container.get("env") or []:
+    name = item.get("name")
+    if "valueFrom" in item:
+        reference = ((item.get("valueFrom") or {}).get("secretKeyRef") or {})
+        resource = str(reference.get("name") or "").split("/")[-1]
+        version = str(reference.get("key") or reference.get("version") or "")
+        if not version.isdigit() or version.startswith("0"):
+            raise SystemExit(f"{surface}: secret reference is not pinned to a numeric version")
+        actual_secrets[name] = {"resource": resource, "version": version}
+    else:
+        actual_values[name] = str(item.get("value", ""))
+if actual_values != expected_env or actual_secrets != expected_secrets:
+    raise SystemExit(f"{surface}: exact environment/secret allowlist postcondition failed")
+url = status.get("url") or ""
+if default_disabled == "true" and url:
+    raise SystemExit(f"{surface}: external-origin rejection failed; default URL still exists")
+if default_disabled == "false" and not url:
+    raise SystemExit(f"{surface}: private synthetic path requires the internal default URL")
+candidate_percent = sum(
+    int(item.get("percent") or 0)
+    for item in status.get("traffic") or []
+    if item.get("revisionName") == candidate
+)
+if prior_exists == "true" and adopted != "true" and candidate_percent != 0:
+    raise SystemExit(f"{surface}: staged candidate unexpectedly received traffic")
+if prior_exists == "false" or adopted == "true":
+    def exact_sole_candidate(items):
+        return (
+            len(items) == 1
+            and items[0].get("revisionName") == candidate
+            and int(items[0].get("percent") or 0) == 100
+            and not items[0].get("tag")
+            and not items[0].get("latestRevision", False)
+        )
+    if not exact_sole_candidate(spec.get("traffic") or []):
+        raise SystemExit(f"{surface}: new companion desired traffic is not the sole candidate")
+    if not exact_sole_candidate(status.get("traffic") or []):
+        raise SystemExit(f"{surface}: new companion observed traffic is not the sole candidate")
+PY
+  actual_traffic="$(python3 "$STATE_TOOL" traffic-state "$service_json")" || {
+    echo "ERROR: ${surface}/${region} staged traffic is malformed or unconverged" >&2
+    return 1
+  }
+  if [ "$prior_exists" = true ]; then
+    expected_traffic="$(prior_traffic_json "$prior")" || return 1
+    if ! python3 - "$expected_traffic" "$actual_traffic" <<'PY'
+import json
+import sys
+
+expected = json.loads(sys.argv[1])
+actual = json.loads(sys.argv[2])
+if actual != expected:
+    raise SystemExit("staged deploy changed prior traffic allocation or tags")
+PY
+    then
+      echo "ERROR: ${surface}/${region} changed its prior traffic during staging" >&2
+      return 1
+    fi
+  fi
+  python3 "$STATE_TOOL" hash-service "$service_json"
+}
+
+stage_one() {
+  local surface="$1" region="$2" service account candidate prior prior_exists traffic
+  local set_env set_secrets postcondition_hash default_url_arg traffic_arg adopted=false
+  local journal_record="" journal_state="" recorded_hash="" revision_rc=0 revision_description=""
+  service="$(surface_service "$surface")"
+  account="$(surface_account "$surface")"
+  prior="$(prior_json_path "$surface" "$region")"
+  if [ "$ROLLOUT_MODE" = initial_split ]; then
+    journal_record="$(stage_journal_read service "$surface" "$region")" || return 1
+    prior_exists="$(jq -r .prior_exists <<<"$journal_record")" || return 1
+    adopted="$(jq -r .adopted_bootstrap <<<"$journal_record")" || return 1
+    candidate="$(jq -er .candidate_revision <<<"$journal_record")" || return 1
+    journal_state="$(jq -er .state <<<"$journal_record")" || return 1
+    if [ "$prior_exists" = true ]; then
+      traffic="$(prior_traffic_json "$prior")"
+    else
+      traffic='[]'
+    fi
+  else
+    if [ -f "$prior" ]; then
+      prior_exists=true
+      traffic="$(prior_traffic_json "$prior")"
+    else
+      prior_exists=false
+      traffic='[]'
+    fi
+    candidate="${service}-${REVISION_SUFFIX}"
+  fi
+  surface_env_vars "$surface" "$region"
+  surface_secret_bindings "$surface"
+  set_env="$(IFS='|'; echo "^|^${SURFACE_ENV[*]}")"
+  set_secrets="$(IFS=,; echo "${SURFACE_SECRETS[*]}")"
+  if [ "$DEFAULT_URL_DISABLED" = true ]; then default_url_arg=--no-default-url; else default_url_arg=--default-url; fi
+  traffic_arg=""
+  if [ "$prior_exists" = true ]; then
+    traffic_arg=--no-traffic
+  fi
+  if [ "$ROLLOUT_MODE" = initial_split ] && [ "$journal_state" = pending ]; then
+    stage_journal_transition service "$surface" "$region" pending deploy_intent
+    journal_state=deploy_intent
+  fi
+  if [ "$ROLLOUT_MODE" = initial_split ] && [ "$journal_state" = staged ]; then
+    postcondition_hash="$(verify_service_postcondition \
+      "$surface" "$service" "$region" "$candidate" "$prior_exists" "$prior" "$adopted")" || return 1
+    recorded_hash="$(jq -er .postcondition_sha256 <<<"$journal_record")" || return 1
+    [ "$postcondition_hash" = "$recorded_hash" ] || {
+      echo "ERROR: staged service drifted from the initial-stage journal: ${service}/${region}" >&2
+      return 1
+    }
+    log "resuming verified staged ${surface} service ${service}/${candidate} in ${region}"
+  else
+    if [ "$adopted" = true ]; then
+      log "adopting verified bootstrap ${surface} service ${service}/${candidate} in ${region}"
+    else
+      revision_description="$(gc run revisions describe "$candidate" \
+        --region="$region" --format=json 2>&1)" || revision_rc=$?
+      if [ "$revision_rc" = 0 ]; then
+        [ "$ROLLOUT_MODE" = initial_split ] && [ "$journal_state" = deploy_intent ] || {
+          echo "ERROR: refusing to adopt unjournaled candidate ${candidate}/${region}" >&2
+          return 1
+        }
+        log "inspecting exact recorded candidate ${service}/${candidate} before resume"
+      else
+        case "$revision_description" in
+          *NOT_FOUND*|*"not found"*) ;;
+          *) echo "ERROR: cannot determine candidate state: ${candidate}/${region}" >&2; return 1 ;;
+        esac
+        if [ "$prior_exists" = true ]; then
+          log "staging ${surface} as ${service}/${candidate} in ${region} with zero requested traffic"
+        else
+          log "creating off-map ${surface} service ${service}/${candidate} in ${region} at its sole revision"
+        fi
+        if ! gc run deploy "$service" \
+          --region="$region" \
+          --image="$IMAGE" \
+          --revision-suffix="$REVISION_SUFFIX" \
+          ${traffic_arg:+"$traffic_arg"} \
+          --allow-unauthenticated \
+          --ingress="$TR_CLOUD_RUN_INGRESS" \
+          "$default_url_arg" \
+          --service-account="$account" \
+          --port=8080 \
+          --cpu=1 \
+          --memory="$MEMORY" \
+          --concurrency="$CONCURRENCY" \
+          --min-instances="$MIN_INSTANCES" \
+          --max-instances="$MAX_INSTANCES" \
+          --max="$MAX_INSTANCES" \
+          --timeout="${TIMEOUT_SECONDS}s" \
+          --network="$CLOUD_RUN_NETWORK" \
+          --subnet="$CLOUD_RUN_SUBNET" \
+          --vpc-egress=private-ranges-only \
+          --startup-probe="httpGet.path=/ready,initialDelaySeconds=0,timeoutSeconds=10,periodSeconds=10,failureThreshold=18" \
+          --deploy-health-check \
+          --set-env-vars="$set_env" \
+          --set-secrets="$set_secrets" \
+            --quiet >/dev/null; then
+          log "deploy command exited non-zero; inspecting immutable postconditions"
+        fi
+      fi
+    fi
+    postcondition_hash="$(verify_service_postcondition \
+      "$surface" "$service" "$region" "$candidate" "$prior_exists" "$prior" "$adopted")" || return 1
+    if [ "$ROLLOUT_MODE" = initial_split ]; then
+      stage_journal_transition service "$surface" "$region" deploy_intent staged "$postcondition_hash"
+      journal_state=staged
+    fi
+  fi
+  jq -cn \
+    --arg surface "$surface" \
+    --arg name "$service" \
+    --arg region "$region" \
+    --argjson prior_exists "$prior_exists" \
+    --argjson prior_traffic "$traffic" \
+    --argjson adopted_bootstrap "$adopted" \
+    --arg candidate_revision "$candidate" \
+    --arg runtime_service_account "$account" \
+    --arg ingress "$TR_CLOUD_RUN_INGRESS" \
+    --argjson default_url_disabled "$DEFAULT_URL_DISABLED" \
+    --argjson concurrency "$CONCURRENCY" \
+    --argjson min_instances "$MIN_INSTANCES" \
+    --argjson service_max_instances "$MAX_INSTANCES" \
+    --argjson revision_max_instances "$MAX_INSTANCES" \
+    --argjson timeout_seconds "$TIMEOUT_SECONDS" \
+    --arg memory "$MEMORY" \
+    --argjson cpu 1 \
+    --argjson container_port 8080 \
+    --arg vpc_network "$CLOUD_RUN_NETWORK" \
+    --arg vpc_subnet "$CLOUD_RUN_SUBNET" \
+    --arg vpc_egress private-ranges-only \
+    --arg startup_probe_path /ready \
+    --argjson startup_probe_initial_delay_seconds 0 \
+    --argjson startup_probe_timeout_seconds 10 \
+    --argjson startup_probe_period_seconds 10 \
+    --argjson startup_probe_failure_threshold 18 \
+    --argjson max_request_body_bytes "$MAX_REQUEST_BODY_BYTES" \
+    --argjson max_in_flight_request_body_bytes "$MAX_IN_FLIGHT_REQUEST_BODY_BYTES" \
+    --argjson max_concurrent_request_bodies "$MAX_CONCURRENT_REQUEST_BODIES" \
+    --argjson request_body_read_timeout_seconds "$REQUEST_BODY_READ_TIMEOUT_SECONDS" \
+    --arg postcondition_sha256 "$postcondition_hash" \
+    '{surface:$surface,name:$name,region:$region,prior_exists:$prior_exists,
+      prior_traffic:$prior_traffic,adopted_bootstrap:$adopted_bootstrap,
+      candidate_revision:$candidate_revision,
+      runtime_service_account:$runtime_service_account,ingress:$ingress,
+      default_url_disabled:$default_url_disabled,concurrency:$concurrency,
+      min_instances:$min_instances,service_max_instances:$service_max_instances,
+      revision_max_instances:$revision_max_instances,timeout_seconds:$timeout_seconds,
+      memory:$memory,cpu:$cpu,container_port:$container_port,
+      vpc_network:$vpc_network,vpc_subnet:$vpc_subnet,vpc_egress:$vpc_egress,
+      startup_probe_path:$startup_probe_path,
+      startup_probe_initial_delay_seconds:$startup_probe_initial_delay_seconds,
+      startup_probe_timeout_seconds:$startup_probe_timeout_seconds,
+      startup_probe_period_seconds:$startup_probe_period_seconds,
+      startup_probe_failure_threshold:$startup_probe_failure_threshold,
+      max_request_body_bytes:$max_request_body_bytes,
+      max_in_flight_request_body_bytes:$max_in_flight_request_body_bytes,
+      max_concurrent_request_bodies:$max_concurrent_request_bodies,
+      request_body_read_timeout_seconds:$request_body_read_timeout_seconds,
+      postcondition_sha256:$postcondition_sha256}' >>"$ENTRIES_FILE"
+}
+
+for surface in "${SURFACES[@]}"; do
+  while IFS= read -r region; do
+    stage_one "$surface" "$region"
+  done < <(surface_region_lines "$surface")
+done
+
+PRIOR_HASH="$(python3 "$STATE_TOOL" hash-url-map "$PRIOR_URL_MAP")"
+CANDIDATE_HASH="$(python3 "$STATE_TOOL" hash-url-map "$CANDIDATE_URL_MAP")"
+if [ "$ROLLOUT_MODE" = existing_split ] && [ "$PRIOR_HASH" != "$CANDIDATE_HASH" ]; then
+  echo "ERROR: existing split URL map would change during a regional traffic ramp" >&2
+  exit 1
 fi
+
+if [ "$ROLLOUT_MODE" = initial_split ]; then
+  non_staged="$(python3 - "$STAGE_JOURNAL" <<'PY'
+import json
+import sys
+from pathlib import Path
+value = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(sum(item["state"] != "staged" for item in value["service_states"]))
+PY
+)" || exit 1
+  [ "$non_staged" = 0 ] || {
+    echo "ERROR: initial-stage journal has unsettled services before manifest publication" >&2
+    exit 1
+  }
+  stage_phase="$(jq -er .phase "$STAGE_JOURNAL")" || exit 1
+  if [ "$stage_phase" = services ]; then
+    stage_journal_set_phase services manifest_intent
+    stage_phase=manifest_intent
+  fi
+else
+  stage_phase=""
+fi
+
+if [ ! -e "$MANIFEST" ]; then
+  python3 "$STATE_TOOL" build-manifest \
+    --manifest "$MANIFEST" \
+    --entries "$ENTRIES_FILE" \
+    --rollout-mode "$ROLLOUT_MODE" \
+    --project-id "$PROJECT_ID" \
+    --image "$IMAGE" \
+    --release "$RELEASE" \
+    --created-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --regions "$REGION_CSV" \
+    --primary-region "$TR_PRIMARY_REGION" \
+    --gateway-regions "$GATEWAY_REGION_CSV" \
+    --internal-regions "$INTERNAL_ALLOWED_REGION_CSV" \
+    --bootstrap-artifact-sha256 "$BOOTSTRAP_ARTIFACT_SHA256" \
+    --legacy-hardening-artifact-sha256 "$LEGACY_HARDENING_ARTIFACT_SHA256" \
+    --frontend-attestation-sha256 "$FRONTEND_ATTESTATION_SHA256" \
+    --legacy-fallback "$LEGACY_FALLBACK_FILE" \
+    --domains "$DOMAINS" \
+    --preserved-hosts "$PRESERVED_HOSTS" \
+    --url-map-name "$URL_MAP_NAME" \
+    --https-proxy "$HTTPS_PROXY" \
+    --prior-snapshot "$PRIOR_URL_MAP_NAME" \
+    --candidate-snapshot "$CANDIDATE_URL_MAP_NAME" \
+    --prior-sha256 "$PRIOR_HASH" \
+    --candidate-sha256 "$CANDIDATE_HASH"
+elif [ "$ROLLOUT_MODE" != initial_split ] || \
+    { [ "$stage_phase" != manifest_intent ] && [ "$stage_phase" != complete ]; }; then
+  echo "ERROR: rollout manifest exists without a journaled publication intent" >&2
+  exit 1
+fi
+
+python3 "$STATE_TOOL" validate-manifest "$MANIFEST"
+if [ "$ROLLOUT_MODE" = initial_split ]; then
+  manifest_sha="$(python3 - "$MANIFEST" <<'PY'
+import hashlib
+import sys
+from pathlib import Path
+print(hashlib.sha256(Path(sys.argv[1]).read_bytes()).hexdigest())
+PY
+)" || exit 1
+  recorded_manifest_sha="$(jq -r '.manifest_sha256 // ""' "$STAGE_JOURNAL")"
+  if [ "$stage_phase" = complete ]; then
+    [ "$recorded_manifest_sha" = "$manifest_sha" ] || {
+      echo "ERROR: completed initial-stage manifest hash drifted" >&2
+      exit 1
+    }
+  else
+    stage_journal_set_phase manifest_intent complete "" "$manifest_sha"
+  fi
+fi
+log "six-surface staging is Ready and postverified; promotion manifest: ${MANIFEST}"
+log "no Cloud Run traffic or HTTPS URL-map route was changed by this command"

--- a/scripts/deploy/rollout_bootstrap_internal.sh
+++ b/scripts/deploy/rollout_bootstrap_internal.sh
@@ -1,0 +1,2322 @@
+#!/usr/bin/env bash
+# Forward-only prerequisite for the first six-surface split.
+#
+# Bootstrap mode creates and promotes only the canonical private internal
+# service. Verification mode is read-only and is called by rollout.sh before
+# an initial split may reconcile a backend or deploy a revision.
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  bash scripts/deploy/rollout_bootstrap_internal.sh --artifact PATH
+  bash scripts/deploy/rollout_bootstrap_internal.sh --verify-artifact PATH --expected-image IMAGE@sha256:DIGEST
+EOF
+  exit 2
+}
+
+MODE=""
+ARTIFACT=""
+EXPECTED_IMAGE=""
+case "$#:${1:-}" in
+  2:--artifact)
+    MODE=bootstrap
+    ARTIFACT="$2"
+    ;;
+  4:--verify-artifact)
+    [ "$3" = --expected-image ] || usage
+    MODE=verify
+    ARTIFACT="$2"
+    EXPECTED_IMAGE="$4"
+    ;;
+  *) usage ;;
+esac
+[ -n "$ARTIFACT" ] || usage
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+STATE_TOOL="${SCRIPT_DIR}/rollout_state.py"
+
+if [ "$MODE" = bootstrap ]; then
+  BOOTSTRAP_OPERATION_ID="${TR_ROLLOUT_OPERATION_ID:-}"
+  if ! [[ "$BOOTSTRAP_OPERATION_ID" =~ ^[A-Za-z0-9._:-]{8,160}$ ]]; then
+    echo "ERROR: internal bootstrap requires TR_ROLLOUT_OPERATION_ID" >&2
+    exit 2
+  fi
+  BOOTSTRAP_OPERATION_LOCK="${TR_ROLLOUT_LOCAL_LOCK_PATH:-${TMPDIR:-/tmp}/trusted-router-${PROJECT_ID}.stage.lock}"
+  if [ "${TR_ROLLOUT_LOCAL_LOCK_HELD:-}" != "$BOOTSTRAP_OPERATION_LOCK" ]; then
+    export TR_ROLLOUT_LOCAL_LOCK_HELD="$BOOTSTRAP_OPERATION_LOCK"
+    exec python3 "${SCRIPT_DIR}/rollout_local_lock.py" \
+      "$BOOTSTRAP_OPERATION_LOCK" -- /bin/bash "$0" "$@"
+  fi
+fi
+
+for command_name in gcloud jq python3; do
+  command -v "$command_name" >/dev/null || {
+    echo "ERROR: required command is missing: ${command_name}" >&2
+    exit 1
+  }
+done
+
+[ "$INTERNAL_SERVICE" = trusted-router-billing ] || {
+  echo "ERROR: internal bootstrap requires trusted-router-billing" >&2
+  exit 1
+}
+BOOTSTRAP_LEGACY_CONSOLE_SERVICE="${LEGACY_CONSOLE_SERVICE:-${TR_LEGACY_CONSOLE_SERVICE:-$SERVICE}}"
+[ "$BOOTSTRAP_LEGACY_CONSOLE_SERVICE" = trusted-router ] || {
+  echo "ERROR: internal bootstrap requires the canonical legacy monolith" >&2
+  exit 1
+}
+[ "$INTERNAL_RUN_SERVICE_ACCOUNT" = "tr-internal@${PROJECT_ID}.iam.gserviceaccount.com" ] || {
+  echo "ERROR: internal bootstrap requires the canonical dedicated identity" >&2
+  exit 1
+}
+SYNTHETIC_RUN_SERVICE_ACCOUNT="${TR_SYNTHETIC_RUN_SERVICE_ACCOUNT:-tr-synthetic@${PROJECT_ID}.iam.gserviceaccount.com}"
+[ "$SYNTHETIC_RUN_SERVICE_ACCOUNT" = "tr-synthetic@${PROJECT_ID}.iam.gserviceaccount.com" ] || {
+  echo "ERROR: synthetic cutover requires the canonical dedicated identity" >&2
+  exit 1
+}
+CLOUD_RUN_NETWORK="${TR_CLOUD_RUN_NETWORK:-default}"
+CLOUD_RUN_SUBNET="${TR_CLOUD_RUN_SUBNET:-default}"
+[ "$CLOUD_RUN_NETWORK" = default ] && [ "$CLOUD_RUN_SUBNET" = default ] || {
+  echo "ERROR: internal bootstrap pins the reviewed default VPC network/subnet" >&2
+  exit 1
+}
+SYNTHETIC_NETWORK="${TR_SYNTHETIC_NETWORK:-default}"
+SYNTHETIC_SUBNET="${TR_SYNTHETIC_SUBNET:-default}"
+for resource_name in "$SYNTHETIC_NETWORK" "$SYNTHETIC_SUBNET"; do
+  [[ "$resource_name" =~ ^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$ ]] || {
+    echo "ERROR: synthetic VPC network/subnet name is invalid" >&2
+    exit 1
+  }
+done
+
+validate_region() {
+  local label="$1" value="$2"
+  [[ "$value" =~ ^[a-z]+-[a-z0-9]+[0-9]$ ]] || {
+    echo "ERROR: ${label} contains invalid region ${value:-<empty>}" >&2
+    return 1
+  }
+}
+
+BOOTSTRAP_REGIONS=()
+add_bootstrap_region() {
+  local region="$1" existing
+  validate_region "bootstrap inventory" "$region"
+  for existing in "${BOOTSTRAP_REGIONS[@]-}"; do
+    [ "$existing" = "$region" ] && return 0
+  done
+  BOOTSTRAP_REGIONS+=("$region")
+}
+
+IFS=',' read -r -a CONTROL_REGIONS <<<"$TR_CONTROL_PLANE_REGIONS"
+[ "${#CONTROL_REGIONS[@]}" -gt 0 ] || {
+  echo "ERROR: control-plane region inventory is empty" >&2
+  exit 1
+}
+for region in "${CONTROL_REGIONS[@]}"; do add_bootstrap_region "$region"; done
+IFS=',' read -r -a MONITOR_REGIONS <<<"$TR_SYNTHETIC_MONITOR_REGIONS"
+[ "${#MONITOR_REGIONS[@]}" -gt 0 ] || {
+  echo "ERROR: synthetic monitor region inventory is empty" >&2
+  exit 1
+}
+for region in "${MONITOR_REGIONS[@]}"; do add_bootstrap_region "$region"; done
+for region in \
+  "$TR_SYNTHETIC_THROUGHPUT_REGION" \
+  "$TR_SYNTHETIC_IMAGE_REGION" \
+  "$TR_SYNTHETIC_VIDEO_REGION"; do
+  add_bootstrap_region "$region"
+done
+BOOTSTRAP_REGION_CSV="$(IFS=,; echo "${BOOTSTRAP_REGIONS[*]}")"
+MONITOR_REGION_CSV="$(IFS=,; echo "${MONITOR_REGIONS[*]}")"
+
+if [ "$MODE" = verify ]; then
+  [ -d "$(dirname "$ARTIFACT")" ] || {
+    echo "ERROR: bootstrap artifact directory is absent" >&2
+    exit 1
+  }
+  ARTIFACT_DIR="$(cd "$(dirname "$ARTIFACT")" && pwd)"
+else
+  ARTIFACT_DIR="$(mkdir -p "$(dirname "$ARTIFACT")" && cd "$(dirname "$ARTIFACT")" && pwd)"
+fi
+ARTIFACT="${ARTIFACT_DIR}/$(basename "$ARTIFACT")"
+JOURNAL="${ARTIFACT}.state"
+
+read_journal_revision_suffix() {
+  python3 - "$JOURNAL" <<'PY'
+import json
+import os
+import re
+import stat
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+if path.is_symlink() or not path.is_file():
+    raise SystemExit("bootstrap state must be a regular non-symlink file")
+if stat.S_IMODE(os.stat(path).st_mode) != 0o600:
+    raise SystemExit("bootstrap state must have mode 0600")
+value = json.loads(path.read_text(encoding="utf-8"))
+suffix = value.get("revision_suffix") if isinstance(value, dict) else None
+if not isinstance(suffix, str) or not re.fullmatch(r"[a-z][a-z0-9-]{0,34}[a-z0-9]", suffix):
+    raise SystemExit("bootstrap state revision suffix is invalid")
+print(suffix)
+PY
+}
+
+synthetic_inventory_lines() {
+  local region
+  for region in "${MONITOR_REGIONS[@]}"; do
+    printf '%s\t%s\t%s\n' \
+      "$region" \
+      "trusted-router-synthetic-${region}" \
+      "trusted-router-synthetic-${region}-every-three-minutes"
+  done
+  printf '%s\t%s\t%s\n' \
+    "$TR_SYNTHETIC_THROUGHPUT_REGION" \
+    "trusted-router-throughput-${TR_SYNTHETIC_THROUGHPUT_REGION}" \
+    "trusted-router-throughput-${TR_SYNTHETIC_THROUGHPUT_REGION}-every-five-minutes"
+  printf '%s\t%s\t%s\n' \
+    "$TR_SYNTHETIC_IMAGE_REGION" \
+    "trusted-router-image-generation-${TR_SYNTHETIC_IMAGE_REGION}" \
+    "trusted-router-image-generation-${TR_SYNTHETIC_IMAGE_REGION}-every-six-hours"
+  printf '%s\t%s\t%s\n' \
+    "$TR_SYNTHETIC_VIDEO_REGION" \
+    "trusted-router-video-generation-${TR_SYNTHETIC_VIDEO_REGION}" \
+    "trusted-router-video-generation-${TR_SYNTHETIC_VIDEO_REGION}-daily"
+}
+
+validate_artifact_and_emit_services() {
+  local expected_image="$1"
+  python3 - "$ARTIFACT" "$PROJECT_ID" "$expected_image" \
+    "$BOOTSTRAP_REGION_CSV" "$MONITOR_REGION_CSV" \
+    "$TR_SYNTHETIC_THROUGHPUT_REGION" "$TR_SYNTHETIC_IMAGE_REGION" \
+    "$TR_SYNTHETIC_VIDEO_REGION" <<'PY'
+import ipaddress
+import json
+import os
+import re
+import stat
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit
+
+(
+    raw_path,
+    project,
+    image,
+    raw_regions,
+    raw_monitor_regions,
+    throughput_region,
+    image_region,
+    video_region,
+) = sys.argv[1:]
+path = Path(raw_path)
+if path.is_symlink() or not path.is_file():
+    raise SystemExit("bootstrap artifact must be a regular non-symlink file")
+if stat.S_IMODE(os.stat(path).st_mode) != 0o600:
+    raise SystemExit("bootstrap artifact must have mode 0600")
+value = json.loads(path.read_text(encoding="utf-8"))
+fields = {
+    "schema_version", "kind", "project_id", "image", "release",
+    "created_at", "regions", "internal_service", "runtime_service_account",
+    "synthetic_service_account", "ingress", "default_url_enabled",
+    "synthetic_inventory", "data_mode", "services",
+}
+if not isinstance(value, dict) or set(value) != fields:
+    raise SystemExit("bootstrap artifact fields differ from schema v1")
+if value["schema_version"] != 1 or value["kind"] != "trusted-router-internal-bootstrap":
+    raise SystemExit("bootstrap artifact schema/kind is unsupported")
+if value["project_id"] != project or value["image"] != image:
+    raise SystemExit("bootstrap artifact is not bound to this project/image")
+if not re.fullmatch(r"[^\s,|@]+@sha256:[0-9a-f]{64}", value["image"]):
+    raise SystemExit("bootstrap image is not immutable")
+if value["internal_service"] != "trusted-router-billing":
+    raise SystemExit("bootstrap artifact names the wrong internal service")
+if value["runtime_service_account"] != f"tr-internal@{project}.iam.gserviceaccount.com":
+    raise SystemExit("bootstrap artifact names the wrong runtime identity")
+if value["synthetic_service_account"] != f"tr-synthetic@{project}.iam.gserviceaccount.com":
+    raise SystemExit("bootstrap artifact names the wrong synthetic identity")
+if value["ingress"] != "internal-and-cloud-load-balancing" or value["default_url_enabled"] is not True:
+    raise SystemExit("bootstrap artifact private-origin contract differs")
+if not isinstance(value["release"], str) or not re.fullmatch(r"[A-Za-z0-9._-]{1,128}", value["release"]):
+    raise SystemExit("bootstrap release is invalid")
+if not isinstance(value["created_at"], str) or not re.fullmatch(
+    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", value["created_at"]
+):
+    raise SystemExit("bootstrap timestamp is invalid")
+regions = raw_regions.split(",")
+if value["regions"] != regions:
+    raise SystemExit("bootstrap artifact region inventory differs")
+expected_synthetic = {
+    "monitor_regions": raw_monitor_regions.split(","),
+    "throughput_region": throughput_region,
+    "image_region": image_region,
+    "video_region": video_region,
+}
+if value["synthetic_inventory"] != expected_synthetic:
+    raise SystemExit("bootstrap artifact synthetic inventory differs")
+data_mode = value["data_mode"]
+data_mode_fields = {
+    "storage_backend", "analytics_read_mode", "request_record_write_mode",
+    "generation_records_enabled", "bigtable_mirror_writes_enabled",
+    "analytics_dual_read_started_at", "analytics_clickhouse_primary_started_at",
+    "operational_clickhouse_url", "operational_clickhouse_user",
+    "operational_clickhouse_database",
+}
+if not isinstance(data_mode, dict) or set(data_mode) != data_mode_fields:
+    raise SystemExit("bootstrap artifact data mode fields differ")
+mode = (
+    data_mode["storage_backend"],
+    data_mode["analytics_read_mode"],
+    data_mode["request_record_write_mode"],
+    data_mode["generation_records_enabled"],
+    data_mode["bigtable_mirror_writes_enabled"],
+)
+if mode == ("spanner-bigtable", "bigtable", "typed", "true", "true"):
+    if any(data_mode[name] for name in (
+        "operational_clickhouse_url", "operational_clickhouse_user",
+        "operational_clickhouse_database",
+    )):
+        raise SystemExit("bootstrap artifact Bigtable mode has ClickHouse fields")
+elif mode == ("spanner-clickhouse", "clickhouse-only", "typed", "true", "false"):
+    if data_mode["operational_clickhouse_user"] != "tr_control_read" or data_mode["operational_clickhouse_database"] != "tr":
+        raise SystemExit("bootstrap artifact ClickHouse identity/database differs")
+    parsed = urlsplit(data_mode["operational_clickhouse_url"])
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname or parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise SystemExit("bootstrap artifact ClickHouse URL is malformed")
+    try:
+        private = ipaddress.ip_address(parsed.hostname).is_private
+    except ValueError:
+        private = parsed.hostname.endswith(".internal")
+    if not private:
+        raise SystemExit("bootstrap artifact ClickHouse URL is not private")
+else:
+    raise SystemExit("bootstrap artifact data mode is not reviewed")
+for field in ("analytics_dual_read_started_at", "analytics_clickhouse_primary_started_at"):
+    timestamp = data_mode[field]
+    if not isinstance(timestamp, str) or (timestamp and not re.fullmatch(
+        r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", timestamp
+    )):
+        raise SystemExit(f"bootstrap artifact {field} is invalid")
+services = value["services"]
+if not isinstance(services, list) or len(services) != len(regions):
+    raise SystemExit("bootstrap artifact service inventory differs")
+seen = set()
+for service in services:
+    if not isinstance(service, dict) or set(service) != {
+        "region", "revision", "postcondition_sha256"
+    }:
+        raise SystemExit("bootstrap service fields differ")
+    region = service["region"]
+    revision = service["revision"]
+    digest = service["postcondition_sha256"]
+    if region not in regions or region in seen:
+        raise SystemExit("bootstrap service region is missing or duplicated")
+    if not isinstance(revision, str) or not re.fullmatch(r"[a-z][a-z0-9-]{0,61}", revision):
+        raise SystemExit("bootstrap revision is invalid")
+    if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+        raise SystemExit("bootstrap service digest is invalid")
+    seen.add(region)
+    print(region, revision, digest, sep="\t")
+if seen != set(regions):
+    raise SystemExit("bootstrap service inventory is incomplete")
+PY
+}
+
+verify_live_internal_service() {
+  local region="$1" revision="$2" expected_hash="$3"
+  local service_json service_path service_secret_file service_iam actual_hash
+  local env_name secret version version_json enabled_version
+  service_json="$(gc run services describe "$INTERNAL_SERVICE" \
+    --region="$region" --format=json)" || {
+      echo "ERROR: bootstrapped internal service is absent in ${region}" >&2
+      return 1
+    }
+  service_iam="$(gc run services get-iam-policy "$INTERNAL_SERVICE" \
+    --region="$region" --format=json)" || return 1
+  jq -e '
+    [.bindings[]? | select(any(.members[]?; . == "allUsers"))
+      | {role, condition: (.condition // null),
+         allUsersCount: ([.members[]? | select(. == "allUsers")] | length)}]
+    == [{role:"roles/run.invoker",condition:null,allUsersCount:1}]
+  ' <<<"$service_iam" >/dev/null || {
+    echo "ERROR: internal bootstrap invoker IAM drifted in ${region}" >&2
+    return 1
+  }
+  service_path="$(mktemp "${TMPDIR:-/tmp}/tr-internal-live-XXXXXX")"
+  service_secret_file="$(mktemp "${TMPDIR:-/tmp}/tr-internal-live-secrets-XXXXXX")"
+  printf '%s' "$service_json" >"$service_path"
+  if ! python3 - "$service_path" "$INTERNAL_SERVICE" "$revision" \
+    "$INTERNAL_RUN_SERVICE_ACCOUNT" "$EXPECTED_IMAGE" \
+    "https://${INTERNAL_SERVICE}-${PROJECT_NUMBER}.${region}.run.app" \
+    "$service_secret_file" "$ARTIFACT_RELEASE" "$PROJECT_ID" "$TR_REGIONS" \
+    "$TR_PRIMARY_REGION" "$SPANNER_INSTANCE_ID" "$SPANNER_DATABASE_ID" \
+    "$BIGTABLE_INSTANCE_ID" "$BIGTABLE_GENERATION_TABLE" \
+    "$BYOK_KMS_KEY_NAME" "$CLOUD_RUN_NETWORK" "$CLOUD_RUN_SUBNET" \
+    "$ARTIFACT_STORAGE_BACKEND" "$ARTIFACT_ANALYTICS_READ_MODE" \
+    "$ARTIFACT_REQUEST_RECORD_WRITE_MODE" \
+    "$ARTIFACT_GENERATION_RECORDS_ENABLED" \
+    "$ARTIFACT_BIGTABLE_MIRROR_WRITES_ENABLED" \
+    "$ARTIFACT_ANALYTICS_DUAL_READ_STARTED_AT" \
+    "$ARTIFACT_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT" \
+    "$ARTIFACT_OPERATIONAL_CLICKHOUSE_URL" \
+    "$ARTIFACT_OPERATIONAL_CLICKHOUSE_USER" \
+    "$ARTIFACT_OPERATIONAL_CLICKHOUSE_DATABASE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+(
+    path,
+    expected_service,
+    expected_revision,
+    expected_identity,
+    expected_image,
+    expected_url,
+    secret_output,
+    expected_release,
+    project,
+    regions,
+    primary_region,
+    spanner_instance,
+    spanner_database,
+    bigtable_instance,
+    generation_table,
+    byok_key,
+    expected_network,
+    expected_subnet,
+    storage_backend,
+    analytics_read_mode,
+    request_record_write_mode,
+    generation_records_enabled,
+    bigtable_mirror_writes_enabled,
+    analytics_dual_read_started_at,
+    analytics_clickhouse_primary_started_at,
+    operational_clickhouse_url,
+    operational_clickhouse_user,
+    operational_clickhouse_database,
+) = sys.argv[1:]
+data = json.loads(Path(path).read_text(encoding="utf-8"))
+metadata = data.get("metadata") or {}
+annotations = metadata.get("annotations") or {}
+spec = data.get("spec") or {}
+template = spec.get("template") or {}
+template_spec = template.get("spec") or {}
+status = data.get("status") or {}
+if metadata.get("name") not in {None, expected_service}:
+    raise SystemExit("internal service name differs")
+if not any(
+    item.get("type") == "Ready" and str(item.get("status", "")).lower() == "true"
+    for item in status.get("conditions", [])
+):
+    raise SystemExit("internal service is not Ready")
+if metadata.get("generation") is None or str(status.get("observedGeneration")) != str(metadata["generation"]):
+    raise SystemExit("internal service generation is not observed")
+if status.get("latestReadyRevisionName") != expected_revision:
+    raise SystemExit("bootstrapped revision is no longer latest Ready")
+def exact_sole_target(items, revision):
+    return (
+        len(items) == 1
+        and items[0].get("revisionName") == revision
+        and int(items[0].get("percent", 0) or 0) == 100
+        and not items[0].get("tag")
+        and not items[0].get("latestRevision", False)
+    )
+
+if not exact_sole_target(spec.get("traffic") or [], expected_revision):
+    raise SystemExit("bootstrapped revision is not the sole desired traffic target")
+if not exact_sole_target(status.get("traffic") or [], expected_revision):
+    raise SystemExit("bootstrapped revision is not the sole 100% target")
+if annotations.get("run.googleapis.com/ingress") != "internal-and-cloud-load-balancing":
+    raise SystemExit("internal ingress differs")
+if annotations.get("run.googleapis.com/ingress-status") != "internal-and-cloud-load-balancing":
+    raise SystemExit("effective internal ingress differs")
+if str(annotations.get("run.googleapis.com/default-url-disabled", "false")).lower() not in {"", "false"}:
+    raise SystemExit("internal default URL is disabled")
+if status.get("url") != expected_url:
+    raise SystemExit("internal private default URL differs")
+if template_spec.get("serviceAccountName") != expected_identity:
+    raise SystemExit("internal runtime identity differs")
+if int(template_spec.get("containerConcurrency", -1)) != 8:
+    raise SystemExit("internal concurrency differs")
+if str(template_spec.get("timeoutSeconds", "")).removesuffix("s") != "300":
+    raise SystemExit("internal timeout differs")
+template_annotations = (template.get("metadata") or {}).get("annotations") or {}
+if str(template_annotations.get("autoscaling.knative.dev/minScale")) != "2":
+    raise SystemExit("internal minimum differs")
+if str(template_annotations.get("autoscaling.knative.dev/maxScale")) != "50":
+    raise SystemExit("internal revision maximum differs")
+if str((spec.get("scaling") or {}).get("maxInstanceCount")) != "50":
+    raise SystemExit("internal service maximum differs")
+containers = template_spec.get("containers") or []
+if len(containers) != 1:
+    raise SystemExit("internal revision must have exactly one container")
+container = containers[0]
+if container.get("image") != expected_image:
+    raise SystemExit("internal bootstrap image differs")
+if container.get("command") not in (None, []):
+    raise SystemExit("internal container command differs")
+if container.get("args") not in (None, []):
+    raise SystemExit("internal container arguments differ")
+if container.get("volumeMounts") not in (None, []):
+    raise SystemExit("internal container volume mounts differ")
+if template_spec.get("volumes") not in (None, []):
+    raise SystemExit("internal volumes differ")
+if template_spec.get("initContainers") not in (None, []):
+    raise SystemExit("internal init containers differ")
+ports = container.get("ports") or []
+if len(ports) != 1 or int(ports[0].get("containerPort", -1)) != 8080:
+    raise SystemExit("internal container port differs")
+limits = (container.get("resources") or {}).get("limits") or {}
+if str(limits.get("memory")) != "2Gi":
+    raise SystemExit("internal memory differs")
+if str(limits.get("cpu") or "") not in {"1", "1000m"}:
+    raise SystemExit("internal CPU differs")
+network_raw = template_annotations.get("run.googleapis.com/network-interfaces")
+try:
+    interfaces = json.loads(network_raw)
+except (TypeError, ValueError):
+    raise SystemExit("internal VPC network annotation is invalid") from None
+if not isinstance(interfaces, list) or len(interfaces) != 1:
+    raise SystemExit("internal VPC interface inventory differs")
+
+def exact_resource(value, kind, expected):
+    text = str(value or "").rstrip("/")
+    return text == expected or (
+        f"/projects/{project}/" in f"/{text}"
+        and text.endswith(f"/{kind}/{expected}")
+    )
+
+if not exact_resource(interfaces[0].get("network"), "networks", expected_network):
+    raise SystemExit("internal VPC network differs")
+if not exact_resource(interfaces[0].get("subnetwork"), "subnetworks", expected_subnet):
+    raise SystemExit("internal VPC subnet differs")
+if template_annotations.get("run.googleapis.com/vpc-access-egress") != "private-ranges-only":
+    raise SystemExit("internal VPC egress differs")
+probe = container.get("startupProbe") or {}
+http_get = probe.get("httpGet") or {}
+expected_probe = {
+    "initialDelaySeconds": 0,
+    "timeoutSeconds": 10,
+    "periodSeconds": 10,
+    "failureThreshold": 18,
+}
+if http_get.get("path") != "/ready":
+    raise SystemExit("internal /ready startup probe is absent")
+if http_get.get("port") is not None and int(http_get["port"]) != 8080:
+    raise SystemExit("internal startup probe port differs")
+for field, expected in expected_probe.items():
+    if int(probe.get(field, -1)) != expected:
+        raise SystemExit(f"internal startup probe {field} differs")
+env_items = container.get("env", []) or []
+env_names = [item.get("name") for item in env_items]
+if any(not name for name in env_names) or len(env_names) != len(set(env_names)):
+    raise SystemExit("internal environment contains missing or duplicate names")
+env = {item["name"]: item for item in env_items}
+expected_plain = {
+    "TR_ENVIRONMENT": "production",
+    "TR_RELEASE": expected_release,
+    "TR_SERVICE_SURFACE": "internal",
+    "TR_API_BASE_URL": "https://api.trustedrouter.com/v1",
+    "TR_TRUSTED_DOMAIN": "trustedrouter.com",
+    "TR_TRUSTED_DOMAIN_ALIASES": "allyrouter.com,uptimerouter.com",
+    "TR_GCP_PROJECT_ID": project,
+    "TR_REGIONS": regions,
+    "TR_PRIMARY_REGION": primary_region,
+    "TR_ENABLE_LIVE_PROVIDERS": "false",
+    "TR_RATE_LIMIT_CLIENT_IP_MODE": "edge_header",
+    "TR_MAX_REQUEST_BODY_BYTES": "33554432",
+    "TR_MAX_IN_FLIGHT_REQUEST_BODY_BYTES": "67108864",
+    "TR_MAX_CONCURRENT_REQUEST_BODIES": "4",
+    "TR_REQUEST_BODY_READ_TIMEOUT_SECONDS": "30",
+    "TR_REMEDIATOR_IN_PROCESS_ENABLED": "false",
+    "TR_SYNTHETIC_SCHEDULER_INTERVAL_SECONDS": "0",
+    "TR_ACTIVATION_REMINDER_INTERVAL_SECONDS": "0",
+    "TR_REGIONAL_QUOTA_LEASES_ENABLED": "false",
+    "TR_STORAGE_BACKEND": storage_backend,
+    "TR_SPANNER_INSTANCE_ID": spanner_instance,
+    "TR_SPANNER_DATABASE_ID": spanner_database,
+    "TR_BIGTABLE_INSTANCE_ID": bigtable_instance,
+    "TR_BIGTABLE_GENERATION_TABLE": generation_table,
+    "TR_SPANNER_POOL_SIZE": "8",
+    "TR_BIGTABLE_MIRROR_WRITES_ENABLED": bigtable_mirror_writes_enabled,
+    "TR_GENERATION_RECORDS_ENABLED": generation_records_enabled,
+    "TR_ANALYTICS_READ_MODE": analytics_read_mode,
+    "TR_ANALYTICS_DUAL_READ_STARTED_AT": analytics_dual_read_started_at,
+    "TR_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT": analytics_clickhouse_primary_started_at,
+    "TR_REQUEST_RECORD_WRITE_MODE": request_record_write_mode,
+    "TR_SETTLE_OUTBOX_ENABLED": "true",
+    "TR_ANALYTICS_OUTBOX_ENABLED": "true",
+    "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED": "true",
+    "TR_BYOK_KMS_KEY_NAME": byok_key,
+    "TR_AWS_REGION": "us-east-1",
+    "TR_SES_FROM_EMAIL": "alerts@alerts.trustedrouter.com",
+    "TR_SES_FROM_NAME": "TrustedRouter Alerts",
+    "TR_SES_ALERT_FROM_EMAIL": "alerts@alerts.trustedrouter.com",
+    "TR_SES_ALERT_FROM_NAME": "TrustedRouter Alerts",
+    "TR_SES_ALERT_CONFIGURATION_SET": "trustedrouter-alerts",
+}
+if analytics_read_mode != "bigtable":
+    expected_plain.update({
+        "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_URL": operational_clickhouse_url,
+        "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_USER": operational_clickhouse_user,
+        "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_DATABASE": operational_clickhouse_database,
+    })
+actual_plain = {
+    name: str(item.get("value", ""))
+    for name, item in env.items()
+    if "valueFrom" not in item
+}
+if actual_plain != expected_plain:
+    raise SystemExit("internal exact plain environment differs")
+expected_secrets = {
+    "TR_SENTRY_DSN": "trustedrouter-sentry-dsn",
+    "TR_INTERNAL_GATEWAY_TOKEN": "trustedrouter-internal-gateway-token",
+    "TR_OBSERVER_INTERNAL_TOKEN": "trustedrouter-observer-internal-token",
+    "TR_SYNTHETIC_MONITOR_API_KEY": "trustedrouter-synthetic-monitor-api-key",
+    "TR_STRIPE_SECRET_KEY": "trustedrouter-internal-stripe-payment-intents-key",
+    "TR_AWS_ACCESS_KEY_ID": "trustedrouter-internal-ses-access-key-id",
+    "TR_AWS_SECRET_ACCESS_KEY": "trustedrouter-internal-ses-secret-access-key",
+}
+if analytics_read_mode != "bigtable":
+    expected_secrets["TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_PASSWORD"] = (
+        "trustedrouter-clickhouse-control-read-password"
+    )
+actual_secrets = {}
+actual_secret_versions = {}
+for name, item in env.items():
+    if "valueFrom" not in item:
+        continue
+    reference = (item.get("valueFrom") or {}).get("secretKeyRef") or {}
+    resource = str(reference.get("name") or reference.get("secret") or "").split("/")[-1]
+    version = str(reference.get("key") or reference.get("version") or "")
+    if not version.isdigit() or version.startswith("0"):
+        raise SystemExit(f"internal secret {name} is not pinned numerically")
+    actual_secrets[name] = resource
+    actual_secret_versions[name] = version
+if actual_secrets != expected_secrets:
+    raise SystemExit("internal bootstrap secret allowlist differs")
+Path(secret_output).write_text(
+    "".join(
+        f"{name}\t{actual_secrets[name]}\t{actual_secret_versions[name]}\n"
+        for name in sorted(expected_secrets)
+    ),
+    encoding="utf-8",
+)
+PY
+  then
+    rm -f "$service_path" "$service_secret_file"
+    return 1
+  fi
+  while IFS=$'\t' read -r env_name secret version; do
+    [ -n "$env_name" ] || continue
+    version_json="$(gc secrets versions describe "$version" \
+      --secret="$secret" --format=json)" || {
+        rm -f "$service_path" "$service_secret_file"
+        return 1
+      }
+    enabled_version="$(jq -er 'select(.state == "ENABLED") | .name | split("/")[-1]' \
+      <<<"$version_json")" || {
+        echo "ERROR: bootstrapped internal secret ${secret}:${version} is not enabled" >&2
+        rm -f "$service_path" "$service_secret_file"
+        return 1
+      }
+    [ "$enabled_version" = "$version" ] || {
+      echo "ERROR: bootstrapped internal secret version resolution differs for ${secret}" >&2
+      rm -f "$service_path" "$service_secret_file"
+      return 1
+    }
+  done <"$service_secret_file"
+  actual_hash="$(python3 "$STATE_TOOL" hash-service "$service_path")"
+  rm -f "$service_path" "$service_secret_file"
+  [ "$actual_hash" = "$expected_hash" ] || {
+    echo "ERROR: bootstrapped internal service hash drifted in ${region}" >&2
+    return 1
+  }
+}
+
+verify_synthetic_job_target() {
+  local region="$1" job_name="$2" scheduler_name="$3"
+  local expected_base expected_run_uri job_json job_path job_secret_file
+  local scheduler_json scheduler_path env_name secret version version_json enabled_version
+  local secret_policy job_iam
+  expected_base="https://${INTERNAL_SERVICE}-${PROJECT_NUMBER}.${region}.run.app"
+  expected_run_uri="https://${region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${PROJECT_ID}/jobs/${job_name}:run"
+  job_json="$(gc run jobs describe "$job_name" --region="$region" --format=json)" || {
+    echo "ERROR: synthetic job ${region}/${job_name} is absent" >&2
+    return 1
+  }
+  job_iam="$(gc run jobs get-iam-policy "$job_name" \
+    --region="$region" --format=json)" || return 1
+  if ! printf '%s' "$job_iam" | python3 -c '
+import json
+import sys
+
+policy = json.load(sys.stdin)
+bindings = policy.get("bindings") or []
+if len(bindings) != 1:
+    raise SystemExit("synthetic Job IAM binding inventory differs")
+binding = bindings[0]
+if binding.get("role") != "roles/run.invoker" or binding.get("condition") is not None:
+    raise SystemExit("synthetic Job invoker binding differs")
+members = binding.get("members") or []
+if members != [sys.argv[1]]:
+    raise SystemExit("synthetic Job invoker member inventory differs")
+' "serviceAccount:${SYNTHETIC_RUN_SERVICE_ACCOUNT}"; then
+    echo "ERROR: synthetic Cloud Run Job ${region}/${job_name} IAM differs" >&2
+    return 1
+  fi
+  job_path="$(mktemp "${TMPDIR:-/tmp}/tr-synthetic-job-XXXXXX")"
+  job_secret_file="$(mktemp "${TMPDIR:-/tmp}/tr-synthetic-secrets-XXXXXX")"
+  printf '%s' "$job_json" >"$job_path"
+  if ! python3 - "$job_path" "$job_name" "$region" \
+    "$SYNTHETIC_RUN_SERVICE_ACCOUNT" "$expected_base" \
+    "$SYNTHETIC_NETWORK" "$SYNTHETIC_SUBNET" "$PROJECT_ID" \
+    "$job_secret_file" "$EXPECTED_IMAGE" "$ARTIFACT_RELEASE" "$TR_REGIONS" \
+    "$TR_PRIMARY_REGION" "$REGION" "$SPANNER_INSTANCE_ID" \
+    "$SPANNER_DATABASE_ID" "$BIGTABLE_INSTANCE_ID" \
+    "$BIGTABLE_GENERATION_TABLE" "$MONITOR_REGION_CSV" <<'PY'
+import json
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit
+
+(
+    path,
+    job_name,
+    region,
+    expected_identity,
+    expected_base,
+    expected_network,
+    expected_subnet,
+    project,
+    secret_output,
+    expected_image,
+    expected_release,
+    gateway_regions,
+    primary_region,
+    vertex_location,
+    spanner_instance,
+    spanner_database,
+    bigtable_instance,
+    generation_table,
+    raw_monitor_regions,
+) = sys.argv[1:]
+data = json.loads(Path(path).read_text(encoding="utf-8"))
+containers = []
+container_specs = []
+identities = []
+network_annotations = []
+task_counts = []
+parallelisms = []
+def visit(value):
+    if isinstance(value, dict):
+        annotations = value.get("annotations")
+        if isinstance(annotations, dict) and any(
+            name in annotations
+            for name in (
+                "run.googleapis.com/network-interfaces",
+                "run.googleapis.com/vpc-access-egress",
+            )
+        ):
+            network_annotations.append(annotations)
+        for key, child in value.items():
+            if key in {"serviceAccount", "serviceAccountName"} and isinstance(child, str):
+                identities.append(child)
+            if key == "containers" and isinstance(child, list):
+                containers.extend(child)
+                container_specs.append(value)
+            if key == "taskCount":
+                task_counts.append(child)
+            if key == "parallelism":
+                parallelisms.append(child)
+            visit(child)
+    elif isinstance(value, list):
+        for child in value:
+            visit(child)
+visit(data.get("spec") or {})
+reported_name = str((data.get("metadata") or {}).get("name") or "").rstrip("/").split("/")[-1]
+if reported_name and reported_name != job_name:
+    raise SystemExit("synthetic job name differs")
+if sorted(set(identities)) != [expected_identity]:
+    raise SystemExit("synthetic job identity differs")
+if len(containers) != 1 or len(container_specs) != 1:
+    raise SystemExit("synthetic job must expose exactly one container")
+if task_counts != [1] or parallelisms != [1]:
+    raise SystemExit("synthetic job task fan-out differs")
+job_spec = container_specs[0]
+container = containers[0]
+if container.get("image") != expected_image:
+    raise SystemExit("synthetic job image differs")
+if container.get("command") != ["/app/.venv/bin/python"]:
+    raise SystemExit("synthetic job command differs")
+if container.get("volumeMounts") not in (None, []):
+    raise SystemExit("synthetic job volume mounts differ")
+if job_spec.get("volumes") not in (None, []):
+    raise SystemExit("synthetic job volumes differ")
+if job_spec.get("initContainers") not in (None, []):
+    raise SystemExit("synthetic job init containers differ")
+if int(job_spec.get("maxRetries", -1)) != 0:
+    raise SystemExit("synthetic job retry contract differs")
+
+if job_name == f"trusted-router-synthetic-{region}":
+    family = "monitor"
+    expected_module = "trusted_router.synthetic.cli"
+    expected_cpu, expected_memory, expected_timeout = "2", "1Gi", "300"
+elif job_name == f"trusted-router-throughput-{region}":
+    family = "throughput"
+    expected_module = "trusted_router.synthetic.cli"
+    expected_cpu, expected_memory, expected_timeout = "1", "1Gi", "300"
+elif job_name == f"trusted-router-image-generation-{region}":
+    family = "image"
+    expected_module = "trusted_router.synthetic.image_generation"
+    expected_cpu, expected_memory, expected_timeout = "1", "512Mi", "300"
+elif job_name == f"trusted-router-video-generation-{region}":
+    family = "video"
+    expected_module = "trusted_router.synthetic.video_generation"
+    expected_cpu, expected_memory, expected_timeout = "1", "512Mi", "1200"
+else:
+    raise SystemExit("synthetic job family differs")
+if container.get("args") != ["-m", expected_module]:
+    raise SystemExit("synthetic job arguments differ")
+limits = (container.get("resources") or {}).get("limits") or {}
+actual_cpu = str(limits.get("cpu") or "")
+if actual_cpu not in {expected_cpu, f"{int(expected_cpu) * 1000}m"}:
+    raise SystemExit("synthetic job CPU differs")
+if str(limits.get("memory") or "") != expected_memory:
+    raise SystemExit("synthetic job memory differs")
+if str(job_spec.get("timeoutSeconds", "")).removesuffix("s") != expected_timeout:
+    raise SystemExit("synthetic job timeout differs")
+if len(network_annotations) != 1:
+    raise SystemExit("synthetic job VPC annotation inventory differs")
+annotations = network_annotations[0]
+try:
+    interfaces = json.loads(annotations.get("run.googleapis.com/network-interfaces"))
+except (TypeError, ValueError):
+    raise SystemExit("synthetic job VPC network annotation is invalid") from None
+if not isinstance(interfaces, list) or len(interfaces) != 1:
+    raise SystemExit("synthetic job VPC interface count differs")
+
+def exact_resource(value, kind, expected):
+    text = str(value or "").rstrip("/")
+    if text == expected:
+        return True
+    if f"/projects/{project}/" not in f"/{text}":
+        return False
+    return text.endswith(f"/{kind}/{expected}")
+
+interface = interfaces[0]
+if not exact_resource(interface.get("network"), "networks", expected_network):
+    raise SystemExit("synthetic job VPC network differs")
+if not exact_resource(interface.get("subnetwork"), "subnetworks", expected_subnet):
+    raise SystemExit("synthetic job VPC subnet differs")
+if annotations.get("run.googleapis.com/vpc-access-egress") != "private-ranges-only":
+    raise SystemExit("synthetic job VPC egress differs")
+env_items = container.get("env", []) or []
+env_names = [item.get("name") for item in env_items]
+if any(not name for name in env_names) or len(env_names) != len(set(env_names)):
+    raise SystemExit("synthetic job environment contains missing or duplicate names")
+env = {item["name"]: item for item in env_items}
+expected_ingest = expected_base + "/v1/internal/synthetic/samples"
+if env.get("TR_SYNTHETIC_INGEST_URL", {}).get("value") != expected_ingest:
+    raise SystemExit("synthetic ingest URL does not target internal")
+expected_plain = {
+    "TR_ENVIRONMENT": "worker",
+    "TR_SERVICE_SURFACE": "observer",
+    "TR_RELEASE": expected_release,
+    "TR_ENABLE_LIVE_PROVIDERS": "false",
+    "TR_API_BASE_URL": "https://api.trustedrouter.com/v1",
+    "TR_TRUSTED_DOMAIN": "trustedrouter.com",
+    "TR_STORAGE_BACKEND": "spanner-bigtable",
+    "TR_GCP_PROJECT_ID": project,
+    "TR_SPANNER_INSTANCE_ID": spanner_instance,
+    "TR_SPANNER_DATABASE_ID": spanner_database,
+    "TR_BIGTABLE_INSTANCE_ID": bigtable_instance,
+    "TR_BIGTABLE_GENERATION_TABLE": generation_table,
+    "TR_REGIONS": gateway_regions,
+    "TR_PRIMARY_REGION": primary_region,
+    "TR_SYNTHETIC_MONITOR_MODEL": "trustedrouter/monitor",
+    "TR_SYNTHETIC_MONITOR_TIMEOUT_SECONDS": "30",
+    "TR_SYNTHETIC_CONTROL_PLANE_URL": "https://trustedrouter.com",
+    "TR_SYNTHETIC_RUNS_PER_INVOCATION": "1",
+    "TR_SYNTHETIC_RUN_SPACING_SECONDS": "0",
+    "VERTEX_PROJECT_ID": project,
+    "VERTEX_LOCATION": vertex_location,
+    "TR_SYNTHETIC_MONITOR_REGION": region,
+    "TR_SYNTHETIC_INGEST_URL": expected_ingest,
+    "TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL": expected_base,
+}
+if family == "monitor":
+    monitor_regions = raw_monitor_regions.split(",")
+    if region not in monitor_regions:
+        raise SystemExit("synthetic monitor region is outside inventory")
+    expected_plain.update({
+        "TR_SYNTHETIC_BENCHMARK_INGEST_URL": expected_base + "/v1/internal/synthetic/benchmark",
+        "TR_SYNTHETIC_ROUTE_HEALTH_URL": expected_base + "/v1/internal/synthetic/route-health",
+        "TR_SYNTHETIC_BILLING_CONCURRENCY": "2",
+        "TR_SYNTHETIC_START_DELAY_SECONDS": str(monitor_regions.index(region) * 20),
+        "TR_SYNTHETIC_ROTATION_ENABLED": "true",
+        "TR_SYNTHETIC_ROTATION_PER_PASS": "2",
+        "TR_SYNTHETIC_THROUGHPUT_ENABLED": "false",
+        "TR_SYNTHETIC_THROUGHPUT_ONLY": "false",
+    })
+    if region == primary_region:
+        expected_plain["TR_SYNTHETIC_REMEDIATOR_URL"] = expected_base + "/v1/internal/synthetic/remediate"
+elif family == "throughput":
+    expected_plain.update({
+        "TR_SYNTHETIC_BENCHMARK_INGEST_URL": expected_base + "/v1/internal/synthetic/benchmark",
+        "TR_SYNTHETIC_ROUTE_HEALTH_URL": expected_base + "/v1/internal/synthetic/route-health",
+        "TR_SYNTHETIC_BILLING_CONCURRENCY": "1",
+        "TR_SYNTHETIC_START_DELAY_SECONDS": "0",
+        "TR_SYNTHETIC_ROTATION_ENABLED": "false",
+        "TR_SYNTHETIC_ROTATION_PER_PASS": "0",
+        "TR_SYNTHETIC_THROUGHPUT_ENABLED": "true",
+        "TR_SYNTHETIC_THROUGHPUT_ONLY": "true",
+        "TR_SYNTHETIC_THROUGHPUT_REGION": region,
+        "TR_SYNTHETIC_THROUGHPUT_ROUTE_LIMIT": "200",
+        "TR_SYNTHETIC_THROUGHPUT_MAX_TOKENS": "512",
+        "TR_SYNTHETIC_THROUGHPUT_MINIMUM_OUTPUT_TOKENS": "128",
+        "TR_SYNTHETIC_THROUGHPUT_TIMEOUT_SECONDS": "90",
+        "TR_SYNTHETIC_THROUGHPUT_TIMEOUT_CEILING_SECONDS": "210",
+        "TR_SYNTHETIC_THROUGHPUT_INTERVAL_SECONDS": "300",
+    })
+elif family == "image":
+    expected_plain.update({
+        "TR_SYNTHETIC_IMAGE_MODEL": "google/gemini-3.1-flash-image-preview",
+        "TR_SYNTHETIC_IMAGE_PROVIDER": "google-ai-studio",
+        "TR_SYNTHETIC_IMAGE_TIMEOUT_SECONDS": "120",
+        "TR_SYNTHETIC_IMAGE_CONFIRMATION_DELAY_SECONDS": "2",
+    })
+else:
+    expected_plain.update({
+        "TR_SYNTHETIC_VIDEO_TIMEOUT_SECONDS": "900",
+        "TR_SYNTHETIC_VIDEO_POLL_INTERVAL_SECONDS": "5",
+    })
+actual_plain = {
+    name: str(item.get("value", ""))
+    for name, item in env.items()
+    if "valueFrom" not in item
+}
+if actual_plain != expected_plain:
+    raise SystemExit("synthetic job exact plain environment differs")
+expected_secrets = {
+    "TR_OBSERVER_INTERNAL_TOKEN": "trustedrouter-observer-internal-token",
+    "TR_SYNTHETIC_MONITOR_API_KEY": "trustedrouter-synthetic-monitor-api-key",
+}
+actual_secrets = {}
+for name, item in env.items():
+    if "valueFrom" not in item:
+        continue
+    reference = (item.get("valueFrom") or {}).get("secretKeyRef") or {}
+    resource = str(reference.get("name") or reference.get("secret") or "").split("/")[-1]
+    version = str(reference.get("key") or reference.get("version") or "")
+    if not version.isdigit() or version.startswith("0"):
+        raise SystemExit(f"synthetic Job secret {name} is not pinned numerically")
+    actual_secrets[name] = {"resource": resource, "version": version}
+if {name: item["resource"] for name, item in actual_secrets.items()} != expected_secrets:
+    raise SystemExit("synthetic Job exact secret allowlist differs")
+Path(secret_output).write_text(
+    "".join(
+        f"{name}\t{actual_secrets[name]['resource']}\t{actual_secrets[name]['version']}\n"
+        for name in sorted(expected_secrets)
+    ),
+    encoding="utf-8",
+)
+PY
+  then
+    rm -f "$job_path" "$job_secret_file"
+    return 1
+  fi
+  while IFS=$'\t' read -r env_name secret version; do
+    [ -n "$env_name" ] || continue
+    version_json="$(gc secrets versions describe "$version" \
+      --secret="$secret" --format=json)" || {
+        rm -f "$job_path" "$job_secret_file"
+        return 1
+      }
+    enabled_version="$(jq -er 'select(.state == "ENABLED") | .name | split("/")[-1]' \
+      <<<"$version_json")" || {
+        echo "ERROR: synthetic Job secret ${secret}:${version} is not enabled" >&2
+        rm -f "$job_path" "$job_secret_file"
+        return 1
+      }
+    [ "$enabled_version" = "$version" ] || {
+      echo "ERROR: synthetic Job secret version resolution differs for ${secret}" >&2
+      rm -f "$job_path" "$job_secret_file"
+      return 1
+    }
+    secret_policy="$(gc secrets get-iam-policy "$secret" --format=json)" || {
+      rm -f "$job_path" "$job_secret_file"
+      return 1
+    }
+    if ! printf '%s' "$secret_policy" | python3 -c '
+import json
+import sys
+
+policy = json.load(sys.stdin)
+expected = sorted(sys.argv[1:])
+bindings = policy.get("bindings") or []
+if len(bindings) != 1:
+    raise SystemExit("synthetic secret IAM binding inventory differs")
+binding = bindings[0]
+if binding.get("role") != "roles/secretmanager.secretAccessor":
+    raise SystemExit("synthetic secret IAM role differs")
+if binding.get("condition") is not None:
+    raise SystemExit("synthetic secret IAM grant is conditional")
+members = binding.get("members") or []
+if len(members) != len(set(members)) or sorted(members) != expected:
+    raise SystemExit("synthetic secret IAM member inventory differs")
+' "serviceAccount:${INTERNAL_RUN_SERVICE_ACCOUNT}" \
+      "serviceAccount:${SYNTHETIC_RUN_SERVICE_ACCOUNT}"; then
+      echo "ERROR: ${secret} does not have the exact two-consumer IAM policy" >&2
+      rm -f "$job_path" "$job_secret_file"
+      return 1
+    fi
+  done <"$job_secret_file"
+  rm -f "$job_path" "$job_secret_file"
+  scheduler_json="$(gc scheduler jobs describe "$scheduler_name" \
+    --location="$region" --format=json)" || {
+      echo "ERROR: synthetic scheduler ${region}/${scheduler_name} is absent" >&2
+      return 1
+    }
+  scheduler_path="$(mktemp "${TMPDIR:-/tmp}/tr-synthetic-scheduler-XXXXXX")"
+  printf '%s' "$scheduler_json" >"$scheduler_path"
+  if ! python3 - "$scheduler_path" "$scheduler_name" "$job_name" \
+    "$SYNTHETIC_RUN_SERVICE_ACCOUNT" "$expected_run_uri" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path, expected_name, job_name, expected_identity, expected_uri = sys.argv[1:]
+data = json.loads(Path(path).read_text(encoding="utf-8"))
+reported_name = str(data.get("name") or "").rstrip("/").split("/")[-1]
+if reported_name != expected_name:
+    raise SystemExit("synthetic Scheduler name differs")
+target = data.get("httpTarget") or {}
+oauth = target.get("oauthToken") or {}
+if oauth.get("serviceAccountEmail") != expected_identity:
+    raise SystemExit("synthetic Scheduler OAuth identity differs")
+if set(oauth) != {"serviceAccountEmail"}:
+    raise SystemExit("synthetic Scheduler OAuth scope fields differ")
+if target.get("oidcToken") not in (None, {}):
+    raise SystemExit("synthetic Scheduler has an unexpected OIDC audience")
+if target.get("uri") != expected_uri:
+    raise SystemExit("synthetic Scheduler target differs")
+if str(target.get("httpMethod", "")).upper() != "POST":
+    raise SystemExit("synthetic Scheduler method differs")
+if str(data.get("state", "")).upper() != "ENABLED":
+    raise SystemExit("synthetic Scheduler is not enabled")
+if job_name.startswith("trusted-router-synthetic-"):
+    expected_schedule = "*/3 * * * *"
+elif job_name.startswith("trusted-router-throughput-"):
+    expected_schedule = "*/5 * * * *"
+elif job_name.startswith("trusted-router-image-generation-"):
+    expected_schedule = "17 */6 * * *"
+elif job_name.startswith("trusted-router-video-generation-"):
+    expected_schedule = "41 9 * * *"
+else:
+    raise SystemExit("synthetic Scheduler family differs")
+if data.get("schedule") != expected_schedule:
+    raise SystemExit("synthetic Scheduler cadence differs")
+if data.get("timeZone") != "Etc/UTC":
+    raise SystemExit("synthetic Scheduler time zone differs")
+headers = target.get("headers") or {}
+if headers not in ({}, {"User-Agent": "Google-Cloud-Scheduler"}):
+    raise SystemExit("synthetic Scheduler headers differ")
+if target.get("body") not in (None, ""):
+    raise SystemExit("synthetic Scheduler RunJob body differs")
+
+def duration_seconds(value):
+    text = str(value or "")
+    if not text.endswith("s"):
+        raise SystemExit("synthetic Scheduler duration is malformed")
+    return float(text[:-1])
+
+if duration_seconds(data.get("attemptDeadline")) != 300:
+    raise SystemExit("synthetic Scheduler attempt deadline differs")
+retry = data.get("retryConfig") or {}
+if set(retry) != {
+    "retryCount", "maxRetryDuration", "minBackoffDuration",
+    "maxBackoffDuration", "maxDoublings",
+}:
+    raise SystemExit("synthetic Scheduler retry fields differ")
+if int(retry.get("retryCount", -1)) != 0 or int(retry.get("maxDoublings", -1)) != 3:
+    raise SystemExit("synthetic Scheduler retry count/doublings differ")
+if duration_seconds(retry.get("maxRetryDuration")) != 0:
+    raise SystemExit("synthetic Scheduler retry duration differs")
+if duration_seconds(retry.get("minBackoffDuration")) != 5:
+    raise SystemExit("synthetic Scheduler minimum backoff differs")
+if duration_seconds(retry.get("maxBackoffDuration")) != 60:
+    raise SystemExit("synthetic Scheduler maximum backoff differs")
+PY
+  then
+    rm -f "$scheduler_path"
+    return 1
+  fi
+  rm -f "$scheduler_path"
+}
+
+verify_exact_synthetic_inventories() {
+  local expected_file actual_file inventory_file region
+  expected_file="$(mktemp "${TMPDIR:-/tmp}/tr-synthetic-expected-XXXXXX")"
+  actual_file="$(mktemp "${TMPDIR:-/tmp}/tr-synthetic-actual-XXXXXX")"
+  synthetic_inventory_lines >"$expected_file"
+  for region in "${BOOTSTRAP_REGIONS[@]}"; do
+    inventory_file="$(mktemp "${TMPDIR:-/tmp}/tr-synthetic-inventory-XXXXXX")"
+    if ! gc run jobs list --region="$region" --format=json >"$inventory_file"; then
+      rm -f "$expected_file" "$actual_file" "$inventory_file"
+      return 1
+    fi
+    if ! python3 - "$region" "$inventory_file" <<'PY' >>"$actual_file"
+import json
+import sys
+from pathlib import Path
+
+region, path = sys.argv[1:]
+for item in json.loads(Path(path).read_text(encoding="utf-8")):
+    metadata = item.get("metadata") or {}
+    name = str(metadata.get("name") or item.get("name") or "").split("/")[-1]
+    if name.startswith((
+        "trusted-router-synthetic-", "trusted-router-throughput-",
+        "trusted-router-image-generation-", "trusted-router-video-generation-",
+    )):
+        print(region, name, sep="\t")
+PY
+    then
+      rm -f "$expected_file" "$actual_file" "$inventory_file"
+      return 1
+    fi
+    rm -f "$inventory_file"
+  done
+  python3 - "$expected_file" "$actual_file" <<'PY'
+import sys
+from pathlib import Path
+
+expected = {
+    tuple(line.split("\t")[:2])
+    for line in Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+    if line
+}
+actual_rows = [
+    tuple(line.split("\t"))
+    for line in Path(sys.argv[2]).read_text(encoding="utf-8").splitlines()
+    if line
+]
+if len(actual_rows) != len(set(actual_rows)) or set(actual_rows) != expected:
+    raise SystemExit("synthetic Cloud Run Job inventory differs")
+PY
+  rm -f "$actual_file"
+  : >"$actual_file"
+  for region in "${BOOTSTRAP_REGIONS[@]}"; do
+    inventory_file="$(mktemp "${TMPDIR:-/tmp}/tr-scheduler-inventory-XXXXXX")"
+    if ! gc scheduler jobs list --location="$region" --format=json >"$inventory_file"; then
+      rm -f "$expected_file" "$actual_file" "$inventory_file"
+      return 1
+    fi
+    if ! python3 - "$region" "$inventory_file" <<'PY' >>"$actual_file"
+import json
+import sys
+from pathlib import Path
+
+region, path = sys.argv[1:]
+for item in json.loads(Path(path).read_text(encoding="utf-8")):
+    raw = str(item.get("name") or (item.get("metadata") or {}).get("name") or "")
+    name = raw.split("/")[-1]
+    if name.startswith((
+        "trusted-router-synthetic-", "trusted-router-throughput-",
+        "trusted-router-image-generation-", "trusted-router-video-generation-",
+    )):
+        print(region, name, sep="\t")
+PY
+    then
+      rm -f "$expected_file" "$actual_file" "$inventory_file"
+      return 1
+    fi
+    rm -f "$inventory_file"
+  done
+  python3 - "$expected_file" "$actual_file" <<'PY'
+import sys
+from pathlib import Path
+
+expected = {
+    (parts[0], parts[2])
+    for line in Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+    if line
+    for parts in [line.split("\t")]
+}
+actual_rows = [
+    tuple(line.split("\t"))
+    for line in Path(sys.argv[2]).read_text(encoding="utf-8").splitlines()
+    if line
+]
+if len(actual_rows) != len(set(actual_rows)) or set(actual_rows) != expected:
+    raise SystemExit("synthetic Cloud Scheduler inventory differs")
+PY
+  rm -f "$expected_file" "$actual_file"
+}
+
+verify_private_origin_connectivity() {
+  local zone="${TR_PRIVATE_RUN_APP_DNS_ZONE:-trusted-router-private-run-app}"
+  local region subnet_json zone_json apex_json wildcard_json
+  for region in "${BOOTSTRAP_REGIONS[@]}"; do
+    subnet_json="$(gc compute networks subnets describe "$SYNTHETIC_SUBNET" \
+      --region="$region" --format=json)" || return 1
+    jq -e --arg network "$SYNTHETIC_NETWORK" '
+      .privateIpGoogleAccess == true and
+      ((.network // "") | rtrimstr("/") | endswith("/networks/" + $network))
+    ' <<<"$subnet_json" >/dev/null || {
+      echo "ERROR: private internal origin lacks PGA in ${region}" >&2
+      return 1
+    }
+  done
+  zone_json="$(gc dns managed-zones describe "$zone" --format=json)" || return 1
+  jq -e --arg network "$SYNTHETIC_NETWORK" '
+    .dnsName == "run.app." and .visibility == "private" and
+    any(.privateVisibilityConfig.networks[]?;
+      (.networkUrl // "") | rtrimstr("/") | endswith("/networks/" + $network))
+  ' <<<"$zone_json" >/dev/null || return 1
+  apex_json="$(gc dns record-sets describe run.app. --zone="$zone" --type=A --format=json)" || return 1
+  jq -e '(.rrdatas | sort) == [
+    "199.36.153.8", "199.36.153.9", "199.36.153.10", "199.36.153.11"
+  ]' <<<"$apex_json" >/dev/null || return 1
+  wildcard_json="$(gc dns record-sets describe '*.run.app.' \
+    --zone="$zone" --type=CNAME --format=json)" || return 1
+  jq -e '.rrdatas == ["run.app."]' <<<"$wildcard_json" >/dev/null
+}
+
+verify_synthetic_identity_contract() {
+  local synthetic_account_json synthetic_account_policy ancestor_rows
+  local ancestor_type ancestor_id
+  synthetic_account_json="$(gc iam service-accounts describe \
+    "$SYNTHETIC_RUN_SERVICE_ACCOUNT" --format=json)" || return 1
+  jq -e --arg email "$SYNTHETIC_RUN_SERVICE_ACCOUNT" '
+    .email == $email and ((.disabled // false) == false)
+  ' <<<"$synthetic_account_json" >/dev/null || {
+    echo "ERROR: synthetic Job identity is absent or disabled" >&2
+    return 1
+  }
+  synthetic_account_policy="$(gc iam service-accounts get-iam-policy \
+    "$SYNTHETIC_RUN_SERVICE_ACCOUNT" --format=json)" || return 1
+  if ! printf '%s' "$synthetic_account_policy" | python3 -c '
+import json
+import sys
+
+policy = json.load(sys.stdin)
+bindings = policy.get("bindings") or []
+if len(bindings) != 1:
+    raise SystemExit("synthetic identity IAM binding inventory differs")
+binding = bindings[0]
+if binding.get("role") != "roles/iam.serviceAccountUser":
+    raise SystemExit("synthetic identity actAs role differs")
+if binding.get("condition") is not None:
+    raise SystemExit("synthetic identity actAs grant is conditional")
+members = binding.get("members") or []
+if members != [sys.argv[1]]:
+    raise SystemExit("synthetic identity actAs member inventory differs")
+' "serviceAccount:${DEPLOY_SERVICE_ACCOUNT}"; then
+    echo "ERROR: synthetic Job identity IAM is not the narrow reviewed policy" >&2
+    return 1
+  fi
+  verify_exact_unconditional_roles \
+    "project IAM roles on the synthetic Job identity" \
+    "serviceAccount:${SYNTHETIC_RUN_SERVICE_ACCOUNT}" \
+    "" \
+    gc projects get-iam-policy "$PROJECT_ID" || return 1
+  ancestor_rows="$(gc projects get-ancestors "$PROJECT_ID" --format=json | \
+    python3 -c '
+import json
+import re
+import sys
+
+items = json.load(sys.stdin)
+if not isinstance(items, list):
+    raise SystemExit("synthetic identity ancestor inventory is malformed")
+seen = set()
+has_project = False
+for item in items:
+    if not isinstance(item, dict) or set(item) < {"type", "id"}:
+        raise SystemExit("synthetic identity ancestor inventory is malformed")
+    kind = item["type"]
+    identifier = str(item["id"])
+    if kind not in {"project", "folder", "organization"} or not re.fullmatch(r"[A-Za-z0-9._:-]+", identifier):
+        raise SystemExit("synthetic identity ancestor entry is invalid")
+    pair = (kind, identifier)
+    if pair in seen:
+        raise SystemExit("synthetic identity ancestor is duplicated")
+    seen.add(pair)
+    has_project = has_project or (kind == "project" and identifier == sys.argv[1])
+    print(kind, identifier, sep="\t")
+if not has_project:
+    raise SystemExit("synthetic identity ancestor inventory omits project")
+' "$PROJECT_ID")" || return 1
+  while IFS=$'\t' read -r ancestor_type ancestor_id; do
+    [ -n "$ancestor_type" ] || continue
+    case "$ancestor_type" in
+      project)
+        [ "$ancestor_id" = "$PROJECT_ID" ] || {
+          echo "ERROR: synthetic identity ancestor project differs" >&2
+          return 1
+        }
+        ;;
+      folder)
+        verify_exact_unconditional_roles \
+          "folder ancestor IAM roles on the synthetic Job identity" \
+          "serviceAccount:${SYNTHETIC_RUN_SERVICE_ACCOUNT}" "" \
+          gc resource-manager folders get-iam-policy "$ancestor_id" || return 1
+        ;;
+      organization)
+        verify_exact_unconditional_roles \
+          "organization ancestor IAM roles on the synthetic Job identity" \
+          "serviceAccount:${SYNTHETIC_RUN_SERVICE_ACCOUNT}" "" \
+          gc organizations get-iam-policy "$ancestor_id" || return 1
+        ;;
+      *) return 1 ;;
+    esac
+  done <<<"$ancestor_rows"
+}
+
+preflight_legacy_data_mode() {
+  local region service_json revision revision_json region_state expected_state=""
+  for region in "${CONTROL_REGIONS[@]}"; do
+    service_json="$(gc run services describe "$BOOTSTRAP_LEGACY_CONSOLE_SERVICE" \
+      --region="$region" --format=json)" || return 1
+    revision="$(printf '%s' "$service_json" | python3 -c '
+import json
+import sys
+
+service = json.load(sys.stdin)
+traffic = service.get("status", {}).get("traffic", []) or []
+live = [item for item in traffic if int(item.get("percent", 0) or 0) > 0]
+if len(live) != 1 or int(live[0].get("percent", 0)) != 100:
+    raise SystemExit("legacy console traffic is not one unambiguous 100% revision")
+revision = live[0].get("revisionName")
+if not isinstance(revision, str) or not revision:
+    raise SystemExit("legacy console serving revision is absent")
+print(revision)
+')" || return 1
+    revision_json="$(gc run revisions describe "$revision" \
+      --region="$region" --format=json)" || return 1
+    region_state="$(printf '%s' "$revision_json" | python3 -c '
+import json
+import sys
+
+revision = json.load(sys.stdin)
+containers = (revision.get("spec") or {}).get("containers") or []
+if len(containers) != 1:
+    raise SystemExit("legacy console serving container inventory differs")
+env = {
+    item.get("name"): str(item.get("value", ""))
+    for item in containers[0].get("env", []) or []
+    if item.get("name") and "valueFrom" not in item
+}
+secrets = {
+    item.get("name"): {
+        "resource": str(
+            (((item.get("valueFrom") or {}).get("secretKeyRef") or {}).get("name") or "")
+        ).split("/")[-1],
+        "version": str(
+            (((item.get("valueFrom") or {}).get("secretKeyRef") or {}).get("key")
+            or ((item.get("valueFrom") or {}).get("secretKeyRef") or {}).get("version")
+            or "")
+        ),
+    }
+    for item in containers[0].get("env", []) or []
+    if item.get("name") and "valueFrom" in item
+}
+value = {
+    "storage_backend": env.get("TR_STORAGE_BACKEND", "spanner-bigtable"),
+    "analytics_read_mode": env.get("TR_ANALYTICS_READ_MODE", "bigtable"),
+    "request_record_write_mode": env.get("TR_REQUEST_RECORD_WRITE_MODE", ""),
+    "generation_records_enabled": env.get("TR_GENERATION_RECORDS_ENABLED", "true"),
+    "bigtable_mirror_writes_enabled": env.get("TR_BIGTABLE_MIRROR_WRITES_ENABLED", "true"),
+    "analytics_dual_read_started_at": env.get("TR_ANALYTICS_DUAL_READ_STARTED_AT", ""),
+    "analytics_clickhouse_primary_started_at": env.get("TR_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT", ""),
+    "operational_clickhouse_url": env.get("TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_URL", ""),
+    "operational_clickhouse_user": env.get("TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_USER", ""),
+    "operational_clickhouse_database": env.get("TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_DATABASE", ""),
+    "operational_clickhouse_password_secret": secrets.get(
+        "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_PASSWORD", {}
+    ).get("resource", ""),
+    "operational_clickhouse_password_version": secrets.get(
+        "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_PASSWORD", {}
+    ).get("version", ""),
+}
+print(json.dumps(value, sort_keys=True, separators=(",", ":")))
+')" || return 1
+    if [ -z "$expected_state" ]; then
+      expected_state="$region_state"
+    elif [ "$region_state" != "$expected_state" ]; then
+      echo "ERROR: legacy console data mode differs across control regions" >&2
+      return 1
+    fi
+  done
+  BOOTSTRAP_STORAGE_BACKEND="$(jq -er '.storage_backend' <<<"$expected_state")"
+  BOOTSTRAP_ANALYTICS_READ_MODE="$(jq -er '.analytics_read_mode' <<<"$expected_state")"
+  BOOTSTRAP_REQUEST_RECORD_WRITE_MODE="$(jq -er '.request_record_write_mode' <<<"$expected_state")"
+  BOOTSTRAP_GENERATION_RECORDS_ENABLED="$(jq -er '.generation_records_enabled' <<<"$expected_state")"
+  BOOTSTRAP_BIGTABLE_MIRROR_WRITES_ENABLED="$(jq -er '.bigtable_mirror_writes_enabled' <<<"$expected_state")"
+  BOOTSTRAP_ANALYTICS_DUAL_READ_STARTED_AT="$(jq -r '.analytics_dual_read_started_at' <<<"$expected_state")"
+  BOOTSTRAP_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT="$(jq -r '.analytics_clickhouse_primary_started_at' <<<"$expected_state")"
+  BOOTSTRAP_OPERATIONAL_CLICKHOUSE_URL="$(jq -r '.operational_clickhouse_url' <<<"$expected_state")"
+  BOOTSTRAP_OPERATIONAL_CLICKHOUSE_USER="$(jq -r '.operational_clickhouse_user' <<<"$expected_state")"
+  BOOTSTRAP_OPERATIONAL_CLICKHOUSE_DATABASE="$(jq -r '.operational_clickhouse_database' <<<"$expected_state")"
+  BOOTSTRAP_OPERATIONAL_CLICKHOUSE_PASSWORD_SECRET="$(jq -r '.operational_clickhouse_password_secret' <<<"$expected_state")"
+  BOOTSTRAP_OPERATIONAL_CLICKHOUSE_PASSWORD_VERSION="$(jq -r '.operational_clickhouse_password_version' <<<"$expected_state")"
+  case "$BOOTSTRAP_STORAGE_BACKEND:$BOOTSTRAP_ANALYTICS_READ_MODE:$BOOTSTRAP_REQUEST_RECORD_WRITE_MODE:$BOOTSTRAP_GENERATION_RECORDS_ENABLED:$BOOTSTRAP_BIGTABLE_MIRROR_WRITES_ENABLED" in
+    spanner-bigtable:bigtable:typed:true:true)
+      [ -z "$BOOTSTRAP_OPERATIONAL_CLICKHOUSE_URL" ] && \
+        [ -z "$BOOTSTRAP_OPERATIONAL_CLICKHOUSE_USER" ] && \
+        [ -z "$BOOTSTRAP_OPERATIONAL_CLICKHOUSE_DATABASE" ] && \
+        [ -z "$BOOTSTRAP_OPERATIONAL_CLICKHOUSE_PASSWORD_SECRET" ] && \
+        [ -z "$BOOTSTRAP_OPERATIONAL_CLICKHOUSE_PASSWORD_VERSION" ] || {
+          echo "ERROR: Bigtable mode has stale operational ClickHouse bindings" >&2
+          return 1
+        }
+      ;;
+    spanner-clickhouse:clickhouse-only:typed:true:false)
+      [ "$BOOTSTRAP_OPERATIONAL_CLICKHOUSE_USER" = tr_control_read ] && \
+        [ "$BOOTSTRAP_OPERATIONAL_CLICKHOUSE_DATABASE" = tr ] && \
+        [ "$BOOTSTRAP_OPERATIONAL_CLICKHOUSE_PASSWORD_SECRET" = trustedrouter-clickhouse-control-read-password ] && \
+        [[ "$BOOTSTRAP_OPERATIONAL_CLICKHOUSE_PASSWORD_VERSION" =~ ^[1-9][0-9]*$ ]] || {
+          echo "ERROR: serving ClickHouse credentials differ from the canonical internal contract" >&2
+          return 1
+        }
+      python3 - "$BOOTSTRAP_OPERATIONAL_CLICKHOUSE_URL" <<'PY' || return 1
+import ipaddress
+import sys
+from urllib.parse import urlsplit
+
+parsed = urlsplit(sys.argv[1])
+if parsed.scheme not in {"http", "https"} or not parsed.hostname or parsed.username or parsed.password or parsed.query or parsed.fragment:
+    raise SystemExit("serving operational ClickHouse URL is malformed")
+try:
+    private = ipaddress.ip_address(parsed.hostname).is_private
+except ValueError:
+    private = parsed.hostname.endswith(".internal")
+if not private:
+    raise SystemExit("serving operational ClickHouse URL is not private")
+PY
+      ;;
+    *)
+      echo "ERROR: legacy data mode is not a reviewed bootstrap contract" >&2
+      return 1
+      ;;
+  esac
+}
+
+verify_artifact_live() {
+  local artifact_rows region revision digest
+  artifact_rows="$(validate_artifact_and_emit_services "$EXPECTED_IMAGE")" || return 1
+  ARTIFACT_RELEASE="$(jq -er '.release' "$ARTIFACT")" || return 1
+  ARTIFACT_STORAGE_BACKEND="$(jq -er '.data_mode.storage_backend' "$ARTIFACT")"
+  ARTIFACT_ANALYTICS_READ_MODE="$(jq -er '.data_mode.analytics_read_mode' "$ARTIFACT")"
+  ARTIFACT_REQUEST_RECORD_WRITE_MODE="$(jq -er '.data_mode.request_record_write_mode' "$ARTIFACT")"
+  ARTIFACT_GENERATION_RECORDS_ENABLED="$(jq -er '.data_mode.generation_records_enabled' "$ARTIFACT")"
+  ARTIFACT_BIGTABLE_MIRROR_WRITES_ENABLED="$(jq -er '.data_mode.bigtable_mirror_writes_enabled' "$ARTIFACT")"
+  ARTIFACT_ANALYTICS_DUAL_READ_STARTED_AT="$(jq -r '.data_mode.analytics_dual_read_started_at' "$ARTIFACT")"
+  ARTIFACT_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT="$(jq -r '.data_mode.analytics_clickhouse_primary_started_at' "$ARTIFACT")"
+  ARTIFACT_OPERATIONAL_CLICKHOUSE_URL="$(jq -r '.data_mode.operational_clickhouse_url' "$ARTIFACT")"
+  ARTIFACT_OPERATIONAL_CLICKHOUSE_USER="$(jq -r '.data_mode.operational_clickhouse_user' "$ARTIFACT")"
+  ARTIFACT_OPERATIONAL_CLICKHOUSE_DATABASE="$(jq -r '.data_mode.operational_clickhouse_database' "$ARTIFACT")"
+  bash "${SCRIPT_DIR}/rollout_iam_verify.sh" --project "$PROJECT_ID"
+  verify_synthetic_identity_contract
+  verify_private_origin_connectivity
+  while IFS=$'\t' read -r region revision digest; do
+    [ -n "$region" ] || continue
+    verify_live_internal_service "$region" "$revision" "$digest"
+  done <<<"$artifact_rows"
+  verify_exact_synthetic_inventories
+  while IFS=$'\t' read -r region job_name scheduler_name; do
+    [ -n "$region" ] || continue
+    verify_synthetic_job_target "$region" "$job_name" "$scheduler_name"
+  done < <(synthetic_inventory_lines)
+  log "internal bootstrap artifact and synthetic cutover are verified"
+}
+
+if [ "$MODE" = verify ]; then
+  [[ "$EXPECTED_IMAGE" =~ ^[^,\|[:space:]@]+@sha256:[0-9a-f]{64}$ ]] || {
+    echo "ERROR: bootstrap verification requires an immutable expected image" >&2
+    exit 1
+  }
+  verify_artifact_live
+  exit 0
+fi
+
+[ ! -e "$ARTIFACT" ] || {
+  echo "ERROR: refusing to overwrite internal bootstrap artifact ${ARTIFACT}" >&2
+  exit 1
+}
+
+[ -n "${TR_LEGACY_HARDENING_ARTIFACT:-}" ] || {
+  echo "ERROR: internal bootstrap requires TR_LEGACY_HARDENING_ARTIFACT" >&2
+  exit 1
+}
+bash "${SCRIPT_DIR}/rollout_legacy_harden.sh" \
+  --verify-artifact "$TR_LEGACY_HARDENING_ARTIFACT" || exit 1
+
+preflight_initial_split_boundary() {
+  local https_proxy="${TR_HTTPS_PROXY:-trusted-router-control-https-proxy}"
+  local url_map_name url_map_json
+  [[ "$https_proxy" =~ ^[a-z][a-z0-9-]{0,61}[a-z0-9]$ ]] || {
+    echo "ERROR: internal bootstrap HTTPS proxy name is invalid" >&2
+    return 1
+  }
+  url_map_name="$(gc compute target-https-proxies describe "$https_proxy" \
+    --global --format='value(urlMap.basename())')" || return 1
+  [[ "$url_map_name" =~ ^[a-z][a-z0-9-]{0,61}[a-z0-9]$ ]] || {
+    echo "ERROR: internal bootstrap could not resolve the active HTTPS URL map" >&2
+    return 1
+  }
+  url_map_json="$(gc compute url-maps describe "$url_map_name" \
+    --global --format=json)" || return 1
+  if jq -e 'any(.pathMatchers[]?; .name == "trusted-router-service-surfaces")' \
+      <<<"$url_map_json" >/dev/null; then
+    echo "ERROR: internal bootstrap is initial-split-only; the six-surface URL map is already active" >&2
+    return 1
+  fi
+}
+preflight_initial_split_boundary
+
+# Use the same complete six-runtime IAM/Secret Manager inventory gate as the
+# main stage. Bootstrap is allowed to create a revision only after that
+# verifier proves the current project is already least-privilege.
+bash "${SCRIPT_DIR}/rollout_iam_verify.sh" --project "$PROJECT_ID"
+# This script never creates or grants the seventh identity. Its separately
+# approved least-privilege bootstrap must exist before any internal revision is
+# staged, otherwise the synthetic cutover has no safe runtime principal.
+verify_synthetic_identity_contract
+preflight_legacy_data_mode
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tr-internal-bootstrap-XXXXXX")"
+trap 'rm -rf "$WORK_DIR"' EXIT
+ENTRIES_FILE="${WORK_DIR}/services.jsonl"
+: >"$ENTRIES_FILE"
+chmod 600 "$ENTRIES_FILE"
+
+RELEASE="${TR_RELEASE:-$(git rev-parse --short HEAD 2>/dev/null || echo local)}"
+[[ "$RELEASE" =~ ^[A-Za-z0-9._-]{1,128}$ ]] || {
+  echo "ERROR: bootstrap release is invalid" >&2
+  exit 1
+}
+if [ -n "${TR_INTERNAL_BOOTSTRAP_REVISION_SUFFIX:-}" ]; then
+  REVISION_SUFFIX="$TR_INTERNAL_BOOTSTRAP_REVISION_SUFFIX"
+elif [ -e "$JOURNAL" ] || [ -L "$JOURNAL" ]; then
+  # Recovery without an explicit override must resume the exact recorded
+  # revision name. Generating a fresh suffix here would turn a retry into a
+  # second bootstrap cohort.
+  REVISION_SUFFIX="$(read_journal_revision_suffix)"
+else
+  REVISION_SUFFIX="ib$(date -u +%Y%m%d%H%M%S)-${GITHUB_RUN_ATTEMPT:-0}"
+fi
+[[ "$REVISION_SUFFIX" =~ ^[a-z][a-z0-9-]{0,34}[a-z0-9]$ ]] || {
+  echo "ERROR: internal bootstrap revision suffix is invalid" >&2
+  exit 1
+}
+
+IMAGE_METADATA="$(gc artifacts docker images describe "$IMAGE" --format=json)" || {
+  echo "ERROR: bootstrap image does not exist: ${IMAGE}" >&2
+  exit 1
+}
+IMAGE="$(jq -er '
+  .image_summary.fully_qualified_digest //
+  .imageSummary.fullyQualifiedDigest //
+  .fully_qualified_digest //
+  .fullyQualifiedDigest
+' <<<"$IMAGE_METADATA")" || {
+  echo "ERROR: bootstrap image did not resolve to a digest" >&2
+  exit 1
+}
+[[ "$IMAGE" =~ ^[^,\|[:space:]@]+@sha256:[0-9a-f]{64}$ ]] || {
+  echo "ERROR: bootstrap image digest is invalid" >&2
+  exit 1
+}
+
+account_json="$(gc iam service-accounts describe "$INTERNAL_RUN_SERVICE_ACCOUNT" --format=json)"
+jq -e --arg email "$INTERNAL_RUN_SERVICE_ACCOUNT" '
+  .email == $email and ((.disabled // false) == false)
+' <<<"$account_json" >/dev/null || {
+  echo "ERROR: internal runtime service account is missing or disabled" >&2
+  exit 1
+}
+account_policy="$(gc iam service-accounts get-iam-policy \
+  "$INTERNAL_RUN_SERVICE_ACCOUNT" --format=json)"
+jq -e --arg member "serviceAccount:${DEPLOY_SERVICE_ACCOUNT}" '
+  ([.bindings[]? | select(any(.members[]?; . == $member))
+    | {role, condition: (.condition // null)}] | unique)
+  == [{role:"roles/iam.serviceAccountUser",condition:null}]
+' <<<"$account_policy" >/dev/null || {
+  echo "ERROR: deploy identity lacks exact actAs on internal runtime identity" >&2
+  exit 1
+}
+
+SECRET_BINDINGS=(
+  "TR_SENTRY_DSN=trustedrouter-sentry-dsn"
+  "TR_INTERNAL_GATEWAY_TOKEN=trustedrouter-internal-gateway-token"
+  "TR_OBSERVER_INTERNAL_TOKEN=trustedrouter-observer-internal-token"
+  "TR_SYNTHETIC_MONITOR_API_KEY=trustedrouter-synthetic-monitor-api-key"
+  "TR_STRIPE_SECRET_KEY=trustedrouter-internal-stripe-payment-intents-key"
+  "TR_AWS_ACCESS_KEY_ID=trustedrouter-internal-ses-access-key-id"
+  "TR_AWS_SECRET_ACCESS_KEY=trustedrouter-internal-ses-secret-access-key"
+)
+if [ "$BOOTSTRAP_ANALYTICS_READ_MODE" != bigtable ]; then
+  SECRET_BINDINGS+=(
+    "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_PASSWORD=trustedrouter-clickhouse-control-read-password"
+  )
+fi
+PINNED_SECRETS=()
+for binding in "${SECRET_BINDINGS[@]}"; do
+  env_name="${binding%%=*}"
+  secret="${binding#*=}"
+  gc secrets describe "$secret" >/dev/null
+  if [ "$env_name" = TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_PASSWORD ]; then
+    requested_version="$BOOTSTRAP_OPERATIONAL_CLICKHOUSE_PASSWORD_VERSION"
+  else
+    requested_version=latest
+  fi
+  version_json="$(gc secrets versions describe "$requested_version" \
+    --secret="$secret" --format=json)"
+  version="$(jq -er 'select(.state == "ENABLED") | .name | split("/")[-1]' \
+    <<<"$version_json")" || {
+      echo "ERROR: bootstrap secret ${secret}:${requested_version} is not enabled" >&2
+      exit 1
+    }
+  [[ "$version" =~ ^[1-9][0-9]*$ ]] || {
+    echo "ERROR: bootstrap secret ${secret} did not resolve numerically" >&2
+    exit 1
+  }
+  if [ "$requested_version" != latest ] && [ "$version" != "$requested_version" ]; then
+    echo "ERROR: serving ClickHouse password version resolution differs" >&2
+    exit 1
+  fi
+  secret_policy="$(gc secrets get-iam-policy "$secret" --format=json)"
+  jq -e --arg member "serviceAccount:${INTERNAL_RUN_SERVICE_ACCOUNT}" '
+    ([.bindings[]? | select(any(.members[]?; . == $member))
+      | {role, condition: (.condition // null)}] | unique)
+    == [{role:"roles/secretmanager.secretAccessor",condition:null}]
+  ' <<<"$secret_policy" >/dev/null || {
+    echo "ERROR: internal identity lacks exact secretAccessor on ${secret}" >&2
+    exit 1
+  }
+  PINNED_SECRETS+=("${env_name}=${secret}:${version}")
+done
+
+verify_private_origin_connectivity
+
+ENV_VARS=(
+  "TR_ENVIRONMENT=production"
+  "TR_RELEASE=${RELEASE}"
+  "TR_SERVICE_SURFACE=internal"
+  "TR_API_BASE_URL=https://api.trustedrouter.com/v1"
+  "TR_TRUSTED_DOMAIN=trustedrouter.com"
+  "TR_TRUSTED_DOMAIN_ALIASES=allyrouter.com,uptimerouter.com"
+  "TR_GCP_PROJECT_ID=${PROJECT_ID}"
+  "TR_REGIONS=${TR_REGIONS}"
+  "TR_PRIMARY_REGION=${TR_PRIMARY_REGION}"
+  "TR_ENABLE_LIVE_PROVIDERS=false"
+  "TR_RATE_LIMIT_CLIENT_IP_MODE=edge_header"
+  "TR_MAX_REQUEST_BODY_BYTES=33554432"
+  "TR_MAX_IN_FLIGHT_REQUEST_BODY_BYTES=67108864"
+  "TR_MAX_CONCURRENT_REQUEST_BODIES=4"
+  "TR_REQUEST_BODY_READ_TIMEOUT_SECONDS=30"
+  "TR_REMEDIATOR_IN_PROCESS_ENABLED=false"
+  "TR_SYNTHETIC_SCHEDULER_INTERVAL_SECONDS=0"
+  "TR_ACTIVATION_REMINDER_INTERVAL_SECONDS=0"
+  "TR_REGIONAL_QUOTA_LEASES_ENABLED=false"
+  "TR_STORAGE_BACKEND=${BOOTSTRAP_STORAGE_BACKEND}"
+  "TR_SPANNER_INSTANCE_ID=${SPANNER_INSTANCE_ID}"
+  "TR_SPANNER_DATABASE_ID=${SPANNER_DATABASE_ID}"
+  "TR_BIGTABLE_INSTANCE_ID=${BIGTABLE_INSTANCE_ID}"
+  "TR_BIGTABLE_GENERATION_TABLE=${BIGTABLE_GENERATION_TABLE}"
+  "TR_SPANNER_POOL_SIZE=8"
+  "TR_BIGTABLE_MIRROR_WRITES_ENABLED=${BOOTSTRAP_BIGTABLE_MIRROR_WRITES_ENABLED}"
+  "TR_GENERATION_RECORDS_ENABLED=${BOOTSTRAP_GENERATION_RECORDS_ENABLED}"
+  "TR_ANALYTICS_READ_MODE=${BOOTSTRAP_ANALYTICS_READ_MODE}"
+  "TR_ANALYTICS_DUAL_READ_STARTED_AT=${BOOTSTRAP_ANALYTICS_DUAL_READ_STARTED_AT}"
+  "TR_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT=${BOOTSTRAP_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT}"
+  "TR_REQUEST_RECORD_WRITE_MODE=${BOOTSTRAP_REQUEST_RECORD_WRITE_MODE}"
+  "TR_SETTLE_OUTBOX_ENABLED=true"
+  "TR_ANALYTICS_OUTBOX_ENABLED=true"
+  "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true"
+  "TR_BYOK_KMS_KEY_NAME=${BYOK_KMS_KEY_NAME}"
+  "TR_AWS_REGION=us-east-1"
+  "TR_SES_FROM_EMAIL=alerts@alerts.trustedrouter.com"
+  "TR_SES_FROM_NAME=TrustedRouter Alerts"
+  "TR_SES_ALERT_FROM_EMAIL=alerts@alerts.trustedrouter.com"
+  "TR_SES_ALERT_FROM_NAME=TrustedRouter Alerts"
+  "TR_SES_ALERT_CONFIGURATION_SET=trustedrouter-alerts"
+)
+if [ "$BOOTSTRAP_ANALYTICS_READ_MODE" != bigtable ]; then
+  ENV_VARS+=(
+    "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_URL=${BOOTSTRAP_OPERATIONAL_CLICKHOUSE_URL}"
+    "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_USER=${BOOTSTRAP_OPERATIONAL_CLICKHOUSE_USER}"
+    "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_DATABASE=${BOOTSTRAP_OPERATIONAL_CLICKHOUSE_DATABASE}"
+  )
+fi
+SET_ENV_VARS="$(IFS='|'; echo "^|^${ENV_VARS[*]}")"
+SET_SECRETS="$(IFS=,; echo "${PINNED_SECRETS[*]}")"
+
+EXPECTED_ENV_FILE="${WORK_DIR}/expected-env.json"
+EXPECTED_SECRET_FILE="${WORK_DIR}/expected-secrets.json"
+printf '%s\n' "${ENV_VARS[@]}" | jq -Rn '
+  [inputs | capture("^(?<name>[^=]+)=(?<value>.*)$")] | from_entries
+' >"$EXPECTED_ENV_FILE"
+printf '%s\n' "${PINNED_SECRETS[@]}" | jq -Rn '
+  [inputs | capture("^(?<name>[^=]+)=(?<resource>.*):(?<version>[1-9][0-9]*)$")
+    | {key: .name, value: {resource: .resource, version: .version}}] | from_entries
+' >"$EXPECTED_SECRET_FILE"
+chmod 600 "$EXPECTED_ENV_FILE" "$EXPECTED_SECRET_FILE"
+
+verify_bootstrap_candidate() {
+  local region="$1" candidate="$2" require_serving="$3"
+  local service_json service_path service_iam
+  service_path="${WORK_DIR}/service-${region}.json"
+  service_json="$(gc run services describe "$INTERNAL_SERVICE" \
+    --region="$region" --format=json)" || return 1
+  printf '%s' "$service_json" >"$service_path"
+  service_iam="$(gc run services get-iam-policy "$INTERNAL_SERVICE" \
+    --region="$region" --format=json)" || return 1
+  jq -e '
+    [.bindings[]? | select(any(.members[]?; . == "allUsers"))
+      | {role, condition: (.condition // null),
+         allUsersCount: ([.members[]? | select(. == "allUsers")] | length)}]
+    == [{role:"roles/run.invoker",condition:null,allUsersCount:1}]
+  ' <<<"$service_iam" >/dev/null || return 1
+  if ! python3 - "$service_path" "$EXPECTED_ENV_FILE" "$EXPECTED_SECRET_FILE" \
+    "$candidate" "$INTERNAL_RUN_SERVICE_ACCOUNT" "$IMAGE" 2Gi 1 8080 \
+    "$CLOUD_RUN_NETWORK" "$CLOUD_RUN_SUBNET" private-ranges-only \
+    /ready 0 10 10 18 "$PROJECT_ID" "$require_serving" \
+    "https://${INTERNAL_SERVICE}-${PROJECT_NUMBER}.${region}.run.app" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+(
+    service_path,
+    env_path,
+    secret_path,
+    candidate,
+    account,
+    expected_image,
+    memory,
+    cpu,
+    port,
+    network,
+    subnet,
+    vpc_egress,
+    probe_path,
+    probe_initial_delay,
+    probe_timeout,
+    probe_period,
+    probe_failures,
+    project,
+    require_serving,
+    expected_url,
+) = sys.argv[1:]
+service = json.loads(Path(service_path).read_text(encoding="utf-8"))
+expected_env = json.loads(Path(env_path).read_text(encoding="utf-8"))
+expected_secrets = json.loads(Path(secret_path).read_text(encoding="utf-8"))
+metadata = service.get("metadata") or {}
+annotations = metadata.get("annotations") or {}
+spec = service.get("spec") or {}
+template = spec.get("template") or {}
+template_annotations = (template.get("metadata") or {}).get("annotations") or {}
+template_spec = template.get("spec") or {}
+status = service.get("status") or {}
+if status.get("latestCreatedRevisionName") != candidate or status.get("latestReadyRevisionName") != candidate:
+    raise SystemExit("internal bootstrap candidate is not latest Ready")
+if not any(item.get("type") == "Ready" and item.get("status") == "True" for item in status.get("conditions", [])):
+    raise SystemExit("internal bootstrap candidate is not Ready")
+if str(status.get("observedGeneration")) != str(metadata.get("generation")):
+    raise SystemExit("internal bootstrap generation is unobserved")
+if annotations.get("run.googleapis.com/ingress") != "internal-and-cloud-load-balancing":
+    raise SystemExit("internal bootstrap ingress differs")
+if annotations.get("run.googleapis.com/ingress-status") != "internal-and-cloud-load-balancing":
+    raise SystemExit("internal bootstrap effective ingress differs")
+if str(annotations.get("run.googleapis.com/default-url-disabled", "false")).lower() not in {"", "false"}:
+    raise SystemExit("internal bootstrap default URL is disabled")
+if status.get("url") != expected_url:
+    raise SystemExit("internal bootstrap default URL differs")
+if template_spec.get("serviceAccountName") != account:
+    raise SystemExit("internal bootstrap identity differs")
+if int(template_spec.get("containerConcurrency", -1)) != 8:
+    raise SystemExit("internal bootstrap concurrency differs")
+if str(template_spec.get("timeoutSeconds", "")).removesuffix("s") != "300":
+    raise SystemExit("internal bootstrap timeout differs")
+if str(template_annotations.get("autoscaling.knative.dev/minScale")) != "2":
+    raise SystemExit("internal bootstrap minimum differs")
+if str(template_annotations.get("autoscaling.knative.dev/maxScale")) != "50":
+    raise SystemExit("internal bootstrap revision maximum differs")
+if str((spec.get("scaling") or {}).get("maxInstanceCount")) != "50":
+    raise SystemExit("internal bootstrap service maximum differs")
+containers = template_spec.get("containers") or []
+if len(containers) != 1:
+    raise SystemExit("internal bootstrap container count differs")
+container = containers[0]
+if container.get("image") != expected_image:
+    raise SystemExit("internal bootstrap image differs")
+if container.get("command") not in (None, []):
+    raise SystemExit("internal bootstrap container command differs")
+if container.get("args") not in (None, []):
+    raise SystemExit("internal bootstrap container arguments differ")
+if container.get("volumeMounts") not in (None, []):
+    raise SystemExit("internal bootstrap container volume mounts differ")
+if template_spec.get("volumes") not in (None, []):
+    raise SystemExit("internal bootstrap volumes differ")
+if template_spec.get("initContainers") not in (None, []):
+    raise SystemExit("internal bootstrap init containers differ")
+ports = container.get("ports") or []
+if len(ports) != 1 or int(ports[0].get("containerPort", -1)) != int(port):
+    raise SystemExit("internal bootstrap container port differs")
+limits = (container.get("resources") or {}).get("limits") or {}
+if str(limits.get("memory")) != memory:
+    raise SystemExit("internal bootstrap memory differs")
+actual_cpu = str(limits.get("cpu") or "")
+if actual_cpu not in {cpu, f"{int(cpu) * 1000}m"}:
+    raise SystemExit("internal bootstrap CPU differs")
+network_interfaces_raw = template_annotations.get("run.googleapis.com/network-interfaces")
+try:
+    network_interfaces = json.loads(network_interfaces_raw)
+except (TypeError, ValueError):
+    raise SystemExit("internal bootstrap VPC network annotation is invalid") from None
+if not isinstance(network_interfaces, list) or len(network_interfaces) != 1:
+    raise SystemExit("internal bootstrap VPC network interface count differs")
+
+def exact_resource(value, kind, expected):
+    text = str(value or "").rstrip("/")
+    if text == expected:
+        return True
+    if f"/projects/{project}/" not in f"/{text}":
+        return False
+    return text.endswith(f"/{kind}/{expected}")
+
+interface = network_interfaces[0]
+if not exact_resource(interface.get("network"), "networks", network):
+    raise SystemExit("internal bootstrap VPC network differs")
+if not exact_resource(interface.get("subnetwork"), "subnetworks", subnet):
+    raise SystemExit("internal bootstrap VPC subnet differs")
+if template_annotations.get("run.googleapis.com/vpc-access-egress") != vpc_egress:
+    raise SystemExit("internal bootstrap VPC egress differs")
+probe = container.get("startupProbe") or {}
+http_get = probe.get("httpGet") or {}
+if http_get.get("path") != probe_path:
+    raise SystemExit("internal bootstrap /ready probe is absent")
+if http_get.get("port") is not None and int(http_get["port"]) != int(port):
+    raise SystemExit("internal bootstrap startup probe port differs")
+expected_probe = {
+    "initialDelaySeconds": int(probe_initial_delay),
+    "timeoutSeconds": int(probe_timeout),
+    "periodSeconds": int(probe_period),
+    "failureThreshold": int(probe_failures),
+}
+for name, expected in expected_probe.items():
+    if int(probe.get(name, -1)) != expected:
+        raise SystemExit(f"internal bootstrap startup probe {name} differs")
+env_items = container.get("env", []) or []
+env_names = [item.get("name") for item in env_items]
+if any(not name for name in env_names) or len(env_names) != len(set(env_names)):
+    raise SystemExit("internal bootstrap environment contains missing or duplicate names")
+actual_env = {}
+actual_secrets = {}
+for item in env_items:
+    name = item.get("name")
+    if "valueFrom" not in item:
+        actual_env[name] = str(item.get("value", ""))
+        continue
+    reference = (item.get("valueFrom") or {}).get("secretKeyRef") or {}
+    actual_secrets[name] = {
+        "resource": str(reference.get("name") or "").split("/")[-1],
+        "version": str(reference.get("key") or reference.get("version") or ""),
+    }
+if actual_env != expected_env or actual_secrets != expected_secrets:
+    raise SystemExit("internal bootstrap exact env/secret allowlist differs")
+positive = [item for item in status.get("traffic", []) if int(item.get("percent", 0) or 0) > 0]
+if require_serving == "true":
+    def exact_sole_target(items):
+        return (
+            len(items) == 1
+            and items[0].get("revisionName") == candidate
+            and int(items[0].get("percent", 0) or 0) == 100
+            and not items[0].get("tag")
+            and not items[0].get("latestRevision", False)
+        )
+    if not exact_sole_target(spec.get("traffic") or []):
+        raise SystemExit("internal bootstrap desired traffic inventory differs")
+    if not exact_sole_target(status.get("traffic") or []):
+        raise SystemExit("internal bootstrap candidate is not sole 100% target")
+else:
+    candidate_percent = sum(int(item.get("percent", 0) or 0) for item in positive if item.get("revisionName") == candidate)
+    if candidate_percent not in {0, 100}:
+        raise SystemExit("internal bootstrap candidate has partial pre-promotion traffic")
+PY
+  then
+    return 1
+  fi
+  python3 "$STATE_TOOL" hash-service "$service_path"
+}
+
+validate_journal_and_emit_states() {
+  python3 - "$JOURNAL" "$PROJECT_ID" "$IMAGE" "$RELEASE" \
+    "$REVISION_SUFFIX" "$BOOTSTRAP_REGION_CSV" "$INTERNAL_SERVICE" \
+    "$INTERNAL_RUN_SERVICE_ACCOUNT" "$BOOTSTRAP_OPERATION_ID" <<'PY'
+import json
+import os
+import re
+import stat
+import sys
+from pathlib import Path
+
+(
+    raw_path,
+    project,
+    image,
+    release,
+    revision_suffix,
+    raw_regions,
+    service,
+    account,
+    operation_id,
+) = sys.argv[1:]
+path = Path(raw_path)
+if path.is_symlink() or not path.is_file():
+    raise SystemExit("bootstrap state must be a regular non-symlink file")
+if stat.S_IMODE(os.stat(path).st_mode) != 0o600:
+    raise SystemExit("bootstrap state must have mode 0600")
+value = json.loads(path.read_text(encoding="utf-8"))
+fields = {
+    "schema_version", "kind", "project_id", "image", "release",
+    "created_at", "revision_suffix", "regions", "internal_service",
+    "runtime_service_account", "operation_id", "region_states",
+}
+if not isinstance(value, dict) or set(value) != fields:
+    raise SystemExit("bootstrap state fields differ from schema v1")
+if value["schema_version"] != 1 or value["kind"] != "trusted-router-internal-bootstrap-state":
+    raise SystemExit("bootstrap state schema/kind is unsupported")
+expected = {
+    "project_id": project,
+    "image": image,
+    "release": release,
+    "revision_suffix": revision_suffix,
+    "regions": raw_regions.split(","),
+    "internal_service": service,
+    "runtime_service_account": account,
+    "operation_id": operation_id,
+}
+for field, expected_value in expected.items():
+    if value[field] != expected_value:
+        raise SystemExit(f"bootstrap state {field} differs")
+if not isinstance(value["created_at"], str) or not re.fullmatch(
+    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", value["created_at"]
+):
+    raise SystemExit("bootstrap state timestamp is invalid")
+states = value["region_states"]
+regions = expected["regions"]
+if not isinstance(states, list) or len(states) != len(regions):
+    raise SystemExit("bootstrap state region inventory differs")
+seen = set()
+allowed_states = {"pending", "deploy_intent", "deployed", "traffic_intent", "settled"}
+for item in states:
+    if not isinstance(item, dict) or set(item) != {"region", "state"}:
+        raise SystemExit("bootstrap region state fields differ")
+    region = item["region"]
+    state = item["state"]
+    if region not in regions or region in seen or state not in allowed_states:
+        raise SystemExit("bootstrap region state is invalid")
+    seen.add(region)
+    print(region, state, sep="\t")
+if seen != set(regions):
+    raise SystemExit("bootstrap state region inventory is incomplete")
+PY
+}
+
+create_bootstrap_journal() {
+  python3 - "$JOURNAL" "$PROJECT_ID" "$IMAGE" "$RELEASE" \
+    "$REVISION_SUFFIX" "$BOOTSTRAP_REGION_CSV" "$INTERNAL_SERVICE" \
+    "$INTERNAL_RUN_SERVICE_ACCOUNT" "$BOOTSTRAP_OPERATION_ID" \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" <<'PY'
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+(
+    raw_path,
+    project,
+    image,
+    release,
+    revision_suffix,
+    raw_regions,
+    service,
+    account,
+    operation_id,
+    created_at,
+) = sys.argv[1:]
+path = Path(raw_path)
+value = {
+    "schema_version": 1,
+    "kind": "trusted-router-internal-bootstrap-state",
+    "project_id": project,
+    "image": image,
+    "release": release,
+    "created_at": created_at,
+    "revision_suffix": revision_suffix,
+    "regions": raw_regions.split(","),
+    "internal_service": service,
+    "runtime_service_account": account,
+    "operation_id": operation_id,
+    "region_states": [
+        {"region": region, "state": "pending"}
+        for region in raw_regions.split(",")
+    ],
+}
+descriptor, temporary = tempfile.mkstemp(
+    dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+)
+try:
+    os.fchmod(descriptor, 0o600)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+        json.dump(value, output, indent=2, sort_keys=True)
+        output.write("\n")
+        output.flush()
+        os.fsync(output.fileno())
+    # link() is the atomic no-replace publish operation: concurrent bootstrap
+    # attempts cannot overwrite or adopt one another's provenance state.
+    os.link(temporary, path)
+    directory = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory)
+    finally:
+        os.close(directory)
+    os.unlink(temporary)
+except BaseException:
+    try:
+        os.unlink(temporary)
+    except FileNotFoundError:
+        pass
+    raise
+PY
+}
+
+journal_region_state() {
+  local wanted_region="$1"
+  validate_journal_and_emit_states | while IFS=$'\t' read -r region state; do
+    if [ "$region" = "$wanted_region" ]; then
+      printf '%s\n' "$state"
+    fi
+    true
+  done
+}
+
+journal_transition() {
+  local region="$1" old_state="$2" new_state="$3"
+  validate_journal_and_emit_states >/dev/null
+  python3 - "$JOURNAL" "$region" "$old_state" "$new_state" <<'PY'
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+path = Path(sys.argv[1])
+region, old_state, new_state = sys.argv[2:]
+allowed = {
+    ("pending", "deploy_intent"),
+    ("deploy_intent", "deployed"),
+    ("deployed", "traffic_intent"),
+    ("traffic_intent", "settled"),
+}
+if (old_state, new_state) not in allowed:
+    raise SystemExit("invalid bootstrap state transition")
+value = json.loads(path.read_text(encoding="utf-8"))
+matches = [item for item in value["region_states"] if item["region"] == region]
+if len(matches) != 1 or matches[0]["state"] != old_state:
+    raise SystemExit("bootstrap state changed concurrently")
+matches[0]["state"] = new_state
+descriptor, temporary = tempfile.mkstemp(
+    dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+)
+try:
+    os.fchmod(descriptor, 0o600)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+        json.dump(value, output, indent=2, sort_keys=True)
+        output.write("\n")
+        output.flush()
+        os.fsync(output.fileno())
+    os.replace(temporary, path)
+    directory = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory)
+    finally:
+        os.close(directory)
+except BaseException:
+    try:
+        os.unlink(temporary)
+    except FileNotFoundError:
+        pass
+    raise
+PY
+}
+
+internal_service_presence() {
+  local region="$1" output_path error_path
+  output_path="${WORK_DIR}/presence-${region}.json"
+  error_path="${WORK_DIR}/presence-${region}.err"
+  if gc run services describe "$INTERNAL_SERVICE" \
+      --region="$region" --format=json >"$output_path" 2>"$error_path"; then
+    printf '%s\n' present
+    return 0
+  fi
+  if grep -Eqi 'NOT_FOUND|not[ -]found|does not exist' "$error_path"; then
+    printf '%s\n' absent
+    return 0
+  fi
+  cat "$error_path" >&2
+  echo "ERROR: could not prove internal service absence in ${region}" >&2
+  return 1
+}
+
+preflight_bootstrap_provenance() {
+  local region state presence rows
+  if [ ! -e "$JOURNAL" ] && [ ! -L "$JOURNAL" ]; then
+    # A new journal is permitted only when the entire reviewed region cohort
+    # is absent. Any existing service is unrecorded and must be investigated,
+    # never adopted by matching its current shape after the fact.
+    for region in "${BOOTSTRAP_REGIONS[@]}"; do
+      presence="$(internal_service_presence "$region")" || return 1
+      [ "$presence" = absent ] || {
+        echo "ERROR: unrecorded internal service exists in ${region}; refusing bootstrap" >&2
+        return 1
+      }
+    done
+    create_bootstrap_journal
+  fi
+
+  rows="$(validate_journal_and_emit_states)" || return 1
+  while IFS=$'\t' read -r region state; do
+    [ -n "$region" ] || continue
+    presence="$(internal_service_presence "$region")" || return 1
+    case "$state:$presence" in
+      pending:absent|deploy_intent:absent)
+        ;;
+      deploy_intent:present|deployed:present|traffic_intent:present)
+        verify_bootstrap_candidate "$region" \
+          "${INTERNAL_SERVICE}-${REVISION_SUFFIX}" false >/dev/null || {
+          echo "ERROR: recorded internal bootstrap cohort differs in ${region}" >&2
+          return 1
+        }
+        ;;
+      settled:present)
+        verify_bootstrap_candidate "$region" \
+          "${INTERNAL_SERVICE}-${REVISION_SUFFIX}" true >/dev/null || {
+          echo "ERROR: settled internal bootstrap cohort differs in ${region}" >&2
+          return 1
+        }
+        ;;
+      pending:present)
+        echo "ERROR: unrecorded internal service appeared in ${region}" >&2
+        return 1
+        ;;
+      *)
+        echo "ERROR: recorded internal bootstrap service is absent in ${region}" >&2
+        return 1
+        ;;
+    esac
+  done <<<"$rows"
+}
+
+preflight_bootstrap_provenance
+
+for region in "${BOOTSTRAP_REGIONS[@]}"; do
+  candidate="${INTERNAL_SERVICE}-${REVISION_SUFFIX}"
+  journal_state="$(journal_region_state "$region")"
+  [ -n "$journal_state" ] || {
+    echo "ERROR: bootstrap journal omits ${region}" >&2
+    exit 1
+  }
+  if [ "$journal_state" = pending ]; then
+    journal_transition "$region" pending deploy_intent
+    journal_state=deploy_intent
+  fi
+  if [ "$journal_state" = deploy_intent ]; then
+    bootstrap_presence="$(internal_service_presence "$region")" || exit 1
+    if [ "$bootstrap_presence" = absent ]; then
+      log "creating private internal bootstrap ${candidate} in ${region} at its sole revision"
+      # Cloud Run rejects --no-traffic on initial service creation. This
+      # service is private, absent from the legacy URL map, and its first
+      # revision is therefore safely created as the sole 100% target.
+      if ! gc run deploy "$INTERNAL_SERVICE" \
+        --region="$region" \
+        --image="$IMAGE" \
+        --revision-suffix="$REVISION_SUFFIX" \
+        --allow-unauthenticated \
+        --ingress=internal-and-cloud-load-balancing \
+        --default-url \
+        --service-account="$INTERNAL_RUN_SERVICE_ACCOUNT" \
+        --port=8080 \
+        --memory=2Gi \
+        --cpu=1 \
+        --concurrency=8 \
+        --min-instances=2 \
+        --max-instances=50 \
+        --max=50 \
+        --timeout=300s \
+        --network="$CLOUD_RUN_NETWORK" \
+        --subnet="$CLOUD_RUN_SUBNET" \
+        --vpc-egress=private-ranges-only \
+        --startup-probe="httpGet.path=/ready,initialDelaySeconds=0,timeoutSeconds=10,periodSeconds=10,failureThreshold=18" \
+        --deploy-health-check \
+        --set-env-vars="$SET_ENV_VARS" \
+        --set-secrets="$SET_SECRETS" \
+        --quiet >/dev/null; then
+        log "internal bootstrap deploy exited non-zero; inspecting exact postconditions"
+      fi
+    else
+      log "resuming exact recorded internal bootstrap ${candidate} in ${region}"
+    fi
+    verify_bootstrap_candidate "$region" "$candidate" false >/dev/null
+    journal_transition "$region" deploy_intent deployed
+    journal_state=deployed
+  fi
+  if [ "$journal_state" = deployed ]; then
+    verify_bootstrap_candidate "$region" "$candidate" false >/dev/null
+    journal_transition "$region" deployed traffic_intent
+    journal_state=traffic_intent
+  fi
+  if [ "$journal_state" = traffic_intent ]; then
+    if ! gc run services update-traffic "$INTERNAL_SERVICE" \
+      --region="$region" --clear-tags \
+      --to-revisions="${candidate}=100" --quiet >/dev/null; then
+      log "internal bootstrap traffic command exited non-zero; inspecting exact postconditions"
+    fi
+    service_hash="$(verify_bootstrap_candidate "$region" "$candidate" true)"
+    journal_transition "$region" traffic_intent settled
+    journal_state=settled
+  fi
+  [ "$journal_state" = settled ] || {
+    echo "ERROR: bootstrap journal did not settle ${region}" >&2
+    exit 1
+  }
+  service_hash="$(verify_bootstrap_candidate "$region" "$candidate" true)"
+  python3 - "$region" "$candidate" "$service_hash" <<'PY' >>"$ENTRIES_FILE"
+import json
+import sys
+print(json.dumps({
+    "region": sys.argv[1],
+    "revision": sys.argv[2],
+    "postcondition_sha256": sys.argv[3],
+}, sort_keys=True, separators=(",", ":")))
+PY
+done
+
+python3 - "$ARTIFACT" "$PROJECT_ID" "$IMAGE" "$RELEASE" \
+  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$BOOTSTRAP_REGION_CSV" \
+  "$INTERNAL_SERVICE" "$INTERNAL_RUN_SERVICE_ACCOUNT" \
+  "$SYNTHETIC_RUN_SERVICE_ACCOUNT" "$MONITOR_REGION_CSV" \
+  "$TR_SYNTHETIC_THROUGHPUT_REGION" "$TR_SYNTHETIC_IMAGE_REGION" \
+  "$TR_SYNTHETIC_VIDEO_REGION" "$BOOTSTRAP_STORAGE_BACKEND" \
+  "$BOOTSTRAP_ANALYTICS_READ_MODE" "$BOOTSTRAP_REQUEST_RECORD_WRITE_MODE" \
+  "$BOOTSTRAP_GENERATION_RECORDS_ENABLED" \
+  "$BOOTSTRAP_BIGTABLE_MIRROR_WRITES_ENABLED" \
+  "$BOOTSTRAP_ANALYTICS_DUAL_READ_STARTED_AT" \
+  "$BOOTSTRAP_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT" \
+  "$BOOTSTRAP_OPERATIONAL_CLICKHOUSE_URL" \
+  "$BOOTSTRAP_OPERATIONAL_CLICKHOUSE_USER" \
+  "$BOOTSTRAP_OPERATIONAL_CLICKHOUSE_DATABASE" "$ENTRIES_FILE" <<'PY'
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+(
+    artifact,
+    project,
+    image,
+    release,
+    created_at,
+    raw_regions,
+    service,
+    account,
+    synthetic_account,
+    raw_monitor_regions,
+    throughput_region,
+    image_region,
+    video_region,
+    storage_backend,
+    analytics_read_mode,
+    request_record_write_mode,
+    generation_records_enabled,
+    bigtable_mirror_writes_enabled,
+    analytics_dual_read_started_at,
+    analytics_clickhouse_primary_started_at,
+    operational_clickhouse_url,
+    operational_clickhouse_user,
+    operational_clickhouse_database,
+    entries_path,
+) = sys.argv[1:]
+entries = [
+    json.loads(line)
+    for line in Path(entries_path).read_text(encoding="utf-8").splitlines()
+    if line
+]
+value = {
+    "schema_version": 1,
+    "kind": "trusted-router-internal-bootstrap",
+    "project_id": project,
+    "image": image,
+    "release": release,
+    "created_at": created_at,
+    "regions": raw_regions.split(","),
+    "internal_service": service,
+    "runtime_service_account": account,
+    "synthetic_service_account": synthetic_account,
+    "ingress": "internal-and-cloud-load-balancing",
+    "default_url_enabled": True,
+    "synthetic_inventory": {
+        "monitor_regions": raw_monitor_regions.split(","),
+        "throughput_region": throughput_region,
+        "image_region": image_region,
+        "video_region": video_region,
+    },
+    "data_mode": {
+        "storage_backend": storage_backend,
+        "analytics_read_mode": analytics_read_mode,
+        "request_record_write_mode": request_record_write_mode,
+        "generation_records_enabled": generation_records_enabled,
+        "bigtable_mirror_writes_enabled": bigtable_mirror_writes_enabled,
+        "analytics_dual_read_started_at": analytics_dual_read_started_at,
+        "analytics_clickhouse_primary_started_at": analytics_clickhouse_primary_started_at,
+        "operational_clickhouse_url": operational_clickhouse_url,
+        "operational_clickhouse_user": operational_clickhouse_user,
+        "operational_clickhouse_database": operational_clickhouse_database,
+    },
+    "services": entries,
+}
+path = Path(artifact)
+descriptor, temporary = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
+try:
+    os.fchmod(descriptor, 0o600)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+        json.dump(value, output, indent=2, sort_keys=True)
+        output.write("\n")
+        output.flush()
+        os.fsync(output.fileno())
+    os.replace(temporary, path)
+    directory = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory)
+    finally:
+        os.close(directory)
+except BaseException:
+    try:
+        os.unlink(temporary)
+    except FileNotFoundError:
+        pass
+    raise
+PY
+validate_artifact_and_emit_services "$IMAGE" >/dev/null
+log "internal bootstrap is serving in every configured/synthetic region"
+log "durable non-secret bootstrap artifact: ${ARTIFACT}"

--- a/scripts/deploy/rollout_frontend_attest.py
+++ b/scripts/deploy/rollout_frontend_attest.py
@@ -1,0 +1,1016 @@
+#!/usr/bin/env python3
+"""Capture and re-verify the public GCP rollout frontend contract.
+
+The artifact intentionally contains only resource identities and normalized,
+non-secret state.  Both commands are read-only with respect to GCP and DNS;
+``capture`` is the only command that writes, and it writes only its artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import ipaddress
+import json
+import os
+import re
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+SCHEMA_VERSION = 1
+SMOKE_RELATIVE_PATH = "scripts/deploy/rollout_smoke.sh"
+MAX_PROVIDER_OUTPUT = 4 * 1024 * 1024
+MAX_ARTIFACT_SIZE = 2 * 1024 * 1024
+PROJECT_RE = re.compile(r"[a-z][a-z0-9-]{4,28}[a-z0-9]")
+RESOURCE_RE = re.compile(r"[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?")
+SHA256_RE = re.compile(r"[0-9a-f]{64}")
+REQUIRED_HOSTS = (
+    "trustedrouter.com",
+    "www.trustedrouter.com",
+    "status.trustedrouter.com",
+    "trust.trustedrouter.com",
+    "eu.trustedrouter.com",
+    "status-us.trustedrouter.com",
+    "status-eu.trustedrouter.com",
+    "allyrouter.com",
+    "www.allyrouter.com",
+    "status.allyrouter.com",
+    "trust.allyrouter.com",
+    "uptimerouter.com",
+    "www.uptimerouter.com",
+    "status.uptimerouter.com",
+    "trust.uptimerouter.com",
+)
+
+
+class AttestationError(ValueError):
+    """A fail-closed frontend attestation error."""
+
+
+def _exact_dict(value: Any, keys: set[str], label: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != keys:
+        raise AttestationError(f"{label} fields differ from schema v1")
+    return value
+
+
+def _string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise AttestationError(f"{label} is invalid")
+    return value
+
+
+def _project(value: Any) -> str:
+    value = _string(value, "project ID")
+    if not PROJECT_RE.fullmatch(value):
+        raise AttestationError("project ID is invalid")
+    return value
+
+
+def _resource_name(value: Any, label: str) -> str:
+    value = _string(value, label)
+    if not RESOURCE_RE.fullmatch(value):
+        raise AttestationError(f"{label} is invalid")
+    return value
+
+
+def _host(value: Any, *, pattern: bool = False) -> str:
+    value = _string(value, "hostname")
+    wildcard = pattern and value.startswith("*.")
+    candidate = value[2:] if wildcard else value
+    if value != value.lower() or len(candidate) > 253 or candidate.endswith("."):
+        raise AttestationError("hostname is invalid")
+    labels = candidate.split(".")
+    if len(labels) < 2:
+        raise AttestationError("hostname is invalid")
+    for label in labels:
+        if not 1 <= len(label) <= 63 or not re.fullmatch(r"[a-z0-9](?:[a-z0-9-]*[a-z0-9])?", label):
+            raise AttestationError("hostname is invalid")
+    return value
+
+
+def _hosts(value: str) -> list[str]:
+    if not isinstance(value, str) or not value or value.strip() != value:
+        raise AttestationError("host inventory is invalid")
+    hosts = value.split(",")
+    if not 1 <= len(hosts) <= 32 or any(not item for item in hosts):
+        raise AttestationError("host inventory is invalid")
+    normalized = [_host(item) for item in hosts]
+    if len(set(normalized)) != len(normalized):
+        raise AttestationError("host inventory contains duplicates")
+    if normalized != list(REQUIRED_HOSTS):
+        raise AttestationError("host inventory differs from the managed-domain contract")
+    return normalized
+
+
+def _compute_resource(project: str, collection: str, name: str) -> str:
+    return f"projects/{project}/global/{collection}/{name}"
+
+
+def _certificate_manager_resource(project: str, collection: str, name: str) -> str:
+    return f"projects/{project}/locations/global/{collection}/{name}"
+
+
+def _reference_path(value: Any, *, api: str) -> str:
+    value = _string(value, "provider resource reference")
+    if value.startswith("projects/"):
+        return value
+    if value.startswith("//"):
+        parsed = value[2:].split("/", 1)
+        expected_service = (
+            "certificatemanager.googleapis.com" if api == "certificate-manager" else None
+        )
+        if len(parsed) != 2 or parsed[0] != expected_service:
+            raise AttestationError("provider resource reference is invalid")
+        return parsed[1]
+    parsed_url = urlsplit(value)
+    if parsed_url.scheme != "https" or parsed_url.query or parsed_url.fragment:
+        raise AttestationError("provider resource reference is invalid")
+    if api == "compute":
+        if parsed_url.netloc not in {
+            "www.googleapis.com",
+            "compute.googleapis.com",
+        } or not parsed_url.path.startswith("/compute/v1/"):
+            raise AttestationError("provider resource reference is invalid")
+        return parsed_url.path.removeprefix("/compute/v1/")
+    if parsed_url.netloc != "certificatemanager.googleapis.com" or not parsed_url.path.startswith(
+        "/v1/"
+    ):
+        raise AttestationError("provider resource reference is invalid")
+    return parsed_url.path.removeprefix("/v1/")
+
+
+def _compute_ref(
+    value: Any,
+    project: str,
+    collection: str,
+    *,
+    expected_name: str | None = None,
+) -> tuple[str, str]:
+    path = _reference_path(value, api="compute")
+    prefix = f"projects/{project}/global/{collection}/"
+    if not path.startswith(prefix) or "/" in path.removeprefix(prefix):
+        raise AttestationError("compute resource identity differs")
+    name = _resource_name(path.removeprefix(prefix), "compute resource name")
+    if expected_name is not None and name != expected_name:
+        raise AttestationError("compute resource identity differs")
+    return _compute_resource(project, collection, name), name
+
+
+def _certificate_manager_ref(
+    value: Any,
+    project: str,
+    collection: str,
+    *,
+    expected_name: str | None = None,
+) -> tuple[str, str]:
+    path = _reference_path(value, api="certificate-manager")
+    prefix = f"projects/{project}/locations/global/{collection}/"
+    if not path.startswith(prefix) or "/" in path.removeprefix(prefix):
+        raise AttestationError("Certificate Manager resource identity differs")
+    name = _resource_name(path.removeprefix(prefix), "Certificate Manager resource name")
+    if expected_name is not None and name != expected_name:
+        raise AttestationError("Certificate Manager resource identity differs")
+    return _certificate_manager_resource(project, collection, name), name
+
+
+def _map_entry_ref(value: Any, project: str, map_name: str) -> tuple[str, str]:
+    path = _reference_path(value, api="certificate-manager")
+    prefix = (
+        f"projects/{project}/locations/global/certificateMaps/{map_name}/certificateMapEntries/"
+    )
+    if not path.startswith(prefix) or "/" in path.removeprefix(prefix):
+        raise AttestationError("certificate-map entry identity differs")
+    name = _resource_name(path.removeprefix(prefix), "certificate-map entry name")
+    return f"{prefix}{name}", name
+
+
+def _run_read_only(argv: list[str], *, label: str) -> bytes:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "CLOUDSDK_CORE_DISABLE_PROMPTS": "1",
+            "LC_ALL": "C",
+        }
+    )
+    try:
+        result = subprocess.run(  # noqa: S603 -- fixed argv, never a shell
+            argv,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=30,
+            env=environment,
+        )
+    except FileNotFoundError as error:
+        raise AttestationError(f"required read-only tool is unavailable: {label}") from error
+    except subprocess.TimeoutExpired as error:
+        raise AttestationError(f"read-only query timed out: {label}") from error
+    if result.returncode != 0:
+        raise AttestationError(f"read-only query failed: {label}")
+    if len(result.stdout) > MAX_PROVIDER_OUTPUT:
+        raise AttestationError(f"read-only query output is too large: {label}")
+    return result.stdout
+
+
+def _gcloud(arguments: list[str], *, expected: type[dict] | type[list], label: str) -> Any:
+    raw = _run_read_only(["gcloud", *arguments, "--format=json"], label=label)
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise AttestationError(f"provider returned malformed JSON: {label}") from error
+    if not isinstance(value, expected):
+        raise AttestationError(f"provider returned the wrong JSON shape: {label}")
+    return value
+
+
+def _dig(host: str, record_type: str) -> list[str]:
+    raw = _run_read_only(
+        ["dig", "+time=5", "+tries=1", "+short", host, record_type],
+        label=f"DNS {record_type}",
+    )
+    try:
+        text = raw.decode("ascii")
+    except UnicodeDecodeError as error:
+        raise AttestationError("DNS response is malformed") from error
+    addresses: set[str] = set()
+    version = 4 if record_type == "A" else 6
+    for line in text.splitlines():
+        candidate = line.strip()
+        if not candidate:
+            continue
+        try:
+            address = ipaddress.ip_address(candidate)
+        except ValueError as error:
+            # CNAMEs and any other non-address answer are fail-closed.  The
+            # rollout domains must resolve directly to the attested VIP.
+            raise AttestationError("DNS response contains a non-address answer") from error
+        if address.version != version:
+            raise AttestationError("DNS response contains the wrong address family")
+        addresses.add(address.compressed)
+    return sorted(addresses, key=lambda item: ipaddress.ip_address(item).packed)
+
+
+def _provider_name(resource: dict[str, Any], expected: str, label: str) -> None:
+    if resource.get("name") != expected:
+        raise AttestationError(f"{label} name differs")
+
+
+def _provider_compute_self_link(
+    resource: dict[str, Any], project: str, collection: str, name: str
+) -> str:
+    canonical, _ = _compute_ref(resource.get("selfLink"), project, collection, expected_name=name)
+    return canonical
+
+
+def _normalized_ports(forwarding_rule: dict[str, Any]) -> list[str]:
+    if forwarding_rule.get("allPorts") not in (None, False):
+        raise AttestationError("forwarding rule exposes ports other than TCP/443")
+    has_range = "portRange" in forwarding_rule and forwarding_rule.get("portRange") is not None
+    has_ports = "ports" in forwarding_rule and forwarding_rule.get("ports") is not None
+    if has_range == has_ports:
+        raise AttestationError("forwarding rule port contract is ambiguous")
+    if has_range:
+        if forwarding_rule["portRange"] not in {"443", "443-443"}:
+            raise AttestationError("forwarding rule does not expose exactly TCP/443")
+    else:
+        if forwarding_rule["ports"] != ["443"]:
+            raise AttestationError("forwarding rule does not expose exactly TCP/443")
+    return ["443"]
+
+
+def _certificate_domains(
+    resource: dict[str, Any], managed: Any, san_field: str, label: str
+) -> list[str]:
+    if not isinstance(managed, dict) or managed.get("status", managed.get("state")) != "ACTIVE":
+        raise AttestationError(f"{label} is not ACTIVE")
+    configured_domains = managed.get("domains")
+    san_domains = resource.get(san_field)
+    if (
+        not isinstance(configured_domains, list)
+        or not configured_domains
+        or not isinstance(san_domains, list)
+        or not san_domains
+    ):
+        raise AttestationError(f"{label} hostname inventory is invalid")
+    normalized_configured = sorted(_host(item, pattern=True) for item in configured_domains)
+    normalized_sans = sorted(_host(item, pattern=True) for item in san_domains)
+    if (
+        len(set(normalized_configured)) != len(normalized_configured)
+        or len(set(normalized_sans)) != len(normalized_sans)
+        or normalized_configured != normalized_sans
+    ):
+        raise AttestationError(f"{label} hostname inventory is inconsistent")
+    return normalized_sans
+
+
+def _pattern_covers(pattern: str, host: str) -> bool:
+    if pattern == host:
+        return True
+    if not pattern.startswith("*."):
+        return False
+    suffix = pattern[2:]
+    return host.endswith(f".{suffix}") and len(host.split(".")) == len(suffix.split(".")) + 1
+
+
+def _select_certificate_map_entry(
+    entries: list[dict[str, Any]], host: str
+) -> dict[str, Any]:
+    """Select the one Certificate Manager entry that GCP will use for *host*.
+
+    Certificate maps do not union certificates across all matching entries.  An
+    exact hostname shadows wildcard entries, the most-specific wildcard shadows
+    PRIMARY, and PRIMARY is used only when no hostname selector matches.  Treat
+    ties at the effective precedence as ambiguous instead of blessing one based
+    on provider response order.
+    """
+
+    exact = [entry for entry in entries if entry["hostname"] == host]
+    if exact:
+        selected = exact
+    else:
+        wildcards = [
+            entry
+            for entry in entries
+            if isinstance(entry["hostname"], str)
+            and entry["hostname"].startswith("*.")
+            and _pattern_covers(entry["hostname"], host)
+        ]
+        if wildcards:
+            most_specific = max(len(entry["hostname"][2:].split(".")) for entry in wildcards)
+            selected = [
+                entry
+                for entry in wildcards
+                if len(entry["hostname"][2:].split(".")) == most_specific
+            ]
+        else:
+            selected = [entry for entry in entries if entry["matcher"] == "PRIMARY"]
+    if len(selected) != 1:
+        raise AttestationError("certificate-map selector is missing or ambiguous")
+    return selected[0]
+
+
+def _capture_compute_certificate(project: str, reference: str) -> dict[str, Any]:
+    canonical, name = _compute_ref(reference, project, "sslCertificates")
+    response = _gcloud(
+        [
+            "compute",
+            "ssl-certificates",
+            "describe",
+            name,
+            "--global",
+            f"--project={project}",
+        ],
+        expected=dict,
+        label="managed SSL certificate",
+    )
+    _provider_name(response, name, "managed SSL certificate")
+    _provider_compute_self_link(response, project, "sslCertificates", name)
+    if response.get("type") != "MANAGED":
+        raise AttestationError("direct SSL certificate is not Google-managed")
+    return {
+        "resource": canonical,
+        "provider": "compute-managed",
+        "state": "ACTIVE",
+        "domains": _certificate_domains(
+            response,
+            response.get("managed"),
+            "subjectAlternativeNames",
+            "managed SSL certificate",
+        ),
+    }
+
+
+def _capture_certificate_manager_certificate(project: str, reference: str) -> dict[str, Any]:
+    canonical, name = _certificate_manager_ref(reference, project, "certificates")
+    response = _gcloud(
+        [
+            "certificate-manager",
+            "certificates",
+            "describe",
+            name,
+            "--location=global",
+            f"--project={project}",
+        ],
+        expected=dict,
+        label="Certificate Manager certificate",
+    )
+    response_canonical, _ = _certificate_manager_ref(
+        response.get("name"), project, "certificates", expected_name=name
+    )
+    if response_canonical != canonical:
+        raise AttestationError("Certificate Manager certificate identity differs")
+    return {
+        "resource": canonical,
+        "provider": "certificate-manager-managed",
+        "state": "ACTIVE",
+        "domains": _certificate_domains(
+            response,
+            response.get("managed"),
+            "sanDnsnames",
+            "Certificate Manager certificate",
+        ),
+    }
+
+
+def _capture_direct_binding(
+    project: str, references: list[Any], hosts: list[str]
+) -> dict[str, Any]:
+    if not references or not all(isinstance(item, str) for item in references):
+        raise AttestationError("direct certificate binding is invalid")
+    certificates = [_capture_compute_certificate(project, item) for item in references]
+    certificates.sort(key=lambda item: item["resource"])
+    if len({item["resource"] for item in certificates}) != len(certificates):
+        raise AttestationError("direct certificate binding contains duplicates")
+    for host in hosts:
+        if not any(
+            _pattern_covers(domain, host)
+            for certificate in certificates
+            for domain in certificate["domains"]
+        ):
+            raise AttestationError("an attested host lacks ACTIVE certificate coverage")
+    return {
+        "mode": "direct",
+        "certificate_map": None,
+        "entries": [],
+        "certificates": certificates,
+    }
+
+
+def _capture_map_binding(project: str, reference: str, hosts: list[str]) -> dict[str, Any]:
+    canonical_map, map_name = _certificate_manager_ref(reference, project, "certificateMaps")
+    map_response = _gcloud(
+        [
+            "certificate-manager",
+            "maps",
+            "describe",
+            map_name,
+            "--location=global",
+            f"--project={project}",
+        ],
+        expected=dict,
+        label="certificate map",
+    )
+    observed_map, _ = _certificate_manager_ref(
+        map_response.get("name"), project, "certificateMaps", expected_name=map_name
+    )
+    if observed_map != canonical_map:
+        raise AttestationError("certificate map identity differs")
+
+    raw_entries = _gcloud(
+        [
+            "certificate-manager",
+            "maps",
+            "entries",
+            "list",
+            f"--map={map_name}",
+            "--location=global",
+            f"--project={project}",
+        ],
+        expected=list,
+        label="certificate-map entries",
+    )
+    if not raw_entries:
+        raise AttestationError("certificate map has no entries")
+    entries: list[dict[str, Any]] = []
+    certificate_references: set[str] = set()
+    for raw_entry in raw_entries:
+        if not isinstance(raw_entry, dict):
+            raise AttestationError("certificate-map entry is malformed")
+        entry_resource, _ = _map_entry_ref(raw_entry.get("name"), project, map_name)
+        if raw_entry.get("state") != "ACTIVE":
+            raise AttestationError("certificate-map entry is not ACTIVE")
+        hostname = raw_entry.get("hostname")
+        matcher = raw_entry.get("matcher")
+        if hostname is not None:
+            hostname = _host(hostname, pattern=True)
+            if matcher is not None:
+                raise AttestationError("certificate-map entry selector is ambiguous")
+        elif matcher != "PRIMARY":
+            raise AttestationError("certificate-map entry selector is invalid")
+        raw_certificates = raw_entry.get("certificates")
+        if not isinstance(raw_certificates, list) or not raw_certificates:
+            raise AttestationError("certificate-map entry has no certificates")
+        entry_certificates: list[str] = []
+        for raw_certificate in raw_certificates:
+            certificate_resource, _ = _certificate_manager_ref(
+                raw_certificate, project, "certificates"
+            )
+            entry_certificates.append(certificate_resource)
+            certificate_references.add(certificate_resource)
+        entry_certificates.sort()
+        if len(set(entry_certificates)) != len(entry_certificates):
+            raise AttestationError("certificate-map entry contains duplicate certificates")
+        entries.append(
+            {
+                "resource": entry_resource,
+                "state": "ACTIVE",
+                "hostname": hostname,
+                "matcher": matcher,
+                "certificates": entry_certificates,
+            }
+        )
+    entries.sort(key=lambda item: item["resource"])
+    if len({item["resource"] for item in entries}) != len(entries):
+        raise AttestationError("certificate map contains duplicate entry identities")
+
+    certificates = [
+        _capture_certificate_manager_certificate(project, reference)
+        for reference in sorted(certificate_references)
+    ]
+    by_resource = {item["resource"]: item for item in certificates}
+    for host in hosts:
+        selected_entry = _select_certificate_map_entry(entries, host)
+        if not any(
+            _pattern_covers(domain, host)
+            for certificate_resource in selected_entry["certificates"]
+            for domain in by_resource[certificate_resource]["domains"]
+        ):
+            raise AttestationError("an attested host lacks ACTIVE certificate-map coverage")
+    return {
+        "mode": "certificate-map",
+        "certificate_map": canonical_map,
+        "entries": entries,
+        "certificates": certificates,
+    }
+
+
+def _capture_frontend(request: dict[str, Any]) -> dict[str, Any]:
+    project = request["project_id"]
+    forwarding_name = request["forwarding_rule"]
+    proxy_name = request["https_proxy"]
+    map_name = request["url_map"]
+    hosts = request["hosts"]
+
+    forwarding = _gcloud(
+        [
+            "compute",
+            "forwarding-rules",
+            "describe",
+            forwarding_name,
+            "--global",
+            f"--project={project}",
+        ],
+        expected=dict,
+        label="global forwarding rule",
+    )
+    _provider_name(forwarding, forwarding_name, "global forwarding rule")
+    forwarding_resource = _provider_compute_self_link(
+        forwarding, project, "forwardingRules", forwarding_name
+    )
+    proxy_resource, _ = _compute_ref(
+        forwarding.get("target"), project, "targetHttpsProxies", expected_name=proxy_name
+    )
+    ip_value = _string(forwarding.get("IPAddress"), "forwarding-rule VIP")
+    try:
+        vip = ipaddress.ip_address(ip_value).compressed
+    except ValueError as error:
+        raise AttestationError("forwarding-rule VIP is not an IP address") from error
+    if forwarding.get("IPProtocol") != "TCP":
+        raise AttestationError("forwarding rule protocol is not TCP")
+    if forwarding.get("networkTier") != "PREMIUM":
+        raise AttestationError("forwarding rule network tier is not PREMIUM")
+    if forwarding.get("loadBalancingScheme") != "EXTERNAL_MANAGED":
+        raise AttestationError("forwarding rule is not EXTERNAL_MANAGED")
+    ports = _normalized_ports(forwarding)
+
+    proxy = _gcloud(
+        [
+            "compute",
+            "target-https-proxies",
+            "describe",
+            proxy_name,
+            "--global",
+            f"--project={project}",
+        ],
+        expected=dict,
+        label="global target HTTPS proxy",
+    )
+    _provider_name(proxy, proxy_name, "global target HTTPS proxy")
+    observed_proxy_resource = _provider_compute_self_link(
+        proxy, project, "targetHttpsProxies", proxy_name
+    )
+    if observed_proxy_resource != proxy_resource:
+        raise AttestationError("forwarding rule target HTTPS proxy differs")
+    url_map_resource, _ = _compute_ref(
+        proxy.get("urlMap"), project, "urlMaps", expected_name=map_name
+    )
+
+    url_map = _gcloud(
+        [
+            "compute",
+            "url-maps",
+            "describe",
+            map_name,
+            "--global",
+            f"--project={project}",
+        ],
+        expected=dict,
+        label="global URL map",
+    )
+    _provider_name(url_map, map_name, "global URL map")
+    if _provider_compute_self_link(url_map, project, "urlMaps", map_name) != url_map_resource:
+        raise AttestationError("target HTTPS proxy URL map differs")
+
+    certificate_map = proxy.get("certificateMap")
+    ssl_certificates = proxy.get("sslCertificates")
+    has_map = isinstance(certificate_map, str) and bool(certificate_map)
+    has_direct = isinstance(ssl_certificates, list) and bool(ssl_certificates)
+    if has_map == has_direct:
+        raise AttestationError("HTTPS proxy certificate binding mode is ambiguous")
+    if has_map:
+        if ssl_certificates not in (None, []):
+            raise AttestationError("HTTPS proxy certificate binding mode is ambiguous")
+        binding = _capture_map_binding(project, certificate_map, hosts)
+    else:
+        if certificate_map is not None:
+            raise AttestationError("HTTPS proxy certificate binding mode is ambiguous")
+        binding = _capture_direct_binding(project, ssl_certificates, hosts)
+
+    dns: list[dict[str, Any]] = []
+    expected_a = [vip] if ipaddress.ip_address(vip).version == 4 else []
+    expected_aaaa = [vip] if ipaddress.ip_address(vip).version == 6 else []
+    for host in hosts:
+        records_a = _dig(host, "A")
+        records_aaaa = _dig(host, "AAAA")
+        if records_a != expected_a or records_aaaa != expected_aaaa:
+            raise AttestationError("public DNS does not resolve exactly to the attested VIP")
+        dns.append({"host": host, "a": records_a, "aaaa": records_aaaa})
+
+    return {
+        "forwarding_rule": {
+            "resource": forwarding_resource,
+            "ip_address": vip,
+            "ip_protocol": "TCP",
+            "ports": ports,
+            "network_tier": "PREMIUM",
+            "load_balancing_scheme": "EXTERNAL_MANAGED",
+            "target_https_proxy": proxy_resource,
+        },
+        "https_proxy": {
+            "resource": proxy_resource,
+            "url_map": url_map_resource,
+        },
+        "url_map": {"resource": url_map_resource},
+        "certificate_binding": binding,
+        "dns": dns,
+    }
+
+
+def _smoke_path() -> Path:
+    return Path(__file__).resolve().parents[2] / SMOKE_RELATIVE_PATH
+
+
+def _smoke_identity() -> dict[str, str]:
+    path = _smoke_path()
+    try:
+        info = path.lstat()
+    except OSError as error:
+        raise AttestationError("repository-owned rollout smoke script is unavailable") from error
+    if not stat.S_ISREG(info.st_mode) or path.is_symlink():
+        raise AttestationError("repository-owned rollout smoke script is not a regular file")
+    try:
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError as error:
+        raise AttestationError("repository-owned rollout smoke script cannot be read") from error
+    return {"path": SMOKE_RELATIVE_PATH, "sha256": digest}
+
+
+def _request(
+    *, project: str, forwarding_rule: str, https_proxy: str, url_map: str, hosts: str
+) -> dict[str, Any]:
+    return {
+        "project_id": _project(project),
+        "forwarding_rule": _resource_name(forwarding_rule, "forwarding-rule name"),
+        "https_proxy": _resource_name(https_proxy, "HTTPS-proxy name"),
+        "url_map": _resource_name(url_map, "URL-map name"),
+        "hosts": _hosts(hosts),
+    }
+
+
+def _validate_request_artifact(value: Any) -> dict[str, Any]:
+    request = _exact_dict(
+        value,
+        {"project_id", "forwarding_rule", "https_proxy", "url_map", "hosts"},
+        "attestation request",
+    )
+    hosts = request["hosts"]
+    if not isinstance(hosts, list) or not all(isinstance(item, str) for item in hosts):
+        raise AttestationError("artifact host inventory is invalid")
+    rebuilt = _request(
+        project=request["project_id"],
+        forwarding_rule=request["forwarding_rule"],
+        https_proxy=request["https_proxy"],
+        url_map=request["url_map"],
+        hosts=",".join(hosts),
+    )
+    if rebuilt != request:
+        raise AttestationError("attestation request is not canonical")
+    return request
+
+
+def _validate_certificate_artifact(value: Any, project: str, hosts: list[str]) -> None:
+    binding = _exact_dict(
+        value,
+        {"mode", "certificate_map", "entries", "certificates"},
+        "certificate binding",
+    )
+    if binding["mode"] not in {"direct", "certificate-map"}:
+        raise AttestationError("certificate binding mode is invalid")
+    if not isinstance(binding["entries"], list) or not isinstance(binding["certificates"], list):
+        raise AttestationError("certificate binding inventory is invalid")
+    certificate_resources: list[str] = []
+    certificate_domains: dict[str, list[str]] = {}
+    expected_provider = (
+        "compute-managed" if binding["mode"] == "direct" else "certificate-manager-managed"
+    )
+    for certificate in binding["certificates"]:
+        certificate = _exact_dict(
+            certificate,
+            {"resource", "provider", "state", "domains"},
+            "certificate",
+        )
+        if certificate["provider"] != expected_provider or certificate["state"] != "ACTIVE":
+            raise AttestationError("certificate identity or state is invalid")
+        if binding["mode"] == "direct":
+            canonical, _ = _compute_ref(certificate["resource"], project, "sslCertificates")
+        else:
+            canonical, _ = _certificate_manager_ref(
+                certificate["resource"], project, "certificates"
+            )
+        if canonical != certificate["resource"]:
+            raise AttestationError("certificate resource is not canonical")
+        domains = certificate["domains"]
+        if not isinstance(domains, list) or not domains:
+            raise AttestationError("certificate hostname inventory is invalid")
+        normalized_domains = sorted(_host(item, pattern=True) for item in domains)
+        if normalized_domains != domains or len(set(domains)) != len(domains):
+            raise AttestationError("certificate hostname inventory is not canonical")
+        certificate_resources.append(canonical)
+        certificate_domains[canonical] = domains
+    if certificate_resources != sorted(certificate_resources) or len(
+        set(certificate_resources)
+    ) != len(certificate_resources):
+        raise AttestationError("certificate inventory is not canonical")
+
+    if binding["mode"] == "direct":
+        if binding["certificate_map"] is not None or binding["entries"]:
+            raise AttestationError("direct certificate binding is invalid")
+        for host in hosts:
+            if not any(
+                _pattern_covers(domain, host)
+                for domains in certificate_domains.values()
+                for domain in domains
+            ):
+                raise AttestationError("artifact certificate coverage is incomplete")
+        return
+
+    canonical_map, map_name = _certificate_manager_ref(
+        binding["certificate_map"], project, "certificateMaps"
+    )
+    if canonical_map != binding["certificate_map"]:
+        raise AttestationError("certificate map resource is not canonical")
+    entry_resources: list[str] = []
+    validated_entries: list[dict[str, Any]] = []
+    for entry in binding["entries"]:
+        entry = _exact_dict(
+            entry,
+            {"resource", "state", "hostname", "matcher", "certificates"},
+            "certificate-map entry",
+        )
+        canonical_entry, _ = _map_entry_ref(entry["resource"], project, map_name)
+        if canonical_entry != entry["resource"] or entry["state"] != "ACTIVE":
+            raise AttestationError("certificate-map entry identity or state is invalid")
+        if entry["hostname"] is not None:
+            if _host(entry["hostname"], pattern=True) != entry["hostname"]:
+                raise AttestationError("certificate-map hostname is not canonical")
+            if entry["matcher"] is not None:
+                raise AttestationError("certificate-map selector is ambiguous")
+        elif entry["matcher"] != "PRIMARY":
+            raise AttestationError("certificate-map selector is invalid")
+        references = entry["certificates"]
+        if (
+            not isinstance(references, list)
+            or not references
+            or references != sorted(references)
+            or len(set(references)) != len(references)
+            or any(reference not in certificate_domains for reference in references)
+        ):
+            raise AttestationError("certificate-map entry certificate inventory is invalid")
+        entry_resources.append(canonical_entry)
+        validated_entries.append(entry)
+    if entry_resources != sorted(entry_resources) or len(set(entry_resources)) != len(
+        entry_resources
+    ):
+        raise AttestationError("certificate-map entry inventory is not canonical")
+    for host in hosts:
+        selected = _select_certificate_map_entry(validated_entries, host)
+        if not any(
+            _pattern_covers(domain, host)
+            for certificate in selected["certificates"]
+            for domain in certificate_domains[certificate]
+        ):
+            raise AttestationError("artifact certificate-map coverage is incomplete")
+
+
+def _validate_frontend_artifact(value: Any, request: dict[str, Any]) -> None:
+    frontend = _exact_dict(
+        value,
+        {"forwarding_rule", "https_proxy", "url_map", "certificate_binding", "dns"},
+        "frontend attestation",
+    )
+    project = request["project_id"]
+    expected_forwarding = _compute_resource(project, "forwardingRules", request["forwarding_rule"])
+    expected_proxy = _compute_resource(project, "targetHttpsProxies", request["https_proxy"])
+    expected_map = _compute_resource(project, "urlMaps", request["url_map"])
+    forwarding = _exact_dict(
+        frontend["forwarding_rule"],
+        {
+            "resource",
+            "ip_address",
+            "ip_protocol",
+            "ports",
+            "network_tier",
+            "load_balancing_scheme",
+            "target_https_proxy",
+        },
+        "forwarding-rule attestation",
+    )
+    if (
+        forwarding["resource"] != expected_forwarding
+        or forwarding["target_https_proxy"] != expected_proxy
+        or forwarding["ip_protocol"] != "TCP"
+        or forwarding["ports"] != ["443"]
+        or forwarding["network_tier"] != "PREMIUM"
+        or forwarding["load_balancing_scheme"] != "EXTERNAL_MANAGED"
+    ):
+        raise AttestationError("forwarding-rule artifact contract differs")
+    try:
+        vip = ipaddress.ip_address(forwarding["ip_address"]).compressed
+    except (TypeError, ValueError) as error:
+        raise AttestationError("artifact VIP is invalid") from error
+    if vip != forwarding["ip_address"]:
+        raise AttestationError("artifact VIP is not canonical")
+    proxy = _exact_dict(frontend["https_proxy"], {"resource", "url_map"}, "HTTPS-proxy attestation")
+    url_map = _exact_dict(frontend["url_map"], {"resource"}, "URL-map attestation")
+    if proxy != {"resource": expected_proxy, "url_map": expected_map} or url_map != {
+        "resource": expected_map
+    }:
+        raise AttestationError("HTTPS-proxy or URL-map artifact contract differs")
+    _validate_certificate_artifact(frontend["certificate_binding"], project, request["hosts"])
+    dns = frontend["dns"]
+    if not isinstance(dns, list) or len(dns) != len(request["hosts"]):
+        raise AttestationError("artifact DNS inventory is invalid")
+    expected_a = [vip] if ipaddress.ip_address(vip).version == 4 else []
+    expected_aaaa = [vip] if ipaddress.ip_address(vip).version == 6 else []
+    for item, host in zip(dns, request["hosts"], strict=True):
+        item = _exact_dict(item, {"host", "a", "aaaa"}, "DNS attestation")
+        if item != {"host": host, "a": expected_a, "aaaa": expected_aaaa}:
+            raise AttestationError("artifact DNS contract differs")
+
+
+def _validate_artifact(value: Any) -> dict[str, Any]:
+    artifact = _exact_dict(
+        value, {"schema_version", "request", "frontend", "smoke"}, "frontend artifact"
+    )
+    if artifact["schema_version"] != SCHEMA_VERSION:
+        raise AttestationError("frontend artifact schema version differs")
+    request = _validate_request_artifact(artifact["request"])
+    _validate_frontend_artifact(artifact["frontend"], request)
+    smoke = _exact_dict(artifact["smoke"], {"path", "sha256"}, "smoke identity")
+    if (
+        smoke["path"] != SMOKE_RELATIVE_PATH
+        or not isinstance(smoke["sha256"], str)
+        or not SHA256_RE.fullmatch(smoke["sha256"])
+    ):
+        raise AttestationError("smoke identity is invalid")
+    return artifact
+
+
+def _read_artifact(path: Path) -> dict[str, Any]:
+    try:
+        info = path.lstat()
+    except OSError as error:
+        raise AttestationError("frontend artifact is unavailable") from error
+    if not stat.S_ISREG(info.st_mode) or stat.S_IMODE(info.st_mode) != 0o600:
+        raise AttestationError("frontend artifact must be a regular mode-0600 file")
+    if info.st_size > MAX_ARTIFACT_SIZE:
+        raise AttestationError("frontend artifact is too large")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise AttestationError("frontend artifact JSON is malformed") from error
+    return _validate_artifact(value)
+
+
+def _atomic_write(path: Path, value: dict[str, Any]) -> None:
+    smoke_path = _smoke_path().resolve()
+    own_path = Path(__file__).resolve()
+    destination = path.resolve(strict=False)
+    if destination in {smoke_path, own_path}:
+        raise AttestationError("artifact destination aliases a repository-owned executable")
+    try:
+        if path.exists() or path.is_symlink():
+            info = path.lstat()
+            if not stat.S_ISREG(info.st_mode):
+                raise AttestationError("artifact destination is not a regular file")
+        path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        descriptor, temporary = tempfile.mkstemp(
+            dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+        )
+    except AttestationError:
+        raise
+    except OSError as error:
+        raise AttestationError("artifact destination cannot be prepared") from error
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            json.dump(value, output, indent=2, sort_keys=True)
+            output.write("\n")
+            output.flush()
+            os.fsync(output.fileno())
+        os.replace(temporary, path)
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+        if stat.S_IMODE(path.lstat().st_mode) != 0o600:
+            raise AttestationError("frontend artifact mode differs after atomic write")
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _capture(args: argparse.Namespace) -> None:
+    request = _request(
+        project=args.project,
+        forwarding_rule=args.forwarding_rule,
+        https_proxy=args.https_proxy,
+        url_map=args.url_map,
+        hosts=args.hosts,
+    )
+    artifact = {
+        "schema_version": SCHEMA_VERSION,
+        "request": request,
+        "frontend": _capture_frontend(request),
+        "smoke": _smoke_identity(),
+    }
+    _validate_artifact(artifact)
+    _atomic_write(args.artifact, artifact)
+    print("frontend attestation captured", file=sys.stderr)
+
+
+def _verify(args: argparse.Namespace) -> None:
+    artifact = _read_artifact(args.artifact)
+    if artifact["smoke"] != _smoke_identity():
+        raise AttestationError("repository-owned rollout smoke script hash differs")
+    current_frontend = _capture_frontend(artifact["request"])
+    if current_frontend != artifact["frontend"]:
+        raise AttestationError("live frontend contract differs from the captured artifact")
+    print("frontend attestation verified", file=sys.stderr)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Capture and verify the public GCP rollout frontend attestation."
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+    capture = commands.add_parser("capture")
+    capture.add_argument("--project", required=True)
+    capture.add_argument("--forwarding-rule", required=True)
+    capture.add_argument("--https-proxy", required=True)
+    capture.add_argument("--url-map", required=True)
+    capture.add_argument("--hosts", required=True)
+    capture.add_argument("--artifact", type=Path, required=True)
+    capture.set_defaults(handler=_capture)
+    verify = commands.add_parser("verify-artifact")
+    verify.add_argument("artifact", type=Path)
+    verify.set_defaults(handler=_verify)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    try:
+        args.handler(args)
+    except AttestationError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except OSError:
+        # Provider output and artifact content are deliberately never reflected
+        # in logs, including unusual filesystem failures.
+        print("ERROR: frontend attestation filesystem operation failed", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deploy/rollout_frontend_attest.py
+++ b/scripts/deploy/rollout_frontend_attest.py
@@ -33,7 +33,6 @@ REQUIRED_HOSTS = (
     "trustedrouter.com",
     "www.trustedrouter.com",
     "status.trustedrouter.com",
-    "trust.trustedrouter.com",
     "eu.trustedrouter.com",
     "status-us.trustedrouter.com",
     "status-eu.trustedrouter.com",
@@ -228,7 +227,18 @@ def _gcloud(arguments: list[str], *, expected: type[dict] | type[list], label: s
     return value
 
 
-def _dig(host: str, record_type: str) -> list[str]:
+def _dig(
+    host: str, record_type: str, managed_hosts: frozenset[str]
+) -> tuple[list[str], list[str]]:
+    """Resolve one managed host; return (addresses, cname_chain).
+
+    A managed host may be a CNAME, but only to another managed host: the
+    production DNS policy (quill-cloud-proxy/tools/fix-trustedrouter-dns.sh)
+    keeps www as a CNAME to the apex, and the apex is itself attested here.
+    Any other non-address answer is fail-closed, so a host delegated outside
+    the managed set - a static-site CNAME, a parked domain - can never be
+    attested as resolving to the VIP by way of whatever it delegates to.
+    """
     raw = _run_read_only(
         ["dig", "+time=5", "+tries=1", "+short", host, record_type],
         label=f"DNS {record_type}",
@@ -238,6 +248,7 @@ def _dig(host: str, record_type: str) -> list[str]:
     except UnicodeDecodeError as error:
         raise AttestationError("DNS response is malformed") from error
     addresses: set[str] = set()
+    chain: list[str] = []
     version = 4 if record_type == "A" else 6
     for line in text.splitlines():
         candidate = line.strip()
@@ -245,14 +256,22 @@ def _dig(host: str, record_type: str) -> list[str]:
             continue
         try:
             address = ipaddress.ip_address(candidate)
-        except ValueError as error:
-            # CNAMEs and any other non-address answer are fail-closed.  The
-            # rollout domains must resolve directly to the attested VIP.
-            raise AttestationError("DNS response contains a non-address answer") from error
+        except ValueError:
+            target = candidate.lower().rstrip(".")
+            if target not in managed_hosts or target == host:
+                raise AttestationError(
+                    "DNS response delegates outside the managed hosts"
+                ) from None
+            if addresses:
+                raise AttestationError(
+                    "DNS response interleaves a CNAME after addresses"
+                ) from None
+            chain.append(target)
+            continue
         if address.version != version:
             raise AttestationError("DNS response contains the wrong address family")
         addresses.add(address.compressed)
-    return sorted(addresses, key=lambda item: ipaddress.ip_address(item).packed)
+    return sorted(addresses, key=lambda item: ipaddress.ip_address(item).packed), chain
 
 
 def _provider_name(resource: dict[str, Any], expected: str, label: str) -> None:
@@ -634,12 +653,18 @@ def _capture_frontend(request: dict[str, Any]) -> dict[str, Any]:
     dns: list[dict[str, Any]] = []
     expected_a = [vip] if ipaddress.ip_address(vip).version == 4 else []
     expected_aaaa = [vip] if ipaddress.ip_address(vip).version == 6 else []
+    managed = frozenset(hosts)
     for host in hosts:
-        records_a = _dig(host, "A")
-        records_aaaa = _dig(host, "AAAA")
+        records_a, chain_a = _dig(host, "A", managed)
+        records_aaaa, chain_aaaa = _dig(host, "AAAA", managed)
         if records_a != expected_a or records_aaaa != expected_aaaa:
             raise AttestationError("public DNS does not resolve exactly to the attested VIP")
-        dns.append({"host": host, "a": records_a, "aaaa": records_aaaa})
+        if chain_a != chain_aaaa:
+            raise AttestationError("public DNS CNAME chain differs between address families")
+        entry: dict[str, Any] = {"host": host, "a": records_a, "aaaa": records_aaaa}
+        if chain_a:
+            entry["cname"] = chain_a
+        dns.append(entry)
 
     return {
         "forwarding_rule": {
@@ -867,9 +892,22 @@ def _validate_frontend_artifact(value: Any, request: dict[str, Any]) -> None:
         raise AttestationError("artifact DNS inventory is invalid")
     expected_a = [vip] if ipaddress.ip_address(vip).version == 4 else []
     expected_aaaa = [vip] if ipaddress.ip_address(vip).version == 6 else []
+    managed = frozenset(request["hosts"])
     for item, host in zip(dns, request["hosts"], strict=True):
-        item = _exact_dict(item, {"host", "a", "aaaa"}, "DNS attestation")
-        if item != {"host": host, "a": expected_a, "aaaa": expected_aaaa}:
+        if not isinstance(item, dict):
+            raise AttestationError("DNS attestation fields differ from schema v1")
+        keys = {"host", "a", "aaaa"} | ({"cname"} if "cname" in item else set())
+        item = _exact_dict(item, keys, "DNS attestation")
+        chain = item.get("cname", [])
+        chain_ok = (
+            isinstance(chain, list)
+            and (chain or "cname" not in item)
+            and len(set(chain)) == len(chain)
+            and all(isinstance(t, str) and t in managed and t != host for t in chain)
+        )
+        if not chain_ok:
+            raise AttestationError("artifact DNS CNAME chain is invalid")
+        if (item["host"], item["a"], item["aaaa"]) != (host, expected_a, expected_aaaa):
             raise AttestationError("artifact DNS contract differs")
 
 

--- a/scripts/deploy/rollout_iam_verify.sh
+++ b/scripts/deploy/rollout_iam_verify.sh
@@ -1,0 +1,1285 @@
+#!/usr/bin/env bash
+# Read-only IAM and mounted-secret verification for the six-surface rollout.
+#
+# This gate intentionally owns no reconciliation path.  Every gcloud command
+# below is a describe, list, or get-iam-policy operation so it is safe to run
+# both before staging and before every promotion step.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 --project PROJECT [--manifest PATH]" >&2
+}
+
+PROJECT_ARGUMENT=""
+MANIFEST_PATH=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --project)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      [ -z "$PROJECT_ARGUMENT" ] || { echo "ERROR: --project may be specified only once" >&2; exit 2; }
+      PROJECT_ARGUMENT="$2"
+      shift 2
+      ;;
+    --manifest)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      [ -z "$MANIFEST_PATH" ] || { echo "ERROR: --manifest may be specified only once" >&2; exit 2; }
+      MANIFEST_PATH="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+[[ "$PROJECT_ARGUMENT" =~ ^[a-z][a-z0-9-]{4,28}[a-z0-9]$ ]] || {
+  echo "ERROR: --project must be a canonical GCP project identifier" >&2
+  exit 2
+}
+if [ -n "$MANIFEST_PATH" ] && [ ! -f "$MANIFEST_PATH" ]; then
+  echo "ERROR: --manifest must name a readable regular file" >&2
+  exit 2
+fi
+
+PROJECT_ID="$PROJECT_ARGUMENT"
+export PROJECT_ID
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+SURFACES=(public actions console chat webhooks internal)
+
+surface_account() {
+  case "$1" in
+    public) echo "$PUBLIC_RUN_SERVICE_ACCOUNT" ;;
+    actions) echo "$ACTIONS_RUN_SERVICE_ACCOUNT" ;;
+    console) echo "$CONSOLE_RUN_SERVICE_ACCOUNT" ;;
+    chat) echo "$CHAT_RUN_SERVICE_ACCOUNT" ;;
+    webhooks) echo "$WEBHOOKS_RUN_SERVICE_ACCOUNT" ;;
+    internal) echo "$INTERNAL_RUN_SERVICE_ACCOUNT" ;;
+    *) return 2 ;;
+  esac
+}
+
+for surface in "${SURFACES[@]}"; do
+  expected_account="tr-${surface}@${PROJECT_ID}.iam.gserviceaccount.com"
+  [ "$(surface_account "$surface")" = "$expected_account" ] || {
+    echo "ERROR: six-surface IAM verification requires canonical runtime identities" >&2
+    exit 1
+  }
+done
+if [ "${#RUNTIME_SERVICE_ACCOUNTS[@]}" -ne 6 ]; then
+  echo "ERROR: runtime service-account inventory is not the canonical six-account set" >&2
+  exit 1
+fi
+
+RUNTIME_CSV="$(IFS=,; echo "${RUNTIME_SERVICE_ACCOUNTS[*]}")"
+
+ROLLOUT_REQUIRE_RECOVERY_BUNDLE="${TR_ROLLOUT_REQUIRE_RECOVERY_BUNDLE:-false}"
+ROLLOUT_RECOVERY_GCS_PREFIX="${TR_ROLLOUT_RECOVERY_GCS_PREFIX:-}"
+ROLLOUT_RECOVERY_GCS_ROLE="${TR_ROLLOUT_RECOVERY_GCS_ROLE:-}"
+ROLLOUT_BUNDLE_GCS_URI="${TR_ROLLOUT_BUNDLE_GCS_URI:-}"
+ROLLOUT_AUTHORITY_GCS_URI="${TR_ROLLOUT_AUTHORITY_GCS_URI:-}"
+ROLLOUT_STATE_GCS_URI="${TR_ROLLOUT_STATE_GCS_URI:-}"
+ROLLOUT_STATE_GCS_ROLE="${TR_ROLLOUT_STATE_GCS_ROLE:-}"
+case "$ROLLOUT_REQUIRE_RECOVERY_BUNDLE" in
+  true|false) ;;
+  *)
+    echo "ERROR: TR_ROLLOUT_REQUIRE_RECOVERY_BUNDLE must be true or false" >&2
+    exit 2
+    ;;
+esac
+ROLLOUT_RECOVERY_ACTIVE=false
+if [ "$ROLLOUT_REQUIRE_RECOVERY_BUNDLE" = true ] ||
+   [ -n "$ROLLOUT_RECOVERY_GCS_PREFIX$ROLLOUT_RECOVERY_GCS_ROLE$ROLLOUT_BUNDLE_GCS_URI$ROLLOUT_AUTHORITY_GCS_URI" ]; then
+  ROLLOUT_RECOVERY_ACTIVE=true
+fi
+ROLLOUT_STATE_BUCKET=""
+ROLLOUT_STATE_OBJECT=""
+if [ "$ROLLOUT_RECOVERY_ACTIVE" = false ]; then
+  if { [ -n "$ROLLOUT_STATE_GCS_URI" ] && [ -z "$ROLLOUT_STATE_GCS_ROLE" ]; } ||
+     { [ -z "$ROLLOUT_STATE_GCS_URI" ] && [ -n "$ROLLOUT_STATE_GCS_ROLE" ]; }; then
+    echo "ERROR: rollout journal URI and custom role must be configured together" >&2
+    exit 1
+  fi
+fi
+if [ "$ROLLOUT_RECOVERY_ACTIVE" = false ] && [ -n "$ROLLOUT_STATE_GCS_URI" ]; then
+  if ! ROLLOUT_STATE_PARTS="$(python3 -c '
+import re
+import sys
+
+uri, project, role = sys.argv[1:4]
+match = re.fullmatch(
+    r"gs://([a-z0-9][a-z0-9._-]{1,220}[a-z0-9])/"
+    r"([A-Za-z0-9][A-Za-z0-9._/-]{0,1023})",
+    uri,
+)
+if not match or "//" in match.group(2):
+    raise SystemExit("invalid rollout journal URI")
+if not re.fullmatch(
+    rf"projects/{re.escape(project)}/roles/[A-Za-z0-9_.]{{3,64}}", role
+):
+    raise SystemExit("invalid rollout journal custom role")
+print(match.group(1) + "\t" + match.group(2))
+' "$ROLLOUT_STATE_GCS_URI" "$PROJECT_ID" "$ROLLOUT_STATE_GCS_ROLE" 2>/dev/null)"; then
+    echo "ERROR: rollout journal URI or custom role is noncanonical" >&2
+    exit 1
+  fi
+  IFS=$'\t' read -r ROLLOUT_STATE_BUCKET ROLLOUT_STATE_OBJECT <<<"$ROLLOUT_STATE_PARTS"
+fi
+
+ROLLOUT_RECOVERY_BUCKET=""
+ROLLOUT_RECOVERY_OBJECT_PREFIX=""
+ROLLOUT_RECOVERY_EPOCH=""
+if [ "$ROLLOUT_RECOVERY_ACTIVE" = true ]; then
+  if [ -z "$ROLLOUT_RECOVERY_GCS_PREFIX" ] ||
+     [ -z "$ROLLOUT_RECOVERY_GCS_ROLE" ] ||
+     [ -z "$ROLLOUT_BUNDLE_GCS_URI" ] ||
+     [ -z "$ROLLOUT_AUTHORITY_GCS_URI" ] ||
+     [ -z "$ROLLOUT_STATE_GCS_URI" ]; then
+    echo "ERROR: recovery IAM verification requires prefix, role, bundle, authority, and state URIs" >&2
+    exit 1
+  fi
+  if [ -n "$ROLLOUT_STATE_GCS_ROLE" ] &&
+     [ "$ROLLOUT_STATE_GCS_ROLE" != "$ROLLOUT_RECOVERY_GCS_ROLE" ]; then
+    echo "ERROR: legacy journal and recovery custom-role inputs disagree" >&2
+    exit 1
+  fi
+  if ! ROLLOUT_RECOVERY_PARTS="$(python3 -c '
+import re
+import sys
+
+prefix, bundle, authority, state, project, role = sys.argv[1:]
+bucket_pattern = r"[a-z0-9][a-z0-9._-]{1,220}[a-z0-9]"
+prefix_match = re.fullmatch(
+    rf"gs://({bucket_pattern})/(trusted-router-rollouts/{re.escape(project)})",
+    prefix,
+)
+if not prefix_match:
+    raise SystemExit("noncanonical recovery prefix")
+bucket, object_prefix = prefix_match.groups()
+release_prefix = f"{prefix}/releases/"
+if not bundle.startswith(release_prefix):
+    raise SystemExit("bundle is outside the recovery releases prefix")
+epoch = bundle[len(release_prefix):]
+if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{7,159}", epoch):
+    raise SystemExit("bundle epoch is not unique and canonical")
+if authority != f"{prefix}/authority.json":
+    raise SystemExit("authority is outside the exact recovery object")
+if state != f"{bundle}/promotion-state.json":
+    raise SystemExit("state is outside the exact recovery bundle")
+if not re.fullmatch(
+    rf"projects/{re.escape(project)}/roles/[A-Za-z][A-Za-z0-9_.]{{2,63}}",
+    role,
+):
+    raise SystemExit("recovery role is not project-local and canonical")
+print("\t".join((bucket, object_prefix, epoch)))
+' "$ROLLOUT_RECOVERY_GCS_PREFIX" "$ROLLOUT_BUNDLE_GCS_URI" \
+    "$ROLLOUT_AUTHORITY_GCS_URI" "$ROLLOUT_STATE_GCS_URI" \
+    "$PROJECT_ID" "$ROLLOUT_RECOVERY_GCS_ROLE" 2>/dev/null)"; then
+    echo "ERROR: rollout recovery prefix, bundle, authority, state, or role is noncanonical" >&2
+    exit 1
+  fi
+  IFS=$'\t' read -r ROLLOUT_RECOVERY_BUCKET \
+    ROLLOUT_RECOVERY_OBJECT_PREFIX ROLLOUT_RECOVERY_EPOCH \
+    <<<"$ROLLOUT_RECOVERY_PARTS"
+fi
+
+read_cloud_json() {
+  local label="$1"
+  shift
+  local output
+  if ! output="$("$@" 2>/dev/null)"; then
+    echo "ERROR: cannot read ${label}" >&2
+    return 1
+  fi
+  if ! printf '%s' "$output" | python3 -c '
+import json
+import sys
+
+label = sys.argv[1]
+try:
+    value = json.load(sys.stdin)
+except json.JSONDecodeError:
+    raise SystemExit(f"{label}: response is not valid JSON") from None
+if isinstance(value, dict):
+    for binding in value.get("bindings") or []:
+        members = binding.get("members") or []
+        if any(member in {"allUsers", "allAuthenticatedUsers"} for member in members):
+            raise SystemExit(f"{label}: public IAM principal is forbidden")
+' "$label"
+  then
+    echo "ERROR: ${label} contains a public or malformed IAM policy" >&2
+    return 1
+  fi
+  printf '%s' "$output"
+}
+
+describe_iam_role_definition_readonly() {
+  local role="$1"
+  local scope role_id
+  case "$role" in
+    roles/*)
+      gc iam roles describe "$role" --format=json
+      ;;
+    projects/*/roles/*)
+      scope="${role#projects/}"
+      scope="${scope%%/roles/*}"
+      role_id="${role##*/}"
+      [ "$scope" = "$PROJECT_ID" ] || return 1
+      gc iam roles describe "$role_id" --format=json
+      ;;
+    organizations/*/roles/*)
+      scope="${role#organizations/}"
+      scope="${scope%%/roles/*}"
+      role_id="${role##*/}"
+      [[ "$scope" =~ ^[0-9]+$ ]] || return 1
+      gcloud --billing-project "$PROJECT_ID" iam roles describe "$role_id" \
+        --organization="$scope" --format=json
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+# Verify all and only the expected direct bindings for the six runtime
+# principals, plus no binding for the dedicated synthetic identity, on one
+# resource policy. Bindings for unrelated administrators or service agents
+# remain outside this verifier's ownership boundary.
+verify_six_runtime_matrix_json() {
+  local label="$1"
+  local expected_csv="$2"
+  python3 -c '
+import json
+import sys
+
+label, accounts_csv, expected_csv, project = sys.argv[1:5]
+accounts = accounts_csv.split(",")
+if len(accounts) != 6 or len(set(accounts)) != 6:
+    raise SystemExit(f"{label}: runtime identity inventory is not exactly six")
+
+expected = {}
+for item in expected_csv.split(","):
+    surface, separator, role = item.partition("=")
+    if not separator or surface in expected:
+        raise SystemExit(f"{label}: invalid expected IAM matrix")
+    expected[surface] = role
+surfaces = ("public", "actions", "console", "chat", "webhooks", "internal")
+if set(expected) != set(surfaces):
+    raise SystemExit(f"{label}: expected IAM matrix does not cover six surfaces")
+
+members = {
+    "serviceAccount:" + account: expected[surface]
+    for surface, account in zip(surfaces, accounts)
+}
+members[f"serviceAccount:tr-synthetic@{project}.iam.gserviceaccount.com"] = ""
+policy = json.load(sys.stdin)
+if not isinstance(policy, dict) or not isinstance(policy.get("bindings", []), list):
+    raise SystemExit(f"{label}: malformed IAM policy")
+found = {member: [] for member in members}
+for binding in policy.get("bindings", []):
+    if not isinstance(binding, dict):
+        raise SystemExit(f"{label}: malformed IAM binding")
+    role = binding.get("role")
+    binding_members = binding.get("members", [])
+    if not isinstance(role, str) or not isinstance(binding_members, list):
+        raise SystemExit(f"{label}: malformed IAM binding")
+    condition = binding.get("condition") if "condition" in binding else None
+    for member in binding_members:
+        if member in found:
+            found[member].append((role, condition))
+
+for member, wanted_role in members.items():
+    wanted = [] if not wanted_role else [(wanted_role, None)]
+    if found[member] != wanted:
+        raise SystemExit(f"{label}: six-runtime IAM matrix drift")
+' "$label" "$RUNTIME_CSV" "$expected_csv" "$PROJECT_ID"
+}
+
+verify_policy_from_cloud() {
+  local label="$1"
+  local expected_csv="$2"
+  shift 2
+  local policy
+  policy="$(read_cloud_json "${label} IAM policy" "$@")" || return 1
+  if ! printf '%s' "$policy" | verify_six_runtime_matrix_json "$label" "$expected_csv"; then
+    echo "ERROR: ${label} has unsafe six-runtime IAM" >&2
+    return 1
+  fi
+}
+
+# Normalize a provider list response to one resource identifier per line.  The
+# command that produced the response is already scoped to PROJECT_ID; full
+# resource names are nevertheless checked again so a malformed/cross-project
+# inventory cannot cause the verifier to audit the wrong object and miss the
+# actual one.
+normalize_project_inventory_json() {
+  local label="$1"
+  local kind="$2"
+  local parent="$3"
+  python3 -c '
+import json
+import re
+import sys
+
+label, kind, project, parent = sys.argv[1:5]
+items = json.load(sys.stdin)
+if not isinstance(items, list):
+    raise SystemExit(f"{label}: inventory is not a list")
+identifier = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}")
+location_identifier = re.compile(r"[a-z0-9][a-z0-9-]{0,62}")
+service_account_email = re.compile(
+    r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}@"
+    r"[A-Za-z0-9](?:[A-Za-z0-9.-]{0,250}[A-Za-z0-9])?[.]gserviceaccount[.]com"
+)
+
+def resource_id(item):
+    if not isinstance(item, dict):
+        raise SystemExit(f"{label}: malformed inventory entry")
+    value = item.get("name")
+    if kind == "kms-location":
+        value = item.get("locationId", value)
+        prefix = f"projects/{project}/locations/"
+    elif kind == "spanner-instance":
+        prefix = f"projects/{project}/instances/"
+    elif kind == "spanner-database":
+        prefix = f"projects/{project}/instances/{parent}/databases/"
+    elif kind == "bigtable-instance":
+        prefix = f"projects/{project}/instances/"
+    elif kind == "bigtable-table":
+        prefix = f"projects/{project}/instances/{parent}/tables/"
+    elif kind == "kms-keyring":
+        prefix = f"projects/{project}/locations/{parent}/keyRings/"
+    elif kind == "kms-key":
+        location, separator, keyring = parent.partition("/")
+        if not separator:
+            raise SystemExit(f"{label}: malformed key parent")
+        prefix = f"projects/{project}/locations/{location}/keyRings/{keyring}/cryptoKeys/"
+    elif kind == "service-account":
+        email = item.get("email")
+        if not isinstance(email, str) or not service_account_email.fullmatch(email):
+            raise SystemExit(f"{label}: malformed service-account email")
+        name = item.get("name")
+        unique_id = item.get("uniqueId")
+        allowed_accounts = {email}
+        if unique_id is not None:
+            unique_id = str(unique_id)
+            if not re.fullmatch(r"[0-9]{6,32}", unique_id):
+                raise SystemExit(f"{label}: malformed service-account unique id")
+            allowed_accounts.add(unique_id)
+        if name is not None:
+            prefixes = (
+                f"projects/{project}/serviceAccounts/",
+                "projects/-/serviceAccounts/",
+            )
+            matching_prefix = next(
+                (prefix for prefix in prefixes if name.startswith(prefix)), None
+            ) if isinstance(name, str) else None
+            if matching_prefix is None or name[len(matching_prefix):] not in allowed_accounts:
+                raise SystemExit(f"{label}: cross-project service-account entry")
+        return email
+    else:
+        raise SystemExit(f"{label}: unknown inventory kind")
+    if not isinstance(value, str):
+        raise SystemExit(f"{label}: malformed resource name")
+    if value.startswith("projects/"):
+        if not value.startswith(prefix):
+            raise SystemExit(f"{label}: cross-project or wrong-parent entry")
+        value = value[len(prefix):]
+    validator = location_identifier if kind == "kms-location" else identifier
+    if not validator.fullmatch(value):
+        raise SystemExit(f"{label}: invalid resource identifier")
+    return value
+
+values = [resource_id(item) for item in items]
+if len(values) != len(set(values)):
+    raise SystemExit(f"{label}: duplicate inventory entry")
+print("\n".join(sorted(values)))
+' "$label" "$kind" "$PROJECT_ID" "$parent"
+}
+
+# Project- and ancestor-level grants cannot be safely constrained to one
+# runtime, secret, key, or recovery object. Resolve every role directly bound
+# to the deploy principal and reject broad data access, token minting, or
+# project-wide actAs. Narrow resource bindings are audited separately.
+verify_deploy_broad_permissions_absent_json() {
+  local label="$1"
+  local policy="$2"
+  local deploy_member="serviceAccount:${DEPLOY_SERVICE_ACCOUNT}"
+  local roles role role_json
+  if ! roles="$(printf '%s' "$policy" | python3 -c '
+import json
+import sys
+
+member = sys.argv[1]
+policy = json.load(sys.stdin)
+if not isinstance(policy, dict) or not isinstance(policy.get("bindings", []), list):
+    raise SystemExit("malformed IAM policy")
+roles = []
+for binding in policy.get("bindings", []):
+    if not isinstance(binding, dict):
+        raise SystemExit("malformed IAM binding")
+    role = binding.get("role")
+    members = binding.get("members", [])
+    if not isinstance(role, str) or not role or not isinstance(members, list):
+        raise SystemExit("malformed IAM binding")
+    if member in members:
+        roles.append(role)
+if len(set(roles)) != len(roles):
+    raise SystemExit("deploy principal has duplicate role bindings")
+print("\n".join(sorted(roles)))
+' "$deploy_member")"; then
+    echo "ERROR: cannot inspect deploy identity bindings at ${label}" >&2
+    return 1
+  fi
+  while IFS= read -r role; do
+    [ -n "$role" ] || continue
+    role_json="$(read_cloud_json "deploy identity role definition" \
+      describe_iam_role_definition_readonly "$role")" || return 1
+    if ! printf '%s' "$role_json" | python3 -c '
+import json
+import sys
+
+value = json.load(sys.stdin)
+permissions = value.get("includedPermissions")
+if not isinstance(permissions, list) or any(not isinstance(item, str) for item in permissions):
+    raise SystemExit("role permission inventory is malformed")
+forbidden = {
+    "aiplatform.endpoints.predict",
+    "bigtable.tables.mutateRows",
+    "bigtable.tables.readRows",
+    "cloudkms.cryptoKeyVersions.useToDecrypt",
+    "cloudkms.cryptoKeyVersions.useToEncrypt",
+    "iam.serviceAccounts.actAs",
+    "iam.serviceAccounts.getAccessToken",
+    "secretmanager.versions.access",
+    "spanner.databases.read",
+    "spanner.databases.write",
+    "spanner.sessions.create",
+}
+if forbidden.intersection(permissions) or any(
+    permission.startswith("storage.objects.") for permission in permissions
+):
+    raise SystemExit("deploy role contains project/ancestor data or impersonation permission")
+'; then
+      echo "ERROR: deploy identity has a broad data or impersonation permission at ${label}" >&2
+      return 1
+    fi
+  done <<<"$roles"
+}
+
+verify_journal_role_and_bucket_policy() {
+  [ -n "$ROLLOUT_STATE_GCS_URI" ] || return 0
+  local role_json bucket_policy expected_expression
+  role_json="$(read_cloud_json "rollout journal custom-role definition" \
+    describe_iam_role_definition_readonly "$ROLLOUT_STATE_GCS_ROLE")" || return 1
+  if ! printf '%s' "$role_json" | python3 -c '
+import json
+import sys
+
+expected_name = sys.argv[1]
+value = json.load(sys.stdin)
+if value.get("name") != expected_name:
+    raise SystemExit("rollout journal custom role identity mismatch")
+if value.get("deleted", False) is not False:
+    raise SystemExit("rollout journal custom role is deleted")
+permissions = value.get("includedPermissions")
+expected = {
+    "storage.objects.get",
+    "storage.objects.create",
+    "storage.objects.delete",
+}
+if not isinstance(permissions, list) or len(permissions) != len(set(permissions)):
+    raise SystemExit("rollout journal custom role permission inventory is malformed")
+if set(permissions) != expected:
+    raise SystemExit("rollout journal custom role permissions drifted")
+' "$ROLLOUT_STATE_GCS_ROLE"; then
+    echo "ERROR: rollout journal custom role is not the exact three-permission role" >&2
+    return 1
+  fi
+
+  bucket_policy="$(read_cloud_json "rollout journal bucket IAM policy" \
+    gc storage buckets get-iam-policy "gs://${ROLLOUT_STATE_BUCKET}" --format=json)" || return 1
+  expected_expression="resource.name == \"projects/_/buckets/${ROLLOUT_STATE_BUCKET}/objects/${ROLLOUT_STATE_OBJECT}\""
+  if ! printf '%s' "$bucket_policy" | python3 -c '
+import json
+import sys
+
+role, member, title, expression = sys.argv[1:5]
+policy = json.load(sys.stdin)
+if not isinstance(policy, dict) or not isinstance(policy.get("bindings", []), list):
+    raise SystemExit("rollout journal bucket IAM policy is malformed")
+role_bindings = []
+member_bindings = []
+for binding in policy.get("bindings", []):
+    if not isinstance(binding, dict):
+        raise SystemExit("rollout journal bucket IAM binding is malformed")
+    binding_role = binding.get("role")
+    members = binding.get("members", [])
+    if not isinstance(binding_role, str) or not isinstance(members, list):
+        raise SystemExit("rollout journal bucket IAM binding is malformed")
+    if binding_role == role:
+        role_bindings.append(binding)
+    if member in members:
+        member_bindings.append(binding)
+if len(role_bindings) != 1 or len(member_bindings) != 1 or role_bindings[0] is not member_bindings[0]:
+    raise SystemExit("rollout journal bucket binding is not unique")
+binding = role_bindings[0]
+if binding.get("members") != [member]:
+    raise SystemExit("rollout journal bucket role has noncanonical members")
+condition = binding.get("condition")
+if not isinstance(condition, dict):
+    raise SystemExit("rollout journal bucket role lacks its object condition")
+if condition.get("title") != title or condition.get("expression") != expression:
+    raise SystemExit("rollout journal bucket object condition drifted")
+if set(condition) - {"title", "expression", "description"}:
+    raise SystemExit("rollout journal bucket condition has unknown fields")
+' "$ROLLOUT_STATE_GCS_ROLE" "serviceAccount:${DEPLOY_SERVICE_ACCOUNT}" \
+    "trusted-router-rollout-journal" "$expected_expression"; then
+    echo "ERROR: rollout journal bucket IAM is not the exact object-scoped binding" >&2
+    return 1
+  fi
+}
+
+verify_recovery_role_and_bucket_policy() {
+  [ "$ROLLOUT_RECOVERY_ACTIVE" = true ] || return 0
+  local role_json bucket_json bucket_policy
+  local authority_resource bundle_resource_prefix expected_expression
+
+  role_json="$(read_cloud_json "rollout recovery custom-role definition" \
+    describe_iam_role_definition_readonly "$ROLLOUT_RECOVERY_GCS_ROLE")" || return 1
+  if ! printf '%s' "$role_json" | python3 -c '
+import json
+import sys
+
+expected_name = sys.argv[1]
+value = json.load(sys.stdin)
+if value.get("name") != expected_name:
+    raise SystemExit("rollout recovery custom role identity mismatch")
+if value.get("deleted", False) is not False:
+    raise SystemExit("rollout recovery custom role is deleted")
+permissions = value.get("includedPermissions")
+expected = {
+    "storage.objects.create",
+    "storage.objects.delete",
+    "storage.objects.get",
+}
+if not isinstance(permissions, list) or len(permissions) != len(set(permissions)):
+    raise SystemExit("rollout recovery custom role permission inventory is malformed")
+if set(permissions) != expected:
+    raise SystemExit("rollout recovery custom role permissions drifted")
+' "$ROLLOUT_RECOVERY_GCS_ROLE"; then
+    echo "ERROR: rollout recovery custom role is not the exact three-permission role" >&2
+    return 1
+  fi
+
+  bucket_json="$(read_cloud_json "rollout recovery bucket metadata" \
+    gc storage buckets describe "gs://${ROLLOUT_RECOVERY_BUCKET}" \
+      --format=json)" || return 1
+  if ! printf '%s' "$bucket_json" | python3 -c '
+import json
+import sys
+
+expected_name = sys.argv[1]
+value = json.load(sys.stdin)
+if value.get("name") != expected_name:
+    raise SystemExit("rollout recovery bucket identity mismatch")
+iam = value.get("iamConfiguration") or {}
+uniform = iam.get("uniformBucketLevelAccess") or {}
+if uniform.get("enabled") is not True:
+    raise SystemExit("rollout recovery bucket lacks uniform access")
+if str(iam.get("publicAccessPrevention", "")).lower() != "enforced":
+    raise SystemExit("rollout recovery bucket lacks public-access prevention")
+if (value.get("versioning") or {}).get("enabled") is not True:
+    raise SystemExit("rollout recovery bucket lacks versioning")
+retention = (value.get("retentionPolicy") or {}).get("retentionPeriod")
+try:
+    retention_seconds = int(retention)
+except (TypeError, ValueError):
+    raise SystemExit("rollout recovery bucket retention is malformed") from None
+if retention_seconds < 7 * 24 * 60 * 60:
+    raise SystemExit("rollout recovery bucket retention is shorter than seven days")
+' "$ROLLOUT_RECOVERY_BUCKET"; then
+    echo "ERROR: rollout recovery bucket protection contract drifted" >&2
+    return 1
+  fi
+
+  authority_resource="projects/_/buckets/${ROLLOUT_RECOVERY_BUCKET}/objects/${ROLLOUT_RECOVERY_OBJECT_PREFIX}/authority.json"
+  bundle_resource_prefix="projects/_/buckets/${ROLLOUT_RECOVERY_BUCKET}/objects/${ROLLOUT_RECOVERY_OBJECT_PREFIX}/releases/${ROLLOUT_RECOVERY_EPOCH}/"
+  expected_expression="resource.name == \"${authority_resource}\" || resource.name.startsWith(\"${bundle_resource_prefix}\")"
+  bucket_policy="$(read_cloud_json "rollout recovery bucket IAM policy" \
+    gc storage buckets get-iam-policy "gs://${ROLLOUT_RECOVERY_BUCKET}" \
+      --format=json)" || return 1
+  if ! printf '%s' "$bucket_policy" | python3 -c '
+import json
+import sys
+
+role, member, title, expression = sys.argv[1:5]
+policy = json.load(sys.stdin)
+bindings = policy.get("bindings")
+if not isinstance(bindings, list) or len(bindings) != 1:
+    raise SystemExit("recovery bucket must have one exact binding")
+binding = bindings[0]
+if not isinstance(binding, dict) or set(binding) != {"role", "members", "condition"}:
+    raise SystemExit("recovery bucket binding shape drifted")
+if binding.get("role") != role or binding.get("members") != [member]:
+    raise SystemExit("recovery bucket role or principal drifted")
+condition = binding.get("condition")
+if not isinstance(condition, dict) or set(condition) != {"title", "expression"}:
+    raise SystemExit("recovery bucket condition shape drifted")
+if condition.get("title") != title or condition.get("expression") != expression:
+    raise SystemExit("recovery bucket condition scope drifted")
+' "$ROLLOUT_RECOVERY_GCS_ROLE" "serviceAccount:${DEPLOY_SERVICE_ACCOUNT}" \
+    "trusted-router-rollout-recovery" "$expected_expression"; then
+    echo "ERROR: rollout recovery bucket IAM is not the exact authority-and-bundle binding" >&2
+    return 1
+  fi
+}
+
+EMPTY_MATRIX="public=,actions=,console=,chat=,webhooks=,internal="
+PROJECT_MATRIX="public=roles/serviceusage.serviceUsageConsumer,actions=,console=roles/serviceusage.serviceUsageConsumer,chat=roles/serviceusage.serviceUsageConsumer,webhooks=roles/serviceusage.serviceUsageConsumer,internal=roles/serviceusage.serviceUsageConsumer"
+SPANNER_MATRIX="public=roles/spanner.databaseReader,actions=,console=roles/spanner.databaseUser,chat=roles/spanner.databaseReader,webhooks=roles/spanner.databaseUser,internal=roles/spanner.databaseUser"
+BIGTABLE_MATRIX="public=roles/bigtable.reader,actions=,console=roles/bigtable.reader,chat=,webhooks=,internal=roles/bigtable.user"
+BYOK_MATRIX="public=,actions=,console=roles/cloudkms.cryptoKeyEncrypterDecrypter,chat=,webhooks=,internal=roles/cloudkms.cryptoKeyDecrypter"
+GOOGLE_ADS_MATRIX="public=,actions=,console=roles/cloudkms.cryptoKeyEncrypter,chat=,webhooks=,internal="
+
+PROJECT_POLICY_JSON="$(read_cloud_json "project IAM policy" \
+  gc projects get-iam-policy "$PROJECT_ID" --format=json)" || exit 1
+if ! printf '%s' "$PROJECT_POLICY_JSON" | \
+    verify_six_runtime_matrix_json "project" "$PROJECT_MATRIX"; then
+  echo "ERROR: project has unsafe six-runtime IAM" >&2
+  exit 1
+fi
+verify_deploy_broad_permissions_absent_json "project" "$PROJECT_POLICY_JSON"
+
+# A named-resource audit is insufficient: a stale grant on an older database,
+# table, key, or service account remains live.  Inventory every resource in the
+# project and require the exact configured matrix only at the canonical target;
+# all other resources must have zero six-runtime/synthetic bindings.  This is a
+# read-only gate and deliberately owns no automatic cleanup path.
+SPANNER_INSTANCES_JSON="$(read_cloud_json "Spanner instance inventory" \
+  gc spanner instances list --format=json)" || exit 1
+if ! SPANNER_INSTANCE_IDS="$(printf '%s' "$SPANNER_INSTANCES_JSON" | \
+    normalize_project_inventory_json "Spanner instance" spanner-instance "")"; then
+  echo "ERROR: Spanner instance inventory is malformed" >&2
+  exit 1
+fi
+SPANNER_INSTANCE_FOUND=0
+SPANNER_DATABASE_FOUND=0
+while IFS= read -r spanner_instance; do
+  [ -n "$spanner_instance" ] || continue
+  [ "$spanner_instance" != "$SPANNER_INSTANCE_ID" ] || SPANNER_INSTANCE_FOUND=1
+  verify_policy_from_cloud "Spanner inventory instance" "$EMPTY_MATRIX" \
+    gc spanner instances get-iam-policy "$spanner_instance" --format=json
+
+  spanner_databases_json="$(read_cloud_json "Spanner database inventory" \
+    gc spanner databases list --instance="$spanner_instance" --format=json)" || exit 1
+  if ! spanner_database_ids="$(printf '%s' "$spanner_databases_json" | \
+      normalize_project_inventory_json "Spanner database" spanner-database \
+        "$spanner_instance")"; then
+    echo "ERROR: Spanner database inventory is malformed" >&2
+    exit 1
+  fi
+  while IFS= read -r spanner_database; do
+    [ -n "$spanner_database" ] || continue
+    spanner_matrix="$EMPTY_MATRIX"
+    if [ "$spanner_instance" = "$SPANNER_INSTANCE_ID" ] && \
+       [ "$spanner_database" = "$SPANNER_DATABASE_ID" ]; then
+      SPANNER_DATABASE_FOUND=1
+      spanner_matrix="$SPANNER_MATRIX"
+    fi
+    verify_policy_from_cloud "Spanner inventory database" "$spanner_matrix" \
+      gc spanner databases get-iam-policy "$spanner_database" \
+        --instance="$spanner_instance" --format=json
+  done <<<"$spanner_database_ids"
+done <<<"$SPANNER_INSTANCE_IDS"
+[ "$SPANNER_INSTANCE_FOUND" = 1 ] && [ "$SPANNER_DATABASE_FOUND" = 1 ] || {
+  echo "ERROR: canonical Spanner instance/database is absent from the project inventory" >&2
+  exit 1
+}
+
+BIGTABLE_INSTANCES_JSON="$(read_cloud_json "Bigtable instance inventory" \
+  gc bigtable instances list --format=json)" || exit 1
+if ! BIGTABLE_INSTANCE_IDS="$(printf '%s' "$BIGTABLE_INSTANCES_JSON" | \
+    normalize_project_inventory_json "Bigtable instance" bigtable-instance "")"; then
+  echo "ERROR: Bigtable instance inventory is malformed" >&2
+  exit 1
+fi
+BIGTABLE_INSTANCE_FOUND=0
+BIGTABLE_TABLE_FOUND=0
+while IFS= read -r bigtable_instance; do
+  [ -n "$bigtable_instance" ] || continue
+  bigtable_matrix="$EMPTY_MATRIX"
+  if [ "$bigtable_instance" = "$BIGTABLE_INSTANCE_ID" ]; then
+    BIGTABLE_INSTANCE_FOUND=1
+    bigtable_matrix="$BIGTABLE_MATRIX"
+  fi
+  verify_policy_from_cloud "Bigtable inventory instance" "$bigtable_matrix" \
+    gc bigtable instances get-iam-policy "$bigtable_instance" --format=json
+
+  bigtable_tables_json="$(read_cloud_json "Bigtable table inventory" \
+    gc bigtable tables list --instances="$bigtable_instance" --format=json)" || exit 1
+  if ! bigtable_table_ids="$(printf '%s' "$bigtable_tables_json" | \
+      normalize_project_inventory_json "Bigtable table" bigtable-table \
+        "$bigtable_instance")"; then
+    echo "ERROR: Bigtable table inventory is malformed" >&2
+    exit 1
+  fi
+  while IFS= read -r bigtable_table; do
+    [ -n "$bigtable_table" ] || continue
+    if [ "$bigtable_instance" = "$BIGTABLE_INSTANCE_ID" ] && \
+       [ "$bigtable_table" = "$BIGTABLE_GENERATION_TABLE" ]; then
+      BIGTABLE_TABLE_FOUND=1
+    fi
+    verify_policy_from_cloud "Bigtable inventory table" "$EMPTY_MATRIX" \
+      gc bigtable tables get-iam-policy "$bigtable_table" \
+        --instance="$bigtable_instance" --format=json
+  done <<<"$bigtable_table_ids"
+done <<<"$BIGTABLE_INSTANCE_IDS"
+[ "$BIGTABLE_INSTANCE_FOUND" = 1 ] && [ "$BIGTABLE_TABLE_FOUND" = 1 ] || {
+  echo "ERROR: canonical Bigtable instance/table is absent from the project inventory" >&2
+  exit 1
+}
+
+KMS_LOCATIONS_JSON="$(read_cloud_json "KMS location inventory" \
+  gc kms locations list --format=json)" || exit 1
+if ! KMS_LOCATION_IDS="$(printf '%s' "$KMS_LOCATIONS_JSON" | \
+    normalize_project_inventory_json "KMS location" kms-location "")"; then
+  echo "ERROR: KMS location inventory is malformed" >&2
+  exit 1
+fi
+KMS_LOCATION_FOUND=0
+KMS_KEYRING_FOUND=0
+BYOK_KEY_FOUND=0
+GOOGLE_ADS_KEY_FOUND=0
+while IFS= read -r kms_location; do
+  [ -n "$kms_location" ] || continue
+  [ "$kms_location" != "$REGION" ] || KMS_LOCATION_FOUND=1
+  kms_keyrings_json="$(read_cloud_json "KMS keyring inventory" \
+    gc kms keyrings list --location="$kms_location" --format=json)" || exit 1
+  if ! kms_keyring_ids="$(printf '%s' "$kms_keyrings_json" | \
+      normalize_project_inventory_json "KMS keyring" kms-keyring \
+        "$kms_location")"; then
+    echo "ERROR: KMS keyring inventory is malformed" >&2
+    exit 1
+  fi
+  while IFS= read -r kms_keyring; do
+    [ -n "$kms_keyring" ] || continue
+    if [ "$kms_location" = "$REGION" ] && \
+       [ "$kms_keyring" = "$KMS_KEYRING_ID" ]; then
+      KMS_KEYRING_FOUND=1
+    fi
+    verify_policy_from_cloud "KMS inventory keyring" "$EMPTY_MATRIX" \
+      gc kms keyrings get-iam-policy "$kms_keyring" \
+        --location="$kms_location" --format=json
+
+    kms_keys_json="$(read_cloud_json "KMS key inventory" \
+      gc kms keys list --keyring="$kms_keyring" \
+        --location="$kms_location" --format=json)" || exit 1
+    if ! kms_key_ids="$(printf '%s' "$kms_keys_json" | \
+        normalize_project_inventory_json "KMS key" kms-key \
+          "${kms_location}/${kms_keyring}")"; then
+      echo "ERROR: KMS key inventory is malformed" >&2
+      exit 1
+    fi
+    while IFS= read -r kms_key; do
+      [ -n "$kms_key" ] || continue
+      kms_matrix="$EMPTY_MATRIX"
+      if [ "$kms_location" = "$REGION" ] && \
+         [ "$kms_keyring" = "$KMS_KEYRING_ID" ] && \
+         [ "$kms_key" = "$BYOK_KMS_KEY_ID" ]; then
+        BYOK_KEY_FOUND=1
+        kms_matrix="$BYOK_MATRIX"
+      elif [ "$kms_location" = "$REGION" ] && \
+           [ "$kms_keyring" = "$KMS_KEYRING_ID" ] && \
+           [ "$kms_key" = "$GOOGLE_ADS_KMS_KEY_ID" ]; then
+        GOOGLE_ADS_KEY_FOUND=1
+        kms_matrix="$GOOGLE_ADS_MATRIX"
+      fi
+      verify_policy_from_cloud "KMS inventory key" "$kms_matrix" \
+        gc kms keys get-iam-policy "$kms_key" --keyring="$kms_keyring" \
+          --location="$kms_location" --format=json
+    done <<<"$kms_key_ids"
+  done <<<"$kms_keyring_ids"
+done <<<"$KMS_LOCATION_IDS"
+[ "$KMS_LOCATION_FOUND" = 1 ] && [ "$KMS_KEYRING_FOUND" = 1 ] && \
+  [ "$BYOK_KEY_FOUND" = 1 ] && [ "$GOOGLE_ADS_KEY_FOUND" = 1 ] || {
+  echo "ERROR: canonical KMS location/keyring/keys are absent from the project inventory" >&2
+  exit 1
+}
+
+SERVICE_ACCOUNTS_JSON="$(read_cloud_json "service-account inventory" \
+  gc iam service-accounts list --format=json)" || exit 1
+if ! SERVICE_ACCOUNT_EMAILS="$(printf '%s' "$SERVICE_ACCOUNTS_JSON" | \
+    normalize_project_inventory_json "service account" service-account "")"; then
+  echo "ERROR: project service-account inventory is malformed" >&2
+  exit 1
+fi
+CANONICAL_SERVICE_ACCOUNT_INVENTORY="|"
+for runtime_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}" \
+  "$SYNTHETIC_RUN_SERVICE_ACCOUNT"; do
+  CANONICAL_SERVICE_ACCOUNT_INVENTORY="${CANONICAL_SERVICE_ACCOUNT_INVENTORY}${runtime_account}|"
+  case $'\n'"$SERVICE_ACCOUNT_EMAILS"$'\n' in
+    *$'\n'"${runtime_account}"$'\n'*) ;;
+    *)
+      echo "ERROR: a canonical split/synthetic identity is absent from the project inventory" >&2
+      exit 1
+      ;;
+  esac
+done
+while IFS= read -r service_account; do
+  [ -n "$service_account" ] || continue
+  case "$CANONICAL_SERVICE_ACCOUNT_INVENTORY" in
+    *"|${service_account}|"*) continue ;;
+  esac
+  verify_policy_from_cloud "other project service account" "$EMPTY_MATRIX" \
+    gc iam service-accounts get-iam-policy "$service_account" --format=json
+done <<<"$SERVICE_ACCOUNT_EMAILS"
+
+# Project ancestors are an inherited privilege boundary.  A read failure is a
+# hard failure because absence cannot otherwise be proven.
+ANCESTORS_JSON="$(read_cloud_json "project ancestor inventory" \
+  gc projects get-ancestors "$PROJECT_ID" --format=json)" || exit 1
+if ! ANCESTOR_ROWS="$(printf '%s' "$ANCESTORS_JSON" | python3 -c '
+import json
+import re
+import sys
+
+items = json.load(sys.stdin)
+expected_project = sys.argv[1]
+if not isinstance(items, list):
+    raise SystemExit("malformed ancestor inventory")
+seen = set()
+rows = []
+for item in items:
+    if not isinstance(item, dict):
+        raise SystemExit("malformed ancestor inventory")
+    kind = item.get("type")
+    identifier = str(item.get("id", ""))
+    if kind not in {"project", "folder", "organization"}:
+        raise SystemExit("unknown ancestor type")
+    if not re.fullmatch(r"[A-Za-z0-9-]+", identifier):
+        raise SystemExit("invalid ancestor identifier")
+    key = (kind, identifier)
+    if key in seen:
+        raise SystemExit("duplicate ancestor")
+    seen.add(key)
+    if kind != "project":
+        rows.append(key)
+project_rows = [key for key in seen if key[0] == "project"]
+if project_rows != [("project", expected_project)]:
+    raise SystemExit("project ancestor inventory does not identify the audited project")
+print("\n".join("\t".join(row) for row in rows))
+' "$PROJECT_ID")"; then
+  echo "ERROR: project ancestor inventory is malformed" >&2
+  exit 1
+fi
+while IFS=$'\t' read -r ancestor_type ancestor_id; do
+  [ -n "$ancestor_type" ] || continue
+  case "$ancestor_type" in
+    folder)
+      ancestor_policy="$(read_cloud_json "folder ancestor IAM policy" \
+        gc resource-manager folders get-iam-policy "$ancestor_id" --format=json)" || exit 1
+      if ! printf '%s' "$ancestor_policy" | \
+          verify_six_runtime_matrix_json "folder ancestor" "$EMPTY_MATRIX"; then
+        echo "ERROR: folder ancestor has unsafe six-runtime IAM" >&2
+        exit 1
+      fi
+      verify_deploy_broad_permissions_absent_json "folder ancestor" "$ancestor_policy"
+      ;;
+    organization)
+      ancestor_policy="$(read_cloud_json "organization ancestor IAM policy" \
+        gc organizations get-iam-policy "$ancestor_id" --format=json)" || exit 1
+      if ! printf '%s' "$ancestor_policy" | \
+          verify_six_runtime_matrix_json "organization ancestor" "$EMPTY_MATRIX"; then
+        echo "ERROR: organization ancestor has unsafe six-runtime IAM" >&2
+        exit 1
+      fi
+      verify_deploy_broad_permissions_absent_json "organization ancestor" "$ancestor_policy"
+      ;;
+    *)
+      echo "ERROR: project ancestor inventory is malformed" >&2
+      exit 1
+      ;;
+  esac
+done <<<"$ANCESTOR_ROWS"
+
+if [ "$ROLLOUT_RECOVERY_ACTIVE" = true ]; then
+  verify_recovery_role_and_bucket_policy
+else
+  verify_journal_role_and_bucket_policy
+fi
+
+synthetic_description="$(read_cloud_json "synthetic service-account description" \
+  gc iam service-accounts describe "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
+    --format=json)" || exit 1
+if ! printf '%s' "$synthetic_description" | python3 -c '
+import json
+import sys
+
+expected = sys.argv[1]
+value = json.load(sys.stdin)
+if value.get("email") != expected or value.get("disabled", False) is not False:
+    raise SystemExit("synthetic identity is absent, renamed, or disabled")
+' "$SYNTHETIC_RUN_SERVICE_ACCOUNT"; then
+  echo "ERROR: canonical synthetic service account is absent, renamed, or disabled" >&2
+  exit 1
+fi
+synthetic_policy="$(read_cloud_json "synthetic service-account IAM policy" \
+  gc iam service-accounts get-iam-policy "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
+    --format=json)" || exit 1
+if ! printf '%s' "$synthetic_policy" | python3 -c '
+import json
+import sys
+
+policy = json.load(sys.stdin)
+expected = [{
+    "role": "roles/iam.serviceAccountUser",
+    "members": [sys.argv[1]],
+}]
+bindings = policy.get("bindings") or []
+if bindings != expected:
+    raise SystemExit("synthetic identity actAs policy differs")
+' "serviceAccount:${DEPLOY_SERVICE_ACCOUNT}"; then
+  echo "ERROR: synthetic identity does not have the exact deploy-only actAs policy" >&2
+  exit 1
+fi
+
+# The shared helper is the canonical complete-policy contract for runtime
+# service accounts.  `post` requires exactly one unconditional deploy
+# serviceAccountUser grant, permits only explicitly configured operators, and
+# rejects every cross-runtime or otherwise unapproved direct principal.
+for runtime_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do
+  runtime_description="$(read_cloud_json "runtime service-account description" \
+    gc iam service-accounts describe "$runtime_account" --format=json)" || exit 1
+  if ! printf '%s' "$runtime_description" | python3 -c '
+import json
+import sys
+
+expected = sys.argv[1]
+value = json.load(sys.stdin)
+if value.get("email") != expected or value.get("disabled", False) is not False:
+    raise SystemExit("runtime identity is absent, renamed, or disabled")
+' "$runtime_account"; then
+    echo "ERROR: a canonical runtime service account is absent, renamed, or disabled" >&2
+    exit 1
+  fi
+  runtime_policy="$(read_cloud_json "runtime service-account IAM policy" \
+    gc iam service-accounts get-iam-policy "$runtime_account" --format=json)" || exit 1
+  if ! printf '%s' "$runtime_policy" | \
+      verify_runtime_service_account_policy_json "$runtime_account" post; then
+    echo "ERROR: a runtime service account has unsafe direct IAM" >&2
+    exit 1
+  fi
+  if ! printf '%s' "$runtime_policy" | python3 -c '
+import json
+import sys
+
+member = sys.argv[1]
+policy = json.load(sys.stdin)
+matches = [
+    (binding.get("role"), binding.get("condition") if "condition" in binding else None)
+    for binding in policy.get("bindings", [])
+    if member in (binding.get("members") or [])
+]
+if matches:
+    raise SystemExit("synthetic identity may not impersonate a split runtime")
+' "serviceAccount:tr-synthetic@${PROJECT_ID}.iam.gserviceaccount.com"; then
+    echo "ERROR: synthetic identity has a direct binding on a runtime service account" >&2
+    exit 1
+  fi
+done
+
+SECRETS_JSON="$(read_cloud_json "Secret Manager inventory" \
+  gc secrets list --format=json)" || exit 1
+if ! SECRET_NAMES="$(printf '%s' "$SECRETS_JSON" | python3 -c '
+import json
+import re
+import sys
+
+project = sys.argv[1]
+items = json.load(sys.stdin)
+if not isinstance(items, list):
+    raise SystemExit("malformed secret inventory")
+names = []
+prefix = f"projects/{project}/secrets/"
+for item in items:
+    if not isinstance(item, dict) or not isinstance(item.get("name"), str):
+        raise SystemExit("malformed secret inventory")
+    name = item["name"]
+    if name.startswith("projects/"):
+        if not name.startswith(prefix):
+            raise SystemExit("cross-project secret inventory entry")
+        name = name[len(prefix):]
+    if not re.fullmatch(r"[A-Za-z0-9_-]{1,255}", name):
+        raise SystemExit("invalid secret resource identifier")
+    names.append(name)
+if len(set(names)) != len(names):
+    raise SystemExit("duplicate secret inventory entry")
+print("\n".join(sorted(names)))
+' "$PROJECT_ID")"; then
+  echo "ERROR: Secret Manager inventory is malformed" >&2
+  exit 1
+fi
+
+if ! printf '%s' "$TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON" | python3 -c '
+import json
+import sys
+
+inventory = set(sys.argv[1].splitlines())
+value = json.load(sys.stdin)
+missing = sorted(set(value) - inventory)
+if missing:
+    raise SystemExit("preserved secret accessor allowlist references absent resources")
+' "$SECRET_NAMES"; then
+  echo "ERROR: explicit preserved secret accessor inventory is invalid" >&2
+  exit 1
+fi
+
+SECRET_INVENTORY="|"
+while IFS= read -r secret_name; do
+  [ -n "$secret_name" ] || continue
+  SECRET_INVENTORY="${SECRET_INVENTORY}${secret_name}|"
+  if expected_surfaces="$(secret_expected_surfaces "$secret_name")"; then
+    :
+  else
+    expected_surfaces=""
+  fi
+  secret_policy="$(read_cloud_json "Secret Manager inventory-item IAM policy" \
+    gc secrets get-iam-policy "$secret_name" --format=json)" || exit 1
+  if ! printf '%s' "$secret_policy" | \
+      secret_iam_policy_contract_json verify "$secret_name" "$expected_surfaces"; then
+    echo "ERROR: a Secret Manager resource has unsafe exact accessor IAM" >&2
+    exit 1
+  fi
+done <<<"$SECRET_NAMES"
+
+if [ -n "$MANIFEST_PATH" ]; then
+  # The recovery manifest is intentionally non-secret.  Reject any injected
+  # secret-like field before emitting the small, fixed candidate inventory.
+  if ! MANIFEST_ROWS="$(python3 -c '
+import json
+import re
+import sys
+
+path, expected_project = sys.argv[1:3]
+try:
+    with open(path, encoding="utf-8") as source:
+        manifest = json.load(source)
+except (OSError, json.JSONDecodeError):
+    raise SystemExit("manifest is unreadable")
+
+forbidden = re.compile(r"(?:^|_)(?:secret|token|password|credential|private_key)(?:_|$)", re.I)
+def reject_sensitive_keys(value):
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if forbidden.search(str(key)):
+                raise SystemExit("manifest contains a sensitive field")
+            reject_sensitive_keys(item)
+    elif isinstance(value, list):
+        for item in value:
+            reject_sensitive_keys(item)
+reject_sensitive_keys(manifest)
+
+if not isinstance(manifest, dict) or manifest.get("project_id") != expected_project:
+    raise SystemExit("manifest project mismatch")
+regions = manifest.get("regions")
+internal_regions = manifest.get("internal_regions")
+services = manifest.get("services")
+if (
+    not isinstance(regions, list)
+    or not regions
+    or not isinstance(internal_regions, list)
+    or not internal_regions
+    or not isinstance(services, list)
+):
+    raise SystemExit("manifest candidate inventory is malformed")
+if len(set(regions)) != len(regions) or any(
+    not isinstance(region, str) or not re.fullmatch(r"[a-z]+-[a-z0-9]+[0-9]", region)
+    for region in regions
+):
+    raise SystemExit("manifest region inventory is malformed")
+if (
+    len(set(internal_regions)) != len(internal_regions)
+    or not set(regions).issubset(internal_regions)
+    or any(
+        not isinstance(region, str)
+        or not re.fullmatch(r"[a-z]+-[a-z0-9]+[0-9]", region)
+        for region in internal_regions
+    )
+):
+    raise SystemExit("manifest internal region inventory is malformed")
+
+names = {
+    "public": "trusted-router-public",
+    "actions": "trusted-router-actions",
+    "console": "trusted-router-console",
+    "chat": "trusted-router-chat",
+    "webhooks": "trusted-router-webhooks",
+    "internal": "trusted-router-billing",
+}
+rows = []
+seen = set()
+for entry in services:
+    if not isinstance(entry, dict):
+        raise SystemExit("manifest candidate entry is malformed")
+    surface = entry.get("surface")
+    region = entry.get("region")
+    name = entry.get("name")
+    candidate = entry.get("candidate_revision")
+    account = entry.get("runtime_service_account")
+    allowed_regions = internal_regions if surface == "internal" else regions
+    if surface not in names or region not in allowed_regions or name != names[surface]:
+        raise SystemExit("manifest candidate entry is noncanonical")
+    if account != f"tr-{surface}@{expected_project}.iam.gserviceaccount.com":
+        raise SystemExit("manifest candidate identity is noncanonical")
+    if not isinstance(candidate, str) or not re.fullmatch(r"[a-z][a-z0-9-]{0,61}", candidate):
+        raise SystemExit("manifest candidate revision is malformed")
+    if not candidate.startswith(name + "-"):
+        raise SystemExit("manifest candidate revision does not belong to its service")
+    key = (surface, region)
+    if key in seen:
+        raise SystemExit("manifest candidate inventory contains duplicates")
+    seen.add(key)
+    rows.append((surface, name, region, candidate, account))
+expected = {
+    (surface, region)
+    for surface in names
+    for region in (internal_regions if surface == "internal" else regions)
+}
+if seen != expected:
+    raise SystemExit("manifest candidate inventory is not the complete surface-region matrix")
+print("\n".join("\t".join(row) for row in sorted(rows)))
+' "$MANIFEST_PATH" "$PROJECT_ID" 2>/dev/null)"; then
+    echo "ERROR: rollout manifest candidate inventory is invalid" >&2
+    exit 1
+  fi
+
+  while IFS=$'\t' read -r surface service_name region candidate account; do
+    [ -n "$surface" ] || continue
+    revision_json="$(read_cloud_json "candidate Cloud Run revision" \
+      gc run revisions describe "$candidate" --region="$region" --format=json)" || exit 1
+    if ! MOUNTED_REFS="$(printf '%s' "$revision_json" | python3 -c '
+import json
+import re
+import sys
+
+project, candidate, account = sys.argv[1:4]
+revision = json.load(sys.stdin)
+if not isinstance(revision, dict):
+    raise SystemExit("candidate revision is malformed")
+metadata = revision.get("metadata") or {}
+spec = revision.get("spec") or {}
+if metadata.get("name") != candidate or spec.get("serviceAccountName") != account:
+    raise SystemExit("candidate revision identity mismatch")
+
+prefix = f"projects/{project}/secrets/"
+def normalize_name(value):
+    if not isinstance(value, str):
+        raise SystemExit("candidate secret reference is malformed")
+    if value.startswith("projects/"):
+        if not value.startswith(prefix):
+            raise SystemExit("candidate has a cross-project secret reference")
+        value = value[len(prefix):]
+    if not re.fullmatch(r"[A-Za-z0-9_-]{1,255}", value):
+        raise SystemExit("candidate secret reference is malformed")
+    return value
+
+def normalize_version(value):
+    if isinstance(value, bool):
+        raise SystemExit("candidate secret version is not numeric")
+    value = str(value)
+    if not re.fullmatch(r"[1-9][0-9]*", value):
+        raise SystemExit("candidate secret version is not numeric")
+    return value
+
+refs = []
+containers = spec.get("containers") or []
+if not isinstance(containers, list) or not containers:
+    raise SystemExit("candidate revision has no container inventory")
+for container in containers:
+    if not isinstance(container, dict):
+        raise SystemExit("candidate container is malformed")
+    for env in container.get("env") or []:
+        if not isinstance(env, dict):
+            raise SystemExit("candidate environment is malformed")
+        reference = ((env.get("valueFrom") or {}).get("secretKeyRef"))
+        if reference is None:
+            continue
+        if not isinstance(reference, dict):
+            raise SystemExit("candidate secret reference is malformed")
+        refs.append((normalize_name(reference.get("name")), normalize_version(
+            reference.get("key", reference.get("version"))
+        )))
+for volume in spec.get("volumes") or []:
+    if not isinstance(volume, dict):
+        raise SystemExit("candidate volume is malformed")
+    secret = volume.get("secret")
+    if secret is None:
+        continue
+    if not isinstance(secret, dict):
+        raise SystemExit("candidate secret volume is malformed")
+    name = normalize_name(secret.get("secretName", secret.get("name")))
+    items = secret.get("items")
+    if not isinstance(items, list) or not items:
+        raise SystemExit("candidate secret volume has an implicit version")
+    for item in items:
+        if not isinstance(item, dict):
+            raise SystemExit("candidate secret volume item is malformed")
+        refs.append((name, normalize_version(item.get("key", item.get("version")))))
+print("\n".join("\t".join(ref) for ref in sorted(set(refs))))
+' "$PROJECT_ID" "$candidate" "$account" 2>/dev/null)"; then
+      echo "ERROR: a candidate revision has malformed or unpinned mounted-secret metadata" >&2
+      exit 1
+    fi
+
+    while IFS=$'\t' read -r mounted_secret mounted_version; do
+      [ -n "$mounted_secret" ] || continue
+      case "$SECRET_INVENTORY" in
+        *"|${mounted_secret}|"*) ;;
+        *)
+          echo "ERROR: a candidate revision references a secret outside the verified project inventory" >&2
+          exit 1
+          ;;
+      esac
+      if mounted_owners="$(secret_expected_surfaces "$mounted_secret")"; then
+        case " ${mounted_owners} " in
+          *" ${surface} "*) ;;
+          *)
+            echo "ERROR: a candidate revision mounts a secret outside its declared surface ownership" >&2
+            exit 1
+            ;;
+        esac
+      else
+        echo "ERROR: a candidate revision mounts a secret with no declared static owner set" >&2
+        exit 1
+      fi
+      version_json="$(read_cloud_json "mounted secret-version status" \
+        gc secrets versions describe "$mounted_version" \
+          --secret="$mounted_secret" --format=json)" || exit 1
+      if ! printf '%s' "$version_json" | python3 -c '
+import json
+import sys
+
+project, secret, version = sys.argv[1:4]
+value = json.load(sys.stdin)
+if value.get("state") != "ENABLED":
+    raise SystemExit("mounted secret version is not enabled")
+name = value.get("name")
+expected = f"projects/{project}/secrets/{secret}/versions/{version}"
+if name is not None and name != expected:
+    raise SystemExit("mounted secret version identity mismatch")
+' "$PROJECT_ID" "$mounted_secret" "$mounted_version"; then
+        echo "ERROR: a candidate revision has a disabled or mismatched mounted secret version" >&2
+        exit 1
+      fi
+    done <<<"$MOUNTED_REFS"
+  done <<<"$MANIFEST_ROWS"
+fi
+
+echo "six-surface rollout IAM verification passed"

--- a/scripts/deploy/rollout_journal.py
+++ b/scripts/deploy/rollout_journal.py
@@ -1,0 +1,568 @@
+#!/usr/bin/env python3
+"""Atomic, secret-free rollout journal, lease, authority, and bundle records."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import tempfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+
+def _read(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _timestamp(value: datetime | None = None) -> str:
+    return (value or _now()).isoformat()
+
+
+def _atomic_write(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+    )
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            json.dump(value, output, indent=2, sort_keys=True)
+            output.write("\n")
+            output.flush()
+            os.fsync(output.fileno())
+        os.replace(temporary, path)
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _manifest_identity(manifest_path: Path) -> dict[str, Any]:
+    manifest = _read(manifest_path)
+    url_map = manifest.get("url_map") or {}
+    return {
+        "schema_version": 1,
+        "manifest_sha256": _digest(manifest_path),
+        "project_id": manifest.get("project_id"),
+        "url_map_name": url_map.get("name"),
+        "prior_url_map_sha256": url_map.get("prior_sha256"),
+        "candidate_url_map_sha256": url_map.get("candidate_sha256"),
+    }
+
+
+def _state(path: Path, manifest_path: Path) -> dict[str, Any]:
+    identity = _manifest_identity(manifest_path)
+    try:
+        state = _read(path)
+    except FileNotFoundError:
+        state = {**identity, "attempts": [], "lease": None}
+    if not isinstance(state, dict):
+        raise ValueError("promotion state must be an object")
+    # Older local journals did not include the explicit lease member. Their
+    # manifest identity is still checked below before they are upgraded.
+    if "lease" not in state:
+        state["lease"] = None
+    if set(state) != {*identity, "attempts", "lease"}:
+        raise ValueError("promotion state fields differ from schema v1")
+    for key, expected in identity.items():
+        if state.get(key) != expected:
+            raise ValueError("promotion state belongs to a different rollout manifest")
+    if not isinstance(state.get("attempts"), list):
+        raise ValueError("promotion state attempts are invalid")
+    for attempt in state["attempts"]:
+        if not isinstance(attempt, dict) or set(attempt) != {
+            "attempted_at",
+            "operation",
+            "surface",
+            "service",
+            "region",
+            "target",
+        }:
+            raise ValueError("promotion state attempt fields differ")
+        _parse_timestamp(attempt["attempted_at"])
+        _validate_operation(attempt["operation"])
+        for key in ("surface", "service", "region"):
+            if attempt[key] is not None and not isinstance(attempt[key], str):
+                raise ValueError("promotion state attempt identity is invalid")
+        if not isinstance(attempt["target"], str):
+            raise ValueError("promotion state attempt target is invalid")
+    if state["lease"] is not None and not isinstance(state["lease"], dict):
+        raise ValueError("promotion state lease is invalid")
+    if state["lease"] is not None:
+        lease = state["lease"]
+        if "mutation" not in lease:
+            lease["mutation"] = None
+        if set(lease) != {
+            "owner",
+            "operation",
+            "acquired_at",
+            "expires_at",
+            "mutation",
+        }:
+            raise ValueError("promotion state lease fields differ")
+        _validate_owner(lease["owner"])
+        _validate_operation(lease["operation"])
+        _parse_timestamp(lease["acquired_at"])
+        _parse_timestamp(lease["expires_at"])
+        mutation = lease["mutation"]
+        if mutation is not None:
+            if not isinstance(mutation, dict) or set(mutation) != {
+                "operation",
+                "started_at",
+            }:
+                raise ValueError("promotion state in-flight mutation fields differ")
+            _validate_operation(mutation["operation"])
+            _parse_timestamp(mutation["started_at"])
+    return state
+
+
+def _parse_timestamp(value: Any) -> datetime:
+    if not isinstance(value, str):
+        raise ValueError("lease expiry is absent")
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("lease expiry must include a timezone")
+    return parsed.astimezone(UTC)
+
+
+def _validate_owner(value: Any) -> str:
+    if not isinstance(value, str) or not re.fullmatch(
+        r"[A-Za-z0-9._:-]{8,160}", value
+    ):
+        raise ValueError("rollout operation owner is invalid")
+    return value
+
+
+def _validate_operation(value: Any) -> str:
+    if not isinstance(value, str) or not re.fullmatch(
+        r"[a-z][a-z0-9:-]{0,127}", value
+    ):
+        raise ValueError("rollout operation is invalid")
+    return value
+
+
+def _validate_gcs_uri(value: Any) -> str:
+    if not isinstance(value, str):
+        raise ValueError("rollout bundle URI is invalid")
+    match = re.fullmatch(
+        r"gs://[a-z0-9][a-z0-9._-]{1,220}[a-z0-9]/([^\x00-\x1f\x7f]+)",
+        value,
+    )
+    if (
+        not match
+        or value.endswith("/")
+        or "//" in match.group(1)
+        or any(part in {"", ".", ".."} for part in match.group(1).split("/"))
+    ):
+        raise ValueError("rollout bundle URI is invalid")
+    return value
+
+
+def _acquire(args: argparse.Namespace) -> None:
+    _validate_owner(args.owner)
+    _validate_operation(args.operation)
+    state = _state(args.state, args.manifest)
+    current = state.get("lease")
+    now = _now()
+    if current:
+        expired = _parse_timestamp(current.get("expires_at")) <= now
+        if not expired:
+            raise ValueError("another rollout operation holds the active lease")
+        if not args.allow_expired_takeover:
+            raise ValueError("expired rollout lease requires explicit reconciled takeover")
+        if current.get("mutation") is not None:
+            raise ValueError(
+                "expired rollout lease has an unresolved provider mutation; "
+                "cloud-owner reconciliation is required"
+            )
+    state["lease"] = {
+        "owner": args.owner,
+        "operation": args.operation,
+        "acquired_at": _timestamp(now),
+        "expires_at": _timestamp(now + timedelta(seconds=args.ttl_seconds)),
+        "mutation": None,
+    }
+    _atomic_write(args.state, state)
+
+
+def _refresh(args: argparse.Namespace) -> None:
+    _validate_owner(args.owner)
+    state = _state(args.state, args.manifest)
+    lease = state.get("lease") or {}
+    now = _now()
+    if lease.get("owner") != args.owner:
+        raise ValueError("rollout operation no longer owns the active lease")
+    if _parse_timestamp(lease.get("expires_at")) <= now:
+        raise ValueError("rollout operation lease expired before refresh")
+    lease["expires_at"] = _timestamp(now + timedelta(seconds=args.ttl_seconds))
+    state["lease"] = lease
+    _atomic_write(args.state, state)
+
+
+def _assert_lease(args: argparse.Namespace) -> None:
+    _validate_owner(args.owner)
+    state = _state(args.state, args.manifest)
+    lease = state.get("lease") or {}
+    if lease.get("owner") != args.owner:
+        raise ValueError("rollout operation no longer owns the active lease")
+    if _parse_timestamp(lease.get("expires_at")) <= _now():
+        raise ValueError("rollout operation lease expired")
+
+
+def _release(args: argparse.Namespace) -> None:
+    _validate_owner(args.owner)
+    state = _state(args.state, args.manifest)
+    lease = state.get("lease") or {}
+    if lease.get("owner") != args.owner:
+        raise ValueError("rollout operation cannot release another owner's lease")
+    if lease.get("mutation") is not None:
+        raise ValueError("rollout operation cannot release an in-flight provider mutation")
+    state["lease"] = None
+    _atomic_write(args.state, state)
+
+
+def _mutation_begin(args: argparse.Namespace) -> None:
+    _validate_owner(args.owner)
+    _validate_operation(args.operation)
+    state = _state(args.state, args.manifest)
+    lease = state.get("lease") or {}
+    if lease.get("owner") != args.owner:
+        raise ValueError("provider mutation is not owned by the active lease")
+    if _parse_timestamp(lease.get("expires_at")) <= _now():
+        raise ValueError("rollout operation lease expired before provider mutation")
+    if lease.get("mutation") is not None:
+        raise ValueError("another provider mutation is already in flight")
+    lease["mutation"] = {
+        "operation": args.operation,
+        "started_at": _timestamp(),
+    }
+    state["lease"] = lease
+    _atomic_write(args.state, state)
+
+
+def _mutation_end(args: argparse.Namespace) -> None:
+    _validate_owner(args.owner)
+    _validate_operation(args.operation)
+    state = _state(args.state, args.manifest)
+    lease = state.get("lease") or {}
+    if lease.get("owner") != args.owner:
+        raise ValueError("provider mutation is not owned by the active lease")
+    if _parse_timestamp(lease.get("expires_at")) <= _now():
+        raise ValueError(
+            "rollout lease expired with a provider mutation in flight; "
+            "cloud-owner reconciliation is required"
+        )
+    mutation = lease.get("mutation")
+    if not isinstance(mutation, dict) or mutation.get("operation") != args.operation:
+        raise ValueError("provider mutation completion does not match the active fence")
+    lease["mutation"] = None
+    state["lease"] = lease
+    _atomic_write(args.state, state)
+
+
+def _append(args: argparse.Namespace) -> None:
+    state = _state(args.state, args.manifest)
+    lease = state.get("lease") or {}
+    if lease and not args.owner:
+        raise ValueError("rollout attempt append requires the active lease owner")
+    if args.owner:
+        _validate_owner(args.owner)
+    if args.owner and lease.get("owner") != args.owner:
+        raise ValueError("rollout attempt append is not owned by the active lease")
+    _validate_operation(args.operation)
+    state["attempts"].append(
+        {
+            "attempted_at": _timestamp(),
+            "operation": args.operation,
+            "surface": args.surface or None,
+            "service": args.service or None,
+            "region": args.region or None,
+            "target": args.target,
+        }
+    )
+    _atomic_write(args.state, state)
+
+
+def _init(args: argparse.Namespace) -> None:
+    if args.state.exists():
+        _state(args.state, args.manifest)
+        return
+    _atomic_write(args.state, _state(args.state, args.manifest))
+
+
+def _bundle_write(args: argparse.Namespace) -> None:
+    manifest = _read(args.manifest)
+    manifest_dir = args.manifest.parent.resolve()
+    names = [
+        args.manifest.name,
+        manifest["url_map"]["prior_snapshot"],
+        manifest["url_map"]["candidate_snapshot"],
+    ]
+    promotion_state = manifest.get("promotion_state")
+    if (
+        not isinstance(promotion_state, str)
+        or Path(promotion_state).name != promotion_state
+        or promotion_state in {*names, "bundle.json", "authority.json"}
+    ):
+        raise ValueError("recovery bundle promotion-state filename is unsafe")
+    if len(names) != len(set(names)):
+        raise ValueError("recovery bundle filenames must be distinct")
+    files = []
+    for name in names:
+        path = manifest_dir / name
+        if path.resolve().parent != manifest_dir or not path.is_file():
+            raise ValueError(f"recovery bundle file is unsafe or absent: {name}")
+        files.append({"name": name, "sha256": _digest(path)})
+    _atomic_write(
+        args.output,
+        {
+            "schema_version": 1,
+            "kind": "trusted-router-rollout-recovery-bundle",
+            "project_id": manifest["project_id"],
+            "release": manifest["release"],
+            "manifest": args.manifest.name,
+            "manifest_sha256": _digest(args.manifest),
+            "promotion_state": promotion_state,
+            "files": files,
+        },
+    )
+
+
+def _bundle_validate(args: argparse.Namespace) -> None:
+    descriptor = _read(args.descriptor)
+    required = {
+        "schema_version",
+        "kind",
+        "project_id",
+        "release",
+        "manifest",
+        "manifest_sha256",
+        "promotion_state",
+        "files",
+    }
+    if not isinstance(descriptor, dict) or set(descriptor) != required:
+        raise ValueError("recovery bundle descriptor fields differ")
+    if descriptor["schema_version"] != 1 or descriptor["kind"] != (
+        "trusted-router-rollout-recovery-bundle"
+    ):
+        raise ValueError("recovery bundle descriptor schema differs")
+    names: set[str] = set()
+    for item in descriptor["files"]:
+        if not isinstance(item, dict) or set(item) != {"name", "sha256"}:
+            raise ValueError("recovery bundle file record differs")
+        name = item["name"]
+        path = args.directory / name
+        if (
+            not isinstance(name, str)
+            or Path(name).name != name
+            or name in names
+            or not path.is_file()
+            or _digest(path) != item["sha256"]
+        ):
+            raise ValueError(f"recovery bundle file validation failed: {name!r}")
+        names.add(name)
+    if descriptor["manifest"] not in names:
+        raise ValueError("recovery bundle manifest record is absent")
+    promotion_state = descriptor["promotion_state"]
+    if (
+        not isinstance(promotion_state, str)
+        or Path(promotion_state).name != promotion_state
+        or promotion_state in names
+    ):
+        raise ValueError("recovery bundle promotion-state record is invalid")
+    manifest_path = args.directory / descriptor["manifest"]
+    if _digest(manifest_path) != descriptor["manifest_sha256"]:
+        raise ValueError("recovery bundle manifest digest differs")
+    print(manifest_path)
+
+
+def _authority_write(args: argparse.Namespace) -> None:
+    manifest = _read(args.manifest)
+    _validate_gcs_uri(args.bundle_uri)
+    promotion_state = manifest.get("promotion_state")
+    if not isinstance(promotion_state, str) or Path(promotion_state).name != promotion_state:
+        raise ValueError("rollout authority promotion-state filename is invalid")
+    _atomic_write(
+        args.output,
+        {
+            "schema_version": 1,
+            "kind": "trusted-router-rollout-authority",
+            "project_id": manifest["project_id"],
+            "url_map_name": manifest["url_map"]["name"],
+            "manifest_sha256": _digest(args.manifest),
+            "release": manifest["release"],
+            "bundle_uri": args.bundle_uri,
+            "promotion_state": promotion_state,
+            "state": args.state_value,
+            "updated_at": _timestamp(),
+        },
+    )
+
+
+def _authority_validate(args: argparse.Namespace) -> None:
+    value = _read(args.authority)
+    manifest = _read(args.manifest)
+    _validate_gcs_uri(args.bundle_uri)
+    promotion_state = manifest.get("promotion_state")
+    if not isinstance(promotion_state, str) or Path(promotion_state).name != promotion_state:
+        raise ValueError("rollout authority promotion-state filename is invalid")
+    expected = {
+        "schema_version": 1,
+        "kind": "trusted-router-rollout-authority",
+        "project_id": manifest["project_id"],
+        "url_map_name": manifest["url_map"]["name"],
+        "manifest_sha256": _digest(args.manifest),
+        "release": manifest["release"],
+        "bundle_uri": args.bundle_uri,
+        "promotion_state": promotion_state,
+    }
+    if not isinstance(value, dict) or set(value) != {
+        *expected,
+        "state",
+        "updated_at",
+    } or any(value.get(key) != item for key, item in expected.items()):
+        raise ValueError("rollout authority belongs to another manifest")
+    if value.get("state") != args.expected_state:
+        raise ValueError(f"rollout authority is {value.get('state')!r}, not {args.expected_state!r}")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    validate = sub.add_parser("validate")
+    validate.add_argument("state", type=Path)
+    validate.add_argument("manifest", type=Path)
+
+    initialize = sub.add_parser("init")
+    initialize.add_argument("state", type=Path)
+    initialize.add_argument("manifest", type=Path)
+
+    acquire = sub.add_parser("lease-acquire")
+    acquire.add_argument("state", type=Path)
+    acquire.add_argument("manifest", type=Path)
+    acquire.add_argument("owner")
+    acquire.add_argument("operation")
+    acquire.add_argument("--ttl-seconds", type=int, default=900)
+    acquire.add_argument("--allow-expired-takeover", action="store_true")
+
+    refresh = sub.add_parser("lease-refresh")
+    refresh.add_argument("state", type=Path)
+    refresh.add_argument("manifest", type=Path)
+    refresh.add_argument("owner")
+    refresh.add_argument("--ttl-seconds", type=int, default=900)
+
+    lease_assert = sub.add_parser("lease-assert")
+    lease_assert.add_argument("state", type=Path)
+    lease_assert.add_argument("manifest", type=Path)
+    lease_assert.add_argument("owner")
+
+    mutation_begin = sub.add_parser("lease-mutation-begin")
+    mutation_begin.add_argument("state", type=Path)
+    mutation_begin.add_argument("manifest", type=Path)
+    mutation_begin.add_argument("owner")
+    mutation_begin.add_argument("operation")
+
+    mutation_end = sub.add_parser("lease-mutation-end")
+    mutation_end.add_argument("state", type=Path)
+    mutation_end.add_argument("manifest", type=Path)
+    mutation_end.add_argument("owner")
+    mutation_end.add_argument("operation")
+
+    release = sub.add_parser("lease-release")
+    release.add_argument("state", type=Path)
+    release.add_argument("manifest", type=Path)
+    release.add_argument("owner")
+
+    append = sub.add_parser("append")
+    append.add_argument("state", type=Path)
+    append.add_argument("manifest", type=Path)
+    append.add_argument("operation")
+    append.add_argument("surface")
+    append.add_argument("service")
+    append.add_argument("region")
+    append.add_argument("target")
+    append.add_argument("--owner", default="")
+
+    bundle_write = sub.add_parser("bundle-write")
+    bundle_write.add_argument("manifest", type=Path)
+    bundle_write.add_argument("output", type=Path)
+
+    bundle_validate = sub.add_parser("bundle-validate")
+    bundle_validate.add_argument("descriptor", type=Path)
+    bundle_validate.add_argument("directory", type=Path)
+
+    authority_write = sub.add_parser("authority-write")
+    authority_write.add_argument("manifest", type=Path)
+    authority_write.add_argument("output", type=Path)
+    authority_write.add_argument("state_value", choices=("active", "closed"))
+    authority_write.add_argument("bundle_uri")
+
+    authority_validate = sub.add_parser("authority-validate")
+    authority_validate.add_argument("authority", type=Path)
+    authority_validate.add_argument("manifest", type=Path)
+    authority_validate.add_argument("expected_state", choices=("active", "closed"))
+    authority_validate.add_argument("bundle_uri")
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    try:
+        if args.command == "validate":
+            _state(args.state, args.manifest)
+        elif args.command == "init":
+            _init(args)
+        elif args.command == "lease-acquire":
+            if args.ttl_seconds < 60 or args.ttl_seconds > 3600:
+                raise ValueError("lease TTL must be from 60 through 3600 seconds")
+            _acquire(args)
+        elif args.command == "lease-refresh":
+            if args.ttl_seconds < 60 or args.ttl_seconds > 3600:
+                raise ValueError("lease TTL must be from 60 through 3600 seconds")
+            _refresh(args)
+        elif args.command == "lease-assert":
+            _assert_lease(args)
+        elif args.command == "lease-mutation-begin":
+            _mutation_begin(args)
+        elif args.command == "lease-mutation-end":
+            _mutation_end(args)
+        elif args.command == "lease-release":
+            _release(args)
+        elif args.command == "append":
+            _append(args)
+        elif args.command == "bundle-write":
+            _bundle_write(args)
+        elif args.command == "bundle-validate":
+            _bundle_validate(args)
+        elif args.command == "authority-write":
+            _authority_write(args)
+        elif args.command == "authority-validate":
+            _authority_validate(args)
+        else:  # pragma: no cover
+            raise AssertionError(args.command)
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as error:
+        raise SystemExit(str(error)) from error
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deploy/rollout_legacy_harden.py
+++ b/scripts/deploy/rollout_legacy_harden.py
@@ -1,0 +1,1235 @@
+#!/usr/bin/env python3
+"""Journaled forward hardening for the retained legacy Cloud Run monolith."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+NAME_RE = re.compile(r"[a-z][a-z0-9-]{0,61}\Z")
+PROJECT_RE = re.compile(r"[a-z][a-z0-9-]{4,28}[a-z0-9]\Z")
+REGION_RE = re.compile(r"[a-z]+-[a-z0-9]+[0-9]\Z")
+SA_RE = re.compile(
+    r"[a-z][a-z0-9-]{4,28}[a-z0-9]@[a-z][a-z0-9-]{4,28}[a-z0-9]"
+    r"[.]iam[.]gserviceaccount[.]com\Z"
+)
+COMPUTE_SA_RE = re.compile(r"[1-9][0-9]{5,19}-compute@developer[.]gserviceaccount[.]com\Z")
+IMAGE_RE = re.compile(r"[^\s,@]+@sha256:[0-9a-f]{64}\Z")
+SECRET_RE = re.compile(r"[A-Za-z0-9_-]{1,255}\Z")
+INGRESS = "internal-and-cloud-load-balancing"
+JOURNAL_STATES = {
+    "captured",
+    "normalize_intent",
+    "normalized",
+    "deploy_intent",
+    "deployed",
+    "ramp10_intent",
+    "ramp10",
+    "ramp50_intent",
+    "ramp50",
+    "ramp100_intent",
+    "ramp100",
+    "rollback_intent",
+    "rolled_back",
+}
+JOURNAL_FIELDS = {
+    "schema_version",
+    "kind",
+    "project_id",
+    "service",
+    "runtime_service_account",
+    "operation_id",
+    "revision_suffix",
+    "created_at",
+    "updated_at",
+    "secret_refs",
+    "regions",
+}
+JOURNAL_REGION_FIELDS = {
+    "region",
+    "state",
+    "baseline_revision",
+    "baseline_was_latest",
+    "baseline_revision_sha256",
+    "image",
+    "iam_sha256",
+    "expected_candidate_revision_sha256",
+    "candidate_revision",
+    "rollback_percent",
+}
+ARTIFACT_FIELDS = {
+    "schema_version",
+    "kind",
+    "project_id",
+    "service",
+    "runtime_service_account",
+    "operation_id",
+    "revision_suffix",
+    "regions",
+    "secret_refs",
+    "journal_sha256",
+    "created_at",
+}
+ARTIFACT_REGION_FIELDS = {
+    "region",
+    "serving_revision",
+    "service_sha256",
+    "revision_sha256",
+    "iam_sha256",
+}
+
+
+def _canonical(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _sha(value: Any) -> str:
+    return hashlib.sha256(_canonical(value)).hexdigest()
+
+
+def _file_sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _validate_timestamp(value: Any) -> None:
+    if not isinstance(value, str):
+        raise ValueError("legacy hardening timestamp is invalid")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise ValueError("legacy hardening timestamp is invalid") from error
+    if parsed.tzinfo is None:
+        raise ValueError("legacy hardening timestamp must include a timezone")
+
+
+def _atomic(path: Path, value: Any, *, exclusive: bool = False) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if exclusive and path.exists():
+        raise ValueError(f"refusing to overwrite recovery artifact: {path}")
+    descriptor, temporary = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+    )
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            json.dump(value, output, indent=2, sort_keys=True)
+            output.write("\n")
+            output.flush()
+            os.fsync(output.fileno())
+        if exclusive:
+            os.link(temporary, path)
+            os.unlink(temporary)
+        else:
+            os.replace(temporary, path)
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+class Cloud:
+    def __init__(self, project: str) -> None:
+        self.project = project
+        executable = shutil.which("gcloud")
+        if executable is None:
+            raise ValueError("gcloud is required for legacy hardening")
+        self.executable = executable
+
+    def run(self, *arguments: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+        result = subprocess.run(  # noqa: S603
+            [self.executable, "--project", self.project, *arguments],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if check and result.returncode:
+            raise ValueError("read-only gcloud inspection failed")
+        return result
+
+    def json(self, *arguments: str) -> Any:
+        result = self.run(*arguments, "--format=json")
+        return json.loads(result.stdout)
+
+    def optional_json(self, *arguments: str) -> Any | None:
+        result = self.run(*arguments, "--format=json", check=False)
+        if result.returncode:
+            return None
+        return json.loads(result.stdout)
+
+
+def _basename(value: Any) -> str:
+    return str(value or "").rstrip("/").split("/")[-1]
+
+
+def _container(value: dict[str, Any]) -> dict[str, Any]:
+    template = ((value.get("spec") or {}).get("template") or {}).get("spec") or {}
+    containers = template.get("containers") or []
+    if len(containers) != 1 or template.get("initContainers") or template.get("volumes"):
+        raise ValueError("legacy hardening requires exactly one container and no volumes")
+    container = containers[0]
+    if container.get("volumeMounts"):
+        raise ValueError("legacy hardening does not support secret or data volumes")
+    return container
+
+
+def _revision_container(value: dict[str, Any]) -> dict[str, Any]:
+    spec = value.get("spec") or {}
+    containers = spec.get("containers") or []
+    if len(containers) != 1 or spec.get("initContainers") or spec.get("volumes"):
+        raise ValueError("legacy hardening requires exactly one revision container")
+    container = containers[0]
+    if container.get("volumeMounts"):
+        raise ValueError("legacy hardening does not support revision volume mounts")
+    return container
+
+
+def _service_semantic(service: dict[str, Any]) -> dict[str, Any]:
+    metadata = service.get("metadata") or {}
+    spec = service.get("spec") or {}
+    template = spec.get("template") or {}
+    template_metadata = template.get("metadata") or {}
+    template_spec = template.get("spec") or {}
+    annotations = metadata.get("annotations") or {}
+    template_annotations = template_metadata.get("annotations") or {}
+    selected_annotations = {
+        key: value
+        for key, value in annotations.items()
+        if key
+        in {
+            "run.googleapis.com/ingress",
+            "run.googleapis.com/ingress-status",
+            "run.googleapis.com/default-url-disabled",
+            "run.googleapis.com/maxScale",
+            "run.googleapis.com/minScale",
+        }
+    }
+    selected_template_annotations = {
+        key: value
+        for key, value in template_annotations.items()
+        if key
+        in {
+            "autoscaling.knative.dev/minScale",
+            "autoscaling.knative.dev/maxScale",
+            "run.googleapis.com/vpc-access-egress",
+            "run.googleapis.com/network-interfaces",
+            "run.googleapis.com/startup-cpu-boost",
+        }
+    }
+    containers = []
+    for container in template_spec.get("containers") or []:
+        copied = {
+            key: container[key]
+            for key in (
+                "image",
+                "ports",
+                "resources",
+                "startupProbe",
+                "command",
+                "args",
+                "volumeMounts",
+            )
+            if key in container
+        }
+        copied["env"] = sorted(
+            container.get("env") or [], key=lambda item: str(item.get("name", ""))
+        )
+        containers.append(copied)
+    return {
+        "metadata": {"annotations": selected_annotations},
+        "spec": {
+            "scaling": spec.get("scaling") or {},
+            "template": {
+                "metadata": {
+                    "annotations": selected_template_annotations,
+                    "name": template_metadata.get("name"),
+                },
+                "spec": {
+                    "containerConcurrency": template_spec.get("containerConcurrency"),
+                    "serviceAccountName": template_spec.get("serviceAccountName"),
+                    "timeoutSeconds": template_spec.get("timeoutSeconds"),
+                    "volumes": template_spec.get("volumes") or [],
+                    "initContainers": template_spec.get("initContainers") or [],
+                    "containers": containers,
+                },
+            },
+        },
+    }
+
+
+def _secret_resource(value: Any, project: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError("legacy secret resource is not a string")
+    if SECRET_RE.fullmatch(value):
+        return value
+    match = re.fullmatch(r"projects/([^/]+)/secrets/([^/]+)", value)
+    if match is None or match.group(1) != project or not SECRET_RE.fullmatch(match.group(2)):
+        raise ValueError("legacy secret resource is not local and canonical")
+    return match.group(2)
+
+
+def _secret_refs(container: dict[str, Any], project: str) -> list[dict[str, str]]:
+    refs: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for item in container.get("env") or []:
+        reference = (item.get("valueFrom") or {}).get("secretKeyRef") or {}
+        if not reference:
+            continue
+        name = item.get("name")
+        resource = _secret_resource(reference.get("name"), project)
+        version = str(reference.get("key") or "")
+        if (
+            not isinstance(name, str)
+            or not re.fullmatch(r"[A-Z][A-Z0-9_]{0,127}", name)
+            or name in seen
+            or not (version == "latest" or re.fullmatch(r"[1-9][0-9]*", version))
+        ):
+            raise ValueError("legacy secret reference is malformed or duplicated")
+        seen.add(name)
+        refs.append({"name": name, "resource": resource, "version": version})
+    return sorted(refs, key=lambda item: item["name"])
+
+
+def _revision_semantic(revision: dict[str, Any]) -> dict[str, Any]:
+    metadata = revision.get("metadata") or {}
+    spec = copy.deepcopy(revision.get("spec") or {})
+    return {
+        "annotations": {
+            key: value
+            for key, value in sorted((metadata.get("annotations") or {}).items())
+            if not key.startswith("client.knative.dev/")
+            and key
+            not in {
+                "run.googleapis.com/client-name",
+                "run.googleapis.com/client-version",
+                "run.googleapis.com/operation-id",
+                "serving.knative.dev/creator",
+                "serving.knative.dev/lastModifier",
+            }
+        },
+        "spec": spec,
+    }
+
+
+def _replace_secret_versions(value: dict[str, Any], pins: list[dict[str, str]]) -> dict[str, Any]:
+    result = copy.deepcopy(value)
+    by_name = {item["name"]: item for item in pins}
+    containers = (result.get("spec") or {}).get("containers") or []
+    if len(containers) != 1:
+        raise ValueError("legacy revision semantic has inexact containers")
+    for item in containers[0].get("env") or []:
+        reference = (item.get("valueFrom") or {}).get("secretKeyRef") or {}
+        if reference:
+            expected = by_name.get(item.get("name"))
+            if expected is None or _basename(reference.get("name")) != expected["resource"]:
+                raise ValueError("legacy revision secret resources differ across regions")
+            reference["key"] = expected["version"]
+    return result
+
+
+def _traffic(service: dict[str, Any]) -> tuple[str, bool]:
+    desired = (service.get("spec") or {}).get("traffic") or []
+    observed = (service.get("status") or {}).get("traffic") or []
+    if len(desired) != 1 or len(observed) != 1:
+        raise ValueError("legacy traffic must have one 100-percent target")
+    target, live = desired[0], observed[0]
+    if target.get("tag") is not None or live.get("tag") is not None:
+        raise ValueError("legacy traffic tags must be removed before hardening")
+    if target.get("percent") != 100 or live.get("percent") != 100:
+        raise ValueError("legacy traffic must serve exactly 100 percent")
+    revision = _basename(live.get("revisionName"))
+    if not NAME_RE.fullmatch(revision):
+        raise ValueError("legacy serving revision is invalid")
+    desired_revision = _basename(target.get("revisionName"))
+    latest = target.get("latestRevision") is True
+    if not latest and desired_revision != revision:
+        raise ValueError("legacy desired and observed traffic differ")
+    return revision, latest
+
+
+def _ready(service: dict[str, Any], revision: str) -> None:
+    metadata = service.get("metadata") or {}
+    status = service.get("status") or {}
+    if status.get("observedGeneration") != metadata.get("generation"):
+        raise ValueError("legacy service generation is not observed")
+    if status.get("latestReadyRevisionName") != revision:
+        raise ValueError("legacy serving revision is not latest Ready")
+    ready = [
+        item
+        for item in status.get("conditions") or []
+        if item.get("type") == "Ready" and item.get("status") == "True"
+    ]
+    if len(ready) != 1:
+        raise ValueError("legacy service is not exactly Ready")
+
+
+def _ready_revision(value: dict[str, Any], expected_name: str) -> None:
+    if _basename((value.get("metadata") or {}).get("name")) != expected_name:
+        raise ValueError("legacy revision identity differs")
+    ready = [
+        item
+        for item in (value.get("status") or {}).get("conditions") or []
+        if item.get("type") == "Ready" and item.get("status") == "True"
+    ]
+    if len(ready) != 1:
+        raise ValueError("legacy revision is not exactly Ready")
+
+
+def _iam(cloud: Cloud, service: str, region: str) -> str:
+    policy = cloud.json("run", "services", "get-iam-policy", service, f"--region={region}")
+    matches = []
+    for binding in policy.get("bindings") or []:
+        members = binding.get("members") or []
+        if "allAuthenticatedUsers" in members:
+            raise ValueError("legacy service IAM contains allAuthenticatedUsers")
+        if "allUsers" in members:
+            matches.append(binding)
+    if (
+        len(matches) != 1
+        or matches[0].get("role") != "roles/run.invoker"
+        or matches[0].get("condition")
+        or (matches[0].get("members") or []).count("allUsers") != 1
+    ):
+        raise ValueError("legacy service requires one unconditional public invoker binding")
+    bindings = [
+        {
+            "role": binding.get("role"),
+            "members": sorted(binding.get("members") or []),
+            "condition": binding.get("condition") or None,
+        }
+        for binding in policy.get("bindings") or []
+    ]
+    bindings.sort(key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":")))
+    return _sha({"bindings": bindings})
+
+
+def _verify_secret(cloud: Cloud, resource: str, version: str, runtime_member: str) -> None:
+    metadata = cloud.json("secrets", "versions", "describe", version, f"--secret={resource}")
+    if metadata.get("state") != "ENABLED" or _basename(metadata.get("name")) != version:
+        raise ValueError("legacy pinned secret version is not enabled")
+    policy = cloud.json("secrets", "get-iam-policy", resource)
+    public = {"allUsers", "allAuthenticatedUsers"}
+    access = []
+    for binding in policy.get("bindings") or []:
+        members = set(binding.get("members") or [])
+        if members & public:
+            raise ValueError("legacy secret policy contains a public principal")
+        if runtime_member in members:
+            if (binding.get("members") or []).count(runtime_member) != 1:
+                raise ValueError("legacy runtime secret access is duplicated")
+            access.append(binding)
+    if (
+        len(access) != 1
+        or access[0].get("role") != "roles/secretmanager.secretAccessor"
+        or access[0].get("condition")
+    ):
+        raise ValueError("legacy runtime secret access is not exact")
+
+
+def _resolve_pins(cloud: Cloud, refs_by_region: list[list[dict[str, str]]]) -> list[dict[str, str]]:
+    shapes = [[(item["name"], item["resource"]) for item in refs] for refs in refs_by_region]
+    if not shapes or any(shape != shapes[0] for shape in shapes[1:]):
+        raise ValueError("legacy secret resource mappings differ across regions")
+    pins: list[dict[str, str]] = []
+    for index, item in enumerate(refs_by_region[0]):
+        resolved_versions: set[str] = set()
+        for regional_refs in refs_by_region:
+            version = regional_refs[index]["version"]
+            if version == "latest":
+                latest = cloud.json(
+                    "secrets",
+                    "versions",
+                    "describe",
+                    "latest",
+                    f"--secret={item['resource']}",
+                )
+                if latest.get("state") != "ENABLED":
+                    raise ValueError("legacy latest secret version is not enabled")
+                version = _basename(latest.get("name"))
+            if not re.fullmatch(r"[1-9][0-9]*", version):
+                raise ValueError("legacy resolved secret version is not numeric")
+            resolved_versions.add(version)
+        if len(resolved_versions) != 1:
+            raise ValueError("legacy mounted secret versions differ across regions")
+        pins.append({**item, "version": resolved_versions.pop()})
+    return pins
+
+
+def _describe_service(cloud: Cloud, service: str, region: str) -> dict[str, Any]:
+    return cloud.json("run", "services", "describe", service, f"--region={region}")
+
+
+def _describe_revision(cloud: Cloud, revision: str, region: str) -> dict[str, Any]:
+    return cloud.json("run", "revisions", "describe", revision, f"--region={region}")
+
+
+def _normalized_traffic(items: list[dict[str, Any]]) -> dict[str, int]:
+    result: dict[str, int] = {}
+    seen: set[str] = set()
+    for item in items:
+        if item.get("latestRevision") is True or item.get("tag") is not None:
+            raise ValueError("legacy hardening traffic must stay named and untagged")
+        revision = _basename(item.get("revisionName"))
+        percent = item.get("percent")
+        if (
+            not NAME_RE.fullmatch(revision)
+            or isinstance(percent, bool)
+            or not isinstance(percent, int)
+        ):
+            raise ValueError("legacy hardening traffic target is malformed")
+        if not 0 <= percent <= 100:
+            raise ValueError("legacy hardening traffic percent is invalid")
+        if percent == 0 or revision in seen:
+            raise ValueError("legacy traffic contains a duplicate or zero-percent target")
+        seen.add(revision)
+        result[revision] = percent
+    if sum(result.values()) != 100:
+        raise ValueError("legacy hardening traffic does not total 100 percent")
+    return result
+
+
+def _allocation(
+    cloud: Cloud, service_name: str, region: str
+) -> tuple[dict[str, Any], dict[str, int]]:
+    service = _describe_service(cloud, service_name, region)
+    desired = _normalized_traffic((service.get("spec") or {}).get("traffic") or [])
+    observed = _normalized_traffic((service.get("status") or {}).get("traffic") or [])
+    if desired != observed:
+        raise ValueError("legacy desired and observed traffic have not converged")
+    return service, desired
+
+
+def _verify_allocation(
+    cloud: Cloud, service_name: str, region: str, baseline: str, candidate: str, percent: int
+) -> None:
+    _, actual = _allocation(cloud, service_name, region)
+    expected: dict[str, int] = {}
+    if percent:
+        expected[candidate] = percent
+    if percent < 100:
+        expected[baseline] = 100 - percent
+    if actual != expected:
+        raise ValueError("legacy traffic ramp postcondition differs")
+
+
+def _set_state(path: Path, journal: dict[str, Any], region: str, state: str) -> None:
+    if state not in JOURNAL_STATES:
+        raise ValueError("legacy hardening journal transition is invalid")
+    entry = next(item for item in journal["regions"] if item["region"] == region)
+    entry["state"] = state
+    journal["updated_at"] = datetime.now(UTC).isoformat()
+    _atomic(path, journal)
+
+
+def _validate_secret_refs(value: Any) -> list[dict[str, str]]:
+    if not isinstance(value, list):
+        raise ValueError("legacy hardening secret refs are not a list")
+    result: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for item in value:
+        if not isinstance(item, dict) or set(item) != {"name", "resource", "version"}:
+            raise ValueError("legacy hardening secret ref fields differ")
+        name = item["name"]
+        resource = item["resource"]
+        version = item["version"]
+        if (
+            not isinstance(name, str)
+            or not re.fullmatch(r"[A-Z][A-Z0-9_]{0,127}", name)
+            or name in seen
+            or not isinstance(resource, str)
+            or not SECRET_RE.fullmatch(resource)
+            or not isinstance(version, str)
+            or not re.fullmatch(r"[1-9][0-9]*", version)
+        ):
+            raise ValueError("legacy hardening secret ref is invalid or duplicated")
+        seen.add(name)
+        result.append(item)
+    if result != sorted(result, key=lambda item: item["name"]):
+        raise ValueError("legacy hardening secret refs are not canonical")
+    return result
+
+
+def _validate_journal(
+    args: argparse.Namespace,
+    value: Any,
+    regions: list[str],
+    *,
+    path: Path,
+) -> dict[str, Any]:
+    if path.stat().st_mode & 0o777 != 0o600:
+        raise ValueError("legacy hardening state must be mode 0600")
+    if not isinstance(value, dict) or set(value) != JOURNAL_FIELDS:
+        raise ValueError("legacy hardening state fields differ")
+    if (
+        value["schema_version"] != 1
+        or value["kind"] != "trusted-router-legacy-hardening-state"
+        or value["project_id"] != args.project
+        or value["service"] != args.service
+        or value["runtime_service_account"] != args.runtime_service_account
+        or value["operation_id"] != args.operation_id
+    ):
+        raise ValueError("legacy hardening state identity differs")
+    _validate_timestamp(value["created_at"])
+    _validate_timestamp(value["updated_at"])
+    suffix = value["revision_suffix"]
+    if (
+        not isinstance(suffix, str)
+        or not NAME_RE.fullmatch(suffix)
+        or len(f"{args.service}-{suffix}") > 63
+    ):
+        raise ValueError("legacy hardening state suffix is invalid")
+    _validate_secret_refs(value["secret_refs"])
+    entries = value["regions"]
+    if (
+        not isinstance(entries, list)
+        or any(not isinstance(item, dict) for item in entries)
+        or [item.get("region") for item in entries] != regions
+    ):
+        raise ValueError("legacy hardening state region inventory differs")
+    for item in entries:
+        if not isinstance(item, dict) or set(item) != JOURNAL_REGION_FIELDS:
+            raise ValueError("legacy hardening regional state fields differ")
+        if (
+            item["state"] not in JOURNAL_STATES
+            or not isinstance(item["baseline_was_latest"], bool)
+            or not NAME_RE.fullmatch(str(item["baseline_revision"]))
+            or item["candidate_revision"] != f"{args.service}-{suffix}"
+            or not IMAGE_RE.fullmatch(str(item["image"]))
+            or any(
+                not re.fullmatch(r"[0-9a-f]{64}", str(item[field]))
+                for field in (
+                    "baseline_revision_sha256",
+                    "iam_sha256",
+                    "expected_candidate_revision_sha256",
+                )
+            )
+            or (
+                item["rollback_percent"] is not None
+                and item["rollback_percent"] not in {0, 10, 50, 100}
+            )
+            or (
+                item["state"] in {"rollback_intent", "rolled_back"}
+                and item["rollback_percent"] is None
+            )
+            or (
+                item["state"] not in {"rollback_intent", "rolled_back"}
+                and item["rollback_percent"] is not None
+            )
+        ):
+            raise ValueError("legacy hardening regional state is invalid")
+    if len({item["image"] for item in entries}) != 1:
+        raise ValueError("legacy hardening state image cohort differs")
+    return value
+
+
+def _validate_inputs(args: argparse.Namespace) -> list[str]:
+    if not PROJECT_RE.fullmatch(args.project) or not NAME_RE.fullmatch(args.service):
+        raise ValueError("legacy hardening project/service is invalid")
+    if not (
+        (
+            SA_RE.fullmatch(args.runtime_service_account)
+            and args.runtime_service_account.endswith(f"@{args.project}.iam.gserviceaccount.com")
+        )
+        or COMPUTE_SA_RE.fullmatch(args.runtime_service_account)
+    ):
+        raise ValueError("legacy runtime service account is invalid")
+    if args.artifact is not None and (
+        not isinstance(args.operation_id, str)
+        or not re.fullmatch(r"[A-Za-z0-9._:-]{8,160}", args.operation_id)
+    ):
+        raise ValueError("legacy hardening operation ID is invalid")
+    regions = args.regions.split(",")
+    if (
+        not regions
+        or len(regions) != len(set(regions))
+        or any(not REGION_RE.fullmatch(region) for region in regions)
+    ):
+        raise ValueError("legacy hardening region inventory is invalid")
+    return regions
+
+
+def _capture_plan(
+    args: argparse.Namespace, cloud: Cloud, regions: list[str], suffix: str
+) -> dict[str, Any]:
+    captured: list[dict[str, Any]] = []
+    refs_by_region: list[list[dict[str, str]]] = []
+    for region in regions:
+        candidate = f"{args.service}-{suffix}"
+        if (
+            cloud.optional_json("run", "revisions", "describe", candidate, f"--region={region}")
+            is not None
+        ):
+            raise ValueError("legacy hardening candidate already exists without this journal")
+        service = _describe_service(cloud, args.service, region)
+        baseline, latest = _traffic(service)
+        _ready(service, baseline)
+        revision = _describe_revision(cloud, baseline, region)
+        _ready_revision(revision, baseline)
+        container = _revision_container(revision)
+        if (revision.get("spec") or {}).get("serviceAccountName") != args.runtime_service_account:
+            raise ValueError("legacy serving revision runtime identity differs")
+        image = container.get("image")
+        if not isinstance(image, str) or not IMAGE_RE.fullmatch(image):
+            raise ValueError("legacy serving image must be immutable")
+        refs = _secret_refs(container, args.project)
+        refs_by_region.append(refs)
+        captured.append(
+            {
+                "region": region,
+                "state": "captured",
+                "baseline_revision": baseline,
+                "baseline_was_latest": latest,
+                "baseline_revision_sha256": _sha(_revision_semantic(revision)),
+                "image": image,
+                "iam_sha256": _iam(cloud, args.service, region),
+                "rollback_percent": None,
+            }
+        )
+    pins = _resolve_pins(cloud, refs_by_region)
+    if len({entry["image"] for entry in captured}) != 1:
+        raise ValueError("legacy serving image differs across regions")
+    runtime_member = f"serviceAccount:{args.runtime_service_account}"
+    for pin in pins:
+        _verify_secret(cloud, pin["resource"], pin["version"], runtime_member)
+    for entry in captured:
+        revision = _describe_revision(cloud, entry["baseline_revision"], entry["region"])
+        expected = _replace_secret_versions(_revision_semantic(revision), pins)
+        entry["expected_candidate_revision_sha256"] = _sha(expected)
+        entry["candidate_revision"] = f"{args.service}-{suffix}"
+    return {
+        "schema_version": 1,
+        "kind": "trusted-router-legacy-hardening-state",
+        "project_id": args.project,
+        "service": args.service,
+        "runtime_service_account": args.runtime_service_account,
+        "operation_id": args.operation_id,
+        "revision_suffix": suffix,
+        "created_at": datetime.now(UTC).isoformat(),
+        "updated_at": datetime.now(UTC).isoformat(),
+        "secret_refs": pins,
+        "regions": captured,
+    }
+
+
+def _verify_candidate(
+    args: argparse.Namespace, cloud: Cloud, journal: dict[str, Any], entry: dict[str, Any]
+) -> None:
+    region = entry["region"]
+    service = _describe_service(cloud, args.service, region)
+    candidate = entry["candidate_revision"]
+    _ready(service, candidate)
+    annotations = (service.get("metadata") or {}).get("annotations") or {}
+    if (
+        annotations.get("run.googleapis.com/ingress") != INGRESS
+        or annotations.get("run.googleapis.com/ingress-status") != INGRESS
+    ):
+        raise ValueError("legacy hardening ingress postcondition differs")
+    service_template = ((service.get("spec") or {}).get("template") or {}).get("spec") or {}
+    if service_template.get("serviceAccountName") != args.runtime_service_account:
+        raise ValueError("legacy service template runtime identity differs")
+    if _container(service).get("image") != entry["image"]:
+        raise ValueError("legacy service template image differs")
+    revision = _describe_revision(cloud, candidate, region)
+    _ready_revision(revision, candidate)
+    revision_spec = revision.get("spec") or {}
+    if revision_spec.get("serviceAccountName") != args.runtime_service_account:
+        raise ValueError("legacy candidate runtime identity differs")
+    if _sha(_revision_semantic(revision)) != entry["expected_candidate_revision_sha256"]:
+        raise ValueError("legacy candidate revision differs from journaled contract")
+    if _revision_container(revision).get("image") != entry["image"]:
+        raise ValueError("legacy candidate image differs")
+    runtime_member = f"serviceAccount:{args.runtime_service_account}"
+    for pin in journal["secret_refs"]:
+        _verify_secret(cloud, pin["resource"], pin["version"], runtime_member)
+    if _iam(cloud, args.service, region) != entry["iam_sha256"]:
+        raise ValueError("legacy service invoker IAM drifted")
+
+
+def _current_candidate_percent(
+    args: argparse.Namespace,
+    cloud: Cloud,
+    entry: dict[str, Any],
+) -> int:
+    _, allocation = _allocation(cloud, args.service, entry["region"])
+    baseline = entry["baseline_revision"]
+    candidate = entry["candidate_revision"]
+    if not set(allocation).issubset({baseline, candidate}):
+        raise ValueError("legacy traffic contains an unowned revision")
+    percent = allocation.get(candidate, 0)
+    expected_baseline = 0 if percent == 100 else 100 - percent
+    if allocation.get(baseline, 0) != expected_baseline:
+        raise ValueError("legacy traffic allocation is not an owned cohort")
+    return percent
+
+
+def _normalize_entry(
+    args: argparse.Namespace,
+    cloud: Cloud,
+    journal: dict[str, Any],
+    path: Path,
+    entry: dict[str, Any],
+) -> None:
+    if entry["state"] not in {"captured", "normalize_intent"}:
+        return
+    _verify_baseline(args, cloud, journal, entry)
+    service = _describe_service(cloud, args.service, entry["region"])
+    serving, latest = _traffic(service)
+    if serving != entry["baseline_revision"]:
+        raise ValueError("legacy baseline traffic drifted before normalization")
+    if entry["state"] == "captured":
+        if not latest:
+            _verify_allocation(
+                cloud,
+                args.service,
+                entry["region"],
+                entry["baseline_revision"],
+                entry["candidate_revision"],
+                0,
+            )
+            _set_state(path, journal, entry["region"], "normalized")
+            return
+        _set_state(path, journal, entry["region"], "normalize_intent")
+    if latest:
+        cloud.run(
+            "run",
+            "services",
+            "update-traffic",
+            args.service,
+            f"--region={entry['region']}",
+            f"--to-revisions={entry['baseline_revision']}=100",
+            "--clear-tags",
+            "--quiet",
+            check=False,
+        )
+    _verify_allocation(
+        cloud,
+        args.service,
+        entry["region"],
+        entry["baseline_revision"],
+        entry["candidate_revision"],
+        0,
+    )
+    _set_state(path, journal, entry["region"], "normalized")
+
+
+def _candidate_exists(cloud: Cloud, entry: dict[str, Any]) -> bool:
+    return (
+        cloud.optional_json(
+            "run",
+            "revisions",
+            "describe",
+            entry["candidate_revision"],
+            f"--region={entry['region']}",
+        )
+        is not None
+    )
+
+
+def _deploy_entry(
+    args: argparse.Namespace,
+    cloud: Cloud,
+    journal: dict[str, Any],
+    path: Path,
+    entry: dict[str, Any],
+) -> None:
+    _verify_baseline(args, cloud, journal, entry)
+    if entry["state"] == "rolled_back":
+        entry["rollback_percent"] = None
+        if entry["baseline_was_latest"]:
+            service = _describe_service(cloud, args.service, entry["region"])
+            _, latest = _traffic(service)
+            if latest:
+                _set_state(path, journal, entry["region"], "normalize_intent")
+                _normalize_entry(args, cloud, journal, path, entry)
+            else:
+                _set_state(path, journal, entry["region"], "normalized")
+        else:
+            _set_state(path, journal, entry["region"], "normalized")
+    _normalize_entry(args, cloud, journal, path, entry)
+    if entry["state"] not in {"normalized", "deploy_intent", "deployed"}:
+        return
+    if entry["state"] == "deployed":
+        _verify_candidate(args, cloud, journal, entry)
+        _verify_allocation(
+            cloud,
+            args.service,
+            entry["region"],
+            entry["baseline_revision"],
+            entry["candidate_revision"],
+            0,
+        )
+        return
+    if entry["state"] == "normalized":
+        _set_state(path, journal, entry["region"], "deploy_intent")
+    if not _candidate_exists(cloud, entry):
+        secrets = ",".join(
+            f"{item['name']}={item['resource']}:{item['version']}"
+            for item in journal["secret_refs"]
+        )
+        command = [
+            "run",
+            "services",
+            "update",
+            args.service,
+            f"--region={entry['region']}",
+            f"--revision-suffix={journal['revision_suffix']}",
+            f"--image={entry['image']}",
+            f"--service-account={args.runtime_service_account}",
+            "--no-traffic",
+            f"--ingress={INGRESS}",
+            "--quiet",
+        ]
+        if secrets:
+            command.append(f"--set-secrets={secrets}")
+        cloud.run(*command, check=False)
+    _verify_candidate(args, cloud, journal, entry)
+    _verify_allocation(
+        cloud,
+        args.service,
+        entry["region"],
+        entry["baseline_revision"],
+        entry["candidate_revision"],
+        0,
+    )
+    _set_state(path, journal, entry["region"], "deployed")
+
+
+def _allowed_percent(entry: dict[str, Any]) -> set[int]:
+    state = entry["state"]
+    if state in {
+        "captured",
+        "normalize_intent",
+        "normalized",
+        "deploy_intent",
+        "deployed",
+        "rolled_back",
+    }:
+        return {0}
+    if state == "ramp10_intent":
+        return {0, 10}
+    if state == "ramp10":
+        return {10}
+    if state == "ramp50_intent":
+        return {10, 50}
+    if state == "ramp50":
+        return {50}
+    if state == "ramp100_intent":
+        return {50, 100}
+    if state == "ramp100":
+        return {100}
+    if state == "rollback_intent":
+        return {0, int(entry["rollback_percent"] or 0)}
+    raise ValueError("legacy hardening journal state has no traffic contract")
+
+
+def _verify_baseline(
+    args: argparse.Namespace,
+    cloud: Cloud,
+    journal: dict[str, Any],
+    entry: dict[str, Any],
+) -> None:
+    revision = _describe_revision(cloud, entry["baseline_revision"], entry["region"])
+    _ready_revision(revision, entry["baseline_revision"])
+    if _sha(_revision_semantic(revision)) != entry["baseline_revision_sha256"]:
+        raise ValueError("legacy baseline revision drifted")
+    if _iam(cloud, args.service, entry["region"]) != entry["iam_sha256"]:
+        raise ValueError("legacy invoker IAM drifted")
+    runtime_member = f"serviceAccount:{args.runtime_service_account}"
+    for pin in journal["secret_refs"]:
+        _verify_secret(cloud, pin["resource"], pin["version"], runtime_member)
+
+
+def _rollback(
+    args: argparse.Namespace,
+    cloud: Cloud,
+    journal: dict[str, Any],
+    path: Path,
+) -> None:
+    percents: dict[str, int] = {}
+    for entry in journal["regions"]:
+        _verify_baseline(args, cloud, journal, entry)
+        try:
+            percent = _current_candidate_percent(args, cloud, entry)
+        except ValueError:
+            service = _describe_service(cloud, args.service, entry["region"])
+            serving, latest = _traffic(service)
+            if not latest or serving != entry["baseline_revision"]:
+                raise
+            percent = 0
+        if percent not in _allowed_percent(entry):
+            raise ValueError("legacy rollback found unowned traffic drift")
+        percents[entry["region"]] = percent
+    for entry in journal["regions"]:
+        percent = percents[entry["region"]]
+        entry["rollback_percent"] = percent
+        _set_state(path, journal, entry["region"], "rollback_intent")
+        must_restore = bool(percent)
+        if not must_restore:
+            service = _describe_service(cloud, args.service, entry["region"])
+            serving, latest = _traffic(service)
+            must_restore = latest or serving != entry["baseline_revision"]
+        if must_restore:
+            cloud.run(
+                "run",
+                "services",
+                "update-traffic",
+                args.service,
+                f"--region={entry['region']}",
+                f"--to-revisions={entry['baseline_revision']}=100",
+                "--clear-tags",
+                "--quiet",
+                check=False,
+            )
+        _verify_allocation(
+            cloud,
+            args.service,
+            entry["region"],
+            entry["baseline_revision"],
+            entry["candidate_revision"],
+            0,
+        )
+        _set_state(path, journal, entry["region"], "rolled_back")
+
+
+def _deploy(args: argparse.Namespace, cloud: Cloud, journal: dict[str, Any], path: Path) -> None:
+    for entry in journal["regions"]:
+        _deploy_entry(args, cloud, journal, path, entry)
+    phases = ((10, "deployed", 0), (50, "ramp10", 10), (100, "ramp50", 50))
+    for percent, prior_state, prior_percent in phases:
+        for entry in journal["regions"]:
+            state = entry["state"]
+            target_state = f"ramp{percent}"
+            intent_state = f"ramp{percent}_intent"
+            if state == target_state:
+                _verify_candidate(args, cloud, journal, entry)
+                _verify_allocation(
+                    cloud,
+                    args.service,
+                    entry["region"],
+                    entry["baseline_revision"],
+                    entry["candidate_revision"],
+                    percent,
+                )
+                continue
+            if state not in {prior_state, intent_state}:
+                continue
+            _verify_baseline(args, cloud, journal, entry)
+            if state == prior_state:
+                _set_state(path, journal, entry["region"], intent_state)
+            current_percent = _current_candidate_percent(args, cloud, entry)
+            if current_percent not in {prior_percent, percent}:
+                raise ValueError("legacy traffic changed outside the journaled ramp")
+            if current_percent != percent:
+                traffic = f"{entry['candidate_revision']}={percent}"
+                if percent < 100:
+                    traffic += f",{entry['baseline_revision']}={100 - percent}"
+                cloud.run(
+                    "run",
+                    "services",
+                    "update-traffic",
+                    args.service,
+                    f"--region={entry['region']}",
+                    f"--to-revisions={traffic}",
+                    "--clear-tags",
+                    "--quiet",
+                    check=False,
+                )
+            _verify_candidate(args, cloud, journal, entry)
+            _verify_allocation(
+                cloud,
+                args.service,
+                entry["region"],
+                entry["baseline_revision"],
+                entry["candidate_revision"],
+                percent,
+            )
+            _set_state(path, journal, entry["region"], target_state)
+
+
+def _artifact(args: argparse.Namespace, cloud: Cloud, journal: dict[str, Any]) -> dict[str, Any]:
+    entries = []
+    for entry in journal["regions"]:
+        if entry["state"] != "ramp100":
+            raise ValueError("legacy hardening journal did not settle every region")
+        _verify_candidate(args, cloud, journal, entry)
+        _verify_allocation(
+            cloud,
+            args.service,
+            entry["region"],
+            entry["baseline_revision"],
+            entry["candidate_revision"],
+            100,
+        )
+        service = _describe_service(cloud, args.service, entry["region"])
+        entries.append(
+            {
+                "region": entry["region"],
+                "serving_revision": entry["candidate_revision"],
+                "service_sha256": _sha(_service_semantic(service)),
+                "revision_sha256": entry["expected_candidate_revision_sha256"],
+                "iam_sha256": _iam(cloud, args.service, entry["region"]),
+            }
+        )
+    return {
+        "schema_version": 1,
+        "kind": "trusted-router-legacy-hardening-artifact",
+        "project_id": args.project,
+        "service": args.service,
+        "runtime_service_account": args.runtime_service_account,
+        "operation_id": args.operation_id,
+        "revision_suffix": journal["revision_suffix"],
+        "regions": entries,
+        "secret_refs": journal["secret_refs"],
+        "journal_sha256": _file_sha(Path(f"{args.artifact}.state")),
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+
+
+def _verify_artifact(args: argparse.Namespace, cloud: Cloud, regions: list[str]) -> None:
+    path = args.verify_artifact
+    if path.is_symlink() or not path.is_file():
+        raise ValueError("legacy hardening artifact must be a regular file")
+    if path.stat().st_mode & 0o777 != 0o600:
+        raise ValueError("legacy hardening artifact must be mode 0600")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict) or set(value) != ARTIFACT_FIELDS:
+        raise ValueError("legacy hardening artifact fields differ")
+    if (
+        value["schema_version"] != 1
+        or value["kind"] != "trusted-router-legacy-hardening-artifact"
+        or value["project_id"] != args.project
+        or value["service"] != args.service
+        or value["runtime_service_account"] != args.runtime_service_account
+        or not re.fullmatch(r"[A-Za-z0-9._:-]{8,160}", str(value["operation_id"]))
+        or not NAME_RE.fullmatch(str(value["revision_suffix"]))
+        or not re.fullmatch(r"[0-9a-f]{64}", str(value["journal_sha256"]))
+    ):
+        raise ValueError("legacy hardening artifact identity differs")
+    _validate_timestamp(value["created_at"])
+    _validate_secret_refs(value["secret_refs"])
+    if (
+        not isinstance(value["regions"], list)
+        or any(not isinstance(item, dict) for item in value["regions"])
+        or [item.get("region") for item in value["regions"]] != regions
+    ):
+        raise ValueError("legacy hardening artifact region inventory differs")
+    journal = {
+        "revision_suffix": value["revision_suffix"],
+        "secret_refs": value["secret_refs"],
+    }
+    for record in value["regions"]:
+        if not isinstance(record, dict) or set(record) != ARTIFACT_REGION_FIELDS:
+            raise ValueError("legacy hardening artifact regional fields differ")
+        if record["serving_revision"] != f"{args.service}-{value['revision_suffix']}" or any(
+            not re.fullmatch(r"[0-9a-f]{64}", str(record[field]))
+            for field in ("service_sha256", "revision_sha256", "iam_sha256")
+        ):
+            raise ValueError("legacy hardening artifact regional contract is invalid")
+        revision = _describe_revision(cloud, record["serving_revision"], record["region"])
+        entry = {
+            "region": record["region"],
+            "candidate_revision": record["serving_revision"],
+            "expected_candidate_revision_sha256": record["revision_sha256"],
+            "image": _revision_container(revision)["image"],
+            "iam_sha256": record["iam_sha256"],
+        }
+        _verify_candidate(args, cloud, journal, entry)
+        service = _describe_service(cloud, args.service, record["region"])
+        if (
+            _sha(_service_semantic(service)) != record["service_sha256"]
+            or _iam(cloud, args.service, record["region"]) != record["iam_sha256"]
+        ):
+            raise ValueError("legacy hardening live postcondition drifted")
+        serving, latest = _traffic(service)
+        if latest or serving != record["serving_revision"]:
+            raise ValueError("legacy hardening serving traffic drifted")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project", required=True)
+    parser.add_argument("--service", required=True)
+    parser.add_argument("--regions", required=True)
+    parser.add_argument("--runtime-service-account", required=True)
+    parser.add_argument(
+        "--operation-id", default=os.environ.get("TR_ROLLOUT_OPERATION_ID", "")
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--artifact", type=Path)
+    mode.add_argument("--verify-artifact", type=Path)
+    parser.add_argument(
+        "--revision-suffix", default=os.environ.get("TR_LEGACY_HARDENING_REVISION_SUFFIX", "")
+    )
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    try:
+        regions = _validate_inputs(args)
+        cloud = Cloud(args.project)
+        if args.verify_artifact:
+            _verify_artifact(args, cloud, regions)
+            return
+        assert args.artifact is not None
+        state_path = Path(f"{args.artifact}.state")
+        if args.artifact.exists():
+            raise ValueError("legacy hardening artifact already exists; use verify mode")
+        if state_path.exists():
+            if state_path.is_symlink() or not state_path.is_file():
+                raise ValueError("legacy hardening state must be a regular file")
+            journal = json.loads(state_path.read_text(encoding="utf-8"))
+            journal = _validate_journal(args, journal, regions, path=state_path)
+            suffix = journal.get("revision_suffix")
+            if args.revision_suffix and args.revision_suffix != suffix:
+                raise ValueError("legacy hardening resume suffix differs")
+        else:
+            suffix = args.revision_suffix
+            if not NAME_RE.fullmatch(suffix) or len(f"{args.service}-{suffix}") > 63:
+                raise ValueError("legacy hardening requires a canonical explicit revision suffix")
+            journal = _capture_plan(args, cloud, regions, suffix)
+            _atomic(state_path, journal, exclusive=True)
+            journal = _validate_journal(args, journal, regions, path=state_path)
+        if any(entry["state"] == "rollback_intent" for entry in journal["regions"]):
+            _rollback(args, cloud, journal, state_path)
+        try:
+            _deploy(args, cloud, journal, state_path)
+        except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as error:
+            try:
+                _rollback(args, cloud, journal, state_path)
+            except (
+                OSError,
+                ValueError,
+                KeyError,
+                TypeError,
+                json.JSONDecodeError,
+            ) as rollback_error:
+                raise ValueError(
+                    "legacy hardening failed and automatic traffic rollback did not settle"
+                ) from rollback_error
+            raise ValueError(
+                "legacy hardening failed; exact baseline traffic was restored"
+            ) from error
+        _atomic(args.artifact, _artifact(args, cloud, journal), exclusive=True)
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as error:
+        raise SystemExit(str(error)) from error
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deploy/rollout_legacy_harden.sh
+++ b/scripts/deploy/rollout_legacy_harden.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Forward-harden the retained legacy monolith before an initial six-surface split.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/_lib.sh"
+
+if [ "${1:-}" = --artifact ]; then
+  LEGACY_OPERATION_LOCK="${TR_ROLLOUT_LOCAL_LOCK_PATH:-${TMPDIR:-/tmp}/trusted-router-${PROJECT_ID}.stage.lock}"
+  if [ "${TR_ROLLOUT_LOCAL_LOCK_HELD:-}" != "$LEGACY_OPERATION_LOCK" ]; then
+    export TR_ROLLOUT_LOCAL_LOCK_HELD="$LEGACY_OPERATION_LOCK"
+    exec python3 "${SCRIPT_DIR}/rollout_local_lock.py" \
+      "$LEGACY_OPERATION_LOCK" -- /bin/bash "$0" "$@"
+  fi
+fi
+
+exec python3 "${SCRIPT_DIR}/rollout_legacy_harden.py" \
+  --project "$PROJECT_ID" \
+  --service "$LEGACY_CONSOLE_SERVICE" \
+  --regions "$TR_CONTROL_PLANE_REGIONS" \
+  --runtime-service-account "$RUN_SERVICE_ACCOUNT" \
+  "$@"

--- a/scripts/deploy/rollout_local_lock.py
+++ b/scripts/deploy/rollout_local_lock.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Run one local rollout command under a fail-fast advisory operation lock."""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    if len(sys.argv) < 4 or sys.argv[2] != "--":
+        raise SystemExit("usage: rollout_local_lock.py LOCK -- COMMAND [ARG ...]")
+    path = Path(sys.argv[1])
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    flags = os.O_RDWR | os.O_CREAT
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise SystemExit("rollout operation lock is not a regular file")
+        os.fchmod(descriptor, 0o600)
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as error:
+            raise SystemExit("another local rollout operation holds the lock") from error
+        return subprocess.run(sys.argv[3:], check=False).returncode  # noqa: S603
+    finally:
+        os.close(descriptor)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deploy/rollout_recovery.sh
+++ b/scripts/deploy/rollout_recovery.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# Publish/recover the private manifest-bound rollout bundle and active authority.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATE_TOOL="${SCRIPT_DIR}/rollout_state.py"
+JOURNAL_TOOL="${SCRIPT_DIR}/rollout_journal.py"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  rollout_recovery.sh publish MANIFEST
+  rollout_recovery.sh recover gs://BUCKET/DEDICATED_PREFIX DESTINATION_DIRECTORY
+  rollout_recovery.sh close MANIFEST
+
+publish/close require TR_ROLLOUT_BUNDLE_GCS_URI and
+TR_ROLLOUT_AUTHORITY_GCS_URI beneath TR_ROLLOUT_RECOVERY_GCS_PREFIX. The bundle
+URI is a unique release prefix; the authority URI is the environment-wide CAS
+record that supersedes older manifests. No object contents are printed.
+EOF
+  exit 2
+}
+
+[ "$#" -ge 2 ] || usage
+COMMAND="$1"
+TARGET="$2"
+case "$COMMAND" in publish|recover|close) ;; *) usage ;; esac
+if [ "$COMMAND" = recover ]; then
+  [ "$#" -eq 3 ] || usage
+  RECOVER_DESTINATION="$3"
+else
+  [ "$#" -eq 2 ] || usage
+  RECOVER_DESTINATION=""
+fi
+
+for binary in gcloud python3; do
+  command -v "$binary" >/dev/null || {
+    echo "ERROR: required command is missing: ${binary}" >&2
+    exit 1
+  }
+done
+
+verify_recovery_uri_contract() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import re
+import sys
+
+prefix, bundle, authority = sys.argv[1:]
+match = re.fullmatch(
+    r"gs://([a-z0-9][a-z0-9._-]{1,220}[a-z0-9])/([^\x00-\x1f\x7f]+)",
+    prefix,
+)
+if (
+    not match
+    or prefix.endswith("/")
+    or "//" in match.group(2)
+    or any(part in {"", ".", ".."} for part in match.group(2).split("/"))
+):
+    raise SystemExit("TR_ROLLOUT_RECOVERY_GCS_PREFIX is not canonical")
+bucket, object_prefix = match.groups()
+if authority != f"gs://{bucket}/{object_prefix}/authority.json":
+    raise SystemExit("rollout authority URI is outside the recovery prefix")
+release_prefix = f"gs://{bucket}/{object_prefix}/releases/"
+if not bundle.startswith(release_prefix):
+    raise SystemExit("rollout bundle URI is outside the recovery releases prefix")
+epoch = bundle[len(release_prefix):]
+if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{7,159}", epoch):
+    raise SystemExit("rollout bundle must use one unique canonical manifest epoch")
+print(bucket)
+PY
+}
+
+object_generation() {
+  local uri="$1" metadata
+  if metadata="$(gcloud storage objects describe "$uri" --format=json 2>&1)"; then
+    python3 - "$metadata" <<'PY'
+import json
+import sys
+
+generation = (json.loads(sys.argv[1]) or {}).get("generation")
+if not str(generation).isdigit() or int(generation) <= 0:
+    raise SystemExit("GCS object generation is invalid")
+print(generation)
+PY
+    return
+  fi
+  case "$metadata" in
+    *NOT_FOUND*|*"not found"*|*"No URLs matched"*) echo 0 ;;
+    *) echo "ERROR: cannot inspect private rollout object" >&2; return 1 ;;
+  esac
+}
+
+verify_bucket_contract() {
+  local bucket="$1" bucket_json
+  bucket_json="$(gcloud storage buckets describe "gs://${bucket}" --format=json)" || return 1
+  python3 - "$bucket_json" <<'PY'
+import json
+import sys
+
+bucket = json.loads(sys.argv[1])
+iam = bucket.get("iamConfiguration") or {}
+if (iam.get("uniformBucketLevelAccess") or {}).get("enabled") is not True:
+    raise SystemExit("rollout recovery bucket must use uniform bucket IAM")
+if str(iam.get("publicAccessPrevention", "")).lower() != "enforced":
+    raise SystemExit("rollout recovery bucket must enforce public access prevention")
+if (bucket.get("versioning") or {}).get("enabled") is not True:
+    raise SystemExit("rollout recovery bucket must enable object versioning")
+retention = bucket.get("retentionPolicy") or {}
+try:
+    seconds = int(retention.get("retentionPeriod") or 0)
+except (TypeError, ValueError):
+    seconds = 0
+if seconds < 604800:
+    raise SystemExit("rollout recovery bucket retention must be at least seven days")
+PY
+}
+
+upload_immutable() {
+  local source="$1" uri="$2" generation remote
+  generation="$(object_generation "$uri")" || return 1
+  if [ "$generation" = 0 ]; then
+    gcloud storage cp "$source" "$uri" --if-generation-match=0 --quiet >/dev/null || return 1
+  else
+    remote="$(mktemp "${TMPDIR:-/tmp}/tr-recovery-existing-XXXXXX")"
+    chmod 600 "$remote"
+    gcloud storage cp "$uri" "$remote" --quiet >/dev/null || { rm -f "$remote"; return 1; }
+    cmp -s "$source" "$remote" || {
+      rm -f "$remote"
+      echo "ERROR: immutable rollout recovery object already exists with different bytes" >&2
+      return 1
+    }
+    rm -f "$remote"
+  fi
+}
+
+cas_authority() {
+  local manifest="$1" state_value="$2" authority="$3"
+  local generation candidate observed current remote upload_failed=0
+  generation="$(object_generation "$authority")" || return 1
+  if [ "$generation" -gt 0 ]; then
+    current="$(mktemp "${TMPDIR:-/tmp}/tr-authority-current-XXXXXX")"
+    chmod 600 "$current"
+    gcloud storage cp "$authority" "$current" --quiet >/dev/null || {
+      rm -f "$current"
+      return 1
+    }
+    python3 "$JOURNAL_TOOL" authority-validate \
+      "$current" "$manifest" active "$BUNDLE_URI" || {
+      rm -f "$current"
+      echo "ERROR: refusing to overwrite another or closed rollout authority" >&2
+      return 1
+    }
+    rm -f "$current"
+    [ "$state_value" = closed ] || return 0
+  elif [ "$state_value" = closed ]; then
+    echo "ERROR: rollout authority does not exist" >&2
+    return 1
+  fi
+  candidate="$(mktemp "${TMPDIR:-/tmp}/tr-authority-candidate-XXXXXX")"
+  rm -f "$candidate"
+  python3 "$JOURNAL_TOOL" authority-write "$manifest" "$candidate" \
+    "$state_value" "$BUNDLE_URI" || return 1
+  gcloud storage cp "$candidate" "$authority" \
+    --if-generation-match="$generation" --quiet >/dev/null || upload_failed=1
+  observed="$(object_generation "$authority")" || { rm -f "$candidate"; return 1; }
+  [ "$observed" -gt "$generation" ] || {
+    rm -f "$candidate"
+    echo "ERROR: rollout authority generation did not advance" >&2
+    return 1
+  }
+  remote="$(mktemp "${TMPDIR:-/tmp}/tr-authority-observed-XXXXXX")"
+  chmod 600 "$remote"
+  gcloud storage cp "$authority" "$remote" --quiet >/dev/null || {
+    rm -f "$candidate" "$remote"
+    return 1
+  }
+  cmp -s "$candidate" "$remote" || {
+    rm -f "$candidate" "$remote"
+    echo "ERROR: rollout authority CAS lost a concurrent update" >&2
+    return 1
+  }
+  rm -f "$remote"
+  if [ "$upload_failed" = 1 ]; then
+    echo "rollout authority upload exited non-zero after applying; exact CAS verified" >&2
+  fi
+  rm -f "$candidate"
+}
+
+if [ "$COMMAND" = recover ]; then
+  BUNDLE_URI="$TARGET"
+  DESTINATION="$RECOVER_DESTINATION"
+  AUTHORITY_URI="${TR_ROLLOUT_AUTHORITY_GCS_URI:-}"
+  RECOVERY_PREFIX="${TR_ROLLOUT_RECOVERY_GCS_PREFIX:-}"
+  [ -n "$AUTHORITY_URI" ] && [ -n "$RECOVERY_PREFIX" ] || {
+    echo "ERROR: recovery requires authority and recovery-prefix GCS URIs" >&2
+    exit 1
+  }
+  BUNDLE_BUCKET="$(verify_recovery_uri_contract \
+    "$RECOVERY_PREFIX" "$BUNDLE_URI" "$AUTHORITY_URI")" || exit 1
+  verify_bucket_contract "$BUNDLE_BUCKET"
+  [ -n "$DESTINATION" ] || usage
+  mkdir -p "$DESTINATION"
+  DESTINATION="$(cd "$DESTINATION" && pwd)"
+  descriptor="${DESTINATION}/bundle.json"
+  gcloud storage cp "${BUNDLE_URI}/bundle.json" "$descriptor" --quiet >/dev/null
+  chmod 600 "$descriptor"
+  names="$(python3 - "$descriptor" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+value = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+for item in value.get("files") or []:
+    name = item.get("name")
+    if not isinstance(name, str) or Path(name).name != name:
+        raise SystemExit("unsafe recovery bundle filename")
+    print(name)
+PY
+)" || exit 1
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    gcloud storage cp "${BUNDLE_URI}/${name}" "${DESTINATION}/${name}" --quiet >/dev/null
+    chmod 600 "${DESTINATION}/${name}"
+  done <<<"$names"
+  manifest_path="$(python3 "$JOURNAL_TOOL" bundle-validate "$descriptor" "$DESTINATION")"
+  python3 "$STATE_TOOL" validate-manifest "$manifest_path"
+  state_name="$(python3 - "$descriptor" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+print(json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))["promotion_state"])
+PY
+)" || exit 1
+  state_uri="${BUNDLE_URI}/${state_name}"
+  state_generation="$(object_generation "$state_uri")" || exit 1
+  [ "$state_generation" -gt 0 ] || {
+    echo "ERROR: recovery bundle has no durable promotion journal" >&2
+    exit 1
+  }
+  gcloud storage cp "$state_uri" "${DESTINATION}/${state_name}" --quiet >/dev/null
+  chmod 600 "${DESTINATION}/${state_name}"
+  printf '%s\n' "$state_generation" >"${DESTINATION}/promotion-state.generation"
+  chmod 600 "${DESTINATION}/promotion-state.generation"
+  python3 "$JOURNAL_TOOL" validate "${DESTINATION}/${state_name}" "$manifest_path"
+  gcloud storage cp "$AUTHORITY_URI" "${DESTINATION}/authority.json" --quiet >/dev/null
+  chmod 600 "${DESTINATION}/authority.json"
+  python3 "$JOURNAL_TOOL" authority-validate \
+    "${DESTINATION}/authority.json" "$manifest_path" active "$BUNDLE_URI"
+  printf '%s\n' "$manifest_path"
+  exit 0
+fi
+
+MANIFEST="$TARGET"
+python3 "$STATE_TOOL" validate-manifest "$MANIFEST"
+MANIFEST_DIR="$(cd "$(dirname "$MANIFEST")" && pwd)"
+MANIFEST="${MANIFEST_DIR}/$(basename "$MANIFEST")"
+BUNDLE_URI="${TR_ROLLOUT_BUNDLE_GCS_URI:-}"
+AUTHORITY_URI="${TR_ROLLOUT_AUTHORITY_GCS_URI:-}"
+RECOVERY_PREFIX="${TR_ROLLOUT_RECOVERY_GCS_PREFIX:-}"
+[ -n "$BUNDLE_URI" ] && [ -n "$AUTHORITY_URI" ] && \
+  [ -n "$RECOVERY_PREFIX" ] || {
+  echo "ERROR: rollout recovery requires prefix, bundle, and authority GCS URIs" >&2
+  exit 1
+}
+BUNDLE_BUCKET="$(verify_recovery_uri_contract \
+  "$RECOVERY_PREFIX" "$BUNDLE_URI" "$AUTHORITY_URI")" || exit 1
+verify_bucket_contract "$BUNDLE_BUCKET"
+
+if [ "$COMMAND" = publish ]; then
+  names=""
+  descriptor="${MANIFEST_DIR}/bundle.json"
+  [ ! -e "$descriptor" ] || {
+    echo "ERROR: refusing to overwrite local recovery bundle descriptor" >&2
+    exit 1
+  }
+  python3 "$JOURNAL_TOOL" bundle-write "$MANIFEST" "$descriptor"
+  names="$(python3 - "$descriptor" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+for item in json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))["files"]:
+    print(item["name"])
+PY
+)" || exit 1
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    upload_immutable "${MANIFEST_DIR}/${name}" "${BUNDLE_URI}/${name}"
+  done <<<"$names"
+  upload_immutable "$descriptor" "${BUNDLE_URI}/bundle.json"
+  state_name="$(jq -er '.promotion_state' "$MANIFEST")" || exit 1
+  state_path="${MANIFEST_DIR}/${state_name}"
+  python3 "$JOURNAL_TOOL" init "$state_path" "$MANIFEST"
+  python3 - "$state_path" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if state.get("lease") is not None or state.get("attempts") != []:
+    raise SystemExit("initial recovery bundle journal is not idle and empty")
+PY
+  upload_immutable "$state_path" "${BUNDLE_URI}/${state_name}"
+  cas_authority "$MANIFEST" active "$AUTHORITY_URI"
+  exit 0
+fi
+
+authority_local="$(mktemp "${TMPDIR:-/tmp}/tr-authority-current-XXXXXX")"
+chmod 600 "$authority_local"
+gcloud storage cp "$AUTHORITY_URI" "$authority_local" --quiet >/dev/null
+python3 "$JOURNAL_TOOL" authority-validate \
+  "$authority_local" "$MANIFEST" active "$BUNDLE_URI"
+rm -f "$authority_local"
+cas_authority "$MANIFEST" closed "$AUTHORITY_URI"

--- a/scripts/deploy/rollout_rollback.sh
+++ b/scripts/deploy/rollout_rollback.sh
@@ -1,0 +1,2192 @@
+#!/usr/bin/env bash
+# Promote or roll back a staged six-surface Cloud Run release.
+#
+# The manifest contains no rendered environment or secret data.  It is safe to
+# retain as an operator recovery record, but it is intentionally not printed by
+# this helper.  Every mutating command is recorded before execution because a
+# provider command may apply its mutation and still exit non-zero.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_edge_security.sh
+source "${SCRIPT_DIR}/_edge_security.sh"
+STATE_TOOL="${SCRIPT_DIR}/rollout_state.py"
+JOURNAL_TOOL="${SCRIPT_DIR}/rollout_journal.py"
+IAM_VERIFY="${SCRIPT_DIR}/rollout_iam_verify.sh"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  bash scripts/deploy/rollout_rollback.sh promote MANIFEST
+  bash scripts/deploy/rollout_rollback.sh promote-step MANIFEST primary|secondary|all 10|50|100
+  bash scripts/deploy/rollout_rollback.sh verify MANIFEST [primary|secondary|all] [PERCENT]
+  bash scripts/deploy/rollout_rollback.sh rollback MANIFEST
+
+`promote` requires TR_ROLLOUT_SMOKE_COMMAND to name an executable callback. It
+is called as CALLBACK MANIFEST PHASE PERCENT after each Admin-API-verified
+phase. Existing phases are primary/secondary; initial phases are
+initial-companions, initial-map, and initial-console. The initial transaction
+never changes Cloud Run traffic: all companions are new and the verified
+bootstrap internal revision is adopted at 100%, so the URL-map import is the
+only serving cutover. Workflows may instead call
+promote-step for an existing split, run authenticated LB/browser synthetics,
+and invoke rollback on failure.
+EOF
+  exit 2
+}
+
+[ "$#" -ge 2 ] || usage
+COMMAND="$1"
+MANIFEST="$2"
+shift 2
+
+python3 "$STATE_TOOL" validate-manifest "$MANIFEST"
+MANIFEST_DIR="$(cd "$(dirname "$MANIFEST")" && pwd)"
+PROJECT_ID="$(jq -er '.project_id' "$MANIFEST")"
+ROLLOUT_MODE="$(jq -er '.rollout_mode' "$MANIFEST")"
+URL_MAP_NAME="$(jq -er '.url_map.name' "$MANIFEST")"
+HTTPS_PROXY="$(jq -er '.url_map.https_proxy' "$MANIFEST")"
+PRIOR_URL_MAP="${MANIFEST_DIR}/$(jq -er '.url_map.prior_snapshot' "$MANIFEST")"
+CANDIDATE_URL_MAP="${MANIFEST_DIR}/$(jq -er '.url_map.candidate_snapshot' "$MANIFEST")"
+PROMOTION_STATE="${MANIFEST_DIR}/$(jq -er '.promotion_state' "$MANIFEST")"
+EXPECTED_PRIOR_HASH="$(jq -er '.url_map.prior_sha256' "$MANIFEST")"
+EXPECTED_CANDIDATE_HASH="$(jq -er '.url_map.candidate_sha256' "$MANIFEST")"
+EXPECTED_FRONTEND_ATTESTATION_SHA256="$(jq -er '.frontend_attestation_sha256' "$MANIFEST")"
+EXPECTED_LEGACY_HARDENING_SHA256="$(jq -r '.legacy_hardening_artifact_sha256 // ""' "$MANIFEST")"
+FRONTEND_ATTESTATION="${MANIFEST}.frontend-attestation.json"
+LEGACY_HARDENING_ARTIFACT="${MANIFEST}.legacy-hardening.json"
+STATE_GCS_URI="${TR_ROLLOUT_STATE_GCS_URI:-}"
+REQUIRE_DURABLE_STATE="${TR_ROLLOUT_REQUIRE_DURABLE_STATE:-true}"
+REQUIRE_RECOVERY_BUNDLE="${TR_ROLLOUT_REQUIRE_RECOVERY_BUNDLE:-false}"
+BUNDLE_GCS_URI="${TR_ROLLOUT_BUNDLE_GCS_URI:-}"
+AUTHORITY_GCS_URI="${TR_ROLLOUT_AUTHORITY_GCS_URI:-}"
+RECOVERY_GCS_PREFIX="${TR_ROLLOUT_RECOVERY_GCS_PREFIX:-}"
+RECOVERY_GCS_ROLE="${TR_ROLLOUT_RECOVERY_GCS_ROLE:-}"
+STATE_GCS_ROLE="${TR_ROLLOUT_STATE_GCS_ROLE:-}"
+STATE_GCS_BUCKET=""
+STATE_GCS_OBJECT=""
+STATE_STORE_GENERATION=""
+GENERATION_MARKER="${MANIFEST_DIR}/promotion-state.generation"
+LEASE_OWNER="${TR_ROLLOUT_OPERATION_ID:-}"
+LEASE_TTL_SECONDS="${TR_ROLLOUT_LEASE_TTL_SECONDS:-900}"
+PROVIDER_MUTATION_TIMEOUT_SECONDS="${TR_ROLLOUT_PROVIDER_MUTATION_TIMEOUT_SECONDS:-300}"
+LEASE_TAKEOVER="${TR_ROLLOUT_TAKEOVER_EXPIRED_LEASE:-false}"
+LEASE_HELD=0
+LEASE_OPERATION=""
+
+artifact_sha256() {
+  python3 - "$1" <<'PY'
+import hashlib
+import os
+import stat
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+metadata = os.lstat(path)
+if not stat.S_ISREG(metadata.st_mode) or stat.S_IMODE(metadata.st_mode) != 0o600:
+    raise SystemExit("rollout prerequisite artifact must be a regular mode-0600 file")
+print(hashlib.sha256(path.read_bytes()).hexdigest())
+PY
+}
+
+verify_prerequisite_artifacts() {
+  local actual
+  actual="$(artifact_sha256 "$FRONTEND_ATTESTATION")" || return 1
+  [ "$actual" = "$EXPECTED_FRONTEND_ATTESTATION_SHA256" ] || {
+    echo "ERROR: frontend attestation digest differs from the manifest" >&2
+    return 1
+  }
+  python3 "${SCRIPT_DIR}/rollout_frontend_attest.py" \
+    verify-artifact "$FRONTEND_ATTESTATION" || return 1
+  if [ "$ROLLOUT_MODE" = initial_split ]; then
+    [ -n "$EXPECTED_LEGACY_HARDENING_SHA256" ] || {
+      echo "ERROR: initial manifest has no legacy-hardening artifact digest" >&2
+      return 1
+    }
+    actual="$(artifact_sha256 "$LEGACY_HARDENING_ARTIFACT")" || return 1
+    [ "$actual" = "$EXPECTED_LEGACY_HARDENING_SHA256" ] || {
+      echo "ERROR: legacy-hardening artifact digest differs from the manifest" >&2
+      return 1
+    }
+    TR_LEGACY_HARDENING_ARTIFACT="$LEGACY_HARDENING_ARTIFACT" \
+      bash "${SCRIPT_DIR}/rollout_legacy_harden.sh" \
+        --verify-artifact "$LEGACY_HARDENING_ARTIFACT" || return 1
+  elif [ -n "$EXPECTED_LEGACY_HARDENING_SHA256" ]; then
+    echo "ERROR: existing split unexpectedly binds legacy hardening" >&2
+    return 1
+  fi
+}
+case "$REQUIRE_DURABLE_STATE" in
+  true|false) ;;
+  *) echo "ERROR: TR_ROLLOUT_REQUIRE_DURABLE_STATE must be true or false" >&2; exit 2 ;;
+esac
+case "$REQUIRE_RECOVERY_BUNDLE:$LEASE_TAKEOVER" in
+  true:true|true:false|false:true|false:false) ;;
+  *) echo "ERROR: recovery bundle/lease takeover flags must be true or false" >&2; exit 2 ;;
+esac
+if [ "$REQUIRE_RECOVERY_BUNDLE" = true ]; then
+  [ -n "$BUNDLE_GCS_URI" ] && [ -n "$AUTHORITY_GCS_URI" ] && \
+    [ -n "$RECOVERY_GCS_PREFIX" ] && [ -n "$RECOVERY_GCS_ROLE" ] || {
+    echo "ERROR: production recovery requires prefix, bundle, authority, and role inputs" >&2
+    exit 1
+  }
+  python3 - "$RECOVERY_GCS_PREFIX" "$BUNDLE_GCS_URI" "$AUTHORITY_GCS_URI" <<'PY' || exit 1
+import re
+import sys
+
+prefix, bundle, authority = sys.argv[1:]
+match = re.fullmatch(
+    r"gs://([a-z0-9][a-z0-9._-]{1,220}[a-z0-9])/([^\x00-\x1f\x7f]+)",
+    prefix,
+)
+if (
+    not match
+    or prefix.endswith("/")
+    or "//" in match.group(2)
+    or any(part in {"", ".", ".."} for part in match.group(2).split("/"))
+):
+    raise SystemExit("TR_ROLLOUT_RECOVERY_GCS_PREFIX is not canonical")
+bucket, object_prefix = match.groups()
+expected_authority = f"gs://{bucket}/{object_prefix}/authority.json"
+release_prefix = f"gs://{bucket}/{object_prefix}/releases/"
+if authority != expected_authority:
+    raise SystemExit("rollout authority URI is outside the dedicated recovery prefix")
+if not bundle.startswith(release_prefix):
+    raise SystemExit("rollout bundle URI is outside the dedicated releases prefix")
+epoch = bundle[len(release_prefix):]
+if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{7,159}", epoch):
+    raise SystemExit("rollout bundle must use one unique canonical manifest epoch")
+PY
+  if [ -n "$STATE_GCS_ROLE" ] && [ "$STATE_GCS_ROLE" != "$RECOVERY_GCS_ROLE" ]; then
+    echo "ERROR: legacy journal and recovery custom-role inputs disagree" >&2
+    exit 1
+  fi
+  STATE_GCS_ROLE="$RECOVERY_GCS_ROLE"
+  expected_state_uri="${BUNDLE_GCS_URI%/}/$(basename "$PROMOTION_STATE")"
+  if [ -n "$STATE_GCS_URI" ] && [ "$STATE_GCS_URI" != "$expected_state_uri" ]; then
+    echo "ERROR: rollout state URI is outside the manifest recovery bundle" >&2
+    exit 1
+  fi
+  STATE_GCS_URI="$expected_state_uri"
+fi
+if [ "$REQUIRE_DURABLE_STATE" = true ] && [ -z "$STATE_GCS_URI" ]; then
+  echo "ERROR: durable rollout state requires TR_ROLLOUT_STATE_GCS_URI" >&2
+  exit 1
+fi
+if [ -n "$LEASE_OWNER" ] && ! [[ "$LEASE_OWNER" =~ ^[A-Za-z0-9._:-]{8,160}$ ]]; then
+  echo "ERROR: TR_ROLLOUT_OPERATION_ID is invalid" >&2
+  exit 1
+fi
+if ! [[ "$LEASE_TTL_SECONDS" =~ ^[0-9]+$ ]] || \
+   [ "$LEASE_TTL_SECONDS" -lt 60 ] || [ "$LEASE_TTL_SECONDS" -gt 3600 ]; then
+  echo "ERROR: TR_ROLLOUT_LEASE_TTL_SECONDS must be from 60 through 3600" >&2
+  exit 2
+fi
+if ! [[ "$PROVIDER_MUTATION_TIMEOUT_SECONDS" =~ ^[0-9]+$ ]] || \
+   [ "$PROVIDER_MUTATION_TIMEOUT_SECONDS" -lt 5 ] || \
+   [ "$PROVIDER_MUTATION_TIMEOUT_SECONDS" -ge $((LEASE_TTL_SECONDS - 15)) ]; then
+  echo "ERROR: provider mutation timeout must be at least 5 seconds and end 15 seconds before lease expiry" >&2
+  exit 2
+fi
+if [ "$REQUIRE_DURABLE_STATE" = true ] && [ -z "$LEASE_OWNER" ] && \
+   [ "$COMMAND" != verify ]; then
+  echo "ERROR: durable rollout commands require TR_ROLLOUT_OPERATION_ID" >&2
+  exit 1
+fi
+if [ -n "$STATE_GCS_URI" ]; then
+  state_uri_parts="$(python3 - "$STATE_GCS_URI" <<'PY'
+import re
+import sys
+
+match = re.fullmatch(r"gs://([a-z0-9][a-z0-9._-]{1,220}[a-z0-9])/([^\x00-\x1f\x7f]+)", sys.argv[1])
+if not match or match.group(2).endswith("/") or "//" in match.group(2):
+    raise SystemExit("TR_ROLLOUT_STATE_GCS_URI must name one canonical GCS object")
+bucket, object_name = match.groups()
+if any(part in {"", ".", ".."} for part in object_name.split("/")):
+    raise SystemExit("TR_ROLLOUT_STATE_GCS_URI contains an unsafe object path")
+print(bucket)
+print(object_name)
+PY
+)" || exit 1
+  STATE_GCS_BUCKET="${state_uri_parts%%$'\n'*}"
+  STATE_GCS_OBJECT="${state_uri_parts#*$'\n'}"
+  if ! [[ "$STATE_GCS_ROLE" =~ ^projects/${PROJECT_ID}/roles/[A-Za-z][A-Za-z0-9_.]{2,63}$ ]]; then
+    echo "ERROR: durable rollout state requires a project-local TR_ROLLOUT_STATE_GCS_ROLE" >&2
+    exit 1
+  fi
+fi
+MANIFEST_SHA256="$(python3 - "$MANIFEST" <<'PY'
+import hashlib
+import sys
+from pathlib import Path
+
+print(hashlib.sha256(Path(sys.argv[1]).read_bytes()).hexdigest())
+PY
+)"
+PROMOTION_STARTED=0
+
+[ -x "$IAM_VERIFY" ] || {
+  echo "ERROR: six-runtime IAM verifier is missing or not executable" >&2
+  exit 1
+}
+
+gc() { gcloud --project "$PROJECT_ID" "$@"; }
+
+bounded_gc_mutation() {
+  python3 - "$PROVIDER_MUTATION_TIMEOUT_SECONDS" "$PROJECT_ID" "$@" <<'PY'
+import os
+import signal
+import subprocess
+import sys
+
+timeout = int(sys.argv[1])
+command = ["gcloud", "--project", sys.argv[2], *sys.argv[3:]]
+process = subprocess.Popen(command, start_new_session=True)
+try:
+    raise SystemExit(process.wait(timeout=timeout))
+except subprocess.TimeoutExpired:
+    os.killpg(process.pid, signal.SIGTERM)
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        os.killpg(process.pid, signal.SIGKILL)
+        process.wait()
+    print(
+        "ERROR: provider mutation exceeded its lease-bounded deadline; "
+        "the durable mutation fence remains unresolved",
+        file=sys.stderr,
+    )
+    raise SystemExit(124)
+PY
+}
+log() { echo "[$(date +%H:%M:%S)] $*" >&2; }
+
+verify_access_contract() {
+  bash "$IAM_VERIFY" --project "$PROJECT_ID" --manifest "$MANIFEST"
+}
+
+require_snapshot_hashes() {
+  local prior_hash candidate_hash
+  [ -f "$PRIOR_URL_MAP" ] || { echo "ERROR: prior URL-map snapshot is missing" >&2; return 1; }
+  [ -f "$CANDIDATE_URL_MAP" ] || { echo "ERROR: candidate URL-map snapshot is missing" >&2; return 1; }
+  prior_hash="$(python3 "$STATE_TOOL" hash-url-map "$PRIOR_URL_MAP")" || return 1
+  candidate_hash="$(python3 "$STATE_TOOL" hash-url-map "$CANDIDATE_URL_MAP")" || return 1
+  [ "$prior_hash" = "$EXPECTED_PRIOR_HASH" ] || {
+    echo "ERROR: prior URL-map snapshot hash drifted" >&2
+    return 1
+  }
+  [ "$candidate_hash" = "$EXPECTED_CANDIDATE_HASH" ] || {
+    echo "ERROR: candidate URL-map snapshot hash drifted" >&2
+    return 1
+  }
+}
+
+current_url_map_hash() {
+  local current
+  current="$(mktemp "${TMPDIR:-/tmp}/tr-url-map-current-XXXXXX")"
+  gc compute url-maps describe "$URL_MAP_NAME" --global --format=json >"$current" || return 1
+  python3 "$STATE_TOOL" hash-url-map "$current" || return 1
+  rm -f "$current"
+}
+
+verify_https_proxy_binding() {
+  local live_map
+  live_map="$(gc compute target-https-proxies describe "$HTTPS_PROXY" \
+    --global --format='value(urlMap.basename())')" || return 1
+  [ "$live_map" = "$URL_MAP_NAME" ] || {
+    echo "ERROR: HTTPS proxy ${HTTPS_PROXY} no longer targets manifest map ${URL_MAP_NAME}" >&2
+    return 1
+  }
+}
+
+verify_legacy_fallback() {
+  [ "$ROLLOUT_MODE" = initial_split ] || return 0
+  local entries entry service region current expected_hash actual_hash
+  local expected_generation actual_generation expected_traffic actual_traffic
+  local backend expected_backend_hash actual_backend_hash backend_current
+  local regions legacy_neg expected_revision expected_revision_hash revision_current
+  local expected_iam_hash iam_current actual_iam_hash legacy_account legacy_refs
+  local legacy_secret legacy_version secret_version_current secret_policy_current
+  entries="$(jq -c '.legacy_fallback[]' "$MANIFEST")" || return 1
+  [ -n "$entries" ] || {
+    echo "ERROR: initial manifest has no legacy fallback cohort" >&2
+    return 1
+  }
+  backend="$(jq -er '.legacy_fallback[0].backend' "$MANIFEST")" || return 1
+  expected_backend_hash="$(jq -er '.legacy_fallback[0].backend_postcondition_sha256' "$MANIFEST")" || return 1
+  if ! jq -e --arg backend "$backend" --arg digest "$expected_backend_hash" '
+      all(.legacy_fallback[];
+        .backend == $backend and .backend_postcondition_sha256 == $digest)
+    ' "$MANIFEST" >/dev/null; then
+    echo "ERROR: legacy fallback backend binding differs across regions" >&2
+    return 1
+  fi
+  backend_current="$(mktemp "${TMPDIR:-/tmp}/tr-legacy-backend-current-XXXXXX")"
+  gc compute backend-services describe "$backend" --global --format=json \
+    >"$backend_current" || return 1
+  actual_backend_hash="$(python3 "$STATE_TOOL" hash-resource "$backend_current")" || return 1
+  [ "$actual_backend_hash" = "$expected_backend_hash" ] || {
+    echo "ERROR: legacy fallback backend drifted" >&2
+    return 1
+  }
+  regions="$(jq -r '.regions[]' "$MANIFEST")" || return 1
+  python3 - "$backend_current" "$PROJECT_ID" "$regions" <<'PY' || return 1
+import json
+import sys
+from pathlib import Path
+
+backend = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+project = sys.argv[2]
+regions = sys.argv[3].splitlines()
+expected = {
+    (
+        f"https://www.googleapis.com/compute/v1/projects/{project}/regions/"
+        f"{region}/networkEndpointGroups/trusted-router-control-neg"
+    )
+    for region in regions
+}
+actual = {item.get("group") for item in backend.get("backends") or []}
+if actual != expected:
+    raise SystemExit("legacy fallback backend regional NEG membership drifted")
+PY
+  rm -f "$backend_current"
+  while IFS= read -r region; do
+    [ -n "$region" ] || continue
+    legacy_neg="$(mktemp "${TMPDIR:-/tmp}/tr-legacy-neg-current-XXXXXX")"
+    gc compute network-endpoint-groups describe trusted-router-control-neg \
+      --region="$region" --format=json >"$legacy_neg" || return 1
+    python3 - "$legacy_neg" <<'PY' || return 1
+import json
+import sys
+from pathlib import Path
+
+neg = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if neg.get("networkEndpointType") not in {None, "SERVERLESS"}:
+    raise SystemExit("legacy fallback NEG is not serverless")
+if (neg.get("cloudRun") or {}) != {"service": "trusted-router"}:
+    raise SystemExit("legacy fallback NEG target drifted")
+PY
+    rm -f "$legacy_neg"
+  done <<<"$regions"
+  while IFS= read -r entry; do
+    service="$(jq -er '.service' <<<"$entry")" || return 1
+    region="$(jq -er '.region' <<<"$entry")" || return 1
+    expected_generation="$(jq -er '.generation' <<<"$entry")" || return 1
+    expected_hash="$(jq -er '.postcondition_sha256' <<<"$entry")" || return 1
+    expected_revision="$(jq -er '.serving_revision' <<<"$entry")" || return 1
+    expected_revision_hash="$(jq -er '.serving_revision_sha256' <<<"$entry")" || return 1
+    expected_iam_hash="$(jq -er '.invoker_iam_sha256' <<<"$entry")" || return 1
+    expected_traffic="$(python3 - "$entry" <<'PY'
+import json
+import sys
+
+print(json.dumps(json.loads(sys.argv[1])["traffic"], sort_keys=True, separators=(",", ":")))
+PY
+)" || return 1
+    current="$(mktemp "${TMPDIR:-/tmp}/tr-legacy-service-current-XXXXXX")"
+    gc run services describe "$service" --region="$region" --format=json \
+      >"$current" || return 1
+    revision_current="$(mktemp "${TMPDIR:-/tmp}/tr-legacy-revision-current-XXXXXX")"
+    iam_current="$(mktemp "${TMPDIR:-/tmp}/tr-legacy-iam-current-XXXXXX")"
+    legacy_refs="$(mktemp "${TMPDIR:-/tmp}/tr-legacy-secret-refs-XXXXXX")"
+    gc run revisions describe "$expected_revision" --region="$region" --format=json \
+      >"$revision_current" || return 1
+    gc run services get-iam-policy "$service" --region="$region" --format=json \
+      >"$iam_current" || return 1
+    actual_generation="$(jq -er '
+      if (.metadata.generation | type) == "number" and
+         .metadata.generation == .status.observedGeneration
+      then .metadata.generation
+      else error("legacy service generation is not observed") end
+    ' "$current")" || return 1
+    actual_hash="$(python3 "$STATE_TOOL" hash-service "$current")" || return 1
+    actual_revision_hash="$(python3 "$STATE_TOOL" hash-revision "$revision_current")" || return 1
+    actual_iam_hash="$(python3 "$STATE_TOOL" hash-iam-policy "$iam_current")" || return 1
+    actual_traffic="$(python3 "$STATE_TOOL" traffic-state "$current" | python3 -c '
+import json, sys
+print(json.dumps(json.load(sys.stdin), sort_keys=True, separators=(",", ":")))
+')" || return 1
+    legacy_account="$(python3 - "$current" "$revision_current" "$iam_current" \
+      "$expected_revision" "$legacy_refs" <<'PY'
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+service = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+revision = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+policy = json.loads(Path(sys.argv[3]).read_text(encoding="utf-8"))
+expected_revision = sys.argv[4]
+refs_path = Path(sys.argv[5])
+status = service.get("status") or {}
+annotations = (service.get("metadata") or {}).get("annotations") or {}
+if not any(
+    item.get("type") == "Ready" and item.get("status") == "True"
+    for item in status.get("conditions") or []
+):
+    raise SystemExit("legacy fallback service is not Ready")
+if status.get("latestReadyRevisionName") != expected_revision:
+    raise SystemExit("legacy fallback latest Ready revision drifted")
+if annotations.get("run.googleapis.com/ingress") != "internal-and-cloud-load-balancing":
+    raise SystemExit("legacy fallback desired ingress is not LB-only")
+if annotations.get("run.googleapis.com/ingress-status") != "internal-and-cloud-load-balancing":
+    raise SystemExit("legacy fallback effective ingress is not LB-only")
+
+revision_status = revision.get("status") or {}
+if (revision.get("metadata") or {}).get("name") != expected_revision or not any(
+    item.get("type") == "Ready" and item.get("status") == "True"
+    for item in revision_status.get("conditions") or []
+):
+    raise SystemExit("legacy fallback serving revision is not Ready")
+revision_spec = revision.get("spec") or {}
+containers = revision_spec.get("containers") or []
+account = revision_spec.get("serviceAccountName")
+if len(containers) != 1 or not isinstance(account, str) or not account:
+    raise SystemExit("legacy fallback revision identity/container shape is inexact")
+
+all_users = []
+for binding in policy.get("bindings") or []:
+    members = binding.get("members") or []
+    if "allUsers" in members:
+        all_users.append(
+            (binding.get("role"), binding.get("condition"), members.count("allUsers"))
+        )
+if all_users != [("roles/run.invoker", None, 1)]:
+    raise SystemExit("legacy fallback service IAM lacks exact unconditional allUsers invoker")
+
+resource_re = re.compile(
+    r"(?:projects/[a-z][a-z0-9-]{4,28}[a-z0-9]/secrets/)?"
+    r"[a-z][a-z0-9-]{0,253}[a-z0-9]$"
+)
+refs = []
+for item in containers[0].get("env") or []:
+    secret_ref = ((item.get("valueFrom") or {}).get("secretKeyRef") or {})
+    if not secret_ref:
+        continue
+    resource = secret_ref.get("name")
+    version = str(secret_ref.get("key") or "")
+    if not isinstance(resource, str) or not resource_re.fullmatch(resource):
+        raise SystemExit("legacy fallback has a malformed mounted secret resource")
+    if not re.fullmatch(r"[1-9][0-9]*", version):
+        raise SystemExit("legacy fallback mounted secret versions must be numeric")
+    refs.append((resource, version))
+if len(refs) != len(set(refs)):
+    raise SystemExit("legacy fallback has duplicate mounted secret references")
+with refs_path.open("w", encoding="utf-8") as output:
+    for resource, version in sorted(refs):
+        output.write(f"{resource}\t{version}\n")
+os.chmod(refs_path, 0o600)
+print(account)
+PY
+)" || return 1
+    rm -f "$current"
+    if [ "$actual_generation" != "$expected_generation" ] || \
+       [ "$actual_hash" != "$expected_hash" ] || \
+       [ "$actual_revision_hash" != "$expected_revision_hash" ] || \
+       [ "$actual_iam_hash" != "$expected_iam_hash" ] || \
+       [ "$actual_traffic" != "$expected_traffic" ]; then
+      echo "ERROR: legacy fallback ${service}/${region} drifted" >&2
+      return 1
+    fi
+    while IFS=$'\t' read -r legacy_secret legacy_version; do
+      [ -n "$legacy_secret" ] || continue
+      secret_version_current="$(mktemp "${TMPDIR:-/tmp}/tr-legacy-secret-version-XXXXXX")"
+      secret_policy_current="$(mktemp "${TMPDIR:-/tmp}/tr-legacy-secret-policy-XXXXXX")"
+      gc secrets versions describe "$legacy_version" --secret="$legacy_secret" \
+        --format=json >"$secret_version_current" || return 1
+      gc secrets get-iam-policy "$legacy_secret" --format=json \
+        >"$secret_policy_current" || return 1
+      python3 - "$secret_version_current" "$secret_policy_current" \
+        "serviceAccount:${legacy_account}" <<'PY' || return 1
+import json
+import sys
+from pathlib import Path
+
+version = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+policy = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+member = sys.argv[3]
+if version.get("state") != "ENABLED":
+    raise SystemExit("legacy fallback mounted secret version is not ENABLED")
+direct = sorted(
+    (binding.get("role"), binding.get("condition"))
+    for binding in policy.get("bindings") or []
+    if member in (binding.get("members") or [])
+)
+if direct != [("roles/secretmanager.secretAccessor", None)]:
+    raise SystemExit("legacy fallback runtime lacks exact mounted-secret access")
+PY
+      rm -f "$secret_version_current" "$secret_policy_current"
+    done <"$legacy_refs"
+    rm -f "$revision_current" "$iam_current" "$legacy_refs"
+  done <<<"$entries"
+}
+
+assert_private_recovery_artifacts() {
+  python3 - "$MANIFEST" "$PRIOR_URL_MAP" "$CANDIDATE_URL_MAP" "$PROMOTION_STATE" <<'PY' || return 1
+import stat
+import sys
+from pathlib import Path
+
+for raw in sys.argv[1:]:
+    path = Path(raw)
+    if not path.exists():
+        continue
+    mode = stat.S_IMODE(path.stat().st_mode)
+    if mode & 0o077:
+        raise SystemExit(f"rollout recovery artifact must be mode 0600: {path.name}")
+PY
+}
+
+state_store_object_generation() {
+  local metadata
+  if metadata="$(gc storage objects describe "$STATE_GCS_URI" --format=json 2>&1)"; then
+    python3 - "$metadata" <<'PY' || return 1
+import json
+import sys
+
+generation = (json.loads(sys.argv[1]) or {}).get("generation")
+try:
+    generation = int(generation)
+except (TypeError, ValueError):
+    raise SystemExit("durable rollout journal has no numeric GCS generation") from None
+if generation <= 0:
+    raise SystemExit("durable rollout journal has an invalid GCS generation")
+print(generation)
+PY
+    return
+  fi
+  case "$metadata" in
+    *NOT_FOUND*|*"not found"*|*"No URLs matched"*) echo 0 ;;
+    *) echo "ERROR: cannot inspect durable rollout journal metadata" >&2; return 1 ;;
+  esac
+}
+
+state_store_pull() {
+  [ -n "$STATE_GCS_URI" ] || return 0
+  local generation temporary same
+  generation="$(state_store_object_generation)" || return 1
+  if [ "$generation" = 0 ]; then
+    [ ! -e "$PROMOTION_STATE" ] || {
+      echo "ERROR: local rollout journal exists but the configured durable object does not" >&2
+      return 1
+    }
+    STATE_STORE_GENERATION=0
+    return 0
+  fi
+  temporary="$(mktemp "${MANIFEST_DIR}/.promotion-state.remote.XXXXXX")"
+  chmod 600 "$temporary"
+  gc storage cp "$STATE_GCS_URI" "$temporary" --quiet >/dev/null || {
+    rm -f "$temporary"
+    echo "ERROR: cannot read the durable rollout journal" >&2
+    return 1
+  }
+  promotion_state_file_is_valid "$temporary" || {
+    rm -f "$temporary"
+    echo "ERROR: durable rollout journal belongs to another or invalid manifest" >&2
+    return 1
+  }
+  if [ -e "$PROMOTION_STATE" ]; then
+    same="$(python3 - "$PROMOTION_STATE" "$temporary" <<'PY'
+import sys
+from pathlib import Path
+
+print("true" if Path(sys.argv[1]).read_bytes() == Path(sys.argv[2]).read_bytes() else "false")
+PY
+)" || { rm -f "$temporary"; return 1; }
+    if [ "$same" = true ]; then
+      rm -f "$temporary"
+    else
+      # The generation-checked object is authoritative across hosted-runner
+      # crashes and concurrent stale local workspaces.
+      mv "$temporary" "$PROMOTION_STATE"
+      chmod 600 "$PROMOTION_STATE"
+    fi
+  else
+    mv "$temporary" "$PROMOTION_STATE"
+    chmod 600 "$PROMOTION_STATE"
+  fi
+  STATE_STORE_GENERATION="$generation"
+  printf '%s\n' "$generation" >"$GENERATION_MARKER" || return 1
+  chmod 600 "$GENERATION_MARKER" || return 1
+}
+
+verify_recovery_authority() {
+  [ "$REQUIRE_RECOVERY_BUNDLE" = true ] || return 0
+  local authority_local
+  authority_local="$(mktemp "${MANIFEST_DIR}/.authority-current.XXXXXX")"
+  chmod 600 "$authority_local"
+  gcloud storage cp "$AUTHORITY_GCS_URI" "$authority_local" --quiet >/dev/null || {
+    rm -f "$authority_local"
+    echo "ERROR: cannot read active rollout authority" >&2
+    return 1
+  }
+  python3 "$JOURNAL_TOOL" authority-validate "$authority_local" "$MANIFEST" \
+    active "$BUNDLE_GCS_URI" || {
+    rm -f "$authority_local"
+    return 1
+  }
+  rm -f "$authority_local"
+}
+
+preflight_durable_state_store() {
+  [ -n "$STATE_GCS_URI" ] || return 0
+  local bucket_json policy_json role_json deploy_member expected_resource
+  bucket_json="$(gc storage buckets describe "gs://${STATE_GCS_BUCKET}" --format=json)" || {
+    echo "ERROR: configured rollout journal bucket is not readable" >&2
+    return 1
+  }
+  policy_json="$(gc storage buckets get-iam-policy "gs://${STATE_GCS_BUCKET}" --format=json)" || {
+    echo "ERROR: configured rollout journal bucket IAM is not readable" >&2
+    return 1
+  }
+  role_json="$(gc iam roles describe "$STATE_GCS_ROLE" --format=json)" || {
+    echo "ERROR: configured rollout journal custom role is not readable" >&2
+    return 1
+  }
+  deploy_member="serviceAccount:${TR_DEPLOY_SERVICE_ACCOUNT:-tr-deploy@${PROJECT_ID}.iam.gserviceaccount.com}"
+  expected_resource="projects/_/buckets/${STATE_GCS_BUCKET}/objects/${STATE_GCS_OBJECT}"
+  python3 - "$bucket_json" "$policy_json" "$role_json" "$STATE_GCS_ROLE" \
+    "$deploy_member" "$expected_resource" <<'PY' || return 1
+import json
+import sys
+
+bucket, policy, role = (json.loads(value) for value in sys.argv[1:4])
+expected_role, deploy_member, expected_resource = sys.argv[4:]
+iam = bucket.get("iamConfiguration") or {}
+uniform = (iam.get("uniformBucketLevelAccess") or {}).get("enabled")
+if uniform is not True or str(iam.get("publicAccessPrevention", "")).lower() != "enforced":
+    raise SystemExit("rollout journal bucket must enforce uniform IAM and public access prevention")
+if (bucket.get("versioning") or {}).get("enabled") is not True:
+    raise SystemExit("rollout journal bucket must enable object versioning")
+expected_condition = {
+    "title": "trusted-router-rollout-journal",
+    "expression": f'resource.name == "{expected_resource}"',
+}
+direct = []
+for binding in policy.get("bindings", []) or []:
+    members = binding.get("members", []) or []
+    if deploy_member in members:
+        condition = binding.get("condition") or {}
+        direct.append(
+            {
+                "role": binding.get("role"),
+                "members": members,
+                "condition": {
+                    "title": condition.get("title"),
+                    "expression": condition.get("expression"),
+                },
+            }
+        )
+expected_binding = {
+    "role": expected_role,
+    "members": [deploy_member],
+    "condition": expected_condition,
+}
+if direct != [expected_binding]:
+    raise SystemExit("deploy identity must have one exact object-scoped journal binding")
+permissions = sorted(role.get("includedPermissions") or [])
+expected_permissions = sorted(
+    ["storage.objects.create", "storage.objects.delete", "storage.objects.get"]
+)
+if permissions != expected_permissions or str(role.get("stage", "GA")) == "DISABLED":
+    raise SystemExit("rollout journal custom role permissions are not least-privilege")
+PY
+  state_store_pull || return 1
+  verify_recovery_authority || return 1
+}
+
+persist_state_candidate() {
+  local candidate="$1" prior_generation="$STATE_STORE_GENERATION"
+  local upload_failed=0 observed_generation remote same
+  gc storage cp "$candidate" "$STATE_GCS_URI" \
+    --if-generation-match="$prior_generation" --quiet >/dev/null || upload_failed=1
+  observed_generation="$(state_store_object_generation)" || return 1
+  if [ "$observed_generation" = 0 ] || [ "$observed_generation" -le "$prior_generation" ]; then
+    echo "ERROR: durable rollout journal generation did not advance" >&2
+    return 1
+  fi
+  remote="$(mktemp "${MANIFEST_DIR}/.promotion-state.verify.XXXXXX")"
+  chmod 600 "$remote"
+  gc storage cp "$STATE_GCS_URI" "$remote" --quiet >/dev/null || {
+    rm -f "$remote"
+    echo "ERROR: cannot verify the durable rollout journal write" >&2
+    return 1
+  }
+  same="$(python3 - "$candidate" "$remote" <<'PY'
+import sys
+from pathlib import Path
+
+print("true" if Path(sys.argv[1]).read_bytes() == Path(sys.argv[2]).read_bytes() else "false")
+PY
+)" || { rm -f "$remote"; return 1; }
+  rm -f "$remote"
+  [ "$same" = true ] || {
+    echo "ERROR: durable rollout journal write lost its generation race" >&2
+    return 1
+  }
+  if [ "$upload_failed" = 1 ]; then
+    log "journal upload exited non-zero after applying; verified generation and content"
+  fi
+  mv "$candidate" "$PROMOTION_STATE"
+  chmod 600 "$PROMOTION_STATE"
+  STATE_STORE_GENERATION="$observed_generation"
+  printf '%s\n' "$observed_generation" >"$GENERATION_MARKER" || return 1
+  chmod 600 "$GENERATION_MARKER" || return 1
+}
+
+append_attempt_file() {
+  local state_path="$1" operation="$2" surface="$3" service="$4" region="$5" target="$6"
+  if [ "$LEASE_HELD" = 1 ]; then
+    python3 "$JOURNAL_TOOL" append "$state_path" "$MANIFEST" \
+      "$operation" "$surface" "$service" "$region" "$target" \
+      --owner "$LEASE_OWNER" || return 1
+  else
+    python3 "$JOURNAL_TOOL" append "$state_path" "$MANIFEST" \
+      "$operation" "$surface" "$service" "$region" "$target" || return 1
+  fi
+}
+
+record_attempt() {
+  local operation="$1" surface="$2" service="$3" region="$4" target="$5"
+  local candidate
+  if [ -z "$STATE_GCS_URI" ]; then
+    append_attempt_file "$PROMOTION_STATE" "$operation" "$surface" "$service" "$region" "$target"
+    return
+  fi
+  state_store_pull || return 1
+  candidate="$(mktemp "${MANIFEST_DIR}/.promotion-state.candidate.XXXXXX")"
+  chmod 600 "$candidate"
+  if [ -e "$PROMOTION_STATE" ]; then
+    cp "$PROMOTION_STATE" "$candidate"
+  else
+    rm -f "$candidate"
+  fi
+  append_attempt_file "$candidate" "$operation" "$surface" "$service" "$region" "$target" || {
+    rm -f "$candidate"
+    return 1
+  }
+  persist_state_candidate "$candidate" || {
+    rm -f "$candidate"
+    return 1
+  }
+}
+
+acquire_operation_lease() {
+  local operation="$1" candidate takeover_arg=""
+  if [ -z "$LEASE_OWNER" ]; then
+    LEASE_OWNER="local-${PPID}-$$-${RANDOM}"
+  fi
+  if [ "$LEASE_TAKEOVER" = true ]; then
+    # Reconcile all live provider state while the expired lease still belongs
+    # to its recorded owner. This is read-only and must succeed before a new
+    # operation may replace that ownership record.
+    preflight_candidates || return 1
+    takeover_arg=--allow-expired-takeover
+  fi
+  if [ -z "$STATE_GCS_URI" ]; then
+    python3 "$JOURNAL_TOOL" lease-acquire "$PROMOTION_STATE" "$MANIFEST" \
+      "$LEASE_OWNER" "$operation" --ttl-seconds "$LEASE_TTL_SECONDS" \
+      ${takeover_arg:+"$takeover_arg"} || return 1
+  else
+    state_store_pull || return 1
+    candidate="$(mktemp "${MANIFEST_DIR}/.promotion-state.lease.XXXXXX")"
+    chmod 600 "$candidate"
+    if [ -e "$PROMOTION_STATE" ]; then cp "$PROMOTION_STATE" "$candidate"; else rm -f "$candidate"; fi
+    python3 "$JOURNAL_TOOL" lease-acquire "$candidate" "$MANIFEST" \
+      "$LEASE_OWNER" "$operation" --ttl-seconds "$LEASE_TTL_SECONDS" \
+      ${takeover_arg:+"$takeover_arg"} || { rm -f "$candidate"; return 1; }
+    persist_state_candidate "$candidate" || { rm -f "$candidate"; return 1; }
+  fi
+  LEASE_OPERATION="$operation"
+  LEASE_HELD=1
+}
+
+refresh_operation_lease() {
+  [ "$LEASE_HELD" = 1 ] || {
+    echo "ERROR: provider mutation requires an active rollout operation lease" >&2
+    return 1
+  }
+  local candidate
+  verify_prerequisite_artifacts || return 1
+  verify_recovery_authority || return 1
+  if [ -z "$STATE_GCS_URI" ]; then
+    python3 "$JOURNAL_TOOL" lease-refresh "$PROMOTION_STATE" "$MANIFEST" \
+      "$LEASE_OWNER" --ttl-seconds "$LEASE_TTL_SECONDS" || return 1
+  else
+    state_store_pull || return 1
+    candidate="$(mktemp "${MANIFEST_DIR}/.promotion-state.refresh.XXXXXX")"
+    chmod 600 "$candidate"
+    cp "$PROMOTION_STATE" "$candidate"
+    python3 "$JOURNAL_TOOL" lease-refresh "$candidate" "$MANIFEST" \
+      "$LEASE_OWNER" --ttl-seconds "$LEASE_TTL_SECONDS" || {
+      rm -f "$candidate"
+      return 1
+    }
+    persist_state_candidate "$candidate" || {
+      rm -f "$candidate"
+      return 1
+    }
+  fi
+}
+
+assert_operation_lease() {
+  [ "$LEASE_HELD" = 1 ] || {
+    echo "ERROR: provider mutation requires an active rollout operation lease" >&2
+    return 1
+  }
+  if [ -n "$STATE_GCS_URI" ]; then
+    state_store_pull || return 1
+  fi
+  python3 "$JOURNAL_TOOL" lease-assert "$PROMOTION_STATE" "$MANIFEST" \
+    "$LEASE_OWNER" || return 1
+  verify_recovery_authority || return 1
+  verify_prerequisite_artifacts || return 1
+}
+
+transition_operation_mutation() {
+  local transition="$1" operation="$2" candidate
+  [ "$LEASE_HELD" = 1 ] || {
+    echo "ERROR: provider mutation requires an active rollout operation lease" >&2
+    return 1
+  }
+  case "$transition" in begin|end) ;;
+    *) echo "ERROR: invalid provider mutation fence transition" >&2; return 2 ;;
+  esac
+  if [ -z "$STATE_GCS_URI" ]; then
+    python3 "$JOURNAL_TOOL" "lease-mutation-${transition}" \
+      "$PROMOTION_STATE" "$MANIFEST" "$LEASE_OWNER" "$operation" || return 1
+    return 0
+  fi
+  state_store_pull || return 1
+  candidate="$(mktemp "${MANIFEST_DIR}/.promotion-state.mutation.XXXXXX")"
+  chmod 600 "$candidate"
+  cp "$PROMOTION_STATE" "$candidate"
+  python3 "$JOURNAL_TOOL" "lease-mutation-${transition}" \
+    "$candidate" "$MANIFEST" "$LEASE_OWNER" "$operation" || {
+    rm -f "$candidate"
+    return 1
+  }
+  persist_state_candidate "$candidate" || {
+    rm -f "$candidate"
+    return 1
+  }
+}
+
+begin_operation_mutation() {
+  transition_operation_mutation begin "$1"
+}
+
+end_operation_mutation() {
+  transition_operation_mutation end "$1"
+}
+
+release_operation_lease() {
+  [ "$LEASE_HELD" = 1 ] || return 0
+  local candidate
+  if [ -z "$STATE_GCS_URI" ]; then
+    python3 "$JOURNAL_TOOL" lease-release "$PROMOTION_STATE" "$MANIFEST" \
+      "$LEASE_OWNER" || return 1
+  else
+    state_store_pull || return 1
+    candidate="$(mktemp "${MANIFEST_DIR}/.promotion-state.release.XXXXXX")"
+    chmod 600 "$candidate"
+    cp "$PROMOTION_STATE" "$candidate"
+    python3 "$JOURNAL_TOOL" lease-release "$candidate" "$MANIFEST" \
+      "$LEASE_OWNER" || { rm -f "$candidate"; return 1; }
+    persist_state_candidate "$candidate" || { rm -f "$candidate"; return 1; }
+  fi
+  LEASE_HELD=0
+  LEASE_OPERATION=""
+}
+
+promotion_state_file_is_valid() {
+  local state_path="$1"
+  [ -f "$state_path" ] || return 1
+  jq -e \
+    --arg manifest "$MANIFEST_SHA256" \
+    --arg project "$PROJECT_ID" \
+    --arg map "$URL_MAP_NAME" \
+    --arg prior "$EXPECTED_PRIOR_HASH" \
+    --arg candidate "$EXPECTED_CANDIDATE_HASH" '
+      .schema_version == 1 and .manifest_sha256 == $manifest and
+      .project_id == $project and .url_map_name == $map and
+      .prior_url_map_sha256 == $prior and
+      .candidate_url_map_sha256 == $candidate and
+      (.attempts | type == "array")
+    ' "$state_path" >/dev/null
+}
+
+promotion_state_is_valid() {
+  promotion_state_file_is_valid "$PROMOTION_STATE"
+}
+
+latest_map_operation() {
+  promotion_state_is_valid || return 1
+  python3 - "$PROMOTION_STATE" <<'PY' || return 1
+import json
+import sys
+from pathlib import Path
+
+state = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+operations = {
+    "url-map",
+    "url-map-state",
+    "rollback-url-map",
+    "rollback-url-map-state",
+}
+matches = [item for item in state["attempts"] if item.get("operation") in operations]
+if matches:
+    item = matches[-1]
+    print(f"{item['operation']}|{item['target']}")
+PY
+}
+
+latest_traffic_operation() {
+  local entry="$1" service region
+  promotion_state_is_valid || return 1
+  service="$(jq -er '.name' <<<"$entry")" || return 1
+  region="$(jq -er '.region' <<<"$entry")" || return 1
+  python3 - "$PROMOTION_STATE" "$service" "$region" <<'PY' || return 1
+import json
+import sys
+from pathlib import Path
+
+state = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+service, region = sys.argv[2:]
+operations = {
+    "traffic",
+    "traffic-state",
+    "rollback-traffic",
+    "rollback-tags",
+    "rollback-traffic-state",
+}
+matches = [
+    item
+    for item in state["attempts"]
+    if item.get("operation") in operations
+    and item.get("service") == service
+    and item.get("region") == region
+]
+if matches:
+    item = matches[-1]
+    print(f"{item['operation']}|{item['target']}")
+PY
+}
+
+candidate_map_is_owned_for_promotion() {
+  [ "$(latest_map_operation)" = "url-map-state|candidate" ]
+}
+
+candidate_map_is_owned_for_rollback() {
+  case "$(latest_map_operation)" in
+    url-map\|candidate|url-map-state\|candidate|rollback-url-map\|prior) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+candidate_traffic_is_owned() {
+  local entry="$1" actual="$2"
+  [ "$(latest_traffic_operation "$entry")" = "traffic-state|${actual}" ]
+}
+
+service_json() {
+  local service="$1" region="$2" output="$3"
+  gc run services describe "$service" --region="$region" --format=json >"$output" || return 1
+}
+
+assert_candidate_contract() {
+  local entry="$1"
+  local service region candidate expected_hash current_hash ready
+  local current iam
+  service="$(jq -er '.name' <<<"$entry")" || return 1
+  region="$(jq -er '.region' <<<"$entry")" || return 1
+  candidate="$(jq -er '.candidate_revision' <<<"$entry")" || return 1
+  expected_hash="$(jq -er '.postcondition_sha256' <<<"$entry")" || return 1
+  current="$(mktemp "${TMPDIR:-/tmp}/tr-service-current-XXXXXX")"
+  service_json "$service" "$region" "$current" || return 1
+  current_hash="$(python3 "$STATE_TOOL" hash-service "$current")" || return 1
+  ready="$(jq -r --arg revision "$candidate" '
+    if .status.latestReadyRevisionName == $revision and
+       any(.status.conditions[]?; .type == "Ready" and .status == "True")
+    then "true" else "false" end
+  ' "$current")" || return 1
+  python3 - "$entry" "$current" "$MANIFEST" <<'PY' || return 1
+import json
+import sys
+from pathlib import Path
+entry = json.loads(sys.argv[1])
+service = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+manifest = json.loads(Path(sys.argv[3]).read_text(encoding="utf-8"))
+metadata = service.get("metadata") or {}
+annotations = metadata.get("annotations") or {}
+spec = service.get("spec") or {}
+template = spec.get("template") or {}
+template_annotations = (template.get("metadata") or {}).get("annotations") or {}
+template_spec = template.get("spec") or {}
+status = service.get("status") or {}
+if metadata.get("generation") is None or status.get("observedGeneration") is None:
+    raise SystemExit("service generation metadata is absent")
+if str(status.get("observedGeneration")) != str(metadata.get("generation")):
+    raise SystemExit("service desired generation is not observed")
+if annotations.get("run.googleapis.com/ingress") != entry["ingress"]:
+    raise SystemExit("service ingress differs from manifest")
+if annotations.get("run.googleapis.com/ingress-status") != entry["ingress"]:
+    raise SystemExit("effective service ingress differs from desired ingress")
+expected_default_url = "true" if entry["default_url_disabled"] else None
+actual_default_url = annotations.get("run.googleapis.com/default-url-disabled")
+if entry["default_url_disabled"]:
+    if str(actual_default_url).lower() != expected_default_url:
+        raise SystemExit("default URL disablement annotation differs from manifest")
+elif str(actual_default_url or "").lower() not in {"", "false"}:
+    raise SystemExit("internal default URL annotation differs from manifest")
+if template_spec.get("serviceAccountName") != entry["runtime_service_account"]:
+    raise SystemExit("runtime identity differs from manifest")
+if int(template_spec.get("containerConcurrency", -1)) != entry["concurrency"]:
+    raise SystemExit("concurrency differs from manifest")
+if str(template_spec.get("timeoutSeconds", "")).removesuffix("s") != str(entry["timeout_seconds"]):
+    raise SystemExit("timeout differs from manifest")
+if str(template_annotations.get("autoscaling.knative.dev/minScale")) != str(entry["min_instances"]):
+    raise SystemExit("revision min instances differs from manifest")
+if str(template_annotations.get("autoscaling.knative.dev/maxScale")) != str(entry["revision_max_instances"]):
+    raise SystemExit("revision max instances differs from manifest")
+service_max = (spec.get("scaling") or {}).get("maxInstanceCount")
+if service_max is None:
+    service_max = annotations.get("run.googleapis.com/maxScale")
+if str(service_max) != str(entry["service_max_instances"]):
+    raise SystemExit("service max instances differs from manifest")
+url = status.get("url") or ""
+if entry["default_url_disabled"] and url:
+    raise SystemExit("disabled default URL became externally addressable")
+if not entry["default_url_disabled"] and not url:
+    raise SystemExit("internal private default URL is absent")
+containers = template_spec.get("containers") or []
+if len(containers) != 1:
+    raise SystemExit("service must contain exactly one application container")
+if template_spec.get("volumes") not in (None, []):
+    raise SystemExit("unexpected service volumes are forbidden")
+if template_spec.get("initContainers") not in (None, []):
+    raise SystemExit("init containers are forbidden")
+container = containers[0]
+if container.get("volumeMounts") not in (None, []):
+    raise SystemExit("unexpected volume mounts are forbidden")
+if container.get("command") not in (None, []) or container.get("args") not in (None, []):
+    raise SystemExit("container command/args override is forbidden")
+if container.get("image") != manifest["image"]:
+    raise SystemExit("candidate image differs from the immutable manifest digest")
+ports = container.get("ports") or []
+if len(ports) != 1 or int(ports[0].get("containerPort", -1)) != entry["container_port"]:
+    raise SystemExit("container port differs from manifest")
+limits = (container.get("resources") or {}).get("limits") or {}
+if str(limits.get("memory")) != entry["memory"]:
+    raise SystemExit("memory differs from manifest")
+actual_cpu = str(limits.get("cpu") or "")
+if actual_cpu not in {str(entry["cpu"]), f'{entry["cpu"] * 1000}m'}:
+    raise SystemExit("CPU differs from manifest")
+network_interfaces_raw = template_annotations.get("run.googleapis.com/network-interfaces")
+try:
+    network_interfaces = json.loads(network_interfaces_raw)
+except (TypeError, ValueError):
+    raise SystemExit("VPC network annotation is invalid") from None
+if not isinstance(network_interfaces, list) or len(network_interfaces) != 1:
+    raise SystemExit("VPC network interface count differs from manifest")
+
+def exact_resource(value, kind, expected):
+    text = str(value or "").rstrip("/")
+    if text == expected:
+        return True
+    if f'/projects/{manifest["project_id"]}/' not in f'/{text}':
+        return False
+    return text.endswith(f'/{kind}/{expected}')
+
+interface = network_interfaces[0]
+if not exact_resource(interface.get("network"), "networks", entry["vpc_network"]):
+    raise SystemExit("VPC network differs from manifest")
+if not exact_resource(interface.get("subnetwork"), "subnetworks", entry["vpc_subnet"]):
+    raise SystemExit("VPC subnet differs from manifest")
+if template_annotations.get("run.googleapis.com/vpc-access-egress") != entry["vpc_egress"]:
+    raise SystemExit("VPC egress differs from manifest")
+probe = container.get("startupProbe") or {}
+http_get = probe.get("httpGet") or {}
+if http_get.get("path") != entry["startup_probe_path"]:
+    raise SystemExit("startup probe path differs from manifest")
+if http_get.get("port") is not None and int(http_get["port"]) != entry["container_port"]:
+    raise SystemExit("startup probe port differs from manifest")
+expected_probe = {
+    "initialDelaySeconds": entry["startup_probe_initial_delay_seconds"],
+    "timeoutSeconds": entry["startup_probe_timeout_seconds"],
+    "periodSeconds": entry["startup_probe_period_seconds"],
+    "failureThreshold": entry["startup_probe_failure_threshold"],
+}
+for name, expected in expected_probe.items():
+    if int(probe.get(name, -1)) != expected:
+        raise SystemExit(f"startup probe {name} differs from manifest")
+env = {
+    item.get("name"): str(item.get("value", ""))
+    for item in container.get("env") or []
+    if item.get("name") and "valueFrom" not in item
+}
+expected_env = {
+    "TR_SERVICE_SURFACE": entry["surface"],
+    "TR_RATE_LIMIT_CLIENT_IP_MODE": "edge_header",
+    "TR_MAX_REQUEST_BODY_BYTES": str(entry["max_request_body_bytes"]),
+    "TR_MAX_IN_FLIGHT_REQUEST_BODY_BYTES": str(
+        entry["max_in_flight_request_body_bytes"]
+    ),
+    "TR_MAX_CONCURRENT_REQUEST_BODIES": str(
+        entry["max_concurrent_request_bodies"]
+    ),
+    "TR_REQUEST_BODY_READ_TIMEOUT_SECONDS": str(
+        entry["request_body_read_timeout_seconds"]
+    ),
+    "TR_SYNTHETIC_SCHEDULER_INTERVAL_SECONDS": "0",
+    "TR_REMEDIATOR_IN_PROCESS_ENABLED": "false",
+}
+for name, expected in expected_env.items():
+    if env.get(name) != expected:
+        raise SystemExit(f"runtime admission contract {name} differs from manifest")
+PY
+  iam="$(gc run services get-iam-policy "$service" --region="$region" --format=json)" || return 1
+  jq -e '
+    [.bindings[]? | select(any(.members[]?; . == "allUsers"))
+      | {role, condition: (.condition // null),
+         allUsersCount: ([.members[]? | select(. == "allUsers")] | length)}]
+    == [{role:"roles/run.invoker",condition:null,allUsersCount:1}]
+  ' <<<"$iam" >/dev/null || {
+    echo "ERROR: ${service}/${region} unauthenticated LB invocation IAM drifted" >&2
+    return 1
+  }
+  rm -f "$current"
+  [ "$current_hash" = "$expected_hash" ] || {
+    echo "ERROR: service postcondition drift for ${service} in ${region}" >&2
+    return 1
+  }
+  [ "$ready" = "true" ] || {
+    echo "ERROR: candidate ${candidate} is not the latest Ready revision" >&2
+    return 1
+  }
+}
+
+candidate_percent() {
+  local service="$1" region="$2" candidate="$3"
+  gc run services describe "$service" --region="$region" --format=json \
+    | jq -r --arg revision "$candidate" '
+        [.status.traffic[]? | select(.revisionName == $revision) | (.percent // 0)]
+        | add // 0
+      '
+}
+
+edge_name() {
+  local surface="$1" kind="$2"
+  case "${surface}:${kind}" in
+    public:backend) echo trusted-router-public-backend ;;
+    actions:backend) echo trusted-router-actions-backend ;;
+    console:backend) echo trusted-router-console-backend ;;
+    chat:backend) echo trusted-router-chat-backend ;;
+    webhooks:backend) echo trusted-router-webhooks-backend ;;
+    internal:backend) echo trusted-router-billing-backend ;;
+    public:neg) echo trusted-router-public-neg ;;
+    actions:neg) echo trusted-router-actions-neg ;;
+    console:neg) echo trusted-router-console-neg ;;
+    chat:neg) echo trusted-router-chat-neg ;;
+    webhooks:neg) echo trusted-router-webhooks-neg ;;
+    internal:neg) echo trusted-router-billing-neg ;;
+    public:policy) echo trusted-router-public-edge ;;
+    actions:policy) echo trusted-router-actions-edge ;;
+    console:policy) echo trusted-router-console-edge ;;
+    chat:policy) echo trusted-router-chat-edge ;;
+    webhooks:policy) echo trusted-router-webhooks-edge ;;
+    internal:policy) echo trusted-router-billing-edge ;;
+    *) return 2 ;;
+  esac
+}
+
+assert_no_unmanaged_url_map_references() {
+  local names name map_json
+  names="$(gc compute url-maps list --format='value(name)')" || return 1
+  [ -n "$names" ] || {
+    echo "ERROR: global URL-map inventory is empty" >&2
+    return 1
+  }
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    [[ "$name" =~ ^[a-z][a-z0-9-]{0,61}$ ]] || {
+      echo "ERROR: global URL-map inventory contains a noncanonical name" >&2
+      return 1
+    }
+    [ "$name" = "$URL_MAP_NAME" ] && continue
+    map_json="$(mktemp "${TMPDIR:-/tmp}/tr-url-map-inventory-XXXXXX")"
+    gc compute url-maps describe "$name" --global --format=json >"$map_json" || return 1
+    python3 - "$name" "$map_json" <<'PY' || return 1
+import json
+import sys
+from pathlib import Path
+
+map_name, path = sys.argv[1:]
+managed = {
+    "trusted-router-public-backend",
+    "trusted-router-actions-backend",
+    "trusted-router-console-backend",
+    "trusted-router-chat-backend",
+    "trusted-router-webhooks-backend",
+    "trusted-router-billing-backend",
+}
+
+def strings(value):
+    if isinstance(value, dict):
+        for item in value.values():
+            yield from strings(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from strings(item)
+    elif isinstance(value, str):
+        yield value
+
+for value in strings(json.loads(Path(path).read_text(encoding="utf-8"))):
+    basename = value.rstrip("/").rsplit("/", 1)[-1]
+    if basename in managed:
+        raise SystemExit(
+            f"managed backend {basename} is also reachable from URL map {map_name}"
+        )
+PY
+    rm -f "$map_json"
+  done <<<"$names"
+}
+
+assert_edge_contract() {
+  local surface entry service backend neg policy timeout backend_json policy_file region neg_json regions
+  local backend_payload policy_payload regions_csv
+  regions="$(jq -r '.regions[]' "$MANIFEST")" || return 1
+  regions_csv="${regions//$'\n'/,}"
+  for surface in public actions console chat webhooks internal; do
+    entry="$(jq -cer --arg surface "$surface" '[.services[] | select(.surface == $surface)][0]' "$MANIFEST")" || return 1
+    service="$(jq -er '.name' <<<"$entry")" || return 1
+    timeout="$(jq -er '.timeout_seconds' <<<"$entry")" || return 1
+    backend="$(edge_name "$surface" backend)" || return 1
+    neg="$(edge_name "$surface" neg)" || return 1
+    policy="$(edge_name "$surface" policy)" || return 1
+    backend_json="$(mktemp "${TMPDIR:-/tmp}/tr-backend-current-XXXXXX")"
+    gc compute backend-services describe "$backend" --global --format=json >"$backend_json" || return 1
+    backend_payload="$(<"$backend_json")"
+    verify_edge_backend_contract_json "$surface" "$backend_payload" \
+      "$PROJECT_ID" "$regions_csv" "$service" "$neg" "$policy" "$timeout" || return 1
+    rm -f "$backend_json"
+    policy_file="$(mktemp "${TMPDIR:-/tmp}/tr-policy-current-XXXXXX")"
+    gc compute security-policies describe "$policy" --global --format=json >"$policy_file" || return 1
+    policy_payload="$(<"$policy_file")"
+    verify_cloud_armor_policy_contract_json "$policy_payload" || return 1
+    rm -f "$policy_file"
+    while IFS= read -r region; do
+      neg_json="$(gc compute network-endpoint-groups describe "$neg" --region="$region" --format=json)" || return 1
+      python3 - "$service" "$neg" "$region" "$neg_json" <<'PY' || return 1
+import json
+import sys
+
+service, neg, region, raw = sys.argv[1:]
+target = (json.loads(raw).get("cloudRun") or {})
+if target != {"service": service}:
+    raise SystemExit(
+        f"{neg}/{region} must target exactly Cloud Run service {service} without tag/urlMask"
+    )
+PY
+    done <<<"$regions"
+  done
+}
+
+traffic_argument_for_percent() {
+  local entry="$1" percent="$2"
+  python3 - "$percent" "$entry" <<'PY' || return 1
+from __future__ import annotations
+import json
+import math
+import sys
+from collections import defaultdict
+
+target = int(sys.argv[1])
+entry = json.loads(sys.argv[2])
+candidate = entry["candidate_revision"]
+if target == 100:
+    print(f"{candidate}=100")
+    raise SystemExit
+prior_by_revision: dict[str, int] = defaultdict(int)
+for item in entry["prior_traffic"]:
+    if item["percent"] > 0:
+        prior_by_revision[item["resolved_revision"]] += item["percent"]
+prior = sorted(prior_by_revision.items())
+if not prior:
+    raise SystemExit("cannot ramp a previously absent service below 100 percent")
+remaining = 100 - target
+total = sum(percent for _, percent in prior)
+raw = [remaining * percent / total for _, percent in prior]
+assigned = [math.floor(value) for value in raw]
+for index in sorted(range(len(raw)), key=lambda item: raw[item] - assigned[item], reverse=True)[: remaining - sum(assigned)]:
+    assigned[index] += 1
+parts = [f"{candidate}={target}"]
+parts.extend(
+    f"{revision}={share}"
+    for (revision, _), share in zip(prior, assigned, strict=True)
+    if share
+)
+print(",".join(parts))
+PY
+}
+
+restore_traffic_argument() {
+  local entry="$1"
+  python3 - "$entry" <<'PY' || return 1
+import json
+import sys
+from collections import defaultdict
+
+entry = json.loads(sys.argv[1])
+targets: dict[str, int] = defaultdict(int)
+for item in entry["prior_traffic"]:
+    if item["percent"] > 0:
+        target = "LATEST" if item["latest_revision"] else item["revision"]
+        targets[target] += item["percent"]
+print(",".join(f"{target}={targets[target]}" for target in sorted(targets)))
+PY
+}
+
+restore_tag_arguments() {
+  local entry="$1"
+  jq -r '[.prior_traffic[] | select(.tag != null and .tag != "")
+    | "\(.tag)=\(if .latest_revision then "LATEST" else .revision end)"] | join(",")' <<<"$entry"
+}
+
+verify_exact_prior_traffic() {
+  local entry="$1" service="$2" region="$3"
+  local current actual expected
+  current="$(mktemp "${TMPDIR:-/tmp}/tr-traffic-current-XXXXXX")"
+  service_json "$service" "$region" "$current" || return 1
+  # Sort object keys as well as target rows so semantically identical JSON is
+  # not rejected merely because the manifest encoder used a different key
+  # insertion order.
+  actual="$(python3 "$STATE_TOOL" traffic-state "$current" | jq -Sc 'sort_by(.tag // "", .latest_revision, .revision // "", .percent)')" || return 1
+  expected="$(jq -Sc '.prior_traffic | sort_by(.tag // "", .latest_revision, .revision // "", .percent)' <<<"$entry")" || return 1
+  rm -f "$current"
+  [ "$actual" = "$expected" ] || {
+    echo "ERROR: exact prior traffic targets were not restored for ${service}/${region}" >&2
+    return 1
+  }
+}
+
+verify_candidate_allocation() {
+  local entry="$1" expected="$2"
+  local service region candidate current
+  service="$(jq -er '.name' <<<"$entry")" || return 1
+  region="$(jq -er '.region' <<<"$entry")" || return 1
+  candidate="$(jq -er '.candidate_revision' <<<"$entry")" || return 1
+  current="$(mktemp "${TMPDIR:-/tmp}/tr-allocation-current-XXXXXX")"
+  service_json "$service" "$region" "$current" || return 1
+  python3 - "$entry" "$expected" "$current" "$STATE_TOOL" <<'PY' || return 1
+from __future__ import annotations
+import json
+import math
+import subprocess
+import sys
+from collections import defaultdict
+
+entry = json.loads(sys.argv[1])
+target = int(sys.argv[2])
+service = json.load(open(sys.argv[3], encoding="utf-8"))
+candidate = entry["candidate_revision"]
+prior_by_revision: dict[str, int] = defaultdict(int)
+for item in entry["prior_traffic"]:
+    if item["percent"] > 0:
+        prior_by_revision[item["resolved_revision"]] += item["percent"]
+prior = sorted(prior_by_revision.items())
+expected_positive: dict[str, int] = {candidate: target} if target else {}
+remaining = 100 - target
+if remaining:
+    if not prior:
+        raise SystemExit("previously absent service cannot have remaining prior traffic")
+    total = sum(percent for _, percent in prior)
+    raw = [remaining * percent / total for _, percent in prior]
+    assigned = [math.floor(value) for value in raw]
+    for index in sorted(
+        range(len(raw)), key=lambda item: raw[item] - assigned[item], reverse=True
+    )[: remaining - sum(assigned)]:
+        assigned[index] += 1
+    for (revision, _), share in zip(prior, assigned, strict=True):
+        if share:
+            expected_positive[revision] = (
+                expected_positive.get(revision, 0) + share
+            )
+state = json.loads(
+    subprocess.check_output(
+        [sys.executable, sys.argv[4], "traffic-state", sys.argv[3]], text=True
+    )
+)
+if any(item["latest_revision"] for item in state):
+    raise SystemExit("live traffic unexpectedly contains a floating LATEST target")
+actual_positive: dict[str, int] = defaultdict(int)
+for item in state:
+    if item["percent"] > 0:
+        actual_positive[item["resolved_revision"]] += item["percent"]
+if dict(actual_positive) != expected_positive:
+    raise SystemExit(
+        f"exact traffic allocation failed: {dict(actual_positive)!r} != {expected_positive!r}"
+    )
+actual_tags = sorted(
+    (
+        item["tag"],
+        item["latest_revision"],
+        item["revision"],
+        item["resolved_revision"],
+    )
+    for item in state
+    if item["tag"] is not None
+)
+expected_tags = sorted(
+    (
+        item["tag"],
+        item["latest_revision"],
+        item["revision"],
+        item["resolved_revision"],
+    )
+    for item in entry["prior_traffic"]
+    if item["tag"] is not None
+)
+if actual_tags != expected_tags:
+    raise SystemExit(f"traffic tags drifted: {actual_tags!r} != {expected_tags!r}")
+PY
+  rm -f "$current"
+  assert_candidate_contract "$entry" || return 1
+}
+
+validate_step_transition() {
+  local cohort="$1" target="$2" entry actual entry_cohort previous entries service region candidate
+  case "$target" in
+    10) previous=0 ;;
+    50) previous=10 ;;
+    100) previous=50 ;;
+    *) return 2 ;;
+  esac
+  entries="$(jq -c '.services[]' "$MANIFEST")" || return 1
+  while IFS= read -r entry; do
+    if entry_in_cohort "$entry" "$cohort"; then
+      entry_cohort="$cohort"
+    else
+      entry_cohort=other
+    fi
+    service="$(jq -er '.name' <<<"$entry")" || return 1
+    region="$(jq -er '.region' <<<"$entry")" || return 1
+    candidate="$(jq -er '.candidate_revision' <<<"$entry")" || return 1
+    actual="$(candidate_percent "$service" "$region" "$candidate")" || return 1
+    if [ "$entry_cohort" = "$cohort" ]; then
+      [ "$actual" = "$previous" ] || [ "$actual" = "$target" ] || {
+        echo "ERROR: ${cohort} ${target}% step is out of order (found ${actual}%)" >&2
+        return 1
+      }
+    elif [ "$cohort" = primary ]; then
+      [ "$actual" = 0 ] || {
+        echo "ERROR: secondary region moved before the primary cohort completed" >&2
+        return 1
+      }
+    else
+      [ "$actual" = 100 ] || {
+        echo "ERROR: secondary ramp requires every primary candidate at 100%" >&2
+        return 1
+      }
+    fi
+  done <<<"$entries"
+}
+
+entry_in_cohort() {
+  local entry="$1" cohort="$2"
+  local region primary
+  region="$(jq -er '.region' <<<"$entry")" || return 2
+  primary="$(jq -er '.regions[0]' "$MANIFEST")" || return 2
+  case "$cohort" in
+    primary) [ "$region" = "$primary" ] ;;
+    secondary) [ "$region" != "$primary" ] ;;
+    all) return 0 ;;
+    *) return 2 ;;
+  esac
+}
+
+preflight_candidates() {
+  local entry prior_exists adopted actual live_map_hash entries surface
+  verify_prerequisite_artifacts || return 1
+  require_snapshot_hashes || return 1
+  verify_https_proxy_binding || return 1
+  verify_legacy_fallback || return 1
+  verify_access_contract || return 1
+  assert_no_unmanaged_url_map_references || return 1
+  assert_edge_contract || return 1
+  live_map_hash="$(current_url_map_hash)" || return 1
+  if [ "$ROLLOUT_MODE" = existing_split ]; then
+    [ "$live_map_hash" = "$EXPECTED_PRIOR_HASH" ] || {
+      echo "ERROR: existing-split URL map drifted" >&2
+      return 1
+    }
+  elif [ "$live_map_hash" = "$EXPECTED_CANDIDATE_HASH" ]; then
+    promotion_state_is_valid && candidate_map_is_owned_for_promotion || {
+      echo "ERROR: candidate URL map is live without this manifest's recorded import attempt" >&2
+      return 1
+    }
+  elif [ "$live_map_hash" != "$EXPECTED_PRIOR_HASH" ]; then
+    echo "ERROR: initial-split URL map is neither the known prior nor candidate" >&2
+    return 1
+  fi
+  entries="$(jq -c '.services[]' "$MANIFEST")" || return 1
+  while IFS= read -r entry; do
+    prior_exists="$(jq -r '.prior_exists' <<<"$entry")"
+    adopted="$(jq -r '.adopted_bootstrap' <<<"$entry")"
+    surface="$(jq -er '.surface' <<<"$entry")" || return 1
+    actual="$(candidate_percent \
+      "$(jq -er '.name' <<<"$entry")" \
+      "$(jq -er '.region' <<<"$entry")" \
+      "$(jq -er '.candidate_revision' <<<"$entry")")" || return 1
+    if [ "$ROLLOUT_MODE" = "initial_split" ]; then
+      case "$actual" in 0|100) ;; *)
+        echo "ERROR: initial-split candidate traffic must be 0% or 100%" >&2
+        return 1 ;;
+      esac
+    else
+      case "$actual" in 0|10|50|100) ;; *)
+        echo "ERROR: existing-split candidate traffic is outside the monotonic ramp" >&2
+        return 1 ;;
+      esac
+    fi
+    if [ "$ROLLOUT_MODE" = initial_split ]; then
+      [ "$actual" = 100 ] || {
+        echo "ERROR: every initial companion must be fully staged before URL-map cutover" >&2
+        return 1
+      }
+      if [ "$prior_exists" = true ]; then
+        [ "$surface" = internal ] && [ "$adopted" = true ] && \
+          verify_exact_prior_traffic "$entry" \
+            "$(jq -er '.name' <<<"$entry")" \
+            "$(jq -er '.region' <<<"$entry")" >/dev/null 2>&1 || {
+          echo "ERROR: only a manifest-bound exact bootstrap internal revision may preexist initially" >&2
+          return 1
+        }
+      fi
+    else
+      if [ "$prior_exists" = "false" ] && [ "$actual" != "0" ] && [ "$actual" != "100" ]; then
+        echo "ERROR: previously absent companion has an unexpected partial traffic split" >&2
+        return 1
+      fi
+      if [ "$actual" != 0 ] && [ "$prior_exists" = true ]; then
+        candidate_traffic_is_owned "$entry" "$actual" || {
+          echo "ERROR: ${surface} candidate traffic lacks this manifest's completed promotion state" >&2
+          return 1
+        }
+      fi
+    fi
+    verify_candidate_allocation "$entry" "$actual" || return 1
+  done <<<"$entries"
+}
+
+update_entry_traffic() {
+  local entry="$1" percent="$2"
+  local service region surface argument provider_status=0
+  service="$(jq -er '.name' <<<"$entry")" || return 1
+  region="$(jq -er '.region' <<<"$entry")" || return 1
+  surface="$(jq -er '.surface' <<<"$entry")" || return 1
+  local actual
+  actual="$(candidate_percent "$service" "$region" "$(jq -er '.candidate_revision' <<<"$entry")")" || return 1
+  if [ "$actual" = "$percent" ]; then
+    verify_candidate_allocation "$entry" "$percent" || return 1
+    return
+  fi
+  if [ "$actual" -gt "$percent" ]; then
+    echo "ERROR: refusing to demote ${service}/${region} from ${actual}% to ${percent}%" >&2
+    return 1
+  fi
+  argument="$(traffic_argument_for_percent "$entry" "$percent")" || return 1
+  record_attempt "traffic" "$surface" "$service" "$region" "$percent" || return 1
+  refresh_operation_lease || return 1
+  begin_operation_mutation traffic || return 1
+  bounded_gc_mutation run services update-traffic "$service" \
+      --region="$region" \
+      --to-revisions="$argument" \
+      --quiet >/dev/null || provider_status=$?
+  if [ "$provider_status" -eq 124 ]; then
+    return 1
+  elif [ "$provider_status" -ne 0 ]; then
+    log "traffic command exited non-zero; inspecting provider state"
+  fi
+  assert_operation_lease || return 1
+  verify_candidate_allocation "$entry" "$percent" || return 1
+  end_operation_mutation traffic || return 1
+  record_attempt "traffic-state" "$surface" "$service" "$region" "$percent" || return 1
+}
+
+promote_step() {
+  local cohort="$1" percent="$2" embedded="${3:-}" entry entries
+  case "$cohort" in primary|secondary|all) ;; *) usage ;; esac
+  case "$percent" in 10|50|100) ;; *) usage ;; esac
+  [ "$ROLLOUT_MODE" = existing_split ] || {
+    echo "ERROR: promote-step is only valid for an existing six-surface split" >&2
+    return 1
+  }
+  [ "$cohort" != all ] || {
+    echo "ERROR: existing-split ramps must name primary or secondary explicitly" >&2
+    return 1
+  }
+  preflight_candidates || return 1
+  if [ "$embedded" != embedded ]; then
+    require_smoke_callback || return 1
+    run_smoke_callback preflight 0 || return 1
+    preflight_candidates || return 1
+  fi
+  validate_step_transition "$cohort" "$percent" || return 1
+  PROMOTION_STARTED=1
+  entries="$(jq -c '.services[]' "$MANIFEST")" || return 1
+  while IFS= read -r entry; do
+    entry_in_cohort "$entry" "$cohort" || continue
+    update_entry_traffic "$entry" "$percent" || return 1
+  done <<<"$entries"
+}
+
+verify_initial_candidate_set() {
+  local entry entries
+  [ "$ROLLOUT_MODE" = initial_split ] || return 2
+  entries="$(jq -c '.services[]' "$MANIFEST")" || return 1
+  while IFS= read -r entry; do
+    verify_candidate_allocation "$entry" 100 || return 1
+  done <<<"$entries"
+}
+
+import_candidate_url_map() {
+  local current_hash provider_status=0
+  current_hash="$(current_url_map_hash)" || return 1
+  if [ "$current_hash" = "$EXPECTED_CANDIDATE_HASH" ]; then
+    verify_https_proxy_binding || return 1
+    verify_legacy_fallback || return 1
+    promotion_state_is_valid && candidate_map_is_owned_for_promotion || {
+      echo "ERROR: candidate URL map became live without this rollout's current import ownership" >&2
+      return 1
+    }
+    return
+  fi
+  [ "$current_hash" = "$EXPECTED_PRIOR_HASH" ] || {
+    echo "ERROR: live URL map is neither manifest prior nor candidate; refusing overwrite" >&2
+    return 1
+  }
+  verify_https_proxy_binding || return 1
+  verify_legacy_fallback || return 1
+  record_attempt "url-map" "" "$URL_MAP_NAME" "global" "candidate" || return 1
+  refresh_operation_lease || return 1
+  begin_operation_mutation url-map || return 1
+  # The durable fence is now held. Re-read every off-map candidate immediately
+  # before the provider import so a concurrent service/revision change cannot
+  # ride through an earlier smoke or preflight check.
+  if ! verify_initial_candidate_set || \
+     [ "$(current_url_map_hash)" != "$EXPECTED_PRIOR_HASH" ] || \
+     ! verify_https_proxy_binding || ! verify_legacy_fallback; then
+    # No provider mutation has started, so it is safe to settle this fence
+    # before returning the failed immediate precondition.
+    end_operation_mutation url-map || return 1
+    return 1
+  fi
+  bounded_gc_mutation compute url-maps import "$URL_MAP_NAME" --global \
+      --source="$CANDIDATE_URL_MAP" --quiet >/dev/null || provider_status=$?
+  if [ "$provider_status" -eq 124 ]; then
+    return 1
+  elif [ "$provider_status" -ne 0 ]; then
+    log "URL-map import exited non-zero; inspecting provider state"
+  fi
+  assert_operation_lease || return 1
+  local imported_hash
+  imported_hash="$(current_url_map_hash)" || return 1
+  verify_https_proxy_binding || return 1
+  verify_legacy_fallback || return 1
+  [ "$imported_hash" = "$EXPECTED_CANDIDATE_HASH" ] || {
+    echo "ERROR: candidate URL-map postcondition failed" >&2
+    return 1
+  }
+  verify_initial_candidate_set || return 1
+  # Re-read the candidate immediately before settling the durable fence. This
+  # catches a same-hash import race followed by a second out-of-band rewrite.
+  [ "$(current_url_map_hash)" = "$EXPECTED_CANDIDATE_HASH" ] || return 1
+  end_operation_mutation url-map || return 1
+  record_attempt "url-map-state" "" "$URL_MAP_NAME" "global" "candidate" || return 1
+}
+
+require_smoke_callback() {
+  local callback="${TR_ROLLOUT_SMOKE_COMMAND:-}"
+  [ -n "$callback" ] || {
+    echo "ERROR: promotion requires TR_ROLLOUT_SMOKE_COMMAND" >&2
+    return 1
+  }
+  [ "$callback" = "${SCRIPT_DIR}/rollout_smoke.sh" ] || {
+    echo "ERROR: rollout smoke callback must be the repository-owned script" >&2
+    return 1
+  }
+  [ -f "$callback" ] && [ ! -L "$callback" ] && [ -x "$callback" ] || {
+    echo "ERROR: repository rollout smoke callback is not a regular executable" >&2
+    return 1
+  }
+}
+
+run_smoke_callback() {
+  local cohort="$1" percent="$2"
+  local callback="${TR_ROLLOUT_SMOKE_COMMAND:-}"
+  require_smoke_callback || return 1
+  "$callback" "$MANIFEST" "$cohort" "$percent" || return 1
+  verify_prerequisite_artifacts || return 1
+  preflight_candidates
+}
+
+promote_initial_split() {
+  local entry entries
+  local live_hash
+  live_hash="$(current_url_map_hash)" || return 1
+  # The five web companions are brand-new, and internal is the exact private
+  # bootstrap revision. They are already at their sole 100% revision while the
+  # prior map still targets the untouched legacy monolith. Do not issue any
+  # Cloud Run traffic mutation during the initial split.
+  entries="$(jq -c '.services[]' "$MANIFEST")" || return 1
+  while IFS= read -r entry; do
+    verify_candidate_allocation "$entry" 100 || return 1
+  done <<<"$entries"
+  if [ "$live_hash" = "$EXPECTED_PRIOR_HASH" ]; then
+    run_smoke_callback initial-companions 100 || return 1
+    verify_access_contract || return 1
+    preflight_candidates || return 1
+    import_candidate_url_map || return 1
+  elif [ "$live_hash" = "$EXPECTED_CANDIDATE_HASH" ]; then
+    # A resume is valid only when the durable journal's current map operation
+    # owns this exact candidate import. This also catches an identical
+    # out-of-band import between the entry preflight and the callback.
+    import_candidate_url_map || return 1
+  else
+    echo "ERROR: initial split URL map is neither prior nor candidate" >&2
+    return 1
+  fi
+  run_smoke_callback initial-map 100 || return 1
+  verify_access_contract || return 1
+  preflight_candidates || return 1
+  # Retain the explicit console phase for browser orchestration, but it is a
+  # post-cutover verification callback rather than a traffic change.
+  run_smoke_callback initial-console 100 || return 1
+  preflight_candidates || return 1
+}
+
+cohort_percent_bounds() {
+  local cohort="$1" entry actual entries service region candidate
+  local minimum=101 maximum=-1
+  entries="$(jq -c '.services[]' "$MANIFEST")" || return 1
+  while IFS= read -r entry; do
+    entry_in_cohort "$entry" "$cohort" || continue
+    service="$(jq -er '.name' <<<"$entry")" || return 1
+    region="$(jq -er '.region' <<<"$entry")" || return 1
+    candidate="$(jq -er '.candidate_revision' <<<"$entry")" || return 1
+    actual="$(candidate_percent "$service" "$region" "$candidate")" || return 1
+    [ "$actual" -lt "$minimum" ] && minimum="$actual"
+    [ "$actual" -gt "$maximum" ] && maximum="$actual"
+  done <<<"$entries"
+  [ "$maximum" -ge 0 ] || return 1
+  printf '%s %s\n' "$minimum" "$maximum"
+}
+
+promote_existing_split() {
+  [ "$EXPECTED_PRIOR_HASH" = "$EXPECTED_CANDIDATE_HASH" ] || {
+    echo "ERROR: an existing split must keep the URL map unchanged during regional ramps" >&2
+    return 1
+  }
+  local live_hash
+  live_hash="$(current_url_map_hash)" || return 1
+  [ "$live_hash" = "$EXPECTED_PRIOR_HASH" ] || {
+    echo "ERROR: existing split URL map drifted before promotion" >&2
+    return 1
+  }
+  local cohort percent bounds cohort_min cohort_max primary_bounds primary_min primary_max cohorts
+  bounds="$(cohort_percent_bounds secondary)" || return 1
+  read -r cohort_min cohort_max <<<"$bounds" || return 1
+  cohorts="primary secondary"
+  if [ "$cohort_max" -gt 0 ]; then
+    primary_bounds="$(cohort_percent_bounds primary)" || return 1
+    read -r primary_min primary_max <<<"$primary_bounds" || return 1
+    [ "$primary_min" = 100 ] && [ "$primary_max" = 100 ] || {
+      echo "ERROR: secondary resume requires the complete primary cohort at 100%" >&2
+      return 1
+    }
+    cohorts="secondary"
+  fi
+  for cohort in $cohorts; do
+    for percent in 10 50 100; do
+      bounds="$(cohort_percent_bounds "$cohort")" || return 1
+      read -r cohort_min cohort_max <<<"$bounds" || return 1
+      if [ "$cohort_max" -gt "$percent" ]; then
+        continue
+      fi
+      promote_step "$cohort" "$percent" embedded || return 1
+      run_smoke_callback "$cohort" "$percent" || return 1
+      preflight_candidates || return 1
+    done
+  done
+}
+
+restore_entry() {
+  local entry="$1"
+  local service region surface prior_exists traffic tags provider_status=0
+  service="$(jq -er '.name' <<<"$entry")" || return 1
+  region="$(jq -er '.region' <<<"$entry")" || return 1
+  surface="$(jq -er '.surface' <<<"$entry")" || return 1
+  prior_exists="$(jq -er '.prior_exists' <<<"$entry")" || return 1
+  [ "$prior_exists" = "true" ] || return 0
+  if verify_exact_prior_traffic "$entry" "$service" "$region" >/dev/null 2>&1; then
+    record_attempt "rollback-traffic-state" "$surface" "$service" "$region" "prior" || return 1
+    return 0
+  fi
+  traffic="$(restore_traffic_argument "$entry")" || return 1
+  [ -n "$traffic" ] || {
+    echo "ERROR: preexisting ${service}/${region} has no captured prior traffic" >&2
+    return 1
+  }
+  record_attempt "rollback-traffic" "$surface" "$service" "$region" "prior" || return 1
+  refresh_operation_lease || return 1
+  begin_operation_mutation rollback-traffic || return 1
+  bounded_gc_mutation run services update-traffic "$service" \
+      --region="$region" --to-revisions="$traffic" --quiet >/dev/null || \
+      provider_status=$?
+  if [ "$provider_status" -eq 124 ]; then
+    return 1
+  elif [ "$provider_status" -ne 0 ]; then
+    log "rollback traffic command exited non-zero; inspecting provider state"
+  fi
+  assert_operation_lease || return 1
+  # Tags are restored separately because gcloud models them independently
+  # from --to-revisions. Exact traffic intent (including floating LATEST) is
+  # verified after both mutations.
+  tags="$(restore_tag_arguments "$entry")" || return 1
+  if [ -n "$tags" ]; then
+    record_attempt "rollback-tags" "$surface" "$service" "$region" "prior" || return 1
+    refresh_operation_lease || return 1
+    provider_status=0
+    bounded_gc_mutation run services update-traffic "$service" --region="$region" \
+        --set-tags="$tags" --quiet >/dev/null || provider_status=$?
+    if [ "$provider_status" -eq 124 ]; then
+      return 1
+    elif [ "$provider_status" -ne 0 ]; then
+      log "rollback tag command exited non-zero; inspecting provider state"
+    fi
+    assert_operation_lease || return 1
+  else
+    record_attempt "rollback-tags" "$surface" "$service" "$region" "clear" || return 1
+    refresh_operation_lease || return 1
+    provider_status=0
+    bounded_gc_mutation run services update-traffic "$service" --region="$region" \
+        --clear-tags --quiet >/dev/null || provider_status=$?
+    if [ "$provider_status" -eq 124 ]; then
+      return 1
+    elif [ "$provider_status" -ne 0 ]; then
+      log "rollback clear-tags command exited non-zero; inspecting provider state"
+    fi
+    assert_operation_lease || return 1
+  fi
+  verify_exact_prior_traffic "$entry" "$service" "$region" || return 1
+  end_operation_mutation rollback-traffic || return 1
+  record_attempt "rollback-traffic-state" "$surface" "$service" "$region" "prior" || return 1
+}
+
+traffic_was_attempted() {
+  local entry="$1" latest
+  latest="$(latest_traffic_operation "$entry")" || return 1
+  case "$latest" in
+    traffic\|*|traffic-state\|*|rollback-traffic\|*|rollback-tags\|*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+preflight_rollback_entry() {
+  local entry="$1" service region candidate actual
+  service="$(jq -er '.name' <<<"$entry")" || return 1
+  region="$(jq -er '.region' <<<"$entry")" || return 1
+  candidate="$(jq -er '.candidate_revision' <<<"$entry")" || return 1
+  if verify_exact_prior_traffic "$entry" "$service" "$region" >/dev/null 2>&1; then
+    return 0
+  fi
+  actual="$(candidate_percent "$service" "$region" "$candidate")" || return 1
+  case "$actual" in 0|10|50|100) ;; *)
+    echo "ERROR: ${service}/${region} is not in a known prior/candidate traffic state" >&2
+    return 1 ;;
+  esac
+  verify_candidate_allocation "$entry" "$actual" || {
+    echo "ERROR: ${service}/${region} changed outside this rollout; refusing rollback" >&2
+    return 1
+  }
+}
+
+preflight_unattempted_entry() {
+  local entry="$1" service region prior_exists candidate actual
+  service="$(jq -er '.name' <<<"$entry")" || return 1
+  region="$(jq -er '.region' <<<"$entry")" || return 1
+  prior_exists="$(jq -er '.prior_exists' <<<"$entry")" || return 1
+  if [ "$prior_exists" = true ]; then
+    verify_exact_prior_traffic "$entry" "$service" "$region" >/dev/null 2>&1 || {
+      echo "ERROR: unattempted ${service}/${region} is not at its exact prior traffic state" >&2
+      return 1
+    }
+    return 0
+  fi
+  candidate="$(jq -er '.candidate_revision' <<<"$entry")" || return 1
+  actual="$(candidate_percent "$service" "$region" "$candidate")" || return 1
+  case "$actual" in 0|100) ;; *)
+    echo "ERROR: unattempted new companion ${service}/${region} has partial traffic" >&2
+    return 1 ;;
+  esac
+  verify_candidate_allocation "$entry" "$actual" || return 1
+}
+
+rollback_manifest() {
+  local current_hash entry restored_hash rollback_failed=0 attempted_entries all_entries
+  local provider_status=0
+  require_snapshot_hashes || return 1
+  verify_https_proxy_binding || return 1
+  current_hash="$(current_url_map_hash)" || return 1
+  case "$current_hash" in
+    "$EXPECTED_PRIOR_HASH") ;;
+    "$EXPECTED_CANDIDATE_HASH")
+      candidate_map_is_owned_for_rollback || {
+        echo "ERROR: candidate URL map is live without a recorded rollout attempt" >&2
+        return 1
+      }
+      ;;
+    *)
+      echo "ERROR: live URL map is an unknown third state; refusing rollback mutations" >&2
+      return 1
+      ;;
+  esac
+
+  if [ "$ROLLOUT_MODE" = initial_split ]; then
+    # The split services are all new and have no prior traffic state. Their
+    # health/config failure may be the reason for rollback, so do not make
+    # recovery depend on them. Ownership of the candidate map plus the exact
+    # proxy and legacy fallback cohort are the complete rollback authority.
+    verify_legacy_fallback || return 1
+    if [ "$current_hash" = "$EXPECTED_CANDIDATE_HASH" ]; then
+      verify_https_proxy_binding || return 1
+      verify_legacy_fallback || return 1
+      record_attempt "rollback-url-map" "" "$URL_MAP_NAME" "global" "prior" || return 1
+      refresh_operation_lease || return 1
+      begin_operation_mutation rollback-url-map || return 1
+      bounded_gc_mutation compute url-maps import "$URL_MAP_NAME" --global \
+          --source="$PRIOR_URL_MAP" --quiet >/dev/null || provider_status=$?
+      if [ "$provider_status" -eq 124 ]; then
+        return 1
+      elif [ "$provider_status" -ne 0 ]; then
+        log "rollback URL-map import exited non-zero; inspecting provider state"
+      fi
+      assert_operation_lease || return 1
+      restored_hash="$(current_url_map_hash)" || return 1
+      verify_https_proxy_binding || return 1
+      verify_legacy_fallback || return 1
+      [ "$restored_hash" = "$EXPECTED_PRIOR_HASH" ] || {
+        echo "ERROR: initial rollback did not restore the legacy URL map" >&2
+        return 1
+      }
+      [ "$(current_url_map_hash)" = "$EXPECTED_PRIOR_HASH" ] || return 1
+      end_operation_mutation rollback-url-map || return 1
+      record_attempt "rollback-url-map-state" "" "$URL_MAP_NAME" "global" "prior" || return 1
+    elif promotion_state_is_valid && [ -n "$(latest_map_operation)" ]; then
+      record_attempt "rollback-url-map-state" "" "$URL_MAP_NAME" "global" "prior" || return 1
+    fi
+    log "initial rollback restored the verified legacy URL map; split services were untouched"
+    return 0
+  fi
+
+  all_entries="$(jq -c '.services[]' "$MANIFEST")" || return 1
+  if ! promotion_state_is_valid; then
+    [ "$current_hash" = "$EXPECTED_PRIOR_HASH" ] || {
+      echo "ERROR: rollback state is missing or invalid while the candidate URL map is live" >&2
+      return 1
+    }
+    while IFS= read -r entry; do
+      preflight_unattempted_entry "$entry" || {
+        echo "ERROR: rollback state is missing or invalid with non-prior traffic live" >&2
+        return 1
+      }
+    done <<<"$all_entries"
+    log "no valid rollout attempts exist and every service remains at its safe staged/prior state"
+    return 0
+  fi
+  attempted_entries=""
+  while IFS= read -r entry; do
+    if traffic_was_attempted "$entry"; then
+      attempted_entries="${attempted_entries}${entry}"$'\n'
+    else
+      preflight_unattempted_entry "$entry" || return 1
+    fi
+  done <<<"$all_entries"
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    preflight_rollback_entry "$entry" || return 1
+  done <<<"$attempted_entries"
+
+  # Existing-split traffic rollback restores console before any other surface.
+  # Initial split has no traffic attempts: restoring the prior map atomically
+  # returns every managed host to the untouched legacy monolith.
+  if [ "$ROLLOUT_MODE" = existing_split ]; then
+    while IFS= read -r entry; do
+      [ -n "$entry" ] || continue
+      [ "$(jq -r '.surface' <<<"$entry")" = console ] || continue
+      restore_entry "$entry" || {
+        echo "ERROR: console rollback failed; refusing remaining rollback" >&2
+        return 1
+      }
+    done <<<"$attempted_entries"
+  fi
+
+  if [ "$current_hash" = "$EXPECTED_CANDIDATE_HASH" ] && \
+     [ "$EXPECTED_CANDIDATE_HASH" != "$EXPECTED_PRIOR_HASH" ]; then
+    verify_https_proxy_binding || return 1
+    verify_legacy_fallback || return 1
+    record_attempt "rollback-url-map" "" "$URL_MAP_NAME" "global" "prior" || return 1
+    refresh_operation_lease || return 1
+    provider_status=0
+    begin_operation_mutation rollback-url-map || return 1
+    bounded_gc_mutation compute url-maps import "$URL_MAP_NAME" --global \
+        --source="$PRIOR_URL_MAP" --quiet >/dev/null || provider_status=$?
+    if [ "$provider_status" -eq 124 ]; then
+      return 1
+    elif [ "$provider_status" -ne 0 ]; then
+      log "rollback URL-map import exited non-zero; inspecting provider state"
+    fi
+    assert_operation_lease || return 1
+    restored_hash="$(current_url_map_hash)" || return 1
+    verify_https_proxy_binding || return 1
+    verify_legacy_fallback || return 1
+    [ "$restored_hash" = "$EXPECTED_PRIOR_HASH" ] || {
+      echo "ERROR: prior URL map was not restored; companion rollback was not attempted" >&2
+      return 1
+    }
+    [ "$(current_url_map_hash)" = "$EXPECTED_PRIOR_HASH" ] || return 1
+    end_operation_mutation rollback-url-map || return 1
+    record_attempt "rollback-url-map-state" "" "$URL_MAP_NAME" "global" "prior" || return 1
+  elif promotion_state_is_valid && [ -n "$(latest_map_operation)" ]; then
+    record_attempt "rollback-url-map-state" "" "$URL_MAP_NAME" "global" "prior" || return 1
+  fi
+
+  # Companion failures after the prior map is restored cannot affect public
+  # routing, so attempt every recorded entry and report a partial failure.
+  for surface in internal webhooks chat actions public; do
+    while IFS= read -r entry; do
+      [ -n "$entry" ] || continue
+      [ "$(jq -r '.surface' <<<"$entry")" = "$surface" ] || continue
+      restore_entry "$entry" || rollback_failed=1
+    done <<<"$attempted_entries"
+  done
+  [ "$rollback_failed" = 0 ] || {
+    echo "ERROR: rollback restored routing but one or more attempted companion traffic states failed" >&2
+    return 1
+  }
+  log "rollback restored the captured URL map and all preexisting service traffic"
+}
+
+verify_manifest_state() {
+  local cohort="${1:-all}" expected="${2:-}" entry live_hash matched=0 entries
+  case "$cohort" in primary|secondary|all) ;; *)
+    echo "ERROR: verify cohort must be primary, secondary, or all" >&2
+    return 2 ;;
+  esac
+  if [ -n "$expected" ]; then
+    case "$expected" in 0|10|50|100) ;; *)
+      echo "ERROR: verify percent must be 0, 10, 50, or 100" >&2
+      return 2 ;;
+    esac
+  fi
+  preflight_candidates || return 1
+  live_hash="$(current_url_map_hash)" || return 1
+  if [ "$ROLLOUT_MODE" = existing_split ]; then
+    [ "$live_hash" = "$EXPECTED_PRIOR_HASH" ] || {
+      echo "ERROR: existing-split URL map drifted during verification" >&2
+      return 1
+    }
+  elif [ "$live_hash" != "$EXPECTED_PRIOR_HASH" ] && \
+       [ "$live_hash" != "$EXPECTED_CANDIDATE_HASH" ]; then
+    echo "ERROR: initial-split URL map is an unknown state during verification" >&2
+    return 1
+  elif [ "$cohort" = all ] && [ "$expected" = 100 ] && \
+       [ "$live_hash" != "$EXPECTED_CANDIDATE_HASH" ]; then
+    echo "ERROR: fully promoted initial split does not use the candidate URL map" >&2
+    return 1
+  fi
+  entries="$(jq -c '.services[]' "$MANIFEST")" || return 1
+  while IFS= read -r entry; do
+    entry_in_cohort "$entry" "$cohort" || continue
+    matched=$((matched + 1))
+    assert_candidate_contract "$entry" || return 1
+    if [ -n "$expected" ]; then
+      verify_candidate_allocation "$entry" "$expected" || return 1
+    fi
+  done <<<"$entries"
+  [ "$matched" -gt 0 ] || {
+    echo "ERROR: verify cohort selected no service entries" >&2
+    return 1
+  }
+}
+
+assert_private_recovery_artifacts
+preflight_durable_state_store
+
+case "$COMMAND" in
+  promote)
+    [ "$#" -eq 0 ] || usage
+    promotion_failed=0
+    acquire_operation_lease "promote" || promotion_failed=1
+    require_smoke_callback || promotion_failed=1
+    if [ "$promotion_failed" = 0 ]; then
+      preflight_candidates || promotion_failed=1
+    fi
+    if [ "$promotion_failed" = 0 ]; then
+      run_smoke_callback preflight 0 || promotion_failed=1
+    fi
+    if [ "$promotion_failed" = 0 ]; then
+      PROMOTION_STARTED=1
+      if [ "$ROLLOUT_MODE" = "initial_split" ]; then
+        promote_initial_split || promotion_failed=1
+      else
+        promote_existing_split || promotion_failed=1
+      fi
+    fi
+    if [ "$promotion_failed" != 0 ]; then
+      if [ "$PROMOTION_STARTED" = 1 ]; then
+        log "promotion failed; attempting manifest rollback"
+        rollback_manifest || log "ERROR: automatic rollback also failed"
+      fi
+      release_operation_lease || log "ERROR: failed to release rollout operation lease"
+      exit 1
+    fi
+    release_operation_lease || exit 1
+    ;;
+  promote-step)
+    [ "$#" -eq 2 ] || usage
+    promotion_failed=0
+    acquire_operation_lease "promote-step:$1:$2" || promotion_failed=1
+    if [ "$promotion_failed" = 0 ]; then
+      promote_step "$1" "$2" || promotion_failed=1
+    fi
+    if [ "$promotion_failed" != 0 ]; then
+      if [ "$PROMOTION_STARTED" = 1 ]; then
+        log "promotion step failed; attempting manifest rollback"
+        rollback_manifest || log "ERROR: automatic rollback also failed"
+      fi
+      release_operation_lease || log "ERROR: failed to release rollout operation lease"
+      exit 1
+    fi
+    release_operation_lease || exit 1
+    ;;
+  verify)
+    [ "$#" -le 2 ] || usage
+    verify_manifest_state "${1:-all}" "${2:-}"
+    ;;
+  rollback)
+    [ "$#" -eq 0 ] || usage
+    rollback_failed=0
+    acquire_operation_lease "rollback" || rollback_failed=1
+    if [ "$rollback_failed" = 0 ]; then
+      rollback_manifest || rollback_failed=1
+    fi
+    release_operation_lease || rollback_failed=1
+    [ "$rollback_failed" = 0 ] || exit 1
+    ;;
+  *) usage ;;
+esac

--- a/scripts/deploy/rollout_smoke.sh
+++ b/scripts/deploy/rollout_smoke.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# Repository-owned, side-effect-free API and Firefox smoke callback.
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: rollout_smoke.sh MANIFEST PHASE PERCENT" >&2
+  exit 2
+}
+
+[ "$#" -eq 3 ] || usage
+MANIFEST="$1"
+PHASE="$2"
+PERCENT="$3"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+STATE_TOOL="${SCRIPT_DIR}/rollout_state.py"
+AUTH_HEADER_FILE="${TR_ROLLOUT_SMOKE_AUTH_HEADER_FILE:-}"
+STORAGE_STATE="${TR_ROLLOUT_SMOKE_PLAYWRIGHT_STORAGE_STATE:-}"
+
+[ "${TR_ROLLOUT_SMOKE_PRODUCTION_APPROVED:-false}" = true ] || {
+  echo "ERROR: production rollout smoke requires explicit approval" >&2
+  exit 1
+}
+case "$PHASE" in
+  preflight|initial-companions|initial-map|initial-console|primary|secondary) ;;
+  *) echo "ERROR: rollout smoke phase is invalid" >&2; exit 2 ;;
+esac
+case "$PERCENT" in 0|10|50|100) ;;
+  *) echo "ERROR: rollout smoke percent is invalid" >&2; exit 2 ;;
+esac
+
+python3 "$STATE_TOOL" validate-manifest "$MANIFEST"
+python3 - "$AUTH_HEADER_FILE" "$STORAGE_STATE" <<'PY'
+import json
+import re
+import stat
+import sys
+from pathlib import Path
+
+header_path, storage_path = (Path(value) for value in sys.argv[1:])
+for path in (header_path, storage_path):
+    info = path.lstat()
+    if not stat.S_ISREG(info.st_mode) or stat.S_IMODE(info.st_mode) != 0o600:
+        raise SystemExit(f"smoke credential file must be a regular mode-0600 file: {path}")
+header = header_path.read_text(encoding="utf-8")
+if not re.fullmatch(r"Authorization: Bearer [^\x00-\x20\x7f]{16,8192}\n?", header):
+    raise SystemExit("smoke authorization header file is malformed")
+state = json.loads(storage_path.read_text(encoding="utf-8"))
+if not isinstance(state, dict) or set(state) != {"cookies", "origins"}:
+    raise SystemExit("Playwright storage state fields differ")
+if not isinstance(state["cookies"], list) or not isinstance(state["origins"], list):
+    raise SystemExit("Playwright storage state is malformed")
+PY
+
+DOMAINS="$(python3 - "$MANIFEST" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+domains = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8")).get("domains")
+if not isinstance(domains, list) or not all(isinstance(item, str) for item in domains):
+    raise SystemExit("manifest smoke domains are invalid")
+print(",".join(domains))
+PY
+)" || exit 1
+[ "$DOMAINS" = "trustedrouter.com,allyrouter.com,uptimerouter.com" ] || {
+  echo "ERROR: rollout smoke domain inventory differs" >&2
+  exit 1
+}
+
+SMOKE_TMP="$(mktemp -d "${TMPDIR:-/tmp}/tr-rollout-smoke.XXXXXX")"
+trap 'rm -rf "$SMOKE_TMP"' EXIT
+PLAYWRIGHT_OUTPUT="${SMOKE_TMP}/playwright-results"
+mkdir -m 700 "$PLAYWRIGHT_OUTPUT"
+
+check_code() {
+  local name="$1" expected="$2" url="$3"
+  shift 3
+  local code
+  code="$(curl --disable --silent --show-error --max-time 20 --output "${SMOKE_TMP}/${name}" \
+    --write-out '%{http_code}' "$@" "$url")" || {
+    echo "ERROR: smoke request failed: ${name}" >&2
+    return 1
+  }
+  [ "$code" = "$expected" ] || {
+    echo "ERROR: ${name} returned ${code}, expected ${expected}" >&2
+    return 1
+  }
+}
+
+# Exercise the two high-risk split routes only through their pre-body auth
+# gates. The deliberately non-actionable JSON remains invalid for the handler
+# behind each gate, so even an unexpected routing/auth regression cannot turn
+# this callback into inference, a credit reservation, or payment work.
+check_auth_rejection() {
+  local name="$1" url="$2" expected_message="$3"
+  local request_id="tr-rollout-${name}"
+  local code
+  code="$(curl --disable --silent --show-error --max-time 20 \
+    --request POST \
+    --header 'authorization:' \
+    --header 'cookie:' \
+    --header 'content-type: application/json' \
+    --header "x-request-id: ${request_id}" \
+    --data '{"smoke":"auth-gate-only"}' \
+    --dump-header "${SMOKE_TMP}/${name}.headers" \
+    --output "${SMOKE_TMP}/${name}" \
+    --write-out '%{http_code}' \
+    "$url")" || {
+    echo "ERROR: smoke auth-rejection request failed: ${name}" >&2
+    return 1
+  }
+  [ "$code" = 401 ] || {
+    echo "ERROR: ${name} returned ${code}, expected 401" >&2
+    return 1
+  }
+  python3 - \
+    "${SMOKE_TMP}/${name}" \
+    "${SMOKE_TMP}/${name}.headers" \
+    "$expected_message" \
+    "$request_id" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+body_path, headers_path = (Path(value) for value in sys.argv[1:3])
+expected_message, expected_request_id = sys.argv[3:]
+
+payload = json.loads(body_path.read_text(encoding="utf-8"))
+error = payload.get("error") if isinstance(payload, dict) else None
+expected_error = {
+    "code": 401,
+    "message": expected_message,
+    "type": "unauthorized",
+    "source": "router",
+}
+if error != expected_error:
+    raise SystemExit(f"smoke auth-rejection body differs: {error!r}")
+
+# curl can record an informational response before the final one. Reset the
+# map on each HTTP status line and verify only the final response block.
+headers: dict[str, str] = {}
+for raw_line in headers_path.read_text(encoding="iso-8859-1").splitlines():
+    line = raw_line.rstrip("\r")
+    if line.startswith("HTTP/"):
+        headers = {}
+    elif ":" in line:
+        name, value = line.split(":", 1)
+        headers[name.strip().lower()] = value.strip()
+
+if not headers.get("content-type", "").lower().startswith("application/json"):
+    raise SystemExit("smoke auth-rejection response is not JSON")
+if headers.get("x-trustedrouter-request-id") != expected_request_id:
+    raise SystemExit("smoke auth-rejection request id was not echoed by the application")
+if headers.get("strict-transport-security") != "max-age=63072000; includeSubDomains":
+    raise SystemExit("smoke auth-rejection response lacks the reviewed HSTS contract")
+for forbidden in ("x-trustedrouter-provider", "x-trustedrouter-served-model"):
+    if forbidden in headers:
+        raise SystemExit(f"smoke auth-rejection unexpectedly returned {forbidden}")
+PY
+}
+
+IFS=',' read -r -a domain_list <<<"$DOMAINS"
+for domain in "${domain_list[@]}"; do
+  safe_domain="${domain//./-}"
+  check_code "${safe_domain}-home" 200 "https://${domain}/"
+  check_code "${safe_domain}-health" 200 "https://${domain}/health"
+  check_code "${safe_domain}-ready" 200 "https://${domain}/ready"
+  check_code "${safe_domain}-models" 200 "https://${domain}/v1/models"
+  check_code "${safe_domain}-session" 200 "https://${domain}/auth/session" \
+    --header "@${AUTH_HEADER_FILE}"
+  python3 - "${SMOKE_TMP}/${safe_domain}-session" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8")).get("data") or {}
+if data.get("authenticated") is not True or data.get("management") is not True:
+    raise SystemExit("authenticated management smoke session is not active")
+PY
+  check_code "${safe_domain}-invalid-action" 422 \
+    "https://${domain}/support/inquiry" \
+    --header 'content-type: application/json' \
+    --data '{"name":"","email":"invalid","category":"api","subject":"","message":"","website":""}'
+  check_code "${safe_domain}-invalid-webhook" 400 \
+    "https://${domain}/internal/stripe/webhook" \
+    --header 'content-type: application/json' \
+    --header 'stripe-signature: t=0,v1=invalid' \
+    --data '{"id":"evt_rollout_invalid","type":"payment_intent.succeeded","data":{"object":{"id":"pi_invalid"}}}'
+  check_auth_rejection \
+    "chat-auth-${safe_domain}" \
+    "https://${domain}/chat-proxy/v1/chat/completions" \
+    "Missing Authentication header"
+  check_auth_rejection \
+    "internal-auth-${safe_domain}" \
+    "https://${domain}/v1/internal/gateway/authorize" \
+    "Invalid internal service token"
+done
+
+export TR_ROLLOUT_SMOKE_DOMAINS="$DOMAINS"
+export TR_ROLLOUT_SMOKE_AUTH_HEADER_FILE="$AUTH_HEADER_FILE"
+export TR_ROLLOUT_SMOKE_PLAYWRIGHT_STORAGE_STATE="$STORAGE_STATE"
+export TR_ROLLOUT_SMOKE_PHASE="$PHASE"
+export TR_ROLLOUT_SMOKE_PERCENT="$PERCENT"
+export TR_ROLLOUT_SMOKE_PLAYWRIGHT_OUTPUT_DIR="$PLAYWRIGHT_OUTPUT"
+cd "$ROOT_DIR"
+npx playwright test \
+  --config=playwright.rollout.config.js \
+  --project=firefox \
+  tests/browser/production_rollout_smoke.spec.js
+
+echo "rollout smoke passed phase=${PHASE} percent=${PERCENT}" >&2

--- a/scripts/deploy/rollout_state.py
+++ b/scripts/deploy/rollout_state.py
@@ -1,0 +1,1027 @@
+#!/usr/bin/env python3
+"""Non-secret state handling for the six-surface Cloud Run rollout.
+
+The rollout manifest is deliberately a recovery record, not a rendered deploy
+specification.  Environment values and Secret Manager references stay out of
+it; immutable postcondition hashes are enough to detect revision drift during
+promotion and rollback.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Any
+
+SURFACES = ("public", "actions", "console", "chat", "webhooks", "internal")
+OUTPUT_ONLY_URL_MAP_KEYS = {
+    "creationTimestamp",
+    "fingerprint",
+    "id",
+    "kind",
+    "selfLink",
+}
+TOP_LEVEL_FIELDS = {
+    "schema_version",
+    "rollout_mode",
+    "project_id",
+    "image",
+    "release",
+    "created_at",
+    "regions",
+    "primary_region",
+    "gateway_regions",
+    "internal_regions",
+    "bootstrap_artifact_sha256",
+    "legacy_hardening_artifact_sha256",
+    "frontend_attestation_sha256",
+    "legacy_fallback",
+    "domains",
+    "preserved_hosts",
+    "url_map",
+    "promotion_state",
+    "services",
+}
+URL_MAP_FIELDS = {
+    "name",
+    "https_proxy",
+    "prior_snapshot",
+    "candidate_snapshot",
+    "prior_sha256",
+    "candidate_sha256",
+}
+SERVICE_FIELDS = {
+    "surface",
+    "name",
+    "region",
+    "prior_exists",
+    "prior_traffic",
+    "adopted_bootstrap",
+    "candidate_revision",
+    "runtime_service_account",
+    "ingress",
+    "default_url_disabled",
+    "concurrency",
+    "min_instances",
+    "service_max_instances",
+    "revision_max_instances",
+    "timeout_seconds",
+    "memory",
+    "cpu",
+    "container_port",
+    "vpc_network",
+    "vpc_subnet",
+    "vpc_egress",
+    "startup_probe_path",
+    "startup_probe_initial_delay_seconds",
+    "startup_probe_timeout_seconds",
+    "startup_probe_period_seconds",
+    "startup_probe_failure_threshold",
+    "max_request_body_bytes",
+    "max_in_flight_request_body_bytes",
+    "max_concurrent_request_bodies",
+    "request_body_read_timeout_seconds",
+    "postcondition_sha256",
+}
+TRAFFIC_FIELDS = {"revision", "resolved_revision", "latest_revision", "percent", "tag"}
+LEGACY_FALLBACK_FIELDS = {
+    "service",
+    "backend",
+    "region",
+    "generation",
+    "serving_revision",
+    "serving_revision_sha256",
+    "traffic",
+    "postcondition_sha256",
+    "backend_postcondition_sha256",
+    "invoker_iam_sha256",
+}
+SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+RESOURCE_NAME_RE = re.compile(r"[a-z][a-z0-9-]{0,61}\Z")
+REVISION_NAME_RE = re.compile(r"[a-z][a-z0-9-]{0,61}\Z")
+TAG_RE = re.compile(r"[a-z][a-z0-9-]{0,61}\Z")
+SERVICE_ACCOUNT_RE = re.compile(
+    r"[a-z][a-z0-9-]{4,28}[a-z0-9]@[a-z][a-z0-9-]{4,28}[a-z0-9][.]iam[.]gserviceaccount[.]com\Z"
+)
+REQUIRED_PRESERVED_HOSTS = {
+    "api.trustedrouter.com",
+    "api.allyrouter.com",
+    "api.uptimerouter.com",
+    "api.quillrouter.com",
+    "api-aws.trustedrouter.com",
+    "api-azure.trustedrouter.com",
+    "api-azure-nz.trustedrouter.com",
+    "api-azure-sea.trustedrouter.com",
+    "api-eu-west-1.trustedrouter.com",
+    "aws.trustedrouter.com",
+    "azure.trustedrouter.com",
+}
+FORBIDDEN_MANIFEST_KEY_RE = re.compile(
+    r"(?:^|_)(?:env|secret|token|password|credential|client_secret|private_key)(?:_|$)",
+    re.IGNORECASE,
+)
+FORBIDDEN_MANIFEST_VALUE_RE = re.compile(
+    r"(?:projects/[^\s/]+/secrets/|secretKeyRef|:latest\b|versions/(?:latest|\d+)|"
+    r"-----BEGIN [A-Z ]*PRIVATE KEY-----|GCP_SERVICE_ACCOUNT_KEY_JSON|"
+    r"(?:^|[^A-Za-z0-9])(?:sk|rk)_(?:live|test)_[A-Za-z0-9]|"
+    r"(?:^|[^A-Za-z0-9])(?:AKIA[0-9A-Z]{12,}|ASIA[0-9A-Z]{12,}|"
+    r"AIza[0-9A-Za-z_-]{20,}|gh[pousr]_[0-9A-Za-z]{20,}|"
+    r"xox[baprs]-[0-9A-Za-z-]{10,}|ya29[.][0-9A-Za-z_-]{20,})|"
+    r"(?:^|[^A-Za-z0-9])TR_[A-Z0-9_]+=)",
+    re.IGNORECASE,
+)
+
+
+def _read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _strip_url_map_output(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _strip_url_map_output(item)
+            for key, item in value.items()
+            if key not in OUTPUT_ONLY_URL_MAP_KEYS
+        }
+    if isinstance(value, list):
+        return [_strip_url_map_output(item) for item in value]
+    return value
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+
+
+def _sha256(value: Any) -> str:
+    return hashlib.sha256(_canonical_bytes(value)).hexdigest()
+
+
+def _atomic_write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            json.dump(value, output, indent=2, sort_keys=True)
+            output.write("\n")
+        os.replace(temporary_name, path)
+    except BaseException:
+        try:
+            os.unlink(temporary_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _manifest_strings(value: Any, path: tuple[str, ...] = ()) -> list[tuple[tuple[str, ...], str]]:
+    strings: list[tuple[tuple[str, ...], str]] = []
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if FORBIDDEN_MANIFEST_KEY_RE.search(str(key)):
+                raise ValueError(f"manifest contains forbidden field {'.'.join((*path, str(key)))}")
+            strings.extend(_manifest_strings(item, (*path, str(key))))
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            strings.extend(_manifest_strings(item, (*path, str(index))))
+    elif isinstance(value, str):
+        strings.append((path, value))
+    return strings
+
+
+def _validate_prior_traffic_state(
+    traffic_state: Any,
+    *,
+    prior_exists: bool,
+) -> list[dict[str, Any]]:
+    """Validate that captured Cloud Run traffic can be restored exactly."""
+    if not isinstance(traffic_state, list):
+        raise ValueError("prior_traffic must be a list")
+    traffic_targets: set[tuple[str, str | None]] = set()
+    traffic_tags: set[str] = set()
+    positive_total = 0
+    for traffic in traffic_state:
+        if not isinstance(traffic, dict) or set(traffic) != TRAFFIC_FIELDS:
+            raise ValueError("prior_traffic fields differ from schema v1")
+        revision = traffic["revision"]
+        resolved_revision = traffic["resolved_revision"]
+        latest_revision = traffic["latest_revision"]
+        percent = traffic["percent"]
+        tag = traffic["tag"]
+        if not isinstance(latest_revision, bool):
+            raise ValueError("traffic latest_revision must be boolean")
+        if latest_revision:
+            raise ValueError("captured traffic must not contain floating LATEST traffic or tags")
+        if not isinstance(revision, str) or not REVISION_NAME_RE.fullmatch(revision):
+            raise ValueError("traffic revision must be a canonical name")
+        if resolved_revision != revision:
+            raise ValueError("named traffic target resolved_revision must equal revision")
+        if not isinstance(resolved_revision, str) or not REVISION_NAME_RE.fullmatch(
+            resolved_revision
+        ):
+            raise ValueError("traffic resolved_revision must be canonical")
+        if isinstance(percent, bool) or not isinstance(percent, int) or not 0 <= percent <= 100:
+            raise ValueError("traffic percent must be an integer from 0 through 100")
+        if tag is not None:
+            if not isinstance(tag, str) or not TAG_RE.fullmatch(tag):
+                raise ValueError("traffic tag must be null or a canonical name")
+            if percent > 0:
+                raise ValueError(
+                    "positive traffic targets must be untagged; tags use separate "
+                    "zero-percent targets"
+                )
+            if tag in traffic_tags:
+                raise ValueError("prior traffic tags must be unique")
+            traffic_tags.add(tag)
+        elif percent == 0:
+            raise ValueError(
+                "untagged zero-percent traffic targets are not exactly restorable"
+            )
+        traffic_target = (revision, tag)
+        if traffic_target in traffic_targets:
+            raise ValueError("prior traffic targets must be unique")
+        traffic_targets.add(traffic_target)
+        if percent > 0:
+            positive_total += percent
+    if prior_exists:
+        if not traffic_state or positive_total != 100:
+            raise ValueError("preexisting services require exact prior traffic summing to 100")
+    elif traffic_state:
+        raise ValueError("previously absent services must have empty prior traffic")
+    return traffic_state
+
+
+def validate_manifest(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError("manifest must be a JSON object")
+    unknown = set(value) - TOP_LEVEL_FIELDS
+    missing = TOP_LEVEL_FIELDS - set(value)
+    if unknown or missing:
+        raise ValueError(
+            f"manifest top-level fields differ: missing={sorted(missing)}, unknown={sorted(unknown)}"
+        )
+    if value["schema_version"] != 1:
+        raise ValueError("manifest schema_version must be 1")
+    if value["rollout_mode"] not in {"initial_split", "existing_split"}:
+        raise ValueError("manifest rollout_mode must be initial_split or existing_split")
+    bootstrap_artifact_sha256 = value["bootstrap_artifact_sha256"]
+    legacy_hardening_artifact_sha256 = value["legacy_hardening_artifact_sha256"]
+    frontend_attestation_sha256 = value["frontend_attestation_sha256"]
+    if not isinstance(frontend_attestation_sha256, str) or not SHA256_RE.fullmatch(
+        frontend_attestation_sha256
+    ):
+        raise ValueError("manifest must bind the verified frontend attestation sha256")
+    if value["rollout_mode"] == "initial_split":
+        if not isinstance(bootstrap_artifact_sha256, str) or not SHA256_RE.fullmatch(
+            bootstrap_artifact_sha256
+        ):
+            raise ValueError(
+                "initial_split must bind the verified bootstrap artifact sha256"
+            )
+        if not isinstance(legacy_hardening_artifact_sha256, str) or not SHA256_RE.fullmatch(
+            legacy_hardening_artifact_sha256
+        ):
+            raise ValueError(
+                "initial_split must bind the verified legacy-hardening artifact sha256"
+            )
+    elif bootstrap_artifact_sha256 is not None:
+        raise ValueError("existing_split must not carry a bootstrap artifact digest")
+    elif legacy_hardening_artifact_sha256 is not None:
+        raise ValueError("existing_split must not carry a legacy-hardening artifact digest")
+    project_id = value["project_id"]
+    if not isinstance(project_id, str) or not re.fullmatch(
+        r"[a-z][a-z0-9-]{4,28}[a-z0-9]", project_id
+    ):
+        raise ValueError("manifest project_id is not a canonical GCP project id")
+    if not isinstance(value["image"], str) or not re.fullmatch(
+        r"[^\s,|@]{1,430}@sha256:[0-9a-f]{64}", value["image"]
+    ):
+        raise ValueError("manifest image must be an immutable sha256 digest reference")
+    if not isinstance(value["release"], str) or not re.fullmatch(r"[A-Za-z0-9._-]{1,128}", value["release"]):
+        raise ValueError("manifest release is invalid")
+    if not isinstance(value["created_at"], str) or not re.fullmatch(
+        r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:[.]\d+)?(?:Z|[+-]\d{2}:\d{2})",
+        value["created_at"],
+    ):
+        raise ValueError("manifest created_at must be an ISO-8601 timestamp")
+    regions = value["regions"]
+    if (
+        not isinstance(regions, list)
+        or not regions
+        or len(regions) != len(set(regions))
+        or any(not isinstance(region, str) or not re.fullmatch(r"[a-z]+-[a-z0-9]+[0-9]", region) for region in regions)
+    ):
+        raise ValueError("manifest regions must be a non-empty unique list")
+    gateway_regions = value["gateway_regions"]
+    if (
+        not isinstance(gateway_regions, list)
+        or not gateway_regions
+        or len(gateway_regions) != len(set(gateway_regions))
+        or any(
+            not isinstance(region, str)
+            or not re.fullmatch(r"[a-z]+-[a-z0-9]+[0-9]", region)
+            for region in gateway_regions
+        )
+    ):
+        raise ValueError("manifest gateway_regions must be a non-empty unique list")
+    internal_regions = value["internal_regions"]
+    if (
+        not isinstance(internal_regions, list)
+        or not internal_regions
+        or len(internal_regions) != len(set(internal_regions))
+        or any(
+            not isinstance(region, str)
+            or not re.fullmatch(r"[a-z]+-[a-z0-9]+[0-9]", region)
+            for region in internal_regions
+        )
+        or not set(regions).issubset(internal_regions)
+    ):
+        raise ValueError(
+            "manifest internal_regions must be unique and include every control region"
+        )
+    if value["primary_region"] != regions[0] or value["primary_region"] not in gateway_regions:
+        raise ValueError(
+            "manifest primary_region must be the first control region and a gateway region"
+        )
+    legacy_fallback = value["legacy_fallback"]
+    if not isinstance(legacy_fallback, list):
+        raise ValueError("manifest legacy_fallback must be a list")
+    if value["rollout_mode"] == "existing_split":
+        if legacy_fallback:
+            raise ValueError("existing_split must not carry a legacy fallback cohort")
+    else:
+        seen_legacy_regions: set[str] = set()
+        for index, entry in enumerate(legacy_fallback):
+            if not isinstance(entry, dict) or set(entry) != LEGACY_FALLBACK_FIELDS:
+                raise ValueError(
+                    f"manifest legacy_fallback[{index}] fields differ from schema v1"
+                )
+            if entry["service"] != "trusted-router":
+                raise ValueError("initial fallback service must be the legacy monolith")
+            if entry["backend"] != "trusted-router-control-backend":
+                raise ValueError("initial fallback backend must remain the legacy control backend")
+            region = entry["region"]
+            if region not in regions or region in seen_legacy_regions:
+                raise ValueError("initial fallback regional inventory is inexact")
+            seen_legacy_regions.add(region)
+            generation = entry["generation"]
+            if isinstance(generation, bool) or not isinstance(generation, int) or generation <= 0:
+                raise ValueError("initial fallback generation must be a positive integer")
+            revision = entry["serving_revision"]
+            if (
+                not isinstance(revision, str)
+                or not REVISION_NAME_RE.fullmatch(revision)
+                or not revision.startswith("trusted-router-")
+            ):
+                raise ValueError("initial fallback serving revision is invalid")
+            traffic = _validate_prior_traffic_state(entry["traffic"], prior_exists=True)
+            if (
+                len(traffic) != 1
+                or traffic[0]["resolved_revision"] != revision
+                or traffic[0]["percent"] != 100
+                or traffic[0]["tag"] is not None
+            ):
+                raise ValueError(
+                    "initial fallback must be one named untagged 100%-serving revision"
+                )
+            if not SHA256_RE.fullmatch(str(entry["postcondition_sha256"])):
+                raise ValueError("initial fallback postcondition hash is invalid")
+            if not SHA256_RE.fullmatch(str(entry["serving_revision_sha256"])):
+                raise ValueError("initial fallback serving revision hash is invalid")
+            if not SHA256_RE.fullmatch(
+                str(entry["backend_postcondition_sha256"])
+            ):
+                raise ValueError("initial fallback backend hash is invalid")
+            if not SHA256_RE.fullmatch(str(entry["invoker_iam_sha256"])):
+                raise ValueError("initial fallback invoker IAM hash is invalid")
+        if seen_legacy_regions != set(regions):
+            raise ValueError("initial fallback must cover every control region exactly")
+    if value["domains"] != [
+        "trustedrouter.com",
+        "allyrouter.com",
+        "uptimerouter.com",
+    ]:
+        raise ValueError("manifest must pin the canonical three-domain inventory")
+    preserved_hosts = value["preserved_hosts"]
+    if (
+        not isinstance(preserved_hosts, list)
+        or not preserved_hosts
+        or len(preserved_hosts) != len(set(preserved_hosts))
+        or any(
+            not isinstance(host, str)
+            or not re.fullmatch(
+                r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:[.][a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+",
+                host,
+            )
+            for host in preserved_hosts
+        )
+    ):
+        raise ValueError("manifest preserved_hosts must be a non-empty unique list")
+    if not REQUIRED_PRESERVED_HOSTS.issubset(preserved_hosts):
+        raise ValueError("manifest preserved_hosts omits a required API/AWS/Azure host")
+    required_regional_aliases = {
+        f"api-{region}.quillrouter.com"
+        for region in set(regions) | set(gateway_regions)
+    }
+    if not required_regional_aliases.issubset(preserved_hosts):
+        raise ValueError("manifest preserved_hosts omits a regional quillrouter API alias")
+    url_map = value["url_map"]
+    if not isinstance(url_map, dict) or set(url_map) != URL_MAP_FIELDS:
+        raise ValueError("manifest url_map fields differ from schema v1")
+    if not isinstance(url_map["name"], str) or not RESOURCE_NAME_RE.fullmatch(url_map["name"]):
+        raise ValueError("manifest URL-map name is invalid")
+    if not isinstance(url_map["https_proxy"], str) or not RESOURCE_NAME_RE.fullmatch(
+        url_map["https_proxy"]
+    ):
+        raise ValueError("manifest HTTPS proxy name is invalid")
+    for field in ("prior_snapshot", "candidate_snapshot"):
+        snapshot = Path(url_map[field])
+        if snapshot.is_absolute() or ".." in snapshot.parts or snapshot.name != url_map[field]:
+            raise ValueError(f"manifest {field} must be a sibling filename")
+    if url_map["prior_snapshot"] == url_map["candidate_snapshot"]:
+        raise ValueError("manifest URL-map snapshots must use distinct sibling files")
+    if value["promotion_state"] != "promotion-state.json":
+        raise ValueError("manifest promotion_state must be promotion-state.json")
+    for field in ("prior_sha256", "candidate_sha256"):
+        if not isinstance(url_map[field], str) or not SHA256_RE.fullmatch(url_map[field]):
+            raise ValueError(f"manifest url_map.{field} is not a sha256 digest")
+
+    services = value["services"]
+    expected_pairs = {
+        (surface, region)
+        for surface in SURFACES
+        for region in (internal_regions if surface == "internal" else regions)
+    }
+    actual_pairs: set[tuple[str, str]] = set()
+    if not isinstance(services, list):
+        raise ValueError("manifest services must be a list")
+    names_by_surface: dict[str, str] = {}
+    accounts_by_surface: dict[str, str] = {}
+    contracts_by_surface: dict[str, tuple[Any, ...]] = {}
+    platform_contracts_by_surface: dict[str, tuple[Any, ...]] = {}
+    for index, service in enumerate(services):
+        if not isinstance(service, dict) or set(service) != SERVICE_FIELDS:
+            raise ValueError(f"manifest services[{index}] fields differ from schema v1")
+        pair = (service["surface"], service["region"])
+        if pair in actual_pairs:
+            raise ValueError(f"duplicate manifest service entry {pair!r}")
+        actual_pairs.add(pair)
+        if not isinstance(service["prior_exists"], bool):
+            raise ValueError(f"manifest services[{index}].prior_exists must be boolean")
+        if not isinstance(service["adopted_bootstrap"], bool):
+            raise ValueError(
+                f"manifest services[{index}].adopted_bootstrap must be boolean"
+            )
+        try:
+            _validate_prior_traffic_state(
+                service["prior_traffic"], prior_exists=service["prior_exists"]
+            )
+        except ValueError as error:
+            raise ValueError(f"manifest services[{index}] {error}") from error
+        for field in (
+            "concurrency",
+            "min_instances",
+            "service_max_instances",
+            "revision_max_instances",
+            "timeout_seconds",
+            "max_request_body_bytes",
+            "max_in_flight_request_body_bytes",
+            "max_concurrent_request_bodies",
+            "request_body_read_timeout_seconds",
+            "cpu",
+            "container_port",
+            "startup_probe_initial_delay_seconds",
+            "startup_probe_timeout_seconds",
+            "startup_probe_period_seconds",
+            "startup_probe_failure_threshold",
+        ):
+            if isinstance(service[field], bool) or not isinstance(service[field], int) or service[field] < 0:
+                raise ValueError(f"manifest services[{index}].{field} must be non-negative")
+        surface = service["surface"]
+        name = service["name"]
+        account = service["runtime_service_account"]
+        if not isinstance(name, str) or not RESOURCE_NAME_RE.fullmatch(name):
+            raise ValueError(f"manifest services[{index}].name is invalid")
+        if not isinstance(account, str) or not SERVICE_ACCOUNT_RE.fullmatch(account):
+            raise ValueError(f"manifest services[{index}].runtime_service_account is invalid")
+        if not account.endswith(f"@{project_id}.iam.gserviceaccount.com"):
+            raise ValueError("runtime service account must belong to manifest project")
+        if not str(service["candidate_revision"]).startswith(f"{name}-") or not REVISION_NAME_RE.fullmatch(
+            str(service["candidate_revision"])
+        ):
+            raise ValueError(f"manifest services[{index}].candidate_revision is invalid")
+        if service["ingress"] != "internal-and-cloud-load-balancing":
+            raise ValueError("all manifest services must pin LB-only ingress")
+        if not isinstance(service["default_url_disabled"], bool):
+            raise ValueError("manifest default_url_disabled must be boolean")
+        if service["default_url_disabled"] != (surface != "internal"):
+            raise ValueError("only internal may retain its default Cloud Run URL")
+        if service["concurrency"] <= 0 or service["service_max_instances"] <= 0:
+            raise ValueError("manifest concurrency and service max must be positive")
+        if service["revision_max_instances"] != service["service_max_instances"]:
+            raise ValueError("service and revision max-instance caps must match")
+        if service["max_request_body_bytes"] <= 0 or service["max_in_flight_request_body_bytes"] < service["max_request_body_bytes"]:
+            raise ValueError("manifest request-body budgets are invalid")
+        if service["max_concurrent_request_bodies"] <= 0 or service["request_body_read_timeout_seconds"] <= 0:
+            raise ValueError("manifest request-body concurrency/timeout must be positive")
+        if not isinstance(service["memory"], str) or not re.fullmatch(
+            r"[1-9][0-9]*(?:Mi|Gi)", service["memory"]
+        ):
+            raise ValueError("manifest memory must be a canonical Cloud Run quantity")
+        for field in ("vpc_network", "vpc_subnet"):
+            if not isinstance(service[field], str) or not RESOURCE_NAME_RE.fullmatch(
+                service[field]
+            ):
+                raise ValueError(f"manifest {field} must be a canonical resource name")
+        if service["vpc_egress"] != "private-ranges-only":
+            raise ValueError("manifest VPC egress must be private-ranges-only")
+        if service["startup_probe_path"] != "/ready":
+            raise ValueError("manifest startup probe must use /ready")
+        names_by_surface.setdefault(surface, name)
+        accounts_by_surface.setdefault(surface, account)
+        if names_by_surface[surface] != name or accounts_by_surface[surface] != account:
+            raise ValueError("service name/account must be stable across regions")
+        contract = tuple(
+            service[field]
+            for field in (
+                "ingress",
+                "default_url_disabled",
+                "concurrency",
+                "min_instances",
+                "service_max_instances",
+                "revision_max_instances",
+                "timeout_seconds",
+                "max_request_body_bytes",
+                "max_in_flight_request_body_bytes",
+                "max_concurrent_request_bodies",
+                "request_body_read_timeout_seconds",
+            )
+        )
+        contracts_by_surface.setdefault(surface, contract)
+        if contracts_by_surface[surface] != contract:
+            raise ValueError("surface runtime contract must be stable across regions")
+        platform_contract = tuple(
+            service[field]
+            for field in (
+                "memory",
+                "cpu",
+                "container_port",
+                "vpc_network",
+                "vpc_subnet",
+                "vpc_egress",
+                "startup_probe_path",
+                "startup_probe_initial_delay_seconds",
+                "startup_probe_timeout_seconds",
+                "startup_probe_period_seconds",
+                "startup_probe_failure_threshold",
+            )
+        )
+        platform_contracts_by_surface.setdefault(surface, platform_contract)
+        if platform_contracts_by_surface[surface] != platform_contract:
+            raise ValueError("surface platform contract must be stable across regions")
+        if not SHA256_RE.fullmatch(str(service["postcondition_sha256"])):
+            raise ValueError(f"manifest services[{index}].postcondition_sha256 is invalid")
+    if actual_pairs != expected_pairs:
+        missing_pairs = sorted(expected_pairs - actual_pairs)
+        extra_pairs = sorted(actual_pairs - expected_pairs)
+        raise ValueError(
+            f"manifest must contain one service per surface and region: "
+            f"missing={missing_pairs}, extra={extra_pairs}"
+        )
+    if len(set(names_by_surface.values())) != len(SURFACES):
+        raise ValueError("the six surfaces must use distinct Cloud Run service names")
+    if len(set(accounts_by_surface.values())) != len(SURFACES):
+        raise ValueError("the six surfaces must use distinct runtime service accounts")
+    expected_names = {
+        "public": "trusted-router-public",
+        "actions": "trusted-router-actions",
+        "console": "trusted-router-console",
+        "chat": "trusted-router-chat",
+        "webhooks": "trusted-router-webhooks",
+        "internal": "trusted-router-billing",
+    }
+    if names_by_surface != expected_names:
+        raise ValueError("manifest service names differ from the canonical six-service inventory")
+    expected_accounts = {
+        surface: f"tr-{surface}@{project_id}.iam.gserviceaccount.com"
+        for surface in SURFACES
+    }
+    if accounts_by_surface != expected_accounts:
+        raise ValueError("manifest runtime identities differ from the canonical six-SA inventory")
+    expected_contracts = {
+        "public": ("internal-and-cloud-load-balancing", True, 4, 0, 10, 10, 60, 1048576, 4194304, 2, 10),
+        "actions": ("internal-and-cloud-load-balancing", True, 4, 0, 2, 2, 30, 262144, 1048576, 2, 10),
+        "console": ("internal-and-cloud-load-balancing", True, 4, 1, 20, 20, 300, 4194304, 16777216, 2, 30),
+        "chat": ("internal-and-cloud-load-balancing", True, 2, 1, 20, 20, 300, 33554432, 67108864, 2, 30),
+        "webhooks": ("internal-and-cloud-load-balancing", True, 4, 1, 10, 10, 60, 1048576, 4194304, 2, 10),
+        "internal": ("internal-and-cloud-load-balancing", False, 8, 2, 50, 50, 300, 33554432, 67108864, 4, 30),
+    }
+    if contracts_by_surface != expected_contracts:
+        raise ValueError("manifest runtime contracts differ from the reviewed six-surface constants")
+    expected_platform_contracts = {
+        "public": ("1Gi", 1, 8080, "default", "default", "private-ranges-only", "/ready", 0, 10, 10, 18),
+        "actions": ("512Mi", 1, 8080, "default", "default", "private-ranges-only", "/ready", 0, 10, 10, 18),
+        "console": ("2Gi", 1, 8080, "default", "default", "private-ranges-only", "/ready", 0, 10, 10, 18),
+        "chat": ("2Gi", 1, 8080, "default", "default", "private-ranges-only", "/ready", 0, 10, 10, 18),
+        "webhooks": ("1Gi", 1, 8080, "default", "default", "private-ranges-only", "/ready", 0, 10, 10, 18),
+        "internal": ("2Gi", 1, 8080, "default", "default", "private-ranges-only", "/ready", 0, 10, 10, 18),
+    }
+    if platform_contracts_by_surface != expected_platform_contracts:
+        raise ValueError(
+            "manifest platform contracts differ from the reviewed six-surface constants"
+        )
+    if value["rollout_mode"] == "existing_split":
+        if not all(service["prior_exists"] for service in services):
+            raise ValueError("existing_split requires every service to preexist")
+        if url_map["prior_sha256"] != url_map["candidate_sha256"]:
+            raise ValueError("existing_split must preserve the URL map")
+    else:
+        if url_map["prior_sha256"] == url_map["candidate_sha256"]:
+            raise ValueError("initial_split must produce a distinct candidate URL map")
+        for surface in SURFACES:
+            inventory = {
+                service["prior_exists"]
+                for service in services
+                if service["surface"] == surface
+            }
+            expected_inventory = {surface == "internal"}
+            if inventory != expected_inventory:
+                raise ValueError(
+                    "initial_split requires five absent web companions and the "
+                    f"preexisting bootstrap internal cohort; {surface}={inventory!r}"
+                )
+    for service in services:
+        prior_revisions = {
+            traffic["resolved_revision"] for traffic in service["prior_traffic"]
+        }
+        if service["candidate_revision"] in prior_revisions:
+            adopted_bootstrap = (
+                value["rollout_mode"] == "initial_split"
+                and service["surface"] == "internal"
+                and service["adopted_bootstrap"]
+                and service["prior_exists"]
+                and len(service["prior_traffic"]) == 1
+                and service["prior_traffic"][0]["resolved_revision"]
+                == service["candidate_revision"]
+                and service["prior_traffic"][0]["percent"] == 100
+                and service["prior_traffic"][0]["tag"] is None
+            )
+            if not adopted_bootstrap:
+                raise ValueError(
+                    "candidate revision must differ from every prior traffic target"
+                )
+
+        should_adopt_bootstrap = (
+            value["rollout_mode"] == "initial_split"
+            and service["surface"] == "internal"
+        )
+        if service["adopted_bootstrap"] != should_adopt_bootstrap:
+            raise ValueError(
+                "only every initial internal entry may adopt the verified bootstrap"
+            )
+
+    for field_path, string in _manifest_strings(value):
+        if FORBIDDEN_MANIFEST_VALUE_RE.search(string):
+            raise ValueError(
+                "manifest contains a secret-like value at " + ".".join(field_path)
+            )
+    return value
+
+
+def _service_contract(service: dict[str, Any]) -> dict[str, Any]:
+    metadata = service.get("metadata") or {}
+    spec = service.get("spec") or {}
+    template = spec.get("template") or {}
+    template_metadata = template.get("metadata") or {}
+    template_spec = template.get("spec") or {}
+    annotations = metadata.get("annotations") or {}
+    template_annotations = template_metadata.get("annotations") or {}
+    selected_annotations = {
+        key: value
+        for key, value in annotations.items()
+        if key
+        in {
+            "run.googleapis.com/ingress",
+            "run.googleapis.com/ingress-status",
+            "run.googleapis.com/default-url-disabled",
+            "run.googleapis.com/maxScale",
+            "run.googleapis.com/minScale",
+        }
+    }
+    selected_template_annotations = {
+        key: value
+        for key, value in template_annotations.items()
+        if key
+        in {
+            "autoscaling.knative.dev/minScale",
+            "autoscaling.knative.dev/maxScale",
+            "run.googleapis.com/vpc-access-egress",
+            "run.googleapis.com/network-interfaces",
+            "run.googleapis.com/startup-cpu-boost",
+        }
+    }
+    containers = []
+    for container in template_spec.get("containers") or []:
+        copied = {
+            key: container[key]
+            for key in (
+                "image",
+                "ports",
+                "resources",
+                "startupProbe",
+                "command",
+                "args",
+                "volumeMounts",
+            )
+            if key in container
+        }
+        copied["env"] = sorted(
+            container.get("env") or [], key=lambda item: str(item.get("name", ""))
+        )
+        containers.append(copied)
+    return {
+        "metadata": {"annotations": selected_annotations},
+        "spec": {
+            "scaling": spec.get("scaling") or {},
+            "template": {
+                "metadata": {
+                    "annotations": selected_template_annotations,
+                    "name": template_metadata.get("name"),
+                },
+                "spec": {
+                    "containerConcurrency": template_spec.get("containerConcurrency"),
+                    "serviceAccountName": template_spec.get("serviceAccountName"),
+                    "timeoutSeconds": template_spec.get("timeoutSeconds"),
+                    "volumes": template_spec.get("volumes") or [],
+                    "initContainers": template_spec.get("initContainers") or [],
+                    "containers": containers,
+                },
+            },
+        },
+    }
+
+
+def _revision_contract(revision: dict[str, Any]) -> dict[str, Any]:
+    """Return the immutable legacy revision fields needed for safe fallback."""
+    metadata = revision.get("metadata") or {}
+    return {
+        "metadata": {
+            "name": metadata.get("name"),
+            "annotations": metadata.get("annotations") or {},
+            "labels": metadata.get("labels") or {},
+        },
+        "spec": revision.get("spec") or {},
+    }
+
+
+def _iam_policy_contract(policy: dict[str, Any]) -> dict[str, Any]:
+    bindings = []
+    for binding in policy.get("bindings") or []:
+        bindings.append(
+            {
+                "role": binding.get("role"),
+                "members": sorted(binding.get("members") or []),
+                "condition": binding.get("condition") or None,
+            }
+        )
+    bindings.sort(
+        key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":"))
+    )
+    return {"bindings": bindings}
+
+
+def _traffic_state(service: dict[str, Any]) -> list[dict[str, Any]]:
+    spec = service.get("spec") or {}
+    status = service.get("status") or {}
+    desired = list(spec.get("traffic") or [])
+    observed = list(status.get("traffic") or [])
+    if not desired:
+        desired = observed
+    if desired and not any(bool(target.get("latestRevision", False)) for target in desired):
+        def named_state(targets: list[dict[str, Any]]) -> list[tuple[str, int, str | None]]:
+            normalized: list[tuple[str, int, str | None]] = []
+            for target in targets:
+                revision = target.get("revisionName")
+                if not isinstance(revision, str) or not revision:
+                    raise ValueError(f"observed traffic target has no named revision: {target!r}")
+                if bool(target.get("latestRevision", False)):
+                    raise ValueError("observed traffic unexpectedly contains floating LATEST")
+                normalized.append(
+                    (
+                        revision,
+                        int(target.get("percent") or 0),
+                        target.get("tag") or None,
+                    )
+                )
+            return sorted(normalized, key=lambda item: (item[2] or "", item[0], item[1]))
+
+        if named_state(desired) != named_state(observed):
+            raise ValueError(
+                "Cloud Run desired and observed named traffic targets have not converged"
+            )
+    result: list[dict[str, Any]] = []
+    for target in desired:
+        latest = bool(target.get("latestRevision", False))
+        revision = target.get("revisionName")
+        tag = target.get("tag") or None
+        percent = int(target.get("percent") or 0)
+        resolved = revision
+        if latest:
+            revision = None
+            if tag is not None:
+                candidates = {
+                    item.get("revisionName")
+                    for item in observed
+                    if item.get("revisionName") and item.get("tag") == tag
+                }
+            else:
+                candidates = {
+                    item.get("revisionName")
+                    for item in observed
+                    if item.get("revisionName")
+                    and not item.get("tag")
+                    and int(item.get("percent") or 0) == percent
+                }
+            if resolved:
+                candidates.add(resolved)
+            if not candidates:
+                latest_ready = status.get("latestReadyRevisionName")
+                if latest_ready:
+                    candidates.add(latest_ready)
+            if len(candidates) != 1:
+                raise ValueError(
+                    f"cannot resolve floating LATEST traffic target: {target!r}"
+                )
+            resolved = next(iter(candidates))
+        if not resolved:
+            raise ValueError(f"traffic target has no resolved revision: {target!r}")
+        result.append(
+            {
+                "revision": revision,
+                "resolved_revision": resolved,
+                "latest_revision": latest,
+                "percent": percent,
+                "tag": tag,
+            }
+        )
+    return sorted(
+        result,
+        key=lambda item: (
+            item["tag"] or "",
+            item["latest_revision"],
+            item["revision"] or "",
+            item["percent"],
+        ),
+    )
+
+
+def _validate_captured_service_traffic(path: Path) -> None:
+    service = _read_json(path)
+    traffic = _traffic_state(service)
+    _validate_prior_traffic_state(traffic, prior_exists=True)
+
+
+def _build_manifest(args: argparse.Namespace) -> None:
+    services = [
+        json.loads(line)
+        for line in args.entries.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    manifest = {
+        "schema_version": 1,
+        "rollout_mode": args.rollout_mode,
+        "project_id": args.project_id,
+        "image": args.image,
+        "release": args.release,
+        "created_at": args.created_at,
+        "regions": args.regions.split(","),
+        "primary_region": args.primary_region,
+        "gateway_regions": args.gateway_regions.split(","),
+        "internal_regions": args.internal_regions.split(","),
+        "bootstrap_artifact_sha256": args.bootstrap_artifact_sha256 or None,
+        "legacy_hardening_artifact_sha256": (
+            args.legacy_hardening_artifact_sha256 or None
+        ),
+        "frontend_attestation_sha256": args.frontend_attestation_sha256,
+        "legacy_fallback": [
+            json.loads(line)
+            for line in args.legacy_fallback.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ],
+        "domains": args.domains.split(","),
+        "preserved_hosts": args.preserved_hosts.split(","),
+        "url_map": {
+            "name": args.url_map_name,
+            "https_proxy": args.https_proxy,
+            "prior_snapshot": args.prior_snapshot,
+            "candidate_snapshot": args.candidate_snapshot,
+            "prior_sha256": args.prior_sha256,
+            "candidate_sha256": args.candidate_sha256,
+        },
+        "promotion_state": "promotion-state.json",
+        "services": services,
+    }
+    validate_manifest(manifest)
+    _atomic_write_json(args.manifest, manifest)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    sanitize = subparsers.add_parser("sanitize-url-map")
+    sanitize.add_argument("input", type=Path)
+    sanitize.add_argument("output", type=Path)
+
+    hash_url_map = subparsers.add_parser("hash-url-map")
+    hash_url_map.add_argument("input", type=Path)
+
+    hash_service = subparsers.add_parser("hash-service")
+    hash_service.add_argument("input", type=Path)
+
+    hash_resource = subparsers.add_parser("hash-resource")
+    hash_resource.add_argument("input", type=Path)
+
+    hash_revision = subparsers.add_parser("hash-revision")
+    hash_revision.add_argument("input", type=Path)
+
+    hash_iam_policy = subparsers.add_parser("hash-iam-policy")
+    hash_iam_policy.add_argument("input", type=Path)
+
+    traffic_state = subparsers.add_parser("traffic-state")
+    traffic_state.add_argument("input", type=Path)
+
+    validate_traffic = subparsers.add_parser("validate-prior-traffic")
+    validate_traffic.add_argument("input", type=Path)
+
+    validate = subparsers.add_parser("validate-manifest")
+    validate.add_argument("manifest", type=Path)
+
+    build = subparsers.add_parser("build-manifest")
+    build.add_argument("--manifest", type=Path, required=True)
+    build.add_argument("--entries", type=Path, required=True)
+    build.add_argument("--rollout-mode", required=True)
+    build.add_argument("--project-id", required=True)
+    build.add_argument("--image", required=True)
+    build.add_argument("--release", required=True)
+    build.add_argument("--created-at", required=True)
+    build.add_argument("--regions", required=True)
+    build.add_argument("--primary-region", required=True)
+    build.add_argument("--gateway-regions", required=True)
+    build.add_argument("--internal-regions", required=True)
+    build.add_argument("--bootstrap-artifact-sha256", required=True)
+    build.add_argument("--legacy-hardening-artifact-sha256", required=True)
+    build.add_argument("--frontend-attestation-sha256", required=True)
+    build.add_argument("--legacy-fallback", type=Path, required=True)
+    build.add_argument("--domains", required=True)
+    build.add_argument("--preserved-hosts", required=True)
+    build.add_argument("--url-map-name", required=True)
+    build.add_argument("--https-proxy", required=True)
+    build.add_argument("--prior-snapshot", required=True)
+    build.add_argument("--candidate-snapshot", required=True)
+    build.add_argument("--prior-sha256", required=True)
+    build.add_argument("--candidate-sha256", required=True)
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    if args.command == "sanitize-url-map":
+        _atomic_write_json(args.output, _strip_url_map_output(_read_json(args.input)))
+    elif args.command == "hash-url-map":
+        print(_sha256(_strip_url_map_output(_read_json(args.input))))
+    elif args.command == "hash-service":
+        print(_sha256(_service_contract(_read_json(args.input))))
+    elif args.command == "hash-resource":
+        print(_sha256(_strip_url_map_output(_read_json(args.input))))
+    elif args.command == "hash-revision":
+        print(_sha256(_revision_contract(_read_json(args.input))))
+    elif args.command == "hash-iam-policy":
+        print(_sha256(_iam_policy_contract(_read_json(args.input))))
+    elif args.command == "traffic-state":
+        print(json.dumps(_traffic_state(_read_json(args.input)), sort_keys=True))
+    elif args.command == "validate-prior-traffic":
+        _validate_captured_service_traffic(args.input)
+    elif args.command == "validate-manifest":
+        validate_manifest(_read_json(args.manifest))
+    elif args.command == "build-manifest":
+        _build_manifest(args)
+    else:  # pragma: no cover - argparse owns command totality.
+        raise AssertionError(args.command)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deploy/secrets.sh
+++ b/scripts/deploy/secrets.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 # Phase 3: push provider/OAuth/SES/Stripe secrets to Secret Manager and
-# grant the Cloud Run runtime service account access to them. Reads
+# verify exact per-resource split-runtime access. Reads
 # values from $TR_LOCAL_KEYS_FILE (~/.quill_cloud_keys.private by default)
 # or from the current shell environment.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/deploy/_lib.sh
 source "${SCRIPT_DIR}/_lib.sh"
+
+validate_runtime_service_accounts
 
 validate_synthetic_monitor_candidate() {
   local value="$1"
@@ -83,6 +85,205 @@ require_secret_from_env_file() {
   log "uploaded secret ${secret_name}"
 }
 
+secret_exists_or_error() {
+  local secret_name="$1"
+  local describe_error=""
+  if describe_error="$(gc secrets describe "$secret_name" --format='value(name)' 2>&1)"; then
+    return 0
+  fi
+  if [[ "$describe_error" == *"NOT_FOUND"* ]] ||
+     [[ "$describe_error" == *"not found"* ]]; then
+    return 1
+  fi
+  echo "ERROR: cannot determine whether secret ${secret_name} exists: ${describe_error}" >&2
+  return 2
+}
+
+ensure_generated_secret_resource() {
+  local secret_name="$1"
+  local existence_rc=0
+  if secret_exists_or_error "$secret_name"; then
+    return 0
+  else
+    existence_rc=$?
+  fi
+  if [ "$existence_rc" -ne 1 ]; then
+    return 1
+  fi
+  ensure_secret_value "$secret_name" "$(python3 - <<'PY'
+import secrets
+print(secrets.token_urlsafe(48))
+PY
+)"
+  log "generated secret ${secret_name}"
+}
+
+reconcile_declared_secret_iam() {
+  local inventory_json=""
+  local secret_names=""
+  local plans_file=""
+  local secret_name=""
+  local expected_surfaces=""
+  local policy_json=""
+  local plan=""
+  local action=""
+  local role=""
+  local member=""
+  local declared=0
+
+  inventory_json="$(gc secrets list --format=json)" || {
+    echo "ERROR: cannot inventory Secret Manager before exact IAM reconciliation" >&2
+    return 1
+  }
+  secret_names="$(printf '%s' "$inventory_json" | python3 -c '
+import json
+import re
+import sys
+
+project = sys.argv[1]
+items = json.load(sys.stdin)
+if not isinstance(items, list):
+    raise SystemExit("Secret Manager inventory is not a list")
+prefix = f"projects/{project}/secrets/"
+names = []
+for item in items:
+    if not isinstance(item, dict) or not isinstance(item.get("name"), str):
+        raise SystemExit("Secret Manager inventory entry is malformed")
+    name = item["name"]
+    if name.startswith("projects/"):
+        if not name.startswith(prefix):
+            raise SystemExit("Secret Manager inventory contains a cross-project resource")
+        name = name[len(prefix):]
+    if not re.fullmatch(r"[A-Za-z0-9_-]{1,255}", name):
+        raise SystemExit("Secret Manager inventory contains an invalid resource name")
+    names.append(name)
+if len(names) != len(set(names)):
+    raise SystemExit("Secret Manager inventory contains duplicate resources")
+print("\n".join(sorted(names)))
+' "$PROJECT_ID")" || return 1
+  if ! printf '%s' "$TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON" | python3 -c '
+import json
+import sys
+
+inventory = set(sys.argv[1].splitlines())
+value = json.load(sys.stdin)
+if set(value) - inventory:
+    raise SystemExit("preserved accessor allowlist references an absent secret")
+' "$secret_names"; then
+    echo "ERROR: preserved secret accessor allowlist references absent resources" >&2
+    return 1
+  fi
+
+  plans_file="$(mktemp "${TMPDIR:-/tmp}/tr-secret-iam-plans-XXXXXX")"
+  chmod 600 "$plans_file"
+  # Inventory and validate the complete project before the first mutation.
+  # Unrelated non-public bindings are never removed: they must be explicitly
+  # listed in TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON or this preflight fails.
+  while IFS= read -r secret_name; do
+    [ -n "$secret_name" ] || continue
+    policy_json="$(gc secrets get-iam-policy "$secret_name" --format=json)" || {
+      echo "ERROR: cannot read Secret Manager IAM for ${secret_name}" >&2
+      return 1
+    }
+    if expected_surfaces="$(secret_expected_surfaces "$secret_name")"; then
+      declared=1
+    else
+      expected_surfaces=""
+      declared=0
+      if deploy_service_account_owns_secret "$secret_name" ||
+         synthetic_service_account_owns_secret "$secret_name"; then
+        declared=1
+      fi
+    fi
+    plan="$(printf '%s' "$policy_json" | secret_iam_policy_contract_json plan \
+      "$secret_name" "$expected_surfaces")" || {
+      echo "ERROR: unsafe Secret Manager IAM preflight for ${secret_name}" >&2
+      return 1
+    }
+    if [ "$declared" = "0" ] && [ -n "$plan" ]; then
+      echo "ERROR: unknown secret ${secret_name} has runtime, deploy, synthetic, or public IAM; remove it in a separately reviewed owner change" >&2
+      return 1
+    fi
+    while IFS=$'\t' read -r action role member; do
+      [ -n "$action" ] || continue
+      [ "$declared" = "1" ] || continue
+      printf '%s\t%s\t%s\t%s\n' \
+        "$secret_name" "$action" "$role" "$member" >>"$plans_file"
+    done <<<"$plan"
+  done <<<"$secret_names"
+
+  while IFS=$'\t' read -r secret_name action role member; do
+    [ -n "$secret_name" ] || continue
+    case "$action" in
+      add)
+        gc secrets add-iam-policy-binding "$secret_name" \
+          --member="$member" \
+          --role="$role" \
+          --condition=None \
+          --quiet >/dev/null
+        ;;
+      remove)
+        gc secrets remove-iam-policy-binding "$secret_name" \
+          --member="$member" \
+          --role="$role" \
+          --condition=None \
+          --quiet >/dev/null
+        ;;
+      *)
+        echo "ERROR: invalid preflighted secret IAM action ${action}" >&2
+        return 1
+        ;;
+    esac
+  done <"$plans_file"
+
+  while IFS= read -r secret_name; do
+    [ -n "$secret_name" ] || continue
+    if expected_surfaces="$(secret_expected_surfaces "$secret_name")"; then
+      :
+    else
+      expected_surfaces=""
+    fi
+    policy_json="$(gc secrets get-iam-policy "$secret_name" --format=json)" || return 1
+    if ! printf '%s' "$policy_json" | secret_iam_policy_contract_json verify \
+        "$secret_name" "$expected_surfaces"; then
+      echo "ERROR: exact Secret Manager IAM postcondition failed for ${secret_name}" >&2
+      return 1
+    fi
+  done <<<"$secret_names"
+  rm -f "$plans_file"
+}
+
+verify_runtime_secret_access() {
+  local requirement="$1"
+  local secret_name="$2"
+  local expected_surfaces=""
+  local existence_rc=0
+  local policy_json=""
+  if secret_exists_or_error "$secret_name"; then
+    :
+  else
+    existence_rc=$?
+    if [ "$existence_rc" -eq 1 ] && [ "$requirement" = "optional" ]; then
+      return 0
+    fi
+    if [ "$existence_rc" -eq 1 ]; then
+      echo "ERROR: required runtime secret ${secret_name} does not exist" >&2
+    fi
+    return 1
+  fi
+  if expected_surfaces="$(secret_expected_surfaces "$secret_name")"; then
+    :
+  else
+    expected_surfaces=""
+  fi
+  policy_json="$(gc secrets get-iam-policy "$secret_name" --format=json)" || return 1
+  if ! printf '%s' "$policy_json" | secret_iam_policy_contract_json verify \
+      "$secret_name" "$expected_surfaces"; then
+    echo "ERROR: exact Secret Manager accessor contract failed for ${secret_name}" >&2
+    return 1
+  fi
+}
+
 ensure_secret_from_prompt_file() {
   local secret_name="$1"
   local prompt_file="$2"
@@ -139,13 +340,11 @@ ensure_secret_from_env_file "TOGETHER_API_KEY" "trustedrouter-together-api-key" 
 ensure_secret_from_env_file "FIREWORKS_API_KEY" "trustedrouter-fireworks-api-key" "FIREWORKS_AI_API_KEY"
 ensure_secret_from_env_file "DEEPINFRA_API_KEY" "trustedrouter-deepinfra-api-key"
 # Cohere — embeddings only (native /v2/embed in the enclave). Reads
-# COHERE_API_KEY from ~/.quill_cloud_keys.private. Runtime read access comes
-# from the project-level secretAccessor binding (infra.sh), like every other
-# provider secret.
+# COHERE_API_KEY from ~/.quill_cloud_keys.private. The chat-only resource
+# binding is verified below with every other provider secret.
 ensure_secret_from_env_file "COHERE_API_KEY" "trustedrouter-cohere-api-key"
 # Voyage AI — embeddings only (OpenAI-shaped /v1/embeddings in the enclave).
-# Reads VOYAGE_API_KEY from ~/.quill_cloud_keys.private. Same project-level
-# secretAccessor binding as every other provider secret.
+# Reads VOYAGE_API_KEY from ~/.quill_cloud_keys.private. It is also chat-only.
 ensure_secret_from_env_file "VOYAGE_API_KEY" "trustedrouter-voyage-api-key"
 # Xiaomi MiMo — OpenAI-compatible chat (api.xiaomimimo.com/v1). Reads
 # XIAOMI_API_KEY from ~/.quill_cloud_keys.private.
@@ -228,7 +427,7 @@ ensure_secret_from_prompt_file "trustedrouter-socrates-advisor-prompt-v1" "$SOCR
 ensure_secret_from_prompt_file "trustedrouter-athena-worker-prompt-v1" "$ATHENA_PROMPTS_FILE" "Worker Prompt V1"
 
 ensure_secret_from_env_file "TR_SYNTHETIC_MONITOR_API_KEY" "trustedrouter-synthetic-monitor-api-key" "SYNTHETIC_MONITOR_API_KEY"
-ensure_secret_from_env_file "SENTRY_DSN" "trustedrouter-sentry-dsn"
+require_secret_from_env_file "SENTRY_DSN" "trustedrouter-sentry-dsn"
 ensure_secret_from_env_file \
   "TR_OPS_CHAT_WEBHOOK_SECRET" \
   "trustedrouter-ops-chat-webhook-secret" \
@@ -238,68 +437,11 @@ ensure_secret_from_env_file \
 # pushed to Secret Manager like every other TR secret. The GHA WIF service
 # account receives access only to the individual secrets it needs.
 ensure_secret_from_env_file "TR_API_KEY_FOR_SELF_HEAL" "trustedrouter-tr-api-key-for-self-heal"
-TR_DEPLOY_SA="${TR_DEPLOY_SA:-tr-deploy@${PROJECT_ID}.iam.gserviceaccount.com}"
-
-grant_tr_deploy_secret_access() {
-  local secret_name="$1"
-  if ! gc secrets describe "$secret_name" >/dev/null 2>&1; then
-    return
-  fi
-  log "granting ${TR_DEPLOY_SA} accessor on ${secret_name}"
-  gc secrets add-iam-policy-binding "$secret_name" \
-    --member="serviceAccount:${TR_DEPLOY_SA}" \
-    --role="roles/secretmanager.secretAccessor" \
-    --quiet >/dev/null \
-    || log "WARN: per-secret binding for ${secret_name} returned non-zero"
-}
-
-grant_tr_deploy_secret_access "trustedrouter-tr-api-key-for-self-heal"
-grant_tr_deploy_secret_access "trustedrouter-ops-chat-webhook-secret"
-grant_tr_deploy_secret_access "trustedrouter-together-api-key"
-grant_tr_deploy_secret_access "trustedrouter-parasail-api-key"
-grant_tr_deploy_secret_access "trustedrouter-lightning-api-key"
-grant_tr_deploy_secret_access "trustedrouter-gmi-api-key"
-grant_tr_deploy_secret_access "trustedrouter-deepinfra-api-key"
-grant_tr_deploy_secret_access "trustedrouter-phala-confidential-api-key"
-grant_tr_deploy_secret_access "trustedrouter-siliconflow-api-key"
-grant_tr_deploy_secret_access "trustedrouter-venice-api-key"
-grant_tr_deploy_secret_access "trustedrouter-openai-api-key"
-grant_tr_deploy_secret_access "trustedrouter-grok-api-key"
-grant_tr_deploy_secret_access "trustedrouter-deepseek-api-key"
-grant_tr_deploy_secret_access "trustedrouter-mistral-api-key"
-grant_tr_deploy_secret_access "trustedrouter-zai-api-key"
-grant_tr_deploy_secret_access "trustedrouter-cerebras-api-key"
-grant_tr_deploy_secret_access "trustedrouter-kimi-api-key"
-grant_tr_deploy_secret_access "trustedrouter-fireworks-api-key"
-grant_tr_deploy_secret_access "trustedrouter-gemini-api-key"
-grant_tr_deploy_secret_access "trustedrouter-novita-api-key"
-grant_tr_deploy_secret_access "trustedrouter-nebius-api-key"
-grant_tr_deploy_secret_access "trustedrouter-minimax-api-key"
-grant_tr_deploy_secret_access "trustedrouter-crusoe-api-key"
-grant_tr_deploy_secret_access "trustedrouter-friendli-api-key"
-grant_tr_deploy_secret_access "trustedrouter-baseten-api-key"
-grant_tr_deploy_secret_access "trustedrouter-telnyx-api-key"
-grant_tr_deploy_secret_access "trustedrouter-veriff-api-key"
-grant_tr_deploy_secret_access "trustedrouter-veriff-shared-secret-key"
-grant_tr_deploy_secret_access "trustedrouter-wafer-api-key"
-grant_tr_deploy_secret_access "trustedrouter-alibaba-api-key"
-grant_tr_deploy_secret_access "trustedrouter-makora-api-key"
-grant_tr_deploy_secret_access "trustedrouter-chutes-api-key"
-grant_tr_deploy_secret_access "trustedrouter-digitalocean-api-key"
-grant_tr_deploy_secret_access "trustedrouter-cloudflare-workers-ai-api-token"
-grant_tr_deploy_secret_access "trustedrouter-inceptron-api-key"
-grant_tr_deploy_secret_access "trustedrouter-morph-api-key"
-grant_tr_deploy_secret_access "trustedrouter-atlas-cloud-api-key"
-grant_tr_deploy_secret_access "trustedrouter-streamlake-api-key"
-grant_tr_deploy_secret_access "trustedrouter-neurometric-api-key"
-grant_tr_deploy_secret_access "trustedrouter-engy-api-key"
-grant_tr_deploy_secret_access "trustedrouter-pearl-api-key"
-grant_tr_deploy_secret_access "trustedrouter-zero-g-api-key"
-grant_tr_deploy_secret_access "trustedrouter-clickhouse-control-read-password"
-grant_tr_deploy_secret_access "trustedrouter-adyen-test-api-key"
-grant_tr_deploy_secret_access "trustedrouter-adyen-test-client-key"
-grant_tr_deploy_secret_access "trustedrouter-adyen-test-hmac-key"
-grant_tr_deploy_secret_access "trustedrouter-adyen-test-reference-key"
+if [ -n "${TR_DEPLOY_SA:-}" ] && [ "$TR_DEPLOY_SA" != "$DEPLOY_SERVICE_ACCOUNT" ]; then
+  echo "ERROR: TR_DEPLOY_SA must match TR_DEPLOY_SERVICE_ACCOUNT" >&2
+  exit 1
+fi
+TR_DEPLOY_SA="$DEPLOY_SERVICE_ACCOUNT"
 
 # Axiom logging — ship structured logs to a dedicated dataset for
 # slice-and-dice analysis (request_id correlation, rate-limit hits,
@@ -309,6 +451,57 @@ grant_tr_deploy_secret_access "trustedrouter-adyen-test-reference-key"
 ensure_secret_from_env_file "AXIOM_API_TOKEN" "trustedrouter-axiom-api-token" "AXIOM_TOKEN" "AXIOM_API_KEY"
 require_secret_from_env_file "STRIPE_SECRET_KEY" "trustedrouter-stripe-secret-key" "STRIPE_KEY"
 require_secret_from_env_file "STRIPE_WEBHOOK_SECRET" "trustedrouter-stripe-webhook-secret"
+require_secret_from_env_file \
+  "TR_INTERNAL_STRIPE_PAYMENT_INTENTS_KEY" \
+  "trustedrouter-internal-stripe-payment-intents-key"
+
+# The internal billing process creates off-session PaymentIntents but must not
+# inherit the console's full Stripe key. Stripe restricted live keys carry the
+# rk_live_ prefix; the exact dashboard permission contract is documented and
+# must be verified provider-side because Secret Manager can only attest to the
+# stored bytes and IAM, not Stripe's permission switches.
+_internal_stripe_key="$(gc secrets versions access latest \
+  --secret=trustedrouter-internal-stripe-payment-intents-key)"
+_console_stripe_key="$(gc secrets versions access latest \
+  --secret=trustedrouter-stripe-secret-key)"
+case "$_internal_stripe_key" in
+  rk_live_?*) ;;
+  *)
+    echo "ERROR: internal Stripe key must be a live restricted rk_live_ key" >&2
+    exit 1
+    ;;
+esac
+if [ "$_internal_stripe_key" = "$_console_stripe_key" ]; then
+  echo "ERROR: internal Stripe key must differ from the console Stripe key" >&2
+  exit 1
+fi
+unset _internal_stripe_key _console_stripe_key
+
+ensure_secret_from_env_file \
+  "TR_ATTRIBUTION_COOKIE_SECRET" \
+  "trustedrouter-attribution-cookie-secret"
+_attribution_exists_rc=0
+if secret_exists_or_error trustedrouter-attribution-cookie-secret; then
+  :
+else
+  _attribution_exists_rc=$?
+  if [ "$_attribution_exists_rc" -ne 1 ]; then
+    exit 1
+  fi
+  ensure_secret_value trustedrouter-attribution-cookie-secret "$(python3 - <<'PY'
+import secrets
+print(secrets.token_hex(32))
+PY
+)"
+  log "generated secret trustedrouter-attribution-cookie-secret"
+fi
+_attribution_cookie_secret="$(gc secrets versions access latest \
+  --secret=trustedrouter-attribution-cookie-secret)"
+if [ "${#_attribution_cookie_secret}" -lt 32 ]; then
+  echo "ERROR: attribution cookie secret must contain at least 32 characters" >&2
+  exit 1
+fi
+unset _attribution_exists_rc _attribution_cookie_secret
 
 # OAuth + SES secrets — independently optional. Push to Secret Manager only
 # when the local keys file (or env) supplies a value; production fail-closed
@@ -323,9 +516,36 @@ ensure_secret_from_env_file "GITHUB_CLIENT_SECRET" "trustedrouter-github-client-
 ensure_secret_from_env_file \
   "GITHUB_ALIAS_CREDENTIALS_JSON" \
   "trustedrouter-github-alias-credentials-json"
-# SES email credentials only; not used for AWS hosting or failover.
-ensure_secret_from_env_file "AWS_ACCESS_KEY_ID" "trustedrouter-aws-access-key-id"
-ensure_secret_from_env_file "AWS_SECRET_ACCESS_KEY" "trustedrouter-aws-secret-access-key"
+# SES email credentials only; not used for AWS hosting or failover. Internal
+# billing gets an independent AWS principal whose provider-side policy allows
+# ses:SendEmail and nothing else; sharing the console/actions key would undo
+# the service-account split even if Secret Manager resource names differed.
+require_secret_from_env_file "AWS_ACCESS_KEY_ID" "trustedrouter-aws-access-key-id"
+require_secret_from_env_file "AWS_SECRET_ACCESS_KEY" "trustedrouter-aws-secret-access-key"
+require_secret_from_env_file \
+  "TR_INTERNAL_SES_ACCESS_KEY_ID" \
+  "trustedrouter-internal-ses-access-key-id"
+require_secret_from_env_file \
+  "TR_INTERNAL_SES_SECRET_ACCESS_KEY" \
+  "trustedrouter-internal-ses-secret-access-key"
+_internal_ses_access_key_id="$(gc secrets versions access latest \
+  --secret=trustedrouter-internal-ses-access-key-id)"
+_internal_ses_secret_access_key="$(gc secrets versions access latest \
+  --secret=trustedrouter-internal-ses-secret-access-key)"
+_shared_ses_access_key_id="$(gc secrets versions access latest \
+  --secret=trustedrouter-aws-access-key-id)"
+_shared_ses_secret_access_key="$(gc secrets versions access latest \
+  --secret=trustedrouter-aws-secret-access-key)"
+if [ "$_internal_ses_access_key_id" = "$_shared_ses_access_key_id" ] ||
+   [ "$_internal_ses_secret_access_key" = "$_shared_ses_secret_access_key" ]; then
+  echo "ERROR: internal SES credentials must differ from console/actions SES credentials" >&2
+  exit 1
+fi
+unset \
+  _internal_ses_access_key_id \
+  _internal_ses_secret_access_key \
+  _shared_ses_access_key_id \
+  _shared_ses_secret_access_key
 ensure_secret_from_env_file "PAYPAL_CLIENT_ID" "trustedrouter-paypal-client-id"
 ensure_secret_from_env_file "PAYPAL_CLIENT_SECRET" "trustedrouter-paypal-client-secret"
 ensure_secret_from_env_file "PAYPAL_WEBHOOK_ID" "trustedrouter-paypal-webhook-id"
@@ -334,33 +554,214 @@ ensure_secret_from_env_file "ADYEN_CLIENT_KEY" "trustedrouter-adyen-test-client-
 ensure_secret_from_env_file "ADYEN_HMAC_KEY" "trustedrouter-adyen-test-hmac-key"
 ensure_secret_from_env_file \
   "ADYEN_REFERENCE_KEY" "trustedrouter-adyen-test-reference-key"
-if ! gc secrets describe trustedrouter-internal-gateway-token >/dev/null 2>&1; then
-  ensure_secret_value trustedrouter-internal-gateway-token "$(python3 - <<'PY'
-import secrets
-print(secrets.token_urlsafe(48))
-PY
-)"
-  log "generated secret trustedrouter-internal-gateway-token"
-fi
-if ! gc secrets describe trustedrouter-observer-internal-token >/dev/null 2>&1; then
-  ensure_secret_value trustedrouter-observer-internal-token "$(python3 - <<'PY'
-import secrets
-print(secrets.token_urlsafe(48))
-PY
-)"
-  log "generated secret trustedrouter-observer-internal-token"
-fi
+ensure_generated_secret_resource trustedrouter-internal-gateway-token
+ensure_generated_secret_resource trustedrouter-observer-internal-token
 # A copied billing token would silently undo the surface split. Compare values
 # without logging either secret and fail before the rollout can consume them.
 _observer_token_check="$(gc secrets versions access latest \
   --secret=trustedrouter-observer-internal-token)"
 _gateway_token_check="$(gc secrets versions access latest \
   --secret=trustedrouter-internal-gateway-token)"
+_attribution_token_check="$(gc secrets versions access latest \
+  --secret=trustedrouter-attribution-cookie-secret)"
 if [ "$_observer_token_check" = "$_gateway_token_check" ]; then
   echo "ERROR: observer internal token must differ from billing gateway token" >&2
   exit 1
 fi
-unset _observer_token_check _gateway_token_check
+if [ "$_attribution_token_check" = "$_gateway_token_check" ] ||
+   [ "$_attribution_token_check" = "$_observer_token_check" ]; then
+  echo "ERROR: attribution cookie secret must differ from internal credentials" >&2
+  exit 1
+fi
+if secret_exists_or_error trustedrouter-synthetic-monitor-api-key; then
+  _monitor_token_check="$(gc secrets versions access latest \
+    --secret=trustedrouter-synthetic-monitor-api-key)"
+  if [ "$_monitor_token_check" = "$_observer_token_check" ] ||
+     [ "$_monitor_token_check" = "$_gateway_token_check" ] ||
+     [ "$_monitor_token_check" = "$_attribution_token_check" ]; then
+    echo "ERROR: synthetic monitor key must differ from browser and internal credentials" >&2
+    exit 1
+  fi
+  unset _monitor_token_check
+else
+  _monitor_exists_rc=$?
+  if [ "$_monitor_exists_rc" -ne 1 ]; then
+    exit 1
+  fi
+  unset _monitor_exists_rc
+fi
+unset _observer_token_check _gateway_token_check _attribution_token_check
+
+# Reconcile only the declared six-surface, synthetic, and checked-in deploy
+# resources. The complete project inventory is still read before the first
+# mutation: an unknown secret with runtime, deploy, synthetic, or public access
+# fails closed for a separate owner review instead of being rewritten here.
+log "reconciling declared Secret Manager accessor ownership"
+reconcile_declared_secret_iam
+
+# Repeat the named capability checks as readable postconditions. Optional
+# means the resource may be absent, never that an existing resource may have a
+# broader owner set.
+log "verifying required split-runtime Secret Manager ownership"
+verify_runtime_secret_access required \
+  trustedrouter-attribution-cookie-secret \
+  "$PUBLIC_RUN_SERVICE_ACCOUNT" "$CONSOLE_RUN_SERVICE_ACCOUNT"
+verify_runtime_secret_access required \
+  trustedrouter-sentry-dsn \
+  "$CONSOLE_RUN_SERVICE_ACCOUNT" \
+  "$CHAT_RUN_SERVICE_ACCOUNT" \
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT" \
+  "$INTERNAL_RUN_SERVICE_ACCOUNT"
+verify_runtime_secret_access required \
+  trustedrouter-stripe-secret-key \
+  "$CONSOLE_RUN_SERVICE_ACCOUNT"
+verify_runtime_secret_access required \
+  trustedrouter-stripe-webhook-secret \
+  "$WEBHOOKS_RUN_SERVICE_ACCOUNT"
+verify_runtime_secret_access required \
+  trustedrouter-internal-stripe-payment-intents-key \
+  "$INTERNAL_RUN_SERVICE_ACCOUNT"
+for secret_name in \
+  trustedrouter-aws-access-key-id \
+  trustedrouter-aws-secret-access-key; do
+  verify_runtime_secret_access required "$secret_name" \
+    "$ACTIONS_RUN_SERVICE_ACCOUNT" "$CONSOLE_RUN_SERVICE_ACCOUNT"
+done
+for secret_name in \
+  trustedrouter-internal-ses-access-key-id \
+  trustedrouter-internal-ses-secret-access-key \
+  trustedrouter-internal-gateway-token \
+  trustedrouter-observer-internal-token \
+  trustedrouter-synthetic-monitor-api-key; do
+  verify_runtime_secret_access required "$secret_name" \
+    "$INTERNAL_RUN_SERVICE_ACCOUNT"
+done
+
+log "verifying optional split-runtime Secret Manager ownership"
+verify_runtime_secret_access optional \
+  trustedrouter-ops-chat-webhook-secret \
+  "$ACTIONS_RUN_SERVICE_ACCOUNT"
+for secret_name in \
+  trustedrouter-google-client-id \
+  trustedrouter-google-client-secret \
+  trustedrouter-google-alias-credentials-json \
+  trustedrouter-github-client-id \
+  trustedrouter-github-client-secret \
+  trustedrouter-github-alias-credentials-json \
+  trustedrouter-clickhouse-provider-read-password \
+  trustedrouter-twilio-account-sid \
+  trustedrouter-twilio-api-key-sid \
+  trustedrouter-twilio-api-key-secret \
+  trustedrouter-twilio-auth-token; do
+  verify_runtime_secret_access optional "$secret_name" \
+    "$CONSOLE_RUN_SERVICE_ACCOUNT"
+done
+for secret_name in \
+  trustedrouter-paypal-client-id \
+  trustedrouter-paypal-client-secret \
+  trustedrouter-adyen-test-reference-key; do
+  verify_runtime_secret_access optional "$secret_name" \
+    "$CONSOLE_RUN_SERVICE_ACCOUNT" "$WEBHOOKS_RUN_SERVICE_ACCOUNT"
+done
+for secret_name in \
+  trustedrouter-paypal-webhook-id \
+  trustedrouter-adyen-test-hmac-key \
+  trustedrouter-veriff-shared-secret-key; do
+  verify_runtime_secret_access optional "$secret_name" \
+    "$WEBHOOKS_RUN_SERVICE_ACCOUNT"
+done
+for secret_name in \
+  trustedrouter-adyen-test-api-key \
+  trustedrouter-adyen-test-client-key \
+  trustedrouter-veriff-api-key; do
+  verify_runtime_secret_access optional "$secret_name" \
+    "$CONSOLE_RUN_SERVICE_ACCOUNT"
+done
+verify_runtime_secret_access optional \
+  trustedrouter-clickhouse-password \
+  "$CONSOLE_RUN_SERVICE_ACCOUNT" "$INTERNAL_RUN_SERVICE_ACCOUNT"
+verify_runtime_secret_access optional \
+  trustedrouter-clickhouse-control-read-password \
+  "$PUBLIC_RUN_SERVICE_ACCOUNT" \
+  "$CONSOLE_RUN_SERVICE_ACCOUNT" \
+  "$INTERNAL_RUN_SERVICE_ACCOUNT"
+# None of the six split runtimes reads AXIOM_API_TOKEN. Keep the secret
+# detached instead of granting a logging credential by habit; an explicitly
+# approved external shipper can own it separately.
+verify_runtime_secret_access optional trustedrouter-axiom-api-token
+for secret_name in \
+  trustedrouter-federation-peer-token \
+  trustedrouter-federation-home-token \
+  trustedrouter-federation-credit-inbound-token \
+  trustedrouter-federation-credit-peer-token \
+  trustedrouter-federation-settlement-inbound-tokens \
+  trustedrouter-federation-settlement-home-token; do
+  verify_runtime_secret_access optional "$secret_name" \
+    "$INTERNAL_RUN_SERVICE_ACCOUNT"
+done
+
+# The chat surface validates the caller and forwards to the separately attested
+# API service; it never calls inference providers directly.  Keep every
+# upstream provider credential and inference prompt detached from all six
+# split runtimes.  Telnyx is the sole exception because console owns the voice
+# operation routes; it is still forbidden on chat.
+DETACHED_PROVIDER_SECRET_NAMES=(
+  trustedrouter-anthropic-api-key
+  trustedrouter-openai-api-key
+  trustedrouter-openai-video-api-key
+  trustedrouter-gemini-api-key
+  trustedrouter-cerebras-api-key
+  trustedrouter-deepseek-api-key
+  trustedrouter-mistral-api-key
+  trustedrouter-kimi-api-key
+  trustedrouter-zai-api-key
+  trustedrouter-together-api-key
+  trustedrouter-fireworks-api-key
+  trustedrouter-deepinfra-api-key
+  trustedrouter-cohere-api-key
+  trustedrouter-voyage-api-key
+  trustedrouter-xiaomi-api-key
+  trustedrouter-grok-api-key
+  trustedrouter-novita-api-key
+  trustedrouter-phala-api-key
+  trustedrouter-phala-confidential-api-key
+  trustedrouter-siliconflow-api-key
+  trustedrouter-tinfoil-api-key
+  trustedrouter-venice-api-key
+  trustedrouter-nebius-api-key
+  trustedrouter-minimax-api-key
+  trustedrouter-friendli-api-key
+  trustedrouter-baseten-api-key
+  trustedrouter-telnyx-api-key
+  trustedrouter-thinking-machines-api-key
+  trustedrouter-wafer-api-key
+  trustedrouter-crusoe-api-key
+  trustedrouter-makora-api-key
+  trustedrouter-alibaba-api-key
+  trustedrouter-ltx-api-key
+  trustedrouter-runway-api-key
+  trustedrouter-kling-api-key
+  trustedrouter-chutes-api-key
+  trustedrouter-digitalocean-api-key
+  trustedrouter-cloudflare-workers-ai-api-token
+  trustedrouter-inceptron-api-key
+  trustedrouter-morph-api-key
+  trustedrouter-atlas-cloud-api-key
+  trustedrouter-streamlake-api-key
+  trustedrouter-neurometric-api-key
+  trustedrouter-engy-api-key
+  trustedrouter-pearl-api-key
+  trustedrouter-zero-g-api-key
+  trustedrouter-athena-worker-prompt-v1
+)
+for secret_name in "${DETACHED_PROVIDER_SECRET_NAMES[@]}"; do
+  if [ "$secret_name" = "trustedrouter-telnyx-api-key" ]; then
+    verify_runtime_secret_access optional "$secret_name" \
+      "$CONSOLE_RUN_SERVICE_ACCOUNT"
+  else
+    verify_runtime_secret_access optional "$secret_name"
+  fi
+done
 
 # Runtime-SA project-level IAM bindings live in infra.sh (Phase 1
 # bootstrap, run as a project Owner). Calling projects.setIamPolicy

--- a/scripts/deploy/service_surface_url_map.py
+++ b/scripts/deploy/service_surface_url_map.py
@@ -228,6 +228,13 @@ def first_party_hosts(domains: list[str] | tuple[str, ...]) -> list[str]:
                 "status-eu.trustedrouter.com",
             }
         )
+        # trust.trustedrouter.com is published by the enclave repository
+        # (quill-cloud-proxy) as a static site and its DNS is owned there
+        # (tools/fix-trustedrouter-dns.sh pins the CNAME). The control LB must
+        # not claim it: a host rule here would be unreachable today and would
+        # invite a later DNS flip that the enclave tooling reverts. The brand
+        # trust hosts stay, because the application serves them.
+        hosts.discard("trust.trustedrouter.com")
     return sorted(hosts)
 
 

--- a/scripts/deploy/service_surface_url_map.py
+++ b/scripts/deploy/service_surface_url_map.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Build the four-service HTTPS URL map without disturbing unrelated hosts.
+"""Build the six-service HTTPS URL map without disturbing unrelated hosts.
 
 The public service is the default failure domain.  Only the explicit patterns
-below can reach the authenticated control service or the internal billing
-service.  Keep this module importable: route-totality tests compare every
-registered FastAPI route with this exact deployment contract.
+below can reach anonymous actions, account/console, chat, signed webhooks, or
+internal billing services. Keep this module importable: route-totality tests
+compare every registered FastAPI route with this exact deployment contract.
 """
 
 from __future__ import annotations
@@ -12,10 +12,40 @@ from __future__ import annotations
 import argparse
 import copy
 import json
+import os
+import tempfile
 from pathlib import Path
 from typing import Any, Literal
 
-Surface = Literal["public", "actions", "control", "internal"]
+Surface = Literal["public", "actions", "console", "chat", "webhooks", "internal"]
+
+
+def _atomic_write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            json.dump(value, output, indent=2, sort_keys=True)
+            output.write("\n")
+            output.flush()
+            os.fsync(output.fileno())
+        os.replace(temporary_name, path)
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    except BaseException:
+        try:
+            os.unlink(temporary_name)
+        except FileNotFoundError:
+            pass
+        raise
 
 PUBLIC_PATH_PATTERNS = (
     "/analytics/events",
@@ -50,7 +80,7 @@ ACTIONS_PATH_PATTERNS = (
     "/trustedos/inquiry",
 )
 
-CONTROL_PATH_PATTERNS = (
+CONSOLE_PATH_PATTERNS = (
     "/v1/*",
     "/models/user",
     "/v1/models/user",
@@ -62,7 +92,6 @@ CONTROL_PATH_PATTERNS = (
     "/provider",
     "/provider/*",
     "/mcp",
-    "/chat-proxy/*",
     "/auth",
     "/auth/*",
     "/byok",
@@ -111,18 +140,25 @@ CONTROL_PATH_PATTERNS = (
     "/signup",
     "/notify",
     "/notify/*",
+    "/internal/chat/issue-browser-key",
+    "/v1/internal/chat/issue-browser-key",
+)
+
+CHAT_PATH_PATTERNS = (
+    "/chat-proxy/*",
+)
+
+WEBHOOK_PATH_PATTERNS = (
     "/internal/stripe/webhook",
     "/internal/paypal/webhook",
     "/internal/adyen/webhook",
     "/internal/veriff/webhook",
     "/internal/ses/notifications",
-    "/internal/chat/issue-browser-key",
     "/v1/internal/stripe/webhook",
     "/v1/internal/paypal/webhook",
     "/v1/internal/adyen/webhook",
     "/v1/internal/veriff/webhook",
     "/v1/internal/ses/notifications",
-    "/v1/internal/chat/issue-browser-key",
 )
 
 INTERNAL_PATH_PATTERNS = (
@@ -133,7 +169,9 @@ INTERNAL_PATH_PATTERNS = (
 _PATTERNS: dict[Surface, tuple[str, ...]] = {
     "public": PUBLIC_PATH_PATTERNS,
     "actions": ACTIONS_PATH_PATTERNS,
-    "control": CONTROL_PATH_PATTERNS,
+    "console": CONSOLE_PATH_PATTERNS,
+    "chat": CHAT_PATH_PATTERNS,
+    "webhooks": WEBHOOK_PATH_PATTERNS,
     "internal": INTERNAL_PATH_PATTERNS,
 }
 _MATCHER_NAME = "trusted-router-service-surfaces"
@@ -214,19 +252,65 @@ def rewrite_url_map(
     existing: dict[str, Any],
     public_backend: str,
     actions_backend: str,
-    control_backend: str,
+    console_backend: str,
+    chat_backend: str,
+    webhooks_backend: str,
     internal_backend: str,
     domains: list[str] | tuple[str, ...],
+    preserved_hosts: list[str] | tuple[str, ...],
 ) -> dict[str, Any]:
-    """Return an importable URL map with a first-party four-way bulkhead."""
+    """Return an importable URL map with a first-party six-way bulkhead."""
     if existing.get("defaultUrlRedirect") is not None:
         raise ValueError("cannot convert a redirect-only URL map into the HTTPS service map")
+    if existing.get("defaultRouteAction") is not None:
+        raise ValueError("refusing a top-level default route action on the managed URL map")
+    if existing.get("headerAction") is not None:
+        raise ValueError(
+            "refusing a top-level header action that could inject credentials into managed hosts"
+        )
     if not existing.get("defaultService"):
         raise ValueError("refusing to rewrite a URL map without an existing default service")
     domain_set = {domain.strip().lower().rstrip(".") for domain in domains if domain.strip()}
     if not domain_set:
         raise ValueError("at least one first-party domain is required")
     managed_hosts = set(first_party_hosts(tuple(domain_set)))
+    for rule in existing.get("hostRules", []):
+        hosts = list(rule.get("hosts") or [])
+        if "*" in hosts:
+            raise ValueError("refusing to rewrite a URL map with a catch-all host rule")
+        if any(
+            str(host).strip().lower().rstrip(".") == f"*.{domain}"
+            for host in hosts
+            for domain in domain_set
+        ):
+            raise ValueError(
+                "refusing to rewrite a wildcard first-party host rule; split it into "
+                "explicit attested, regional, and public hosts first"
+            )
+    preserved_host_set = {
+        host.strip().lower().rstrip(".") for host in preserved_hosts if host.strip()
+    }
+    if not preserved_host_set:
+        raise ValueError("an explicit preserved-host inventory is required")
+    managed_inventory_overlap = sorted(preserved_host_set & managed_hosts)
+    if managed_inventory_overlap:
+        raise ValueError(
+            "preserved-host inventory must exclude managed public web host(s): "
+            + ", ".join(managed_inventory_overlap)
+        )
+    explicitly_routed_hosts = {
+        str(host).strip().lower().rstrip(".")
+        for rule in existing.get("hostRules", [])
+        for host in (rule.get("hosts") or [])
+        if host != "*"
+    }
+    missing_host_rules = sorted(preserved_host_set - explicitly_routed_hosts)
+    if missing_host_rules:
+        raise ValueError(
+            "preserved host(s) rely on the top-level default instead of an explicit "
+            "hostRule: "
+            + ", ".join(missing_host_rules)
+        )
 
     result = _strip_output_only(copy.deepcopy(existing))
     host_rules: list[dict[str, Any]] = []
@@ -266,16 +350,26 @@ def rewrite_url_map(
     backend_for: dict[Surface, str] = {
         "public": public_backend,
         "actions": actions_backend,
-        "control": control_backend,
+        "console": console_backend,
+        "chat": chat_backend,
+        "webhooks": webhooks_backend,
         "internal": internal_backend,
     }
+    surface_order: tuple[Surface, ...] = (
+        "public",
+        "actions",
+        "console",
+        "chat",
+        "webhooks",
+        "internal",
+    )
     path_matchers.append(
         {
             "name": _MATCHER_NAME,
             "defaultService": public_backend,
             "pathRules": [
                 {"paths": list(_PATTERNS[surface]), "service": backend_for[surface]}
-                for surface in ("public", "actions", "control", "internal")
+                for surface in surface_order
             ],
         }
     )
@@ -308,9 +402,12 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--public-backend", required=True)
     parser.add_argument("--actions-backend", required=True)
-    parser.add_argument("--control-backend", required=True)
+    parser.add_argument("--console-backend", required=True)
+    parser.add_argument("--chat-backend", required=True)
+    parser.add_argument("--webhooks-backend", required=True)
     parser.add_argument("--internal-backend", required=True)
     parser.add_argument("--domains", required=True)
+    parser.add_argument("--preserved-hosts", required=True)
     return parser
 
 
@@ -321,11 +418,14 @@ def main() -> None:
         existing,
         args.public_backend,
         args.actions_backend,
-        args.control_backend,
+        args.console_backend,
+        args.chat_backend,
+        args.webhooks_backend,
         args.internal_backend,
         args.domains.split(","),
+        args.preserved_hosts.split(","),
     )
-    args.output.write_text(json.dumps(rewritten, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _atomic_write_json(args.output, rewritten)
 
 
 if __name__ == "__main__":

--- a/scripts/deploy/set_new_signups.sh
+++ b/scripts/deploy/set_new_signups.sh
@@ -24,14 +24,20 @@ esac
 
 command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 1; }
 
-control_service="${TR_CONTROL_SERVICE:-$SERVICE}"
+# _lib.sh resolves the canonical split-console companion (or its explicit
+# operator override). Never fall back to the legacy combined monolith here.
+console_service="$CONSOLE_SERVICE"
+if [ "$console_service" = "$LEGACY_CONSOLE_SERVICE" ]; then
+  echo "ERROR: split console ${console_service} aliases the legacy combined monolith" >&2
+  exit 1
+fi
 IFS=',' read -r -a targets <<<"$TR_CONTROL_PLANE_REGIONS"
 timestamp="$(date -u +%Y%m%d%H%M%S)"
 revision_suffix="signup-${state}-${timestamp}-$$"
 
 serving_revision() {
   local target="$1"
-  gc run services describe "$control_service" --region="$target" --format=json \
+  gc run services describe "$console_service" --region="$target" --format=json \
     | jq -er '[.status.traffic[]? | select((.percent // 0) == 100) | .revisionName] |
       unique | if length == 1 then .[0] else error("expected exactly one 100% revision") end'
 }
@@ -55,8 +61,8 @@ for target in "${targets[@]}"; do
   [ -n "$target" ] || continue
   current_revision="$(serving_revision "$target")"
   current_surface="$(revision_env "$target" "$current_revision" TR_SERVICE_SURFACE)"
-  if [ "$current_surface" != "control" ]; then
-    echo "ERROR: ${control_service}/${target} serves ${current_revision} with surface=${current_surface:-unset}, expected control" >&2
+  if [ "$current_surface" != "console" ]; then
+    echo "ERROR: ${console_service}/${target} serves ${current_revision} with surface=${current_surface:-unset}, expected console" >&2
     exit 1
   fi
   clean_targets+=("$target")
@@ -68,8 +74,8 @@ done
 # traffic. A separate latestCreated lookup is racy with concurrent rollouts.
 candidate_revisions=()
 for target in "${clean_targets[@]}"; do
-  log "setting new_signups=${desired} on ${control_service}/${target}"
-  revision="$(gc run services update "$control_service" \
+  log "setting new_signups=${desired} on ${console_service}/${target}"
+  revision="$(gc run services update "$console_service" \
     --region="$target" \
     --update-env-vars="TR_NEW_SIGNUPS_ENABLED=${desired}" \
     --revision-suffix="$revision_suffix" \
@@ -77,9 +83,9 @@ for target in "${clean_targets[@]}"; do
     --format='value(status.latestCreatedRevisionName)' \
     --quiet)"
   [ -n "$revision" ] || { echo "ERROR: no revision created in ${target}" >&2; exit 1; }
-  expected_revision="${control_service}-${revision_suffix}"
+  expected_revision="${console_service}-${revision_suffix}"
   if [ "$revision" != "$expected_revision" ]; then
-    echo "ERROR: ${control_service}/${target} created unexpected revision ${revision}; expected ${expected_revision}" >&2
+    echo "ERROR: ${console_service}/${target} created unexpected revision ${revision}; expected ${expected_revision}" >&2
     exit 1
   fi
   candidate_revisions+=("$revision")
@@ -90,8 +96,8 @@ for index in "${!clean_targets[@]}"; do
   revision="${candidate_revisions[$index]}"
   candidate_surface="$(revision_env "$target" "$revision" TR_SERVICE_SURFACE)"
   candidate_gate="$(revision_env "$target" "$revision" TR_NEW_SIGNUPS_ENABLED)"
-  if [ "$candidate_surface" != "control" ] || [ "$candidate_gate" != "$desired" ]; then
-    echo "ERROR: staged ${control_service}/${target}/${revision} has surface=${candidate_surface:-unset} signups=${candidate_gate:-unset}" >&2
+  if [ "$candidate_surface" != "console" ] || [ "$candidate_gate" != "$desired" ]; then
+    echo "ERROR: staged ${console_service}/${target}/${revision} has surface=${candidate_surface:-unset} signups=${candidate_gate:-unset}" >&2
     exit 1
   fi
 done
@@ -103,7 +109,7 @@ for index in "${!clean_targets[@]}"; do
   target="${clean_targets[$index]}"
   current_revision="$(serving_revision "$target")"
   if [ "$current_revision" != "${original_revisions[$index]}" ]; then
-    echo "ERROR: ${control_service}/${target} changed from ${original_revisions[$index]} to ${current_revision} while staging; refusing to overwrite concurrent rollout" >&2
+    echo "ERROR: ${console_service}/${target} changed from ${original_revisions[$index]} to ${current_revision} while staging; refusing to overwrite concurrent rollout" >&2
     exit 1
   fi
 done
@@ -114,11 +120,11 @@ rollback_promoted() {
   for ((rollback_index = count - 1; rollback_index >= 0; rollback_index--)); do
     rollback_target="${clean_targets[$rollback_index]}"
     rollback_revision="${original_revisions[$rollback_index]}"
-    if ! gc run services update-traffic "$control_service" \
+    if ! gc run services update-traffic "$console_service" \
       --region="$rollback_target" \
       --to-revisions="${rollback_revision}=100" \
       --quiet >/dev/null; then
-      echo "CRITICAL: rollback failed for ${control_service}/${rollback_target}/${rollback_revision}" >&2
+      echo "CRITICAL: rollback failed for ${console_service}/${rollback_target}/${rollback_revision}" >&2
     fi
   done
 }
@@ -127,11 +133,11 @@ promoted=0
 for index in "${!clean_targets[@]}"; do
   target="${clean_targets[$index]}"
   revision="${candidate_revisions[$index]}"
-  if ! gc run services update-traffic "$control_service" \
+  if ! gc run services update-traffic "$console_service" \
     --region="$target" \
     --to-revisions="${revision}=100" \
     --quiet >/dev/null; then
-    echo "ERROR: failed to promote ${control_service}/${target}/${revision}; rolling back" >&2
+    echo "ERROR: failed to promote ${console_service}/${target}/${revision}; rolling back" >&2
     # A timed-out CLI may have committed the traffic change server-side before
     # returning nonzero, so restore the current attempted region too.
     rollback_promoted "$((promoted + 1))"
@@ -145,12 +151,12 @@ for index in "${!clean_targets[@]}"; do
   revision="$(serving_revision "$target")"
   actual_surface="$(revision_env "$target" "$revision" TR_SERVICE_SURFACE)"
   actual_gate="$(revision_env "$target" "$revision" TR_NEW_SIGNUPS_ENABLED)"
-  if [ "$actual_surface" != "control" ] || [ "$actual_gate" != "$desired" ]; then
-    echo "ERROR: ${control_service}/${target}/${revision} verifies surface=${actual_surface:-unset} signups=${actual_gate:-unset}" >&2
+  if [ "$actual_surface" != "console" ] || [ "$actual_gate" != "$desired" ]; then
+    echo "ERROR: ${console_service}/${target}/${revision} verifies surface=${actual_surface:-unset} signups=${actual_gate:-unset}" >&2
     rollback_promoted "$promoted"
     exit 1
   fi
-  log "verified ${control_service}/${target}/${revision}: new_signups=${actual_gate}"
+  log "verified ${console_service}/${target}/${revision}: new_signups=${actual_gate}"
 done
 
 log "new account creation is ${state} in every control-plane region"

--- a/scripts/deploy/synthetic.sh
+++ b/scripts/deploy/synthetic.sh
@@ -10,15 +10,13 @@ source "${SCRIPT_DIR}/_lib.sh"
 # shellcheck source=scripts/deploy/_private_run_ingress.sh
 source "${SCRIPT_DIR}/_private_run_ingress.sh"
 
+validate_runtime_service_accounts
+
 # Observer-token jobs cannot safely target the legacy combined service: before
 # the split that service accepts only the billing gateway token, so the jobs
 # would deploy successfully and then silently 401 every ingest. Require the
-# independently named internal service explicitly and re-check its live
+# independently named internal service and re-check its live
 # contract immediately before every job deployment below.
-[ -n "${TR_BILLING_SERVICE:-}" ] || {
-  echo "ERROR: TR_BILLING_SERVICE is required; refusing observer-token jobs against the legacy service" >&2
-  exit 1
-}
 [ "$TR_BILLING_SERVICE" != "$SERVICE" ] || {
   echo "ERROR: TR_BILLING_SERVICE must be separate from legacy SERVICE" >&2
   exit 1
@@ -30,6 +28,52 @@ case "$TR_BILLING_SERVICE" in
     ;;
 esac
 SYNTHETIC_INGEST_SERVICE="$TR_BILLING_SERVICE"
+[ "$SYNTHETIC_RUN_SERVICE_ACCOUNT" = "tr-synthetic@${PROJECT_ID}.iam.gserviceaccount.com" ] || {
+  echo "ERROR: synthetic Jobs require the canonical dedicated tr-synthetic identity" >&2
+  exit 1
+}
+synthetic_account_json="$(gc iam service-accounts describe \
+  "$SYNTHETIC_RUN_SERVICE_ACCOUNT" --format=json)" || {
+    echo "ERROR: dedicated synthetic identity is not provisioned; separate narrow IAM approval is required" >&2
+    exit 1
+  }
+if ! printf '%s' "$synthetic_account_json" | python3 -c '
+import json
+import sys
+
+account = json.load(sys.stdin)
+if account.get("email") != sys.argv[1] or account.get("disabled", False) is not False:
+    raise SystemExit("synthetic identity is missing, disabled, or renamed")
+' "$SYNTHETIC_RUN_SERVICE_ACCOUNT"; then
+  echo "ERROR: dedicated synthetic identity is missing, disabled, or renamed" >&2
+  exit 1
+fi
+synthetic_account_policy="$(gc iam service-accounts get-iam-policy \
+  "$SYNTHETIC_RUN_SERVICE_ACCOUNT" --format=json)" || exit 1
+if ! printf '%s' "$synthetic_account_policy" | python3 -c '
+import json
+import sys
+
+policy = json.load(sys.stdin)
+bindings = policy.get("bindings") or []
+if len(bindings) != 1:
+    raise SystemExit("synthetic identity IAM binding inventory differs")
+binding = bindings[0]
+if binding.get("role") != "roles/iam.serviceAccountUser":
+    raise SystemExit("synthetic identity actAs role differs")
+if binding.get("condition") is not None:
+    raise SystemExit("synthetic identity actAs grant is conditional")
+if (binding.get("members") or []) != [sys.argv[1]]:
+    raise SystemExit("synthetic identity actAs member inventory differs")
+' "serviceAccount:${DEPLOY_SERVICE_ACCOUNT}"; then
+  echo "ERROR: dedicated synthetic identity IAM is not the narrow reviewed policy" >&2
+  exit 1
+fi
+verify_exact_unconditional_roles \
+  "project IAM roles on the synthetic Job identity" \
+  "serviceAccount:${SYNTHETIC_RUN_SERVICE_ACCOUNT}" \
+  "" \
+  gc projects get-iam-policy "$PROJECT_ID"
 
 if ! gc secrets describe trustedrouter-synthetic-monitor-api-key >/dev/null 2>&1; then
   log "synthetic monitor key secret is missing; skipping synthetic monitor deploy"
@@ -40,30 +84,132 @@ if ! gc secrets describe trustedrouter-observer-internal-token >/dev/null 2>&1; 
   exit 1
 fi
 
-SECRET_ENVS=(
-  "TR_SENTRY_DSN=trustedrouter-sentry-dsn:latest"
-  "TR_OBSERVER_INTERNAL_TOKEN=trustedrouter-observer-internal-token:latest"
-  "TR_SYNTHETIC_MONITOR_API_KEY=trustedrouter-synthetic-monitor-api-key:latest"
-)
-add_secret_env_if_exists() {
-  local env_name="$1"
-  local secret_name="$2"
-  if gc secrets describe "$secret_name" >/dev/null 2>&1; then
-    SECRET_ENVS+=("${env_name}=${secret_name}:latest")
-  fi
+verify_synthetic_secret_access() {
+  local secret_name policy_json expected_surfaces
+  for secret_name in \
+    trustedrouter-observer-internal-token \
+    trustedrouter-synthetic-monitor-api-key; do
+    expected_surfaces="$(secret_expected_surfaces "$secret_name")" || return 1
+    policy_json="$(gc secrets get-iam-policy "$secret_name" --format=json)" || return 1
+    if ! printf '%s' "$policy_json" | secret_iam_policy_contract_json verify \
+        "$secret_name" "$expected_surfaces"; then
+      echo "ERROR: ${secret_name} does not have the exact reviewed accessor policy" >&2
+      return 1
+    fi
+  done
 }
-add_secret_env_if_exists "ANTHROPIC_API_KEY" "trustedrouter-anthropic-api-key"
-add_secret_env_if_exists "OPENAI_API_KEY" "trustedrouter-openai-api-key"
-add_secret_env_if_exists "GEMINI_API_KEY" "trustedrouter-gemini-api-key"
-add_secret_env_if_exists "CEREBRAS_API_KEY" "trustedrouter-cerebras-api-key"
-add_secret_env_if_exists "DEEPSEEK_API_KEY" "trustedrouter-deepseek-api-key"
-add_secret_env_if_exists "MISTRAL_API_KEY" "trustedrouter-mistral-api-key"
-add_secret_env_if_exists "KIMI_API_KEY" "trustedrouter-kimi-api-key"
-add_secret_env_if_exists "ZAI_API_KEY" "trustedrouter-zai-api-key"
+
+resolve_newest_enabled_secret_version() {
+  local secret_name="$1" versions_json
+  versions_json="$(gc secrets versions list "$secret_name" \
+    --filter='state=ENABLED' --format=json)" || return 1
+  printf '%s' "$versions_json" | python3 -c '
+import json
+import sys
+
+items = json.load(sys.stdin)
+versions = []
+for item in items:
+    if item.get("state") != "ENABLED":
+        continue
+    version = str(item.get("name") or "").rstrip("/").split("/")[-1]
+    if not version.isdigit() or version.startswith("0"):
+        raise SystemExit("enabled secret version name is not numeric")
+    versions.append(int(version))
+if not versions:
+    raise SystemExit("secret has no enabled numeric version")
+print(max(versions))
+'
+}
+
+OBSERVER_SECRET_VERSION="$(resolve_newest_enabled_secret_version \
+  trustedrouter-observer-internal-token)" || {
+    echo "ERROR: cannot resolve an enabled observer-token version" >&2
+    exit 1
+  }
+MONITOR_SECRET_VERSION="$(resolve_newest_enabled_secret_version \
+  trustedrouter-synthetic-monitor-api-key)" || {
+    echo "ERROR: cannot resolve an enabled synthetic-monitor version" >&2
+    exit 1
+  }
+SECRET_ENVS=(
+  "TR_OBSERVER_INTERNAL_TOKEN=trustedrouter-observer-internal-token:${OBSERVER_SECRET_VERSION}"
+  "TR_SYNTHETIC_MONITOR_API_KEY=trustedrouter-synthetic-monitor-api-key:${MONITOR_SECRET_VERSION}"
+)
 # Complete allowlist: --set-secrets removes legacy gateway/payment bindings
 # from an existing job instead of preserving omitted secrets across updates.
 SET_SECRETS="$(IFS=,; echo "${SECRET_ENVS[*]}")"
 
+verify_synthetic_job_secret_contract() {
+  local job_name="$1" region="$2" job_json
+  job_json="$(gc run jobs describe "$job_name" --region="$region" --format=json)" || {
+    echo "ERROR: cannot read deployed synthetic Job ${region}/${job_name}" >&2
+    return 1
+  }
+  printf '%s' "$job_json" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+expected_identity, observer_version, monitor_version = sys.argv[1:]
+containers = []
+identities = []
+
+def visit(value):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key in {"serviceAccount", "serviceAccountName"} and isinstance(child, str):
+                identities.append(child)
+            if key == "containers" and isinstance(child, list):
+                containers.extend(child)
+            visit(child)
+    elif isinstance(value, list):
+        for child in value:
+            visit(child)
+
+visit(data.get("spec") or {})
+if sorted(set(identities)) != [expected_identity]:
+    raise SystemExit("synthetic Job runtime identity differs")
+if len(containers) != 1:
+    raise SystemExit("synthetic Job container inventory differs")
+env = {
+    item.get("name"): item
+    for item in containers[0].get("env", [])
+    if item.get("name")
+}
+actual = {}
+for name, item in env.items():
+    if "valueFrom" not in item:
+        continue
+    reference = (item.get("valueFrom") or {}).get("secretKeyRef") or {}
+    actual[name] = {
+        "resource": str(reference.get("name") or reference.get("secret") or "").split("/")[-1],
+        "version": str(reference.get("key") or reference.get("version") or ""),
+    }
+expected = {
+    "TR_OBSERVER_INTERNAL_TOKEN": {
+        "resource": "trustedrouter-observer-internal-token",
+        "version": observer_version,
+    },
+    "TR_SYNTHETIC_MONITOR_API_KEY": {
+        "resource": "trustedrouter-synthetic-monitor-api-key",
+        "version": monitor_version,
+    },
+}
+if actual != expected:
+    raise SystemExit("synthetic Job exact numeric secret map differs")
+' "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
+    "$OBSERVER_SECRET_VERSION" "$MONITOR_SECRET_VERSION" || {
+      echo "ERROR: deployed synthetic Job ${region}/${job_name} secret contract failed" >&2
+      return 1
+    }
+}
+
+SYNTHETIC_RELEASE="${TR_RELEASE:-$(git rev-parse --short HEAD 2>/dev/null || echo local)}"
+[[ "$SYNTHETIC_RELEASE" =~ ^[A-Za-z0-9._-]{1,128}$ ]] || {
+  echo "ERROR: synthetic release is invalid" >&2
+  exit 1
+}
 BASE_ENV_VARS=(
   # These are one-shot workers, not the public control-plane process. Using
   # the worker runtime keeps control-plane-only dependencies such as SES out
@@ -71,7 +217,7 @@ BASE_ENV_VARS=(
   # remain explicit below.
   "TR_ENVIRONMENT=worker"
   "TR_SERVICE_SURFACE=observer"
-  "TR_RELEASE=$(git rev-parse --short HEAD 2>/dev/null || echo local)"
+  "TR_RELEASE=${SYNTHETIC_RELEASE}"
   "TR_ENABLE_LIVE_PROVIDERS=false"
   "TR_API_BASE_URL=https://api.trustedrouter.com/v1"
   "TR_TRUSTED_DOMAIN=trustedrouter.com"
@@ -101,6 +247,8 @@ BASE_ENV_VARS=(
 verify_synthetic_ingest_service_contract() {
   local target_region="$1"
   local service_json=""
+  local revision_name=""
+  local revision_json=""
 
   service_json="$(gc run services describe "$SYNTHETIC_INGEST_SERVICE" \
     --region "$target_region" \
@@ -108,12 +256,12 @@ verify_synthetic_ingest_service_contract() {
       echo "ERROR: internal synthetic ingest service is absent in ${target_region}" >&2
       return 1
     }
-  if ! printf '%s' "$service_json" | python3 -c '
+  revision_name="$(printf '%s' "$service_json" | python3 -c '
 import json
 import sys
 
 data = json.load(sys.stdin)
-expected_name, expected_observer_secret, expected_gateway_secret = sys.argv[1:4]
+expected_name = sys.argv[1]
 metadata = data.get("metadata", {})
 reported_name = metadata.get("name")
 if reported_name and reported_name != expected_name:
@@ -129,11 +277,41 @@ if not ready:
 annotations = metadata.get("annotations", {}) or {}
 if annotations.get("run.googleapis.com/ingress") != "internal-and-cloud-load-balancing":
     raise SystemExit("service ingress is not internal-and-cloud-load-balancing")
-template = data.get("spec", {}).get("template", {})
-pod_spec = template.get("spec", template)
-containers = pod_spec.get("containers", [])
+traffic = [
+    item
+    for item in data.get("status", {}).get("traffic", []) or []
+    if int(item.get("percent", 0) or 0) > 0
+]
+if len(traffic) != 1 or int(traffic[0].get("percent", 0) or 0) != 100:
+    raise SystemExit("service must have exactly one revision serving 100 percent")
+revision = traffic[0].get("revisionName")
+if not revision:
+    raise SystemExit("serving traffic does not name an immutable revision")
+print(revision)
+' "$SYNTHETIC_INGEST_SERVICE")" || {
+    echo "ERROR: internal synthetic ingest service contract failed in ${target_region}" >&2
+    return 1
+  }
+  revision_json="$(gc run revisions describe "$revision_name" \
+    --region "$target_region" --format=json)" || {
+    echo "ERROR: serving internal revision ${revision_name} is absent in ${target_region}" >&2
+    return 1
+  }
+  if ! printf '%s' "$revision_json" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+expected_identity, expected_observer_secret, expected_gateway_secret = sys.argv[1:4]
+spec = data.get("spec", {})
+actual_identity = spec.get("serviceAccountName") or spec.get("serviceAccount")
+if actual_identity != expected_identity:
+    raise SystemExit(
+        f"serving revision identity is {actual_identity!r}, expected {expected_identity!r}"
+    )
+containers = spec.get("containers", [])
 if len(containers) != 1:
-    raise SystemExit("service must have exactly one container")
+    raise SystemExit("serving revision must have exactly one container")
 env = {
     item.get("name"): item
     for item in containers[0].get("env", [])
@@ -150,21 +328,99 @@ if secret_name("TR_OBSERVER_INTERNAL_TOKEN") != expected_observer_secret:
     raise SystemExit("observer token is not bound to the dedicated secret")
 if secret_name("TR_INTERNAL_GATEWAY_TOKEN") != expected_gateway_secret:
     raise SystemExit("billing gateway token is not bound to the dedicated secret")
-' "$SYNTHETIC_INGEST_SERVICE" \
+' "$INTERNAL_RUN_SERVICE_ACCOUNT" \
       trustedrouter-observer-internal-token \
       trustedrouter-internal-gateway-token; then
-    echo "ERROR: internal synthetic ingest service contract failed in ${target_region}" >&2
+    echo "ERROR: serving internal revision contract failed in ${target_region}" >&2
     return 1
   fi
 }
 
-if ! gc artifacts docker images describe "$IMAGE" >/dev/null 2>&1; then
+IMAGE_METADATA="$(gc artifacts docker images describe "$IMAGE" --format=json)" || {
   echo "ERROR: image ${IMAGE} does not exist. Run scripts/deploy/image.sh before synthetic.sh." >&2
   exit 1
-fi
+}
+IMAGE="$(printf '%s' "$IMAGE_METADATA" | python3 -c '
+import json
+import sys
 
-ensure_project_role "serviceAccount:${RUN_SERVICE_ACCOUNT}" "roles/run.developer"
-ensure_project_role "serviceAccount:${RUN_SERVICE_ACCOUNT}" "roles/secretmanager.secretAccessor"
+data = json.load(sys.stdin)
+summary = data.get("image_summary") or data.get("imageSummary") or {}
+value = (
+    summary.get("fully_qualified_digest")
+    or summary.get("fullyQualifiedDigest")
+    or data.get("fully_qualified_digest")
+    or data.get("fullyQualifiedDigest")
+)
+if not isinstance(value, str):
+    raise SystemExit("image metadata omits fully qualified digest")
+print(value)
+')" || {
+  echo "ERROR: synthetic image did not resolve to an immutable digest" >&2
+  exit 1
+}
+[[ "$IMAGE" =~ ^[^,|[:space:]@]+@sha256:[0-9a-f]{64}$ ]] || {
+  echo "ERROR: synthetic image digest is invalid" >&2
+  exit 1
+}
+
+verify_exact_synthetic_job_invoker_policy() {
+  local job_name="$1"
+  local region="$2"
+  local policy_json
+  policy_json="$(gc run jobs get-iam-policy "$job_name" \
+    --region="$region" --format=json)" || return 1
+  if ! printf '%s' "$policy_json" | python3 -c '
+import json
+import sys
+
+policy = json.load(sys.stdin)
+bindings = policy.get("bindings") or []
+if len(bindings) != 1:
+    raise SystemExit("synthetic Job IAM binding inventory differs")
+binding = bindings[0]
+if binding.get("role") != "roles/run.invoker" or binding.get("condition") is not None:
+    raise SystemExit("synthetic Job invoker binding differs")
+if (binding.get("members") or []) != [sys.argv[1]]:
+    raise SystemExit("synthetic Job invoker member inventory differs")
+' "serviceAccount:${SYNTHETIC_RUN_SERVICE_ACCOUNT}"; then
+    echo "ERROR: Cloud Run Job ${region}/${job_name} IAM is not the exact singleton invoker policy" >&2
+    return 1
+  fi
+}
+
+ensure_synthetic_job_invoker() {
+  local job_name="$1"
+  local region="$2"
+  local member="serviceAccount:${SYNTHETIC_RUN_SERVICE_ACCOUNT}"
+  gc run jobs add-iam-policy-binding "$job_name" \
+    --region="$region" \
+    --member="$member" \
+    --role="roles/run.invoker" \
+    --condition=None \
+    --quiet >/dev/null
+  verify_exact_synthetic_job_invoker_policy "$job_name" "$region"
+}
+
+verify_existing_synthetic_job_invoker_or_absent() {
+  local job_name="$1"
+  local region="$2"
+  local describe_error=""
+  if describe_error="$(gc run jobs describe "$job_name" \
+      --region="$region" --format='value(metadata.name)' 2>&1)"; then
+    verify_exact_synthetic_job_invoker_policy "$job_name" "$region"
+    return
+  fi
+  case "$describe_error" in
+    *NOT_FOUND*|*not\ found*|*Not\ Found*|*Cannot\ find*|*could\ not\ be\ found*|*was\ not\ found*)
+      return 0
+      ;;
+    *)
+      echo "ERROR: cannot determine whether Cloud Run job ${region}/${job_name} exists: ${describe_error}" >&2
+      return 1
+      ;;
+  esac
+}
 
 upsert_scheduler() {
   local scheduler_name="$1"
@@ -178,9 +434,18 @@ upsert_scheduler() {
     if ! gc scheduler jobs update http "$scheduler_name" \
       --location "$region" \
       --schedule "$schedule" \
+      --time-zone Etc/UTC \
       --uri "$run_uri" \
       --http-method POST \
-      --oauth-service-account-email "$RUN_SERVICE_ACCOUNT" \
+      --oauth-service-account-email "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
+      --clear-headers \
+      --clear-message-body \
+      --attempt-deadline=300s \
+      --max-retry-attempts=0 \
+      --max-retry-duration=0s \
+      --min-backoff=5s \
+      --max-backoff=60s \
+      --max-doublings=3 \
       --quiet >/dev/null; then
       log "WARN: failed to update synthetic scheduler ${scheduler_name}; leaving existing schedule in place"
       return 1
@@ -190,9 +455,16 @@ upsert_scheduler() {
     if ! gc scheduler jobs create http "$scheduler_name" \
       --location "$region" \
       --schedule "$schedule" \
+      --time-zone Etc/UTC \
       --uri "$run_uri" \
       --http-method POST \
-      --oauth-service-account-email "$RUN_SERVICE_ACCOUNT" \
+      --oauth-service-account-email "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
+      --attempt-deadline=300s \
+      --max-retry-attempts=0 \
+      --max-retry-duration=0s \
+      --min-backoff=5s \
+      --max-backoff=60s \
+      --max-doublings=3 \
       --quiet >/dev/null; then
       log "WARN: failed to create synthetic scheduler ${scheduler_name}; deploy the job exists but is not scheduled"
       return 1
@@ -200,8 +472,7 @@ upsert_scheduler() {
   fi
 }
 
-SYNTHETIC_MONITOR_REGIONS="${TR_SYNTHETIC_MONITOR_REGIONS:-us-central1,europe-west4}"
-IFS=',' read -ra _REGION_LIST <<<"$SYNTHETIC_MONITOR_REGIONS"
+IFS=',' read -ra _REGION_LIST <<<"$TR_SYNTHETIC_MONITOR_REGIONS"
 monitor_index=0
 for monitor_region in "${_REGION_LIST[@]}"; do
   [ -n "$monitor_region" ] || continue
@@ -219,6 +490,7 @@ for monitor_region in "${_REGION_LIST[@]}"; do
     # Cloud Run URL. Otherwise an apex TLS/DNS incident prevents the monitor
     # from recording the very failure it observed.
     "TR_SYNTHETIC_INGEST_URL=${regional_ingest_base}/v1/internal/synthetic/samples"
+    "TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL=${regional_ingest_base}"
     "TR_SYNTHETIC_BENCHMARK_INGEST_URL=${regional_ingest_base}/v1/internal/synthetic/benchmark"
     "TR_SYNTHETIC_ROUTE_HEALTH_URL=${regional_ingest_base}/v1/internal/synthetic/route-health"
     "TR_SYNTHETIC_BILLING_CONCURRENCY=2"
@@ -242,21 +514,27 @@ for monitor_region in "${_REGION_LIST[@]}"; do
 
   ensure_private_run_app_access "$monitor_region"
   verify_synthetic_ingest_service_contract "$monitor_region"
+  verify_synthetic_secret_access
+  verify_existing_synthetic_job_invoker_or_absent "$job_name" "$monitor_region"
   log "deploying synthetic Cloud Run job ${job_name} in ${monitor_region}"
   gc run jobs deploy "$job_name" \
     --region "$monitor_region" \
     --image "$IMAGE" \
     --command="/app/.venv/bin/python" \
     --args="-m,trusted_router.synthetic.cli" \
-    --service-account "$RUN_SERVICE_ACCOUNT" \
+    --service-account "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
     "${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]}" \
     --set-env-vars "$set_env_vars" \
     --set-secrets "$SET_SECRETS" \
+    --tasks 1 \
+    --parallelism 1 \
     --max-retries 0 \
     --task-timeout 300s \
     --cpu 2 \
     --memory 1Gi \
     --quiet >/dev/null
+  verify_synthetic_job_secret_contract "$job_name" "$monitor_region"
+  ensure_synthetic_job_invoker "$job_name" "$monitor_region"
   # CPU 2 + 1Gi mem: the synthetic CLI fans out N probes per pass
   # concurrently via asyncio.gather + httpx. On 1 CPU / 512Mi (the
   # Cloud Run default) the parallel TLS handshakes serialize and
@@ -281,7 +559,7 @@ done
 # Sustained-output benchmark: one deterministic top-200 route per tick. This
 # has a separate Cloud Run Job so a slow 512-token stream cannot delay or
 # overlap TLS, attestation, billing, fallback, or short provider probes.
-throughput_region="us-central1"
+throughput_region="$TR_SYNTHETIC_THROUGHPUT_REGION"
 throughput_ingest_base="https://${SYNTHETIC_INGEST_SERVICE}-${PROJECT_NUMBER}.${throughput_region}.run.app"
 throughput_job_name="trusted-router-throughput-${throughput_region}"
 throughput_scheduler_name="${throughput_job_name}-every-five-minutes"
@@ -293,6 +571,7 @@ throughput_env_vars=(
   "${BASE_ENV_VARS[@]}"
   "TR_SYNTHETIC_MONITOR_REGION=${throughput_region}"
   "TR_SYNTHETIC_INGEST_URL=${throughput_ingest_base}/v1/internal/synthetic/samples"
+  "TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL=${throughput_ingest_base}"
   "TR_SYNTHETIC_BENCHMARK_INGEST_URL=${throughput_ingest_base}/v1/internal/synthetic/benchmark"
   "TR_SYNTHETIC_ROUTE_HEALTH_URL=${throughput_ingest_base}/v1/internal/synthetic/route-health"
   "TR_SYNTHETIC_BILLING_CONCURRENCY=1"
@@ -316,21 +595,28 @@ throughput_set_env_vars="$(IFS='|'; echo "^|^${throughput_env_vars[*]}")"
 
 ensure_private_run_app_access "$throughput_region"
 verify_synthetic_ingest_service_contract "$throughput_region"
+verify_synthetic_secret_access
+verify_existing_synthetic_job_invoker_or_absent \
+  "$throughput_job_name" "$throughput_region"
 log "deploying isolated throughput Cloud Run job ${throughput_job_name}"
 gc run jobs deploy "$throughput_job_name" \
   --region "$throughput_region" \
   --image "$IMAGE" \
   --command="/app/.venv/bin/python" \
   --args="-m,trusted_router.synthetic.cli" \
-  --service-account "$RUN_SERVICE_ACCOUNT" \
+  --service-account "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
   "${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]}" \
   --set-env-vars "$throughput_set_env_vars" \
   --set-secrets "$SET_SECRETS" \
+  --tasks 1 \
+  --parallelism 1 \
   --max-retries 0 \
   --task-timeout 300s \
   --cpu 1 \
   --memory 1Gi \
   --quiet >/dev/null
+verify_synthetic_job_secret_contract "$throughput_job_name" "$throughput_region"
+ensure_synthetic_job_invoker "$throughput_job_name" "$throughput_region"
 
 upsert_scheduler \
   "$throughput_scheduler_name" \
@@ -354,7 +640,7 @@ done
 
 # Image generation is materially more expensive than text PONG probes. Keep it
 # isolated and run one canonical end-to-end request every six hours.
-image_region="us-central1"
+image_region="$TR_SYNTHETIC_IMAGE_REGION"
 image_ingest_base="https://${SYNTHETIC_INGEST_SERVICE}-${PROJECT_NUMBER}.${image_region}.run.app"
 image_job_name="trusted-router-image-generation-${image_region}"
 image_scheduler_name="${image_job_name}-every-six-hours"
@@ -362,6 +648,7 @@ image_env_vars=(
   "${BASE_ENV_VARS[@]}"
   "TR_SYNTHETIC_MONITOR_REGION=${image_region}"
   "TR_SYNTHETIC_INGEST_URL=${image_ingest_base}/v1/internal/synthetic/samples"
+  "TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL=${image_ingest_base}"
   "TR_SYNTHETIC_IMAGE_MODEL=google/gemini-3.1-flash-image-preview"
   "TR_SYNTHETIC_IMAGE_PROVIDER=google-ai-studio"
   "TR_SYNTHETIC_IMAGE_TIMEOUT_SECONDS=120"
@@ -371,21 +658,27 @@ image_set_env_vars="$(IFS='|'; echo "^|^${image_env_vars[*]}")"
 
 ensure_private_run_app_access "$image_region"
 verify_synthetic_ingest_service_contract "$image_region"
+verify_synthetic_secret_access
+verify_existing_synthetic_job_invoker_or_absent "$image_job_name" "$image_region"
 log "deploying isolated image-generation Cloud Run job ${image_job_name}"
 gc run jobs deploy "$image_job_name" \
   --region "$image_region" \
   --image "$IMAGE" \
   --command="/app/.venv/bin/python" \
   --args="-m,trusted_router.synthetic.image_generation" \
-  --service-account "$RUN_SERVICE_ACCOUNT" \
+  --service-account "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
   "${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]}" \
   --set-env-vars "$image_set_env_vars" \
   --set-secrets "$SET_SECRETS" \
+  --tasks 1 \
+  --parallelism 1 \
   --max-retries 0 \
   --task-timeout 300s \
   --cpu 1 \
   --memory 512Mi \
   --quiet >/dev/null
+verify_synthetic_job_secret_contract "$image_job_name" "$image_region"
+ensure_synthetic_job_invoker "$image_job_name" "$image_region"
 
 upsert_scheduler \
   "$image_scheduler_name" \
@@ -398,7 +691,7 @@ upsert_scheduler \
 # The current seven-day total is $2.499276 including TrustedRouter's 20% fee,
 # or about $10.71 per 30 days. max-retries=0 plus a date-scoped idempotency key
 # prevents duplicate billing.
-video_region="us-central1"
+video_region="$TR_SYNTHETIC_VIDEO_REGION"
 video_ingest_base="https://${SYNTHETIC_INGEST_SERVICE}-${PROJECT_NUMBER}.${video_region}.run.app"
 video_job_name="trusted-router-video-generation-${video_region}"
 video_scheduler_name="${video_job_name}-daily"
@@ -406,6 +699,7 @@ video_env_vars=(
   "${BASE_ENV_VARS[@]}"
   "TR_SYNTHETIC_MONITOR_REGION=${video_region}"
   "TR_SYNTHETIC_INGEST_URL=${video_ingest_base}/v1/internal/synthetic/samples"
+  "TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL=${video_ingest_base}"
   "TR_SYNTHETIC_VIDEO_TIMEOUT_SECONDS=900"
   "TR_SYNTHETIC_VIDEO_POLL_INTERVAL_SECONDS=5"
 )
@@ -413,21 +707,27 @@ video_set_env_vars="$(IFS='|'; echo "^|^${video_env_vars[*]}")"
 
 ensure_private_run_app_access "$video_region"
 verify_synthetic_ingest_service_contract "$video_region"
+verify_synthetic_secret_access
+verify_existing_synthetic_job_invoker_or_absent "$video_job_name" "$video_region"
 log "deploying isolated daily video-generation Cloud Run job ${video_job_name}"
 gc run jobs deploy "$video_job_name" \
   --region "$video_region" \
   --image "$IMAGE" \
   --command="/app/.venv/bin/python" \
   --args="-m,trusted_router.synthetic.video_generation" \
-  --service-account "$RUN_SERVICE_ACCOUNT" \
+  --service-account "$SYNTHETIC_RUN_SERVICE_ACCOUNT" \
   "${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]}" \
   --set-env-vars "$video_set_env_vars" \
   --set-secrets "$SET_SECRETS" \
+  --tasks 1 \
+  --parallelism 1 \
   --max-retries 0 \
   --task-timeout 1200s \
   --cpu 1 \
   --memory 512Mi \
   --quiet >/dev/null
+verify_synthetic_job_secret_contract "$video_job_name" "$video_region"
+ensure_synthetic_job_invoker "$video_job_name" "$video_region"
 
 upsert_scheduler \
   "$video_scheduler_name" \

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import sys
+import warnings
 from pathlib import Path
 from typing import Any, Literal, NamedTuple
 from urllib.parse import urlsplit
@@ -220,55 +221,69 @@ def _comma_set(raw: str, *, primary: str | None = None) -> tuple[str, ...]:
 # adding a credential requires naming every process allowed to receive it.
 SERVICE_SURFACE_SECRET_OWNERS: dict[str, frozenset[str]] = {
     "ops_chat_webhook_secret": frozenset({"actions"}),
-    "postgres_dsn": frozenset({"public", "control", "internal", "observer"}),
-    "postgres_iam_auth": frozenset({"public", "control", "internal", "observer"}),
-    "clickhouse_url": frozenset({"control", "internal"}),
-    "clickhouse_password": frozenset({"control", "internal"}),
-    "provider_analytics_clickhouse_url": frozenset({"control"}),
-    "provider_analytics_clickhouse_password": frozenset({"control"}),
+    "postgres_dsn": frozenset(
+        {"public", "console", "chat", "webhooks", "internal", "observer"}
+    ),
+    "postgres_iam_auth": frozenset(
+        {"public", "console", "chat", "webhooks", "internal", "observer"}
+    ),
+    "clickhouse_url": frozenset({"console", "internal"}),
+    "clickhouse_password": frozenset({"console", "internal"}),
+    "provider_analytics_clickhouse_url": frozenset({"console"}),
+    "provider_analytics_clickhouse_password": frozenset({"console"}),
     "operational_analytics_clickhouse_url": frozenset(
-        {"public", "control", "internal", "observer"}
+        {"public", "console", "internal", "observer"}
     ),
     "operational_analytics_clickhouse_password": frozenset(
-        {"public", "control", "internal", "observer"}
+        {"public", "console", "internal", "observer"}
     ),
-    "sentry_dsn": frozenset({"control", "internal", "observer"}),
-    "google_data_manager_enabled": frozenset({"control"}),
-    "google_data_manager_kms_key_name": frozenset({"control"}),
-    "attribution_cookie_secret": frozenset({"public", "control"}),
+    "sentry_dsn": frozenset({"console", "chat", "webhooks", "internal", "observer"}),
+    "google_data_manager_enabled": frozenset({"console"}),
+    "google_data_manager_kms_key_name": frozenset({"console"}),
+    "attribution_cookie_secret": frozenset({"public", "console"}),
     "internal_gateway_token": frozenset({"internal"}),
     # Internal owns this only for synthetic/Sentry routes; its billing routes
     # still select internal_gateway_token by path.
     "observer_internal_token": frozenset({"internal", "observer"}),
-    "stripe_webhook_secret": frozenset({"control"}),
-    "stripe_secret_key": frozenset({"control"}),
-    "paypal_client_id": frozenset({"control"}),
-    "paypal_client_secret": frozenset({"control"}),
-    "paypal_webhook_id": frozenset({"control"}),
-    "adyen_enabled": frozenset({"control"}),
-    "adyen_api_key": frozenset({"control"}),
-    "adyen_client_key": frozenset({"control"}),
-    "adyen_hmac_key": frozenset({"control"}),
-    "adyen_reference_key": frozenset({"control"}),
-    "byok_kms_key_name": frozenset({"control", "internal"}),
-    "byok_envelope_key_b64": frozenset({"control", "internal"}),
-    "google_client_id": frozenset({"control"}),
-    "google_client_secret": frozenset({"control"}),
-    "google_alias_credentials_json": frozenset({"control"}),
-    "github_client_id": frozenset({"control"}),
-    "github_client_secret": frozenset({"control"}),
-    "github_alias_credentials_json": frozenset({"control"}),
-    "x402_enabled": frozenset({"control"}),
-    "notify_enabled": frozenset({"control"}),
-    "veriff_enabled": frozenset({"control"}),
-    "veriff_api_key": frozenset({"control"}),
-    "veriff_shared_secret_key": frozenset({"control"}),
-    "telnyx_api_key": frozenset({"control"}),
-    "twilio_account_sid": frozenset({"control"}),
-    "twilio_auth_token": frozenset({"control"}),
-    "twilio_api_key_secret": frozenset({"control"}),
-    "aws_access_key_id": frozenset({"control", "actions"}),
-    "aws_secret_access_key": frozenset({"control", "actions"}),
+    "stripe_webhook_secret": frozenset({"webhooks"}),
+    # Console uses its checkout credential; internal receives a distinct,
+    # provider-restricted PaymentIntent credential for settlement auto-refill.
+    "stripe_secret_key": frozenset({"console", "internal"}),
+    # PayPal verifies callbacks through its API, so the receiver needs the
+    # OAuth client pair as well as its webhook id.  The console needs only the
+    # client pair for checkout/capture.
+    "paypal_checkout_enabled": frozenset({"console", "webhooks"}),
+    "paypal_client_id": frozenset({"console", "webhooks"}),
+    "paypal_client_secret": frozenset({"console", "webhooks"}),
+    "paypal_webhook_id": frozenset({"webhooks"}),
+    "adyen_enabled": frozenset({"console", "webhooks"}),
+    "adyen_api_key": frozenset({"console"}),
+    "adyen_client_key": frozenset({"console"}),
+    "adyen_hmac_key": frozenset({"webhooks"}),
+    # The console signs the opaque merchant reference; the webhook service
+    # verifies it before crediting the ledger.
+    "adyen_reference_key": frozenset({"console", "webhooks"}),
+    "byok_kms_key_name": frozenset({"console", "internal"}),
+    "byok_envelope_key_b64": frozenset({"console", "internal"}),
+    "google_client_id": frozenset({"console"}),
+    "google_client_secret": frozenset({"console"}),
+    "google_alias_credentials_json": frozenset({"console"}),
+    "github_client_id": frozenset({"console"}),
+    "github_client_secret": frozenset({"console"}),
+    "github_alias_credentials_json": frozenset({"console"}),
+    "x402_enabled": frozenset({"console"}),
+    "notify_enabled": frozenset({"console"}),
+    "veriff_enabled": frozenset({"console", "webhooks"}),
+    "veriff_api_key": frozenset({"console"}),
+    "veriff_shared_secret_key": frozenset({"webhooks"}),
+    "telnyx_api_key": frozenset({"console"}),
+    "twilio_account_sid": frozenset({"console"}),
+    "twilio_auth_token": frozenset({"console"}),
+    "twilio_api_key_secret": frozenset({"console"}),
+    # Each surface receives an independently provisioned SES send-only
+    # credential.  Internal needs it for post-settlement budget alerts.
+    "aws_access_key_id": frozenset({"console", "actions", "internal"}),
+    "aws_secret_access_key": frozenset({"console", "actions", "internal"}),
     "synthetic_monitor_api_key": frozenset({"internal", "observer"}),
     "federation_peer_token": frozenset({"internal"}),
     "federation_home_token": frozenset({"internal"}),
@@ -305,7 +320,10 @@ class Settings(BaseSettings):
         "combined",
         "public",
         "actions",
+        "console",
         "control",
+        "chat",
+        "webhooks",
         "internal",
         "observer",
     ] = "combined"
@@ -535,7 +553,7 @@ class Settings(BaseSettings):
     # on the safe default and aggregate into the untrusted_lb bucket.
     rate_limit_client_ip_mode: str = "untrusted"
 
-    # Shared only by the anonymous public surface and the account/control
+    # Shared only by the anonymous public surface and the account/console
     # surface so an attribution cookie survives the LB hand-off between them.
     # This must never reuse the internal gateway credential: compromise of the
     # public renderer must not disclose a token accepted by billing routes.
@@ -563,6 +581,10 @@ class Settings(BaseSettings):
     paypal_client_id: str | None = None
     paypal_client_secret: str | None = None
     paypal_webhook_id: str | None = None
+    # Explicit paired-surface capability bit. Deployed console and webhooks
+    # revisions must both receive the same true/false value before URL-map
+    # promotion; credentials alone never turn checkout on in production.
+    paypal_checkout_enabled: bool | None = None
     paypal_api_base_url: str = "https://api-m.paypal.com"
     # Adyen is staged dark until the test merchant, HMAC webhook, and end-to-end
     # checkout canary are all green. Keep checkout enablement separate from
@@ -600,10 +622,10 @@ class Settings(BaseSettings):
     google_client_secret: str | None = None
     google_oauth_redirect_url: str | None = None
     # The public service must render login links without receiving the OAuth
-    # client secrets owned by the control service. These are deliberately
+    # client secrets owned by the console service. These are deliberately
     # non-secret presentation flags, set from the same rollout manifest that
-    # configures the control service. ``None`` is rejected on a deployed public
-    # surface so a split rollout cannot silently remove a login method.
+    # configures the console service. ``None`` is rejected on both deployed
+    # surfaces so a split rollout cannot silently remove a login method.
     google_oauth_login_available: bool | None = None
     # Backup domains use independent provider credentials so login remains
     # available even if the canonical domain or its OAuth app is unavailable.
@@ -967,10 +989,11 @@ class Settings(BaseSettings):
     # status page reads as "we are not sure our own service works".
     # Defaults True (the GCP shape); standalone deployments set it False.
     synthetic_image_probe_enabled: bool = True
-    # Explicit control-plane /health URL attached to the canonical
-    # target. Standalone deployments set this to their own control plane
-    # (e.g. the App Runner URL) so control_plane_health measures the
-    # RIGHT cloud; on GCP the per-region Cloud Run URLs already cover it.
+    # Explicit private regional billing-origin /health URL attached to the
+    # canonical target. It must never be auto-derived from the legacy public
+    # run.app URL. Standalone deployments set this to their own control plane
+    # (e.g. the App Runner URL) so control_plane_health measures the RIGHT
+    # cloud; on GCP it names the private regional billing origin.
     synthetic_control_plane_health_url: str | None = None
     # Extra gateway targets that share the canonical hostname but are
     # addressed at a SPECIFIC TCP endpoint: "name=connect_host,..." (e.g.
@@ -1070,6 +1093,14 @@ class Settings(BaseSettings):
     @model_validator(mode="after")
     def production_is_fail_closed(self) -> Settings:
         environment = self.environment.lower()
+        if self.service_surface == "control":
+            warnings.warn(
+                "TR_SERVICE_SURFACE=control is deprecated; use console",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self.service_surface = "console"
+        surface = self.service_surface
         if self.synthetic_control_plane_base_url:
             parsed_control_plane = urlsplit(self.synthetic_control_plane_base_url)
             if (
@@ -1326,14 +1357,17 @@ class Settings(BaseSettings):
         if self.identity_session_stale_after_days <= 0:
             raise ValueError("TR_IDENTITY_SESSION_STALE_AFTER_DAYS must be positive")
         if self.veriff_enabled and environment not in {"local", "test"}:
-            missing_veriff = [
-                name
-                for name, value in (
+            required_veriff = (
+                (("TR_VERIFF_API_KEY", self.veriff_api_key),)
+                if surface == "console"
+                else (("TR_VERIFF_SHARED_SECRET_KEY", self.veriff_shared_secret_key),)
+                if surface == "webhooks"
+                else (
                     ("TR_VERIFF_API_KEY", self.veriff_api_key),
                     ("TR_VERIFF_SHARED_SECRET_KEY", self.veriff_shared_secret_key),
                 )
-                if not value
-            ]
+            )
+            missing_veriff = [name for name, value in required_veriff if not value]
             if missing_veriff:
                 raise ValueError("TR_VERIFF_ENABLED requires " + ", ".join(missing_veriff))
         if self.adyen_environment not in {"test", "live"}:
@@ -1356,46 +1390,67 @@ class Settings(BaseSettings):
         if self.adyen_reference_key and len(self.adyen_reference_key.encode("utf-8")) < 32:
             raise ValueError("TR_ADYEN_REFERENCE_KEY must be at least 32 bytes")
         if self.adyen_enabled:
-            missing_adyen = [
-                name
-                for name, value in (
+            required_adyen = (
+                (
+                    ("TR_ADYEN_API_KEY", self.adyen_api_key),
+                    ("TR_ADYEN_CLIENT_KEY", self.adyen_client_key),
+                    ("TR_ADYEN_REFERENCE_KEY", self.adyen_reference_key),
+                    ("TR_ADYEN_MERCHANT_ACCOUNT", self.adyen_merchant_account),
+                )
+                if surface == "console"
+                else (
+                    ("TR_ADYEN_HMAC_KEY", self.adyen_hmac_key),
+                    ("TR_ADYEN_REFERENCE_KEY", self.adyen_reference_key),
+                    ("TR_ADYEN_MERCHANT_ACCOUNT", self.adyen_merchant_account),
+                )
+                if surface == "webhooks"
+                else (
                     ("TR_ADYEN_API_KEY", self.adyen_api_key),
                     ("TR_ADYEN_CLIENT_KEY", self.adyen_client_key),
                     ("TR_ADYEN_HMAC_KEY", self.adyen_hmac_key),
                     ("TR_ADYEN_REFERENCE_KEY", self.adyen_reference_key),
                     ("TR_ADYEN_MERCHANT_ACCOUNT", self.adyen_merchant_account),
                 )
-                if not value
-            ]
-            if self.adyen_environment == "live" and not self.adyen_live_endpoint_prefix:
+            )
+            missing_adyen = [name for name, value in required_adyen if not value]
+            if (
+                surface in {"combined", "console"}
+                and self.adyen_environment == "live"
+                and not self.adyen_live_endpoint_prefix
+            ):
                 missing_adyen.append("TR_ADYEN_LIVE_ENDPOINT_PREFIX")
             if missing_adyen:
                 raise ValueError("TR_ADYEN_ENABLED requires " + ", ".join(missing_adyen))
         if (
             self.x402_enabled
             and environment not in {"local", "test"}
-            and (not self.stripe_secret_key or not self.stripe_webhook_secret)
         ):
-            raise ValueError(
-                "TR_X402_ENABLED requires TR_STRIPE_SECRET_KEY and "
-                "TR_STRIPE_WEBHOOK_SECRET outside local/test"
-            )
+            if surface == "console" and not self.stripe_secret_key:
+                raise ValueError(
+                    "TR_X402_ENABLED requires TR_STRIPE_SECRET_KEY outside local/test"
+                )
+            if surface == "combined" and (
+                not self.stripe_secret_key or not self.stripe_webhook_secret
+            ):
+                raise ValueError(
+                    "TR_X402_ENABLED requires TR_STRIPE_SECRET_KEY and "
+                    "TR_STRIPE_WEBHOOK_SECRET outside local/test"
+                )
         if environment in {"local", "test"}:
             return self
         production = environment == "production"
         missing = []
-        surface = self.service_surface
-        if environment != "worker" and surface in {"control", "public"}:
+        if environment != "worker" and surface in {"console", "public"}:
             if not self.attribution_cookie_secret:
                 missing.append("TR_ATTRIBUTION_COOKIE_SECRET")
             elif len(self.attribution_cookie_secret.encode("utf-8")) < 32:
                 missing.append("TR_ATTRIBUTION_COOKIE_SECRET (at least 32 bytes)")
-        if environment != "worker" and surface == "public":
+        if environment != "worker" and surface in {"public", "console"}:
             if self.google_oauth_login_available is None:
-                missing.append("TR_GOOGLE_OAUTH_LOGIN_AVAILABLE")
+                missing.append("TR_GOOGLE_OAUTH_LOGIN_AVAILABLE=true or false")
             if self.github_oauth_login_available is None:
-                missing.append("TR_GITHUB_OAUTH_LOGIN_AVAILABLE")
-        if environment != "worker" and surface == "control":
+                missing.append("TR_GITHUB_OAUTH_LOGIN_AVAILABLE=true or false")
+        if environment != "worker" and surface == "console":
             for provider, advertised, configured in (
                 (
                     "GOOGLE",
@@ -1410,7 +1465,7 @@ class Settings(BaseSettings):
             ):
                 if advertised is not None and advertised != configured:
                     missing.append(
-                        f"TR_{provider}_OAUTH_LOGIN_AVAILABLE must match the control "
+                        f"TR_{provider}_OAUTH_LOGIN_AVAILABLE must match the console "
                         f"service's {provider} OAuth credential capability"
                     )
         if (
@@ -1452,28 +1507,48 @@ class Settings(BaseSettings):
         # rejects it before any deployed server starts, so do not let missing
         # credentials mask that clearer ownership error here.
         gateway_surfaces = {"internal"}
-        sentry_surfaces = {"combined", "control", "internal", "observer"}
-        account_surfaces = {"combined", "control"}
-        email_surfaces = {"combined", "control", "actions"}
+        sentry_surfaces = {
+            "combined",
+            "console",
+            "chat",
+            "webhooks",
+            "internal",
+            "observer",
+        }
+        account_surfaces = {"combined", "console"}
+        email_surfaces = {"combined", "console", "actions", "internal"}
         if surface in gateway_surfaces and not self.internal_gateway_token:
             missing.append("TR_INTERNAL_GATEWAY_TOKEN")
         if surface in {"internal", "observer"} and not self.observer_internal_token:
             missing.append("TR_OBSERVER_INTERNAL_TOKEN")
-        if surface == "control" and environment != "worker":
-            if not self.stripe_webhook_secret:
-                missing.append("TR_STRIPE_WEBHOOK_SECRET")
+        if surface in {"console", "internal"} and environment != "worker":
             if not self.stripe_secret_key:
                 missing.append("TR_STRIPE_SECRET_KEY")
-        paypal_fields = [
-            self.paypal_client_id,
-            self.paypal_client_secret,
-            self.paypal_webhook_id,
-        ]
-        if any(paypal_fields) and not all(paypal_fields):
+        if surface == "webhooks" and environment != "worker":
+            if not self.stripe_webhook_secret:
+                missing.append("TR_STRIPE_WEBHOOK_SECRET")
+        if surface in {"console", "webhooks"} and self.paypal_checkout_enabled is None:
+            missing.append("TR_PAYPAL_CHECKOUT_ENABLED=true or false")
+        paypal_client_fields = [self.paypal_client_id, self.paypal_client_secret]
+        if any(paypal_client_fields) and not all(paypal_client_fields):
+            missing.append(
+                "TR_PAYPAL_CLIENT_ID and TR_PAYPAL_CLIENT_SECRET must both be set or both unset"
+            )
+        if surface == "webhooks" and any(
+            (*paypal_client_fields, self.paypal_webhook_id)
+        ) and not all((*paypal_client_fields, self.paypal_webhook_id)):
             missing.append(
                 "TR_PAYPAL_CLIENT_ID, TR_PAYPAL_CLIENT_SECRET, and "
-                "TR_PAYPAL_WEBHOOK_ID must all be set or all unset"
+                "TR_PAYPAL_WEBHOOK_ID must all be set on the webhooks surface or all unset"
             )
+        if self.paypal_checkout_enabled:
+            required_paypal = [*paypal_client_fields]
+            if surface == "webhooks":
+                required_paypal.append(self.paypal_webhook_id)
+            if not all(required_paypal):
+                missing.append(
+                    "TR_PAYPAL_CHECKOUT_ENABLED=true requires the surface's PayPal credentials"
+                )
         if production:
             if surface in sentry_surfaces and not self.sentry_dsn:
                 missing.append("TR_SENTRY_DSN")
@@ -1529,7 +1604,14 @@ class Settings(BaseSettings):
                 missing.append("TR_BIGTABLE_MIRROR_WRITES_ENABLED=false")
             if self.request_record_write_mode != "typed":
                 missing.append("TR_REQUEST_RECORD_WRITE_MODE=typed")
-        if storage_required and self.analytics_read_mode != "bigtable":
+        analytics_reader_surfaces = {
+            "combined",
+            "public",
+            "console",
+            "internal",
+            "observer",
+        }
+        if surface in analytics_reader_surfaces and self.analytics_read_mode != "bigtable":
             if not self.operational_analytics_clickhouse_url:
                 missing.append("TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_URL")
             if not self.operational_analytics_clickhouse_password:
@@ -1684,8 +1766,29 @@ class Settings(BaseSettings):
         )
 
     @property
+    def paypal_checkout_ready(self) -> bool:
+        credentials_ready = bool(self.paypal_client_id and self.paypal_client_secret)
+        if self.paypal_checkout_enabled is not None:
+            return self.paypal_checkout_enabled and credentials_ready
+        # Preserve the local/test composite developer experience. Deployed
+        # surfaces reject an unspecified capability bit during validation.
+        return self.environment.lower() in {"local", "test"} and credentials_ready
+
+    @property
+    def paypal_webhook_ready(self) -> bool:
+        # Deliberately independent of the checkout capability bit: signed
+        # callbacks already in flight must still settle after new checkout is
+        # disabled.
+        return bool(
+            self.paypal_client_id
+            and self.paypal_client_secret
+            and self.paypal_webhook_id
+        )
+
+    @property
     def paypal_enabled(self) -> bool:
-        return bool(self.paypal_client_id and self.paypal_client_secret)
+        """Compatibility presentation alias for checkout readiness."""
+        return self.paypal_checkout_ready
 
     @property
     def phone_verification_funding_enforced(self) -> bool:
@@ -1701,7 +1804,10 @@ class Settings(BaseSettings):
 
     @property
     def veriff_configured(self) -> bool:
-        return bool(self.veriff_api_key and self.veriff_shared_secret_key)
+        # Session creation and callback verification live in different
+        # processes. The console needs only the API credential; the webhooks
+        # service checks its signature secret in the receiver itself.
+        return bool(self.veriff_api_key)
 
     @property
     def adyen_checkout_ready(self) -> bool:
@@ -1709,7 +1815,6 @@ class Settings(BaseSettings):
             self.adyen_enabled
             and self.adyen_api_key
             and self.adyen_client_key
-            and self.adyen_hmac_key
             and self.adyen_reference_key
             and self.adyen_merchant_account
             and (self.adyen_environment == "test" or self.adyen_live_endpoint_prefix)

--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -57,7 +57,7 @@ from trusted_router.routes.email_verify import register_email_verify_routes
 from trusted_router.routes.identity_verify import register_identity_verify_routes
 from trusted_router.routes.inference import register_inference_routes
 from trusted_router.routes.internal import (
-    register_control_internal_routes,
+    register_console_internal_routes,
     register_external_webhook_routes,
     register_gateway_internal_routes,
     register_internal_routes,
@@ -102,7 +102,8 @@ def create_app(
     if surface == "combined" and settings.environment.lower() not in {"local", "test"}:
         raise ValueError(
             "TR_SERVICE_SURFACE=combined is restricted to local/test; deploy an explicit "
-            "public, actions, control, internal, or observer service surface"
+            "public, actions, console, chat, webhooks, internal, or observer "
+            "service surface"
         )
     validate_auto_model_order(settings.auto_model_order)
     if configure_store_arg:
@@ -177,7 +178,7 @@ def create_app(
             threading.Thread(target=loop, name="home-settlement", daemon=True).start()
 
     if (
-        surface in {"combined", "control"}
+        surface in {"combined", "console"}
         and settings.activation_reminder_interval_seconds > 0
     ):
 
@@ -382,20 +383,21 @@ def create_app(
         register_bedrock_group_buy_public_routes(app, settings)
     if surface in {"combined", "actions"}:
         register_public_action_routes(app, settings)
-    if surface in {"combined", "control"}:
+    if surface in {"combined", "console"}:
         register_bedrock_group_buy_control_routes(app, settings)
     api = _make_api_router(settings, surface)
-    if surface in {"combined", "control"}:
+    if surface in {"combined", "console"}:
         register_oauth_routes(app, api)
         register_console_routes(app)
         register_provider_portal_routes(app)
         register_mcp_routes(app, settings)
+    if surface in {"combined", "chat"}:
         # Same-origin streaming pipe for the authenticated chat playground.
         # It is deliberately absent from anonymous and billing processes.
         register_chat_proxy_routes(app)
     app.include_router(api)
     app.include_router(api, prefix="/v1")
-    if surface in {"combined", "control"}:
+    if surface in {"combined", "console"}:
         versioned_compat = APIRouter()
         register_versioned_compat_stub_routes(versioned_compat)
         app.include_router(versioned_compat, prefix="/v1")
@@ -513,7 +515,7 @@ def _make_api_router(settings: Settings, surface: str) -> APIRouter:
         # into 500s (or widening the observer database role).
         register_user_model_public_routes(router)
 
-    if surface in {"combined", "control"}:
+    if surface in {"combined", "console"}:
         register_authenticated_catalog_routes(router)
         register_auth_routes(router)
         register_byok_routes(router)
@@ -526,7 +528,7 @@ def _make_api_router(settings: Settings, surface: str) -> APIRouter:
         register_activity_routes(router)
         register_client_events_routes(router)
         register_workspace_routes(router)
-        if _control_plane_inference_enabled(settings):
+        if _console_inference_enabled(settings):
             register_inference_routes(inference_router)
             router.include_router(inference_router)
         register_compat_stub_routes(router)
@@ -536,13 +538,16 @@ def _make_api_router(settings: Settings, surface: str) -> APIRouter:
         register_identity_verify_routes(router)
         register_notify_routes(router)
         register_wallet_oauth_routes(router)
+
+    if surface in {"combined", "webhooks"}:
         register_ses_notification_routes(router, settings)
 
     if surface == "combined":
         register_internal_routes(router)
-    elif surface == "control":
+    elif surface == "console":
+        register_console_internal_routes(router)
+    elif surface == "webhooks":
         register_external_webhook_routes(router)
-        register_control_internal_routes(router)
     elif surface == "internal":
         register_gateway_internal_routes(router)
         register_observer_internal_routes(router)
@@ -551,8 +556,8 @@ def _make_api_router(settings: Settings, surface: str) -> APIRouter:
     return router
 
 
-def _control_plane_inference_enabled(settings: Settings) -> bool:
-    """Inference handlers run in the *control plane* only in local/test
+def _console_inference_enabled(settings: Settings) -> bool:
+    """Inference handlers run in the *console service* only in local/test
     environments — production inference goes through the attested
     enclave (api.trustedrouter.com) and never touches this service. This
     gate keeps the local dev loop fast (no enclave dependency) while

--- a/src/trusted_router/public_user_models.py
+++ b/src/trusted_router/public_user_models.py
@@ -1,0 +1,297 @@
+"""Bounded, process-local cache for anonymous user-model reads.
+
+The public service is intentionally a separate DDoS bulkhead, but these reads
+still reach the shared operational database.  Keep both the database work and
+the process memory bounded, coalesce concurrent misses, and retain a short
+stale value when the backing store is unavailable.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from collections import OrderedDict, deque
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, TypeVar
+
+from trusted_router.serialization import user_model_public_shape
+from trusted_router.storage_custom_models import (
+    CUSTOM_MODEL_PREFIX,
+    CUSTOM_MODEL_SLUG_PATTERN,
+    normalize_custom_model_id,
+)
+from trusted_router.storage_models import UserProvidedModel
+
+PUBLIC_USER_MODEL_LIST_LIMIT = 100
+PUBLIC_USER_MODEL_LIST_MAX_BYTES = 256 * 1024
+PUBLIC_USER_MODEL_DETAIL_CACHE_MAX_KEYS = 256
+PUBLIC_USER_MODEL_FRESH_SECONDS = 30.0
+PUBLIC_USER_MODEL_NEGATIVE_SECONDS = 15.0
+PUBLIC_USER_MODEL_STALE_SECONDS = 300.0
+PUBLIC_USER_MODEL_FAILURE_BACKOFF_SECONDS = 2.0
+PUBLIC_USER_MODEL_MAX_CONCURRENT_MISSES = 4
+PUBLIC_USER_MODEL_MISS_BUDGET = 32
+PUBLIC_USER_MODEL_MISS_WINDOW_SECONDS = 30.0
+PUBLIC_USER_MODEL_CACHE_CONTROL = (
+    "public, max-age=15, s-maxage=30, stale-while-revalidate=300"
+)
+
+_T = TypeVar("_T")
+
+
+@dataclass(frozen=True)
+class _Entry:
+    value: Any
+    fresh_until: float
+    stale_until: float
+
+
+_CONDITION = threading.Condition(threading.RLock())
+_LIST_CACHE: dict[str | None, _Entry] = {}
+_DETAIL_CACHE: OrderedDict[str, _Entry] = OrderedDict()
+_LOADING: set[tuple[str, str | None]] = set()
+_DETAIL_MISS_TIMES: deque[float] = deque()
+_ACTIVE_DETAIL_MISSES = 0
+_FAILED = object()
+
+
+class PublicUserModelReadLimited(RuntimeError):
+    """The process-wide anonymous Store-read budget is exhausted."""
+
+
+class PublicUserModelUnavailable(RuntimeError):
+    """The backing Store failed recently; retry after a short backoff."""
+
+
+def reset_public_user_model_cache() -> None:
+    """Clear process-local state when tests or the app swap Store backends."""
+
+    global _ACTIVE_DETAIL_MISSES
+    with _CONDITION:
+        _LIST_CACHE.clear()
+        _DETAIL_CACHE.clear()
+        _LOADING.clear()
+        _DETAIL_MISS_TIMES.clear()
+        _ACTIVE_DETAIL_MISSES = 0
+        _CONDITION.notify_all()
+
+
+def normalized_public_user_model_id(model_id: str) -> str | None:
+    """Return a canonical user-model id only for the persisted id grammar."""
+
+    normalized = normalize_custom_model_id(model_id)
+    if not normalized.startswith(CUSTOM_MODEL_PREFIX):
+        return None
+    slug = normalized.removeprefix(CUSTOM_MODEL_PREFIX)
+    if not CUSTOM_MODEL_SLUG_PATTERN.fullmatch(slug):
+        return None
+    return normalized
+
+
+def cached_public_user_model_list(
+    kind: str | None,
+    loader: Callable[[int], list[UserProvidedModel]],
+) -> list[dict[str, Any]]:
+    """Return a row- and byte-bounded public list through singleflight."""
+
+    cache_key = ("list", kind)
+
+    def load() -> list[dict[str, Any]]:
+        models = loader(PUBLIC_USER_MODEL_LIST_LIMIT)
+        return _bounded_public_shapes(models[:PUBLIC_USER_MODEL_LIST_LIMIT])
+
+    return _cached_value(
+        cache_key,
+        cache=_LIST_CACHE,
+        item_key=kind,
+        loader=load,
+        max_entries=4,
+        admit_detail_miss=False,
+    )
+
+
+def cached_public_user_model(
+    model_id: str,
+    loader: Callable[[], UserProvidedModel | None],
+) -> dict[str, Any] | None:
+    """Return one public shape, including bounded negative-result caching."""
+
+    cache_key = ("detail", model_id)
+
+    def load() -> dict[str, Any] | None:
+        model = loader()
+        if model is None or not model.enabled or model.status != "active":
+            return None
+        return user_model_public_shape(model)
+
+    return _cached_value(
+        cache_key,
+        cache=_DETAIL_CACHE,
+        item_key=model_id,
+        loader=load,
+        max_entries=PUBLIC_USER_MODEL_DETAIL_CACHE_MAX_KEYS,
+        admit_detail_miss=True,
+    )
+
+
+def _cached_value(
+    cache_key: tuple[str, str | None],
+    *,
+    cache: dict[_T, _Entry] | OrderedDict[_T, _Entry],
+    item_key: _T,
+    loader: Callable[[], Any],
+    max_entries: int,
+    admit_detail_miss: bool,
+) -> Any:
+    now = time.monotonic()
+    stale: _Entry | None = None
+    with _CONDITION:
+        entry = cache.get(item_key)
+        if entry is not None and now < entry.fresh_until:
+            _touch(cache, item_key)
+            return _entry_value(entry)
+        if entry is not None and now < entry.stale_until:
+            stale = entry
+        if cache_key in _LOADING:
+            if stale is not None:
+                _touch(cache, item_key)
+                return _entry_value(stale)
+            while cache_key in _LOADING:
+                _CONDITION.wait()
+            entry = cache.get(item_key)
+            if entry is not None and time.monotonic() < entry.stale_until:
+                _touch(cache, item_key)
+                return _entry_value(entry)
+        _LOADING.add(cache_key)
+
+        if admit_detail_miss and not _admit_detail_miss(now):
+            if stale is not None:
+                _LOADING.discard(cache_key)
+                _touch(cache, item_key)
+                _CONDITION.notify_all()
+                return _entry_value(stale)
+            _store_failure(cache, item_key, max_entries=max_entries, now=now)
+            _LOADING.discard(cache_key)
+            _CONDITION.notify_all()
+            raise PublicUserModelReadLimited
+
+    try:
+        value = loader()
+    except Exception as exc:
+        with _CONDITION:
+            if admit_detail_miss:
+                _release_detail_miss()
+            _LOADING.discard(cache_key)
+            if stale is None:
+                _store_failure(
+                    cache,
+                    item_key,
+                    max_entries=max_entries,
+                    now=time.monotonic(),
+                )
+            else:
+                cache[item_key] = _Entry(
+                    value=stale.value,
+                    fresh_until=time.monotonic()
+                    + PUBLIC_USER_MODEL_FAILURE_BACKOFF_SECONDS,
+                    stale_until=stale.stale_until,
+                )
+                _touch(cache, item_key)
+            _CONDITION.notify_all()
+        if stale is not None:
+            return stale.value
+        raise PublicUserModelUnavailable from exc
+
+    now = time.monotonic()
+    fresh_seconds = (
+        PUBLIC_USER_MODEL_NEGATIVE_SECONDS
+        if value is None
+        else PUBLIC_USER_MODEL_FRESH_SECONDS
+    )
+    with _CONDITION:
+        if admit_detail_miss:
+            _release_detail_miss()
+        cache[item_key] = _Entry(
+            value=value,
+            fresh_until=now + fresh_seconds,
+            stale_until=now + fresh_seconds + PUBLIC_USER_MODEL_STALE_SECONDS,
+        )
+        _touch(cache, item_key)
+        while len(cache) > max_entries:
+            if isinstance(cache, OrderedDict):
+                cache.popitem(last=False)
+            else:
+                cache.pop(next(iter(cache)))
+        _LOADING.discard(cache_key)
+        _CONDITION.notify_all()
+    return value
+
+
+def _entry_value(entry: _Entry) -> Any:
+    if entry.value is _FAILED:
+        raise PublicUserModelUnavailable
+    return entry.value
+
+
+def _admit_detail_miss(now: float) -> bool:
+    global _ACTIVE_DETAIL_MISSES
+    cutoff = now - PUBLIC_USER_MODEL_MISS_WINDOW_SECONDS
+    while _DETAIL_MISS_TIMES and _DETAIL_MISS_TIMES[0] <= cutoff:
+        _DETAIL_MISS_TIMES.popleft()
+    if (
+        _ACTIVE_DETAIL_MISSES >= PUBLIC_USER_MODEL_MAX_CONCURRENT_MISSES
+        or len(_DETAIL_MISS_TIMES) >= PUBLIC_USER_MODEL_MISS_BUDGET
+    ):
+        return False
+    _ACTIVE_DETAIL_MISSES += 1
+    _DETAIL_MISS_TIMES.append(now)
+    return True
+
+
+def _release_detail_miss() -> None:
+    global _ACTIVE_DETAIL_MISSES
+    _ACTIVE_DETAIL_MISSES = max(0, _ACTIVE_DETAIL_MISSES - 1)
+
+
+def _store_failure(
+    cache: dict[_T, _Entry] | OrderedDict[_T, _Entry],
+    item_key: _T,
+    *,
+    max_entries: int,
+    now: float,
+) -> None:
+    cache[item_key] = _Entry(
+        value=_FAILED,
+        fresh_until=now + PUBLIC_USER_MODEL_FAILURE_BACKOFF_SECONDS,
+        stale_until=now + PUBLIC_USER_MODEL_FAILURE_BACKOFF_SECONDS,
+    )
+    _touch(cache, item_key)
+    while len(cache) > max_entries:
+        if isinstance(cache, OrderedDict):
+            cache.popitem(last=False)
+        else:
+            cache.pop(next(iter(cache)))
+
+
+def _touch(cache: dict[_T, _Entry] | OrderedDict[_T, _Entry], key: _T) -> None:
+    if isinstance(cache, OrderedDict):
+        cache.move_to_end(key)
+
+
+def _bounded_public_shapes(
+    models: list[UserProvidedModel],
+) -> list[dict[str, Any]]:
+    shapes: list[dict[str, Any]] = []
+    # Count the exact compact JSON envelope plus each comma-separated item.
+    used_bytes = len(b'{"data":[]}')
+    for model in models:
+        shape = user_model_public_shape(model)
+        encoded = json.dumps(shape, separators=(",", ":"), ensure_ascii=False).encode()
+        item_bytes = len(encoded) + (1 if shapes else 0)
+        if used_bytes + item_bytes > PUBLIC_USER_MODEL_LIST_MAX_BYTES:
+            break
+        shapes.append(shape)
+        used_bytes += item_bytes
+    return shapes

--- a/src/trusted_router/regions.py
+++ b/src/trusted_router/regions.py
@@ -215,36 +215,9 @@ def region_payload(settings: Settings) -> list[dict[str, Any]]:
                 if region == primary
                 else f"https://{settings.regional_api_hostname_template.format(region=region)}/v1"
             ),
-            # Per-region Cloud Run direct URL. The synthetic monitor
-            # uses this for /health probes that need to hit a
-            # SPECIFIC region's Cloud Run (not whichever region the
-            # global LB picks). The Cloud Run-managed cert covers
-            # `*.{region}.run.app` so it works for every region we
-            # have a Cloud Run service in — including the cold ones
-            # where the regional `api-{region}.quillrouter.com`
-            # hostname doesn't have a cert.
-            #
-            # Cold/warm doesn't matter: Cloud Run direct URLs work
-            # whether the service is at min-scale=0 or 1; they just
-            # incur a cold-start on first request after idle. The
-            # synthetic monitor probes them anyway because the cold-
-            # start tax IS the metric we want to measure.
-            "control_plane_url": _cloud_run_direct_url(settings, region),
         }
         for region in configured_regions(settings)
     ]
-
-
-def _cloud_run_direct_url(settings: Settings, region: str) -> str:
-    """Build the Cloud Run direct URL for `region`. Format is
-    `https://{service}-{project_number}.{region}.run.app`.
-
-    project_number is read from settings if available so per-region
-    URLs work in dev/staging projects without code edits. Falls back
-    to the prod hash if unset (tests / unconfigured environments)."""
-    project_number = getattr(settings, "gcp_project_number", "") or "44325983244"
-    service = getattr(settings, "cloud_run_service_name", "") or "trusted-router"
-    return f"https://{service}-{project_number}.{region}.run.app"
 
 
 def region_map_payload(settings: Settings) -> list[dict[str, Any]]:

--- a/src/trusted_router/routes/chat_proxy.py
+++ b/src/trusted_router/routes/chat_proxy.py
@@ -16,8 +16,8 @@ ACAO headers).
 This module adds a minimal same-origin streaming pipe at the one browser-used
 endpoint, ``POST /chat-proxy/v1/chat/completions``. A valid inference key is
 resolved locally before any body read or outbound allocation; the handler then
-forwards the request bytes-for-bytes to api.trustedrouter.com and streams the
-response bytes back.
+forwards the request bytes-for-bytes to the same managed domain's attested API
+host and streams the response bytes back.
 The proxy:
 
   * NEVER deserializes / inspects / logs the request or response body.
@@ -42,6 +42,13 @@ from fastapi.responses import StreamingResponse
 
 from trusted_router.auth import InferencePrincipal, SettingsDep
 from trusted_router.config import Settings
+from trusted_router.domains import (
+    configured_control_domains,
+    request_api_base_url,
+    request_hostname,
+)
+from trusted_router.errors import api_error
+from trusted_router.types import ErrorType
 
 # Headers we strip from the incoming browser request before forwarding
 # (httpx will re-derive Host/Content-Length itself; hop-by-hop headers
@@ -97,7 +104,7 @@ def register_chat_proxy_routes(router: APIRouter | FastAPI) -> None:
 async def _forward(
     request: Request, path: str, settings: Settings
 ) -> StreamingResponse:
-    upstream_base = _upstream_base_url(settings)
+    upstream_base = _upstream_base_url(request, settings)
     upstream_url = f"{upstream_base}/v1/{path}"
     query = request.url.query
     if query:
@@ -163,12 +170,22 @@ async def _forward(
     )
 
 
-def _upstream_base_url(settings: Settings) -> str:
-    # settings.api_base_url is "https://api.trustedrouter.com/v1" in
-    # production. Strip the trailing /v1 so we can rebuild it from the
-    # {path} parameter in the route — also future-proofs against
-    # non-/v1 paths (e.g. /openai/v1/responses).
-    base = settings.api_base_url.rstrip("/")
+def _upstream_base_url(request: Request, settings: Settings) -> str:
+    # Keep each operational alias on its own attested API hostname. The domain
+    # helper derives only from the configured first-party allowlist. Reject an
+    # unknown or malformed Host before allocating an outbound client: the edge
+    # should never send one here, and silently falling back would let a valid
+    # browser key turn a misdirected request into canonical API traffic.
+    if request_hostname(request) not in configured_control_domains(settings):
+        raise api_error(
+            421,
+            "Chat proxy request Host is not a configured domain",
+            ErrorType.BAD_REQUEST,
+        )
+    base = request_api_base_url(request, settings).rstrip("/")
+    # Strip the trailing /v1 so we can rebuild it from the {path} parameter in
+    # the route — also future-proofs against non-/v1 paths (for example,
+    # /openai/v1/responses).
     if base.endswith("/v1"):
         base = base[: -len("/v1")]
     return base

--- a/src/trusted_router/routes/internal/__init__.py
+++ b/src/trusted_router/routes/internal/__init__.py
@@ -30,8 +30,8 @@ def register_external_webhook_routes(router: APIRouter) -> None:
     veriff.register(router)
 
 
-def register_control_internal_routes(router: APIRouter) -> None:
-    """Register private helpers owned by the authenticated control surface."""
+def register_console_internal_routes(router: APIRouter) -> None:
+    """Register session-authenticated helpers owned by the console surface."""
     chat_browser_key.register(router)
 
 
@@ -54,13 +54,13 @@ def register_observer_internal_routes(router: APIRouter) -> None:
 def register_internal_routes(router: APIRouter) -> None:
     """Legacy local/test composite containing every internal route group."""
     register_external_webhook_routes(router)
-    register_control_internal_routes(router)
+    register_console_internal_routes(router)
     register_gateway_internal_routes(router)
     register_observer_internal_routes(router)
 
 
 __all__ = [
-    "register_control_internal_routes",
+    "register_console_internal_routes",
     "register_external_webhook_routes",
     "register_gateway_internal_routes",
     "register_internal_routes",

--- a/src/trusted_router/routes/internal/adyen.py
+++ b/src/trusted_router/routes/internal/adyen.py
@@ -10,6 +10,7 @@ from fastapi.responses import PlainTextResponse
 
 from trusted_router.auth import SettingsDep
 from trusted_router.errors import api_error
+from trusted_router.routes.internal.webhook_work import run_provider_webhook_work
 from trusted_router.services.adyen_billing import (
     apply_adyen_notification,
     notification_items,
@@ -17,6 +18,8 @@ from trusted_router.services.adyen_billing import (
     verify_adyen_notification,
 )
 from trusted_router.types import ErrorType
+
+MAX_ADYEN_NOTIFICATION_ITEMS = 100
 
 
 def register(router: APIRouter) -> None:
@@ -31,22 +34,44 @@ def register(router: APIRouter) -> None:
             raise api_error(400, "Invalid Adyen webhook payload", ErrorType.BAD_REQUEST)
 
         items = notification_items(payload)
-        # Validate the whole batch before mutating anything. If one item is
-        # forged or malformed, Adyen can retry the batch without leaving a
-        # partially accepted payment behind.
-        for item in items:
-            verify_adyen_notification(item, settings)
-        live_value: Any = payload.get("live")
-        if isinstance(live_value, bool):
-            live = live_value
-        elif isinstance(live_value, str) and live_value.lower() in {"true", "false"}:
-            live = live_value.lower() == "true"
-        else:
-            raise api_error(400, "Invalid Adyen webhook environment", ErrorType.BAD_REQUEST)
-        prepared = [
-            prepare_adyen_notification(item, live=live, settings=settings)
-            for item in items
-        ]
-        for notification in prepared:
-            apply_adyen_notification(notification)
-        return PlainTextResponse("[accepted]")
+        if len(items) > MAX_ADYEN_NOTIFICATION_ITEMS:
+            raise api_error(
+                413,
+                "Adyen webhook batch is too large",
+                ErrorType.BAD_REQUEST,
+            )
+        return await run_provider_webhook_work(
+            "adyen",
+            _process_adyen_notifications,
+            items,
+            payload,
+            settings,
+        )
+
+
+def _process_adyen_notifications(
+    items: list[Any],
+    payload: dict[str, Any],
+    settings: Any,
+) -> PlainTextResponse:
+    """Verify the complete batch before any synchronous Store mutation."""
+
+    # Validate the whole batch before mutating anything. If one item is
+    # forged or malformed, Adyen can retry the batch without leaving a
+    # partially accepted payment behind.
+    for item in items:
+        verify_adyen_notification(item, settings)
+    live_value: Any = payload.get("live")
+    if isinstance(live_value, bool):
+        live = live_value
+    elif isinstance(live_value, str) and live_value.lower() in {"true", "false"}:
+        live = live_value.lower() == "true"
+    else:
+        raise api_error(400, "Invalid Adyen webhook environment", ErrorType.BAD_REQUEST)
+    prepared = [
+        prepare_adyen_notification(item, live=live, settings=settings)
+        for item in items
+    ]
+    for notification in prepared:
+        apply_adyen_notification(notification)
+    return PlainTextResponse("[accepted]")

--- a/src/trusted_router/routes/internal/chat_browser_key.py
+++ b/src/trusted_router/routes/internal/chat_browser_key.py
@@ -24,13 +24,12 @@ session cookie that backs /console/*). Returns 302 → /?reason=signin
 when unauth (the existing console-shaped gate; the chat JS catches
 the redirect and pops the sign-in modal).
 
-Each call creates a NEW key — we do not cache raw keys server-side
-(would violate the "we only ever store hashes" invariant). Client
-preserves continuity across page refreshes and browser restarts via a
-scoped localStorage key plus a one-shot `tr_chat_key` cookie that JS
-reads + clears on page load. So this endpoint is only called when the
-current user/workspace has no reusable browser key or when a cached key
-is rejected and must rotate.
+Each successful call creates a NEW key — we do not cache raw keys
+server-side (would violate the "we only ever store hashes" invariant).
+Client preserves continuity across page refreshes and browser restarts
+via a scoped localStorage key plus a one-shot `tr_chat_key` cookie that
+JS reads + clears on page load. A small atomic per-workspace cap bounds
+lost-storage/retry amplification without changing that browser contract.
 """
 
 from __future__ import annotations
@@ -40,11 +39,13 @@ import secrets
 from typing import Any
 
 from fastapi import APIRouter, Response
+from starlette.concurrency import run_in_threadpool
 
 from trusted_router.auth import SettingsDep
-from trusted_router.errors import assert_workspace_billing_active
+from trusted_router.errors import api_error, assert_workspace_billing_active
 from trusted_router.routes.console._shared import ConsoleDep
 from trusted_router.storage import STORE
+from trusted_router.types import ErrorType
 
 # Soft cap per browser-issued key. $5/day in microdollars. This caps the
 # blast radius if the key leaks via XSS or shared DevTools session. The
@@ -55,6 +56,11 @@ CHAT_BROWSER_KEY_LIMIT_MICRODOLLARS = 5_000_000
 # 30 days. The chat client sees this via browser storage; when it expires
 # the next Send pops a fresh `/internal/chat/issue-browser-key` call.
 CHAT_BROWSER_KEY_TTL_DAYS = 30
+
+# Normal clients reuse one workspace-scoped key from browser storage. Five
+# slots allow several browsers/profiles while bounding repeated or concurrent
+# issuance. Expired and disabled keys do not consume a slot.
+CHAT_BROWSER_ACTIVE_KEY_CAP = 5
 
 # Short-lived cookie that hands the raw key from server → JS. HttpOnly
 # would defeat the point (JS needs to read it). Mitigations:
@@ -90,15 +96,26 @@ def register(router: APIRouter) -> None:
         ).replace("+00:00", "Z")
 
         assert_workspace_billing_active(ctx.workspace)  # quiesce: no new keys while paused
-        raw_key, api_key = STORE.create_api_key(
+        issued = await run_in_threadpool(
+            STORE.issue_chat_browser_key,
             workspace_id=ctx.workspace.id,
             name=name,
             creator_user_id=ctx.user.id,
-            management=False,  # never grant management on a browser key
             limit_microdollars=CHAT_BROWSER_KEY_LIMIT_MICRODOLLARS,
             expires_at=expires_at,
-            include_byok_in_limit=True,
+            active_key_cap=CHAT_BROWSER_ACTIVE_KEY_CAP,
         )
+        if issued is None:
+            raise api_error(
+                429,
+                (
+                    "This workspace already has the maximum number of active "
+                    "browser keys. Reuse a saved key or revoke one in the console."
+                ),
+                ErrorType.RATE_LIMITED,
+                headers={"Retry-After": "60"},
+            )
+        raw_key, api_key = issued
 
         # Set the one-shot cookie so the chat client's page-load
         # bootstrap can pick up the key without an extra request. JS

--- a/src/trusted_router/routes/internal/paypal.py
+++ b/src/trusted_router/routes/internal/paypal.py
@@ -7,11 +7,11 @@ import uuid
 from typing import Any
 
 from fastapi import APIRouter, Request
-from starlette.concurrency import run_in_threadpool
 
 from trusted_router.auth import SettingsDep
 from trusted_router.errors import api_error
 from trusted_router.money import money_pair
+from trusted_router.routes.internal.webhook_work import run_provider_webhook_work
 from trusted_router.services.paypal_billing import (
     credit_paypal_capture,
     verify_paypal_webhook_signature,
@@ -30,7 +30,8 @@ def register(router: APIRouter) -> None:
         if not isinstance(event, dict):
             raise api_error(400, "Invalid PayPal webhook payload", ErrorType.BAD_REQUEST)
 
-        await run_in_threadpool(
+        await run_provider_webhook_work(
+            "paypal",
             verify_paypal_webhook_signature,
             headers=request.headers,
             event=event,
@@ -43,7 +44,9 @@ def register(router: APIRouter) -> None:
             # synchronous. Keep both off the shared async control-plane loop so
             # a slow PayPal API/Store cannot stall unrelated login or console
             # requests.
-            result = await run_in_threadpool(credit_paypal_capture, event)
+            result = await run_provider_webhook_work(
+                "paypal", credit_paypal_capture, event
+            )
             return {
                 "data": {
                     "event_id": event_id,

--- a/src/trusted_router/routes/internal/veriff.py
+++ b/src/trusted_router/routes/internal/veriff.py
@@ -7,7 +7,9 @@ from typing import Any
 from fastapi import APIRouter, Request
 
 from trusted_router.auth import SettingsDep
+from trusted_router.config import Settings
 from trusted_router.errors import api_error
+from trusted_router.routes.internal.webhook_work import run_provider_webhook_work
 from trusted_router.storage import STORE
 from trusted_router.types import ErrorType
 from trusted_router.veriff_verify import (
@@ -22,83 +24,97 @@ def register(router: APIRouter) -> None:
     @router.post("/internal/veriff/webhook")
     async def veriff_webhook(request: Request, settings: SettingsDep) -> dict[str, Any]:
         raw = await request.body()
-        if settings.veriff_shared_secret_key:
-            try:
-                verify_veriff_signature(
-                    raw,
-                    request.headers.get("x-hmac-signature"),
-                    shared_secret=settings.veriff_shared_secret_key,
-                )
-            except VeriffVerificationError as exc:
-                raise api_error(
-                    403,
-                    "Veriff signature verification failed",
-                    ErrorType.FORBIDDEN,
-                ) from exc
-        elif settings.environment.lower() not in {"local", "test"}:
+        return await run_provider_webhook_work(
+            "veriff",
+            _process_veriff_webhook,
+            raw,
+            request.headers.get("x-hmac-signature"),
+            settings,
+        )
+
+
+def _process_veriff_webhook(
+    raw: bytes,
+    signature: str | None,
+    settings: Settings,
+) -> dict[str, Any]:
+    if settings.veriff_shared_secret_key:
+        try:
+            verify_veriff_signature(
+                raw,
+                signature,
+                shared_secret=settings.veriff_shared_secret_key,
+            )
+        except VeriffVerificationError as exc:
             raise api_error(
                 403,
-                "Veriff webhook is not configured",
+                "Veriff signature verification failed",
                 ErrorType.FORBIDDEN,
-            )
-
-        try:
-            payload = json.loads(raw)
-        except (UnicodeDecodeError, json.JSONDecodeError):
-            return {"data": {"ignored": True}}
-        verification = payload.get("verification") if isinstance(payload, dict) else None
-        if not isinstance(verification, dict):
-            return {"data": {"ignored": True}}
-
-        session_id = verification.get("id")
-        provider_status = verification.get("status")
-        vendor_data = verification.get("vendorData")
-        raw_code = verification.get("code")
-        if not isinstance(raw_code, (int, str)):
-            return {"data": {"ignored": True}}
-        try:
-            code = int(raw_code)
-        except (TypeError, ValueError):
-            return {"data": {"ignored": True}}
-        decision_status = mapped_status(provider_status, code)
-        if (
-            not isinstance(session_id, str)
-            or not session_id
-            or not isinstance(vendor_data, str)
-            or not vendor_data
-            or decision_status is None
-        ):
-            return {"data": {"ignored": True}}
-
-        event_id = f"{session_id}#{provider_status}#{code}"
-        if not STORE.record_webhook_event_once("veriff", event_id):
-            return {"data": {"replayed": True}}
-
-        user = STORE.get_user(vendor_data)
-        if user is None:
-            log.info("veriff_webhook.ignored reason=unknown_user")
-            return {"data": {"ignored": True}}
-        if session_id != user.veriff_session_id:
-            log.info("veriff_webhook.ignored reason=stale_session")
-            return {"data": {"ignored": True}}
-
-        approved_name = verified_name(verification) if decision_status == "approved" else None
-        reason, reason_code = decision_reason(verification)
-        STORE.set_user_identity_status(
-            user.id,
-            status=decision_status,
-            decision_code=code,
-            decision_reason=reason,
-            decision_reason_code=reason_code,
-            verified_name=approved_name,
+            ) from exc
+    elif settings.environment.lower() not in {"local", "test"}:
+        raise api_error(
+            403,
+            "Veriff webhook is not configured",
+            ErrorType.FORBIDDEN,
         )
-        log.info(
-            "veriff_webhook.decision status=%s code=%s reason_code=%s",
-            decision_status,
-            code,
-            reason_code,
-        )
-        return {"data": {"status": decision_status}}
+
+    try:
+        payload = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return {"data": {"ignored": True}}
+    verification = payload.get("verification") if isinstance(payload, dict) else None
+    if not isinstance(verification, dict):
+        return {"data": {"ignored": True}}
+
+    session_id = verification.get("id")
+    provider_status = verification.get("status")
+    vendor_data = verification.get("vendorData")
+    raw_code = verification.get("code")
+    if not isinstance(raw_code, (int, str)):
+        return {"data": {"ignored": True}}
+    try:
+        code = int(raw_code)
+    except (TypeError, ValueError):
+        return {"data": {"ignored": True}}
+    decision_status = mapped_status(provider_status, code)
+    if (
+        not isinstance(session_id, str)
+        or not session_id
+        or not isinstance(vendor_data, str)
+        or not vendor_data
+        or decision_status is None
+    ):
+        return {"data": {"ignored": True}}
+
+    event_id = f"{session_id}#{provider_status}#{code}"
+    if not STORE.record_webhook_event_once("veriff", event_id):
+        return {"data": {"replayed": True}}
+
+    user = STORE.get_user(vendor_data)
+    if user is None:
+        log.info("veriff_webhook.ignored reason=unknown_user")
+        return {"data": {"ignored": True}}
+    if session_id != user.veriff_session_id:
+        log.info("veriff_webhook.ignored reason=stale_session")
+        return {"data": {"ignored": True}}
+
+    approved_name = verified_name(verification) if decision_status == "approved" else None
+    reason, reason_code = decision_reason(verification)
+    STORE.set_user_identity_status(
+        user.id,
+        status=decision_status,
+        decision_code=code,
+        decision_reason=reason,
+        decision_reason_code=reason_code,
+        verified_name=approved_name,
+    )
+    log.info(
+        "veriff_webhook.decision status=%s code=%s reason_code=%s",
+        decision_status,
+        code,
+        reason_code,
+    )
+    return {"data": {"status": decision_status}}
 
 
 def mapped_status(provider_status: Any, code: int) -> str | None:

--- a/src/trusted_router/routes/internal/webhook.py
+++ b/src/trusted_router/routes/internal/webhook.py
@@ -30,6 +30,7 @@ from trusted_router.auth import SettingsDep
 from trusted_router.errors import api_error
 from trusted_router.money import MICRODOLLARS_PER_CENT
 from trusted_router.routes.helpers import json_body
+from trusted_router.routes.internal.webhook_work import run_provider_webhook_work
 from trusted_router.services.x402_billing import X402_PAYMENT_METHOD, credit_x402_payment_intent
 from trusted_router.storage import STORE
 from trusted_router.types import ErrorType
@@ -44,9 +45,15 @@ def register(router: APIRouter) -> None:
         sig = request.headers.get("stripe-signature")
         if settings.stripe_webhook_secret:
             try:
-                constructed = stripe.Webhook.construct_event(
-                    raw, sig, settings.stripe_webhook_secret
+                constructed = await run_provider_webhook_work(
+                    "stripe",
+                    stripe.Webhook.construct_event,
+                    raw,
+                    sig,
+                    settings.stripe_webhook_secret,
                 )
+            except HTTPException:
+                raise
             except Exception as exc:
                 raise api_error(400, "Invalid Stripe webhook", ErrorType.BAD_REQUEST) from exc
             # `construct_event` returns a `stripe.Event` (a `StripeObject`
@@ -92,10 +99,17 @@ def register(router: APIRouter) -> None:
             workspace_id = metadata.get("workspace_id")
             amount_total = int(obj.get("amount_total") or 0)
             customer_id = obj.get("customer")
-            if workspace_id and STORE.get_credit_account(workspace_id) is not None:
+            if workspace_id and await run_provider_webhook_work(
+                "stripe", STORE.get_credit_account, workspace_id
+            ) is not None:
                 if event_type == "checkout.session.completed" and obj.get("mode") == "setup":
                     if isinstance(customer_id, str):
-                        STORE.set_stripe_customer(workspace_id, customer_id=customer_id)
+                        await run_provider_webhook_work(
+                            "stripe",
+                            STORE.set_stripe_customer,
+                            workspace_id,
+                            customer_id=customer_id,
+                        )
                     return {
                         "data": {
                             "setup_pending": True,
@@ -135,14 +149,18 @@ def register(router: APIRouter) -> None:
                     checkout_session=obj,
                     payment_method=payment_method,
                 )
-                credited = STORE.credit_workspace_typed_direct(
+                credited = await run_provider_webhook_work(
+                    "stripe",
+                    _credit_workspace_with_lifetime,
                     workspace_id,
                     amount_microdollars,
                     credit_event_id,
-                    lifetime_topup_user_id=_lifetime_topup_user_id(workspace_id, metadata),
+                    metadata,
                 )
                 if credited:
-                    record_credit_purchase(
+                    await run_provider_webhook_work(
+                        "stripe",
+                        record_credit_purchase,
                         workspace_id,
                         amount_microdollars=amount_microdollars,
                         payment_method=(
@@ -155,7 +173,12 @@ def register(router: APIRouter) -> None:
                 # PaymentIntent's `payment_method` if Checkout was set up
                 # with `setup_future_usage`).
                 if isinstance(customer_id, str) and payment_method != "ach":
-                    STORE.set_stripe_customer(workspace_id, customer_id=customer_id)
+                    await run_provider_webhook_work(
+                        "stripe",
+                        STORE.set_stripe_customer,
+                        workspace_id,
+                        customer_id=customer_id,
+                    )
                 return {
                     "data": {
                         "credited": credited,
@@ -177,14 +200,21 @@ def register(router: APIRouter) -> None:
                 isinstance(workspace_id, str)
                 and isinstance(customer_id, str)
                 and isinstance(payment_method, str)
-                and STORE.get_credit_account(workspace_id) is not None
+                and await run_provider_webhook_work(
+                    "stripe", STORE.get_credit_account, workspace_id
+                )
+                is not None
             ):
-                STORE.set_stripe_customer(
+                await run_provider_webhook_work(
+                    "stripe",
+                    STORE.set_stripe_customer,
                     workspace_id,
                     customer_id=customer_id,
                     payment_method_id=payment_method,
                 )
-                record_payment_method_saved(
+                await run_provider_webhook_work(
+                    "stripe",
+                    record_payment_method_saved,
                     workspace_id,
                     payment_method="stripe_card",
                 )
@@ -201,7 +231,9 @@ def register(router: APIRouter) -> None:
             metadata = obj.get("metadata") or {}
             if metadata.get("payment_method") == X402_PAYMENT_METHOD:
                 try:
-                    result = credit_x402_payment_intent(
+                    result = await run_provider_webhook_work(
+                        "stripe",
+                        credit_x402_payment_intent,
                         obj,
                         expected_workspace_id=None,
                         settings=settings,
@@ -237,30 +269,43 @@ def register(router: APIRouter) -> None:
                     metadata=metadata,
                     payment_intent_amount_cents=obj.get("amount"),
                 )
-                credited = STORE.credit_workspace_typed_direct(
+                credited = await run_provider_webhook_work(
+                    "stripe",
+                    _credit_workspace_with_lifetime,
                     workspace_id,
                     amount_microdollars,
                     event_id,
-                    lifetime_topup_user_id=_lifetime_topup_user_id(workspace_id, metadata),
+                    metadata,
                 )
                 if credited:
-                    record_credit_purchase(
+                    await run_provider_webhook_work(
+                        "stripe",
+                        record_credit_purchase,
                         workspace_id,
                         amount_microdollars=amount_microdollars,
                         payment_method="stripe_auto_refill",
                     )
-                STORE.record_auto_refill_outcome(workspace_id, status="succeeded")
+                await run_provider_webhook_work(
+                    "stripe",
+                    STORE.record_auto_refill_outcome,
+                    workspace_id,
+                    status="succeeded",
+                )
                 # Also persist the payment-method if Stripe surfaced one —
                 # first auto-refill after a Checkout that didn't include
                 # setup_future_usage might be the first time we see the PM.
                 payment_method = obj.get("payment_method")
                 if isinstance(payment_method, str):
-                    STORE.set_stripe_customer(
+                    await run_provider_webhook_work(
+                        "stripe",
+                        STORE.set_stripe_customer,
                         workspace_id,
                         customer_id=str(obj.get("customer") or ""),
                         payment_method_id=payment_method,
                     )
-                    record_payment_method_saved(
+                    await run_provider_webhook_work(
+                        "stripe",
+                        record_payment_method_saved,
                         workspace_id,
                         payment_method="stripe_card",
                     )
@@ -268,17 +313,24 @@ def register(router: APIRouter) -> None:
             if (
                 metadata.get("payment_method") in {None, "auto", "card"}
                 and isinstance(workspace_id, str)
-                and STORE.get_credit_account(workspace_id) is not None
+                and await run_provider_webhook_work(
+                    "stripe", STORE.get_credit_account, workspace_id
+                )
+                is not None
             ):
                 payment_method = obj.get("payment_method")
                 customer_id = obj.get("customer")
                 if isinstance(payment_method, str) and isinstance(customer_id, str):
-                    STORE.set_stripe_customer(
+                    await run_provider_webhook_work(
+                        "stripe",
+                        STORE.set_stripe_customer,
                         workspace_id,
                         customer_id=customer_id,
                         payment_method_id=payment_method,
                     )
-                    record_payment_method_saved(
+                    await run_provider_webhook_work(
+                        "stripe",
+                        record_payment_method_saved,
                         workspace_id,
                         payment_method="stripe_card",
                     )
@@ -316,7 +368,12 @@ def register(router: APIRouter) -> None:
             if metadata.get("auto_refill") == "true" and isinstance(workspace_id, str):
                 last_error = obj.get("last_payment_error") or {}
                 code = last_error.get("code") or "unknown"
-                STORE.record_auto_refill_outcome(workspace_id, status=f"failed:{code}")
+                await run_provider_webhook_work(
+                    "stripe",
+                    STORE.record_auto_refill_outcome,
+                    workspace_id,
+                    status=f"failed:{code}",
+                )
                 return {"data": {"event_id": event_id, "auto_refill_failed": True, "code": code}}
 
         if event_type in {"charge.refunded", "charge.refund.updated"}:
@@ -341,6 +398,20 @@ def register(router: APIRouter) -> None:
                 }
 
         return {"data": {"ignored": True, "event_id": event_id}}
+
+
+def _credit_workspace_with_lifetime(
+    workspace_id: str,
+    amount_microdollars: int,
+    event_id: str,
+    metadata: dict[str, Any],
+) -> bool:
+    return STORE.credit_workspace_typed_direct(
+        workspace_id,
+        amount_microdollars,
+        event_id,
+        lifetime_topup_user_id=_lifetime_topup_user_id(workspace_id, metadata),
+    )
 
 
 def _lifetime_topup_user_id(workspace_id: str, metadata: dict[str, Any]) -> str | None:

--- a/src/trusted_router/routes/internal/webhook_work.py
+++ b/src/trusted_router/routes/internal/webhook_work.py
@@ -1,0 +1,42 @@
+"""Per-provider admission for blocking webhook verification and Store work."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+from starlette.concurrency import run_in_threadpool
+
+from trusted_router.errors import api_error
+from trusted_router.types import ErrorType
+
+WEBHOOK_MAX_BLOCKING_TASKS_PER_PROVIDER = 4
+
+_T = TypeVar("_T")
+_PROVIDER_SLOTS = {
+    provider: threading.BoundedSemaphore(WEBHOOK_MAX_BLOCKING_TASKS_PER_PROVIDER)
+    for provider in ("adyen", "paypal", "ses", "stripe", "veriff")
+}
+
+
+async def run_provider_webhook_work(
+    provider: str,
+    func: Callable[..., _T],
+    *args: Any,
+    **kwargs: Any,
+) -> _T:
+    """Run blocking provider work without exhausting Starlette's threadpool."""
+
+    slot = _PROVIDER_SLOTS[provider]
+    if not slot.acquire(blocking=False):
+        raise api_error(
+            503,
+            f"{provider.title()} webhook processor is busy; retry",
+            ErrorType.SERVICE_UNAVAILABLE,
+            headers={"Retry-After": "1"},
+        )
+    try:
+        return await run_in_threadpool(func, *args, **kwargs)
+    finally:
+        slot.release()

--- a/src/trusted_router/routes/oauth_keys.py
+++ b/src/trusted_router/routes/oauth_keys.py
@@ -1,30 +1,44 @@
 from __future__ import annotations
 
-import base64
 import datetime as dt
 import hashlib
 import re
+import threading
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from pydantic import ValidationError
+from starlette.concurrency import run_in_threadpool
 
 from trusted_router.auth import ManagementPrincipal, SettingsDep, principal_from_request
 from trusted_router.config import Settings
 from trusted_router.domains import request_control_origin
-from trusted_router.errors import api_error, assert_workspace_billing_active
+from trusted_router.errors import api_error
 from trusted_router.money import (
     dollars_to_microdollars,
     format_money_display,
     microdollars_to_decimal,
+)
+from trusted_router.request_limits import (
+    fingerprint_subject,
+    normalized_client_identity,
 )
 from trusted_router.routes.helpers import json_body
 from trusted_router.schemas import CheckoutRequest
 from trusted_router.serialization import key_shape
 from trusted_router.services.stripe_billing import create_checkout_session
 from trusted_router.storage import STORE, OAuthAuthorizationCode
+from trusted_router.storage_oauth_codes import (
+    OAuthCodeMethodMismatch,
+    OAuthCodeVerifierMismatch,
+    OAuthCodeVerifierNotAscii,
+    OAuthCodeVerifierRequired,
+    OAuthWorkspaceBillingPaused,
+    OAuthWorkspaceUnavailable,
+)
+from trusted_router.storage_rate_limits import InMemoryRateLimits
 from trusted_router.typed_balance import live_credit_summary
 from trusted_router.types import ErrorType
 from trusted_router.views import render_template
@@ -47,6 +61,21 @@ OAUTH_AUTHORIZATION_FIELDS = (
     "spawn_agent",
     "spawn_cloud",
 )
+OAUTH_CODE_PATTERN = re.compile(r"^auth_code-[A-Za-z0-9_-]{43}$")
+_OAUTH_EXCHANGE_SLOTS = threading.BoundedSemaphore(4)
+_OAUTH_EXCHANGE_RATE_LIMITS = InMemoryRateLimits(
+    lock=threading.RLock(),
+    max_buckets=10_000,
+)
+_OAUTH_EXCHANGE_GLOBAL_RATE_LIMITS = InMemoryRateLimits(
+    lock=threading.RLock(),
+    max_buckets=1,
+)
+_OAUTH_EXCHANGE_PER_SOURCE_LIMIT = 120
+# One source can consume at most one eighth of this process-local backstop.
+# That keeps a bounded aggregate ceiling without letting a single attacker
+# reserve every exchange slot for the rest of the minute.
+_OAUTH_EXCHANGE_GLOBAL_LIMIT = 960
 
 
 def register_oauth_key_routes(router: APIRouter) -> None:
@@ -152,38 +181,108 @@ def register_oauth_key_routes(router: APIRouter) -> None:
         )
 
     @router.post("/auth/keys")
-    async def auth_keys(request: Request) -> JSONResponse:
+    async def auth_keys(request: Request, settings: SettingsDep) -> JSONResponse:
         body = await json_body(request)
-        raw_code = str(body.get("code") or "")
+        raw_value = body.get("code")
+        raw_code = raw_value if isinstance(raw_value, str) else ""
         if not raw_code:
             raise api_error(400, "code is required", ErrorType.BAD_REQUEST)
-        code = STORE.consume_oauth_authorization_code(raw_code)
-        if code is None:
-            raise api_error(403, "Invalid or expired authorization code", ErrorType.FORBIDDEN)
-        _verify_pkce(code, body)
-        # Quiesce: a pre-pause OAuth code must not mint a key during pause.
-        assert_workspace_billing_active(STORE.get_workspace(code.workspace_id))
-        raw_key, key = STORE.create_api_key(
-            workspace_id=code.workspace_id,
-            name=code.key_label,
-            creator_user_id=code.user_id,
-            management=False,
-            limit_microdollars=code.limit_microdollars,
-            limit_reset=code.limit_reset,
-            expires_at=code.expires_at,
+        if not OAUTH_CODE_PATTERN.fullmatch(raw_code):
+            raise api_error(
+                403,
+                "Invalid or expired authorization code",
+                ErrorType.FORBIDDEN,
+            )
+        if not _OAUTH_EXCHANGE_SLOTS.acquire(blocking=False):
+            raise api_error(
+                429,
+                "Authorization-code exchange is busy",
+                ErrorType.RATE_LIMITED,
+                headers={"Retry-After": "1"},
+            )
+        try:
+            if settings.rate_limit_enabled:
+                source = fingerprint_subject(
+                    normalized_client_identity(request, settings)
+                )
+                hit = _OAUTH_EXCHANGE_RATE_LIMITS.hit(
+                    namespace="oauth_code_exchange_source",
+                    subject=source,
+                    limit=_OAUTH_EXCHANGE_PER_SOURCE_LIMIT,
+                    window_seconds=60,
+                )
+                if not hit.allowed:
+                    raise api_error(
+                        429,
+                        "Authorization-code exchange rate exceeded",
+                        ErrorType.RATE_LIMITED,
+                        headers={"Retry-After": str(hit.retry_after_seconds)},
+                    )
+                global_hit = _OAUTH_EXCHANGE_GLOBAL_RATE_LIMITS.hit(
+                    namespace="oauth_code_exchange_global",
+                    subject="all",
+                    limit=_OAUTH_EXCHANGE_GLOBAL_LIMIT,
+                    window_seconds=60,
+                )
+                if not global_hit.allowed:
+                    raise api_error(
+                        429,
+                        "Authorization-code exchange is busy",
+                        ErrorType.RATE_LIMITED,
+                        headers={"Retry-After": str(global_hit.retry_after_seconds)},
+                    )
+            payload = await run_in_threadpool(_exchange_oauth_code, raw_code, body)
+        finally:
+            _OAUTH_EXCHANGE_SLOTS.release()
+        return JSONResponse(payload)
+
+
+def _exchange_oauth_code(raw_code: str, body: dict[str, Any]) -> dict[str, Any]:
+    """Run one atomic Store exchange outside the ASGI event loop."""
+    verifier_value = body.get("code_verifier")
+    method_value = body.get("code_challenge_method")
+    code_verifier = str(verifier_value or "") or None
+    code_challenge_method = str(method_value or "") or None
+    try:
+        exchange = STORE.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=code_verifier,
+            code_challenge_method=code_challenge_method,
         )
-        # Return the signed-in user's identity alongside the key so the app
-        # knows WHO signed in without a second /auth/userinfo round-trip
-        # ("Sign in with TrustedRouter" = key + identity).
-        user = STORE.get_user(code.user_id) if code.user_id else None
-        return JSONResponse(
-            {
-                "key": raw_key,
-                "user_id": code.user_id,
-                "identity": _identity_payload(user),
-                "data": key_shape(key),
-            }
-        )
+    except OAuthCodeMethodMismatch as exc:
+        raise api_error(
+            400,
+            "code_challenge_method does not match authorization code",
+            ErrorType.BAD_REQUEST,
+        ) from exc
+    except OAuthCodeVerifierRequired as exc:
+        raise api_error(400, "code_verifier is required", ErrorType.BAD_REQUEST) from exc
+    except OAuthCodeVerifierNotAscii as exc:
+        raise api_error(400, "code_verifier must be ASCII", ErrorType.BAD_REQUEST) from exc
+    except OAuthCodeVerifierMismatch as exc:
+        raise api_error(403, "Invalid code_verifier", ErrorType.FORBIDDEN) from exc
+    except OAuthWorkspaceBillingPaused as exc:
+        raise api_error(
+            503,
+            "Workspace billing is paused",
+            ErrorType.SERVICE_UNAVAILABLE,
+            headers={"Retry-After": "30"},
+        ) from exc
+    except OAuthWorkspaceUnavailable as exc:
+        raise api_error(
+            503,
+            "Authorization workspace is unavailable",
+            ErrorType.SERVICE_UNAVAILABLE,
+            headers={"Retry-After": "30"},
+        ) from exc
+    if exchange is None:
+        raise api_error(403, "Invalid or expired authorization code", ErrorType.FORBIDDEN)
+    return {
+        "key": exchange.raw_key,
+        "user_id": exchange.authorization_code.user_id,
+        "identity": _identity_payload(exchange.user),
+        "data": key_shape(exchange.api_key),
+    }
 
 
 def _create_code(
@@ -354,33 +453,6 @@ def _key_label(raw: Any, callback_url: str) -> str:
     if len(value) > 100:
         raise api_error(400, "key_label must be at most 100 characters", ErrorType.BAD_REQUEST)
     return value
-
-
-def _verify_pkce(code: OAuthAuthorizationCode, body: dict[str, Any]) -> None:
-    if not code.code_challenge:
-        return
-    supplied_method = body.get("code_challenge_method")
-    if supplied_method not in {None, ""} and str(supplied_method) != code.code_challenge_method:
-        raise api_error(
-            400, "code_challenge_method does not match authorization code", ErrorType.BAD_REQUEST
-        )
-    verifier = str(body.get("code_verifier") or "")
-    if not verifier:
-        raise api_error(400, "code_verifier is required", ErrorType.BAD_REQUEST)
-    if code.code_challenge_method == "plain":
-        expected = verifier
-    else:
-        try:
-            verifier_bytes = verifier.encode("ascii")
-        except UnicodeEncodeError as exc:
-            raise api_error(400, "code_verifier must be ASCII", ErrorType.BAD_REQUEST) from exc
-        expected = (
-            base64.urlsafe_b64encode(hashlib.sha256(verifier_bytes).digest())
-            .decode("ascii")
-            .rstrip("=")
-        )
-    if expected != code.code_challenge:
-        raise api_error(403, "Invalid code_verifier", ErrorType.FORBIDDEN)
 
 
 def _principal_user_id(principal: Any) -> str | None:

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -124,8 +124,14 @@ from trusted_router.provider_contract import (
     PROVIDER_CATALOG_V2_SCHEMA,
 )
 from trusted_router.public_analytics_snapshots import current_public_analytics_snapshot
+from trusted_router.public_user_models import (
+    PUBLIC_USER_MODEL_CACHE_CONTROL,
+    PublicUserModelReadLimited,
+    PublicUserModelUnavailable,
+    cached_public_user_model,
+    normalized_public_user_model_id,
+)
 from trusted_router.request_limits import normalized_client_identity
-from trusted_router.serialization import user_model_public_shape
 from trusted_router.services.email import EmailMessage, get_email_service
 from trusted_router.services.ops_chat import OpsChatSupportMessage, fanout_support_message
 from trusted_router.services.trust_release import (
@@ -1617,15 +1623,30 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
         return public_chat_html(settings)
 
     @public_html_route("/user-chat")
-    async def user_chat(model: str = Query(..., min_length=1)) -> str:
+    async def user_chat(model: str = Query(..., min_length=1)) -> HTMLResponse:
         locked_model_id = normalize_custom_model_id(model)
-        user_model = STORE.get_user_model(locked_model_id)
-        return public_chat_html(
-            settings,
-            locked_model_id=locked_model_id,
-            locked_model_label=(
-                "User-provided model" if user_model is not None else "Custom model"
+        user_model = None
+        public_model_id = normalized_public_user_model_id(locked_model_id)
+        if public_model_id is not None:
+            try:
+                user_model = await run_in_threadpool(
+                    cached_public_user_model,
+                    public_model_id,
+                    lambda: STORE.get_user_model(public_model_id),
+                )
+            except (PublicUserModelReadLimited, PublicUserModelUnavailable):
+                # The chat page can still proxy a custom model when the
+                # cosmetic user-model label is temporarily unavailable.
+                user_model = None
+        return HTMLResponse(
+            public_chat_html(
+                settings,
+                locked_model_id=locked_model_id,
+                locked_model_label=(
+                    "User-provided model" if user_model is not None else "Custom model"
+                ),
             ),
+            headers={"cache-control": PUBLIC_USER_MODEL_CACHE_CONTROL},
         )
 
     @public_html_route("/synth")
@@ -1665,22 +1686,37 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
                 )
             return HTMLResponse(body)
         body = public_model_detail_html(settings, cleaned)
-        if body is None:
-            user_model = STORE.get_user_model(normalize_custom_model_id(cleaned))
-            if (
-                user_model is not None
-                and user_model.enabled
-                and user_model.status == "active"
-            ):
-                shape = user_model_public_shape(user_model)
+        normalized = normalized_public_user_model_id(cleaned)
+        checked_user_model = body is None and normalized is not None
+        if checked_user_model:
+            assert normalized is not None
+            try:
+                shape = await run_in_threadpool(
+                    cached_public_user_model,
+                    normalized,
+                    lambda: STORE.get_user_model(normalized),
+                )
+            except PublicUserModelReadLimited:
+                return HTMLResponse(
+                    public_model_not_found_html(settings, cleaned),
+                    status_code=429,
+                    headers={"Retry-After": "30", "cache-control": "no-store"},
+                )
+            except PublicUserModelUnavailable:
+                return HTMLResponse(
+                    public_model_not_found_html(settings, cleaned),
+                    status_code=503,
+                    headers={"Retry-After": "2", "cache-control": "no-store"},
+                )
+            if shape is not None:
                 body = render_template(
                     "public/user_model_detail.html",
                     api_base_url=settings.api_base_url,
                     site_url=(
-                        f"https://{settings.trusted_domain}/models/{user_model.id}"
+                        f"https://{settings.trusted_domain}/models/{shape['id']}"
                     ),
-                    title=f"{user_model.name} | User-provided model",
-                    heading=user_model.name,
+                    title=f"{shape['name']} | User-provided model",
+                    heading=shape["name"],
                     description=shape["privacy_notice"],
                     robots_meta="noindex",
                     model=shape,
@@ -1692,8 +1728,20 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
             return HTMLResponse(
                 public_model_not_found_html(settings, cleaned),
                 status_code=404,
+                headers=(
+                    {"cache-control": PUBLIC_USER_MODEL_CACHE_CONTROL}
+                    if checked_user_model
+                    else None
+                ),
             )
-        return HTMLResponse(body)
+        return HTMLResponse(
+            body,
+            headers=(
+                {"cache-control": PUBLIC_USER_MODEL_CACHE_CONTROL}
+                if checked_user_model
+                else None
+            ),
+        )
 
     @app.get("/og.png")
     async def og_image() -> FileResponse:

--- a/src/trusted_router/routes/ses_notifications.py
+++ b/src/trusted_router/routes/ses_notifications.py
@@ -29,10 +29,10 @@ from urllib.parse import urlparse
 import httpx
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
-from starlette.concurrency import run_in_threadpool
 
 from trusted_router.config import Settings
 from trusted_router.errors import api_error
+from trusted_router.routes.internal.webhook_work import run_provider_webhook_work
 from trusted_router.services.ses_suppression import (
     SesSuppressionService,
     SesSuppressionSyncError,
@@ -42,6 +42,7 @@ from trusted_router.storage import STORE
 from trusted_router.types import ErrorType
 
 log = logging.getLogger(__name__)
+SES_FEEDBACK_MAX_RECIPIENTS = 100
 _SNS_CONFIRM_MAX_CONCURRENT = 2
 _SNS_CONFIRM_SLOTS = threading.BoundedSemaphore(_SNS_CONFIRM_MAX_CONCURRENT)
 
@@ -61,7 +62,7 @@ def register_ses_notification_routes(router: APIRouter, settings: Settings) -> N
             # Verification may fetch/cache an AWS signing certificate. It is
             # synchronous cryptographic/network work and must not block the
             # shared control-plane event loop.
-            await run_in_threadpool(verify_sns_message, envelope)
+            await run_provider_webhook_work("ses", verify_sns_message, envelope)
         except SnsVerificationError as exc:
             log.warning("ses_notification.signature_invalid reason=%s", exc)
             # TEMP(2026-07-05): mirror the failure to stderr so it reaches
@@ -96,7 +97,11 @@ def register_ses_notification_routes(router: APIRouter, settings: Settings) -> N
                 )
             try:
                 try:
-                    await run_in_threadpool(_confirm_subscription, subscribe_url)
+                    await run_provider_webhook_work(
+                        "ses",
+                        _confirm_subscription,
+                        subscribe_url,
+                    )
                 finally:
                     _SNS_CONFIRM_SLOTS.release()
             except httpx.HTTPError as exc:
@@ -104,12 +109,20 @@ def register_ses_notification_routes(router: APIRouter, settings: Settings) -> N
                 raise api_error(502, "failed to confirm SNS subscription", ErrorType.INTERNAL_ERROR) from exc
             log.info("ses_notification.subscribed topic=%s", envelope.get("TopicArn"))
             if message_id:
-                await run_in_threadpool(STORE.record_sns_message_once, message_id)
+                await run_provider_webhook_work(
+                    "ses",
+                    STORE.record_sns_message_once,
+                    message_id,
+                )
             return JSONResponse({"data": {"confirmed": True, "topic_arn": envelope.get("TopicArn")}})
 
         if msg_type == "UnsubscribeConfirmation":
             if message_id:
-                await run_in_threadpool(STORE.record_sns_message_once, message_id)
+                await run_provider_webhook_work(
+                    "ses",
+                    STORE.record_sns_message_once,
+                    message_id,
+                )
             return JSONResponse({"data": {"unsubscribed": True}})
 
         # Notification path: parse the SES feedback envelope.
@@ -117,20 +130,25 @@ def register_ses_notification_routes(router: APIRouter, settings: Settings) -> N
         if not isinstance(feedback_raw, str):
             return JSONResponse({"data": {"ignored": True, "reason": "non-string Message"}})
         try:
-            feedback: dict[str, Any] = json.loads(feedback_raw)
+            parsed_feedback: Any = json.loads(feedback_raw)
         except json.JSONDecodeError:
             return JSONResponse({"data": {"ignored": True, "reason": "Message is not JSON"}})
+        if not isinstance(parsed_feedback, dict):
+            return JSONResponse({"data": {"ignored": True, "reason": "Message is not an object"}})
+        feedback: dict[str, Any] = parsed_feedback
 
         kind = str(feedback.get("notificationType") or feedback.get("eventType") or "")
+        _validate_feedback_recipient_cap(kind, feedback)
         # Apply the suppression first so a transient storage failure leaves the
         # SNS message retryable. The message-id claim only controls reporting:
         # suppression writes are idempotent, while duplicate SNS deliveries
         # must not inflate bounce/complaint counts.
         try:
-            # Suppression sync and the replay check both talk to the Store;
-            # keep them off the event loop (the bounded-verification contract)
-            # while preserving the account-suppression failure mapping.
-            blocked_count = await run_in_threadpool(
+            # The bounded per-provider work pool replaces the shared threadpool
+            # (the bounded-verification contract) while preserving the
+            # account-suppression failure mapping from the suppression mirror.
+            blocked_count = await run_provider_webhook_work(
+                "ses",
                 _apply_feedback,
                 kind,
                 feedback,
@@ -146,7 +164,11 @@ def register_ses_notification_routes(router: APIRouter, settings: Settings) -> N
             ) from exc
         replayed = bool(
             message_id
-            and not await run_in_threadpool(STORE.record_sns_message_once, message_id)
+            and not await run_provider_webhook_work(
+                "ses",
+                STORE.record_sns_message_once,
+                message_id,
+            )
         )
         if replayed:
             blocked_count = 0
@@ -168,6 +190,30 @@ def _confirm_subscription(url: str) -> None:
     response.raise_for_status()
 
 
+def _feedback_recipients(kind: str, feedback: dict[str, Any]) -> list[Any]:
+    if kind in {"Bounce", "bounce"}:
+        raw_feedback = feedback.get("bounce")
+        field_name = "bouncedRecipients"
+    elif kind in {"Complaint", "complaint"}:
+        raw_feedback = feedback.get("complaint")
+        field_name = "complainedRecipients"
+    else:
+        return []
+    provider_feedback = raw_feedback if isinstance(raw_feedback, dict) else {}
+    raw_recipients = provider_feedback.get(field_name)
+    return raw_recipients if isinstance(raw_recipients, list) else []
+
+
+def _validate_feedback_recipient_cap(kind: str, feedback: dict[str, Any]) -> None:
+    recipient_count = len(_feedback_recipients(kind, feedback))
+    if recipient_count > SES_FEEDBACK_MAX_RECIPIENTS:
+        raise api_error(
+            400,
+            f"SES feedback may contain at most {SES_FEEDBACK_MAX_RECIPIENTS} recipients",
+            ErrorType.BAD_REQUEST,
+        )
+
+
 def _apply_feedback(
     kind: str,
     feedback: dict[str, Any],
@@ -182,6 +228,10 @@ def _apply_feedback(
     supported. Processing is idempotent because suppression writes use the
     normalized recipient as their key.
     """
+    # Keep the invariant at the Store boundary as well as in the route. A
+    # future caller cannot accidentally turn one signed message into an
+    # unbounded sequence of writes by bypassing route-level validation.
+    _validate_feedback_recipient_cap(kind, feedback)
     blocked_count = 0
     tags = _mail_tags(feedback)
     if kind in {"Bounce", "bounce"}:

--- a/src/trusted_router/routes/user_models.py
+++ b/src/trusted_router/routes/user_models.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import hashlib
+import math
 import secrets
+import threading
+import time
 import uuid
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from typing import Any, NoReturn
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
+from starlette.concurrency import run_in_threadpool
 
 from trusted_router.auth import (
     ManagementPrincipal,
@@ -37,7 +43,11 @@ from trusted_router.services.user_model_secrets import (
     encrypt_user_model_signing_secret,
 )
 from trusted_router.storage import STORE
-from trusted_router.storage_custom_models import normalize_custom_model_id
+from trusted_router.storage_custom_models import (
+    CUSTOM_MODEL_PREFIX,
+    CUSTOM_MODEL_SLUG_PATTERN,
+    normalize_custom_model_id,
+)
 from trusted_router.storage_models import UserProvidedModel
 from trusted_router.storage_user_models import USER_PROVIDED_MODEL_LIMIT_PER_USER
 from trusted_router.types import ErrorType
@@ -46,6 +56,152 @@ from trusted_router.user_model_rules import (
     validate_user_model_display_name,
     validate_user_model_slug,
     verify_clock_signature,
+)
+
+# Availability routes intentionally sit outside the normal management-only
+# dependency: a model owner can call them with that model's signing secret.
+# That also means an anonymous caller can reach the model-id boundary. Keep the
+# pre-Store admission state process-wide and fixed-cardinality so changing the
+# id on every request cannot grow a limiter map or turn misses into unbounded
+# database work.
+_CLOCK_ROUTE_MAX_IN_FLIGHT = 16
+_CLOCK_ROUTE_MAX_LOOKUPS_PER_WINDOW = 32
+_CLOCK_ROUTE_WINDOW_SECONDS = 1.0
+
+# A probe can occupy a socket for up to twenty seconds. Two per process is
+# enough to make progress without letting signed retries consume the whole
+# outbound pool. Per-model exclusion/cadence uses fixed stripes rather than a
+# process-lifetime dict keyed by attacker-controlled model ids.
+_CLOCK_PROBE_MAX_IN_FLIGHT = 2
+_CLOCK_PROBE_CADENCE_SECONDS = 15.0
+_CLOCK_PROBE_STRIPES = 256
+
+
+class _AdmissionLease:
+    def __init__(self, release: Callable[[], None]) -> None:
+        self._release = release
+        self._released = False
+
+    def __enter__(self) -> _AdmissionLease:
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc: BaseException | None,
+        _traceback: object,
+    ) -> None:
+        self.release()
+
+    def release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        self._release()
+
+
+class _ClockRouteAdmission:
+    """Bound concurrent and per-second Store admission without keyed state."""
+
+    def __init__(
+        self,
+        *,
+        max_in_flight: int,
+        max_per_window: int,
+        window_seconds: float,
+    ) -> None:
+        self._slots = threading.BoundedSemaphore(max_in_flight)
+        self._max_per_window = max_per_window
+        self._window_seconds = window_seconds
+        self._state_lock = threading.Lock()
+        self._window_started = time.monotonic()
+        self._accepted_in_window = 0
+
+    def acquire(self) -> _AdmissionLease:
+        if not self._slots.acquire(blocking=False):
+            _raise_clock_rate_limit(1.0)
+
+        try:
+            now = time.monotonic()
+            retry_after = 0.0
+            with self._state_lock:
+                elapsed = max(0.0, now - self._window_started)
+                if elapsed >= self._window_seconds:
+                    self._window_started = now
+                    self._accepted_in_window = 0
+                    elapsed = 0.0
+
+                if self._accepted_in_window >= self._max_per_window:
+                    retry_after = max(0.001, self._window_seconds - elapsed)
+                else:
+                    self._accepted_in_window += 1
+
+            if retry_after > 0:
+                _raise_clock_rate_limit(retry_after)
+        except BaseException:
+            self._slots.release()
+            raise
+        return _AdmissionLease(self._slots.release)
+
+
+class _ClockProbeAdmission:
+    """Very small global probe pool plus striped per-model exclusion."""
+
+    def __init__(
+        self,
+        *,
+        max_in_flight: int,
+        cadence_seconds: float,
+        stripes: int,
+    ) -> None:
+        self._global_slots = threading.BoundedSemaphore(max_in_flight)
+        self._model_slots = [threading.Lock() for _ in range(stripes)]
+        self._next_allowed = [-math.inf] * stripes
+        self._state_lock = threading.Lock()
+        self._cadence_seconds = cadence_seconds
+
+    def acquire(self, model_id: str) -> _AdmissionLease:
+        stripe = _clock_stripe(model_id, len(self._model_slots))
+        model_slot = self._model_slots[stripe]
+        if not model_slot.acquire(blocking=False):
+            _raise_clock_rate_limit(1.0)
+
+        global_acquired = False
+        try:
+            now = time.monotonic()
+            with self._state_lock:
+                retry_after = self._next_allowed[stripe] - now
+            if retry_after > 0:
+                _raise_clock_rate_limit(retry_after)
+            if not self._global_slots.acquire(blocking=False):
+                _raise_clock_rate_limit(1.0)
+            global_acquired = True
+        except BaseException:
+            if global_acquired:
+                self._global_slots.release()
+            model_slot.release()
+            raise
+
+        def release() -> None:
+            with self._state_lock:
+                self._next_allowed[stripe] = (
+                    time.monotonic() + self._cadence_seconds
+                )
+            self._global_slots.release()
+            model_slot.release()
+
+        return _AdmissionLease(release)
+
+
+_CLOCK_ROUTE_ADMISSION = _ClockRouteAdmission(
+    max_in_flight=_CLOCK_ROUTE_MAX_IN_FLIGHT,
+    max_per_window=_CLOCK_ROUTE_MAX_LOOKUPS_PER_WINDOW,
+    window_seconds=_CLOCK_ROUTE_WINDOW_SECONDS,
+)
+_CLOCK_PROBE_ADMISSION = _ClockProbeAdmission(
+    max_in_flight=_CLOCK_PROBE_MAX_IN_FLIGHT,
+    cadence_seconds=_CLOCK_PROBE_CADENCE_SECONDS,
+    stripes=_CLOCK_PROBE_STRIPES,
 )
 
 
@@ -265,20 +421,25 @@ def register_user_model_routes(router: APIRouter) -> None:
         request: Request,
         settings: SettingsDep,
     ) -> dict[str, Any]:
-        existing = await _clock_target(model_id, request, settings)
-        result = await probe_user_model(existing, settings)
-        if not result.ok:
-            STORE.set_user_model_online(
+        canonical_model_id = _persisted_user_model_id(model_id)
+        with _CLOCK_ROUTE_ADMISSION.acquire():
+            existing = await _clock_target(canonical_model_id, request, settings)
+            with _CLOCK_PROBE_ADMISSION.acquire(_clock_probe_subject(existing)):
+                result = await probe_user_model(existing, settings)
+            if not result.ok:
+                await run_in_threadpool(
+                    STORE.set_user_model_online,
+                    existing.id,
+                    owner_user_id=existing.owner_user_id,
+                    online=False,
+                )
+                raise api_error(409, result.detail, ErrorType.CONFLICT)
+            updated = await run_in_threadpool(
+                STORE.set_user_model_online,
                 existing.id,
                 owner_user_id=existing.owner_user_id,
-                online=False,
+                online=True,
             )
-            raise api_error(409, result.detail, ErrorType.CONFLICT)
-        updated = STORE.set_user_model_online(
-            existing.id,
-            owner_user_id=existing.owner_user_id,
-            online=True,
-        )
         return {"data": user_model_owner_shape(updated)}
 
     @router.post("/user-models/{model_id:path}/clock-out")
@@ -287,12 +448,15 @@ def register_user_model_routes(router: APIRouter) -> None:
         request: Request,
         settings: SettingsDep,
     ) -> dict[str, Any]:
-        existing = await _clock_target(model_id, request, settings)
-        updated = STORE.set_user_model_online(
-            existing.id,
-            owner_user_id=existing.owner_user_id,
-            online=False,
-        )
+        canonical_model_id = _persisted_user_model_id(model_id)
+        with _CLOCK_ROUTE_ADMISSION.acquire():
+            existing = await _clock_target(canonical_model_id, request, settings)
+            updated = await run_in_threadpool(
+                STORE.set_user_model_online,
+                existing.id,
+                owner_user_id=existing.owner_user_id,
+                online=False,
+            )
         return {"data": user_model_owner_shape(updated)}
 
     @router.post("/user-models/{model_id:path}/heartbeat")
@@ -301,19 +465,22 @@ def register_user_model_routes(router: APIRouter) -> None:
         request: Request,
         settings: SettingsDep,
     ) -> dict[str, Any]:
-        existing = await _clock_target(model_id, request, settings)
-        interval = existing.heartbeat_interval_seconds
-        if interval is None:
-            raise api_error(
-                400,
-                "No heartbeat interval is configured for this model",
-                ErrorType.BAD_REQUEST,
+        canonical_model_id = _persisted_user_model_id(model_id)
+        with _CLOCK_ROUTE_ADMISSION.acquire():
+            existing = await _clock_target(canonical_model_id, request, settings)
+            interval = existing.heartbeat_interval_seconds
+            if interval is None:
+                raise api_error(
+                    400,
+                    "No heartbeat interval is configured for this model",
+                    ErrorType.BAD_REQUEST,
+                )
+            expires_at = datetime.now(UTC) + timedelta(seconds=2 * interval)
+            updated = await run_in_threadpool(
+                STORE.record_user_model_heartbeat,
+                existing.id,
+                expires_at=expires_at.isoformat().replace("+00:00", "Z"),
             )
-        expires_at = datetime.now(UTC) + timedelta(seconds=2 * interval)
-        updated = STORE.record_user_model_heartbeat(
-            existing.id,
-            expires_at=expires_at.isoformat().replace("+00:00", "Z"),
-        )
         return {"data": user_model_owner_shape(updated)}
 
     @router.post("/user-models/{model_id:path}/probe")
@@ -436,21 +603,18 @@ async def _clock_target(
     key can do. It deliberately does NOT extend to editing the model: changing
     endpoint_url decides where prompts go, so it stays with the owner's account.
     """
-    model = STORE.get_user_model(normalize_custom_model_id(model_id))
+    # The route validates and admits the canonical persisted id before this
+    # function. Keep the synchronous backend entirely off the event loop.
+    model = await run_in_threadpool(STORE.get_user_model, model_id)
     signature = request.headers.get("tr-signature")
     if signature and model is not None and model.encrypted_signing_secret is not None:
         try:
-            secret = decrypt_user_model_secret(
-                model.encrypted_signing_secret,
+            await run_in_threadpool(
+                _verify_model_clock_signature,
+                model,
                 settings,
-                workspace_id=model.owner_workspace_id,
-                purpose=USER_MODEL_SIGNING_PURPOSE,
-            )
-            verify_clock_signature(
-                secret,
                 signature,
                 await request.body(),
-                now=datetime.now(UTC),
             )
         except ValueError as exc:
             raise api_error(
@@ -459,8 +623,78 @@ async def _clock_target(
                 ErrorType.UNAUTHORIZED,
             ) from exc
         return model
-    principal = require_management(request, settings)
-    return _require_owner_user_model(model_id, principal)
+    principal = await run_in_threadpool(require_management, request, settings)
+    if model is None or model.owner_user_id != _owner_user_id(principal):
+        raise api_error(404, "Resource not found", ErrorType.NOT_FOUND)
+    return model
+
+
+def _persisted_user_model_id(model_id: str) -> str:
+    """Validate the bounded persisted id grammar without touching Store."""
+
+    # The canonical prefix plus the 64-character slug is well below this cap.
+    # Check raw length first so normalization never does attacker-sized work.
+    if len(model_id) > 128:
+        raise api_error(404, "Resource not found", ErrorType.NOT_FOUND)
+    canonical = normalize_custom_model_id(model_id)
+    if not canonical.startswith(CUSTOM_MODEL_PREFIX):
+        raise api_error(404, "Resource not found", ErrorType.NOT_FOUND)
+    slug = canonical.removeprefix(CUSTOM_MODEL_PREFIX)
+    if not CUSTOM_MODEL_SLUG_PATTERN.fullmatch(slug):
+        raise api_error(404, "Resource not found", ErrorType.NOT_FOUND)
+    return canonical
+
+
+def _verify_model_clock_signature(
+    model: UserProvidedModel,
+    settings: Settings,
+    signature: str,
+    body: bytes,
+) -> None:
+    encrypted_secret = model.encrypted_signing_secret
+    if encrypted_secret is None:
+        raise ValueError("model signing secret is unavailable")
+    secret = decrypt_user_model_secret(
+        encrypted_secret,
+        settings,
+        workspace_id=model.owner_workspace_id,
+        purpose=USER_MODEL_SIGNING_PURPOSE,
+    )
+    verify_clock_signature(
+        secret,
+        signature,
+        body,
+        now=datetime.now(UTC),
+    )
+
+
+def _clock_stripe(value: str, stripe_count: int) -> int:
+    digest = hashlib.sha256(value.encode("utf-8")).digest()
+    return int.from_bytes(digest[:4], "big") % stripe_count
+
+
+def _clock_probe_subject(model: UserProvidedModel) -> str:
+    # Recreating a deleted model with the same slug is a new persisted model,
+    # so it must not inherit the old incarnation's cooldown. The encrypted
+    # signing secret is unique per creation/rotation; hash it before building
+    # the fixed-stripe subject so limiter state never retains ciphertext.
+    encrypted_secret = model.encrypted_signing_secret
+    incarnation = (
+        f"{encrypted_secret.ciphertext}:{encrypted_secret.nonce}"
+        if encrypted_secret is not None
+        else model.created_at
+    )
+    incarnation_hash = hashlib.sha256(incarnation.encode("utf-8")).hexdigest()
+    return f"{model.id}:{incarnation_hash}"
+
+
+def _raise_clock_rate_limit(retry_after_seconds: float) -> NoReturn:
+    raise api_error(
+        429,
+        "Model availability endpoint is busy; retry",
+        ErrorType.RATE_LIMITED,
+        headers={"Retry-After": str(max(1, math.ceil(retry_after_seconds)))},
+    )
 
 
 def _require_owner_user_model(

--- a/src/trusted_router/routes/user_models_public.py
+++ b/src/trusted_router/routes/user_models_public.py
@@ -2,30 +2,80 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Response
+from starlette.concurrency import run_in_threadpool
 
 from trusted_router.errors import api_error
-from trusted_router.serialization import user_model_public_shape
+from trusted_router.public_user_models import (
+    PUBLIC_USER_MODEL_CACHE_CONTROL,
+    PublicUserModelReadLimited,
+    PublicUserModelUnavailable,
+    cached_public_user_model,
+    cached_public_user_model_list,
+    normalized_public_user_model_id,
+)
 from trusted_router.storage import STORE
-from trusted_router.storage_custom_models import normalize_custom_model_id
 from trusted_router.types import ErrorType
 
 
 def register_user_model_public_routes(router: APIRouter) -> None:
     @router.get("/models/user-provided")
     async def list_public_user_models(
+        response: Response,
         kind: Literal["machine", "agent", "human"] | None = Query(default=None),
     ) -> dict[str, Any]:
-        return {
-            "data": [
-                user_model_public_shape(model)
-                for model in STORE.list_public_user_models(kind=kind)
-            ]
-        }
+        try:
+            rows = await run_in_threadpool(
+                cached_public_user_model_list,
+                kind,
+                lambda limit: STORE.list_public_user_models(kind=kind, limit=limit),
+            )
+        except PublicUserModelUnavailable as exc:
+            raise api_error(
+                503,
+                "Public model listing temporarily unavailable",
+                ErrorType.SERVICE_UNAVAILABLE,
+                headers={"Retry-After": "2", "cache-control": "no-store"},
+            ) from exc
+        response.headers["cache-control"] = PUBLIC_USER_MODEL_CACHE_CONTROL
+        return {"data": rows}
 
     @router.get("/models/user-provided/{model_id:path}")
-    async def get_public_user_model(model_id: str) -> dict[str, Any]:
-        model = STORE.get_user_model(normalize_custom_model_id(model_id))
-        if model is None or not model.enabled or model.status != "active":
-            raise api_error(404, "Resource not found", ErrorType.NOT_FOUND)
-        return {"data": user_model_public_shape(model)}
+    async def get_public_user_model(model_id: str, response: Response) -> dict[str, Any]:
+        normalized = normalized_public_user_model_id(model_id)
+        response.headers["cache-control"] = PUBLIC_USER_MODEL_CACHE_CONTROL
+        if normalized is None:
+            raise api_error(
+                404,
+                "Resource not found",
+                ErrorType.NOT_FOUND,
+                headers={"cache-control": PUBLIC_USER_MODEL_CACHE_CONTROL},
+            )
+        try:
+            shape = await run_in_threadpool(
+                cached_public_user_model,
+                normalized,
+                lambda: STORE.get_user_model(normalized),
+            )
+        except PublicUserModelReadLimited as exc:
+            raise api_error(
+                429,
+                "Public model lookup rate exceeded",
+                ErrorType.RATE_LIMITED,
+                headers={"Retry-After": "30", "cache-control": "no-store"},
+            ) from exc
+        except PublicUserModelUnavailable as exc:
+            raise api_error(
+                503,
+                "Public model lookup temporarily unavailable",
+                ErrorType.SERVICE_UNAVAILABLE,
+                headers={"Retry-After": "2", "cache-control": "no-store"},
+            ) from exc
+        if shape is None:
+            raise api_error(
+                404,
+                "Resource not found",
+                ErrorType.NOT_FOUND,
+                headers={"cache-control": PUBLIC_USER_MODEL_CACHE_CONTROL},
+            )
+        return {"data": shape}

--- a/src/trusted_router/services/paypal_billing.py
+++ b/src/trusted_router/services/paypal_billing.py
@@ -89,7 +89,7 @@ def create_paypal_checkout_session(
     if workspace is None:
         raise api_error(404, "Workspace not found", ErrorType.NOT_FOUND)
 
-    if not settings.paypal_enabled:
+    if not settings.paypal_checkout_ready:
         if settings.environment.lower() in {"local", "test"}:
             record_checkout_started(
                 workspace_id,
@@ -174,7 +174,7 @@ def capture_paypal_order_for_workspace(
     workspace_id: str,
     settings: Settings,
 ) -> PayPalCaptureResult:
-    if not settings.paypal_enabled:
+    if not settings.paypal_checkout_ready:
         raise api_error(400, "PayPal checkout is not configured", ErrorType.BAD_REQUEST)
     order = _paypal_post(
         settings,
@@ -248,7 +248,7 @@ def verify_paypal_webhook_signature(
     event: Mapping[str, Any],
     settings: Settings,
 ) -> None:
-    if not settings.paypal_enabled:
+    if not settings.paypal_client_id or not settings.paypal_client_secret:
         raise api_error(400, "PayPal webhook is not configured", ErrorType.BAD_REQUEST)
     if not settings.paypal_webhook_id:
         if settings.environment.lower() in {"local", "test"}:

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -79,7 +79,7 @@ from trusted_router.storage_models import (
     normalize_provider_access_role,
     normalize_provider_access_slug,
 )
-from trusted_router.storage_oauth_codes import InMemoryOAuthCodes
+from trusted_router.storage_oauth_codes import InMemoryOAuthCodes, OAuthCodeExchange
 from trusted_router.storage_rate_limits import InMemoryRateLimits
 from trusted_router.storage_synthetic import InMemorySyntheticChecks
 from trusted_router.storage_user_models import InMemoryUserProvidedModels
@@ -147,13 +147,21 @@ class InMemoryStore:
         self.broadcast_store = InMemoryBroadcastDestinations(lock=self._lock)
         self.video_job_store = InMemoryVideoJobs(lock=self._lock)
         self.auth_session_store = InMemoryAuthSessions(lock=self._lock)
-        self.oauth_code_store = InMemoryOAuthCodes(lock=self._lock)
+        self.oauth_code_store = InMemoryOAuthCodes(
+            lock=self._lock,
+            workspaces=self.workspaces,
+            users=self.users,
+            api_keys=self.api_keys.keys,
+            api_key_ids_by_lookup_hash=self.api_keys.key_ids_by_lookup_hash,
+        )
         self.rate_limit_store = InMemoryRateLimits(lock=self._lock)
         self.wallet_challenges = InMemoryWalletChallenges()
         self.verification_tokens = InMemoryVerificationTokens()
         self.email_blocks = InMemoryEmailBlocks()
 
     def reset(self) -> None:
+        from trusted_router.public_user_models import reset_public_user_model_cache
+
         with self._lock:
             self.users.clear()
             self.user_ids_by_email.clear()
@@ -188,6 +196,7 @@ class InMemoryStore:
             self.wallet_challenges.reset()
             self.verification_tokens.reset()
             self.email_blocks.reset()
+        reset_public_user_model_cache()
 
     def readiness_check(self) -> None:
         """The in-memory backend has no external serving dependency."""
@@ -766,6 +775,25 @@ class InMemoryStore:
             tags=tags,
         )
 
+    def issue_chat_browser_key(
+        self,
+        *,
+        workspace_id: str,
+        name: str,
+        creator_user_id: str,
+        limit_microdollars: int,
+        expires_at: str,
+        active_key_cap: int,
+    ) -> tuple[str, ApiKey] | None:
+        return self.api_keys.issue_chat_browser_key(
+            workspace_id=workspace_id,
+            name=name,
+            creator_user_id=creator_user_id,
+            limit_microdollars=limit_microdollars,
+            expires_at=expires_at,
+            active_key_cap=active_key_cap,
+        )
+
     def get_key_by_hash(self, key_hash: str) -> ApiKey | None:
         return self.api_keys.get_by_hash(key_hash)
 
@@ -1112,8 +1140,9 @@ class InMemoryStore:
         self,
         *,
         kind: str | None = None,
+        limit: int | None = None,
     ) -> list[UserProvidedModel]:
-        return self.user_model_store.list_public(kind=kind)
+        return self.user_model_store.list_public(kind=kind, limit=limit)
 
     def create_broadcast_destination(
         self,
@@ -2218,6 +2247,19 @@ class InMemoryStore:
     def consume_oauth_authorization_code(self, raw_code: str) -> OAuthAuthorizationCode | None:
         return self.oauth_code_store.consume(raw_code)
 
+    def exchange_oauth_authorization_code(
+        self,
+        raw_code: str,
+        *,
+        code_verifier: str | None,
+        code_challenge_method: str | None,
+    ) -> OAuthCodeExchange | None:
+        return self.oauth_code_store.exchange(
+            raw_code,
+            code_verifier=code_verifier,
+            code_challenge_method=code_challenge_method,
+        )
+
     # ── Email send blocks (SES bounce/complaint suppression) ────────────
     # Delegates to the composed InMemoryEmailBlocks store; see
     # storage_email_blocks.py for the data + logic.
@@ -2339,7 +2381,10 @@ STORE: Store = cast(Store, _STORE_PROXY)
 
 
 def configure_store(target: Store) -> None:
+    from trusted_router.public_user_models import reset_public_user_model_cache
+
     _STORE_PROXY._configure(target)
+    reset_public_user_model_cache()
 
 
 def typed_billing_store(store: Any = None) -> TypedBillingStore | None:

--- a/src/trusted_router/storage_chat_browser_keys.py
+++ b/src/trusted_router/storage_chat_browser_keys.py
@@ -1,0 +1,91 @@
+"""Shared invariants for automatically issued chat-browser API keys.
+
+The route returns the raw key exactly once.  Storage persists only the same
+salted hash, lookup hash, and short label as every other API key; this module
+never accepts a previously stored secret and therefore cannot recover one.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+from trusted_router.security import (
+    hash_api_key,
+    key_label,
+    lookup_hash_api_key,
+    new_api_key,
+    new_hash_salt,
+    new_key_id,
+)
+from trusted_router.storage_models import ApiKey
+
+CHAT_BROWSER_KEY_NAME_PREFIX = "chat-browser-"
+CHAT_BROWSER_KEY_TAG = "trustedrouter_key_kind"
+CHAT_BROWSER_KEY_TAG_VALUE = "chat-browser"
+CHAT_BROWSER_KEY_GUARD_KIND = "chat_browser_key_guard"
+
+
+def is_active_chat_browser_key(
+    key: ApiKey,
+    *,
+    now: dt.datetime | None = None,
+) -> bool:
+    """Return whether ``key`` consumes one durable browser-key slot.
+
+    The name fallback includes keys issued before the purpose tag existed.
+    An invalid expiry is treated as expired, matching API-key authentication's
+    fail-closed timestamp handling.
+    """
+    is_browser_key = (
+        key.tags.get(CHAT_BROWSER_KEY_TAG) == CHAT_BROWSER_KEY_TAG_VALUE
+        or key.name.startswith(CHAT_BROWSER_KEY_NAME_PREFIX)
+    )
+    if not is_browser_key or key.disabled:
+        return False
+    if key.expires_at is None:
+        return True
+    try:
+        expires_at = dt.datetime.fromisoformat(key.expires_at.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=dt.UTC)
+    instant = now or dt.datetime.now(dt.UTC)
+    if instant.tzinfo is None:
+        instant = instant.replace(tzinfo=dt.UTC)
+    return expires_at > instant
+
+
+def new_chat_browser_api_key(
+    *,
+    workspace_id: str,
+    name: str,
+    creator_user_id: str,
+    limit_microdollars: int,
+    expires_at: str,
+) -> tuple[str, ApiKey]:
+    """Create the one-shot raw value and its hash-only durable record."""
+    raw = new_api_key()
+    salt = new_hash_salt()
+    key = ApiKey(
+        hash=new_key_id(),
+        salt=salt,
+        secret_hash=hash_api_key(raw, salt),
+        lookup_hash=lookup_hash_api_key(raw),
+        name=name,
+        label=key_label(raw),
+        workspace_id=workspace_id,
+        creator_user_id=creator_user_id,
+        management=False,
+        limit_microdollars=limit_microdollars,
+        include_byok_in_limit=True,
+        expires_at=expires_at,
+        tags={CHAT_BROWSER_KEY_TAG: CHAT_BROWSER_KEY_TAG_VALUE},
+        usage_shard_count=1,
+    )
+    return raw, key
+
+
+def validate_chat_browser_key_cap(active_key_cap: int) -> None:
+    if active_key_cap < 1:
+        raise ValueError("active chat-browser key cap must be positive")

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -154,6 +154,7 @@ from trusted_router.storage_models import (
     UserModelPayout,
     _is_expired,
 )
+from trusted_router.storage_oauth_codes import OAuthCodeExchange
 from trusted_router.types import IdentityVerificationStatus, UsageType
 
 T = TypeVar("T")
@@ -1282,6 +1283,19 @@ class SpannerBigtableStore:
     def consume_oauth_authorization_code(self, raw_code: str) -> OAuthAuthorizationCode | None:
         return self.oauth_code_store.consume(raw_code)
 
+    def exchange_oauth_authorization_code(
+        self,
+        raw_code: str,
+        *,
+        code_verifier: str | None,
+        code_challenge_method: str | None,
+    ) -> OAuthCodeExchange | None:
+        return self.oauth_code_store.exchange(
+            raw_code,
+            code_verifier=code_verifier,
+            code_challenge_method=code_challenge_method,
+        )
+
     # API key + per-key spend cap. The actual logic lives in
     # storage_gcp_keys.SpannerApiKeys; these methods are thin delegations.
     def create_api_key(
@@ -1322,6 +1336,25 @@ class SpannerBigtableStore:
             budget_alert_only=budget_alert_only,
             tags=tags,
             usage_shard_count=usage_shard_count,
+        )
+
+    def issue_chat_browser_key(
+        self,
+        *,
+        workspace_id: str,
+        name: str,
+        creator_user_id: str,
+        limit_microdollars: int,
+        expires_at: str,
+        active_key_cap: int,
+    ) -> tuple[str, ApiKey] | None:
+        return self.api_keys.issue_chat_browser_key(
+            workspace_id=workspace_id,
+            name=name,
+            creator_user_id=creator_user_id,
+            limit_microdollars=limit_microdollars,
+            expires_at=expires_at,
+            active_key_cap=active_key_cap,
         )
 
     def get_key_by_hash(self, key_hash: str) -> ApiKey | None:
@@ -1695,8 +1728,9 @@ class SpannerBigtableStore:
         self,
         *,
         kind: str | None = None,
+        limit: int | None = None,
     ) -> list[UserProvidedModel]:
-        return self.user_model_store.list_public(kind=kind)
+        return self.user_model_store.list_public(kind=kind, limit=limit)
 
     def create_broadcast_destination(
         self,

--- a/src/trusted_router/storage_gcp_keys.py
+++ b/src/trusted_router/storage_gcp_keys.py
@@ -24,6 +24,12 @@ from trusted_router.security import (
     new_key_id,
     verify_api_key,
 )
+from trusted_router.storage_chat_browser_keys import (
+    CHAT_BROWSER_KEY_GUARD_KIND,
+    is_active_chat_browser_key,
+    new_chat_browser_api_key,
+    validate_chat_browser_key_cap,
+)
 from trusted_router.storage_gcp_codec import workspace_key_id as _workspace_key_id
 from trusted_router.storage_gcp_counters import (
     KEY_LIMIT_COLUMNS,
@@ -186,6 +192,90 @@ class SpannerApiKeys:
                 {"key_id": key.hash},
             )
         return raw, key
+
+    def issue_chat_browser_key(
+        self,
+        *,
+        workspace_id: str,
+        name: str,
+        creator_user_id: str,
+        limit_microdollars: int,
+        expires_at: str,
+        active_key_cap: int,
+    ) -> tuple[str, ApiKey] | None:
+        """Serialize cap check + key creation on one workspace guard row."""
+        validate_chat_browser_key_cap(active_key_cap)
+
+        def txn(transaction: Any) -> tuple[str, ApiKey] | None:
+            guard = self._io.read_entity_tx(
+                transaction,
+                CHAT_BROWSER_KEY_GUARD_KIND,
+                workspace_id,
+                dict,
+            )
+            rows = list(
+                transaction.execute_sql(
+                    _CONSOLE_API_KEYS_SQL,
+                    params={
+                        "workspace_id": workspace_id,
+                        "prefix": f"{workspace_id}#",
+                    },
+                    param_types={
+                        "workspace_id": self._io.param_types.STRING,
+                        "prefix": self._io.param_types.STRING,
+                    },
+                )
+            )
+            keys_by_hash: dict[str, ApiKey] = {}
+            for row in rows:
+                key = api_key_from_json(row[0])
+                keys_by_hash[key.hash] = key
+            if (
+                sum(is_active_chat_browser_key(key) for key in keys_by_hash.values())
+                >= active_key_cap
+            ):
+                # No raw secret, key id, salt, or durable row is created on
+                # refusal. The transaction is read-only in this branch.
+                return None
+
+            raw, key = new_chat_browser_api_key(
+                workspace_id=workspace_id,
+                name=name,
+                creator_user_id=creator_user_id,
+                limit_microdollars=limit_microdollars,
+                expires_at=expires_at,
+            )
+            self._io.write_entity_tx(transaction, "api_key", key.hash, key)
+            transaction.insert_or_update(
+                table=KEY_LIMIT_TABLE,
+                columns=KEY_LIMIT_COLUMNS,
+                values=key_limit_mirror_rows(
+                    key.hash,
+                    key,
+                    self._io.spanner_module.COMMIT_TIMESTAMP,
+                ),
+            )
+            self._io.write_entity_tx(
+                transaction,
+                "api_key_lookup",
+                key.lookup_hash,
+                {"key_id": key.hash},
+            )
+            self._io.write_entity_tx(
+                transaction,
+                "api_key_by_workspace",
+                _workspace_key_id(workspace_id, key.hash),
+                {"key_id": key.hash},
+            )
+            self._io.write_entity_tx(
+                transaction,
+                CHAT_BROWSER_KEY_GUARD_KIND,
+                workspace_id,
+                {"revision": int((guard or {}).get("revision", 0)) + 1},
+            )
+            return raw, key
+
+        return run_in_transaction_with_retry(self._io.database, txn)
 
     def get_by_hash(self, key_hash: str) -> ApiKey | None:
         return self._io.read_entity("api_key", key_hash, ApiKey)

--- a/src/trusted_router/storage_gcp_oauth_codes.py
+++ b/src/trusted_router/storage_gcp_oauth_codes.py
@@ -17,12 +17,29 @@ from trusted_router.security import (
     new_key_id,
     verify_api_key,
 )
-from trusted_router.storage_gcp_io import SpannerIO
+from trusted_router.storage_gcp_codec import workspace_key_id as _workspace_key_id
+from trusted_router.storage_gcp_counters import (
+    KEY_LIMIT_COLUMNS,
+    KEY_LIMIT_TABLE,
+    credit_shard_count,
+    key_limit_mirror_rows,
+)
+from trusted_router.storage_gcp_io import SpannerIO, run_in_transaction_with_retry
 from trusted_router.storage_models import (
+    CreditAccount,
     OAuthAuthorizationCode,
+    User,
+    Workspace,
     _is_expired,
     iso_now,
     utcnow,
+)
+from trusted_router.storage_oauth_codes import (
+    OAuthCodeExchange,
+    OAuthWorkspaceBillingPaused,
+    OAuthWorkspaceUnavailable,
+    new_oauth_delegated_api_key,
+    verify_oauth_pkce,
 )
 
 
@@ -109,3 +126,114 @@ class SpannerOAuthCodes:
             return code
 
         return self._io.database.run_in_transaction(txn)
+
+    def exchange(
+        self,
+        raw_code: str,
+        *,
+        code_verifier: str | None,
+        code_challenge_method: str | None,
+    ) -> OAuthCodeExchange | None:
+        """Atomically verify the grant and persist its delegated API key."""
+        lookup_hash = lookup_hash_api_key(raw_code)
+
+        def txn(transaction: Any) -> OAuthCodeExchange | None:
+            lookup = self._io.read_entity_tx(
+                transaction,
+                "oauth_code_lookup",
+                lookup_hash,
+                dict,
+            )
+            if not lookup:
+                return None
+            code = self._io.read_entity_tx(
+                transaction,
+                "oauth_code",
+                str(lookup["code_id"]),
+                OAuthAuthorizationCode,
+            )
+            if code is None or code.consumed_at is not None:
+                return None
+            if _is_expired(code.code_expires_at):
+                self._io.delete_entities_tx(transaction, "oauth_code", [code.hash])
+                self._io.delete_entities_tx(
+                    transaction,
+                    "oauth_code_lookup",
+                    [lookup_hash],
+                )
+                return None
+            if not verify_api_key(raw_code, code.salt, code.secret_hash):
+                return None
+
+            verify_oauth_pkce(
+                code,
+                code_verifier=code_verifier,
+                code_challenge_method=code_challenge_method,
+            )
+            workspace = self._io.read_entity_tx(
+                transaction,
+                "workspace",
+                code.workspace_id,
+                Workspace,
+            )
+            if workspace is None or workspace.deleted:
+                raise OAuthWorkspaceUnavailable
+            if workspace.billing_paused:
+                raise OAuthWorkspaceBillingPaused
+            user = (
+                self._io.read_entity_tx(transaction, "user", code.user_id, User)
+                if code.user_id
+                else None
+            )
+
+            usage_shard_count = 1
+            if code.limit_microdollars is None:
+                # Match SpannerBigtableStore.create_api_key without its
+                # pre-transaction cache: a concurrent reshard changes this
+                # entity and therefore aborts/retries the whole exchange.
+                credit = self._io.read_entity_tx(
+                    transaction,
+                    "credit",
+                    code.workspace_id,
+                    CreditAccount,
+                )
+                if credit is None:
+                    raise OAuthWorkspaceUnavailable
+                usage_shard_count = credit_shard_count(credit)
+
+            raw_key, key = new_oauth_delegated_api_key(
+                code,
+                usage_shard_count=usage_shard_count,
+            )
+            self._io.write_entity_tx(transaction, "api_key", key.hash, key)
+            transaction.insert_or_update(
+                table=KEY_LIMIT_TABLE,
+                columns=KEY_LIMIT_COLUMNS,
+                values=key_limit_mirror_rows(
+                    key.hash,
+                    key,
+                    self._io.spanner_module.COMMIT_TIMESTAMP,
+                ),
+            )
+            self._io.write_entity_tx(
+                transaction,
+                "api_key_lookup",
+                key.lookup_hash,
+                {"key_id": key.hash},
+            )
+            self._io.write_entity_tx(
+                transaction,
+                "api_key_by_workspace",
+                _workspace_key_id(code.workspace_id, key.hash),
+                {"key_id": key.hash},
+            )
+            code.consumed_at = iso_now()
+            self._io.write_entity_tx(transaction, "oauth_code", code.hash, code)
+            return OAuthCodeExchange(
+                raw_key=raw_key,
+                api_key=key,
+                authorization_code=code,
+                user=user,
+            )
+
+        return run_in_transaction_with_retry(self._io.database, txn)

--- a/src/trusted_router/storage_gcp_user_models.py
+++ b/src/trusted_router/storage_gcp_user_models.py
@@ -406,21 +406,37 @@ class SpannerUserProvidedModels:
             [_user_model_slot_id(normalize_custom_model_id(model_id), authorization_id)],
         )
 
-    def list_public(self, *, kind: str | None = None) -> list[UserProvidedModel]:
-        rows = self._io.list_entities(
-            _USER_PROVIDED_MODEL_KIND,
-            prefix="",
-            cls=UserProvidedModel,
+    def list_public(
+        self,
+        *,
+        kind: str | None = None,
+        limit: int | None = None,
+    ) -> list[UserProvidedModel]:
+        where = (
+            "kind=@entity_kind "
+            "AND JSON_VALUE(body, '$.enabled')='true' "
+            "AND JSON_VALUE(body, '$.status')='active'"
         )
-        models = [
-            model
-            for model in rows
-            if model.enabled
-            and model.status == "active"
-            and (kind is None or model.kind == kind)
-        ]
-        models.sort(key=lambda item: item.created_at)
-        return models
+        params: dict[str, Any] = {"entity_kind": _USER_PROVIDED_MODEL_KIND}
+        param_types: dict[str, Any] = {
+            "entity_kind": self._io.param_types.STRING,
+        }
+        if kind is not None:
+            where += " AND JSON_VALUE(body, '$.kind')=@model_kind"
+            params["model_kind"] = kind
+            param_types["model_kind"] = self._io.param_types.STRING
+        suffix = " ORDER BY JSON_VALUE(body, '$.created_at'), id"
+        if limit is not None:
+            suffix += " LIMIT @limit"
+            params["limit"] = max(0, int(limit))
+            param_types["limit"] = self._io.param_types.INT64
+        with self._io.database.snapshot() as snapshot:
+            rows = snapshot.execute_sql(
+                f"SELECT body FROM tr_entities WHERE {where}{suffix}",  # noqa: S608 - predicates are fixed; values are bound parameters.
+                params=params,
+                param_types=param_types,
+            )
+            return [_decode_user_model(row[0]) for row in rows]
 
     def _mutate(
         self,

--- a/src/trusted_router/storage_keys.py
+++ b/src/trusted_router/storage_keys.py
@@ -41,6 +41,11 @@ from trusted_router.spend_windows import (
     utcnow,
     window_floors,
 )
+from trusted_router.storage_chat_browser_keys import (
+    is_active_chat_browser_key,
+    new_chat_browser_api_key,
+    validate_chat_browser_key_cap,
+)
 from trusted_router.storage_errors import DeferredSettlementCapReached
 from trusted_router.storage_models import (
     ApiKey,
@@ -145,6 +150,37 @@ class InMemoryApiKeys:
             self.keys[key_id] = api_key
             self.key_ids_by_lookup_hash[lookup_hash] = key_id
             return key, api_key
+
+    def issue_chat_browser_key(
+        self,
+        *,
+        workspace_id: str,
+        name: str,
+        creator_user_id: str,
+        limit_microdollars: int,
+        expires_at: str,
+        active_key_cap: int,
+    ) -> tuple[str, ApiKey] | None:
+        """Atomically refuse before secret generation when the cap is full."""
+        validate_chat_browser_key_cap(active_key_cap)
+        with self._lock:
+            active = sum(
+                is_active_chat_browser_key(key)
+                for key in self.keys.values()
+                if key.workspace_id == workspace_id
+            )
+            if active >= active_key_cap:
+                return None
+            raw, key = new_chat_browser_api_key(
+                workspace_id=workspace_id,
+                name=name,
+                creator_user_id=creator_user_id,
+                limit_microdollars=limit_microdollars,
+                expires_at=expires_at,
+            )
+            self.keys[key.hash] = key
+            self.key_ids_by_lookup_hash[key.lookup_hash] = key.hash
+            return raw, key
 
     def get_by_hash(self, key_hash: str) -> ApiKey | None:
         with self._lock:

--- a/src/trusted_router/storage_oauth_codes.py
+++ b/src/trusted_router/storage_oauth_codes.py
@@ -1,16 +1,22 @@
-"""OAuth authorization codes: short-lived single-use grants used by the
-TrustedRouter-as-OAuth-IdP flow to issue scoped API keys to third-party
-apps. Mints a raw secret + record on `create`, validates + marks consumed
-on `consume`. PKCE challenge is stored on the record but verification
-lives in the OAuth route handler."""
+"""OAuth authorization-code creation and atomic delegated-key exchange.
+
+The raw authorization code and delegated API key are returned once and never
+persisted. Exchange belongs in storage because PKCE verification, grant
+consumption, and every key/index/limit write must commit or roll back together.
+"""
 
 from __future__ import annotations
 
+import base64
 import datetime as dt
+import hashlib
+import hmac
 import threading
+from dataclasses import dataclass
 
 from trusted_router.security import (
     hash_api_key,
+    key_label,
     lookup_hash_api_key,
     new_api_key,
     new_hash_salt,
@@ -18,16 +24,130 @@ from trusted_router.security import (
     verify_api_key,
 )
 from trusted_router.storage_models import (
+    ApiKey,
     OAuthAuthorizationCode,
+    User,
+    Workspace,
     _is_expired,
     iso_now,
     utcnow,
 )
 
 
+class OAuthCodeVerifierRequired(ValueError):
+    """The grant requires PKCE but the exchange omitted its verifier."""
+
+
+class OAuthCodeVerifierNotAscii(ValueError):
+    """S256 PKCE requires an ASCII verifier."""
+
+
+class OAuthCodeVerifierMismatch(ValueError):
+    """The supplied PKCE verifier does not satisfy the grant."""
+
+
+class OAuthCodeMethodMismatch(ValueError):
+    """The exchange supplied a method different from the grant's method."""
+
+
+class OAuthWorkspaceUnavailable(RuntimeError):
+    """The grant's workspace disappeared before exchange."""
+
+
+class OAuthWorkspaceBillingPaused(RuntimeError):
+    """The grant's workspace is quiesced and may not mint a key."""
+
+
+@dataclass(frozen=True)
+class OAuthCodeExchange:
+    """One committed authorization-code exchange.
+
+    ``user`` is read inside the same transaction so a post-commit identity
+    lookup cannot turn a consumed grant into a failed response with no
+    recoverable raw key.
+    """
+
+    raw_key: str
+    api_key: ApiKey
+    authorization_code: OAuthAuthorizationCode
+    user: User | None
+
+
+def verify_oauth_pkce(
+    code: OAuthAuthorizationCode,
+    *,
+    code_verifier: str | None,
+    code_challenge_method: str | None,
+) -> None:
+    """Validate the exchange proof without mutating the grant."""
+    if not code.code_challenge:
+        return
+    if (
+        code_challenge_method not in {None, ""}
+        and code_challenge_method != code.code_challenge_method
+    ):
+        raise OAuthCodeMethodMismatch
+    verifier = code_verifier or ""
+    if not verifier:
+        raise OAuthCodeVerifierRequired
+    if code.code_challenge_method == "plain":
+        expected = verifier
+    else:
+        try:
+            verifier_bytes = verifier.encode("ascii")
+        except UnicodeEncodeError as exc:
+            raise OAuthCodeVerifierNotAscii from exc
+        expected = (
+            base64.urlsafe_b64encode(hashlib.sha256(verifier_bytes).digest())
+            .decode("ascii")
+            .rstrip("=")
+        )
+    if not hmac.compare_digest(expected, code.code_challenge):
+        raise OAuthCodeVerifierMismatch
+
+
+def new_oauth_delegated_api_key(
+    code: OAuthAuthorizationCode,
+    *,
+    usage_shard_count: int = 1,
+) -> tuple[str, ApiKey]:
+    """Build the response-only raw key and its hash-only durable record."""
+    raw = new_api_key()
+    salt = new_hash_salt()
+    key = ApiKey(
+        hash=new_key_id(),
+        salt=salt,
+        secret_hash=hash_api_key(raw, salt),
+        lookup_hash=lookup_hash_api_key(raw),
+        name=code.key_label,
+        label=key_label(raw),
+        workspace_id=code.workspace_id,
+        creator_user_id=code.user_id,
+        management=False,
+        limit_microdollars=code.limit_microdollars,
+        limit_reset=code.limit_reset,
+        include_byok_in_limit=True,
+        expires_at=code.expires_at,
+        usage_shard_count=usage_shard_count,
+    )
+    return raw, key
+
+
 class InMemoryOAuthCodes:
-    def __init__(self, *, lock: threading.RLock) -> None:
+    def __init__(
+        self,
+        *,
+        lock: threading.RLock,
+        workspaces: dict[str, Workspace],
+        users: dict[str, User],
+        api_keys: dict[str, ApiKey],
+        api_key_ids_by_lookup_hash: dict[str, str],
+    ) -> None:
         self._lock = lock
+        self._workspaces = workspaces
+        self._users = users
+        self._api_keys = api_keys
+        self._api_key_ids_by_lookup_hash = api_key_ids_by_lookup_hash
         self.codes: dict[str, OAuthAuthorizationCode] = {}
         self.code_ids_by_lookup_hash: dict[str, str] = {}
 
@@ -102,3 +222,65 @@ class InMemoryOAuthCodes:
                 return None
             code.consumed_at = iso_now()
             return code
+
+    def exchange(
+        self,
+        raw_code: str,
+        *,
+        code_verifier: str | None,
+        code_challenge_method: str | None,
+    ) -> OAuthCodeExchange | None:
+        """Verify, consume, and mint under the Store's shared lock."""
+        with self._lock:
+            lookup_hash = lookup_hash_api_key(raw_code)
+            code_id = self.code_ids_by_lookup_hash.get(lookup_hash)
+            code = self.codes.get(code_id) if code_id is not None else None
+            if code is None or code.consumed_at is not None:
+                return None
+            if _is_expired(code.code_expires_at):
+                self.codes.pop(code.hash, None)
+                self.code_ids_by_lookup_hash.pop(lookup_hash, None)
+                return None
+            if not verify_api_key(raw_code, code.salt, code.secret_hash):
+                return None
+
+            verify_oauth_pkce(
+                code,
+                code_verifier=code_verifier,
+                code_challenge_method=code_challenge_method,
+            )
+            workspace = self._workspaces.get(code.workspace_id)
+            if workspace is None or workspace.deleted:
+                raise OAuthWorkspaceUnavailable
+            if bool(getattr(workspace, "billing_paused", False)):
+                raise OAuthWorkspaceBillingPaused
+
+            # Generate every fallible value before mutating durable state.
+            user = self._users.get(code.user_id) if code.user_id else None
+            raw_key, key = new_oauth_delegated_api_key(code)
+            key_existed = key.hash in self._api_keys
+            previous_key = self._api_keys.get(key.hash)
+            lookup_existed = key.lookup_hash in self._api_key_ids_by_lookup_hash
+            previous_key_id = self._api_key_ids_by_lookup_hash.get(key.lookup_hash)
+            previous_consumed_at = code.consumed_at
+            try:
+                self._api_keys[key.hash] = key
+                self._api_key_ids_by_lookup_hash[key.lookup_hash] = key.hash
+                code.consumed_at = iso_now()
+            except BaseException:
+                if key_existed and previous_key is not None:
+                    self._api_keys[key.hash] = previous_key
+                else:
+                    self._api_keys.pop(key.hash, None)
+                if lookup_existed and previous_key_id is not None:
+                    self._api_key_ids_by_lookup_hash[key.lookup_hash] = previous_key_id
+                else:
+                    self._api_key_ids_by_lookup_hash.pop(key.lookup_hash, None)
+                code.consumed_at = previous_consumed_at
+                raise
+            return OAuthCodeExchange(
+                raw_key=raw_key,
+                api_key=key,
+                authorization_code=code,
+                user=user,
+            )

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -53,6 +53,11 @@ from trusted_router.security import (
 )
 from trusted_router.spend_windows import KeyWindowLimitExceeded, window_floors
 from trusted_router.storage_auth_context import build_session_auth_context
+from trusted_router.storage_chat_browser_keys import (
+    is_active_chat_browser_key,
+    new_chat_browser_api_key,
+    validate_chat_browser_key_cap,
+)
 from trusted_router.storage_codec import json_body
 from trusted_router.storage_custom_models import normalize_custom_model_id
 from trusted_router.storage_errors import (
@@ -116,6 +121,13 @@ from trusted_router.storage_models import (
     normalize_provider_access_role,
     normalize_provider_access_slug,
     utcnow,
+)
+from trusted_router.storage_oauth_codes import (
+    OAuthCodeExchange,
+    OAuthWorkspaceBillingPaused,
+    OAuthWorkspaceUnavailable,
+    new_oauth_delegated_api_key,
+    verify_oauth_pkce,
 )
 from trusted_router.storage_postgres_group_buy import PostgresBedrockGroupBuy
 from trusted_router.storage_postgres_operational_analytics_outbox import (
@@ -1641,6 +1653,99 @@ class PostgresStore:
             expiry_field="code_expires_at",
         )
 
+    def exchange_oauth_authorization_code(
+        self,
+        raw_code: str,
+        *,
+        code_verifier: str | None,
+        code_challenge_method: str | None,
+    ) -> OAuthCodeExchange | None:
+        """Lock, verify, consume, and mint in one SQL transaction."""
+        lookup_hash = lookup_hash_api_key(raw_code)
+
+        def exchange(conn: Any) -> OAuthCodeExchange | None:
+            lookup = self._read_entity_tx(
+                conn,
+                "oauth_code_lookup",
+                lookup_hash,
+                dict,
+            )
+            if lookup is None:
+                return None
+            code = self._read_entity_tx(
+                conn,
+                "oauth_code",
+                str(lookup["code_id"]),
+                OAuthAuthorizationCode,
+                for_update=True,
+            )
+            if code is None or code.consumed_at is not None:
+                return None
+            if _is_expired(code.code_expires_at):
+                return None
+            if not verify_api_key(raw_code, code.salt, code.secret_hash):
+                return None
+
+            verify_oauth_pkce(
+                code,
+                code_verifier=code_verifier,
+                code_challenge_method=code_challenge_method,
+            )
+            workspace = self._read_entity_tx(
+                conn,
+                "workspace",
+                code.workspace_id,
+                Workspace,
+                for_update=True,
+            )
+            if workspace is None or workspace.deleted:
+                raise OAuthWorkspaceUnavailable
+            if workspace.billing_paused:
+                raise OAuthWorkspaceBillingPaused
+            user = (
+                self._read_entity_tx(conn, "user", code.user_id, User)
+                if code.user_id
+                else None
+            )
+
+            raw_key, key = new_oauth_delegated_api_key(code)
+            self._write_entity_tx(conn, "api_key", key.hash, key)
+            self._write_entity_tx(
+                conn,
+                "api_key_lookup",
+                key.lookup_hash,
+                {"key_id": key.hash},
+            )
+            self._write_entity_tx(
+                conn,
+                "api_key_by_workspace",
+                workspace_key_id(code.workspace_id, key.hash),
+                {"key_id": key.hash},
+            )
+            conn.execute(
+                "INSERT INTO tr_key_limit "
+                "(workspace_id, key_hash, shard, limit_micro, include_byok, "
+                "day_limit_micro, week_limit_micro, month_limit_micro, "
+                "source_updated_at, updated_at) "
+                "VALUES (%s, %s, 0, %s, true, NULL, NULL, NULL, "
+                "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                (
+                    code.workspace_id,
+                    key.hash,
+                    _int8_param(code.limit_microdollars),
+                ),
+            )
+            code.consumed_at = iso_now()
+            self._write_entity_tx(conn, "oauth_code", code.hash, code)
+            return OAuthCodeExchange(
+                raw_key=raw_key,
+                api_key=key,
+                authorization_code=code,
+                user=user,
+            )
+
+        return self._run_transaction(exchange)
+
     # Email send blocks ------------------------------------------------------
 
     def block_email_sending(
@@ -1761,6 +1866,78 @@ class PostgresStore:
 
         self._run_transaction(create)
         return raw, key
+
+    def issue_chat_browser_key(
+        self,
+        *,
+        workspace_id: str,
+        name: str,
+        creator_user_id: str,
+        limit_microdollars: int,
+        expires_at: str,
+        active_key_cap: int,
+    ) -> tuple[str, ApiKey] | None:
+        """Lock the workspace so concurrent issuers share one cap check."""
+        validate_chat_browser_key_cap(active_key_cap)
+
+        def issue(conn: Any) -> tuple[str, ApiKey] | None:
+            workspace = self._read_entity_tx(
+                conn,
+                "workspace",
+                workspace_id,
+                Workspace,
+                for_update=True,
+            )
+            if workspace is None:
+                raise ValueError("workspace not found")
+            rows = conn.execute(
+                _CONSOLE_API_KEYS_SQL,
+                (workspace_id, workspace_id, workspace_id),
+            ).fetchall()
+            keys_by_hash: dict[str, ApiKey] = {}
+            for row in rows:
+                key = api_key_from_json(row[0])
+                keys_by_hash[key.hash] = key
+            if (
+                sum(is_active_chat_browser_key(key) for key in keys_by_hash.values())
+                >= active_key_cap
+            ):
+                # Refusal performs reads only: no raw secret generation and no
+                # partial lookup/index/limit rows.
+                return None
+
+            raw, key = new_chat_browser_api_key(
+                workspace_id=workspace_id,
+                name=name,
+                creator_user_id=creator_user_id,
+                limit_microdollars=limit_microdollars,
+                expires_at=expires_at,
+            )
+            self._write_entity_tx(conn, "api_key", key.hash, key)
+            self._write_entity_tx(
+                conn,
+                "api_key_lookup",
+                key.lookup_hash,
+                {"key_id": key.hash},
+            )
+            self._write_entity_tx(
+                conn,
+                "api_key_by_workspace",
+                workspace_key_id(workspace_id, key.hash),
+                {"key_id": key.hash},
+            )
+            conn.execute(
+                "INSERT INTO tr_key_limit "
+                "(workspace_id, key_hash, shard, limit_micro, include_byok, "
+                "day_limit_micro, week_limit_micro, month_limit_micro, "
+                "source_updated_at, updated_at) "
+                "VALUES (%s, %s, 0, %s, true, NULL, NULL, NULL, "
+                "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                (workspace_id, key.hash, _int8_param(limit_microdollars)),
+            )
+            return raw, key
+
+        return self._run_transaction(issue)
 
     def get_key_by_hash(self, key_hash: str) -> ApiKey | None:
         return self._read_entity("api_key", key_hash, ApiKey)
@@ -2651,6 +2828,7 @@ class PostgresStore:
         self,
         *,
         kind: str | None = None,
+        limit: int | None = None,
     ) -> list[UserProvidedModel]:
         self._not_implemented("list_public_user_models")
 

--- a/src/trusted_router/storage_user_models.py
+++ b/src/trusted_router/storage_user_models.py
@@ -286,7 +286,12 @@ class InMemoryUserProvidedModels:
             if not slots:
                 self.slots.pop(canonical, None)
 
-    def list_public(self, *, kind: str | None = None) -> list[UserProvidedModel]:
+    def list_public(
+        self,
+        *,
+        kind: str | None = None,
+        limit: int | None = None,
+    ) -> list[UserProvidedModel]:
         with self._lock:
             rows = [
                 model
@@ -296,7 +301,7 @@ class InMemoryUserProvidedModels:
                 and (kind is None or model.kind == kind)
             ]
         rows.sort(key=lambda item: item.created_at)
-        return rows
+        return rows if limit is None else rows[: max(0, int(limit))]
 
     def _owned_model(self, model_id: str, owner_user_id: str) -> UserProvidedModel:
         model = self.models.get(normalize_custom_model_id(model_id))

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -53,6 +53,7 @@ from trusted_router.storage_models import (
     WalletChallenge,
     Workspace,
 )
+from trusted_router.storage_oauth_codes import OAuthCodeExchange
 from trusted_router.types import UsageType
 
 
@@ -269,6 +270,13 @@ class Store(Protocol):
         spawn_cloud: str | None = ...,
     ) -> tuple[str, OAuthAuthorizationCode]: ...
     def consume_oauth_authorization_code(self, raw_code: str) -> OAuthAuthorizationCode | None: ...
+    def exchange_oauth_authorization_code(
+        self,
+        raw_code: str,
+        *,
+        code_verifier: str | None,
+        code_challenge_method: str | None,
+    ) -> OAuthCodeExchange | None: ...
 
     # Email send blocks (SES bounce/complaint suppression) -------------------
     def block_email_sending(
@@ -308,6 +316,16 @@ class Store(Protocol):
         budget_alert_only: bool = ...,
         tags: dict[str, str] | None = ...,
     ) -> tuple[str, ApiKey]: ...
+    def issue_chat_browser_key(
+        self,
+        *,
+        workspace_id: str,
+        name: str,
+        creator_user_id: str,
+        limit_microdollars: int,
+        expires_at: str,
+        active_key_cap: int,
+    ) -> tuple[str, ApiKey] | None: ...
     def get_key_by_hash(self, key_hash: str) -> ApiKey | None: ...
     def typed_key_usage(
         self,
@@ -526,6 +544,7 @@ class Store(Protocol):
         self,
         *,
         kind: str | None = ...,
+        limit: int | None = ...,
     ) -> list[UserProvidedModel]: ...
 
     # Broadcast destinations -------------------------------------------------

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -13,7 +13,7 @@ import ssl
 import time
 import uuid
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from dataclasses import field as dataclass_field
 from typing import Any
 from urllib.parse import urljoin, urlsplit, urlunsplit
@@ -76,15 +76,11 @@ class SyntheticTarget:
     name: str
     api_base_url: str
     region: str | None = None
-    # Cloud Run direct URL for this region's control plane. When set,
-    # the synthetic monitor probes /health here too — separately from
-    # api_base_url's enclave probe — so we get a distinct per-region
-    # signal even when api_base_url's regional hostname CNAMEs to the
-    # global LB (cold regions, or warm regions whose ACME cert hasn't
-    # been issued yet because the MIG is at targetSize=0).
-    #
-    # None for the canonical target since that probe already hits the
-    # global enclave LB by definition.
+    # Explicit internal-service origin whose /health endpoint the synthetic
+    # monitor probes. GCP regional targets may only receive a separately
+    # configured ${SERVICE}-billing Cloud Run origin; it is never inferred
+    # from public region metadata. Standalone deployments may attach their
+    # explicitly configured control-plane origin to the canonical target.
     control_plane_url: str | None = None
     # ATTESTED-CERT-ONLY target: the gateway serves a self-signed cert it
     # minted inside the TEE (AWS Nitro standalone deployments), so CA
@@ -224,12 +220,67 @@ def _region_api_base_url(canonical_url: str, public_host: str) -> str:
     return urlunsplit(parsed._replace(netloc=netloc))
 
 
+def _regional_internal_health_origin(settings: Settings) -> str | None:
+    """Return the configured regional billing origin, failing closed.
+
+    Regional GCP health checks need a specific service and region, but public
+    region metadata must not disclose a private service URL. Accept only an
+    exact Cloud Run origin for a ``${SERVICE}-billing`` service in the
+    monitor's own region. In particular, legacy, console, and public service
+    origins cannot become credentialed synthetic targets.
+    """
+    raw_origin = settings.synthetic_control_plane_health_url
+    if not raw_origin:
+        return None
+    monitor_region = settings.synthetic_monitor_region
+    if not monitor_region:
+        raise ValueError(
+            "TR_SYNTHETIC_MONITOR_REGION is required when regional internal "
+            "health is configured"
+        )
+
+    parsed = urlsplit(raw_origin)
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError(
+            "TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL must be an exact HTTPS "
+            "${SERVICE}-billing Cloud Run origin in TR_SYNTHETIC_MONITOR_REGION"
+        ) from exc
+    host = parsed.hostname or ""
+    expected_suffix = f".{monitor_region}.run.app"
+    service_and_project = (
+        host[: -len(expected_suffix)] if host.endswith(expected_suffix) else ""
+    )
+    service, separator, project_number = service_and_project.rpartition("-")
+    if (
+        parsed.scheme != "https"
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path not in {"", "/"}
+        or parsed.query
+        or parsed.fragment
+        or port is not None
+        or not separator
+        or not project_number.isdigit()
+        or not service.endswith("-billing")
+    ):
+        raise ValueError(
+            "TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL must be an exact HTTPS "
+            "${SERVICE}-billing Cloud Run origin in TR_SYNTHETIC_MONITOR_REGION"
+        )
+    return urlunsplit(("https", host, "", "", ""))
+
+
 def configured_targets(settings: Settings) -> list[SyntheticTarget]:
+    regional_probes_enabled = settings.synthetic_regional_probes_enabled
     canonical = SyntheticTarget(
         "canonical",
         settings.api_base_url,
         choose_region(settings),
-        control_plane_url=settings.synthetic_control_plane_health_url,
+        control_plane_url=(
+            None if regional_probes_enabled else settings.synthetic_control_plane_health_url
+        ),
         attested=settings.synthetic_canonical_attested,
         expected_pcr0=settings.attestation_expected_pcr0,
     )
@@ -237,21 +288,21 @@ def configured_targets(settings: Settings) -> list[SyntheticTarget]:
     # and must find the canonical target, not a per-enclave sibling that
     # shares the same hostname.
     targets = [canonical, *_gateway_region_targets(settings, canonical)]
-    if not settings.synthetic_regional_probes_enabled:
+    if not regional_probes_enabled:
         # Standalone single-gateway deployment: the per-region alias and
-        # Cloud Run URL templates below are GCP topology and would
+        # regional hostname templates below are GCP topology and would
         # fabricate targets that do not exist (verified live: with
         # TR_REGIONS=eu-west-3 the loop appends
-        # api-eu-west-3.quillrouter.com + a nonexistent *.run.app URL,
-        # both permanently down). One hostname, one canonical target — plus
+        # api-eu-west-3.quillrouter.com, which is permanently down). One
+        # hostname, one canonical target — plus
         # whatever per-enclave endpoints are explicitly configured above,
         # which are real addresses of that same hostname rather than
         # hostnames derived from a template.
         return targets
+    internal_health_origin = _regional_internal_health_origin(settings)
     for region in region_payload(settings):
         name = str(region["id"])
         api_base_url = str(region["api_base_url"])
-        control_plane_url = region.get("control_plane_url") or None
         if name == choose_region(settings):
             # The canonical hostname now publishes all healthy gateway regions,
             # so it is not a primary-region-only signal. Probe the primary
@@ -260,28 +311,37 @@ def configured_targets(settings: Settings) -> list[SyntheticTarget]:
             regional_hostname = settings.regional_api_hostname_template.format(region=name)
             regional_api_base_url = f"https://{regional_hostname}/v1"
             if regional_api_base_url != settings.api_base_url:
-                targets.append(
-                    SyntheticTarget(name, regional_api_base_url, name, control_plane_url)
-                )
+                targets.append(SyntheticTarget(name, regional_api_base_url, name))
                 continue
         # If the api_base_url is already represented (e.g. the primary
         # region whose api_base_url == settings.api_base_url), skip
-        # adding a duplicate enclave target — but DO still attach the
-        # control_plane_url to the canonical target so we don't lose
-        # the per-region health probe.
+        # adding a duplicate enclave target.
         existing = next((t for t in targets if t.api_base_url == api_base_url), None)
         if existing is not None:
-            if control_plane_url and existing.control_plane_url is None:
-                # Replace canonical target with one carrying the
-                # primary's Cloud Run direct URL.
-                targets[targets.index(existing)] = SyntheticTarget(
-                    existing.name,
-                    existing.api_base_url,
-                    existing.region,
-                    control_plane_url,
-                )
             continue
-        targets.append(SyntheticTarget(name, api_base_url, name, control_plane_url))
+        targets.append(SyntheticTarget(name, api_base_url, name))
+
+    if internal_health_origin:
+        monitor_region = settings.synthetic_monitor_region
+        target_index = next(
+            (index for index, target in enumerate(targets) if target.name == monitor_region),
+            None,
+        )
+        if target_index is None:
+            regional_matches = [
+                index
+                for index, target in enumerate(targets)
+                if target.region == monitor_region
+            ]
+            if len(regional_matches) != 1:
+                raise ValueError(
+                    "TR_SYNTHETIC_MONITOR_REGION must identify one configured "
+                    "regional target"
+                )
+            target_index = regional_matches[0]
+        targets[target_index] = replace(
+            targets[target_index], control_plane_url=internal_health_origin
+        )
     return targets
 
 

--- a/tests/browser/production_rollout_smoke.spec.js
+++ b/tests/browser/production_rollout_smoke.spec.js
@@ -1,0 +1,145 @@
+const { expect, test } = require("@playwright/test");
+
+const DOMAINS = (process.env.TR_ROLLOUT_SMOKE_DOMAINS || "").split(",").filter(Boolean);
+
+test("signed-in production surfaces respond on every managed apex", async ({ browser }) => {
+  expect(DOMAINS).toEqual([
+    "trustedrouter.com",
+    "allyrouter.com",
+    "uptimerouter.com",
+  ]);
+
+  const context = await browser.newContext({
+    storageState: process.env.TR_ROLLOUT_SMOKE_PLAYWRIGHT_STORAGE_STATE,
+    extraHTTPHeaders: {
+      Authorization: require("node:fs")
+        .readFileSync(process.env.TR_ROLLOUT_SMOKE_AUTH_HEADER_FILE, "utf8")
+        .trim()
+        .replace(/^Authorization:\s*/, ""),
+    },
+  });
+  const page = await context.newPage();
+  try {
+    for (const domain of DOMAINS) {
+      const origin = `https://${domain}`;
+      const home = await page.goto(`${origin}/`, { waitUntil: "domcontentloaded" });
+      expect(home?.status()).toBe(200);
+      await expect(page.locator("body")).toContainText(`api.${domain}`);
+
+      const support = await page.goto(`${origin}/support`, {
+        waitUntil: "domcontentloaded",
+      });
+      expect(support?.status()).toBe(200);
+      await expect(page.locator("#support-inquiry")).toBeVisible();
+
+      const session = await page.request.get(`${origin}/auth/session`);
+      expect(session.status()).toBe(200);
+      const sessionJson = await session.json();
+      expect(sessionJson.data.authenticated).toBe(true);
+      expect(sessionJson.data.management).toBe(true);
+
+      const consolePage = await page.goto(`${origin}/console/api-keys`, {
+        waitUntil: "domcontentloaded",
+      });
+      expect(consolePage?.status()).toBe(200);
+      expect(new URL(page.url()).pathname).toBe("/console/api-keys");
+
+      const models = await page.request.get(`${origin}/v1/models`);
+      expect(models.status()).toBe(200);
+      expect((await models.json()).data.length).toBeGreaterThan(100);
+    }
+  } finally {
+    await context.close();
+  }
+});
+
+test("Firefox reaches split auth gates without inference or billing credentials", async ({
+  browser,
+}) => {
+  expect(DOMAINS).toEqual([
+    "trustedrouter.com",
+    "allyrouter.com",
+    "uptimerouter.com",
+  ]);
+
+  // This context intentionally inherits neither the signed-in storage state
+  // nor the management Authorization header used by the preceding smoke. Each
+  // fetch also omits credentials explicitly so only the pre-body auth gates can
+  // run; no browser key, internal token, prompt, API-key hash, or payment data
+  // is present in these requests.
+  const context = await browser.newContext({
+    extraHTTPHeaders: {},
+    storageState: { cookies: [], origins: [] },
+  });
+  const page = await context.newPage();
+  try {
+    for (const domain of DOMAINS) {
+      const origin = `https://${domain}`;
+      const home = await page.goto(`${origin}/`, { waitUntil: "domcontentloaded" });
+      expect(home?.status()).toBe(200);
+      expect((await context.cookies()).some((cookie) => cookie.name === "tr_session")).toBe(
+        false,
+      );
+
+      const safePost = async (path, requestId) =>
+        page.evaluate(
+          async ({ body, requestId: id, route }) => {
+            const response = await fetch(route, {
+              method: "POST",
+              credentials: "omit",
+              redirect: "manual",
+              headers: {
+                "content-type": "application/json",
+                "x-request-id": id,
+              },
+              body: JSON.stringify(body),
+            });
+            return {
+              body: await response.json(),
+              contentType: response.headers.get("content-type"),
+              requestId: response.headers.get("x-trustedrouter-request-id"),
+              status: response.status,
+            };
+          },
+          {
+            body: { smoke: "auth-gate-only" },
+            requestId,
+            route: path,
+          },
+        );
+
+      const safeDomain = domain.replaceAll(".", "-");
+      const chatRequestId = `tr-rollout-firefox-chat-${safeDomain}`;
+      const chat = await safePost(
+        "/chat-proxy/v1/chat/completions",
+        chatRequestId,
+      );
+      expect(chat.status).toBe(401);
+      expect(chat.contentType).toContain("application/json");
+      expect(chat.requestId).toBe(chatRequestId);
+      expect(chat.body.error).toEqual({
+        code: 401,
+        message: "Missing Authentication header",
+        source: "router",
+        type: "unauthorized",
+      });
+
+      const internalRequestId = `tr-rollout-firefox-internal-${safeDomain}`;
+      const internal = await safePost(
+        "/v1/internal/gateway/authorize",
+        internalRequestId,
+      );
+      expect(internal.status).toBe(401);
+      expect(internal.contentType).toContain("application/json");
+      expect(internal.requestId).toBe(internalRequestId);
+      expect(internal.body.error).toEqual({
+        code: 401,
+        message: "Invalid internal service token",
+        source: "router",
+        type: "unauthorized",
+      });
+    }
+  } finally {
+    await context.close();
+  }
+});

--- a/tests/browser/six_surface_server.py
+++ b/tests/browser/six_surface_server.py
@@ -1,0 +1,446 @@
+"""Test-only six-surface ASGI front door for Playwright.
+
+The dispatcher constructs six real TrustedRouter applications and selects one
+with the same ``route_surface`` function used to build the production URL map.
+It is intentionally local-only: storage is in memory, observability is off,
+and the chat proxy's upstream is a synthetic in-process stream.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+from collections.abc import AsyncIterator, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import patch
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, RedirectResponse, StreamingResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from scripts.deploy.service_surface_url_map import Surface, route_surface
+from trusted_router.auth import set_session_cookie
+from trusted_router.config import Settings
+from trusted_router.routes import chat_proxy as chat_proxy_routes
+from trusted_router.storage import STORE, InMemoryStore, configure_store
+
+CANONICAL_TEST_DOMAIN = "trustedrouter.localhost"
+ALIAS_TEST_DOMAINS = ("allyrouter.localhost", "uptimerouter.localhost")
+TEST_DOMAINS = (CANONICAL_TEST_DOMAIN, *ALIAS_TEST_DOMAINS)
+SURFACES: tuple[Surface, ...] = (
+    "public",
+    "actions",
+    "console",
+    "chat",
+    "webhooks",
+    "internal",
+)
+_LOCAL_READINESS_HOSTS = {"127.0.0.1", "localhost"}
+_MANAGED_TEST_HOSTS = {
+    host
+    for domain in TEST_DOMAINS
+    for host in (domain, f"www.{domain}", f"status.{domain}", f"trust.{domain}")
+}
+
+_NETWORK_GUARD_ATTRIBUTE = "_trustedrouter_six_surface_test_network_guard"
+_existing_network_guard = cast(
+    ContextVar[bool] | None,
+    getattr(socket, _NETWORK_GUARD_ATTRIBUTE, None),
+)
+if _existing_network_guard is None:
+    _network_guard = ContextVar(
+        "trustedrouter_six_surface_test_network_blocked",
+        default=False,
+    )
+    original_connect = socket.socket.connect
+    original_connect_ex = socket.socket.connect_ex
+    original_sendto = socket.socket.sendto
+
+    def _guarded_connect(instance: socket.socket, address: Any) -> None:
+        if _network_guard.get():
+            raise RuntimeError("six-surface browser harness blocks outbound network")
+        original_connect(instance, address)
+
+    def _guarded_connect_ex(instance: socket.socket, address: Any) -> int:
+        if _network_guard.get():
+            raise RuntimeError("six-surface browser harness blocks outbound network")
+        return original_connect_ex(instance, address)
+
+    def _guarded_sendto(instance: socket.socket, data: Any, *args: Any) -> int:
+        if _network_guard.get():
+            raise RuntimeError("six-surface browser harness blocks outbound network")
+        return original_sendto(instance, data, *args)
+
+    socket.socket.connect = _guarded_connect  # type: ignore[assignment]
+    socket.socket.connect_ex = _guarded_connect_ex  # type: ignore[assignment]
+    socket.socket.sendto = _guarded_sendto  # type: ignore[assignment]
+    setattr(socket, _NETWORK_GUARD_ATTRIBUTE, _network_guard)
+else:
+    _network_guard = _existing_network_guard
+
+_OUTBOUND_NETWORK_BLOCKED = _network_guard
+
+
+@contextmanager
+def _without_outbound_network() -> Iterator[None]:
+    token = _OUTBOUND_NETWORK_BLOCKED.set(True)
+    try:
+        yield
+    finally:
+        _OUTBOUND_NETWORK_BLOCKED.reset(token)
+
+_CREDENTIAL_ENV_PREFIXES = (
+    "TR_",
+    "AWS_",
+    "AZURE_",
+    "GCP_",
+    "GOOGLE_",
+    "AXIOM_",
+    "OPENAI_",
+    "ANTHROPIC_",
+    "STRIPE_",
+    "PAYPAL_",
+    "ADYEN_",
+    "VERIFF_",
+    "SENTRY_",
+)
+_CREDENTIAL_ENV_SUFFIXES = (
+    "_API_KEY",
+    "_API_TOKEN",
+    "_ACCESS_KEY",
+    "_SECRET",
+    "_SECRET_KEY",
+    "_TOKEN",
+    "_PASSWORD",
+    "_CREDENTIALS",
+    "_CREDENTIALS_JSON",
+    "_KEY_JSON",
+    "_DSN",
+)
+_CREDENTIAL_ENV_EXACT = {
+    "DATABASE_URL",
+    "CLICKHOUSE_URL",
+    "REDIS_URL",
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+}
+
+
+def _is_credential_environment_name(name: str) -> bool:
+    upper_name = name.upper()
+    return (
+        upper_name in _CREDENTIAL_ENV_EXACT
+        or upper_name.startswith(_CREDENTIAL_ENV_PREFIXES)
+        or upper_name.endswith(_CREDENTIAL_ENV_SUFFIXES)
+        or "CREDENTIAL" in upper_name
+    )
+
+
+@contextmanager
+def _without_ambient_credentials() -> Iterator[None]:
+    """Temporarily remove credentials while a local harness request runs."""
+
+    removed = {
+        name: value
+        for name, value in os.environ.items()
+        if _is_credential_environment_name(name)
+    }
+    for name in removed:
+        os.environ.pop(name, None)
+    try:
+        yield
+    finally:
+        # A tested route must not be able to leave a new credential behind.
+        for name in tuple(os.environ):
+            if _is_credential_environment_name(name):
+                os.environ.pop(name, None)
+        os.environ.update(removed)
+
+
+# ``trusted_router.main`` exposes a module-level ASGI app. Importing its factory
+# therefore constructs one app immediately, before this harness builds the six
+# explicit surfaces below. Keep that otherwise-unused app just as isolated as
+# the request dispatcher: it must never see shell credentials, a real Store,
+# the repository's dotenv file, or the developer's local key file. The custom
+# local-key source reads the model-field default directly, so an environment
+# override alone is not sufficient here.
+_import_local_keys_field = Settings.model_fields["local_keys_file"]
+with (
+    _without_ambient_credentials(),
+    _without_outbound_network(),
+    patch.dict(Settings.model_config, {"env_file": None}),
+    patch.object(_import_local_keys_field, "default", Path(os.devnull)),
+):
+    os.environ.update(
+        {
+            "TR_ENVIRONMENT": "test",
+            "TR_STORAGE_BACKEND": "memory",
+            "TR_LOCAL_KEYS_FILE": os.devnull,
+        }
+    )
+    from trusted_router.main import create_app
+
+
+def _settings(surface: Surface) -> Settings:
+    """Build deterministic settings inside the scrubbed harness environment."""
+
+    values: dict[str, Any] = {
+        "environment": "test",
+        "release": "six-surface-browser-test",
+        "service_name": f"trusted-router-{surface}-browser-test",
+        "service_surface": surface,
+        "storage_backend": "memory",
+        "local_keys_file": Path(os.devnull),
+        "trusted_domain": CANONICAL_TEST_DOMAIN,
+        "trusted_domain_aliases": ",".join(ALIAS_TEST_DOMAINS),
+        "api_base_url": f"https://api.{CANONICAL_TEST_DOMAIN}/v1",
+        "rate_limit_enabled": False,
+        "sentry_dsn": None,
+    }
+    if surface == "public":
+        values.update(
+            google_oauth_login_available=True,
+            github_oauth_login_available=False,
+        )
+    elif surface == "console":
+        values.update(
+            google_client_id="browser-test-client",
+            google_client_secret="browser-test-secret",  # noqa: S106
+            google_oauth_login_available=True,
+            github_oauth_login_available=False,
+        )
+    elif surface == "webhooks":
+        values["stripe_webhook_secret"] = (
+            "whsec_browser_harness_invalid_signature_only"  # noqa: S105
+        )
+    elif surface == "internal":
+        values["internal_gateway_token"] = (
+            "browser-harness-internal-token-never-sent"  # noqa: S105
+        )
+
+    return Settings(_env_file=None, **values)
+
+
+async def _synthetic_chat_forward(
+    request: Request,
+    _path: str,
+    settings: Settings,
+) -> StreamingResponse:
+    """Replace the real inference hop after the real chat-route auth gate."""
+
+    await request.body()
+    selected_upstream = chat_proxy_routes._upstream_base_url(request, settings)
+
+    async def chunks() -> AsyncIterator[bytes]:
+        yield (
+            b'data: {"id":"chatcmpl-six-surface","object":"chat.completion.chunk",'
+            b'"model":"trustedrouter/test","choices":[{"index":0,"delta":'
+            b'{"content":"Six-surface local reply."}}]}\n\n'
+        )
+        yield (
+            b'data: {"id":"chatcmpl-six-surface","object":"chat.completion.chunk",'
+            b'"model":"trustedrouter/test","choices":[{"index":0,"delta":{},'
+            b'"finish_reason":"stop"}],"usage":{"prompt_tokens":3,'
+            b'"completion_tokens":4,"total_tokens":7,"cost_microdollars":0}}\n\n'
+        )
+        yield b"data: [DONE]\n\n"
+
+    return StreamingResponse(
+        chunks(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-TrustedRouter-Provider": "browser-harness",
+            "X-TrustedRouter-Served-Model": "trustedrouter/test",
+            "X-TR-Test-Upstream": selected_upstream,
+        },
+    )
+
+
+def _harness_app(settings: Settings) -> FastAPI:
+    harness = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
+
+    def issue_session(email: str) -> tuple[Any, Any, str]:
+        user = STORE.ensure_user(email)
+        workspace = STORE.list_workspaces_for_user(user.id)[0]
+        raw_token, _session = STORE.create_auth_session(
+            user_id=user.id,
+            provider="browser-harness",
+            label=email,
+            ttl_seconds=3600,
+            state="active",
+        )
+        return user, workspace, raw_token
+
+    @harness.post("/__test__/session")
+    async def create_test_session(request: Request) -> JSONResponse:
+        payload = await request.json()
+        email = str(payload.get("email", "")).strip().lower()
+        if not email.endswith("@example.test"):
+            return JSONResponse({"error": "test email required"}, status_code=400)
+        user, workspace, raw_token = issue_session(email)
+        response = JSONResponse(
+            {"user_id": user.id, "workspace_id": workspace.id, "email": email}
+        )
+        set_session_cookie(response, raw_token, settings)
+        return response
+
+    @harness.get("/__test__/login")
+    async def create_manual_browser_session(request: Request) -> RedirectResponse:
+        """Give a local browser a fake session without exposing cookie APIs."""
+
+        email = str(request.query_params.get("email", "")).strip().lower()
+        if not email.endswith("@example.test"):
+            return RedirectResponse("/?reason=signin", status_code=303)
+        _user, _workspace, raw_token = issue_session(email)
+        response = RedirectResponse("/chat", status_code=303)
+        set_session_cookie(response, raw_token, settings)
+        return response
+
+    @harness.get("/__test__/state")
+    async def test_state(request: Request) -> JSONResponse:
+        target = STORE.target
+        if not isinstance(target, InMemoryStore):
+            return JSONResponse({"error": "memory store required"}, status_code=500)
+        stripe_event_id = request.query_params.get("stripe_event_id", "")
+        return JSONResponse(
+            {
+                "stripe_event_recorded": stripe_event_id in target.stripe_events,
+                "stripe_event_count": len(target.stripe_events),
+                "webhook_event_count": len(target.webhook_events),
+                "credit_movement_count": len(target.credit_movements),
+                "lifetime_topup_count": len(target.lifetime_topups),
+            }
+        )
+
+    return harness
+
+
+class SixSurfaceDispatcher:
+    """Host-restricted ASGI dispatcher with a test-only surface proof header."""
+
+    def __init__(self) -> None:
+        configure_store(InMemoryStore())
+        self._request_environment_lock = asyncio.Lock()
+        local_keys_field = Settings.model_fields["local_keys_file"]
+        # Do not let a developer shell's provider, cloud, observability, or
+        # payment credentials enter any of the six app instances. The custom
+        # Settings source reads the model-field default directly, hence the
+        # temporary default override as well as the empty environment.
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch.object(local_keys_field, "default", Path(os.devnull)),
+        ):
+            self.settings = {surface: _settings(surface) for surface in SURFACES}
+            self.apps: dict[Surface, ASGIApp] = {
+                surface: create_app(
+                    self.settings[surface],
+                    configure_store_arg=False,
+                    init_observability=False,
+                )
+                for surface in SURFACES
+            }
+            self.harness: ASGIApp = _harness_app(self.settings["console"])
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "lifespan":
+            await self._lifespan(receive, send)
+            return
+        if scope["type"] != "http":
+            await JSONResponse({"error": "unsupported scope"}, status_code=400)(
+                scope, receive, send
+            )
+            return
+
+        # Environment mutation is process-global, so serialize local requests
+        # while their ambient credentials are absent. The Playwright harness
+        # uses one worker, and the synthetic stream is finite and in-process.
+        async with self._request_environment_lock:
+            with _without_ambient_credentials():
+                with _without_outbound_network():
+                    await self._dispatch_http(scope, receive, send)
+
+    async def _dispatch_http(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        """Dispatch one HTTP request with outbound sockets already disabled."""
+
+        hostname = self._hostname(scope)
+        if hostname not in _MANAGED_TEST_HOSTS | _LOCAL_READINESS_HOSTS:
+            await JSONResponse({"error": "unknown test host"}, status_code=421)(
+                scope, receive, send
+            )
+            return
+
+        path = str(scope.get("path") or "/")
+        if path.startswith("/__test__/"):
+            await self._send_with_surface(
+                self.harness,
+                "harness",
+                scope,
+                receive,
+                send,
+            )
+            return
+
+        surface = route_surface(path)
+        selected = self.apps[surface]
+        if surface == "chat":
+            # The actual chat FastAPI route and API-key dependency still run;
+            # only its outbound network hop is replaced.
+            with patch.object(
+                chat_proxy_routes,
+                "_forward",
+                _synthetic_chat_forward,
+            ):
+                await self._send_with_surface(
+                    selected, surface, scope, receive, send
+                )
+            return
+        await self._send_with_surface(selected, surface, scope, receive, send)
+
+    @staticmethod
+    def _hostname(scope: Scope) -> str:
+        headers = dict(cast(list[tuple[bytes, bytes]], scope.get("headers", [])))
+        return headers.get(b"host", b"").decode("ascii").split(":", 1)[0].lower()
+
+    @staticmethod
+    async def _send_with_surface(
+        selected: ASGIApp,
+        surface: str,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        async def send_with_header(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = [
+                    (key, value)
+                    for key, value in message.get("headers", [])
+                    if key.lower() != b"x-tr-test-surface"
+                ]
+                headers.append((b"x-tr-test-surface", surface.encode("ascii")))
+                message = {**message, "headers": headers}
+            await send(message)
+
+        await selected(scope, receive, send_with_header)
+
+    @staticmethod
+    async def _lifespan(receive: Receive, send: Send) -> None:
+        while True:
+            message = await receive()
+            if message["type"] == "lifespan.startup":
+                await send({"type": "lifespan.startup.complete"})
+            elif message["type"] == "lifespan.shutdown":
+                await send({"type": "lifespan.shutdown.complete"})
+                return
+
+
+app = SixSurfaceDispatcher()

--- a/tests/browser/six_surface_split.spec.js
+++ b/tests/browser/six_surface_split.spec.js
@@ -1,0 +1,223 @@
+const { expect, test } = require("@playwright/test");
+
+const DOMAINS = [
+  "trustedrouter.localhost",
+  "allyrouter.localhost",
+  "uptimerouter.localhost",
+];
+
+function origin(domain) {
+  return `http://${domain}:18081`;
+}
+
+async function surface(response) {
+  const headers = typeof response.allHeaders === "function"
+    ? await response.allHeaders()
+    : response.headers;
+  return headers["x-tr-test-surface"];
+}
+
+async function localFetch(page, path, { method = "GET", headers = {}, data } = {}) {
+  return page.evaluate(async ({ requestPath, requestMethod, requestHeaders, requestData }) => {
+    const response = await fetch(requestPath, {
+      method: requestMethod,
+      headers: {
+        ...(requestData === undefined ? {} : { "content-type": "application/json" }),
+        ...requestHeaders,
+      },
+      body: requestData === undefined ? undefined : JSON.stringify(requestData),
+      credentials: "same-origin",
+    });
+    const text = await response.text();
+    let json = null;
+    try {
+      json = JSON.parse(text);
+    } catch (_error) {
+      // Static assets and SSE responses are intentionally not JSON.
+    }
+    return {
+      status: response.status,
+      headers: Object.fromEntries(response.headers.entries()),
+      text,
+      json,
+    };
+  }, {
+    requestPath: path,
+    requestMethod: method,
+    requestHeaders: headers,
+    requestData: data,
+  });
+}
+
+async function localOnlyContext(browser) {
+  const context = await browser.newContext();
+  await context.route("**/*", async (route) => {
+    const hostname = new URL(route.request().url()).hostname;
+    if (hostname.endsWith(".localhost") || hostname === "127.0.0.1") {
+      await route.continue();
+      return;
+    }
+    await route.abort("blockedbyclient");
+  });
+  return context;
+}
+
+test("all three domains traverse the six real service surfaces without side effects", async ({
+  browser,
+}) => {
+  const context = await localOnlyContext(browser);
+  const page = await context.newPage();
+
+  try {
+    for (const domain of DOMAINS) {
+      const base = origin(domain);
+
+      const home = await page.goto(`${base}/`);
+      expect(home.status()).toBe(200);
+      expect(await surface(home)).toBe("public");
+      await expect(page.locator(".brand-mark").first()).toBeVisible();
+      await expect(page.locator("body")).toContainText(`api.${domain}`);
+
+      const asset = await localFetch(page, "/static/dashboard.css");
+      expect(asset.status).toBe(200);
+      expect(await surface(asset)).toBe("public");
+
+      const consoleRedirectPromise = page.waitForResponse(
+        (response) => new URL(response.url()).pathname === "/console/api-keys",
+      );
+      await page.goto(`${base}/console/api-keys`);
+      const consoleRedirect = await consoleRedirectPromise;
+      expect(consoleRedirect.status()).toBe(302);
+      const consoleHeaders = await consoleRedirect.allHeaders();
+      expect(consoleHeaders.location).toBe("/?reason=signin");
+      expect(await surface(consoleRedirect)).toBe("console");
+
+      await page.goto(`${base}/support`);
+      const actionRequests = [];
+      const recordAction = (request) => {
+        if (request.url().endsWith("/support/inquiry")) actionRequests.push(request.url());
+      };
+      page.on("request", recordAction);
+      await page.getByRole("button", { name: "Send support request" }).click();
+      await expect(page.locator("#support-inquiry [data-role=status]")).toContainText(
+        "Please complete your name, email, subject, and message.",
+      );
+      expect(actionRequests).toEqual([]);
+      page.off("request", recordAction);
+
+      const invalidAction = await localFetch(page, "/support/inquiry", {
+        method: "POST",
+        data: {
+          name: "",
+          email: "not-an-email",
+          category: "api",
+          subject: "",
+          message: "",
+          website: "",
+        },
+      });
+      expect(invalidAction.status).toBe(422);
+      expect(await surface(invalidAction)).toBe("actions");
+
+      const eventId = `evt_invalid_signature_${domain.replaceAll(".", "_")}`;
+      const statePath = `/__test__/state?stripe_event_id=${eventId}`;
+      const before = (await localFetch(page, statePath)).json;
+      const invalidWebhook = await localFetch(
+        page,
+        "/internal/stripe/webhook",
+        {
+          method: "POST",
+          headers: { "stripe-signature": "t=0,v1=invalid" },
+          data: {
+            id: eventId,
+            type: "payment_intent.succeeded",
+            data: { object: { id: "pi_never_recorded" } },
+          },
+        },
+      );
+      expect(invalidWebhook.status).toBe(400);
+      expect(await surface(invalidWebhook)).toBe("webhooks");
+      const after = (await localFetch(page, statePath)).json;
+      expect(after).toEqual(before);
+      expect(after.stripe_event_recorded).toBe(false);
+
+      const rejectedInternal = await localFetch(
+        page,
+        "/internal/gateway/authorize",
+        {
+          method: "POST",
+          data: {
+            api_key_hash: "browser-harness-missing-key",
+            model: "trustedrouter/test",
+          },
+        },
+      );
+      expect(rejectedInternal.status).toBe(401);
+      expect(await surface(rejectedInternal)).toBe("internal");
+    }
+  } finally {
+    await context.close();
+  }
+});
+
+test("signed-in chat crosses public, console, and chat services on every domain", async ({
+  browser,
+}) => {
+  const context = await localOnlyContext(browser);
+  const page = await context.newPage();
+
+  try {
+    for (const domain of DOMAINS) {
+      const base = origin(domain);
+
+      await page.goto(`${base}/`);
+      const session = await localFetch(page, "/__test__/session", {
+        method: "POST",
+        data: { email: `chat-${domain.replaceAll(".", "-")}@example.test` },
+      });
+      expect(session.status).toBe(200);
+      expect(await surface(session)).toBe("harness");
+
+      const modelsResponsePromise = page.waitForResponse(
+        (response) => new URL(response.url()).pathname === "/v1/models",
+      );
+      const chatPage = await page.goto(`${base}/chat`);
+      const modelsResponse = await modelsResponsePromise;
+      expect(chatPage.status()).toBe(200);
+      expect(await surface(chatPage)).toBe("public");
+      expect(await surface(modelsResponse)).toBe("public");
+
+      const authResponsePromise = page.waitForResponse(
+        (response) => new URL(response.url()).pathname === "/auth/session",
+      );
+      const issueKeyResponsePromise = page.waitForResponse(
+        (response) =>
+          new URL(response.url()).pathname === "/internal/chat/issue-browser-key",
+      );
+      const chatProxyResponsePromise = page.waitForResponse(
+        (response) =>
+          new URL(response.url()).pathname === "/chat-proxy/v1/chat/completions",
+      );
+      await page.locator("[data-chat-input]").fill("Prove the local split.");
+      await page.locator("[data-chat-send]").click();
+      await expect(page.locator(".chat-msg-assistant").last()).toContainText(
+        "Six-surface local reply.",
+      );
+      const [authResponse, issueKeyResponse, chatProxyResponse] =
+        await Promise.all([
+          authResponsePromise,
+          issueKeyResponsePromise,
+          chatProxyResponsePromise,
+        ]);
+      expect(await surface(authResponse)).toBe("console");
+      expect(await surface(issueKeyResponse)).toBe("console");
+      expect(await surface(chatProxyResponse)).toBe("chat");
+      const chatProxyHeaders = await chatProxyResponse.allHeaders();
+      expect(chatProxyHeaders["x-tr-test-upstream"]).toBe(
+        `https://api.${domain}`,
+      );
+    }
+  } finally {
+    await context.close();
+  }
+});

--- a/tests/browser/test_six_surface_server.py
+++ b/tests/browser/test_six_surface_server.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.responses import JSONResponse
+
+
+def _server_module() -> ModuleType:
+    path = Path(__file__).with_name("six_surface_server.py")
+    spec = importlib.util.spec_from_file_location("six_surface_browser_server", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+SERVER = _server_module()
+
+
+def test_main_factory_import_cannot_read_ambient_or_file_credentials(
+    tmp_path: Path,
+) -> None:
+    """Exercise the import in a fresh interpreter where main is not cached."""
+
+    dotenv_secret = "dotenv-browser-harness-canary"  # noqa: S105
+    local_secret = "local-file-browser-harness-canary"  # noqa: S105
+    ambient_secret = "ambient-browser-harness-canary"  # noqa: S105
+    (tmp_path / ".env").write_text(
+        "TR_GOOGLE_CLIENT_ID=dotenv-client\n"
+        f"TR_GOOGLE_CLIENT_SECRET={dotenv_secret}\n",
+        encoding="utf-8",
+    )
+    local_keys = tmp_path / "local-keys.private"
+    local_keys.write_text(
+        "GITHUB_CLIENT_ID=local-file-client\n"
+        f"GITHUB_CLIENT_SECRET={local_secret}\n",
+        encoding="utf-8",
+    )
+    repository = Path(__file__).resolve().parents[2]
+    probe = """
+import importlib
+import sys
+from pathlib import Path
+
+repository = Path(sys.argv[1])
+sys.path.insert(0, str(repository))
+from trusted_router.config import Settings
+
+Settings.model_fields["local_keys_file"].default = Path(sys.argv[2])
+importlib.import_module("tests.browser.six_surface_server")
+from trusted_router import main
+
+settings = main.app.state.settings
+assert settings.environment == "test"
+assert settings.storage_backend == "memory"
+assert settings.stripe_secret_key is None
+assert settings.google_client_id is None
+assert settings.google_client_secret is None
+assert settings.github_client_id is None
+assert settings.github_client_secret is None
+"""
+    result = subprocess.run(  # noqa: S603 - fixed interpreter and probe.
+        [sys.executable, "-c", probe, str(repository), str(local_keys)],
+        cwd=tmp_path,
+        env={
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "TR_ENVIRONMENT": "test",
+            "TR_STORAGE_BACKEND": "memory",
+            "TR_STRIPE_SECRET_KEY": ambient_secret,
+        },
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_harness_constructs_only_the_six_explicit_surface_apps() -> None:
+    assert set(SERVER.app.apps) == {
+        "public",
+        "actions",
+        "console",
+        "chat",
+        "webhooks",
+        "internal",
+    }
+    assert {
+        name: settings.service_surface
+        for name, settings in SERVER.app.settings.items()
+    } == {
+        "public": "public",
+        "actions": "actions",
+        "console": "console",
+        "chat": "chat",
+        "webhooks": "webhooks",
+        "internal": "internal",
+    }
+
+    with TestClient(SERVER.app, base_url="http://unmanaged.localhost") as client:
+        response = client.get("/health")
+    assert response.status_code == 421
+    assert "x-tr-test-surface" not in response.headers
+
+
+def test_harness_scrubs_credentials_during_all_six_app_constructions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    credential_names = (
+        "OPENAI_API_KEY",
+        "AXIOM_API_TOKEN",
+        "GCP_SERVICE_ACCOUNT_KEY_JSON",
+        "AWS_ACCESS_KEY_ID",
+        "TR_STRIPE_SECRET_KEY",
+    )
+    observed: list[dict[str, str | None]] = []
+
+    def construction_probe(
+        _settings: Any,
+        **_kwargs: Any,
+    ) -> JSONResponse:
+        observed.append({name: os.environ.get(name) for name in credential_names})
+        return JSONResponse({"test": True})
+
+    monkeypatch.setattr(SERVER, "create_app", construction_probe)
+    with patch.dict(
+        os.environ,
+        {name: f"browser-test-canary-{name}" for name in credential_names},
+    ):
+        SERVER.SixSurfaceDispatcher()
+
+    assert observed == [
+        {name: None for name in credential_names}
+        for _surface in SERVER.SURFACES
+    ]
+
+
+def test_every_request_has_a_fail_closed_outbound_socket_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    credential_names = (
+        "OPENAI_API_KEY",
+        "AXIOM_API_TOKEN",
+        "GCP_SERVICE_ACCOUNT_KEY_JSON",
+        "AWS_SECRET_ACCESS_KEY",
+        "TR_STRIPE_SECRET_KEY",
+    )
+
+    async def outbound_probe(
+        _scope: Any,
+        _receive: Any,
+        send: Any,
+    ) -> None:
+        credentials_absent = all(
+            os.environ.get(name) is None for name in credential_names
+        )
+        probe_socket = socket.socket()
+        try:
+            with pytest.raises(
+                RuntimeError,
+                match="six-surface browser harness blocks outbound network",
+            ):
+                probe_socket.connect(("127.0.0.1", 9))
+        finally:
+            probe_socket.close()
+        await JSONResponse(
+            {
+                "credentials_absent": credentials_absent,
+                "network_blocked": True,
+            }
+        )(_scope, _receive, send)
+
+    monkeypatch.setitem(SERVER.app.apps, "public", outbound_probe)
+    canaries = {
+        name: f"browser-request-canary-{name}" for name in credential_names
+    }
+    with patch.dict(os.environ, canaries):
+        with TestClient(
+            SERVER.app,
+            base_url="http://trustedrouter.localhost",
+        ) as client:
+            response = client.get("/")
+        assert {name: os.environ.get(name) for name in credential_names} == canaries
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "credentials_absent": True,
+        "network_blocked": True,
+    }
+    assert response.headers["x-tr-test-surface"] == "public"
+    assert SERVER._OUTBOUND_NETWORK_BLOCKED.get() is False
+
+
+def test_manual_browser_login_uses_only_a_fake_local_session() -> None:
+    with TestClient(
+        SERVER.app,
+        base_url="http://trustedrouter.localhost",
+    ) as client:
+        login = client.get(
+            "/__test__/login?email=manual-browser@example.test",
+            follow_redirects=False,
+        )
+        assert login.status_code == 303
+        assert login.headers["location"] == "/chat"
+        assert login.headers["x-tr-test-surface"] == "harness"
+
+        session = client.get("/auth/session")
+        assert session.status_code == 200
+        assert session.headers["x-tr-test-surface"] == "console"
+        assert session.json()["data"]["authenticated"] is True
+
+
+@pytest.mark.parametrize(
+    "domain",
+    [
+        "trustedrouter.localhost",
+        "allyrouter.localhost",
+        "uptimerouter.localhost",
+    ],
+)
+def test_six_surface_dispatch_is_local_and_total(domain: str) -> None:
+    with TestClient(SERVER.app, base_url=f"http://{domain}") as client:
+        public = client.get("/")
+        assert public.status_code == 200
+        assert public.headers["x-tr-test-surface"] == "public"
+        assert f"https://api.{domain}/v1" in public.text
+
+        static = client.get("/static/dashboard.css")
+        assert static.status_code == 200
+        assert static.headers["x-tr-test-surface"] == "public"
+
+        console = client.get("/console/api-keys", follow_redirects=False)
+        assert console.status_code == 302
+        assert console.headers["location"] == "/?reason=signin"
+        assert console.headers["x-tr-test-surface"] == "console"
+
+        actions = client.post(
+            "/support/inquiry",
+            json={
+                "name": "",
+                "email": "invalid",
+                "category": "api",
+                "subject": "",
+                "message": "",
+                "website": "",
+            },
+        )
+        assert actions.status_code == 422
+        assert actions.headers["x-tr-test-surface"] == "actions"
+
+        event_id = f"evt_invalid_{domain}"
+        before = client.get(
+            "/__test__/state", params={"stripe_event_id": event_id}
+        ).json()
+        webhook = client.post(
+            "/internal/stripe/webhook",
+            headers={"stripe-signature": "t=0,v1=invalid"},
+            json={
+                "id": event_id,
+                "type": "payment_intent.succeeded",
+                "data": {"object": {"id": "pi_never_recorded"}},
+            },
+        )
+        assert webhook.status_code == 400
+        assert webhook.headers["x-tr-test-surface"] == "webhooks"
+        after = client.get(
+            "/__test__/state", params={"stripe_event_id": event_id}
+        ).json()
+        assert after == before
+        assert after["stripe_event_recorded"] is False
+
+        internal = client.post(
+            "/internal/gateway/authorize",
+            json={
+                "api_key_hash": "browser-harness-missing-key",
+                "model": "trustedrouter/test",
+            },
+        )
+        assert internal.status_code == 401
+        assert internal.headers["x-tr-test-surface"] == "internal"
+
+
+@pytest.mark.parametrize(
+    "domain",
+    [
+        "trustedrouter.localhost",
+        "allyrouter.localhost",
+        "uptimerouter.localhost",
+    ],
+)
+def test_real_session_key_and_chat_routes_cross_three_surfaces(domain: str) -> None:
+    with TestClient(SERVER.app, base_url=f"http://{domain}") as client:
+        session = client.post(
+            "/__test__/session",
+            json={"email": f"python-{domain.replace('.', '-')}@example.test"},
+        )
+        assert session.status_code == 200
+        assert session.headers["x-tr-test-surface"] == "harness"
+
+        auth = client.get("/auth/session")
+        assert auth.status_code == 200
+        assert auth.headers["x-tr-test-surface"] == "console"
+
+        chat_page = client.get("/chat")
+        assert chat_page.status_code == 200
+        assert chat_page.headers["x-tr-test-surface"] == "public"
+
+        issued = client.post("/internal/chat/issue-browser-key")
+        assert issued.status_code == 200
+        assert issued.headers["x-tr-test-surface"] == "console"
+        raw_key = issued.json()["data"]["raw_key"]
+
+        proxied = client.post(
+            "/chat-proxy/v1/chat/completions",
+            headers={"authorization": f"Bearer {raw_key}"},
+            json={
+                "model": "trustedrouter/test",
+                "messages": [{"role": "user", "content": "local only"}],
+                "stream": True,
+            },
+        )
+        assert proxied.status_code == 200
+        assert proxied.headers["x-tr-test-surface"] == "chat"
+        assert proxied.headers["x-tr-test-upstream"] == f"https://api.{domain}"
+        assert "Six-surface local reply." in proxied.text

--- a/tests/conformance/test_chat_browser_key_semantics.py
+++ b/tests/conformance/test_chat_browser_key_semantics.py
@@ -1,0 +1,165 @@
+"""Atomic browser-key cap semantics shared by every storage backend."""
+
+from __future__ import annotations
+
+import datetime as dt
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+from trusted_router.storage_chat_browser_keys import is_active_chat_browser_key
+from trusted_router.storage_models import ApiKey
+from trusted_router.store_protocol import Store
+
+_ACTIVE_CAP = 3
+_LIMIT_MICRODOLLARS = 5_000_000
+
+
+def _future_expiry() -> str:
+    return (dt.datetime.now(dt.UTC) + dt.timedelta(days=30)).isoformat()
+
+
+def _issue(
+    store: Store,
+    *,
+    workspace_id: str,
+    user_id: str,
+    name: str,
+) -> tuple[str, ApiKey] | None:
+    return store.issue_chat_browser_key(
+        workspace_id=workspace_id,
+        name=name,
+        creator_user_id=user_id,
+        limit_microdollars=_LIMIT_MICRODOLLARS,
+        expires_at=_future_expiry(),
+        active_key_cap=_ACTIVE_CAP,
+    )
+
+
+def test_chat_browser_key_cap_refuses_without_persistent_create_work(
+    store: Store,
+    workspace_id: str,
+    user_id: str,
+) -> None:
+    issued = [
+        _issue(
+            store,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            name=f"chat-browser-cap-{index}",
+        )
+        for index in range(_ACTIVE_CAP)
+    ]
+    assert all(result is not None for result in issued)
+    before = store.list_api_keys_with_usage(workspace_id)
+
+    refused = _issue(
+        store,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        name="chat-browser-cap-refused",
+    )
+
+    assert refused is None
+    assert store.list_api_keys_with_usage(workspace_id) == before
+    assert sum(
+        is_active_chat_browser_key(snapshot.api_key) for snapshot in before
+    ) == _ACTIVE_CAP
+
+
+def test_expired_legacy_browser_key_does_not_consume_cap(
+    store: Store,
+    workspace_id: str,
+    user_id: str,
+) -> None:
+    store.create_api_key(
+        workspace_id=workspace_id,
+        name="chat-browser-legacy-expired",
+        creator_user_id=user_id,
+        expires_at="2000-01-01T00:00:00Z",
+    )
+
+    result = store.issue_chat_browser_key(
+        workspace_id=workspace_id,
+        name="chat-browser-current",
+        creator_user_id=user_id,
+        limit_microdollars=_LIMIT_MICRODOLLARS,
+        expires_at=_future_expiry(),
+        active_key_cap=1,
+    )
+
+    assert result is not None
+    raw, key = result
+    assert key.management is False
+    assert store.get_key_by_raw(raw) is not None
+    assert raw not in {key.secret_hash, key.lookup_hash, key.label}
+
+
+def test_chat_browser_key_cap_is_isolated_per_workspace(
+    store: Store,
+    workspace_id: str,
+    user_id: str,
+    unique: str,
+) -> None:
+    first = store.issue_chat_browser_key(
+        workspace_id=workspace_id,
+        name="chat-browser-first-workspace",
+        creator_user_id=user_id,
+        limit_microdollars=_LIMIT_MICRODOLLARS,
+        expires_at=_future_expiry(),
+        active_key_cap=1,
+    )
+    assert first is not None
+    assert (
+        store.issue_chat_browser_key(
+            workspace_id=workspace_id,
+            name="chat-browser-first-workspace-refused",
+            creator_user_id=user_id,
+            limit_microdollars=_LIMIT_MICRODOLLARS,
+            expires_at=_future_expiry(),
+            active_key_cap=1,
+        )
+        is None
+    )
+    other = store.create_workspace(
+        user_id,
+        f"chat-browser-other-{unique}",
+        trial_credit_microdollars=0,
+    )
+
+    second = store.issue_chat_browser_key(
+        workspace_id=other.id,
+        name="chat-browser-other-workspace",
+        creator_user_id=user_id,
+        limit_microdollars=_LIMIT_MICRODOLLARS,
+        expires_at=_future_expiry(),
+        active_key_cap=1,
+    )
+
+    assert second is not None
+
+
+def test_concurrent_chat_browser_key_issuance_is_capped(
+    store: Store,
+    workspace_id: str,
+    user_id: str,
+) -> None:
+    callers = _ACTIVE_CAP * 3
+    barrier = threading.Barrier(callers)
+
+    def issue(index: int) -> tuple[str, ApiKey] | None:
+        barrier.wait(timeout=10)
+        return _issue(
+            store,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            name=f"chat-browser-concurrent-{index}",
+        )
+
+    with ThreadPoolExecutor(max_workers=callers) as executor:
+        results = list(executor.map(issue, range(callers)))
+
+    assert sum(result is not None for result in results) == _ACTIVE_CAP
+    stored = store.list_api_keys_with_usage(workspace_id)
+    assert sum(
+        is_active_chat_browser_key(snapshot.api_key) for snapshot in stored
+    ) == _ACTIVE_CAP

--- a/tests/conformance/test_store_semantics.py
+++ b/tests/conformance/test_store_semantics.py
@@ -25,11 +25,19 @@ Known limits of this suite — read before trusting it
 
 from __future__ import annotations
 
+import base64
 import datetime as dt
+import hashlib
 import threading
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
+from trusted_router.storage_oauth_codes import (
+    OAuthCodeMethodMismatch,
+    OAuthCodeVerifierMismatch,
+    OAuthWorkspaceUnavailable,
+)
 from trusted_router.store_protocol import Store
 from trusted_router.typed_balance import live_credit_summary
 
@@ -696,6 +704,174 @@ def test_oauth_authorization_code_is_single_use(store: Store, workspace_id: str)
     )
     assert store.consume_oauth_authorization_code(raw_code) is not None
     assert store.consume_oauth_authorization_code(raw_code) is None
+
+
+@pytest.mark.parametrize("method", [None, "plain", "S256"])
+def test_atomic_oauth_exchange_supports_every_pkce_mode(
+    store: Store,
+    workspace_id: str,
+    user_id: str,
+    unique: str,
+    method: str | None,
+) -> None:
+    """Every backend must mint one non-management key in the grant transaction."""
+    verifier = f"conformance-{unique}-" + "v" * 43
+    challenge = None
+    if method == "plain":
+        challenge = verifier
+    elif method == "S256":
+        challenge = (
+            base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest())
+            .decode("ascii")
+            .rstrip("=")
+        )
+    raw_code, _code = store.create_oauth_authorization_code(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        callback_url=f"https://{unique}.example.com/cb",
+        key_label="atomic conformance",
+        ttl_seconds=300,
+        app_id=2,
+        code_challenge=challenge,
+        code_challenge_method=method,
+    )
+
+    result = store.exchange_oauth_authorization_code(
+        raw_code,
+        code_verifier=verifier if method else None,
+        code_challenge_method=method,
+    )
+
+    assert result is not None
+    assert result.api_key.management is False
+    assert result.api_key.workspace_id == workspace_id
+    assert result.user is not None and result.user.id == user_id
+    stored_key = store.get_key_by_raw(result.raw_key)
+    assert stored_key is not None and stored_key.hash == result.api_key.hash
+    assert (
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=verifier if method else None,
+            code_challenge_method=method,
+        )
+        is None
+    )
+
+
+def test_atomic_oauth_exchange_rejections_do_not_burn_grant(
+    store: Store,
+    workspace_id: str,
+    user_id: str,
+    unique: str,
+) -> None:
+    verifier = f"correct-{unique}-" + "c" * 43
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest())
+        .decode("ascii")
+        .rstrip("=")
+    )
+    raw_code, _code = store.create_oauth_authorization_code(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        callback_url=f"https://retry-{unique}.example.com/cb",
+        key_label="retry conformance",
+        ttl_seconds=300,
+        app_id=3,
+        code_challenge=challenge,
+        code_challenge_method="S256",
+    )
+
+    with pytest.raises(OAuthCodeMethodMismatch):
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=verifier,
+            code_challenge_method="plain",
+        )
+    with pytest.raises(OAuthCodeVerifierMismatch):
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier="wrong-" + "w" * 43,
+            code_challenge_method="S256",
+        )
+
+    result = store.exchange_oauth_authorization_code(
+        raw_code,
+        code_verifier=verifier,
+        code_challenge_method="S256",
+    )
+    assert result is not None
+    assert result.api_key.management is False
+
+
+def test_deleted_workspace_cannot_redeem_oauth_grant(
+    store: Store,
+    workspace_id: str,
+    user_id: str,
+    unique: str,
+) -> None:
+    raw_code, _code = store.create_oauth_authorization_code(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        callback_url=f"https://deleted-{unique}.example.com/cb",
+        key_label="deleted workspace conformance",
+        ttl_seconds=300,
+        app_id=5,
+    )
+    store.update_workspace(workspace_id, deleted=True)
+    assert store.get_workspace(workspace_id) is None
+
+    with pytest.raises(OAuthWorkspaceUnavailable):
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=None,
+            code_challenge_method=None,
+        )
+
+    assert store.list_keys(workspace_id) == []
+    restored = store.update_workspace(workspace_id, deleted=False)
+    assert restored is not None
+    assert (
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=None,
+            code_challenge_method=None,
+        )
+        is not None
+    )
+
+
+def test_concurrent_atomic_oauth_exchange_mints_exactly_one_key(
+    store: Store,
+    workspace_id: str,
+    user_id: str,
+    unique: str,
+) -> None:
+    raw_code, _code = store.create_oauth_authorization_code(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        callback_url=f"https://race-{unique}.example.com/cb",
+        key_label="concurrent conformance",
+        ttl_seconds=300,
+        app_id=4,
+    )
+    callers = 8
+    ready = threading.Barrier(callers)
+
+    def exchange(_index: int):
+        ready.wait(timeout=10)
+        return store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=None,
+            code_challenge_method=None,
+        )
+
+    with ThreadPoolExecutor(max_workers=callers) as executor:
+        results = list(executor.map(exchange, range(callers)))
+
+    assert sum(result is not None for result in results) == 1
+    keys = store.list_keys(workspace_id)
+    assert len(keys) == 1
+    assert keys[0].management is False
 
 
 # --------------------------------------------------------------------------

--- a/tests/deploy_script_harness.py
+++ b/tests/deploy_script_harness.py
@@ -148,6 +148,29 @@ _STUB = r"""#!/usr/bin/env bash
 # have any. The run's stdin is /dev/null, so this returns immediately when the
 # stub is not in a pipeline.
 cat >/dev/null 2>&1 || true
+if [ -n "${HARNESS_SEQUENCE_FIXTURES:-}" ] && [ -f "$HARNESS_SEQUENCE_FIXTURES" ]; then
+  joined="${0##*/} $*"
+  while IFS=$'\t' read -r sequence_id pattern; do
+    [ -n "$pattern" ] || continue
+    if printf '%s' "$joined" | grep -Eq -- "$pattern"; then
+      count_file="$HARNESS_STATE_DIR/sequence-${sequence_id}.count"
+      response_file="$HARNESS_STATE_DIR/sequence-${sequence_id}.responses"
+      count=0
+      if [ -f "$count_file" ]; then
+        IFS= read -r count < "$count_file"
+      fi
+      count=$((count + 1))
+      printf '%s\n' "$count" > "$count_file"
+      encoded_reply="$(sed -n "${count}p" "$response_file")"
+      if [ -z "$encoded_reply" ]; then
+        encoded_reply="$(tail -n 1 "$response_file")"
+      fi
+      printf '%s' "$encoded_reply" | base64 --decode
+      printf '\n'
+      exit 0
+    fi
+  done < "$HARNESS_SEQUENCE_FIXTURES"
+fi
 if [ -n "${HARNESS_FIXTURES:-}" ] && [ -f "$HARNESS_FIXTURES" ]; then
   joined="${0##*/} $*"
   while IFS=$'\t' read -r pattern encoded_reply; do
@@ -194,7 +217,12 @@ _SYNTHETIC_INGEST_SERVICE_JSON = json.dumps(
                 "run.googleapis.com/ingress": "internal-and-cloud-load-balancing"
             },
         },
-        "status": {"conditions": [{"type": "Ready", "status": "True"}]},
+        "status": {
+            "conditions": [{"type": "Ready", "status": "True"}],
+            "traffic": [
+                {"revisionName": "trusted-router-billing-harness", "percent": 100}
+            ],
+        },
         "spec": {
             "template": {
                 "spec": {
@@ -229,6 +257,142 @@ _SYNTHETIC_INGEST_SERVICE_JSON = json.dumps(
     },
     separators=(",", ":"),
 )
+_SYNTHETIC_INGEST_REVISION_JSON = json.dumps(
+    {
+        "metadata": {"name": "trusted-router-billing-harness"},
+        "spec": {
+            "serviceAccountName": "tr-internal@quill-cloud-proxy.iam.gserviceaccount.com",
+            "containers": [
+                {
+                    "env": [
+                        {"name": "TR_SERVICE_SURFACE", "value": "internal"},
+                        {
+                            "name": "TR_OBSERVER_INTERNAL_TOKEN",
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "trustedrouter-observer-internal-token",
+                                    "key": "latest",
+                                }
+                            },
+                        },
+                        {
+                            "name": "TR_INTERNAL_GATEWAY_TOKEN",
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "trustedrouter-internal-gateway-token",
+                                    "key": "latest",
+                                }
+                            },
+                        },
+                    ]
+                }
+            ],
+        },
+    },
+    separators=(",", ":"),
+)
+_SYNTHETIC_SECRET_POLICY_JSON = json.dumps(
+    {
+        "bindings": [
+            {
+                "role": "roles/secretmanager.secretAccessor",
+                "members": [
+                    "serviceAccount:tr-internal@quill-cloud-proxy.iam.gserviceaccount.com",
+                    "serviceAccount:tr-synthetic@quill-cloud-proxy.iam.gserviceaccount.com",
+                ],
+            }
+        ]
+    },
+    separators=(",", ":"),
+)
+_SYNTHETIC_ACCOUNT_JSON = json.dumps(
+    {
+        "email": "tr-synthetic@quill-cloud-proxy.iam.gserviceaccount.com",
+        "disabled": False,
+    },
+    separators=(",", ":"),
+)
+_SYNTHETIC_ACCOUNT_POLICY_JSON = json.dumps(
+    {
+        "bindings": [
+            {
+                "role": "roles/iam.serviceAccountUser",
+                "members": [
+                    "serviceAccount:tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com"
+                ],
+            }
+        ]
+    },
+    separators=(",", ":"),
+)
+_SYNTHETIC_VERSION_LIST_JSON = json.dumps(
+    [
+        {
+            "name": "projects/quill-cloud-proxy/secrets/fixture/versions/7",
+            "state": "ENABLED",
+        }
+    ],
+    separators=(",", ":"),
+)
+_SYNTHETIC_JOB_POLICY_JSON = json.dumps(
+    {
+        "bindings": [
+            {
+                "role": "roles/run.invoker",
+                "members": [
+                    "serviceAccount:tr-synthetic@quill-cloud-proxy.iam.gserviceaccount.com"
+                ],
+            }
+        ]
+    },
+    separators=(",", ":"),
+)
+_SYNTHETIC_JOB_JSON = json.dumps(
+    {
+        "spec": {
+            "template": {
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "serviceAccountName": (
+                                "tr-synthetic@quill-cloud-proxy.iam.gserviceaccount.com"
+                            ),
+                            "containers": [
+                                {
+                                    "env": [
+                                        {
+                                            "name": "TR_OBSERVER_INTERNAL_TOKEN",
+                                            "valueFrom": {
+                                                "secretKeyRef": {
+                                                    "name": (
+                                                        "trustedrouter-observer-internal-token"
+                                                    ),
+                                                    "key": "7",
+                                                }
+                                            },
+                                        },
+                                        {
+                                            "name": "TR_SYNTHETIC_MONITOR_API_KEY",
+                                            "valueFrom": {
+                                                "secretKeyRef": {
+                                                    "name": (
+                                                        "trustedrouter-synthetic-monitor-api-key"
+                                                    ),
+                                                    "key": "7",
+                                                }
+                                            },
+                                        },
+                                    ]
+                                }
+                            ],
+                        }
+                    }
+                }
+            }
+        }
+    },
+    separators=(",", ":"),
+)
 
 
 @dataclass(frozen=True)
@@ -240,6 +404,11 @@ class ScriptFixture:
     env: dict[str, str] = field(default_factory=dict)
     #: ``(extended-regex over "<command> <argv...>", stdout)`` in priority order.
     responses: tuple[tuple[str, str], ...] = ()
+    #: Like ``responses``, but each matching call consumes the next reply and
+    #: then repeats the last one. This lets tests model an IAM policy changing
+    #: between two preflight reads instead of proving ordering against a
+    #: forever-static fake control plane.
+    sequential_responses: tuple[tuple[str, tuple[str, ...]], ...] = ()
     #: Extended regexes whose matching command must exit 1 instead of succeeding.
     failures: tuple[str, ...] = ()
     #: Files to create under ``$HOME`` before the run, path -> contents.
@@ -375,9 +544,42 @@ SCRIPT_FIXTURES: dict[str, ScriptFixture] = {
     "scripts/deploy/synthetic.sh": ScriptFixture(
         env={"TR_BILLING_SERVICE": "trusted-router-billing"},
         responses=(
+            (r"projects describe .*--format=value\(projectNumber\)", "123456789"),
+            (r"projects get-iam-policy .*--format=json", '{"bindings":[]}'),
+            (
+                r"iam service-accounts describe tr-synthetic@.*--format=json",
+                _SYNTHETIC_ACCOUNT_JSON,
+            ),
+            (
+                r"iam service-accounts get-iam-policy tr-synthetic@.*--format=json",
+                _SYNTHETIC_ACCOUNT_POLICY_JSON,
+            ),
+            (
+                r"secrets versions list .*--filter=state=ENABLED.*--format=json",
+                _SYNTHETIC_VERSION_LIST_JSON,
+            ),
+            (
+                r"secrets get-iam-policy .*--format=json",
+                _SYNTHETIC_SECRET_POLICY_JSON,
+            ),
+            (
+                r"run jobs get-iam-policy .*--format=json",
+                _SYNTHETIC_JOB_POLICY_JSON,
+            ),
+            (r"run jobs describe .*--format=json", _SYNTHETIC_JOB_JSON),
+            (
+                r"artifacts docker images describe .*--format=json",
+                '{"image_summary":{"fully_qualified_digest":'
+                '"us-central1-docker.pkg.dev/quill-cloud-proxy/trusted-router/'
+                'trusted-router@sha256:' + "a" * 64 + '"}}',
+            ),
             (
                 r"run services describe trusted-router-billing.*--format=json",
                 _SYNTHETIC_INGEST_SERVICE_JSON,
+            ),
+            (
+                r"run revisions describe trusted-router-billing-harness.*--format=json",
+                _SYNTHETIC_INGEST_REVISION_JSON,
             ),
             (
                 r"dns managed-zones describe trusted-router-private-run-app --format=json",
@@ -526,6 +728,24 @@ class DeployScriptHarness:
                 for pattern, reply in fixture.responses
             )
         )
+        state_dir = run_dir / "state"
+        state_dir.mkdir()
+        sequence_fixtures_file = run_dir / "sequence-fixtures.tsv"
+        sequence_fixtures_file.write_text(
+            "".join(
+                f"{index}\t{pattern}\n"
+                for index, (pattern, _) in enumerate(fixture.sequential_responses)
+            )
+        )
+        for index, (_, replies) in enumerate(fixture.sequential_responses):
+            if not replies:
+                raise ValueError("sequential response fixtures must not be empty")
+            (state_dir / f"sequence-{index}.responses").write_text(
+                "".join(
+                    f"{base64.b64encode(reply.encode()).decode('ascii')}\n"
+                    for reply in replies
+                )
+            )
         failures_file = run_dir / "failures.txt"
         failures_file.write_text("".join(f"{pattern}\n" for pattern in fixture.failures))
 
@@ -536,6 +756,8 @@ class DeployScriptHarness:
             "LANG": "C",
             "HARNESS_ARGV_LOG": str(argv_log),
             "HARNESS_FIXTURES": str(fixtures_file),
+            "HARNESS_SEQUENCE_FIXTURES": str(sequence_fixtures_file),
+            "HARNESS_STATE_DIR": str(state_dir),
             "HARNESS_FAILURES": str(failures_file),
             "HARNESS_VERIFIER_RC": str(verifier_rc),
             **{k: v for k, v in fixture.env.items() if k not in omit_env},

--- a/tests/test_attested_transport.py
+++ b/tests/test_attested_transport.py
@@ -164,10 +164,10 @@ class TestTargetPlumbing:
         assert all(t.expected_pcr0 is None for t in configured_targets(settings))
 
     def test_standalone_topology_is_one_canonical_target(self) -> None:
-        """Regional alias/Cloud-Run probing is GCP topology. On a
-        standalone deployment the templates fabricate hostnames that do
-        not exist (api-eu-west-3.quillrouter.com, a nonexistent *.run.app
-        URL) which would sit permanently down on the status page."""
+        """Regional alias probing is GCP topology. On a standalone
+        deployment the template fabricates a hostname that does not exist
+        (api-eu-west-3.quillrouter.com), which would sit permanently down on
+        the status page."""
         settings = Settings(
             environment="test",
             sentry_dsn=None,
@@ -183,9 +183,64 @@ class TestTargetPlumbing:
 
     def test_gcp_topology_unchanged_by_standalone_settings(self) -> None:
         settings = Settings(environment="test", sentry_dsn=None)
-        names = [t.name for t in configured_targets(settings)]
+        targets = configured_targets(settings)
+        names = [target.name for target in targets]
         assert names[0] == "canonical"
         assert len(names) > 1  # regional targets still present by default
+        assert all(target.control_plane_url is None for target in targets)
+
+    def test_regional_health_targets_configured_private_billing_origin(self) -> None:
+        origin = (
+            "https://trusted-router-billing-44325983244.europe-west4.run.app"
+        )
+        settings = Settings(
+            environment="test",
+            sentry_dsn=None,
+            regions="us-central1,europe-west4",
+            synthetic_monitor_region="europe-west4",
+            synthetic_control_plane_health_url=origin,
+        )
+
+        targets = configured_targets(settings)
+
+        assert [
+            (target.name, target.control_plane_url)
+            for target in targets
+            if target.control_plane_url is not None
+        ] == [("europe-west4", origin)]
+        assert all(
+            target.control_plane_url is None
+            or "trusted-router-billing-" in target.control_plane_url
+            for target in targets
+        )
+
+    @pytest.mark.parametrize(
+        "origin",
+        [
+            "https://trusted-router-44325983244.europe-west4.run.app",
+            "https://trusted-router-console-44325983244.europe-west4.run.app",
+            "https://trusted-router-public-44325983244.europe-west4.run.app",
+            "https://trusted-router-billing-44325983244.us-central1.run.app",
+            "https://trusted-router-billing-44325983244.europe-west4.run.app/health",
+            "https://trusted-router-billing-44325983244.europe-west4.run.app?probe=1",
+            "http://trusted-router-billing-44325983244.europe-west4.run.app",
+            "https://billing.example.com",
+        ],
+    )
+    def test_regional_health_rejects_non_private_billing_origin(self, origin: str) -> None:
+        settings = Settings(
+            environment="test",
+            sentry_dsn=None,
+            regions="us-central1,europe-west4",
+            synthetic_monitor_region="europe-west4",
+            synthetic_control_plane_health_url=origin,
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=r"\$\{SERVICE\}-billing Cloud Run origin",
+        ):
+            configured_targets(settings)
 
     def test_target_defaults_are_backward_compatible(self) -> None:
         target = SyntheticTarget("canonical", "https://api.trustedrouter.com/v1")

--- a/tests/test_auth_and_routing.py
+++ b/tests/test_auth_and_routing.py
@@ -288,6 +288,8 @@ def test_regions_endpoint_and_gateway_authorize_include_routing_metadata() -> No
         "europe-west4",
         "asia-northeast1",
     ]
+    assert all("control_plane_url" not in item for item in regions.json()["data"])
+    assert ".run.app" not in regions.text
     assert regions.json()["trustedrouter"]["primary_region"] == "europe-west4"
     assert authorize.status_code == 200, authorize.text
     data = authorize.json()["data"]
@@ -295,6 +297,8 @@ def test_regions_endpoint_and_gateway_authorize_include_routing_metadata() -> No
     assert data["requested_model"] == "trustedrouter/auto"
     assert data["model"] == auto_leader
     assert data["region"] == "asia-northeast1"
+    assert all("control_plane_url" not in item for item in data["regions"])
+    assert ".run.app" not in str(data["regions"])
     assert len(data["route_candidates"]) >= 2
     assert data["route_candidates"][0]["model"] == auto_leader
     # The exact tail of the auto rollover depends on which providers are

--- a/tests/test_broadcast.py
+++ b/tests/test_broadcast.py
@@ -56,6 +56,10 @@ def test_broadcast_inline_drain_defaults_to_non_production_only() -> None:
             storage_backend="spanner-bigtable",
             internal_gateway_token="token",  # noqa: S106 - placeholder test secret.
             observer_internal_token="observer-token",  # noqa: S106 - test secret.
+            stripe_secret_key="rk_test_payment_intents",  # noqa: S106
+            aws_access_key_id="internal-ses-access",
+            aws_secret_access_key="internal-ses-secret",  # noqa: S106
+            ses_from_email="noreply@example.com",
             sentry_dsn="https://example@sentry.invalid/1",
             spanner_instance_id="inst",
             spanner_database_id="db",

--- a/tests/test_chat_proxy.py
+++ b/tests/test_chat_proxy.py
@@ -1,5 +1,5 @@
 """Tests for /chat-proxy/v1/* — the same-origin streaming pipe the
-chat playground uses to reach api.trustedrouter.com without tripping
+chat playground uses to reach its domain's attested API without tripping
 browser CORS.
 
 These tests use httpx.MockTransport to stand in for api.trustedrouter.com
@@ -49,7 +49,10 @@ def _install_upstream(
 
 
 def _authenticated_client(settings: Settings) -> tuple[TestClient, str]:
-    client = TestClient(create_app(settings))
+    client = TestClient(
+        create_app(settings),
+        base_url="https://trustedrouter.com",
+    )
     user = STORE.ensure_user("chat-proxy@example.com")
     workspace = STORE.list_workspaces_for_user(user.id)[0]
     raw_key, _ = STORE.create_api_key(
@@ -132,6 +135,66 @@ def test_chat_proxy_forwards_body_and_returns_response(
     import json
 
     assert json.loads(captured["body"]) == body
+
+
+@pytest.mark.parametrize(
+    "domain",
+    ("trustedrouter.com", "allyrouter.com", "uptimerouter.com"),
+)
+def test_chat_proxy_keeps_each_managed_domain_on_its_attested_api_alias(
+    settings: Settings,
+    monkeypatch: pytest.MonkeyPatch,
+    domain: str,
+) -> None:
+    captured_urls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_urls.append(str(request.url))
+        return _streaming_response(status_code=200, content=b"{}")
+
+    _install_upstream(monkeypatch, handler)
+    client, raw_key = _authenticated_client(settings)
+
+    response = client.post(
+        "/chat-proxy/v1/chat/completions",
+        json={"model": "x", "messages": []},
+        headers={
+            "Authorization": f"Bearer {raw_key}",
+            "Host": domain,
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured_urls == [f"https://api.{domain}/v1/chat/completions"]
+
+
+def test_chat_proxy_rejects_an_untrusted_host_before_upstream_work(
+    settings: Settings,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_urls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_urls.append(str(request.url))
+        return _streaming_response(status_code=200, content=b"{}")
+
+    _install_upstream(monkeypatch, handler)
+    client, raw_key = _authenticated_client(settings)
+
+    response = client.post(
+        "/chat-proxy/v1/chat/completions",
+        json={"model": "x", "messages": []},
+        headers={
+            "Authorization": f"Bearer {raw_key}",
+            "Host": "attacker.example",
+        },
+    )
+
+    assert response.status_code == 421
+    assert response.json()["error"]["message"] == (
+        "Chat proxy request Host is not a configured domain"
+    )
+    assert captured_urls == []
 
 
 def test_chat_proxy_forwards_streaming_sse(

--- a/tests/test_clickhouse_node_provisioning.py
+++ b/tests/test_clickhouse_node_provisioning.py
@@ -75,7 +75,7 @@ def test_rollout_prefers_private_clickhouse_load_balancer() -> None:
     script = (ROOT / "scripts/deploy/rollout.sh").read_text()
 
     assert "compute addresses describe tr-clickhouse-ilb" in script
-    assert 'TR_PROVIDER_ANALYTICS_CLICKHOUSE_URL=${PROVIDER_ANALYTICS_CLICKHOUSE_URL}' in script
+    assert 'TR_PROVIDER_ANALYTICS_CLICKHOUSE_URL=${PROVIDER_CLICKHOUSE_URL}' in script
 
 
 def test_operational_deploy_moves_benchmark_code_schema_and_replay_together() -> None:

--- a/tests/test_clickhouse_operational_deploy.py
+++ b/tests/test_clickhouse_operational_deploy.py
@@ -150,7 +150,8 @@ def test_rollout_preserves_dual_read_mode_and_uses_distinct_reader_secret() -> N
     rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
     secrets = (ROOT / "scripts/deploy/secrets.sh").read_text()
     assert "TR_ANALYTICS_READ_MODE" in rollout
-    assert "LIVE_ANALYTICS_READ_MODE" in rollout
+    assert 'serving_env_value TR_ANALYTICS_READ_MODE bigtable' in rollout
+    assert 'TR_ANALYTICS_READ_MODE=${ANALYTICS_READ_MODE}' in rollout
     assert "TR_ANALYTICS_DUAL_READ_STARTED_AT" in rollout
     assert "TR_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT" in rollout
     assert "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true" in rollout

--- a/tests/test_contract_regressions.py
+++ b/tests/test_contract_regressions.py
@@ -156,7 +156,7 @@ def test_gateway_refund_repeat_cannot_restore_credit_twice(
 
 
 def test_production_prompt_routes_are_absent_and_gateway_requires_internal_token() -> None:
-    control_client = TestClient(_production_app("control"))
+    control_client = TestClient(_production_app("console"))
     internal_client = TestClient(_production_app("internal"))
 
     prompt = control_client.post(
@@ -202,7 +202,6 @@ def test_all_stubbed_coverage_routes_have_stable_error_shapes(client: TestClient
 
 def _production_app(surface: str):
     internal_token = "prod" + "-internal-token"
-    webhook_secret = "whsec_" + "test"
     stripe_key = "sk_" + "test_secret"
     values = {
         "environment": "production",
@@ -213,12 +212,14 @@ def _production_app(surface: str):
         "spanner_database_id": "trusted-router",
         "bigtable_instance_id": "trusted-router-logs",
     }
-    if surface == "control":
+    if surface == "console":
         values.update(
             {
                 "attribution_cookie_secret": "attribution-cookie-" + "a" * 32,
-                "stripe_webhook_secret": webhook_secret,
                 "stripe_secret_key": stripe_key,
+                "google_oauth_login_available": False,
+                "github_oauth_login_available": False,
+                "paypal_checkout_enabled": False,
                 "aws_access_key_id": "test-access-key",
                 "aws_secret_access_key": "test-secret-key",
                 "ses_from_email": "noreply@example.com",
@@ -230,6 +231,10 @@ def _production_app(surface: str):
             {
                 "internal_gateway_token": internal_token,
                 "observer_internal_token": "prod-observer-token",
+                "stripe_secret_key": "rk_test_payment_intents",
+                "aws_access_key_id": "internal-ses-access",
+                "aws_secret_access_key": "internal-ses-secret",
+                "ses_from_email": "noreply@example.com",
             }
         )
     return create_app(

--- a/tests/test_ddos_edge_deploy.py
+++ b/tests/test_ddos_edge_deploy.py
@@ -1037,8 +1037,11 @@ def test_edge_surface_inventory_is_total_and_never_claims_live_completion() -> N
     required_hosts.update(
         {"eu.trustedrouter.com", "status-us.trustedrouter.com", "status-eu.trustedrouter.com"}
     )
+    # Enclave-published static site; DNS owned by quill-cloud-proxy, not the LB.
+    required_hosts.discard("trust.trustedrouter.com")
     declared_hosts = {host for surface in surfaces for host in surface.get("hosts", [])}
     assert required_hosts <= declared_hosts
+    assert "trust.trustedrouter.com" not in declared_hosts
     assert {"aws.trustedrouter.com", "api-aws.trustedrouter.com"} <= declared_hosts
     assert {
         "azure.trustedrouter.com",

--- a/tests/test_ddos_edge_deploy.py
+++ b/tests/test_ddos_edge_deploy.py
@@ -33,29 +33,279 @@ def test_cloud_run_security_defaults_are_per_service_and_cost_bounded() -> None:
     assert 'TR_CLOUD_RUN_MAX_INSTANCES="${TR_CLOUD_RUN_MAX_INSTANCES:-20}"' in shared
 
 
-def test_gcp_edge_reconciler_preserves_headers_and_repairs_every_security_control(
+def _exact_policy() -> dict[str, object]:
+    allowed = (
+        r"^(trustedrouter[.]com|www[.]trustedrouter[.]com|status[.]trustedrouter[.]com|"
+        r"trust[.]trustedrouter[.]com|eu[.]trustedrouter[.]com|status-us[.]trustedrouter[.]com|"
+        r"status-eu[.]trustedrouter[.]com|allyrouter[.]com|www[.]allyrouter[.]com|"
+        r"status[.]allyrouter[.]com|trust[.]allyrouter[.]com|uptimerouter[.]com|"
+        r"www[.]uptimerouter[.]com|status[.]uptimerouter[.]com|trust[.]uptimerouter[.]com)"
+        r"(:[0-9]+)?$"
+    )
+
+    def rate(count: int) -> dict[str, object]:
+        return {
+            "rateLimitThreshold": {"count": count, "intervalSec": 60},
+            "conformAction": "allow",
+            "exceedAction": "deny(429)",
+            "enforceOnKey": "IP",
+        }
+
+    source = {"config": {"srcIpRanges": ["*"]}, "versionedExpr": "SRC_IPS_V1"}
+    return {
+        "type": "CLOUD_ARMOR",
+        "description": (
+            "TrustedRouter exact edge controls; host and all-path gates enforced, "
+            "route-shape rules previewed"
+        ),
+        "rules": [
+            {
+                "priority": 900,
+                "action": "deny(403)",
+                "description": "Reject hosts outside canonical and marketing aliases",
+                "preview": False,
+                "match": {
+                    "expr": {
+                        "expression": (
+                            "!has(request.headers['host']) || "
+                            f"!request.headers['host'].lower().matches('{allowed}')"
+                        )
+                    }
+                },
+            },
+            {
+                "priority": 1000,
+                "action": "throttle",
+                "description": "Browser inference proxy per-client throttle",
+                "preview": True,
+                "match": {
+                    "expr": {"expression": "request.path.startsWith('/chat-proxy/')"}
+                },
+                "rateLimitOptions": rate(120),
+            },
+            {
+                "priority": 1100,
+                "action": "throttle",
+                "description": "State-changing request per-client throttle",
+                "preview": True,
+                "match": {
+                    "expr": {
+                        "expression": (
+                            "request.method != 'GET' && request.method != 'HEAD' && "
+                            "request.method != 'OPTIONS'"
+                        )
+                    }
+                },
+                "rateLimitOptions": rate(300),
+            },
+            {
+                "priority": 1200,
+                "action": "throttle",
+                "description": "All-path per-source safety ceiling",
+                "preview": False,
+                "match": source,
+                "rateLimitOptions": rate(2400),
+            },
+            {
+                "priority": 2_147_483_647,
+                "action": "allow",
+                "description": (
+                    "Default allow; bounded route classes are evaluated first"
+                ),
+                "preview": False,
+                "match": source,
+            },
+        ]
+    }
+
+
+def _exact_public_backend() -> dict[str, object]:
+    return {
+        "customRequestHeaders": ["X-TrustedRouter-Client-IP:{client_ip_address}"],
+        "customResponseHeaders": [],
+        "edgeSecurityPolicy": "",
+        "iap": {"enabled": False, "oauth2ClientId": " "},
+        "logConfig": {
+            "enable": True,
+            "sampleRate": 0.1,
+        },
+        "enableCDN": True,
+        "compressionMode": "AUTOMATIC",
+        "cdnPolicy": {
+            "cacheMode": "USE_ORIGIN_HEADERS",
+            "negativeCaching": False,
+            "negativeCachingPolicy": [],
+            "serveWhileStale": 600,
+            "cacheKeyPolicy": {
+                "includeHost": True,
+                "includeProtocol": True,
+                "includeQueryString": True,
+                "queryStringBlacklist": [],
+                "queryStringWhitelist": [],
+                "includeHttpHeaders": [],
+                "includeNamedCookies": [],
+            },
+        },
+    }
+
+
+def _exact_rollout_public_backend() -> dict[str, object]:
+    backend = _exact_public_backend()
+    backend.update(
+        {
+            "name": "trusted-router-public-backend",
+            "loadBalancingScheme": "EXTERNAL_MANAGED",
+            "protocol": "HTTP",
+            "timeoutSec": 60,
+            "securityPolicy": (
+                "https://www.googleapis.com/compute/v1/projects/quill-cloud-proxy/"
+                "global/securityPolicies/trusted-router-public-edge"
+            ),
+            "backends": [
+                {
+                    "group": (
+                        "https://www.googleapis.com/compute/v1/projects/"
+                        "quill-cloud-proxy/regions/us-central1/networkEndpointGroups/"
+                        "trusted-router-public-neg"
+                    )
+                },
+                {
+                    "group": (
+                        "https://www.googleapis.com/compute/v1/projects/"
+                        "quill-cloud-proxy/regions/europe-west4/networkEndpointGroups/"
+                        "trusted-router-public-neg"
+                    )
+                },
+            ],
+        }
+    )
+    return backend
+
+
+def _set_nested(value: dict[str, object], path: tuple[object, ...], replacement: object) -> None:
+    current: object = value
+    for component in path[:-1]:
+        if isinstance(component, int):
+            assert isinstance(current, list)
+            current = current[component]
+        else:
+            assert isinstance(current, dict)
+            current = current[component]
+    last = path[-1]
+    if isinstance(last, int):
+        assert isinstance(current, list)
+        current[last] = replacement
+    else:
+        assert isinstance(current, dict)
+        current[last] = replacement
+
+
+def test_shared_edge_verifiers_accept_only_the_exact_rollout_contract(
+    tmp_path: Path,
+) -> None:
+    driver = tmp_path / "driver.sh"
+    driver.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+source {ROOT / 'scripts/deploy/_edge_security.sh'}
+verify_edge_backend_contract_json public "$BACKEND_JSON" quill-cloud-proxy \
+  us-central1,europe-west4 trusted-router-public trusted-router-public-neg \
+  trusted-router-public-edge 60
+verify_cloud_armor_policy_contract_json "$POLICY_JSON"
+""",
+        encoding="utf-8",
+    )
+    exact_env = {
+        "BACKEND_JSON": json.dumps(_exact_rollout_public_backend(), separators=(",", ":")),
+        "POLICY_JSON": json.dumps(_exact_policy(), separators=(",", ":")),
+    }
+    exact = _run_bash(driver, env=exact_env)
+    assert exact.returncode == 0, exact.stderr
+
+    armor_drifts: tuple[tuple[tuple[object, ...], object], ...] = (
+        (("userIpRequestHeaders",), ["X-Forwarded-For"]),
+        (("recaptchaOptionsConfig",), {"redirectSiteKey": "injected"}),
+        (("rules", 0, "headerAction"), {"requestHeadersToAdds": []}),
+        (("rules", 1, "rateLimitOptions", "banDurationSec"), 600),
+    )
+    for path, replacement in armor_drifts:
+        policy = json.loads(json.dumps(_exact_policy()))
+        _set_nested(policy, path, replacement)
+        drift = _run_bash(
+            driver,
+            env={**exact_env, "POLICY_JSON": json.dumps(policy, separators=(",", ":"))},
+        )
+        assert drift.returncode != 0, path
+
+    backend_drifts: tuple[tuple[tuple[object, ...], object], ...] = (
+        (("cdnPolicy", "requestCoalescing"), False),
+        (("cdnPolicy", "signedUrlCacheMaxAgeSec"), 3600),
+        (("cdnPolicy", "signedUrlKeyNames"), ["legacy-key"]),
+        (("cdnPolicy", "clientTtl"), 60),
+        (("cdnPolicy", "defaultTtl"), 60),
+        (("cdnPolicy", "maxTtl"), 60),
+        (("cdnPolicy", "bypassCacheOnRequestHeaders"), [{"headerName": "Authorization"}]),
+        (("cdnPolicy", "cacheKeyPolicy", "includeHttpHeaders"), ["Authorization"]),
+        (("cdnPolicy", "cacheKeyPolicy", "includeNamedCookies"), ["session"]),
+        (("cdnPolicy", "cacheKeyPolicy", "includeUserAgent"), True),
+        (("cdnPolicy", "unknownProviderField"), True),
+    )
+    for path, replacement in backend_drifts:
+        backend = json.loads(json.dumps(_exact_rollout_public_backend()))
+        _set_nested(backend, path, replacement)
+        drift = _run_bash(
+            driver,
+            env={**exact_env, "BACKEND_JSON": json.dumps(backend, separators=(",", ":"))},
+        )
+        assert drift.returncode != 0, path
+
+
+def test_gcp_edge_reconciler_clears_stale_backend_and_armor_state(
     tmp_path: Path,
 ) -> None:
     calls = tmp_path / "calls.log"
+    imported_policy = tmp_path / "imported-policy.json"
     driver = tmp_path / "driver.sh"
     driver.write_text(
         f"""#!/usr/bin/env bash
 set -euo pipefail
 source {ROOT / 'scripts/deploy/_edge_security.sh'}
 CALLS={calls}
+IMPORTED_POLICY={imported_policy}
+POLICY_IMPORTED=0
+BACKEND_UPDATES=0
 gc() {{
   printf '%s\\n' "$*" >> "$CALLS"
   case "$*" in
-    "compute security-policies describe tr-public-policy --global") return 1 ;;
-    "compute security-policies rules describe "*) return 1 ;;
+    "compute security-policies import tr-public-policy "*)
+      for value in "$@"; do
+        case "$value" in
+          --file-name=*) cp "${{value#--file-name=}}" "$IMPORTED_POLICY" ;;
+        esac
+      done
+      [ -s "$IMPORTED_POLICY" ] || return 92
+      POLICY_IMPORTED=1
+      ;;
+    "compute security-policies describe tr-public-policy --global --format=json")
+      [ "$POLICY_IMPORTED" = 1 ] || return 91
+      if [ "${{FAKE_ARMOR_EXTRA:-0}}" = 1 ]; then
+        python3 -c 'import json,sys; value=json.load(open(sys.argv[1], encoding="utf-8")); value["rules"][0]["headerAction"]={{"requestHeadersToAdds":[{{"headerName":"X-Injected","headerValue":"unsafe"}}]}}; print(json.dumps(value))' "$IMPORTED_POLICY"
+      else
+        command cat "$IMPORTED_POLICY"
+      fi
+      ;;
+    "compute backend-services update tr-public-backend "*)
+      BACKEND_UPDATES=$((BACKEND_UPDATES + 1))
+      ;;
     "compute backend-services describe tr-public-backend --global --format=json")
-      printf '%s\\n' '{{"customRequestHeaders":["X-Existing:keep","x-trustedrouter-client-ip:spoof"]}}'
+      if [ "$BACKEND_UPDATES" -eq 0 ]; then
+        printf '%s\\n' '{{"customRequestHeaders":["Authorization: stale"],"customResponseHeaders":["X-Internal: stale"],"edgeSecurityPolicy":"stale","iap":{{"enabled":true}},"enableCDN":false}}'
+      else
+        printf '%s\\n' "$FAKE_BACKEND_JSON"
+      fi
       ;;
     "compute backend-services describe tr-public-backend --global --format=value(securityPolicy.basename())")
       printf '%s\\n' tr-public-policy
-      ;;
-    "compute backend-services describe tr-public-backend --global --format=json(customRequestHeaders,securityPolicy)")
-      printf '%s\\n' '{{"customRequestHeaders":["X-Existing:keep","X-TrustedRouter-Client-IP:{{client_ip_address}}"],"securityPolicy":"/global/securityPolicies/tr-public-policy"}}'
       ;;
   esac
 }}
@@ -65,84 +315,117 @@ reconcile_edge_backend tr-public-backend tr-public-policy
         encoding="utf-8",
     )
 
-    result = _run_bash(driver)
+    result = _run_bash(
+        driver,
+        env={
+            "TR_PUBLIC_BACKEND": "tr-public-backend",
+            "FAKE_BACKEND_JSON": json.dumps(
+                _exact_public_backend(), separators=(",", ":")
+            ),
+        },
+    )
     assert result.returncode == 0, result.stderr
     invoked = calls.read_text(encoding="utf-8")
-    assert "security-policies create tr-public-policy" in invoked
-    assert "security-policies rules update 2147483647" in invoked
-    assert invoked.count("security-policies rules create") == 4
-    assert invoked.count("--action=throttle") == 3
-    assert invoked.count("--preview") == 2
-    host_rule = next(
-        line
-        for line in invoked.splitlines()
-        if "security-policies rules create 900" in line
-    )
-    assert "--preview" not in host_rule
-    assert "--action=deny-403" in host_rule
-    global_rule = next(
-        line
-        for line in invoked.splitlines()
-        if "security-policies rules create 1200" in line
-    )
-    assert "--preview" not in global_rule
-    assert "--action=throttle" in global_rule
-    assert "--exceed-action=deny-429" in global_rule
-    assert "--enforce-on-key=IP" in global_rule
+    assert "security-policies import tr-public-policy" in invoked
     assert "--security-policy=tr-public-policy" in invoked
+    assert "--edge-security-policy=" in invoked
+    assert "--iap=disabled,oauth2-client-id= ,oauth2-client-secret= " in invoked
+    assert "--no-custom-request-headers" in invoked
+    assert "--no-custom-response-headers" in invoked
     assert "--enable-logging" in invoked
-    assert "--custom-request-header=X-Existing:keep" in invoked
-    assert (
-        "--custom-request-header=X-TrustedRouter-Client-IP:{client_ip_address}" in invoked
+    assert "--logging-sample-rate=0.1" in invoked
+    assert "--logging-optional=" not in invoked
+    assert "--custom-request-header=X-TrustedRouter-Client-IP:{client_ip_address}" in invoked
+    assert "--enable-cdn" in invoked
+    assert "--cache-mode=USE_ORIGIN_HEADERS" in invoked
+    assert "--no-negative-caching" in invoked
+    assert "--request-coalescing" in invoked
+    assert "--compression-mode=AUTOMATIC" in invoked
+    imported = json.loads(imported_policy.read_text(encoding="utf-8"))
+    contract_fields = ("priority", "action", "preview", "match", "rateLimitOptions")
+    assert [
+        {field: rule[field] for field in contract_fields if field in rule}
+        for rule in imported["rules"]
+    ] == [
+        {field: rule[field] for field in contract_fields if field in rule}
+        for rule in _exact_policy()["rules"]
+    ]
+    assert all(
+        field not in rule
+        for rule in imported["rules"]
+        for field in ("headerAction", "redirectOptions", "preconfiguredWafConfig")
     )
-    assert "--custom-request-header=x-trustedrouter-client-ip:spoof" not in invoked
+
+    drift_result = _run_bash(
+        driver,
+        env={
+            "TR_PUBLIC_BACKEND": "tr-public-backend",
+            "FAKE_ARMOR_EXTRA": "1",
+            "FAKE_BACKEND_JSON": json.dumps(
+                _exact_public_backend(), separators=(",", ":")
+            ),
+        },
+    )
+    assert drift_result.returncode != 0
+    assert "retains forbidden fields" in drift_result.stderr
+
+    for field, value in (
+        ("requestCoalescing", False),
+        ("signedUrlCacheMaxAgeSec", "3600"),
+    ):
+        stale_backend = _exact_public_backend()
+        assert isinstance(stale_backend["cdnPolicy"], dict)
+        stale_backend["cdnPolicy"][field] = value
+        drift_result = _run_bash(
+            driver,
+            env={
+                "TR_PUBLIC_BACKEND": "tr-public-backend",
+                "FAKE_BACKEND_JSON": json.dumps(stale_backend, separators=(",", ":")),
+            },
+        )
+        assert drift_result.returncode != 0
+        assert "CDN/cache-key contract drifted" in drift_result.stderr
+
+    stale_backend = _exact_public_backend()
+    assert isinstance(stale_backend["cdnPolicy"], dict)
+    cache_key = stale_backend["cdnPolicy"]["cacheKeyPolicy"]
+    assert isinstance(cache_key, dict)
+    cache_key["includeUserAgent"] = True
+    drift_result = _run_bash(
+        driver,
+        env={
+            "TR_PUBLIC_BACKEND": "tr-public-backend",
+            "FAKE_BACKEND_JSON": json.dumps(stale_backend, separators=(",", ":")),
+        },
+    )
+    assert drift_result.returncode != 0
+    assert "CDN/cache-key contract drifted" in drift_result.stderr
 
 
-def test_gcp_existing_host_gate_and_all_path_ceiling_are_forced_out_of_preview(
+@pytest.mark.parametrize(
+    "setting",
+    ("TR_CLOUD_ARMOR_PREVIEW", "TR_EDGE_ALLOWED_HOST_REGEX"),
+)
+def test_gcp_edge_contract_rejects_runtime_tuning_overrides(
     tmp_path: Path,
+    setting: str,
 ) -> None:
-    calls = tmp_path / "calls.log"
     driver = tmp_path / "driver.sh"
     driver.write_text(
         f"""#!/usr/bin/env bash
 set -euo pipefail
 source {ROOT / 'scripts/deploy/_edge_security.sh'}
-CALLS={calls}
-gc() {{
-  printf '%s\\n' "$*" >> "$CALLS"
-}}
+gc() {{ :; }}
 log() {{ :; }}
-TR_CLOUD_ARMOR_PREVIEW=1 _reconcile_cloud_armor_policy tr-existing-policy
+{setting}=unsafe _reconcile_cloud_armor_policy tr-existing-policy
 """,
         encoding="utf-8",
     )
 
     result = _run_bash(driver)
 
-    assert result.returncode == 0, result.stderr
-    updates = calls.read_text(encoding="utf-8").splitlines()
-    host_updates = [
-        line
-        for line in updates
-        if "security-policies rules update 900" in line
-    ]
-    assert len(host_updates) == 1
-    assert "--no-preview" in host_updates[0]
-    assert "--preview" not in host_updates[0]
-    assert "--action=deny-403" in host_updates[0]
-
-    global_updates = [
-        line
-        for line in updates
-        if "security-policies rules update 1200" in line
-    ]
-    assert len(global_updates) == 1
-    global_update = global_updates[0]
-    assert "--no-preview" in global_update
-    assert "--preview" not in global_update
-    assert "--enforce-on-key=IP" in global_update
-    assert "--action=throttle" in global_update
-    assert "--exceed-action=deny-429" in global_update
+    assert result.returncode == 2
+    assert "not an operator override" in result.stderr
 
 
 def test_gcp_edge_reconciler_is_parameterized_for_multiple_backends(tmp_path: Path) -> None:
@@ -182,7 +465,7 @@ TR_CLOUD_ARMOR_LOG_SAMPLE_RATE=0.not-a-number \
 
     result = _run_bash(driver)
     assert result.returncode == 2
-    assert "must be between 0 and 1" in result.stderr
+    assert "fixed at 0.1" in result.stderr
 
 
 def test_private_run_app_reconciler_uses_private_google_access(tmp_path: Path) -> None:
@@ -698,10 +981,18 @@ def test_every_synthetic_job_uses_private_run_app_ingress() -> None:
 
     assert 'source "${SCRIPT_DIR}/_private_run_ingress.sh"' in deploy
     assert '"TR_SERVICE_SURFACE=observer"' in deploy
+    assert "resolve_newest_enabled_secret_version" in deploy
+    assert "enabled secret version name is not numeric" in deploy
     assert (
-        '"TR_OBSERVER_INTERNAL_TOKEN=trustedrouter-observer-internal-token:latest"'
-        in deploy
+        '"TR_OBSERVER_INTERNAL_TOKEN=trustedrouter-observer-internal-token:'
+        '${OBSERVER_SECRET_VERSION}"' in deploy
     )
+    assert (
+        '"TR_SYNTHETIC_MONITOR_API_KEY=trustedrouter-synthetic-monitor-api-key:'
+        '${MONITOR_SECRET_VERSION}"' in deploy
+    )
+    assert "trustedrouter-observer-internal-token:latest" not in deploy
+    assert "trustedrouter-synthetic-monitor-api-key:latest" not in deploy
     assert '"TR_INTERNAL_GATEWAY_TOKEN=' not in deploy
     assert "TR_INTERNAL_GATEWAY_TOKEN=trustedrouter" not in deploy
     assert (
@@ -721,7 +1012,11 @@ def test_every_synthetic_job_uses_private_run_app_ingress() -> None:
 def test_secret_bootstrap_provisions_a_distinct_observer_credential() -> None:
     deploy = (ROOT / "scripts/deploy/secrets.sh").read_text(encoding="utf-8")
 
-    assert "generated secret trustedrouter-observer-internal-token" in deploy
+    assert (
+        "ensure_generated_secret_resource trustedrouter-observer-internal-token"
+        in deploy
+    )
+    assert 'log "generated secret ${secret_name}"' in deploy
     assert "secrets.token_urlsafe(48)" in deploy
     assert "--secret=trustedrouter-observer-internal-token" in deploy
     assert "--secret=trustedrouter-internal-gateway-token" in deploy
@@ -761,14 +1056,16 @@ def test_edge_surface_inventory_is_total_and_never_claims_live_completion() -> N
 def test_runbook_has_emergency_promotion_and_independent_cost_caps() -> None:
     runbook = (ROOT / "docs/runbooks/ddos-edge-hardening.md").read_text(encoding="utf-8")
 
-    assert "TR_CLOUD_ARMOR_PREVIEW=0" in runbook
+    assert "preview-only until a separately approved" in runbook
     assert "TR_AWS_WAF_PREVIEW=0" in runbook
     assert "HighRatePerIpBlock" in runbook
-    assert "actions-backend=actions-edge" in runbook
+    assert "public, actions, console, chat, webhooks, and" in runbook
     for row in (
         "| Public/static | 4 | 10 |",
         "| Anonymous actions | 4 | 2 |",
-        "| Control | 4 | 20 |",
+        "| Console | 4 | 20 |",
+        "| Chat proxy | 2 | 20 |",
+        "| Webhooks | 4 | 10 |",
         "| Billing/internal gateway | 8 | 50 |",
         "| Observer/status worker | 4 | 4 |",
     ):

--- a/tests/test_deploy_iam_helpers.py
+++ b/tests/test_deploy_iam_helpers.py
@@ -20,7 +20,13 @@ case "$*" in
     ;;
   *"projects get-iam-policy"*)
     if [ "${FAKE_BINDING_PRESENT:-0}" = "1" ]; then
-      printf '%s\\n' "${FAKE_ROLE}"
+      if [ "${FAKE_BINDING_CONDITIONAL:-0}" = "1" ]; then
+        printf '{"bindings":[{"role":"%s","members":["%s"],"condition":{"title":"temporary","expression":"true"}}]}\\n' "${FAKE_ROLE}" "${FAKE_MEMBER}"
+      else
+        printf '{"bindings":[{"role":"%s","members":["%s"]}]}\\n' "${FAKE_ROLE}" "${FAKE_MEMBER}"
+      fi
+    else
+      printf '{"bindings":[]}\\n'
     fi
     ;;
   *"projects add-iam-policy-binding"*)
@@ -45,6 +51,7 @@ def _run_ensure_project_role(
     tmp_path: Path,
     *,
     binding_present: bool,
+    binding_conditional: bool = False,
     add_denied: bool = False,
 ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
     _, calls = _fake_gcloud(tmp_path)
@@ -55,8 +62,10 @@ def _run_ensure_project_role(
         "PROJECT_ID": "test-project",
         "FAKE_GCLOUD_CALLS": str(calls),
         "FAKE_BINDING_PRESENT": "1" if binding_present else "0",
+        "FAKE_BINDING_CONDITIONAL": "1" if binding_conditional else "0",
         "FAKE_ADD_DENIED": "1" if add_denied else "0",
         "FAKE_ROLE": role,
+        "FAKE_MEMBER": "serviceAccount:runtime@test-project.iam.gserviceaccount.com",
     }
     result = subprocess.run(  # noqa: S603 - fixed local test command
         [
@@ -96,3 +105,18 @@ def test_missing_project_role_fails_after_one_denied_write(tmp_path: Path) -> No
     assert result.returncode != 0
     assert sum("add-iam-policy-binding" in call for call in calls) == 1
     assert "Policy update access denied" in result.stderr
+
+
+def test_conditional_project_role_does_not_satisfy_unconditional_grant(
+    tmp_path: Path,
+) -> None:
+    result, calls = _run_ensure_project_role(
+        tmp_path,
+        binding_present=True,
+        binding_conditional=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    writes = [call for call in calls if "add-iam-policy-binding" in call]
+    assert len(writes) == 1
+    assert "--condition=None" in writes[0]

--- a/tests/test_deploy_script_execution.py
+++ b/tests/test_deploy_script_execution.py
@@ -957,6 +957,36 @@ def test_synthetic_jobs_execute_private_ingress_preflight_in_their_own_region(
         and call[4:6] == ["jobs", "deploy"]
     ]
     assert len(deploys) == 5
+    version_reads = [
+        call
+        for call in run.calls
+        if call[:6]
+        == [
+            "gcloud",
+            "--project",
+            "quill-cloud-proxy",
+            "secrets",
+            "versions",
+            "list",
+        ]
+    ]
+    assert len(version_reads) == 2
+    assert max(run.calls.index(call) for call in version_reads) < deploys[0][0]
+    postdeploy_secret_checks = [
+        call
+        for call in run.calls
+        if call[:6]
+        == [
+            "gcloud",
+            "--project",
+            "quill-cloud-proxy",
+            "run",
+            "jobs",
+            "describe",
+        ]
+        and "--format=json" in call
+    ]
+    assert len(postdeploy_secret_checks) == 5
     subnet_updates = [
         (index, call)
         for index, call in enumerate(run.calls)
@@ -991,10 +1021,24 @@ def test_synthetic_jobs_execute_private_ingress_preflight_in_their_own_region(
     for deploy_index, deploy in deploys:
         region = deploy[deploy.index("--region") + 1]
         deploy_text = " ".join(deploy)
+        regional_internal_origin = (
+            f"https://trusted-router-billing-123456789.{region}.run.app"
+        )
         assert "TR_SERVICE_SURFACE=observer" in deploy_text
         assert (
-            "TR_OBSERVER_INTERNAL_TOKEN=trustedrouter-observer-internal-token:latest"
+            "TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL="
+            f"{regional_internal_origin}"
+        ) in deploy_text
+        assert (
+            "TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL="
+            f"{regional_internal_origin}/"
+        ) not in deploy_text
+        assert (
+            "TR_OBSERVER_INTERNAL_TOKEN=trustedrouter-observer-internal-token:7"
             in deploy_text
+        )
+        assert deploy[deploy.index("--service-account") + 1] == (
+            "tr-synthetic@quill-cloud-proxy.iam.gserviceaccount.com"
         )
         assert "TR_INTERNAL_GATEWAY_TOKEN" not in deploy_text
         assert "--set-secrets" in deploy
@@ -1036,6 +1080,47 @@ def test_synthetic_jobs_execute_private_ingress_preflight_in_their_own_region(
         contract_read = fresh_contract_reads[0]
         assert contract_read[6] == "trusted-router-billing"
         assert contract_read[contract_read.index("--region") + 1] == region
+        contract_index = max(
+            index
+            for index, call in enumerate(run.calls[:deploy_index])
+            if call is contract_read
+        )
+        immediate_job_window = run.calls[contract_index + 1 : deploy_index]
+        assert sum(
+            call[:5]
+            == [
+                "gcloud",
+                "--project",
+                "quill-cloud-proxy",
+                "secrets",
+                "get-iam-policy",
+            ]
+            for call in immediate_job_window
+        ) == 2
+        assert sum(
+            call[:6]
+            == [
+                "gcloud",
+                "--project",
+                "quill-cloud-proxy",
+                "run",
+                "jobs",
+                "get-iam-policy",
+            ]
+            for call in immediate_job_window
+        ) == 1
+        assert any(
+            call[:6]
+            == [
+                "gcloud",
+                "--project",
+                "quill-cloud-proxy",
+                "run",
+                "revisions",
+                "describe",
+            ]
+            for call in immediate_job_window
+        )
         latest_preflight = fresh_subnet_updates[0]
         preflight_region = next(
             (
@@ -1050,10 +1135,10 @@ def test_synthetic_jobs_execute_private_ingress_preflight_in_their_own_region(
         previous_deploy_index = deploy_index
 
 
-def test_synthetic_deploy_requires_explicit_split_billing_service_before_any_job(
+def test_synthetic_deploy_defaults_to_split_billing_service_and_checks_live_contract(
     tmp_path: Path,
 ) -> None:
-    isolated = DeployScriptHarness(tmp_path / "synthetic-no-split-service")
+    isolated = DeployScriptHarness(tmp_path / "synthetic-default-split-service")
 
     run = isolated.run(
         "scripts/deploy/synthetic.sh",
@@ -1061,15 +1146,17 @@ def test_synthetic_deploy_requires_explicit_split_billing_service_before_any_job
         omit_env=("TR_BILLING_SERVICE",),
     )
 
-    assert run.returncode != 0
-    assert "TR_BILLING_SERVICE is required" in run.stderr
-    assert not any(
-        call[:4] == ["gcloud", "--project", "quill-cloud-proxy", "run"]
+    assert run.returncode == 0, summarise(run)
+    deploy_indices = [
+        index
+        for index, call in enumerate(run.calls)
+        if call[:4] == ["gcloud", "--project", "quill-cloud-proxy", "run"]
         and call[4:6] == ["jobs", "deploy"]
-        for call in run.calls
-    )
-    assert not any(
-        call[:6]
+    ]
+    contract_indices = [
+        index
+        for index, call in enumerate(run.calls)
+        if call[:6]
         == [
             "gcloud",
             "--project",
@@ -1078,8 +1165,168 @@ def test_synthetic_deploy_requires_explicit_split_billing_service_before_any_job
             "services",
             "describe",
         ]
-        for call in run.calls
+        and call[6] == "trusted-router-billing"
+    ]
+    assert len(deploy_indices) == len(contract_indices) == 5
+    assert all(
+        contract < deploy
+        for contract, deploy in zip(contract_indices, deploy_indices, strict=True)
     )
+
+
+def test_synthetic_deploy_rejects_internal_billing_alias_divergence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    script = "scripts/deploy/synthetic.sh"
+    fixture = SCRIPT_FIXTURES[script]
+    monkeypatch.setitem(
+        SCRIPT_FIXTURES,
+        script,
+        replace(
+            fixture,
+            env={
+                **fixture.env,
+                "TR_INTERNAL_SERVICE": "trusted-router-other-internal",
+            },
+        ),
+    )
+    run = DeployScriptHarness(tmp_path / "synthetic-alias-drift").run(script)
+
+    assert run.returncode != 0
+    assert "must resolve to the same Cloud Run service" in run.stderr
+    assert not any(call[4:6] == ["jobs", "deploy"] for call in run.calls)
+
+
+def test_synthetic_deploy_rechecks_secret_iam_and_stops_on_mid_run_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    script = "scripts/deploy/synthetic.sh"
+    fixture = SCRIPT_FIXTURES[script]
+    member = "serviceAccount:tr-synthetic@quill-cloud-proxy.iam.gserviceaccount.com"
+    internal_member = (
+        "serviceAccount:tr-internal@quill-cloud-proxy.iam.gserviceaccount.com"
+    )
+    valid = json.dumps(
+        {
+            "bindings": [
+                {
+                    "role": "roles/secretmanager.secretAccessor",
+                    "members": [internal_member, member],
+                }
+            ]
+        }
+    )
+    conditional = json.dumps(
+        {
+            "bindings": [
+                {
+                    "role": "roles/secretmanager.secretAccessor",
+                    "members": [member],
+                    "condition": {
+                        "title": "expires",
+                        "expression": "request.time < timestamp('2030-01-01T00:00:00Z')",
+                    },
+                }
+            ]
+        }
+    )
+    monkeypatch.setitem(
+        SCRIPT_FIXTURES,
+        script,
+        replace(
+            fixture,
+            sequential_responses=(
+                    (
+                        r"secrets get-iam-policy .*--format=json",
+                        (valid, valid, conditional),
+                    ),
+            ),
+        ),
+    )
+    run = DeployScriptHarness(tmp_path / "synthetic-secret-drift").run(script)
+
+    assert run.returncode != 0
+    assert "noncanonical role or condition" in run.stderr
+    deploys = [call for call in run.calls if call[4:6] == ["jobs", "deploy"]]
+    assert len(deploys) == 1
+
+
+def test_synthetic_deploy_rejects_conditional_existing_job_invoker_before_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    script = "scripts/deploy/synthetic.sh"
+    fixture = SCRIPT_FIXTURES[script]
+    member = "serviceAccount:tr-synthetic@quill-cloud-proxy.iam.gserviceaccount.com"
+    conditional_policy = json.dumps(
+        {
+            "bindings": [
+                {
+                    "role": "roles/run.invoker",
+                    "members": [member],
+                    "condition": {
+                        "title": "temporary",
+                        "expression": "request.time < timestamp('2030-01-01T00:00:00Z')",
+                    },
+                }
+            ]
+        }
+    )
+    responses = (
+        (r"run jobs get-iam-policy .*--format=json", conditional_policy),
+        *(
+            response
+            for response in fixture.responses
+            if "run jobs get-iam-policy" not in response[0]
+        ),
+    )
+    monkeypatch.setitem(
+        SCRIPT_FIXTURES,
+        script,
+        replace(fixture, responses=responses),
+    )
+    run = DeployScriptHarness(tmp_path / "synthetic-invoker-condition").run(script)
+
+    assert run.returncode != 0
+    assert "not the exact singleton invoker policy" in run.stderr
+    assert not any(call[4:6] == ["jobs", "deploy"] for call in run.calls)
+
+
+def test_synthetic_deploy_rejects_wrong_serving_revision_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    script = "scripts/deploy/synthetic.sh"
+    fixture = SCRIPT_FIXTURES[script]
+    revision_reply = next(
+        reply
+        for pattern, reply in fixture.responses
+        if "run revisions describe" in pattern
+    )
+    revision = json.loads(revision_reply)
+    revision["spec"]["serviceAccountName"] = (
+        "tr-console@quill-cloud-proxy.iam.gserviceaccount.com"
+    )
+    responses = (
+        (r"run revisions describe .*--format=json", json.dumps(revision)),
+        *(
+            response
+            for response in fixture.responses
+            if "run revisions describe" not in response[0]
+        ),
+    )
+    monkeypatch.setitem(
+        SCRIPT_FIXTURES,
+        script,
+        replace(fixture, responses=responses),
+    )
+    run = DeployScriptHarness(tmp_path / "synthetic-serving-identity").run(script)
+
+    assert run.returncode != 0
+    assert "serving internal revision contract failed" in run.stderr
+    assert not any(call[4:6] == ["jobs", "deploy"] for call in run.calls)
 
 
 @pytest.mark.parametrize(
@@ -1204,6 +1451,7 @@ def test_synthetic_private_ingress_drift_stops_before_any_job_deploy(
             r"dns managed-zones describe trusted-router-private-run-app --format=json",
             zone_json,
         ),
+        *fixture.responses,
     )
     monkeypatch.setitem(
         SCRIPT_FIXTURES,

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -9,6 +9,13 @@ from scripts.check_price_coverage import (
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def _deploy_secret_owner_allowlist() -> str:
+    library = (ROOT / "scripts/deploy/_lib.sh").read_text(encoding="utf-8")
+    start = library.index("deploy_service_account_owns_secret() {")
+    end = library.index("synthetic_service_account_owns_secret() {", start)
+    return library[start:end]
+
+
 def test_top_level_deploy_passes_spanner_config_to_unshared_migration() -> None:
     deploy = (ROOT / "scripts/deploy-gcp.sh").read_text()
 
@@ -40,20 +47,17 @@ def test_deploy_pins_thirty_cent_signup_credit_policy() -> None:
     assert '"TR_SIGNUP_TRIAL_CREDIT_MICRODOLLARS=300000"' in rollout
 
 
-def test_deploy_removes_only_explicitly_missing_optional_secrets() -> None:
+def test_deploy_uses_complete_surface_secret_sets_and_fails_closed_on_lookup_errors() -> None:
     rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
 
-    mandatory_block = rollout.split("SECRET_ENVS=(", 1)[1].split(")", 1)[0]
-    assert "TR_GOOGLE_ADS_CONVERSION_FEED_PASSWORD" not in mandatory_block
-    assert (
-        'REMOVE_SECRET_ENVS=("TR_GOOGLE_ADS_CONVERSION_FEED_PASSWORD")' in rollout
-    )
+    assert 'surface_secret_bindings()' in rollout
+    assert 'pin_surface_secret_versions' in rollout
+    assert '--set-secrets="$set_secrets"' in rollout
+    assert '--remove-secrets' not in rollout
     assert "trustedrouter-google-ads-conversion-feed-password" not in rollout
-    assert '[[ "$describe_error" == *"NOT_FOUND"* ]]' in rollout
-    assert "cannot determine whether optional secret" in rollout
-    assert 'REMOVE_SECRET_ENVS+=("${env_name}")' in rollout
-    assert 'REMOVE_SECRETS_ARGS=(--remove-secrets ' in rollout
-    assert '"${REMOVE_SECRETS_ARGS[@]}"' in rollout
+    assert '*NOT_FOUND*|*"not found"*) echo absent' in rollout
+    assert "cannot determine Secret Manager state" in rollout
+    assert "KNOWN_OPTIONAL_RUNTIME_SECRETS=(" in rollout
 
 
 def test_deploy_wires_three_cloud_ops_chat_support_fanout() -> None:
@@ -64,10 +68,7 @@ def test_deploy_wires_three_cloud_ops_chat_support_fanout() -> None:
     assert "https://b.trustedrouter.com,https://c.allyrouter.com" in rollout
     assert "trustedrouter-ops-chat-webhook-secret" in rollout
     assert '"OPS_SUPPORT_HOOK_SECRET"' in secrets
-    assert (
-        'grant_tr_deploy_secret_access "trustedrouter-ops-chat-webhook-secret"'
-        in secrets
-    )
+    assert "trustedrouter-ops-chat-webhook-secret" not in _deploy_secret_owner_allowlist()
 
 
 def test_deploy_serves_user_provided_models() -> None:
@@ -87,29 +88,22 @@ def test_deploy_wires_veriff_config_and_secrets() -> None:
     rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
     secrets = (ROOT / "scripts/deploy/secrets.sh").read_text()
 
-    # A PAIR that must agree: enabling the custom-model gate without a
-    # reachable Veriff would 403 every create/edit with an unsatisfiable
-    # requirement. Activated together 2026-08-16 (secrets exist); if either
-    # ever flips back, the other must flip with it in the same commit.
-    veriff_enabled = '"TR_VERIFF_ENABLED=true"' in rollout
-    gate_enabled = '"TR_CUSTOM_MODELS_REQUIRE_VERIFICATION=true"' in rollout
-    assert veriff_enabled == gate_enabled, (
-        "TR_VERIFF_ENABLED and TR_CUSTOM_MODELS_REQUIRE_VERIFICATION must flip together"
-    )
-    assert veriff_enabled, "identity verification is meant to be live in prod"
+    # The explicit/serving bit, never secret existence, controls new identity
+    # verification. Console and webhook receive the same bit; a complete
+    # verifier group remains mounted for late callbacks when disabled.
+    assert "resolve_explicit_or_serving_flag" in rollout
+    assert "TR_VERIFF_ENABLED TR_VERIFF_ENABLED" in rollout
+    assert '"TR_VERIFF_ENABLED=${VERIFF_ENABLED}"' in rollout
+    assert '"TR_CUSTOM_MODELS_REQUIRE_VERIFICATION=${VERIFF_ENABLED}"' in rollout
+    assert "VERIFF_SECRET_GROUP_STATE" in rollout
     assert '"TR_VERIFF_BASE_URL=https://stationapi.veriff.com"' in rollout
-    assert (
-        'add_secret_env_if_exists "TR_VERIFF_API_KEY" "trustedrouter-veriff-api-key"'
-        in rollout
-    )
+    assert '"TR_VERIFF_API_KEY=trustedrouter-veriff-api-key"' in rollout
     assert "TR_VERIFF_SHARED_SECRET_KEY" in rollout
     assert '"VERIFF_API_KEY" "trustedrouter-veriff-api-key"' in secrets
     assert "VERIFF_SHARED_SECRET_KEY" in secrets
-    assert 'grant_tr_deploy_secret_access "trustedrouter-veriff-api-key"' in secrets
-    assert (
-        'grant_tr_deploy_secret_access "trustedrouter-veriff-shared-secret-key"'
-        in secrets
-    )
+    deploy_allowlist = _deploy_secret_owner_allowlist()
+    assert "trustedrouter-veriff-api-key" not in deploy_allowlist
+    assert "trustedrouter-veriff-shared-secret-key" not in deploy_allowlist
 
 
 def test_all_attested_control_plane_regions_remain_warm() -> None:
@@ -132,10 +126,10 @@ def test_all_attested_control_plane_regions_remain_warm() -> None:
     )
     assert 'TR_CLOUD_RUN_CONCURRENCY="${TR_CLOUD_RUN_CONCURRENCY:-8}"' in library
     assert 'TR_SPANNER_POOL_SIZE="${TR_SPANNER_POOL_SIZE:-8}"' in library
-    assert '--concurrency "$TR_CLOUD_RUN_CONCURRENCY"' in rollout
-    assert '--min "$min_instances"' in rollout
-    assert '--min-instances default' in rollout
-    assert '"TR_SPANNER_POOL_SIZE=${TR_SPANNER_POOL_SIZE}"' in rollout
+    assert 'cloud_run_min_instances_for_region()' in rollout
+    assert 'CONCURRENCY="$TR_CLOUD_RUN_CONCURRENCY"' in rollout
+    assert 'SPANNER_POOL_SIZE="$TR_SPANNER_POOL_SIZE"' in rollout
+    assert '--min-instances="$MIN_INSTANCES"' in rollout
 
 
 def test_production_deploy_interlocks_regional_quota_issuance() -> None:
@@ -221,14 +215,14 @@ def test_production_deploy_provisions_and_schedules_regional_quota_reconciliatio
 def test_deploy_preserves_request_record_mode_without_silent_legacy_fallback() -> None:
     rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
 
-    assert '--format=json 2>/dev/null' in rollout
-    assert 'select(.name == "TR_REQUEST_RECORD_WRITE_MODE")' in rollout
+    assert 'serving_env_value TR_REQUEST_RECORD_WRITE_MODE' in rollout
+    assert 'case "$REQUEST_RECORD_WRITE_MODE" in legacy|typed)' in rollout
     assert 'cannot determine TR_REQUEST_RECORD_WRITE_MODE' in rollout
     assert '*) REQUEST_RECORD_WRITE_MODE="legacy"' not in rollout
-    assert "[?name='TR_REQUEST_RECORD_WRITE_MODE']" not in rollout
+    assert 'TR_REQUEST_RECORD_WRITE_MODE=${REQUEST_RECORD_WRITE_MODE}' in rollout
 
 
-def test_deploy_provider_secrets_include_priced_glm52_backends() -> None:
+def test_deploy_detaches_provider_keys_but_keeps_discovery_secret_provisioning() -> None:
     rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
     secrets = (ROOT / "scripts/deploy/secrets.sh").read_text()
 
@@ -237,15 +231,17 @@ def test_deploy_provider_secrets_include_priced_glm52_backends() -> None:
         "FIREWORKS_API_KEY": "trustedrouter-fireworks-api-key",
         "NOVITA_API_KEY": "trustedrouter-novita-api-key",
         "BASETEN_API_KEY": "trustedrouter-baseten-api-key",
-        "TELNYX_API_KEY": "trustedrouter-telnyx-api-key",
         "THINKING_MACHINES_API_KEY": "trustedrouter-thinking-machines-api-key",
         "WAFER_API_KEY": "trustedrouter-wafer-api-key",
         "CRUSOE_API_KEY": "trustedrouter-crusoe-api-key",
         "MAKORA_API_KEY": "trustedrouter-makora-api-key",
     }
     for env_name, secret_name in expected.items():
-        assert f'add_secret_env_if_exists "{env_name}" "{secret_name}"' in rollout
+        assert secret_name in rollout
+        assert f"{env_name}={secret_name}" not in rollout
         assert f'ensure_secret_from_env_file "{env_name}" "{secret_name}"' in secrets
+    assert "trustedrouter-telnyx-api-key|trustedrouter-twilio-account-sid" in rollout
+    assert '"TR_TELNYX_API_KEY=trustedrouter-telnyx-api-key"' in rollout
 
 
 def test_deploy_prefers_explicit_google_ai_studio_key() -> None:
@@ -259,7 +255,7 @@ def test_deploy_prefers_explicit_google_ai_studio_key() -> None:
     assert 'value="${!alias:-}"' in secrets
 
 
-def test_deploy_wires_athena_worker_prompt_secret() -> None:
+def test_deploy_keeps_athena_prompt_out_of_all_six_web_services() -> None:
     rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
     secrets = (ROOT / "scripts/deploy/secrets.sh").read_text()
 
@@ -268,16 +264,14 @@ def test_deploy_wires_athena_worker_prompt_secret() -> None:
         'ensure_secret_from_prompt_file "trustedrouter-athena-worker-prompt-v1" '
         '"$ATHENA_PROMPTS_FILE" "Worker Prompt V1"'
     ) in secrets
-    assert (
-        'add_secret_env_if_exists "TR_ATHENA_WORKER_PROMPT" "trustedrouter-athena-worker-prompt-v1"'
-    ) in rollout
+    assert "trustedrouter-athena-worker-prompt-v1" in rollout
+    assert "TR_ATHENA_WORKER_PROMPT=" not in rollout
 
 
 def test_hourly_kimi_discovery_has_narrow_secret_access_wiring() -> None:
-    secrets = (ROOT / "scripts/deploy/secrets.sh").read_text()
     workflow = (ROOT / ".github/workflows/refresh-prices.yml").read_text()
 
-    assert 'grant_tr_deploy_secret_access "trustedrouter-kimi-api-key"' in secrets
+    assert "trustedrouter-kimi-api-key" in _deploy_secret_owner_allowlist()
     assert "KIMI_API_KEY:trustedrouter-kimi-api-key" in workflow
     assert "no project-wide Secret" in workflow
 
@@ -291,7 +285,6 @@ def test_hourly_cloudflare_discovery_uses_funded_account() -> None:
 
 
 def test_every_authenticated_discovery_feed_is_wired_to_narrow_secret_access() -> None:
-    secrets = (ROOT / "scripts/deploy/secrets.sh").read_text(encoding="utf-8")
     workflow = (ROOT / ".github/workflows/refresh-prices.yml").read_text(
         encoding="utf-8"
     )
@@ -318,7 +311,7 @@ def test_every_authenticated_discovery_feed_is_wired_to_narrow_secret_access() -
             "workflow loads none of them"
         )
         secret_name = workflow_pairs[wired_env]
-        assert f'grant_tr_deploy_secret_access "{secret_name}"' in secrets, (
+        assert secret_name in _deploy_secret_owner_allowlist(), (
             f"{provider} discovery loads {secret_name}, but secrets.sh does not "
             "grant the refresh service account narrow access"
         )
@@ -333,12 +326,14 @@ def test_provider_portal_uses_private_vpc_and_dedicated_clickhouse_reader() -> N
     ).read_text(encoding="utf-8")
 
     assert "compute addresses describe tr-clickhouse-ilb" in rollout
-    assert 'PROVIDER_ANALYTICS_CLICKHOUSE_URL="http://${clickhouse_ilb_ip}:8123"' in rollout
-    assert 'PROVIDER_ANALYTICS_CLICKHOUSE_URL="http://10.128.15.214:8123"' in rollout
+    assert 'PROVIDER_CLICKHOUSE_URL="http://${clickhouse_address_output}:8123"' in rollout
+    assert "provider ClickHouse URL must resolve through a private VPC address" in rollout
     assert "TR_PROVIDER_ANALYTICS_CLICKHOUSE_USER=tr_provider_read" in rollout
-    assert "--vpc-egress private-ranges-only" in rollout
-    assert '--network "${TR_CLOUD_RUN_NETWORK:-default}"' in rollout
-    assert '--subnet "${TR_CLOUD_RUN_SUBNET:-default}"' in rollout
+    assert "--vpc-egress=private-ranges-only" in rollout
+    assert 'CLOUD_RUN_NETWORK="${TR_CLOUD_RUN_NETWORK:-default}"' in rollout
+    assert 'CLOUD_RUN_SUBNET="${TR_CLOUD_RUN_SUBNET:-default}"' in rollout
+    assert '--network="$CLOUD_RUN_NETWORK"' in rollout
+    assert '--subnet="$CLOUD_RUN_SUBNET"' in rollout
 
     for content in (secrets, rollout, reader):
         assert "trustedrouter-clickhouse-provider-read-password" in content

--- a/tests/test_deploy_service_names.py
+++ b/tests/test_deploy_service_names.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+INFRA = (ROOT / "scripts/deploy/infra.sh").read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("env_update", "expected_console", "expected_legacy"),
+    (
+        ({}, "trusted-router-console", "trusted-router"),
+        ({"SERVICE": "router-canary"}, "router-canary-console", "router-canary"),
+        (
+            {
+                "TR_CONSOLE_SERVICE": "reviewed-console",
+                "TR_LEGACY_CONSOLE_SERVICE": "reviewed-monolith",
+            },
+            "reviewed-console",
+            "reviewed-monolith",
+        ),
+    ),
+)
+def test_console_and_legacy_monolith_names_resolve_independently(
+    tmp_path: Path,
+    env_update: dict[str, str],
+    expected_console: str,
+    expected_legacy: str,
+) -> None:
+    fake_gcloud = tmp_path / "gcloud"
+    fake_gcloud.write_text(
+        "#!/usr/bin/env bash\nprintf '123456789\\n'\n",
+        encoding="utf-8",
+    )
+    fake_gcloud.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{tmp_path}:{os.environ['PATH']}",
+        "PROJECT_ID": "test-project",
+    }
+    for variable in (
+        "SERVICE",
+        "TR_CONSOLE_SERVICE",
+        "TR_LEGACY_CONSOLE_SERVICE",
+    ):
+        env.pop(variable, None)
+    env.update(env_update)
+
+    result = subprocess.run(  # noqa: S603 - fixed local shell and repository script
+        [
+            "/bin/bash",
+            "-c",
+            (
+                "source scripts/deploy/_lib.sh; "
+                "printf '%s\\t%s\\n' \"$CONSOLE_SERVICE\" \"$LEGACY_CONSOLE_SERVICE\""
+            ),
+        ],
+        cwd=ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == f"{expected_console}\t{expected_legacy}"
+
+
+def test_legacy_iam_retirement_rejects_a_console_monolith_alias() -> None:
+    start = INFRA.index("verify_legacy_runtime_retirement_ready() {")
+    end = INFRA.index("verify_identity_resource_manager_ancestors_empty() {", start)
+    helper = INFRA[start:end]
+
+    assert 'if [ "$CONSOLE_SERVICE" = "$LEGACY_CONSOLE_SERVICE" ]; then' in helper
+    assert "split console ${CONSOLE_SERVICE} aliases the legacy monolith" in helper
+    assert helper.index('"$CONSOLE_SERVICE"') < helper.index("local -a services=(")

--- a/tests/test_deploy_workflow_regions.py
+++ b/tests/test_deploy_workflow_regions.py
@@ -3,6 +3,25 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def test_rollout_artifact_paths_are_initialized_from_runner_temp() -> None:
+    workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
+    deploy = workflow.index("\n  deploy:")
+    steps = workflow.index("    steps:", deploy)
+    capture = workflow.index("- name: Capture frontend attestation", deploy)
+    setup = workflow[deploy:capture]
+
+    assert "${{ runner.temp }}" not in workflow[deploy:steps]
+    assert (
+        'echo "TR_ROLLOUT_MANIFEST=${RUNNER_TEMP}/tr-rollout/manifest.json"'
+        in setup
+    )
+    assert (
+        'echo "TR_ROLLOUT_FRONTEND_ATTESTATION=${RUNNER_TEMP}/tr-rollout/'
+        'frontend-attestation.json"' in setup
+    )
+    assert setup.count('>> "$GITHUB_ENV"') == 2
+
+
 def test_every_load_balanced_control_plane_region_is_staged() -> None:
     workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
     start = workflow.index("- name: Roll secondary warm regions sequentially")

--- a/tests/test_deploy_workflow_regions.py
+++ b/tests/test_deploy_workflow_regions.py
@@ -122,15 +122,34 @@ def test_superseded_push_stops_before_production_mutation() -> None:
     assert "if: ${{ needs.confirm-current-main.outputs.proceed == 'true' }}" in workflow
 
 
-def test_runtime_secret_validation_is_parallel_and_does_not_restore_stale_ses_keys() -> None:
+def test_runtime_secret_validation_is_metadata_only_and_covers_every_surface() -> None:
     workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
     sync = workflow.index("sync-runtime-secrets:")
     confirm = workflow.index("confirm-current-main:", sync)
     section = workflow[sync:confirm]
 
     assert "needs: [gate-on-ci]" in section
+    for surface in ("public", "actions", "console", "chat", "webhooks", "internal"):
+        assert f'"{surface}|' in section
+    for secret in (
+        "trustedrouter-attribution-cookie-secret",
+        "trustedrouter-stripe-secret-key",
+        "trustedrouter-stripe-webhook-secret",
+        "trustedrouter-internal-stripe-payment-intents-key",
+        "trustedrouter-aws-access-key-id",
+        "trustedrouter-aws-secret-access-key",
+        "trustedrouter-internal-ses-access-key-id",
+        "trustedrouter-internal-ses-secret-access-key",
+        "trustedrouter-internal-gateway-token",
+        "trustedrouter-observer-internal-token",
+        "trustedrouter-synthetic-monitor-api-key",
+        "trustedrouter-sentry-dsn",
+    ):
+        assert secret in section
     assert "trustedrouter-aws-access-key-id" in section
-    assert "gcloud secrets versions access latest" in section
+    assert "gcloud secrets versions list" in section
+    assert "--filter='state=ENABLED'" in section
+    assert "gcloud secrets versions access" not in section
     assert "secrets.TR_AWS_ACCESS_KEY_ID" not in section
     assert "secrets.TR_AWS_SECRET_ACCESS_KEY" not in section
     assert "trustedrouter-clickhouse-provider-read-password" in section
@@ -142,3 +161,16 @@ def test_shared_load_balancer_is_reconciled_once_per_workflow() -> None:
 
     assert workflow.count('TR_DEPLOY_RECONCILE_LB: "1"') == 1
     assert workflow.count('TR_DEPLOY_RECONCILE_LB: "0"') == 1
+
+
+def test_synthetic_deploy_requires_billing_surface_and_cannot_be_masked() -> None:
+    workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
+    start = workflow.index("- name: Deploy synthetic monitor Cloud Run Job")
+    end = workflow.index("- name: Deploy Google Ads conversion uploader", start)
+    synthetic = workflow[start:end]
+
+    assert "continue-on-error" not in synthetic
+    assert "TR_BILLING_SERVICE: trusted-router-billing" in synthetic
+    assert "TR_BILLING_SERVICE must name the internal billing service" in synthetic
+    assert "bash scripts/deploy/synthetic.sh" in synthetic
+    assert "|| true" not in synthetic

--- a/tests/test_domain_aliases.py
+++ b/tests/test_domain_aliases.py
@@ -486,10 +486,12 @@ def test_alias_oauth_credentials_are_normalized_and_fail_closed() -> None:
 def test_production_oauth_requires_credentials_for_every_backup_domain() -> None:
     values = {
         "environment": "production",
-        "service_surface": "control",
+        "service_surface": "console",
         "attribution_cookie_secret": "oauth-attribution-" + "a" * 32,
-        "stripe_webhook_secret": "whsec-test",
         "stripe_secret_key": "sk-test",
+        "google_oauth_login_available": True,
+        "github_oauth_login_available": False,
+        "paypal_checkout_enabled": False,
         "sentry_dsn": "https://example@example.ingest.sentry.io/1",
         "aws_access_key_id": "test-access-key",
         "aws_secret_access_key": "test-secret-key",

--- a/tests/test_engy_provider.py
+++ b/tests/test_engy_provider.py
@@ -206,9 +206,12 @@ def test_engy_hourly_refresh_and_secret_wiring_are_complete() -> None:
         'ensure_secret_from_env_file "ENGY_API_KEY" "trustedrouter-engy-api-key"'
         in secrets
     )
-    assert 'grant_tr_deploy_secret_access "trustedrouter-engy-api-key"' in secrets
     assert (
-        'add_secret_env_if_exists "ENGY_API_KEY" "trustedrouter-engy-api-key"'
-        in rollout
+        "trustedrouter-engy-api-key"
+        in secrets.split("DETACHED_PROVIDER_SECRET_NAMES=(", 1)[1].split(")", 1)[0]
+    )
+    assert (
+        "trustedrouter-engy-api-key"
+        in rollout.split("KNOWN_OPTIONAL_RUNTIME_SECRETS=(", 1)[1].split(")", 1)[0]
     )
     assert "ENGY_API_KEY:trustedrouter-engy-api-key" in workflow

--- a/tests/test_gcp_runtime_iam_contract.py
+++ b/tests/test_gcp_runtime_iam_contract.py
@@ -1,0 +1,1298 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+LIB = (ROOT / "scripts/deploy/_lib.sh").read_text(encoding="utf-8")
+INFRA = (ROOT / "scripts/deploy/infra.sh").read_text(encoding="utf-8")
+SECRETS = (ROOT / "scripts/deploy/secrets.sh").read_text(encoding="utf-8")
+SYNTHETIC = (ROOT / "scripts/deploy/synthetic.sh").read_text(encoding="utf-8")
+RUNBOOK = (ROOT / "docs/runbooks/ddos-edge-hardening.md").read_text(encoding="utf-8")
+PRICE_REFRESH = (ROOT / ".github/workflows/refresh-prices.yml").read_text(
+    encoding="utf-8"
+)
+
+RUNTIME_VARIABLES = (
+    "PUBLIC_RUN_SERVICE_ACCOUNT",
+    "ACTIONS_RUN_SERVICE_ACCOUNT",
+    "CONSOLE_RUN_SERVICE_ACCOUNT",
+    "CHAT_RUN_SERVICE_ACCOUNT",
+    "WEBHOOKS_RUN_SERVICE_ACCOUNT",
+    "INTERNAL_RUN_SERVICE_ACCOUNT",
+)
+
+
+def _shell_words(source: str) -> str:
+    return " ".join(source.replace("\\\n", " ").split())
+
+
+def _function_body(source: str, name: str, next_name: str) -> str:
+    start = source.index(f"{name}() {{")
+    end = source.index(f"{next_name}() {{", start)
+    return source[start:end]
+
+
+def _infra_is_resource_scoped(source: str) -> bool:
+    words = _shell_words(source)
+    required = (
+        'gc spanner databases add-iam-policy-binding "$SPANNER_DATABASE_ID"',
+        'gc bigtable instances add-iam-policy-binding "$BIGTABLE_INSTANCE_ID"',
+        'gc kms keys add-iam-policy-binding "$BYOK_KMS_KEY_ID"',
+        'gc kms keys add-iam-policy-binding "$GOOGLE_ADS_KMS_KEY_ID"',
+        '"$PUBLIC_RUN_SERVICE_ACCOUNT" "$CHAT_RUN_SERVICE_ACCOUNT"; do '
+        'member="serviceAccount:${service_account}"',
+        '"$CONSOLE_RUN_SERVICE_ACCOUNT" "$WEBHOOKS_RUN_SERVICE_ACCOUNT" '
+        '"$INTERNAL_RUN_SERVICE_ACCOUNT"; do',
+        '"roles/spanner.databaseReader"',
+        '"roles/spanner.databaseUser"',
+        '"roles/bigtable.reader"',
+        '"roles/bigtable.user"',
+        '--member="serviceAccount:${CONSOLE_RUN_SERVICE_ACCOUNT}" '
+        '--role="roles/cloudkms.cryptoKeyEncrypterDecrypter"',
+        '--member="serviceAccount:${INTERNAL_RUN_SERVICE_ACCOUNT}" '
+        '--role="roles/cloudkms.cryptoKeyDecrypter"',
+    )
+    forbidden = (
+        'ensure_project_role "$member" "roles/spanner.',
+        'ensure_project_role "$member" "roles/bigtable.',
+        'ensure_project_role "$member" "roles/cloudkms.',
+        'ensure_project_role "$member" "roles/secretmanager.secretAccessor"',
+        'gc projects add-iam-policy-binding "$PROJECT_ID" --member="$member" '
+        '--role="roles/spanner.',
+        'gc projects add-iam-policy-binding "$PROJECT_ID" --member="$member" '
+        '--role="roles/bigtable.',
+    )
+    return all(item in words for item in required) and not any(
+        item in words for item in forbidden
+    )
+
+
+def _anti_reuse_contract_is_complete(source: str) -> bool:
+    words = _shell_words(source)
+    checks = (
+        'case "$_internal_stripe_key" in rk_live_?*)',
+        '[ "$_internal_stripe_key" = "$_console_stripe_key" ]',
+        '[ "$_internal_ses_access_key_id" = "$_shared_ses_access_key_id" ]',
+        '[ "$_internal_ses_secret_access_key" = "$_shared_ses_secret_access_key" ]',
+        '[ "$_observer_token_check" = "$_gateway_token_check" ]',
+        '[ "$_attribution_token_check" = "$_gateway_token_check" ]',
+        '[ "$_attribution_token_check" = "$_observer_token_check" ]',
+        '[ "$_monitor_token_check" = "$_observer_token_check" ]',
+        '[ "$_monitor_token_check" = "$_gateway_token_check" ]',
+        '[ "$_monitor_token_check" = "$_attribution_token_check" ]',
+    )
+    secret_values = (
+        "$_internal_stripe_key",
+        "$_console_stripe_key",
+        "$_internal_ses_access_key_id",
+        "$_internal_ses_secret_access_key",
+        "$_shared_ses_access_key_id",
+        "$_shared_ses_secret_access_key",
+        "$_observer_token_check",
+        "$_gateway_token_check",
+        "$_attribution_token_check",
+        "$_monitor_token_check",
+    )
+    logged_lines = "\n".join(
+        line for line in source.splitlines() if "echo " in line or "log " in line
+    )
+    return all(check in words for check in checks) and not any(
+        value in logged_lines for value in secret_values
+    )
+
+
+def _desired_runtime_grants_precede_obsolete_removals(source: str) -> bool:
+    words = _shell_words(source)
+    marker = "granting and verifying desired runtime IAM before obsolete-role cleanup"
+    if marker not in words:
+        return False
+    tail = words[words.index(marker) :]
+    contracts = (
+        (
+            (
+                'gc kms keys add-iam-policy-binding "$GOOGLE_ADS_KMS_KEY_ID"',
+            ),
+            'verify_resource_role_present "Google Ads KMS key"',
+            'remove_kms_role_if_present "$member" "$role" "$GOOGLE_ADS_KMS_KEY_ID"',
+            'verify_only_resource_role "Google Ads KMS key"',
+        ),
+        (
+            (
+                'ensure_project_role "$member" "roles/serviceusage.serviceUsageConsumer"',
+            ),
+            'verify_resource_role_present "project" "$member" '
+            '"roles/serviceusage.serviceUsageConsumer"',
+            'remove_project_role_if_present "$member" '
+            '"roles/serviceusage.serviceUsageConsumer"',
+            'verify_only_resource_role "project" "$member" "$expected_project_role"',
+        ),
+        (
+            (
+                'gc spanner databases add-iam-policy-binding "$SPANNER_DATABASE_ID" '
+                '--instance="$SPANNER_INSTANCE_ID" --member="$member" '
+                '--role="roles/spanner.databaseReader"',
+                'gc spanner databases add-iam-policy-binding "$SPANNER_DATABASE_ID" '
+                '--instance="$SPANNER_INSTANCE_ID" --member="$member" '
+                '--role="roles/spanner.databaseUser"',
+            ),
+            'verify_resource_role_present "Spanner database"',
+            'remove_spanner_role_if_present "$member"',
+            'verify_only_resource_role "Spanner database" "$member" '
+            '"$expected_spanner_role"',
+        ),
+        (
+            (
+                'gc bigtable instances add-iam-policy-binding "$BIGTABLE_INSTANCE_ID" '
+                '--member="$member" --role="roles/bigtable.reader"',
+                'gc bigtable instances add-iam-policy-binding "$BIGTABLE_INSTANCE_ID" '
+                '--member="$member" --role="roles/bigtable.user"',
+            ),
+            'verify_resource_role_present "Bigtable instance"',
+            'remove_bigtable_role_if_present "$member"',
+            'verify_only_resource_role "Bigtable instance" "$member" '
+            '"$expected_bigtable_role"',
+        ),
+        (
+            (
+                'gc kms keys add-iam-policy-binding "$BYOK_KMS_KEY_ID" '
+                '--keyring="$KMS_KEYRING_ID" --location="$REGION" '
+                '--member="serviceAccount:${CONSOLE_RUN_SERVICE_ACCOUNT}" '
+                '--role="roles/cloudkms.cryptoKeyEncrypterDecrypter"',
+                'gc kms keys add-iam-policy-binding "$BYOK_KMS_KEY_ID" '
+                '--keyring="$KMS_KEYRING_ID" --location="$REGION" '
+                '--member="serviceAccount:${INTERNAL_RUN_SERVICE_ACCOUNT}" '
+                '--role="roles/cloudkms.cryptoKeyDecrypter"',
+            ),
+            'verify_resource_role_present "BYOK KMS key"',
+            'remove_kms_role_if_present "$member" "$role"',
+            'verify_only_resource_role "BYOK KMS key"',
+        ),
+    )
+    for grants, presence, removal, postverify in contracts:
+        if any(grant not in tail for grant in grants):
+            return False
+        if presence not in tail or removal not in tail or postverify not in tail:
+            return False
+        removal_position = tail.index(removal)
+        if any(tail.index(grant) >= removal_position for grant in grants):
+            return False
+        presence_position = tail.index(presence)
+        if presence_position >= removal_position:
+            return False
+        if tail.index(postverify, removal_position) <= removal_position:
+            return False
+    return True
+
+
+def test_six_runtime_service_accounts_are_distinct_and_never_legacy() -> None:
+    array = re.search(r"RUNTIME_SERVICE_ACCOUNTS=\(\n(?P<body>.*?)\n\)", LIB, re.S)
+    assert array is not None
+    assert tuple(re.findall(r'"\$(\w+_RUN_SERVICE_ACCOUNT)"', array["body"])) == (
+        RUNTIME_VARIABLES
+    )
+    assert "validate_runtime_service_accounts" in INFRA
+    assert "validate_runtime_service_accounts" in SECRETS
+    assert 'if [ "$service_account" = "$RUN_SERVICE_ACCOUNT" ]' in LIB
+    assert "runtime service accounts must be distinct" in LIB
+    assert "deploy service account must not be a runtime identity" in LIB
+    expected_ids = {
+        "PUBLIC": "tr-public",
+        "ACTIONS": "tr-actions",
+        "CONSOLE": "tr-console",
+        "CHAT": "tr-chat",
+        "WEBHOOKS": "tr-webhooks",
+        "INTERNAL": "tr-internal",
+    }
+    for surface, account_id in expected_ids.items():
+        assignment = (
+            f'{surface}_RUN_SERVICE_ACCOUNT="'
+            + "${TR_"
+            + surface
+            + "_RUN_SERVICE_ACCOUNT:-"
+            + account_id
+            + "@${PROJECT_ID}.iam.gserviceaccount.com}"
+            + '"'
+        )
+        assert assignment in LIB
+    assert (
+        'DEPLOY_SERVICE_ACCOUNT="${TR_DEPLOY_SERVICE_ACCOUNT:-'
+        'tr-deploy@${PROJECT_ID}.iam.gserviceaccount.com}"' in LIB
+    )
+    assert "deploy service account must belong to ${PROJECT_ID}" in LIB
+
+
+def test_deploy_actas_is_bound_to_the_six_runtime_accounts() -> None:
+    words = _shell_words(INFRA)
+    assert (
+        'for service_account in "${RUNTIME_SERVICE_ACCOUNTS[@]}"; do gc iam '
+        in words
+    )
+    assert (
+        'service-accounts add-iam-policy-binding "$service_account" '
+        '--member="serviceAccount:${DEPLOY_SERVICE_ACCOUNT}" '
+        '--role="roles/iam.serviceAccountUser"' in words
+    )
+    assert (
+        'verify_only_resource_role "runtime service-account actAs" '
+        '"serviceAccount:${DEPLOY_SERVICE_ACCOUNT}" '
+        '"roles/iam.serviceAccountUser"' in words
+    )
+    # Non-surface actAs targets are the conversion job and dedicated synthetic Job.
+    assert words.count('--role="roles/iam.serviceAccountUser"') == 3
+    assert '"$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT"' in words
+    assert '"$SYNTHETIC_RUN_SERVICE_ACCOUNT"' in words
+
+
+def test_runtime_data_and_kms_roles_are_resource_scoped() -> None:
+    assert _infra_is_resource_scoped(INFRA)
+
+
+def test_desired_runtime_iam_is_granted_and_verified_before_cleanup() -> None:
+    assert _desired_runtime_grants_precede_obsolete_removals(INFRA)
+
+
+@pytest.mark.parametrize(
+    "premature_removal",
+    (
+        'remove_kms_role_if_present "$member" "$role" "$GOOGLE_ADS_KMS_KEY_ID"',
+        'remove_project_role_if_present "$member" '
+        '"roles/serviceusage.serviceUsageConsumer"',
+        'remove_spanner_role_if_present "$member" "roles/spanner.databaseReader"',
+        'remove_bigtable_role_if_present "$member" "roles/bigtable.reader"',
+        'remove_kms_role_if_present "$member" "$role"',
+    ),
+)
+def test_remove_before_add_mutations_break_the_runtime_iam_contract(
+    premature_removal: str,
+) -> None:
+    marker = 'log "granting and verifying desired runtime IAM before obsolete-role cleanup"'
+    assert marker in INFRA
+    mutated = INFRA.replace(marker, f"{marker}\n{premature_removal}", 1)
+    assert not _desired_runtime_grants_precede_obsolete_removals(mutated)
+
+
+@pytest.mark.parametrize(
+    ("old", "new"),
+    (
+        (
+            'gc spanner databases add-iam-policy-binding "$SPANNER_DATABASE_ID"',
+            'gc projects add-iam-policy-binding "$PROJECT_ID"',
+        ),
+        (
+            'gc bigtable instances add-iam-policy-binding "$BIGTABLE_INSTANCE_ID"',
+            'gc projects add-iam-policy-binding "$PROJECT_ID"',
+        ),
+        (
+            'gc kms keys add-iam-policy-binding "$BYOK_KMS_KEY_ID"',
+            'gc projects add-iam-policy-binding "$PROJECT_ID"',
+        ),
+        (
+            '"$PUBLIC_RUN_SERVICE_ACCOUNT" "$CHAT_RUN_SERVICE_ACCOUNT"',
+            '"$PUBLIC_RUN_SERVICE_ACCOUNT" "$ACTIONS_RUN_SERVICE_ACCOUNT"',
+        ),
+    ),
+)
+def test_resource_scope_mutations_break_the_contract(old: str, new: str) -> None:
+    assert old in INFRA
+    assert not _infra_is_resource_scoped(INFRA.replace(old, new))
+
+
+def test_project_roles_are_complete_and_actions_has_none() -> None:
+    words = _shell_words(INFRA)
+    assert (
+        '"$PUBLIC_RUN_SERVICE_ACCOUNT" "$CONSOLE_RUN_SERVICE_ACCOUNT" '
+        '"$CHAT_RUN_SERVICE_ACCOUNT" "$WEBHOOKS_RUN_SERVICE_ACCOUNT" '
+        '"$INTERNAL_RUN_SERVICE_ACCOUNT"; do ensure_project_role '
+        '"serviceAccount:${service_account}" '
+        '"roles/serviceusage.serviceUsageConsumer"' in words
+    )
+    assert (
+        '"project" "serviceAccount:${ACTIONS_RUN_SERVICE_ACCOUNT}" "" '
+        'gc projects get-iam-policy "$PROJECT_ID"' in words
+    )
+    for role in ("roles/editor", "roles/owner", "roles/run.developer"):
+        assert f'remove_project_role_if_present "$member" "{role}"' in INFRA
+    deploy_preflight = _function_body(
+        INFRA,
+        "verify_deploy_identity_has_no_project_data_roles",
+        "preflight_identity_iam_removal_targets",
+    )
+    for role in (
+        "roles/secretmanager.secretAccessor",
+        "roles/secretmanager.admin",
+        "roles/spanner.databaseReader",
+        "roles/spanner.databaseUser",
+        "roles/bigtable.reader",
+        "roles/bigtable.user",
+        "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+        "roles/iam.serviceAccountUser",
+        "roles/iam.serviceAccountTokenCreator",
+        "roles/editor",
+        "roles/owner",
+    ):
+        assert role in deploy_preflight
+    assert "remove-iam-policy-binding" not in deploy_preflight
+    assert "describe_iam_role_definition" in deploy_preflight
+    for permission in (
+        "iam.serviceAccounts.actAs",
+        "iam.serviceAccounts.getAccessToken",
+        "secretmanager.versions.access",
+        "cloudkms.cryptoKeyVersions.useToDecrypt",
+    ):
+        assert permission in deploy_preflight
+
+
+def test_runtime_secret_reconciler_is_preflighted_targeted_and_exact() -> None:
+    helper = _function_body(
+        LIB,
+        "secret_iam_policy_contract_json",
+        "validate_nonempty_region_list",
+    )
+    body = _function_body(
+        SECRETS,
+        "reconcile_declared_secret_iam",
+        "verify_runtime_secret_access",
+    )
+    assert "roles/secretmanager.secretAccessor" in helper
+    assert "allUsers" in helper and "allAuthenticatedUsers" in helper
+    assert "unapproved unrelated secret principal" in helper
+    assert "TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON" in helper
+    assert "secret_iam_policy_contract_json plan" in body
+    assert "unknown secret ${secret_name}" in body
+    assert "add-iam-policy-binding" in body
+    assert "remove-iam-policy-binding" in body
+    assert "set-iam-policy" not in body
+    first_mutation = min(
+        body.index("gc secrets add-iam-policy-binding"),
+        body.index("gc secrets remove-iam-policy-binding"),
+    )
+    assert body.index('done <<<"$secret_names"') < first_mutation
+
+    required_bindings = (
+        "trustedrouter-attribution-cookie-secret",
+        "trustedrouter-sentry-dsn",
+        "trustedrouter-stripe-secret-key",
+        "trustedrouter-stripe-webhook-secret",
+        "trustedrouter-internal-stripe-payment-intents-key",
+        "trustedrouter-aws-access-key-id",
+        "trustedrouter-aws-secret-access-key",
+        "trustedrouter-internal-ses-access-key-id",
+        "trustedrouter-internal-ses-secret-access-key",
+        "trustedrouter-internal-gateway-token",
+        "trustedrouter-observer-internal-token",
+        "trustedrouter-synthetic-monitor-api-key",
+    )
+    verification_tail = LIB[LIB.index("secret_expected_surfaces()") :]
+    for secret_name in required_bindings:
+        assert secret_name in verification_tail
+
+
+@pytest.mark.parametrize(
+    ("bindings", "error_fragment"),
+    (
+        (
+            [
+                {
+                    "role": "roles/secretmanager.secretAccessor",
+                    "members": [
+                        "serviceAccount:tr-public@quill-cloud-proxy.iam.gserviceaccount.com"
+                    ],
+                    "condition": {"title": "expired", "expression": "false"},
+                }
+            ],
+            "noncanonical role or condition",
+        ),
+        (
+            [
+                {
+                    "role": "roles/secretmanager.secretAccessor",
+                    "members": [
+                        "serviceAccount:tr-public@quill-cloud-proxy.iam.gserviceaccount.com"
+                    ],
+                },
+                {
+                    "role": "roles/secretmanager.secretAccessor",
+                    "members": [
+                        "serviceAccount:tr-actions@quill-cloud-proxy.iam.gserviceaccount.com"
+                    ],
+                    "condition": {"title": "temporary", "expression": "true"},
+                },
+            ],
+            "noncanonical role or condition",
+        ),
+    ),
+    ids=("conditional-owner", "conditional-non-owner"),
+)
+def test_runtime_secret_verifier_rejects_conditional_owner_and_nonowner_bindings(
+    tmp_path: Path,
+    bindings: list[dict[str, object]],
+    error_fragment: str,
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_gcloud = fake_bin / "gcloud"
+    fake_gcloud.write_text(
+        "#!/usr/bin/env bash\n"
+        "if [[ \"$*\" == *\"projects describe\"* ]]; then\n"
+        "  printf '123456789\\n'\n"
+        "else\n"
+        "  exit 2\n"
+        "fi\n"
+    )
+    fake_gcloud.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "HOME": str(tmp_path),
+        "FAKE_SECRET_POLICY": json.dumps(
+            {"bindings": bindings}, separators=(",", ":")
+        ),
+    }
+    run = subprocess.run(  # noqa: S603 - fixed shell and repo-local helpers
+        [
+            "/bin/bash",
+            "-c",
+            'source "$1"; printf "%s" "$FAKE_SECRET_POLICY" | '
+            'secret_iam_policy_contract_json plan test-secret "public"',
+            "bash",
+            str(ROOT / "scripts/deploy/_lib.sh"),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=ROOT,
+        check=False,
+    )
+
+    assert run.returncode != 0
+    assert error_fragment in run.stderr
+
+
+def _run_secret_iam_reconciler(
+    tmp_path: Path,
+    secrets: dict[str, dict[str, object]],
+    *,
+    preserved: dict[str, list[str]] | None = None,
+) -> tuple[subprocess.CompletedProcess[str], dict[str, object], list[str]]:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    state_path = tmp_path / "secret-state.json"
+    events_path = tmp_path / "events.log"
+    state_path.write_text(json.dumps(secrets, sort_keys=True), encoding="utf-8")
+    events_path.write_text("", encoding="utf-8")
+    fake_gcloud = fake_bin / "gcloud"
+    fake_gcloud.write_text(
+        r'''#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+if args[:1] == ["--project"]:
+    args = args[2:]
+state_path = Path(os.environ["FAKE_SECRET_STATE"])
+events_path = Path(os.environ["FAKE_SECRET_EVENTS"])
+with events_path.open("a", encoding="utf-8") as output:
+    output.write(" ".join(args) + "\n")
+
+def option(name):
+    for index, value in enumerate(args):
+        if value.startswith(name + "="):
+            return value.split("=", 1)[1]
+        if value == name and index + 1 < len(args):
+            return args[index + 1]
+    return ""
+
+if args[:2] == ["projects", "describe"]:
+    print("123456789")
+    raise SystemExit(0)
+state = json.loads(state_path.read_text(encoding="utf-8"))
+if args[:2] == ["secrets", "list"]:
+    print(json.dumps([
+        {"name": f"projects/quill-cloud-proxy/secrets/{name}"}
+        for name in sorted(state)
+    ], separators=(",", ":")))
+    raise SystemExit(0)
+if args[:2] == ["secrets", "get-iam-policy"]:
+    print(json.dumps(state[args[2]], separators=(",", ":")))
+    raise SystemExit(0)
+if args[:2] in (
+    ["secrets", "add-iam-policy-binding"],
+    ["secrets", "remove-iam-policy-binding"],
+):
+    action = args[1].split("-", 1)[0]
+    secret = args[2]
+    member = option("--member")
+    role = option("--role")
+    if option("--condition") != "None":
+        raise SystemExit(88)
+    bindings = state[secret].setdefault("bindings", [])
+    matches = [
+        binding for binding in bindings
+        if binding.get("role") == role and binding.get("condition") is None
+    ]
+    if action == "add":
+        binding = matches[0] if matches else {"role": role, "members": []}
+        if not matches:
+            bindings.append(binding)
+        if member in binding["members"]:
+            raise SystemExit(89)
+        binding["members"].append(member)
+    else:
+        found = False
+        for binding in matches:
+            if member in binding.get("members", []):
+                binding["members"].remove(member)
+                found = True
+        if not found:
+            raise SystemExit(90)
+        state[secret]["bindings"] = [
+            binding for binding in bindings if binding.get("members")
+        ]
+    state_path.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
+    raise SystemExit(0)
+print("unexpected fake gcloud call: " + " ".join(args), file=sys.stderr)
+raise SystemExit(87)
+''',
+        encoding="utf-8",
+    )
+    fake_gcloud.chmod(0o755)
+    helper = tmp_path / "secret-reconciler.sh"
+    helper.write_text(
+        _function_body(
+            SECRETS,
+            "reconcile_declared_secret_iam",
+            "verify_runtime_secret_access",
+        ),
+        encoding="utf-8",
+    )
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "HOME": str(tmp_path),
+        "FAKE_SECRET_STATE": str(state_path),
+        "FAKE_SECRET_EVENTS": str(events_path),
+        "TR_SECRET_IAM_PRESERVED_ACCESSORS_JSON": json.dumps(preserved or {}),
+    }
+    run = subprocess.run(  # noqa: S603 - isolated fake gcloud and repo helper
+        [
+            "/bin/bash",
+            "-c",
+            'source "$1"; source "$2"; reconcile_declared_secret_iam',
+            "bash",
+            str(ROOT / "scripts/deploy/_lib.sh"),
+            str(helper),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=ROOT,
+        check=False,
+    )
+    final_state = json.loads(state_path.read_text(encoding="utf-8"))
+    events = events_path.read_text(encoding="utf-8").splitlines()
+    return run, final_state, events
+
+
+def _secret_accessor_members(policy: dict[str, object]) -> set[str]:
+    return {
+        member
+        for binding in policy.get("bindings", [])
+        if binding.get("role") == "roles/secretmanager.secretAccessor"
+        and binding.get("condition") is None
+        for member in binding.get("members", [])
+    }
+
+
+def test_secret_iam_reconciler_mutates_only_declared_owner_bindings(
+    tmp_path: Path,
+) -> None:
+    preserved_member = "group:billing-auditors@example.com"
+    secrets = {
+        "trustedrouter-attribution-cookie-secret": {
+            "bindings": [
+                {
+                    "role": "roles/secretmanager.secretAccessor",
+                    "members": [
+                        "serviceAccount:tr-actions@quill-cloud-proxy.iam.gserviceaccount.com",
+                        preserved_member,
+                    ],
+                },
+                {
+                    "role": "roles/secretmanager.secretAccessor",
+                    "members": ["allUsers"],
+                },
+            ]
+        },
+        "trustedrouter-openai-api-key": {
+            "bindings": [
+                {
+                    "role": "roles/secretmanager.secretAccessor",
+                    "members": [
+                        "serviceAccount:tr-chat@quill-cloud-proxy.iam.gserviceaccount.com"
+                    ],
+                }
+            ]
+        },
+        "trustedrouter-observer-internal-token": {
+            "bindings": [
+                {
+                    "role": "roles/secretmanager.secretAccessor",
+                    "members": [
+                        "serviceAccount:tr-internal@quill-cloud-proxy.iam.gserviceaccount.com"
+                    ],
+                }
+            ]
+        },
+        "owner-managed-existing-secret": {"bindings": []},
+    }
+
+    run, final_state, events = _run_secret_iam_reconciler(
+        tmp_path,
+        secrets,
+        preserved={
+            "trustedrouter-attribution-cookie-secret": [preserved_member]
+        },
+    )
+
+    assert run.returncode == 0, run.stderr
+    assert _secret_accessor_members(
+        final_state["trustedrouter-attribution-cookie-secret"]
+    ) == {
+        "serviceAccount:tr-public@quill-cloud-proxy.iam.gserviceaccount.com",
+        "serviceAccount:tr-console@quill-cloud-proxy.iam.gserviceaccount.com",
+        preserved_member,
+    }
+    assert _secret_accessor_members(final_state["trustedrouter-openai-api-key"]) == {
+        "serviceAccount:tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com"
+    }
+    assert _secret_accessor_members(
+        final_state["trustedrouter-observer-internal-token"]
+    ) == {
+        "serviceAccount:tr-internal@quill-cloud-proxy.iam.gserviceaccount.com",
+        "serviceAccount:tr-synthetic@quill-cloud-proxy.iam.gserviceaccount.com",
+    }
+    assert final_state["owner-managed-existing-secret"] == {"bindings": []}
+    mutations = [
+        event
+        for event in events
+        if "add-iam-policy-binding" in event or "remove-iam-policy-binding" in event
+    ]
+    assert mutations
+    assert all("set-iam-policy" not in event for event in events)
+    assert not any("owner-managed-existing-secret" in event for event in mutations)
+
+
+def test_secret_iam_reconciler_fails_before_mutation_on_unknown_managed_grant(
+    tmp_path: Path,
+) -> None:
+    secrets = {
+        "trustedrouter-attribution-cookie-secret": {"bindings": []},
+        "owner-managed-existing-secret": {
+            "bindings": [
+                {
+                    "role": "roles/secretmanager.secretAccessor",
+                    "members": [
+                        "serviceAccount:tr-public@quill-cloud-proxy.iam.gserviceaccount.com"
+                    ],
+                }
+            ]
+        },
+    }
+
+    run, final_state, events = _run_secret_iam_reconciler(tmp_path, secrets)
+
+    assert run.returncode != 0
+    assert final_state == secrets
+    assert not any("iam-policy-binding" in event for event in events)
+
+
+def test_deploy_secret_accessor_residual_is_exact_and_never_project_wide() -> None:
+    allowlist = _function_body(
+        LIB,
+        "deploy_service_account_owns_secret",
+        "synthetic_service_account_owns_secret",
+    )
+    grants = set(re.findall(r"trustedrouter-[a-z0-9-]+", allowlist))
+    workflow_reads = set(re.findall(r"trustedrouter-[a-z0-9-]+", PRICE_REFRESH))
+    workflow_reads.discard("trustedrouter-pricing-bot")
+    assert grants == workflow_reads
+    assert "grant_tr_deploy_secret_access" not in SECRETS
+    assert (
+        'ensure_project_role "$member" "roles/secretmanager.secretAccessor"'
+        not in INFRA
+    )
+    assert 'TR_DEPLOY_SA="$DEPLOY_SERVICE_ACCOUNT"' in SECRETS
+    assert "TR_DEPLOY_SA must match TR_DEPLOY_SERVICE_ACCOUNT" in SECRETS
+
+
+def test_split_runtimes_cannot_read_upstream_model_provider_secrets() -> None:
+    provider_creation_block = SECRETS[
+        SECRETS.index('ensure_secret_from_env_file "ANTHROPIC_API_KEY"') :
+        SECRETS.index("# Dedicated read-only ClickHouse credential")
+    ]
+    provisioned = set(
+        re.findall(r"trustedrouter-[a-z0-9-]+", provider_creation_block)
+    )
+    provisioned -= {
+        "trustedrouter-veriff-api-key",
+        "trustedrouter-veriff-shared-secret-key",
+    }
+    manifest = re.search(
+        r"DETACHED_PROVIDER_SECRET_NAMES=\(\n(?P<body>.*?)\n\)",
+        SECRETS,
+        re.S,
+    )
+    assert manifest is not None
+    detached_secrets = set(
+        re.findall(r"trustedrouter-[a-z0-9-]+", manifest["body"])
+    )
+    assert detached_secrets - {"trustedrouter-athena-worker-prompt-v1"} == provisioned
+    ownership_loop = SECRETS[
+        manifest.end() : SECRETS.index(
+            "# Runtime-SA project-level IAM bindings", manifest.end()
+        )
+    ]
+    assert '"$CHAT_RUN_SERVICE_ACCOUNT"' not in ownership_loop
+    assert (
+        'verify_runtime_secret_access optional "$secret_name"\n'
+        '  fi' in ownership_loop
+    )
+    assert (
+        'verify_runtime_secret_access optional "$secret_name" \\\n'
+        '      "$CONSOLE_RUN_SERVICE_ACCOUNT"' in ownership_loop
+    )
+
+
+def test_axiom_token_is_detached_from_every_split_runtime() -> None:
+    axiom_call = SECRETS[
+        SECRETS.index(
+            "verify_runtime_secret_access optional trustedrouter-axiom-api-token"
+        ) :
+        SECRETS.index("for secret_name in \\\n  trustedrouter-federation-peer-token")
+    ]
+    assert "RUN_SERVICE_ACCOUNT" not in axiom_call
+
+
+def test_actions_has_no_data_or_kms_capability() -> None:
+    words = _shell_words(INFRA)
+    assert (
+        '"Spanner database" "serviceAccount:${ACTIONS_RUN_SERVICE_ACCOUNT}" ""'
+        in words
+    )
+    assert (
+        '"$ACTIONS_RUN_SERVICE_ACCOUNT" "$CHAT_RUN_SERVICE_ACCOUNT" '
+        '"$WEBHOOKS_RUN_SERVICE_ACCOUNT"; do verify_only_resource_role '
+        '"Bigtable instance"' in words
+    )
+    assert (
+        '"$PUBLIC_RUN_SERVICE_ACCOUNT" "$ACTIONS_RUN_SERVICE_ACCOUNT" '
+        '"$CHAT_RUN_SERVICE_ACCOUNT" "$WEBHOOKS_RUN_SERVICE_ACCOUNT"; do '
+        'verify_only_resource_role "BYOK KMS key"' in words
+    )
+    assert (
+        '"$PUBLIC_RUN_SERVICE_ACCOUNT" "$ACTIONS_RUN_SERVICE_ACCOUNT" '
+        '"$CHAT_RUN_SERVICE_ACCOUNT" "$WEBHOOKS_RUN_SERVICE_ACCOUNT" '
+        '"$INTERNAL_RUN_SERVICE_ACCOUNT"; do verify_only_resource_role '
+        '"Google Ads KMS key"' in words
+    )
+
+
+def test_restricted_provider_credentials_have_mutation_sensitive_anti_reuse_checks() -> None:
+    assert _anti_reuse_contract_is_complete(SECRETS)
+
+
+@pytest.mark.parametrize(
+    "needle",
+    (
+        '[ "$_internal_stripe_key" = "$_console_stripe_key" ]',
+        '[ "$_internal_ses_access_key_id" = "$_shared_ses_access_key_id" ]',
+        '[ "$_internal_ses_secret_access_key" = "$_shared_ses_secret_access_key" ]',
+        '[ "$_attribution_token_check" = "$_observer_token_check" ]',
+        '[ "$_monitor_token_check" = "$_gateway_token_check" ]',
+    ),
+)
+def test_removing_a_reuse_guard_breaks_the_contract(needle: str) -> None:
+    assert needle in SECRETS
+    assert not _anti_reuse_contract_is_complete(SECRETS.replace(needle, "[ 1 = 2 ]", 1))
+
+
+def test_synthetic_job_identity_has_only_direct_job_and_secret_contracts() -> None:
+    words = _shell_words(SYNTHETIC)
+    secret_envs = re.search(r"SECRET_ENVS=\(\n(?P<body>.*?)\n\)", SYNTHETIC, re.S)
+    assert secret_envs is not None
+    assert set(re.findall(r"trustedrouter-[a-z0-9-]+", secret_envs["body"])) == {
+        "trustedrouter-observer-internal-token",
+        "trustedrouter-synthetic-monitor-api-key",
+    }
+    assert "roles/run.developer" not in SYNTHETIC
+    assert "ensure_project_role" not in SYNTHETIC
+    assert 'gc run jobs add-iam-policy-binding "$job_name"' in words
+    assert '--role="roles/run.invoker"' in words
+    assert "--condition=None" in words
+    assert "verify_synthetic_secret_access" in SYNTHETIC
+    assert "verify_existing_synthetic_job_invoker_or_absent" in SYNTHETIC
+    assert "verify_exact_unconditional_roles" in SYNTHETIC
+    assert "--flatten='bindings[].members'" not in SYNTHETIC
+    assert words.count('ensure_synthetic_job_invoker "$') == 4
+
+
+def test_legacy_retirement_is_guarded_and_covers_data_and_both_kms_keys() -> None:
+    words = _shell_words(INFRA)
+    assert 'if [ "$TR_RETIRE_LEGACY_RUN_SERVICE_ACCOUNT_IAM" = "1" ]; then' in INFRA
+    assert "verify_legacy_runtime_retirement_ready" in INFRA
+    assert "verify_legacy_synthetic_secret_access_ready" in INFRA
+    assert "verify_legacy_cloud_run_service_inventory" in INFRA
+    assert "verify_legacy_synthetic_jobs_ready" in INFRA
+    assert "cloud_run_inventory_lines services" in INFRA
+    assert "cloud_run_inventory_lines jobs" in INFRA
+    assert '"roles/run.invoker"' in INFRA
+    assert 'oauth.get("serviceAccountEmail") != expected_identity' in INFRA
+    assert 'for key_id in "$BYOK_KMS_KEY_ID" "$GOOGLE_ADS_KMS_KEY_ID"' in words
+    assert '"retired project" "$member" "" gc projects get-iam-policy' in words
+    assert "sole-revision 100%" in RUNBOOK
+    assert "TR_RETIRE_LEGACY_RUN_SERVICE_ACCOUNT_IAM=1" in RUNBOOK
+
+
+def test_provider_side_restrictions_are_explicitly_outside_secret_manager() -> None:
+    assert "Payment Intents" in RUNBOOK
+    assert "ses:SendEmail" in RUNBOOK
+    assert "ses:SendRawEmail" in RUNBOOK
+    assert "Secret Manager" in RUNBOOK
+    assert "cannot prove Stripe dashboard permissions or an AWS IAM policy" in RUNBOOK
+
+
+def test_iam_queries_preserve_conditions_and_cover_direct_resource_ancestors() -> None:
+    helper = _function_body(
+        LIB,
+        "iam_direct_binding_tokens_for_member",
+        "iam_member_has_unconditional_role",
+    )
+    assert "--format=json" in helper
+    assert '"condition" in binding' in helper
+    assert 'prefix = "conditional:"' in helper
+    assert "--flatten" not in helper
+
+    preflight = _function_body(
+        INFRA,
+        "preflight_identity_iam_removal_targets",
+        "verify_identity_ancestor_scopes_empty",
+    )
+    for command in (
+        'gc projects get-iam-policy "$PROJECT_ID"',
+        'gc spanner instances get-iam-policy "$SPANNER_INSTANCE_ID"',
+        'gc spanner databases get-iam-policy "$SPANNER_DATABASE_ID"',
+        'gc bigtable instances get-iam-policy "$BIGTABLE_INSTANCE_ID"',
+        'gc bigtable tables get-iam-policy "$BIGTABLE_GENERATION_TABLE"',
+        'gc kms keyrings get-iam-policy "$KMS_KEYRING_ID"',
+        'gc kms keys get-iam-policy "$key_id"',
+    ):
+        assert command in preflight
+    for roles in ("project_roles", "database_roles", "bigtable_roles", "kms_roles"):
+        assert f'"${roles}"' in preflight
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        'gc spanner instances get-iam-policy "$SPANNER_INSTANCE_ID"',
+        'gc bigtable tables get-iam-policy "$BIGTABLE_GENERATION_TABLE"',
+        'gc kms keyrings get-iam-policy "$KMS_KEYRING_ID"',
+    ),
+)
+def test_removing_an_ancestor_read_breaks_the_preflight_contract(command: str) -> None:
+    preflight = _function_body(
+        INFRA,
+        "preflight_identity_iam_removal_targets",
+        "verify_identity_ancestor_scopes_empty",
+    )
+    assert command in preflight
+    assert command not in preflight.replace(command, "gc false", 1)
+
+
+def test_every_removal_target_is_preflighted_before_the_first_runtime_removal() -> None:
+    preflight_call = INFRA.index(
+        'log "preflighting all runtime IAM removal targets and direct ancestor policies"'
+    )
+    first_runtime_removal = INFRA.index(
+        'remove_kms_role_if_present "$member" "$role" "$GOOGLE_ADS_KMS_KEY_ID"',
+        preflight_call,
+    )
+    assert preflight_call < first_runtime_removal
+    for call in (
+        'preflight_identity_iam_removal_targets "split runtime" "$service_account"',
+        "verify_legacy_runtime_retirement_ready",
+        "verify_legacy_cloud_run_service_inventory",
+        "verify_legacy_synthetic_secret_access_ready",
+        "verify_legacy_synthetic_jobs_ready",
+        'preflight_identity_iam_removal_targets "legacy runtime" "$RUN_SERVICE_ACCOUNT"',
+    ):
+        assert preflight_call < INFRA.index(call, preflight_call) < first_runtime_removal
+
+
+def test_deploy_actas_audit_is_exact_read_only_and_project_aware() -> None:
+    start = INFRA.index("verify_deploy_actas_inventory() {")
+    end = INFRA.index('\n}\n\nlog "enabling required GCP APIs"', start) + 3
+    body = INFRA[start:end]
+    assert "service-accounts list --format=json" in body
+    assert "verify_exact_unconditional_roles" in body
+    assert "roles/iam.serviceAccountUser" in body
+    assert "verify_deploy_identity_has_no_project_data_roles" in body
+    assert "remove-iam-policy-binding" not in body
+    preflight = (
+        'verify_deploy_actas_inventory '
+        '"$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT" preflight'
+    )
+    postverify = (
+        'verify_deploy_actas_inventory '
+        '"$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT" post'
+    )
+    assert preflight in INFRA
+    assert postverify in INFRA
+    assert INFRA.index(preflight) < INFRA.index(
+        'remove_kms_role_if_present "$member" "$role" "$GOOGLE_ADS_KMS_KEY_ID"',
+        INFRA.index(preflight),
+    )
+    assert INFRA.index(postverify) > INFRA.index(
+        'gc iam service-accounts add-iam-policy-binding \\\n  "$GOOGLE_DATA_MANAGER_SERVICE_ACCOUNT"'
+    )
+
+
+def test_regions_and_internal_billing_alias_are_validated_fail_closed() -> None:
+    body = _function_body(LIB, "validate_runtime_service_accounts", "read_key_file_var")
+    assert 'if [ "$TR_BILLING_SERVICE" != "$INTERNAL_SERVICE" ]' in body
+    assert "validate_nonempty_region_list TR_CONTROL_PLANE_REGIONS" in body
+    for variable in (
+        "TR_SYNTHETIC_MONITOR_REGIONS",
+        "TR_SYNTHETIC_THROUGHPUT_REGION",
+        "TR_SYNTHETIC_IMAGE_REGION",
+        "TR_SYNTHETIC_VIDEO_REGION",
+    ):
+        assert f"validate_nonempty_region_list {variable}" in body
+
+
+def test_synthetic_live_contract_checks_one_full_traffic_revision_and_runtime_sa() -> None:
+    body = _function_body(
+        SYNTHETIC,
+        "verify_synthetic_ingest_service_contract",
+        "ensure_synthetic_job_invoker",
+    )
+    assert "len(traffic) != 1" in body
+    assert "!= 100" in body
+    assert 'gc run revisions describe "$revision_name"' in body
+    assert '"$INTERNAL_RUN_SERVICE_ACCOUNT"' in body
+    assert "serving revision identity" in body
+
+
+def test_condition_aware_iam_helper_rejects_state_change_between_reads(
+    tmp_path: Path,
+) -> None:
+    member = "serviceAccount:test@quill-cloud-proxy.iam.gserviceaccount.com"
+    valid = json.dumps(
+        {
+            "bindings": [
+                {"role": "roles/run.invoker", "members": [member]}
+            ]
+        },
+        separators=(",", ":"),
+    )
+    conditional = json.dumps(
+        {
+            "bindings": [
+                {
+                    "role": "roles/run.invoker",
+                    "members": [member],
+                    "condition": {"title": "temporary", "expression": "true"},
+                }
+            ]
+        },
+        separators=(",", ":"),
+    )
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_gcloud = fake_bin / "gcloud"
+    fake_gcloud.write_text(
+        "#!/usr/bin/env bash\n"
+        "if [[ \"$*\" == *\"projects describe\"* ]]; then\n"
+        "  printf '123456789\\n'\n"
+        "  exit 0\n"
+        "fi\n"
+        "if [ ! -f \"$FAKE_IAM_STATE\" ]; then\n"
+        "  : > \"$FAKE_IAM_STATE\"\n"
+        f"  printf '%s\\n' '{valid}'\n"
+        "else\n"
+        f"  printf '%s\\n' '{conditional}'\n"
+        "fi\n"
+    )
+    fake_gcloud.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "HOME": str(tmp_path),
+        "FAKE_IAM_STATE": str(tmp_path / "iam-state"),
+    }
+    run = subprocess.run(  # noqa: S603 - fixed shell and repo-local helper
+        [
+            "/bin/bash",
+            "-c",
+            'source "$1"; '
+            'verify_exact_unconditional_roles first "$2" roles/run.invoker '
+            'gc projects get-iam-policy "$PROJECT_ID"; '
+            'if verify_exact_unconditional_roles second "$2" roles/run.invoker '
+            'gc projects get-iam-policy "$PROJECT_ID"; then exit 91; fi',
+            "bash",
+            str(ROOT / "scripts/deploy/_lib.sh"),
+            member,
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=ROOT,
+        check=False,
+    )
+
+    assert run.returncode == 0
+    assert "conditional:roles/run.invoker" in run.stderr
+
+
+def _run_runtime_service_account_policy_contract(
+    tmp_path: Path,
+    policy: dict[str, object],
+    *,
+    phase: str = "post",
+    operator_members: str = "",
+) -> subprocess.CompletedProcess[str]:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_gcloud = fake_bin / "gcloud"
+    fake_gcloud.write_text(
+        "#!/usr/bin/env bash\n"
+        "if [[ \"$*\" == *\"projects describe\"* ]]; then\n"
+        "  printf '123456789\\n'\n"
+        "else\n"
+        "  printf 'unexpected gcloud call: %s\\n' \"$*\" >&2\n"
+        "  exit 2\n"
+        "fi\n"
+    )
+    fake_gcloud.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "HOME": str(tmp_path),
+        "RUNTIME_POLICY": json.dumps(policy, separators=(",", ":")),
+        "POLICY_PHASE": phase,
+        "TR_RUNTIME_SERVICE_ACCOUNT_OPERATOR_MEMBERS": operator_members,
+    }
+    return subprocess.run(  # noqa: S603 - fixed shell and repo-local helper
+        [
+            "/bin/bash",
+            "-c",
+            'source "$1"; printf "%s" "$RUNTIME_POLICY" | '
+            "verify_runtime_service_account_policy_json "
+            '"$PUBLIC_RUN_SERVICE_ACCOUNT" "$POLICY_PHASE"',
+            "bash",
+            str(ROOT / "scripts/deploy/_lib.sh"),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=ROOT,
+        check=False,
+    )
+
+
+def test_runtime_service_account_policy_allows_deploy_and_explicit_operator(
+    tmp_path: Path,
+) -> None:
+    deploy = "serviceAccount:tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com"
+    operator = "user:operator@example.com"
+    run = _run_runtime_service_account_policy_contract(
+        tmp_path,
+        {
+            "bindings": [
+                {"role": "roles/iam.serviceAccountUser", "members": [deploy]},
+                {"role": "roles/iam.serviceAccountUser", "members": [operator]},
+            ]
+        },
+        operator_members=operator,
+    )
+
+    assert run.returncode == 0, run.stderr
+
+
+@pytest.mark.parametrize(
+    "role",
+    (
+        "roles/iam.serviceAccountUser",
+        "roles/iam.serviceAccountTokenCreator",
+        "roles/viewer",
+    ),
+)
+def test_runtime_service_account_policy_rejects_every_cross_runtime_role(
+    tmp_path: Path,
+    role: str,
+) -> None:
+    deploy = "serviceAccount:tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com"
+    other_runtime = (
+        "serviceAccount:tr-actions@quill-cloud-proxy.iam.gserviceaccount.com"
+    )
+    run = _run_runtime_service_account_policy_contract(
+        tmp_path,
+        {
+            "bindings": [
+                {"role": "roles/iam.serviceAccountUser", "members": [deploy]},
+                {"role": role, "members": [other_runtime]},
+            ]
+        },
+    )
+
+    assert run.returncode != 0
+    assert "split runtime principal" in run.stderr
+
+
+@pytest.mark.parametrize(
+    ("binding", "operator_members", "error_fragment"),
+    (
+        (
+            {
+                "role": "roles/iam.serviceAccountUser",
+                "members": [
+                    "serviceAccount:tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com"
+                ],
+                "condition": {"title": "temporary", "expression": "true"},
+            },
+            "",
+            "deploy principal bindings",
+        ),
+        (
+            {
+                "role": "roles/iam.serviceAccountTokenCreator",
+                "members": [
+                    "serviceAccount:tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com"
+                ],
+            },
+            "",
+            "deploy principal bindings",
+        ),
+        (
+            {
+                "role": "roles/iam.serviceAccountUser",
+                "members": ["user:unlisted@example.com"],
+            },
+            "",
+            "unapproved principal",
+        ),
+        (
+            {
+                "role": "roles/iam.serviceAccountTokenCreator",
+                "members": ["user:operator@example.com"],
+            },
+            "user:operator@example.com",
+            "must have only unconditional serviceAccountUser",
+        ),
+    ),
+    ids=(
+        "conditional-deploy",
+        "deploy-token-creator",
+        "unknown-principal",
+        "operator-token-creator",
+    ),
+)
+def test_runtime_service_account_policy_rejects_noncanonical_direct_bindings(
+    tmp_path: Path,
+    binding: dict[str, object],
+    operator_members: str,
+    error_fragment: str,
+) -> None:
+    deploy = "serviceAccount:tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com"
+    bindings: list[dict[str, object]] = []
+    if deploy not in binding.get("members", []):
+        bindings.append(
+            {"role": "roles/iam.serviceAccountUser", "members": [deploy]}
+        )
+    bindings.append(binding)
+    run = _run_runtime_service_account_policy_contract(
+        tmp_path,
+        {"bindings": bindings},
+        operator_members=operator_members,
+    )
+
+    assert run.returncode != 0
+    assert error_fragment in run.stderr
+
+
+def test_runtime_policy_contract_is_mutation_sensitive_to_cross_runtime_drift(
+    tmp_path: Path,
+) -> None:
+    deploy = "serviceAccount:tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com"
+    valid = {"bindings": [{"role": "roles/iam.serviceAccountUser", "members": [deploy]}]}
+    mutated = json.loads(json.dumps(valid))
+    mutated["bindings"].append(
+        {
+            "role": "roles/iam.serviceAccountUser",
+            "members": [
+                "serviceAccount:tr-chat@quill-cloud-proxy.iam.gserviceaccount.com"
+            ],
+        }
+    )
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_gcloud = fake_bin / "gcloud"
+    fake_gcloud.write_text(
+        "#!/usr/bin/env bash\n"
+        "printf '123456789\\n'\n"
+    )
+    fake_gcloud.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "HOME": str(tmp_path),
+        "VALID_POLICY": json.dumps(valid, separators=(",", ":")),
+        "MUTATED_POLICY": json.dumps(mutated, separators=(",", ":")),
+    }
+    run = subprocess.run(  # noqa: S603 - fixed shell and repo-local helper
+        [
+            "/bin/bash",
+            "-c",
+            'source "$1"; '
+            'printf "%s" "$VALID_POLICY" | '
+            'verify_runtime_service_account_policy_json "$PUBLIC_RUN_SERVICE_ACCOUNT" post; '
+            'if printf "%s" "$MUTATED_POLICY" | '
+            'verify_runtime_service_account_policy_json "$PUBLIC_RUN_SERVICE_ACCOUNT" post; '
+            "then exit 91; fi",
+            "bash",
+            str(ROOT / "scripts/deploy/_lib.sh"),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=ROOT,
+        check=False,
+    )
+
+    assert run.returncode == 0
+    assert "split runtime principal" in run.stderr
+
+
+def test_runtime_policy_shared_contract_is_used_by_infra_pre_and_post_audits() -> None:
+    helper = _function_body(
+        LIB,
+        "verify_runtime_service_account_policy_json",
+        "validate_runtime_service_accounts",
+    )
+    assert "roles/iam.serviceAccountTokenCreator" not in helper
+    assert "split runtime principal" in helper
+    assert "unapproved principal" in helper
+    assert "operator" in helper
+    audit_start = INFRA.index("verify_deploy_actas_inventory() {")
+    audit_end = INFRA.index('\n}\n\nlog "enabling required GCP APIs"', audit_start)
+    audit = INFRA[audit_start:audit_end]
+    assert "verify_runtime_service_account_policy_json" in audit
+    assert '"$service_account" "$phase"' in audit

--- a/tests/test_infra_synthetic_retirement.py
+++ b/tests/test_infra_synthetic_retirement.py
@@ -1,0 +1,614 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+INFRA = (ROOT / "scripts/deploy/infra.sh").read_text(encoding="utf-8")
+LIB = (ROOT / "scripts/deploy/_lib.sh").read_text(encoding="utf-8")
+PROJECT_ID = "quill-cloud-proxy"
+LEGACY_IDENTITY = "123456789-compute@developer.gserviceaccount.com"
+SYNTHETIC_IDENTITY = f"tr-synthetic@{PROJECT_ID}.iam.gserviceaccount.com"
+INTERNAL_IDENTITY = f"tr-internal@{PROJECT_ID}.iam.gserviceaccount.com"
+DEPLOY_IDENTITY = f"tr-deploy@{PROJECT_ID}.iam.gserviceaccount.com"
+
+CANONICAL_JOBS = (
+    (
+        "us-central1",
+        "trusted-router-synthetic-us-central1",
+        "trusted-router-synthetic-us-central1-every-three-minutes",
+    ),
+    (
+        "europe-west1",
+        "trusted-router-throughput-europe-west1",
+        "trusted-router-throughput-europe-west1-every-five-minutes",
+    ),
+    (
+        "asia-northeast1",
+        "trusted-router-image-generation-asia-northeast1",
+        "trusted-router-image-generation-asia-northeast1-every-six-hours",
+    ),
+    (
+        "us-east1",
+        "trusted-router-video-generation-us-east1",
+        "trusted-router-video-generation-us-east1-daily",
+    ),
+)
+
+
+def _function_body(source: str, name: str, next_name: str) -> str:
+    start = source.index(f"{name}() {{")
+    end = source.index(f"{next_name}() {{", start)
+    return source[start:end]
+
+
+RETIREMENT_HELPERS = "\n".join(
+    (
+        _function_body(
+            INFRA,
+            "verify_identity_resource_manager_ancestors_empty",
+            "verify_synthetic_retirement_identity_ready",
+        ),
+        _function_body(
+            INFRA,
+            "verify_synthetic_retirement_identity_ready",
+            "verify_legacy_synthetic_secret_access_ready",
+        ),
+        _function_body(
+            INFRA,
+            "verify_legacy_synthetic_secret_access_ready",
+            "synthetic_job_inventory_lines",
+        ),
+        _function_body(
+            INFRA,
+            "synthetic_job_inventory_lines",
+            "cloud_run_inventory_lines",
+        ),
+        _function_body(
+            INFRA,
+            "cloud_run_inventory_lines",
+            "cloud_run_job_service_account",
+        ),
+        _function_body(
+            INFRA,
+            "cloud_run_job_service_account",
+            "verify_legacy_cloud_run_service_inventory",
+        ),
+        _function_body(
+            INFRA,
+            "verify_legacy_synthetic_jobs_ready",
+            "describe_iam_role_definition",
+        ),
+    )
+)
+
+FAKE_GCLOUD = r'''#!/usr/bin/env python3
+import json
+import os
+import sys
+
+args = sys.argv[1:]
+
+
+def option(name):
+    prefix = name + "="
+    for index, value in enumerate(args):
+        if value.startswith(prefix):
+            return value[len(prefix):]
+        if value == name and index + 1 < len(args):
+            return args[index + 1]
+    return ""
+
+
+def emit(value):
+    print(json.dumps(value, separators=(",", ":")))
+    raise SystemExit(0)
+
+
+if args[:3] == ["iam", "service-accounts", "describe"]:
+    emit(json.loads(os.environ["FAKE_ACCOUNT_JSON"]))
+if args[:3] == ["iam", "service-accounts", "get-iam-policy"]:
+    emit(json.loads(os.environ["FAKE_ACCOUNT_POLICY"]))
+if args[:2] == ["projects", "get-ancestors"]:
+    emit(json.loads(os.environ["FAKE_ANCESTORS"]))
+if args[:3] == ["resource-manager", "folders", "get-iam-policy"]:
+    emit(json.loads(os.environ["FAKE_FOLDER_POLICY"]))
+if args[:2] == ["organizations", "get-iam-policy"]:
+    emit(json.loads(os.environ["FAKE_ORGANIZATION_POLICY"]))
+if args[:3] == ["run", "jobs", "list"]:
+    emit(json.loads(os.environ["FAKE_JOB_INVENTORY"]))
+if args[:3] == ["run", "jobs", "describe"]:
+    key = option("--region") + "/" + args[3]
+    identities = json.loads(os.environ["FAKE_JOB_IDENTITIES"])
+    if key not in identities:
+        raise SystemExit(3)
+    emit(
+        {
+            "spec": {
+                "template": {
+                    "template": {"serviceAccount": identities[key]}
+                }
+            }
+        }
+    )
+if args[:3] == ["run", "jobs", "get-iam-policy"]:
+    emit(json.loads(os.environ["FAKE_JOB_POLICY"]))
+if args[:3] == ["scheduler", "jobs", "describe"]:
+    region = option("--location")
+    scheduler_name = args[3]
+    scheduler_identities = json.loads(os.environ["FAKE_SCHEDULER_IDENTITIES"])
+    key = region + "/" + scheduler_name
+    if key not in scheduler_identities:
+        raise SystemExit(3)
+    job_name = scheduler_name.rsplit("-every-", 1)[0]
+    if scheduler_name.endswith("-daily"):
+        job_name = scheduler_name[:-len("-daily")]
+    uri = (
+        f"https://{region}-run.googleapis.com/apis/run.googleapis.com/v1/"
+        f"namespaces/{os.environ['FAKE_PROJECT_ID']}/jobs/{job_name}:run"
+    )
+    emit(
+        {
+            "state": "ENABLED",
+            "httpTarget": {
+                "uri": uri,
+                "httpMethod": "POST",
+                "oauthToken": {
+                    "serviceAccountEmail": scheduler_identities[key]
+                },
+            },
+        }
+    )
+if args[:2] == ["secrets", "list"]:
+    emit(json.loads(os.environ["FAKE_SECRET_INVENTORY"]))
+if args[:2] == ["secrets", "get-iam-policy"]:
+    policies = json.loads(os.environ["FAKE_SECRET_POLICIES"])
+    if args[2] not in policies:
+        raise SystemExit(3)
+    emit(policies[args[2]])
+if "get-iam-policy" in args:
+    emit(json.loads(os.environ["FAKE_RESOURCE_POLICY"]))
+
+print("unexpected fake gc invocation: " + " ".join(args), file=sys.stderr)
+raise SystemExit(2)
+'''
+
+SHELL_HARNESS = r'''
+gc() {
+  "$FAKE_GCLOUD" "$@"
+}
+
+verify_exact_unconditional_roles() {
+  local label="$1"
+  local member="$2"
+  local expected="$3"
+  local policy
+  local actual
+  shift 3
+  policy="$("$@")" || return 1
+  actual="$(printf '%s' "$policy" | python3 -c '
+import json
+import sys
+
+policy = json.load(sys.stdin)
+member = sys.argv[1]
+tokens = []
+for binding in policy.get("bindings") or []:
+    if member not in (binding.get("members") or []):
+        continue
+    prefix = "conditional:" if binding.get("condition") is not None else ""
+    tokens.append(prefix + str(binding.get("role") or ""))
+print("\n".join(sorted(tokens)))
+' "$member")" || return 1
+  if [ "$actual" != "$expected" ]; then
+    echo "ERROR: ${label} roles are ${actual}, expected ${expected}" >&2
+    return 1
+  fi
+}
+
+verify_all_synthetic_retirement_contracts() {
+  verify_synthetic_retirement_identity_ready || return 1
+  verify_legacy_synthetic_secret_access_ready || return 1
+  verify_legacy_synthetic_jobs_ready
+}
+'''
+
+
+def _valid_secret_policy() -> dict[str, object]:
+    return {
+        "bindings": [
+            {
+                "role": "roles/secretmanager.secretAccessor",
+                "members": [
+                    f"serviceAccount:{INTERNAL_IDENTITY}",
+                    f"serviceAccount:{SYNTHETIC_IDENTITY}",
+                ],
+            }
+        ]
+    }
+
+
+def _base_state() -> dict[str, str]:
+    inventory = [
+        {
+            "metadata": {
+                "name": job_name,
+                "labels": {"cloud.googleapis.com/location": region},
+            }
+        }
+        for region, job_name, _ in CANONICAL_JOBS
+    ]
+    job_identities = {
+        f"{region}/{job_name}": SYNTHETIC_IDENTITY
+        for region, job_name, _ in CANONICAL_JOBS
+    }
+    scheduler_identities = {
+        f"{region}/{scheduler_name}": SYNTHETIC_IDENTITY
+        for region, _, scheduler_name in CANONICAL_JOBS
+    }
+    return {
+        "FAKE_ACCOUNT_JSON": json.dumps(
+            {"email": SYNTHETIC_IDENTITY, "disabled": False}
+        ),
+        "FAKE_ACCOUNT_POLICY": json.dumps(
+            {
+                "bindings": [
+                    {
+                        "role": "roles/iam.serviceAccountUser",
+                        "members": [f"serviceAccount:{DEPLOY_IDENTITY}"],
+                    }
+                ]
+            }
+        ),
+        "FAKE_ANCESTORS": json.dumps(
+            [
+                {"type": "project", "id": PROJECT_ID},
+                {"type": "folder", "id": "456789"},
+                {"type": "organization", "id": "987654"},
+            ]
+        ),
+        "FAKE_FOLDER_POLICY": json.dumps({"bindings": []}),
+        "FAKE_ORGANIZATION_POLICY": json.dumps({"bindings": []}),
+        "FAKE_JOB_INVENTORY": json.dumps(inventory),
+        "FAKE_JOB_IDENTITIES": json.dumps(job_identities),
+        "FAKE_JOB_POLICY": json.dumps(
+            {
+                "bindings": [
+                    {
+                        "role": "roles/run.invoker",
+                        "members": [f"serviceAccount:{SYNTHETIC_IDENTITY}"],
+                    }
+                ]
+            }
+        ),
+        "FAKE_SCHEDULER_IDENTITIES": json.dumps(scheduler_identities),
+        "FAKE_SECRET_INVENTORY": json.dumps(
+            [
+                {"name": "trustedrouter-observer-internal-token"},
+                {"name": "trustedrouter-synthetic-monitor-api-key"},
+                {"name": "owner-managed-existing-secret"},
+            ]
+        ),
+        "FAKE_SECRET_POLICIES": json.dumps(
+            {
+                "trustedrouter-observer-internal-token": _valid_secret_policy(),
+                "trustedrouter-synthetic-monitor-api-key": _valid_secret_policy(),
+                "owner-managed-existing-secret": {
+                    "bindings": [
+                        {
+                            "role": "roles/secretmanager.viewer",
+                            "members": ["group:unrelated-owners@example.com"],
+                        }
+                    ]
+                },
+            }
+        ),
+        "FAKE_RESOURCE_POLICY": json.dumps({"bindings": []}),
+    }
+
+
+def _run_retirement_helper(
+    tmp_path: Path,
+    function_name: str,
+    *,
+    state_updates: dict[str, str] | None = None,
+    synthetic_identity: str = SYNTHETIC_IDENTITY,
+) -> subprocess.CompletedProcess[str]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    fake_gcloud = tmp_path / "fake-gc"
+    fake_gcloud.write_text(FAKE_GCLOUD, encoding="utf-8")
+    fake_gcloud.chmod(0o755)
+    helpers = tmp_path / "retirement-helpers.sh"
+    helpers.write_text(RETIREMENT_HELPERS + SHELL_HARNESS, encoding="utf-8")
+
+    env = {
+        **os.environ,
+        **_base_state(),
+        "FAKE_GCLOUD": str(fake_gcloud),
+        "FAKE_PROJECT_ID": PROJECT_ID,
+        "PROJECT_ID": PROJECT_ID,
+        "PROJECT_NUMBER": "123456789",
+        "RUN_SERVICE_ACCOUNT": LEGACY_IDENTITY,
+        "SYNTHETIC_RUN_SERVICE_ACCOUNT": synthetic_identity,
+        "INTERNAL_RUN_SERVICE_ACCOUNT": INTERNAL_IDENTITY,
+        "DEPLOY_SERVICE_ACCOUNT": DEPLOY_IDENTITY,
+        "SPANNER_INSTANCE_ID": "trusted-router",
+        "SPANNER_DATABASE_ID": "trusted-router",
+        "BIGTABLE_INSTANCE_ID": "trusted-router",
+        "BIGTABLE_GENERATION_TABLE": "generations",
+        "KMS_KEYRING_ID": "trusted-router",
+        "BYOK_KMS_KEY_ID": "byok",
+        "GOOGLE_ADS_KMS_KEY_ID": "google-ads",
+        "REGION": "us-central1",
+        "TR_SYNTHETIC_MONITOR_REGIONS": "us-central1",
+        "TR_SYNTHETIC_THROUGHPUT_REGION": "europe-west1",
+        "TR_SYNTHETIC_IMAGE_REGION": "asia-northeast1",
+        "TR_SYNTHETIC_VIDEO_REGION": "us-east1",
+    }
+    env.update(state_updates or {})
+    return subprocess.run(  # noqa: S603 - fixed shell and test-owned helper
+        [
+            "/bin/bash",
+            "-c",
+            'set -uo pipefail; source "$1"; "$2"',
+            "bash",
+            str(helpers),
+            function_name,
+        ],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_legacy_retirement_requires_a_separate_canonical_synthetic_identity() -> None:
+    assert (
+        'SYNTHETIC_RUN_SERVICE_ACCOUNT="${TR_SYNTHETIC_RUN_SERVICE_ACCOUNT:-'
+        'tr-synthetic@${PROJECT_ID}.iam.gserviceaccount.com}"' in LIB
+    )
+    assert (
+        'ensure_runtime_service_account "$SYNTHETIC_RUN_SERVICE_ACCOUNT" '
+        '"TrustedRouter synthetic jobs"' in INFRA
+    )
+    assert "verify_synthetic_service_account_policy preflight" in INFRA
+    assert "verify_synthetic_service_account_policy post" in INFRA
+    assert INFRA.count("verify_synthetic_data_iam_empty") >= 3
+    preflight_section = INFRA.index(
+        'log "preflighting all runtime IAM removal targets and direct ancestor policies"'
+    )
+    preflight = INFRA.index(
+        "  verify_synthetic_retirement_identity_ready", preflight_section
+    )
+    first_legacy_removal = INFRA.index(
+        'remove_project_role_if_present "$member" "roles/secretmanager.secretAccessor"',
+        INFRA.index(
+            'if [ "$TR_RETIRE_LEGACY_RUN_SERVICE_ACCOUNT_IAM" = "1" ]; then',
+            INFRA.index('log "removing broad legacy'),
+        ),
+    )
+    assert preflight < first_legacy_removal
+    jobs = _function_body(
+        INFRA,
+        "verify_legacy_synthetic_jobs_ready",
+        "describe_iam_role_definition",
+    )
+    assert 'local member="serviceAccount:${SYNTHETIC_RUN_SERVICE_ACCOUNT}"' in jobs
+    assert 'if [ "$identity" = "$RUN_SERVICE_ACCOUNT" ]' in jobs
+    assert '"$SYNTHETIC_RUN_SERVICE_ACCOUNT" \\' in jobs
+
+
+def test_synthetic_retirement_contract_accepts_only_the_narrow_migrated_state(
+    tmp_path: Path,
+) -> None:
+    run = _run_retirement_helper(
+        tmp_path, "verify_all_synthetic_retirement_contracts"
+    )
+
+    assert run.returncode == 0, run.stderr
+
+
+@pytest.mark.parametrize("canonical_index", range(len(CANONICAL_JOBS)))
+def test_each_canonical_job_still_using_legacy_blocks_retirement(
+    tmp_path: Path,
+    canonical_index: int,
+) -> None:
+    region, job_name, _ = CANONICAL_JOBS[canonical_index]
+    identities = json.loads(_base_state()["FAKE_JOB_IDENTITIES"])
+    identities[f"{region}/{job_name}"] = LEGACY_IDENTITY
+
+    run = _run_retirement_helper(
+        tmp_path,
+        "verify_legacy_synthetic_jobs_ready",
+        state_updates={"FAKE_JOB_IDENTITIES": json.dumps(identities)},
+    )
+
+    assert run.returncode != 0
+    assert "still uses legacy identity" in run.stderr
+
+
+def test_unaccounted_job_using_legacy_also_blocks_retirement(tmp_path: Path) -> None:
+    state = _base_state()
+    inventory = json.loads(state["FAKE_JOB_INVENTORY"])
+    inventory.append(
+        {
+            "metadata": {
+                "name": "forgotten-synthetic",
+                "labels": {"cloud.googleapis.com/location": "australia-southeast1"},
+            }
+        }
+    )
+    identities = json.loads(state["FAKE_JOB_IDENTITIES"])
+    identities["australia-southeast1/forgotten-synthetic"] = LEGACY_IDENTITY
+
+    run = _run_retirement_helper(
+        tmp_path,
+        "verify_legacy_synthetic_jobs_ready",
+        state_updates={
+            "FAKE_JOB_INVENTORY": json.dumps(inventory),
+            "FAKE_JOB_IDENTITIES": json.dumps(identities),
+        },
+    )
+
+    assert run.returncode != 0
+    assert "forgotten-synthetic still uses legacy identity" in run.stderr
+
+
+def test_canonical_scheduler_using_legacy_blocks_retirement(tmp_path: Path) -> None:
+    region, _, scheduler_name = CANONICAL_JOBS[0]
+    schedulers = json.loads(_base_state()["FAKE_SCHEDULER_IDENTITIES"])
+    schedulers[f"{region}/{scheduler_name}"] = LEGACY_IDENTITY
+
+    run = _run_retirement_helper(
+        tmp_path,
+        "verify_legacy_synthetic_jobs_ready",
+        state_updates={"FAKE_SCHEDULER_IDENTITIES": json.dumps(schedulers)},
+    )
+
+    assert run.returncode != 0
+    assert "canonical synthetic scheduler" in run.stderr
+    assert "is unsafe" in run.stderr
+
+
+def test_legacy_job_invoker_binding_blocks_retirement(tmp_path: Path) -> None:
+    policy = {
+        "bindings": [
+            {
+                "role": "roles/run.invoker",
+                "members": [
+                    f"serviceAccount:{SYNTHETIC_IDENTITY}",
+                    f"serviceAccount:{LEGACY_IDENTITY}",
+                ],
+            }
+        ]
+    }
+
+    run = _run_retirement_helper(
+        tmp_path,
+        "verify_legacy_synthetic_jobs_ready",
+        state_updates={"FAKE_JOB_POLICY": json.dumps(policy)},
+    )
+
+    assert run.returncode != 0
+    assert "must have only the dedicated synthetic invoker" in run.stderr
+
+
+def test_legacy_secret_consumer_blocks_retirement(tmp_path: Path) -> None:
+    policy = _valid_secret_policy()
+    members = policy["bindings"][0]["members"]  # type: ignore[index]
+    assert isinstance(members, list)
+    members[1] = f"serviceAccount:{LEGACY_IDENTITY}"
+    policies = json.loads(_base_state()["FAKE_SECRET_POLICIES"])
+    policies["trustedrouter-observer-internal-token"] = policy
+
+    run = _run_retirement_helper(
+        tmp_path,
+        "verify_legacy_synthetic_secret_access_ready",
+        state_updates={"FAKE_SECRET_POLICIES": json.dumps(policies)},
+    )
+
+    assert run.returncode != 0
+    assert "exactly the internal and dedicated synthetic consumers" in run.stderr
+
+
+def test_unknown_secret_with_synthetic_accessor_blocks_retirement(
+    tmp_path: Path,
+) -> None:
+    inventory = json.loads(_base_state()["FAKE_SECRET_INVENTORY"])
+    inventory.append({"name": "owner-managed-future-secret"})
+    policies = json.loads(_base_state()["FAKE_SECRET_POLICIES"])
+    policies["owner-managed-future-secret"] = {
+        "bindings": [
+            {
+                "role": "roles/secretmanager.secretAccessor",
+                "members": [f"serviceAccount:{SYNTHETIC_IDENTITY}"],
+            },
+            {
+                "role": "roles/secretmanager.viewer",
+                "members": ["group:unrelated-owners@example.com"],
+            },
+        ]
+    }
+
+    run = _run_retirement_helper(
+        tmp_path,
+        "verify_legacy_synthetic_secret_access_ready",
+        state_updates={
+            "FAKE_SECRET_INVENTORY": json.dumps(inventory),
+            "FAKE_SECRET_POLICIES": json.dumps(policies),
+        },
+    )
+
+    assert run.returncode != 0
+    assert "non-synthetic secret owner-managed-future-secret roles are" in run.stderr
+    assert "roles/secretmanager.secretAccessor" in run.stderr
+
+
+def test_unapproved_or_broad_synthetic_identity_blocks_retirement(
+    tmp_path: Path,
+) -> None:
+    unapproved = _run_retirement_helper(
+        tmp_path / "unapproved",
+        "verify_synthetic_retirement_identity_ready",
+        synthetic_identity=f"custom-monitor@{PROJECT_ID}.iam.gserviceaccount.com",
+    )
+    assert unapproved.returncode != 0
+    assert "canonical dedicated synthetic identity" in unapproved.stderr
+
+    broad_policy = {
+        "bindings": [
+            {
+                "role": "roles/editor",
+                "members": [f"serviceAccount:{SYNTHETIC_IDENTITY}"],
+            }
+        ]
+    }
+    broad = _run_retirement_helper(
+        tmp_path / "broad",
+        "verify_synthetic_retirement_identity_ready",
+        state_updates={"FAKE_RESOURCE_POLICY": json.dumps(broad_policy)},
+    )
+    assert broad.returncode != 0
+    assert "synthetic identity project roles are roles/editor" in broad.stderr
+
+
+@pytest.mark.parametrize(
+    ("policy_variable", "error_fragment"),
+    (
+        (
+            "FAKE_FOLDER_POLICY",
+            "synthetic identity inherited folder 456789 roles are roles/editor",
+        ),
+        (
+            "FAKE_ORGANIZATION_POLICY",
+            "synthetic identity inherited organization 987654 roles are roles/editor",
+        ),
+    ),
+)
+def test_direct_folder_or_organization_binding_blocks_retirement(
+    tmp_path: Path,
+    policy_variable: str,
+    error_fragment: str,
+) -> None:
+    ancestor_policy = {
+        "bindings": [
+            {
+                "role": "roles/editor",
+                "members": [f"serviceAccount:{SYNTHETIC_IDENTITY}"],
+            }
+        ]
+    }
+
+    run = _run_retirement_helper(
+        tmp_path,
+        "verify_synthetic_retirement_identity_ready",
+        state_updates={policy_variable: json.dumps(ancestor_policy)},
+    )
+
+    assert run.returncode != 0
+    assert error_fragment in run.stderr

--- a/tests/test_internal_chat_browser_key.py
+++ b/tests/test_internal_chat_browser_key.py
@@ -17,18 +17,26 @@ Contract being locked:
 from __future__ import annotations
 
 import datetime as dt
+import threading
+from concurrent.futures import ThreadPoolExecutor
 
+import pytest
 from fastapi.testclient import TestClient
 
+import trusted_router.storage_chat_browser_keys as chat_browser_key_storage
 from trusted_router.config import Settings
 from trusted_router.main import create_app
+from trusted_router.routes.internal import chat_browser_key as chat_browser_key_routes
 from trusted_router.routes.internal.chat_browser_key import (
+    CHAT_BROWSER_ACTIVE_KEY_CAP,
     CHAT_BROWSER_KEY_COOKIE_MAX_AGE,
     CHAT_BROWSER_KEY_COOKIE_NAME,
     CHAT_BROWSER_KEY_LIMIT_MICRODOLLARS,
     CHAT_BROWSER_KEY_TTL_DAYS,
 )
-from trusted_router.storage import STORE
+from trusted_router.storage import STORE, InMemoryStore
+from trusted_router.storage_chat_browser_keys import is_active_chat_browser_key
+from trusted_router.storage_models import ApiKey
 
 
 def _console_client() -> tuple[TestClient, str, str]:
@@ -110,6 +118,24 @@ def test_issue_chat_browser_key_creates_scoped_key_and_sets_cookie() -> None:
     assert "SameSite=lax" in set_cookie or "samesite=lax" in set_cookie.lower()
 
 
+def test_issue_chat_browser_key_offloads_atomic_store_transaction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _, _ = _console_client()
+    offloaded: list[str] = []
+
+    async def recorded_threadpool(func, *args, **kwargs):
+        offloaded.append(func.__name__)
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(chat_browser_key_routes, "run_in_threadpool", recorded_threadpool)
+
+    response = client.post("/internal/chat/issue-browser-key")
+
+    assert response.status_code == 200, response.text
+    assert offloaded == ["issue_chat_browser_key"]
+
+
 def test_issue_chat_browser_key_creates_non_management_key() -> None:
     """Browser keys MUST NOT be management-tier. Management gives access
     to /v1/keys and other admin surfaces — way too much for a chat
@@ -163,6 +189,95 @@ def test_issue_chat_browser_key_multiple_calls_produce_distinct_keys() -> None:
     assert body2["key_hash"] in hashes
 
 
+def test_issue_chat_browser_key_refuses_after_active_workspace_cap() -> None:
+    client, _, workspace_id = _console_client()
+
+    responses = [
+        client.post("/internal/chat/issue-browser-key")
+        for _ in range(CHAT_BROWSER_ACTIVE_KEY_CAP)
+    ]
+    assert all(response.status_code == 200 for response in responses)
+
+    refused = client.post("/internal/chat/issue-browser-key")
+    assert refused.status_code == 429
+    assert refused.headers["retry-after"] == "60"
+    assert "revoke one in the console" in refused.json()["error"]["message"]
+    assert sum(
+        is_active_chat_browser_key(key) for key in STORE.list_keys(workspace_id)
+    ) == CHAT_BROWSER_ACTIVE_KEY_CAP
+    assert CHAT_BROWSER_KEY_COOKIE_NAME not in refused.headers.get("set-cookie", "")
+
+
+def test_chat_browser_key_cap_refusal_generates_no_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = InMemoryStore()
+    user = store.ensure_user("chat-key-cap-no-work@example.com")
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    expires_at = (dt.datetime.now(dt.UTC) + dt.timedelta(days=1)).isoformat()
+    first = store.issue_chat_browser_key(
+        workspace_id=workspace.id,
+        name="chat-browser-first",
+        creator_user_id=user.id,
+        limit_microdollars=1,
+        expires_at=expires_at,
+        active_key_cap=1,
+    )
+    assert first is not None
+    before = list(store.list_keys(workspace.id))
+    secret_calls = 0
+    original_new_api_key = chat_browser_key_storage.new_api_key
+
+    def counted_new_api_key() -> str:
+        nonlocal secret_calls
+        secret_calls += 1
+        return original_new_api_key()
+
+    monkeypatch.setattr(chat_browser_key_storage, "new_api_key", counted_new_api_key)
+    refused = store.issue_chat_browser_key(
+        workspace_id=workspace.id,
+        name="chat-browser-refused",
+        creator_user_id=user.id,
+        limit_microdollars=1,
+        expires_at=expires_at,
+        active_key_cap=1,
+    )
+
+    assert refused is None
+    assert secret_calls == 0
+    assert store.list_keys(workspace.id) == before
+
+
+def test_concurrent_chat_browser_key_issuance_never_exceeds_cap() -> None:
+    store = InMemoryStore()
+    user = store.ensure_user("chat-key-cap-concurrency@example.com")
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    expires_at = (dt.datetime.now(dt.UTC) + dt.timedelta(days=1)).isoformat()
+    callers = CHAT_BROWSER_ACTIVE_KEY_CAP * 3
+    barrier = threading.Barrier(callers)
+
+    def issue(index: int) -> tuple[str, ApiKey] | None:
+        barrier.wait(timeout=5)
+        return store.issue_chat_browser_key(
+            workspace_id=workspace.id,
+            name=f"chat-browser-concurrent-{index}",
+            creator_user_id=user.id,
+            limit_microdollars=1,
+            expires_at=expires_at,
+            active_key_cap=CHAT_BROWSER_ACTIVE_KEY_CAP,
+        )
+
+    with ThreadPoolExecutor(max_workers=callers) as executor:
+        results = list(executor.map(issue, range(callers)))
+
+    assert sum(result is not None for result in results) == CHAT_BROWSER_ACTIVE_KEY_CAP
+    stored = store.list_keys(workspace.id)
+    assert sum(is_active_chat_browser_key(key) for key in stored) == CHAT_BROWSER_ACTIVE_KEY_CAP
+    raw_keys = {result[0] for result in results if result is not None}
+    assert len(raw_keys) == CHAT_BROWSER_ACTIVE_KEY_CAP
+    assert all(raw not in repr(stored) for raw in raw_keys)
+
+
 def test_issue_chat_browser_key_secure_flag_in_production() -> None:
     """In production env the Secure flag is set so the cookie is never
     sent over plain HTTP. In local env it's omitted so http://127.0.0.1
@@ -170,10 +285,12 @@ def test_issue_chat_browser_key_secure_flag_in_production() -> None:
     # Production app
     prod_settings = Settings(
         environment="production",
-        service_surface="control",
+        service_surface="console",
         attribution_cookie_secret="attribution-cookie-secret-for-control-test",  # noqa: S106
-        stripe_webhook_secret="w",  # noqa: S106 - test fixture.
         stripe_secret_key="s",  # noqa: S106 - test fixture.
+        google_oauth_login_available=False,
+        github_oauth_login_available=False,
+        paypal_checkout_enabled=False,
         sentry_dsn="https://example@example.ingest.sentry.io/1",
         aws_access_key_id="test-access-key",
         aws_secret_access_key="test-secret-key",  # noqa: S106 - test fixture.

--- a/tests/test_neurometric_provider.py
+++ b/tests/test_neurometric_provider.py
@@ -320,8 +320,8 @@ def test_neurometric_hourly_refresh_and_secret_wiring_are_complete() -> None:
         '"trustedrouter-neurometric-api-key"'
     ) in secrets
     assert (
-        'grant_tr_deploy_secret_access "trustedrouter-neurometric-api-key"'
-        in secrets
+        "trustedrouter-neurometric-api-key"
+        in secrets.split("DETACHED_PROVIDER_SECRET_NAMES=(", 1)[1].split(")", 1)[0]
     )
     assert (
         "NEUROMETRIC_API_KEY:trustedrouter-neurometric-api-key"

--- a/tests/test_oauth_atomic_exchange.py
+++ b/tests/test_oauth_atomic_exchange.py
@@ -1,0 +1,169 @@
+"""Atomic in-memory OAuth grant exchange under failures and forced races."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from trusted_router import storage_oauth_codes
+from trusted_router.storage import InMemoryStore
+from trusted_router.storage_oauth_codes import OAuthWorkspaceUnavailable
+
+
+def _challenge(verifier: str) -> str:
+    return (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest())
+        .decode("ascii")
+        .rstrip("=")
+    )
+
+
+def _grant(store: InMemoryStore) -> tuple[str, str, str]:
+    user = store.ensure_user("atomic-oauth@example.com")
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    verifier = "atomic-verifier-" + "a" * 43
+    raw_code, _code = store.create_oauth_authorization_code(
+        workspace_id=workspace.id,
+        user_id=user.id,
+        callback_url="https://atomic.example.com/cb",
+        key_label="atomic test",
+        ttl_seconds=300,
+        app_id=10,
+        code_challenge=_challenge(verifier),
+        code_challenge_method="S256",
+    )
+    return raw_code, verifier, workspace.id
+
+
+def test_memory_atomic_oauth_exchange_has_one_winner_under_forced_race() -> None:
+    store = InMemoryStore()
+    raw_code, verifier, workspace_id = _grant(store)
+    callers = 16
+    ready = threading.Barrier(callers)
+
+    def exchange(_index: int):
+        ready.wait(timeout=10)
+        return store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=verifier,
+            code_challenge_method="S256",
+        )
+
+    with ThreadPoolExecutor(max_workers=callers) as executor:
+        results = list(executor.map(exchange, range(callers)))
+
+    winners = [result for result in results if result is not None]
+    assert len(winners) == 1
+    winner = winners[0]
+    keys = store.list_keys(workspace_id)
+    assert len(keys) == 1
+    assert keys[0].hash == winner.api_key.hash
+    assert keys[0].management is False
+    assert raw_code not in json.dumps(store.oauth_code_store.codes, default=vars)
+    assert winner.raw_key not in json.dumps(keys[0].__dict__)
+
+
+def test_memory_key_build_failure_leaves_grant_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = InMemoryStore()
+    raw_code, verifier, workspace_id = _grant(store)
+    original = storage_oauth_codes.new_oauth_delegated_api_key
+
+    def fail_key_build(_code):
+        raise RuntimeError("key generator unavailable")
+
+    monkeypatch.setattr(
+        storage_oauth_codes,
+        "new_oauth_delegated_api_key",
+        fail_key_build,
+    )
+    with pytest.raises(RuntimeError, match="key generator unavailable"):
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=verifier,
+            code_challenge_method="S256",
+        )
+
+    assert store.list_keys(workspace_id) == []
+    assert store.oauth_code_store.code_ids_by_lookup_hash
+    code = next(iter(store.oauth_code_store.codes.values()))
+    assert code.consumed_at is None
+
+    monkeypatch.setattr(
+        storage_oauth_codes,
+        "new_oauth_delegated_api_key",
+        original,
+    )
+    retry = store.exchange_oauth_authorization_code(
+        raw_code,
+        code_verifier=verifier,
+        code_challenge_method="S256",
+    )
+    assert retry is not None
+    assert len(store.list_keys(workspace_id)) == 1
+
+
+def test_memory_partial_index_failure_rolls_back_key_and_consumption() -> None:
+    store = InMemoryStore()
+    raw_code, verifier, workspace_id = _grant(store)
+
+    class BrokenIndex(dict[str, str]):
+        def __setitem__(self, key: str, value: str) -> None:
+            raise RuntimeError("index write failed")
+
+    store.oauth_code_store._api_key_ids_by_lookup_hash = BrokenIndex()  # noqa: SLF001
+    with pytest.raises(RuntimeError, match="index write failed"):
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=verifier,
+            code_challenge_method="S256",
+        )
+
+    assert store.list_keys(workspace_id) == []
+    code = next(iter(store.oauth_code_store.codes.values()))
+    assert code.consumed_at is None
+
+    store.oauth_code_store._api_key_ids_by_lookup_hash = (  # noqa: SLF001
+        store.api_keys.key_ids_by_lookup_hash
+    )
+    assert (
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=verifier,
+            code_challenge_method="S256",
+        )
+        is not None
+    )
+
+
+def test_memory_missing_workspace_does_not_consume_grant() -> None:
+    store = InMemoryStore()
+    raw_code, verifier, workspace_id = _grant(store)
+    workspace = store.workspaces.pop(workspace_id)
+
+    with pytest.raises(OAuthWorkspaceUnavailable):
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=verifier,
+            code_challenge_method="S256",
+        )
+
+    assert store.oauth_code_store.codes
+    assert next(iter(store.oauth_code_store.codes.values())).consumed_at is None
+    assert store.list_keys(workspace_id) == []
+
+    store.workspaces[workspace_id] = workspace
+    assert (
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=verifier,
+            code_challenge_method="S256",
+        )
+        is not None
+    )

--- a/tests/test_oauth_key_delegation.py
+++ b/tests/test_oauth_key_delegation.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+from collections.abc import Iterator
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 from urllib.parse import parse_qs, urlsplit
@@ -13,7 +15,17 @@ from fastapi.testclient import TestClient
 from tests.fakes.spanner import make_fake_store
 from trusted_router.config import Settings
 from trusted_router.main import create_app
+from trusted_router.routes import oauth_keys as oauth_key_routes
 from trusted_router.storage import STORE, InMemoryStore
+
+
+@pytest.fixture(autouse=True)
+def _reset_oauth_exchange_limiter() -> Iterator[None]:
+    oauth_key_routes._OAUTH_EXCHANGE_RATE_LIMITS.reset()
+    oauth_key_routes._OAUTH_EXCHANGE_GLOBAL_RATE_LIMITS.reset()
+    yield
+    oauth_key_routes._OAUTH_EXCHANGE_RATE_LIMITS.reset()
+    oauth_key_routes._OAUTH_EXCHANGE_GLOBAL_RATE_LIMITS.reset()
 
 
 def _pkce_challenge(verifier: str) -> str:
@@ -164,11 +176,25 @@ def test_oauth_code_exchange_rejects_wrong_pkce_verifier(
 ) -> None:
     code, _ = _create_code(client, user_headers, verifier="correct-" + "c" * 43)
 
-    response = client.post("/v1/auth/keys", json={"code": code, "code_verifier": "wrong-" + "d" * 43})
+    response = client.post(
+        "/v1/auth/keys",
+        json={"code": code, "code_verifier": "wrong-" + "d" * 43},
+    )
 
     assert response.status_code == 403
     assert response.json()["error"]["message"] == "Invalid code_verifier"
-    assert not STORE.list_keys(STORE.find_user_by_email("alice@example.com").id)
+    alice = STORE.find_user_by_email("alice@example.com")
+    assert alice is not None
+    workspace = STORE.list_workspaces_for_user(alice.id)[0]
+    assert STORE.list_keys(workspace.id) == []
+
+    retry = client.post(
+        "/v1/auth/keys",
+        json={"code": code, "code_verifier": "correct-" + "c" * 43},
+    )
+
+    assert retry.status_code == 200, retry.text
+    assert len(STORE.list_keys(workspace.id)) == 1
 
 
 def test_oauth_plain_pkce_exchange(
@@ -218,6 +244,63 @@ def test_oauth_code_exchange_rejects_method_mismatch(
     assert response.status_code == 400
     assert response.json()["error"]["message"] == "code_challenge_method does not match authorization code"
 
+    retry = client.post(
+        "/v1/auth/keys",
+        json={
+            "code": code,
+            "code_verifier": verifier,
+            "code_challenge_method": "plain",
+        },
+    )
+
+    assert retry.status_code == 200, retry.text
+
+
+def test_oauth_code_exchange_missing_verifier_does_not_consume_code(
+    client: TestClient,
+    user_headers: dict[str, str],
+) -> None:
+    verifier = "required-verifier-" + "r" * 43
+    code, _ = _create_code(client, user_headers, verifier=verifier)
+
+    missing = client.post("/v1/auth/keys", json={"code": code})
+    retry = client.post(
+        "/v1/auth/keys",
+        json={"code": code, "code_verifier": verifier},
+    )
+
+    assert missing.status_code == 400
+    assert missing.json()["error"]["message"] == "code_verifier is required"
+    assert retry.status_code == 200, retry.text
+
+
+def test_oauth_code_exchange_paused_workspace_can_retry_after_resume(
+    client: TestClient,
+    user_headers: dict[str, str],
+) -> None:
+    code, _ = _create_code(
+        client,
+        user_headers,
+        code_challenge=None,
+        code_challenge_method=None,
+    )
+    alice = STORE.find_user_by_email("alice@example.com")
+    assert alice is not None
+    workspace = STORE.list_workspaces_for_user(alice.id)[0]
+    STORE.update_workspace(workspace.id, billing_paused=True)
+
+    paused = client.post("/v1/auth/keys", json={"code": code})
+
+    assert paused.status_code == 503
+    assert paused.headers["retry-after"] == "30"
+    assert STORE.list_keys(workspace.id) == []
+
+    STORE.update_workspace(workspace.id, billing_paused=False)
+    retry = client.post("/v1/auth/keys", json={"code": code})
+
+    assert retry.status_code == 200, retry.text
+    assert len(STORE.list_keys(workspace.id)) == 1
+
 
 def test_oauth_code_exchange_requires_code(client: TestClient) -> None:
     response = client.post("/v1/auth/keys", json={})
@@ -226,11 +309,288 @@ def test_oauth_code_exchange_requires_code(client: TestClient) -> None:
     assert response.json()["error"]["message"] == "code is required"
 
 
-def test_oauth_code_exchange_rejects_unknown_code(client: TestClient) -> None:
+def test_oauth_code_exchange_rejects_malformed_code_before_store(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store_reads = 0
+
+    def forbidden_exchange(
+        _self: InMemoryStore,
+        _raw_code: str,
+        **_kwargs: Any,
+    ) -> None:
+        nonlocal store_reads
+        store_reads += 1
+        raise AssertionError("malformed code reached the Store")
+
+    monkeypatch.setattr(
+        InMemoryStore,
+        "exchange_oauth_authorization_code",
+        forbidden_exchange,
+    )
     response = client.post("/v1/auth/keys", json={"code": "auth_code-missing"})
 
     assert response.status_code == 403
     assert response.json()["error"]["message"] == "Invalid or expired authorization code"
+    assert store_reads == 0
+
+
+def test_oauth_code_exchange_offloads_store_transaction(
+    client: TestClient,
+    user_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    code, _ = _create_code(
+        client,
+        user_headers,
+        code_challenge=None,
+        code_challenge_method=None,
+    )
+    offloaded: list[object] = []
+
+    async def recorded_threadpool(func, *args):
+        offloaded.append(func)
+        return func(*args)
+
+    monkeypatch.setattr(oauth_key_routes, "run_in_threadpool", recorded_threadpool)
+
+    response = client.post("/v1/auth/keys", json={"code": code})
+
+    assert response.status_code == 200, response.text
+    assert offloaded == [oauth_key_routes._exchange_oauth_code]
+
+
+def test_oauth_code_exchange_refuses_when_store_slots_are_full(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store_reads = 0
+
+    def forbidden_exchange(
+        _self: InMemoryStore,
+        _raw_code: str,
+        **_kwargs: Any,
+    ) -> None:
+        nonlocal store_reads
+        store_reads += 1
+        raise AssertionError("busy OAuth exchange reached the Store")
+
+    monkeypatch.setattr(
+        InMemoryStore,
+        "exchange_oauth_authorization_code",
+        forbidden_exchange,
+    )
+    acquired = 0
+    try:
+        for _ in range(4):
+            assert oauth_key_routes._OAUTH_EXCHANGE_SLOTS.acquire(blocking=False)
+            acquired += 1
+
+        response = client.post(
+            "/v1/auth/keys",
+            json={"code": "auth_code-" + "a" * 43},
+        )
+    finally:
+        for _ in range(acquired):
+            oauth_key_routes._OAUTH_EXCHANGE_SLOTS.release()
+
+    assert response.status_code == 429
+    assert response.headers["retry-after"] == "1"
+    assert store_reads == 0
+
+
+def test_oauth_code_exchange_rate_denial_releases_slot_and_keeps_cors(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store_reads = 0
+
+    def forbidden_exchange(
+        _self: InMemoryStore,
+        _raw_code: str,
+        **_kwargs: Any,
+    ) -> None:
+        nonlocal store_reads
+        store_reads += 1
+        raise AssertionError("rate-limited OAuth exchange reached the Store")
+
+    monkeypatch.setattr(
+        InMemoryStore,
+        "exchange_oauth_authorization_code",
+        forbidden_exchange,
+    )
+    monkeypatch.setattr(
+        oauth_key_routes._OAUTH_EXCHANGE_RATE_LIMITS,
+        "hit",
+        lambda **_kwargs: SimpleNamespace(allowed=False, retry_after_seconds=17),
+    )
+
+    response = client.post(
+        "/v1/auth/keys",
+        headers={"origin": "https://web.lorehex.co"},
+        json={"code": "auth_code-" + "a" * 43},
+    )
+
+    assert response.status_code == 429
+    assert response.headers["retry-after"] == "17"
+    assert response.headers["access-control-allow-origin"] == "*"
+    assert store_reads == 0
+    assert oauth_key_routes._OAUTH_EXCHANGE_SLOTS.acquire(blocking=False)
+    oauth_key_routes._OAUTH_EXCHANGE_SLOTS.release()
+
+
+def test_oauth_code_exchange_one_source_cannot_throttle_another(
+    client: TestClient,
+    user_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    verifier = "isolated-source-verifier-" + "i" * 43
+    code, _ = _create_code(client, user_headers, verifier=verifier)
+    monkeypatch.setattr(oauth_key_routes, "_OAUTH_EXCHANGE_PER_SOURCE_LIMIT", 2)
+    monkeypatch.setattr(
+        oauth_key_routes,
+        "normalized_client_identity",
+        lambda request, _settings: request.headers.get("x-test-source", "unknown"),
+    )
+
+    attacker_headers = {"x-test-source": "attacker"}
+    invalid_code = "auth_code-" + "a" * 43
+    assert client.post(
+        "/v1/auth/keys",
+        headers=attacker_headers,
+        json={"code": invalid_code},
+    ).status_code == 403
+    assert client.post(
+        "/v1/auth/keys",
+        headers=attacker_headers,
+        json={"code": invalid_code},
+    ).status_code == 403
+    denied = client.post(
+        "/v1/auth/keys",
+        headers=attacker_headers,
+        json={"code": invalid_code},
+    )
+
+    assert denied.status_code == 429
+    victim = client.post(
+        "/v1/auth/keys",
+        headers={"x-test-source": "victim"},
+        json={"code": code, "code_verifier": verifier},
+    )
+    assert victim.status_code == 200, victim.text
+    stored_subjects = {
+        key[1] for key in oauth_key_routes._OAUTH_EXCHANGE_RATE_LIMITS.buckets
+    }
+    assert oauth_key_routes.fingerprint_subject("attacker") in stored_subjects
+    assert oauth_key_routes.fingerprint_subject("victim") in stored_subjects
+    assert "attacker" not in stored_subjects
+    assert "victim" not in stored_subjects
+
+
+def test_oauth_code_exchange_global_denial_releases_slot(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        oauth_key_routes._OAUTH_EXCHANGE_RATE_LIMITS,
+        "hit",
+        lambda **_kwargs: SimpleNamespace(allowed=True, retry_after_seconds=0),
+    )
+    monkeypatch.setattr(
+        oauth_key_routes._OAUTH_EXCHANGE_GLOBAL_RATE_LIMITS,
+        "hit",
+        lambda **_kwargs: SimpleNamespace(allowed=False, retry_after_seconds=23),
+    )
+
+    response = client.post(
+        "/v1/auth/keys",
+        json={"code": "auth_code-" + "g" * 43},
+    )
+
+    assert response.status_code == 429
+    assert response.headers["retry-after"] == "23"
+    acquired = 0
+    try:
+        for _ in range(4):
+            assert oauth_key_routes._OAUTH_EXCHANGE_SLOTS.acquire(blocking=False)
+            acquired += 1
+    finally:
+        for _ in range(acquired):
+            oauth_key_routes._OAUTH_EXCHANGE_SLOTS.release()
+
+
+def test_oauth_code_exchange_honors_disabled_rate_limiting(
+    test_settings: Settings,
+    user_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_limit(**_kwargs):
+        raise AssertionError("disabled OAuth limiter was called")
+
+    monkeypatch.setattr(
+        oauth_key_routes._OAUTH_EXCHANGE_RATE_LIMITS,
+        "hit",
+        unexpected_limit,
+    )
+    monkeypatch.setattr(
+        oauth_key_routes._OAUTH_EXCHANGE_GLOBAL_RATE_LIMITS,
+        "hit",
+        unexpected_limit,
+    )
+    settings = test_settings.model_copy(update={"rate_limit_enabled": False})
+    with TestClient(create_app(settings, init_observability=False)) as disabled_client:
+        verifier = "disabled-limiter-verifier-" + "d" * 43
+        code, _ = _create_code(disabled_client, user_headers, verifier=verifier)
+        response = disabled_client.post(
+            "/v1/auth/keys",
+            json={"code": code, "code_verifier": verifier},
+        )
+
+    assert response.status_code == 200, response.text
+
+
+@pytest.mark.parametrize(
+    "limiter_name",
+    ["_OAUTH_EXCHANGE_RATE_LIMITS", "_OAUTH_EXCHANGE_GLOBAL_RATE_LIMITS"],
+)
+def test_oauth_code_exchange_limiter_failure_releases_slot(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    limiter_name: str,
+) -> None:
+    def limiter_failure(**_kwargs):
+        raise RuntimeError("limiter unavailable")
+
+    if limiter_name == "_OAUTH_EXCHANGE_GLOBAL_RATE_LIMITS":
+        monkeypatch.setattr(
+            oauth_key_routes._OAUTH_EXCHANGE_RATE_LIMITS,
+            "hit",
+            lambda **_kwargs: SimpleNamespace(
+                allowed=True,
+                retry_after_seconds=0,
+            ),
+        )
+    monkeypatch.setattr(
+        getattr(oauth_key_routes, limiter_name),
+        "hit",
+        limiter_failure,
+    )
+
+    with pytest.raises(RuntimeError, match="limiter unavailable"):
+        client.post(
+            "/v1/auth/keys",
+            json={"code": "auth_code-" + "b" * 43},
+        )
+
+    acquired = 0
+    try:
+        for _ in range(4):
+            assert oauth_key_routes._OAUTH_EXCHANGE_SLOTS.acquire(blocking=False)
+            acquired += 1
+    finally:
+        for _ in range(acquired):
+            oauth_key_routes._OAUTH_EXCHANGE_SLOTS.release()
 
 
 def test_oauth_key_exchange_has_browser_cors_preflight(client: TestClient) -> None:
@@ -279,12 +639,18 @@ def test_oauth_code_exchange_rejects_non_ascii_verifier(
     client: TestClient,
     user_headers: dict[str, str],
 ) -> None:
-    code, _ = _create_code(client, user_headers, verifier="ascii-" + "g" * 43)
+    verifier = "ascii-" + "g" * 43
+    code, _ = _create_code(client, user_headers, verifier=verifier)
 
     response = client.post("/v1/auth/keys", json={"code": code, "code_verifier": "not-ascii-é"})
 
     assert response.status_code == 400
     assert response.json()["error"]["message"] == "code_verifier must be ASCII"
+    retry = client.post(
+        "/v1/auth/keys",
+        json={"code": code, "code_verifier": verifier},
+    )
+    assert retry.status_code == 200, retry.text
 
 
 def test_oauth_code_creation_requires_management_auth(client: TestClient) -> None:

--- a/tests/test_pearl_provider.py
+++ b/tests/test_pearl_provider.py
@@ -229,5 +229,8 @@ def test_pearl_hourly_refresh_and_secret_wiring_are_complete() -> None:
         'ensure_secret_from_env_file "PEARL_RESEARCH_API_KEY" '
         '"trustedrouter-pearl-api-key"'
     ) in secrets
-    assert 'grant_tr_deploy_secret_access "trustedrouter-pearl-api-key"' in secrets
+    assert (
+        "trustedrouter-pearl-api-key"
+        in secrets.split("DETACHED_PROVIDER_SECRET_NAMES=(", 1)[1].split(")", 1)[0]
+    )
     assert "PEARL_RESEARCH_API_KEY:trustedrouter-pearl-api-key" in workflow

--- a/tests/test_postgres_chat_browser_key.py
+++ b/tests/test_postgres_chat_browser_key.py
@@ -1,0 +1,74 @@
+"""Postgres browser-key issuance executes atomically on the real SQL shape."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+from tests.fakes.postgres import (
+    SqlitePostgresConn,
+    postgres_store_on,
+    sqlite_postgres_conn,
+)
+from trusted_router.storage_models import ApiKey, Workspace
+from trusted_router.storage_postgres import PostgresStore
+
+
+def _store() -> tuple[PostgresStore, SqlitePostgresConn, Workspace]:
+    conn = sqlite_postgres_conn()
+    store = postgres_store_on(conn)
+    workspace = Workspace(id="ws-chat-browser", name="Chat", owner_user_id="user-chat")
+    store._run_transaction(  # noqa: SLF001 - backend SQL harness.
+        lambda transaction: store._write_entity_tx(  # noqa: SLF001
+            transaction,
+            "workspace",
+            workspace.id,
+            workspace,
+        )
+    )
+    return store, conn, workspace
+
+
+def _issue(store: PostgresStore, workspace: Workspace) -> tuple[str, ApiKey] | None:
+    return store.issue_chat_browser_key(
+        workspace_id=workspace.id,
+        name="chat-browser-postgres",
+        creator_user_id=workspace.owner_user_id,
+        limit_microdollars=5_000_000,
+        expires_at=(dt.datetime.now(dt.UTC) + dt.timedelta(days=30)).isoformat(),
+        active_key_cap=1,
+    )
+
+
+def test_postgres_chat_browser_cap_refusal_writes_nothing() -> None:
+    store, conn, workspace = _store()
+    first = _issue(store, workspace)
+    assert first is not None
+    raw, key = first
+    assert store.get_key_by_raw(raw) is not None
+    assert key.management is False
+    before = {
+        kind: conn.count_entities(kind)
+        for kind in ("api_key", "api_key_lookup", "api_key_by_workspace")
+    }
+
+    refused = _issue(store, workspace)
+
+    assert refused is None
+    assert {
+        kind: conn.count_entities(kind)
+        for kind in ("api_key", "api_key_lookup", "api_key_by_workspace")
+    } == before
+
+
+def test_postgres_chat_browser_partial_create_rolls_back() -> None:
+    store, conn, workspace = _store()
+    conn.fail_on = "INSERT INTO tr_key_limit"
+
+    with pytest.raises(RuntimeError, match="connection reset"):
+        _issue(store, workspace)
+
+    assert conn.count_entities("api_key") == 0
+    assert conn.count_entities("api_key_lookup") == 0
+    assert conn.count_entities("api_key_by_workspace") == 0

--- a/tests/test_postgres_oauth_atomic_exchange.py
+++ b/tests/test_postgres_oauth_atomic_exchange.py
@@ -1,0 +1,274 @@
+"""Postgres OAuth exchange runs on one real SQL transaction and rolls back."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from typing import Any
+
+import pytest
+
+from tests.fakes.postgres import (
+    SqlitePostgresConn,
+    postgres_store_on,
+    sqlite_postgres_conn,
+)
+from trusted_router.storage_models import User, Workspace
+from trusted_router.storage_oauth_codes import (
+    OAuthCodeMethodMismatch,
+    OAuthCodeVerifierMismatch,
+    OAuthWorkspaceBillingPaused,
+    OAuthWorkspaceUnavailable,
+)
+from trusted_router.storage_postgres import PostgresStore
+
+
+def _challenge(verifier: str) -> str:
+    return (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest())
+        .decode("ascii")
+        .rstrip("=")
+    )
+
+
+def _store(
+    *,
+    billing_paused: bool = False,
+    pkce_method: str | None = "S256",
+) -> tuple[PostgresStore, SqlitePostgresConn, str, str, str]:
+    conn = sqlite_postgres_conn()
+    store = postgres_store_on(conn)
+    user = User(id="user-oauth-postgres", email="oauth-postgres@example.com")
+    workspace = Workspace(
+        id="ws-oauth-postgres",
+        name="OAuth Postgres",
+        owner_user_id=user.id,
+        billing_paused=billing_paused,
+    )
+
+    def seed(transaction: Any) -> None:
+        store._write_entity_tx(transaction, "user", user.id, user)  # noqa: SLF001
+        store._write_entity_tx(  # noqa: SLF001
+            transaction,
+            "workspace",
+            workspace.id,
+            workspace,
+        )
+
+    store._run_transaction(seed)  # noqa: SLF001
+    verifier = "postgres-verifier-" + "p" * 43
+    challenge = None
+    if pkce_method == "plain":
+        challenge = verifier
+    elif pkce_method == "S256":
+        challenge = _challenge(verifier)
+    raw_code, _code = store.create_oauth_authorization_code(
+        workspace_id=workspace.id,
+        user_id=user.id,
+        callback_url="https://postgres-atomic.example.com/cb",
+        key_label="Postgres atomic OAuth",
+        ttl_seconds=300,
+        app_id=30,
+        limit_microdollars=9_000_000,
+        limit_reset="weekly",
+        code_challenge=challenge,
+        code_challenge_method=pkce_method,
+    )
+    return store, conn, raw_code, verifier, workspace.id
+
+
+def _typed_key_count(conn: SqlitePostgresConn) -> int:
+    return int(conn._raw.execute("SELECT count(*) FROM tr_key_limit").fetchone()[0])  # noqa: SLF001
+
+
+def test_postgres_oauth_partial_key_create_rolls_back_and_can_retry() -> None:
+    store, conn, raw_code, verifier, workspace_id = _store()
+    conn.fail_on = "INSERT INTO tr_key_limit"
+
+    with pytest.raises(RuntimeError, match="connection reset"):
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=verifier,
+            code_challenge_method="S256",
+        )
+
+    assert conn.count_entities("api_key") == 0
+    assert conn.count_entities("api_key_lookup") == 0
+    assert conn.count_entities("api_key_by_workspace") == 0
+    assert _typed_key_count(conn) == 0
+    code_body = conn._raw.execute(  # noqa: SLF001
+        "SELECT body FROM tr_entities WHERE kind = ?",
+        ("oauth_code",),
+    ).fetchone()[0]
+    assert json.loads(code_body).get("consumed_at") is None
+
+    conn.fail_on = None
+    retry = store.exchange_oauth_authorization_code(
+        raw_code,
+        code_verifier=verifier,
+        code_challenge_method="S256",
+    )
+
+    assert retry is not None
+    assert retry.api_key.workspace_id == workspace_id
+    assert retry.api_key.management is False
+    assert conn.count_entities("api_key") == 1
+    assert conn.count_entities("api_key_lookup") == 1
+    assert conn.count_entities("api_key_by_workspace") == 1
+    assert _typed_key_count(conn) == 1
+    assert store.get_key_by_raw(retry.raw_key) is not None
+
+
+def test_postgres_success_persists_hashes_only_and_replay_creates_no_key() -> None:
+    store, conn, raw_code, verifier, _workspace_id = _store()
+
+    first = store.exchange_oauth_authorization_code(
+        raw_code,
+        code_verifier=verifier,
+        code_challenge_method="S256",
+    )
+    replay = store.exchange_oauth_authorization_code(
+        raw_code,
+        code_verifier=verifier,
+        code_challenge_method="S256",
+    )
+
+    assert first is not None
+    assert replay is None
+    assert conn.count_entities("api_key") == 1
+    durable_bodies = [
+        row[0]
+        for row in conn._raw.execute(  # noqa: SLF001
+            "SELECT body FROM tr_entities"
+        ).fetchall()
+    ]
+    durable_json = json.dumps(durable_bodies)
+    assert raw_code not in durable_json
+    assert first.raw_key not in durable_json
+
+
+@pytest.mark.parametrize("method", [None, "plain", "S256"])
+def test_postgres_oauth_supports_no_pkce_plain_and_s256(method: str | None) -> None:
+    store, _conn, raw_code, verifier, _workspace_id = _store(pkce_method=method)
+
+    result = store.exchange_oauth_authorization_code(
+        raw_code,
+        code_verifier=verifier if method else None,
+        code_challenge_method=method,
+    )
+
+    assert result is not None
+    assert result.api_key.management is False
+
+
+def test_postgres_wrong_pkce_proofs_do_not_consume_grant() -> None:
+    store, conn, raw_code, verifier, _workspace_id = _store()
+
+    with pytest.raises(OAuthCodeMethodMismatch):
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=verifier,
+            code_challenge_method="plain",
+        )
+    with pytest.raises(OAuthCodeVerifierMismatch):
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier="wrong-" + "x" * 43,
+            code_challenge_method="S256",
+        )
+
+    assert conn.count_entities("api_key") == 0
+    assert _typed_key_count(conn) == 0
+    assert (
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=verifier,
+            code_challenge_method="S256",
+        )
+        is not None
+    )
+
+
+def test_postgres_paused_workspace_keeps_grant_retryable() -> None:
+    store, conn, raw_code, verifier, workspace_id = _store(billing_paused=True)
+
+    with pytest.raises(OAuthWorkspaceBillingPaused):
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=verifier,
+            code_challenge_method="S256",
+        )
+
+    assert conn.count_entities("api_key") == 0
+    assert _typed_key_count(conn) == 0
+
+    def resume(transaction: Any) -> None:
+        workspace = store._read_entity_tx(  # noqa: SLF001
+            transaction,
+            "workspace",
+            workspace_id,
+            Workspace,
+            for_update=True,
+        )
+        assert workspace is not None
+        workspace.billing_paused = False
+        store._write_entity_tx(  # noqa: SLF001
+            transaction,
+            "workspace",
+            workspace.id,
+            workspace,
+        )
+
+    store._run_transaction(resume)  # noqa: SLF001
+    assert (
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=verifier,
+            code_challenge_method="S256",
+        )
+        is not None
+    )
+
+
+def test_postgres_missing_workspace_keeps_grant_retryable() -> None:
+    store, conn, raw_code, verifier, workspace_id = _store()
+    workspace = store._read_entity("workspace", workspace_id, Workspace)  # noqa: SLF001
+    assert workspace is not None
+    store._run_transaction(  # noqa: SLF001
+        lambda transaction: store._delete_entity_tx(  # noqa: SLF001
+            transaction,
+            "workspace",
+            workspace_id,
+        )
+    )
+
+    with pytest.raises(OAuthWorkspaceUnavailable):
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=verifier,
+            code_challenge_method="S256",
+        )
+
+    code_body = conn._raw.execute(  # noqa: SLF001
+        "SELECT body FROM tr_entities WHERE kind = ?",
+        ("oauth_code",),
+    ).fetchone()[0]
+    assert json.loads(code_body).get("consumed_at") is None
+    assert conn.count_entities("api_key") == 0
+    store._run_transaction(  # noqa: SLF001
+        lambda transaction: store._write_entity_tx(  # noqa: SLF001
+            transaction,
+            "workspace",
+            workspace_id,
+            workspace,
+        )
+    )
+    assert (
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=verifier,
+            code_challenge_method="S256",
+        )
+        is not None
+    )

--- a/tests/test_provider_wave2_catalogs.py
+++ b/tests/test_provider_wave2_catalogs.py
@@ -324,5 +324,8 @@ def test_wave2_hourly_refresh_and_secret_wiring_are_complete() -> None:
         "STREAMLAKE_API_KEY": "trustedrouter-streamlake-api-key",
     }.items():
         assert f'ensure_secret_from_env_file "{env_name}" "{secret_name}"' in secrets
-        assert f'grant_tr_deploy_secret_access "{secret_name}"' in secrets
+        assert (
+            secret_name
+            in secrets.split("DETACHED_PROVIDER_SECRET_NAMES=(", 1)[1].split(")", 1)[0]
+        )
         assert f"{env_name}:{secret_name}" in workflow

--- a/tests/test_public_user_models_cache.py
+++ b/tests/test_public_user_models_cache.py
@@ -1,0 +1,473 @@
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from urllib.parse import quote
+
+import pytest
+from fastapi.testclient import TestClient
+
+import trusted_router.public_user_models as public_cache
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.storage import InMemoryStore
+from trusted_router.storage_models import UserProvidedModel
+
+
+class _Clock:
+    def __init__(self, now: float = 1_000.0) -> None:
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest.fixture(autouse=True)
+def _isolated_public_cache() -> Iterator[None]:
+    public_cache.reset_public_user_model_cache()
+    yield
+    public_cache.reset_public_user_model_cache()
+
+
+def _model(
+    suffix: str,
+    *,
+    name: str | None = None,
+    description: str = "",
+) -> UserProvidedModel:
+    return UserProvidedModel(
+        id=f"trustedrouter/user-{suffix}",
+        owner_user_id="owner",
+        owner_workspace_id="workspace",
+        name=name or f"Public model {suffix}",
+        description=description,
+        display_name="community-operator",
+        kind="machine",
+    )
+
+
+def _client(*, raise_server_exceptions: bool = True) -> TestClient:
+    return TestClient(
+        create_app(Settings(environment="test"), init_observability=False),
+        raise_server_exceptions=raise_server_exceptions,
+    )
+
+
+def test_list_and_detail_cache_hits_repeat_zero_store_work_within_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = _model("cache-hit")
+    calls = {"list": 0, "detail": 0, "owner": 0}
+
+    def list_models(
+        _self: InMemoryStore,
+        *,
+        kind: str | None = None,
+        limit: int | None = None,
+    ) -> list[UserProvidedModel]:
+        calls["list"] += 1
+        assert kind is None
+        assert limit == public_cache.PUBLIC_USER_MODEL_LIST_LIMIT
+        return [model]
+
+    def get_model(_self: InMemoryStore, model_id: str) -> UserProvidedModel | None:
+        calls["detail"] += 1
+        assert model_id == model.id
+        return model
+
+    def get_owner(_self: InMemoryStore, user_id: str) -> None:
+        calls["owner"] += 1
+        assert user_id == model.owner_user_id
+        return None
+
+    monkeypatch.setattr(InMemoryStore, "list_public_user_models", list_models)
+    monkeypatch.setattr(InMemoryStore, "get_user_model", get_model)
+    monkeypatch.setattr(InMemoryStore, "get_user", get_owner)
+    client = _client()
+
+    first_list = client.get("/v1/models/user-provided")
+    assert first_list.status_code == 200
+    after_first_list = calls.copy()
+    assert after_first_list == {"list": 1, "detail": 0, "owner": 1}
+
+    second_list = client.get("/v1/models/user-provided")
+    assert second_list.status_code == 200
+    assert second_list.json() == first_list.json()
+    assert calls == after_first_list
+
+    first_detail = client.get(f"/v1/models/user-provided/{model.id}")
+    assert first_detail.status_code == 200
+    after_first_detail = calls.copy()
+    assert after_first_detail == {"list": 1, "detail": 1, "owner": 2}
+
+    second_detail = client.get(f"/v1/models/user-provided/{model.id}")
+    assert second_detail.status_code == 200
+    assert second_detail.json() == first_detail.json()
+    assert calls == after_first_detail
+
+
+@pytest.mark.parametrize("cache_kind", ("list", "detail"))
+def test_concurrent_cache_miss_collapses_to_one_loader(
+    cache_kind: str,
+) -> None:
+    workers = 8
+    start = threading.Barrier(workers + 1)
+    loader_entered = threading.Event()
+    release_loader = threading.Event()
+    call_lock = threading.Lock()
+    loader_calls = 0
+    model = _model(f"singleflight-{cache_kind}")
+
+    def load_list(limit: int) -> list[UserProvidedModel]:
+        nonlocal loader_calls
+        assert limit == public_cache.PUBLIC_USER_MODEL_LIST_LIMIT
+        with call_lock:
+            loader_calls += 1
+        loader_entered.set()
+        assert release_loader.wait(timeout=5)
+        return [model]
+
+    def load_detail() -> UserProvidedModel:
+        nonlocal loader_calls
+        with call_lock:
+            loader_calls += 1
+        loader_entered.set()
+        assert release_loader.wait(timeout=5)
+        return model
+
+    def invoke() -> object:
+        start.wait(timeout=5)
+        if cache_kind == "list":
+            return public_cache.cached_public_user_model_list(None, load_list)
+        return public_cache.cached_public_user_model(model.id, load_detail)
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = [executor.submit(invoke) for _ in range(workers)]
+        start.wait(timeout=5)
+        try:
+            assert loader_entered.wait(timeout=5)
+        finally:
+            release_loader.set()
+        results = [future.result(timeout=5) for future in futures]
+
+    assert loader_calls == 1
+    assert all(result == results[0] for result in results)
+
+
+def test_stale_list_loader_failure_has_sequential_failure_backoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _Clock()
+    monkeypatch.setattr(public_cache.time, "monotonic", clock)
+    model = _model("stale-list", name="Last known good")
+    loader_calls = 0
+    outage = False
+
+    def loader(limit: int) -> list[UserProvidedModel]:
+        nonlocal loader_calls
+        loader_calls += 1
+        assert limit == public_cache.PUBLIC_USER_MODEL_LIST_LIMIT
+        if outage:
+            raise RuntimeError("store unavailable")
+        return [model]
+
+    initial = public_cache.cached_public_user_model_list("machine", loader)
+    assert loader_calls == 1
+    clock.advance(public_cache.PUBLIC_USER_MODEL_FRESH_SECONDS + 0.1)
+    outage = True
+
+    first_stale = public_cache.cached_public_user_model_list("machine", loader)
+    assert first_stale == initial
+    assert loader_calls == 2
+
+    clock.advance(public_cache.PUBLIC_USER_MODEL_FAILURE_BACKOFF_SECONDS - 0.01)
+    second_stale = public_cache.cached_public_user_model_list("machine", loader)
+    assert second_stale == initial
+    assert loader_calls == 2
+
+    clock.advance(0.02)
+    third_stale = public_cache.cached_public_user_model_list("machine", loader)
+    assert third_stale == initial
+    assert loader_calls == 3
+
+
+def test_detail_admission_exhaustion_serves_valid_stale_without_overwriting_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _Clock()
+    monkeypatch.setattr(public_cache.time, "monotonic", clock)
+    old_model = _model("stale-detail", name="Last known good")
+    new_model = _model("stale-detail", name="Recovered value")
+
+    initial = public_cache.cached_public_user_model(old_model.id, lambda: old_model)
+    assert initial is not None and initial["name"] == "Last known good"
+    clock.advance(public_cache.PUBLIC_USER_MODEL_FRESH_SECONDS + 0.1)
+
+    for index in range(public_cache.PUBLIC_USER_MODEL_MISS_BUDGET):
+        model_id = f"trustedrouter/user-budget-burn-{index:02d}"
+        assert public_cache.cached_public_user_model(model_id, lambda: None) is None
+
+    entry_before = public_cache._DETAIL_CACHE[old_model.id]
+    stale_loader_calls = 0
+
+    def should_not_load_while_limited() -> UserProvidedModel:
+        nonlocal stale_loader_calls
+        stale_loader_calls += 1
+        return new_model
+
+    limited_result = public_cache.cached_public_user_model(
+        old_model.id,
+        should_not_load_while_limited,
+    )
+    assert limited_result is not None and limited_result["name"] == "Last known good"
+    assert stale_loader_calls == 0
+    assert public_cache._DETAIL_CACHE[old_model.id] is entry_before
+    assert public_cache._DETAIL_CACHE[old_model.id].value["name"] == "Last known good"
+
+    clock.advance(public_cache.PUBLIC_USER_MODEL_MISS_WINDOW_SECONDS + 0.1)
+    recovered = public_cache.cached_public_user_model(old_model.id, lambda: new_model)
+    assert recovered is not None and recovered["name"] == "Recovered value"
+
+
+def test_unique_valid_detail_ids_are_bounded_by_global_miss_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store_ids: list[str] = []
+
+    def missing_model(_self: InMemoryStore, model_id: str) -> None:
+        store_ids.append(model_id)
+        return None
+
+    monkeypatch.setattr(InMemoryStore, "get_user_model", missing_model)
+    client = _client()
+    statuses: list[int] = []
+    responses = []
+    total = public_cache.PUBLIC_USER_MODEL_MISS_BUDGET + 5
+
+    for index in range(total):
+        model_id = f"trustedrouter/user-budget-miss-{index:02d}"
+        response = client.get(f"/v1/models/user-provided/{model_id}")
+        responses.append(response)
+        statuses.append(response.status_code)
+
+    budget = public_cache.PUBLIC_USER_MODEL_MISS_BUDGET
+    assert statuses[:budget] == [404] * budget
+    assert statuses[budget:] == [429] * (total - budget)
+    assert len(store_ids) == budget
+    assert all(response.headers["cache-control"] == "no-store" for response in responses[budget:])
+    assert all(response.headers["retry-after"] == "30" for response in responses[budget:])
+
+
+def test_unique_valid_detail_ids_are_bounded_by_global_miss_concurrency() -> None:
+    extra = 2
+    total = public_cache.PUBLIC_USER_MODEL_MAX_CONCURRENT_MISSES + extra
+    start = threading.Barrier(total + 1)
+    all_slots_active = threading.Event()
+    extra_attempts_finished = threading.Event()
+    release = threading.Event()
+    state_lock = threading.Lock()
+    active = 0
+    finished_before_release = 0
+    max_active = 0
+    loader_calls = 0
+
+    def loader() -> None:
+        nonlocal active, loader_calls, max_active
+        with state_lock:
+            active += 1
+            loader_calls += 1
+            max_active = max(max_active, active)
+            if active == public_cache.PUBLIC_USER_MODEL_MAX_CONCURRENT_MISSES:
+                all_slots_active.set()
+        try:
+            assert release.wait(timeout=5)
+        finally:
+            with state_lock:
+                active -= 1
+        return None
+
+    def invoke(index: int) -> str:
+        nonlocal finished_before_release
+        start.wait(timeout=5)
+        try:
+            public_cache.cached_public_user_model(
+                f"trustedrouter/user-concurrent-miss-{index:02d}",
+                loader,
+            )
+        except public_cache.PublicUserModelReadLimited:
+            outcome = "limited"
+        else:
+            outcome = "loaded"
+        with state_lock:
+            finished_before_release += 1
+            if finished_before_release == extra:
+                extra_attempts_finished.set()
+        return outcome
+
+    with ThreadPoolExecutor(max_workers=total) as executor:
+        futures = [executor.submit(invoke, index) for index in range(total)]
+        start.wait(timeout=5)
+        try:
+            assert all_slots_active.wait(timeout=5)
+            # The admitted loaders remain blocked. Requiring the two excess
+            # calls to finish before releasing them makes the ceiling proof
+            # independent of thread scheduling order.
+            assert extra_attempts_finished.wait(timeout=5)
+        finally:
+            release.set()
+        outcomes = [future.result(timeout=5) for future in futures]
+
+    limit = public_cache.PUBLIC_USER_MODEL_MAX_CONCURRENT_MISSES
+    assert loader_calls == limit
+    assert max_active == limit
+    assert outcomes.count("loaded") == limit
+    assert outcomes.count("limited") == extra
+
+
+@pytest.mark.parametrize(
+    "invalid_id",
+    (
+        "openai/gpt-4",
+        "trustedrouter/user--leading-dash",
+        "trustedrouter/user-bad!",
+        "trustedrouter/user-bad/extra",
+    ),
+)
+def test_invalid_detail_ids_return_404_with_zero_model_store_work(
+    monkeypatch: pytest.MonkeyPatch,
+    invalid_id: str,
+) -> None:
+    store_calls = 0
+
+    def forbidden(*_args: object, **_kwargs: object) -> None:
+        nonlocal store_calls
+        store_calls += 1
+        raise AssertionError("invalid public model id reached Store")
+
+    monkeypatch.setattr(InMemoryStore, "get_user_model", forbidden)
+    monkeypatch.setattr(InMemoryStore, "get_user", forbidden)
+    client = _client()
+
+    encoded = quote(invalid_id, safe="/!")
+    response = client.get(f"/v1/models/user-provided/{encoded}")
+
+    assert response.status_code == 404
+    assert response.headers["cache-control"] == public_cache.PUBLIC_USER_MODEL_CACHE_CONTROL
+    assert store_calls == 0
+
+
+def test_list_route_bounds_rows_and_actual_serialized_response_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    limit = public_cache.PUBLIC_USER_MODEL_LIST_LIMIT
+    small_models = [_model(f"small-{index:03d}") for index in range(limit + 25)]
+    # Multi-byte text catches an implementation that bounds characters but
+    # emits far more UTF-8 bytes than the response budget permits.
+    huge_description = "▦" * 10_000
+    huge_models = [
+        _model(f"large-{index:03d}", description=huge_description)
+        for index in range(limit + 25)
+    ]
+    store_calls: list[tuple[str | None, int | None]] = []
+
+    def list_models(
+        _self: InMemoryStore,
+        *,
+        kind: str | None = None,
+        limit: int | None = None,
+    ) -> list[UserProvidedModel]:
+        store_calls.append((kind, limit))
+        return huge_models if kind == "machine" else small_models
+
+    monkeypatch.setattr(InMemoryStore, "list_public_user_models", list_models)
+    client = _client()
+
+    row_limited = client.get("/v1/models/user-provided")
+    assert row_limited.status_code == 200
+    assert len(row_limited.json()["data"]) == public_cache.PUBLIC_USER_MODEL_LIST_LIMIT
+
+    byte_limited = client.get("/v1/models/user-provided?kind=machine")
+    assert byte_limited.status_code == 200
+    assert 0 < len(byte_limited.json()["data"]) < public_cache.PUBLIC_USER_MODEL_LIST_LIMIT
+    assert len(byte_limited.content) <= public_cache.PUBLIC_USER_MODEL_LIST_MAX_BYTES
+    assert store_calls == [(None, limit), ("machine", limit)]
+
+
+@pytest.mark.parametrize(
+    ("path", "store_method"),
+    (
+        ("/v1/models/user-provided", "list_public_user_models"),
+        (
+            "/v1/models/user-provided/trustedrouter/user-loader-failure",
+            "get_user_model",
+        ),
+    ),
+)
+def test_loader_failure_is_503_and_retries_no_store_work_during_backoff(
+    monkeypatch: pytest.MonkeyPatch,
+    path: str,
+    store_method: str,
+) -> None:
+    store_calls = 0
+
+    def unavailable(*_args: object, **_kwargs: object) -> None:
+        nonlocal store_calls
+        store_calls += 1
+        raise RuntimeError("store unavailable")
+
+    monkeypatch.setattr(InMemoryStore, store_method, unavailable)
+    client = _client(raise_server_exceptions=False)
+
+    first = client.get(path)
+    second = client.get(path)
+
+    assert first.status_code == 503
+    assert second.status_code == 503
+    assert first.headers["retry-after"] == "2"
+    assert second.headers["retry-after"] == "2"
+    assert first.headers["cache-control"] == "no-store"
+    assert second.headers["cache-control"] == "no-store"
+    assert store_calls == 1
+
+
+@pytest.mark.parametrize("cache_kind", ("list", "detail"))
+def test_loader_failure_backoff_expires_before_store_retry(
+    monkeypatch: pytest.MonkeyPatch,
+    cache_kind: str,
+) -> None:
+    clock = _Clock()
+    monkeypatch.setattr(public_cache.time, "monotonic", clock)
+    loader_calls = 0
+
+    def fail_list(_limit: int) -> list[UserProvidedModel]:
+        nonlocal loader_calls
+        loader_calls += 1
+        raise RuntimeError("store unavailable")
+
+    def fail_detail() -> None:
+        nonlocal loader_calls
+        loader_calls += 1
+        raise RuntimeError("store unavailable")
+
+    def read() -> object:
+        if cache_kind == "list":
+            return public_cache.cached_public_user_model_list(None, fail_list)
+        return public_cache.cached_public_user_model(
+            "trustedrouter/user-failure-backoff",
+            fail_detail,
+        )
+
+    with pytest.raises(public_cache.PublicUserModelUnavailable):
+        read()
+    with pytest.raises(public_cache.PublicUserModelUnavailable):
+        read()
+    assert loader_calls == 1
+
+    clock.advance(public_cache.PUBLIC_USER_MODEL_FAILURE_BACKOFF_SECONDS + 0.01)
+    with pytest.raises(public_cache.PublicUserModelUnavailable):
+        read()
+    assert loader_calls == 2

--- a/tests/test_rate_limit_trust.py
+++ b/tests/test_rate_limit_trust.py
@@ -34,10 +34,12 @@ def fixed_rate_limit_clock(monkeypatch: pytest.MonkeyPatch) -> None:
 def _production_settings(**updates: object) -> Settings:
     values: dict[str, object] = {
         "environment": "production",
-        "service_surface": "control",
+        "service_surface": "console",
         "attribution_cookie_secret": "test-attribution-cookie-secret-32-bytes",
-        "stripe_webhook_secret": "whsec_test",
         "stripe_secret_key": "sk_test_secret",
+        "google_oauth_login_available": False,
+        "github_oauth_login_available": False,
+        "paypal_checkout_enabled": False,
         "sentry_dsn": "https://example@example.ingest.sentry.io/1",
         "aws_access_key_id": "test-access-key",
         "aws_secret_access_key": "test-secret-key",

--- a/tests/test_rollout_frontend_attest.py
+++ b/tests/test_rollout_frontend_attest.py
@@ -1,0 +1,480 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPOSITORY = Path(__file__).resolve().parents[1]
+SOURCE = REPOSITORY / "scripts" / "deploy" / "rollout_frontend_attest.py"
+SMOKE = REPOSITORY / "scripts" / "deploy" / "rollout_smoke.sh"
+PROJECT = "attest-prod1"
+FORWARDING_RULE = "tr-public-https"
+HTTPS_PROXY = "tr-public-proxy"
+URL_MAP = "tr-six-surface-map"
+CERTIFICATE_MAP = "tr-public-cert-map"
+VIP = "34.111.20.30"
+HOSTS = [
+    "trustedrouter.com",
+    "www.trustedrouter.com",
+    "status.trustedrouter.com",
+    "trust.trustedrouter.com",
+    "eu.trustedrouter.com",
+    "status-us.trustedrouter.com",
+    "status-eu.trustedrouter.com",
+    "allyrouter.com",
+    "www.allyrouter.com",
+    "status.allyrouter.com",
+    "trust.allyrouter.com",
+    "uptimerouter.com",
+    "www.uptimerouter.com",
+    "status.uptimerouter.com",
+    "trust.uptimerouter.com",
+]
+SECRET_SENTINEL = "DO-NOT-LOG-OR-PERSIST-PRIVATE-KEY"  # noqa: S105
+
+
+def _compute_url(collection: str, name: str) -> str:
+    return f"https://www.googleapis.com/compute/v1/projects/{PROJECT}/global/{collection}/{name}"
+
+
+def _cm_resource(collection: str, name: str) -> str:
+    return f"projects/{PROJECT}/locations/global/{collection}/{name}"
+
+
+def _map_entry_resource(name: str) -> str:
+    return (
+        f"projects/{PROJECT}/locations/global/certificateMaps/{CERTIFICATE_MAP}/"
+        f"certificateMapEntries/{name}"
+    )
+
+
+def _default_state() -> dict[str, Any]:
+    certificates: dict[str, dict[str, Any]] = {}
+    entries: list[dict[str, Any]] = []
+    for index, host in enumerate(HOSTS, start=1):
+        certificate_name = f"tr-host-{index}"
+        certificate_resource = _cm_resource("certificates", certificate_name)
+        certificates[certificate_name] = {
+            "name": certificate_resource,
+            "managed": {"state": "ACTIVE", "domains": [host]},
+            "sanDnsnames": [host],
+            # This simulates unrelated/sensitive provider response fields.  The
+            # attestation artifact and errors must never reproduce them.
+            "privateKey": SECRET_SENTINEL,
+        }
+        entries.append(
+            {
+                "name": _map_entry_resource(f"host-{index}"),
+                "state": "ACTIVE",
+                "hostname": host,
+                "certificates": [certificate_resource],
+            }
+        )
+    return {
+        "forwarding_rule": {
+            "name": FORWARDING_RULE,
+            "selfLink": _compute_url("forwardingRules", FORWARDING_RULE),
+            "IPAddress": VIP,
+            "IPProtocol": "TCP",
+            "portRange": "443-443",
+            "networkTier": "PREMIUM",
+            "loadBalancingScheme": "EXTERNAL_MANAGED",
+            "target": _compute_url("targetHttpsProxies", HTTPS_PROXY),
+        },
+        "https_proxy": {
+            "name": HTTPS_PROXY,
+            "selfLink": _compute_url("targetHttpsProxies", HTTPS_PROXY),
+            "urlMap": _compute_url("urlMaps", URL_MAP),
+            "certificateMap": (
+                "//certificatemanager.googleapis.com/"
+                + _cm_resource("certificateMaps", CERTIFICATE_MAP)
+            ),
+        },
+        "url_map": {
+            "name": URL_MAP,
+            "selfLink": _compute_url("urlMaps", URL_MAP),
+        },
+        "certificate_map": {
+            "name": _cm_resource("certificateMaps", CERTIFICATE_MAP),
+        },
+        "certificate_map_entries": entries,
+        "certificates": certificates,
+        "compute_certificates": {},
+        "dns": {host: {"A": [VIP], "AAAA": []} for host in HOSTS},
+    }
+
+
+GCLOUD_FAKE = r"""#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+state = json.loads(Path(os.environ["FAKE_FRONTEND_STATE"]).read_text())
+if state.get("fail_gcloud"):
+    sys.stderr.write(state.get("provider_secret", "provider failure"))
+    raise SystemExit(23)
+args = sys.argv[1:]
+key = None
+value = None
+if args[:3] == ["compute", "forwarding-rules", "describe"]:
+    key = "forwarding_rule"
+    value = state[key]
+elif args[:3] == ["compute", "target-https-proxies", "describe"]:
+    key = "https_proxy"
+    value = state[key]
+elif args[:3] == ["compute", "url-maps", "describe"]:
+    key = "url_map"
+    value = state[key]
+elif args[:3] == ["compute", "ssl-certificates", "describe"]:
+    key = "compute_certificate"
+    value = state["compute_certificates"][args[3]]
+elif args[:3] == ["certificate-manager", "maps", "describe"]:
+    key = "certificate_map"
+    value = state[key]
+elif args[:4] == ["certificate-manager", "maps", "entries", "list"]:
+    key = "certificate_map_entries"
+    value = state[key]
+elif args[:3] == ["certificate-manager", "certificates", "describe"]:
+    key = "certificate"
+    value = state["certificates"][args[3]]
+else:
+    raise SystemExit(97)
+if state.get("malformed_gcloud") == key:
+    sys.stdout.write("not-json")
+else:
+    json.dump(value, sys.stdout)
+"""
+
+
+DIG_FAKE = r"""#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+state = json.loads(Path(os.environ["FAKE_FRONTEND_STATE"]).read_text())
+if state.get("fail_dig"):
+    sys.stderr.write(state.get("provider_secret", "dns failure"))
+    raise SystemExit(29)
+host, record_type = sys.argv[-2:]
+answers = state["dns"][host][record_type]
+for answer in answers:
+    print(answer)
+"""
+
+
+class Harness:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.script = root / "scripts" / "deploy" / SOURCE.name
+        self.smoke = root / "scripts" / "deploy" / SMOKE.name
+        self.state_path = root / "provider-state.json"
+        self.artifact = root / "artifacts" / "frontend-attestation.json"
+        self.fake_bin = root / "fake-bin"
+        self.fake_bin.mkdir(parents=True)
+        self.script.parent.mkdir(parents=True)
+        shutil.copy2(SOURCE, self.script)
+        shutil.copy2(SMOKE, self.smoke)
+        for name, body in (("gcloud", GCLOUD_FAKE), ("dig", DIG_FAKE)):
+            executable = self.fake_bin / name
+            executable.write_text(body, encoding="utf-8")
+            executable.chmod(0o755)
+        self.state = _default_state()
+        self.write_state()
+        self.environment = os.environ.copy()
+        self.environment["PATH"] = f"{self.fake_bin}{os.pathsep}{self.environment['PATH']}"
+        self.environment["FAKE_FRONTEND_STATE"] = str(self.state_path)
+
+    def write_state(self) -> None:
+        self.state_path.write_text(json.dumps(self.state), encoding="utf-8")
+
+    def capture(
+        self,
+        *,
+        artifact: Path | None = None,
+        hosts: list[str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(  # noqa: S603 -- fixed local test executable and argv
+            [
+                sys.executable,
+                str(self.script),
+                "capture",
+                "--project",
+                PROJECT,
+                "--forwarding-rule",
+                FORWARDING_RULE,
+                "--https-proxy",
+                HTTPS_PROXY,
+                "--url-map",
+                URL_MAP,
+                "--hosts",
+                ",".join(hosts or HOSTS),
+                "--artifact",
+                str(artifact or self.artifact),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=self.environment,
+        )
+
+    def verify(self, *, artifact: Path | None = None) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(  # noqa: S603 -- fixed local test executable and argv
+            [
+                sys.executable,
+                str(self.script),
+                "verify-artifact",
+                str(artifact or self.artifact),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=self.environment,
+        )
+
+
+@pytest.fixture
+def harness(tmp_path: Path) -> Harness:
+    return Harness(tmp_path)
+
+
+def test_capture_and_live_verify_certificate_map(harness: Harness) -> None:
+    captured = harness.capture()
+    assert captured.returncode == 0, captured.stderr
+    assert stat.S_IMODE(harness.artifact.stat().st_mode) == 0o600
+    artifact_text = harness.artifact.read_text(encoding="utf-8")
+    artifact = json.loads(artifact_text)
+    assert artifact["schema_version"] == 1
+    assert artifact["request"]["hosts"] == HOSTS
+    assert artifact["frontend"]["certificate_binding"]["mode"] == "certificate-map"
+    assert artifact["frontend"]["forwarding_rule"] == {
+        "resource": f"projects/{PROJECT}/global/forwardingRules/{FORWARDING_RULE}",
+        "ip_address": VIP,
+        "ip_protocol": "TCP",
+        "ports": ["443"],
+        "network_tier": "PREMIUM",
+        "load_balancing_scheme": "EXTERNAL_MANAGED",
+        "target_https_proxy": (f"projects/{PROJECT}/global/targetHttpsProxies/{HTTPS_PROXY}"),
+    }
+    assert SECRET_SENTINEL not in artifact_text
+    assert SECRET_SENTINEL not in captured.stdout + captured.stderr
+
+    verified = harness.verify()
+    assert verified.returncode == 0, verified.stderr
+    assert SECRET_SENTINEL not in verified.stdout + verified.stderr
+
+
+def test_capture_rejects_partial_managed_host_inventory(harness: Harness) -> None:
+    result = harness.capture(hosts=HOSTS[:3])
+    assert result.returncode != 0
+    assert "managed-domain contract" in result.stderr
+    assert not harness.artifact.exists()
+
+
+def test_capture_and_live_verify_direct_managed_certificates(harness: Harness) -> None:
+    certificate_name = "tr-direct-cert"
+    certificate_url = _compute_url("sslCertificates", certificate_name)
+    harness.state["https_proxy"].pop("certificateMap")
+    harness.state["https_proxy"]["sslCertificates"] = [certificate_url]
+    harness.state["compute_certificates"][certificate_name] = {
+        "name": certificate_name,
+        "selfLink": certificate_url,
+        "type": "MANAGED",
+        "managed": {"status": "ACTIVE", "domains": list(reversed(HOSTS))},
+        "subjectAlternativeNames": list(HOSTS),
+        "privateKey": SECRET_SENTINEL,
+    }
+    harness.write_state()
+
+    captured = harness.capture()
+    assert captured.returncode == 0, captured.stderr
+    artifact = json.loads(harness.artifact.read_text(encoding="utf-8"))
+    binding = artifact["frontend"]["certificate_binding"]
+    assert binding["mode"] == "direct"
+    assert binding["certificate_map"] is None
+    assert binding["entries"] == []
+    assert binding["certificates"][0]["domains"] == sorted(HOSTS)
+    assert harness.verify().returncode == 0
+
+
+@pytest.mark.parametrize(
+    "drift",
+    ["wrong-proxy", "wrong-map", "wrong-vip", "wrong-scheme", "extra-ipv6"],
+)
+def test_capture_rejects_hostile_frontend_contract(harness: Harness, drift: str) -> None:
+    if drift == "wrong-proxy":
+        harness.state["forwarding_rule"]["target"] = _compute_url(
+            "targetHttpsProxies", "attacker-proxy"
+        )
+    elif drift == "wrong-map":
+        harness.state["https_proxy"]["urlMap"] = _compute_url("urlMaps", "attacker-map")
+    elif drift == "wrong-vip":
+        harness.state["forwarding_rule"]["IPAddress"] = "34.111.20.31"
+    elif drift == "wrong-scheme":
+        harness.state["forwarding_rule"]["loadBalancingScheme"] = "EXTERNAL"
+    else:
+        harness.state["dns"][HOSTS[0]]["AAAA"] = ["2001:4860:4860::8888"]
+    harness.write_state()
+
+    result = harness.capture()
+    assert result.returncode == 1
+    assert not harness.artifact.exists()
+
+
+@pytest.mark.parametrize("drift", ["inactive-certificate", "missing-host"])
+def test_capture_rejects_inactive_or_incomplete_certificates(harness: Harness, drift: str) -> None:
+    certificate = harness.state["certificates"]["tr-host-2"]
+    if drift == "inactive-certificate":
+        certificate["managed"]["state"] = "PROVISIONING"
+    else:
+        certificate["managed"]["domains"] = ["unrelated.example.com"]
+        certificate["sanDnsnames"] = ["unrelated.example.com"]
+    harness.write_state()
+
+    result = harness.capture()
+    assert result.returncode == 1
+    assert not harness.artifact.exists()
+
+
+@pytest.mark.parametrize("shadow", ["exact", "wildcard", "ambiguous-exact"])
+def test_certificate_map_enforces_selector_precedence(
+    harness: Harness, shadow: str
+) -> None:
+    host_index = 1 if shadow == "wildcard" else 0
+    host = HOSTS[host_index]
+    exact_entry = harness.state["certificate_map_entries"][host_index]
+
+    fallback_name = f"fallback-{shadow}"
+    fallback_resource = _cm_resource("certificates", fallback_name)
+    harness.state["certificates"][fallback_name] = {
+        "name": fallback_resource,
+        "managed": {"state": "ACTIVE", "domains": [host]},
+        "sanDnsnames": [host],
+    }
+    fallback_entry = {
+        "name": _map_entry_resource(f"fallback-{shadow}"),
+        "state": "ACTIVE",
+        "certificates": [fallback_resource],
+    }
+
+    if shadow == "exact":
+        fallback_entry["hostname"] = "*.trustedrouter.com"
+        bad_certificate = harness.state["certificates"]["tr-host-1"]
+        bad_certificate["managed"]["domains"] = ["unrelated.example.com"]
+        bad_certificate["sanDnsnames"] = ["unrelated.example.com"]
+    elif shadow == "wildcard":
+        exact_entry["hostname"] = "unused.trustedrouter.com"
+        fallback_entry["matcher"] = "PRIMARY"
+        wildcard_resource = _cm_resource("certificates", "bad-wildcard")
+        harness.state["certificates"]["bad-wildcard"] = {
+            "name": wildcard_resource,
+            "managed": {"state": "ACTIVE", "domains": ["*.unrelated.example.com"]},
+            "sanDnsnames": ["*.unrelated.example.com"],
+        }
+        harness.state["certificate_map_entries"].append(
+            {
+                "name": _map_entry_resource("bad-wildcard"),
+                "state": "ACTIVE",
+                "hostname": "*.trustedrouter.com",
+                "certificates": [wildcard_resource],
+            }
+        )
+    else:
+        fallback_entry["hostname"] = host
+    harness.state["certificate_map_entries"].append(fallback_entry)
+    harness.write_state()
+
+    result = harness.capture()
+    assert result.returncode == 1
+    assert not harness.artifact.exists()
+
+
+@pytest.mark.parametrize("drift", ["provider", "dns"])
+def test_verify_requeries_live_state_and_rejects_post_capture_drift(
+    harness: Harness, drift: str
+) -> None:
+    assert harness.capture().returncode == 0
+    if drift == "provider":
+        harness.state["https_proxy"]["urlMap"] = _compute_url("urlMaps", "replacement-map")
+    else:
+        harness.state["dns"][HOSTS[-1]]["A"] = ["34.111.20.99"]
+    harness.write_state()
+
+    verified = harness.verify()
+    assert verified.returncode == 1
+    assert "verified" not in verified.stderr
+
+
+def test_verify_rejects_changed_repository_smoke_hash(harness: Harness) -> None:
+    assert harness.capture().returncode == 0
+    with harness.smoke.open("a", encoding="utf-8") as output:
+        output.write("\n# post-capture drift\n")
+
+    verified = harness.verify()
+    assert verified.returncode == 1
+    assert "hash differs" in verified.stderr
+
+
+def test_verify_rejects_malformed_extra_fields_and_insecure_mode(harness: Harness) -> None:
+    assert harness.capture().returncode == 0
+    artifact = json.loads(harness.artifact.read_text(encoding="utf-8"))
+    artifact["unexpected"] = True
+    harness.artifact.write_text(json.dumps(artifact), encoding="utf-8")
+    harness.artifact.chmod(0o600)
+    malformed = harness.verify()
+    assert malformed.returncode == 1
+    assert "fields differ" in malformed.stderr
+
+    del artifact["unexpected"]
+    harness.artifact.write_text(json.dumps(artifact), encoding="utf-8")
+    harness.artifact.chmod(0o644)
+    insecure = harness.verify()
+    assert insecure.returncode == 1
+    assert "mode-0600" in insecure.stderr
+
+
+def test_provider_output_failure_is_silent_and_fail_closed(harness: Harness) -> None:
+    harness.state["fail_gcloud"] = True
+    harness.state["provider_secret"] = SECRET_SENTINEL
+    harness.write_state()
+
+    failed = harness.capture()
+    assert failed.returncode == 1
+    assert SECRET_SENTINEL not in failed.stdout + failed.stderr
+    assert not harness.artifact.exists()
+
+    harness.state.pop("fail_gcloud")
+    harness.state["malformed_gcloud"] = "forwarding_rule"
+    harness.write_state()
+    malformed = harness.capture()
+    assert malformed.returncode == 1
+    assert not harness.artifact.exists()
+
+
+def test_atomic_output_failure_leaves_no_partial_artifact(harness: Harness) -> None:
+    destination = harness.root / "artifact-is-a-directory"
+    destination.mkdir()
+
+    failed = harness.capture(artifact=destination)
+    assert failed.returncode == 1
+    assert destination.is_dir()
+    assert list(harness.root.glob(".artifact-is-a-directory.*.tmp")) == []
+
+
+def test_capture_replaces_existing_artifact_with_mode_0600(harness: Harness) -> None:
+    harness.artifact.parent.mkdir(parents=True)
+    harness.artifact.write_text("old", encoding="utf-8")
+    harness.artifact.chmod(0o666)
+
+    captured = harness.capture()
+    assert captured.returncode == 0, captured.stderr
+    assert stat.S_IMODE(harness.artifact.stat().st_mode) == 0o600
+    assert json.loads(harness.artifact.read_text(encoding="utf-8"))["schema_version"] == 1

--- a/tests/test_rollout_frontend_attest.py
+++ b/tests/test_rollout_frontend_attest.py
@@ -24,7 +24,6 @@ HOSTS = [
     "trustedrouter.com",
     "www.trustedrouter.com",
     "status.trustedrouter.com",
-    "trust.trustedrouter.com",
     "eu.trustedrouter.com",
     "status-us.trustedrouter.com",
     "status-eu.trustedrouter.com",
@@ -478,3 +477,46 @@ def test_capture_replaces_existing_artifact_with_mode_0600(harness: Harness) -> 
     assert captured.returncode == 0, captured.stderr
     assert stat.S_IMODE(harness.artifact.stat().st_mode) == 0o600
     assert json.loads(harness.artifact.read_text(encoding="utf-8"))["schema_version"] == 1
+
+
+def test_capture_accepts_a_cname_that_chains_through_a_managed_host(harness: Harness) -> None:
+    """www is a CNAME to the apex by production DNS policy; the apex is attested.
+
+    The chain is recorded in the artifact so verify re-checks the same path.
+    """
+    harness.state["dns"]["www.trustedrouter.com"]["A"] = ["trustedrouter.com.", VIP]
+    harness.state["dns"]["www.trustedrouter.com"]["AAAA"] = ["trustedrouter.com."]
+    harness.write_state()
+
+    captured = harness.capture()
+    assert captured.returncode == 0, captured.stderr
+    artifact = json.loads(harness.artifact.read_text(encoding="utf-8"))
+    entries = {entry["host"]: entry for entry in artifact["frontend"]["dns"]}
+    assert entries["www.trustedrouter.com"]["cname"] == ["trustedrouter.com"]
+    assert entries["www.trustedrouter.com"]["a"] == [VIP]
+    assert "cname" not in entries["trustedrouter.com"]
+
+    verified = harness.verify()
+    assert verified.returncode == 0, verified.stderr
+
+
+@pytest.mark.parametrize(
+    "answers",
+    [
+        ["lore-hex.github.io.", "185.199.111.153"],
+        ["trustedrouter.com.", "lore-hex.github.io.", VIP],
+        [VIP, "trustedrouter.com."],
+        ["www.trustedrouter.com.", VIP],
+    ],
+    ids=["outside-managed", "outside-mid-chain", "cname-after-address", "self-cname"],
+)
+def test_capture_rejects_cnames_that_leave_the_managed_set(
+    harness: Harness, answers: list[str]
+) -> None:
+    harness.state["dns"]["www.trustedrouter.com"]["A"] = answers
+    harness.write_state()
+
+    captured = harness.capture()
+    assert captured.returncode != 0
+    assert "DNS response" in captured.stderr
+    assert not harness.artifact.exists()

--- a/tests/test_rollout_iam_verify.py
+++ b/tests/test_rollout_iam_verify.py
@@ -1,0 +1,1152 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFIER = ROOT / "scripts/deploy/rollout_iam_verify.sh"
+PROJECT = "quill-cloud-proxy"
+SURFACES = ("public", "actions", "console", "chat", "webhooks", "internal")
+SERVICES = {
+    "public": "trusted-router-public",
+    "actions": "trusted-router-actions",
+    "console": "trusted-router-console",
+    "chat": "trusted-router-chat",
+    "webhooks": "trusted-router-webhooks",
+    "internal": "trusted-router-billing",
+}
+
+
+def _account(surface: str) -> str:
+    return f"tr-{surface}@{PROJECT}.iam.gserviceaccount.com"
+
+
+def _member(surface: str) -> str:
+    return f"serviceAccount:{_account(surface)}"
+
+
+def _synthetic_member() -> str:
+    return f"serviceAccount:tr-synthetic@{PROJECT}.iam.gserviceaccount.com"
+
+
+def _binding(
+    role: str,
+    surfaces: tuple[str, ...],
+    *,
+    condition: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    value: dict[str, Any] = {
+        "role": role,
+        "members": [_member(surface) for surface in surfaces],
+    }
+    if condition is not None:
+        value["condition"] = condition
+    return value
+
+
+def _policy(*bindings: dict[str, Any]) -> dict[str, Any]:
+    return {"bindings": list(bindings)}
+
+
+def _candidate(surface: str) -> str:
+    return f"{SERVICES[surface]}-iamverify"
+
+
+def _revision(surface: str) -> dict[str, Any]:
+    env: list[dict[str, Any]] = []
+    if surface in {"public", "console"}:
+        env.append(
+            {
+                "name": "TR_ATTRIBUTION_COOKIE_SECRET",
+                "valueFrom": {
+                    "secretKeyRef": {
+                        "name": "trustedrouter-attribution-cookie-secret",
+                        "key": "7",
+                    }
+                },
+            }
+        )
+    return {
+        "metadata": {"name": _candidate(surface)},
+        "spec": {
+            "serviceAccountName": _account(surface),
+            "containers": [{"env": env}],
+        },
+    }
+
+
+def _valid_state() -> dict[str, Any]:
+    deploy_member = f"serviceAccount:tr-deploy@{PROJECT}.iam.gserviceaccount.com"
+    return {
+        "policies": {
+            "project": _policy(
+                _binding(
+                    "roles/serviceusage.serviceUsageConsumer",
+                    ("public", "console", "chat", "webhooks", "internal"),
+                )
+            ),
+            "spanner_instance": _policy(),
+            "spanner_database": _policy(
+                _binding("roles/spanner.databaseReader", ("public", "chat")),
+                _binding(
+                    "roles/spanner.databaseUser",
+                    ("console", "webhooks", "internal"),
+                ),
+            ),
+            "bigtable_instance": _policy(
+                _binding("roles/bigtable.reader", ("public", "console")),
+                _binding("roles/bigtable.user", ("internal",)),
+            ),
+            "bigtable_table": _policy(),
+            "keyring": _policy(),
+            "byok": _policy(
+                _binding(
+                    "roles/cloudkms.cryptoKeyEncrypterDecrypter", ("console",)
+                ),
+                _binding("roles/cloudkms.cryptoKeyDecrypter", ("internal",)),
+            ),
+            "ads": _policy(
+                _binding("roles/cloudkms.cryptoKeyEncrypter", ("console",))
+            ),
+            "folder": _policy(),
+            "organization": _policy(),
+        },
+        "service_account_policies": {
+            _account(surface): _policy(
+                {
+                    "role": "roles/iam.serviceAccountUser",
+                    "members": [deploy_member],
+                }
+            )
+            for surface in SURFACES
+        }
+        | {
+            f"tr-synthetic@{PROJECT}.iam.gserviceaccount.com": _policy(
+                {
+                    "role": "roles/iam.serviceAccountUser",
+                    "members": [deploy_member],
+                }
+            ),
+            f"unrelated-build@{PROJECT}.iam.gserviceaccount.com": _policy(),
+        },
+        "inventories": {
+            "spanner_instances": ["trusted-router-nam6"],
+            "spanner_databases": {"trusted-router-nam6": ["trusted-router"]},
+            "bigtable_instances": ["trusted-router-logs"],
+            "bigtable_tables": {
+                "trusted-router-logs": ["trustedrouter-generations"]
+            },
+            "kms_locations": ["us-central1"],
+            "kms_keyrings": {"us-central1": ["trusted-router"]},
+            "kms_keys": {
+                "us-central1/trusted-router": [
+                    "byok-envelope",
+                    "google-ads-click-envelope",
+                ]
+            },
+            "service_accounts": [
+                *[_account(surface) for surface in SURFACES],
+                f"tr-synthetic@{PROJECT}.iam.gserviceaccount.com",
+                f"unrelated-build@{PROJECT}.iam.gserviceaccount.com",
+            ],
+        },
+        "inventory_policies": {},
+        "secrets": {
+            "trustedrouter-attribution-cookie-secret": _policy(
+                _binding(
+                    "roles/secretmanager.secretAccessor", ("public", "console")
+                )
+            ),
+            "unrelated-build-secret": _policy(),
+        },
+        "versions": {
+            "trustedrouter-attribution-cookie-secret|7": "ENABLED",
+        },
+        "revisions": {
+            _candidate(surface): _revision(surface) for surface in SURFACES
+        },
+        "roles": {},
+        "bucket_metadata": {
+            "name": "trusted-router-rollout-recovery",
+            "iamConfiguration": {
+                "uniformBucketLevelAccess": {"enabled": True},
+                "publicAccessPrevention": "enforced",
+            },
+            "versioning": {"enabled": True},
+            "retentionPolicy": {"retentionPeriod": "604800"},
+        },
+        "bucket_policy": _policy(),
+    }
+
+
+def _write_manifest(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "project_id": PROJECT,
+                "regions": ["us-central1"],
+                "internal_regions": ["us-central1"],
+                "services": [
+                    {
+                        "surface": surface,
+                        "name": SERVICES[surface],
+                        "region": "us-central1",
+                        "candidate_revision": _candidate(surface),
+                        "runtime_service_account": _account(surface),
+                    }
+                    for surface in SURFACES
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+FAKE_GCLOUD = r'''#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+state = json.loads(Path(os.environ["FAKE_GCLOUD_STATE"]).read_text(encoding="utf-8"))
+events = Path(os.environ["FAKE_GCLOUD_EVENTS"])
+args = sys.argv[1:]
+if args[:1] == ["--project"]:
+    if len(args) < 2 or args[1] != "quill-cloud-proxy":
+        raise SystemExit(81)
+    args = args[2:]
+with events.open("a", encoding="utf-8") as output:
+    output.write("gcloud " + " ".join(args) + "\n")
+
+mutating = {
+    "add-iam-policy-binding", "remove-iam-policy-binding", "set-iam-policy",
+    "create", "delete", "deploy", "import", "update", "update-traffic",
+}
+if any(item in mutating for item in args):
+    print("mutation rejected", file=sys.stderr)
+    raise SystemExit(90)
+
+def option(name):
+    for index, value in enumerate(args):
+        if value.startswith(name + "="):
+            return value.split("=", 1)[1]
+        if value == name and index + 1 < len(args):
+            return args[index + 1]
+    return None
+
+def finish(value):
+    if isinstance(value, str):
+        print(value)
+    else:
+        print(json.dumps(value, separators=(",", ":")))
+    raise SystemExit(0)
+
+def inventory_policy(key, fallback=None):
+    if key in state["inventory_policies"]:
+        return state["inventory_policies"][key]
+    return {"bindings": []} if fallback is None else fallback
+
+if args[:2] == ["projects", "describe"]:
+    finish("123456789")
+if args[:2] == ["projects", "get-iam-policy"]:
+    finish(state["policies"]["project"])
+if args[:2] == ["projects", "get-ancestors"]:
+    finish([
+        {"type": "project", "id": "quill-cloud-proxy"},
+        {"type": "folder", "id": "1234"},
+        {"type": "organization", "id": "5678"},
+    ])
+if args[:3] == ["resource-manager", "folders", "get-iam-policy"]:
+    finish(state["policies"]["folder"])
+if args[:2] == ["organizations", "get-iam-policy"]:
+    finish(state["policies"]["organization"])
+if args[:3] == ["spanner", "instances", "list"]:
+    finish([
+        {"name": f"projects/quill-cloud-proxy/instances/{name}"}
+        for name in state["inventories"]["spanner_instances"]
+    ])
+if args[:3] == ["spanner", "instances", "get-iam-policy"]:
+    name = args[3]
+    fallback = state["policies"]["spanner_instance"] if name == "trusted-router-nam6" else None
+    finish(inventory_policy(f"spanner_instance|{name}", fallback))
+if args[:3] == ["spanner", "databases", "list"]:
+    instance = option("--instance")
+    finish([
+        {"name": f"projects/quill-cloud-proxy/instances/{instance}/databases/{name}"}
+        for name in state["inventories"]["spanner_databases"].get(instance, [])
+    ])
+if args[:3] == ["spanner", "databases", "get-iam-policy"]:
+    name = args[3]
+    instance = option("--instance")
+    fallback = (
+        state["policies"]["spanner_database"]
+        if instance == "trusted-router-nam6" and name == "trusted-router"
+        else None
+    )
+    finish(inventory_policy(f"spanner_database|{instance}|{name}", fallback))
+if args[:3] == ["bigtable", "instances", "list"]:
+    finish([
+        {"name": f"projects/quill-cloud-proxy/instances/{name}"}
+        for name in state["inventories"]["bigtable_instances"]
+    ])
+if args[:3] == ["bigtable", "instances", "get-iam-policy"]:
+    name = args[3]
+    fallback = state["policies"]["bigtable_instance"] if name == "trusted-router-logs" else None
+    finish(inventory_policy(f"bigtable_instance|{name}", fallback))
+if args[:3] == ["bigtable", "tables", "list"]:
+    instance = option("--instances")
+    finish([
+        {"name": f"projects/quill-cloud-proxy/instances/{instance}/tables/{name}"}
+        for name in state["inventories"]["bigtable_tables"].get(instance, [])
+    ])
+if args[:3] == ["bigtable", "tables", "get-iam-policy"]:
+    name = args[3]
+    instance = option("--instance")
+    fallback = (
+        state["policies"]["bigtable_table"]
+        if instance == "trusted-router-logs" and name == "trustedrouter-generations"
+        else None
+    )
+    finish(inventory_policy(f"bigtable_table|{instance}|{name}", fallback))
+if args[:3] == ["kms", "locations", "list"]:
+    finish([{"locationId": name} for name in state["inventories"]["kms_locations"]])
+if args[:3] == ["kms", "keyrings", "list"]:
+    location = option("--location")
+    finish([
+        {
+            "name": (
+                f"projects/quill-cloud-proxy/locations/{location}/keyRings/{name}"
+            )
+        }
+        for name in state["inventories"]["kms_keyrings"].get(location, [])
+    ])
+if args[:3] == ["kms", "keyrings", "get-iam-policy"]:
+    name = args[3]
+    location = option("--location")
+    fallback = (
+        state["policies"]["keyring"]
+        if location == "us-central1" and name == "trusted-router"
+        else None
+    )
+    finish(inventory_policy(f"kms_keyring|{location}|{name}", fallback))
+if args[:3] == ["kms", "keys", "list"]:
+    location = option("--location")
+    keyring = option("--keyring")
+    finish([
+        {
+            "name": (
+                f"projects/quill-cloud-proxy/locations/{location}/keyRings/"
+                f"{keyring}/cryptoKeys/{name}"
+            )
+        }
+        for name in state["inventories"]["kms_keys"].get(f"{location}/{keyring}", [])
+    ])
+if args[:3] == ["kms", "keys", "get-iam-policy"]:
+    name = args[3]
+    location = option("--location")
+    keyring = option("--keyring")
+    fallback = None
+    if location == "us-central1" and keyring == "trusted-router":
+        if name == "byok-envelope":
+            fallback = state["policies"]["byok"]
+        elif name == "google-ads-click-envelope":
+            fallback = state["policies"]["ads"]
+    finish(inventory_policy(f"kms_key|{location}|{keyring}|{name}", fallback))
+if args[:3] == ["iam", "service-accounts", "list"]:
+    finish([
+        {
+            "name": f"projects/quill-cloud-proxy/serviceAccounts/{100000000000000000000 + index}",
+            "email": email,
+            "uniqueId": str(100000000000000000000 + index),
+        }
+        for index, email in enumerate(state["inventories"]["service_accounts"])
+    ])
+if args[:3] == ["iam", "service-accounts", "describe"]:
+    finish({"email": args[3], "disabled": False})
+if args[:3] == ["iam", "service-accounts", "get-iam-policy"]:
+    finish(state["service_account_policies"][args[3]])
+if args[:3] == ["iam", "roles", "describe"]:
+    role = args[3]
+    if role not in state["roles"]:
+        matches = [value for name, value in state["roles"].items() if name.endswith("/roles/" + role)]
+        if len(matches) != 1:
+            raise SystemExit(83)
+        finish(matches[0])
+    finish(state["roles"][role])
+if args[:3] == ["storage", "buckets", "get-iam-policy"]:
+    finish(state["bucket_policy"])
+if args[:3] == ["storage", "buckets", "describe"]:
+    finish(state["bucket_metadata"])
+if args[:2] == ["secrets", "list"]:
+    finish([
+        {"name": f"projects/quill-cloud-proxy/secrets/{name}"}
+        for name in state["secrets"]
+    ])
+if args[:2] == ["secrets", "get-iam-policy"]:
+    finish(state["secrets"][args[2]])
+if args[:3] == ["secrets", "versions", "describe"]:
+    secret = option("--secret")
+    version = args[3]
+    finish({
+        "name": f"projects/quill-cloud-proxy/secrets/{secret}/versions/{version}",
+        "state": state["versions"].get(f"{secret}|{version}", "MISSING"),
+    })
+if args[:3] == ["run", "revisions", "describe"]:
+    finish(state["revisions"][args[3]])
+
+print("unexpected fake gcloud command", file=sys.stderr)
+raise SystemExit(82)
+'''
+
+
+def _run(
+    tmp_path: Path,
+    state: dict[str, Any],
+    *,
+    with_manifest: bool = True,
+    extra_env: dict[str, str] | None = None,
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake = fake_bin / "gcloud"
+    fake.write_text(FAKE_GCLOUD, encoding="utf-8")
+    fake.chmod(0o755)
+    state_path = tmp_path / "state.json"
+    original_state = json.dumps(state, sort_keys=True)
+    state_path.write_text(original_state, encoding="utf-8")
+    events_path = tmp_path / "events.log"
+    events_path.write_text("", encoding="utf-8")
+    command = [str(VERIFIER), "--project", PROJECT]
+    if with_manifest:
+        manifest_path = tmp_path / "manifest.json"
+        _write_manifest(manifest_path)
+        command.extend(("--manifest", str(manifest_path)))
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "HOME": str(tmp_path),
+        "FAKE_GCLOUD_STATE": str(state_path),
+        "FAKE_GCLOUD_EVENTS": str(events_path),
+        "REGION": "us-central1",
+    }
+    env.pop("TR_ROLLOUT_STATE_GCS_URI", None)
+    env.pop("TR_ROLLOUT_STATE_GCS_ROLE", None)
+    env.pop("TR_ROLLOUT_REQUIRE_RECOVERY_BUNDLE", None)
+    env.pop("TR_ROLLOUT_RECOVERY_GCS_PREFIX", None)
+    env.pop("TR_ROLLOUT_RECOVERY_GCS_ROLE", None)
+    env.pop("TR_ROLLOUT_BUNDLE_GCS_URI", None)
+    env.pop("TR_ROLLOUT_AUTHORITY_GCS_URI", None)
+    env.update(extra_env or {})
+    run = subprocess.run(  # noqa: S603 - repo-local script and isolated fake PATH
+        command,
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert state_path.read_text(encoding="utf-8") == original_state
+    events = events_path.read_text(encoding="utf-8").splitlines()
+    forbidden = (
+        " add-iam-policy-binding",
+        " remove-iam-policy-binding",
+        " set-iam-policy",
+        " create ",
+        " delete ",
+        " deploy ",
+        " import ",
+        " update ",
+        " update-traffic",
+    )
+    assert all(not any(token in event for token in forbidden) for event in events)
+    return run, events
+
+
+RECOVERY_BUCKET = "trusted-router-rollout-recovery"
+RECOVERY_EPOCH = "manifest-20260821T120000Z-deadbeef"
+RECOVERY_ROLE = f"projects/{PROJECT}/roles/trustedRouterRolloutRecovery"
+
+
+def _recovery_env() -> dict[str, str]:
+    prefix = f"gs://{RECOVERY_BUCKET}/trusted-router-rollouts/{PROJECT}"
+    bundle = f"{prefix}/releases/{RECOVERY_EPOCH}"
+    return {
+        "TR_ROLLOUT_REQUIRE_RECOVERY_BUNDLE": "true",
+        "TR_ROLLOUT_RECOVERY_GCS_PREFIX": prefix,
+        "TR_ROLLOUT_RECOVERY_GCS_ROLE": RECOVERY_ROLE,
+        "TR_ROLLOUT_BUNDLE_GCS_URI": bundle,
+        "TR_ROLLOUT_AUTHORITY_GCS_URI": f"{prefix}/authority.json",
+        "TR_ROLLOUT_STATE_GCS_URI": f"{bundle}/promotion-state.json",
+        "TR_ROLLOUT_STATE_GCS_ROLE": RECOVERY_ROLE,
+    }
+
+
+def _state_with_exact_recovery() -> dict[str, Any]:
+    state = _valid_state()
+    state["roles"][RECOVERY_ROLE] = {
+        "name": RECOVERY_ROLE,
+        "deleted": False,
+        "includedPermissions": [
+            "storage.objects.create",
+            "storage.objects.delete",
+            "storage.objects.get",
+        ],
+    }
+    authority_resource = (
+        f"projects/_/buckets/{RECOVERY_BUCKET}/objects/"
+        f"trusted-router-rollouts/{PROJECT}/authority.json"
+    )
+    bundle_resource_prefix = (
+        f"projects/_/buckets/{RECOVERY_BUCKET}/objects/"
+        f"trusted-router-rollouts/{PROJECT}/releases/{RECOVERY_EPOCH}/"
+    )
+    state["bucket_policy"] = _policy(
+        {
+            "role": RECOVERY_ROLE,
+            "members": [
+                f"serviceAccount:tr-deploy@{PROJECT}.iam.gserviceaccount.com"
+            ],
+            "condition": {
+                "title": "trusted-router-rollout-recovery",
+                "expression": (
+                    f'resource.name == "{authority_resource}" || '
+                    f'resource.name.startsWith("{bundle_resource_prefix}")'
+                ),
+            },
+        }
+    )
+    return state
+
+
+def test_happy_manifest_audits_every_scope_candidate_and_pinned_version(
+    tmp_path: Path,
+) -> None:
+    run, events = _run(tmp_path, _valid_state())
+
+    assert run.returncode == 0, run.stderr
+    assert run.stdout.strip() == "six-surface rollout IAM verification passed"
+    joined = "\n".join(events)
+    for command in (
+        "projects get-iam-policy",
+        "projects get-ancestors",
+        "resource-manager folders get-iam-policy",
+        "organizations get-iam-policy",
+        "spanner instances get-iam-policy",
+        "spanner databases get-iam-policy",
+        "bigtable instances get-iam-policy",
+        "bigtable tables get-iam-policy",
+        "kms keyrings get-iam-policy",
+        "kms keys get-iam-policy",
+        "iam service-accounts get-iam-policy",
+        "secrets list",
+        "secrets get-iam-policy",
+        "run revisions describe",
+        "secrets versions describe 7",
+    ):
+        assert command in joined
+    assert joined.count("run revisions describe") == 6
+
+
+def test_stage_mode_never_reads_candidate_revisions_or_secret_versions(
+    tmp_path: Path,
+) -> None:
+    run, events = _run(tmp_path, _valid_state(), with_manifest=False)
+
+    assert run.returncode == 0, run.stderr
+    assert not any("run revisions describe" in event for event in events)
+    assert not any("secrets versions describe" in event for event in events)
+
+
+@pytest.mark.parametrize(
+    ("target", "principal"),
+    (
+        ("spanner_instance", "runtime"),
+        ("spanner_database", "synthetic"),
+        ("bigtable_instance", "synthetic"),
+        ("bigtable_table", "runtime"),
+        ("kms_keyring", "runtime"),
+        ("kms_key", "synthetic"),
+        ("service_account", "runtime"),
+    ),
+)
+def test_full_project_inventory_rejects_grant_on_any_other_resource(
+    tmp_path: Path,
+    target: str,
+    principal: str,
+) -> None:
+    state = _valid_state()
+    member = _member("public") if principal == "runtime" else _synthetic_member()
+    binding = {"role": "roles/viewer", "members": [member]}
+
+    if target == "spanner_instance":
+        state["inventories"]["spanner_instances"].append("archive-spanner")
+        state["inventories"]["spanner_databases"]["archive-spanner"] = []
+        state["inventory_policies"]["spanner_instance|archive-spanner"] = _policy(
+            binding
+        )
+    elif target == "spanner_database":
+        state["inventories"]["spanner_databases"]["trusted-router-nam6"].append(
+            "archive-database"
+        )
+        state["inventory_policies"][
+            "spanner_database|trusted-router-nam6|archive-database"
+        ] = _policy(binding)
+    elif target == "bigtable_instance":
+        state["inventories"]["bigtable_instances"].append("archive-bigtable")
+        state["inventories"]["bigtable_tables"]["archive-bigtable"] = []
+        state["inventory_policies"]["bigtable_instance|archive-bigtable"] = _policy(
+            binding
+        )
+    elif target == "bigtable_table":
+        state["inventories"]["bigtable_tables"]["trusted-router-logs"].append(
+            "archive-table"
+        )
+        state["inventory_policies"][
+            "bigtable_table|trusted-router-logs|archive-table"
+        ] = _policy(binding)
+    elif target == "kms_keyring":
+        state["inventories"]["kms_keyrings"]["us-central1"].append(
+            "archive-keyring"
+        )
+        state["inventories"]["kms_keys"]["us-central1/archive-keyring"] = []
+        state["inventory_policies"][
+            "kms_keyring|us-central1|archive-keyring"
+        ] = _policy(binding)
+    elif target == "kms_key":
+        state["inventories"]["kms_keys"]["us-central1/trusted-router"].append(
+            "archive-key"
+        )
+        state["inventory_policies"][
+            "kms_key|us-central1|trusted-router|archive-key"
+        ] = _policy(binding)
+    else:
+        email = f"legacy-runtime@{PROJECT}.iam.gserviceaccount.com"
+        state["inventories"]["service_accounts"].append(email)
+        state["service_account_policies"][email] = _policy(
+            {
+                "role": "roles/iam.serviceAccountTokenCreator",
+                "members": [member],
+            }
+        )
+
+    run, events = _run(tmp_path, state, with_manifest=False)
+
+    assert run.returncode != 0
+    assert "unsafe six-runtime IAM" in run.stderr
+    assert any(" list " in f" {event} " for event in events)
+
+
+@pytest.mark.parametrize(
+    "inventory",
+    (
+        "spanner_instances",
+        "spanner_databases",
+        "bigtable_instances",
+        "bigtable_tables",
+        "kms_locations",
+        "kms_keyrings",
+        "kms_keys",
+        "service_accounts",
+    ),
+)
+def test_full_project_inventory_requires_every_canonical_resource(
+    tmp_path: Path,
+    inventory: str,
+) -> None:
+    state = _valid_state()
+    values = state["inventories"][inventory]
+    if isinstance(values, list):
+        values.clear()
+    else:
+        for resources in values.values():
+            resources.clear()
+
+    run, _ = _run(tmp_path, state, with_manifest=False)
+
+    assert run.returncode != 0
+    assert "absent from the project inventory" in run.stderr
+
+
+def test_unknown_secret_with_direct_runtime_grant_is_rejected(tmp_path: Path) -> None:
+    state = _valid_state()
+    state["secrets"]["unrelated-build-secret"] = _policy(
+        _binding("roles/secretmanager.secretAccessor", ("public",))
+    )
+
+    run, _ = _run(tmp_path, state)
+
+    assert run.returncode != 0
+    assert "unsafe exact accessor IAM" in run.stderr
+    assert "unrelated-build-secret" not in run.stdout + run.stderr
+
+
+def test_unknown_secret_with_direct_synthetic_grant_is_rejected(tmp_path: Path) -> None:
+    state = _valid_state()
+    state["secrets"]["unrelated-build-secret"] = _policy(
+        {
+            "role": "roles/secretmanager.secretAccessor",
+            "members": [_synthetic_member()],
+        }
+    )
+
+    run, _ = _run(tmp_path, state)
+
+    assert run.returncode != 0
+    assert "unsafe exact accessor IAM" in run.stderr
+    assert "unrelated-build-secret" not in run.stdout + run.stderr
+
+
+def test_observer_secret_requires_exact_internal_and_synthetic_owners(
+    tmp_path: Path,
+) -> None:
+    state = _valid_state()
+    state["secrets"]["trustedrouter-observer-internal-token"] = _policy(
+        {
+            "role": "roles/secretmanager.secretAccessor",
+            "members": [_member("internal"), _synthetic_member()],
+        }
+    )
+
+    run, _ = _run(tmp_path, state, with_manifest=False)
+
+    assert run.returncode == 0, run.stderr
+
+
+@pytest.mark.parametrize(
+    "target",
+    (
+        "project",
+        "spanner_instance",
+        "spanner_database",
+        "bigtable_instance",
+        "bigtable_table",
+        "keyring",
+        "byok",
+        "ads",
+        "folder",
+        "organization",
+    ),
+)
+def test_synthetic_identity_has_no_data_or_ancestor_role(
+    tmp_path: Path,
+    target: str,
+) -> None:
+    state = _valid_state()
+    state["policies"][target]["bindings"].append(
+        {
+            "role": "roles/viewer",
+            "members": [_synthetic_member()],
+        }
+    )
+
+    run, _ = _run(tmp_path, state, with_manifest=False)
+
+    assert run.returncode != 0
+    assert "unsafe six-runtime IAM" in run.stderr
+
+
+def test_synthetic_identity_cannot_impersonate_runtime_account(tmp_path: Path) -> None:
+    state = _valid_state()
+    state["service_account_policies"][_account("internal")]["bindings"].append(
+        {
+            "role": "roles/iam.serviceAccountTokenCreator",
+            "members": [_synthetic_member()],
+        }
+    )
+
+    run, _ = _run(tmp_path, state, with_manifest=False)
+
+    assert run.returncode != 0
+    assert "runtime service account has unsafe direct IAM" in run.stderr
+
+
+def test_known_secret_rejects_non_owner_accessor_principal(tmp_path: Path) -> None:
+    state = _valid_state()
+    state["secrets"]["trustedrouter-attribution-cookie-secret"]["bindings"].append(
+        {
+            "role": "roles/secretmanager.secretAccessor",
+            "members": ["serviceAccount:unrelated-build@quill-cloud-proxy.iam.gserviceaccount.com"],
+        }
+    )
+
+    run, _ = _run(tmp_path, state)
+
+    assert run.returncode != 0
+    assert "unsafe exact accessor IAM" in run.stderr
+
+
+@pytest.mark.parametrize(
+    "target",
+    ("project", "spanner_database", "runtime_account", "secret"),
+)
+def test_public_principal_is_rejected_on_every_policy_class(
+    tmp_path: Path,
+    target: str,
+) -> None:
+    state = _valid_state()
+    binding = {"role": "roles/viewer", "members": ["allUsers"]}
+    if target == "runtime_account":
+        state["service_account_policies"][_account("public")]["bindings"].append(
+            binding
+        )
+    elif target == "secret":
+        state["secrets"]["unrelated-build-secret"]["bindings"].append(
+            {
+                "role": "roles/secretmanager.secretAccessor",
+                "members": ["allAuthenticatedUsers"],
+            }
+        )
+    else:
+        state["policies"][target]["bindings"].append(binding)
+
+    run, _ = _run(tmp_path, state)
+
+    assert run.returncode != 0
+    assert "public or malformed IAM policy" in run.stderr
+
+
+@pytest.mark.parametrize("parent", ("spanner_instance", "folder"))
+def test_parent_scope_runtime_role_is_rejected(tmp_path: Path, parent: str) -> None:
+    state = _valid_state()
+    state["policies"][parent] = _policy(
+        _binding("roles/viewer", ("public",))
+    )
+
+    run, _ = _run(tmp_path, state)
+
+    assert run.returncode != 0
+    assert "IAM matrix drift" in run.stderr
+
+
+def test_cross_runtime_service_account_binding_is_rejected(tmp_path: Path) -> None:
+    state = _valid_state()
+    state["service_account_policies"][_account("public")]["bindings"].append(
+        {
+            "role": "roles/iam.serviceAccountTokenCreator",
+            "members": [_member("chat")],
+        }
+    )
+
+    run, _ = _run(tmp_path, state)
+
+    assert run.returncode != 0
+    assert "split runtime principal" in run.stderr
+
+
+@pytest.mark.parametrize("drift", ("conditional", "extra"))
+def test_conditional_or_extra_deploy_binding_is_rejected(
+    tmp_path: Path,
+    drift: str,
+) -> None:
+    state = _valid_state()
+    bindings = state["service_account_policies"][_account("public")]["bindings"]
+    if drift == "conditional":
+        bindings[0]["condition"] = {
+            "title": "temporary",
+            "expression": "request.time < timestamp('2030-01-01T00:00:00Z')",
+        }
+    else:
+        bindings.append(
+            {
+                "role": "roles/iam.serviceAccountTokenCreator",
+                "members": [f"serviceAccount:tr-deploy@{PROJECT}.iam.gserviceaccount.com"],
+            }
+        )
+
+    run, _ = _run(tmp_path, state)
+
+    assert run.returncode != 0
+    assert "deploy principal" in run.stderr
+
+
+@pytest.mark.parametrize("drift", ("disabled", "latest"))
+def test_disabled_or_latest_mounted_secret_version_is_rejected(
+    tmp_path: Path,
+    drift: str,
+) -> None:
+    state = _valid_state()
+    if drift == "disabled":
+        state["versions"]["trustedrouter-attribution-cookie-secret|7"] = "DISABLED"
+    else:
+        reference = state["revisions"][_candidate("public")]["spec"]["containers"][0][
+            "env"
+        ][0]["valueFrom"]["secretKeyRef"]
+        reference["key"] = "latest"
+
+    run, _ = _run(tmp_path, state)
+
+    assert run.returncode != 0
+    assert "secret" in run.stderr.lower()
+    assert "trustedrouter-attribution-cookie-secret" not in run.stdout + run.stderr
+
+
+@pytest.mark.parametrize(
+    "permission",
+    (
+        "storage.objects.get",
+        "storage.objects.getIamPolicy",
+        "secretmanager.versions.access",
+        "cloudkms.cryptoKeyVersions.useToDecrypt",
+        "iam.serviceAccounts.actAs",
+    ),
+)
+def test_project_broad_data_or_impersonation_permission_on_deploy_is_rejected(
+    tmp_path: Path,
+    permission: str,
+) -> None:
+    state = _valid_state()
+    deploy_member = f"serviceAccount:tr-deploy@{PROJECT}.iam.gserviceaccount.com"
+    state["policies"]["project"]["bindings"].append(
+        {"role": "roles/storage.objectAdmin", "members": [deploy_member]}
+    )
+    state["roles"]["roles/storage.objectAdmin"] = {
+        "name": "roles/storage.objectAdmin",
+        "includedPermissions": [permission],
+    }
+
+    run, events = _run(tmp_path, state)
+
+    assert run.returncode != 0
+    assert "broad data or impersonation permission at project" in run.stderr
+    assert any(
+        "iam roles describe roles/storage.objectAdmin" in event for event in events
+    )
+
+
+def test_exact_object_scoped_rollout_journal_role_and_bucket_binding_are_allowed(
+    tmp_path: Path,
+) -> None:
+    state = _valid_state()
+    role = f"projects/{PROJECT}/roles/trustedRouterRolloutJournal"
+    uri = "gs://trusted-router-rollout-state/releases/state.json"
+    deploy_member = f"serviceAccount:tr-deploy@{PROJECT}.iam.gserviceaccount.com"
+    state["roles"][role] = {
+        "name": role,
+        "deleted": False,
+        "includedPermissions": [
+            "storage.objects.get",
+            "storage.objects.create",
+            "storage.objects.delete",
+        ],
+    }
+    state["bucket_policy"] = _policy(
+        {
+            "role": role,
+            "members": [deploy_member],
+            "condition": {
+                "title": "trusted-router-rollout-journal",
+                "description": "forward-only rollout recovery journal",
+                "expression": (
+                    'resource.name == "projects/_/buckets/'
+                    'trusted-router-rollout-state/objects/releases/state.json"'
+                ),
+            },
+        }
+    )
+
+    run, events = _run(
+        tmp_path,
+        state,
+        extra_env={
+            "TR_ROLLOUT_STATE_GCS_URI": uri,
+            "TR_ROLLOUT_STATE_GCS_ROLE": role,
+        },
+    )
+
+    assert run.returncode == 0, run.stderr
+    assert any("storage buckets get-iam-policy" in event for event in events)
+    assert any(
+        "iam roles describe trustedRouterRolloutJournal" in event for event in events
+    )
+
+
+def test_rollout_journal_bucket_condition_drift_is_rejected(tmp_path: Path) -> None:
+    state = _valid_state()
+    role = f"projects/{PROJECT}/roles/trustedRouterRolloutJournal"
+    state["roles"][role] = {
+        "name": role,
+        "includedPermissions": [
+            "storage.objects.get",
+            "storage.objects.create",
+            "storage.objects.delete",
+        ],
+    }
+    state["bucket_policy"] = _policy(
+        {
+            "role": role,
+            "members": [
+                f"serviceAccount:tr-deploy@{PROJECT}.iam.gserviceaccount.com"
+            ],
+            "condition": {
+                "title": "trusted-router-rollout-journal",
+                "expression": (
+                    'resource.name.startsWith("projects/_/buckets/'
+                    'trusted-router-rollout-state/objects/")'
+                ),
+            },
+        }
+    )
+
+    run, _ = _run(
+        tmp_path,
+        state,
+        extra_env={
+            "TR_ROLLOUT_STATE_GCS_URI": (
+                "gs://trusted-router-rollout-state/releases/state.json"
+            ),
+            "TR_ROLLOUT_STATE_GCS_ROLE": role,
+        },
+    )
+
+    assert run.returncode != 0
+    assert "exact object-scoped binding" in run.stderr
+
+
+def test_recovery_bundle_iam_is_read_only_and_exactly_object_scoped(
+    tmp_path: Path,
+) -> None:
+    run, events = _run(
+        tmp_path,
+        _state_with_exact_recovery(),
+        extra_env=_recovery_env(),
+    )
+
+    assert run.returncode == 0, run.stderr
+    joined = "\n".join(events)
+    assert "storage buckets describe" in joined
+    assert "storage buckets get-iam-policy" in joined
+    assert "iam roles describe trustedRouterRolloutRecovery" in joined
+
+
+def test_recovery_bundle_uses_recovery_role_without_legacy_state_role(
+    tmp_path: Path,
+) -> None:
+    env = _recovery_env()
+    env.pop("TR_ROLLOUT_STATE_GCS_ROLE")
+
+    run, _ = _run(
+        tmp_path,
+        _state_with_exact_recovery(),
+        extra_env=env,
+    )
+
+    assert run.returncode == 0, run.stderr
+
+
+def test_recovery_bundle_rejects_broad_project_prefix_binding(tmp_path: Path) -> None:
+    state = _state_with_exact_recovery()
+    state["bucket_policy"]["bindings"][0]["condition"]["expression"] = (
+        'resource.name.startsWith("projects/_/buckets/'
+        f'{RECOVERY_BUCKET}/objects/trusted-router-rollouts/{PROJECT}/")'
+    )
+
+    run, _ = _run(tmp_path, state, extra_env=_recovery_env())
+
+    assert run.returncode != 0
+    assert "exact authority-and-bundle binding" in run.stderr
+
+
+@pytest.mark.parametrize("principal", ("allUsers", "group:unknown@example.com"))
+def test_recovery_bundle_rejects_public_and_unknown_principals(
+    tmp_path: Path,
+    principal: str,
+) -> None:
+    state = _state_with_exact_recovery()
+    state["bucket_policy"]["bindings"].append(
+        {"role": "roles/storage.objectViewer", "members": [principal]}
+    )
+
+    run, _ = _run(tmp_path, state, extra_env=_recovery_env())
+
+    assert run.returncode != 0
+    if principal == "allUsers":
+        assert "public or malformed IAM policy" in run.stderr
+    else:
+        assert "exact authority-and-bundle binding" in run.stderr
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("uniform", False),
+        ("public_prevention", "inherited"),
+        ("versioning", False),
+        ("retention", "604799"),
+    ),
+)
+def test_recovery_bundle_rejects_weakened_bucket_protection(
+    tmp_path: Path,
+    field: str,
+    value: object,
+) -> None:
+    state = _state_with_exact_recovery()
+    metadata = state["bucket_metadata"]
+    if field == "uniform":
+        metadata["iamConfiguration"]["uniformBucketLevelAccess"]["enabled"] = value
+    elif field == "public_prevention":
+        metadata["iamConfiguration"]["publicAccessPrevention"] = value
+    elif field == "versioning":
+        metadata["versioning"]["enabled"] = value
+    else:
+        metadata["retentionPolicy"]["retentionPeriod"] = value
+
+    run, _ = _run(tmp_path, state, extra_env=_recovery_env())
+
+    assert run.returncode != 0
+    assert "bucket protection contract drifted" in run.stderr
+
+
+def test_recovery_bundle_rejects_role_permission_expansion(tmp_path: Path) -> None:
+    state = _state_with_exact_recovery()
+    state["roles"][RECOVERY_ROLE]["includedPermissions"].append(
+        "storage.objects.list"
+    )
+
+    run, _ = _run(tmp_path, state, extra_env=_recovery_env())
+
+    assert run.returncode != 0
+    assert "exact three-permission role" in run.stderr
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    (
+        (
+            "TR_ROLLOUT_AUTHORITY_GCS_URI",
+            f"gs://{RECOVERY_BUCKET}/trusted-router-rollouts/{PROJECT}/other.json",
+        ),
+        (
+            "TR_ROLLOUT_BUNDLE_GCS_URI",
+            f"gs://{RECOVERY_BUCKET}/trusted-router-rollouts/{PROJECT}/releases/short",
+        ),
+        (
+            "TR_ROLLOUT_STATE_GCS_URI",
+            f"gs://{RECOVERY_BUCKET}/trusted-router-rollouts/{PROJECT}/promotion-state.json",
+        ),
+        (
+            "TR_ROLLOUT_STATE_GCS_ROLE",
+            f"projects/{PROJECT}/roles/aDifferentRolloutRole",
+        ),
+    ),
+)
+def test_recovery_bundle_rejects_noncanonical_authority_bundle_state_or_role(
+    tmp_path: Path,
+    name: str,
+    value: str,
+) -> None:
+    env = _recovery_env()
+    env[name] = value
+
+    run, events = _run(
+        tmp_path,
+        _state_with_exact_recovery(),
+        extra_env=env,
+    )
+
+    assert run.returncode != 0
+    assert not any("storage buckets" in event for event in events)

--- a/tests/test_rollout_journal.py
+++ b/tests/test_rollout_journal.py
@@ -1,0 +1,185 @@
+"""Focused tests for the atomic rollout journal and recovery records."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL = ROOT / "scripts/deploy/rollout_journal.py"
+
+
+def _run(*arguments: str | Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603
+        [sys.executable, str(TOOL), *(str(value) for value in arguments)],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _manifest(tmp_path: Path) -> Path:
+    prior = tmp_path / "map.prior.json"
+    candidate = tmp_path / "map.candidate.json"
+    prior.write_text('{"name":"prior"}\n', encoding="utf-8")
+    candidate.write_text('{"name":"candidate"}\n', encoding="utf-8")
+    prior.chmod(0o600)
+    candidate.chmod(0o600)
+    manifest = tmp_path / "rollout.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "project_id": "quill-cloud-proxy",
+                "release": "release-1",
+                "promotion_state": "promotion-state.json",
+                "url_map": {
+                    "name": "trusted-router-map",
+                    "prior_sha256": "1" * 64,
+                    "candidate_sha256": "2" * 64,
+                    "prior_snapshot": prior.name,
+                    "candidate_snapshot": candidate.name,
+                },
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    manifest.chmod(0o600)
+    return manifest
+
+
+def test_active_lease_excludes_every_second_operation(tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path)
+    state = tmp_path / "promotion-state.json"
+
+    _run("lease-acquire", state, manifest, "operation-one", "promote")
+    assert state.stat().st_mode & 0o777 == 0o600
+
+    for owner in ("operation-two", "operation-one"):
+        conflict = _run(
+            "lease-acquire", state, manifest, owner, "rollback", check=False
+        )
+        assert conflict.returncode != 0
+        assert "active lease" in conflict.stderr
+
+    ownerless = _run(
+        "append", state, manifest, "traffic", "public", "service", "region", "10",
+        check=False,
+    )
+    assert ownerless.returncode != 0
+    assert "active lease owner" in ownerless.stderr
+
+    _run(
+        "append", state, manifest, "traffic", "public", "service", "region", "10",
+        "--owner", "operation-one",
+    )
+    _run("lease-refresh", state, manifest, "operation-one", "--ttl-seconds", "60")
+    _run("lease-release", state, manifest, "operation-one")
+    value = json.loads(state.read_text(encoding="utf-8"))
+    assert value["lease"] is None
+    assert value["attempts"][0]["target"] == "10"
+
+
+def test_expired_lease_requires_explicit_takeover(tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path)
+    state = tmp_path / "promotion-state.json"
+    _run("lease-acquire", state, manifest, "operation-one", "promote")
+    value = json.loads(state.read_text(encoding="utf-8"))
+    value["lease"]["expires_at"] = "2000-01-01T00:00:00+00:00"
+    state.write_text(json.dumps(value), encoding="utf-8")
+    state.chmod(0o600)
+
+    refused = _run(
+        "lease-acquire", state, manifest, "operation-two", "rollback", check=False
+    )
+    assert refused.returncode != 0
+    assert "explicit reconciled takeover" in refused.stderr
+
+    _run(
+        "lease-acquire", state, manifest, "operation-two", "rollback",
+        "--allow-expired-takeover",
+    )
+    assert json.loads(state.read_text(encoding="utf-8"))["lease"]["owner"] == (
+        "operation-two"
+    )
+
+
+def test_inflight_provider_mutation_permanently_fences_expired_takeover(
+    tmp_path: Path,
+) -> None:
+    manifest = _manifest(tmp_path)
+    state = tmp_path / "promotion-state.json"
+    _run("lease-acquire", state, manifest, "operation-one", "promote")
+    _run(
+        "lease-mutation-begin",
+        state,
+        manifest,
+        "operation-one",
+        "url-map",
+    )
+
+    release = _run(
+        "lease-release", state, manifest, "operation-one", check=False
+    )
+    assert release.returncode != 0
+    assert "in-flight provider mutation" in release.stderr
+
+    value = json.loads(state.read_text(encoding="utf-8"))
+    value["lease"]["expires_at"] = "2000-01-01T00:00:00+00:00"
+    state.write_text(json.dumps(value), encoding="utf-8")
+    state.chmod(0o600)
+    takeover = _run(
+        "lease-acquire",
+        state,
+        manifest,
+        "operation-two",
+        "rollback",
+        "--allow-expired-takeover",
+        check=False,
+    )
+    assert takeover.returncode != 0
+    assert "unresolved provider mutation" in takeover.stderr
+
+
+def test_state_schema_rejects_unknown_fields(tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path)
+    state = tmp_path / "promotion-state.json"
+    _run("lease-acquire", state, manifest, "operation-one", "promote")
+    value = json.loads(state.read_text(encoding="utf-8"))
+    value["unbound"] = True
+    state.write_text(json.dumps(value), encoding="utf-8")
+
+    result = _run("validate", state, manifest, check=False)
+    assert result.returncode != 0
+    assert "fields differ" in result.stderr
+
+
+def test_bundle_and_authority_are_atomic_exact_records(tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path)
+    descriptor = tmp_path / "bundle.json"
+    authority = tmp_path / "authority.json"
+
+    _run("bundle-write", manifest, descriptor)
+    assert descriptor.stat().st_mode & 0o777 == 0o600
+    validated = _run("bundle-validate", descriptor, tmp_path)
+    assert Path(validated.stdout.strip()) == manifest
+
+    bundle_uri = "gs://trusted-router-rollout/releases/release-0001"
+    _run("authority-write", manifest, authority, "active", bundle_uri)
+    assert authority.stat().st_mode & 0o777 == 0o600
+    _run("authority-validate", authority, manifest, "active", bundle_uri)
+    closed_mismatch = _run(
+        "authority-validate", authority, manifest, "closed", bundle_uri, check=False
+    )
+    assert closed_mismatch.returncode != 0
+
+    (tmp_path / "map.candidate.json").write_text(
+        '{"name":"tampered"}\n', encoding="utf-8"
+    )
+    tampered = _run("bundle-validate", descriptor, tmp_path, check=False)
+    assert tampered.returncode != 0
+    assert "validation failed" in tampered.stderr

--- a/tests/test_rollout_legacy_harden.py
+++ b/tests/test_rollout_legacy_harden.py
@@ -1,0 +1,392 @@
+"""Executable fake-provider tests for the legacy hardening prerequisite."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "scripts/deploy/rollout_legacy_harden.py"
+PROJECT = "quill-cloud-proxy"
+SERVICE = "trusted-router"
+REGIONS = ["us-central1", "us-east4"]
+RUNTIME_ACCOUNT = "123456789-compute@developer.gserviceaccount.com"
+IMAGE = "us-central1-docker.pkg.dev/quill-cloud-proxy/trusted-router/app@sha256:" + (
+    "a" * 64
+)
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("rollout_legacy_harden", SOURCE)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _revision(region: str) -> dict[str, Any]:
+    name = f"trusted-router-prior-{region}"
+    return {
+        "metadata": {"name": name, "annotations": {}},
+        "spec": {
+            "serviceAccountName": RUNTIME_ACCOUNT,
+            "containerConcurrency": 2,
+            "timeoutSeconds": 300,
+            "containers": [
+                {
+                    "image": IMAGE,
+                    "command": ["python"],
+                    "args": ["-m", "trusted_router"],
+                    "ports": [{"containerPort": 8080}],
+                    "resources": {"limits": {"cpu": "1", "memory": "2Gi"}},
+                    "startupProbe": {
+                        "httpGet": {"path": "/ready", "port": 8080},
+                        "failureThreshold": 18,
+                        "periodSeconds": 10,
+                        "timeoutSeconds": 10,
+                    },
+                    "env": [
+                        {"name": "TR_REGION", "value": region},
+                        {
+                            "name": "STRIPE_SECRET_KEY",
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "trustedrouter-stripe-secret-key",
+                                    "key": "latest",
+                                }
+                            },
+                        },
+                    ],
+                }
+            ],
+        },
+        "status": {"conditions": [{"type": "Ready", "status": "True"}]},
+    }
+
+
+def _service(region: str, revision: dict[str, Any]) -> dict[str, Any]:
+    name = revision["metadata"]["name"]
+    return {
+        "metadata": {
+            "name": SERVICE,
+            "generation": 7,
+            "annotations": {
+                "run.googleapis.com/ingress": "all",
+                "run.googleapis.com/ingress-status": "all",
+                "run.googleapis.com/default-url-disabled": "false",
+            },
+        },
+        "spec": {
+            "traffic": [{"latestRevision": True, "percent": 100}],
+            "template": {
+                "metadata": {
+                    "name": name,
+                    "annotations": {
+                        "run.googleapis.com/vpc-access-egress": "private-ranges-only"
+                    },
+                },
+                "spec": copy.deepcopy(revision["spec"]),
+            },
+        },
+        "status": {
+            "observedGeneration": 7,
+            "latestCreatedRevisionName": name,
+            "latestReadyRevisionName": name,
+            "traffic": [{"revisionName": name, "percent": 100}],
+            "conditions": [{"type": "Ready", "status": "True"}],
+        },
+    }
+
+
+class FakeCloud:
+    def __init__(self) -> None:
+        self.services: dict[str, dict[str, Any]] = {}
+        self.revisions: dict[tuple[str, str], dict[str, Any]] = {}
+        for region in REGIONS:
+            revision = _revision(region)
+            self.services[region] = _service(region, revision)
+            self.revisions[(region, revision["metadata"]["name"])] = revision
+        self.events: list[list[str]] = []
+        self.nonzero_after_apply = False
+        self.fail_before_once: str | None = None
+
+    @staticmethod
+    def _option(arguments: tuple[str, ...], name: str) -> str:
+        prefix = f"{name}="
+        return next(item[len(prefix) :] for item in arguments if item.startswith(prefix))
+
+    def json(self, *arguments: str) -> Any:
+        if arguments[:3] == ("run", "services", "describe"):
+            return copy.deepcopy(self.services[self._option(arguments, "--region")])
+        if arguments[:3] == ("run", "revisions", "describe"):
+            key = (self._option(arguments, "--region"), arguments[3])
+            if key not in self.revisions:
+                raise ValueError("revision absent")
+            return copy.deepcopy(self.revisions[key])
+        if arguments[:4] == ("run", "services", "get-iam-policy", SERVICE):
+            return {
+                "bindings": [
+                    {"role": "roles/run.invoker", "members": ["allUsers"]},
+                    {
+                        "role": "roles/run.invoker",
+                        "members": [f"serviceAccount:{RUNTIME_ACCOUNT}"],
+                    },
+                ],
+                "etag": "ignored-output-only",
+            }
+        if arguments[:3] == ("secrets", "versions", "describe"):
+            version = "7" if arguments[3] == "latest" else arguments[3]
+            return {
+                "name": (
+                    "projects/quill-cloud-proxy/secrets/"
+                    f"trustedrouter-stripe-secret-key/versions/{version}"
+                ),
+                "state": "ENABLED",
+            }
+        if arguments[:3] == ("secrets", "get-iam-policy", "trustedrouter-stripe-secret-key"):
+            return {
+                "bindings": [
+                    {
+                        "role": "roles/secretmanager.secretAccessor",
+                        "members": [f"serviceAccount:{RUNTIME_ACCOUNT}"],
+                    }
+                ]
+            }
+        raise AssertionError(f"unexpected read: {arguments!r}")
+
+    def optional_json(self, *arguments: str) -> Any | None:
+        try:
+            return self.json(*arguments)
+        except ValueError:
+            return None
+
+    def run(
+        self, *arguments: str, check: bool = True
+    ) -> subprocess.CompletedProcess[str]:
+        del check
+        self.events.append(list(arguments))
+        region = self._option(arguments, "--region")
+        command_text = " ".join(arguments)
+        if self.fail_before_once and self.fail_before_once in command_text:
+            self.fail_before_once = None
+            return subprocess.CompletedProcess(arguments, 23, "", "provider error")
+        if arguments[:3] == ("run", "services", "update-traffic"):
+            assignments = self._option(arguments, "--to-revisions").split(",")
+            traffic = []
+            for assignment in assignments:
+                revision, percent = assignment.rsplit("=", 1)
+                traffic.append({"revisionName": revision, "percent": int(percent)})
+            service = self.services[region]
+            service["spec"]["traffic"] = copy.deepcopy(traffic)
+            service["status"]["traffic"] = copy.deepcopy(traffic)
+            service["metadata"]["generation"] += 1
+            service["status"]["observedGeneration"] = service["metadata"]["generation"]
+        elif arguments[:3] == ("run", "services", "update"):
+            service = self.services[region]
+            suffix = self._option(arguments, "--revision-suffix")
+            candidate = f"{SERVICE}-{suffix}"
+            baseline = service["status"]["traffic"][0]["revisionName"]
+            spec = copy.deepcopy(self.revisions[(region, baseline)]["spec"])
+            spec["serviceAccountName"] = self._option(arguments, "--service-account")
+            pins = self._option(arguments, "--set-secrets")
+            versions = {
+                name: value.rsplit(":", 1)[1]
+                for name, value in (item.split("=", 1) for item in pins.split(","))
+            }
+            for item in spec["containers"][0]["env"]:
+                reference = ((item.get("valueFrom") or {}).get("secretKeyRef") or {})
+                if reference:
+                    reference["key"] = versions[item["name"]]
+            revision = {
+                "metadata": {"name": candidate, "annotations": {}},
+                "spec": spec,
+                "status": {"conditions": [{"type": "Ready", "status": "True"}]},
+            }
+            self.revisions[(region, candidate)] = revision
+            service["metadata"]["annotations"]["run.googleapis.com/ingress"] = (
+                "internal-and-cloud-load-balancing"
+            )
+            service["metadata"]["annotations"]["run.googleapis.com/ingress-status"] = (
+                "internal-and-cloud-load-balancing"
+            )
+            service["spec"]["template"] = {
+                "metadata": {
+                    "name": candidate,
+                    "annotations": {
+                        "run.googleapis.com/vpc-access-egress": "private-ranges-only"
+                    },
+                },
+                "spec": copy.deepcopy(spec),
+            }
+            service["metadata"]["generation"] += 1
+            service["status"]["observedGeneration"] = service["metadata"]["generation"]
+            service["status"]["latestCreatedRevisionName"] = candidate
+            service["status"]["latestReadyRevisionName"] = candidate
+        else:
+            raise AssertionError(f"unexpected mutation: {arguments!r}")
+        return subprocess.CompletedProcess(
+            arguments, 19 if self.nonzero_after_apply else 0, "", "provider error"
+        )
+
+
+def _invoke(
+    module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    cloud: FakeCloud,
+    artifact: Path,
+    *extra: str,
+) -> None:
+    monkeypatch.setattr(module, "Cloud", lambda project: cloud)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(SOURCE),
+            "--project",
+            PROJECT,
+            "--service",
+            SERVICE,
+            "--regions",
+            ",".join(REGIONS),
+            "--runtime-service-account",
+            RUNTIME_ACCOUNT,
+            "--operation-id",
+            "legacy-hardener-test-operation",
+            *extra,
+            str(artifact),
+        ],
+    )
+    module.main()
+
+
+def test_hardens_latest_legacy_cohort_and_verifies_read_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _load()
+    cloud = FakeCloud()
+    cloud.nonzero_after_apply = True
+    artifact = tmp_path / "legacy.json"
+
+    _invoke(
+        module,
+        monkeypatch,
+        cloud,
+        artifact,
+        "--revision-suffix",
+        "hard1",
+        "--artifact",
+    )
+
+    state_path = Path(f"{artifact}.state")
+    assert artifact.stat().st_mode & 0o777 == 0o600
+    assert state_path.stat().st_mode & 0o777 == 0o600
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert {item["state"] for item in state["regions"]} == {"ramp100"}
+    assert state["secret_refs"] == [
+        {
+            "name": "STRIPE_SECRET_KEY",
+            "resource": "trustedrouter-stripe-secret-key",
+            "version": "7",
+        }
+    ]
+    for region in REGIONS:
+        service = cloud.services[region]
+        assert service["metadata"]["annotations"]["run.googleapis.com/ingress"] == (
+            "internal-and-cloud-load-balancing"
+        )
+        assert service["spec"]["traffic"] == [
+            {"revisionName": "trusted-router-hard1", "percent": 100}
+        ]
+    updates = [event for event in cloud.events if event[:3] == ["run", "services", "update"]]
+    assert len(updates) == len(REGIONS)
+    assert all(f"--service-account={RUNTIME_ACCOUNT}" in event for event in updates)
+    assert all(
+        "--set-secrets=STRIPE_SECRET_KEY=trustedrouter-stripe-secret-key:7" in event
+        for event in updates
+    )
+
+    before = copy.deepcopy(cloud.events)
+    _invoke(module, monkeypatch, cloud, artifact, "--verify-artifact")
+    assert cloud.events == before
+
+
+def test_mid_ramp_failure_rolls_back_then_same_suffix_resume_adopts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _load()
+    cloud = FakeCloud()
+    cloud.fail_before_once = "trusted-router-hard2=50,trusted-router-prior-us-east4=50"
+    artifact = tmp_path / "legacy.json"
+
+    with pytest.raises(SystemExit, match="exact baseline traffic was restored"):
+        _invoke(
+            module,
+            monkeypatch,
+            cloud,
+            artifact,
+            "--revision-suffix",
+            "hard2",
+            "--artifact",
+        )
+
+    assert not artifact.exists()
+    state_path = Path(f"{artifact}.state")
+    assert {item["state"] for item in json.loads(state_path.read_text())["regions"]} == {
+        "rolled_back"
+    }
+    for region in REGIONS:
+        assert cloud.services[region]["spec"]["traffic"] == [
+            {"revisionName": f"trusted-router-prior-{region}", "percent": 100}
+        ]
+    deploy_count = sum(
+        event[:3] == ["run", "services", "update"] for event in cloud.events
+    )
+
+    _invoke(module, monkeypatch, cloud, artifact, "--artifact")
+    assert artifact.exists()
+    assert sum(
+        event[:3] == ["run", "services", "update"] for event in cloud.events
+    ) == deploy_count
+    assert {item["state"] for item in json.loads(state_path.read_text())["regions"]} == {
+        "ramp100"
+    }
+
+
+def test_tampered_state_and_cross_project_secret_fail_without_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _load()
+    cloud = FakeCloud()
+    artifact = tmp_path / "legacy.json"
+    state_path = Path(f"{artifact}.state")
+    state_path.write_text('{"unbound":true}\n', encoding="utf-8")
+    state_path.chmod(0o600)
+    with pytest.raises(SystemExit, match="state fields differ"):
+        _invoke(module, monkeypatch, cloud, artifact, "--artifact")
+    assert cloud.events == []
+
+    state_path.unlink()
+    for revision in cloud.revisions.values():
+        reference = revision["spec"]["containers"][0]["env"][1]["valueFrom"][
+            "secretKeyRef"
+        ]
+        reference["name"] = "projects/attacker-project/secrets/stripe-key"
+    with pytest.raises(SystemExit, match="not local and canonical"):
+        _invoke(
+            module,
+            monkeypatch,
+            cloud,
+            artifact,
+            "--revision-suffix",
+            "hard3",
+            "--artifact",
+        )
+    assert cloud.events == []

--- a/tests/test_rollout_local_lock.py
+++ b/tests/test_rollout_local_lock.py
@@ -1,0 +1,51 @@
+"""Local serialization contract for pre-promotion rollout mutations."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LOCK = ROOT / "scripts/deploy/rollout_local_lock.py"
+
+
+def _command(lock_path: Path, delay: str) -> list[str]:
+    return [
+        sys.executable,
+        str(LOCK),
+        str(lock_path),
+        "--",
+        sys.executable,
+        "-c",
+        f"import time; time.sleep({delay})",
+    ]
+
+
+def test_local_rollout_lock_rejects_concurrent_mutation_and_releases_on_exit(
+    tmp_path: Path,
+) -> None:
+    lock_path = tmp_path / "rollout.lock"
+    first = subprocess.Popen(  # noqa: S603
+        _command(lock_path, "0.6"),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    deadline = time.monotonic() + 2
+    while not lock_path.exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    time.sleep(0.05)
+    second = subprocess.run(  # noqa: S603
+        _command(lock_path, "0"), capture_output=True, text=True, check=False
+    )
+    assert second.returncode != 0
+    assert "another local rollout operation" in second.stderr
+    assert first.wait(timeout=2) == 0
+
+    third = subprocess.run(  # noqa: S603
+        _command(lock_path, "0"), capture_output=True, text=True, check=False
+    )
+    assert third.returncode == 0, third.stderr
+    assert lock_path.stat().st_mode & 0o777 == 0o600

--- a/tests/test_rollout_smoke.py
+++ b/tests/test_rollout_smoke.py
@@ -1,0 +1,254 @@
+"""Execution tests for the repository-owned production smoke callback."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import NoReturn
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.test_six_surface_rollout import _fixture
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.routes import chat_proxy
+from trusted_router.routes.internal import gateway
+
+ROOT = Path(__file__).resolve().parents[1]
+SMOKE = ROOT / "scripts/deploy/rollout_smoke.sh"
+
+
+def _fake_commands(tmp_path: Path) -> tuple[Path, Path]:
+    binary_dir = tmp_path / "smoke-bin"
+    binary_dir.mkdir()
+    events = tmp_path / "smoke-events"
+    curl = binary_dir / "curl"
+    curl.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, os, sys\n"
+        "from pathlib import Path\n"
+        "args = sys.argv[1:]\n"
+        "fault = os.environ.get('SMOKE_FAULT', '')\n"
+        "output = Path(args[args.index('--output') + 1])\n"
+        "url = next(value for value in args if value.startswith('https://'))\n"
+        "headers = [args[index + 1] for index, value in enumerate(args) "
+        "if value == '--header']\n"
+        "request_id = next((value.split(':', 1)[1].strip() for value in headers "
+        "if value.lower().startswith('x-request-id:')), '')\n"
+        "if url.endswith('/auth/session'):\n"
+        "    body = {'data': {'authenticated': True, 'management': True}}\n"
+        "elif url.endswith('/v1/models'):\n"
+        "    body = {'data': list(range(101))}\n"
+        "elif url.endswith('/chat-proxy/v1/chat/completions'):\n"
+        "    assert '--request' in args and args[args.index('--request') + 1] == 'POST'\n"
+        "    assert not any(value.split(':', 1)[1].strip() for value in headers "
+        "if value.lower().startswith('authorization:'))\n"
+        "    body = {'error': {'code': 401, 'message': 'Missing Authentication header', "
+        "'type': 'unauthorized', 'source': 'router'}}\n"
+        "elif url.endswith('/v1/internal/gateway/authorize'):\n"
+        "    assert '--request' in args and args[args.index('--request') + 1] == 'POST'\n"
+        "    assert not any(value.split(':', 1)[1].strip() for value in headers "
+        "if value.lower().startswith('authorization:'))\n"
+        "    body = {'error': {'code': 401, 'message': 'Invalid internal service token', "
+        "'type': 'unauthorized', 'source': 'router'}}\n"
+        "else:\n"
+        "    body = {}\n"
+        "output.write_text(json.dumps(body), encoding='utf-8')\n"
+        "code = ('401' if url.endswith(('/chat-proxy/v1/chat/completions', "
+        "'/v1/internal/gateway/authorize')) else "
+        "('422' if url.endswith('/support/inquiry') else "
+        "('400' if url.endswith('/internal/stripe/webhook') else '200')))\n"
+        "if '--dump-header' in args:\n"
+        "    header_output = Path(args[args.index('--dump-header') + 1])\n"
+        "    extra_header = (\n"
+        "        'x-trustedrouter-provider: must-not-exist\\r\\n'\n"
+        "        if fault == 'chat-provider-header' and "
+        "url.endswith('/chat-proxy/v1/chat/completions')\n"
+        "        else ''\n"
+        "    )\n"
+        "    header_output.write_text(\n"
+        "        'HTTP/2 401\\r\\n'\n"
+        "        'content-type: application/json\\r\\n'\n"
+        "        f'x-trustedrouter-request-id: {request_id}\\r\\n'\n"
+        "        'strict-transport-security: max-age=63072000; includeSubDomains\\r\\n'\n"
+        "        f'{extra_header}\\r\\n',\n"
+        "        encoding='iso-8859-1',\n"
+        "    )\n"
+        "with Path(os.environ['SMOKE_EVENTS']).open('a', encoding='utf-8') as log:\n"
+        "    log.write(f'curl {url} {code}\\n')\n"
+        "print(code, end='')\n",
+        encoding="utf-8",
+    )
+    curl.chmod(0o755)
+    npx = binary_dir / "npx"
+    npx.write_text(
+        "#!/usr/bin/env bash\n"
+        "printf 'npx' >> \"$SMOKE_EVENTS\"\n"
+        "printf ' %s' \"$@\" >> \"$SMOKE_EVENTS\"\n"
+        "printf '\\n' >> \"$SMOKE_EVENTS\"\n",
+        encoding="utf-8",
+    )
+    npx.chmod(0o755)
+    return binary_dir, events
+
+
+def _credentials(tmp_path: Path) -> tuple[Path, Path]:
+    header = tmp_path / "authorization.header"
+    header.write_text("Authorization: Bearer " + "a" * 32 + "\n", encoding="utf-8")
+    header.chmod(0o600)
+    storage = tmp_path / "storage-state.json"
+    storage.write_text('{"cookies":[],"origins":[]}\n', encoding="utf-8")
+    storage.chmod(0o600)
+    return header, storage
+
+
+def _run(
+    tmp_path: Path,
+    manifest: Path,
+    *,
+    approved: str,
+    fault: str = "",
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    binary_dir, events = _fake_commands(tmp_path)
+    header, storage = _credentials(tmp_path)
+    result = subprocess.run(  # noqa: S603
+        ["/bin/bash", str(SMOKE), str(manifest), "primary", "10"],
+        env={
+            **os.environ,
+            "PATH": f"{binary_dir}:{os.environ['PATH']}",
+            "SMOKE_EVENTS": str(events),
+            "SMOKE_FAULT": fault,
+            "TR_ROLLOUT_SMOKE_PRODUCTION_APPROVED": approved,
+            "TR_ROLLOUT_SMOKE_AUTH_HEADER_FILE": str(header),
+            "TR_ROLLOUT_SMOKE_PLAYWRIGHT_STORAGE_STATE": str(storage),
+        },
+        capture_output=True,
+        text=True,
+    )
+    return result, events
+
+
+def test_fixed_smoke_runs_api_matrix_and_firefox(tmp_path: Path) -> None:
+    manifest, _, _ = _fixture(tmp_path, regions=["us-central1"])
+    result, events = _run(tmp_path, manifest, approved="true")
+    assert result.returncode == 0, result.stderr
+    lines = events.read_text(encoding="utf-8").splitlines()
+    for domain in ("trustedrouter.com", "allyrouter.com", "uptimerouter.com"):
+        assert f"curl https://{domain}/ 200" in lines
+        assert f"curl https://{domain}/auth/session 200" in lines
+        assert f"curl https://{domain}/support/inquiry 422" in lines
+        assert f"curl https://{domain}/internal/stripe/webhook 400" in lines
+        assert f"curl https://{domain}/chat-proxy/v1/chat/completions 401" in lines
+        assert f"curl https://{domain}/v1/internal/gateway/authorize 401" in lines
+    assert any(
+        line.startswith("npx playwright test ")
+        and "--project=firefox" in line
+        and "production_rollout_smoke.spec.js" in line
+        for line in lines
+    )
+
+
+def test_fixed_smoke_requires_explicit_production_approval_before_network(
+    tmp_path: Path,
+) -> None:
+    manifest, _, _ = _fixture(tmp_path, regions=["us-central1"])
+    result, events = _run(tmp_path, manifest, approved="false")
+    assert result.returncode != 0
+    assert "explicit approval" in result.stderr
+    assert not events.exists()
+
+
+def test_fixed_smoke_fails_closed_before_firefox_on_upstream_header_drift(
+    tmp_path: Path,
+) -> None:
+    manifest, _, _ = _fixture(tmp_path, regions=["us-central1"])
+    result, events = _run(
+        tmp_path,
+        manifest,
+        approved="true",
+        fault="chat-provider-header",
+    )
+    assert result.returncode != 0
+    assert "unexpectedly returned x-trustedrouter-provider" in result.stderr
+    assert not any(
+        line.startswith("npx ")
+        for line in events.read_text(encoding="utf-8").splitlines()
+    )
+
+
+def _unexpected_high_risk_work(*_args: object, **_kwargs: object) -> NoReturn:
+    raise AssertionError("auth-rejection smoke reached high-risk handler work")
+
+
+def test_chat_smoke_rejection_stops_before_outbound_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def unexpected_forward(*args: object, **kwargs: object) -> NoReturn:
+        _unexpected_high_risk_work(*args, **kwargs)
+
+    monkeypatch.setattr(chat_proxy, "_forward", unexpected_forward)
+    client = TestClient(
+        create_app(
+            Settings(environment="test", service_surface="chat"),
+            configure_store_arg=False,
+            init_observability=False,
+        )
+    )
+
+    response = client.post(
+        "/chat-proxy/v1/chat/completions",
+        headers={"host": "trustedrouter.com", "x-request-id": "tr-rollout-chat-test"},
+        json={"smoke": "auth-gate-only"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["error"] == {
+        "code": 401,
+        "message": "Missing Authentication header",
+        "type": "unauthorized",
+        "source": "router",
+    }
+    assert response.headers["x-trustedrouter-request-id"] == "tr-rollout-chat-test"
+    assert response.headers["strict-transport-security"] == (
+        "max-age=63072000; includeSubDomains"
+    )
+
+
+def test_internal_smoke_rejection_stops_before_billing_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def unexpected_authorize(*args: object, **kwargs: object) -> NoReturn:
+        _unexpected_high_risk_work(*args, **kwargs)
+
+    monkeypatch.setattr(gateway, "authorize_gateway", unexpected_authorize)
+    client = TestClient(
+        create_app(
+            Settings(
+                environment="test",
+                service_surface="internal",
+                internal_gateway_token="rollout-test-internal-token",  # noqa: S106
+            ),
+            configure_store_arg=False,
+            init_observability=False,
+        )
+    )
+
+    response = client.post(
+        "/v1/internal/gateway/authorize",
+        headers={"host": "trustedrouter.com", "x-request-id": "tr-rollout-internal-test"},
+        json={"smoke": "auth-gate-only"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["error"] == {
+        "code": 401,
+        "message": "Invalid internal service token",
+        "type": "unauthorized",
+        "source": "router",
+    }
+    assert response.headers["x-trustedrouter-request-id"] == "tr-rollout-internal-test"
+    assert response.headers["strict-transport-security"] == (
+        "max-age=63072000; includeSubDomains"
+    )

--- a/tests/test_security_contracts.py
+++ b/tests/test_security_contracts.py
@@ -103,6 +103,10 @@ def test_sentry_test_route_is_disabled_in_production_unless_explicitly_enabled()
         service_surface="internal",
         internal_gateway_token="internal-prod-sentry-test",  # noqa: S106 - test config.
         observer_internal_token="observer-prod-sentry-test",  # noqa: S106 - test config.
+        stripe_secret_key="rk_test_payment_intents",  # noqa: S106 - test config.
+        aws_access_key_id="internal-ses-access",
+        aws_secret_access_key="internal-ses-secret",  # noqa: S106 - test config.
+        ses_from_email="noreply@example.com",
         sentry_dsn="https://example@example.ingest.sentry.io/1",
         storage_backend="spanner-bigtable",
         spanner_instance_id="trusted-router",
@@ -140,16 +144,17 @@ def test_sentry_test_route_is_disabled_in_production_unless_explicitly_enabled()
 
 
 def test_production_rejects_spoofable_user_header_auth() -> None:
-    webhook_secret = "whsec_" + "test"
     stripe_key = "sk_" + "test_secret"
     prod_client = TestClient(
         create_app(
             Settings(
                 environment="production",
-                service_surface="control",
+                service_surface="console",
                 attribution_cookie_secret="attribution-cookie-" + "a" * 32,
-                stripe_webhook_secret=webhook_secret,
                 stripe_secret_key=stripe_key,
+                google_oauth_login_available=False,
+                github_oauth_login_available=False,
+                paypal_checkout_enabled=False,
                 sentry_dsn="https://example@example.ingest.sentry.io/1",
                 aws_access_key_id="test-access-key",
                 aws_secret_access_key="test-secret-key",  # noqa: S106 - test fixture.
@@ -241,7 +246,7 @@ def test_deployed_stripe_webhook_fails_closed_without_verification_secret() -> N
     # Bypass Settings' startup validation to independently pin the route's
     # defense in depth. A future construction-path regression still must not
     # make an Internet-deployed webhook trust raw JSON.
-    settings = Settings(environment="test", service_surface="control")
+    settings = Settings(environment="test", service_surface="webhooks")
     settings.environment = "canary"
     client = TestClient(create_app(settings, init_observability=False))
 
@@ -812,11 +817,19 @@ def test_local_key_file_is_not_loaded_under_pytest(monkeypatch) -> None:
 
 
 def test_playwright_server_runs_with_test_observability_disabled() -> None:
-    config = (Path(__file__).resolve().parents[1] / "playwright.config.js").read_text(encoding="utf-8")
+    repository = Path(__file__).resolve().parents[1]
+    config = (repository / "playwright.config.js").read_text(encoding="utf-8")
+    server = (repository / "tests/browser/six_surface_server.py").read_text(
+        encoding="utf-8"
+    )
 
-    assert "TR_ENVIRONMENT=test" in config
-    assert "TR_STORAGE_BACKEND=memory" in config
-    assert "TR_SENTRY_DSN=" in config
+    assert "tests.browser.six_surface_server:app" in config
+    assert "reuseExistingServer: false" in config
+    assert '"environment": "test"' in server
+    assert '"storage_backend": "memory"' in server
+    assert '"sentry_dsn": None' in server
+    assert "_without_ambient_credentials()" in server
+    assert "_without_outbound_network()" in server
 
 
 def test_inference_key_labels_are_partial_and_raw_key_is_one_time_only(

--- a/tests/test_service_surface_routing.py
+++ b/tests/test_service_surface_routing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import re
 from pathlib import Path
 from types import ModuleType
@@ -24,13 +25,25 @@ def _load_url_map_module() -> ModuleType:
 
 
 URL_MAP = _load_url_map_module()
+PRESERVED_HOSTS = [
+    "api.trustedrouter.com",
+    "api.allyrouter.com",
+    "api.uptimerouter.com",
+    "api-aws.trustedrouter.com",
+    "api-azure.trustedrouter.com",
+    "api-azure-nz.trustedrouter.com",
+    "api-azure-sea.trustedrouter.com",
+    "api-eu-west-1.trustedrouter.com",
+]
 
 
 def _concrete(path: str) -> str:
     return re.sub(r"\{[^}]+\}", "sample", path)
 
 
-@pytest.mark.parametrize("surface", ["public", "actions", "control", "internal"])
+@pytest.mark.parametrize(
+    "surface", ["public", "actions", "console", "chat", "webhooks", "internal"]
+)
 def test_every_registered_route_maps_to_its_service_surface(surface: str) -> None:
     app = create_app(
         Settings(environment="test", service_surface=surface),
@@ -52,13 +65,18 @@ def test_every_registered_route_maps_to_its_service_surface(surface: str) -> Non
         "/internal/adyen/webhook",
         "/internal/veriff/webhook",
         "/internal/ses/notifications",
-        "/internal/chat/issue-browser-key",
     ],
 )
-def test_control_exceptions_beat_the_internal_wildcard(prefix: str, path: str) -> None:
+def test_webhook_exceptions_beat_the_internal_wildcard(prefix: str, path: str) -> None:
     unversioned = path.removeprefix("/internal")
     candidate = f"{prefix}/internal{unversioned}"
-    assert URL_MAP.route_surface(candidate) == "control"
+    assert URL_MAP.route_surface(candidate) == "webhooks"
+    assert URL_MAP.route_surface(f"{prefix}/internal/gateway/authorize") == "internal"
+
+
+@pytest.mark.parametrize("prefix", ["", "/v1"])
+def test_console_browser_key_exception_beats_the_internal_wildcard(prefix: str) -> None:
+    assert URL_MAP.route_surface(f"{prefix}/internal/chat/issue-browser-key") == "console"
     assert URL_MAP.route_surface(f"{prefix}/internal/gateway/authorize") == "internal"
 
 
@@ -67,7 +85,7 @@ def test_catalog_public_and_authenticated_paths_have_distinct_owners(prefix: str
     assert URL_MAP.route_surface(f"{prefix}/models/count") == "public"
     assert URL_MAP.route_surface(f"{prefix}/models/picker") == "public"
     assert URL_MAP.route_surface(f"{prefix}/models/author/slug/endpoints") == "public"
-    assert URL_MAP.route_surface(f"{prefix}/models/user") == "control"
+    assert URL_MAP.route_surface(f"{prefix}/models/user") == "console"
     assert URL_MAP.route_surface(f"{prefix}/models/user-provided") == "public"
     assert URL_MAP.route_surface(f"{prefix}/models/user-provided/sample") == "public"
 
@@ -82,18 +100,18 @@ def test_group_buy_public_reads_and_private_state_have_distinct_owners() -> None
     assert URL_MAP.route_surface("/bedrock-group-buy") == "public"
     assert URL_MAP.route_surface("/bedrock-group-buy/") == "public"
     assert URL_MAP.route_surface("/v1/bedrock-group-buy") == "public"
-    assert URL_MAP.route_surface("/bedrock-group-buy/manage") == "control"
-    assert URL_MAP.route_surface("/bedrock-group-buy/pledge") == "control"
-    assert URL_MAP.route_surface("/bedrock-group-buy/withdraw") == "control"
-    assert URL_MAP.route_surface("/v1/bedrock-group-buy/me") == "control"
-    assert URL_MAP.route_surface("/v1/bedrock-group-buy/pledge") == "control"
+    assert URL_MAP.route_surface("/bedrock-group-buy/manage") == "console"
+    assert URL_MAP.route_surface("/bedrock-group-buy/pledge") == "console"
+    assert URL_MAP.route_surface("/bedrock-group-buy/withdraw") == "console"
+    assert URL_MAP.route_surface("/v1/bedrock-group-buy/me") == "console"
+    assert URL_MAP.route_surface("/v1/bedrock-group-buy/pledge") == "console"
 
 
 @pytest.mark.parametrize("prefix", ["", "/v1"])
-def test_carrier_texml_is_public_but_notification_mutations_are_control(prefix: str) -> None:
+def test_carrier_texml_is_public_but_notification_mutations_are_console(prefix: str) -> None:
     assert URL_MAP.route_surface(f"{prefix}/notify/texml") == "public"
-    assert URL_MAP.route_surface(f"{prefix}/notify") == "control"
-    assert URL_MAP.route_surface(f"{prefix}/notify/phone/start") == "control"
+    assert URL_MAP.route_surface(f"{prefix}/notify") == "console"
+    assert URL_MAP.route_surface(f"{prefix}/notify/phone/start") == "console"
 
 
 def test_rewrite_preserves_explicit_unrelated_hosts_but_defaults_unknown_to_public() -> None:
@@ -106,7 +124,7 @@ def test_rewrite_preserves_explicit_unrelated_hosts_but_defaults_unknown_to_publ
             {"hosts": ["trustedrouter.com", "www.trustedrouter.com"], "pathMatcher": "old"},
             {
                 "hosts": [
-                    "api.trustedrouter.com",
+                    *PRESERVED_HOSTS,
                     "aws.trustedrouter.com",
                     "azure.trustedrouter.com",
                     "b.trustedrouter.com",
@@ -136,9 +154,12 @@ def test_rewrite_preserves_explicit_unrelated_hosts_but_defaults_unknown_to_publ
         existing,
         "public-backend",
         "actions-backend",
-        "control-backend",
+        "console-backend",
+        "chat-backend",
+        "webhooks-backend",
         "internal-backend",
         ["trustedrouter.com", "allyrouter.com", "uptimerouter.com"],
+        PRESERVED_HOSTS,
     )
 
     assert result["defaultService"] == "public-backend"
@@ -169,8 +190,7 @@ def test_rewrite_preserves_explicit_unrelated_hosts_but_defaults_unknown_to_publ
         if rule is not first_party
         for host in rule["hosts"]
     }
-    assert preserved_hosts == {
-        "api.trustedrouter.com",
+    assert preserved_hosts == set(PRESERVED_HOSTS) | {
         "aws.trustedrouter.com",
         "azure.trustedrouter.com",
         "b.trustedrouter.com",
@@ -186,7 +206,9 @@ def test_rewrite_preserves_explicit_unrelated_hosts_but_defaults_unknown_to_publ
     assert {rule["service"] for rule in matcher["pathRules"]} == {
         "public-backend",
         "actions-backend",
-        "control-backend",
+        "console-backend",
+        "chat-backend",
+        "webhooks-backend",
         "internal-backend",
     }
     assert result["tests"][0]["service"] == "public-backend"
@@ -202,9 +224,12 @@ def test_rewrite_refuses_an_existing_catch_all_host_rule() -> None:
             },
             "public",
             "actions",
-            "control",
+            "console",
+            "chat",
+            "webhooks",
             "internal",
             ["trustedrouter.com"],
+            PRESERVED_HOSTS,
         )
 
 
@@ -214,9 +239,12 @@ def test_rewrite_refuses_missing_unrelated_default_service() -> None:
             {"hostRules": []},
             "public",
             "actions",
-            "control",
+            "console",
+            "chat",
+            "webhooks",
             "internal",
             ["trustedrouter.com"],
+            PRESERVED_HOSTS,
         )
 
 
@@ -231,9 +259,12 @@ def test_rewrite_refuses_first_party_wildcard_instead_of_stealing_subdomains() -
             },
             "public",
             "actions",
-            "control",
+            "console",
+            "chat",
+            "webhooks",
             "internal",
             ["trustedrouter.com"],
+            PRESERVED_HOSTS,
         )
 
 
@@ -244,13 +275,15 @@ def test_rewrite_refuses_reserved_matcher_owned_by_unrelated_host() -> None:
             {
                 "hosts": ["unrelated.example"],
                 "pathMatcher": "trusted-router-service-surfaces",
-            }
+            },
+            {"hosts": PRESERVED_HOSTS, "pathMatcher": "regional"},
         ],
         "pathMatchers": [
             {
                 "name": "trusted-router-service-surfaces",
                 "defaultService": "unrelated-backend",
-            }
+            },
+            {"name": "regional", "defaultService": "regional-backend"},
         ],
     }
 
@@ -259,7 +292,111 @@ def test_rewrite_refuses_reserved_matcher_owned_by_unrelated_host() -> None:
             existing,
             "public-backend",
             "actions-backend",
-            "control-backend",
+            "console-backend",
+            "chat-backend",
+            "webhooks-backend",
             "internal-backend",
             ["trustedrouter.com", "allyrouter.com", "uptimerouter.com"],
+            PRESERVED_HOSTS,
         )
+
+
+def test_rewrite_refuses_preserved_host_that_relied_on_old_default() -> None:
+    missing = "api-azure-sea.trustedrouter.com"
+    explicitly_routed = [host for host in PRESERVED_HOSTS if host != missing]
+
+    with pytest.raises(ValueError, match="top-level default"):
+        URL_MAP.rewrite_url_map(
+            {
+                "defaultService": "legacy-attested-default",
+                "hostRules": [
+                    {"hosts": explicitly_routed, "pathMatcher": "attested"}
+                ],
+                "pathMatchers": [
+                    {"name": "attested", "defaultService": "attested-backend"}
+                ],
+            },
+            "public-backend",
+            "actions-backend",
+            "console-backend",
+            "chat-backend",
+            "webhooks-backend",
+            "internal-backend",
+            ["trustedrouter.com", "allyrouter.com", "uptimerouter.com"],
+            PRESERVED_HOSTS,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        (
+            "headerAction",
+            {
+                "requestHeadersToAdd": [
+                    {"headerName": "Authorization", "headerValue": "Bearer stale"}
+                ]
+            },
+            "header action",
+        ),
+        ("defaultRouteAction", {"weightedBackendServices": []}, "default route action"),
+    ],
+)
+def test_rewrite_refuses_global_actions_that_can_affect_managed_hosts(
+    field: str,
+    value: object,
+    message: str,
+) -> None:
+    existing = {
+        "defaultService": "legacy",
+        "hostRules": [{"hosts": PRESERVED_HOSTS, "pathMatcher": "preserved"}],
+        "pathMatchers": [{"name": "preserved", "defaultService": "legacy"}],
+        field: value,
+    }
+
+    with pytest.raises(ValueError, match=message):
+        URL_MAP.rewrite_url_map(
+            existing,
+            "public",
+            "actions",
+            "console",
+            "chat",
+            "webhooks",
+            "internal",
+            ["trustedrouter.com", "allyrouter.com", "uptimerouter.com"],
+            PRESERVED_HOSTS,
+        )
+
+
+def test_atomic_url_map_output_is_private_and_complete(tmp_path: Path) -> None:
+    output = tmp_path / "candidate-url-map.json"
+    output.write_text('{"stale":true}\n', encoding="utf-8")
+    output.chmod(0o644)
+
+    expected = {"name": "candidate", "hostRules": [{"hosts": ["example.com"]}]}
+    URL_MAP._atomic_write_json(output, expected)
+
+    assert json.loads(output.read_text(encoding="utf-8")) == expected
+    assert output.stat().st_mode & 0o777 == 0o600
+    assert list(tmp_path.glob(f".{output.name}.*.tmp")) == []
+
+
+def test_atomic_url_map_replace_failure_preserves_prior_file_and_cleans_temp(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "candidate-url-map.json"
+    prior = b'{"name":"known-good"}\n'
+    output.write_bytes(prior)
+    output.chmod(0o640)
+
+    def fail_replace(_source: str, _destination: Path) -> None:
+        raise OSError("injected os.replace failure")
+
+    monkeypatch.setattr(URL_MAP.os, "replace", fail_replace)
+    with pytest.raises(OSError, match="injected os.replace failure"):
+        URL_MAP._atomic_write_json(output, {"name": "candidate"})
+
+    assert output.read_bytes() == prior
+    assert output.stat().st_mode & 0o777 == 0o640
+    assert list(tmp_path.glob(f".{output.name}.*.tmp")) == []

--- a/tests/test_service_surface_routing.py
+++ b/tests/test_service_surface_routing.py
@@ -171,7 +171,6 @@ def test_rewrite_preserves_explicit_unrelated_hosts_but_defaults_unknown_to_publ
         "trustedrouter.com",
         "www.trustedrouter.com",
         "status.trustedrouter.com",
-        "trust.trustedrouter.com",
         "eu.trustedrouter.com",
         "status-us.trustedrouter.com",
         "status-eu.trustedrouter.com",

--- a/tests/test_service_surface_secret_isolation.py
+++ b/tests/test_service_surface_secret_isolation.py
@@ -21,10 +21,12 @@ _PRODUCTION_STORAGE = {
     "spanner_database_id": "trusted-router",
     "bigtable_instance_id": "trusted-router-logs",
 }
-_CONTROL_SECRETS = {
+_CONSOLE_SECRETS = {
     "attribution_cookie_secret": _ATTRIBUTION_SECRET,
-    "stripe_webhook_secret": "whsec-test",
     "stripe_secret_key": "sk-test",
+    "paypal_checkout_enabled": False,
+    "google_oauth_login_available": False,
+    "github_oauth_login_available": False,
     "sentry_dsn": "https://example@example.ingest.sentry.io/1",
     "aws_access_key_id": "ses-access",
     "aws_secret_access_key": "ses-secret",
@@ -32,6 +34,17 @@ _CONTROL_SECRETS = {
     "byok_kms_key_name": (
         "projects/test/locations/global/keyRings/trusted-router/cryptoKeys/byok-envelope"
     ),
+}
+_INTERNAL_BILLING_SECRETS = {
+    "internal_gateway_token": _GATEWAY_SECRET,
+    "observer_internal_token": "observer-only-" + "o" * 32,
+    # These values model independently provisioned, restricted credentials;
+    # they deliberately do not reuse the console/actions secret resources.
+    "stripe_secret_key": "rk-test-payment-intents",
+    "sentry_dsn": "https://example@example.ingest.sentry.io/1",
+    "aws_access_key_id": "internal-ses-access",
+    "aws_secret_access_key": "internal-ses-secret",
+    "ses_from_email": "noreply@example.com",
 }
 
 _ACTION_FORBIDDEN_CONFIG: tuple[tuple[str, object, str], ...] = (
@@ -148,6 +161,7 @@ _SENSITIVE_TEST_VALUES: dict[str, object] = {
     "observer_internal_token": "observer-only-" + "o" * 32,
     "stripe_webhook_secret": "whsec-test",
     "stripe_secret_key": "sk-test",
+    "paypal_checkout_enabled": True,
     "paypal_client_id": "paypal-client",
     "paypal_client_secret": "paypal-secret",
     "paypal_webhook_id": "paypal-webhook",
@@ -187,16 +201,23 @@ _SENSITIVE_TEST_VALUES: dict[str, object] = {
 _EXPECTED_OWNER_GROUPS: tuple[tuple[frozenset[str], tuple[str, ...]], ...] = (
     (frozenset({"actions"}), ("ops_chat_webhook_secret",)),
     (
-        frozenset({"public", "control", "internal", "observer"}),
+        frozenset(
+            {"public", "console", "chat", "webhooks", "internal", "observer"}
+        ),
         (
             "postgres_dsn",
             "postgres_iam_auth",
+        ),
+    ),
+    (
+        frozenset({"public", "console", "internal", "observer"}),
+        (
             "operational_analytics_clickhouse_url",
             "operational_analytics_clickhouse_password",
         ),
     ),
     (
-        frozenset({"control", "internal"}),
+        frozenset({"console", "internal"}),
         (
             "clickhouse_url",
             "clickhouse_password",
@@ -205,22 +226,14 @@ _EXPECTED_OWNER_GROUPS: tuple[tuple[frozenset[str], tuple[str, ...]], ...] = (
         ),
     ),
     (
-        frozenset({"control"}),
+        frozenset({"console"}),
         (
             "provider_analytics_clickhouse_url",
             "provider_analytics_clickhouse_password",
             "google_data_manager_enabled",
             "google_data_manager_kms_key_name",
-            "stripe_webhook_secret",
-            "stripe_secret_key",
-            "paypal_client_id",
-            "paypal_client_secret",
-            "paypal_webhook_id",
-            "adyen_enabled",
             "adyen_api_key",
             "adyen_client_key",
-            "adyen_hmac_key",
-            "adyen_reference_key",
             "google_client_id",
             "google_client_secret",
             "google_alias_credentials_json",
@@ -229,17 +242,32 @@ _EXPECTED_OWNER_GROUPS: tuple[tuple[frozenset[str], tuple[str, ...]], ...] = (
             "github_alias_credentials_json",
             "x402_enabled",
             "notify_enabled",
-            "veriff_enabled",
             "veriff_api_key",
-            "veriff_shared_secret_key",
             "telnyx_api_key",
             "twilio_account_sid",
             "twilio_auth_token",
             "twilio_api_key_secret",
         ),
     ),
-    (frozenset({"control", "internal", "observer"}), ("sentry_dsn",)),
-    (frozenset({"public", "control"}), ("attribution_cookie_secret",)),
+    (frozenset({"console", "internal"}), ("stripe_secret_key",)),
+    (
+        frozenset({"console", "webhooks"}),
+        (
+            "paypal_checkout_enabled",
+            "paypal_client_id",
+            "paypal_client_secret",
+            "adyen_enabled",
+            "veriff_enabled",
+        ),
+    ),
+    (frozenset({"webhooks"}), ("paypal_webhook_id", "adyen_hmac_key")),
+    (frozenset({"console", "webhooks"}), ("adyen_reference_key",)),
+    (frozenset({"webhooks"}), ("stripe_webhook_secret", "veriff_shared_secret_key")),
+    (
+        frozenset({"console", "chat", "webhooks", "internal", "observer"}),
+        ("sentry_dsn",),
+    ),
+    (frozenset({"public", "console"}), ("attribution_cookie_secret",)),
     (
         frozenset({"internal"}),
         ("internal_gateway_token",),
@@ -253,7 +281,7 @@ _EXPECTED_OWNER_GROUPS: tuple[tuple[frozenset[str], tuple[str, ...]], ...] = (
         ("synthetic_monitor_api_key",),
     ),
     (
-        frozenset({"control", "actions"}),
+        frozenset({"console", "actions", "internal"}),
         ("aws_access_key_id", "aws_secret_access_key"),
     ),
     (
@@ -273,7 +301,15 @@ _EXPECTED_SENSITIVE_SETTING_OWNERS = {
     for owners, field_names in _EXPECTED_OWNER_GROUPS
     for field_name in field_names
 }
-_DEPLOYED_WEB_SURFACES = ("public", "actions", "control", "internal", "observer")
+_DEPLOYED_WEB_SURFACES = (
+    "public",
+    "actions",
+    "console",
+    "chat",
+    "webhooks",
+    "internal",
+    "observer",
+)
 _UNAUTHORIZED_SENSITIVE_CASES = tuple(
     (field_name, surface)
     for field_name, owners in sorted(_EXPECTED_SENSITIVE_SETTING_OWNERS.items())
@@ -296,7 +332,7 @@ def test_every_sensitive_setting_rejects_an_unauthorized_deployed_surface(
     assert set(_SENSITIVE_TEST_VALUES) == set(_EXPECTED_SENSITIVE_SETTING_OWNERS)
     assert SERVICE_SURFACE_SECRET_OWNERS == _EXPECTED_SENSITIVE_SETTING_OWNERS
     overrides: dict[str, object] = {field_name: _SENSITIVE_TEST_VALUES[field_name]}
-    if surface in {"public", "control"}:
+    if surface in {"public", "console"}:
         overrides.setdefault("attribution_cookie_secret", _ATTRIBUTION_SECRET)
     if surface in {"internal", "observer"}:
         overrides.setdefault(
@@ -305,6 +341,10 @@ def test_every_sensitive_setting_rejects_an_unauthorized_deployed_surface(
         )
         if surface == "internal":
             overrides.setdefault("internal_gateway_token", _GATEWAY_SECRET)
+            overrides.setdefault("stripe_secret_key", "rk-test-payment-intents")
+            overrides.setdefault("aws_access_key_id", "internal-ses-access")
+            overrides.setdefault("aws_secret_access_key", "internal-ses-secret")
+            overrides.setdefault("ses_from_email", "noreply@example.com")
     if field_name == "ops_chat_webhook_secret":
         overrides["ops_chat_webhook_urls"] = "https://ops.example/hook"
     if field_name == "postgres_iam_auth":
@@ -369,28 +409,69 @@ def test_public_production_needs_only_attribution_and_non_secret_login_flags() -
     assert settings.github_oauth_enabled is False
 
 
-def test_control_rejects_oauth_presentation_capability_drift() -> None:
-    with pytest.raises(ValidationError, match="must match the control service"):
+def test_console_rejects_oauth_presentation_capability_drift() -> None:
+    with pytest.raises(ValidationError, match="must match the console service"):
         Settings(
             environment="canary",
-            service_surface="control",
+            service_surface="console",
             attribution_cookie_secret=_ATTRIBUTION_SECRET,
-            stripe_webhook_secret="whsec-test",  # noqa: S106 - test credential.
             stripe_secret_key="sk-test",  # noqa: S106 - test credential.
+            paypal_checkout_enabled=False,
             google_oauth_login_available=True,
             github_oauth_login_available=False,
         )
 
     settings = Settings(
         environment="canary",
-        service_surface="control",
+        service_surface="console",
         attribution_cookie_secret=_ATTRIBUTION_SECRET,
-        stripe_webhook_secret="whsec-test",  # noqa: S106 - test credential.
         stripe_secret_key="sk-test",  # noqa: S106 - test credential.
+        paypal_checkout_enabled=False,
         google_oauth_login_available=False,
         github_oauth_login_available=False,
     )
     assert settings.google_oauth_enabled is False
+
+
+@pytest.mark.parametrize(
+    "missing_field",
+    ("google_oauth_login_available", "github_oauth_login_available"),
+)
+def test_console_requires_explicit_oauth_presentation_capabilities(
+    missing_field: str,
+) -> None:
+    capabilities = {
+        "google_oauth_login_available": False,
+        "github_oauth_login_available": False,
+    }
+    capabilities.pop(missing_field)
+
+    with pytest.raises(ValidationError, match=f"TR_{missing_field.upper()}=true or false"):
+        Settings(
+            environment="canary",
+            service_surface="console",
+            attribution_cookie_secret=_ATTRIBUTION_SECRET,
+            stripe_secret_key="sk-test",  # noqa: S106 - test credential.
+            paypal_checkout_enabled=False,
+            **capabilities,
+        )
+
+
+def test_console_accepts_oauth_capabilities_that_exactly_match_credentials() -> None:
+    settings = Settings(
+        environment="canary",
+        service_surface="console",
+        attribution_cookie_secret=_ATTRIBUTION_SECRET,
+        stripe_secret_key="sk-test",  # noqa: S106 - test credential.
+        paypal_checkout_enabled=False,
+        google_client_id="google-client",
+        google_client_secret="google-secret",  # noqa: S106 - test credential.
+        google_oauth_login_available=True,
+        github_oauth_login_available=False,
+    )
+
+    assert settings.google_oauth_enabled is True
+    assert settings.github_oauth_enabled is False
 
 
 def test_actions_production_has_no_store_or_private_plane_credentials() -> None:
@@ -525,24 +606,30 @@ def test_public_production_rejects_private_surface_secrets(name: str, value: str
         )
 
 
-def test_internal_and_observer_require_gateway_observability_but_not_account_secrets() -> None:
-    for surface in ("internal", "observer"):
-        auth = {
-            "observer_internal_token": _SENSITIVE_TEST_VALUES["observer_internal_token"]
-        }
-        if surface == "internal":
-            auth["internal_gateway_token"] = _GATEWAY_SECRET
-        settings = _production(
-            surface,
-            sentry_dsn="https://example@example.ingest.sentry.io/1",
-            **auth,
-        )
-        assert settings.stripe_secret_key is None
-        assert settings.aws_access_key_id is None
-        assert settings.byok_kms_key_name is None
+def test_internal_requires_restricted_billing_and_email_credentials() -> None:
+    settings = _production("internal", **_INTERNAL_BILLING_SECRETS)
+
+    assert settings.stripe_secret_key == "rk-test-payment-intents"  # noqa: S105
+    assert settings.aws_access_key_id == "internal-ses-access"
+    assert settings.aws_secret_access_key == "internal-ses-secret"  # noqa: S105
+    assert settings.ses_from_email == "noreply@example.com"
+    assert settings.stripe_webhook_secret is None
 
 
-@pytest.mark.parametrize("surface", ("internal", "observer"))
+@pytest.mark.parametrize(
+    "missing_field",
+    ("stripe_secret_key", "aws_access_key_id", "aws_secret_access_key", "ses_from_email"),
+)
+def test_internal_fails_closed_when_a_billing_side_effect_credential_is_missing(
+    missing_field: str,
+) -> None:
+    values = dict(_INTERNAL_BILLING_SECRETS)
+    values.pop(missing_field)
+
+    with pytest.raises(ValidationError, match=f"TR_{missing_field.upper()}"):
+        _production("internal", **values)
+
+
 @pytest.mark.parametrize(
     ("name", "value"),
     (
@@ -553,58 +640,223 @@ def test_internal_and_observer_require_gateway_observability_but_not_account_sec
         ("aws_secret_access_key", "ses-secret"),
     ),
 )
-def test_non_account_surfaces_reject_account_secrets(
-    surface: str,
+def test_observer_rejects_billing_and_account_secrets(
     name: str,
     value: str,
 ) -> None:
-    auth = {
-        "observer_internal_token": _SENSITIVE_TEST_VALUES["observer_internal_token"]
-    }
-    if surface == "internal":
-        auth["internal_gateway_token"] = _GATEWAY_SECRET
     with pytest.raises(ValidationError, match=f"unset TR_{name.upper()}"):
         _production(
-            surface,
+            "observer",
             sentry_dsn="https://example@example.ingest.sentry.io/1",
-            **auth,
+            observer_internal_token=_SENSITIVE_TEST_VALUES["observer_internal_token"],
             **{name: value},
         )
 
 
-def test_control_requires_dedicated_attribution_secret() -> None:
-    with pytest.raises(ValidationError, match="TR_ATTRIBUTION_COOKIE_SECRET"):
-        _production("control", **{k: v for k, v in _CONTROL_SECRETS.items() if k != "attribution_cookie_secret"})
+@pytest.mark.parametrize(
+    ("name", "value"),
+    (
+        ("attribution_cookie_secret", _ATTRIBUTION_SECRET),
+        ("stripe_webhook_secret", "whsec-test"),
+    ),
+)
+def test_internal_rejects_console_and_webhook_only_secrets(
+    name: str,
+    value: str,
+) -> None:
+    with pytest.raises(ValidationError, match=f"unset TR_{name.upper()}"):
+        _production("internal", **_INTERNAL_BILLING_SECRETS, **{name: value})
 
-    settings = _production("control", **_CONTROL_SECRETS)
+
+def test_console_requires_dedicated_attribution_secret() -> None:
+    with pytest.raises(ValidationError, match="TR_ATTRIBUTION_COOKIE_SECRET"):
+        _production(
+            "console",
+            **{
+                k: v
+                for k, v in _CONSOLE_SECRETS.items()
+                if k != "attribution_cookie_secret"
+            },
+        )
+
+    settings = _production("console", **_CONSOLE_SECRETS)
     assert settings.attribution_cookie_secret == _ATTRIBUTION_SECRET
     assert settings.internal_gateway_token is None
 
 
-def test_control_rejects_the_internal_gateway_credential() -> None:
+def test_console_rejects_the_internal_gateway_credential() -> None:
     with pytest.raises(ValidationError, match="unset TR_INTERNAL_GATEWAY_TOKEN"):
         _production(
-            "control",
-            **_CONTROL_SECRETS,
+            "console",
+            **_CONSOLE_SECRETS,
             internal_gateway_token=_GATEWAY_SECRET,
         )
 
 
+def test_console_x402_needs_checkout_key_but_rejects_webhook_secret() -> None:
+    settings = _production("console", **_CONSOLE_SECRETS, x402_enabled=True)
+
+    assert settings.x402_enabled is True
+    assert settings.stripe_secret_key == "sk-test"  # noqa: S105 - test credential.
+    assert settings.stripe_webhook_secret is None
+
+    with pytest.raises(ValidationError, match="unset TR_STRIPE_WEBHOOK_SECRET"):
+        _production(
+            "console",
+            **_CONSOLE_SECRETS,
+            x402_enabled=True,
+            stripe_webhook_secret="whsec-test",  # noqa: S106 - test credential.
+        )
+
+
+def test_paypal_credentials_are_split_between_console_and_webhooks() -> None:
+    console = _production(
+        "console",
+        **{**_CONSOLE_SECRETS, "paypal_checkout_enabled": True},
+        paypal_client_id="paypal-client",
+        paypal_client_secret="paypal-secret",  # noqa: S106 - test credential.
+    )
+    assert console.paypal_enabled is True
+    assert console.paypal_webhook_id is None
+
+    webhooks = _production(
+        "webhooks",
+        sentry_dsn="https://example@example.ingest.sentry.io/1",
+        stripe_webhook_secret="whsec-test",  # noqa: S106 - test credential.
+        paypal_checkout_enabled=True,
+        paypal_client_id="paypal-client",
+        paypal_client_secret="paypal-secret",  # noqa: S106 - test credential.
+        paypal_webhook_id="paypal-webhook",
+    )
+    assert webhooks.paypal_webhook_ready is True
+
+    with pytest.raises(ValidationError, match="must all be set on the webhooks surface"):
+        _production(
+            "webhooks",
+            sentry_dsn="https://example@example.ingest.sentry.io/1",
+            stripe_webhook_secret="whsec-test",  # noqa: S106 - test credential.
+            paypal_checkout_enabled=True,
+            paypal_client_id="paypal-client",
+            paypal_client_secret="paypal-secret",  # noqa: S106 - test credential.
+        )
+
+
+def test_adyen_checkout_and_webhook_credentials_are_disjoint() -> None:
+    console = _production(
+        "console",
+        **_CONSOLE_SECRETS,
+        adyen_enabled=True,
+        adyen_api_key="adyen-api",
+        adyen_client_key="adyen-client",
+        adyen_reference_key="r" * 32,
+        adyen_merchant_account="merchant",
+    )
+    assert console.adyen_checkout_ready is True
+    assert console.adyen_hmac_key is None
+
+    webhooks = _production(
+        "webhooks",
+        sentry_dsn="https://example@example.ingest.sentry.io/1",
+        stripe_webhook_secret="whsec-test",  # noqa: S106 - test credential.
+        paypal_checkout_enabled=False,
+        adyen_hmac_key="ab" * 32,
+        adyen_reference_key="r" * 32,
+        adyen_merchant_account="merchant",
+    )
+    assert webhooks.adyen_webhook_ready is True
+    assert webhooks.adyen_api_key is None
+    assert webhooks.adyen_client_key is None
+
+
+def test_veriff_session_and_callback_credentials_are_disjoint() -> None:
+    console = _production(
+        "console",
+        **_CONSOLE_SECRETS,
+        veriff_enabled=True,
+        veriff_api_key="veriff-api",
+    )
+    assert console.veriff_configured is True
+    assert console.veriff_shared_secret_key is None
+
+    webhooks = _production(
+        "webhooks",
+        sentry_dsn="https://example@example.ingest.sentry.io/1",
+        stripe_webhook_secret="whsec-test",  # noqa: S106 - test credential.
+        paypal_checkout_enabled=False,
+        veriff_shared_secret_key="veriff-shared",  # noqa: S106 - test credential.
+    )
+    assert webhooks.veriff_api_key is None
+
+    with pytest.raises(ValidationError, match="unset TR_VERIFF_SHARED_SECRET_KEY"):
+        _production(
+            "console",
+            **_CONSOLE_SECRETS,
+            veriff_enabled=True,
+            veriff_api_key="veriff-api",
+            veriff_shared_secret_key="veriff-shared",  # noqa: S106 - test credential.
+        )
+    with pytest.raises(ValidationError, match="unset TR_VERIFF_API_KEY"):
+        _production(
+            "webhooks",
+            sentry_dsn="https://example@example.ingest.sentry.io/1",
+            stripe_webhook_secret="whsec-test",  # noqa: S106 - test credential.
+            paypal_checkout_enabled=False,
+            veriff_shared_secret_key="veriff-shared",  # noqa: S106 - test credential.
+            veriff_api_key="veriff-api",
+        )
+
+
+@pytest.mark.parametrize(
+    ("surface", "surface_secrets"),
+    [
+        ("chat", {}),
+        (
+            "webhooks",
+            {
+                "stripe_webhook_secret": "whsec-test",
+                "paypal_checkout_enabled": False,
+            },
+        ),
+    ],
+)
+def test_narrow_store_surfaces_do_not_receive_clickhouse_credentials(
+    surface: str,
+    surface_secrets: dict[str, object],
+) -> None:
+    settings = _production(
+        surface,
+        storage_backend="spanner-clickhouse",
+        analytics_read_mode="clickhouse-only",
+        generation_records_enabled=True,
+        operational_analytics_outbox_enabled=True,
+        analytics_outbox_enabled=True,
+        bigtable_mirror_writes_enabled=False,
+        request_record_write_mode="typed",
+        settle_outbox_enabled=True,
+        sentry_dsn="https://example@example.ingest.sentry.io/1",
+        **surface_secrets,
+    )
+
+    assert settings.operational_analytics_clickhouse_url == ""
+    assert settings.operational_analytics_clickhouse_password == ""
+
+
 def test_deployed_canary_surfaces_enforce_secret_ownership_too() -> None:
-    with pytest.raises(ValidationError, match="TR_STRIPE_WEBHOOK_SECRET"):
+    with pytest.raises(ValidationError, match="TR_STRIPE_SECRET_KEY"):
         Settings(
             environment="canary",
-            service_surface="control",
+            service_surface="console",
             attribution_cookie_secret=_ATTRIBUTION_SECRET,
+            paypal_checkout_enabled=False,
         )
 
     with pytest.raises(ValidationError, match="unset TR_INTERNAL_GATEWAY_TOKEN"):
         Settings(
             environment="canary",
-            service_surface="control",
+            service_surface="console",
             attribution_cookie_secret=_ATTRIBUTION_SECRET,
-            stripe_webhook_secret="whsec-test",  # noqa: S106 - test credential.
             stripe_secret_key="sk-test",  # noqa: S106 - test credential.
+            paypal_checkout_enabled=False,
             internal_gateway_token=_GATEWAY_SECRET,
         )
 
@@ -630,7 +882,7 @@ def test_attribution_and_gateway_credentials_cannot_be_reused() -> None:
         _production(
             "combined",
             **{
-                **_CONTROL_SECRETS,
+                **_CONSOLE_SECRETS,
                 "internal_gateway_token": _GATEWAY_SECRET,
                 "attribution_cookie_secret": _GATEWAY_SECRET,
             },
@@ -678,13 +930,13 @@ def test_deployed_validation_errors_hide_misrouted_secret_values() -> None:
     assert canary not in message
 
 
-def test_public_cookie_survives_control_handoff_without_sharing_gateway_secret() -> None:
+def test_public_cookie_survives_console_handoff_without_sharing_gateway_secret() -> None:
     public = Settings(
         service_surface="public",
         attribution_cookie_secret=_ATTRIBUTION_SECRET,
     )
-    control = Settings(
-        service_surface="control",
+    console = Settings(
+        service_surface="console",
         attribution_cookie_secret=_ATTRIBUTION_SECRET,
     )
     now = dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
@@ -693,12 +945,12 @@ def test_public_cookie_survives_control_handoff_without_sharing_gateway_secret()
 
     encoded = encode_attribution_cookie(context, public)
 
-    assert decode_attribution_cookie(encoded, control) == context
+    assert decode_attribution_cookie(encoded, console) == context
     assert (
         decode_attribution_cookie(
             encoded,
             Settings(
-                service_surface="control",
+                service_surface="console",
                 attribution_cookie_secret="rotated-" + "r" * 32,
             ),
         )

--- a/tests/test_service_surfaces.py
+++ b/tests/test_service_surfaces.py
@@ -66,15 +66,35 @@ def test_combined_surface_is_rejected_outside_local_and_test() -> None:
         )
 
 
+def test_deprecated_control_surface_normalizes_exactly_to_console() -> None:
+    with pytest.warns(DeprecationWarning, match="use console"):
+        settings = Settings(environment="test", service_surface="control")
+
+    assert settings.service_surface == "console"
+    paths = _paths(
+        create_app(
+            settings,
+            configure_store_arg=False,
+            init_observability=False,
+        )
+    )
+    assert "/console" in paths
+    assert "/chat-proxy/v1/chat/completions" not in paths
+    assert "/internal/stripe/webhook" not in paths
+    assert "/internal/gateway/authorize" not in paths
+
+
 def test_split_surface_route_inventory_is_total_and_has_one_owner() -> None:
     combined = _signatures(_app("combined"))
     public = _signatures(_app("public"))
     actions = _signatures(_app("actions"))
-    control = _signatures(_app("control"))
+    console = _signatures(_app("console"))
+    chat = _signatures(_app("chat"))
+    webhooks = _signatures(_app("webhooks"))
     internal = _signatures(_app("internal"))
 
-    assert combined == public | actions | control | internal
-    owned = [public, actions, control, internal]
+    assert combined == public | actions | console | chat | webhooks | internal
+    owned = [public, actions, console, chat, webhooks, internal]
     for index, left in enumerate(owned):
         for right in owned[index + 1 :]:
             assert _without_shared_health(left).isdisjoint(_without_shared_health(right))
@@ -154,7 +174,9 @@ def test_public_openapi_keeps_customer_routes_from_split_services() -> None:
     assert "/v1/internal/gateway/authorize" not in paths
 
 
-@pytest.mark.parametrize("surface", ["actions", "control", "internal", "observer"])
+@pytest.mark.parametrize(
+    "surface", ["actions", "console", "chat", "webhooks", "internal", "observer"]
+)
 def test_non_public_split_surfaces_do_not_serve_openapi(surface: str) -> None:
     from fastapi.testclient import TestClient
 
@@ -186,8 +208,8 @@ def test_actions_surface_owns_only_anonymous_form_submissions() -> None:
     }
 
 
-def test_control_surface_owns_login_console_and_signed_webhooks_only() -> None:
-    paths = _paths(_app("control"))
+def test_console_surface_owns_account_and_console_routes_only() -> None:
+    paths = _paths(_app("console"))
 
     assert {
         "/auth/google/login",
@@ -196,12 +218,6 @@ def test_control_surface_owns_login_console_and_signed_webhooks_only() -> None:
         "/console",
         "/signup",
         "/v1/signup",
-        "/internal/stripe/webhook",
-        "/v1/internal/stripe/webhook",
-        "/internal/ses/notifications",
-        "/v1/internal/ses/notifications",
-        "/internal/chat/issue-browser-key",
-        "/v1/internal/chat/issue-browser-key",
         "/bedrock-group-buy/manage",
         "/bedrock-group-buy/pledge",
         "/v1/bedrock-group-buy/me",
@@ -213,6 +229,47 @@ def test_control_surface_owns_login_console_and_signed_webhooks_only() -> None:
     assert "/internal/gateway/authorize" not in paths
     assert "/v1/internal/gateway/authorize" not in paths
     assert "/internal/synthetic/run" not in paths
+    assert "/chat-proxy/v1/chat/completions" not in paths
+    assert {
+        path
+        for path in paths
+        if path.startswith(("/internal/", "/v1/internal/"))
+    } == {
+        "/internal/chat/issue-browser-key",
+        "/v1/internal/chat/issue-browser-key",
+    }
+
+
+def test_chat_surface_owns_only_the_authenticated_proxy() -> None:
+    paths = _paths(_app("chat"))
+
+    assert paths == {
+        "/health",
+        "/v1/health",
+        "/ready",
+        "/v1/ready",
+        "/chat-proxy/v1/chat/completions",
+    }
+
+
+def test_webhooks_surface_owns_only_externally_signed_callbacks() -> None:
+    paths = _paths(_app("webhooks"))
+
+    callback_paths = {
+        "/internal/stripe/webhook",
+        "/internal/paypal/webhook",
+        "/internal/adyen/webhook",
+        "/internal/veriff/webhook",
+        "/internal/ses/notifications",
+    }
+    assert paths == {
+        "/health",
+        "/v1/health",
+        "/ready",
+        "/v1/ready",
+        *callback_paths,
+        *(f"/v1{path}" for path in callback_paths),
+    }
 
 
 def test_internal_surface_owns_gateway_federation_and_workers_only() -> None:
@@ -261,7 +318,7 @@ def test_versioned_api_pairs_never_split_across_surface_owners() -> None:
     combined = _app("combined")
     owners = {
         surface: _paths(_app(surface))
-        for surface in ("public", "actions", "control", "internal")
+        for surface in ("public", "actions", "console", "chat", "webhooks", "internal")
     }
 
     for paths in _endpoints(combined).values():
@@ -282,7 +339,9 @@ def test_versioned_api_pairs_never_split_across_surface_owners() -> None:
     [
         ("public", set()),
         ("actions", set()),
-        ("control", {"_start_activation_reminder_loop"}),
+        ("console", {"_start_activation_reminder_loop"}),
+        ("chat", set()),
+        ("webhooks", set()),
         (
             "internal",
             {
@@ -332,8 +391,10 @@ def test_anonymous_surface_ready_does_not_touch_the_billing_store(
     }
 
 
-def test_observer_ready_fails_when_its_status_store_is_unavailable(
+@pytest.mark.parametrize("surface", ["console", "chat", "webhooks", "internal", "observer"])
+def test_stateful_surface_ready_fails_when_its_store_is_unavailable(
     monkeypatch: pytest.MonkeyPatch,
+    surface: str,
 ) -> None:
     from fastapi.testclient import TestClient
 
@@ -344,7 +405,7 @@ def test_observer_ready_fails_when_its_status_store_is_unavailable(
         "trusted_router.storage.InMemoryStore.readiness_check",
         unavailable,
     )
-    response = TestClient(_app("observer")).get("/ready")
+    response = TestClient(_app(surface)).get("/ready")
 
     assert response.status_code == 503
     assert response.headers["retry-after"] == "5"

--- a/tests/test_session_cookie_attributes.py
+++ b/tests/test_session_cookie_attributes.py
@@ -63,10 +63,12 @@ def _looks_like_date(piece: str) -> bool:
 def production_settings() -> Settings:
     return Settings(
         environment="production",
-        service_surface="control",
+        service_surface="console",
         attribution_cookie_secret="attribution-cookie-secret-for-control-test",  # noqa: S106
-        stripe_webhook_secret="whsec_test",  # noqa: S106 - test fixture.
         stripe_secret_key="sk_test",  # noqa: S106 - test fixture.
+        google_oauth_login_available=True,
+        github_oauth_login_available=False,
+        paypal_checkout_enabled=False,
         sentry_dsn="https://example@example.ingest.sentry.io/1",
         aws_access_key_id="test-access-key",
         aws_secret_access_key="test-secret-key",  # noqa: S106 - test fixture.
@@ -127,10 +129,12 @@ def test_session_cookie_is_httponly_secure_lax_in_production() -> None:
 
     settings = Settings(
         environment="production",
-        service_surface="control",
+        service_surface="console",
         attribution_cookie_secret="attribution-cookie-secret-for-control-test",  # noqa: S106
-        stripe_webhook_secret="w",  # noqa: S106 - test fixture.
         stripe_secret_key="s",  # noqa: S106 - test fixture.
+        google_oauth_login_available=False,
+        github_oauth_login_available=False,
+        paypal_checkout_enabled=False,
         sentry_dsn="https://example@example.ingest.sentry.io/1",
         aws_access_key_id="test-access-key",
         aws_secret_access_key="test-secret-key",  # noqa: S106 - test fixture.
@@ -214,10 +218,12 @@ def test_set_session_cookie_also_sets_signed_in_hint_for_marketing_js() -> None:
 
     settings = Settings(
         environment="production",
-        service_surface="control",
+        service_surface="console",
         attribution_cookie_secret="attribution-cookie-secret-for-control-test",  # noqa: S106
-        stripe_webhook_secret="w",  # noqa: S106 - test fixture.
         stripe_secret_key="s",  # noqa: S106 - test fixture.
+        google_oauth_login_available=False,
+        github_oauth_login_available=False,
+        paypal_checkout_enabled=False,
         sentry_dsn="https://example@example.ingest.sentry.io/1",
         aws_access_key_id="test-access-key",
         aws_secret_access_key="test-secret-key",  # noqa: S106 - test fixture.

--- a/tests/test_signup_operator_script.py
+++ b/tests/test_signup_operator_script.py
@@ -24,6 +24,8 @@ def _write_harness(
         """set -euo pipefail
 PROJECT_ID=harness-project
 SERVICE=trusted-router
+CONSOLE_SERVICE="${TR_CONSOLE_SERVICE:-trusted-router-console}"
+LEGACY_CONSOLE_SERVICE="${TR_LEGACY_CONSOLE_SERVICE:-trusted-router}"
 TR_CONTROL_PLANE_REGIONS=region-a,region-b
 log() { printf '%s\\n' "$*" >&2; }
 gc() { gcloud "$@"; }
@@ -44,20 +46,22 @@ done
 state="$FAKE_GCLOUD_STATE/$region"
 mkdir -p "$state"
 if [ "$1 $2 $3" = "run services describe" ]; then
-  revision="$(cat "$state/serving" 2>/dev/null || printf 'trusted-router-old')"
+  [ "$4" = trusted-router-console ] || exit 92
+  revision="$(cat "$state/serving" 2>/dev/null || printf 'trusted-router-console-old')"
   printf '{"status":{"traffic":[{"percent":100,"revisionName":"%s"}]}}\n' "$revision"
 elif [ "$1 $2 $3" = "run revisions describe" ]; then
   revision="$4"
-  surface=control
-  if [ "$region" = "${FAKE_BAD_REGION:-}" ] && [ "$revision" = trusted-router-old ]; then
+  surface=console
+  if [ "$region" = "${FAKE_BAD_REGION:-}" ] && [ "$revision" = trusted-router-console-old ]; then
     surface=public
   fi
-  if [ "$region" = "${FAKE_BAD_CANDIDATE_REGION:-}" ] && [ "$revision" != trusted-router-old ]; then
+  if [ "$region" = "${FAKE_BAD_CANDIDATE_REGION:-}" ] && [ "$revision" != trusted-router-console-old ]; then
     surface=public
   fi
   gate="$(cat "$state/gate" 2>/dev/null || printf true)"
   printf '{"spec":{"containers":[{"env":[{"name":"TR_SERVICE_SURFACE","value":"%s"},{"name":"TR_NEW_SIGNUPS_ENABLED","value":"%s"}]}]}}\n' "$surface" "$gate"
 elif [ "$1 $2 $3" = "run services update" ]; then
+  [ "$4" = trusted-router-console ] || exit 92
   suffix="" desired=""
   for arg in "$@"; do
     case "$arg" in
@@ -65,15 +69,16 @@ elif [ "$1 $2 $3" = "run services update" ]; then
       --update-env-vars=TR_NEW_SIGNUPS_ENABLED=*) desired="${arg##*=}" ;;
     esac
   done
-  revision="trusted-router-${suffix}"
+  revision="trusted-router-console-${suffix}"
   printf '%s\n' "$desired" >"$state/gate"
   printf '%s\n' "$revision"
 elif [ "$1 $2 $3" = "run services update-traffic" ]; then
+  [ "$4" = trusted-router-console ] || exit 92
   for arg in "$@"; do
     case "$arg" in --to-revisions=*) revision="${arg#--to-revisions=}"; revision="${revision%=100}" ;; esac
   done
   if [ "$region" = "${FAKE_TRAFFIC_FAILURE_REGION:-}" ] \
-      && [ "$revision" != trusted-router-old ]; then
+      && [ "$revision" != trusted-router-console-old ]; then
     printf '%s\n' "$revision" >"$state/serving"
     exit 73
   fi
@@ -142,7 +147,7 @@ def _run(script: Path, env_file: Path, action: str) -> subprocess.CompletedProce
     )
 
 
-def test_signup_operator_moves_every_control_region_and_verifies_serving_revision(
+def test_signup_operator_moves_every_console_region_and_verifies_serving_revision(
     tmp_path: Path,
 ) -> None:
     script, env_file = _write_harness(tmp_path)
@@ -158,6 +163,9 @@ def test_signup_operator_moves_every_control_region_and_verifies_serving_revisio
     assert all("--no-traffic" in call for call in updates)
     assert all("latestCreatedRevisionName" in call for call in updates)
     assert all("TR_NEW_SIGNUPS_ENABLED=false" in call for call in updates)
+    assert all("trusted-router-console" in call for call in updates + traffic)
+    assert not any("run services update trusted-router " in call for call in calls)
+    assert not any("run services update-traffic trusted-router " in call for call in calls)
     assert all("=100" in call for call in traffic)
     assert "new account creation is off" in result.stderr
     first_traffic = min(index for index, call in enumerate(calls) if call.startswith("run services update-traffic "))
@@ -182,7 +190,7 @@ def test_signup_operator_preflights_the_whole_fleet_before_any_mutation(
     result = _run(script, env_file, "disable")
 
     assert result.returncode != 0
-    assert "expected control" in result.stderr
+    assert "expected console" in result.stderr
     calls = (tmp_path / "gcloud.log").read_text(encoding="utf-8").splitlines()
     assert not any(call.startswith("run services update ") for call in calls)
     assert not any(call.startswith("run services update-traffic ") for call in calls)
@@ -195,6 +203,21 @@ def test_signup_operator_rejects_unknown_action_without_cloud_calls(tmp_path: Pa
 
     assert result.returncode == 2
     assert "usage:" in result.stderr
+    assert not (tmp_path / "gcloud.log").exists()
+
+
+def test_signup_operator_rejects_legacy_monolith_alias_without_cloud_calls(
+    tmp_path: Path,
+) -> None:
+    script, env_file = _write_harness(tmp_path)
+    env = json.loads(env_file.read_text(encoding="utf-8"))
+    env["TR_CONSOLE_SERVICE"] = "trusted-router"
+    env_file.write_text(json.dumps(env), encoding="utf-8")
+
+    result = _run(script, env_file, "disable")
+
+    assert result.returncode != 0
+    assert "aliases the legacy combined monolith" in result.stderr
     assert not (tmp_path / "gcloud.log").exists()
 
 
@@ -223,5 +246,5 @@ def test_signup_operator_rolls_back_prior_regions_when_promotion_fails(
     assert "rolling back" in result.stderr
     state = tmp_path / "state"
     assert (state / "region-a" / "serving").read_text(encoding="utf-8").strip() == (
-        "trusted-router-old"
+        "trusted-router-console-old"
     )

--- a/tests/test_six_surface_rollout.py
+++ b/tests/test_six_surface_rollout.py
@@ -1,0 +1,2981 @@
+"""Executable contracts for the six-surface Cloud Run release transaction."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+PROJECT = "quill-cloud-proxy"
+STATE_TOOL = ROOT / "scripts/deploy/rollout_state.py"
+HELPER = ROOT / "scripts/deploy/rollout_rollback.sh"
+ROLLOUT = ROOT / "scripts/deploy/rollout.sh"
+RECOVERY = ROOT / "scripts/deploy/rollout_recovery.sh"
+
+SURFACES = ("public", "actions", "console", "chat", "webhooks", "internal")
+SERVICES = {
+    "public": "trusted-router-public",
+    "actions": "trusted-router-actions",
+    "console": "trusted-router-console",
+    "chat": "trusted-router-chat",
+    "webhooks": "trusted-router-webhooks",
+    "internal": "trusted-router-billing",
+}
+EDGES = {
+    "public": ("trusted-router-public-backend", "trusted-router-public-neg", "trusted-router-public-edge"),
+    "actions": ("trusted-router-actions-backend", "trusted-router-actions-neg", "trusted-router-actions-edge"),
+    "console": ("trusted-router-console-backend", "trusted-router-console-neg", "trusted-router-console-edge"),
+    "chat": ("trusted-router-chat-backend", "trusted-router-chat-neg", "trusted-router-chat-edge"),
+    "webhooks": ("trusted-router-webhooks-backend", "trusted-router-webhooks-neg", "trusted-router-webhooks-edge"),
+    "internal": ("trusted-router-billing-backend", "trusted-router-billing-neg", "trusted-router-billing-edge"),
+}
+CONTRACTS = {
+    "public": (4, 0, 10, 60, 1_048_576, 4_194_304, 2, 10),
+    "actions": (4, 0, 2, 30, 262_144, 1_048_576, 2, 10),
+    "console": (4, 1, 20, 300, 4_194_304, 16_777_216, 2, 30),
+    "chat": (2, 1, 20, 300, 33_554_432, 67_108_864, 2, 30),
+    "webhooks": (4, 1, 10, 60, 1_048_576, 4_194_304, 2, 10),
+    "internal": (8, 2, 50, 300, 33_554_432, 67_108_864, 4, 30),
+}
+MEMORY = {
+    "public": "1Gi",
+    "actions": "512Mi",
+    "console": "2Gi",
+    "chat": "2Gi",
+    "webhooks": "1Gi",
+    "internal": "2Gi",
+}
+IMAGE = "us-central1-docker.pkg.dev/quill-cloud-proxy/trusted-router/app@sha256:" + "1" * 64
+STATE_GCS_URI = "gs://trusted-router-rollout-state/releases/test/promotion-state.json"
+STATE_GCS_ROLE = "projects/quill-cloud-proxy/roles/trustedRouterRolloutJournal"
+RECOVERY_PREFIX = "gs://trusted-router-rollout-state/recovery/quill-cloud-proxy"
+RECOVERY_BUNDLE = f"{RECOVERY_PREFIX}/releases/test-epoch-0001"
+RECOVERY_AUTHORITY = f"{RECOVERY_PREFIX}/authority.json"
+FRONTEND_TOOL = ROOT / "scripts/deploy/rollout_frontend_attest.py"
+SMOKE = ROOT / "scripts/deploy/rollout_smoke.sh"
+FRONTEND_HOSTS = [
+    "trustedrouter.com",
+    "www.trustedrouter.com",
+    "status.trustedrouter.com",
+    "trust.trustedrouter.com",
+    "eu.trustedrouter.com",
+    "status-us.trustedrouter.com",
+    "status-eu.trustedrouter.com",
+    "allyrouter.com",
+    "www.allyrouter.com",
+    "status.allyrouter.com",
+    "trust.allyrouter.com",
+    "uptimerouter.com",
+    "www.uptimerouter.com",
+    "status.uptimerouter.com",
+    "trust.uptimerouter.com",
+]
+FRONTEND_VIP = "34.111.20.30"
+
+
+def _run_state(*args: str | Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603
+        [sys.executable, str(STATE_TOOL), *(str(arg) for arg in args)],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _hash_json(path: Path, kind: str) -> str:
+    return _run_state(kind, path).stdout.strip()
+
+
+def _policy() -> dict[str, Any]:
+    allowed = (
+        r"^(trustedrouter[.]com|www[.]trustedrouter[.]com|status[.]trustedrouter[.]com|"
+        r"trust[.]trustedrouter[.]com|eu[.]trustedrouter[.]com|status-us[.]trustedrouter[.]com|"
+        r"status-eu[.]trustedrouter[.]com|allyrouter[.]com|www[.]allyrouter[.]com|"
+        r"status[.]allyrouter[.]com|trust[.]allyrouter[.]com|uptimerouter[.]com|"
+        r"www[.]uptimerouter[.]com|status[.]uptimerouter[.]com|"
+        r"trust[.]uptimerouter[.]com)(:[0-9]+)?$"
+    )
+
+    def throttle(priority: int, count: int, *, expression: str | None, preview: bool) -> dict[str, Any]:
+        match: dict[str, Any]
+        if expression is None:
+            match = {
+                "config": {"srcIpRanges": ["*"]},
+                "versionedExpr": "SRC_IPS_V1",
+            }
+        else:
+            match = {"expr": {"expression": expression}}
+        descriptions = {
+            1000: "Browser inference proxy per-client throttle",
+            1100: "State-changing request per-client throttle",
+            1200: "All-path per-source safety ceiling",
+        }
+        return {
+            "priority": priority,
+            "action": "throttle",
+            "description": descriptions[priority],
+            "preview": preview,
+            "match": match,
+            "rateLimitOptions": {
+                "rateLimitThreshold": {"count": count, "intervalSec": 60},
+                "conformAction": "allow",
+                "exceedAction": "deny(429)",
+                "enforceOnKey": "IP",
+            },
+        }
+
+    return {
+        "type": "CLOUD_ARMOR",
+        "description": (
+            "TrustedRouter exact edge controls; host and all-path gates enforced, "
+            "route-shape rules previewed"
+        ),
+        "rules": [
+            {
+                "priority": 900,
+                "action": "deny(403)",
+                "description": "Reject hosts outside canonical and marketing aliases",
+                "preview": False,
+                "match": {
+                    "expr": {
+                        "expression": "!has(request.headers['host']) || "
+                        f"!request.headers['host'].lower().matches('{allowed}')"
+                    }
+                },
+            },
+            throttle(
+                1000,
+                120,
+                expression="request.path.startsWith('/chat-proxy/')",
+                preview=True,
+            ),
+            throttle(
+                1100,
+                300,
+                expression=(
+                    "request.method != 'GET' && request.method != 'HEAD' && "
+                    "request.method != 'OPTIONS'"
+                ),
+                preview=True,
+            ),
+            throttle(1200, 2400, expression=None, preview=False),
+            {
+                "priority": 2_147_483_647,
+                "action": "allow",
+                "description": "Default allow; bounded route classes are evaluated first",
+                "preview": False,
+                "match": {
+                    "config": {"srcIpRanges": ["*"]},
+                    "versionedExpr": "SRC_IPS_V1",
+                },
+            },
+        ]
+    }
+
+
+def _iam_policy(mapping: dict[str, str]) -> dict[str, Any]:
+    bindings: dict[str, list[str]] = {}
+    for surface, role in mapping.items():
+        if role:
+            bindings.setdefault(role, []).append(
+                f"serviceAccount:tr-{surface}@quill-cloud-proxy.iam.gserviceaccount.com"
+            )
+    return {
+        "bindings": [
+            {"role": role, "members": members}
+            for role, members in sorted(bindings.items())
+        ]
+    }
+
+
+def _iam_fixture() -> dict[str, Any]:
+    empty = {surface: "" for surface in SURFACES}
+    return {
+        "project": _iam_policy(
+            {
+                **{surface: "roles/serviceusage.serviceUsageConsumer" for surface in SURFACES},
+                "actions": "",
+            }
+        ),
+        "ancestors": [{"type": "project", "id": "quill-cloud-proxy"}],
+        "spanner_instance": _iam_policy(empty),
+        "spanner_database": _iam_policy(
+            {
+                "public": "roles/spanner.databaseReader",
+                "actions": "",
+                "console": "roles/spanner.databaseUser",
+                "chat": "roles/spanner.databaseReader",
+                "webhooks": "roles/spanner.databaseUser",
+                "internal": "roles/spanner.databaseUser",
+            }
+        ),
+        "bigtable_instance": _iam_policy(
+            {
+                "public": "roles/bigtable.reader",
+                "actions": "",
+                "console": "roles/bigtable.reader",
+                "chat": "",
+                "webhooks": "",
+                "internal": "roles/bigtable.user",
+            }
+        ),
+        "bigtable_table": _iam_policy(empty),
+        "kms_keyring": _iam_policy(empty),
+        "byok": _iam_policy(
+            {
+                "public": "",
+                "actions": "",
+                "console": "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+                "chat": "",
+                "webhooks": "",
+                "internal": "roles/cloudkms.cryptoKeyDecrypter",
+            }
+        ),
+        "google_ads": _iam_policy(
+            {
+                **empty,
+                "console": "roles/cloudkms.cryptoKeyEncrypter",
+            }
+        ),
+        "secrets": [],
+    }
+
+
+def _service_json(surface: str, region: str) -> tuple[dict[str, Any], str, str]:
+    service = SERVICES[surface]
+    candidate = f"{service}-candidate"
+    prior = f"{service}-prior"
+    concurrency, minimum, maximum, timeout, body, inflight, body_slots, read_timeout = CONTRACTS[surface]
+    annotations = {
+        "run.googleapis.com/ingress": "internal-and-cloud-load-balancing",
+        "run.googleapis.com/ingress-status": "internal-and-cloud-load-balancing",
+        "run.googleapis.com/maxScale": str(maximum),
+    }
+    if surface != "internal":
+        annotations["run.googleapis.com/default-url-disabled"] = "true"
+    env = [
+        {"name": "TR_SERVICE_SURFACE", "value": surface},
+        {"name": "TR_RATE_LIMIT_CLIENT_IP_MODE", "value": "edge_header"},
+        {"name": "TR_MAX_REQUEST_BODY_BYTES", "value": str(body)},
+        {"name": "TR_MAX_IN_FLIGHT_REQUEST_BODY_BYTES", "value": str(inflight)},
+        {"name": "TR_MAX_CONCURRENT_REQUEST_BODIES", "value": str(body_slots)},
+        {"name": "TR_REQUEST_BODY_READ_TIMEOUT_SECONDS", "value": str(read_timeout)},
+        {"name": "TR_SYNTHETIC_SCHEDULER_INTERVAL_SECONDS", "value": "0"},
+        {"name": "TR_REMEDIATOR_IN_PROCESS_ENABLED", "value": "false"},
+    ]
+    data = {
+        "metadata": {"name": service, "generation": 7, "annotations": annotations},
+        "spec": {
+            "traffic": [{"revisionName": prior, "percent": 100}],
+            "template": {
+                "metadata": {
+                    "name": candidate,
+                    "annotations": {
+                        "autoscaling.knative.dev/minScale": str(minimum),
+                        "autoscaling.knative.dev/maxScale": str(maximum),
+                        "run.googleapis.com/network-interfaces": json.dumps(
+                            [{"network": "default", "subnetwork": "default"}],
+                            separators=(",", ":"),
+                        ),
+                        "run.googleapis.com/vpc-access-egress": "private-ranges-only",
+                    },
+                },
+                "spec": {
+                    "serviceAccountName": (
+                        f"tr-{surface}@quill-cloud-proxy.iam.gserviceaccount.com"
+                    ),
+                    "containerConcurrency": concurrency,
+                    "timeoutSeconds": f"{timeout}s",
+                    "containers": [
+                        {
+                            "image": IMAGE,
+                            "ports": [{"containerPort": 8080, "name": "http1"}],
+                            "resources": {
+                                "limits": {"cpu": "1000m", "memory": MEMORY[surface]}
+                            },
+                            "startupProbe": {
+                                "httpGet": {"path": "/ready", "port": 8080},
+                                "initialDelaySeconds": 0,
+                                "timeoutSeconds": 10,
+                                "periodSeconds": 10,
+                                "failureThreshold": 18,
+                            },
+                            "env": env,
+                        }
+                    ],
+                },
+            },
+        },
+        "status": {
+            "observedGeneration": 7,
+            "latestCreatedRevisionName": candidate,
+            "latestReadyRevisionName": candidate,
+            "conditions": [{"type": "Ready", "status": "True"}],
+            "url": "" if surface != "internal" else f"https://{service}-{region}.run.app",
+            "traffic": [{"revisionName": prior, "percent": 100}],
+        },
+    }
+    return data, candidate, prior
+
+
+def _fixture(
+    tmp_path: Path,
+    mode: str = "existing_split",
+    regions: list[str] | None = None,
+    internal_regions: list[str] | None = None,
+) -> tuple[Path, Path, Path]:
+    regions = list(regions or ["us-central1", "europe-west4"])
+    internal_regions = list(internal_regions or regions)
+    prior_map = {
+        "name": "trusted-router-map",
+        "selfLink": (
+            "https://www.googleapis.com/compute/v1/projects/quill-cloud-proxy/"
+            "global/urlMaps/trusted-router-map"
+        ),
+        "defaultService": "trusted-router-control-backend",
+    }
+    candidate_map = copy.deepcopy(prior_map)
+    if mode == "initial_split":
+        candidate_map["description"] = "six-surface candidate"
+    prior_path = tmp_path / "url-map.prior.json"
+    candidate_path = tmp_path / "url-map.candidate.json"
+    prior_path.write_text(json.dumps(prior_map), encoding="utf-8")
+    candidate_path.write_text(json.dumps(candidate_map), encoding="utf-8")
+    prior_path.chmod(0o600)
+    candidate_path.chmod(0o600)
+    prior_hash = _hash_json(prior_path, "hash-url-map")
+    candidate_hash = _hash_json(candidate_path, "hash-url-map")
+
+    services: list[dict[str, Any]] = []
+    live_services: dict[str, Any] = {}
+    backends: dict[str, Any] = {}
+    policies: dict[str, Any] = {}
+    negs: dict[str, Any] = {}
+    legacy_fallback: list[dict[str, Any]] = []
+    for surface in SURFACES:
+        concurrency, minimum, maximum, timeout, body, inflight, body_slots, read_timeout = CONTRACTS[surface]
+        backend, neg, policy = EDGES[surface]
+        backends[backend] = {
+            "name": backend,
+            "loadBalancingScheme": "EXTERNAL_MANAGED",
+            "protocol": "HTTP",
+            "timeoutSec": timeout,
+            "securityPolicy": (
+                "https://www.googleapis.com/compute/v1/projects/"
+                f"quill-cloud-proxy/global/securityPolicies/{policy}"
+            ),
+            "customRequestHeaders": ["X-TrustedRouter-Client-IP:{client_ip_address}"],
+            "customResponseHeaders": [],
+            "iap": {"enabled": False},
+            "logConfig": {
+                "enable": True,
+                "sampleRate": 0.1,
+                "optionalMode": "EXCLUDE_ALL_OPTIONAL",
+            },
+            "enableCDN": surface == "public",
+            "backends": [
+                {
+                    "group": (
+                        f"https://www.googleapis.com/compute/v1/projects/quill-cloud-proxy/"
+                        f"regions/{region}/networkEndpointGroups/{neg}"
+                    )
+                }
+                for region in regions
+            ],
+        }
+        if surface == "public":
+            backends[backend].update(
+                {
+                    "compressionMode": "AUTOMATIC",
+                    "cdnPolicy": {
+                        "cacheMode": "USE_ORIGIN_HEADERS",
+                        "negativeCaching": False,
+                        "serveWhileStale": 600,
+                        "cacheKeyPolicy": {
+                            "includeHost": True,
+                            "includeProtocol": True,
+                            "includeQueryString": True,
+                            "queryStringBlacklist": [],
+                            "queryStringWhitelist": [],
+                        },
+                    },
+                }
+            )
+        policies[policy] = _policy()
+        service_regions = internal_regions if surface == "internal" else regions
+        for region in service_regions:
+            service_json, candidate, prior = _service_json(surface, region)
+            prior_exists = True
+            prior_traffic = [
+                {
+                    "revision": prior,
+                    "resolved_revision": prior,
+                    "latest_revision": False,
+                    "percent": 100,
+                    "tag": None,
+                }
+            ]
+            adopted_bootstrap = False
+            if mode == "initial_split":
+                service_json["spec"]["traffic"] = [
+                    {"revisionName": candidate, "percent": 100}
+                ]
+                service_json["status"]["traffic"] = [
+                    {"revisionName": candidate, "percent": 100}
+                ]
+                if surface == "internal":
+                    prior = candidate
+                    prior_traffic = [
+                        {
+                            "revision": candidate,
+                            "resolved_revision": candidate,
+                            "latest_revision": False,
+                            "percent": 100,
+                            "tag": None,
+                        }
+                    ]
+                    adopted_bootstrap = True
+                else:
+                    prior_exists = False
+                    prior_traffic = []
+            service_path = tmp_path / f"service-{surface}-{region}.json"
+            service_path.write_text(json.dumps(service_json), encoding="utf-8")
+            postcondition = _hash_json(service_path, "hash-service")
+            services.append(
+                {
+                    "surface": surface,
+                    "name": SERVICES[surface],
+                    "region": region,
+                    "prior_exists": prior_exists,
+                    "prior_traffic": prior_traffic,
+                    "adopted_bootstrap": adopted_bootstrap,
+                    "candidate_revision": candidate,
+                    "runtime_service_account": (
+                        f"tr-{surface}@quill-cloud-proxy.iam.gserviceaccount.com"
+                    ),
+                    "ingress": "internal-and-cloud-load-balancing",
+                    "default_url_disabled": surface != "internal",
+                    "concurrency": concurrency,
+                    "min_instances": minimum,
+                    "service_max_instances": maximum,
+                    "revision_max_instances": maximum,
+                    "timeout_seconds": timeout,
+                    "memory": MEMORY[surface],
+                    "cpu": 1,
+                    "container_port": 8080,
+                    "vpc_network": "default",
+                    "vpc_subnet": "default",
+                    "vpc_egress": "private-ranges-only",
+                    "startup_probe_path": "/ready",
+                    "startup_probe_initial_delay_seconds": 0,
+                    "startup_probe_timeout_seconds": 10,
+                    "startup_probe_period_seconds": 10,
+                    "startup_probe_failure_threshold": 18,
+                    "max_request_body_bytes": body,
+                    "max_in_flight_request_body_bytes": inflight,
+                    "max_concurrent_request_bodies": body_slots,
+                    "request_body_read_timeout_seconds": read_timeout,
+                    "postcondition_sha256": postcondition,
+                }
+            )
+            live_services[f"{SERVICES[surface]}|{region}"] = service_json
+            negs[f"{neg}|{region}"] = {"cloudRun": {"service": SERVICES[surface]}}
+
+    legacy_backend = {
+        "name": "trusted-router-control-backend",
+        "selfLink": (
+            "https://www.googleapis.com/compute/v1/projects/quill-cloud-proxy/"
+            "global/backendServices/trusted-router-control-backend"
+        ),
+        "loadBalancingScheme": "EXTERNAL_MANAGED",
+        "protocol": "HTTP",
+        "timeoutSec": 300,
+        "backends": [
+            {
+                "group": (
+                    "https://www.googleapis.com/compute/v1/projects/quill-cloud-proxy/"
+                    f"regions/{region}/networkEndpointGroups/trusted-router-control-neg"
+                )
+            }
+            for region in regions
+        ],
+    }
+    backends["trusted-router-control-backend"] = legacy_backend
+    legacy_backend_path = tmp_path / "legacy-backend.json"
+    legacy_backend_path.write_text(json.dumps(legacy_backend), encoding="utf-8")
+    legacy_backend_hash = _hash_json(legacy_backend_path, "hash-resource")
+    legacy_hardening_regions: list[dict[str, str]] = []
+    if mode == "initial_split":
+        for region in regions:
+            legacy_service, _, _ = _service_json("console", region)
+            legacy_service = json.loads(
+                json.dumps(legacy_service).replace(
+                    "trusted-router-console", "trusted-router"
+                )
+            )
+            legacy_service["status"]["latestCreatedRevisionName"] = (
+                "trusted-router-prior"
+            )
+            legacy_service["status"]["latestReadyRevisionName"] = (
+                "trusted-router-prior"
+            )
+            legacy_service["spec"]["template"]["spec"]["serviceAccountName"] = (
+                "123456789-compute@developer.gserviceaccount.com"
+            )
+            legacy_path = tmp_path / f"legacy-service-{region}.json"
+            legacy_path.write_text(json.dumps(legacy_service), encoding="utf-8")
+            legacy_hash = _hash_json(legacy_path, "hash-service")
+            legacy_revision = {
+                "metadata": {"name": "trusted-router-prior"},
+                "spec": legacy_service["spec"]["template"]["spec"],
+                "status": {"conditions": [{"type": "Ready", "status": "True"}]},
+            }
+            legacy_revision_path = tmp_path / f"legacy-revision-{region}.json"
+            legacy_revision_path.write_text(
+                json.dumps(legacy_revision), encoding="utf-8"
+            )
+            legacy_revision_hash = _hash_json(
+                legacy_revision_path, "hash-revision"
+            )
+            legacy_iam = {
+                "bindings": [
+                    {"role": "roles/run.invoker", "members": ["allUsers"]}
+                ]
+            }
+            legacy_iam_path = tmp_path / f"legacy-iam-{region}.json"
+            legacy_iam_path.write_text(json.dumps(legacy_iam), encoding="utf-8")
+            legacy_iam_hash = _hash_json(legacy_iam_path, "hash-iam-policy")
+            hardening_revision_hash = hashlib.sha256(
+                json.dumps(
+                    {"annotations": {}, "spec": legacy_revision["spec"]},
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode()
+            ).hexdigest()
+            legacy_hardening_regions.append(
+                {
+                    "region": region,
+                    "serving_revision": "trusted-router-prior",
+                    "service_sha256": legacy_hash,
+                    "revision_sha256": hardening_revision_hash,
+                    "iam_sha256": legacy_iam_hash,
+                }
+            )
+            live_services[f"trusted-router|{region}"] = legacy_service
+            negs[f"trusted-router-control-neg|{region}"] = {
+                "networkEndpointType": "SERVERLESS",
+                "cloudRun": {"service": "trusted-router"},
+            }
+            legacy_fallback.append(
+                {
+                    "service": "trusted-router",
+                    "backend": "trusted-router-control-backend",
+                    "region": region,
+                    "generation": 7,
+                    "serving_revision": "trusted-router-prior",
+                    "serving_revision_sha256": legacy_revision_hash,
+                    "traffic": [
+                        {
+                            "revision": "trusted-router-prior",
+                            "resolved_revision": "trusted-router-prior",
+                            "latest_revision": False,
+                            "percent": 100,
+                            "tag": None,
+                        }
+                    ],
+                    "postcondition_sha256": legacy_hash,
+                    "backend_postcondition_sha256": legacy_backend_hash,
+                    "invoker_iam_sha256": legacy_iam_hash,
+                }
+            )
+
+    preserved = [
+        "api.trustedrouter.com",
+        "api.allyrouter.com",
+        "api.uptimerouter.com",
+        "api.quillrouter.com",
+        "api-aws.trustedrouter.com",
+        "api-azure.trustedrouter.com",
+        "api-azure-nz.trustedrouter.com",
+        "api-azure-sea.trustedrouter.com",
+        "api-eu-west-1.trustedrouter.com",
+        "aws.trustedrouter.com",
+        "azure.trustedrouter.com",
+        *(f"api-{region}.quillrouter.com" for region in regions),
+    ]
+    manifest_path = tmp_path / "manifest.json"
+    legacy_hardening_path = Path(f"{manifest_path}.legacy-hardening.json")
+    legacy_hardening_sha256: str | None = None
+    if mode == "initial_split":
+        legacy_hardening_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "trusted-router-legacy-hardening-artifact",
+                    "project_id": "quill-cloud-proxy",
+                    "service": "trusted-router",
+                    "runtime_service_account": (
+                        "123456789-compute@developer.gserviceaccount.com"
+                    ),
+                    "operation_id": "legacy-hardener-test-operation",
+                    "revision_suffix": "prior",
+                    "regions": legacy_hardening_regions,
+                    "secret_refs": [],
+                    "journal_sha256": "9" * 64,
+                    "created_at": "2026-08-20T11:00:00+00:00",
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        legacy_hardening_path.chmod(0o600)
+        legacy_hardening_sha256 = hashlib.sha256(
+            legacy_hardening_path.read_bytes()
+        ).hexdigest()
+    manifest = {
+        "schema_version": 1,
+        "rollout_mode": mode,
+        "project_id": "quill-cloud-proxy",
+        "image": IMAGE,
+        "release": "test-release",
+        "created_at": "2026-08-20T12:00:00Z",
+        "regions": regions,
+        "primary_region": regions[0],
+        "gateway_regions": regions,
+        "internal_regions": internal_regions,
+        "bootstrap_artifact_sha256": "2" * 64 if mode == "initial_split" else None,
+        "legacy_hardening_artifact_sha256": legacy_hardening_sha256,
+        "frontend_attestation_sha256": "0" * 64,
+        "legacy_fallback": legacy_fallback,
+        "domains": ["trustedrouter.com", "allyrouter.com", "uptimerouter.com"],
+        "preserved_hosts": preserved,
+        "url_map": {
+            "name": "trusted-router-map",
+            "https_proxy": "trusted-router-control-https-proxy",
+            "prior_snapshot": prior_path.name,
+            "candidate_snapshot": candidate_path.name,
+            "prior_sha256": prior_hash,
+            "candidate_sha256": candidate_hash,
+        },
+        "promotion_state": "promotion-state.json",
+        "services": services,
+    }
+    certificate_name = "trusted-router-test-cert"
+    certificate_url = (
+        "https://www.googleapis.com/compute/v1/projects/quill-cloud-proxy/"
+        f"global/sslCertificates/{certificate_name}"
+    )
+    cloud_state = {
+        "url_map_name": "trusted-router-map",
+        "https_proxy": "trusted-router-control-https-proxy",
+        "live_map": "prior",
+        "url_maps": {"prior": prior_map, "candidate": candidate_map, "unknown": {"name": "other"}},
+        "other_url_maps": {},
+        "services": live_services,
+        "backends": backends,
+        "policies": policies,
+        "negs": negs,
+        "iam": _iam_fixture(),
+        "fail_before": [],
+        "fail_after": [],
+        "forwarding_rule": {
+            "name": "trusted-router-https",
+            "selfLink": (
+                "https://www.googleapis.com/compute/v1/projects/quill-cloud-proxy/"
+                "global/forwardingRules/trusted-router-https"
+            ),
+            "IPAddress": FRONTEND_VIP,
+            "IPProtocol": "TCP",
+            "portRange": "443-443",
+            "networkTier": "PREMIUM",
+            "loadBalancingScheme": "EXTERNAL_MANAGED",
+            "target": (
+                "https://www.googleapis.com/compute/v1/projects/quill-cloud-proxy/"
+                "global/targetHttpsProxies/trusted-router-control-https-proxy"
+            ),
+        },
+        "proxy": {
+            "name": "trusted-router-control-https-proxy",
+            "selfLink": (
+                "https://www.googleapis.com/compute/v1/projects/quill-cloud-proxy/"
+                "global/targetHttpsProxies/trusted-router-control-https-proxy"
+            ),
+            "urlMap": prior_map["selfLink"],
+            "sslCertificates": [certificate_url],
+        },
+        "ssl_certificates": {
+            certificate_name: {
+                "name": certificate_name,
+                "selfLink": certificate_url,
+                "type": "MANAGED",
+                "managed": {"status": "ACTIVE", "domains": FRONTEND_HOSTS},
+                "subjectAlternativeNames": FRONTEND_HOSTS,
+            }
+        },
+        "dns": {
+            host: {"A": [FRONTEND_VIP], "AAAA": []} for host in FRONTEND_HOSTS
+        },
+    }
+    cloud_state_path = tmp_path / "cloud-state.json"
+    cloud_state_path.write_text(json.dumps(cloud_state), encoding="utf-8")
+    frontend_path = Path(f"{manifest_path}.frontend-attestation.json")
+    _capture_frontend_artifact(tmp_path, cloud_state_path, frontend_path)
+    manifest["frontend_attestation_sha256"] = hashlib.sha256(
+        frontend_path.read_bytes()
+    ).hexdigest()
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    manifest_path.chmod(0o600)
+    _run_state("validate-manifest", manifest_path)
+    return manifest_path, cloud_state_path, tmp_path / "events.log"
+
+
+FAKE_GCLOUD = r'''#!/usr/bin/env python3
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+state_path = Path(os.environ["FAKE_GCLOUD_STATE"])
+event_path = Path(os.environ["ROLLOUT_EVENT_LOG"])
+state = json.loads(state_path.read_text(encoding="utf-8"))
+args = sys.argv[1:]
+if args[:1] == ["--project"]:
+    args = args[2:]
+joined = " ".join(args)
+with event_path.open("a", encoding="utf-8") as output:
+    output.write("gcloud " + joined + "\n")
+
+def option(name):
+    for index, arg in enumerate(args):
+        if arg.startswith(name + "="):
+            return arg.split("=", 1)[1]
+        if arg == name and index + 1 < len(args):
+            return args[index + 1]
+    return None
+
+def finish(value=None, code=0):
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    if value is not None:
+        print(json.dumps(value) if not isinstance(value, str) else value)
+    raise SystemExit(code)
+
+def matching(bucket):
+    for index, pattern in enumerate(state.get(bucket, [])):
+        if pattern in joined:
+            state[bucket].pop(index)
+            state_path.write_text(json.dumps(state), encoding="utf-8")
+            return True
+    return False
+
+if matching("fail_before"):
+    finish(code=1)
+
+for index, pattern in enumerate(state.get("sleep_before", [])):
+    if pattern in joined:
+        state["sleep_before"].pop(index)
+        state_path.write_text(json.dumps(state), encoding="utf-8")
+        time.sleep(float(state.get("sleep_seconds", 30)))
+        break
+
+if args[:2] == ["projects", "describe"]:
+    finish("123456789")
+if args[:2] == ["projects", "get-iam-policy"]:
+    finish(state["iam"]["project"])
+if args[:2] == ["projects", "get-ancestors"]:
+    finish(state["iam"]["ancestors"])
+if args[:3] == ["spanner", "instances", "list"]:
+    finish([{"name": "projects/quill-cloud-proxy/instances/trusted-router-nam6"}])
+if args[:3] == ["spanner", "databases", "list"]:
+    finish([{"name": "projects/quill-cloud-proxy/instances/trusted-router-nam6/databases/trusted-router"}])
+if args[:3] == ["spanner", "instances", "get-iam-policy"]:
+    finish(state["iam"]["spanner_instance"])
+if args[:3] == ["spanner", "databases", "get-iam-policy"]:
+    finish(state["iam"]["spanner_database"])
+if args[:3] == ["bigtable", "instances", "list"]:
+    finish([{"name": "projects/quill-cloud-proxy/instances/trusted-router-logs"}])
+if args[:3] == ["bigtable", "tables", "list"]:
+    finish([{"name": "projects/quill-cloud-proxy/instances/trusted-router-logs/tables/trustedrouter-generations"}])
+if args[:3] == ["bigtable", "instances", "get-iam-policy"]:
+    finish(state["iam"]["bigtable_instance"])
+if args[:3] == ["bigtable", "tables", "get-iam-policy"]:
+    finish(state["iam"]["bigtable_table"])
+if args[:3] == ["kms", "locations", "list"]:
+    finish([{"locationId": "us-central1"}])
+if args[:3] == ["kms", "keyrings", "list"]:
+    finish([{"name": "projects/quill-cloud-proxy/locations/us-central1/keyRings/trusted-router"}])
+if args[:3] == ["kms", "keys", "list"]:
+    finish([
+        {"name": "projects/quill-cloud-proxy/locations/us-central1/keyRings/trusted-router/cryptoKeys/byok-envelope"},
+        {"name": "projects/quill-cloud-proxy/locations/us-central1/keyRings/trusted-router/cryptoKeys/google-ads-click-envelope"},
+    ])
+if args[:3] == ["kms", "keyrings", "get-iam-policy"]:
+    finish(state["iam"]["kms_keyring"])
+if args[:3] == ["kms", "keys", "get-iam-policy"]:
+    key = args[3]
+    finish(state["iam"]["byok" if key == "byok-envelope" else "google_ads"])
+if args[:2] == ["secrets", "list"]:
+    finish(state["iam"]["secrets"])
+if args[:3] == ["secrets", "get-iam-policy"]:
+    finish(state["iam"].get("secret_policies", {}).get(args[3], {"bindings": []}))
+if args[:3] == ["storage", "buckets", "describe"]:
+    finish(state["gcs"]["bucket"])
+if args[:3] == ["storage", "buckets", "get-iam-policy"]:
+    finish(state["gcs"]["policy"])
+if args[:3] == ["storage", "objects", "describe"]:
+    item = state["gcs"].get("objects", {}).get(args[3])
+    if item is None:
+        finish("NOT_FOUND", code=1)
+    finish({"generation": str(item["generation"])})
+if args[:2] == ["storage", "cp"]:
+    source, destination = args[2:4]
+    objects = state["gcs"].setdefault("objects", {})
+    if source.startswith("gs://"):
+        item = objects.get(source)
+        if item is None:
+            finish("NOT_FOUND", code=1)
+        Path(destination).write_text(item["content"], encoding="utf-8")
+        finish()
+    expected = int(option("--if-generation-match"))
+    current = objects.get(destination)
+    actual = 0 if current is None else int(current["generation"])
+    if state["gcs"].pop("conflict_once", False):
+        if current is None:
+            finish("precondition failed", code=1)
+        current["generation"] = actual + 1
+        objects[destination] = current
+        finish("precondition failed", code=1)
+    if actual != expected:
+        finish("precondition failed", code=1)
+    objects[destination] = {
+        "generation": actual + 1,
+        "content": Path(source).read_text(encoding="utf-8"),
+    }
+    finish(code=1 if matching("fail_after") else 0)
+if args[:3] == ["compute", "forwarding-rules", "describe"]:
+    finish(state["forwarding_rule"])
+if args[:3] == ["compute", "target-https-proxies", "describe"]:
+    if args[3] != state.get("https_proxy", "trusted-router-control-https-proxy"):
+        finish("NOT_FOUND", code=1)
+    if option("--format") == "json":
+        finish(state["proxy"])
+    finish(state.get("proxy_map", state.get("url_map_name", "trusted-router-map")))
+if args[:3] == ["compute", "ssl-certificates", "describe"]:
+    finish(state["ssl_certificates"][args[3]])
+if args[:3] == ["iam", "roles", "describe"]:
+    finish(state["gcs"]["role"])
+if args[:3] == ["iam", "service-accounts", "describe"]:
+    finish({"email": args[3], "disabled": False})
+if args[:3] == ["iam", "service-accounts", "list"]:
+    finish([
+        {"email": f"tr-{surface}@quill-cloud-proxy.iam.gserviceaccount.com"}
+        for surface in ("public", "actions", "console", "chat", "webhooks", "internal", "synthetic")
+    ])
+if args[:3] == ["iam", "service-accounts", "get-iam-policy"]:
+    deploy = "serviceAccount:tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com"
+    finish(
+        {
+            "bindings": [
+                {"role": "roles/iam.serviceAccountUser", "members": [deploy]}
+            ]
+        }
+    )
+if args[:3] == ["compute", "url-maps", "list"]:
+    names = [state.get("url_map_name", "trusted-router-map")]
+    names.extend(sorted(state.get("other_url_maps", {})))
+    finish("\n".join(names))
+if args[:3] == ["compute", "url-maps", "describe"]:
+    if args[3] in state.get("other_url_maps", {}):
+        finish(state["other_url_maps"][args[3]])
+    finish(state["url_maps"][state["live_map"]])
+if args[:3] == ["compute", "url-maps", "import"]:
+    source = option("--source") or ""
+    state["live_map"] = "candidate" if "candidate" in source else "prior"
+    finish(code=1 if matching("fail_after") else 0)
+if args[:3] == ["run", "services", "describe"]:
+    key = f"{args[3]}|{option('--region')}"
+    finish(state["services"][key])
+if args[:3] == ["run", "services", "list"]:
+    inventory = []
+    for key, service in state["services"].items():
+        _, region = key.rsplit("|", 1)
+        item = json.loads(json.dumps(service))
+        item.setdefault("metadata", {}).setdefault("labels", {})[
+            "cloud.googleapis.com/location"
+        ] = region
+        inventory.append(item)
+    finish(inventory)
+if args[:3] == ["run", "revisions", "describe"]:
+    candidate = args[3]
+    region = option("--region")
+    for service in state["services"].values():
+        if (
+            service["status"]["latestReadyRevisionName"] == candidate
+            and service["status"].get("url", "").endswith(f"-{region}.run.app")
+        ) or (
+            service["status"]["latestReadyRevisionName"] == candidate
+            and any(key.endswith("|" + region) and value is service for key, value in state["services"].items())
+        ):
+            finish(
+                {
+                    "metadata": {"name": candidate},
+                    "spec": service["spec"]["template"]["spec"],
+                    "status": {
+                        "conditions": [{"type": "Ready", "status": "True"}]
+                    },
+                }
+            )
+    finish("NOT_FOUND", code=1)
+if args[:3] == ["run", "services", "get-iam-policy"]:
+    key = f"{args[3]}|{option('--region')}"
+    finish(
+        state.get("service_iam", {}).get(
+            key,
+            {"bindings": [{"role": "roles/run.invoker", "members": ["allUsers"]}]},
+        )
+    )
+if args[:3] == ["run", "services", "update-traffic"]:
+    key = f"{args[3]}|{option('--region')}"
+    service = state["services"][key]
+    if option("--to-revisions") is not None:
+        traffic = []
+        for assignment in option("--to-revisions").split(","):
+            revision, raw_percent = assignment.rsplit("=", 1)
+            if revision == "LATEST":
+                revision = service["status"]["latestReadyRevisionName"]
+            traffic.append({"revisionName": revision, "percent": int(raw_percent)})
+        tags = [item for item in service["spec"].get("traffic", []) if item.get("tag")]
+        service["spec"]["traffic"] = traffic + tags
+        service["status"]["traffic"] = traffic + tags
+    if option("--set-tags") is not None:
+        positive = [item for item in service["spec"].get("traffic", []) if not item.get("tag")]
+        tags = []
+        for assignment in option("--set-tags").split(","):
+            tag, revision = assignment.split("=", 1)
+            if revision == "LATEST":
+                revision = service["status"]["latestReadyRevisionName"]
+            tags.append({"revisionName": revision, "percent": 0, "tag": tag})
+        service["spec"]["traffic"] = positive + tags
+        service["status"]["traffic"] = positive + tags
+    if "--clear-tags" in args:
+        service["spec"]["traffic"] = [item for item in service["spec"].get("traffic", []) if not item.get("tag")]
+        service["status"]["traffic"] = [item for item in service["status"].get("traffic", []) if not item.get("tag")]
+    state["services"][key] = service
+    finish(code=1 if matching("fail_after") else 0)
+if args[:3] == ["compute", "backend-services", "describe"]:
+    finish(state["backends"][args[3]])
+if args[:3] == ["compute", "security-policies", "describe"]:
+    finish(state["policies"][args[3]])
+if args[:3] == ["compute", "network-endpoint-groups", "describe"]:
+    finish(state["negs"][f"{args[3]}|{option('--region')}"])
+finish(code=2)
+'''
+
+FAKE_DIG = r'''#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+state = json.loads(Path(os.environ["FAKE_GCLOUD_STATE"]).read_text(encoding="utf-8"))
+host, record_type = sys.argv[-2:]
+for answer in state["dns"][host][record_type]:
+    print(answer)
+'''
+
+FAKE_JQ = r'''#!/usr/bin/env python3
+import json
+import sys
+
+args = sys.argv[1:]
+raw = any("r" in item for item in args if item.startswith("-") and not item.startswith("--"))
+compact = any("c" in item for item in args if item.startswith("-") and not item.startswith("--"))
+sort_keys = any("S" in item for item in args if item.startswith("-") and not item.startswith("--"))
+exit_status = any("e" in item for item in args if item.startswith("-") and not item.startswith("--"))
+variables = {}
+position = 0
+while position < len(args):
+    if args[position] == "--arg":
+        variables[args[position + 1]] = args[position + 2]
+        position += 3
+    elif args[position].startswith("-"):
+        position += 1
+    else:
+        break
+query = args[position]
+files = args[position + 1:]
+if files:
+    data = json.loads(open(files[-1], encoding="utf-8").read())
+else:
+    data = json.load(sys.stdin)
+normalized = " ".join(query.split())
+
+def path_value(expression):
+    value = data
+    for part in expression.removeprefix(".").split("."):
+        if part.endswith("[0]"):
+            value = value[part[:-3]][0]
+        else:
+            value = value[part]
+    return value
+
+if normalized.startswith(".services[] | select(.surface == $surface)"):
+    result = [item for item in data["services"] if item["surface"] == variables["surface"]]
+elif normalized == '.services[] | select(.surface == "console")':
+    result = [item for item in data["services"] if item["surface"] == "console"]
+elif normalized == '[.services[] | select(.surface == $surface)][0]':
+    result = next(item for item in data["services"] if item["surface"] == variables["surface"])
+elif normalized == '.services[]':
+    result = data["services"]
+elif normalized == '.legacy_fallback[]':
+    result = data["legacy_fallback"]
+elif normalized == '.regions[]':
+    result = data["regions"]
+elif normalized == '.legacy_hardening_artifact_sha256 // ""':
+    result = data.get("legacy_hardening_artifact_sha256") or ""
+elif normalized == '.cloudRun.service // ""':
+    result = (data.get("cloudRun") or {}).get("service", "")
+elif normalized.startswith(".email == $email and"):
+    result = data.get("email") == variables["email"] and not data.get("disabled", False)
+elif "roles/iam.serviceAccountUser" in normalized and "$member" in normalized:
+    direct = [
+        {
+            "role": binding.get("role"),
+            "condition": binding.get("condition"),
+        }
+        for binding in data.get("bindings", [])
+        if variables["member"] in binding.get("members", [])
+    ]
+    result = direct == [
+        {"role": "roles/iam.serviceAccountUser", "condition": None}
+    ]
+elif normalized == 'any(.pathMatchers[]?; .name == "trusted-router-service-surfaces")':
+    result = any(
+        item.get("name") == "trusted-router-service-surfaces"
+        for item in data.get("pathMatchers", [])
+    )
+elif normalized == "any(.[]; .latest_revision)":
+    result = any(item.get("latest_revision") for item in data)
+elif normalized.startswith("if .status.latestReadyRevisionName == $revision"):
+    result = (
+        data.get("status", {}).get("latestReadyRevisionName") == variables["revision"]
+        and any(
+            item.get("type") == "Ready" and item.get("status") == "True"
+            for item in data.get("status", {}).get("conditions", [])
+        )
+    )
+elif normalized.startswith("if (.metadata.generation | type) == \"number\""):
+    result = data["metadata"]["generation"]
+    if result != data["status"]["observedGeneration"]:
+        raise SystemExit(1)
+elif normalized.startswith("all(.legacy_fallback[];"):
+    result = all(
+        item["backend"] == variables["backend"]
+        and item["backend_postcondition_sha256"] == variables["digest"]
+        for item in data["legacy_fallback"]
+    )
+elif 'select(any(.members[]?; . == "allUsers"))' in normalized:
+    matches = [
+        {
+            "role": binding.get("role"),
+            "condition": binding.get("condition"),
+            "allUsersCount": binding.get("members", []).count("allUsers"),
+        }
+        for binding in data.get("bindings", [])
+        if "allUsers" in binding.get("members", [])
+    ]
+    result = matches == [
+        {
+            "role": "roles/run.invoker",
+            "condition": None,
+            "allUsersCount": 1,
+        }
+    ]
+elif "select(.revisionName == $revision)" in normalized and "add // 0" in normalized:
+    result = sum(
+        int(item.get("percent", 0) or 0)
+        for item in data.get("status", {}).get("traffic", [])
+        if item.get("revisionName") == variables["revision"]
+    )
+elif normalized.startswith('[.prior_traffic[] | select(.tag != null'):
+    result = ",".join(
+        f"{item['tag']}={'LATEST' if item['latest_revision'] else item['revision']}"
+        for item in data["prior_traffic"]
+        if item.get("tag")
+    )
+elif normalized.startswith("sort_by(.tag"):
+    result = sorted(
+        data,
+        key=lambda item: (
+            item.get("tag") or "",
+            item.get("latest_revision"),
+            item.get("revision") or "",
+            item.get("percent"),
+        ),
+    )
+elif normalized.startswith(".prior_traffic | sort_by(.tag"):
+    result = sorted(
+        data["prior_traffic"],
+        key=lambda item: (
+            item.get("tag") or "",
+            item.get("latest_revision"),
+            item.get("revision") or "",
+            item.get("percent"),
+        ),
+    )
+elif normalized.startswith(".schema_version == 1 and .manifest_sha256"):
+    result = (
+        data.get("schema_version") == 1
+        and data.get("manifest_sha256") == variables["manifest"]
+        and data.get("project_id") == variables["project"]
+        and data.get("url_map_name") == variables["map"]
+        and data.get("prior_url_map_sha256") == variables["prior"]
+        and data.get("candidate_url_map_sha256") == variables["candidate"]
+        and isinstance(data.get("attempts"), list)
+    )
+elif '.operation == "traffic"' in normalized:
+    result = any(
+        item.get("operation") == "traffic"
+        and item.get("service") == variables["service"]
+        and item.get("region") == variables["region"]
+        for item in data.get("attempts", [])
+    )
+elif '.operation == "url-map"' in normalized:
+    result = any(item.get("operation") == "url-map" for item in data.get("attempts", []))
+elif normalized.startswith(".") and all(token not in normalized for token in " |(){}"):
+    result = path_value(normalized)
+else:
+    raise SystemExit(f"unsupported fake jq query: {normalized}")
+
+truthy = result is not False and result is not None
+if exit_status and not truthy:
+    raise SystemExit(1)
+if isinstance(result, list) and normalized in {
+    ".services[]",
+    ".legacy_fallback[]",
+    ".regions[]",
+} or normalized.startswith(".services[] |"):
+    for item in result:
+        print(
+            item
+            if raw and isinstance(item, str)
+            else json.dumps(item, separators=(",", ":"), sort_keys=sort_keys)
+        )
+elif raw and isinstance(result, bool):
+    print("true" if result else "false")
+elif raw and isinstance(result, (str, int, float)):
+    print(result)
+else:
+    print(
+        json.dumps(
+            result,
+            separators=(",", ":") if compact else None,
+            sort_keys=sort_keys,
+        )
+    )
+'''
+
+
+def _install_fake_gcloud(tmp_path: Path) -> Path:
+    binary = tmp_path / "bin" / "gcloud"
+    binary.parent.mkdir(exist_ok=True)
+    binary.write_text(FAKE_GCLOUD, encoding="utf-8")
+    binary.chmod(0o755)
+    jq = binary.parent / "jq"
+    jq.write_text(FAKE_JQ, encoding="utf-8")
+    jq.chmod(0o755)
+    dig = binary.parent / "dig"
+    dig.write_text(FAKE_DIG, encoding="utf-8")
+    dig.chmod(0o755)
+    curl = binary.parent / "curl"
+    curl.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, sys\n"
+        "from pathlib import Path\n"
+        "args=sys.argv[1:]\n"
+        "output=args[args.index('--output')+1]\n"
+        "url=next(item for item in args if item.startswith('https://'))\n"
+        "if url.endswith('/chat-proxy/v1/chat/completions') or url.endswith('/v1/internal/gateway/authorize'):\n"
+        " message='Missing Authentication header' if '/chat-proxy/' in url else 'Invalid internal service token'\n"
+        " request_id=next(value for i,value in enumerate(args) if i > 0 and args[i-1] == '--header' and value.startswith('x-request-id: ')).split(': ',1)[1]\n"
+        " body={'error': {'code': 401, 'message': message, 'type': 'unauthorized', 'source': 'router'}}\n"
+        " headers=args[args.index('--dump-header')+1]\n"
+        " Path(headers).write_text('HTTP/2 401\\ncontent-type: application/json\\nx-trustedrouter-request-id: '+request_id+'\\nstrict-transport-security: max-age=63072000; includeSubDomains\\n\\n', encoding='iso-8859-1')\n"
+        " code='401'\n"
+        "elif url.endswith('/auth/session'):\n"
+        " body={'data': {'authenticated': True, 'management': True}}; code='200'\n"
+        "else:\n"
+        " body={}; code='422' if url.endswith('/support/inquiry') else '400' if url.endswith('/internal/stripe/webhook') else '200'\n"
+        "Path(output).write_text(json.dumps(body), encoding='utf-8')\n"
+        "print(code, end='')\n",
+        encoding="utf-8",
+    )
+    curl.chmod(0o755)
+    npx = binary.parent / "npx"
+    npx.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, os, sys\n"
+        "from pathlib import Path\n"
+        "phase=os.environ.get('TR_ROLLOUT_SMOKE_PHASE','')\n"
+        "percent=os.environ.get('TR_ROLLOUT_SMOKE_PERCENT','')\n"
+        "with Path(os.environ['ROLLOUT_EVENT_LOG']).open('a', encoding='utf-8') as out: out.write(f'smoke {phase} {percent}\\n')\n"
+        "if os.environ.get('OOB_IMPORT_PHASE') == phase:\n"
+        " p=Path(os.environ['FAKE_GCLOUD_STATE']); s=json.loads(p.read_text()); s['live_map']='candidate'; p.write_text(json.dumps(s))\n"
+        "raise SystemExit(1 if os.environ.get('FAIL_SMOKE_PHASE') == phase else 0)\n",
+        encoding="utf-8",
+    )
+    npx.chmod(0o755)
+    return binary.parent
+
+
+def _capture_frontend_artifact(
+    tmp_path: Path, cloud_state: Path, artifact: Path
+) -> None:
+    fake_bin = _install_fake_gcloud(tmp_path)
+    environment = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "FAKE_GCLOUD_STATE": str(cloud_state),
+        "ROLLOUT_EVENT_LOG": str(tmp_path / "frontend-events.log"),
+    }
+    result = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            str(FRONTEND_TOOL),
+            "capture",
+            "--project",
+            PROJECT,
+            "--forwarding-rule",
+            "trusted-router-https",
+            "--https-proxy",
+            "trusted-router-control-https-proxy",
+            "--url-map",
+            "trusted-router-map",
+            "--hosts",
+            ",".join(FRONTEND_HOSTS),
+            "--artifact",
+            str(artifact),
+        ],
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def _smoke_callback(tmp_path: Path) -> Path:
+    callback = tmp_path / "smoke"
+    callback.write_text(
+        "#!/usr/bin/env bash\n"
+        "echo \"smoke $2 $3\" >> \"$ROLLOUT_EVENT_LOG\"\n"
+        "if [ \"${OOB_IMPORT_PHASE:-}\" = \"$2\" ]; then\n"
+        "  python3 - \"$FAKE_GCLOUD_STATE\" <<'PY'\n"
+        "import json, sys\n"
+        "from pathlib import Path\n"
+        "path = Path(sys.argv[1])\n"
+        "state = json.loads(path.read_text(encoding='utf-8'))\n"
+        "state['live_map'] = 'candidate'\n"
+        "path.write_text(json.dumps(state), encoding='utf-8')\n"
+        "PY\n"
+        "fi\n"
+        "[ \"${FAIL_SMOKE_PHASE:-}\" != \"$2\" ]\n",
+        encoding="utf-8",
+    )
+    callback.chmod(0o755)
+    return callback
+
+
+def _run_helper(
+    tmp_path: Path,
+    manifest: Path,
+    cloud_state: Path,
+    events: Path,
+    *arguments: str,
+    fail_smoke: str = "",
+    invalid_smoke: bool = False,
+    durable: bool = False,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    fake_bin = _install_fake_gcloud(tmp_path)
+    manifest_value = json.loads(manifest.read_text(encoding="utf-8"))
+    auth_header = tmp_path / "smoke-authorization.header"
+    storage_state = tmp_path / "smoke-storage-state.json"
+    auth_header.write_text(
+        "Authorization: Bearer test-rollout-token-1234567890\n", encoding="utf-8"
+    )
+    storage_state.write_text('{"cookies":[],"origins":[]}\n', encoding="utf-8")
+    auth_header.chmod(0o600)
+    storage_state.chmod(0o600)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "FAKE_GCLOUD_STATE": str(cloud_state),
+        "ROLLOUT_EVENT_LOG": str(events),
+        "TR_ROLLOUT_SMOKE_COMMAND": str(
+            tmp_path / "missing-smoke"
+            if invalid_smoke
+            else SMOKE
+        ),
+        "TR_ROLLOUT_SMOKE_AUTH_HEADER_FILE": str(auth_header),
+        "TR_ROLLOUT_SMOKE_PLAYWRIGHT_STORAGE_STATE": str(storage_state),
+        "TR_ROLLOUT_SMOKE_PRODUCTION_APPROVED": "true",
+        "TR_CONTROL_PLANE_REGIONS": ",".join(manifest_value["regions"]),
+        "TR_REGIONS": ",".join(manifest_value["gateway_regions"]),
+        "FAIL_SMOKE_PHASE": fail_smoke,
+        "TR_ROLLOUT_REQUIRE_DURABLE_STATE": "false",
+    }
+    if durable:
+        env.update(
+            {
+                "TR_ROLLOUT_REQUIRE_DURABLE_STATE": "true",
+                "TR_ROLLOUT_STATE_GCS_URI": STATE_GCS_URI,
+                "TR_ROLLOUT_STATE_GCS_ROLE": STATE_GCS_ROLE,
+                "TR_ROLLOUT_OPERATION_ID": "test-operation-0001",
+            }
+        )
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(  # noqa: S603
+        ["/bin/bash", str(HELPER), arguments[0], str(manifest), *arguments[1:]],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _run_recovery(
+    tmp_path: Path,
+    cloud_state: Path,
+    *arguments: str | Path,
+    bundle_uri: str = RECOVERY_BUNDLE,
+) -> subprocess.CompletedProcess[str]:
+    fake_bin = _install_fake_gcloud(tmp_path)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "FAKE_GCLOUD_STATE": str(cloud_state),
+        "ROLLOUT_EVENT_LOG": str(tmp_path / "recovery-events.log"),
+        "TR_ROLLOUT_RECOVERY_GCS_PREFIX": RECOVERY_PREFIX,
+        "TR_ROLLOUT_BUNDLE_GCS_URI": bundle_uri,
+        "TR_ROLLOUT_AUTHORITY_GCS_URI": RECOVERY_AUTHORITY,
+    }
+    return subprocess.run(  # noqa: S603
+        ["/bin/bash", str(RECOVERY), *(str(value) for value in arguments)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _promotion_state_value(manifest_path: Path, attempts: list[dict[str, Any]]) -> dict[str, Any]:
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    return {
+        "schema_version": 1,
+        "manifest_sha256": hashlib.sha256(manifest_path.read_bytes()).hexdigest(),
+        "project_id": manifest["project_id"],
+        "url_map_name": manifest["url_map"]["name"],
+        "prior_url_map_sha256": manifest["url_map"]["prior_sha256"],
+        "candidate_url_map_sha256": manifest["url_map"]["candidate_sha256"],
+        "attempts": attempts,
+    }
+
+
+def _configure_durable_state(state_path: Path, manifest_path: Path) -> None:
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["gcs"] = {
+        "bucket": {
+            "iamConfiguration": {
+                "uniformBucketLevelAccess": {"enabled": True},
+                "publicAccessPrevention": "enforced",
+            },
+            "versioning": {"enabled": True},
+            "retentionPolicy": {"retentionPeriod": 604800},
+        },
+        "policy": {
+            "bindings": [
+                {
+                    "role": STATE_GCS_ROLE,
+                    "members": [
+                        "serviceAccount:tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com"
+                    ],
+                    "condition": {
+                        "title": "trusted-router-rollout-journal",
+                        "expression": (
+                            'resource.name == "projects/_/buckets/'
+                            'trusted-router-rollout-state/objects/releases/test/'
+                            'promotion-state.json"'
+                        ),
+                    },
+                }
+            ]
+        },
+        "role": {
+            "name": STATE_GCS_ROLE,
+            "stage": "GA",
+            "includedPermissions": [
+                "storage.objects.create",
+                "storage.objects.delete",
+                "storage.objects.get",
+            ],
+        },
+        "objects": {},
+    }
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+
+def _put_durable_journal(
+    state_path: Path,
+    manifest_path: Path,
+    attempts: list[dict[str, Any]],
+    *,
+    generation: int = 1,
+) -> None:
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["gcs"]["objects"][STATE_GCS_URI] = {
+        "generation": generation,
+        "content": json.dumps(_promotion_state_value(manifest_path, attempts), indent=2, sort_keys=True)
+        + "\n",
+    }
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+
+def _candidate_percents(state_path: Path) -> set[int]:
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    values = set()
+    for service in state["services"].values():
+        candidate = service["status"]["latestReadyRevisionName"]
+        values.add(
+            sum(
+                int(item.get("percent", 0))
+                for item in service["status"]["traffic"]
+                if item.get("revisionName") == candidate
+            )
+        )
+    return values
+
+
+def _set_candidate_percent(state_path: Path, percent: int) -> None:
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    for service in state["services"].values():
+        candidate = service["status"]["latestReadyRevisionName"]
+        prior = service["spec"]["traffic"][0]["revisionName"]
+        traffic = [{"revisionName": candidate, "percent": percent}]
+        if percent < 100:
+            traffic.append({"revisionName": prior, "percent": 100 - percent})
+        service["spec"]["traffic"] = copy.deepcopy(traffic)
+        service["status"]["traffic"] = copy.deepcopy(traffic)
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+
+def _set_service_candidate_percent(
+    state_path: Path,
+    service_name: str,
+    region: str,
+    percent: int,
+) -> None:
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    service = state["services"][f"{service_name}|{region}"]
+    candidate = service["status"]["latestReadyRevisionName"]
+    prior = service["spec"]["traffic"][0]["revisionName"]
+    traffic = [{"revisionName": candidate, "percent": percent}]
+    if percent < 100:
+        traffic.append({"revisionName": prior, "percent": 100 - percent})
+    service["spec"]["traffic"] = copy.deepcopy(traffic)
+    service["status"]["traffic"] = copy.deepcopy(traffic)
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+
+def _traffic_state_attempts(
+    manifest_path: Path,
+    percent: int,
+    *,
+    regions: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    return [
+        {
+            "attempted_at": "2026-08-20T12:00:00+00:00",
+            "operation": "traffic-state",
+            "surface": entry["surface"],
+            "service": entry["name"],
+            "region": entry["region"],
+            "target": str(percent),
+        }
+        for entry in manifest["services"]
+        if regions is None or entry["region"] in regions
+    ]
+
+
+def _write_local_promotion_state(
+    manifest_path: Path,
+    attempts: list[dict[str, Any]],
+) -> Path:
+    path = manifest_path.parent / "promotion-state.json"
+    path.write_text(
+        json.dumps(_promotion_state_value(manifest_path, attempts), indent=2, sort_keys=True)
+        + "\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o600)
+    return path
+
+
+def _stage_fixture(tmp_path: Path, *, floating_latest: bool) -> tuple[Path, Path]:
+    region = "us-central1"
+    services: dict[str, Any] = {}
+    for surface in SURFACES:
+        service, _, prior = _service_json(surface, region)
+        if floating_latest and surface == "public":
+            service["spec"]["traffic"] = [
+                {"latestRevision": True, "percent": 100}
+            ]
+            service["status"]["traffic"] = [
+                {"revisionName": prior, "percent": 100}
+            ]
+        services[f"{SERVICES[surface]}|{region}"] = service
+    url_map = {
+        "name": "trusted-router-map",
+        "selfLink": (
+            "https://www.googleapis.com/compute/v1/projects/quill-cloud-proxy/"
+            "global/urlMaps/trusted-router-map"
+        ),
+        "defaultService": (
+            "https://www.googleapis.com/compute/v1/projects/quill-cloud-proxy/"
+            "global/backendServices/legacy-backend"
+        ),
+        "hostRules": [
+            {
+                "hosts": [
+                    "api.trustedrouter.com",
+                    "api.allyrouter.com",
+                    "api.uptimerouter.com",
+                    "api.quillrouter.com",
+                    "api-aws.trustedrouter.com",
+                    "api-azure.trustedrouter.com",
+                    "api-azure-nz.trustedrouter.com",
+                    "api-azure-sea.trustedrouter.com",
+                    "api-eu-west-1.trustedrouter.com",
+                    "aws.trustedrouter.com",
+                    "azure.trustedrouter.com",
+                    "api-us-central1.quillrouter.com",
+                ],
+                "pathMatcher": "preserved-apis",
+            }
+        ],
+        "pathMatchers": [
+            {
+                "name": "preserved-apis",
+                "defaultService": (
+                    "https://www.googleapis.com/compute/v1/projects/"
+                    "quill-cloud-proxy/global/backendServices/legacy-backend"
+                ),
+            },
+            {
+                # These fixtures pre-create all six split services and are
+                # meant to exercise the existing-split traffic validator. The
+                # reserved matcher is the rollout's authoritative mode marker;
+                # without it the stricter initial-split inventory correctly
+                # rejects the pre-existing public companion before the
+                # intended traffic-shape assertion is reached.
+                "name": "trusted-router-service-surfaces",
+                "defaultService": (
+                    "https://www.googleapis.com/compute/v1/projects/"
+                    "quill-cloud-proxy/global/backendServices/"
+                    "trusted-router-public-backend"
+                ),
+            },
+        ],
+    }
+    certificate_name = "trusted-router-stage-cert"
+    certificate_url = (
+        "https://www.googleapis.com/compute/v1/projects/quill-cloud-proxy/"
+        f"global/sslCertificates/{certificate_name}"
+    )
+    state = {
+        "url_map_name": "trusted-router-map",
+        "https_proxy": "trusted-router-control-https-proxy",
+        "live_map": "prior",
+        "url_maps": {"prior": url_map, "candidate": url_map},
+        "other_url_maps": {},
+        "services": services,
+        "backends": {},
+        "policies": {},
+        "negs": {},
+        "iam": _iam_fixture(),
+        "fail_before": [],
+        "fail_after": [],
+        "forwarding_rule": {
+            "name": "trusted-router-https",
+            "selfLink": (
+                "https://www.googleapis.com/compute/v1/projects/quill-cloud-proxy/"
+                "global/forwardingRules/trusted-router-https"
+            ),
+            "IPAddress": FRONTEND_VIP,
+            "IPProtocol": "TCP",
+            "portRange": "443-443",
+            "networkTier": "PREMIUM",
+            "loadBalancingScheme": "EXTERNAL_MANAGED",
+            "target": (
+                "https://www.googleapis.com/compute/v1/projects/quill-cloud-proxy/"
+                "global/targetHttpsProxies/trusted-router-control-https-proxy"
+            ),
+        },
+        "proxy": {
+            "name": "trusted-router-control-https-proxy",
+            "selfLink": (
+                "https://www.googleapis.com/compute/v1/projects/quill-cloud-proxy/"
+                "global/targetHttpsProxies/trusted-router-control-https-proxy"
+            ),
+            "urlMap": url_map["selfLink"],
+            "sslCertificates": [certificate_url],
+        },
+        "ssl_certificates": {
+            certificate_name: {
+                "name": certificate_name,
+                "selfLink": certificate_url,
+                "type": "MANAGED",
+                "managed": {"status": "ACTIVE", "domains": FRONTEND_HOSTS},
+                "subjectAlternativeNames": FRONTEND_HOSTS,
+            }
+        },
+        "dns": {
+            host: {"A": [FRONTEND_VIP], "AAAA": []} for host in FRONTEND_HOSTS
+        },
+    }
+    state_path = tmp_path / "stage-cloud-state.json"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    return state_path, tmp_path / "stage-events.log"
+
+
+def _run_stage(
+    tmp_path: Path,
+    state: Path,
+    events: Path,
+    *,
+    revision_suffix: str = "rtest1",
+    regions: str = "us-central1",
+) -> subprocess.CompletedProcess[str]:
+    fake_bin = _install_fake_gcloud(tmp_path)
+    frontend_attestation = tmp_path / "stage-frontend-attestation.json"
+    _capture_frontend_artifact(tmp_path, state, frontend_attestation)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "FAKE_GCLOUD_STATE": str(state),
+        "ROLLOUT_EVENT_LOG": str(events),
+        "TR_CONTROL_PLANE_REGIONS": regions,
+        "TR_REGIONS": regions,
+        "TR_PRIMARY_REGION": regions.split(",")[0],
+        "TR_SYNTHETIC_MONITOR_REGIONS": regions,
+        "TR_SYNTHETIC_THROUGHPUT_REGION": regions.split(",")[0],
+        "TR_SYNTHETIC_IMAGE_REGION": regions.split(",")[0],
+        "TR_SYNTHETIC_VIDEO_REGION": regions.split(",")[0],
+        "TR_RELEASE": "test-release",
+        "TR_ROLLOUT_REVISION_SUFFIX": revision_suffix,
+        "TR_ROLLOUT_OPERATION_ID": "stage-fixture-operation",
+        "TR_ROLLOUT_LOCAL_LOCK_PATH": str(tmp_path / "rollout-operation.lock"),
+        "TR_ROLLOUT_FRONTEND_ATTESTATION": str(frontend_attestation),
+        "IMAGE": IMAGE,
+    }
+    return subprocess.run(  # noqa: S603
+        ["/bin/bash", str(ROLLOUT), "--manifest", str(tmp_path / "stage-manifest.json")],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _mutation_events(events: Path) -> list[str]:
+    if not events.exists():
+        return []
+    mutation_markers = (
+        " run deploy ",
+        " services update ",
+        " url-maps import ",
+        " backend-services create ",
+        " backend-services update ",
+        " backend-services add-backend ",
+        " backend-services remove-backend ",
+        " network-endpoint-groups create ",
+        " security-policies create ",
+        " security-policies rules create ",
+        " security-policies rules update ",
+    )
+    return [
+        line
+        for line in events.read_text(encoding="utf-8").splitlines()
+        if any(marker in f" {line} " for marker in mutation_markers)
+    ]
+
+
+def test_stage_rejects_floating_latest_before_any_mutation(tmp_path: Path) -> None:
+    state, events = _stage_fixture(tmp_path, floating_latest=True)
+    result = _run_stage(tmp_path, state, events)
+    assert result.returncode != 0
+    assert "floating LATEST traffic or tags" in result.stderr
+    assert _mutation_events(events) == []
+    assert not (tmp_path / "stage-manifest.json").exists()
+
+
+def test_stage_rejects_positive_tagged_prior_traffic_before_any_mutation(
+    tmp_path: Path,
+) -> None:
+    state_path, events = _stage_fixture(tmp_path, floating_latest=False)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    service = state["services"]["trusted-router-public|us-central1"]
+    prior = service["spec"]["traffic"][0]["revisionName"]
+    tagged = [{"revisionName": prior, "percent": 100, "tag": "stable"}]
+    service["spec"]["traffic"] = copy.deepcopy(tagged)
+    service["status"]["traffic"] = copy.deepcopy(tagged)
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    result = _run_stage(tmp_path, state_path, events)
+
+    assert result.returncode != 0
+    assert "positive traffic targets must be untagged" in result.stderr
+    assert _mutation_events(events) == []
+    assert not (tmp_path / "stage-manifest.json").exists()
+
+
+def test_stage_rejects_untagged_zero_percent_prior_before_any_mutation(
+    tmp_path: Path,
+) -> None:
+    state_path, events = _stage_fixture(tmp_path, floating_latest=False)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    service = state["services"]["trusted-router-public|us-central1"]
+    prior = service["spec"]["traffic"][0]["revisionName"]
+    traffic = [
+        {"revisionName": prior, "percent": 100},
+        {"revisionName": "trusted-router-public-retired", "percent": 0},
+    ]
+    service["spec"]["traffic"] = copy.deepcopy(traffic)
+    service["status"]["traffic"] = copy.deepcopy(traffic)
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    result = _run_stage(tmp_path, state_path, events)
+
+    assert result.returncode != 0
+    assert "untagged zero-percent traffic targets" in result.stderr
+    assert _mutation_events(events) == []
+    assert not (tmp_path / "stage-manifest.json").exists()
+
+
+def test_stage_refuses_existing_recovery_snapshot_before_any_mutation(tmp_path: Path) -> None:
+    state, events = _stage_fixture(tmp_path, floating_latest=False)
+    (tmp_path / "url-map.prior.json").write_text("{}", encoding="utf-8")
+    result = _run_stage(tmp_path, state, events)
+    assert result.returncode != 0
+    assert "refusing to overwrite existing rollout recovery artifact" in result.stderr
+    assert _mutation_events(events) == []
+
+
+@pytest.mark.parametrize(
+    ("revision_suffix", "regions", "message"),
+    [
+        ("r_bad", "us-central1", "canonical revision suffix"),
+        ("rtest1", "us-central1,us-central1", "duplicate control-plane region"),
+    ],
+)
+def test_stage_rejects_malformed_identifiers_before_any_mutation(
+    tmp_path: Path,
+    revision_suffix: str,
+    regions: str,
+    message: str,
+) -> None:
+    state, events = _stage_fixture(tmp_path, floating_latest=False)
+    result = _run_stage(
+        tmp_path,
+        state,
+        events,
+        revision_suffix=revision_suffix,
+        regions=regions,
+    )
+    assert result.returncode != 0
+    assert message in result.stderr
+    assert _mutation_events(events) == []
+
+
+def test_existing_split_promotes_every_surface_in_primary_then_secondary(tmp_path: Path) -> None:
+    manifest, state, events = _fixture(tmp_path)
+    result = _run_helper(tmp_path, manifest, state, events, "promote")
+    assert result.returncode == 0, result.stderr
+    assert _candidate_percents(state) == {100}
+    lines = events.read_text(encoding="utf-8").splitlines()
+    smokes = [line for line in lines if line.startswith("smoke ")]
+    assert smokes == [
+        "smoke preflight 0",
+        "smoke primary 10",
+        "smoke primary 50",
+        "smoke primary 100",
+        "smoke secondary 10",
+        "smoke secondary 50",
+        "smoke secondary 100",
+    ]
+    first_secondary = next(index for index, line in enumerate(lines) if "--region=europe-west4" in line and "update-traffic" in line)
+    primary_100_smoke = lines.index("smoke primary 100")
+    assert primary_100_smoke < first_secondary
+    assert not any("url-maps import" in line for line in lines)
+
+
+def test_private_internal_synthetic_region_is_verified_but_not_added_to_lb(
+    tmp_path: Path,
+) -> None:
+    manifest, state, events = _fixture(
+        tmp_path,
+        regions=["us-central1"],
+        internal_regions=["us-central1", "europe-west4"],
+    )
+
+    result = _run_helper(tmp_path, manifest, state, events, "verify", "all", "0")
+
+    assert result.returncode == 0, result.stderr
+    cloud = json.loads(state.read_text(encoding="utf-8"))
+    internal_backend = cloud["backends"]["trusted-router-billing-backend"]
+    assert len(internal_backend["backends"]) == 1
+    assert "us-central1" in internal_backend["backends"][0]["group"]
+    assert "europe-west4" not in internal_backend["backends"][0]["group"]
+
+
+def test_promote_requires_executable_smoke_before_any_mutation(tmp_path: Path) -> None:
+    manifest, state, events = _fixture(tmp_path, regions=["us-central1"])
+    result = _run_helper(
+        tmp_path,
+        manifest,
+        state,
+        events,
+        "promote",
+        invalid_smoke=True,
+    )
+    assert result.returncode != 0
+    assert "must be an executable file" in result.stderr
+    assert _mutation_events(events) == []
+
+
+def test_preflight_dns_tls_smoke_failure_does_zero_mutations(tmp_path: Path) -> None:
+    manifest, state, events = _fixture(tmp_path, regions=["us-central1"])
+    result = _run_helper(
+        tmp_path,
+        manifest,
+        state,
+        events,
+        "promote",
+        fail_smoke="preflight",
+    )
+    assert result.returncode != 0
+    lines = events.read_text(encoding="utf-8").splitlines()
+    assert "smoke preflight 0" in lines
+    assert not any("update-traffic" in line or "url-maps import" in line for line in lines)
+
+
+def test_required_durable_journal_configuration_fails_before_mutation(
+    tmp_path: Path,
+) -> None:
+    manifest, state, events = _fixture(tmp_path, regions=["us-central1"])
+    result = _run_helper(
+        tmp_path,
+        manifest,
+        state,
+        events,
+        "promote-step",
+        "primary",
+        "10",
+        extra_env={"TR_ROLLOUT_REQUIRE_DURABLE_STATE": "true"},
+    )
+    assert result.returncode != 0
+    assert "requires TR_ROLLOUT_STATE_GCS_URI" in result.stderr
+    assert _mutation_events(events) == []
+
+
+def test_private_recovery_bundle_restores_a_fresh_runner(tmp_path: Path) -> None:
+    manifest, state_path, _ = _fixture(tmp_path, regions=["us-central1"])
+    _configure_durable_state(state_path, manifest)
+
+    published = _run_recovery(tmp_path, state_path, "publish", manifest)
+    assert published.returncode == 0, published.stderr
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    objects = state["gcs"]["objects"]
+    expected = {
+        f"{RECOVERY_BUNDLE}/bundle.json",
+        f"{RECOVERY_BUNDLE}/{manifest.name}",
+        f"{RECOVERY_BUNDLE}/url-map.prior.json",
+        f"{RECOVERY_BUNDLE}/url-map.candidate.json",
+        f"{RECOVERY_BUNDLE}/promotion-state.json",
+        RECOVERY_AUTHORITY,
+    }
+    assert expected <= set(objects)
+
+    destination = tmp_path / "fresh-runner"
+    recovered = _run_recovery(
+        tmp_path,
+        state_path,
+        "recover",
+        RECOVERY_BUNDLE,
+        destination,
+    )
+    assert recovered.returncode == 0, recovered.stderr
+    recovered_manifest = Path(recovered.stdout.strip())
+    assert recovered_manifest == destination / manifest.name
+    assert all(
+        path.stat().st_mode & 0o777 == 0o600
+        for path in destination.iterdir()
+        if path.is_file()
+    )
+    _run_state("validate-manifest", recovered_manifest)
+
+
+def test_publish_refuses_to_supersede_another_active_manifest(
+    tmp_path: Path,
+) -> None:
+    first_dir = tmp_path / "first"
+    first_dir.mkdir()
+    first, state_path, _ = _fixture(first_dir, regions=["us-central1"])
+    _configure_durable_state(state_path, first)
+    published = _run_recovery(first_dir, state_path, "publish", first)
+    assert published.returncode == 0, published.stderr
+    before = json.loads(state_path.read_text(encoding="utf-8"))["gcs"]["objects"][
+        RECOVERY_AUTHORITY
+    ]["content"]
+
+    second_dir = tmp_path / "second"
+    second_dir.mkdir()
+    second, _, _ = _fixture(second_dir, regions=["us-central1"])
+    second_value = json.loads(second.read_text(encoding="utf-8"))
+    second_value["release"] = "different-release"
+    second.write_text(json.dumps(second_value), encoding="utf-8")
+    refused = _run_recovery(
+        second_dir,
+        state_path,
+        "publish",
+        second,
+        bundle_uri=f"{RECOVERY_PREFIX}/releases/test-epoch-0002",
+    )
+    assert refused.returncode != 0
+    assert "refusing to overwrite" in refused.stderr
+    after = json.loads(state_path.read_text(encoding="utf-8"))["gcs"]["objects"][
+        RECOVERY_AUTHORITY
+    ]["content"]
+    assert after == before
+
+
+def test_durable_journal_resumes_on_a_fresh_runner(tmp_path: Path) -> None:
+    manifest, state, events = _fixture(tmp_path, regions=["us-central1"])
+    _configure_durable_state(state, manifest)
+    first = _run_helper(
+        tmp_path,
+        manifest,
+        state,
+        events,
+        "promote-step",
+        "primary",
+        "10",
+        durable=True,
+    )
+    assert first.returncode == 0, first.stderr
+    local_journal = tmp_path / "promotion-state.json"
+    assert local_journal.stat().st_mode & 0o777 == 0o600
+    local_journal.unlink()
+
+    resumed = _run_helper(
+        tmp_path,
+        manifest,
+        state,
+        events,
+        "promote-step",
+        "primary",
+        "50",
+        durable=True,
+    )
+
+    assert resumed.returncode == 0, resumed.stderr
+    assert _candidate_percents(state) == {50}
+    assert local_journal.exists()
+    assert local_journal.stat().st_mode & 0o777 == 0o600
+    lines = events.read_text(encoding="utf-8").splitlines()
+    assert any("storage cp" in line and "--if-generation-match=" in line for line in lines)
+
+
+def test_durable_journal_cas_conflict_stops_before_provider_mutation(
+    tmp_path: Path,
+) -> None:
+    manifest, state_path, events = _fixture(tmp_path, regions=["us-central1"])
+    _configure_durable_state(state_path, manifest)
+    _put_durable_journal(state_path, manifest, [])
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["gcs"]["conflict_once"] = True
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    result = _run_helper(
+        tmp_path,
+        manifest,
+        state_path,
+        events,
+        "promote-step",
+        "primary",
+        "10",
+        durable=True,
+    )
+
+    assert result.returncode != 0
+    assert _candidate_percents(state_path) == {0}
+    assert not any(
+        "run services update-traffic" in line
+        for line in events.read_text(encoding="utf-8").splitlines()
+    )
+
+
+def test_active_operation_lease_rejects_concurrent_rollback_without_mutation(
+    tmp_path: Path,
+) -> None:
+    manifest, state_path, events = _fixture(tmp_path, regions=["us-central1"])
+    promotion = _promotion_state_value(manifest, [])
+    promotion["lease"] = {
+        "owner": "first-operation-0001",
+        "operation": "promote-step:primary:10",
+        "acquired_at": "2026-08-21T00:00:00+00:00",
+        "expires_at": "2099-08-21T00:00:00+00:00",
+    }
+    promotion_path = tmp_path / "promotion-state.json"
+    promotion_path.write_text(json.dumps(promotion), encoding="utf-8")
+    promotion_path.chmod(0o600)
+
+    refused = _run_helper(
+        tmp_path,
+        manifest,
+        state_path,
+        events,
+        "rollback",
+        extra_env={"TR_ROLLOUT_OPERATION_ID": "second-operation-0002"},
+    )
+    assert refused.returncode != 0
+    assert "active lease" in refused.stderr
+    assert _mutation_events(events) == []
+    assert json.loads(promotion_path.read_text(encoding="utf-8"))["lease"][
+        "owner"
+    ] == "first-operation-0001"
+
+
+def test_expired_operation_lease_requires_explicit_reconciled_takeover(
+    tmp_path: Path,
+) -> None:
+    manifest, state_path, events = _fixture(tmp_path, regions=["us-central1"])
+    promotion = _promotion_state_value(manifest, [])
+    promotion["lease"] = {
+        "owner": "crashed-operation-0001",
+        "operation": "promote-step:primary:10",
+        "acquired_at": "2000-01-01T00:00:00+00:00",
+        "expires_at": "2000-01-01T00:01:00+00:00",
+    }
+    promotion_path = tmp_path / "promotion-state.json"
+    promotion_path.write_text(json.dumps(promotion), encoding="utf-8")
+    promotion_path.chmod(0o600)
+
+    refused = _run_helper(
+        tmp_path,
+        manifest,
+        state_path,
+        events,
+        "rollback",
+        extra_env={"TR_ROLLOUT_OPERATION_ID": "recovery-operation-0002"},
+    )
+    assert refused.returncode != 0
+    assert "explicit reconciled takeover" in refused.stderr
+    assert _mutation_events(events) == []
+
+    taken_over = _run_helper(
+        tmp_path,
+        manifest,
+        state_path,
+        events,
+        "rollback",
+        extra_env={
+            "TR_ROLLOUT_OPERATION_ID": "recovery-operation-0002",
+            "TR_ROLLOUT_TAKEOVER_EXPIRED_LEASE": "true",
+        },
+    )
+    assert taken_over.returncode == 0, taken_over.stderr
+    assert json.loads(promotion_path.read_text(encoding="utf-8"))["lease"] is None
+    assert _mutation_events(events) == []
+
+
+def test_provider_timeout_kills_command_and_permanently_fences_takeover(
+    tmp_path: Path,
+) -> None:
+    manifest, state_path, events = _fixture(tmp_path, regions=["us-central1"])
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["sleep_before"] = [
+        "run services update-traffic trusted-router-public"
+    ]
+    state["sleep_seconds"] = 30
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    timed_out = _run_helper(
+        tmp_path,
+        manifest,
+        state_path,
+        events,
+        "promote-step",
+        "primary",
+        "10",
+        extra_env={
+            "TR_ROLLOUT_OPERATION_ID": "timed-operation-0001",
+            "TR_ROLLOUT_LEASE_TTL_SECONDS": "60",
+            "TR_ROLLOUT_PROVIDER_MUTATION_TIMEOUT_SECONDS": "5",
+        },
+    )
+    assert timed_out.returncode != 0
+    assert "lease-bounded deadline" in timed_out.stderr
+    assert _candidate_percents(state_path) == {0}
+
+    promotion_path = tmp_path / "promotion-state.json"
+    promotion = json.loads(promotion_path.read_text(encoding="utf-8"))
+    assert promotion["lease"]["owner"] == "timed-operation-0001"
+    assert promotion["lease"]["mutation"]["operation"] == "traffic"
+    promotion["lease"]["expires_at"] = "2000-01-01T00:00:00+00:00"
+    promotion_path.write_text(json.dumps(promotion), encoding="utf-8")
+    promotion_path.chmod(0o600)
+    mutation_events_before = _mutation_events(events)
+
+    refused = _run_helper(
+        tmp_path,
+        manifest,
+        state_path,
+        events,
+        "rollback",
+        extra_env={
+            "TR_ROLLOUT_OPERATION_ID": "recovery-operation-0002",
+            "TR_ROLLOUT_TAKEOVER_EXPIRED_LEASE": "true",
+        },
+    )
+    assert refused.returncode != 0
+    assert "unresolved provider mutation" in refused.stderr
+    assert _mutation_events(events) == mutation_events_before
+
+
+def test_durable_pre_provider_record_allows_fresh_runner_rollback(
+    tmp_path: Path,
+) -> None:
+    manifest, state_path, events = _fixture(tmp_path, regions=["us-central1"])
+    _configure_durable_state(state_path, manifest)
+    _set_service_candidate_percent(
+        state_path, "trusted-router-public", "us-central1", 10
+    )
+    public_attempt = _traffic_state_attempts(manifest, 10)[0]
+    public_attempt["operation"] = "traffic"
+    _put_durable_journal(state_path, manifest, [public_attempt])
+
+    result = _run_helper(
+        tmp_path,
+        manifest,
+        state_path,
+        events,
+        "rollback",
+        durable=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert _candidate_percents(state_path) == {0}
+
+
+@pytest.mark.parametrize(
+    ("current", "target", "expected_updates"),
+    [(10, 50, 6), (50, 50, 0), (50, 100, 6), (100, 100, 0)],
+)
+def test_promote_step_resumes_monotonically_at_every_boundary(
+    tmp_path: Path,
+    current: int,
+    target: int,
+    expected_updates: int,
+) -> None:
+    manifest, state, events = _fixture(tmp_path, regions=["us-central1"])
+    _set_candidate_percent(state, current)
+    _write_local_promotion_state(
+        manifest,
+        _traffic_state_attempts(manifest, current),
+    )
+    result = _run_helper(
+        tmp_path,
+        manifest,
+        state,
+        events,
+        "promote-step",
+        "primary",
+        str(target),
+    )
+    assert result.returncode == 0, result.stderr
+    assert _candidate_percents(state) == {target}
+    updates = [
+        line
+        for line in events.read_text(encoding="utf-8").splitlines()
+        if "run services update-traffic" in line
+    ]
+    assert len(updates) == expected_updates
+
+
+def test_invalid_promotion_transition_does_zero_mutations(tmp_path: Path) -> None:
+    manifest, state, events = _fixture(tmp_path, regions=["us-central1"])
+    result = _run_helper(
+        tmp_path,
+        manifest,
+        state,
+        events,
+        "promote-step",
+        "primary",
+        "50",
+    )
+    assert result.returncode != 0
+    assert "out of order" in result.stderr
+    assert not any(
+        "run services update-traffic" in line
+        for line in events.read_text(encoding="utf-8").splitlines()
+    )
+
+
+def test_nonzero_after_apply_is_accepted_only_after_postcondition(tmp_path: Path) -> None:
+    manifest, state_path, events = _fixture(tmp_path)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["fail_after"] = ["update-traffic trusted-router-public --region=us-central1"]
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    result = _run_helper(tmp_path, manifest, state_path, events, "promote")
+    assert result.returncode == 0, result.stderr
+    assert "inspecting provider state" in result.stderr
+    assert _candidate_percents(state_path) == {100}
+
+
+def test_mid_cohort_failure_rolls_back_only_recorded_attempts_and_surfaces_failure(tmp_path: Path) -> None:
+    manifest, state_path, events = _fixture(tmp_path)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["fail_before"] = [
+        "update-traffic trusted-router-actions --region=us-central1 --to-revisions=trusted-router-actions-candidate=50"
+    ]
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    result = _run_helper(tmp_path, manifest, state_path, events, "promote")
+    assert result.returncode != 0
+    assert _candidate_percents(state_path) == {0}
+    promotion_state = json.loads((tmp_path / "promotion-state.json").read_text(encoding="utf-8"))
+    attempted = {
+        (item["service"], item["region"])
+        for item in promotion_state["attempts"]
+        if item["operation"] == "traffic"
+    }
+    assert ("trusted-router-public", "us-central1") in attempted
+    assert not any(region == "europe-west4" for _, region in attempted)
+
+
+def test_explicit_rollback_surfaces_partial_restore_failure(tmp_path: Path) -> None:
+    manifest, state_path, events = _fixture(tmp_path, regions=["us-central1"])
+    promoted = _run_helper(
+        tmp_path,
+        manifest,
+        state_path,
+        events,
+        "promote-step",
+        "primary",
+        "10",
+    )
+    assert promoted.returncode == 0, promoted.stderr
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["fail_before"] = [
+        "update-traffic trusted-router-public --region=us-central1 "
+        "--to-revisions=trusted-router-public-prior=100"
+    ]
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    result = _run_helper(tmp_path, manifest, state_path, events, "rollback")
+    assert result.returncode != 0
+    assert "one or more attempted companion traffic states failed" in result.stderr
+    assert _candidate_percents(state_path) == {0, 10}
+
+
+def test_rollback_restores_duplicate_zero_percent_tag_target_exactly(tmp_path: Path) -> None:
+    manifest_path, state_path, events = _fixture(
+        tmp_path,
+        regions=["us-central1"],
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    public_entry = next(
+        item for item in manifest["services"] if item["surface"] == "public"
+    )
+    prior = public_entry["prior_traffic"][0]["revision"]
+    public_entry["prior_traffic"].append(
+        {
+            "revision": prior,
+            "resolved_revision": prior,
+            "latest_revision": False,
+            "percent": 0,
+            "tag": "stable",
+        }
+    )
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    _run_state("validate-manifest", manifest_path)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    public = state["services"]["trusted-router-public|us-central1"]
+    public["spec"]["traffic"].append(
+        {"revisionName": prior, "percent": 0, "tag": "stable"}
+    )
+    public["status"]["traffic"].append(
+        {"revisionName": prior, "percent": 0, "tag": "stable"}
+    )
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    promoted = _run_helper(
+        tmp_path,
+        manifest_path,
+        state_path,
+        events,
+        "promote-step",
+        "primary",
+        "10",
+    )
+    assert promoted.returncode == 0, promoted.stderr
+    restored = _run_helper(tmp_path, manifest_path, state_path, events, "rollback")
+    assert restored.returncode == 0, restored.stderr
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["services"]["trusted-router-public|us-central1"]["status"][
+        "traffic"
+    ] == [
+        {"revisionName": prior, "percent": 100},
+        {"revisionName": prior, "percent": 0, "tag": "stable"},
+    ]
+
+
+def test_unknown_url_map_refuses_rollback_without_mutation(tmp_path: Path) -> None:
+    manifest, state_path, events = _fixture(tmp_path, regions=["us-central1"])
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["live_map"] = "unknown"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    result = _run_helper(tmp_path, manifest, state_path, events, "rollback")
+    assert result.returncode != 0
+    assert "unknown third state" in result.stderr
+    assert not any(
+        "update-traffic" in line or "url-maps import" in line
+        for line in events.read_text(encoding="utf-8").splitlines()
+    )
+
+
+def test_initial_split_cuts_over_only_by_url_map(tmp_path: Path) -> None:
+    manifest, state, events = _fixture(tmp_path, "initial_split")
+    result = _run_helper(tmp_path, manifest, state, events, "promote")
+    assert result.returncode == 0, result.stderr
+    lines = events.read_text(encoding="utf-8").splitlines()
+    companion_smoke = lines.index("smoke initial-companions 100")
+    assert lines.index("smoke preflight 0") < companion_smoke
+    map_import = next(index for index, line in enumerate(lines) if "url-maps import" in line)
+    map_smoke = lines.index("smoke initial-map 100")
+    assert companion_smoke < map_import < map_smoke
+    assert not any("update-traffic" in line for line in lines)
+    console_smoke = lines.index("smoke initial-console 100")
+    assert map_smoke < console_smoke < len(lines) - 1
+    assert any("run services describe" in line for line in lines[console_smoke + 1 :])
+
+
+def test_initial_smoke_failure_never_imports_map_or_shifts_console(tmp_path: Path) -> None:
+    manifest, state, events = _fixture(tmp_path, "initial_split")
+    result = _run_helper(
+        tmp_path,
+        manifest,
+        state,
+        events,
+        "promote",
+        fail_smoke="initial-companions",
+    )
+    assert result.returncode != 0
+    lines = events.read_text(encoding="utf-8").splitlines()
+    assert not any("url-maps import" in line for line in lines)
+    assert not any("update-traffic" in line for line in lines)
+    # Every split candidate is 100%-but-unrouted, and the untouched legacy
+    # monolith remains at its exact named 100%-serving fallback revision.
+    assert _candidate_percents(state) == {100}
+
+
+def test_initial_map_only_rollback_ignores_broken_split_candidate(
+    tmp_path: Path,
+) -> None:
+    manifest, state_path, events = _fixture(
+        tmp_path, "initial_split", regions=["us-central1"]
+    )
+    promoted = _run_helper(tmp_path, manifest, state_path, events, "promote")
+    assert promoted.returncode == 0, promoted.stderr
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    split = state["services"]["trusted-router-public|us-central1"]
+    split["status"]["conditions"] = [{"type": "Ready", "status": "False"}]
+    split["spec"]["template"]["spec"]["containers"][0]["env"].append(
+        {"name": "HOSTILE_DRIFT", "value": "true"}
+    )
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    events.write_text("", encoding="utf-8")
+    rolled_back = _run_helper(tmp_path, manifest, state_path, events, "rollback")
+
+    assert rolled_back.returncode == 0, rolled_back.stderr
+    final_state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert final_state["live_map"] == "prior"
+    lines = events.read_text(encoding="utf-8").splitlines()
+    assert any("url-maps import" in line for line in lines)
+    assert not any("update-traffic" in line for line in lines)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda state: state["services"]["trusted-router|us-central1"]["status"].update(
+            conditions=[{"type": "Ready", "status": "False"}]
+        ),
+        lambda state: state["service_iam"].update(
+            {
+                "trusted-router|us-central1": {
+                    "bindings": [
+                        {
+                            "role": "roles/run.invoker",
+                            "members": ["allUsers"],
+                            "condition": {"title": "expired", "expression": "false"},
+                        }
+                    ]
+                }
+            }
+        ),
+        lambda state: state["negs"][
+            "trusted-router-control-neg|us-central1"
+        ]["cloudRun"].update(service="trusted-router-console"),
+    ],
+)
+def test_legacy_fallback_drift_blocks_initial_promotion_without_mutation(
+    tmp_path: Path,
+    mutation: Any,
+) -> None:
+    manifest, state_path, events = _fixture(
+        tmp_path, "initial_split", regions=["us-central1"]
+    )
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state.setdefault("service_iam", {})
+    mutation(state)
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    result = _run_helper(tmp_path, manifest, state_path, events, "promote")
+
+    assert result.returncode != 0
+    assert _mutation_events(events) == []
+
+
+def test_initial_manifest_rejects_floating_latest_legacy_fallback(
+    tmp_path: Path,
+) -> None:
+    manifest_path, _, _ = _fixture(
+        tmp_path, "initial_split", regions=["us-central1"]
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    traffic = manifest["legacy_fallback"][0]["traffic"][0]
+    traffic.update(revision=None, latest_revision=True)
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    result = _run_state("validate-manifest", manifest_path, check=False)
+
+    assert result.returncode != 0
+    assert "LATEST" in result.stderr
+
+
+def test_initial_out_of_band_candidate_import_between_callback_and_cutover_is_rejected(
+    tmp_path: Path,
+) -> None:
+    manifest, state_path, events = _fixture(tmp_path, "initial_split")
+    result = _run_helper(
+        tmp_path,
+        manifest,
+        state_path,
+        events,
+        "promote",
+        extra_env={"OOB_IMPORT_PHASE": "initial-companions"},
+    )
+    assert result.returncode != 0
+    assert "without this manifest's recorded import attempt" in result.stderr
+    assert not any(
+        "url-maps import" in line or "update-traffic" in line
+        for line in events.read_text(encoding="utf-8").splitlines()
+    )
+
+
+def test_out_of_band_candidate_map_and_invalid_verify_cohort_do_zero_mutations(tmp_path: Path) -> None:
+    manifest, state_path, events = _fixture(tmp_path, "initial_split")
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["live_map"] = "candidate"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    result = _run_helper(tmp_path, manifest, state_path, events, "promote")
+    assert result.returncode != 0
+    assert not any("update-traffic" in line or "url-maps import" in line for line in events.read_text(encoding="utf-8").splitlines())
+
+    events.write_text("", encoding="utf-8")
+    result = _run_helper(tmp_path, manifest, state_path, events, "verify", "bogus", "100")
+    assert result.returncode != 0
+    assert events.read_text(encoding="utf-8") == ""
+
+
+def test_live_service_contract_drift_blocks_verify_without_mutation(tmp_path: Path) -> None:
+    manifest, state_path, events = _fixture(tmp_path)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    service = state["services"]["trusted-router-chat|us-central1"]
+    for item in service["spec"]["template"]["spec"]["containers"][0]["env"]:
+        if item["name"] == "TR_MAX_REQUEST_BODY_BYTES":
+            item["value"] = "4194304"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    result = _run_helper(tmp_path, manifest, state_path, events, "verify", "all", "0")
+    assert result.returncode != 0
+    assert not any("update-traffic" in line or "url-maps import" in line for line in events.read_text(encoding="utf-8").splitlines())
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda container, annotations: container["resources"]["limits"].update(
+                memory="4Gi"
+            ),
+            "memory differs",
+        ),
+        (
+            lambda container, annotations: container["ports"][0].update(
+                containerPort=9090
+            ),
+            "container port differs",
+        ),
+        (
+            lambda container, annotations: container["startupProbe"].update(
+                timeoutSeconds=1
+            ),
+            "startup probe timeoutSeconds differs",
+        ),
+        (
+            lambda container, annotations: annotations.update(
+                {"run.googleapis.com/vpc-access-egress": "all-traffic"}
+            ),
+            "VPC egress differs",
+        ),
+    ],
+)
+def test_platform_contract_drift_blocks_verify_without_mutation(
+    tmp_path: Path,
+    mutate: Any,
+    message: str,
+) -> None:
+    manifest, state_path, events = _fixture(tmp_path, regions=["us-central1"])
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    service = state["services"]["trusted-router-chat|us-central1"]
+    template = service["spec"]["template"]
+    container = template["spec"]["containers"][0]
+    mutate(container, template["metadata"]["annotations"])
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    result = _run_helper(tmp_path, manifest, state_path, events, "verify", "all", "0")
+
+    assert result.returncode != 0
+    assert message in result.stderr
+    assert _mutation_events(events) == []
+
+
+@pytest.mark.parametrize("drift", ("sidecar", "command", "volume"))
+def test_container_shape_drift_blocks_verify_without_mutation(
+    tmp_path: Path,
+    drift: str,
+) -> None:
+    manifest, state_path, events = _fixture(tmp_path, regions=["us-central1"])
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    template_spec = state["services"]["trusted-router-chat|us-central1"]["spec"][
+        "template"
+    ]["spec"]
+    if drift == "sidecar":
+        template_spec["containers"].append(
+            {"image": "example.invalid/sidecar@sha256:" + "2" * 64}
+        )
+    elif drift == "command":
+        template_spec["containers"][0]["command"] = ["/bin/sh"]
+        template_spec["containers"][0]["args"] = ["-c", "exit 0"]
+    else:
+        template_spec["volumes"] = [{"name": "unexpected", "emptyDir": {}}]
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    result = _run_helper(tmp_path, manifest, state_path, events, "verify", "all", "0")
+
+    assert result.returncode != 0
+    assert _mutation_events(events) == []
+
+
+def test_https_proxy_repoint_blocks_promotion_without_mutation(tmp_path: Path) -> None:
+    manifest, state_path, events = _fixture(tmp_path, regions=["us-central1"])
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["proxy_map"] = "out-of-band-map"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    result = _run_helper(tmp_path, manifest, state_path, events, "promote")
+
+    assert result.returncode != 0
+    assert "no longer targets manifest map" in result.stderr
+    assert _mutation_events(events) == []
+
+
+def test_extra_cloud_armor_priority_blocks_verify_without_mutation(tmp_path: Path) -> None:
+    manifest, state_path, events = _fixture(tmp_path, regions=["us-central1"])
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["policies"]["trusted-router-public-edge"]["rules"].append(
+        {
+            "priority": 100,
+            "action": "allow",
+            "preview": False,
+            "match": {"config": {"srcIpRanges": ["*"]}},
+        }
+    )
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    result = _run_helper(tmp_path, manifest, state_path, events, "verify", "all", "0")
+    assert result.returncode != 0
+    assert "unexpected Cloud Armor priority set" in result.stderr
+    assert _mutation_events(events) == []
+
+
+def test_cloud_armor_header_injection_blocks_verify_without_mutation(
+    tmp_path: Path,
+) -> None:
+    manifest, state_path, events = _fixture(tmp_path, regions=["us-central1"])
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    default_rule = next(
+        rule
+        for rule in state["policies"]["trusted-router-public-edge"]["rules"]
+        if rule["priority"] == 2_147_483_647
+    )
+    default_rule["headerAction"] = {
+        "requestHeadersToAdds": [
+            {"headerName": "Authorization", "headerValue": "Bearer stale"}
+        ]
+    }
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    result = _run_helper(tmp_path, manifest, state_path, events, "verify", "all", "0")
+
+    assert result.returncode != 0
+    assert "retains forbidden fields" in result.stderr
+    assert _mutation_events(events) == []
+
+
+def test_second_url_map_reference_blocks_promotion_without_mutation(
+    tmp_path: Path,
+) -> None:
+    manifest, state_path, events = _fixture(tmp_path, regions=["us-central1"])
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["other_url_maps"] = {
+        "rogue-map": {
+            "name": "rogue-map",
+            "defaultService": (
+                "https://www.googleapis.com/compute/v1/projects/quill-cloud-proxy/"
+                "global/backendServices/trusted-router-public-backend"
+            ),
+        }
+    }
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    result = _run_helper(tmp_path, manifest, state_path, events, "verify", "all", "0")
+
+    assert result.returncode != 0
+    assert "also reachable from URL map rogue-map" in result.stderr
+    assert not any(
+        "update-traffic" in line or "url-maps import" in line
+        for line in events.read_text(encoding="utf-8").splitlines()
+    )
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (
+            lambda state: state["backends"]["trusted-router-public-backend"].update(
+                timeoutSec=61
+            ),
+            "timeout differs",
+        ),
+        (
+            lambda state: state["backends"]["trusted-router-public-backend"][
+                "backends"
+            ][0].update(
+                group=(
+                    "https://www.googleapis.com/compute/v1/projects/other-project/"
+                    "regions/us-central1/networkEndpointGroups/"
+                    "trusted-router-public-neg"
+                )
+            ),
+            "exact same-project regional inventory",
+        ),
+        (
+            lambda state: state["backends"]["trusted-router-public-backend"].update(
+                securityPolicy=(
+                    "https://www.googleapis.com/compute/v1/projects/other-project/"
+                    "global/securityPolicies/trusted-router-public-edge"
+                )
+            ),
+            "wrong Cloud Armor policy",
+        ),
+        (
+            lambda state: state["negs"][
+                "trusted-router-public-neg|us-central1"
+            ]["cloudRun"].update(tag="candidate"),
+            "without tag/urlMask",
+        ),
+        (
+            lambda state: state["negs"][
+                "trusted-router-public-neg|us-central1"
+            ]["cloudRun"].update(urlMask="example.com/<service>"),
+            "without tag/urlMask",
+        ),
+        (
+            lambda state: state["backends"]["trusted-router-public-backend"][
+                "customRequestHeaders"
+            ].append("Authorization:Bearer stale-internal-token"),
+            "request-header allowlist",
+        ),
+        (
+            lambda state: state["backends"]["trusted-router-public-backend"].update(
+                iap={"enabled": True}
+            ),
+            "IAP contract is not disabled",
+        ),
+        (
+            lambda state: state["backends"]["trusted-router-public-backend"].update(
+                customResponseHeaders=["X-Internal-Token: stale"]
+            ),
+            "retains custom response headers",
+        ),
+        (
+            lambda state: state["backends"]["trusted-router-public-backend"][
+                "logConfig"
+            ].update(sampleRate=1.0),
+            "logging contract drifted",
+        ),
+        (
+            lambda state: state["backends"]["trusted-router-public-backend"][
+                "cdnPolicy"
+            ]["cacheKeyPolicy"].update(includeHost=False),
+            "CDN/cache-key contract drifted",
+        ),
+        (
+            lambda state: state["backends"]["trusted-router-public-backend"].update(
+                edgeSecurityPolicy="projects/other/global/securityPolicies/stale"
+            ),
+            "unexpected edge security policy",
+        ),
+    ],
+)
+def test_edge_resource_identity_drift_blocks_verify_without_mutation(
+    tmp_path: Path,
+    mutation: Any,
+    message: str,
+) -> None:
+    manifest, state_path, events = _fixture(tmp_path, regions=["us-central1"])
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    mutation(state)
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    result = _run_helper(tmp_path, manifest, state_path, events, "verify", "all", "0")
+
+    assert result.returncode != 0
+    assert message in result.stderr
+    assert not any(
+        "update-traffic" in line or "url-maps import" in line
+        for line in events.read_text(encoding="utf-8").splitlines()
+    )
+
+
+def test_manifest_rejects_positive_tagged_traffic_before_helper_math(
+    tmp_path: Path,
+) -> None:
+    manifest_path, _, _ = _fixture(tmp_path, regions=["us-central1"])
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    public_entry = next(
+        item for item in manifest["services"] if item["surface"] == "public"
+    )
+    public_entry["prior_traffic"][0]["tag"] = "stable"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    result = _run_state("validate-manifest", manifest_path, check=False)
+
+    assert result.returncode != 0
+    assert "positive traffic targets must be untagged" in result.stderr
+
+
+def test_conditional_allusers_invoker_is_rejected_without_mutation(tmp_path: Path) -> None:
+    manifest, state_path, events = _fixture(tmp_path, regions=["us-central1"])
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["service_iam"] = {
+        "trusted-router-public|us-central1": {
+            "bindings": [
+                {
+                    "role": "roles/run.invoker",
+                    "members": ["allUsers"],
+                    "condition": {
+                        "title": "expires",
+                        "expression": "request.time < timestamp('2026-08-21T00:00:00Z')",
+                    },
+                }
+            ]
+        }
+    }
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    result = _run_helper(tmp_path, manifest, state_path, events, "verify", "all", "0")
+    assert result.returncode != 0
+    assert "unauthenticated LB invocation IAM drifted" in result.stderr
+    assert not any(
+        "update-traffic" in line or "url-maps import" in line
+        for line in events.read_text(encoding="utf-8").splitlines()
+    )
+
+
+def test_traffic_state_preserves_duplicate_tag_target_and_diagnoses_latest(tmp_path: Path) -> None:
+    service_path = tmp_path / "service.json"
+    service_path.write_text(
+        json.dumps(
+            {
+                "spec": {
+                    "traffic": [
+                        {"revisionName": "service-prior", "percent": 100},
+                        {"revisionName": "service-prior", "percent": 0, "tag": "stable"},
+                        {"latestRevision": True, "percent": 0, "tag": "floating"},
+                    ]
+                },
+                "status": {
+                    "latestReadyRevisionName": "service-candidate",
+                    "traffic": [
+                        {"revisionName": "service-prior", "percent": 100},
+                        {"revisionName": "service-prior", "percent": 0, "tag": "stable"},
+                        {"revisionName": "service-candidate", "percent": 0, "tag": "floating"},
+                    ],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    traffic = json.loads(_run_state("traffic-state", service_path).stdout)
+    assert len(traffic) == 3
+    floating = next(item for item in traffic if item["tag"] == "floating")
+    assert floating == {
+        "revision": None,
+        "resolved_revision": "service-candidate",
+        "latest_revision": True,
+        "percent": 0,
+        "tag": "floating",
+    }
+
+
+def test_traffic_state_rejects_unconverged_named_desired_and_observed(tmp_path: Path) -> None:
+    service_path = tmp_path / "service.json"
+    service_path.write_text(
+        json.dumps(
+            {
+                "spec": {"traffic": [{"revisionName": "service-a", "percent": 100}]},
+                "status": {
+                    "traffic": [{"revisionName": "service-b", "percent": 100}]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = _run_state("traffic-state", service_path, check=False)
+    assert result.returncode != 0
+    assert "have not converged" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda value: value["url_map"].update(candidate_snapshot="url-map.prior.json"), "distinct"),
+        (lambda value: value.update(image="repo/image:mutable"), "immutable"),
+        (
+            lambda value: value["preserved_hosts"].remove("api-us-central1.quillrouter.com"),
+            "regional quillrouter",
+        ),
+        (
+            lambda value: value["services"][0]["prior_traffic"][0].update(
+                resolved_revision="trusted-router-public-other"
+            ),
+            "resolved_revision",
+        ),
+        (
+            lambda value: value["services"][0]["prior_traffic"][0].update(
+                revision=None,
+                latest_revision=True,
+            ),
+            "LATEST",
+        ),
+        (
+            lambda value: value["services"][0]["prior_traffic"][0].update(
+                tag="serving"
+            ),
+            "positive traffic targets must be untagged",
+        ),
+    ],
+)
+def test_manifest_mutations_fail_closed(
+    tmp_path: Path,
+    mutation: Any,
+    message: str,
+) -> None:
+    manifest_path, _, _ = _fixture(tmp_path)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    mutation(manifest)
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    result = _run_state("validate-manifest", manifest_path, check=False)
+    assert result.returncode != 0
+    assert message in result.stderr
+
+
+def test_manifest_and_promotion_state_never_contain_secret_material(tmp_path: Path) -> None:
+    manifest_path, state, events = _fixture(tmp_path)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    serialized = json.dumps(manifest)
+    assert "secretKeyRef" not in serialized
+    assert "/secrets/" not in serialized
+    assert "TR_" not in serialized
+    result = _run_helper(tmp_path, manifest_path, state, events, "promote-step", "primary", "10")
+    assert result.returncode == 0, result.stderr
+    promotion = (tmp_path / "promotion-state.json").read_text(encoding="utf-8")
+    assert "secretKeyRef" not in promotion
+    assert "/secrets/" not in promotion
+    assert "TR_" not in promotion
+
+
+def test_service_hash_covers_service_max_and_numeric_secret_version(tmp_path: Path) -> None:
+    data, _, _ = _service_json("console", "us-central1")
+    container = data["spec"]["template"]["spec"]["containers"][0]
+    container["env"].append(
+        {
+            "name": "TR_STRIPE_SECRET_KEY",
+            "valueFrom": {
+                "secretKeyRef": {"name": "trustedrouter-stripe-secret-key", "key": "17"}
+            },
+        }
+    )
+    path = tmp_path / "service.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    original = _hash_json(path, "hash-service")
+    data["metadata"]["annotations"]["run.googleapis.com/maxScale"] = "21"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    assert _hash_json(path, "hash-service") != original
+    data["metadata"]["annotations"]["run.googleapis.com/maxScale"] = "20"
+    container["env"][-1]["valueFrom"]["secretKeyRef"]["key"] = "18"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    assert _hash_json(path, "hash-service") != original
+
+
+def test_rollout_sources_pin_digest_numeric_secrets_and_exact_body_bulkheads() -> None:
+    source = (ROOT / "scripts/deploy/rollout.sh").read_text(encoding="utf-8")
+    assert "IMAGE=\"$RESOLVED_IMAGE\"" in source
+    assert "fully_qualified_digest" in source
+    assert "pin_surface_secret_versions" in source
+    assert ":latest" not in source
+    assert "TR_RATE_LIMIT_CLIENT_IP_MODE=edge_header" in source
+    assert "TR_MAX_CONCURRENT_REQUEST_BODIES=${MAX_CONCURRENT_REQUEST_BODIES}" in source
+    assert "TR_SYNTHETIC_SCHEDULER_INTERVAL_SECONDS=0" in source
+    assert "TR_REMEDIATOR_IN_PROCESS_ENABLED=false" in source
+    assert "--deploy-health-check" in source
+    assert "httpGet.path=/ready" in source

--- a/tests/test_six_surface_rollout.py
+++ b/tests/test_six_surface_rollout.py
@@ -65,7 +65,6 @@ FRONTEND_HOSTS = [
     "trustedrouter.com",
     "www.trustedrouter.com",
     "status.trustedrouter.com",
-    "trust.trustedrouter.com",
     "eu.trustedrouter.com",
     "status-us.trustedrouter.com",
     "status-eu.trustedrouter.com",

--- a/tests/test_six_surface_rollout_stage_execution.py
+++ b/tests/test_six_surface_rollout_stage_execution.py
@@ -1,0 +1,2274 @@
+"""End-to-end fake-provider execution of six-surface staging."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+import os
+import stat
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+ROLLOUT = ROOT / "scripts/deploy/rollout.sh"
+BOOTSTRAP = ROOT / "scripts/deploy/rollout_bootstrap_internal.sh"
+FRONTEND_ATTEST = ROOT / "scripts/deploy/rollout_frontend_attest.py"
+LEGACY_HARDENER = ROOT / "scripts/deploy/rollout_legacy_harden.py"
+STATE_TOOL = ROOT / "scripts/deploy/rollout_state.py"
+URL_MAP_TOOL = ROOT / "scripts/deploy/service_surface_url_map.py"
+
+PROJECT = "quill-cloud-proxy"
+REGIONS = ("us-central1", "europe-west4")
+SURFACES = ("public", "actions", "console", "chat", "webhooks", "internal")
+SERVICES = {
+    "public": "trusted-router-public",
+    "actions": "trusted-router-actions",
+    "console": "trusted-router-console",
+    "chat": "trusted-router-chat",
+    "webhooks": "trusted-router-webhooks",
+    "internal": "trusted-router-billing",
+}
+EDGES = {
+    "public": (
+        "trusted-router-public-backend",
+        "trusted-router-public-neg",
+        "trusted-router-public-edge",
+    ),
+    "actions": (
+        "trusted-router-actions-backend",
+        "trusted-router-actions-neg",
+        "trusted-router-actions-edge",
+    ),
+    "console": (
+        "trusted-router-console-backend",
+        "trusted-router-console-neg",
+        "trusted-router-console-edge",
+    ),
+    "chat": (
+        "trusted-router-chat-backend",
+        "trusted-router-chat-neg",
+        "trusted-router-chat-edge",
+    ),
+    "webhooks": (
+        "trusted-router-webhooks-backend",
+        "trusted-router-webhooks-neg",
+        "trusted-router-webhooks-edge",
+    ),
+    "internal": (
+        "trusted-router-billing-backend",
+        "trusted-router-billing-neg",
+        "trusted-router-billing-edge",
+    ),
+}
+CONTRACTS = {
+    "public": (4, 0, 10, 60),
+    "actions": (4, 0, 2, 30),
+    "console": (4, 1, 20, 300),
+    "chat": (2, 1, 20, 300),
+    "webhooks": (4, 1, 10, 60),
+    "internal": (8, 2, 50, 300),
+}
+IMAGE = (
+    "us-central1-docker.pkg.dev/quill-cloud-proxy/trusted-router/trusted-router"
+    "@sha256:" + "a" * 64
+)
+
+PRESERVED_HOSTS = (
+    "api.trustedrouter.com",
+    "api.allyrouter.com",
+    "api.uptimerouter.com",
+    "api.quillrouter.com",
+    "api-aws.trustedrouter.com",
+    "api-azure.trustedrouter.com",
+    "api-azure-nz.trustedrouter.com",
+    "api-azure-sea.trustedrouter.com",
+    "api-eu-west-1.trustedrouter.com",
+    "aws.trustedrouter.com",
+    "azure.trustedrouter.com",
+    *(f"api-{region}.quillrouter.com" for region in REGIONS),
+)
+FRONTEND_HOSTS = (
+    "trustedrouter.com",
+    "www.trustedrouter.com",
+    "status.trustedrouter.com",
+    "trust.trustedrouter.com",
+    "eu.trustedrouter.com",
+    "status-us.trustedrouter.com",
+    "status-eu.trustedrouter.com",
+    "allyrouter.com",
+    "www.allyrouter.com",
+    "status.allyrouter.com",
+    "trust.allyrouter.com",
+    "uptimerouter.com",
+    "www.uptimerouter.com",
+    "status.uptimerouter.com",
+    "trust.uptimerouter.com",
+)
+FRONTEND_VIP = "34.111.20.30"
+
+
+def _load_rewriter() -> Callable[..., dict[str, Any]]:
+    spec = importlib.util.spec_from_file_location("stage_url_map", URL_MAP_TOOL)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.rewrite_url_map
+
+
+def _load_legacy_hardener() -> Any:
+    spec = importlib.util.spec_from_file_location("stage_legacy_hardener", LEGACY_HARDENER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _policy() -> dict[str, Any]:
+    allowed = (
+        r"^(trustedrouter[.]com|www[.]trustedrouter[.]com|status[.]trustedrouter[.]com|"
+        r"trust[.]trustedrouter[.]com|eu[.]trustedrouter[.]com|status-us[.]trustedrouter[.]com|"
+        r"status-eu[.]trustedrouter[.]com|allyrouter[.]com|www[.]allyrouter[.]com|"
+        r"status[.]allyrouter[.]com|trust[.]allyrouter[.]com|uptimerouter[.]com|"
+        r"www[.]uptimerouter[.]com|status[.]uptimerouter[.]com|"
+        r"trust[.]uptimerouter[.]com)(:[0-9]+)?$"
+    )
+
+    def throttle(priority: int, count: int, expression: str | None, preview: bool) -> dict[str, Any]:
+        match = (
+            {
+                "config": {"srcIpRanges": ["*"]},
+                "versionedExpr": "SRC_IPS_V1",
+            }
+            if expression is None
+            else {"expr": {"expression": expression}}
+        )
+        descriptions = {
+            1000: "Browser inference proxy per-client throttle",
+            1100: "State-changing request per-client throttle",
+            1200: "All-path per-source safety ceiling",
+        }
+        return {
+            "priority": priority,
+            "action": "throttle",
+            "description": descriptions[priority],
+            "preview": preview,
+            "match": match,
+            "rateLimitOptions": {
+                "rateLimitThreshold": {"count": count, "intervalSec": 60},
+                "conformAction": "allow",
+                "exceedAction": "deny(429)",
+                "enforceOnKey": "IP",
+            },
+        }
+
+    return {
+        "type": "CLOUD_ARMOR",
+        "description": (
+            "TrustedRouter exact edge controls; host and all-path gates enforced, "
+            "route-shape rules previewed"
+        ),
+        "rules": [
+            {
+                "priority": 900,
+                "action": "deny(403)",
+                "description": "Reject hosts outside canonical and marketing aliases",
+                "preview": False,
+                "match": {
+                    "expr": {
+                        "expression": "!has(request.headers['host']) || "
+                        f"!request.headers['host'].lower().matches('{allowed}')"
+                    }
+                },
+            },
+            throttle(1000, 120, "request.path.startsWith('/chat-proxy/')", True),
+            throttle(
+                1100,
+                300,
+                "request.method != 'GET' && request.method != 'HEAD' && "
+                "request.method != 'OPTIONS'",
+                True,
+            ),
+            throttle(1200, 2400, None, False),
+            {
+                "priority": 2_147_483_647,
+                "action": "allow",
+                "description": "Default allow; bounded route classes are evaluated first",
+                "preview": False,
+                "match": {
+                    "config": {"srcIpRanges": ["*"]},
+                    "versionedExpr": "SRC_IPS_V1",
+                },
+            },
+        ]
+    }
+
+
+def _binding(role: str, surfaces: tuple[str, ...]) -> dict[str, Any]:
+    return {
+        "role": role,
+        "members": [
+            f"serviceAccount:tr-{surface}@{PROJECT}.iam.gserviceaccount.com"
+            for surface in surfaces
+        ],
+    }
+
+
+def _prior_service(surface: str, region: str) -> dict[str, Any]:
+    service = SERVICES[surface]
+    revision = f"{service}-prior"
+    annotations = {
+        "run.googleapis.com/ingress": "internal-and-cloud-load-balancing",
+        "run.googleapis.com/ingress-status": "internal-and-cloud-load-balancing",
+        "run.googleapis.com/maxScale": str(CONTRACTS[surface][2]),
+    }
+    if surface not in {"console", "internal"}:
+        annotations["run.googleapis.com/default-url-disabled"] = "true"
+    return {
+        "metadata": {"name": service, "generation": 4, "annotations": annotations},
+        "spec": {
+            "scaling": {"maxInstanceCount": CONTRACTS[surface][2]},
+            "traffic": [{"revisionName": revision, "percent": 100}],
+            "template": {"metadata": {"name": revision}, "spec": {"containers": [{}]}},
+        },
+        "status": {
+            "observedGeneration": 4,
+            "latestCreatedRevisionName": revision,
+            "latestReadyRevisionName": revision,
+            "conditions": [{"type": "Ready", "status": "True"}],
+            "url": (
+                f"https://{service}-123456789.{region}.run.app"
+                if surface in {"console", "internal"}
+                else ""
+            ),
+            "traffic": [{"revisionName": revision, "percent": 100}],
+        },
+    }
+
+
+def _legacy_console_service(region: str) -> dict[str, Any]:
+    service = json.loads(
+        json.dumps(_prior_service("console", region)).replace(
+            "trusted-router-console", "trusted-router"
+        )
+    )
+    revision = _serving_console_revision()
+    service["spec"]["template"]["spec"] = copy.deepcopy(revision["spec"])
+    return service
+
+
+def _serving_console_revision() -> dict[str, Any]:
+    values = {
+        "TR_NEW_SIGNUPS_ENABLED": "true",
+        "TR_GOOGLE_OAUTH_LOGIN_AVAILABLE": "false",
+        "TR_GITHUB_OAUTH_LOGIN_AVAILABLE": "false",
+        "TR_PAYPAL_CHECKOUT_ENABLED": "false",
+        "TR_ADYEN_ENABLED": "false",
+        "TR_VERIFF_ENABLED": "false",
+        "TR_STORAGE_BACKEND": "spanner-bigtable",
+        "TR_REQUEST_RECORD_WRITE_MODE": "typed",
+        "TR_ANALYTICS_READ_MODE": "bigtable",
+        "TR_GENERATION_RECORDS_ENABLED": "true",
+        "TR_BIGTABLE_MIRROR_WRITES_ENABLED": "true",
+        "TR_PROVIDER_ANALYTICS_CLICKHOUSE_URL": "http://10.8.0.5:8123",
+    }
+    return {
+        "metadata": {"name": "trusted-router-prior"},
+        "spec": {
+            "serviceAccountName": (
+                "123456789-compute@developer.gserviceaccount.com"
+            ),
+            "containers": [
+                {
+                    "image": IMAGE,
+                    "env": [
+                        {"name": name, "value": value}
+                        for name, value in values.items()
+                    ],
+                }
+            ]
+        },
+        "status": {"conditions": [{"type": "Ready", "status": "True"}]},
+    }
+
+
+def _synthetic_inventory() -> list[tuple[str, str, str]]:
+    return [
+        (
+            region,
+            f"trusted-router-synthetic-{region}",
+            f"trusted-router-synthetic-{region}-every-three-minutes",
+        )
+        for region in REGIONS
+    ] + [
+        (
+            REGIONS[0],
+            f"trusted-router-throughput-{REGIONS[0]}",
+            f"trusted-router-throughput-{REGIONS[0]}-every-five-minutes",
+        ),
+        (
+            REGIONS[0],
+            f"trusted-router-image-generation-{REGIONS[0]}",
+            f"trusted-router-image-generation-{REGIONS[0]}-every-six-hours",
+        ),
+        (
+            REGIONS[0],
+            f"trusted-router-video-generation-{REGIONS[0]}",
+            f"trusted-router-video-generation-{REGIONS[0]}-daily",
+        ),
+    ]
+
+
+def _synthetic_job(region: str, job_name: str) -> dict[str, Any]:
+    base = f"https://trusted-router-billing-123456789.{region}.run.app"
+    plain = {
+        "TR_ENVIRONMENT": "worker",
+        "TR_SERVICE_SURFACE": "observer",
+        "TR_RELEASE": "stage-execution-test",
+        "TR_ENABLE_LIVE_PROVIDERS": "false",
+        "TR_API_BASE_URL": "https://api.trustedrouter.com/v1",
+        "TR_TRUSTED_DOMAIN": "trustedrouter.com",
+        "TR_STORAGE_BACKEND": "spanner-bigtable",
+        "TR_GCP_PROJECT_ID": PROJECT,
+        "TR_SPANNER_INSTANCE_ID": "trusted-router-nam6",
+        "TR_SPANNER_DATABASE_ID": "trusted-router",
+        "TR_BIGTABLE_INSTANCE_ID": "trusted-router-logs",
+        "TR_BIGTABLE_GENERATION_TABLE": "trustedrouter-generations",
+        "TR_REGIONS": ",".join(REGIONS),
+        "TR_PRIMARY_REGION": REGIONS[0],
+        "TR_SYNTHETIC_MONITOR_MODEL": "trustedrouter/monitor",
+        "TR_SYNTHETIC_MONITOR_TIMEOUT_SECONDS": "30",
+        "TR_SYNTHETIC_CONTROL_PLANE_URL": "https://trustedrouter.com",
+        "TR_SYNTHETIC_RUNS_PER_INVOCATION": "1",
+        "TR_SYNTHETIC_RUN_SPACING_SECONDS": "0",
+        "VERTEX_PROJECT_ID": PROJECT,
+        "VERTEX_LOCATION": "us-central1",
+        "TR_SYNTHETIC_MONITOR_REGION": region,
+        "TR_SYNTHETIC_INGEST_URL": f"{base}/v1/internal/synthetic/samples",
+        "TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL": base,
+    }
+    if job_name.startswith("trusted-router-synthetic-"):
+        module, cpu, memory, timeout = (
+            "trusted_router.synthetic.cli",
+            "2",
+            "1Gi",
+            "300s",
+        )
+        plain.update(
+            {
+                "TR_SYNTHETIC_BENCHMARK_INGEST_URL": (
+                    f"{base}/v1/internal/synthetic/benchmark"
+                ),
+                "TR_SYNTHETIC_ROUTE_HEALTH_URL": (
+                    f"{base}/v1/internal/synthetic/route-health"
+                ),
+                "TR_SYNTHETIC_BILLING_CONCURRENCY": "2",
+                "TR_SYNTHETIC_START_DELAY_SECONDS": str(REGIONS.index(region) * 20),
+                "TR_SYNTHETIC_ROTATION_ENABLED": "true",
+                "TR_SYNTHETIC_ROTATION_PER_PASS": "2",
+                "TR_SYNTHETIC_THROUGHPUT_ENABLED": "false",
+                "TR_SYNTHETIC_THROUGHPUT_ONLY": "false",
+            }
+        )
+        if region == REGIONS[0]:
+            plain["TR_SYNTHETIC_REMEDIATOR_URL"] = (
+                f"{base}/v1/internal/synthetic/remediate"
+            )
+    elif job_name.startswith("trusted-router-throughput-"):
+        module, cpu, memory, timeout = (
+            "trusted_router.synthetic.cli",
+            "1",
+            "1Gi",
+            "300s",
+        )
+        plain.update(
+            {
+                "TR_SYNTHETIC_BENCHMARK_INGEST_URL": (
+                    f"{base}/v1/internal/synthetic/benchmark"
+                ),
+                "TR_SYNTHETIC_ROUTE_HEALTH_URL": (
+                    f"{base}/v1/internal/synthetic/route-health"
+                ),
+                "TR_SYNTHETIC_BILLING_CONCURRENCY": "1",
+                "TR_SYNTHETIC_START_DELAY_SECONDS": "0",
+                "TR_SYNTHETIC_ROTATION_ENABLED": "false",
+                "TR_SYNTHETIC_ROTATION_PER_PASS": "0",
+                "TR_SYNTHETIC_THROUGHPUT_ENABLED": "true",
+                "TR_SYNTHETIC_THROUGHPUT_ONLY": "true",
+                "TR_SYNTHETIC_THROUGHPUT_REGION": region,
+                "TR_SYNTHETIC_THROUGHPUT_ROUTE_LIMIT": "200",
+                "TR_SYNTHETIC_THROUGHPUT_MAX_TOKENS": "512",
+                "TR_SYNTHETIC_THROUGHPUT_MINIMUM_OUTPUT_TOKENS": "128",
+                "TR_SYNTHETIC_THROUGHPUT_TIMEOUT_SECONDS": "90",
+                "TR_SYNTHETIC_THROUGHPUT_TIMEOUT_CEILING_SECONDS": "210",
+                "TR_SYNTHETIC_THROUGHPUT_INTERVAL_SECONDS": "300",
+            }
+        )
+    elif job_name.startswith("trusted-router-image-generation-"):
+        module, cpu, memory, timeout = (
+            "trusted_router.synthetic.image_generation",
+            "1",
+            "512Mi",
+            "300s",
+        )
+        plain.update(
+            {
+                "TR_SYNTHETIC_IMAGE_MODEL": "google/gemini-3.1-flash-image-preview",
+                "TR_SYNTHETIC_IMAGE_PROVIDER": "google-ai-studio",
+                "TR_SYNTHETIC_IMAGE_TIMEOUT_SECONDS": "120",
+                "TR_SYNTHETIC_IMAGE_CONFIRMATION_DELAY_SECONDS": "2",
+            }
+        )
+    else:
+        module, cpu, memory, timeout = (
+            "trusted_router.synthetic.video_generation",
+            "1",
+            "512Mi",
+            "1200s",
+        )
+        plain.update(
+            {
+                "TR_SYNTHETIC_VIDEO_TIMEOUT_SECONDS": "900",
+                "TR_SYNTHETIC_VIDEO_POLL_INTERVAL_SECONDS": "5",
+            }
+        )
+    environment = [{"name": name, "value": value} for name, value in plain.items()]
+    environment.extend(
+        [
+            {
+                "name": "TR_OBSERVER_INTERNAL_TOKEN",
+                "valueFrom": {
+                    "secretKeyRef": {
+                        "name": "trustedrouter-observer-internal-token",
+                        "key": "7",
+                    }
+                },
+            },
+            {
+                "name": "TR_SYNTHETIC_MONITOR_API_KEY",
+                "valueFrom": {
+                    "secretKeyRef": {
+                        "name": "trustedrouter-synthetic-monitor-api-key",
+                        "key": "7",
+                    }
+                },
+            },
+        ]
+    )
+    return {
+        "metadata": {"name": job_name},
+        "spec": {
+            "template": {
+                "spec": {
+                    "taskCount": 1,
+                    "parallelism": 1,
+                    "template": {
+                        "metadata": {
+                            "annotations": {
+                                "run.googleapis.com/network-interfaces": json.dumps(
+                                    [{"network": "default", "subnetwork": "default"}],
+                                    separators=(",", ":"),
+                                ),
+                                "run.googleapis.com/vpc-access-egress": (
+                                    "private-ranges-only"
+                                ),
+                            }
+                        },
+                        "spec": {
+                            "serviceAccountName": (
+                                "tr-synthetic@quill-cloud-proxy.iam.gserviceaccount.com"
+                            ),
+                            "maxRetries": 0,
+                            "timeoutSeconds": timeout,
+                            "containers": [
+                                {
+                                    "image": IMAGE,
+                                    "command": ["/app/.venv/bin/python"],
+                                    "args": ["-m", module],
+                                    "resources": {
+                                        "limits": {"cpu": cpu, "memory": memory}
+                                    },
+                                    "env": environment,
+                                }
+                            ],
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+def _synthetic_scheduler(
+    region: str, job_name: str, scheduler_name: str
+) -> dict[str, Any]:
+    if job_name.startswith("trusted-router-synthetic-"):
+        schedule = "*/3 * * * *"
+    elif job_name.startswith("trusted-router-throughput-"):
+        schedule = "*/5 * * * *"
+    elif job_name.startswith("trusted-router-image-generation-"):
+        schedule = "17 */6 * * *"
+    else:
+        schedule = "41 9 * * *"
+    return {
+        "name": scheduler_name,
+        "state": "ENABLED",
+        "schedule": schedule,
+        "timeZone": "Etc/UTC",
+        "attemptDeadline": "300s",
+        "retryConfig": {
+            "retryCount": 0,
+            "maxRetryDuration": "0s",
+            "minBackoffDuration": "5s",
+            "maxBackoffDuration": "60s",
+            "maxDoublings": 3,
+        },
+        "httpTarget": {
+            "uri": (
+                f"https://{region}-run.googleapis.com/apis/run.googleapis.com/v1/"
+                f"namespaces/{PROJECT}/jobs/{job_name}:run"
+            ),
+            "httpMethod": "POST",
+            "oauthToken": {
+                "serviceAccountEmail": (
+                    "tr-synthetic@quill-cloud-proxy.iam.gserviceaccount.com"
+                )
+            },
+        },
+    }
+
+
+def _initial_state() -> dict[str, Any]:
+    backend_links = {
+        surface: (
+            f"https://www.googleapis.com/compute/v1/projects/{PROJECT}/global/"
+            f"backendServices/{EDGES[surface][0]}"
+        )
+        for surface in SURFACES
+    }
+    managed_hosts = [
+        f"{prefix}{domain}"
+        for domain in ("trustedrouter.com", "allyrouter.com", "uptimerouter.com")
+        for prefix in ("", "www.", "status.", "trust.")
+    ] + ["eu.trustedrouter.com", "status-us.trustedrouter.com", "status-eu.trustedrouter.com"]
+    prior_map = {
+        "name": "trusted-router-map",
+        "selfLink": (
+            f"https://www.googleapis.com/compute/v1/projects/{PROJECT}/global/"
+            "urlMaps/trusted-router-map"
+        ),
+        "defaultService": (
+            f"https://www.googleapis.com/compute/v1/projects/{PROJECT}/global/"
+            "backendServices/trusted-router-control-backend"
+        ),
+        "hostRules": [
+            {"hosts": list(PRESERVED_HOSTS), "pathMatcher": "preserved-api"},
+            {"hosts": managed_hosts, "pathMatcher": "legacy-console"},
+        ],
+        "pathMatchers": [
+            {"name": "preserved-api", "defaultService": "api-gateway-backend"},
+            {
+                "name": "legacy-console",
+                "defaultService": (
+                    f"https://www.googleapis.com/compute/v1/projects/{PROJECT}/global/"
+                    "backendServices/trusted-router-control-backend"
+                ),
+            },
+        ],
+    }
+    candidate_map = _load_rewriter()(
+        prior_map,
+        backend_links["public"],
+        backend_links["actions"],
+        backend_links["console"],
+        backend_links["chat"],
+        backend_links["webhooks"],
+        backend_links["internal"],
+        ["trustedrouter.com", "allyrouter.com", "uptimerouter.com"],
+        list(PRESERVED_HOSTS),
+    )
+    backends: dict[str, Any] = {}
+    negs: dict[str, Any] = {}
+    for surface in SURFACES:
+        backend, neg, policy = EDGES[surface]
+        timeout = CONTRACTS[surface][3]
+        backends[backend] = {
+            "name": backend,
+            "selfLink": backend_links[surface],
+            "loadBalancingScheme": "EXTERNAL_MANAGED",
+            "protocol": "HTTP",
+            "timeoutSec": timeout,
+            "securityPolicy": (
+                f"https://www.googleapis.com/compute/v1/projects/{PROJECT}/global/"
+                f"securityPolicies/{policy}"
+            ),
+            "customRequestHeaders": [
+                "X-TrustedRouter-Client-IP:{client_ip_address}"
+            ],
+            "customResponseHeaders": [],
+            "iap": {"enabled": False},
+            "logConfig": {
+                "enable": True,
+                "sampleRate": 0.1,
+                "optionalMode": "EXCLUDE_ALL_OPTIONAL",
+            },
+            "enableCDN": surface == "public",
+            "backends": [
+                {
+                    "group": (
+                        f"https://www.googleapis.com/compute/v1/projects/{PROJECT}/regions/"
+                        f"{region}/networkEndpointGroups/{neg}"
+                    )
+                }
+                for region in REGIONS
+            ],
+        }
+        for region in REGIONS:
+            negs[f"{neg}|{region}"] = {"cloudRun": {"service": SERVICES[surface]}}
+    backends["trusted-router-control-backend"] = {
+        "name": "trusted-router-control-backend",
+        "selfLink": (
+            f"https://www.googleapis.com/compute/v1/projects/{PROJECT}/global/"
+            "backendServices/trusted-router-control-backend"
+        ),
+        "loadBalancingScheme": "EXTERNAL_MANAGED",
+        "protocol": "HTTP",
+        "timeoutSec": 300,
+        "backends": [
+            {
+                "group": (
+                    f"https://www.googleapis.com/compute/v1/projects/{PROJECT}/regions/"
+                    f"{region}/networkEndpointGroups/trusted-router-control-neg"
+                )
+            }
+            for region in REGIONS
+        ],
+    }
+    for region in REGIONS:
+        negs[f"trusted-router-control-neg|{region}"] = {
+            "networkEndpointType": "SERVERLESS",
+            "cloudRun": {"service": "trusted-router"},
+        }
+
+    required_secret_owners = {
+        "trustedrouter-attribution-cookie-secret": ("public", "console"),
+        "trustedrouter-sentry-dsn": ("console", "chat", "webhooks", "internal"),
+        "trustedrouter-stripe-secret-key": ("console",),
+        "trustedrouter-internal-stripe-payment-intents-key": ("internal",),
+        "trustedrouter-stripe-webhook-secret": ("webhooks",),
+        "trustedrouter-internal-gateway-token": ("internal",),
+        "trustedrouter-observer-internal-token": ("internal",),
+        "trustedrouter-synthetic-monitor-api-key": ("internal",),
+        "trustedrouter-aws-access-key-id": ("actions", "console"),
+        "trustedrouter-aws-secret-access-key": ("actions", "console"),
+        "trustedrouter-internal-ses-access-key-id": ("internal",),
+        "trustedrouter-internal-ses-secret-access-key": ("internal",),
+        "trustedrouter-ops-chat-webhook-secret": ("actions",),
+        "trustedrouter-clickhouse-provider-read-password": ("console",),
+        # Keep the optional console array non-empty on Bash 3.2; the fixture
+        # also verifies that an optional mounted credential remains console-only.
+        "trustedrouter-telnyx-api-key": ("console",),
+    }
+    synthetic_inventory = _synthetic_inventory()
+    proxy_link = (
+        f"https://www.googleapis.com/compute/v1/projects/{PROJECT}/global/"
+        "targetHttpsProxies/trusted-router-control-https-proxy"
+    )
+    certificate_link = (
+        f"https://www.googleapis.com/compute/v1/projects/{PROJECT}/global/"
+        "sslCertificates/trusted-router-managed"
+    )
+    return {
+        "url_map": prior_map,
+        "expected_candidate_map": candidate_map,
+        "forwarding_rule": {
+            "name": "trusted-router-public-https",
+            "selfLink": (
+                f"https://www.googleapis.com/compute/v1/projects/{PROJECT}/global/"
+                "forwardingRules/trusted-router-public-https"
+            ),
+            "IPAddress": FRONTEND_VIP,
+            "IPProtocol": "TCP",
+            "portRange": "443-443",
+            "networkTier": "PREMIUM",
+            "loadBalancingScheme": "EXTERNAL_MANAGED",
+            "target": proxy_link,
+        },
+        "https_proxy_resource": {
+            "name": "trusted-router-control-https-proxy",
+            "selfLink": proxy_link,
+            "urlMap": prior_map["selfLink"],
+            "sslCertificates": [certificate_link],
+        },
+        "ssl_certificates": {
+            "trusted-router-managed": {
+                "name": "trusted-router-managed",
+                "selfLink": certificate_link,
+                "type": "MANAGED",
+                "managed": {"status": "ACTIVE", "domains": list(FRONTEND_HOSTS)},
+                "subjectAlternativeNames": list(FRONTEND_HOSTS),
+            }
+        },
+        "dns": {
+            host: {"A": [FRONTEND_VIP], "AAAA": []} for host in FRONTEND_HOSTS
+        },
+        "services": {
+            f"trusted-router|{region}": _legacy_console_service(region)
+            for region in REGIONS
+        },
+        "serving_console_revision": _serving_console_revision(),
+        "backends": backends,
+        "policies": {EDGES[surface][2]: _policy() for surface in SURFACES},
+        "negs": negs,
+        "required_secret_owners": {
+            secret: list(owners) for secret, owners in required_secret_owners.items()
+        },
+        "latest_secret_versions": {},
+        "jobs": {
+            f"{job_name}|{region}": _synthetic_job(region, job_name)
+            for region, job_name, _ in synthetic_inventory
+        },
+        "schedulers": {
+            f"{scheduler_name}|{region}": _synthetic_scheduler(
+                region, job_name, scheduler_name
+            )
+            for region, job_name, scheduler_name in synthetic_inventory
+        },
+        "iam": {
+            "project": {
+                "bindings": [
+                    _binding(
+                        "roles/serviceusage.serviceUsageConsumer",
+                        ("public", "console", "chat", "webhooks", "internal"),
+                    )
+                ]
+            },
+            "spanner": {
+                "bindings": [
+                    _binding("roles/spanner.databaseReader", ("public", "chat")),
+                    _binding(
+                        "roles/spanner.databaseUser", ("console", "webhooks", "internal")
+                    ),
+                ]
+            },
+            "bigtable": {
+                "bindings": [
+                    _binding("roles/bigtable.reader", ("public", "console")),
+                    _binding("roles/bigtable.user", ("internal",)),
+                ]
+            },
+            "byok": {
+                "bindings": [
+                    _binding("roles/cloudkms.cryptoKeyEncrypterDecrypter", ("console",)),
+                    _binding("roles/cloudkms.cryptoKeyDecrypter", ("internal",)),
+                ]
+            },
+            "ads": {
+                "bindings": [
+                    _binding("roles/cloudkms.cryptoKeyEncrypter", ("console",))
+                ]
+            },
+        },
+        "deploy_fail_after_remaining": 1,
+        "fatal_deploy_before_regions": [],
+        "corrupt_traffic_after_deploy_service": "",
+        "deployed_revisions": [],
+        "deployments": [],
+    }
+
+
+FAKE_GCLOUD = r'''#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+state_path = Path(os.environ["FAKE_GCLOUD_STATE"])
+events_path = Path(os.environ["FAKE_GCLOUD_EVENTS"])
+state = json.loads(state_path.read_text(encoding="utf-8"))
+args = sys.argv[1:]
+if args[:1] == ["--project"]:
+    args = args[2:]
+joined = " ".join(args)
+with events_path.open("a", encoding="utf-8") as output:
+    output.write("gcloud " + joined + "\n")
+
+def option(name):
+    for index, arg in enumerate(args):
+        if arg.startswith(name + "="):
+            return arg.split("=", 1)[1]
+        if arg == name and index + 1 < len(args):
+            return args[index + 1]
+    return None
+
+def finish(value=None, code=0):
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    if value is not None:
+        if isinstance(value, str):
+            print(value)
+        else:
+            print(json.dumps(value, separators=(",", ":")))
+    raise SystemExit(code)
+
+def missing():
+    print("NOT_FOUND", file=sys.stderr)
+    finish(code=1)
+
+def member(surface):
+    return f"serviceAccount:tr-{surface}@quill-cloud-proxy.iam.gserviceaccount.com"
+
+def require_stage_journal():
+    expected = os.environ.get("EXPECTED_STAGE_JOURNAL")
+    if not expected:
+        return
+    path = Path(expected)
+    if not path.is_file() or path.stat().st_mode & 0o777 != 0o600:
+        print("initial-stage mutation preceded its mode-0600 journal", file=sys.stderr)
+        finish(code=95)
+
+if args[:2] == ["projects", "describe"]:
+    finish("123456789")
+if args[:3] == ["compute", "forwarding-rules", "describe"]:
+    finish(state["forwarding_rule"])
+if args[:3] == ["compute", "target-https-proxies", "describe"]:
+    if option("--format") == "json":
+        finish(state["https_proxy_resource"])
+    finish("trusted-router-map")
+if args[:3] == ["compute", "ssl-certificates", "describe"]:
+    finish(state["ssl_certificates"][args[3]])
+if args[:3] == ["iam", "service-accounts", "describe"]:
+    finish({"email": args[3], "disabled": False})
+if args[:3] == ["iam", "service-accounts", "list"]:
+    finish([
+        {"email": f"tr-{surface}@quill-cloud-proxy.iam.gserviceaccount.com"}
+        for surface in (
+            "public", "actions", "console", "chat", "webhooks", "internal", "synthetic"
+        )
+    ])
+if args[:3] == ["iam", "service-accounts", "get-iam-policy"]:
+    finish({"bindings": [{"role": "roles/iam.serviceAccountUser", "members": [
+        "serviceAccount:tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com"
+    ]}]})
+if args[:3] == ["compute", "url-maps", "describe"]:
+    finish(state["url_map"])
+if args[:3] == ["compute", "url-maps", "list"]:
+    finish("trusted-router-map")
+if args[:3] == ["compute", "url-maps", "validate"]:
+    finish()
+if args[:3] == ["compute", "url-maps", "import"]:
+    finish(code=97)
+if args[:3] == ["run", "services", "list"]:
+    finish([
+        {
+            "metadata": {
+                "name": key.split("|", 1)[0],
+                "labels": {"cloud.googleapis.com/location": key.split("|", 1)[1]},
+            }
+        }
+        for key in state["services"]
+    ])
+if args[:3] == ["run", "services", "describe"]:
+    key = f"{args[3]}|{option('--region')}"
+    if key not in state["services"]:
+        missing()
+    finish(state["services"][key])
+if args[:3] == ["run", "services", "get-iam-policy"]:
+    finish({"bindings": [{"role": "roles/run.invoker", "members": ["allUsers"]}]})
+if args[:3] == ["run", "revisions", "describe"]:
+    revision_key = f"{args[3]}|{option('--region')}"
+    if revision_key in state.get("deployed_revisions", []):
+        finish({"metadata": {"name": args[3]}})
+    if args[3].endswith(("-rstage1", "-rbad1")):
+        missing()
+    finish(state["serving_console_revision"])
+if args[:3] == ["run", "services", "update-traffic"]:
+    key = f"{args[3]}|{option('--region')}"
+    service = state["services"][key]
+    assignments = option("--to-revisions").split(",")
+    traffic = []
+    for assignment in assignments:
+        revision, percent = assignment.rsplit("=", 1)
+        traffic.append({"revisionName": revision, "percent": int(percent)})
+    service["spec"]["traffic"] = traffic
+    service["status"]["traffic"] = traffic
+    state["services"][key] = service
+    finish()
+if args[:3] == ["run", "jobs", "describe"]:
+    finish(state["jobs"][f"{args[3]}|{option('--region')}"])
+if args[:3] == ["run", "jobs", "get-iam-policy"]:
+    finish({"bindings": [{
+        "role": "roles/run.invoker",
+        "members": [
+            "serviceAccount:tr-synthetic@quill-cloud-proxy.iam.gserviceaccount.com"
+        ],
+    }]})
+if args[:3] == ["run", "jobs", "list"]:
+    region = option("--region")
+    finish([
+        {"metadata": {"name": key.split("|", 1)[0]}}
+        for key in state["jobs"]
+        if key.endswith("|" + region)
+    ])
+if args[:3] == ["scheduler", "jobs", "describe"]:
+    finish(state["schedulers"][f"{args[3]}|{option('--location')}"])
+if args[:3] == ["scheduler", "jobs", "list"]:
+    region = option("--location")
+    finish([
+        value for key, value in state["schedulers"].items()
+        if key.endswith("|" + region)
+    ])
+if args[:2] == ["run", "deploy"]:
+    require_stage_journal()
+    service = args[2]
+    region = option("--region")
+    key = f"{service}|{region}"
+    if region in state.get("fatal_deploy_before_regions", []):
+        finish(code=88)
+    previous = state["services"].get(key)
+    if previous is None and "--no-traffic" in args:
+        print("--no-traffic not supported when creating a new service", file=sys.stderr)
+        finish(code=96)
+    account = option("--service-account")
+    surface = account.split("@", 1)[0].removeprefix("tr-")
+    candidate = f"{service}-{option('--revision-suffix')}"
+    delimiter_value = option("--set-env-vars")
+    delimiter = delimiter_value[1:delimiter_value.index("^", 1)]
+    raw_environment = delimiter_value[len(delimiter) + 2:]
+    values = dict(item.split("=", 1) for item in raw_environment.split(delimiter))
+    secrets = {}
+    raw_secrets = option("--set-secrets") or ""
+    for item in filter(None, raw_secrets.split(",")):
+        name, reference = item.split("=", 1)
+        resource, version = reference.rsplit(":", 1)
+        secrets[name] = (resource, version)
+    env = [{"name": name, "value": value} for name, value in values.items()]
+    env.extend({
+        "name": name,
+        "valueFrom": {"secretKeyRef": {"name": resource, "key": version}},
+    } for name, (resource, version) in secrets.items())
+    maximum = int(option("--max"))
+    minimum = int(option("--min-instances"))
+    default_disabled = "--no-default-url" in args
+    annotations = {
+        "run.googleapis.com/ingress": option("--ingress"),
+        "run.googleapis.com/ingress-status": option("--ingress"),
+        "run.googleapis.com/maxScale": str(maximum),
+    }
+    if default_disabled:
+        annotations["run.googleapis.com/default-url-disabled"] = "true"
+    prior_traffic = (
+        previous["status"]["traffic"]
+        if previous is not None
+        else [{"revisionName": candidate, "percent": 100}]
+    )
+    generation = int(previous["metadata"].get("generation", 0)) + 1 if previous else 1
+    state["services"][key] = {
+        "metadata": {"name": service, "generation": generation, "annotations": annotations},
+        "spec": {
+            "scaling": {"maxInstanceCount": maximum},
+            "traffic": prior_traffic,
+            "template": {
+                "metadata": {"name": candidate, "annotations": {
+                    "autoscaling.knative.dev/minScale": str(minimum),
+                    "autoscaling.knative.dev/maxScale": str(maximum),
+                    "run.googleapis.com/network-interfaces": json.dumps(
+                        [{
+                            "network": option("--network"),
+                            "subnetwork": option("--subnet"),
+                        }],
+                        separators=(",", ":"),
+                    ),
+                    "run.googleapis.com/vpc-access-egress": option("--vpc-egress"),
+                }},
+                "spec": {
+                    "serviceAccountName": account,
+                    "containerConcurrency": int(option("--concurrency")),
+                    "timeoutSeconds": option("--timeout"),
+                    "containers": [{
+                        "image": option("--image"),
+                        "ports": [{
+                            "containerPort": int(option("--port")),
+                            "name": "http1",
+                        }],
+                        "resources": {"limits": {
+                            "cpu": option("--cpu") or "1",
+                            "memory": option("--memory"),
+                        }},
+                        "startupProbe": {
+                            "httpGet": {"path": "/ready", "port": int(option("--port"))},
+                            "initialDelaySeconds": 0,
+                            "timeoutSeconds": 10,
+                            "periodSeconds": 10,
+                            "failureThreshold": 18,
+                        },
+                        "env": env,
+                    }],
+                },
+            },
+        },
+        "status": {
+            "observedGeneration": generation,
+            "latestCreatedRevisionName": candidate,
+            "latestReadyRevisionName": candidate,
+            "conditions": [{"type": "Ready", "status": "True"}],
+            "url": (
+                ""
+                if default_disabled
+                else f"https://{service}-123456789.{region}.run.app"
+            ),
+            "traffic": prior_traffic,
+        },
+    }
+    state["deployments"].append(key)
+    revision_key = f"{candidate}|{region}"
+    if revision_key not in state["deployed_revisions"]:
+        state["deployed_revisions"].append(revision_key)
+    if state.get("corrupt_traffic_after_deploy_service") == service:
+        old_revision = prior_traffic[0]["revisionName"]
+        corrupted = [
+            {"revisionName": old_revision, "percent": 90},
+            {"revisionName": candidate, "percent": 10, "tag": "hostile"},
+        ]
+        state["services"][key]["spec"]["traffic"] = corrupted
+        state["services"][key]["status"]["traffic"] = corrupted
+        state["corrupt_traffic_after_deploy_service"] = ""
+        finish(code=1)
+    if state["deploy_fail_after_remaining"]:
+        state["deploy_fail_after_remaining"] -= 1
+        finish(code=1)
+    finish()
+if args[:3] == ["projects", "get-iam-policy", "quill-cloud-proxy"]:
+    finish(state["iam"]["project"])
+if args[:3] == ["spanner", "instances", "list"]:
+    finish([{"name": "projects/quill-cloud-proxy/instances/trusted-router-nam6"}])
+if args[:3] == ["spanner", "databases", "list"]:
+    finish([{"name": "projects/quill-cloud-proxy/instances/trusted-router-nam6/databases/trusted-router"}])
+if args[:3] == ["spanner", "instances", "get-iam-policy"]:
+    finish({"bindings": []})
+if args[:3] == ["spanner", "databases", "get-iam-policy"]:
+    finish(state["iam"]["spanner"])
+if args[:3] == ["bigtable", "instances", "list"]:
+    finish([{"name": "projects/quill-cloud-proxy/instances/trusted-router-logs"}])
+if args[:3] == ["bigtable", "tables", "list"]:
+    finish([{"name": "projects/quill-cloud-proxy/instances/trusted-router-logs/tables/trustedrouter-generations"}])
+if args[:3] == ["bigtable", "instances", "get-iam-policy"]:
+    finish(state["iam"]["bigtable"])
+if args[:3] == ["bigtable", "tables", "get-iam-policy"]:
+    finish({"bindings": []})
+if args[:3] == ["kms", "locations", "list"]:
+    finish([{"locationId": "us-central1"}])
+if args[:3] == ["kms", "keyrings", "list"]:
+    finish([{"name": "projects/quill-cloud-proxy/locations/us-central1/keyRings/trusted-router"}])
+if args[:3] == ["kms", "keys", "list"]:
+    finish([
+        {"name": "projects/quill-cloud-proxy/locations/us-central1/keyRings/trusted-router/cryptoKeys/byok-envelope"},
+        {"name": "projects/quill-cloud-proxy/locations/us-central1/keyRings/trusted-router/cryptoKeys/google-ads-click-envelope"},
+    ])
+if args[:3] == ["kms", "keyrings", "get-iam-policy"]:
+    finish({"bindings": []})
+if args[:3] == ["kms", "keys", "get-iam-policy"]:
+    finish(state["iam"]["byok" if args[3] == "byok-envelope" else "ads"])
+if args[:3] == ["projects", "get-ancestors", "quill-cloud-proxy"]:
+    finish([{"type": "project", "id": "quill-cloud-proxy"}])
+if args[:2] == ["secrets", "describe"]:
+    finish({"name": args[2]}) if args[2] in state["required_secret_owners"] else missing()
+if args[:2] == ["secrets", "list"]:
+    finish([{"name": name} for name in state["required_secret_owners"]])
+if args[:3] == ["secrets", "versions", "describe"]:
+    secret = option("--secret")
+    if secret not in state["required_secret_owners"]:
+        missing()
+    requested = args[3]
+    version = (
+        str(state.get("latest_secret_versions", {}).get(secret, 7))
+        if requested == "latest"
+        else requested
+    )
+    finish({"state": "ENABLED", "name": f"projects/quill-cloud-proxy/secrets/{secret}/versions/{version}"})
+if args[:3] == ["secrets", "get-iam-policy", args[2] if len(args) > 2 else ""]:
+    secret = args[2]
+    owners = state["required_secret_owners"].get(secret)
+    if owners is None:
+        missing()
+    members = [member(surface) for surface in owners]
+    if secret == "trustedrouter-telnyx-api-key":
+        members.append(
+            "serviceAccount:tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com"
+        )
+    if secret in {
+        "trustedrouter-observer-internal-token",
+        "trustedrouter-synthetic-monitor-api-key",
+    }:
+        members.append(
+            "serviceAccount:tr-synthetic@quill-cloud-proxy.iam.gserviceaccount.com"
+        )
+    finish({"bindings": [{
+        "role": "roles/secretmanager.secretAccessor",
+        "members": members,
+    }]})
+if args[:4] == ["artifacts", "docker", "images", "describe"]:
+    finish({"image_summary": {"fully_qualified_digest": os.environ["IMAGE"]}})
+if args[:4] == ["compute", "networks", "subnets", "describe"]:
+    finish({
+        "privateIpGoogleAccess": True,
+        "network": "https://www.googleapis.com/compute/v1/projects/quill-cloud-proxy/global/networks/default",
+    })
+if args[:3] == ["dns", "managed-zones", "describe"]:
+    finish({
+        "dnsName": "run.app.",
+        "visibility": "private",
+        "privateVisibilityConfig": {"networks": [{
+            "networkUrl": "https://www.googleapis.com/compute/v1/projects/quill-cloud-proxy/global/networks/default"
+        }]},
+    })
+if args[:3] == ["dns", "record-sets", "describe"]:
+    if args[3] == "run.app.":
+        finish({"rrdatas": ["199.36.153.11", "199.36.153.9", "199.36.153.8", "199.36.153.10"]})
+    finish({"rrdatas": ["run.app."]})
+if args[:3] == ["compute", "backend-services", "describe"]:
+    backend = state["backends"][args[3]]
+    output_format = option("--format") or ""
+    if "value(selfLink)" in output_format:
+        finish(backend["selfLink"])
+    if "value(securityPolicy.basename())" in output_format:
+        finish(backend["securityPolicy"].rstrip("/").split("/")[-1])
+    finish(backend)
+if args[:3] == ["compute", "backend-services", "list"]:
+    finish(list(state["backends"].values()))
+if args[:3] == ["compute", "backend-services", "update"]:
+    require_stage_journal()
+    backend = state["backends"][args[3]]
+    if option("--timeout"):
+        backend["timeoutSec"] = int(option("--timeout").removesuffix("s"))
+    if "--enable-cdn" in args:
+        backend["enableCDN"] = True
+        backend["compressionMode"] = option("--compression-mode") or "AUTOMATIC"
+        backend["cdnPolicy"] = {
+            "cacheMode": option("--cache-mode") or "USE_ORIGIN_HEADERS",
+            "negativeCaching": "--no-negative-caching" not in args,
+            "serveWhileStale": int(option("--serve-while-stale") or "0"),
+            "cacheKeyPolicy": {
+                "includeHost": "--cache-key-include-host" in args,
+                "includeProtocol": "--cache-key-include-protocol" in args,
+                "includeQueryString": "--cache-key-include-query-string" in args,
+                "queryStringBlacklist": [],
+                "queryStringWhitelist": [],
+            },
+        }
+    if "--no-enable-cdn" in args:
+        backend["enableCDN"] = False
+    if "--no-negative-caching" in args:
+        backend.setdefault("cdnPolicy", {})["negativeCaching"] = False
+    if "--enable-logging" in args:
+        backend["logConfig"] = {
+            "enable": True,
+            "sampleRate": float(option("--logging-sample-rate") or "1"),
+            "optionalMode": "EXCLUDE_ALL_OPTIONAL",
+        }
+    if option("--security-policy"):
+        backend["securityPolicy"] = (
+            "https://www.googleapis.com/compute/v1/projects/quill-cloud-proxy/global/"
+            f"securityPolicies/{option('--security-policy')}"
+        )
+    headers = [item.split("=", 1)[1] for item in args if item.startswith("--custom-request-header=")]
+    if headers:
+        backend["customRequestHeaders"] = headers
+    finish()
+if args[:3] == ["compute", "network-endpoint-groups", "describe"]:
+    finish(state["negs"][f"{args[3]}|{option('--region')}"])
+if args[:3] == ["compute", "security-policies", "describe"]:
+    finish(state["policies"][args[3]])
+if args[:3] == ["compute", "security-policies", "import"]:
+    require_stage_journal()
+    state["policies"][args[3]] = json.loads(
+        Path(option("--file-name")).read_text(encoding="utf-8")
+    )
+    finish()
+if args[:4] == ["compute", "security-policies", "rules", "describe"]:
+    policy = option("--security-policy")
+    priority = int(args[4])
+    finish(next(item for item in state["policies"][policy]["rules"] if item["priority"] == priority))
+if args[:4] == ["compute", "security-policies", "rules", "update"]:
+    require_stage_journal()
+    finish()
+print("unsupported fake gcloud: " + joined, file=sys.stderr)
+finish(code=2)
+'''
+
+
+FAKE_JQ = r'''#!/usr/bin/env python3
+import json
+import os
+import re
+import sys
+
+args = sys.argv[1:]
+letters = "".join(arg[1:] for arg in args if arg.startswith("-") and not arg.startswith("--"))
+raw = "r" in letters
+compact = "c" in letters
+exit_status = "e" in letters
+slurp = "s" in letters
+raw_input = "R" in letters
+null_input = "n" in letters
+variables = {}
+position = 0
+while position < len(args):
+    item = args[position]
+    if item == "--arg":
+        variables[args[position + 1]] = args[position + 2]
+        position += 3
+    elif item == "--argjson":
+        variables[args[position + 1]] = json.loads(args[position + 2])
+        position += 3
+    elif item.startswith("-"):
+        position += 1
+    else:
+        break
+query = args[position]
+files = args[position + 1:]
+text = (
+    ""
+    if null_input and not files and "inputs" not in query
+    else open(files[-1], encoding="utf-8").read()
+    if files
+    else sys.stdin.read()
+)
+if raw_input:
+    data = text
+elif slurp:
+    data = [json.loads(line) for line in text.splitlines() if line.strip()]
+elif null_input:
+    data = None
+else:
+    data = json.loads(text)
+normalized = " ".join(query.split())
+with open(os.environ["FAKE_GCLOUD_EVENTS"], "a", encoding="utf-8") as output:
+    output.write("jq " + normalized + "\n")
+stream = False
+
+def direct_bindings():
+    return sorted({
+        (binding.get("role"), json.dumps(binding.get("condition"), sort_keys=True))
+        for binding in data.get("bindings", [])
+        if variables["member"] in binding.get("members", [])
+    })
+
+if normalized.startswith(".email == $email and"):
+    result = data.get("email") == variables["email"] and not data.get("disabled", False)
+elif "roles/iam.serviceAccountUser" in normalized and normalized.startswith("([.bindings"):
+    result = direct_bindings() == [("roles/iam.serviceAccountUser", "null")]
+elif "roles/secretmanager.secretAccessor" in normalized and normalized.startswith("([.bindings"):
+    result = direct_bindings() == [("roles/secretmanager.secretAccessor", "null")]
+elif normalized == 'any(.pathMatchers[]?; .name == "trusted-router-service-surfaces")':
+    result = any(item.get("name") == "trusted-router-service-surfaces" for item in data.get("pathMatchers", []))
+elif normalized == "any(.[]; .latest_revision)":
+    result = any(item.get("latest_revision") for item in data)
+elif "console traffic is not one unambiguous 100% revision" in normalized:
+    live = [item for item in data.get("status", {}).get("traffic", []) if int(item.get("percent", 0)) > 0]
+    if len(live) != 1 or live[0].get("percent") != 100 or not live[0].get("revisionName"):
+        raise SystemExit(1)
+    result = live[0]["revisionName"]
+elif "legacy fallback is not one named untagged 100% target" in normalized:
+    traffic = data.get("status", {}).get("traffic", [])
+    if (
+        len(traffic) != 1
+        or traffic[0].get("percent") != 100
+        or traffic[0].get("tag") is not None
+        or not traffic[0].get("revisionName")
+    ):
+        raise SystemExit(1)
+    result = traffic[0]["revisionName"]
+elif "legacy fallback generation is not observed" in normalized:
+    generation = data.get("metadata", {}).get("generation")
+    observed = data.get("status", {}).get("observedGeneration")
+    if not isinstance(generation, int) or isinstance(generation, bool):
+        raise SystemExit(1)
+    if generation != observed:
+        raise SystemExit(1)
+    result = generation
+elif "bootstrap artifact has inexact regional service inventory" in normalized:
+    matches = [
+        item.get("revision")
+        for item in data.get("services", [])
+        if item.get("region") == variables["region"]
+    ]
+    if len(matches) != 1:
+        raise SystemExit(1)
+    result = matches[0]
+elif ".spec.containers[0].env" in normalized and ".value][0] // $default" in normalized:
+    result = next((item.get("value") for item in data["spec"]["containers"][0].get("env", []) if item.get("name") == variables["name"] and "valueFrom" not in item), variables["default"])
+elif ".spec.containers[0].env" in normalized and ".valueFrom.secretKeyRef.name" in normalized:
+    result = next((item["valueFrom"]["secretKeyRef"].get("name", "").split("/")[-1] for item in data["spec"]["containers"][0].get("env", []) if item.get("name") == variables["name"] and "valueFrom" in item), "")
+elif normalized.startswith("[ .bindings") or (normalized.startswith("[.bindings") and "| unique" in normalized):
+    result = [{"role": role, "condition": json.loads(condition)} for role, condition in direct_bindings()]
+elif normalized == '[{role:$role,condition:null}]':
+    result = [{"role": variables["role"], "condition": None}]
+elif normalized == ".[] | [.type, (.id|tostring)] | @tsv":
+    result = [f"{item['type']}\t{item['id']}" for item in data]
+    stream = True
+elif normalized == ".state":
+    result = data.get("state")
+elif normalized == ".postcondition_sha256":
+    result = data.get("postcondition_sha256")
+elif normalized in {
+    '.candidate_snapshot_sha256 // ""',
+    '.manifest_sha256 // ""',
+}:
+    result = data.get(normalized.split()[0].removeprefix(".")) or ""
+elif normalized == 'select(.state == "ENABLED") | .name | split("/")[-1]':
+    result = data.get("name", "").split("/")[-1] if data.get("state") == "ENABLED" else None
+elif normalized == ".name":
+    result = data.get("name")
+elif "fully_qualified_digest" in normalized:
+    summary = data.get("image_summary") or data.get("imageSummary") or {}
+    result = summary.get("fully_qualified_digest") or summary.get("fullyQualifiedDigest") or data.get("fully_qualified_digest") or data.get("fullyQualifiedDigest")
+elif normalized.startswith(".privateIpGoogleAccess == true"):
+    network = data.get("network", "").rstrip("/")
+    result = data.get("privateIpGoogleAccess") is True and network.endswith("/networks/" + variables["network"])
+elif normalized.startswith('.dnsName == "run.app."'):
+    networks = data.get("privateVisibilityConfig", {}).get("networks", [])
+    result = data.get("dnsName") == "run.app." and data.get("visibility") == "private" and any(item.get("networkUrl", "").rstrip("/").endswith("/networks/" + variables["network"]) for item in networks)
+elif normalized.startswith("(.rrdatas | sort) =="):
+    result = sorted(data.get("rrdatas", [])) == sorted(["199.36.153.8", "199.36.153.9", "199.36.153.10", "199.36.153.11"])
+elif normalized == '.rrdatas == ["run.app."]':
+    result = data.get("rrdatas") == ["run.app."]
+elif normalized == ".":
+    result = data
+elif re.fullmatch(r"\.[a-z_]+(?:\.[a-z_]+)*", normalized):
+    result = data
+    for field in normalized.removeprefix(".").split("."):
+        result = result[field]
+elif normalized == "any(.[]; .name == $name)":
+    result = any(item.get("name") == variables["name"] for item in data)
+elif normalized == ".selfLink":
+    result = data.get("selfLink")
+elif "endswith(\"/regions/\" + $region" in normalized and "| length" in normalized:
+    suffix = f"/regions/{variables['region']}/networkEndpointGroups/{variables['neg']}"
+    result = sum(1 for item in data.get("backends", []) if item.get("group", "").endswith(suffix))
+elif normalized.startswith('(\"/projects/\" + $project') and "| @tsv" in normalized:
+    exact = (
+        f"/projects/{variables['project']}/regions/{variables['region']}"
+        f"/networkEndpointGroups/{variables['neg']}"
+    )
+    suffix = (
+        f"/regions/{variables['region']}/networkEndpointGroups/{variables['neg']}"
+    )
+    groups = [item.get("group", "") for item in data.get("backends", [])]
+    exact_count = sum(1 for group in groups if group == exact.lstrip("/") or group.endswith(exact))
+    wrong_count = sum(1 for group in groups if group.endswith(suffix) and not group.endswith(exact))
+    result = f"{exact_count}\t{wrong_count}"
+elif normalized == ".backends[]?.group":
+    result = [item.get("group") for item in data.get("backends", [])]
+    stream = True
+elif raw_input and "networkEndpointGroups" in normalized and "$neg" in normalized:
+    regions = [line for line in data.splitlines() if line]
+    result = sorted(f"/regions/{region}/networkEndpointGroups/{variables['neg']}" for region in regions)
+elif normalized.startswith("[.backends[]?.group | capture"):
+    result = sorted(re.search(r"(/regions/[^/]+/networkEndpointGroups/[^/]+)$", item["group"]).group(1) for item in data.get("backends", []))
+elif normalized == ".cloudRun.service // \"\"":
+    result = (data.get("cloudRun") or {}).get("service", "")
+elif "select((.securityPolicy" in normalized and "join(\",\")" in normalized:
+    result = ",".join(sorted({item["name"] for item in data if item.get("securityPolicy", "").split("/")[-1] == variables["policy"]}))
+elif raw_input and "capture(\"^(?<name>[^=]+)=(?<value>.*)$\")" in normalized:
+    result = dict(line.split("=", 1) for line in data.splitlines() if line)
+elif raw_input and "(?<resource>.*):(?<version>" in normalized:
+    result = {}
+    for line in data.splitlines():
+        if not line:
+            continue
+        name, reference = line.split("=", 1)
+        resource, version = reference.rsplit(":", 1)
+        result[name] = {"resource": resource, "version": version}
+elif 'select(any(.members[]?; . == "allUsers"))' in normalized:
+    bindings = [binding for binding in data.get("bindings", []) if "allUsers" in binding.get("members", [])]
+    if "allUsersCount" in normalized:
+        result = [
+            {
+                "role": binding.get("role"),
+                "condition": binding.get("condition"),
+                "allUsersCount": binding.get("members", []).count("allUsers"),
+            }
+            for binding in bindings
+        ] == [{
+            "role": "roles/run.invoker",
+            "condition": None,
+            "allUsersCount": 1,
+        }]
+    else:
+        result = sorted({binding.get("role") for binding in bindings}) == [
+            "roles/run.invoker"
+        ]
+elif normalized.startswith("{service:$service,backend:$backend"):
+    result = {
+        "service": variables["service"],
+        "backend": variables["backend"],
+        "region": variables["region"],
+        "generation": variables["generation"],
+        "serving_revision": variables["serving_revision"],
+        "serving_revision_sha256": variables["serving_revision_sha256"],
+        "traffic": variables["traffic"],
+        "postcondition_sha256": variables["postcondition_sha256"],
+        "backend_postcondition_sha256": variables[
+            "backend_postcondition_sha256"
+        ],
+        "invoker_iam_sha256": variables["invoker_iam_sha256"],
+    }
+elif normalized.startswith("{surface:$surface,name:$name"):
+    result = {
+        "surface": variables["surface"],
+        "name": variables["name"],
+        "region": variables["region"],
+        "prior_exists": variables["prior_exists"],
+        "prior_traffic": variables["prior_traffic"],
+        "adopted_bootstrap": variables["adopted_bootstrap"],
+        "candidate_revision": variables["candidate_revision"],
+        "runtime_service_account": variables["runtime_service_account"],
+        "ingress": variables["ingress"],
+        "default_url_disabled": variables["default_url_disabled"],
+        "concurrency": variables["concurrency"],
+        "min_instances": variables["min_instances"],
+        "service_max_instances": variables["service_max_instances"],
+        "revision_max_instances": variables["revision_max_instances"],
+        "timeout_seconds": variables["timeout_seconds"],
+        "memory": variables["memory"],
+        "cpu": variables["cpu"],
+        "container_port": variables["container_port"],
+        "vpc_network": variables["vpc_network"],
+        "vpc_subnet": variables["vpc_subnet"],
+        "vpc_egress": variables["vpc_egress"],
+        "startup_probe_path": variables["startup_probe_path"],
+        "startup_probe_initial_delay_seconds": variables[
+            "startup_probe_initial_delay_seconds"
+        ],
+        "startup_probe_timeout_seconds": variables[
+            "startup_probe_timeout_seconds"
+        ],
+        "startup_probe_period_seconds": variables[
+            "startup_probe_period_seconds"
+        ],
+        "startup_probe_failure_threshold": variables[
+            "startup_probe_failure_threshold"
+        ],
+        "max_request_body_bytes": variables["max_request_body_bytes"],
+        "max_in_flight_request_body_bytes": variables["max_in_flight_request_body_bytes"],
+        "max_concurrent_request_bodies": variables["max_concurrent_request_bodies"],
+        "request_body_read_timeout_seconds": variables["request_body_read_timeout_seconds"],
+        "postcondition_sha256": variables["postcondition_sha256"],
+    }
+else:
+    print("unsupported fake jq: " + normalized, file=sys.stderr)
+    raise SystemExit(2)
+
+truthy = result is not False and result is not None
+if exit_status and not truthy:
+    raise SystemExit(1)
+items = result if stream else [result]
+for item in items:
+    if raw and isinstance(item, bool):
+        print("true" if item else "false")
+    elif raw and isinstance(item, (str, int, float)):
+        print(item)
+    else:
+        print(json.dumps(item, separators=(",", ":") if compact else None))
+'''
+
+
+FAKE_DIG = r'''#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+state = json.loads(Path(os.environ["FAKE_GCLOUD_STATE"]).read_text(encoding="utf-8"))
+host, record_type = sys.argv[-2:]
+for answer in state["dns"][host][record_type]:
+    print(answer)
+'''
+
+
+def _install_fakes(tmp_path: Path) -> Path:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    for name, source in (
+        ("gcloud", FAKE_GCLOUD),
+        ("jq", FAKE_JQ),
+        ("dig", FAKE_DIG),
+    ):
+        path = fake_bin / name
+        path.write_text(source, encoding="utf-8")
+        path.chmod(0o755)
+    return fake_bin
+
+
+def _write_legacy_hardening_artifact(state_path: Path) -> Path:
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    hardener = _load_legacy_hardener()
+    policy = {
+        "bindings": [
+            {
+                "role": "roles/run.invoker",
+                "members": ["allUsers"],
+                "condition": None,
+            }
+        ]
+    }
+    iam_sha256 = hardener._sha(policy)  # noqa: SLF001
+    revision = state["serving_console_revision"]
+    revision_sha256 = hardener._sha(  # noqa: SLF001
+        hardener._revision_semantic(revision)  # noqa: SLF001
+    )
+    artifact = {
+        "schema_version": 1,
+        "kind": "trusted-router-legacy-hardening-artifact",
+        "project_id": PROJECT,
+        "service": "trusted-router",
+        "runtime_service_account": (
+            "123456789-compute@developer.gserviceaccount.com"
+        ),
+        "operation_id": "legacy-hardener-test-operation",
+        "revision_suffix": "prior",
+        "regions": [
+            {
+                "region": region,
+                "serving_revision": "trusted-router-prior",
+                "service_sha256": hardener._sha(  # noqa: SLF001
+                    hardener._service_semantic(  # noqa: SLF001
+                        state["services"][f"trusted-router|{region}"]
+                    )
+                ),
+                "revision_sha256": revision_sha256,
+                "iam_sha256": iam_sha256,
+            }
+            for region in REGIONS
+        ],
+        "secret_refs": [],
+        "journal_sha256": "0" * 64,
+        "created_at": "2026-08-21T00:00:00+00:00",
+    }
+    path = state_path.with_name("legacy-hardening.json")
+    path.write_text(json.dumps(artifact, sort_keys=True), encoding="utf-8")
+    path.chmod(0o600)
+    return path
+
+
+def _capture_frontend_attestation(
+    state_path: Path, fake_bin: Path, environment: dict[str, str]
+) -> Path:
+    artifact = state_path.with_name("frontend-attestation.json")
+    result = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            str(FRONTEND_ATTEST),
+            "capture",
+            "--project",
+            PROJECT,
+            "--forwarding-rule",
+            "trusted-router-public-https",
+            "--https-proxy",
+            "trusted-router-control-https-proxy",
+            "--url-map",
+            "trusted-router-map",
+            "--hosts",
+            ",".join(FRONTEND_HOSTS),
+            "--artifact",
+            str(artifact),
+        ],
+        env={**environment, "PATH": f"{fake_bin}:{environment['PATH']}"},
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert artifact.stat().st_mode & 0o777 == 0o600
+    return artifact
+
+
+def _fake_environment(
+    fake_bin: Path,
+    state_path: Path,
+    events_path: Path,
+    *,
+    bootstrap_suffix: str = "iboot1",
+    rollout_suffix: str = "rstage1",
+) -> dict[str, str]:
+    environment = {
+        **{key: value for key, value in os.environ.items() if not key.startswith("TR_")},
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "FAKE_GCLOUD_STATE": str(state_path),
+        "FAKE_GCLOUD_EVENTS": str(events_path),
+        "PROJECT_ID": PROJECT,
+        "TR_CONTROL_PLANE_REGIONS": ",".join(REGIONS),
+        "TR_REGIONS": ",".join(REGIONS),
+        "TR_PRIMARY_REGION": REGIONS[0],
+        "TR_SYNTHETIC_MONITOR_REGIONS": ",".join(REGIONS),
+        "TR_SYNTHETIC_THROUGHPUT_REGION": REGIONS[0],
+        "TR_SYNTHETIC_IMAGE_REGION": REGIONS[0],
+        "TR_SYNTHETIC_VIDEO_REGION": REGIONS[0],
+        "TR_RELEASE": "stage-execution-test",
+        "TR_ROLLOUT_REVISION_SUFFIX": rollout_suffix,
+        "TR_ROLLOUT_OPERATION_ID": "stage-execution-operation",
+        "TR_INTERNAL_BOOTSTRAP_REVISION_SUFFIX": bootstrap_suffix,
+        "TR_ROLLOUT_LOCAL_LOCK_PATH": str(
+            state_path.with_name("rollout-operation.lock")
+        ),
+        "IMAGE": IMAGE,
+    }
+    legacy_artifact = _write_legacy_hardening_artifact(state_path)
+    frontend_artifact = _capture_frontend_attestation(
+        state_path, fake_bin, environment
+    )
+    environment["TR_LEGACY_HARDENING_ARTIFACT"] = str(legacy_artifact)
+    environment["TR_ROLLOUT_FRONTEND_ATTESTATION"] = str(frontend_artifact)
+    return environment
+
+
+def test_bootstrap_rejects_unrecorded_internal_service_before_mutation(
+    tmp_path: Path,
+) -> None:
+    state_path = tmp_path / "fake-cloud.json"
+    events_path = tmp_path / "gcloud-events.log"
+    state = _initial_state()
+    state["deploy_fail_after_remaining"] = 0
+    state["services"][f"trusted-router-billing|{REGIONS[0]}"] = _prior_service(
+        "internal", REGIONS[0]
+    )
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    fake_bin = _install_fakes(tmp_path)
+    env = _fake_environment(fake_bin, state_path, events_path)
+    artifact = tmp_path / "bootstrap" / "internal.json"
+
+    rejected = subprocess.run(  # noqa: S603
+        ["/bin/bash", str(BOOTSTRAP), "--artifact", str(artifact)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert rejected.returncode != 0
+    assert "unrecorded internal service" in rejected.stderr
+    assert not artifact.exists()
+    assert not Path(f"{artifact}.state").exists()
+    events = events_path.read_text(encoding="utf-8").splitlines()
+    assert not any(
+        " run deploy " in f" {line} " or " update-traffic " in f" {line} "
+        for line in events
+    )
+
+
+def test_bootstrap_reads_legacy_monolith_without_new_console_dependency(
+    tmp_path: Path,
+) -> None:
+    state_path = tmp_path / "fake-cloud.json"
+    events_path = tmp_path / "gcloud-events.log"
+    state = _initial_state()
+    state["deploy_fail_after_remaining"] = 0
+    assert all(
+        not key.startswith("trusted-router-console|") for key in state["services"]
+    )
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    fake_bin = _install_fakes(tmp_path)
+    env = _fake_environment(fake_bin, state_path, events_path)
+    env["TR_CONSOLE_SERVICE"] = "trusted-router-console"
+    env["TR_LEGACY_CONSOLE_SERVICE"] = "trusted-router"
+    env["LEGACY_CONSOLE_SERVICE"] = "trusted-router"
+    artifact = tmp_path / "bootstrap" / "internal.json"
+
+    result = subprocess.run(  # noqa: S603
+        ["/bin/bash", str(BOOTSTRAP), "--artifact", str(artifact)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    events = events_path.read_text(encoding="utf-8").splitlines()
+    legacy_describes = [
+        line
+        for line in events
+        if "run services describe trusted-router --region=" in line
+    ]
+    assert len(legacy_describes) == len(REGIONS)
+    assert not any("trusted-router-console" in line for line in events)
+    assert not any("run deploy trusted-router " in line for line in events)
+
+
+def test_bootstrap_rejects_path_bearing_private_health_origin(
+    tmp_path: Path,
+) -> None:
+    state_path = tmp_path / "fake-cloud.json"
+    events_path = tmp_path / "gcloud-events.log"
+    state_path.write_text(json.dumps(_initial_state()), encoding="utf-8")
+    fake_bin = _install_fakes(tmp_path)
+    env = _fake_environment(fake_bin, state_path, events_path)
+    artifact = tmp_path / "bootstrap" / "internal.json"
+
+    bootstrap = subprocess.run(  # noqa: S603
+        ["/bin/bash", str(BOOTSTRAP), "--artifact", str(artifact)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert bootstrap.returncode == 0, bootstrap.stderr
+
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    key = f"trusted-router-synthetic-{REGIONS[0]}|{REGIONS[0]}"
+    env_items = state["jobs"][key]["spec"]["template"]["spec"]["template"][
+        "spec"
+    ]["containers"][0]["env"]
+    health_origin = next(
+        item
+        for item in env_items
+        if item["name"] == "TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL"
+    )
+    health_origin["value"] += "/healthz"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    event_start = len(events_path.read_text(encoding="utf-8").splitlines())
+
+    rejected = subprocess.run(  # noqa: S603
+        [
+            "/bin/bash",
+            str(BOOTSTRAP),
+            "--verify-artifact",
+            str(artifact),
+            "--expected-image",
+            IMAGE,
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert rejected.returncode != 0
+    rejected_events = events_path.read_text(encoding="utf-8").splitlines()[
+        event_start:
+    ]
+    assert not any(
+        " run deploy " in f" {line} "
+        or " update-traffic " in f" {line} "
+        or " url-maps import " in f" {line} "
+        or " backend-services update " in f" {line} "
+        for line in rejected_events
+    )
+
+
+def test_bootstrap_resumes_journal_and_initial_stage_never_deploys_legacy(
+    tmp_path: Path,
+) -> None:
+    state_path = tmp_path / "fake-cloud.json"
+    events_path = tmp_path / "gcloud-events.log"
+    state = _initial_state()
+    state["deploy_fail_after_remaining"] = 0
+    state["fatal_deploy_before_regions"] = [REGIONS[0]]
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    fake_bin = _install_fakes(tmp_path)
+    env = _fake_environment(fake_bin, state_path, events_path)
+    artifact = tmp_path / "bootstrap" / "internal.json"
+    journal = Path(f"{artifact}.state")
+
+    interrupted = subprocess.run(  # noqa: S603
+        ["/bin/bash", str(BOOTSTRAP), "--artifact", str(artifact)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert interrupted.returncode != 0
+    assert not artifact.exists()
+    interrupted_state = json.loads(journal.read_text(encoding="utf-8"))
+    assert stat.S_IMODE(journal.stat().st_mode) == 0o600
+    assert interrupted_state["revision_suffix"] == "iboot1"
+    assert interrupted_state["region_states"] == [
+        {"region": REGIONS[0], "state": "deploy_intent"},
+        {"region": REGIONS[1], "state": "pending"},
+    ]
+
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["fatal_deploy_before_regions"] = []
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    resume_env = dict(env)
+    resume_env.pop("TR_INTERNAL_BOOTSTRAP_REVISION_SUFFIX")
+    resumed = subprocess.run(  # noqa: S603
+        ["/bin/bash", str(BOOTSTRAP), "--artifact", str(artifact)],
+        env=resume_env,
+        capture_output=True,
+        text=True,
+    )
+    assert resumed.returncode == 0, resumed.stderr
+    settled_state = json.loads(journal.read_text(encoding="utf-8"))
+    assert {item["state"] for item in settled_state["region_states"]} == {"settled"}
+    assert json.loads(artifact.read_text(encoding="utf-8"))["image"] == IMAGE
+
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["corrupt_traffic_after_deploy_service"] = "trusted-router-public"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    manifest = tmp_path / "resumed-stage" / "manifest.json"
+    stage_journal = Path(f"{manifest}.stage.state")
+    drift_env = dict(env)
+    drift_env["TR_INTERNAL_BOOTSTRAP_ARTIFACT"] = str(artifact)
+    drift_env["TR_ROLLOUT_REVISION_SUFFIX"] = "rbad1"
+    drift_env["EXPECTED_STAGE_JOURNAL"] = str(stage_journal)
+    event_start = len(events_path.read_text(encoding="utf-8").splitlines())
+    interrupted_stage = subprocess.run(  # noqa: S603
+        ["/bin/bash", str(ROLLOUT), "--manifest", str(manifest)],
+        env=drift_env,
+        capture_output=True,
+        text=True,
+    )
+    assert interrupted_stage.returncode != 0
+    assert not manifest.exists()
+    assert stage_journal.exists(), interrupted_stage.stderr
+    assert stat.S_IMODE(stage_journal.stat().st_mode) == 0o600
+    interrupted_stage_state = json.loads(stage_journal.read_text(encoding="utf-8"))
+    public_us = next(
+        item
+        for item in interrupted_stage_state["service_states"]
+        if item["surface"] == "public" and item["region"] == REGIONS[0]
+    )
+    assert public_us["state"] == "deploy_intent"
+    assert public_us["candidate_revision"] == "trusted-router-public-rbad1"
+
+    # The provider applied the immutable candidate and then returned nonzero,
+    # but also changed traffic/tag state. Staging must reject that ambiguous
+    # result. Once the exact off-map sole-candidate state is independently
+    # restored, a fresh process adopts only the journal-owned same suffix.
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    public_key = f"trusted-router-public|{REGIONS[0]}"
+    repaired_traffic = [
+        {"revisionName": "trusted-router-public-rbad1", "percent": 100}
+    ]
+    state["services"][public_key]["spec"]["traffic"] = repaired_traffic
+    state["services"][public_key]["status"]["traffic"] = repaired_traffic
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    resume_stage_env = dict(drift_env)
+    resume_stage_env.pop("TR_ROLLOUT_REVISION_SUFFIX")
+    resumed_stage = subprocess.run(  # noqa: S603
+        ["/bin/bash", str(ROLLOUT), "--manifest", str(manifest)],
+        env=resume_stage_env,
+        capture_output=True,
+        text=True,
+    )
+    assert resumed_stage.returncode == 0, resumed_stage.stderr
+    assert manifest.exists()
+    completed_stage_state = json.loads(stage_journal.read_text(encoding="utf-8"))
+    assert completed_stage_state["phase"] == "complete"
+    assert {item["state"] for item in completed_stage_state["service_states"]} == {
+        "staged"
+    }
+    final_fake_state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert final_fake_state["deployments"].count(public_key) == 1
+    assert all(
+        revision.split("|", 1)[0].endswith("-rbad1")
+        or "-iboot1|" in revision
+        for revision in final_fake_state["deployed_revisions"]
+    )
+    stage_events = events_path.read_text(encoding="utf-8").splitlines()[event_start:]
+    assert not any("run deploy trusted-router " in line for line in stage_events)
+    assert not any(
+        " update-traffic " in f" {line} " or " url-maps import " in f" {line} "
+        for line in stage_events
+    )
+
+
+def test_bootstrap_preserves_reviewed_spanner_clickhouse_mode(tmp_path: Path) -> None:
+    state_path = tmp_path / "fake-cloud.json"
+    events_path = tmp_path / "gcloud-events.log"
+    state = _initial_state()
+    state["deploy_fail_after_remaining"] = 0
+    serving_env = state["serving_console_revision"]["spec"]["containers"][0]["env"]
+    plain = {item["name"]: item for item in serving_env if "valueFrom" not in item}
+    plain["TR_STORAGE_BACKEND"]["value"] = "spanner-clickhouse"
+    plain["TR_ANALYTICS_READ_MODE"]["value"] = "clickhouse-only"
+    plain["TR_BIGTABLE_MIRROR_WRITES_ENABLED"]["value"] = "false"
+    serving_env.extend(
+        [
+            {
+                "name": "TR_ANALYTICS_DUAL_READ_STARTED_AT",
+                "value": "2026-08-01T00:00:00Z",
+            },
+            {
+                "name": "TR_ANALYTICS_CLICKHOUSE_PRIMARY_STARTED_AT",
+                "value": "2026-08-02T00:00:00Z",
+            },
+            {
+                "name": "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_URL",
+                "value": "http://10.8.0.5:8123",
+            },
+            {
+                "name": "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_USER",
+                "value": "tr_control_read",
+            },
+            {
+                "name": "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_DATABASE",
+                "value": "tr",
+            },
+            {
+                "name": "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_PASSWORD",
+                "valueFrom": {
+                    "secretKeyRef": {
+                        "name": "trustedrouter-clickhouse-control-read-password",
+                        "key": "7",
+                    }
+                },
+            },
+        ]
+    )
+    state["required_secret_owners"][
+        "trustedrouter-clickhouse-control-read-password"
+    ] = ["public", "console", "internal"]
+    state["latest_secret_versions"][
+        "trustedrouter-clickhouse-control-read-password"
+    ] = 8
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    fake_bin = _install_fakes(tmp_path)
+    env = _fake_environment(fake_bin, state_path, events_path)
+    artifact_path = tmp_path / "bootstrap" / "internal.json"
+
+    result = subprocess.run(  # noqa: S603
+        ["/bin/bash", str(BOOTSTRAP), "--artifact", str(artifact_path)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert artifact["data_mode"] == {
+        "storage_backend": "spanner-clickhouse",
+        "analytics_read_mode": "clickhouse-only",
+        "request_record_write_mode": "typed",
+        "generation_records_enabled": "true",
+        "bigtable_mirror_writes_enabled": "false",
+        "analytics_dual_read_started_at": "2026-08-01T00:00:00Z",
+        "analytics_clickhouse_primary_started_at": "2026-08-02T00:00:00Z",
+        "operational_clickhouse_url": "http://10.8.0.5:8123",
+        "operational_clickhouse_user": "tr_control_read",
+        "operational_clickhouse_database": "tr",
+    }
+    deployed = json.loads(state_path.read_text(encoding="utf-8"))["services"][
+        f"trusted-router-billing|{REGIONS[0]}"
+    ]
+    deployed_env = {
+        item["name"]: item
+        for item in deployed["spec"]["template"]["spec"]["containers"][0]["env"]
+    }
+    assert deployed_env["TR_STORAGE_BACKEND"]["value"] == "spanner-clickhouse"
+    assert deployed_env["TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_PASSWORD"][
+        "valueFrom"
+    ]["secretKeyRef"] == {
+        "name": "trustedrouter-clickhouse-control-read-password",
+        "key": "7",
+    }
+
+
+def test_staging_reconciles_and_postverifies_all_six_surfaces(tmp_path: Path) -> None:
+    state_path = tmp_path / "fake-cloud.json"
+    events_path = tmp_path / "gcloud-events.log"
+    manifest_path = tmp_path / "rollout" / "manifest.json"
+    state_path.write_text(json.dumps(_initial_state()), encoding="utf-8")
+    fake_bin = _install_fakes(tmp_path)
+    env = _fake_environment(fake_bin, state_path, events_path)
+    bootstrap_artifact = tmp_path / "bootstrap" / "internal.json"
+    bootstrap_result = subprocess.run(  # noqa: S603
+        ["/bin/bash", str(BOOTSTRAP), "--artifact", str(bootstrap_artifact)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert bootstrap_result.returncode == 0, bootstrap_result.stderr
+    assert "deploy exited non-zero; inspecting exact postconditions" in (
+        bootstrap_result.stderr
+    )
+    artifact = json.loads(bootstrap_artifact.read_text(encoding="utf-8"))
+    artifact_text = bootstrap_artifact.read_text(encoding="utf-8")
+    bootstrap_state = Path(f"{bootstrap_artifact}.state")
+    state_journal = json.loads(bootstrap_state.read_text(encoding="utf-8"))
+    assert stat.S_IMODE(bootstrap_artifact.stat().st_mode) == 0o600
+    assert stat.S_IMODE(bootstrap_state.stat().st_mode) == 0o600
+    assert state_journal["revision_suffix"] == "iboot1"
+    assert state_journal["image"] == IMAGE
+    assert state_journal["regions"] == list(REGIONS)
+    assert {item["state"] for item in state_journal["region_states"]} == {
+        "settled"
+    }
+    assert "secret" not in artifact_text.lower()
+    assert "trustedrouter-" not in artifact_text
+    assert artifact["regions"] == list(REGIONS)
+    assert artifact["internal_service"] == "trusted-router-billing"
+    assert artifact["synthetic_service_account"] == (
+        "tr-synthetic@quill-cloud-proxy.iam.gserviceaccount.com"
+    )
+    assert len(artifact["services"]) == len(REGIONS)
+    bootstrap_events = events_path.read_text(encoding="utf-8").splitlines()
+    assert not any("run deploy trusted-router " in line for line in bootstrap_events)
+    assert [
+        line for line in bootstrap_events if "run services update-traffic" in line
+    ] == [
+        (
+            "gcloud run services update-traffic trusted-router-billing "
+            f"--region={region} --clear-tags "
+            "--to-revisions=trusted-router-billing-iboot1=100 --quiet"
+        )
+        for region in REGIONS
+    ]
+
+    clean_verified_state = json.loads(state_path.read_text(encoding="utf-8"))
+
+    def assert_artifact_verify_rejects(mutator: Callable[[dict[str, Any]], None]) -> None:
+        hostile_state = copy.deepcopy(clean_verified_state)
+        mutator(hostile_state)
+        state_path.write_text(json.dumps(hostile_state), encoding="utf-8")
+        event_start = len(events_path.read_text(encoding="utf-8").splitlines())
+        rejected = subprocess.run(  # noqa: S603
+            [
+                "/bin/bash",
+                str(BOOTSTRAP),
+                "--verify-artifact",
+                str(bootstrap_artifact),
+                "--expected-image",
+                IMAGE,
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert rejected.returncode != 0
+        rejected_events = events_path.read_text(encoding="utf-8").splitlines()[
+            event_start:
+        ]
+        assert not any(
+            " run deploy " in f" {line} "
+            or " update-traffic " in f" {line} "
+            or " url-maps import " in f" {line} "
+            or " backend-services update " in f" {line} "
+            for line in rejected_events
+        )
+
+    internal_key = f"trusted-router-billing|{REGIONS[0]}"
+
+    def internal_container(value: dict[str, Any]) -> dict[str, Any]:
+        return value["services"][internal_key]["spec"]["template"]["spec"][
+            "containers"
+        ][0]
+
+    assert_artifact_verify_rejects(
+        lambda value: value["services"][internal_key]["spec"]["template"][
+            "spec"
+        ]["containers"].append({"image": IMAGE})
+    )
+    assert_artifact_verify_rejects(
+        lambda value: internal_container(value).__setitem__("args", ["hostile"])
+    )
+    assert_artifact_verify_rejects(
+        lambda value: value["services"][internal_key]["spec"]["template"][
+            "spec"
+        ].__setitem__("volumes", [{"name": "hostile"}])
+    )
+    assert_artifact_verify_rejects(
+        lambda value: internal_container(value)["resources"]["limits"].__setitem__(
+            "memory", "4Gi"
+        )
+    )
+    hostile_job_key = f"trusted-router-synthetic-{REGIONS[0]}|{REGIONS[0]}"
+    assert_artifact_verify_rejects(
+        lambda value: value["jobs"][hostile_job_key]["spec"]["template"]["spec"][
+            "template"
+        ]["spec"]["containers"][0].__setitem__(
+            "image", IMAGE.rsplit(":", 1)[0] + ":" + "b" * 64
+        )
+    )
+
+    def add_path_to_private_health_origin(value: dict[str, Any]) -> None:
+        env = value["jobs"][hostile_job_key]["spec"]["template"]["spec"][
+            "template"
+        ]["spec"]["containers"][0]["env"]
+        item = next(
+            item
+            for item in env
+            if item["name"] == "TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL"
+        )
+        item["value"] += "/healthz"
+
+    assert_artifact_verify_rejects(add_path_to_private_health_origin)
+    hostile_scheduler_key = (
+        f"trusted-router-synthetic-{REGIONS[0]}-every-three-minutes|{REGIONS[0]}"
+    )
+
+    def add_scheduler_execution_override(value: dict[str, Any]) -> None:
+        target = value["schedulers"][hostile_scheduler_key]["httpTarget"]
+        target["body"] = "eyJvdmVycmlkZSI6dHJ1ZX0="
+        target["headers"] = {"X-TrustedRouter-Override": "true"}
+
+    assert_artifact_verify_rejects(add_scheduler_execution_override)
+    state_path.write_text(json.dumps(clean_verified_state), encoding="utf-8")
+
+    # The artifact verifier is fail-closed and read-only when one job still
+    # points at the legacy console origin.
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    broken_key = f"trusted-router-synthetic-{REGIONS[0]}|{REGIONS[0]}"
+    broken_env = state["jobs"][broken_key]["spec"]["template"]["spec"][
+        "template"
+    ]["spec"]["containers"][0]["env"]
+    next(
+        item for item in broken_env if item["name"] == "TR_SYNTHETIC_INGEST_URL"
+    )["value"] = (
+        "https://trusted-router-123456789.us-central1.run.app/"
+        "v1/internal/synthetic/samples"
+    )
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    before_failed_verify = len(events_path.read_text(encoding="utf-8").splitlines())
+    failed_verify = subprocess.run(  # noqa: S603
+        [
+            "/bin/bash",
+            str(BOOTSTRAP),
+            "--verify-artifact",
+            str(bootstrap_artifact),
+            "--expected-image",
+            IMAGE,
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert failed_verify.returncode != 0
+    failed_verify_events = events_path.read_text(encoding="utf-8").splitlines()[
+        before_failed_verify:
+    ]
+    assert not any(
+        " run deploy " in f" {line} "
+        or " update-traffic " in f" {line} "
+        or " url-maps import " in f" {line} "
+        for line in failed_verify_events
+    )
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["jobs"][broken_key] = _synthetic_job(
+        REGIONS[0], f"trusted-router-synthetic-{REGIONS[0]}"
+    )
+    state["deploy_fail_after_remaining"] = 1
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    env["TR_INTERNAL_BOOTSTRAP_ARTIFACT"] = str(bootstrap_artifact)
+    stage_journal_path = Path(f"{manifest_path}.stage.state")
+    env["EXPECTED_STAGE_JOURNAL"] = str(stage_journal_path)
+    main_event_start = len(events_path.read_text(encoding="utf-8").splitlines())
+    result = subprocess.run(  # noqa: S603
+        ["/bin/bash", str(ROLLOUT), "--manifest", str(manifest_path)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "deploy command exited non-zero; inspecting immutable postconditions" in result.stderr
+    assert "no Cloud Run traffic or HTTPS URL-map route was changed" in result.stderr
+    assert stage_journal_path.exists()
+    assert stat.S_IMODE(stage_journal_path.stat().st_mode) == 0o600
+    completed_stage = json.loads(stage_journal_path.read_text(encoding="utf-8"))
+    assert completed_stage["phase"] == "complete"
+    assert completed_stage["revision_suffix"] == "rstage1"
+    assert {item["state"] for item in completed_stage["edge_states"]} == {
+        "reconciled"
+    }
+    assert {item["state"] for item in completed_stage["service_states"]} == {
+        "staged"
+    }
+
+    subprocess.run(  # noqa: S603
+        [sys.executable, str(STATE_TOOL), "validate-manifest", str(manifest_path)],
+        check=True,
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    prior_snapshot = manifest_path.parent / manifest["url_map"]["prior_snapshot"]
+    candidate_snapshot = manifest_path.parent / manifest["url_map"]["candidate_snapshot"]
+    assert prior_snapshot.exists() and candidate_snapshot.exists()
+    assert stat.S_IMODE(manifest_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(prior_snapshot.stat().st_mode) == 0o600
+    assert stat.S_IMODE(candidate_snapshot.stat().st_mode) == 0o600
+    assert json.loads(prior_snapshot.read_text(encoding="utf-8")) != json.loads(
+        candidate_snapshot.read_text(encoding="utf-8")
+    )
+    assert manifest["rollout_mode"] == "initial_split"
+    assert manifest["bootstrap_artifact_sha256"] == __import__("hashlib").sha256(
+        bootstrap_artifact.read_bytes()
+    ).hexdigest()
+    persisted_legacy = Path(f"{manifest_path}.legacy-hardening.json")
+    persisted_frontend = Path(f"{manifest_path}.frontend-attestation.json")
+    assert stat.S_IMODE(persisted_legacy.stat().st_mode) == 0o600
+    assert stat.S_IMODE(persisted_frontend.stat().st_mode) == 0o600
+    assert manifest["legacy_hardening_artifact_sha256"] == hashlib.sha256(
+        persisted_legacy.read_bytes()
+    ).hexdigest()
+    assert manifest["frontend_attestation_sha256"] == hashlib.sha256(
+        persisted_frontend.read_bytes()
+    ).hexdigest()
+    assert completed_stage["legacy_hardening_artifact_sha256"] == manifest[
+        "legacy_hardening_artifact_sha256"
+    ]
+    assert completed_stage["frontend_attestation_sha256"] == manifest[
+        "frontend_attestation_sha256"
+    ]
+    assert manifest["regions"] == list(REGIONS)
+    assert manifest["internal_regions"] == list(REGIONS)
+    assert manifest["primary_region"] == REGIONS[0]
+    assert manifest["url_map"]["https_proxy"] == (
+        "trusted-router-control-https-proxy"
+    )
+    assert len(manifest["services"]) == len(SURFACES) * len(REGIONS)
+    assert {item["candidate_revision"] for item in manifest["services"]} == {
+        *(f"{SERVICES[surface]}-rstage1" for surface in SURFACES if surface != "internal"),
+        "trusted-router-billing-iboot1",
+    }
+    assert all(
+        item["adopted_bootstrap"] == (item["surface"] == "internal")
+        for item in manifest["services"]
+    )
+
+    final_state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert final_state["deploy_fail_after_remaining"] == 0
+    assert len(final_state["deployments"]) == len(SURFACES) * len(REGIONS)
+    for surface in SURFACES:
+        for region in REGIONS:
+            service = final_state["services"][f"{SERVICES[surface]}|{region}"]
+            prior_revision = (
+                "trusted-router-billing-iboot1"
+                if surface == "internal"
+                else f"{SERVICES[surface]}-rstage1"
+            )
+            assert service["status"]["latestReadyRevisionName"] == prior_revision
+            assert service["status"]["traffic"] == [
+                {"revisionName": prior_revision, "percent": 100}
+            ]
+    for region in REGIONS:
+        legacy = final_state["services"][f"trusted-router|{region}"]
+        assert legacy["status"]["traffic"] == [
+            {"revisionName": "trusted-router-prior", "percent": 100}
+        ]
+
+    events = events_path.read_text(encoding="utf-8").splitlines()
+    main_events = events[main_event_start:]
+    first_mutation = next(
+        index
+        for index, line in enumerate(main_events)
+        if " backend-services update " in f" {line} "
+        or " security-policies rules update " in f" {line} "
+        or " run deploy " in f" {line} "
+    )
+    synthetic_proof = [
+        index
+        for index, line in enumerate(main_events)
+        if " scheduler jobs describe " in f" {line} "
+    ]
+    assert synthetic_proof and max(synthetic_proof) < first_mutation
+    assert len([line for line in main_events if " run deploy " in f" {line} "]) == 10
+    assert not any(
+        "--no-traffic" in line
+        for line in main_events
+        if " run deploy " in f" {line} "
+    )
+    assert any("backend-services update trusted-router-public-backend" in line for line in main_events)
+    assert any(
+        "security-policies import trusted-router-public-edge" in line
+        for line in main_events
+    )
+    assert any("network-endpoint-groups describe trusted-router-billing-neg" in line for line in main_events)
+    assert not any("run services update-traffic" in line for line in main_events)
+    assert not any("url-maps import" in line for line in events)

--- a/tests/test_six_surface_rollout_stage_execution.py
+++ b/tests/test_six_surface_rollout_stage_execution.py
@@ -1690,9 +1690,23 @@ def test_bootstrap_reads_legacy_monolith_without_new_console_dependency(
         for line in events
         if "run services describe trusted-router --region=" in line
     ]
-    assert len(legacy_describes) == len(REGIONS)
+    # Bootstrap reads the legacy monolith in every region — hardening-artifact
+    # verification plus the data-mode preflight, all read-only describes. The
+    # count per region is symmetric but not pinned: it moves whenever a
+    # verification pass is added, and the property being proved is coverage
+    # plus read-only-ness, not the number of reads.
+    described_regions = {
+        line.split("--region=", 1)[1].split()[0] for line in legacy_describes
+    }
+    assert described_regions == set(REGIONS)
+    per_region = [
+        sum(f"--region={region}" in line for line in legacy_describes)
+        for region in REGIONS
+    ]
+    assert len(set(per_region)) == 1, per_region
     assert not any("trusted-router-console" in line for line in events)
     assert not any("run deploy trusted-router " in line for line in events)
+    assert not any("update-traffic trusted-router " in line for line in events)
 
 
 def test_bootstrap_rejects_path_bearing_private_health_origin(

--- a/tests/test_six_surface_rollout_stage_execution.py
+++ b/tests/test_six_surface_rollout_stage_execution.py
@@ -96,7 +96,6 @@ FRONTEND_HOSTS = (
     "trustedrouter.com",
     "www.trustedrouter.com",
     "status.trustedrouter.com",
-    "trust.trustedrouter.com",
     "eu.trustedrouter.com",
     "status-us.trustedrouter.com",
     "status-eu.trustedrouter.com",
@@ -554,6 +553,7 @@ def _initial_state() -> dict[str, Any]:
         f"{prefix}{domain}"
         for domain in ("trustedrouter.com", "allyrouter.com", "uptimerouter.com")
         for prefix in ("", "www.", "status.", "trust.")
+        if f"{prefix}{domain}" != "trust.trustedrouter.com"
     ] + ["eu.trustedrouter.com", "status-us.trustedrouter.com", "status-eu.trustedrouter.com"]
     prior_map = {
         "name": "trusted-router-map",

--- a/tests/test_spanner_chat_browser_key.py
+++ b/tests/test_spanner_chat_browser_key.py
@@ -1,0 +1,42 @@
+"""Native-Spanner browser-key cap under an explicitly forced commit race."""
+
+from __future__ import annotations
+
+import datetime as dt
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage_chat_browser_keys import is_active_chat_browser_key
+from trusted_router.storage_models import ApiKey
+
+
+def test_spanner_chat_browser_cap_retries_concurrent_guard_conflicts() -> None:
+    store, database, _bigtable = make_fake_store()
+    user = store.ensure_user("spanner-chat-cap@example.com")
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    cap = 3
+    callers = 8
+    # Fake Spanner pauses every caller after its first transaction callback but
+    # before commit. They all observe the same absent guard; one wins and the
+    # others must ABORT/retry against the newly durable count.
+    database._ready_barrier = threading.Barrier(callers)  # noqa: SLF001
+
+    def issue(index: int) -> tuple[str, ApiKey] | None:
+        return store.issue_chat_browser_key(
+            workspace_id=workspace.id,
+            name=f"chat-browser-spanner-race-{index}",
+            creator_user_id=user.id,
+            limit_microdollars=5_000_000,
+            expires_at=(dt.datetime.now(dt.UTC) + dt.timedelta(days=30)).isoformat(),
+            active_key_cap=cap,
+        )
+
+    with ThreadPoolExecutor(max_workers=callers) as executor:
+        results = list(executor.map(issue, range(callers)))
+
+    assert database.aborts >= 1
+    assert sum(result is not None for result in results) == cap
+    assert sum(
+        is_active_chat_browser_key(key) for key in store.list_keys(workspace.id)
+    ) == cap

--- a/tests/test_spanner_oauth_atomic_exchange.py
+++ b/tests/test_spanner_oauth_atomic_exchange.py
@@ -1,0 +1,295 @@
+"""Native-Spanner OAuth exchange transactions under aborts and failures."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+from typing import Any
+
+import pytest
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router import storage_gcp_oauth_codes
+from trusted_router.storage_gcp_counters import KEY_LIMIT_TABLE
+from trusted_router.storage_oauth_codes import (
+    OAuthWorkspaceBillingPaused,
+    OAuthWorkspaceUnavailable,
+)
+
+
+def _challenge(verifier: str) -> str:
+    return (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest())
+        .decode("ascii")
+        .rstrip("=")
+    )
+
+
+def _grant(
+    store: Any,
+    *,
+    limit_microdollars: int | None = 7_000_000,
+) -> tuple[str, str, str]:
+    user = store.ensure_user("spanner-atomic-oauth@example.com")
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    verifier = "spanner-verifier-" + "s" * 43
+    raw_code, _code = store.create_oauth_authorization_code(
+        workspace_id=workspace.id,
+        user_id=user.id,
+        callback_url="https://spanner-atomic.example.com/cb",
+        key_label="Spanner atomic OAuth",
+        ttl_seconds=300,
+        app_id=20,
+        limit_microdollars=limit_microdollars,
+        limit_reset="monthly",
+        code_challenge=_challenge(verifier),
+        code_challenge_method="S256",
+    )
+    return raw_code, verifier, workspace.id
+
+
+def _set_credit_shards(store: Any, workspace_id: str, shard_count: int) -> None:
+    account = store.get_credit_account(workspace_id)
+    assert account is not None
+    account.shard_count = shard_count
+    store._write_entity(  # noqa: SLF001
+        "credit",
+        workspace_id,
+        account,
+    )
+
+
+def test_spanner_atomic_oauth_exchange_retries_to_one_winner() -> None:
+    store, database, _bigtable = make_fake_store()
+    raw_code, verifier, workspace_id = _grant(store)
+    callers = 8
+    database._ready_barrier = threading.Barrier(callers)  # noqa: SLF001
+
+    def exchange(_index: int):
+        return store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=verifier,
+            code_challenge_method="S256",
+        )
+
+    with ThreadPoolExecutor(max_workers=callers) as executor:
+        results = list(executor.map(exchange, range(callers)))
+
+    winners = [result for result in results if result is not None]
+    assert database.aborts >= 1
+    assert len(winners) == 1
+    assert len(store.list_keys(workspace_id)) == 1
+    assert winners[0].api_key.management is False
+    durable_json = json.dumps([row.body for row in database.rows.values()])
+    assert raw_code not in durable_json
+    assert winners[0].raw_key not in durable_json
+
+
+def test_spanner_partial_key_write_failure_rolls_back_every_row() -> None:
+    store, database, _bigtable = make_fake_store()
+    raw_code, verifier, workspace_id = _grant(store)
+    original_io = store.oauth_code_store._io  # noqa: SLF001
+
+    def fail_after_key_write(
+        transaction: Any,
+        kind: str,
+        entity_id: str,
+        value: Any,
+    ) -> None:
+        if kind == "api_key_lookup":
+            raise RuntimeError("Spanner write unavailable")
+        original_io.write_entity_tx(transaction, kind, entity_id, value)
+
+    store.oauth_code_store._io = replace(  # noqa: SLF001
+        original_io,
+        write_entity_tx=fail_after_key_write,
+    )
+    with pytest.raises(RuntimeError, match="Spanner write unavailable"):
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=verifier,
+            code_challenge_method="S256",
+        )
+
+    assert not any(kind == "api_key" for kind, _entity_id in database.rows)
+    assert not any(kind == "api_key_lookup" for kind, _entity_id in database.rows)
+    assert not any(kind == "api_key_by_workspace" for kind, _entity_id in database.rows)
+    assert database.typed.get("tr_key_limit", {}) == {}
+    stored_code = next(
+        row for (kind, _entity_id), row in database.rows.items() if kind == "oauth_code"
+    )
+    assert json.loads(stored_code.body).get("consumed_at") is None
+
+    store.oauth_code_store._io = original_io  # noqa: SLF001
+    retry = store.exchange_oauth_authorization_code(
+        raw_code,
+        code_verifier=verifier,
+        code_challenge_method="S256",
+    )
+    assert retry is not None
+    assert len(store.list_keys(workspace_id)) == 1
+    assert len(database.typed["tr_key_limit"]) == 1
+
+
+def test_spanner_paused_workspace_keeps_grant_retryable() -> None:
+    store, database, _bigtable = make_fake_store()
+    raw_code, verifier, workspace_id = _grant(store)
+    store.update_workspace(workspace_id, billing_paused=True)
+
+    with pytest.raises(OAuthWorkspaceBillingPaused):
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=verifier,
+            code_challenge_method="S256",
+        )
+
+    assert not any(kind == "api_key" for kind, _entity_id in database.rows)
+    assert database.typed.get("tr_key_limit", {}) == {}
+    store.update_workspace(workspace_id, billing_paused=False)
+    assert (
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=verifier,
+            code_challenge_method="S256",
+        )
+        is not None
+    )
+
+
+def test_spanner_missing_workspace_keeps_grant_retryable() -> None:
+    store, database, _bigtable = make_fake_store()
+    raw_code, verifier, workspace_id = _grant(store)
+    workspace = store.get_workspace(workspace_id)
+    assert workspace is not None
+    store._delete_entities("workspace", [workspace_id])  # noqa: SLF001
+
+    with pytest.raises(OAuthWorkspaceUnavailable):
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=verifier,
+            code_challenge_method="S256",
+        )
+
+    stored_code = next(
+        row for (kind, _entity_id), row in database.rows.items() if kind == "oauth_code"
+    )
+    assert json.loads(stored_code.body).get("consumed_at") is None
+    assert not any(kind == "api_key" for kind, _entity_id in database.rows)
+    store._write_entity("workspace", workspace_id, workspace)  # noqa: SLF001
+    assert (
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=verifier,
+            code_challenge_method="S256",
+        )
+        is not None
+    )
+
+
+def test_spanner_missing_credit_configuration_keeps_grant_retryable() -> None:
+    store, database, _bigtable = make_fake_store()
+    raw_code, verifier, workspace_id = _grant(store, limit_microdollars=None)
+    credit = store.get_credit_account(workspace_id)
+    assert credit is not None
+    store._delete_entities("credit", [workspace_id])  # noqa: SLF001
+
+    with pytest.raises(OAuthWorkspaceUnavailable):
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=verifier,
+            code_challenge_method="S256",
+        )
+
+    stored_code = next(
+        row for (kind, _entity_id), row in database.rows.items() if kind == "oauth_code"
+    )
+    assert json.loads(stored_code.body).get("consumed_at") is None
+    assert not any(kind == "api_key" for kind, _entity_id in database.rows)
+    store._write_entity("credit", workspace_id, credit)  # noqa: SLF001
+    assert (
+        store.exchange_oauth_authorization_code(
+            raw_code,
+            code_verifier=verifier,
+            code_challenge_method="S256",
+        )
+        is not None
+    )
+
+
+def test_spanner_uncapped_oauth_key_preserves_create_api_key_sharding() -> None:
+    store, database, _bigtable = make_fake_store()
+    raw_code, verifier, workspace_id = _grant(store, limit_microdollars=None)
+    _set_credit_shards(store, workspace_id, 8)
+    store._credit_shard_counts.invalidate(workspace_id)  # noqa: SLF001
+
+    _baseline_raw, baseline = store.create_api_key(
+        workspace_id=workspace_id,
+        name="pre-atomic semantics",
+        creator_user_id=None,
+    )
+    exchange = store.exchange_oauth_authorization_code(
+        raw_code,
+        code_verifier=verifier,
+        code_challenge_method="S256",
+    )
+
+    assert baseline.usage_shard_count == 8
+    assert exchange is not None
+    assert exchange.api_key.usage_shard_count == baseline.usage_shard_count
+    assert {
+        shard
+        for key_hash, shard in database.typed[KEY_LIMIT_TABLE]
+        if key_hash == exchange.api_key.hash
+    } == set(range(8))
+
+
+def test_spanner_oauth_shard_selection_retries_concurrent_reshard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, database, _bigtable = make_fake_store()
+    raw_code, verifier, workspace_id = _grant(store, limit_microdollars=None)
+    _set_credit_shards(store, workspace_id, 4)
+    entered = threading.Event()
+    resume = threading.Event()
+    observed_counts: list[int] = []
+    original = storage_gcp_oauth_codes.new_oauth_delegated_api_key
+
+    def pause_first_build(code, *, usage_shard_count: int = 1):
+        observed_counts.append(usage_shard_count)
+        if len(observed_counts) == 1:
+            entered.set()
+            assert resume.wait(timeout=10)
+        return original(code, usage_shard_count=usage_shard_count)
+
+    monkeypatch.setattr(
+        storage_gcp_oauth_codes,
+        "new_oauth_delegated_api_key",
+        pause_first_build,
+    )
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(
+            store.exchange_oauth_authorization_code,
+            raw_code,
+            code_verifier=verifier,
+            code_challenge_method="S256",
+        )
+        assert entered.wait(timeout=10)
+        _set_credit_shards(store, workspace_id, 8)
+        resume.set()
+        exchange = future.result(timeout=10)
+
+    assert database.aborts >= 1
+    assert observed_counts[0] == 4
+    assert observed_counts[-1] == 8
+    assert exchange is not None
+    assert exchange.api_key.usage_shard_count == 8
+    assert {
+        shard
+        for key_hash, shard in database.typed[KEY_LIMIT_TABLE]
+        if key_hash == exchange.api_key.hash
+    } == set(range(8))

--- a/tests/test_stubs_and_security.py
+++ b/tests/test_stubs_and_security.py
@@ -512,10 +512,12 @@ def test_production_dashboard_does_not_default_to_dev_user_header() -> None:
         Settings(
             **TEST_SES_SETTINGS,
             environment="production",
-            service_surface="control",
+            service_surface="console",
             attribution_cookie_secret="attribution-cookie-" + "a" * 32,
-            stripe_webhook_secret="whsec_test",  # noqa: S106
             stripe_secret_key="sk_test",  # noqa: S106
+            google_oauth_login_available=False,
+            github_oauth_login_available=False,
+            paypal_checkout_enabled=False,
             sentry_dsn="https://example@example.ingest.sentry.io/1",
             storage_backend="spanner-bigtable",
             spanner_instance_id="trusted-router",
@@ -961,10 +963,12 @@ def test_production_config_fails_closed() -> None:
 def test_production_config_requires_ses_delivery_credentials() -> None:
     values = {
         "environment": "production",
-        "service_surface": "control",
+        "service_surface": "console",
         "attribution_cookie_secret": "attribution-cookie-" + "a" * 32,
-        "stripe_webhook_secret": "whsec_" + "test",
         "stripe_secret_key": "sk_" + "test_secret",
+        "google_oauth_login_available": False,
+        "github_oauth_login_available": False,
+        "paypal_checkout_enabled": False,
         "sentry_dsn": "https://example@example.ingest.sentry.io/1",
         "storage_backend": "spanner-bigtable",
         "spanner_instance_id": "trusted-router",
@@ -991,10 +995,12 @@ def test_production_config_requires_ses_delivery_credentials() -> None:
 def test_production_spanner_clickhouse_config_is_explicit_and_bigtable_free() -> None:
     values = {
         "environment": "production",
-        "service_surface": "control",
+        "service_surface": "console",
         "attribution_cookie_secret": "attribution-cookie-" + "a" * 32,
-        "stripe_webhook_secret": "whsec_" + "test",
         "stripe_secret_key": "sk_" + "test_secret",
+        "google_oauth_login_available": False,
+        "github_oauth_login_available": False,
+        "paypal_checkout_enabled": False,
         "sentry_dsn": "https://example@example.ingest.sentry.io/1",
         "storage_backend": "spanner-clickhouse",
         "spanner_instance_id": "trusted-router",
@@ -1023,17 +1029,18 @@ def test_production_spanner_clickhouse_config_is_explicit_and_bigtable_free() ->
 
 
 def test_production_control_plane_does_not_register_inference_routes() -> None:
-    webhook_secret = "whsec_" + "test"
     stripe_key = "sk_" + "test_secret"
     sentry_dsn = "https://example@example.ingest.sentry.io/1"
     prod_app = create_app(
         Settings(
             **TEST_SES_SETTINGS,
             environment="production",
-            service_surface="control",
+            service_surface="console",
             attribution_cookie_secret="attribution-cookie-" + "a" * 32,
-            stripe_webhook_secret=webhook_secret,
             stripe_secret_key=stripe_key,
+            google_oauth_login_available=False,
+            github_oauth_login_available=False,
+            paypal_checkout_enabled=False,
             sentry_dsn=sentry_dsn,
             storage_backend="spanner-bigtable",
             spanner_instance_id="trusted-router",

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -2943,7 +2943,7 @@ def test_synthetic_deploy_targets_public_api_and_private_internal_ingest() -> No
     assert '"TR_SERVICE_SURFACE=observer"' in body
     assert '"TR_SERVICE_SURFACE=internal"' not in body
     assert (
-        '"TR_OBSERVER_INTERNAL_TOKEN=trustedrouter-observer-internal-token:latest"'
+        '"TR_OBSERVER_INTERNAL_TOKEN=trustedrouter-observer-internal-token:${OBSERVER_SECRET_VERSION}"'
         in body
     )
     assert '"TR_INTERNAL_GATEWAY_TOKEN=' not in body

--- a/tests/test_telephony_service.py
+++ b/tests/test_telephony_service.py
@@ -226,14 +226,16 @@ class TestTelnyxVoiceRequestShape:
         service = telephony.TelephonyService(
             _settings(
                 environment="production",
-                service_surface="control",
+                service_surface="console",
                 attribution_cookie_secret="a" * 32,
                 api_base_url="https://api.trustedrouter.com/v1",
                 trusted_domain="trustedrouter.com",
                 telnyx_texml_account_id="acct-1",
                 telnyx_texml_application_id="app-1",
-                stripe_webhook_secret="whsec_test",  # noqa: S106 - test config.
                 stripe_secret_key="sk_test",  # noqa: S106 - test config.
+                google_oauth_login_available=False,
+                github_oauth_login_available=False,
+                paypal_checkout_enabled=False,
                 sentry_dsn="https://example@example.ingest.sentry.io/1",
                 aws_access_key_id="test-access-key",
                 aws_secret_access_key="test-secret-key",  # noqa: S106 - test config.

--- a/tests/test_user_model_clock_admission.py
+++ b/tests/test_user_model_clock_admission.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import socket
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from trusted_router.routes import user_models as user_model_routes
+from trusted_router.services.user_model_probe import ProbeResult
+from trusted_router.storage import InMemoryStore
+
+_OWNER_HEADERS = {"x-trustedrouter-user": "clock-boundary-owner@example.com"}
+
+
+def _route_admission(
+    *,
+    max_in_flight: int = 16,
+    max_per_window: int = 100,
+    window_seconds: float = 60.0,
+) -> user_model_routes._ClockRouteAdmission:
+    return user_model_routes._ClockRouteAdmission(
+        max_in_flight=max_in_flight,
+        max_per_window=max_per_window,
+        window_seconds=window_seconds,
+    )
+
+
+def _probe_admission(
+    *,
+    max_in_flight: int = 2,
+    cadence_seconds: float = 0.0,
+) -> user_model_routes._ClockProbeAdmission:
+    return user_model_routes._ClockProbeAdmission(
+        max_in_flight=max_in_flight,
+        cadence_seconds=cadence_seconds,
+        stripes=256,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _fresh_clock_admission(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Process-wide production gates are deliberately stateful. Give each test
+    # a fresh equivalent so one test's cadence cannot leak into another.
+    monkeypatch.setattr(
+        user_model_routes,
+        "_CLOCK_ROUTE_ADMISSION",
+        _route_admission(
+            max_in_flight=user_model_routes._CLOCK_ROUTE_MAX_IN_FLIGHT,
+            max_per_window=user_model_routes._CLOCK_ROUTE_MAX_LOOKUPS_PER_WINDOW,
+            window_seconds=user_model_routes._CLOCK_ROUTE_WINDOW_SECONDS,
+        ),
+    )
+    monkeypatch.setattr(
+        user_model_routes,
+        "_CLOCK_PROBE_ADMISSION",
+        _probe_admission(
+            max_in_flight=user_model_routes._CLOCK_PROBE_MAX_IN_FLIGHT,
+            cadence_seconds=user_model_routes._CLOCK_PROBE_CADENCE_SECONDS,
+        ),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _public_dns(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("8.8.8.8", 0))
+        ],
+    )
+
+
+def _create_model(client: TestClient, slug: str) -> dict[str, Any]:
+    response = client.post(
+        "/v1/user-models",
+        headers=_OWNER_HEADERS,
+        json={
+            "name": f"Clock model {slug}",
+            "slug": slug,
+            "kind": "machine",
+            "display_name": slug,
+            "endpoint_url": "https://owner.example/v1",
+            "upstream_model_id": "owner-model",
+            "supports_streaming": False,
+            "heartbeat_interval_seconds": 30,
+            "max_concurrency": 1,
+            "prompt_price_microdollars_per_million_tokens": 100,
+            "completion_price_microdollars_per_million_tokens": 200,
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["data"]
+
+
+def _clock_signature(secret: str, body: bytes = b"") -> str:
+    timestamp = int(time.time())
+    digest = hmac.new(
+        secret.encode("utf-8"),
+        str(timestamp).encode("ascii") + b"." + body,
+        hashlib.sha256,
+    ).hexdigest()
+    return f"t={timestamp},v1={digest}"
+
+
+def test_malformed_model_ids_are_rejected_before_the_store_lookup(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original = InMemoryStore.get_user_model
+    reads = 0
+
+    def tracked(self: InMemoryStore, model_id: str) -> Any:
+        nonlocal reads
+        reads += 1
+        return original(self, model_id)
+
+    monkeypatch.setattr(InMemoryStore, "get_user_model", tracked)
+    malformed = (
+        "not-a-user-model",
+        "trustedrouter/not-user-model",
+        "trustedrouter/user-ab",
+        "trustedrouter/user-bad_slug",
+        f"trustedrouter/user-{'x' * 65}",
+    )
+
+    for model_id in malformed:
+        response = client.post(f"/v1/user-models/{model_id}/heartbeat")
+        assert response.status_code == 404, (model_id, response.text)
+
+    assert reads == 0
+
+
+def test_random_valid_misses_have_a_process_wide_pre_store_budget(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # One slot also makes this sensitive to a missing finally-release: all five
+    # admitted misses must reach Store even though authentication then raises.
+    monkeypatch.setattr(
+        user_model_routes,
+        "_CLOCK_ROUTE_ADMISSION",
+        _route_admission(max_in_flight=1, max_per_window=5),
+    )
+    original = InMemoryStore.get_user_model
+    reads = 0
+
+    def tracked(self: InMemoryStore, model_id: str) -> Any:
+        nonlocal reads
+        reads += 1
+        return original(self, model_id)
+
+    monkeypatch.setattr(InMemoryStore, "get_user_model", tracked)
+    responses = [
+        client.post(f"/v1/user-models/trustedrouter/user-miss-{index:02d}/heartbeat")
+        for index in range(12)
+    ]
+
+    assert reads == 5
+    assert sum(response.status_code == 401 for response in responses) == 5
+    rejected = [response for response in responses if response.status_code == 429]
+    assert len(rejected) == 7
+    assert all(response.headers["retry-after"] == "60" for response in rejected)
+
+
+def test_signed_and_management_clock_flows_remain_compatible(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def passing_probe(*_args: Any, **_kwargs: Any) -> ProbeResult:
+        return ProbeResult(ok=True, detail="ok")
+
+    monkeypatch.setattr(user_model_routes, "probe_user_model", passing_probe)
+    model = _create_model(client, "clock-compatible")
+    signed = {"TR-Signature": _clock_signature(model["signing_secret"])}
+
+    clocked_in = client.post(
+        f"/v1/user-models/{model['id']}/clock-in",
+        headers=signed,
+    )
+    # Preserve the established `user-<slug>` management alias as well as the
+    # canonical id returned to signed owners.
+    heartbeat = client.post(
+        "/v1/user-models/user-clock-compatible/heartbeat",
+        headers=_OWNER_HEADERS,
+    )
+    clocked_out = client.post(
+        f"/v1/user-models/{model['id']}/clock-out",
+        headers={"TR-Signature": _clock_signature(model["signing_secret"])},
+    )
+
+    assert clocked_in.status_code == 200, clocked_in.text
+    assert clocked_in.json()["data"]["online"] is True
+    assert heartbeat.status_code == 200, heartbeat.text
+    assert heartbeat.json()["data"]["heartbeat_expires_at"]
+    assert clocked_out.status_code == 200, clocked_out.text
+    assert clocked_out.json()["data"]["online"] is False
+
+
+def test_clock_in_rejects_overlap_and_then_enforces_post_probe_cadence(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(user_model_routes, "_CLOCK_ROUTE_ADMISSION", _route_admission())
+    monkeypatch.setattr(
+        user_model_routes,
+        "_CLOCK_PROBE_ADMISSION",
+        _probe_admission(max_in_flight=2, cadence_seconds=60.0),
+    )
+    model = _create_model(client, "clock-overlap")
+    started = threading.Event()
+    release = threading.Event()
+    calls = 0
+
+    async def blocking_probe(*_args: Any, **_kwargs: Any) -> ProbeResult:
+        nonlocal calls
+        calls += 1
+        started.set()
+        await asyncio.to_thread(release.wait)
+        return ProbeResult(ok=True, detail="ok")
+
+    monkeypatch.setattr(user_model_routes, "probe_user_model", blocking_probe)
+    path = f"/v1/user-models/{model['id']}/clock-in"
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(client.post, path, headers=_OWNER_HEADERS)
+        assert started.wait(timeout=2)
+        try:
+            overlap = client.post(path, headers=_OWNER_HEADERS)
+        finally:
+            release.set()
+        completed = first.result(timeout=2)
+
+    cadence = client.post(path, headers=_OWNER_HEADERS)
+    assert completed.status_code == 200, completed.text
+    for rejected in (overlap, cadence):
+        assert rejected.status_code == 429, rejected.text
+        assert int(rejected.headers["retry-after"]) >= 1
+    assert calls == 1
+
+
+def test_clock_in_global_probe_cap_releases_for_the_next_model(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(user_model_routes, "_CLOCK_ROUTE_ADMISSION", _route_admission())
+    monkeypatch.setattr(
+        user_model_routes,
+        "_CLOCK_PROBE_ADMISSION",
+        _probe_admission(max_in_flight=1),
+    )
+    first_model = _create_model(client, "clock-global-one")
+    second_model = _create_model(client, "clock-global-two")
+
+    def distinct_model_stripes(value: str, _stripe_count: int) -> int:
+        return 0 if first_model["id"] in value else 1
+
+    # Make the two model locks provably distinct: the rejection below must
+    # come from the global slot, not an accidental hash-stripe collision.
+    monkeypatch.setattr(user_model_routes, "_clock_stripe", distinct_model_stripes)
+    started = threading.Event()
+    release = threading.Event()
+    calls: list[str] = []
+
+    async def blocking_probe(model: Any, *_args: Any, **_kwargs: Any) -> ProbeResult:
+        calls.append(model.id)
+        if model.id == first_model["id"]:
+            started.set()
+            await asyncio.to_thread(release.wait)
+        return ProbeResult(ok=True, detail="ok")
+
+    monkeypatch.setattr(user_model_routes, "probe_user_model", blocking_probe)
+    first_path = f"/v1/user-models/{first_model['id']}/clock-in"
+    second_path = f"/v1/user-models/{second_model['id']}/clock-in"
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(client.post, first_path, headers=_OWNER_HEADERS)
+        assert started.wait(timeout=2)
+        try:
+            capped = client.post(second_path, headers=_OWNER_HEADERS)
+        finally:
+            release.set()
+        completed = first.result(timeout=2)
+
+    admitted_after_release = client.post(second_path, headers=_OWNER_HEADERS)
+    assert completed.status_code == 200, completed.text
+    assert capped.status_code == 429, capped.text
+    assert capped.headers["retry-after"] == "1"
+    assert admitted_after_release.status_code == 200, admitted_after_release.text
+    assert calls == [first_model["id"], second_model["id"]]
+
+
+@pytest.mark.asyncio
+async def test_slow_heartbeat_store_write_does_not_block_the_event_loop(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(user_model_routes, "_CLOCK_ROUTE_ADMISSION", _route_admission())
+    model = _create_model(client, "clock-off-loop")
+    original = InMemoryStore.record_user_model_heartbeat
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_record(
+        self: InMemoryStore,
+        model_id: str,
+        *,
+        expires_at: str,
+    ) -> Any:
+        started.set()
+        assert release.wait(timeout=2)
+        return original(self, model_id, expires_at=expires_at)
+
+    monkeypatch.setattr(InMemoryStore, "record_user_model_heartbeat", blocking_record)
+    transport = httpx.ASGITransport(app=client.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as async_client:
+        request = asyncio.create_task(
+            async_client.post(
+                f"/v1/user-models/{model['id']}/heartbeat",
+                headers=_OWNER_HEADERS,
+            )
+        )
+        assert await asyncio.to_thread(started.wait, 2)
+        ticks = 0
+        for _ in range(5):
+            await asyncio.sleep(0.01)
+            ticks += 1
+        release.set()
+        response = await request
+
+    assert ticks == 5
+    assert response.status_code == 200, response.text

--- a/tests/test_user_models.py
+++ b/tests/test_user_models.py
@@ -1213,11 +1213,13 @@ def test_earnings_console_renders_and_transfers_with_idempotent_flash(
 def test_https_is_required_outside_local_and_test() -> None:
     settings = Settings(
         environment="staging",
-        service_surface="control",
+        service_surface="console",
         custom_models_require_verification=False,
         attribution_cookie_secret="staging-attribution-" + "a" * 32,
-        stripe_webhook_secret="whsec_staging",  # noqa: S106 - test fixture.
         stripe_secret_key="sk_staging",  # noqa: S106 - test fixture.
+        google_oauth_login_available=False,
+        github_oauth_login_available=False,
+        paypal_checkout_enabled=False,
     )
     client = TestClient(create_app(settings, init_observability=False))
     user = STORE.ensure_user("staging-owner@example.com")

--- a/tests/test_webhook_event_loop_isolation.py
+++ b/tests/test_webhook_event_loop_isolation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import threading
 from collections.abc import Awaitable, Callable
 
@@ -10,6 +11,7 @@ from fastapi.testclient import TestClient
 from trusted_router.config import Settings
 from trusted_router.main import create_app
 from trusted_router.services.paypal_billing import verify_paypal_webhook_signature
+from trusted_router.storage import InMemoryStore
 
 
 def _loop_thread_client(settings: Settings) -> tuple[TestClient, list[str]]:
@@ -39,6 +41,39 @@ def test_deployed_paypal_webhook_fails_closed_without_webhook_id() -> None:
         verify_paypal_webhook_signature(headers={}, event={}, settings=settings)
 
     assert captured.value.status_code == 400
+
+
+def test_disabled_checkout_still_verifies_late_paypal_webhooks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    outbound_calls = 0
+
+    def accepted(*_args: object, **_kwargs: object) -> dict[str, str]:
+        nonlocal outbound_calls
+        outbound_calls += 1
+        return {"verification_status": "SUCCESS"}
+
+    monkeypatch.setattr("trusted_router.services.paypal_billing._paypal_post", accepted)
+    settings = Settings(
+        environment="test",
+        paypal_checkout_enabled=False,
+        paypal_client_id="paypal-client",
+        paypal_client_secret="paypal-secret",  # noqa: S106
+        paypal_webhook_id="WEBHOOKID",
+    )
+    headers = {
+        "paypal-transmission-id": "transmission-id",
+        "paypal-transmission-time": "2026-08-19T00:00:00Z",
+        "paypal-cert-url": "https://api-m.paypal.com/v1/notifications/certs/CERT-1",
+        "paypal-auth-algo": "SHA256withRSA",
+        "paypal-transmission-sig": "signature",
+    }
+
+    verify_paypal_webhook_signature(headers=headers, event={"id": "WH-LATE"}, settings=settings)
+
+    assert settings.paypal_checkout_ready is False
+    assert settings.paypal_webhook_ready is True
+    assert outbound_calls == 1
 
 
 def test_paypal_webhook_verification_runs_off_the_event_loop(
@@ -101,6 +136,209 @@ def test_sns_certificate_verification_runs_off_the_event_loop(
     assert verification_threads[0] != loop_threads[0]
 
 
+def test_ses_feedback_and_message_claim_run_off_the_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, loop_thread = _loop_thread_client(Settings(environment="test"))
+    feedback_threads: list[str] = []
+    claim_threads: list[str] = []
+    original_block = InMemoryStore.block_email_sending
+    original_claim = InMemoryStore.record_sns_message_once
+
+    def verified(_envelope: dict[str, object]) -> None:
+        return None
+
+    def block(self: InMemoryStore, **kwargs: object) -> object:
+        feedback_threads.append(str(threading.get_ident()))
+        return original_block(self, **kwargs)  # type: ignore[arg-type]
+
+    def claim(self: InMemoryStore, message_id: str) -> bool:
+        claim_threads.append(str(threading.get_ident()))
+        return original_claim(self, message_id)
+
+    monkeypatch.setattr(
+        "trusted_router.routes.ses_notifications.verify_sns_message",
+        verified,
+    )
+    monkeypatch.setattr(InMemoryStore, "block_email_sending", block)
+    monkeypatch.setattr(InMemoryStore, "record_sns_message_once", claim)
+
+    response = client.post(
+        "/v1/internal/ses/notifications",
+        json={
+            "Type": "Notification",
+            "MessageId": "feedback-thread-check",
+            "Message": json.dumps(
+                {
+                    "notificationType": "Bounce",
+                    "bounce": {
+                        "bounceType": "Permanent",
+                        "bouncedRecipients": [{"emailAddress": "thread@example.com"}],
+                    },
+                }
+            ),
+        },
+    )
+
+    assert response.status_code == 200
+    assert feedback_threads and feedback_threads[0] != loop_thread
+    assert claim_threads and claim_threads[0] != loop_thread
+
+
+@pytest.mark.parametrize(
+    ("kind", "container_name", "recipient_name"),
+    (
+        ("Bounce", "bounce", "bouncedRecipients"),
+        ("Complaint", "complaint", "complainedRecipients"),
+    ),
+)
+def test_ses_feedback_recipient_cap_rejects_cap_plus_one_before_store_work(
+    monkeypatch: pytest.MonkeyPatch,
+    kind: str,
+    container_name: str,
+    recipient_name: str,
+) -> None:
+    from trusted_router.routes.ses_notifications import SES_FEEDBACK_MAX_RECIPIENTS
+
+    client, _loop_thread = _loop_thread_client(Settings(environment="test"))
+    store_calls = 0
+
+    def verified(_envelope: dict[str, object]) -> None:
+        return None
+
+    def forbidden(*_args: object, **_kwargs: object) -> object:
+        nonlocal store_calls
+        store_calls += 1
+        raise AssertionError("over-limit SES feedback reached Store")
+
+    monkeypatch.setattr(
+        "trusted_router.routes.ses_notifications.verify_sns_message",
+        verified,
+    )
+    monkeypatch.setattr(InMemoryStore, "block_email_sending", forbidden)
+    monkeypatch.setattr(InMemoryStore, "record_sns_message_once", forbidden)
+
+    recipients = [
+        {"emailAddress": f"recipient-{index}@example.com"}
+        for index in range(SES_FEEDBACK_MAX_RECIPIENTS + 1)
+    ]
+    response = client.post(
+        "/v1/internal/ses/notifications",
+        json={
+            "Type": "Notification",
+            "MessageId": f"recipient-cap-{kind.lower()}",
+            "Message": json.dumps(
+                {
+                    "notificationType": kind,
+                    container_name: {recipient_name: recipients},
+                }
+            ),
+        },
+    )
+
+    assert response.status_code == 400
+    assert str(SES_FEEDBACK_MAX_RECIPIENTS) in response.text
+    assert store_calls == 0
+
+
+@pytest.mark.parametrize(
+    ("kind", "container_name", "recipient_name"),
+    (
+        ("Bounce", "bounce", "bouncedRecipients"),
+        ("Complaint", "complaint", "complainedRecipients"),
+    ),
+)
+def test_ses_feedback_recipient_cap_accepts_exactly_the_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    kind: str,
+    container_name: str,
+    recipient_name: str,
+) -> None:
+    from trusted_router.routes.ses_notifications import SES_FEEDBACK_MAX_RECIPIENTS
+
+    client, _loop_thread = _loop_thread_client(Settings(environment="test"))
+
+    def verified(_envelope: dict[str, object]) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "trusted_router.routes.ses_notifications.verify_sns_message",
+        verified,
+    )
+    recipients = [
+        {"emailAddress": f"at-cap-{kind.lower()}-{index}@example.com"}
+        for index in range(SES_FEEDBACK_MAX_RECIPIENTS)
+    ]
+    response = client.post(
+        "/v1/internal/ses/notifications",
+        json={
+            "Type": "Notification",
+            "MessageId": f"recipient-at-cap-{kind.lower()}",
+            "Message": json.dumps(
+                {
+                    "notificationType": kind,
+                    container_name: {
+                        "bounceType": "Permanent",
+                        recipient_name: recipients,
+                    },
+                }
+            ),
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"]["blocked_count"] == SES_FEEDBACK_MAX_RECIPIENTS
+
+
+def test_ses_provider_concurrency_ceiling_refuses_before_verification_or_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trusted_router.routes.internal import webhook_work
+
+    client, _loop_thread = _loop_thread_client(Settings(environment="test"))
+    verification_calls = 0
+    store_calls = 0
+
+    def forbidden_verification(_envelope: dict[str, object]) -> None:
+        nonlocal verification_calls
+        verification_calls += 1
+        raise AssertionError("capacity-denied SES message reached verification")
+
+    def forbidden_store(*_args: object, **_kwargs: object) -> object:
+        nonlocal store_calls
+        store_calls += 1
+        raise AssertionError("capacity-denied SES message reached Store")
+
+    monkeypatch.setattr(
+        "trusted_router.routes.ses_notifications.verify_sns_message",
+        forbidden_verification,
+    )
+    monkeypatch.setattr(InMemoryStore, "block_email_sending", forbidden_store)
+    monkeypatch.setattr(InMemoryStore, "record_sns_message_once", forbidden_store)
+
+    slot = webhook_work._PROVIDER_SLOTS["ses"]
+    acquired = 0
+    try:
+        for _ in range(webhook_work.WEBHOOK_MAX_BLOCKING_TASKS_PER_PROVIDER):
+            assert slot.acquire(blocking=False)
+            acquired += 1
+        response = client.post(
+            "/v1/internal/ses/notifications",
+            json={
+                "Type": "Notification",
+                "MessageId": "provider-capacity",
+                "Message": "{}",
+            },
+        )
+        assert response.status_code == 503
+        assert response.headers["retry-after"] == "1"
+        assert verification_calls == 0
+        assert store_calls == 0
+    finally:
+        for _ in range(acquired):
+            slot.release()
+
+
 @pytest.mark.parametrize(
     "headers",
     [
@@ -135,7 +373,7 @@ def test_paypal_forged_headers_are_rejected_before_outbound_verification(
     monkeypatch.setattr("trusted_router.services.paypal_billing._paypal_post", forbidden)
     settings = Settings(
         environment="test",
-        paypal_enabled=True,
+        paypal_checkout_enabled=True,
         paypal_client_id="paypal-client",
         paypal_client_secret="paypal-secret",  # noqa: S106
         paypal_webhook_id="WEBHOOKID",
@@ -164,7 +402,7 @@ def test_paypal_webhook_postback_has_a_process_wide_cost_ceiling(
     paypal._PAYPAL_WEBHOOK_VERIFY_LIMITER.reset()
     settings = Settings(
         environment="test",
-        paypal_enabled=True,
+        paypal_checkout_enabled=True,
         paypal_client_id="paypal-client",
         paypal_client_secret="paypal-secret",  # noqa: S106
         paypal_webhook_id="WEBHOOKID",
@@ -214,7 +452,7 @@ def test_paypal_webhook_concurrency_ceiling_refuses_before_outbound(
     paypal._PAYPAL_WEBHOOK_VERIFY_LIMITER.reset()
     settings = Settings(
         environment="test",
-        paypal_enabled=True,
+        paypal_checkout_enabled=True,
         paypal_client_id="paypal-client",
         paypal_client_secret="paypal-secret",  # noqa: S106
         paypal_webhook_id="WEBHOOKID",

--- a/tests/test_zero_g_provider.py
+++ b/tests/test_zero_g_provider.py
@@ -449,13 +449,13 @@ def test_zero_g_hourly_refresh_and_optional_secret_wiring_are_complete() -> None
         '"trustedrouter-zero-g-api-key"'
     ) in secrets
     assert (
-        'grant_tr_deploy_secret_access "trustedrouter-zero-g-api-key"'
-        in secrets
+        "trustedrouter-zero-g-api-key"
+        in secrets.split("DETACHED_PROVIDER_SECRET_NAMES=(", 1)[1].split(")", 1)[0]
     )
     assert (
-        'add_secret_env_if_exists "ZERO_G_API_KEY" '
-        '"trustedrouter-zero-g-api-key"'
-    ) in rollout
+        "trustedrouter-zero-g-api-key"
+        in rollout.split("KNOWN_OPTIONAL_RUNTIME_SECRETS=(", 1)[1].split(")", 1)[0]
+    )
     assert "Pull optional 0G Private Computer key" in workflow
     assert "ZERO_G_API_KEY=${KEY}" in workflow
 


### PR DESCRIPTION
The six-surface split as one PR. Supersedes #730 (app split + atomic OAuth), #713 (exact edge/IAM contracts), and #712 (journaled rollout/recovery/cutover): those three were only consistent as a whole — PR2's six-surface test server depends on the URL-map surface rename that lived in PR4, so #730 alone failed 47 tests on its first CI run. Authored by codex; reviewed, rebased, and hardened by Fable. Base: `main` (after #732's bridge and one deploy of it).

## What lands
- **Surfaces**: public / actions / console / chat-proxy / webhooks / internal as separate processes with fail-closed roles, per-surface body caps, worker budgets, and secret sets; OAuth code exchange is one transaction.
- **Edge and IAM as reviewed artifacts**: per-surface Cloud Armor policies imported as full replacements (verifier rejects supersets); six runtime identities with exact per-secret and per-role grants; read-only `rollout_iam_verify.sh` fails closed on any grant outside the contract.
- **Cutover machinery**: journaled, CAS-committed, resumable stage/promote/rollback; the cutover is one atomic URL-map import with the legacy monolith untouched as the rollback target; recovery bundle under a single conditional IAM binding; mandatory authenticated browser smoke at every promote phase.
- Removes #732's temporary combined-surface bridge (`TR_ALLOW_DEPLOYED_COMBINED_SURFACE`) as the split's own cleanup.

## Known work tracked inside this PR before it leaves draft
- `rollout.sh` rebased over today's five regional-quota PRs (codex-resolved; harness-verified)
- deploy.yml: job-level `${{ runner.temp }}` (GitHub cannot parse the file) → step-scoped
- `infra.sh`: create→describe propagation retry (done, `53c4ab9b`); deploy-identity audit must allow the legacy runtime identity while `TR_RETIRE_LEGACY_RUN_SERVICE_ACCOUNT_IAM=0`; `RUN_SERVICE_ACCOUNT` must name `trusted-router-control-run@` explicitly
- Three rollout state-machine tests: promote-before-executable-smoke message precedence; mid-cohort rollback leaving `{0,10,50}`; provider-timeout fencing (timing-sensitive)
- `test_bootstrap_reads_legacy_monolith_without_new_console_dependency` at the rebased tip
- trust.trustedrouter.com stays enclave-owned (GitHub Pages); attestation accepts first-party CNAME chains (done, `ba967529`)

## Gate
Full suite + ruff + mypy in an isolated worktree, GitHub CI green, actionlint clean on every workflow file, codex adversarial pass on the final head. Merges only with the manual cutover window scheduled; the merge itself deploys nothing new (initial split is operator-driven).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
