### PR TITLE
Improve provider catalog layout and ZDR labels

### DIFF
--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -475,7 +475,7 @@ PROVIDERS: dict[str, Provider] = {
             "Contracted Zero Data Retention is active for TrustedRouter's managed "
             "OpenAI account, effective July 28, 2026, and live enforcement was "
             "verified on July 29, 2026. This guarantee applies only to "
-            "TrustedRouter-funded prepaid routes; customer BYOK credentials use the "
+            "TrustedRouter-funded routes; customer BYOK credentials use the "
             "data controls on the customer's own OpenAI organization or project."
         ),
         provider_policy_url=(
@@ -509,7 +509,7 @@ PROVIDERS: dict[str, Provider] = {
         provider_policy=(
             "TrustedRouter's managed Vertex AI account is covered by contractual "
             "Zero Data Retention. This guarantee applies only to TrustedRouter-funded "
-            "prepaid routes. TrustedRouter does not invoke Google Search or Maps "
+            "routes. TrustedRouter does not invoke Google Search or Maps "
             "grounding or Gemini Live session resumption on these routes. Google AI "
             "Studio is classified separately."
         ),

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -4963,12 +4963,19 @@ def _provider_view(provider: Provider) -> dict[str, object]:
         "confidential_compute": provider.provider_confidential_compute,
         "provider_e2ee": provider.provider_e2ee,
         "zero_data_retention_label": (
-            "prepaid only"
-            if provider.prepaid_zero_data_retention
-            and provider.provider_zero_data_retention is not True
+            "yes"
+            if provider.provider_zero_data_retention is True
+            or provider.prepaid_zero_data_retention
             else f"scheduled {provider.prepaid_zero_data_retention_effective_on}"
             if provider.prepaid_zero_data_retention_effective_on
             else _policy_label(provider.provider_zero_data_retention)
+        ),
+        "zero_data_retention_scope_label": (
+            "All routes"
+            if provider.provider_zero_data_retention is True
+            else "TR-funded routes"
+            if provider.prepaid_zero_data_retention
+            else None
         ),
         "confidential_compute_label": _policy_label(provider.provider_confidential_compute),
         "provider_e2ee_label": _policy_label(provider.provider_e2ee),
@@ -5011,7 +5018,7 @@ def _provider_faq_items(
         )
     elif provider.prepaid_zero_data_retention:
         zdr_answer = (
-            f"TrustedRouter records managed prepaid {provider.name} routes as zero data "
+            f"TrustedRouter records its managed {provider.name} routes as zero data "
             "retention. That classification does not automatically cover every direct or "
             "BYOK account. Use provider.min_privacy=zdr to require an eligible route."
         )
@@ -5061,9 +5068,9 @@ def _provider_privacy_tier(provider: Provider) -> str:
     if provider.provider_e2ee and provider.provider_confidential_compute:
         return "Confidential"
     if provider.provider_zero_data_retention:
-        return "No logs"
+        return "ZDR"
     if provider.prepaid_zero_data_retention:
-        return "No logs (prepaid)"
+        return "ZDR"
     if provider.provider_confidential_compute:
         return "Confidential compute"
     return "No provider claim"

--- a/src/trusted_router/static/charter.css
+++ b/src/trusted_router/static/charter.css
@@ -2685,9 +2685,93 @@ body.auth.auth-shell {
   white-space: nowrap;
 }
 
-.provider-policy-cell {
-  width: 260px;
-  min-width: 220px;
+.provider-catalog-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  padding: 14px;
+}
+
+.provider-catalog-card {
+  display: grid;
+  min-width: 0;
+  gap: 14px;
+  align-content: start;
+  padding: 16px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--r-card);
+  background: var(--surface-raised);
+}
+
+.provider-catalog-card[hidden] {
+  display: none;
+}
+
+.provider-card-head {
+  display: flex;
+  min-width: 0;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.provider-card-head .provider-identity {
+  min-width: 0;
+}
+
+.provider-card-head .provider-identity-copy strong,
+.provider-card-head .provider-identity-copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.provider-card-trust {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.provider-card-facts {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin: 0;
+}
+
+.provider-card-facts > div {
+  min-width: 0;
+}
+
+.provider-card-facts dt {
+  margin-bottom: 6px;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+
+.provider-card-facts dd {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  margin: 0;
+}
+
+.provider-card-facts small,
+.provider-scope-note {
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.provider-catalog-card > .provider-policy-details {
+  min-width: 0;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-hairline);
 }
 
 .provider-policy-details summary {
@@ -2735,6 +2819,7 @@ body.auth.auth-shell {
 
 .provider-policy-full p {
   margin: 0 0 8px;
+  overflow-wrap: anywhere;
 }
 
 .provider-explorer-empty {
@@ -3117,6 +3202,10 @@ body.auth.auth-shell {
     justify-content: flex-start;
   }
 
+  .provider-catalog-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
   .model-card-main {
     gap: 16px;
   }
@@ -3144,6 +3233,21 @@ body.auth.auth-shell {
     font-family: var(--font-ui);
     font-size: 9px;
     text-transform: uppercase;
+  }
+}
+
+@media (max-width: 520px) {
+  .provider-explorer-toolbar,
+  .provider-card-facts {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .provider-explorer-count {
+    margin: 0;
+  }
+
+  .provider-card-head {
+    align-items: flex-start;
   }
 }
 

--- a/src/trusted_router/templates/dashboard.html
+++ b/src/trusted_router/templates/dashboard.html
@@ -99,7 +99,7 @@
 
     <section class="charter-stat-band" aria-label="{{ brand_name }} facts">
       <div class="charter-stat"><strong>600+</strong><span>AI models</span></div>
-      <div class="charter-stat"><strong>81+</strong><span>providers</span></div>
+      <div class="charter-stat"><strong>90+</strong><span>providers</span></div>
       <div class="charter-stat"><strong>3 clouds</strong><span>GCP · AWS · Azure</span></div>
     </section>
 

--- a/src/trusted_router/templates/public/provider_detail.html
+++ b/src/trusted_router/templates/public/provider_detail.html
@@ -4,7 +4,7 @@
 <section class="panel">
   <div class="panel-head">
     <h2 class="provider-detail-title">{{ provider_identity(provider.id, provider.name, size="large", subtitle=provider.id) }}</h2>
-    <span class="pill {% if provider.privacy_tier in ['Confidential', 'TR gateway', 'No logs', 'No logs (prepaid)'] %}good{% endif %}">{{ provider.privacy_tier }}</span>
+    <span class="pill {% if provider.privacy_tier in ['Confidential', 'TR gateway', 'ZDR'] %}good{% endif %}">{{ provider.privacy_tier }}</span>
   </div>
   <div class="panel-body">
     <p><a href="/providers">All providers</a></p>
@@ -14,9 +14,9 @@
         <tr><th>Routing status</th><td><span class="pill {% if provider.routing_status == 'active' %}good{% endif %}">{{ provider.routing_status_label }}</span></td></tr>
         {% if provider.homepage_url %}<tr><th>Provider website</th><td><a href="{{ provider.homepage_url }}" rel="nofollow noopener">{{ provider.homepage_url }}</a></td></tr>{% endif %}
         <tr><th>Models</th><td>{{ provider.served_model_count }} public model{{ '' if provider.served_model_count == 1 else 's' }}</td></tr>
-        <tr><th>Prepaid routes</th><td>{{ provider.prepaid_model_count }}</td></tr>
+        <tr><th>Credits routes</th><td>{{ provider.prepaid_model_count }}</td></tr>
         <tr><th>BYOK routes</th><td>{{ provider.byok_model_count }}</td></tr>
-        <tr><th>Zero data retention</th><td><span class="pill {% if provider.zero_data_retention or provider.prepaid_zero_data_retention %}good{% endif %}">{{ provider.zero_data_retention_label }}</span></td></tr>
+        <tr><th>Zero data retention</th><td><span class="pill {% if provider.zero_data_retention or provider.prepaid_zero_data_retention %}good{% endif %}">{{ provider.zero_data_retention_label }}</span>{% if provider.zero_data_retention_scope_label %} <span class="provider-scope-note">{{ provider.zero_data_retention_scope_label }}</span>{% endif %}</td></tr>
         <tr><th>Confidential compute</th><td><span class="pill {% if provider.confidential_compute %}good{% endif %}">{{ provider.confidential_compute_label }}</span></td></tr>
         <tr><th>Provider E2EE</th><td><span class="pill {% if provider.provider_e2ee %}good{% endif %}">{{ provider.provider_e2ee_label }}</span></td></tr>
         <tr><th>Policy note</th><td>{{ provider.policy }}{% if provider.policy_url %}<br><a href="{{ provider.policy_url }}">Policy source</a>{% endif %}</td></tr>

--- a/src/trusted_router/templates/public/providers.html
+++ b/src/trusted_router/templates/public/providers.html
@@ -33,49 +33,48 @@
     </label>
     <p class="provider-explorer-count" aria-live="polite"><strong data-provider-result-count>{{ providers|length }} entries</strong></p>
   </div>
-  <div class="model-table-wrap">
-    <table class="provider-catalog-table">
-      <thead>
-        <tr>
-          <th>Provider</th>
-          <th>Routing</th>
-          <th>Trust tier</th>
-          <th>Prepaid</th>
-          <th>BYOK</th>
-          <th>ZDR</th>
-          <th>Confidential compute</th>
-          <th>Provider E2EE</th>
-          <th>Policy note</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for provider in providers %}
-        <tr data-provider-row data-provider-id="{{ provider.id }}">
-          <td>{{ provider_identity(provider.id, provider.name, provider.detail_href, subtitle=provider.id) }}</td>
-          <td><span class="pill {% if provider.routing_status == 'active' %}good{% endif %}">{{ provider.routing_status_label }}</span></td>
-          <td><span class="pill {% if provider.privacy_tier in ['Confidential', 'TR gateway', 'No logs', 'No logs (prepaid)'] %}good{% endif %}">{{ provider.privacy_tier }}</span></td>
-          <td>{% if provider.supports_prepaid %}<span class="pill good">yes</span>{% else %}no{% endif %}</td>
-          <td>{% if provider.supports_byok %}<span class="pill good">yes</span>{% else %}no{% endif %}</td>
-          <td><span class="pill {% if provider.zero_data_retention or provider.prepaid_zero_data_retention %}good{% endif %}">{{ provider.zero_data_retention_label }}</span></td>
-          <td><span class="pill {% if provider.confidential_compute %}good{% endif %}">{{ provider.confidential_compute_label }}</span></td>
-          <td><span class="pill {% if provider.provider_e2ee %}good{% endif %}">{{ provider.provider_e2ee_label }}</span></td>
-          <td class="provider-policy-cell">
-            <details class="provider-policy-details">
-              <summary>
-                <span class="provider-policy-preview">{{ provider.policy }}</span>
-                <span class="provider-policy-toggle provider-policy-show">Show more</span>
-                <span class="provider-policy-toggle provider-policy-hide">Show less</span>
-              </summary>
-              <div class="provider-policy-full">
-                <p>{{ provider.policy }}</p>
-                {% if provider.policy_url %}<a href="{{ provider.policy_url }}">Policy source</a>{% endif %}
-              </div>
-            </details>
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+  <div class="provider-catalog-grid">
+    {% for provider in providers %}
+    <article class="provider-catalog-card" data-provider-row data-provider-id="{{ provider.id }}">
+      <header class="provider-card-head">
+        {{ provider_identity(provider.id, provider.name, provider.detail_href, subtitle=provider.id) }}
+        <span class="pill {% if provider.routing_status == 'active' %}good{% endif %}">{{ provider.routing_status_label }}</span>
+      </header>
+      <div class="provider-card-trust" aria-label="{{ provider.name }} trust and access">
+        <span class="pill {% if provider.privacy_tier in ['Confidential', 'TR gateway', 'ZDR'] %}good{% endif %}">{{ provider.privacy_tier }}</span>
+        {% if provider.supports_prepaid %}<span class="pill good">Credits</span>{% endif %}
+        {% if provider.supports_byok %}<span class="pill">BYOK</span>{% endif %}
+      </div>
+      <dl class="provider-card-facts">
+        <div>
+          <dt>Zero data retention</dt>
+          <dd>
+            <span class="pill {% if provider.zero_data_retention or provider.prepaid_zero_data_retention %}good{% endif %}">{{ provider.zero_data_retention_label }}</span>
+            {% if provider.zero_data_retention_scope_label %}<small>{{ provider.zero_data_retention_scope_label }}</small>{% endif %}
+          </dd>
+        </div>
+        <div>
+          <dt>Confidential compute</dt>
+          <dd><span class="pill {% if provider.confidential_compute %}good{% endif %}">{{ provider.confidential_compute_label }}</span></dd>
+        </div>
+        <div>
+          <dt>Provider E2EE</dt>
+          <dd><span class="pill {% if provider.provider_e2ee %}good{% endif %}">{{ provider.provider_e2ee_label }}</span></dd>
+        </div>
+      </dl>
+      <details class="provider-policy-details">
+        <summary>
+          <span class="provider-policy-preview">{{ provider.policy }}</span>
+          <span class="provider-policy-toggle provider-policy-show">Show policy</span>
+          <span class="provider-policy-toggle provider-policy-hide">Hide policy</span>
+        </summary>
+        <div class="provider-policy-full">
+          <p>{{ provider.policy }}</p>
+          {% if provider.policy_url %}<a href="{{ provider.policy_url }}">Policy source</a>{% endif %}
+        </div>
+      </details>
+    </article>
+    {% endfor %}
   </div>
   <div class="provider-explorer-empty" data-provider-empty hidden>
     <strong>No matching providers</strong>

--- a/tests/browser/dashboard.spec.js
+++ b/tests/browser/dashboard.spec.js
@@ -16,7 +16,7 @@ test("homepage opens sign-in modal and handles missing MetaMask", async ({ page 
   const homepageStats = page.locator(".charter-stat-band .charter-stat");
   await expect(homepageStats).toHaveCount(3);
   await expect(homepageStats.nth(0)).toContainText("600+AI models");
-  await expect(homepageStats.nth(1)).toContainText("81+providers");
+  await expect(homepageStats.nth(1)).toContainText("90+providers");
   await expect(homepageStats.last()).toContainText("3 cloudsGCP · AWS · Azure");
   await expect(page.locator(".region-map-card")).toHaveCount(0);
   await expect(page.locator("body")).toHaveCSS("font-size", "15.5px");

--- a/tests/browser/providers.spec.js
+++ b/tests/browser/providers.spec.js
@@ -20,5 +20,18 @@ test("provider catalog searches and expands policy notes", async ({ page }) => {
   await policy.locator("summary").click();
   await expect(policy).toHaveAttribute("open", "");
   await expect(policy.locator(".provider-policy-full")).toBeVisible();
-  await expect(policy.getByText("Show less", { exact: true })).toBeVisible();
+  await expect(policy.getByText("Hide policy", { exact: true })).toBeVisible();
+});
+
+test("provider catalog fits a mobile viewport without horizontal scrolling", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/providers");
+
+  const dimensions = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+  }));
+
+  expect(dimensions.scrollWidth).toBe(dimensions.clientWidth);
+  await expect(page.locator(".provider-catalog-grid")).toHaveCSS("grid-template-columns", "320px");
 });

--- a/tests/test_openai_contracted_zdr.py
+++ b/tests/test_openai_contracted_zdr.py
@@ -103,7 +103,8 @@ def test_zdr_alias_can_use_openai_only_through_contracted_credits_route() -> Non
 def test_public_pages_explain_active_openai_prepaid_scope(client: TestClient) -> None:
     providers = client.get("/providers")
     assert providers.status_code == 200
-    assert "prepaid only" in providers.text
+    assert "TR-funded routes" in providers.text
+    assert "prepaid only" not in providers.text
     assert "Contracted Zero Data Retention is active" in providers.text
     assert "July 28, 2026" in providers.text
     assert "verified on July 29, 2026" in providers.text

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -540,8 +540,8 @@ def test_public_providers_page_has_search_and_collapsed_policy_notes(
     assert 'data-provider-search' in response.text
     assert 'data-provider-row data-provider-id="tinfoil"' in response.text
     assert '<details class="provider-policy-details">' in response.text
-    assert "Show more" in response.text
-    assert "Show less" in response.text
+    assert "Show policy" in response.text
+    assert "Hide policy" in response.text
     assert "/static/providers.js" in response.text
 
 
@@ -739,7 +739,7 @@ def test_dashboard_links_to_public_models_not_keyed_api_catalog(client: TestClie
     assert "One Unified Interface." in response.text
     assert "Privacy with proof." in response.text
     assert "Better privacy, better prices, better uptime, no subscriptions." in response.text
-    assert '<strong>81+</strong><span>providers</span>' in response.text
+    assert '<strong>90+</strong><span>providers</span>' in response.text
     assert '<strong>3 clouds</strong><span>GCP · AWS · Azure</span>' in response.text
     assert 'class="region-map-card"' not in response.text
     assert "Provable privacy." not in response.text

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -530,6 +530,7 @@ def test_homepage_has_plain_llm_seo_positioning(client: TestClient) -> None:
     assert "Cheaper routes" in response.text
     assert "Faster migration" in response.text
     assert "More reliable inference" in response.text
+    assert "<strong>90+</strong><span>providers</span>" in response.text
     assert 'href="/llms.txt"' in response.text
 
 
@@ -542,6 +543,9 @@ def test_public_provider_route_defaults_to_html_for_link_checkers(client: TestCl
         in response.text
     )
     assert "Provider transparency" in response.text
+    assert 'class="provider-catalog-grid"' in response.text
+    assert 'class="provider-catalog-table"' not in response.text
+    assert "No logs (prepaid)" not in response.text
     assert "application/json" not in response.headers["content-type"]
 
     json_response = client.get("/providers", headers={"accept": "application/json"})
@@ -1101,16 +1105,31 @@ def test_provider_detail_page_links_served_models(client: TestClient) -> None:
     assert "FAQPage" in json.dumps(provider_schema)
 
 
-def test_vertex_provider_page_scopes_zdr_to_managed_prepaid_routes(
+def test_vertex_provider_page_presents_zdr_with_managed_route_scope(
     client: TestClient,
 ) -> None:
     response = client.get("/providers/google-vertex")
 
     assert response.status_code == 200
-    assert "No logs (prepaid)" in response.text
-    assert "prepaid only" in response.text
+    assert ">ZDR</span>" in response.text
+    assert ">yes</span>" in response.text
+    assert "TR-funded routes" in response.text
+    assert "No logs (prepaid)" not in response.text
+    assert "prepaid only" not in response.text
     assert "contractual Zero Data Retention" in response.text
     assert "Google AI Studio is classified separately" in response.text
+
+
+def test_openai_provider_page_presents_zdr_with_managed_route_scope(
+    client: TestClient,
+) -> None:
+    response = client.get("/providers/openai")
+
+    assert response.status_code == 200
+    assert ">ZDR</span>" in response.text
+    assert ">yes</span>" in response.text
+    assert "TR-funded routes" in response.text
+    assert "No logs (prepaid)" not in response.text
 
 
 def test_provider_detail_links_indexable_performance_page(


### PR DESCRIPTION
## Summary
- update the homepage provider count to 90+
- replace the horizontally scrolling provider table with responsive provider cards
- present OpenAI and Vertex managed routes as ZDR with an explicit TR-funded route scope
- add browser regression coverage for filtering and mobile overflow

## Verification
- 161 targeted pytest tests
- 24 Playwright browser tests
- Ruff
- Stylelint
- desktop and 390px visual checks