### PR TITLE
Verify generated catalog statuses after creation

### DIFF
--- a/.github/workflows/refresh-prices.yml
+++ b/.github/workflows/refresh-prices.yml
@@ -395,6 +395,7 @@ jobs:
           # run succeeds. Both the checks and these statuses are emitted by
           # the repository's pinned GitHub Actions app.
           ci_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${ci_run_id}"
+          expected_status_url="${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/statuses/${SNAPSHOT_SHA}"
           for context in "lint" "test (1)" "test (2)" "test (3)"; do
             status_json=$(gh api \
               --method POST \
@@ -403,11 +404,28 @@ jobs:
               -f context="${context}" \
               -f description="Exact snapshot CI passed" \
               -f target_url="${ci_url}")
-            if [ "$(jq -r .sha <<<"${status_json}")" != "${SNAPSHOT_SHA}" ] || \
+            status_id=$(jq -r '.id // empty' <<<"${status_json}")
+            if ! [[ "${status_id}" =~ ^[0-9]+$ ]] || \
+               [ "$(jq -r .url <<<"${status_json}")" != "${expected_status_url}" ] || \
                [ "$(jq -r .context <<<"${status_json}")" != "${context}" ] || \
                [ "$(jq -r .state <<<"${status_json}")" != "success" ] || \
-               [ "$(jq -r .creator.login <<<"${status_json}")" != "github-actions[bot]" ]; then
+               [ "$(jq -r .target_url <<<"${status_json}")" != "${ci_url}" ]; then
               echo "failed to publish exact snapshot status '${context}'"
+              exit 1
+            fi
+
+            # The create-status response currently omits `creator` and `sha`.
+            # Re-read this exact status from the SHA-scoped endpoint before
+            # trusting it for protected-main promotion.
+            verified_status=$(gh api \
+              "repos/${GITHUB_REPOSITORY}/statuses/${SNAPSHOT_SHA}" \
+              --jq "map(select(.id == ${status_id}))[0] // empty")
+            if [ -z "${verified_status}" ] || \
+               [ "$(jq -r .context <<<"${verified_status}")" != "${context}" ] || \
+               [ "$(jq -r .state <<<"${verified_status}")" != "success" ] || \
+               [ "$(jq -r .target_url <<<"${verified_status}")" != "${ci_url}" ] || \
+               [ "$(jq -r .creator.login <<<"${verified_status}")" != "github-actions[bot]" ]; then
+              echo "failed to verify exact snapshot status '${context}'"
               exit 1
             fi
           done

--- a/tests/test_refresh_workflow_dispatch.py
+++ b/tests/test_refresh_workflow_dispatch.py
@@ -34,10 +34,13 @@ def test_price_refresh_checks_exact_branch_sha_before_advancing_main() -> None:
     assert status_bridge in workflow
     assert 'for context in "lint" "test (1)" "test (2)" "test (3)"' in workflow
     assert '-f target_url="${ci_url}"' in workflow
-    assert '$(jq -r .sha <<<"${status_json}")' in workflow
+    assert 'expected_status_url="${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/statuses/${SNAPSHOT_SHA}"' in workflow
+    assert "status_id=$(jq -r '.id // empty'" in workflow
+    assert '$(jq -r .url <<<"${status_json}")' in workflow
     assert '$(jq -r .context <<<"${status_json}")' in workflow
     assert '$(jq -r .state <<<"${status_json}")' in workflow
-    assert '$(jq -r .creator.login <<<"${status_json}")' in workflow
+    assert '--jq "map(select(.id == ${status_id}))[0] // empty"' in workflow
+    assert '$(jq -r .creator.login <<<"${verified_status}")' in workflow
     assert '!= "github-actions[bot]"' in workflow
     main_push = 'git push origin "HEAD:refs/heads/main"'
     assert main_push in workflow


### PR DESCRIPTION
## Summary\n- verify the create-status response using fields GitHub actually returns\n- re-read the exact status by ID from the candidate SHA before trusting its bot creator\n- preserve exact-SHA CI, branch-race, and protected-main checks\n\n## Root cause\nGitHub's create commit status response omits creator and sha, so the refresh rejected its own valid status after exact-SHA CI passed. The SHA-scoped list endpoint exposes creator and is now used for the second-stage verification.\n\n## Tests\n- uv run pytest -q tests/test_refresh_workflow_dispatch.py\n- uv run ruff check tests/test_refresh_workflow_dispatch.py\n- YAML safe-load of refresh-prices.yml