### PR TITLE
Verify generated price refreshes before protected push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  # Bot-authored pricing commits use GITHUB_TOKEN, so GitHub suppresses
-  # their normal push-triggered workflows. refresh-prices.yml dispatches
-  # CI explicitly for the generated commit before dispatching deploy.yml.
+  # Bot-authored pricing branches use GITHUB_TOKEN, so GitHub suppresses their
+  # normal push-triggered workflows. refresh-prices.yml dispatches CI for the
+  # generated branch before advancing protected main with the checked SHA.
   workflow_dispatch: {}
 
 # Independent jobs instead of one serial pipeline: wall time becomes the

--- a/.github/workflows/refresh-prices.yml
+++ b/.github/workflows/refresh-prices.yml
@@ -33,7 +33,7 @@ concurrency:
 
 permissions:
   id-token: write   # for Workload Identity Federation
-  contents: write   # auto-commit + push the snapshot diff to main
+  contents: write   # push the generated snapshot branch
   actions: write    # dispatch ci.yml + deploy.yml for a new snapshot
   issues: write     # upsert the durable model-discovery coverage alert
                     # (GITHUB_TOKEN-pushed commits don't auto-trigger
@@ -287,7 +287,7 @@ jobs:
         # The refresh can change parsers, provider manifests, model ownership,
         # routing, pricing, and SEO output in one pass. GitHub suppresses
         # push-triggered CI for commits created with GITHUB_TOKEN, so these
-        # checks must run before the bot is allowed to move main. This keeps
+        # checks must run before the bot is allowed to publish. This keeps
         # the last known-good snapshot live when a provider page changes in a
         # way the self-healer or catalog merger does not understand yet.
         run: |
@@ -295,7 +295,7 @@ jobs:
           uv run mypy
           uv run pytest -q
 
-      - name: Commit and push if changed
+      - name: Commit, verify, and push if changed
         run: |
           set -euo pipefail
           git config user.name "trustedrouter-pricing-bot"
@@ -329,42 +329,83 @@ jobs:
 
           git commit -F /tmp/commit-msg.txt
 
-          # Push with retry. A parallel bot run, a human commit, or the
-          # release-digest bot can land on main between our checkout and push
-          # (non-fast-forward). Rebase our freshly-computed snapshot on top and
-          # retry instead of failing the run. A genuine snapshot↔snapshot
-          # rebase conflict is a CLEAN skip — the next hourly run recomputes
-          # from live prices and recommits (self-healing). Fixes the recurring
-          # "failed to push some refs" races.
-          pushed=""
-          for attempt in 1 2 3; do
-            if git push origin HEAD:main; then pushed=1; break; fi
-            echo "push rejected (attempt ${attempt}); rebasing onto origin/main"
-            git fetch -q origin main
-            if ! git rebase origin/main; then
-              git rebase --abort || true
-              echo "::warning::price-refresh: snapshot rebase conflict — skipping; next hourly run recovers"
-              exit 0
+          # Main requires CI checks before accepting a commit, so publish a
+          # unique temporary branch and attach exact-SHA checks there first.
+          # The organization intentionally forbids Actions-created PRs.
+          BRANCH="automation/price-refresh-${GITHUB_RUN_ID}"
+          SNAPSHOT_SHA=$(git rev-parse HEAD)
+          cleanup_branch() {
+            git push origin --delete "${BRANCH}" >/dev/null 2>&1 || true
+          }
+          trap cleanup_branch EXIT
+          git push origin "HEAD:refs/heads/${BRANCH}"
+          gh workflow run ci.yml \
+            --ref "${BRANCH}" \
+            --repo "${GITHUB_REPOSITORY}"
+          echo "  dispatched ci.yml for generated snapshot branch"
+
+          ci_passed=""
+          for _ in $(seq 1 180); do
+            run_json=$(gh run list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --workflow ci.yml \
+              --branch "${BRANCH}" \
+              --event workflow_dispatch \
+              --json databaseId,headSha,status,conclusion \
+              --jq "map(select(.headSha == \"${SNAPSHOT_SHA}\"))[0] // empty")
+            if [ -n "${run_json}" ]; then
+              status=$(jq -r .status <<<"${run_json}")
+              conclusion=$(jq -r .conclusion <<<"${run_json}")
+              echo "  ci run $(jq -r .databaseId <<<"${run_json}"): status=${status} conclusion=${conclusion:-<pending>}"
+              if [ "${status}" = "completed" ]; then
+                if [ "${conclusion}" = "success" ]; then
+                  ci_passed=1
+                  break
+                fi
+                echo "generated snapshot CI concluded '${conclusion}'"
+                exit 1
+              fi
             fi
