### PR TITLE
Model-check the surface cutover and auto-refill handoff protocols

### DIFF
--- a/proofs/AutoRefillHandoff.cfg
+++ b/proofs/AutoRefillHandoff.cfg
@@ -1,0 +1,49 @@
+\* Model-checking configuration for AutoRefillHandoff.
+\*
+\* NumSettlements = 2 permits two independently interleaved threshold
+\* crossings while the single control drain is busy. MaxDeliveries = 2 puts a
+\* duplicate delivery beside the original. MaxAttempts = 2 covers a failed
+\* drain attempt followed by a retry. MaxCrashes = 2 covers death after the
+\* durable enqueue and death after Stripe completes but before success is
+\* recorded, followed by an idempotent retry.
+\*
+\* MEASURED RUN: TLC 2.19 with -workers auto on an 8-core Apple M2, 8 GB RAM,
+\* JDK 21.0.12: 3,687 states generated, 1,117 distinct, search depth 15,
+\* 1.28 seconds wall time. This is one measured run, not a runtime promise.
+\*
+\* WHAT THE BOUNDS COST, STATED SO NOBODY HAS TO GUESS
+\*
+\*   There are two threshold-crossing settlements, at most two deliveries per
+\*   settlement, two drain claims per settlement, and two process deaths for
+\*   the whole run. This covers the smallest duplicate/retry/interleaving
+\*   shapes but NOT an unbounded redelivery storm, a long retry schedule, or
+\*   concurrent control drains. The money amount and threshold arithmetic are
+\*   abstracted to the fact that the threshold was crossed; boundary math and
+\*   multiple workspaces are outside this model.
+\*
+\*   Stripe is an atomic idempotent completion keyed by settlement identity.
+\*   Provider-side expiration or accidental reuse of that key, webhook credit
+\*   application, card fee arithmetic, and operator repair after explicit
+\*   failure are not covered. Weak fairness is the stated assumption that the
+\*   drain keeps running; permanent scheduler starvation is outside the
+\*   liveness claim.
+\*
+\*   Nothing here is checked with a CONSTRAINT. The finite constants are the
+\*   whole bound; TLC exhausts every state inside them.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    NumSettlements = 2
+    MaxDeliveries = 2
+    MaxAttempts = 2
+    MaxCrashes = 2
+
+\* Kept separate so each guard-deletion experiment names the law it breaks.
+INVARIANTS
+    NoDoubleCharge
+    NoSilentDrop
+    ChargeOnlyWhereCredentialed
+
+PROPERTIES
+    EventuallyCharged

