### PR TITLE
Deploy overhead package: overlap the waits, pre-warm the capacity, measure every run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -348,14 +348,16 @@ jobs:
     outputs:
       TR_DEPLOY_MUTEX_OPERATION: ${{ steps.acquire_mutex.outputs.TR_DEPLOY_MUTEX_OPERATION }}
       TR_DEPLOY_MUTEX_GENERATION: ${{ steps.acquire_mutex.outputs.TR_DEPLOY_MUTEX_GENERATION }}
+      TR_DEPLOY_MUTEX_CREATED_AT: ${{ steps.acquire_mutex.outputs.TR_DEPLOY_MUTEX_CREATED_AT }}
       sha: ${{ needs.build-image.outputs.sha }}
       image: ${{ needs.build-image.outputs.image }}
+      primary_live_seconds: ${{ steps.primary_live.outputs.primary_live_seconds }}
       previous_europe_west4_revision: ${{ steps.prev.outputs.europe_west4_revision }}
       previous_us_east4_revision: ${{ steps.prev.outputs.us_east4_revision }}
       previous_southamerica_east1_revision: ${{ steps.prev.outputs.southamerica_east1_revision }}
-      europe_west4_revision: ${{ steps.warm_all.outputs.europe_west4_revision }}
-      us_east4_revision: ${{ steps.warm_all.outputs.us_east4_revision }}
-      southamerica_east1_revision: ${{ steps.warm_all.outputs.southamerica_east1_revision }}
+      europe_west4_revision: ${{ steps.wait_secondary_warms.outputs.europe_west4_revision }}
+      us_east4_revision: ${{ steps.wait_secondary_warms.outputs.us_east4_revision }}
+      southamerica_east1_revision: ${{ steps.wait_secondary_warms.outputs.southamerica_east1_revision }}
     # The mutex TTL is 90 minutes. The two lock-owning job bounds total
     # 25 + 55 = 80 minutes, leaving 10 minutes for the job handoff queue gap.
     timeout-minutes: 25
@@ -401,10 +403,12 @@ jobs:
           printf '%s\n' "$fence" >> "$GITHUB_ENV"
           printf '%s\n' "$fence" >> "$GITHUB_OUTPUT"
 
-      # Staged regional deploy. Warm all four no-traffic revisions together,
-      # then gate primary-live on us-central1's unchanged 10/50/100 ramp and
-      # 3-minute single-region synthetic watch. The follow-on job inherits the
-      # same mutex fence and ramps the already-warm secondaries serially.
+      # Staged regional deploy. Launch all four no-traffic revisions together,
+      # but gate primary-live only on us-central1's warm plus its unchanged
+      # 10/50/100 ramp and 3-minute single-region synthetic watch. Secondary
+      # warms continue through those primary ramp/canary steps and are joined
+      # before this job can succeed. Warm processes never move traffic, so the
+      # serial traffic containment required by #695 is unchanged.
       #
       # Hotfix mode (workflow_dispatch input `hotfix: true`): the
       # watchdogs skip baseline + use --skip-baseline so a sick prod
@@ -476,6 +480,19 @@ jobs:
             printf '%s\n' "${revision}" >"${revision_file}"
           }
 
+          run_warm() {
+            local status_file="$1"
+            shift
+            local status
+            set +e
+            warm_region "$@"
+            status=$?
+            set -e
+            printf '%s\n' "${status}" >"${status_file}.tmp.$$"
+            mv "${status_file}.tmp.$$" "${status_file}"
+            return "${status}"
+          }
+
           # rollout.sh gates global load-balancer mutation on
           # TR_DEPLOY_RECONCILE_LB. Only the primary process receives 1; all
           # concurrent secondary processes receive 0 and cannot mutate the LB.
@@ -493,46 +510,51 @@ jobs:
             "${RUNNER_TEMP}/revision-us-east4"
             "${RUNNER_TEMP}/revision-southamerica-east1"
           )
+          status_files=(
+            "${RUNNER_TEMP}/warmup-status-us-central1"
+            "${RUNNER_TEMP}/warmup-status-europe-west4"
+            "${RUNNER_TEMP}/warmup-status-us-east4"
+            "${RUNNER_TEMP}/warmup-status-southamerica-east1"
+          )
+          secondary_state="${RUNNER_TEMP}/secondary-warms.tsv"
+          rm -f "${secondary_state}" "${status_files[@]}" "${revision_files[@]}"
           pids=()
           primary_started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
-          (warm_region "us-central1" "1" "${revision_files[0]}") >"${logs[0]}" 2>&1 &
+          (run_warm "${status_files[0]}" "us-central1" "1" "${revision_files[0]}") >"${logs[0]}" 2>&1 &
           pids+=("$!")
-          (warm_region "europe-west4" "0" "${revision_files[1]}") >"${logs[1]}" 2>&1 &
+          (run_warm "${status_files[1]}" "europe-west4" "0" "${revision_files[1]}") >"${logs[1]}" 2>&1 &
           pids+=("$!")
-          (warm_region "us-east4" "0" "${revision_files[2]}") >"${logs[2]}" 2>&1 &
+          (run_warm "${status_files[2]}" "us-east4" "0" "${revision_files[2]}") >"${logs[2]}" 2>&1 &
           pids+=("$!")
-          (warm_region "southamerica-east1" "0" "${revision_files[3]}") >"${logs[3]}" 2>&1 &
+          (run_warm "${status_files[3]}" "southamerica-east1" "0" "${revision_files[3]}") >"${logs[3]}" 2>&1 &
           pids+=("$!")
 
-          statuses=()
-          for idx in "${!pids[@]}"; do
-            if wait "${pids[$idx]}"; then
-              statuses[$idx]=0
-            else
-              statuses[$idx]=$?
-            fi
+          # A new GitHub step cannot use bash `wait` on a child from this
+          # shell, so persist PID + atomic status paths for the end-of-job
+          # collector. The processes themselves continue on this same runner.
+          for idx in 1 2 3; do
+            printf '%s\t%s\t%s\t%s\t%s\n' \
+              "${regions[$idx]}" "${pids[$idx]}" "${logs[$idx]}" \
+              "${status_files[$idx]}" "${revision_files[$idx]}" \
+              >>"${secondary_state}"
           done
 
-          failed=0
-          for idx in "${!regions[@]}"; do
-            printf '\n=== warmup: %s ===\n' "${regions[$idx]}"
-            cat "${logs[$idx]}"
-            if [ "${statuses[$idx]}" -ne 0 ]; then
-              echo "::error::${regions[$idx]} no-traffic warmup failed."
-              failed=1
-            fi
-          done
-          if [ "$failed" -ne 0 ]; then
-            echo "::error::Regional warmup failed; no traffic moved. Successful warm revisions remain at zero traffic."
-            exit 1
+          primary_status=0
+          if wait "${pids[0]}"; then
+            primary_status=0
+          else
+            primary_status=$?
+          fi
+          printf '\n=== warmup: %s ===\n' "${regions[0]}"
+          cat "${logs[0]}"
+          if [ "${primary_status}" -ne 0 ]; then
+            echo "::error::us-central1 no-traffic warmup failed; no traffic moved."
+            exit "${primary_status}"
           fi
 
           echo "primary_started_at=${primary_started_at}" >> "$GITHUB_OUTPUT"
           echo "us_central1_revision=$(<"${revision_files[0]}")" >> "$GITHUB_OUTPUT"
-          echo "europe_west4_revision=$(<"${revision_files[1]}")" >> "$GITHUB_OUTPUT"
-          echo "us_east4_revision=$(<"${revision_files[2]}")" >> "$GITHUB_OUTPUT"
-          echo "southamerica_east1_revision=$(<"${revision_files[3]}")" >> "$GITHUB_OUTPUT"
 
       - name: Stage traffic 10/50/100 (us-central1)
         # Ramps the new revision from 10% → 50% → 100% with a 1-min
@@ -541,6 +563,8 @@ jobs:
         # fails before any secondary receives traffic.
         env:
           TR_WATCHDOG_SLO_CLASS: router_core
+          TR_STAGED_WATCHDOG_BASELINE_FILE: ${{ runner.temp }}/final-watchdog-baseline-us-central1.json
+          TR_STAGED_WATCHDOG_SKIP_BASELINE: ${{ inputs.hotfix == true && '1' || '0' }}
         run: bash scripts/deploy/staged_traffic.sh us-central1 "${{ steps.warm_all.outputs.us_central1_revision }}" "${{ steps.prev.outputs.us_central1_revision }}"
 
       - name: Canary gate — watch us-central1 only (3 min)
@@ -550,7 +574,7 @@ jobs:
         # contained to us-central1.
         id: canary_us
         continue-on-error: true
-        run: python3 scripts/deploy/watchdog.py --regions us-central1 --duration-min 3 --rollback-after 2 --slo-class router_core ${{ steps.wd_args.outputs.extra }}
+        run: python3 scripts/deploy/watchdog.py --regions us-central1 --duration-min 3 --rollback-after 2 --slo-class router_core --baseline-input "${RUNNER_TEMP}/final-watchdog-baseline-us-central1.json" ${{ steps.wd_args.outputs.extra }}
 
       - name: Rollback us-central1 + abort (canary tripped)
         if: ${{ steps.canary_us.outcome == 'failure' && steps.canary_us.outputs.rollback_regions != '' }}
