### PR TITLE
Approve both Novita endpoint tag variants

### DIFF
--- a/scripts/check_price_spike.py
+++ b/scripts/check_price_spike.py
@@ -90,8 +90,24 @@ APPROVED_ENDPOINT_PRICE_TRANSITIONS = frozenset(
             Decimal("0.00000132"),
         ),
         # Novita's authenticated catalog and current public pricing table both
-        # list the 0731 FP8 revision separately from the cheaper unversioned route:
+        # list the 0731 revision separately from the cheaper unversioned route.
+        # Its API has emitted the same SKU with both plain and FP8 endpoint tags,
+        # so pin the exact transition under each canonical identity:
         # https://novita.ai/pricing
+        (
+            "deepseek/deepseek-v4-flash-0731 "
+            "[novita:novita:deepseek/deepseek-v4-flash-0731]",
+            "prompt",
+            Decimal("0.00000014"),
+            Decimal("0.00000044"),
+        ),
+        (
+            "deepseek/deepseek-v4-flash-0731 "
+            "[novita:novita:deepseek/deepseek-v4-flash-0731]",
+            "completion",
+            Decimal("0.00000028"),
+            Decimal("0.00000132"),
+        ),
         (
             "deepseek/deepseek-v4-flash-0731 "
             "[novita:novita/fp8:deepseek/deepseek-v4-flash-0731]",

--- a/tests/test_check_price_spike.py
+++ b/tests/test_check_price_spike.py
@@ -715,8 +715,9 @@ def test_different_atlas_v4_flash_0731_transition_still_blocks(
     assert "PRICE SPIKE FAILURES" in capsys.readouterr().out
 
 
+@pytest.mark.parametrize("endpoint_tag", ["novita", "novita/fp8"])
 def test_confirmed_novita_v4_flash_0731_transition_is_allowed(
-    tmp_path: Path, capsys
+    tmp_path: Path, capsys, endpoint_tag: str
 ) -> None:
     from scripts.check_price_spike import main
 
@@ -732,7 +733,7 @@ def test_confirmed_novita_v4_flash_0731_transition_is_allowed(
         ],
         model_id="deepseek/deepseek-v4-flash-0731",
     )
-    before_payload["models"][0]["endpoints"][0]["tag"] = "novita/fp8"
+    before_payload["models"][0]["endpoints"][0]["tag"] = endpoint_tag
     before = _write(tmp_path, "before.json", before_payload)
     after_payload = _make_endpoint_snapshot(
         ("0.00000008", "0.00000018"),
@@ -746,15 +747,16 @@ def test_confirmed_novita_v4_flash_0731_transition_is_allowed(
         ],
         model_id="deepseek/deepseek-v4-flash-0731",
     )
-    after_payload["models"][0]["endpoints"][0]["tag"] = "novita/fp8"
+    after_payload["models"][0]["endpoints"][0]["tag"] = endpoint_tag
     after = _write(tmp_path, "after.json", after_payload)
 
     assert main([str(before), str(after), "--summary"]) == 0
     assert "PRICE SPIKE FAILURES" not in capsys.readouterr().out
 
 
+@pytest.mark.parametrize("endpoint_tag", ["novita", "novita/fp8"])
 def test_different_novita_v4_flash_0731_transition_still_blocks(
-    tmp_path: Path, capsys
+    tmp_path: Path, capsys, endpoint_tag: str
 ) -> None:
     from scripts.check_price_spike import main
 
@@ -770,7 +772,7 @@ def test_different_novita_v4_flash_0731_transition_still_blocks(
         ],
         model_id="deepseek/deepseek-v4-flash-0731",
     )
-    before_payload["models"][0]["endpoints"][0]["tag"] = "novita/fp8"
+    before_payload["models"][0]["endpoints"][0]["tag"] = endpoint_tag
     before = _write(tmp_path, "before.json", before_payload)
     after_payload = _make_endpoint_snapshot(
         ("0.00000008", "0.00000018"),
@@ -784,7 +786,7 @@ def test_different_novita_v4_flash_0731_transition_still_blocks(
         ],
         model_id="deepseek/deepseek-v4-flash-0731",
     )
-    after_payload["models"][0]["endpoints"][0]["tag"] = "novita/fp8"
+    after_payload["models"][0]["endpoints"][0]["tag"] = endpoint_tag
     after = _write(tmp_path, "after.json", after_payload)
 
     assert main([str(before), str(after), "--summary"]) == 1


### PR DESCRIPTION
## Summary

- Approve the same exact Novita DeepSeek V4 Flash 0731 transition under the provider-manifest identity `novita` and public-snapshot identity `novita/fp8`.
- Parameterize regression tests across both identities.
- Preserve exact old and new values so any different price remains blocked.

## Verification

- Fail-first: the provider-manifest identity `novita` failed before the production update while the snapshot identity `novita/fp8` passed.
- Both unapproved near-miss cases remained blocked.
- `uv run pytest -q tests/test_check_price_spike.py` (37 passed)
- `uv run ruff check scripts/check_price_spike.py tests/test_check_price_spike.py`
