### PR TITLE
Match OpenRouter provider fallback semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,10 +295,13 @@ remains available.
   Tinfoil first. Chat requests also honor OpenRouter-style `models` and
   `provider` routing filters (`order`, `only`, `ignore`, `allow_fallbacks`,
   `min_privacy`, `data_collection`, and `sort`) so clients can request explicit
-  fallback chains or provider preferences. Setting `allow_fallbacks=false`
-  either at the request top level or as `provider.allow_fallbacks` is a hard
-  model-integrity guarantee: TrustedRouter authorizes one provider route for
-  the requested model and fails instead of substituting another model.
+  fallback chains or provider preferences. `provider.order` is a preference
+  while fallbacks are enabled, and unlisted providers remain eligible after the
+  preferred list. With `allow_fallbacks=false`, routing is restricted to the
+  ordered provider set and only its first available route is authorized.
+  `provider.only` is always a hard provider allowlist. Setting
+  `allow_fallbacks=false` either at the request top level or as
+  `provider.allow_fallbacks` also prevents substituting another model.
   `min_privacy="confidential"` is a
   hard provider-side confidential-compute + E2EE requirement and fails closed;
   the request-value aliases `e2e` and `e2ee` select the same tier

--- a/src/trusted_router/routing.py
+++ b/src/trusted_router/routing.py
@@ -493,6 +493,12 @@ def _routing_for_body(
     if "only" in overrides:
         override_only = frozenset(_provider_filter_list("only", overrides["only"]))
         effective_only = override_only if not prefs.only else prefs.only & override_only
+        if not effective_only:
+            raise api_error(
+                400,
+                "No route candidates match the requested provider filters",
+                ErrorType.MODEL_NOT_SUPPORTED,
+            )
         prefs = dataclasses.replace(prefs, only=effective_only)
     override_requirements = frozenset(
         int(requirement) for requirement in overrides.get("privacy_requirements", ())
@@ -521,6 +527,23 @@ def _routing_for_body(
                 ErrorType.MODEL_NOT_SUPPORTED,
             )
         prefs = dataclasses.replace(prefs, provider_jurisdiction=jurisdiction)
+    if not prefs.allow_fallbacks and prefs.order:
+        # OpenRouter treats `order` as a preference while fallbacks are enabled,
+        # but disabling fallbacks prevents routing outside that ordered set.
+        # Keep an explicit `only` restriction as the ceiling by intersecting it
+        # with `order`; a disjoint request then fails closed in the normal
+        # provider-filter path instead of silently selecting an unlisted host.
+        ordered_providers = frozenset(prefs.order)
+        effective_only = (
+            prefs.only & ordered_providers if prefs.only else ordered_providers
+        )
+        if not effective_only:
+            raise api_error(
+                400,
+                "No route candidates match the requested provider filters",
+                ErrorType.MODEL_NOT_SUPPORTED,
+            )
+        prefs = dataclasses.replace(prefs, only=effective_only)
     return ids, prefs
 
 

--- a/tests/test_gateway_fallback_billing.py
+++ b/tests/test_gateway_fallback_billing.py
@@ -34,6 +34,50 @@ def _client_and_key() -> tuple[TestClient, dict]:
     return client, created.json()["data"]
 
 
+def test_gateway_authorize_never_escapes_no_fallback_provider_order() -> None:
+    client, key = _client_and_key()
+
+    unavailable = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": key["hash"],
+            "model": "google/gemma-4-31b-it",
+            "estimated_input_tokens": 4,
+            "max_output_tokens": 2,
+            "idempotency_key": "provider-order-unavailable",
+            "provider": {
+                "order": ["moonshot"],
+                "allow_fallbacks": False,
+            },
+        },
+    )
+
+    assert unavailable.status_code == 400, unavailable.text
+    assert "provider filters" in unavailable.json()["error"]["message"].lower()
+
+    pinned = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": key["hash"],
+            "model": "google/gemma-4-31b-it",
+            "estimated_input_tokens": 4,
+            "max_output_tokens": 2,
+            "idempotency_key": "provider-order-tinfoil",
+            "provider": {
+                "order": ["tinfoil"],
+                "allow_fallbacks": False,
+            },
+        },
+    )
+
+    assert pinned.status_code == 200, pinned.text
+    data = pinned.json()["data"]
+    assert data["provider"] == "tinfoil"
+    assert {candidate["provider"] for candidate in data["route_candidates"]} == {
+        "tinfoil"
+    }
+
+
 def test_gateway_authorize_fake_spanner_uses_typed_without_allowlist_settings() -> None:
     store, db, _ = make_fake_store()
     ws = "ws_gcp_capability_authorize"

