### PR TITLE
runbook: receipt-key collector cadence must beat the heartbeat threshold

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -567,12 +567,16 @@ https://docs.phala.com/phala-cloud/confidential-ai/confidential-model/confidenti
 
 The append-only inference-receipt key log is fed by a Cloud Scheduler job
 (created 2026-08-26; recreate with the same internal-token header as the
-settle-outbox drain if it is ever lost):
+settle-outbox drain if it is ever lost). The schedule MUST beat the fleet
+page's heartbeat staleness threshold (`HEARTBEAT_STALE_SECONDS` = 11 min in
+`synthetic/fleet.py`) or `job:receipt-key-collector` reads stale for most of
+every cycle and the remediator pages on a healthy collector — this happened
+at the original 30-minute cadence (fixed to 5 minutes 2026-08-28):
 
 ```
 gcloud scheduler jobs create http trusted-router-receipt-key-collect \
   --location us-central1 \
-  --schedule "*/30 * * * *" \
+  --schedule "*/5 * * * *" \
   --uri "https://trusted-router-vsjf6qu4la-uc.a.run.app/v1/internal/gateway/receipt-keys/collect" \
   --http-method POST \
   --headers "x-trustedrouter-internal-token=<internal gateway token>"


### PR DESCRIPTION
The 'receipt-key collector 11-29 minutes stale' ops signal was a false positive by construction: \`HEARTBEAT_STALE_SECONDS\` (11 min, \`synthetic/fleet.py\`, sized for 1-3 min synthetic cadences) applied to a 30-minute scheduler means a healthy collector reads stale for ~19 minutes of every cycle, re-paging every 30-min bucket. Verified live: 26/26 scheduler attempts in 12h returned HTTP 200 in 0.8-2.7s.

The live job is already updated to \`*/5 * * * *\` (userUpdateTime 2026-08-28T01:59:34Z); worst-case apparent age is now ~10 min (5-min cadence + 5-min bucket-start flooring), under the threshold. This PR records the constraint in the runbook's recreate instructions so the mismatch cannot be reintroduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)