### PR TITLE
Stop the detached synthetic tests racing the task they assert on

### DIFF
--- a/tests/test_synthetic_run_rotation.py
+++ b/tests/test_synthetic_run_rotation.py
@@ -102,12 +102,20 @@ def no_network_probes(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
 
 
 def _post_run(settings: Settings, body: dict[str, Any]) -> Any:
-    client = TestClient(create_app(settings, init_observability=False))
-    return client.post(
-        "/v1/internal/synthetic/run",
-        json=body,
-        headers={"x-trustedrouter-internal-token": OBSERVER_TOKEN},
-    )
+    # detach=true dispatches the pass with asyncio.create_task (synthetic.py:420)
+    # and only tracks it in _BACKGROUND_RUNS. A bare TestClient does NOT drive
+    # that task to completion before .post() returns, so asserting its effects
+    # straight afterwards is a race: it wins on an idle machine and loses under
+    # a loaded CI run (-n 4 plus coverage), which is why
+    # test_eventbridge_tick_runs_one_bounded_remediator_pass intermittently saw
+    # events == []. Entering the client as a context manager runs lifespan and,
+    # on exit, drains the portal so detached tasks have actually completed.
+    with TestClient(create_app(settings, init_observability=False)) as client:
+        return client.post(
+            "/v1/internal/synthetic/run",
+            json=body,
+            headers={"x-trustedrouter-internal-token": OBSERVER_TOKEN},
+        )
 
 
 class TestRotation:
@@ -283,8 +291,8 @@ class TestDetachMode:
     def test_detach_still_runs_the_pass(self, no_network_probes: dict[str, Any]) -> None:
         settings = _settings(synthetic_monitor_api_key="sk-test-monitor")
         _post_run(settings, {"detach": True, "rotation_count": 2})
-        # TestClient drives the event loop to completion on exit, so the
-        # background task has run by the time the response is returned.
+        # _post_run enters the TestClient as a context manager, so the detached
+        # task has completed by the time the response is returned.
         assert no_network_probes["rotation_calls"], "detached pass never executed"
         assert no_network_probes["rotation_calls"][0]["count"] == 2
 


### PR DESCRIPTION
`test_eventbridge_tick_runs_one_bounded_remediator_pass` has now failed **three CI runs across unrelated PRs** with `assert [] == ['heartbeat', 'remediate', 'heartbeat']`, while passing locally every time — 8/8 in isolation, 34/34 for its file, and a full-suite run in CI's own `-n 4 --dist loadgroup` mode.

## It isn't flaky luck, it's a real race

`detach=true` dispatches the pass with `asyncio.create_task` (`synthetic.py:420`) and only records it in `_BACKGROUND_RUNS`. A **bare** `TestClient` does not drive that task to completion before `.post()` returns, so asserting its effects immediately afterwards races the task — won on an idle machine, lost under a loaded CI run.

The file documented the wrong assumption explicitly:

> `# TestClient drives the event loop to completion on exit, so the background task has run by the time the response is returned.`

That is not true of a client that is never entered as a context manager.

## Demonstrated, not assumed

My first attempt to reproduce — stressing the test 12× under CPU contention — failed **0/12**, so rather than ship an unproven fix I built a probe that forces the race. With the detached pass made to take 250 ms:

```
bare TestClient  -> (202, ['heartbeat'])                            ← work unfinished
context-managed  -> (202, ['remediate', 'heartbeat', 'heartbeat'])  ← completed
```

The bare client returns with the detached work incomplete — the exact shape of the CI failure. Entering the client as a context manager runs lifespan and drains the portal on exit, so the task has actually completed.

## Change

`_post_run` now enters `TestClient` as a context manager, and the misleading comment is replaced with what is actually true. Four detach-mode tests depend on this. 34 tests pass in the file.

This has been costing CI cycles on PRs that cannot possibly affect it — the most recent was a PR touching only `proofs/*.tla`.