### PR TITLE
Repair hourly price refresh lifecycle gate

### DIFF
--- a/.github/workflows/refresh-prices.yml
+++ b/.github/workflows/refresh-prices.yml
@@ -178,7 +178,11 @@ jobs:
                       WANDB_API_KEY:trustedrouter-wandb-api-key; do
             env="${pair%%:*}"
             secret="${pair#*:}"
-            KEY=$(gcloud secrets versions access latest --secret="${secret}" --project=quill-cloud-proxy)
+            if ! KEY=$(gcloud secrets versions access latest \
+              --secret="${secret}" --project=quill-cloud-proxy); then
+              echo "::error title=Provider refresh secret unavailable::${env} cannot access ${secret}; reconcile its per-secret tr-deploy accessor binding with scripts/deploy/secrets.sh"
+              exit 1
+            fi
             echo "::add-mask::${KEY}"
             echo "${env}=${KEY}" >> "$GITHUB_ENV"
           done

--- a/tests/test_phala_july_2026_lifecycle.py
+++ b/tests/test_phala_july_2026_lifecycle.py
@@ -54,7 +54,7 @@ def test_phala_retirement_is_provider_scoped(monkeypatch: pytest.MonkeyPatch) ->
     # Qwen revision after Phala's route is removed. Their own lifecycle notices
     # govern those independent routes.
     if catalog_predates(provider_lifecycle.ALIBABA_OCTOBER_2026_RETIREMENT_AT):
-        assert qwen_providers == {"alibaba", "wandb"}
+        assert {"alibaba", "wandb"} <= qwen_providers
 
 
 def test_non_confidential_phala_qwen_route_is_not_published() -> None:
@@ -70,8 +70,9 @@ def test_public_catalog_uses_effective_price_and_active_routes(
 ) -> None:
     monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
 
-    qwen_price = model_to_openrouter_shape(MODELS["qwen/qwen-2.5-7b-instruct"])
-    qwen_endpoints = endpoints_for_model("qwen/qwen-2.5-7b-instruct")
+    model_id = "qwen/qwen3-30b-a3b-instruct-2507"
+    qwen_price = model_to_openrouter_shape(MODELS[model_id])
+    qwen_endpoints = endpoints_for_model(model_id)
     assert qwen_endpoints
     assert all(endpoint.provider != "phala" for endpoint in qwen_endpoints)
     assert qwen_price["trustedrouter"]["prompt_price_microdollars_per_million_tokens"] == min(
@@ -82,14 +83,17 @@ def test_public_catalog_uses_effective_price_and_active_routes(
     # to serve it. Provider lifecycle policy must remove only the retired
     # Phala and Alibaba routes rather than deleting the canonical model.
     if catalog_predates(provider_lifecycle.ALIBABA_OCTOBER_2026_RETIREMENT_AT):
-        retired_qwen = model_to_openrouter_shape(MODELS["qwen/qwen3-30b-a3b-instruct-2507"])
+        retired_qwen = model_to_openrouter_shape(MODELS[model_id])
         assert all(
             endpoint["provider"] != "phala"
             for endpoint in retired_qwen["trustedrouter"]["endpoints"]
         )
     else:
-        surviving_endpoints = endpoints_for_model("qwen/qwen3-30b-a3b-instruct-2507")
-        assert {endpoint.provider for endpoint in surviving_endpoints} == {"wandb"}
+        surviving_providers = {
+            endpoint.provider for endpoint in endpoints_for_model(model_id)
+        }
+        assert "wandb" in surviving_providers
+        assert {"phala", "alibaba"}.isdisjoint(surviving_providers)
 
 
 def test_phala_hourly_parser_applies_announced_policy() -> None:


### PR DESCRIPTION
## Summary

- make the Phala lifecycle publication test follow the actual retired Qwen revision instead of assuming an unrelated provider model remains in every live refresh
- keep provider lifecycle assertions robust when additional healthy providers are added
- surface the exact environment variable and secret binding when hourly refresh credential access fails

## Production repair

- restored the missing per-secret `roles/secretmanager.secretAccessor` binding for `tr-deploy@` on `trustedrouter-wandb-api-key`
- started a replacement hourly refresh run after the IAM repair

## Tests

- `.venv/bin/pytest -q tests/test_phala_july_2026_lifecycle.py tests/test_deploy_secret_wiring.py::test_every_authenticated_discovery_feed_is_wired_to_narrow_secret_access tests/test_refresh_workflow_dispatch.py`
- `.venv/bin/ruff check tests/test_phala_july_2026_lifecycle.py tests/test_refresh_workflow_dispatch.py`
- parsed `.github/workflows/refresh-prices.yml` with PyYAML
