### PR TITLE
Audit and repair typed total_usage, not just reserved

### DIFF
--- a/src/trusted_router/storage_gcp_counter_reconcile.py
+++ b/src/trusted_router/storage_gcp_counter_reconcile.py
@@ -40,6 +40,65 @@ _OPEN_REGIONAL_QUOTA_ESCROW = (
     "ORDER BY open_index.id"
 )
 _OPEN_REGIONAL_QUOTA_STATES = frozenset({"pending", "active", "draining", "quarantined"})
+# ── Typed `total_usage` ledger reconstruction ───────────────────────────────
+# `total_usage` has exactly TWO writers on this store, and both leave a durable
+# row, so the counter is reconstructible rather than merely trusted:
+#
+#   1. the typed settle (storage_gcp_counter_dml.release_credit) adds `actual`,
+#      and only for Credits traffic -- storage_gcp_authorize passes
+#      `book_actual if settled_usage_type == "Credits" else 0`, so a non-Credits
+#      settle bumps nothing. Its row is the settled tr_reservation.
+#   2. deferred federated settlement (storage_gcp_federated_settlement) adds a
+#      peer plane's debt straight to `total_usage`, with NO reservation in this
+#      plane -- the authorize happened elsewhere. Its row is the insert-once
+#      federated_settlement_claim.
+#
+# Summing only (1) -- which is what the retired PR #89 did -- reads every
+# federated microdollar as drift. Both arms are required.
+_SETTLED_CREDIT_ACTUALS = (
+    "SELECT COALESCE(SUM(actual_micro), 0) FROM tr_reservation "
+    "WHERE workspace_id=@ws AND ws_shard=0 AND settled=true "
+    "AND settled_usage_type='Credits'"
+)
+_FEDERATED_SETTLEMENT_APPLIED = (
+    "/* federated_settlement_applied */ "
+    "SELECT COALESCE(SUM(CAST(JSON_VALUE(body, '$.cost_microdollars') AS INT64)), 0) "
+    "FROM tr_entities WHERE kind='federated_settlement_claim' "
+    "AND JSON_VALUE(body, '$.workspace_id')=@ws"
+)
+#: The pre-flip baseline typed `total_usage` was seeded from. Rows created after
+#: the flip omit `total_usage` at insert (storage_gcp_counters.CREDIT_BALANCE_COLUMNS)
+#: so they start at the Spanner default 0 and need no baseline at all.
+#:
+#: This field is REMOVED by the reviewed cleanup migration
+#: (storage_gcp_credit_json_cleanup.LEGACY_CREDIT_MONEY_FIELDS) and its value is
+#: not archived anywhere. So absent means one of two things we cannot tell apart:
+#: a post-flip workspace whose baseline is genuinely 0, or a pre-flip workspace
+#: whose baseline was deleted. The audit reports those as UNAUDITABLE rather than
+#: guessing 0, because guessing 0 would report every pre-flip workspace's entire
+#: historical spend as drift.
+_JSON_USAGE_BASELINE = (
+    "/* json_usage_baseline */ "
+    "SELECT id, JSON_VALUE(body, '$.total_usage_microdollars') "
+    "FROM tr_entities WHERE kind='credit'"
+)
+_TYPED_USAGE_ROWS = "SELECT workspace_id, shard, total_usage FROM tr_credit_balance"
+#: Fleet-wide forms of the two ledger arms, grouped so the audit stays ONE
+#: snapshot rather than two queries per workspace.
+_SETTLED_CREDIT_ACTUALS_BY_WS = (
+    "SELECT workspace_id, COALESCE(SUM(actual_micro), 0) FROM tr_reservation "
+    "WHERE ws_shard=0 AND settled=true AND settled_usage_type='Credits' "
+    "GROUP BY workspace_id"
+)
+_FEDERATED_SETTLEMENT_APPLIED_BY_WS = (
+    "/* federated_settlement_applied_by_ws */ "
+    "SELECT JSON_VALUE(body, '$.workspace_id'), "
+    "COALESCE(SUM(CAST(JSON_VALUE(body, '$.cost_microdollars') AS INT64)), 0) "
+    "FROM tr_entities WHERE kind='federated_settlement_claim' "
+    "GROUP BY JSON_VALUE(body, '$.workspace_id')"
+)
+
+
 _NONCLOSED_REGIONAL_QUOTA_LEASES_FOR_REPAIR = (
     "/* nonclosed_regional_quota_leases_for_repair */ "
     "SELECT COUNT(*) FROM tr_entities "
@@ -58,22 +117,44 @@ class InvariantReport:
     credit_violations: int = 0  # reserved != open-hold sum, or reserved < 0
     key_violations: int = 0
     regional_lease_violations: int = 0
+    usage_rows: int = 0
+    usage_violations: int = 0  # total_usage != baseline + settled actuals + federated
+    #: Rows whose baseline is unrecoverable, so usage can be neither confirmed nor
+    #: faulted. Counted apart from violations: calling them clean would overstate
+    #: coverage, and calling them violations would cry wolf on every workspace the
+    #: JSON cleanup has already run against.
+    usage_unauditable: int = 0
     samples: dict[str, dict] = field(default_factory=dict)
 
     @property
     def clean(self) -> bool:
+        """No violated invariant. Says nothing about `usage_unauditable` -- see
+        `fully_audited` for whether the sweep actually covered everything."""
         return (
             self.credit_violations == 0
             and self.key_violations == 0
             and self.regional_lease_violations == 0
+            and self.usage_violations == 0
         )
 
+    @property
+    def fully_audited(self) -> bool:
+        """Every row was checkable. CLEAN with unauditable rows is a narrower
+        claim than it looks, and an operator reading only `clean` would not see
+        the difference."""
+        return self.usage_unauditable == 0
+
     def summary(self) -> str:
+        usage = f"usage: {self.usage_violations}/{self.usage_rows}"
+        if self.usage_unauditable:
+            usage += f" ({self.usage_unauditable} unauditable)"
         return (
             f"credit: {self.credit_violations}/{self.credit_rows} | "
             f"key: {self.key_violations}/{self.key_rows} | "
             f"regional lease: {self.regional_lease_violations}/{self.regional_lease_rows} | "
+            f"{usage} | "
             f"{'CLEAN' if self.clean else 'VIOLATIONS'}"
+            f"{'' if self.fully_audited else ' (PARTIAL)'}"
         )
 
 
@@ -180,6 +261,31 @@ def audit_typed_invariants(store: Any, *, max_samples: int = 20) -> InvariantRep
             credit_holds[scope] = credit_holds.get(scope, 0) + int(row[3] or 0)
         key_holds = {(r[0], r[1]): int(r[2] or 0) for r in snap.execute_sql(_OPEN_KEY_HOLDS)}
         regional_rows = list(snap.execute_sql(_OPEN_REGIONAL_QUOTA_ESCROW))
+        # Usage arm, read in the SAME snapshot: a settle that lands between two
+        # reads would otherwise show as drift equal to its own actual.
+        # Summed ACROSS shards, unlike the reserved arm. `reserved` is compared
+        # per (scope, shard) because each shard holds its own reservations, but
+        # both usage ledgers are per-WORKSPACE -- a settled reservation and a
+        # federated claim name a workspace, not a shard. Comparing shard 0 alone
+        # against a whole-workspace ledger would report every sharded workspace's
+        # other shards as missing usage.
+        typed_usage: dict[str, int] = {}
+        for row in snap.execute_sql(_TYPED_USAGE_ROWS):
+            workspace = str(row[0])
+            typed_usage[workspace] = typed_usage.get(workspace, 0) + int(row[2] or 0)
+        settled_actuals = {
+            str(r[0]): int(r[1] or 0)
+            for r in snap.execute_sql(_SETTLED_CREDIT_ACTUALS_BY_WS)
+        }
+        federated_applied = {
+            str(r[0]): int(r[1] or 0)
+            for r in snap.execute_sql(_FEDERATED_SETTLEMENT_APPLIED_BY_WS)
+            if r[0] is not None
+        }
+        usage_baselines = {
+            str(r[0]): (None if r[1] is None else int(r[1]))
+            for r in snap.execute_sql(_JSON_USAGE_BASELINE)
+        }
 
     regional_holds, regional_errors = _regional_quota_escrow(regional_rows)
     for scope, held in regional_holds.items():
@@ -209,6 +315,58 @@ def audit_typed_invariants(store: Any, *, max_samples: int = 20) -> InvariantRep
 
     report.credit_rows, report.credit_violations = _check(typed_credit, credit_holds, "credit")
     report.key_rows, report.key_violations = _check(typed_key, key_holds, "api_key")
+    # ── usage: total_usage must equal everything the ledger says was booked ──
+    # Both directions again, in the same spirit as _check: a federated claim or a
+    # settled actual for a workspace with NO typed row is a booking that landed
+    # nowhere, and iterating typed rows alone cannot see it.
+    for workspace_id, actual_usage in typed_usage.items():
+        report.usage_rows += 1
+        baseline = usage_baselines.get(workspace_id)
+        booked = settled_actuals.get(workspace_id, 0) + federated_applied.get(workspace_id, 0)
+        if baseline is None:
+            report.usage_unauditable += 1
+            _sample(
+                f"usage-unauditable:{workspace_id}",
+                {
+                    "typed_total_usage": actual_usage,
+                    "ledger_booked": booked,
+                    "baseline": None,
+                    "why": "no JSON total_usage_microdollars: pre-flip baseline "
+                    "deleted by the credit-JSON cleanup, or a post-flip row that "
+                    "never had one. Those are indistinguishable, so neither "
+                    "confirmed nor faulted.",
+                },
+            )
+            continue
+        expected = baseline + booked
+        if actual_usage != expected or actual_usage < 0:
+            report.usage_violations += 1
+            _sample(
+                f"usage:{workspace_id}",
+                {
+                    "typed_total_usage": actual_usage,
+                    "expected": expected,
+                    "baseline": baseline,
+                    "settled_actuals": settled_actuals.get(workspace_id, 0),
+                    "federated_applied": federated_applied.get(workspace_id, 0),
+                    "delta": actual_usage - expected,
+                },
+            )
+    for workspace_id in set(settled_actuals) | set(federated_applied):
+        if workspace_id in typed_usage:
+            continue
+        booked = settled_actuals.get(workspace_id, 0) + federated_applied.get(workspace_id, 0)
+        if booked > 0:
+            report.usage_violations += 1
+            _sample(
+                f"usage-orphan-booking:{workspace_id}",
+                {
+                    "typed_total_usage": None,
+                    "settled_actuals": settled_actuals.get(workspace_id, 0),
+                    "federated_applied": federated_applied.get(workspace_id, 0),
+                },
+            )
+
     report.regional_lease_rows = len(regional_rows)
     report.regional_lease_violations = len(regional_errors)
     for index_id, error in regional_errors.items():
@@ -379,4 +537,190 @@ def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False)
         return res
     res.applied = True
     res.keys_repaired = result["keys"]
