### PR TITLE
Stop expected missing secrets from producing deploy error logs

### DIFF
--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -91,21 +91,28 @@ SECRET_ENVS=(
 )
 # Retired environment bindings remain on Cloud Run until explicitly removed.
 REMOVE_SECRET_ENVS=("TR_GOOGLE_ADS_CONVERSION_FEED_PASSWORD")
+
+# Read the metadata inventory once. Probing every optional name with
+# `secrets describe` records an ERROR audit event for each expected missing
+# secret, which obscures real Secret Manager failures and inflates logging
+# volume. The inventory contains names only, never secret values. Failure to
+# list is fatal so an IAM or API outage cannot silently strip bindings.
+OPTIONAL_SECRET_NAMES=""
+if ! OPTIONAL_SECRET_NAMES="$(gc secrets list --format='value(name)')"; then
+  log "cannot list optional secret inventory"
+  exit 1
+fi
+
 add_secret_env_if_exists() {
   local env_name="$1"
   local secret_name="$2"
-  local describe_error=""
-  if describe_error="$(gc secrets describe "$secret_name" 2>&1)"; then
+  if grep -Fxq -- "$secret_name" <<<"$OPTIONAL_SECRET_NAMES"; then
     SECRET_ENVS+=("${env_name}=${secret_name}:latest")
-  elif [[ "$describe_error" == *"NOT_FOUND"* ]] || \
-       [[ "$describe_error" == *"not found"* ]]; then
+  else
     # gcloud --update-secrets preserves old bindings. Explicit removal keeps
     # a deleted optional secret from making an otherwise healthy revision
     # unroutable in regions that still carry the stale environment entry.
     REMOVE_SECRET_ENVS+=("${env_name}")
-  else
-    log "cannot determine whether optional secret ${secret_name} exists"
-    return 1
   fi
 }
 # Carrier credentials for /v1/notify. Optional bindings: if the secrets are

--- a/tests/test_deploy_script_execution.py
+++ b/tests/test_deploy_script_execution.py
@@ -246,6 +246,50 @@ def test_gcp_no_traffic_warm_preprovisions_and_tags_candidate(
     assert "--no-traffic" in deploy
 
 
+def test_rollout_lists_optional_secrets_once_without_missing_secret_probes(
+    harness: DeployScriptHarness,
+) -> None:
+    run = harness.run("scripts/deploy/rollout.sh")
+    assert run.returncode == 0, summarise(run)
+
+    inventory_calls = [
+        call
+        for call in run.calls
+        if call[0:4] == ["gcloud", "--project", "quill-cloud-proxy", "secrets"]
+        and call[4] == "list"
+    ]
+    assert len(inventory_calls) == 1
+    assert not any(
+        call[0:4] == ["gcloud", "--project", "quill-cloud-proxy", "secrets"]
+        and call[4] == "describe"
+        for call in run.calls
+    )
+
+
+def test_rollout_fails_closed_when_optional_secret_inventory_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    script = "scripts/deploy/rollout.sh"
+    fixture = SCRIPT_FIXTURES[script]
+    monkeypatch.setitem(
+        SCRIPT_FIXTURES,
+        script,
+        replace(fixture, failures=(r"secrets list --format=value\(name\)",)),
+    )
+    isolated = DeployScriptHarness(tmp_path / "secret-inventory-failure")
+
+    run = isolated.run(script)
+
+    assert run.returncode != 0
+    assert "cannot list optional secret inventory" in run.stderr
+    assert not any(
+        call[0:4] == ["gcloud", "--project", "quill-cloud-proxy", "run"]
+        and call[4:6] == ["deploy", "trusted-router"]
+        for call in run.calls
+    )
+
+
 def test_warm_primer_caps_below_a_high_service_minimum(
     harness: DeployScriptHarness,
 ) -> None:

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -85,8 +85,10 @@ def test_deploy_removes_only_explicitly_missing_optional_secrets() -> None:
         'REMOVE_SECRET_ENVS=("TR_GOOGLE_ADS_CONVERSION_FEED_PASSWORD")' in rollout
     )
     assert "trustedrouter-google-ads-conversion-feed-password" not in rollout
-    assert '[[ "$describe_error" == *"NOT_FOUND"* ]]' in rollout
-    assert "cannot determine whether optional secret" in rollout
+    assert "gc secrets list --format='value(name)'" in rollout
+    assert 'grep -Fxq -- "$secret_name" <<<"$OPTIONAL_SECRET_NAMES"' in rollout
+    assert "cannot list optional secret inventory" in rollout
+    assert 'gc secrets describe "$secret_name"' not in rollout
     assert 'REMOVE_SECRET_ENVS+=("${env_name}")' in rollout
     assert 'REMOVE_SECRETS_ARGS=(--remove-secrets ' in rollout
     assert '"${REMOVE_SECRETS_ARGS[@]}"' in rollout


### PR DESCRIPTION
## Summary
- inventory Secret Manager names once per rollout instead of probing each optional secret
- preserve removal of stale optional Cloud Run bindings
- fail closed when inventory metadata cannot be listed
- add deploy-harness regressions for one inventory call, zero missing-secret probes, and inventory failure

## Verification
- `uv run pytest -q tests/test_deploy_secret_wiring.py tests/test_deploy_script_execution.py` (118 passed)
- `bash -n scripts/deploy/rollout.sh`
- `shellcheck scripts/deploy/rollout.sh` (informational pre-existing source/path findings only)
- `uv run ruff check tests/test_deploy_secret_wiring.py tests/test_deploy_script_execution.py`
- `git diff --check`