### PR TITLE
Let the public surface see the analytics outbox it reports on

### DIFF
--- a/scripts/deploy/public_surface.sh
+++ b/scripts/deploy/public_surface.sh
@@ -318,6 +318,14 @@ ENV_VARS=(
   "TR_BIGTABLE_GENERATION_TABLE=$(legacy_env_required TR_BIGTABLE_GENERATION_TABLE)"
   "TR_BIGTABLE_MIRROR_WRITES_ENABLED=$(legacy_env_required TR_BIGTABLE_MIRROR_WRITES_ENABLED)"
   "TR_ANALYTICS_READ_MODE=${ANALYTICS_READ_MODE}"
+  # The public surface serves /status.json, whose analytics section reports
+  # outbox freshness. Without this flag the store is built with NO outbox
+  # object, the page publishes reason=not_configured, and stage (c) of
+  # verify-cloud-complete fails on every deploy — which is exactly what
+  # happened when this service took over the domain (#742). The API service
+  # does the enqueueing; this flag only lets the public store SEE the outbox
+  # to read the oldest undelivered row.
+  "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true"
   "TR_ENABLE_LIVE_PROVIDERS=false"
   "TR_GOOGLE_OAUTH_LOGIN_AVAILABLE=${GOOGLE_OAUTH_AVAILABLE}"
   "TR_GITHUB_OAUTH_LOGIN_AVAILABLE=${GITHUB_OAUTH_AVAILABLE}"

--- a/tests/test_cloud_rollout_completeness.py
+++ b/tests/test_cloud_rollout_completeness.py
@@ -1268,3 +1268,25 @@ def test_a_status_url_that_is_not_a_url_stops_the_run(tmp_path: Path) -> None:
     assert result.returncode == 1
     assert "not an https:// URL" in result.stderr
     assert harness.fetched_urls == []
+
+
+def test_every_gcp_surface_that_serves_status_builds_the_outbox() -> None:
+    """The surface that answers /status.json must be able to SEE the outbox.
+
+    When the T1 public website became its own service (#742) it took over
+    trustedrouter.com — including /status.json — with an env list that never
+    set TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED. Its store was built with no
+    outbox object, the page published `analytics.reason=not_configured`, and
+    stage (c) of verify-cloud-complete failed on every subsequent deploy
+    while the actual pipeline (enqueued by the API service) drained green.
+
+    The rollout script for any surface that serves the public status page
+    must therefore carry the flag. The API service's rollout.sh already
+    does; this pins the public one.
+    """
+    public = (ROOT / "scripts/deploy/public_surface.sh").read_text(encoding="utf-8")
+    assert '"TR_SERVICE_SURFACE=public"' in public
+    assert '"TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true"' in public
+
+    api = (ROOT / "scripts/deploy/rollout.sh").read_text(encoding="utf-8")
+    assert "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED" in api

--- a/tests/test_public_surface_deploy.py
+++ b/tests/test_public_surface_deploy.py
@@ -46,6 +46,10 @@ BASE_ENV = {
     "TR_BIGTABLE_GENERATION_TABLE": "trustedrouter-generations",
     "TR_BIGTABLE_MIRROR_WRITES_ENABLED": "true",
     "TR_ANALYTICS_READ_MODE": "clickhouse",
+    # The status page this surface serves reports outbox freshness; without
+    # this its store has no outbox object and publishes not_configured,
+    # failing verify-cloud-complete stage (c) on every deploy.
+    "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED": "true",
     "TR_ENABLE_LIVE_PROVIDERS": "false",
     "TR_GOOGLE_OAUTH_LOGIN_AVAILABLE": "true",
     "TR_GITHUB_OAUTH_LOGIN_AVAILABLE": "true",


### PR DESCRIPTION
Every deploy since the T1 cutover (#742) has failed
`verify-cloud-complete` at stage (c: analytics available):
`trustedrouter.com/status.json` publishes
`analytics: {available: false, reason: "not_configured"}`.

The regression is an env gap, not a dead pipeline. The new
`trusted-router-public` service took over the domain — including
`/status.json` — with an ENV_VARS list that never set
`TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED`. Its store is built with
`_operational_analytics_outbox = None` ([storage_gcp.py:481](src/trusted_router/storage_gcp.py#L481)), and the
freshness read at [storage_gcp.py:3741](src/trusted_router/storage_gcp.py#L3741) then truthfully answers
`not_configured`. Meanwhile the API service (which does the enqueueing)
still carries the flag and the drain is green — the reporting surface
just could not see the outbox it was asked to report on.

Timeline confirming: last green deploy 14:17Z; the first two failures
(17:16Z, 17:59Z) predate today's mutex PR entirely; the completeness
check reproduces locally with `bash scripts/deploy/verify_gcp_complete.sh`.

One line: the public surface's env list gains the flag, so its store
constructs the Spanner outbox object and can read the oldest
undelivered row. Enqueueing stays on the API service.

The pinned test asserts both status-serving surfaces carry the flag,
with the incident written into its docstring. The behavioral proof is
the live gate itself: after this deploys, `verify_gcp_complete.sh`
should exit 0 — I will verify that, not just the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)