### PR TITLE
blog: label it Featured, and make both sections newest-first

### DIFF
--- a/src/trusted_router/content/blog.py
+++ b/src/trusted_router/content/blog.py
@@ -35,11 +35,12 @@ class BlogPost:
 #: tell the two posts that explain what this company is from the twenty-six
 #: that report a benchmark result.
 #:
-#: Slugs rather than a flag on BlogPost, so the running order lives in one
-#: place and is read in one glance. `test_featured_slugs_all_resolve` fails if
-#: one stops matching a post -- a typo or a rename would otherwise empty this
-#: section in silence, and an empty featured section looks exactly like a
-#: design choice.
+#: Slugs rather than a flag on BlogPost, so the selection lives in one place and
+#: is read in one glance. This chooses WHICH posts are featured, not their
+#: order -- the section renders newest-first, like the archive below it.
+#: `test_featured_slugs_all_resolve` fails if one stops matching a post: a typo
+#: or a rename would otherwise empty this section in silence, and an empty
+#: featured section looks exactly like a design choice.
 FEATURED_SLUGS: tuple[str, ...] = (
     "synth-iris-prometheus-zeus",
     "they-are-still-training-on-your-data",

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -2233,30 +2233,40 @@ def _blog_og_image(settings: Settings, post: BlogPost) -> str:
     return f"https://{settings.trusted_domain}/og.png"
 
 
+def _newest_first(posts: Iterable[BlogPost]) -> list[BlogPost]:
+    """Reverse-chronological, enforced here rather than trusted upstream.
+
+    BLOG_POSTS is a hand-maintained tuple and had drifted: the-models-that-say-no
+    (2026-06-16) sat above a 2026-06-17 post. Sorting at render time makes the
+    order a property of the code instead of a thing every future author has to
+    remember, and `published_date` is ISO so the string compare is the date
+    compare.
+    """
+    return sorted(posts, key=lambda post: post.published_date, reverse=True)
+
+
 def _blog_index_posts(settings: Settings) -> tuple[BlogIndexPost, ...]:
     return tuple(
-        BlogIndexPost(post=post, image=_blog_og_image(settings, post)) for post in BLOG_POSTS
+        BlogIndexPost(post=post, image=_blog_og_image(settings, post))
+        for post in _newest_first(BLOG_POSTS)
     )
 
 
 def _featured_blog_posts(settings: Settings) -> tuple[BlogIndexPost, ...]:
-    """The featured posts, in FEATURED_SLUGS order.
+    """The featured posts, newest first.
 
-    Ordered by the tuple rather than by date: the point of the section is an
-    editorial running order, and sorting it chronologically would hand that
-    decision back to the calendar.
+    FEATURED_SLUGS chooses WHICH posts are featured; it does not choose their
+    order. Both sections on this page read newest-first, so a reader does not
+    have to work out that one of them follows a different rule.
 
     A slug that matches no post is skipped here and fails a test instead. The
     blog index should not 500 because somebody renamed a post, but it also
     should not silently show one card where two were intended.
     """
+    featured = [BLOG_POSTS_BY_SLUG[slug] for slug in FEATURED_SLUGS if slug in BLOG_POSTS_BY_SLUG]
     return tuple(
-        BlogIndexPost(
-            post=BLOG_POSTS_BY_SLUG[slug],
-            image=_blog_og_image(settings, BLOG_POSTS_BY_SLUG[slug]),
-        )
-        for slug in FEATURED_SLUGS
-        if slug in BLOG_POSTS_BY_SLUG
+        BlogIndexPost(post=post, image=_blog_og_image(settings, post))
+        for post in _newest_first(featured)
     )
 
 

--- a/src/trusted_router/templates/public/blog_index.html
+++ b/src/trusted_router/templates/public/blog_index.html
@@ -65,7 +65,7 @@
   </div>
   {% if featured %}
   <section class="blog-featured" aria-labelledby="featured-heading">
-    <p class="blog-featured-label" id="featured-heading">Start here</p>
+    <p class="blog-featured-label" id="featured-heading">Featured</p>
     <div class="blog-featured-grid">
       {% for item in featured %}
       <article class="blog-feature">

--- a/tests/test_blog_featured.py
+++ b/tests/test_blog_featured.py
@@ -15,7 +15,7 @@ from fastapi.testclient import TestClient
 
 from trusted_router.config import Settings
 from trusted_router.content.blog import BLOG_POSTS_BY_SLUG, FEATURED_SLUGS
-from trusted_router.dashboard import _featured_blog_posts
+from trusted_router.dashboard import _blog_index_posts, _featured_blog_posts
 
 
 def test_featured_slugs_all_resolve() -> None:
@@ -34,26 +34,43 @@ def test_the_featured_section_is_not_empty() -> None:
     assert all(item.image for item in featured)
 
 
-def test_featured_order_follows_the_tuple_not_the_calendar() -> None:
-    """The running order is editorial. Sorting by date would hand the decision
-    back to the calendar, which is what the chronological list below already
-    does."""
-    featured = _featured_blog_posts(Settings(environment="test"))
+def test_featured_is_newest_first_regardless_of_slug_order() -> None:
+    """FEATURED_SLUGS chooses WHICH posts are featured, not their order.
 
-    assert [item.post.slug for item in featured] == list(FEATURED_SLUGS)
+    Both sections on the page read newest-first so a reader does not have to
+    work out that one follows a different rule. The assertion is meaningful
+    only because the slug order and the date order currently DISAGREE -- if
+    they ever coincide this test would pass without exercising the sort, so it
+    checks that too.
+    """
+    featured = _featured_blog_posts(Settings(environment="test"))
     dates = [item.post.published_date for item in featured]
-    assert dates != sorted(dates, reverse=True), (
-        "featured order coincides with newest-first, so this test proves nothing; "
-        "pick a case where editorial order and date order differ"
+
+    assert dates == sorted(dates, reverse=True)
+    slug_order = [BLOG_POSTS_BY_SLUG[s].published_date for s in FEATURED_SLUGS]
+    assert slug_order != dates, (
+        "FEATURED_SLUGS order now coincides with newest-first, so this test no "
+        "longer proves the sort runs; reorder the tuple or pick another case"
     )
+
+
+def test_the_archive_is_always_newest_first() -> None:
+    """BLOG_POSTS is hand-maintained and had drifted: the-models-that-say-no
+    (2026-06-16) sat above a 2026-06-17 post. The order is sorted at render
+    time now, so this asserts the rendered list rather than the tuple."""
+    posts = _blog_index_posts(Settings(environment="test"))
+    dates = [item.post.published_date for item in posts]
+
+    assert dates == sorted(dates, reverse=True)
+    assert len(posts) == len(BLOG_POSTS_BY_SLUG)
 
 
 def test_the_blog_index_shows_featured_above_the_archive(client: TestClient) -> None:
     html = client.get("/blog", headers={"accept": "text/html"}).text
 
-    assert "Start here" in html
+    assert "Featured" in html
     assert "All posts" in html
-    assert html.index("Start here") < html.index("All posts")
+    assert html.index("Featured") < html.index("All posts")
     for slug in FEATURED_SLUGS:
         assert f'href="/blog/{slug}"' in html, slug
 


### PR DESCRIPTION
Follow-up to #804: relabel `Start here` → `Featured`, and make ordering
consistently reverse-chronological.

## The ordering change found a real bug

`FEATURED_SLUGS` now chooses **which** posts are featured, not their order.
Both sections render newest-first, so a reader doesn't have to work out that
one follows a different rule. This reverses my earlier call to keep an
editorial running order.

While checking, **the archive turned out not to be reverse-chronological
either.** `BLOG_POSTS` is a hand-maintained tuple and had drifted —
`the-models-that-say-no` (2026-06-16) sat above a 2026-06-17 post.

Rather than reorder the tuple and rely on every future author to keep it
sorted, both lists are sorted at render time. The order is now a property of
the code instead of a thing someone has to remember. `published_date` is ISO,
so the string compare is the date compare.

## The ordering test is inverted, deliberately

The old test asserted featured order followed the tuple and **differed** from
newest-first. The new one asserts newest-first — and additionally asserts that
slug order and date order still *disagree*. If they ever coincide, the test
would pass without exercising the sort at all, which is the same failure mode
the old version guarded against in the opposite direction.

Also added: a test that the rendered archive is newest-first across all 38
posts. It asserts the **rendered** list, not the tuple, since the tuple no
longer determines order.

Verified rendered: `Featured` label present, `Start here` gone, and
`they-are-still-training-on-your-data` (2026-08-05) now precedes
`synth-iris-prometheus-zeus` (2026-06-24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)