### PR TITLE
Make missing regional ledger settlement retryable

### DIFF
--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -2970,7 +2970,11 @@ class SpannerBigtableStore:
     ) -> None:
         ledger = self._regional_quota_ledger
         if ledger is None:
-            raise RuntimeError("regional quota ledger is unavailable")
+            from trusted_router.regional_quota_ledger import (
+                RegionalLeaseLedgerError,
+            )
+
+            raise RegionalLeaseLedgerError("regional quota ledger is unavailable")
         lease_id = authorization.regional_lease_id
         fencing_token = authorization.regional_fencing_token
         hold_id = authorization.regional_hold_id

--- a/tests/test_regional_quota_spanner.py
+++ b/tests/test_regional_quota_spanner.py
@@ -7,7 +7,10 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from tests.fakes.spanner import make_fake_store
-from trusted_router.regional_quota_ledger import InMemoryRegionalQuotaLedger
+from trusted_router.regional_quota_ledger import (
+    InMemoryRegionalQuotaLedger,
+    RegionalLeaseLedgerError,
+)
 from trusted_router.services.settle_outbox_apply import ApplyOutcome, apply_frozen_settle
 from trusted_router.storage import configure_store
 from trusted_router.storage_gcp_authorize import settle_atomic
@@ -361,6 +364,34 @@ def test_store_regional_authorize_settle_replay_and_reconcile_end_to_end() -> No
         7_500,
         0,
     )
+
+
+def test_missing_regional_ledger_is_a_retryable_settlement_error() -> None:
+    store, _database, _ = make_fake_store(request_record_write_mode="typed")
+    authorization = GatewayAuthorization(
+        id="gwa-missing-regional-ledger",
+        workspace_id="ws-regional-ledger",
+        key_hash="key-hash",
+        model_id="model",
+        provider="provider",
+        usage_type=UsageType.CREDITS,
+        estimated_microdollars=10_000,
+        settlement="regional_lease",
+        regional_lease_id="lease-1",
+        regional_fencing_token=1,
+        regional_hold_id="gwa-missing-regional-ledger",
+        region="us-central1",
+    )
+
+    with pytest.raises(
+        RegionalLeaseLedgerError,
+        match="regional quota ledger is unavailable",
+    ):
+        store._finalize_regional_quota_hold(
+            authorization,
+            success=True,
+            actual_microdollars=7_500,
+        )
 
 
 def test_regional_authorize_does_not_escrow_for_unconfigured_region() -> None:


### PR DESCRIPTION
## Summary
- classify a missing regional quota ledger as a retryable ledger failure
- preserve the durable settle outbox instead of surfacing a raw 500
- add a regression test for the real storage adapter path

## Verification
- `uv run pytest -q tests/test_regional_quota_spanner.py tests/test_settle_outbox_drain.py -k regional`
- `uv run ruff check src/trusted_router/storage_gcp.py tests/test_regional_quota_spanner.py`
- `uv run mypy`