### PR TITLE
Don't fail the coverage run when branch protection merely cannot be read

### DIFF
--- a/scripts/security/check_repo_security_coverage.py
+++ b/scripts/security/check_repo_security_coverage.py
@@ -157,9 +157,22 @@ PROTECTED_REPOS = {
 }
 
 
-def check_branch_protection(org: str, token: str) -> list[str]:
-    """Return a list of problems. Empty means the protection still holds."""
+def check_branch_protection(org: str, token: str) -> tuple[list[str], list[str]]:
+    """Return (problems, unreadable).
+
+    These are separated deliberately. Reading branch protection requires admin
+    rights on the repository, which the default GITHUB_TOKEN does not have — not
+    even for the repository it is running in. Treating "could not read" as a
+    failure therefore made this job fail on every scheduled run and file an issue
+    saying a repository could not receive a vulnerability report, while its own
+    output read `covered: 39/39`. That is a false alarm on a weekly timer, which
+    is the fastest way to train someone to ignore a security check.
+
+    Unreadable is reported, never silently passed, and never counted as a real
+    problem unless a token that can actually read the setting is supplied.
+    """
     problems: list[str] = []
+    unreadable: list[str] = []
     for repo, required in sorted(PROTECTED_REPOS.items()):
         status, body = _get(f"/repos/{org}/{repo}/branches/main/protection", token)
         if status == 404:
@@ -167,7 +180,9 @@ def check_branch_protection(org: str, token: str) -> list[str]:
             continue
         if status != 200 or not isinstance(body, dict):
             # Same rule as everywhere else here: could-not-read is its own state.
-            problems.append(f"{repo}: could not read protection (HTTP {status}) — NOT treating as unprotected")
+            unreadable.append(
+                f"{repo}: could not read protection (HTTP {status}) — NOT treating as unprotected"
+            )
             continue
 
         checks = body.get("required_status_checks") or {}
@@ -189,7 +204,7 @@ def check_branch_protection(org: str, token: str) -> list[str]:
             "required_approving_review_count"
         )
         print(f"  {repo}: contexts={sorted(contexts)} enforce_admins={admins} required_reviews={reviews}")
-    return problems
+    return problems, unreadable
 
 
 def main() -> int:
@@ -209,12 +224,20 @@ def main() -> int:
         raise SystemExit("REPO_SECURITY_TOKEN or GITHUB_TOKEN must be set")
 
     print("branch protection on production repositories:")
-    protection_problems = check_branch_protection(args.org, token)
+    protection_problems, protection_unreadable = check_branch_protection(args.org, token)
     if protection_problems:
         print("\n  BRANCH PROTECTION PROBLEMS:")
         for line in protection_problems:
             print(f"    - {line}")
-    else:
+    if protection_unreadable:
+        print("\n  BRANCH PROTECTION NOT ASSERTED (could not read):")
+        for line in protection_unreadable:
+            print(f"    - {line}")
+        print(
+            "    Reading branch protection needs Administration: read. Set the\n"
+            "    REPO_SECURITY_TOKEN secret to turn this half into a real assertion."
+        )
+    if not protection_problems and not protection_unreadable:
         print("  ok — protection holds on all production repositories")
     print()
 
@@ -265,7 +288,7 @@ def main() -> int:
 
     if uncovered or protection_problems:
         return 1
-    if unreadable:
+    if unreadable or protection_unreadable:
         return 0 if args.allow_unreadable else 1
     return 0
 


### PR DESCRIPTION
The first scheduled run after #870 merged **failed and filed [#885](https://github.com/Lore-Hex/quill-router/issues/885)** — while its own output read `covered: 39/39`.

Nothing was wrong. Reading branch protection needs `Administration: read`, which the default `GITHUB_TOKEN` lacks *even for its own repository*, so both reads returned **HTTP 403** — and I had made any protection problem fail the run unconditionally.

A false alarm on a weekly timer is worse than no check. It trains you to close the issue unread, and then the true positive gets closed the same way.

## Fix

`unreadable` is now its own state for protection, exactly as it already was for PVR: reported prominently, never silently passed, never counted as a real problem, gated behind `--allow-unreadable`. A **404 still counts as a real problem** — on a repository that exists, that is what "branch not protected" looks like.

## Verified per status code, not assumed

| input | result |
|---|---|
| HTTP 403 (the actual failure) | unreadable |
| HTTP 500 / transport failure | unreadable |
| HTTP 404 | **problem** |
| HTTP 200, required contexts present | ok |
| mutation: `allow_force_pushes` re-enabled | **problem** |

That last row is the regression this check exists to catch, so it is the one worth proving.

## Follow-up for a human

Until a fine-grained PAT with `Administration: read` is saved as `REPO_SECURITY_TOKEN`, the protection half reports **NOT ASSERTED** rather than passing. The SECURITY.md half still asserts and still fails the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)