### PR TITLE
Make application logs and direct-sink delivery failures visible

### DIFF
--- a/clickhouse/check_fleet_analytics_freshness.py
+++ b/clickhouse/check_fleet_analytics_freshness.py
@@ -14,6 +14,13 @@ is ``drain_lag_seconds``: the age of the oldest row still sitting in that
 cloud's outbox.  Rows leave the outbox only after ClickHouse has accepted them,
 so a lag that stops falling is a drain that has stopped delivering.
 
+Direct mode has no durable outbox and cannot use that proof: its bounded buffer
+drops oldest rows, making the retained head look young again. For a direct
+reading this checker additionally requires a recent successful delivery and
+zero cumulative drops/flush failures. The registry may continue to name the
+plane's ``spanner``/``postgres`` system of record while the publisher reports
+the ``direct`` delivery backend, which lets verifier tolerance deploy first.
+
 WHY THE FLEET AND NOT ONE CLOUD
     This started as an AWS-only check, and an AWS-only check would have been
     the outage repeating itself one layer up.  Between 2026-08-02 and
@@ -75,9 +82,12 @@ from trusted_router.operational_analytics_fleet import (
 from trusted_router.operational_analytics_freshness import (
     ANALYTICS_STATUS_KEY,
     AVAILABLE_FIELD,
+    BACKEND_DIRECT,
     BACKEND_FIELD,
     DEFAULT_MAX_DRAIN_LAG_SECONDS,
     DRAIN_LAG_FIELD,
+    DROPPED_TOTAL_FIELD,
+    FLUSH_FAILURES_FIELD,
     GENERATED_AT_FIELD,
     OUTBOX_DEPTH_FIELD,
     PUBLISHABLE_REASONS,
@@ -85,6 +95,7 @@ from trusted_router.operational_analytics_freshness import (
     REASON_NO_DATA,
     REASON_NOT_CONFIGURED,
     REASON_UNREACHABLE,
+    SECONDS_SINCE_LAST_DELIVERY_FIELD,
     publishable_backend,
     publishable_reason,
 )
@@ -93,6 +104,11 @@ from trusted_router.operational_analytics_freshness import (
 #: The AWS-EU control plane; not trustedrouter.com, which is the GCP deployment
 #: and would answer this question about the wrong cloud.
 DEFAULT_STATUS_URL = "https://gchircrcif.eu-west-3.awsapprunner.com/status.json"
+
+#: A direct sink has no durable, unbounded backlog: its buffer drops oldest
+#: rows. Delivery age is therefore its primary liveness signal and must page
+#: much sooner than the durable outbox's one-hour backlog threshold.
+DEFAULT_MAX_DIRECT_DELIVERY_AGE_SECONDS = 600.0
 
 
 def _float(value: Any) -> float | None:
@@ -212,6 +228,7 @@ def evaluate(
     max_drain_lag_seconds: float = DEFAULT_MAX_DRAIN_LAG_SECONDS,
     max_age_seconds: int = 3_600,
     max_outbox_depth: int | None = None,
+    max_direct_delivery_age_seconds: float = DEFAULT_MAX_DIRECT_DELIVERY_AGE_SECONDS,
     expected_backend: str | None = None,
     expects_outbox: bool = True,
 ) -> list[str]:
@@ -270,7 +287,11 @@ def evaluate(
     # mismatches every expected backend and so still fails, loudly, without
     # letting the remote page choose the words.
     backend = publishable_backend(section.get(BACKEND_FIELD))
-    if expected_backend is not None and backend != expected_backend:
+    # ``direct`` is a delivery mechanism, not the plane's system-of-record
+    # backend. Accept it alongside the registry's current spanner/postgres
+    # value so this verifier can ship before any producer changes its value.
+    # Every non-direct mismatch retains the original wrong-plane alarm.
+    if expected_backend is not None and backend not in {expected_backend, BACKEND_DIRECT}:
         problems.append(
             f"answered by {BACKEND_FIELD}={backend!r}, but this cloud runs "
             f"{expected_backend!r}. The registry's status_url is pointed at another "
@@ -302,6 +323,45 @@ def evaluate(
     depth = _int(section.get(OUTBOX_DEPTH_FIELD))
     if max_outbox_depth is not None and depth is not None and depth > max_outbox_depth:
         problems.append(f"outbox holds {depth} undelivered rows (> {max_outbox_depth})")
+
+    if backend == BACKEND_DIRECT:
+        delivery_age = _float(section.get(SECONDS_SINCE_LAST_DELIVERY_FIELD))
+        if delivery_age is not None and delivery_age < 0:
+            problems.append(
+                f"{ANALYTICS_STATUS_KEY}.{SECONDS_SINCE_LAST_DELIVERY_FIELD} is negative"
+            )
+        elif delivery_age is not None and delivery_age > max_direct_delivery_age_seconds:
+            problems.append(
+                f"direct sink has not delivered for {delivery_age:.0f}s "
+                f"(> {max_direct_delivery_age_seconds:.0f}s)"
+            )
+        elif (
+            delivery_age is None
+            and lag is not None
+            and lag > max_direct_delivery_age_seconds
+        ):
+            problems.append(
+                f"direct sink has never delivered and its oldest retained row is "
+                f"{lag:.0f}s old (> {max_direct_delivery_age_seconds:.0f}s)"
+            )
+
+        for field_name, label in (
+            (DROPPED_TOTAL_FIELD, "rows dropped"),
+            (FLUSH_FAILURES_FIELD, "flush failures"),
+        ):
+            counter = _int(section.get(field_name))
+            if counter is None:
+                problems.append(
+                    f"{ANALYTICS_STATUS_KEY}.{field_name} missing or unparseable "
+                    "for direct backend"
+                )
+            elif counter < 0:
+                problems.append(f"{ANALYTICS_STATUS_KEY}.{field_name} is negative")
+            elif counter > 0:
+                problems.append(
+                    f"direct sink reports {label}={counter}; the cumulative counter "
+                    "has grown since this process started"
+                )
 
     return problems
 
@@ -336,6 +396,7 @@ def evaluate_fleet(
     max_drain_lag_seconds: float = DEFAULT_MAX_DRAIN_LAG_SECONDS,
     max_age_seconds: int = 3_600,
     max_outbox_depth: int | None = None,
+    max_direct_delivery_age_seconds: float = DEFAULT_MAX_DIRECT_DELIVERY_AGE_SECONDS,
     minimum_measured: int = 1,
 ) -> FleetResult:
     """Problems and unchecked notes, each prefixed with the cloud it is about.
@@ -418,6 +479,7 @@ def evaluate_fleet(
             max_drain_lag_seconds=max_drain_lag_seconds,
             max_age_seconds=max_age_seconds,
             max_outbox_depth=max_outbox_depth,
+            max_direct_delivery_age_seconds=max_direct_delivery_age_seconds,
             expected_backend=entry.expected_backend,
             expects_outbox=entry.expects_outbox,
         ):
@@ -458,6 +520,11 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     )
     parser.add_argument("--max-age-seconds", type=int, default=3_600)
     parser.add_argument("--max-outbox-depth", type=int, default=None)
+    parser.add_argument(
+        "--max-direct-delivery-age-seconds",
+        type=float,
+        default=DEFAULT_MAX_DIRECT_DELIVERY_AGE_SECONDS,
+    )
     parser.add_argument("--problems-file", default=None)
     return parser.parse_args(argv)
 
@@ -550,6 +617,7 @@ def main(argv: list[str] | None = None) -> int:
         max_drain_lag_seconds=args.max_drain_lag_seconds,
         max_age_seconds=args.max_age_seconds,
         max_outbox_depth=args.max_outbox_depth,
+        max_direct_delivery_age_seconds=args.max_direct_delivery_age_seconds,
     )
 
     summary = " ".join(f"{cloud}={lags.get(cloud)}" for cloud in sorted(lags)) or "no clouds read"

--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -13,6 +13,8 @@ Heavy logic lives elsewhere:
 
 from __future__ import annotations
 
+import logging
+import sys
 from typing import Any
 
 from fastapi import APIRouter, FastAPI, Request
@@ -95,6 +97,39 @@ from trusted_router.storage_errors import (
 )
 from trusted_router.types import ErrorType
 
+_APP_CONSOLE_HANDLER_MARKER = "_trusted_router_app_console"
+
+
+def _configure_application_logging() -> None:
+    """Make app logs visible to the container runtime, exactly once.
+
+    Uvicorn configures handlers for its own logger names, not for the root
+    logger.  In production ``init_axiom`` then adds a queue handler to root.
+    That root handler is enough to suppress ``logging.lastResort`` even though
+    it has no stderr/stdout destination, so every ``trusted_router.*`` record
+    otherwise bypasses Cloud Run's container-log collector.
+
+    Own the console destination on the package logger instead of changing root
+    or uvicorn's loggers.  Propagation remains enabled so Axiom and Sentry keep
+    receiving the same records.  The marker makes repeated app factories and
+    in-process reloads idempotent.
+    """
+    app_logger = logging.getLogger("trusted_router")
+    app_logger.disabled = False
+    app_logger.setLevel(logging.INFO)
+    app_logger.propagate = True
+    if any(
+        getattr(handler, _APP_CONSOLE_HANDLER_MARKER, False)
+        for handler in app_logger.handlers
+    ):
+        return
+
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(logging.Formatter("%(levelname)s %(name)s %(message)s"))
+    setattr(handler, _APP_CONSOLE_HANDLER_MARKER, True)
+    app_logger.addHandler(handler)
+
 
 def create_app(
     settings: Settings | None = None,
@@ -122,6 +157,7 @@ def create_app(
     if init_observability:
         init_sentry(settings)
         init_axiom(settings)
+    _configure_application_logging()
     # Swagger UI moves to /api/reference so the public docs hub can own
     # /docs (the marketing nav points "Docs" there). ReDoc stays at /redoc.
     app = FastAPI(

--- a/src/trusted_router/operational_analytics_direct.py
+++ b/src/trusted_router/operational_analytics_direct.py
@@ -622,10 +622,32 @@ class DirectOperationalAnalyticsSink:
         samples quietly ceasing to arrive. A delivery path whose failure mode
         is invisible is not an improvement over the one it replaced.
         """
+        oldest, _stats = self.freshness_snapshot()
+        return oldest
+
+    def freshness_snapshot(self) -> tuple[dt.datetime | None, SinkStats]:
+        """Return one lock-consistent delivery-health snapshot.
+
+        The public freshness surface needs the buffer head and cumulative
+        counters from the same instant.  Returning a copy also prevents a
+        caller from observing the mutable ``stats`` object while the flusher
+        changes it underneath serialization.
+        """
         with self._lock:
-            if not self._buffer:
-                return None
-            return min(commit_ts for _table, _row, commit_ts in self._buffer)
+            oldest = (
+                min(commit_ts for _table, _row, commit_ts in self._buffer)
+                if self._buffer
+                else None
+            )
+            stats = SinkStats(
+                published=self.stats.published,
+                inserted=self.stats.inserted,
+                dropped=self.stats.dropped,
+                quarantined=self.stats.quarantined,
+                flush_failures=self.stats.flush_failures,
+                last_success_unix=self.stats.last_success_unix,
+            )
+        return oldest, stats
 
     # -- internals ----------------------------------------------------------
 
@@ -639,9 +661,10 @@ class DirectOperationalAnalyticsSink:
         )
         try:
             events = normalise_operational_event(row)
+            quarantined = False
         except ValueError as exc:
             events = [quarantine_event(row, exc)]
-            self.stats.quarantined += 1
+            quarantined = True
         with self._lock:
             before = len(self._buffer)
             for event in events:
@@ -651,8 +674,11 @@ class DirectOperationalAnalyticsSink:
             overflow = before + len(events) - self._buffer_rows
             if overflow > 0:
                 self.stats.dropped += overflow
+            if quarantined:
+                self.stats.quarantined += 1
             self.stats.published += len(events)
-        if len(self._buffer) >= self._flush_batch:
+            buffered = len(self._buffer)
+        if buffered >= self._flush_batch:
             self._wake.set()
 
     def _run(self) -> None:
@@ -661,18 +687,20 @@ class DirectOperationalAnalyticsSink:
             self._wake.wait(timeout=self._flush_interval)
             self._wake.clear()
             try:
-                flushed = self.flush()
+                self.flush()
             except Exception as exc:
-                self.stats.flush_failures += 1
+                _oldest, stats = self.freshness_snapshot()
+                with self._lock:
+                    buffered = len(self._buffer)
                 # error(), not just exception(): this must be greppable and
                 # must carry the counts, because the failure is otherwise
                 # invisible from outside the process.
                 log.error(
                     "operational_analytics_direct.flush_failed "
                     "buffered=%d dropped=%d failures=%d error=%s: %s",
-                    len(self._buffer),
-                    self.stats.dropped,
-                    self.stats.flush_failures,
+                    buffered,
+                    stats.dropped,
+                    stats.flush_failures,
                     type(exc).__name__,
                     str(exc)[:200],
                 )
@@ -683,8 +711,6 @@ class DirectOperationalAnalyticsSink:
                 failure_delay = min(failure_delay * 2, FAILURE_BACKOFF_CAP_SECONDS)
                 continue
             failure_delay = self._flush_interval
-            if flushed:
-                self.stats.last_success_unix = time.time()
 
     def flush(self) -> int:
         """Send everything buffered, grouped per table. Raises on failure
@@ -724,8 +750,12 @@ class DirectOperationalAnalyticsSink:
                 ]
                 for item in reversed(remaining):
                     self._buffer.appendleft(item)
+                self.stats.flush_failures += 1
             raise
-        self.stats.inserted += sent
+        with self._lock:
+            self.stats.inserted += sent
+            if sent:
+                self.stats.last_success_unix = time.time()
         return sent
 
     def close(self) -> None:

--- a/src/trusted_router/operational_analytics_fleet.py
+++ b/src/trusted_router/operational_analytics_fleet.py
@@ -74,6 +74,7 @@ from dataclasses import dataclass
 from trusted_router import byok_v1_attestations, regions
 from trusted_router.config import Settings
 from trusted_router.operational_analytics_freshness import (
+    BACKEND_DIRECT,
     BACKEND_POSTGRES,
     BACKEND_SPANNER,
 )
@@ -82,7 +83,9 @@ from trusted_router.synthetic import fleet as synthetic_fleet
 #: Backends a control plane can legitimately answer this question from. The
 #: registry pins one per cloud so a status page belonging to a DIFFERENT cloud
 #: cannot answer for this one; see :class:`FleetAnalyticsEndpoint`.
-KNOWN_BACKENDS: frozenset[str] = frozenset({BACKEND_SPANNER, BACKEND_POSTGRES})
+KNOWN_BACKENDS: frozenset[str] = frozenset(
+    {BACKEND_SPANNER, BACKEND_POSTGRES, BACKEND_DIRECT}
+)
 
 
 @dataclass(frozen=True)

--- a/src/trusted_router/operational_analytics_freshness.py
+++ b/src/trusted_router/operational_analytics_freshness.py
@@ -14,8 +14,8 @@ runner included -- can ask it ``SELECT max(created_at) FROM
 activity_generations``.  A freshness check that cannot reach the thing it
 checks is not a check.
 
-The signal that *is* reachable is the outbox, and it is strictly better than a
-ClickHouse timestamp for this purpose.  Rows are deleted from the outbox only
+The signal that *is* reachable is the publisher's delivery state. For durable
+outboxes, rows are deleted only
 after ClickHouse has accepted them (``SELECT -> insert -> DELETE``, in that
 order, gated on every configured target succeeding), so the age of the OLDEST
 undelivered row is an end-to-end statement about the whole pipeline:
@@ -30,6 +30,12 @@ running to say so -- which is the failure that actually happened: between
 2026-08-02 and 2026-08-17 the drain was never installed at all, the outbox grew
 to 465,119 rows, and nothing anywhere reported it, because the alarm is emitted
 BY the process that was missing.
+
+The direct sink is deliberately different: its bounded buffer drops oldest
+rows, so its oldest retained row can stay young during an outage. Direct-mode
+readings therefore add time since the last successful delivery plus cumulative
+drop and flush-failure counters. An empty direct buffer no longer impersonates
+the healthiest state after the flusher has died.
 
 The control plane is the natural publisher because it is already the only
 public thing that holds a DSQL connection, and the query is an index seek on
@@ -48,6 +54,7 @@ back, for every cloud, with no credentials at all.
 from __future__ import annotations
 
 import datetime as dt
+import math
 from dataclasses import dataclass
 from typing import Any
 
@@ -63,6 +70,9 @@ REASON_FIELD = "reason"
 BACKEND_FIELD = "backend"
 DRAIN_LAG_FIELD = "drain_lag_seconds"
 OUTBOX_DEPTH_FIELD = "outbox_depth"
+SECONDS_SINCE_LAST_DELIVERY_FIELD = "seconds_since_last_delivery"
+DROPPED_TOTAL_FIELD = "dropped_total"
+FLUSH_FAILURES_FIELD = "flush_failures"
 GENERATED_AT_FIELD = "generated_at"
 
 #: Every key the published section may contain, in both of its forms.  Pinned
@@ -70,7 +80,16 @@ GENERATED_AT_FIELD = "generated_at"
 #: can safely narrow later: an added key is a promise to whoever started
 #: reading it.
 PUBLISHED_AVAILABLE_FIELDS: frozenset[str] = frozenset(
-    {AVAILABLE_FIELD, BACKEND_FIELD, DRAIN_LAG_FIELD, OUTBOX_DEPTH_FIELD, GENERATED_AT_FIELD}
+    {
+        AVAILABLE_FIELD,
+        BACKEND_FIELD,
+        DRAIN_LAG_FIELD,
+        OUTBOX_DEPTH_FIELD,
+        SECONDS_SINCE_LAST_DELIVERY_FIELD,
+        DROPPED_TOTAL_FIELD,
+        FLUSH_FAILURES_FIELD,
+        GENERATED_AT_FIELD,
+    }
 )
 PUBLISHED_UNAVAILABLE_FIELDS: frozenset[str] = frozenset({AVAILABLE_FIELD, REASON_FIELD})
 
@@ -112,6 +131,7 @@ PUBLISHABLE_REASONS: frozenset[str] = frozenset(
 BACKEND_SPANNER = "spanner"
 BACKEND_POSTGRES = "postgres"
 BACKEND_MEMORY = "memory"
+BACKEND_DIRECT = "direct"
 #: A backend name the publisher does not recognise.  Narrowed for the same
 #: reason as :data:`PUBLISHABLE_REASONS` above -- every value on the public page
 #: comes from a closed vocabulary -- and it is not silently dropped, because the
@@ -120,25 +140,30 @@ BACKEND_MEMORY = "memory"
 BACKEND_UNKNOWN = "unknown"
 
 PUBLISHABLE_BACKENDS: frozenset[str] = frozenset(
-    {BACKEND_SPANNER, BACKEND_POSTGRES, BACKEND_MEMORY}
+    {BACKEND_SPANNER, BACKEND_POSTGRES, BACKEND_MEMORY, BACKEND_DIRECT}
 )
 
 
 @dataclass(frozen=True)
 class OutboxFreshness:
-    """One storage backend's answer to "how old is the oldest undelivered row?".
+    """One delivery backend's externally publishable freshness answer.
 
     Carrying availability in the reading rather than returning a bare
     ``datetime | None`` is the whole point.  ``None`` already means "the outbox
-    is empty", which is the healthiest state there is; a backend that could not
-    look, or has no outbox to look at, must not be able to express itself with
-    the same value.  Every backend answers with one of these, so a backend that
-    cannot answer is *loud* rather than absent.
+    is empty", which is the healthiest durable-outbox state there is; a backend
+    that could not look, or has no outbox to look at, must not be able to
+    express itself with the same value. Direct mode supplements that ambiguous
+    bounded-buffer head with delivery age and cumulative counters. Every
+    backend answers with one of these, so a backend that cannot answer is
+    *loud* rather than absent.
     """
 
     backend: str
     oldest_enqueued_at: dt.datetime | None = None
     outbox_depth: int | None = None
+    seconds_since_last_delivery: float | None = None
+    dropped_total: int | None = None
+    flush_failures: int | None = None
     available: bool = True
     reason: str | None = None
 
@@ -209,6 +234,9 @@ def analytics_status_section(
     now: dt.datetime,
     outbox_depth: int | None = None,
     backend: str = "postgres",
+    seconds_since_last_delivery: float | None = None,
+    dropped_total: int | None = None,
+    flush_failures: int | None = None,
 ) -> dict[str, Any]:
     """Project the outbox's head onto the public status contract.
 
@@ -240,8 +268,30 @@ def analytics_status_section(
         BACKEND_FIELD: publishable_backend(backend),
         DRAIN_LAG_FIELD: round(lag, 3),
         OUTBOX_DEPTH_FIELD: None if outbox_depth is None else max(0, int(outbox_depth)),
+        SECONDS_SINCE_LAST_DELIVERY_FIELD: _publishable_non_negative_float(
+            seconds_since_last_delivery
+        ),
+        DROPPED_TOTAL_FIELD: _publishable_non_negative_int(dropped_total),
+        FLUSH_FAILURES_FIELD: _publishable_non_negative_int(flush_failures),
         GENERATED_AT_FIELD: _iso(moment),
     }
+
+
+def _publishable_non_negative_float(value: object) -> float | None:
+    """Narrow an internal reading to a finite, non-negative JSON number."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    number = float(value)
+    if not math.isfinite(number):
+        return None
+    return round(max(0.0, number), 3)
+
+
+def _publishable_non_negative_int(value: object) -> int | None:
+    """Narrow a cumulative counter without invoking arbitrary conversion code."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return max(0, value)
 
 
 def analytics_status_from_reading(
@@ -273,4 +323,7 @@ def analytics_status_from_reading(
         now=now,
         outbox_depth=reading.outbox_depth,
         backend=reading.backend,
+        seconds_since_last_delivery=reading.seconds_since_last_delivery,
+        dropped_total=reading.dropped_total,
+        flush_failures=reading.flush_failures,
     )

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -23,6 +23,7 @@ from trusted_router.operational_analytics import (
     stable_rows_fingerprint,
 )
 from trusted_router.operational_analytics_freshness import (
+    BACKEND_DIRECT,
     BACKEND_SPANNER,
     REASON_NOT_CONFIGURED,
     REASON_UNREACHABLE,
@@ -3775,6 +3776,24 @@ class SpannerBigtableStore:
         outbox = self._operational_analytics_outbox
         if outbox is None:
             return OutboxFreshness.unavailable(BACKEND_SPANNER, REASON_NOT_CONFIGURED)
+        from trusted_router.operational_analytics_direct import (
+            DirectOperationalAnalyticsSink,
+        )
+
+        if isinstance(outbox, DirectOperationalAnalyticsSink):
+            oldest, stats = outbox.freshness_snapshot()
+            seconds_since_last_delivery = (
+                None
+                if stats.last_success_unix <= 0
+                else max(0.0, time.time() - stats.last_success_unix)
+            )
+            return OutboxFreshness(
+                backend=BACKEND_DIRECT,
+                oldest_enqueued_at=oldest,
+                seconds_since_last_delivery=seconds_since_last_delivery,
+                dropped_total=stats.dropped,
+                flush_failures=stats.flush_failures,
+            )
         try:
             oldest = outbox.oldest_enqueued_at(timeout=OUTBOX_FRESHNESS_TIMEOUT_SECONDS)
         except Exception as exc:

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import logging
 import secrets
+import time
 import uuid
 from collections.abc import Callable
 from pathlib import Path
@@ -33,6 +34,7 @@ from trusted_router.custom_model_billing import (
 )
 from trusted_router.money import DEFAULT_SIGNUP_CREDIT_MICRODOLLARS
 from trusted_router.operational_analytics_freshness import (
+    BACKEND_DIRECT,
     BACKEND_POSTGRES,
     REASON_NOT_CONFIGURED,
     REASON_UNREACHABLE,
@@ -4666,6 +4668,24 @@ class PostgresStore:
         outbox = self._operational_analytics_outbox
         if outbox is None:
             return OutboxFreshness.unavailable(BACKEND_POSTGRES, REASON_NOT_CONFIGURED)
+        from trusted_router.operational_analytics_direct import (
+            DirectOperationalAnalyticsSink,
+        )
+
+        if isinstance(outbox, DirectOperationalAnalyticsSink):
+            oldest, stats = outbox.freshness_snapshot()
+            seconds_since_last_delivery = (
+                None
+                if stats.last_success_unix <= 0
+                else max(0.0, time.time() - stats.last_success_unix)
+            )
+            return OutboxFreshness(
+                backend=BACKEND_DIRECT,
+                oldest_enqueued_at=oldest,
+                seconds_since_last_delivery=seconds_since_last_delivery,
+                dropped_total=stats.dropped,
+                flush_failures=stats.flush_failures,
+            )
         try:
             with self._pool.connection(timeout=OUTBOX_FRESHNESS_TIMEOUT_SECONDS) as conn:
                 with conn.transaction():

--- a/tests/test_application_logging.py
+++ b/tests/test_application_logging.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import logging
+import queue
+from collections.abc import Iterator
+
+import pytest
+
+from trusted_router.axiom_config import _DroppingQueueHandler
+from trusted_router.config import Settings
+from trusted_router.main import (
+    _APP_CONSOLE_HANDLER_MARKER,
+    create_app,
+)
+
+
+@pytest.fixture
+def isolated_application_logging() -> Iterator[None]:
+    """Restore the process-global logging graph after each regression test."""
+    root = logging.getLogger()
+    app_logger = logging.getLogger("trusted_router")
+    original_root_handlers = list(root.handlers)
+    original_app_handlers = list(app_logger.handlers)
+    original_state = (app_logger.level, app_logger.propagate, app_logger.disabled)
+    try:
+        for handler in list(app_logger.handlers):
+            if getattr(handler, _APP_CONSOLE_HANDLER_MARKER, False):
+                app_logger.removeHandler(handler)
+        yield
+    finally:
+        for handler in list(root.handlers):
+            if handler not in original_root_handlers:
+                root.removeHandler(handler)
+        for handler in list(app_logger.handlers):
+            if handler not in original_app_handlers:
+                app_logger.removeHandler(handler)
+                handler.close()
+        for handler in original_app_handlers:
+            if handler not in app_logger.handlers:
+                app_logger.addHandler(handler)
+        app_logger.setLevel(original_state[0])
+        app_logger.propagate = original_state[1]
+        app_logger.disabled = original_state[2]
+
+
+def test_entrypoint_app_logger_reaches_container_stream_with_structured_extra(
+    capfd: pytest.CaptureFixture[str],
+    isolated_application_logging: None,
+) -> None:
+    create_app(
+        Settings(environment="test"),
+        configure_store_arg=False,
+        init_observability=False,
+    )
+
+    logging.getLogger("trusted_router.regression.sink").warning(
+        "sink delivery warning",
+        extra={"sink": {"backend": "direct", "dropped_total": 7}},
+    )
+
+    captured = capfd.readouterr()
+    assert "WARNING trusted_router.regression.sink sink delivery warning" in (
+        captured.err + captured.out
+    )
+
+
+def test_axiom_root_handler_can_no_longer_swallow_application_logs(
+    capfd: pytest.CaptureFixture[str],
+    isolated_application_logging: None,
+) -> None:
+    """Pin the production mechanism behind the missing Cloud Logging lines.
+
+    A root handler suppresses logging.lastResort.  Axiom installs precisely
+    such a non-console handler in production, so before the app-owned stream
+    handler this warning had no path to stderr or stdout.
+    """
+    root = logging.getLogger()
+    root.addHandler(_DroppingQueueHandler(queue.Queue()))
+
+    create_app(
+        Settings(environment="test"),
+        configure_store_arg=False,
+        init_observability=False,
+    )
+    logging.getLogger("trusted_router.regression.axiom").warning("visible despite axiom")
+
+    captured = capfd.readouterr()
+    assert "visible despite axiom" in captured.err + captured.out
+
+
+def test_application_console_configuration_is_idempotent(
+    capfd: pytest.CaptureFixture[str],
+    isolated_application_logging: None,
+) -> None:
+    settings = Settings(environment="test")
+    create_app(settings, configure_store_arg=False, init_observability=False)
+    create_app(settings, configure_store_arg=False, init_observability=False)
+
+    logging.getLogger("trusted_router.regression.reload").warning("only once")
+
+    captured = capfd.readouterr()
+    assert (captured.err + captured.out).count("only once") == 1

--- a/tests/test_direct_analytics_freshness.py
+++ b/tests/test_direct_analytics_freshness.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import datetime as dt
+import math
+
+import pytest
+
+import clickhouse.check_fleet_analytics_freshness as fleet_check
+from trusted_router import operational_analytics_direct, storage_gcp
+from trusted_router.operational_analytics_direct import DirectOperationalAnalyticsSink
+from trusted_router.operational_analytics_freshness import (
+    ANALYTICS_STATUS_KEY,
+    BACKEND_DIRECT,
+    BACKEND_SPANNER,
+    DROPPED_TOTAL_FIELD,
+    FLUSH_FAILURES_FIELD,
+    SECONDS_SINCE_LAST_DELIVERY_FIELD,
+    OutboxFreshness,
+    analytics_status_from_reading,
+)
+from trusted_router.storage_gcp import SpannerBigtableStore
+from trusted_router.storage_postgres import PostgresStore
+
+
+def _sink(*, buffer_rows: int = 4) -> DirectOperationalAnalyticsSink:
+    return DirectOperationalAnalyticsSink(
+        url="http://clickhouse.internal:8123",
+        database="tr",
+        user="tr",
+        password="pw",  # noqa: S106
+        buffer_rows=buffer_rows,
+        post=lambda _url, _body, _headers: None,
+        start_thread=False,
+    )
+
+
+def _enqueue(sink: DirectOperationalAnalyticsSink, event_id: str) -> None:
+    # An intentionally incomplete synthetic row takes the quarantine path,
+    # which is still a real ClickHouse delivery and keeps this test independent
+    # of the much larger synthetic payload schema.
+    sink._publish("synthetic", event_id, {"id": event_id})
+
+
+def _gcp_reading(sink: DirectOperationalAnalyticsSink) -> OutboxFreshness:
+    store = object.__new__(SpannerBigtableStore)
+    store._operational_analytics_outbox = sink
+    return store.operational_analytics_outbox_freshness()
+
+
+def _payload(reading: OutboxFreshness, *, now: dt.datetime) -> dict[str, object]:
+    return {
+        ANALYTICS_STATUS_KEY: analytics_status_from_reading(reading, now=now),
+    }
+
+
+def test_healthy_direct_sink_with_recent_delivery_passes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = dt.datetime.now(dt.UTC)
+    sink = _sink()
+    monkeypatch.setattr(operational_analytics_direct.time, "time", now.timestamp)
+    _enqueue(sink, "delivered")
+    assert sink.flush() == 1
+    _enqueue(sink, "newly-buffered")
+
+    reading = _gcp_reading(sink)
+
+    assert reading.backend == BACKEND_DIRECT
+    assert reading.oldest_enqueued_at is not None
+    assert reading.seconds_since_last_delivery == pytest.approx(0.0, abs=0.1)
+    assert reading.dropped_total == 0
+    assert reading.flush_failures == 0
+    assert fleet_check.evaluate(
+        _payload(reading, now=now),
+        now=now,
+        expected_backend=BACKEND_SPANNER,
+    ) == []
+
+
+def test_idle_but_healthy_direct_sink_passes(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = dt.datetime.now(dt.UTC)
+    sink = _sink()
+    monkeypatch.setattr(operational_analytics_direct.time, "time", now.timestamp)
+    _enqueue(sink, "delivered")
+    assert sink.flush() == 1
+
+    reading = _gcp_reading(sink)
+
+    assert reading.oldest_enqueued_at is None
+    assert reading.seconds_since_last_delivery == pytest.approx(0.0, abs=0.1)
+    assert fleet_check.evaluate(_payload(reading, now=now), now=now) == []
+
+
+def test_never_delivered_is_distinct_from_healthy_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = dt.datetime.now(dt.UTC)
+    monkeypatch.setattr(storage_gcp.time, "time", now.timestamp)
+    reading = _gcp_reading(_sink())
+
+    assert reading.oldest_enqueued_at is None
+    assert reading.seconds_since_last_delivery is None
+    assert reading.dropped_total == 0
+    assert reading.flush_failures == 0
+    section = analytics_status_from_reading(reading, now=now)
+    assert section[SECONDS_SINCE_LAST_DELIVERY_FIELD] is None
+    assert fleet_check.evaluate({ANALYTICS_STATUS_KEY: section}, now=now) == []
+
+
+def test_never_delivered_with_an_ageing_row_alarms() -> None:
+    now = dt.datetime.now(dt.UTC)
+    reading = OutboxFreshness(
+        backend=BACKEND_DIRECT,
+        oldest_enqueued_at=now - dt.timedelta(seconds=601),
+        seconds_since_last_delivery=None,
+        dropped_total=0,
+        flush_failures=0,
+    )
+
+    problems = fleet_check.evaluate(_payload(reading, now=now), now=now)
+
+    assert any("has never delivered" in problem for problem in problems)
+
+
+def test_dead_bounded_sink_reproduces_incident_old_signal_passes_new_signal_alarms(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dropping oldest keeps backlog age young; delivery health catches it.
+
+    This is the 2026-08-26 failure shape. The pre-change store mislabeled the
+    sink as Spanner and published only the retained buffer head. Because that
+    buffer is bounded, old rows disappear and the legacy reading passes. The
+    direct reading must fail on delivery age and counted loss instead.
+    """
+    now = dt.datetime.now(dt.UTC)
+    sink = _sink(buffer_rows=2)
+
+    # Establish one real delivery, then make the sink stale for twenty minutes.
+    monkeypatch.setattr(
+        operational_analytics_direct.time,
+        "time",
+        lambda: now.timestamp() - 1_200,
+    )
+    _enqueue(sink, "last-success")
+    assert sink.flush() == 1
+    monkeypatch.setattr(operational_analytics_direct.time, "time", now.timestamp)
+
+    def dead_post(_url: str, _body: bytes, _headers: dict[str, str]) -> None:
+        raise OSError("ClickHouse refuses the credential")
+
+    sink._post = dead_post
+    for index in range(4):
+        _enqueue(sink, f"lost-{index}")
+    with pytest.raises(OSError):
+        sink.flush()
+
+    oldest = sink.oldest_enqueued_at()
+    assert oldest is not None
+    legacy = OutboxFreshness(
+        backend=BACKEND_SPANNER,
+        oldest_enqueued_at=oldest,
+    )
+    # The old status shape says healthy: only the two newest rows survive, so
+    # its oldest retained timestamp is seconds old rather than 20 minutes old.
+    assert fleet_check.evaluate(
+        _payload(legacy, now=now),
+        now=now,
+        expected_backend=BACKEND_SPANNER,
+    ) == []
+
+    reading = _gcp_reading(sink)
+    assert reading.seconds_since_last_delivery == pytest.approx(1_200.0, abs=0.1)
+    assert reading.dropped_total == 2
+    assert reading.flush_failures == 1
+    problems = fleet_check.evaluate(
+        _payload(reading, now=now),
+        now=now,
+        expected_backend=BACKEND_SPANNER,
+    )
+
+    assert any("has not delivered for 1200s" in problem for problem in problems)
+    assert any("rows dropped=2" in problem for problem in problems)
+    assert any("flush failures=1" in problem for problem in problems)
+    assert not any("oldest undelivered" in problem for problem in problems)
+
+
+def test_postgres_store_recognises_a_direct_sink_without_touching_its_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = dt.datetime.now(dt.UTC)
+    monkeypatch.setattr(operational_analytics_direct.time, "time", now.timestamp)
+    sink = _sink()
+    _enqueue(sink, "delivered")
+    assert sink.flush() == 1
+    store = object.__new__(PostgresStore)
+    store._operational_analytics_outbox = sink
+
+    reading = store.operational_analytics_outbox_freshness()
+
+    assert reading.backend == BACKEND_DIRECT
+    assert reading.seconds_since_last_delivery == pytest.approx(0.0, abs=0.1)
+
+
+def test_direct_publisher_narrows_backend_and_numeric_fields() -> None:
+    now = dt.datetime.now(dt.UTC)
+    section = analytics_status_from_reading(
+        OutboxFreshness(
+            backend=BACKEND_DIRECT,
+            seconds_since_last_delivery=-3.5,
+            dropped_total=-2,
+            flush_failures=object(),  # type: ignore[arg-type]
+        ),
+        now=now,
+    )
+
+    assert section["backend"] == BACKEND_DIRECT
+    assert section[SECONDS_SINCE_LAST_DELIVERY_FIELD] == 0.0
+    assert section[DROPPED_TOTAL_FIELD] == 0
+    assert section[FLUSH_FAILURES_FIELD] is None
+
+    non_finite = analytics_status_from_reading(
+        OutboxFreshness(
+            backend=BACKEND_DIRECT,
+            seconds_since_last_delivery=math.inf,
+            dropped_total=0,
+            flush_failures=0,
+        ),
+        now=now,
+    )
+    assert non_finite[SECONDS_SINCE_LAST_DELIVERY_FIELD] is None
+
+
+def test_fleet_checker_keeps_accepting_spanner_and_alarms_on_stalled_direct() -> None:
+    now = dt.datetime.now(dt.UTC)
+    spanner = OutboxFreshness(backend=BACKEND_SPANNER)
+    assert fleet_check.evaluate(
+        _payload(spanner, now=now),
+        now=now,
+        expected_backend=BACKEND_SPANNER,
+    ) == []
+
+    stalled = OutboxFreshness(
+        backend=BACKEND_DIRECT,
+        seconds_since_last_delivery=601.0,
+        dropped_total=0,
+        flush_failures=0,
+    )
+    problems = fleet_check.evaluate(
+        _payload(stalled, now=now),
+        now=now,
+        expected_backend=BACKEND_SPANNER,
+    )
+    assert any("has not delivered" in problem for problem in problems)
+    assert not any("answered by backend" in problem for problem in problems)

--- a/tests/test_operational_analytics_direct.py
+++ b/tests/test_operational_analytics_direct.py
@@ -204,7 +204,7 @@ class TestSinkDelivery:
             sink.flush()
         backlog = sink.oldest_enqueued_at()
         assert backlog is not None, "undelivered rows must surface as backlog"
-        assert sink.stats.flush_failures == 0  # raised to caller, counted in _run
+        assert sink.stats.flush_failures == 1
         assert sink.flush() == 1
         assert sink.oldest_enqueued_at() is None, "delivered backlog must clear"
 


### PR DESCRIPTION
The two observability gaps behind today's telemetry-sink incident, fixed with the incident encoded as regressions.

## 1. App logs never reached Cloud Logging

**Diagnosis**: the Axiom integration installs a queue handler on the **root** logger — enough to suppress `logging.lastResort`, with no console destination. Every `trusted_router.*` record (including #848's `flush_failed` ERROR) bypassed the container-log collector all day.

**Fix**: one marker-idempotent stderr `StreamHandler` on the `trusted_router` package logger in `create_app`, propagation preserved (Axiom/Sentry unchanged). Regression test reproduces the Axiom root handler and proves it can no longer mute app logs; the tests fail with the hook removed (verified in review).

**Post-merge verification planned**: trigger a known WARNING on the deployed service and confirm it via `gcloud logging read` before closing this out.

## 2. A dying direct sink read as healthy

A bounded buffer that drops oldest rows keeps its head young; an idle-dead sink reports empty — indistinguishable from healthiest. Direct-mode freshness now publishes `backend: "direct"`, `seconds_since_last_delivery` (never-delivered ≠ healthy-empty), `dropped_total`, `flush_failures` — closed-vocabulary narrowed. The fleet checker tolerates `direct` **before** any producer publishes it and alarms on delivery age > 600 s or nonzero loss counters. `test_dead_bounded_sink_reproduces_incident_old_signal_passes_new_signal_alarms` is the incident as a test.

Gates: ruff, mypy (306 files), targeted suites green; full suite running (sandbox-blocked socket modules included) — merge waits on it plus the in-flight enclave release A (control-plane auto-deploy shouldn't churn under its synthetic gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)