### PR TITLE
Publish substantive company verification pages

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -151,6 +151,8 @@ SEO_CORE_PATHS: tuple[str, ...] = (
     # source, so adding a region adds its sitemap entry with it.
     *(f"/{slug}" for slug in MODEL_REGION_SLUGS),
     "/",
+    "/about",
+    "/contact",
     "/choose",
     "/models",
     "/providers",
@@ -2349,6 +2351,7 @@ def _organization_node(settings: Settings) -> dict[str, object]:
         "name": "TrustedRouter",
         "legalName": settings.legal_entity_name,
         "url": f"https://{domain}/",
+        "mainEntityOfPage": f"https://{domain}/about",
         "logo": _absolute_url(settings, "/static/logo.png"),
         # EIN and DUNS are already published on /legal for procurement. Repeating
         # them here in the machine-readable node is the difference between a
@@ -2390,7 +2393,7 @@ def _organization_node(settings: Settings) -> dict[str, object]:
                 "contactType": "sales",
                 "email": settings.support_email,
                 "telephone": settings.legal_entity_phone,
-                "url": f"https://{domain}/legal",
+                "url": f"https://{domain}/contact",
                 "availableLanguage": ["en"],
             },
         ],
@@ -2915,13 +2918,101 @@ def public_legal_html(settings: Settings) -> str:
     )
 
 
+def public_about_html(settings: Settings) -> str:
+    path = "/about"
+    page_url = f"https://{settings.trusted_domain}{path}"
+    return (
+        _env()
+        .get_template("public/about.html")
+        .render(
+            json_ld_blob=_json_ld_graph(
+                settings,
+                _breadcrumb_node(settings, (("Home", "/"), ("About", path))),
+                {
+                    "@type": "AboutPage",
+                    "name": "About TrustedRouter",
+                    "url": page_url,
+                    "description": (
+                        "TrustedRouter is operated by Lore Hex Corp and provides an "
+                        "OpenAI-compatible, attested AI routing service."
+                    ),
+                    "mainEntity": {"@id": f"https://{settings.trusted_domain}/#organization"},
+                },
+            ),
+            api_base_url=settings.api_base_url,
+            site_url=page_url,
+            title="About TrustedRouter | Company, Product & Trust",
+            heading="About TrustedRouter",
+            description=(
+                "Meet the company behind TrustedRouter, review its legal identity, product, "
+                "open-source infrastructure, customers, and independently checkable trust evidence."
+            ),
+            entity=legal_entity(settings),
+            google_enabled=settings.google_oauth_enabled,
+            github_enabled=settings.github_oauth_enabled,
+            static_version=_static_version(settings),
+        )
+    )
+
+
+def public_contact_html(settings: Settings) -> str:
+    path = "/contact"
+    page_url = f"https://{settings.trusted_domain}{path}"
+    return (
+        _env()
+        .get_template("public/contact.html")
+        .render(
+            json_ld_blob=_json_ld_graph(
+                settings,
+                _breadcrumb_node(settings, (("Home", "/"), ("Contact", path))),
+                {
+                    "@type": "ContactPage",
+                    "name": "Contact TrustedRouter",
+                    "url": page_url,
+                    "description": (
+                        "Direct product, business, support, security, privacy, legal, and "
+                        "procurement contact details for TrustedRouter and Lore Hex Corp."
+                    ),
+                    "mainEntity": {"@id": f"https://{settings.trusted_domain}/#organization"},
+                },
+            ),
+            api_base_url=settings.api_base_url,
+            site_url=page_url,
+            title="Contact TrustedRouter | Support, Security & Business",
+            heading="Contact TrustedRouter",
+            description=(
+                "Contact Lore Hex Corp for TrustedRouter product, business, support, security, "
+                "privacy, legal, procurement, billing, and account questions."
+            ),
+            entity=legal_entity(settings),
+            support_email=settings.support_email,
+            google_enabled=settings.google_oauth_enabled,
+            github_enabled=settings.github_oauth_enabled,
+            static_version=_static_version(settings),
+        )
+    )
+
+
 def public_privacy_html(settings: Settings) -> str:
+    path = "/privacy"
+    page_url = f"https://{settings.trusted_domain}{path}"
     return (
         _env()
         .get_template("public/privacy.html")
         .render(
+            json_ld_blob=_json_ld_graph(
+                settings,
+                _breadcrumb_node(settings, (("Home", "/"), ("Privacy", path))),
+                {
+                    "@type": "WebPage",
+                    "name": "TrustedRouter Privacy Policy",
+                    "url": page_url,
+                    "dateModified": "2026-08-24",
+                    "about": {"@id": f"https://{settings.trusted_domain}/#organization"},
+                },
+            ),
             api_base_url=settings.api_base_url,
-            site_url=f"https://{settings.trusted_domain}/privacy",
+            site_url=page_url,
             title="Privacy Policy | TrustedRouter",
             heading="Privacy policy",
             description=(
@@ -4106,6 +4197,9 @@ def llms_txt(settings: Settings) -> str:
         "",
         "## Primary Links",
         f"- [Homepage](https://{domain}/)",
+        f"- [About TrustedRouter](https://{domain}/about)",
+        f"- [Contact TrustedRouter](https://{domain}/contact)",
+        f"- [Privacy policy](https://{domain}/privacy)",
         f"- [Models](https://{domain}/models)",
         f"- [Providers](https://{domain}/providers)",
         f"- [AI gateway comparisons](https://{domain}/compare)",

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -59,6 +59,7 @@ from trusted_router.dashboard import (
     hipaa_readiness_json,
     llms_txt,
     procurement_json,
+    public_about_html,
     public_apps_html,
     public_baa_html,
     public_benchmark_report_html,
@@ -69,6 +70,7 @@ from trusted_router.dashboard import (
     public_chat_html,
     public_competitor_compare_html,
     public_competitor_compare_index_html,
+    public_contact_html,
     public_dpa_html,
     public_fusion_html,
     public_hipaa_readiness_html,
@@ -1260,6 +1262,14 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     @public_html_route("/security")
     async def security() -> str:
         return public_page_html(settings, "security")
+
+    @public_html_route("/about")
+    async def about() -> str:
+        return public_about_html(settings)
+
+    @public_html_route("/contact")
+    async def contact() -> str:
+        return public_contact_html(settings)
 
     @public_html_route("/legal")
     async def legal() -> str:

--- a/src/trusted_router/templates/public/_footer.html
+++ b/src/trusted_router/templates/public/_footer.html
@@ -58,6 +58,8 @@
     </div>
     <div class="footer-col">
       <h3>Company</h3>
+      <a href="/about">About</a>
+      <a href="/contact">Contact</a>
       <a href="/blog">Blog</a>
       <a href="/customers/robot-robot-human">Customer story</a>
       <a href="/resources">Resources</a>

--- a/src/trusted_router/templates/public/about.html
+++ b/src/trusted_router/templates/public/about.html
@@ -1,0 +1,60 @@
+{% extends "public/_base.html" %}
+{% block body %}
+<article data-substantive-content="about">
+  <section class="public-proof-strip" aria-label="TrustedRouter company facts">
+    <div><strong>Operator</strong><span>{{ entity.name }}</span></div>
+    <div><strong>Entity</strong><span>{{ entity.type }}</span></div>
+    <div><strong>Founder</strong><span>{{ entity.signatory_name }}</span></div>
+    <div><strong>Headquarters</strong><span>{{ entity.address }}</span></div>
+  </section>
+
+  <section class="marketing-split">
+    <div class="marketing-copy">
+      <span class="eyebrow">The company</span>
+      <h2>One inspectable route to the models developers actually use.</h2>
+      <p>TrustedRouter is an AI routing company operated by {{ entity.name }}, a {{ entity.type }}. We give developers and businesses one OpenAI-compatible API for models served across multiple providers, with routing controls for price, reliability, region, and privacy posture.</p>
+      <p>Founder {{ entity.signatory_name }} started TrustedRouter around a simple problem: a model gateway should not become a new place that quietly collects every prompt. The service separates the public website and account control plane from the prompt path, publishes the gateway source, and exposes live hardware-attestation evidence so customers can check which code is running.</p>
+      <p>We build the router, provider integrations, confidential-compute gateway, model evaluations, and operational tooling in public repositories. Product claims are paired with pages a customer can inspect: live model and provider catalogs, current status, legal and procurement records, security architecture, and reproducible trust evidence.</p>
+    </div>
+    <div class="panel">
+      <div class="panel-head"><h2>Company record</h2></div>
+      <div class="panel-body">
+        <p><strong>Legal name:</strong> {{ entity.name }}</p>
+        <p><strong>Structure:</strong> {{ entity.type }}</p>
+        <p><strong>Address:</strong> {{ entity.address }}</p>
+        <p><strong>Telephone:</strong> <a href="tel:{{ entity.phone }}">{{ entity.phone }}</a></p>
+        <p><strong>EIN:</strong> {{ entity.ein }}<br><strong>DUNS:</strong> {{ entity.duns }}</p>
+        <p>The complete procurement packet, including current contract and compliance checkpoints, is published at <a href="/legal">/legal</a>.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="marketing-grid three" aria-label="How TrustedRouter operates">
+    <div class="marketing-card">
+      <span class="card-label">Product</span>
+      <h3>Compatible by design</h3>
+      <p>Applications can move to TrustedRouter by changing an OpenAI SDK base URL. The live catalog lists model IDs, prices, providers, context limits, privacy labels, and route availability instead of asking customers to rely on a static sales list.</p>
+      <a class="btn" href="/models">Browse live models</a>
+    </div>
+    <div class="marketing-card">
+      <span class="card-label">Trust</span>
+      <h3>Evidence over promises</h3>
+      <p>The hosted prompt path runs through an attested gateway. Customers can inspect the source commit, container image digest, and attestation instructions, then compare that evidence with the public code and current security documentation.</p>
+      <a class="btn" href="https://trust.trustedrouter.com">Verify the gateway</a>
+    </div>
+    <div class="marketing-card">
+      <span class="card-label">Customers</span>
+      <h3>Built for production workloads</h3>
+      <p>Teams use the service for coding agents, document workflows, research, evaluations, and applications that need access to more than one model provider. Our customer story shows how Robot, Robot &amp; Human uses one private API for legal-document work.</p>
+      <a class="btn" href="/customers/robot-robot-human">Read the customer story</a>
+    </div>
+  </section>
+
+  <section class="limitation-band">
+    <span class="pill">Verify us</span>
+    <div>
+      <p>Do not take this page as the only evidence that TrustedRouter is a real business. Check the <a href="/legal">legal and procurement packet</a>, <a href="https://github.com/Lore-Hex/quill-router">open-source router</a>, <a href="https://status.trustedrouter.com">service status</a>, <a href="https://trust.trustedrouter.com">live trust evidence</a>, and the direct channels on our <a href="/contact">contact page</a>. These records are deliberately public so a customer, auditor, or software agent can verify the operator and reach a person.</p>
+    </div>
+  </section>
+</article>
+{% endblock %}

--- a/src/trusted_router/templates/public/contact.html
+++ b/src/trusted_router/templates/public/contact.html
@@ -1,0 +1,57 @@
+{% extends "public/_base.html" %}
+{% block body %}
+<article data-substantive-content="contact">
+  <section class="public-proof-strip" aria-label="TrustedRouter contact details">
+    <div><strong>Email</strong><span><a href="mailto:{{ support_email }}">{{ support_email }}</a></span></div>
+    <div><strong>Security</strong><span><a href="mailto:{{ entity.security_contact_email }}">{{ entity.security_contact_email }}</a></span></div>
+    <div><strong>Telephone</strong><span><a href="tel:{{ entity.phone }}">{{ entity.phone }}</a></span></div>
+    <div><strong>Mail</strong><span>{{ entity.address }}</span></div>
+  </section>
+
+  <section class="model-catalog">
+    <div class="model-catalog-head">
+      <div>
+        <span class="eyebrow">Direct channels</span>
+        <h2>Reach the right person without guessing.</h2>
+      </div>
+      <p>TrustedRouter is operated by {{ entity.name }}. Use the channel that matches your request so account details and security reports reach the appropriate queue.</p>
+    </div>
+    <div class="marketing-grid three">
+      <div class="marketing-card">
+        <span class="card-label">Product and business</span>
+        <h3><a href="mailto:{{ support_email }}">{{ support_email }}</a></h3>
+        <p>Use this address for product questions, sales and enterprise discussions, integrations, model or provider availability, billing, invoices, account access, partnerships, and general company inquiries. Existing customers can also use the structured <a href="/support">support form</a>.</p>
+      </div>
+      <div class="marketing-card">
+        <span class="card-label">Security and privacy</span>
+        <h3><a href="mailto:{{ entity.security_contact_email }}">{{ entity.security_contact_email }}</a></h3>
+        <p>Use this private address for vulnerability reports, responsible disclosure, suspected incidents, privacy requests, data access or deletion requests, and questions about the attested gateway. Do not publish an unpatched vulnerability or include live credentials.</p>
+      </div>
+      <div class="marketing-card">
+        <span class="card-label">Legal and procurement</span>
+        <h3>{{ entity.name }}</h3>
+        <p>Contract, DPA, BAA, subprocessor, tax, and vendor-onboarding information is collected in the <a href="/legal">legal and procurement packet</a>. Send follow-up questions to <a href="mailto:{{ support_email }}">{{ support_email }}</a> and identify the customer or organization involved.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="marketing-split">
+    <div class="marketing-copy">
+      <span class="eyebrow">Help us investigate</span>
+      <h2>Include identifiers, never secrets.</h2>
+      <p>For a routing or API problem, include the approximate UTC time, model ID, provider or route if known, region, HTTP status, and the request or generation ID. Those identifiers let us trace operational metadata without needing to see the prompt or output.</p>
+      <p>Never send an API key, BYOK provider credential, full prompt, model output, payment-card number, wallet secret, password, or other sensitive credential by email or through the support form. Redact customer data from screenshots and reproducible examples.</p>
+      <p>Support is provided on a commercially reasonable basis unless a signed agreement states a specific response time. For an active availability issue, check <a href="https://status.trustedrouter.com">status.trustedrouter.com</a> first; it publishes current incidents and service history.</p>
+    </div>
+    <div class="panel">
+      <div class="panel-head"><h2>Company contact</h2></div>
+      <div class="panel-body">
+        <p><strong>{{ entity.name }}</strong><br>{{ entity.address }}</p>
+        <p><a href="tel:{{ entity.phone }}">{{ entity.phone }}</a><br><a href="mailto:{{ support_email }}">{{ support_email }}</a></p>
+        <p>For information about the company, read <a href="/about">About TrustedRouter</a>. For personal-information practices and rights requests, read the <a href="/privacy">Privacy Policy</a>.</p>
+        <p>Source-code issues that contain no customer data or credentials can be reported in the relevant <a href="https://github.com/Lore-Hex">Lore Hex GitHub repository</a>.</p>
+      </div>
+    </div>
+  </section>
+</article>
+{% endblock %}

--- a/src/trusted_router/templates/public/privacy.html
+++ b/src/trusted_router/templates/public/privacy.html
@@ -1,13 +1,16 @@
 {% extends "public/_base.html" %}
 {% block body %}
 <section class="public-proof-strip">
-  <div><strong>Effective</strong><span>August 18, 2026</span></div>
+  <div><strong>Effective</strong><span>August 24, 2026</span></div>
   <div><strong>Controller</strong><span>{{ entity.name }}</span></div>
   <div><strong>Prompt and output logs</strong><span>Never</span></div>
   <div><strong>Contact</strong><span><a href="mailto:{{ entity.security_contact_email }}">{{ entity.security_contact_email }}</a></span></div>
 </section>
 
-<section class="model-catalog legal-copy">
+<section class="model-catalog legal-copy" data-substantive-content="privacy">
+  <div class="model-catalog-head"><div><span class="eyebrow">Plain-language summary</span><h2>The privacy boundary, in brief</h2></div></div>
+  <p>TrustedRouter is operated by {{ entity.name }}. Ordinary inference requests are designed to pass through the attested gateway without becoming prompt or output logs. We retain the account, billing, security, and usage metadata needed to provide the service, and downstream model providers process requests according to the route you select. Batch is a separate, opt-in mode with encrypted temporary retention. This summary is not a replacement for the complete policy below.</p>
+
   <div class="model-catalog-head"><div><span class="eyebrow">Scope</span><h2>What this policy covers</h2></div></div>
   <p>This Privacy Policy explains how {{ entity.name }}, a {{ entity.type }}, collects, uses, discloses, and protects information when you use TrustedRouter websites, dashboards, APIs, SDKs, plugins, and related services.</p>
 
@@ -54,6 +57,6 @@
   <p>We may update this policy as the service changes. We will post the updated policy here and change the effective date. Material changes may also be communicated through the service or account email.</p>
 
   <h2>Contact</h2>
-  <p>{{ entity.name }}<br>{{ entity.address }}<br>{{ entity.phone }}<br><a href="mailto:{{ entity.security_contact_email }}">{{ entity.security_contact_email }}</a></p>
+  <p>{{ entity.name }}<br>{{ entity.address }}<br>{{ entity.phone }}<br><a href="mailto:{{ entity.security_contact_email }}">{{ entity.security_contact_email }}</a><br>Additional business and support channels are published at <a href="/contact">/contact</a>.</p>
 </section>
 {% endblock %}

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import html as html_lib
 import json
 import logging
 import re
@@ -42,6 +43,9 @@ def test_robots_and_sitemap_are_public(client: TestClient) -> None:
     assert core.status_code == 200
     assert "<urlset" in core.text
     assert "<loc>https://trustedrouter.com/eu</loc>" in core.text
+    assert "<loc>https://trustedrouter.com/about</loc>" in core.text
+    assert "<loc>https://trustedrouter.com/contact</loc>" in core.text
+    assert "<loc>https://trustedrouter.com/privacy</loc>" in core.text
     assert "<loc>https://trustedrouter.com/trust</loc>" in core.text
     assert "<loc>https://trustedrouter.com/api/reference</loc>" in core.text
     assert "<loc>https://trustedrouter.com/docs/x402</loc>" in core.text
@@ -807,6 +811,68 @@ def _json_ld(html: str) -> dict[str, object]:
     return payload
 
 
+def _substantive_page_text(page_html: str, page_name: str) -> str:
+    match = re.search(
+        rf'<(?P<tag>article|section)[^>]*data-substantive-content="{page_name}"[^>]*>'
+        r"(?P<content>.*?)</(?P=tag)>",
+        page_html,
+        flags=re.DOTALL,
+    )
+    assert match is not None
+    without_tags = re.sub(r"<[^>]+>", " ", match.group("content"))
+    return re.sub(r"\s+", " ", html_lib.unescape(without_tags)).strip()
+
+
+def test_company_verification_pages_are_substantive_and_machine_readable(
+    client: TestClient,
+) -> None:
+    pages = {
+        "about": client.get("/about"),
+        "contact": client.get("/contact"),
+        "privacy": client.get("/privacy"),
+    }
+    for page_name, response in pages.items():
+        assert response.status_code == 200
+        assert len(_substantive_page_text(response.text, page_name)) >= 500
+        assert f'<link rel="canonical" href="https://trustedrouter.com/{page_name}">' in (
+            response.text
+        )
+
+    about = pages["about"]
+    assert "About TrustedRouter | Company, Product &amp; Trust" in about.text
+    assert "Lore Hex Corp" in about.text
+    assert "Delaware C Corporation" in about.text
+    assert "Joseph Perla" in about.text
+    assert "41-5339728" in about.text
+    assert "144992055" in about.text
+
+    contact = pages["contact"]
+    assert "Contact TrustedRouter | Support, Security &amp; Business" in contact.text
+    assert "help@trustedrouter.com" in contact.text
+    assert "security@trustedrouter.com" in contact.text
+    assert "+1-305-239-7350" in contact.text
+    assert "1111 Brickell Ave" in contact.text
+
+    for response, page_type in ((about, "AboutPage"), (contact, "ContactPage")):
+        payload = _json_ld(response.text)
+        graph = payload.get("@graph")
+        assert isinstance(graph, list)
+        organization = next(node for node in graph if node.get("@type") == "Organization")
+        assert organization["legalName"] == "Lore Hex Corp"
+        assert organization["mainEntityOfPage"] == "https://trustedrouter.com/about"
+        assert any(node.get("@type") == page_type for node in graph)
+
+    privacy_payload = _json_ld(pages["privacy"].text)
+    privacy_graph = privacy_payload.get("@graph")
+    assert isinstance(privacy_graph, list)
+    assert any(node.get("name") == "TrustedRouter Privacy Policy" for node in privacy_graph)
+
+    llms = client.get("/llms.txt")
+    assert "https://trustedrouter.com/about" in llms.text
+    assert "https://trustedrouter.com/contact" in llms.text
+    assert "https://trustedrouter.com/privacy" in llms.text
+
+
 def test_public_legal_packet_exposes_procurement_checkpoint(client: TestClient) -> None:
     page = client.get("/legal")
     assert page.status_code == 200
@@ -1369,6 +1435,8 @@ def test_resources_directory_links_previous_orphan_pages(client: TestClient) -> 
         assert f'href="{path}"' in response.text, path
 
     footer = client.get("/")
+    assert 'href="/about"' in footer.text
+    assert 'href="/contact"' in footer.text
     assert 'href="/resources"' in footer.text
     assert 'href="/customers/robot-robot-human"' in footer.text
     assert 'href="/careers"' in footer.text


### PR DESCRIPTION
## Summary
- publish real, canonical About and Contact pages and expand Privacy with a plain-language summary
- expose verified operator, legal, support, security, and procurement details with structured data
- add all three pages to the core sitemap, llms.txt, and site footer

## Verification
- 97 public SEO and revenue page tests passed
- Ruff checks passed
- substantive rendered content: About 2,728 characters; Contact 2,417; Privacy 7,769
- visually reviewed the styled pages in a local browser