+    return res
+
+
+# ── Repair: typed `total_usage` ─────────────────────────────────────────────
+# Companion to repair_typed_reserved, and deliberately stricter. `reserved` is
+# derived from state that is still open, so recomputing it is safe whenever the
+# workspace is quiesced. `total_usage` is a MONOTONIC lifetime total: writing it
+# rewrites history, and writing it DOWN destroys the record of spend that was
+# really booked. So this refuses to lower it unless the caller says so in as
+# many words, and refuses entirely unless every hold is drained -- an open hold
+# is a settle that has not yet added its actual, which would read as an
+# over-count and "repair" the counter backwards.
+
+
+@dataclass
+class UsageRepairResult:
+    workspace_id: str
+    ready: bool
+    reasons: list[str] = field(default_factory=list)
+    applied: bool = False
+    total_usage_before: int | None = None
+    total_usage_after: int | None = None
+    baseline: int | None = None
+    settled_actuals: int = 0
+    federated_applied: int = 0
+
+    @property
+    def delta(self) -> int | None:
+        if self.total_usage_before is None or self.total_usage_after is None:
+            return None
+        return self.total_usage_after - self.total_usage_before
+
+
+def repair_typed_usage(
+    store: Any,
+    workspace_id: str,
+    *,
+    apply: bool = False,
+    allow_decrease: bool = False,
+) -> UsageRepairResult:
+    """Set typed `total_usage` = JSON baseline + settled Credits actuals +
+    federated settlement claims, for a fully drained PAUSED workspace.
+
+    Read-only when apply=False (reports before/after). Fail-closed: refuses
+    unless billing_paused, unsharded, fully drained, and the JSON baseline still
+    exists. Refuses to LOWER the counter unless allow_decrease=True."""
+    pt = store._param_types
+    res = UsageRepairResult(workspace_id=workspace_id, ready=False)
+    usage_row_sql = (
+        "SELECT total_usage FROM tr_credit_balance WHERE workspace_id=@pk AND shard=0"
+    )
+    open_holds_sql = (
+        "SELECT COUNT(*) FROM tr_reservation WHERE workspace_id=@ws AND settled=false"
+    )
+    baseline_sql = (
+        "/* json_usage_baseline_one */ "
+        "SELECT JSON_VALUE(body, '$.total_usage_microdollars') FROM tr_entities "
+        "WHERE kind='credit' AND id=@ws"
+    )
+
+    workspace = store.get_workspace(workspace_id)
+    credit_account = store.get_credit_account(workspace_id)
+    ws_param = {"ws": workspace_id}
+    ws_type = {"ws": pt.STRING}
+    with store._database.snapshot(multi_use=True) as snap:
+        usage_row = list(snap.execute_sql(
+            usage_row_sql, params={"pk": workspace_id}, param_types={"pk": pt.STRING},
+        ))
+        open_holds = list(snap.execute_sql(
+            open_holds_sql, params=ws_param, param_types=ws_type,
+        ))[0][0]
+        baseline_row = list(snap.execute_sql(
+            baseline_sql, params=ws_param, param_types=ws_type,
+        ))
+        settled = list(snap.execute_sql(
+            _SETTLED_CREDIT_ACTUALS, params=ws_param, param_types=ws_type,
+        ))[0][0]
+        federated = list(snap.execute_sql(
+            _FEDERATED_SETTLEMENT_APPLIED, params=ws_param, param_types=ws_type,
+        ))[0][0]
+
+    baseline = None
+    if baseline_row and baseline_row[0][0] is not None:
+        baseline = int(baseline_row[0][0])
+
+    if workspace is None or not getattr(workspace, "billing_paused", False):
+        res.reasons.append("workspace not billing-paused — pause it before repair")
+    if credit_account is not None and credit_shard_count(credit_account) != 1:
+        res.reasons.append("credit ledger is sharded — consolidate before shard-zero repair")
+    if not usage_row:
+        res.reasons.append("no typed credit row")
+    if int(open_holds) != 0:
+        res.reasons.append(
+            f"{open_holds} holds still open — drain them first, or their actuals "
+            "land after this write and the counter is wrong again"
+        )
+    if baseline is None:
+        res.reasons.append(
+            "no JSON total_usage_microdollars baseline — it was removed by the "
+            "credit-JSON cleanup and is not archived, so the pre-flip total "
+            "cannot be reconstructed and this workspace is not repairable here"
+        )
+
+    res.baseline = baseline
+    res.settled_actuals = int(settled)
+    res.federated_applied = int(federated)
+    if usage_row:
+        res.total_usage_before = int(usage_row[0][0])
+    if baseline is not None:
+        res.total_usage_after = baseline + int(settled) + int(federated)
+
+    if (
+        res.total_usage_before is not None
+        and res.total_usage_after is not None
+        and res.total_usage_after < res.total_usage_before
+        and not allow_decrease
+    ):
+        res.reasons.append(
+            f"refusing to lower total_usage "
+            f"{res.total_usage_before} -> {res.total_usage_after}: it is monotonic, "
+            "so a decrease means the ledger is missing rows rather than the "
+            "counter being wrong. Investigate first; pass allow_decrease=True "
+            "only once you know why"
+        )
+
+    res.ready = not res.reasons
+    if not res.ready or not apply:
+        return res
+
+    cts = store._spanner.COMMIT_TIMESTAMP
+    target = res.total_usage_after
+
+    def _txn(transaction: Any) -> dict | None:
+        # Re-read and re-validate the whole plan inside the txn, same discipline
+        # as repair_typed_reserved: a workspace unpaused, a hold opened, or the
+        # baseline cleaned up between the snapshot and here must abort.
+        ws = store._read_entity_tx(transaction, "workspace", workspace_id, Workspace)
+        if ws is None or not ws.billing_paused:
+            return None
+        credit = store._read_entity_tx(transaction, "credit", workspace_id, CreditAccount)
+        if credit is not None and credit_shard_count(credit) != 1:
+            return None
+        if int(list(transaction.execute_sql(
+            open_holds_sql, params=ws_param, param_types=ws_type,
+        ))[0][0]) != 0:
+            return None
+        current = list(transaction.execute_sql(
+            usage_row_sql, params={"pk": workspace_id}, param_types={"pk": pt.STRING},
+        ))
+        if not current:
+            return None  # typed row vanished — never re-create it as a partial row
+        fresh_baseline = list(transaction.execute_sql(
+            baseline_sql, params=ws_param, param_types=ws_type,
+        ))
+        if not fresh_baseline or fresh_baseline[0][0] is None:
+            return None
+        recomputed = (
+            int(fresh_baseline[0][0])
+            + int(list(transaction.execute_sql(
+                _SETTLED_CREDIT_ACTUALS, params=ws_param, param_types=ws_type,
+            ))[0][0])
+            + int(list(transaction.execute_sql(
+                _FEDERATED_SETTLEMENT_APPLIED, params=ws_param, param_types=ws_type,
+            ))[0][0])
+        )
+        if recomputed != target:
+            return None  # the ledger moved under us — abort rather than write a stale total
+        if recomputed < int(current[0][0]) and not allow_decrease:
+            return None
+        transaction.insert_or_update(
+            table="tr_credit_balance",
+            columns=("workspace_id", "shard", "total_usage", "updated_at"),
+            values=[(workspace_id, 0, recomputed, cts)],
+        )
+        return {"total_usage": recomputed}
+
+    result = store._run_in_transaction(_txn)
+    if result is None:
+        res.ready = False
+        res.reasons.append(
+            "aborted: not paused / sharded / a hold opened / typed row missing / "
+            "baseline gone / the ledger moved between plan and write"
+        )
+        return res
+    res.applied = True
+    res.total_usage_after = result["total_usage"]
     return res

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -1497,6 +1497,108 @@ def _execute_sql(
     params: dict[str, Any],
 ) -> list[list[str]]:
     kind = params.get("kind", "")
