### PR TITLE
deploy: AWS workflow needs GCP WIF for the cross-cloud deploy mutex

### DIFF
--- a/.github/workflows/deploy-aws-control-plane.yml
+++ b/.github/workflows/deploy-aws-control-plane.yml
@@ -46,6 +46,18 @@ jobs:
           role-to-assume: arn:aws:iam::330422590279:role/tr-router-github-deploy
           aws-region: eu-west-3
 
+      # The production deploy mutex lives in GCS (deploy_mutex.sh) so ONE
+      # lock covers every cloud's deploy tooling; this AWS deploy therefore
+      # needs GCP auth too, via the repo's existing workload identity.
+      - name: Authenticate to GCP via WIF
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: projects/44325983244/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v3
+
       - uses: docker/setup-buildx-action@v3
 
       - name: Deploy tr-eu from this commit


### PR DESCRIPTION
The production deploy mutex is a GCS object (one lock across all clouds' tooling — correct design); the AWS deploy runner needs the repo's existing WIF auth to contend on it. Copies the exact auth steps from deploy.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)