### PR TITLE
Survive GitHub: a verified repo mirror, and a way to ship without Actions

### DIFF
--- a/.github/workflows/mirror-repo.yml
+++ b/.github/workflows/mirror-repo.yml
@@ -1,0 +1,48 @@
+name: Mirror repo to GCS
+
+# The repository, as a verified git bundle in a versioned GCS bucket.
+#
+# WHAT THIS IS FOR, precisely: losing the repository — an account action, a
+# deleted org, a compromised owner. It is NOT an answer to a GitHub outage.
+# During an outage the code was never at risk; every clone is a full copy. What
+# an outage takes is the ability to ship, and this workflow cannot help with
+# that because it runs on the thing that is down. That half is
+# scripts/deploy/break_glass_deploy.sh, which runs from a laptop.
+#
+# Daily is the right cadence for the same reason the trust-drift check is
+# daily: match the interval to how fast the watched thing changes and how long
+# you can tolerate not knowing. Losing a day of commits to a catastrophic
+# account event is an acceptable worst case when every developer clone is also
+# a full copy; paying for an hourly full-history bundle upload is not.
+on:
+  schedule:
+    - cron: "41 5 * * *"
+  workflow_dispatch:
+
+permissions:
+  id-token: write # for Workload Identity Federation
+  contents: read
+
+concurrency:
+  group: mirror-repo
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    name: bundle and upload
+    runs-on: ubuntu-latest
+    steps:
+      # A shallow checkout is fine here: the script does not bundle this
+      # checkout. It mirror-clones origin itself, because a CI checkout has one
+      # local branch and `git bundle --all` over it produced a bundle that
+      # restored 3 refs out of 46 -- every object present, 42 branches
+      # unreachable by name. Only the script is needed from this checkout.
+      - uses: actions/checkout@v4
+      - name: Authenticate to GCP via WIF
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/44325983244/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com
+      - uses: google-github-actions/setup-gcloud@v2
+      - name: Mirror
+        run: scripts/deploy/mirror_repo_to_gcs.sh --apply

