### PR TITLE
Redesign public model discovery

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -129,6 +129,18 @@ PROVIDER_PERFORMANCE_INDEX_MIN_SAMPLES = 20
 MODEL_COMPARE_URL_LIMIT = 2_600
 MODEL_COMPARE_MODEL_LIMIT = 73
 MODEL_COMPARE_PAGE_SIZE = 100
+MODEL_DISCOVERY_PAGE_SIZE = 24
+MODEL_DISCOVERY_PRIORITY: tuple[str, ...] = (
+    "z-ai/glm-5.3-flash",
+    "z-ai/glm-5.3",
+    "moonshotai/kimi-k3",
+    "deepseek/deepseek-v4-pro-0813",
+    "deepseek/deepseek-v4-flash-0731",
+    "minimax/minimax-m3",
+)
+_MODEL_DISCOVERY_PRIORITY_INDEX = {
+    model_id: index for index, model_id in enumerate(MODEL_DISCOVERY_PRIORITY)
+}
 SEO_CORE_PATHS: tuple[str, ...] = (
     "/azure-openai-alternative",
     "/deepseek-api-privacy",
@@ -3368,14 +3380,22 @@ def subprocessors_json(settings: Settings) -> str:
 
 def public_models_html(settings: Settings, *, model_filter: str = "all") -> str:
     test_mode = settings.environment == "test"
-    models = [_model_view(model, test_mode=test_mode) for model in MODELS.values()]
+    all_models = [_model_view(model, test_mode=test_mode) for model in MODELS.values()]
+    all_models.sort(key=_model_discovery_sort_key)
+    models = all_models
     normalized_filter = model_filter.strip().lower()
-    if normalized_filter == "open":
+    if normalized_filter in {"open", "open-weight"}:
+        normalized_filter = "open"
         models = [model for model in models if model.get("open_weights")]
     elif normalized_filter == "us":
         models = [model for model in models if model.get("us_provider_available")]
     elif normalized_filter == "eu":
         models = [model for model in models if model.get("eu_focused_provider_available")]
+    elif normalized_filter == "zdr":
+        models = [model for model in models if model.get("zdr_available")]
+    elif normalized_filter in {"e2e", "confidential"}:
+        normalized_filter = "e2e"
+        models = [model for model in models if model.get("e2e_available")]
     else:
         normalized_filter = "all"
     item_list_rows: list[dict[str, object]] = []
@@ -3401,12 +3421,23 @@ def public_models_html(settings: Settings, *, model_filter: str = "all") -> str:
                 "privacy policy, and live API routes. Filter open-weight, US, and EU options."
             ),
             models=models,
+            total_model_count=len(all_models),
+            total_provider_count=len(
+                {
+                    str(provider["slug"])
+                    for model in all_models
+                    for provider in cast(list[dict[str, str]], model["providers"])
+                }
+            ),
+            initial_page_size=MODEL_DISCOVERY_PAGE_SIZE,
             active_filter=normalized_filter,
             model_filters=[
                 {"id": "all", "label": "All", "href": "/models"},
                 {"id": "open", "label": "Open weights", "href": "/models?filter=open"},
                 {"id": "us", "label": "US providers", "href": "/models?filter=us"},
                 {"id": "eu", "label": "EU-focused", "href": "/models?filter=eu"},
+                {"id": "zdr", "label": "ZDR available", "href": "/models?filter=zdr"},
+                {"id": "e2e", "label": "E2EE available", "href": "/models?filter=e2e"},
             ],
             json_ld_blob=_json_ld_graph(
                 settings,
@@ -3421,6 +3452,23 @@ def public_models_html(settings: Settings, *, model_filter: str = "all") -> str:
             static_version=_static_version(settings),
         )
     )
+
+
+def _model_discovery_sort_key(model: Mapping[str, object]) -> tuple[int, int, int, str]:
+    model_id = str(model["id"])
+    featured_rank = _MODEL_DISCOVERY_PRIORITY_INDEX.get(model_id)
+    if featured_rank is not None:
+        return (0, featured_rank, 0, "")
+    ai_iq = model.get("ai_iq")
+    ai_iq_rank = 1_000_000
+    if isinstance(ai_iq, Mapping):
+        try:
+            ai_iq_rank = int(ai_iq.get("rank", ai_iq_rank))
+        except (TypeError, ValueError):
+            pass
+    section = 2 if model.get("is_meta") else 1
+    provider_count = int(model.get("provider_count") or 0)
+    return (section, ai_iq_rank, -provider_count, str(model["name"]).casefold())
 
 
 def public_benchmarks_html(settings: Settings) -> str:
@@ -4667,12 +4715,14 @@ def docs_llms_full_txt(settings: Settings) -> str:
 
 def _model_view(model: Model, *, test_mode: bool = False) -> dict[str, object]:
     provider = PROVIDERS[model.provider]
-    endpoints = endpoints_for_model(model.id) if model.id not in META_MODEL_IDS else []
+    is_meta = model.id in META_MODEL_IDS
+    endpoints = endpoints_for_model(model.id) if not is_meta else []
+    route_endpoints = _model_route_endpoints(model)
     ai_iq = (
         ai_iq_for_model(model.id, test_mode=test_mode) if model.id not in META_MODEL_IDS else None
     )
     if (
-        model.id in META_MODEL_IDS
+        is_meta
         and model.prompt_price_microdollars_per_million_tokens == 0
         and model.completion_price_microdollars_per_million_tokens == 0
     ):
@@ -4687,6 +4737,13 @@ def _model_view(model: Model, *, test_mode: bool = False) -> dict[str, object]:
     else:
         prompt = _price(model.prompt_price_microdollars_per_million_tokens)
         completion = _price(model.completion_price_microdollars_per_million_tokens)
