### PR TITLE
Keep latency page metadata search-ready

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -1789,8 +1789,8 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
         og_card="llm-provider-latency-benchmarks.png",
         title="LLM Provider Latency Benchmarks",
         description=(
-            "Measured time-to-first-token, throughput, and "
-            "success rate for LLM providers routed through TrustedRouter."
+            "Compare measured time-to-first-token, throughput, uptime, and success rates "
+            "across LLM providers routed continuously through TrustedRouter."
         ),
         faq_items=(
             (


### PR DESCRIPTION
Summary

Lengthen the latency benchmark meta description after removing stale TTFB wording. Keep TTFT, throughput, uptime, and success rate as the public metrics.

Verification

SEO metadata test passed. Leaderboard tests passed. Ruff and diff checks passed.