### PR TITLE
Select no-fallback providers after eligibility

### DIFF
--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -351,6 +351,7 @@ def _authorize_gateway_sync(
     if partner_mode is not None:
         _force_partner_credit_routes(body_dict)
     native_retention_allowed = _native_batch_request_allows_retention(body_dict, settings)
+    route_preferences = provider_route_preferences(body_dict)
     # Embedding-only models can't go through the chat resolver (it
     # rejects supports_chat=False). Route them to the embeddings
     # resolver so the attested enclave can authorize + bill an
@@ -382,7 +383,11 @@ def _authorize_gateway_sync(
             )
         endpoint_candidates = [_user_model_gateway_candidate(user_model)]
     elif is_video_request:
-        endpoint_candidates = video_route_endpoint_candidates(body_dict, settings)
+        endpoint_candidates = video_route_endpoint_candidates(
+            body_dict,
+            settings,
+            defer_no_fallback_selection=True,
+        )
     elif is_image_request:
         if custom_model is not None:
             raise api_error(
@@ -390,13 +395,25 @@ def _authorize_gateway_sync(
                 "Custom models do not support image generation",
                 ErrorType.MODEL_NOT_SUPPORTED,
             )
-        endpoint_candidates = image_route_endpoint_candidates(body_dict, settings)
+        endpoint_candidates = image_route_endpoint_candidates(
+            body_dict,
+            settings,
+            defer_no_fallback_selection=True,
+        )
     elif is_embeddings_request:
-        endpoint_candidates = embeddings_route_endpoint_candidates(body_dict, settings)
+        endpoint_candidates = embeddings_route_endpoint_candidates(
+            body_dict,
+            settings,
+            defer_no_fallback_selection=True,
+        )
         if not endpoint_candidates:
             raise api_error(400, "Model does not support embeddings", ErrorType.MODEL_NOT_SUPPORTED)
     else:
-        endpoint_candidates = chat_route_endpoint_candidates(body_dict, settings)
+        endpoint_candidates = chat_route_endpoint_candidates(
+            body_dict,
+            settings,
+            defer_no_fallback_selection=True,
+        )
         if not endpoint_candidates:
             raise api_error(
                 400, "Model does not support chat completions", ErrorType.MODEL_NOT_SUPPORTED
@@ -436,6 +453,12 @@ def _authorize_gateway_sync(
             for candidate_model, candidate_endpoint in endpoint_candidates
             if UsageType.for_endpoint(candidate_endpoint) == UsageType.CREDITS
         ]
+    # ``allow_fallbacks=false`` removes alternate models in the resolver, but
+    # provider selection must happen after regional, workspace/BYOK, and
+    # service-tier eligibility. Truncating the raw catalog first can pin an
+    # unusable endpoint and reject a model another eligible provider serves.
+    if not route_preferences.allow_fallbacks:
+        endpoint_candidates = endpoint_candidates[:1]
     if not endpoint_candidates:
         raise api_error(
             400,

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -351,7 +351,6 @@ def _authorize_gateway_sync(
     if partner_mode is not None:
         _force_partner_credit_routes(body_dict)
     native_retention_allowed = _native_batch_request_allows_retention(body_dict, settings)
-    route_preferences = provider_route_preferences(body_dict)
     # Embedding-only models can't go through the chat resolver (it
     # rejects supports_chat=False). Route them to the embeddings
     # resolver so the attested enclave can authorize + bill an
@@ -366,6 +365,7 @@ def _authorize_gateway_sync(
             "web_search is not available for this privacy tier",
             ErrorType.BAD_REQUEST,
         )
+    route_preferences = provider_route_preferences(body_dict)
     requested_model = MODELS.get(route_model_id) if route_model_id else None
     is_video_request = body.route_type == "videos"
     is_image_request = body.route_type == "images"

--- a/src/trusted_router/routing.py
+++ b/src/trusted_router/routing.py
@@ -209,7 +209,10 @@ def chat_route_candidates(body: dict[str, Any], settings: Settings) -> list[Mode
 
 
 def chat_route_endpoint_candidates(
-    body: dict[str, Any], settings: Settings
+    body: dict[str, Any],
+    settings: Settings,
+    *,
+    defer_no_fallback_selection: bool = False,
 ) -> list[tuple[Model, ModelEndpoint]]:
     raw_ids, prefs = _routing_for_body(body, settings)
     candidates: list[tuple[Model, ModelEndpoint]] = []
@@ -238,13 +241,16 @@ def chat_route_endpoint_candidates(
             ErrorType.MODEL_NOT_SUPPORTED,
         )
     candidates = _sort_endpoint_candidates(candidates, prefs)
-    if not prefs.allow_fallbacks:
+    if not prefs.allow_fallbacks and not defer_no_fallback_selection:
         return candidates[:1]
     return candidates
 
 
 def image_route_endpoint_candidates(
-    body: dict[str, Any], settings: Settings
+    body: dict[str, Any],
+    settings: Settings,
+    *,
+    defer_no_fallback_selection: bool = False,
 ) -> list[tuple[Model, ModelEndpoint]]:
     """Resolve only models whose normalized image contract is implemented."""
 
@@ -275,7 +281,7 @@ def image_route_endpoint_candidates(
             ErrorType.MODEL_NOT_SUPPORTED,
         )
     candidates = _sort_endpoint_candidates(candidates, prefs)
-    if not prefs.allow_fallbacks:
+    if not prefs.allow_fallbacks and not defer_no_fallback_selection:
         return candidates[:1]
     return candidates
 
@@ -301,7 +307,10 @@ def catalog_endpoint_candidates(
 
 
 def embeddings_route_endpoint_candidates(
-    body: dict[str, Any], settings: Settings
+    body: dict[str, Any],
+    settings: Settings,
+    *,
+    defer_no_fallback_selection: bool = False,
 ) -> list[tuple[Model, ModelEndpoint]]:
     """Endpoint candidates for an embeddings request — the gateway-authorize
     analogue of `chat_route_endpoint_candidates`, accepting only
@@ -335,13 +344,16 @@ def embeddings_route_endpoint_candidates(
             ErrorType.MODEL_NOT_SUPPORTED,
         )
     candidates = _sort_endpoint_candidates(candidates, prefs)
-    if not prefs.allow_fallbacks:
+    if not prefs.allow_fallbacks and not defer_no_fallback_selection:
         return candidates[:1]
     return candidates
 
 
 def video_route_endpoint_candidates(
-    body: dict[str, Any], settings: Settings
+    body: dict[str, Any],
+    settings: Settings,
+    *,
+    defer_no_fallback_selection: bool = False,
 ) -> list[tuple[Model, ModelEndpoint]]:
     """Resolve only provider endpoints backed by the attested video worker."""
     raw_ids, prefs = _routing_for_body(body, settings)
@@ -371,7 +383,7 @@ def video_route_endpoint_candidates(
             ErrorType.MODEL_NOT_SUPPORTED,
         )
     candidates = _sort_endpoint_candidates(candidates, prefs)
-    if not prefs.allow_fallbacks:
+    if not prefs.allow_fallbacks and not defer_no_fallback_selection:
         return candidates[:1]
     return candidates
 

--- a/tests/test_auth_and_routing.py
+++ b/tests/test_auth_and_routing.py
@@ -6,6 +6,7 @@ from trusted_router.catalog import MODELS
 from trusted_router.config import Settings
 from trusted_router.main import create_app
 from trusted_router.providers import ProviderClient, ProviderError, ProviderResult
+from trusted_router.routing import chat_route_endpoint_candidates
 from trusted_router.routing_candidates import FAST_MODEL_ORDER, auto_candidate_models
 from trusted_router.storage import STORE
 
@@ -399,6 +400,63 @@ def test_gateway_authorize_top_level_no_fallbacks_ignores_stale_alternatives() -
         "openai/gpt-oss-20b"
     }
     assert len(data["route_candidates"]) == 1
+
+
+def test_gateway_no_fallbacks_selects_an_eligible_provider_for_exact_model() -> None:
+    """Provider eligibility must run before pinning one exact-model endpoint."""
+    settings = Settings(environment="test")
+    raw_candidates = chat_route_endpoint_candidates(
+        {
+            "model": "openai/gpt-oss-20b",
+            "provider": {"usage": "byok"},
+        },
+        settings,
+    )
+    first_provider = raw_candidates[0][1].provider
+    eligible_provider = next(
+        endpoint.provider
+        for _model, endpoint in raw_candidates[1:]
+        if endpoint.provider != first_provider
+    )
+
+    app = create_app(settings)
+    local_client = TestClient(app)
+    created = local_client.post(
+        "/v1/keys",
+        headers={"x-trustedrouter-user": "exact-model@example.com"},
+        json={"name": "exact-model"},
+    ).json()
+    configured = local_client.put(
+        f"/v1/byok/providers/{eligible_provider}",
+        headers={"x-trustedrouter-user": "exact-model@example.com"},
+        json={"secret_ref": f"env://{eligible_provider.upper()}_API_KEY"},
+    )
+    assert configured.status_code == 201, configured.text
+
+    authorize = local_client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": created["data"]["hash"],
+            "model": "openai/gpt-oss-20b",
+            "models": ["google/gemini-2.0-flash-lite"],
+            "allow_fallbacks": False,
+            "provider": {"usage": "byok"},
+            "estimated_input_tokens": 10,
+            "max_output_tokens": 4,
+        },
+    )
+
+    assert authorize.status_code == 200, authorize.text
+    data = authorize.json()["data"]
+    assert data["requested_model"] == "openai/gpt-oss-20b"
+    assert data["model"] == "openai/gpt-oss-20b"
+    assert data["provider"] == eligible_provider
+    assert [candidate["model"] for candidate in data["route_candidates"]] == [
+        "openai/gpt-oss-20b"
+    ]
+    assert [candidate["provider"] for candidate in data["route_candidates"]] == [
+        eligible_provider
+    ]
 
 
 def test_gateway_authorize_expands_fast_router_pool() -> None:


### PR DESCRIPTION
## What changed
- keep `allow_fallbacks=false` pinned to the explicitly requested model
- defer selecting its single provider until region, workspace/BYOK, service-tier, and fixed-cost eligibility have run
- preserve existing direct routing helper behavior outside gateway authorization

## Regression proof
The new test failed before the implementation with `No authorized route candidates are available for this workspace`: the first raw GPT OSS BYOK endpoint was not configured, while a later provider for the same exact model was configured. It now authorizes exactly one GPT OSS endpoint and never inspects or emits the stale Gemini fallback model.

## Verification
- `uv run ruff check src/trusted_router/routing.py src/trusted_router/routes/internal/gateway.py tests/test_auth_and_routing.py`
- `uv run mypy src/trusted_router/routing.py src/trusted_router/routes/internal/gateway.py`
- 201 routing/catalog/gateway/video tests pass
