### PR TITLE
Restore provider-effective transaction monitoring

### DIFF
--- a/src/trusted_router/synthetic/cli.py
+++ b/src/trusted_router/synthetic/cli.py
@@ -14,7 +14,10 @@ import httpx
 from trusted_router.config import Settings, get_settings
 from trusted_router.provider_reliability import model_deadlines
 from trusted_router.storage_models import ProviderBenchmarkSample, SyntheticProbeSample
-from trusted_router.synthetic.internal_auth import synthetic_observer_token
+from trusted_router.synthetic.internal_auth import (
+    synthetic_observer_token,
+    synthetic_transaction_token,
+)
 from trusted_router.synthetic.probes import (
     DEFAULT_SYNTHETIC_BILLING_CONCURRENCY,
     SyntheticTarget,
@@ -441,6 +444,7 @@ async def run() -> int:
     )
     control_plane = os.environ.get("TR_SYNTHETIC_CONTROL_PLANE_URL", "https://trustedrouter.com")
     observer_token = synthetic_observer_token(settings)
+    transaction_token = synthetic_transaction_token(settings)
     api_key = settings.synthetic_monitor_api_key
     timeout = httpx.Timeout(settings.synthetic_monitor_timeout_seconds)
     remediator_url = os.environ.get("TR_SYNTHETIC_REMEDIATOR_URL")
@@ -593,10 +597,11 @@ async def run() -> int:
                 settings=settings,
                 monitor_region=monitor_region,
                 control_plane=control_plane,
-                # Provider-facing jobs never hold the billing-gateway
-                # credential. Ledger authorize/settle/fallback probes remain
-                # inside the internal service that owns that capability.
-                internal_token=None,
+                # Split observer jobs never hold billing authority. The
+                # explicit combined migration bridge still does, so it must
+                # keep exercising authorize/settle/fallback until the
+                # internal service takes ownership.
+                internal_token=transaction_token,
                 api_key=api_key,
                 timeout=timeout,
                 rotation_enabled=rotation_enabled,

--- a/src/trusted_router/synthetic/internal_auth.py
+++ b/src/trusted_router/synthetic/internal_auth.py
@@ -20,3 +20,22 @@ def synthetic_observer_token(settings: Settings) -> str | None:
     ):
         return settings.internal_gateway_token
     return settings.observer_internal_token
+
+
+def synthetic_transaction_token(settings: Settings) -> str | None:
+    """Return billing authority only for the explicit combined migration bridge.
+
+    Split observer jobs must never receive or use this credential. The bridge
+    is different: production still runs the pre-split combined service, and
+    its monitor jobs already carry the gateway token until the internal
+    service cutover is complete. Keeping this decision here prevents a future
+    CLI refactor from silently disabling authorize/settle/fallback coverage or
+    accidentally extending billing authority to an observer surface.
+    """
+
+    if (
+        settings.service_surface == "combined"
+        and settings.allow_deployed_combined_surface
+    ):
+        return settings.internal_gateway_token
+    return None

--- a/src/trusted_router/synthetic/remediator.py
+++ b/src/trusted_router/synthetic/remediator.py
@@ -45,6 +45,8 @@ DETECTORS (v1, all T0 blast radius — detection and paging only):
   * monitor freshness    — this deployment's own probe fleet has stopped
                            reporting (peers will also catch this within
                            three cadences; local detection is faster).
+  * transaction probes  — the general probe fleet is alive but authorize,
+                           settle, or fallback coverage has gone silent.
 
 Every detector is exception-isolated: a broken detector loses its own
 signal, never the loop, and the loop itself heartbeats so /fleet shows the
@@ -69,6 +71,10 @@ REMEDIATION_PROBE = "remediation"
 # Best effort: one decision row per (playbook, subject, bucket) per process.
 # The check and set are unsynchronised, so duplicates are possible.
 DECISION_BUCKET_SECONDS = 30 * 60
+# Regional monitor jobs run every three minutes. Five missed cadences is long
+# enough to absorb rollout/cold-start jitter without allowing a billing or
+# fallback blind spot to survive unnoticed for hours.
+TRANSACTION_PROBE_STALE_SECONDS = 15 * 60
 _DECISION_MARKS: dict[str, int] = {}
 
 
@@ -191,10 +197,77 @@ def _detect_monitor_stale(settings: Settings) -> list[Decision]:
     ]
 
 