--- a/tests/test_routing_unit.py
+++ b/tests/test_routing_unit.py
@@ -157,6 +157,95 @@ def test_chat_route_candidates_allow_fallbacks_false_returns_only_head() -> None
     assert candidates[0].provider == "mistral"
 
 
+def test_provider_order_is_soft_while_fallbacks_are_enabled() -> None:
+    candidates = chat_route_endpoint_candidates(
+        {
+            "model": "google/gemma-4-31b-it",
+            "provider": {"order": ["moonshot"], "allow_fallbacks": True},
+        },
+        _settings(),
+    )
+
+    assert candidates
+    assert "kimi" not in {endpoint.provider for _model, endpoint in candidates}
+    assert len(candidates) > 1
+
+
+def test_provider_order_with_fallbacks_disabled_never_escapes_ordered_set() -> None:
+    with pytest.raises(HTTPException) as ctx:
+        chat_route_endpoint_candidates(
+            {
+                "model": "google/gemma-4-31b-it",
+                "provider": {"order": ["moonshot"], "allow_fallbacks": False},
+            },
+            _settings(),
+        )
+
+    assert ctx.value.status_code == 400
+    assert "provider filters" in ctx.value.detail["error"]["message"].lower()
+
+
+def test_provider_order_with_fallbacks_disabled_selects_first_available_ordered_route() -> None:
+    candidates = chat_route_endpoint_candidates(
+        {
+            "model": "google/gemma-4-31b-it",
+            "provider": {
+                "order": ["moonshot", "together", "cerebras"],
+                "allow_fallbacks": False,
+            },
+        },
+        _settings(),
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0][1].provider == "together"
+
+
+def test_provider_only_remains_hard_with_fallbacks_enabled() -> None:
+    candidates = chat_route_endpoint_candidates(
+        {
+            "model": "google/gemma-4-31b-it",
+            "provider": {"only": ["tinfoil"], "allow_fallbacks": True},
+        },
+        _settings(),
+    )
+
+    assert candidates
+    assert {endpoint.provider for _model, endpoint in candidates} == {"tinfoil"}
+
+
+def test_disjoint_only_and_no_fallback_order_fail_closed() -> None:
+    with pytest.raises(HTTPException) as ctx:
+        chat_route_endpoint_candidates(
+            {
+                "model": "google/gemma-4-31b-it",
+                "provider": {
+                    "only": ["cerebras"],
+                    "order": ["together"],
+                    "allow_fallbacks": False,
+                },
+            },
+            _settings(),
+        )
+
+    assert ctx.value.status_code == 400
+    assert "provider filters" in ctx.value.detail["error"]["message"].lower()
+
+
+def test_disjoint_alias_and_request_provider_allowlists_fail_closed() -> None:
+    with pytest.raises(HTTPException) as ctx:
+        chat_route_endpoint_candidates(
+            {
+                "model": "trustedrouter/eu",
+                "provider": {"only": ["deepseek"]},
+            },
+            _settings(),
+        )
+
+    assert ctx.value.status_code == 400
+    assert "provider filters" in ctx.value.detail["error"]["message"].lower()
+
+
 @pytest.mark.parametrize(
     "fallback_control",
     [


### PR DESCRIPTION
## Summary
- make `provider.order` soft while fallbacks are enabled and a closed eligible set when `allow_fallbacks=false`
- keep `provider.only` as a hard allowlist and fail closed on disjoint policy intersections
- add route and gateway regressions for provider pinning
- clarify the routing contract in the README

## Verification
- `uv run ruff check src/trusted_router/routing.py tests/test_routing_unit.py tests/test_gateway_fallback_billing.py`
- `uv run mypy src/trusted_router/routing.py`
- `uv run pytest -q` (6678 passed, 313 skipped, 10 xfailed)