### PR TITLE
Contain per-key gateway authorize contention

### DIFF
--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -595,6 +595,10 @@ class Settings(BaseSettings):
     rate_limit_ip_per_window: int = 240
     rate_limit_key_per_window: int = 1200
     rate_limit_internal_per_window: int = 6000
+    # A contended Spanner authorize can occupy a worker for the full RPC
+    # budget. Keep one API key from filling every worker in a service instance
+    # while still allowing ordinary low-latency traffic to scale horizontally.
+    gateway_authorize_max_in_flight_per_key: int = 4
     # Only front doors that overwrite X-TrustedRouter-Client-IP may opt into
     # edge_header. Public origins that cannot perform that overwrite must stay
     # on the safe default and aggregate into the untrusted_lb bucket.
@@ -1207,6 +1211,10 @@ class Settings(BaseSettings):
             ("TR_RATE_LIMIT_IP_PER_WINDOW", self.rate_limit_ip_per_window),
             ("TR_RATE_LIMIT_KEY_PER_WINDOW", self.rate_limit_key_per_window),
             ("TR_RATE_LIMIT_INTERNAL_PER_WINDOW", self.rate_limit_internal_per_window),
+            (
+                "TR_GATEWAY_AUTHORIZE_MAX_IN_FLIGHT_PER_KEY",
+                self.gateway_authorize_max_in_flight_per_key,
+            ),
         ):
             if value <= 0:
                 raise ValueError(f"{name} must be positive")

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -107,6 +107,7 @@ from trusted_router.services.broadcast import (
     should_drain_inline,
 )
 from trusted_router.services.federation import FederationClient, FederationUnavailable
+from trusted_router.services.keyed_admission import KeyedConcurrencyAdmission
 from trusted_router.services.receipt_key_collector import collect_receipt_keys
 from trusted_router.services.regional_quota_leases import LeaseSettlementError
 from trusted_router.services.settle_outbox_apply import normalized_prompt_accounting