+    cached_prices = _cached_prompt_prices(route_endpoints)
+    if cached_prices:
+        cached_prompt = _price_values_range(cached_prices)
+    elif is_meta:
+        cached_prompt = "selected route"
+    else:
+        cached_prompt = "Not published"
     providers = _endpoint_provider_views(endpoints, fallback_provider=model.provider)
     endpoint_postures = {
         (
@@ -4710,14 +4767,35 @@ def _model_view(model: Model, *, test_mode: bool = False) -> dict[str, object]:
         provider_confidential_compute,
         provider_e2ee,
     ) = next(iter(endpoint_postures))
+    prompt_price_sort = _minimum_model_price(
+        model,
+        endpoints=route_endpoints,
+        attr="prompt_price_microdollars_per_million_tokens",
+    )
+    completion_price_sort = _minimum_model_price(
+        model,
+        endpoints=route_endpoints,
+        attr="completion_price_microdollars_per_million_tokens",
+    )
+    provider_search_terms = [
+        term
+        for provider_view in providers
+        for term in (provider_view["slug"], provider_view["name"])
+    ]
     return {
         "id": model.id,
         "name": model.name,
         "provider": provider.name,
         "publisher_slug": model.provider,
         "context_length": f"{model.context_length:,}",
+        "context_length_compact": _compact_token_count(model.context_length),
+        "context_length_int": model.context_length,
         "prompt_price": prompt,
+        "cached_prompt_price": cached_prompt,
         "completion_price": completion,
+        "prompt_price_sort": prompt_price_sort,
+        "cached_price_sort": min(cached_prices) if cached_prices else None,
+        "completion_price_sort": completion_price_sort,
         # Derive from endpoints (not the raw Model flag): supplemental
         # provider-native models carry prepaid_available=False as a catalog
         # dedup marker, but DO have a priced Credits endpoint and are fully
@@ -4735,6 +4813,19 @@ def _model_view(model: Model, *, test_mode: bool = False) -> dict[str, object]:
             "varies by route" if len(providers) == 1 else "varies by provider"
         ),
         "open_weights": model_open_weights(model),
+        "is_meta": is_meta,
+        "featured_rank": _MODEL_DISCOVERY_PRIORITY_INDEX.get(model.id),
+        "zdr_available": any(
+            endpoint_zero_data_retention(endpoint) is True for endpoint in route_endpoints
+        ),
+        "confidential_available": any(
+            endpoint_confidential_compute(endpoint) is True for endpoint in route_endpoints
+        ),
+        "e2e_available": any(
+            endpoint_confidential_compute(endpoint) is True
+            and endpoint_e2ee(endpoint) is True
+            for endpoint in route_endpoints
+        ),
         "orchestration_primitive": orchestration_primitive(model.id),
         "orchestration_role": orchestration_role(model.id),
         "canonical_model_id": canonical_orchestration_model_id(model.id),
@@ -4743,6 +4834,16 @@ def _model_view(model: Model, *, test_mode: bool = False) -> dict[str, object]:
         "ai_iq": ai_iq,
         "us_provider_available": model_us_provider_available(model),
         "eu_focused_provider_available": model_eu_focused_provider_available(model),
+        "search_text": " ".join(
+            (
+                model.id,
+                model.name,
+                model.provider,
+                provider.name,
+                *provider_search_terms,
+            )
+        ).casefold(),
+        "endpoints_url": None if is_meta else f"/v1/models/{model.id}/endpoints",
         "detail_href": f"/models/{model.id}",
         "benchmarks_href": (
             f"/models/{model.id}/benchmarks"
@@ -4760,6 +4861,60 @@ def _model_view(model: Model, *, test_mode: bool = False) -> dict[str, object]:
             else None
         ),
     }
