### PR TITLE
Fix Parasail discovery delisting reconciliation

### DIFF
--- a/scripts/pricing/providers/parasail.py
+++ b/scripts/pricing/providers/parasail.py
@@ -42,6 +42,7 @@ from scripts.pricing.base import (
     PROVIDER_FETCH_UA,
     ModelPrice,
     ProviderPricingResult,
+    reconcile_manifest_tombstones,
     validate,
 )
 from scripts.pricing.model_ids import mapped_or_canonical_model_id, remember_upstream_id
@@ -562,10 +563,10 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
 
     Mirrors the wafer.py hook: update existing supplement rows in
     place, append templates for newly-served ahead-of-snapshot models,
-    and stamp provenance. Rows are NOT removed when a model temporarily
-    drops off the page — the runtime treats stale supplement prices as
-    better than delisting a routable model mid-day; removal is an
-    operator decision."""
+    and stamp provenance. Rows are never deleted automatically. A model
+    absent from the authenticated serving catalog is retained on its first
+    fresh miss and marked unroutable on its second; a later reappearance
+    clears that machine-owned tombstone."""
     raw = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
     rows = raw.get("models")
     if not isinstance(rows, list):
@@ -636,7 +637,26 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
             row.pop("unresolved_since", None)
         updated.append(model_id)
 
-    missing = sorted(set(_MANIFEST_EXPECTED) - set(updated))
+    # The public pricing table can lag the authenticated serving catalog in
+    # either direction. Require prices for every expected model that the fresh
+    # API still serves, but do not block the entire catalog when Parasail
+    # removes a historical route while its pricing row remains published.
+    # Shared tombstone semantics retain the route on the first fresh miss,
+    # disable it on the second, and recover it if it later reappears.
+    present_rows = {
+        model_id: dict(existing_by_id[model_id])
+        for model_id in _LIVE_MODEL_IDS
+        if model_id in existing_by_id
+    }
+    rows = reconcile_manifest_tombstones(
+        rows,
+        present_rows,
+        priced_ids=set(result.prices),
+        source=result.source,
+    )
+
+    live_expected = set(_MANIFEST_EXPECTED) & _LIVE_MODEL_IDS
+    missing = sorted(live_expected - set(updated))
     if missing:
         raise RuntimeError(f"parasail manifest did not update expected model(s): {missing}")
 
@@ -650,6 +670,7 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
     raw["generated_at"] = datetime.now(UTC).replace(microsecond=0).isoformat().replace(
         "+00:00", "Z"
     )
