### PR TITLE
Operational analytics: direct ClickHouse sink; take telemetry off Spanner

### DIFF
--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -231,6 +231,10 @@ SERVICE_SURFACE_SECRET_OWNERS: dict[str, frozenset[str]] = {
     "operational_analytics_clickhouse_url": frozenset(
         {"public", "control", "internal", "observer"}
     ),
+    # The write USER is not in this map: it is a username with a non-empty
+    # default, not a secret, exactly like the read user above it. Only the
+    # credential is surface-restricted.
+    "operational_analytics_clickhouse_write_password": frozenset({"control", "internal"}),
     "operational_analytics_clickhouse_password": frozenset(
         {"public", "control", "internal", "observer"}
     ),
@@ -286,6 +290,35 @@ def _sensitive_setting_is_configured(field_name: str, value: object) -> bool:
     if field_name in {"google_alias_credentials_json", "github_alias_credentials_json"}:
         return value != "{}"
     return bool(value)
+
+
+def operational_analytics_sink_problems(settings: Any) -> list[str]:
+    """Fail-closed checks for HOW operational telemetry leaves the process.
+
+    Pure and duck-typed so the contract is testable without constructing a
+    full production Settings. Called from production_is_fail_closed for the
+    spanner-clickhouse backend.
+    """
+    problems: list[str] = []
+    sink = settings.operational_analytics_sink
+    if sink not in ("outbox", "direct"):
+        problems.append(
+            f"TR_OPERATIONAL_ANALYTICS_SINK must be 'outbox' or 'direct' (got {sink!r})"
+        )
+    if not (settings.operational_analytics_outbox_enabled or sink == "direct"):
+        problems.append(
+            "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true (or TR_OPERATIONAL_ANALYTICS_SINK=direct)"
+        )
+    if sink == "direct" and not (
+        settings.operational_analytics_clickhouse_url
+        and settings.operational_analytics_clickhouse_write_password
+    ):
+        problems.append(
+            "TR_OPERATIONAL_ANALYTICS_SINK=direct requires "
+            "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_URL and "
+            "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_WRITE_PASSWORD"
+        )
+    return problems
 
 
 class Settings(BaseSettings):
@@ -406,6 +439,17 @@ class Settings(BaseSettings):
     # Durable tenant-activity and synthetic-status stream. Kept independent
     # from provider analytics so its privacy and cutover can be controlled.
     operational_analytics_outbox_enabled: bool = False
+    # HOW operational telemetry leaves the process. "outbox" is the historical
+    # path: rows into the billing database, polled out by a drainer -- a
+    # standing tax on the money path that on 2026-08-25 measured ~25% of the
+    # whole Spanner instance while idle. "direct" writes canonical rows
+    # straight to ClickHouse from a bounded in-process buffer
+    # (operational_analytics_direct.py) and needs a WRITE-capable ClickHouse
+    # credential below. Per-cloud cutover: flip this only where that
+    # credential is provisioned.
+    operational_analytics_sink: str = "outbox"
+    operational_analytics_clickhouse_write_user: str = "tr"
+    operational_analytics_clickhouse_write_password: str = ""
     # Client-observed figures include upstream provider-caused failures and can
     # understate a healthy gateway. Keep them off public surfaces until
     # per-provider attribution makes the number fair to publish.
@@ -1572,8 +1616,7 @@ class Settings(BaseSettings):
                 )
             if not self.generation_records_enabled:
                 missing.append("TR_GENERATION_RECORDS_ENABLED=true")
-            if not self.operational_analytics_outbox_enabled:
-                missing.append("TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true")
+            missing.extend(operational_analytics_sink_problems(self))
             if not self.analytics_outbox_enabled:
                 missing.append("TR_ANALYTICS_OUTBOX_ENABLED=true")
             if self.bigtable_mirror_writes_enabled:

--- a/src/trusted_router/operational_analytics_direct.py
+++ b/src/trusted_router/operational_analytics_direct.py
@@ -1,25 +1,57 @@
-"""Drain tenant activity and synthetic metadata from Spanner to ClickHouse."""
+"""Direct-to-ClickHouse sink for operational analytics.
+
+WHY THIS EXISTS. Operational telemetry -- activity rows, synthetic probe
+samples, client SDK beacons -- used to be written into a 32-shard outbox table
+in the BILLING database and polled out by a drainer at 64 queries per cycle,
+every ~1.5 seconds, forever. Spanner's own query stats measured that drain at
+~25% of the whole instance's CPU while doing nothing, and on launch day
+(2026-08-25) that standing tax was the missing headroom that let a modest
+traffic bump collapse authorize/settle for every cloud. The outbox pattern
+buys transactional coupling with business writes -- a property operational
+telemetry does not need and should not pay for. Bounded, counted loss is the
+correct contract for ops data; the money path is for money.
+
+So this sink writes telemetry straight to ClickHouse: canonicalise at the
+producer, buffer in memory (bounded, drop-oldest, counted), flush in batches
+from one background thread. Loss window on an instance kill is one flush
+interval of TELEMETRY, not revenue. Selected per deployment via
+``settings.operational_analytics_sink`` ("outbox" stays the default until a
+cloud's ClickHouse write credential is provisioned; see config validation).
+
+The canonicalisation below is EXTRACTED VERBATIM from
+clickhouse/ingest_operational_outbox.py so rows are byte-identical to what the
+drainer produced. The drainer keeps a frozen copy only until the outbox is
+decommissioned; clickhouse/ingest_operational_outbox_postgres.py (AWS/Azure)
+keeps its own until those planes cut over. Do not let the copies drift --
+delete them.
+"""
 
 from __future__ import annotations
 
-import argparse
+import base64
 import datetime as dt
 import hashlib
 import json
 import logging
-import math
-import os
-import subprocess
+import threading
 import time
-from collections import defaultdict
+import urllib.parse
+import urllib.request
+from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import Any
 
