### PR TITLE
Update homepage provider and model counts

### DIFF
--- a/src/trusted_router/static/charter.css
+++ b/src/trusted_router/static/charter.css
@@ -1226,7 +1226,7 @@ pre {
 
 .charter-stat-band {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   padding-top: 16px;
   padding-bottom: 16px;
   border-top: 1px solid var(--border-default);
@@ -2068,13 +2068,9 @@ body.auth.auth-shell {
   }
 
   .charter-stat-band {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     padding-right: 20px;
     padding-left: 20px;
-  }
-
-  .charter-stat:nth-child(2) {
-    border-right: 0;
   }
 
   .home-section {

--- a/src/trusted_router/templates/dashboard.html
+++ b/src/trusted_router/templates/dashboard.html
@@ -53,7 +53,7 @@
       <div class="home-hero-copy">
         <div class="kicker">{% if alternate_brand %}Powered by TrustedRouter{% else %}Own your alpha{% endif %}</div>
         <h1>
-          <span class="hero-line">550+ AI Models at your fingertips.</span>
+          <span class="hero-line">600+ AI Models at your fingertips.</span>
           <span class="hero-line">One Unified Interface.</span>
           <em class="hero-line">Privacy with proof.</em>
         </h1>
@@ -96,7 +96,8 @@
     </section>
 
     <section class="charter-stat-band" aria-label="{{ brand_name }} facts">
-      <div class="charter-stat"><strong>550+</strong><span>AI models</span></div>
+      <div class="charter-stat"><strong>600+</strong><span>AI models</span></div>
+      <div class="charter-stat"><strong>81+</strong><span>providers</span></div>
       <div class="charter-stat"><strong>3 clouds</strong><span>GCP · AWS · Azure</span></div>
     </section>
 

--- a/tests/browser/dashboard.spec.js
+++ b/tests/browser/dashboard.spec.js
@@ -4,7 +4,7 @@ test("homepage opens sign-in modal and handles missing MetaMask", async ({ page 
   await page.goto("/");
 
   await expect(page.getByRole("heading", {
-    name: "550+ AI Models at your fingertips. One Unified Interface. Privacy with proof.",
+    name: "600+ AI Models at your fingertips. One Unified Interface. Privacy with proof.",
   })).toBeVisible();
   const headlineLines = page.locator(".charter-home-hero h1 .hero-line");
   await expect(headlineLines).toHaveCount(3);
@@ -14,8 +14,9 @@ test("homepage opens sign-in modal and handles missing MetaMask", async ({ page 
     "Better privacy, better prices, better uptime, no subscriptions.",
   );
   const homepageStats = page.locator(".charter-stat-band .charter-stat");
-  await expect(homepageStats).toHaveCount(2);
-  await expect(homepageStats.first()).toContainText("550+AI models");
+  await expect(homepageStats).toHaveCount(3);
+  await expect(homepageStats.nth(0)).toContainText("600+AI models");
+  await expect(homepageStats.nth(1)).toContainText("81+providers");
   await expect(homepageStats.last()).toContainText("3 cloudsGCP · AWS · Azure");
   await expect(page.locator(".region-map-card")).toHaveCount(0);
   await expect(page.locator("body")).toHaveCSS("font-size", "15.5px");
@@ -406,7 +407,7 @@ test("homepage and console redirect are usable on mobile width", async ({ page }
   await page.goto("/");
 
   await expect(page.getByRole("heading", {
-    name: "550+ AI Models at your fingertips. One Unified Interface. Privacy with proof.",
+    name: "600+ AI Models at your fingertips. One Unified Interface. Privacy with proof.",
   })).toBeVisible();
   let overflow = await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth);
   expect(overflow).toBeLessThanOrEqual(2);

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -676,10 +676,11 @@ def test_dashboard_links_to_public_models_not_keyed_api_catalog(client: TestClie
     # Redesigned homepage (2026-06): a static routing-diagram hero replaces the
     # animated orbital scene, on the friend-provided modern layout. Assert the
     # new conversion surface rather than the old orbital-scene markup.
-    assert "550+ AI Models at your fingertips." in response.text
+    assert "600+ AI Models at your fingertips." in response.text
     assert "One Unified Interface." in response.text
     assert "Privacy with proof." in response.text
     assert "Better privacy, better prices, better uptime, no subscriptions." in response.text
+    assert '<strong>81+</strong><span>providers</span>' in response.text
     assert '<strong>3 clouds</strong><span>GCP · AWS · Azure</span>' in response.text
     assert 'class="region-map-card"' not in response.text
     assert "Provable privacy." not in response.text


### PR DESCRIPTION
Updates the homepage to advertise 600+ AI models and 81+ providers while retaining the 3-cloud proof point. Expands the fact band to three responsive columns and updates server-rendered and Playwright assertions. Focused homepage test, Ruff, mypy, diff-check, and independent review are green; full no-space suite is running.