### PR TITLE
Rank live provider routes by TTFT and privacy

### DIFF
--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -749,9 +749,26 @@ def provider_to_openrouter_shape(provider: Provider) -> dict[str, object]:
 
 
 def providers_for_display() -> tuple[Provider, ...]:
-    """Provider transparency should lead with privacy-forward upstreams."""
-    pinned = [PROVIDERS[slug] for slug in _PROVIDER_DISPLAY_ORDER if slug in PROVIDERS]
-    pinned_slugs = {provider.slug for provider in pinned}
-    return tuple(
-        pinned + [provider for provider in PROVIDERS.values() if provider.slug not in pinned_slugs]
-    )
+    """Order transparency surfaces by the strongest tracked privacy posture."""
+    pinned_rank = {slug: index for index, slug in enumerate(_PROVIDER_DISPLAY_ORDER)}
+
+    def display_key(provider: Provider) -> tuple[int, int, str, str]:
+        if provider.slug == "trustedrouter":
+            posture_rank = 0
+        elif provider.provider_confidential_compute is True and provider.provider_e2ee is True:
+            posture_rank = 1
+        elif (
+            provider.provider_zero_data_retention is True
+            or provider.prepaid_zero_data_retention is True
+        ):
+            posture_rank = 2
+        else:
+            posture_rank = 3
+        return (
+            posture_rank,
+            pinned_rank.get(provider.slug, len(pinned_rank)),
+            provider.name.casefold(),
+            provider.slug,
+        )
+
+    return tuple(sorted(PROVIDERS.values(), key=display_key))

