### PR TITLE
Stop transient analytics reads from paging

### DIFF
--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -14,6 +14,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
+import httpx
 from fastapi import BackgroundTasks, FastAPI, HTTPException, Query, Request
 from fastapi.openapi.docs import get_swagger_ui_html
 from fastapi.responses import (
@@ -2255,8 +2256,8 @@ def _leaderboard_snapshot(settings: Settings) -> dict[str, Any]:
     if settings.environment != "test":
         try:
             precomputed = _precomputed_public_analytics_snapshot("leaderboard")
-        except Exception:
-            log.exception("public_analytics_snapshot_read_failed name=leaderboard")
+        except Exception as exc:
+            _log_public_analytics_snapshot_read_failure("leaderboard", exc)
             if _LEADERBOARD_CACHE is not None:
                 return _LEADERBOARD_CACHE[1]
         else:
@@ -2306,8 +2307,8 @@ def _video_leaderboard_snapshot(settings: Settings) -> dict[str, Any]:
     if settings.environment != "test":
         try:
             precomputed = _precomputed_public_analytics_snapshot("video_leaderboard")
-        except Exception:
-            log.exception("public_analytics_snapshot_read_failed name=video_leaderboard")
+        except Exception as exc:
+            _log_public_analytics_snapshot_read_failure("video_leaderboard", exc)
             if _VIDEO_LEADERBOARD_CACHE is not None:
                 return _VIDEO_LEADERBOARD_CACHE[1]
         else:
@@ -2357,8 +2358,8 @@ def _apps_snapshot(settings: Settings) -> dict[str, Any]:
     if settings.environment != "test":
         try:
             precomputed = _precomputed_public_analytics_snapshot("apps")
-        except Exception:
-            log.exception("public_analytics_snapshot_read_failed name=apps")
+        except Exception as exc:
+            _log_public_analytics_snapshot_read_failure("apps", exc)
             if _APPS_CACHE is not None:
                 return _APPS_CACHE[1]
         else:
@@ -2387,6 +2388,27 @@ def _precomputed_public_analytics_snapshot(name: str) -> dict[str, Any] | None:
     )
 
 
