### PR TITLE
Approve exact Novita V4 Flash 0731 pricing

### DIFF
--- a/scripts/check_price_spike.py
+++ b/scripts/check_price_spike.py
@@ -89,6 +89,23 @@ APPROVED_ENDPOINT_PRICE_TRANSITIONS = frozenset(
             Decimal("0.00000028"),
             Decimal("0.00000132"),
         ),
+        # Novita's authenticated catalog and current public pricing table both
+        # list the 0731 revision separately from the cheaper unversioned route:
+        # https://novita.ai/pricing
+        (
+            "deepseek/deepseek-v4-flash-0731 "
+            "[novita:novita:deepseek/deepseek-v4-flash-0731]",
+            "prompt",
+            Decimal("0.00000014"),
+            Decimal("0.00000044"),
+        ),
+        (
+            "deepseek/deepseek-v4-flash-0731 "
+            "[novita:novita:deepseek/deepseek-v4-flash-0731]",
+            "completion",
+            Decimal("0.00000028"),
+            Decimal("0.00000132"),
+        ),
         # Fireworks' announced 2026-08-22 price change for DeepSeek V4 Flash
         # 0731. The input increase remains below the generic 2x gate; pin the
         # completion transition exactly so a parser error still fails closed:

--- a/tests/test_check_price_spike.py
+++ b/tests/test_check_price_spike.py
@@ -715,6 +715,90 @@ def test_different_atlas_v4_flash_0731_transition_still_blocks(
     assert "PRICE SPIKE FAILURES" in capsys.readouterr().out
 
 
+def test_confirmed_novita_v4_flash_0731_transition_is_allowed(
+    tmp_path: Path, capsys
+) -> None:
+    from scripts.check_price_spike import main
+
+    before = _write(
+        tmp_path,
+        "before.json",
+        _make_endpoint_snapshot(
+            ("0.00000008", "0.00000018"),
+            [
+                (
+                    "novita",
+                    "deepseek/deepseek-v4-flash-0731",
+                    "0.00000014",
+                    "0.00000028",
+                )
+            ],
+            model_id="deepseek/deepseek-v4-flash-0731",
+        ),
+    )
+    after = _write(
+        tmp_path,
+        "after.json",
+        _make_endpoint_snapshot(
+            ("0.00000008", "0.00000018"),
+            [
+                (
+                    "novita",
+                    "deepseek/deepseek-v4-flash-0731",
+                    "0.00000044",
+                    "0.00000132",
+                )
+            ],
+            model_id="deepseek/deepseek-v4-flash-0731",
+        ),
+    )
+
+    assert main([str(before), str(after), "--summary"]) == 0
+    assert "PRICE SPIKE FAILURES" not in capsys.readouterr().out
+
+
+def test_different_novita_v4_flash_0731_transition_still_blocks(
+    tmp_path: Path, capsys
+) -> None:
+    from scripts.check_price_spike import main
+
+    before = _write(
+        tmp_path,
+        "before.json",
+        _make_endpoint_snapshot(
+            ("0.00000008", "0.00000018"),
+            [
+                (
+                    "novita",
+                    "deepseek/deepseek-v4-flash-0731",
+                    "0.00000014",
+                    "0.00000028",
+                )
+            ],
+            model_id="deepseek/deepseek-v4-flash-0731",
+        ),
+    )
+    after = _write(
+        tmp_path,
+        "after.json",
+        _make_endpoint_snapshot(
+            ("0.00000008", "0.00000018"),
+            [
+                (
+                    "novita",
+                    "deepseek/deepseek-v4-flash-0731",
+                    "0.00000045",
+                    "0.00000132",
+                )
+            ],
+            model_id="deepseek/deepseek-v4-flash-0731",
+        ),
+    )
+
+    assert main([str(before), str(after), "--summary"]) == 1
+    assert "PRICE SPIKE FAILURES" in capsys.readouterr().out
+
+
 def test_confirmed_fireworks_v4_flash_0731_transition_is_allowed(
     tmp_path: Path, capsys
 ) -> None:


### PR DESCRIPTION
## Summary
- approve only Novita's exact DeepSeek V4 Flash 0731 input transition from /bin/zsh.14/M to /bin/zsh.44/M
- approve only the exact output transition from /bin/zsh.28/M to .32/M
- leave the unversioned Novita route and all other price changes guarded
- add allow/reject regression tests, including a one-cent-per-million mismatch that must remain blocked

## Sources
- Novita authenticated /openai/v1/models catalog
- https://novita.ai/pricing

## Tests
- uv run pytest -q tests/test_check_price_spike.py
- uv run ruff check scripts/check_price_spike.py tests/test_check_price_spike.py