### PR TITLE
Fix chat model catalog discovery

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -3676,7 +3676,9 @@ def public_chat_html(
             # provider response headers are visible without any CORS
             # expose-headers work, so "via {provider}" lights up.
             api_base_url="/chat-proxy/v1",
-            catalog_base_url="https://api.trustedrouter.com/v1",
+            # Catalog discovery is public control-plane metadata. Keep it
+            # same-origin so browsers never depend on gateway CORS policy.
+            catalog_base_url="/v1",
             site_url=f"https://{settings.trusted_domain}/chat",
             title="Chat | TrustedRouter",
             heading="Chat",
@@ -3700,7 +3702,7 @@ def public_fusion_html(settings: Settings) -> str:
         .get_template("public/fusion_playground.html")
         .render(
             api_base_url="/chat-proxy/v1",
-            catalog_base_url="https://api.trustedrouter.com/v1",
+            catalog_base_url="/v1",
             site_url=f"https://{settings.trusted_domain}/synth",
             title="Synth | TrustedRouter",
             heading="Synth",

--- a/tests/test_chat_page.py
+++ b/tests/test_chat_page.py
@@ -60,7 +60,8 @@ def test_chat_page_renders_without_auth() -> None:
     assert "/auth/session" in body
     assert "/internal/chat/issue-browser-key" in body
     assert "tr_chat_key" in body  # keyCookieName
-    assert 'catalogBaseUrl: "https://api.trustedrouter.com/v1"' in body
+    assert 'catalogBaseUrl: "/v1"' in body
+    assert 'catalogBaseUrl: "https://api.trustedrouter.com/v1"' not in body
 
     # Static assets are referenced
     assert "/static/model_catalog.js" in body


### PR DESCRIPTION
## Summary
- load chat and Synth model catalogs from the same-origin public `/v1/models` endpoint
- avoid gateway CORS blocking all model discovery
- add a regression assertion for the same-origin catalog URL

## Verification
- `uv run pytest -q tests/test_chat_page.py` (10 passed)
- reproduced in production before the fix: `chat: model catalog load failed: TypeError: Failed to fetch`
