### PR TITLE
Hold Sakana routes under global region policy

### DIFF
--- a/scripts/pricing/providers/sakana.py
+++ b/scripts/pricing/providers/sakana.py
@@ -15,6 +15,8 @@ from scripts.pricing.providers._direct_openai import DirectOpenAIProvider, Direc
 from trusted_router.provider_contracts import (
     SAKANA_FUGU_MODEL_ID,
     SAKANA_FUGU_ROUTE_HOLD_REASON,
+    SAKANA_NAMAZU_MODEL_ID,
+    SAKANA_NAMAZU_ROUTE_HOLD_REASON,
 )
 
 SLUG = "sakana"
@@ -26,9 +28,9 @@ MANIFEST_STALE_FALLBACK = True
 
 MODEL_MAP = {
     "fugu-ultra-v1.1": SAKANA_FUGU_MODEL_ID,
-    "sakana-namazu-v1.0": "sakana-ai/sakana-namazu-v1.0",
+    "sakana-namazu-v1.0": SAKANA_NAMAZU_MODEL_ID,
 }
-EXPECTED_MODELS = ("sakana-ai/sakana-namazu-v1.0",)
+EXPECTED_MODELS = (SAKANA_NAMAZU_MODEL_ID,)
 logger = logging.getLogger("pricing")
 
 
@@ -138,7 +140,7 @@ def _parse_pricing(html: str) -> dict[str, ModelPrice]:
     """Strictly parse every published Sakana chat price for regression tests."""
 
     soup = BeautifulSoup(html, "html.parser")
-    prices = {"sakana-ai/sakana-namazu-v1.0": _parse_namazu_price(soup)}
+    prices = {SAKANA_NAMAZU_MODEL_ID: _parse_namazu_price(soup)}
     fugu = _parse_fugu_price(soup)
     if fugu is not None:
         prices[SAKANA_FUGU_MODEL_ID] = fugu
@@ -147,7 +149,7 @@ def _parse_pricing(html: str) -> dict[str, ModelPrice]:
 
 def _load_prices() -> dict[str, ModelPrice]:
     soup = BeautifulSoup(fetch_html(PRICING_URL), "html.parser")
-    prices = {"sakana-ai/sakana-namazu-v1.0": _parse_namazu_price(soup)}
+    prices = {SAKANA_NAMAZU_MODEL_ID: _parse_namazu_price(soup)}
     try:
         fugu = _parse_fugu_price(soup)
     except RuntimeError as exc:
