### PR TITLE
confidential-cowork: tell people how to actually open the download

### DIFF
--- a/src/trusted_router/static/charter.css
+++ b/src/trusted_router/static/charter.css
@@ -875,6 +875,57 @@ tbody tr:hover {
   font-size: 12px;
 }
 
+.cc-first-launch {
+  max-width: 780px;
+  margin: -10px 0 24px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--r-control);
+  background: var(--surface-card);
+  font-size: 14px;
+}
+
+.cc-first-launch summary {
+  padding: 12px 16px;
+  color: var(--text-display);
+  cursor: pointer;
+  font-weight: 500;
+  list-style: none;
+}
+
+.cc-first-launch summary::-webkit-details-marker {
+  display: none;
+}
+
+.cc-first-launch summary::before {
+  content: "+";
+  margin-right: 9px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+.cc-first-launch[open] summary::before {
+  content: "\2212";
+}
+
+.cc-first-launch > *:not(summary) {
+  margin: 0 16px 12px;
+  color: var(--text-body);
+  line-height: 1.6;
+}
+
+.cc-first-launch ol {
+  padding-left: 20px;
+}
+
+.cc-first-launch li {
+  margin-bottom: 6px;
+}
+
+.cc-first-launch code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
 .cc-product-shot {
   height: clamp(300px, 30vw, 430px);
   margin: 0;

--- a/src/trusted_router/templates/public/confidential_cowork.html
+++ b/src/trusted_router/templates/public/confidential_cowork.html
@@ -11,6 +11,17 @@
     <a class="btn" href="mailto:support@trustedrouter.com?subject=Confidential%20Cowork%20enterprise">Enterprise deployment <span aria-hidden="true">→</span></a>
   </div>
   <p class="cc-platform-note">One universal download for Apple silicon and Intel Macs. OpenAI compatible API.</p>
+  <details class="cc-first-launch">
+    <summary>Opening it the first time takes one extra step on macOS</summary>
+    <p>This build is not yet signed with an Apple Developer ID or notarized, so macOS refuses the first launch and reports that it cannot verify the app is free of malware. That message is about the missing Apple signature, not about anything found in the download. Verify the file against the published SHA-256 if you want to confirm what you received.</p>
+    <ol>
+      <li>Open the downloaded <code>.dmg</code> and drag <strong>Confidential Cowork</strong> into Applications.</li>
+      <li>Launch it once from Applications and dismiss the warning.</li>
+      <li>Open <strong>System Settings &rarr; Privacy &amp; Security</strong>, scroll to Security, and choose <strong>Open Anyway</strong> for Confidential Cowork.</li>
+      <li>Launch it again and confirm. macOS remembers the choice.</li>
+    </ol>
+    <p>On macOS 15 and later, Control-clicking <strong>Open</strong> no longer works for an unnotarized app; the Privacy &amp; Security panel is the only route. Computer Use separately needs Screen Recording and Accessibility permission in that same panel.</p>
+  </details>
   <figure class="cc-product-shot">
     <img src="/static/confidential-cowork-desktop.png" alt="Confidential Cowork desktop app showing its native workspace, confidential model route, and Auto safety mode" width="1094" height="768" loading="eager" fetchpriority="high">
     <figcaption>Every LLM request carries the confidential provider policy. The app cannot silently fall back to an ordinary route.</figcaption>
@@ -61,7 +72,7 @@
     <h2 id="start-heading">Self-serve in minutes. Enterprise controls when you need them.</h2>
   </div>
   <ol class="flow-steps cc-flow">
-    <li><span>1</span><strong>Download</strong><p>Install the signed macOS app and open a local project.</p></li>
+    <li><span>1</span><strong>Download</strong><p>Install the macOS app and open a local project.</p></li>
     <li><span>2</span><strong>Sign in</strong><p>Use TrustedRouter OAuth. No custom gateway can replace the confidential boundary.</p></li>
     <li><span>3</span><strong>Choose a region</strong><p>Require United States or European Union processing, then start working.</p></li>
   </ol>


### PR DESCRIPTION
## Why

The macOS build the page links to is ad-hoc signed and not notarized. `spctl -a -t exec` on the published app returns `rejected`, so macOS refuses the first launch with *"Apple could not verify 'Confidential Cowork' is free of malware that may harm your Mac or compromise your privacy."*

The page gave the user nothing to work with: no install guidance at all, and step 1 of the flow described it as **"the signed macOS app"**, which is the one thing it isn't.

## What changed

- A collapsed **first-launch note** under the download button with the working steps: launch once, then **System Settings → Privacy & Security → Open Anyway**. That path works on macOS 14, 15, and 26.
- It explicitly says Control-clicking **Open** does not work on macOS 15+, because that is the advice everyone finds elsewhere and it strands them.
- It says plainly that the dialog is about the missing Apple signature, not about anything found in the download, and points at the published SHA-256.
- Notes that Computer Use separately needs Screen Recording and Accessibility.
- Drops the "signed" claim from the Download step.

## This is interim

It comes out once the build is Developer ID signed and notarized — at that point none of it is true any more. The pipeline fix is Lore-Hex/QuillCode#new (`fix/notarize-macos-disk-image`); the remaining blocker is the Apple Developer ID certificate and notary key.

## Testing

`tests/test_public_revenue_pages.py` and `tests/test_public_seo_pages.py` — 101 passed. Rendered locally and checked both the collapsed and expanded states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)