### PR TITLE
Keep ClickHouse ingestion live during deploys

### DIFF
--- a/scripts/deploy/clickhouse_operational_analytics.sh
+++ b/scripts/deploy/clickhouse_operational_analytics.sh
@@ -91,7 +91,17 @@ for index in 0 1 2; do
 done
 
 archive="$(mktemp "${TMPDIR:-/tmp}/tr-clickhouse-operational.XXXXXX.tar.gz")"
-trap 'rm -f "$archive"' EXIT
+ingester_stopped=0
+cleanup() {
+  local status="$?"
+  rm -f "$archive"
+  if [ "$ingester_stopped" -eq 1 ]; then
+    log "deployment exited during parser/schema cutover; restarting live ingest"
+    node_ssh 0 --command="sudo systemctl start tr-clickhouse-operational-ingest.service" || true
+  fi
+  return "$status"
+}
+trap cleanup EXIT
 tar -C "$ROOT" -czf "$archive" clickhouse src/trusted_router
 node_ssh 0 --command="sudo mkdir -p /opt/tr-clickhouse"
 node_ssh 0 --command="sudo tar -xzf - -C /opt/tr-clickhouse" <"$archive"
@@ -141,17 +151,24 @@ node_ssh 0 --command="sudo sh -c '
   install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-spanner-delivery.timer \
     /etc/systemd/system/tr-clickhouse-spanner-delivery.timer
   systemctl daemon-reload
-  systemctl stop tr-clickhouse-operational-ingest.service 2>/dev/null || true
 '"
 
-# Deploy the parser before the additive column. The ingester is stopped while
-# these two versions move together, so rows queue durably in Spanner instead
-# of being written with the column default during a version-skew window.
+# The running process retains its loaded parser while the new files are copied.
+# Pause only for the additive schema cutover, then restart on the new parser
+# before any bounded replay, backfill, replica sync, or reader setup begins.
+log "pausing live operational ingest for parser/schema cutover"
+node_ssh 0 --command="sudo systemctl stop tr-clickhouse-operational-ingest.service"
+ingester_stopped=1
+
 log "adding workspace attribution to benchmark samples"
 benchmark_workspace_schema="$(cat "$BENCHMARK_WORKSPACE_SCHEMA")"
 for index in 0 1 2; do
   node_query "$index" "$benchmark_workspace_schema"
 done
+
+log "resuming live operational ingest after parser/schema cutover"
+node_ssh 0 --command="sudo systemctl start tr-clickhouse-operational-ingest.service"
+ingester_stopped=0
 
 log "replaying bounded benchmark history with workspace attribution"
 node_ssh 0 --command="sudo sh -c '
@@ -242,7 +259,7 @@ for index in 0 1 2; do
     "${SCRIPT_DIR}/clickhouse_control_reader.sh"
 done
 
-node_ssh 0 --command="sudo systemctl start tr-clickhouse-operational-ingest.service"
+node_ssh 0 --command="sudo systemctl is-active --quiet tr-clickhouse-operational-ingest.service"
 node_ssh 0 --command="sudo systemctl start tr-clickhouse-synthetic-reconcile.timer tr-clickhouse-client-rollup.timer tr-clickhouse-public-snapshots.timer tr-clickhouse-public-snapshots.service tr-clickhouse-archive-restore.timer tr-clickhouse-spanner-delivery.timer tr-clickhouse-spanner-delivery.service"
 
 log "operational analytics infrastructure is ready; Bigtable is still authoritative"

--- a/tests/test_clickhouse_node_provisioning.py
+++ b/tests/test_clickhouse_node_provisioning.py
@@ -84,12 +84,12 @@ def test_operational_deploy_moves_benchmark_code_schema_and_replay_together() ->
     upload = script.index("sudo tar -xzf - -C /opt/tr-clickhouse")
     stop = script.index("systemctl stop tr-clickhouse-operational-ingest.service")
     migration = script.index('log "adding workspace attribution to benchmark samples"')
-    replay = script.index("clickhouse.backfill_benchmark_samples")
     restart = script.index(
-        "systemctl start tr-clickhouse-operational-ingest.service", replay
+        "systemctl start tr-clickhouse-operational-ingest.service", migration
     )
+    replay = script.index("clickhouse.backfill_benchmark_samples")
 
-    assert upload < stop < migration < replay < restart
+    assert upload < stop < migration < restart < replay
     assert "007_benchmark_samples_workspace_id.sql" in script
     assert "TR_CLICKHOUSE_BENCHMARK_WORKSPACE_BACKFILL_LIMIT" in script
 

--- a/tests/test_clickhouse_operational_deploy.py
+++ b/tests/test_clickhouse_operational_deploy.py
@@ -57,14 +57,26 @@ def test_provider_rollup_schema_replicates_all_published_granularities() -> None
         assert f"provider_analytics_{granularity}_replicated" in schema
 
 
-def test_operational_deploy_backfills_before_starting_live_ingest() -> None:
+def test_operational_deploy_resumes_live_ingest_before_backfills() -> None:
     script = (ROOT / "scripts/deploy/clickhouse_operational_analytics.sh").read_text()
-    backfill = script.index("clickhouse.backfill_operational_analytics --apply")
+    stop = script.index(
+        "systemctl stop tr-clickhouse-operational-ingest.service"
+    )
+    migration = script.index('log "adding workspace attribution to benchmark samples"')
     start = script.index(
         "systemctl start tr-clickhouse-operational-ingest.service",
-        backfill,
+        migration,
     )
-    assert backfill < start
+    replay = script.index("clickhouse.backfill_benchmark_samples")
+    backfill = script.index("clickhouse.backfill_operational_analytics --apply")
+    assert stop < migration < start < replay < backfill
+    paused_section = script[stop:start]
+    assert "backfill_" not in paused_section
+    assert "SYSTEM SYNC REPLICA" not in paused_section
+    assert "clickhouse_replicate_rollups.sh" not in paused_section
+    assert "trap cleanup EXIT" in script
+    assert 'if [ "$ingester_stopped" -eq 1 ]' in script
+    assert "deployment exited during parser/schema cutover" in script
     assert "SYSTEM SYNC REPLICA" in script
     assert "clickhouse_replicate_rollups.sh" in script
     assert "clickhouse_operational_analytics_finalize.sh --apply" in script


### PR DESCRIPTION
## Summary
- pause operational ingestion only for the parser/schema cutover
- resume ingestion before replay, backfill, replica sync, and reader setup
- restart ingestion from the EXIT cleanup trap if cutover fails
- add ordering and recovery regression coverage

## Root cause
The operational analytics deploy stopped ingestion before roughly fifteen minutes of bounded backfills and setup work. Synthetic jobs continued writing durable samples, but public snapshots and monitoring heartbeats went stale until ingestion restarted.

## Verification
- 38 focused deployment tests pass
- ruff passes
- bash syntax check passes
- production status is current with zero drain lag and no stale monitor data