### PR TITLE
trust: AWS record mirrors release metadata and names its real TLS mode

### DIFF
--- a/src/trusted_router/services/trust_release.py
+++ b/src/trusted_router/services/trust_release.py
@@ -324,7 +324,30 @@ def validated_aws_metadata(payload: object) -> Mapping[str, Any]:
         # A record whose accepted set excludes its own current measurement would
         # have a verifier reject the enclave that is answering them.
         raise ValueError("AWS pcr0 is absent from its own accepted set")
-    return {"pcr0": pcr0, "accepted_pcr0s": accepted}
+    metadata: dict[str, Any] = {"pcr0": pcr0, "accepted_pcr0s": accepted}
+
+    if "release_state" in payload:
+        release_state = payload["release_state"]
+        if not isinstance(release_state, str) or release_state not in {"current", "rolling"}:
+            raise ValueError("invalid AWS release state")
+        metadata["release_state"] = release_state
+
+    source_commit_present = "source_commit" in payload
+    if source_commit_present:
+        source_commit = payload["source_commit"]
+        if not isinstance(source_commit, str) or _COMMIT_RE.fullmatch(source_commit) is None:
+            raise ValueError("invalid AWS source commit")
+        metadata["source_commit"] = source_commit
+
+    if "source_commit_provenance" in payload:
+        provenance = payload["source_commit_provenance"]
+        if not source_commit_present:
+            raise ValueError("AWS source commit provenance requires source commit")
+        if not isinstance(provenance, str) or provenance not in {"operator-asserted", "ci"}:
+            raise ValueError("invalid AWS source commit provenance")
+        metadata["source_commit_provenance"] = provenance
+
+    return metadata
 
 
 #: Optional descriptions a region entry may carry, copied verbatim and not

--- a/src/trusted_router/trust.py
+++ b/src/trusted_router/trust.py
@@ -141,11 +141,9 @@ def gcp_release_json(settings: Settings) -> str:
 def aws_release(settings: Settings, *, metadata: Mapping[str, Any] | None = None) -> dict[str, Any]:
     """Publish the AWS Nitro serving plane's measurement.
 
-    Deploy-time configured rather than resolved live: the enclave answers
-    attestation over a self-signed certificate, so fetching it from here would
-    mean the control plane making an unauthenticated TLS connection and parsing
-    CBOR on a public route. The staleness that trade buys is checked out of band
-    by scripts/verify_trust_measurements.py, which .github/workflows/trust-drift.yml
+    Mirrored from the plane-owned release record rather than resolved from a
+    live attestation here. Its staleness is checked out of band by
+    scripts/verify_trust_measurements.py, which .github/workflows/trust-drift.yml
     runs hourly in --strict mode — until that workflow existed, nothing executed
     the comparison this docstring relies on.
     """
