### PR TITLE
blog: a Start here section above the archive

### DIFF
--- a/src/trusted_router/content/blog.py
+++ b/src/trusted_router/content/blog.py
@@ -28,6 +28,23 @@ class BlogPost:
         return f"/blog/{self.slug}"
 
 
+#: Posts surfaced above the archive on /blog.
+#:
+#: The index is chronological, which answers "what is newest" and not "what
+#: should I read first". A reader landing on a 38-post archive has no way to
+#: tell the two posts that explain what this company is from the twenty-six
+#: that report a benchmark result.
+#:
+#: Slugs rather than a flag on BlogPost, so the running order lives in one
+#: place and is read in one glance. `test_featured_slugs_all_resolve` fails if
+#: one stops matching a post -- a typo or a rename would otherwise empty this
+#: section in silence, and an empty featured section looks exactly like a
+#: design choice.
+FEATURED_SLUGS: tuple[str, ...] = (
+    "synth-iris-prometheus-zeus",
+    "they-are-still-training-on-your-data",
+)
+
 BLOG_POSTS: tuple[BlogPost, ...] = (
     BlogPost(
         slug="you-are-a-model-provider",

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -63,7 +63,12 @@ from trusted_router.competitor_comparisons import (
     VERIFIED_ON as COMPETITOR_COMPARISONS_VERIFIED_ON,
 )
 from trusted_router.config import Settings
-from trusted_router.content.blog import BLOG_POSTS, BLOG_POSTS_BY_SLUG, BlogPost
+from trusted_router.content.blog import (
+    BLOG_POSTS,
+    BLOG_POSTS_BY_SLUG,
+    FEATURED_SLUGS,
+    BlogPost,
+)
 from trusted_router.content.legal import (
     hipaa_readiness_packet,
     legal_entity,
@@ -2232,6 +2237,27 @@ def _blog_index_posts(settings: Settings) -> tuple[BlogIndexPost, ...]:
     )
 
 
+def _featured_blog_posts(settings: Settings) -> tuple[BlogIndexPost, ...]:
+    """The featured posts, in FEATURED_SLUGS order.
+
+    Ordered by the tuple rather than by date: the point of the section is an
+    editorial running order, and sorting it chronologically would hand that
+    decision back to the calendar.
+
+    A slug that matches no post is skipped here and fails a test instead. The
+    blog index should not 500 because somebody renamed a post, but it also
+    should not silently show one card where two were intended.
+    """
+    return tuple(
+        BlogIndexPost(
+            post=BLOG_POSTS_BY_SLUG[slug],
+            image=_blog_og_image(settings, BLOG_POSTS_BY_SLUG[slug]),
+        )
+        for slug in FEATURED_SLUGS
+        if slug in BLOG_POSTS_BY_SLUG
+    )
+
+
 def _json_ld_graph(settings: Settings, *nodes: dict[str, object] | None) -> str:
     """Every page's graph, with the operating company always in it.
 
@@ -2856,6 +2882,7 @@ def public_blog_index_html(settings: Settings) -> str:
                 "Read TrustedRouter engineering notes on attested AI routing, model evaluations, "
                 "provider privacy, confidential compute, reliability, and open source infrastructure."
             ),
+            featured=_featured_blog_posts(settings),
             posts=_blog_index_posts(settings),
             json_ld_blob=_blog_index_json_ld(settings),
             google_enabled=settings.google_oauth_enabled,

--- a/src/trusted_router/templates/public/blog_index.html
+++ b/src/trusted_router/templates/public/blog_index.html
@@ -10,6 +10,28 @@
     margin: 4px 0 10px; max-width: none; color: var(--inkstrong); }
   .blog-index-head p { color: var(--muted); font-size: 18px; line-height: 1.55;
     margin: 0 0 8px; max-width: 620px; }
+  /* Featured: a two-up card row, deliberately unlike the list below it. Same
+     visual weight as the list and the reader cannot tell which to start with,
+     which is the whole problem this section exists to fix. */
+  .blog-featured { margin: 18px 0 6px; }
+  .blog-featured-label { font-family: var(--font-mono); font-size: 12.5px;
+    letter-spacing: .08em; text-transform: uppercase; color: var(--muted);
+    margin: 0 0 12px; }
+  .blog-featured-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 22px; }
+  .blog-feature { border: 1px solid var(--line); border-radius: var(--r-panel);
+    background: var(--panel); overflow: hidden; display: flex; flex-direction: column; }
+  .blog-feature .blog-thumb { border: none; border-radius: 0;
+    border-bottom: 1px solid var(--line); }
+  .blog-feature-copy { padding: 16px 18px 18px; }
+  .blog-feature h2 { font-size: 22px; line-height: 1.25; margin: 6px 0 8px; }
+  .blog-feature h2 a { color: var(--inkstrong); text-decoration: none; }
+  .blog-feature h2 a:hover { color: var(--blue); }
+  .blog-feature .blog-dek { font-family: var(--font-display); font-size: 16.5px;
+    line-height: 1.55; color: var(--ink); margin: 0 0 10px; }
+  .blog-all-label { font-family: var(--font-mono); font-size: 12.5px;
+    letter-spacing: .08em; text-transform: uppercase; color: var(--muted);
+    margin: 34px 0 0; padding-top: 26px; border-top: 1px solid var(--line); }
   .blog-list { margin-top: 14px; }
   .blog-list-item { display: grid; grid-template-columns: minmax(190px, 260px) minmax(0, 1fr);
     gap: 22px; align-items: start; padding: 26px 0; border-top: 1px solid var(--line); }
@@ -31,6 +53,7 @@
   .blog-list-item .blog-src a { color: var(--muted); }
   @media (max-width: 700px) {
     .blog-index-head h1 { font-size: 32px; }
+    .blog-featured-grid { grid-template-columns: 1fr; }
     .blog-list-item { grid-template-columns: 1fr; gap: 12px; }
     .blog-list-item h2 { font-size: 23px; }
   }
@@ -40,6 +63,33 @@
     <h1>{{ heading }}</h1>
     <p>{{ description }}</p>
   </div>
+  {% if featured %}
+  <section class="blog-featured" aria-labelledby="featured-heading">
+    <p class="blog-featured-label" id="featured-heading">Start here</p>
+    <div class="blog-featured-grid">
+      {% for item in featured %}
+      <article class="blog-feature">
+        <a class="blog-thumb" href="{{ item.post.href }}" aria-label="Read {{ item.post.title }}">
+          <img
+            src="{{ item.image }}"
+            alt="{{ item.post.title }} visual summary"
+            loading="eager"
+            decoding="async"
+            fetchpriority="high"
+          >
+        </a>
+        <div class="blog-feature-copy">
+          <div class="blog-date">{{ item.post.published_date }}</div>
+          <h2><a href="{{ item.post.href }}">{{ item.post.title }}</a></h2>
+          <p class="blog-dek">{{ item.post.description }}</p>
+          <a class="blog-readmore" href="{{ item.post.href }}">Read &rarr;</a>
+        </div>
+      </article>
+      {% endfor %}
+    </div>
+  </section>
+  <p class="blog-all-label">All posts</p>
+  {% endif %}
   <div class="blog-list">
     {% for item in posts %}
     <article class="blog-list-item">
@@ -47,9 +97,9 @@
         <img
           src="{{ item.image }}"
           alt="{{ item.post.title }} visual summary"
-          loading="{{ 'eager' if loop.first else 'lazy' }}"
+          loading="{{ 'eager' if loop.first and not featured else 'lazy' }}"
           decoding="async"
-          {% if loop.first %}fetchpriority="high"{% endif %}
+          {% if loop.first and not featured %}fetchpriority="high"{% endif %}
         >
       </a>
       <div class="blog-copy">

--- a/tests/test_blog_featured.py
+++ b/tests/test_blog_featured.py
@@ -1,0 +1,77 @@
+"""The featured section on /blog.
+
+The index is chronological, which answers "what is newest" and not "what should
+I read first". A reader landing on a 38-post archive cannot tell the posts that
+explain what this company is from the ones reporting a benchmark result.
+
+The assertion that matters most is that the section is not empty. A featured
+section rendering zero cards looks exactly like a deliberate design choice, so
+a typo in a slug would be invisible in review and in production.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from trusted_router.config import Settings
+from trusted_router.content.blog import BLOG_POSTS_BY_SLUG, FEATURED_SLUGS
+from trusted_router.dashboard import _featured_blog_posts
+
+
+def test_featured_slugs_all_resolve() -> None:
+    """A slug that matches no post is skipped at render time so the page cannot
+    500 over an editorial typo. This is where that typo is supposed to surface
+    instead."""
+    missing = [slug for slug in FEATURED_SLUGS if slug not in BLOG_POSTS_BY_SLUG]
+
+    assert not missing, f"featured slugs match no post: {missing}"
+
+
+def test_the_featured_section_is_not_empty() -> None:
+    featured = _featured_blog_posts(Settings(environment="test"))
+
+    assert len(featured) == len(FEATURED_SLUGS)
+    assert all(item.image for item in featured)
+
+
+def test_featured_order_follows_the_tuple_not_the_calendar() -> None:
+    """The running order is editorial. Sorting by date would hand the decision
+    back to the calendar, which is what the chronological list below already
+    does."""
+    featured = _featured_blog_posts(Settings(environment="test"))
+
+    assert [item.post.slug for item in featured] == list(FEATURED_SLUGS)
+    dates = [item.post.published_date for item in featured]
+    assert dates != sorted(dates, reverse=True), (
+        "featured order coincides with newest-first, so this test proves nothing; "
+        "pick a case where editorial order and date order differ"
+    )
+
+
+def test_the_blog_index_shows_featured_above_the_archive(client: TestClient) -> None:
+    html = client.get("/blog", headers={"accept": "text/html"}).text
+
+    assert "Start here" in html
+    assert "All posts" in html
+    assert html.index("Start here") < html.index("All posts")
+    for slug in FEATURED_SLUGS:
+        assert f'href="/blog/{slug}"' in html, slug
+
+
+def test_featured_posts_still_appear_in_the_archive(client: TestClient) -> None:
+    """Featuring a post promotes it; it does not remove it from the record. A
+    reader scanning by date should still find it where its date says it is."""
+    html = client.get("/blog", headers={"accept": "text/html"})
+    archive = html.text[html.text.index("All posts") :]
+
+    for slug in FEATURED_SLUGS:
+        assert f'href="/blog/{slug}"' in archive, slug
+
+
+def test_every_post_is_still_listed(client: TestClient) -> None:
+    """The archive is the complete record; the featured section must not have
+    quietly filtered it."""
+    html = client.get("/blog", headers={"accept": "text/html"}).text
+
+    for slug in BLOG_POSTS_BY_SLUG:
+        assert f'href="/blog/{slug}"' in html, slug


### PR DESCRIPTION
A `Start here` row above the chronological list, featuring
[synth-iris-prometheus-zeus](https://trustedrouter.com/blog/synth-iris-prometheus-zeus)
and
[they-are-still-training-on-your-data](https://trustedrouter.com/blog/they-are-still-training-on-your-data).

## Why

The index is chronological, which answers "what is newest" and not "what should
I read first". Someone landing on 38 posts can't tell the two that explain what
this company is from the twenty-six reporting a benchmark result.

## Three decisions you may want different

- **Featured posts still appear in the archive below.** Featuring promotes a
  post; it doesn't remove it from the record. One line to change if you'd
  rather they not repeat.
- **Order follows `FEATURED_SLUGS`, not the calendar.** Synth renders first
  because you listed it first, even though the training-data post is newer.
  Sorting by date would hand the decision back to the calendar, which the list
  below already does.
- **The cards look unlike the list rows** — bordered, two-up, their own label.
  At equal visual weight a reader can't tell which to start with, which is the
  problem this exists to fix.

## Changing what's featured

Edit `FEATURED_SLUGS` in `src/trusted_router/content/blog.py`. A slug matching
no post is skipped at render time — the page won't 500 over an editorial typo —
and fails `test_featured_slugs_all_resolve` instead. **An empty featured
section looks identical to a deliberate design choice**, which is how that
class of mistake ships unnoticed.

## Verification

Rendered from a running server and read back: `Start here` → both posts in the
given order → `All posts` → full archive, every post still listed.

The ordering test asserts featured order **differs** from newest-first —
otherwise it would pass trivially on today's two posts and prove nothing.

6338 passed, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)