### PR TITLE
Primary-live deploys: warm everything early, converge behind the same lock

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -345,11 +345,20 @@ jobs:
     needs: [build-image, migrate-schema, sync-runtime-secrets, confirm-current-main]
     if: ${{ needs.confirm-current-main.outputs.proceed == 'true' }}
     runs-on: ubuntu-latest
-    # Must stay UNDER the deployment mutex TTL (deploy_mutex.sh, 5400s): a job
-    # that outlives the lease invites a legal expired-lock takeover while this
-    # run is still shifting traffic — the exact overlap the mutex exists to
-    # prevent. GitHub's default 360-minute bound is four TTLs too generous.
-    timeout-minutes: 85
+    outputs:
+      TR_DEPLOY_MUTEX_OPERATION: ${{ steps.acquire_mutex.outputs.TR_DEPLOY_MUTEX_OPERATION }}
+      TR_DEPLOY_MUTEX_GENERATION: ${{ steps.acquire_mutex.outputs.TR_DEPLOY_MUTEX_GENERATION }}
+      sha: ${{ needs.build-image.outputs.sha }}
+      image: ${{ needs.build-image.outputs.image }}
+      previous_europe_west4_revision: ${{ steps.prev.outputs.europe_west4_revision }}
+      previous_us_east4_revision: ${{ steps.prev.outputs.us_east4_revision }}
+      previous_southamerica_east1_revision: ${{ steps.prev.outputs.southamerica_east1_revision }}
+      europe_west4_revision: ${{ steps.warm_all.outputs.europe_west4_revision }}
+      us_east4_revision: ${{ steps.warm_all.outputs.us_east4_revision }}
+      southamerica_east1_revision: ${{ steps.warm_all.outputs.southamerica_east1_revision }}
+    # The mutex TTL is 90 minutes. The two lock-owning job bounds total
+    # 25 + 55 = 80 minutes, leaving 10 minutes for the job handoff queue gap.
+    timeout-minutes: 25
     env:
       PROJECT_ID: quill-cloud-proxy
       REGION: us-central1
@@ -378,18 +387,24 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Acquire production deployment mutex
+        id: acquire_mutex
         env:
           TR_DEPLOY_MUTEX_OWNER: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           TR_DEPLOY_MUTEX_TOOL: workflow
-        run: bash scripts/deploy/deploy_mutex.sh acquire >> "$GITHUB_ENV"
+        # No pipeline here: GitHub's default run shell is `bash -e` WITHOUT
+        # pipefail, so `acquire | tee` would exit with tee's 0 and a BLOCKED
+        # acquire would let the deploy proceed without holding the lock. The
+        # command substitution propagates acquire's exit code under -e, and
+        # the fence reaches ENV and OUTPUT only when acquisition succeeded.
+        run: |
+          fence="$(bash scripts/deploy/deploy_mutex.sh acquire)"
+          printf '%s\n' "$fence" >> "$GITHUB_ENV"
+          printf '%s\n' "$fence" >> "$GITHUB_OUTPUT"
 
-      # Staged regional deploy. Deploy us-central1 first, gate on a
-      # 3-min single-region synthetic watch; only proceed to the
-      # secondary warm regions if us-central1 stays up. Once the image has
-      # passed the primary's full ramp and 3-minute canary, secondary revisions
-      # warm in parallel without traffic, then ramp serially. Incident #695
-      # (billing 5xx, 2026-08-20) showed that overlapping revision warmups and
-      # traffic ramps can amplify billing transaction contention.
+      # Staged regional deploy. Warm all four no-traffic revisions together,
+      # then gate primary-live on us-central1's unchanged 10/50/100 ramp and
+      # 3-minute single-region synthetic watch. The follow-on job inherits the
+      # same mutex fence and ramps the already-warm secondaries serially.
       #
       # Hotfix mode (workflow_dispatch input `hotfix: true`): the
       # watchdogs skip baseline + use --skip-baseline so a sick prod
@@ -424,6 +439,214 @@ jobs:
             echo "${key}=${rev}" >> "$GITHUB_OUTPUT"
             echo "  pre-deploy ${region}: ${rev}"
           done
