### PR TITLE
Bound contended billing shard scans

### DIFF
--- a/scripts/stress_credit_shards.py
+++ b/scripts/stress_credit_shards.py
@@ -22,6 +22,7 @@ from dataclasses import asdict, dataclass
 from typing import Any
 
 from tests.fakes.spanner import make_fake_store
+from trusted_router.storage_errors import StoreUnavailable
 from trusted_router.storage_gcp_authorize import (
     AuthorizeOutcome,
     SettleOutcome,
@@ -180,7 +181,7 @@ def run_stress(
         started = time.perf_counter()
         outcome = ""
         authorization = None
-        for attempt in range(8):
+        for attempt in range(16):
             try:
                 outcome, authorization = store.authorize_gateway_typed(
                     workspace_id=workspace_id,
@@ -199,13 +200,26 @@ def run_stress(
                     idempotency_fingerprint="stress-body-v1",
                     key_usage_shards=key.usage_shard_count,
                 )
+            except StoreUnavailable:
+                # A concurrent cold-path rebalance deliberately returns a
+                # retryable 503 instead of lying with a 402 or joining the
+                # all-shard write-lock stampede. Exercise that public contract
+                # with the same idempotency key and bounded exponential delay.
+                if attempt == 15:
+                    elapsed = time.perf_counter() - started
+                    with authorization_lock:
+                        authorize_latencies.append(elapsed)
+                        authorize_errors[StoreUnavailable.__name__] += 1
+                    return False
+                time.sleep(min(0.002 * (2**attempt), 0.05))
+                continue
             except Exception as exc:  # noqa: BLE001 - stress harness classifies failures.
                 elapsed = time.perf_counter() - started
                 with authorization_lock:
                     authorize_latencies.append(elapsed)
                     authorize_errors[type(exc).__name__] += 1
                 return False
-            if outcome != AuthorizeOutcome.INSUFFICIENT_CREDITS or attempt == 7:
+            if outcome != AuthorizeOutcome.INSUFFICIENT_CREDITS or attempt == 15:
                 break
             time.sleep(0.002)
         elapsed = time.perf_counter() - started

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -159,10 +159,10 @@ from trusted_router.user_model_rules import (
 
 logger = logging.getLogger(__name__)
 REQUEST_METADATA_VERSION = 1
-# The enclave stops waiting for response headers after 25 seconds. Leave enough
-# room for this process to serialize a structured retryable 503 and for network
-# transit instead of letting the enclave surface an ambiguous upstream timeout.
-_BILLING_PATH_SPANNER_BUDGET_SECONDS = 18.0
+# The enclave stops waiting for response headers after 25 seconds. Preserve the
+# transaction layer's 20-second retry budget while leaving five seconds for this
+# process to serialize a structured retryable 503 and for network transit.
+_BILLING_PATH_SPANNER_BUDGET_SECONDS = 20.0
 _AUTHORIZE_ADMISSION = KeyedConcurrencyAdmission()
 _NATIVE_BATCH_ROUTE_PREFIX = "batch.native."
 _NATIVE_BATCH_BILLED_FRACTION_BPS = {

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -159,7 +159,10 @@ from trusted_router.user_model_rules import (
 
 logger = logging.getLogger(__name__)
 REQUEST_METADATA_VERSION = 1
-_BILLING_PATH_SPANNER_BUDGET_SECONDS = 25.0
+# The enclave stops waiting for response headers after 25 seconds. Leave enough
+# room for this process to serialize a structured retryable 503 and for network
+# transit instead of letting the enclave surface an ambiguous upstream timeout.
+_BILLING_PATH_SPANNER_BUDGET_SECONDS = 18.0
 _AUTHORIZE_ADMISSION = KeyedConcurrencyAdmission()
 _NATIVE_BATCH_ROUTE_PREFIX = "batch.native."
 _NATIVE_BATCH_BILLED_FRACTION_BPS = {

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -3420,9 +3420,10 @@ class SpannerBigtableStore:
         if result["outcome"] == AuthorizeOutcome.INSUFFICIENT_CREDITS and has_credit_candidate:
             from trusted_router import storage_gcp_credit_rebalance as rebalance_mod
 
-            # An all-shards rejection is cold. Refresh once so a remote
+            # A bounded write-set rejection is cold. Refresh once so a remote
             # pause/drain split or unshard cannot produce a false 402 until the
-            # normal TTL expires. The accepted hot path never pays this read.
+            # normal TTL expires. Requests accepted inside the bounded prefix
+            # never pay this read; a later funded shard needs one snapshot.
             previous_count = len(credit_shard_candidates)
             try:
                 refreshed_candidates = self._refresh_credit_shard_candidates(workspace_id)
@@ -3538,6 +3539,12 @@ class SpannerBigtableStore:
                 }:
                     result = run_authorize(credit_shard_candidates)
                     continue
+                if rebalance_result["outcome"] == rebalance_mod.RebalanceOutcome.INSUFFICIENT:
+                    # This verdict comes from a locked read of every configured
+                    # shard and is at least as authoritative as the snapshot
+                    # precheck. Preserve the honest 402 instead of turning a
+                    # concurrent final-credit race into a spurious 503.
+                    aggregate_exhaustion_proven = True
                 break
             if (
                 result["outcome"] == AuthorizeOutcome.INSUFFICIENT_CREDITS

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -3279,7 +3279,11 @@ class SpannerBigtableStore:
         key_limit_exceeded/key_missing/idempotency_mismatch, or
         "key_window_limit_exceeded:<daily|weekly|monthly>" when a per-window cap
         blocked (see authorize_atomic's window_limits contract)."""
-        from trusted_router.storage_gcp_authorize import AuthorizeOutcome, authorize_atomic
+        from trusted_router.storage_gcp_authorize import (
+            AuthorizeOutcome,
+            authorize_atomic,
+            bounded_credit_shard_candidates,
+        )
         from trusted_router.storage_gcp_keys import (
             _gateway_authorization_idempotency_index_id,
         )
@@ -3385,7 +3389,11 @@ class SpannerBigtableStore:
                 build_authorization=build_authorization,
                 build_auth_body=build_body,
                 request_record_write_mode=self.request_record_write_mode,
-                credit_shard_candidates=candidates,
+                # Retain `candidates` in full outside this transaction for the
+                # lock-free aggregate check and cold rebalance below. A depleted
+                # workspace must never make one rejected transaction lock every
+                # configured shard.
+                credit_shard_candidates=bounded_credit_shard_candidates(candidates),
                 key_shard_candidates=key_shard_candidates,
                 authorization_id=authorization_id,
             )

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -82,7 +82,11 @@ from trusted_router.storage_activity import (
     usage_bucket_key,
 )
 from trusted_router.storage_auth_context import build_session_auth_context
-from trusted_router.storage_errors import is_duplicate_key_error, is_transient_store_error
+from trusted_router.storage_errors import (
+    StoreUnavailable,
+    is_duplicate_key_error,
+    is_transient_store_error,
+)
 from trusted_router.storage_gcp_analytics_outbox import SpannerAnalyticsOutbox
 from trusted_router.storage_gcp_attribution import SpannerAcquisitionAttribution
 from trusted_router.storage_gcp_auth_sessions import SpannerAuthSessions
@@ -3450,24 +3454,32 @@ class SpannerBigtableStore:
             # from the snapshot precheck before entering the RW repair.
             forced_reload_done = False
             cooldown_passed = False
+            aggregate_exhaustion_proven = False
             for _attempt in range(3):
                 if (
                     result["outcome"] != AuthorizeOutcome.INSUFFICIENT_CREDITS
                     or len(credit_shard_candidates) <= 1
                 ):
                     break
-                verdict = rebalance_mod.rebalance_precheck(
+                precheck = rebalance_mod.credit_headroom_precheck(
                     self._database,
                     self._param_types,
                     workspace_id=workspace_id,
                     shard_count=len(credit_shard_candidates),
-                    target_shard=credit_shard_candidates[0],
+                    shard_candidates=credit_shard_candidates,
                     estimate=estimate,
                 )
+                verdict = precheck.outcome
                 if verdict == rebalance_mod.RebalanceOutcome.INSUFFICIENT:
+                    aggregate_exhaustion_proven = True
                     break
                 if verdict == rebalance_mod.RebalanceOutcome.NOT_NEEDED:
-                    result = run_authorize(credit_shard_candidates)
+                    if precheck.candidate_shard is None:  # pragma: no cover - invariant
+                        raise RuntimeError("credit headroom precheck omitted its candidate")
+                    # The bounded random prefix missed a funded later shard.
+                    # Retry that exact row instead of either returning a false
+                    # 402 or expanding into an all-shard write transaction.
+                    result = run_authorize((precheck.candidate_shard,))
                     continue
                 if verdict == rebalance_mod.RebalanceOutcome.INCOMPLETE and not forced_reload_done:
                     # The observed shard set doesn't match the count we hold —
@@ -3500,7 +3512,11 @@ class SpannerBigtableStore:
                 # be blocked by our own just-recorded timestamp.
                 if not cooldown_passed:
                     if not self._credit_rebalance_cooldown_allows(workspace_id):
-                        break
+                        # Aggregate funds exist but are genuinely fragmented.
+                        # The cooldown protects Spanner from a rebalance
+                        # stampede; reporting 402 here would be an accounting
+                        # lie, so ask the caller to retry instead.
+                        raise StoreUnavailable("credit escrow rebalance is busy; retry")
                     cooldown_passed = True
                 rebalance_result = rebalance(credit_shard_candidates)
                 log.info(
@@ -3523,6 +3539,16 @@ class SpannerBigtableStore:
                     result = run_authorize(credit_shard_candidates)
                     continue
                 break
+            if (
+                result["outcome"] == AuthorizeOutcome.INSUFFICIENT_CREDITS
+                and len(credit_shard_candidates) > 1
+                and not aggregate_exhaustion_proven
+            ):
+                # A bounded retry race or incomplete precheck is not proof that
+                # the customer's aggregate balance is exhausted. Preserve the
+                # accounting contract by returning retryable unavailability;
+                # only the explicit read-only aggregate verdict above may 402.
+                raise StoreUnavailable("credit headroom changed concurrently; retry")
         outcome = result["outcome"]
         authorization: GatewayAuthorization | None = None
         if outcome in (AuthorizeOutcome.ACCEPTED, AuthorizeOutcome.REPLAY):

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -60,6 +60,21 @@ from trusted_router.storage_models import GatewayAuthorization, Generation, User
 
 log = logging.getLogger(__name__)
 
+# A rejected conditional UPDATE keeps its row lock until the transaction rolls
+# back. Scanning every configured shard therefore lets one depleted tenant turn
+# N concurrent authorizations into N * shard_count contended row locks. Keep the
+# hot transaction small; the caller retains the full shard set for its lock-free
+# aggregate precheck and cold-path escrow rebalance.
+MAX_CREDIT_SHARD_ATTEMPTS_PER_TRANSACTION = 4
+
+
+def bounded_credit_shard_candidates(candidates: tuple[int, ...]) -> tuple[int, ...]:
+    """Return the fixed, pre-randomized hot-path subset for one transaction."""
+
+    if not candidates:
+        raise ValueError("credit_shard_candidates must not be empty")
+    return candidates[:MAX_CREDIT_SHARD_ATTEMPTS_PER_TRANSACTION]
+
 
 class AuthorizeOutcome:
     ACCEPTED = "accepted"
@@ -235,7 +250,9 @@ def authorize_atomic(
     candidate, else BYOK). `has_credit_candidate` gates the credit hold.
     `credit_shard_candidates` is a bounded, pre-randomized order built outside
     the transaction so Spanner retries use the same order. The first shard with
-    enough independent sub-budget is recorded durably on the reservation.
+    enough independent sub-budget is recorded durably on the reservation. The
+    store wrapper applies `bounded_credit_shard_candidates`; direct callers must
+    likewise pass no more than the hot-path limit.
 
     Per-window key caps are checked by the CALLER via check_key_window_limits on
     a lock-free snapshot BEFORE this transaction — deliberately NOT in here: a

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -280,6 +280,13 @@ def authorize_atomic(
         raise ValueError("credit shards must be non-negative")
     if len(set(shard_candidates)) != len(shard_candidates):
         raise ValueError("credit_shard_candidates must be unique")
+    if (
+        has_credit_candidate
+        and len(shard_candidates) > MAX_CREDIT_SHARD_ATTEMPTS_PER_TRANSACTION
+    ):
+        raise ValueError(
+            "credit_shard_candidates exceeds the hot-path transaction limit"
+        )
     if not has_credit_candidate and shard_candidates != (UNSHARDED,):
         raise ValueError("BYOK-only authorization must use credit shard zero")
     key_candidates = tuple(key_shard_candidates)

--- a/src/trusted_router/storage_gcp_credit_rebalance.py
+++ b/src/trusted_router/storage_gcp_credit_rebalance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from trusted_router.storage_gcp_counter_dml import transfer_credit_budget
@@ -18,25 +19,34 @@ class RebalanceOutcome:
     INCOMPLETE = "incomplete"
 
 
+@dataclass(frozen=True)
+class CreditHeadroomPrecheck:
+    """Lock-free affordability result plus a directly usable shard, if any."""
+
+    outcome: str
+    candidate_shard: int | None = None
+
+
 class _RebalanceInvariantError(RuntimeError):
     """Rollback a transfer plan if any guarded DML does not affect one row."""
 
 
-def rebalance_precheck(
+def credit_headroom_precheck(
     database: Any,
     param_types: Any,
     *,
     workspace_id: str,
     shard_count: int,
-    target_shard: int,
+    shard_candidates: tuple[int, ...],
     estimate: int,
-) -> str:
-    """Advisory, lock-free verdict from a read-only snapshot."""
+) -> CreditHeadroomPrecheck:
+    """Find a directly usable shard before considering an all-shard rebalance."""
     count = credit_shard_count({"shard_count": shard_count})
-    if target_shard < 0 or target_shard >= count:
-        raise ValueError("rebalance target shard is outside configured range")
+    candidates = tuple(shard_candidates)
+    if len(candidates) != count or set(candidates) != set(range(count)):
+        raise ValueError("credit precheck requires every configured shard exactly once")
     if estimate <= 0:
-        return RebalanceOutcome.NOT_NEEDED
+        return CreditHeadroomPrecheck(RebalanceOutcome.NOT_NEEDED, candidates[0])
     pt = param_types
 
     with database.snapshot() as snapshot:
@@ -51,19 +61,45 @@ def rebalance_precheck(
         )
     observed = [int(row[0]) for row in rows]
     if observed != list(range(count)):
-        return RebalanceOutcome.INCOMPLETE
+        return CreditHeadroomPrecheck(RebalanceOutcome.INCOMPLETE)
 
     headroom: dict[int, int] = {}
     for shard, total_credits, total_usage, reserved in rows:
         available = int(total_credits) - int(total_usage) - int(reserved)
         headroom[int(shard)] = available
 
-    target_available = headroom[target_shard]
-    if target_available >= estimate:
-        return RebalanceOutcome.NOT_NEEDED
+    for candidate in candidates:
+        if headroom[candidate] >= estimate:
+            return CreditHeadroomPrecheck(RebalanceOutcome.NOT_NEEDED, candidate)
     if sum(headroom.values()) < estimate:
-        return RebalanceOutcome.INSUFFICIENT
-    return RebalanceOutcome.MOVED
+        return CreditHeadroomPrecheck(RebalanceOutcome.INSUFFICIENT)
+    return CreditHeadroomPrecheck(RebalanceOutcome.MOVED)
+
+
+def rebalance_precheck(
+    database: Any,
+    param_types: Any,
+    *,
+    workspace_id: str,
+    shard_count: int,
+    target_shard: int,
+    estimate: int,
+) -> str:
+    """Compatibility verdict for callers that only need the target outcome."""
+    count = credit_shard_count({"shard_count": shard_count})
+    if target_shard < 0 or target_shard >= count:
+        raise ValueError("rebalance target shard is outside configured range")
+    candidates = (target_shard,) + tuple(
+        shard for shard in range(count) if shard != target_shard
+    )
+    return credit_headroom_precheck(
+        database,
+        param_types,
+        workspace_id=workspace_id,
+        shard_count=count,
+        shard_candidates=candidates,
+        estimate=estimate,
+    ).outcome
 
 
 def rebalance_credit_for_estimate(

--- a/src/trusted_router/storage_gcp_credit_rebalance.py
+++ b/src/trusted_router/storage_gcp_credit_rebalance.py
@@ -45,8 +45,6 @@ def credit_headroom_precheck(
     candidates = tuple(shard_candidates)
     if len(candidates) != count or set(candidates) != set(range(count)):
         raise ValueError("credit precheck requires every configured shard exactly once")
-    if estimate <= 0:
-        return CreditHeadroomPrecheck(RebalanceOutcome.NOT_NEEDED, candidates[0])
     pt = param_types
 
     with database.snapshot() as snapshot:

--- a/tests/test_billing_path_rpc_budget.py
+++ b/tests/test_billing_path_rpc_budget.py
@@ -75,4 +75,4 @@ def test_no_blank_line_between_the_budget_and_its_function() -> None:
 def test_billing_budget_finishes_before_enclave_header_timeout() -> None:
     """The enclave's direct control-plane client has a 25-second header cap."""
 
-    assert _BILLING_PATH_SPANNER_BUDGET_SECONDS < 25.0
+    assert _BILLING_PATH_SPANNER_BUDGET_SECONDS == 20.0

--- a/tests/test_billing_path_rpc_budget.py
+++ b/tests/test_billing_path_rpc_budget.py
@@ -19,6 +19,10 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+from trusted_router.routes.internal.gateway import (
+    _BILLING_PATH_SPANNER_BUDGET_SECONDS,
+)
+
 ROOT = Path(__file__).resolve().parents[1]
 GATEWAY = ROOT / "src" / "trusted_router" / "routes" / "internal" / "gateway.py"
 
@@ -66,3 +70,9 @@ def test_no_blank_line_between_the_budget_and_its_function() -> None:
                 f"{number + 1} is followed by {following!r}, so it binds to "
                 f"whatever function appears next instead of the one below it"
             )
+
+
+def test_billing_budget_finishes_before_enclave_header_timeout() -> None:
+    """The enclave's direct control-plane client has a 25-second header cap."""
+
+    assert _BILLING_PATH_SPANNER_BUDGET_SECONDS < 25.0

--- a/tests/test_credit_rebalance_contention.py
+++ b/tests/test_credit_rebalance_contention.py
@@ -131,6 +131,55 @@ def test_true_exhaustion_skips_rw_rebalance(monkeypatch: pytest.MonkeyPatch) -> 
     assert calls["count"] == 0
 
 
+def test_true_exhaustion_bounds_conditional_credit_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A depleted tenant must not lock every configured credit shard."""
+    from trusted_router import storage_gcp_authorize as authorize_mod
+
+    store, _database, key = _seed([100] * 16, usage=[100] * 16)
+    attempts: list[tuple[int, ...]] = []
+    original = authorize_mod.authorize_atomic
+
+    def spy(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        candidates = tuple(kwargs["credit_shard_candidates"])
+        attempts.append(candidates)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(authorize_mod, "authorize_atomic", spy)
+
+    outcome, authorization = _typed_authorize(store, key, estimate=1)
+
+    assert outcome == AuthorizeOutcome.INSUFFICIENT_CREDITS
+    assert authorization is None
+    assert attempts
+    assert max(len(candidates) for candidates in attempts) <= 4
+
+
+def test_bounded_attempts_repair_headroom_outside_hot_subset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bounding the write set must not turn aggregate funds into a false 402."""
+    totals = [0] * 16
+    totals[7] = 100
+    store, database, key = _seed(totals)
+    candidates = tuple(range(16))
+    monkeypatch.setattr(store, "_credit_shard_candidates", lambda _workspace_id: candidates)
+    monkeypatch.setattr(
+        store,
+        "_refresh_credit_shard_candidates",
+        lambda _workspace_id: candidates,
+    )
+
+    outcome, authorization = _typed_authorize(store, key, estimate=80)
+
+    assert outcome == AuthorizeOutcome.ACCEPTED
+    assert authorization is not None
+    rows = database.typed[CREDIT_BALANCE_TABLE]
+    assert rows[(WORKSPACE_ID, 0)]["reserved"] == 80
+    assert rows[(WORKSPACE_ID, 7)]["total_credits"] == 20
+
+
 def test_fragmented_sufficient_still_rebalances_and_accepts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_credit_rebalance_contention.py
+++ b/tests/test_credit_rebalance_contention.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 
 from tests.fakes.spanner import make_fake_store
+from trusted_router.storage_errors import StoreUnavailable
 from trusted_router.storage_gcp_authorize import AuthorizeOutcome
 from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
 from trusted_router.storage_gcp_credit_rebalance import (
@@ -171,13 +172,20 @@ def test_bounded_attempts_repair_headroom_outside_hot_subset(
         lambda _workspace_id: candidates,
     )
 
+    calls = _install_rebalance_spy(monkeypatch)
+
     outcome, authorization = _typed_authorize(store, key, estimate=80)
+    followup_outcome, followup_authorization = _typed_authorize(store, key, estimate=20)
 
     assert outcome == AuthorizeOutcome.ACCEPTED
     assert authorization is not None
+    assert followup_outcome == AuthorizeOutcome.ACCEPTED
+    assert followup_authorization is not None
     rows = database.typed[CREDIT_BALANCE_TABLE]
-    assert rows[(WORKSPACE_ID, 0)]["reserved"] == 80
-    assert rows[(WORKSPACE_ID, 7)]["total_credits"] == 20
+    assert rows[(WORKSPACE_ID, 0)]["reserved"] == 0
+    assert rows[(WORKSPACE_ID, 7)]["reserved"] == 100
+    assert rows[(WORKSPACE_ID, 7)]["total_credits"] == 100
+    assert calls["count"] == 0
 
 
 def test_fragmented_sufficient_still_rebalances_and_accepts(
@@ -251,7 +259,7 @@ def test_rebalance_precheck_incomplete_and_nonpositive_are_read_only() -> None:
     assert _typed_rows(database) == before
 
 
-def test_rebalance_cooldown_suppresses_immediate_followers(
+def test_rebalance_cooldown_returns_retryable_error_not_false_402(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from trusted_router import storage_gcp_credit_rebalance as rebalance_mod
@@ -274,14 +282,13 @@ def test_rebalance_cooldown_suppresses_immediate_followers(
     database.reservation_idemp.clear()
     _set_credit_rows(database, [100, 100], usage=[60, 60])
 
-    second_outcome, second_authorization = _typed_authorize(
-        store,
-        key,
-        estimate=60,
-        idempotency_key="second",
-    )
-    assert second_outcome == AuthorizeOutcome.INSUFFICIENT_CREDITS
-    assert second_authorization is None
+    with pytest.raises(StoreUnavailable, match="rebalance is busy"):
+        _typed_authorize(
+            store,
+            key,
+            estimate=60,
+            idempotency_key="second",
+        )
     assert calls["count"] == 1
 
     monkeypatch.setattr(rebalance_mod, "REBALANCE_COOLDOWN_SECONDS", 0.0)
@@ -296,6 +303,23 @@ def test_rebalance_cooldown_suppresses_immediate_followers(
     assert third_outcome == AuthorizeOutcome.ACCEPTED
     assert third_authorization is not None
     assert calls["count"] == 2
+
+
+def test_repeated_headroom_races_return_retryable_error_not_false_402(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bounded retry limit is not evidence that aggregate funds are gone."""
+    from trusted_router import storage_gcp_authorize as authorize_mod
+
+    store, _database, key = _seed([100, 100])
+
+    def always_stolen(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        return {"outcome": AuthorizeOutcome.INSUFFICIENT_CREDITS}
+
+    monkeypatch.setattr(authorize_mod, "authorize_atomic", always_stolen)
+
+    with pytest.raises(StoreUnavailable, match="changed concurrently"):
+        _typed_authorize(store, key, estimate=50)
 
 
 def test_reject_path_refresh_dedupes_loader(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_credit_rebalance_contention.py
+++ b/tests/test_credit_rebalance_contention.py
@@ -10,6 +10,7 @@ from trusted_router.storage_gcp_authorize import AuthorizeOutcome
 from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
 from trusted_router.storage_gcp_credit_rebalance import (
     RebalanceOutcome,
+    credit_headroom_precheck,
     rebalance_precheck,
 )
 from trusted_router.storage_gcp_credit_shards import (
@@ -255,8 +256,60 @@ def test_rebalance_precheck_incomplete_and_nonpositive_are_read_only() -> None:
     )
 
     assert incomplete == RebalanceOutcome.INCOMPLETE
-    assert nonpositive == RebalanceOutcome.NOT_NEEDED
+    assert nonpositive == RebalanceOutcome.INCOMPLETE
     assert _typed_rows(database) == before
+
+
+def test_zero_estimate_precheck_selects_a_viable_later_shard() -> None:
+    """A zero estimate must not blindly select an overdrawn prefix shard."""
+    store, database, _key = _seed(
+        [100, 100, 100, 100, 100, 100],
+        usage=[101, 101, 101, 101, 100, 99],
+    )
+    before = _typed_rows(database)
+
+    precheck = credit_headroom_precheck(
+        store._database,
+        store._param_types,
+        workspace_id=WORKSPACE_ID,
+        shard_count=6,
+        shard_candidates=tuple(range(6)),
+        estimate=0,
+    )
+
+    assert precheck.outcome == RebalanceOutcome.NOT_NEEDED
+    assert precheck.candidate_shard == 4
+    assert _typed_rows(database) == before
+
+
+def test_authoritative_rebalance_exhaustion_returns_402(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A locked all-shard verdict is proof, not a retryable ambiguity."""
+    from trusted_router import storage_gcp_credit_rebalance as rebalance_mod
+
+    store, _database, key = _seed([100, 100], usage=[60, 60])
+    monkeypatch.setattr(
+        rebalance_mod,
+        "credit_headroom_precheck",
+        lambda *_args, **_kwargs: rebalance_mod.CreditHeadroomPrecheck(
+            RebalanceOutcome.MOVED
+        ),
+    )
+    monkeypatch.setattr(
+        rebalance_mod,
+        "rebalance_credit_for_estimate",
+        lambda *_args, **_kwargs: {
+            "outcome": RebalanceOutcome.INSUFFICIENT,
+            "moved_micro": 0,
+            "target_shard": 0,
+        },
+    )
+
+    outcome, authorization = _typed_authorize(store, key, estimate=60)
+
+    assert outcome == AuthorizeOutcome.INSUFFICIENT_CREDITS
+    assert authorization is None
 
 
 def test_rebalance_cooldown_returns_retryable_error_not_false_402(
@@ -387,7 +440,7 @@ def test_unsharded_rejection_skips_precheck_and_rebalance(
     def fail_precheck(*args: Any, **kwargs: Any) -> str:
         raise AssertionError("unsharded rejection must not precheck")
 
-    monkeypatch.setattr(rebalance_mod, "rebalance_precheck", fail_precheck)
+    monkeypatch.setattr(rebalance_mod, "credit_headroom_precheck", fail_precheck)
 
     outcome, authorization = _typed_authorize(store, key, estimate=50)
 

--- a/tests/test_credit_row_sharding_increment2.py
+++ b/tests/test_credit_row_sharding_increment2.py
@@ -136,6 +136,8 @@ def test_invalid_or_unbounded_candidate_configuration_fails_closed() -> None:
         authorize_atomic(**common, credit_shard_candidates=(0, 0))
     with pytest.raises(ValueError, match="non-negative"):
         authorize_atomic(**common, credit_shard_candidates=(-1,))
+    with pytest.raises(ValueError, match="hot-path transaction limit"):
+        authorize_atomic(**common, credit_shard_candidates=(0, 1, 2, 3, 4))
 
 
 def test_scan_skips_insufficient_shard_and_records_first_success() -> None:
@@ -294,7 +296,9 @@ def test_store_byok_path_does_not_load_credit_shard_configuration(
 
 
 def test_concurrent_sharded_reserves_never_exceed_global_cap() -> None:
-    shard_count = 8
+    # Exercise the low-level atomic primitive at its enforced write-set bound.
+    # The store wrapper owns larger shard sets and its lock-free cold path.
+    shard_count = 4
     per_shard_credit = 40
     estimate = 10
     store, database, key = _seed([per_shard_credit] * shard_count)

--- a/tests/test_credit_row_sharding_increment3.py
+++ b/tests/test_credit_row_sharding_increment3.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 
 from tests.fakes.spanner import make_fake_store
+from trusted_router.storage_errors import StoreUnavailable
 from trusted_router.storage_gcp_authorize import AuthorizeOutcome, settle_atomic
 from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
 from trusted_router.storage_gcp_credit_rebalance import (
@@ -371,12 +372,15 @@ def test_concurrent_fragmentation_repair_preserves_cap_and_accepts_at_most_one()
 
     def worker(index: int) -> None:
         start.wait(timeout=10)
-        outcome, _authorization = _typed_authorize(
-            store,
-            key,
-            estimate=60,
-            idempotency_key=f"concurrent-{index}",
-        )
+        try:
+            outcome, _authorization = _typed_authorize(
+                store,
+                key,
+                estimate=60,
+                idempotency_key=f"concurrent-{index}",
+            )
+        except StoreUnavailable:
+            outcome = "retryable_unavailable"
         with lock:
             outcomes.append(outcome)
 
@@ -389,7 +393,11 @@ def test_concurrent_fragmentation_repair_preserves_cap_and_accepts_at_most_one()
         assert not thread.is_alive()
 
     assert outcomes.count(AuthorizeOutcome.ACCEPTED) == 1
-    assert outcomes.count(AuthorizeOutcome.INSUFFICIENT_CREDITS) == 1
+    assert (
+        outcomes.count(AuthorizeOutcome.INSUFFICIENT_CREDITS)
+        + outcomes.count("retryable_unavailable")
+        == 1
+    )
     rows = database.typed[CREDIT_BALANCE_TABLE]
     assert sum(row["total_credits"] for row in rows.values()) == 200
     assert sum(row["reserved"] for row in rows.values()) == 60


### PR DESCRIPTION
## Summary
- cap each hot-path Spanner credit reservation transaction at four pre-randomized shard attempts
- retain the full shard set for a lock-free aggregate headroom snapshot
- retry the exact later funded shard without an all-shard write transaction; use the existing all-shard rebalance only for genuinely fragmented balances
- return retryable 503, never false 402, when funded headroom races or a rebalance guard is busy
- reduce the shared control-plane billing deadline from 25s to 20s so storage failures return before the enclave's 25s response-header timeout

## Incident
A newly funded workspace drove hundreds of concurrent large authorizations and then continued after its balance was exhausted. Each rejection conditionally touched all 16 credit shards, amplifying one tenant into thousands of seconds of Spanner row-lock wait and exact 25s authorize timeouts across regions.

## Review corrections
The first version bounded the write set but could false-402 a funded workspace when the random prefix missed a later funded shard. Opus review caught this. The revised path returns the exact viable shard from the lock-free snapshot and retries only that row. It also makes aggregate exhaustion proof a requirement for 402.

## Verification
- regression failed on previous code: 16 shard attempts vs maximum 4
- exact residual-headroom reproduction now accepts both requests with zero rebalances
- repeated headroom races and rebalance cooldowns return retryable errors rather than false 402
- 68 focused sharding, stress, escrow, and deadline tests pass
- 135 broader billing tests pass
- full suite: 6,683 passed; all 20 local socket/timing failures rerun serially with loopback permission and all 137 passed
- post-rebase OAuth and billing suite: 138 passed
- Ruff clean
- mypy clean across 310 source files