-PROJECT = "quill-cloud-proxy"
-SPANNER_INSTANCE = "trusted-router-nam6"
-SPANNER_DATABASE = "trusted-router"
-OUTBOX_TABLE = "tr_operational_analytics_outbox"
-OUTBOX_SHARDS = 32
+from trusted_router.storage_models import Generation, SyntheticProbeSample
+from trusted_router.storage_operational_analytics import (
+    ACTIVITY_EVENT_KIND,
+    CLIENT_EVENTS_EVENT_KIND,
+    SYNTHETIC_EVENT_KIND,
+    activity_payload,
+    synthetic_payload,
+)
+
+log = logging.getLogger("trusted_router.operational_analytics_direct")
 
 ACTIVITY_COLUMNS = (
     "generation_id",
@@ -217,8 +249,6 @@ EVENT_TABLES = {
     "quarantine": "operational_outbox_quarantine",
 }
 
-log = logging.getLogger("trusted_router.operational_analytics_ingest")
-
 
 @dataclass(frozen=True)
 class OperationalOutboxRow:
@@ -239,241 +269,10 @@ class CanonicalOperationalEvent:
     row: dict[str, Any]
 
 
-@dataclass(frozen=True)
-class DrainResult:
-    fetched: int
-    inserted: int
-    rows_per_second: float
-    quarantined: int = 0
-    lag_seconds: float = 0.0
-
-
-class OutboxSource(Protocol):
-    def fetch(self, *, limit: int) -> list[OperationalOutboxRow]:
-        # ONE unordered global read, not 32 ordered per-shard reads. Spanner
-        # stores rows in primary-key order, so results arrive
-        # (shard, commit_ts)-ordered per split anyway; delivery order does not
-        # matter (delete is by key, ClickHouse dedups by event) and this same
-        # statement doubles as the emptiness probe. The per-shard ORDER BY
-        # fan-out this replaces ran 64 statements every ~1.5s around the
-        # clock -- measured at ~25% of the whole 300-PU instance on
-        # 2026-08-25 -- to mostly discover an empty table. This path is
-        # interim: the direct sink (trusted_router.operational_analytics_direct)
-        # removes the outbox entirely; this drainer then only clears residue.
-        rows: list[OperationalOutboxRow] = []
-        with self._database.snapshot() as snapshot:
-            results = snapshot.execute_sql(
-                # OUTBOX_TABLE is a module constant, not caller input.
-                "SELECT shard, commit_ts, event_kind, event_id, payload "  # noqa: S608
-                f"FROM {OUTBOX_TABLE} LIMIT @limit",
-                params={"limit": limit},
-                param_types={"limit": self._pt.INT64},
-            )
-            for row in results:
-                rows.append(
-                    OperationalOutboxRow(
-                        shard=int(row[0]),
-                        commit_ts=row[1],
-                        event_kind=str(row[2]),
-                        event_id=str(row[3]),
-                        payload=str(row[4]),
-                    )
-                )
-        return rows
-
-    def delete(self, rows: list[OperationalOutboxRow]) -> None: ...
-
-    def oldest_commit_ts(self) -> dt.datetime | None: ...
-
-
-class BatchWriter(Protocol):
-    def insert(self, events: list[CanonicalOperationalEvent]) -> None: ...
-
-
 def _utc(value: dt.datetime) -> dt.datetime:
     if value.tzinfo is None:
         return value.replace(tzinfo=dt.UTC)
     return value.astimezone(dt.UTC)
-
-
-class SpannerOperationalOutboxSource:
-    def __init__(
-        self,
-        *,
-        project: str,
-        instance: str,
-        database: str,
-        shard_count: int = OUTBOX_SHARDS,
-    ) -> None:
-        from google.cloud import spanner
-        from google.cloud.spanner_v1 import param_types
-
-        self._database = (
-            spanner.Client(project=project, disable_builtin_metrics=True)
-            .instance(instance)
-            .database(database)
-        )
-        self._pt = param_types
-        self._shard_count = shard_count
-
-    def fetch(self, *, limit: int) -> list[OperationalOutboxRow]:
-        if limit < 1:
-            return []
-        per_shard = max(1, math.ceil(limit / self._shard_count) * 2)
-        rows: list[OperationalOutboxRow] = []
-        with self._database.snapshot(multi_use=True) as snapshot:
-            for shard in range(self._shard_count):
-                values = snapshot.execute_sql(
-                    "SELECT shard, commit_ts, event_kind, event_id, payload "
-                    "FROM tr_operational_analytics_outbox "
-                    "WHERE shard=@shard ORDER BY commit_ts, event_kind, event_id "
-                    "LIMIT @limit",
-                    params={"shard": shard, "limit": per_shard},
-                    param_types={"shard": self._pt.INT64, "limit": self._pt.INT64},
-                )
-                rows.extend(
-                    OperationalOutboxRow(
-                        shard=int(row[0]),
-                        commit_ts=_utc(row[1]),
-                        event_kind=str(row[2]),
-                        event_id=str(row[3]),
-                        payload=str(row[4]),
-                    )
-                    for row in values
-                )
-        rows.sort(
-            key=lambda row: (
-                row.commit_ts,
-                row.shard,
-                row.event_kind,
-                row.event_id,
-            )
-        )
-        return rows[:limit]
-
-    def delete(self, rows: list[OperationalOutboxRow]) -> None:
-        if not rows:
-            return
-        from google.cloud.spanner_v1 import KeySet
-
-        with self._database.batch() as batch:
-            batch.delete(OUTBOX_TABLE, KeySet(keys=[list(row.key) for row in rows]))
-
-    def oldest_commit_ts(self) -> dt.datetime | None:
-        oldest: dt.datetime | None = None
-        with self._database.snapshot(multi_use=True) as snapshot:
-            for shard in range(self._shard_count):
-                values = list(
-                    snapshot.execute_sql(
-                        "SELECT commit_ts FROM tr_operational_analytics_outbox "
-                        "WHERE shard=@shard ORDER BY commit_ts LIMIT 1",
-                        params={"shard": shard},
-                        param_types={"shard": self._pt.INT64},
-                    )
-                )
-                if values:
-                    candidate = _utc(values[0][0])
-                    oldest = candidate if oldest is None else min(oldest, candidate)
-        return oldest
-
-
-class ClickHouseOperationalWriter:
-    """Inserts a batch into one ClickHouse endpoint via clickhouse-client.
-
-    `host`/`port`/`secure` default to unset, and an unset connection flag is
-    omitted from argv entirely rather than passed as a default. That is what
-    keeps a writer constructed the historical way — password/user/database
-    only — emitting the byte-identical command it always did, talking to the
-    node on this machine. A drain with one configured endpoint therefore
-    behaves exactly as it did before remote endpoints existed.
-    """
-
-    def __init__(
-        self,
-        *,
-        password: str,
-        database: str = "tr",
-        user: str = "tr",
-        host: str = "",
-        port: int = 0,
-        secure: bool = False,
-        timeout_seconds: float | None = None,
-    ) -> None:
-        self._password = password
-        self._database = database
-        # The user was hardcoded to "tr" while the database was already a
-        # parameter, so this class silently only worked on the GCP cluster.
-        # The AWS-EU node authenticates as "default" into database "default"
-        # (its schema is applied unqualified), so a drain pointed at it failed
-        # authentication on the very first insert -- after the rows had been
-        # read, which is the worst place to discover a credential mismatch.
-        self._user = user
-        self._host = host
-        self._port = port
-        self._secure = secure
-        # None means "wait forever", which is what the local writer has always
-        # done and what it keeps doing. A REMOTE endpoint needs a finite bound:
-        # a node that completes the TCP handshake and then stalls -- a wedged
-        # server, a silently blackholed path -- would otherwise hang
-        # subprocess.run indefinitely, freezing the whole sweep inside a daemon
-        # that still looks alive while the outbox grows behind it.
-        self._timeout_seconds = timeout_seconds
-
-    def insert(self, events: list[CanonicalOperationalEvent]) -> None:
-        grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
-        for event in events:
-            grouped[event.event_kind].append(event.row)
-        for event_kind, rows in grouped.items():
-            table = EVENT_TABLES.get(event_kind)
-            if table is None:
-                raise ValueError(f"unsupported operational event kind: {event_kind}")
-            if not isinstance(table, str):
-                raise ValueError(
-                    f"operational event kind must be expanded before insert: {event_kind}"
-                )
-            payload = "\n".join(
-                json.dumps(row, separators=(",", ":"), sort_keys=True) for row in rows
-            ).encode("utf-8")
-            command = ["/usr/bin/clickhouse-client"]
-            # Omitted, not defaulted: see the class docstring. With no host,
-            # port or TLS configured this list is exactly what it has always
-            # been, so the single-node deployment is untouched.
-            if self._host:
-                command += ["--host", self._host]
-            if self._port:
-                command += ["--port", str(self._port)]
-            if self._secure:
-                command.append("--secure")
-            command += [
-                "--user",
-                self._user,
-                "--database",
-                self._database,
-                "--query",
-                f"INSERT INTO {table} FORMAT JSONEachRow",
-            ]
-            env = os.environ.copy()
-            env["CLICKHOUSE_PASSWORD"] = self._password
-            try:
-                result = subprocess.run(  # noqa: S603 - fixed executable and table allowlist.
-                    command,
-                    input=payload,
-                    env=env,
-                    capture_output=True,
-                    check=False,
-                    timeout=self._timeout_seconds,
-                )
-            except subprocess.TimeoutExpired as exc:
-                # Raising is the point: the caller must not reach its DELETE,
-                # so the rows stay queued and the next sweep retries them.
-                raise RuntimeError(
-                    f"ClickHouse {event_kind} insert to "
-                    f"{self._host or 'localhost'} timed out after "
-                    f"{self._timeout_seconds}s"
-                ) from exc
-            if result.returncode != 0:
-                detail = result.stderr.decode("utf-8", errors="replace")[:1000]
-                raise RuntimeError(f"ClickHouse {event_kind} insert failed: {detail}")
 
 
 def _event_id(tenant_id: str, batch_id: str, kind: str, index: int) -> str:
@@ -703,100 +502,212 @@ def quarantine_event(
     )
 
 
-def drain_once(
-    source: OutboxSource,
-    writer: BatchWriter,
-    *,
-    batch_size: int,
-) -> DrainResult:
-    rows = source.fetch(limit=batch_size)
-    if not rows:
-        return DrainResult(fetched=0, inserted=0, rows_per_second=0.0)
-    lag_seconds = _lag_seconds(min(row.commit_ts for row in rows))
-    events: list[CanonicalOperationalEvent] = []
-    quarantined = 0
-    for row in rows:
-        try:
-            events.extend(normalise_operational_event(row))
-        except ValueError as exc:
-            events.append(quarantine_event(row, exc))
-            quarantined += 1
-    started = time.monotonic()
-    writer.insert(events)
-    source.delete(rows)
-    elapsed = max(time.monotonic() - started, 0.000_001)
-    return DrainResult(
-        fetched=len(rows),
-        inserted=len(events) - quarantined,
-        rows_per_second=len(events) / elapsed,
-        quarantined=quarantined,
-        lag_seconds=lag_seconds,
-    )
+# ---------------------------------------------------------------------------
+# The sink
+# ---------------------------------------------------------------------------
+
+#: Bounded buffer size. At ~2 rows/second of steady telemetry this is hours of
+#: ClickHouse outage before anything drops; when it does drop it drops OLDEST
+#: (the newest telemetry is the operationally interesting end) and counts.
+DEFAULT_BUFFER_ROWS = 20_000
+DEFAULT_FLUSH_INTERVAL_SECONDS = 2.0
+DEFAULT_FLUSH_BATCH_ROWS = 1_000
+#: Failure backoff cap. Telemetry freshness is worth little enough that
+#: hammering a down ClickHouse would be its own kind of self-harm.
+FAILURE_BACKOFF_CAP_SECONDS = 30.0
 
 
-def _lag_seconds(oldest: dt.datetime | None) -> float:
-    if oldest is None:
-        return 0.0
-    return max(0.0, (dt.datetime.now(dt.UTC) - _utc(oldest)).total_seconds())
+@dataclass
+class SinkStats:
+    published: int = 0
+    inserted: int = 0
+    dropped: int = 0
+    quarantined: int = 0
+    flush_failures: int = 0
+    last_success_unix: float = 0.0
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--project", default=os.environ.get("GCP_PROJECT_ID", PROJECT))
-    parser.add_argument(
-        "--spanner-instance",
-        default=os.environ.get("SPANNER_INSTANCE_ID", SPANNER_INSTANCE),
-    )
-    parser.add_argument(
-        "--spanner-database",
-        default=os.environ.get("SPANNER_DATABASE_ID", SPANNER_DATABASE),
-    )
-    parser.add_argument("--shards", type=int, default=OUTBOX_SHARDS)
-    parser.add_argument("--batch-size", type=int, default=5000)
-    parser.add_argument("--poll-seconds", type=float, default=2.0)
-    parser.add_argument("--once", action="store_true")
-    args = parser.parse_args()
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s %(name)s %(message)s",
-    )
-    password = os.environ.get("CH_PASSWORD", "")
-    if not password:
-        raise SystemExit("CH_PASSWORD is required")
-    source = SpannerOperationalOutboxSource(
-        project=args.project,
-        instance=args.spanner_instance,
-        database=args.spanner_database,
-        shard_count=args.shards,
-    )
-    writer = ClickHouseOperationalWriter(password=password)
-    # Idle backoff: the poll interval doubles while the outbox stays empty
-    # (cap 30s) and snaps back to fast the moment work appears. Combined with
-    # the single-statement fetch this takes the idle cost from 64 statements
-    # per ~1.5s to one statement per 30s. Lag is measured from the batch in
-    # hand: an empty outbox HAS no lag, and the per-cycle 32-statement
-    # watermark this replaces was the single largest query load on the
-    # production Spanner instance (measured 2026-08-25).
-    idle_delay = max(0.1, args.poll_seconds)
-    while True:
-        result = drain_once(source, writer, batch_size=max(1, args.batch_size))
-        if result.fetched:
-            log.info(
-                "operational_analytics_outbox.metrics rows=%d rows_per_second=%.3f "
-                "drain_lag_seconds=%.3f quarantined=%d",
-                result.inserted,
-                result.rows_per_second,
-                result.lag_seconds,
-                result.quarantined,
+class DirectOperationalAnalyticsSink:
+    """Bounded in-process buffer draining to ClickHouse from one thread.
+
+    Duck-type-compatible with SpannerOperationalAnalyticsOutbox /
+    PostgresOperationalAnalyticsOutbox where the stores touch it: the
+    ``enqueue_*`` family and ``oldest_enqueued_at``. The ``_tx`` variants
+    accept and ignore the transaction handle -- the whole point is that
+    telemetry no longer rides business transactions. A transaction that
+    retries may therefore publish the same event twice, and an aborted one
+    may publish a phantom; ClickHouse deduplicates by event_id and the data
+    is operational, so both are accepted trades, stated here on purpose.
+    """
+
+    def __init__(
+        self,
+        *,
+        url: str,
+        database: str,
+        user: str,
+        password: str,
+        buffer_rows: int = DEFAULT_BUFFER_ROWS,
+        flush_interval_seconds: float = DEFAULT_FLUSH_INTERVAL_SECONDS,
+        flush_batch_rows: int = DEFAULT_FLUSH_BATCH_ROWS,
+        post: Callable[[str, bytes, dict[str, str]], None] | None = None,
+        start_thread: bool = True,
+    ) -> None:
+        if not url:
+            raise ValueError("direct operational analytics sink requires a ClickHouse url")
+        if not password:
+            raise ValueError(
+                "direct operational analytics sink requires a WRITE-capable "
+                "ClickHouse credential; the read user cannot INSERT"
             )
-        if args.once:
+        self._url = url.rstrip("/")
+        self._database = database
+        self._auth = base64.b64encode(f"{user}:{password}".encode()).decode()
+        self._buffer_rows = buffer_rows
+        self._buffer: deque[tuple[str, dict[str, Any]]] = deque(maxlen=buffer_rows)
+        self._lock = threading.Lock()
+        self._wake = threading.Event()
+        self._closed = threading.Event()
+        self._flush_interval = flush_interval_seconds
+        self._flush_batch = flush_batch_rows
+        self._post = post or self._http_post
+        self.stats = SinkStats()
+        self._thread: threading.Thread | None = None
+        if start_thread:
+            self._thread = threading.Thread(
+                target=self._run, name="operational-analytics-direct", daemon=True
+            )
+            self._thread.start()
+
+    # -- producer surface (documented duck-type of the outbox writers) ------
+
+    def enqueue_activity(self, generation: Generation) -> None:
+        self._publish(ACTIVITY_EVENT_KIND, generation.id, activity_payload(generation))
+
+    def enqueue_activity_tx(self, transaction: Any, generation: Generation) -> None:
+        self.enqueue_activity(generation)
+
+    def enqueue_synthetic(self, sample: SyntheticProbeSample) -> None:
+        self._publish(SYNTHETIC_EVENT_KIND, sample.id, synthetic_payload(sample))
+
+    def enqueue_synthetic_tx(self, transaction: Any, sample: SyntheticProbeSample) -> None:
+        self.enqueue_synthetic(sample)
+
+    def enqueue_client_events(self, payload: dict[str, Any]) -> None:
+        self._publish(
+            CLIENT_EVENTS_EVENT_KIND,
+            f"{payload['tenant_id']}:{payload['batch_id']}",
+            payload,
+        )
+
+    def oldest_enqueued_at(self, *, timeout: float | None = None) -> dt.datetime | None:
+        """The freshness contract's question is "how old is the undelivered
+        backlog"; this sink's backlog is the in-memory buffer, delivered
+        within seconds or dropped WITH A COUNT. Publishing None (= empty)
+        keeps /status truthful for the common case; sustained delivery
+        failure surfaces through stats/logs rather than a phantom lag."""
+        return None
+
+    # -- internals ----------------------------------------------------------
+
+    def _publish(self, event_kind: str, event_id: str, payload: dict[str, Any]) -> None:
+        row = OperationalOutboxRow(
+            shard=0,
+            commit_ts=dt.datetime.now(dt.UTC),
+            event_kind=event_kind,
+            event_id=event_id,
+            payload=json.dumps(payload),
+        )
+        try:
+            events = normalise_operational_event(row)
+        except ValueError as exc:
+            events = [quarantine_event(row, exc)]
+            self.stats.quarantined += 1
+        with self._lock:
+            before = len(self._buffer)
+            for event in events:
+                table = EVENT_TABLES[event.event_kind]
+                assert isinstance(table, str)
+                self._buffer.append((table, event.row))
+            overflow = before + len(events) - self._buffer_rows
+            if overflow > 0:
+                self.stats.dropped += overflow
+            self.stats.published += len(events)
+        if len(self._buffer) >= self._flush_batch:
+            self._wake.set()
+
+    def _run(self) -> None:
+        failure_delay = self._flush_interval
+        while not self._closed.is_set():
+            self._wake.wait(timeout=self._flush_interval)
+            self._wake.clear()
+            try:
+                flushed = self.flush()
+            except Exception:
+                self.stats.flush_failures += 1
+                log.exception("operational_analytics_direct.flush_failed")
+                # Failure backoff: nothing was consumed, so retry later
+                # rather than immediately -- a down ClickHouse must not turn
+                # this thread into a hot loop.
+                self._closed.wait(timeout=failure_delay)
+                failure_delay = min(failure_delay * 2, FAILURE_BACKOFF_CAP_SECONDS)
+                continue
+            failure_delay = self._flush_interval
+            if flushed:
+                self.stats.last_success_unix = time.time()
+
+    def flush(self) -> int:
+        """Send everything buffered, grouped per table. Raises on failure
+        with rows RETAINED (front of the deque) for the next attempt."""
+        with self._lock:
+            batch = list(self._buffer)
+            self._buffer.clear()
+        if not batch:
             return 0
-        if result.fetched == 0:
-            time.sleep(idle_delay)
-            idle_delay = min(idle_delay * 2, 30.0)
-        else:
-            idle_delay = max(0.1, args.poll_seconds)
+        by_table: dict[str, list[dict[str, Any]]] = {}
+        for table, row in batch:
+            by_table.setdefault(table, []).append(row)
+        sent = 0
+        try:
+            for table, rows in by_table.items():
+                body = "\n".join(json.dumps(row, default=str) for row in rows).encode()
+                query = f"INSERT INTO {self._database}.{table} FORMAT JSONEachRow"
+                self._post(
+                    f"{self._url}/?query={urllib.parse.quote(query)}",
+                    body,
+                    {
+                        "Authorization": f"Basic {self._auth}",
+                        "Content-Type": "application/x-ndjson",
+                    },
+                )
+                sent += len(rows)
+                by_table[table] = []
+        except Exception:
+            with self._lock:
+                # Put back everything not confirmed sent, oldest first, ahead
+                # of anything published meanwhile. maxlen drops overflow from
+                # the RIGHT via appendleft ordering -- newest retained.
+                remaining = [(table, row) for table, rows in by_table.items() for row in rows]
+                for item in reversed(remaining):
+                    self._buffer.appendleft(item)
+            raise
+        self.stats.inserted += sent
+        return sent
 
+    def close(self) -> None:
+        self._closed.set()
+        self._wake.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+        try:
+            self.flush()
+        except Exception:
+            log.exception("operational_analytics_direct.final_flush_failed")
 
-if __name__ == "__main__":
-    raise SystemExit(main())
+    @staticmethod
+    def _http_post(url: str, body: bytes, headers: dict[str, str]) -> None:
+        if not url.startswith(("http://", "https://")):
+            raise ValueError(f"clickhouse url must be http(s), got {url.split(':', 1)[0]!r}")
+        request = urllib.request.Request(url, data=body, headers=headers, method="POST")  # noqa: S310
+        with urllib.request.urlopen(request, timeout=10) as response:  # noqa: S310
+            response.read()

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -934,8 +934,7 @@ class InMemoryStore:
             hidden_prompt=hidden_prompt,
             enabled=enabled,
             slug=slug,
-            other_model_exists=lambda model_id: self.user_model_store.get(model_id)
-            is not None,
+            other_model_exists=lambda model_id: self.user_model_store.get(model_id) is not None,
         )
 
     def list_custom_models_for_user(self, owner_user_id: str) -> list[CustomModel]:
@@ -955,8 +954,9 @@ class InMemoryStore:
             model_id,
             owner_user_id=owner_user_id,
             patch=patch,
-            other_model_exists=lambda candidate_id: self.user_model_store.get(candidate_id)
-            is not None,
+            other_model_exists=lambda candidate_id: (
+                self.user_model_store.get(candidate_id) is not None
+            ),
         )
 
     def delete_custom_model(self, model_id: str, *, owner_user_id: str) -> bool:
@@ -1013,8 +1013,7 @@ class InMemoryStore:
             enabled=enabled,
             status=status,
             slug=slug,
-            other_model_exists=lambda model_id: self.custom_model_store.get(model_id)
-            is not None,
+            other_model_exists=lambda model_id: self.custom_model_store.get(model_id) is not None,
         )
 
     def list_user_models_for_user(self, owner_user_id: str) -> list[UserProvidedModel]:
@@ -1040,10 +1039,9 @@ class InMemoryStore:
             model_id,
             owner_user_id=owner_user_id,
             patch=patch,
-            other_model_exists=lambda candidate_id: self.custom_model_store.get(
-                candidate_id
-            )
-            is not None,
+            other_model_exists=lambda candidate_id: (
+                self.custom_model_store.get(candidate_id) is not None
+            ),
         )
 
     def delete_user_model(self, model_id: str, *, owner_user_id: str) -> bool:
@@ -1427,9 +1425,7 @@ class InMemoryStore:
                 amount_microdollars=amount,
                 counterparty_account_id=payer_workspace_id,
                 custom_model_id=custom_model_id,
-                authorization_id=(
-                    user_model_authorization_id_from_payout_event_id(event_id)
-                ),
+                authorization_id=(user_model_authorization_id_from_payout_event_id(event_id)),
             )
             return True
 
@@ -1860,9 +1856,7 @@ class InMemoryStore:
             custom_model_revision=custom_model_revision,
             user_provided_model_id=user_provided_model_id,
             user_provided_model_revision=user_provided_model_revision,
-            user_model_prompt_price_microdollars_per_m=(
-                user_model_prompt_price_microdollars_per_m
-            ),
+            user_model_prompt_price_microdollars_per_m=(user_model_prompt_price_microdollars_per_m),
             user_model_completion_price_microdollars_per_m=(
                 user_model_completion_price_microdollars_per_m
             ),
@@ -1951,9 +1945,7 @@ class InMemoryStore:
             self.client_events_batches.append(dict(payload))
             if len(self.client_events_batches) > 1_000:
                 removed = self.client_events_batches.pop(0)
-                self.client_event_ids.discard(
-                    f"{removed['tenant_id']}:{removed['batch_id']}"
-                )
+                self.client_event_ids.discard(f"{removed['tenant_id']}:{removed['batch_id']}")
 
     def record_provider_benchmark(self, sample: ProviderBenchmarkSample) -> None:
         self.generation_store.record_benchmark(sample)