@@ -155,31 +153,48 @@ def aws_release(settings: Settings, *, metadata: Mapping[str, Any] | None = None
     if metadata is not None:
         pcr0 = str(metadata.get("pcr0") or NOT_CONFIGURED)
         accepted = tuple(str(v) for v in metadata.get("accepted_pcr0s", []) if v != NOT_CONFIGURED)
+        mirrored_source_commit = metadata.get("source_commit")
+        source_commit_provenance = (
+            metadata.get("source_commit_provenance")
+            if mirrored_source_commit is not None
+            else None
+        )
+        release_state = metadata.get("release_state")
     else:
         pcr0 = settings.trust_aws_pcr0 or NOT_CONFIGURED
         accepted = settings.trust_aws_accepted_pcr0_list
+        mirrored_source_commit = None
+        source_commit_provenance = None
+        release_state = None
+    source_commit = mirrored_source_commit or settings.trust_aws_source_commit or NOT_CONFIGURED
     return {
         "platform": "aws-nitro-enclaves",
         "source_repo": ATTESTED_GATEWAY_REPO,
         "source_repositories": _source_repositories(),
-        "source_commit": settings.trust_aws_source_commit or NOT_CONFIGURED,
+        "source_commit": source_commit,
+        **(
+            {"source_commit_provenance": source_commit_provenance}
+            if source_commit_provenance is not None
+            else {}
+        ),
         "image_reference": settings.trust_aws_image_reference or NOT_CONFIGURED,
         # PCR0 measures the enclave image file: kernel, ramdisk, and
         # application, as built by nitro-cli build-enclave.
         "measurement_type": "nitro-pcr0-sha384",
         "pcr0": pcr0,
         "accepted_pcr0s": list(accepted),
+        **({"release_state": release_state} if release_state is not None else {}),
         "release_metadata_status": ("configured" if accepted else NOT_CONFIGURED),
         "attestation_format": "cose-sign1-nitro-attestation-document",
         "attestation_root": AWS_ATTESTATION_ROOT,
         "api_base_url": f"https://{AWS_API_HOSTNAME}/v1",
         "tls": {
-            # Deliberately not a public-CA certificate. The enclave generates
-            # its own key, and binds the certificate fingerprint and the TLS
-            # exporter value into the attestation's user_data, so the connection
-            # you are on is the connection that was attested. Chain validation
-            # is replaced by that binding, not dropped.
-            "mode": "attested-self-signed-inside-enclave",
+            # The enclave obtains a public-CA (Let's Encrypt) certificate via
+            # ACME dns01 running inside the enclave, so normal WebPKI chain
+            # validation works. The attestation still binds the served
+            # certificate's SHA-256 into user_data[0:32]; that stronger anchor
+            # is unchanged from the self-signed era.
+            "mode": "acme-inside-nitro-enclave",
             "hostname": AWS_API_HOSTNAME,
             # Measured against the live enclave 2026-08-15, 8/8 samples:
             # user_data is 96 bytes and [0:32] is SHA-256 of the served

--- a/tests/test_trust_release.py
+++ b/tests/test_trust_release.py
@@ -11,6 +11,7 @@ from trusted_router.main import create_app
 from trusted_router.services.trust_release import (
     TrustReleaseResolver,
     TrustReleaseUnavailable,
+    validated_aws_metadata,
 )
 
 SOURCE_COMMIT = "5e7c096"
@@ -348,9 +349,7 @@ def test_aws_and_azure_release_records_publish_configured_measurements() -> None
     assert aws.json()["pcr0"] == AWS_PCR0
     assert aws.json()["accepted_pcr0s"] == [AWS_PCR0]
     assert aws.json()["measurement_type"] == "nitro-pcr0-sha384"
-    # The self-signed certificate is the design; the page must say what stands
-    # in for chain validation rather than leaving it looking like a weakness.
-    assert aws.json()["tls"]["mode"] == "attested-self-signed-inside-enclave"
+    assert aws.json()["tls"]["mode"] == "acme-inside-nitro-enclave"
     assert "exporter" in aws.json()["tls"]["certificate_binding"]
 
     assert azure.status_code == 200
@@ -590,6 +589,73 @@ def test_aws_record_is_mirrored_from_the_plane_not_control_plane_config(
 
     assert record["pcr0"] == upstream, "the mirrored record must win over local config"
     assert record["accepted_pcr0s"] == [upstream]
+
+
+def test_aws_release_metadata_is_validated_and_mirrored(httpx_mock: HTTPXMock) -> None:
+    upstream = "ab" * 48
+    payload = _aws_upstream(upstream, [upstream])
+    payload.update(
+        {
+            "release_state": "current",
+            "source_commit": "445d68c",
+            "source_commit_provenance": "operator-asserted",
+            "unexpected": "must not pass through",
+        }
+    )
+    httpx_mock.add_response(
+        url=re.compile(r"https://trust\.example/aws\.json\?tr_cache_bucket=\d+"),
+        json=payload,
+    )
+    settings = Settings(
+        environment="test", trust_aws_release_url="https://trust.example/aws.json"
+    )
+    with TestClient(create_app(settings, init_observability=False)) as client:
+        record = client.get("/trust/aws-release.json").json()
+
+    assert record["release_state"] == "current"
+    assert record["source_commit"] == "445d68c"
+    assert record["source_commit_provenance"] == "operator-asserted"
+    assert "unexpected" not in record
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("release_state", "bogus"), ("source_commit", "zzz")],
+)
+def test_aws_release_metadata_refuses_invalid_new_fields(field: str, value: str) -> None:
+    upstream = "ab" * 48
+    payload = _aws_upstream(upstream, [upstream])
+    payload[field] = value
+
+    with pytest.raises(ValueError):
+        validated_aws_metadata(payload)
+
+
+@pytest.mark.parametrize(
+    ("configured_commit", "expected_commit"),
+    [(None, "not-configured"), ("1234567", "1234567")],
+)
+def test_aws_release_without_new_metadata_uses_source_commit_fallback(
+    httpx_mock: HTTPXMock,
+    configured_commit: str | None,
+    expected_commit: str,
+) -> None:
+    upstream = "ab" * 48
+    httpx_mock.add_response(
+        url=re.compile(r"https://trust\.example/aws\.json\?tr_cache_bucket=\d+"),
+        json=_aws_upstream(upstream, [upstream]),
+    )
+    settings = Settings(
+        environment="test",
+        trust_aws_release_url="https://trust.example/aws.json",
+        trust_aws_source_commit=configured_commit,
+    )
+    with TestClient(create_app(settings, init_observability=False)) as client:
+        record = client.get("/trust/aws-release.json").json()
+
+    assert "release_state" not in record
+    assert record["source_commit"] == expected_commit
+    assert "source_commit_provenance" not in record
 
 
 def test_unreachable_upstream_falls_back_without_claiming_it_is_live(


### PR DESCRIPTION
Live-verified drift fix: api-aws serves a Let's Encrypt cert (ACME dns01 inside the enclave, the dns01-renewal release) while the published record still claimed `attested-self-signed-inside-enclave`. Mode is now `acme-inside-nitro-enclave`; the attestation's cert binding (user_data[0:32] = SHA-256 of served cert DER, verified live 2026-08-28) is unchanged and remains the stronger anchor.

Also widens the AWS mirror whitelist to `release_state` / `source_commit` / `source_commit_provenance` with strict refusal validation, so the live record reaches parity with the signed plane record instead of showing not-configured. Tests: 28 passed; refusal paths mutation-tested (validation bypassed → new tests fail → restored). Companion proxy PR updates the static record and re-points check-public-tls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)