### PR TITLE
Make Spanner deadline test deterministic

### DIFF
--- a/tests/test_storage_gcp_io.py
+++ b/tests/test_storage_gcp_io.py
@@ -270,7 +270,11 @@ class _CommitDatabase:
         return result
 
 
-def test_configure_spanner_rpc_deadlines_caps_commit_and_retry_budget() -> None:
+def test_configure_spanner_rpc_deadlines_caps_commit_and_retry_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _Clock()
+    _install_clock(monkeypatch, clock)
     database = _CommitDatabase(_CommitApi())
     configure_spanner_rpc_deadlines(database, max_seconds=7.0)
 


### PR DESCRIPTION
Summary: use the existing fake monotonic clock in the Spanner deadline budget test, preserving the exact seven-second assertion without wall-clock scheduling jitter. Verification: focused storage tests 11 passed; Ruff passed; diff check passed.