### PR TITLE
Improve pricing, model, and provider discovery

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -3422,13 +3422,10 @@ def public_models_html(settings: Settings, *, model_filter: str = "all") -> str:
             ),
             models=models,
             total_model_count=len(all_models),
-            total_provider_count=len(
-                {
-                    str(provider["slug"])
-                    for model in all_models
-                    for provider in cast(list[dict[str, str]], model["providers"])
-                }
-            ),
+            # Count the complete public provider catalog, not only providers with
+            # a currently routable model. TrustedRouter itself is the router,
+            # rather than an upstream provider.
+            total_provider_count=sum(slug != "trustedrouter" for slug in PROVIDERS),
             initial_page_size=MODEL_DISCOVERY_PAGE_SIZE,
             active_filter=normalized_filter,
             model_filters=[

--- a/src/trusted_router/static/charter.css
+++ b/src/trusted_router/static/charter.css
@@ -2671,6 +2671,83 @@ body.auth.auth-shell {
   font-size: 14px;
 }
 
+.provider-explorer-toolbar {
+  grid-template-columns: minmax(0, 1fr) auto;
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.provider-explorer-count {
+  align-self: end;
+  margin: 0 0 12px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.provider-policy-cell {
+  width: 260px;
+  min-width: 220px;
+}
+
+.provider-policy-details summary {
+  display: grid;
+  gap: 7px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.provider-policy-details summary::-webkit-details-marker {
+  display: none;
+}
+
+.provider-policy-preview {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--text-body);
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+}
+
+.provider-policy-toggle {
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.provider-policy-hide,
+.provider-policy-details[open] .provider-policy-preview,
+.provider-policy-details[open] .provider-policy-show {
+  display: none;
+}
+
+.provider-policy-details[open] .provider-policy-hide {
+  display: inline;
+}
+
+.provider-policy-full {
+  padding-top: 8px;
+  color: var(--text-body);
+}
+
+.provider-policy-full p {
+  margin: 0 0 8px;
+}
+
+.provider-explorer-empty {
+  padding: 32px 24px;
+  border-top: 1px solid var(--border-hairline);
+  text-align: center;
+}
+
+.provider-explorer-empty p {
+  margin: 6px 0 0;
+  color: var(--text-muted);
+}
+
 .model-quick-row {
   display: flex;
   flex-wrap: wrap;

--- a/src/trusted_router/static/providers.js
+++ b/src/trusted_router/static/providers.js
@@ -1,0 +1,42 @@
+(() => {
+  "use strict";
+
+  const root = document.querySelector("[data-provider-explorer]");
+  const input = root?.querySelector("[data-provider-search]");
+  const rows = Array.from(document.querySelectorAll("[data-provider-row]"));
+  const resultCount = root?.querySelector("[data-provider-result-count]");
+  const empty = document.querySelector("[data-provider-empty]");
+
+  if (!root || !input || !resultCount || !empty || rows.length === 0) return;
+
+  const normalize = (value) => value.trim().toLocaleLowerCase();
+  const haystacks = new Map(rows.map((row) => [row, normalize(row.textContent || "")]));
+
+  const syncUrl = (query) => {
+    const url = new URL(window.location.href);
+    if (query) url.searchParams.set("q", query);
+    else url.searchParams.delete("q");
+    window.history.replaceState({}, "", `${url.pathname}${url.search}${url.hash}`);
+  };
+
+  const applySearch = () => {
+    const query = input.value.trim();
+    const terms = normalize(query).split(/\s+/).filter(Boolean);
+    let visible = 0;
+
+    rows.forEach((row) => {
+      const matches = terms.every((term) => haystacks.get(row).includes(term));
+      row.hidden = !matches;
+      if (matches) visible += 1;
+    });
+
+    resultCount.textContent = `${visible} ${visible === 1 ? "entry" : "entries"}`;
+    empty.hidden = visible !== 0;
+    syncUrl(query);
+  };
+
+  const initialQuery = new URL(window.location.href).searchParams.get("q") || "";
+  input.value = initialQuery;
+  input.addEventListener("input", applySearch);
+  applySearch();
+})();

--- a/src/trusted_router/templates/public/pricing.html
+++ b/src/trusted_router/templates/public/pricing.html
@@ -1,6 +1,14 @@
 {% extends "public/_base.html" %}
 {% block body %}
 
+<section class="cta-band" aria-label="Per-model pricing" style="margin-bottom:24px">
+  <div>
+    <strong>Per-model pricing</strong>
+    <span>Input, cached-input, output, and provider-specific prices are listed on the Models page.</span>
+  </div>
+  <a class="btn secondary" href="/models">Browse model prices</a>
+</section>
+
 <section class="marketing-grid three" aria-label="Ways to pay">
   <div class="marketing-card">
     <span class="card-icon">01</span>

--- a/src/trusted_router/templates/public/providers.html
+++ b/src/trusted_router/templates/public/providers.html
@@ -19,8 +19,22 @@
       <a class="btn" href="/providers/marketplace">List your models <span aria-hidden="true">→</span></a>
     </div>
   </div>
+  <div class="model-explorer-toolbar provider-explorer-toolbar" data-provider-explorer>
+    <label class="model-search-field">
+      <span class="model-control-label">Search providers</span>
+      <input
+        type="search"
+        aria-label="Search providers"
+        placeholder="Search provider, privacy tier, routing, or policy"
+        autocomplete="off"
+        spellcheck="false"
+        data-provider-search
+      >
+    </label>
+    <p class="provider-explorer-count" aria-live="polite"><strong data-provider-result-count>{{ providers|length }} entries</strong></p>
+  </div>
   <div class="model-table-wrap">
-    <table>
+    <table class="provider-catalog-table">
       <thead>
         <tr>
           <th>Provider</th>
@@ -36,7 +50,7 @@
       </thead>
       <tbody>
         {% for provider in providers %}
-        <tr>
+        <tr data-provider-row data-provider-id="{{ provider.id }}">
           <td>{{ provider_identity(provider.id, provider.name, provider.detail_href, subtitle=provider.id) }}</td>
           <td><span class="pill {% if provider.routing_status == 'active' %}good{% endif %}">{{ provider.routing_status_label }}</span></td>
           <td><span class="pill {% if provider.privacy_tier in ['Confidential', 'TR gateway', 'No logs', 'No logs (prepaid)'] %}good{% endif %}">{{ provider.privacy_tier }}</span></td>
@@ -45,14 +59,27 @@
           <td><span class="pill {% if provider.zero_data_retention or provider.prepaid_zero_data_retention %}good{% endif %}">{{ provider.zero_data_retention_label }}</span></td>
           <td><span class="pill {% if provider.confidential_compute %}good{% endif %}">{{ provider.confidential_compute_label }}</span></td>
           <td><span class="pill {% if provider.provider_e2ee %}good{% endif %}">{{ provider.provider_e2ee_label }}</span></td>
-          <td>
-            {{ provider.policy }}
-            {% if provider.policy_url %}<br><a href="{{ provider.policy_url }}">Policy source</a>{% endif %}
+          <td class="provider-policy-cell">
+            <details class="provider-policy-details">
+              <summary>
+                <span class="provider-policy-preview">{{ provider.policy }}</span>
+                <span class="provider-policy-toggle provider-policy-show">Show more</span>
+                <span class="provider-policy-toggle provider-policy-hide">Show less</span>
+              </summary>
+              <div class="provider-policy-full">
+                <p>{{ provider.policy }}</p>
+                {% if provider.policy_url %}<a href="{{ provider.policy_url }}">Policy source</a>{% endif %}
+              </div>
+            </details>
           </td>
         </tr>
         {% endfor %}
       </tbody>
     </table>
+  </div>
+  <div class="provider-explorer-empty" data-provider-empty hidden>
+    <strong>No matching providers</strong>
+    <p>Try a provider name, routing status, privacy tier, or policy term.</p>
   </div>
 </section>
 
@@ -73,4 +100,7 @@
     <p>Use <span class="mono">trustedrouter/zdr</span> for the zero-retention pool, <span class="mono">trustedrouter/eu</span> for EU-focused provider selection, or <span class="mono">trustedrouter/e2e</span> for the confidential + E2EE pool. When selecting a model or provider directly, set <span class="mono">provider.min_privacy = "zdr"</span> or the stronger <span class="mono">provider.min_privacy = "confidential"</span>; these hard filters fail closed if no eligible endpoint remains. Use <span class="mono">trustedrouter/auto</span> when breadth and health are the priority.</p>
   </div>
 </section>
+{% endblock %}
+{% block body_scripts %}
+<script src="/static/providers.js?v={{ static_version|default('local') }}"></script>
 {% endblock %}

--- a/tests/browser/providers.spec.js
+++ b/tests/browser/providers.spec.js
@@ -1,0 +1,24 @@
+const { expect, test } = require("@playwright/test");
+
+test("provider catalog searches and expands policy notes", async ({ page }) => {
+  await page.goto("/providers");
+
+  const search = page.getByRole("searchbox", { name: "Search providers" });
+  const tinfoil = page.locator('[data-provider-id="tinfoil"]');
+  const anthropic = page.locator('[data-provider-id="anthropic"]');
+
+  await expect(search).toBeVisible();
+  await search.fill("tinfoil");
+  await expect(tinfoil).toBeVisible();
+  await expect(anthropic).toBeHidden();
+  await expect(page.locator("[data-provider-result-count]")).toHaveText("1 entry");
+  await expect(page).toHaveURL(/\?q=tinfoil$/);
+
+  const policy = tinfoil.locator(".provider-policy-details");
+  await expect(policy).not.toHaveAttribute("open", "");
+  await expect(policy.locator(".provider-policy-preview")).toBeVisible();
+  await policy.locator("summary").click();
+  await expect(policy).toHaveAttribute("open", "");
+  await expect(policy.locator(".provider-policy-full")).toBeVisible();
+  await expect(policy.getByText("Show less", { exact: true })).toBeVisible();
+});

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -530,6 +530,21 @@ def test_public_models_page_is_a_ranked_searchable_price_explorer(
     assert glm < kimi < deepseek < router_alias
 
 
+def test_public_providers_page_has_search_and_collapsed_policy_notes(
+    client: TestClient,
+) -> None:
+    response = client.get("/providers")
+
+    assert response.status_code == 200
+    assert 'type="search"' in response.text
+    assert 'data-provider-search' in response.text
+    assert 'data-provider-row data-provider-id="tinfoil"' in response.text
+    assert '<details class="provider-policy-details">' in response.text
+    assert "Show more" in response.text
+    assert "Show less" in response.text
+    assert "/static/providers.js" in response.text
+
+
 def test_public_model_detail_lists_distinct_serving_providers(client: TestClient) -> None:
     model_id = "moonshotai/kimi-k2.6"
     response = client.get(f"/models/{model_id}")

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from trusted_router.catalog import endpoints_for_model
+from trusted_router.catalog import PROVIDERS, endpoints_for_model
 from trusted_router.dashboard import PUBLIC_PAGES
 from trusted_router.storage import STORE
 
@@ -282,6 +282,8 @@ def test_public_pricing_matches_five_point_five_percent_billing_policy(
     assert "Cheaper. Smarter. More reliable. More secure." in pricing.text
     assert "5.5% pay as you go fee on credit purchases" in pricing.text
     assert 'href="https://openrouter.ai/pricing"' in pricing.text
+    assert "provider-specific prices are listed on the Models page" in pricing.text
+    assert '<a class="btn secondary" href="/models">Browse model prices</a>' in pricing.text
     assert "10% markup" not in pricing.text
 
     comparison = client.get("/compare/openrouter")
@@ -518,6 +520,8 @@ def test_public_models_page_is_a_ranked_searchable_price_explorer(
     assert 'href="/for-developers"' in body
     assert 'href="/docs/quickstart"' not in body
     assert 'data-endpoints-url="/v1/models/z-ai/glm-5.3-flash/endpoints"' in body
+    public_provider_count = sum(slug != "trustedrouter" for slug in PROVIDERS)
+    assert f"{public_provider_count} providers" in body
 
     glm = body.index('data-model-id="z-ai/glm-5.3-flash"')
     kimi = body.index('data-model-id="moonshotai/kimi-k3"')


### PR DESCRIPTION
## Summary
- add a prominent per-model pricing link on `/pricing`
- count the complete 85-provider external catalog on `/models`
- add instant URL-backed search to `/providers`
- collapse provider policy notes behind accessible native disclosure controls

## Verification
- `uv run ruff check src/trusted_router/dashboard.py tests/test_public_revenue_pages.py`
- `uv run pytest tests/test_public_revenue_pages.py -q` (36 passed)
- `npm run lint:css`
- `node --check src/trusted_router/static/providers.js`
- `npm run test:browser -- tests/browser/providers.spec.js` (1 passed)
- visual browser pass for search and policy expansion
- `git diff --check`