### PR TITLE
Make gateway canary verification point-read only

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -500,6 +500,22 @@ gcloud spanner databases execute-sql trusted-router \
 Spot-check settle latency is unchanged in `httpRequest.latency` for
 `/internal/gateway/settle`.
 
+Do not locate a canary authorization by scanning `tr_gateway_authorization.payload`.
+The payload JSON is intentionally not indexed; a production scan can consume millions
+of row reads and compete with customer billing traffic. Use the bounded verifier, which
+resolves the existing idempotency index and then uses primary-key reads:
+
+```bash
+uv run python scripts/verify_gateway_authorization.py \
+  --workspace-id <workspace-id> \
+  --key-hash <key-hash> \
+  --idempotency-key <canary-idempotency-key>
+```
+
+When the authorization ID is already available, prefer
+`--authorization-id <gwa-id>`; that path is primary-key-only. The verifier emits only
+billing and routing metadata. It never emits prompt or response content.
+
 Resume the drain after the flip. The job already exists and is paused:
 
 ```bash

--- a/scripts/verify_gateway_authorization.py
+++ b/scripts/verify_gateway_authorization.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Verify one gateway authorization without scanning production request tables."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+from typing import Any
+
+from google.cloud import spanner
+from google.cloud.spanner_v1 import param_types
+
+RESERVATION_BY_SCOPE_SQL = (
+    "SELECT reservation_id, authorization_id "
+    "FROM tr_reservation@{FORCE_INDEX=tr_reservation_by_idemp} "
+    "WHERE idempotency_scope=@scope"
+)
+AUTHORIZATION_BY_ID_SQL = (
+    "SELECT authorization_id, workspace_id, key_hash, reservation_id, model_id, provider, "
+    "usage_type, estimated_microdollars, settled, created_at, terminal_at, payload "
+    "FROM tr_gateway_authorization WHERE authorization_id=@authorization_id"
+)
+RESERVATION_BY_ID_SQL = (
+    "SELECT reservation_id, workspace_id, key_hash, credit_reserved_micro, "
+    "key_reserved_micro, actual_micro, hold_usage_type, settled_usage_type, settled, "
+    "created_at, expires_at, terminal_at FROM tr_reservation "
+    "WHERE reservation_id=@reservation_id"
+)
+OUTBOX_BY_AUTHORIZATION_SQL = (
+    "SELECT intent_kind, settle_origin, actual_cost_micro, model_id, selected_usage_type, "
+    "status, attempts, created_at, updated_at, terminal_at FROM tr_settle_outbox "
+    "WHERE authorization_id=@authorization_id ORDER BY intent_kind"
+)
+GENERATION_BY_ID_SQL = (
+    "SELECT generation_id, workspace_id, key_hash, created_at, terminal_at, payload "
+    "FROM tr_generation WHERE generation_id=@generation_id"
+)
+
+
+def idempotency_scope(workspace_id: str, key_hash: str, idempotency_key: str) -> str:
+    digest = hashlib.sha256(idempotency_key.encode("utf-8")).hexdigest()
+    return f"{workspace_id}#{key_hash}#{digest}"
+
+
+def _one(rows: Any, *, label: str) -> tuple[Any, ...]:
+    materialized = list(rows)
+    if len(materialized) != 1:
+        raise RuntimeError(f"expected one {label} row, found {len(materialized)}")
+    return tuple(materialized[0])
+
+
+def _json_object(value: Any) -> dict[str, Any]:
+    if not isinstance(value, str):
+        return {}
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, (dt.datetime, dt.date)):
+        return value.isoformat()
+    return value
+
+
+def _authorization_summary(row: tuple[Any, ...]) -> dict[str, Any]:
+    payload = _json_object(row[11])
+    return {
+        "authorization_id": row[0],
+        "workspace_id": row[1],
+        "key_hash": row[2],
+        "reservation_id": row[3],
+        "model_id": row[4],
+        "provider": row[5],
+        "usage_type": row[6],
+        "estimated_microdollars": row[7],
+        "settled": row[8],
+        "created_at": _json_safe(row[9]),
+        "terminal_at": _json_safe(row[10]),
+        "finalization_outcome": payload.get("finalization_outcome"),
+        "finalized_cost_microdollars": payload.get("finalized_cost_microdollars"),
+        "finalized_generation_id": payload.get("finalized_generation_id"),
+        "finalized_model_id": payload.get("finalized_model_id"),
+        "finalized_provider": payload.get("finalized_provider"),
+        "finalized_region": payload.get("finalized_region"),
+    }
+
+
+def verify_authorization(
+    snapshot: Any,
+    *,
+    workspace_id: str | None = None,
+    key_hash: str | None = None,
+    idempotency_key: str | None = None,
+    authorization_id: str | None = None,
+) -> dict[str, Any]:
+    if authorization_id is None:
+        if not (workspace_id and key_hash and idempotency_key):
+            raise ValueError("workspace_id, key_hash, and idempotency_key are required together")
+        scope = idempotency_scope(workspace_id, key_hash, idempotency_key)
+        reservation_ref = _one(
+            snapshot.execute_sql(
+                RESERVATION_BY_SCOPE_SQL,
+                params={"scope": scope},
+                param_types={"scope": param_types.STRING},
+            ),
+            label="idempotency reservation",
+        )
+        reservation_id, authorization_id = reservation_ref
+    else:
+        reservation_id = None
+
+    authorization_row = _one(
+        snapshot.execute_sql(
+            AUTHORIZATION_BY_ID_SQL,
+            params={"authorization_id": authorization_id},
+            param_types={"authorization_id": param_types.STRING},
+        ),
+        label="gateway authorization",
+    )
+    authorization = _authorization_summary(authorization_row)
+    reservation_id = reservation_id or authorization["reservation_id"]
+    reservation_row = _one(
+        snapshot.execute_sql(
+            RESERVATION_BY_ID_SQL,
+            params={"reservation_id": reservation_id},
+            param_types={"reservation_id": param_types.STRING},
+        ),
+        label="reservation",
+    )
+    reservation = {
+        "reservation_id": reservation_row[0],
+        "workspace_id": reservation_row[1],
+        "key_hash": reservation_row[2],
+        "credit_reserved_microdollars": reservation_row[3],
+        "key_reserved_microdollars": reservation_row[4],
+        "actual_microdollars": reservation_row[5],
+        "hold_usage_type": reservation_row[6],
+        "settled_usage_type": reservation_row[7],
+        "settled": reservation_row[8],
+        "created_at": _json_safe(reservation_row[9]),
+        "expires_at": _json_safe(reservation_row[10]),
+        "terminal_at": _json_safe(reservation_row[11]),
+    }
+    outbox_rows = snapshot.execute_sql(
+        OUTBOX_BY_AUTHORIZATION_SQL,
+        params={"authorization_id": authorization_id},
+        param_types={"authorization_id": param_types.STRING},
+    )
+    outbox = [
+        {
+            "intent_kind": row[0],
+            "settle_origin": row[1],
+            "actual_cost_microdollars": row[2],
+            "model_id": row[3],
+            "selected_usage_type": row[4],
+            "status": row[5],
+            "attempts": row[6],
+            "created_at": _json_safe(row[7]),
+            "updated_at": _json_safe(row[8]),
+            "terminal_at": _json_safe(row[9]),
+        }
+        for row in outbox_rows
+    ]
+
+    generation = None
+    generation_id = authorization.get("finalized_generation_id")
+    if generation_id:
+        generation_row = _one(
+            snapshot.execute_sql(
+                GENERATION_BY_ID_SQL,
+                params={"generation_id": generation_id},
+                param_types={"generation_id": param_types.STRING},
+            ),
+            label="generation",
+        )
+        payload = _json_object(generation_row[5])
+        generation = {
+            "generation_id": generation_row[0],
+            "workspace_id": generation_row[1],
+            "key_hash": generation_row[2],
+            "created_at": _json_safe(generation_row[3]),
+            "terminal_at": _json_safe(generation_row[4]),
+            "model": payload.get("model"),
+            "provider": payload.get("provider"),
+            "usage_type": payload.get("usage_type"),
+            "status": payload.get("status"),
+            "finish_reason": payload.get("finish_reason"),
+            "cost_microdollars": payload.get("total_cost_microdollars"),
+        }
+
+    return {
+        "authorization": authorization,
+        "reservation": reservation,
+        "outbox": outbox,
+        "generation": generation,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project", default=os.getenv("GCP_PROJECT_ID", "quill-cloud-proxy"))
+    parser.add_argument(
+        "--instance", default=os.getenv("SPANNER_INSTANCE_ID", "trusted-router-nam6")
+    )
+    parser.add_argument("--database", default=os.getenv("SPANNER_DATABASE_ID", "trusted-router"))
+    selector = parser.add_mutually_exclusive_group(required=True)
+    selector.add_argument("--authorization-id")
+    selector.add_argument("--idempotency-key")
+    parser.add_argument("--workspace-id")
+    parser.add_argument("--key-hash")
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    if args.idempotency_key and not (args.workspace_id and args.key_hash):
+        raise SystemExit("--workspace-id and --key-hash are required with --idempotency-key")
+    client = spanner.Client(project=args.project, disable_builtin_metrics=True)
+    database = client.instance(args.instance).database(args.database)
+    with database.snapshot(multi_use=True) as snapshot:
+        result = verify_authorization(
+            snapshot,
+            workspace_id=args.workspace_id,
+            key_hash=args.key_hash,
+            idempotency_key=args.idempotency_key,
+            authorization_id=args.authorization_id,
+        )
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_verify_gateway_authorization.py
+++ b/tests/test_verify_gateway_authorization.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+import re
+from pathlib import Path
+from typing import Any
+
+from trusted_router.storage_gcp_keys import _gateway_authorization_idempotency_index_id
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "verify_gateway_authorization.py"
+SPEC = importlib.util.spec_from_file_location("verify_gateway_authorization", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+verify = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(verify)
+
+
+class FakeSnapshot:
+    def __init__(self) -> None:
+        self.queries: list[tuple[str, dict[str, Any]]] = []
+
+    def execute_sql(
+        self,
+        sql: str,
+        *,
+        params: dict[str, Any],
+        param_types: dict[str, Any],
+    ) -> list[tuple[Any, ...]]:
+        del param_types
+        self.queries.append((sql, params))
+        now = dt.datetime(2026, 8, 22, tzinfo=dt.UTC)
+        if sql == verify.RESERVATION_BY_SCOPE_SQL:
+            return [("res-1", "gwa-1")]
+        if sql == verify.AUTHORIZATION_BY_ID_SQL:
+            return [
+                (
+                    "gwa-1",
+                    "ws-1",
+                    "key-1",
+                    "res-1",
+                    "openai/gpt-5-mini",
+                    "azure",
+                    "Credits",
+                    100,
+                    True,
+                    now,
+                    now,
+                    '{"finalization_outcome":"settled",'
+                    '"finalized_cost_microdollars":42,'
+                    '"finalized_generation_id":"gen-1",'
+                    '"finalized_model_id":"openai/gpt-5-mini",'
+                    '"finalized_provider":"azure"}',
+                )
+            ]
+        if sql == verify.RESERVATION_BY_ID_SQL:
+            return [
+                (
+                    "res-1",
+                    "ws-1",
+                    "key-1",
+                    100,
+                    0,
+                    42,
+                    "Credits",
+                    "Credits",
+                    True,
+                    now,
+                    now,
+                    now,
+                )
+            ]
+        if sql == verify.OUTBOX_BY_AUTHORIZATION_SQL:
+            return [
+                ("settle", "inline", 42, "openai/gpt-5-mini", "Credits", "done", 1, now, now, now)
+            ]
+        if sql == verify.GENERATION_BY_ID_SQL:
+            return [
+                (
+                    "gen-1",
+                    "ws-1",
+                    "key-1",
+                    now,
+                    now,
+                    '{"model":"openai/gpt-5-mini","provider":"azure",'
+                    '"usage_type":"Credits","status":"completed",'
+                    '"finish_reason":"stop","total_cost_microdollars":42}',
+                )
+            ]
+        raise AssertionError(f"unexpected SQL: {sql}")
+
+
+def test_idempotency_verification_uses_index_then_primary_keys() -> None:
+    snapshot = FakeSnapshot()
+
+    result = verify.verify_authorization(
+        snapshot,
+        workspace_id="ws-1",
+        key_hash="key-1",
+        idempotency_key="canary-1",
+    )
+
+    assert result["authorization"]["authorization_id"] == "gwa-1"
+    assert result["reservation"]["actual_microdollars"] == 42
+    assert result["outbox"][0]["status"] == "done"
+    assert result["generation"]["generation_id"] == "gen-1"
+    assert "FORCE_INDEX=tr_reservation_by_idemp" in snapshot.queries[0][0]
+    assert all(
+        "JSON_VALUE" not in sql.split("WHERE", maxsplit=1)[-1] for sql, _ in snapshot.queries
+    )
+
+
+def test_operational_code_does_not_scan_authorization_payload_json() -> None:
+    offenders: list[str] = []
+    forbidden = re.compile(
+        r"from\s+tr_gateway_authorization\b.{0,4000}?where\b.{0,4000}?"
+        r"(?:json_value\([^)]*payload|starts_with\(\s*json_value\([^)]*payload)",
+        flags=re.DOTALL,
+    )
+    for root in (ROOT / "scripts", ROOT / ".github" / "workflows"):
+        for path in root.rglob("*"):
+            if not path.is_file() or path.suffix not in {".py", ".sh", ".yml", ".yaml"}:
+                continue
+            normalized = " ".join(path.read_text(errors="ignore").lower().split())
+            if forbidden.search(normalized):
+                offenders.append(str(path.relative_to(ROOT)))
+    assert offenders == []
+
+
+def test_scope_matches_the_application_idempotency_contract() -> None:
+    assert verify.idempotency_scope("ws-1", "key-1", "canary-1") == (
+        _gateway_authorization_idempotency_index_id("ws-1", "key-1", "canary-1")
+    )
+
+
+def test_authorization_id_path_skips_the_secondary_index_lookup() -> None:
+    snapshot = FakeSnapshot()
+
+    result = verify.verify_authorization(snapshot, authorization_id="gwa-1")
+
+    assert result["authorization"]["authorization_id"] == "gwa-1"
+    assert snapshot.queries[0][0] == verify.AUTHORIZATION_BY_ID_SQL
+    assert all(sql != verify.RESERVATION_BY_SCOPE_SQL for sql, _ in snapshot.queries)
+
+
+def test_cli_uses_multi_read_snapshot_without_metrics_export() -> None:
+    source = SCRIPT.read_text()
+
+    assert "disable_builtin_metrics=True" in source
+    assert "snapshot(multi_use=True)" in source


### PR DESCRIPTION
## Summary
- add a bounded Spanner verifier that resolves the existing idempotency index, then reads authorization, reservation, outbox, and generation rows by key
- reject committed operational scripts that filter gateway authorization payload JSON
- document the safe canary verification procedure

## Incident evidence
The previous ad hoc verifier scanned 621,772 authorization rows in 20.1s and a combined audit scanned 8.9M rows in 4.7s, triggering the strict Spanner p99 alert. The replacement was exercised against the same production canary: the idempotency lookup scanned 2 rows in 49ms and subsequent reads were primary-key bounded.

## Tests
- uv run ruff check scripts/verify_gateway_authorization.py tests/test_verify_gateway_authorization.py
- uv run ruff format --check scripts/verify_gateway_authorization.py tests/test_verify_gateway_authorization.py
- uv run pytest -q tests/test_verify_gateway_authorization.py
- live read-only verification of the exact incident canary record