### PR TITLE
Route exact-intent traffic into landing experiment

### DIFF
--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -193,6 +193,12 @@ CHOOSE_CATALOG_STALE_SECONDS = 86_400
 MODEL_REGION_PAGE_CACHE_SECONDS = 300
 MODEL_REGION_PAGE_STALE_SECONDS = 86_400
 INDEXNOW_KEY = "360a02e48445d297f9612a4c3fef878b"
+OPENROUTER_LANDING_EXPERIMENT_CAMPAIGNS = frozenset(
+    {
+        "openrouter_alternative_exact",
+        "openrouter_lp_multi_20260822",
+    }
+)
 _STATUS_CACHE: tuple[float, dict[str, Any]] | None = None
 # /fleet fans out to every peer's status.json, so its cache TTL is what keeps
 # a page-refresh storm from turning into a cross-cloud fetch storm.
@@ -998,9 +1004,24 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     async def seo_x402_llm_api() -> str:
         return public_page_html(settings, "x402-llm-api")
 
+    def openrouter_landing_experiment_redirect(request: Request) -> RedirectResponse:
+        attribution = getattr(request.state, "acquisition_attribution", None)
+        seed = getattr(attribution, "anonymous_id", None)
+        selected_path = assigned_openrouter_landing_path(seed)
+        query = request.url.query
+        location = f"{selected_path}?{query}" if query else selected_path
+        return RedirectResponse(url=location, status_code=307)
+
     @public_html_route("/openrouter-alternative")
-    async def seo_openrouter_alternative() -> str:
-        return public_page_html(settings, "openrouter-alternative")
+    async def seo_openrouter_alternative(
+        request: Request,
+    ) -> Response:
+        if (
+            request.query_params.get("utm_campaign")
+            in OPENROUTER_LANDING_EXPERIMENT_CAMPAIGNS
+        ):
+            return openrouter_landing_experiment_redirect(request)
+        return HTMLResponse(public_page_html(settings, "openrouter-alternative"))
 
     @public_html_route("/private-llm-api")
     async def seo_private_llm_api() -> str:
@@ -1019,12 +1040,7 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     async def experiment_openrouter_landing_router(
         request: Request,
     ) -> RedirectResponse:
-        attribution = getattr(request.state, "acquisition_attribution", None)
-        seed = getattr(attribution, "anonymous_id", None)
-        selected_path = assigned_openrouter_landing_path(seed)
-        query = request.url.query
-        location = f"{selected_path}?{query}" if query else selected_path
-        return RedirectResponse(url=location, status_code=307)
+        return openrouter_landing_experiment_redirect(request)
 
     @public_html_route(
         "/openrouter-alternative/lp/{variant_slug}",

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -274,6 +274,42 @@ def test_openrouter_experiment_router_is_sticky_and_preserves_campaign_query(
     assert '<meta name="robots" content="noindex,follow">' in rendered.text
 
 
+@pytest.mark.parametrize(
+    "campaign",
+    ["openrouter_alternative_exact", "openrouter_lp_multi_20260822"],
+)
+def test_openrouter_paid_campaign_enters_landing_experiment_without_ad_edit(
+    client: TestClient,
+    campaign: str,
+) -> None:
+    query = (
+        "utm_source=google&utm_medium=cpc&"
+        f"utm_campaign={campaign}&utm_term=openrouter+alternative&"
+        "utm_content=search&gclid=paid-click-123"
+    )
+
+    response = client.get(
+        f"/openrouter-alternative?{query}",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 307
+    destination = urlsplit(response.headers["location"])
+    assert destination.path in OPENROUTER_PAID_LANDING_PATHS
+    assert parse_qs(destination.query) == parse_qs(query)
+
+
+def test_openrouter_non_experiment_campaign_keeps_canonical_page(
+    client: TestClient,
+) -> None:
+    response = client.get(
+        "/openrouter-alternative?utm_source=google&utm_campaign=seo_baseline"
+    )
+
+    assert response.status_code == 200
+    assert "OpenRouter Alternatives: 10 AI Gateways Compared (2026)" in response.text
+
+
 def test_openrouter_experiment_assignment_reaches_every_arm() -> None:
     assigned = {
         assigned_openrouter_landing_path(f"anonymous-{index}")


### PR DESCRIPTION
## Summary
- route the existing exact-intent Google campaign into the six-arm landing-page experiment
- preserve every campaign and click parameter through stable anonymous assignment
- keep organic and unrelated campaign traffic on the canonical SEO page

## Verification
- `uv run ruff check src/trusted_router/routes/public.py tests/test_public_seo_pages.py`
- `uv run mypy src/trusted_router/routes/public.py`
- `uv run pytest -q tests/test_public_seo_pages.py tests/test_acquisition_attribution.py` (109 passed)
- public OpenAPI generator produced no diff