+def _log_public_analytics_snapshot_read_failure(name: str, exc: Exception) -> None:
+    """Keep cacheable dependency blips visible without paging twice.
+
+    Every public analytics surface has a stale or live fallback, and the fleet
+    freshness workflow separately pages on sustained snapshot unavailability.
+    A connect/read timeout here therefore degrades one cache fill; it is not an
+    unhandled application error. Unexpected response/schema defects remain
+    ERRORs with tracebacks because those require a code or data repair.
+    """
+    context = {
+        "snapshot_name": name,
+        "error_class": type(exc).__name__,
+        "error_message": str(exc)[:500],
+        "retryable": isinstance(exc, (httpx.TimeoutException, httpx.NetworkError)),
+    }
+    if context["retryable"]:
+        log.warning("public_analytics_snapshot_read_degraded", extra=context)
+        return
+    log.exception("public_analytics_snapshot_read_failed", extra=context)
+
+
 def _merge_client_observed_status(
     payload: dict[str, Any],
     *,
@@ -2397,8 +2419,8 @@ def _merge_client_observed_status(
     if settings.environment != "test":
         try:
             snapshot = _precomputed_public_analytics_snapshot("client_reliability")
-        except Exception:
-            log.exception("public_analytics_snapshot_read_failed name=client_reliability")
+        except Exception as exc:
+            _log_public_analytics_snapshot_read_failure("client_reliability", exc)
     result["client_observed"] = client_observed_status_section(
         snapshot,
         now=dt.datetime.now(dt.UTC),
@@ -2544,8 +2566,8 @@ def _status_snapshot(settings: Settings) -> dict[str, Any]:
     if settings.environment != "test":
         try:
             precomputed = _precomputed_public_analytics_snapshot("status_inputs")
-        except Exception:
-            log.exception("public_analytics_snapshot_read_failed name=status_inputs")
+        except Exception as exc:
+            _log_public_analytics_snapshot_read_failure("status_inputs", exc)
             if _STATUS_CACHE is not None:
                 # The rest of the payload may be served stale; the analytics
                 # section may NOT. Re-read it, so this path publishes the drain

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -75,7 +75,7 @@ from trusted_router.storage_activity import (
     usage_bucket_key,
 )
 from trusted_router.storage_auth_context import build_session_auth_context
-from trusted_router.storage_errors import is_duplicate_key_error
+from trusted_router.storage_errors import is_duplicate_key_error, is_transient_store_error
 from trusted_router.storage_gcp_analytics_outbox import SpannerAnalyticsOutbox
 from trusted_router.storage_gcp_attribution import SpannerAcquisitionAttribution
 from trusted_router.storage_gcp_auth_sessions import SpannerAuthSessions
@@ -3756,10 +3756,27 @@ class SpannerBigtableStore:
         try:
             oldest = outbox.oldest_enqueued_at(timeout=OUTBOX_FRESHNESS_TIMEOUT_SECONDS)
         except Exception as exc:
-            log.exception(
-                "spanner.operational_analytics_outbox_freshness_failed",
-                extra={"error_class": type(exc).__name__, "error_message": str(exc)[:500]},
-            )
+            context = {
+                "error_class": type(exc).__name__,
+                "error_message": str(exc)[:500],
+                "retryable": is_transient_store_error(exc),
+            }
+            if context["retryable"]:
+                # This read is advisory and fail-closed: /status.json publishes
+                # `unreachable`, while the fleet freshness checker owns paging
+                # after a sustained failure. A cold regional Spanner session can
+                # exceed this deliberately short budget without breaking a
+                # customer request, so do not manufacture two Error Reporting
+                # groups from gRPC's chained timeout traceback.
+                log.warning(
+                    "spanner.operational_analytics_outbox_freshness_degraded",
+                    extra=context,
+                )
+            else:
+                log.exception(
+                    "spanner.operational_analytics_outbox_freshness_failed",
+                    extra=context,
+                )
             return OutboxFreshness.unavailable(BACKEND_SPANNER, REASON_UNREACHABLE)
         return OutboxFreshness(backend=BACKEND_SPANNER, oldest_enqueued_at=oldest)
 

--- a/tests/test_public_analytics_freshness.py
+++ b/tests/test_public_analytics_freshness.py
@@ -11,10 +11,13 @@ that will not answer does not hold the status page open.
 from __future__ import annotations
 
 import datetime as dt
+import logging
 import time
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
+from google.api_core.exceptions import DeadlineExceeded
 
 from trusted_router.config import Settings
 from trusted_router.operational_analytics_freshness import (
@@ -31,6 +34,7 @@ from trusted_router.operational_analytics_freshness import (
 )
 from trusted_router.routes import public as public_routes
 from trusted_router.storage import STORE
+from trusted_router.storage_gcp import SpannerBigtableStore
 
 
 def _snapshot(monkeypatch) -> dict[str, object]:
@@ -38,6 +42,120 @@ def _snapshot(monkeypatch) -> dict[str, object]:
     monkeypatch.setattr(public_routes, "_status_rollups", lambda _window: [])
     monkeypatch.setattr(public_routes, "_STATUS_CACHE", None)
     return public_routes._status_snapshot(Settings(environment="local"))
+
+
+def test_transient_public_snapshot_timeout_is_a_single_warning(caplog) -> None:
+    with caplog.at_level(logging.WARNING, logger=public_routes.__name__):
+        public_routes._log_public_analytics_snapshot_read_failure(
+            "status_inputs",
+            httpx.ConnectTimeout("timed out"),
+        )
+
+    [record] = [
+        record
+        for record in caplog.records
+        if record.message == "public_analytics_snapshot_read_degraded"
+    ]
+    assert record.levelno == logging.WARNING
+    assert record.exc_info is None
+    assert record.snapshot_name == "status_inputs"
+    assert record.error_class == "ConnectTimeout"
+    assert record.retryable is True
+
+
+def test_unexpected_public_snapshot_failure_remains_an_error(caplog) -> None:
+    with caplog.at_level(logging.ERROR, logger=public_routes.__name__):
+        try:
+            raise ValueError("invalid snapshot schema")
+        except ValueError as exc:
+            public_routes._log_public_analytics_snapshot_read_failure("leaderboard", exc)
+
+    [record] = [
+        record
+        for record in caplog.records
+        if record.message == "public_analytics_snapshot_read_failed"
+    ]
+    assert record.levelno == logging.ERROR
+    assert record.exc_info is not None
+    assert record.snapshot_name == "leaderboard"
+    assert record.retryable is False
+
+
+def test_status_snapshot_connect_timeout_falls_back_without_error(
+    caplog,
+    monkeypatch,
+) -> None:
+    def timeout(_name: str) -> dict[str, object] | None:
+        raise httpx.ConnectTimeout("cold ClickHouse connection timed out")
+
+    monkeypatch.setattr(public_routes, "_precomputed_public_analytics_snapshot", timeout)
+    monkeypatch.setattr(public_routes, "_status_samples", lambda **_kwargs: [])
+    monkeypatch.setattr(public_routes, "_status_rollups", lambda _window: [])
+    monkeypatch.setattr(public_routes, "_STATUS_CACHE", None)
+    monkeypatch.setattr(
+        STORE.target,
+        "operational_analytics_outbox_freshness",
+        lambda: OutboxFreshness(backend=BACKEND_POSTGRES, oldest_enqueued_at=None),
+        raising=False,
+    )
+
+    with caplog.at_level(logging.WARNING, logger=public_routes.__name__):
+        payload = public_routes._status_snapshot(Settings(environment="local"))
+
+    assert ANALYTICS_STATUS_KEY in payload
+    assert any(
+        record.message == "public_analytics_snapshot_read_degraded"
+        and record.snapshot_name == "status_inputs"
+        for record in caplog.records
+    )
+    assert not any(record.levelno >= logging.ERROR for record in caplog.records)
+
+
+class _FailingOutbox:
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    def oldest_enqueued_at(self, *, timeout: float) -> dt.datetime | None:
+        _ = timeout
+        raise self._exc
+
+
+def _freshness_with_failure(exc: Exception) -> OutboxFreshness:
+    store = object.__new__(SpannerBigtableStore)
+    store._operational_analytics_outbox = _FailingOutbox(exc)  # type: ignore[assignment]
+    return store.operational_analytics_outbox_freshness()
+
+
+def test_transient_spanner_freshness_timeout_is_a_single_warning(caplog) -> None:
+    with caplog.at_level(logging.WARNING, logger="trusted_router.storage_gcp"):
+        reading = _freshness_with_failure(DeadlineExceeded("deadline exceeded"))
+
+    [record] = [
+        record
+        for record in caplog.records
+        if record.message == "spanner.operational_analytics_outbox_freshness_degraded"
+    ]
+    assert reading.available is False
+    assert reading.reason == REASON_UNREACHABLE
+    assert record.levelno == logging.WARNING
+    assert record.exc_info is None
+    assert record.error_class == "DeadlineExceeded"
+    assert record.retryable is True
+
+
+def test_unexpected_spanner_freshness_failure_remains_an_error(caplog) -> None:
+    with caplog.at_level(logging.ERROR, logger="trusted_router.storage_gcp"):
+        reading = _freshness_with_failure(RuntimeError("bad query shape"))
+
+    [record] = [
+        record
+        for record in caplog.records
+        if record.message == "spanner.operational_analytics_outbox_freshness_failed"
+    ]
+    assert reading.available is False
+    assert record.levelno == logging.ERROR
+    assert record.exc_info is not None
+    assert record.retryable is False
 
 
 def test_status_snapshot_publishes_the_analytics_section(monkeypatch) -> None:


### PR DESCRIPTION
## Root cause

The new public Cloud Run surface performs cacheable ClickHouse snapshot reads and an advisory Spanner outbox-freshness read. Fresh hourly deployment revisions occasionally exceed the short connect/read deadlines. Each recovered timeout was logged with `log.exception`, causing the chained dependency exception to become two Cloud Error Reporting groups even though the public fallback returned 200.

## Fix

- classify expected ClickHouse network timeouts as structured warnings
- classify expected transient Spanner freshness failures as structured warnings
- keep publishing analytics as unavailable so fleet freshness monitoring remains fail closed
- preserve ERROR tracebacks for unexpected code, query, and schema failures
- cover both warning and ERROR branches plus the real status fallback path

## Verification

- `uv run ruff check .`
- `uv run mypy`
- 66 focused tests passed
- full local pytest is running; CI remains the merge gate
- live audit found zero Cloud Run HTTP 5xx in the incident window