@@ -2418,6 +2410,13 @@ def create_store(settings: Any) -> Store:
                 "operational_analytics_outbox_enabled",
                 False,
             ),
+            operational_analytics_sink=getattr(settings, "operational_analytics_sink", "outbox"),
+            operational_analytics_clickhouse_write_user=getattr(
+                settings, "operational_analytics_clickhouse_write_user", "tr"
+            ),
+            operational_analytics_clickhouse_write_password=getattr(
+                settings, "operational_analytics_clickhouse_write_password", ""
+            ),
             operational_analytics_clickhouse_url=getattr(
                 settings, "operational_analytics_clickhouse_url", ""
             ),
@@ -2440,9 +2439,7 @@ def create_store(settings: Any) -> Store:
             analytics_dual_read_grace_seconds=getattr(
                 settings, "analytics_dual_read_grace_seconds", 30
             ),
-            regional_quota_leases_enabled=getattr(
-                settings, "regional_quota_leases_enabled", False
-            ),
+            regional_quota_leases_enabled=getattr(settings, "regional_quota_leases_enabled", False),
             regional_quota_bigtable_table=getattr(
                 settings,
                 "regional_quota_bigtable_table",

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -155,6 +155,9 @@ from trusted_router.storage_models import (
     UserModelPayout,
     _is_expired,
 )
+from trusted_router.storage_operational_analytics import (
+    OperationalAnalyticsWriter,
+)
 from trusted_router.types import IdentityVerificationStatus, UsageType
 
 T = TypeVar("T")
@@ -287,6 +290,9 @@ class SpannerBigtableStore:
         request_record_write_mode: str = "legacy",
         analytics_outbox_enabled: bool = False,
         operational_analytics_outbox_enabled: bool = False,
+        operational_analytics_sink: str = "outbox",
+        operational_analytics_clickhouse_write_user: str = "tr",
+        operational_analytics_clickhouse_write_password: str = "",
         operational_analytics_clickhouse_url: str = "",
         operational_analytics_clickhouse_user: str = "tr_control_read",
         operational_analytics_clickhouse_password: str = "",
@@ -426,9 +432,7 @@ class SpannerBigtableStore:
         # profile map therefore opens the ledger even when local issuance is off.
         if profiles:
             if not bigtable_instance_id:
-                raise ValueError(
-                    "regional quota app profiles require a Bigtable instance"
-                )
+                raise ValueError("regional quota app profiles require a Bigtable instance")
             try:
                 from google.cloud import bigtable
             except ImportError as exc:  # pragma: no cover - production image.
@@ -479,11 +483,28 @@ class SpannerBigtableStore:
         self.api_keys = SpannerApiKeys(io)
         self.acquisition_store = SpannerAcquisitionAttribution(io)
         self.bedrock_group_buy_store = SpannerBedrockGroupBuy(io)
-        self._operational_analytics_outbox = (
-            SpannerOperationalAnalyticsOutbox(self._database, self._param_types)
-            if operational_analytics_outbox_enabled
-            else None
-        )
+        self._operational_analytics_outbox: OperationalAnalyticsWriter | None
+        if operational_analytics_sink == "direct":
+            # Telemetry stops touching Spanner entirely: canonical rows go
+            # straight to ClickHouse from a bounded in-process buffer. The
+            # sink duck-types the outbox writer, so every enqueue site below
+            # is unchanged. See operational_analytics_direct.py for why.
+            from trusted_router.operational_analytics_direct import (
+                DirectOperationalAnalyticsSink,
+            )
+
+            self._operational_analytics_outbox = DirectOperationalAnalyticsSink(
+                url=operational_analytics_clickhouse_url,
+                database=operational_analytics_clickhouse_database,
+                user=operational_analytics_clickhouse_write_user,
+                password=operational_analytics_clickhouse_write_password,
+            )
+        else:
+            self._operational_analytics_outbox = (
+                SpannerOperationalAnalyticsOutbox(self._database, self._param_types)
+                if operational_analytics_outbox_enabled
+                else None
+            )
         self.generation_store = SpannerGenerations(
             io,
             bt_table=self._bt_table,
@@ -3300,8 +3321,7 @@ class SpannerBigtableStore:
                 # gateway route splits on ':'.
                 return (
                     AuthorizeVerdict(
-                        f"{AuthorizeOutcome.KEY_WINDOW_LIMIT_EXCEEDED}:"
-                        f"{window_decision.window}",
+                        f"{AuthorizeOutcome.KEY_WINDOW_LIMIT_EXCEEDED}:{window_decision.window}",
                         rate_limit=window_decision,
                     ),
                     None,

--- a/src/trusted_router/storage_gcp_generations.py
+++ b/src/trusted_router/storage_gcp_generations.py
@@ -58,13 +58,13 @@ from trusted_router.storage_gcp_generation_records import (
     upsert_generation_record,
 )
 from trusted_router.storage_gcp_io import SpannerIO
-from trusted_router.storage_gcp_operational_analytics_outbox import (
-    SpannerOperationalAnalyticsOutbox,
-)
 from trusted_router.storage_models import (
     Generation,
     ProviderBenchmarkSample,
     _is_byok,
+)
+from trusted_router.storage_operational_analytics import (
+    OperationalAnalyticsWriter,
 )
 
 log = logging.getLogger(__name__)
@@ -72,9 +72,7 @@ ACTIVITY_SCAN_LIMIT = 5000
 
 
 class _AddUsageCallback(Protocol):
-    def __call__(
-        self, key_hash: str, cost_microdollars: int, *, is_byok: bool
-    ) -> None: ...
+    def __call__(self, key_hash: str, cost_microdollars: int, *, is_byok: bool) -> None: ...
 
 
 class SpannerGenerations:
@@ -92,7 +90,7 @@ class SpannerGenerations:
         legacy_family: str | None = None,
         add_usage_to_key: _AddUsageCallback,
         analytics_outbox: SpannerAnalyticsOutbox | None = None,
-        operational_analytics_outbox: SpannerOperationalAnalyticsOutbox | None = None,
+        operational_analytics_outbox: OperationalAnalyticsWriter | None = None,
     ) -> None:
         self._io = io
         self._bt_table = bt_table

--- a/src/trusted_router/storage_operational_analytics.py
+++ b/src/trusted_router/storage_operational_analytics.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import datetime as dt
 import hashlib
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 from trusted_router.catalog import MODELS
 from trusted_router.client_reliability import (
@@ -30,6 +30,25 @@ if TYPE_CHECKING:
     from trusted_router.client_events_schema import ClientEventsBatch
 
 OPERATIONAL_ANALYTICS_OUTBOX_SHARDS = 32
+
+
+class OperationalAnalyticsWriter(Protocol):
+    """What the stores need from an operational-telemetry writer.
+
+    Two implementations: the durable outboxes (Spanner/Postgres rows drained
+    by a poller) and DirectOperationalAnalyticsSink (straight to ClickHouse,
+    no billing-database involvement). The stores hold this Protocol so the
+    choice is wiring, not code.
+    """
+
+    def enqueue_activity(self, generation: Any) -> None: ...
+    def enqueue_activity_tx(self, transaction: Any, generation: Any) -> None: ...
+    def enqueue_synthetic(self, sample: Any) -> None: ...
+    def enqueue_synthetic_tx(self, transaction: Any, sample: Any) -> None: ...
+    def enqueue_client_events(self, payload: dict[str, Any]) -> None: ...
+    def oldest_enqueued_at(self, *, timeout: float | None = None) -> dt.datetime | None: ...
+
+
 ACTIVITY_EVENT_KIND = "activity"
 SYNTHETIC_EVENT_KIND = "synthetic"
 CLIENT_EVENTS_EVENT_KIND = "client_events"
@@ -81,7 +100,9 @@ def build_client_events_payload(
     events: list[dict[str, Any]] = []
     for event in batch.events:
         attempts = event.attempts
-        outcome = attempts[-1].outcome if event.final_outcome == "exhausted" else event.final_outcome
+        outcome = (
+            attempts[-1].outcome if event.final_outcome == "exhausted" else event.final_outcome
+        )
         error_class = next(
             (attempt.error_class for attempt in attempts if attempt.error_class is not None),
             None,
@@ -122,16 +143,12 @@ def build_client_events_payload(
 
     counters: list[dict[str, Any]] = []
     for counter in batch.counters:
-        bucket_start = received_at - dt.timedelta(
-            milliseconds=counter.window_start_age_ms
-        )
+        bucket_start = received_at - dt.timedelta(milliseconds=counter.window_start_age_ms)
         counter_payload = counter.model_dump(mode="json")
         counter_payload.pop("window_start_age_ms")
         counter_payload.update(
             {
-                "bucket_start": _iso_milliseconds(
-                    bucket_start.replace(second=0, microsecond=0)
-                ),
+                "bucket_start": _iso_milliseconds(bucket_start.replace(second=0, microsecond=0)),
                 "tr_fault": int(
                     classify_tr_fault(
                         level=counter.level,

--- a/tests/test_operational_analytics_direct.py
+++ b/tests/test_operational_analytics_direct.py
@@ -1,0 +1,253 @@
+"""The direct ClickHouse sink: canonical parity, bounded loss, honest retries.
+
+The sink exists to take operational telemetry OFF the billing database (the
+outbox drain measured ~25% of the production Spanner instance while idle,
+2026-08-25). Its contracts:
+
+  * rows are byte-identical to what the outbox drainer produced (the
+    canonicalisation is extracted verbatim; the parity test here is what
+    keeps the frozen drainer copy honest until it is deleted),
+  * the buffer is bounded and drops OLDEST with a count -- never blocks a
+    request thread, never grows without limit,
+  * a failed flush retains rows for the next attempt; nothing is silently
+    lost while ClickHouse is down until the bound forces counted drops.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from trusted_router.config import operational_analytics_sink_problems
+from trusted_router.operational_analytics_direct import (
+    DirectOperationalAnalyticsSink,
+    OperationalOutboxRow,
+    normalise_operational_event,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_drainer():
+    spec = importlib.util.spec_from_file_location(
+        "ingest_operational_outbox",
+        REPO_ROOT / "clickhouse" / "ingest_operational_outbox.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+SYNTHETIC_PAYLOAD = {
+    "id": "sample-1",
+    "probe_type": "tls_health",
+    "target": "canonical",
+    "target_url": "https://api.trustedrouter.com/health",
+    "monitor_region": "us-central1",
+    "status": "up",
+    "target_region": "us-central1",
+    "latency_milliseconds": 42,
+    "ttfb_milliseconds": 12,
+    "dns_milliseconds": 1,
+    "tcp_connect_milliseconds": 2,
+    "tls_handshake_milliseconds": 3,
+    "gateway_processing_milliseconds": 4,
+    "connection_reused": 1,
+    "protocol": "h2",
+    "http_status": 200,
+    "error_type": "",
+    "provider": "",
+    "model": "",
+    "selected_provider": "",
+    "selected_model": "",
+    "generation_id": "",
+    "attestation_digest": "",
+    "source_commit": "abc1234",
+    "cost_microdollars": 0,
+    "output_match": 1,
+    "created_at": "2026-08-25T22:00:00+00:00",
+}
+
+COMMIT_TS = dt.datetime(2026, 8, 25, 22, 0, 5, tzinfo=dt.UTC)
+
+
+def _row(kind: str, payload: dict) -> OperationalOutboxRow:
+    return OperationalOutboxRow(
+        shard=0,
+        commit_ts=COMMIT_TS,
+        event_kind=kind,
+        event_id="evt-1",
+        payload=json.dumps(payload),
+    )
+
+
+class TestCanonicalParityWithTheFrozenDrainer:
+    """The extraction and the drainer must emit identical rows until the
+    drainer is deleted. If this fails, one copy was edited without the
+    other -- fix the drift, do not relax the comparison."""
+
+    def test_synthetic_rows_identical(self) -> None:
+        drainer = _load_drainer()
+        ours = normalise_operational_event(_row("synthetic", SYNTHETIC_PAYLOAD))
+        theirs = drainer.normalise_operational_event(
+            drainer.OperationalOutboxRow(
+                shard=0,
+                commit_ts=COMMIT_TS,
+                event_kind="synthetic",
+                event_id="evt-1",
+                payload=json.dumps(SYNTHETIC_PAYLOAD),
+            )
+        )
+        assert [(e.event_kind, e.row) for e in ours] == [(e.event_kind, e.row) for e in theirs]
+
+    def test_bad_payload_raises_in_both(self) -> None:
+        drainer = _load_drainer()
+        broken = dict(SYNTHETIC_PAYLOAD)
+        del broken["status"]
+        with pytest.raises(ValueError):
+            normalise_operational_event(_row("synthetic", broken))
+        with pytest.raises(ValueError):
+            drainer.normalise_operational_event(
+                drainer.OperationalOutboxRow(
+                    shard=0,
+                    commit_ts=COMMIT_TS,
+                    event_kind="synthetic",
+                    event_id="evt-1",
+                    payload=json.dumps(broken),
+                )
+            )
+
+
+class _CapturingPost:
+    def __init__(self, fail_times: int = 0) -> None:
+        self.calls: list[tuple[str, bytes]] = []
+        self.fail_times = fail_times
+
+    def __call__(self, url: str, body: bytes, headers: dict[str, str]) -> None:
+        if self.fail_times > 0:
+            self.fail_times -= 1
+            raise OSError("clickhouse down")
+        self.calls.append((url, body))
+
+
+def _sink(post, **kwargs) -> DirectOperationalAnalyticsSink:
+    return DirectOperationalAnalyticsSink(
+        url="http://clickhouse.internal:8123",
+        database="tr",
+        user="tr",
+        password="pw",  # noqa: S106
+        post=post,
+        start_thread=False,
+        **kwargs,
+    )
+
+
+class TestSinkDelivery:
+    def test_flush_groups_rows_into_the_right_table_as_jsoneachrow(self) -> None:
+        post = _CapturingPost()
+        sink = _sink(post)
+        sink._publish("synthetic", "evt-1", SYNTHETIC_PAYLOAD)
+        assert sink.flush() == 1
+        (url, body) = post.calls[0]
+        assert "INSERT%20INTO%20tr.synthetic_probe_samples" in url
+        parsed = [json.loads(line) for line in body.decode().splitlines()]
+        assert parsed[0]["id"] == "sample-1"
+        assert sink.stats.inserted == 1
+
+    def test_failed_flush_retains_rows_and_the_next_attempt_delivers(self) -> None:
+        post = _CapturingPost(fail_times=1)
+        sink = _sink(post)
+        sink._publish("synthetic", "evt-1", SYNTHETIC_PAYLOAD)
+        with pytest.raises(OSError):
+            sink.flush()
+        assert sink.stats.inserted == 0
+        assert sink.flush() == 1
+        assert sink.stats.inserted == 1
+
+    def test_overflow_drops_oldest_and_counts(self) -> None:
+        post = _CapturingPost()
+        sink = _sink(post, buffer_rows=2)
+        for index in range(4):
+            payload = dict(SYNTHETIC_PAYLOAD, id=f"sample-{index}")
+            sink._publish("synthetic", f"evt-{index}", payload)
+        assert sink.stats.dropped == 2
+        assert sink.flush() == 2
+        rows = [json.loads(line) for _, body in post.calls for line in body.decode().splitlines()]
+        # newest retained, oldest gone
+        assert [row["id"] for row in rows] == ["sample-2", "sample-3"]
+
+    def test_unparseable_payload_is_quarantined_not_lost(self) -> None:
+        post = _CapturingPost()
+        sink = _sink(post)
+        sink._publish("synthetic", "evt-bad", {"id": "x"})
+        assert sink.stats.quarantined == 1
+        assert sink.flush() == 1
+        (url, _) = post.calls[0]
+        assert "operational_outbox_quarantine" in url
+
+    def test_duck_type_surface_matches_the_outbox_writer(self) -> None:
+        sink = _sink(_CapturingPost())
+        # _tx variants ignore the transaction handle by design (documented
+        # dup/phantom trade); freshness reads as empty.
+        assert sink.oldest_enqueued_at() is None
+        assert sink.oldest_enqueued_at(timeout=1.0) is None
+        for name in (
+            "enqueue_activity",
+            "enqueue_activity_tx",
+            "enqueue_synthetic",
+            "enqueue_synthetic_tx",
+            "enqueue_client_events",
+        ):
+            assert callable(getattr(sink, name))
+
+
+def _stub(**overrides) -> SimpleNamespace:
+    base = dict(
+        operational_analytics_sink="outbox",
+        operational_analytics_outbox_enabled=True,
+        operational_analytics_clickhouse_url="http://ch:8123",
+        operational_analytics_clickhouse_write_password="pw",  # noqa: S106
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class TestConfigValidation:
+    def test_direct_without_write_password_is_refused(self) -> None:
+        problems = " ".join(
+            operational_analytics_sink_problems(
+                _stub(
+                    operational_analytics_sink="direct",
+                    operational_analytics_clickhouse_write_password="",
+                )
+            )
+        )
+        assert "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_WRITE_PASSWORD" in problems
+
+    def test_direct_satisfies_the_outbox_requirement(self) -> None:
+        problems = operational_analytics_sink_problems(
+            _stub(
+                operational_analytics_sink="direct",
+                operational_analytics_outbox_enabled=False,
+            )
+        )
+        assert problems == []
+
+    def test_outbox_disabled_without_direct_is_refused(self) -> None:
+        problems = " ".join(
+            operational_analytics_sink_problems(_stub(operational_analytics_outbox_enabled=False))
+        )
+        assert "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED" in problems
+
+    def test_unknown_sink_value_is_refused(self) -> None:
+        problems = " ".join(
+            operational_analytics_sink_problems(_stub(operational_analytics_sink="carrier-pigeon"))
+        )
+        assert "TR_OPERATIONAL_ANALYTICS_SINK" in problems

--- a/tests/test_service_surface_secret_isolation.py
+++ b/tests/test_service_surface_secret_isolation.py
@@ -63,6 +63,11 @@ _ACTION_FORBIDDEN_CONFIG: tuple[tuple[str, object, str], ...] = (
         "ops-clickhouse-secret",
         "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_PASSWORD",
     ),
+    (
+        "operational_analytics_clickhouse_write_password",
+        "ops-clickhouse-write-secret",
+        "TR_OPERATIONAL_ANALYTICS_CLICKHOUSE_WRITE_PASSWORD",
+    ),
     ("google_data_manager_enabled", True, "TR_GOOGLE_DATA_MANAGER_ENABLED"),
     (
         "google_data_manager_kms_key_name",
@@ -144,6 +149,7 @@ _SENSITIVE_TEST_VALUES: dict[str, object] = {
     "provider_analytics_clickhouse_password": "provider-clickhouse-secret",
     "operational_analytics_clickhouse_url": "https://ops-clickhouse.example",
     "operational_analytics_clickhouse_password": "ops-clickhouse-secret",
+    "operational_analytics_clickhouse_write_password": "ops-clickhouse-write-secret",
     "sentry_dsn": "https://example@example.ingest.sentry.io/1",
     "google_data_manager_enabled": True,
     "google_data_manager_kms_key_name": "projects/test/locations/global/keyRings/gdm/keys/k",
@@ -205,6 +211,7 @@ _EXPECTED_OWNER_GROUPS: tuple[tuple[frozenset[str], tuple[str, ...]], ...] = (
         (
             "clickhouse_url",
             "clickhouse_password",
+            "operational_analytics_clickhouse_write_password",
         ),
     ),
     (


### PR DESCRIPTION
Root-cause fix for the launch-day incident: the operational-analytics outbox drain was measured (Spanner query stats) at ~25% of the production instance's CPU while idle — 64 ordered scans every ~1.5s against the billing database, for telemetry that never needed transactional durability.

- New `operational_analytics_direct.py`: bounded in-process buffer → batched ClickHouse inserts. Canonicalisation extracted verbatim from the drainer, pinned by a parity test. Drop-oldest with a count, quarantine, retain-and-retry with capped backoff.
- Zero enqueue-site changes: sink duck-types the outbox writer behind an `OperationalAnalyticsWriter` Protocol.
- Per-cloud cutover via `TR_OPERATIONAL_ANALYTICS_SINK=direct` (fail-closed on write credential; default stays `outbox` — this PR is behaviorally inert until the env flips).
- Interim drainer taming: single unordered global fetch (doubles as the emptiness probe), 32-statement watermark deleted, idle backoff → idle cost ~43 qps → ~0.03.

Affected suites: 899 passed. New: 11 tests incl. drainer parity. Sensitive-setting registered in the surface-isolation mirrors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)