### PR TITLE
Fix empty Cloud Run env parsing in deploys

### DIFF
--- a/scripts/deploy/regional_quota_rollout.sh
+++ b/scripts/deploy/regional_quota_rollout.sh
@@ -102,7 +102,10 @@ if len(matches) > 1:
 if not matches:
     print(default)
 else:
-    value = matches[0].get("value")
+    item = matches[0]
+    if "valueFrom" in item:
+        raise SystemExit(f"environment variable is not a plain value: {name}")
+    value = item.get("value", "")
     if not isinstance(value, str):
         raise SystemExit(f"environment variable is not a plain value: {name}")
     print(value)

--- a/tests/shell/test_regional_quota_rollout.sh
+++ b/tests/shell/test_regional_quota_rollout.sh
@@ -152,6 +152,31 @@ test_raw_issuance_input_is_normalized_in_shell() {
   fi
 }
 
+test_revision_env_accepts_cloud_run_empty_plain_values() {
+  local name_only='{"spec":{"containers":[{"env":[{"name":"EMPTY"}]}]}}'
+  [ "$(regional_quota_revision_env "$name_only" EMPTY fallback)" = "" ] ||
+    fail "Cloud Run name-only empty value was not preserved"
+
+  local explicit_empty='{"spec":{"containers":[{"env":[{"name":"EMPTY","value":""}]}]}}'
+  [ "$(regional_quota_revision_env "$explicit_empty" EMPTY fallback)" = "" ] ||
+    fail "explicit empty value was not preserved"
+
+  [ "$(regional_quota_revision_env "$name_only" MISSING fallback)" = "fallback" ] ||
+    fail "missing environment variable did not use its default"
+}
+
+test_revision_env_rejects_non_plain_values() {
+  local secret_ref='{"spec":{"containers":[{"env":[{"name":"SECRET","valueFrom":{"secretKeyRef":{"name":"secret","key":"latest"}}}]}]}}'
+  if regional_quota_revision_env "$secret_ref" SECRET fallback >/dev/null 2>&1; then
+    fail "secret-backed environment variable was accepted as plain text"
+  fi
+
+  local non_string='{"spec":{"containers":[{"env":[{"name":"INVALID","value":false}]}]}}'
+  if regional_quota_revision_env "$non_string" INVALID fallback >/dev/null 2>&1; then
+    fail "non-string environment variable was accepted as plain text"
+  fi
+}
+
 test_missing_issuance_marker_blocks_enable() {
   SCENARIO=missing_marker
   if regional_quota_preflight_issuance_fleet >/dev/null 2>&1; then
@@ -180,7 +205,9 @@ test_ambiguous_traffic_fails_closed
 test_read_errors_are_not_fresh_environments
 test_only_exact_service_not_found_is_a_fresh_environment
 test_raw_issuance_input_is_normalized_in_shell
+test_revision_env_accepts_cloud_run_empty_plain_values
+test_revision_env_rejects_non_plain_values
 test_missing_issuance_marker_blocks_enable
 test_capability_false_blocks_enable
 test_all_compatible_active_revisions_pass
-printf '%s\n' 'regional quota rollout shell tests: 8 passed'
+printf '%s\n' 'regional quota rollout shell tests: 10 passed'

--- a/tests/test_regional_quota_rollout_shell.py
+++ b/tests/test_regional_quota_rollout_shell.py
@@ -18,4 +18,4 @@ def test_regional_quota_rollout_shell_contract() -> None:
         check=False,
     )
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "8 passed" in result.stdout
+    assert "10 passed" in result.stdout


### PR DESCRIPTION
## Summary
- treat Cloud Run name-only environment entries as empty plain-string values
- continue rejecting secret-backed and malformed environment entries
- add shell regressions for the serialized empty-value shape

## Verification
- `bash tests/shell/test_regional_quota_rollout.sh`
- `uv run pytest -q tests/test_regional_quota_rollout_shell.py tests/test_deploy_secret_wiring.py tests/test_deploy_script_execution.py` (120 passed)
- `uv run ruff check .`
- `uv run mypy`
- `shellcheck scripts/deploy/regional_quota_rollout.sh tests/shell/test_regional_quota_rollout.sh`

This fixes the pre-traffic failure in deploy run 33161920506 without changing regional quota values or secret handling.