### PR TITLE
Catalog v2: optional receipts capability, snapshot drift reconciled

### DIFF
--- a/scripts/export_provider_check_contract.py
+++ b/scripts/export_provider_check_contract.py
@@ -153,6 +153,12 @@ def _catalog_contract(catalog: ModuleType) -> dict[str, Any]:
                 "overload_status": 503,
                 "retry_after_header": "Retry-After",
             },
+            "receipts": {
+                "required": False,
+                "specs": sorted(catalog._RECEIPT_SPECS),
+                "algorithms": sorted(catalog._RECEIPT_ALGORITHMS),
+                "delivery": sorted(catalog._RECEIPT_DELIVERY),
+            },
             "pricing": {
                 "currency": "USD",
                 "unit": "per_1m_tokens",

--- a/scripts/pricing/provider_contract_catalog.py
+++ b/scripts/pricing/provider_contract_catalog.py
@@ -35,6 +35,11 @@ _MODEL_V2_FIELDS = _MODEL_FIELDS | {"reliability"}
 _CAPABILITY_FIELDS = frozenset(
     {"streaming", "tools", "structured_output", "reasoning", "prompt_caching"}
 )
+_CAPABILITY_V2_OPTIONAL_FIELDS = frozenset({"receipts"})
+_RECEIPT_FIELDS = frozenset({"spec", "algorithms", "delivery"})
+_RECEIPT_SPECS = frozenset({"inference-receipt/1"})
+_RECEIPT_ALGORITHMS = frozenset({"EdDSA"})
+_RECEIPT_DELIVERY = frozenset({"header", "stream-chunk"})
 _PRICING_FIELDS = frozenset(
     {
         "currency",
@@ -89,12 +94,13 @@ def _require_exact_fields(
     expected: frozenset[str],
     *,
     label: str,
+    optional: frozenset[str] = frozenset(),
 ) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise RuntimeError(f"{label} must be an object")
     keys = frozenset(str(key) for key in value)
     missing = sorted(expected - keys)
-    extra = sorted(keys - expected)
+    extra = sorted(keys - expected - optional)
     if missing or extra:
         raise RuntimeError(f"{label} fields invalid: missing={missing}, extra={extra}")
     return value
@@ -296,12 +302,40 @@ def discover_provider_contract_catalog(
         )
 
         capabilities = _require_exact_fields(
-            row["capabilities"], _CAPABILITY_FIELDS, label=f"{label}.capabilities"
+            row["capabilities"],
+            _CAPABILITY_FIELDS,
+            label=f"{label}.capabilities",
+            optional=_CAPABILITY_V2_OPTIONAL_FIELDS if is_v2 else frozenset(),
         )
         parsed_capabilities = {
-            key: _require_bool(value, label=f"{label}.capabilities.{key}")
-            for key, value in capabilities.items()
+            key: _require_bool(
+                capabilities[key], label=f"{label}.capabilities.{key}"
+            )
+            for key in _CAPABILITY_FIELDS
         }
+        if "receipts" in capabilities:
+            receipts = _require_exact_fields(
+                capabilities["receipts"],
+                _RECEIPT_FIELDS,
+                label=f"{label}.capabilities.receipts",
+            )
+            receipt_spec = _require_string(
+                receipts["spec"], label=f"{label}.capabilities.receipts.spec"
+            )
+            if receipt_spec not in _RECEIPT_SPECS:
+                raise RuntimeError(
+                    f"{label}.capabilities.receipts.spec is unsupported"
+                )
+            _require_string_set(
+                receipts["algorithms"],
+                allowed=_RECEIPT_ALGORITHMS,
+                label=f"{label}.capabilities.receipts.algorithms",
+            )
+            _require_string_set(
+                receipts["delivery"],
+                allowed=_RECEIPT_DELIVERY,
+                label=f"{label}.capabilities.receipts.delivery",
+            )
         pricing = _require_exact_fields(
             row["pricing"], _PRICING_FIELDS, label=f"{label}.pricing"
         )

--- a/src/trusted_router/data/provider_check_contract.json
+++ b/src/trusted_router/data/provider_check_contract.json
@@ -70,6 +70,9 @@
         "structured_output",
         "tools"
       ],
+      "_CAPABILITY_V2_OPTIONAL_FIELDS": [
+        "receipts"
+      ],
       "_CAPACITY_SCOPES": [
         "global",
         "model",
@@ -158,6 +161,21 @@
         "status_url",
         "support_contact"
       ],
+      "_RECEIPT_ALGORITHMS": [
+        "EdDSA"
+      ],
+      "_RECEIPT_DELIVERY": [
+        "header",
+        "stream-chunk"
+      ],
+      "_RECEIPT_FIELDS": [
+        "algorithms",
+        "delivery",
+        "spec"
+      ],
+      "_RECEIPT_SPECS": [
+        "inference-receipt/1"
+      ],
       "_RELIABILITY_FIELDS": [
         "capacity_scope",
         "completion_timeout_seconds",
@@ -190,12 +208,25 @@
         "minimum_request": 0,
         "prompt_caching_matches_cached_input_presence": true,
         "unit": "per_1m_tokens"
+      },
+      "receipts": {
+        "algorithms": [
+          "EdDSA"
+        ],
+        "delivery": [
+          "header",
+          "stream-chunk"
+        ],
+        "required": false,
+        "specs": [
+          "inference-receipt/1"
+        ]
       }
     },
     "model_id_pattern": "^[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._/-]*$",
     "owner_pattern": "^[a-z0-9][a-z0-9._-]*$"
   },
