### PR TITLE
Reinstate the workspace-directory refresh timer

### DIFF
--- a/clickhouse/refresh_workspace_directory.py
+++ b/clickhouse/refresh_workspace_directory.py
@@ -1,10 +1,15 @@
-"""Refresh the no-PII ClickHouse workspace directory from Spanner, on demand.
+"""Refresh the no-PII ClickHouse workspace directory from Spanner.
 
-Not a scheduled job, deliberately. Since 2026-08-19 every new activity row
-carries its own ``workspace_id``, so the tenant_id map only matters for the
-closed set of rows written before that change -- a set that cannot grow. Run
-this when a workspace RENAME should be reflected in ``workspace_directory``,
-or to re-freeze the historical map; there is nothing that needs it hourly.
+Scheduled every 30 minutes since 2026-08-26 (tr-clickhouse-workspace-directory
+.timer). An earlier version of this docstring said "not a scheduled job,
+deliberately", reasoning that the tenant_id map only matters for the closed set
+of pre-2026-08-19 rows. That reasoning covered the MAP and forgot the
+DIRECTORY: workspace/domain signup reporting joins new activity to
+``workspace_directory`` for names, so every workspace created after the last
+manual run reports as an unnamed id. It was run by hand on Aug 23 and Aug 24
+and then not again; by Aug 26 the directory was 685 workspaces behind while
+live usage stayed current. A dimension table that only updates when somebody
+remembers it is how that happens, so now the timer remembers.
 
 The projection permits workspace ids and workspace names only; all other
 entity attributes are discarded before a ClickHouse payload is built.

--- a/clickhouse/tr-clickhouse-workspace-directory.service
+++ b/clickhouse/tr-clickhouse-workspace-directory.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=TrustedRouter workspace directory refresh from Spanner
+After=network-online.target clickhouse-server.service
+
+[Service]
+Type=oneshot
+User=tr-clickhouse-ingest
+Group=tr-clickhouse-ingest
+WorkingDirectory=/opt/tr-clickhouse
+Environment=PYTHONPATH=/opt/tr-clickhouse/src
+EnvironmentFile=/etc/tr-clickhouse-ingest.env
+ExecStart=/opt/tr-clickhouse/venv/bin/python -m clickhouse.refresh_workspace_directory
+TimeoutStartSec=5m
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=/var/lib/tr-clickhouse-ingest

--- a/clickhouse/tr-clickhouse-workspace-directory.timer
+++ b/clickhouse/tr-clickhouse-workspace-directory.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Refresh the ClickHouse workspace directory every 30 minutes
+
+[Timer]
+OnBootSec=10min
+OnUnitActiveSec=30min
+RandomizedDelaySec=5min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/deploy/clickhouse_live_ingestion.sh
+++ b/scripts/deploy/clickhouse_live_ingestion.sh
@@ -64,6 +64,10 @@ ssh_node --command="sudo sh -c '
     /etc/systemd/system/tr-clickhouse-reconcile.service
   install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-reconcile.timer \
     /etc/systemd/system/tr-clickhouse-reconcile.timer
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-workspace-directory.service \
+    /etc/systemd/system/tr-clickhouse-workspace-directory.service
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-workspace-directory.timer \
+    /etc/systemd/system/tr-clickhouse-workspace-directory.timer
   install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-archive.service \
     /etc/systemd/system/tr-clickhouse-archive.service
   install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-archive.timer \
@@ -109,6 +113,7 @@ ssh_node --command="sudo sh -c '
       systemctl is-active \"\$unit\"
     fi
   done
+  systemctl enable --now tr-clickhouse-workspace-directory.timer
   systemctl enable --now tr-clickhouse-reconcile.timer
   systemctl enable --now tr-clickhouse-archive.timer
   systemctl enable --now tr-clickhouse-archive-restore.timer

--- a/tests/test_clickhouse_operational_deploy.py
+++ b/tests/test_clickhouse_operational_deploy.py
@@ -369,21 +369,32 @@ def test_capacity_probe_is_disposable_and_uses_a_conservative_gate() -> None:
     assert "add_shard_now" in script
 
 
-def test_workspace_directory_is_on_demand_not_a_timer() -> None:
-    """The directory refresh is an operator tool, not a scheduled unit.
+def test_workspace_directory_timer_is_installed_and_enabled() -> None:
+    """Reinstated 2026-08-26, and this test used to assert the opposite.
 