+            sleep 15
           done
-          if [ -z "${pushed}" ]; then
-            echo "push still failing after retries"
+          if [ -z "${ci_passed}" ]; then
+            echo "generated snapshot CI did not pass within 45 minutes"
             exit 1
           fi
 
-          # Bot-pushed commits don't auto-trigger downstream workflows
-          # (GHA loop prevention applies to the `push` event when the
-          # token is GITHUB_TOKEN). `workflow_dispatch` is the only
-          # exception. Dispatch CI first, then deploy; deploy.yml's
-          # same-SHA gate waits for that CI run to pass before rollout.
-          # Failing either dispatch is a release failure, not a warning:
-          # otherwise a generated catalog can land on main but never
-          # become deployable.
+          # Never rebase generated output after checking it: that would create
+          # an untested SHA. If main moved during refresh/CI, queue a fresh run
+          # from the new head and discard this temporary branch.
+          git fetch -q origin main
+          if [ "$(git rev-parse origin/main)" != "${GITHUB_SHA}" ]; then
+            echo "::warning::main advanced during price refresh; queueing a fresh recomputation"
+            gh workflow run refresh-prices.yml \
+              --ref main \
+              --repo "${GITHUB_REPOSITORY}"
+            exit 0
+          fi
+
+          push_log=$(mktemp)
+          if ! git push origin "HEAD:refs/heads/main" 2>"${push_log}"; then
+            cat "${push_log}" >&2
+            git fetch -q origin main
+            if [ "$(git rev-parse origin/main)" != "${GITHUB_SHA}" ]; then
+              echo "::warning::main raced the checked snapshot push; queueing a fresh recomputation"
+              gh workflow run refresh-prices.yml \
+                --ref main \
+                --repo "${GITHUB_REPOSITORY}"
+              exit 0
+            fi
+            echo "branch protection rejected an exact SHA with successful required checks"
+            exit 1
+          fi
+
+          # GITHUB_TOKEN pushes do not start push-triggered workflows. The
+          # exact SHA already has a successful ci.yml run, so dispatch the
+          # staged deploy; deploy.yml independently verifies that same SHA.
           # Discovered live on 2026-05-13: hourly bot was committing
           # but TR's deployed catalog was stuck on a 3-phala-endpoint
           # snapshot for hours because deploy.yml never auto-fired.
-          gh workflow run ci.yml --ref main --repo "${GITHUB_REPOSITORY}"
-          echo "  dispatched ci.yml for new snapshot"
           gh workflow run deploy.yml --ref main --repo "${GITHUB_REPOSITORY}" \
             -f deploy_synthetic_monitor=true
           echo "  dispatched deploy.yml for new snapshot"

--- a/tests/test_provider_wave3_catalogs.py
+++ b/tests/test_provider_wave3_catalogs.py
@@ -1203,7 +1203,7 @@ def test_price_coverage_failure_blocks_commit_and_deploy() -> None:
 
     audit = workflow.index("- name: Price-source coverage audit")
     blocker = workflow.index("- name: Block unsafe coverage before publication")
-    commit = workflow.index("- name: Commit and push if changed")
+    commit = workflow.index("- name: Commit, verify, and push if changed")
     assert audit < blocker < commit
     blocker_step = workflow[blocker:commit]
     assert "steps.coverage_audit.outcome == 'failure'" in blocker_step

