### PR TITLE
Keep unpriced Fireworks GLM 5.3 route dark

### DIFF
--- a/scripts/pricing/openai_catalog.py
+++ b/scripts/pricing/openai_catalog.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 from typing import Any
 
@@ -132,12 +132,15 @@ def discover_available_priced_chat_catalog(
     explicit_map: dict[str, str],
     upstream_id_map: dict[str, str],
     include: Callable[[dict[str, Any]], bool] | None = None,
+    preserve_unpriced_model_ids: Collection[str] = (),
 ) -> dict[str, dict[str, Any]]:
     """Intersect an authenticated model list with independently sourced prices.
 
     Some first-party catalogs expose availability and capabilities but keep
     prices on a separate official page. Only the intersection is eligible for
-    publication; availability alone can never create an unpriced route.
+    routing. Callers may explicitly preserve reviewed unmatched model IDs as
+    metadata so the shared manifest writer can classify them
+    ``awaiting-price``; availability alone can never create a priced route.
     """
 
     discovered: dict[str, dict[str, Any]] = {}
@@ -150,7 +153,9 @@ def discover_available_priced_chat_catalog(
         if not _supports_text_output(source):
             continue
         model_id = mapped_or_canonical_model_id(native_id, explicit_map)
-        if model_id is None or model_id not in prices:
+        if model_id is None or (
+            model_id not in prices and model_id not in preserve_unpriced_model_ids
+        ):
             continue
         remember_upstream_id(upstream_id_map, model_id, native_id)
         row: dict[str, Any] = {

--- a/scripts/pricing/providers/fireworks.py
+++ b/scripts/pricing/providers/fireworks.py
@@ -77,6 +77,7 @@ _DISPLAY_NAMES = {
     "qwen/qwen3.8-max": "Qwen 3.8 Max",
     "z-ai/glm-5.2": "GLM 5.2",
     "z-ai/glm-5.2-fast": "GLM 5.2 Fast",
+    "z-ai/glm-5.3-flash": "GLM 5.3 Flash",
 }
 
 _NATIVE_TO_CANONICAL = {
@@ -92,6 +93,7 @@ _NATIVE_TO_CANONICAL = {
     "accounts/fireworks/models/deepseek-v4-flash-0731": "deepseek/deepseek-v4-flash-0731",
     "accounts/fireworks/models/glm-5p2": "z-ai/glm-5.2",
     "accounts/fireworks/routers/glm-5p2-fast": "z-ai/glm-5.2-fast",
+    "accounts/fireworks/models/glm-5p3-flash": "z-ai/glm-5.3-flash",
     "accounts/fireworks/models/glm-5p1": "z-ai/glm-5.1",
     "accounts/fireworks/models/gpt-oss-120b": "openai/gpt-oss-120b",
     "accounts/fireworks/models/gpt-oss-20b": "openai/gpt-oss-20b",
@@ -124,6 +126,7 @@ _VERSIONED_PRICE_FAMILIES = {
     "deepseek/deepseek-v4-flash-": "deepseek/deepseek-v4-flash",
     "deepseek/deepseek-v4-pro-": "deepseek/deepseek-v4-pro",
 }
+_PRESERVE_UNPRICED_MODEL_IDS = frozenset({"z-ai/glm-5.3-flash"})
 
 
 def _live_model_rows() -> list[dict[str, Any]]:
@@ -185,6 +188,7 @@ def fetch() -> ProviderPricingResult:
         prices=result.prices,
         explicit_map=resolved_native_map,
         upstream_id_map=UPSTREAM_ID_MAP,
+        preserve_unpriced_model_ids=_PRESERVE_UNPRICED_MODEL_IDS,
     )
     # A verified launch exception is allowed to precede the account model-list
     # feed, but only while the first-party pricing page still publishes it.

--- a/src/trusted_router/data/provider_models/fireworks.json
+++ b/src/trusted_router/data/provider_models/fireworks.json
@@ -2,8 +2,8 @@
   "_about": "Provider-native supplement for the Fireworks AI serverless models enabled on the TrustedRouter Fireworks account. Verified against https://api.fireworks.ai/inference/v1/models, Fireworks' first-party pricing page, and direct chat completions. Kimi K3 is a verified launch route served before the account model-list feed caught up. Fireworks uses full accounts/fireworks/models/... upstream IDs, so the enclave preserves upstream_id verbatim for this provider.",
   "provider": "fireworks",
   "source": "https://api.fireworks.ai/inference/v1/models",
-  "generated_at": "2026-08-25T18:42:44Z",
-  "model_count": 20,
+  "generated_at": "2026-08-27T18:33:32Z",
+  "model_count": 21,
   "models": [
     {
       "id": "moonshotai/kimi-k3",
@@ -216,9 +216,9 @@
       "upstream_id": "accounts/fireworks/models/deepseek-v4-pro-0813",
       "context_length": 1048576,
       "created": 1786637155,
-      "input_token_price_per_m": 1740000,
-      "output_token_price_per_m": 3480000,
-      "cached_input_token_price_per_m": 145000
+      "input_token_price_per_m": 1320000,
+      "output_token_price_per_m": 3960000,
+      "cached_input_token_price_per_m": 44000
     },
     {
       "display_name": "MiniMax M2.7 on Fireworks",
@@ -483,6 +483,28 @@
       "input_token_price_per_m": 600000,
       "output_token_price_per_m": 2400000,
       "cached_input_token_price_per_m": 120000
+    },
+    {
+      "display_name": "GLM 5.3 Flash on Fireworks",
+      "title": "accounts/fireworks/models/glm-5p3-flash",
+      "model_type": "chat",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "endpoints": [
+        "chat/completions"
+      ],
+      "status": 1,
+      "id": "z-ai/glm-5.3-flash",
+      "upstream_id": "accounts/fireworks/models/glm-5p3-flash",
+      "context_length": 1048576,
+      "created": 1787754936,
+      "routable": false,
+      "routable_reason": "awaiting-price",
+      "unresolved_since": "2026-08-27"
     }
   ],
   "pricing_source": "https://docs.fireworks.ai/serverless/pricing.md",

--- a/tests/test_fireworks_pricing.py
+++ b/tests/test_fireworks_pricing.py
@@ -247,6 +247,109 @@ def test_fireworks_fetch_keeps_verified_launch_model_while_catalog_lags(
     assert "moonshotai/kimi-k3" in fireworks._DISCOVERED_MANIFEST_ROWS
 
 
+def test_fireworks_fetch_preserves_live_unpriced_model_as_dark_metadata(
+    monkeypatch,
+) -> None:  # noqa: ANN001
+    native_id = "accounts/fireworks/models/glm-5p3-flash"
+    monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
+    monkeypatch.setattr(fireworks, "UPSTREAM_ID_MAP", dict(fireworks.UPSTREAM_ID_MAP))
+    monkeypatch.setattr(
+        fireworks,
+        "fetch_provider",
+        lambda **_kwargs: ProviderPricingResult(
+            slug="fireworks",
+            prices={model_id: _price() for model_id in fireworks.EXPECTED_MODELS},
+            source="deterministic",
+        ),
+    )
+    live_rows = [
+        {"id": fireworks.UPSTREAM_ID_MAP[model_id]}
+        for model_id in fireworks.EXPECTED_MODELS
+        if model_id not in fireworks.VERIFIED_PRICED_LAUNCH_MODELS
+    ]
+    live_rows.append(
+        {
+            "id": native_id,
+            "name": "GLM 5.3 Flash",
+            "context_length": 1_048_576,
+        }
+    )
+    live_rows.extend(
+        [
+            {
+                "id": "accounts/fireworks/models/qwen3-embedding-8b",
+                "kind": "EMBEDDING_MODEL",
+                "supports_chat": True,
+            },
+            {
+                "id": "accounts/fireworks/models/qwen3p8-2p4t-a95b",
+                "kind": "HF_BASE_MODEL",
+                "supports_chat": True,
+            },
+        ]
+    )
+    monkeypatch.setattr(
+        fireworks,
+        "fetch_json",
+        lambda *_args, **_kwargs: {"data": live_rows},
+    )
+
+    result = fireworks.fetch()
+
+    assert "z-ai/glm-5.3-flash" not in result.prices
+    assert fireworks._DISCOVERED_MANIFEST_ROWS["z-ai/glm-5.3-flash"] == {
+        "id": "z-ai/glm-5.3-flash",
+        "upstream_id": native_id,
+        "display_name": "GLM 5.3 Flash on Fireworks",
+        "endpoints": ["chat/completions"],
+        "context_length": 1_048_576,
+    }
+    assert fireworks.UPSTREAM_ID_MAP["z-ai/glm-5.3-flash"] == native_id
+    assert "qwen/qwen3-embedding-8b" not in fireworks._DISCOVERED_MANIFEST_ROWS
+    assert "qwen/qwen3p8-2p4t-a95b" not in fireworks._DISCOVERED_MANIFEST_ROWS
+
+
+def test_fireworks_manifest_keeps_unpriced_model_dark(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:  # noqa: ANN001
+    manifest_path = tmp_path / "fireworks.json"
+    manifest_path.write_text(
+        json.dumps({"provider": "fireworks", "models": []}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(fireworks, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(
+        fireworks,
+        "_DISCOVERED_MANIFEST_ROWS",
+        {
+            "z-ai/glm-5.3-flash": {
+                "id": "z-ai/glm-5.3-flash",
+                "upstream_id": "accounts/fireworks/models/glm-5p3-flash",
+                "display_name": "GLM 5.3 Flash on Fireworks",
+                "endpoints": ["chat/completions"],
+                "context_length": 1_048_576,
+            }
+        },
+    )
+    result = ProviderPricingResult(
+        slug="fireworks",
+        prices={},
+        source="api",
+        fetched_url=fireworks.URL,
+    )
+
+    fireworks.write_provider_manifest(result)
+
+    row = json.loads(manifest_path.read_text(encoding="utf-8"))["models"][0]
+    assert row["id"] == "z-ai/glm-5.3-flash"
+    assert row["routable"] is False
+    assert row["routable_reason"] == "awaiting-price"
+    assert row["unresolved_since"]
+    assert "input_token_price_per_m" not in row
+    assert "output_token_price_per_m" not in row
+
+
 def test_fireworks_manifest_appends_discovered_models_and_tombstones_delisted(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_provider_wave3_catalogs.py
+++ b/tests/test_provider_wave3_catalogs.py
@@ -297,6 +297,38 @@ def test_price_joined_catalog_excludes_non_text_output_models() -> None:
     assert upstream_ids == {"vendor/text": "vendor/text"}
 
 
+def test_price_joined_catalog_can_preserve_unpriced_models_as_metadata() -> None:
+    upstream_ids: dict[str, str] = {}
+    discovered = discover_available_priced_chat_catalog(
+        [
+            {"id": "vendor/priced", "context_length": 128_000},
+            {"id": "vendor/new", "context_length": 256_000},
+            {"id": "vendor/ignored", "context_length": 512_000},
+        ],
+        prices={"vendor/priced": ModelPrice(1, 2)},
+        explicit_map={
+            "vendor/priced": "vendor/priced",
+            "vendor/new": "vendor/new",
+            "vendor/ignored": "vendor/ignored",
+        },
+        upstream_id_map=upstream_ids,
+        preserve_unpriced_model_ids={"vendor/new"},
+    )
+
+    assert set(discovered) == {"vendor/new", "vendor/priced"}
+    assert discovered["vendor/new"] == {
+        "id": "vendor/new",
+        "upstream_id": "vendor/new",
+        "display_name": "vendor/new",
+        "endpoints": ["chat/completions"],
+        "context_length": 256_000,
+    }
+    assert upstream_ids == {
+        "vendor/new": "vendor/new",
+        "vendor/priced": "vendor/priced",
+    }
+
+
 def test_direct_provider_catalog_fetch_uses_shared_retry_helper(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- preserve reviewed live provider models as explicit awaiting-price metadata
- add Fireworks GLM 5.3 Flash using its exact upstream model ID without inventing a price
- keep unreviewed aliases and embedding/reranker models out of the chat manifest
- refresh verified Fireworks DeepSeek V4 Pro 0813 rates from the first-party pricing page

## Safety
- no endpoint is created for GLM 5.3 Flash
- no price is assigned
- the manifest row is routable=false with routable_reason=awaiting-price
- strict live discovery coverage now passes

## Verification
- regression tests failed before implementation
- 111 pricing/coverage tests pass
- 174 catalog/manifest contract tests pass (1 skipped)
- full Ruff passes
- full mypy passes
- authenticated Fireworks catalog fetch confirms the exact upstream ID
- live strict model-discovery audit exits 0