-  "contract_version": "9b6b5aba71fb7ffc62bb0de07dd9055c343f781358c69daf54af32de620e0026",
+  "contract_version": "daf822353b83ddbf6a23eaa2deb449d42bc441a53d345c94278040be989a4371",
   "decision_tables": [
     {
       "max_tokens": 512,

--- a/src/trusted_router/provider_contract.py
+++ b/src/trusted_router/provider_contract.py
@@ -219,6 +219,13 @@ _V1_EXAMPLE_DATA = PROVIDER_CATALOG_EXAMPLE["data"]
 assert isinstance(_V1_EXAMPLE_DATA, list)
 _V2_MODEL_EXAMPLE = copy.deepcopy(_V1_EXAMPLE_DATA[0])
 assert isinstance(_V2_MODEL_EXAMPLE, dict)
+_V2_CAPABILITIES_EXAMPLE = _V2_MODEL_EXAMPLE["capabilities"]
+assert isinstance(_V2_CAPABILITIES_EXAMPLE, dict)
+_V2_CAPABILITIES_EXAMPLE["receipts"] = {
+    "spec": "inference-receipt/1",
+    "algorithms": ["EdDSA"],
+    "delivery": ["header", "stream-chunk"],
+}
 _V2_MODEL_EXAMPLE["reliability"] = {
     "first_token_timeout_seconds": 20,
     "completion_timeout_seconds": 120,
@@ -322,6 +329,30 @@ assert isinstance(model_required, list)
 model_required.append("reliability")
 model_properties = model_schema["properties"]
 assert isinstance(model_properties, dict)
+capabilities_schema = model_properties["capabilities"]
+assert isinstance(capabilities_schema, dict)
+capabilities_properties = capabilities_schema["properties"]
+assert isinstance(capabilities_properties, dict)
+capabilities_properties["receipts"] = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["spec", "algorithms", "delivery"],
+    "properties": {
+        "spec": {"const": "inference-receipt/1"},
+        "algorithms": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": True,
+            "items": {"enum": ["EdDSA"]},
+        },
+        "delivery": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": True,
+            "items": {"enum": ["header", "stream-chunk"]},
+        },
+    },
+}
 model_properties["reliability"] = {
     "type": "object",
     "additionalProperties": False,

--- a/tests/test_provider_catalog_receipts.py
+++ b/tests/test_provider_catalog_receipts.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+from scripts.pricing.provider_contract_catalog import (
+    discover_provider_contract_catalog,
+)
+from trusted_router.provider_contract import (
+    PROVIDER_CATALOG_EXAMPLE,
+    PROVIDER_CATALOG_SCHEMA,
+    PROVIDER_CATALOG_V2_EXAMPLE,
+    PROVIDER_CATALOG_V2_SCHEMA,
+)
+
+
+def _v2_payload() -> dict[str, Any]:
+    return copy.deepcopy(PROVIDER_CATALOG_V2_EXAMPLE)
+
+
+def _validate_with_both_contracts(payload: dict[str, Any]) -> None:
+    Draft202012Validator(PROVIDER_CATALOG_V2_SCHEMA).validate(payload)
+    discover_provider_contract_catalog(payload, upstream_id_map={})
+
+
+def test_v2_receipts_capability_is_valid() -> None:
+    payload = _v2_payload()
+
+    _validate_with_both_contracts(payload)
+
+    assert payload["data"][0]["capabilities"]["receipts"] == {
+        "spec": "inference-receipt/1",
+        "algorithms": ["EdDSA"],
+        "delivery": ["header", "stream-chunk"],
+    }
+
+
+def test_v2_receipts_capability_rejects_unknown_keys() -> None:
+    payload = _v2_payload()
+    payload["data"][0]["capabilities"]["receipts"]["unexpected"] = True
+
+    with pytest.raises(ValidationError):
+        Draft202012Validator(PROVIDER_CATALOG_V2_SCHEMA).validate(payload)
+    with pytest.raises(RuntimeError, match="receipts fields invalid"):
+        discover_provider_contract_catalog(payload, upstream_id_map={})
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("spec", "inference-receipt/2"),
+        ("algorithms", ["ES256"]),
+        ("delivery", ["body"]),
+    ],
+)
+def test_v2_receipts_capability_rejects_unknown_vocabulary(
+    field: str,
+    value: object,
+) -> None:
+    payload = _v2_payload()
+    payload["data"][0]["capabilities"]["receipts"][field] = value
+
+    with pytest.raises(ValidationError):
+        Draft202012Validator(PROVIDER_CATALOG_V2_SCHEMA).validate(payload)
+    with pytest.raises(RuntimeError, match="unsupported"):
+        discover_provider_contract_catalog(payload, upstream_id_map={})
+
+
+def test_v2_receipts_capability_is_optional_and_v1_remains_frozen() -> None:
+    payload = _v2_payload()
+    del payload["data"][0]["capabilities"]["receipts"]
+
+    _validate_with_both_contracts(payload)
+
+    v2_capabilities = PROVIDER_CATALOG_V2_SCHEMA["$defs"]["model"]["properties"][
+        "capabilities"
+    ]
+    v1_capabilities = PROVIDER_CATALOG_SCHEMA["$defs"]["model"]["properties"][
+        "capabilities"
+    ]
+    assert "receipts" not in v2_capabilities["required"]
+    assert "receipts" not in v1_capabilities["properties"]
+    assert "receipts" not in PROVIDER_CATALOG_EXAMPLE["data"][0]["capabilities"]
+
+
+def test_v1_continues_to_reject_receipts() -> None:
+    payload = copy.deepcopy(PROVIDER_CATALOG_EXAMPLE)
+    payload["data"][0]["capabilities"]["receipts"] = {
+        "spec": "inference-receipt/1",
+        "algorithms": ["EdDSA"],
+        "delivery": ["header", "stream-chunk"],
+    }
+
+    with pytest.raises(ValidationError):
+        Draft202012Validator(PROVIDER_CATALOG_SCHEMA).validate(payload)
+    with pytest.raises(RuntimeError, match="capabilities fields invalid"):
+        discover_provider_contract_catalog(payload, upstream_id_map={})

--- a/tests/test_provider_check_contract_parity.py
+++ b/tests/test_provider_check_contract_parity.py
@@ -84,6 +84,12 @@ def test_contract_guards_are_nonempty_and_deterministic() -> None:
         assert len(set(first["source_hashes"].values())) == len(first["source_hashes"])
         assert first["leaderboard"]["models"]
         assert first["leaderboard"]["providers"]
+        assert first["catalog_contract"]["invariants"]["receipts"] == {
+            "required": False,
+            "specs": ["inference-receipt/1"],
+            "algorithms": ["EdDSA"],
+            "delivery": ["header", "stream-chunk"],
+        }
         assert "trusted_router.catalog" not in sys.modules
     finally:
         if previous_catalog is not None:


### PR DESCRIPTION
Optional `receipts` capability in catalog v2 (closed vocab, v1 frozen-untouched) + the 9b6b/973e snapshot-drift diagnosis and fix (973e was a stale export retaining availability-first ordering and the older deadline pin). Deterministic re-export verified twice; trustedrouter-provider-check syncs to this snapshot in its own PR next. 602 contract/snapshot/catalog tests green; ruff+mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)