### PR TITLE
Fix Phala GLM 5.2 upstream transition

### DIFF
--- a/scripts/pricing/providers/phala.py
+++ b/scripts/pricing/providers/phala.py
@@ -87,7 +87,6 @@ _NATIVE_TO_OR_ID = {
     "phala/gemma-3-27b-it": "google/gemma-3-27b-it",
     "phala/glm-5": "z-ai/glm-5",
     "phala/glm-5.1": "z-ai/glm-5.1",
-    "phala/glm-5.2": "z-ai/glm-5.2",
     "phala/glm-4.7": "z-ai/glm-4.7",
     "phala/glm-4.7-flash": "z-ai/glm-4.7-flash",
     "phala/kimi-k2.5": "moonshotai/kimi-k2.5",
@@ -103,8 +102,10 @@ _NATIVE_TO_OR_ID = {
     "phala/minimax-m2.5": "minimax/minimax-m2.5",
 }
 _STANDARD_PASSTHROUGH_TO_OR_ID = {
-    # Direct visible-content canary passed on 2026-07-29. This is not a
-    # phala/* Confidential AI ID, so catalog_data.py forces Standard privacy.
+    # These are not phala/* Confidential AI IDs, so catalog_data.py forces
+    # Standard privacy. GLM 5.2 moved from phala/glm-5.2 to the upstream-author
+    # ID on 2026-08-27; a direct visible-content canary returned exact PONG.
+    "z-ai/glm-5.2": "z-ai/glm-5.2",
     "moonshotai/kimi-k3": "moonshotai/kimi-k3",
     "z-ai/glm-5.3-flash": "z-ai/glm-5.3-flash",
 }

--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -305,7 +305,11 @@ _MODEL_PROVIDER_PRIVACY_OVERRIDES: dict[tuple[str, str], ModelProviderPrivacyOve
                 "confidential-model/confidential-ai-api"
             ),
         )
