### PR TITLE
Make the MCP server, the SDKs, and the company machine-readable

### DIFF
--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -328,6 +328,15 @@ class Settings(BaseSettings):
     legal_entity_name: str = "Lore Hex Corp"
     legal_entity_type: str = "Delaware C Corporation"
     legal_entity_address: str = "1111 Brickell Ave, Floor 10, Miami, FL 33131"
+    # Structured components of the same address. schema.org PostalAddress wants
+    # them separately, and splitting the display string at runtime would be a
+    # parser guessing at commas -- wrong the first time somebody adds a suite
+    # number. Kept beside the display string so the two are edited together.
+    legal_entity_street: str = "1111 Brickell Ave, Floor 10"
+    legal_entity_city: str = "Miami"
+    legal_entity_region: str = "FL"
+    legal_entity_postal_code: str = "33131"
+    legal_entity_country: str = "US"
     legal_entity_phone: str = "+1-305-239-7350"
     legal_entity_ein: str = "41-5339728"
     legal_entity_duns: str = "144992055"
@@ -1085,8 +1094,7 @@ class Settings(BaseSettings):
         surface = self.service_surface
         if self.attribution_cookie_key and self.attribution_cookie_secret:
             raise ValueError(
-                "TR_ATTRIBUTION_COOKIE_KEY and TR_ATTRIBUTION_COOKIE_SECRET "
-                "must not both be set"
+                "TR_ATTRIBUTION_COOKIE_KEY and TR_ATTRIBUTION_COOKIE_SECRET must not both be set"
             )
         attribution_cookie_key_bytes: bytes | None = None
         if self.attribution_cookie_key:
@@ -1096,13 +1104,9 @@ class Settings(BaseSettings):
                     validate=True,
                 )
             except (binascii.Error, ValueError) as exc:
-                raise ValueError(
-                    "TR_ATTRIBUTION_COOKIE_KEY must be valid base64"
-                ) from exc
+                raise ValueError("TR_ATTRIBUTION_COOKIE_KEY must be valid base64") from exc
             if len(attribution_cookie_key_bytes) != 32:
-                raise ValueError(
-                    "TR_ATTRIBUTION_COOKIE_KEY must decode to exactly 32 bytes"
-                )
+                raise ValueError("TR_ATTRIBUTION_COOKIE_KEY must decode to exactly 32 bytes")
         deployed_combined_bridge = (
             surface == "combined"
             and environment not in {"local", "test"}
@@ -1147,15 +1151,12 @@ class Settings(BaseSettings):
             raise ValueError("TR_MAX_REQUEST_BODY_BYTES must be positive")
         if self.max_in_flight_request_body_bytes < self.max_request_body_bytes:
             raise ValueError(
-                "TR_MAX_IN_FLIGHT_REQUEST_BODY_BYTES must be at least "
-                "TR_MAX_REQUEST_BODY_BYTES"
+                "TR_MAX_IN_FLIGHT_REQUEST_BODY_BYTES must be at least TR_MAX_REQUEST_BODY_BYTES"
             )
         if self.max_concurrent_request_bodies <= 0:
             raise ValueError("TR_MAX_CONCURRENT_REQUEST_BODIES must be positive")
         if not 0 < self.request_body_read_timeout_seconds <= 300:
-            raise ValueError(
-                "TR_REQUEST_BODY_READ_TIMEOUT_SECONDS must be between 0 and 300"
-            )
+            raise ValueError("TR_REQUEST_BODY_READ_TIMEOUT_SECONDS must be between 0 and 300")
         if self.rate_limit_window_seconds <= 0:
             raise ValueError("TR_RATE_LIMIT_WINDOW_SECONDS must be positive")
         for name, value in (
@@ -1166,9 +1167,7 @@ class Settings(BaseSettings):
             if value <= 0:
                 raise ValueError(f"{name} must be positive")
         if self.rate_limit_client_ip_mode not in {"untrusted", "edge_header"}:
-            raise ValueError(
-                "TR_RATE_LIMIT_CLIENT_IP_MODE must be 'untrusted' or 'edge_header'"
-            )
+            raise ValueError("TR_RATE_LIMIT_CLIENT_IP_MODE must be 'untrusted' or 'edge_header'")
         if self.signup_trial_credit_microdollars < 0:
             raise ValueError("TR_SIGNUP_TRIAL_CREDIT_MICRODOLLARS cannot be negative")
         for name, value in (
@@ -1225,13 +1224,9 @@ class Settings(BaseSettings):
             raise ValueError(
                 "TR_REGIONAL_QUOTA_RECONCILER_WORKER is valid only in worker processes"
             )
-        if (
-            self.regional_quota_lease_issuance_enabled
-            and not self.regional_quota_leases_enabled
-        ):
+        if self.regional_quota_lease_issuance_enabled and not self.regional_quota_leases_enabled:
             raise ValueError(
-                "TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED requires "
-                "TR_REGIONAL_QUOTA_LEASES_ENABLED"
+                "TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED requires TR_REGIONAL_QUOTA_LEASES_ENABLED"
             )
         if self.regional_quota_lease_issuance_enabled:
             if not self.regional_quota_lease_pilot_workspace_ids.strip():
@@ -1253,9 +1248,7 @@ class Settings(BaseSettings):
                         "TR_REGIONAL_QUOTA_LEASES_ENABLED requires typed request records"
                     )
                 if not self.settle_outbox_enabled:
-                    raise ValueError(
-                        "TR_REGIONAL_QUOTA_LEASES_ENABLED requires the settle outbox"
-                    )
+                    raise ValueError("TR_REGIONAL_QUOTA_LEASES_ENABLED requires the settle outbox")
                 if not self.bigtable_instance_id:
                     raise ValueError(
                         "TR_REGIONAL_QUOTA_LEASES_ENABLED requires a Bigtable instance"
@@ -1325,9 +1318,7 @@ class Settings(BaseSettings):
         if environment not in {"local", "test"} and any(
             not url.startswith("https://") for url in ops_chat_urls
         ):
-            raise ValueError(
-                "TR_OPS_CHAT_WEBHOOK_URLS must contain only HTTPS URLs when deployed"
-            )
+            raise ValueError("TR_OPS_CHAT_WEBHOOK_URLS must contain only HTTPS URLs when deployed")
         if not 1 <= self.google_data_manager_batch_size <= 2_000:
             raise ValueError("TR_GOOGLE_DATA_MANAGER_BATCH_SIZE must be between 1 and 2000")
         if self.google_data_manager_lease_seconds < 30:
@@ -1335,17 +1326,11 @@ class Settings(BaseSettings):
         if not 1 <= self.google_data_manager_max_attempts <= 20:
             raise ValueError("TR_GOOGLE_DATA_MANAGER_MAX_ATTEMPTS must be between 1 and 20")
         if not 1.0 <= self.google_data_manager_timeout_seconds <= 120.0:
-            raise ValueError(
-                "TR_GOOGLE_DATA_MANAGER_TIMEOUT_SECONDS must be between 1 and 120"
-            )
+            raise ValueError("TR_GOOGLE_DATA_MANAGER_TIMEOUT_SECONDS must be between 1 and 120")
         if not 1 <= self.google_data_manager_repair_lookback_days <= 90:
-            raise ValueError(
-                "TR_GOOGLE_DATA_MANAGER_REPAIR_LOOKBACK_DAYS must be between 1 and 90"
-            )
+            raise ValueError("TR_GOOGLE_DATA_MANAGER_REPAIR_LOOKBACK_DAYS must be between 1 and 90")
         if not 1 <= self.google_data_manager_status_poll_attempts <= 30:
-            raise ValueError(
-                "TR_GOOGLE_DATA_MANAGER_STATUS_POLL_ATTEMPTS must be between 1 and 30"
-            )
+            raise ValueError("TR_GOOGLE_DATA_MANAGER_STATUS_POLL_ATTEMPTS must be between 1 and 30")
         if not 0.1 <= self.google_data_manager_status_poll_seconds <= 30.0:
             raise ValueError(
                 "TR_GOOGLE_DATA_MANAGER_STATUS_POLL_SECONDS must be between 0.1 and 30"
@@ -1370,10 +1355,7 @@ class Settings(BaseSettings):
                 )
                 if not value
             ]
-            if (
-                environment not in {"local", "test"}
-                and not self.google_data_manager_kms_key_name
-            ):
+            if environment not in {"local", "test"} and not self.google_data_manager_kms_key_name:
                 missing_google_data_manager.append("TR_GOOGLE_DATA_MANAGER_KMS_KEY_NAME")
             if missing_google_data_manager:
                 raise ValueError(
@@ -1445,12 +1427,11 @@ class Settings(BaseSettings):
         missing = []
         if environment != "worker" and surface in {"control", "public"}:
             if not self.attribution_cookie_key and not self.attribution_cookie_secret:
-                missing.append(
-                    "TR_ATTRIBUTION_COOKIE_KEY or TR_ATTRIBUTION_COOKIE_SECRET"
-                )
-            elif self.attribution_cookie_secret and len(
-                self.attribution_cookie_secret.encode("utf-8")
-            ) < 32:
+                missing.append("TR_ATTRIBUTION_COOKIE_KEY or TR_ATTRIBUTION_COOKIE_SECRET")
+            elif (
+                self.attribution_cookie_secret
+                and len(self.attribution_cookie_secret.encode("utf-8")) < 32
+            ):
                 missing.append("TR_ATTRIBUTION_COOKIE_SECRET (at least 32 bytes)")
         if environment != "worker" and surface == "public":
             if self.google_oauth_login_available is None:
@@ -1494,9 +1475,7 @@ class Settings(BaseSettings):
                 self.internal_gateway_token.encode("utf-8"),
             )
         ):
-            missing.append(
-                "TR_ATTRIBUTION_COOKIE_KEY must differ from TR_INTERNAL_GATEWAY_TOKEN"
-            )
+            missing.append("TR_ATTRIBUTION_COOKIE_KEY must differ from TR_INTERNAL_GATEWAY_TOKEN")
         if (
             self.observer_internal_token
             and self.internal_gateway_token
@@ -1505,9 +1484,7 @@ class Settings(BaseSettings):
                 self.internal_gateway_token.encode("utf-8"),
             )
         ):
