### PR TITLE
Activate funded NScale routes

### DIFF
--- a/src/trusted_router/data/provider_models/nscale.json
+++ b/src/trusted_router/data/provider_models/nscale.json
@@ -23,8 +23,7 @@
       "fixed_output_price_microdollars": {
         "1k": 1364
       },
-      "routable": false,
-      "routable_reason": "provider-canary-failed",
+      "routable": true,
       "input_token_price_per_m": 0,
       "output_token_price_per_m": 0
     },
@@ -199,8 +198,7 @@
       "id": "moonshotai/kimi-k2.5",
       "upstream_id": "moonshotai/Kimi-K2.5",
       "context_length": 262144,
-      "routable": false,
-      "routable_reason": "provider-canary-failed",
+      "routable": true,
       "input_token_price_per_m": 450000,
       "output_token_price_per_m": 2200000
     },
@@ -221,8 +219,7 @@
       "id": "nvidia/nemotron-3-nano-30b-a3b-bf16",
       "upstream_id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
       "context_length": 256000,
-      "routable": false,
-      "routable_reason": "provider-canary-failed",
+      "routable": true,
       "input_token_price_per_m": 50000,
       "output_token_price_per_m": 200000
     },
@@ -243,8 +240,7 @@
       "id": "openai/gpt-oss-120b",
       "upstream_id": "openai/gpt-oss-120b",
       "context_length": 131072,
-      "routable": false,
-      "routable_reason": "provider-canary-failed",
+      "routable": true,
       "input_token_price_per_m": 100000,
       "output_token_price_per_m": 400000
     },
@@ -265,8 +261,7 @@
       "id": "openai/gpt-oss-20b",
       "upstream_id": "openai/gpt-oss-20b",
       "context_length": 131072,
-      "routable": false,
-      "routable_reason": "provider-canary-failed",
+      "routable": true,
       "input_token_price_per_m": 50000,
       "output_token_price_per_m": 200000
     },
@@ -287,8 +282,7 @@
       "id": "qwen/qwen2.5-coder-32b-instruct",
       "upstream_id": "Qwen/Qwen2.5-Coder-32B-Instruct",
       "context_length": 131072,
-      "routable": false,
-      "routable_reason": "provider-canary-failed",
+      "routable": true,
       "input_token_price_per_m": 60000,
       "output_token_price_per_m": 200000
     },
@@ -309,8 +303,7 @@
       "id": "qwen/qwen2.5-coder-3b-instruct",
       "upstream_id": "Qwen/Qwen2.5-Coder-3B-Instruct",
       "context_length": 32768,
-      "routable": false,
-      "routable_reason": "provider-canary-failed",
+      "routable": true,
       "input_token_price_per_m": 10000,
       "output_token_price_per_m": 30000
     },
@@ -397,8 +390,7 @@
       "id": "qwen/qwen3-235b-a22b-instruct-2507",
       "upstream_id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
       "context_length": 32768,
-      "routable": false,
-      "routable_reason": "provider-canary-failed",
+      "routable": true,
       "input_token_price_per_m": 200000,
       "output_token_price_per_m": 600000
     },
@@ -419,8 +411,7 @@
       "id": "qwen/qwen3-32b",
       "upstream_id": "Qwen/Qwen3-32B",
       "context_length": 40960,
-      "routable": false,
-      "routable_reason": "provider-canary-failed",
+      "routable": true,
       "input_token_price_per_m": 80000,
       "output_token_price_per_m": 250000
     },
@@ -507,15 +498,14 @@
       "id": "qwen/qwen3-embedding-8b",
       "upstream_id": "Qwen/Qwen3-Embedding-8B",
       "context_length": 32768,
-      "routable": false,
-      "routable_reason": "provider-canary-failed",
+      "routable": true,
       "input_token_price_per_m": 40000,
       "output_token_price_per_m": 0
     }
   ],
   "source": "https://inference.api.nscale.com/v1/models",
   "pricing_source": "https://docs.nscale.com/docs/ai-services/models",
-  "generated_at": "2026-08-24T21:51:19Z",
+  "generated_at": "2026-08-25T17:56:30Z",
   "price_scale": "microdollars_per_million",
   "model_count": 23
 }

--- a/tests/test_nscale_provider.py
+++ b/tests/test_nscale_provider.py
@@ -428,9 +428,30 @@ def test_nscale_catalog_is_fail_closed_and_privacy_is_not_overclaimed() -> None:
         "embedding",
         "image",
     }
-    for row in raw["models"]:
-        assert row["routable"] is False
-        assert row["routable_reason"] == "provider-canary-failed"
+    routable = [row for row in raw["models"] if row.get("routable") is not False]
+    blocked = [row for row in raw["models"] if row.get("routable") is False]
+    assert routable
+    assert blocked
+    assert all(
+        row.get("routable_reason") == "provider-canary-failed" for row in blocked
+    )
+    assert all(
+        row["input_token_price_per_m"] > 0
+        and row["output_token_price_per_m"] > 0
+        for row in routable
+        if row["model_type"] == "chat"
+    )
+    assert all(
+        row["input_token_price_per_m"] > 0
+        and row["output_token_price_per_m"] == 0
+        for row in routable
+        if row["model_type"] == "embedding"
+    )
+    assert all(
+        row["fixed_output_price_microdollars"] == {"1k": 1_364}
+        for row in routable
+        if row["model_type"] == "image"
+    )
 
     provider = PROVIDERS[nscale.SLUG]
     assert provider.supports_prepaid is True


### PR DESCRIPTION
## Summary
- refresh NScale after the account was funded
- publish only the 10 routes that passed authenticated provider canaries
- keep the 13 failing routes dark with provider-canary-failed
- update the fail-closed regression test to validate mixed healthy/blocked catalogs and exact modality pricing

## Verification
- authenticated NScale /models: 23 models, all priced
- exact PONG canary through openai/gpt-oss-20b: HTTP 200
- 103 focused tests passed
- ruff passed
- mypy passed (303 files)
- git diff --check passed

Sakana remains intentionally blocked: its current terms prohibit credential/credit sharing and using the service to provide a competing AI API; Namazu is also geographically restricted and Fugu lacks a provider-side total-cost bound.