### PR TITLE
Recover catalog refresh, CI, and repository mirror

### DIFF
--- a/scripts/check_price_spike.py
+++ b/scripts/check_price_spike.py
@@ -145,6 +145,94 @@ APPROVED_ENDPOINT_PRICE_TRANSITIONS = frozenset(
             Decimal("0.000006"),
             Decimal("0.00002"),
         ),
+        # DigitalOcean's official pricing page currently publishes these
+        # exact rates. Approve only the observed old-to-current transitions;
+        # every other DigitalOcean increase remains guarded:
+        # https://docs.digitalocean.com/products/inference/details/pricing/
+        (
+            "deepseek/deepseek-v3.2 [digitalocean:digitalocean:deepseek-3.2]",
+            "prompt",
+            Decimal("0.00000025"),
+            Decimal("0.0000005"),
+        ),
+        (
+            "deepseek/deepseek-v3.2 [digitalocean:digitalocean:deepseek-3.2]",
+            "completion",
+            Decimal("0.0000008"),
+            Decimal("0.0000016"),
+        ),
+        (
+            "deepseek/deepseek-v3.2 "
+            "[digitalocean:digitalocean:deepseek-3.2] cached-input",
+            "prompt",
+            Decimal("0.000000075"),
+            Decimal("0.00000015"),
+        ),
+        (
+            "deepseek/deepseek-v4-flash "
+            "[digitalocean:digitalocean:deepseek-4-flash]",
+            "prompt",
+            Decimal("0.000000068"),
+            Decimal("0.00000014"),
+        ),
+        (
+            "deepseek/deepseek-v4-pro "
+            "[digitalocean:digitalocean:deepseek-v4-pro]",
+            "prompt",
+            Decimal("0.00000087"),
+            Decimal("0.00000174"),
+        ),
+        (
+            "deepseek/deepseek-v4-pro "
+            "[digitalocean:digitalocean:deepseek-v4-pro]",
+            "completion",
+            Decimal("0.00000174"),
+            Decimal("0.00000348"),
+        ),
+        (
+            "deepseek/deepseek-v4-pro "
+            "[digitalocean:digitalocean:deepseek-v4-pro] cached-input",
+            "prompt",
+            Decimal("0.000000174"),
+            Decimal("0.000000348"),
+        ),
+        (
+            "xiaomi/mimo-v2.5-pro [digitalocean:digitalocean:mimo-v2.5-pro]",
+            "prompt",
+            Decimal("0.0000004"),
+            Decimal("0.0000008"),
+        ),
+        (
+            "xiaomi/mimo-v2.5-pro [digitalocean:digitalocean:mimo-v2.5-pro]",
+            "completion",
+            Decimal("0.0000015"),
+            Decimal("0.000003"),
+        ),
+        (
+            "xiaomi/mimo-v2.5-pro "
+            "[digitalocean:digitalocean:mimo-v2.5-pro] cached-input",
+            "prompt",
+            Decimal("0.00000008"),
+            Decimal("0.00000016"),
+        ),
+        (
+            "z-ai/glm-5.2 [digitalocean:digitalocean:glm-5.2]",
+            "prompt",
+            Decimal("0.0000007"),
+            Decimal("0.0000014"),
+        ),
+        (
+            "z-ai/glm-5.2 [digitalocean:digitalocean:glm-5.2]",
+            "completion",
+            Decimal("0.0000022"),
+            Decimal("0.0000044"),
+        ),
+        (
+            "z-ai/glm-5.2 [digitalocean:digitalocean:glm-5.2] cached-input",
+            "prompt",
+            Decimal("0.000000105"),
+            Decimal("0.00000021"),
+        ),
         # IO.NET's authenticated model catalog is the provider-owned source
         # used by the hourly adapter. The dashboard documentation confirms
         # that model-specific prices are published in the Models UI/API:
@@ -168,7 +256,7 @@ APPROVED_ENDPOINT_PRICE_TRANSITIONS = frozenset(
             "[io-net:io-net:zai-org/GLM-5.3-Flash] cached-input",
             "prompt",
             Decimal("0.00000003"),
-            Decimal("0.00000006"),
+            Decimal("0.000000075"),
         ),
     }
 )

--- a/scripts/deploy/mirror_repo_to_gcs.sh
+++ b/scripts/deploy/mirror_repo_to_gcs.sh
@@ -96,7 +96,10 @@ run() {
 
 ensure_bucket() {
   log "ensuring versioned private mirror bucket gs://${MIRROR_BUCKET}"
-  run gc services enable storage.googleapis.com
+  # Storage is a project bootstrap prerequisite, not a permission this daily
+  # backup job should hold. Re-enabling an already enabled API still requires
+  # serviceusage.services.enable, so doing it here made the least-privileged
+  # CI identity fail before it could inspect or update the mirror bucket.
   if ! gc storage buckets describe "gs://${MIRROR_BUCKET}" >/dev/null 2>&1; then
     run gc storage buckets create "gs://${MIRROR_BUCKET}" \
       --location=US \

--- a/tests/test_check_price_spike.py
+++ b/tests/test_check_price_spike.py
@@ -951,7 +951,7 @@ def test_confirmed_io_net_price_transitions_are_allowed() -> None:
     after = {
         mistral: {"prompt": "0.0000000635", "completion": "0.00000009875"},
         mistral_cached: {"prompt": "0.00000003175", "completion": "0"},
-        glm_cached: {"prompt": "0.00000006", "completion": "0"},
+        glm_cached: {"prompt": "0.000000075", "completion": "0"},
     }
 
     failures, changes, removed = check(before, after)
@@ -980,7 +980,7 @@ def test_confirmed_io_net_price_transitions_are_allowed() -> None:
             "z-ai/glm-5.3-flash "
             "[io-net:io-net:zai-org/GLM-5.3-Flash] cached-input",
             "0.00000003",
-            "0.000000061",
+            "0.000000076",
         ),
     ],
 )
