### PR TITLE
Resolve Cloud Run probe tags with a JSON read, not an unsupported projection

### DIFF
--- a/scripts/deploy/_cloud_run_revision_probe.sh
+++ b/scripts/deploy/_cloud_run_revision_probe.sh
@@ -1,6 +1,31 @@
 # shellcheck shell=bash
 # Shared Cloud Run revision-tag helpers. Callers own traps and probe policy.
 
+cloud_run_probe_tag_revision() {
+  local service="$1"
+  local region="$2"
+  local project="$3"
+  local tag="$4"
+  local document
+
+  document="$(gcloud run services describe "$service" \
+    --region="$region" \
+    --project="$project" \
+    --format=json)" || return 1
+  printf '%s' "$document" | python3 -c '
+import json, sys
+tag = sys.argv[1]
+try:
+    document = json.load(sys.stdin)
+except Exception:
+    raise SystemExit(1)
+for entry in document.get("status", {}).get("traffic", []):
+    if entry.get("tag") == tag:
+        print(entry.get("revisionName", ""))
+        break
+' "$tag"
+}
+
 cloud_run_probe_tag_reconcile() {
   local service="$1"
   local region="$2"
@@ -14,10 +39,8 @@ cloud_run_probe_tag_reconcile() {
     --project="$project" \
     --update-tags="${tag}=${revision}" \
     --quiet || return 1
-  resolved="$(gcloud run services describe "$service" \
-    --region="$region" \
-    --project="$project" \
-    --format="value(status.traffic[?tag='${tag}'].revisionName)")" || return 1
+  resolved="$(cloud_run_probe_tag_revision \
+    "$service" "$region" "$project" "$tag")" || return 1
   if [ "$resolved" != "$revision" ]; then
     echo "ERROR: probe tag ${tag} resolves to ${resolved:-<nothing>}, expected ${revision}" >&2
     return 1
@@ -45,10 +68,8 @@ cloud_run_probe_tag_remove() {
         --project="$project" \
         --remove-tags="$tag" \
         --quiet; then
-      if resolved="$(gcloud run services describe "$service" \
-          --region="$region" \
-          --project="$project" \
-          --format="value(status.traffic[?tag='${tag}'].revisionName)")"; then
+      if resolved="$(cloud_run_probe_tag_revision \
+          "$service" "$region" "$project" "$tag")"; then
         if [ -z "$resolved" ]; then
           return 0
         fi
@@ -77,10 +98,8 @@ cloud_run_probe_tagged_base_url() {
   local resolved
   local service_url
 
-  resolved="$(gcloud run services describe "$service" \
-    --region="$region" \
-    --project="$project" \
-    --format="value(status.traffic[?tag='${tag}'].revisionName)")" || return 1
+  resolved="$(cloud_run_probe_tag_revision \
+    "$service" "$region" "$project" "$tag")" || return 1
   [ "$resolved" = "$revision" ] || {
     echo "ERROR: probe tag ${tag} resolves to ${resolved:-<nothing>}, expected ${revision}" >&2
     return 1

--- a/tests/deploy_script_harness.py
+++ b/tests/deploy_script_harness.py
@@ -150,6 +150,14 @@ _STUB = r"""#!/usr/bin/env bash
 cat >/dev/null 2>&1 || true
 joined="${0##*/} $*"
 
+if { [ "${0##*/}" = "gcloud" ] || [ "${0##*/}" = "gc" ]; } \
+    && [[ " $* " == *" run services describe "* ]] \
+    && [[ " $* " == *"status.traffic[?tag="* ]]; then
+  printf '%s\n' \
+    'HARNESS ERROR: gcloud does not support JMESPath filters in resource projections' >&2
+  exit 64
+fi
+
 if [ "${HARNESS_PUBLIC_SURFACE_SMOKE:-0}" = "1" ]; then
   region=""
   previous=""
@@ -268,11 +276,39 @@ print(
 PY
     exit 0
   fi
-  if [[ " $* " == *" run services describe trusted-router-public "* ]] \
-      && [[ " $* " == *"status.traffic"* ]]; then
-    if [ -f "${HARNESS_PROBE_TAG_STATE_DIR}/${region}" ]; then
-      cat "${HARNESS_PROBE_TAG_STATE_DIR}/${region}"
-    fi
+  if [[ " $* " == *" run services update-traffic trusted-router "* ]] \
+      && [[ " $* " == *" --update-tags="* ]]; then
+    tag_assignment=""
+    for argument in "$@"; do
+      case "$argument" in --update-tags=*) tag_assignment="${argument#--update-tags=}" ;; esac
+    done
+    printf '%s\n' "${tag_assignment#*=}" >"${HARNESS_PROBE_TAG_STATE_DIR}/${region}"
+    exit 0
+  fi
+  if [[ " $* " == *" run services update-traffic trusted-router "* ]] \
+      && [[ " $* " == *" --remove-tags="* ]]; then
+    rm -f "${HARNESS_PROBE_TAG_STATE_DIR}/${region}"
+    exit 0
+  fi
+  if [[ " $* " == *" run services describe trusted-router "* ]] \
+      && [[ " $* " == *" --format=json "* ]]; then
+    python3 - "$HARNESS_PROBE_TAG_STATE_DIR" "$region" <<'PY'
+import json
+import pathlib
+import sys
+
+tag_path = pathlib.Path(sys.argv[1]) / sys.argv[2]
+traffic = [{"percent": 100, "revisionName": "trusted-router-active"}]
+if tag_path.is_file():
+    traffic.append(
+        {
+            "percent": 0,
+            "revisionName": tag_path.read_text().strip(),
+            "tag": "staged-probe",
+        }
+    )
+print(json.dumps({"status": {"traffic": traffic}}, separators=(",", ":")))
+PY
     exit 0
   fi
   if [[ " $* " == *" run services describe trusted-router-public "* ]] \
@@ -551,16 +587,6 @@ _SYNTHETIC_INGEST_SERVICE_JSON = json.dumps(
     separators=(",", ":"),
 )
 
-_PUBLIC_SURFACE_LEGACY_SERVICE_JSON = json.dumps(
-    {
-        "status": {
-            "traffic": [
-                {"percent": 100, "revisionName": "trusted-router-active"}
-            ]
-        }
-    },
-    separators=(",", ":"),
-)
 _PUBLIC_SURFACE_PUBLIC_SERVICE_JSON = json.dumps(
     {
         "metadata": {
@@ -725,10 +751,6 @@ SCRIPT_FIXTURES: dict[str, ScriptFixture] = {
         env={"HARNESS_PUBLIC_SURFACE_SMOKE": "1"},
         responses=(
             (r"projects describe.*projectNumber", "44325983244"),
-            (
-                r"run services describe trusted-router .*--format=json",
-                _PUBLIC_SURFACE_LEGACY_SERVICE_JSON,
-            ),
             (
                 r"run revisions describe trusted-router-active .*--format=json",
                 _PUBLIC_SURFACE_LEGACY_REVISION_JSON,

--- a/tests/test_deploy_watchdog.py
+++ b/tests/test_deploy_watchdog.py
@@ -5,10 +5,13 @@ import io
 import json
 import os
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
 import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def _load_watchdog() -> Any:
@@ -149,6 +152,7 @@ def _run_staged_probe(
     resolved_tag_revision: str = "new-rev",
     remove_failures: int = 0,
     remove_always_fails: bool = False,
+    remove_leaves_tag: bool = False,
 ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
     stub_bin = tmp_path / "bin"
     stub_bin.mkdir()
@@ -172,9 +176,22 @@ case " $* " in
       fi
       exit 1
     fi
-    : >"$STAGED_TAG_STATE"
+    if [ "$STAGED_REMOVE_LEAVES_TAG" != "1" ]; then
+      : >"$STAGED_TAG_STATE"
+    fi
     ;;
-  *"status.traffic"*) cat "$STAGED_TAG_STATE" ;;
+  *"status.traffic[?tag="*)
+    printf '%s\\n' 'TEST ERROR: unsupported gcloud resource projection' >&2
+    exit 64
+    ;;
+  *" --format=json"*)
+    tagged_revision="$(cat "$STAGED_TAG_STATE")"
+    if [ -n "$tagged_revision" ]; then
+      printf '{"status":{"traffic":[{"percent":100,"revisionName":"old-rev"},{"percent":0,"revisionName":"%s","tag":"staged-probe"}]}}\\n' "$tagged_revision"
+    else
+      printf '%s\\n' '{"status":{"traffic":[{"percent":100,"revisionName":"old-rev"}]}}'
+    fi
+    ;;
   *"status.url"*) printf '%s\\n' 'https://trusted-router-hash-uc.a.run.app' ;;
 esac
 """
@@ -194,10 +211,19 @@ printf '%s' "$code"
 [ "$code" != "000" ]
 """
     )
-    for name in ("python3", "sleep"):
-        stub = stub_bin / name
-        stub.write_text("#!/usr/bin/env bash\nexit 0\n")
-        stub.chmod(0o755)
+    sleep = stub_bin / "sleep"
+    sleep.write_text("#!/usr/bin/env bash\nexit 0\n")
+    sleep.chmod(0o755)
+    python3 = stub_bin / "python3"
+    python3.write_text(
+        """#!/usr/bin/env bash
+if [ "$1" = "-c" ]; then
+  exec "$STAGED_REAL_PYTHON" "$@"
+fi
+exit 0
+"""
+    )
+    python3.chmod(0o755)
     gcloud.chmod(0o755)
     curl.chmod(0o755)
     script = Path(__file__).resolve().parents[1] / "scripts" / "deploy" / "staged_traffic.sh"
@@ -213,6 +239,8 @@ printf '%s' "$code"
         "STAGED_TAG_STATE": str(tag_state),
         "STAGED_REMOVE_FAILURES_STATE": str(remove_failures_state),
         "STAGED_REMOVE_ALWAYS_FAILS": "1" if remove_always_fails else "0",
+        "STAGED_REMOVE_LEAVES_TAG": "1" if remove_leaves_tag else "0",
+        "STAGED_REAL_PYTHON": sys.executable,
         "TR_LEGACY_PROBE_RETRY_SECONDS": "0",
         "TR_PROBE_TAG_REMOVE_RETRY_SECONDS": "0",
     }
@@ -224,6 +252,94 @@ printf '%s' "$code"
         timeout=20,
     )
     return run, call_log.read_text().splitlines()
+
+
+def test_probe_tag_resolution_uses_json_and_unset_tag_resolves_to_empty(
+    tmp_path: Path,
+) -> None:
+    stub_bin = tmp_path / "bin"
+    stub_bin.mkdir()
+    call_log = tmp_path / "calls.log"
+    service_json = tmp_path / "service.json"
+    gcloud = stub_bin / "gcloud"
+    gcloud.write_text(
+        """#!/usr/bin/env bash
+printf 'gcloud %s\\n' "$*" >>"$PROBE_CALL_LOG"
+case " $* " in
+  # Match real gcloud: this unsupported projection succeeds with empty output.
+  # The call-log assertion below proves the implementation never takes it.
+  *"status.traffic[?tag="*) exit 0 ;;
+  *" --format=json"*) cat "$PROBE_SERVICE_JSON" ;;
+  *) exit 9 ;;
+esac
+"""
+    )
+    gcloud.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{stub_bin}:/bin:/usr/bin",
+        "PROBE_CALL_LOG": str(call_log),
+        "PROBE_SERVICE_JSON": str(service_json),
+    }
+    command = (
+        f"source {ROOT / 'scripts/deploy/_cloud_run_revision_probe.sh'}; "
+        "cloud_run_probe_tag_revision trusted-router us-central1 test-project "
+        "staged-probe"
+    )
+
+    service_json.write_text(
+        json.dumps(
+            {
+                "status": {
+                    "traffic": [
+                        {"percent": 100, "revisionName": "old-rev"},
+                        {
+                            "percent": 0,
+                            "revisionName": "new-rev",
+                            "tag": "staged-probe",
+                        },
+                    ]
+                }
+            }
+        )
+    )
+    resolved = subprocess.run(  # noqa: S603 - fixed shell with stubbed gcloud
+        ["/bin/bash", "-c", command],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=10,
+    )
+
+    assert resolved.returncode == 0, resolved.stderr
+    assert resolved.stdout == "new-rev\n"
+    calls = call_log.read_text().splitlines()
+    assert calls == [
+        "gcloud run services describe trusted-router --region=us-central1 "
+        "--project=test-project --format=json"
+    ]
+
+    call_log.write_text("")
+    service_json.write_text(
+        json.dumps(
+            {
+                "status": {
+                    "traffic": [{"percent": 100, "revisionName": "old-rev"}]
+                }
+            }
+        )
+    )
+    unresolved = subprocess.run(  # noqa: S603 - fixed shell with stubbed gcloud
+        ["/bin/bash", "-c", command],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=10,
+    )
+
+    assert unresolved.returncode == 0, unresolved.stderr
+    assert unresolved.stdout == ""
+    assert call_log.read_text().splitlines() == calls
 
 
 @pytest.mark.parametrize(
@@ -265,6 +381,12 @@ def test_staged_legacy_probe_uses_regional_origin_and_classifies_results(
         for call in calls
         if call.startswith("gcloud run services update-traffic")
     )
+    assert any(
+        "--format=json" in call
+        for call in calls
+        if call.startswith("gcloud run services describe")
+    )
+    assert not any("status.traffic[?tag=" in call for call in calls)
     rollback_calls = [
         call
         for call in calls
@@ -286,9 +408,12 @@ def test_staged_probe_reconciles_and_verifies_a_leftover_tag(tmp_path: Path) -> 
 
     assert run.returncode == 0, run.stderr
     assert any("--update-tags=staged-probe=new-rev" in call for call in calls)
+    assert any("--format=json" in call for call in calls)
+    assert not any("status.traffic[?tag=" in call for call in calls)
     assert any("--remove-tags=staged-probe" in call for call in calls)
     assert not any(call.startswith("curl ") for call in calls)
     assert "probe tag does not resolve to new-rev" in run.stdout
+    assert "resolves to old-rev, expected new-rev" in run.stderr
 
 
 def test_staged_probe_tag_cleanup_retries_a_transient_failure(tmp_path: Path) -> None:
@@ -318,3 +443,23 @@ def test_staged_probe_tag_cleanup_permanent_failure_is_nonzero(tmp_path: Path) -
         "--project=test-project --remove-tags=staged-probe --quiet"
     ) in run.stderr
     assert sum("--remove-tags=staged-probe" in call for call in calls) == 6
+
+
+def test_staged_probe_tag_cleanup_verifies_a_successful_removal(
+    tmp_path: Path,
+) -> None:
+    run, calls = _run_staged_probe(
+        tmp_path,
+        console_code="302",
+        session_code="401",
+        remove_leaves_tag=True,
+    )
+
+    assert run.returncode != 0
+    assert "still resolves to new-rev after removal attempt" in run.stderr
+    assert "probe tag staged-probe may still be addressable" in run.stderr
+    assert sum("--remove-tags=staged-probe" in call for call in calls) == 6
+    removal_index = next(
+        index for index, call in enumerate(calls) if "--remove-tags=staged-probe" in call
+    )
+    assert any("--format=json" in call for call in calls[removal_index + 1 :])


### PR DESCRIPTION
**Production bug, found by running the real routed deploy.** The shared probe helper resolved a Cloud Run revision tag with:

```
--format="value(status.traffic[?tag='<tag>'].revisionName)"
```

That is JMESPath. gcloud's resource projection does **not** support it — it returns **empty** rather than erroring. So `cloud_run_probe_tag_reconcile` always failed ("probe tag … resolves to \<nothing\>"), and the removal check always read as "already gone" without verifying anything.

The live routed deploy of the T1 public split aborted in us-central1 on exactly this. It **failed safe** — previously serving revision kept 100%, nothing promoted — which is why there was no outage.

Both call sites now read `--format=json` and match the tag in Python. Verified against the live service: tag set → resolved to the correct revision → removed.

## Why this survived four review rounds and green CI

The harness's fake gcloud was canned to satisfy the broken projection, so the tests asserted the bug was fine. That is the same failure shape as two earlier findings in the T1 split (a URL-map simulator that disagreed with the emitted map; a fixture without the output-only fields real `gcloud` rejects).

So the fake now **rejects** any JMESPath projection outright:

```
HARNESS ERROR: gcloud does not support JMESPath filters in resource projections   (exit 64)
```

and the legacy service's JSON describe includes the tagged-traffic entry, so the shared helper is exercised the way production exercises it.

## Impact if unlanded

The T1 public split is live, so the next scheduled deploy runs `public_surface.sh routed`, which uses this helper — that job fails (safely). The legacy `staged_traffic.sh` probe also uses it and currently degrades to "inconclusive", meaning it never gates a legacy ramp.

126 tests pass across the deploy/watchdog/surface files.

Written by codex; reviewed by Claude / Fable.