### PR TITLE
Feature Axios coverage on homepage

### DIFF
--- a/src/trusted_router/static/charter.css
+++ b/src/trusted_router/static/charter.css
@@ -1262,6 +1262,55 @@ pre {
   text-transform: uppercase;
 }
 
+.home-press-band {
+  border-bottom: 1px solid var(--border-hairline);
+  background: var(--surface-card);
+}
+
+.home-press-mention {
+  display: grid;
+  grid-template-columns: 150px minmax(0, 1fr) auto;
+  gap: 28px;
+  align-items: center;
+  padding: 22px 0;
+  color: inherit;
+  text-decoration: none;
+}
+
+.home-press-source {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+}
+
+.home-press-source strong {
+  color: var(--text-display);
+  font-family: var(--font-body);
+  font-size: 15px;
+  font-weight: 600;
+  text-transform: none;
+}
+
+.home-press-mention q {
+  color: var(--text-body);
+  font-family: var(--font-display);
+  font-size: 17px;
+  line-height: 1.45;
+}
+
+.home-press-link {
+  color: var(--text-accent);
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.home-press-mention:hover .home-press-link,
+.home-press-mention:focus-visible .home-press-link {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
 .home-section {
   padding: 96px 0;
 }
@@ -2071,6 +2120,17 @@ body.auth.auth-shell {
     padding-left: 20px;
   }
 
+  .home-press-mention {
+    grid-template-columns: 1fr auto;
+    gap: 10px 20px;
+    padding: 22px 0;
+  }
+
+  .home-press-mention q {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
+
   .home-section {
     padding: 64px 0;
   }
@@ -2219,6 +2279,17 @@ body.auth.auth-shell {
   .charter-stat {
     padding-right: 8px;
     padding-left: 8px;
+  }
+
+  .home-press-mention {
+    display: flex;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .home-press-mention q {
+    font-size: 16px;
   }
 
   .public-proof-strip {

--- a/src/trusted_router/templates/dashboard.html
+++ b/src/trusted_router/templates/dashboard.html
@@ -101,6 +101,21 @@
       <div class="charter-stat"><strong>3 clouds</strong><span>GCP · AWS · Azure</span></div>
     </section>
 
+    <section class="home-press-band" aria-label="Featured press">
+      <div class="home-wrap">
+        <a
+          class="home-press-mention"
+          href="https://www.axios.com/2026/08/25/routing-is-coming-for-the-frontier-ai-labs"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <span class="home-press-source">Featured in <strong>Axios</strong></span>
+          <q>In a demo, I was able to use a DeepSeek model in under 30 seconds using TrustedRouter, an open-source routing company.</q>
+          <span class="home-press-link">Read the story <span aria-hidden="true">→</span></span>
+        </a>
+      </div>
+    </section>
+
     <section class="home-section" aria-label="How {{ brand_name }} works">
       <div class="home-wrap narrow">
         <div class="section-lead center">

--- a/tests/browser/dashboard.spec.js
+++ b/tests/browser/dashboard.spec.js
@@ -474,6 +474,21 @@ test("homepage exposes privacy, no-subscription, and open-source claims", async 
   ).toBeVisible();
 });
 
+test("homepage links the Axios feature and demo result", async ({ page }) => {
+  await page.goto("/");
+
+  const feature = page.locator(".home-press-mention");
+  await expect(feature).toBeVisible();
+  await expect(feature).toContainText("Featured in Axios");
+  await expect(feature).toContainText("DeepSeek model in under 30 seconds");
+  await expect(feature).toHaveAttribute(
+    "href",
+    "https://www.axios.com/2026/08/25/routing-is-coming-for-the-frontier-ai-labs",
+  );
+  await expect(feature).toHaveAttribute("rel", "noopener noreferrer");
+  await expect(feature).toHaveAttribute("target", "_blank");
+});
+
 test("local trust page links the public source repositories and release files", async ({ page }) => {
   await page.goto("/trust");
 

--- a/tests/test_stubs_and_security.py
+++ b/tests/test_stubs_and_security.py
@@ -359,6 +359,13 @@ def test_dashboard_and_trust_pages_are_real_surfaces(client: TestClient) -> None
     assert "GLM" in dashboard.text
     assert "Gemma" in dashboard.text
     assert "Google" in dashboard.text
+    assert "Featured in" in dashboard.text
+    assert "Axios" in dashboard.text
+    assert "DeepSeek model in under 30 seconds" in dashboard.text
+    assert (
+        'href="https://www.axios.com/2026/08/25/'
+        'routing-is-coming-for-the-frontier-ai-labs"'
+    ) in dashboard.text
     # Inline console is gone — these used to be rendered server-side here.
     assert "Workspace Console" not in dashboard.text
     assert 'id="signupForm"' not in dashboard.text


### PR DESCRIPTION
## Summary
- add a prominent but restrained Axios feature strip below the homepage facts
- quote the reporter's under-30-second TrustedRouter demo result
- keep the mention responsive and link directly to the Axios article

## Verification
- `ruff check tests/test_stubs_and_security.py`
- `stylelint src/trusted_router/static/charter.css`
- `eslint tests/browser/dashboard.spec.js`
- `pytest -q tests/test_stubs_and_security.py` (50 passed)
- `playwright test tests/browser/dashboard.spec.js` (22 passed)
- desktop and mobile screenshot review