### PR TITLE
synthetic: run slots expire; EventBridge failures get a DLQ and alarms

### DIFF
--- a/scripts/deploy/aws_eu_control_plane.sh
+++ b/scripts/deploy/aws_eu_control_plane.sh
@@ -104,6 +104,7 @@ ATTESTATION_PCR0="${ATTESTATION_PCR0:?set ATTESTATION_PCR0 to the published encl
 # component in src/trusted_router/synthetic/components.py — renaming one here
 # silently unpublishes its component, so change both together.
 GATEWAY_REGION_TARGETS="${GATEWAY_REGION_TARGETS:-eu-west-1=quill-enclave-nlb-6ed55aa238055cfc.elb.eu-west-1.amazonaws.com,eu-west-3=quill-enclave-nlb-aa2d3be423fa9027.elb.eu-west-3.amazonaws.com}"
+SYNTHETIC_RUN_DEADLINE_SECONDS="${SYNTHETIC_RUN_DEADLINE_SECONDS:-240}"
 
 release_aws_control_plane_deploy_mutex() {
   local deploy_status=$?
@@ -300,6 +301,7 @@ CONFIG=$(cat <<JSON
         "TR_SYNTHETIC_IMAGE_PROBE_ENABLED": "false",
         "TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL": "https://aws.trustedrouter.com",
         "TR_SYNTHETIC_CONTROL_PLANE_BASE_URL": "https://trustedrouter.com",
+        "TR_SYNTHETIC_RUN_DEADLINE_SECONDS": "${SYNTHETIC_RUN_DEADLINE_SECONDS}",
 
         "TR_SYNTHETIC_SCHEDULER_INTERVAL_SECONDS": "0",
         "TR_REMEDIATOR_IN_PROCESS_ENABLED": "false",
@@ -427,6 +429,69 @@ echo "https://${URL}"
 if [ "${SKIP_EVENTBRIDGE:-0}" != "1" ]; then
   log "aligning EventBridge rule tr-eu-synthetic-1min"
 
+  RULE_NAME="tr-eu-synthetic-1min"
+  RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT}:rule/${RULE_NAME}"
+  DLQ_NAME="tr-eu-synthetic-dlq"
+  DLQ_ARN="arn:aws:sqs:${REGION}:${ACCOUNT}:${DLQ_NAME}"
+  DLQ_URL="https://sqs.${REGION}.amazonaws.com/${ACCOUNT}/${DLQ_NAME}"
+  ALARM_TOPIC_NAME="tr-eu-synthetic-alarms"
+  ALARM_TOPIC_ARN="arn:aws:sns:${REGION}:${ACCOUNT}:${ALARM_TOPIC_NAME}"
+
+  if aws sqs get-queue-url --region "$REGION" --queue-name "$DLQ_NAME" >/dev/null 2>&1; then
+    log "reusing SQS DLQ ${DLQ_NAME}"
+  else
+    log "creating SQS DLQ ${DLQ_NAME}"
+    aws sqs create-queue --region "$REGION" --queue-name "$DLQ_NAME" >/dev/null
+  fi
+
+  # EventBridge rule DLQs require a resource policy in addition to the target
+  # execution role permission. Reconcile both deterministic policies on every
+  # run: set-queue-attributes and put-role-policy are idempotent and repair
+  # manual drift instead of treating this as a one-time bootstrap.
+  DLQ_ATTRIBUTES=$(python3 - "$DLQ_ARN" "$RULE_ARN" <<'PY'
+import json
+import sys
+
+queue_arn, rule_arn = sys.argv[1:3]
+policy = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowEventBridgeRuleToSendToDLQ",
+            "Effect": "Allow",
+            "Principal": {"Service": "events.amazonaws.com"},
+            "Action": "sqs:SendMessage",
+            "Resource": queue_arn,
+            "Condition": {"ArnEquals": {"aws:SourceArn": rule_arn}},
+        }
+    ],
+}
+print(json.dumps({"Policy": json.dumps(policy, separators=(",", ":"))}))
+PY
+)
+  aws sqs set-queue-attributes --region "$REGION" --queue-url "$DLQ_URL" \
+    --attributes "$DLQ_ATTRIBUTES"
+
+  ROLE_NAME="tr-eu-eventbridge-invoke-par"
+  ROLE_ARN="arn:aws:iam::${ACCOUNT}:role/${ROLE_NAME}"
+  DLQ_ROLE_POLICY=$(python3 - "$DLQ_ARN" <<'PY'
+import json
+import sys
+
+print(json.dumps({
+    "Version": "2012-10-17",
+    "Statement": [{
+        "Sid": "SendSyntheticFailuresToDLQ",
+        "Effect": "Allow",
+        "Action": "sqs:SendMessage",
+        "Resource": sys.argv[1],
+    }],
+}))
+PY
+)
+  aws iam put-role-policy --role-name "$ROLE_NAME" \
+    --policy-name tr-eu-synthetic-dlq-send --policy-document "$DLQ_ROLE_POLICY"
+
   # Re-authorize the connection with the CURRENT observer-only token.
   #
   # The connection stores its own copy of the credential. When the token
