### PR TITLE
Derive the standalone ClickHouse schema set instead of listing it

### DIFF
--- a/clickhouse/011_workspace_directory_single_node.sql
+++ b/clickhouse/011_workspace_directory_single_node.sql
@@ -1,7 +1,7 @@
 -- Column-for-column single-node counterpart to 010_workspace_directory.sql.
 -- The engine is the only difference from the replicated definition.
 
-CREATE TABLE IF NOT EXISTS tr.workspace_directory
+CREATE TABLE IF NOT EXISTS workspace_directory
 (
     tenant_id           FixedString(64),
     workspace_id        LowCardinality(String),

--- a/clickhouse/013_activity_generations_workspace_id_single_node.sql
+++ b/clickhouse/013_activity_generations_workspace_id_single_node.sql
@@ -1,5 +1,5 @@
 -- Single-node (AWS) variant of 012. MUST be applied to a node before the
 -- clickhouse/ tree is next shipped there: the updated drain inserts the
 -- workspace_id column, and an un-migrated node rejects the insert.
-ALTER TABLE tr.activity_generations
+ALTER TABLE activity_generations
     ADD COLUMN IF NOT EXISTS workspace_id LowCardinality(String) DEFAULT '' AFTER tenant_id;

--- a/scripts/deploy/_clickhouse_single_node_schema.sh
+++ b/scripts/deploy/_clickhouse_single_node_schema.sh
@@ -1,0 +1,78 @@
+# shellcheck shell=bash
+# The ordered schema a STANDALONE ClickHouse node needs, derived rather than listed.
+#
+# Every standalone node -- AWS Paris, AWS Stockholm, Azure -- needs the same set,
+# and each script used to carry its own copy of it. Two carried a literal
+# `006`+`009` and one globbed `clickhouse/00*.sql`, which stops matching the
+# moment a migration crosses a digit boundary. Both were wrong the same way and
+# for the same reason: the list was written once and the directory kept moving.
+# 010 through 013 landed and no node built by any of those three scripts got
+# them.
+#
+# That failure is silent where it hurts. clickhouse/013_*.sql adds the
+# workspace_id column the drain inserts (clickhouse/ingest_operational_outbox.py),
+# an un-migrated node REJECTS that insert, and shard failures are contained
+# (clickhouse/ingest_operational_outbox_postgres.py) -- so the unit stays active,
+# reports healthy, and delivers nothing.
+#
+# WHICH FILES, AND WHY NOT THE OTHERS
+# `*_single_node.sql` is the naming the repo already uses to mark "standalone
+# variant of this migration". The rest are excluded because they target a
+# different topology or a different dataset:
+#   001-002  provider-benchmark schemas, not operational analytics
+#   003-005, 007-008, 010, 012  the Keeper / ON CLUSTER replicated topology,
+#            which is GCP's cluster; a standalone node has no Keeper to
+#            coordinate with and these fail or create the wrong engine there.
+# Adding a new standalone migration requires nothing here: name it
+# `*_single_node.sql` and every node picks it up.
+
+single_node_migrations() {
+  local root="$1"
+  local -a found=()
+  local path
+
+  while IFS= read -r path; do
+    [ -n "$path" ] && found+=("$path")
+  done < <(find "$root/clickhouse" -maxdepth 1 -name '*_single_node.sql' -print 2>/dev/null | LC_ALL=C sort)
+
+  if [ "${#found[@]}" -eq 0 ]; then
+    echo "no clickhouse/*_single_node.sql found under ${root}" >&2
+    echo "a rename would otherwise apply an EMPTY schema and look like success" >&2
+    return 1
+  fi
+
+  # Every consumer of this set connects to the `default` database: the AWS
+  # control plane and drain installer both default CH_DATABASE to `default`, and
+  # so does Azure. Only GCP uses `tr`, and GCP runs the ON CLUSTER migrations
+  # instead of these. So a database-qualified statement in this set would be
+  # applied somewhere nothing reads -- which is worse than skipping it, because
+  # the apply SUCCEEDS. 011 and 013 shipped qualified `tr.` for exactly that
+  # reason and nobody noticed; this refuses instead.
+  local qualified
+  qualified="$(
+    python3 - "${found[@]}" <<'PY'
+import pathlib
+import re
+import sys
+
+pattern = re.compile(
+    r"\b(?:CREATE|ALTER|DROP)\s+TABLE\s+(?:IF\s+(?:NOT\s+)?EXISTS\s+)?"
+    r"([A-Za-z_][A-Za-z0-9_]*)\.",
+    re.IGNORECASE,
+)
+for name in sys.argv[1:]:
+    text = pathlib.Path(name).read_text(encoding="utf-8")
+    for database in pattern.findall(text):
+        print(f"{pathlib.Path(name).name}: {database}.")
+PY
+  )"
+  if [ -n "$qualified" ]; then
+    echo "database-qualified statements in the single-node schema set:" >&2
+    echo "$qualified" >&2
+    echo "standalone nodes use the 'default' database; qualifying sends these" >&2
+    echo "somewhere no drain reads, and the apply still reports success" >&2
+    return 1
+  fi
+
+  printf '%s\n' "${found[@]}"
+}