@@ -586,6 +610,96 @@ jobs:
             exit 1
           fi
 
+      - name: Record primary-live timing
+        id: primary_live
+        env:
+          MUTEX_CREATED_AT: ${{ steps.acquire_mutex.outputs.TR_DEPLOY_MUTEX_CREATED_AT }}
+        run: |
+          set -euo pipefail
+          primary_live_seconds="$(python3 - "${MUTEX_CREATED_AT}" <<'PY'
+          from datetime import datetime, timezone
+          import sys
+
+          raw = sys.argv[1]
+          acquired = datetime.fromisoformat(
+              raw[:-1] + "+00:00" if raw.endswith("Z") else raw
+          )
+          if acquired.tzinfo is None:
+              raise SystemExit("mutex created_at must include a timezone")
+          print(max(0, int((datetime.now(timezone.utc) - acquired).total_seconds())))
+          PY
+          )"
+          echo "primary_live_seconds=${primary_live_seconds}" >> "$GITHUB_OUTPUT"
+          echo "primary live after ${primary_live_seconds}s from mutex acquisition"
+
+      - name: Wait for secondary no-traffic warms
+        id: wait_secondary_warms
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          secondary_state="${RUNNER_TEMP}/secondary-warms.tsv"
+          if [ ! -s "${secondary_state}" ]; then
+            echo "::error::secondary warm state is missing"
+            exit 1
+          fi
+
+          failed=0
+          while IFS=$'\t' read -r region pid log_file status_file revision_file; do
+            # Background processes persist across steps on the same runner,
+            # but they are no longer children of this shell. Wait by polling
+            # their atomic status file and use the PID to detect an abnormal
+            # exit that could not write one.
+            # Bounded poll: a warm that neither writes status nor dies
+            # (or whose PID was recycled by an unrelated process, defeating
+            # kill -0) must become a named per-region failure here, not a
+            # generic job timeout with the mutex still held.
+            poll_deadline=$((SECONDS + 900))
+            while [ ! -s "${status_file}" ]; do
+              if ! kill -0 "${pid}" 2>/dev/null; then
+                # kill -0 losing a race with the status write is benign:
+                # the warm may finish and exit between our two checks. Give
+                # the atomic mv a moment and trust the FILE, not the PID.
+                sleep 1
+                if [ -s "${status_file}" ]; then
+                  break
+                fi
+                echo "::error::${region} warm exited without recording status"
+                failed=1
+                break
+              fi
+              if [ "$SECONDS" -ge "$poll_deadline" ]; then
+                echo "::error::${region} warm produced no status within 15 minutes"
+                failed=1
+                break
+              fi
+              sleep 1
+            done
+
+            printf '\n=== warmup: %s ===\n' "${region}"
+            cat "${log_file}" || true
+            if [ ! -s "${status_file}" ]; then
+              continue
+            fi
+            status="$(<"${status_file}")"
+            if [[ ! "${status}" =~ ^[0-9]+$ ]] || [ "${status}" -ne 0 ]; then
+              echo "::error::${region} no-traffic warmup failed with status ${status:-missing}."
+              failed=1
+              continue
+            fi
+            if [ ! -s "${revision_file}" ]; then
+              echo "::error::${region} warm succeeded without a revision result"
+              failed=1
+              continue
+            fi
+            key="${region//-/_}_revision"
+            echo "${key}=$(<"${revision_file}")" >> "$GITHUB_OUTPUT"
+          done <"${secondary_state}"
+
+          if [ "${failed}" -ne 0 ]; then
+            echo "::error::Regional warmup failed; no secondary traffic moved. Successful warm revisions remain at zero traffic."
+            exit 1
+          fi
+
       # Mutex release ownership:
       # - deploy fails/cancels: this conditional release runs promptly.
       # - deploy succeeds and rollout-secondaries runs: ownership transfers,
@@ -593,6 +707,22 @@ jobs:
       # - deploy succeeds but GitHub never schedules rollout-secondaries: no
       #   release runs; the 90-minute TTL recovers. Queued deploys fail closed
       #   during that freeze, so production mutations never overlap.
+      - name: Sweep staged-probe tags from never-ramped regions
+        if: ${{ failure() || cancelled() }}
+        # A warmed-but-never-ramped candidate keeps the staged-probe tag, and
+        # the tag keeps its baked revision minimum allocated at 0% traffic —
+        # paid instances that survive until some future deploy reconciles the
+        # tag. Ramps remove the tag themselves; every abort path lands here.
+        # Removal is idempotent, and a region whose ramp already cleaned up is
+        # a no-op.
+        run: |
+          for region in us-central1 europe-west4 us-east4 southamerica-east1; do
+            gcloud run services update-traffic "trusted-router" \
+              --region "$region" --project "$PROJECT_ID" \
+              --remove-tags staged-probe --quiet \
+              && echo "swept $region" || echo "sweep $region: nothing to remove or call failed (non-fatal)"
+          done
+
       - name: Release production deployment mutex after primary-live failure
         if: ${{ failure() || cancelled() }}
         run: bash scripts/deploy/deploy_mutex.sh release
@@ -616,14 +746,18 @@ jobs:
         env:
           DEPLOY_MUTEX_OPERATION: ${{ needs.deploy.outputs.TR_DEPLOY_MUTEX_OPERATION }}
           DEPLOY_MUTEX_GENERATION: ${{ needs.deploy.outputs.TR_DEPLOY_MUTEX_GENERATION }}
+          DEPLOY_MUTEX_CREATED_AT: ${{ needs.deploy.outputs.TR_DEPLOY_MUTEX_CREATED_AT }}
         run: |
           set -euo pipefail
-          if [ -z "${DEPLOY_MUTEX_OPERATION}" ] || [ -z "${DEPLOY_MUTEX_GENERATION}" ]; then
+          if [ -z "${DEPLOY_MUTEX_OPERATION}" ] || \
+             [ -z "${DEPLOY_MUTEX_GENERATION}" ] || \
+             [ -z "${DEPLOY_MUTEX_CREATED_AT}" ]; then
             echo "::error::deploy did not export a complete mutex fence"
             exit 1
           fi
           echo "TR_DEPLOY_MUTEX_OPERATION=${DEPLOY_MUTEX_OPERATION}" >> "$GITHUB_ENV"
           echo "TR_DEPLOY_MUTEX_GENERATION=${DEPLOY_MUTEX_GENERATION}" >> "$GITHUB_ENV"
+          echo "TR_DEPLOY_MUTEX_CREATED_AT=${DEPLOY_MUTEX_CREATED_AT}" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@v4
         with:
@@ -697,6 +831,7 @@ jobs:
           NEW_SOUTHAMERICA_EAST1: ${{ needs.deploy.outputs.southamerica_east1_revision }}
           WD_EXTRA: ${{ steps.wd_args.outputs.extra }}
           TR_WATCHDOG_SLO_CLASS: router_core
+          TR_STAGED_WATCHDOG_SKIP_BASELINE: ${{ inputs.hotfix == true && '1' || '0' }}
           TR_BILLING_5XX_GATE_SKIP: ${{ inputs.hotfix == true && 'true' || 'false' }}
         run: |
           set -euo pipefail
@@ -734,12 +869,15 @@ jobs:
             local revision="$2"
             local previous
             local rollout_started_at
+            local watchdog_baseline
             previous="$(previous_revision "${region}")"
             # The billing window belongs to this region's traffic ramp, not to
             # the earlier parallel warmup or a sibling's ramp.
             rollout_started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            watchdog_baseline="${RUNNER_TEMP}/final-watchdog-baseline-${region}.json"
 
-            if ! bash scripts/deploy/staged_traffic.sh \
+            if ! TR_STAGED_WATCHDOG_BASELINE_FILE="${watchdog_baseline}" \
+              bash scripts/deploy/staged_traffic.sh \
                 "${region}" "${revision}" "${previous}"; then
               rollback_region "${region}" || true
               return 1
@@ -770,6 +908,7 @@ jobs:
               --duration-min 3 \
               --rollback-after 2 \
               --slo-class router_core \
+              --baseline-input "${watchdog_baseline}" \
               "${watchdog_extra[@]}"; then
               rollback_region "${region}"
               return 1
@@ -782,10 +921,11 @@ jobs:
             fi
           }
 
-          # Incident containment from #695 (billing 5xx, 2026-08-20): all
-          # revision warmups completed in deploy before primary traffic moved.
-          # Keep the three secondary 10/50/100 ramps explicit, serial, and
-          # stop-on-failure; no ramp overlaps a sibling ramp.
+          # Incident containment from #695 (billing 5xx, 2026-08-20): every
+          # secondary no-traffic warm was joined successfully by the deploy job
+          # before this job was scheduled. Keep the three secondary 10/50/100
+          # ramps explicit, serial, and stop-on-failure; no traffic move ever
+          # overlaps a sibling traffic move.
           reconciler_log="${RUNNER_TEMP}/regional-quota-reconciler.log"
           bash scripts/deploy/regional_quota_reconciler.sh >"${reconciler_log}" 2>&1 &
           reconciler_pid=$!
