### PR TITLE
One production deployment mutex for workflows and hands

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -345,6 +345,11 @@ jobs:
     needs: [build-image, migrate-schema, sync-runtime-secrets, confirm-current-main]
     if: ${{ needs.confirm-current-main.outputs.proceed == 'true' }}
     runs-on: ubuntu-latest
+    # Must stay UNDER the deployment mutex TTL (deploy_mutex.sh, 5400s): a job
+    # that outlives the lease invites a legal expired-lock takeover while this
+    # run is still shifting traffic — the exact overlap the mutex exists to
+    # prevent. GitHub's default 360-minute bound is four TTLs too generous.
+    timeout-minutes: 85
     env:
       PROJECT_ID: quill-cloud-proxy
       REGION: us-central1
@@ -371,6 +376,12 @@ jobs:
 
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v2
+
+      - name: Acquire production deployment mutex
+        env:
+          TR_DEPLOY_MUTEX_OWNER: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TR_DEPLOY_MUTEX_TOOL: workflow
+        run: bash scripts/deploy/deploy_mutex.sh acquire >> "$GITHUB_ENV"
 
       # Staged regional deploy. Deploy us-central1 first, gate on a
       # 3-min single-region synthetic watch; only proceed to the
@@ -837,6 +848,10 @@ jobs:
           SPANNER_DATABASE_ID: trusted-router
         run: scripts/deploy/retire_settle_outbox_hot_index.sh
 
+      - name: Release production deployment mutex
+        if: always()
+        run: bash scripts/deploy/deploy_mutex.sh release
+
   public-surface-companion:
     # This job creates/updates the isolated T1 service only after the legacy
     # rollout is healthy. It never prepares or imports a URL map. Before the
@@ -847,8 +862,13 @@ jobs:
     continue-on-error: false
     runs-on: ubuntu-latest
     # Four sequential regional Cloud Run deploys normally finish in 12-20
