### PR TITLE
Regional settle survives an erased hold: drain the lease, fall back, never 500

### DIFF
--- a/src/trusted_router/services/regional_quota_leases.py
+++ b/src/trusted_router/services/regional_quota_leases.py
@@ -44,6 +44,10 @@ class LeaseSettlementError(RegionalQuotaLeaseError):
     pass
 
 
+class UnknownRegionalReservationError(LeaseSettlementError):
+    """The durable lease snapshot no longer contains a request hold."""
+
+
 @dataclass(frozen=True, slots=True)
 class QuotaLeaseHold:
     hold_id: str
@@ -253,7 +257,7 @@ class RegionalQuotaLease:
     def _required_hold(self, hold_id: str) -> QuotaLeaseHold:
         hold = self._hold(hold_id)
         if hold is None:
-            raise LeaseSettlementError("unknown regional reservation")
+            raise UnknownRegionalReservationError("unknown regional reservation")
         return hold
 
     def _replace_hold(self, replacement: QuotaLeaseHold) -> RegionalQuotaLease:

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -2759,12 +2759,58 @@ class SpannerBigtableStore:
         authorization = self.get_gateway_authorization(authorization_id)
         if authorization is None or authorization.credit_reservation_id is None:
             return TypedFinalizeResult(finalized=False, activity_indexed=False)
+        regional_hold_unknown = False
         if authorization.settlement == "regional_lease":
-            self._finalize_regional_quota_hold(
-                authorization,
-                success=success,
-                actual_microdollars=actual_microdollars,
+            from trusted_router.services.regional_quota_leases import (
+                LeaseState,
+                UnknownRegionalReservationError,
             )
+
+            try:
+                self._finalize_regional_quota_hold(
+                    authorization,
+                    success=success,
+                    actual_microdollars=actual_microdollars,
+                )
+            except UnknownRegionalReservationError:
+                # A pre-CAS-fix stale Bigtable writer could erase a newer hold
+                # while the request's Spanner reservation remained durable.
+                # Disable further issuance from the damaged lease before the
+                # direct booking; otherwise its erased capacity could be spent
+                # again during the remaining TTL. Claim the Spanner reservation
+                # below as the exactly-once boundary. Every failure to durably
+                # drain remains retryable/fail-closed.
+                ledger = self._regional_quota_ledger
+                assert ledger is not None
+                local = ledger.get(
+                    str(authorization.regional_lease_id),
+                    region=str(authorization.region),
+                )
+                if local is None:
+                    from trusted_router.regional_quota_ledger import (
+                        RegionalLeaseNotFound,
+                    )
+
+                    raise RegionalLeaseNotFound("regional lease was not found") from None
+                if local.state == LeaseState.ACTIVE:
+                    local = ledger.begin_drain(
+                        local.lease_id,
+                        region=local.region,
+                        fencing_token=local.fencing_token,
+                    )
+                if local.state not in {
+                    LeaseState.DRAINING,
+                    LeaseState.CLOSED,
+                    LeaseState.QUARANTINED,
+                }:
+                    raise RuntimeError("damaged regional lease remained available") from None
+                regional_hold_unknown = True
+                log.error(
+                    "regional quota hold missing; using typed reservation fallback "
+                    "authorization_id=%s lease_id=%s",
+                    authorization.id,
+                    authorization.regional_lease_id,
+                )
         actual_usage_type = UsageType.coerce(selected_usage_type)
         generation_writes: list[tuple[str, str, str]] = []
         if success and generation is not None:
@@ -2808,6 +2854,7 @@ class SpannerBigtableStore:
             ),
             user_model_payout=user_model_payout,
             app_markup_payout=app_markup_payout,
+            regional_hold_unknown=regional_hold_unknown,
         )
         spanner_ms = (time.perf_counter() - spanner_start) * 1000
         if result["outcome"] == SettleOutcome.ERROR:
@@ -3099,7 +3146,7 @@ class SpannerBigtableStore:
         region = authorization.region
         if not lease_id or not fencing_token or not hold_id or not region:
             raise RuntimeError("regional authorization is missing lease identity")
