### PR TITLE
Make ClickHouse worker deploy bundles immutable

### DIFF
--- a/scripts/deploy/_clickhouse_bundle.sh
+++ b/scripts/deploy/_clickhouse_bundle.sh
@@ -1,0 +1,47 @@
+# shellcheck shell=bash
+# Build a deterministic ClickHouse worker bundle from committed source only.
+
+build_clickhouse_bundle() {
+  local root="$1"
+  local archive="$2"
+  local dirty
+  local stage
+
+  dirty="$(git -C "$root" status --porcelain --untracked-files=all -- \
+    clickhouse src/trusted_router)"
+  if [ -n "$dirty" ]; then
+    echo "refusing ClickHouse deployment from modified worker source:" >&2
+    echo "$dirty" >&2
+    return 1
+  fi
+
+  git -C "$root" archive \
+    --format=tar.gz \
+    --output="$archive" \
+    HEAD \
+    clickhouse \
+    src/trusted_router
+
+  stage="$(mktemp -d "${TMPDIR:-/tmp}/tr-clickhouse-bundle.XXXXXX")"
+  if ! tar -xzf "$archive" -C "$stage"; then
+    rm -rf "$stage"
+    return 1
+  fi
+  if ! python3 - "$stage/src/trusted_router/data" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+root = Path(sys.argv[1])
+for path in sorted(root.rglob("*.json")):
+    try:
+        json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"provider bundle contains invalid JSON: {path}: {exc}")
+PY
+  then
+    rm -rf "$stage"
+    return 1
+  fi
+  rm -rf "$stage"
+}

--- a/scripts/deploy/clickhouse_live_ingestion.sh
+++ b/scripts/deploy/clickhouse_live_ingestion.sh
@@ -6,7 +6,10 @@
 # enqueue setting.
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=scripts/deploy/_clickhouse_bundle.sh
+source "${SCRIPT_DIR}/_clickhouse_bundle.sh"
 PROJECT="${PROJECT:-quill-cloud-proxy}"
 ZONE="${ZONE:-us-central1-a}"
 NAME="${NAME:-tr-clickhouse-1}"
@@ -32,7 +35,7 @@ fi
 
 archive=$(mktemp "${TMPDIR:-/tmp}/tr-clickhouse-live.XXXXXX.tar.gz")
 trap 'rm -f "$archive"' EXIT
-tar -C "$ROOT" -czf "$archive" clickhouse src/trusted_router
+build_clickhouse_bundle "$ROOT" "$archive"
 
 ssh_node --command="sudo mkdir -p /opt/tr-clickhouse"
 ssh_node --command="sudo tar -xzf - -C /opt/tr-clickhouse" < "$archive"

--- a/scripts/deploy/clickhouse_operational_analytics.sh
+++ b/scripts/deploy/clickhouse_operational_analytics.sh
@@ -7,6 +7,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 # shellcheck source=scripts/deploy/_lib.sh
 source "${SCRIPT_DIR}/_lib.sh"
+# shellcheck source=scripts/deploy/_clickhouse_bundle.sh
+source "${SCRIPT_DIR}/_clickhouse_bundle.sh"
 
 NAMES=(tr-clickhouse-1 tr-clickhouse-2 tr-clickhouse-3)
 ZONES=(us-central1-a us-central1-b us-central1-c)
@@ -102,7 +104,7 @@ cleanup() {
   return "$status"
 }
 trap cleanup EXIT
-tar -C "$ROOT" -czf "$archive" clickhouse src/trusted_router
+build_clickhouse_bundle "$ROOT" "$archive"
 node_ssh 0 --command="sudo mkdir -p /opt/tr-clickhouse"
 node_ssh 0 --command="sudo tar -xzf - -C /opt/tr-clickhouse" <"$archive"
 

--- a/tests/test_clickhouse_operational_deploy.py
+++ b/tests/test_clickhouse_operational_deploy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 import subprocess
 import sys
+import tarfile
 from pathlib import Path
 
 ROOT = Path(__file__).parents[1]
@@ -88,6 +89,91 @@ def test_operational_deploy_resumes_live_ingest_before_backfills() -> None:
     assert "tr-clickhouse-synthetic-reconcile.timer" in script
     assert "systemctl enable" in script
     assert 'id_column="event_id"' in script