--- a/docs/runbook-github-outage.md
+++ b/docs/runbook-github-outage.md
@@ -1,0 +1,76 @@
+# GitHub is down, or the repository is gone
+
+Two different failures that get conflated. They need different answers, and the
+answer to one does nothing for the other.
+
+## Which one is this?
+
+| Symptom | This is | Go to |
+|---|---|---|
+| Actions failing, pushes rejected, github.com 5xx | an **outage** | [Shipping without Actions](#shipping-without-actions) |
+| Repository or org missing, access revoked | **repository loss** | [Restoring from the mirror](#restoring-from-the-mirror) |
+
+**An outage does not touch production.** Cloud Run keeps serving, the enclaves
+keep attesting, ClickHouse keeps ingesting. Nothing customer-facing degrades
+except GitHub OAuth sign-in, which is accepted: users who chose GitHub login
+are already exposed to GitHub being down, and Google login is unaffected.
+
+What an outage takes away is the ability to **ship**. The mirror does not help
+with that — the code was never at risk, since every clone is a full copy.
+
+## Shipping without Actions
+
+```bash
+scripts/deploy/break_glass_deploy.sh            # print the plan, change nothing
+scripts/deploy/break_glass_deploy.sh --apply
+```
+
+Builds via Cloud Build (server side, no local Docker), rolls out to every
+control-plane region using the same `rollout.sh` the workflow calls, and smoke
+checks `/v1/models`.
+
+**Before you run it, read what it skips.** The script prints this too, and the
+list is in its header: no CI gate, no schema migrations, no staged canary, no
+automatic rollback, no secret sync or Cloud Run Jobs. It prints the currently
+serving revision per region before touching anything — **write those down**,
+they are your rollback and you cannot look them up once the new revision is
+live and you are in a hurry.
+
+Use it for one thing: getting a known-good fix serving. Everything else waits.
+
+## Restoring from the mirror
+
+A verified bundle of every ref is uploaded daily to a versioned bucket by
+`.github/workflows/mirror-repo.yml`, and the same script runs from a laptop.
+
+```bash
+gcloud storage cp gs://quill-cloud-proxy-git-mirror/quill-router/latest.bundle .
+git clone latest.bundle quill-router
+```
+
+Dated bundles sit beside `latest.bundle`; versioning is on and noncurrent
+generations are kept 365 days, so a bad overwrite is recoverable.
+
+**Verified end to end on 2026-08-23**: restored from the bucket to 265
+branches at the origin tip.
+
+## Why the mirror is a bundle and not a second git host
+
+A self-hosted GitLab on GCP was considered and rejected. It is a database, a
+Redis, backups, upgrades and its own runners — a stateful system operated to
+protect against a stateless dependency, and least trustworthy exactly when
+first needed, because nothing exercises it. A bundle in GCS has no service to
+keep alive and restores with `git clone`.
+
+Cloud Source Repositories would be the obvious home and is closed to new
+customers, which is why this depends on nothing but GCS.
+
+## What the mirror check actually proves
+
+`git bundle verify` is **not** sufficient, and this was measured: on a bundle
+with seven bytes overwritten, `verify` **passed** and `git clone` **failed**.
+verify only checks that prerequisite commits are satisfiable. The script
+therefore clones every bundle into a scratch directory and compares both the
+restored HEAD and the restored branch count against the source. A bundle that
+restores the right HEAD while carrying one branch out of 265 is the failure
+that check exists to catch.

--- a/scripts/deploy/azure_control_plane.sh
+++ b/scripts/deploy/azure_control_plane.sh
@@ -199,13 +199,19 @@ preflight() {
     # run would build a second app beside the real one and report success.
     echo "container app ${APP} not found in ${RG}. Available:" >&2
     az containerapp list -g "$RG" --query "[].name" -o tsv 2>/dev/null | sed 's/^/  /' >&2
-    local serving
-    serving="$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
-      "https://${TRUSTED_DOMAIN:-azure.trustedrouter.com}/v1/health" 2>/dev/null || echo 000)"
-    if [ "$serving" = "200" ]; then
-      echo "refusing: ${TRUSTED_DOMAIN:-azure.trustedrouter.com} is already serving (200)," >&2
-      echo "so creating ${APP} would add a second app beside the live one." >&2
-      echo "Set APP= and APP_ENV= to the app that is actually serving." >&2
+    # Distinguish a genuine first run from drift WITHOUT a network call. The
+    # first version curled the public hostname, which is wrong twice over: a
+    # deploy preflight that needs the public internet fails for its own reasons
+    # offline, and it made an ordinary unit test reach production. The resource
+    # group already knows. Empty means first run and creating is correct.
+    # Non-empty means something here is already the deployment, and creating
+    # would stand up a second app beside it.
+    local existing
+    existing="$(az containerapp list -g "$RG" --query "[].name" -o tsv 2>/dev/null | tr "\n" " ")"
+    if [ -n "${existing// /}" ]; then
+      echo "refusing: ${RG} already contains container app(s): ${existing}" >&2
+      echo "Creating ${APP} would stand up a second app beside one of those." >&2
+      echo "Set APP= and APP_ENV= to the deployment that is actually serving." >&2
       problems=1
     fi
   fi

--- a/scripts/deploy/azure_control_plane.sh
+++ b/scripts/deploy/azure_control_plane.sh
@@ -47,8 +47,12 @@ set -euo pipefail
 STACK="${STACK:-tr-azure}"
 RG="${RG:-$STACK}"
 LOCATION="${LOCATION:-uaenorth}"
-APP="${APP:-$STACK}"
-APP_ENV="${APP_ENV:-$STACK-env}"
+# The live app and environment carry a -vnet suffix; the pre-vnet names have
+# not existed since the VNet migration. These defaults were still $STACK and
+# $STACK-env, which meant this script targeted a container app and a managed
+# environment that do not exist -- see the preflight below for what that cost.
+APP="${APP:-$STACK-vnet}"
+APP_ENV="${APP_ENV:-$STACK-env-vnet}"
 PG_NAME="${PG_NAME:-$STACK-pg}"
 PG_ADMIN="${PG_ADMIN:-tradmin}"
 PG_DB="${PG_DB:-trustedrouter}"
@@ -166,6 +170,49 @@ else
   PG_PASSWORD="$(cat "$PW_FILE")"
 fi
 DSN="postgresql://${PG_ADMIN}:${PG_PASSWORD}@${PG_HOST}:5432/${PG_DB}?sslmode=require"
+
+# PREFLIGHT. Runs before the ACR build because the build takes minutes and this
+# takes seconds, and the whole point is to fail while the operator still has
+# options.
+#
+# MEASURED 2026-08-23: with the pre-vnet defaults this script targeted
+# containerapp "tr-azure" in environment "tr-azure-env". Neither exists. The
+# live control plane -- the one azure.trustedrouter.com resolves to and which
+# answers 200 -- is "tr-azure-vnet" in "tr-azure-env-vnet", and that name
+# appears nowhere in this repository. So an Azure deploy failed at the
+# `containerapp create` step, AFTER the image build, having changed nothing.
+# In an emergency that is minutes spent to arrive at a confusing error.
+preflight() {
+  local problems=0
+  if ! exists az group show -n "$RG"; then
+    echo "resource group ${RG} not found" >&2
+    problems=1
+  fi
+  if ! exists az containerapp env show -g "$RG" -n "$APP_ENV"; then
+    echo "managed environment ${APP_ENV} not found in ${RG}. Available:" >&2
+    az containerapp env list -g "$RG" --query "[].name" -o tsv 2>/dev/null | sed 's/^/  /' >&2
+    problems=1
+  fi
+  if ! exists az containerapp show -g "$RG" -n "$APP"; then
+    # Not fatal on its own: first-run genuinely creates the app. It IS fatal
+    # when something is already serving the public hostname, because then this
+    # run would build a second app beside the real one and report success.
+    echo "container app ${APP} not found in ${RG}. Available:" >&2
+    az containerapp list -g "$RG" --query "[].name" -o tsv 2>/dev/null | sed 's/^/  /' >&2
+    local serving
+    serving="$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+      "https://${TRUSTED_DOMAIN:-azure.trustedrouter.com}/v1/health" 2>/dev/null || echo 000)"
+    if [ "$serving" = "200" ]; then
+      echo "refusing: ${TRUSTED_DOMAIN:-azure.trustedrouter.com} is already serving (200)," >&2
+      echo "so creating ${APP} would add a second app beside the live one." >&2
+      echo "Set APP= and APP_ENV= to the app that is actually serving." >&2
+      problems=1
+    fi
+  fi
+  [ "$problems" -eq 0 ] || die "preflight failed; nothing was built or changed"
+  log "preflight ok: ${APP} in ${APP_ENV} (${RG})"
+}
+preflight
 
 log "building linux/amd64 image in ACR ${ACR}"
 az acr build --registry "$ACR" --platform linux/amd64 \

--- a/scripts/deploy/break_glass_deploy.sh
+++ b/scripts/deploy/break_glass_deploy.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Ship the control plane from a laptop when GitHub Actions cannot.
+#
+# WHY THIS EXISTS
+#
+# A GitHub outage does not touch production: Cloud Run keeps serving, the
+# enclaves keep attesting, ClickHouse keeps ingesting. What it takes away is
+# the ability to SHIP, because CI and every deploy job run on Actions. A git
+# mirror does not help with that -- the code was never at risk -- so this is
+# the other half, and it deliberately depends on nothing but gcloud and a
+# checkout you already have.
+#
+# WHAT THIS IS NOT
+#
+# It is not the deploy workflow. deploy.yml runs about forty steps across five
+# jobs: a CI-green gate, schema migrations, secret sync, a staged rollout with
+# a three-minute canary and automatic rollback, a billing-path gate, a
+# watchdog, smoke tests and several Cloud Run Jobs. This runs the rollout and
+# the smoke check, and SKIPS the rest. Enumerated, because a break-glass path
+# whose omissions are undocumented is how an emergency turns into an outage:
+#
+#   * NO CI gate. Nothing here checks that the tree you are deploying passes
+#     tests. You are asserting that yourself.
+#   * NO schema migrations. If your change needs a column, run the relevant
+#     scripts/deploy/migrate_*.sh first, by hand, and know which one.
+#   * NO staged canary and NO automatic rollback. rollout.sh is invoked
+#     directly; if the new revision is bad, you roll back by hand with the
+#     revision this script prints before deploying. WRITE IT DOWN.
+#   * NO secret sync, ads uploader, synthetic monitor, or reconciler jobs.
+#
+# Use it for one thing: getting a known-good fix serving while Actions is
+# unavailable. Anything else should wait for the real pipeline.
+#
+# Idempotent in the sense rollout.sh is. Without --apply it prints the plan.
+#
+#   scripts/deploy/break_glass_deploy.sh                 # show the plan
+#   scripts/deploy/break_glass_deploy.sh --apply
+#
+# REQUIRES: gcloud authenticated as a principal with the deploy roles (the
+# workflow uses tr-deploy@; a human owner also works), and Docker not at all --
+# the image is built by Cloud Build, server side.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+APPLY=0
+
+if [ "${1:-}" = "--apply" ]; then
+  APPLY=1
+elif [ $# -ne 0 ]; then
+  echo "usage: $0 [--apply]" >&2
+  exit 2
+fi
+
+run() {
+  if [ "$APPLY" -eq 0 ]; then
+    printf '[plan]'
+    printf ' %q' "$@"
+    printf '\n'
+    return 0
+  fi
+  "$@"
+}
+
+COMMIT="$(git -C "$REPO_ROOT" rev-parse --short HEAD)"
+DIRTY=""
+if ! git -C "$REPO_ROOT" diff --quiet || ! git -C "$REPO_ROOT" diff --cached --quiet; then
+  DIRTY="yes"
+fi
+
+preflight() {
+  log "break-glass deploy of ${COMMIT} to ${TR_CONTROL_PLANE_REGIONS}"
+  if [ -n "$DIRTY" ]; then
+    # Not fatal: the entire point of break-glass is shipping a fix that may not
+    # have gone through a normal branch. But an unrecorded tree is a revision
+    # nobody can reconstruct later, so it is said out loud.
+    log "WARNING working tree is DIRTY; the deployed image will not match any commit"
+  fi
+  if ! gc auth list --filter=status:ACTIVE --format='value(account)' | head -1 | grep -q .; then
+    echo "no active gcloud account; run: gcloud auth login" >&2
+    exit 1
+  fi
+  log "gcloud account: $(gc auth list --filter=status:ACTIVE --format='value(account)' | head -1)"
+}
+
+record_rollback_target() {
+  # Printed BEFORE anything changes, because the rollback target is the thing
+  # you cannot look up once the new revision is serving and you are in a hurry.
+  log "current revisions, for rollback:"
+  local region
+  for region in ${TR_CONTROL_PLANE_REGIONS//,/ }; do
+    local revision
+    revision="$(gc run services describe "$SERVICE" --region="$region" \
+      --format='value(status.traffic[0].revisionName)' 2>/dev/null || echo "<unknown>")"
+    log "  ${region}: ${revision}"
+    log "    roll back with: gcloud run services update-traffic ${SERVICE} \\"
+    log "      --region=${region} --project=${PROJECT_ID} --to-revisions=${revision}=100"
+  done
+}
+
+build_image() {
+  log "building ${IMAGE} via Cloud Build (server side; no local Docker needed)"
+  run gc builds submit "$REPO_ROOT" --tag "$IMAGE"
+}
+
+roll_out() {
+  log "rolling out to every control-plane region, with traffic"
+  # rollout.sh is the same script deploy.yml calls. Reusing it rather than
+  # reimplementing `gcloud run deploy` here is deliberate: a second copy of the
+  # deploy would drift from the real one and be wrong in exactly the emergency
+  # it exists for.
+  if [ "$APPLY" -eq 0 ]; then
+    printf '[plan] TR_ALLOW_DEPLOYED_COMBINED_SURFACE=true IMAGE=%q bash %q\n' \
+      "$IMAGE" "${SCRIPT_DIR}/rollout.sh"
+    return 0
+  fi
+  TR_ALLOW_DEPLOYED_COMBINED_SURFACE=true IMAGE="$IMAGE" bash "${SCRIPT_DIR}/rollout.sh"
+}
+
+smoke() {
+  local base="https://${TRUSTED_DOMAIN:-trustedrouter.com}"
+  log "smoke checking ${base}"
+  if [ "$APPLY" -eq 0 ]; then
+    printf '[plan] curl -fsS %q/v1/models\n' "$base"
+    return 0
+  fi
+  local code
+  code="$(curl -fsS --max-time 20 -o /dev/null -w '%{http_code}' "${base}/v1/models")" || {
+    echo "SMOKE FAILED: ${base}/v1/models did not answer" >&2
+    echo "roll back using the revisions printed above" >&2
+    exit 1
+  }
+  log "smoke ok (${code})"
+}
+
+preflight
+record_rollback_target
+build_image
+roll_out
+smoke
+
+log "done. This skipped migrations, the canary and the rollback watchdog."
+log "Re-run the real pipeline when GitHub is back."

--- a/scripts/deploy/mirror_repo_to_gcs.sh
+++ b/scripts/deploy/mirror_repo_to_gcs.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# Mirror this git repository to a versioned GCS bucket as a verified bundle.
+#
+# WHAT THIS PROTECTS AGAINST, AND WHAT IT DOES NOT
+#
+# It protects against LOSING the repository: an account action, a deleted org,
+# a compromised owner. It does NOT protect against a GitHub outage, and it is
+# worth being blunt about that because the two get conflated. During an outage
+# the code was never at risk -- every clone is already a full copy, and several
+# exist on laptops and CI caches. What an outage takes away is the ability to
+# SHIP, because CI and the deploy workflow run on GitHub Actions. A mirror does
+# nothing for that; scripts/deploy/break_glass_deploy.sh is the answer to that
+# half, and it is a separate script for exactly that reason.
+#
+# WHY A BUNDLE AND NOT A MIRROR REPOSITORY
+#
+# `git bundle` produces ONE file that `git clone` accepts directly. Restoring
+# is `gcloud storage cp` then `git clone the-file`, with no service to have
+# been keeping alive, no auth to have rotated, and nothing to have silently
+# stopped replicating. Cloud Source Repositories would be the obvious home and
+# is closed to new customers, so this deliberately depends on nothing but GCS.
+#
+# WHY IT VERIFIES BEFORE IT UPLOADS
+#
+# An unverified backup is a belief, not a backup. Both checks run, and it is
+# worth knowing which one earns its place, because the obvious one does not:
+#
+#   MEASURED, on a bundle with seven bytes overwritten at offset 200 --
+#   `git bundle verify` PASSED and `git clone` FAILED.
+#
+# verify checks that the bundle's prerequisite commits are satisfiable, not
+# that every object in it is intact, so on its own it is close to a vacuous
+# guard against corruption. The clone into a scratch directory, and the
+# comparison of the restored HEAD against the source HEAD, is the check that
+# actually establishes the bundle restores. verify is kept because it fails
+# faster and with a clearer message on a truncated or wrong-history bundle,
+# but it is not the one being relied on.
+#
+# Idempotent. Without --apply it only prints what it would do.
+#
+#   scripts/deploy/mirror_repo_to_gcs.sh            # dry run
+#   scripts/deploy/mirror_repo_to_gcs.sh --apply
+#
+# Runs anywhere with gcloud auth: GitHub Actions on a schedule, or a laptop.
+# The laptop path is the one that still works when Actions does not.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+REPO_NAME="${TR_MIRROR_REPO_NAME:-$(basename "$REPO_ROOT")}"
+# Bundled from a fresh --mirror clone, never from the working checkout.
+# MEASURED, and the reason this is not simpler: bundling a normal checkout
+# captures whatever refs happen to be local. A CI checkout has one branch, so
+# `git bundle --all` there produced a bundle that restored 3 refs out of 46 --
+# every object present (27,460 in-pack) and 42 branches unreachable by name.
+# A --mirror clone holds every ref as a local ref, and its bundle restored 45
+# remote branches.
+MIRROR_SOURCE_URL="${TR_MIRROR_SOURCE_URL:-$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || echo "$REPO_ROOT")}"
+MIRROR_BUCKET="${TR_MIRROR_BUCKET:-${PROJECT_ID}-git-mirror}"
+# Keep a year of daily bundles. Versioning is belt and braces: a bundle
+# overwritten by a corrupted one is recoverable from the previous generation.
+RETENTION_DAYS="${TR_MIRROR_RETENTION_DAYS:-365}"
+APPLY=0
+
+if [ "${1:-}" = "--apply" ]; then
+  APPLY=1
+elif [ $# -ne 0 ]; then
+  echo "usage: $0 [--apply]" >&2
+  exit 2
+fi
+
+# Set before any trap fires. `local bundle` inside main() is out of scope by the
+# time an EXIT trap runs, which under `set -u` turns every clean exit into an
+# "unbound variable" error after the work already succeeded.
+BUNDLE_PATH=""
+MIRROR_WORKDIR=""
+cleanup() {
+  [ -n "$BUNDLE_PATH" ] && rm -f "$BUNDLE_PATH"
+  [ -n "$MIRROR_WORKDIR" ] && rm -rf "$MIRROR_WORKDIR"
+  return 0
+}
+trap cleanup EXIT
+
+run() {
+  if [ "$APPLY" -eq 0 ]; then
+    printf '[dry-run]'
+    printf ' %q' "$@"
+    printf '\n'
+    return 0
+  fi
+  "$@"
+}
+
+ensure_bucket() {
+  log "ensuring versioned private mirror bucket gs://${MIRROR_BUCKET}"
+  run gc services enable storage.googleapis.com
+  if ! gc storage buckets describe "gs://${MIRROR_BUCKET}" >/dev/null 2>&1; then
+    run gc storage buckets create "gs://${MIRROR_BUCKET}" \
+      --location=US \
+      --uniform-bucket-level-access \
+      --public-access-prevention
+  fi
+  # Versioning first, then lifecycle: a lifecycle rule that deletes
+  # noncurrent versions is meaningless without versioning turned on.
+  run gc storage buckets update "gs://${MIRROR_BUCKET}" --versioning
+  local lifecycle
+  lifecycle="$(mktemp)"
+  cat >"$lifecycle" <<JSON
+{
+  "rule": [
+    {
+      "action": {"type": "Delete"},
+      "condition": {"daysSinceNoncurrentTime": ${RETENTION_DAYS}}
+    }
+  ]
+}
+JSON
+  run gc storage buckets update "gs://${MIRROR_BUCKET}" --lifecycle-file="$lifecycle"
+  rm -f "$lifecycle"
+}
+
+# Build and verify. This half runs for real even in dry-run mode: it touches no
+# cloud state, and a dry run that skipped it would report success without ever
+# having established the thing the script is for.
+build_and_verify_bundle() {
+  local bundle="$1"
+  local work
+  work="$(mktemp -d)"
+  MIRROR_WORKDIR="$work"
+
+  log "mirror-cloning ${MIRROR_SOURCE_URL}"
+  git clone --quiet --mirror "$MIRROR_SOURCE_URL" "${work}/src.git"
+  local source_refs
+  source_refs="$(git -C "${work}/src.git" for-each-ref | wc -l | tr -d " ")"
+  log "source holds ${source_refs} refs"
+
+  log "bundling every ref"
+  git -C "${work}/src.git" bundle create "$bundle" --all
+
+  log "verifying prerequisites (fast check; does not prove objects are intact)"
+  git -C "${work}/src.git" bundle verify "$bundle" >/dev/null
+
+  log "cloning the bundle to prove it restores (the check that catches corruption)"
+  if ! git clone --quiet "$bundle" "${work}/restored" >"${work}/clone.log" 2>&1; then
+    echo "the bundle does not clone -- it is not a usable backup" >&2
+    sed 's/^/  /' "${work}/clone.log" >&2
+    exit 1
+  fi
+  local source_head restored_head restored_branches
+  source_head="$(git -C "${work}/src.git" rev-parse HEAD)"
+  restored_head="$(git -C "${work}/restored" rev-parse HEAD)"
+  # Exclude origin/HEAD: it is a symbolic ref, not a branch, and counting it
+  # made a first version of this guard vacuous -- a single-branch repository
+  # scored 2 and sailed past a "at least 2 branches" threshold.
+  local source_branches
+  source_branches="$(git -C "${work}/src.git" for-each-ref refs/heads --format=. | wc -l | tr -d " ")"
+  # awk, not `grep -v ... | wc -l`: _lib.sh sets pipefail, and grep exits 1
+  # when it filters everything out. On a bundle carrying no branches -- the
+  # exact case this guard exists to catch -- that killed the script before it
+  # could print why, so the operator saw a bare exit 1.
+  restored_branches="$(git -C "${work}/restored" for-each-ref refs/remotes/origin \
+    --format='%(refname)' | awk '!/\/HEAD$/ {n++} END {print n+0}')"
+
+  if [ "$source_head" != "$restored_head" ]; then
+    echo "restored HEAD ${restored_head} != source HEAD ${source_head}" >&2
+    exit 1
+  fi
+  # The guard that catches the real failure: a bundle can restore the correct
+  # HEAD while carrying one branch out of forty-six, with every object present
+  # and nothing reachable by name. Comparing HEAD alone called that a success.
+  # Comparing against the SOURCE count rather than a threshold means it holds
+  # for a one-branch repository and a thousand-branch one alike.
+  if [ "$restored_branches" -ne "$source_branches" ]; then
+    echo "restored ${restored_branches} branches, source has ${source_branches}" >&2
+    echo "the bundle is not a faithful mirror" >&2
+    exit 1
+  fi
+  log "restore check passed: ${source_head}, ${restored_branches}/${source_branches} branches"
+
+  rm -rf "$work"
+  MIRROR_WORKDIR=""
+}
+
+main() {
+  ensure_bucket
+
+  local stamp bundle
+  # Bundle name carries the date so the object list reads as a history, and
+  # the object is also written to latest.bundle so a restore never has to
+  # guess which date is newest.
+  stamp="$(date -u +%Y-%m-%d)"
+  bundle="$(mktemp -t "${REPO_NAME}.XXXXXX")"
+  BUNDLE_PATH="$bundle"
+
+  build_and_verify_bundle "$bundle"
+
+  local size
+  size="$(wc -c <"$bundle" | tr -d ' ')"
+  log "uploading ${size} bytes"
+  run gc storage cp "$bundle" "gs://${MIRROR_BUCKET}/${REPO_NAME}/${stamp}.bundle"
+  run gc storage cp "$bundle" "gs://${MIRROR_BUCKET}/${REPO_NAME}/latest.bundle"
+
+  log "mirror complete"
+  log "restore with:"
+  log "  gcloud storage cp gs://${MIRROR_BUCKET}/${REPO_NAME}/latest.bundle ."
+  log "  git clone latest.bundle ${REPO_NAME}"
+}
+
+main "$@"

--- a/tests/test_deploy_script_execution.py
+++ b/tests/test_deploy_script_execution.py
@@ -80,10 +80,7 @@ def _settings_from_containerapp_mutation(call: list[str]) -> Settings:
         for argument in call[start:end]
         if argument.startswith("TR_") and "=" in argument
     }
-    kwargs = {
-        env_name.removeprefix("TR_").lower(): value
-        for env_name, value in raw_env.items()
-    }
+    kwargs = {env_name.removeprefix("TR_").lower(): value for env_name, value in raw_env.items()}
     # Container Apps resolves these references before starting the process.
     kwargs["attribution_cookie_secret"] = "a" * 64
     kwargs["postgres_dsn"] = "postgresql://canary.invalid/trustedrouter"
@@ -105,9 +102,7 @@ def _settings_kwargs_from_cloud_run_job(call: list[str]) -> dict[str, object]:
         for name, value in _cloud_run_job_env(call).items()
         if name.startswith("TR_")
     }
-    secret_flag = next(
-        flag for flag in ("--update-secrets", "--set-secrets") if flag in call
-    )
+    secret_flag = next(flag for flag in ("--update-secrets", "--set-secrets") if flag in call)
     for binding in call[call.index(secret_flag) + 1].split(","):
         name, separator, reference = binding.partition("=")
         if not separator or not name.startswith("TR_"):
@@ -211,9 +206,7 @@ def test_regional_quota_reconciler_creates_only_when_scheduler_is_not_found(
         tmp_path,
         monkeypatch,
         describe_rc=1,
-        describe_stderr=(
-            "ERROR: (gcloud.scheduler.jobs.describe) NOT_FOUND: Job not found.\n"
-        ),
+        describe_stderr=("ERROR: (gcloud.scheduler.jobs.describe) NOT_FOUND: Job not found.\n"),
     )
 
     assert run.returncode == 0, summarise(run)
@@ -306,9 +299,7 @@ def test_aws_observer_executes_bounded_capacity_tcp_health_and_waf_before_schedu
     ]
     assert len(postcondition_queries) == 2
     service_updates = [
-        call
-        for call in run.calls
-        if call[:3] == ["aws", "apprunner", "update-service"]
+        call for call in run.calls if call[:3] == ["aws", "apprunner", "update-service"]
     ]
     assert len(service_updates) == 1
     service_config = service_updates[0][service_updates[0].index("--source-configuration") + 1]
@@ -346,14 +337,8 @@ def test_aws_observer_executes_bounded_capacity_tcp_health_and_waf_before_schedu
     ]
     assert len(scheduler_rules) == 1
     scheduler_index, scheduler_rule = scheduler_rules[0]
-    assert scheduler_rule[scheduler_rule.index("--schedule-expression") + 1] == (
-        "rate(2 minutes)"
-    )
-    scheduler_targets = [
-        call
-        for call in run.calls
-        if call[:3] == ["aws", "events", "put-targets"]
-    ]
+    assert scheduler_rule[scheduler_rule.index("--schedule-expression") + 1] == ("rate(2 minutes)")
+    scheduler_targets = [call for call in run.calls if call[:3] == ["aws", "events", "put-targets"]]
     assert len(scheduler_targets) == 1
     targets = json.loads(scheduler_targets[0][scheduler_targets[0].index("--targets") + 1])
     assert len(targets) == 1
@@ -373,10 +358,7 @@ def test_aws_observer_initial_create_reaches_running_postconditions_waf_and_sche
 ) -> None:
     script = "scripts/deploy/aws_eu_control_plane.sh"
     fixture = SCRIPT_FIXTURES[script]
