### PR TITLE
Keep unpriced Parasail GLM 5.3 route dark

### DIFF
--- a/scripts/pricing/providers/parasail.py
+++ b/scripts/pricing/providers/parasail.py
@@ -162,6 +162,7 @@ _NATIVE_TO_OR_ID = {
     "parasail-glm-52": "z-ai/glm-5.2",
     "zai-org/GLM-5.2": "z-ai/glm-5.2",
     "zai-org/GLM-5.2-FP8": "z-ai/glm-5.2",
+    "zai-org/GLM-5.3-Flash": "z-ai/glm-5.3-flash",
     "parasail-glm47": "z-ai/glm-4.7",
     "zai-org/GLM-4.7": "z-ai/glm-4.7",
     "zai-org/GLM-4.7-FP8": "z-ai/glm-4.7",
@@ -204,6 +205,7 @@ _NATIVE_TO_OR_ID = {
     "ByteDance-Seed/UI-TARS-1.5-7B": "bytedance/ui-tars-1.5-7b",
 }
 UPSTREAM_ID_MAP = {or_id: native_id for native_id, or_id in _NATIVE_TO_OR_ID.items()}
+_LIVE_MODEL_IDS: set[str] = set()
 
 # SKIPPED — not yet supported by TR's chat-completions path:
 #   - parasail-bge-m3 / BAAI/bge-m3 (embedding model)
@@ -224,6 +226,7 @@ UPSTREAM_ID_MAP = {or_id: native_id for native_id, or_id in _NATIVE_TO_OR_ID.ite
 # a page row NOT in this map lands in notes as "unmapped" so the
 # operator adds it deliberately.
 _DISPLAY_TO_OR_ID = {
+    "GLM-5.3 Flash": "z-ai/glm-5.3-flash",
     "GLM-5.2": "z-ai/glm-5.2",
     "GLM-5.1": "z-ai/glm-5.1",
     "GLM-5": "z-ai/glm-5",
@@ -334,6 +337,9 @@ def _http_client() -> httpx.Client:
 def fetch() -> ProviderPricingResult:
     """Scrape prices from the public pricing page, gate on /v1/models
     liveness, and return prices only for models that appear in BOTH."""
+    global _LIVE_MODEL_IDS  # noqa: PLW0603
+
+    _LIVE_MODEL_IDS = set()
     notes: list[str] = []
 
     # Price source: the public pricing page. A fetch/parse failure
@@ -384,6 +390,7 @@ def fetch() -> ProviderPricingResult:
         if provider_model_retired(SLUG, or_id, native_id):
             continue
         or_ids_live.add(or_id)
+    _LIVE_MODEL_IDS = or_ids_live
 
     prices: dict[str, ModelPrice] = {}
     for or_id, rates in sorted(page_prices.items()):
@@ -424,6 +431,25 @@ def fetch() -> ProviderPricingResult:
 # Metadata (context/modalities) mirrors the OR snapshot entries for
 # the same checkpoints served by other providers.
 _MANIFEST_ROW_TEMPLATES: dict[str, dict[str, Any]] = {
+    "z-ai/glm-5.3-flash": {
+        "id": "z-ai/glm-5.3-flash",
+        "upstream_id": "zai-org/GLM-5.3-Flash",
+        "display_name": "Parasail GLM 5.3 Flash",
+        "title": "z-ai/glm-5.3-flash",
+        "context_length": 1048576,
+        "max_output_tokens": 131072,
+        "model_type": "chat",
+        "features": [
+            "reasoning",
+            "function-calling",
+            "structured-outputs",
+            "serverless",
+        ],
+        "input_modalities": ["text"],
+        "output_modalities": ["text"],
+        "endpoints": ["chat/completions"],
+        "status": 1,
+    },
     "z-ai/glm-5.2": {
         "id": "z-ai/glm-5.2",
         "upstream_id": "parasail-glm-52",
@@ -528,6 +554,25 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
     }
     updated: list[str] = []
     appended: list[str] = []
+
+    # Current-family routes can appear in Parasail's authenticated catalog
+    # before its public pricing table. Keep the known route visible as dark
+    # metadata so discovery coverage is complete, but never authorize it until
+    # the authoritative pricing page publishes positive rates.
+    for model_id, template in sorted(_MANIFEST_ROW_TEMPLATES.items()):
+        if model_id in existing_by_id or model_id not in _LIVE_MODEL_IDS:
+            continue
+        if model_id != "z-ai/glm-5.3-flash":
+            continue
+        row = dict(template)
+        if model_id not in result.prices:
+            row["routable"] = False
+            row["routable_reason"] = "awaiting-price"
+            row["unresolved_since"] = datetime.now(UTC).date().isoformat()
+        rows.append(row)
+        existing_by_id[model_id] = row
+        appended.append(model_id)
+
     for model_id, price in sorted(result.prices.items()):
         row = existing_by_id.get(model_id)
         if row is None:
@@ -545,6 +590,10 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
             row["cached_input_token_price_per_m"] = tier.prompt_cached_micro_per_m
         else:
             row.pop("cached_input_token_price_per_m", None)
+        if row.get("routable_reason") == "awaiting-price":
+            row.pop("routable", None)
+            row.pop("routable_reason", None)
+            row.pop("unresolved_since", None)
         updated.append(model_id)
 
     missing = sorted(set(_MANIFEST_EXPECTED) - set(updated))

--- a/src/trusted_router/data/provider_models/parasail.json
+++ b/src/trusted_router/data/provider_models/parasail.json
@@ -2,8 +2,8 @@
   "_about": "Provider-native supplement for Parasail models live ahead of the shared snapshot. Prices refreshed hourly from the public pricing page (www.parasail.io/pricing); model liveness gated on api.parasail.io/v1/models.",
   "provider": "parasail",
   "source": "https://www.parasail.io/pricing",
-  "generated_at": "2026-08-24T16:40:13Z",
-  "model_count": 4,
+  "generated_at": "2026-08-27T16:56:40Z",
+  "model_count": 5,
   "models": [
     {
       "id": "z-ai/glm-5.2",
@@ -115,6 +115,34 @@
       "input_token_price_per_m": 750000,
       "output_token_price_per_m": 3500000,
       "cached_input_token_price_per_m": 160000
+    },
+    {
+      "id": "z-ai/glm-5.3-flash",
+      "upstream_id": "zai-org/GLM-5.3-Flash",
+      "display_name": "Parasail GLM 5.3 Flash",
+      "title": "z-ai/glm-5.3-flash",
+      "context_length": 1048576,
+      "max_output_tokens": 131072,
+      "model_type": "chat",
+      "features": [
+        "reasoning",
+        "function-calling",
+        "structured-outputs",
+        "serverless"
+      ],
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "routable": false,
+      "routable_reason": "awaiting-price",
+      "unresolved_since": "2026-08-27"
     }
   ]
 }

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -2294,3 +2294,8 @@ def test_parasail_qwen_397b_uses_working_native_upstream_id() -> None:
     assert byok.upstream_id == "parasail-qwen35-397b-a17b"
     assert prepaid.prompt_price_microdollars_per_million_tokens == 527_500
     assert prepaid.completion_price_microdollars_per_million_tokens == 3_798_000
+
+
+def test_parasail_glm_53_flash_stays_dark_until_price_is_published() -> None:
+    assert "z-ai/glm-5.3-flash@parasail/prepaid" not in MODEL_ENDPOINTS
+    assert "z-ai/glm-5.3-flash@parasail/byok" not in MODEL_ENDPOINTS

--- a/tests/test_parasail_pricing.py
+++ b/tests/test_parasail_pricing.py
@@ -95,6 +95,7 @@ def test_fetch_prices_only_models_on_both_page_and_api(monkeypatch) -> None:  # 
             {"id": "MiniMaxAI/Minimax-M3"},
             # API-only model with a known mapping: unpriced note
             {"id": "zai-org/GLM-5.2"},
+            {"id": "zai-org/GLM-5.3-Flash"},
         ]
     }
     _fake_clients(monkeypatch, html, models_payload)
@@ -111,6 +112,7 @@ def test_fetch_prices_only_models_on_both_page_and_api(monkeypatch) -> None:  # 
     assert "nvidia/nemotron-3-ultra-550b-a55b" in joined  # page-only
     assert "Brand New Model 9000" in joined  # unmapped page row
     assert "z-ai/glm-5.2" in joined  # api-only, page missing
+    assert "z-ai/glm-5.3-flash" in joined
 
 
 def test_fetch_case_variant_native_ids_map_to_one_model(monkeypatch) -> None:  # noqa: ANN001
@@ -175,6 +177,7 @@ def test_write_provider_manifest_appends_new_models(tmp_path, monkeypatch) -> No
             {"id": "Qwen/Qwen3.5-397B-A17B"},
             {"id": "moonshotai/Kimi-K2.7-Code"},
             {"id": "MiniMaxAI/MiniMax-M3"},
+            {"id": "zai-org/GLM-5.3-Flash"},
         ]
     }
     _fake_clients(monkeypatch, html, models_payload)
