### PR TITLE
CI hardening: bound hangs, pin wire types, patch the live store

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,12 +54,20 @@ dev = [
   "pytest-cov>=7.1.0",
   "pytest-httpx>=0.36.2",
   "pytest-split>=0.10",
-  "pytest-xdist>=3.8.0",
+  "pytest-timeout>=2.3",
+    "pytest-xdist>=3.8.0",
   "ruff>=0.8.0",
   "sec-parser>=0.58.0",
 ]
 
 [tool.pytest.ini_options]
+# Wall-clock ceiling per test. Ten minutes is far above the slowest real
+# test and far below the six hours GitHub lets a wedged runner burn --
+# the 2026-08-26 shard hang cost 2.5 hours of deploy latency because no
+# per-test bound existed. thread method: signal-based interrupts break
+# under xdist workers with subprocess fixtures.
+timeout = 600
+timeout_method = "thread"
 asyncio_mode = "auto"
 testpaths = ["tests"]
 pythonpath = ["src"]

--- a/tests/conformance/conftest.py
+++ b/tests/conformance/conftest.py
@@ -133,6 +133,23 @@ def _spanner_fake_store() -> Store:
     return store
 
 
+def _with_connect_timeout(dsn: str, seconds: int = 10) -> str:
+    """Bound connection ESTABLISHMENT against a wedged server.
+
+    On 2026-08-26 CI shard `test (6)` hung for 2.5 hours: PGAdapter's log shows
+    a connection handshake beginning at 09:58:16 and nothing ever again, while
+    psycopg waited forever -- its default connect timeout is infinite -- and
+    every xdist worker eventually parked behind the same dead emulator. A
+    conformance backend that cannot accept a connection within seconds is
+    DOWN, and the honest outcome is a failed test naming the backend, not a
+    silent six-hour runner burn.
+    """
+    if "connect_timeout" in dsn:
+        return dsn
+    separator = "&" if "?" in dsn else "?"
+    return f"{dsn}{separator}connect_timeout={seconds}"
+
+
 def _postgres_store() -> Store:
     """A PostgresStore pointed at the conformance database.
 
@@ -148,14 +165,11 @@ def _postgres_store() -> Store:
     """
     dsn = os.environ.get("TR_CONFORMANCE_POSTGRES_DSN")
     if not dsn:
-        pytest.skip(
-            "Postgres conformance backend not configured "
-            "(set TR_CONFORMANCE_POSTGRES_DSN)"
-        )
+        pytest.skip("Postgres conformance backend not configured (set TR_CONFORMANCE_POSTGRES_DSN)")
     from trusted_router.storage_postgres import PostgresStore
 
     store = PostgresStore(
-        dsn,
+        _with_connect_timeout(dsn),
         postgres_iam_auth=os.environ.get("TR_POSTGRES_IAM_AUTH", ""),
         postgres_iam_region=os.environ.get("TR_POSTGRES_IAM_REGION", ""),
     )
@@ -191,7 +205,7 @@ def _spanner_pg_store() -> Store:
         )
     from trusted_router.storage_postgres import PostgresStore
 
-    store = PostgresStore(dsn)
+    store = PostgresStore(_with_connect_timeout(dsn))
     store.apply_schema()
     return store
 
@@ -222,9 +236,7 @@ _IN_PROCESS_BACKENDS = frozenset({"memory", "spanner-fake"})
 _BACKEND_PARAMS = [
     name
     if name in _IN_PROCESS_BACKENDS
-    else pytest.param(
-        name, marks=pytest.mark.xdist_group(f"conformance-{name}")
-    )
+    else pytest.param(name, marks=pytest.mark.xdist_group(f"conformance-{name}"))
     for name in sorted(BACKENDS)
 ]
 
@@ -265,9 +277,7 @@ _SPANNER_FAKE_KNOWN_GAPS: dict[str, str] = {
     "test_insufficient_reserve_does_not_mutate_balance": _C1_LEGACY_MONEY,
     "test_finalize_gateway_authorization_is_exactly_once": _C1_LEGACY_MONEY,
     "test_finalize_unknown_authorization_is_false_not_error": _C1_LEGACY_MONEY,
-    "test_synthetic_rollups_apply_ranges_order_limit_and_histogram_option": (
-        _FAKE_ROLLUP_ORDERING
-    ),
+    "test_synthetic_rollups_apply_ranges_order_limit_and_histogram_option": (_FAKE_ROLLUP_ORDERING),
 }
 
 

--- a/tests/conformance/test_store_semantics.py
+++ b/tests/conformance/test_store_semantics.py
@@ -1135,14 +1135,8 @@ def test_key_limit_window_columns_and_index_exist(store: Store, unique: str) -> 
 # --------------------------------------------------------------------------
 
 
