### PR TITLE
refresh-test-durations: upload the dotfile it exists to record

### DIFF
--- a/.github/workflows/refresh-test-durations.yml
+++ b/.github/workflows/refresh-test-durations.yml
@@ -39,3 +39,7 @@ jobs:
           name: test-durations
           path: .test_durations
           if-no-files-found: error
+          # .test_durations is a dotfile; upload-artifact v4 silently excludes
+          # hidden files unless told otherwise — the first run recorded a full
+          # suite and then uploaded nothing.
+          include-hidden-files: true


### PR DESCRIPTION
One line: `include-hidden-files: true`. upload-artifact v4 silently excludes dotfiles by default, so the first recorder run recorded the full suite and uploaded nothing (`if-no-files-found: error` caught it — fail-closed working as intended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)