### PR TITLE
Warm with a primer, not full capacity; secondaries watch 1 minute at 100%

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -903,9 +903,13 @@ jobs:
               return 1
             fi
 
+            # 1 minute, not 3 (Joseph, 2026-08-25): by the time a secondary
+            # reaches 100%, the image has served the primary's full ramp AND
+            # its 3-minute canary, plus this region's own two gated windows.
+            # Measured: the 3-minute version was 9 of 39 total deploy minutes.
             if ! python3 scripts/deploy/watchdog.py \
               --regions "${region}" \
-              --duration-min 3 \
+              --duration-min 1 \
               --rollback-after 2 \
               --slo-class router_core \
               --baseline-input "${watchdog_baseline}" \

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -768,17 +768,32 @@ deploy_one_region() {
   if [ "${TR_DEPLOY_NO_TRAFFIC:-0}" = "1" ]; then
     # Cloud Run revisions are immutable: clearing a temporary revision minimum
     # would create a second cold revision and recreate the 100% cutover stall.
-    # Instead the candidate carries the same minimum as the existing service.
-    # The probe tag assigned below activates it at 0% traffic. Cloud Run uses
-    # the larger (not the sum) of service/revision minimums, so after convergence
-    # capacity is still the original service minimum. On rollback, removing the
-    # tag and traffic reference deactivates this revision minimum completely.
-    revision_min_instances="$min_instances"
-    # CAVEAT (review F5): this bakes today's service minimum into the revision
-    # forever — effective capacity is max(service, revision), so LOWERING a
-    # region's TR_CLOUD_RUN_MIN_INSTANCES_BY_REGION later changes nothing
-    # until the next deploy replaces the serving revision. Capacity
-    # reductions therefore require a redeploy to take effect. The max-not-sum
+    # The candidate therefore bakes a revision minimum, activated at 0% by the
+    # probe tag below; effective capacity is max(service, revision), so
+    # convergence is cost-neutral and rollback deactivates it.
+    #
+    # PRIMER, not full capacity (measured 2026-08-25): matching the service
+    # minimum made `gcloud run deploy` WAIT for that many instances to go
+    # Ready at warm time — us-east4 pins 8, and the parallel warm step ran
+    # 7m37 instead of ~2m; the 100%-stall cost moved into the warm and grew.
+    # A small primer absorbs the 10% step instantly, and the staged
+    # 10/50/100 ramp itself gives Cloud Run scale time for the rest.
+    local prewarm_floor="${TR_CLOUD_RUN_PREWARM_MIN_INSTANCES:-2}"
+    if [[ ! "$prewarm_floor" =~ ^[0-9]+$ ]]; then
+      log "invalid TR_CLOUD_RUN_PREWARM_MIN_INSTANCES=${prewarm_floor}; using 2"
+      prewarm_floor=2
+    fi
+    if [ "$min_instances" != "default" ] && [ "$prewarm_floor" -gt "$min_instances" ]; then
+      # Never prime ABOVE the service minimum: a cold region (min 0/1) should
+      # not pay for primer instances its steady state never runs.
+      prewarm_floor="$min_instances"
+    fi
+    revision_min_instances="$prewarm_floor"
+    # CAVEAT (review F5): this bakes today's primer into the revision
+    # forever — effective capacity is max(service, revision). With the primer
+    # capped at min(2, service minimum), a later reduction of a region's
+    # service minimum below the primer still needs a redeploy to fully take
+    # effect, but the exposure is at most 2 instances. The max-not-sum
     # and tag-activation semantics are platform behavior asserted here, not
     # testable against stubs — verify billing once after the first prod run.
     log "capacity before ${target}: service min=${min_instances}; candidate revision min=${revision_min_instances}"

--- a/tests/test_deploy_script_execution.py
+++ b/tests/test_deploy_script_execution.py
@@ -245,6 +245,52 @@ def test_gcp_no_traffic_warm_preprovisions_and_tags_candidate(
     assert deploy[deploy.index("--min-instances") + 1] == "2"
     assert "--no-traffic" in deploy
 
+
+def test_warm_primer_caps_below_a_high_service_minimum(
+    harness: DeployScriptHarness,
+) -> None:
+    """The pre-warm regression, pinned (measured 2026-08-25).
+
+    Priming the candidate with the FULL service minimum made the no-traffic
+    deploy wait for that many instances to go Ready — us-east4 pins 8, and
+    the parallel warm step ran 7m37 instead of ~2m. The revision minimum must
+    be the small primer, capped by the service minimum, never the service
+    minimum itself.
+    """
+    run = harness.run(
+        "scripts/deploy/rollout.sh",
+        extra_env={"TR_CLOUD_RUN_MIN_INSTANCES": "8"},
+    )
+    assert run.returncode == 0, summarise(run)
+    deploy = next(
+        call
+        for call in run.calls
+        if call[0:4] == ["gcloud", "--project", "quill-cloud-proxy", "run"]
+        and call[4:7] == ["deploy", "trusted-router", "--region"]
+    )
+    assert deploy[deploy.index("--min") + 1] == "8"
+    assert deploy[deploy.index("--min-instances") + 1] == "2"
+
+
+def test_warm_primer_never_exceeds_a_cold_service_minimum(
+    harness: DeployScriptHarness,
+) -> None:
+    """A cold region (service min below the primer) must not pay for primer
+    instances its steady state never runs."""
+    run = harness.run(
+        "scripts/deploy/rollout.sh",
+        extra_env={"TR_CLOUD_RUN_MIN_INSTANCES": "1"},
+    )
+    assert run.returncode == 0, summarise(run)
+    deploy = next(
+        call
+        for call in run.calls
+        if call[0:4] == ["gcloud", "--project", "quill-cloud-proxy", "run"]
+        and call[4:7] == ["deploy", "trusted-router", "--region"]
+    )
+    assert deploy[deploy.index("--min") + 1] == "1"
+    assert deploy[deploy.index("--min-instances") + 1] == "1"
+
     tag_index = next(
         index
         for index, call in enumerate(run.calls)

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -171,7 +171,11 @@ def test_all_attested_control_plane_regions_remain_warm() -> None:
     assert '--concurrency "$TR_CLOUD_RUN_CONCURRENCY"' in rollout
     assert '--min "$min_instances"' in rollout
     assert 'local revision_min_instances="default"' in rollout
-    assert 'revision_min_instances="$min_instances"' in rollout
+    # The warm primer, not the full service minimum: matching service min made
+    # the no-traffic deploy wait for that many Ready instances (us-east4 pins
+    # 8; the warm step ran 7m37). The primer caps at min(2, service minimum).
+    assert 'prewarm_floor="${TR_CLOUD_RUN_PREWARM_MIN_INSTANCES:-2}"' in rollout
+    assert 'revision_min_instances="$prewarm_floor"' in rollout
     assert '--min-instances "$revision_min_instances"' in rollout
     assert '"TR_SPANNER_POOL_SIZE=${TR_SPANNER_POOL_SIZE}"' in rollout
 


### PR DESCRIPTION
Both approved by Joseph 2026-08-25, from the measured 39m09 run
(deploy.full_convergence_seconds=2349).

**1. The pre-warm regression, fixed.** Priming the candidate revision
with the FULL service minimum made the no-traffic deploy wait for that
many instances to go Ready — us-east4 pins 8, and the parallel warm
step ran **7m37** instead of ~2m: the 100%-stall cost moved into the
warm and grew. The revision minimum is now a primer,
`min(TR_CLOUD_RUN_PREWARM_MIN_INSTANCES=2, service minimum)`: enough to
absorb the 10% step instantly, with the staged 10/50/100 ramp giving
Cloud Run scale time for the rest. Pinned by two harness executions: a
high-min region (8) primes at 2; a cold region (1) never exceeds its
own steady state.

**2. Per-secondary post-100% watch: 3m → 1m** (9 of the measured 39
minutes). By the time a secondary reaches 100%, the image has served
the primary's full ramp AND its 3-minute canary — which is untouched,
and is now the only `duration-min 3` in the workflow — plus that
region's own two gated windows.

Expected next full deploy: **~27-28m** full convergence, self-reported
by the run per the existing metrics step.

ruff · mypy · full suite 6559(+116 rerun) passed · yaml parses ·
harness executions green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)