+
+      - name: Warm all four regions in parallel (no traffic)
+        id: warm_all
+        env:
+          IMAGE_TAG: ${{ needs.build-image.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          warm_region() {
+            local region="$1"
+            local reconcile_lb="$2"
+            local revision_file="$3"
+            echo "deploying ${region} no-traffic"
+            if ! TR_DEPLOY_TARGET_REGIONS="${region}" \
+                TR_DEPLOY_NO_TRAFFIC="1" \
+                TR_DEPLOY_RECONCILE_LB="${reconcile_lb}" \
+                IMAGE_TAG="${IMAGE_TAG}" \
+                bash scripts/deploy/rollout.sh; then
+              echo "${region} no-traffic deploy failed"
+              return 1
+            fi
+
+            local revision
+            if ! revision="$(gcloud run services describe "${SERVICE}" \
+                --region="${region}" --project="${PROJECT_ID}" \
+                --format='value(status.latestCreatedRevisionName)')"; then
+              echo "${region} revision lookup failed after its no-traffic deploy"
+              return 1
+            fi
+            if [ -z "${revision}" ]; then
+              echo "${region} deploy did not create a revision"
+              return 1
+            fi
+            echo "new ${region} revision: ${revision}"
+            printf '%s\n' "${revision}" >"${revision_file}"
+          }
+
+          # rollout.sh gates global load-balancer mutation on
+          # TR_DEPLOY_RECONCILE_LB. Only the primary process receives 1; all
+          # concurrent secondary processes receive 0 and cannot mutate the LB.
+          # Every rollout inherits TR_DEPLOY_MUTEX_OPERATION from this job.
+          regions=(us-central1 europe-west4 us-east4 southamerica-east1)
+          logs=(
+            "${RUNNER_TEMP}/warmup-us-central1.log"
+            "${RUNNER_TEMP}/warmup-europe-west4.log"
+            "${RUNNER_TEMP}/warmup-us-east4.log"
+            "${RUNNER_TEMP}/warmup-southamerica-east1.log"
+          )
+          revision_files=(
+            "${RUNNER_TEMP}/revision-us-central1"
+            "${RUNNER_TEMP}/revision-europe-west4"
+            "${RUNNER_TEMP}/revision-us-east4"
+            "${RUNNER_TEMP}/revision-southamerica-east1"
+          )
+          pids=()
+          primary_started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          (warm_region "us-central1" "1" "${revision_files[0]}") >"${logs[0]}" 2>&1 &
+          pids+=("$!")
+          (warm_region "europe-west4" "0" "${revision_files[1]}") >"${logs[1]}" 2>&1 &
+          pids+=("$!")
+          (warm_region "us-east4" "0" "${revision_files[2]}") >"${logs[2]}" 2>&1 &
+          pids+=("$!")
+          (warm_region "southamerica-east1" "0" "${revision_files[3]}") >"${logs[3]}" 2>&1 &
+          pids+=("$!")
+
+          statuses=()
+          for idx in "${!pids[@]}"; do
+            if wait "${pids[$idx]}"; then
+              statuses[$idx]=0
+            else
+              statuses[$idx]=$?
+            fi
+          done
+
+          failed=0
+          for idx in "${!regions[@]}"; do
+            printf '\n=== warmup: %s ===\n' "${regions[$idx]}"
+            cat "${logs[$idx]}"
+            if [ "${statuses[$idx]}" -ne 0 ]; then
+              echo "::error::${regions[$idx]} no-traffic warmup failed."
+              failed=1
+            fi
+          done
+          if [ "$failed" -ne 0 ]; then
+            echo "::error::Regional warmup failed; no traffic moved. Successful warm revisions remain at zero traffic."
+            exit 1
+          fi
+
+          echo "primary_started_at=${primary_started_at}" >> "$GITHUB_OUTPUT"
+          echo "us_central1_revision=$(<"${revision_files[0]}")" >> "$GITHUB_OUTPUT"
+          echo "europe_west4_revision=$(<"${revision_files[1]}")" >> "$GITHUB_OUTPUT"
+          echo "us_east4_revision=$(<"${revision_files[2]}")" >> "$GITHUB_OUTPUT"
+          echo "southamerica_east1_revision=$(<"${revision_files[3]}")" >> "$GITHUB_OUTPUT"
+
+      - name: Stage traffic 10/50/100 (us-central1)
+        # Ramps the new revision from 10% → 50% → 100% with a 1-min
+        # synthetic watch between stages. On any watch trip, traffic
+        # is reverted to 100% on the old revision and the workflow
+        # fails before any secondary receives traffic.
+        env:
+          TR_WATCHDOG_SLO_CLASS: router_core
+        run: bash scripts/deploy/staged_traffic.sh us-central1 "${{ steps.warm_all.outputs.us_central1_revision }}" "${{ steps.prev.outputs.us_central1_revision }}"
+
+      - name: Canary gate — watch us-central1 only (3 min)
+        # Single-region 3-min canary. Down × 2 in a row trips it
+        # (faster reaction than the final watch). The secondaries have
+        # warm revisions but remain at zero traffic, so the bad change is
+        # contained to us-central1.
+        id: canary_us
+        continue-on-error: true
+        run: python3 scripts/deploy/watchdog.py --regions us-central1 --duration-min 3 --rollback-after 2 --slo-class router_core ${{ steps.wd_args.outputs.extra }}
+
+      - name: Rollback us-central1 + abort (canary tripped)
+        if: ${{ steps.canary_us.outcome == 'failure' && steps.canary_us.outputs.rollback_regions != '' }}
+        env:
+          PREV_US: ${{ steps.prev.outputs.us_central1_revision }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PREV_US}" ]; then
+            echo "no prior us-central1 revision recorded; cannot rollback"
+            exit 1
+          fi
+          echo "us-central1 canary failed; rolling traffic back to ${PREV_US}"
+          gcloud run services update-traffic "${SERVICE}" \
+            --region=us-central1 --project="${PROJECT_ID}" \
+            --to-revisions="${PREV_US}=100" --quiet
+          echo "secondaries remain warm at zero traffic; safe."
+          exit 1
+
+      - name: Billing-path gate + rollback (us-central1)
+        env:
+          PREV_US: ${{ steps.prev.outputs.us_central1_revision }}
+          TR_BILLING_5XX_GATE_SKIP: ${{ inputs.hotfix == true && 'true' || 'false' }}
+        run: |
+          set -euo pipefail
+          if ! bash scripts/deploy/assert_no_billing_5xx.sh \
+              us-central1 \
+              "${{ steps.warm_all.outputs.primary_started_at }}" \
+              "${{ steps.warm_all.outputs.us_central1_revision }}"; then
+            echo "us-central1 emitted billing-path 5xx; rolling back to ${PREV_US}"
+            gcloud run services update-traffic "${SERVICE}" \
+              --region=us-central1 --project="${PROJECT_ID}" \
+              --to-revisions="${PREV_US}=100" --quiet
+            exit 1
+          fi
+
+      # Mutex release ownership:
+      # - deploy fails/cancels: this conditional release runs promptly.
+      # - deploy succeeds and rollout-secondaries runs: ownership transfers,
+      #   and that job releases on success or failure.
+      # - deploy succeeds but GitHub never schedules rollout-secondaries: no
+      #   release runs; the 90-minute TTL recovers. Queued deploys fail closed
+      #   during that freeze, so production mutations never overlap.
+      - name: Release production deployment mutex after primary-live failure
+        if: ${{ failure() || cancelled() }}
+        run: bash scripts/deploy/deploy_mutex.sh release
+
+  rollout-secondaries:
+    needs: [deploy]
+    if: ${{ success() }}
+    runs-on: ubuntu-latest
+    # The mutex TTL is 90 minutes. The two lock-owning job bounds total
+    # 25 + 55 = 80 minutes, leaving 10 minutes for the job handoff queue gap.
+    timeout-minutes: 55
+    env:
+      PROJECT_ID: quill-cloud-proxy
+      REGION: us-central1
+      REPO: trusted-router
+      SERVICE: trusted-router
+      SHA: ${{ needs.deploy.outputs.sha }}
+      IMAGE: ${{ needs.deploy.outputs.image }}
+    steps:
+      - name: Import production deployment mutex fence
+        env:
+          DEPLOY_MUTEX_OPERATION: ${{ needs.deploy.outputs.TR_DEPLOY_MUTEX_OPERATION }}
+          DEPLOY_MUTEX_GENERATION: ${{ needs.deploy.outputs.TR_DEPLOY_MUTEX_GENERATION }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DEPLOY_MUTEX_OPERATION}" ] || [ -z "${DEPLOY_MUTEX_GENERATION}" ]; then
+            echo "::error::deploy did not export a complete mutex fence"
+            exit 1
+          fi
+          echo "TR_DEPLOY_MUTEX_OPERATION=${DEPLOY_MUTEX_OPERATION}" >> "$GITHUB_ENV"
+          echo "TR_DEPLOY_MUTEX_GENERATION=${DEPLOY_MUTEX_GENERATION}" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Authenticate to GCP via WIF
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/44325983244/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Compute watchdog args (hotfix vs normal)
+        id: wd_args
+        run: |
+          if [ "${{ inputs.hotfix }}" = "true" ]; then
+            echo "extra=--skip-baseline --rollback-after 99 --baseline-grace-sec 0" >> "$GITHUB_OUTPUT"
+            echo "::warning::HOTFIX MODE — watchdog gating disabled. Synthetic 'down' will not block this deploy."
+          else
+            echo "extra=" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Detect optional deploy surfaces
         id: optional
@@ -464,88 +687,16 @@ jobs:
           echo "deploy_google_data_manager=${deploy_google_data_manager}" >> "$GITHUB_OUTPUT"
           echo "deploy_google_data_manager=${deploy_google_data_manager}"
 
-      - name: Deploy us-central1 (no-traffic)
-        id: deploy_us
+      - name: Ramp secondaries serially while reconciler deploys
         env:
-          IMAGE_TAG: ${{ needs.build-image.outputs.sha }}
-          TR_DEPLOY_TARGET_REGIONS: us-central1
-          TR_DEPLOY_NO_TRAFFIC: "1"
-          # Global LB topology is shared by every region. Reconcile it exactly
-          # once here; concurrent secondary rollouts must not race on it.
-          TR_DEPLOY_RECONCILE_LB: "1"
-        run: |
-          echo "started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
-          bash scripts/deploy/rollout.sh
-
-      - name: Resolve us-central1 new revision
-        id: new_us
-        run: |
-          rev=$(gcloud run services describe "${SERVICE}" \
-            --region=us-central1 --project="${PROJECT_ID}" \
-            --format='value(status.latestCreatedRevisionName)')
-          echo "revision=${rev}" >> "$GITHUB_OUTPUT"
-          echo "  new us-central1 revision: ${rev}"
-
-      - name: Stage traffic 10/50/100 (us-central1)
-        # Ramps the new revision from 10% → 50% → 100% with a 1-min
-        # synthetic watch between stages. On any watch trip, traffic
-        # is reverted to 100% on the old revision and the workflow
-        # fails before ever shipping anything to europe-west4.
-        env:
-          TR_WATCHDOG_SLO_CLASS: router_core
-        run: bash scripts/deploy/staged_traffic.sh us-central1 "${{ steps.new_us.outputs.revision }}" "${{ steps.prev.outputs.us_central1_revision }}"
-
-      - name: Canary gate — watch us-central1 only (3 min)
-        # Single-region 3-min canary. Down × 2 in a row trips it
-        # (faster reaction than the final watch). europe-west4 hasn't
-        # received the new image yet, so the bad change is contained.
-        id: canary_us
-        continue-on-error: true
-        run: python3 scripts/deploy/watchdog.py --regions us-central1 --duration-min 3 --rollback-after 2 --slo-class router_core ${{ steps.wd_args.outputs.extra }}
-
-      - name: Rollback us-central1 + abort (canary tripped)
-        if: ${{ steps.canary_us.outcome == 'failure' && steps.canary_us.outputs.rollback_regions != '' }}
-        env:
-          PREV_US: ${{ steps.prev.outputs.us_central1_revision }}
-        run: |
-          set -euo pipefail
-          if [ -z "${PREV_US}" ]; then
-            echo "no prior us-central1 revision recorded; cannot rollback"
-            exit 1
-          fi
-          echo "us-central1 canary failed; rolling traffic back to ${PREV_US}"
-          gcloud run services update-traffic "${SERVICE}" \
-            --region=us-central1 --project="${PROJECT_ID}" \
-            --to-revisions="${PREV_US}=100" --quiet
-          echo "europe-west4 NEVER received the bad image; safe."
-          exit 1
-
-      - name: Billing-path gate + rollback (us-central1)
-        env:
-          PREV_US: ${{ steps.prev.outputs.us_central1_revision }}
-          TR_BILLING_5XX_GATE_SKIP: ${{ inputs.hotfix == true && 'true' || 'false' }}
-        run: |
-          set -euo pipefail
-          if ! bash scripts/deploy/assert_no_billing_5xx.sh \
-              us-central1 \
-              "${{ steps.deploy_us.outputs.started_at }}" \
-              "${{ steps.new_us.outputs.revision }}"; then
-            echo "us-central1 emitted billing-path 5xx; rolling back to ${PREV_US}"
-            gcloud run services update-traffic "${SERVICE}" \
-              --region=us-central1 --project="${PROJECT_ID}" \
-              --to-revisions="${PREV_US}=100" --quiet
-            exit 1
-          fi
-
-      - name: Warm secondaries in parallel, ramp serially
-        env:
-          IMAGE_TAG: ${{ needs.build-image.outputs.sha }}
-          PREV_EU: ${{ steps.prev.outputs.europe_west4_revision }}
-          PREV_US_EAST4: ${{ steps.prev.outputs.us_east4_revision }}
-          PREV_SOUTHAMERICA_EAST1: ${{ steps.prev.outputs.southamerica_east1_revision }}
+          PREV_EU: ${{ needs.deploy.outputs.previous_europe_west4_revision }}
+          PREV_US_EAST4: ${{ needs.deploy.outputs.previous_us_east4_revision }}
+          PREV_SOUTHAMERICA_EAST1: ${{ needs.deploy.outputs.previous_southamerica_east1_revision }}
+          NEW_EU: ${{ needs.deploy.outputs.europe_west4_revision }}
+          NEW_US_EAST4: ${{ needs.deploy.outputs.us_east4_revision }}
+          NEW_SOUTHAMERICA_EAST1: ${{ needs.deploy.outputs.southamerica_east1_revision }}
           WD_EXTRA: ${{ steps.wd_args.outputs.extra }}
           TR_WATCHDOG_SLO_CLASS: router_core
-          TR_DEPLOY_RECONCILE_LB: "0"
           TR_BILLING_5XX_GATE_SKIP: ${{ inputs.hotfix == true && 'true' || 'false' }}
         run: |
           set -euo pipefail
@@ -578,41 +729,12 @@ jobs:
               --to-revisions="${previous}=100" --quiet
           }
 
-          warm_secondary() {
-            local region="$1"
-            local revision_file="$2"
-            echo "deploying ${region} no-traffic"
-            if ! TR_DEPLOY_TARGET_REGIONS="${region}" \
-                TR_DEPLOY_NO_TRAFFIC="1" \
-                IMAGE_TAG="${IMAGE_TAG}" \
-                bash scripts/deploy/rollout.sh; then
-              echo "${region} no-traffic deploy failed"
-              return 1
-            fi
-
-            local revision
-            if ! revision="$(gcloud run services describe "${SERVICE}" \
-                --region="${region}" --project="${PROJECT_ID}" \
-                --format='value(status.latestCreatedRevisionName)')"; then
-              echo "${region} revision lookup failed after its no-traffic deploy"
-              return 1
-            fi
-            if [ -z "${revision}" ]; then
-              echo "${region} deploy did not create a revision"
-              return 1
-            fi
-            echo "new ${region} revision: ${revision}"
-            printf '%s\n' "${revision}" >"${revision_file}"
-          }
-
           ramp_secondary() {
             local region="$1"
-            local revision_file="$2"
+            local revision="$2"
             local previous
-            local revision
             local rollout_started_at
             previous="$(previous_revision "${region}")"
-            revision="$(cat "${revision_file}")"
             # The billing window belongs to this region's traffic ramp, not to
             # the earlier parallel warmup or a sibling's ramp.
             rollout_started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -660,69 +782,45 @@ jobs:
             fi
           }
 
-          # Incident containment from #695 (billing 5xx, 2026-08-20):
-          # overlapping revision warmups and traffic ramps can amplify billing
-          # transaction contention. Warm all no-traffic revisions in parallel,
-          # but never overlap a traffic ramp with another region's warmup or
-          # ramp. TR_DEPLOY_MUTEX_OPERATION is inherited by every warmup
-          # subshell, so rollout.sh remains inside the fleet mutex.
-          regions=(europe-west4 us-east4 southamerica-east1)
-          logs=(
-            "${RUNNER_TEMP}/secondary-warmup-europe-west4.log"
-            "${RUNNER_TEMP}/secondary-warmup-us-east4.log"
-            "${RUNNER_TEMP}/secondary-warmup-southamerica-east1.log"
-          )
-          revision_files=(
-            "${RUNNER_TEMP}/secondary-revision-europe-west4"
-            "${RUNNER_TEMP}/secondary-revision-us-east4"
-            "${RUNNER_TEMP}/secondary-revision-southamerica-east1"
-          )
-          pids=()
+          # Incident containment from #695 (billing 5xx, 2026-08-20): all
+          # revision warmups completed in deploy before primary traffic moved.
+          # Keep the three secondary 10/50/100 ramps explicit, serial, and
+          # stop-on-failure; no ramp overlaps a sibling ramp.
+          reconciler_log="${RUNNER_TEMP}/regional-quota-reconciler.log"
+          bash scripts/deploy/regional_quota_reconciler.sh >"${reconciler_log}" 2>&1 &
+          reconciler_pid=$!
 
-          (warm_secondary "europe-west4" "${revision_files[0]}") >"${logs[0]}" 2>&1 &
-          pids+=("$!")
-          (warm_secondary "us-east4" "${revision_files[1]}") >"${logs[1]}" 2>&1 &
-          pids+=("$!")
-          (warm_secondary "southamerica-east1" "${revision_files[2]}") >"${logs[2]}" 2>&1 &
-          pids+=("$!")
-
-          statuses=()
-          for idx in "${!pids[@]}"; do
-            if wait "${pids[$idx]}"; then
-              statuses[$idx]=0
-            else
-              statuses[$idx]=$?
-            fi
-          done
-
-          failed=0
-          for idx in "${!regions[@]}"; do
-            printf '\n=== %s ===\n' "${regions[$idx]}"
-            cat "${logs[$idx]}"
-            if [ "${statuses[$idx]}" -ne 0 ]; then
-              echo "::error::${regions[$idx]} no-traffic warmup failed."
-              failed=1
-            fi
-          done
-          if [ "$failed" -ne 0 ]; then
-            echo "::error::Secondary warmup failed; no secondary traffic moved. Successful warm revisions remain at zero traffic."
-            exit 1
-          fi
-
-          # Phase 2 is deliberately explicit and serial. A failure rolls back
-          # that region inside ramp_secondary and exits before a later warm
-          # revision can receive traffic.
-          if ! ramp_secondary "europe-west4" "${revision_files[0]}"; then
+          ramp_status=0
+          if ! ramp_secondary "europe-west4" "${NEW_EU}"; then
             echo "::error::europe-west4 ramp failed and was rolled back. Later regions remain warm at zero traffic and never received traffic."
-            exit 1
+            ramp_status=1
           fi
-          if ! ramp_secondary "us-east4" "${revision_files[1]}"; then
+          if [ "${ramp_status}" -eq 0 ] && \
+             ! ramp_secondary "us-east4" "${NEW_US_EAST4}"; then
             echo "::error::us-east4 ramp failed and was rolled back. Later regions remain warm at zero traffic and never received traffic."
-            exit 1
+            ramp_status=1
           fi
-          if ! ramp_secondary "southamerica-east1" "${revision_files[2]}"; then
-            echo "::error::southamerica-east1 ramp failed and was rolled back. Later regions remain warm at zero traffic and never received traffic."
-            exit 1
+          if [ "${ramp_status}" -eq 0 ] && \
+             ! ramp_secondary "southamerica-east1" "${NEW_SOUTHAMERICA_EAST1}"; then
+            echo "::error::southamerica-east1 ramp failed and was rolled back."
+            ramp_status=1
+          fi
+
+          reconciler_status=0
+          if wait "${reconciler_pid}"; then
+            reconciler_status=0
+          else
+            reconciler_status=$?
+          fi
+          printf '\n=== regional quota reconciler deploy ===\n'
+          cat "${reconciler_log}"
+
+          if [ "${ramp_status}" -ne 0 ]; then
+            exit "${ramp_status}"
+          fi
+          if [ "${reconciler_status}" -ne 0 ]; then
+            echo "::error::Regional quota reconciler deploy failed with status ${reconciler_status}."
+            exit "${reconciler_status}"
           fi
 
       - name: Deploy synthetic monitor Cloud Run Job
@@ -749,12 +847,6 @@ jobs:
         # deploy leaves conversions durably queued, but this workflow stays red
         # so ad spend is never scaled under silently broken attribution.
         run: bash scripts/deploy/google_data_manager.sh
-
-      - name: Deploy regional quota reconciler
-        # The worker cannot authorize traffic. It continues draining already
-        # issued bounded escrow even when serving issuance is disabled, and is
-        # mandatory once a workspace canary has ever been enabled.
-        run: bash scripts/deploy/regional_quota_reconciler.sh
 
       # No cross-region "final watchdog" step. Each region's health is
       # gated by its own per-region canary above (us-central1 first,
@@ -929,12 +1021,12 @@ jobs:
     # owner cutover it deploys the smokeable run.app companion; after cutover
     # it detects the public backend in the live map and preserves routed-mode
     # ingress/header trust on every later automatic deploy.
-    needs: [deploy]
+    needs: [rollout-secondaries]
     continue-on-error: false
     runs-on: ubuntu-latest
     # Four sequential regional Cloud Run deploys normally finish in 12-20
     # minutes. Thirty allows cold image pulls and bounded smoke retries.
-    # NOTE: this job runs AFTER the deploy job has released the production
+    # NOTE: this job runs AFTER rollout-secondaries has released the production
     # deployment mutex, and does not hold it. That is deliberate scope: the
     # mutex fences trusted-router revisions/traffic, which manual rollout
     # scripts also mutate; the T1 companion touches only its own service and
@@ -1031,27 +1123,24 @@ jobs:
   # below to be an exact invocation of a script the registry proves by
   # execution -- not a mention of one.
   #
-  # Out of band by construction: it runs after the deploy job, so it can make
-  # the run red and can never leave GCP half-deployed. Read-only -- one public
-  # GET, no credentials, no cloud SDK.
+  # Out of band by construction: it runs after rollout-secondaries has finished
+  # and released the mutex, so it gates full convergence without extending the
+  # mutation lock. Read-only -- one public GET, no credentials, no cloud SDK.
   #
   # `if: always()` is load-bearing and was missing. With a bare `needs:
-  # [deploy]`, GitHub SKIPS this job when deploy fails -- and a deploy that
-  # failed PARTWAY has already mutated production, which is exactly the state
-  # somebody needs to know the completeness of. The check would have been absent
-  # from every run where it mattered most.
+  # [rollout-secondaries]`, GitHub SKIPS this job when the follow-on fails --
+  # and a secondary rollout that failed PARTWAY has already mutated production.
   #
   # What it still does NOT cover, stated because a comment here once claimed it
   # ran "after every production mutation" and that is false: `migrate-schema`
-  # and `sync-runtime-secrets` mutate production BEFORE `deploy`, and this job
-  # is skipped when `deploy` is skipped -- which is exactly what happens when
-  # `confirm-current-main` says do not proceed. A run can therefore migrate the
-  # schema, rotate runtime secrets, skip the deploy, and never reach this check.
-  # The coverage is: every run in which the deploy job ran, whatever its result.
+  # and `sync-runtime-secrets` mutate production BEFORE `deploy`. It also does
+  # not run when primary-live fails, because rollout-secondaries never schedules.
+  # The coverage is: every run in which rollout-secondaries ran, whatever its
+  # result; that is the workflow's full-convergence gate.
   # ---------------------------------------------------------------------------
   verify-cloud-complete:
-    needs: [deploy]
-    if: ${{ always() && needs.deploy.result != 'skipped' }}
+    needs: [rollout-secondaries]
+    if: ${{ always() && needs.rollout-secondaries.result != 'skipped' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -320,6 +320,17 @@ gcloud storage rm \
 Normal recovery does not require manual removal: locks expire after 90 minutes,
 and the next acquirer can take over an expired generation safely.
 
+In deploy workflow status, **deployed** now means the primary is live: all four
+regional revisions are warm, and `us-central1` has completed its 10/50/100 ramp
+and unchanged three-minute canary (normally about nine minutes). The
+`rollout-secondaries` follow-on job imports the same generation fence, keeps the
+same lock held while the three secondary ramps and regional-quota reconciler
+converge, and releases it only after that work finishes or fails. Thus another
+cloud's rollout cannot interleave in the middle of GCP convergence.
+`verify-cloud-complete` still gates full-cloud convergence after the follow-on;
+the public-surface companion remains outside the mutex and starts only after
+the locked convergence job finishes.
+
 ---
 
 ## <a id="cloud-bake-ladder"></a>Canary-cloud bake ladder

--- a/docs/storage-portability/multi-cloud-separation.md
+++ b/docs/storage-portability/multi-cloud-separation.md
@@ -388,18 +388,21 @@ it to be an exact invocation of a script the registry proves by execution — an
 `echo` of the command is not one.
 
 What stayed in YAML, because a workflow cannot be executed from a test: that the
-job exists, that it depends on `deploy`, and that it runs `if: always()`. Those
-are read as text out of `.github/workflows/deploy.yml`.
+job exists, that it depends on `rollout-secondaries`, that the convergence job
+depends on primary-live `deploy`, and that the completeness gate runs `if:
+always()`. Those edges are read as text out of
+`.github/workflows/deploy.yml`.
 
-`if: always()` on `needs: [deploy]` is load-bearing and was missing: with a bare
-`needs:`, GitHub SKIPS a job when its dependency fails, and a deploy that failed
-PARTWAY has already mutated production. **Its coverage, stated exactly:** every
-run in which the `deploy` job ran, whatever the result. Not "after every
-production mutation" — `migrate-schema` and `sync-runtime-secrets` run *before*
-`deploy` and mutate production, and the job is skipped when `deploy` is skipped,
-which is what happens when `confirm-current-main` says do not proceed. A run can
-migrate the schema, rotate runtime secrets, skip the deploy and never reach this
-check.
+`if: always()` on `needs: [rollout-secondaries]` is load-bearing: with a bare
+`needs:`, GitHub SKIPS a job when secondary convergence fails, even though that
+job may already have shifted traffic in one or more regions. **Its coverage,
+stated exactly:** every run in which `rollout-secondaries` ran, whatever the
+result. It does not run when primary-live `deploy` fails, because the convergence
+job never schedules. It also does not mean "after every production mutation" —
+`migrate-schema` and `sync-runtime-secrets` run *before* `deploy` and mutate
+production, and the gate is skipped when `confirm-current-main` says not to
+proceed. A run can migrate the schema, rotate runtime secrets, skip the deploy
+and never reach this check.
 
 Honest caveat, because this is a control that has never fired: it lands with
 this change and has not yet run on a merge.

--- a/tests/test_cloud_rollout_completeness.py
+++ b/tests/test_cloud_rollout_completeness.py
@@ -812,15 +812,21 @@ def test_an_unbound_script_must_carry_a_named_reason_and_a_real_control() -> Non
             "`exit 0` and a call sealed in `if false` all used to pass here, which is "
             "the defect this shape closes."
         )
-        # The prose in multi-cloud-separation.md and the runbook says this check
-        # reads the job's `needs` and its `if:`. It did not, until now.
-        assert "deploy" in str(job.get("needs", "")), (
-            f"{cloud}: {control.workflow} job {control.job!r} does not depend on `deploy`, "
-            "so it can run before the thing it is supposed to check"
+        # The completeness gate follows full convergence, whose dependency on
+        # primary-live is also pinned. Checking only either edge would allow
+        # the gate to run before one half of the rollout it is meant to assess.
+        assert "rollout-secondaries" in str(job.get("needs", "")), (
+            f"{cloud}: {control.workflow} job {control.job!r} does not depend on "
+            "`rollout-secondaries`, so it can run before full convergence"
+        )
+        convergence_job = workflow["jobs"].get("rollout-secondaries", {})
+        assert "deploy" in str(convergence_job.get("needs", "")), (
+            f"{cloud}: {control.workflow} job 'rollout-secondaries' does not depend "
+            "on `deploy`, so it can run before primary-live"
         )
         assert "always()" in str(job.get("if", "")), (
             f"{cloud}: {control.workflow} job {control.job!r} has no `if: always()`, so it "
-            "is skipped exactly when the deploy it follows failed"
+            "is skipped exactly when secondary convergence failed"
         )
 
     gcp = crc.ROLLOUT_REGISTRY["gcp"]

--- a/tests/test_deploy_mutex.py
+++ b/tests/test_deploy_mutex.py
@@ -467,16 +467,44 @@ def test_workflow_and_manual_scripts_share_the_mutex_scope() -> None:
         encoding="utf-8"
     )
     acquire = workflow.index("- name: Acquire production deployment mutex")
-    rollout = workflow.index("- name: Deploy us-central1 (no-traffic)")
-    release = workflow.index("- name: Release production deployment mutex")
+    rollout = workflow.index("- name: Warm all four regions in parallel (no traffic)")
+    primary_release = workflow.index(
+        "- name: Release production deployment mutex after primary-live failure"
+    )
+    secondary_job = workflow.index("\n  rollout-secondaries:")
+    secondary_release = workflow.index(
+        "- name: Release production deployment mutex", secondary_job
+    )
 
-    assert acquire < rollout < release
-    assert 'deploy_mutex.sh acquire >> "$GITHUB_ENV"' in workflow[acquire:rollout]
+    assert acquire < rollout < primary_release < secondary_job < secondary_release
+    assert "id: acquire_mutex" in workflow[acquire:rollout]
+    acquire_step = workflow[acquire:rollout]
+    # The fence must reach BOTH files, and acquire must never sit on the left
+    # of a pipe: GitHub's default run shell lacks pipefail, so a blocked
+    # acquire would exit 0 through tee and the deploy would proceed WITHOUT
+    # holding the lock. The command-substitution form propagates the exit.
+    assert 'fence="$(bash scripts/deploy/deploy_mutex.sh acquire)"' in acquire_step
+    assert 'printf \'%s\\n\' "$fence" >> "$GITHUB_ENV"' in acquire_step
+    assert 'printf \'%s\\n\' "$fence" >> "$GITHUB_OUTPUT"' in acquire_step
     assert "${{ github.server_url }}/${{ github.repository }}/actions/runs/" in workflow[
         acquire:rollout
     ]
-    assert "if: always()" in workflow[release : release + 180]
-    assert "deploy_mutex.sh release" in workflow[release : release + 180]
+    assert "if: ${{ failure() || cancelled() }}" in workflow[
+        primary_release : primary_release + 240
+    ]
+    assert "deploy_mutex.sh release" in workflow[
+        primary_release : primary_release + 240
+    ]
+    assert "needs.deploy.outputs.TR_DEPLOY_MUTEX_OPERATION" in workflow[
+        secondary_job:secondary_release
+    ]
+    assert "needs.deploy.outputs.TR_DEPLOY_MUTEX_GENERATION" in workflow[
+        secondary_job:secondary_release
+    ]
+    assert "if: always()" in workflow[secondary_release : secondary_release + 180]
+    assert "deploy_mutex.sh release" in workflow[
+        secondary_release : secondary_release + 180
+    ]
 
     # These large scripts need unrelated Cloud Run/watchdog fixtures to finish;
     # the generation-aware behavioral tests above execute their shared helper,
@@ -608,20 +636,31 @@ deploy_mutex_acquire >/dev/null
     assert "deploy_mutex.reentrant" not in result.stderr
 
 
-def test_deploy_job_timeout_stays_under_the_mutex_ttl() -> None:
-    """Review finding M3: a deploy job outliving the lease invites a legal
-    expired-lock takeover while the run is still shifting traffic."""
+def test_lock_owning_job_timeouts_stay_under_the_mutex_ttl() -> None:
+    """Both lock-owning jobs plus their handoff fit inside the lease."""
     import re
 
     workflow = (ROOT / ".github" / "workflows" / "deploy.yml").read_text(
         encoding="utf-8"
     )
-    deploy_job = workflow.split("\n  deploy:\n", 1)[1].split("\n  public-surface", 1)[0]
-    match = re.search(r"timeout-minutes:\s*(\d+)", deploy_job)
-    assert match is not None, "deploy job must bound its runtime"
+    deploy_job = workflow.split("\n  deploy:\n", 1)[1].split(
+        "\n  rollout-secondaries:\n", 1
+    )[0]
+    rollout_job = workflow.split("\n  rollout-secondaries:\n", 1)[1].split(
+        "\n  public-surface-companion:\n", 1
+    )[0]
+    deploy_match = re.search(r"timeout-minutes:\s*(\d+)", deploy_job)
+    rollout_match = re.search(r"timeout-minutes:\s*(\d+)", rollout_job)
+    assert deploy_match is not None, "deploy job must bound its runtime"
+    assert rollout_match is not None, "rollout-secondaries must bound its runtime"
     ttl_match = re.search(
         r"TR_DEPLOY_MUTEX_TTL_SECONDS:-(\d+)",
         (ROOT / "scripts" / "deploy" / "deploy_mutex.sh").read_text(encoding="utf-8"),
     )
     assert ttl_match is not None
-    assert int(match.group(1)) * 60 < int(ttl_match.group(1))
+    deploy_minutes = int(deploy_match.group(1))
+    rollout_minutes = int(rollout_match.group(1))
+    ttl_seconds = int(ttl_match.group(1))
+    assert deploy_minutes == 25
+    assert rollout_minutes == 55
+    assert (deploy_minutes + rollout_minutes) * 60 < ttl_seconds

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -224,9 +224,15 @@ def test_production_deploy_provisions_and_schedules_regional_quota_reconciliatio
     assert workflow.index("bash scripts/deploy/regional_quota_ledger.sh") < workflow.index(
         "bash scripts/deploy/rollout.sh"
     )
-    assert workflow.index("bash scripts/deploy/regional_quota_reconciler.sh") > workflow.index(
-        "- name: Warm secondaries in parallel, ramp serially"
-    )
+    rollout = workflow.split("\n  rollout-secondaries:\n", 1)[1].split(
+        "\n  public-surface-companion:\n", 1
+    )[0]
+    reconciler_start = rollout.index("bash scripts/deploy/regional_quota_reconciler.sh")
+    first_ramp = rollout.index('ramp_secondary "europe-west4"')
+    last_ramp = rollout.index('ramp_secondary "southamerica-east1"')
+    reconciler_wait = rollout.index('wait "${reconciler_pid}"')
+    assert reconciler_start < first_ramp < last_ramp < reconciler_wait
+    assert 'regional_quota_reconciler.sh >"${reconciler_log}" 2>&1 &' in rollout
     assert "--transactional-writes" in provisioner
     assert "trusted-router-logs-c1" in library
     assert "us-central1=tr-quota-us-central1" in library

--- a/tests/test_deploy_workflow_regions.py
+++ b/tests/test_deploy_workflow_regions.py
@@ -5,14 +5,19 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def test_every_load_balanced_control_plane_region_is_staged() -> None:
     workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
-    start = workflow.index("- name: Warm secondaries in parallel, ramp serially")
-    end = workflow.index("- name: Deploy synthetic monitor Cloud Run Job", start)
-    rollout = workflow[start:end]
+    deploy = workflow.split("\n  deploy:\n", 1)[1].split(
+        "\n  rollout-secondaries:\n", 1
+    )[0]
+    rollout = workflow.split("\n  rollout-secondaries:\n", 1)[1].split(
+        "\n  public-surface-companion:\n", 1
+    )[0]
 
     assert "deploy_cold_regions:" not in workflow
     assert "steps.optional.outputs.deploy_cold_regions" not in workflow
-    assert "regions=(europe-west4 us-east4 southamerica-east1)" in rollout
-    assert 'TR_DEPLOY_TARGET_REGIONS="${region}"' in rollout
+    assert "regions=(us-central1 europe-west4 us-east4 southamerica-east1)" in deploy
+    assert 'TR_DEPLOY_TARGET_REGIONS="${region}"' in deploy
+    for region in ("europe-west4", "us-east4", "southamerica-east1"):
+        assert f'ramp_secondary "{region}"' in rollout
 
 
 def test_prod_smoke_checks_each_control_plane_region_directly() -> None:
@@ -59,81 +64,124 @@ def test_public_snapshot_worker_swap_is_verified_and_rollbackable() -> None:
     assert r'mv \"\$previous_builder\" \"\$builder\"' in script
 
 
-def test_warm_secondary_regions_warm_in_parallel_then_ramp_serially() -> None:
+def test_all_regions_warm_in_parallel_before_primary_traffic_moves() -> None:
     workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
-    primary_canary = workflow.index("- name: Canary gate — watch us-central1 only")
-    start = workflow.index("- name: Warm secondaries in parallel, ramp serially")
-    end = workflow.index("- name: Deploy synthetic monitor Cloud Run Job", start)
-    rollout = workflow[start:end]
+    deploy = workflow.split("\n  deploy:\n", 1)[1].split(
+        "\n  rollout-secondaries:\n", 1
+    )[0]
+    start = deploy.index("- name: Warm all four regions in parallel (no traffic)")
+    end = deploy.index("- name: Stage traffic 10/50/100 (us-central1)", start)
+    warm = deploy[start:end]
 
-    assert primary_canary < start
-    assert "regions=(europe-west4 us-east4 southamerica-east1)" in rollout
-    assert "PREV_SOUTHAMERICA_EAST1" in rollout
-    assert "southamerica-east1)" in rollout
-    assert 'if ! TR_DEPLOY_TARGET_REGIONS="${region}"' in rollout
-    assert 'if ! bash scripts/deploy/staged_traffic.sh \\' in rollout
-    assert 'if ! active_traffic="$(gcloud run services describe' in rollout
-    assert '[ "${active_traffic}" != "1" ]' in rollout
-    first_wait = rollout.index('if wait "${pids[$idx]}"; then')
-    for region, log_index in (
-        ("europe-west4", 0),
-        ("us-east4", 1),
-        ("southamerica-east1", 2),
+    assert "regions=(us-central1 europe-west4 us-east4 southamerica-east1)" in warm
+    assert 'if ! TR_DEPLOY_TARGET_REGIONS="${region}"' in warm
+    first_wait = warm.index('if wait "${pids[$idx]}"; then')
+    for region, reconcile_lb, log_index in (
+        ("us-central1", "1", 0),
+        ("europe-west4", "0", 1),
+        ("us-east4", "0", 2),
+        ("southamerica-east1", "0", 3),
     ):
         invocation = (
-            f'(warm_secondary "{region}" "${{revision_files[{log_index}]}}") '
+            f'(warm_region "{region}" "{reconcile_lb}" '
+            f'"${{revision_files[{log_index}]}}") '
             f'>"${{logs[{log_index}]}}" 2>&1 &'
         )
-        assert rollout.index(invocation) < first_wait
-    assert rollout.count('pids+=("$!")') == 3
-    assert 'printf \'\\n=== %s ===\\n\' "${regions[$idx]}"' in rollout
-    assert 'cat "${logs[$idx]}"' in rollout
-    assert 'if [ "$failed" -ne 0 ]; then' in rollout
-    assert 'rollback_region "${region}"' in rollout
-    assert 'TR_DEPLOY_RECONCILE_LB: "0"' in rollout
-    assert "TR_DEPLOY_MUTEX_OPERATION is inherited by every warmup" in rollout
-    assert "#695 (billing 5xx, 2026-08-20)" in rollout
-    assert (
-        "overlapping revision warmups and traffic ramps can amplify billing\n"
-        "          # transaction contention"
-    ) in rollout
-    assert "assert_no_billing_5xx.sh" in rollout
-    assert "--slo-class router_core" in rollout
+        assert warm.index(invocation) < first_wait
+    assert warm.count('pids+=("$!")') == 4
+    assert 'printf \'\\n=== warmup: %s ===\\n\' "${regions[$idx]}"' in warm
+    assert 'cat "${logs[$idx]}"' in warm
+    assert "Regional warmup failed; no traffic moved" in warm
+    assert "TR_DEPLOY_RECONCILE_LB" in warm
+    assert "Only the primary process receives 1" in warm
 
-    warmup_failure = rollout.index(
-        "Secondary warmup failed; no secondary traffic moved"
+    primary_ramp = deploy.index("- name: Stage traffic 10/50/100 (us-central1)")
+    primary_canary = deploy.index("- name: Canary gate — watch us-central1 only")
+    assert first_wait < primary_ramp < primary_canary
+    assert 'staged_traffic.sh europe-west4' not in deploy
+    assert 'staged_traffic.sh us-east4' not in deploy
+    assert 'staged_traffic.sh southamerica-east1' not in deploy
+    assert "ramp_secondary" not in deploy
+    assert "timeout-minutes: 25" in deploy
+    release = deploy.index(
+        "- name: Release production deployment mutex after primary-live failure"
     )
-    ramp_eu = rollout.index('ramp_secondary "europe-west4"')
-    ramp_us = rollout.index('ramp_secondary "us-east4"')
-    ramp_sa = rollout.index('ramp_secondary "southamerica-east1"')
-    assert first_wait < warmup_failure < ramp_eu < ramp_us < ramp_sa
-    assert "Later regions remain warm at zero traffic and never received traffic" in rollout
+    assert "if: ${{ failure() || cancelled() }}" in deploy[release : release + 220]
+    assert "GitHub never schedules rollout-secondaries" in deploy
+    assert "the 90-minute TTL recovers" in deploy
+    assert "Queued deploys fail closed" in deploy
 
-    staged_call = rollout.index("bash scripts/deploy/staged_traffic.sh")
-    staged_line = rollout[staged_call : rollout.index("\n", staged_call)]
+
+def test_secondaries_ramp_serially_while_reconciler_deploys() -> None:
+    workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
+    rollout = workflow.split("\n  rollout-secondaries:\n", 1)[1].split(
+        "\n  public-surface-companion:\n", 1
+    )[0]
+
+    assert "needs: [deploy]" in rollout
+    assert "if: ${{ success() }}" in rollout
+    assert "timeout-minutes: 55" in rollout
+    first_step = rollout.index("- name: Import production deployment mutex fence")
+    checkout = rollout.index("- uses: actions/checkout@v4")
+    assert first_step < checkout
+    assert "needs.deploy.outputs.TR_DEPLOY_MUTEX_OPERATION" in rollout
+    assert "needs.deploy.outputs.TR_DEPLOY_MUTEX_GENERATION" in rollout
+    assert 'echo "TR_DEPLOY_MUTEX_OPERATION=${DEPLOY_MUTEX_OPERATION}"' in rollout
+    assert 'echo "TR_DEPLOY_MUTEX_GENERATION=${DEPLOY_MUTEX_GENERATION}"' in rollout
+
+    ramp_step = rollout.index(
+        "- name: Ramp secondaries serially while reconciler deploys"
+    )
+    ramp = rollout[ramp_step : rollout.index("- name: Deploy synthetic monitor", ramp_step)]
+    staged_call = ramp.index("bash scripts/deploy/staged_traffic.sh")
+    staged_line = ramp[staged_call : ramp.index("\n", staged_call)]
     assert "&" not in staged_line
-    ramp_start = rollout.index("ramp_secondary()")
-    staged_call = rollout.index("bash scripts/deploy/staged_traffic.sh", ramp_start)
-    stamp = rollout.index(
-        'rollout_started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"',
-        ramp_start,
-    )
-    billing_gate = rollout.index("assert_no_billing_5xx.sh", ramp_start)
-    assert ramp_start < stamp < staged_call < billing_gate
-    assert "secondary-started-" not in rollout
+    stamp = ramp.index('rollout_started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"')
+    billing_gate = ramp.index("assert_no_billing_5xx.sh")
+    assert stamp < staged_call < billing_gate
+
+    reconciler = ramp.index("regional_quota_reconciler.sh")
+    ramp_eu = ramp.index('ramp_secondary "europe-west4"')
+    ramp_us = ramp.index('ramp_secondary "us-east4"')
+    ramp_sa = ramp.index('ramp_secondary "southamerica-east1"')
+    wait = ramp.index('wait "${reconciler_pid}"')
+    assert reconciler < ramp_eu < ramp_us < ramp_sa < wait
+    assert 'regional_quota_reconciler.sh >"${reconciler_log}" 2>&1 &' in ramp
+    assert 'printf \'\\n=== regional quota reconciler deploy ===\\n\'' in ramp
+    assert '[ "${ramp_status}" -eq 0 ]' in ramp
+    assert "Later regions remain warm at zero traffic and never received traffic" in ramp
+    assert "#695 (billing 5xx, 2026-08-20)" in ramp
+    assert "--slo-class router_core" in ramp
+    assert "secondary-started-" not in ramp
+
+    release = rollout.index("- name: Release production deployment mutex")
+    assert "if: always()" in rollout[release : release + 180]
+    assert "deploy_mutex.sh release" in rollout[release : release + 180]
+
+
+def test_full_convergence_jobs_need_rollout_secondaries() -> None:
+    workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
+    companion = workflow.split("\n  public-surface-companion:\n", 1)[1].split(
+        "\n  verify-cloud-complete:\n", 1
+    )[0]
+    verify = workflow.split("\n  verify-cloud-complete:\n", 1)[1]
+
+    assert "needs: [rollout-secondaries]" in companion
+    assert "needs: [rollout-secondaries]" in verify
+    assert "needs.rollout-secondaries.result != 'skipped'" in verify
 
 
 def test_primary_rollout_gates_on_router_core_and_billing_path_errors() -> None:
     workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
-    primary = workflow.index("- name: Deploy us-central1 (no-traffic)")
-    secondary = workflow.index("- name: Warm secondaries in parallel, ramp serially")
+    primary = workflow.index("- name: Warm all four regions in parallel (no traffic)")
+    secondary = workflow.index("\n  rollout-secondaries:", primary)
     rollout = workflow[primary:secondary]
 
     assert "TR_WATCHDOG_SLO_CLASS: router_core" in rollout
     assert "--slo-class router_core" in rollout
     assert "- name: Billing-path gate + rollback (us-central1)" in rollout
     assert "scripts/deploy/assert_no_billing_5xx.sh" in rollout
-    assert '"${{ steps.new_us.outputs.revision }}"' in rollout
+    assert '"${{ steps.warm_all.outputs.us_central1_revision }}"' in rollout
     assert '--to-revisions="${PREV_US}=100"' in rollout
 
 
@@ -163,7 +211,7 @@ def test_superseded_push_stops_before_production_mutation() -> None:
 def test_rollback_capture_uses_the_sole_serving_revision() -> None:
     workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
     start = workflow.index("- name: Capture pre-deploy revisions")
-    end = workflow.index("- name: Detect optional deploy surfaces", start)
+    end = workflow.index("- name: Warm all four regions in parallel", start)
     capture = workflow[start:end]
 
     assert "set -euo pipefail" in capture
@@ -192,5 +240,27 @@ def test_runtime_secret_validation_is_parallel_and_does_not_restore_stale_ses_ke
 def test_shared_load_balancer_is_reconciled_once_per_workflow() -> None:
     workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
 
-    assert workflow.count('TR_DEPLOY_RECONCILE_LB: "1"') == 1
-    assert workflow.count('TR_DEPLOY_RECONCILE_LB: "0"') == 1
+    assert workflow.count('(warm_region "us-central1" "1"') == 1
+    for region in ("europe-west4", "us-east4", "southamerica-east1"):
+        assert workflow.count(f'(warm_region "{region}" "0"') == 1
+    assert 'TR_DEPLOY_RECONCILE_LB="${reconcile_lb}"' in workflow
+
+
+def test_mutex_acquire_step_cannot_swallow_a_blocked_exit() -> None:
+    """A blocked acquire must fail the step.
+
+    GitHub's default run shell is `bash -e` WITHOUT pipefail, so piping
+    acquire into tee makes the step's exit code tee's — a refused lock
+    would deploy WITHOUT holding it. The acquire invocation must therefore
+    never sit on the left of an unguarded pipe.
+    """
+    workflow = (ROOT / ".github" / "workflows" / "deploy.yml").read_text(
+        encoding="utf-8"
+    )
+    for line in workflow.splitlines():
+        if "deploy_mutex.sh acquire" in line and "|" in line.split("acquire", 1)[1]:
+            raise AssertionError(
+                "deploy_mutex.sh acquire is piped; a blocked acquire would "
+                "exit 0 through the pipe under bash -e without pipefail: "
+                + line.strip()
+            )


### PR DESCRIPTION
Joseph's levers 1+2: free overlaps and a job split. No watchdog window,
ramp step, or canary second changes.

## Shape

**`deploy` (primary-live, ~9.5-11m):** acquire mutex → warm ALL FOUR
regions' no-traffic revisions in parallel (the primary's deploy was
always just a warmup; LB reconciliation stays primary-only) → ramp
us-central1 10/50/100 unchanged → 3-min canary unchanged → success.
This is the moment new code serves.

**`rollout-secondaries` (needs: deploy):** imports the mutex fence from
job outputs, ramps the three already-warm secondaries serially exactly
per #695, runs the reconciler deploy in the background alongside,
smokes, releases the lock in `always()`.

**Release-ownership matrix** (commented in the workflow, pinned by
tests): primary fails → primary's conditional release; primary succeeds
→ secondaries' `always()` release; secondaries never scheduled → the
90-min TTL recovers (freeze, never overlap). Timeouts 25+55 < TTL, the
arithmetic stated inline. The lock spans both jobs, so another cloud's
canary still fail-closes mid-convergence.

## The review catch

Codex's draft piped the acquire: `acquire | tee -a $GITHUB_ENV
$GITHUB_OUTPUT`. GitHub's default run shell is `bash -e` **without
pipefail** — a BLOCKED acquire would exit 0 through tee and the deploy
would proceed without holding the lock. Its own structural test had
pinned the broken construct verbatim. Fixed to command substitution
(exit code propagates; the fence reaches both files only on success),
with two tests standing guard: the pin asserts the safe form, and a
second fails on ANY pipe after `deploy_mutex.sh acquire`.

## Measured context

First live ladder run (32794630988): primary lane 12m19 (deploy 1m35 +
ramp 7m13 + canary 3m31), secondaries 27m58. The ramp overrun is
overhead around the windows (~31s watchdog startup per step, one 3m07
Cloud Run traffic-update stall), not the windows themselves — follow-up
material, not this PR.

## Verification

ruff · mypy · full suite **6414 passed** (one apparent failure was a
stale shared-venv artifact in my test harness, not the diff — 21/21
green with an honest venv) · focused workflow/mutex/bake suites 100
passed · YAML parses · runbook + multi-cloud-separation docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)