### PR TITLE
Add multi-arm paid landing page experiment

### DIFF
--- a/docs/marketing/google-landing-page-experiment-2026-08-20.md
+++ b/docs/marketing/google-landing-page-experiment-2026-08-20.md
@@ -11,7 +11,7 @@ Improve paid-search conversion through the complete first-party funnel:
 5. settled credit purchase
 
 The experiment keeps the existing Google Ads budget. It reallocates traffic
-away from weak hot-model cells and compares two landing experiences under the
+away from weak hot-model cells and compares distinct landing promises under the
 same search intent.
 
 ## Production Baseline
@@ -59,6 +59,43 @@ The challenger preserves the OpenRouter promise but puts key creation, working
 SDK code, and the three migration steps in the first screen. It is no-index and
 canonicalized to the permanent OpenRouter page.
 
+## Experiment 1B: Multi-Arm OpenRouter Landing Test
+
+The first directional results favored action-led pages, but did not identify
+which product promise drives the first successful API call. Send one unchanged
+ad to the first-party experiment router:
+
+```text
+https://trustedrouter.com/openrouter-alternative/experiment
+  ?utm_source=google
+  &utm_medium=paid_search
+  &utm_campaign=openrouter_lp_multi_20260822
+  &utm_content=<unchanged-ad-creative-id>
+```
+
+The router assigns a visitor consistently to one of six pages. It preserves the
+complete query string, so the ad creative remains measurable while the landing
+path identifies the page arm.
+
+| Arm | Landing path | Promise |
+|---|---|---|
+| Control | `/openrouter-alternative/quickstart` | Keep the SDK and switch the base URL |
+| Breadth | `/openrouter-alternative/lp/every-model` | Hundreds of models behind one key |
+| Reliability | `/openrouter-alternative/lp/provider-failover` | Automatic provider fallback |
+| Privacy | `/openrouter-alternative/lp/privacy-with-proof` | Verify the prompt path |
+| Price | `/openrouter-alternative/lp/usage-pricing` | Usage pricing without a subscription |
+| Controls | `/openrouter-alternative/lp/production-controls` | Scoped keys, limits, and policy |
+
+Every arm uses the same OpenAI SDK sample, key-creation flow, page structure,
+and no-card-required reassurance. The promise, proof, and sample route vary.
+All experiment pages are `noindex,follow` and canonicalize to the permanent
+OpenRouter alternative page.
+
+Assignment uses a one-way hash of the anonymous first-party attribution ID.
+TrustedRouter does not store an additional experiment identity. Global Privacy
+Control and Do Not Track requests receive the control page without an
+attribution cookie.
+
 ## Experiment 2: Private LLM API
 
 Start only after Experiment 1 has enough activation data. Use the same 50/50
@@ -92,6 +129,12 @@ https://trustedrouter.com/private-llm-api/quickstart
 - Guardrail: the challenger must not reduce activation per engaged visitor.
 - Do not optimize toward click-through rate or signup volume alone.
 - Do not name a payment winner from one purchase.
+- For the six-arm test, require at least 100 engaged visitors and three
+  activated users in an arm before promoting its promise.
+- Compare each challenger to the quickstart control with a two-sided 95%
+  interval for activated users per engaged visitor.
+- Keep the ad text, keywords, geography, device mix, bids, and schedule fixed
+  during the landing-page test.
 - Review after each arm has at least 20 activated users or after 30 days,
   whichever comes first.
 - Pause an arm early only for a severe defect or when its 95% confidence
@@ -121,6 +164,15 @@ Inspect one destination directly:
 uv run python scripts/marketing_funnel_report.py \
   --source google \
   --landing /openrouter-alternative/quickstart \
