### PR TITLE
State the Azure analytics env instead of letting it default off

### DIFF
--- a/.github/workflows/check-analytics-freshness.yml
+++ b/.github/workflows/check-analytics-freshness.yml
@@ -80,9 +80,9 @@ name: Check fleet analytics freshness
 #          before #672, so it still sent Aurora DSQL a SET LOCAL
 #          statement_timeout that DSQL rejects. Redeployed.
 #   azure  was publishing no analytics section at all -- the control plane had
-#          never been redeployed past revision 0000001. Redeployed; it now
-#          reports not_configured, which is the honest answer for a cloud with
-#          no outbox and is what expects_outbox=False asserts.
+#          never been redeployed past revision 0000001. That historical deploy
+#          first reported not_configured; Azure now publishes a live Postgres
+#          outbox lag and the registry requires expects_outbox=True.
 #
 #   fleet analytics freshness: OK aws=0.0 azure=None gcp=0.287 unchecked=1
 #
@@ -285,7 +285,7 @@ jobs:
             echo
             echo "Lines marked \`(unchecked)\` are NOT failures and NOT passes. They are the"
             echo "clouds this run did not measure and why — a cloud with no public status"
-            echo "page, or one the registry declares runs no outbox at all (Azure today)."
+            echo "page, or one the registry deliberately declares runs no outbox at all."
             echo "They are printed on every run so \"we do not watch that cloud\" stays a"
             echo "visible fact instead of an absence from a list."
             echo

--- a/clickhouse/check_fleet_analytics_freshness.py
+++ b/clickhouse/check_fleet_analytics_freshness.py
@@ -36,8 +36,9 @@ one of those is safe to ignore.
 
 UNCHECKED IS A THIRD OUTCOME, AND IT IS PRINTED
     Two registry states are neither pass nor fail: a cloud with no public
-    status page (``reason=``), and a cloud that legitimately runs no
-    operational-analytics outbox (``expects_outbox=False`` -- Azure today).
+    status page (``reason=``), and a cloud deliberately declared to run no
+    operational-analytics outbox (``expects_outbox=False``). All deployed
+    clouds currently expect an outbox, including Azure.
     Failing those every day would be crying wolf about something nobody can
     fix, and the repo has already learned what that costs: see
     ``CANARY_COUNT_GATE_FROM`` in

--- a/docs/clickhouse-reliability.md
+++ b/docs/clickhouse-reliability.md
@@ -283,12 +283,13 @@ after merge instead of a morning after. Deploy all three, confirm each
 `workflow_dispatch`, then enable both triggers in the one commit the workflow
 header spells out.
 
-Two states are neither pass nor fail, and are printed as `(unchecked)` on every
-run rather than skipped: a cloud with no public status page (`reason=`), and a
-cloud that legitimately runs no outbox (`expects_outbox=False` — Azure today,
-whose deploy script sets no `TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED`). The
-second one becomes a **failure** the day that cloud publishes a real lag, which
-is the day it needs watching.
+Two registry states are neither pass nor fail, and are printed as `(unchecked)`
+on every run rather than skipped: a cloud with no public status page
+(`reason=`), and a cloud deliberately declared to run no outbox
+(`expects_outbox=False`). All deployed clouds currently expect an outbox,
+including Azure; Azure's deploy refuses to replace that live pipeline with an
+outbox-off revision when discovery fails. A future outbox-free entry becomes a
+**failure** the day it publishes a real lag, which is the day it needs watching.
 
 To ask about one cloud during an incident:
 

--- a/docs/storage-portability/multi-cloud-separation.md
+++ b/docs/storage-portability/multi-cloud-separation.md
@@ -498,11 +498,12 @@ under it, and this paragraph has already been wrong once. Ask:
 The last reading taken while editing this section: `gcp` VERIFIED, `aws` and
 `azure` both 5. That is a note about a moment, not a claim about now.
 
-**Azure has no operational-analytics outbox.** `azure_control_plane.sh` sets no
-`TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED` at all, so the cloud enqueues nothing,
-has nothing to drain, and stage (e) fails. It is a canary
-(`aws-eu-and-azure-canary.md` §3) and it still counts: a canary whose operational
-history is unrecorded cannot answer the question canaries exist to answer.
+**Azure now has a live operational-analytics outbox and drain.** Its public
+status reports the Postgres-backed lag, and `azure_control_plane.sh` discovers
+the private ClickHouse target plus its Key Vault reference before enabling the
+outbox. Because the fleet registry expects this pipeline, failed discovery
+refuses the deploy instead of silently replacing the live revision with an
+outbox-off one. An explicit operator decision is required to disable it.
 
 ### Checklist for the next cloud
 

--- a/scripts/deploy/azure_control_plane.sh
+++ b/scripts/deploy/azure_control_plane.sh
@@ -63,6 +63,8 @@ IMAGE_TAG="${IMAGE_TAG:-azure}"
 RELEASE_COMMIT="${RELEASE_COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo unknown)}"
 STATE_DIR="${STATE_DIR:-$HOME/.config/$STACK}"
 PW_FILE="${PW_FILE:-$STATE_DIR/pgpw}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 # The attested Azure gateway this control plane fronts, and the health host the
 # status page is published under.
