### PR TITLE
Fix Novita FP8 price approval identity

### DIFF
--- a/scripts/check_price_spike.py
+++ b/scripts/check_price_spike.py
@@ -90,18 +90,18 @@ APPROVED_ENDPOINT_PRICE_TRANSITIONS = frozenset(
             Decimal("0.00000132"),
         ),
         # Novita's authenticated catalog and current public pricing table both
-        # list the 0731 revision separately from the cheaper unversioned route:
+        # list the 0731 FP8 revision separately from the cheaper unversioned route:
         # https://novita.ai/pricing
         (
             "deepseek/deepseek-v4-flash-0731 "
-            "[novita:novita:deepseek/deepseek-v4-flash-0731]",
+            "[novita:novita/fp8:deepseek/deepseek-v4-flash-0731]",
             "prompt",
             Decimal("0.00000014"),
             Decimal("0.00000044"),
         ),
         (
             "deepseek/deepseek-v4-flash-0731 "
-            "[novita:novita:deepseek/deepseek-v4-flash-0731]",
+            "[novita:novita/fp8:deepseek/deepseek-v4-flash-0731]",
             "completion",
             Decimal("0.00000028"),
             Decimal("0.00000132"),

--- a/tests/test_check_price_spike.py
+++ b/tests/test_check_price_spike.py
@@ -720,38 +720,34 @@ def test_confirmed_novita_v4_flash_0731_transition_is_allowed(
 ) -> None:
     from scripts.check_price_spike import main
 
-    before = _write(
-        tmp_path,
-        "before.json",
-        _make_endpoint_snapshot(
-            ("0.00000008", "0.00000018"),
-            [
-                (
-                    "novita",
-                    "deepseek/deepseek-v4-flash-0731",
-                    "0.00000014",
-                    "0.00000028",
-                )
-            ],
-            model_id="deepseek/deepseek-v4-flash-0731",
-        ),
+    before_payload = _make_endpoint_snapshot(
+        ("0.00000008", "0.00000018"),
+        [
+            (
+                "novita",
+                "deepseek/deepseek-v4-flash-0731",
+                "0.00000014",
+                "0.00000028",
+            )
+        ],
+        model_id="deepseek/deepseek-v4-flash-0731",
     )
-    after = _write(
-        tmp_path,
-        "after.json",
-        _make_endpoint_snapshot(
-            ("0.00000008", "0.00000018"),
-            [
-                (
-                    "novita",
-                    "deepseek/deepseek-v4-flash-0731",
-                    "0.00000044",
-                    "0.00000132",
-                )
-            ],
-            model_id="deepseek/deepseek-v4-flash-0731",
-        ),
+    before_payload["models"][0]["endpoints"][0]["tag"] = "novita/fp8"
+    before = _write(tmp_path, "before.json", before_payload)
+    after_payload = _make_endpoint_snapshot(
+        ("0.00000008", "0.00000018"),
+        [
+            (
+                "novita",
+                "deepseek/deepseek-v4-flash-0731",
+                "0.00000044",
+                "0.00000132",
+            )
+        ],
+        model_id="deepseek/deepseek-v4-flash-0731",
     )
+    after_payload["models"][0]["endpoints"][0]["tag"] = "novita/fp8"
+    after = _write(tmp_path, "after.json", after_payload)
 
     assert main([str(before), str(after), "--summary"]) == 0
     assert "PRICE SPIKE FAILURES" not in capsys.readouterr().out
@@ -762,38 +758,34 @@ def test_different_novita_v4_flash_0731_transition_still_blocks(
 ) -> None:
     from scripts.check_price_spike import main
 
-    before = _write(
-        tmp_path,
-        "before.json",
-        _make_endpoint_snapshot(
-            ("0.00000008", "0.00000018"),
-            [
-                (
-                    "novita",
-                    "deepseek/deepseek-v4-flash-0731",
-                    "0.00000014",
-                    "0.00000028",
-                )
-            ],
-            model_id="deepseek/deepseek-v4-flash-0731",
-        ),
+    before_payload = _make_endpoint_snapshot(
+        ("0.00000008", "0.00000018"),
+        [
+            (
+                "novita",
+                "deepseek/deepseek-v4-flash-0731",
+                "0.00000014",
+                "0.00000028",
+            )
+        ],
+        model_id="deepseek/deepseek-v4-flash-0731",
     )
-    after = _write(
-        tmp_path,
-        "after.json",
-        _make_endpoint_snapshot(
-            ("0.00000008", "0.00000018"),
-            [
-                (
-                    "novita",
-                    "deepseek/deepseek-v4-flash-0731",
-                    "0.00000045",
-                    "0.00000132",
-                )
-            ],
-            model_id="deepseek/deepseek-v4-flash-0731",
-        ),
+    before_payload["models"][0]["endpoints"][0]["tag"] = "novita/fp8"
+    before = _write(tmp_path, "before.json", before_payload)
+    after_payload = _make_endpoint_snapshot(
+        ("0.00000008", "0.00000018"),
+        [
+            (
+                "novita",
+                "deepseek/deepseek-v4-flash-0731",
+                "0.00000045",
+                "0.00000132",
+            )
+        ],
+        model_id="deepseek/deepseek-v4-flash-0731",
     )
+    after_payload["models"][0]["endpoints"][0]["tag"] = "novita/fp8"
+    after = _write(tmp_path, "after.json", after_payload)
 
     assert main([str(before), str(after), "--summary"]) == 1
     assert "PRICE SPIKE FAILURES" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- Match the approved DeepSeek V4 Flash 0731 transition against Novita's canonical `novita/fp8` endpoint tag.
- Update regression fixtures to use the production endpoint identity.
- Retain exact old and new price matching so nearby changes remain blocked.

## Verification

- `uv run pytest -q tests/test_check_price_spike.py`
- `uv run ruff check scripts/check_price_spike.py tests/test_check_price_spike.py`
- Fail-first proof: the corrected regression failed before the allowlist-key fix while the near-miss rejection passed.