+def _detect_transaction_probe_stale(settings: Settings) -> list[Decision]:
+    """Page when privileged transaction coverage disappears by itself."""
+
+    import datetime as dt
+
+    from trusted_router.storage import STORE
+    from trusted_router.storage_models import utcnow
+    from trusted_router.synthetic.components import OPS_PROBE_TYPES
+
+    if not (
+        settings.service_surface in {"combined", "internal"}
+        and settings.synthetic_monitor_api_key
+        and settings.internal_gateway_token
+    ):
+        return []
+
+    # Absence before any monitor sample exists is provisioning, not an outage.
+    # Once sibling probes are flowing, each privileged probe becomes required.
+    recent = STORE.synthetic_probe_samples(limit=50)
+    if not any(sample.probe_type not in OPS_PROBE_TYPES for sample in recent):
+        return []
+
+    now = utcnow()
+    required: dict[str, tuple[str, ...]] = {
+        "gateway_authorize": ("gateway_authorize", "gateway_authorize_settle"),
+        "gateway_settle": ("gateway_settle", "gateway_authorize_settle"),
+        "provider_fallback": ("provider_fallback",),
+    }
+    decisions: list[Decision] = []
+    for subject, probe_types in required.items():
+        candidates = [
+            sample
+            for probe_type in probe_types
+            for sample in STORE.synthetic_probe_samples(probe_type=probe_type, limit=1)
+        ]
+        ages: list[tuple[float, str]] = []
+        for sample in candidates:
+            try:
+                created = dt.datetime.fromisoformat(sample.created_at.replace("Z", "+00:00"))
+            except ValueError:
+                continue
+            ages.append(((now - created).total_seconds(), sample.created_at))
+        if ages:
+            age, last_sample_at = min(ages, key=lambda item: item[0])
+            if age <= TRANSACTION_PROBE_STALE_SECONDS:
+                continue
+            detail = (
+                f"no {subject} sample for {int(age)}s (last {last_sample_at}); "
+                "the general probe fleet is alive but transaction effectiveness is unobserved"
+            )
+        else:
+            detail = (
+                f"no {subject} sample exists while the general probe fleet is alive; "
+                "transaction effectiveness is unobserved"
+            )
+        decisions.append(
+            Decision(
+                playbook="transaction-monitor-stale",
+                subject=subject,
+                detail=detail,
+                page=True,
+            )
+        )
+    return decisions
+
+
 DETECTORS = (
     _detect_stale_heartbeats,
     _detect_route_quarantine,
     _detect_monitor_stale,
+    _detect_transaction_probe_stale,
 )
 
 

--- a/tests/test_remediator.py
+++ b/tests/test_remediator.py
@@ -124,6 +124,95 @@ def test_fresh_probes_produce_no_monitor_decision(sentry_events: list[str]) -> N
     assert not any(d.playbook == "monitor-stale" for d in decisions)
 
 
