### PR TITLE
Authorize retry replay returns the stored authorization instead of 500

### DIFF
--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -186,6 +186,14 @@ from trusted_router.types import IdentityVerificationStatus, UsageType
 T = TypeVar("T")
 log = logging.getLogger(__name__)
 
+
+class _AuthorizationReplay(Exception):
+    """Divert a rebuilt authorization into the transaction's replay read."""
+
+    def __init__(self, authorization_id: str) -> None:
+        super().__init__(authorization_id)
+        self.authorization_id = authorization_id
+
 #: Whole-call budget for the /status.json outbox-lag read. Same 3s as
 #: `readiness_check`, and the same rule: a public page degrades rather than
 #: waits. See `SpannerBigtableStore.operational_analytics_outbox_freshness`.
@@ -3367,7 +3375,14 @@ class SpannerBigtableStore:
         ) -> GatewayAuthorization:
             existing = built_authorizations.get(authorization_id)
             if existing is not None:
-                assert existing.credit_reservation_id == reservation_id
+                if existing.credit_reservation_id != reservation_id:
+                    # A cold-path retry can race an already-committed attempt
+                    # after the route's pre-transaction idempotency probe was
+                    # removed. Do not let the fresh reservation reach the hold
+                    # DML with an authorization object tied to the old hold.
+                    # The typed signal below rebuilds once, then the atomic
+                    # transaction's first read returns the stored winner.
+                    raise _AuthorizationReplay(authorization_id)
                 return existing
             built = GatewayAuthorization(
                 id=authorization_id,
@@ -3459,28 +3474,39 @@ class SpannerBigtableStore:
         )
 
         def run_authorize(candidates: tuple[int, ...]) -> dict[str, Any]:
-            return authorize_atomic(
-                self._database,
-                self._param_types,
-                workspace_id=workspace_id,
-                key_hash=key_hash,
-                estimate=estimate,
-                has_credit_candidate=has_credit_candidate,
-                reservation_usage_type=str(usage),
-                idempotency_scope=scope,
-                idempotency_fingerprint=idempotency_fingerprint,
-                expires_at=expires_at,
-                build_authorization=build_authorization,
-                build_auth_body=build_body,
-                request_record_write_mode=self.request_record_write_mode,
-                # Retain `candidates` in full outside this transaction for the
-                # lock-free aggregate check and cold rebalance below. A depleted
-                # workspace must never make one rejected transaction lock every
-                # configured shard.
-                credit_shard_candidates=bounded_credit_shard_candidates(candidates),
-                key_shard_candidates=key_shard_candidates,
-                authorization_id=authorization_id,
-            )
+            def invoke() -> dict[str, Any]:
+                return authorize_atomic(
+                    self._database,
+                    self._param_types,
+                    workspace_id=workspace_id,
+                    key_hash=key_hash,
+                    estimate=estimate,
+                    has_credit_candidate=has_credit_candidate,
+                    reservation_usage_type=str(usage),
+                    idempotency_scope=scope,
+                    idempotency_fingerprint=idempotency_fingerprint,
+                    expires_at=expires_at,
+                    build_authorization=build_authorization,
+                    build_auth_body=build_body,
+                    request_record_write_mode=self.request_record_write_mode,
+                    # Retain `candidates` in full outside this transaction for the
+                    # lock-free aggregate check and cold rebalance below. A depleted
+                    # workspace must never make one rejected transaction lock every
+                    # configured shard.
+                    credit_shard_candidates=bounded_credit_shard_candidates(candidates),
+                    key_shard_candidates=key_shard_candidates,
+                    authorization_id=authorization_id,
+                )
+
+            try:
+                return invoke()
+            except _AuthorizationReplay as replay:
+                # authorize_atomic builds its response object before opening
+                # the transaction. Drop that stale object and enter once more:
+                # the transaction's first operation is the scoped idempotency
+                # read, so a winner replays before any new key/credit hold DML.
+                built_authorizations.pop(replay.authorization_id, None)
+                return invoke()
 
         result = run_authorize(credit_shard_candidates)
         if result["outcome"] == AuthorizeOutcome.KEY_LIMIT_EXCEEDED and key_counter_shards > 1:

--- a/tests/test_gateway_authorize_spanner_operations.py
+++ b/tests/test_gateway_authorize_spanner_operations.py
@@ -6,6 +6,7 @@ import pytest
 from starlette.requests import Request
 
 from tests.fakes.spanner import make_fake_store