-    service_arn = (
-        "arn:aws:apprunner:eu-west-3:330422590279:"
-        "service/tr-eu/harness-service-id"
-    )
+    service_arn = "arn:aws:apprunner:eu-west-3:330422590279:service/tr-eu/harness-service-id"
     responses = (
         (r"apprunner list-services", ""),
         (r"apprunner create-service", service_arn),
@@ -404,16 +386,11 @@ def test_aws_observer_initial_create_reaches_running_postconditions_waf_and_sche
     ]
     assert len(creates) == 1
     create_index, create = creates[0]
-    assert not any(
-        call[:3] == ["aws", "apprunner", "update-service"] for call in run.calls
-    )
+    assert not any(call[:3] == ["aws", "apprunner", "update-service"] for call in run.calls)
     assert create[create.index("--auto-scaling-configuration-arn") + 1].startswith(
-        "arn:aws:apprunner:eu-west-3:330422590279:"
-        "autoscalingconfiguration/tr-eu-observer-bounded/"
+        "arn:aws:apprunner:eu-west-3:330422590279:autoscalingconfiguration/tr-eu-observer-bounded/"
     )
-    assert create[create.index("--health-check-configuration") + 1].startswith(
-        "Protocol=TCP"
-    )
+    assert create[create.index("--health-check-configuration") + 1].startswith("Protocol=TCP")
 
     running_index = next(
         index
@@ -439,9 +416,7 @@ def test_aws_observer_initial_create_reaches_running_postconditions_waf_and_sche
         if call[:3] == ["aws", "wafv2", "associate-web-acl"]
     )
     schedule_index = next(
-        index
-        for index, call in enumerate(run.calls)
-        if call[:3] == ["aws", "events", "put-rule"]
+        index for index, call in enumerate(run.calls) if call[:3] == ["aws", "events", "put-rule"]
     )
     assert create_index < running_index < scaling_index < health_index < waf_index
     assert waf_index < schedule_index