@@ -93,6 +95,25 @@ GATEWAY_REGION_TARGETS="${GATEWAY_REGION_TARGETS:-uaenorth=quill-enclave-uaenort
 # need in order to be PROVISIONED.
 KEYS_FILE="${KEYS_FILE:-$HOME/.quill_cloud_keys.private}"
 SECRETS_DIR="${SECRETS_DIR:-$HOME/.quill-secrets}"
+
+# Operational analytics. These are the resources provisioned for the live
+# uaenorth pipeline. The app reaches the node by its private VNet address and
+# reads the password through a Container Apps Key Vault reference backed by the
+# node's existing user-assigned identity. The password value never enters this
+# process, argv, cloud-init, or an operator-visible log.
+CLICKHOUSE_NODE="${CLICKHOUSE_NODE:-tr-azure-clickhouse-$LOCATION}"
+CLICKHOUSE_VAULT="${CLICKHOUSE_VAULT:-tr-azure-analytics-kv}"
+CLICKHOUSE_SECRET_NAME="${CLICKHOUSE_SECRET_NAME:-clickhouse-default-password}"
+CLICKHOUSE_IDENTITY="${CLICKHOUSE_IDENTITY:-tr-azure-analytics-$LOCATION-id}"
+CLICKHOUSE_USER="${CLICKHOUSE_USER:-default}"
+CLICKHOUSE_DATABASE="${CLICKHOUSE_DATABASE:-default}"
+
+# This is deliberately a decision, not a boolean that could be inherited by
+# accident. The only accepted opt-out reads as an operator action in shell
+# history:
+#
+#   AZURE_ANALYTICS_OPERATOR_DECISION=disable bash scripts/deploy/azure_control_plane.sh
+AZURE_ANALYTICS_OPERATOR_DECISION="${AZURE_ANALYTICS_OPERATOR_DECISION:-}"
 
 # Federation + deferred settlement. Identity federates from the GCP home plane
 # (a peer token grants directory reads only); credits do not. Deferred
@@ -147,11 +168,89 @@ if path.exists():
 PY
 }
 
-exists az containerapp env show -g "$RG" -n "$APP_ENV" \
-  || die "no Container Apps environment '$APP_ENV' in '$RG' — run: CANARY=$STACK LOCATION=$LOCATION APP_LOCATION=$LOCATION bash scripts/deploy/azure_canary.sh"
+registry_expects_outbox() {
+  # Read the deployment contract without importing the application (a deploy
+  # host need not have its Python dependencies installed). Both the dataclass
+  # default and Azure's fleet entry are parsed, so omitting expects_outbox from
+  # the entry still means whatever the registry class says it means.
+  python3 - "$REPO_ROOT/src/trusted_router/operational_analytics_fleet.py" azure <<'PY'
+import ast
+import sys
+from pathlib import Path
 
-PG_HOST="$(az postgres flexible-server show -g "$RG" -n "$PG_NAME" --query fullyQualifiedDomainName -o tsv)"
-ACR_SERVER="$(az acr show -g "$RG" -n "$ACR" --query loginServer -o tsv)"
+path = Path(sys.argv[1])
+cloud = sys.argv[2]
+tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+default = None
+fleet_value = None
+for statement in tree.body:
+    if isinstance(statement, ast.ClassDef) and statement.name == "FleetAnalyticsEndpoint":
+        for field in statement.body:
+            if (
+                isinstance(field, ast.AnnAssign)
+                and isinstance(field.target, ast.Name)
+                and field.target.id == "expects_outbox"
+                and isinstance(field.value, ast.Constant)
+                and isinstance(field.value.value, bool)
+            ):
+                default = field.value.value
+    if isinstance(statement, ast.AnnAssign) and isinstance(statement.target, ast.Name):
+        if statement.target.id == "ANALYTICS_FRESHNESS_FLEET":
+            fleet_value = statement.value
+
+if default is None or fleet_value is None:
+    raise SystemExit(f"cannot read expects_outbox contract from {path}")
+
+matches = []
+for node in ast.walk(fleet_value):
+    if not isinstance(node, ast.Call):
+        continue
+    function_name = node.func.id if isinstance(node.func, ast.Name) else None
+    if function_name != "FleetAnalyticsEndpoint":
+        continue
+    keywords = {item.arg: item.value for item in node.keywords if item.arg is not None}
+    cloud_node = keywords.get("cloud")
+    if not isinstance(cloud_node, ast.Constant) or cloud_node.value != cloud:
+        continue
+    expected_node = keywords.get("expects_outbox")
+    if expected_node is None:
+        matches.append(default)
+    elif isinstance(expected_node, ast.Constant) and isinstance(expected_node.value, bool):
+        matches.append(expected_node.value)
+    else:
+        raise SystemExit(f"{cloud}: expects_outbox is not a literal bool in {path}")
+
+if len(matches) != 1:
+    raise SystemExit(f"expected exactly one fleet entry for {cloud}, found {len(matches)}")
+print("true" if matches[0] else "false")
+PY
+}
+
+print_analytics_discovery_failure() {
+  cat >&2 <<FAIL
+[FAIL] refusing to deploy: Azure analytics discovery was incomplete.
+
+The fleet registry says azure expects_outbox=${ANALYTICS_EXPECTS_OUTBOX_DISPLAY}. A failed
+lookup must not turn a working production outbox off.
+
+Looked for:
+  private IP   VM ${CLICKHOUSE_NODE} in resource group ${RG}: ${CLICKHOUSE_HOST:-not found}
+  password     Key Vault ${CLICKHOUSE_VAULT}, secret ${CLICKHOUSE_SECRET_NAME}: $([ -n "$CLICKHOUSE_SECRET_ID" ] && echo reference found || echo not found)
+  identity     ${CLICKHOUSE_IDENTITY} in resource group ${RG}: $([ -n "$CLICKHOUSE_IDENTITY_ID" ] && echo found || echo not found)
+  location     ${LOCATION}
+
+Verify the active account and each lookup by hand:
+  az account show --query '{name:name,id:id,tenantId:tenantId}' -o json
+  az vm list-ip-addresses -g ${RG} -n ${CLICKHOUSE_NODE} --query '[0].virtualMachine.network.privateIpAddresses[0]' -o tsv
+  az keyvault secret show --vault-name ${CLICKHOUSE_VAULT} -n ${CLICKHOUSE_SECRET_NAME} --query id -o tsv
+  az identity show -g ${RG} -n ${CLICKHOUSE_IDENTITY} --query id -o tsv
+
+If disabling this live pipeline is an explicit operator decision, say so in
+shell history and re-run with:
+  AZURE_ANALYTICS_OPERATOR_DECISION=disable bash scripts/deploy/azure_control_plane.sh
+FAIL
+}
 
 OBSERVER_TOKEN="$(read_secret trustedrouter-observer-internal-token TR_OBSERVER_INTERNAL_TOKEN)"
 MONITOR_KEY="$(read_secret trustedrouter-synthetic-monitor-api-key TR_SYNTHETIC_MONITOR_API_KEY)"
