### PR TITLE
Move beautifulsoup4 to runtime deps; smoke the no-dev import in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,27 @@ jobs:
   # tests/test_check_format_ordering.py, in
   # test_an_unchanged_write_side_is_silent_and_reads_no_network, which drives
   # the real main() with every network seam replaced by a function that raises.
+  no-dev-import-smoke:
+    # The production image installs with --no-dev (Dockerfile), while every
+    # other CI job syncs the dev group. A runtime module importing a dev-only
+    # package therefore passes ALL tests and then crashes the container at
+    # startup, failing every deploy at the traffic ramp — which is exactly
+    # what happened when markdown_negotiation imported bs4 while
+    # beautifulsoup4 sat in the dev group (#764, discovered 2026-08-23).
+    # This job boots the app's import graph the way production does.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+      - name: Sync without dev dependencies, exactly like the image
+        run: uv sync --frozen --no-dev
+      - name: Import the app the way uvicorn does at boot
+        env:
+          TR_ENVIRONMENT: test
+        run: uv run --no-sync python -c "import trusted_router.main"
+
   byok-format-ordering:
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,13 @@ requires-python = ">=3.11"
 license = "BUSL-1.1"
 dependencies = [
   "axiom-py>=0.9.0",
+  # Runtime since #764: markdown_negotiation imports bs4 on the startup
+  # path (middleware -> dashboard -> main). It lived in the dev group with
+  # a comment promising it was test-only, so CI (which installs dev deps)
+  # stayed green while the --no-dev production image crashed on boot and
+  # every deploy failed at the traffic ramp. The ci.yml no-dev import
+  # smoke exists to make this class of drift fail in CI instead.
+  "beautifulsoup4>=4.12.0",
   "boto3>=1.35.0",
   "cbor2>=5.6",
   "cryptography>=43.0.0",
@@ -40,11 +47,6 @@ packages = ["src/trusted_router"]
 
 [dependency-groups]
 dev = [
-  # beautifulsoup4 is used by the hourly pricing refresh workflow
-  # (scripts/pricing/parsers/*.py) and tests/test_pricing_*.py.
-  # Not used at runtime — catalog.py reads the committed JSON
-  # snapshot — so it stays out of the deployed wheel.
-  "beautifulsoup4>=4.12.0",
   # Evals can optionally parse PDFs/SEC filings, but these packages pull
   # a large ML/document stack (torch, triton, transformers, OCR). Keep
   # them out of the production API image.

--- a/uv.lock
+++ b/uv.lock
@@ -4554,6 +4554,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-py" },
+    { name = "beautifulsoup4" },
     { name = "boto3" },
     { name = "cbor2" },
     { name = "cryptography" },
@@ -4576,7 +4577,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "beautifulsoup4" },
     { name = "docling" },
     { name = "hypothesis" },
     { name = "mypy" },
@@ -4593,6 +4593,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "axiom-py", specifier = ">=0.9.0" },
+    { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "boto3", specifier = ">=1.35.0" },
     { name = "cbor2", specifier = ">=5.6" },
     { name = "cryptography", specifier = ">=43.0.0" },
@@ -4615,7 +4616,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "docling", specifier = ">=2.58.0" },
     { name = "hypothesis", specifier = ">=6.152.4" },
     { name = "mypy", specifier = ">=1.13" },


### PR DESCRIPTION
Main is currently undeployable: every deploy since #764 fails at the
us-central1 traffic ramp because revision containers crash on boot with
`ModuleNotFoundError: No module named 'bs4'`
([markdown_negotiation.py:46](src/trusted_router/markdown_negotiation.py#L46), imported at startup via
middleware → dashboard → main). Production keeps serving the old
revision — the staged ramp refused to shift traffic to a revision that
never became ready, which is it working as designed.

Why CI never saw it: `beautifulsoup4` sat in the **dev** dependency
group with a comment promising it was test-only, every CI job syncs the
dev group, and the production image installs `--no-dev`
([Dockerfile:14-17](Dockerfile#L14)). All tests green; container cannot boot.

Two changes:

1. **beautifulsoup4 moves to `[project] dependencies`** (with the
   incident written into the comment where the stale promise used to
   be), `uv.lock` re-resolved — a 2-line lock diff.
2. **`no-dev-import-smoke` CI job**: `uv sync --frozen --no-dev` then
   `python -c "import trusted_router.main"` — boots the import graph
   exactly the way uvicorn does in the image, so the entire class of
   "runtime module imports a dev-only package" fails in CI instead of
   at the production ramp.

Verified locally: the import fails on main under `--no-dev` and
succeeds with this change; full dev sync restored afterwards.

This also unblocks #771's fix (T1 outbox flag), which merged but cannot
reach production while deploys fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)