### PR TITLE
Install markdown parser in production image

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ requires-python = ">=3.11"
 license = "BUSL-1.1"
 dependencies = [
   "axiom-py>=0.9.0",
+  # Public markdown negotiation parses rendered HTML at request time.
+  "beautifulsoup4>=4.12.0",
   "boto3>=1.35.0",
   "cbor2>=5.6",
   "cryptography>=43.0.0",
@@ -40,11 +42,6 @@ packages = ["src/trusted_router"]
 
 [dependency-groups]
 dev = [
-  # beautifulsoup4 is used by the hourly pricing refresh workflow
-  # (scripts/pricing/parsers/*.py) and tests/test_pricing_*.py.
-  # Not used at runtime — catalog.py reads the committed JSON
-  # snapshot — so it stays out of the deployed wheel.
-  "beautifulsoup4>=4.12.0",
   # Evals can optionally parse PDFs/SEC filings, but these packages pull
   # a large ML/document stack (torch, triton, transformers, OCR). Keep
   # them out of the production API image.

--- a/tests/test_runtime_dependencies.py
+++ b/tests/test_runtime_dependencies.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+def test_markdown_negotiation_parser_is_a_runtime_dependency() -> None:
+    """The production image installs project dependencies without the dev group."""
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    runtime_dependencies = pyproject["project"]["dependencies"]
+
+    assert any(
+        dependency.split(">=", 1)[0] == "beautifulsoup4"
+        for dependency in runtime_dependencies
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -4554,6 +4554,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-py" },
+    { name = "beautifulsoup4" },
     { name = "boto3" },
     { name = "cbor2" },
     { name = "cryptography" },
@@ -4576,7 +4577,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "beautifulsoup4" },
     { name = "docling" },
     { name = "hypothesis" },
     { name = "mypy" },
@@ -4593,6 +4593,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "axiom-py", specifier = ">=0.9.0" },
+    { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "boto3", specifier = ">=1.35.0" },
     { name = "cbor2", specifier = ">=5.6" },
     { name = "cryptography", specifier = ">=43.0.0" },
@@ -4615,7 +4616,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "docling", specifier = ">=2.58.0" },
     { name = "hypothesis", specifier = ">=6.152.4" },
     { name = "mypy", specifier = ">=1.13" },


### PR DESCRIPTION
Production revision trusted-router-01200-dqv failed before serving traffic with ModuleNotFoundError: No module named 'bs4'. Public markdown negotiation imports BeautifulSoup at runtime, but beautifulsoup4 was only in the dev dependency group while the Cloud Run image installs with --no-dev.\n\nThis moves beautifulsoup4 into project runtime dependencies, refreshes uv.lock, and adds a regression guard.\n\nVerified:\n- 32 focused markdown/discoverability/runtime dependency tests pass\n- frozen --no-dev export contains beautifulsoup4==4.14.3\n- production-only environment imports trusted_router.markdown_negotiation\n\nNo traffic shifted to the failed revision; production stayed on trusted-router-01199-649.