### PR TITLE
drain: bound every wait; systemd watchdog kills silent hangs

### DIFF
--- a/clickhouse/_sdnotify.py
+++ b/clickhouse/_sdnotify.py
@@ -1,0 +1,26 @@
+"""Minimal systemd notification support without a runtime dependency."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import socket
+
+
+def sd_notify(state: str) -> None:
+    """Send *state* to systemd, or do nothing outside a notify unit.
+
+    Send failures are swallowed, matching systemd's own sd_notify(3): a stale
+    NOTIFY_SOCKET (manual run with a copied environment) or a transient socket
+    error must not crash the drain loop it exists to keep alive — the watchdog
+    then fires, which is the correct failure mode, not an exception here.
+    """
+    address = os.environ.get("NOTIFY_SOCKET")
+    if not address:
+        return
+    if address.startswith("@"):
+        address = "\0" + address[1:]
+    with contextlib.suppress(OSError):
+        with socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as notifier:
+            notifier.connect(address)
+            notifier.sendall(state.encode())

--- a/clickhouse/ingest_operational_outbox.py
+++ b/clickhouse/ingest_operational_outbox.py
@@ -14,6 +14,8 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, Protocol
 
+from clickhouse._sdnotify import sd_notify
+
 PROJECT = "quill-cloud-proxy"
 SPANNER_INSTANCE = "trusted-router-nam6"
 SPANNER_DATABASE = "trusted-router"
@@ -742,7 +744,9 @@ def main() -> int:
     # watermark this replaces was the single largest query load on the
     # production Spanner instance (measured 2026-08-25).
     idle_delay = max(0.1, args.poll_seconds)
+    sd_notify("READY=1")
     while True:
+        sd_notify("WATCHDOG=1")
         result = drain_once(source, writer, batch_size=max(1, args.batch_size))
         if result.fetched:
             log.info(

--- a/clickhouse/ingest_operational_outbox_postgres.py
+++ b/clickhouse/ingest_operational_outbox_postgres.py
@@ -187,6 +187,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
+from clickhouse._sdnotify import sd_notify
 from clickhouse.ingest_operational_outbox import (
     ClickHouseOperationalWriter,
     OperationalOutboxRow,
@@ -317,6 +318,21 @@ DEFAULT_REPLICA_TIMEOUT_SECONDS = 60.0
 #: Age of the oldest undelivered row at which the backlog stops being normal
 #: catch-up and becomes something an operator has to decide about.
 DEFAULT_MAX_LAG_SECONDS = 3600.0
+
+#: Aurora DSQL expires connections at roughly one hour. Reconnect while the
+#: handle is still predictably usable instead of discovering expiry mid-poll.
+CONNECTION_MAX_AGE_SECONDS = 45 * 60
+
+LIBPQ_SOCKET_BOUNDS = {
+    "connect_timeout": 10,
+    "keepalives": 1,
+    "keepalives_idle": 30,
+    "keepalives_interval": 10,
+    "keepalives_count": 3,
+    # Milliseconds. Linux bounds unacknowledged writes and idle-read stalls;
+    # it is a client socket option and needs no support from DSQL.
+    "tcp_user_timeout": 30_000,
+}
 
 #: Failures a single target may accumulate in one sweep before the rest of that
 #: sweep skips it. Bounds a wedged node's cost from "one timeout per shard" to
@@ -738,6 +754,7 @@ class PostgresOperationalOutboxSource:
         self._iam_region = iam_region
         self._attempts = attempts
         self._connection: Any = None
+        self._connected_at: float | None = None
 
     # -- connection ---------------------------------------------------------
 
@@ -745,6 +762,11 @@ class PostgresOperationalOutboxSource:
         if self._connection is not None:
             self._connection.close()
             self._connection = None
+            self._connected_at = None
+
+    def _record_connection(self, connection: Any) -> Any:
+        self._connected_at = time.monotonic()
+        return connection
 
     def _connect(self) -> Any:
         if not self._iam_auth:
@@ -757,7 +779,14 @@ class PostgresOperationalOutboxSource:
                     "DSN must not contain a password; set PGPASSWORD instead so the "
                     "secret does not appear in argv"
                 )
-            return self._psycopg.connect(self._dsn, autocommit=False)
+            return self._record_connection(
+                self._psycopg.connect(
+                    self._dsn,
+                    autocommit=False,
+                    options="-c statement_timeout=60000",
+                    **LIBPQ_SOCKET_BOUNDS,
+                )
+            )
         if self._iam_auth != "aws-dsql":
             raise ValueError(
                 f"Unsupported --iam-auth value {self._iam_auth!r}; expected 'aws-dsql' or empty"
@@ -785,11 +814,26 @@ class PostgresOperationalOutboxSource:
             else client.generate_db_connect_auth_token
         )
         token = mint(Hostname=hostname, Region=region, ExpiresIn=900)
-        return self._psycopg.connect(self._dsn, password=token, autocommit=False)
+        # Do not send statement_timeout to DSQL: support for that GUC is not
+        # assured. The libpq/kernel socket bounds remain entirely client-side.
+        return self._record_connection(
+            self._psycopg.connect(
+                self._dsn,
+                password=token,
+                autocommit=False,
+                **LIBPQ_SOCKET_BOUNDS,
+            )
+        )
 
     def _live_connection(self) -> Any:
         # Reused across statements: a fresh connect per shard would be 64+
         # handshakes per sweep, and on DSQL each one also mints an IAM token.
+        if (
+            self._connection is not None
+            and self._connected_at is not None
+            and time.monotonic() - self._connected_at >= CONNECTION_MAX_AGE_SECONDS
+        ):
+            self._discard_connection()
         if self._connection is None or getattr(self._connection, "closed", False):
             self._connection = self._connect()
         return self._connection
@@ -813,6 +857,7 @@ class PostgresOperationalOutboxSource:
 
     def _discard_connection(self) -> None:
         connection, self._connection = self._connection, None
+        self._connected_at = None
         if connection is None:
             return
         # Already broken; closing is best-effort cleanup, not a result.
@@ -997,6 +1042,9 @@ def drain_once(
         begin_sweep()
     started = time.monotonic()
     for shard in range(shard_count):
+        # A busy sweep can run much longer than WatchdogSec. Ping before each
+        # independently bounded shard so healthy backlog catch-up is not killed.
+        sd_notify("WATCHDOG=1")
         try:
             result = drain_shard_once(
                 source, writer, shard=shard, batch_size=batch_size, cursors=cursors
@@ -1104,7 +1152,9 @@ def main() -> int:
     # that could not be deleted is stepped over, and that only helps if the next
     # sweep remembers where it got to.
     cursors: dict[int, tuple[str, str]] = {}
+    sd_notify("READY=1")
     while True:
+        sd_notify("WATCHDOG=1")
         result = drain_once(
             source,
             writer,

--- a/clickhouse/tr-clickhouse-operational-ingest-postgres.service
+++ b/clickhouse/tr-clickhouse-operational-ingest-postgres.service
@@ -4,7 +4,11 @@ After=network-online.target clickhouse-server.service
 Wants=network-online.target
 
 [Service]
-Type=simple
+Type=notify
+NotifyAccess=main
+# The drain pings per shard. One normal shard is bounded by 60s Postgres fetch
+# + 60s ClickHouse write + 60s Postgres delete = 180s; 3x is 540s, plus 60s.
+WatchdogSec=600
 User=tr-clickhouse-ingest
 Group=tr-clickhouse-ingest
 WorkingDirectory=/opt/tr-clickhouse

--- a/clickhouse/tr-clickhouse-operational-ingest.service
+++ b/clickhouse/tr-clickhouse-operational-ingest.service
@@ -4,7 +4,11 @@ After=network-online.target clickhouse-server.service
 Wants=network-online.target
 
 [Service]
-Type=simple
+Type=notify
+NotifyAccess=main
+# Spanner has no psycopg socket knobs; 600s bounds a vanished client/server
+# exchange while leaving 3x headroom over the Postgres sibling's 180s shard.
+WatchdogSec=600
 User=tr-clickhouse-ingest
 Group=tr-clickhouse-ingest
 WorkingDirectory=/opt/tr-clickhouse

--- a/tests/test_aws_analytics_drain_install.py
+++ b/tests/test_aws_analytics_drain_install.py
@@ -83,6 +83,15 @@ def test_install_creates_what_the_unit_hardening_requires() -> None:
     assert "install -d -o '$SERVICE_USER' -g '$SERVICE_USER'" in script
 
 
+def test_drain_unit_is_notify_watchdog_managed() -> None:
+    unit = UNIT.read_text()
+
+    assert "Type=notify" in unit
+    assert "NotifyAccess=main" in unit
+    assert "WatchdogSec=600" in unit
+    assert "Restart=always" in unit
+
+
 def test_install_refuses_to_proceed_without_dsql_permission() -> None:
     """The one precondition that fails silently at runtime, so it fails loudly here.
 