@@ -465,11 +440,7 @@ def test_aws_observer_never_secures_or_schedules_a_non_running_service(
     fixture = SCRIPT_FIXTURES[script]
     responses = (
         (r"apprunner describe-service.*Service\.Status", reported_status),
-        *(
-            response
-            for response in fixture.responses
-            if "Service\\.Status" not in response[0]
-        ),
+        *(response for response in fixture.responses if "Service\\.Status" not in response[0]),
     )
     monkeypatch.setitem(
         SCRIPT_FIXTURES,
@@ -555,8 +526,7 @@ def test_aws_observer_fails_closed_when_legacy_credential_cannot_be_inspected(
     [
         (
             r"apprunner describe-service.*AutoScalingConfigurationSummary",
-            "arn:aws:apprunner:eu-west-3:330422590279:"
-            "autoscalingconfiguration/unbounded/1/drift",
+            "arn:aws:apprunner:eu-west-3:330422590279:autoscalingconfiguration/unbounded/1/drift",
             "AutoScalingConfigurationSummary",
         ),
         (
@@ -577,11 +547,7 @@ def test_aws_observer_stops_before_waf_and_schedule_on_each_live_postcondition_d
     fixture = SCRIPT_FIXTURES[script]
     responses = (
         (fixture_pattern, drift_value),
-        *(
-            response
-            for response in fixture.responses
-            if query_fragment not in response[0]
-        ),
+        *(response for response in fixture.responses if query_fragment not in response[0]),
     )
     monkeypatch.setitem(
         SCRIPT_FIXTURES,
@@ -594,9 +560,7 @@ def test_aws_observer_stops_before_waf_and_schedule_on_each_live_postcondition_d
 
     assert run.returncode != 0
     assert "expected" in run.stderr
-    assert not any(
-        call[:3] == ["aws", "wafv2", "associate-web-acl"] for call in run.calls
-    )
+    assert not any(call[:3] == ["aws", "wafv2", "associate-web-acl"] for call in run.calls)
     assert not any(call[:3] == ["aws", "events", "put-rule"] for call in run.calls)
     assert not run.verifier_calls
 
@@ -621,7 +585,8 @@ def test_azure_observer_executes_single_revision_bounded_http_scaling(
     mutations = [
         (index, call)
         for index, call in enumerate(run.calls)
-        if call[:3] in (
+        if call[:3]
+        in (
             ["az", "containerapp", "update"],
             ["az", "containerapp", "create"],
         )
@@ -634,10 +599,7 @@ def test_azure_observer_executes_single_revision_bounded_http_scaling(
     mutation_text = " ".join(mutation)
     if script.endswith("azure_canary_app.sh"):
         assert "TR_SERVICE_SURFACE=public" in mutation_text
-        assert (
-            "TR_ATTRIBUTION_COOKIE_SECRET=secretref:attribution-cookie-secret"
-            in mutation_text
-        )
+        assert "TR_ATTRIBUTION_COOKIE_SECRET=secretref:attribution-cookie-secret" in mutation_text
         assert "TR_INTERNAL_GATEWAY_TOKEN" not in mutation_text
         assert "TR_SYNTHETIC_MONITOR_API_KEY" not in mutation_text
         assert "TR_FEDERATION_" not in mutation_text
@@ -704,16 +666,25 @@ def test_azure_observer_executes_single_revision_bounded_http_scaling(
 
 
 @pytest.mark.parametrize(
-    ("script", "app_name", "password_file", "expected_max"),
+    ("script", "rg_name", "app_name", "password_file", "expected_max"),
     [
         (
             "scripts/deploy/azure_control_plane.sh",
+            # Resource group and app name are no longer the same string. The
+            # container app is tr-azure-vnet inside resource group tr-azure;
+            # the pre-vnet name has not existed since the VNet migration, and
+            # this fixture asserting `-g tr-azure -n tr-azure` is why the
+            # script could target a nonexistent app with every deploy test
+            # still green -- the harness faked the name the script asked for
+            # rather than the one Azure has.
             "tr-azure",
+            "tr-azure-vnet",
             ".config/tr-azure/pgpw",
             "1",
         ),
         (
             "scripts/deploy/azure_canary_app.sh",
+            "tr-canary",
             "tr-canary",
             ".config/tr-canary/pgpw",
             "2",
@@ -724,6 +695,7 @@ def test_azure_observer_initial_create_is_bounded_too(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     script: str,
+    rg_name: str,
     app_name: str,
     password_file: str,
     expected_max: str,
@@ -736,9 +708,16 @@ def test_azure_observer_initial_create_is_bounded_too(
         replace(
             fixture,
             home_files=home_files,
-            failures=(
-                rf"^az containerapp show -g {app_name} -n {app_name}$",
+            responses=(
+                # A genuine first run: the resource group is empty. The
+                # preflight distinguishes "nothing deployed yet, create it"
+                # from "something else is already the deployment here" by
+                # listing the group, and the harness answers unknown commands
+                # with "stub-output", which would read as a phantom app.
+                (r"^az containerapp list -g \S+ --query", ""),
+                *fixture.responses,
             ),
+            failures=(rf"^az containerapp show -g {rg_name} -n {app_name}$",),
         ),
     )
     isolated = DeployScriptHarness(tmp_path / f"azure-create-{expected_max}")
@@ -746,15 +725,9 @@ def test_azure_observer_initial_create_is_bounded_too(
     run = isolated.run(script, verifier_rc=0)
 
     assert run.returncode == 0, summarise(run)
-    creates = [
-        call
-        for call in run.calls
-        if call[:3] == ["az", "containerapp", "create"]
-    ]
+    creates = [call for call in run.calls if call[:3] == ["az", "containerapp", "create"]]
     assert len(creates) == 1
-    assert not any(
-        call[:3] == ["az", "containerapp", "update"] for call in run.calls
-    )
+    assert not any(call[:3] == ["az", "containerapp", "update"] for call in run.calls)
     create = creates[0]
     create_index = run.calls.index(create)
     assert create[create.index("--min-replicas") + 1] == "1"
@@ -763,14 +736,9 @@ def test_azure_observer_initial_create_is_bounded_too(
     if script.endswith("azure_canary_app.sh"):
         create_text = " ".join(create)
         assert "TR_SERVICE_SURFACE=public" in create_text
-        assert (
-            "TR_ATTRIBUTION_COOKIE_SECRET=secretref:attribution-cookie-secret"
-            in create_text
-        )
+        assert "TR_ATTRIBUTION_COOKIE_SECRET=secretref:attribution-cookie-secret" in create_text
         attribution_secrets = [
-            argument
-            for argument in create
-            if argument.startswith("attribution-cookie-secret=")
+            argument for argument in create if argument.startswith("attribution-cookie-secret=")
         ]
         assert len(attribution_secrets) == 1
         assert len(attribution_secrets[0].partition("=")[2]) == 64
@@ -787,9 +755,7 @@ def test_azure_observer_initial_create_is_bounded_too(
         create_text = " ".join(create)
         assert "TR_SERVICE_SURFACE=observer" in create_text
         assert "TR_OBSERVER_INTERNAL_TOKEN=secretref:observer-token" in create_text
-        assert any(
-            argument.startswith("observer-token=") for argument in create
-        )
+        assert any(argument.startswith("observer-token=") for argument in create)
         assert "TR_INTERNAL_GATEWAY_TOKEN" not in create_text
         assert "TR_FEDERATION_" not in create_text
     set_mode_index = next(
@@ -865,10 +831,7 @@ def test_azure_canary_persists_a_missing_dedicated_attribution_secret_before_upd
         index
         for index, call in enumerate(run.calls)
         if call[:4] == ["az", "containerapp", "secret", "set"]
-        and any(
-            argument.startswith("attribution-cookie-secret=")
-            for argument in call
-        )
+        and any(argument.startswith("attribution-cookie-secret=") for argument in call)
     )
     update_index = next(
         index
@@ -884,10 +847,7 @@ def test_azure_canary_persists_a_missing_dedicated_attribution_secret_before_upd
     )
     assert len(stored) == 64
     update_text = " ".join(run.calls[update_index])
-    assert (
-        "TR_ATTRIBUTION_COOKIE_SECRET=secretref:attribution-cookie-secret"
-        in update_text
-    )
+    assert "TR_ATTRIBUTION_COOKIE_SECRET=secretref:attribution-cookie-secret" in update_text
     assert "TR_INTERNAL_GATEWAY_TOKEN" not in update_text
     assert "TR_FEDERATION_" not in update_text
 
@@ -917,24 +877,13 @@ def test_azure_canary_fails_closed_if_a_retired_oauth_credential_survives_cleanu
     run = isolated.run(script, verifier_rc=0)
 
     assert run.returncode != 0
-    assert (
-        "public canary retains forbidden OAuth env TR_GOOGLE_CLIENT_SECRET"
-        in run.stderr
-    )
-    update = next(
-        call for call in run.calls if call[:3] == ["az", "containerapp", "update"]
-    )
+    assert "public canary retains forbidden OAuth env TR_GOOGLE_CLIENT_SECRET" in run.stderr
+    update = next(call for call in run.calls if call[:3] == ["az", "containerapp", "update"])
     remove_index = update.index("--remove-env-vars")
-    assert "TR_GOOGLE_CLIENT_SECRET" in update[
-        remove_index + 1 : update.index("--min-replicas")
-    ]
+    assert "TR_GOOGLE_CLIENT_SECRET" in update[remove_index + 1 : update.index("--min-replicas")]
+    assert not any(call[:4] == ["az", "containerapp", "revision", "set-mode"] for call in run.calls)
     assert not any(
-        call[:4] == ["az", "containerapp", "revision", "set-mode"]
-        for call in run.calls
-    )
-    assert not any(
-        call[:3] == ["az", "containerapp", "show"]
-        and "ingress.fqdn" in " ".join(call)
+        call[:3] == ["az", "containerapp", "show"] and "ingress.fqdn" in " ".join(call)
         for call in run.calls
     )
 
@@ -958,30 +907,20 @@ def test_azure_canary_fails_closed_if_an_oauth_capability_flag_drifts_true(
             fixture,
             responses=(
                 (fixture_fragment, "true"),
-                *(
-                    response
-                    for response in fixture.responses
-                    if provider not in response[0]
-                ),
+                *(response for response in fixture.responses if provider not in response[0]),
             ),
         ),
     )
-    isolated = DeployScriptHarness(
-        tmp_path / f"azure-canary-{provider.lower()}-capability-drift"
-    )
+    isolated = DeployScriptHarness(tmp_path / f"azure-canary-{provider.lower()}-capability-drift")
 
     run = isolated.run(script, verifier_rc=0)
 
     assert run.returncode != 0
     assert "public canary OAuth capability verification failed" in run.stderr
     assert f"{provider.lower()}=true" in run.stderr
+    assert not any(call[:4] == ["az", "containerapp", "revision", "set-mode"] for call in run.calls)
     assert not any(
-        call[:4] == ["az", "containerapp", "revision", "set-mode"]
-        for call in run.calls
-    )
-    assert not any(
-        call[:3] == ["az", "containerapp", "show"]
-        and "ingress.fqdn" in " ".join(call)
+        call[:3] == ["az", "containerapp", "show"] and "ingress.fqdn" in " ".join(call)
         for call in run.calls
     )
 
@@ -1038,7 +977,8 @@ def test_azure_observer_rejects_reused_billing_gateway_credential_before_mutatio
     assert run.returncode != 0
     assert "must differ from the billing gateway token" in run.stderr
     assert not any(
-        call[:3] in (
+        call[:3]
+        in (
             ["az", "containerapp", "create"],
             ["az", "containerapp", "update"],
         )
@@ -1073,20 +1013,14 @@ def test_azure_surfaces_fail_closed_on_each_live_scaling_postcondition_drift(
     fixture = SCRIPT_FIXTURES[script]
     responses = (
         (fixture_fragment, reported_value),
-        *(
-            response
-            for response in fixture.responses
-            if fixture_fragment not in response[0]
-        ),
+        *(response for response in fixture.responses if fixture_fragment not in response[0]),
     )
     monkeypatch.setitem(
         SCRIPT_FIXTURES,
         script,
         replace(fixture, responses=responses),
     )
-    isolated = DeployScriptHarness(
-        tmp_path / f"azure-drift-{Path(script).stem}-{reported_value}"
-    )
+    isolated = DeployScriptHarness(tmp_path / f"azure-drift-{Path(script).stem}-{reported_value}")
 
     run = isolated.run(script, verifier_rc=0)
 
@@ -1095,8 +1029,7 @@ def test_azure_surfaces_fail_closed_on_each_live_scaling_postcondition_drift(
     assert reported_value in run.stderr
     assert not run.verifier_calls
     assert not any(
-        call[:3] == ["az", "containerapp", "show"]
-        and "ingress.fqdn" in " ".join(call)
+        call[:3] == ["az", "containerapp", "show"] and "ingress.fqdn" in " ".join(call)
         for call in run.calls
     )
 
@@ -1155,8 +1088,7 @@ def test_synthetic_jobs_execute_private_ingress_preflight_in_their_own_region(
         assert "TR_ALLOW_DEPLOYED_COMBINED_SURFACE" not in deployed_env
         assert "TR_RATE_LIMIT_ENABLED" not in deployed_env
         assert (
-            "TR_OBSERVER_INTERNAL_TOKEN=trustedrouter-observer-internal-token:latest"
-            in deploy_text
+            "TR_OBSERVER_INTERNAL_TOKEN=trustedrouter-observer-internal-token:latest" in deploy_text
         )
         assert "TR_INTERNAL_GATEWAY_TOKEN" not in deploy_text
         assert "--set-secrets" in deploy
@@ -1290,8 +1222,7 @@ def test_synthetic_combined_bridge_restores_legacy_job_deploys(
         region = deploy[deploy.index("--region") + 1]
         assert f"https://trusted-router-stub-output.{region}.run.app" in deploy_text
         assert (
-            "TR_INTERNAL_GATEWAY_TOKEN=trustedrouter-internal-gateway-token:latest"
-            in deploy_text
+            "TR_INTERNAL_GATEWAY_TOKEN=trustedrouter-internal-gateway-token:latest" in deploy_text
         )
         assert "TR_OBSERVER_INTERNAL_TOKEN" not in deploy_text
         assert deployed_env["TR_SERVICE_SURFACE"] == "combined"
@@ -1390,7 +1321,7 @@ def test_synthetic_combined_bridge_job_environment_constructs_settings(
         '{"secretKeyRef":{"name":"wrong-secret"}}},'
         '{"name":"TR_INTERNAL_GATEWAY_TOKEN","valueFrom":'
         '{"secretKeyRef":{"name":"trustedrouter-internal-gateway-token"}}}'
-        '] }]}}}}',
+        "] }]}}}}",
     ],
     ids=("not-ready", "public-ingress", "wrong-surface", "wrong-observer-secret"),
 )
@@ -1519,8 +1450,7 @@ def test_the_script_calls_the_gate_for_its_own_cloud(
         f"for {cloud}.\n{summarise(run)}"
     )
     assert run.returncode == 0, (
-        f"{script} called the gate, the gate passed, and the script still failed.\n"
-        f"{summarise(run)}"
+        f"{script} called the gate, the gate passed, and the script still failed.\n{summarise(run)}"
     )
 
 


### PR DESCRIPTION
Covers exposures 1 and 3 from the GitHub-resilience discussion. Exposure 2
(GitHub OAuth sign-in degrading during an outage) is accepted as-is — users who
chose GitHub login are already exposed to GitHub being down, and Google login
is unaffected.

## Two failures that get conflated

**A GitHub outage does not touch production.** Cloud Run keeps serving, the
enclaves keep attesting, ClickHouse keeps ingesting. What it takes away is the
ability to **ship**, because CI and every deploy job run on Actions. A mirror
does nothing for that — the code was never at risk, since every clone is a full
copy.

| Failure | Answer |
|---|---|
| Outage — can't ship | `scripts/deploy/break_glass_deploy.sh` |
| Repository loss | daily verified bundle in a versioned GCS bucket |

## Why not a self-hosted GitLab on GCP

It is a database, a Redis, backups, upgrades and its own runners — a stateful
system operated to protect against a stateless dependency, and least
trustworthy exactly when first needed, because nothing exercises it. A bundle
restores with `git clone` and has no service to have kept alive. Cloud Source
Repositories would be the obvious home and is closed to new customers, so this
depends on nothing but GCS.

## break_glass_deploy.sh

Builds via Cloud Build (server side, no local Docker) and calls the same
`rollout.sh` the workflow calls, rather than reimplementing the deploy — a
second copy would drift from the real one and be wrong in exactly the emergency
it exists for.

What it **skips** is enumerated in the header and printed at runtime: no CI
gate, no schema migrations, no staged canary, no automatic rollback, no secret
sync or Cloud Run Jobs. It prints the currently serving revision per region
**before** touching anything — that is the rollback target nobody can look up
once the new revision is live.

## Three defects found by running it, not reasoning about it

- **`git bundle verify` is not a corruption check.** On a bundle with seven
  bytes overwritten, `verify` **passed** and `git clone` **failed** — it only
  checks that prerequisite commits are satisfiable. The clone-and-compare is
  what's relied on; verify is kept because it fails faster on a truncated one.
- **Bundling a CI checkout is not a mirror.** `actions/checkout` leaves one
  local branch, so `git bundle --all` produced a bundle restoring **3 refs out
  of 46** — every object present (27,460 in-pack), 42 branches unreachable by
  name. The script now mirror-clones origin itself. The guard compares restored
  branch count against the **source** count rather than a threshold: a first
  version used "at least 2" and a single-branch repo scored 2 on `origin/HEAD`.
- **The failure path printed nothing.** `_lib.sh` sets `pipefail`, and the
  `grep -v` filtering `origin/HEAD` exits 1 when it filters everything out —
  killing the script before its own error message, on precisely the input the
  guard exists for. Counting with `awk` fixed it.

## Verified against production GCP

Not a dry run:

```
bundle uploaded  -> gs://quill-cloud-proxy-git-mirror/quill-router/{2026-08-23,latest}.bundle
restored FROM THE BUCKET -> 265 branches, HEAD at origin tip, contains today's commits
bucket           -> versioning_enabled=True, 365d noncurrent retention, PAP enforced
break-glass dry run -> read live serving revisions in all 4 regions, emitted valid rollback commands
```

The mirror bucket already exists and holds a current bundle; merging this adds
the daily schedule.

## Remaining

`break_glass_deploy.sh --apply` has **not** been run — that would deploy to
production. Its read-only half is verified. Worth one deliberate rehearsal at a
quiet moment, since an untested emergency path is the one that fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)