### PR TITLE
Fix regional quota escrow invariant audit

### DIFF
--- a/src/trusted_router/storage_gcp_counter_reconcile.py
+++ b/src/trusted_router/storage_gcp_counter_reconcile.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -10,10 +11,10 @@ from trusted_router.storage_models import ApiKey, CreditAccount, Workspace
 
 # ── Standing typed-side invariant auditor ───────────────────────────────────
 # This auditor is the standing typed-side tripwire: for every typed counter row,
-# `reserved` MUST equal the sum of that scope's OPEN typed-origin holds
-# (tr_reservation, settled=false), and MUST be >= 0. A violation means a hold
-# leaked or a release double-applied. Run it on a schedule + before each ramp
-# batch; wire an alert on the "release row-count != 1" log line as the live
+# `reserved` MUST equal the sum of that scope's OPEN typed-origin request holds
+# plus remaining regional quota escrow, and MUST be >= 0. A violation means a
+# hold leaked or a release double-applied. Run it on a schedule + before each
+# ramp batch; wire an alert on the "release row-count != 1" log line as the live
 # signal between audits.
 
 # Shard-aware (the typed counter PK is (scope, shard); reservations carry the
@@ -28,31 +29,134 @@ _OPEN_KEY_HOLDS = (
     "SELECT key_hash, key_shard, COALESCE(SUM(key_reserved_micro), 0) "
     "FROM tr_reservation WHERE settled = false GROUP BY key_hash, key_shard"
 )
+_OPEN_REGIONAL_QUOTA_ESCROW = (
+    "/* open_regional_quota_escrow */ "
+    "SELECT open_index.id, open_index.body, lease_record.id, lease_record.body "
+    "FROM tr_entities AS open_index "
+    "LEFT JOIN tr_entities AS lease_record "
+    "ON lease_record.kind='regional_quota_lease' "
+    "AND lease_record.id=JSON_VALUE(open_index.body, '$.lease_entity_id') "
+    "WHERE open_index.kind='regional_quota_lease_open' "
+    "ORDER BY open_index.id"
+)
+_OPEN_REGIONAL_QUOTA_STATES = frozenset({"pending", "active", "draining", "quarantined"})
+_NONCLOSED_REGIONAL_QUOTA_LEASES_FOR_REPAIR = (
+    "/* nonclosed_regional_quota_leases_for_repair */ "
+    "SELECT COUNT(*) FROM tr_entities "
+    "WHERE kind='regional_quota_lease' "
+    "AND JSON_VALUE(body, '$.workspace_id')=@ws "
+    "AND (JSON_VALUE(body, '$.state') IS NULL "
+    "OR JSON_VALUE(body, '$.state')!='closed')"
+)
 
 
 @dataclass
 class InvariantReport:
     credit_rows: int = 0
     key_rows: int = 0
+    regional_lease_rows: int = 0
     credit_violations: int = 0  # reserved != open-hold sum, or reserved < 0
     key_violations: int = 0
+    regional_lease_violations: int = 0
     samples: dict[str, dict] = field(default_factory=dict)
 
     @property
     def clean(self) -> bool:
-        return self.credit_violations == 0 and self.key_violations == 0
+        return (
+            self.credit_violations == 0
+            and self.key_violations == 0
+            and self.regional_lease_violations == 0
+        )
 
     def summary(self) -> str:
         return (
             f"credit: {self.credit_violations}/{self.credit_rows} | "
             f"key: {self.key_violations}/{self.key_rows} | "
+            f"regional lease: {self.regional_lease_violations}/{self.regional_lease_rows} | "
             f"{'CLEAN' if self.clean else 'VIOLATIONS'}"
         )
 
 
