### PR TITLE
deploy: expose the bake-gate override as a dispatch input

### DIFF
--- a/.github/workflows/deploy-aws-control-plane.yml
+++ b/.github/workflows/deploy-aws-control-plane.yml
@@ -22,6 +22,10 @@ on:
       attestation_pcr0:
         description: "Published enclave PCR0 pin (from trust/aws-release.json) - the script refuses to run without it; pinning is the point"
         required: true
+      bake_override_reason:
+        description: "Non-empty ONLY to override the cloud bake gate (TR_CLOUD_BAKE_OVERRIDE); state the incident/justification - it is recorded in the run log"
+        required: false
+        default: ""
 
 concurrency:
   group: deploy-aws-control-plane
@@ -64,4 +68,5 @@ jobs:
         env:
           SKIP_EVENTBRIDGE: ${{ inputs.skip_eventbridge }}
           ATTESTATION_PCR0: ${{ inputs.attestation_pcr0 }}
+          TR_CLOUD_BAKE_OVERRIDE: ${{ inputs.bake_override_reason }}
         run: bash scripts/deploy/aws_eu_control_plane.sh


### PR DESCRIPTION
Run 33180157138 got through credentials, PCR0, and the cross-cloud mutex; the bake gate then refused a fresh candidate, as designed. This exposes TR_CLOUD_BAKE_OVERRIDE as an explicit dispatch input so an incident deploy states its reason in the run log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)