+from trusted_router import storage_gcp_authorize, storage_gcp_key_escrow
 from trusted_router.config import Settings
 from trusted_router.routes.internal import gateway
 from trusted_router.schemas import GatewayAuthorizeRequest
@@ -113,6 +114,72 @@ def test_typed_authorize_replay_and_mismatch_still_come_from_transaction() -> No
     with pytest.raises(Exception) as raised:
         gateway._authorize_gateway_sync(_request(), changed, settings)
     assert getattr(raised.value, "status_code", None) == 409
+
+
+def test_typed_replay_race_returns_stored_authorization_without_second_reservation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mutation guard: restoring the reservation-id assert makes this fail."""
+    store, database, key = _seed_typed_gateway_store()
+    key.usage_shard_count = 2
+    store._write_entity("api_key", key.hash, key)
+    settings = Settings(environment="test")
+    first = gateway._authorize_gateway_sync(_request(), _body(key.hash), settings)
+
+    real_authorize_atomic = storage_gcp_authorize.authorize_atomic
+    forced_retry = False
+
+    def force_cold_retry(*args: object, **kwargs: object) -> dict[str, object]:
+        nonlocal forced_retry
+        result = real_authorize_atomic(*args, **kwargs)
+        if not forced_retry:
+            assert result["outcome"] == AuthorizeOutcome.REPLAY
+            forced_retry = True
+            return {"outcome": AuthorizeOutcome.KEY_LIMIT_EXCEEDED}
+        return result
+
+    monkeypatch.setattr(storage_gcp_authorize, "authorize_atomic", force_cold_retry)
+    monkeypatch.setattr(
+        storage_gcp_key_escrow,
+        "rebalance_key_limit_headroom",
+        lambda *_args, **_kwargs: True,
+    )
+
+    replay = gateway._authorize_gateway_sync(_request(), _body(key.hash), settings)
+
+    assert forced_retry is True
+    assert replay["data"]["idempotent_replay"] is True
+    assert replay["data"]["authorization_id"] == first["data"]["authorization_id"]
+    assert (
+        replay["data"]["credit_reservation_id"]
+        == first["data"]["credit_reservation_id"]
+    )
+    assert list(database.reservations) == [first["data"]["credit_reservation_id"]]
+
+
+def test_typed_replay_has_exact_sequential_spanner_operation_count() -> None:
+    _store, database, key = _seed_typed_gateway_store()
+    gateway._BROADCAST_EMPTY_CACHE.clear()
+    assert gateway._broadcast_destinations_for_authorize(key.workspace_id) == []
+    gateway._authorize_gateway_sync(_request(), _body(key.hash), Settings(environment="test"))
+    before = (
+        database.snapshot_execute_sql_calls,
+        database.transaction_execute_sql_calls,
+        database.transaction_execute_update_calls,
+    )
+
+    replay = gateway._authorize_gateway_sync(
+        _request(), _body(key.hash), Settings(environment="test")
+    )
+
+    after = (
+        database.snapshot_execute_sql_calls,
+        database.transaction_execute_sql_calls,
+        database.transaction_execute_update_calls,
+    )
+    operation_count = sum(end - start for start, end in zip(before, after, strict=True))
+    assert replay["data"]["idempotent_replay"] is True
+    assert operation_count == 6
 
 
 def test_typed_accepted_authorization_is_returned_without_post_commit_read(


### PR DESCRIPTION
Fixes the active billing-path 5xx (root-caused from the Cloud Monitoring alerts): retries with the same idempotency key hit a bare assert that assumed the lane-B-removed pre-txn probe had intercepted replays — onset dates exactly to the diet's deploy (0 tracebacks before Aug 27; 8 since, at rollout retry storms).

Fix: assert deleted; mismatch raises typed `_AuthorizationReplay` → transaction aborts cleanly → re-entry resolves the stored idempotency winner **before any hold DML** → caller receives the original authorization. Replay path op-count-pinned at 6, fresh at 10 (both by test, keeping the diet's budget honest).

Gate (Fable): full suite **7,650 passed / 0 failed** unsandboxed; mutation re-run via reverse-edit — reinstating the assert fails the named race test, restore is green; no code path can reach the old assert (deleted, source-searched).

Authored by Sol (codex-cli); reviewed, tested, and mutation-verified by Fable. Needs admin merge (gate-on-ci quirk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)