### PR TITLE
Give the definitively-bad key its own error type: invalid_api_key

### DIFF
--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -251,7 +251,7 @@ def _authorize_gateway_sync(
     require_internal_gateway(request, settings)
     api_key = _api_key_for_gateway_authorization(body)
     if api_key is None or api_key.disabled or is_api_key_expired(api_key.expires_at):
-        raise api_error(401, "Invalid API key", ErrorType.UNAUTHORIZED)
+        raise api_error(401, "Invalid API key", ErrorType.INVALID_API_KEY)
     workspace = STORE.get_workspace(api_key.workspace_id)
     if workspace is None:
         raise api_error(403, "Workspace is unavailable", ErrorType.FORBIDDEN)
@@ -945,7 +945,7 @@ def _gateway_validate_sync(
         api_key_lookup_hash=body.api_key_lookup_hash,
     )
     if api_key is None or api_key.disabled or is_api_key_expired(api_key.expires_at):
-        raise api_error(401, "Invalid API key", ErrorType.UNAUTHORIZED)
+        raise api_error(401, "Invalid API key", ErrorType.INVALID_API_KEY)
     workspace = STORE.get_workspace(api_key.workspace_id)
     if workspace is None:
         raise api_error(403, "Workspace is unavailable", ErrorType.FORBIDDEN)
@@ -977,7 +977,7 @@ def _gateway_key_info_sync(
         api_key_lookup_hash=body.api_key_lookup_hash,
     )
     if api_key is None or api_key.disabled or is_api_key_expired(api_key.expires_at):
-        raise api_error(401, "Invalid API key", ErrorType.UNAUTHORIZED)
+        raise api_error(401, "Invalid API key", ErrorType.INVALID_API_KEY)
     from trusted_router.routes.keys import _enriched_key_shape
 
     return {"data": _enriched_key_shape(api_key)}
@@ -994,7 +994,7 @@ def _gateway_resolve_custom_model_sync(
         api_key_lookup_hash=body.api_key_lookup_hash,
     )
     if api_key is None or api_key.disabled or is_api_key_expired(api_key.expires_at):
-        raise api_error(401, "Invalid API key", ErrorType.UNAUTHORIZED)
+        raise api_error(401, "Invalid API key", ErrorType.INVALID_API_KEY)
     workspace = STORE.get_workspace(api_key.workspace_id)
     if workspace is None:
         raise api_error(403, "Workspace is unavailable", ErrorType.FORBIDDEN)

--- a/src/trusted_router/types.py
+++ b/src/trusted_router/types.py
@@ -63,6 +63,15 @@ class ErrorType(StrEnum):
 
     BAD_REQUEST = "bad_request"
     UNAUTHORIZED = "unauthorized"
+    # A credential the customer PRESENTED that the plane definitively rejects:
+    # unknown, disabled, or expired. Split from the generic UNAUTHORIZED so the
+    # enclave's negative auth cache can discriminate this -- and only this --
+    # from every 401 that might mean the enclave's own internal credential is
+    # broken. Caching the generic type would turn one control-plane auth
+    # misconfiguration into every customer locked out for the cache TTL. This
+    # string is a WIRE CONTRACT with enclave-go/internal/authcache; both sides
+    # pin it with a test.
+    INVALID_API_KEY = "invalid_api_key"
     FORBIDDEN = "forbidden"
     VERIFICATION_REQUIRED = "verification_required"
     MODEL_OFF_THE_CLOCK = "model_off_the_clock"

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -882,7 +882,7 @@ def test_internal_gateway_rejects_disabled_key(user_headers: dict[str, str], cli
         },
     )
     assert resp.status_code == 401
-    assert resp.json()["error"]["type"] == "unauthorized"
+    assert resp.json()["error"]["type"] == "invalid_api_key"  # the enclave negative-cache wire contract
 
 
 def test_stripe_webhook_handles_stripe_object_from_construct_event(

--- a/tests/test_gateway_error_taxonomy.py
+++ b/tests/test_gateway_error_taxonomy.py
@@ -1,0 +1,22 @@
+"""The invalid_api_key wire contract with the enclave's negative auth cache.
+
+enclave-go/internal/authcache caches ONLY definitive invalid-credential
+verdicts, discriminated by this exact type string. If the string drifts, the
+cache silently never fires -- "configured, healthy, and empty" -- and every
+bad key becomes a control-plane round trip again. The enclave side pins the
+same literal in authcache/cache_test.go.
+"""
+
+from trusted_router.types import ErrorType
+
+
+def test_invalid_api_key_type_is_the_enclave_cache_contract() -> None:
+    assert ErrorType.INVALID_API_KEY == "invalid_api_key"
+
+
+def test_gateway_bad_key_sites_emit_the_contract_type() -> None:
+    from pathlib import Path
+
+    gateway = Path("src/trusted_router/routes/internal/gateway.py").read_text()
+    assert 'api_error(401, "Invalid API key", ErrorType.INVALID_API_KEY)' in gateway
+    assert 'api_error(401, "Invalid API key", ErrorType.UNAUTHORIZED)' not in gateway


### PR DESCRIPTION
The enclave's new negative auth cache must discriminate "the customer's key is definitively bad" from "the enclave's own credential is broken" — both said `type="unauthorized"` until now. Caching the latter would lock out every customer for the cache TTL on one misconfiguration.

`ErrorType.INVALID_API_KEY` (`"invalid_api_key"`) is now emitted at all four bad-customer-key sites in the internal gateway. The string is a **wire contract** with `enclave-go/internal/authcache` — pinned by a test on each side, the sealer-binding-table pattern.

Public-surface 401s in `auth.py` deliberately keep the generic type: those strings are a published contract clients may match on, and the enclave doesn't consume them.

Gates: ruff clean, mypy clean, full suite 6303/6303 after updating the one test that pinned the old generic type on the disabled-key path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)