### PR TITLE
Accept 128-byte AWS user_data ahead of signed inference receipts

### DIFF
--- a/scripts/verify_trust_measurements.py
+++ b/scripts/verify_trust_measurements.py
@@ -133,12 +133,15 @@ WHAT THIS DOES NOT ESTABLISH
       "every enclave we happened to reach matched", nothing more. Enumerating
       the fleet needs per-NLB pinning (see trusted_router.synthetic.probes and
       TR_SYNTHETIC_GATEWAY_REGION_TARGETS), which is a different tool's job.
-    * The AWS certificate binding checked here is user_data[0:32] only. user_data
-      is 96 bytes: [0:32] is SHA-256 of the served certificate DER (verified on
-      6/6 samples when this was written, 8/8 on re-measurement), [32:64] is a
-      constant this script does not interpret, and [64:96] is the TLS exporter
-      channel binding, which cannot be checked from here because CPython's ssl
-      module exposes no keying-material export. The payload's public_key/SPKI
+    * The AWS certificate binding checked here is user_data[0:32] only. The
+      first 96 bytes are unchanged: [0:32] is SHA-256 of the served certificate
+      DER (verified on 6/6 samples when this was written, 8/8 on
+      re-measurement), [32:64] is the device hash this script does not
+      interpret, and [64:96] is the TLS exporter channel binding, which cannot
+      be checked from here because CPython's ssl module exposes no
+      keying-material export.
+      A 128-byte payload additionally carries a receipt-key commitment, which
+      this script tolerates but does not verify. The payload's public_key/SPKI
       binding is likewise not checked here; probes.py::_aws_cert_binding_ok
       checks both and is the reference for that.
     * Matching the accepted SET is not proof the primary is serving. Both are
@@ -218,10 +221,11 @@ NOT_CONFIGURED = "not-configured"
 # up as more than one module id, few enough that the whole run stays under a
 # CI step's patience. It buys a lower bound, not coverage — see the scope limit.
 DEFAULT_AWS_SAMPLES = 5
-# The enclave's user_data layout, in bytes. Named so a future reader does not
-# have to rediscover that the certificate hash is 32 bytes and not 64, which is
-# what trust.py's published `certificate_binding` string used to say.
-AWS_USER_DATA_LENGTH = 96
+# The enclave's user_data layout, in bytes. The first 96 bytes remain cert fp
+# [0:32], device hash [32:64], and exporter [64:96]. Bytes [96:128], when
+# present, are the receipt-key commitment for the signed-inference-receipts
+# project — tolerated, not verified, by this script.
+AWS_USER_DATA_LENGTHS = frozenset({96, 128})
 AWS_USER_DATA_CERT_SHA256 = slice(0, 32)
 
 