--- a/proofs/AutoRefillHandoff.tla
+++ b/proofs/AutoRefillHandoff.tla
@@ -1,0 +1,215 @@
+--------------------------- MODULE AutoRefillHandoff ---------------------------
+(***************************************************************************)
+(* Settlement-to-charge handoff for auto-refill. Settlement runs on the     *)
+(* internal surface, which deliberately has no Stripe credential. A         *)
+(* threshold-crossing settlement atomically creates durable pending work; a *)
+(* control-owned drain claims that work and is the only site allowed to      *)
+(* submit a charge.                                                         *)
+(*                                                                         *)
+(* Multiple deliveries model duplicate enqueue/event delivery. Transient    *)
+(* drain failures and CrashProcess return claimed work to pending. A crash   *)
+(* may occur after Stripe has completed the charge but before the durable    *)
+(* row records success; providerCharged is the idempotency-key result that   *)
+(* makes the retry observe, rather than repeat, that charge. Permanent or    *)
+(* exhausted failure is terminal only when explicitly recorded.             *)
+(*                                                                         *)
+(* The reviewed pre-fix path called Stripe directly from settlement. With   *)
+(* no key it returned stripe_not_configured and left no work behind. The     *)
+(* NoSilentDrop mutant assigns "forgotten" instead of "pending" in          *)
+(* SettleAndEnqueue and is that defect as one atomic handoff mutation.       *)
+(*                                                                         *)
+(* MUTATION CHECKS (TLC -workers 1, restored after every run)               *)
+(*                                                                         *)
+(* NoDoubleCharge: delete ~providerCharged[e] from SubmitCharge. Violated   *)
+(*   in 5 states: SettleAndEnqueue -> Claim -> SubmitCharge -> SubmitCharge. *)
+(* NoSilentDrop: replace SettleAndEnqueue's pending delivery with forgotten *)
+(*   and zero deliveries. Violated in 2 states: SettleAndEnqueue.           *)
+(* ChargeOnlyWhereCredentialed: delete site = "control" from SubmitCharge.  *)
+(*   Violated in 3 states: SettleAndEnqueue -> Claim; the internal-site      *)
+(*   charge is then ENABLED, which is what the invariant directly checks.   *)
+(*                                                                         *)
+(* Every quoted trace is the shortest single-worker breadth-first trace.    *)
+(* The restored model passes at the counts in AutoRefillHandoff.cfg.         *)
+(***************************************************************************)
+
+EXTENDS Naturals
+
+CONSTANTS NumSettlements, MaxDeliveries, MaxAttempts, MaxCrashes
+
+ASSUME /\ NumSettlements \in Nat \ {0}
+       /\ MaxDeliveries \in Nat \ {0}
+       /\ MaxAttempts \in Nat \ {0}
+       /\ MaxCrashes \in Nat
+
+Settlements == 1..NumSettlements
+Surfaces == {"internal", "control"}
+Statuses == {"unsettled", "pending", "charging", "charged", "failed", "forgotten"}
+TerminalStatuses == {"charged", "failed"}
+
+VARIABLES
+    settled,
+    status,
+    deliveries,
+    attempts,
+    providerCharged,
+    completedCharges,
+    drainOwner,
+    crashCount
+
+vars == <<
+    settled, status, deliveries, attempts, providerCharged,
+    completedCharges, drainOwner, crashCount
+>>
+
+Init ==
+    /\ settled = [e \in Settlements |-> FALSE]
+    /\ status = [e \in Settlements |-> "unsettled"]
+    /\ deliveries = [e \in Settlements |-> 0]
+    /\ attempts = [e \in Settlements |-> 0]
+    /\ providerCharged = [e \in Settlements |-> FALSE]
+    /\ completedCharges = [e \in Settlements |-> 0]
+    /\ drainOwner = [e \in Settlements |-> "none"]
+    /\ crashCount = 0
+
+(* Settlement and durable enqueue are one storage transaction. *)
+SettleAndEnqueue(e) ==
+    /\ e \in Settlements
+    /\ ~settled[e]
+    /\ settled' = [settled EXCEPT ![e] = TRUE]
+    /\ status' = [status EXCEPT ![e] = "pending"]
+    /\ deliveries' = [deliveries EXCEPT ![e] = 1]
+    /\ UNCHANGED <<
+        attempts, providerCharged, completedCharges, drainOwner, crashCount
+       >>
+
+DuplicateEnqueue(e) ==
+    /\ e \in Settlements
+    /\ settled[e]
+    /\ status[e] \in {"pending", "charging"}
+    /\ deliveries[e] < MaxDeliveries
+    /\ deliveries' = [deliveries EXCEPT ![e] = @ + 1]
+    /\ UNCHANGED <<
+        settled, status, attempts, providerCharged, completedCharges,
+        drainOwner, crashCount
+       >>
+
+DrainIdle == \A e \in Settlements : status[e] # "charging"
+
+ClaimOnControlDrain(e) ==
+    /\ e \in Settlements
+    /\ status[e] = "pending"
+    /\ deliveries[e] > 0
+    /\ attempts[e] < MaxAttempts \/ providerCharged[e]
+    /\ DrainIdle
+    /\ status' = [status EXCEPT ![e] = "charging"]
+    /\ attempts' = [attempts EXCEPT
+          ![e] = IF providerCharged[e] THEN @ ELSE @ + 1]
+    /\ drainOwner' = [drainOwner EXCEPT ![e] = "control"]
+    /\ UNCHANGED <<
+        settled, deliveries, providerCharged, completedCharges, crashCount
+       >>
+
+(* Stripe's idempotency record is durable before the local outcome record. *)
+SubmitCharge(e, site) ==
+    /\ e \in Settlements
+    /\ site \in Surfaces
+    /\ site = "control"
+    /\ status[e] = "charging"
+    /\ drainOwner[e] = "control"
+    /\ ~providerCharged[e]
+    /\ completedCharges[e] < 2
+    /\ providerCharged' = [providerCharged EXCEPT ![e] = TRUE]
+    /\ completedCharges' = [completedCharges EXCEPT ![e] = @ + 1]
+    /\ UNCHANGED <<
+        settled, status, deliveries, attempts, drainOwner, crashCount
+       >>
+
+RecordChargeSuccess(e) ==
+    /\ e \in Settlements
+    /\ status[e] = "charging"
+    /\ drainOwner[e] = "control"
+    /\ providerCharged[e]
+    /\ status' = [status EXCEPT ![e] = "charged"]
+    /\ deliveries' = [deliveries EXCEPT ![e] = 0]
+    /\ drainOwner' = [drainOwner EXCEPT ![e] = "none"]
+    /\ UNCHANGED <<
+        settled, attempts, providerCharged, completedCharges, crashCount
+       >>
+
+RecordPermanentFailure(e) ==
+    /\ e \in Settlements
+    /\ status[e] = "charging"
+    /\ drainOwner[e] = "control"
+    /\ ~providerCharged[e]
+    /\ status' = [status EXCEPT ![e] = "failed"]
+    /\ deliveries' = [deliveries EXCEPT ![e] = 0]
+    /\ drainOwner' = [drainOwner EXCEPT ![e] = "none"]
+    /\ UNCHANGED <<
+        settled, attempts, providerCharged, completedCharges, crashCount
+       >>
+
+RetryTransientFailure(e) ==
+    /\ e \in Settlements
+    /\ status[e] = "charging"
+    /\ drainOwner[e] = "control"
+    /\ ~providerCharged[e]
+    /\ attempts[e] < MaxAttempts
+    /\ status' = [status EXCEPT ![e] = "pending"]
+    /\ drainOwner' = [drainOwner EXCEPT ![e] = "none"]
+    /\ UNCHANGED <<
+        settled, deliveries, attempts, providerCharged, completedCharges,
+        crashCount
+       >>
+
+RecordExhaustedFailure(e) ==
+    /\ e \in Settlements
+    /\ status[e] = "pending"
+    /\ attempts[e] = MaxAttempts
+    /\ ~providerCharged[e]
+    /\ status' = [status EXCEPT ![e] = "failed"]
+    /\ deliveries' = [deliveries EXCEPT ![e] = 0]
+    /\ UNCHANGED <<
+        settled, attempts, providerCharged, completedCharges, drainOwner,
+        crashCount
+       >>
+
+CrashProcess ==
+    /\ crashCount < MaxCrashes
+    /\ \E e \in Settlements : status[e] \in {"pending", "charging"}
+    /\ crashCount' = crashCount + 1
+    /\ status' = [e \in Settlements |->
+          IF status[e] = "charging" THEN "pending" ELSE status[e]]
+    /\ drainOwner' = [e \in Settlements |->
+          IF drainOwner[e] = "control" THEN "none" ELSE drainOwner[e]]
+    /\ UNCHANGED <<
+        settled, deliveries, attempts, providerCharged, completedCharges
+       >>
+
+Next ==
+    \/ \E e \in Settlements : SettleAndEnqueue(e)
+    \/ \E e \in Settlements : DuplicateEnqueue(e)
+    \/ \E e \in Settlements : ClaimOnControlDrain(e)
+    \/ \E e \in Settlements, site \in Surfaces : SubmitCharge(e, site)
+    \/ \E e \in Settlements : RecordChargeSuccess(e)
+    \/ \E e \in Settlements : RecordPermanentFailure(e)
+    \/ \E e \in Settlements : RetryTransientFailure(e)
+    \/ \E e \in Settlements : RecordExhaustedFailure(e)
+    \/ CrashProcess
+
+(* The weak-fairness assumption is the model's "assuming the drain runs". *)
+Spec == Init /\ [][Next]_vars /\ WF_vars(Next)
+
+NoDoubleCharge ==
+    \A e \in Settlements : completedCharges[e] <= 1
+
+NoSilentDrop ==
+    \A e \in Settlements :
+        settled[e] => status[e] \in {"pending", "charging", "charged", "failed"}
+
+ChargeOnlyWhereCredentialed ==
+    \A e \in Settlements : ~ENABLED SubmitCharge(e, "internal")
+
+EventuallyCharged ==
+    \A e \in Settlements : settled[e] ~> status[e] \in TerminalStatuses
+
+=============================================================================

--- a/proofs/SurfaceCutover.cfg
+++ b/proofs/SurfaceCutover.cfg
@@ -1,0 +1,50 @@
+\* Model-checking configuration for SurfaceCutover.
+\*
+\* NumRegions = 2 is the smallest fleet that can expose the reviewed split:
+\* region 1 promotes to New, then region 2 fails while still on Old. It also
+\* covers failures and a process death at every phase before and after a
+\* promotion, recovery in either regional order, smoke gating, and ingress
+\* restoration. MaxCrashes = 2 lets a second process die while recovering the
+\* first death, so recovery state must itself be durable.
+\*
+\* MEASURED RUN: TLC 2.19 with -workers auto on an 8-core Apple M2, 8 GB RAM,
+\* JDK 21.0.12: 2,104 states generated, 784 distinct, search depth 30,
+\* 1.32 seconds wall time. This is one measured run, not a runtime promise.
+\*
+\* WHAT THE BOUNDS COST, STATED SO NOBODY HAS TO GUESS
+\*
+\*   Two regions cover the split-fleet shape but NOT three-way or four-way
+\*   recovery orderings, and not defects indexed to a particular production
+\*   region. Revisions are only Old and New: chained deploy attempts, revision
+\*   garbage collection, and rollback from New to an older-than-Old revision
+\*   are not covered.
+\*
+\*   At most two crashes occur. That covers death during the forward rollout
+\*   followed by death during recovery, but NOT an unbounded crash loop.
+\*   Weak fairness assumes an enabled recovery operation eventually runs; a
+\*   permanently unavailable Cloud Run control plane is outside the claim.
+\*
+\*   Provider calls are atomic successful transitions or an interruption into
+\*   recovery. Ambiguous partial provider effects finer than the explicitly
+\*   separated arm/promote/restrict steps are not represented. The public and
+\*   internal smoke payloads differ in code, but both have the same protocol
+\*   role here: only a passed probe may authorize traffic.
+\*
+\*   Nothing here is checked with a CONSTRAINT. The finite constants are the
+\*   whole bound; TLC exhausts every state inside them.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    NumRegions = 2
+    MaxCrashes = 2
+
+\* Kept separate so each guard-deletion experiment names the law it breaks.
+INVARIANTS
+    NoSplitFleet
+    AlwaysRecoverable
+    NoTrafficWithoutSmoke
+    IngressNeverStrandedOpen
+
+PROPERTIES
+    EventuallyConsistent

--- a/proofs/SurfaceCutover.tla
+++ b/proofs/SurfaceCutover.tla
@@ -1,0 +1,365 @@
+----------------------------- MODULE SurfaceCutover -----------------------------
+(***************************************************************************)
+(* The routed Cloud Run rollout shared by public_surface.sh and             *)
+(* internal_surface.sh. A region is handled at a time: capture its serving  *)
+(* revision, durably arm ingress recovery, widen ingress, create a          *)
+(* no-traffic candidate, tag and smoke it, durably arm promotion recovery,  *)
+(* promote it, restrict ingress, and clear the marker.                      *)
+(*                                                                         *)
+(* The shell scripts which prompted this model restored only the region in  *)
+(* flight when a later region failed. That is not a fleet rollback: an      *)
+(* earlier region could keep serving New while the failing region returned  *)
+(* to Old. The repaired protocol represented here keeps every captured      *)
+(* previous revision durable for the whole attempt and cannot terminate a   *)
+(* failed attempt until every region has been restored. Deleting the        *)
+(* AllOld guard from TerminateFailure recreates the reviewed defect.        *)
+(*                                                                         *)
+(* ProviderFailure and SmokeFailure may interrupt any running phase. Crash  *)
+(* is a separate action enabled at every nonterminal state (including       *)
+(* recovery), up to the explicit MaxCrashes bound. Recovery operations are  *)
+(* atomic abstractions of the corresponding provider calls. Weak fairness   *)
+(* says an enabled finite workflow is not ignored forever; it does not say  *)
+(* that a permanently unavailable provider recovers.                       *)
+(*                                                                         *)
+(* MUTATION CHECKS (TLC -workers 1, restored after every run)               *)
+(*                                                                         *)
+(* NoSplitFleet: weaken AllOld in TerminateFailure to current-region Old.    *)
+(*   Violated in 14 states:                                                 *)
+(*   Record -> ArmIngress -> Widen -> Deploy -> Tag -> PassSmoke ->         *)
+(*   ArmPromotion -> Promote -> Restrict -> Clear -> Advance ->             *)
+(*   ProviderFailure -> TerminateFailure, leaving <<New, Old>>.             *)
+(* AlwaysRecoverable: delete serving[r] = Old from ForgetUnusedRecovery.   *)
+(*   Violated in 11 states: the first region promotes, ProviderFailure      *)
+(*   begins recovery, then ForgetUnusedRecovery erases its rollback record. *)
+(* NoTrafficWithoutSmoke: delete smoked[current] from ArmPromotion.         *)
+(*   Violated in 8 states: Tag -> ArmPromotion -> Promote skips PassSmoke.  *)
+(* IngressNeverStrandedOpen: delete ~ingressOpen[current] from              *)
+(*   ClearPromotionMarker. Violated in 22 states: both regions clear and    *)
+(*   advance without RestrictIngress, then FinishSuccess strands both open. *)
+(*                                                                         *)
+(* Every quoted trace is the shortest single-worker breadth-first trace.    *)
+(* The restored model passes at the counts recorded in SurfaceCutover.cfg.  *)
+(***************************************************************************)
+
+EXTENDS Naturals
+
+CONSTANTS NumRegions, MaxCrashes
+
+ASSUME /\ NumRegions \in Nat \ {0}
+       /\ MaxCrashes \in Nat
+
+Regions == 1..NumRegions
+Versions == {"Old", "New"}
+NoRevision == "none"
+MarkerPhases == {"none", "ingress-armed", "promotion-armed"}
+RunningPhases == {
+    "record", "arm-ingress", "widen", "deploy", "tag",
+    "smoke", "promote", "post-promotion", "advance",
+    "finish"
+}
+FailureOutcomes == {"provider-failed", "smoke-failed", "crashed"}
+TerminalOutcomes == {"succeeded", "failed"}
+
+VARIABLES
+    phase,
+    current,
+    serving,
+    previous,
+    ingressOpen,
+    deployed,
+    tagged,
+    smoked,
+    markerRegion,
+    markerPhase,
+    outcome,
+    crashCount
+
+vars == <<
+    phase, current, serving, previous, ingressOpen, deployed, tagged, smoked,
+    markerRegion, markerPhase, outcome, crashCount
+>>
+
+AllOld == \A r \in Regions : serving[r] = "Old"
+AllNew == \A r \in Regions : serving[r] = "New"
+AllIngressRestricted == \A r \in Regions : ~ingressOpen[r]
+SameVersion == \E version \in Versions : \A r \in Regions : serving[r] = version
+
+Init ==
+    /\ phase = "record"
+    /\ current = 1
+    /\ serving = [r \in Regions |-> "Old"]
+    /\ previous = [r \in Regions |-> NoRevision]
+    /\ ingressOpen = [r \in Regions |-> FALSE]
+    /\ deployed = [r \in Regions |-> FALSE]
+    /\ tagged = [r \in Regions |-> FALSE]
+    /\ smoked = [r \in Regions |-> FALSE]
+    /\ markerRegion = 0
+    /\ markerPhase = "none"
+    /\ outcome = "running"
+    /\ crashCount = 0
+
+RecordServingRevision ==
+    /\ outcome = "running"
+    /\ phase = "record"
+    /\ current \in Regions
+    /\ previous' = [previous EXCEPT ![current] = serving[current]]
+    /\ phase' = "arm-ingress"
+    /\ UNCHANGED <<
+        current, serving, ingressOpen, deployed, tagged, smoked,
+        markerRegion, markerPhase, outcome, crashCount
+       >>
+
+ArmIngressRecovery ==
+    /\ outcome = "running"
+    /\ phase = "arm-ingress"
+    /\ previous[current] = serving[current]
+    /\ markerRegion' = current
+    /\ markerPhase' = "ingress-armed"
+    /\ phase' = "widen"
+    /\ UNCHANGED <<
+        current, serving, previous, ingressOpen, deployed, tagged, smoked,
+        outcome, crashCount
+       >>
+
+WidenIngress ==
+    /\ outcome = "running"
+    /\ phase = "widen"
+    /\ markerRegion = current
+    /\ markerPhase = "ingress-armed"
+    /\ ingressOpen' = [ingressOpen EXCEPT ![current] = TRUE]
+    /\ phase' = "deploy"
+    /\ UNCHANGED <<
+        current, serving, previous, deployed, tagged, smoked,
+        markerRegion, markerPhase, outcome, crashCount
+       >>
+
+DeployWithoutTraffic ==
+    /\ outcome = "running"
+    /\ phase = "deploy"
+    /\ ingressOpen[current]
+    /\ deployed' = [deployed EXCEPT ![current] = TRUE]
+    /\ phase' = "tag"
+    /\ UNCHANGED <<
+        current, serving, previous, ingressOpen, tagged, smoked,
+        markerRegion, markerPhase, outcome, crashCount
+       >>
+
+TagCandidate ==
+    /\ outcome = "running"
+    /\ phase = "tag"
+    /\ deployed[current]
+    /\ tagged' = [tagged EXCEPT ![current] = TRUE]
+    /\ phase' = "smoke"
+    /\ UNCHANGED <<
+        current, serving, previous, ingressOpen, deployed, smoked,
+        markerRegion, markerPhase, outcome, crashCount
+       >>
+
+PassSmoke ==
+    /\ outcome = "running"
+    /\ phase = "smoke"
+    /\ tagged[current]
+    /\ ~smoked[current]
+    /\ smoked' = [smoked EXCEPT ![current] = TRUE]
+    /\ UNCHANGED <<
+        phase, current, serving, previous, ingressOpen, deployed, tagged,
+        markerRegion, markerPhase, outcome, crashCount
+       >>
+
+ArmPromotion ==
+    /\ outcome = "running"
+    /\ phase = "smoke"
+    /\ smoked[current]
+    /\ previous[current] = "Old"
+    /\ markerRegion = current
+    /\ markerPhase = "ingress-armed"
+    /\ markerPhase' = "promotion-armed"
+    /\ phase' = "promote"
+    /\ UNCHANGED <<
+        current, serving, previous, ingressOpen, deployed, tagged, smoked,
+        markerRegion, outcome, crashCount
+       >>
+
+Promote ==
+    /\ outcome = "running"
+    /\ phase = "promote"
+    /\ markerRegion = current
+    /\ markerPhase = "promotion-armed"
+    /\ serving' = [serving EXCEPT ![current] = "New"]
+    /\ phase' = "post-promotion"
+    /\ UNCHANGED <<
+        current, previous, ingressOpen, deployed, tagged, smoked,
+        markerRegion, markerPhase, outcome, crashCount
+       >>
+
+RestrictIngress ==
+    /\ outcome = "running"
+    /\ phase = "post-promotion"
+    /\ ingressOpen[current]
+    /\ ingressOpen' = [ingressOpen EXCEPT ![current] = FALSE]
+    /\ UNCHANGED <<
+        phase, current, serving, previous, deployed, tagged, smoked,
+        markerRegion, markerPhase, outcome, crashCount
+       >>
+
+ClearPromotionMarker ==
+    /\ outcome = "running"
+    /\ phase = "post-promotion"
+    /\ ~ingressOpen[current]
+    /\ markerRegion = current
+    /\ markerPhase = "promotion-armed"
+    /\ markerRegion' = 0
+    /\ markerPhase' = "none"
+    /\ phase' = "advance"
+    /\ UNCHANGED <<
+        current, serving, previous, ingressOpen, deployed, tagged, smoked,
+        outcome, crashCount
+       >>
+
+AdvanceRegion ==
+    /\ outcome = "running"
+    /\ phase = "advance"
+    /\ IF current = NumRegions
+          THEN /\ current' = NumRegions + 1
+               /\ phase' = "finish"
+          ELSE /\ current' = current + 1
+               /\ phase' = "record"
+    /\ UNCHANGED <<
+        serving, previous, ingressOpen, deployed, tagged, smoked,
+        markerRegion, markerPhase, outcome, crashCount
+       >>
+
+FinishSuccess ==
+    /\ outcome = "running"
+    /\ phase = "finish"
+    /\ AllNew
+    /\ markerPhase = "none"
+    /\ outcome' = "succeeded"
+    /\ phase' = "terminal"
+    /\ UNCHANGED <<
+        current, serving, previous, ingressOpen, deployed, tagged, smoked,
+        markerRegion, markerPhase, crashCount
+       >>
+
+BeginFailure(kind) ==
+    /\ kind \in {"provider-failed", "smoke-failed"}
+    /\ outcome = "running"
+    /\ phase \in RunningPhases
+    /\ outcome' = kind
+    /\ phase' = "recover"
+    /\ UNCHANGED <<
+        current, serving, previous, ingressOpen, deployed, tagged, smoked,
+        markerRegion, markerPhase, crashCount
+       >>
+
+Crash ==
+    /\ outcome \notin TerminalOutcomes
+    /\ crashCount < MaxCrashes
+    /\ crashCount' = crashCount + 1
+    /\ outcome' = "crashed"
+    /\ phase' = "recover"
+    /\ UNCHANGED <<
+        current, serving, previous, ingressOpen, deployed, tagged, smoked,
+        markerRegion, markerPhase
+       >>
+
+RestoreTraffic(r) ==
+    /\ outcome \in FailureOutcomes
+    /\ phase = "recover"
+    /\ r \in Regions
+    /\ serving[r] = "New"
+    /\ previous[r] = "Old"
+    /\ serving' = [serving EXCEPT ![r] = "Old"]
+    /\ UNCHANGED <<
+        phase, current, previous, ingressOpen, deployed, tagged, smoked,
+        markerRegion, markerPhase, outcome, crashCount
+       >>
+
+RestoreIngress(r) ==
+    /\ outcome \in FailureOutcomes
+    /\ phase = "recover"
+    /\ r \in Regions
+    /\ ingressOpen[r]
+    /\ ingressOpen' = [ingressOpen EXCEPT ![r] = FALSE]
+    /\ UNCHANGED <<
+        phase, current, serving, previous, deployed, tagged, smoked,
+        markerRegion, markerPhase, outcome, crashCount
+       >>
+
+ClearRecoveryMarker ==
+    /\ outcome \in FailureOutcomes
+    /\ phase = "recover"
+    /\ markerPhase # "none"
+    /\ markerRegion' = 0
+    /\ markerPhase' = "none"
+    /\ UNCHANGED <<
+        phase, current, serving, previous, ingressOpen, deployed, tagged, smoked,
+        outcome, crashCount
+       >>
+
+(* A previous revision may be discarded only while that region still serves *)
+(* Old. Removing this guard is the AlwaysRecoverable mutation experiment.   *)
+ForgetUnusedRecovery(r) ==
+    /\ outcome \notin TerminalOutcomes
+    /\ phase = "recover"
+    /\ r \in Regions
+    /\ previous[r] # NoRevision
+    /\ serving[r] = "Old"
+    /\ previous' = [previous EXCEPT ![r] = NoRevision]
+    /\ UNCHANGED <<
+        phase, current, serving, ingressOpen, deployed, tagged, smoked,
+        markerRegion, markerPhase, outcome, crashCount
+       >>
+
+TerminateFailure ==
+    /\ outcome \in FailureOutcomes
+    /\ phase = "recover"
+    /\ AllOld
+    /\ AllIngressRestricted
+    /\ markerPhase = "none"
+    /\ outcome' = "failed"
+    /\ phase' = "terminal"
+    /\ UNCHANGED <<
+        current, serving, previous, ingressOpen, deployed, tagged, smoked,
+        markerRegion, markerPhase, crashCount
+       >>
+
+Next ==
+    \/ RecordServingRevision
+    \/ ArmIngressRecovery
+    \/ WidenIngress
+    \/ DeployWithoutTraffic
+    \/ TagCandidate
+    \/ PassSmoke
+    \/ ArmPromotion
+    \/ Promote
+    \/ RestrictIngress
+    \/ ClearPromotionMarker
+    \/ AdvanceRegion
+    \/ FinishSuccess
+    \/ \E kind \in {"provider-failed", "smoke-failed"} : BeginFailure(kind)
+    \/ Crash
+    \/ \E r \in Regions : RestoreTraffic(r)
+    \/ \E r \in Regions : RestoreIngress(r)
+    \/ ClearRecoveryMarker
+    \/ \E r \in Regions : ForgetUnusedRecovery(r)
+    \/ TerminateFailure
+
+Spec == Init /\ [][Next]_vars /\ WF_vars(Next)
+
+NoSplitFleet ==
+    outcome \in TerminalOutcomes => SameVersion
+
+AlwaysRecoverable ==
+    \A r \in Regions : serving[r] = "Old" \/ previous[r] = "Old"
+
+NoTrafficWithoutSmoke ==
+    \A r \in Regions : serving[r] = "New" => smoked[r]
+
+IngressNeverStrandedOpen ==
+    outcome \in TerminalOutcomes => AllIngressRestricted
+
+EventuallyConsistent ==
+    <> (outcome \in TerminalOutcomes /\ SameVersion)
+
+=============================================================================


### PR DESCRIPTION
Two TLA+ specs for the protocols that each produced a **High** finding in adversarial review this week. Both were found by a human reading the code; these catch that class mechanically.

## SurfaceCutover.tla

Models the multi-region routed deploy used by `public_surface.sh` and `internal_surface.sh`: record serving revision → arm ingress recovery → widen ingress → deploy `--no-traffic` → tag → smoke → arm promotion marker → promote → restrict ingress → clear. **Process death is modelled as an action that can fire between any two steps** — that's the part tests can't reach.

| Invariant | Claim |
|---|---|
| `NoSplitFleet` | a terminated deploy leaves all regions on one version |
| `AlwaysRecoverable` | no reachable state has a promoted region with no way back |
| `NoTrafficWithoutSmoke` | no region serves a revision that didn't pass smoke |
| `IngressNeverStrandedOpen` | no terminal state leaves ingress widened |
| `EventuallyConsistent` (property) | every attempt reaches one-version terminal state |

## AutoRefillHandoff.tla

Models settlement on a surface that must **not** hold payment credentials handing off to a control-owned drain: durable enqueue, drain, retries, duplicate delivery, crashes between enqueue and drain. `NoDoubleCharge`, `NoSilentDrop` (a threshold crossing may never simply vanish), `ChargeOnlyWhereCredentialed` (the charge action is only enabled where the credential lives), plus `EventuallyCharged`.

## Mutation evidence — every invariant proved capable of failing

A spec that passes proves nothing until it's been shown it *can* fail. For each invariant the smallest guard deletion was applied, TLC run, the counterexample recorded, and the guard restored. All traces re-run at `-workers 1`, since a parallel search returns the first counterexample found, not the shortest.

| Invariant | Mutation | Counterexample | Trace |
|---|---|---|---:|
| NoSplitFleet | `TerminateFailure`: `AllOld` → current-region only (**the reviewed pre-fix behavior**) | yes | 14 |
| AlwaysRecoverable | drop `serving[r] = "Old"` from `ForgetUnusedRecovery` | yes | 11 |
| NoTrafficWithoutSmoke | drop `smoked[current]` from `ArmPromotion` | yes | 8 |
| IngressNeverStrandedOpen | drop `~ingressOpen[current]` from `ClearPromotionMarker` | yes | 22 |
| NoDoubleCharge | drop `~providerCharged[e]` from `SubmitCharge` | yes | 5 |
| NoSilentDrop | replace durable pending delivery with `forgotten` | yes | 2 |
| ChargeOnlyWhereCredentialed | drop `site = "control"` from `SubmitCharge` | yes | 3 |

**The reviewer independently re-ran the NoSplitFleet mutation.** Applying the pre-fix protocol yields `Error: Invariant NoSplitFleet is violated` at State 14 with `serving = <<"New", "Old">>` and `outcome = "failed"` — a terminated failed deploy leaving the fleet split, exactly the reported production defect. Unmutated: `Model checking completed. No error has been found.`

No invariant lacked a failing mutant. One that did would be reported as suspect rather than proven.

## Conventions

Follows the directory's existing discipline: **no state `CONSTRAINT`** (it would turn "no error found" into "no error found in the part we looked at"), invariants declared individually so a mutation answers *which* law a guard held up, and the bounds' cost stated rather than implied. `check.sh` discovers both automatically.

Exhaustive: SurfaceCutover 2,104 states / 784 distinct / depth 30; AutoRefillHandoff 3,687 / 1,117 / depth 15 — about 1.3s each.

**Not covered, stated plainly:** four-region recovery ordering, chained deployments, unbounded crash loops, permanent provider unavailability; and on the refill side, unbounded redelivery, concurrent drain fleets, threshold arithmetic, Stripe idempotency-key expiry, webhook crediting.

Written by codex; reviewed by Claude / Fable.