+def _entity_body(raw: Any) -> dict[str, Any]:
+    body = json.loads(str(raw))
+    if not isinstance(body, dict):
+        raise ValueError("entity body is not an object")
+    return body
+
+
+def _required_int(body: dict[str, Any], field_name: str) -> int:
+    value = body.get(field_name)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"{field_name} is not an integer")
+    return value
+
+
+def _regional_quota_escrow(
+    rows: list[list[Any]],
+) -> tuple[dict[tuple[str, int], int], dict[str, str]]:
+    """Return outstanding global lease escrow grouped by typed credit shard.
+
+    Regional leases reserve credit directly instead of creating an ordinary
+    ``tr_reservation`` row. The open index and canonical lease are both checked
+    so a missing, duplicated, stale, or malformed index cannot silently alter
+    the expected typed balance.
+    """
+
+    holds: dict[tuple[str, int], int] = {}
+    errors: dict[str, str] = {}
+    seen_leases: set[str] = set()
+    for row in rows:
+        index_id = str(row[0])
+        try:
+            open_index = _entity_body(row[1])
+            lease_entity_id = open_index.get("lease_entity_id")
+            if not isinstance(lease_entity_id, str) or not lease_entity_id:
+                raise ValueError("open index has no lease_entity_id")
+            if row[2] is None or str(row[2]) != lease_entity_id or row[3] is None:
+                raise ValueError("indexed canonical lease is missing")
+            if lease_entity_id in seen_leases:
+                raise ValueError("canonical lease has more than one open index")
+            seen_leases.add(lease_entity_id)
+
+            lease = _entity_body(row[3])
+            workspace_id = lease.get("workspace_id")
+            region = lease.get("region")
+            lease_id = lease.get("lease_id")
+            expires_at = lease.get("expires_at")
+            if not all(isinstance(value, str) and value for value in (
+                workspace_id,
+                region,
+                lease_id,
+                expires_at,
+            )):
+                raise ValueError("canonical lease identity is incomplete")
+            if lease_entity_id != f"{workspace_id}#{region}#{lease_id}":
+                raise ValueError("canonical lease id does not match its body")
+            if index_id != f"{expires_at}#{workspace_id}#{region}#{lease_id}":
+                raise ValueError("open index id does not match the canonical lease")
+            for field_name in ("workspace_id", "region", "lease_id", "expires_at"):
+                if open_index.get(field_name) != lease.get(field_name):
+                    raise ValueError(f"open index {field_name} does not match canonical lease")
+
+            state = lease.get("state")
+            if state not in _OPEN_REGIONAL_QUOTA_STATES:
+                raise ValueError(f"open index points to lease in {state!r} state")
+            granted = _required_int(lease, "granted_microdollars")
+            reconciled = _required_int(lease, "reconciled_spent_microdollars")
+            shard = _required_int(lease, "credit_shard")
+            if granted < 0 or reconciled < 0 or reconciled > granted or shard < 0:
+                raise ValueError("canonical lease escrow values are invalid")
+            outstanding = granted - reconciled
+            scope = (str(workspace_id), shard)
+            holds[scope] = holds.get(scope, 0) + outstanding
+        except (TypeError, ValueError) as exc:
+            errors[index_id] = str(exc)
+    return holds, errors
+
+
 def audit_typed_invariants(store: Any, *, max_samples: int = 20) -> InvariantReport:
     """Assert, in one consistent snapshot, that every typed `reserved` equals the
-    sum of that (scope, shard)'s OPEN typed-origin holds and is non-negative.
+    sum of that (scope, shard)'s request holds and regional lease escrow.
     Checks BOTH directions: a typed row whose reserved != its open holds, AND an
     open hold group with no typed row (that leak is invisible if you only iterate
     typed rows). Read-only."""
@@ -75,6 +179,11 @@ def audit_typed_invariants(store: Any, *, max_samples: int = 20) -> InvariantRep
             scope = (str(row[0]), shard)
             credit_holds[scope] = credit_holds.get(scope, 0) + int(row[3] or 0)
         key_holds = {(r[0], r[1]): int(r[2] or 0) for r in snap.execute_sql(_OPEN_KEY_HOLDS)}
+        regional_rows = list(snap.execute_sql(_OPEN_REGIONAL_QUOTA_ESCROW))
+
+    regional_holds, regional_errors = _regional_quota_escrow(regional_rows)
+    for scope, held in regional_holds.items():
+        credit_holds[scope] = credit_holds.get(scope, 0) + held
 
     def _sample(key: str, value: dict) -> None:
         if len(report.samples) < max_samples:
@@ -100,6 +209,10 @@ def audit_typed_invariants(store: Any, *, max_samples: int = 20) -> InvariantRep
 
     report.credit_rows, report.credit_violations = _check(typed_credit, credit_holds, "credit")
     report.key_rows, report.key_violations = _check(typed_key, key_holds, "api_key")
+    report.regional_lease_rows = len(regional_rows)
+    report.regional_lease_violations = len(regional_errors)
+    for index_id, error in regional_errors.items():
+        _sample(f"regional-lease:{index_id}", {"error": error})
     return report
 
 
@@ -159,7 +272,7 @@ def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False)
         if b.get("workspace_id") == workspace_id
     ]
     key_hashes = [str(body["hash"]) for body in key_bodies]
