### PR TITLE
Handle Fireworks August model retirements

### DIFF
--- a/scripts/pricing/parsers/fireworks.py
+++ b/scripts/pricing/parsers/fireworks.py
@@ -6,26 +6,75 @@ import re
 from decimal import Decimal
 
 MODEL_LABELS = {
+    # Match Fast labels before their standard prefixes. These are distinct
+    # Fireworks routers with different prices and lifecycle dates.
+    "Kimi K3 Fast": "moonshotai/kimi-k3-fast",
+    "Kimi K2.7 Code Fast": "moonshotai/kimi-k2.7-code-fast",
+    "Kimi K2.6 Fast": "moonshotai/kimi-k2.6-fast",
+    "GLM 5.2 Fast": "z-ai/glm-5.2-fast",
     "Kimi K3": "moonshotai/kimi-k3",
     "Kimi K2.7 Code": "moonshotai/kimi-k2.7-code",
     "Kimi K2.6": "moonshotai/kimi-k2.6",
     "Kimi K2.5": "moonshotai/kimi-k2.5",
     "DeepSeek V4 Pro": "deepseek/deepseek-v4-pro",
+    "DeepSeek V4 Pro 0813": "deepseek/deepseek-v4-pro-0813",
     "DeepSeek V4 Flash (0731)": "deepseek/deepseek-v4-flash-0731",
     "DeepSeek V4 Flash": "deepseek/deepseek-v4-flash",
     "GLM 5.2": "z-ai/glm-5.2",
     "GLM 5.1": "z-ai/glm-5.1",
+    "Qwen 3.7 Plus": "qwen/qwen3.7-plus",
+    "Qwen 3.8 Max": "qwen/qwen3.8-max",
     "OpenAI GPT OSS 120B": "openai/gpt-oss-120b",
     "OpenAI GPT OSS 20B": "openai/gpt-oss-20b",
+    "Muse Glimmer 30B": "meta-models/muse-glimmer-30b",
+    "NVIDIA Nemotron 3.5 Lightning 30B A3B": "nvidia/nemotron-3.5-lightning",
+    "NVIDIA Nemotron 3 Ultra (Preview)": "nvidia/nemotron-3-ultra-550b-a55b",
     "MiniMax M3": "minimax/minimax-m3",
     "MiniMax M2.7": "minimax/minimax-m2.7",
     "MiniMax 2.7": "minimax/minimax-m2.7",
     "MiniMax 2.5": "minimax/minimax-m2.5",
 }
 
+_FAMILY_AUTHORS = (
+    ("deepseek-", "deepseek"),
+    ("glm-", "z-ai"),
+    ("gpt-oss-", "openai"),
+    ("kimi-", "moonshotai"),
+    ("minimax-", "minimax"),
+    ("qwen", "qwen"),
+)
+_LINKED_PRICE_ROW = re.compile(
+    r"\[(?P<label>[^]]+)\]\((?P<href>[^)]+)\)\s*\|\s*"
+    r"\$(?P<prompt>[0-9]+(?:\.[0-9]+)?)\s*/\s*"
+    r"\$(?P<cached>[0-9]+(?:\.[0-9]+)?)\s*/\s*"
+    r"\$(?P<completion>[0-9]+(?:\.[0-9]+)?)",
+    flags=re.I,
+)
+
 
 def _money_to_micro(raw: str) -> int:
     return int((Decimal(raw) * Decimal(1_000_000)).to_integral_value())
+
+
+def _canonical_linked_model(label: str, href: str) -> str | None:
+    slug = href.rstrip("/").rsplit("/", 1)[-1].casefold().replace("_", "-")
+    slug = re.sub(r"-(\d+)p(\d+)(?=$|-)", r"-\1.\2", slug)
+    slug = re.sub(r"([km])(\d+)p(\d+)(?=$|-)", r"\1\2.\3", slug)
+    slug = re.sub(r"qwen(\d+)p(\d+)(?=$|-)", r"qwen\1.\2", slug)
+    label_words = set(re.findall(r"[a-z0-9]+", label.casefold()))
+    slug_words = set(slug.split("-"))
+    # Fireworks sometimes gives a Fast or US row the standard model's link.
+    # Auto-aliasing that row would overwrite the standard price, so require
+    # those modifiers to be present in the provider-native slug as well.
+    if any(
+        modifier in label_words and modifier not in slug_words
+        for modifier in ("fast", "us")
+    ):
+        return None
+    for prefix, author in _FAMILY_AUTHORS:
+        if slug.startswith(prefix):
+            return f"{author}/{slug}"
+    return None
 
 
 def parse(html: str) -> dict:
@@ -49,5 +98,17 @@ def parse(html: str) -> dict:
             "prompt_micro_per_m": _money_to_micro(prompt),
             "prompt_cached_micro_per_m": _money_to_micro(cached),
             "completion_micro_per_m": _money_to_micro(completion),
+        }
+    for match in _LINKED_PRICE_ROW.finditer(text):
+        label = match.group("label")
+        if label in MODEL_LABELS:
+            continue
+        model_id = _canonical_linked_model(label, match.group("href"))
+        if model_id is None or model_id in out:
+            continue
+        out[model_id] = {
+            "prompt_micro_per_m": _money_to_micro(match.group("prompt")),
+            "prompt_cached_micro_per_m": _money_to_micro(match.group("cached")),
+            "completion_micro_per_m": _money_to_micro(match.group("completion")),
         }
     return out

--- a/scripts/pricing/providers/fireworks.py
+++ b/scripts/pricing/providers/fireworks.py
@@ -1,16 +1,15 @@
-"""Fireworks AI — human-only provider config.
+"""Fireworks AI catalog and first-party pricing integration.
 
 Fireworks publishes a first-party serverless pricing table for its headline
 models. We fetch that docs page and parse the standard serving-path prices.
 Prices become routable only when the authenticated operator model list also