@@ -190,8 +193,66 @@ def test_write_provider_manifest_appends_new_models(tmp_path, monkeypatch) -> No
     assert by_id["moonshotai/kimi-k2.7-code"]["input_token_price_per_m"] == 750_000
     assert by_id["moonshotai/kimi-k2.7-code"]["upstream_id"] == "parasail-kimi-k27-code"
     assert by_id["minimax/minimax-m3"]["context_length"] == 1_048_576
+    # Live discovery without a price remains visible but impossible to route.
+    unresolved = by_id["z-ai/glm-5.3-flash"]
+    assert unresolved["upstream_id"] == "zai-org/GLM-5.3-Flash"
+    assert unresolved["routable"] is False
+    assert unresolved["routable_reason"] == "awaiting-price"
+    assert "input_token_price_per_m" not in unresolved
     assert saved["model_count"] == len(saved["models"])
     assert any("appended" in n for n in notes)
+
+
+def test_write_provider_manifest_promotes_glm_53_only_after_official_price(
+    tmp_path, monkeypatch
+) -> None:  # noqa: ANN001
+    manifest = {
+        "provider": "parasail",
+        "models": [
+            {
+                **parasail._MANIFEST_ROW_TEMPLATES["z-ai/glm-5.3-flash"],
+                "routable": False,
+                "routable_reason": "awaiting-price",
+                "unresolved_since": "2026-08-27",
+            }
+        ],
+    }
+    path = tmp_path / "parasail.json"
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+    monkeypatch.setattr(parasail, "MANIFEST_PATH", path)
+    monkeypatch.setattr(parasail, "_MANIFEST_EXPECTED", [])
+
+    html = _page(_row("GLM-5.3 Flash", "0.15", "0.50", "0.03"))
+    _fake_clients(
+        monkeypatch,
+        html,
+        {"data": [{"id": "zai-org/GLM-5.3-Flash"}]},
+    )
+
+    parasail.write_provider_manifest(parasail.fetch())
+
+    row = json.loads(path.read_text(encoding="utf-8"))["models"][0]
+    assert row["input_token_price_per_m"] == 150_000
+    assert row["output_token_price_per_m"] == 500_000
+    assert row["cached_input_token_price_per_m"] == 30_000
+    assert "routable" not in row
+    assert "routable_reason" not in row
+    assert "unresolved_since" not in row
+
+
+def test_write_provider_manifest_does_not_invent_unseen_glm_53(tmp_path, monkeypatch) -> None:  # noqa: ANN001
+    path = tmp_path / "parasail.json"
+    path.write_text(json.dumps({"provider": "parasail", "models": []}), encoding="utf-8")
+    monkeypatch.setattr(parasail, "MANIFEST_PATH", path)
+    monkeypatch.setattr(parasail, "_MANIFEST_EXPECTED", [])
+
+    html = _page(_row("MiniMax M3", "0.30", "1.20", "0.06"))
+    _fake_clients(monkeypatch, html, {"data": [{"id": "MiniMaxAI/MiniMax-M3"}]})
+
+    parasail.write_provider_manifest(parasail.fetch())
+
+    ids = {row["id"] for row in json.loads(path.read_text(encoding="utf-8"))["models"]}
+    assert "z-ai/glm-5.3-flash" not in ids
 
 
 def test_parse_pricing_page_raises_on_layout_change() -> None:


### PR DESCRIPTION
## Summary
- recognize Parasail's live zai-org/GLM-5.3-Flash ID
- publish it as metadata-only while Parasail's official pricing page has no rate
- automatically promote it only after the official page publishes positive pricing
- keep prepaid and BYOK routes absent until then

## Verification
- 183 focused catalog, coverage, and manifest tests passed
- full ruff check passed
- full mypy passed
- production-equivalent strict coverage audit no longer reports Parasail GLM 5.3 as unpublished

Official source: https://www.parasail.io/pricing