### PR TITLE
Settle-convoy harm limitation: fast-burn alert, overrun rollup, per-key shed

### DIFF
--- a/clickhouse/014_reservation_overruns.sql
+++ b/clickhouse/014_reservation_overruns.sql
@@ -1,0 +1,18 @@
+-- Hourly settled reservation overruns, recomputed from authoritative Spanner rows.
+
+CREATE TABLE IF NOT EXISTS tr.reservation_overruns ON CLUSTER trustedrouter
+(
+    hour                        DateTime('UTC'),
+    hold_usage_type             LowCardinality(String),
+    settled_n                   UInt64,
+    overrun_n                   UInt64,
+    overrun_micro               UInt64,
+    max_single_overrun_micro    UInt64,
+    refreshed_at                DateTime('UTC')
+)
+ENGINE = ReplicatedReplacingMergeTree(
+    '/trustedrouter/tables/{shard}/reservation_overruns-v1',
+    '{replica}',
+    refreshed_at
+)
+ORDER BY (hour, hold_usage_type);

--- a/clickhouse/015_reservation_overruns_single_node.sql
+++ b/clickhouse/015_reservation_overruns_single_node.sql
@@ -1,0 +1,15 @@
+-- Column-for-column single-node counterpart to 014_reservation_overruns.sql.
+-- The engine is the only difference from the replicated definition.
+
+CREATE TABLE IF NOT EXISTS reservation_overruns
+(
+    hour                        DateTime('UTC'),
+    hold_usage_type             LowCardinality(String),
+    settled_n                   UInt64,
+    overrun_n                   UInt64,
+    overrun_micro               UInt64,
+    max_single_overrun_micro    UInt64,
+    refreshed_at                DateTime('UTC')
+)
+ENGINE = ReplacingMergeTree(refreshed_at)
+ORDER BY (hour, hold_usage_type);