-    # minutes. Thirty allows cold image pulls and bounded smoke retries without
-    # letting this T1 follow-on hold the workflow-wide production lock for hours.
+    # minutes. Thirty allows cold image pulls and bounded smoke retries.
+    # NOTE: this job runs AFTER the deploy job has released the production
+    # deployment mutex, and does not hold it. That is deliberate scope: the
+    # mutex fences trusted-router revisions/traffic, which manual rollout
+    # scripts also mutate; the T1 companion touches only its own service and
+    # is serialized against other workflow runs by the concurrency group. If
+    # manual T1 tooling ever appears, give it the same mutex first.
     timeout-minutes: 30
     env:
       PROJECT_ID: quill-cloud-proxy

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -15,6 +15,7 @@ Index:
 - [GCP enclave deploy keeps auto-rolling back europe-west4](#eu-rollback)
 - [GCP enclave deploy fails with "unrecognized arguments: --min-ready"](#min-ready)
 - [Hourly price bot commits but TR catalog stays stale](#bot-doesnt-deploy)
+- [Production deployment mutex](#deployment-mutex)
 - [Status page shows a region "down" but the region is actually healthy](#stale-status)
 - [`refresh.py` reports "too_many_failures" locally](#local-refresh-fails)
 - [A provider serves a model but TR's `/v1/models` doesn't list it](#missing-model)
@@ -280,6 +281,34 @@ The reason for the workaround: GHA's loop-prevention says commits
 pushed by `GITHUB_TOKEN` don't trigger `push:` events. `workflow_dispatch`
 events from `GITHUB_TOKEN` DO fire workflows — that's the exception
 we exploit.
+
+---
+
+## <a id="deployment-mutex"></a>Production deployment mutex
+
+The control-plane deploy workflow, direct `rollout.sh` runs, and manual
+`staged_traffic.sh` traffic shifts share a generation-fenced lock in GCS. It
+prevents two operators or automation paths from changing production Cloud Run
+revisions or traffic at the same time. Inspect the current metadata-only holder
+record without changing it:
+
+```bash
+bash scripts/deploy/deploy_mutex.sh status
+```
+
+Break glass only after running `status`, checking that the recorded owner is no
+longer active, and confirming that no GitHub Actions or manual production deploy
+is still running. Use the generation printed by `status`; the precondition keeps
+this command from deleting a replacement lock acquired after the inspection:
+
+```bash
+gcloud storage rm \
+  gs://tr-deploy-mutex-quill-cloud-proxy/locks/trusted-router-production.json \
+  --if-generation-match=GENERATION
+```
+
+Normal recovery does not require manual removal: locks expire after 90 minutes,
+and the next acquirer can take over an expired generation safely.
 
 ---
 

--- a/scripts/deploy/deploy_mutex.sh
+++ b/scripts/deploy/deploy_mutex.sh
@@ -1,0 +1,435 @@
+#!/usr/bin/env bash
+# Generation-fenced production deployment mutex shared by automation and
+# operators. Source this file to call deploy_mutex_acquire/release in the
+# current shell, or execute it with acquire, release, or status.
+
+_deploy_mutex_log() {
+  printf '%s\n' "$*" >&2
+}
+
+_deploy_mutex_uri() {
+  local bucket="${TR_DEPLOY_MUTEX_BUCKET:-tr-deploy-mutex-quill-cloud-proxy}"
+  if [[ ! "$bucket" =~ ^[a-z0-9][a-z0-9._-]{1,220}[a-z0-9]$ ]]; then
+    _deploy_mutex_log "deploy_mutex.invalid_bucket bucket=${bucket}"
+    return 1
+  fi
+  printf 'gs://%s/locks/trusted-router-production.json\n' "$bucket"
+}
+
+_deploy_mutex_generation() {
+  local uri="$1"
+  local generation
+  if ! generation="$(
+    gcloud storage objects describe "$uri" --format='value(generation)' 2>/dev/null
+  )"; then
+    return 1
+  fi
+  if [[ ! "$generation" =~ ^[0-9]+$ ]]; then
+    return 1
+  fi
+  printf '%s\n' "$generation"
+}
+
+_deploy_mutex_json_field() {
+  local path="$1"
+  local field="$2"
+  python3 - "$path" "$field" <<'PY'
+import json
+import sys
+
+try:
+    value = json.load(open(sys.argv[1], encoding="utf-8"))[sys.argv[2]]
+except (OSError, KeyError, TypeError, ValueError):
+    raise SystemExit(1)
+if not isinstance(value, str) or any(ord(char) < 32 for char in value):
+    raise SystemExit(1)
+print(value)
+PY
+}
+
+_deploy_mutex_expired() {
+  local expires_at="$1"
+  python3 - "$expires_at" <<'PY'
+from datetime import UTC, datetime
+import sys
+
+try:
+    raw = sys.argv[1]
+    parsed = datetime.fromisoformat(raw[:-1] + "+00:00" if raw.endswith("Z") else raw)
+    if parsed.tzinfo is None:
+        raise ValueError("timezone required")
+except ValueError:
+    raise SystemExit(2)
+raise SystemExit(0 if parsed <= datetime.now(UTC) else 1)
+PY
+}
+
+_deploy_mutex_write_record() {
+  local path="$1"
+  local owner="$2"
+  local operation_id="$3"
+  local ttl_seconds="$4"
+  local tool="$5"
+  local pid="$6"
+  python3 - "$path" "$owner" "$operation_id" "$ttl_seconds" "$tool" "$pid" <<'PY'
+from datetime import UTC, datetime, timedelta
+import json
+import sys
+
+path, owner, operation_id, ttl_raw, tool, pid_raw = sys.argv[1:]
+if not owner or len(owner) > 512 or any(ord(char) < 32 for char in owner):
+    raise SystemExit("owner must be 1..512 printable characters")
+if tool not in {"workflow", "manual"}:
+    raise SystemExit("tool must be workflow or manual")
+try:
+    ttl_seconds = int(ttl_raw)
+    pid = int(pid_raw)
+except ValueError:
+    raise SystemExit("ttl and pid must be integers") from None
+created = datetime.now(UTC).replace(microsecond=0)
+record = {
+    "owner": owner,
+    "operation_id": operation_id,
+    "created_at": created.isoformat().replace("+00:00", "Z"),
+    "expires_at": (created + timedelta(seconds=ttl_seconds))
+    .isoformat()
+    .replace("+00:00", "Z"),
+    "tool": tool,
+    "pid": pid,
+}
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(record, handle, separators=(",", ":"), sort_keys=True)
+    handle.write("\n")
+PY
+}
+
+_deploy_mutex_default_owner() {
+  local user_name
+  local host_name
+  user_name="$(whoami)"
+  host_name="$(hostname)"
+  printf 'manual:%s@%s\n' "$user_name" "$host_name"
+}
+
+deploy_mutex_acquire() {
+  if [ -n "${TR_DEPLOY_MUTEX_OPERATION:-}" ]; then
+    DEPLOY_MUTEX_SCOPE_DEPTH=$((${DEPLOY_MUTEX_SCOPE_DEPTH:-0} + 1))
+    DEPLOY_MUTEX_SCOPE_OWNS_LOCK="${DEPLOY_MUTEX_SCOPE_OWNS_LOCK:-0}"
+    _deploy_mutex_log \
+      "deploy_mutex.reentrant operation_id=${TR_DEPLOY_MUTEX_OPERATION}"
+    printf 'TR_DEPLOY_MUTEX_OPERATION=%s\n' "$TR_DEPLOY_MUTEX_OPERATION"
+    printf 'TR_DEPLOY_MUTEX_GENERATION=%s\n' \
+      "${TR_DEPLOY_MUTEX_GENERATION:-}"
+    return 0
+  fi
+
+  local ttl_raw="${TR_DEPLOY_MUTEX_TTL_SECONDS:-5400}"
+  if [[ ! "$ttl_raw" =~ ^[0-9]+$ ]]; then
+    _deploy_mutex_log "deploy_mutex.invalid_ttl ttl_seconds=${ttl_raw}"
+    return 1
+  fi
+  local ttl_seconds=$((10#$ttl_raw))
+  if [ "$ttl_seconds" -lt 60 ] || [ "$ttl_seconds" -gt 14400 ]; then
+    _deploy_mutex_log "deploy_mutex.invalid_ttl ttl_seconds=${ttl_seconds}"
+    return 1
+  fi
+
+  local uri
+  if ! uri="$(_deploy_mutex_uri)"; then
+    return 1
+  fi
+  local owner="${TR_DEPLOY_MUTEX_OWNER:-}"
+  if [ -z "$owner" ]; then
+    owner="$(_deploy_mutex_default_owner)"
+  fi
+  local tool="${TR_DEPLOY_MUTEX_TOOL:-}"
+  if [ -z "$tool" ]; then
+    if [ "${GITHUB_ACTIONS:-false}" = "true" ]; then
+      tool="workflow"
+    else
+      tool="manual"
+    fi
+  fi
+  local operation_id
+  operation_id="$(python3 -c 'import uuid; print(uuid.uuid4())')"
+  local record_file
+  local holder_file
+  record_file="$(mktemp "${TMPDIR:-/tmp}/tr-deploy-mutex-record.XXXXXX")"
+  holder_file="$(mktemp "${TMPDIR:-/tmp}/tr-deploy-mutex-holder.XXXXXX")"
+  if ! _deploy_mutex_write_record \
+      "$record_file" "$owner" "$operation_id" "$ttl_seconds" "$tool" "$$"; then
+    rm -f "$record_file" "$holder_file"
+    _deploy_mutex_log "deploy_mutex.invalid_metadata"
+    return 1
+  fi
+
+  local created_at
+  local expires_at
+  created_at="$(_deploy_mutex_json_field "$record_file" created_at)"
+  expires_at="$(_deploy_mutex_json_field "$record_file" expires_at)"
+
+  local created=0
+  if gcloud storage cp "$record_file" "$uri" \
+      --if-generation-match=0 >/dev/null 2>&1; then
+    created=1
+  else
+    local previous_generation
+    if ! previous_generation="$(_deploy_mutex_generation "$uri")"; then
+      rm -f "$record_file" "$holder_file"
+      _deploy_mutex_log "deploy_mutex.acquire_failed reason=holder_unreadable"
+      return 1
+    fi
+    if ! gcloud storage cp \
+        "${uri}#${previous_generation}" "$holder_file" >/dev/null 2>&1; then
+      rm -f "$record_file" "$holder_file"
+      _deploy_mutex_log \
+        "deploy_mutex.acquire_failed reason=holder_changed generation=${previous_generation}"
+      return 1
+    fi
+
+    local previous_owner
+    local previous_operation
+    local previous_created_at
+    local previous_expires_at
+    if ! previous_owner="$(_deploy_mutex_json_field "$holder_file" owner)" ||
+       ! previous_operation="$(_deploy_mutex_json_field "$holder_file" operation_id)" ||
+       ! previous_created_at="$(_deploy_mutex_json_field "$holder_file" created_at)" ||
+       ! previous_expires_at="$(_deploy_mutex_json_field "$holder_file" expires_at)"; then
+      rm -f "$record_file" "$holder_file"
+      _deploy_mutex_log \
+        "deploy_mutex.acquire_failed reason=holder_metadata_invalid generation=${previous_generation}"
+      return 1
+    fi
+
+    local expiry_rc
+    if _deploy_mutex_expired "$previous_expires_at"; then
+      if ! gcloud storage rm "$uri" \
+          --if-generation-match="$previous_generation" >/dev/null 2>&1; then
+        rm -f "$record_file" "$holder_file"
+        _deploy_mutex_log \
+          "deploy_mutex.acquire_failed reason=takeover_lost generation=${previous_generation}"
+        return 1
+      fi
+      _deploy_mutex_log \
+        "deploy_mutex.expired_takeover previous_owner=${previous_owner} previous_operation_id=${previous_operation} previous_generation=${previous_generation}"
+      if gcloud storage cp "$record_file" "$uri" \
+          --if-generation-match=0 >/dev/null 2>&1; then
+        created=1
+      else
+        rm -f "$record_file" "$holder_file"
+        _deploy_mutex_log "deploy_mutex.acquire_failed reason=takeover_create_lost"
+        return 1
+      fi
+    else
+      expiry_rc=$?
+      rm -f "$record_file" "$holder_file"
+      if [ "$expiry_rc" -eq 2 ]; then
+        _deploy_mutex_log \
+          "deploy_mutex.acquire_failed reason=holder_expiry_invalid generation=${previous_generation}"
+      else
+        _deploy_mutex_log \
+          "deploy_mutex.blocked owner=${previous_owner} operation_id=${previous_operation} created_at=${previous_created_at} expires_at=${previous_expires_at}"
+      fi
+      return 1
+    fi
+  fi
+
+  # Post-create verification. The create-if-generation-0 succeeded, so an
+  # object we wrote exists — but the describe below reads the CURRENT object
+  # at that name, and in the break-glass window (manual rm + an immediate
+  # re-acquire by someone else) the current object may no longer be ours.
+  # Rule, per review: NEVER delete on ambiguity. The only branch that may
+  # remove the object is the one that has read it back and proven the
+  # operation_id is ours — and that branch is the success path, which keeps
+  # it. Every failure here leaves the object alone: if it is ours the TTL
+  # unblocks deploys in at most 90 minutes (a freeze, which is safe); if it
+  # is someone else's, deleting it would let two deploys run concurrently
+  # (which is the one thing this mutex exists to prevent). Reads are retried
+  # because the object was written milliseconds ago.
+  if [ "$created" -ne 1 ]; then
+    # Unreachable today (every non-created branch above returns), kept as a
+    # guard for future edits: verification below assumes the create happened.
+    rm -f "$record_file" "$holder_file"
+    _deploy_mutex_log "deploy_mutex.acquire_failed reason=not_created"
+    return 1
+  fi
+  local generation=""
+  local verify_attempt
+  for verify_attempt in 1 2 3; do
+    if generation="$(_deploy_mutex_generation "$uri")"; then
+      break
+    fi
+    generation=""
+    sleep "$verify_attempt"
+  done
+  if [ -z "$generation" ]; then
+    rm -f "$record_file" "$holder_file"
+    _deploy_mutex_log \
+      "deploy_mutex.acquire_failed reason=generation_unreadable cleanup=none note=object_left_until_ttl"
+    return 1
+  fi
+  local read_ok=0
+  for verify_attempt in 1 2 3; do
+    if gcloud storage cp \
+        "${uri}#${generation}" "$holder_file" >/dev/null 2>&1; then
+      read_ok=1
+      break
+    fi
+    sleep "$verify_attempt"
+  done
+  local acquired_operation=""
+  if [ "$read_ok" -ne 1 ] ||
+     ! acquired_operation="$(_deploy_mutex_json_field "$holder_file" operation_id)"; then
+    rm -f "$record_file" "$holder_file"
+    _deploy_mutex_log \
+      "deploy_mutex.acquire_failed reason=fence_unreadable generation=${generation} cleanup=none note=object_left_until_ttl"
+    return 1
+  fi
+  if [ "$acquired_operation" != "$operation_id" ]; then
+    # The current object belongs to a DIFFERENT operation: ours is already
+    # gone (break-glass removal plus an immediate re-acquire is the only
+    # path here). Deleting would kill the new holder's live lock.
+    rm -f "$record_file" "$holder_file"
+    _deploy_mutex_log \
+      "deploy_mutex.acquire_failed reason=lock_replaced generation=${generation} holder_operation_id=${acquired_operation}"
+    return 1
+  fi
+  rm -f "$record_file" "$holder_file"
+
+  export TR_DEPLOY_MUTEX_OPERATION="$operation_id"
+  export TR_DEPLOY_MUTEX_GENERATION="$generation"
+  DEPLOY_MUTEX_SCOPE_DEPTH=$((${DEPLOY_MUTEX_SCOPE_DEPTH:-0} + 1))
+  DEPLOY_MUTEX_SCOPE_OWNS_LOCK=1
+  _deploy_mutex_log \
+    "deploy_mutex.acquired owner=${owner} operation_id=${operation_id} generation=${generation} created_at=${created_at} expires_at=${expires_at} ttl_seconds=${ttl_seconds} tool=${tool}"
+  printf 'TR_DEPLOY_MUTEX_OPERATION=%s\n' "$operation_id"
+  printf 'TR_DEPLOY_MUTEX_GENERATION=%s\n' "$generation"
+}
+
+deploy_mutex_release() {
+  local operation_id="${TR_DEPLOY_MUTEX_OPERATION:-}"
+  local generation="${TR_DEPLOY_MUTEX_GENERATION:-}"
+  local scope_depth="${DEPLOY_MUTEX_SCOPE_DEPTH:-0}"
+  local scope_owns_lock="${DEPLOY_MUTEX_SCOPE_OWNS_LOCK:-0}"
+  if [ "${DEPLOY_MUTEX_RELEASE_RECORDED:-0}" != "1" ]; then
+    if [ "$scope_depth" -gt 1 ]; then
+      DEPLOY_MUTEX_SCOPE_DEPTH=$((scope_depth - 1))
+      _deploy_mutex_log \
+        "deploy_mutex.release_noop reason=reentrant_scope operation_id=${operation_id:-missing}"
+      return 0
+    fi
+    if [ "$scope_owns_lock" -ne 1 ]; then
+      if [ "$scope_depth" -gt 0 ]; then
+        DEPLOY_MUTEX_SCOPE_DEPTH=$((scope_depth - 1))
+      fi
+      _deploy_mutex_log \
+        "deploy_mutex.release_noop reason=scope_did_not_acquire operation_id=${operation_id:-missing}"
+      return 0
+    fi
+  fi
+  if [ -z "$operation_id" ] && [ -z "$generation" ]; then
+    _deploy_mutex_log "deploy_mutex.release_noop reason=no_operation"
+    return 0
+  fi
+  if [ -z "$operation_id" ] || [[ ! "$generation" =~ ^[0-9]+$ ]]; then
+    _deploy_mutex_log \
+      "deploy_mutex.release_failed operation_id=${operation_id:-missing} generation=${generation:-missing} reason=invalid_fence"
+    return 0
+  fi
+  local uri
+  if ! uri="$(_deploy_mutex_uri)"; then
+    _deploy_mutex_log \
+      "deploy_mutex.release_failed operation_id=${operation_id} generation=${generation} reason=invalid_bucket"
+    return 0
+  fi
+  if gcloud storage rm "$uri" \
+      --if-generation-match="$generation" >/dev/null 2>&1; then
+    _deploy_mutex_log \
+      "deploy_mutex.released operation_id=${operation_id} generation=${generation}"
+  else
+    _deploy_mutex_log \
+      "deploy_mutex.release_failed operation_id=${operation_id} generation=${generation}"
+  fi
+  # The fence is spent either way: the lock is gone, was taken over, or will
+  # expire. Leaving these exported would make a LATER acquire in this same
+  # shell take the reentrant fast path and "hold" a lock that no longer
+  # exists — a manual deploy running with no lock at all.
+  unset TR_DEPLOY_MUTEX_OPERATION TR_DEPLOY_MUTEX_GENERATION
+  DEPLOY_MUTEX_SCOPE_DEPTH=0
+  DEPLOY_MUTEX_SCOPE_OWNS_LOCK=0
+  return 0
+}
+
+deploy_mutex_status() {
+  local uri
+  if ! uri="$(_deploy_mutex_uri)"; then
+    return 1
+  fi
+  local error_file
+  error_file="$(mktemp "${TMPDIR:-/tmp}/tr-deploy-mutex-status.XXXXXX")"
+  local generation
+  if ! generation="$(
+    gcloud storage objects describe "$uri" \
+      --format='value(generation)' 2>"$error_file"
+  )"; then
+    if grep -Eiq '404|not[ _-]?found|no urls matched' "$error_file"; then
+      rm -f "$error_file"
+      printf 'unlocked\n'
+      return 0
+    fi
+    _deploy_mutex_log "deploy_mutex.status_failed uri=${uri}"
+    rm -f "$error_file"
+    return 1
+  fi
+  rm -f "$error_file"
+  if [[ ! "$generation" =~ ^[0-9]+$ ]]; then
+    _deploy_mutex_log "deploy_mutex.status_failed reason=generation_invalid"
+    return 1
+  fi
+  local holder_file
+  holder_file="$(mktemp "${TMPDIR:-/tmp}/tr-deploy-mutex-status.XXXXXX")"
+  if ! gcloud storage cp \
+      "${uri}#${generation}" "$holder_file" >/dev/null 2>&1; then
+    rm -f "$holder_file"
+    _deploy_mutex_log "deploy_mutex.status_failed reason=holder_changed"
+    return 1
+  fi
+  python3 - "$holder_file" "$generation" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    record = json.load(handle)
+record["generation"] = int(sys.argv[2])
+print(json.dumps(record, indent=2, sort_keys=True))
+PY
+  local status_rc=$?
+  rm -f "$holder_file"
+  return "$status_rc"
+}
+
+_deploy_mutex_main() {
+  if [ "$#" -ne 1 ]; then
+    printf 'usage: %s acquire|release|status\n' "$0" >&2
+    return 2
+  fi
+  case "$1" in
+    acquire) deploy_mutex_acquire ;;
+    release)
+      DEPLOY_MUTEX_RELEASE_RECORDED=1
+      deploy_mutex_release
+      ;;
+    status) deploy_mutex_status ;;
+    *)
+      printf 'usage: %s acquire|release|status\n' "$0" >&2
+      return 2
+      ;;
+  esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  set -u
+  set -o pipefail
+  _deploy_mutex_main "$@"
+  exit $?
+fi

--- a/scripts/deploy/infra.sh
+++ b/scripts/deploy/infra.sh
@@ -16,6 +16,7 @@ gc services enable \
   datamanager.googleapis.com \
   spanner.googleapis.com \
   bigtableadmin.googleapis.com \
+  storage.googleapis.com \
   cloudbuild.googleapis.com
 
 log "ensuring Spanner instance/database"
@@ -82,6 +83,34 @@ for service_account in "$DEPLOY_SERVICE_ACCOUNT" "$OPS_SERVICE_ACCOUNT"; do
     --role="$BIGTABLE_SCHEMA_ROLE" \
     --quiet >/dev/null
 done
+
+log "ensuring production deployment mutex bucket"
+DEPLOY_MUTEX_BUCKET="${TR_DEPLOY_MUTEX_BUCKET:-tr-deploy-mutex-quill-cloud-proxy}"
+DEPLOY_MUTEX_LOCATION="${TR_DEPLOY_MUTEX_LOCATION:-us-central1}"
+DEPLOY_MUTEX_LIFECYCLE_FILE="$(mktemp "${TMPDIR:-/tmp}/tr-deploy-mutex-lifecycle-XXXXXX.json")"
+printf '%s\n' \
+  '{"rule":[{"action":{"type":"Delete"},"condition":{"age":1}}]}' \
+  >"$DEPLOY_MUTEX_LIFECYCLE_FILE"
+if ! gc storage buckets describe "gs://${DEPLOY_MUTEX_BUCKET}" >/dev/null 2>&1; then
+  gc storage buckets create "gs://${DEPLOY_MUTEX_BUCKET}" \
+    --location="$DEPLOY_MUTEX_LOCATION" \
+    --uniform-bucket-level-access \
+    --public-access-prevention \
+    --lifecycle-file="$DEPLOY_MUTEX_LIFECYCLE_FILE" \
+    --quiet
+fi
+# Reassert the safety controls on existing buckets as well as newly created
+# ones so a later manual setting change is repaired by the idempotent script.
+gc storage buckets update "gs://${DEPLOY_MUTEX_BUCKET}" \
+  --uniform-bucket-level-access \
+  --public-access-prevention \
+  --lifecycle-file="$DEPLOY_MUTEX_LIFECYCLE_FILE" \
+  --quiet
+rm -f "$DEPLOY_MUTEX_LIFECYCLE_FILE"
+gc storage buckets add-iam-policy-binding "gs://${DEPLOY_MUTEX_BUCKET}" \
+  --member="serviceAccount:${DEPLOY_SERVICE_ACCOUNT}" \
+  --role="roles/storage.objectAdmin" \
+  --quiet >/dev/null
 
 log "ensuring BYOK envelope KMS key"
 if ! gc kms keyrings describe "$KMS_KEYRING_ID" --location "$REGION" >/dev/null 2>&1; then

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -18,8 +18,29 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/deploy/_lib.sh
 source "${SCRIPT_DIR}/_lib.sh"
+# shellcheck source=scripts/deploy/deploy_mutex.sh
+source "${SCRIPT_DIR}/deploy_mutex.sh"
 # shellcheck source=scripts/deploy/regional_quota_rollout.sh
 source "${SCRIPT_DIR}/regional_quota_rollout.sh"
+
+release_rollout_deploy_mutex() {
+  local rollout_status=$?
+  # Finish the release uninterrupted; a signal here would leak the mutex
+  # until its TTL.
+  trap '' INT TERM
+  trap - EXIT
+  if [ "${DEPLOY_MUTEX_SCOPE_OWNS_LOCK:-0}" -eq 1 ]; then
+    deploy_mutex_release
+  fi
+  exit "$rollout_status"
+}
+trap release_rollout_deploy_mutex EXIT
+
+# The workflow exports its outer lock through GITHUB_ENV. A direct operator
+# invocation has no such operation and owns this script-level scope instead.
+if [ -z "${TR_DEPLOY_MUTEX_OPERATION:-}" ]; then
+  deploy_mutex_acquire
+fi
 
 TRUST_SOURCE_COMMIT=""
 TRUST_IMAGE_REFERENCE=""

--- a/scripts/deploy/staged_traffic.sh
+++ b/scripts/deploy/staged_traffic.sh
@@ -23,6 +23,8 @@ WATCHDOG_SLO_CLASS="${TR_WATCHDOG_SLO_CLASS:-router_core}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/deploy/_cloud_run_revision_probe.sh
 source "${SCRIPT_DIR}/_cloud_run_revision_probe.sh"
+# shellcheck source=scripts/deploy/deploy_mutex.sh
+source "${SCRIPT_DIR}/deploy_mutex.sh"
 LEGACY_PROBE_ATTEMPTS="${TR_LEGACY_PROBE_ATTEMPTS:-3}"
 LEGACY_PROBE_RETRY_SECONDS="${TR_LEGACY_PROBE_RETRY_SECONDS:-2}"
 LEGACY_PROBE_TAG="staged-probe"
@@ -57,9 +59,30 @@ cleanup_probe_tag() {
   return 1
 }
 
-trap cleanup_probe_tag EXIT
+cleanup_staged_traffic() {
+  local staged_status=$?
+  # A signal landing mid-cleanup would exit without re-running this handler,
+  # leaking the mutex until its TTL. Finish cleanup uninterrupted.
+  trap '' INT TERM
+  trap - EXIT
+  if ! cleanup_probe_tag && [ "$staged_status" -eq 0 ]; then
+    staged_status=1
+  fi
+  if [ "${DEPLOY_MUTEX_SCOPE_OWNS_LOCK:-0}" -eq 1 ]; then
+    deploy_mutex_release
+  fi
+  exit "$staged_status"
+}
+
+# The workflow owns one mutex across every regional ramp. A direct manual
+# traffic shift acquires the same object and releases it through the chained
+# EXIT cleanup below.
+trap cleanup_staged_traffic EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
+if [ -z "${TR_DEPLOY_MUTEX_OPERATION:-}" ]; then
+  deploy_mutex_acquire
+fi
 
 shift_traffic() {
   local new_pct="$1"

--- a/src/trusted_router/regional_quota_reconcile_cli.py
+++ b/src/trusted_router/regional_quota_reconcile_cli.py
@@ -45,6 +45,23 @@ def main() -> int:
     if lock is None:
         logger.info("regional_quota.reconciler_lock_busy")
         return 0
+    logger.info(
+        "regional_quota.reconciler_lock_acquired owner=%s fencing_token=%d ttl_seconds=%d",
+        owner,
+        int(lock.fencing_token),
+        _LOCK_TTL_SECONDS,
+    )
+    previous_owner = getattr(lock, "previous_owner", None)
+    previous_fencing_token = getattr(lock, "previous_fencing_token", None)
+    if previous_owner is not None and previous_fencing_token is not None:
+        logger.info(
+            "regional_quota.reconciler_lock_takeover owner=%s fencing_token=%d "
+            "previous_owner=%s previous_fencing_token=%d",
+            owner,
+            int(lock.fencing_token),
+            previous_owner,
+            int(previous_fencing_token),
+        )
 
     exit_code = 1
     try:
@@ -60,10 +77,17 @@ def main() -> int:
             )
         except Exception:
             logger.exception("regional_quota.reconciler_lock_release_failed")
-            released = False
-        if not released:
-            logger.error("regional_quota.reconciler_lock_release_lost")
             exit_code = 1
+        else:
+            if released:
+                logger.info(
+                    "regional_quota.reconciler_lock_released owner=%s fencing_token=%d",
+                    owner,
+                    int(lock.fencing_token),
+                )
+            else:
+                logger.error("regional_quota.reconciler_lock_release_lost")
+                exit_code = 1
     if exit_code == 0:
         record_heartbeat("job:regional-quota-reconcile", settings=settings)
     return exit_code

--- a/src/trusted_router/storage_gcp_regional_quota.py
+++ b/src/trusted_router/storage_gcp_regional_quota.py
@@ -106,6 +106,11 @@ class RegionalQuotaReconcilerLock:
     fencing_token: int
     expires_at: str
     updated_at: str
+    # Acquisition-only metadata. These defaults keep older persisted lock rows
+    # readable, and the transaction below deliberately does not persist the
+    # previous holder on the new lock row.
+    previous_owner: str | None = None
+    previous_fencing_token: int | None = None
 
     @property
     def expires_datetime(self) -> datetime:
@@ -151,6 +156,12 @@ def acquire_regional_quota_reconciler_lock(
             _RECONCILER_LOCK_ID,
             lock,
         )
+        if current is not None and current.owner is not None:
+            return dataclasses.replace(
+                lock,
+                previous_owner=current.owner,
+                previous_fencing_token=current.fencing_token,
+            )
         return lock
 
     return store._run_in_transaction(txn)

--- a/tests/test_deploy_mutex.py
+++ b/tests/test_deploy_mutex.py
@@ -1,0 +1,537 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+MUTEX_SCRIPT = ROOT / "scripts" / "deploy" / "deploy_mutex.sh"
+
+_GCLOUD_STUB = r'''#!/usr/bin/env python3
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+from pathlib import Path
+import shutil
+import sys
+
+args = sys.argv[1:]
+state = Path(os.environ["MUTEX_STUB_STATE"])
+guard_path = state / "guard"
+object_path = state / "object.json"
+generation_path = state / "generation"
+counter_path = state / "counter"
+calls_path = Path(os.environ["MUTEX_STUB_CALLS"])
+mutations_path = Path(os.environ["MUTEX_STUB_MUTATIONS"])
+
+
+def append(path: Path, value: object) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(value, separators=(",", ":")) + "\n")
+
+
+def precondition(name: str) -> str | None:
+    prefix = f"--{name}="
+    for index, argument in enumerate(args):
+        if argument.startswith(prefix):
+            return argument[len(prefix) :]
+        if argument == f"--{name}" and index + 1 < len(args):
+            return args[index + 1]
+    return None
+
+
+with guard_path.open("a+", encoding="utf-8") as guard:
+    fcntl.flock(guard, fcntl.LOCK_EX)
+    append(calls_path, args)
+
+if args[:2] == ["storage", "cp"]:
+    source = args[2]
+    destination = args[3]
+    if destination.startswith("gs://"):
+        if precondition("if-generation-match") != "0":
+            raise SystemExit(2)
+        with guard_path.open("a+", encoding="utf-8") as guard:
+            fcntl.flock(guard, fcntl.LOCK_EX)
+            if object_path.exists():
+                print("precondition failed", file=sys.stderr)
+                raise SystemExit(1)
+            generation = int(counter_path.read_text() or "0") + 1
+            counter_path.write_text(str(generation), encoding="utf-8")
+            shutil.copyfile(source, object_path)
+            generation_path.write_text(str(generation), encoding="utf-8")
+            record = json.loads(object_path.read_text(encoding="utf-8"))
+            append(
+                mutations_path,
+                {
+                    "action": "create",
+                    "generation": generation,
+                    "operation_id": record["operation_id"],
+                },
+            )
+        raise SystemExit(0)
+
+    requested_generation = None
+    if "#" in source:
+        source, requested_generation = source.rsplit("#", 1)
+    if os.environ.get("MUTEX_STUB_DOWNLOAD_FAIL") == "1":
+        print("injected download failure", file=sys.stderr)
+        raise SystemExit(1)
+    with guard_path.open("a+", encoding="utf-8") as guard:
+        fcntl.flock(guard, fcntl.LOCK_SH)
+        if not object_path.exists():
+            print("not found: 404", file=sys.stderr)
+            raise SystemExit(1)
+        generation = generation_path.read_text(encoding="utf-8")
+        if requested_generation is not None and requested_generation != generation:
+            print("generation changed", file=sys.stderr)
+            raise SystemExit(1)
+        shutil.copyfile(object_path, destination)
+    raise SystemExit(0)
+
+if args[:3] == ["storage", "objects", "describe"]:
+    replace_flag = state / "replace-on-describe"
+    if replace_flag.exists():
+        # Simulates the break-glass window: between our create and our
+        # verification describe, an operator removed the lock and a second
+        # acquirer immediately created its own. The current object at the
+        # name is theirs, at a NEW generation.
+        with guard_path.open("a+", encoding="utf-8") as guard:
+            fcntl.flock(guard, fcntl.LOCK_EX)
+            if object_path.exists() and replace_flag.exists():
+                replace_flag.unlink()
+                generation = int(counter_path.read_text() or "0") + 1
+                counter_path.write_text(str(generation), encoding="utf-8")
+                record = json.loads(object_path.read_text(encoding="utf-8"))
+                record["operation_id"] = "someone-elses-operation"
+                object_path.write_text(
+                    json.dumps(record, separators=(",", ":")), encoding="utf-8"
+                )
+                generation_path.write_text(str(generation), encoding="utf-8")
+                append(
+                    mutations_path,
+                    {"action": "replace", "generation": generation},
+                )
+    with guard_path.open("a+", encoding="utf-8") as guard:
+        fcntl.flock(guard, fcntl.LOCK_SH)
+        if not object_path.exists():
+            print("not found: 404", file=sys.stderr)
+            raise SystemExit(1)
+        print(generation_path.read_text(encoding="utf-8"))
+    raise SystemExit(0)
+
+if args[:2] == ["storage", "rm"]:
+    if os.environ.get("MUTEX_STUB_RM_FAIL") == "1":
+        print("injected delete failure", file=sys.stderr)
+        raise SystemExit(1)
+    expected_generation = precondition("if-generation-match")
+    with guard_path.open("a+", encoding="utf-8") as guard:
+        fcntl.flock(guard, fcntl.LOCK_EX)
+        if not object_path.exists():
+            print("not found: 404", file=sys.stderr)
+            raise SystemExit(1)
+        generation = generation_path.read_text(encoding="utf-8")
+        # Real gcloud deletes unconditionally when no precondition is given.
+        # Modeling an unfenced rm as a failure here would let a test of an
+        # unfenced-delete bug pass while production deleted a live lock.
+        if expected_generation is not None and expected_generation != generation:
+            print("precondition failed", file=sys.stderr)
+            raise SystemExit(1)
+        object_path.unlink()
+        generation_path.unlink()
+        append(
+            mutations_path,
+            {"action": "delete", "generation": int(generation)},
+        )
+    raise SystemExit(0)
+
+print(f"unsupported gcloud invocation: {args!r}", file=sys.stderr)
+raise SystemExit(2)
+'''
+
+
+@dataclass
+class MutexHarness:
+    root: Path
+    bin_dir: Path
+    state_dir: Path
+    calls_path: Path
+    mutations_path: Path
+
+    @classmethod
+    def build(cls, root: Path) -> MutexHarness:
+        bin_dir = root / "bin"
+        state_dir = root / "state"
+        temp_dir = root / "tmp"
+        home_dir = root / "home"
+        for directory in (bin_dir, state_dir, temp_dir, home_dir):
+            directory.mkdir(parents=True)
+        calls_path = root / "calls.jsonl"
+        mutations_path = root / "mutations.jsonl"
+        calls_path.write_text("", encoding="utf-8")
+        mutations_path.write_text("", encoding="utf-8")
+        (state_dir / "counter").write_text("0", encoding="utf-8")
+        gcloud = bin_dir / "gcloud"
+        gcloud.write_text(_GCLOUD_STUB, encoding="utf-8")
+        gcloud.chmod(0o755)
+        (bin_dir / "python3").symlink_to(sys.executable)
+        return cls(root, bin_dir, state_dir, calls_path, mutations_path)
+
+    def env(self, owner: str, **extra: str) -> dict[str, str]:
+        env = {
+            "PATH": f"{self.bin_dir}:/bin:/usr/bin",
+            "HOME": str(self.root / "home"),
+            "TMPDIR": str(self.root / "tmp"),
+            "LANG": "C",
+            "MUTEX_STUB_STATE": str(self.state_dir),
+            "MUTEX_STUB_CALLS": str(self.calls_path),
+            "MUTEX_STUB_MUTATIONS": str(self.mutations_path),
+            "TR_DEPLOY_MUTEX_BUCKET": "trusted-router-mutex-test",
+            "TR_DEPLOY_MUTEX_OWNER": owner,
+            "TR_DEPLOY_MUTEX_TOOL": "manual",
+            "TR_DEPLOY_MUTEX_TTL_SECONDS": "60",
+            **extra,
+        }
+        assert "TR_SENTRY_DSN" not in env
+        return env
+
+    def run(
+        self,
+        command: str,
+        owner: str,
+        **extra: str,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(  # noqa: S603 - repo script and isolated stub PATH.
+            ["bash", str(MUTEX_SCRIPT), command],  # noqa: S607
+            cwd=ROOT,
+            env=self.env(owner, **extra),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=20,
+        )
+
+    def popen(self, owner: str) -> subprocess.Popen[str]:
+        return subprocess.Popen(  # noqa: S603 - repo script and isolated stub PATH.
+            ["bash", str(MUTEX_SCRIPT), "acquire"],  # noqa: S607
+            cwd=ROOT,
+            env=self.env(owner),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+    def record(self) -> dict[str, object]:
+        return json.loads((self.state_dir / "object.json").read_text(encoding="utf-8"))
+
+    def generation(self) -> int:
+        return int((self.state_dir / "generation").read_text(encoding="utf-8"))
+
+    def calls(self) -> list[list[str]]:
+        return [
+            json.loads(line)
+            for line in self.calls_path.read_text(encoding="utf-8").splitlines()
+        ]
+
+    def mutations(self) -> list[dict[str, object]]:
+        return [
+            json.loads(line)
+            for line in self.mutations_path.read_text(encoding="utf-8").splitlines()
+        ]
+
+    def clear_calls(self) -> None:
+        self.calls_path.write_text("", encoding="utf-8")
+
+
+@pytest.fixture
+def mutex(tmp_path: Path) -> MutexHarness:
+    return MutexHarness.build(tmp_path)
+
+
+def _exported(stdout: str) -> dict[str, str]:
+    return dict(line.split("=", 1) for line in stdout.splitlines() if "=" in line)
+
+
+def test_two_concurrent_acquires_have_exactly_one_winner(
+    mutex: MutexHarness,
+) -> None:
+    contenders = [mutex.popen("manual:one@test"), mutex.popen("manual:two@test")]
+    results = [process.communicate(timeout=20) for process in contenders]
+    returncodes = [process.returncode for process in contenders]
+
+    assert sorted(returncodes) == [0, 1]
+    winner_index = returncodes.index(0)
+    loser_index = returncodes.index(1)
+    winner_exports = _exported(results[winner_index][0])
+    assert mutex.record()["operation_id"] == winner_exports[
+        "TR_DEPLOY_MUTEX_OPERATION"
+    ]
+    assert "deploy_mutex.blocked" in results[loser_index][1]
+    assert mutex.mutations() == [
+        {
+            "action": "create",
+            "generation": 1,
+            "operation_id": winner_exports["TR_DEPLOY_MUTEX_OPERATION"],
+        }
+    ]
+
+
+def test_expired_holder_is_replaced_and_old_release_is_fenced(
+    mutex: MutexHarness,
+) -> None:
+    first = mutex.run("acquire", "manual:crashed@test")
+    assert first.returncode == 0, first.stderr
+    first_exports = _exported(first.stdout)
+    first_generation = int(first_exports["TR_DEPLOY_MUTEX_GENERATION"])
+    expired = mutex.record()
+    expired["expires_at"] = "2000-01-01T00:00:00Z"
+    (mutex.state_dir / "object.json").write_text(
+        json.dumps(expired), encoding="utf-8"
+    )
+
+    replacement = mutex.run("acquire", "manual:replacement@test")
+    assert replacement.returncode == 0, replacement.stderr
+    replacement_exports = _exported(replacement.stdout)
+    replacement_generation = int(
+        replacement_exports["TR_DEPLOY_MUTEX_GENERATION"]
+    )
+    assert replacement_generation > first_generation
+    assert "deploy_mutex.expired_takeover" in replacement.stderr
+    assert "previous_owner=manual:crashed@test" in replacement.stderr
+
+    stale_release = mutex.run(
+        "release",
+        "manual:crashed@test",
+        TR_DEPLOY_MUTEX_OPERATION=first_exports["TR_DEPLOY_MUTEX_OPERATION"],
+        TR_DEPLOY_MUTEX_GENERATION=str(first_generation),
+    )
+    assert stale_release.returncode == 0
+    assert "deploy_mutex.release_failed" in stale_release.stderr
+    assert mutex.generation() == replacement_generation
+    assert mutex.record()["operation_id"] == replacement_exports[
+        "TR_DEPLOY_MUTEX_OPERATION"
+    ]
+
+
+def test_stale_generation_cannot_release_current_owner(mutex: MutexHarness) -> None:
+    acquired = mutex.run("acquire", "manual:owner@test")
+    assert acquired.returncode == 0, acquired.stderr
+    exported = _exported(acquired.stdout)
+    generation = int(exported["TR_DEPLOY_MUTEX_GENERATION"])
+
+    released = mutex.run(
+        "release",
+        "manual:owner@test",
+        TR_DEPLOY_MUTEX_OPERATION=exported["TR_DEPLOY_MUTEX_OPERATION"],
+        TR_DEPLOY_MUTEX_GENERATION=str(generation + 1),
+    )
+
+    assert released.returncode == 0
+    assert "deploy_mutex.release_failed" in released.stderr
+    assert mutex.generation() == generation
+
+
+def test_reentrant_acquire_never_touches_storage(mutex: MutexHarness) -> None:
+    env = mutex.env(
+        "manual:nested@test",
+        TR_DEPLOY_MUTEX_OPERATION="existing-operation",
+        TR_DEPLOY_MUTEX_GENERATION="77",
+    )
+    result = subprocess.run(  # noqa: S603 - fixed shell and repo script.
+        [
+            "/bin/bash",
+            "-c",
+            'source "$1"; deploy_mutex_acquire >/dev/null; deploy_mutex_release',
+            "mutex-reentrant-test",
+            str(MUTEX_SCRIPT),
+        ],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=20,
+    )
+
+    assert result.returncode == 0
+    assert "deploy_mutex.reentrant" in result.stderr
+    assert "reason=scope_did_not_acquire" in result.stderr
+    assert mutex.calls() == []
+    assert mutex.mutations() == []
+
+
+def test_release_failure_is_logged_but_does_not_change_exit_status(
+    mutex: MutexHarness,
+) -> None:
+    acquired = mutex.run("acquire", "manual:owner@test")
+    assert acquired.returncode == 0, acquired.stderr
+    exported = _exported(acquired.stdout)
+    mutex.clear_calls()
+
+    released = mutex.run(
+        "release",
+        "manual:owner@test",
+        TR_DEPLOY_MUTEX_OPERATION=exported["TR_DEPLOY_MUTEX_OPERATION"],
+        TR_DEPLOY_MUTEX_GENERATION=exported["TR_DEPLOY_MUTEX_GENERATION"],
+        MUTEX_STUB_RM_FAIL="1",
+    )
+
+    assert released.returncode == 0
+    assert "deploy_mutex.release_failed" in released.stderr
+    assert mutex.record()["operation_id"] == exported["TR_DEPLOY_MUTEX_OPERATION"]
+
+
+def test_status_prints_generation_and_reports_unlocked(mutex: MutexHarness) -> None:
+    acquired = mutex.run("acquire", "manual:owner@test")
+    assert acquired.returncode == 0, acquired.stderr
+    exported = _exported(acquired.stdout)
+
+    status = mutex.run("status", "manual:inspector@test")
+    assert status.returncode == 0, status.stderr
+    assert json.loads(status.stdout)["generation"] == int(
+        exported["TR_DEPLOY_MUTEX_GENERATION"]
+    )
+
+    released = mutex.run(
+        "release",
+        "manual:owner@test",
+        TR_DEPLOY_MUTEX_OPERATION=exported["TR_DEPLOY_MUTEX_OPERATION"],
+        TR_DEPLOY_MUTEX_GENERATION=exported["TR_DEPLOY_MUTEX_GENERATION"],
+    )
+    assert released.returncode == 0
+    status = mutex.run("status", "manual:inspector@test")
+    assert status.returncode == 0
+    assert status.stdout == "unlocked\n"
+
+
+def test_workflow_and_manual_scripts_share_the_mutex_scope() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "deploy.yml").read_text(
+        encoding="utf-8"
+    )
+    acquire = workflow.index("- name: Acquire production deployment mutex")
+    rollout = workflow.index("- name: Deploy us-central1 (no-traffic)")
+    release = workflow.index("- name: Release production deployment mutex")
+
+    assert acquire < rollout < release
+    assert 'deploy_mutex.sh acquire >> "$GITHUB_ENV"' in workflow[acquire:rollout]
+    assert "${{ github.server_url }}/${{ github.repository }}/actions/runs/" in workflow[
+        acquire:rollout
+    ]
+    assert "if: always()" in workflow[release : release + 180]
+    assert "deploy_mutex.sh release" in workflow[release : release + 180]
+
+    # These large scripts need unrelated Cloud Run/watchdog fixtures to finish;
+    # the generation-aware behavioral tests above execute their shared helper,
+    # while this assertion binds both manual entry points to its fail-closed guard.
+    for relative in ("scripts/deploy/rollout.sh", "scripts/deploy/staged_traffic.sh"):
+        script = (ROOT / relative).read_text(encoding="utf-8")
+        assert 'source "${SCRIPT_DIR}/deploy_mutex.sh"' in script
+        assert 'if [ -z "${TR_DEPLOY_MUTEX_OPERATION:-}" ]; then' in script
+        assert "deploy_mutex_acquire" in script
+        assert "deploy_mutex_release" in script
+
+
+def test_infra_provisions_a_private_short_lived_mutex_bucket() -> None:
+    infra = (ROOT / "scripts" / "deploy" / "infra.sh").read_text(encoding="utf-8")
+
+    assert "tr-deploy-mutex-quill-cloud-proxy" in infra
+    assert "--uniform-bucket-level-access" in infra
+    assert "--public-access-prevention" in infra
+    assert '{"rule":[{"action":{"type":"Delete"},"condition":{"age":1}}]}' in infra
+    assert '--member="serviceAccount:${DEPLOY_SERVICE_ACCOUNT}"' in infra
+    assert '--role="roles/storage.objectAdmin"' in infra
+
+
+def test_unreadable_fence_leaves_the_lock_in_place(mutex: MutexHarness) -> None:
+    """Never delete on ambiguity — review finding M2.
+
+    A transient failure reading our own fence back must NOT remove the
+    object: in the break-glass window the current object can belong to a
+    different acquirer, and deleting it would let two deploys mutate
+    production concurrently. The cost of leaving it is a TTL-bounded
+    freeze, which is the safe side.
+    """
+    acquire = mutex.run("acquire", "owner-a", MUTEX_STUB_DOWNLOAD_FAIL="1")
+    assert acquire.returncode == 1
+    assert "reason=fence_unreadable" in acquire.stderr
+    assert "cleanup=none" in acquire.stderr
+    # The object survives, and no delete of any kind was attempted.
+    assert (mutex.state_dir / "object.json").exists()
+    assert all(m["action"] != "delete" for m in mutex.mutations())
+    assert not any(c[:2] == ["storage", "rm"] for c in mutex.calls())
+
+
+def test_replaced_lock_is_not_deleted_by_the_loser(mutex: MutexHarness) -> None:
+    """Break-glass rm + immediate re-acquire between our create and verify.
+
+    The verification must recognise the current object as someone else's and
+    walk away. Deleting it — fenced or not — would kill the new holder's
+    live lock.
+    """
+    (mutex.state_dir / "replace-on-describe").touch()
+    acquire = mutex.run("acquire", "owner-a")
+    assert acquire.returncode == 1
+    assert "reason=lock_replaced" in acquire.stderr
+    assert "holder_operation_id=someone-elses-operation" in acquire.stderr
+    record = mutex.record()
+    assert record["operation_id"] == "someone-elses-operation"
+    assert all(m["action"] != "delete" for m in mutex.mutations())
+
+
+def test_release_unsets_the_fence_so_reacquire_is_real(mutex: MutexHarness) -> None:
+    """Review finding M1: stale exported fences must not survive release.
+
+    acquire -> release -> acquire in ONE shell must perform a second real
+    GCS acquisition, not a reentrant no-op against a lock that no longer
+    exists.
+    """
+    script = f"""
+set -euo pipefail
+source {json.dumps(str(MUTEX_SCRIPT))}
+deploy_mutex_acquire >/dev/null
+deploy_mutex_release
+if [ -n "${{TR_DEPLOY_MUTEX_OPERATION:-}}" ]; then
+  echo "FENCE SURVIVED RELEASE" >&2
+  exit 90
+fi
+deploy_mutex_acquire >/dev/null
+"""
+    result = subprocess.run(  # noqa: S603 - repo script and isolated stub PATH.
+        ["bash", "-c", script],  # noqa: S607
+        cwd=ROOT,
+        env=mutex.env("owner-a"),
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=20,
+    )
+    assert result.returncode == 0, result.stderr
+    creates = [m for m in mutex.mutations() if m["action"] == "create"]
+    deletes = [m for m in mutex.mutations() if m["action"] == "delete"]
+    assert len(creates) == 2, "second acquire must be a real acquisition"
+    assert len(deletes) == 1
+    assert "deploy_mutex.reentrant" not in result.stderr
+
+
+def test_deploy_job_timeout_stays_under_the_mutex_ttl() -> None:
+    """Review finding M3: a deploy job outliving the lease invites a legal
+    expired-lock takeover while the run is still shifting traffic."""
+    import re
+
+    workflow = (ROOT / ".github" / "workflows" / "deploy.yml").read_text(
+        encoding="utf-8"
+    )
+    deploy_job = workflow.split("\n  deploy:\n", 1)[1].split("\n  public-surface", 1)[0]
+    match = re.search(r"timeout-minutes:\s*(\d+)", deploy_job)
+    assert match is not None, "deploy job must bound its runtime"
+    ttl_match = re.search(
+        r"TR_DEPLOY_MUTEX_TTL_SECONDS:-(\d+)",
+        (ROOT / "scripts" / "deploy" / "deploy_mutex.sh").read_text(encoding="utf-8"),
+    )
+    assert ttl_match is not None
+    assert int(match.group(1)) * 60 < int(ttl_match.group(1))

--- a/tests/test_deploy_watchdog.py
+++ b/tests/test_deploy_watchdog.py
@@ -215,6 +215,11 @@ printf '%s' "$code"
         "STAGED_REMOVE_ALWAYS_FAILS": "1" if remove_always_fails else "0",
         "TR_LEGACY_PROBE_RETRY_SECONDS": "0",
         "TR_PROBE_TAG_REMOVE_RETRY_SECONDS": "0",
+        # This helper exercises a traffic ramp nested inside the workflow's
+        # already-acquired deployment-mutex scope. Dedicated mutex tests cover
+        # direct/manual acquisition against a generation-aware storage stub.
+        "TR_DEPLOY_MUTEX_OPERATION": "watchdog-test-operation",
+        "TR_DEPLOY_MUTEX_GENERATION": "1",
     }
     run = subprocess.run(  # noqa: S603 - fixed local script and stubbed PATH
         ["/bin/bash", str(script), "us-central1", "new-rev", "old-rev"],

--- a/tests/test_regional_quota_reconcile_cli.py
+++ b/tests/test_regional_quota_reconcile_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 from types import SimpleNamespace
@@ -12,20 +13,41 @@ from trusted_router import regional_quota_reconcile_cli as worker
 
 
 @pytest.fixture(autouse=True)
-def _isolate_observability(monkeypatch: pytest.MonkeyPatch) -> None:
+def _isolate_observability(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     monkeypatch.setattr(worker, "init_sentry", lambda _settings: None)
     monkeypatch.setattr(worker, "record_heartbeat", lambda *_args, **_kwargs: None)
+    caplog.set_level(logging.INFO, logger=worker.__name__)
 
 
 class _Store:
-    def __init__(self, result: dict[str, int], *, lock_available: bool = True) -> None:
+    def __init__(
+        self,
+        result: dict[str, int],
+        *,
+        lock_available: bool = True,
+        release_result: bool = True,
+        reconcile_error: Exception | None = None,
+        release_error: Exception | None = None,
+        previous_owner: str | None = None,
+        previous_fencing_token: int | None = None,
+    ) -> None:
         self.result = result
         self.limits: list[int] = []
         self.lock_available = lock_available
+        self.release_result = release_result
+        self.reconcile_error = reconcile_error
+        self.release_error = release_error
+        self.previous_owner = previous_owner
+        self.previous_fencing_token = previous_fencing_token
         self.released: list[tuple[str, int]] = []
 
     def reconcile_regional_quota_leases(self, *, limit: int) -> dict[str, int]:
         self.limits.append(limit)
+        if self.reconcile_error is not None:
+            raise self.reconcile_error
         return self.result
 
     def verify_regional_quota_ledger(self) -> tuple[str, ...]:
@@ -41,7 +63,11 @@ class _Store:
         assert ttl_seconds == 90
         if not self.lock_available:
             return None
-        return SimpleNamespace(fencing_token=7)
+        return SimpleNamespace(
+            fencing_token=7,
+            previous_owner=self.previous_owner,
+            previous_fencing_token=self.previous_fencing_token,
+        )
 
     def release_regional_quota_reconciler_lock(
         self,
@@ -50,7 +76,9 @@ class _Store:
         fencing_token: int,
     ) -> bool:
         self.released.append((owner, fencing_token))
-        return True
+        if self.release_error is not None:
+            raise self.release_error
+        return self.release_result
 
 
 def test_disabled_worker_does_not_open_storage(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -68,7 +96,10 @@ def test_disabled_worker_does_not_open_storage(monkeypatch: pytest.MonkeyPatch) 
     assert worker.main() == 0
 
 
-def test_worker_reconciles_with_bounded_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_worker_reconciles_with_bounded_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     store = _Store({"inspected": 2, "reconciled": 2, "closed": 1, "errors": 0})
     monkeypatch.setattr(
         worker,
@@ -91,6 +122,107 @@ def test_worker_reconciles_with_bounded_limit(monkeypatch: pytest.MonkeyPatch) -
     assert len(store.released) == 1
     assert store.released[0][1] == 7
     assert heartbeats == ["job:regional-quota-reconcile"]
+    assert "regional_quota.reconciler_lock_acquired" in caplog.text
+    assert "regional_quota.reconciler_lock_released" in caplog.text
+
+
+def test_worker_logs_expired_lock_takeover(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = _Store(
+        {"inspected": 1, "reconciled": 1, "closed": 1, "errors": 0},
+        previous_owner="rqrec-expired-owner",
+        previous_fencing_token=6,
+    )
+    monkeypatch.setattr(
+        worker,
+        "get_settings",
+        lambda: SimpleNamespace(
+            regional_quota_reconciler_worker=True,
+            regional_quota_leases_enabled=True,
+            regional_quota_reconcile_limit=25,
+        ),
+    )
+    monkeypatch.setattr(worker, "create_store", lambda _settings: store)
+
+    assert worker.main() == 0
+    assert "regional_quota.reconciler_lock_takeover" in caplog.text
+    assert "previous_owner=rqrec-expired-owner" in caplog.text
+    assert "previous_fencing_token=6" in caplog.text
+
+
+def test_reconcile_exception_still_releases_lock_and_exits_one(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = _Store(
+        {"inspected": 0, "reconciled": 0, "closed": 0, "errors": 0},
+        reconcile_error=RuntimeError("reconcile exploded"),
+    )
+    monkeypatch.setattr(
+        worker,
+        "get_settings",
+        lambda: SimpleNamespace(
+            regional_quota_reconciler_worker=True,
+            regional_quota_leases_enabled=True,
+            regional_quota_reconcile_limit=25,
+        ),
+    )
+    monkeypatch.setattr(worker, "create_store", lambda _settings: store)
+
+    assert worker.main() == 1
+    assert len(store.released) == 1
+    assert "regional_quota.reconciler_failed" in caplog.text
+    assert "regional_quota.reconciler_lock_released" in caplog.text
+
+
+def test_release_lost_exits_one_and_logs(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = _Store(
+        {"inspected": 1, "reconciled": 1, "closed": 1, "errors": 0},
+        release_result=False,
+    )
+    monkeypatch.setattr(
+        worker,
+        "get_settings",
+        lambda: SimpleNamespace(
+            regional_quota_reconciler_worker=True,
+            regional_quota_leases_enabled=True,
+            regional_quota_reconcile_limit=25,
+        ),
+    )
+    monkeypatch.setattr(worker, "create_store", lambda _settings: store)
+
+    assert worker.main() == 1
+    assert "regional_quota.reconciler_lock_release_lost" in caplog.text
+    assert "regional_quota.reconciler_lock_released" not in caplog.text
+
+
+def test_release_exception_is_caught_and_exits_one(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = _Store(
+        {"inspected": 1, "reconciled": 1, "closed": 1, "errors": 0},
+        release_error=RuntimeError("release exploded"),
+    )
+    monkeypatch.setattr(
+        worker,
+        "get_settings",
+        lambda: SimpleNamespace(
+            regional_quota_reconciler_worker=True,
+            regional_quota_leases_enabled=True,
+            regional_quota_reconcile_limit=25,
+        ),
+    )
+    monkeypatch.setattr(worker, "create_store", lambda _settings: store)
+
+    assert worker.main() == 1
+    assert "regional_quota.reconciler_lock_release_failed" in caplog.text
+    assert "regional_quota.reconciler_lock_release_lost" not in caplog.text
 
 
 def test_worker_fails_execution_when_any_lease_fails(
@@ -169,6 +301,7 @@ def test_worker_fails_closed_when_no_ledger_region_is_verified(
 
 def test_worker_skips_when_another_reconciler_owns_the_lock(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     store = _Store(
         {"inspected": 1, "reconciled": 1, "closed": 1, "errors": 0},
@@ -188,6 +321,7 @@ def test_worker_skips_when_another_reconciler_owns_the_lock(
     assert worker.main() == 0
     assert store.limits == []
     assert store.released == []
+    assert "regional_quota.reconciler_lock_busy" in caplog.text
 
 
 def test_worker_environment_does_not_require_serving_pilot_allowlist() -> None:

--- a/tests/test_regional_quota_spanner.py
+++ b/tests/test_regional_quota_spanner.py
@@ -775,6 +775,8 @@ def test_reconciler_lock_is_single_owner_and_fenced_after_expiry() -> None:
     )
     assert replacement is not None
     assert replacement.fencing_token == first.fencing_token + 1
+    assert replacement.previous_owner == "worker-a"
+    assert replacement.previous_fencing_token == first.fencing_token
     assert (
         store.release_regional_quota_reconciler_lock(
             owner="worker-a",


### PR DESCRIPTION
A manual staged rollout overlapped an hourly catalog deployment.
Serving stayed healthy, but the deploy's convergence smoke failed
because two revisions were intentionally receiving traffic — the GHA
`concurrency` group serializes workflow runs and nothing else. This PR
makes that overlap impossible, and finishes the reconciler-singleton
observability.

## The mutex

One generation-fenced lock object in GCS
(`gs://tr-deploy-mutex-quill-cloud-proxy/locks/trusted-router-production.json`),
held before any mutation of Cloud Run revisions or traffic:

| Property | Mechanism |
|---|---|
| Atomic acquire | `cp --if-generation-match=0` |
| Owner identity, operation id, creation, expiry | metadata-only JSON body (90-min TTL default, bounded 1–240 min) |
| Fail closed | live holder → print owner/operation/created/expires, exit non-zero |
| Crash recovery | expired lock → delete fenced on the observed generation, then fresh create — exactly one contender wins |
| Owner fencing on release | delete fenced on the generation recorded at acquire; stale owners cannot release newer locks |
| No deadlock | reentrancy by env fence: helpers invoked by the workflow see `TR_DEPLOY_MUTEX_OPERATION` and skip |
| Always-release | `if: always()` step in the workflow; EXIT traps installed *before* acquire in `rollout.sh` / `staged_traffic.sh`, INT/TERM ignored during cleanup |
| Coverage | push deploys (incl. hourly catalog), workflow dispatches, and manual script runs all pass through the same acquire |

## Adversarial review round (independent pass over the diff)

Three majors, all fixed with regression tests:

1. **Never delete on ambiguity.** The first draft could delete a
   *different* holder's live lock when its own fence read-back failed
   (and had an unfenced `rm`). Now every ambiguous failure leaves the
   object — a TTL-bounded freeze is the safe side. Tests prove the
   object survives and zero `rm` calls occur; the gcloud stub models
   unfenced deletes faithfully so that bug class can't pass its own test.
2. **Release spends the fence.** `TR_DEPLOY_MUTEX_*` are unset on every
   real release, so acquire→release→acquire in one shell re-acquires
   for real instead of reentrantly "holding" nothing.
3. **Deploy job bounded under the lease.** `timeout-minutes: 85` vs the
   5400s TTL, with a test pinning job-timeout < TTL. GitHub's 360-min
   default would have let a slow deploy legally coexist with a takeover.

Minor findings also addressed: signal-window leak in cleanup, and the
companion job's comment falsely claiming it holds the lock.

## Reconciler singleton (already on main via #706/#707)

Gap-closure only: `acquired` / `released` / `expired takeover` events
with owner + fencing token (takeover metadata is acquisition-only —
persisted rows unchanged), and CLI tests for reconcile-raises,
release-lost, and release-raises. Exit codes stay honest; heartbeat
suppressed on any failure.

## Verification

- `ruff check`, `mypy`: clean
- Full suite: **6174 passed, 307 skipped, 10 xfailed** (one hypothesis
  deadline flake occurred only while two suites ran concurrently;
  passes in isolation and is untouched by this diff)
- `bash -n` + ShellCheck on all four changed scripts: clean
- Live GCS semantics exercised with the real `tr-deploy` identity
  against the production bucket: create-if-0 wins once, second create
  and wrong-generation delete both refused, fenced delete succeeds
- Bucket provisioned (uniform access, PAP, 1-day lifecycle sweep,
  `tr-deploy` objectAdmin); `infra.sh` re-asserts it idempotently
- No test reaches Sentry (init monkeypatched / clean env asserted)

Out of scope, unchanged: Spanner topology, lease enablement (US Central
pilot only), Bigtable profiles, tr-ops-local IAM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)