### PR TITLE
Make the one-query outbox fetch actually execute

### DIFF
--- a/clickhouse/ingest_operational_outbox.py
+++ b/clickhouse/ingest_operational_outbox.py
@@ -7,7 +7,6 @@ import datetime as dt
 import hashlib
 import json
 import logging
-import math
 import os
 import subprocess
 import time
@@ -249,37 +248,7 @@ class DrainResult:
 
 
 class OutboxSource(Protocol):
-    def fetch(self, *, limit: int) -> list[OperationalOutboxRow]:
-        # ONE unordered global read, not 32 ordered per-shard reads. Spanner
-        # stores rows in primary-key order, so results arrive
-        # (shard, commit_ts)-ordered per split anyway; delivery order does not
-        # matter (delete is by key, ClickHouse dedups by event) and this same
-        # statement doubles as the emptiness probe. The per-shard ORDER BY
-        # fan-out this replaces ran 64 statements every ~1.5s around the
-        # clock -- measured at ~25% of the whole 300-PU instance on
-        # 2026-08-25 -- to mostly discover an empty table. This path is
-        # interim: the direct sink (trusted_router.operational_analytics_direct)
-        # removes the outbox entirely; this drainer then only clears residue.
-        rows: list[OperationalOutboxRow] = []
-        with self._database.snapshot() as snapshot:
-            results = snapshot.execute_sql(
-                # OUTBOX_TABLE is a module constant, not caller input.
-                "SELECT shard, commit_ts, event_kind, event_id, payload "  # noqa: S608
-                f"FROM {OUTBOX_TABLE} LIMIT @limit",
-                params={"limit": limit},
-                param_types={"limit": self._pt.INT64},
-            )
-            for row in results:
-                rows.append(
-                    OperationalOutboxRow(
-                        shard=int(row[0]),
-                        commit_ts=row[1],
-                        event_kind=str(row[2]),
-                        event_id=str(row[3]),
-                        payload=str(row[4]),
-                    )
-                )
-        return rows
+    def fetch(self, *, limit: int) -> list[OperationalOutboxRow]: ...
 
     def delete(self, rows: list[OperationalOutboxRow]) -> None: ...
 
@@ -319,37 +288,32 @@ class SpannerOperationalOutboxSource:
     def fetch(self, *, limit: int) -> list[OperationalOutboxRow]:
         if limit < 1:
             return []
-        per_shard = max(1, math.ceil(limit / self._shard_count) * 2)
+        # Delivery order is not load-bearing: ClickHouse replacement uses the
+        # stable outbox commit timestamp as its version, and delete addresses
+        # only the exact fetched primary keys after every insert succeeds.
+        # Quarantine rows are append-only diagnostics and can repeat after a
+        # partial insert retry, but they have no ordering semantics.
+        # One global LIMIT therefore replaces the ordered query per shard.
         rows: list[OperationalOutboxRow] = []
