### PR TITLE
Harden catalog discovery against live feed omissions

### DIFF
--- a/scripts/check_price_coverage.py
+++ b/scripts/check_price_coverage.py
@@ -511,6 +511,7 @@ _STALE_MANIFEST_PROVIDER_MODULES = (
     io_net,
     jina,
     krea,
+    near_ai,
     bfl,
     decart,
     nscale,

--- a/scripts/pricing/providers/near_ai.py
+++ b/scripts/pricing/providers/near_ai.py
@@ -37,6 +37,8 @@ MANIFEST_PATH = (
     / "provider_models"
     / "near-ai.json"
 )
+MANIFEST_STALE_FALLBACK = True
+INCLUDE_IN_PRICE_INDEX = True
 
 # Native ID -> (TR canonical ID, pinned direct TLS domain). This table mirrors
 # the enclave's release policy intentionally: catalog discovery cannot make a
@@ -219,6 +221,17 @@ def fetch() -> ProviderPricingResult:
         if context_length is not None:
             row["context_length"] = context_length
         discovered[model_id] = row
+
+    live_endpoints_without_prices = sorted(
+        native_id
+        for native_id, (model_id, pinned_domain) in _VERIFIED_DIRECT_MODELS.items()
+        if domains.get(native_id) == pinned_domain and model_id not in prices
+    )
+    if live_endpoints_without_prices:
+        raise RuntimeError(
+            "near-ai: pinned direct endpoint remains published without a pricing row: "
+            + ", ".join(live_endpoints_without_prices)
+        )
 
     _DISCOVERED_MANIFEST_ROWS = discovered
     errors = validate(prices, EXPECTED_MODELS)

--- a/scripts/pricing/providers/together.py
+++ b/scripts/pricing/providers/together.py
@@ -6,8 +6,10 @@ just hit the API and translate.
 
 `/v1/models` includes models that require a separately provisioned dedicated
 endpoint. Publishing all of them as prepaid routes caused deterministic 400s.
-The documented `/v1/endpoints?type=serverless` endpoint is therefore the
-availability source of truth; prices still come from `/v1/models`.
+The documented `/v1/endpoints?type=serverless` endpoint is the primary
+availability source, while a bounded one-token probe covers curated canary
+models that remain callable but are temporarily omitted from that feed.
+Prices still come from `/v1/models`.
 
 Both endpoints require an API key (Bearer auth). The workflow can provide one
 via the TOGETHER_API_KEY env var. Without it, the fetch returns 401 and
@@ -38,6 +40,7 @@ from scripts.pricing.openai_catalog import positive_int
 SLUG = "together"
 URL = "https://api.together.xyz/v1/models"
 SERVERLESS_ENDPOINTS_URL = "https://api.together.xyz/v1/endpoints?type=serverless"
+CHAT_COMPLETIONS_URL = "https://api.together.xyz/v1/chat/completions"
 MANIFEST_PATH = (
     Path(__file__).resolve().parents[3]
     / "src"
@@ -91,6 +94,54 @@ UPSTREAM_ID_MAP = {or_id: native_id for native_id, or_id in _NATIVE_TO_OR_ID.ite
 _DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
 
 
+def _probe_expected_serverless_model(
+    client: httpx.Client,
+    headers: dict[str, str],
+    native_id: str,
+) -> bool:
+    """Confirm a curated model omitted from Together's endpoint feed.
+
+    A definitive model-not-available response permits normal tombstoning.
+    Transport errors, throttles, auth failures, and ambiguous responses fail
+    the provider refresh so the committed last-known-good catalog is retained.
+    """
+
+    try:
+        response = client.post(
+            CHAT_COMPLETIONS_URL,
+            headers={**headers, "Content-Type": "application/json"},
+            json={
+                "model": native_id,
+                "messages": [{"role": "user", "content": "Reply PONG"}],
+                "max_tokens": 1,
+                "temperature": 0,
+            },
+        )
+    except httpx.HTTPError as exc:
+        raise RuntimeError(
+            f"together: availability probe transport failure for {native_id}"
+        ) from exc
+
+    if 200 <= response.status_code < 300:
+        return True
+
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = None
+    error = payload.get("error") if isinstance(payload, dict) else None
+    code = error.get("code") if isinstance(error, dict) else None
+    if response.status_code in {400, 404} and code in {
+        "model_not_available",
+        "model_not_found",
+    }:
+        return False
+    raise RuntimeError(
+        "together: ambiguous availability probe failure for "
+        f"{native_id} (status={response.status_code}, code={code or 'unknown'})"
+    )
+
+
 def _row_to_micro_per_m(price_per_token: object) -> int | None:
     """Convert Together's USD-per-million value to integer microdollars."""
     if price_per_token is None:
@@ -114,6 +165,7 @@ def fetch() -> ProviderPricingResult:
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
     transport = httpx.HTTPTransport(retries=PROVIDER_FETCH_TRANSPORT_RETRIES)
+    notes: list[str] = []
     with httpx.Client(
         timeout=PROVIDER_FETCH_TIMEOUT,
         follow_redirects=True,
@@ -125,23 +177,45 @@ def fetch() -> ProviderPricingResult:
         endpoints_response = client.get(SERVERLESS_ENDPOINTS_URL, headers=headers)
         endpoints_response.raise_for_status()
         endpoints_payload = endpoints_response.json()
-    endpoint_rows = (
-        endpoints_payload.get("data") or []
-        if isinstance(endpoints_payload, dict)
-        else endpoints_payload
-    )
-    serverless_model_ids = {
-        row.get("model")
-        for row in endpoint_rows
-        if isinstance(row, dict)
-        and row.get("type") == "serverless"
-        and row.get("state") == "STARTED"
-        and isinstance(row.get("model"), str)
-    }
-    if isinstance(payload, dict):
-        rows = payload.get("data") or []
-    else:
-        rows = payload
+        endpoint_rows = (
+            endpoints_payload.get("data") or []
+            if isinstance(endpoints_payload, dict)
+            else endpoints_payload
+        )
+        serverless_model_ids = {
+            row.get("model")
+            for row in endpoint_rows
+            if isinstance(row, dict)
+            and row.get("type") == "serverless"
+            and row.get("state") == "STARTED"
+            and isinstance(row.get("model"), str)
+        }
+        if isinstance(payload, dict):
+            rows = payload.get("data") or []
+        else:
+            rows = payload
+        catalog_chat_ids = {
+            row.get("id")
+            for row in rows
+            if isinstance(row, dict)
+            and row.get("type") == "chat"
+            and isinstance(row.get("id"), str)
+        }
+        for model_id in EXPECTED_MODELS:
+            native_id = UPSTREAM_ID_MAP.get(model_id)
+            if (
+                native_id is None
+                or native_id not in catalog_chat_ids
+                or native_id in serverless_model_ids
+            ):
+                continue
+            if _probe_expected_serverless_model(client, headers, native_id):
+                serverless_model_ids.add(native_id)
+                notes.append(
+                    f"availability probe retained {native_id} omitted from endpoint feed"
+                )
+            else:
+                notes.append(f"availability probe confirmed {native_id} is unavailable")
     prices: dict[str, ModelPrice] = {}
     discovered: dict[str, dict[str, Any]] = {}
     for row in rows:
@@ -187,7 +261,6 @@ def fetch() -> ProviderPricingResult:
             manifest_row["context_length"] = context_length
         discovered[or_id] = manifest_row
 
-    notes: list[str] = []
     if not prices:
         notes.append(
             "no started Together serverless models matched the TrustedRouter "

--- a/src/trusted_router/provider_manifest_policy.py
+++ b/src/trusted_router/provider_manifest_policy.py
@@ -38,6 +38,7 @@ EXPIRING_PROVIDER_MANIFEST_SLUGS = RUNTIME_ONLY_PROVIDER_MANIFEST_SLUGS | frozen
         "featherless",
         "sakana",
         "jina",
+        "near-ai",
         "nvidia-nim",
         "wandb",
         "nscale",

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -1355,7 +1355,6 @@ def test_liberty_nemotron_resolves_only_to_working_canonical_prepaid_routes() ->
         assert "nebius" not in prepaid
     else:
         assert prepaid["nebius"] == "nvidia/Nemotron-3-Ultra-550b-a55b"
-    assert prepaid["together"] == "nvidia/nemotron-3-ultra-550b-a55b"
     assert "gmi" not in prepaid
 
 

--- a/tests/test_gateway_fallback_billing.py
+++ b/tests/test_gateway_fallback_billing.py
@@ -543,7 +543,7 @@ def test_gateway_authorizes_every_liberty_alias_to_working_nemotron_hosts() -> N
             if route["model"] == "nvidia/nemotron-3-ultra-550b-a55b"
             and route["usage_type"] == "Credits"
         }
-        expected_hosts = {"baseten", "together"}
+        expected_hosts = {"baseten"}
         if not provider_model_retired(
             "nebius",
             "nvidia/nemotron-3-ultra-550b-a55b",

--- a/tests/test_near_ai_provider.py
+++ b/tests/test_near_ai_provider.py
@@ -146,6 +146,47 @@ def test_near_ai_fetch_fails_closed_on_direct_domain_drift(
         near_ai.fetch()
 
 
+def test_near_ai_fetch_keeps_last_known_good_when_live_endpoint_loses_price(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dsv4 = "deepseek-ai/DeepSeek-V4-Flash"
+    glm = "z-ai/glm-5.2"
+    gemma = "google/gemma-4-31B-it"
+    catalog = {"data": [_catalog_row(dsv4), _catalog_row(glm)]}
+    endpoint_payload = _endpoints(dsv4, glm, gemma)
+
+    class FakeResponse:
+        def __init__(self, payload: object) -> None:
+            self.payload = payload
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> object:
+            return copy.deepcopy(self.payload)
+
+    class FakeClient:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def get(self, url: str, **_kwargs: object) -> FakeResponse:
+            return FakeResponse(catalog if url == near_ai.CATALOG_URL else endpoint_payload)
+
+    monkeypatch.setenv("NEAR_API_KEY", "test-key")
+    monkeypatch.setattr(near_ai.httpx, "Client", FakeClient)
+
+    with pytest.raises(RuntimeError, match="endpoint remains published without a pricing row"):
+        near_ai.fetch()
+    assert near_ai.MANIFEST_STALE_FALLBACK is True
+    assert near_ai.INCLUDE_IN_PRICE_INDEX is True
+
+
 def test_near_ai_parser_rejects_bad_money_and_untrusted_endpoint_shapes() -> None:
     assert near_ai._microdollars_per_million_from_per_token("0.00000017") == 170_000
     assert near_ai._microdollars_per_million_from_per_token("NaN") is None

--- a/tests/test_nebius_august_2026_lifecycle.py
+++ b/tests/test_nebius_august_2026_lifecycle.py
@@ -72,18 +72,8 @@ def test_nebius_retirements_are_provider_scoped(
             at=_CUTOFF,
         )
 
-    # Both checkpoints remain available from other providers after Nebius's
-    # route is removed.
-    assert {"baseten", "together"}.issubset(
-        {endpoint.provider for endpoint in endpoints_for_model("nvidia/nemotron-3-ultra-550b-a55b")}
-    )
-    assert {
-        "deepinfra",
-        "makora",
-        "siliconflow",
-    }.issubset(
-        {endpoint.provider for endpoint in endpoints_for_model("deepseek/deepseek-v4-flash")}
-    )
+    # This test owns only Nebius's lifecycle. Other providers may add or
+    # remove the same checkpoints independently without invalidating it.
 
 
 def test_hourly_refresh_cannot_restore_retired_nebius_routes(

--- a/tests/test_together_pricing.py
+++ b/tests/test_together_pricing.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from types import TracebackType
 from typing import Any
 
+import pytest
 from pytest import MonkeyPatch
 
 from scripts.pricing import refresh
@@ -110,6 +111,56 @@ class _FakeTogetherClient:
         return _FakeTogetherEndpointsResponse()
 
 
+class _FakeProbeResponse:
+    def __init__(self, status_code: int, payload: dict[str, Any]) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _MissingM3TogetherClient(_FakeTogetherClient):
+    probe_status = 200
+    probe_payload: dict[str, Any] = {"choices": []}
+
+    def get(
+        self, url: str, *, headers: dict[str, str]
+    ) -> _FakeTogetherModelsResponse | _FakeTogetherEndpointsResponse:
+        response = super().get(url, headers=headers)
+        if url != together.SERVERLESS_ENDPOINTS_URL:
+            return response
+
+        class MissingM3Endpoints(_FakeTogetherEndpointsResponse):
+            def json(self) -> dict[str, list[dict[str, Any]]]:
+                payload = super().json()
+                payload["data"] = [
+                    row
+                    for row in payload["data"]
+                    if row["model"] != "MiniMaxAI/MiniMax-M3"
+                ]
+                return payload
+
+        return MissingM3Endpoints()
+
+    def post(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        json: dict[str, Any],
+    ) -> _FakeProbeResponse:
+        assert url == together.CHAT_COMPLETIONS_URL
+        assert headers["Authorization"].startswith("Bearer ")
+        assert json == {
+            "model": "MiniMaxAI/MiniMax-M3",
+            "messages": [{"role": "user", "content": "Reply PONG"}],
+            "max_tokens": 1,
+            "temperature": 0,
+        }
+        return _FakeProbeResponse(self.probe_status, self.probe_payload)
+
+
 def test_together_llama_33_turbo_price_change_is_mapped(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("TOGETHER_API_KEY", "fake-together-key")
     monkeypatch.setattr(together.httpx, "Client", _FakeTogetherClient)
@@ -167,6 +218,77 @@ def test_together_excludes_deployable_but_non_serverless_models(
 
     assert "deepseek/deepseek-v4-pro" in result.prices
     assert "deepseek/deepseek-r1-0528" not in result.prices
+
+
+def test_together_probe_retains_callable_expected_model_omitted_from_feed(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("TOGETHER_API_KEY", "fake-together-key")
+    monkeypatch.setattr(together.httpx, "Client", _MissingM3TogetherClient)
+    manifest_path = tmp_path / "together.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "provider": "together",
+                "models": [
+                    {
+                        "id": "minimax/minimax-m3",
+                        "upstream_id": "MiniMaxAI/MiniMax-M3",
+                        "status": 1,
+                        "missing_since": "2026-08-28",
+                        "input_token_price_per_m": 300_000,
+                        "output_token_price_per_m": 1_200_000,
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(together, "MANIFEST_PATH", manifest_path)
+
+    result = together.fetch()
+    together.write_provider_manifest(result)
+    rows = {
+        row["id"]: row
+        for row in json.loads(manifest_path.read_text(encoding="utf-8"))["models"]
+    }
+
+    assert "minimax/minimax-m3" in result.prices
+    assert any("probe retained MiniMaxAI/MiniMax-M3" in note for note in result.notes)
+    assert rows["minimax/minimax-m3"].get("routable", True) is True
+    assert "missing_since" not in rows["minimax/minimax-m3"]
+
+
+def test_together_probe_allows_definitively_unavailable_model_to_retire(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    class UnavailableClient(_MissingM3TogetherClient):
+        probe_status = 400
+        probe_payload = {"error": {"code": "model_not_available"}}
+
+    monkeypatch.setenv("TOGETHER_API_KEY", "fake-together-key")
+    monkeypatch.setattr(together.httpx, "Client", UnavailableClient)
+
+    result = together.fetch()
+
+    assert "minimax/minimax-m3" not in result.prices
+    assert any("confirmed MiniMaxAI/MiniMax-M3 is unavailable" in note for note in result.notes)
+
+
+def test_together_probe_ambiguous_failure_preserves_last_known_good(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    class ThrottledClient(_MissingM3TogetherClient):
+        probe_status = 503
+        probe_payload = {"error": {"code": "upstream_unavailable"}}
+
+    monkeypatch.setenv("TOGETHER_API_KEY", "fake-together-key")
+    monkeypatch.setattr(together.httpx, "Client", ThrottledClient)
+
+    with pytest.raises(RuntimeError, match="ambiguous availability probe failure"):
+        together.fetch()
 
 
 def test_together_refresh_adds_new_started_serverless_chat_models(


### PR DESCRIPTION
## Summary
- retain Together canary models when the serverless endpoint feed omits a model that still passes a bounded one-token call
- treat ambiguous Together probe failures as refresh failures, while allowing definitive model-not-available responses to retire normally
- retain NEAR's committed manifest when a pinned direct endpoint remains published but its pricing row disappears
- remove unrelated cross-provider availability assumptions from lifecycle tests

## Production evidence
- Together MiniMax M3 is absent from `/v1/endpoints?type=serverless` but a direct one-token request returned HTTP 200
- Together Nemotron returned HTTP 400 `model_not_available`
- three NEAR routes omitted from the pricing catalog returned HTTP 200 through their pinned direct domains; the fourth remains in the signed endpoint registry but had a transient TLS failure
- a temporary live manifest rebuild cleared M3's miss marker and tombstoned only the unavailable Nemotron route

## Tests
- `uv run ruff check .`
- `uv run mypy`
- 52 focused provider, catalog, lifecycle, routing, and billing tests
- live Together and NEAR adapter/fallback checks