+
+    def _claim_bodies() -> list[dict]:
+        out = []
+        for (row_kind, _eid), row in db.rows.items():
+            if row_kind != "federated_settlement_claim":
+                continue
+            try:
+                out.append(json.loads(row.body))
+            except (TypeError, ValueError):
+                continue
+        return out
+
+    def _settled_credit_actuals(workspace_id: str | None) -> dict[str, int]:
+        # Mirrors the real predicates rather than reimplementing intent: only a
+        # SETTLED reservation on shard 0 whose settled_usage_type is Credits ever
+        # reached tr_credit_balance.total_usage (storage_gcp_authorize passes 0
+        # for every other usage type).
+        totals: dict[str, int] = {}
+        for rec in db.reservations.values():
+            if not rec.get("settled"):
+                continue
+            if rec.get("settled_usage_type") != "Credits":
+                continue
+            if int(rec.get("ws_shard") or 0) != 0:
+                continue
+            ws = rec.get("workspace_id")
+            if ws is None or (workspace_id is not None and ws != workspace_id):
+                continue
+            totals[str(ws)] = totals.get(str(ws), 0) + int(rec.get("actual_micro") or 0)
+        return totals
+
+    if "/* json_usage_baseline_one */" in sql:
+        _require_pred(sql, "kind='credit'", "usage baseline kind")
+        _require_pred(sql, "$.total_usage_microdollars", "usage baseline field")
+        row = db.rows.get(("credit", str(params["ws"])))
+        if row is None:
+            return []
+        body = json.loads(row.body)
+        raw = body.get("total_usage_microdollars")
+        return [[None if raw is None else str(raw)]]
+    if "/* json_usage_baseline */" in sql:
+        _require_pred(sql, "kind='credit'", "usage baseline kind")
+        _require_pred(sql, "$.total_usage_microdollars", "usage baseline field")
+        out: list[list[Any]] = []
+        for (row_kind, entity_id), row in sorted(db.rows.items()):
+            if row_kind != "credit":
+                continue
+            try:
+                body = json.loads(row.body)
+            except (TypeError, ValueError):
+                continue
+            raw = body.get("total_usage_microdollars")
+            out.append([entity_id, None if raw is None else str(raw)])
+        return out
+    if "/* federated_settlement_applied_by_ws */" in sql:
+        _require_pred(sql, "kind='federated_settlement_claim'", "federated claim kind")
+        _require_pred(sql, "$.cost_microdollars", "federated claim amount")
+        totals: dict[str, int] = {}
+        for body in _claim_bodies():
+            ws = body.get("workspace_id")
+            if ws is None:
+                continue
+            totals[str(ws)] = totals.get(str(ws), 0) + int(body.get("cost_microdollars") or 0)
+        return [[ws, amount] for ws, amount in sorted(totals.items())]
+    if "/* federated_settlement_applied */" in sql:
+        _require_pred(sql, "kind='federated_settlement_claim'", "federated claim kind")
+        _require_pred(sql, "$.cost_microdollars", "federated claim amount")
+        workspace_id = str(params["ws"])
+        return [[sum(
+            int(body.get("cost_microdollars") or 0)
+            for body in _claim_bodies()
+            if body.get("workspace_id") == workspace_id
+        )]]
+    if "SELECT workspace_id, shard, total_usage FROM tr_credit_balance" in sql:
+        return [
+            [pk[0], pk[1], int(rec.get("total_usage") or 0)]
+            for pk, rec in sorted(db.typed.get("tr_credit_balance", {}).items())
+        ]
+    if "SUM(actual_micro)" in sql and "GROUP BY workspace_id" in sql:
+        _require_pred(sql, "settled=true", "settled-actuals settled filter")
+        _require_pred(sql, "settled_usage_type='Credits'", "settled-actuals usage-type filter")
+        _require_pred(sql, "ws_shard=0", "settled-actuals shard filter")
+        return [[ws, amount] for ws, amount in sorted(_settled_credit_actuals(None).items())]
+    if "SUM(actual_micro)" in sql:
+        _require_pred(sql, "settled=true", "settled-actuals settled filter")
+        _require_pred(sql, "settled_usage_type='Credits'", "settled-actuals usage-type filter")
+        _require_pred(sql, "ws_shard=0", "settled-actuals shard filter")
+        workspace_id = str(params["ws"])
+        return [[_settled_credit_actuals(workspace_id).get(workspace_id, 0)]]
+    if (
+        "SELECT COUNT(*) FROM tr_reservation WHERE workspace_id=@ws AND settled=false" in sql
+        # repair_typed_reserved's nonzero-shard probe is a SUPERSTRING of this
+        # one; matching loosely would answer it with the all-shard count and
+        # silently turn its shard check into a no-op.
+        and "ws_shard!=0" not in sql
+    ):
+        workspace_id = str(params["ws"])
+        return [[sum(
+            1
+            for rec in db.reservations.values()
+            if rec.get("workspace_id") == workspace_id and not rec.get("settled")
+        )]]
     if "/* nonclosed_regional_quota_leases_for_repair */" in sql:
         workspace_id = str(params["ws"])
         count = 0

