### PR TITLE
Publish OAuth authorization server metadata for agent discovery

### DIFF
--- a/src/trusted_router/routes/oauth_keys.py
+++ b/src/trusted_router/routes/oauth_keys.py
@@ -30,6 +30,8 @@ from trusted_router.types import ErrorType
 from trusted_router.views import render_template
 
 PKCE_METHODS = {"S256", "plain"}
+OAUTH_AUTHORIZATION_ENDPOINT_PATH = "/auth"
+OAUTH_KEY_EXCHANGE_ENDPOINT_PATH = "/auth/keys"
 RESET_INTERVALS = {"daily", "weekly", "monthly"}
 OAUTH_FUNDING_AMOUNTS = {"5", "20", "100"}
 OAUTH_DEFAULT_FUNDING_AMOUNT = "20"
@@ -50,7 +52,7 @@ OAUTH_AUTHORIZATION_FIELDS = (
 
 
 def register_oauth_key_routes(router: APIRouter) -> None:
-    @router.get("/auth")
+    @router.get(OAUTH_AUTHORIZATION_ENDPOINT_PATH)
     async def oauth_authorize_page(request: Request, settings: SettingsDep) -> Response:
         params = _oauth_params_from_query(request)
         try:
@@ -151,7 +153,7 @@ def register_oauth_key_routes(router: APIRouter) -> None:
             }
         )
 
-    @router.post("/auth/keys")
+    @router.post(OAUTH_KEY_EXCHANGE_ENDPOINT_PATH)
     async def auth_keys(request: Request) -> JSONResponse:
         body = await json_body(request)
         raw_code = str(body.get("code") or "")

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -128,6 +128,11 @@ from trusted_router.provider_contract import (
 from trusted_router.public_analytics_snapshots import current_public_analytics_snapshot
 from trusted_router.request_limits import normalized_client_identity
 from trusted_router.routes.mcp import MCP_PROTOCOL_VERSION
+from trusted_router.routes.oauth_keys import (
+    OAUTH_AUTHORIZATION_ENDPOINT_PATH,
+    OAUTH_KEY_EXCHANGE_ENDPOINT_PATH,
+    PKCE_METHODS,
+)
 from trusted_router.serialization import user_model_public_shape
 from trusted_router.services.email import EmailMessage, get_email_service
 from trusted_router.services.ops_chat import OpsChatSupportMessage, fanout_support_message
@@ -1481,6 +1486,27 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
                 },
                 "capabilities": {"tools": {}},
                 "documentation": f"https://{domain}/docs/mcp",
+            },
+            headers={"cache-control": "public, max-age=300, s-maxage=3600"},
+        )
+
+    @app.get("/.well-known/oauth-authorization-server", include_in_schema=False)
+    async def oauth_authorization_server_metadata(request: Request) -> JSONResponse:
+        """Describe the delegated API-key authorization flow to public clients."""
+        origin = f"https://{request_control_domain(request, settings)}"
+        return JSONResponse(
+            {
+                "issuer": origin,
+                "authorization_endpoint": f"{origin}{OAUTH_AUTHORIZATION_ENDPOINT_PATH}",
+                "token_endpoint": f"{origin}{OAUTH_KEY_EXCHANGE_ENDPOINT_PATH}",
+                "response_types_supported": ["code"],
+                "grant_types_supported": ["authorization_code"],
+                "code_challenge_methods_supported": sorted(PKCE_METHODS),
+                "token_endpoint_auth_methods_supported": ["none"],
+                "service_documentation": f"{origin}/sign-in-with-trustedrouter",
+                # scopes_supported is deliberately absent. API keys have no scope or
+                # permission concept, so advertising scopes would falsely imply that
+                # a requested narrow scope produces anything but a full-access key.
             },
             headers={"cache-control": "public, max-age=300, s-maxage=3600"},
         )

--- a/tests/test_agent_discovery_round2.py
+++ b/tests/test_agent_discovery_round2.py
@@ -9,12 +9,17 @@ from __future__ import annotations
 
 import json
 import re
+from urllib.parse import urlsplit
 
 import pytest
+from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 
 from trusted_router.config import Settings
 from trusted_router.dashboard import llms_txt
+from trusted_router.domains import configured_control_domains
+from trusted_router.main import create_app
+from trusted_router.routes.oauth_keys import PKCE_METHODS
 
 PAGES_WITH_STRUCTURED_DATA = ["/", "/trust", "/docs", "/models", "/legal", "/support"]
 
