### PR TITLE
Ship markdown parser in production image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,18 @@ jobs:
       - name: Stylelint
         run: npx stylelint "src/trusted_router/static/*.css"
 
+  production-import:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+      - name: Sync production dependencies only
+        run: uv sync --frozen --no-dev
+      - name: Import the production application
+        run: uv run --no-sync python -c "import trusted_router.main"
+
   test:
     runs-on: ubuntu-latest
     env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.11"
 license = "BUSL-1.1"
 dependencies = [
   "axiom-py>=0.9.0",
+  "beautifulsoup4>=4.12.0",
   "boto3>=1.35.0",
   "cbor2>=5.6",
   "cryptography>=43.0.0",
@@ -40,11 +41,6 @@ packages = ["src/trusted_router"]
 
 [dependency-groups]
 dev = [
-  # beautifulsoup4 is used by the hourly pricing refresh workflow
-  # (scripts/pricing/parsers/*.py) and tests/test_pricing_*.py.
-  # Not used at runtime — catalog.py reads the committed JSON
-  # snapshot — so it stays out of the deployed wheel.
-  "beautifulsoup4>=4.12.0",
   # Evals can optionally parse PDFs/SEC filings, but these packages pull
   # a large ML/document stack (torch, triton, transformers, OCR). Keep
   # them out of the production API image.

--- a/uv.lock
+++ b/uv.lock
@@ -4554,6 +4554,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-py" },
+    { name = "beautifulsoup4" },
     { name = "boto3" },
     { name = "cbor2" },
     { name = "cryptography" },
@@ -4576,7 +4577,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "beautifulsoup4" },
     { name = "docling" },
     { name = "hypothesis" },
     { name = "mypy" },
@@ -4593,6 +4593,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "axiom-py", specifier = ">=0.9.0" },
+    { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "boto3", specifier = ">=1.35.0" },
     { name = "cbor2", specifier = ">=5.6" },
     { name = "cryptography", specifier = ">=43.0.0" },
@@ -4615,7 +4616,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "docling", specifier = ">=2.58.0" },
     { name = "hypothesis", specifier = ">=6.152.4" },
     { name = "mypy", specifier = ">=1.13" },


### PR DESCRIPTION
Root cause: the new Cloud Run revision crashed with ModuleNotFoundError for bs4 because markdown negotiation imports BeautifulSoup at runtime while beautifulsoup4 was dev-only. This promotes it to production dependencies and adds a CI job that installs only production dependencies before importing the application. Verified with an isolated no-dev install, 20 markdown negotiation tests, Ruff, lockfile check, and diff check.