-            missing.append(
-                "TR_OBSERVER_INTERNAL_TOKEN must differ from TR_INTERNAL_GATEWAY_TOKEN"
-            )
+            missing.append("TR_OBSERVER_INTERNAL_TOKEN must differ from TR_INTERNAL_GATEWAY_TOKEN")
         if (
             self.observer_internal_token
             and self.synthetic_monitor_api_key
@@ -1517,8 +1494,7 @@ class Settings(BaseSettings):
             )
         ):
             missing.append(
-                "TR_OBSERVER_INTERNAL_TOKEN must differ from "
-                "TR_SYNTHETIC_MONITOR_API_KEY"
+                "TR_OBSERVER_INTERNAL_TOKEN must differ from TR_SYNTHETIC_MONITOR_API_KEY"
             )
 
         # #712 removes the temporary combined bridge.  Until then it retains
@@ -1567,9 +1543,7 @@ class Settings(BaseSettings):
                 and _sensitive_setting_is_configured(field_name, configured_value)
             ):
                 environment_name = f"TR_{field_name.upper()}"
-                missing.append(
-                    f"unset {environment_name} for TR_SERVICE_SURFACE={surface}"
-                )
+                missing.append(f"unset {environment_name} for TR_SERVICE_SURFACE={surface}")
         if self.bootstrap_management_key:
             missing.append("unset TR_BOOTSTRAP_MANAGEMENT_KEY")
         storage_required = surface != "actions"