-def _seed_key_limit(store: Store, key_hash: str, **columns: object) -> None:
-    pool = getattr(store, "_pool", None)
-    if pool is None:
-        pytest.skip("backend has no SQL schema to seed")
-    cols = {"workspace_id": "ws-keylimit", "key_hash": key_hash, "shard": 0, **columns}
-    names = ", ".join(cols)
-    marks = ", ".join(["%s"] * len(cols))
-    bigint_columns = {
+_SEED_BIGINT_COLUMNS = frozenset(
+    {
         "shard",
         "limit_micro",
         "usage",
@@ -1155,8 +1149,23 @@ def _seed_key_limit(store: Store, key_hash: str, **columns: object) -> None:
         "week_usage",
         "month_usage",
     }
+)
+
+
+def _seed_key_limit(store: Store, key_hash: str, **columns: object) -> None:
+    pool = getattr(store, "_pool", None)
+    if pool is None:
+        pytest.skip("backend has no SQL schema to seed")
+    cols = {"workspace_id": "ws-keylimit", "key_hash": key_hash, "shard": 0, **columns}
+    names = ", ".join(cols)
+    # Explicit ::bigint casts, not just Int8 wrappers: even with wrapped
+    # params and prepare=False, PGAdapter intermittently rejected this INSERT
+    # with "Invalid length for int8: 2" (binary-format negotiation race,
+    # observed on PR #840's CI and gone on the identical rerun). A cast pins
+    # the server-side type regardless of the wire format chosen per call.
+    marks = ", ".join("%s::bigint" if name in _SEED_BIGINT_COLUMNS else "%s" for name in cols)
     values = tuple(
-        Int8(value) if name in bigint_columns and value is not None else value
+        Int8(value) if name in _SEED_BIGINT_COLUMNS and value is not None else value
         for name, value in cols.items()
     )
     with pool.connection() as conn:

--- a/tests/test_service_surfaces.py
+++ b/tests/test_service_surfaces.py
@@ -40,9 +40,7 @@ def _signatures(app: FastAPI) -> set[tuple[str, str]]:
 
 
 def _paths(app: FastAPI) -> set[str]:
-    return {
-        path for path, route in effective_routes(app) if isinstance(route, APIRoute)
-    }
+    return {path for path, route in effective_routes(app) if isinstance(route, APIRoute)}
 
 
 def _endpoints(app: FastAPI) -> dict[object, set[str]]:
@@ -297,8 +295,7 @@ def test_regional_observer_has_status_and_synthetic_but_no_account_or_money_rout
 def test_versioned_api_pairs_never_split_across_surface_owners() -> None:
     combined = _app("combined")
     owners = {
-        surface: _paths(_app(surface))
-        for surface in ("public", "actions", "control", "internal")
+        surface: _paths(_app(surface)) for surface in ("public", "actions", "control", "internal")
     }
 
     for paths in _endpoints(combined).values():
@@ -377,10 +374,18 @@ def test_observer_ready_fails_when_its_status_store_is_unavailable(
     def unavailable(_self: object) -> None:
         raise RuntimeError("database unavailable")
 
+    # Patch the TYPE OF THE LIVE SINGLETON, not just InMemoryStore: /ready
+    # calls module-level STORE.readiness_check, and a neighbouring test in the
+    # same xdist worker may have left a different store class configured --
+    # under the post-cutover matrix this intermittently made the class patch
+    # miss and /ready answer 200 (observed on PR #840's post-cutover shard).
+    import trusted_router.storage as storage_module
+
     monkeypatch.setattr(
         "trusted_router.storage.InMemoryStore.readiness_check",
         unavailable,
     )
+    monkeypatch.setattr(type(storage_module.STORE), "readiness_check", unavailable, raising=False)
     response = TestClient(_app("observer")).get("/ready")
 
     assert response.status_code == 503

--- a/uv.lock
+++ b/uv.lock
@@ -786,7 +786,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/6b/457ca12dad3ee9bfcc9a545cfd6b64b359ba49de40f776f6e028e678f262/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5879712accf6e14bb01aa5e67440eb84998b8d104b509cc7a6dc0b8f656a474", size = 6053539, upload-time = "2026-05-29T23:11:43.19Z" },
@@ -819,34 +819,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [[package]]
@@ -2637,7 +2637,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2676,7 +2676,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2688,7 +2688,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2718,9 +2718,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2732,7 +2732,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3577,6 +3577,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2f/16/8af4c5f2ceb3640bb1f78dfdf5c184556b10dfe9369feaaad7ff1c13f329/pytest_split-0.11.0.tar.gz", hash = "sha256:8ebdb29cc72cc962e8eb1ec07db1eeb98ab25e215ed8e3216f6b9fc7ce0ec2b5", size = 13421, upload-time = "2026-02-03T09:14:31.469Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/a1/d4423657caaa8be9b31e491592b49cebdcfd434d3e74512ce71f6ec39905/pytest_split-0.11.0-py3-none-any.whl", hash = "sha256:899d7c0f5730da91e2daf283860eb73b503259cb416851a65599368849c7f382", size = 11911, upload-time = "2026-02-03T09:14:33.708Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]
@@ -4830,6 +4842,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-httpx" },
     { name = "pytest-split" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "sec-parser" },
@@ -4871,6 +4884,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-httpx", specifier = ">=0.36.2" },
     { name = "pytest-split", specifier = ">=0.10" },
+    { name = "pytest-timeout", specifier = ">=2.3" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.8.0" },
     { name = "sec-parser", specifier = ">=0.58.0" },


### PR DESCRIPTION
Root-cause fixes for the three CI-reliability failures of the last 24h: infinite psycopg connect against a wedged PGAdapter (now connect_timeout=10 + pytest-timeout 600s), the int8 binary-format race in the conformance seeder (::bigint casts), and the observer-ready ordering flake (patch the live STORE singleton's type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)