### PR TITLE
MCP: serve the model-advisor skill via the Skills Extension (SEP-2640)

### DIFF
--- a/skills/trustedrouter-model-advisor/SKILL.md
+++ b/skills/trustedrouter-model-advisor/SKILL.md
@@ -13,3 +13,8 @@ Use the canonical source:
 - Raw `SKILL.md`: `https://raw.githubusercontent.com/Lore-Hex/LLM-advisor/main/SKILL.md`
 
 When this local skill is invoked, read the canonical raw `SKILL.md` above and follow it. Keep this file as a pointer only.
+
+Agents connected to the TrustedRouter MCP server do not need this pointer: the
+server publishes the canonical skill through the Skills Extension (SEP-2640),
+so `skills/list` and `skills/get` return the CURRENT text without any
+client-side change when the skill is edited.

--- a/src/trusted_router/mcp_skills.py
+++ b/src/trusted_router/mcp_skills.py
@@ -1,0 +1,250 @@
+"""Skills Extension for the TrustedRouter MCP server (SEP-2640).
+
+WHY. The model-advisor skill's canonical copy lives in its own repository
+(Lore-Hex/LLM-advisor) so Codex, Claude Code, Hermes and others can share one
+playbook. Today every agent has to know that URL and fetch it by hand, and the
+copy vendored here is a POINTER file that goes stale the moment the canonical
+one changes. Serving the skill over MCP inverts that: a client that has already
+connected to TrustedRouter discovers the skill through the protocol and gets
+the CURRENT text on every refresh, with no client-side change when the skill
+is edited. That is the "upgrade continuously" property.
+
+PROTOCOL. This implements the Skills Extension as specified in SEP-2640
+(Extensions Track, Resources-based):
+
+    capability   "extensions": {"io.modelcontextprotocol/skills": {}}
+    methods      skills/list  (paginated via nextCursor), skills/get
+    URIs         skill://<skill-path>/SKILL.md
+    entry        {name, description, resources: [{uri, digest, size}] | "dynamic",
+                  plus SKILL.md frontmatter verbatim}
+    limits       512 resources and 16 MiB per skill
+    freshness    ttlMs / cacheScope hints, matching tools/list semantics
+
+SEP-2640 is IN REVIEW, not ratified. It is an extension precisely so servers
+can ship it before ratification: a client that does not understand the
+capability simply never calls the methods, and nothing else in this server
+changes. If the SEP moves, this module is the only thing that moves with it.
+
+FRESHNESS vs AVAILABILITY. The canonical text is fetched over the network, so
+this module never lets that fetch become a hard dependency of the MCP server:
+content is cached for ``CACHE_TTL_SECONDS``, a failed refresh serves the last
+known-good copy rather than an error, and the very first fetch failing degrades
+to the vendored pointer text. A skill server that 500s because GitHub is slow
+would be worse than a slightly stale skill.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+#: Extension capability key from SEP-2640.
+SKILLS_EXTENSION_KEY = "io.modelcontextprotocol/skills"
+
+#: The one skill this server publishes today.
+SKILL_NAME = "trustedrouter-model-advisor"
+SKILL_URI = f"skill://{SKILL_NAME}/SKILL.md"
+CANONICAL_URL = "https://raw.githubusercontent.com/Lore-Hex/LLM-advisor/main/SKILL.md"
+CANONICAL_REPO = "https://github.com/Lore-Hex/LLM-advisor"
+
+#: Cache lifetime for the canonical text, and the ttlMs hint handed to clients.
+#: Short enough that an edit to the skill reaches agents the same session,
+#: long enough that a busy client does not turn every skills/list into an
+#: egress request.
+CACHE_TTL_SECONDS = 900
+FETCH_TIMEOUT_SECONDS = 5.0
+
+#: SEP-2640 per-skill ceilings. Enforced here rather than assumed: a canonical
+#: file that grows past the limit must fail loudly at the server, not produce a
+#: response clients are entitled to reject.
+MAX_RESOURCES_PER_SKILL = 512
+MAX_SKILL_BYTES = 16 * 1024 * 1024
+
+#: Served when the canonical fetch has never succeeded. Mirrors the vendored
+#: pointer file so an offline server still tells the agent where to look.
+_FALLBACK_TEXT = f"""---
+name: {SKILL_NAME}
+description: Pointer to the canonical TrustedRouter model advisor skill.
+---
+
+# TrustedRouter Model Advisor
+
+The canonical copy could not be fetched from {CANONICAL_REPO}. Read it directly:
+
+- Raw `SKILL.md`: {CANONICAL_URL}
+"""
+
+
+def parse_frontmatter(text: str) -> tuple[dict[str, str], str]:
+    """Split leading YAML-ish frontmatter from a SKILL.md body.
+
+    Deliberately not a YAML parser: SEP-2640 asks for the frontmatter
+    "verbatim", skill frontmatter is flat ``key: value`` by convention, and
+    taking a YAML dependency here would let a malformed skill file execute
+    parser edge cases inside the MCP request path.
+    """
+    if not text.startswith("---"):
+        return {}, text
+    lines = text.splitlines()
+    closing = next((i for i in range(1, len(lines)) if lines[i].strip() == "---"), None)
+    if closing is None:
+        return {}, text
+    fields: dict[str, str] = {}
+    for line in lines[1:closing]:
+        key, sep, value = line.partition(":")
+        if sep and key.strip():
+            fields[key.strip()] = value.strip()
+    return fields, "\n".join(lines[closing + 1 :]).lstrip("\n")
+
+
+@dataclass
+class _Cached:
+    text: str
+    digest: str
+    size: int
+    fetched_at: float
+    is_fallback: bool = True
+
+
+@dataclass
+class SkillsRegistry:
+    """Serves the advisor skill, refreshing it from the canonical repository.
+
+    One instance per server process. ``_cached`` is the last known-good copy
+    and is only ever replaced by a SUCCESSFUL fetch, which is what makes a
+    GitHub outage a staleness problem instead of an availability one.
+    """
+
+    client_factory: Any = None
+    _cached: _Cached | None = field(default=None, repr=False)
+
+    def _fetch(self) -> str | None:
+        try:
+            if self.client_factory is not None:
+                return str(self.client_factory(CANONICAL_URL))
+            response = httpx.get(
+                CANONICAL_URL, timeout=FETCH_TIMEOUT_SECONDS, follow_redirects=True
+            )
+            if response.status_code != 200:
+                return None
+            return response.text
+        except Exception:
+            # Any failure -> serve what we already have. Never propagate.
+            return None
+
+    def current(self, *, now: float | None = None, force: bool = False) -> _Cached:
+        moment = time.monotonic() if now is None else now
+        cached = self._cached
+        fresh = (
+            cached is not None
+            and not cached.is_fallback
+            and (moment - cached.fetched_at) < CACHE_TTL_SECONDS
+        )
+        if fresh and not force:
+            assert cached is not None
+            return cached
+        text = self._fetch()
+        if text is None:
+            if cached is not None:
+                return cached
+            return _Cached(
+                text=_FALLBACK_TEXT,
+                digest=_sha256(_FALLBACK_TEXT),
+                size=len(_FALLBACK_TEXT.encode("utf-8")),
+                fetched_at=moment,
+                is_fallback=True,
+            )
+        size = len(text.encode("utf-8"))
+        if size > MAX_SKILL_BYTES:
+            raise SkillTooLarge(
+                f"{SKILL_NAME}: canonical SKILL.md is {size} bytes, over the "
+                f"SEP-2640 ceiling of {MAX_SKILL_BYTES}"
+            )
+        self._cached = _Cached(
+            text=text,
+            digest=_sha256(text),
+            size=size,
+            fetched_at=moment,
+            is_fallback=False,
+        )
+        return self._cached
+
+    def entry(self, *, force: bool = False) -> dict[str, Any]:
+        """One SEP-2640 skill entry."""
+        cached = self.current(force=force)
+        fields, _body = parse_frontmatter(cached.text)
+        resources = [{"uri": SKILL_URI, "digest": f"sha256:{cached.digest}", "size": cached.size}]
+        if len(resources) > MAX_RESOURCES_PER_SKILL:  # pragma: no cover - single resource today
+            raise SkillTooLarge(f"{SKILL_NAME}: over {MAX_RESOURCES_PER_SKILL} resources")
+        return {
+            "name": fields.get("name", SKILL_NAME),
+            "description": fields.get("description", ""),
+            "resources": resources,
+            "frontmatter": fields,
+            "_meta": {
+                "source": CANONICAL_URL,
+                "stale": cached.is_fallback,
+            },
+        }
+
+    def list_result(self, *, force: bool = False) -> dict[str, Any]:
+        """`skills/list`. No nextCursor: one skill fits in one page, and an
+        absent cursor is how the spec spells "that was everything"."""
+        return {
+            "skills": [self.entry(force=force)],
+            "ttlMs": CACHE_TTL_SECONDS * 1000,
+            "cacheScope": "session",
+        }
+
+    def get_result(self, *, name: str | None = None, uri: str | None = None) -> dict[str, Any]:
+        """`skills/get`. Always forces a refresh -- a client calling get is
+        asking whether the skill CHANGED, so answering from cache would defeat
+        the point of serving it over the protocol at all."""
+        if name and name != SKILL_NAME:
+            raise SkillNotFound(f"Unknown skill: {name}")
+        if uri and uri != SKILL_URI:
+            raise SkillNotFound(f"Unknown skill uri: {uri}")
+        return {"skill": self.entry(force=True)}
+
+    def list_resources(self) -> list[dict[str, Any]]:
+        """`resources/list`. The skill's files as ordinary MCP resources, so a
+        client that understands Resources but not the Skills Extension can
+        still see -- and read -- the advisor text."""
+        cached = self.current()
+        return [
+            {
+                "uri": SKILL_URI,
+                "name": f"{SKILL_NAME}/SKILL.md",
+                "description": "TrustedRouter model advisor skill (canonical, refreshed).",
+                "mimeType": "text/markdown",
+                "size": cached.size,
+            }
+        ]
+
+    def read_resource(self, uri: str) -> dict[str, Any]:
+        """`resources/read` for a skill:// URI.
+
+        SEP-2640 is explicit that reading this URI grants no approval on its
+        own -- a skill is loaded through the host's skill-loading path. This
+        returns the bytes; it does not activate anything.
+        """
+        if uri != SKILL_URI:
+            raise SkillNotFound(f"Unknown skill uri: {uri}")
+        cached = self.current()
+        return {"contents": [{"uri": uri, "mimeType": "text/markdown", "text": cached.text}]}
+
+
+class SkillNotFound(LookupError):
+    pass
+
+
+class SkillTooLarge(ValueError):
+    pass
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()

--- a/src/trusted_router/routes/mcp.py
+++ b/src/trusted_router/routes/mcp.py
@@ -22,6 +22,11 @@ from trusted_router.config import Settings
 from trusted_router.dashboard import docs_llms_full_txt
 from trusted_router.errors import error_response
 from trusted_router.mcp_metadata import MCP_SERVER_NAME, MCP_SERVER_TITLE
+from trusted_router.mcp_skills import (
+    SKILLS_EXTENSION_KEY,
+    SkillNotFound,
+    SkillsRegistry,
+)
 from trusted_router.request_limits import enforce_authenticated_rate_limit
 from trusted_router.scopes import SCOPE_BALANCE_READ, SCOPE_INFERENCE
 from trusted_router.storage import STORE, ApiKey
@@ -93,6 +98,10 @@ class TrustedRouterMCP:
         self._model_shapes_by_id: dict[str, dict[str, object]] | None = None
         self._provider_shapes: tuple[dict[str, object], ...] | None = None
         self._docs_chunks: tuple[str, ...] | None = None
+        # Skills Extension (SEP-2640). Holds the last known-good copy of the
+        # canonical advisor skill for the process lifetime, so a GitHub
+        # hiccup degrades to staleness rather than an error.
+        self._skills = SkillsRegistry()
         self._handlers: dict[str, Callable[[dict[str, Any], Request], Awaitable[Any]]] = {
             "ping": self._tool_ping,
             "models-list": self._tool_models_list,
@@ -169,7 +178,16 @@ class TrustedRouterMCP:
                 request_id,
                 {
                     "protocolVersion": MCP_PROTOCOL_VERSION,
-                    "capabilities": {"tools": {}},
+                    # `resources` is advertised because the Skills Extension is
+                    # Resources-based: skill:// URIs are read through
+                    # resources/read. `extensions` is how SEP-2640 says a
+                    # server opts in; a client that does not know the key
+                    # simply never calls skills/*.
+                    "capabilities": {
+                        "tools": {},
+                        "resources": {},
+                        "extensions": {SKILLS_EXTENSION_KEY: {}},
+                    },
                     "serverInfo": {
                         "name": MCP_SERVER_NAME,
                         "title": MCP_SERVER_TITLE,
@@ -177,6 +195,38 @@ class TrustedRouterMCP:
                     },
                 },
             )
+        if method == "skills/list":
+            try:
+                result = await run_in_threadpool(self._skills.list_result)
+                return _mcp_result(request_id, result)
+            except Exception:
+                return _mcp_error(request_id, -32603, "Skill listing failed")
+        if method == "skills/get":
+            try:
+                result = await run_in_threadpool(
+                    self._skills.get_result,
+                    name=(str(params["name"]) if params.get("name") else None),
+                    uri=(str(params["uri"]) if params.get("uri") else None),
+                )
+                return _mcp_result(request_id, result)
+            except SkillNotFound as exc:
+                return _mcp_error(request_id, -32602, str(exc))
+            except Exception:
+                return _mcp_error(request_id, -32603, "Skill fetch failed")
+        if method == "resources/read":
+            uri = str(params.get("uri") or "")
+            if uri.startswith("skill://"):
+                try:
+                    read = await run_in_threadpool(self._skills.read_resource, uri)
+                    return _mcp_result(request_id, read)
+                except SkillNotFound as exc:
+                    return _mcp_error(request_id, -32602, str(exc))
+                except Exception:
+                    return _mcp_error(request_id, -32603, "Skill read failed")
+            return _mcp_error(request_id, -32602, f"Unknown resource uri: {uri}")
+        if method == "resources/list":
+            listing = await run_in_threadpool(self._skills.list_resources)
+            return _mcp_result(request_id, {"resources": listing})
         if method == "tools/list":
             return _mcp_result(request_id, {"tools": _mcp_tools()})
         if method == "tools/call":

--- a/tests/test_mcp_skills_extension.py
+++ b/tests/test_mcp_skills_extension.py
@@ -1,0 +1,157 @@
+"""Skills Extension (SEP-2640) on the TrustedRouter MCP server.
+
+The point of serving the advisor skill over MCP is that an agent already
+connected to TrustedRouter picks up skill edits with no client change. These
+tests pin the two things that property depends on: a refresh really re-reads
+the canonical source, and a canonical source that is unreachable degrades to
+STALE rather than to an error.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from trusted_router.mcp_skills import (
+    CACHE_TTL_SECONDS,
+    MAX_SKILL_BYTES,
+    SKILL_NAME,
+    SKILL_URI,
+    SKILLS_EXTENSION_KEY,
+    SkillNotFound,
+    SkillsRegistry,
+    SkillTooLarge,
+    parse_frontmatter,
+)
+
+V1 = "---\nname: trustedrouter-model-advisor\ndescription: First.\n---\n\n# One\n"
+V2 = "---\nname: trustedrouter-model-advisor\ndescription: Second.\n---\n\n# Two\n"
+
+
+class _Source:
+    """Canonical source whose content and availability the test controls."""
+
+    def __init__(self, text: str | None) -> None:
+        self.text = text
+        self.calls = 0
+
+    def __call__(self, _url: str) -> str:
+        self.calls += 1
+        if self.text is None:
+            raise RuntimeError("canonical source unreachable")
+        return self.text
+
+
+class TestContinuousUpgrade:
+    def test_get_always_refetches_so_an_edit_reaches_the_agent(self) -> None:
+        src = _Source(V1)
+        reg = SkillsRegistry(client_factory=src)
+        assert reg.get_result(name=SKILL_NAME)["skill"]["description"] == "First."
+        src.text = V2  # the skill is edited upstream
+        assert reg.get_result(name=SKILL_NAME)["skill"]["description"] == "Second."
+        assert src.calls == 2, "skills/get must re-read; a cached answer defeats the feature"
+
+    def test_list_serves_cache_within_ttl_then_refreshes(self) -> None:
+        src = _Source(V1)
+        reg = SkillsRegistry(client_factory=src)
+        reg.current(now=0.0)
+        reg.current(now=CACHE_TTL_SECONDS - 1)
+        assert src.calls == 1, "inside the TTL a list must not hit the network"
+        src.text = V2
+        reg.current(now=CACHE_TTL_SECONDS + 1)
+        assert src.calls == 2
+        assert reg.entry()["description"] == "Second."
+
+    def test_digest_changes_with_content(self) -> None:
+        src = _Source(V1)
+        reg = SkillsRegistry(client_factory=src)
+        first = reg.entry()["resources"][0]["digest"]
+        src.text = V2
+        second = reg.entry(force=True)["resources"][0]["digest"]
+        assert first != second and first.startswith("sha256:")
+
+
+class TestAvailabilityIsNotHostage:
+    def test_unreachable_source_serves_last_known_good_not_an_error(self) -> None:
+        src = _Source(V1)
+        reg = SkillsRegistry(client_factory=src)
+        reg.current(now=0.0)
+        src.text = None  # canonical source goes down
+        entry = reg.entry(force=True)
+        assert entry["description"] == "First.", "a failed refresh must serve the cached skill"
+        assert entry["_meta"]["stale"] is False
+
+    def test_never_fetched_and_unreachable_degrades_to_a_pointer(self) -> None:
+        reg = SkillsRegistry(client_factory=_Source(None))
+        entry = reg.entry()
+        assert entry["name"] == SKILL_NAME
+        assert entry["_meta"]["stale"] is True
+        body = reg.read_resource(SKILL_URI)["contents"][0]["text"]
+        assert "LLM-advisor" in body, "offline fallback must still name the canonical source"
+
+
+class TestSpecConformance:
+    def test_list_shape_matches_sep_2640(self) -> None:
+        reg = SkillsRegistry(client_factory=_Source(V1))
+        result = reg.list_result()
+        assert set(result) == {"skills", "ttlMs", "cacheScope"}
+        entry = result["skills"][0]
+        assert {"name", "description", "resources"} <= set(entry)
+        res = entry["resources"][0]
+        assert set(res) == {"uri", "digest", "size"}
+        assert res["uri"] == SKILL_URI and res["uri"].startswith("skill://")
+
+    def test_unknown_name_or_uri_is_rejected(self) -> None:
+        reg = SkillsRegistry(client_factory=_Source(V1))
+        with pytest.raises(SkillNotFound):
+            reg.get_result(name="not-a-skill")
+        with pytest.raises(SkillNotFound):
+            reg.read_resource("skill://nope/SKILL.md")
+
+    def test_oversized_skill_is_refused_not_truncated(self) -> None:
+        big = "---\nname: x\ndescription: y\n---\n" + ("a" * (MAX_SKILL_BYTES + 1))
+        reg = SkillsRegistry(client_factory=_Source(big))
+        with pytest.raises(SkillTooLarge):
+            reg.current()
+
+    def test_frontmatter_parsing_is_verbatim_and_total(self) -> None:
+        fields, body = parse_frontmatter(V1)
+        assert fields == {"name": SKILL_NAME, "description": "First."}
+        assert body.strip() == "# One"
+        assert parse_frontmatter("no frontmatter") == ({}, "no frontmatter")
+        assert parse_frontmatter("---\nunterminated: yes\n")[0] == {}
+
+
+class TestServerAdvertisesTheExtension:
+    def test_initialize_declares_the_capability(self, client, inference_headers) -> None:
+        response = client.post(
+            "/mcp",
+            headers={**inference_headers, "content-type": "application/json"},
+            json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        )
+        assert response.status_code == 200
+        caps = response.json()["result"]["capabilities"]
+        assert SKILLS_EXTENSION_KEY in caps.get("extensions", {})
+        assert "resources" in caps
+
+    def test_skills_list_is_reachable_over_jsonrpc(
+        self, client, inference_headers, monkeypatch
+    ) -> None:
+        # Pin the canonical source so this test asserts protocol wiring, not
+        # GitHub's availability.
+        import trusted_router.mcp_skills as skills
+
+        monkeypatch.setattr(
+            skills.SkillsRegistry,
+            "_fetch",
+            lambda self: "---\nname: trustedrouter-model-advisor\ndescription: d\n---\n",
+        )
+        response = client.post(
+            "/mcp",
+            headers={**inference_headers, "content-type": "application/json"},
+            json={"jsonrpc": "2.0", "id": 2, "method": "skills/list", "params": {}},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert "result" in body, body
+        names = [s["name"] for s in body["result"]["skills"]]
+        assert SKILL_NAME in names


### PR DESCRIPTION
Lets agents connected to the TrustedRouter MCP server pick up advisor-skill edits **with no client-side change** — the upgrade-continuously property.

Today the canonical skill lives in `Lore-Hex/LLM-advisor` and the copy vendored here is a pointer that goes stale on every upstream edit. This serves it through the protocol instead.

**Implements SEP-2640** (Extensions Track, Resources-based):
- capability `"extensions": {"io.modelcontextprotocol/skills": {}}`
- `skills/list`, `skills/get`
- `skill://trustedrouter-model-advisor/SKILL.md`
- entries carry `{uri, digest, size}` + verbatim frontmatter; `ttlMs`/`cacheScope` freshness hints
- 512-resource / 16 MiB ceilings enforced rather than assumed

`resources/list`+`resources/read` also serve it, so a Resources-only client can still read it.

**On the spec being unratified:** SEP-2640 is *In Review* — which is what the Extensions Track is for. A client that doesn't know the capability key never calls `skills/*`; nothing else in the server changes. If the SEP moves, `mcp_skills.py` is the only file that moves.

**Availability:** the canonical fetch never blocks the event loop, a failed refresh serves last-known-good, and a never-succeeded fetch degrades to a pointer naming the canonical URL — never an error. `skills/get` always re-reads, since a client calling it is asking whether the skill changed.

11 new tests (continuous upgrade, staleness-not-failure, spec shape, capability advertisement); existing MCP suite green; mypy clean across 307 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)