--- a/src/trusted_router/choose_catalog.py
+++ b/src/trusted_router/choose_catalog.py
@@ -13,13 +13,19 @@ from typing import Any
 
 from trusted_router.ai_iq import ai_iq_catalog_payload
 from trusted_router.catalog import (
+    ADVISOR_MODEL_ID,
     AUTO_MODEL_ID,
     CHEAP_MODEL_ID,
+    CONFIDENTIAL_MODEL_ID,
     E2E_MODEL_ID,
+    EU_MODEL_ID,
+    FAST_MODEL_ID,
     META_MODEL_IDS,
     MODELS,
+    ORCHESTRATION_PRIMITIVE_MODEL_IDS,
     PRIVACY_TIER_LABELS,
     PROVIDERS,
+    ROUTING_MODEL_ALIAS_TARGETS,
     ROUTING_MODEL_MIN_PRIVACY_TIERS,
     SYNTH_MODEL_ID,
     ZDR_MODEL_ID,
@@ -37,10 +43,14 @@ from trusted_router.storage_models import utcnow
 
 _ROUTE_IDS = (
     AUTO_MODEL_ID,
+    FAST_MODEL_ID,
     CHEAP_MODEL_ID,
+    EU_MODEL_ID,
     ZDR_MODEL_ID,
     E2E_MODEL_ID,
+    CONFIDENTIAL_MODEL_ID,
     SYNTH_MODEL_ID,
+    ADVISOR_MODEL_ID,
 )
 
 _ROUTE_DESCRIPTIONS = {
@@ -48,15 +58,29 @@ _ROUTE_DESCRIPTIONS = {
         "Ranks configured model candidates and rolls over across healthy providers. "
         "No upstream privacy floor is implied."
     ),
+    FAST_MODEL_ID: (
+        "Prefers healthy candidates with low measured time to first token and keeps fallback. "
+        "No upstream privacy floor is implied."
+    ),
     CHEAP_MODEL_ID: (
         "Chooses from the lowest-cost paid candidates. No upstream privacy floor is implied."
+    ),
+    EU_MODEL_ID: (
+        "Prefers EU-focused providers. Use the EU regional API hostname when gateway region "
+        "also matters."
     ),
     ZDR_MODEL_ID: "Enforces a zero-retention or stronger provider endpoint for every attempt.",
     E2E_MODEL_ID: (
         "Enforces provider confidential compute plus provider-side end-to-end encryption."
     ),
+    CONFIDENTIAL_MODEL_ID: (
+        "Readable alias for the same confidential-compute plus provider-E2EE route pool."
+    ),
     SYNTH_MODEL_ID: (
         "Runs a model panel, judge, and synthesizer. Every inner inference call is billable."
+    ),
+    ADVISOR_MODEL_ID: (
+        "Runs a worker with optional advisor calls. Every inner inference call is billable."
     ),
 }
 
@@ -101,9 +125,11 @@ def build_choose_catalog_payload(
     }
     models: list[dict[str, Any]] = []
     catalog_route_count = 0
+    catalog_provider_slugs: set[str] = set()
     for model in catalog_models:
         endpoints = list(endpoints_for_model(model.id))
         catalog_route_count += len(endpoints)
+        catalog_provider_slugs.update(endpoint.provider for endpoint in endpoints)
         quality = quality_models.get(model.id)
         if quality is None or not endpoints or _positive_quality_score(quality) is None:
             continue
@@ -148,13 +174,13 @@ def build_choose_catalog_payload(
         "quality_updated_at": quality_updated_at,
         "performance_updated_at": str(measured.get("generated_at", "")),
         "catalog_model_count": len(catalog_models),
+        "catalog_provider_count": len(catalog_provider_slugs),
         "catalog_route_count": catalog_route_count,
         "evaluated_model_count": len(models),
         "models": models,
         "routes": [_meta_route_row(route_id) for route_id in _ROUTE_IDS if route_id in MODELS],
         "privacy_tiers": [
-            {"tier": tier, "label": label}
-            for tier, label in sorted(PRIVACY_TIER_LABELS.items())
+            {"tier": tier, "label": label} for tier, label in sorted(PRIVACY_TIER_LABELS.items())
         ],
     }
 
@@ -258,8 +284,9 @@ def _meta_route_row(model_id: str) -> dict[str, Any]:
     shape = model_to_openrouter_shape(MODELS[model_id])
     trustedrouter = shape["trustedrouter"]
     assert isinstance(trustedrouter, dict)
-    floor = ROUTING_MODEL_MIN_PRIVACY_TIERS.get(model_id, 0)
-    component_usage = model_id == SYNTH_MODEL_ID
+    canonical_model_id = ROUTING_MODEL_ALIAS_TARGETS.get(model_id, model_id)
+    floor = ROUTING_MODEL_MIN_PRIVACY_TIERS.get(canonical_model_id, 0)
+    component_usage = model_id in ORCHESTRATION_PRIMITIVE_MODEL_IDS
     return {
         "id": model_id,
         "name": model_id.removeprefix("trustedrouter/"),

--- a/src/trusted_router/static/choose-app.html
+++ b/src/trusted_router/static/choose-app.html
@@ -5,8 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>Choose an LLM | TrustedRouter</title>
   <meta name="description" content="Compare independently scored models against live TrustedRouter pricing, provider privacy, context, and measured performance.">
+  <meta name="robots" content="noindex,follow">
+  <link rel="canonical" href="https://trustedrouter.com/choose">
   <link rel="stylesheet" href="/static/choose-app.css?v=2">
-  <script src="/static/choose-app.js?v=2" defer></script>
+  <script src="/static/choose-app.js?v=3" defer></script>
 </head>
 <body>
   <div class="app-shell">
@@ -18,14 +20,15 @@
       <div class="catalog-state">
         <span class="live-dot" aria-hidden="true"></span>
         <span><strong id="liveCount">...</strong> live models</span>
+        <span><strong id="providerCount">...</strong> providers</span>
         <span><strong id="evaluatedCount">...</strong> independently scored</span>
       </div>
     </header>
 
     <section class="intro">
-      <p class="eyebrow">Smart. Cheap. Fast.</p>
+      <p class="eyebrow">Smart. Cheap. Fast. Private.</p>
       <h1>Choose with route-level facts.</h1>
-      <p>Quality comes from independent evaluations. Price, privacy, context, and performance come from the exact provider routes TrustedRouter can call.</p>
+      <p>Quality comes from independent evaluations. Price, privacy, context, and performance come from the live model and provider routes TrustedRouter can call.</p>
     </section>
 
     <main>

--- a/src/trusted_router/static/choose-app.js
+++ b/src/trusted_router/static/choose-app.js
@@ -490,13 +490,17 @@
   }
 
   function recommendedRoutes() {
-    if (state.privacy >= 3) return [routeById("trustedrouter/e2e")].filter(Boolean);
-    if (state.privacy >= 2) return [routeById("trustedrouter/zdr"), routeById("trustedrouter/e2e")].filter(Boolean);
+    const confidential = routeById("trustedrouter/confidential") || routeById("trustedrouter/e2e");
+    if (state.privacy >= 3) return [confidential].filter(Boolean);
+    if (state.privacy >= 2) return [routeById("trustedrouter/zdr"), confidential].filter(Boolean);
     if (state.quality === "frontier" || state.preference.quality >= 0.5) {
       return [routeById("trustedrouter/synth"), routeById("trustedrouter/auto")].filter(Boolean);
     }
     if (state.preference.cost >= 0.45) {
       return [routeById("trustedrouter/cheap"), routeById("trustedrouter/auto")].filter(Boolean);
+    }
+    if (state.preference.speed >= 0.45) {
+      return [routeById("trustedrouter/fast"), routeById("trustedrouter/auto")].filter(Boolean);
     }
     return [routeById("trustedrouter/auto"), routeById("trustedrouter/cheap")].filter(Boolean);
   }
@@ -771,8 +775,9 @@
       if (!response.ok) throw new Error(`Catalog request failed with HTTP ${response.status}.`);
       state.catalog = normalizeCatalog(await response.json());
       dom.liveCount.textContent = String(state.catalog.catalog_model_count);
+      dom.providerCount.textContent = String(state.catalog.catalog_provider_count);
       dom.evaluatedCount.textContent = String(state.catalog.evaluated_model_count);
-      setLoadState(`${state.catalog.evaluated_model_count} independently scored models matched against ${state.catalog.catalog_route_count} live provider routes.`);
+      setLoadState(`${state.catalog.evaluated_model_count} independently scored models matched against ${state.catalog.catalog_route_count} live routes across ${state.catalog.catalog_provider_count} providers.`);
       render();
     } catch (error) {
       state.catalog = null;
@@ -797,7 +802,7 @@
       "triangle", "tooltip", "privacy", "privacyNote", "problem", "examples", "guess", "rationale",
       "qualitySegments", "speedSegments", "qualityWeight", "costWeight", "speedWeight", "loadState",
       "loadText", "resultsTitle", "modelResults", "routeRecommendation", "liveCount",
-      "evaluatedCount",
+      "providerCount", "evaluatedCount",
     ]) dom[id] = byId(id);
     dom.retryCatalog = byId("retry-catalog");
   }

--- a/src/trusted_router/synthetic/leaderboard.py
+++ b/src/trusted_router/synthetic/leaderboard.py
@@ -327,7 +327,7 @@ class ProviderStats:
 
 
 def _sort_key(p50_ttft_ms: int | None) -> tuple[int, int]:
-    # Latency breaks reliability ties; un-measured (None) sinks to the bottom.
+    # Fastest measured TTFT first; un-measured (None) sinks to the bottom.
     return (0 if p50_ttft_ms is not None else 1, p50_ttft_ms or 0)
 
 
@@ -448,8 +448,8 @@ def aggregate_leaderboard(
     models.sort(
         key=lambda stats: (
             0 if stats.rank_eligible else 1,
-            -stats.provider_availability,
             *_sort_key(stats.p50_ttft_ms),
+            -stats.provider_availability,
             stats.model,
             stats.provider,
         )
@@ -535,8 +535,8 @@ def _aggregate_providers(
     providers.sort(
         key=lambda stats: (
             0 if stats.rank_eligible else 1,
-            -stats.provider_availability,
             *_sort_key(stats.p50_ttft_ms),
+            -stats.provider_availability,
             stats.provider,
         )
     )

--- a/src/trusted_router/templates/public/choose.html
+++ b/src/trusted_router/templates/public/choose.html
@@ -2,7 +2,7 @@
 {% block hero %}
 <section class="public-hero marketing-hero">
   <div>
-    <span class="eyebrow">Smart · Cheap · Fast — pick two</span>
+    <span class="eyebrow">Current models · live provider routes</span>
     <h1>Choose the right model for the job.</h1>
     <p class="lead">Describe your task and how private it has to be. We combine independent quality
       scores with live provider routes, integer pricing, privacy posture, and measured performance.</p>
@@ -12,7 +12,7 @@
     </div>
   </div>
   <div class="public-hero-metrics" aria-label="TrustedRouter quick facts">
-    <div><strong>Hundreds</strong><span>of live models &amp; routes</span></div>
+    <div><strong>Live</strong><span>model &amp; provider catalog</span></div>
     <div><strong>E2E</strong><span>encrypted routes available</span></div>
     <div><strong>0</strong><span>prompt or output logs. Always.</span></div>
   </div>
@@ -94,23 +94,27 @@ Estimate cost and speed before making billable calls.</code></pre>
 
 # let the router pick, per request:
 model="trustedrouter/auto"     # general rollover, no upstream privacy floor
+model="trustedrouter/fast"     # lowest measured TTFT among healthy candidates
 model="trustedrouter/cheap"    # lowest-cost paid candidate pool
+model="trustedrouter/eu"       # EU-focused provider pool
 model="trustedrouter/zdr"      # zero-retention or stronger routes
-model="trustedrouter/e2e"      # end-to-end encrypted routes
-model="trustedrouter/synth"    # billable panel + judge + synthesizer</code></pre>
+model="trustedrouter/confidential"  # provider confidential compute + E2EE
+model="trustedrouter/synth"    # billable panel + judge + synthesizer
+model="trustedrouter/advisor"  # worker with optional billable advisors</code></pre>
   </div>
 </section>
 
 <section class="quote-feature">
   <div>
     <span class="eyebrow">The shortcut</span>
-    <h2>The corner you actually want rarely exists in one model.</h2>
+    <h2>Compare the frontier you can actually route.</h2>
   </div>
   <div>
-    <p>Frontier-smart, real-time-fast, dirt-cheap and private almost never coexist in a single model.
-      TrustedRouter's <code>auto</code>, <code>cheap</code> and <code>synth</code> routes handle the
-      tradeoff through one OpenAI-shaped endpoint. Gateway attestation verifies TrustedRouter does not
-      log prompt content; the upstream privacy guarantee depends on the selected route.
+    <p>The chooser loads current models and provider endpoints from the same deployed catalog as
+      <code>/v1/models</code>. TrustedRouter's <code>auto</code>, <code>fast</code>, <code>cheap</code>,
+      <code>confidential</code>, and orchestration routes expose those choices through one
+      OpenAI-shaped endpoint. Gateway attestation verifies the router hop; endpoint rows state the
+      downstream provider posture separately.
       <button class="btn primary" type="button" data-action="open-signin">Create a key</button></p>
   </div>
 </section>

--- a/src/trusted_router/templates/public/leaderboard.html
+++ b/src/trusted_router/templates/public/leaderboard.html
@@ -21,7 +21,7 @@
   <div class="status-note">
     Continuously sampled from TrustedRouter's monitor regions using a
     {{ snapshot.window_label or "recent live sample" }}. Time-to-first-token (TTFT),
-    time-to-first-byte (TTFB), effective throughput, and success rate come from real
+    effective throughput, and success rate come from real
     streaming requests, not vendor claims. Completion rate shows the end-user result.
     Provider availability excludes failures owned by TrustedRouter, customers, or route
     configuration, while still reporting those failures under their actual owner.
@@ -40,7 +40,7 @@
     <div class="status-section-head">
       <div>
         <h2>Providers</h2>
-        <p>Ranked by provider-attributed availability, then p50 time-to-first-token across all of a provider's models
+        <p>Ranked by p50 time-to-first-token across all of a provider's models. Provider-attributed availability remains visible and breaks latency ties
           ({{ snapshot.provider_count }} providers · {{ snapshot.total_samples }} availability samples ·
           {{ snapshot.total_throughput_samples }} sustained throughput samples). Providers below the
           evidence floor remain visible as warming, but do not receive a rank.</p>
@@ -85,7 +85,7 @@
     <div class="status-section-head">
       <div>
         <h2>Models</h2>
-        <p>Qualified models are ranked by provider-attributed availability, then p50 TTFT. Thin availability and
+        <p>Qualified models are ranked by p50 TTFT, with provider-attributed availability as a tie-breaker. Thin availability and
           throughput measurements stay visible below the ranked set as warming.</p>
       </div>
     </div>
@@ -95,7 +95,7 @@
           <tr>
             <th>#</th><th>Model</th><th>Provider</th>
             <th>Completion</th><th>Provider availability</th><th>Within deadline</th><th>Capacity accepted</th>
-            <th>p50 TTFT</th><th>p95 TTFT</th><th>p50 TTFB</th><th>p95 TTFB</th>
+            <th>p50 TTFT</th><th>p95 TTFT</th>
             <th>Effective throughput</th><th>Config excluded</th><th>Samples</th>
           </tr>
         </thead>
@@ -113,8 +113,6 @@
             <td>{% if m.capacity_acceptance_rate is not none %}{{ '%.2f'|format(m.capacity_acceptance_rate * 100) }}%{% else %}—{% endif %}</td>
             <td>{% if m.p50_ttft_ms is not none %}{{ m.p50_ttft_ms }} ms{% else %}—{% endif %}</td>
             <td>{% if m.p95_ttft_ms is not none %}{{ m.p95_ttft_ms }} ms{% else %}—{% endif %}</td>
-            <td>{% if m.p50_ttfb_ms is not none %}{{ m.p50_ttfb_ms }} ms{% else %}—{% endif %}</td>
-            <td>{% if m.p95_ttfb_ms is not none %}{{ m.p95_ttfb_ms }} ms{% else %}—{% endif %}</td>
             <td>{% if m.p50_tokens_per_second is not none and m.throughput_sample_count %}{{ '%.0f'|format(m.p50_tokens_per_second) }} tok/s{% if m.throughput_sample_count < 3 %} <span class="lb-badge">warming</span>{% endif %}{% else %}—{% endif %}</td>
             <td>{% if m.excluded_count %}{{ m.excluded_count }}{% if m.top_excluded %} <code>{{ m.top_excluded }}</code>{% endif %}{% else %}—{% endif %}</td>
             <td>{{ m.sample_count }}</td>

--- a/src/trusted_router/templates/public/model_section.html
+++ b/src/trusted_router/templates/public/model_section.html
@@ -98,17 +98,16 @@
     {% elif section == "performance" %}
     {% if measured %}
     <h3>Measured performance</h3>
-    <p class="muted-copy">Continuously sampled p50/p95 time-to-first-token (TTFT), time-to-first-byte (TTFB), effective throughput, and success rate for {{ model.name }}. Effective throughput uses provider-reported output tokens over complete request time. Unsupported route and probe-configuration rows are separated from provider downtime, and no prompt or output content is stored.</p>
+    <p class="muted-copy">Continuously sampled p50/p95 time-to-first-token (TTFT), effective throughput, and success rate for {{ model.name }}. Effective throughput uses provider-reported output tokens over complete request time. Unsupported route and probe-configuration rows are separated from provider downtime, and no prompt or output content is stored.</p>
     <div class="leaderboard-table-wrap">
       <table class="leaderboard-table">
-        <thead><tr><th>Provider</th><th>p50 TTFT</th><th>p95 TTFT</th><th>p50 TTFB</th><th>Effective throughput</th><th>Uptime</th><th>Config excluded</th><th>Availability samples</th></tr></thead>
+        <thead><tr><th>Provider</th><th>p50 TTFT</th><th>p95 TTFT</th><th>Effective throughput</th><th>Uptime</th><th>Config excluded</th><th>Availability samples</th></tr></thead>
         <tbody>
           {% for r in measured %}
           <tr>
             <td>{{ provider_identity(r.provider, r.provider, "/providers/" ~ r.provider) }}</td>
             <td>{% if r.p50_ttft_ms is not none %}{{ r.p50_ttft_ms }} ms{% else %}—{% endif %}</td>
             <td>{% if r.p95_ttft_ms is not none %}{{ r.p95_ttft_ms }} ms{% else %}—{% endif %}</td>
-            <td>{% if r.p50_ttfb_ms is not none %}{{ r.p50_ttfb_ms }} ms{% else %}—{% endif %}</td>
             <td>{% if r.p50_tokens_per_second is not none %}{{ '%.0f'|format(r.p50_tokens_per_second) }} tok/s <span class="lb-sample-count">n={{ r.throughput_sample_count }}</span>{% else %}—{% endif %}</td>
             <td>{% if r.sample_count %}{{ '%.2f'|format(r.uptime * 100) }}%{% else %}—{% endif %}</td>
             <td>{% if r.excluded_count %}{{ r.excluded_count }}{% if r.top_excluded %} <code>{{ r.top_excluded }}</code>{% endif %}{% else %}—{% endif %}</td>

--- a/src/trusted_router/templates/public/provider_detail.html
+++ b/src/trusted_router/templates/public/provider_detail.html
@@ -42,13 +42,12 @@
     {% if measured.models %}
     <div class="leaderboard-table-wrap" style="margin-top:12px">
       <table class="leaderboard-table">
-        <thead><tr><th>Model</th><th>p50 TTFT</th><th>p50 TTFB</th><th>Effective throughput</th><th>Uptime</th><th>Config excluded</th><th>Availability samples</th></tr></thead>
+        <thead><tr><th>Model</th><th>p50 TTFT</th><th>Effective throughput</th><th>Uptime</th><th>Config excluded</th><th>Availability samples</th></tr></thead>
         <tbody>
           {% for m in measured.models %}
           <tr>
             <td><a href="/models/{{ m.model }}/performance">{{ m.model }}</a></td>
             <td>{% if m.p50_ttft_ms is not none %}{{ m.p50_ttft_ms }} ms{% else %}—{% endif %}</td>
-            <td>{% if m.p50_ttfb_ms is not none %}{{ m.p50_ttfb_ms }} ms{% else %}—{% endif %}</td>
             <td>{% if m.p50_tokens_per_second is not none %}{{ '%.0f'|format(m.p50_tokens_per_second) }} tok/s <span class="lb-sample-count">n={{ m.throughput_sample_count }}</span>{% else %}—{% endif %}</td>
             <td>{% if m.sample_count %}{{ '%.2f'|format(m.uptime * 100) }}%{% else %}—{% endif %}</td>
             <td>{% if m.excluded_count %}{{ m.excluded_count }}{% if m.top_excluded %} <code>{{ m.top_excluded }}</code>{% endif %}{% else %}—{% endif %}</td>

--- a/src/trusted_router/templates/public/provider_performance.html
+++ b/src/trusted_router/templates/public/provider_performance.html
@@ -18,7 +18,6 @@
       <tbody>
         <tr><th>p50 TTFT</th><td>{% if measured.provider_row.p50_ttft_ms is not none %}{{ measured.provider_row.p50_ttft_ms }} ms{% else %}—{% endif %}</td></tr>
         <tr><th>p95 TTFT</th><td>{% if measured.provider_row.p95_ttft_ms is not none %}{{ measured.provider_row.p95_ttft_ms }} ms{% else %}—{% endif %}</td></tr>
-        <tr><th>p50 TTFB</th><td>{% if measured.provider_row.p50_ttfb_ms is not none %}{{ measured.provider_row.p50_ttfb_ms }} ms{% else %}—{% endif %}</td></tr>
         <tr><th>Effective throughput</th><td>{% if measured.provider_row.p50_tokens_per_second is not none %}{{ '%.0f'|format(measured.provider_row.p50_tokens_per_second) }} tok/s <span class="lb-sample-count">n={{ measured.provider_row.throughput_sample_count|default(0) }}</span>{% else %}—{% endif %}</td></tr>
         <tr><th>Uptime</th><td>{% if measured.provider_row.sample_count %}{{ '%.2f'|format(measured.provider_row.uptime * 100) }}%{% else %}—{% endif %}</td></tr>
       </tbody>
@@ -33,13 +32,12 @@
   <div class="panel-body">
     <div class="leaderboard-table-wrap">
       <table class="leaderboard-table">
-        <thead><tr><th>Model</th><th>p50 TTFT</th><th>p50 TTFB</th><th>Effective throughput</th><th>Uptime</th><th>Config excluded</th><th>Availability samples</th></tr></thead>
+        <thead><tr><th>Model</th><th>p50 TTFT</th><th>Effective throughput</th><th>Uptime</th><th>Config excluded</th><th>Availability samples</th></tr></thead>
         <tbody>
           {% for m in measured.models %}
           <tr>
             <td><a href="/models/{{ m.model }}/performance">{{ m.model }}</a></td>
             <td>{% if m.p50_ttft_ms is not none %}{{ m.p50_ttft_ms }} ms{% else %}—{% endif %}</td>
-            <td>{% if m.p50_ttfb_ms is not none %}{{ m.p50_ttfb_ms }} ms{% else %}—{% endif %}</td>
             <td>{% if m.p50_tokens_per_second is not none %}{{ '%.0f'|format(m.p50_tokens_per_second) }} tok/s <span class="lb-sample-count">n={{ m.throughput_sample_count }}</span>{% else %}—{% endif %}</td>
             <td>{% if m.sample_count %}{{ '%.2f'|format(m.uptime * 100) }}%{% else %}—{% endif %}</td>
             <td>{% if m.excluded_count %}{{ m.excluded_count }}{% if m.top_excluded %} <code>{{ m.top_excluded }}</code>{% endif %}{% else %}—{% endif %}</td>

--- a/src/trusted_router/templates/public/providers.html
+++ b/src/trusted_router/templates/public/providers.html
@@ -15,7 +15,7 @@
       <h2>Trusted gateway first, then explicit provider claims.</h2>
     </div>
     <div>
-      <p>Zero data retention, confidential compute, and encrypted provider routes are shown only when explicitly tracked. Unknown stays unknown.</p>
+      <p>TrustedRouter is listed first, followed by verified confidential providers, ZDR providers, and every remaining provider. Claims appear only when explicitly tracked. Unknown stays unknown.</p>
       <a class="btn" href="/providers/marketplace">List your models <span aria-hidden="true">→</span></a>
     </div>
   </div>

--- a/tests/browser/dashboard.spec.js
+++ b/tests/browser/dashboard.spec.js
@@ -532,13 +532,14 @@ test("model picker applies privacy to exact provider routes", async ({ page }) =
   const picker = page.frameLocator("#tr-choose-frame");
 
   await expect(picker.locator("#loadState")).toContainText("independently scored models");
+  await expect(picker.locator("#providerCount")).not.toHaveText("...");
   await picker.getByRole("button", { name: /Simple/ }).click();
   await picker.getByRole("button", { name: /Any/ }).click();
   await picker.locator("#privacy").selectOption("3");
 
   await expect(picker.locator(".model-card").first()).toBeVisible();
   await expect(picker.locator(".route-recommendation code").first()).toHaveText(
-    "trustedrouter/e2e",
+    "trustedrouter/confidential",
   );
   await expect(picker.locator(".model-card", { hasText: "DeepSeek V4 Pro" })).toHaveCount(0);
   const routeLabels = await picker.locator(".provider-route").allTextContents();

--- a/tests/test_choose_catalog.py
+++ b/tests/test_choose_catalog.py
@@ -7,9 +7,13 @@ from typing import Any
 from fastapi.testclient import TestClient
 
 from trusted_router.catalog import (
+    ADVISOR_MODEL_ID,
     AUTO_MODEL_ID,
     CHEAP_MODEL_ID,
+    CONFIDENTIAL_MODEL_ID,
     E2E_MODEL_ID,
+    EU_MODEL_ID,
+    FAST_MODEL_ID,
     MODELS,
     PRIVACY_TIER_CONFIDENTIAL,
     PRIVACY_TIER_ZERO_RETENTION,
@@ -45,17 +49,14 @@ def test_choose_catalog_is_compact_endpoint_scoped_and_cached(client: TestClient
 
     payload = response.json()
     assert payload["catalog_model_count"] > payload["evaluated_model_count"] > 0
+    assert payload["catalog_provider_count"] > 0
     assert payload["catalog_route_count"] > payload["catalog_model_count"]
     for model in payload["models"]:
         assert model["quality"]["score"] > 0
         assert model["endpoints"]
         for endpoint in model["endpoints"]:
-            assert isinstance(
-                endpoint["prompt_price_microdollars_per_million_tokens"], int
-            )
-            assert isinstance(
-                endpoint["completion_price_microdollars_per_million_tokens"], int
-            )
+            assert isinstance(endpoint["prompt_price_microdollars_per_million_tokens"], int)
+            assert isinstance(endpoint["completion_price_microdollars_per_million_tokens"], int)
             assert endpoint["provider"]
             assert endpoint["usage_type"] in {"BYOK", "Credits"}
             assert endpoint["privacy_tier"] in {0, 1, 2, 3}
@@ -98,14 +99,15 @@ def test_choose_route_guarantees_match_runtime_source_of_truth(
     client: TestClient,
     test_settings: Settings,
 ) -> None:
-    routes = {
-        route["id"]: route for route in client.get("/choose/catalog.json").json()["routes"]
-    }
+    routes = {route["id"]: route for route in client.get("/choose/catalog.json").json()["routes"]}
 
     assert routes[AUTO_MODEL_ID]["min_privacy_tier"] == 0
+    assert routes[FAST_MODEL_ID]["min_privacy_tier"] == 0
     assert routes[CHEAP_MODEL_ID]["min_privacy_tier"] == 0
+    assert routes[EU_MODEL_ID]["min_privacy_tier"] == 0
     assert routes[ZDR_MODEL_ID]["min_privacy_tier"] == PRIVACY_TIER_ZERO_RETENTION
     assert routes[E2E_MODEL_ID]["min_privacy_tier"] == PRIVACY_TIER_CONFIDENTIAL
+    assert routes[CONFIDENTIAL_MODEL_ID]["min_privacy_tier"] == PRIVACY_TIER_CONFIDENTIAL
     assert ROUTING_MODEL_MIN_PRIVACY_TIERS[ZDR_MODEL_ID] == PRIVACY_TIER_ZERO_RETENTION
     assert ROUTING_MODEL_MIN_PRIVACY_TIERS[E2E_MODEL_ID] == PRIVACY_TIER_CONFIDENTIAL
     assert AUTO_MODEL_ID not in ROUTING_MODEL_MIN_PRIVACY_TIERS
@@ -126,16 +128,20 @@ def test_choose_route_guarantees_match_runtime_source_of_truth(
     assert all(endpoint.provider != "gmi" for _model, endpoint in e2e_candidates)
 
 
-def test_choose_synth_pricing_is_component_usage_not_free(client: TestClient) -> None:
-    routes = {
-        route["id"]: route for route in client.get("/choose/catalog.json").json()["routes"]
-    }
+def test_choose_orchestration_pricing_is_component_usage_not_free(client: TestClient) -> None:
+    routes = {route["id"]: route for route in client.get("/choose/catalog.json").json()["routes"]}
     synth = routes[SYNTH_MODEL_ID]
 
     assert synth["pricing_mode"] == "component_usage"
     assert synth["prompt_price_min_microdollars_per_million_tokens"] is None
     assert synth["completion_price_min_microdollars_per_million_tokens"] is None
     assert "Every inner inference call is billable" in synth["description"]
+
+    advisor = routes[ADVISOR_MODEL_ID]
+    assert advisor["pricing_mode"] == "component_usage"
+    assert advisor["prompt_price_min_microdollars_per_million_tokens"] is None
+    assert advisor["completion_price_min_microdollars_per_million_tokens"] is None
+    assert "Every inner inference call is billable" in advisor["description"]
 
 
 def test_choose_catalog_omits_unscored_and_zero_score_models() -> None:

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -173,7 +173,7 @@ def test_models_sorted_fastest_first_unmeasured_last() -> None:
     assert ordered[2] == "unknown/m"  # un-measured at the bottom
 
 
-def test_models_and_providers_rank_reliability_before_latency() -> None:
+def test_models_and_providers_rank_ttft_before_reliability() -> None:
     samples = [
         _sample(provider="reliable", model="reliable/m", ttft=500),
         _sample(
@@ -195,15 +195,17 @@ def test_models_and_providers_rank_reliability_before_latency() -> None:
     result = aggregate_leaderboard(samples)
 
     assert [row["model"] for row in result["models"]] == [
-        "reliable/m",
         "flaky/m",
+        "reliable/m",
     ]
     assert [row["provider"] for row in result["providers"]] == [
-        "reliable",
         "flaky",
+        "reliable",
     ]
-    assert result["models"][0]["uptime"] == 1.0
-    assert result["models"][1]["uptime"] == 0.5
+    assert result["models"][0]["p50_ttft_ms"] == 50
+    assert result["models"][0]["provider_availability"] == 0.5
+    assert result["models"][1]["p50_ttft_ms"] == 500
+    assert result["models"][1]["provider_availability"] == 1.0
 
 
 def test_min_samples_filters_thin_models() -> None:
@@ -366,9 +368,7 @@ def test_thin_rows_stay_visible_but_do_not_receive_ranks() -> None:
 
 
 def test_legacy_short_request_speed_never_creates_zero_sample_throughput() -> None:
-    result = aggregate_leaderboard(
-        [_sample(provider="p", model="p/m", ttft=50, tps=9999.0)]
-    )
+    result = aggregate_leaderboard([_sample(provider="p", model="p/m", ttft=50, tps=9999.0)])
 
     model = result["models"][0]
     provider = result["providers"][0]

--- a/tests/test_leaderboard_page.py
+++ b/tests/test_leaderboard_page.py
@@ -92,10 +92,11 @@ def test_leaderboard_page_renders_measurements() -> None:
     assert "Effective throughput" in body
     assert "200 tok/s" in body
     assert "n=1" not in body
-    assert "Ranked by provider-attributed availability, then p50" in body
+    assert "Ranked by p50 time-to-first-token" in body
     assert "Capacity accepted" in body
     assert "Provider availability" in body
-    assert "p95 TTFB" in body
+    assert "p50 TTFB" not in body
+    assert "p95 TTFB" not in body
     assert "cerebras" in body  # seeded provider row
     assert "meta/llama-3.3-70b" in body  # seeded model row
 

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -366,8 +366,11 @@ def test_choose_page_embeds_the_triangle_app(client: TestClient) -> None:
     assert "Trusted Execution Environment" in response.text
     assert "Tinfoil first" not in response.text
     assert "providers such as" not in response.text
-    assert "trustedrouter/e2e" in response.text
+    assert "trustedrouter/confidential" in response.text
+    assert "trustedrouter/fast" in response.text
+    assert "trustedrouter/eu" in response.text
     assert "trustedrouter/synth" in response.text
+    assert "trustedrouter/advisor" in response.text
     # Must unfurl with the tailored triangle social card (the PNG is checked
     # into static/og/, so _og_image_url resolves it rather than the default).
     assert 'property="og:title"' in response.text
@@ -381,10 +384,13 @@ def test_choose_app_static_asset_is_served(client: TestClient) -> None:
     response = client.get("/static/choose-app.html")
 
     assert response.status_code == 200
+    assert '<meta name="robots" content="noindex,follow">' in response.text
+    assert '<link rel="canonical" href="https://trustedrouter.com/choose">' in response.text
     assert "Choose with route-level facts." in response.text
     assert "Upstream privacy floor" in response.text
+    assert 'id="providerCount"' in response.text
     assert "/static/choose-app.css?v=2" in response.text
-    assert "/static/choose-app.js?v=2" in response.text
+    assert "/static/choose-app.js?v=3" in response.text
     assert "fonts.googleapis.com" not in response.text
     # Privacy floor defaults to Open (any provider), not ZDR.
     assert '<option value="0" selected>' in response.text

--- a/tests/test_stubs_and_security.py
+++ b/tests/test_stubs_and_security.py
@@ -30,6 +30,8 @@ TEST_BYOK_KMS_KEY_NAME = (
 def test_signup_credit_defaults_stay_aligned() -> None:
     assert DEFAULT_SIGNUP_CREDIT_MICRODOLLARS == 300_000
     assert Settings(environment="test").signup_trial_credit_microdollars == 300_000
+
+
 TEST_SES_SETTINGS = {
     "aws_access_key_id": "test-access-key",
     "aws_secret_access_key": "test-secret-key",
@@ -52,7 +54,9 @@ def test_stubbed_endpoints_are_explicit(client: TestClient) -> None:
         assert resp.json()["error"]["type"] == type_
 
 
-def test_content_storage_cannot_be_enabled(client: TestClient, user_headers: dict[str, str]) -> None:
+def test_content_storage_cannot_be_enabled(
+    client: TestClient, user_headers: dict[str, str]
+) -> None:
     workspaces = client.get("/v1/workspaces", headers=user_headers).json()["data"]
     workspace_id = workspaces[0]["id"]
     resp = client.patch(
@@ -94,7 +98,9 @@ def test_users_cannot_select_another_users_workspace(client: TestClient) -> None
     assert resp.json()["error"]["type"] == "forbidden"
 
 
-def test_management_keys_are_pinned_to_their_workspace(client: TestClient, user_headers: dict[str, str]) -> None:
+def test_management_keys_are_pinned_to_their_workspace(
+    client: TestClient, user_headers: dict[str, str]
+) -> None:
     personal_key = client.post("/v1/keys", headers=user_headers, json={"name": "personal"}).json()
     personal_workspace_id = personal_key["data"]["workspace_id"]
     org = client.post("/v1/workspaces", headers=user_headers, json={"name": "Org"}).json()["data"]
@@ -106,7 +112,9 @@ def test_management_keys_are_pinned_to_their_workspace(client: TestClient, user_
     ).json()["key"]
     management_headers = {"authorization": f"Bearer {org_management_key}"}
 
-    workspace_resp = client.get(f"/v1/workspaces/{personal_workspace_id}", headers=management_headers)
+    workspace_resp = client.get(
+        f"/v1/workspaces/{personal_workspace_id}", headers=management_headers
+    )
     assert workspace_resp.status_code == 403
     assert workspace_resp.json()["error"]["type"] == "forbidden"
 
@@ -131,7 +139,9 @@ def test_management_keys_are_pinned_to_their_workspace(client: TestClient, user_
     assert checkout_resp.json()["error"]["type"] == "forbidden"
 
 
-def test_users_have_uuid_ids_not_email_identifiers(client: TestClient, user_headers: dict[str, str]) -> None:
+def test_users_have_uuid_ids_not_email_identifiers(
+    client: TestClient, user_headers: dict[str, str]
+) -> None:
     org = client.post("/v1/workspaces", headers=user_headers, json={"name": "Org"}).json()["data"]
     org_headers = {**user_headers, "x-trustedrouter-workspace": org["id"]}
     add = client.post(
@@ -377,15 +387,25 @@ def test_dashboard_and_trust_pages_are_real_surfaces(client: TestClient) -> None
     assert providers_json.status_code == 200
     assert providers_json.headers["content-type"].startswith("application/json")
     provider_rows = providers_json.json()["data"]
-    assert [item["id"] for item in provider_rows[:2]] == ["tinfoil", "trustedrouter"]
+    assert [item["id"] for item in provider_rows[:2]] == ["trustedrouter", "tinfoil"]
+    display_groups = [
+        0
+        if item["id"] == "trustedrouter"
+        else 1
+        if item["provider_confidential_compute"] is True and item["provider_e2ee"] is True
+        else 2
+        if item["provider_zero_data_retention"] is True
+        or item["prepaid_zero_data_retention"] is True
+        else 3
+        for item in provider_rows
+    ]
+    assert display_groups == sorted(display_groups)
     tinfoil = next(item for item in provider_rows if item["id"] == "tinfoil")
     assert tinfoil["provider_e2ee"] is True
     openai = next(item for item in provider_rows if item["id"] == "openai")
     assert openai["provider_zero_data_retention"] is False
     assert openai["provider_confidential_compute"] is None
-    google_ai_studio = next(
-        item for item in provider_rows if item["id"] == "google-ai-studio"
-    )
+    google_ai_studio = next(item for item in provider_rows if item["id"] == "google-ai-studio")
     google_vertex = next(item for item in provider_rows if item["id"] == "google-vertex")
     assert google_ai_studio["provider_zero_data_retention"] is False
     assert google_ai_studio["supports_byok"] is True
@@ -634,9 +654,7 @@ def test_static_fonts_force_woff2_media_type(
     # Some minimal Linux images do not register WOFF2 in /etc/mime.types.
     # Simulate that production environment so the application owns the
     # browser-facing contract instead of relying on the host image.
-    monkeypatch.setattr(
-        "starlette.responses.guess_type", lambda _path: ("text/plain", None)
-    )
+    monkeypatch.setattr("starlette.responses.guess_type", lambda _path: ("text/plain", None))
 
     font = client.get("/static/fonts/archivo-latin.woff2")
 
@@ -905,6 +923,7 @@ def test_public_bearer_does_not_authenticate_or_use_durable_limiter(
 
 def test_rate_limit_does_not_touch_store_and_remains_local_on_store_error(monkeypatch) -> None:
     """Request admission must not depend on or amplify a storage outage."""
+
     def boom(self, *_args, **_kwargs):
         del self
         raise RuntimeError("Aborted: Deadlock with higher priority transaction.")
@@ -1057,12 +1076,17 @@ def test_production_control_plane_does_not_register_inference_routes() -> None:
     assert ("/v1/internal/gateway/authorize", "POST") not in registered
 
 
-def test_prompt_output_never_enter_metadata_store(client: TestClient, inference_headers: dict[str, str]) -> None:
+def test_prompt_output_never_enter_metadata_store(
+    client: TestClient, inference_headers: dict[str, str]
+) -> None:
     prompt = "super private user prompt"
     resp = client.post(
         "/v1/chat/completions",
         headers=inference_headers,
-        json={"model": "anthropic/claude-sonnet-4.6", "messages": [{"role": "user", "content": prompt}]},
+        json={
+            "model": "anthropic/claude-sonnet-4.6",
+            "messages": [{"role": "user", "content": prompt}],
+        },
     )
     assert resp.status_code == 200
     assert prompt not in str(STORE.generation_store.generations)
@@ -1302,9 +1326,7 @@ def test_in_memory_rate_limit_bucket_cardinality_is_capped() -> None:
     # is throttled collectively instead of resetting per identity.
     assert hit.allowed is False
     # Distinct subjects below the cap keep their own buckets untouched.
-    early = limits.hit(
-        namespace="internal", subject="fabricated-1", limit=3, window_seconds=60
-    )
+    early = limits.hit(namespace="internal", subject="fabricated-1", limit=3, window_seconds=60)
     assert early.allowed is True
 
 


### PR DESCRIPTION
## Summary
- refresh `/choose` from the live model/provider catalog and expose current route aliases
- rank public leaderboards by measured TTFT, using provider availability only as a tie-breaker
- order `/providers` as TrustedRouter, verified confidential providers, ZDR providers, then the remaining catalog
- remove redundant public TTFB columns

## Verification
- 121 focused Python tests passed
- 4 Playwright model-picker tests passed
- Ruff, JavaScript syntax, and diff checks passed

The LLM Advisor package was updated separately in Lore-Hex/LLM-advisor@28ba220.