### PR TITLE
Authorize: 14 sequential Spanner RPCs down to 10

### DIFF
--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -15,7 +15,10 @@ import functools
 import hashlib
 import json
 import logging
+import threading
+import time
 import uuid
+from collections import OrderedDict
 from datetime import datetime
 from functools import lru_cache
 from time import perf_counter
@@ -164,6 +167,10 @@ REQUEST_METADATA_VERSION = 1
 # process to serialize a structured retryable 503 and for network transit.
 _BILLING_PATH_SPANNER_BUDGET_SECONDS = 20.0
 _AUTHORIZE_ADMISSION = KeyedConcurrencyAdmission()
+_BROADCAST_EMPTY_CACHE_TTL_SECONDS = 60.0
+_BROADCAST_EMPTY_CACHE_MAX_ENTRIES = 1_024
+_BROADCAST_EMPTY_CACHE: OrderedDict[str, float] = OrderedDict()
+_BROADCAST_EMPTY_CACHE_LOCK = threading.Lock()
 _NATIVE_BATCH_ROUTE_PREFIX = "batch.native."
 _NATIVE_BATCH_BILLED_FRACTION_BPS = {
     "openai": 5_000,
@@ -533,7 +540,7 @@ def _authorize_gateway_sync(
     reservation_usage_type = UsageType.CREDITS if has_credit_candidate else UsageType.BYOK
     broadcast_destinations = [
         payload
-        for destination in STORE.list_broadcast_destinations(workspace.id)
+        for destination in _broadcast_destinations_for_authorize(workspace.id)
         if (payload := gateway_destination_payload(destination)) is not None
     ]
     native_batch_eligible = _native_batch_eligibility(
@@ -600,26 +607,23 @@ def _authorize_gateway_sync(
             custom_model=custom_model,
         )
 
-    existing_authorization = STORE.get_gateway_authorization_by_idempotency_key(
-        workspace.id, api_key.hash, request_idempotency_key
-    )
-    if existing_authorization is None:
-        # Typed authorizations have no JSON idempotency index; whenever the
-        # active store has typed billing, retries must replay from the typed
-        # table because the legacy cohort brake no longer exists after C1.
-        _typed_store = typed_billing_store(STORE)
-        if _typed_store is not None:
-            existing_authorization = _typed_store.get_typed_authorization_by_idempotency(
-                workspace.id, api_key.hash, request_idempotency_key
-            )
-    if existing_authorization is not None:
-        if existing_authorization.idempotency_fingerprint != request_fingerprint:
-            raise api_error(
-                409,
-                "Idempotency key was already used for a different gateway request",
-                ErrorType.CONFLICT,
-            )
-        return _replay_response(existing_authorization)
+    _typed_store = typed_billing_store(STORE)
+    if _typed_store is None:
+        # Non-typed stores still use their legacy authorization index. Typed
+        # Spanner never writes that entity index on the production route after
+        # C1; its reservation transaction below owns idempotency and money
+        # atomically, so probing either index here only adds happy-path RPCs.
+        existing_authorization = STORE.get_gateway_authorization_by_idempotency_key(
+            workspace.id, api_key.hash, request_idempotency_key
+        )
+        if existing_authorization is not None:
+            if existing_authorization.idempotency_fingerprint != request_fingerprint:
+                raise api_error(
+                    409,
+                    "Idempotency key was already used for a different gateway request",
+                    ErrorType.CONFLICT,
+                )
+            return _replay_response(existing_authorization)
     # Suspension stops NEW authorizations. Resolve replay first so a lost
     # response can be recovered and in-flight work can settle under frozen terms.
     _assert_oauth_app_allows_new_authorization(api_key)
@@ -655,7 +659,6 @@ def _authorize_gateway_sync(
     # C1 removed the workspace cohort/denylist brake: GCP now always uses typed
     # billing when the store exposes that capability. Emergency rollback is the
     # previous deploy revision; the memory store below remains the test twin.
-    _typed_store = typed_billing_store(STORE)
     if _typed_store is not None:
         import datetime as _dt
 
@@ -1429,6 +1432,34 @@ def _authorization_endpoint_candidates(
             continue
         candidates.append((model, endpoint))
     return candidates or fallback
+
+
+def _broadcast_destinations_for_authorize(workspace_id: str) -> list[Any]:
+    """Skip the destination-index RPC briefly after an observed empty result."""
+    now = time.monotonic()
+    with _BROADCAST_EMPTY_CACHE_LOCK:
+        expires_at = _BROADCAST_EMPTY_CACHE.get(workspace_id)
+        if expires_at is not None:
+            if now < expires_at:
+                _BROADCAST_EMPTY_CACHE.move_to_end(workspace_id)
+                return []
+            del _BROADCAST_EMPTY_CACHE[workspace_id]
+
+    destinations = STORE.list_broadcast_destinations(workspace_id)
+    with _BROADCAST_EMPTY_CACHE_LOCK:
+        if destinations:
+            # Positive results are deliberately uncached: destination changes
+            # must take effect on the next authorize. A newly-created first
+            # destination can be hidden only by a previously cached empty result,
+            # delaying response metadata and native-batch eligibility by at most
+            # this cache's 60-second TTL.
+            _BROADCAST_EMPTY_CACHE.pop(workspace_id, None)
+        else:
+            _BROADCAST_EMPTY_CACHE[workspace_id] = now + _BROADCAST_EMPTY_CACHE_TTL_SECONDS
+            _BROADCAST_EMPTY_CACHE.move_to_end(workspace_id)
+            while len(_BROADCAST_EMPTY_CACHE) > _BROADCAST_EMPTY_CACHE_MAX_ENTRIES:
+                _BROADCAST_EMPTY_CACHE.popitem(last=False)
+    return destinations
 
 
 def _gateway_authorize_response(

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -3301,11 +3301,17 @@ class SpannerBigtableStore:
             else None
         )
 
+        built_authorizations: dict[str, GatewayAuthorization] = {}
+
         def build_authorization(
             authorization_id: str,
             reservation_id: str,
         ) -> GatewayAuthorization:
-            return GatewayAuthorization(
+            existing = built_authorizations.get(authorization_id)
+            if existing is not None:
+                assert existing.credit_reservation_id == reservation_id
+                return existing
+            built = GatewayAuthorization(
                 id=authorization_id,
                 workspace_id=workspace_id,
                 key_hash=key_hash,
@@ -3337,6 +3343,8 @@ class SpannerBigtableStore:
                 additional_cost_reservation_microdollars=additional_cost_reservation_microdollars,
                 native_batch_eligible=native_batch_eligible,
             )
+            built_authorizations[authorization_id] = built
+            return built
 
         def build_body(authorization_id: str, reservation_id: str) -> str:
             return _json_body(build_authorization(authorization_id, reservation_id))
@@ -3558,7 +3566,15 @@ class SpannerBigtableStore:
                 raise StoreUnavailable("credit headroom changed concurrently; retry")
         outcome = result["outcome"]
         authorization: GatewayAuthorization | None = None
-        if outcome in (AuthorizeOutcome.ACCEPTED, AuthorizeOutcome.REPLAY):
+        if outcome == AuthorizeOutcome.ACCEPTED:
+            # authorize_atomic stamps one client timestamp onto both the object
+            # and the inserted typed row/payload. No commit-generated response
+            # field exists, so the just-inserted object is byte-for-byte the
+            # response record and a strong post-commit point read adds no truth.
+            authorization = built_authorizations[result["authorization_id"]]
+        elif outcome == AuthorizeOutcome.REPLAY:
+            # A replay must respond from the winner's stored authorization, not
+            # this call's provisional object.
             authorization = self.get_gateway_authorization(result["authorization_id"])
         from trusted_router.storage_gcp_authorize import AuthorizeVerdict
 

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -199,6 +199,8 @@ class FakeSpannerDatabase:
         # cannot masquerade as one logical Store operation.
         self.snapshot_execute_sql_calls = 0
         self.snapshot_sql: list[str] = []
+        self.transaction_execute_sql_calls = 0
+        self.transaction_execute_update_calls = 0
 
     def run_in_transaction(self, fn: Any, *, timeout_secs: float | None = None) -> Any:
         # timeout_secs mirrors google-cloud-spanner's Database.run_in_transaction
@@ -379,6 +381,7 @@ class _FakeTransaction:
         params: dict[str, Any] | None = None,
         param_types: Any = None,
     ) -> list[list[str]]:
+        self.db.transaction_execute_sql_calls += 1
         return _execute_sql(self.db, self, sql, params or {})
 
     def _pinned_read(
@@ -497,6 +500,7 @@ class _FakeTransaction:
         and serialize via abort-retry), evaluates the WHERE predicate, and
         conditionally buffers the SET. Returns the modified-row count.
         """
+        self.db.transaction_execute_update_calls += 1
         if self._did_mutation:
             raise RuntimeError(
                 "DML after a mutation in the same transaction — DML+mutation "

--- a/tests/test_gateway_authorize_spanner_operations.py
+++ b/tests/test_gateway_authorize_spanner_operations.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+from starlette.requests import Request
+
+from tests.fakes.spanner import make_fake_store
+from trusted_router.config import Settings
+from trusted_router.routes.internal import gateway
+from trusted_router.schemas import GatewayAuthorizeRequest
+from trusted_router.storage import CreditAccount, Workspace, configure_store
+from trusted_router.storage_gcp import SpannerBigtableStore
+from trusted_router.storage_gcp_authorize import AuthorizeOutcome
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
+
+
+def _request() -> Request:
+    return Request({"type": "http", "method": "POST", "path": "/", "headers": []})
+
+
+def _seed_typed_gateway_store() -> tuple[SpannerBigtableStore, object, object]:
+    store, database, _ = make_fake_store(request_record_write_mode="typed")
+    workspace = Workspace(id="ws-rpc", name="RPC", owner_user_id="user-rpc")
+    store._write_entity("workspace", workspace.id, workspace)
+    store._write_entity("credit", workspace.id, CreditAccount(workspace_id=workspace.id))
+    database.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(workspace.id, 0)] = {
+        "workspace_id": workspace.id,
+        "shard": 0,
+        "total_credits": 50_000_000,
+        "total_usage": 0,
+        "reserved": 0,
+        "source_updated_at": None,
+        "updated_at": None,
+    }
+    _raw, key = store.api_keys.create(
+        workspace_id=workspace.id,
+        name="rpc-key",
+        creator_user_id=workspace.owner_user_id,
+        limit_microdollars=50_000_000,
+    )
+    configure_store(store)
+    return store, database, key
+
+
+def _body(key_hash: str, *, idempotency_key: str = "rpc-idem") -> GatewayAuthorizeRequest:
+    return GatewayAuthorizeRequest(
+        api_key_hash=key_hash,
+        idempotency_key=idempotency_key,
+        model="anthropic/claude-haiku-4.5",
+        estimated_input_tokens=100,
+        max_output_tokens=100,
+    )
+
+
+def test_typed_authorize_route_does_not_call_legacy_idempotency_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _store, _database, key = _seed_typed_gateway_store()
+
+    def forbidden(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("typed authorize must never probe the legacy entity index")
+
+    monkeypatch.setattr(
+        SpannerBigtableStore,
+        "get_gateway_authorization_by_idempotency_key",
+        forbidden,
+    )
+
+    response = gateway._authorize_gateway_sync(
+        _request(), _body(key.hash), Settings(environment="test")
+    )
+
+    assert response["data"]["authorization_id"]
+    assert response["data"]["idempotent_replay"] is False
+
+
+def test_typed_authorize_route_does_not_call_typed_pretransaction_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _store, _database, key = _seed_typed_gateway_store()
+
+    def forbidden(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("typed fresh authorize must rely on its in-transaction probe")
+
+    monkeypatch.setattr(
+        SpannerBigtableStore,
+        "get_typed_authorization_by_idempotency",
+        forbidden,
+    )
+
+    response = gateway._authorize_gateway_sync(
+        _request(), _body(key.hash), Settings(environment="test")
+    )
+
+    assert response["data"]["authorization_id"]
+    assert response["data"]["idempotent_replay"] is False
+
+
+def test_typed_authorize_replay_and_mismatch_still_come_from_transaction() -> None:
+    _store, _database, key = _seed_typed_gateway_store()
+    settings = Settings(environment="test")
+    first = gateway._authorize_gateway_sync(_request(), _body(key.hash), settings)
+
+    replay = gateway._authorize_gateway_sync(_request(), _body(key.hash), settings)
+
+    assert replay["data"]["authorization_id"] == first["data"]["authorization_id"]
+    assert replay["data"]["credit_reservation_id"] == first["data"]["credit_reservation_id"]
+    assert replay["data"]["idempotent_replay"] is True
+
+    changed = _body(key.hash)
+    changed.max_output_tokens += 1
+    with pytest.raises(Exception) as raised:
+        gateway._authorize_gateway_sync(_request(), changed, settings)
+    assert getattr(raised.value, "status_code", None) == 409
+
+
+def test_typed_accepted_authorization_is_returned_without_post_commit_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, _database, key = _seed_typed_gateway_store()
+
+    def forbidden(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("accepted authorize already has the exact inserted record")
+
+    monkeypatch.setattr(SpannerBigtableStore, "get_gateway_authorization", forbidden)
+    outcome, authorization = store.authorize_gateway_typed(
+        workspace_id=key.workspace_id,
+        key_hash=key.hash,
+        estimate=1_000_000,
+        has_credit_candidate=True,
+        reservation_usage_type="Credits",
+        model_id="m",
+        provider="anthropic",
+        requested_model_id="m",
+        candidate_model_ids=["m"],
+        region="us",
+        endpoint_id="e",
+        candidate_endpoint_ids=["e"],
+        idempotency_key="direct-idem",
+        idempotency_fingerprint="direct-fingerprint",
+    )
+
+    assert outcome == AuthorizeOutcome.ACCEPTED
+    assert authorization is not None
+
+
+def test_typed_accepted_authorization_matches_persisted_record() -> None:
+    store, _database, key = _seed_typed_gateway_store()
+    outcome, authorization = store.authorize_gateway_typed(
+        workspace_id=key.workspace_id,
+        key_hash=key.hash,
+        estimate=1_000_000,
+        has_credit_candidate=True,
+        reservation_usage_type="Credits",
+        model_id="m",
+        provider="anthropic",
+        requested_model_id="m",
+        candidate_model_ids=["m"],
+        region="us",
+        endpoint_id="e",
+        candidate_endpoint_ids=["e"],
+        idempotency_key="direct-equivalence",
+        idempotency_fingerprint="direct-equivalence-fingerprint",
+    )
+    assert outcome == AuthorizeOutcome.ACCEPTED
+    assert authorization is not None
+
+    persisted = store.get_gateway_authorization(authorization.id)
+
+    assert persisted is not None
+    assert dataclasses.asdict(authorization) == dataclasses.asdict(persisted)
+
+
+def test_fresh_typed_gateway_authorize_has_exact_sequential_spanner_operation_count() -> None:
+    _store, database, key = _seed_typed_gateway_store()
+    gateway._BROADCAST_EMPTY_CACHE.clear()
+    assert gateway._broadcast_destinations_for_authorize(key.workspace_id) == []
+    before = (
+        database.snapshot_execute_sql_calls,
+        database.transaction_execute_sql_calls,
+        database.transaction_execute_update_calls,
+    )
+
+    response = gateway._authorize_gateway_sync(
+        _request(), _body(key.hash), Settings(environment="test")
+    )
+
+    after = (
+        database.snapshot_execute_sql_calls,
+        database.transaction_execute_sql_calls,
+        database.transaction_execute_update_calls,
+    )
+    operation_count = sum(end - start for start, end in zip(before, after, strict=True))
+    assert response["data"]["authorization_id"]
+    # Representative steady-state fresh request: the workspace's observed-empty
+    # broadcast cache is warm, while this idempotency key and authorization are new.
+    assert operation_count == 10
+
+
+def test_broadcast_empty_results_are_cached_until_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _store, _database, key = _seed_typed_gateway_store()
+    gateway._BROADCAST_EMPTY_CACHE.clear()
+    now = [100.0]
+    calls = 0
+
+    def list_empty(_self: object, workspace_id: str) -> list[object]:
+        nonlocal calls
+        assert workspace_id == key.workspace_id
+        calls += 1
+        return []
+
+    monkeypatch.setattr(gateway.time, "monotonic", lambda: now[0])
+    monkeypatch.setattr(SpannerBigtableStore, "list_broadcast_destinations", list_empty)
+
+    assert gateway._broadcast_destinations_for_authorize(key.workspace_id) == []
+    assert gateway._broadcast_destinations_for_authorize(key.workspace_id) == []
+    assert calls == 1
+
+    now[0] += gateway._BROADCAST_EMPTY_CACHE_TTL_SECONDS + 0.001
+    assert gateway._broadcast_destinations_for_authorize(key.workspace_id) == []
+    assert calls == 2
+
+
+def test_positive_broadcast_results_are_never_cached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _store, _database, key = _seed_typed_gateway_store()
+    gateway._BROADCAST_EMPTY_CACHE.clear()
+    destination = object()
+    calls = 0
+
+    def list_positive(_self: object, workspace_id: str) -> list[object]:
+        nonlocal calls
+        assert workspace_id == key.workspace_id
+        calls += 1
+        return [destination]
+
+    monkeypatch.setattr(SpannerBigtableStore, "list_broadcast_destinations", list_positive)
+
+    assert gateway._broadcast_destinations_for_authorize(key.workspace_id) == [destination]
+    assert gateway._broadcast_destinations_for_authorize(key.workspace_id) == [destination]
+    assert calls == 2
+    assert key.workspace_id not in gateway._BROADCAST_EMPTY_CACHE
+
+
+def test_broadcast_empty_cache_evicts_oldest_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _store, _database, _key = _seed_typed_gateway_store()
+    gateway._BROADCAST_EMPTY_CACHE.clear()
+    monkeypatch.setattr(gateway, "_BROADCAST_EMPTY_CACHE_MAX_ENTRIES", 2)
+    monkeypatch.setattr(
+        SpannerBigtableStore,
+        "list_broadcast_destinations",
+        lambda _self, _workspace_id: [],
+    )
+
+    for workspace_id in ("ws-1", "ws-2", "ws-3"):
+        assert gateway._broadcast_destinations_for_authorize(workspace_id) == []
+
+    assert list(gateway._BROADCAST_EMPTY_CACHE) == ["ws-2", "ws-3"]


### PR DESCRIPTION
Every RPC here is inside every user's TTFT — the enclave blocks on authorize before dialing any provider. Four proven reductions: the legacy idempotency probe (index unwritten since the 2026-06-26 cutover; only writer is an unreachable compat method), the redundant pre-transaction typed probe (replay + fingerprint-409 now resolve in the transaction, both tested), the unconditional broadcast-destination read (empty results cached 60s in-process, positives never cached), and the post-commit re-read (the transaction's exact object is returned; `created_at` was already a client timestamp; dataclass equality vs a post-commit read is tested).

A count test pins a fresh authorize at **10 sequential operations**, so a reintroduced probe fails with a number. Sol authored; Fable reviewed: 320 tests green including the security file, ruff/mypy clean, pin mutation-tested (reintroducing a probe turns 2 tests red).