--- a/tests/test_azure_clickhouse_drain_install.py
+++ b/tests/test_azure_clickhouse_drain_install.py
@@ -16,6 +16,8 @@ from .deploy_script_harness import (
 )
 
 SCRIPT = "scripts/deploy/azure_clickhouse_drain_install.sh"
+ROOT = Path(__file__).resolve().parents[1]
+UNIT = ROOT / "clickhouse/tr-clickhouse-operational-ingest-postgres.service"
 
 
 def _fixture(
@@ -83,6 +85,15 @@ def test_preflight_authenticates_to_postgres_and_clickhouse(
         if "keyvault secret show" in call
     ]
     assert len(secret_checks) == 2
+
+
+def test_installed_unit_is_notify_watchdog_managed() -> None:
+    unit = UNIT.read_text()
+
+    assert "Type=notify" in unit
+    assert "NotifyAccess=main" in unit
+    assert "WatchdogSec=600" in unit
+    assert "Restart=always" in unit
 
 
 def test_final_verification_requires_a_clickhouse_row_count_to_advance(

--- a/tests/test_clickhouse_operational_deploy.py
+++ b/tests/test_clickhouse_operational_deploy.py
@@ -91,6 +91,18 @@ def test_operational_deploy_resumes_live_ingest_before_backfills() -> None:
     assert 'id_column="event_id"' in script
 
 
+def test_gcp_spanner_drain_is_notify_watchdog_managed() -> None:
+    unit = (ROOT / "clickhouse/tr-clickhouse-operational-ingest.service").read_text()
+    drain = (ROOT / "clickhouse/ingest_operational_outbox.py").read_text()
+
+    assert "Type=notify" in unit
+    assert "NotifyAccess=main" in unit
+    assert "WatchdogSec=600" in unit
+    assert "Restart=always" in unit
+    assert 'sd_notify("READY=1")' in drain
+    assert 'sd_notify("WATCHDOG=1")' in drain
+
+
 def test_clickhouse_manual_deploys_bundle_only_valid_committed_source() -> None:
     helper = (ROOT / "scripts/deploy/_clickhouse_bundle.sh").read_text()
     assert "git -C \"$root\" status --porcelain" in helper

--- a/tests/test_operational_analytics_outbox_postgres.py
+++ b/tests/test_operational_analytics_outbox_postgres.py
@@ -19,8 +19,11 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+import os
+import socket
 import sqlite3
 import sys
+import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -1049,6 +1052,182 @@ def test_a_non_admin_role_gets_the_scoped_token_not_the_admin_one(
     assert "admin" not in minted
     assert minted["scoped"]["Hostname"] == "cluster.dsql.eu-west-3.on.aws"
     assert captured["password"] == "scoped-token"  # noqa: S105 - fake token, not a secret
+
+
+def test_both_connect_paths_bound_every_libpq_socket_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The daemon cannot recover from a socket call that never returns."""
+    import clickhouse.ingest_operational_outbox_postgres as drain
+
+    _, dsql = _connect_with(
+        "host=cluster.dsql.eu-west-3.on.aws user=tr_analytics_drain dbname=postgres",
+        monkeypatch,
+    )
+    plain: dict[str, Any] = {}
+    source = drain.PostgresOperationalOutboxSource(dsn="postgresql://db.internal/tr")
+
+    class _FakePsycopg:
+        @staticmethod
+        def connect(dsn: str, **kwargs: Any) -> str:
+            plain.update(dsn=dsn, **kwargs)
+            return "connection"
+
+    source._psycopg = _FakePsycopg
+    assert source._connect() == "connection"
+
+    expected = {
+        "connect_timeout": 10,
+        "keepalives": 1,
+        "keepalives_idle": 30,
+        "keepalives_interval": 10,
+        "keepalives_count": 3,
+        "tcp_user_timeout": 30_000,
+    }
+    for captured in (dsql, plain):
+        for key, value in expected.items():
+            assert captured[key] == value
+    assert "options" not in dsql
+    assert plain["options"] == "-c statement_timeout=60000"
+
+
+def test_connection_is_recycled_before_dsqls_one_hour_expiry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import clickhouse.ingest_operational_outbox_postgres as drain
+
+    class _Connection:
+        closed = False
+
+        def __init__(self) -> None:
+            self.close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    old = _Connection()
+    new = _Connection()
+    connects: list[dict[str, Any]] = []
+    source = drain.PostgresOperationalOutboxSource(dsn="postgresql://db.internal/tr")
+    source._connection = old
+    source._connected_at = 100.0
+
+    class _FakePsycopg:
+        @staticmethod
+        def connect(dsn: str, **kwargs: Any) -> _Connection:
+            connects.append({"dsn": dsn, **kwargs})
+            return new
+
+    source._psycopg = _FakePsycopg
+    monkeypatch.setattr(
+        drain.time,
+        "monotonic",
+        lambda: 100.0 + drain.CONNECTION_MAX_AGE_SECONDS,
+    )
+
+    assert source._live_connection() is new
+    assert old.close_calls == 1
+    assert len(connects) == 1
+
+
+def test_main_loop_iteration_sends_systemd_watchdog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import clickhouse.ingest_operational_outbox_postgres as drain
+
+    class _Source:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        def oldest_enqueued_at(self) -> None:
+            return None
+
+    monkeypatch.setattr(drain, "PostgresOperationalOutboxSource", _Source)
+    monkeypatch.setattr(
+        drain,
+        "clickhouse_targets_from_env",
+        lambda env: [SimpleNamespace(describe=lambda: "test@local/tr")],
+    )
+    monkeypatch.setattr(drain, "build_operational_writer", lambda targets: object())
+    monkeypatch.setattr(
+        drain,
+        "drain_once",
+        lambda *args, **kwargs: drain.SweepResult(
+            fetched=0,
+            inserted=0,
+            rows_per_second=0.0,
+        ),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["ingest_operational_outbox_postgres", "--dsn", "postgresql://db/tr", "--once"],
+    )
+
+    with (
+        tempfile.TemporaryDirectory(prefix="tr-notify-", dir="/tmp") as directory,
+        socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as receiver,
+    ):
+        notify_socket = os.path.join(directory, "notify.sock")
+        monkeypatch.setenv("NOTIFY_SOCKET", notify_socket)
+        try:
+            receiver.bind(notify_socket)
+        except PermissionError:
+            # The managed macOS test sandbox denies bind(AF_UNIX) even in /tmp.
+            # CI and normal hosts take the real datagram path above; retain a
+            # call-site proof locally instead of skipping the protection.
+            messages: list[str] = []
+            monkeypatch.setattr(drain, "sd_notify", messages.append)
+            assert drain.main() == 0
+            assert set(messages) == {"READY=1", "WATCHDOG=1"}
+        else:
+            receiver.settimeout(1.0)
+            assert drain.main() == 0
+            messages_bytes = {receiver.recv(128), receiver.recv(128)}
+            assert messages_bytes == {b"READY=1", b"WATCHDOG=1"}
+
+
+def test_sd_notify_translates_systemds_abstract_socket_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import clickhouse._sdnotify as notify
+
+    connected: list[str] = []
+    sent: list[bytes] = []
+
+    class _Socket:
+        def __enter__(self) -> _Socket:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def connect(self, address: str) -> None:
+            connected.append(address)
+
+        def sendall(self, payload: bytes) -> None:
+            sent.append(payload)
+
+    monkeypatch.setenv("NOTIFY_SOCKET", "@tr-drain")
+    monkeypatch.setattr(notify.socket, "socket", lambda *args: _Socket())
+
+    notify.sd_notify("WATCHDOG=1")
+
+    assert connected == ["\0tr-drain"]
+    assert sent == [b"WATCHDOG=1"]
+
+
+def test_busy_sweep_refreshes_watchdog_before_each_shard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import clickhouse.ingest_operational_outbox_postgres as drain
+
+    messages: list[str] = []
+    monkeypatch.setattr(drain, "sd_notify", messages.append)
+
+    drain.drain_once(_FakeSource([]), _FakeWriter(), batch_size=10, shard_count=3)
+
+    assert messages == ["WATCHDOG=1"] * 3
 
 
 def test_a_password_in_the_dsn_is_refused_on_both_connect_paths() -> None:


### PR DESCRIPTION
Hardening from the 2026-08-28 AWS monitor blackout: the outbox drain zombied for 14h on a half-dead DSQL socket (no timeout, no exception, systemd 'active'). Adds libpq socket bounds (connect_timeout, keepalives, tcp_user_timeout) on both connect branches, 45-min proactive connection recycling inside DSQL's ~1h lifetime, and Type=notify units with WatchdogSec=600 fed by stdlib sd_notify pings per iteration and per shard (arithmetic in the unit comment). GCP Spanner drain loop gets the same pings. 119 tests passed; each protection mutation-tested. VM rollout via the install scripts follows merge (drain code deploys by script, not CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)