+def test_live_probe_fleet_pages_when_transaction_probes_disappear(
+    sentry_events: list[str],
+) -> None:
+    _record(
+        SyntheticProbeSample(
+            id="syn_tls_live_transaction_blind",
+            probe_type="tls_health",
+            target="canonical",
+            target_url="https://api.trustedrouter.com/v1",
+            monitor_region="test-1",
+            status="up",
+        )
+    )
+
+    decisions = run_remediator_pass(
+        _settings(
+            service_surface="internal",
+            synthetic_monitor_api_key="sk-tr-test",
+            internal_gateway_token="gateway-test",  # noqa: S106 - test fixture.
+        )
+    )
+
+    stale = [d for d in decisions if d.playbook == "transaction-monitor-stale"]
+    assert {d.subject for d in stale} == {
+        "gateway_authorize",
+        "gateway_settle",
+        "provider_fallback",
+    }
+    assert sum("transaction-monitor-stale" in event for event in sentry_events) == 3
+
+
+def test_fresh_transaction_probes_keep_dead_man_quiet(
+    sentry_events: list[str],
+) -> None:
+    for probe_type in (
+        "tls_health",
+        "gateway_authorize",
+        "gateway_settle",
+        "provider_fallback",
+    ):
+        _record(
+            SyntheticProbeSample(
+                id=f"syn_fresh_{probe_type}",
+                probe_type=probe_type,
+                target="canonical" if probe_type == "tls_health" else "control-plane",
+                target_url="https://trustedrouter.com",
+                monitor_region="test-1",
+                status="up",
+            )
+        )
+
+    decisions = run_remediator_pass(
+        _settings(
+            service_surface="internal",
+            synthetic_monitor_api_key="sk-tr-test",
+            internal_gateway_token="gateway-test",  # noqa: S106 - test fixture.
+        )
+    )
+
+    assert not any(d.playbook == "transaction-monitor-stale" for d in decisions)
+    assert not any("transaction-monitor-stale" in event for event in sentry_events)
+
+
+def test_observer_surface_never_claims_transaction_monitor_ownership(
+    sentry_events: list[str],
+) -> None:
+    _record(
+        SyntheticProbeSample(
+            id="syn_observer_tls_only",
+            probe_type="tls_health",
+            target="canonical",
+            target_url="https://api.trustedrouter.com/v1",
+            monitor_region="test-1",
+            status="up",
+        )
+    )
+
+    decisions = run_remediator_pass(
+        _settings(
+            service_surface="observer",
+            synthetic_monitor_api_key="sk-tr-test",
+            observer_internal_token="observer-test",  # noqa: S106 - test fixture.
+        )
+    )
+
+    assert not any(d.playbook == "transaction-monitor-stale" for d in decisions)
+    assert not any("transaction-monitor-stale" in event for event in sentry_events)
+
+
 def test_decision_rows_bucket_and_dedupe(sentry_events: list[str]) -> None:
     fleet.register_heartbeat_target("scheduler:bucketed")
     _record(

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -2849,7 +2849,10 @@ async def test_primary_synthetic_job_invokes_scheduled_remediator(
 
 
 def test_synthetic_credential_selection_uses_gateway_only_for_combined_bridge() -> None:
-    from trusted_router.synthetic.internal_auth import synthetic_observer_token
+    from trusted_router.synthetic.internal_auth import (
+        synthetic_observer_token,
+        synthetic_transaction_token,
+    )
 
     both = Settings(
         environment="test",
@@ -2870,6 +2873,39 @@ def test_synthetic_credential_selection_uses_gateway_only_for_combined_bridge() 
     assert synthetic_observer_token(both) == "observer-only"
     assert synthetic_observer_token(billing_only) is None
     assert synthetic_observer_token(bridged) == "billing-only"
+    assert synthetic_transaction_token(both) is None
+    assert synthetic_transaction_token(billing_only) is None
+    assert synthetic_transaction_token(bridged) == "billing-only"
+
+
+@pytest.mark.asyncio
+async def test_combined_bridge_job_keeps_transaction_probe_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trusted_router.synthetic import cli as cli_module
+
+    transaction_tokens: list[str | None] = []
+
+    async def empty_pass(**kwargs: Any) -> tuple[list[Any], list[Any]]:
+        transaction_tokens.append(kwargs["internal_token"])
+        return [], []
+
+    settings = Settings(
+        environment="test",
+        service_surface="combined",
+        allow_deployed_combined_surface=True,
+        internal_gateway_token="billing-only",  # noqa: S106 - test placeholder.
+    )
+    monkeypatch.setattr(cli_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(cli_module, "_probe_and_rotation_pass", empty_pass)
+    monkeypatch.setenv("TR_SYNTHETIC_RUNS_PER_INVOCATION", "1")
+    monkeypatch.delenv("TR_SYNTHETIC_REMEDIATOR_URL", raising=False)
+    monkeypatch.delenv("TR_SYNTHETIC_ROTATION_ENABLED", raising=False)
+    monkeypatch.delenv("TR_SYNTHETIC_THROUGHPUT_ENABLED", raising=False)
+    monkeypatch.delenv("TR_SYNTHETIC_THROUGHPUT_ONLY", raising=False)
+
+    assert await cli_module.run() == 0
+    assert transaction_tokens == ["billing-only"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Root cause\n\nPR #714 correctly removed billing authority from split observer jobs, but also unconditionally disabled authorize, settle, and fallback probes in the temporary combined migration bridge. Production is still on that bridge, so transaction samples stopped after the hardened monitor image deployed on Aug 22.\n\n## Fix\n\n- allow transaction probes only for the explicit combined migration bridge\n- keep split observer jobs unable to use billing authority\n- add a 15-minute dead-man detector for authorize, settle, and fallback sample freshness\n- add regression and isolation tests\n\n## Verification\n\n- regression test failed before the implementation and passes after it\n- ruff clean\n- mypy clean\n- 567 focused synthetic, service-surface, admission, and deployment tests pass