### PR TITLE
Deploy restarts every daemon whose code it ships, not just one of them

### DIFF
--- a/scripts/deploy/clickhouse_live_ingestion.sh
+++ b/scripts/deploy/clickhouse_live_ingestion.sh
@@ -94,6 +94,21 @@ ssh_node --command="sudo sh -c '
   systemctl daemon-reload
   systemctl enable tr-clickhouse-ingest.service
   systemctl restart tr-clickhouse-ingest.service
+  # Restart EVERY long-running daemon whose code this deploy just replaced,
+  # not only the benchmark drain. On 2026-08-23 this script shipped a new
+  # ACTIVITY_COLUMNS allowlist while tr-clickhouse-operational-ingest kept the
+  # old module in memory: it silently dropped the new workspace_id key from
+  # every payload while systemctl reported active -- a running process says
+  # nothing about WHICH code it runs. Timer-driven oneshots pick up new code
+  # on their next fire and need no restart. The operational units are guarded
+  # on existence because they are installed by a different script (and the
+  # postgres variant only exists on the AWS/Azure nodes).
+  for unit in tr-clickhouse-operational-ingest.service tr-clickhouse-operational-ingest-postgres.service; do
+    if [ -f \"/etc/systemd/system/\$unit\" ]; then
+      systemctl restart \"\$unit\"
+      systemctl is-active \"\$unit\"
+    fi
+  done
   systemctl enable --now tr-clickhouse-reconcile.timer
   systemctl enable --now tr-clickhouse-archive.timer
   systemctl enable --now tr-clickhouse-archive-restore.timer

--- a/tests/test_clickhouse_operational_deploy.py
+++ b/tests/test_clickhouse_operational_deploy.py
@@ -358,3 +358,33 @@ def test_workspace_directory_is_on_demand_not_a_timer() -> None:
     # need the workspace_id column before the drain ships.
     assert "010_workspace_directory.sql" in deploy
     assert "012_activity_generations_workspace_id.sql" in deploy
+
+
+def test_live_ingestion_restarts_every_daemon_whose_code_it_ships() -> None:
+    """The deploy replaces /opt/tr-clickhouse wholesale, so every long-running
+    daemon on that tree must be restarted, not only the benchmark drain.
+
+    On 2026-08-23 this script shipped a new ACTIVITY_COLUMNS allowlist while
+    tr-clickhouse-operational-ingest kept the old module in memory: it
+    silently dropped the new workspace_id key from every payload, and
+    systemctl reported "active" throughout -- a running process says nothing
+    about which code it runs. Asserting only that the benchmark drain is
+    restarted was exactly the under-assertion that let this through.
+
+    Timer-driven oneshots (archive, rollups, reconcile) pick up new code on
+    their next fire and need no restart.
+    """
+    script = (ROOT / "scripts/deploy/clickhouse_live_ingestion.sh").read_text()
+
+    assert "systemctl restart tr-clickhouse-ingest.service" in script
+    # The operational drains restart through the guarded loop: both units are
+    # named, and the loop both restarts and re-asserts activeness. The guard
+    # exists because the postgres variant only exists on the AWS/Azure nodes.
+    loop = script[script.index("for unit in") : script.index("done", script.index("for unit in"))]
+    assert "tr-clickhouse-operational-ingest.service" in loop
+    assert "tr-clickhouse-operational-ingest-postgres.service" in loop
+    assert "systemctl restart" in loop
+    assert "systemctl is-active" in loop
+    # The restart must come AFTER the tree extraction that replaces the code,
+    # or it restarts the daemons into the same stale module.
+    assert script.index("tar -xzf - -C /opt/tr-clickhouse") < script.index("for unit in")


### PR DESCRIPTION
## The gap

`clickhouse_live_ingestion.sh` replaces `/opt/tr-clickhouse` wholesale, then restarted **only** `tr-clickhouse-ingest.service`. Every other long-running daemon on that tree kept its old module in memory.

On 2026-08-23 that was not hypothetical: the script shipped a new `ACTIVITY_COLUMNS` allowlist while `tr-clickhouse-operational-ingest` kept running the old one — silently dropping the new `workspace_id` key from every payload it projected, with `systemctl` reporting `active` the whole time. A running process says nothing about *which* code it runs; `is-active` cannot see stale modules.

## The fix

A restart loop after the tree extraction covering both operational drains, guarded on unit-file existence (they're installed by a different script, and the postgres variant only exists on the AWS/Azure nodes), each followed by the same `is-active` assertion the script already uses. Timer-driven oneshots (archive, rollups, reconcile) pick up new code on their next fire and need no restart.

## The verification worth mentioning

The edit sits inside `--command="sudo sh -c '...'"`, where a bare `"` or `$` truncates the remote command at runtime **while the outer script still passes `bash -n`**. So verification extracts the embedded block, unescapes it exactly as bash would (`\"`→`"`, `\$`→`$`), and runs `bash -n` on *that* — the remote shell's view, not the local file's.

## The test

Pins the loop, both unit names, the restart+assert pair, and the extract-before-restart ordering (restarting before extraction would bounce daemons back into the same stale module). Asserting only that the benchmark drain restarts was precisely the under-assertion that let this through. Removing the loop fails the test — verified by mutation.

`ruff` clean · `mypy` clean (299 files) · 21 tests green · mutation caught

🤖 Generated with [Claude Code](https://claude.com/claude-code)