### PR TITLE
Publish supported_parameters on the public model catalog

### DIFF
--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 from dataclasses import replace
 from datetime import datetime
 
+from trusted_router.catalog_capabilities import (
+    manifest_supported_parameters,
+    provider_extension_parameters,
+    union_supported_parameters,
+)
 from trusted_router.catalog_data import (  # noqa: F401 - re-exported for back-compat
     _EMBEDDING_SPECS,
     _MODEL_PROVIDER_PRIVACY_OVERRIDES,
@@ -525,6 +530,15 @@ def model_to_openrouter_shape(model: Model) -> dict[str, object]:
     byok_available = (
         False if is_meta else any(endpoint.usage_type == "BYOK" for endpoint in endpoints)
     )
+    supported_parameters = union_supported_parameters(
+        manifest_supported_parameters(
+            {},
+            supports_chat=model.supports_chat,
+            supports_embeddings=model.supports_embeddings,
+        ),
+        model.supported_parameters,
+        *(endpoint.supported_parameters for endpoint in endpoints),
+    )
 
     # For meta routers, derive prompt/completion price from the candidate range
     # rather than the catalog's hard-coded 0. Most OpenRouter-compat
@@ -685,6 +699,12 @@ def model_to_openrouter_shape(model: Model) -> dict[str, object]:
                 "provider_us_based": PROVIDERS[endpoint.provider].provider_headquarters_country
                 == PROVIDER_JURISDICTION_US,
                 "provider_eu_focused": endpoint.provider in EU_FOCUSED_PROVIDER_ORDER,
+                "supported_parameters": list(
+                    union_supported_parameters(
+                        endpoint.supported_parameters,
+                        provider_extension_parameters(endpoint.provider),
+                    )
+                ),
                 "request_price_microdollars": endpoint.request_price_microdollars,
             }
             for endpoint in endpoints
@@ -722,6 +742,7 @@ def model_to_openrouter_shape(model: Model) -> dict[str, object]:
             "is_moderated": False,
         },
         "per_request_limits": None,
+        "supported_parameters": list(supported_parameters),
         "trustedrouter": tr_block,
     }
 

