### PR TITLE
Repair stale failed Cloud Run traffic before deploy

### DIFF
--- a/scripts/deploy/resolve_failed_revision_repair.py
+++ b/scripts/deploy/resolve_failed_revision_repair.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Plan repair of failed Cloud Run revisions left in service traffic state."""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from scripts.deploy.resolve_active_revision import resolve_active_revision
+
+
+@dataclass(frozen=True)
+class FailedRevisionRepair:
+    """A safe rollback target and the failed revisions it makes removable."""
+
+    active_revision: str
+    failed_revisions: tuple[str, ...]
+
+
+def _traffic_revision_names(service: Mapping[str, Any]) -> set[str]:
+    names: set[str] = set()
+    for parent_name in ("spec", "status"):
+        parent = service.get(parent_name)
+        if parent is None:
+            continue
+        if not isinstance(parent, Mapping):
+            raise ValueError(f"service {parent_name} is not an object")
+        traffic = parent.get("traffic", [])
+        if not isinstance(traffic, list):
+            raise ValueError(f"service {parent_name} traffic is not a list")
+        for item in traffic:
+            if not isinstance(item, Mapping):
+                raise ValueError(f"service {parent_name} traffic contains a non-object entry")
+            revision = item.get("revisionName")
+            if revision is not None:
+                if not isinstance(revision, str) or not revision:
+                    raise ValueError(
+                        f"service {parent_name} traffic has an invalid revisionName"
+                    )
+                names.add(revision)
+    return names
+
+
+def plan_failed_revision_repair(
+    service: Mapping[str, Any], failed_revisions: Iterable[str]
+) -> FailedRevisionRepair | None:
+    """Return a rollback plan when failed revisions remain traffic-referenced.
+
+    The sole effective 100% revision is the only safe automatic target. If the
+    service is actively split, ambiguous, or malformed, resolution raises and
+    the deploy remains fail-closed.
+    """
+    failed = {revision for revision in failed_revisions if revision}
+    referenced = tuple(sorted(failed & _traffic_revision_names(service)))
+    if not referenced:
+        return None
+    return FailedRevisionRepair(
+        active_revision=resolve_active_revision(service),
+        failed_revisions=referenced,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    try:
+        service = json.load(sys.stdin)
+        if not isinstance(service, Mapping):
+            raise ValueError("Cloud Run service document is not an object")
+        plan = plan_failed_revision_repair(service, args)
+        if plan is not None:
+            print(f"{plan.active_revision}\t{','.join(plan.failed_revisions)}")
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(f"cannot plan failed Cloud Run revision repair: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -655,21 +655,60 @@ prune_failed_revisions() {
   # routed (so they're safe to delete) and remove them. Idempotent;
   # no-op when everything is healthy.
   local target="$1"
-  local serving
-  serving=$(gc run services describe "$SERVICE" --region "$target" \
-    --format='value(status.traffic[].revisionName)' 2>/dev/null \
-    | tr ';' ' ')
+  local service_json
+  if ! service_json=$(gc run services describe "$SERVICE" --region "$target" \
+      --format=json 2>/dev/null); then
+    log "  WARN: cannot inspect ${target} traffic before pruning failed revisions"
+    return 1
+  fi
   local failed_revs
   failed_revs=$(gc run revisions list --service "$SERVICE" --region "$target" \
     --format='value(metadata.name,status.conditions[0].status)' 2>/dev/null \
     | awk '$2 == "False" { print $1 }')
+  [ -n "$failed_revs" ] || return 0
+
+  # A failed canary can remain in spec.traffic even though Cloud Run correctly
+  # keeps 100% of effective traffic on the old healthy revision. That stale
+  # desired split makes every later `gcloud run deploy --no-traffic` return the
+  # old failure after it has successfully created a new Ready revision. Roll
+  # the desired state back to the sole effective 100% revision first. The
+  # update also removes a dangling staged-probe tag while preserving unrelated
+  # tags. A real active split is ambiguous and the planner fails closed.
+  local repair_plan
+  if ! repair_plan=$(python3 "${SCRIPT_DIR}/resolve_failed_revision_repair.py" \
+      $failed_revs <<<"$service_json"); then
+    log "  ERROR: cannot safely resolve stale failed traffic in ${target}"
+    return 1
+  fi
+  if [ -n "$repair_plan" ]; then
+    local active_revision="${repair_plan%%$'\t'*}"
+    local referenced_failed="${repair_plan#*$'\t'}"
+    log "  repairing stale failed traffic in ${target}: ${referenced_failed}; restoring 100% ${active_revision}"
+    if ! gc run services update-traffic "$SERVICE" --region "$target" \
+        --to-revisions="${active_revision}=100" --quiet >/dev/null 2>&1; then
+      # Cloud Run can persist the requested repair but return non-zero while
+      # the old failed configuration is reconciling. Verify state instead of
+      # trusting either the success or failure exit code.
+      log "  WARN: traffic repair command returned non-zero; verifying live state"
+    fi
+    if ! service_json=$(gc run services describe "$SERVICE" --region "$target" \
+        --format=json 2>/dev/null); then
+      log "  ERROR: cannot verify stale failed traffic repair in ${target}"
+      return 1
+    fi
+    local remaining_plan
+    if ! remaining_plan=$(python3 "${SCRIPT_DIR}/resolve_failed_revision_repair.py" \
+        $failed_revs <<<"$service_json"); then
+      log "  ERROR: repaired traffic in ${target} is not an unambiguous 100% split"
+      return 1
+    fi
+    if [ -n "$remaining_plan" ]; then
+      log "  ERROR: failed revisions remain referenced after traffic repair in ${target}"
+      return 1
+    fi
+  fi
+
   for rev in $failed_revs; do
-    # Skip if this NotReady revision is somehow still in the traffic
-    # split — better to leave it and let the operator decide than risk
-    # hitting a revision we deleted while live.
-    case " $serving " in
-      *" $rev "*) continue ;;
-    esac
     log "  pruning failed revision ${rev} in ${target}"
     gc run revisions delete "$rev" --region "$target" --quiet >/dev/null 2>&1 \
       || log "  WARN: failed to prune ${rev}; will let gcloud's deploy step error if it cares"

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -174,6 +174,19 @@ def test_all_attested_control_plane_regions_remain_warm() -> None:
     assert '"TR_SPANNER_POOL_SIZE=${TR_SPANNER_POOL_SIZE}"' in rollout
 
 
+def test_rollout_repairs_stale_failed_traffic_before_pruning_revisions() -> None:
+    rollout = (ROOT / "scripts/deploy/rollout.sh").read_text(encoding="utf-8")
+    prune = rollout.split("prune_failed_revisions() {", 1)[1].split(
+        "\n}\n\nis_warm_region()", 1
+    )[0]
+
+    planner = 'resolve_failed_revision_repair.py"'
+    rollback = '--to-revisions="${active_revision}=100"'
+    delete = 'run revisions delete "$rev"'
+    assert prune.count(planner) == 2
+    assert prune.index(planner) < prune.index(rollback) < prune.index(delete)
+
+
 def test_production_deploy_interlocks_regional_quota_issuance() -> None:
     rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
     helper = (ROOT / "scripts/deploy/regional_quota_rollout.sh").read_text()

--- a/tests/test_resolve_failed_revision_repair.py
+++ b/tests/test_resolve_failed_revision_repair.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts.deploy.resolve_failed_revision_repair import plan_failed_revision_repair
+
+
+def _service(*, spec: list[dict[str, object]], status: list[dict[str, object]]) -> dict:
+    return {"spec": {"traffic": spec}, "status": {"traffic": status}}
+
+
+def test_plans_repair_for_failed_desired_canary_and_dangling_tag() -> None:
+    service = _service(
+        spec=[
+            {"revisionName": "healthy", "percent": 90},
+            {"revisionName": "failed", "percent": 10},
+        ],
+        status=[
+            {"revisionName": "healthy", "percent": 100},
+            {"revisionName": "failed", "tag": "staged-probe"},
+            {"revisionName": "restore", "tag": "restore-candidate"},
+        ],
+    )
+
+    plan = plan_failed_revision_repair(service, ["failed", "unreferenced-failure"])
+
+    assert plan is not None
+    assert plan.active_revision == "healthy"
+    assert plan.failed_revisions == ("failed",)
+
+
+def test_no_plan_when_failed_revisions_are_not_traffic_referenced() -> None:
+    service = _service(
+        spec=[{"revisionName": "healthy", "percent": 100}],
+        status=[{"revisionName": "healthy", "percent": 100}],
+    )
+
+    assert plan_failed_revision_repair(service, ["old-failed"]) is None
+
+
+def test_repair_fails_closed_during_real_effective_split() -> None:
+    service = _service(
+        spec=[
+            {"revisionName": "healthy", "percent": 90},
+            {"revisionName": "failed", "percent": 10},
+        ],
+        status=[
+            {"revisionName": "healthy", "percent": 90},
+            {"revisionName": "other", "percent": 10},
+            {"revisionName": "failed", "tag": "staged-probe"},
+        ],
+    )
+
+    with pytest.raises(ValueError, match="exactly one 100%-traffic revision"):
+        plan_failed_revision_repair(service, ["failed"])
+
+
+@pytest.mark.parametrize("parent", ["spec", "status"])
+def test_repair_rejects_malformed_traffic(parent: str) -> None:
+    service = _service(
+        spec=[{"revisionName": "healthy", "percent": 100}],
+        status=[{"revisionName": "healthy", "percent": 100}],
+    )
+    service[parent]["traffic"] = "not-a-list"
+
+    with pytest.raises(ValueError, match=f"service {parent} traffic is not a list"):
+        plan_failed_revision_repair(service, ["failed"])


### PR DESCRIPTION
## Summary
- detect failed Cloud Run revisions that remain referenced by desired traffic or a stale probe tag
- restore desired traffic to the sole effective 100% healthy revision before pruning
- verify the live state after mutation, including when gcloud reports a misleading nonzero result
- fail closed when effective traffic is split or ambiguous

## Incident
Revision `trusted-router-01200-dqv` failed app startup. Cloud Run correctly kept effective traffic at 100% on `trusted-router-01199-649`, but desired traffic retained a 90/10 split and a stale `staged-probe` reference. The next deploy created healthy revision `trusted-router-01201-5nk` but still returned the old revision's failure.

## Verification
- `bash -n scripts/deploy/rollout.sh`
- `uv run ruff check .`
- 37 focused deploy/helper tests passed
- malformed state and active split tests prove the repair remains fail-closed