--- a/scripts/deploy/aws_eu_clickhouse.sh
+++ b/scripts/deploy/aws_eu_clickhouse.sh
@@ -49,6 +49,19 @@ else
 fi
 CH_PASSWORD="$(aws secretsmanager get-secret-value --region "$REGION" --secret-id "$SECRET_ID" --query SecretString --output text)"
 
+# The standalone schema, DERIVED (see the helper for why a literal list rots).
+# Built before the node so a bad set fails here rather than half-way through a
+# boot, and so this script cannot create a node it has no schema for.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=scripts/deploy/_clickhouse_single_node_schema.sh
+. "$(dirname "${BASH_SOURCE[0]}")/_clickhouse_single_node_schema.sh"
+SCHEMA_FILES=()
+while IFS= read -r _schema; do
+  SCHEMA_FILES+=("$_schema")
+done < <(single_node_migrations "$REPO_ROOT") || exit 1
+[ "${#SCHEMA_FILES[@]}" -gt 0 ] || { echo "empty single-node schema set" >&2; exit 1; }
+OPERATIONAL_SCHEMA="$(cat "${SCHEMA_FILES[@]}")"
+
 # ---------------------------------------------------------------------------
 # 2. Security group: VPC-internal only. No 0.0.0.0/0 on 8123/9000 ever.
 # ---------------------------------------------------------------------------
@@ -132,6 +145,28 @@ chmod 640 /etc/clickhouse-server/users.d/default-password.xml
 
 systemctl enable clickhouse-server
 systemctl restart clickhouse-server
+
+# Apply the standalone schema HERE rather than printing it for someone to run.
+# It used to be step 1 of NEXT_STEPS, described as a human step needing the
+# ClickHouse password -- but this script already read that password from Secrets
+# Manager to write users.d above, so the only thing the human step added was a
+# chance to run a stale command. The set it told you to apply was the glob
+# clickhouse/00 star .sql, which silently stopped matching at 010.
+#
+# aws_eu_north_clickhouse.sh already does it this way; this makes the two nodes
+# of the same cloud boot the same.
+cat > /root/operational_schema.sql <<'SQLEOF'
+${OPERATIONAL_SCHEMA}
+SQLEOF
+for attempt in \$(seq 1 60); do
+  if CLICKHOUSE_PASSWORD='${CH_PASSWORD}' clickhouse-client --user default --database default --query 'SELECT 1' >/dev/null 2>&1; then
+    break
+  fi
+  sleep 5
+done
+CLICKHOUSE_PASSWORD='${CH_PASSWORD}' clickhouse-client --user default --database default \
+  --multiquery < /root/operational_schema.sql
+rm -f /root/operational_schema.sql
 USERDATA
 )"
   INSTANCE_ID="$(aws ec2 run-instances --region "$REGION" \
@@ -197,25 +232,20 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 NEXT_STEPS=$(cat <<NEXT
 
