### PR TITLE
deploy: keep the checkout clean of the GCP credentials file

### DIFF
--- a/.github/workflows/deploy-aws-control-plane.yml
+++ b/.github/workflows/deploy-aws-control-plane.yml
@@ -40,7 +40,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      # Checkout into a subdirectory: the GCP auth action writes its
+      # credentials file into the workspace ROOT, and the deploy script
+      # refuses a dirty tree ("a dirty tree deploys unvalidated code").
+      # Keeping the repo one level down keeps the tree clean.
       - uses: actions/checkout@v4
+        with:
+          path: src
 
       # The account's GitHub OIDC provider is pre-existing; this role is the
       # quill-router deploy grant (the TR_AWS_* repo secrets are dead - the
@@ -69,4 +75,5 @@ jobs:
           SKIP_EVENTBRIDGE: ${{ inputs.skip_eventbridge }}
           ATTESTATION_PCR0: ${{ inputs.attestation_pcr0 }}
           TR_CLOUD_BAKE_OVERRIDE: ${{ inputs.bake_override_reason }}
+        working-directory: src
         run: bash scripts/deploy/aws_eu_control_plane.sh


### PR DESCRIPTION
Run 33180406933 passed credentials, PCR0, mutex, and the bake override — then failed the script's dirty-tree assertion because google-github-actions/auth drops its credentials file in the workspace root. Subdirectory checkout keeps the validated tree clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)