--- a/tests/test_billing_usage_drift.py
+++ b/tests/test_billing_usage_drift.py
@@ -1,0 +1,311 @@
+"""Drift detection and repair for typed `total_usage`.
+
+The module already audits and repairs typed `reserved`. Usage had neither, and
+the retired PR #89 proposed the invariant
+
+    total_usage == JSON baseline + Σ settled-Credits actual_micro
+
+which is no longer the whole story on this store. `total_usage` now has TWO
+writers: the typed settle, and deferred federated settlement applying a peer
+plane's debt with no reservation in this plane at all. Summing only the first
+reads every federated microdollar as drift, so the federated case has a test of
+its own below -- it is the one #89's arithmetic would have got wrong.
+
+The second thing these pin is what happens when the baseline is GONE. It is a
+residual raw key in the credit JSON body, and the reviewed cleanup migration
+deletes it without archiving the value, so an absent baseline is ambiguous: a
+post-flip workspace whose real baseline is 0, or a pre-flip workspace whose
+baseline was removed. Reporting it as drift would cry wolf on every cleaned
+workspace; reporting it as clean would overstate what was checked. It is
+counted separately, and `fully_audited` is how an operator sees the difference.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.storage import Workspace
+from trusted_router.storage_gcp_counter_reconcile import (
+    audit_typed_invariants,
+    repair_typed_usage,
+)
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
+
+_CLAIM_KIND = "federated_settlement_claim"
+
+
+def _workspace(store: Any, ws: str, *, paused: bool = True) -> None:
+    store._write_entity(
+        "workspace", ws, Workspace(id=ws, name="t", owner_user_id="u", billing_paused=paused)
+    )
+
+
+def _credit(store: Any, db: Any, ws: str, *, baseline: int | None, total_usage: int) -> None:
+    body: dict[str, Any] = {"workspace_id": ws, "shard_count": 1}
+    if baseline is not None:
+        body["total_usage_microdollars"] = baseline
+    store._write_entity("credit", ws, body)
+    db.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(ws, 0)] = {
+        "workspace_id": ws,
+        "shard": 0,
+        "total_credits": 100_000_000,
+        "total_usage": total_usage,
+        "reserved": 0,
+    }
+
+
+def _settled(db: Any, rid: str, ws: str, actual: int, *, usage_type: str = "Credits") -> None:
+    db.reservations[rid] = {
+        "reservation_id": rid,
+        "workspace_id": ws,
+        "ws_shard": 0,
+        "settled": True,
+        "settled_usage_type": usage_type,
+        "actual_micro": actual,
+        "credit_reserved_micro": actual,
+    }
+
+
+def _open_hold(db: Any, rid: str, ws: str, held: int) -> None:
+    db.reservations[rid] = {
+        "reservation_id": rid,
+        "workspace_id": ws,
+        "ws_shard": 0,
+        "settled": False,
+        "credit_reserved_micro": held,
+    }
+
+
+def _federated_claim(store: Any, ws: str, claim_id: str, cost: int) -> None:
+    store._write_entity(
+        _CLAIM_KIND,
+        claim_id,
+        json.loads(json.dumps({
+            "source_plane": "aws-eu",
+            "authorization_id": f"auth_{claim_id}",
+            "workspace_id": ws,
+            "cost_microdollars": cost,
+        })),
+    )
+
+
+def test_usage_matching_the_ledger_is_clean() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_ok"
+    _credit(store, db, ws, baseline=2_000_000, total_usage=2_450_000)
+    _settled(db, "r1", ws, 300_000)
+    _settled(db, "r2", ws, 150_000)
+
+    report = audit_typed_invariants(store)
+
+    assert report.usage_rows == 1
+    assert report.usage_violations == 0
+    assert report.usage_unauditable == 0
+    assert report.clean and report.fully_audited
+
+
+def test_federated_settlement_is_booked_usage_not_drift() -> None:
+    """The case PR #89's arithmetic would have failed.
+
+    A peer plane served this workspace's traffic and delivered the debt. The
+    home plane added it straight to total_usage and there is NO reservation
+    here, because the authorize happened on the other plane. An audit that sums
+    only settled reservations reports the whole federated amount as drift.
+    """
+    store, db, _ = make_fake_store()
+    ws = "ws_federated"
+    _credit(store, db, ws, baseline=1_000_000, total_usage=1_875_000)
+    _settled(db, "r1", ws, 125_000)
+    _federated_claim(store, ws, "c1", 500_000)
+    _federated_claim(store, ws, "c2", 250_000)
+
+    report = audit_typed_invariants(store)
+
+    assert report.usage_violations == 0, report.samples
+    assert report.clean
+
+    # And the arithmetic really did depend on those claims: drop them and the
+    # same counter becomes a violation of exactly their size.
+    for claim_id in ("c1", "c2"):
+        del db.rows[(_CLAIM_KIND, claim_id)]
+    regressed = audit_typed_invariants(store)
+    assert regressed.usage_violations == 1
+    assert regressed.samples[f"usage:{ws}"]["delta"] == 750_000
+
+
+def test_non_credits_settles_do_not_count_toward_usage() -> None:
+    """storage_gcp_authorize passes `book_actual if settled_usage_type ==
+    "Credits" else 0`, so a non-Credits settle never reached total_usage."""
+    store, db, _ = make_fake_store()
+    ws = "ws_mixed"
+    _credit(store, db, ws, baseline=0, total_usage=100_000)
+    _settled(db, "r1", ws, 100_000)
+    _settled(db, "r2", ws, 900_000, usage_type="Subscription")
+
+    report = audit_typed_invariants(store)
+
+    assert report.usage_violations == 0, report.samples
+
+
+def test_real_usage_drift_is_caught_with_its_arithmetic() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_drift"
+    _credit(store, db, ws, baseline=2_000_000, total_usage=2_000_000)  # settle never landed
+    _settled(db, "r1", ws, 420_000)
+
+    report = audit_typed_invariants(store)
+
+    assert report.usage_violations == 1
+    assert not report.clean
+    sample = report.samples[f"usage:{ws}"]
+    assert sample["expected"] == 2_420_000
+    assert sample["typed_total_usage"] == 2_000_000
+    assert sample["delta"] == -420_000
+    assert sample["settled_actuals"] == 420_000
+
+
+def test_a_missing_baseline_is_unauditable_not_a_violation() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_cleaned"
+    _credit(store, db, ws, baseline=None, total_usage=9_999_999)
+    _settled(db, "r1", ws, 1_000)
+
+    report = audit_typed_invariants(store)
+
+    assert report.usage_violations == 0
+    assert report.usage_unauditable == 1
+    # CLEAN, but explicitly NOT fully audited -- the distinction an operator needs.
+    assert report.clean
+    assert not report.fully_audited
+    assert "(PARTIAL)" in report.summary()
+    assert report.samples[f"usage-unauditable:{ws}"]["baseline"] is None
+
+
+def test_booked_usage_with_no_typed_row_is_a_violation() -> None:
+    """The reverse direction, matching the reserved arm: a booking that landed
+    nowhere is invisible if you only iterate typed rows."""
+    store, db, _ = make_fake_store()
+    ws = "ws_orphan"
+    _settled(db, "r1", ws, 640_000)
+
+    report = audit_typed_invariants(store)
+
+    assert report.usage_violations == 1
+    assert report.samples[f"usage-orphan-booking:{ws}"]["settled_actuals"] == 640_000
+
+
+def test_repair_dry_run_reports_without_writing() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_repair"
+    _workspace(store, ws)
+    _credit(store, db, ws, baseline=2_000_000, total_usage=2_000_000)
+    _settled(db, "r1", ws, 420_000)
+    _federated_claim(store, ws, "c1", 80_000)
+
+    result = repair_typed_usage(store, ws, apply=False)
+
+    assert result.ready and not result.applied
+    assert result.total_usage_before == 2_000_000
+    assert result.total_usage_after == 2_500_000
+    assert result.baseline == 2_000_000
+    assert result.settled_actuals == 420_000
+    assert result.federated_applied == 80_000
+    assert result.delta == 500_000
+    assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["total_usage"] == 2_000_000
+
+
+def test_repair_applies_the_reconstructed_total() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_apply"
+    _workspace(store, ws)
+    _credit(store, db, ws, baseline=2_000_000, total_usage=2_000_000)
+    _settled(db, "r1", ws, 420_000)
+
+    result = repair_typed_usage(store, ws, apply=True)
+
+    assert result.applied
+    assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["total_usage"] == 2_420_000
+    assert audit_typed_invariants(store).usage_violations == 0
+
+
+def test_repair_refuses_an_unpaused_workspace() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_live"
+    _workspace(store, ws, paused=False)
+    _credit(store, db, ws, baseline=0, total_usage=0)
+
+    result = repair_typed_usage(store, ws, apply=True)
+
+    assert not result.ready and not result.applied
+    assert any("billing-paused" in r for r in result.reasons)
+
+
+def test_repair_refuses_while_a_hold_is_open() -> None:
+    """An open hold is a settle that has not added its actual yet: repairing now
+    writes a total that the settle immediately invalidates."""
+    store, db, _ = make_fake_store()
+    ws = "ws_draining"
+    _workspace(store, ws)
+    _credit(store, db, ws, baseline=1_000_000, total_usage=1_000_000)
+    _open_hold(db, "r_open", ws, 50_000)
+
+    result = repair_typed_usage(store, ws, apply=True)
+
+    assert not result.ready and not result.applied
+    assert any("holds still open" in r for r in result.reasons)
+
+
+def test_repair_refuses_when_the_baseline_was_cleaned_up() -> None:
+    store, db, _ = make_fake_store()
+    ws = "ws_nobaseline"
+    _workspace(store, ws)
+    _credit(store, db, ws, baseline=None, total_usage=5_000_000)
+
+    result = repair_typed_usage(store, ws, apply=True)
+
+    assert not result.ready and not result.applied
+    assert any("baseline" in r for r in result.reasons)
+
+
+def test_repair_refuses_to_lower_usage_unless_told_to() -> None:
+    """total_usage is monotonic, so a computed decrease means the ledger is
+    missing rows -- not that the counter is too high."""
+    store, db, _ = make_fake_store()
+    ws = "ws_down"
+    _workspace(store, ws)
+    _credit(store, db, ws, baseline=1_000_000, total_usage=5_000_000)
+
+    refused = repair_typed_usage(store, ws, apply=True)
+    assert not refused.ready and not refused.applied
+    assert any("refusing to lower" in r for r in refused.reasons)
+    assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["total_usage"] == 5_000_000
+
+    forced = repair_typed_usage(store, ws, apply=True, allow_decrease=True)
+    assert forced.applied
+    assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["total_usage"] == 1_000_000
+
+
+def test_usage_is_summed_across_shards() -> None:
+    """Unlike `reserved`, which is per (scope, shard), both usage ledgers name a
+    WORKSPACE. Comparing shard 0 alone against a whole-workspace ledger would
+    report every other shard's usage as missing."""
+    store, db, _ = make_fake_store()
+    ws = "ws_sharded"
+    # baseline 1M + settled 1M == 2M, spread 800k/700k/500k across three shards.
+    _credit(store, db, ws, baseline=1_000_000, total_usage=800_000)  # shard 0
+    db.typed[CREDIT_BALANCE_TABLE][(ws, 1)] = {
+        "workspace_id": ws, "shard": 1, "total_credits": 0,
+        "total_usage": 700_000, "reserved": 0,
+    }
+    db.typed[CREDIT_BALANCE_TABLE][(ws, 2)] = {
+        "workspace_id": ws, "shard": 2, "total_credits": 0,
+        "total_usage": 500_000, "reserved": 0,
+    }
+    _settled(db, "r1", ws, 1_000_000)
+
+    report = audit_typed_invariants(store)
+
+    assert report.usage_rows == 1, "one workspace, not one row per shard"
+    assert report.usage_violations == 0, report.samples