@@ -165,6 +264,55 @@ unset LEGACY_GATEWAY_TOKEN
 # The monitor key is what makes the leaderboard green: rotation calls the
 # gateway as a CUSTOMER of itself. Without it there is a status page with no
 # model rows, which reads as "no data" rather than "not measured".
+
+case "$AZURE_ANALYTICS_OPERATOR_DECISION" in
+  ""|disable) ;;
+  *) die "AZURE_ANALYTICS_OPERATOR_DECISION must be unset or exactly 'disable'" ;;
+esac
+
+ANALYTICS_EXPECTS_OUTBOX="$(registry_expects_outbox)"
+case "$ANALYTICS_EXPECTS_OUTBOX" in
+  true) ANALYTICS_EXPECTS_OUTBOX_DISPLAY=True ;;
+  false) ANALYTICS_EXPECTS_OUTBOX_DISPLAY=False ;;
+  *) die "fleet registry returned invalid expects_outbox=${ANALYTICS_EXPECTS_OUTBOX}" ;;
+esac
+
+# Resolve all three non-secret pieces before any build or Container App
+# mutation. A private address without a usable Key Vault reference and identity
+# is not a partial success: the new revision would start, then fail on first use.
+CLICKHOUSE_HOST="$(az vm list-ip-addresses -g "$RG" -n "$CLICKHOUSE_NODE" \
+  --query "[0].virtualMachine.network.privateIpAddresses[0]" -o tsv 2>/dev/null || true)"
+CLICKHOUSE_SECRET_ID="$(az keyvault secret show --vault-name "$CLICKHOUSE_VAULT" \
+  -n "$CLICKHOUSE_SECRET_NAME" --query id -o tsv 2>/dev/null || true)"
+CLICKHOUSE_IDENTITY_ID="$(az identity show -g "$RG" -n "$CLICKHOUSE_IDENTITY" \
+  --query id -o tsv 2>/dev/null || true)"
+
+ANALYTICS_DISCOVERED=true
+case "$CLICKHOUSE_HOST" in ""|None) ANALYTICS_DISCOVERED=false ;; esac
+case "$CLICKHOUSE_SECRET_ID" in ""|None) ANALYTICS_DISCOVERED=false ;; esac
+case "$CLICKHOUSE_IDENTITY_ID" in ""|None) ANALYTICS_DISCOVERED=false ;; esac
+
+if [ "$AZURE_ANALYTICS_OPERATOR_DECISION" = "disable" ]; then
+  OUTBOX_ENABLED=false
+  CLICKHOUSE_URL_EFFECTIVE=""
+  log "operator explicitly decided to disable Azure analytics; outbox OFF"
+elif [ "$ANALYTICS_DISCOVERED" = "true" ] && [ "$ANALYTICS_EXPECTS_OUTBOX" = "true" ]; then
+  OUTBOX_ENABLED=true
+  CLICKHOUSE_URL_EFFECTIVE="http://${CLICKHOUSE_HOST}:8123"
+  log "analytics ON: ${CLICKHOUSE_NODE} at ${CLICKHOUSE_URL_EFFECTIVE}; password remains in Key Vault"
+else
+  print_analytics_discovery_failure
+  if [ "$ANALYTICS_EXPECTS_OUTBOX" = "false" ]; then
+    echo "The registry does not expect an outbox, but disabling still requires the explicit operator decision above." >&2
+  fi
+  exit 1
+fi
+
+exists az containerapp env show -g "$RG" -n "$APP_ENV" \
+  || die "no Container Apps environment '$APP_ENV' in '$RG' — run: CANARY=$STACK LOCATION=$LOCATION APP_LOCATION=$LOCATION bash scripts/deploy/azure_canary.sh"
+
+PG_HOST="$(az postgres flexible-server show -g "$RG" -n "$PG_NAME" --query fullyQualifiedDomainName -o tsv)"
+ACR_SERVER="$(az acr show -g "$RG" -n "$ACR" --query loginServer -o tsv)"
 
 if exists az containerapp show -g "$RG" -n "$APP"; then
   PG_PASSWORD="$(az containerapp secret show -g "$RG" -n "$APP" --secret-name pg-password --query value -o tsv)"