@@ -1010,6 +1150,76 @@ jobs:
           SPANNER_INSTANCE_ID: trusted-router-nam6
           SPANNER_DATABASE_ID: trusted-router
         run: scripts/deploy/retire_settle_outbox_hot_index.sh
+
+      - name: Sweep staged-probe tags from never-ramped regions
+        if: ${{ failure() || cancelled() }}
+        # A warmed-but-never-ramped candidate keeps the staged-probe tag, and
+        # the tag keeps its baked revision minimum allocated at 0% traffic —
+        # paid instances that survive until some future deploy reconciles the
+        # tag. Ramps remove the tag themselves; every abort path lands here.
+        # Removal is idempotent, and a region whose ramp already cleaned up is
+        # a no-op.
+        run: |
+          for region in us-central1 europe-west4 us-east4 southamerica-east1; do
+            gcloud run services update-traffic "trusted-router" \
+              --region "$region" --project "$PROJECT_ID" \
+              --remove-tags staged-probe --quiet \
+              && echo "swept $region" || echo "sweep $region: nothing to remove or call failed (non-fatal)"
+          done
+
+      - name: Report full convergence timing
+        # Observability only, after all traffic has moved: a metrics
+        # formatting problem must never turn a converged deploy red or block
+        # the companion job behind it.
+        continue-on-error: true
+        if: ${{ success() }}
+        env:
+          MUTEX_CREATED_AT: ${{ needs.deploy.outputs.TR_DEPLOY_MUTEX_CREATED_AT }}
+          PRIMARY_LIVE_SECONDS: ${{ needs.deploy.outputs.primary_live_seconds }}
+        run: |
+          set -euo pipefail
+          full_convergence_seconds="$(python3 - "${MUTEX_CREATED_AT}" <<'PY'
+          from datetime import datetime, timezone
+          import sys
+
+          raw = sys.argv[1]
+          acquired = datetime.fromisoformat(
+              raw[:-1] + "+00:00" if raw.endswith("Z") else raw
+          )
+          if acquired.tzinfo is None:
+              raise SystemExit("mutex created_at must include a timezone")
+          print(max(0, int((datetime.now(timezone.utc) - acquired).total_seconds())))
+          PY
+          )"
+          if [[ ! "${PRIMARY_LIVE_SECONDS}" =~ ^[0-9]+$ ]]; then
+            echo "::error::primary-live timing is missing or invalid"
+            exit 1
+          fi
+
+          metric_line="deploy.full_convergence_seconds=${full_convergence_seconds} primary_live_seconds=${PRIMARY_LIVE_SECONDS}"
+          echo "================================================================"
+          echo "${metric_line}"
+          echo "================================================================"
+          {
+            echo "## Deployment convergence"
+            echo
+            echo "- \`deploy.full_convergence_seconds=${full_convergence_seconds}\`"
+            echo "- \`primary_live_seconds=${PRIMARY_LIVE_SECONDS}\`"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+          payload="$(jq -cn \
+            --arg event "deploy.full_convergence" \
+            --arg sha "${SHA}" \
+            --arg run_id "${GITHUB_RUN_ID}" \
+            --argjson full_convergence_seconds "${full_convergence_seconds}" \
+            --argjson primary_live_seconds "${PRIMARY_LIVE_SECONDS}" \
+            '{event: $event, source_commit: $sha, github_run_id: $run_id,
+              full_convergence_seconds: $full_convergence_seconds,
+              primary_live_seconds: $primary_live_seconds}')"
+          if ! gcloud logging write tr-deploy-metrics "${payload}" \
+              --project="${PROJECT_ID}" --severity=NOTICE --payload-type=json; then
+            echo "::warning::failed to write deploy convergence metadata to Cloud Logging"
+          fi
 
       - name: Release production deployment mutex
         if: always()

