### PR TITLE
Fix production Markdown runtime dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,21 @@ on:
 # conclusion for the SHA, and a run only concludes success when every job
 # succeeds, so the gate semantics are unchanged by the split.
 jobs:
+  runtime-import:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+      # Match the production Docker image dependency set. The regular test
+      # jobs include development packages, which can otherwise mask a missing
+      # runtime dependency until Cloud Run starts the image.
+      - name: Install production dependencies only
+        run: uv sync --frozen --no-dev
+      - name: Import runtime-only modules
+        run: uv run --no-dev python -c "import bs4; import trusted_router.markdown_negotiation"
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.11"
 license = "BUSL-1.1"
 dependencies = [
   "axiom-py>=0.9.0",
+  "beautifulsoup4>=4.12.0",
   "boto3>=1.35.0",
   "cbor2>=5.6",
   "cryptography>=43.0.0",
@@ -40,11 +41,6 @@ packages = ["src/trusted_router"]
 
 [dependency-groups]
 dev = [
-  # beautifulsoup4 is used by the hourly pricing refresh workflow
-  # (scripts/pricing/parsers/*.py) and tests/test_pricing_*.py.
-  # Not used at runtime — catalog.py reads the committed JSON
-  # snapshot — so it stays out of the deployed wheel.
-  "beautifulsoup4>=4.12.0",
   # Evals can optionally parse PDFs/SEC filings, but these packages pull
   # a large ML/document stack (torch, triton, transformers, OCR). Keep
   # them out of the production API image.

--- a/uv.lock
+++ b/uv.lock
@@ -4554,6 +4554,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-py" },
+    { name = "beautifulsoup4" },
     { name = "boto3" },
     { name = "cbor2" },
     { name = "cryptography" },
@@ -4576,7 +4577,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "beautifulsoup4" },
     { name = "docling" },
     { name = "hypothesis" },
     { name = "mypy" },
@@ -4593,6 +4593,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "axiom-py", specifier = ">=0.9.0" },
+    { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "boto3", specifier = ">=1.35.0" },
     { name = "cbor2", specifier = ">=5.6" },
     { name = "cryptography", specifier = ">=43.0.0" },
@@ -4615,7 +4616,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "docling", specifier = ">=2.58.0" },
     { name = "hypothesis", specifier = ">=6.152.4" },
     { name = "mypy", specifier = ">=1.13" },


### PR DESCRIPTION
## Summary
- move Beautiful Soup into production dependencies because Markdown negotiation imports it at app startup
- add a CI job that installs only production dependencies and imports the runtime Markdown module
- refresh the frozen lockfile

## Incident
The zero-traffic Cloud Run canary `trusted-router-01200-dqv` exited before listening on port 8080 with `ModuleNotFoundError: No module named 'bs4'`. Existing production traffic stayed on `trusted-router-01199-649`.

## Verification
- production-only `uv sync --frozen --no-dev`
- production imports: `bs4`, `trusted_router.markdown_negotiation`
- `uv run ruff check .`
- `uv run pytest -q tests/test_markdown_negotiation.py` (20 passed)
- `uv lock --check`