-    with store._database.snapshot(multi_use=True) as snap:  # 3 reads below — must be multi-use
+    with store._database.snapshot(multi_use=True) as snap:
         cb = list(snap.execute_sql(
             credit_row_sql, params={"pk": workspace_id}, param_types={"pk": pt.STRING},
         ))
@@ -168,6 +281,11 @@ def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False)
         ))[0][0]
         nonzero_shard = list(snap.execute_sql(
             nonzero_shard_sql, params={"ws": workspace_id}, param_types={"ws": pt.STRING},
+        ))[0][0]
+        open_regional_leases = list(snap.execute_sql(
+            _NONCLOSED_REGIONAL_QUOTA_LEASES_FOR_REPAIR,
+            params={"ws": workspace_id},
+            param_types={"ws": pt.STRING},
         ))[0][0]
 
     if workspace is None or not getattr(workspace, "billing_paused", False):
@@ -180,6 +298,10 @@ def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False)
         res.reasons.append("no typed credit row")
     if int(nonzero_shard) != 0:
         res.reasons.append(f"{nonzero_shard} open holds on a nonzero shard — sharded ws not handled")
+    if int(open_regional_leases) != 0:
+        res.reasons.append(
+            f"{open_regional_leases} regional quota leases are open — drain them before repair"
+        )
     res.ready = not res.reasons
     if cb:
         res.credit_reserved_before = int(cb[0][0])
