### PR TITLE
Apply DeepSeek weekend off-peak pricing

### DIFF
--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import os
 import sys
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta, timezone
 
 # Test-only clock override, e.g. TR_LIFECYCLE_CLOCK_OVERRIDE=2027-01-01T00:00:00Z.
 # Every effective-dated cutover below is a scheduled change of behaviour: a
@@ -41,6 +41,9 @@ CEREBRAS_GEMMA4_SHARED_RETIREMENT_AT = datetime(2026, 9, 3, 0, 0, tzinfo=UTC)
 NOVITA_LING_30_TINY_RETIREMENT_AT = datetime(2026, 8, 13, 15, 0, tzinfo=UTC)
 ALIBABA_OCTOBER_2026_RETIREMENT_AT = datetime(2026, 10, 9, 16, 0, tzinfo=UTC)
 DEEPSEEK_V4_PRICING_EFFECTIVE_AT = datetime(2026, 8, 16, 16, 0, tzinfo=UTC)
+DEEPSEEK_WEEKEND_OFF_PEAK_EFFECTIVE_AT = datetime(
+    2026, 8, 22, 16, 0, tzinfo=UTC
+)
 FIREWORKS_DSV4_FLASH_0731_PRICING_EFFECTIVE_AT = datetime(
     2026, 8, 22, 12, 0, tzinfo=UTC
 )
@@ -52,6 +55,7 @@ DEEPSEEK_V4_PEAK_WINDOWS_UTC = (
     (1 * 60 * 60, 4 * 60 * 60),
     (6 * 60 * 60, 10 * 60 * 60),
 )
+_BEIJING_TIME = timezone(timedelta(hours=8), "Asia/Shanghai")
 
 
 @dataclass(frozen=True)
@@ -521,6 +525,13 @@ def _deepseek_v4_family(provider_slug: str, model_id: str) -> str | None:
 def _deepseek_v4_period(effective_at: datetime) -> str:
     if effective_at < DEEPSEEK_V4_PRICING_EFFECTIVE_AT:
         return "legacy"
+    # DeepSeek's published schedule applies the off-peak rate throughout
+    # Saturdays and Sundays in Beijing time from 2026-08-23 onward.
+    if (
+        effective_at >= DEEPSEEK_WEEKEND_OFF_PEAK_EFFECTIVE_AT
+        and effective_at.astimezone(_BEIJING_TIME).weekday() >= 5
+    ):
+        return "off_peak"
     seconds_since_midnight = (
         effective_at.hour * 60 * 60 + effective_at.minute * 60 + effective_at.second
     )
@@ -577,6 +588,13 @@ def provider_pricing_schedule(
             {"start": clock(start), "end": clock(end)}
             for start, end in DEEPSEEK_V4_PEAK_WINDOWS_UTC
         ],
+        "weekend_off_peak": {
+            "effective_at": DEEPSEEK_WEEKEND_OFF_PEAK_EFFECTIVE_AT.isoformat().replace(
+                "+00:00", "Z"
+            ),
+            "timezone": "Asia/Shanghai",
+            "days": ["Saturday", "Sunday"],
+        },
         # Authorization time, not settlement time, selects the period so a
         # long stream cannot change price midway through the request.
         "rate_locked_at": "authorization",

--- a/src/trusted_router/templates/public/model_section.html
+++ b/src/trusted_router/templates/public/model_section.html
@@ -159,7 +159,7 @@
           <td>{{ endpoint.completion_price }}</td>
           <td>
             {% if endpoint.pricing_schedule %}
-            DeepSeek direct authorization-time pricing. New rates begin 2026-08-16 16:00 UTC. Peak 01:00–04:00 UTC and 06:00–10:00 UTC.
+            DeepSeek direct authorization-time pricing. New rates begin 2026-08-16 16:00 UTC. Weekday peak windows are 01:00–04:00 UTC and 06:00–10:00 UTC. Weekends are off-peak all day in Beijing time beginning 2026-08-23.
             {% else %}
             Flat
             {% endif %}