-        for model_id in ("moonshotai/kimi-k3", "z-ai/glm-5.3-flash")
+        for model_id in (
+            "moonshotai/kimi-k3",
+            "z-ai/glm-5.2",
+            "z-ai/glm-5.3-flash",
+        )
     },
     **{
         (model_id, "venice"): ModelProviderPrivacyOverride(

--- a/src/trusted_router/data/provider_models/phala.json
+++ b/src/trusted_router/data/provider_models/phala.json
@@ -7,20 +7,20 @@
   "models": [
     {
       "id": "z-ai/glm-5.2",
-      "upstream_id": "phala/glm-5.2",
-      "display_name": "Phala GLM 5.2",
+      "upstream_id": "z-ai/glm-5.2",
+      "display_name": "Z.ai: GLM 5.2",
       "title": "z-ai/glm-5.2",
       "context_length": 1048576,
       "max_output_tokens": 131072,
-      "input_token_price_per_m": 1400000,
-      "output_token_price_per_m": 4400000,
-      "cached_input_token_price_per_m": 700000,
+      "input_token_price_per_m": 1260000,
+      "output_token_price_per_m": 3000000,
+      "cached_input_token_price_per_m": 220000,
       "model_type": "chat",
       "features": [
         "reasoning",
         "function-calling",
         "structured-outputs",
-        "confidential-compute"
+        "serverless"
       ],
       "input_modalities": [
         "text"
@@ -32,7 +32,24 @@
         "chat/completions"
       ],
       "status": 1,
-      "missing_since": "2026-07-30"
+      "supported_features": [
+        "json_mode",
+        "reasoning",
+        "structured_outputs",
+        "tools"
+      ],
+      "supported_sampling_parameters": [
+        "frequency_penalty",
+        "max_tokens",
+        "min_p",
+        "presence_penalty",
+        "repetition_penalty",
+        "seed",
+        "stop",
+        "temperature",
+        "top_k",
+        "top_p"
+      ]
     },
     {
       "id": "moonshotai/kimi-k3",

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -2261,7 +2261,7 @@ def test_glm_52_supplements_publish_current_model_across_providers() -> None:
     assert deepinfra.upstream_id == "zai-org/GLM-5.2"
     assert fireworks.upstream_id == "accounts/fireworks/models/glm-5p2"
     assert novita.upstream_id == "zai-org/glm-5.2"
-    assert phala.upstream_id == "phala/glm-5.2"
+    assert phala.upstream_id == "z-ai/glm-5.2"
     assert siliconflow.upstream_id == "zai-org/GLM-5.2"
     assert tinfoil.upstream_id == "glm-5-2"
     assert together.upstream_id == "zai-org/GLM-5.2"

--- a/tests/test_kimi_k3_gmi_phala.py
+++ b/tests/test_kimi_k3_gmi_phala.py
@@ -280,6 +280,17 @@ def test_phala_kimi_k3_pass_through_is_standard_not_confidential() -> None:
     assert endpoint_e2ee(endpoint) is False
 
 
+def test_phala_glm_52_pass_through_is_standard_not_confidential() -> None:
+    endpoint = MODEL_ENDPOINTS["z-ai/glm-5.2@phala/prepaid"]
+
+    assert endpoint.upstream_id == "z-ai/glm-5.2"
+    assert endpoint_privacy_tier(endpoint) == PRIVACY_TIER_STANDARD
+    assert endpoint_stores_content(endpoint) is True
+    assert endpoint_zero_data_retention(endpoint) is False
+    assert endpoint_confidential_compute(endpoint) is False
+    assert endpoint_e2ee(endpoint) is False
+
+
 def test_phala_glm_53_pass_through_is_standard_not_confidential() -> None:
     endpoint = MODEL_ENDPOINTS["z-ai/glm-5.3-flash@phala/prepaid"]
 

--- a/tests/test_phala_july_2026_lifecycle.py
+++ b/tests/test_phala_july_2026_lifecycle.py
@@ -122,8 +122,23 @@ def test_phala_parser_publishes_confidential_and_standard_pass_through_routes(
     payload = {
         "data": [
             {
-                "id": "phala/glm-5.2",
-                "pricing": {"prompt": "0.0000003", "completion": "0.000002"},
+                "id": "z-ai/glm-5.2",
+                "name": "Z.ai: GLM 5.2",
+                "context_length": 1_048_576,
+                "max_output_length": 131_072,
+                "input_modalities": ["text"],
+                "output_modalities": ["text"],
+                "supported_features": [
+                    "json_mode",
+                    "reasoning",
+                    "structured_outputs",
+                    "tools",
+                ],
+                "pricing": {
+                    "prompt": "0.00000126",
+                    "completion": "0.000003",
+                    "input_cache_read": "0.00000022",
+                },
             },
             {
                 "id": "openai/gpt-5.5",
@@ -198,7 +213,7 @@ def test_phala_parser_publishes_confidential_and_standard_pass_through_routes(
         "z-ai/glm-5.2",
         "z-ai/glm-5.3-flash",
     }
-    assert phala.UPSTREAM_ID_MAP["z-ai/glm-5.2"] == "phala/glm-5.2"
+    assert phala.UPSTREAM_ID_MAP["z-ai/glm-5.2"] == "z-ai/glm-5.2"
     assert phala.UPSTREAM_ID_MAP["moonshotai/kimi-k3"] == "moonshotai/kimi-k3"
     assert phala.UPSTREAM_ID_MAP["z-ai/glm-5.3-flash"] == "z-ai/glm-5.3-flash"
     assert result.prices["moonshotai/kimi-k3"] == ModelPrice(
@@ -210,6 +225,10 @@ def test_phala_parser_publishes_confidential_and_standard_pass_through_routes(
         150_000,
         500_000,
         prompt_cached_micro_per_m=30_000,
+    )
+    assert (
+        phala._DISCOVERED_MANIFEST_ROWS["z-ai/glm-5.2"]["upstream_id"]
+        == "z-ai/glm-5.2"
     )
     assert (
         phala._DISCOVERED_MANIFEST_ROWS["moonshotai/kimi-k3"]["upstream_id"] == "moonshotai/kimi-k3"
@@ -247,6 +266,10 @@ def test_phala_parser_publishes_confidential_and_standard_pass_through_routes(
 
     written = json.loads(manifest_path.read_text(encoding="utf-8"))
     rows_by_id = {row["id"]: row for row in written["models"]}
+    assert rows_by_id["z-ai/glm-5.2"]["upstream_id"] == "z-ai/glm-5.2"
+    assert rows_by_id["z-ai/glm-5.2"]["input_token_price_per_m"] == 1_260_000
+    assert rows_by_id["z-ai/glm-5.2"]["cached_input_token_price_per_m"] == 220_000
+    assert rows_by_id["z-ai/glm-5.2"]["output_token_price_per_m"] == 3_000_000
     assert rows_by_id["moonshotai/kimi-k3"]["upstream_id"] == "moonshotai/kimi-k3"
     assert rows_by_id["moonshotai/kimi-k3"]["input_token_price_per_m"] == 3_000_000
     assert rows_by_id["z-ai/glm-5.3-flash"]["input_token_price_per_m"] == 150_000


### PR DESCRIPTION
## Summary
- follow Phala's live GLM 5.2 ID transition from `phala/glm-5.2` to `z-ai/glm-5.2`
- retain exact live prices and capability metadata in the generated manifest
- conservatively classify this upstream-author route as Standard, not confidential/ZDR/E2E
- add parser, catalog, route, and privacy regression coverage

## Live verification
- Phala `/v1/models` reports `z-ai/glm-5.2` at 1.26/3.00 USD per million input/output tokens and 0.22 cached input
- direct authenticated non-streaming canary returned exact `PONG` with integer usage

## Tests
- `uv run pytest -q tests/test_check_price_coverage.py tests/test_phala_july_2026_lifecycle.py tests/test_kimi_k3_gmi_phala.py tests/test_catalog_routing_contracts.py`
- `uv run mypy`
- `uv run ruff check ...`
- `uv run python -m scripts.check_format_ordering`
- `git diff --check`