### PR TITLE
deploy: ATTESTATION_PCR0 is a required dispatch input

### DIFF
--- a/.github/workflows/deploy-aws-control-plane.yml
+++ b/.github/workflows/deploy-aws-control-plane.yml
@@ -19,6 +19,9 @@ on:
         description: "Skip the EventBridge alignment section (SKIP_EVENTBRIDGE=1)"
         required: false
         default: "0"
+      attestation_pcr0:
+        description: "Published enclave PCR0 pin (from trust/aws-release.json) - the script refuses to run without it; pinning is the point"
+        required: true
 
 concurrency:
   group: deploy-aws-control-plane
@@ -48,4 +51,5 @@ jobs:
       - name: Deploy tr-eu from this commit
         env:
           SKIP_EVENTBRIDGE: ${{ inputs.skip_eventbridge }}
+          ATTESTATION_PCR0: ${{ inputs.attestation_pcr0 }}
         run: bash scripts/deploy/aws_eu_control_plane.sh


### PR DESCRIPTION
OIDC role assumption verified working on run 33178930075; the remaining gate is the script's deliberate PCR0 pin requirement. Dispatchers now pass it explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)