-The node is up but the AWS cloud is NOT complete. Run these, in order, and this
-script will exit 0 the next time it is run:
+The node is up WITH ITS SCHEMA APPLIED, but the AWS cloud is NOT complete. Run
+these, in order, and this script will exit 0 the next time it is run:
 
-  1. apply the schema to the node (from inside the VPC):
-       for f in clickhouse/00*.sql; do
-         clickhouse-client --host ${PRIVATE_IP} --user default --multiquery < "\$f"
-       done
-
-  2. redeploy the control plane so settle enqueues and the outbox is readable.
+  1. redeploy the control plane so settle enqueues and the outbox is readable.
      Its own knobs, not the TR_* names — it builds those:
        CLICKHOUSE_URL=http://${PRIVATE_IP}:8123 \\
        VPC_CONNECTOR_ARN=${CONNECTOR_ARN} \\
        bash scripts/deploy/aws_eu_control_plane.sh
      (EgressConfiguration=VPC follows from a non-empty VPC_CONNECTOR_ARN.)
 
-  3. install the process that actually MOVES rows — the step that was missed:
+  2. install the process that actually MOVES rows — the step that was missed:
        bash scripts/deploy/aws_eu_clickhouse_drain_install.sh
 
-  4. re-run this script, or just the check:
+  3. re-run this script, or just the check:
        bash scripts/deploy/verify_cloud_complete.sh aws
 
 NEXT

--- a/scripts/deploy/aws_eu_north_clickhouse.sh
+++ b/scripts/deploy/aws_eu_north_clickhouse.sh
@@ -65,8 +65,14 @@ SG_NAME="${SG_NAME:-tr-eu-north-clickhouse-sg}"
 SECRET_ID="${SECRET_ID:-quill/tr-eu-north-clickhouse-password}"
 INSTANCE_PROFILE="${INSTANCE_PROFILE:-quill-enclave-instance-profile}"
 PEER_WITH_PARIS="${PEER_WITH_PARIS:-1}"            # 0 to bring your own path.
-SCHEMA_FILE="${SCHEMA_FILE:-$(dirname "$0")/../../clickhouse/006_operational_analytics_single_node.sql}"
-CLIENT_SCHEMA_FILE="${CLIENT_SCHEMA_FILE:-$(dirname "$0")/../../clickhouse/009_client_events_single_node.sql}"
+# The standalone schema is DERIVED, not listed. These were pinned to exactly
+# 006 and 009 -- the same two files Paris's glob happened to match -- so this
+# node was built without 011 or 013 and therefore without the workspace_id
+# column the drain inserts. That is silent: the insert fails, shard failures are
+# contained, and the unit stays active reporting healthy while this node, whose
+# entire job is being a SECOND copy of the history, receives nothing.
+# shellcheck source=scripts/deploy/_clickhouse_single_node_schema.sh
+. "$(dirname "$0")/_clickhouse_single_node_schema.sh"
 
 log(){ printf '\n=== %s\n' "$*" >&2; }
 
@@ -123,8 +129,14 @@ if [ "$REGION" = "$PARIS_REGION" ]; then
   echo "REGION and PARIS_REGION are both $REGION; a second copy in the same region is not a second failure domain" >&2
   exit 1
 fi
-[ -r "$SCHEMA_FILE" ] || { echo "schema file not readable: $SCHEMA_FILE" >&2; exit 1; }
-[ -r "$CLIENT_SCHEMA_FILE" ] || { echo "schema file not readable: $CLIENT_SCHEMA_FILE" >&2; exit 1; }
+SCHEMA_FILES=()
+while IFS= read -r _schema; do
+  SCHEMA_FILES+=("$_schema")
+done < <(single_node_migrations "$(cd "$(dirname "$0")/../.." && pwd)") || exit 1
+[ "${#SCHEMA_FILES[@]}" -gt 0 ] || { echo "empty single-node schema set" >&2; exit 1; }
+for _schema in "${SCHEMA_FILES[@]}"; do
+  [ -r "$_schema" ] || { echo "schema file not readable: $_schema" >&2; exit 1; }
+done
 
 PARIS_VPC_CIDR="$(aws ec2 describe-vpcs --region "$PARIS_REGION" --vpc-ids "$PARIS_VPC_ID" \
   --query 'Vpcs[0].CidrBlock' --output text)"