-contains the model. The supplemental manifest is pruned from that intersection.
+contains the model. The supplemental manifest is rebuilt from that intersection
+so newly published, priced chat models are added automatically.
 """
 
 from __future__ import annotations
 
-import json
 import os
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -20,11 +19,14 @@ from scripts.pricing.base import (
     fetch_provider,
     validate,
 )
+from scripts.pricing.manifest import write_discovered_chat_manifest
 from scripts.pricing.model_ids import (
     canonicalize_unqualified_model_id,
     price_aliases_for_versioned_families,
     remember_upstream_id,
 )
+from scripts.pricing.openai_catalog import discover_available_priced_chat_catalog
+from trusted_router.provider_lifecycle import provider_model_retired
 
 SLUG = "fireworks"
 URL = "https://docs.fireworks.ai/serverless/pricing.md"
@@ -41,40 +43,90 @@ MANIFEST_PATH = (
 EXPECTED_MODELS = [
     "moonshotai/kimi-k3",
     "moonshotai/kimi-k2.6",
-    "deepseek/deepseek-v4-pro",
+    "moonshotai/kimi-k2.7-code",
+    "deepseek/deepseek-v4-pro-0813",
+    "deepseek/deepseek-v4-flash-0731",
     "z-ai/glm-5.2",
-    "z-ai/glm-5.1",
+    "z-ai/glm-5.2-fast",
     "openai/gpt-oss-120b",
+    "meta-models/muse-glimmer-30b",
+    "minimax/minimax-m3",
+    "nvidia/nemotron-3.5-lightning",
+    "nvidia/nemotron-3-ultra-550b-a55b",
+    "qwen/qwen3.8-max",
 ]
+
+_DISPLAY_NAMES = {
+    "deepseek/deepseek-v4-flash-0731": "DeepSeek V4 Flash 0731",
+    "deepseek/deepseek-v4-pro": "DeepSeek V4 Pro",
+    "deepseek/deepseek-v4-pro-0813": "DeepSeek V4 Pro 0813",
+    "minimax/minimax-m2.7": "MiniMax M2.7",
+    "minimax/minimax-m3": "MiniMax M3",
+    "meta-models/muse-glimmer-30b": "Muse Glimmer 30B",
+    "moonshotai/kimi-k2.6": "Kimi K2.6",
+    "moonshotai/kimi-k2.6-fast": "Kimi K2.6 Fast",
+    "moonshotai/kimi-k2.7-code": "Kimi K2.7 Code",
+    "moonshotai/kimi-k2.7-code-fast": "Kimi K2.7 Code Fast",
+    "moonshotai/kimi-k3": "Kimi K3",
+    "moonshotai/kimi-k3-fast": "Kimi K3 Fast",
+    "nvidia/nemotron-3.5-lightning": "NVIDIA Nemotron 3.5 Lightning",
+    "nvidia/nemotron-3-ultra-550b-a55b": "NVIDIA Nemotron 3 Ultra",
+    "openai/gpt-oss-20b": "OpenAI GPT OSS 20B",
+    "openai/gpt-oss-120b": "OpenAI GPT OSS 120B",
+    "qwen/qwen3.7-plus": "Qwen 3.7 Plus",
+    "qwen/qwen3.8-max": "Qwen 3.8 Max",
+    "z-ai/glm-5.2": "GLM 5.2",
+    "z-ai/glm-5.2-fast": "GLM 5.2 Fast",
+}
 
 _NATIVE_TO_CANONICAL = {
     "accounts/fireworks/models/kimi-k3": "moonshotai/kimi-k3",
     "accounts/fireworks/models/kimi-k2p6": "moonshotai/kimi-k2.6",
     "accounts/fireworks/models/kimi-k2p7-code": "moonshotai/kimi-k2.7-code",
+    "accounts/fireworks/routers/kimi-k3-fast": "moonshotai/kimi-k3-fast",
+    "accounts/fireworks/routers/kimi-k2p6-turbo": "moonshotai/kimi-k2.6-fast",
+    "accounts/fireworks/routers/kimi-k2p7-code-fast": "moonshotai/kimi-k2.7-code-fast",
     "accounts/fireworks/models/deepseek-v4-pro": "deepseek/deepseek-v4-pro",
+    "accounts/fireworks/models/deepseek-v4-pro-0813": "deepseek/deepseek-v4-pro-0813",
     "accounts/fireworks/models/deepseek-v4-flash": "deepseek/deepseek-v4-flash",
+    "accounts/fireworks/models/deepseek-v4-flash-0731": "deepseek/deepseek-v4-flash-0731",
     "accounts/fireworks/models/glm-5p2": "z-ai/glm-5.2",
+    "accounts/fireworks/routers/glm-5p2-fast": "z-ai/glm-5.2-fast",
     "accounts/fireworks/models/glm-5p1": "z-ai/glm-5.1",
     "accounts/fireworks/models/gpt-oss-120b": "openai/gpt-oss-120b",
     "accounts/fireworks/models/gpt-oss-20b": "openai/gpt-oss-20b",
     "accounts/fireworks/models/minimax-m3": "minimax/minimax-m3",
     "accounts/fireworks/models/minimax-m2p7": "minimax/minimax-m2.7",
+    "accounts/fireworks/models/qwen3p7-plus": "qwen/qwen3.7-plus",
+    "accounts/fireworks/models/qwen3p8-max": "qwen/qwen3.8-max",
+    "accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b": (
+        "nvidia/nemotron-3.5-lightning"
+    ),
+    "accounts/fireworks/models/nemotron-3-ultra-nvfp4": (
+        "nvidia/nemotron-3-ultra-550b-a55b"
+    ),
+    "accounts/fireworks/models/muse-glimmer-30b": "meta-models/muse-glimmer-30b",
 }
 UPSTREAM_ID_MAP = {canonical: native for native, canonical in _NATIVE_TO_CANONICAL.items()}
-# Fast is an account router rather than a row in /v1/models. It remains an
-# explicit, separately smoke-tested route and is not subject to model pruning.
-UPSTREAM_ID_MAP["z-ai/glm-5.2-fast"] = "accounts/fireworks/routers/glm-5p2-fast"
 # Fireworks can publish and serve a launch model before its authenticated
 # /v1/models response catches up. Keep only explicitly verified exceptions,
 # and only while the first-party pricing page still contains the model.
 VERIFIED_PRICED_LAUNCH_MODELS = frozenset({"moonshotai/kimi-k3"})
-_DISCOVERED_LIVE_MODEL_IDS: set[str] = set()
+_VISION_MODEL_IDS = frozenset(
+    {
+        "moonshotai/kimi-k3",
+        "moonshotai/kimi-k3-fast",
+        "qwen/qwen3.8-max",
+    }
+)
+_DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
 _VERSIONED_PRICE_FAMILIES = {
     "deepseek/deepseek-v4-flash-": "deepseek/deepseek-v4-flash",
+    "deepseek/deepseek-v4-pro-": "deepseek/deepseek-v4-pro",
 }
 
 
-def _live_model_ids() -> set[str]:
+def _live_model_rows() -> list[dict[str, Any]]:
     api_key = os.environ.get("FIREWORKS_API_KEY") or os.environ.get("FIREWORKS_AI_API_KEY")
     if not api_key:
         raise RuntimeError("fireworks: FIREWORKS_API_KEY is required")
@@ -85,26 +137,30 @@ def _live_model_ids() -> set[str]:
     rows = payload.get("data") if isinstance(payload, dict) else None
     if not isinstance(rows, list):
         raise RuntimeError("fireworks: /v1/models response has no data list")
-    discovered: set[str] = set()
-    for row in rows:
-        if not isinstance(row, dict):
-            continue
-        native_id = row.get("id")
-        if not isinstance(native_id, str):
-            continue
-        canonical = _NATIVE_TO_CANONICAL.get(native_id) or canonicalize_unqualified_model_id(
-            native_id
-        )
-        if canonical is not None:
-            discovered.add(canonical)
-            remember_upstream_id(UPSTREAM_ID_MAP, canonical, native_id)
-    return discovered
+    return [row for row in rows if isinstance(row, dict)]
 
 
 def fetch() -> ProviderPricingResult:
-    global _DISCOVERED_LIVE_MODEL_IDS
+    global _DISCOVERED_MANIFEST_ROWS
 
-    live_model_ids = _live_model_ids()
+    source_rows = _live_model_rows()
+    live_model_ids: set[str] = set()
+    live_rows: list[dict[str, Any]] = []
+    resolved_native_map = dict(_NATIVE_TO_CANONICAL)
+    for row in source_rows:
+        native_id = row.get("id")
+        if not isinstance(native_id, str):
+            continue
+        canonical = resolved_native_map.get(native_id) or canonicalize_unqualified_model_id(
+            native_id
+        )
+        if canonical is None or provider_model_retired(SLUG, canonical, native_id):
+            continue
+        resolved_native_map[native_id] = canonical
+        live_model_ids.add(canonical)
+        live_rows.append(row)
+        remember_upstream_id(UPSTREAM_ID_MAP, canonical, native_id)
+
     price_aliases = price_aliases_for_versioned_families(
         live_model_ids,
         _VERSIONED_PRICE_FAMILIES,
@@ -118,13 +174,37 @@ def fetch() -> ProviderPricingResult:
     )
     verified_launch_ids = VERIFIED_PRICED_LAUNCH_MODELS.intersection(result.prices)
     routable_model_ids = live_model_ids | verified_launch_ids
-    _DISCOVERED_LIVE_MODEL_IDS = routable_model_ids
     docs_only = sorted(set(result.prices) - routable_model_ids)
     result.prices = {
         model_id: price
         for model_id, price in result.prices.items()
         if model_id in routable_model_ids
     }
+    discovered = discover_available_priced_chat_catalog(
+        live_rows,
+        prices=result.prices,
+        explicit_map=resolved_native_map,
+        upstream_id_map=UPSTREAM_ID_MAP,
+    )
+    # A verified launch exception is allowed to precede the account model-list
+    # feed, but only while the first-party pricing page still publishes it.
+    for model_id in verified_launch_ids - set(discovered):
+        upstream_id = UPSTREAM_ID_MAP.get(model_id)
+        if upstream_id is None:
+            continue
+        discovered[model_id] = {
+            "id": model_id,
+            "upstream_id": upstream_id,
+            "display_name": model_id,
+            "endpoints": ["chat/completions"],
+        }
+    for model_id in _VISION_MODEL_IDS:
+        if model_id in discovered:
+            discovered[model_id]["input_modalities"] = ["text", "image"]
+    for model_id, row in discovered.items():
+        fallback_name = model_id.rsplit("/", 1)[-1].replace("-", " ").title()
+        row["display_name"] = f"{_DISPLAY_NAMES.get(model_id, fallback_name)} on Fireworks"
+    _DISCOVERED_MANIFEST_ROWS = discovered
     errors = validate(result.prices, EXPECTED_MODELS)
     if errors:
         raise RuntimeError("; ".join(errors))
@@ -142,56 +222,12 @@ def fetch() -> ProviderPricingResult:
 
 
 def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
-    """Refresh prices and remove retired Fireworks model routes.
+    """Publish the fresh intersection of Fireworks availability and prices."""
 