+
+
+def test_clickhouse_manual_deploys_bundle_only_valid_committed_source() -> None:
+    helper = (ROOT / "scripts/deploy/_clickhouse_bundle.sh").read_text()
+    assert "git -C \"$root\" status --porcelain" in helper
+    assert "git -C \"$root\" archive" in helper
+    assert "provider bundle contains invalid JSON" in helper
+    assert "path.read_text(encoding=\"utf-8\")" in helper
+
+    for relative in (
+        "scripts/deploy/clickhouse_live_ingestion.sh",
+        "scripts/deploy/clickhouse_operational_analytics.sh",
+    ):
+        script = (ROOT / relative).read_text()
+        assert "source \"${SCRIPT_DIR}/_clickhouse_bundle.sh\"" in script
+        assert "build_clickhouse_bundle \"$ROOT\" \"$archive\"" in script
+        assert 'tar -C "$ROOT" -czf "$archive" clickhouse src/trusted_router' not in script
+
+
+def _committed_clickhouse_fixture(tmp_path: Path, *, manifest: bytes) -> Path:
+    repo = tmp_path / "repo"
+    (repo / "clickhouse").mkdir(parents=True)
+    data = repo / "src/trusted_router/data/provider_models"
+    data.mkdir(parents=True)
+    (repo / "clickhouse/worker.py").write_text("VALUE = 1\n")
+    (data / "provider.json").write_bytes(manifest)
+    for command in (
+        ["git", "init", "-q"],
+        ["git", "config", "user.email", "test@trustedrouter.com"],
+        ["git", "config", "user.name", "TrustedRouter Test"],
+        ["git", "add", "clickhouse", "src/trusted_router"],
+        ["git", "commit", "-qm", "fixture"],
+    ):
+        subprocess.run(command, cwd=repo, check=True, capture_output=True)  # noqa: S603
+    return repo
+
+
+def _run_bundle_helper(repo: Path, archive: Path) -> subprocess.CompletedProcess[str]:
+    helper = ROOT / "scripts/deploy/_clickhouse_bundle.sh"
+    return subprocess.run(  # noqa: S603
+        [
+            "/bin/bash",
+            "-c",
+            'source "$1"; build_clickhouse_bundle "$2" "$3"',
+            "bundle-test",
+            str(helper),
+            str(repo),
+            str(archive),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_clickhouse_bundle_is_a_valid_committed_snapshot(tmp_path: Path) -> None:
+    repo = _committed_clickhouse_fixture(tmp_path, manifest=b'{"models": []}\n')
+    archive = tmp_path / "bundle.tar.gz"
+
+    result = _run_bundle_helper(repo, archive)
+
+    assert result.returncode == 0, result.stderr
+    with tarfile.open(archive) as bundle:
+        assert "src/trusted_router/data/provider_models/provider.json" in bundle.getnames()
+
+
+def test_clickhouse_bundle_rejects_dirty_or_invalid_source(tmp_path: Path) -> None:
+    dirty_repo = _committed_clickhouse_fixture(
+        tmp_path / "dirty",
+        manifest=b'{"models": []}\n',
+    )
+    (dirty_repo / "src/trusted_router/data/provider_models/provider.json").write_bytes(
+        b"\xa3"
+    )
+    dirty = _run_bundle_helper(dirty_repo, tmp_path / "dirty.tar.gz")
+    assert dirty.returncode != 0
+    assert "refusing ClickHouse deployment from modified worker source" in dirty.stderr
+
+    invalid_repo = _committed_clickhouse_fixture(
+        tmp_path / "invalid",
+        manifest=b"\xa3",
+    )
+    invalid = _run_bundle_helper(invalid_repo, tmp_path / "invalid.tar.gz")
+    assert invalid.returncode != 0
+    assert "provider bundle contains invalid JSON" in invalid.stderr
 
 
 def test_client_telemetry_single_node_schema_is_applied_with_operational_schema() -> None:


### PR DESCRIPTION
## Summary
- build manual ClickHouse worker deployments from committed Git objects only
- refuse deployments when worker source is dirty
- validate every bundled data JSON file before any production connection
- cover valid, dirty, and corrupt bundle cases

## Incident
A manual operational analytics deployment on 2026-08-22 archived a mutable worktree. The resulting provider manifest was not valid UTF-8, causing one parity check, one Spanner-delivery check, and public snapshot generation to fail until the next source sync. This closes that path without changing production read mode or Bigtable fallback.

## Verification
- 42 focused ClickHouse deployment tests pass
- ruff passes for the changed Python test
- shell syntax and shellcheck pass