### PR TITLE
Make disabled fallbacks a hard model guarantee

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,11 @@ remains available.
   Tinfoil first. Chat requests also honor OpenRouter-style `models` and
   `provider` routing filters (`order`, `only`, `ignore`, `allow_fallbacks`,
   `min_privacy`, `data_collection`, and `sort`) so clients can request explicit
-  fallback chains or provider preferences. `min_privacy="confidential"` is a
+  fallback chains or provider preferences. Setting `allow_fallbacks=false`
+  either at the request top level or as `provider.allow_fallbacks` is a hard
+  model-integrity guarantee: TrustedRouter authorizes one provider route for
+  the requested model and fails instead of substituting another model.
+  `min_privacy="confidential"` is a
   hard provider-side confidential-compute + E2EE requirement and fails closed;
   the request-value aliases `e2e` and `e2ee` select the same tier
   rather than falling back to a weaker route.

--- a/src/trusted_router/routing.py
+++ b/src/trusted_router/routing.py
@@ -377,20 +377,39 @@ def video_route_endpoint_candidates(
 
 
 def provider_route_preferences(body: dict[str, Any]) -> RoutePreferences:
-    raw = body.get("provider")
-    if not isinstance(raw, dict):
-        return RoutePreferences()
+    raw_provider = body.get("provider")
+    raw = raw_provider if isinstance(raw_provider, dict) else {}
 
     order = tuple(_provider_filter_list("order", raw.get("order")))
     only = frozenset(_provider_filter_list("only", raw.get("only")))
     ignore = frozenset(_provider_filter_list("ignore", raw.get("ignore")))
-    allow_fallbacks = raw.get("allow_fallbacks")
+    top_level_allow_fallbacks = body.get("allow_fallbacks")
+    nested_allow_fallbacks = raw.get("allow_fallbacks")
+    if top_level_allow_fallbacks is not None and not isinstance(
+        top_level_allow_fallbacks, bool
+    ):
+        raise api_error(400, "allow_fallbacks must be a boolean", ErrorType.BAD_REQUEST)
+    if nested_allow_fallbacks is not None and not isinstance(nested_allow_fallbacks, bool):
+        raise api_error(400, "provider.allow_fallbacks must be a boolean", ErrorType.BAD_REQUEST)
+    if (
+        top_level_allow_fallbacks is not None
+        and nested_allow_fallbacks is not None
+        and top_level_allow_fallbacks != nested_allow_fallbacks
+    ):
+        raise api_error(
+            400,
+            "allow_fallbacks conflicts with provider.allow_fallbacks",
+            ErrorType.BAD_REQUEST,
+        )
+    allow_fallbacks = (
+        top_level_allow_fallbacks
+        if top_level_allow_fallbacks is not None
+        else nested_allow_fallbacks
+    )
     if allow_fallbacks is None:
         allow_fallbacks_bool = True
-    elif isinstance(allow_fallbacks, bool):
-        allow_fallbacks_bool = allow_fallbacks
     else:
-        raise api_error(400, "provider.allow_fallbacks must be a boolean", ErrorType.BAD_REQUEST)
+        allow_fallbacks_bool = allow_fallbacks
 
     data_collection = raw.get("data_collection")
     if data_collection is not None:
@@ -458,8 +477,12 @@ def _routing_for_body(
     AUTO, build the RoutePreferences. Suffix-derived overrides win over
     body-set fields (per OpenRouter: the suffix is the explicit shorthand
     and is meant to be authoritative)."""
-    ids, overrides = _requested_model_ids(body, settings)
     prefs = provider_route_preferences(body)
+    ids, overrides = _requested_model_ids(
+        body,
+        settings,
+        include_fallback_models=prefs.allow_fallbacks,
+    )
     if "sort" in overrides:
         prefs = dataclasses.replace(prefs, sort=overrides["sort"])
     if "order" in overrides:
@@ -543,7 +566,10 @@ def resolve_model_alias(model_id: str) -> str:
 
 
 def _requested_model_ids(
-    body: dict[str, Any], settings: Settings
+    body: dict[str, Any],
+    settings: Settings,
+    *,
+    include_fallback_models: bool = True,
 ) -> tuple[list[str], dict[str, Any]]:
     ids: list[str] = []
     overrides: dict[str, Any] = {}
@@ -595,7 +621,16 @@ def _requested_model_ids(
         take(model_id)
 
     fallback_models = body.get("models")
-    if fallback_models is not None:
+    if not model_id and not include_fallback_models and fallback_models is not None:
+        if not isinstance(fallback_models, list):
+            raise api_error(400, "models must be an array of model IDs", ErrorType.BAD_REQUEST)
+        if not fallback_models:
+            raise api_error(400, "model is required", ErrorType.BAD_REQUEST)
+        primary = fallback_models[0]
+        if not isinstance(primary, str) or not primary.strip():
+            raise api_error(400, "models must contain only model IDs", ErrorType.BAD_REQUEST)
+        take(primary.strip())
+    elif include_fallback_models and fallback_models is not None:
         if not isinstance(fallback_models, list):
             raise api_error(400, "models must be an array of model IDs", ErrorType.BAD_REQUEST)
         for item in fallback_models:

--- a/tests/test_auth_and_routing.py
+++ b/tests/test_auth_and_routing.py
@@ -157,9 +157,9 @@ def test_provider_order_sort_and_no_fallbacks_shape_candidate_list(
         "/v1/chat/completions",
         headers=inference_headers,
         json={
+            "model": "mistralai/mistral-small-2603",
             "models": [
                 "openai/gpt-5.4-nano",
-                "mistralai/mistral-small-2603",
                 "deepseek/deepseek-v4-flash",
             ],
             "provider": {
@@ -346,8 +346,8 @@ def test_gateway_authorize_honors_models_and_provider_filters() -> None:
         "/v1/internal/gateway/authorize",
         json={
             "api_key_hash": created["data"]["hash"],
-            "model": "openai/gpt-5.4-nano",
-            "models": ["mistralai/mistral-small-2603", "deepseek/deepseek-v4-flash"],
+            "model": "deepseek/deepseek-v4-flash",
+            "models": ["openai/gpt-5.4-nano", "mistralai/mistral-small-2603"],
             "provider": {"order": ["deepseek"], "usage": "byok", "allow_fallbacks": False},
             "estimated_input_tokens": 10,
             "max_output_tokens": 4,
@@ -361,6 +361,44 @@ def test_gateway_authorize_honors_models_and_provider_filters() -> None:
     assert [item["model"] for item in pinned_data["route_candidates"]] == [
         "deepseek/deepseek-v4-flash",
     ]
+
+
+def test_gateway_authorize_top_level_no_fallbacks_ignores_stale_alternatives() -> None:
+    app = create_app(Settings(environment="test"))
+    local_client = TestClient(app)
+    created = local_client.post(
+        "/v1/keys",
+        headers={"x-trustedrouter-user": "alice@example.com"},
+        json={"name": "gateway"},
+    ).json()
+    configured = local_client.put(
+        "/v1/byok/providers/deepinfra",
+        headers={"x-trustedrouter-user": "alice@example.com"},
+        json={"secret_ref": "env://DEEPINFRA_API_KEY"},
+    )
+    assert configured.status_code == 201, configured.text
+
+    authorize = local_client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": created["data"]["hash"],
+            "model": "openai/gpt-oss-20b",
+            "models": ["google/gemini-2.0-flash-lite"],
+            "allow_fallbacks": False,
+            "provider": {"only": ["deepinfra"], "usage": "byok"},
+            "estimated_input_tokens": 10,
+            "max_output_tokens": 4,
+        },
+    )
+
+    assert authorize.status_code == 200, authorize.text
+    data = authorize.json()["data"]
+    assert data["requested_model"] == "openai/gpt-oss-20b"
+    assert data["model"] == "openai/gpt-oss-20b"
+    assert {item["model"] for item in data["route_candidates"]} == {
+        "openai/gpt-oss-20b"
+    }
+    assert len(data["route_candidates"]) == 1
 
 
 def test_gateway_authorize_expands_fast_router_pool() -> None:

--- a/tests/test_routing_unit.py
+++ b/tests/test_routing_unit.py
@@ -144,9 +144,9 @@ def test_chat_route_candidates_provider_order_reorders() -> None:
 def test_chat_route_candidates_allow_fallbacks_false_returns_only_head() -> None:
     candidates = chat_route_candidates(
         {
+            "model": "mistralai/mistral-small-2603",
             "models": [
                 "openai/gpt-5.4-nano",
-                "mistralai/mistral-small-2603",
                 "anthropic/claude-sonnet-4.6",
             ],
             "provider": {"allow_fallbacks": False, "order": ["mistral"]},
@@ -155,6 +155,51 @@ def test_chat_route_candidates_allow_fallbacks_false_returns_only_head() -> None
     )
     assert len(candidates) == 1
     assert candidates[0].provider == "mistral"
+
+
+@pytest.mark.parametrize(
+    "fallback_control",
+    [
+        {"allow_fallbacks": False},
+        {"provider": {"allow_fallbacks": False}},
+    ],
+)
+def test_allow_fallbacks_false_never_validates_or_routes_fallback_models(
+    fallback_control: dict[str, object],
+) -> None:
+    """A disabled fallback list is inert, including stale model IDs.
+
+    Validating the fallback array before applying the flag can reject a valid
+    primary with an error naming a model the caller explicitly disabled.
+    """
+
+    candidates = chat_route_endpoint_candidates(
+        {
+            "model": "openai/gpt-oss-20b",
+            "models": ["google/gemini-2.0-flash-lite"],
+            **fallback_control,
+        },
+        _settings(),
+    )
+
+    assert len(candidates) == 1
+    model, _endpoint = candidates[0]
+    assert model.id == "openai/gpt-oss-20b"
+
+
+def test_allow_fallbacks_false_uses_first_models_entry_when_model_is_absent() -> None:
+    candidates = chat_route_candidates(
+        {
+            "models": [
+                "openai/gpt-5.4-nano",
+                "google/gemini-2.0-flash-lite",
+            ],
+            "allow_fallbacks": False,
+        },
+        _settings(),
+    )
+
+    assert [candidate.id for candidate in candidates] == ["openai/gpt-5.4-nano"]
 
 
 def test_chat_route_candidates_sort_by_throughput_uses_rank_table() -> None:
@@ -208,6 +253,43 @@ def test_provider_route_preferences_handles_missing_provider_key() -> None:
     assert prefs.allow_fallbacks is True
     assert prefs.sort is None
     assert prefs.data_collection is None
+
+
+def test_provider_route_preferences_accepts_top_level_allow_fallbacks_alias() -> None:
+    prefs = provider_route_preferences({"allow_fallbacks": False})
+    assert prefs.allow_fallbacks is False
+
+
+def test_top_level_no_fallbacks_pins_exact_request_to_one_provider_route() -> None:
+    candidates = chat_route_endpoint_candidates(
+        {
+            "model": "openai/gpt-oss-20b",
+            "allow_fallbacks": False,
+        },
+        _settings(),
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0][0].id == "openai/gpt-oss-20b"
+
+
+def test_provider_route_preferences_rejects_conflicting_fallback_controls() -> None:
+    with pytest.raises(HTTPException) as ctx:
+        provider_route_preferences(
+            {
+                "allow_fallbacks": False,
+                "provider": {"allow_fallbacks": True},
+            }
+        )
+    assert ctx.value.status_code == 400
+    assert "conflict" in ctx.value.detail["error"]["message"].lower()
+
+
+def test_provider_route_preferences_rejects_non_boolean_top_level_fallback_control() -> None:
+    with pytest.raises(HTTPException) as ctx:
+        provider_route_preferences({"allow_fallbacks": "false"})
+    assert ctx.value.status_code == 400
+    assert ctx.value.detail["error"]["message"] == "allow_fallbacks must be a boolean"
 
 
 def test_provider_route_preferences_handles_provider_as_non_dict() -> None:


### PR DESCRIPTION
## Summary

- accept both top-level `allow_fallbacks` and `provider.allow_fallbacks`
- reject conflicting or non-boolean fallback controls
- resolve the no-fallback policy before parsing fallback model IDs
- when fallbacks are disabled, pin an explicit `model`, or the first `models` entry when no explicit model exists
- document the hard model-integrity contract

## Regression coverage

- exact `openai/gpt-oss-20b` request produces one route
- stale Gemini alternatives are inert when fallbacks are disabled
- gateway authorization returns only the requested GPT OSS model and provider route
- conflicts and invalid controls fail with stable 400 errors

## Verification

- focused routing and authorization suite: 76 passed
- Ruff: passed
- mypy: passed
- full suite: 6,630 passed, 313 skipped, 10 expected failures; one unrelated notification test failed only in the 48-minute aggregate run and passed immediately in isolation