@@ -293,6 +441,11 @@ ENV_VARS=(
   "TR_REMEDIATOR_IN_PROCESS_ENABLED=${OBSERVER_REMEDIATOR_IN_PROCESS_ENABLED}"
   "TR_REMEDIATOR_MODE=${OBSERVER_REMEDIATOR_MODE}"
 
+  "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=${OUTBOX_ENABLED}"
+  "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_URL=${CLICKHOUSE_URL_EFFECTIVE}"
+  "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_USER=${CLICKHOUSE_USER}"
+  "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_DATABASE=${CLICKHOUSE_DATABASE}"
+
   "TR_OBSERVER_INTERNAL_TOKEN=secretref:observer-token"
   "TR_SYNTHETIC_MONITOR_API_KEY=secretref:monitor-key"
 )
@@ -302,6 +455,12 @@ SECRET_ARGS=(
   "observer-token=${OBSERVER_TOKEN}"
   "monitor-key=${MONITOR_KEY}"
 )
+if [ "$OUTBOX_ENABLED" = "true" ]; then
+  ENV_VARS+=("TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_PASSWORD=secretref:clickhouse-password")
+  SECRET_ARGS+=(
+    "clickhouse-password=keyvaultref:${CLICKHOUSE_SECRET_ID},identityref:${CLICKHOUSE_IDENTITY_ID}"
+  )
+fi
 RETIRED_OBSERVER_ENV_VARS=(
   TR_INTERNAL_GATEWAY_TOKEN
   TR_FEDERATION_HOME_TOKEN
@@ -309,9 +468,18 @@ RETIRED_OBSERVER_ENV_VARS=(
   TR_FEDERATION_DEFERRED_SETTLEMENT_ENABLED
   TR_FEDERATION_HOME_BASE_URL
 )
+if [ "$OUTBOX_ENABLED" = "false" ]; then
+  # Remove a previously configured reference as part of the explicit opt-out.
+  # The Key Vault value remains untouched and recoverable.
+  RETIRED_OBSERVER_ENV_VARS+=(TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_PASSWORD)
+fi
 
 if exists az containerapp show -g "$RG" -n "$APP"; then
   log "updating $APP"
+  if [ "$OUTBOX_ENABLED" = "true" ]; then
+    az containerapp identity assign -g "$RG" -n "$APP" \
+      --user-assigned "$CLICKHOUSE_IDENTITY_ID" -o none
+  fi
   az containerapp secret set -g "$RG" -n "$APP" --secrets "${SECRET_ARGS[@]}" -o none
   az containerapp update -g "$RG" -n "$APP" \
     --image "$IMAGE_REF" --set-env-vars "${ENV_VARS[@]}" \
@@ -324,12 +492,17 @@ else
   log "creating $APP"
   ACR_USER="$(az acr credential show -n "$ACR" --query username -o tsv)"
   ACR_PASS="$(az acr credential show -n "$ACR" --query 'passwords[0].value' -o tsv)"
+  IDENTITY_CREATE_ARGS=()
+  if [ "$OUTBOX_ENABLED" = "true" ]; then
+    IDENTITY_CREATE_ARGS=(--user-assigned "$CLICKHOUSE_IDENTITY_ID")
+  fi
   az containerapp create -g "$RG" -n "$APP" \
     --environment "$APP_ENV" \
     --image "$IMAGE_REF" \
     --registry-server "$ACR_SERVER" \
     --registry-username "$ACR_USER" \
     --registry-password "$ACR_PASS" \
+    "${IDENTITY_CREATE_ARGS[@]}" \
     --secrets "${SECRET_ARGS[@]}" \
     --env-vars "${ENV_VARS[@]}" \
     --target-port 8080 --ingress external \
@@ -454,41 +627,36 @@ NOTE
 # ...and then the part that is NOT a note.
 #
 # Everything above provisions a control plane that serves, measures itself, and
-# publishes a status page. None of it gives this cloud an operational-analytics
-# pipeline: the ENV_VARS block sets no TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED,
-# so settle enqueues nothing, there is no outbox to drain, and no drain. On AWS
-# that same gap ran for fifteen days behind an entirely green status page
-# because the only alarm is emitted by the missing process.
+# connects to Azure's existing operational-analytics pipeline. Before the first
+# mutation it derives expects_outbox from the fleet registry and discovers the
+# node, Key Vault reference, and managed identity. If any lookup fails while the
+# registry expects the pipeline, the deploy refuses instead of translating a
+# transient CLI failure into OUTBOX_ENABLED=false.
 #
-# So this deploy now ends by asking whether the CLOUD works rather than whether
-# the script finished, and today, on Azure, it says no. That is the correct
-# answer, and no variable this script inherits changes it: the verifier's bound
+# This deploy still ends by asking whether the CLOUD works rather than whether
+# the script finished. No variable this script inherits changes the verifier's
+# answer: its bound
 # is a constant in src/ and its URL comes from the fleet registry, and the two
 # variables it reads at all -- TR_MAX_DRAIN_LAG_SECONDS and TR_STATUS_URL -- it
 # reads only in order to print that they are being IGNORED. (An earlier version
 # of this comment said the verifier "reads no environment variable at all",
 # which was a tidier sentence and not true.) It takes no flags either.
 #
-# The only way to make this exit 0 is to build the pipeline. There is no
-# exemption, no waiver and no registry field that excuses a stage: a cloud that
-# cannot be checked is NOT VERIFIED and this script exits non-zero.
+# There is no exemption, no waiver and no registry field that excuses a stage:
+# a cloud that cannot be checked is NOT VERIFIED and this script exits non-zero.
 # ---------------------------------------------------------------------------
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/deploy/cloud_complete_gate.sh
 . "${SCRIPT_DIR}/cloud_complete_gate.sh"
 
 require_cloud_complete azure "$(cat <<'NEXT'
-The Azure app is deployed and serving. The Azure CLOUD is not complete: it has
-no operational-analytics pipeline at all. To finish it:
+The Azure app, ClickHouse target, outbox configuration, and drain now exist.
+What remains is live verification of the revision just deployed:
 
-  1. give it somewhere to drain TO (a ClickHouse this cloud owns, mirroring
-     scripts/deploy/aws_eu_clickhouse.sh) — this is a COST decision, so it is
-     not made by a deploy script;
-  2. add to the ENV_VARS block in this file:
-       TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true
-       TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_URL=...  (+ user/database/password)
-  3. install a drain against it, mirroring
-     scripts/deploy/aws_eu_clickhouse_drain_install.sh;
-  4. bash scripts/deploy/verify_cloud_complete.sh azure
+  1. wait for https://azure.trustedrouter.com/status.json to publish
+     analytics.available=true, backend=postgres, and a bounded drain lag;
+  2. bash scripts/deploy/verify_cloud_complete.sh azure
+
+If either check fails, fix the reported live stage. Do not disable the outbox to
+make a failed freshness check disappear.
 NEXT
 )"