@@ -453,12 +518,11 @@ if [ "${SKIP_EVENTBRIDGE:-0}" != "1" ]; then
   log "connection AUTHORIZED with current token"
 
   DEST_ARN=$(aws events list-api-destinations --region "$REGION" --name-prefix tr-eu-synthetic-run --query 'ApiDestinations[0].ApiDestinationArn' --output text)
-  ROLE_ARN="arn:aws:iam::${ACCOUNT}:role/tr-eu-eventbridge-invoke-par"
-  TARGETS=$(python3 - "$DEST_ARN" "$ROLE_ARN" "$REGION" <<'PY'
+  TARGETS=$(python3 - "$DEST_ARN" "$ROLE_ARN" "$REGION" "$DLQ_ARN" <<'PY'
 import json
 import sys
 
-dest_arn, role_arn, region = sys.argv[1:4]
+dest_arn, role_arn, region, dlq_arn = sys.argv[1:5]
 rule_input = {
     "monitor_region": region,
     "rotation_count": 8,
@@ -477,13 +541,63 @@ print(json.dumps([
         "Id": "synthetic",
         "Arn": dest_arn,
         "RoleArn": role_arn,
+        "DeadLetterConfig": {"Arn": dlq_arn},
         "Input": json.dumps(rule_input),
     }
 ]))
 PY
 )
-  aws events put-rule --region "$REGION" --name tr-eu-synthetic-1min --schedule-expression 'rate(2 minutes)' --state ENABLED >/dev/null
-  aws events put-targets --region "$REGION" --rule tr-eu-synthetic-1min --targets "$TARGETS" >/dev/null
+  aws events put-rule --region "$REGION" --name "$RULE_NAME" --schedule-expression 'rate(2 minutes)' --state ENABLED >/dev/null
+  aws events put-targets --region "$REGION" --rule "$RULE_NAME" --targets "$TARGETS" >/dev/null
+
+  # tr-ops-chat-cloudwatch-alarms exists only in us-east-1. CloudWatch alarm
+  # state-change events and SNS alarm actions are regional, and this repo has
+  # no established cross-region forwarding stack to mirror safely. Use the
+  # existing SNS alarm-action pattern in Paris, but do not invent a subscriber:
+  # an operator MUST subscribe tr-eu-synthetic-alarms to the approved paging
+  # destination before treating these alarms as chat-paged.
+  if aws sns get-topic-attributes --region "$REGION" \
+      --topic-arn "$ALARM_TOPIC_ARN" >/dev/null 2>&1; then
+    log "reusing regional alarm topic ${ALARM_TOPIC_NAME}"
+  else
+    log "creating regional alarm topic ${ALARM_TOPIC_NAME}"
+    aws sns create-topic --region "$REGION" --name "$ALARM_TOPIC_NAME" >/dev/null
+  fi
+  ALARM_SUBSCRIPTIONS=$(aws sns list-subscriptions-by-topic --region "$REGION" \
+    --topic-arn "$ALARM_TOPIC_ARN" --query 'length(Subscriptions)' --output text 2>/dev/null || echo 0)
+  ALARM_SUBSCRIPTIONS="${ALARM_SUBSCRIPTIONS:-0}"
+  if [ "$ALARM_SUBSCRIPTIONS" = "0" ] || [ "$ALARM_SUBSCRIPTIONS" = "None" ]; then
+    echo "WARNING: ${ALARM_TOPIC_ARN} has no subscription; operator must wire the approved paging destination" >&2
+  fi
+
+  FAILED_ALARM="tr-eu-synthetic-failed-invocations"
+  if aws cloudwatch describe-alarms --region "$REGION" --alarm-names "$FAILED_ALARM" \
+      --query 'length(MetricAlarms)' --output text | grep -qx 1; then
+    log "reconciling alarm ${FAILED_ALARM}"
+  else
+    log "creating alarm ${FAILED_ALARM}"
+  fi
+  aws cloudwatch put-metric-alarm --region "$REGION" --alarm-name "$FAILED_ALARM" \
+    --alarm-description "EventBridge failed to invoke the AWS EU synthetic monitor" \
+    --namespace AWS/Events --metric-name FailedInvocations --dimensions "Name=RuleName,Value=${RULE_NAME}" \
+    --statistic Sum --period 300 --evaluation-periods 3 --datapoints-to-alarm 1 \
+    --threshold 0 --comparison-operator GreaterThanThreshold \
+    --treat-missing-data notBreaching --actions-enabled --alarm-actions "$ALARM_TOPIC_ARN"
+
+  DLQ_ALARM="tr-eu-synthetic-dlq-messages-visible"
+  if aws cloudwatch describe-alarms --region "$REGION" --alarm-names "$DLQ_ALARM" \
+      --query 'length(MetricAlarms)' --output text | grep -qx 1; then
+    log "reconciling alarm ${DLQ_ALARM}"
+  else
+    log "creating alarm ${DLQ_ALARM}"
+  fi
+  aws cloudwatch put-metric-alarm --region "$REGION" --alarm-name "$DLQ_ALARM" \
+    --alarm-description "An AWS EU synthetic invocation was dropped into the DLQ" \
+    --namespace AWS/SQS --metric-name ApproximateNumberOfMessagesVisible \
+    --dimensions "Name=QueueName,Value=${DLQ_NAME}" --statistic Maximum \
+    --period 300 --evaluation-periods 1 --datapoints-to-alarm 1 \
+    --threshold 0 --comparison-operator GreaterThanThreshold \
+    --treat-missing-data notBreaching --actions-enabled --alarm-actions "$ALARM_TOPIC_ARN"
   log "rule aligned: one synthetic + remediation pass every two minutes"
 fi
 

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -1064,6 +1064,11 @@ class Settings(BaseSettings):
     # /responses probe in europe-west4 can legitimately take >10s on slow
     # cheap monitor routes, so 10s creates false downtime.
     synthetic_monitor_timeout_seconds: float = 20.0
+    # Hard wall-clock ceiling for one admitted synthetic run. Eight provider
+    # calls under the billing-concurrency limit of two take four ~20s p99
+    # waves; adding the normal 10-17s probe work gives ~97s. 240s is ~2.47x
+    # that budget while ensuring a wedged read cannot own the run slot forever.
+    synthetic_run_deadline_seconds: float = 240.0
     # Monthly self-funding for the monitor workspace, applied lazily on its
     # own gateway-authorize path (synthetic/funding.py). Each deployment has
     # its own database, so each cloud's monitor funds itself from config —
@@ -1200,6 +1205,8 @@ class Settings(BaseSettings):
                 )
         if self.max_request_body_bytes <= 0:
             raise ValueError("TR_MAX_REQUEST_BODY_BYTES must be positive")
