### PR TITLE
Fix multicloud deploy resource drift

### DIFF
--- a/scripts/deploy/_aws_waf.sh
+++ b/scripts/deploy/_aws_waf.sh
@@ -55,6 +55,7 @@ _aws_waf_rules_json() {
   TR_AWS_WAF_EVALUATION_WINDOW_SECONDS="$window" \
   TR_AWS_WAF_ALLOWED_HOSTS="$allowed_hosts" \
     python3 - <<'PY'
+import base64
 import json
 import os
 
@@ -74,7 +75,9 @@ def visibility(metric: str) -> dict[str, object]:
 def byte_match(field: dict[str, object], value: str) -> dict[str, object]:
     return {
         "ByteMatchStatement": {
-            "SearchString": value,
+            # AWS CLI JSON represents blob values as base64. Passing the raw
+            # string works with shorthand syntax but fails for --rules JSON.
+            "SearchString": base64.b64encode(value.encode("utf-8")).decode("ascii"),
             "FieldToMatch": field,
             "TextTransformations": [{"Priority": 0, "Type": "LOWERCASE"}],
             "PositionalConstraint": "EXACTLY",

--- a/scripts/deploy/azure_control_plane.sh
+++ b/scripts/deploy/azure_control_plane.sh
@@ -122,10 +122,10 @@ SECRETS_DIR="${SECRETS_DIR:-$HOME/.quill-secrets}"
 # reads the password through a Container Apps Key Vault reference backed by the
 # node's existing user-assigned identity. The password value never enters this
 # process, argv, cloud-init, or an operator-visible log.
-CLICKHOUSE_NODE="${CLICKHOUSE_NODE:-tr-azure-clickhouse-$LOCATION}"
-CLICKHOUSE_VAULT="${CLICKHOUSE_VAULT:-tr-azure-analytics-kv}"
-CLICKHOUSE_SECRET_NAME="${CLICKHOUSE_SECRET_NAME:-clickhouse-default-password}"
-CLICKHOUSE_IDENTITY="${CLICKHOUSE_IDENTITY:-tr-azure-analytics-$LOCATION-id}"
+CLICKHOUSE_NODE="${CLICKHOUSE_NODE:-tr-azure-clickhouse-1}"
+CLICKHOUSE_VAULT="${CLICKHOUSE_VAULT:-trquillkv}"
+CLICKHOUSE_SECRET_NAME="${CLICKHOUSE_SECRET_NAME:-tr-azure-clickhouse-password}"
+CLICKHOUSE_IDENTITY="${CLICKHOUSE_IDENTITY:-tr-azure-clickhouse-identity}"
 CLICKHOUSE_USER="${CLICKHOUSE_USER:-default}"
 CLICKHOUSE_DATABASE="${CLICKHOUSE_DATABASE:-default}"
 

--- a/tests/deploy_script_harness.py
+++ b/tests/deploy_script_harness.py
@@ -1468,19 +1468,19 @@ SCRIPT_FIXTURES: dict[str, ScriptFixture] = {
         },
         responses=(
             (
-                r"vm list-ip-addresses.*tr-azure-clickhouse-uaenorth",
+                r"vm list-ip-addresses.*tr-azure-clickhouse-1",
                 "10.61.3.4",
             ),
             (
-                r"keyvault secret show.*clickhouse-default-password.*--query id",
-                "https://tr-azure-analytics-kv.vault.azure.net/secrets/"
-                "clickhouse-default-password/harness-version",
+                r"keyvault secret show.*tr-azure-clickhouse-password.*--query id",
+                "https://trquillkv.vault.azure.net/secrets/"
+                "tr-azure-clickhouse-password/harness-version",
             ),
             (
-                r"identity show.*tr-azure-analytics-uaenorth-id.*--query id",
+                r"identity show.*tr-azure-clickhouse-identity.*--query id",
                 "/subscriptions/harness/resourceGroups/tr-azure/providers/"
                 "Microsoft.ManagedIdentity/userAssignedIdentities/"
-                "tr-azure-analytics-uaenorth-id",
+                "tr-azure-clickhouse-identity",
             ),
             (r"acr build|acr import", "harness"),
             (r"--query .?loginServer", "trazureuaenorthacr.azurecr.io"),

--- a/tests/test_ddos_edge_deploy.py
+++ b/tests/test_ddos_edge_deploy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import json
 import os
 import subprocess
@@ -249,9 +250,26 @@ _aws_waf_rules_json tr-eu.example.awsapprunner.com
         "AggregateKeyType": "IP",
     }
     assert preview_rules["AllowedHosts"]["Action"] == {"Count": {}}
-    allowed_host_json = json.dumps(preview_rules["AllowedHosts"])
-    assert "aws.trustedrouter.com" in allowed_host_json
-    assert "aws.trustedrouter.com:443" in allowed_host_json
+    search_strings: list[str] = []
+
+    def collect_search_strings(value: object) -> None:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                if key == "SearchString":
+                    assert isinstance(child, str)
+                    search_strings.append(child)
+                else:
+                    collect_search_strings(child)
+        elif isinstance(value, list):
+            for child in value:
+                collect_search_strings(child)
+
+    collect_search_strings(preview_rules["AllowedHosts"])
+    decoded_search_strings = {
+        base64.b64decode(value, validate=True).decode("utf-8") for value in search_strings
+    }
+    assert "aws.trustedrouter.com" in decoded_search_strings
+    assert "aws.trustedrouter.com:443" in decoded_search_strings
     assert preview_rules["StateChangingRate"]["Action"] == {"Count": {}}
     assert preview_rules["AwsManagedCommon"]["OverrideAction"] == {"Count": {}}
 

--- a/tests/test_deploy_script_execution.py
+++ b/tests/test_deploy_script_execution.py
@@ -1293,19 +1293,19 @@ def test_azure_observer_refuses_to_drop_its_only_synthetic_owner(
 def _azure_without_analytics_discovery(fixture: ScriptFixture) -> ScriptFixture:
     discovery_fragments = (
         "vm list-ip-addresses",
-        "keyvault secret show.*clickhouse-default-password",
-        "identity show.*tr-azure-analytics-uaenorth-id",
+        "keyvault secret show.*tr-azure-clickhouse-password",
+        "identity show.*tr-azure-clickhouse-identity",
     )
     return replace(
         fixture,
         responses=(
-            (r"vm list-ip-addresses.*tr-azure-clickhouse-uaenorth", ""),
+            (r"vm list-ip-addresses.*tr-azure-clickhouse-1", ""),
             (
-                r"keyvault secret show.*clickhouse-default-password.*--query id",
+                r"keyvault secret show.*tr-azure-clickhouse-password.*--query id",
                 "",
             ),
             (
-                r"identity show.*tr-azure-analytics-uaenorth-id.*--query id",
+                r"identity show.*tr-azure-clickhouse-identity.*--query id",
                 "",
             ),
             *(
@@ -1373,10 +1373,10 @@ def test_azure_observer_emits_the_discovered_operational_analytics_env(
         argument for argument in secret_set if argument.startswith("clickhouse-password=")
     )
     assert clickhouse_reference == (
-        "clickhouse-password=keyvaultref:https://tr-azure-analytics-kv.vault.azure.net/"
-        "secrets/clickhouse-default-password/harness-version,identityref:/subscriptions/"
+        "clickhouse-password=keyvaultref:https://trquillkv.vault.azure.net/"
+        "secrets/tr-azure-clickhouse-password/harness-version,identityref:/subscriptions/"
         "harness/resourceGroups/tr-azure/providers/Microsoft.ManagedIdentity/"
-        "userAssignedIdentities/tr-azure-analytics-uaenorth-id"
+        "userAssignedIdentities/tr-azure-clickhouse-identity"
     )
 
 
@@ -1397,10 +1397,10 @@ def test_azure_observer_refuses_missing_analytics_discovery_before_any_mutation(
 
     assert run.returncode != 0
     assert "expects_outbox=True" in run.stderr
-    assert "tr-azure-clickhouse-uaenorth" in run.stderr
-    assert "tr-azure-analytics-kv" in run.stderr
-    assert "az vm list-ip-addresses -g tr-azure -n tr-azure-clickhouse-uaenorth" in run.stderr
-    assert "az keyvault secret show --vault-name tr-azure-analytics-kv" in run.stderr
+    assert "tr-azure-clickhouse-1" in run.stderr
+    assert "trquillkv" in run.stderr
+    assert "az vm list-ip-addresses -g tr-azure -n tr-azure-clickhouse-1" in run.stderr
+    assert "az keyvault secret show --vault-name trquillkv" in run.stderr
     mutating_prefixes = (
         ["az", "acr", "build"],
         ["az", "acr", "import"],


### PR DESCRIPTION
Summary:
- encode AWS WAFv2 byte-match blobs correctly in JSON deploy payloads
- align Azure control-plane analytics defaults with resources provisioned by the Azure ClickHouse script
- add regression coverage for both production failures

Verification:
- 131 focused deploy tests passed
- Ruff passed
- Bash syntax and diff checks passed