@@ -250,8 +262,7 @@ log "security group: $SG_ID"
 #    finishes booting -- the drain can be pointed at it without a second
 #    manual step that someone forgets.
 # ---------------------------------------------------------------------------
-OPERATIONAL_SCHEMA="$(cat "$SCHEMA_FILE")"
-CLIENT_SCHEMA="$(cat "$CLIENT_SCHEMA_FILE")"
+OPERATIONAL_SCHEMA="$(cat "${SCHEMA_FILES[@]}")"
 
 EXISTING="$(aws ec2 describe-instances --region "$REGION" \
   --filters "Name=tag:Name,Values=$NAME" "Name=instance-state-name,Values=running,pending" \
@@ -323,7 +334,6 @@ systemctl restart clickhouse-server
 # Keeper: this node does not replicate with Paris, the drain writes both.
 cat > /root/operational_schema.sql <<'SQLEOF'
 ${OPERATIONAL_SCHEMA}
-${CLIENT_SCHEMA}
 SQLEOF
 for attempt in \$(seq 1 60); do
   if CLICKHOUSE_PASSWORD='${CH_PASSWORD}' clickhouse-client --user default --database default --query 'SELECT 1' >/dev/null 2>&1; then

--- a/tests/test_clickhouse_node_provisioning.py
+++ b/tests/test_clickhouse_node_provisioning.py
@@ -178,11 +178,38 @@ def test_stockholm_volume_survives_terminating_the_instance() -> None:
 
 def test_stockholm_applies_the_single_node_schema_not_the_replicated_one() -> None:
     """Two regions cannot form a Keeper quorum, so these nodes do not
-    replicate; the drain writes both."""
+    replicate; the drain writes both.
+
+    This used to assert the script contained the literal string
+    "006_operational_analytics_single_node.sql". That pinned the HARDCODING
+    rather than the coverage: the script applied exactly 006 and 009, 010
+    through 013 landed, and this test went on passing while every node it built
+    was missing the workspace_id column the drain inserts.
+
+    Newer contract: the script names no migration at all. It applies the set
+    derived from clickhouse/*_single_node.sql by
+    scripts/deploy/_clickhouse_single_node_schema.sh, and that naming is what
+    excludes the replicated ones -- so the "not the replicated one" half of this
+    test is now structural rather than a denylist of one filename. The
+    derivation itself is pinned in tests/test_single_node_schema_set.py.
+    """
     script = STOCKHOLM.read_text()
 
-    assert "006_operational_analytics_single_node.sql" in script
-    assert "004_operational_analytics_replicated.sql" not in _statements()
+    assert "single_node_migrations" in script
+    assert "_clickhouse_single_node_schema.sh" in script
+
+    # No replicated migration reaches this node -- checked against ALL of them,
+    # not just 004, since the set is derived and a new one could appear.
+    statements = _statements()
+    replicated = [
+        path.name
+        for path in sorted((ROOT / "clickhouse").glob("*.sql"))
+        if not path.name.endswith("_single_node.sql")
+    ]
+    assert replicated, "no non-single-node migrations found; the check would be vacuous"
+    for name in replicated:
+        assert name not in statements, f"{name} is a replicated migration"
+
     # Applied from user-data, so the node is complete when it finishes booting
     # rather than depending on a manual step someone forgets.
     assert "--multiquery < /root/operational_schema.sql" in script

--- a/tests/test_clickhouse_operational_deploy.py
+++ b/tests/test_clickhouse_operational_deploy.py
@@ -177,11 +177,31 @@ def test_clickhouse_bundle_rejects_dirty_or_invalid_source(tmp_path: Path) -> No
 
 
 def test_client_telemetry_single_node_schema_is_applied_with_operational_schema() -> None:
+    """Client telemetry still ships with the operational schema -- but named by
+    DERIVATION now, not by filename.
+
+    This used to assert the script contained the literal strings
+    "006_operational_analytics_single_node.sql" and
+    "009_client_events_single_node.sql". That is what kept the defect alive: the
+    script applied exactly those two, 010 through 013 landed, and this test went
+    on passing because it was asserting the hardcoding rather than the coverage.
+
+    Newer contract: both files are members of clickhouse/*_single_node.sql, and
+    the script applies that whole derived set via
+    scripts/deploy/_clickhouse_single_node_schema.sh. Membership and the
+    derivation are pinned in tests/test_single_node_schema_set.py, including
+    that 013 (the workspace_id column the drain inserts) is in it.
+    """
     script = (ROOT / "scripts/deploy/aws_eu_north_clickhouse.sh").read_text()
 
-    assert "006_operational_analytics_single_node.sql" in script
-    assert "009_client_events_single_node.sql" in script
-    assert "${CLIENT_SCHEMA}" in script
+    assert "single_node_migrations" in script
+    assert 'OPERATIONAL_SCHEMA="$(cat "${SCHEMA_FILES[@]}")"' in script
+    for name in (
+        "006_operational_analytics_single_node.sql",
+        "009_client_events_single_node.sql",
+    ):
+        assert (ROOT / "clickhouse" / name).exists()
+        assert name.endswith("_single_node.sql"), "must be inside the derived set"
 
 
 def test_operational_finalize_requires_live_outbox_before_closing_gap() -> None:

--- a/tests/test_single_node_schema_set.py
+++ b/tests/test_single_node_schema_set.py
@@ -1,0 +1,141 @@
+"""The standalone-node schema set, and the scripts that apply it.
+
+Three scripts each carried their own copy of "which migrations does a standalone
+ClickHouse node need": two literal `006`+`009` lists and one `clickhouse/00*.sql`
+glob. All three were wrong the same way -- 010 through 013 landed and none of
+them picked those up -- and nothing failed, because the list lived in a shell
+glob and a NEXT_STEPS heredoc where no test could see it.
+
+The consequence is specifically silent. clickhouse/013_*.sql adds the
+workspace_id column the drain inserts; an un-migrated node REJECTS the insert;
+shard failures are contained, so the unit stays active and reports healthy while
+delivering nothing.
+
+These run the derivation rather than reading it, so a script that stops using it
+fails here instead of at 3am on a node nobody is watching.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / "scripts/deploy/_clickhouse_single_node_schema.sh"
+PARIS = ROOT / "scripts/deploy/aws_eu_clickhouse.sh"
+STOCKHOLM = ROOT / "scripts/deploy/aws_eu_north_clickhouse.sh"
+
+
+def _derive(root: Path) -> subprocess.CompletedProcess[str]:
+    argv = ["bash", "-c", f'. "{HELPER}"; single_node_migrations "$1"', "_", str(root)]  # noqa: S607 - bash from PATH, as CI runs it
+    return subprocess.run(  # noqa: S603 - fixed argv; running the real helper is the point
+        argv,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_the_set_is_derived_from_the_directory() -> None:
+    """Equality against what is actually on disk, NOT a literal list.
+
+    A literal here would rot in exactly the way the thing it is testing rotted.
+    """
+    expected = sorted(p.name for p in (ROOT / "clickhouse").glob("*_single_node.sql"))
+    result = _derive(ROOT)
+
+    assert result.returncode == 0, result.stderr
+    derived = [Path(line).name for line in result.stdout.split()]
+    assert derived == expected
+    # and the set is not the historical pair that started this
+    assert len(derived) > 2, "if this ever drops back to 006+009, something reverted"
+
+
+def test_the_workspace_id_migration_is_in_the_set() -> None:
+    """Named explicitly because it is the one with teeth: its own header says it
+    MUST be applied before the clickhouse/ tree is next shipped to a node."""
+    result = _derive(ROOT)
+
+    assert result.returncode == 0, result.stderr
+    names = {Path(line).name for line in result.stdout.split()}
+    assert "013_activity_generations_workspace_id_single_node.sql" in names
+    assert "011_workspace_directory_single_node.sql" in names
+
+
+def test_every_single_node_migration_targets_the_default_database() -> None:
+    """Standalone nodes connect to `default`: the AWS control plane and drain
+    installer both default CH_DATABASE to it, and so does Azure. Only GCP uses
+    `tr`, via the ON CLUSTER migrations, which are not in this set. A qualified
+    statement here would apply somewhere nothing reads -- and SUCCEED, which is
+    worse than being skipped."""
+    result = _derive(ROOT)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_a_qualified_migration_is_refused(tmp_path: Path) -> None:
+    """The guard above, shown failing. 011 and 013 really did ship qualified."""
+    (tmp_path / "clickhouse").mkdir()
+    (tmp_path / "clickhouse" / "900_ok_single_node.sql").write_text(
+        "CREATE TABLE IF NOT EXISTS fine (x Int64) ENGINE = MergeTree ORDER BY x;\n"
+    )
+    (tmp_path / "clickhouse" / "901_bad_single_node.sql").write_text(
+        "ALTER TABLE tr.activity_generations ADD COLUMN IF NOT EXISTS y Int64;\n"
+    )
+
+    result = _derive(tmp_path)
+
+    assert result.returncode != 0
+    assert "901_bad_single_node.sql" in result.stderr
+    assert "default" in result.stderr
+
+
+def test_an_empty_set_is_refused_rather_than_applied(tmp_path: Path) -> None:
+    """A rename would otherwise apply nothing and look like success."""
+    (tmp_path / "clickhouse").mkdir()
+    (tmp_path / "clickhouse" / "006_renamed_away.sql").write_text("SELECT 1;\n")
+
+    result = _derive(tmp_path)
+
+    assert result.returncode != 0
+    assert "EMPTY schema" in result.stderr
+
+
+@pytest.mark.parametrize("script", [PARIS, STOCKHOLM], ids=["paris", "stockholm"])
+def test_node_scripts_use_the_shared_derivation(script: Path) -> None:
+    text = script.read_text(encoding="utf-8")
+
+    assert "_clickhouse_single_node_schema.sh" in text
+    assert "single_node_migrations" in text
+    # The two shapes this replaced, neither of which may come back.
+    assert "clickhouse/00*.sql" not in text
+    assert "006_operational_analytics_single_node.sql" not in text
+    assert "009_client_events_single_node.sql" not in text
+
+
+def test_paris_applies_the_schema_instead_of_printing_it() -> None:
+    """It used to be step 1 of a NEXT_STEPS heredoc, described as a human step
+    needing the ClickHouse password -- which the script had already read from
+    Secrets Manager to write users.d. The only thing the human step added was a
+    chance to run a stale command, and it was stale."""
+    text = PARIS.read_text(encoding="utf-8")
+
+    assert "--multiquery < /root/operational_schema.sql" in text
+    assert "OPERATIONAL_SCHEMA" in text
+    # the instruction is gone from the operator steps
+    next_steps = text.split("NEXT_STEPS=$(cat <<NEXT", 1)[1]
+    assert "apply the schema" not in next_steps
+    assert "clickhouse-client" not in next_steps
+
+
+def test_both_nodes_of_the_aws_cloud_apply_the_same_set() -> None:
+    """Stockholm exists to be a second copy of Paris's history. Two nodes built
+    from different schema sets are not copies of each other."""
+    paris = PARIS.read_text(encoding="utf-8")
+    stockholm = STOCKHOLM.read_text(encoding="utf-8")
+
+    for text in (paris, stockholm):
+        assert 'single_node_migrations "' in text
+        assert 'OPERATIONAL_SCHEMA="$(cat "${SCHEMA_FILES[@]}")"' in text


### PR DESCRIPTION
The reported bug was `aws_eu_clickhouse.sh`'s `clickhouse/00*.sql` glob, which matches 001–009 and silently skips 010–013. Looking for it turned up **two more copies of the same defect**, one of them in executed code.

| script | what it applied | shape |
|---|---|---|
| `azure_clickhouse.sh` | literal 006+009 | fixed in #719 |
| `aws_eu_clickhouse.sh` | `clickhouse/00*.sql` | **printed** in NEXT_STEPS |
| `aws_eu_north_clickhouse.sh` | literal 006+009 | **executed** in user-data |

All three were wrong the same way and for the same reason: the list was written once and the directory kept moving. The set is now derived from `clickhouse/*_single_node.sql` by one shared helper, so a new standalone migration needs no edit anywhere.

**Stockholm is the one that mattered most.** It exists to be a second, independent copy of Paris's history — and two nodes built from different schema sets are not copies of each other. It applies its set in user-data, so any node it built lacks `workspace_id`.

## Why this is silent

`013` adds the `workspace_id` column the drain inserts (`ingest_operational_outbox.py:28`). An un-migrated node **rejects** the insert, and shard failures are contained (`ingest_operational_outbox_postgres.py` ~1004), so the systemd unit stays `active` and reports healthy while delivering zero rows. The drain already knows this shape — `ingest_operational_outbox_postgres.py:511` warns about *"deleting rows the second node never received."*

## The helper refuses rather than proceeds

**An empty set**, because a rename would otherwise apply nothing and look like success.

**A database-qualified statement**, because every consumer of this set connects to `default` — the AWS control plane and drain installer both default `CH_DATABASE` to it, and so does Azure. Only GCP uses `tr`, via the ON CLUSTER migrations that aren't in this set. A qualified statement applies somewhere nothing reads **and still succeeds**, which is worse than being skipped. `011` and `013` shipped qualified `tr.` for exactly that reason. Pointed at current main, the helper refuses and names both files.

They're unqualified here, **byte-identical** to the same correction in #719, so the branches merge cleanly whichever lands first. Without that correction this change would be actively harmful — switching to `*_single_node.sql` while those two are `tr.`-qualified would apply them into a database no AWS drain reads.

## On printing vs executing

`aws_eu_clickhouse.sh` now applies the schema in user-data instead of printing it. That step was described as a human one *needing the ClickHouse password* — but the script had already read that password from Secrets Manager to write `users.d`. The only thing the human step added was a chance to run a stale command, and it was stale. Its sibling already applied schema in user-data; the two nodes of one cloud now boot the same way.

This closes the loop on the incident narrated in `verify_cloud_complete.sh`: a script that printed a step and exited 0 is what let 470,897 rows accumulate behind a green status page.

## Verification

`tests/test_single_node_schema_set.py` **runs** the derivation rather than reading it — the original bug survived because it lived in a shell glob and a heredoc where no test could see it. Mutation-verified: restoring the `00*.sql` glob, re-qualifying `013`, and reverting Stockholm to the hardcoded pair each turn it red; restoring turns it green.

One existing test had to change. `test_client_telemetry_single_node_schema_is_applied_with_operational_schema` asserted the script contained the literal strings `006_operational_analytics_single_node.sql` and `009_client_events_single_node.sql`. **That is what kept the defect alive** — it pinned the hardcoding rather than the coverage, and passed throughout. It now asserts the newer contract: both are members of the derived set, with membership and derivation pinned in the new file.

208 tests pass; `bash -n`, `shellcheck -x`, ruff and mypy clean. shellcheck earned its keep here — it caught that a comment I put inside the unquoted user-data heredoc contained backticks, which would have run as a command substitution at expansion time.