+        if self.synthetic_run_deadline_seconds <= 0:
+            raise ValueError("TR_SYNTHETIC_RUN_DEADLINE_SECONDS must be positive")
         if self.max_in_flight_request_body_bytes < self.max_request_body_bytes:
             raise ValueError(
                 "TR_MAX_IN_FLIGHT_REQUEST_BODY_BYTES must be at least TR_MAX_REQUEST_BODY_BYTES"

--- a/src/trusted_router/routes/internal/synthetic.py
+++ b/src/trusted_router/routes/internal/synthetic.py
@@ -5,6 +5,7 @@ import datetime as dt
 import logging
 import random
 import threading
+import time
 from dataclasses import asdict
 from typing import Any
 
@@ -65,6 +66,50 @@ _OPERATION_SLOTS = {
 _BACKGROUND_RUNS: set[asyncio.Task[dict[str, Any]]] = set()
 
 
+class _HeldOperationSlot:
+    """A semaphore admission that can cross an unkillable worker thread.
+
+    Async run tasks release their raw BoundedSemaphore in ``finally``. A
+    remediator pass is different: cancelling the threadpool await cannot stop
+    the worker. This lease lets the deadline owner free capacity immediately
+    while making the worker's eventual ``finally`` a no-op instead of an
+    over-release. The underlying semaphore remains bounded as the guard on
+    every real release.
+    """
+
+    def __init__(self, semaphore: threading.BoundedSemaphore) -> None:
+        self._semaphore = semaphore
+        self._lock = threading.Lock()
+        self._released = False
+
+    def release(self) -> bool:
+        with self._lock:
+            if self._released:
+                return False
+            self._semaphore.release()
+            self._released = True
+            return True
+
+
+def _background_run_done(
+    task: asyncio.Task[dict[str, Any]],
+    slot: _HeldOperationSlot,
+) -> None:
+    # A task can be cancelled before its coroutine executes even one line, in
+    # which case no coroutine finally block runs. The callback is the last
+    # cancellation backstop for the admission.
+    slot.release()
+    _BACKGROUND_RUNS.discard(task)
+    if task.cancelled():
+        return
+    error = task.exception()
+    if error is not None and not isinstance(error, TimeoutError):
+        log.error(
+            "synthetic.background_run_failed",
+            exc_info=(type(error), error, error.__traceback__),
+        )
+
+
 def _admit_operation(name: str) -> threading.BoundedSemaphore:
     slot = _OPERATION_SLOTS[name]
     if not slot.acquire(blocking=False):
@@ -94,10 +139,68 @@ def _admit_operation(name: str) -> threading.BoundedSemaphore:
 async def _run_with_held_slot(
     settings: Settings,
     body: dict[str, Any],
-    slot: threading.BoundedSemaphore,
+    slot: _HeldOperationSlot,
 ) -> dict[str, Any]:
     try:
         return await _run_and_record(settings, body)
+    finally:
+        slot.release()
+
+
+async def _run_with_deadline(
+    settings: Settings,
+    body: dict[str, Any],
+    slot: _HeldOperationSlot,
+) -> dict[str, Any]:
+    started = time.monotonic()
+    try:
+        return await asyncio.wait_for(
+            _run_with_held_slot(settings, body, slot),
+            timeout=settings.synthetic_run_deadline_seconds,
+        )
+    except TimeoutError:
+        log.error(
+            "synthetic.run_deadline_exceeded elapsed_seconds=%.3f pass_args=%r",
+            time.monotonic() - started,
+            body,
+        )
+        raise
+    finally:
+        # Covers cancellation before wait_for has started the child coroutine.
+        # The child's own finally remains the normal owner; this is a no-op
+        # after that release.
+        slot.release()
+
+
+async def _run_high_authority_with_held_slot(
+    settings: Settings,
+    body: dict[str, Any],
+    slot: _HeldOperationSlot,
+) -> dict[str, Any]:
+    try:
+        return await _run_high_authority_and_record(settings, body)
+    finally:
+        slot.release()
+
+
+async def _run_high_authority_with_deadline(
+    settings: Settings,
+    body: dict[str, Any],
+    slot: _HeldOperationSlot,
+) -> dict[str, Any]:
+    started = time.monotonic()
+    try:
+        return await asyncio.wait_for(
+            _run_high_authority_with_held_slot(settings, body, slot),
+            timeout=settings.synthetic_run_deadline_seconds,
+        )
+    except TimeoutError:
+        log.error(
+            "synthetic.run_deadline_exceeded elapsed_seconds=%.3f pass_args=%r",
+            time.monotonic() - started,
+            body,
+        )
+        raise
     finally:
         slot.release()
 
@@ -242,7 +345,7 @@ async def _run_and_record_impl(
 
 def _run_remediator_with_held_slot(
     settings: Settings,
-    slot: threading.BoundedSemaphore,
+    slot: _HeldOperationSlot,
 ) -> int:
     try:
         record_heartbeat("scheduler:remediator", settings=settings)
@@ -253,10 +356,32 @@ def _run_remediator_with_held_slot(
         slot.release()
 
 
+async def _run_remediator_with_deadline(
+    settings: Settings,
+    slot: _HeldOperationSlot,
+) -> int:
+    started = time.monotonic()
+    try:
+        return await asyncio.wait_for(
+            run_in_threadpool(_run_remediator_with_held_slot, settings, slot),
+            timeout=settings.synthetic_run_deadline_seconds,
+        )
+    except TimeoutError:
+        # The worker thread cannot be killed. Relinquish its admission now;
+        # its own finally calls release() too, but the lease makes that late
+        # call a no-op rather than a BoundedSemaphore over-release.
+        slot.release()
+        log.error(
+            "synthetic.remediator_deadline_exceeded elapsed_seconds=%.3f",
+            time.monotonic() - started,
+        )
+        raise
+
+
 async def _run_scheduled_remediator_pass(settings: Settings) -> int | None:
     """Run the EventBridge-owned pass without sacrificing its synthetic tick."""
     try:
-        slot = _admit_operation("remediate")
+        slot = _HeldOperationSlot(_admit_operation("remediate"))
     except HTTPException:
         log.warning("scheduled remediator skipped because another pass owns the slot")
         return None
@@ -265,7 +390,7 @@ async def _run_scheduled_remediator_pass(settings: Settings) -> int | None:
         # be cancelled while TestClient (or the server) tears down its event
         # loop; separate threadpool awaits allowed that cancellation to land
         # after the first heartbeat and before remediation was dispatched.
-        return await run_in_threadpool(_run_remediator_with_held_slot, settings, slot)
+        return await _run_remediator_with_deadline(settings, slot)
     except Exception:
         # A remediation read/decision failure must remain visible, but it must
         # not discard the independent synthetic results from the same tick.
@@ -280,17 +405,13 @@ async def run_synthetic_pass(settings: Settings, *, rotation_count: int = 0) -> 
     scheduler still gets a monitor. Same code path as the route, so the two
     cannot drift into measuring different things.
     """
-    slot = _OPERATION_SLOTS["run"]
-    if not slot.acquire(blocking=False):
+    semaphore = _OPERATION_SLOTS["run"]
+    if not semaphore.acquire(blocking=False):
         log.info("synthetic.pass_skipped_already_running")
         return {"data": {"scheduled": False, "reason": "already_running"}}
-    try:
-        return await _run_high_authority_and_record(
-            settings,
-            {"rotation_count": rotation_count} if rotation_count else {},
-        )
-    finally:
-        slot.release()
+    slot = _HeldOperationSlot(semaphore)
+    body: dict[str, Any] = {"rotation_count": rotation_count} if rotation_count else {}
+    return await _run_high_authority_with_deadline(settings, body, slot)
 
 
 def register(router: APIRouter) -> None:
@@ -388,8 +509,8 @@ def register(router: APIRouter) -> None:
         even while the durable analytics copy catches up.
         """
         require_internal_gateway(request, settings)
-        slot = _admit_operation("remediate")
-        decisions = await run_in_threadpool(_run_remediator_with_held_slot, settings, slot)
+        slot = _HeldOperationSlot(_admit_operation("remediate"))
+        decisions = await _run_remediator_with_deadline(settings, slot)
         return {"data": {"decisions": decisions}}
 
     @router.post("/internal/synthetic/run")
@@ -397,7 +518,7 @@ def register(router: APIRouter) -> None:
         request: Request, settings: SettingsDep, response: Response
     ) -> dict[str, Any]:
         require_internal_gateway(request, settings)
-        slot = _admit_operation("run")
+        slot = _HeldOperationSlot(_admit_operation("run"))
         try:
             body = await json_body(request)
         except BaseException:
@@ -417,15 +538,15 @@ def register(router: APIRouter) -> None:
         # so we do not pretend: the body says scheduled, not recorded.
         if _is_true(body.get("detach")):
             try:
-                task = asyncio.create_task(_run_with_held_slot(settings, body, slot))
+                task = asyncio.create_task(_run_with_deadline(settings, body, slot))
             except Exception:
                 slot.release()
                 raise
             _BACKGROUND_RUNS.add(task)
-            task.add_done_callback(_BACKGROUND_RUNS.discard)
+            task.add_done_callback(lambda done: _background_run_done(done, slot))
             response.status_code = 202
             return {"data": {"scheduled": True}}
-        return await _run_with_held_slot(settings, body, slot)
+        return await _run_with_deadline(settings, body, slot)
 
 
 def _record_probe_samples(samples: list[SyntheticProbeSample]) -> None:

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -2358,40 +2358,44 @@ async def provider_rotation_probe(
         default_first_token_seconds=default_timeout_seconds,
     )
     try:
-        async with client.stream(
-            "POST",
-            url,
-            json=body,
-            headers=_auth_headers(api_key),
-            timeout=httpx.Timeout(deadline.first_token_seconds),
-        ) as response:
-            served_provider = response.headers.get("x-trustedrouter-provider") or provider
-            served_model = response.headers.get("x-trustedrouter-served-model") or model
-            if response.status_code != 200:
-                await response.aread()
-                error_type, error_status, message = _response_error(response)
-                return _rotation_error_sample(
-                    served_provider,
-                    served_model,
-                    region=monitor_region,
-                    elapsed_ms=_elapsed_ms(started),
-                    error_status=error_status,
-                    error_type=error_type,
-                    error_message=message,
-                )
-            observation = await _observe_provider_stream(response, started=started)
-            if observation.stream_error is not None:
-                error_type, status, message = observation.stream_error
-                return _rotation_error_sample(
-                    served_provider,
-                    served_model,
-                    region=monitor_region,
-                    elapsed_ms=observation.elapsed_milliseconds,
-                    error_status=status or 502,
-                    error_type=error_type,
-                    error_message=message,
-                )
-    except (httpx.HTTPError, ValueError) as exc:
+        # httpx's read timeout resets whenever another chunk arrives. The
+        # outer wall-clock deadline is therefore the primary bound for a
+        # provider that trickles bytes forever without completing the stream.
+        async with asyncio.timeout(deadline.first_token_seconds):
+            async with client.stream(
+                "POST",
+                url,
+                json=body,
+                headers=_auth_headers(api_key),
+                timeout=httpx.Timeout(deadline.first_token_seconds),
+            ) as response:
+                served_provider = response.headers.get("x-trustedrouter-provider") or provider
+                served_model = response.headers.get("x-trustedrouter-served-model") or model
+                if response.status_code != 200:
+                    await response.aread()
+                    error_type, error_status, message = _response_error(response)
+                    return _rotation_error_sample(
+                        served_provider,
+                        served_model,
+                        region=monitor_region,
+                        elapsed_ms=_elapsed_ms(started),
+                        error_status=error_status,
+                        error_type=error_type,
+                        error_message=message,
+                    )
+                observation = await _observe_provider_stream(response, started=started)
+                if observation.stream_error is not None:
+                    error_type, status, message = observation.stream_error
+                    return _rotation_error_sample(
+                        served_provider,
+                        served_model,
+                        region=monitor_region,
+                        elapsed_ms=observation.elapsed_milliseconds,
+                        error_status=status or 502,
+                        error_type=error_type,
+                        error_message=message,
+                    )
+    except (TimeoutError, httpx.HTTPError, ValueError) as exc:
         return _rotation_error_sample(
             served_provider,
             served_model,

--- a/tests/test_deploy_script_execution.py
+++ b/tests/test_deploy_script_execution.py
@@ -781,6 +781,7 @@ def test_aws_observer_executes_bounded_capacity_tcp_health_and_waf_before_schedu
     assert len(service_updates) == 1
     service_config = service_updates[0][service_updates[0].index("--source-configuration") + 1]
     assert '"TR_SYNTHETIC_SCHEDULER_INTERVAL_SECONDS": "0"' in service_config
+    assert '"TR_SYNTHETIC_RUN_DEADLINE_SECONDS": "240"' in service_config
     assert '"TR_REMEDIATOR_IN_PROCESS_ENABLED": "false"' in service_config
     observer_secret_reads = [
         call
@@ -819,6 +820,9 @@ def test_aws_observer_executes_bounded_capacity_tcp_health_and_waf_before_schedu
     assert len(scheduler_targets) == 1
     targets = json.loads(scheduler_targets[0][scheduler_targets[0].index("--targets") + 1])
     assert len(targets) == 1
+    assert targets[0]["DeadLetterConfig"] == {
+        "Arn": "arn:aws:sqs:eu-west-3:330422590279:tr-eu-synthetic-dlq"
+    }
     scheduled_body = json.loads(targets[0]["Input"])
     assert scheduled_body == {
         "monitor_region": "eu-west-3",
@@ -826,6 +830,61 @@ def test_aws_observer_executes_bounded_capacity_tcp_health_and_waf_before_schedu
         "run_remediator": True,
         "detach": True,
     }
+    (queue_policy_call,) = [
+        call for call in run.calls if call[:3] == ["aws", "sqs", "set-queue-attributes"]
+    ]
+    queue_attributes = json.loads(
+        queue_policy_call[queue_policy_call.index("--attributes") + 1]
+    )
+    queue_policy = json.loads(queue_attributes["Policy"])
+    assert queue_policy["Statement"][0]["Principal"] == {
+        "Service": "events.amazonaws.com"
+    }
+    assert queue_policy["Statement"][0]["Condition"] == {
+        "ArnEquals": {
+            "aws:SourceArn": "arn:aws:events:eu-west-3:330422590279:rule/tr-eu-synthetic-1min"
+        }
+    }
+    dlq_role_policies = [
+        call
+        for call in run.calls
+        if call[:3] == ["aws", "iam", "put-role-policy"]
+        and "tr-eu-synthetic-dlq-send" in call
+    ]
+    assert len(dlq_role_policies) == 1
+    role_policy = json.loads(
+        dlq_role_policies[0][dlq_role_policies[0].index("--policy-document") + 1]
+    )
+    assert role_policy["Statement"][0]["Action"] == "sqs:SendMessage"
+    assert role_policy["Statement"][0]["Resource"] == (
+        "arn:aws:sqs:eu-west-3:330422590279:tr-eu-synthetic-dlq"
+    )
+    alarms = [
+        call
+        for call in run.calls
+        if call[:3] == ["aws", "cloudwatch", "put-metric-alarm"]
+    ]
+    assert {call[call.index("--alarm-name") + 1] for call in alarms} == {
+        "tr-eu-synthetic-failed-invocations",
+        "tr-eu-synthetic-dlq-messages-visible",
+    }
+    failed_alarm = next(
+        call for call in alarms if "tr-eu-synthetic-failed-invocations" in call
+    )
+    assert failed_alarm[failed_alarm.index("--metric-name") + 1] == "FailedInvocations"
+    assert failed_alarm[failed_alarm.index("--evaluation-periods") + 1] == "3"
+    assert failed_alarm[failed_alarm.index("--period") + 1] == "300"
+    dlq_alarm = next(call for call in alarms if "tr-eu-synthetic-dlq-messages-visible" in call)
+    assert (
+        dlq_alarm[dlq_alarm.index("--metric-name") + 1]
+        == "ApproximateNumberOfMessagesVisible"
+    )
+    assert all("--actions-enabled" in call for call in alarms)
+    assert all(
+        call[call.index("--alarm-actions") + 1]
+        == "arn:aws:sns:eu-west-3:330422590279:tr-eu-synthetic-alarms"
+        for call in alarms
+    )
     assert waf_attach_index < scheduler_index
 
 

--- a/tests/test_synthetic_admission.py
+++ b/tests/test_synthetic_admission.py
@@ -5,6 +5,7 @@ import datetime as dt
 import threading
 import time
 from collections.abc import Iterator
+from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
@@ -27,15 +28,23 @@ def _reset_operation_limits() -> Iterator[None]:
     synthetic_routes._OPERATION_RATE_LIMITS.reset()  # noqa: SLF001
 
 
-def _client() -> TestClient:
+def _client(
+    *,
+    raise_server_exceptions: bool = True,
+    **settings_overrides: Any,
+) -> TestClient:
     settings = Settings(
         environment="test",
         service_surface="internal",
         internal_gateway_token="billing-admission-token",  # noqa: S106
         observer_internal_token=_OBSERVER_TOKEN,
         rate_limit_internal_per_window=10_000,
+        **settings_overrides,
     )
-    return TestClient(create_app(settings, init_observability=False))
+    return TestClient(
+        create_app(settings, init_observability=False),
+        raise_server_exceptions=raise_server_exceptions,
+    )
 
 
 def _headers() -> dict[str, str]:
@@ -102,6 +111,143 @@ def test_detached_synthetic_runs_are_single_flight_and_share_scheduler_slot(
             assert body_calls == 1
         finally:
             release.set()
+
+
+def test_detached_run_deadline_releases_slot_and_logs_tripwire(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    started = threading.Event()
+    run_calls = 0
+
+    async def blocked_forever(
+        _settings: Settings,
+        _body: dict[str, object],
+    ) -> dict[str, object]:
+        nonlocal run_calls
+        run_calls += 1
+        started.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    monkeypatch.setattr(synthetic_routes, "_run_and_record", blocked_forever)
+    with caplog.at_level("ERROR"), _client(synthetic_run_deadline_seconds=0.2) as client:
+        first = client.post(
+            "/v1/internal/synthetic/run",
+            headers=_headers(),
+            json={"detach": True, "rotation_count": 8},
+        )
+        assert first.status_code == 202
+        assert started.wait(timeout=1)
+
+        overlap = client.post(
+            "/v1/internal/synthetic/run",
+            headers=_headers(),
+            json={"detach": True},
+        )
+        assert overlap.status_code == 429
+
+        deadline = time.monotonic() + 2
+        while synthetic_routes._BACKGROUND_RUNS and time.monotonic() < deadline:  # noqa: SLF001
+            time.sleep(0.01)
+        assert not synthetic_routes._BACKGROUND_RUNS  # noqa: SLF001
+
+        recovered = client.post(
+            "/v1/internal/synthetic/run",
+            headers=_headers(),
+            json={"detach": True, "monitor_region": "recovered"},
+        )
+        assert recovered.status_code == 202
+
+    deadline_logs = [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("synthetic.run_deadline_exceeded")
+    ]
+    assert deadline_logs
+    assert "elapsed_seconds=" in deadline_logs[0]
+    assert "rotation_count" in deadline_logs[0]
+    assert run_calls == 2
+
+
+def test_synchronous_run_deadline_releases_slot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def blocked_forever(
+        _settings: Settings,
+        _body: dict[str, object],
+    ) -> dict[str, object]:
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    async def immediate(
+        _settings: Settings,
+        _body: dict[str, object],
+    ) -> dict[str, object]:
+        return {"data": {"recorded": 0}}
+
+    monkeypatch.setattr(synthetic_routes, "_run_and_record", blocked_forever)
+    with _client(
+        synthetic_run_deadline_seconds=0.2,
+        raise_server_exceptions=False,
+    ) as client:
+        timed_out = client.post(
+            "/v1/internal/synthetic/run",
+            headers=_headers(),
+            json={},
+        )
+        assert timed_out.status_code == 500
+
+        monkeypatch.setattr(synthetic_routes, "_run_and_record", immediate)
+        recovered = client.post(
+            "/v1/internal/synthetic/run",
+            headers=_headers(),
+            json={},
+        )
+        assert recovered.status_code == 200
+
+
+def test_remediator_deadline_releases_slot_before_worker_exits(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    started = threading.Event()
+    release = threading.Event()
+    calls = 0
+
+    def first_call_blocks(_settings: Settings) -> list[object]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            started.set()
+            release.wait()
+        return []
+
+    monkeypatch.setattr(synthetic_routes, "run_remediator_pass", first_call_blocks)
+    settings = Settings(
+        environment="test",
+        synthetic_run_deadline_seconds=0.2,
+    )
+    try:
+        with caplog.at_level("ERROR"):
+            assert asyncio.run(synthetic_routes._run_scheduled_remediator_pass(settings)) is None  # noqa: SLF001
+        assert started.is_set()
+
+        # The timed-out worker is still alive, but its lease no longer blocks
+        # a fresh remediation pass.
+        assert asyncio.run(synthetic_routes._run_scheduled_remediator_pass(settings)) == 0  # noqa: SLF001
+    finally:
+        release.set()
+
+    assert any(
+        record.getMessage().startswith("synthetic.remediator_deadline_exceeded")
+        for record in caplog.records
+    )
+    time.sleep(0.05)
+    semaphore = synthetic_routes._OPERATION_SLOTS["remediate"]  # noqa: SLF001
+    assert semaphore.acquire(blocking=False)
+    assert not semaphore.acquire(blocking=False)
+    semaphore.release()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -3652,6 +3652,47 @@ async def test_provider_rotation_probe_measures_ttfb_and_ttft() -> None:
 
 
 @pytest.mark.asyncio
+async def test_provider_rotation_probe_has_total_deadline_for_trickling_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An httpx read timeout resets on each chunk; total wall time must not."""
+    from trusted_router.synthetic import probes as probes_module
+
+    class _Trickle(httpx.AsyncByteStream):
+        async def __aiter__(self) -> AsyncIterator[bytes]:
+            while True:
+                await asyncio.sleep(0.005)
+                yield b" "
+
+    class _Deadline:
+        first_token_seconds = 0.03
+
+    monkeypatch.setattr(
+        probes_module,
+        "model_deadlines",
+        lambda *_args, **_kwargs: _Deadline(),
+    )
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=_Trickle())
+
+    target = SyntheticTarget("rotation", "https://api.trustedrouter.com/v1", "us-central1")
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sample = await provider_rotation_probe(
+            client,
+            target,
+            monitor_region="us-central1",
+            api_key="sk-test",  # noqa: S106 - test placeholder.
+            provider="slow-provider",
+            model="slow/model",
+        )
+
+    assert sample.status == "error"
+    assert sample.error_type == "TimeoutError"
+    assert sample.error_status is None
+
+
+@pytest.mark.asyncio
 async def test_provider_rotation_probe_counts_reasoning_as_token_flow() -> None:
     body = (
         b'data: {"choices":[{"delta":{"role":"assistant"}}]}\n\n'


### PR DESCRIPTION
Second hardening PR from the 2026-08-28 AWS monitor blackout (companion to #904). Slot deadline on every pass path with a release-once lease and a loud `synthetic.run_deadline_exceeded` tripwire; wall-clock bound on rotation streams (httpx read timeouts reset per chunk); idempotent EventBridge DLQ + FailedInvocations/DLQ-depth alarms in the AWS deploy script. 225 touched tests + 7,576 full-suite green; deadline mutation-tested. Note for rollout: once this image deploys to AWS App Runner, the deploy script restores the full payload (rotation_count 8, remediator on) — the temporary defused EventBridge payload is then obsolete by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)