@@ -582,8 +586,8 @@ def _aws_binding_problem(document: dict[Any, Any], peer_certificate_der: bytes |
     user_data = document.get("user_data")
     if not isinstance(user_data, bytes):
         return "attestation carries no user_data, so it binds no certificate"
-    if len(user_data) != AWS_USER_DATA_LENGTH:
-        return f"user_data is {len(user_data)} bytes, want {AWS_USER_DATA_LENGTH}"
+    if len(user_data) not in AWS_USER_DATA_LENGTHS:
+        return f"user_data is {len(user_data)} bytes, want one of {sorted(AWS_USER_DATA_LENGTHS)}"
     expected = hashlib.sha256(peer_certificate_der).digest()
     if user_data[AWS_USER_DATA_CERT_SHA256] != expected:
         return "user_data[0:32] is not SHA-256 of the certificate served on this connection"

--- a/tests/test_trust_measurement_drift.py
+++ b/tests/test_trust_measurement_drift.py
@@ -17,6 +17,8 @@ THE LAW
         regions[] array while naming more than one accepted hostdata value —
         cannot certify its own coverage and is a gap, not a pass;
       * under --strict, a plane that publishes nothing is a failure;
+      * AWS user_data is exactly 96 or 128 bytes, and accepting the future
+        receipt-key commitment does not move the existing three 32-byte fields;
       * the summary states the planes and endpoint count it is based on, so a
         success sentence can never outrun its own coverage again.
 
@@ -110,6 +112,9 @@ SCOPE LIMIT — WHAT THIS DOES NOT ESTABLISH
       and the shape of what the route serves; they are not evidence about what
       any deployed control plane publishes today, and no assertion in this file
       should be read as one.
+    * Accepting 128-byte AWS user_data establishes only verifier tolerance for
+      its final receipt-key commitment. Nothing here verifies that commitment
+      or proves possession of the corresponding receipt key.
     * A record that names one region, one issuer, and TWO accepted hostdata
       values is accepted as covered. That shape is a one-region plane mid-roll
       and a two-region plane whose second region was never published, and the
@@ -190,21 +195,24 @@ def azure_token(hostdata: str, issuer: str) -> bytes:
 
 
 def aws_document(
-    *, pcr0: str = AWS_PCR0, module_id: str = AWS_MODULE_A, cert_der: bytes = AWS_CERT_DER
+    *,
+    pcr0: str = AWS_PCR0,
+    module_id: str = AWS_MODULE_A,
+    cert_der: bytes = AWS_CERT_DER,
+    user_data: bytes | None = None,
 ) -> bytes:
     """The COSE_Sign1 shape the Nitro Security Module emits.
 
     user_data is 96 bytes with the layout measured on the live enclave:
-    [0:32] SHA-256 of the served certificate DER, [32:64] a build-invariant
-    constant (same value across nonces and connections; not interpreted here),
+    [0:32] SHA-256 of the served certificate DER, [32:64] the device hash,
     [64:96] the TLS exporter channel binding, which varies per connection.
     """
-    user_data = hashlib.sha256(cert_der).digest() + bytes(32) + b"\xe1" * 32
+    default_user_data = hashlib.sha256(cert_der).digest() + bytes(32) + b"\xe1" * 32
     payload = {
         "module_id": module_id,
         "digest": "SHA384",
         "pcrs": {0: bytes.fromhex(pcr0)},
-        "user_data": user_data,
+        "user_data": default_user_data if user_data is None else user_data,
     }
     return cbor2.dumps([b"\xa1\x01\x38\x22", {}, cbor2.dumps(payload), b"sig" * 32])
 
@@ -643,6 +651,43 @@ def test_aws_document_must_bind_the_certificate_this_connection_was_served() -> 
 
     assert not result.ok
     assert "user_data[0:32]" in result.detail
+
+
+def test_aws_accepts_128_byte_user_data_without_moving_the_exporter() -> None:
+    """The future receipt commitment extends, rather than rearranges, the layout."""
+    exporter = bytes(range(32))
+    receipt_key_fp = b"\xf4" * 32
+    user_data = (
+        hashlib.sha256(AWS_CERT_DER).digest() + b"\xd2" * 32 + exporter + receipt_key_fp
+    )
+
+    assert user_data[64:96] == exporter
+    transport = whole_fleet(aws_live=aws_document(user_data=user_data))
+    result = results_by_plane(transport)["aws"]
+
+    assert result.ok
+
+
+@pytest.mark.parametrize("length", [127, 129])
+def test_aws_rejects_user_data_adjacent_to_the_allowed_lengths(length: int) -> None:
+    """Tolerance is for the specified receipt layout, not arbitrary trailing bytes."""
+    valid = hashlib.sha256(AWS_CERT_DER).digest() + bytes(64) + b"\xf4" * 32
+    user_data = valid[:length].ljust(length, b"\x00")
+    transport = whole_fleet(aws_live=aws_document(user_data=user_data))
+    result = results_by_plane(transport)["aws"]
+
+    assert not result.ok
+    assert f"user_data is {length} bytes" in result.detail
+
+
+def test_aws_still_rejects_64_byte_user_data() -> None:
+    """The legacy short shape remains invalid; only 128 bytes are newly accepted."""
+    user_data = hashlib.sha256(AWS_CERT_DER).digest() + bytes(32)
+    transport = whole_fleet(aws_live=aws_document(user_data=user_data))
+    result = results_by_plane(transport)["aws"]
+
+    assert not result.ok
+    assert "user_data is 64 bytes" in result.detail
 
 
 def test_aws_document_binding_nothing_fails_closed() -> None:


### PR DESCRIPTION
Phase 0 of signed inference receipts, quill-router half: the trust drift
checker pinned AWS `user_data` at exactly 96 bytes, so the future enclave
release carrying the receipt-key commitment at `[96:128]` would have turned
every AWS drift check red. Verifier tolerance ships first — never the
enforcing half before the thing that lets it pass.

The first 96 bytes keep today's exact semantics (cert fp / device hash /
exporter). Bytes `[96:128]`, when present, are tolerated, not verified —
receipt-chain verification is the reference verifier's job and the scope
limit says so. 64 stays rejected (live planes always carry the exporter under
G6 fail-closed); 127/129 pinned as rejected so the accepted set is exactly
{96, 128}.

Fails-without-fix: with the checker reverted and tests kept, the 128-byte
acceptance test goes red.

Authored by codex-cli; reviewed, gates re-run (ruff, mypy, drift suite 74
passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)