+  --days 30
+```
+
+Report every multi-arm landing page together:
+
+```bash
+uv run python scripts/marketing_funnel_report.py \
+  --source google \
+  --campaign openrouter_lp_multi_20260822 \
   --days 30
 ```
 

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -4,6 +4,7 @@ settings-driven values and renders the Jinja2 template."""
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 from collections.abc import Mapping, Sequence
@@ -361,6 +362,32 @@ class PublicPage:
 
 
 @dataclass(frozen=True)
+class OpenRouterLandingVariant:
+    slug: str
+    title: str
+    description: str
+    kicker: str
+    headline: str
+    lead: str
+    cta: str
+    secondary_label: str
+    secondary_href: str
+    microcopy: str
+    terminal_label: str
+    model_id: str
+    proof_items: tuple[tuple[str, str], ...]
+    cards: tuple[tuple[str, str, str], ...]
+    left_eyebrow: str
+    left_headline: str
+    left_copy: str
+    right_eyebrow: str
+    right_headline: str
+    right_copy: str
+    final_headline: str
+    final_copy: str
+
+
+@dataclass(frozen=True)
 class BlogIndexPost:
     post: BlogPost
     image: str
@@ -379,6 +406,311 @@ OPENROUTER_ALTERNATIVE_ITEMS: tuple[tuple[str, str], ...] = (
     ("Google Vertex AI", "/compare/google-vertex-ai"),
     ("Direct provider APIs", "/providers"),
 )
+
+OPENROUTER_PAID_LANDING_VARIANTS: dict[str, OpenRouterLandingVariant] = {
+    "every-model": OpenRouterLandingVariant(
+        slug="every-model",
+        title="One API for Hundreds of AI Models",
+        description=(
+            "Keep one OpenAI-compatible interface while choosing among hundreds "
+            "of model routes, providers, prices, and privacy tiers."
+        ),
+        kicker="One API for the model market",
+        headline="One key for hundreds of AI models.",
+        lead=(
+            "Keep one OpenAI-compatible interface while models and providers "
+            "change underneath it. Pick an exact model or let TrustedRouter route."
+        ),
+        cta="Create my API key",
+        secondary_label="Browse models",
+        secondary_href="/models",
+        microcopy="Keep your SDK. Switch models with one string.",
+        terminal_label="One interface, any model",
+        model_id="trustedrouter/auto",
+        proof_items=(
+            ("Hundreds", "Model routes in one catalog."),
+            ("One", "OpenAI-compatible interface."),
+            ("Public", "Prices and provider routes."),
+            ("Flexible", "Exact models or router aliases."),
+        ),
+        cards=(
+            (
+                "Integrate once",
+                "Keep the client you already use.",
+                "Chat Completions, Responses, and streaming stay behind one base URL.",
+            ),
+            (
+                "Choose clearly",
+                "Compare the route before you call it.",
+                "Model pages publish providers, prices, context limits, and privacy posture.",
+            ),
+            (
+                "Change quickly",
+                "Try another model with one string.",
+                "Move from a frontier model to an open-weight route without opening another provider account.",
+            ),
+        ),
+        left_eyebrow="Model choice",
+        left_headline="The catalog stays current.",
+        left_copy=(
+            "Use exact model IDs when the model matters. Use trustedrouter/auto, "
+            "cheap, fast, zdr, or e2e when the routing objective matters more."
+        ),
+        right_eyebrow="Migration",
+        right_headline="Your application contract stays familiar.",
+        right_copy=(
+            "The OpenAI SDK, message shape, streaming contract, and base URL pattern "
+            "stay consistent while the selected route changes."
+        ),
+        final_headline="Try the model market through one key.",
+        final_copy="Create a key, run the sample, then change the model ID.",
+    ),
+    "provider-failover": OpenRouterLandingVariant(
+        slug="provider-failover",
+        title="Automatic LLM Provider Failover",
+        description=(
+            "Keep serving through provider errors and capacity limits with measured, "
+            "automatic fallback behind one OpenAI-compatible API."
+        ),
+        kicker="Reliability without retry trees",
+        headline="Keep serving through provider outages.",
+        lead=(
+            "TrustedRouter ranks eligible routes and moves to another provider when "
+            "a route fails. Your application keeps one API contract."
+        ),
+        cta="Test provider failover",
+        secondary_label="See live status",
+        secondary_href="/status",
+        microcopy="Start with trustedrouter/auto and keep your existing SDK.",
+        terminal_label="Automatic fallback",
+        model_id="trustedrouter/auto",
+        proof_items=(
+            ("Automatic", "Fallback across eligible routes."),
+            ("Measured", "Latency and availability data."),
+            ("Visible", "Public provider status."),
+            ("Consistent", "One client contract."),
+        ),
+        cards=(
+            (
+                "Route",
+                "Start with more than one candidate.",
+                "The gateway authorizes eligible routes before invoking the first provider.",
+            ),
+            (
+                "Recover",
+                "Move past retryable failures.",
+                "Rate limits, provider errors, and empty streams can advance to another authorized route.",
+            ),
+            (
+                "Measure",
+                "See how providers behave.",
+                "Public status and leaderboard pages publish metadata-only latency and success measurements.",
+            ),
+        ),
+        left_eyebrow="Application code",
+        left_headline="Keep one request path.",
+        left_copy=(
+            "The gateway owns candidate selection and provider rollover, so your app "
+            "does not need a separate retry tree for every vendor."
+        ),
+        right_eyebrow="Trust boundary",
+        right_headline="Every fallback remains attested.",
+        right_copy=(
+            "A provider failure can move traffic to another eligible route. It never "
+            "moves prompt traffic to a non-attested TrustedRouter gateway."
+        ),
+        final_headline="Run one request through the automatic route.",
+        final_copy="Create a key and test the same API contract your production code uses.",
+    ),
+    "privacy-with-proof": OpenRouterLandingVariant(
+        slug="privacy-with-proof",
+        title="Private LLM Routing With Live Attestation",
+        description=(
+            "Verify the open-source gateway handling your prompts, then restrict "
+            "downstream routing to documented zero-data-retention providers."
+        ),
+        kicker="Privacy with proof",
+        headline="Verify the prompt path before the first prompt.",
+        lead=(
+            "A fresh hardware attestation identifies the running gateway build. "
+            "Realtime inference never logs prompt or output content."
+        ),
+        cta="Create a private API key",
+        secondary_label="Verify the gateway",
+        secondary_href="https://trust.trustedrouter.com",
+        microcopy="Use trustedrouter/zdr to add a downstream retention requirement.",
+        terminal_label="Zero-retention route",
+        model_id="trustedrouter/zdr",
+        proof_items=(
+            ("Attested", "Live gateway evidence."),
+            ("Open", "Published prompt-path source."),
+            ("Realtime", "No prompt or output logs."),
+            ("ZDR", "Policy-filtered providers."),
+        ),
+        cards=(
+            (
+                "Challenge",
+                "Request fresh evidence.",
+                "Bind a nonce to the live gateway and inspect the signed attestation response.",
+            ),
+            (
+                "Compare",
+                "Match the build to published source.",
+                "The trust page links the release digest, source commit, and verification steps.",
+            ),
+            (
+                "Restrict",
+                "Choose the downstream posture.",
+                "The zdr and e2e routes apply distinct provider requirements and fail closed when no route qualifies.",
+            ),
+        ),
+        left_eyebrow="TrustedRouter gateway",
+        left_headline="Verify the code handling the request.",
+        left_copy=(
+            "Hardware attestation covers the running gateway build. The prompt path "
+            "is published and realtime inference does not retain prompt or output content."
+        ),
+        right_eyebrow="Downstream provider",
+        right_headline="Select the provider policy separately.",
+        right_copy=(
+            "Attestation of the router does not turn every model provider into a TEE. "
+            "Use route privacy filters and review the cited provider policy."
+        ),
+        final_headline="Verify first. Then make the request.",
+        final_copy="Create a key and call the ZDR route through the attested gateway.",
+    ),
+    "usage-pricing": OpenRouterLandingVariant(
+        slug="usage-pricing",
+        title="LLM Routing Without a Monthly Subscription",
+        description=(
+            "Pay the provider model cost plus 5.5% for prepaid text and embeddings, "
+            "with published per-model prices and no monthly router plan."
+        ),
+        kicker="Usage pricing",
+        headline="Spend your AI budget on tokens, not subscriptions.",
+        lead=(
+            "Prepaid text and embedding requests cost the provider price plus 5.5%. "
+            "Every model page publishes the rate before you call it."
+        ),
+        cta="Make a low-cost first call",
+        secondary_label="See pricing",
+        secondary_href="/pricing",
+        microcopy="No monthly router plan. Set a limit on each API key.",
+        terminal_label="Route by cost",
+        model_id="trustedrouter/cheap",
+        proof_items=(
+            ("5.5%", "Prepaid text and embedding markup."),
+            ("$0", "Monthly router subscription."),
+            ("Public", "Per-model customer prices."),
+            ("Bounded", "Per-key spend limits."),
+        ),
+        cards=(
+            (
+                "Choose",
+                "Route to the cheapest capable option.",
+                "Use trustedrouter/cheap or select an exact model with a published customer price.",
+            ),
+            (
+                "Limit",
+                "Put a ceiling on every key.",
+                "Create separate keys for applications and set their maximum spend before deployment.",
+            ),
+            (
+                "Inspect",
+                "See usage in microdollar precision.",
+                "Activity metadata records model, provider, token counts, latency, and integer cost.",
+            ),
+        ),
+        left_eyebrow="Cost control",
+        left_headline="Match the model to the job.",
+        left_copy=(
+            "Frontier models remain available when they earn their cost. Cheap and "
+            "fast aliases make lower-cost routes easy to test for the rest."
+        ),
+        right_eyebrow="Billing",
+        right_headline="Keep the ledger inspectable.",
+        right_copy=(
+            "Costs are computed as integer microdollars and displayed per request, "
+            "API key, and workspace instead of being hidden behind a seat plan."
+        ),
+        final_headline="Price one real request.",
+        final_copy="Create a key, call trustedrouter/cheap, and inspect the billed usage.",
+    ),
+    "production-controls": OpenRouterLandingVariant(
+        slug="production-controls",
+        title="Production LLM Gateway Controls",
+        description=(
+            "Ship scoped API keys, workspace budgets, provider policy, fallback, "
+            "and metadata-only activity through one model gateway."
+        ),
+        kicker="Production controls",
+        headline="Ship one model API your team can control.",
+        lead=(
+            "Separate keys by application, set spend limits, filter providers, and "
+            "review usage metadata without collecting prompt or output content."
+        ),
+        cta="Create a scoped API key",
+        secondary_label="Read the docs",
+        secondary_href="/docs",
+        microcopy="Start with one application key and one explicit spend limit.",
+        terminal_label="Production-ready request",
+        model_id="trustedrouter/auto",
+        proof_items=(
+            ("Scoped", "Keys by application."),
+            ("Limited", "Per-key spend ceilings."),
+            ("Filtered", "Provider and privacy policy."),
+            ("Measured", "Metadata-only activity."),
+        ),
+        cards=(
+            (
+                "Separate",
+                "Give each application its own key.",
+                "Disable, rotate, or limit one workload without touching every other integration.",
+            ),
+            (
+                "Constrain",
+                "Express routing policy in the request.",
+                "Choose providers, privacy tiers, regions, model candidates, and sorting objectives.",
+            ),
+            (
+                "Review",
+                "Keep operational evidence without content logs.",
+                "Activity rows include model, provider, status, tokens, latency, and cost rather than prompts or outputs.",
+            ),
+        ),
+        left_eyebrow="Developer workflow",
+        left_headline="Migration stays small.",
+        left_copy=(
+            "Keep the OpenAI client and request shape. Change the base URL, issue a "
+            "scoped key, and adopt routing controls incrementally."
+        ),
+        right_eyebrow="Operator workflow",
+        right_headline="Control the blast radius.",
+        right_copy=(
+            "Workspace and key boundaries make limits, revocation, provider policy, "
+            "and usage review explicit before production traffic grows."
+        ),
+        final_headline="Start with one bounded production key.",
+        final_copy="Create the key, set its limit, and make the first API call.",
+    ),
+}
+
+OPENROUTER_PAID_LANDING_PATHS: tuple[str, ...] = (
+    "/openrouter-alternative/quickstart",
+    *tuple(
+        f"/openrouter-alternative/lp/{slug}"
+        for slug in OPENROUTER_PAID_LANDING_VARIANTS
+    ),
+)
+
+
+def assigned_openrouter_landing_path(seed: str | None) -> str:
+    """Choose one stable experiment arm without retaining visitor identity."""
+    if not seed:
+        return OPENROUTER_PAID_LANDING_PATHS[0]
+    digest = hashlib.sha256(f"openrouter-lp-v1:{seed}".encode()).digest()
+    index = int.from_bytes(digest[:8], "big") % len(OPENROUTER_PAID_LANDING_PATHS)
+    return OPENROUTER_PAID_LANDING_PATHS[index]
 
 
 _NOT_FOUND_PAGE = PublicPage(
@@ -2097,6 +2429,28 @@ def public_page_html(
             else None
         ),
         robots_meta=robots_meta,
+    )
+
+
+def public_openrouter_experiment_html(settings: Settings, variant_slug: str) -> str:
+    variant = OPENROUTER_PAID_LANDING_VARIANTS[variant_slug]
+    path = f"/openrouter-alternative/lp/{variant.slug}"
+    page = PublicPage(
+        template="public/experiment_openrouter_variant.html",
+        title=variant.title,
+        description=variant.description,
+    )
+    return _render_public_page(
+        settings,
+        page,
+        path=path,
+        site_url=canonical_public_url(settings, path),
+        canonical_url_override=canonical_public_url(
+            settings,
+            "/openrouter-alternative",
+        ),
+        robots_meta="noindex,follow",
+        extra_context={"variant": variant},
     )
 
 

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -49,7 +49,9 @@ from trusted_router.client_reliability import client_observed_status_section
 from trusted_router.config import Settings
 from trusted_router.dashboard import (
     MODEL_SEO_SECTIONS,
+    OPENROUTER_PAID_LANDING_VARIANTS,
     STATIC_DIR,
+    assigned_openrouter_landing_path,
     canonical_model_comparison_path,
     dashboard_html,
     docs_llms_full_txt,
@@ -80,6 +82,7 @@ from trusted_router.dashboard import (
     public_model_section_html,
     public_models_html,
     public_not_found_html,
+    public_openrouter_experiment_html,
     public_page_html,
     public_privacy_html,
     public_provider_detail_html,
@@ -1011,6 +1014,34 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
             canonical_path="/openrouter-alternative",
             robots_meta="noindex,follow",
         )
+
+    @public_html_route("/openrouter-alternative/experiment")
+    async def experiment_openrouter_landing_router(
+        request: Request,
+    ) -> RedirectResponse:
+        attribution = getattr(request.state, "acquisition_attribution", None)
+        seed = getattr(attribution, "anonymous_id", None)
+        selected_path = assigned_openrouter_landing_path(seed)
+        query = request.url.query
+        location = f"{selected_path}?{query}" if query else selected_path
+        return RedirectResponse(url=location, status_code=307)
+
+    @public_html_route(
+        "/openrouter-alternative/lp/{variant_slug}",
+        include_slash=False,
+    )
+    async def experiment_openrouter_landing_variant(
+        variant_slug: str,
+    ) -> Response:
+        if variant_slug not in OPENROUTER_PAID_LANDING_VARIANTS:
+            return HTMLResponse(
+                public_not_found_html(
+                    settings,
+                    f"/openrouter-alternative/lp/{variant_slug}",
+                ),
+                status_code=404,
+            )
+        return HTMLResponse(public_openrouter_experiment_html(settings, variant_slug))
 
     @public_html_route("/private-llm-api/quickstart")
     async def experiment_private_llm_quickstart() -> str:

--- a/src/trusted_router/templates/public/experiment_openrouter_quickstart.html
+++ b/src/trusted_router/templates/public/experiment_openrouter_quickstart.html
@@ -39,7 +39,7 @@ print(response.choices[0].message.content)</code></pre>
 <section class="public-proof-strip" aria-label="Migration facts">
   <div><strong>One URL</strong><span>Keep the OpenAI client.</span></div>
   <div><strong>Hundreds</strong><span>Models behind one API.</span></div>
-  <div><strong>5%</strong><span>Prepaid platform fee.</span></div>
+  <div><strong>5.5%</strong><span>Prepaid text and embedding markup.</span></div>
   <div><strong>Always</strong><span>No prompt or output logs.</span></div>
 </section>
 

--- a/src/trusted_router/templates/public/experiment_openrouter_variant.html
+++ b/src/trusted_router/templates/public/experiment_openrouter_variant.html
@@ -1,0 +1,69 @@
+{% extends "public/_base.html" %}
+
+{% block hero %}
+<section class="public-hero marketing-hero" aria-label="{{ variant.kicker }}">
+  <div>
+    <div class="kicker">{{ variant.kicker }}</div>
+    <h1>{{ variant.headline }}</h1>
+    <p class="lead">{{ variant.lead }}</p>
+    <div class="hero-actions">
+      <button class="btn primary" type="button" data-action="open-signin">{{ variant.cta }}</button>
+      <a class="btn" href="{{ variant.secondary_href }}">{{ variant.secondary_label }} <span aria-hidden="true">→</span></a>
+    </div>
+    <p class="microcopy">{{ variant.microcopy }}</p>
+  </div>
+  <div class="copy-terminal">
+    <div class="code-head"><span>{{ variant.terminal_label }}</span><button class="code-copy" type="button" data-action="copy-code" data-copy-target="openrouter-variant-call">Copy</button></div>
+    <pre><code id="openrouter-variant-call">import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["TRUSTEDROUTER_API_KEY"],
+    base_url="{{ api_base_url }}",
+)
+
+response = client.chat.completions.create(
+    model="{{ variant.model_id }}",
+    messages=[{
+        "role": "user",
+        "content": "Reply PONG",
+    }],
+)
+
+print(response.choices[0].message.content)</code></pre>
+  </div>
+</section>
+{% endblock %}
+
+{% block body %}
+<section class="public-proof-strip" aria-label="{{ variant.kicker }} facts">
+  {% for value, label in variant.proof_items %}
+  <div><strong>{{ value }}</strong><span>{{ label }}</span></div>
+  {% endfor %}
+</section>
+
+<section class="marketing-grid three" aria-label="{{ variant.kicker }} details">
+  {% for label, heading, copy in variant.cards %}
+  <div class="marketing-card"><span class="card-label">{{ label }}</span><h3>{{ heading }}</h3><p>{{ copy }}</p></div>
+  {% endfor %}
+</section>
+
+<section class="marketing-split" aria-label="{{ variant.kicker }} explanation">
+  <div class="marketing-copy">
+    <span class="eyebrow">{{ variant.left_eyebrow }}</span>
+    <h2>{{ variant.left_headline }}</h2>
+    <p>{{ variant.left_copy }}</p>
+  </div>
+  <div class="marketing-copy">
+    <span class="eyebrow">{{ variant.right_eyebrow }}</span>
+    <h2>{{ variant.right_headline }}</h2>
+    <p>{{ variant.right_copy }}</p>
+  </div>
+</section>
+
+<section class="cta-band" aria-label="Create a TrustedRouter key">
+  <div><strong>{{ variant.final_headline }}</strong><span>{{ variant.final_copy }}</span></div>
+  <div class="cta-band-actions"><button class="btn primary" type="button" data-action="open-signin">{{ variant.cta }}</button></div>
+  <span class="microcopy">No card required.</span>
+</section>
+{% endblock %}

--- a/tests/test_acquisition_attribution.py
+++ b/tests/test_acquisition_attribution.py
@@ -238,6 +238,33 @@ def test_paid_experiment_preserves_exact_landing_path(client: TestClient) -> Non
     assert context.last_touch["utm_content"] == "or_quickstart_v1"
 
 
+def test_multiarm_landing_redirect_attributes_the_selected_page(
+    client: TestClient,
+) -> None:
+    query = (
+        "utm_source=google&utm_medium=paid_search&"
+        "utm_campaign=openrouter_lp_multi_20260822&"
+        "utm_content=openrouter_exact_control&gclid=multiarm-click-123"
+    )
+    assigned = client.get(
+        f"/openrouter-alternative/experiment?{query}",
+        follow_redirects=False,
+    )
+    assert assigned.status_code == 307
+
+    landing = client.get(assigned.headers["location"])
+    assert landing.status_code == 200
+    context = decode_attribution_cookie(
+        client.cookies.get(ATTRIBUTION_COOKIE_NAME), client.app.state.settings
+    )
+    assert context is not None
+    assert context.last_touch["landing_path"] == assigned.headers["location"].split("?", 1)[0]
+    assert context.last_touch["utm_campaign"] == "openrouter_lp_multi_20260822"
+    assert context.last_touch["utm_content"] == "openrouter_exact_control"
+    assert context.last_touch["gclid_fingerprint"]
+    assert "gclid" not in context.last_touch
+
+
 @pytest.mark.parametrize("header", ["sec-gpc", "dnt"])
 def test_privacy_signals_suppress_attribution_cookie(client: TestClient, header: str) -> None:
     response = client.get(

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -4,11 +4,17 @@ import json
 import logging
 import re
 from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 from fastapi.testclient import TestClient
 
-from trusted_router.dashboard import MODEL_COMPARE_PAGE_SIZE
+from trusted_router.dashboard import (
+    MODEL_COMPARE_PAGE_SIZE,
+    OPENROUTER_PAID_LANDING_PATHS,
+    OPENROUTER_PAID_LANDING_VARIANTS,
+    assigned_openrouter_landing_path,
+)
 from trusted_router.routes.public import INDEXNOW_KEY
 
 
@@ -207,6 +213,102 @@ def test_paid_landing_experiments_are_noindex_and_canonical(
     sitemap = client.get("/sitemap.xml")
     assert sitemap.status_code == 200
     assert f"https://trustedrouter.com{path}" not in sitemap.text
+
+
+def test_openrouter_paid_landing_variants_are_distinct_and_noindex(
+    client: TestClient,
+) -> None:
+    rendered_headlines: set[str] = set()
+    sitemap = client.get("/sitemap.xml")
+    assert sitemap.status_code == 200
+
+    for slug, variant in OPENROUTER_PAID_LANDING_VARIANTS.items():
+        path = f"/openrouter-alternative/lp/{slug}"
+        response = client.get(
+            f"{path}?utm_source=google&utm_campaign=openrouter_lp_multi_20260822"
+        )
+
+        assert response.status_code == 200
+        assert variant.headline in response.text
+        assert f'model="{variant.model_id}"' in response.text
+        assert variant.cta in response.text
+        assert '<meta name="robots" content="noindex,follow">' in response.text
+        assert response.text.count('rel="canonical"') == 1
+        assert (
+            '<link rel="canonical" '
+            'href="https://trustedrouter.com/openrouter-alternative">'
+            in response.text
+        )
+        assert f"https://trustedrouter.com{path}" not in sitemap.text
+        rendered_headlines.add(variant.headline)
+
+    assert len(rendered_headlines) == len(OPENROUTER_PAID_LANDING_VARIANTS)
+
+
+def test_openrouter_experiment_router_is_sticky_and_preserves_campaign_query(
+    client: TestClient,
+) -> None:
+    query = (
+        "utm_source=google&utm_medium=paid_search&"
+        "utm_campaign=openrouter_lp_multi_20260822&"
+        "utm_content=openrouter_exact_control&gclid=test-click-123"
+    )
+    first = client.get(
+        f"/openrouter-alternative/experiment?{query}",
+        follow_redirects=False,
+    )
+    second = client.get(
+        f"/openrouter-alternative/experiment?{query}",
+        follow_redirects=False,
+    )
+
+    assert first.status_code == 307
+    assert second.status_code == 307
+    assert first.headers["location"] == second.headers["location"]
+    destination = urlsplit(first.headers["location"])
+    assert destination.path in OPENROUTER_PAID_LANDING_PATHS
+    assert parse_qs(destination.query) == parse_qs(query)
+
+    rendered = client.get(first.headers["location"])
+    assert rendered.status_code == 200
+    assert '<meta name="robots" content="noindex,follow">' in rendered.text
+
+
+def test_openrouter_experiment_assignment_reaches_every_arm() -> None:
+    assigned = {
+        assigned_openrouter_landing_path(f"anonymous-{index}")
+        for index in range(600)
+    }
+
+    assert assigned == set(OPENROUTER_PAID_LANDING_PATHS)
+    assert assigned_openrouter_landing_path("stable-person") == (
+        assigned_openrouter_landing_path("stable-person")
+    )
+
+
+def test_openrouter_experiment_honors_global_privacy_control(
+    client: TestClient,
+) -> None:
+    response = client.get(
+        "/openrouter-alternative/experiment?utm_source=google",
+        headers={"sec-gpc": "1"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 307
+    assert response.headers["location"].startswith(
+        "/openrouter-alternative/quickstart?"
+    )
+    assert "tr_attribution=" not in response.headers.get("set-cookie", "")
+
+
+def test_unknown_openrouter_landing_variant_is_a_real_404(
+    client: TestClient,
+) -> None:
+    response = client.get("/openrouter-alternative/lp/unknown")
+
+    assert response.status_code == 404
+    assert "Page Not Found" in response.text
 
 
 def test_public_footer_links_to_canonical_trust_page(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- add five focused OpenRouter-alternative landing pages for breadth, failover, privacy, pricing, and production controls
- add a sticky six-arm first-party experiment router that preserves campaign parameters
- keep experiment pages noindex with the permanent OpenRouter page as canonical
- document decision thresholds and correct the stale 5% experiment copy to 5.5%

## Verification
- ruff: passing
- mypy on changed Python modules: passing
- public-page and acquisition suites: 106 passing
- Playwright visual checks at 390px and 1440px: no overflow; primary CTA visible on every arm
