### PR TITLE
Remove stale TTFB leaderboard copy

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -1789,7 +1789,7 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
         og_card="llm-provider-latency-benchmarks.png",
         title="LLM Provider Latency Benchmarks",
         description=(
-            "Measured time-to-first-token, time-to-first-byte, throughput, and "
+            "Measured time-to-first-token, throughput, and "
             "success rate for LLM providers routed through TrustedRouter."
         ),
         faq_items=(
@@ -3395,8 +3395,8 @@ def public_leaderboard_html(settings: Settings, snapshot: dict[str, object]) -> 
             title="LLM Provider & Model Speed Leaderboard | TrustedRouter",
             heading="Provider & model performance",
             description=(
-                "Measured time-to-first-token, time-to-first-byte, effective throughput, and "
-                "uptime for every LLM provider and model TrustedRouter routes to — "
+                "Measured time-to-first-token, effective throughput, and uptime for every "
+                "LLM provider and model TrustedRouter routes to — "
                 "continuously sampled, not vendor-claimed."
             ),
             page_kind="leaderboard",
@@ -3407,7 +3407,7 @@ def public_leaderboard_html(settings: Settings, snapshot: dict[str, object]) -> 
                 _dataset_node(
                     name="TrustedRouter LLM provider and model speed leaderboard",
                     description=(
-                        "Metadata-only measurements for provider TTFT, TTFB, effective throughput, "
+                        "Metadata-only measurements for provider TTFT, effective throughput, "
                         "success rate, and excluded probe configuration rows."
                     ),
                     url=f"https://{settings.trusted_domain}/leaderboard",
@@ -3681,7 +3681,7 @@ def public_provider_performance_html(settings: Settings, provider_slug: str) -> 
             title=f"{provider.name} Speed, Uptime and Throughput | TrustedRouter",
             heading=f"{provider.name} performance",
             description=(
-                f"Review measured TTFT, TTFB, effective throughput, uptime, and sampled model routes "
+                f"Review measured TTFT, effective throughput, uptime, and sampled model routes "
                 f"for {provider.name} on TrustedRouter using metadata-only production probes."
             ),
             og_image=_absolute_url(settings, provider_og_image_url(provider.slug)),
@@ -4896,7 +4896,7 @@ def _model_section_description(model: Model, section: str) -> str:
         )
     if section == "performance":
         return (
-            f"Compare measured TTFT, TTFB, throughput, uptime, and route health for {name} across "
+            f"Compare measured TTFT, throughput, uptime, and route health for {name} across "
             "TrustedRouter providers using metadata-only production probes."
         )
     if section == "pricing":
@@ -4959,7 +4959,7 @@ def _model_section_json_ld(
             _dataset_node(
                 name=f"{model.name} TrustedRouter performance measurements",
                 description=(
-                    f"Measured TTFT, TTFB, throughput, and uptime for {model.name} "
+                    f"Measured TTFT, throughput, and uptime for {model.name} "
                     f"across TrustedRouter provider routes. Current sample count: {sample_count}."
                 ),
                 url=section_url,

--- a/src/trusted_router/templates/public/resources.html
+++ b/src/trusted_router/templates/public/resources.html
@@ -32,7 +32,7 @@
         <li><a href="/rankings">Rankings</a><span>Practical model signals</span></li>
         <li><a href="/leaderboard">Provider leaderboard</a><span>Live route measurements</span></li>
         <li><a href="/compare/models">Model comparisons</a><span>Price, context, routes, and privacy</span></li>
-        <li><a href="/llm-provider-latency-benchmarks">Latency benchmarks</a><span>TTFT, TTFB, and throughput</span></li>
+        <li><a href="/llm-provider-latency-benchmarks">Latency benchmarks</a><span>TTFT, throughput, and uptime</span></li>
       </ul>
     </div>
   </div>

--- a/src/trusted_router/templates/public/seo_llm_provider_latency_benchmarks.html
+++ b/src/trusted_router/templates/public/seo_llm_provider_latency_benchmarks.html
@@ -5,7 +5,7 @@
   <div class="marketing-copy">
     <span class="eyebrow">Measured provider latency</span>
     <h2>Provider speed data from real routed requests.</h2>
-    <p>TrustedRouter publishes metadata-only measurements for time-to-first-token, time-to-first-byte, throughput, uptime, and excluded probe-configuration rows. The goal is to show what the router actually sees, not what a provider claims in a launch post.</p>
+    <p>TrustedRouter publishes metadata-only measurements for time-to-first-token, throughput, uptime, and excluded probe-configuration rows. The goal is to show what the router actually sees, not what a provider claims in a launch post.</p>
     <ul class="check-list">
       <li>✓ Provider and model leaderboards</li>
       <li>✓ Per-provider performance pages when enough samples exist</li>

--- a/src/trusted_router/templates/public/seo_openai_compatible_llm_api.html
+++ b/src/trusted_router/templates/public/seo_openai_compatible_llm_api.html
@@ -34,7 +34,7 @@ print(response.choices[0].message.content)</code></pre>
 </section>
 
 <section class="marketing-grid three">
-  <a class="marketing-card card-as-link" href="/leaderboard"><h3>Measured providers</h3><p>Use live TTFT, TTFB, throughput, and uptime data instead of vendor claims.</p><span class="card-link">Open leaderboard</span></a>
+  <a class="marketing-card card-as-link" href="/leaderboard"><h3>Measured providers</h3><p>Use live TTFT, throughput, and uptime data instead of vendor claims.</p><span class="card-link">Open leaderboard</span></a>
   <a class="marketing-card card-as-link" href="/providers"><h3>Policy-aware routing</h3><p>Compare ZDR, confidential compute, provider E2EE, and upstream policy sources.</p><span class="card-link">Open providers</span></a>
   <a class="marketing-card card-as-link" href="https://trust.trustedrouter.com"><h3>Verify the gateway</h3><p>Check the running image, source commit, digest, and attestation path.</p><span class="card-link">Open trust</span></a>
 </section>

--- a/tests/test_leaderboard_page.py
+++ b/tests/test_leaderboard_page.py
@@ -95,8 +95,8 @@ def test_leaderboard_page_renders_measurements() -> None:
     assert "Ranked by p50 time-to-first-token" in body
     assert "Capacity accepted" in body
     assert "Provider availability" in body
-    assert "p50 TTFB" not in body
-    assert "p95 TTFB" not in body
+    assert "TTFB" not in body
+    assert "time-to-first-byte" not in body.lower()
     assert "cerebras" in body  # seeded provider row
     assert "meta/llama-3.3-70b" in body  # seeded model row
 


### PR DESCRIPTION
## Summary
- remove TTFB from the public leaderboard hero and structured metadata
- align latency benchmark and resource copy around TTFT, throughput, and uptime
- strengthen the leaderboard regression contract so TTFB cannot reappear anywhere in the rendered page

## Verification
- regression assertion failed before the product change
- `uv run pytest -q tests/test_leaderboard_page.py tests/test_measured_pages.py tests/test_public_seo_pages.py tests/test_public_revenue_pages.py` (107 passed)
- `uv run ruff check src/trusted_router/dashboard.py tests/test_leaderboard_page.py`
- `uv run mypy`
- `git diff --check`