@@ -201,6 +323,12 @@ def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False)
             return None
         if int(list(transaction.execute_sql(
             nonzero_shard_sql, params={"ws": workspace_id}, param_types={"ws": pt.STRING},
+        ))[0][0]) != 0:
+            return None
+        if int(list(transaction.execute_sql(
+            _NONCLOSED_REGIONAL_QUOTA_LEASES_FOR_REPAIR,
+            params={"ws": workspace_id},
+            param_types={"ws": pt.STRING},
         ))[0][0]) != 0:
             return None
         if not list(transaction.execute_sql(
@@ -244,7 +372,10 @@ def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False)
     result = store._run_in_transaction(_txn)
     if result is None:
         res.ready = False
-        res.reasons.append("aborted: not paused / nonzero shard / a typed row was missing (key deleted?)")
+        res.reasons.append(
+            "aborted: not paused / open regional lease / nonzero shard / "
+            "a typed row was missing (key deleted?)"
+        )
         return res
     res.applied = True
     res.keys_repaired = result["keys"]

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -1497,6 +1497,60 @@ def _execute_sql(
     params: dict[str, Any],
 ) -> list[list[str]]:
     kind = params.get("kind", "")
+    if "/* nonclosed_regional_quota_leases_for_repair */" in sql:
+        workspace_id = str(params["ws"])
+        count = 0
+        for (row_kind, _entity_id), row in db.rows.items():
+            if row_kind != "regional_quota_lease":
+                continue
+            try:
+                body = json.loads(row.body)
+            except (TypeError, ValueError):
+                continue
+            if body.get("workspace_id") == workspace_id and body.get("state") != "closed":
+                count += 1
+        return [[count]]
+    if "/* open_regional_quota_escrow */" in sql:
+        _require_pred(
+            sql,
+            "open_index.kind='regional_quota_lease_open'",
+            "regional quota open-index kind",
+        )
+        _require_pred(
+            sql,
+            "lease_record.kind='regional_quota_lease'",
+            "regional quota canonical kind",
+        )
+        _require_pred(
+            sql,
+            "lease_record.id=JSON_VALUE(open_index.body, '$.lease_entity_id')",
+            "regional quota canonical pointer",
+        )
+        _require_pred(sql, "LEFT JOIN", "regional quota missing-target detection")
+        output: list[list[Any]] = []
+        for (row_kind, index_id), index_row in db.rows.items():
+            if row_kind != "regional_quota_lease_open":
+                continue
+            try:
+                open_body = json.loads(index_row.body)
+                lease_entity_id = open_body.get("lease_entity_id")
+            except (AttributeError, TypeError, ValueError):
+                lease_entity_id = None
+            lease_row = (
+                db.rows.get(("regional_quota_lease", lease_entity_id))
+                if isinstance(lease_entity_id, str)
+                else None
+            )
+            output.append(
+                [
+                    index_id,
+                    index_row.body,
+                    lease_entity_id if lease_row is not None else None,
+                    lease_row.body if lease_row is not None else None,
+                ]
+            )
+        output.sort(key=lambda row: str(row[0]))
+        return output
     if "/* console_api_keys */" in sql:
         _require_pred(
             sql,

--- a/tests/test_billing_repair_reserved.py
+++ b/tests/test_billing_repair_reserved.py
@@ -9,6 +9,7 @@ from tests.fakes.spanner import make_fake_store
 from trusted_router.storage import Workspace
 from trusted_router.storage_gcp_counter_reconcile import repair_typed_reserved
 from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
+from trusted_router.storage_gcp_regional_quota import GlobalRegionalQuotaLease
 
 
 def _paused_ws(store, ws: str, *, paused: bool = True) -> None:
@@ -132,3 +133,34 @@ def test_repair_zero_holds_zeroes_reserved() -> None:
     result = repair_typed_reserved(store, ws, apply=True)
     assert result.ready and result.applied
     assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["reserved"] == 0
+
+
+def test_repair_refuses_open_regional_lease_even_without_open_index() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_regional_escrow"
+    _paused_ws(store, ws)
+    db.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(ws, 0)] = {
+        "workspace_id": ws,
+        "shard": 0,
+        "total_credits": 1_000_000,
+        "total_usage": 0,
+        "reserved": 625_000,
+    }
+    lease = GlobalRegionalQuotaLease(
+        lease_id="lease-with-missing-index",
+        workspace_id=ws,
+        region="us-central1",
+        fencing_token=1,
+        granted_microdollars=625_000,
+        credit_shard=0,
+        expires_at="2026-08-22T01:00:00Z",
+        state="active",
+    )
+    store._write_entity("regional_quota_lease", lease.entity_id, lease)
+
+    result = repair_typed_reserved(store, ws, apply=True)
+
+    assert not result.ready
+    assert not result.applied
+    assert any("regional quota leases are open" in reason for reason in result.reasons)
+    assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["reserved"] == 625_000

--- a/tests/test_billing_typed_auditor.py
+++ b/tests/test_billing_typed_auditor.py
@@ -9,6 +9,10 @@ from __future__ import annotations
 from tests.fakes.spanner import make_fake_store
 from trusted_router.storage_gcp_counter_reconcile import audit_typed_invariants
 from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
+from trusted_router.storage_gcp_regional_quota import (
+    GlobalRegionalQuotaLease,
+    OpenRegionalQuotaLease,
+)
 
 
 def _credit_row(db, ws: str, reserved: int) -> None:
@@ -30,6 +34,36 @@ def _resv(db, rid: str, *, ws=None, key=None, credit=0, key_micro=0, settled=Fal
         "reservation_id": rid, "workspace_id": ws, "key_hash": key,
         "credit_reserved_micro": credit, "key_reserved_micro": key_micro, "settled": settled,
     }
+
+
+def _regional_lease(
+    store,
+    *,
+    ws: str,
+    lease_id: str,
+    granted: int,
+    reconciled: int,
+) -> None:
+    lease = GlobalRegionalQuotaLease(
+        lease_id=lease_id,
+        workspace_id=ws,
+        region="us-central1",
+        fencing_token=1,
+        granted_microdollars=granted,
+        reconciled_spent_microdollars=reconciled,
+        credit_shard=0,
+        expires_at="2026-08-22T01:00:00Z",
+        state="active",
+    )
+    open_lease = OpenRegionalQuotaLease(
+        lease_entity_id=lease.entity_id,
+        workspace_id=lease.workspace_id,
+        region=lease.region,
+        lease_id=lease.lease_id,
+        expires_at=lease.expires_at,
+    )
+    store._write_entity("regional_quota_lease", lease.entity_id, lease)
+    store._write_entity("regional_quota_lease_open", open_lease.entity_id, open_lease)
 
 
 def test_auditor_clean_when_reserved_equals_open_holds() -> None:
@@ -96,3 +130,37 @@ def test_auditor_key_invariant() -> None:
     assert not report.clean
     assert report.key_violations == 1
     assert f"api_key:{kh}:0" in report.samples
+
+
+def test_auditor_sums_request_holds_and_multiple_regional_leases() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_regional"
+    _credit_row(db, ws, reserved=700_000)
+    _resv(db, "r1", ws=ws, credit=100_000)
+    _regional_lease(store, ws=ws, lease_id="lease-a", granted=400_000, reconciled=100_000)
+    _regional_lease(store, ws=ws, lease_id="lease-b", granted=500_000, reconciled=200_000)
+
+    report = audit_typed_invariants(store)
+
+    assert report.clean, (report.summary(), report.samples)
+    assert report.regional_lease_rows == 2
+
+
+def test_auditor_fails_closed_for_missing_regional_lease_target() -> None:
+    store, _db, _ = make_fake_store()
+    open_lease = OpenRegionalQuotaLease(
+        lease_entity_id="missing#us-central1#lease-missing",
+        workspace_id="missing",
+        region="us-central1",
+        lease_id="lease-missing",
+        expires_at="2026-08-22T01:00:00Z",
+    )
+    store._write_entity("regional_quota_lease_open", open_lease.entity_id, open_lease)
+
+    report = audit_typed_invariants(store)
+
+    assert not report.clean
+    assert report.regional_lease_violations == 1
+    assert report.samples[f"regional-lease:{open_lease.entity_id}"] == {
+        "error": "indexed canonical lease is missing"
+    }

--- a/tests/test_regional_quota_spanner.py
+++ b/tests/test_regional_quota_spanner.py
@@ -14,6 +14,7 @@ from trusted_router.regional_quota_ledger import (
 from trusted_router.services.settle_outbox_apply import ApplyOutcome, apply_frozen_settle
 from trusted_router.storage import configure_store
 from trusted_router.storage_gcp_authorize import settle_atomic
+from trusted_router.storage_gcp_counter_reconcile import audit_typed_invariants
 from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
 from trusted_router.storage_gcp_regional_quota import (
     GlobalRegionalQuotaLease,
@@ -79,6 +80,14 @@ def test_global_grant_and_reconcile_preserve_exact_credit_and_key_totals() -> No
         0,
         6_250_000,
     )
+    assert audit_typed_invariants(store).clean
+
+    # Lease escrow is authoritative, but an additional unmatched reserved unit
+    # must still trip the invariant rather than being hidden by the lease.
+    credit_row = database.typed[CREDIT_BALANCE_TABLE][(workspace.id, global_lease.credit_shard)]
+    credit_row["reserved"] += 1
+    assert not audit_typed_invariants(store).clean
+    credit_row["reserved"] -= 1
 
     global_lease = activate_regional_quota_lease(store, global_lease, now=NOW)
     ledger = InMemoryRegionalQuotaLedger()
@@ -102,6 +111,23 @@ def test_global_grant_and_reconcile_preserve_exact_credit_and_key_totals() -> No
         actual_microdollars=3_250,
         fencing_token=local.fencing_token,
     )
+
+    partial = reconcile_regional_quota_lease(
+        store,
+        global_lease,
+        local,
+        close=False,
+        now=NOW + timedelta(minutes=1),
+    )
+    assert partial.spent_delta_microdollars == 3_250
+    assert partial.unused_released_microdollars == 0
+    assert _credit_totals(database, workspace.id) == (
+        100_000_000,
+        3_250,
+        6_246_750,
+    )
+    assert audit_typed_invariants(store).clean
+
     local = ledger.begin_drain(
         local.lease_id,
         region=local.region,
@@ -115,7 +141,7 @@ def test_global_grant_and_reconcile_preserve_exact_credit_and_key_totals() -> No
         close=True,
         now=NOW + timedelta(minutes=2),
     )
-    assert result.spent_delta_microdollars == 3_250
+    assert result.spent_delta_microdollars == 0
     assert result.unused_released_microdollars == 6_246_750
     assert _credit_totals(database, workspace.id) == (
         100_000_000,
@@ -130,6 +156,7 @@ def test_global_grant_and_reconcile_preserve_exact_credit_and_key_totals() -> No
         )
         == []
     )
+    assert audit_typed_invariants(store).clean
 
     replay = reconcile_regional_quota_lease(
         store,


### PR DESCRIPTION
## Summary
- count remaining regional quota lease escrow in typed credit invariants
- validate open lease indexes against canonical lease records and fail closed on malformed state
- prevent the reserved-counter repair tool from running while canonical regional leases remain open
- add integration regressions for grant, partial reconciliation, close, and true unmatched leakage

## Production verification
- read-only audit: credit 0/969, key 0/1352, regional lease 0/3, CLEAN
- no production balances were changed

## Tests
- uv run pytest -q tests/test_billing_typed_auditor.py tests/test_billing_repair_reserved.py tests/test_regional_quota_spanner.py
- uv run pytest -q tests/test_billing*.py tests/test_regional_quota*.py
- uv run ruff check src/trusted_router/storage_gcp_counter_reconcile.py tests/fakes/spanner.py tests/test_billing_typed_auditor.py tests/test_billing_repair_reserved.py tests/test_regional_quota_spanner.py
- uv run mypy