### PR TITLE
Recover stale staged traffic before deploy

### DIFF
--- a/scripts/deploy/normalize_staged_traffic.sh
+++ b/scripts/deploy/normalize_staged_traffic.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Restore Cloud Run's desired traffic spec to the sole revision that is
+# actually serving before creating another no-traffic revision. A failed
+# update-traffic operation can leave spec.traffic at 90/10 while status.traffic
+# correctly keeps 100% on the old revision; Cloud Run then refuses later
+# deploys until the stale desired split is repaired.
+
+set -euo pipefail
+
+REGION="${1:?usage: $0 <region>}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+service_json="$(
+  gc run services describe "$SERVICE" \
+    --region="$REGION" \
+    --format=json
+)"
+active_revision="$(
+  python3 "${SCRIPT_DIR}/resolve_active_revision.py" <<<"$service_json"
+)"
+
+log "normalizing ${SERVICE}/${REGION} desired traffic to active revision ${active_revision}"
+gc run services update-traffic "$SERVICE" \
+  --region="$REGION" \
+  --to-revisions="${active_revision}=100" \
+  --quiet

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -726,6 +726,11 @@ deploy_one_region() {
   else
     log "deploying Cloud Run service ${SERVICE} to ${target}"
   fi
+  if [ "${TR_DEPLOY_NO_TRAFFIC:-0}" = "1" ]; then
+    SERVICE="$SERVICE" PROJECT_ID="$PROJECT_ID" \
+      bash "${SCRIPT_DIR}/normalize_staged_traffic.sh" "$target" \
+      >>"$logfile" 2>&1
+  fi
   prune_failed_revisions "$target" >>"$logfile" 2>&1 || true
   # A global override wins. Otherwise use the per-region service minimum;
   # unknown warm regions retain one instance and unknown cold regions scale to

--- a/scripts/deploy/staged_traffic.sh
+++ b/scripts/deploy/staged_traffic.sh
@@ -89,15 +89,21 @@ shift_traffic() {
   local old_pct=$((100 - new_pct))
   log "shifting traffic: ${new_pct}% ${NEW_REV} / ${old_pct}% ${OLD_REV}"
   if [ "$old_pct" -eq 0 ]; then
-    gcloud run services update-traffic "$SERVICE" \
-      --region="$REGION" --project="$PROJECT_ID" \
-      --to-revisions="${NEW_REV}=100" \
-      --quiet
+    if ! gcloud run services update-traffic "$SERVICE" \
+        --region="$REGION" --project="$PROJECT_ID" \
+        --to-revisions="${NEW_REV}=100" \
+        --quiet; then
+      rollback_to_old "traffic update to ${new_pct}% failed"
+      return 1
+    fi
   else
-    gcloud run services update-traffic "$SERVICE" \
-      --region="$REGION" --project="$PROJECT_ID" \
-      --to-revisions="${NEW_REV}=${new_pct},${OLD_REV}=${old_pct}" \
-      --quiet
+    if ! gcloud run services update-traffic "$SERVICE" \
+        --region="$REGION" --project="$PROJECT_ID" \
+        --to-revisions="${NEW_REV}=${new_pct},${OLD_REV}=${old_pct}" \
+        --quiet; then
+      rollback_to_old "traffic update to ${new_pct}% failed"
+      return 1
+    fi
   fi
 }
 

--- a/tests/test_deploy_watchdog.py
+++ b/tests/test_deploy_watchdog.py
@@ -153,6 +153,7 @@ def _run_staged_probe(
     remove_failures: int = 0,
     remove_always_fails: bool = False,
     remove_leaves_tag: bool = False,
+    traffic_shift_failure_pct: int | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
     stub_bin = tmp_path / "bin"
     stub_bin.mkdir()
@@ -166,6 +167,10 @@ def _run_staged_probe(
     gcloud.write_text(
         """#!/usr/bin/env bash
 printf 'gcloud %s\\n' "$*" >>"$STAGED_CALL_LOG"
+if [ -n "$STAGED_TRAFFIC_SHIFT_FAILURE_PCT" ] \
+    && [[ " $* " == *" --to-revisions=new-rev=${STAGED_TRAFFIC_SHIFT_FAILURE_PCT},"* ]]; then
+  exit 1
+fi
 case " $* " in
   *" --update-tags="*) printf '%s\\n' "$STAGED_RESOLVED_TAG_REV" >"$STAGED_TAG_STATE" ;;
   *" --remove-tags="*)
@@ -240,6 +245,9 @@ exit 0
         "STAGED_REMOVE_FAILURES_STATE": str(remove_failures_state),
         "STAGED_REMOVE_ALWAYS_FAILS": "1" if remove_always_fails else "0",
         "STAGED_REMOVE_LEAVES_TAG": "1" if remove_leaves_tag else "0",
+        "STAGED_TRAFFIC_SHIFT_FAILURE_PCT": (
+            "" if traffic_shift_failure_pct is None else str(traffic_shift_failure_pct)
+        ),
         "STAGED_REAL_PYTHON": sys.executable,
         "TR_LEGACY_PROBE_RETRY_SECONDS": "0",
         "TR_PROBE_TAG_REMOVE_RETRY_SECONDS": "0",
@@ -468,3 +476,24 @@ def test_staged_probe_tag_cleanup_verifies_a_successful_removal(
         index for index, call in enumerate(calls) if "--remove-tags=staged-probe" in call
     )
     assert any("--format=json" in call for call in calls[removal_index + 1 :])
+
+
+def test_failed_traffic_shift_restores_the_old_desired_revision(tmp_path: Path) -> None:
+    run, calls = _run_staged_probe(
+        tmp_path,
+        console_code="302",
+        session_code="401",
+        traffic_shift_failure_pct=10,
+    )
+
+    assert run.returncode != 0
+    traffic_calls = [
+        call
+        for call in calls
+        if call.startswith("gcloud run services update-traffic")
+        and "--to-revisions=" in call
+    ]
+    assert any("--to-revisions=new-rev=10,old-rev=90" in call for call in traffic_calls)
+    assert any("--to-revisions=old-rev=100" in call for call in traffic_calls)
+    assert "ROLLBACK" in run.stdout
+    assert "traffic update to 10% failed" in run.stdout

--- a/tests/test_normalize_staged_traffic.py
+++ b/tests/test_normalize_staged_traffic.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "deploy" / "normalize_staged_traffic.sh"
+
+
+def _run_normalizer(
+    tmp_path: Path,
+    traffic: list[dict[str, object]],
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    stub_bin = tmp_path / "bin"
+    stub_bin.mkdir()
+    call_log = tmp_path / "calls.log"
+    service_json = tmp_path / "service.json"
+    service_json.write_text(json.dumps({"status": {"traffic": traffic}}))
+    gcloud = stub_bin / "gcloud"
+    gcloud.write_text(
+        """#!/usr/bin/env bash
+printf '%s\\n' "$*" >>"$NORMALIZE_CALL_LOG"
+if [[ " $* " == *" run services describe "* ]]; then
+  cat "$NORMALIZE_SERVICE_JSON"
+fi
+"""
+    )
+    gcloud.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{stub_bin}:/bin:/usr/bin",
+        "NORMALIZE_CALL_LOG": str(call_log),
+        "NORMALIZE_SERVICE_JSON": str(service_json),
+        "PROJECT_ID": "test-project",
+        "SERVICE": "trusted-router",
+    }
+    run = subprocess.run(  # noqa: S603 - fixed local script and stubbed PATH
+        ["/bin/bash", str(SCRIPT), "us-central1"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=10,
+    )
+    calls = call_log.read_text().splitlines() if call_log.exists() else []
+    return run, calls
+
+
+def test_normalizer_restores_desired_traffic_to_the_actual_serving_revision(
+    tmp_path: Path,
+) -> None:
+    run, calls = _run_normalizer(
+        tmp_path,
+        [
+            {"percent": 100, "revisionName": "old-rev"},
+            {"revisionName": "failed-rev", "tag": "staged-probe"},
+        ],
+    )
+
+    assert run.returncode == 0, run.stderr
+    assert any(
+        "run services update-traffic trusted-router" in call
+        and "--to-revisions=old-rev=100" in call
+        for call in calls
+    )
+
+
+def test_normalizer_refuses_to_collapse_live_split_traffic(tmp_path: Path) -> None:
+    run, calls = _run_normalizer(
+        tmp_path,
+        [
+            {"percent": 90, "revisionName": "old-rev"},
+            {"percent": 10, "revisionName": "new-rev"},
+        ],
+    )
+
+    assert run.returncode != 0
+    assert "expected exactly one 100%-traffic revision" in run.stderr
+    assert not any("run services update-traffic" in call for call in calls)


### PR DESCRIPTION
Root cause: a failed Cloud Run update-traffic operation left spec.traffic at 90/10 even though status.traffic safely kept 100% on the old revision. The stale desired split then blocked later no-traffic deploys. This normalizes desired traffic to the sole actually serving revision before a staged deploy and explicitly rolls back when a traffic update itself fails. Verification: 21 targeted recovery/watchdog tests, 99 deployment harness/mutex/workflow tests, Ruff, bash syntax, ShellCheck, and diff check.