### PR TITLE
Stop auto-refill freshness from scanning settlement history

### DIFF
--- a/src/trusted_router/storage_gcp_settle_outbox.py
+++ b/src/trusted_router/storage_gcp_settle_outbox.py
@@ -849,12 +849,16 @@ class SpannerSettleOutbox:
         return _auto_refill_row_from_tuple(rows[0]) if rows else None
 
     def auto_refill_pending_freshness(self) -> tuple[str | None, int]:
-        """Return oldest pending enqueue timestamp and queue depth."""
+        """Return queue freshness without scanning terminal settlement history."""
         with self._database.snapshot() as snapshot:
             rows = list(
                 snapshot.execute_sql(
                     "SELECT MIN(auto_refill_enqueued_at), COUNT(*) "
-                    "FROM tr_settle_outbox WHERE auto_refill_status='pending'"
+                    "FROM tr_settle_outbox"
+                    "@{FORCE_INDEX=tr_settle_outbox_auto_refill_due} "
+                    "WHERE queue_shard IS NOT NULL "
+                    "AND auto_refill_next_attempt_at IS NOT NULL "
+                    "AND auto_refill_status='pending'"
                 )
             )
         if not rows:

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -1466,6 +1466,31 @@ def _execute_settle_outbox_sql(
         if rec is None or rec.get("auto_refill_status") != "pending":
             return []
         return [[rec.get("auto_refill_attempts", 0), rec.get("auto_refill_lease_owner")]]
+    if sql.startswith("SELECT MIN(auto_refill_enqueued_at), COUNT(*)"):
+        _require_pred(
+            sql,
+            "FORCE_INDEX=tr_settle_outbox_auto_refill_due",
+            "auto-freshness-index",
+        )
+        _require_pred(sql, "queue_shard IS NOT NULL", "auto-freshness-shard")
+        _require_pred(
+            sql,
+            "auto_refill_next_attempt_at IS NOT NULL",
+            "auto-freshness-sparse",
+        )
+        _require_pred(sql, "auto_refill_status='pending'", "auto-freshness-status")
+        pending = [
+            rec
+            for rec in db.settle_outbox.values()
+            if rec.get("auto_refill_status") == "pending"
+            and rec.get("queue_shard") is not None
+            and rec.get("auto_refill_next_attempt_at") is not None
+        ]
+        oldest = min(
+            (rec.get("auto_refill_enqueued_at") for rec in pending),
+            default=None,
+        )
+        return [[oldest, len(pending)]]
     if "FORCE_INDEX=tr_settle_outbox_auto_refill_due" in sql:
         _require_pred(sql, "queue_shard IS NOT NULL", "auto-due-shard")
         _require_pred(
@@ -1492,17 +1517,6 @@ def _execute_settle_outbox_sql(
             [rec.get(column) for column in AUTO_REFILL_COLUMNS]
             for rec in rows[: int(p.get("limit", 100))]
         ]
-    if sql.startswith("SELECT MIN(auto_refill_enqueued_at), COUNT(*)"):
-        pending = [
-            rec
-            for rec in db.settle_outbox.values()
-            if rec.get("auto_refill_status") == "pending"
-        ]
-        oldest = min(
-            (rec.get("auto_refill_enqueued_at") for rec in pending),
-            default=None,
-        )
-        return [[oldest, len(pending)]]
     if "auto_refill_status IS NOT NULL" in sql:
         _require_pred(sql, "authorization_id=@aid", "auto-get")
         _require_pred(sql, "intent_kind='settle'", "auto-get")

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -699,6 +699,14 @@ def test_stale_auto_refill_queue_emits_page_worthy_signal(
     assert any("ALERT auto-refill outbox stale" in message for message in alerts)
 
 
+def test_auto_refill_freshness_reads_only_the_sparse_pending_index(
+    fake_store: tuple[Any, Any, Any],
+) -> None:
+    store, _db, _bt = fake_store
+
+    assert _outbox(store).auto_refill_pending_freshness() == (None, 0)
+
+
 def test_settle_emits_timing_line(
     fake_store: tuple[Any, Any, Any],
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
## Root cause
Every control-plane instance runs the auto-refill drain every 30 seconds. Its freshness query scanned the entire 1.29M-row settlement table even when the sparse pending queue was empty. Over the latest 90-minute window it ran 2,115 times, consumed 3,884.7 Spanner CPU-seconds, and reached 4.72s latency.

## Fix
- force the existing sparse tr_settle_outbox_auto_refill_due index
- retain queue-age and depth behavior
- make the Spanner fake enforce the load-bearing index predicates
- add a regression test that fails against the previous full-table query

A production read-only profile of the replacement query scanned 0 rows with an empty queue and used 12.23ms CPU.

## Verification
- ruff passed
- mypy passed
- focused storage and drain suite: 76 passed
- regression test was run against the old query first and failed as expected