### PR TITLE
Scope status checks to deployment capabilities

### DIFF
--- a/src/trusted_router/synthetic/components.py
+++ b/src/trusted_router/synthetic/components.py
@@ -291,6 +291,11 @@ COMPONENT_REQUIRED_CAPABILITIES: dict[str, Callable[[Settings], bool]] = {
     # deployment without one never samples the model path, so publishing the
     # row there would be a permanent "unknown".
     "model_inference": lambda settings: bool(settings.synthetic_monitor_api_key),
+    # These probes call the private authorize/settle surface. Standalone
+    # observer planes deliberately carry only their observer credential, not
+    # the billing gateway credential, so they cannot emit these samples.
+    "billing_settlement": lambda settings: bool(settings.internal_gateway_token),
+    "provider_fallback": lambda settings: bool(settings.internal_gateway_token),
 }
 
 

--- a/src/trusted_router/synthetic/status.py
+++ b/src/trusted_router/synthetic/status.py
@@ -104,8 +104,31 @@ def status_snapshot(
     precomputed_rollups = rollups or []
     ordered = sorted(samples, key=lambda sample: sample.created_at, reverse=True)
     freshness = _monitor_freshness(ordered, now=now)
+    published_component_ids = {
+        str(definition["id"]) for definition in applicable_component_definitions(settings)
+    }
+    published_probe_types = {
+        probe_type
+        for component_id in published_component_ids
+        for probe_type in component_probe_types(component_id)
+    }
+    scoped_slo_samples = [
+        sample
+        for sample in ordered
+        if not sample_component_ids(sample)
+        or any(
+            component_id in published_component_ids
+            for component_id in sample_component_ids(sample)
+        )
+    ]
+    scoped_slo_rollups = [
+        rollup for rollup in precomputed_rollups if rollup.component in published_component_ids
+    ]
     router_core_samples = [
-        sample for sample in ordered if ROUTER_CORE_SLO_ID in sample_slo_class_ids(sample)
+        sample
+        for sample in scoped_slo_samples
+        if ROUTER_CORE_SLO_ID in sample_slo_class_ids(sample)
+        and sample.probe_type in published_probe_types
     ]
     gateway_region_components = published_gateway_region_components(settings)
     # `current.checks` is the MACHINE-readable surface, not a second copy of
@@ -126,6 +149,7 @@ def status_snapshot(
         rollup
         for rollup in precomputed_rollups
         if ROUTER_CORE_SLO_ID in rollup_slo_class_ids(rollup)
+        and rollup.component in published_component_ids
     ]
     five_minute = _scoped_window(
         router_core_samples,
@@ -150,11 +174,11 @@ def status_snapshot(
     )
     monthly = _monthly_history(router_core_rollups)
     components = _components(ordered, now=now, rollups=precomputed_rollups, settings=settings)
-    slo_classes = _slo_classes(ordered, precomputed_rollups, now=now)
+    slo_classes = _slo_classes(scoped_slo_samples, scoped_slo_rollups, now=now)
     slo_history = {
         str(definition["id"]): _slo_long_term_history(
-            ordered,
-            precomputed_rollups,
+            scoped_slo_samples,
+            scoped_slo_rollups,
             slo_id=str(definition["id"]),
         )
         for definition in SLO_DEFINITIONS

--- a/tests/test_per_enclave_probes.py
+++ b/tests/test_per_enclave_probes.py
@@ -556,7 +556,11 @@ def _aws_settings(**overrides: Any) -> Settings:
 
 
 def _gcp_settings() -> Settings:
-    return Settings(environment="test", sentry_dsn=None)
+    return Settings(
+        environment="test",
+        sentry_dsn=None,
+        internal_gateway_token="test-gateway-token",  # noqa: S106
+    )
 
 
 def test_unset_configuration_is_exactly_todays_target_list() -> None:
@@ -817,8 +821,6 @@ def test_configured_aws_publishes_a_component_per_region() -> None:
         "eu_west_1_gateway",
         "eu_west_3_gateway",
         "attestation",
-        "billing_settlement",
-        "provider_fallback",
     )
 
 

--- a/tests/test_status_component_scope.py
+++ b/tests/test_status_component_scope.py
@@ -50,7 +50,11 @@ REGIONAL_GCP_COMPONENT_IDS = (
 
 def _gcp_settings() -> Settings:
     """Production GCP shape: four warm attested regions."""
-    return Settings(environment="test", sentry_dsn=None)
+    return Settings(
+        environment="test",
+        sentry_dsn=None,
+        internal_gateway_token="test-gateway-token",  # noqa: S106 - test fixture.
+    )
 
 
 def _aws_eu_settings() -> Settings:
@@ -179,12 +183,7 @@ def test_aws_eu_does_not_advertise_gcp_regional_gateways() -> None:
         str(definition["id"]) for definition in applicable_component_definitions(_aws_eu_settings())
     )
 
-    assert ids == (
-        "canonical_api",
-        "attestation",
-        "billing_settlement",
-        "provider_fallback",
-    )
+    assert ids == ("canonical_api", "attestation")
     for component_id in REGIONAL_GCP_COMPONENT_IDS:
         assert component_id not in ids
 
@@ -202,6 +201,8 @@ def test_aws_eu_status_snapshot_publishes_no_unmeasurable_components() -> None:
     # them is a row that can never resolve.
     assert "canonical_api" in published
     assert "attestation" in published
+    assert "billing_settlement" not in published
+    assert "provider_fallback" not in published
 
 
 def test_scope_follows_configuration_not_a_hardcoded_cloud_list() -> None:
@@ -328,6 +329,57 @@ def test_aws_eu_status_snapshot_has_no_unknown_component_rows() -> None:
     assert isinstance(components, list)
     unknown = [str(row["id"]) for row in components if row["status"] == "unknown"]
     assert unknown == []
+    assert "billing_settlement" not in _published_ids(snapshot)
+    assert "provider_fallback" not in _published_ids(snapshot)
+    current = snapshot["current"]
+    assert isinstance(current, dict)
+    checks = current["checks"]
+    assert isinstance(checks, list)
+    assert {row["probe_type"] for row in checks} == {"tls_health", "attestation_nonce"}
+
+
+def test_retired_gateway_samples_cannot_poison_standalone_current_status() -> None:
+    """A secret-removal deploy must not leave its status page red forever."""
+    now = utcnow()
+    samples = [
+        _tls_sample(created_at=_iso(now - dt.timedelta(seconds=10))),
+        SyntheticProbeSample(
+            id="syn-attestation-current",
+            probe_type="attestation_nonce",
+            target="canonical",
+            target_url="https://api-aws.trustedrouter.com/attestation",
+            monitor_region="eu-west-3",
+            status="up",
+            created_at=_iso(now - dt.timedelta(seconds=10)),
+        ),
+        SyntheticProbeSample(
+            id="syn-billing-retired",
+            probe_type="gateway_authorize_settle",
+            target="control-plane",
+            target_url="https://aws.trustedrouter.com",
+            monitor_region="eu-west-3",
+            status="up",
+            created_at=_iso(now - dt.timedelta(hours=1)),
+        ),
+        SyntheticProbeSample(
+            id="syn-fallback-retired",
+            probe_type="provider_fallback",
+            target="control-plane",
+            target_url="https://aws.trustedrouter.com",
+            monitor_region="eu-west-3",
+            status="up",
+            created_at=_iso(now - dt.timedelta(hours=1)),
+        ),
+    ]
+
+    snapshot = status_snapshot(samples, now=now, settings=_aws_eu_settings())
+
+    assert snapshot["current"]["overall_status"] == "up"
+    assert snapshot["slo_classes"]["router_core"]["status"] == "up"
+    assert {row["probe_type"] for row in snapshot["current"]["checks"]} == {
+        "tls_health",
+        "attestation_nonce",
+    }
 
 
 def test_a_probe_target_alone_does_not_make_a_component_measurable() -> None:
@@ -339,7 +391,10 @@ def test_a_probe_target_alone_does_not_make_a_component_measurable() -> None:
     from trusted_router.config import Settings as _Settings
 
     without_image_job = _Settings(
-        environment="test", sentry_dsn=None, synthetic_image_probe_enabled=False
+        environment="test",
+        sentry_dsn=None,
+        synthetic_image_probe_enabled=False,
+        internal_gateway_token="test-gateway-token",  # noqa: S106 - test fixture.
     )
 
     ids = tuple(

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -880,7 +880,11 @@ def test_status_keeps_provider_failures_out_of_global_slo_classes() -> None:
     snapshot = status_snapshot(
         samples,
         now=now,
-        settings=Settings(environment="test", synthetic_monitor_api_key="sk-tr-monitor-test"),
+        settings=Settings(
+            environment="test",
+            synthetic_monitor_api_key="sk-tr-monitor-test",
+            internal_gateway_token="test-gateway-token",  # noqa: S106 - test fixture.
+        ),
     )
 
     # Provider-effective failures stay out of the SLO math (July decision),
@@ -978,7 +982,14 @@ def test_status_router_core_burn_rate_alerts_on_short_window_failures() -> None:
         ),
     ]
 
-    snapshot = status_snapshot(samples, now=now)
+    snapshot = status_snapshot(
+        samples,
+        now=now,
+        settings=Settings(
+            environment="test",
+            internal_gateway_token="test-gateway-token",  # noqa: S106 - test fixture.
+        ),
+    )
 
     assert snapshot["slo_classes"]["router_core"]["status"] == "down"
     alert = next(
@@ -1266,7 +1277,13 @@ def test_status_components_group_regions_and_control_plane() -> None:
         ),
     ]
 
-    snapshot = status_snapshot(samples)
+    snapshot = status_snapshot(
+        samples,
+        settings=Settings(
+            environment="test",
+            internal_gateway_token="test-gateway-token",  # noqa: S106 - test fixture.
+        ),
+    )
     components = {component["id"]: component for component in snapshot["components"]}
 
     assert components["canonical_api"]["status"] == "up"


### PR DESCRIPTION
Summary:
- publish billing settlement and forced fallback status only on deployments holding billing gateway authority
- exclude retired probe samples and rollups from current router-core status and SLO math
- preserve historical records while preventing stale legacy samples from falsely marking standalone clouds down
- add an AWS/Azure-shaped regression for fresh TLS and attestation plus retired gateway samples

Verification:
- 155 focused status tests passed
- Ruff passed
- mypy passed
- diff checks passed