### PR TITLE
Treat overlapping synthetic remediation as idempotent

### DIFF
--- a/src/trusted_router/synthetic/cli.py
+++ b/src/trusted_router/synthetic/cli.py
@@ -55,6 +55,7 @@ _DEFAULT_THROUGHPUT_TIMEOUT_SECONDS = 90.0
 _DEFAULT_THROUGHPUT_TIMEOUT_CEILING_SECONDS = 210.0
 _DEFAULT_THROUGHPUT_INTERVAL_SECONDS = THROUGHPUT_INTERVAL_SECONDS
 _DEFAULT_REMEDIATOR_TIMEOUT_SECONDS = 90.0
+_REMEDIATOR_OVERLAP_MESSAGE = "Synthetic operation is already in progress"
 
 
 def _env_flag(name: str, *, default: bool = False) -> bool:
@@ -407,6 +408,15 @@ async def _post_remediator(
             headers={"x-trustedrouter-internal-token": internal_token},
             timeout=httpx.Timeout(timeout_seconds),
         )
+        if response.status_code == 429:
+            payload = response.json()
+            error = payload.get("error") if isinstance(payload, dict) else None
+            if (
+                isinstance(error, dict)
+                and error.get("message") == _REMEDIATOR_OVERLAP_MESSAGE
+            ):
+                print("remediator skipped: another pass is already in progress")
+                return True
         response.raise_for_status()
         payload = response.json()
         decisions = payload.get("data", {}).get("decisions") if isinstance(payload, dict) else None

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -2774,6 +2774,49 @@ async def test_remediator_caller_reports_success_and_failure(
 
 
 @pytest.mark.asyncio
+async def test_remediator_caller_treats_only_active_overlap_as_success(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from trusted_router.synthetic import cli as cli_module
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        message = (
+            "Synthetic operation is already in progress"
+            if request.url.path.endswith("/overlap")
+            else "Synthetic operation rate limit exceeded"
+        )
+        return httpx.Response(
+            429,
+            json={
+                "error": {
+                    "code": 429,
+                    "message": message,
+                    "type": "rate_limited",
+                    "source": "router",
+                }
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        overlap = await cli_module._post_remediator(
+            client,
+            url="https://trustedrouter.com/overlap",
+            internal_token="internal",  # noqa: S106 - test placeholder.
+        )
+        rate_limited = await cli_module._post_remediator(
+            client,
+            url="https://trustedrouter.com/rate-limit",
+            internal_token="internal",  # noqa: S106 - test placeholder.
+        )
+
+    output = capsys.readouterr()
+    assert overlap is True
+    assert rate_limited is False
+    assert "remediator skipped: another pass is already in progress" in output.out
+    assert output.err.count("remediator check failed: HTTPStatusError:") == 1
+
+
+@pytest.mark.asyncio
 async def test_primary_synthetic_job_invokes_scheduled_remediator(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- treat only the exact synthetic remediator overlap response as an idempotent successful no-op
- preserve failures for real rate limits, malformed responses, timeouts, and 5xx
- add a regression test covering both 429 cases

## Verification
- regression test failed before the implementation
- `uv run pytest -q tests/test_synthetic_monitoring.py` (117 passed)
- `uv run pytest -q` (6700 passed, 313 skipped, 10 xfailed)
- `uv run mypy`
- `uv run ruff check src/trusted_router/synthetic/cli.py tests/test_synthetic_monitoring.py`
- `git diff --check`