### PR TITLE
deploy: dispatchable CI workflow for the AWS control plane

### DIFF
--- a/.github/workflows/deploy-aws-control-plane.yml
+++ b/.github/workflows/deploy-aws-control-plane.yml
@@ -1,0 +1,48 @@
+name: Deploy AWS control plane
+
+# Dispatch-only: the AWS App Runner control plane (tr-eu, eu-west-3) has no
+# push-triggered deploy on purpose — its rollout includes EventBridge and IAM
+# mutations an operator should choose to run. Before this workflow existed the
+# deploy required a local Docker build, and the service ran a four-week-old
+# image through the 2026-08-28 monitor blackout because nobody had a machine
+# with Docker handy. An ubuntu runner always does.
+#
+# The workflow is nothing but the operator script: scripts/deploy/
+# aws_eu_control_plane.sh is the single source of truth for the deploy (build
+# by digest, serving-digest assertion, EventBridge alignment, DLQ + alarms).
+# Fixes go THERE, never here.
+
+on:
+  workflow_dispatch:
+    inputs:
+      skip_eventbridge:
+        description: "Skip the EventBridge alignment section (SKIP_EVENTBRIDGE=1)"
+        required: false
+        default: "0"
+
+concurrency:
+  group: deploy-aws-control-plane
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.TR_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.TR_AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Deploy tr-eu from this commit
+        env:
+          SKIP_EVENTBRIDGE: ${{ inputs.skip_eventbridge }}
+        run: bash scripts/deploy/aws_eu_control_plane.sh


### PR DESCRIPTION
Runs `scripts/deploy/aws_eu_control_plane.sh` verbatim on an ubuntu runner (Docker available) with the existing `TR_AWS_*` repo secrets, region eu-west-3, dispatch-only with an optional SKIP_EVENTBRIDGE input. Ends the local-Docker requirement that left tr-eu serving a 08-01 image through the monitor blackout; first dispatch will also surface any missing IAM permissions on the CI user explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)