--- a/tests/test_credit_json_cleanup.py
+++ b/tests/test_credit_json_cleanup.py
@@ -33,17 +33,24 @@ def _seed_credit(
         "auto_refill_enabled": True,
         "future_metadata": {"preserve": True},
     }
+    typed = db.typed.setdefault(CREDIT_BALANCE_TABLE, {})
+    count = shard_count if complete_typed else max(0, shard_count - 1)
     if with_legacy_money:
         body.update(
             {
                 "total_credits_microdollars": 10_000_000,
-                "total_usage_microdollars": 2_000_000,
+                # Must equal the typed usage this fixture goes on to write, summed
+                # over shards. audit_typed_invariants now reconstructs total_usage
+                # from this baseline plus the settled/federated ledgers, and the
+                # cleanup CLI refuses to run while that is violated -- deliberately,
+                # since cleanup DELETES this field and it is the only thing that
+                # makes the check possible afterwards. An arbitrary number here
+                # reads as real drift.
+                "total_usage_microdollars": count * 1_000_000,
                 "reserved_microdollars": 300_000,
             }
         )
     store._write_entity("credit", workspace_id, body)
-    typed = db.typed.setdefault(CREDIT_BALANCE_TABLE, {})
-    count = shard_count if complete_typed else max(0, shard_count - 1)
     for shard in range(count):
         typed[(workspace_id, shard)] = {
             "workspace_id": workspace_id,


### PR DESCRIPTION
`storage_gcp_counter_reconcile.py` could find and fix drift in typed `reserved` and had nothing for `total_usage`. This adds the audit arm and `repair_typed_usage` alongside `repair_typed_reserved`, following the closed #89's intent — but **not its arithmetic**, which no longer holds.

## The invariant #89 proposed is now incomplete

It was `total_usage == JSON baseline + Σ settled-Credits actual_micro`. On current main `total_usage` has **two** writers, not one:

| writer | ledger row |
|---|---|
| typed settle (`storage_gcp_counter_dml.release_credit`) | settled `tr_reservation` |
| deferred federated settlement (`storage_gcp_federated_settlement`) | insert-once `federated_settlement_claim` |

A peer plane serves a federated key's traffic, records the spend as debt, and delivers it; the home plane adds it straight to `total_usage` with **no reservation in this plane**, because the authorize happened elsewhere. Summing only settled reservations reads every federated microdollar as drift. Both arms are summed here, and there's a test for exactly that case — deleting the claims turns the same counter into a violation of precisely their size.

Also: only `Credits` settles count, since `storage_gcp_authorize` passes `book_actual if settled_usage_type == "Credits" else 0`.

## A missing baseline is UNAUDITABLE, never drift

The baseline is a residual raw key in the credit JSON body, and `storage_gcp_credit_json_cleanup` **deletes it without archiving the value**. So absent is ambiguous — a post-flip workspace whose baseline is genuinely 0 (typed rows omit `total_usage` at insert and start at the Spanner default), or a pre-flip workspace whose baseline is gone. Guessing 0 reports a workspace's entire historical spend as drift; calling it clean overstates what was checked. It's counted separately, `clean` and `fully_audited` are distinct properties, and the summary prints `(PARTIAL)`.

Because `clean` gates `scripts/cleanup_legacy_credit_json.py`, usage must now reconcile **before** that migration deletes the baseline — which is the only moment the check is possible at all. That seems like the right place for this gate to bite. It surfaced an inconsistency in that test's fixture, whose baseline never matched the typed rows it wrote; the fixture now derives one from the other.

## Two corrections to my own first cut

**Summed across shards.** `reserved` is compared per `(scope, shard)` because each shard holds its own reservations — but both usage ledgers name a *workspace*. Comparing shard 0 against a whole-workspace ledger would report every sharded workspace's other shards as missing usage.

**The repair is stricter than `repair_typed_reserved`.** `reserved` is derived from still-open state, so recomputing it is safe whenever the workspace is quiesced. `total_usage` is a monotonic lifetime total: writing it rewrites history. It refuses to lower it without an explicit `allow_decrease` (a computed decrease means the ledger is missing rows, not that the counter is wrong), and refuses entirely while any hold is open, since an unsettled hold is an actual that hasn't landed yet.

## Verification

Every guard is mutation-tested — dropping the federated arm, treating a missing baseline as 0, removing the monotonic refusal, and reverting to shard-0-only each turn **exactly one** test red, and restoring turns it green. The fake's new handlers use `_require_pred`, so deleting `settled_usage_type='Credits'` from the real SQL fails the suite rather than being silently emulated in Python.

210 tests pass across the billing/auditor/cleanup/sharding suites; ruff and mypy clean.

## On sequencing

`docs/design/billing-dual-system-deletion-handoff.md` gates this work on step 1b (legacy settle path removed, JSON usage frozen). That precondition holds *behaviourally*: `is_typed_reservation` has no callers, and the legacy `STORE.finalize_gateway_authorization` arm is reachable only when `typed_billing_store(STORE)` returns `None` — a backend **capability** check with no flag or cohort, so on Spanner it never fires. The dead code itself still exists; deleting it is 1b's remaining work and not touched here.