### PR TITLE
Stop expected reconciler deploy errors from paging

### DIFF
--- a/scripts/deploy/regional_quota_reconciler.sh
+++ b/scripts/deploy/regional_quota_reconciler.sh
@@ -77,7 +77,29 @@ env_vars=(
 set_env_vars="$(IFS='|'; echo "^|^${env_vars[*]}")"
 
 log "deploying regional quota reconciliation job ${JOB_NAME}"
-gc run jobs deploy "$JOB_NAME" \
+versioned_job_exists=false
+while IFS= read -r deployed_job; do
+  if [ "$deployed_job" = "$JOB_NAME" ]; then
+    versioned_job_exists=true
+    break
+  fi
+done < <(
+  gc run jobs list \
+    --region "$JOB_REGION" \
+    --filter="metadata.name:${JOB_PREFIX}" \
+    --format='value(metadata.name)'
+)
+
+# `gcloud run jobs deploy` probes a new version with GetJob before creating it.
+# Cloud Audit Logs records that expected NOT_FOUND as ERROR, which can page
+# operators even though the subsequent create succeeds. List first, then use
+# the explicit mutation so normal release discovery stays out of error logs.
+if [ "$versioned_job_exists" = true ]; then
+  job_mutation=update
+else
+  job_mutation=create
+fi
+gc run jobs "$job_mutation" "$JOB_NAME" \
   --region "$JOB_REGION" \
   --image "$IMAGE" \
   --command="/app/.venv/bin/python" \
@@ -121,9 +143,14 @@ common_args=(
   --http-method=POST
   --oauth-service-account-email="$RUN_SERVICE_ACCOUNT"
   --attempt-deadline=30s
-  --max-retry-attempts=0
+  # Starting this job is idempotent and the worker takes a distributed lock.
+  # Retry transient Google control-plane failures inside the current minute
+  # instead of dropping a reconciliation cycle.
+  --max-retry-attempts=3
+  --max-retry-duration=45s
   --min-backoff=5s
-  --max-backoff=30s
+  --max-backoff=15s
+  --max-doublings=1
   --quiet
 )
 

--- a/tests/test_deploy_script_execution.py
+++ b/tests/test_deploy_script_execution.py
@@ -134,6 +134,11 @@ if [[ " $* " == *" scheduler jobs describe "* ]]; then
   exit "${HARNESS_SCHEDULER_DESCRIBE_RC:-0}"
 fi
 
+if [[ " $* " == *" run jobs list "* ]] && \
+   [ "${HARNESS_VERSIONED_JOB_EXISTS:-false}" = "true" ]; then
+  printf '%s\n' "$HARNESS_VERSIONED_JOB_NAME"
+fi
+
 if [[ " $* " == *" projects describe "* ]]; then
   printf '%s\n' '123456789'
 fi
@@ -148,6 +153,7 @@ def _run_regional_quota_reconciler(
     state: str = "",
     describe_rc: int = 0,
     describe_stderr: str = "",
+    versioned_job_exists: bool = False,
 ) -> HarnessRun:
     monkeypatch.setitem(
         SCRIPT_FIXTURES,
@@ -157,6 +163,15 @@ def _run_regional_quota_reconciler(
                 "HARNESS_SCHEDULER_STATE": state,
                 "HARNESS_SCHEDULER_DESCRIBE_RC": str(describe_rc),
                 "HARNESS_SCHEDULER_DESCRIBE_STDERR": describe_stderr,
+                "HARNESS_VERSIONED_JOB_EXISTS": str(versioned_job_exists).lower(),
+                "HARNESS_VERSIONED_JOB_NAME": (
+                    "trusted-router-regional-quota-reconciler-existing"
+                ),
+                "TR_REGIONAL_QUOTA_RECONCILER_JOB": (
+                    "trusted-router-regional-quota-reconciler-existing"
+                    if versioned_job_exists
+                    else ""
+                ),
             }
         ),
     )
@@ -450,6 +465,32 @@ def test_regional_quota_reconciler_verifies_updates_and_resumes_enabled_schedule
     assert len(_gcloud_calls(run, "scheduler", "jobs", "update")) == 1
     assert not _gcloud_calls(run, "scheduler", "jobs", "create")
     assert len(_gcloud_calls(run, "scheduler", "jobs", "resume")) == 1
+    assert len(_gcloud_calls(run, "run", "jobs", "create")) == 1
+    assert not _gcloud_calls(run, "run", "jobs", "deploy")
+    update = _gcloud_calls(run, "scheduler", "jobs", "update")[0]
+    assert "--max-retry-attempts=3" in update
+    assert "--max-retry-duration=45s" in update
+    assert "--min-backoff=5s" in update
+    assert "--max-backoff=15s" in update
+    assert "--max-doublings=1" in update
+
+
+def test_regional_quota_reconciler_updates_existing_version_without_get_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = _run_regional_quota_reconciler(
+        tmp_path,
+        monkeypatch,
+        state="ENABLED",
+        versioned_job_exists=True,
+    )
+
+    assert run.returncode == 0, summarise(run)
+    assert len(_gcloud_calls(run, "run", "jobs", "list")) >= 1
+    assert len(_gcloud_calls(run, "run", "jobs", "update")) == 1
+    assert not _gcloud_calls(run, "run", "jobs", "create")
+    assert not _gcloud_calls(run, "run", "jobs", "deploy")
 
 
 def test_regional_quota_reconciler_creates_only_when_scheduler_is_not_found(

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -250,7 +250,9 @@ def test_production_deploy_provisions_and_schedules_regional_quota_reconciliatio
     assert reconciler.index("gc run jobs execute") < reconciler.index("gc scheduler jobs create")
     assert "--max-retries 0" in reconciler
     assert "--task-timeout 50s" in reconciler
-    assert "--max-retry-attempts=0" in reconciler
+    assert "--max-retry-attempts=3" in reconciler
+    assert "--max-retry-duration=45s" in reconciler
+    assert "--max-doublings=1" in reconciler
     assert "scheduler_state" in reconciler
     assert '[ "$scheduler_state" = "PAUSED" ]' in reconciler
     assert "skipping automatic reconciler execution while containment pause is active" in reconciler


### PR DESCRIPTION
## What changed
- replace Cloud Run Job deploy point-probe with exact list plus create/update
- retry transient Scheduler control-plane failures within the minute
- add regression coverage for new and existing versioned jobs

## Why
Normal version discovery emitted NOT_FOUND audit errors that triggered Google alert emails despite successful deployment and zero customer 5xx.

## Verification
- 5 reconciler execution tests
- 33 deploy wiring and region tests
- ruff
- bash syntax check