@@ -1818,8 +1792,7 @@ class Settings(BaseSettings):
             profile = profile.strip()
             if not separator or not region or not profile:
                 raise ValueError(
-                    "TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES entries must be "
-                    "region=app-profile"
+                    "TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES entries must be region=app-profile"
                 )
             if region in profiles:
                 raise ValueError(

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -697,10 +697,7 @@ OPENROUTER_PAID_LANDING_VARIANTS: dict[str, OpenRouterLandingVariant] = {
 
 OPENROUTER_PAID_LANDING_PATHS: tuple[str, ...] = (
     "/openrouter-alternative/quickstart",
-    *tuple(
-        f"/openrouter-alternative/lp/{slug}"
-        for slug in OPENROUTER_PAID_LANDING_VARIANTS
-    ),
+    *tuple(f"/openrouter-alternative/lp/{slug}" for slug in OPENROUTER_PAID_LANDING_VARIANTS),
 )
 
 
@@ -1967,7 +1964,7 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
             ),
             (
                 "How do I make sure my prompts only reach US providers?",
-                "Set provider.jurisdiction to \"us\" on the request. The router then considers only providers whose recorded operator country is the United States and fails closed when none qualify, rather than falling back to a provider you did not approve. For an exact list rather than a country test, use provider.only with the provider slugs you approved.",
+                'Set provider.jurisdiction to "us" on the request. The router then considers only providers whose recorded operator country is the United States and fails closed when none qualify, rather than falling back to a provider you did not approve. For an exact list rather than a country test, use provider.only with the provider slugs you approved.',
             ),
             (
                 "Does a US provider mean my data stays in the United States?",
@@ -1999,7 +1996,7 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
             ),
             (
                 "Can I require an EU provider the way I can require a US one?",
-                "Not with the jurisdiction preference. provider.jurisdiction accepts \"us\" and nothing else today, so an EU requirement is expressed with provider.only and the provider list on this page. Separately, the EU gateway region is chosen by base URL: https://api-europe-west4.quillrouter.com/v1 begins authentication, policy checks, provider selection, and streaming in Europe West inside the attested gateway.",
+                'Not with the jurisdiction preference. provider.jurisdiction accepts "us" and nothing else today, so an EU requirement is expressed with provider.only and the provider list on this page. Separately, the EU gateway region is chosen by base URL: https://api-europe-west4.quillrouter.com/v1 begins authentication, policy checks, provider selection, and streaming in Europe West inside the attested gateway.',
             ),
             (
                 "Is provider jurisdiction the same as provider privacy posture?",
@@ -2023,7 +2020,7 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
             ),
             (
                 "How do I use a Chinese model without China-bound traffic?",
-                "Set provider.jurisdiction to \"us\" on the request. The router then considers only providers whose recorded operator country is the United States, and fails closed when none serve that model, rather than silently routing elsewhere. provider.only pins an exact operator allowlist when a country test is not specific enough.",
+                'Set provider.jurisdiction to "us" on the request. The router then considers only providers whose recorded operator country is the United States, and fails closed when none serve that model, rather than silently routing elsewhere. provider.only pins an exact operator allowlist when a country test is not specific enough.',
             ),
             (
                 "Which providers are operated from China?",
@@ -2136,6 +2133,7 @@ def dashboard_html(
         _env()
         .get_template("dashboard.html")
         .render(
+            organization_json_ld=_json_ld_graph(settings),
             api_base_url=resolved_api_base_url,
             site_url=site_url,
             canonical_site_url=canonical_site_url,
@@ -2232,12 +2230,21 @@ def _blog_index_posts(settings: Settings) -> tuple[BlogIndexPost, ...]:
     )
 
 
-def _json_ld_graph(*nodes: dict[str, object] | None) -> str:
+def _json_ld_graph(settings: Settings, *nodes: dict[str, object] | None) -> str:
+    """Every page's graph, with the operating company always in it.
+
+    The Organization node is prepended here rather than added at each call
+    site. There are a dozen of those and adding it to each would be a dozen
+    places to forget it, which matters because an assistant asked "who runs
+    this and how do I contact them" has no reason to have landed on whichever
+    page somebody remembered to annotate.
+    """
     graph = [node for node in nodes if node]
     if len(graph) == 1:
         payload: dict[str, object] = {"@context": "https://schema.org", **graph[0]}
     else:
-        payload = {"@context": "https://schema.org", "@graph": graph}
+        graph = [_organization_node(settings), *graph]
+    payload = {"@context": "https://schema.org", "@graph": graph}
     return json.dumps(payload, separators=(",", ":"))
 
 
@@ -2274,6 +2281,7 @@ def _faq_node(faq_items: Sequence[tuple[str, str]]) -> dict[str, object] | None:
 
 def _blog_index_json_ld(settings: Settings) -> str:
     return _json_ld_graph(
+        settings,
         _breadcrumb_node(settings, (("Home", "/"), ("Blog", "/blog"))),
         {
             "@type": "Blog",
@@ -2295,6 +2303,7 @@ def _blog_index_json_ld(settings: Settings) -> str:
 
 def _blog_post_json_ld(settings: Settings, post: BlogPost) -> str:
     return _json_ld_graph(
+        settings,
         _breadcrumb_node(
             settings,
             (("Home", "/"), ("Blog", "/blog"), (post.title, post.href)),
@@ -2316,6 +2325,80 @@ def _blog_post_json_ld(settings: Settings, post: BlogPost) -> str:
             "isBasedOn": post.source_url,
         },
     )
+
+
+def _organization_node(settings: Settings) -> dict[str, object]:
+    """The operating company, in the form a verifier can actually check.
+
+    Every Organization node on the site until now was a two-field publisher
+    stub -- name and url -- attached to a blog post or a dataset. None of them
+    said who operates TrustedRouter, how to reach a human, or where the company
+    is, which is exactly what an assistant is asked when somebody wants to know
+    whether a vendor is real before sending it traffic.
+
+    The values come from the same settings the legal and procurement pages
+    render, so this cannot drift into being a second, prettier set of facts.
+    contactPoint is split by purpose because "who do I email about a
+    vulnerability" and "who do I email about an invoice" are different
+    questions with different answers.
+    """
+    domain = settings.trusted_domain
+    return {
+        "@type": "Organization",
+        "@id": f"https://{domain}/#organization",
+        "name": "TrustedRouter",
+        "legalName": settings.legal_entity_name,
+        "url": f"https://{domain}/",
+        "logo": _absolute_url(settings, "/static/logo.png"),
+        # EIN and DUNS are already published on /legal for procurement. Repeating
+        # them here in the machine-readable node is the difference between a
+        # human being able to verify the company and an assistant being able to.
+        "taxID": settings.legal_entity_ein,
+        "duns": settings.legal_entity_duns,
+        "description": (
+            "An OpenAI-compatible AI router with an attested prompt path: one API "
+            "for hundreds of models across many providers, with provider fallback, "
+            "zero-retention routing, and a gateway whose running source commit and "
+            "image digest can be verified."
+        ),
+        "address": {
+            "@type": "PostalAddress",
+            "streetAddress": settings.legal_entity_street,
+            "addressLocality": settings.legal_entity_city,
+            "addressRegion": settings.legal_entity_region,
+            "postalCode": settings.legal_entity_postal_code,
+            "addressCountry": settings.legal_entity_country,
+        },
+        "contactPoint": [
+            {
+                "@type": "ContactPoint",
+                "contactType": "customer support",
+                "email": settings.support_email,
+                "telephone": settings.legal_entity_phone,
+                "url": f"https://{domain}/support",
+                "availableLanguage": ["en"],
+            },
+            {
+                "@type": "ContactPoint",
+                "contactType": "security",
+                "email": settings.security_contact_email,
+                "url": f"https://{domain}/security",
+                "availableLanguage": ["en"],
+            },
+            {
+                "@type": "ContactPoint",
+                "contactType": "sales",
+                "email": settings.support_email,
+                "telephone": settings.legal_entity_phone,
+                "url": f"https://{domain}/legal",
+                "availableLanguage": ["en"],
+            },
+        ],
+        "sameAs": [
+            "https://github.com/Lore-Hex",
+            f"https://{domain}/trust",
+        ],
+    }
 
 
 def _dataset_node(
@@ -2424,9 +2507,7 @@ def public_page_html(
         page_key=page_key,
         site_url=site_url,
         canonical_url_override=(
-            canonical_public_url(settings, canonical_path)
-            if canonical_path is not None
-            else None
+            canonical_public_url(settings, canonical_path) if canonical_path is not None else None
         ),
         robots_meta=robots_meta,
     )
@@ -2549,13 +2630,12 @@ def public_competitor_compare_index_html(settings: Settings) -> str:
             ),
             comparison_count=len(COMPETITOR_COMPARISONS),
             category_count=len(grouped),
-            source_count=sum(
-                len(comparison.sources) for comparison in COMPETITOR_COMPARISONS
+            source_count=sum(len(comparison.sources) for comparison in COMPETITOR_COMPARISONS),
+            verified_on_label=datetime.fromisoformat(COMPETITOR_COMPARISONS_VERIFIED_ON).strftime(
+                "%B %-d, %Y"
             ),
-            verified_on_label=datetime.fromisoformat(
-                COMPETITOR_COMPARISONS_VERIFIED_ON
-            ).strftime("%B %-d, %Y"),
             json_ld_blob=_json_ld_graph(
+                settings,
                 _breadcrumb_node(settings, (("Home", "/"), ("AI gateway comparisons", path))),
                 _item_list_node(name="TrustedRouter gateway comparisons", items=items),
             ),
@@ -2572,9 +2652,9 @@ def public_competitor_compare_html(settings: Settings, slug: str) -> str | None:
         return None
     path = comparison.href
     canonical_url = canonical_public_url(settings, path)
-    verified_on_label = datetime.fromisoformat(
-        COMPETITOR_COMPARISONS_VERIFIED_ON
-    ).strftime("%B %-d, %Y")
+    verified_on_label = datetime.fromisoformat(COMPETITOR_COMPARISONS_VERIFIED_ON).strftime(
+        "%B %-d, %Y"
+    )
     page_node: dict[str, object] = {
         "@type": "WebPage",
         "name": comparison.title,
@@ -2606,6 +2686,7 @@ def public_competitor_compare_html(settings: Settings, slug: str) -> str | None:
             verified_on_label=verified_on_label,
             faq_items=comparison.faq_items,
             json_ld_blob=_json_ld_graph(
+                settings,
                 _breadcrumb_node(
                     settings,
                     (("Home", "/"), ("Comparisons", "/compare"), (comparison.name, path)),
@@ -2642,9 +2723,9 @@ def _render_public_page(
     verified_on_label: str | None = None
     page_specific_json_ld: tuple[dict[str, object], ...] = ()
     if page_key == "openrouter-alternative":
-        verified_on_label = datetime.fromisoformat(
-            OPENROUTER_ALTERNATIVES_VERIFIED_ON
-        ).strftime("%B %-d, %Y")
+        verified_on_label = datetime.fromisoformat(OPENROUTER_ALTERNATIVES_VERIFIED_ON).strftime(
+            "%B %-d, %Y"
+        )
         page_specific_json_ld = (
             {
                 "@type": "WebPage",
@@ -2687,6 +2768,8 @@ def _render_public_page(
             catalog_evidence=catalog_evidence,
             verified_on_label=verified_on_label,
             json_ld_blob=_json_ld_graph(
+                settings,
+                _organization_node(settings),
                 _breadcrumb_node(settings, (("Home", "/"), (page.title, path))),
                 *page_specific_json_ld,
                 *extra_json_ld,
@@ -2810,6 +2893,10 @@ def public_legal_html(settings: Settings) -> str:
         _env()
         .get_template("public/legal.html")
         .render(
+            # /legal is the procurement page: the entity, EIN and DUNS are
+            # already rendered here for humans, and this is the machine-readable
+            # form of the same facts.
+            json_ld_blob=_json_ld_graph(settings),
             api_base_url=settings.api_base_url,
             site_url=f"https://{settings.trusted_domain}/legal",
             title="Legal And Procurement Packet | TrustedRouter",
@@ -2903,6 +2990,9 @@ def public_support_html(settings: Settings) -> str:
         _env()
         .get_template("public/support.html")
         .render(
+            # The page an assistant reaches for a contact query, so the
+            # contactPoint block belongs here more than anywhere.
+            json_ld_blob=_json_ld_graph(settings),
             api_base_url=settings.api_base_url,
             site_url=f"https://{settings.trusted_domain}/support",
             title="Support | TrustedRouter",
@@ -2948,6 +3038,7 @@ def public_bedrock_group_buy_html(
             og_image=(f"https://{settings.trusted_domain}/static/og/bedrock-group-buy.png"),
             og_image_alt=("TrustedRouter Bedrock Group Buy: $1 million per month and 10% savings"),
             json_ld_blob=_json_ld_graph(
+                settings,
                 _breadcrumb_node(
                     settings,
                     (("Home", "/"), ("Bedrock Group Buy", "/bedrock-group-buy")),
@@ -3150,6 +3241,7 @@ def public_models_html(settings: Settings, *, model_filter: str = "all") -> str:
                 {"id": "eu", "label": "EU-focused", "href": "/models?filter=eu"},
             ],
             json_ld_blob=_json_ld_graph(
+                settings,
                 _breadcrumb_node(settings, (("Home", "/"), ("Models", "/models"))),
                 _item_list_node(
                     name="TrustedRouter model catalog",
@@ -3182,8 +3274,7 @@ def public_benchmarks_html(settings: Settings) -> str:
             providers=[_provider_view(provider) for provider in providers_for_display()],
             benchmark_links=list(_BENCHMARK_INDEX_LINKS),
             monthly_reports=[
-                monthly_benchmark_report_view(report)
-                for report in monthly_benchmark_reports()
+                monthly_benchmark_report_view(report) for report in monthly_benchmark_reports()
             ],
             google_enabled=settings.google_oauth_enabled,
             github_enabled=settings.github_oauth_enabled,
@@ -3193,9 +3284,7 @@ def public_benchmarks_html(settings: Settings) -> str:
 
 
 def public_benchmark_reports_index_html(settings: Settings) -> str:
-    reports = [
-        monthly_benchmark_report_view(report) for report in monthly_benchmark_reports()
-    ]
+    reports = [monthly_benchmark_report_view(report) for report in monthly_benchmark_reports()]
     return (
         _env()
         .get_template("public/benchmark_reports_index.html")
@@ -3210,6 +3299,7 @@ def public_benchmark_reports_index_html(settings: Settings) -> str:
             ),
             reports=reports,
             json_ld_blob=_json_ld_graph(
+                settings,
                 _breadcrumb_node(
                     settings,
                     (
@@ -3312,6 +3402,7 @@ def public_leaderboard_html(settings: Settings, snapshot: dict[str, object]) -> 
             page_kind="leaderboard",
             snapshot=snapshot,
             json_ld_blob=_json_ld_graph(
+                settings,
                 _breadcrumb_node(settings, (("Home", "/"), ("Leaderboard", "/leaderboard"))),
                 _dataset_node(
                     name="TrustedRouter LLM provider and model speed leaderboard",
@@ -3346,6 +3437,7 @@ def public_video_leaderboard_html(settings: Settings, snapshot: dict[str, object
             page_kind="video-leaderboard",
             snapshot=snapshot,
             json_ld_blob=_json_ld_graph(
+                settings,
                 _breadcrumb_node(
                     settings,
                     (
@@ -3491,6 +3583,7 @@ def public_providers_html(settings: Settings) -> str:
             ),
             providers=providers,
             json_ld_blob=_json_ld_graph(
+                settings,
                 _breadcrumb_node(settings, (("Home", "/"), ("Providers", "/providers"))),
                 _item_list_node(
                     name="TrustedRouter provider catalog",
@@ -3536,6 +3629,7 @@ def public_provider_detail_html(settings: Settings, provider_slug: str) -> str |
             measured=measured_for_provider(provider.slug, test_mode=settings.environment == "test"),
             faq_items=provider_faq_items,
             json_ld_blob=_json_ld_graph(
+                settings,
                 _breadcrumb_node(
                     settings,
                     (
@@ -3601,6 +3695,7 @@ def public_provider_performance_html(settings: Settings, provider_slug: str) -> 
             ),
             measured=measured,
             json_ld_blob=_json_ld_graph(
+                settings,
                 _breadcrumb_node(
                     settings,
                     (
@@ -3717,6 +3812,7 @@ def public_model_compare_html(settings: Settings, left_id: str, right_id: str) -
             comparison_neighbors=_model_comparison_neighbor_rows(left.id, right.id),
             faq_items=faq_items,
             json_ld_blob=_json_ld_graph(
+                settings,
                 _breadcrumb_node(
                     settings,
                     (
@@ -3782,6 +3878,7 @@ def public_model_compare_index_html(settings: Settings, *, page: int = 1) -> str
                 for number in range(1, page_count + 1)
             ],
             json_ld_blob=_json_ld_graph(
+                settings,
                 _breadcrumb_node(
                     settings,
                     (("Home", "/"), ("Models", "/models"), ("Compare models", site_path)),
@@ -4008,49 +4105,51 @@ def llms_txt(settings: Settings) -> str:
         ),
         "",
         "## Primary Links",
-        f"- Homepage: https://{domain}/",
-        f"- Models: https://{domain}/models",
-        f"- Providers: https://{domain}/providers",
-        f"- AI gateway comparisons: https://{domain}/compare",
-        f"- Provider marketplace: https://{domain}/providers/marketplace",
+        f"- [Homepage](https://{domain}/)",
+        f"- [Models](https://{domain}/models)",
+        f"- [Providers](https://{domain}/providers)",
+        f"- [AI gateway comparisons](https://{domain}/compare)",
+        f"- [Provider marketplace](https://{domain}/providers/marketplace)",
         (
             "- Model origin vs serving jurisdiction directories (the lab that built a "
-            f"model and the company operating each route are separate): https://{domain}"
-            f"/us-ai-models, https://{domain}/eu-ai-models, https://{domain}/china-ai-models"
+            "model and the company operating each route are separate): "
+            f"[US]({f'https://{domain}/us-ai-models'}), "
+            f"[EU]({f'https://{domain}/eu-ai-models'}), "
+            f"[China]({f'https://{domain}/china-ai-models'})"
         ),
-        f"- EU routing: https://{domain}/eu",
-        f"- TrustedOS for AI clouds: https://{domain}/trustedos",
-        f"- Benchmarks: https://{domain}/benchmarks",
-        f"- Rankings: https://{domain}/rankings",
-        "- Status: https://status.trustedrouter.com/",
-        "- Trust: https://trust.trustedrouter.com/",
-        f"- Legal/procurement packet: https://{domain}/legal",
-        f"- SOC 2 readiness: https://{domain}/legal/soc2-readiness",
-        f"- HIPAA readiness: https://{domain}/legal/hipaa-readiness",
-        f"- Agent setup: https://{domain}/docs/agent-setup",
-        f"- Agent model-advisor skill/playbook: https://{domain}/docs/agent-setup#codex-skill",
+        f"- [EU routing](https://{domain}/eu)",
+        f"- [TrustedOS for AI clouds](https://{domain}/trustedos)",
+        f"- [Benchmarks](https://{domain}/benchmarks)",
+        f"- [Rankings](https://{domain}/rankings)",
+        "- [Status](https://status.trustedrouter.com/)",
+        "- [Trust](https://trust.trustedrouter.com/)",
+        f"- [Legal/procurement packet](https://{domain}/legal)",
+        f"- [SOC 2 readiness](https://{domain}/legal/soc2-readiness)",
+        f"- [HIPAA readiness](https://{domain}/legal/hipaa-readiness)",
+        f"- [Agent setup](https://{domain}/docs/agent-setup)",
+        f"- [Agent model-advisor skill/playbook](https://{domain}/docs/agent-setup#codex-skill)",
         "- Agent skill name: trustedrouter-model-advisor",
-        "- Agent playbook source: https://github.com/Lore-Hex/LLM-advisor",
-        "- Raw agent playbook: https://raw.githubusercontent.com/Lore-Hex/LLM-advisor/main/SKILL.md",
-        f"- MCP server: https://{domain}/docs/mcp",
-        f"- Evals guide: https://{domain}/docs/evals",
-        f"- Provider conformance suite: https://{domain}/docs/provider-conformance",
-        f"- Synth guide: https://{domain}/docs/synth",
-        f"- Responses web search: https://{domain}/docs/web-search",
-        f"- Prompt caching: https://{domain}/docs/prompt-caching",
-        f"- Batch API: https://{domain}/docs/batch",
-        f"- Video generation: https://{domain}/docs/video",
-        f"- Request tagging and cost allocation: https://{domain}/docs/tagging",
-        f"- Client reliability telemetry: https://{domain}/docs/telemetry",
-        f"- Blog: https://{domain}/blog",
-        f"- Migration guide: https://{domain}/docs/migrate-from-openrouter",
-        f"- Request tagging and cost allocation: https://{domain}/docs/tagging",
-        f"- Client reliability telemetry: https://{domain}/docs/telemetry",
+        "- [Agent playbook source](https://github.com/Lore-Hex/LLM-advisor)",
+        "- [Raw agent playbook](https://raw.githubusercontent.com/Lore-Hex/LLM-advisor/main/SKILL.md)",
+        f"- [MCP server](https://{domain}/docs/mcp)",
+        f"- [Evals guide](https://{domain}/docs/evals)",
+        f"- [Provider conformance suite](https://{domain}/docs/provider-conformance)",
+        f"- [Synth guide](https://{domain}/docs/synth)",
+        f"- [Responses web search](https://{domain}/docs/web-search)",
+        f"- [Prompt caching](https://{domain}/docs/prompt-caching)",
+        f"- [Batch API](https://{domain}/docs/batch)",
+        f"- [Video generation](https://{domain}/docs/video)",
+        f"- [Request tagging and cost allocation](https://{domain}/docs/tagging)",
+        f"- [Client reliability telemetry](https://{domain}/docs/telemetry)",
+        f"- [Blog](https://{domain}/blog)",
+        f"- [Migration guide](https://{domain}/docs/migrate-from-openrouter)",
+        f"- [Request tagging and cost allocation](https://{domain}/docs/tagging)",
+        f"- [Client reliability telemetry](https://{domain}/docs/telemetry)",
         "",
         "## API",
-        "- OpenAI compatible base URL: https://api.trustedrouter.com/v1",
-        "- EU regional base URL: https://api-europe-west4.quillrouter.com/v1",
-        f"- Canonical live model catalog (public, no API key): https://{domain}/v1/models",
+        "- [OpenAI compatible base URL](https://api.trustedrouter.com/v1)",
+        "- [EU regional base URL](https://api-europe-west4.quillrouter.com/v1)",
+        f"- [Canonical live model catalog (public, no API key)](https://{domain}/v1/models)",
         (
             "- Read the live model catalog before naming current model IDs, prices, "
             "context windows, or provider availability. This concise llms.txt is a "
@@ -4072,22 +4171,22 @@ def llms_txt(settings: Settings) -> str:
         "",
         "## Developer Resources",
         (
-            "- Named so an agent searching for \"TrustedRouter API docs\", \"TrustedRouter "
-            "OpenAPI spec\" or \"TrustedRouter MCP server\" finds the exact URL here "
+            '- Named so an agent searching for "TrustedRouter API docs", "TrustedRouter '
+            'OpenAPI spec" or "TrustedRouter MCP server" finds the exact URL here '
             "rather than having to guess paths."
         ),
-        f"- TrustedRouter API documentation: https://{domain}/docs",
-        f"- TrustedRouter OpenAPI specification (JSON): https://{domain}/openapi.json",
-        f"- TrustedRouter interactive API reference: https://{domain}/docs",
-        f"- TrustedRouter authentication: https://{domain}/docs#authentication",
-        f"- TrustedRouter MCP server: https://{domain}/docs/mcp",
-        f"- TrustedRouter agent setup guide: https://{domain}/docs/agent-setup",
-        f"- TrustedRouter SDK quickstarts: https://{domain}/docs#sdks",
-        f"- TrustedRouter status page: https://status.{domain}/",
-        f"- TrustedRouter attestation and trust evidence: https://trust.{domain}/",
-        f"- This index: https://{domain}/llms.txt",
-        f"- Extended index with full page text: https://{domain}/llms-full.txt",
-        f"- Machine-readable URL list: https://{domain}/sitemap.xml",
+        f"- [TrustedRouter API documentation](https://{domain}/docs)",
+        f"- [TrustedRouter OpenAPI specification (JSON)](https://{domain}/openapi.json)",
+        f"- [TrustedRouter interactive API reference](https://{domain}/docs)",
+        f"- [TrustedRouter authentication](https://{domain}/docs#authentication)",
+        f"- [TrustedRouter MCP server](https://{domain}/docs/mcp)",
+        f"- [TrustedRouter agent setup guide](https://{domain}/docs/agent-setup)",
+        f"- [TrustedRouter SDK quickstarts](https://{domain}/docs#sdks)",
+        f"- [TrustedRouter status page](https://status.{domain}/)",
+        f"- [TrustedRouter attestation and trust evidence](https://trust.{domain}/)",
+        f"- [This index](https://{domain}/llms.txt)",
+        f"- [Extended index with full page text](https://{domain}/llms-full.txt)",
+        f"- [Machine-readable URL list](https://{domain}/sitemap.xml)",
         "",
         "## Catalog",
         f"- Public model pages: {model_count}",
@@ -4867,7 +4966,7 @@ def _model_section_json_ld(
                 keywords=("LLM latency", model.name, "provider performance"),
             )
         )
-    return _json_ld_graph(*nodes)
+    return _json_ld_graph(settings, *nodes)
 
 
 def _sample_count(row: Mapping[str, object]) -> int:
@@ -5450,6 +5549,7 @@ def _model_json_ld(
     as USD per million tokens, matching the unit the page itself displays.
     """
     return _json_ld_graph(
+        settings,
         _breadcrumb_node(
             settings,
             (("Home", "/"), ("Models", "/models"), (model.name, f"/models/{model.id}")),

--- a/src/trusted_router/routes/mcp.py
+++ b/src/trusted_router/routes/mcp.py
@@ -40,9 +40,7 @@ MAX_MCP_BATCH_ITEMS = 32
 MAX_MCP_CHAT_BATCH_ITEMS = 1
 MAX_MCP_EXPENSIVE_BATCH_ITEMS = 4
 MAX_MCP_STORAGE_BATCH_ITEMS = 4
-_EXPENSIVE_TOOLS = frozenset(
-    {"models-list", "model-endpoints", "providers-list", "docs-search"}
-)
+_EXPENSIVE_TOOLS = frozenset({"models-list", "model-endpoints", "providers-list", "docs-search"})
 _STORAGE_TOOLS = frozenset({"credits-get", "generation-get"})
 _MCP_AUTH_STATE_KEY = "trusted_router_mcp_auth"
 _API_KEY_BEARER_PREFIX = "sk-tr-"
@@ -289,9 +287,7 @@ class TrustedRouterMCP:
             }
         )
 
-    async def _tool_generation_get(
-        self, args: dict[str, Any], request: Request
-    ) -> dict[str, Any]:
+    async def _tool_generation_get(self, args: dict[str, Any], request: Request) -> dict[str, Any]:
         api_key = self._require_api_key(request).api_key
         generation_id = _bounded_string(
             args,
@@ -431,11 +427,7 @@ class TrustedRouterMCP:
             setattr(request.state, _MCP_AUTH_STATE_KEY, error)
             raise error
         api_key = context.api_key
-        if (
-            api_key.disabled
-            or is_api_key_expired(api_key.expires_at)
-            or context.workspace is None
-        ):
+        if api_key.disabled or is_api_key_expired(api_key.expires_at) or context.workspace is None:
             error = MCPToolError(
                 "Invalid TrustedRouter API key",
                 status_code=401,
@@ -540,7 +532,11 @@ def _tool_schema(
     read_only: bool = True,
 ) -> dict[str, Any]:
     clean_properties = {
-        key: {inner_key: inner_value for inner_key, inner_value in value.items() if inner_key != "optional"}
+        key: {
+            inner_key: inner_value
+            for inner_key, inner_value in value.items()
+            if inner_key != "optional"
+        }
         for key, value in properties.items()
     }
     return {
@@ -576,9 +572,7 @@ def _tool_json(payload: Any) -> dict[str, Any]:
 
 def _is_internal_model_shape(shape: dict[str, Any]) -> bool:
     trustedrouter = shape.get("trustedrouter")
-    return bool(
-        isinstance(trustedrouter, dict) and trustedrouter.get("internal_only")
-    )
+    return bool(isinstance(trustedrouter, dict) and trustedrouter.get("internal_only"))
 
 
 def _tool_text(text: str, *, is_error: bool = False) -> dict[str, Any]:
@@ -594,9 +588,7 @@ def _bearer_token(request: Request) -> str:
 
 def _is_api_key_bearer(bearer: str) -> bool:
     """Recognize the same versioned API-key family used by normal auth."""
-    return bearer.startswith(_API_KEY_BEARER_PREFIX) and len(bearer) > len(
-        _API_KEY_BEARER_PREFIX
-    )
+    return bearer.startswith(_API_KEY_BEARER_PREFIX) and len(bearer) > len(_API_KEY_BEARER_PREFIX)
 
 
 def _top_level_tool_names(payload: Any) -> list[str]:

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -127,6 +127,7 @@ from trusted_router.provider_contract import (
 )
 from trusted_router.public_analytics_snapshots import current_public_analytics_snapshot
 from trusted_router.request_limits import normalized_client_identity
+from trusted_router.routes.mcp import MCP_PROTOCOL_VERSION
 from trusted_router.serialization import user_model_public_shape
 from trusted_router.services.email import EmailMessage, get_email_service
 from trusted_router.services.ops_chat import OpsChatSupportMessage, fanout_support_message
@@ -316,10 +317,7 @@ def _inquiry_client_identity(request: Request, settings: Settings) -> str:
     contract and never trust forwarding headers or an arbitrary socket peer.
     """
 
-    if (
-        settings.service_surface == "combined"
-        and settings.allow_deployed_combined_surface
-    ):
+    if settings.service_surface == "combined" and settings.allow_deployed_combined_surface:
         return request.client.host if request.client else "unknown"
     return normalized_client_identity(request, settings)
 
@@ -1022,10 +1020,7 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     async def seo_openrouter_alternative(
         request: Request,
     ) -> Response:
-        if (
-            request.query_params.get("utm_campaign")
-            in OPENROUTER_LANDING_EXPERIMENT_CAMPAIGNS
-        ):
+        if request.query_params.get("utm_campaign") in OPENROUTER_LANDING_EXPERIMENT_CAMPAIGNS:
             return openrouter_landing_experiment_redirect(request)
         return HTMLResponse(public_page_html(settings, "openrouter-alternative"))
 
@@ -1445,6 +1440,51 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
             headers={"cache-control": "public, max-age=300, s-maxage=3600"},
         )
 
+    @app.get("/.well-known/mcp.json", include_in_schema=False)
+    async def mcp_discovery() -> JSONResponse:
+        """Where the MCP server is, for a client that has only the domain.
+
+        Lives with the public documents rather than beside the MCP endpoint
+        itself: /mcp is authenticated and mounted on the control surface, while
+        discovery has to be reachable by anyone holding only the hostname. The
+        surface-routing contract caught the first version of this, which was
+        registered next to the server and so was absent from the public app the
+        URL map points at.
+
+        Everything needed to connect was published in prose on /docs/mcp: the
+        URL, the transport, that it wants a Bearer key. An agent handed
+        "trustedrouter.com" and asked to use its MCP server had to read a
+        marketing page to find them, which is the same discoverability gap that
+        made openapi.json unfindable.
+
+        This mirrors the values the server itself reports at `initialize`
+        rather than restating them, so the document cannot describe a server
+        different from the one that answers.
+        """
+        domain = settings.trusted_domain
+        return JSONResponse(
+            {
+                "name": "trustedrouter",
+                "description": (
+                    "Model catalog, provider metadata, routing advice and inference "
+                    "across hundreds of models through one OpenAI-compatible gateway."
+                ),
+                "version": settings.release,
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "transport": "http",
+                "url": f"https://{domain}/mcp",
+                "authentication": {
+                    "type": "http",
+                    "scheme": "bearer",
+                    "description": "A TrustedRouter API key: Authorization: Bearer sk-tr-...",
+                    "tokenUrl": f"https://{domain}/console/keys",
+                },
+                "capabilities": {"tools": {}},
+                "documentation": f"https://{domain}/docs/mcp",
+            },
+            headers={"cache-control": "public, max-age=300, s-maxage=3600"},
+        )
+
     @app.api_route("/llms.txt", methods=["GET", "HEAD"], response_class=PlainTextResponse)
     async def llms() -> PlainTextResponse:
         return PlainTextResponse(
@@ -1758,18 +1798,12 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
         body = public_model_detail_html(settings, cleaned)
         if body is None:
             user_model = STORE.get_user_model(normalize_custom_model_id(cleaned))
-            if (
-                user_model is not None
-                and user_model.enabled
-                and user_model.status == "active"
-            ):
+            if user_model is not None and user_model.enabled and user_model.status == "active":
                 shape = user_model_public_shape(user_model)
                 body = render_template(
                     "public/user_model_detail.html",
                     api_base_url=settings.api_base_url,
-                    site_url=(
-                        f"https://{settings.trusted_domain}/models/{user_model.id}"
-                    ),
+                    site_url=(f"https://{settings.trusted_domain}/models/{user_model.id}"),
                     title=f"{user_model.name} | User-provided model",
                     heading=user_model.name,
                     description=shape["privacy_notice"],
@@ -2330,9 +2364,7 @@ def _apply_public_client_observed_policy(
 ) -> dict[str, Any]:
     result = dict(payload)
     if not settings.public_client_observed_enabled:
-        result["client_observed"] = _client_observed_liveness(
-            result.get("client_observed")
-        )
+        result["client_observed"] = _client_observed_liveness(result.get("client_observed"))
     return result
 
 

--- a/src/trusted_router/templates/dashboard.html
+++ b/src/trusted_router/templates/dashboard.html
@@ -39,6 +39,9 @@
   <link rel="preload" href="/static/fonts/spectral-300-latin.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/static/dashboard.css?v={{ static_version|default('local') }}">
   <link rel="stylesheet" href="/static/charter.css?v={{ static_version|default('local') }}">
+  {# The homepage carried no structured data at all, which is the page an
+     assistant is most likely to land on when asked who operates this. #}
+  {% if organization_json_ld %}<script type="application/ld+json" nonce="{{ csp_nonce() }}">{{ organization_json_ld|safe }}</script>{% endif %}
   <script nonce="{{ csp_nonce() }}">window.__TR__ = {{ tr_config | safe }};</script>
   <script src="/static/dashboard.js?v={{ static_version|default('local') }}" defer></script>
 </head>

--- a/src/trusted_router/templates/public/docs.html
+++ b/src/trusted_router/templates/public/docs.html
@@ -89,7 +89,12 @@ const r = await client.chat.completions.create({
   <div class="repo-grid">
     <a class="repo-card" href="https://github.com/Lore-Hex/trusted-router-py"><span class="mono">trusted-router-py</span><span class="repo-sub">Python SDK</span></a>
     <a class="repo-card" href="https://github.com/Lore-Hex/trusted-router-js"><span class="mono">trusted-router-js</span><span class="repo-sub">TypeScript SDK</span></a>
-    <a class="repo-card" href="https://github.com/jperla/trusted-router-swift"><span class="mono">trusted-router-swift</span><span class="repo-sub">Swift SDK</span></a>
+    <a class="repo-card" href="https://github.com/Lore-Hex/trusted-router-go"><span class="mono">trusted-router-go</span><span class="repo-sub">Go SDK</span></a>
+    <a class="repo-card" href="https://github.com/Lore-Hex/trusted-router-rust"><span class="mono">trusted-router-rust</span><span class="repo-sub">Rust SDK</span></a>
+    <a class="repo-card" href="https://github.com/Lore-Hex/trusted-router-swift"><span class="mono">trusted-router-swift</span><span class="repo-sub">Swift SDK</span></a>
+    <a class="repo-card" href="https://github.com/Lore-Hex/trusted-router-java"><span class="mono">trusted-router-java</span><span class="repo-sub">Java SDK</span></a>
+    <a class="repo-card" href="https://github.com/Lore-Hex/trustedrouter-ai-sdk-provider"><span class="mono">trustedrouter-ai-sdk-provider</span><span class="repo-sub">Vercel AI SDK provider</span></a>
+    <a class="repo-card" href="https://github.com/Lore-Hex/trustedrouter-provider-check"><span class="mono">trustedrouter-provider-check</span><span class="repo-sub">Provider conformance suite</span></a>
     <a class="repo-card" href="https://github.com/Lore-Hex/quill-router"><span class="mono">quill-router</span><span class="repo-sub">Open-source router</span></a>
   </div>
   <div class="public-proof-strip" style="margin-top:18px">

--- a/src/trusted_router/trust.py
+++ b/src/trusted_router/trust.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from trusted_router.config import Settings
+from trusted_router.dashboard import _organization_node
 from trusted_router.domains import (
     api_base_url_for_domain,
     canonical_public_url,
@@ -340,19 +341,27 @@ def trust_html(
         "TLS boundary, and open-source deployment before sending prompts."
     )
     og_image = html.escape(canonical_public_url(settings, "/og.png"), quote=True)
+    # The @graph form so the operating company travels with the page. /trust is
+    # where somebody lands to decide whether this vendor is real, which makes it
+    # the worst page to omit the contact and address from.
     trust_json_ld = json.dumps(
         {
             "@context": "https://schema.org",
-            "@type": "WebPage",
-            "name": trust_title,
-            "description": trust_description,
-            "url": canonical_public_url(settings, "/trust"),
-            "about": {
-                "@type": "SoftwareApplication",
-                "name": "TrustedRouter",
-                "applicationCategory": "DeveloperApplication",
-                "codeRepository": ATTESTED_GATEWAY_REPO,
-            },
+            "@graph": [
+                _organization_node(settings),
+                {
+                    "@type": "WebPage",
+                    "name": trust_title,
+                    "description": trust_description,
+                    "url": canonical_public_url(settings, "/trust"),
+                    "about": {
+                        "@type": "SoftwareApplication",
+                        "name": "TrustedRouter",
+                        "applicationCategory": "DeveloperApplication",
+                        "codeRepository": ATTESTED_GATEWAY_REPO,
+                    },
+                },
+            ],
         },
         separators=(",", ":"),
     ).replace("<", "\\u003c")

--- a/tests/test_agent_discovery_round2.py
+++ b/tests/test_agent_discovery_round2.py
@@ -1,0 +1,142 @@
+"""Discovery surfaces an assistant needs when handed only the domain.
+
+Each of these existed as prose on a marketing page and nowhere a machine could
+read it. That is the same gap openapi.json had: published, documented, and
+unfindable without first reading a page written for humans.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+from fastapi.testclient import TestClient
+
+from trusted_router.config import Settings
+from trusted_router.dashboard import llms_txt
+
+PAGES_WITH_STRUCTURED_DATA = ["/", "/trust", "/docs", "/models", "/legal", "/support"]
+
+
+def _organization(html: str) -> dict | None:
+    for blob in re.findall(r"application/ld\+json[^>]*>(.*?)</script>", html, re.S):
+        try:
+            graph = json.loads(blob)
+        except json.JSONDecodeError:
+            continue
+        for node in graph.get("@graph", [graph]):
+            if node.get("@type") == "Organization" and "address" in node:
+                return node
+    return None
+
+
+@pytest.mark.parametrize("path", PAGES_WITH_STRUCTURED_DATA)
+def test_every_key_page_identifies_the_operating_company(client: TestClient, path: str) -> None:
+    """Not just the homepage. An assistant asked who runs this has no reason to
+    have landed on whichever page somebody remembered to annotate."""
+    node = _organization(client.get(path, headers={"accept": "text/html"}).text)
+
+    assert node is not None, path
+    assert node["legalName"] == "Lore Hex Corp"
+
+
+def test_the_organization_node_answers_a_contact_query(client: TestClient) -> None:
+    node = _organization(client.get("/", headers={"accept": "text/html"}).text)
+    assert node is not None
+
+    address = node["address"]
+    assert address["@type"] == "PostalAddress"
+    assert address["streetAddress"] == "1111 Brickell Ave, Floor 10"
+    assert address["addressLocality"] == "Miami"
+    assert address["addressRegion"] == "FL"
+    assert address["postalCode"] == "33131"
+    assert address["addressCountry"] == "US"
+
+    contact_types = {point["contactType"] for point in node["contactPoint"]}
+    assert {"customer support", "security", "sales"} <= contact_types
+    assert any(point.get("telephone") for point in node["contactPoint"])
+    assert all(point.get("email") for point in node["contactPoint"])
+
+
+def test_the_organization_node_carries_verifiable_identifiers(
+    client: TestClient,
+) -> None:
+    """EIN and DUNS are the fields a procurement check actually looks up, and
+    they were human-readable on /legal only."""
+    node = _organization(client.get("/legal", headers={"accept": "text/html"}).text)
+
+    assert node is not None
+    assert node["taxID"] == "41-5339728"
+    assert node["duns"] == "144992055"
+
+
+def test_the_mcp_server_is_discoverable_without_reading_a_page(
+    client: TestClient,
+) -> None:
+    """Everything needed to connect was prose on /docs/mcp."""
+    document = client.get("/.well-known/mcp.json").json()
+
+    assert document["url"].endswith("/mcp")
+    assert document["transport"] == "http"
+    assert document["authentication"]["scheme"] == "bearer"
+    assert document["protocolVersion"]
+
+
+def test_the_discovery_document_matches_the_server_it_describes(
+    client: TestClient,
+) -> None:
+    """A discovery document that drifts from the server is worse than none: it
+    sends a client to a protocol version the server will not speak."""
+    from trusted_router.routes.mcp import MCP_PROTOCOL_VERSION
+
+    document = client.get("/.well-known/mcp.json").json()
+
+    assert document["protocolVersion"] == MCP_PROTOCOL_VERSION
+    assert document["name"] == "trustedrouter"
+
+
+def test_llms_txt_is_a_navigation_index() -> None:
+    """The convention asks for a heading, markdown links to deeper resources,
+    and under 30,000 characters. It was 7.8k of bare `Label: https://url`
+    bullets -- readable, but not a link graph anything can traverse."""
+    text = llms_txt(Settings(environment="test"))
+
+    assert text.startswith("# TrustedRouter")
+    assert len(text) < 30_000
+    assert len(re.findall(r"\]\(https?://", text)) > 40
+    bare = re.findall(r"^- [^\[\n]*: https?://", text, re.M)
+    assert not bare, bare[:3]
+
+
+def test_llms_txt_points_at_the_long_form_index() -> None:
+    """Long-form content lives in /llms-full.txt; the index has to link it or
+    the split just hides it."""
+    text = llms_txt(Settings(environment="test"))
+
+    assert "/llms-full.txt" in text
+
+
+def test_every_sdk_is_linked_from_the_docs_page(client: TestClient) -> None:
+    """Three of six SDKs were listed. Go, Rust and Java shipped and were
+    reachable only by guessing the repository name."""
+    html = client.get("/docs", headers={"accept": "text/html"}).text
+
+    for repo in (
+        "trusted-router-py",
+        "trusted-router-js",
+        "trusted-router-go",
+        "trusted-router-rust",
+        "trusted-router-swift",
+        "trusted-router-java",
+    ):
+        assert f"github.com/Lore-Hex/{repo}" in html, repo
+
+
+def test_no_sdk_link_points_at_a_moved_repository(client: TestClient) -> None:
+    """The Swift card pointed at github.com/jperla/..., which 301s to the
+    Lore-Hex org. A redirect is not a broken link, but it is a stale one, and
+    it is the sort that rots into a 404."""
+    html = client.get("/docs", headers={"accept": "text/html"}).text
+
+    assert "github.com/jperla/" not in html

--- a/tests/test_provider_onboarding_page.py
+++ b/tests/test_provider_onboarding_page.py
@@ -132,9 +132,7 @@ def test_provider_reliability_contract_v2_is_public_and_complete(
     provider_schema = schema["properties"]["provider"]
     assert "error_contract" in provider_schema["required"]
     assert (
-        provider_schema["properties"]["error_contract"]["properties"][
-            "overload_status"
-        ]["const"]
+        provider_schema["properties"]["error_contract"]["properties"]["overload_status"]["const"]
         == 503
     )
 
@@ -145,11 +143,19 @@ def test_provider_onboarding_page_is_discoverable(client: TestClient) -> None:
     sitemap = client.get("/sitemap-core.xml")
     llms = client.get("/llms.txt")
 
-    assert providers.status_code == footer.status_code == sitemap.status_code == llms.status_code == 200
+    assert (
+        providers.status_code
+        == footer.status_code
+        == sitemap.status_code
+        == llms.status_code
+        == 200
+    )
     assert 'href="/providers/marketplace"' in providers.text
     assert 'href="/providers/marketplace"' in footer.text
     assert "<loc>https://trustedrouter.com/providers/marketplace</loc>" in sitemap.text
-    assert "Provider marketplace: https://trustedrouter.com/providers/marketplace" in llms.text
+    # llms.txt is a markdown navigation index now, so entries are links rather
+    # than "Label: url" text.
+    assert "[Provider marketplace](https://trustedrouter.com/providers/marketplace)" in llms.text
     assert "https://trustedrouter.com/providers/apply" not in sitemap.text
     assert "https://trustedrouter.com/providers/apply" not in llms.text
 


### PR DESCRIPTION
Four discovery gaps. Each was published, documented, and unreachable without
first reading a page written for humans — the same shape as `openapi.json`
being absent from llms.txt.

## MCP discovery

Everything needed to connect was prose on `/docs/mcp`: the URL, the transport,
that it wants a Bearer key. `/.well-known/mcp.json` now carries them, mirroring
the values the server reports at `initialize` rather than restating them, with a
test that they match — a discovery document that drifts from its server sends
clients to a protocol version the server won't speak.

**It lives in `routes/public.py`, not beside the server it describes.** That was
my first version, and `test_service_surface_routing.py` caught it: `/mcp` is
authenticated and mounted only on the **control** surface, while the URL map
sends `.well-known` to **public**. The document would have 404'd in production
while passing every test I wrote for it, because the test client uses the
combined app where both surfaces coexist.

## SDK links

The docs page listed **three of six**. Go, Rust and Java shipped and were
reachable only by guessing the repo name. All six now, plus the AI SDK provider
and the conformance suite. The Swift card pointed at `github.com/jperla/…`,
which 301s to the Lore-Hex org — not broken, but stale in the way that becomes
a 404.

## llms.txt as a navigation index

It already had a heading and was 7.8k, well under the 30k the convention asks
for. What it did not have was **any markdown links** — every entry was
`Label: https://url` text. Readable, and not a link graph anything can
traverse. Now 50 links, no bare URLs, pointing at `/llms-full.txt` for
long-form content.

## Organization JSON-LD

Every `Organization` node on the site was a two-field publisher stub attached to
a blog post. None said who operates TrustedRouter, how to reach a human, or
where the company is — the questions asked when deciding whether a vendor is
real.

Full node now: `PostalAddress`, three `contactPoint` entries (support, security,
sales), and EIN/DUNS as `taxID`/`duns`, which were human-readable on `/legal`
only.

It is prepended inside `_json_ld_graph` rather than added at each of the twelve
call sites — twelve call sites is twelve places to forget it, and an assistant
has no reason to have landed on whichever page someone remembered to annotate.
The homepage carried **no structured data at all** and is wired separately, as
are `/trust`, `/legal` and `/support`, which build their graphs by hand.

Address components are explicit settings beside the display string rather than
parsed from it: splitting on commas is a guess that breaks the first time
somebody adds a suite number.

## Verification

14 new tests, plus one existing test updated where the llms.txt format
intentionally changed. Full suite **6237 passed**, ruff and mypy clean across
299 files.

Organization node confirmed rendering on `/`, `/trust`, `/docs`, `/models`,
`/blog`, `/legal`, `/support`, `/compare`, `/providers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)