-        if actual_microdollars > authorization.estimated_microdollars:
+        if not 0 <= actual_microdollars <= authorization.estimated_microdollars:
             raise RuntimeError("regional settlement exceeds its exact reservation")
         if success:
             ledger.settle(

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -844,6 +844,7 @@ def typed_finalize_atomic(
     operational_analytics_outbox: Any | None = None,
     user_model_payout: UserModelPayout | None = None,
     app_markup_payout: AppMarkupPayout | None = None,
+    regional_hold_unknown: bool = False,
 ) -> dict:
     """Full DML-only finalize for the typed path (codex 3e, Option B).
 
@@ -909,6 +910,24 @@ def typed_finalize_atomic(
             )
             if credit_count != 1:
                 raise _SettleError("credit release row-count != 1")
+        elif regional_hold_unknown and res.get("hold_usage_type") == "RegionalCredits":
+            # The regional grant already reserved this money, but a historical
+            # stale-CAS overwrite can leave no per-request Bigtable hold for the
+            # reconciler to import. Charge against the reservation's atomic
+            # claim without releasing the still-bounded lease grant. Closing
+            # reconciliation later releases that grant as unused, leaving this
+            # direct charge as the single durable booking.
+            credit_actual = book_actual if settled_usage_type == "Credits" else 0
+            credit_count = release_credit(
+                transaction,
+                pt,
+                res["workspace_id"],
+                0,
+                credit_actual,
+                shard=res["credit_shard"],
+            )
+            if credit_count != 1:
+                raise _SettleError("regional fallback credit booking row-count != 1")
 
         if success and user_model_payout is not None and user_model_payout.amount_microdollars > 0:
             # Deliberately NOT wrapped in a swallow. The payout is two DML

--- a/tests/test_regional_quota_spanner.py
+++ b/tests/test_regional_quota_spanner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -391,6 +392,134 @@ def test_store_regional_authorize_settle_replay_and_reconcile_end_to_end() -> No
         7_500,
         0,
     )
+
+
+def test_regional_settle_falls_back_when_stale_cas_erased_authorized_hold() -> None:
+    store, database, _ = make_fake_store(request_record_write_mode="typed")
+    ledger = InMemoryRegionalQuotaLedger()
+    store._regional_quota_ledger = ledger
+    workspace = store.create_workspace(
+        "owner",
+        "regional-lost-hold",
+        trial_credit_microdollars=100_000_000,
+    )
+    _raw, key = store.create_api_key(
+        workspace_id=workspace.id,
+        name="uncapped",
+        creator_user_id="owner",
+    )
+    outcome, authorization = store.authorize_gateway_regional(
+        authorization_id="gwa-lost-by-stale-cas",
+        workspace_id=workspace.id,
+        key_hash=key.hash,
+        key_usage_shards=key.usage_shard_count,
+        estimate=10_000,
+        model_id="model",
+        provider="provider",
+        requested_model_id="model",
+        candidate_model_ids=["model"],
+        region="us-central1",
+        endpoint_id="provider/model",
+        candidate_endpoint_ids=["provider/model"],
+        idempotency_key="lost-hold-request",
+        idempotency_fingerprint="b" * 64,
+        tags={"test": "regional-lost-hold"},
+        expires_at=datetime.now(UTC) + timedelta(hours=2),
+        lease_ttl_seconds=60,
+        lease_max_microdollars=10_000_000,
+        lease_max_available_basis_points=1_000,
+        lease_shard_count=16,
+    )
+
+    assert outcome == "accepted"
+    assert authorization is not None
+    lease_key = ("us-central1", str(authorization.regional_lease_id))
+    with ledger._lock:
+        current = ledger._leases[lease_key]
+        assert [hold.hold_id for hold in current.holds] == [authorization.id]
+        # Reproduce the pre-#727 Bigtable race: a writer that read the empty
+        # lease before this reservation was allowed to commit its stale snapshot
+        # afterward because a historical version cell satisfied the CAS filter.
+        ledger._leases[lease_key] = replace(current, holds=())
+    before = _credit_totals(database, workspace.id)
+
+    finalized = store.typed_finalize_gateway_authorization_result(
+        authorization.id,
+        success=True,
+        actual_microdollars=7_500,
+        selected_usage_type=UsageType.CREDITS,
+    )
+
+    assert finalized.finalized is True
+    after = _credit_totals(database, workspace.id)
+    assert after == (before[0], 7_500, before[2])
+    reservation = store.read_typed_reservation(str(authorization.credit_reservation_id))
+    assert reservation is not None
+    assert reservation["settled"] is True
+    assert reservation["actual_micro"] == 7_500
+    damaged = ledger.get(lease_key[1], region=lease_key[0])
+    assert damaged is not None
+    assert damaged.state.value == "draining"
+
+    target_shard = int.from_bytes(
+        hashlib.sha256(("b" * 64).encode()).digest()[:4],
+        "big",
+    ) % 16
+    replacement_fingerprint = next(
+        candidate
+        for index in range(10_000)
+        if (
+            candidate := hashlib.sha256(f"replacement-{index}".encode()).hexdigest()
+        )
+        != "b" * 64
+        and int.from_bytes(hashlib.sha256(candidate.encode()).digest()[:4], "big") % 16
+        == target_shard
+    )
+    next_outcome, next_authorization = store.authorize_gateway_regional(
+        authorization_id="gwa-after-lost-hold",
+        workspace_id=workspace.id,
+        key_hash=key.hash,
+        key_usage_shards=key.usage_shard_count,
+        estimate=10_000,
+        model_id="model",
+        provider="provider",
+        requested_model_id="model",
+        candidate_model_ids=["model"],
+        region="us-central1",
+        endpoint_id="provider/model",
+        candidate_endpoint_ids=["provider/model"],
+        idempotency_key="after-lost-hold",
+        idempotency_fingerprint=replacement_fingerprint,
+        tags={},
+        expires_at=datetime.now(UTC) + timedelta(hours=2),
+        lease_ttl_seconds=60,
+        lease_max_microdollars=10_000_000,
+        lease_max_available_basis_points=1_000,
+        lease_shard_count=16,
+    )
+    assert next_outcome == "unavailable"
+    assert next_authorization is None
+    assert ledger.get(lease_key[1], region=lease_key[0]) == damaged
+
+    replay = store.typed_finalize_gateway_authorization_result(
+        authorization.id,
+        success=True,
+        actual_microdollars=7_500,
+        selected_usage_type=UsageType.CREDITS,
+    )
+    assert replay.finalized is False
+    assert _credit_totals(database, workspace.id) == after
+
+    reconciled = store.reconcile_regional_quota_leases(
+        now=datetime.now(UTC) + timedelta(minutes=2),
+    )
+    assert reconciled == {
+        "inspected": 1,
+        "reconciled": 1,
+        "closed": 1,
+        "errors": 0,
+    }
+    assert _credit_totals(database, workspace.id) == (100_000_000, 7_500, 0)
 
 
 def test_missing_regional_ledger_is_a_retryable_settlement_error() -> None:


### PR DESCRIPTION
Closes the third and last bug family behind the billing-path 5xx alerts (Aug 22 incidents: `LeaseSettlementError: unknown regional reservation`).

**Root cause**: stale CAS whole-row overwrites around #727's rollout erased authorized holds. The originating write bug was already hotfixed upstream (`c3c927ca`) — no recurrence since Aug 22 — so this PR is the terminal safety net for the aftermath class: money fails closed (the damaged lease is durably drained first, so erased capacity cannot be issued again), the request fails open (ordinary typed settlement books actual usage; the Spanner reservation claim remains the exactly-once boundary; reconciliation releases the grant), and retries stay idempotent. Six alternative mechanisms eliminated with file:line evidence in the review record.

**Gate (Fable)**: full suite **7,649 passed / 0 failed** unsandboxed; mutation re-run — disabling the fallback handler fails the named stale-CAS regression test, restore green.

With this, the alert taxonomy is fully closed: convoy-class (shed + fast-burn alert + lease program), replay race (#918, deployed), regional aftermath (this PR).

Authored by Sol (codex-cli); reviewed, tested, and mutation-verified by Fable. Needs admin merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)