--- a/clickhouse/rollup_reservation_overruns.py
+++ b/clickhouse/rollup_reservation_overruns.py
@@ -1,0 +1,357 @@
+"""Roll settled reservation overruns from Spanner into ClickHouse each hour.
+
+The 2026-08-25 settle convoy showed that billing contention needs a warehouse
+view without adding work to the settlement transaction itself. Over 31 days,
+12.2% of settlements exceeded their hold ($45.57/day), while 96% of overrun
+dollars came from roughly 0.7% of settlements. This job therefore recomputes
+the two most recently closed UTC hours from authoritative ``tr_reservation``
+rows; the overlap and ``ReplacingMergeTree(refreshed_at)`` make reruns
+idempotent while keeping analytics entirely off the money path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import urllib.parse
+import urllib.request
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+PROJECT = "quill-cloud-proxy"
+SPANNER_INSTANCE = "trusted-router-nam6"
+SPANNER_DATABASE = "trusted-router"
+CLICKHOUSE_URL = "http://localhost:8123/"
+OVERRUN_TABLE = "tr.reservation_overruns"
+SPANNER_SCOPE = "https://www.googleapis.com/auth/spanner.data"
+
+
+class ReservationSource(Protocol):
+    def fetch(
+        self,
+        *,
+        window_start: dt.datetime,
+        window_end: dt.datetime,
+    ) -> list[Mapping[str, Any]]: ...
+
+
+class OverrunWriter(Protocol):
+    def upsert(self, rows: list[dict[str, Any]]) -> None: ...
+
+
+@dataclass(frozen=True)
+class OverrunAggregate:
+    settled_n: int
+    overrun_n: int
+    overrun_micro: int
+    max_single_overrun_micro: int
+
+
+@dataclass(frozen=True)
+class RollupResult:
+    source_rows: int
+    rollup_rows: int
+    window_start: dt.datetime
+    window_end: dt.datetime
+
+
+def _utc(value: dt.datetime) -> dt.datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=dt.UTC)
+    return value.astimezone(dt.UTC)
+
+
+def _parse_timestamp(value: Any, *, field: str) -> dt.datetime:
+    if isinstance(value, dt.datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise ValueError(f"reservation {field} is not an ISO timestamp") from exc
+    else:
+        raise ValueError(f"reservation {field} is not an ISO timestamp")
+    return _utc(parsed)
+
+
+def _spanner_timestamp(value: dt.datetime) -> str:
+    return _utc(value).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _clickhouse_datetime(value: dt.datetime) -> str:
+    return _utc(value).replace(microsecond=0).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def aggregate_reservation_overruns(
+    rows: list[Mapping[str, Any]],
+) -> dict[tuple[dt.datetime, str], OverrunAggregate]:
+    """Aggregate settled reservation rows by UTC hour and hold usage type."""
+    counters: dict[tuple[dt.datetime, str], list[int]] = {}
+    for row in rows:
+        if not bool(row.get("settled")):
+            continue
+        terminal_at = row.get("terminal_at")
+        if terminal_at is None:
+            continue
+        hour = _parse_timestamp(terminal_at, field="terminal_at").replace(
+            minute=0,
+            second=0,
+            microsecond=0,
+        )
+        hold_usage_type = str(row.get("hold_usage_type") or "unknown")
+        actual_micro = int(row.get("actual_micro") or 0)
+        reserved_micro = int(row.get("credit_reserved_micro") or 0)
+        overrun = max(0, actual_micro - reserved_micro)
+        values = counters.setdefault((hour, hold_usage_type), [0, 0, 0, 0])
+        values[0] += 1
+        if overrun > 0:
+            values[1] += 1
+            values[2] += overrun
+            values[3] = max(values[3], overrun)
+    return {
+        key: OverrunAggregate(
+            settled_n=values[0],
+            overrun_n=values[1],
+            overrun_micro=values[2],
+            max_single_overrun_micro=values[3],
+        )
+        for key, values in counters.items()
+    }
+
+
+def build_clickhouse_rows(
+    aggregates: Mapping[tuple[dt.datetime, str], OverrunAggregate],
+    *,
+    refreshed_at: dt.datetime,
+) -> list[dict[str, Any]]:
+    """Construct stable JSONEachRow payloads from pure aggregate values."""
+    refreshed = _clickhouse_datetime(refreshed_at)
+    return [
+        {
+            "hour": _clickhouse_datetime(hour),
+            "hold_usage_type": hold_usage_type,
+            "settled_n": aggregate.settled_n,
+            "overrun_n": aggregate.overrun_n,
+            "overrun_micro": aggregate.overrun_micro,
+            "max_single_overrun_micro": aggregate.max_single_overrun_micro,
+            "refreshed_at": refreshed,
+        }
+        for (hour, hold_usage_type), aggregate in sorted(aggregates.items())
+    ]
+
+
+class SpannerReservationSource:
+    """Read settled reservations through Spanner REST using ADC credentials."""
+
+    def __init__(self, *, project: str, instance: str, database: str) -> None:
+        from google.auth import default
+
+        self._database_url = (
+            "https://spanner.googleapis.com/v1/projects/"
+            f"{urllib.parse.quote(project, safe='')}/instances/"
+            f"{urllib.parse.quote(instance, safe='')}/databases/"
+            f"{urllib.parse.quote(database, safe='')}"
+        )
+        self._credentials, _ = default(scopes=[SPANNER_SCOPE])
+
+    def _token(self) -> str:
+        from google.auth.transport.requests import Request
+
+        if not self._credentials.valid:
+            self._credentials.refresh(Request())
+        token = self._credentials.token
+        if not token:
+            raise RuntimeError("ADC did not provide a Spanner access token")
+        return str(token)
+
+    def _request_json(
+        self,
+        url: str,
+        *,
+        method: str = "POST",
+        body: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        data = None if body is None else json.dumps(body, separators=(",", ":")).encode()
+        request = urllib.request.Request(  # noqa: S310 - fixed Google API origin
+            url,
+            data=data,
+            method=method,
+            headers={
+                "Authorization": f"Bearer {self._token()}",
+                "Content-Type": "application/json",
+            },
+        )
+        with urllib.request.urlopen(request, timeout=300) as response:  # noqa: S310
+            payload = response.read()
+        if not payload:
+            return {}
+        parsed = json.loads(payload)
+        if not isinstance(parsed, dict):
+            raise ValueError("Spanner REST response is not a JSON object")
+        return parsed
+
+    def fetch(
+        self,
+        *,
+        window_start: dt.datetime,
+        window_end: dt.datetime,
+    ) -> list[Mapping[str, Any]]:
+        session = self._request_json(f"{self._database_url}/sessions", body={})
+        session_name = str(session.get("name") or "")
+        if not session_name:
+            raise ValueError("Spanner createSession response omitted the session name")
+        session_url = "https://spanner.googleapis.com/v1/" + session_name
+        try:
+            result = self._request_json(
+                f"{session_url}:executeSql",
+                body={
+                    "sql": (
+                        "SELECT terminal_at, hold_usage_type, actual_micro, "
+                        "credit_reserved_micro, settled FROM tr_reservation "
+                        "WHERE settled = true AND terminal_at >= @window_start "
+                        "AND terminal_at < @window_end"
+                    ),
+                    "params": {
+                        "window_start": _spanner_timestamp(window_start),
+                        "window_end": _spanner_timestamp(window_end),
+                    },
+                    "paramTypes": {
+                        "window_start": {"code": "TIMESTAMP"},
+                        "window_end": {"code": "TIMESTAMP"},
+                    },
+                    "transaction": {"singleUse": {"readOnly": {"strong": True}}},
+                },
+            )
+        finally:
+            self._request_json(session_url, method="DELETE")
+
+        metadata = result.get("metadata")
+        row_type = metadata.get("rowType") if isinstance(metadata, dict) else None
+        fields = row_type.get("fields") if isinstance(row_type, dict) else None
+        if not isinstance(fields, list):
+            raise ValueError("Spanner executeSql response omitted row metadata")
+        names = [str(field["name"]) for field in fields]
+        raw_rows = result.get("rows", [])
+        if not isinstance(raw_rows, list):
+            raise ValueError("Spanner executeSql rows are not a list")
+        return [dict(zip(names, row, strict=True)) for row in raw_rows]
+
+
+class ClickHouseOverrunWriter:
+    """Synchronous JSONEachRow inserts through the ClickHouse HTTP interface."""
+
+    def __init__(self, *, url: str, password: str) -> None:
+        self._url = url
+        self._password = password
+
+    def upsert(self, rows: list[dict[str, Any]]) -> None:
+        if not rows:
+            return
+        payload = (
+            "\n".join(json.dumps(row, separators=(",", ":"), sort_keys=True) for row in rows)
+            + "\n"
+        ).encode()
+        separator = "&" if "?" in self._url else "?"
+        endpoint = self._url + separator + urllib.parse.urlencode(
+            {"query": f"INSERT INTO {OVERRUN_TABLE} FORMAT JSONEachRow"}
+        )
+        request = urllib.request.Request(  # noqa: S310 - configured node URL
+            endpoint,
+            data=payload,
+            method="POST",
+            headers={
+                "Content-Type": "application/x-ndjson",
+                "X-ClickHouse-User": "tr",
+                "X-ClickHouse-Key": self._password,
+            },
+        )
+        with urllib.request.urlopen(request, timeout=300):  # noqa: S310 - configured node URL
+            pass
+
+
+def rollup_reservation_overruns(
+    source: ReservationSource,
+    writer: OverrunWriter | None,
+    *,
+    dry_run: bool = False,
+    started_at: dt.datetime | None = None,
+) -> RollupResult:
+    """Read and replace the two most recently closed UTC hourly buckets."""
+    job_start = _utc(started_at or dt.datetime.now(dt.UTC)).replace(microsecond=0)
+    window_end = job_start.replace(minute=0, second=0, microsecond=0)
+    window_start = window_end - dt.timedelta(hours=2)
+    source_rows = source.fetch(window_start=window_start, window_end=window_end)
+    rows = build_clickhouse_rows(
+        aggregate_reservation_overruns(source_rows),
+        refreshed_at=job_start,
+    )
+    if not dry_run:
+        if writer is None:
+            raise ValueError("writer is required unless dry-run is selected")
+        writer.upsert(rows)
+    return RollupResult(
+        source_rows=len(source_rows),
+        rollup_rows=len(rows),
+        window_start=window_start,
+        window_end=window_end,
+    )
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--project", default=os.environ.get("GCP_PROJECT_ID", PROJECT))
+    parser.add_argument(
+        "--spanner-instance",
+        default=os.environ.get("SPANNER_INSTANCE_ID", SPANNER_INSTANCE),
+    )
+    parser.add_argument(
+        "--spanner-database",
+        default=os.environ.get("SPANNER_DATABASE_ID", SPANNER_DATABASE),
+    )
+    parser.add_argument(
+        "--clickhouse-url",
+        default=os.environ.get("CLICKHOUSE_URL", CLICKHOUSE_URL),
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    source: ReservationSource | None = None,
+    writer: OverrunWriter | None = None,
+) -> int:
+    args = _parse_args(argv)
+    selected_source = source or SpannerReservationSource(
+        project=args.project,
+        instance=args.spanner_instance,
+        database=args.spanner_database,
+    )
+    selected_writer = writer
+    if not args.dry_run and selected_writer is None:
+        selected_writer = ClickHouseOverrunWriter(
+            url=args.clickhouse_url,
+            password=os.environ["CH_PASSWORD"],
+        )
+    result = rollup_reservation_overruns(
+        selected_source,
+        selected_writer,
+        dry_run=args.dry_run,
+        started_at=dt.datetime.now(dt.UTC),
+    )
+    print(
+        f"source_rows={result.source_rows} "
+        f"reservation_overrun_rows={result.rollup_rows} "
+        f"window_start={_spanner_timestamp(result.window_start)} "
+        f"window_end={_spanner_timestamp(result.window_end)} "
+        f"dry_run={str(args.dry_run).lower()}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/clickhouse/tr-clickhouse-overrun-rollup.service
+++ b/clickhouse/tr-clickhouse-overrun-rollup.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=TrustedRouter reservation overrun rollup from Spanner
+After=network-online.target clickhouse-server.service
+
+[Service]
+Type=oneshot
+User=tr-clickhouse-ingest
+Group=tr-clickhouse-ingest
+WorkingDirectory=/opt/tr-clickhouse
+Environment=PYTHONPATH=/opt/tr-clickhouse/src
+EnvironmentFile=/etc/tr-clickhouse-ingest.env
+ExecStart=/opt/tr-clickhouse/venv/bin/python -m clickhouse.rollup_reservation_overruns
+TimeoutStartSec=5m
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=/var/lib/tr-clickhouse-ingest

--- a/clickhouse/tr-clickhouse-overrun-rollup.timer
+++ b/clickhouse/tr-clickhouse-overrun-rollup.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Roll up reservation overruns into ClickHouse hourly
+
+[Timer]
+OnCalendar=hourly
+RandomizedDelaySec=5min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/deploy/clickhouse_live_ingestion.sh
+++ b/scripts/deploy/clickhouse_live_ingestion.sh
@@ -68,6 +68,10 @@ ssh_node --command="sudo sh -c '
     /etc/systemd/system/tr-clickhouse-workspace-directory.service
   install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-workspace-directory.timer \
     /etc/systemd/system/tr-clickhouse-workspace-directory.timer
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-overrun-rollup.service \
+    /etc/systemd/system/tr-clickhouse-overrun-rollup.service
+  install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-overrun-rollup.timer \
+    /etc/systemd/system/tr-clickhouse-overrun-rollup.timer
   install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-archive.service \
     /etc/systemd/system/tr-clickhouse-archive.service
   install -m 0644 /opt/tr-clickhouse/clickhouse/tr-clickhouse-archive.timer \
@@ -95,6 +99,8 @@ ssh_node --command="sudo sh -c '
     --multiquery < /opt/tr-clickhouse/clickhouse/010_workspace_directory.sql
   clickhouse-client --user tr --password \"\$CH_PASSWORD\" --database tr \
     --multiquery < /opt/tr-clickhouse/clickhouse/012_activity_generations_workspace_id.sql
+  clickhouse-client --user tr --password \"\$CH_PASSWORD\" --database tr \
+    --multiquery < /opt/tr-clickhouse/clickhouse/014_reservation_overruns.sql
   systemctl daemon-reload
   systemctl enable tr-clickhouse-ingest.service
   systemctl restart tr-clickhouse-ingest.service
@@ -114,6 +120,7 @@ ssh_node --command="sudo sh -c '
     fi
   done
   systemctl enable --now tr-clickhouse-workspace-directory.timer
+  systemctl enable --now tr-clickhouse-overrun-rollup.timer
   systemctl enable --now tr-clickhouse-reconcile.timer
   systemctl enable --now tr-clickhouse-archive.timer
   systemctl enable --now tr-clickhouse-archive-restore.timer
@@ -121,6 +128,7 @@ ssh_node --command="sudo sh -c '
   systemctl enable --now tr-clickhouse-rollup-daily.timer
   systemctl is-active tr-clickhouse-ingest.service
   systemctl is-active tr-clickhouse-reconcile.timer
+  systemctl is-active tr-clickhouse-overrun-rollup.timer
   systemctl is-active tr-clickhouse-archive.timer
   systemctl is-active tr-clickhouse-archive-restore.timer
   systemctl is-active tr-clickhouse-rollup-hourly.timer

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -502,6 +502,7 @@ ENV_VARS=(
   # into one 240/min bucket. #712 removes this exception while installing each
   # split service's edge identity and independent capacity policy.
   "TR_RATE_LIMIT_ENABLED=false"
+  "TR_SETTLE_PER_KEY_INFLIGHT_LIMIT=16"
   "TR_RELEASE=${TR_DEPLOY_RELEASE_ID:-$(git rev-parse --short HEAD 2>/dev/null || echo local)}"
   # Request-based Cloud Run CPU can pause background coroutines. The scheduled
   # synthetic job invokes /internal/synthetic/remediate instead.

--- a/scripts/deploy/spanner-alerts/contention.yaml
+++ b/scripts/deploy/spanner-alerts/contention.yaml
@@ -8,6 +8,8 @@ documentation:
     lock conflicts. Capacity alone does not fix hot-row contention. Inspect
     transaction insights and billing shard distribution. Runbook:
     docs/spanner-reliability.md.
+    Added 2026-08-27: the fast-burn tier catches a five-minute settle convoy
+    that clears before the slow-burn tier's 600-second window can fire.
 conditions:
   - displayName: "More than 100 aborted commits per minute for 10 minutes"
     conditionThreshold:
@@ -31,6 +33,18 @@ conditions:
       comparison: COMPARISON_GT
       thresholdValue: 2
       duration: 600s
+      trigger:
+        count: 1
+  - displayName: "Fast burn (vs 10-minute slow burn): lock wait exceeds 30 seconds per second for 5 minutes"
+    conditionThreshold:
+      filter: 'resource.type = "spanner_instance" AND resource.labels.instance_id = "trusted-router-nam6" AND metric.type = "spanner.googleapis.com/lock_stat/total/lock_wait_time"'
+      aggregations:
+        - alignmentPeriod: 60s
+          perSeriesAligner: ALIGN_RATE
+          crossSeriesReducer: REDUCE_SUM
+      comparison: COMPARISON_GT
+      thresholdValue: 30
+      duration: 300s
       trigger:
         count: 1
 alertStrategy:

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -599,6 +599,9 @@ class Settings(BaseSettings):
     # budget. Keep one API key from filling every worker in a service instance
     # while still allowing ordinary low-latency traffic to scale horizontally.
     gateway_authorize_max_in_flight_per_key: int = 4
+    # Settlement has a wider gate because it closes already-issued holds, but
+    # one hot key must not consume every Spanner session in an instance.
+    settle_per_key_inflight_limit: int = 16
     # Only front doors that overwrite X-TrustedRouter-Client-IP may opt into
     # edge_header. Public origins that cannot perform that overwrite must stay
     # on the safe default and aggregate into the untrusted_lb bucket.
@@ -1215,6 +1218,7 @@ class Settings(BaseSettings):
                 "TR_GATEWAY_AUTHORIZE_MAX_IN_FLIGHT_PER_KEY",
                 self.gateway_authorize_max_in_flight_per_key,
             ),
+            ("TR_SETTLE_PER_KEY_INFLIGHT_LIMIT", self.settle_per_key_inflight_limit),
         ):
             if value <= 0:
                 raise ValueError(f"{name} must be positive")

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -154,6 +154,7 @@ from trusted_router.storage_errors import (
 from trusted_router.storage_gcp_io import spanner_rpc_budget
 from trusted_router.storage_models import (
     AppMarkupPayout,
+    GatewayAuthorization,
     SettleOutboxRow,
     TypedFinalizeResult,
     UserModelPayout,
@@ -177,6 +178,11 @@ REQUEST_METADATA_VERSION = 1
 # process to serialize a structured retryable 503 and for network transit.
 _BILLING_PATH_SPANNER_BUDGET_SECONDS = 20.0
 _AUTHORIZE_ADMISSION = KeyedConcurrencyAdmission()
+# Process-local harm limitation: this keeps one key from exhausting this
+# instance's Spanner session pool. It cannot stop a fleet-wide settle convoy;
+# at the 2026-08-25 incident scale, roughly 76 concurrent settles still survive
+# the independent per-instance gates and can contend on the same Spanner key.
+_SETTLE_ADMISSION = KeyedConcurrencyAdmission()
 _BROADCAST_EMPTY_CACHE_TTL_SECONDS = 60.0
 _BROADCAST_EMPTY_CACHE_MAX_ENTRIES = 1_024
 _BROADCAST_EMPTY_CACHE: OrderedDict[str, float] = OrderedDict()
@@ -290,6 +296,22 @@ async def authorize_gateway(
         return await run_in_threadpool(_authorize_gateway_sync, request, body, settings)
     finally:
         _AUTHORIZE_ADMISSION.release(subject)
+
+
+async def settle_gateway(
+    request: Request,
+    body: GatewaySettleRequest,
+    settings: Settings,
+    background_tasks: BackgroundTasks | None = None,
+) -> dict[str, Any]:
+    """Run one settlement off-loop behind the process-local per-key gate."""
+    require_internal_gateway(request, settings)
+    return await run_in_threadpool(
+        _settle_gateway_with_admission_sync,
+        body,
+        settings=settings,
+        background_tasks=background_tasks,
+    )
 
 
 @spanner_rpc_budget(_BILLING_PATH_SPANNER_BUDGET_SECONDS)
@@ -1237,16 +1259,7 @@ def register(router: APIRouter) -> None:
         settings: SettingsDep,
         background_tasks: BackgroundTasks,
     ) -> dict[str, Any]:
-        require_internal_gateway(request, settings)
-        # background_tasks.add_task is a plain list append inside the sync core;
-        # the tasks themselves still run on the loop after the response.
-        return await run_in_threadpool(
-            _settle_gateway_authorization,
-            body,
-            success=True,
-            settings=settings,
-            background_tasks=background_tasks,
-        )
+        return await settle_gateway(request, body, settings, background_tasks)
 
     @router.post("/internal/gateway/refund")
     async def gateway_refund(
@@ -1927,19 +1940,62 @@ def _report_route_fallbacks(body: GatewaySettleRequest) -> None:
 
 
 @spanner_rpc_budget(_BILLING_PATH_SPANNER_BUDGET_SECONDS)
+def _settle_gateway_with_admission_sync(
+    body: GatewaySettleRequest,
+    *,
+    settings: Settings,
+    background_tasks: BackgroundTasks | None = None,
+) -> dict[str, Any]:
+    authorization = STORE.get_gateway_authorization(body.authorization_id)
+    if authorization is None:
+        raise api_error(404, "Gateway authorization not found", ErrorType.NOT_FOUND)
+    subject = authorization.key_hash
+    if not _SETTLE_ADMISSION.try_acquire(
+        subject,
+        limit=settings.settle_per_key_inflight_limit,
+    ):
+        logger.warning(
+            "billing.settle_admission_limited",
+            extra={
+                "key_subject_fingerprint": hashlib.sha256(subject.encode("utf-8")).hexdigest()[
+                    :16
+                ],
+                "limit": settings.settle_per_key_inflight_limit,
+            },
+        )
+        raise api_error(
+            503,
+            "Settlement is temporarily unavailable; retry shortly.",
+            ErrorType.SERVICE_UNAVAILABLE,
+            headers={"Retry-After": "1"},
+        )
+    try:
+        return _settle_gateway_authorization(
+            body,
+            success=True,
+            settings=settings,
+            background_tasks=background_tasks,
+            _authorization=authorization,
+        )
+    finally:
+        _SETTLE_ADMISSION.release(subject)
+
+
+@spanner_rpc_budget(_BILLING_PATH_SPANNER_BUDGET_SECONDS)
 def _settle_gateway_authorization(
     body: GatewaySettleRequest,
     *,
     success: bool,
     settings: Settings,
     background_tasks: BackgroundTasks | None = None,
+    _authorization: GatewayAuthorization | None = None,
 ) -> dict[str, Any]:
     timing_start = perf_counter()
     # getattr: some callers/tests build the settle body via model_construct,
     # which skips defaults for unset fields.
     if success and getattr(body, "route_fallbacks", None):
         _report_route_fallbacks(body)
-    authorization = STORE.get_gateway_authorization(body.authorization_id)
+    authorization = _authorization or STORE.get_gateway_authorization(body.authorization_id)
     if authorization is None:
         raise api_error(404, "Gateway authorization not found", ErrorType.NOT_FOUND)
     if authorization.settled:

--- a/tests/test_billing_path_rpc_budget.py
+++ b/tests/test_billing_path_rpc_budget.py
@@ -29,7 +29,11 @@ GATEWAY = ROOT / "src" / "trusted_router" / "routes" / "internal" / "gateway.py"
 #: The billing path: everything that authorizes or settles gateway spend. These
 #: hold the budget because an RPC stall here stalls inference authorization.
 BILLING_PATH_FUNCTIONS = frozenset(
-    {"_authorize_gateway_sync", "_settle_gateway_authorization"}
+    {
+        "_authorize_gateway_sync",
+        "_settle_gateway_with_admission_sync",
+        "_settle_gateway_authorization",
+    }
 )
 
 _BUDGET = "spanner_rpc_budget(_BILLING_PATH_SPANNER_BUDGET_SECONDS)"

--- a/tests/test_gateway_settle_admission.py
+++ b/tests/test_gateway_settle_admission.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from trusted_router.config import Settings
+from trusted_router.routes.internal import gateway
+from trusted_router.schemas import GatewaySettleRequest
+from trusted_router.storage import InMemoryStore
+
+
+def _request() -> Request:
+    return Request({"type": "http", "method": "POST", "path": "/", "headers": []})
+
+
+def test_settle_sheds_above_per_key_limit_and_completion_restores_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    subject = "hot-settlement-key"
+    limit = 2
+    all_started = threading.Event()
+    release = threading.Event()
+    state_lock = threading.Lock()
+    started = 0
+
+    def authorization_for_key(
+        _store: InMemoryStore, _authorization_id: str
+    ) -> SimpleNamespace:
+        return SimpleNamespace(key_hash=subject)
+
+    def blocking_settle(*_args: object, **_kwargs: object) -> dict[str, object]:
+        nonlocal started
+        with state_lock:
+            started += 1
+            if started == limit:
+                all_started.set()
+        assert release.wait(timeout=5)
+        return {"data": {"settled": True}}
+
+    monkeypatch.setattr(
+        InMemoryStore,
+        "get_gateway_authorization",
+        authorization_for_key,
+    )
+    monkeypatch.setattr(gateway, "_settle_gateway_authorization", blocking_settle)
+    settings = Settings(environment="test", settle_per_key_inflight_limit=limit)
+    body = GatewaySettleRequest(authorization_id="gwa-hot")
+
+    async def scenario() -> None:
+        admitted = [
+            asyncio.create_task(gateway.settle_gateway(_request(), body, settings))
+            for _ in range(limit)
+        ]
+        assert await asyncio.to_thread(all_started.wait, 5)
+
+        try:
+            with pytest.raises(HTTPException) as raised:
+                await gateway.settle_gateway(_request(), body, settings)
+            assert raised.value.status_code == 503
+            assert raised.value.headers == {"Retry-After": "1"}
+            assert raised.value.detail["error"]["type"] == "service_unavailable"
+        finally:
+            release.set()
+        assert all(result["data"]["settled"] for result in await asyncio.gather(*admitted))
+        assert gateway._SETTLE_ADMISSION.count(subject) == 0
+
+        restored = await gateway.settle_gateway(_request(), body, settings)
+        assert restored["data"]["settled"] is True
+        assert gateway._SETTLE_ADMISSION.count(subject) == 0
+
+    asyncio.run(scenario())
+
+
+def test_settle_per_key_inflight_limit_must_be_positive() -> None:
+    with pytest.raises(
+        ValueError,
+        match="TR_SETTLE_PER_KEY_INFLIGHT_LIMIT must be positive",
+    ):
+        Settings(environment="test", settle_per_key_inflight_limit=0)
+
+
+def test_settle_per_key_inflight_limit_defaults_to_sixteen() -> None:
+    assert Settings(environment="test").settle_per_key_inflight_limit == 16
+
+
+def test_settle_exception_path_releases_per_key_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    subject = "exception-settlement-key"
+
+    def authorization_for_key(
+        _store: InMemoryStore, _authorization_id: str
+    ) -> SimpleNamespace:
+        return SimpleNamespace(key_hash=subject)
+
+    def failing_settle(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise RuntimeError("settlement exploded")
+
+    monkeypatch.setattr(
+        InMemoryStore,
+        "get_gateway_authorization",
+        authorization_for_key,
+    )
+    monkeypatch.setattr(gateway, "_settle_gateway_authorization", failing_settle)
+    settings = Settings(environment="test", settle_per_key_inflight_limit=1)
+    body = GatewaySettleRequest(authorization_id="gwa-exception")
+
+    with pytest.raises(RuntimeError, match="settlement exploded"):
+        asyncio.run(gateway.settle_gateway(_request(), body, settings))
+    assert gateway._SETTLE_ADMISSION.count(subject) == 0

--- a/tests/test_reservation_overrun_rollup.py
+++ b/tests/test_reservation_overrun_rollup.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from clickhouse.rollup_reservation_overruns import (
+    PROJECT,
+    SPANNER_DATABASE,
+    SPANNER_INSTANCE,
+    OverrunAggregate,
+    _parse_args,
+    aggregate_reservation_overruns,
+    build_clickhouse_rows,
+    rollup_reservation_overruns,
+)
+
+ROOT = Path(__file__).parents[1]
+
+
+class FakeReservationSource:
+    def __init__(self, rows: list[Mapping[str, Any]]) -> None:
+        self.rows = rows
+        self.windows: list[tuple[dt.datetime, dt.datetime]] = []
+
+    def fetch(
+        self,
+        *,
+        window_start: dt.datetime,
+        window_end: dt.datetime,
+    ) -> list[Mapping[str, Any]]:
+        self.windows.append((window_start, window_end))
+        return self.rows
+
+
+class FakeWriter:
+    def __init__(self) -> None:
+        self.rows: list[dict[str, Any]] = []
+
+    def upsert(self, rows: list[dict[str, Any]]) -> None:
+        self.rows.extend(rows)
+
+
+def test_rollup_defaults_to_the_authoritative_production_spanner_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for name in ("GCP_PROJECT_ID", "SPANNER_INSTANCE_ID", "SPANNER_DATABASE_ID"):
+        monkeypatch.delenv(name, raising=False)
+    args = _parse_args([])
+
+    assert PROJECT == args.project == "quill-cloud-proxy"
+    assert SPANNER_INSTANCE == args.spanner_instance == "trusted-router-nam6"
+    assert SPANNER_DATABASE == args.spanner_database == "trusted-router"
+
+
+def test_aggregation_counts_only_positive_overruns_by_hour_and_hold_type() -> None:
+    rows: list[Mapping[str, Any]] = [
+        {
+            "terminal_at": "2026-08-25T10:01:00Z",
+            "hold_usage_type": "Credits",
+            "actual_micro": "100",
+            "credit_reserved_micro": "75",
+            "settled": True,
+        },
+        {
+            "terminal_at": "2026-08-25T10:59:59+00:00",
+            "hold_usage_type": "Credits",
+            "actual_micro": "130",
+            "credit_reserved_micro": "100",
+            "settled": True,
+        },
+        {
+            "terminal_at": dt.datetime(2026, 8, 25, 10, 30, tzinfo=dt.UTC),
+            "hold_usage_type": "Credits",
+            "actual_micro": 80,
+            "credit_reserved_micro": 100,
+            "settled": True,
+        },
+        {
+            "terminal_at": "2026-08-25T10:15:00Z",
+            "hold_usage_type": "BYOK",
+            "actual_micro": 0,
+            "credit_reserved_micro": 0,
+            "settled": True,
+        },
+        {
+            "terminal_at": "2026-08-25T11:01:00Z",
+            "hold_usage_type": "Credits",
+            "actual_micro": 500,
+            "credit_reserved_micro": 125,
+            "settled": True,
+        },
+        {
+            "terminal_at": "2026-08-25T10:20:00Z",
+            "hold_usage_type": "Credits",
+            "actual_micro": 1_000,
+            "credit_reserved_micro": 1,
+            "settled": False,
+        },
+        {
+            "terminal_at": None,
+            "hold_usage_type": "Credits",
+            "actual_micro": 1_000,
+            "credit_reserved_micro": 1,
+            "settled": True,
+        },
+    ]
+
+    aggregates = aggregate_reservation_overruns(rows)
+
+    assert aggregates == {
+        (dt.datetime(2026, 8, 25, 10, tzinfo=dt.UTC), "BYOK"): OverrunAggregate(
+            settled_n=1,
+            overrun_n=0,
+            overrun_micro=0,
+            max_single_overrun_micro=0,
+        ),
+        (dt.datetime(2026, 8, 25, 10, tzinfo=dt.UTC), "Credits"): OverrunAggregate(
+            settled_n=3,
+            overrun_n=2,
+            overrun_micro=55,
+            max_single_overrun_micro=30,
+        ),
+        (dt.datetime(2026, 8, 25, 11, tzinfo=dt.UTC), "Credits"): OverrunAggregate(
+            settled_n=1,
+            overrun_n=1,
+            overrun_micro=375,
+            max_single_overrun_micro=375,
+        ),
+    }
+
+
+def test_row_construction_is_sorted_and_versions_every_metric() -> None:
+    aggregates = {
+        (dt.datetime(2026, 8, 25, 11, tzinfo=dt.UTC), "RegionalCredits"): OverrunAggregate(
+            settled_n=9,
+            overrun_n=2,
+            overrun_micro=450,
+            max_single_overrun_micro=300,
+        ),
+        (dt.datetime(2026, 8, 25, 10, tzinfo=dt.UTC), "Credits"): OverrunAggregate(
+            settled_n=7,
+            overrun_n=1,
+            overrun_micro=25,
+            max_single_overrun_micro=25,
+        ),
+    }
+
+    rows = build_clickhouse_rows(
+        aggregates,
+        refreshed_at=dt.datetime(2026, 8, 25, 12, 5, 6, 987, tzinfo=dt.UTC),
+    )
+
+    assert rows == [
+        {
+            "hour": "2026-08-25 10:00:00",
+            "hold_usage_type": "Credits",
+            "settled_n": 7,
+            "overrun_n": 1,
+            "overrun_micro": 25,
+            "max_single_overrun_micro": 25,
+            "refreshed_at": "2026-08-25 12:05:06",
+        },
+        {
+            "hour": "2026-08-25 11:00:00",
+            "hold_usage_type": "RegionalCredits",
+            "settled_n": 9,
+            "overrun_n": 2,
+            "overrun_micro": 450,
+            "max_single_overrun_micro": 300,
+            "refreshed_at": "2026-08-25 12:05:06",
+        },
+    ]
+
+
+def test_rollup_reads_two_closed_utc_hours_and_dry_run_does_not_write() -> None:
+    source = FakeReservationSource([])
+    writer = FakeWriter()
+    started_at = dt.datetime(2026, 8, 25, 12, 47, 31, tzinfo=dt.UTC)
+
+    result = rollup_reservation_overruns(
+        source,
+        writer,
+        dry_run=True,
+        started_at=started_at,
+    )
+
+    assert source.windows == [
+        (
+            dt.datetime(2026, 8, 25, 10, tzinfo=dt.UTC),
+            dt.datetime(2026, 8, 25, 12, tzinfo=dt.UTC),
+        )
+    ]
+    assert result.window_start == source.windows[0][0]
+    assert result.window_end == source.windows[0][1]
+    assert writer.rows == []
+
+
+def test_overrun_schemas_and_hourly_timer_are_installed() -> None:
+    replicated = (ROOT / "clickhouse/014_reservation_overruns.sql").read_text()
+    single = (ROOT / "clickhouse/015_reservation_overruns_single_node.sql").read_text()
+    service = (ROOT / "clickhouse/tr-clickhouse-overrun-rollup.service").read_text()
+    timer = (ROOT / "clickhouse/tr-clickhouse-overrun-rollup.timer").read_text()
+    installer = (ROOT / "scripts/deploy/clickhouse_live_ingestion.sh").read_text()
+
+    for column in (
+        "hour",
+        "hold_usage_type",
+        "settled_n",
+        "overrun_n",
+        "overrun_micro",
+        "max_single_overrun_micro",
+        "refreshed_at",
+    ):
+        assert column in replicated
+        assert column in single
+    assert "ON CLUSTER trustedrouter" in replicated
+    assert "ReplicatedReplacingMergeTree" in replicated
+    assert "ENGINE = ReplacingMergeTree(refreshed_at)" in single
+    assert "ORDER BY (hour, hold_usage_type)" in replicated
+    assert "ORDER BY (hour, hold_usage_type)" in single
+
+    assert "python -m clickhouse.rollup_reservation_overruns" in service
+    assert "User=tr-clickhouse-ingest" in service
+    assert "EnvironmentFile=/etc/tr-clickhouse-ingest.env" in service
+    assert "ProtectSystem=strict" in service
+    assert "OnCalendar=hourly" in timer
+    assert "Persistent=true" in timer
+
+    for unit in (
+        "tr-clickhouse-overrun-rollup.service",
+        "tr-clickhouse-overrun-rollup.timer",
+    ):
+        assert f"/opt/tr-clickhouse/clickhouse/{unit}" in installer
+        assert f"/etc/systemd/system/{unit}" in installer
+    assert "014_reservation_overruns.sql" in installer
+    assert "systemctl enable --now tr-clickhouse-overrun-rollup.timer" in installer

--- a/tests/test_spanner_reliability_deploy.py
+++ b/tests/test_spanner_reliability_deploy.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import yaml
+
 ROOT = Path(__file__).resolve().parents[1]
 DEPLOY = ROOT / "scripts" / "deploy"
 
@@ -44,6 +46,54 @@ def test_high_priority_cpu_alert_keeps_short_spikes_visible() -> None:
     assert "perSeriesAligner: ALIGN_MAX" in policy
     assert "thresholdValue: 0.45" in policy
     assert "duration: 300s" in policy
+
+
+def test_contention_alert_has_distinct_slow_and_fast_lock_wait_burns() -> None:
+    policy_path = DEPLOY / "spanner-alerts" / "contention.yaml"
+    policy = yaml.safe_load(policy_path.read_text(encoding="utf-8"))
+    conditions = {condition["displayName"]: condition for condition in policy["conditions"]}
+
+    slow = conditions["Lock wait exceeds two seconds per second for 10 minutes"][
+        "conditionThreshold"
+    ]
+    aborts = conditions["More than 100 aborted commits per minute for 10 minutes"][
+        "conditionThreshold"
+    ]
+    fast = conditions[
+        "Fast burn (vs 10-minute slow burn): lock wait exceeds 30 seconds per second for 5 minutes"
+    ]["conditionThreshold"]
+
+    assert len(policy["conditions"]) == 3
+    assert aborts["thresholdValue"] == 1.666666667
+    assert aborts["duration"] == "600s"
+    assert aborts["aggregations"] == [
+        {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_RATE",
+            "crossSeriesReducer": "REDUCE_SUM",
+        }
+    ]
+    assert slow["thresholdValue"] == 2
+    assert slow["duration"] == "600s"
+    assert slow["aggregations"] == [
+        {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_RATE",
+            "crossSeriesReducer": "REDUCE_SUM",
+        }
+    ]
+    assert fast["filter"] == slow["filter"]
+    assert fast["thresholdValue"] == 30
+    assert fast["duration"] == "300s"
+    assert fast["aggregations"] == [
+        {
+            "alignmentPeriod": "60s",
+            "perSeriesAligner": "ALIGN_RATE",
+            "crossSeriesReducer": "REDUCE_SUM",
+        }
+    ]
+    assert "2026-08-27" in policy["documentation"]["content"]
+    assert "600-second window" in policy["documentation"]["content"]
 
 
 def test_backup_copy_workflow_is_deterministic_and_idempotent() -> None:


### PR DESCRIPTION
The design record's three surviving items ([Settle Burst Protection](https://claude.ai/code/artifact/97f43809-7e74-4bdd-a5ed-220aea9003cf)), shipped as harm limitation while the admission end-state is decided.

**1 · Fast-burn contention alert.** The deployed lock-wait alert was enabled during the Aug 25 convoy and structurally could not fire: threshold 2 s/s but duration 600s, while the incident ran ~276 s/s for ~5 minutes and cleared first. New tier: 30 s/s sustained 300s, 60s alignment. Apply after merge: `bash scripts/deploy/spanner_reliability.sh --apply`

**2 · Overrun rollup** (the metric the trilemma decision needs, kept current hourly): `clickhouse/rollup_reservation_overruns.py` + `tr.reservation_overruns` (014/015) + hourly timer, mirroring the workspace-directory idiom; 2-hour overlap makes reruns idempotent. Baseline measured today over 31 days: 12.2% of settles overrun their hold, **$45.57/day**, 96% of dollars in ~0.7% of settles — cap-at-hold would cost ~$1,400/month, which argues for bounded exposure. Install on the VM: `bash scripts/deploy/clickhouse_live_ingestion.sh`

**3 · Per-key settle shed**: past 16 in-flight settles per `key_hash` (env `TR_SETTLE_PER_KEY_INFLIGHT_LIMIT`), `gateway_settle` returns a retryable 503 with `Retry-After: 1`, reusing #873's `KeyedConcurrencyAdmission`. Honestly scoped in-code: protects the instance's Spanner session pool; ~76 concurrent settles still survive per-instance gates at incident scale. Slot release is in `finally`; the 404 path never acquires; the budget decorator on the wrapper composes (`min` of deadlines) and covers the new pre-fetch.

**Verification** (Fable, unsandboxed): full suite **7,562 passed / 0 failed** (Sol's sandbox couldn't bind sockets for 19); mutation check re-run against the real guard — disabling it fails `test_settle_sheds_above_per_key_limit_and_completion_restores_capacity`, restoring goes green.

Authored by Sol (codex-cli); reviewed, tested, and mutation-verified by Fable. Needs admin merge (gate-on-ci only emits on push to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)