--- a/tests/test_refresh_workflow_dispatch.py
+++ b/tests/test_refresh_workflow_dispatch.py
@@ -9,18 +9,33 @@ def test_ci_accepts_explicit_dispatch_for_bot_commits() -> None:
     assert "workflow_dispatch: {}" in workflow
 
 
-def test_price_refresh_dispatches_ci_before_deploy_and_fails_closed() -> None:
+def test_price_refresh_checks_exact_branch_sha_before_advancing_main() -> None:
     workflow = (ROOT / ".github/workflows/refresh-prices.yml").read_text(
         encoding="utf-8"
     )
-    ci_dispatch = 'gh workflow run ci.yml --ref main --repo "${GITHUB_REPOSITORY}"'
+    branch_ci_dispatch = "gh workflow run ci.yml \\\n"
     deploy_dispatch = (
         'gh workflow run deploy.yml --ref main --repo "${GITHUB_REPOSITORY}"'
     )
 
-    assert ci_dispatch in workflow
+    assert 'BRANCH="automation/price-refresh-${GITHUB_RUN_ID}"' in workflow
+    assert "SNAPSHOT_SHA=$(git rev-parse HEAD)" in workflow
+    assert 'git push origin "HEAD:refs/heads/${BRANCH}"' in workflow
+    assert branch_ci_dispatch in workflow
+    assert '--ref "${BRANCH}"' in workflow
+    assert '--branch "${BRANCH}"' in workflow
+    assert 'select(.headSha == \\"${SNAPSHOT_SHA}\\")' in workflow
+    assert 'if [ "${conclusion}" = "success" ]' in workflow
+    assert 'if [ "$(git rev-parse origin/main)" != "${GITHUB_SHA}" ]' in workflow
+    assert "git rebase" not in workflow
+    main_push = 'git push origin "HEAD:refs/heads/main"'
+    assert main_push in workflow
     assert deploy_dispatch in workflow
-    assert workflow.index(ci_dispatch) < workflow.index(deploy_dispatch)
+    assert workflow.index(branch_ci_dispatch) < workflow.index(main_push)
+    assert workflow.index('if [ "${conclusion}" = "success" ]') < workflow.index(
+        main_push
+    )
+    assert workflow.index(main_push) < workflow.index(deploy_dispatch)
     assert "WARN: failed to dispatch deploy.yml" not in workflow
 
 
@@ -29,7 +44,7 @@ def test_price_refresh_validates_generated_catalog_before_committing() -> None:
         encoding="utf-8"
     )
     validation_step = "- name: Validate generated catalog before commit"
-    commit_step = "- name: Commit and push if changed"
+    commit_step = "- name: Commit, verify, and push if changed"
 
     assert validation_step in workflow
     assert workflow.index(validation_step) < workflow.index(commit_step)
@@ -46,7 +61,7 @@ def test_model_discovery_gap_alerts_without_freezing_safe_provider_updates() -> 
         encoding="utf-8"
     )
     coverage_step = "- name: Price-source coverage audit"
-    commit_step = "- name: Commit and push if changed"
+    commit_step = "- name: Commit, verify, and push if changed"
     final_alert = "- name: Reconcile model-discovery coverage issue"
 
     assert workflow.index(coverage_step) < workflow.index(commit_step)


### PR DESCRIPTION
## Root cause
Main now requires four status checks before accepting a commit. The hourly refresh attempted to push its generated commit directly and only dispatch CI afterward, so branch protection correctly rejected it even though every catalog validation passed.

## Fix
- publish each generated snapshot to a unique temporary branch
- explicitly dispatch and wait for exact-SHA CI on that branch
- advance protected main only with the already-green SHA
- if main moves, discard the generated branch and queue a fresh recomputation instead of rebasing untested output
- explicitly dispatch the staged deploy after publication
- retain every pre-publication Ruff, mypy, pytest, spike, and coverage gate

The organization-level ban on Actions-created PRs remains unchanged, and main branch protection is not weakened.

## Tests
- workflow YAML parse
- 127 focused workflow, pricing, spike, and deployment tests
- Ruff
- git diff --check