--- a/src/trusted_router/catalog_capabilities.py
+++ b/src/trusted_router/catalog_capabilities.py
@@ -1,0 +1,124 @@
+"""Normalize provider catalog capability metadata into OpenRouter fields."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+# Keep common OpenRouter parameters stable for clients that compare catalogs or
+# generate deterministic documentation. Provider-specific passthrough fields
+# are retained after this known prefix in lexical order.
+_PARAMETER_ORDER = (
+    "tools",
+    "tool_choice",
+    "parallel_tool_calls",
+    "max_tokens",
+    "max_completion_tokens",
+    "temperature",
+    "top_p",
+    "top_k",
+    "min_p",
+    "reasoning",
+    "reasoning_effort",
+    "include_reasoning",
+    "structured_outputs",
+    "response_format",
+    "stop",
+    "frequency_penalty",
+    "presence_penalty",
+    "repetition_penalty",
+    "seed",
+    "logit_bias",
+    "logprobs",
+    "top_logprobs",
+    "stream_options",
+    "prediction",
+    "verbosity",
+    "web_search_options",
+    "dimensions",
+    "encoding_format",
+)
+_PARAMETER_RANK = {name: index for index, name in enumerate(_PARAMETER_ORDER)}
+
+_FEATURE_PARAMETERS: dict[str, tuple[str, ...]] = {
+    "function-calling": ("tools",),
+    "tools": ("tools",),
+    "tool-choice": ("tool_choice",),
+    "parallel-tool-calls": ("parallel_tool_calls",),
+    "reasoning": ("reasoning", "include_reasoning"),
+    "reasoning-effort": ("reasoning", "reasoning_effort", "include_reasoning"),
+    "reasoning_effort": ("reasoning", "reasoning_effort", "include_reasoning"),
+    "structured-output": ("structured_outputs",),
+    "structured-outputs": ("structured_outputs",),
+    "structured_outputs": ("structured_outputs",),
+    "json-mode": ("response_format",),
+    "json_mode": ("response_format",),
+    "response-format": ("response_format",),
+    "logprobs": ("logprobs",),
+}
+
+
+def _strings(value: object) -> Iterable[str]:
+    if not isinstance(value, (list, tuple, set, frozenset)):
+        return ()
+    return (item.strip() for item in value if isinstance(item, str) and item.strip())
+
+
+_PROVIDER_EXTENSION_PARAMETERS: dict[str, tuple[str, ...]] = {
+    # OpenAI's priority lane is selected per request and is not described by any
+    # manifest or snapshot field.
+    "openai": ("service_tier",),
+}
+
+
+def provider_extension_parameters(provider: str) -> tuple[str, ...]:
+    """Return parameters a provider accepts that no catalog manifest declares."""
+    return _PROVIDER_EXTENSION_PARAMETERS.get(provider, ())
+
+
+def union_supported_parameters(*groups: Iterable[str]) -> tuple[str, ...]:
+    """Return a deterministic union without discarding provider extensions."""
+    names = {name.strip() for group in groups for name in group if name.strip()}
+    return tuple(
+        sorted(
+            names,
+            key=lambda name: (_PARAMETER_RANK.get(name, len(_PARAMETER_RANK)), name),
+        )
+    )
+
+
+def manifest_supported_parameters(
+    raw: Mapping[str, Any],
+    *,
+    supports_chat: bool = True,
+    supports_embeddings: bool = False,
+) -> tuple[str, ...]:
+    """Translate one provider/model record into OpenRouter parameter names.
+
+    Explicit provider arrays are authoritative. Feature labels add only the
+    parameter they directly prove; for example, ``function-calling`` proves
+    ``tools`` but does not imply control through ``tool_choice``.
+    """
+    groups: list[Iterable[str]] = []
+    if supports_chat:
+        # The gateway normalizes response length for every chat adapter.
+        groups.append(("max_tokens",))
+    if supports_embeddings:
+        groups.append(("dimensions", "encoding_format"))
+
+    groups.append(_strings(raw.get("supported_parameters")))
+    groups.append(_strings(raw.get("supported_sampling_parameters")))
+
+    features = {
+        feature.lower().replace(" ", "-")
+        for feature in (
+            *_strings(raw.get("features")),
+            *_strings(raw.get("supported_features")),
+        )
+    }
+    for feature in features:
+        groups.append(_FEATURE_PARAMETERS.get(feature, ()))
+    if raw.get("supports_reasoning") is True:
+        groups.append(("reasoning", "include_reasoning"))
+
+    return union_supported_parameters(*groups)

--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -334,6 +334,7 @@ class Model:
     supports_messages: bool = False
     supports_embeddings: bool = False
     supports_video: bool = False
+    supported_parameters: tuple[str, ...] = ()
     input_modalities: tuple[str, ...] = ("text",)
     output_modalities: tuple[str, ...] = ("text",)
     prepaid_available: bool = False
@@ -362,6 +363,7 @@ class ModelEndpoint:
     provider: str
     usage_type: str
     upstream_id: str | None = None
+    supported_parameters: tuple[str, ...] = ()
     prompt_price_microdollars_per_million_tokens: int = 0
     completion_price_microdollars_per_million_tokens: int = 0
     published_prompt_price_microdollars_per_million_tokens: int = 0

--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -15,6 +15,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from trusted_router.catalog_capabilities import (
+    manifest_supported_parameters,
+    union_supported_parameters,
+)
 from trusted_router.catalog_data import (
     _EMBEDDING_SPECS,
     _PROVIDER_SERVED_MODEL_ALLOWLIST,
@@ -102,6 +106,14 @@ def _endpoint(
         provider=provider_slug,
         usage_type="BYOK" if usage_type.lower() == "byok" else "Credits",
         upstream_id=upstream_id or model.upstream_id,
+        supported_parameters=union_supported_parameters(
+            model.supported_parameters,
+            manifest_supported_parameters(
+                {},
+                supports_chat=model.supports_chat,
+                supports_embeddings=model.supports_embeddings,
+            ),
+        ),
         prompt_price_microdollars_per_million_tokens=model.prompt_price_microdollars_per_million_tokens,
         completion_price_microdollars_per_million_tokens=model.completion_price_microdollars_per_million_tokens,
         published_prompt_price_microdollars_per_million_tokens=model.published_prompt_price_microdollars_per_million_tokens,
@@ -710,6 +722,12 @@ def _ingested_models_and_endpoints() -> tuple[dict[str, Model], dict[str, ModelE
         architecture = raw_model.get("architecture")
         if not isinstance(architecture, dict):
             architecture = {}
+        supported_parameters = union_supported_parameters(
+            *(
+                manifest_supported_parameters(raw_ep)
+                for _p, _c, _t, _slug, raw_ep in per_endpoint_prices
+            )
+        )
         prepaid_available = any(
             slug in GATEWAY_PREPAID_PROVIDER_SLUGS for _p, _c, _t, slug, _ep in per_endpoint_prices
         )
@@ -720,6 +738,7 @@ def _ingested_models_and_endpoints() -> tuple[dict[str, Model], dict[str, ModelE
             context_length=context_length,
             supports_chat=True,
             supports_messages=supports_messages,
+            supported_parameters=supported_parameters,
             input_modalities=_modalities(
                 architecture.get("input_modalities"),
                 default=("text",),
@@ -750,6 +769,7 @@ def _ingested_models_and_endpoints() -> tuple[dict[str, Model], dict[str, ModelE
                     provider=slug,
                     usage_type="Credits",
                     upstream_id=upstream_id,
+                    supported_parameters=manifest_supported_parameters(raw_ep),
                     prompt_price_microdollars_per_million_tokens=prompt_price,
                     completion_price_microdollars_per_million_tokens=completion_price,
                     published_prompt_price_microdollars_per_million_tokens=prompt_price,
@@ -765,6 +785,7 @@ def _ingested_models_and_endpoints() -> tuple[dict[str, Model], dict[str, ModelE
                     provider=slug,
                     usage_type="BYOK",
                     upstream_id=upstream_id,
+                    supported_parameters=manifest_supported_parameters(raw_ep),
                     prompt_price_microdollars_per_million_tokens=prompt_price,
                     completion_price_microdollars_per_million_tokens=completion_price,
                     published_prompt_price_microdollars_per_million_tokens=prompt_price,
@@ -970,6 +991,7 @@ def _supplemental_provider_models_and_endpoints() -> tuple[
             )
             context_length = _as_positive_int(raw_model.get("context_length"))
             name = str(raw_model.get("display_name") or raw_model.get("title") or model_id)
+            supported_parameters = manifest_supported_parameters(raw_model)
             reliability = raw_model.get("reliability")
             if not isinstance(reliability, dict):
                 reliability = {}
@@ -982,6 +1004,7 @@ def _supplemental_provider_models_and_endpoints() -> tuple[
                 upstream_id=upstream_id,
                 supports_chat="chat/completions" in endpoint_types,
                 supports_messages=publisher == "anthropic",
+                supported_parameters=supported_parameters,
                 input_modalities=_modalities(
                     raw_model.get("input_modalities"),
                     default=("text",),
@@ -1026,6 +1049,7 @@ def _supplemental_provider_models_and_endpoints() -> tuple[
                     provider=provider_slug,
                     usage_type="Credits",
                     upstream_id=upstream_id,
+                    supported_parameters=supported_parameters,
                     prompt_price_microdollars_per_million_tokens=prompt_price,
                     completion_price_microdollars_per_million_tokens=completion_price,
                     published_prompt_price_microdollars_per_million_tokens=prompt_price,
@@ -1052,6 +1076,7 @@ def _supplemental_provider_models_and_endpoints() -> tuple[
                     provider=provider_slug,
                     usage_type="BYOK",
                     upstream_id=upstream_id,
+                    supported_parameters=supported_parameters,
                     prompt_price_microdollars_per_million_tokens=prompt_price,
                     completion_price_microdollars_per_million_tokens=completion_price,
                     published_prompt_price_microdollars_per_million_tokens=prompt_price,
@@ -1100,6 +1125,9 @@ def _embedding_models() -> dict[str, Model]:
             supports_chat=False,
             supports_messages=False,
             supports_embeddings=True,
+            supported_parameters=manifest_supported_parameters(
+                {}, supports_chat=False, supports_embeddings=True
+            ),
             prepaid_available=True,
             byok_available=True,
             prompt_price_microdollars_per_million_tokens=prompt_price,
@@ -1158,6 +1186,9 @@ def _embedding_models() -> dict[str, Model]:
                 supports_chat=False,
                 supports_messages=False,
                 supports_embeddings=True,
+                supported_parameters=manifest_supported_parameters(
+                    {}, supports_chat=False, supports_embeddings=True
+                ),
                 input_modalities=input_modalities,
                 output_modalities=("embeddings",),
                 prepaid_available=provider.supports_prepaid,

--- a/src/trusted_router/routes/catalog.py
+++ b/src/trusted_router/routes/catalog.py
@@ -31,6 +31,10 @@ from trusted_router.catalog import (
     provider_to_openrouter_shape,
     providers_for_display,
 )
+from trusted_router.catalog_capabilities import (
+    provider_extension_parameters,
+    union_supported_parameters,
+)
 from trusted_router.image_generation import (
     IMAGE_MODEL_ID_SET,
     image_input_modalities,
@@ -232,19 +236,6 @@ def _truthy_query(value: str | None) -> bool:
     return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _endpoint_supported_parameters(provider: str) -> list[str]:
-    parameters = [
-        "messages",
-        "temperature",
-        "top_p",
-        "max_tokens",
-        "stream",
-    ]
-    if provider == "openai":
-        parameters.append("service_tier")
-    return parameters
-
-
 def _openai_service_tier_metadata(provider: str, model_id: str) -> dict[str, Any]:
     if provider != "openai":
         return {}
@@ -305,6 +296,17 @@ def _public_model_matches_filters(shape: dict[str, Any], request: Request) -> bo
     )
     if region in {"eu", "europe"} and not trustedrouter.get("eu_focused_provider_available"):
         return False
+    requested_parameters = {
+        parameter.strip()
+        for raw in request.query_params.getlist("supported_parameters")
+        for parameter in raw.split(",")
+        if parameter.strip()
+    }
+    supported_parameters = {
+        str(parameter) for parameter in (shape.get("supported_parameters") or [])
+    }
+    if not requested_parameters.issubset(supported_parameters):
+        return False
     requested_output_modalities = {
         modality.strip().lower()
         for raw in request.query_params.getlist("output_modalities")
@@ -334,6 +336,7 @@ def _has_public_model_filters(request: Request) -> bool:
             "provider.region",
             "region",
             "output_modalities",
+            "supported_parameters",
         )
     )
 
@@ -517,7 +520,12 @@ def register_catalog_routes(router: APIRouter) -> None:
                     "completion_price_microdollars_per_million_tokens": (
                         endpoint.completion_price_microdollars_per_million_tokens
                     ),
-                    "supported_parameters": _endpoint_supported_parameters(endpoint.provider),
+                    "supported_parameters": list(
+                        union_supported_parameters(
+                            endpoint.supported_parameters,
+                            provider_extension_parameters(endpoint.provider),
+                        )
+                    ),
                     "trustedrouter": {
                         "attested_gateway": PROVIDERS[endpoint.provider].attested_gateway,
                         "stores_content": endpoint_stores_content(endpoint),

--- a/tests/test_catalog_supported_parameters.py
+++ b/tests/test_catalog_supported_parameters.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from trusted_router.catalog import MODELS, model_to_openrouter_shape
+from trusted_router.catalog_capabilities import manifest_supported_parameters
+
+
+def test_manifest_capabilities_preserve_explicit_parameters_and_features() -> None:
+    supported = manifest_supported_parameters(
+        {
+            "supported_parameters": ["temperature", "top_p"],
+            "supported_sampling_parameters": ["seed", "temperature"],
+            "features": [
+                "function-calling",
+                "structured-outputs",
+                "response-format",
+            ],
+            "supports_reasoning": True,
+        }
+    )
+
+    assert supported == (
+        "tools",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "structured_outputs",
+        "response_format",
+        "seed",
+    )
+
+
+def test_manifest_capabilities_do_not_invent_tool_choice() -> None:
+    supported = manifest_supported_parameters({"features": ["function-calling"]})
+
+    assert "tools" in supported
+    assert "tool_choice" not in supported
+
+
+def test_public_models_publish_openrouter_supported_parameters(client: TestClient) -> None:
+    response = client.get("/v1/models")
+
+    assert response.status_code == 200
+    models = response.json()["data"]
+    assert models
+    assert all(isinstance(model["supported_parameters"], list) for model in models)
+    assert all(
+        model["supported_parameters"] for model in models if model["trustedrouter"]["supports_chat"]
+    )
+
+    by_id = {model["id"]: model for model in models}
+    sonnet = by_id["anthropic/claude-sonnet-5"]
+    assert {"tools", "tool_choice", "reasoning", "structured_outputs"}.issubset(
+        sonnet["supported_parameters"]
+    )
+
+
+def test_model_capabilities_are_union_of_routable_endpoints() -> None:
+    model = MODELS["openai/gpt-oss-120b"]
+    shape = model_to_openrouter_shape(model)
+    endpoint_parameters = {
+        parameter
+        for endpoint in shape["trustedrouter"]["endpoints"]
+        for parameter in endpoint["supported_parameters"]
+    }
+
+    assert endpoint_parameters.issubset(set(shape["supported_parameters"]))
+    assert {"tools", "reasoning", "response_format"}.issubset(shape["supported_parameters"])
+
+
+def test_model_endpoints_publish_endpoint_specific_parameters(client: TestClient) -> None:
+    response = client.get("/v1/models/anthropic/claude-sonnet-5/endpoints")
+
+    assert response.status_code == 200
+    endpoints = response.json()["data"]
+    assert endpoints
+    assert all(isinstance(endpoint["supported_parameters"], list) for endpoint in endpoints)
+    assert any("tools" in endpoint["supported_parameters"] for endpoint in endpoints)
+
+
+def test_models_filter_requires_every_requested_supported_parameter(
+    client: TestClient,
+) -> None:
+    response = client.get("/v1/models?supported_parameters=tools,reasoning")
+
+    assert response.status_code == 200
+    models = response.json()["data"]
+    assert models
+    assert all({"tools", "reasoning"}.issubset(model["supported_parameters"]) for model in models)
+    assert client.get("/v1/models/count?supported_parameters=tools,reasoning").json()["data"][
+        "count"
+    ] == len(models)


### PR DESCRIPTION
`/v1/models` is OpenRouter-shaped but never carried `supported_parameters`, so a client reading the array to build a capability picture saw nothing — there was no way to tell whether a route accepts tools, structured output, or reasoning without trying it.

Models and endpoints now carry a declared parameter tuple, derived from arrays and feature labels the snapshot and provider manifests already ship. No new data collection: the raw fields were already in `openrouter_snapshot.json` and the provider manifests, just never read.

### What it publishes

- A **model** publishes the union of its own array and every routable endpoint's, so the model-level claim never understates a route that can serve it.
- Each **endpoint** publishes its own array, both in the `trustedrouter.endpoints` block and on `/v1/models/{author}/{slug}/endpoints`.
- `/v1/models` and `/v1/models/count` accept `?supported_parameters=a,b` and return only models declaring every requested name.

Nothing is invented. `function-calling` proves `tools` but not `tool_choice`. A provider extension no manifest can describe — OpenAI's `service_tier` — stays an explicit per-provider addition in `provider_extension_parameters` rather than being inferred; it replaces the hardcoded per-provider list that the endpoints route used before, so the OpenAI priority lane keeps advertising it.

### Why it matters beyond the catalog

Downstream gateways read this array to decide what a model can do. Experiential's provider parser is the concrete case: with the array absent, a consumer either has to mark every model as supporting nothing, or leave capabilities unknown and make the operator declare them by hand. See experientiallabs/experiential#638, which reads the array when present and falls back to unknown when it is absent.

### Verification

`ruff check .`, `mypy`, and the full suite pass: **7654 passed, 346 skipped, 10 xfailed**.

New tests cover the manifest translation, that the model array is a superset of its endpoints' arrays, the endpoints route, and the query filter. One of them caught a real gap during development: `_has_public_model_filters` gates whether the filtered path runs at all, so without registering the new key there, `?supported_parameters=` was silently served the cached unfiltered payload.