### PR TITLE
Add Discord community support links

### DIFF
--- a/src/trusted_router/templates/public/_footer.html
+++ b/src/trusted_router/templates/public/_footer.html
@@ -65,6 +65,7 @@
       <a href="/resources">Resources</a>
       <a href="/careers">Careers</a>
       <a href="/support">Support</a>
+      <a href="https://discord.gg/FREVts9KAG" target="_blank" rel="noopener noreferrer">Discord community</a>
       <a href="/legal">Legal</a>
       <a href="/terms">Terms</a>
     </div>

--- a/src/trusted_router/templates/public/support.html
+++ b/src/trusted_router/templates/public/support.html
@@ -4,7 +4,7 @@
   <div><strong>Support</strong><span><a href="mailto:{{ support_email }}">{{ support_email }}</a></span></div>
   <div><strong>Security</strong><span><a href="mailto:{{ entity.security_contact_email }}">{{ entity.security_contact_email }}</a></span></div>
   <div><strong>Status</strong><span><a href="https://status.trustedrouter.com">Live status</a></span></div>
-  <div><strong>Docs</strong><span><a href="/docs">Developer docs</a></span></div>
+  <div><strong>Community</strong><span><a href="https://discord.gg/FREVts9KAG" target="_blank" rel="noopener noreferrer">Join Discord</a></span></div>
 </section>
 
 <section class="support-layout" aria-label="Contact TrustedRouter support">
@@ -79,6 +79,12 @@
       <h2>Reproducible code issues</h2>
       <p>Remove customer data and credentials, then use the relevant public repository for source and plugin issues.</p>
       <a class="btn" href="https://github.com/Lore-Hex/quill-router/issues">Router issues</a>
+    </div>
+    <div>
+      <span class="card-label">Community</span>
+      <h2>Discuss TrustedRouter</h2>
+      <p>Join developers and operators discussing models, routing, privacy, integrations, and support.</p>
+      <a class="btn" href="https://discord.gg/FREVts9KAG" target="_blank" rel="noopener noreferrer">Join Discord</a>
     </div>
   </aside>
 </section>

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -960,6 +960,8 @@ def test_public_privacy_terms_and_support_pages_are_distinct(client: TestClient)
     assert "github.com/Lore-Hex/quill-router/issues" in support.text
     assert "Never send an API key" in support.text
     assert "status.trustedrouter.com" in support.text
+    assert support.text.count('href="https://discord.gg/FREVts9KAG"') == 3
+    assert "Join Discord" in support.text
 
 
 def test_privacy_terms_and_support_are_in_core_sitemap(client: TestClient) -> None:
@@ -1481,6 +1483,8 @@ def test_resources_directory_links_previous_orphan_pages(client: TestClient) -> 
     assert 'href="/resources"' in footer.text
     assert 'href="/customers/robot-robot-human"' in footer.text
     assert 'href="/careers"' in footer.text
+    assert 'href="https://discord.gg/FREVts9KAG"' in footer.text
+    assert "Discord community" in footer.text
     footer_markup = footer.text.split('<footer class="site-footer"', maxsplit=1)[1]
     assert 'href="/china-ai-models"' not in footer_markup
 


### PR DESCRIPTION
## Summary
- add the TrustedRouter Discord community to the global footer
- make Discord a prominent support-page option
- test the rendered invite URL and labels

## Verification
- `uv run pytest -q tests/test_public_seo_pages.py -k "support or footer"`
- `uv run ruff check tests/test_public_seo_pages.py`
- `git diff --check`