-    The hourly timer was removed on 2026-08-19: new activity rows carry
-    workspace_id directly, so the map of tenant_id -> workspace_id only covers
-    the CLOSED set of pre-change rows and never goes stale. A timer would be a
-    standing moving part guarding against a drift that can no longer happen --
-    and it was wired into this deploy script, so removing the units without
-    removing the wiring would break the next deploy at install -m.
+    The hourly timer was removed on 2026-08-19 on the reasoning that new
+    activity rows carry workspace_id directly, so the tenant_id map covers a
+    closed set and cannot drift. That was true of the MAP and false of the
+    DIRECTORY: signup reporting joins new activity to workspace names here, so
+    every workspace created after the last manual run reports as an unnamed id.
+    Between two manual runs (Aug 23 and Aug 24) and Aug 26 the directory fell
+    685 workspaces behind while live usage stayed current.
+
+    Both states of this test pinned the install WIRING, which is the part that
+    breaks deploys when units and installer disagree. Unit content and cadence
+    are pinned in tests/test_workspace_directory_refresh.py.
     """
     deploy = (ROOT / "scripts/deploy/clickhouse_live_ingestion.sh").read_text()
 
-    assert "tr-clickhouse-workspace-directory" not in deploy
-    assert not (ROOT / "clickhouse/tr-clickhouse-workspace-directory.service").exists()
-    assert not (ROOT / "clickhouse/tr-clickhouse-workspace-directory.timer").exists()
+    assert (ROOT / "clickhouse/tr-clickhouse-workspace-directory.service").exists()
+    assert (ROOT / "clickhouse/tr-clickhouse-workspace-directory.timer").exists()
+    for unit in (
+        "tr-clickhouse-workspace-directory.service",
+        "tr-clickhouse-workspace-directory.timer",
+    ):
+        assert f"/opt/tr-clickhouse/clickhouse/{unit}" in deploy
+        assert f"/etc/systemd/system/{unit}" in deploy
+    assert "systemctl enable --now tr-clickhouse-workspace-directory.timer" in deploy
     # The schema applies stay: the directory remains queryable, and new rows
     # need the workspace_id column before the drain ships.
     assert "010_workspace_directory.sql" in deploy

--- a/tests/test_workspace_directory_refresh.py
+++ b/tests/test_workspace_directory_refresh.py
@@ -131,3 +131,31 @@ def test_workspace_directory_schemas_have_matching_columns_and_version_order() -
         "    refreshed_at"
     ) in replicated
     assert "ENGINE = ReplacingMergeTree(refreshed_at)" in single
+
+
+def test_the_refresh_is_scheduled_and_installed() -> None:
+    """The directory went 685 workspaces stale between two manual runs.
+
+    The module used to declare itself deliberately unscheduled, which was true
+    for the tenant map and false for the directory: signup reporting joins new
+    activity to workspace names here, and a dimension table that only updates
+    when somebody remembers it goes quiet exactly when nobody is looking. These
+    pins keep the timer pair present, hardened like its siblings, and actually
+    installed and enabled by the node installer.
+    """
+    root = Path(__file__).resolve().parents[1]
+    service = (root / "clickhouse/tr-clickhouse-workspace-directory.service").read_text()
+    timer = (root / "clickhouse/tr-clickhouse-workspace-directory.timer").read_text()
+    installer = (root / "scripts/deploy/clickhouse_live_ingestion.sh").read_text()
+
+    assert "python -m clickhouse.refresh_workspace_directory" in service
+    assert "User=tr-clickhouse-ingest" in service
+    assert "EnvironmentFile=/etc/tr-clickhouse-ingest.env" in service
+    assert "ProtectSystem=strict" in service
+
+    assert "OnUnitActiveSec=30min" in timer
+    assert "Persistent=true" in timer
+
+    assert "tr-clickhouse-workspace-directory.service" in installer
+    assert "tr-clickhouse-workspace-directory.timer" in installer
+    assert "systemctl enable --now tr-clickhouse-workspace-directory.timer" in installer


### PR DESCRIPTION
Restores the workspace-directory refresh, which stopped at Aug 24 14:03 PDT — because it was never scheduled. The ClickHouse query log shows exactly two writes in four days: manual runs on Aug 23 16:53 and Aug 24 21:04 UTC, zero failures after. Nothing broke; the last person just stopped running it by hand.

**The history matters here.** The hourly timer existed and was *removed on 2026-08-19*, with a test pinning its absence. The removal reasoning — new activity rows carry `workspace_id`, so the tenant map covers a closed set — was true of the **map** and false of the **directory**: signup reporting joins new activity to workspace *names* here, so every workspace created after the last manual run reports as an unnamed id. Between Aug 24 and Aug 26 the directory fell **685 workspaces behind** (1,247 → 1,932 rows on catch-up) while live usage stayed current.

Already done operationally: a catch-up run on tr-clickhouse-1 (via `systemd-run` with the unit's own env file, so the credential never entered argv) — the directory is current as of 12:44 UTC today. This PR is what keeps it current.

- `tr-clickhouse-workspace-directory.service` — copies `spanner-delivery`'s hardening (same user, env file, `ProtectSystem=strict`)
- `tr-clickhouse-workspace-directory.timer` — 30-minute, `Persistent=true` so a reboot doesn't eat a cycle
- installer wires both and `enable --now`s the timer
- the module docstring that declared it "deliberately unscheduled" now explains why that premise didn't survive
- `test_workspace_directory_is_on_demand_not_a_timer` — the guard on the old decision — is rewritten to pin the new one, carrying the round-trip story so the next remover knows what the last removal missed

26 tests pass; ruff and mypy clean.