### PR TITLE
Stop printing unauditable rows as violations

### DIFF
--- a/scripts/audit_typed_counters.py
+++ b/scripts/audit_typed_counters.py
@@ -53,6 +53,12 @@ def _print_report(name: str, sample_label: str, report: AuditReport) -> None:
     print(f"{name}: {report.summary()}")
     for scope, detail in report.samples.items():
         print(f"  {sample_label} {scope}: {detail}")
+    # Rows that could not be checked at all are NOT violations and must not be
+    # printed as though they were. They are the difference between "nothing is
+    # wrong" and "nothing was looked at", which is the whole reason the report
+    # separates `clean` from `fully_audited`.
+    for scope, detail in getattr(report, "unauditable", {}).items():
+        print(f"  UNAUDITABLE {scope}: {detail}")
 
 
 def run_audit(

--- a/src/trusted_router/storage_gcp_counter_reconcile.py
+++ b/src/trusted_router/storage_gcp_counter_reconcile.py
@@ -125,6 +125,12 @@ class InvariantReport:
     #: JSON cleanup has already run against.
     usage_unauditable: int = 0
     samples: dict[str, dict] = field(default_factory=dict)
+    #: Kept OUT of `samples` because callers label everything in there as a
+    #: violation -- scripts/audit_typed_counters.py passes a single
+    #: `sample_label` for the whole dict. Sharing it printed 643 lines reading
+    #: "VIOLATION usage-unauditable:..." underneath a summary that said CLEAN,
+    #: which is a worse read than either fact alone.
+    unauditable: dict[str, dict] = field(default_factory=dict)
 
     @property
     def clean(self) -> bool:
@@ -295,6 +301,10 @@ def audit_typed_invariants(store: Any, *, max_samples: int = 20) -> InvariantRep
         if len(report.samples) < max_samples:
             report.samples[key] = value
 
+    def _unauditable(key: str, value: dict) -> None:
+        if len(report.unauditable) < max_samples:
+            report.unauditable[key] = value
+
     def _check(typed: dict, holds: dict, kind: str) -> tuple[int, int]:
         violations = 0
         # forward: every typed row's reserved must equal its open holds, and >= 0.
@@ -325,7 +335,7 @@ def audit_typed_invariants(store: Any, *, max_samples: int = 20) -> InvariantRep
         booked = settled_actuals.get(workspace_id, 0) + federated_applied.get(workspace_id, 0)
         if baseline is None:
             report.usage_unauditable += 1
-            _sample(
+            _unauditable(
                 f"usage-unauditable:{workspace_id}",
                 {
                     "typed_total_usage": actual_usage,

--- a/tests/test_billing_usage_drift.py
+++ b/tests/test_billing_usage_drift.py
@@ -180,7 +180,13 @@ def test_a_missing_baseline_is_unauditable_not_a_violation() -> None:
     assert report.clean
     assert not report.fully_audited
     assert "(PARTIAL)" in report.summary()
-    assert report.samples[f"usage-unauditable:{ws}"]["baseline"] is None
+
+    # Reported OUT of `samples`. Callers label that dict wholesale --
+    # scripts/audit_typed_counters.py passes one `sample_label` for all of it --
+    # so an unauditable row left in there prints as "VIOLATION" underneath a
+    # summary that says CLEAN. Production's first run printed 643 such lines.
+    assert report.unauditable[f"usage-unauditable:{ws}"]["baseline"] is None
+    assert not report.samples, "unauditable rows must not sit in the violation samples"
 
 
 def test_booked_usage_with_no_typed_row_is_a_violation() -> None:


### PR DESCRIPTION
Caught by the first production run of the usage audit I merged in #807. It reported:

```
audit_typed_invariants: credit: 0/1753 | key: 0/2284 | regional lease: 0/12 | usage: 0/643 (643 unauditable) | CLEAN (PARTIAL)
  VIOLATION usage-unauditable:004a03a0-...
  VIOLATION usage-unauditable:0074ccc4-...
  ... 641 more
```

Both halves are mine, and only one of them is right. The summary is correct — zero violations, 643 rows that could not be checked, honestly marked `CLEAN (PARTIAL)`. The 643 lines below it are not: they say VIOLATION about rows that are explicitly *not* violations, directly under a summary saying CLEAN.

The cause is structural. `scripts/audit_typed_counters.py` labels `report.samples` wholesale — one `sample_label` for the whole dict — so anything placed in there **is** a violation by construction. I put a second, different category into it. Unauditable rows are the opposite of a violation: not "this is wrong" but "this could not be checked", which is the exact distinction `clean` and `fully_audited` exist to keep apart.

They now live in their own `unauditable` mapping with its own sample cap, and the script prints them under `UNAUDITABLE`. Mutation-verified: routing them back into `samples` turns the test red.

**Separately, and worth a decision:** 643 of 643 workspaces are unauditable, so the usage audit currently covers nothing and `repair_typed_usage` would refuse every workspace for lack of a baseline. That is honest — it is reporting exactly what it can prove, which is the design — but it means the feature provides no coverage as shipped. The baseline it needs is the residual `total_usage_microdollars` key in the credit JSON, and `storage_gcp_credit_json_cleanup` deletes that without archiving the value.

If the cleanup has already run fleet-wide, those baselines are gone permanently and no absolute usage invariant is recoverable. The alternative that does not need history is a **delta** check: record `total_usage` and the ledger sums as a checkpoint now, then assert that growth in the counter equals growth in the ledger between checkpoints. That catches the same class of drift going forward and needs nothing from before the flip. I have not built it — it is a design change rather than a fix, and worth deciding on deliberately.