--- a/scripts/deploy/deploy_mutex.sh
+++ b/scripts/deploy/deploy_mutex.sh
@@ -142,6 +142,8 @@ deploy_mutex_acquire() {
     printf 'TR_DEPLOY_MUTEX_OPERATION=%s\n' "$TR_DEPLOY_MUTEX_OPERATION"
     printf 'TR_DEPLOY_MUTEX_GENERATION=%s\n' \
       "${TR_DEPLOY_MUTEX_GENERATION:-}"
+    printf 'TR_DEPLOY_MUTEX_CREATED_AT=%s\n' \
+      "${TR_DEPLOY_MUTEX_CREATED_AT:-}"
     return 0
   fi
 
@@ -324,12 +326,14 @@ deploy_mutex_acquire() {
 
   export TR_DEPLOY_MUTEX_OPERATION="$operation_id"
   export TR_DEPLOY_MUTEX_GENERATION="$generation"
+  export TR_DEPLOY_MUTEX_CREATED_AT="$created_at"
   DEPLOY_MUTEX_SCOPE_DEPTH=$((${DEPLOY_MUTEX_SCOPE_DEPTH:-0} + 1))
   DEPLOY_MUTEX_SCOPE_OWNS_LOCK=1
   _deploy_mutex_log \
     "deploy_mutex.acquired cloud=${cloud} owner=${owner} operation_id=${operation_id} generation=${generation} created_at=${created_at} expires_at=${expires_at} ttl_seconds=${ttl_seconds} tool=${tool}"
   printf 'TR_DEPLOY_MUTEX_OPERATION=%s\n' "$operation_id"
   printf 'TR_DEPLOY_MUTEX_GENERATION=%s\n' "$generation"
+  printf 'TR_DEPLOY_MUTEX_CREATED_AT=%s\n' "$created_at"
 }
 
 deploy_mutex_release() {
@@ -380,7 +384,8 @@ deploy_mutex_release() {
   # expire. Leaving these exported would make a LATER acquire in this same
   # shell take the reentrant fast path and "hold" a lock that no longer
   # exists — a manual deploy running with no lock at all.
-  unset TR_DEPLOY_MUTEX_OPERATION TR_DEPLOY_MUTEX_GENERATION
+  unset TR_DEPLOY_MUTEX_OPERATION TR_DEPLOY_MUTEX_GENERATION \
+    TR_DEPLOY_MUTEX_CREATED_AT
   DEPLOY_MUTEX_SCOPE_DEPTH=0
   DEPLOY_MUTEX_SCOPE_OWNS_LOCK=0
   return 0

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -20,8 +20,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/_lib.sh"
 # shellcheck source=scripts/deploy/deploy_mutex.sh
 source "${SCRIPT_DIR}/deploy_mutex.sh"
+# shellcheck source=scripts/deploy/_cloud_run_revision_probe.sh
+source "${SCRIPT_DIR}/_cloud_run_revision_probe.sh"
 # shellcheck source=scripts/deploy/regional_quota_rollout.sh
 source "${SCRIPT_DIR}/regional_quota_rollout.sh"
+
+WARM_PROBE_TAG="staged-probe"
+WARM_PROBE_REGIONS=()
+WARM_PROBE_CLEANUP_REQUIRED=0
 
 release_rollout_deploy_mutex() {
   local rollout_status=$?
@@ -29,12 +35,31 @@ release_rollout_deploy_mutex() {
   # until its TTL.
   trap '' INT TERM
   trap - EXIT
+  # A failed no-traffic warm must not leave its immutable revision minimum
+  # activated by a tag. Once untagged and absent from the traffic split, Cloud
+  # Run allocates zero instances to the failed candidate.
+  if [ "$rollout_status" -ne 0 ] &&
+     [ "$WARM_PROBE_CLEANUP_REQUIRED" -eq 1 ]; then
+    local cleanup_region
+    for cleanup_region in "${WARM_PROBE_REGIONS[@]}"; do
+      if ! cloud_run_probe_tag_remove \
+          "$SERVICE" "$cleanup_region" "$PROJECT_ID" "$WARM_PROBE_TAG"; then
+        log "CRITICAL: failed warm left ${WARM_PROBE_TAG} cleanup required in ${cleanup_region}"
+      fi
+    done
+  fi
   if [ "${DEPLOY_MUTEX_SCOPE_OWNS_LOCK:-0}" -eq 1 ]; then
     deploy_mutex_release
   fi
   exit "$rollout_status"
 }
 trap release_rollout_deploy_mutex EXIT
+# Funnel signals through EXIT: a SIGTERM from workflow cancellation (or Ctrl-C
+# on a manual run) must still run the trap, which now also owns removing the
+# staged-probe tag from a failed warm — a tagged candidate keeps its baked
+# revision minimum allocated at 0% traffic, which is paid capacity.
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 # The workflow exports its outer lock through GITHUB_ENV. A direct operator
 # invocation has no such operation and owns this script-level scope instead.
@@ -734,11 +759,29 @@ deploy_one_region() {
   prune_failed_revisions "$target" >>"$logfile" 2>&1 || true
   # A global override wins. Otherwise use the per-region service minimum;
   # unknown warm regions retain one instance and unknown cold regions scale to
-  # zero. Service-level minimums remain allocated while staged revisions split
-  # traffic, unlike revision-level minimums which can double or disappear.
+  # zero.
   local min_instances="${TR_CLOUD_RUN_MIN_INSTANCES:-}"
   if [ -z "$min_instances" ]; then
     min_instances="$(cloud_run_min_instances_for_region "$target")"
+  fi
+  local revision_min_instances="default"
+  if [ "${TR_DEPLOY_NO_TRAFFIC:-0}" = "1" ]; then
+    # Cloud Run revisions are immutable: clearing a temporary revision minimum
+    # would create a second cold revision and recreate the 100% cutover stall.
+    # Instead the candidate carries the same minimum as the existing service.
+    # The probe tag assigned below activates it at 0% traffic. Cloud Run uses
+    # the larger (not the sum) of service/revision minimums, so after convergence
+    # capacity is still the original service minimum. On rollback, removing the
+    # tag and traffic reference deactivates this revision minimum completely.
+    revision_min_instances="$min_instances"
+    # CAVEAT (review F5): this bakes today's service minimum into the revision
+    # forever — effective capacity is max(service, revision), so LOWERING a
+    # region's TR_CLOUD_RUN_MIN_INSTANCES_BY_REGION later changes nothing
+    # until the next deploy replaces the serving revision. Capacity
+    # reductions therefore require a redeploy to take effect. The max-not-sum
+    # and tag-activation semantics are platform behavior asserted here, not
+    # testable against stubs — verify billing once after the first prod run.
+    log "capacity before ${target}: service min=${min_instances}; candidate revision min=${revision_min_instances}"
   fi
   # /chat and /synth stream through /chat-proxy/v1 for browser CORS.
   # Synth can legitimately take several model calls before final output, so
@@ -751,7 +794,7 @@ deploy_one_region() {
       --memory "${TR_CLOUD_RUN_MEMORY:-1Gi}" \
       --concurrency "$TR_CLOUD_RUN_CONCURRENCY" \
       --min "$min_instances" \
-      --min-instances default \
+      --min-instances "$revision_min_instances" \
       --timeout "${TR_CLOUD_RUN_TIMEOUT_SECONDS:-300}" \
       --network "${TR_CLOUD_RUN_NETWORK:-default}" \
       --subnet "${TR_CLOUD_RUN_SUBNET:-default}" \
@@ -844,6 +887,45 @@ latest_ready_revision_for_region() {
     --format='value(metadata.name,status.conditions[0].status)' 2>/dev/null \
     | awk '$2 == "True" { print $1; exit }'
 }
+
+warm_no_traffic_candidate() {
+  local target="$1"
+  local revision="$2"
+  local min_instances="$3"
+  local base_url
+
+  # The tag mutation itself is traffic-free. Mark cleanup required before the
+  # call because a failed reconciliation can still have applied the tag.
+  WARM_PROBE_REGIONS+=("$target")
+  WARM_PROBE_CLEANUP_REQUIRED=1
+  log "assigning ${WARM_PROBE_TAG} to ${revision} during the no-traffic warm"
+  cloud_run_probe_tag_reconcile \
+    "$SERVICE" "$target" "$PROJECT_ID" "$WARM_PROBE_TAG" "$revision"
+  base_url="$(cloud_run_probe_tagged_base_url \
+    "$SERVICE" "$target" "$PROJECT_ID" "$WARM_PROBE_TAG" "$revision")"
+  # The revision minimum is activated by the tag. A direct readiness request
+  # proves the tagged route has reached a started candidate before this warm
+  # process reports success; it never moves production traffic.
+  curl -fsS --max-time 30 --retry 5 --retry-all-errors \
+    "${base_url}/ready" >/dev/null
+  log "capacity after ${target} warm: ${revision} ready at revision min=${min_instances}; service min unchanged"
+}
+
+if [ "${TR_DEPLOY_NO_TRAFFIC:-0}" = "1" ]; then
+  for warm_target in "${TARGETS[@]}"; do
+    warm_revision="$(latest_ready_revision_for_region "$warm_target")"
+    if [ -z "$warm_revision" ]; then
+      echo "ERROR: could not find warmed Ready revision for ${warm_target}" >&2
+      exit 1
+    fi
+    warm_min_instances="${TR_CLOUD_RUN_MIN_INSTANCES:-}"
+    if [ -z "$warm_min_instances" ]; then
+      warm_min_instances="$(cloud_run_min_instances_for_region "$warm_target")"
+    fi
+    warm_no_traffic_candidate \
+      "$warm_target" "$warm_revision" "$warm_min_instances"
+  done
+fi
 
 if [ "${TR_DEPLOY_NO_TRAFFIC:-0}" != "1" ]; then
   # Defense against a real 2026-06-05 rollout bug: Cloud Run created Ready

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -77,9 +77,9 @@ elif [ -n "${TRUST_FILE_URL:-}" ]; then
   TRUST_JSON="$(curl -fsSL --max-time 10 "$TRUST_FILE_URL" 2>/dev/null || true)"
 fi
 if [ -n "$TRUST_JSON" ]; then
-  TRUST_SOURCE_COMMIT="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("source_commit", ""))' <<<"$TRUST_JSON")"
-  TRUST_IMAGE_REFERENCE="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("image_reference", ""))' <<<"$TRUST_JSON")"
-  TRUST_IMAGE_DIGEST="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("image_digest", ""))' <<<"$TRUST_JSON")"
+  TRUST_SOURCE_COMMIT="$(python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("source_commit", "") if isinstance(d, dict) else "")' <<<"$TRUST_JSON")"
+  TRUST_IMAGE_REFERENCE="$(python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("image_reference", "") if isinstance(d, dict) else "")' <<<"$TRUST_JSON")"
+  TRUST_IMAGE_DIGEST="$(python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("image_digest", "") if isinstance(d, dict) else "")' <<<"$TRUST_JSON")"
 fi
 
 

--- a/scripts/deploy/staged_traffic.sh
+++ b/scripts/deploy/staged_traffic.sh
@@ -30,15 +30,29 @@ LEGACY_PROBE_RETRY_SECONDS="${TR_LEGACY_PROBE_RETRY_SECONDS:-2}"
 LEGACY_PROBE_TAG="staged-probe"
 LEGACY_PROBE_TAG_READY=0
 LEGACY_PROBE_TAG_CLEANUP_REQUIRED=0
+WATCHDOG_PID=""
+WATCHDOG_GATE_DIR=""
+WATCHDOG_GATE_FILE=""
+FINAL_BASELINE_PID=""
 
 log() { echo "[staged-traffic ${REGION}] $*"; }
 
 configure_probe_tag() {
-  log "tagging ${NEW_REV} for a revision-direct regional probe"
+  local resolved
   # From this point onward the fixed name belongs to this invocation. Cleanup
   # is required even when reconciliation fails, because the pre-existing tag
   # may still point at an older rollout.
   LEGACY_PROBE_TAG_CLEANUP_REQUIRED=1
+  if resolved="$(cloud_run_probe_tag_revision \
+      "$SERVICE" "$REGION" "$PROJECT_ID" "$LEGACY_PROBE_TAG")" &&
+     [ "$resolved" = "$NEW_REV" ]; then
+    # rollout.sh normally assigned this during the no-traffic warm. Keep this
+    # ramp-time path as a cheap idempotent verification for direct/manual use.
+    log "probe tag already resolves to warmed revision ${NEW_REV}"
+    LEGACY_PROBE_TAG_READY=1
+    return 0
+  fi
+  log "tagging ${NEW_REV} for a revision-direct regional probe"
   if cloud_run_probe_tag_reconcile \
       "$SERVICE" "$REGION" "$PROJECT_ID" "$LEGACY_PROBE_TAG" "$NEW_REV"; then
     LEGACY_PROBE_TAG_READY=1
@@ -65,6 +79,8 @@ cleanup_staged_traffic() {
   # leaking the mutex until its TTL. Finish cleanup uninterrupted.
   trap '' INT TERM
   trap - EXIT
+  stop_watchdog
+  stop_final_baseline
   if ! cleanup_probe_tag && [ "$staged_status" -eq 0 ]; then
     staged_status=1
   fi
@@ -72,6 +88,29 @@ cleanup_staged_traffic() {
     deploy_mutex_release
   fi
   exit "$staged_status"
+}
+
+stop_watchdog() {
+  if [ -n "$WATCHDOG_PID" ] && kill -0 "$WATCHDOG_PID" 2>/dev/null; then
+    kill "$WATCHDOG_PID" 2>/dev/null || true
+    wait "$WATCHDOG_PID" 2>/dev/null || true
+  fi
+  WATCHDOG_PID=""
+  if [ -n "$WATCHDOG_GATE_DIR" ]; then
+    rm -f "$WATCHDOG_GATE_FILE"
+    rmdir "$WATCHDOG_GATE_DIR" 2>/dev/null || true
+  fi
+  WATCHDOG_GATE_DIR=""
+  WATCHDOG_GATE_FILE=""
+}
+
+stop_final_baseline() {
+  if [ -n "$FINAL_BASELINE_PID" ] &&
+     kill -0 "$FINAL_BASELINE_PID" 2>/dev/null; then
+    kill "$FINAL_BASELINE_PID" 2>/dev/null || true
+    wait "$FINAL_BASELINE_PID" 2>/dev/null || true
+  fi
+  FINAL_BASELINE_PID=""
 }
 
 # The workflow owns one mutex across every regional ramp. A direct manual
@@ -190,17 +229,91 @@ probe_legacy_surface_or_rollback() {
   log "legacy surface probe passed after ${stage_pct}% shift at ${base_url} (console=${console_code}, auth/session=${session_code})"
 }
 
-watch_or_rollback() {
+start_watchdog() {
   local stage_pct="$1"
-  probe_legacy_surface_or_rollback "$stage_pct"
-  log "watching ${REGION} for 1 min after ${stage_pct}% shift"
-  if ! python3 "${SCRIPT_DIR}/watchdog.py" \
+  WATCHDOG_GATE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tr-watchdog-gate.XXXXXX")"
+  WATCHDOG_GATE_FILE="${WATCHDOG_GATE_DIR}/traffic-shift-complete"
+  # watchdog.py's default 30-second baseline grace was the serialized startup
+  # seen in deploy logs. Start it before update-traffic so grace + baseline
+  # capture overlap Cloud Run routing, while --start-gate-file keeps every
+  # configured polling minute strictly after the shift completes.
+  log "starting watchdog baseline concurrently with ${stage_pct}% traffic shift"
+  python3 "${SCRIPT_DIR}/watchdog.py" \
       --regions "$REGION" \
       --duration-min 1 \
       --rollback-after 1 \
-      --slo-class "$WATCHDOG_SLO_CLASS"; then
+      --slo-class "$WATCHDOG_SLO_CLASS" \
+      --start-gate-file "$WATCHDOG_GATE_FILE" &
+  WATCHDOG_PID=$!
+}
+
+shift_and_watch() {
+  local stage_pct="$1"
+  local watchdog_status
+  start_watchdog "$stage_pct"
+  if ! shift_traffic "$stage_pct"; then
+    stop_watchdog
+    return 1
+  fi
+  : >"$WATCHDOG_GATE_FILE"
+  probe_legacy_surface_or_rollback "$stage_pct"
+  log "watching ${REGION} for 1 min after ${stage_pct}% shift"
+  if wait "$WATCHDOG_PID"; then
+    watchdog_status=0
+  else
+    watchdog_status=$?
+  fi
+  WATCHDOG_PID=""
+  rm -f "$WATCHDOG_GATE_FILE"
+  rmdir "$WATCHDOG_GATE_DIR" 2>/dev/null || true
+  WATCHDOG_GATE_DIR=""
+  WATCHDOG_GATE_FILE=""
+  if [ "$watchdog_status" -ne 0 ]; then
     rollback_to_old "synthetics tripped at ${stage_pct}%"
     exit 1
+  fi
+}
+
+start_final_baseline() {
+  local output_file="${TR_STAGED_WATCHDOG_BASELINE_FILE:-}"
+  [ -n "$output_file" ] || return 0
+  rm -f "$output_file"
+  log "starting final-canary baseline concurrently with 100% traffic shift"
+  if [ "${TR_STAGED_WATCHDOG_SKIP_BASELINE:-0}" = "1" ]; then
+    python3 "${SCRIPT_DIR}/watchdog.py" \
+      --regions "$REGION" \
+      --duration-min 0 \
+      --slo-class "$WATCHDOG_SLO_CLASS" \
+      --baseline-output "$output_file" \
+      --skip-baseline \
+      --baseline-grace-sec 0 &
+  else
+    python3 "${SCRIPT_DIR}/watchdog.py" \
+      --regions "$REGION" \
+      --duration-min 0 \
+      --slo-class "$WATCHDOG_SLO_CLASS" \
+      --baseline-output "$output_file" &
+  fi
+  FINAL_BASELINE_PID=$!
+}
+
+finish_final_baseline() {
+  local output_file="${TR_STAGED_WATCHDOG_BASELINE_FILE:-}"
+  local baseline_status
+  [ -n "$FINAL_BASELINE_PID" ] || return 0
+  if wait "$FINAL_BASELINE_PID"; then
+    baseline_status=0
+  else
+    baseline_status=$?
+  fi
+  FINAL_BASELINE_PID=""
+  if [ "$baseline_status" -ne 0 ] || [ ! -s "$output_file" ]; then
+    if [ -n "$OLD_REV" ]; then
+      rollback_to_old "final canary baseline capture failed"
+    else
+      log "final canary baseline capture failed; no prior revision exists to restore"
+    fi
+    return 1
   fi
 }
 
@@ -209,24 +322,32 @@ if [ -z "$OLD_REV" ]; then
   # split traffic with. Skip staging; flip straight to 100% on the new
   # revision so the deploy completes. Subsequent deploys stage normally.
   log "no prior revision recorded; flipping straight to 100% ${NEW_REV}"
-  gcloud run services update-traffic "$SERVICE" \
-    --region="$REGION" --project="$PROJECT_ID" \
-    --to-revisions="${NEW_REV}=100" \
-    --quiet
+  start_final_baseline
+  if ! gcloud run services update-traffic "$SERVICE" \
+      --region="$REGION" --project="$PROJECT_ID" \
+      --to-revisions="${NEW_REV}=100" \
+      --quiet; then
+    stop_final_baseline
+    exit 1
+  fi
+  finish_final_baseline
   exit 0
 fi
 
 # 10% canary
 configure_probe_tag
-shift_traffic 10
-watch_or_rollback 10
+shift_and_watch 10
 
 # 50% midstage
-shift_traffic 50
-watch_or_rollback 50
+shift_and_watch 50
 
 # Final cut over
-shift_traffic 100
+start_final_baseline
+if ! shift_traffic 100; then
+  stop_final_baseline
+  exit 1
+fi
+finish_final_baseline
 probe_legacy_surface_or_rollback 100
 if ! cleanup_probe_tag; then
   exit 1

--- a/scripts/deploy/watchdog.py
+++ b/scripts/deploy/watchdog.py
@@ -43,6 +43,7 @@ import sys
 import time
 import urllib.request
 from collections.abc import Iterable
+from pathlib import Path
 
 # Worst-of: the per-region effective_status is the worst over its checks.
 # `unknown` is treated as severity 0 for ranking but reported separately
@@ -142,6 +143,50 @@ def write_output(key: str, value: str) -> None:
         print(f"::output::{key}={value}", flush=True)
 
 
+def wait_for_start_gate(path: str, timeout_sec: int) -> None:
+    """Wait until the traffic-shift caller releases the polling window.
+
+    Baseline grace and capture happen before this wait, so callers can overlap
+    that fixed startup cost with a Cloud Run traffic update. The minute loop
+    remains behind the gate, preserving the complete configured watch window
+    after the traffic update has finished.
+    """
+    gate = Path(path)
+    deadline = time.monotonic() + timeout_sec
+    while not gate.exists():
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"watchdog start gate was not released within {timeout_sec}s: {gate}"
+            )
+        time.sleep(0.1)
+
+
+def read_baseline(path: str, regions: Iterable[str]) -> dict[str, str]:
+    """Read a baseline snapshot captured by an earlier watchdog process."""
+    with Path(path).open(encoding="utf-8") as handle:
+        document = json.load(handle)
+    if not isinstance(document, dict):
+        raise ValueError("baseline document must be an object")
+    baseline: dict[str, str] = {}
+    for region in regions:
+        status = document.get(region, "unknown")
+        normalized = normalize_watchdog_status(status)
+        if normalized == "unknown" and status != "unknown":
+            raise ValueError(f"invalid baseline status for {region}: {status!r}")
+        baseline[region] = normalized
+    return baseline
+
+
+def write_baseline(path: str, baseline: dict[str, str]) -> None:
+    """Atomically persist a baseline for a post-shift watchdog invocation."""
+    destination = Path(path)
+    temporary = destination.with_name(destination.name + f".tmp.{os.getpid()}")
+    with temporary.open("w", encoding="utf-8") as handle:
+        json.dump(baseline, handle, separators=(",", ":"), sort_keys=True)
+        handle.write("\n")
+    temporary.replace(destination)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--duration-min", type=int, default=10)
@@ -188,7 +233,40 @@ def main() -> int:
             "regardless of pre-existing badness."
         ),
     )
+    parser.add_argument(
+        "--start-gate-file",
+        default="",
+        help=(
+            "Optional path that must exist before the minute polling window starts. "
+            "Baseline grace/capture still runs immediately, allowing staged traffic "
+            "updates to overlap the 30-second startup cost."
+        ),
+    )
+    parser.add_argument(
+        "--start-gate-timeout-sec",
+        type=int,
+        default=600,
+        help="Maximum wait for --start-gate-file before failing closed.",
+    )
+    parser.add_argument(
+        "--baseline-input",
+        default="",
+        help=(
+            "Read a baseline captured before the traffic shift instead of paying "
+            "the baseline grace in this process. Ignored with --skip-baseline."
+        ),
+    )
+    parser.add_argument(
+        "--baseline-output",
+        default="",
+        help=(
+            "Atomically write the captured baseline for a later watchdog process. "
+            "Use --duration-min 0 for a baseline-only invocation."
+        ),
+    )
     args = parser.parse_args()
+    if args.baseline_input and args.baseline_output:
+        parser.error("--baseline-input and --baseline-output are mutually exclusive")
 
     regions = [r.strip() for r in args.regions.split(",") if r.strip()]
     consecutive_down = {region: 0 for region in regions}
@@ -203,13 +281,21 @@ def main() -> int:
     # blame the deploy for them).
     baseline_down: set[str] = set()
     if not args.skip_baseline:
-        if args.baseline_grace_sec > 0:
-            time.sleep(args.baseline_grace_sec)
-        baseline_snapshot = fetch_per_region(
-            args.status_url,
-            regions,
-            slo_class=args.slo_class,
-        )
+        if args.baseline_input:
+            try:
+                baseline_snapshot = read_baseline(args.baseline_input, regions)
+            except (OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
+                print(f"watchdog: invalid baseline input: {exc}", file=sys.stderr)
+                write_output("rollback_regions", ",".join(sorted(regions)))
+                return 1
+        else:
+            if args.baseline_grace_sec > 0:
+                time.sleep(args.baseline_grace_sec)
+            baseline_snapshot = fetch_per_region(
+                args.status_url,
+                regions,
+                slo_class=args.slo_class,
+            )
         baseline_down = {r for r, s in baseline_snapshot.items() if s == "down"}
         if baseline_down:
             print(
@@ -217,6 +303,30 @@ def main() -> int:
                 f"{sorted(baseline_down)}",
                 flush=True,
             )
+    else:
+        baseline_snapshot = {region: "unknown" for region in regions}
+
+    if args.baseline_output:
+        try:
+            write_baseline(args.baseline_output, baseline_snapshot)
+        except OSError as exc:
+            print(f"watchdog: could not write baseline output: {exc}", file=sys.stderr)
+            write_output("rollback_regions", ",".join(sorted(regions)))
+            return 1
+
+    if args.start_gate_file:
+        if args.start_gate_timeout_sec <= 0:
+            parser.error("--start-gate-timeout-sec must be positive")
+        print(
+            "watchdog: baseline ready; waiting for traffic shift to complete",
+            flush=True,
+        )
+        try:
+            wait_for_start_gate(args.start_gate_file, args.start_gate_timeout_sec)
+        except TimeoutError as exc:
+            print(f"watchdog: {exc}", file=sys.stderr, flush=True)
+            write_output("rollback_regions", ",".join(sorted(regions)))
+            return 1
 
     print(
         f"watchdog: polling {args.status_url} every 60s for {args.duration_min} min; "

--- a/tests/deploy_script_harness.py
+++ b/tests/deploy_script_harness.py
@@ -1734,11 +1734,26 @@ class DeployScriptHarness:
             f"{(extra_env or {}).get('HARNESS_PROBE_TAG_REMOVE_FAILURES', '0')}\n"
         )
 
+        trust_fixture = self.root / "trust-release.json"
+        if not trust_fixture.exists():
+            trust_fixture.write_text(
+                '{"source_commit": "harness-trust-commit", '
+                '"image_reference": "harness.invalid/trusted-router:harness", '
+                '"image_digest": "sha256:%s"}' % ("0" * 64),
+                encoding="utf-8",
+            )
         env = {
             "PATH": str(self.bin),
             "HOME": str(home),
             "TMPDIR": str(tmp),
             "LANG": "C",
+            # rollout.sh's TRUST_FILE default is an operator-laptop path
+            # (_lib.sh): present on that machine, absent on CI, where the
+            # fallback curl hits the stub and returns a bare status code
+            # that json-parses to an int. Pin a harness-owned fixture so
+            # the test is identical on every machine.
+            "TRUST_FILE": str(trust_fixture),
+            "TRUST_FILE_URL": "",
             "HARNESS_ARGV_LOG": str(argv_log),
             "HARNESS_FIXTURES": str(fixtures_file),
             "HARNESS_FAILURES": str(failures_file),

--- a/tests/deploy_script_harness.py
+++ b/tests/deploy_script_harness.py
@@ -1199,6 +1199,60 @@ class ScriptFixture:
 
 
 SCRIPT_FIXTURES: dict[str, ScriptFixture] = {
+    "scripts/deploy/rollout.sh": ScriptFixture(
+        env={
+            "TR_ALLOW_DEPLOYED_COMBINED_SURFACE": "true",
+            "TR_DEPLOY_MUTEX_OPERATION": "harness-rollout-operation",
+            "TR_DEPLOY_MUTEX_GENERATION": "1",
+            "TR_DEPLOY_TARGET_REGIONS": "us-central1",
+            "TR_DEPLOY_NO_TRAFFIC": "1",
+            "TR_DEPLOY_RECONCILE_LB": "0",
+            "IMAGE_TAG": "harness-candidate",
+            "TR_REQUEST_RECORD_WRITE_MODE": "typed",
+            "TR_STORAGE_BACKEND": "spanner-bigtable",
+            "TR_GENERATION_RECORDS_ENABLED": "false",
+            "TR_BIGTABLE_MIRROR_WRITES_ENABLED": "true",
+            "TR_ANALYTICS_READ_MODE": "bigtable",
+            "TR_REGIONAL_QUOTA_LEASES_ENABLED": "false",
+            "TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED": "false",
+            # Reuse the stateful legacy-service tag behavior in the harness.
+            "HARNESS_PUBLIC_SURFACE_SMOKE": "1",
+        },
+        responses=(
+            (
+                r"run revisions describe trusted-router-active .*--format=json",
+                json.dumps(
+                    {
+                        "spec": {
+                            "containers": [
+                                {
+                                    "env": [
+                                        {
+                                            "name": "TR_REGIONAL_QUOTA_LEASES_ENABLED",
+                                            "value": "false",
+                                        },
+                                        {
+                                            "name": "TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED",
+                                            "value": "false",
+                                        },
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    separators=(",", ":"),
+                ),
+            ),
+            (
+                r"run revisions list .*--limit=10",
+                "trusted-router-candidate True",
+            ),
+            (
+                r"run services describe trusted-router .*status.url",
+                "https://trusted-router-hash-uc.a.run.app",
+            ),
+        ),
+    ),
     "scripts/deploy/internal_surface.sh": ScriptFixture(
         env={"HARNESS_INTERNAL_SURFACE_SMOKE": "1"},
         responses=(

--- a/tests/test_deploy_mutex.py
+++ b/tests/test_deploy_mutex.py
@@ -420,6 +420,9 @@ def test_cloud_metadata_is_written_and_printed_in_status(
 
     assert acquired.returncode == 0, acquired.stderr
     assert mutex.record()["cloud"] == "azure"
+    assert _exported(acquired.stdout)["TR_DEPLOY_MUTEX_CREATED_AT"] == mutex.record()[
+        "created_at"
+    ]
     assert "deploy_mutex.acquired cloud=azure" in acquired.stderr
 
     status = mutex.run("status", "manual:inspector@test")
@@ -499,6 +502,9 @@ def test_workflow_and_manual_scripts_share_the_mutex_scope() -> None:
         secondary_job:secondary_release
     ]
     assert "needs.deploy.outputs.TR_DEPLOY_MUTEX_GENERATION" in workflow[
+        secondary_job:secondary_release
+    ]
+    assert "needs.deploy.outputs.TR_DEPLOY_MUTEX_CREATED_AT" in workflow[
         secondary_job:secondary_release
     ]
     assert "if: always()" in workflow[secondary_release : secondary_release + 180]

--- a/tests/test_deploy_script_execution.py
+++ b/tests/test_deploy_script_execution.py
@@ -214,6 +214,67 @@ def _initialize_bake_harness_repo(harness: DeployScriptHarness) -> str:
     ).stdout.strip()
 
 
+def test_gcp_no_traffic_warm_preprovisions_and_tags_candidate(
+    harness: DeployScriptHarness,
+) -> None:
+    run = harness.run("scripts/deploy/rollout.sh")
+    assert run.returncode == 0, summarise(run)
+
+    deploy = next(
+        call
+        for call in run.calls
+        if call[0:4] == ["gcloud", "--project", "quill-cloud-proxy", "run"]
+        and call[4:7] == ["deploy", "trusted-router", "--region"]
+    )
+    assert deploy[deploy.index("--min") + 1] == "2"
+    assert deploy[deploy.index("--min-instances") + 1] == "2"
+    assert "--no-traffic" in deploy
+
+    tag_index = next(
+        index
+        for index, call in enumerate(run.calls)
+        if "--update-tags=staged-probe=trusted-router-candidate" in call
+    )
+    warm_index = next(
+        index
+        for index, call in enumerate(run.calls)
+        if call[0] == "curl"
+        and call[-1]
+        == "https://staged-probe---trusted-router-hash-uc.a.run.app/ready"
+    )
+    assert tag_index < warm_index
+    assert not any("--remove-tags=staged-probe" in call for call in run.calls)
+
+
+def test_gcp_failed_candidate_warm_restores_zero_traffic_capacity(
+    harness: DeployScriptHarness,
+) -> None:
+    run = harness.run(
+        "scripts/deploy/rollout.sh",
+        extra_env={"HARNESS_PUBLIC_SMOKE_TRANSPORT_PATH": "/ready"},
+    )
+    assert run.returncode != 0
+
+    deploy = next(
+        call
+        for call in run.calls
+        if call[0:4] == ["gcloud", "--project", "quill-cloud-proxy", "run"]
+        and call[4:7] == ["deploy", "trusted-router", "--region"]
+    )
+    assert deploy[deploy.index("--min-instances") + 1] == "2"
+    tag_index = next(
+        index
+        for index, call in enumerate(run.calls)
+        if "--update-tags=staged-probe=trusted-router-candidate" in call
+    )
+    restore_index = next(
+        index
+        for index, call in enumerate(run.calls)
+        if "--remove-tags=staged-probe" in call
+    )
+    assert tag_index < restore_index
+
+
 @pytest.mark.parametrize(
     ("script", "cloud", "mutation_prefix"),
     (

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -170,7 +170,9 @@ def test_all_attested_control_plane_regions_remain_warm() -> None:
     assert 'TR_SPANNER_POOL_SIZE="${TR_SPANNER_POOL_SIZE:-8}"' in library
     assert '--concurrency "$TR_CLOUD_RUN_CONCURRENCY"' in rollout
     assert '--min "$min_instances"' in rollout
-    assert '--min-instances default' in rollout
+    assert 'local revision_min_instances="default"' in rollout
+    assert 'revision_min_instances="$min_instances"' in rollout
+    assert '--min-instances "$revision_min_instances"' in rollout
     assert '"TR_SPANNER_POOL_SIZE=${TR_SPANNER_POOL_SIZE}"' in rollout
 
 

--- a/tests/test_deploy_watchdog.py
+++ b/tests/test_deploy_watchdog.py
@@ -144,6 +144,25 @@ def test_trust_degraded_ranks_with_down_in_severity() -> None:
     assert watchdog.SEVERITY["trust_degraded"] > watchdog.SEVERITY["degraded"]
 
 
+def test_watchdog_baseline_artifact_round_trips_atomically(tmp_path: Path) -> None:
+    watchdog = _load_watchdog()
+    artifact = tmp_path / "baseline.json"
+
+    watchdog.write_baseline(
+        str(artifact),
+        {"us-central1": "up", "europe-west4": "down"},
+    )
+
+    assert watchdog.read_baseline(
+        str(artifact), ["us-central1", "europe-west4", "us-east4"]
+    ) == {
+        "us-central1": "up",
+        "europe-west4": "down",
+        "us-east4": "unknown",
+    }
+    assert not list(tmp_path.glob("baseline.json.tmp.*"))
+
+
 def _run_staged_probe(
     tmp_path: Path,
     *,
@@ -154,6 +173,7 @@ def _run_staged_probe(
     remove_always_fails: bool = False,
     remove_leaves_tag: bool = False,
     traffic_shift_failure_pct: int | None = None,
+    watchdog_exit: int = 0,
 ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
     stub_bin = tmp_path / "bin"
     stub_bin.mkdir()
@@ -225,6 +245,46 @@ printf '%s' "$code"
 if [ "$1" = "-c" ]; then
   exec "$STAGED_REAL_PYTHON" "$@"
 fi
+previous=""
+gate_file=""
+for argument in "$@"; do
+  if [ "$previous" = "baseline-output" ]; then
+    printf '%s\n' '{"us-central1":"up"}' >"$argument"
+    previous=""
+    continue
+  fi
+  if [ "$previous" = "start-gate-file" ]; then
+    gate_file="$argument"
+    previous=""
+    continue
+  fi
+  case "$argument" in
+    --baseline-output) previous="baseline-output" ;;
+    --start-gate-file) previous="start-gate-file" ;;
+    *) previous="" ;;
+  esac
+done
+if [ -n "$gate_file" ]; then
+  # Behave like the real watchdog: block until the shell releases the gate
+  # AFTER its traffic shift, record the ordering, then return the injected
+  # verdict. The harness stubs `sleep` as a no-op, so the bounded wait must
+  # use the REAL python interpreter for actual wall-clock waiting.
+  if ! "$STAGED_REAL_PYTHON" - "$gate_file" <<'PYWAIT'
+import pathlib, sys, time
+gate = pathlib.Path(sys.argv[1])
+deadline = time.monotonic() + 10
+while not gate.exists():
+    if time.monotonic() >= deadline:
+        raise SystemExit(96)
+    time.sleep(0.05)
+PYWAIT
+  then
+    echo "python3 watchdog-stub: gate never released" >>"$STAGED_CALL_LOG"
+    exit 96
+  fi
+  echo "watchdog-stub: gate-released" >>"$STAGED_CALL_LOG"
+  exit "${STAGED_STUB_WATCHDOG_EXIT:-0}"
+fi
 exit 0
 """
     )
@@ -249,8 +309,10 @@ exit 0
             "" if traffic_shift_failure_pct is None else str(traffic_shift_failure_pct)
         ),
         "STAGED_REAL_PYTHON": sys.executable,
+        "STAGED_STUB_WATCHDOG_EXIT": str(watchdog_exit),
         "TR_LEGACY_PROBE_RETRY_SECONDS": "0",
         "TR_PROBE_TAG_REMOVE_RETRY_SECONDS": "0",
+        "TR_STAGED_WATCHDOG_BASELINE_FILE": str(tmp_path / "final-baseline.json"),
         # This helper exercises a traffic ramp nested inside the workflow's
         # already-acquired deployment-mutex scope. Dedicated mutex tests cover
         # direct/manual acquisition against a generation-aware storage stub.
@@ -542,3 +604,63 @@ def test_failed_traffic_shift_restores_the_old_desired_revision(tmp_path: Path) 
     assert any("--to-revisions=old-rev=100" in call for call in traffic_calls)
     assert "ROLLBACK" in run.stdout
     assert "traffic update to 10% failed" in run.stdout
+
+
+
+def test_staged_ramp_rolls_back_when_the_watchdog_reports_unhealthy(
+    tmp_path: Path,
+) -> None:
+    """The backgrounded watchdog's verdict must still fail the ramp.
+
+    Review F6: with the watchdog started before the shift (baseline overlap),
+    its exit code travels through `wait "$WATCHDOG_PID"` instead of a
+    synchronous invocation. If that wait were dropped or its status swallowed,
+    every unhealthy deploy would ramp to 100% green. This runs the REAL
+    staged_traffic.sh with a watchdog stub that honors the gate and then
+    reports unhealthy.
+    """
+    run, calls = _run_staged_probe(
+        tmp_path,
+        console_code="302",
+        session_code="401",
+        watchdog_exit=3,
+    )
+    assert run.returncode != 0
+    rollbacks = [
+        call
+        for call in calls
+        if call.startswith("gcloud run services update-traffic")
+        and "--to-revisions=old-rev=100" in call
+    ]
+    assert rollbacks, "unhealthy watchdog verdict must roll traffic back"
+
+
+def test_watchdog_gate_releases_only_after_the_traffic_shift(
+    tmp_path: Path,
+) -> None:
+    """Baseline overlap must not let the watch window start pre-shift.
+
+    The stub records `watchdog-stub: gate-released` the moment the gate file
+    appears. That marker must come AFTER the step's traffic shift call in the
+    recorded call order — releasing the gate before the shift would let the
+    watch window overlap the shift and effectively shorten the observed
+    post-shift window.
+    """
+    run, calls = _run_staged_probe(
+        tmp_path,
+        console_code="302",
+        session_code="401",
+    )
+    assert run.returncode == 0, run.stderr
+    first_shift = next(
+        index
+        for index, call in enumerate(calls)
+        if call.startswith("gcloud run services update-traffic")
+        and "--to-revisions=new-rev=10" in call
+    )
+    first_gate = next(
+        index for index, call in enumerate(calls) if "gate-released" in call
+    )
+    assert first_gate > first_shift, (
+        "the watchdog gate was released before the first traffic shift"
+    )

--- a/tests/test_deploy_workflow_regions.py
+++ b/tests/test_deploy_workflow_regions.py
@@ -64,7 +64,7 @@ def test_public_snapshot_worker_swap_is_verified_and_rollbackable() -> None:
     assert r'mv \"\$previous_builder\" \"\$builder\"' in script
 
 
-def test_all_regions_warm_in_parallel_before_primary_traffic_moves() -> None:
+def test_all_regions_launch_together_but_only_primary_warm_gates_traffic() -> None:
     workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
     deploy = workflow.split("\n  deploy:\n", 1)[1].split(
         "\n  rollout-secondaries:\n", 1
@@ -75,7 +75,7 @@ def test_all_regions_warm_in_parallel_before_primary_traffic_moves() -> None:
 
     assert "regions=(us-central1 europe-west4 us-east4 southamerica-east1)" in warm
     assert 'if ! TR_DEPLOY_TARGET_REGIONS="${region}"' in warm
-    first_wait = warm.index('if wait "${pids[$idx]}"; then')
+    primary_wait = warm.index('if wait "${pids[0]}"; then')
     for region, reconcile_lb, log_index in (
         ("us-central1", "1", 0),
         ("europe-west4", "0", 1),
@@ -83,21 +83,39 @@ def test_all_regions_warm_in_parallel_before_primary_traffic_moves() -> None:
         ("southamerica-east1", "0", 3),
     ):
         invocation = (
-            f'(warm_region "{region}" "{reconcile_lb}" '
+            f'(run_warm "${{status_files[{log_index}]}}" '
+            f'"{region}" "{reconcile_lb}" '
             f'"${{revision_files[{log_index}]}}") '
             f'>"${{logs[{log_index}]}}" 2>&1 &'
         )
-        assert warm.index(invocation) < first_wait
+        assert warm.index(invocation) < primary_wait
     assert warm.count('pids+=("$!")') == 4
-    assert 'printf \'\\n=== warmup: %s ===\\n\' "${regions[$idx]}"' in warm
-    assert 'cat "${logs[$idx]}"' in warm
-    assert "Regional warmup failed; no traffic moved" in warm
+    assert "secondary-warms.tsv" in warm
+    assert '>>"${secondary_state}"' in warm
+    assert 'printf \'\\n=== warmup: %s ===\\n\' "${regions[0]}"' in warm
+    assert 'cat "${logs[0]}"' in warm
+    assert "us-central1 no-traffic warmup failed; no traffic moved" in warm
     assert "TR_DEPLOY_RECONCILE_LB" in warm
     assert "Only the primary process receives 1" in warm
 
     primary_ramp = deploy.index("- name: Stage traffic 10/50/100 (us-central1)")
     primary_canary = deploy.index("- name: Canary gate — watch us-central1 only")
-    assert first_wait < primary_ramp < primary_canary
+    secondary_wait = deploy.index("- name: Wait for secondary no-traffic warms")
+    assert primary_wait < primary_ramp < primary_canary < secondary_wait
+    collector = deploy[
+        secondary_wait : deploy.index(
+            "- name: Release production deployment mutex after primary-live failure",
+            secondary_wait,
+        )
+    ]
+    assert "if: ${{ always() }}" in collector
+    assert 'kill -0 "${pid}"' in collector
+    assert 'done <"${secondary_state}"' in collector
+    assert 'key="${region//-/_}_revision"' in collector
+    for region in ("europe-west4", "us-east4", "southamerica-east1"):
+        key = region.replace("-", "_") + "_revision"
+        assert f"steps.wait_secondary_warms.outputs.{key}" in deploy
+    assert "no secondary traffic moved" in collector
     assert 'staged_traffic.sh europe-west4' not in deploy
     assert 'staged_traffic.sh us-east4' not in deploy
     assert 'staged_traffic.sh southamerica-east1' not in deploy
@@ -240,10 +258,59 @@ def test_runtime_secret_validation_is_parallel_and_does_not_restore_stale_ses_ke
 def test_shared_load_balancer_is_reconciled_once_per_workflow() -> None:
     workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
 
-    assert workflow.count('(warm_region "us-central1" "1"') == 1
+    assert workflow.count('"us-central1" "1" "${revision_files[0]}"') == 1
     for region in ("europe-west4", "us-east4", "southamerica-east1"):
-        assert workflow.count(f'(warm_region "{region}" "0"') == 1
+        assert workflow.count(f'"{region}" "0"') == 1
     assert 'TR_DEPLOY_RECONCILE_LB="${reconcile_lb}"' in workflow
+
+
+def test_probe_tag_is_hoisted_and_watchdog_baseline_overlaps_traffic_shift() -> None:
+    rollout = (ROOT / "scripts/deploy/rollout.sh").read_text(encoding="utf-8")
+    staged = (ROOT / "scripts/deploy/staged_traffic.sh").read_text(encoding="utf-8")
+
+    assert "warm_no_traffic_candidate" in rollout
+    assert "cloud_run_probe_tag_reconcile" in rollout
+    assert '"${base_url}/ready"' in rollout
+    verify = staged.index("probe tag already resolves to warmed revision")
+    reconcile = staged.index("cloud_run_probe_tag_reconcile")
+    assert verify < reconcile
+
+    watchdog_start = staged.index('python3 "${SCRIPT_DIR}/watchdog.py"')
+    watchdog_background = staged.index("&", watchdog_start)
+    shift = staged.index('shift_traffic "$stage_pct"', watchdog_background)
+    gate = staged.index(': >"$WATCHDOG_GATE_FILE"', shift)
+    wait = staged.index('wait "$WATCHDOG_PID"', gate)
+    assert watchdog_start < watchdog_background < shift < gate < wait
+    assert "--start-gate-file" in staged[watchdog_start:shift]
+    final_baseline = staged.index("start_final_baseline")
+    final_shift = staged.rindex("shift_traffic 100")
+    assert final_baseline < final_shift
+
+    workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
+    assert "final-watchdog-baseline-us-central1.json" in workflow
+    assert (
+        '--baseline-input "${RUNNER_TEMP}/final-watchdog-baseline-us-central1.json"'
+        in workflow
+    )
+    assert '--baseline-input "${watchdog_baseline}"' in workflow
+
+
+def test_full_convergence_metrics_are_reported_before_mutex_release() -> None:
+    workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
+    rollout = workflow.split("\n  rollout-secondaries:\n", 1)[1].split(
+        "\n  public-surface-companion:\n", 1
+    )[0]
+
+    report = rollout.index("- name: Report full convergence timing")
+    release = rollout.index("- name: Release production deployment mutex", report)
+    metric = rollout[report:release]
+    assert report < release
+    assert "if: ${{ success() }}" in metric
+    assert "deploy.full_convergence_seconds=${full_convergence_seconds}" in metric
+    assert "primary_live_seconds=${PRIMARY_LIVE_SECONDS}" in metric
+    assert '>>"$GITHUB_STEP_SUMMARY"' in metric
+    assert "gcloud logging write tr-deploy-metrics" in metric
+    assert "--payload-type=json" in metric
 
 
 def test_mutex_acquire_step_cannot_swallow_a_blocked_exit() -> None:


### PR DESCRIPTION
Approved package (Joseph): cut the measured 41m48 full-convergence wall
by attacking overhead only — every watchdog window, ramp step, and
canary second is unchanged.

## The five fixes, from the profiled logs

1. **Watchdog grace overlaps the shift.** The ~30s baseline startup that
   sat serialized after every one of 9+ shifts now runs DURING the
   shift; a gate file releases the polling loop only after
   `update-traffic` returns, so the full configured window runs
   post-shift by construction.
2. **Capacity pre-warm kills the 100% stall** (3m04 observed). The
   candidate revision carries a revision-level `--min-instances` equal
   to the service `--min`; the probe tag keeps it active at 0% traffic.
   gcloud semantics verified against the real CLI: service min is
   divided among traffic-receiving revisions (exactly why the stall
   existed), effective capacity is max(service, revision) so
   convergence is cost-neutral, and rollback deactivates it — no
   restore step to forget.
3. **Probe-tag setup hoisted into warm** (~45s × 4 regions).
4. **Primary ramps on its own warm** (1m35, not the 3m28 slowest
   secondary); secondary warms continue across step boundaries via
   atomic status files + PIDs, collected by an always() end-of-job wait
   that gates success and feeds the revision outputs.
5. **Every deploy self-reports** `full_convergence_seconds` and
   `primary_live_seconds` — step summary + a structured Cloud Logging
   line (`tr-deploy-metrics`) — so the number that matters is monitored
   always.

## Adversarial round: six findings, all fixed here

- **Stranded pre-warm capacity (MEDIUM):** an aborted workflow left
  tagged candidates holding revision minimums (up to 12 paid instances)
  until some future deploy. rollout.sh gains the INT/TERM→EXIT funnel,
  and both jobs' failure paths sweep `staged-probe` tags from
  never-ramped regions (idempotent).
- Collector TOCTOU (spurious red when a warm finishes between the
  status check and `kill -0`): the status FILE is the truth, re-checked
  after a settle beat.
- Unbounded status poll (PID reuse → generic job timeout): 15-minute
  per-region deadline with a named error.
- Metrics step can no longer redden a converged deploy
  (`continue-on-error`).
- The baked-revision-minimum caveat is documented at the source:
  lowering a region's min now requires a redeploy to take effect, and
  the max-not-sum platform assumption gets one manual billing check
  after the first prod run.
- **Verdict semantics are now executed, not asserted:** the harness
  watchdog stub honors the gate with real wall-clock waits, and two
  behavioral tests prove an unhealthy verdict rolls traffic back and
  the gate releases only after the shift. (Also incidentally exercised:
  the wrong-surface probe rollback, via a misconfigured first draft of
  the test.)

## Expected

~41m48 → **~24-25m** full convergence (primary-live ~9m inside it),
measured by fix 5 on the next real deploy. The pending 3m→1m decision
on per-secondary post-100% watches is worth a further ~6m if taken.

## Verification

ruff · mypy · **6536 passed** full suite · 24/24 watchdog harness
(behavioral) · bash -n + shellcheck clean (pre-existing info notes
only) · YAML parses · gcloud flag semantics verified against the
installed CLI, not memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)