@@ -224,7 +226,8 @@ CATALOG = DirectOpenAIProvider(
         include=_include,
         normalize_rows=_normalize_rows,
         operator_hold_reasons={
-            SAKANA_FUGU_MODEL_ID: SAKANA_FUGU_ROUTE_HOLD_REASON
+            SAKANA_FUGU_MODEL_ID: SAKANA_FUGU_ROUTE_HOLD_REASON,
+            SAKANA_NAMAZU_MODEL_ID: SAKANA_NAMAZU_ROUTE_HOLD_REASON,
         },
         canary_max_tokens=64,
         canary_expected_content="PONG",

--- a/src/trusted_router/data/provider_models/sakana.json
+++ b/src/trusted_router/data/provider_models/sakana.json
@@ -58,7 +58,8 @@
       "upstream_id": "sakana-namazu-v1.0",
       "context_length": 256000,
       "created": 1785715200,
-      "routable": true,
+      "routable": false,
+      "routable_reason": "provider-geographic-restriction",
       "input_token_price_per_m": 950000,
       "output_token_price_per_m": 4000000,
       "cached_input_token_price_per_m": 150000

--- a/src/trusted_router/provider_contracts.py
+++ b/src/trusted_router/provider_contracts.py
@@ -2,13 +2,27 @@
 
 SAKANA_FUGU_MODEL_ID = "sakana-ai/fugu-ultra-v1.1"
 SAKANA_FUGU_ROUTE_HOLD_REASON = "unbounded-provider-orchestration-cost"
-OPERATOR_HELD_PROVIDER_MODELS = frozenset({("sakana", SAKANA_FUGU_MODEL_ID)})
+SAKANA_NAMAZU_MODEL_ID = "sakana-ai/sakana-namazu-v1.0"
+SAKANA_NAMAZU_ROUTE_HOLD_REASON = "provider-geographic-restriction"
+OPERATOR_HELD_PROVIDER_MODELS = frozenset(
+    {
+        ("sakana", SAKANA_FUGU_MODEL_ID),
+        ("sakana", SAKANA_NAMAZU_MODEL_ID),
+    }
+)
 
 # Fugu cannot be enabled by changing its manifest alone. Its provider-side
 # orchestration is not bounded by the caller's max output tokens, so authorize
 # cannot reserve a trustworthy ceiling. Enabling it requires a bounded provider
 # contract plus a durable authorization-time lower bound for its private tier
 # selector.
+
+# Sakana's terms exclude the EEA, UK, and Switzerland, and its edge returns an
+# HTML 403 to the europe-west4 gateway. The canonical API currently includes
+# every gateway region in one DNS answer, so a region-local exclusion would
+# make ordinary Namazu calls fail nondeterministically. Keep the discovered
+# model visible but globally unroutable until canonical steering can guarantee
+# a supported egress region without bypassing Sakana's geographic policy.
 
 
 def provider_model_operator_held(provider_slug: str, model_id: str) -> bool:

--- a/tests/test_provider_wave3_catalogs.py
+++ b/tests/test_provider_wave3_catalogs.py
@@ -77,6 +77,7 @@ READY = {
     "sakana",
 }
 RUNTIME_ONLY_READY = READY - {"io-net", "sakana"}
+ROUTABLE_READY = READY - {"sakana"}
 PENDING = {
     "perceptron",
     "perplexity",
@@ -115,7 +116,8 @@ def test_wave3_ready_and_pending_providers_are_fail_closed() -> None:
 
 def test_wave3_manifests_publish_only_canaried_priced_chat_routes() -> None:
     endpoint_providers = {endpoint.provider for endpoint in MODEL_ENDPOINTS.values()}
-    assert READY <= endpoint_providers
+    assert ROUTABLE_READY <= endpoint_providers
+    assert "sakana" not in endpoint_providers
     for module in MODULES:
         manifest = json.loads(module.MANIFEST_PATH.read_text(encoding="utf-8"))
         assert manifest["provider"] == module.SLUG
@@ -128,6 +130,7 @@ def test_wave3_manifests_publish_only_canaried_priced_chat_routes() -> None:
                     "provider-canary-failed",
                     "delisted-upstream",
                     "unbounded-provider-orchestration-cost",
+                    "provider-geographic-restriction",
                 }
                 if reason == "delisted-upstream":
                     assert row.get("missing_since")

--- a/tests/test_sakana_provider.py
+++ b/tests/test_sakana_provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from dataclasses import replace
 
 import pytest
@@ -150,29 +151,52 @@ def test_sakana_routes_are_prepaid_only_and_use_the_operator_secret() -> None:
     fugu = endpoints_for_model("sakana-ai/fugu-ultra-v1.1")
     namazu = endpoints_for_model("sakana-ai/sakana-namazu-v1.0")
     assert not any(endpoint.provider == "sakana" for endpoint in fugu)
-    assert any(endpoint.provider == "sakana" for endpoint in namazu)
+    assert not any(endpoint.provider == "sakana" for endpoint in namazu)
 
 
-def test_sakana_declares_fugu_operator_hold_in_shared_fetcher() -> None:
+def test_sakana_declares_operator_holds_in_shared_fetcher() -> None:
     assert sakana.CATALOG.spec.operator_hold_reasons == {
-        sakana.SAKANA_FUGU_MODEL_ID: sakana.SAKANA_FUGU_ROUTE_HOLD_REASON
+        sakana.SAKANA_FUGU_MODEL_ID: sakana.SAKANA_FUGU_ROUTE_HOLD_REASON,
+        sakana.SAKANA_NAMAZU_MODEL_ID: sakana.SAKANA_NAMAZU_ROUTE_HOLD_REASON,
     }
 
 
-def test_sakana_fugu_is_code_held_even_if_a_manifest_route_is_enabled() -> None:
-    namazu = next(
+@pytest.mark.parametrize(
+    ("model_id", "upstream_id"),
+    [
+        (sakana.SAKANA_FUGU_MODEL_ID, "fugu-ultra-v1.1"),
+        (sakana.SAKANA_NAMAZU_MODEL_ID, "sakana-namazu-v1.0"),
+    ],
+)
+def test_sakana_routes_are_code_held_even_if_a_manifest_route_is_enabled(
+    model_id: str,
+    upstream_id: str,
+) -> None:
+    template = next(
         endpoint
-        for endpoint in endpoints_for_model("sakana-ai/sakana-namazu-v1.0")
-        if endpoint.provider == "sakana"
+        for endpoint in endpoints_for_model("deepseek/deepseek-v4-flash")
+        if endpoint.usage_type == "Credits"
     )
-    fugu = replace(
-        namazu,
-        id="sakana-ai/fugu-ultra-v1.1@sakana/test-enabled",
-        model_id=sakana.SAKANA_FUGU_MODEL_ID,
-        upstream_id="fugu-ultra-v1.1",
+    held = replace(
+        template,
+        id=f"{model_id}@sakana/test-enabled",
+        model_id=model_id,
+        provider="sakana",
+        upstream_id=upstream_id,
     )
 
     assert catalog_ingest._filter_unserved_provider_endpoints(
-        {fugu.id: fugu},
+        {held.id: held},
         explicit_model_ids=frozenset(),
     ) == {}
+
+
+def test_sakana_manifest_keeps_region_restricted_namazu_visible_but_dark() -> None:
+    manifest = json.loads(sakana.MANIFEST_PATH.read_text(encoding="utf-8"))
+    namazu = next(
+        row
+        for row in manifest["models"]
+        if row["id"] == sakana.SAKANA_NAMAZU_MODEL_ID
+    )
+    assert namazu["routable"] is False
+    assert namazu["routable_reason"] == sakana.SAKANA_NAMAZU_ROUTE_HOLD_REASON


### PR DESCRIPTION
## Summary
- keep Sakana Namazu and Fugu visible in the provider manifest while preventing either from entering authorization
- add a code-level Namazu hold that survives stale or incorrectly relisted manifests
- record the geographic-policy hold in the generated manifest

## Root cause
Sakana documents that its API is unavailable in the EEA, UK, and Switzerland and may enforce this with IP controls. Production smoke proved Namazu succeeds from us-central1, us-east4, and southamerica-east1, but Sakana returns an HTML 403 from both europe-west4 enclave addresses. Because api.trustedrouter.com currently publishes all regional enclave IPs in one DNS answer, a region-only filter would still make canonical calls fail nondeterministically.

## Verification
- `uv run ruff check ...`
- 215 focused catalog/provider tests passed
- `uv run mypy`
- direct Sakana call and three non-EU regional TrustedRouter PONGs passed before hold
- Europe West reproduced provider 403 before hold

Claude CLI could not perform the follow-up review because the local CLI is signed out. The original Sakana integration received an Opus `SAFE TO MERGE` review; this hotfix was independently reviewed after the focused suite.