### PR TITLE
Refresh the ClickHouse workspace directory hourly, with no PII by construction

### DIFF
--- a/clickhouse/010_workspace_directory.sql
+++ b/clickhouse/010_workspace_directory.sql
@@ -1,0 +1,17 @@
+-- Workspace directory metadata contains workspace ids and names only.
+
+CREATE TABLE IF NOT EXISTS tr.workspace_directory ON CLUSTER trustedrouter
+(
+    tenant_id           FixedString(64),
+    workspace_id        LowCardinality(String),
+    workspace_name      String,
+    deleted             UInt8,
+    workspace_created_at DateTime('UTC'),
+    refreshed_at        DateTime('UTC')
+)
+ENGINE = ReplicatedReplacingMergeTree(
+    '/trustedrouter/tables/{shard}/workspace_directory-v1',
+    '{replica}',
+    refreshed_at
+)
+ORDER BY tenant_id;

--- a/clickhouse/011_workspace_directory_single_node.sql
+++ b/clickhouse/011_workspace_directory_single_node.sql
@@ -1,0 +1,14 @@
+-- Column-for-column single-node counterpart to 010_workspace_directory.sql.
+-- The engine is the only difference from the replicated definition.
+
+CREATE TABLE IF NOT EXISTS tr.workspace_directory
+(
+    tenant_id           FixedString(64),
+    workspace_id        LowCardinality(String),
+    workspace_name      String,
+    deleted             UInt8,
+    workspace_created_at DateTime('UTC'),
+    refreshed_at        DateTime('UTC')
+)
+ENGINE = ReplacingMergeTree(refreshed_at)
+ORDER BY tenant_id;

