### PR TITLE
Size the status freshness contract in monitor cadences

### DIFF
--- a/src/trusted_router/synthetic/status.py
+++ b/src/trusted_router/synthetic/status.py
@@ -33,12 +33,22 @@ from trusted_router.synthetic.components import (
 )
 from trusted_router.synthetic.rollups import merge_rollups, new_rollup_for_sample
 
-CURRENT_SAMPLE_TTL_SECONDS = 5 * 60
-# Regional monitor jobs run every three minutes so normal Cloud Run startup
-# latency remains inside this five-minute freshness contract. A sample that
-# crosses the contract is degraded; only two missed freshness windows plus a
-# small scheduling allowance are a silent-probe failure.
-SILENT_PROBE_TTL_SECONDS = (2 * CURRENT_SAMPLE_TTL_SECONDS) + 60
+# Regional monitor jobs run every three minutes. The freshness contract must
+# be sized in CADENCES, not wall-clock feel: the previous 5-minute contract was
+# 1.67 cadences, which left the slowest probe key peaking ~275s old at STEADY
+# STATE and flapping the public banner "Degraded" on ~25s of ordinary
+# scheduling jitter -- the 2026-08-23..25 GCP status history's recurring
+# one-hour "Degraded 98.7%" buckets, and a morning of banner flaps during a
+# healthy fleet, were exactly this. Two full cadences plus the startup
+# allowance means one missed cycle is tolerated and a sample midway into its
+# second missed cycle is degraded -- a contract the cadence can actually keep.
+MONITOR_CADENCE_SECONDS = 3 * 60
+CURRENT_SAMPLE_TTL_SECONDS = (2 * MONITOR_CADENCE_SECONDS) + 60
+# Unchanged at 660s: a probe silent past ~11 minutes (3+ cadences) stopped
+# emitting while its siblings kept going -- the silent-disappearance outage.
+# Kept as an absolute rather than re-derived from the widened contract so the
+# "down" boundary does not silently move with it.
+SILENT_PROBE_TTL_SECONDS = 11 * 60
 IMAGE_GENERATION_SAMPLE_TTL_SECONDS = 7 * 60 * 60
 STATUS_HISTORY_HOURS = 48
 # Uptime thresholds for per-bucket coloring. Single-sample blips

--- a/tests/test_monitor_freshness_poison.py
+++ b/tests/test_monitor_freshness_poison.py
@@ -20,6 +20,7 @@ from trusted_router.storage_models import FUTURE_SAMPLE_SKEW_SECONDS, SyntheticP
 from trusted_router.synthetic.rollups import raw_sample_is_within_retention
 from trusted_router.synthetic.status import (
     CURRENT_SAMPLE_TTL_SECONDS,
+    MONITOR_CADENCE_SECONDS,
     SILENT_PROBE_TTL_SECONDS,
     _current_status,
     _monitor_freshness,
@@ -29,7 +30,9 @@ from trusted_router.synthetic.status import (
 NOW = dt.datetime(2026, 8, 2, 12, 0, 0, tzinfo=dt.UTC)
 
 
-def _sample(created_at: dt.datetime, *, status: str = "up", sample_id: str = "s1") -> SyntheticProbeSample:
+def _sample(
+    created_at: dt.datetime, *, status: str = "up", sample_id: str = "s1"
+) -> SyntheticProbeSample:
     return SyntheticProbeSample(
         id=sample_id,
         probe_type="tls_health",
@@ -233,8 +236,14 @@ class TestSilentProbeDisappearance:
         assert current["by_region"]["us-central1"]["status"] == "degraded"
         assert current["by_region"]["us-central1"]["status"] != "down"
 
-    def test_silent_probe_threshold_covers_two_monitor_cycles(self) -> None:
-        assert SILENT_PROBE_TTL_SECONDS > 2 * CURRENT_SAMPLE_TTL_SECONDS
+    def test_silent_probe_threshold_exceeds_degraded_by_a_full_cycle(self) -> None:
+        # The contract is denominated in monitor CADENCES (status.py sizes the
+        # degraded boundary at two cadences + startup allowance). "Down" must
+        # stay a stronger claim than "degraded" by at least one further full
+        # cycle, and must itself cover 3+ cycles of silence -- the
+        # silent-disappearance outage, not one late burst.
+        assert SILENT_PROBE_TTL_SECONDS >= CURRENT_SAMPLE_TTL_SECONDS + MONITOR_CADENCE_SECONDS
+        assert SILENT_PROBE_TTL_SECONDS >= 3 * MONITOR_CADENCE_SECONDS + 60
 
     def test_whole_monitor_stale_stays_unknown_not_false_outage(self) -> None:
         """Cold start / monitor down: every probe stale. monitor_freshness


### PR DESCRIPTION
One boundary — degraded at 300s against a 180s probe cadence — has been flapping the public GCP banner "Router Core Degraded" on ordinary scheduler jitter while every component was healthy, including through this morning. Degraded now starts at two full cadences + startup allowance (420s); the silent-probe down boundary is unchanged at 660s and pinned as an absolute. Invariant test re-denominated in cadences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)