+
+
+def _model_route_endpoints(
+    model: Model,
+    *,
+    _seen: frozenset[str] = frozenset(),
+) -> list[ModelEndpoint]:
+    """Return reachable concrete endpoints without exposing hidden compositions."""
+    if model.id in _seen:
+        return []
+    if model.id not in META_MODEL_IDS:
+        return endpoints_for_model(model.id)
+    if model.hidden_public_metadata:
+        return []
+    next_seen = frozenset((*_seen, model.id))
+    return [
+        endpoint
+        for candidate in meta_candidate_models(model.id)
+        for endpoint in _model_route_endpoints(candidate, _seen=next_seen)
+    ]
+
+
+def _cached_prompt_prices(endpoints: Sequence[ModelEndpoint]) -> list[int]:
+    prices: list[int] = []
+    for endpoint in endpoints:
+        tiers = endpoint.price_tiers or ()
+        for tier in tiers:
+            cached = tier.prompt_cached_price_microdollars_per_million_tokens
+            if cached is not None and cached > 0:
+                prices.append(cached)
+    return prices
+
+
+def _minimum_model_price(
+    model: Model,
+    *,
+    endpoints: Sequence[ModelEndpoint],
+    attr: str,
+) -> int | None:
+    values = [getattr(endpoint, attr) for endpoint in endpoints if getattr(endpoint, attr) > 0]
+    if values:
+        return min(values)
+    model_value = getattr(model, attr)
+    return model_value if model_value > 0 else None
+
+
+def _compact_token_count(value: int) -> str:
+    if value >= 1_000_000:
+        compact = f"{Decimal(value) / Decimal(1_000_000):.2f}".rstrip("0").rstrip(".")
+        return f"{compact}M"
+    if value >= 1_000:
+        compact = f"{Decimal(value) / Decimal(1_000):.0f}"
+        return f"{compact}K"
+    return str(value)
 
 
 def _endpoint_provider_views(
@@ -5832,6 +5987,10 @@ def _endpoint_price_range(endpoints: Sequence[ModelEndpoint], attr: str) -> str:
     values = [getattr(ep, attr) for ep in endpoints if getattr(ep, attr) > 0]
     if not values:
         return _price(0)
+    return _price_values_range(values)
+
+
+def _price_values_range(values: Sequence[int]) -> str:
     low = min(values)
     high = max(values)
     if low == high:

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -3467,7 +3467,8 @@ def _model_discovery_sort_key(model: Mapping[str, object]) -> tuple[int, int, in
         except (TypeError, ValueError):
             pass
     section = 2 if model.get("is_meta") else 1
-    provider_count = int(model.get("provider_count") or 0)
+    raw_provider_count = model.get("provider_count")
+    provider_count = raw_provider_count if isinstance(raw_provider_count, int) else 0
     return (section, ai_iq_rank, -provider_count, str(model["name"]).casefold())
 
 

--- a/src/trusted_router/static/charter.css
+++ b/src/trusted_router/static/charter.css
@@ -2597,6 +2597,539 @@ body.auth.auth-shell {
   }
 }
 
+/* Public model discovery. Keep the decision surface compact and repeat labels
+ * per model so pricing remains legible without a wide table or sticky header. */
+.models-page-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 28px;
+  align-items: end;
+  padding: 30px 0 28px;
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.models-page-hero h1 {
+  margin: 10px 0 8px;
+  font-size: 46px;
+  line-height: 1;
+}
+
+.models-page-hero p {
+  max-width: 740px;
+  margin: 0;
+  color: var(--text-body);
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.models-page-hero-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 18px;
+  justify-content: flex-end;
+  padding-bottom: 2px;
+  font-size: 13px;
+}
+
+.model-explorer {
+  min-width: 0;
+}
+
+.model-explorer-toolbar {
+  position: sticky;
+  z-index: 5;
+  top: 58px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(190px, 240px);
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--border-default);
+  background: color-mix(in srgb, var(--surface-page) 94%, transparent);
+  backdrop-filter: blur(12px);
+}
+
+.model-search-field,
+.model-sort-field {
+  display: grid;
+  min-width: 0;
+  gap: 6px;
+}
+
+.model-control-label {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+}
+
+.model-search-field input,
+.model-sort-field select {
+  width: 100%;
+  min-width: 0;
+  min-height: 43px;
+  padding: 9px 11px;
+  font-size: 14px;
+}
+
+.model-quick-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  padding: 12px 14px;
+  border: 1px solid var(--border-hairline);
+  border-top: 0;
+}
+
+.model-quick-row > span {
+  margin-right: 4px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.model-quick-row button,
+.model-clear-button {
+  padding: 4px 8px;
+  border: 0;
+  background: transparent;
+  color: var(--text-accent);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+}
+
+.model-quick-row button:hover,
+.model-clear-button:hover {
+  color: var(--text-display);
+  text-decoration: underline;
+}
+
+.model-explorer > .model-filter-row {
+  padding: 10px 14px;
+  border: 1px solid var(--border-hairline);
+  border-top: 0;
+}
+
+.model-explorer-status {
+  display: flex;
+  min-height: 47px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 2px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.model-explorer-status p {
+  margin: 0;
+}
+
+.model-explorer-status strong {
+  color: var(--text-display);
+  font-weight: 500;
+}
+
+.model-results {
+  border: 1px solid var(--border-default);
+  background: var(--surface-card);
+}
+
+.model-result-card {
+  display: grid;
+  min-width: 0;
+  border-bottom: 1px solid var(--border-default);
+}
+
+.model-result-card:last-child {
+  border-bottom: 0;
+}
+
+.model-result-card[hidden],
+.provider-chip-overflow {
+  display: none;
+}
+
+.model-card-main {
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) minmax(450px, .95fr);
+  gap: 24px;
+  align-items: center;
+  padding: 18px 20px 14px;
+}
+
+.model-card-heading {
+  display: flex;
+  min-width: 0;
+  gap: 12px;
+  align-items: center;
+}
+
+.model-publisher-logo {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  flex: 0 0 38px;
+  place-items: center;
+  border: 1px solid var(--border-default);
+  border-radius: var(--r-control);
+  background: #fff;
+}
+
+.model-publisher-logo img {
+  width: 32px;
+  height: 32px;
+  object-fit: contain;
+}
+
+.model-card-title,
+.model-card-title-line {
+  min-width: 0;
+}
+
+.model-card-title-line {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.model-card-title h2 {
+  min-width: 0;
+  margin: 0;
+  font-family: var(--font-ui);
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 1.25;
+}
+
+.model-card-title h2 a {
+  color: var(--text-display);
+}
+
+.model-card-title code {
+  display: block;
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-size: 11px;
+  overflow-wrap: anywhere;
+}
+
+.model-featured-badge {
+  flex: 0 0 auto;
+  padding: 2px 5px;
+  border: 1px solid var(--gold-dim);
+  border-radius: var(--r-control);
+  background: var(--gold-tint);
+  color: var(--gold);
+  font-size: 9px;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+
+.model-price-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  min-width: 0;
+}
+
+.model-price-grid > div {
+  min-width: 0;
+  padding: 2px 10px;
+  border-left: 1px solid var(--border-hairline);
+}
+
+.model-price-grid > div:first-child {
+  border-left: 0;
+}
+
+.model-price-grid span,
+.model-price-grid strong {
+  display: block;
+  min-width: 0;
+}
+
+.model-price-grid span {
+  margin-bottom: 4px;
+  color: var(--text-muted);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.model-price-grid strong {
+  color: var(--text-display);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  overflow-wrap: anywhere;
+}
+
+.model-card-meta {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, auto);
+  gap: 12px;
+  align-items: center;
+  padding: 0 20px 14px;
+}
+
+.model-card-badges,
+.model-card-providers {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.model-card-providers {
+  max-width: none;
+  justify-content: flex-end;
+}
+
+.model-card-providers .pill {
+  max-width: 132px;
+}
+
+.model-provider-more {
+  color: var(--text-muted);
+}
+
+.model-iq-pill {
+  color: var(--gold);
+}
+
+.model-route-details {
+  border-top: 1px solid var(--border-hairline);
+}
+
+.model-route-details > summary {
+  display: flex;
+  min-height: 42px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 20px;
+  color: var(--text-accent);
+  cursor: pointer;
+  font-size: 12px;
+  list-style: none;
+}
+
+.model-route-details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.model-route-details[open] > summary > span:last-child {
+  transform: rotate(45deg);
+}
+
+.model-route-results {
+  border-top: 1px solid var(--border-hairline);
+  background: var(--surface-raised);
+}
+
+.model-route-head,
+.model-route-row {
+  display: grid;
+  grid-template-columns: minmax(150px, 1.25fr) minmax(80px, .7fr) repeat(3, minmax(105px, .9fr)) minmax(80px, .65fr);
+  min-width: 0;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 20px;
+}
+
+.model-route-head {
+  color: var(--text-muted);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.model-route-row {
+  border-top: 1px solid var(--border-hairline);
+  color: var(--text-body);
+  font-size: 11px;
+}
+
+.model-route-row > * {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.model-route-provider a {
+  display: flex;
+  min-width: 0;
+  gap: 7px;
+  align-items: center;
+  color: var(--text-display);
+}
+
+.model-route-provider img {
+  width: 24px;
+  height: 24px;
+  flex: 0 0 24px;
+  padding: 2px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--r-control);
+  background: #fff;
+  object-fit: contain;
+}
+
+.model-route-price {
+  color: var(--text-display);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.model-route-loading,
+.model-route-error {
+  margin: 0;
+  padding: 15px 20px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.model-route-error {
+  color: var(--clay);
+}
+
+.model-card-footer {
+  padding: 10px 20px;
+  border-top: 1px solid var(--border-hairline);
+  font-size: 12px;
+}
+
+.model-explorer-empty {
+  padding: 42px 20px;
+  border: 1px solid var(--border-default);
+  text-align: center;
+}
+
+.model-explorer-empty p {
+  margin: 6px 0 14px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.model-show-more-wrap {
+  display: flex;
+  justify-content: center;
+  padding: 18px 0;
+}
+
+.model-catalog-note {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 24px;
+  padding: 20px 0;
+  border-top: 1px solid var(--border-hairline);
+}
+
+.model-catalog-note p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+@media (max-width: 820px) {
+  .models-page-hero,
+  .model-card-main,
+  .model-card-meta,
+  .model-catalog-note {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .models-page-hero-links,
+  .model-card-providers {
+    justify-content: flex-start;
+  }
+
+  .model-card-main {
+    gap: 16px;
+  }
+
+  .model-price-grid > div:first-child {
+    padding-left: 0;
+  }
+
+  .model-route-head {
+    display: none;
+  }
+
+  .model-route-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px 18px;
+    padding-top: 14px;
+    padding-bottom: 14px;
+  }
+
+  .model-route-row > *::before {
+    display: block;
+    margin-bottom: 3px;
+    color: var(--text-muted);
+    content: attr(data-label);
+    font-family: var(--font-ui);
+    font-size: 9px;
+    text-transform: uppercase;
+  }
+}
+
+@media (max-width: 560px) {
+  .models-page-hero {
+    gap: 14px;
+    padding: 10px 0 18px;
+  }
+
+  .models-page-hero h1 {
+    margin: 7px 0 6px;
+    font-size: 34px;
+  }
+
+  .models-page-hero p {
+    font-size: 14px;
+    line-height: 1.42;
+  }
+
+  .models-page-hero-links {
+    gap: 6px 14px;
+    font-size: 12px;
+  }
+
+  .model-explorer-toolbar {
+    position: static;
+    grid-template-columns: minmax(0, 1fr);
+    padding: 10px;
+  }
+
+  .model-search-field input,
+  .model-sort-field select {
+    min-height: 40px;
+  }
+
+  .model-quick-row,
+  .model-explorer > .model-filter-row {
+    padding: 8px 10px;
+  }
+
+  .model-card-main,
+  .model-card-meta {
+    padding-right: 14px;
+    padding-left: 14px;
+  }
+
+  .model-price-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px 0;
+  }
+
+  .model-price-grid > div:nth-child(3) {
+    padding-left: 0;
+    border-left: 0;
+  }
+
+  .model-route-details > summary,
+  .model-route-row {
+    padding-right: 14px;
+    padding-left: 14px;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/src/trusted_router/static/models.js
+++ b/src/trusted_router/static/models.js
@@ -1,0 +1,217 @@
+(() => {
+  const explorer = document.querySelector("[data-model-explorer]");
+  if (!explorer) return;
+
+  const results = explorer.querySelector("[data-model-results]");
+  const search = explorer.querySelector("[data-model-search]");
+  const sort = explorer.querySelector("[data-model-sort]");
+  const count = explorer.querySelector("[data-model-result-count]");
+  const detail = explorer.querySelector("[data-model-result-detail]");
+  const empty = explorer.querySelector("[data-model-empty]");
+  const showMore = explorer.querySelector("[data-model-show-more]");
+  const clearButtons = [...explorer.querySelectorAll("[data-model-clear]")];
+  const cards = [...explorer.querySelectorAll("[data-model-card]")];
+  const pageSize = Number.parseInt(explorer.dataset.pageSize || "24", 10);
+  const params = new URLSearchParams(window.location.search);
+  let visibleLimit = pageSize;
+
+  const normalize = (value) => value.trim().toLocaleLowerCase().replace(/\s+/g, " ");
+  const numberValue = (card, key, fallback = Number.POSITIVE_INFINITY) => {
+    const raw = card.dataset[key];
+    if (raw === undefined || raw === "") return fallback;
+    const value = Number(raw);
+    return Number.isFinite(value) ? value : fallback;
+  };
+
+  search.value = params.get("q") || "";
+  if ([...sort.options].some((option) => option.value === params.get("sort"))) {
+    sort.value = params.get("sort");
+  }
+
+  function sortCards(matches) {
+    const mode = sort.value;
+    return matches.sort((left, right) => {
+      if (mode === "input") return numberValue(left, "inputPrice") - numberValue(right, "inputPrice");
+      if (mode === "cached") return numberValue(left, "cachedPrice") - numberValue(right, "cachedPrice");
+      if (mode === "output") return numberValue(left, "outputPrice") - numberValue(right, "outputPrice");
+      if (mode === "context") return numberValue(right, "context", 0) - numberValue(left, "context", 0);
+      if (mode === "providers") return numberValue(right, "providerCount", 0) - numberValue(left, "providerCount", 0);
+      if (mode === "name") return left.dataset.modelId.localeCompare(right.dataset.modelId);
+      return numberValue(left, "initialIndex", 0) - numberValue(right, "initialIndex", 0);
+    });
+  }
+
+  function writeUrl() {
+    const next = new URLSearchParams(window.location.search);
+    const query = search.value.trim();
+    if (query) next.set("q", query);
+    else next.delete("q");
+    if (sort.value !== "featured") next.set("sort", sort.value);
+    else next.delete("sort");
+    const queryString = next.toString();
+    history.replaceState(null, "", `${window.location.pathname}${queryString ? `?${queryString}` : ""}`);
+  }
+
+  function render() {
+    const query = normalize(search.value);
+    const terms = query.split(" ").filter(Boolean);
+    const matches = sortCards(cards.filter((card) => {
+      const haystack = normalize(card.dataset.searchText || "");
+      return terms.every((term) => haystack.includes(term));
+    }));
+
+    matches.forEach((card) => results.append(card));
+    const visible = matches.slice(0, visibleLimit);
+    const visibleSet = new Set(visible);
+    cards.forEach((card) => { card.hidden = !visibleSet.has(card); });
+
+    count.textContent = `${matches.length} ${matches.length === 1 ? "result" : "results"}`;
+    detail.textContent = matches.length > visible.length ? ` · showing ${visible.length}` : "";
+    empty.hidden = matches.length !== 0;
+    showMore.hidden = matches.length <= visible.length;
+    if (!showMore.hidden) {
+      const remaining = matches.length - visible.length;
+      showMore.textContent = `Show ${Math.min(pageSize, remaining)} more models`;
+    }
+    clearButtons.forEach((button) => { button.hidden = !query && sort.value === "featured"; });
+    writeUrl();
+  }
+
+  search.addEventListener("input", () => {
+    visibleLimit = pageSize;
+    render();
+  });
+  sort.addEventListener("change", () => {
+    visibleLimit = pageSize;
+    render();
+  });
+  showMore.addEventListener("click", () => {
+    visibleLimit += pageSize;
+    render();
+  });
+  clearButtons.forEach((button) => button.addEventListener("click", () => {
+    search.value = "";
+    sort.value = "featured";
+    visibleLimit = pageSize;
+    search.focus();
+    render();
+  }));
+  explorer.querySelectorAll("[data-model-query]").forEach((button) => {
+    button.addEventListener("click", () => {
+      search.value = button.dataset.modelQuery || "";
+      visibleLimit = pageSize;
+      render();
+      search.focus();
+    });
+  });
+
+  function element(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined) node.textContent = text;
+    return node;
+  }
+
+  function dollarsPerMillion(raw) {
+    const value = Number(raw);
+    if (!Number.isFinite(value)) return null;
+    return value * 1_000_000;
+  }
+
+  function formatDollarValue(value) {
+    if (value >= 100) return `$${value.toLocaleString(undefined, { maximumFractionDigits: 0 })}/1M`;
+    if (value >= 1) return `$${value.toFixed(2).replace(/\.00$/, "")}/1M`;
+    if (value >= 0.01) return `$${value.toFixed(3).replace(/0+$/, "").replace(/\.$/, "")}/1M`;
+    return `$${value.toFixed(5).replace(/0+$/, "").replace(/\.$/, "")}/1M`;
+  }
+
+  function priceRange(routes, key) {
+    const values = routes
+      .map((route) => dollarsPerMillion(route.pricing && route.pricing[key]))
+      .filter((value) => value !== null && value > 0)
+      .sort((left, right) => left - right);
+    if (!values.length) return key === "input_cache_read" ? "Not published" : "—";
+    if (values[0] === values[values.length - 1]) return formatDollarValue(values[0]);
+    return `${formatDollarValue(values[0])} – ${formatDollarValue(values[values.length - 1])}`;
+  }
+
+  function privacyLabel(routes) {
+    const postures = routes.map((route) => route.trustedrouter || {});
+    if (postures.some((posture) => posture.provider_confidential_compute === true && posture.provider_e2ee === true)) return "E2EE";
+    if (postures.some((posture) => posture.provider_zero_data_retention === true)) return "ZDR";
+    if (postures.some((posture) => posture.stores_content === false)) return "No store";
+    return "Standard";
+  }
+
+  function routeCell(label, text, className = "") {
+    const cell = element("div", className, text);
+    cell.dataset.label = label;
+    return cell;
+  }
+
+  function renderRoutes(container, routes) {
+    container.replaceChildren();
+    if (!routes.length) {
+      container.append(element("p", "model-route-error", "No active provider routes are published for this model."));
+      return;
+    }
+
+    const grouped = new Map();
+    routes.forEach((route) => {
+      const key = route.provider || route.provider_name || "provider";
+      if (!grouped.has(key)) grouped.set(key, []);
+      grouped.get(key).push(route);
+    });
+
+    const header = element("div", "model-route-head");
+    ["Provider", "Routes", "Input", "Cached input", "Output", "Privacy"].forEach((label) => header.append(element("span", "", label)));
+    container.append(header);
+
+    [...grouped.entries()]
+      .sort(([, left], [, right]) => String(left[0].provider_name || left[0].name).localeCompare(String(right[0].provider_name || right[0].name)))
+      .forEach(([slug, providerRoutes]) => {
+        const first = providerRoutes[0];
+        const row = element("div", "model-route-row");
+        const providerCell = element("div", "model-route-provider");
+        const providerLink = element("a", "", first.provider_name || first.name || slug);
+        providerLink.href = `/providers/${encodeURIComponent(slug)}`;
+        const logo = document.createElement("img");
+        logo.src = `/static/provider-logos/${encodeURIComponent(slug)}.png`;
+        logo.alt = "";
+        logo.width = 24;
+        logo.height = 24;
+        providerLink.prepend(logo);
+        providerCell.dataset.label = "Provider";
+        providerCell.append(providerLink);
+        row.append(providerCell);
+        row.append(routeCell("Routes", [...new Set(providerRoutes.map((route) => route.usage_type))].join(" + ")));
+        row.append(routeCell("Input", priceRange(providerRoutes, "prompt"), "model-route-price"));
+        row.append(routeCell("Cached input", priceRange(providerRoutes, "input_cache_read"), "model-route-price"));
+        row.append(routeCell("Output", priceRange(providerRoutes, "completion"), "model-route-price"));
+        row.append(routeCell("Privacy", privacyLabel(providerRoutes)));
+        container.append(row);
+      });
+  }
+
+  explorer.querySelectorAll("[data-endpoints-url]").forEach((details) => {
+    details.addEventListener("toggle", async () => {
+      if (!details.open || details.dataset.loaded === "true" || details.dataset.loading === "true") return;
+      const container = details.querySelector("[data-route-results]");
+      details.dataset.loading = "true";
+      container.replaceChildren(element("p", "model-route-loading", "Loading current provider routes…"));
+      try {
+        const response = await fetch(details.dataset.endpointsUrl, { headers: { Accept: "application/json" } });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const payload = await response.json();
+        renderRoutes(container, Array.isArray(payload.data) ? payload.data : []);
+        details.dataset.loaded = "true";
+      } catch (_error) {
+        container.replaceChildren(element("p", "model-route-error", "Provider routes could not be loaded. Try again."));
+      } finally {
+        delete details.dataset.loading;
+      }
+    });
+  });
+
+  render();
+})();

--- a/src/trusted_router/templates/public/models.html
+++ b/src/trusted_router/templates/public/models.html
@@ -78,7 +78,7 @@
       <div class="model-card-main">
         <div class="model-card-heading">
           <a class="model-publisher-logo" href="/providers/{{ model.publisher_slug }}" aria-label="{{ model.provider }} provider page">
-            <img src="/static/provider-logos/{{ model.publisher_slug }}.png" alt="" width="36" height="36" loading="lazy" decoding="async">
+            <img src="/static/provider-logos/{{ model.publisher_slug }}.png" alt="{{ model.provider }} logo" width="36" height="36" loading="lazy" decoding="async">
           </a>
           <div class="model-card-title">
             <div class="model-card-title-line">

--- a/src/trusted_router/templates/public/models.html
+++ b/src/trusted_router/templates/public/models.html
@@ -1,117 +1,160 @@
 {% extends "public/_base.html" %}
-{% from "public/_provider_privacy_badges.html" import provider_privacy_badges %}
-{% from "public/_provider_identity.html" import provider_identity %}
-{% block body %}
-<section class="public-proof-strip">
-  <div><strong>Public catalog</strong><span>No auth needed to inspect routes.</span></div>
-  <div><strong>trustedrouter/auto</strong><span>Provider failover target.</span></div>
-  <div><strong>trustedrouter/eu</strong><span>EU-focused routing target.</span></div>
-  <div><strong>trustedrouter/zdr</strong><span>Zero-retention routing target.</span></div>
-  <div><strong>trustedrouter/e2e</strong><span>Confidential + E2EE routes. Alias: trustedrouter/confidential.</span></div>
-  <div><strong>Hard privacy floor</strong><span>Use provider.min_privacy = "confidential" with any selected model.</span></div>
-  <div><strong>Synth presets</strong><span>Iris, Prometheus, Zeus, and code variants.</span></div>
-  <div><strong>Streaming</strong><span>No buffering in the prompt path.</span></div>
-  <div><strong>Hundreds of models</strong><span>More provider routes are added as keys and pricing are verified.</span></div>
-</section>
-
-<section class="model-catalog">
-  <div class="model-catalog-head">
-    <div>
-      <span class="eyebrow">Models</span>
-      <h2>Route by model, provider, price, or privacy posture.</h2>
-    </div>
-    <p>API JSON remains at <span class="mono">{{ api_base_url }}/models</span> with an API key. <a href="/compare/models">Compare models</a>. By jurisdiction: <a href="/us-ai-models">US AI models</a>, <a href="/eu-ai-models">EU AI models</a>, <a href="/china-ai-models">Chinese AI models</a>.</p>
+{% block hero %}
+<section class="models-page-hero">
+  <div>
+    <div class="kicker">Public catalog · {{ total_model_count }} models · {{ total_provider_count }} providers</div>
+    <h1>Find the right model.</h1>
+    <p>Hundreds of models, searchable by name, family, or provider. Compare input and output prices, inspect cached-input rates, and open every provider route without leaving the page.</p>
   </div>
-  <div class="model-filter-row" aria-label="Model filters">
+  <div class="models-page-hero-links">
+    <a href="/choose">Guided model chooser</a>
+    <a href="/compare/models">Compare models</a>
+    <a href="/for-developers">API quickstart</a>
+  </div>
+</section>
+{% endblock %}
+{% block body %}
+<section class="model-explorer" data-model-explorer data-page-size="{{ initial_page_size }}">
+  <div class="model-explorer-toolbar">
+    <label class="model-search-field">
+      <span class="model-control-label">Search models</span>
+      <input
+        type="search"
+        aria-label="Search models"
+        placeholder="Search GLM, Kimi, DeepSeek, provider, or model ID"
+        autocomplete="off"
+        spellcheck="false"
+        data-model-search
+      >
+    </label>
+    <label class="model-sort-field">
+      <span class="model-control-label">Sort by</span>
+      <select data-model-sort aria-label="Sort models">
+        <option value="featured">Featured</option>
+        <option value="input">Lowest input price</option>
+        <option value="cached">Lowest cached-input price</option>
+        <option value="output">Lowest output price</option>
+        <option value="context">Largest context</option>
+        <option value="providers">Most providers</option>
+        <option value="name">Name</option>
+      </select>
+    </label>
+  </div>
+
+  <div class="model-quick-row" aria-label="Popular model searches">
+    <span>Popular now</span>
+    <button type="button" data-model-query="glm 5.3">GLM 5.3</button>
+    <button type="button" data-model-query="kimi k3">Kimi K3</button>
+    <button type="button" data-model-query="deepseek">DeepSeek</button>
+  </div>
+
+  <nav class="model-filter-row" aria-label="Model filters">
     {% for item in model_filters %}
     <a class="pill {% if active_filter == item.id %}good{% endif %}" href="{{ item.href }}">{{ item.label }}</a>
     {% endfor %}
-  </div>
-  <div class="model-table-wrap">
-    <table>
-      <thead>
-        <tr>
-          <th>Model</th>
-          <th>Publisher</th>
-          <th>AI IQ</th>
-          <th>Context</th>
-          <th>Providers</th>
-          <th>Provider policy</th>
-          <th>Prompt</th>
-          <th>Completion</th>
-          <th>Routes</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for model in models %}
-        <tr>
-          <td>
-            {% if model.detail_href %}<a href="{{ model.detail_href }}"><code>{{ model.id }}</code></a>{% else %}<code>{{ model.id }}</code>{% endif %}
-            <br>{{ model.name }}
-            <div class="mini-links">
-              {% if model.open_weights %}<span class="pill good">open weights</span>{% endif %}
-              {% if model.us_provider_available %}<span class="pill">US providers</span>{% endif %}
-              {% if model.eu_focused_provider_available %}<span class="pill">EU-focused</span>{% endif %}
-            </div>
-            {% if model.benchmarks_href or model.providers_href or model.pricing_href %}
-            <div class="mini-links">
-              {% if model.benchmarks_href %}<a href="{{ model.benchmarks_href }}">benchmarks</a>{% endif %}
-              {% if model.providers_href %}<a href="{{ model.providers_href }}">providers</a>{% endif %}
-              {% if model.pricing_href %}<a href="{{ model.pricing_href }}">pricing</a>{% endif %}
-            </div>
-            {% endif %}
-          </td>
-          <td>{{ provider_identity(model.publisher_slug, model.provider, "/providers/" ~ model.publisher_slug) }}</td>
-          <td>
-            {% if model.ai_iq %}
-            <a class="ai-iq-link" href="{{ model.ai_iq.url }}" rel="nofollow noopener">
-              <strong>IQ {{ model.ai_iq.iq }}</strong>
-              <span>#{{ model.ai_iq.rank }}</span>
-            </a>
-            {% else %}
-            <span class="muted-copy">—</span>
-            {% endif %}
-          </td>
-          <td>{{ model.context_length }}</td>
-          <td>
-            <div class="provider-chip-list" aria-label="{{ model.provider_count }} provider{{ '' if model.provider_count == 1 else 's' }}">
-              {% for provider in model.providers %}
-              <a class="pill provider-chip" href="/providers/{{ provider.slug }}" title="{{ provider.slug }}"><img class="provider-logo" src="{{ provider.logo_url }}" alt="{{ provider.name }} logo" aria-hidden="true" width="22" height="22" loading="lazy" decoding="async"><span>{{ provider.name }}</span></a>
-              {% endfor %}
-            </div>
-          </td>
-          <td>
-            {{ provider_privacy_badges(model) }}
-          </td>
-          <td>{{ model.prompt_price }}</td>
-          <td>{{ model.completion_price }}</td>
-          <td>
-            {% if model.prepaid %}<span class="pill good">prepaid</span>{% endif %}
-            {% if model.byok %}<span class="pill">BYOK</span>{% endif %}
-            {% if model.attested %}<span class="pill good">TR router attested</span>{% endif %}
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
-</section>
+  </nav>
 
-<section class="marketing-grid three">
-  <div class="marketing-card">
-    <span class="card-label">Coverage</span>
-    <h3>Top models first.</h3>
-    <p>The catalog includes frontier, open weight, fast, cheap, image capable, and provider specific routes.</p>
+  <div class="model-explorer-status">
+    <p><strong data-model-result-count>{{ models|length }} models</strong><span data-model-result-detail> in the public catalog</span></p>
+    <button class="model-clear-button" type="button" data-model-clear hidden>Clear search</button>
   </div>
-  <div class="marketing-card">
-    <span class="card-label">Latency</span>
-    <h3>Streaming path.</h3>
-    <p>Streaming responses pass through the gateway so clients can render tokens as providers emit them.</p>
+
+  <div class="model-results" data-model-results>
+    {% for model in models %}
+    <article
+      class="model-result-card"
+      data-model-card
+      data-model-id="{{ model.id }}"
+      data-search-text="{{ model.search_text }}"
+      data-initial-index="{{ loop.index0 }}"
+      data-featured-rank="{{ model.featured_rank if model.featured_rank is not none else '' }}"
+      data-input-price="{{ model.prompt_price_sort if model.prompt_price_sort is not none else '' }}"
+      data-cached-price="{{ model.cached_price_sort if model.cached_price_sort is not none else '' }}"
+      data-output-price="{{ model.completion_price_sort if model.completion_price_sort is not none else '' }}"
+      data-context="{{ model.context_length_int }}"
+      data-provider-count="{{ model.provider_count }}"
+      {% if loop.index0 >= initial_page_size %}hidden{% endif %}
+    >
+      <div class="model-card-main">
+        <div class="model-card-heading">
+          <a class="model-publisher-logo" href="/providers/{{ model.publisher_slug }}" aria-label="{{ model.provider }} provider page">
+            <img src="/static/provider-logos/{{ model.publisher_slug }}.png" alt="" width="36" height="36" loading="lazy" decoding="async">
+          </a>
+          <div class="model-card-title">
+            <div class="model-card-title-line">
+              <h2><a href="{{ model.detail_href }}">{{ model.name }}</a></h2>
+              {% if model.featured_rank is not none %}<span class="model-featured-badge">Popular</span>{% endif %}
+            </div>
+            <code>{{ model.id }}</code>
+          </div>
+        </div>
+
+        <div class="model-price-grid" aria-label="{{ model.name }} pricing and context">
+          <div><span>Input</span><strong>{{ model.prompt_price }}</strong></div>
+          <div><span>Cached input</span><strong>{{ model.cached_prompt_price }}</strong></div>
+          <div><span>Output</span><strong>{{ model.completion_price }}</strong></div>
+          <div><span>Context</span><strong title="{{ model.context_length }} tokens">{{ model.context_length_compact }}</strong></div>
+        </div>
+      </div>
+
+      <div class="model-card-meta">
+        <div class="model-card-badges" aria-label="Model attributes">
+          {% if model.open_weights %}<span class="pill good">Open weights</span>{% endif %}
+          {% if model.attested %}<span class="pill good">TR router attested</span>{% endif %}
+          {% if model.provider_policy_varies %}<span class="pill warn">{{ model.provider_policy_variation_label }}</span>{% endif %}
+          {% if model.zdr_available %}<span class="pill good">ZDR route</span>{% endif %}
+          {% if model.e2e_available %}<span class="pill good">E2EE route</span>{% endif %}
+          {% if model.us_provider_available %}<span class="pill">US</span>{% endif %}
+          {% if model.eu_focused_provider_available %}<span class="pill">EU</span>{% endif %}
+          {% if model.ai_iq %}
+          <a class="pill model-iq-pill" href="{{ model.ai_iq.url }}" rel="nofollow noopener">IQ {{ model.ai_iq.iq }} · #{{ model.ai_iq.rank }}</a>
+          {% endif %}
+          {% if model.is_meta %}<span class="pill">Router alias</span>{% endif %}
+        </div>
+
+        <div class="provider-chip-list model-card-providers" aria-label="{{ model.provider_count }} provider{{ '' if model.provider_count == 1 else 's' }}">
+          {% for provider in model.providers %}
+          <a class="pill provider-chip{% if loop.index > 6 %} provider-chip-overflow{% endif %}" href="/providers/{{ provider.slug }}" title="{{ provider.slug }}"><img class="provider-logo" src="{{ provider.logo_url }}" alt="{{ provider.name }} logo" aria-hidden="true" width="22" height="22" loading="lazy" decoding="async"><span>{{ provider.name }}</span></a>
+          {% endfor %}
+          {% if model.provider_count > 6 %}<span class="pill model-provider-more">+{{ model.provider_count - 6 }} more</span>{% endif %}
+        </div>
+      </div>
+
+      {% if model.endpoints_url %}
+      <details class="model-route-details" data-endpoints-url="{{ model.endpoints_url }}">
+        <summary>
+          <span>Compare {{ model.provider_count }} provider{{ '' if model.provider_count == 1 else 's' }} and prices</span>
+          <span aria-hidden="true">+</span>
+        </summary>
+        <div class="model-route-results" data-route-results>
+          <p class="model-route-loading">Open to load current provider routes.</p>
+        </div>
+      </details>
+      {% else %}
+      <div class="model-card-footer">
+        <a href="{{ model.detail_href }}">View routing details</a>
+      </div>
+      {% endif %}
+    </article>
+    {% endfor %}
   </div>
-  <div class="marketing-card">
-    <span class="card-label">Price</span>
-    <h3>Visible before you call.</h3>
-    <p>Model pages show prompt and completion pricing per provider route.</p>
+
+  <div class="model-explorer-empty" data-model-empty hidden>
+    <strong>No matching models</strong>
+    <p>Try a model family, publisher, provider, or exact API ID.</p>
+    <button class="btn" type="button" data-model-clear>Clear search</button>
+  </div>
+
+  <div class="model-show-more-wrap">
+    <button class="btn" type="button" data-model-show-more>Show more models</button>
+  </div>
+
+  <div class="model-catalog-note">
+    <p><strong>API JSON remains</strong> at <code>{{ api_base_url }}/models</code> with an API key. Use <code>trustedrouter/auto</code> for general routing, <code>trustedrouter/eu</code> for EU-focused routes, or a privacy floor such as <code>trustedrouter/zdr</code> or <code>trustedrouter/e2e</code>.</p>
+    <p>Prices are customer prices per one million tokens. Cached input is shown only when a provider publishes a distinct cache-read rate. Filter open weights or browse <a href="/us-ai-models">US</a>, <a href="/eu-ai-models">European</a>, and <a href="/china-ai-models">Chinese</a> model guides.</p>
   </div>
 </section>
+{% endblock %}
+{% block body_scripts %}
+<script src="/static/models.js?v={{ static_version|default('local') }}"></script>
 {% endblock %}

--- a/tests/browser/models.spec.js
+++ b/tests/browser/models.spec.js
@@ -1,0 +1,42 @@
+const { expect, test } = require("@playwright/test");
+
+test("models explorer prioritizes frontier models and searches immediately", async ({ page }) => {
+  await page.goto("/models");
+
+  const search = page.getByRole("searchbox", { name: "Search models" });
+  await expect(search).toBeVisible();
+  const visibleCards = page.locator(".model-result-card:visible");
+  await expect(visibleCards.first()).toHaveAttribute("data-model-id", "z-ai/glm-5.3-flash");
+  expect(await visibleCards.count()).toBeLessThanOrEqual(24);
+  expect(await page.locator(".model-explorer table").count()).toBe(0);
+  expect(await page.evaluate(() => document.documentElement.scrollHeight)).toBeLessThan(12_000);
+
+  await search.fill("kimi k3");
+  await expect(page.locator('.model-result-card[data-model-id="moonshotai/kimi-k3"]')).toBeVisible();
+  await expect(page.locator('.model-result-card[data-model-id="trustedrouter/auto"]')).toBeHidden();
+  await expect(page.locator("[data-model-result-count]")).toContainText("result");
+
+  await search.fill("");
+  await page.locator("[data-model-sort]").selectOption("cached");
+  await expect(visibleCards.first()).not.toHaveAttribute("data-cached-price", "");
+});
+
+test("models explorer loads provider cache prices without horizontal overflow", async ({ page }) => {
+  await page.goto("/models?q=glm-5.3-flash");
+  const card = page.locator('.model-result-card[data-model-id="z-ai/glm-5.3-flash"]');
+  await expect(card).toBeVisible();
+  await card.locator("summary").click();
+  await expect(card.locator(".model-route-row").first()).toBeVisible();
+  await expect(card.getByText("Cached input", { exact: true }).first()).toBeVisible();
+
+  for (const viewport of [
+    { width: 1280, height: 800 },
+    { width: 390, height: 844 },
+  ]) {
+    await page.setViewportSize(viewport);
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - window.innerWidth,
+    );
+    expect(overflow).toBeLessThanOrEqual(2);
+  }
+});

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -503,6 +503,29 @@ def test_public_models_page_does_not_require_api_key(client: TestClient) -> None
     assert "IQ 116" in response.text
 
 
+def test_public_models_page_is_a_ranked_searchable_price_explorer(
+    client: TestClient,
+) -> None:
+    response = client.get("/models")
+
+    assert response.status_code == 200
+    body = response.text
+    assert 'type="search"' in body
+    assert 'data-model-search' in body
+    assert 'data-model-sort' in body
+    assert "Cached input" in body
+    assert "/static/models.js" in body
+    assert 'href="/for-developers"' in body
+    assert 'href="/docs/quickstart"' not in body
+    assert 'data-endpoints-url="/v1/models/z-ai/glm-5.3-flash/endpoints"' in body
+
+    glm = body.index('data-model-id="z-ai/glm-5.3-flash"')
+    kimi = body.index('data-model-id="moonshotai/kimi-k3"')
+    deepseek = body.index('data-model-id="deepseek/deepseek-v4-pro-0813"')
+    router_alias = body.index('data-model-id="trustedrouter/auto"')
+    assert glm < kimi < deepseek < router_alias
+
+
 def test_public_model_detail_lists_distinct_serving_providers(client: TestClient) -> None:
     model_id = "moonshotai/kimi-k2.6"
     response = client.get(f"/models/{model_id}")


### PR DESCRIPTION
## Summary
- replace the oversized models table with a compact ranked card explorer
- prioritize GLM 5.3, Kimi K3, and DeepSeek, with instant search and price/context sorting
- show input, cached-input, output, context, providers, privacy, and attestation without horizontal scrolling
- lazy-load provider-level route prices and cap the default view at 24 models

## Verification
- 103 public-page regression tests
- Ruff, Stylelint, and JavaScript syntax checks
- Playwright desktop/mobile search, sorting, provider expansion, page-height, and overflow tests
- manual desktop and mobile screenshot review