--- a/tests/test_deepseek_time_pricing.py
+++ b/tests/test_deepseek_time_pricing.py
@@ -11,6 +11,7 @@ from trusted_router.config import Settings
 from trusted_router.main import create_app
 from trusted_router.provider_lifecycle import (
     DEEPSEEK_V4_PRICING_EFFECTIVE_AT,
+    DEEPSEEK_WEEKEND_OFF_PEAK_EFFECTIVE_AT,
     ProviderPrice,
     provider_price_microdollars,
     provider_pricing_schedule,
@@ -114,6 +115,48 @@ def test_deepseek_v4_flash_uses_half_open_utc_peak_windows(
 
 
 @pytest.mark.parametrize(
+    ("at", "expected"),
+    [
+        # The new rule starts at Sunday midnight in Beijing. A Sunday instant
+        # inside an otherwise-peak UTC window must use the off-peak rate.
+        (
+            datetime(2026, 8, 23, 2, 0, tzinfo=UTC),
+            ProviderPrice(220_000, 660_000, 7_000),
+        ),
+        # Every later Saturday is off-peak all day in Beijing too.
+        (
+            datetime(2026, 8, 29, 2, 0, tzinfo=UTC),
+            ProviderPrice(220_000, 660_000, 7_000),
+        ),
+        # The weekday peak schedule remains unchanged.
+        (
+            datetime(2026, 8, 24, 2, 0, tzinfo=UTC),
+            ProviderPrice(440_000, 1_320_000, 14_000),
+        ),
+    ],
+)
+def test_deepseek_weekends_are_always_off_peak_in_beijing(
+    at: datetime,
+    expected: ProviderPrice,
+) -> None:
+    assert provider_price_microdollars("deepseek", _FLASH, at=at) == expected
+
+
+def test_deepseek_weekend_rule_does_not_apply_before_announced_cutover() -> None:
+    # Saturday morning in Beijing was still governed by the old time-of-day
+    # schedule because the notice takes effect Sunday at 00:00 Beijing time.
+    assert provider_price_microdollars(
+        "deepseek",
+        _FLASH,
+        at=datetime(2026, 8, 22, 2, 0, tzinfo=UTC),
+    ) == ProviderPrice(440_000, 1_320_000, 14_000)
+
+    assert DEEPSEEK_WEEKEND_OFF_PEAK_EFFECTIVE_AT == datetime(
+        2026, 8, 22, 16, 0, tzinfo=UTC
+    )
+
+
+@pytest.mark.parametrize(
     ("model_id", "off_peak", "peak"),
     [
         (
@@ -156,6 +199,11 @@ def test_deepseek_schedule_metadata_is_explicit_and_authorization_scoped() -> No
             {"start": "01:00", "end": "04:00"},
             {"start": "06:00", "end": "10:00"},
         ],
+        "weekend_off_peak": {
+            "effective_at": "2026-08-22T16:00:00Z",
+            "timezone": "Asia/Shanghai",
+            "days": ["Saturday", "Sunday"],
+        },
         "rate_locked_at": "authorization",
     }
     assert provider_pricing_schedule(
@@ -208,6 +256,7 @@ def test_deepseek_pricing_page_explains_variable_direct_rate(
     assert "authorization-time pricing" in response.text
     assert "01:00–04:00 UTC" in response.text
     assert "06:00–10:00 UTC" in response.text
+    assert "Weekends are off-peak all day in Beijing time" in response.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- apply DeepSeek off-peak pricing all day on Beijing-time weekends from 2026-08-23
- retain weekday peak windows and authorization-time rate locking
- publish the weekend schedule in model endpoint metadata and pricing pages

## Verification
- `uv run pytest -q` (5946 passed, 307 skipped, 10 xfailed)
- `uv run ruff check .`
- `uv run mypy`
- focused post-rebase pricing suite (57 passed)

Source: https://api-docs.deepseek.com/quick_start/pricing/