+    raw["models"] = rows
     raw["model_count"] = len(rows)
     MANIFEST_PATH.write_text(
         json.dumps(raw, indent=2, ensure_ascii=False) + "\n",

--- a/tests/test_parasail_august_2026_lifecycle.py
+++ b/tests/test_parasail_august_2026_lifecycle.py
@@ -181,6 +181,7 @@ def test_parasail_manifest_prunes_retired_rows_at_cutoff(
     }
     active_prices["moonshotai/kimi-k2.7-code"] = ModelPrice(750_000, 3_500_000)
     active_prices["z-ai/glm-5.3"] = ModelPrice(1_400_000, 4_400_000)
+    monkeypatch.setattr(parasail, "_LIVE_MODEL_IDS", set(active_prices))
     parasail.write_provider_manifest(
         ProviderPricingResult(
             slug="parasail",

--- a/tests/test_parasail_pricing.py
+++ b/tests/test_parasail_pricing.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
+from scripts.pricing.base import ModelPrice, ProviderPricingResult
 from scripts.pricing.providers import parasail
 
 
@@ -238,6 +241,107 @@ def test_write_provider_manifest_appends_new_models(tmp_path, monkeypatch) -> No
     assert "input_token_price_per_m" not in unresolved
     assert saved["model_count"] == len(saved["models"])
     assert any("appended" in n for n in notes)
+
+
+def test_write_provider_manifest_tombstones_api_delisting_without_blocking_refresh(
+    tmp_path, monkeypatch
+) -> None:  # noqa: ANN001
+    kimi_id = "moonshotai/kimi-k2.7-code"
+    minimax_id = "minimax/minimax-m3"
+    manifest = {
+        "provider": "parasail",
+        "models": [
+            {
+                **parasail._MANIFEST_ROW_TEMPLATES[kimi_id],
+                "input_token_price_per_m": 750_000,
+                "output_token_price_per_m": 3_500_000,
+            },
+            {
+                **parasail._MANIFEST_ROW_TEMPLATES[minimax_id],
+                "input_token_price_per_m": 300_000,
+                "output_token_price_per_m": 1_200_000,
+            },
+        ],
+    }
+    path = tmp_path / "parasail.json"
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+    monkeypatch.setattr(parasail, "MANIFEST_PATH", path)
+    monkeypatch.setattr(parasail, "_MANIFEST_EXPECTED", [kimi_id, minimax_id])
+    monkeypatch.setattr(parasail, "_LIVE_MODEL_IDS", {minimax_id})
+
+    live_result = ProviderPricingResult(
+        slug="parasail",
+        prices={minimax_id: ModelPrice(300_000, 1_200_000)},
+        source="api",
+        fetched_url=parasail.PRICING_URL,
+    )
+
+    # One fresh omission may be transient, so retain the route but record it.
+    parasail.write_provider_manifest(live_result)
+    first = {
+        row["id"]: row
+        for row in json.loads(path.read_text(encoding="utf-8"))["models"]
+    }
+    assert first[kimi_id]["missing_since"]
+    assert first[kimi_id].get("routable") is not False
+
+    # A second fresh omission confirms the delisting and fails the route closed.
+    parasail.write_provider_manifest(live_result)
+    second = {
+        row["id"]: row
+        for row in json.loads(path.read_text(encoding="utf-8"))["models"]
+    }
+    assert second[kimi_id]["routable"] is False
+    assert second[kimi_id]["routable_reason"] == "delisted-upstream"
+
+    # A fresh live, priced row clears only the machine-owned tombstone.
+    monkeypatch.setattr(parasail, "_LIVE_MODEL_IDS", {kimi_id, minimax_id})
+    restored_result = ProviderPricingResult(
+        slug="parasail",
+        prices={
+            kimi_id: ModelPrice(750_000, 3_500_000),
+            minimax_id: ModelPrice(300_000, 1_200_000),
+        },
+        source="api",
+        fetched_url=parasail.PRICING_URL,
+    )
+    parasail.write_provider_manifest(restored_result)
+    restored = {
+        row["id"]: row
+        for row in json.loads(path.read_text(encoding="utf-8"))["models"]
+    }
+    assert restored[kimi_id]["routable"] is True
+    assert "routable_reason" not in restored[kimi_id]
+    assert "missing_since" not in restored[kimi_id]
+
+
+def test_write_provider_manifest_still_requires_prices_for_live_expected_models(
+    tmp_path, monkeypatch
+) -> None:  # noqa: ANN001
+    model_id = "moonshotai/kimi-k2.7-code"
+    path = tmp_path / "parasail.json"
+    path.write_text(
+        json.dumps(
+            {
+                "provider": "parasail",
+                "models": [dict(parasail._MANIFEST_ROW_TEMPLATES[model_id])],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(parasail, "MANIFEST_PATH", path)
+    monkeypatch.setattr(parasail, "_MANIFEST_EXPECTED", [model_id])
+    monkeypatch.setattr(parasail, "_LIVE_MODEL_IDS", {model_id})
+
+    with pytest.raises(RuntimeError, match="did not update expected model"):
+        parasail.write_provider_manifest(
+            ProviderPricingResult(
+                slug="parasail",
+                prices={},
+                source="api",
+                fetched_url=parasail.PRICING_URL,
+            )
+        )
 
 
 def test_write_provider_manifest_promotes_glm_53_only_after_official_price(


### PR DESCRIPTION
## Summary
- require valid prices only for Parasail models present in the fresh authenticated serving catalog
- retain an absent historical route on the first API miss, tombstone it after a second miss, and recover machine-owned tombstones on reappearance
- add regression coverage for transient omission, confirmed delisting, recovery, and live-without-price fail-closed behavior

## Production root cause
Parasail still publishes a Kimi K2.7 Code pricing row, but its authenticated `/v1/models` catalog no longer advertises the route. The two-source join correctly excluded it; the manifest writer then incorrectly required every historical expected model and blocked the entire hourly refresh.

## Verification
- live authenticated Parasail fetch + temporary-manifest writer dry run: pass
- focused coverage: 71 passed
- pricing-related suite: 519 passed
- full suite: 7,672 passed, 346 skipped, 10 xfailed
- ruff check: pass
- git diff check: pass