--- a/clickhouse/refresh_workspace_directory.py
+++ b/clickhouse/refresh_workspace_directory.py
@@ -1,0 +1,228 @@
+"""Refresh the no-PII ClickHouse workspace directory from Spanner.
+
+The projection permits workspace ids and workspace names only; all other
+entity attributes are discarded before a ClickHouse payload is built.
+ReplacingMergeTree uses ``refreshed_at`` as its version, making repeated runs
+idempotent. A workspace rename therefore converges on the newest row at
+``FINAL``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import urllib.parse
+import urllib.request
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from trusted_router.storage_operational_analytics import analytics_surrogate
+
+PROJECT = "quill-cloud-proxy"
+SPANNER_INSTANCE = "trusted-router-nam6"
+SPANNER_DATABASE = "trusted-router"
+CLICKHOUSE_URL = "http://localhost:8123/"
+DIRECTORY_TABLE = "tr.workspace_directory"
+MAP_TABLE = "tr.tenant_workspace_map"
+
+
+class WorkspaceSource(Protocol):
+    def fetch(self) -> list[Mapping[str, Any]]: ...
+
+
+class DirectoryWriter(Protocol):
+    def upsert_directory(self, rows: list[dict[str, Any]]) -> None: ...
+
+    def upsert_tenant_map(self, rows: list[dict[str, Any]]) -> None: ...
+
+
+@dataclass(frozen=True)
+class RefreshResult:
+    source_rows: int
+    directory_rows: int
+    tenant_map_rows: int
+
+
+def _utc(value: dt.datetime) -> dt.datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=dt.UTC)
+    return value.astimezone(dt.UTC)
+
+
+def _clickhouse_datetime(value: Any, *, field: str) -> str:
+    if isinstance(value, dt.datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise ValueError(f"workspace {field} is not an ISO timestamp") from exc
+    else:
+        raise ValueError(f"workspace {field} is not an ISO timestamp")
+    return _utc(parsed).replace(microsecond=0).strftime("%Y-%m-%d %H:%M:%S")
+
+
+class SpannerWorkspaceSource:
+    """Read only workspace entity bodies from the system of record."""
+
+    def __init__(self, *, project: str, instance: str, database: str) -> None:
+        from google.cloud import spanner
+        from google.cloud.spanner_v1 import param_types
+
+        self._database = (
+            spanner.Client(project=project, disable_builtin_metrics=True)
+            .instance(instance)
+            .database(database)
+        )
+        self._pt = param_types
+
+    def fetch(self) -> list[Mapping[str, Any]]:
+        with self._database.snapshot() as snapshot:
+            values = snapshot.execute_sql(
+                "SELECT body FROM tr_entities WHERE kind=@kind ORDER BY id",
+                params={"kind": "workspace"},
+                param_types={"kind": self._pt.STRING},
+            )
+            bodies: list[Mapping[str, Any]] = []
+            for row in values:
+                body = json.loads(str(row[0]))
+                if not isinstance(body, dict):
+                    raise ValueError("workspace body is not a JSON object")
+                bodies.append(body)
+            return bodies
+
+
+class ClickHouseDirectoryWriter:
+    """Synchronous JSONEachRow inserts through the ClickHouse HTTP interface."""
+
+    def __init__(self, *, url: str, password: str) -> None:
+        self._url = url
+        self._password = password
+
+    def _insert(self, table: str, rows: list[dict[str, Any]]) -> None:
+        if not rows:
+            return
+        payload = (
+            "\n".join(json.dumps(row, separators=(",", ":"), sort_keys=True) for row in rows)
+            + "\n"
+        ).encode()
+        separator = "&" if "?" in self._url else "?"
+        endpoint = self._url + separator + urllib.parse.urlencode(
+            {"query": f"INSERT INTO {table} FORMAT JSONEachRow"}
+        )
+        request = urllib.request.Request(  # noqa: S310 - configured node URL
+            endpoint,
+            data=payload,
+            method="POST",
+            headers={
+                "Content-Type": "application/x-ndjson",
+                "X-ClickHouse-User": "tr",
+                "X-ClickHouse-Key": self._password,
+            },
+        )
+        with urllib.request.urlopen(request, timeout=300):  # noqa: S310 - configured node URL
+            pass
+
+    def upsert_directory(self, rows: list[dict[str, Any]]) -> None:
+        self._insert(DIRECTORY_TABLE, rows)
+
+    def upsert_tenant_map(self, rows: list[dict[str, Any]]) -> None:
+        self._insert(MAP_TABLE, rows)
+
+
+def _project_workspace(body: Mapping[str, Any], *, refreshed_at: dt.datetime) -> dict[str, Any]:
+    workspace_id = str(body["id"])
+    return {
+        "tenant_id": analytics_surrogate("workspace", workspace_id),
+        "workspace_id": workspace_id,
+        "workspace_name": str(body["name"]),
+        "deleted": int(bool(body.get("deleted", False))),
+        "workspace_created_at": _clickhouse_datetime(body["created_at"], field="created_at"),
+        "refreshed_at": _clickhouse_datetime(refreshed_at, field="refreshed_at"),
+    }
+
+
+def refresh_workspace_directory(
+    source: WorkspaceSource,
+    writer: DirectoryWriter | None,
+    *,
+    dry_run: bool = False,
+    started_at: dt.datetime | None = None,
+) -> RefreshResult:
+    """Read, project, and insert one complete workspace directory snapshot."""
+    job_start = _utc(started_at or dt.datetime.now(dt.UTC)).replace(microsecond=0)
+    bodies = source.fetch()
+    directory_rows = [_project_workspace(body, refreshed_at=job_start) for body in bodies]
+    tenant_map_rows = [
+        {"tenant_id": row["tenant_id"], "workspace_id": row["workspace_id"]}
+        for row in directory_rows
+    ]
+    if not dry_run:
+        if writer is None:
+            raise ValueError("writer is required unless dry-run is selected")
+        writer.upsert_directory(directory_rows)
+        writer.upsert_tenant_map(tenant_map_rows)
+    return RefreshResult(
+        source_rows=len(bodies),
+        directory_rows=len(directory_rows),
+        tenant_map_rows=len(tenant_map_rows),
+    )
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--project", default=os.environ.get("GCP_PROJECT_ID", PROJECT))
+    parser.add_argument(
+        "--spanner-instance",
+        default=os.environ.get("SPANNER_INSTANCE_ID", SPANNER_INSTANCE),
+    )
+    parser.add_argument(
+        "--spanner-database",
+        default=os.environ.get("SPANNER_DATABASE_ID", SPANNER_DATABASE),
+    )
+    parser.add_argument(
+        "--clickhouse-url",
+        default=os.environ.get("CLICKHOUSE_URL", CLICKHOUSE_URL),
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    source: WorkspaceSource | None = None,
+    writer: DirectoryWriter | None = None,
+) -> int:
+    args = _parse_args(argv)
+    selected_source = source or SpannerWorkspaceSource(
+        project=args.project,
+        instance=args.spanner_instance,
+        database=args.spanner_database,
+    )
+    selected_writer = writer
+    if not args.dry_run and selected_writer is None:
+        selected_writer = ClickHouseDirectoryWriter(
+            url=args.clickhouse_url,
+            password=os.environ["CH_PASSWORD"],
+        )
+    result = refresh_workspace_directory(
+        selected_source,
+        selected_writer,
+        dry_run=args.dry_run,
+        started_at=dt.datetime.now(dt.UTC),
+    )
+    print(
+        f"source_rows={result.source_rows} "
+        f"workspace_directory_rows={result.directory_rows} "
+        f"tenant_workspace_map_rows={result.tenant_map_rows} "
+        f"dry_run={str(args.dry_run).lower()}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/clickhouse/tr-clickhouse-workspace-directory.service
+++ b/clickhouse/tr-clickhouse-workspace-directory.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=TrustedRouter ClickHouse workspace directory refresh
+After=network-online.target clickhouse-server.service
+Wants=network-online.target
+Requires=clickhouse-server.service
+
+[Service]
+Type=oneshot
+User=tr-clickhouse-ingest
+Group=tr-clickhouse-ingest
+WorkingDirectory=/opt/tr-clickhouse
+Environment=PYTHONUNBUFFERED=1
+Environment=PYTHONPATH=/opt/tr-clickhouse/src
+Environment=HOME=/var/lib/tr-clickhouse-ingest
+Environment=GCP_PROJECT_ID=quill-cloud-proxy
+EnvironmentFile=/etc/tr-clickhouse-ingest.env
+ExecStart=/opt/tr-clickhouse/venv/bin/python -m clickhouse.refresh_workspace_directory
+TimeoutStartSec=30m
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+
+[Install]
+WantedBy=multi-user.target

--- a/clickhouse/tr-clickhouse-workspace-directory.timer
+++ b/clickhouse/tr-clickhouse-workspace-directory.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Hourly TrustedRouter ClickHouse workspace directory refresh
+
+[Timer]
+OnCalendar=hourly
+RandomizedDelaySec=5min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/deploy/clickhouse_live_ingestion.sh
+++ b/scripts/deploy/clickhouse_live_ingestion.sh
@@ -32,7 +32,7 @@ fi
 
 archive=$(mktemp "${TMPDIR:-/tmp}/tr-clickhouse-live.XXXXXX.tar.gz")
 trap 'rm -f "$archive"' EXIT
-tar -C "$ROOT" -czf "$archive" clickhouse
+tar -C "$ROOT" -czf "$archive" clickhouse src/trusted_router
 
 ssh_node --command="sudo mkdir -p /opt/tr-clickhouse"
 ssh_node --command="sudo tar -xzf - -C /opt/tr-clickhouse" < "$archive"
@@ -65,6 +65,10 @@ ssh_node --command="sudo sh -c '
     /etc/systemd/system/tr-clickhouse-archive.service
   install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-archive.timer \
     /etc/systemd/system/tr-clickhouse-archive.timer
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-workspace-directory.service \
+    /etc/systemd/system/tr-clickhouse-workspace-directory.service
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-workspace-directory.timer \
+    /etc/systemd/system/tr-clickhouse-workspace-directory.timer
   install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-archive-restore.service \
     /etc/systemd/system/tr-clickhouse-archive-restore.service
   install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-archive-restore.timer \
@@ -84,17 +88,21 @@ ssh_node --command="sudo sh -c '
     --multiquery < /opt/tr-clickhouse/clickhouse/001_provider_benchmark_samples.sql
   clickhouse-client --user tr --password \"\$CH_PASSWORD\" --database tr \
     --multiquery < /opt/tr-clickhouse/clickhouse/002_provider_analytics_rollups.sql
+  clickhouse-client --user tr --password \"\$CH_PASSWORD\" --database tr \
+    --multiquery < /opt/tr-clickhouse/clickhouse/010_workspace_directory.sql
   systemctl daemon-reload
   systemctl enable tr-clickhouse-ingest.service
   systemctl restart tr-clickhouse-ingest.service
   systemctl enable --now tr-clickhouse-reconcile.timer
   systemctl enable --now tr-clickhouse-archive.timer
+  systemctl enable --now tr-clickhouse-workspace-directory.timer
   systemctl enable --now tr-clickhouse-archive-restore.timer
   systemctl enable --now tr-clickhouse-rollup-hourly.timer
   systemctl enable --now tr-clickhouse-rollup-daily.timer
   systemctl is-active tr-clickhouse-ingest.service
   systemctl is-active tr-clickhouse-reconcile.timer
   systemctl is-active tr-clickhouse-archive.timer
+  systemctl is-active tr-clickhouse-workspace-directory.timer
   systemctl is-active tr-clickhouse-archive-restore.timer
   systemctl is-active tr-clickhouse-rollup-hourly.timer
   systemctl is-active tr-clickhouse-rollup-daily.timer

--- a/tests/test_clickhouse_operational_deploy.py
+++ b/tests/test_clickhouse_operational_deploy.py
@@ -251,3 +251,34 @@ def test_capacity_probe_is_disposable_and_uses_a_conservative_gate() -> None:
     assert "SYSTEM SYNC REPLICA" in script
     assert "throughput * 0.25" in script
     assert "add_shard_now" in script
+
+
+def test_workspace_directory_refresh_is_installed_and_scheduled_hourly() -> None:
+    deploy = (ROOT / "scripts/deploy/clickhouse_live_ingestion.sh").read_text()
+    service = (ROOT / "clickhouse/tr-clickhouse-workspace-directory.service").read_text()
+    timer = (ROOT / "clickhouse/tr-clickhouse-workspace-directory.timer").read_text()
+
+    assert "tr-clickhouse-workspace-directory.service" in deploy
+    assert "tr-clickhouse-workspace-directory.timer" in deploy
+    assert "010_workspace_directory.sql" in deploy
+    assert "systemctl enable --now tr-clickhouse-workspace-directory.timer" in deploy
+    assert "systemctl is-active tr-clickhouse-workspace-directory.timer" in deploy
+    assert "EnvironmentFile=/etc/tr-clickhouse-ingest.env" in service
+    assert "User=tr-clickhouse-ingest" in service
+    assert "WorkingDirectory=/opt/tr-clickhouse" in service
+    assert (
+        "ExecStart=/opt/tr-clickhouse/venv/bin/python "
+        "-m clickhouse.refresh_workspace_directory"
+    ) in service
+    for hardening in (
+        "NoNewPrivileges=true",
+        "PrivateTmp=true",
+        "ProtectHome=true",
+        "ProtectSystem=strict",
+    ):
+        assert hardening in service
+    assert "After=network-online.target clickhouse-server.service" in service
+    assert "Requires=clickhouse-server.service" in service
+    assert "OnCalendar=hourly" in timer
+    assert "RandomizedDelaySec=5min" in timer
+    assert "Persistent=true" in timer

--- a/tests/test_workspace_directory_refresh.py
+++ b/tests/test_workspace_directory_refresh.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from clickhouse.refresh_workspace_directory import main, refresh_workspace_directory
+from trusted_router.storage_operational_analytics import analytics_surrogate
+
+ROOT = Path(__file__).parents[1]
+
+
+class FakeSpannerSource:
+    def __init__(self, bodies: list[Mapping[str, Any]]) -> None:
+        self.bodies = bodies
+        self.fetches = 0
+
+    def fetch(self) -> list[Mapping[str, Any]]:
+        self.fetches += 1
+        return self.bodies
+
+
+class FakeWriter:
+    def __init__(self) -> None:
+        self.directory_rows: list[dict[str, Any]] = []
+        self.tenant_map_rows: list[dict[str, Any]] = []
+
+    def upsert_directory(self, rows: list[dict[str, Any]]) -> None:
+        self.directory_rows.extend(rows)
+
+    def upsert_tenant_map(self, rows: list[dict[str, Any]]) -> None:
+        self.tenant_map_rows.extend(rows)
+
+
+def _source() -> FakeSpannerSource:
+    return FakeSpannerSource(
+        [
+            {
+                "id": "ws-one",
+                "name": "First workspace",
+                "deleted": False,
+                "created_at": "2026-08-20T12:34:56Z",
+                "email": "must-not-be-projected@example.test",
+                "owner_email": "also-must-not-be-projected@example.test",
+            },
+            {
+                "id": "ws-two",
+                "name": "Renamed workspace",
+                "deleted": True,
+                "created_at": "2026-08-21T01:02:03+00:00",
+            },
+        ]
+    )
+
+
+def test_refresh_projects_only_directory_fields_and_updates_both_tables() -> None:
+    source = _source()
+    writer = FakeWriter()
+    started_at = dt.datetime(2026, 8, 22, 9, 10, 11, tzinfo=dt.UTC)
+
+    result = refresh_workspace_directory(source, writer, started_at=started_at)
+
+    assert result.source_rows == result.directory_rows == result.tenant_map_rows == 2
+    assert source.fetches == 1
+    assert [row["deleted"] for row in writer.directory_rows] == [0, 1]
+    assert all(
+        set(row)
+        == {
+            "tenant_id",
+            "workspace_id",
+            "workspace_name",
+            "deleted",
+            "workspace_created_at",
+            "refreshed_at",
+        }
+        for row in writer.directory_rows
+    )
+    assert all("email" not in key for row in writer.directory_rows for key in row)
+    for row in writer.directory_rows:
+        assert row["tenant_id"] == analytics_surrogate("workspace", row["workspace_id"])
+
+    directory_pairs = {
+        (row["tenant_id"], row["workspace_id"]) for row in writer.directory_rows
+    }
+    mapping_pairs = {
+        (row["tenant_id"], row["workspace_id"]) for row in writer.tenant_map_rows
+    }
+    assert directory_pairs == mapping_pairs
+
+
+def test_dry_run_reads_and_counts_but_writes_nothing(capsys: Any) -> None:
+    source = _source()
+    writer = FakeWriter()
+
+    assert main(["--dry-run"], source=source, writer=writer) == 0
+
+    assert source.fetches == 1
+    assert writer.directory_rows == []
+    assert writer.tenant_map_rows == []
+    output = capsys.readouterr().out
+    assert "workspace_directory_rows=2" in output
+    assert "tenant_workspace_map_rows=2" in output
+    assert "dry_run=true" in output
+
+
+def test_refresh_source_contains_no_private_identity_queries() -> None:
+    source = (ROOT / "clickhouse/refresh_workspace_directory.py").read_text().lower()
+    assert "email" not in source
+    assert "kind='user'" not in source
+
+
+def test_workspace_directory_schemas_have_matching_columns_and_version_order() -> None:
+    replicated = (ROOT / "clickhouse/010_workspace_directory.sql").read_text()
+    single = (ROOT / "clickhouse/011_workspace_directory_single_node.sql").read_text()
+
+    for column in (
+        "tenant_id",
+        "workspace_id",
+        "workspace_name",
+        "deleted",
+        "workspace_created_at",
+        "refreshed_at",
+    ):
+        assert column in replicated
+        assert column in single
+    assert "ON CLUSTER trustedrouter" in replicated
+    assert (
+        "'/trustedrouter/tables/{shard}/workspace_directory-v1',\n"
+        "    '{replica}',\n"
+        "    refreshed_at"
+    ) in replicated
+    assert "ENGINE = ReplacingMergeTree(refreshed_at)" in single


### PR DESCRIPTION
## Why

Analysts join ClickHouse analytics to workspaces through `tr.tenant_workspace_map` (`tenant_id → workspace_id`). It was hand-loaded once and went stale **within a day** — 524 rows against 594 live workspaces — so a full day of new signups was unattributable until someone noticed. A directory that drifts is worse than none, because its answers look complete.

## What

- **`clickhouse/refresh_workspace_directory.py`** — reads `kind='workspace'` entities from Spanner, computes `tenant_id` with the *same* `analytics_surrogate()` the writers use (imported, not reimplemented — a second copy of that string format is how the join quietly breaks), and upserts both `tr.workspace_directory` (id, name, deleted, created_at) and the existing `tenant_workspace_map` so the two cannot drift while both exist. `ReplacingMergeTree` on `refreshed_at` makes it idempotent; renames converge at `FINAL`.
- **`010`/`011` schemas** — replicated (`ON CLUSTER trustedrouter`, version column last in the engine args) + single-node variant, mirroring how 004/006 pair.
- **Hourly systemd timer** with the archive units' hardening block; installed and enabled by `clickhouse_live_ingestion.sh` with the same `is-active` assertion.

## The deliberate absence is the point

No email, no user entities, nothing private — workspace ids and names only. Workspace ids are pseudonymous and safe to hold forever, which matters because ClickHouse feeds an **immutable 7-year Parquet archive**: anything that lands there is effectively undeletable. Emails stay in Spanner, one hop away, where erasure remains possible.

Enforced two ways, **both verified by mutation** (an email projection sneaked into the row builder fails both):

1. the projection test rejects any email-like key reaching a writer
2. a source-scan test fails if the strings `email` or `kind='user'` ever appear in the refresh script

## Verification

Written by codex-cli against a pinned spec; gates re-run independently rather than trusted: `ruff check` clean · `mypy` clean (297 files) · 21 tests green · 2/2 PII-guard mutations caught.

Deployment of the timer to the node is the usual `clickhouse_live_ingestion.sh` run and is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)