-        with self._database.snapshot(multi_use=True) as snapshot:
-            for shard in range(self._shard_count):
-                values = snapshot.execute_sql(
-                    "SELECT shard, commit_ts, event_kind, event_id, payload "
-                    "FROM tr_operational_analytics_outbox "
-                    "WHERE shard=@shard ORDER BY commit_ts, event_kind, event_id "
-                    "LIMIT @limit",
-                    params={"shard": shard, "limit": per_shard},
-                    param_types={"shard": self._pt.INT64, "limit": self._pt.INT64},
-                )
-                rows.extend(
-                    OperationalOutboxRow(
-                        shard=int(row[0]),
-                        commit_ts=_utc(row[1]),
-                        event_kind=str(row[2]),
-                        event_id=str(row[3]),
-                        payload=str(row[4]),
-                    )
-                    for row in values
-                )
-        rows.sort(
-            key=lambda row: (
-                row.commit_ts,
-                row.shard,
-                row.event_kind,
-                row.event_id,
+        with self._database.snapshot() as snapshot:
+            values = snapshot.execute_sql(
+                # OUTBOX_TABLE is a module constant, not caller input.
+                "SELECT shard, commit_ts, event_kind, event_id, payload "  # noqa: S608
+                f"FROM {OUTBOX_TABLE} LIMIT @limit",
+                params={"limit": limit},
+                param_types={"limit": self._pt.INT64},
             )
-        )
-        return rows[:limit]
+            rows.extend(
+                OperationalOutboxRow(
+                    shard=int(row[0]),
+                    commit_ts=_utc(row[1]),
+                    event_kind=str(row[2]),
+                    event_id=str(row[3]),
+                    payload=str(row[4]),
+                )
+                for row in values
+            )
+        return rows
 
     def delete(self, rows: list[OperationalOutboxRow]) -> None:
         if not rows:

--- a/tests/test_operational_analytics.py
+++ b/tests/test_operational_analytics.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import ast
 import dataclasses
 import datetime as dt
+import inspect
 import json
 import re
+import textwrap
 import threading
 from typing import Any
 
@@ -13,6 +16,8 @@ import pytest
 from clickhouse.ingest_operational_outbox import (
     CanonicalOperationalEvent,
     OperationalOutboxRow,
+    OutboxSource,
+    SpannerOperationalOutboxSource,
     drain_once,
     expand_client_events_payload,
     normalise_operational_event,
@@ -505,6 +510,93 @@ class _Writer:
         if self.failures:
             self.failures -= 1
             raise RuntimeError("ClickHouse unavailable")
+
+
+def test_outbox_source_protocol_is_behavior_free() -> None:
+    """Protocols define the drain contract; implementations own all behavior."""
+    tree = ast.parse(textwrap.dedent(inspect.getsource(OutboxSource)))
+    methods = [node for node in tree.body[0].body if isinstance(node, ast.FunctionDef)]
+
+    assert methods
+    for method in methods:
+        assert len(method.body) == 1, f"OutboxSource.{method.name} carries behavior"
+        [statement] = method.body
+        assert (
+            isinstance(statement, ast.Expr)
+            and isinstance(statement.value, ast.Constant)
+            and statement.value.value is Ellipsis
+        ), f"OutboxSource.{method.name} carries behavior"
+
+
+class _QueryCountingSnapshot:
+    def __init__(self, database: _QueryCountingDatabase) -> None:
+        self.database = database
+
+    def __enter__(self) -> _QueryCountingSnapshot:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        pass
+
+    def execute_sql(
+        self,
+        sql: str,
+        *,
+        params: dict[str, Any],
+        param_types: dict[str, Any],
+    ) -> list[tuple[object, ...]]:
+        self.database.select_statements.append(sql)
+        self.database.select_params.append((params, param_types))
+        if len(self.database.select_statements) > 1:
+            return []
+        row = _outbox_row()
+        return [(row.shard, row.commit_ts, row.event_kind, row.event_id, row.payload)]
+
+
+class _QueryCountingBatch:
+    def __init__(self, database: _QueryCountingDatabase) -> None:
+        self.database = database
+
+    def __enter__(self) -> _QueryCountingBatch:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        pass
+
+    def delete(self, table: str, key_set: object) -> None:
+        self.database.delete_calls.append((table, key_set))
+
+
+class _QueryCountingDatabase:
+    def __init__(self) -> None:
+        self.select_statements: list[str] = []
+        self.select_params: list[tuple[dict[str, Any], dict[str, Any]]] = []
+        self.delete_calls: list[tuple[str, object]] = []
+
+    def snapshot(self, **_kwargs: object) -> _QueryCountingSnapshot:
+        return _QueryCountingSnapshot(self)
+
+    def batch(self) -> _QueryCountingBatch:
+        return _QueryCountingBatch(self)
+
+
+def test_spanner_drain_loop_uses_one_global_fetch_query_plus_ack() -> None:
+    database = _QueryCountingDatabase()
+    source = object.__new__(SpannerOperationalOutboxSource)
+    source._database = database
+    source._pt = _ParamTypes()
+    source._shard_count = 32
+
+    result = drain_once(source, _Writer(), batch_size=100)
+
+    assert result.fetched == 1
+    assert len(database.select_statements) == 1
+    assert "WHERE shard" not in database.select_statements[0]
+    assert "ORDER BY" not in database.select_statements[0]
+    assert database.select_params == [
+        ({"limit": 100}, {"limit": _ParamTypes.INT64})
+    ]
+    assert len(database.delete_calls) == 1
 
 
 def test_operational_cursor_advances_only_after_clickhouse_ack() -> None:


### PR DESCRIPTION
The #840 drain optimization was dead code — implemented on `OutboxSource(Protocol)` while the instantiated Spanner source kept running 32 ordered per-shard queries per loop. With #855 pinning prod to the outbox sink, that ~25%-of-instance cost became indefinite, on the same Spanner instance as the billing path the enclave blocks on (authorize p50 ~1s).

The fetch now lives on the instantiated source (one unordered global query; safety argument cited at the query site — delivery is idempotent, rows delete only after confirmed insert). The Protocol is behavior-free again with a guard test that fails if it ever grows a concrete method an implementation doesn't override — the exact defect class that made #840 a no-op. Per-loop query count is pinned by test.

Sol authored; Fable reviewed: 35 tests green, ruff/mypy clean, both guards mutation-tested. **After merge the VM ingester needs redeploying** (`clickhouse_operational_analytics.sh` ships committed HEAD to /opt/tr-clickhouse — Cloud Run rollout does not touch it).