### PR TITLE
deploy_mutex: run on the python a laptop actually has

### DIFF
--- a/scripts/deploy/deploy_mutex.sh
+++ b/scripts/deploy/deploy_mutex.sh
@@ -67,7 +67,7 @@ PY
 _deploy_mutex_expired() {
   local expires_at="$1"
   python3 - "$expires_at" <<'PY'
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 import sys
 
 try:
@@ -77,7 +77,7 @@ try:
         raise ValueError("timezone required")
 except ValueError:
     raise SystemExit(2)
-raise SystemExit(0 if parsed <= datetime.now(UTC) else 1)
+raise SystemExit(0 if parsed <= datetime.now(timezone.utc) else 1)
 PY
 }
 
@@ -91,7 +91,7 @@ _deploy_mutex_write_record() {
   local cloud="$7"
   python3 - \
     "$path" "$owner" "$operation_id" "$ttl_seconds" "$tool" "$pid" "$cloud" <<'PY'
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import json
 import sys
 
@@ -107,7 +107,7 @@ try:
     pid = int(pid_raw)
 except ValueError:
     raise SystemExit("ttl and pid must be integers") from None
-created = datetime.now(UTC).replace(microsecond=0)
+created = datetime.now(timezone.utc).replace(microsecond=0)
 record = {
     "cloud": cloud,
     "owner": owner,


### PR DESCRIPTION
The hand-run cloud deploy scripts exist so a human can ship when Actions can't.
Running the Azure one by hand, that path died immediately:

```
ImportError: cannot import name 'UTC' from 'datetime'
deploy_mutex.invalid_metadata
```

`datetime.UTC` arrived in Python **3.11**. `python3` on this Mac is **3.10**
(Anaconda), and `deploy_mutex.sh` embeds python snippets importing it. CI never
saw this because its runners ship a newer interpreter — the break is specific
to the environment the script exists for.

`timezone.utc` is behaviourally identical and available since 3.2, so this
removes the version floor at no cost.

Found by running the deploy rather than reading it. That's the only way this
class of defect surfaces: the script is correct, and the environment it was
written for is the one it was never run in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)