@@ -996,3 +996,45 @@ def test_different_io_net_price_transitions_still_block(
 
     assert len(failures) == 1
     assert route in failures[0]
+
+
+def test_confirmed_digitalocean_official_price_transitions_are_allowed() -> None:
+    v32 = "deepseek/deepseek-v3.2 [digitalocean:digitalocean:deepseek-3.2]"
+    flash = (
+        "deepseek/deepseek-v4-flash "
+        "[digitalocean:digitalocean:deepseek-4-flash]"
+    )
+    pro = (
+        "deepseek/deepseek-v4-pro "
+        "[digitalocean:digitalocean:deepseek-v4-pro]"
+    )
+    mimo = "xiaomi/mimo-v2.5-pro [digitalocean:digitalocean:mimo-v2.5-pro]"
+    glm = "z-ai/glm-5.2 [digitalocean:digitalocean:glm-5.2]"
+    before = {
+        v32: {"prompt": "0.00000025", "completion": "0.0000008"},
+        f"{v32} cached-input": {"prompt": "0.000000075", "completion": "0"},
+        flash: {"prompt": "0.000000068", "completion": "0.000000168"},
+        pro: {"prompt": "0.00000087", "completion": "0.00000174"},
+        f"{pro} cached-input": {"prompt": "0.000000174", "completion": "0"},
+        mimo: {"prompt": "0.0000004", "completion": "0.0000015"},
+        f"{mimo} cached-input": {"prompt": "0.00000008", "completion": "0"},
+        glm: {"prompt": "0.0000007", "completion": "0.0000022"},
+        f"{glm} cached-input": {"prompt": "0.000000105", "completion": "0"},
+    }
+    after = {
+        v32: {"prompt": "0.0000005", "completion": "0.0000016"},
+        f"{v32} cached-input": {"prompt": "0.00000015", "completion": "0"},
+        flash: {"prompt": "0.00000014", "completion": "0.00000028"},
+        pro: {"prompt": "0.00000174", "completion": "0.00000348"},
+        f"{pro} cached-input": {"prompt": "0.000000348", "completion": "0"},
+        mimo: {"prompt": "0.0000008", "completion": "0.000003"},
+        f"{mimo} cached-input": {"prompt": "0.00000016", "completion": "0"},
+        glm: {"prompt": "0.0000014", "completion": "0.0000044"},
+        f"{glm} cached-input": {"prompt": "0.00000021", "completion": "0"},
+    }
+
+    failures, changes, removed = check(before, after)
+
+    assert failures == []
+    assert len(changes) == len(before)
+    assert removed == []

--- a/tests/test_mirror_repo_to_gcs.py
+++ b/tests/test_mirror_repo_to_gcs.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+SCRIPT = Path("scripts/deploy/mirror_repo_to_gcs.sh")
+
+
+def test_mirror_runtime_does_not_require_service_admin() -> None:
+    script = SCRIPT.read_text(encoding="utf-8")
+
+    assert "services enable" not in script
+    assert 'storage buckets describe "gs://${MIRROR_BUCKET}"' in script
+    assert 'storage buckets update "gs://${MIRROR_BUCKET}" --versioning' in script

--- a/tests/test_synthetic_run_rotation.py
+++ b/tests/test_synthetic_run_rotation.py
@@ -103,7 +103,13 @@ def no_network_probes(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
 
 async def _drain_background_runs() -> None:
     while tasks := tuple(synthetic_route._BACKGROUND_RUNS):  # noqa: SLF001
-        await asyncio.gather(*tasks)
+        try:
+            await asyncio.gather(*tasks)
+        finally:
+            # Task done callbacks run on the next event-loop turn. Remove the
+            # tasks explicitly so this cleanup cannot spin on completed tasks
+            # while starving the callbacks that would otherwise remove them.
+            synthetic_route._BACKGROUND_RUNS.difference_update(tasks)  # noqa: SLF001
 
 
 def _post_run(settings: Settings, body: dict[str, Any]) -> Any:


### PR DESCRIPTION
Summary:
- prevent synthetic test cleanup from spinning forever on completed background tasks
- approve only exact DigitalOcean and IONet transitions confirmed by provider-owned sources
- remove the GCS mirror's unnecessary runtime service-enablement call
- add regression coverage for the price gate and mirror permission boundary

Root causes:
- CI shard 6 starved asyncio task done callbacks during cleanup, so CI timed out and deploy correctly refused the commit
- the hourly refresh correctly blocked newly published provider rates
- the mirror workflow was absent from the GCP WIF workflow allowlist; after that live repair, the script attempted an unnecessary service-enablement operation

Validation:
- 1,260 passed, 58 skipped, 2 xfailed on the formerly wedged shard
- 85 focused tests passed
- Ruff and mypy passed
- bash syntax and diff checks passed