### PR TITLE
Make local rate-limit outage test deterministic

### DIFF
--- a/tests/test_stubs_and_security.py
+++ b/tests/test_stubs_and_security.py
@@ -924,6 +924,16 @@ def test_public_bearer_does_not_authenticate_or_use_durable_limiter(
 
 def test_rate_limit_does_not_touch_store_and_remains_local_on_store_error(monkeypatch) -> None:
     """Request admission must not depend on or amplify a storage outage."""
+    from trusted_router import storage_rate_limits
+
+    # Both requests must exercise one tumbling window. Without a fixed clock,
+    # the test can cross a wall-clock minute between requests and correctly
+    # start a fresh bucket, making this storage-independence assertion flaky.
+    monkeypatch.setattr(
+        storage_rate_limits,
+        "utcnow",
+        lambda: dt.datetime(2026, 8, 25, 13, 39, 30, tzinfo=dt.UTC),
+    )
 
     def boom(self, *_args, **_kwargs):
         del self


### PR DESCRIPTION
## Summary

- pin the local ingress limiter clock in the storage-outage regression test
- keep both requests in the same tumbling window
- preserve the production rate-limit implementation and fail-closed CI gate unchanged

## Verification

- focused rate-limit tests: 2 passed
- exact CI shard 4 command: 1,749 passed, 37 skipped
- Ruff and diff checks passed

The previous test could cross a wall-clock minute between two requests. Starting a fresh bucket is correct production behavior, but made the assertion nondeterministic.