### PR TITLE
Prevent shared caching of landing assignments

### DIFF
--- a/docs/marketing/google-landing-page-experiment-2026-08-20.md
+++ b/docs/marketing/google-landing-page-experiment-2026-08-20.md
@@ -62,20 +62,24 @@ canonicalized to the permanent OpenRouter page.
 ## Experiment 1B: Multi-Arm OpenRouter Landing Test
 
 The first directional results favored action-led pages, but did not identify
-which product promise drives the first successful API call. Send one unchanged
-ad to the first-party experiment router:
+which product promise drives the first successful API call. The existing exact
+intent ad keeps its approved destination and assets unchanged:
 
 ```text
-https://trustedrouter.com/openrouter-alternative/experiment
+https://trustedrouter.com/openrouter-alternative
   ?utm_source=google
-  &utm_medium=paid_search
-  &utm_campaign=openrouter_lp_multi_20260822
-  &utm_content=<unchanged-ad-creative-id>
+  &utm_medium=cpc
+  &utm_campaign=openrouter_alternative_exact
+  &utm_term={keyword}
+  &utm_content=search
 ```
 
-The router assigns a visitor consistently to one of six pages. It preserves the
-complete query string, so the ad creative remains measurable while the landing
-path identifies the page arm.
+TrustedRouter recognizes that paid campaign and assigns a visitor consistently
+to one of six pages. The direct `/openrouter-alternative/experiment` entry point
+remains available for future campaigns. Both paths preserve the complete query
+string, so the campaign and ad creative remain measurable while the landing
+path identifies the page arm. Assignment redirects are private and `no-store`,
+which prevents a CDN from serving one visitor's arm to another visitor.
 
 | Arm | Landing path | Promise |
 |---|---|---|

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -1010,7 +1010,14 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
         selected_path = assigned_openrouter_landing_path(seed)
         query = request.url.query
         location = f"{selected_path}?{query}" if query else selected_path
-        return RedirectResponse(url=location, status_code=307)
+        return RedirectResponse(
+            url=location,
+            status_code=307,
+            headers={
+                "cache-control": "private, no-store",
+                "vary": "cookie",
+            },
+        )
 
     @public_html_route("/openrouter-alternative")
     async def seo_openrouter_alternative(

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -265,6 +265,8 @@ def test_openrouter_experiment_router_is_sticky_and_preserves_campaign_query(
     assert first.status_code == 307
     assert second.status_code == 307
     assert first.headers["location"] == second.headers["location"]
+    assert first.headers["cache-control"] == "private, no-store"
+    assert first.headers["vary"] == "cookie"
     destination = urlsplit(first.headers["location"])
     assert destination.path in OPENROUTER_PAID_LANDING_PATHS
     assert parse_qs(destination.query) == parse_qs(query)
@@ -294,6 +296,8 @@ def test_openrouter_paid_campaign_enters_landing_experiment_without_ad_edit(
     )
 
     assert response.status_code == 307
+    assert response.headers["cache-control"] == "private, no-store"
+    assert response.headers["vary"] == "cookie"
     destination = urlsplit(response.headers["location"])
     assert destination.path in OPENROUTER_PAID_LANDING_PATHS
     assert parse_qs(destination.query) == parse_qs(query)


### PR DESCRIPTION
## Summary
- mark A/B assignment redirects `private, no-store` and vary on the attribution cookie
- prevent a CDN from reusing one visitor's assigned arm for another visitor
- document that the approved Google ad URL remains unchanged while TrustedRouter routes its paid campaign

## Verification
- `uv run ruff check src/trusted_router/routes/public.py tests/test_public_seo_pages.py`
- `uv run mypy src/trusted_router/routes/public.py`
- `uv run pytest -q tests/test_public_seo_pages.py tests/test_acquisition_attribution.py` (109 passed)