@@ -94,6 +99,82 @@ def test_the_discovery_document_matches_the_server_it_describes(
 
     assert document["protocolVersion"] == MCP_PROTOCOL_VERSION
     assert document["name"] == "trustedrouter"
+
+
+def test_oauth_authorization_server_metadata_resolves_to_mounted_routes(
+    client: TestClient,
+) -> None:
+    response = client.get("/.well-known/oauth-authorization-server")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/json"
+    document = json.loads(response.text)
+    assert document == response.json()
+
+    advertised_routes = {
+        "issuer": "GET",
+        "authorization_endpoint": "GET",
+        "token_endpoint": "POST",
+        "service_documentation": "GET",
+    }
+    for field, method in advertised_routes.items():
+        parsed = urlsplit(document[field])
+        assert parsed.scheme == "https", field
+        assert parsed.netloc == "trustedrouter.com", field
+        path = parsed.path or "/"
+        assert any(
+            route.path == path and method in (route.methods or set())
+            for route in client.app.routes
+            if isinstance(route, APIRoute)
+        ), field
+
+    assert document["response_types_supported"] == ["code"]
+    assert document["grant_types_supported"] == ["authorization_code"]
+    assert document["token_endpoint_auth_methods_supported"] == ["none"]
+
+
+def test_oauth_metadata_pkce_methods_match_the_exchange_exactly(client: TestClient) -> None:
+    document = client.get("/.well-known/oauth-authorization-server").json()
+
+    assert document["code_challenge_methods_supported"] == sorted(PKCE_METHODS)
+
+
+def test_oauth_metadata_omits_scopes_because_keys_are_not_scoped(client: TestClient) -> None:
+    document = client.get("/.well-known/oauth-authorization-server").json()
+
+    assert "scopes_supported" not in document
+
+
+@pytest.mark.parametrize(
+    "domain",
+    configured_control_domains(Settings(environment="test")),
+)
+def test_oauth_metadata_uses_each_first_party_request_domain(
+    client: TestClient,
+    domain: str,
+) -> None:
+    document = client.get(
+        "/.well-known/oauth-authorization-server",
+        headers={"host": domain},
+    ).json()
+
+    origin = f"https://{domain}"
+    assert document["issuer"] == origin
+    for field in ("authorization_endpoint", "token_endpoint", "service_documentation"):
+        assert document[field].startswith(f"{origin}/"), field
+
+
+def test_oauth_metadata_is_mounted_on_the_public_surface() -> None:
+    public_app = create_app(
+        Settings(environment="test", service_surface="public"),
+        configure_store_arg=False,
+        init_observability=False,
+    )
+    paths = {route.path for route in public_app.routes}
+
+    assert "/.well-known/oauth-authorization-server" in paths
+    response = TestClient(public_app).get("/.well-known/oauth-authorization-server")
+    assert response.status_code == 200
 
 
 def test_llms_txt_is_a_navigation_index() -> None:

--- a/tests/test_service_surface_routing.py
+++ b/tests/test_service_surface_routing.py
@@ -113,6 +113,7 @@ def test_every_combined_route_sent_to_public_is_mounted_by_public() -> None:
         "/leaderboard",
         "/static/charter.css",
         "/robots.txt",
+        "/.well-known/oauth-authorization-server",
         "/health",
         "/ready",
     ],


### PR DESCRIPTION
TrustedRouter **is** an OAuth authorization server for API-key issuance, and none of it was discoverable. An agent holding only the hostname had to read a marketing page to find the flow — the same gap `/.well-known/mcp.json` was added to close.

## The flow that already exists

| Endpoint | Role |
|---|---|
| `GET /auth` | authorization page |
| `POST /auth/approve` | user consent |
| `POST /auth/keys/code` | issues an authorization code (authenticated) |
| `POST /auth/keys` | **token endpoint** — consumes the code, verifies PKCE, mints the key |

Real PKCE: `PKCE_METHODS = {"S256", "plain"}`, with `code_challenge` and `code_challenge_method` validated.

## What is published

RFC 8414 metadata at `/.well-known/oauth-authorization-server`, every value derived from what the code accepts rather than from the RFC's examples — `code_challenge_methods_supported` reads from `PKCE_METHODS`, and the response/grant types list only what the flow implements. URLs are domain-aware, since the app serves several first-party domains.

## scopes_supported is deliberately omitted

There is **no scope concept anywhere**: the flow never reads a `scope` parameter and API keys carry no scopes or permissions. Declaring `scopes_supported` would advertise least-privilege that does not exist — an agent would request a narrow scope, receive a **full-access key**, and believe it was restricted. RFC 8414 makes the field optional, so omitting it is the honest signal.

A comment and a test both record this, so adding scopes later is a deliberate act that follows building scoped keys rather than preceding it.

## Placement

Registered in `public.py` with the other `.well-known` handlers, **not** beside the OAuth routes. The URL map points `/.well-known/*` at the public surface — now live in production — and `mcp_discovery`'s own docstring records an earlier version being registered next to its server and therefore missing from the app actually serving those paths. The map-vs-mounts guard covers the new path.

Reviewer-verified: `/auth/keys` is genuinely the token endpoint (it calls `consume_oauth_authorization_code`, runs `_verify_pkce`, then mints), not `/auth/keys/code` which issues the code.

99 targeted tests pass; author-run full suite 6,309.

Written by codex; reviewed by Claude / Fable.