@@ -159,6 +160,7 @@ from trusted_router.user_model_rules import (
 logger = logging.getLogger(__name__)
 REQUEST_METADATA_VERSION = 1
 _BILLING_PATH_SPANNER_BUDGET_SECONDS = 25.0
+_AUTHORIZE_ADMISSION = KeyedConcurrencyAdmission()
 _NATIVE_BATCH_ROUTE_PREFIX = "batch.native."
 _NATIVE_BATCH_BILLED_FRACTION_BPS = {
     "openai": 5_000,
@@ -242,7 +244,32 @@ async def authorize_gateway(
     free while this request's blocking storage runs; the response is byte-identical.
     Kept ``async`` so callers/tests await it unchanged.
     """
-    return await run_in_threadpool(_authorize_gateway_sync, request, body, settings)
+    subject = body.api_key_lookup_hash or body.api_key_hash
+    assert subject is not None  # GatewayAuthorizeRequest validates one identifier.
+    if not _AUTHORIZE_ADMISSION.try_acquire(
+        subject,
+        limit=settings.gateway_authorize_max_in_flight_per_key,
+    ):
+        logger.warning(
+            "billing.authorize_admission_limited",
+            extra={
+                "request_id": getattr(request.state, "request_id", None),
+                "key_subject_fingerprint": hashlib.sha256(
+                    subject.encode("utf-8")
+                ).hexdigest()[:16],
+                "limit": settings.gateway_authorize_max_in_flight_per_key,
+            },
+        )
+        raise api_error(
+            429,
+            "Too many concurrent requests for this API key",
+            ErrorType.RATE_LIMITED,
+            headers={"Retry-After": "1"},
+        )
+    try:
+        return await run_in_threadpool(_authorize_gateway_sync, request, body, settings)
+    finally:
+        _AUTHORIZE_ADMISSION.release(subject)
 
 
 @spanner_rpc_budget(_BILLING_PATH_SPANNER_BUDGET_SECONDS)

--- a/src/trusted_router/services/keyed_admission.py
+++ b/src/trusted_router/services/keyed_admission.py
@@ -1,0 +1,54 @@
+"""Bounded per-subject concurrency admission for expensive internal work."""
+
+from __future__ import annotations
+
+import threading
+
+
+class KeyedConcurrencyAdmission:
+    """Keep one hot subject from occupying every worker in a process.
+
+    Entries exist only while work is in flight, so memory is bounded by both
+    ``max_subjects`` and the server's own request concurrency. Rejection is
+    immediate: callers should retry with a new request after the advertised
+    backoff rather than queueing work in application memory.
+    """
+
+    def __init__(self, *, max_subjects: int = 10_000) -> None:
+        if max_subjects <= 0:
+            raise ValueError("max_subjects must be positive")
+        self._max_subjects = max_subjects
+        self._lock = threading.Lock()
+        self._in_flight: dict[str, int] = {}
+
+    def try_acquire(self, subject: str, *, limit: int) -> bool:
+        if not subject:
+            raise ValueError("subject must not be empty")
+        if limit <= 0:
+            raise ValueError("limit must be positive")
+        with self._lock:
+            current = self._in_flight.get(subject)
+            if current is None:
+                if len(self._in_flight) >= self._max_subjects:
+                    return False
+                self._in_flight[subject] = 1
+                return True
+            if current >= limit:
+                return False
+            self._in_flight[subject] = current + 1
+            return True
+
+    def release(self, subject: str) -> None:
+        with self._lock:
+            current = self._in_flight.get(subject)
+            if current is None:
+                return
+            if current == 1:
+                self._in_flight.pop(subject, None)
+            else:
+                self._in_flight[subject] = current - 1
+
+    def count(self, subject: str) -> int:
+        """Return a subject's live count for diagnostics and deterministic tests."""
+        with self._lock:
+            return self._in_flight.get(subject, 0)

--- a/tests/test_gateway_authorize_admission.py
+++ b/tests/test_gateway_authorize_admission.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from trusted_router.config import Settings
+from trusted_router.routes.internal import gateway
+from trusted_router.schemas import GatewayAuthorizeRequest
+from trusted_router.services.keyed_admission import KeyedConcurrencyAdmission
+
+
+def _request() -> Request:
+    return Request({"type": "http", "method": "POST", "path": "/", "headers": []})
+
+
+def _body(subject: str) -> GatewayAuthorizeRequest:
+    return GatewayAuthorizeRequest(
+        api_key_lookup_hash=subject,
+        model="anthropic/claude-haiku-4.5",
+        estimated_input_tokens=1,
+        max_output_tokens=1,
+    )
+
+
+def test_keyed_admission_isolates_subjects_and_releases_capacity() -> None:
+    admission = KeyedConcurrencyAdmission(max_subjects=2)
+
+    assert admission.try_acquire("hot", limit=2)
+    assert admission.try_acquire("hot", limit=2)
+    assert not admission.try_acquire("hot", limit=2)
+    assert admission.try_acquire("other", limit=1)
+    assert not admission.try_acquire("third", limit=1)
+
+    admission.release("hot")
+    assert admission.try_acquire("hot", limit=2)
+    admission.release("hot")
+    admission.release("hot")
+    assert admission.count("hot") == 0
+    assert admission.try_acquire("third", limit=1)
+
+
+def test_authorize_rejects_same_key_saturation_without_queueing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    subject = "lookup-admission-regression"
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_authorize(*_args: object) -> dict[str, object]:
+        started.set()
+        assert release.wait(timeout=5)
+        return {"data": {"authorization_id": "gwa-admitted"}}
+
+    monkeypatch.setattr(gateway, "_authorize_gateway_sync", blocking_authorize)
+    settings = Settings(
+        environment="test",
+        gateway_authorize_max_in_flight_per_key=1,
+    )
+
+    async def scenario() -> None:
+        first = asyncio.create_task(gateway.authorize_gateway(_request(), _body(subject), settings))
+        assert await asyncio.to_thread(started.wait, 5)
+
+        with pytest.raises(HTTPException) as raised:
+            await gateway.authorize_gateway(_request(), _body(subject), settings)
+        assert raised.value.status_code == 429
+        assert raised.value.headers == {"Retry-After": "1"}
+        assert raised.value.detail["error"]["type"] == "rate_limited"
+
+        # Another key retains capacity while the hot key is blocked.
+        other = asyncio.create_task(
+            gateway.authorize_gateway(_request(), _body(f"{subject}-other"), settings)
+        )
+        release.set()
+        assert (await first)["data"]["authorization_id"] == "gwa-admitted"
+        assert (await other)["data"]["authorization_id"] == "gwa-admitted"
+
+        # The finally block returns capacity after completion.
+        assert gateway._AUTHORIZE_ADMISSION.count(subject) == 0
+        again = await gateway.authorize_gateway(_request(), _body(subject), settings)
+        assert again["data"]["authorization_id"] == "gwa-admitted"
+
+    asyncio.run(scenario())
+
+
+def test_gateway_authorize_admission_limit_must_be_positive() -> None:
+    with pytest.raises(
+        ValueError,
+        match="TR_GATEWAY_AUTHORIZE_MAX_IN_FLIGHT_PER_KEY must be positive",
+    ):
+        Settings(environment="test", gateway_authorize_max_in_flight_per_key=0)


### PR DESCRIPTION
## Summary
- cap simultaneous gateway authorization transactions per API key per service instance
- reject saturation immediately with non-retried 429 and Retry-After
- preserve capacity for unrelated keys with bounded, ephemeral admission state

## Incident
A newly created signup key generated a modest request burst after exhausting credits. The current Spanner idempotency index groups all of one key's requests into an adjacent range, amplifying roughly 1,400 HTTP authorizations into tens of thousands of transaction aborts/retries and temporary authorize 503s. This patch contains that amplification while the hash-first index migration is staged separately.

## Verification
- `uv run ruff check ...`
- `uv run mypy`
- 39 focused gateway/billing tests passed