-    Account routers are preserved because Fireworks does not expose them in
-    the model-list API. Ordinary model routes must be present in the
-    authenticated operator catalog and on the official pricing page.
-    """
-
-    raw = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
-    rows = raw.get("models")
-    if not isinstance(rows, list):
-        raise RuntimeError("fireworks manifest has no models list")
-
-    retained: list[dict[str, Any]] = []
-    updated = 0
-    removed: list[str] = []
-    for candidate in rows:
-        if not isinstance(candidate, dict):
-            continue
-        model_id = candidate.get("id")
-        upstream_id = candidate.get("upstream_id")
-        if not isinstance(model_id, str) or not isinstance(upstream_id, str):
-            continue
-        is_model_route = upstream_id.startswith("accounts/fireworks/models/")
-        if is_model_route and model_id not in _DISCOVERED_LIVE_MODEL_IDS:
-            removed.append(model_id)
-            continue
-
-        price = result.prices.get(model_id)
-        if price is not None:
-            tier = price.tiers[0]
-            candidate["input_token_price_per_m"] = tier.prompt_micro_per_m
-            candidate["output_token_price_per_m"] = tier.completion_micro_per_m
-            if tier.prompt_cached_micro_per_m is not None:
-                candidate["cached_input_token_price_per_m"] = tier.prompt_cached_micro_per_m
-            else:
-                candidate.pop("cached_input_token_price_per_m", None)
-            updated += 1
-        retained.append(candidate)
-
-    if not retained:
-        raise RuntimeError("fireworks manifest pruning removed every route")
-    rows[:] = retained
-    raw["generated_at"] = (
-        datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return write_discovered_chat_manifest(
+        result,
+        manifest_path=MANIFEST_PATH,
+        discovered_rows=_DISCOVERED_MANIFEST_ROWS,
+        source_url=MODELS_URL,
+        pricing_source_url=URL,
     )
-    raw["model_count"] = len(rows)
-    MANIFEST_PATH.write_text(
-        json.dumps(raw, indent=2, ensure_ascii=False) + "\n",
-        encoding="utf-8",
-    )
-
-    suffix = f", removed {len(removed)} unavailable" if removed else ""
-    return [f"fireworks: refreshed provider_models/fireworks.json ({updated} priced rows{suffix})"]

--- a/src/trusted_router/catalog_registry.py
+++ b/src/trusted_router/catalog_registry.py
@@ -1191,7 +1191,15 @@ def _install_deepseek_v4_pro_release_routes() -> None:
     baseten_current = MODEL_ENDPOINTS.get(
         f"{DEEPSEEK_V4_PRO_0813_MODEL_ID}@baseten/prepaid"
     )
-    if not historical or current is None or baseten_current is None:
+    fireworks_current = MODEL_ENDPOINTS.get(
+        f"{DEEPSEEK_V4_PRO_0813_MODEL_ID}@fireworks/prepaid"
+    )
+    if (
+        not historical
+        or current is None
+        or baseten_current is None
+        or fireworks_current is None
+    ):
         raise RuntimeError("DeepSeek V4 Pro release routes are incomplete")
 
     # Versioned release IDs are immutable Credits-only products. The hourly
@@ -1247,7 +1255,7 @@ def _install_deepseek_v4_pro_release_routes() -> None:
     install(
         DEEPSEEK_V4_PRO_0813_MODEL_ID,
         "DeepSeek V4 Pro 0813",
-        [current, baseten_current],
+        [current, baseten_current, fireworks_current],
     )
 
 

--- a/src/trusted_router/data/provider_models/fireworks.json
+++ b/src/trusted_router/data/provider_models/fireworks.json
@@ -2,9 +2,8 @@
   "_about": "Provider-native supplement for the Fireworks AI serverless models enabled on the TrustedRouter Fireworks account. Verified against https://api.fireworks.ai/inference/v1/models, Fireworks' first-party pricing page, and direct chat completions. Kimi K3 is a verified launch route served before the account model-list feed caught up. Fireworks uses full accounts/fireworks/models/... upstream IDs, so the enclave preserves upstream_id verbatim for this provider.",
   "provider": "fireworks",
   "source": "https://api.fireworks.ai/inference/v1/models",
-  "price_source": "https://docs.fireworks.ai/serverless/pricing",
-  "generated_at": "2026-08-25T08:44:22Z",
-  "model_count": 6,
+  "generated_at": "2026-08-25T09:20:02Z",
+  "model_count": 20,
   "models": [
     {
       "id": "moonshotai/kimi-k3",
@@ -33,7 +32,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "created": 1784483409
     },
     {
       "id": "moonshotai/kimi-k2.6",
@@ -61,7 +61,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "created": 1776455694
     },
     {
       "id": "deepseek/deepseek-v4-pro",
@@ -79,7 +80,8 @@
         "serverless"
       ],
       "input_modalities": [
-        "text"
+        "text",
+        "image"
       ],
       "output_modalities": [
         "text"
@@ -87,7 +89,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "created": 1777003717
     },
     {
       "id": "z-ai/glm-5.2",
@@ -114,7 +117,8 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "created": 1781630293
     },
     {
       "id": "z-ai/glm-5.2-fast",
@@ -123,9 +127,9 @@
       "title": "accounts/fireworks/routers/glm-5p2-fast",
       "context_length": 1048576,
       "max_output_tokens": 65536,
-      "input_token_price_per_m": 2800000,
-      "output_token_price_per_m": 8800000,
-      "cached_input_token_price_per_m": 280000,
+      "input_token_price_per_m": 2100000,
+      "output_token_price_per_m": 6600000,
+      "cached_input_token_price_per_m": 210000,
       "model_type": "chat",
       "features": [
         "reasoning",
@@ -142,12 +146,13 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "created": 1781630293
     },
     {
       "id": "openai/gpt-oss-120b",
       "upstream_id": "accounts/fireworks/models/gpt-oss-120b",
-      "display_name": "GPT OSS 120B on Fireworks",
+      "display_name": "OpenAI GPT OSS 120B on Fireworks",
       "title": "accounts/fireworks/models/gpt-oss-120b",
       "context_length": 131072,
       "max_output_tokens": 65536,
@@ -168,7 +173,318 @@
       "endpoints": [
         "chat/completions"
       ],
-      "status": 1
+      "status": 1,
+      "created": 1754345600
+    },
+    {
+      "display_name": "DeepSeek V4 Flash 0731 on Fireworks",
+      "title": "accounts/fireworks/models/deepseek-v4-flash-0731",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "deepseek/deepseek-v4-flash-0731",
+      "upstream_id": "accounts/fireworks/models/deepseek-v4-flash-0731",
+      "context_length": 1048576,
+      "created": 1785514482,
+      "input_token_price_per_m": 220000,
+      "output_token_price_per_m": 660000,
+      "cached_input_token_price_per_m": 7000
+    },
+    {
+      "display_name": "DeepSeek V4 Pro 0813 on Fireworks",
+      "title": "accounts/fireworks/models/deepseek-v4-pro-0813",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "deepseek/deepseek-v4-pro-0813",
+      "upstream_id": "accounts/fireworks/models/deepseek-v4-pro-0813",
+      "context_length": 1048576,
+      "created": 1786637155,
+      "input_token_price_per_m": 1740000,
+      "output_token_price_per_m": 3480000,
+      "cached_input_token_price_per_m": 145000
+    },
+    {
+      "display_name": "MiniMax M2.7 on Fireworks",
+      "title": "accounts/fireworks/models/minimax-m2p7",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "minimax/minimax-m2.7",
+      "upstream_id": "accounts/fireworks/models/minimax-m2p7",
+      "context_length": 196608,
+      "created": 1775867225,
+      "input_token_price_per_m": 300000,
+      "output_token_price_per_m": 1200000,
+      "cached_input_token_price_per_m": 60000
+    },
+    {
+      "display_name": "MiniMax M3 on Fireworks",
+      "title": "accounts/fireworks/models/minimax-m3",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "minimax/minimax-m3",
+      "upstream_id": "accounts/fireworks/models/minimax-m3",
+      "context_length": 512000,
+      "created": 1781214748,
+      "input_token_price_per_m": 300000,
+      "output_token_price_per_m": 1200000,
+      "cached_input_token_price_per_m": 60000
+    },
+    {
+      "display_name": "Kimi K2.6 Fast on Fireworks",
+      "title": "accounts/fireworks/routers/kimi-k2p6-turbo",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "moonshotai/kimi-k2.6-fast",
+      "upstream_id": "accounts/fireworks/routers/kimi-k2p6-turbo",
+      "context_length": 262144,
+      "created": 1776455694,
+      "input_token_price_per_m": 2000000,
+      "output_token_price_per_m": 8000000,
+      "cached_input_token_price_per_m": 300000
+    },
+    {
+      "display_name": "Kimi K2.7 Code on Fireworks",
+      "title": "accounts/fireworks/models/kimi-k2p7-code",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "moonshotai/kimi-k2.7-code",
+      "upstream_id": "accounts/fireworks/models/kimi-k2p7-code",
+      "context_length": 262144,
+      "created": 1781283600,
+      "input_token_price_per_m": 950000,
+      "output_token_price_per_m": 4000000,
+      "cached_input_token_price_per_m": 190000
+    },
+    {
+      "display_name": "Kimi K2.7 Code Fast on Fireworks",
+      "title": "accounts/fireworks/routers/kimi-k2p7-code-fast",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "moonshotai/kimi-k2.7-code-fast",
+      "upstream_id": "accounts/fireworks/routers/kimi-k2p7-code-fast",
+      "context_length": 262144,
+      "created": 1781283600,
+      "input_token_price_per_m": 1900000,
+      "output_token_price_per_m": 8000000,
+      "cached_input_token_price_per_m": 380000
+    },
+    {
+      "display_name": "Kimi K3 Fast on Fireworks",
+      "title": "accounts/fireworks/routers/kimi-k3-fast",
+      "model_type": "chat",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "moonshotai/kimi-k3-fast",
+      "upstream_id": "accounts/fireworks/routers/kimi-k3-fast",
+      "context_length": 1048576,
+      "created": 1784483409,
+      "input_token_price_per_m": 4500000,
+      "output_token_price_per_m": 22500000,
+      "cached_input_token_price_per_m": 450000
+    },
+    {
+      "display_name": "NVIDIA Nemotron 3.5 Lightning on Fireworks",
+      "title": "accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "nvidia/nemotron-3.5-lightning",
+      "upstream_id": "accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b",
+      "context_length": 262144,
+      "created": 1786139705,
+      "input_token_price_per_m": 50000,
+      "output_token_price_per_m": 200000,
+      "cached_input_token_price_per_m": 10000
+    },
+    {
+      "display_name": "OpenAI GPT OSS 20B on Fireworks",
+      "title": "accounts/fireworks/models/gpt-oss-20b",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "openai/gpt-oss-20b",
+      "upstream_id": "accounts/fireworks/models/gpt-oss-20b",
+      "context_length": 131072,
+      "created": 1754345466,
+      "input_token_price_per_m": 70000,
+      "output_token_price_per_m": 300000,
+      "cached_input_token_price_per_m": 35000
+    },
+    {
+      "display_name": "Qwen 3.7 Plus on Fireworks",
+      "title": "accounts/fireworks/models/qwen3p7-plus",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "qwen/qwen3.7-plus",
+      "upstream_id": "accounts/fireworks/models/qwen3p7-plus",
+      "created": 1781036419,
+      "input_token_price_per_m": 400000,
+      "output_token_price_per_m": 1600000,
+      "cached_input_token_price_per_m": 80000
+    },
+    {
+      "display_name": "Qwen 3.8 Max on Fireworks",
+      "title": "accounts/fireworks/models/qwen3p8-max",
+      "model_type": "chat",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "qwen/qwen3.8-max",
+      "upstream_id": "accounts/fireworks/models/qwen3p8-max",
+      "created": 1785949040,
+      "input_token_price_per_m": 2000000,
+      "output_token_price_per_m": 6000000,
+      "cached_input_token_price_per_m": 250000
+    },
+    {
+      "display_name": "Muse Glimmer 30B on Fireworks",
+      "title": "accounts/fireworks/models/muse-glimmer-30b",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "meta-models/muse-glimmer-30b",
+      "upstream_id": "accounts/fireworks/models/muse-glimmer-30b",
+      "context_length": 131072,
+      "created": 1786326846,
+      "input_token_price_per_m": 350000,
+      "output_token_price_per_m": 1500000,
+      "cached_input_token_price_per_m": 40000
+    },
+    {
+      "display_name": "NVIDIA Nemotron 3 Ultra on Fireworks",
+      "title": "accounts/fireworks/models/nemotron-3-ultra-nvfp4",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "nvidia/nemotron-3-ultra-550b-a55b",
+      "upstream_id": "accounts/fireworks/models/nemotron-3-ultra-nvfp4",
+      "context_length": 262144,
+      "created": 1780415326,
+      "input_token_price_per_m": 600000,
+      "output_token_price_per_m": 2400000,
+      "cached_input_token_price_per_m": 120000
     }
-  ]
+  ],
+  "pricing_source": "https://docs.fireworks.ai/serverless/pricing.md",
+  "price_scale": "microdollars_per_million"
 }

--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -47,6 +47,8 @@ DEEPSEEK_WEEKEND_OFF_PEAK_EFFECTIVE_AT = datetime(
 FIREWORKS_DSV4_FLASH_0731_PRICING_EFFECTIVE_AT = datetime(
     2026, 8, 22, 12, 0, tzinfo=UTC
 )
+FIREWORKS_AUGUST_2026_RETIREMENT_AT = datetime(2026, 8, 27, 0, 0, tzinfo=UTC)
+FIREWORKS_QWEN37_RETIREMENT_AT = datetime(2026, 9, 4, 0, 0, tzinfo=UTC)
 
 # DeepSeek prices direct V4 traffic at twice the off-peak rate during these
 # half-open UTC windows. Keep them as seconds since midnight so boundary
@@ -102,6 +104,43 @@ class _Retirement:
 
 
 _RETIREMENTS = (
+    # Fireworks announced that these Serverless routes retire on 2026-08-27.
+    # The two Kimi retirements apply only to the separately billed Fast
+    # routers; standard Kimi K2.6 and Kimi K2.7 Code remain available. The
+    # notice did not specify a time zone, so use 00:00 UTC conservatively.
+    # Dedicated deployments and equivalent routes on other providers are
+    # unaffected.
+    _Retirement(
+        provider="fireworks",
+        model_ids=frozenset(
+            {
+                "minimax/minimax-m2.7",
+                "openai/gpt-oss-20b",
+                "moonshotai/kimi-k2.6-fast",
+                "moonshotai/kimi-k2.7-code-fast",
+                "deepseek/deepseek-v4-pro",
+            }
+        ),
+        upstream_ids=frozenset(
+            {
+                "accounts/fireworks/models/minimax-m2p7",
+                "accounts/fireworks/models/gpt-oss-20b",
+                "accounts/fireworks/routers/kimi-k2p6-turbo",
+                "accounts/fireworks/routers/kimi-k2p7-code-fast",
+                "accounts/fireworks/models/deepseek-v4-pro",
+            }
+        ),
+        effective_at=FIREWORKS_AUGUST_2026_RETIREMENT_AT,
+    ),
+    # Fireworks extended Qwen 3.7 Plus Serverless through 2026-09-04 and
+    # named Qwen 3.8 Max as its replacement. Keep this separate from the
+    # August cutover so the route is not removed a week early.
+    _Retirement(
+        provider="fireworks",
+        model_ids=frozenset({"qwen/qwen3.7-plus"}),
+        upstream_ids=frozenset({"accounts/fireworks/models/qwen3p7-plus"}),
+        effective_at=FIREWORKS_QWEN37_RETIREMENT_AT,
+    ),
     # Cerebras announced that Qwen 3.8 27B replaces Gemma 4 31B on its
     # Shared Tier on 2026-09-03. The notice did not specify a time zone, so
     # retire the shared route conservatively at 00:00 UTC. Gemma remains

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -452,6 +452,7 @@ def test_qwen_38_routes_only_through_hosts_with_verified_pricing() -> None:
 
     assert f"{model_id}@novita/prepaid" in MODEL_ENDPOINTS
     assert f"{model_id}@atlas-cloud/prepaid" in MODEL_ENDPOINTS
+    assert f"{model_id}@fireworks/prepaid" in MODEL_ENDPOINTS
     assert f"{model_id}@alibaba/prepaid" not in MODEL_ENDPOINTS
     assert f"{model_id}@alibaba/byok" not in MODEL_ENDPOINTS
 
@@ -785,6 +786,7 @@ def test_deepseek_v4_pro_release_routes_are_keyed_and_credits_only() -> None:
     assert {endpoint.provider for endpoint in current_routes} == {
         "deepseek",
         "baseten",
+        "fireworks",
     }
     assert {endpoint.provider for endpoint in current_routes} <= GATEWAY_PREPAID_PROVIDER_SLUGS
     assert [
@@ -797,6 +799,11 @@ def test_deepseek_v4_pro_release_routes_are_keyed_and_credits_only() -> None:
         for endpoint in current_routes
         if endpoint.provider == "baseten"
     ] == [("baseten", "deepseek-ai/DeepSeek-V4-Pro-0813")]
+    assert [
+        (endpoint.provider, endpoint.upstream_id)
+        for endpoint in current_routes
+        if endpoint.provider == "fireworks"
+    ] == [("fireworks", "accounts/fireworks/models/deepseek-v4-pro-0813")]
     baseten = next(
         endpoint for endpoint in current_routes if endpoint.provider == "baseten"
     )

--- a/tests/test_fireworks_august_2026_lifecycle.py
+++ b/tests/test_fireworks_august_2026_lifecycle.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from scripts.pricing import refresh
+from scripts.pricing.base import ModelPrice, ProviderPricingResult
+from trusted_router import provider_lifecycle
+from trusted_router.catalog import endpoints_for_model
+
+_AUGUST_CUTOFF = datetime(2026, 8, 27, 0, 0, tzinfo=UTC)
+_QWEN_CUTOFF = datetime(2026, 9, 4, 0, 0, tzinfo=UTC)
+_AUGUST_RETIRING = {
+    "minimax/minimax-m2.7": "accounts/fireworks/models/minimax-m2p7",
+    "openai/gpt-oss-20b": "accounts/fireworks/models/gpt-oss-20b",
+    "moonshotai/kimi-k2.6-fast": "accounts/fireworks/routers/kimi-k2p6-turbo",
+    "moonshotai/kimi-k2.7-code-fast": "accounts/fireworks/routers/kimi-k2p7-code-fast",
+    "deepseek/deepseek-v4-pro": "accounts/fireworks/models/deepseek-v4-pro",
+}
+_AUGUST_REPLACEMENTS = {
+    "minimax/minimax-m3": "accounts/fireworks/models/minimax-m3",
+    "nvidia/nemotron-3.5-lightning": (
+        "accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b"
+    ),
+    "z-ai/glm-5.2": "accounts/fireworks/models/glm-5p2",
+    "deepseek/deepseek-v4-pro-0813": "accounts/fireworks/models/deepseek-v4-pro-0813",
+}
+_STANDARD_KIMI = {
+    "moonshotai/kimi-k2.6": "accounts/fireworks/models/kimi-k2p6",
+    "moonshotai/kimi-k2.7-code": "accounts/fireworks/models/kimi-k2p7-code",
+}
+
+
+def test_fireworks_august_routes_retire_without_standard_kimi() -> None:
+    for model_id, upstream_id in _AUGUST_RETIRING.items():
+        assert not provider_lifecycle.provider_model_retired(
+            "fireworks",
+            model_id,
+            upstream_id,
+            at=_AUGUST_CUTOFF - timedelta(microseconds=1),
+        )
+        assert provider_lifecycle.provider_model_retired(
+            "fireworks",
+            model_id,
+            upstream_id,
+            at=_AUGUST_CUTOFF,
+        )
+
+    for model_id, upstream_id in {**_STANDARD_KIMI, **_AUGUST_REPLACEMENTS}.items():
+        assert not provider_lifecycle.provider_model_retired(
+            "fireworks",
+            model_id,
+            upstream_id,
+            at=_AUGUST_CUTOFF,
+        )
+
+
+def test_fireworks_qwen_extension_uses_its_own_cutoff() -> None:
+    old_model = "qwen/qwen3.7-plus"
+    old_upstream = "accounts/fireworks/models/qwen3p7-plus"
+
+    assert not provider_lifecycle.provider_model_retired(
+        "fireworks",
+        old_model,
+        old_upstream,
+        at=_QWEN_CUTOFF - timedelta(microseconds=1),
+    )
+    assert provider_lifecycle.provider_model_retired(
+        "fireworks",
+        old_model,
+        old_upstream,
+        at=_QWEN_CUTOFF,
+    )
+    assert not provider_lifecycle.provider_model_retired(
+        "fireworks",
+        "qwen/qwen3.8-max",
+        "accounts/fireworks/models/qwen3p8-max",
+        at=_QWEN_CUTOFF,
+    )
+
+
+def test_fireworks_retirements_are_provider_scoped() -> None:
+    for model_id, upstream_id in {
+        **_AUGUST_RETIRING,
+        "qwen/qwen3.7-plus": "accounts/fireworks/models/qwen3p7-plus",
+    }.items():
+        assert not provider_lifecycle.provider_model_retired(
+            "another-provider",
+            model_id,
+            upstream_id,
+            at=_QWEN_CUTOFF,
+        )
+
+
+def test_hourly_refresh_cannot_restore_retired_fireworks_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prices = {
+        model_id: ModelPrice(1_000_000, 3_000_000)
+        for model_id in {
+            *_AUGUST_RETIRING,
+            *_AUGUST_REPLACEMENTS,
+            *_STANDARD_KIMI,
+            "qwen/qwen3.7-plus",
+            "qwen/qwen3.8-max",
+        }
+    }
+    result = ProviderPricingResult(
+        slug="fireworks",
+        prices=prices,
+        source="api",
+        fetched_url="https://api.fireworks.ai/inference/v1/models",
+    )
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _AUGUST_CUTOFF)
+    august = refresh._index_provider_prices({"fireworks": result})
+    for model_id in _AUGUST_RETIRING:
+        assert "fireworks" not in august.get(model_id, {})
+    for model_id in {*_AUGUST_REPLACEMENTS, *_STANDARD_KIMI, "qwen/qwen3.7-plus"}:
+        assert "fireworks" in august[model_id]
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _QWEN_CUTOFF)
+    september = refresh._index_provider_prices({"fireworks": result})
+    assert "fireworks" not in september.get("qwen/qwen3.7-plus", {})
+    assert "fireworks" in september["qwen/qwen3.8-max"]
+
+
+def test_catalog_filters_fireworks_route_at_cutoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _AUGUST_CUTOFF)
+
+    assert all(
+        endpoint.provider != "fireworks"
+        for endpoint in endpoints_for_model("deepseek/deepseek-v4-pro")
+    )
+    assert any(
+        endpoint.provider == "fireworks"
+        for endpoint in endpoints_for_model("deepseek/deepseek-v4-pro-0813")
+    )

--- a/tests/test_fireworks_pricing.py
+++ b/tests/test_fireworks_pricing.py
@@ -78,7 +78,8 @@ def test_fireworks_dsv4_flash_schedule_is_public_and_authorization_locked() -> N
 def test_fireworks_fetch_intersects_prices_with_operator_catalog(
     monkeypatch,
 ) -> None:  # noqa: ANN001
-    priced_ids = {*fireworks.EXPECTED_MODELS, "moonshotai/kimi-k2.7-code"}
+    docs_only_model = "moonshotai/kimi-k2.5"
+    priced_ids = {*fireworks.EXPECTED_MODELS, docs_only_model}
     monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
     monkeypatch.setattr(
         fireworks,
@@ -103,7 +104,14 @@ def test_fireworks_fetch_intersects_prices_with_operator_catalog(
     result = fireworks.fetch()
 
     assert set(result.prices) == set(fireworks.EXPECTED_MODELS)
-    assert any("kimi-k2.7-code" in note for note in result.notes)
+    assert any(docs_only_model in note for note in result.notes)
+    assert fireworks._DISCOVERED_MANIFEST_ROWS["qwen/qwen3.8-max"][
+        "input_modalities"
+    ] == ["text", "image"]
+    assert (
+        fireworks._DISCOVERED_MANIFEST_ROWS["minimax/minimax-m3"]["display_name"]
+        == "MiniMax M3 on Fireworks"
+    )
 
 
 def test_fireworks_dated_flash_uses_live_native_id_and_family_price(
@@ -162,6 +170,52 @@ def test_fireworks_parser_reads_kimi_k3_standard_pricing() -> None:
     }
 
 
+def test_fireworks_parser_distinguishes_fast_routes_and_replacements() -> None:
+    parsed = fireworks_parser.parse(
+        """
+        | Kimi K2.6 | $0.95 / $0.16 / $4.00 |
+        | Kimi K2.6 Fast | $2.00 / $0.30 / $8.00 |
+        | Kimi K2.7 Code | $0.95 / $0.19 / $4.00 |
+        | Kimi K2.7 Code Fast | $1.90 / $0.38 / $8.00 |
+        | MiniMax M3 | $0.30 / $0.06 / $1.20 |
+        | Muse Glimmer 30B | $0.35 / $0.04 / $1.50 |
+        | NVIDIA Nemotron 3.5 Lightning 30B A3B | $0.05 / $0.01 / $0.20 |
+        | NVIDIA Nemotron 3 Ultra (Preview) | $0.60 / $0.12 / $2.40 |
+        | Qwen 3.8 Max | $2.00 / $0.25 / $6.00 |
+        """
+    )
+
+    assert parsed["moonshotai/kimi-k2.6"]["prompt_micro_per_m"] == 950_000
+    assert parsed["moonshotai/kimi-k2.6-fast"]["prompt_micro_per_m"] == 2_000_000
+    assert parsed["moonshotai/kimi-k2.7-code"]["completion_micro_per_m"] == 4_000_000
+    assert parsed["moonshotai/kimi-k2.7-code-fast"]["completion_micro_per_m"] == 8_000_000
+    assert parsed["minimax/minimax-m3"]["completion_micro_per_m"] == 1_200_000
+    assert parsed["meta-models/muse-glimmer-30b"]["completion_micro_per_m"] == 1_500_000
+    assert parsed["nvidia/nemotron-3.5-lightning"]["prompt_micro_per_m"] == 50_000
+    assert (
+        parsed["nvidia/nemotron-3-ultra-550b-a55b"]["completion_micro_per_m"]
+        == 2_400_000
+    )
+    assert parsed["qwen/qwen3.8-max"]["completion_micro_per_m"] == 6_000_000
+
+
+def test_fireworks_parser_auto_discovers_linked_standard_family_rows() -> None:
+    parsed = fireworks_parser.parse(
+        """
+        | [GLM 5.3](https://app.fireworks.ai/models/fireworks/glm-5p3) |
+          $0.40 / $0.04 / $1.20 |
+        | [Qwen 3.9 Max](https://app.fireworks.ai/models/fireworks/qwen3p9-max) |
+          $0.50 / $0.05 / $1.50 |
+        | [Kimi K4 Fast](https://app.fireworks.ai/models/fireworks/kimi-k4) |
+          $2.00 / $0.20 / $8.00 |
+        """
+    )
+
+    assert parsed["z-ai/glm-5.3"]["completion_micro_per_m"] == 1_200_000
+    assert parsed["qwen/qwen3.9-max"]["prompt_micro_per_m"] == 500_000
+    assert "moonshotai/kimi-k4" not in parsed
+
+
 def test_fireworks_fetch_keeps_verified_launch_model_while_catalog_lags(
     monkeypatch,
 ) -> None:  # noqa: ANN001
@@ -177,7 +231,9 @@ def test_fireworks_fetch_keeps_verified_launch_model_while_catalog_lags(
         ),
     )
     live_rows = [
-        {"id": fireworks.UPSTREAM_ID_MAP[model_id]} for model_id in fireworks.EXPECTED_MODELS
+        {"id": fireworks.UPSTREAM_ID_MAP[model_id]}
+        for model_id in fireworks.EXPECTED_MODELS
+        if model_id not in fireworks.VERIFIED_PRICED_LAUNCH_MODELS
     ]
     monkeypatch.setattr(
         fireworks,
@@ -188,10 +244,10 @@ def test_fireworks_fetch_keeps_verified_launch_model_while_catalog_lags(
     result = fireworks.fetch()
 
     assert "moonshotai/kimi-k3" in result.prices
-    assert "moonshotai/kimi-k3" in fireworks._DISCOVERED_LIVE_MODEL_IDS
+    assert "moonshotai/kimi-k3" in fireworks._DISCOVERED_MANIFEST_ROWS
 
 
-def test_fireworks_manifest_prunes_retired_models_but_keeps_router(
+def test_fireworks_manifest_appends_discovered_models_and_tombstones_delisted(
     tmp_path: Path,
     monkeypatch,
 ) -> None:  # noqa: ANN001
@@ -212,6 +268,7 @@ def test_fireworks_manifest_prunes_retired_models_but_keeps_router(
                         "upstream_id": "accounts/fireworks/models/kimi-k2p5",
                         "input_token_price_per_m": 1,
                         "output_token_price_per_m": 1,
+                        "missing_since": "2026-08-24",
                     },
                     {
                         "id": "z-ai/glm-5.2-fast",
@@ -234,20 +291,42 @@ def test_fireworks_manifest_prunes_retired_models_but_keeps_router(
     monkeypatch.setattr(fireworks, "MANIFEST_PATH", manifest_path)
     monkeypatch.setattr(
         fireworks,
-        "_DISCOVERED_LIVE_MODEL_IDS",
-        {"moonshotai/kimi-k2.6", "moonshotai/kimi-k3"},
+        "_DISCOVERED_MANIFEST_ROWS",
+        {
+            "moonshotai/kimi-k2.6": {
+                "id": "moonshotai/kimi-k2.6",
+                "upstream_id": "accounts/fireworks/models/kimi-k2p6",
+            },
+            "z-ai/glm-5.2-fast": {
+                "id": "z-ai/glm-5.2-fast",
+                "upstream_id": "accounts/fireworks/routers/glm-5p2-fast",
+            },
+            "moonshotai/kimi-k3": {
+                "id": "moonshotai/kimi-k3",
+                "upstream_id": "accounts/fireworks/models/kimi-k3",
+            },
+            "minimax/minimax-m3": {
+                "id": "minimax/minimax-m3",
+                "upstream_id": "accounts/fireworks/models/minimax-m3",
+                "display_name": "MiniMax M3 on Fireworks",
+                "context_length": 512_000,
+            },
+        },
     )
     result = ProviderPricingResult(
         slug="fireworks",
         prices={
             "moonshotai/kimi-k2.6": _price(),
+            "z-ai/glm-5.2-fast": _price(),
             "moonshotai/kimi-k3": ModelPrice(
                 prompt_micro_per_m=3_000_000,
                 completion_micro_per_m=15_000_000,
                 prompt_cached_micro_per_m=300_000,
             ),
+            "minimax/minimax-m3": _price(),
         },
-        source="deterministic",
+        source="api",
+        fetched_url=fireworks.URL,
     )
 
     notes = fireworks.write_provider_manifest(result)
@@ -256,12 +335,19 @@ def test_fireworks_manifest_prunes_retired_models_but_keeps_router(
     by_id = {row["id"]: row for row in raw["models"]}
     assert set(by_id) == {
         "moonshotai/kimi-k2.6",
+        "moonshotai/kimi-k2.5",
         "moonshotai/kimi-k3",
+        "minimax/minimax-m3",
         "z-ai/glm-5.2-fast",
     }
     assert by_id["moonshotai/kimi-k2.6"]["input_token_price_per_m"] == 1_000_000
     assert by_id["moonshotai/kimi-k3"]["input_token_price_per_m"] == 3_000_000
     assert by_id["moonshotai/kimi-k3"]["cached_input_token_price_per_m"] == 300_000
+    assert by_id["minimax/minimax-m3"]["context_length"] == 512_000
+    assert by_id["minimax/minimax-m3"]["display_name"] == "MiniMax M3 on Fireworks"
+    assert by_id["moonshotai/kimi-k2.5"]["routable"] is False
+    assert by_id["moonshotai/kimi-k2.5"]["routable_reason"] == "delisted-upstream"
     assert notes == [
-        "fireworks: refreshed provider_models/fireworks.json (2 priced rows, removed 1 unavailable)"
+        "fireworks: refreshed provider_models/fireworks.json "
+        "(4 priced rows, appended 1, tombstoned 1 unavailable)"
     ]


### PR DESCRIPTION
## Summary\n- retire only the affected Fireworks serverless routes at their exact Aug 27 / Sep 4 cutovers\n- preserve standard Kimi K2.6 and K2.7 Code routes\n- auto-discover authenticated Fireworks models only when exact official pricing is available\n- add replacements, vision metadata, and immutable DeepSeek V4 Pro 0813 routing\n\n## Verification\n- 310 focused tests passed\n- ruff check . passed\n- mypy passed (303 files)\n- direct paid PONGs passed for MiniMax M3, Nemotron Lightning, DeepSeek V4 Pro 0813, Qwen 3.8 Max, Muse Glimmer 30B, and Nemotron 3 Ultra\n- post-cutover simulation excludes all six retired routes while preserving standard Kimi routes\n\nFull pytest reached 2,976 passed / 270 skipped / 10 xfailed; remaining failures were unrelated sandbox-local socket and existing rollout-verifier tests.