--- a/src/trusted_router/cloud_rollout_completeness.py
+++ b/src/trusted_router/cloud_rollout_completeness.py
@@ -426,14 +426,9 @@ ROLLOUT_REGISTRY: dict[str, CloudRollout] = {
     "azure": CloudRollout(
         cloud="azure",
         control_plane_script="scripts/deploy/azure_control_plane.sh",
-        # No such script exists yet: Azure has no operational-analytics outbox
-        # at all, which is the point. The stage that fails says so and names
-        # what has to be built, rather than pointing at a file that is not there.
         drain_install_command=(
-            "write it — Azure has no operational-analytics drain yet; the outbox "
-            "must be enabled in scripts/deploy/azure_control_plane.sh and a drain "
-            "installed against its ClickHouse, mirroring "
-            "scripts/deploy/aws_eu_clickhouse_drain_install.sh"
+            "confirm the existing Azure drain is live, then bash "
+            "scripts/deploy/verify_cloud_complete.sh azure"
         ),
         deploy_scripts=(
             DeployScript("scripts/deploy/azure_control_plane.sh", PROVEN_BY_EXECUTION),
@@ -976,9 +971,9 @@ def declared_outbox_value(cloud: str, root: Path | None = None) -> str | None:
     comment or in operator instructions does not count, see
     :data:`_OUTBOX_DECLARATION_PATTERNS`. These scripts say in their own headers
     that they are THE SOURCE OF TRUTH for the service environment, so the
-    absence of the variable is the absence of the setting — which is exactly
-    Azure's state: ``azure_control_plane.sh`` sets no outbox variable at all,
-    and Azure therefore enqueues nothing to drain.
+    absence of the variable is the absence of the setting. Azure and AWS now
+    both declare a deploy-time value; their runtime evidence comes from the
+    public freshness stages rather than this static read.
 
     Read as text on purpose. This must run from a laptop with no cloud
     credentials, and a check that needs ``az``/``aws`` to run is a check that
@@ -1064,10 +1059,8 @@ def outbox_fact(cloud: str, root: Path | None = None) -> str:
 def outbox_note(cloud: str, root: Path | None = None) -> str | None:
     """The extra line a stage (e) that passes on a COMPUTED value needs.
 
-    ``aws_eu_control_plane.sh`` writes ``"${OUTBOX_ENABLED}"``, which it sets to
-    ``false`` when no ClickHouse secret exists in the region. Statically that is
-    "enabled"; at runtime it may not be. Say so rather than imply more than was
-    measured.
+    AWS and Azure write ``"${OUTBOX_ENABLED}"``. Statically that is "enabled";
+    at runtime it may not be. Say so rather than imply more than was measured.
     """
     value = declared_outbox_value(cloud, root=root)
     if value is None or not value.startswith("$"):

--- a/src/trusted_router/operational_analytics_fleet.py
+++ b/src/trusted_router/operational_analytics_fleet.py
@@ -49,17 +49,15 @@ WHY A ``reason`` FIELD AND NOT AN OMISSION
     can fix is a check people learn to ignore.
 
 WHY ``expects_outbox`` AND NOT A SECOND ``reason``
-    Azure is reachable, publishes a status page, and has no operational-analytics
-    outbox at all: ``scripts/deploy/azure_control_plane.sh`` never sets
-    ``TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED``, so the flag defaults off and
-    ``PostgresStore`` holds no outbox to read. Its section says
-    ``not_configured`` and would say so forever. Retiring it behind ``reason=``
-    would work, and would also throw away the ability to notice the day it
-    changes: an outbox that gets enabled on Azure would go unwatched exactly as
-    AWS-EU's was. ``expects_outbox=False`` instead keeps fetching the page and
-    asserts the ABSENCE -- unchecked while it publishes ``not_configured``, a
-    FAILURE the moment it publishes a real lag, which is the moment somebody
-    needs to come back here and start watching it.
+    Azure originally published ``not_configured`` because its deploy script did
+    not set ``TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED``. ``expects_outbox=False``
+    kept fetching that page and asserted the absence, so enabling the pipeline
+    could not leave it unwatched. Azure now publishes a live Postgres lag and
+    keeps the default ``expects_outbox=True``; its deploy script reads this same
+    registry before mutation and refuses to turn the outbox off when resource
+    discovery fails. The false state remains for a future cloud that deliberately
+    runs no pipeline: it is explicitly unchecked while ``not_configured``, and a
+    FAILURE the moment a real lag appears.
 
 NOTHING HERE DOES IO. :mod:`clickhouse.check_fleet_analytics_freshness` fetches.
 """

--- a/tests/deploy_script_harness.py
+++ b/tests/deploy_script_harness.py
@@ -887,6 +887,21 @@ SCRIPT_FIXTURES: dict[str, ScriptFixture] = {
             ".quill-secrets/trustedrouter-synthetic-monitor-api-key": "harness-fake-monitor\n",
         },
         responses=(
+            (
+                r"vm list-ip-addresses.*tr-azure-clickhouse-uaenorth",
+                "10.61.3.4",
+            ),
+            (
+                r"keyvault secret show.*clickhouse-default-password.*--query id",
+                "https://tr-azure-analytics-kv.vault.azure.net/secrets/"
+                "clickhouse-default-password/harness-version",
+            ),
+            (
+                r"identity show.*tr-azure-analytics-uaenorth-id.*--query id",
+                "/subscriptions/harness/resourceGroups/tr-azure/providers/"
+                "Microsoft.ManagedIdentity/userAssignedIdentities/"
+                "tr-azure-analytics-uaenorth-id",
+            ),
             (r"acr build|acr import", "harness"),
             (r"--query .?loginServer", "trazureuaenorthacr.azurecr.io"),
             (r"--query .?fullyQualifiedDomainName", "tr-azure-pg.postgres.database.azure.com"),

--- a/tests/test_cloud_rollout_completeness.py
+++ b/tests/test_cloud_rollout_completeness.py
@@ -485,19 +485,11 @@ def test_the_limit_of_a_passing_lag_is_printed_on_every_passing_run(tmp_path: Pa
 # ---------------------------------------------------------------------------
 
 
-def test_azure_fails_because_it_has_no_outbox_at_all() -> None:
-    """Pins the state found on 2026-08-17, and the reason it is not benign.
-
-    Azure's control-plane deploy script sets no outbox variable, so settle
-    enqueues nothing. Every published freshness signal for such a cloud is
-    vacuously green. This test flips to the other branch when the outbox is
-    added, which is the point at which it should.
-    """
-    assert crc.declared_outbox_value("azure") is None
-    blockers = crc.outbox_enabled_blockers("azure")
-    assert blockers
-    assert "never sets TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED" in blockers[0]
-    assert "looks perfectly healthy" in blockers[0]
+def test_azure_declares_the_runtime_computed_outbox() -> None:
+    assert crc.declared_outbox_value("azure") == "${OUTBOX_ENABLED}"
+    assert crc.outbox_enabled_blockers("azure") == []
+    note = crc.outbox_note("azure")
+    assert note is not None and "computed at deploy time" in note
 
 
 def test_gcp_and_aws_declare_the_outbox() -> None:
@@ -593,11 +585,16 @@ def test_the_form_the_failure_message_prescribes_is_accepted(tmp_path: Path) -> 
     characters.
     """
     prescription = f"{crc.OUTBOX_ENABLED_ENV}=true"
-    assert prescription in crc.outbox_enabled_blockers("azure")[0]
-
     script_dir = tmp_path / "scripts" / "deploy"
     script_dir.mkdir(parents=True)
-    (script_dir / "azure_control_plane.sh").write_text(
+    target = script_dir / "azure_control_plane.sh"
+    target.write_text(
+        "#!/usr/bin/env bash\n"
+        'az containerapp update --set-env-vars "TR_ENVIRONMENT=canary"\n'
+    )
+    assert prescription in crc.outbox_enabled_blockers("azure", root=tmp_path)[0]
+
+    target.write_text(
         "#!/usr/bin/env bash\n"
         f"# {prescription}   <- a comment is still not a setting\n"
         f"{prescription}\n"

--- a/tests/test_deploy_script_execution.py
+++ b/tests/test_deploy_script_execution.py
@@ -807,6 +807,209 @@ def test_azure_observer_refuses_to_drop_its_only_synthetic_owner(
     assert not run.verifier_calls
 
 
+def _azure_without_analytics_discovery(fixture: ScriptFixture) -> ScriptFixture:
+    discovery_fragments = (
+        "vm list-ip-addresses",
+        "keyvault secret show.*clickhouse-default-password",
+        "identity show.*tr-azure-analytics-uaenorth-id",
+    )
+    return replace(
+        fixture,
+        responses=(
+            (r"vm list-ip-addresses.*tr-azure-clickhouse-uaenorth", ""),
+            (
+                r"keyvault secret show.*clickhouse-default-password.*--query id",
+                "",
+            ),
+            (
+                r"identity show.*tr-azure-analytics-uaenorth-id.*--query id",
+                "",
+            ),
+            *(
+                response
+                for response in fixture.responses
+                if not any(fragment in response[0] for fragment in discovery_fragments)
+            ),
+        ),
+    )
+
+
+def _azure_control_plane_update(run: HarnessRun) -> list[str]:
+    updates = [call for call in run.calls if call[:3] == ["az", "containerapp", "update"]]
+    assert len(updates) == 1, summarise(run)
+    return updates[0]
+
+
+def _azure_update_env(update: list[str]) -> dict[str, str]:
+    start = update.index("--set-env-vars") + 1
+    end = update.index("--remove-env-vars")
+    return {
+        argument.partition("=")[0]: argument.partition("=")[2]
+        for argument in update[start:end]
+        if "=" in argument
+    }
+
+
+def test_azure_observer_emits_the_discovered_operational_analytics_env(
+    tmp_path: Path,
+) -> None:
+    isolated = DeployScriptHarness(tmp_path / "azure-analytics-discovered")
+
+    run = isolated.run("scripts/deploy/azure_control_plane.sh", verifier_rc=0)
+
+    assert run.returncode == 0, summarise(run)
+    update = _azure_control_plane_update(run)
+    env = _azure_update_env(update)
+    assert {
+        name: env[name]
+        for name in (
+            "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED",
+            "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_URL",
+            "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_USER",
+            "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_DATABASE",
+            "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_PASSWORD",
+        )
+    } == {
+        "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED": "true",
+        "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_URL": "http://10.61.3.4:8123",
+        "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_USER": "default",
+        "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_DATABASE": "default",
+        "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_PASSWORD": "secretref:clickhouse-password",
+    }
+
+    identity_assign = next(
+        call
+        for call in run.calls
+        if call[:4] == ["az", "containerapp", "identity", "assign"]
+    )
+    secret_set = next(
+        call for call in run.calls if call[:4] == ["az", "containerapp", "secret", "set"]
+    )
+    assert run.calls.index(identity_assign) < run.calls.index(secret_set) < run.calls.index(update)
+    clickhouse_reference = next(
+        argument for argument in secret_set if argument.startswith("clickhouse-password=")
+    )
+    assert clickhouse_reference == (
+        "clickhouse-password=keyvaultref:https://tr-azure-analytics-kv.vault.azure.net/"
+        "secrets/clickhouse-default-password/harness-version,identityref:/subscriptions/"
+        "harness/resourceGroups/tr-azure/providers/Microsoft.ManagedIdentity/"
+        "userAssignedIdentities/tr-azure-analytics-uaenorth-id"
+    )
+
+
+def test_azure_observer_refuses_missing_analytics_discovery_before_any_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    script = "scripts/deploy/azure_control_plane.sh"
+    fixture = SCRIPT_FIXTURES[script]
+    monkeypatch.setitem(
+        SCRIPT_FIXTURES,
+        script,
+        _azure_without_analytics_discovery(fixture),
+    )
+    isolated = DeployScriptHarness(tmp_path / "azure-analytics-undiscoverable")
+
+    run = isolated.run(script, verifier_rc=0)
+
+    assert run.returncode != 0
+    assert "expects_outbox=True" in run.stderr
+    assert "tr-azure-clickhouse-uaenorth" in run.stderr
+    assert "tr-azure-analytics-kv" in run.stderr
+    assert "az vm list-ip-addresses -g tr-azure -n tr-azure-clickhouse-uaenorth" in run.stderr
+    assert "az keyvault secret show --vault-name tr-azure-analytics-kv" in run.stderr
+    mutating_prefixes = (
+        ["az", "acr", "build"],
+        ["az", "acr", "import"],
+        ["az", "containerapp", "identity", "assign"],
+        ["az", "containerapp", "secret", "set"],
+        ["az", "containerapp", "update"],
+        ["az", "containerapp", "create"],
+        ["az", "containerapp", "revision", "set-mode"],
+        ["az", "postgres", "flexible-server", "firewall-rule"],
+        ["gcloud", "dns"],
+        ["psql"],
+    )
+    assert not any(
+        call[: len(prefix)] == prefix for call in run.calls for prefix in mutating_prefixes
+    ), summarise(run)
+    assert not run.verifier_calls
+
+
+def test_azure_observer_missing_analytics_requires_an_explicit_operator_opt_out(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    script = "scripts/deploy/azure_control_plane.sh"
+    fixture = SCRIPT_FIXTURES[script]
+    monkeypatch.setitem(
+        SCRIPT_FIXTURES,
+        script,
+        _azure_without_analytics_discovery(fixture),
+    )
+    isolated = DeployScriptHarness(tmp_path / "azure-analytics-explicit-opt-out")
+
+    run = isolated.run(
+        script,
+        verifier_rc=0,
+        extra_env={"AZURE_ANALYTICS_OPERATOR_DECISION": "disable"},
+    )
+
+    assert run.returncode == 0, summarise(run)
+    update = _azure_control_plane_update(run)
+    env = _azure_update_env(update)
+    assert env["TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED"] == "false"
+    assert env["TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_URL"] == ""
+    assert "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_PASSWORD" not in env
+    removed = update[
+        update.index("--remove-env-vars") + 1 : update.index("--min-replicas")
+    ]
+    assert "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_PASSWORD" in removed
+    assert "operator explicitly decided to disable Azure analytics" in run.stderr
+
+
+def test_azure_observer_keeps_all_retired_private_env_names_absent(tmp_path: Path) -> None:
+    isolated = DeployScriptHarness(tmp_path / "azure-retired-env-absent")
+
+    run = isolated.run("scripts/deploy/azure_control_plane.sh", verifier_rc=0)
+
+    assert run.returncode == 0, summarise(run)
+    update = _azure_control_plane_update(run)
+    env = _azure_update_env(update)
+    retired = {
+        "TR_INTERNAL_GATEWAY_TOKEN",
+        "TR_FEDERATION_HOME_TOKEN",
+        "TR_FEDERATION_SETTLEMENT_HOME_TOKEN",
+        "TR_FEDERATION_DEFERRED_SETTLEMENT_ENABLED",
+        "TR_FEDERATION_HOME_BASE_URL",
+    }
+    assert retired.isdisjoint(env)
+    removed = set(
+        update[update.index("--remove-env-vars") + 1 : update.index("--min-replicas")]
+    )
+    assert retired <= removed
+
+
+def test_azure_clickhouse_password_never_enters_argv_or_logs(tmp_path: Path) -> None:
+    password = "harness-clickhouse-password-S3CR3T"  # noqa: S105 - leak canary
+    isolated = DeployScriptHarness(tmp_path / "azure-analytics-password-isolation")
+
+    run = isolated.run(
+        "scripts/deploy/azure_control_plane.sh",
+        verifier_rc=0,
+        extra_env={"CLICKHOUSE_PASSWORD": password},
+    )
+
+    assert run.returncode == 0, summarise(run)
+    observable = "\n".join((run.stdout, run.stderr, *("\t".join(call) for call in run.calls)))
+    assert password not in observable
+    key_vault_calls = [
+        call for call in run.calls if call[:4] == ["az", "keyvault", "secret", "show"]
+    ]
+    assert len(key_vault_calls) == 1
+    assert key_vault_calls[0][key_vault_calls[0].index("--query") + 1] == "id"
+
+
 def test_azure_canary_persists_a_missing_dedicated_attribution_secret_before_update(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Closes the half of #674 that is still needed. **This is a live regression risk, not a cleanup.**

## What is wrong today

Azure has a working ClickHouse node and drain in production — `azure.trustedrouter.com/status.json` reports `available: true` with a live `drain_lag_seconds`. But `azure_control_plane.sh`'s `ENV_VARS` block sets **no** `TR_OPERATIONAL_ANALYTICS_*` variable, so `TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED` falls back to `config.py`'s `False`. The script's own comment still says so, and `require_cloud_complete` still declares this cloud incomplete.

So redeploying the Azure control plane from a clean checkout pushes the outbox **off** over a running pipeline. `az containerapp update` happens ~160 lines before the completeness gate, so the gate failure arrives after the damage. `aws_eu_control_plane.sh` sets all four variables; Azure's set none.

## Two choices worth calling out

**The password value is never fetched.** `az keyvault secret show --query id` returns the secret's *URI*, and the container app references it as `keyvaultref:<uri>,identityref:<managed-identity>`. The plaintext never enters argv, a log line, a shell variable, or cloud-init.

**Failing to look cannot disable analytics.** The obvious implementation — *discovery empty, so set `outbox=false`* — would let an expired login, a wrong subscription, or a renamed resource group stop a working pipeline while the deploy reports success. Instead, when discovery is incomplete and the registry says azure `expects_outbox=True`, the script refuses **before any ACR, container app, schema, firewall or DNS mutation** and prints what it searched and the exact `az` commands to check by hand. `expects_outbox` is parsed out of `operational_analytics_fleet.py` rather than hardcoded, so script and registry cannot drift, and it fails closed if it cannot read the contract.

Disabling requires `AZURE_ANALYTICS_OPERATOR_DECISION=disable`, which reads as a decision in shell history. No other value is accepted.

## Deliberately not taken from #674

That branch predates main's refactor and still adds `TR_INTERNAL_GATEWAY_TOKEN` and the `TR_FEDERATION_*` settlement variables that main **retired**, and still carries the pre-VNet `APP_ENV=$STACK-env`. This is cut against current main instead; a test pins all five retired names as absent.

## Verification

Refusal gate verified by mutation: converting the refusal into a silent disable — the exact footgun above — turns the test red; restoring it turns it green. 214 deploy/analytics/completeness tests pass, `bash -n`, `shellcheck -x`, ruff and mypy clean. No live Azure resource was touched.

Also corrects the comments and docs that still asserted Azure runs no outbox (`docs/clickhouse-reliability.md`, `clickhouse/check_fleet_analytics_freshness.py`), which contradicted the registry.