### PR TITLE
Remove retired BYOK AAD v1 control-plane support

### DIFF
--- a/docs/design/byok-aad-v2-attestations.json
+++ b/docs/design/byok-aad-v2-attestations.json
@@ -1,5 +1,87 @@
 {
-  "schema": "trustedrouter/byok-aad-v1-zero-attestation/v2",
+  "schema": "trustedrouter/byok-aad-v1-zero-attestation/v3",
   "about": "Recorded output of scripts/check_no_v1_envelopes.py, one entry per standalone cloud. Read by tests/test_byok_v1_removal_gate.py, which refuses the removal of v1 BYOK envelope support until EVERY cloud here attests zero v1 envelopes. It is one fleet-wide verdict, not three: an AWS or Azure enclave falls over to the home control plane when its own cannot be dialled, so a v1 envelope in any cloud's database can be handed to any cloud's enclave. An entry asserts that a run happened against that cloud's database; writing one by hand asserts a run that did not. The gate can check the shape, not the truth.",
-  "attestations": {}
+  "attestations": {
+    "aws": {
+      "cloud": "aws",
+      "outcome": "empty_witnessed",
+      "recorded_at": "2026-08-29T17:17:32+00:00",
+      "backend": "postgres",
+      "surface_fingerprint": "0b59aa80a894094a",
+      "rows_scanned": 0,
+      "rows_scanned_by_kind": {},
+      "envelopes_seen": 0,
+      "v1_envelopes": 0,
+      "v2_envelopes": 0,
+      "missing_envelopes": 0,
+      "census_migrated_kind_counts": {},
+      "census_sampled_kinds": [
+        "api_key",
+        "api_key_by_workspace",
+        "api_key_lookup",
+        "credit",
+        "email_user",
+        "gateway_authorization",
+        "synthetic_probe"
+      ],
+      "census_v1_literal_rows": 0,
+      "census_positive_control_rows": 4939183,
+      "census_source": "postgres:postgres@tnt642i3ofzpn5z62msacutpuu.dsql.eu-west-3.on.aws:5432 as admin (database/user from server; host/port from negotiated connection)",
+      "operator": "joseph@jperla.com",
+      "note": "Fresh Step 4 precondition audit after the fourteen-day retention window; single-statement read-only census with a literal-search positive control, using an AWS DSQL admin IAM token against the live multi-region cluster."
+    },
+    "azure": {
+      "cloud": "azure",
+      "outcome": "empty_witnessed",
+      "recorded_at": "2026-08-29T17:19:27+00:00",
+      "backend": "postgres",
+      "surface_fingerprint": "0b59aa80a894094a",
+      "rows_scanned": 0,
+      "rows_scanned_by_kind": {},
+      "envelopes_seen": 0,
+      "v1_envelopes": 0,
+      "v2_envelopes": 0,
+      "missing_envelopes": 0,
+      "census_migrated_kind_counts": {},
+      "census_sampled_kinds": [
+        "api_key",
+        "api_key_lookup",
+        "gateway_authorization"
+      ],
+      "census_v1_literal_rows": 0,
+      "census_positive_control_rows": 2634120,
+      "census_source": "postgres:trustedrouter@tr-azure-pg.postgres.database.azure.com:5432 as tradmin (database/user from server; host/port from negotiated connection)",
+      "operator": "joseph@jperla.com",
+      "note": "Fresh Step 4 precondition audit after the fourteen-day retention window, executed read-only inside live Azure revision tr-azure-vnet--0000007. The deployed scanner found zero migrated rows and zero V1 envelopes; the current Step 4 single-statement census found zero migrated rows, zero V1 literals, and 2,634,120 positive-control body rows. Private DNS resolved the configured PostgreSQL host to 10.61.2.4, and the connection identified database trustedrouter with effective role tradmin."
+    },
+    "gcp": {
+      "cloud": "gcp",
+      "outcome": "clean",
+      "recorded_at": "2026-08-29T17:16:17+00:00",
+      "backend": "spanner",
+      "surface_fingerprint": "0b59aa80a894094a",
+      "rows_scanned": 11,
+      "rows_scanned_by_kind": {
+        "byok": 10,
+        "user_provided_model": 1
+      },
+      "envelopes_seen": 11,
+      "v1_envelopes": 0,
+      "v2_envelopes": 11,
+      "missing_envelopes": 1,
+      "census_migrated_kind_counts": {
+        "byok": 10,
+        "user_provided_model": 1
+      },
+      "census_sampled_kinds": [
+        "acquisition_attribution",
+        "activation_reminder"
+      ],
+      "census_v1_literal_rows": 0,
+      "census_positive_control_rows": 9074020,
+      "census_source": "spanner:projects/quill-cloud-proxy/instances/trusted-router-nam6/databases/trusted-router (from CLI arguments, not asked of the server)",
+      "operator": "joseph@jperla.com",
+      "note": "Fresh Step 4 precondition audit after the fourteen-day retention window using the tr-ops-local read-only Spanner identity. The multi-use snapshot found zero whole-body V1 literals and its same-column literal-search positive control matched the populated production table."
+    }
+  }
 }

--- a/docs/design/byok-aad-v2-attestations.json
+++ b/docs/design/byok-aad-v2-attestations.json
@@ -81,7 +81,7 @@
       "census_positive_control_rows": 9074020,
       "census_source": "spanner:projects/quill-cloud-proxy/instances/trusted-router-nam6/databases/trusted-router (from CLI arguments, not asked of the server)",
       "operator": "joseph@jperla.com",
-      "note": "Fresh Step 4 precondition audit after the fourteen-day retention window using the tr-ops-local read-only Spanner identity. The multi-use snapshot found zero whole-body V1 literals and its same-column literal-search positive control matched the populated production table."
+      "note": "Fresh Step 4 precondition audit after the fourteen-day retention window, authenticated as tr-ops-local@quill-cloud-proxy.iam.gserviceaccount.com and targeting projects/quill-cloud-proxy/instances/trusted-router-nam6/databases/trusted-router. The multi-use snapshot found zero whole-body V1 literals and its same-column literal-search positive control matched 9,074,020 rows in the populated production table. The database name is still client-composed, as census_source states; the observed production row count is the independent live-service corroboration."
     }
   }
 }

--- a/docs/design/byok-aad-v2-migration.md
+++ b/docs/design/byok-aad-v2-migration.md
@@ -1,20 +1,21 @@
 # BYOK envelope AAD v2 — migration plan
 
-**Status:** deployed through step 3 on GCP, AWS, and Azure; step 4 is not started
+**Status:** Step 4 precondition passed fleet-wide on 2026-08-29; removal is prepared for deployment
 **Owner:** TrustedRouter platform/security
 **Blocks on:** nothing. The reachable exploit path is already closed (#544).
 **Spans:** `quill-router` and `quill-cloud-proxy`. Ordering between them is the
 whole difficulty — **and it repeats per cloud deployment**, see §4.0.
 
-**Progress (2026-08-15):** the per-cloud sequence is complete through step 3.
-Step 4 remains deliberately undone, so every enclave and control plane still
-reads v1 envelopes during the retention window.
+**Progress (2026-08-29):** the per-cloud sequence is complete through step 3,
+the backfill has been idle for fourteen days, and fresh fleet audits found zero
+V1 envelopes. The Step 4 code removes V1 read and mutation paths; production
+deployment and the required post-deploy re-audit remain.
 
 | Cloud | Step 1: enclave reads v1/v2 | Step 2: control plane writes v2 | Step 3: database backfill | Step-4 attestation |
 |---|---|---|---|---|
-| GCP | complete in every serving region | complete | 7 BYOK envelopes migrated; 7 v2, 0 v1 after an independent audit | **not recorded** |
-| AWS | complete in Paris and Ireland | complete on both Fargate services and both App Runner services | read-only audit returned zero rows; nothing was rewritten | **not recorded** |
-| Azure | complete in UAE North and Southeast Asia | complete | read-only audit returned zero rows; nothing was rewritten | **not recorded** |
+| GCP | complete in every serving region | complete | 7 original BYOK envelopes migrated; fresh audit now sees 11 V2 envelopes and 0 V1 | `clean`, recorded 2026-08-29 |
+| AWS | complete in Paris and Ireland | complete on both Fargate services and both App Runner services | read-only audit returned zero migrated-kind rows; independent whole-table literal census is zero | `empty_witnessed`, recorded 2026-08-29 |
+| Azure | complete in UAE North and Southeast Asia | complete | read-only audit returned zero migrated-kind rows; independent whole-table literal census is zero | `empty_witnessed`, recorded 2026-08-29 |
 
 The backfill implementation landed in quill-router#573. The standalone
 operator configuration and mandatory explicit-KMS apply gate landed in
@@ -36,8 +37,9 @@ because it is a file that a test reads: `byok-aad-v2-attestations.json`, written
 only by `scripts/check_no_v1_envelopes.py`, which pairs the audit with a census
 computed by different SQL — including one question that assumes neither the
 entity kind nor the field name the envelope is stored under — and refuses to
-call an uncorroborated empty result an attestation. It is empty today. Nobody
-has run it against a real database.
+call an uncorroborated empty result an attestation. The ledger now contains
+fresh GCP, AWS, and Azure entries; their source fields and operator notes record
+how each live database was corroborated.
 
 And the last column is read as **one row, not three**: see §4.0 point 2. The
 enclaves cross-read on control-plane failover, so a v1 envelope left in any one
@@ -49,9 +51,10 @@ database can be handed to any cloud's enclave.
 
 AES-GCM associated data binds a ciphertext to its context: an envelope sealed
 for one (workspace, provider) must fail to open in another. That guarantee holds
-only if the map from context to AAD bytes is **injective**. Ours is not.
+only if the map from context to AAD bytes is **injective**. The retired V1 map
+was not.
 
-`byok_crypto.py:189`
+The removed V1 implementation was:
 
 ```python
 def _aad(workspace_id: str, provider: str) -> bytes:
@@ -65,8 +68,8 @@ ambiguous:
 _aad("a:b", "c") == _aad("a", "b:c") == b"trustedrouter:byok:a:b:c"
 ```
 
-Worse, `encrypt_control_secret` (`byok_crypto.py:86-98`) routes its `purpose`
-into the **same namespace** through the `provider` slot:
+Worse, the old `encrypt_control_secret` routed its `purpose` into the **same
+namespace** through the `provider` slot:
 
 ```python
 def encrypt_control_secret(raw_secret, settings, *, workspace_id, purpose):
@@ -78,7 +81,7 @@ So a BYOK provider key and a control secret in one workspace can share AAD, and
 each will decrypt the other. Control-secret purposes are built by
 `broadcast_secret_context(destination_id, "api_key" | "headers")`.
 
-### What is already fixed, and what is not
+### Resolution
 
 The **reachable** path is closed. The console BYOK route used to accept any
 lowercased string up to 64 characters as a provider name, so a tenant could
@@ -86,17 +89,10 @@ register `broadcast:bdst_…:api-key` and collide deliberately. It now validates
 against the catalog exactly as the API route does (#544), and
 `tests/test_byok_aad_namespace_property.py` holds that.
 
-What remains is the **encoding**. Colon collisions need a colon inside a
-workspace id, and all three backends mint `str(uuid.uuid4())` with no
-caller-supplied id, so it is not reachable by normal issuance. It is still
-wrong, and it is the kind of wrong that becomes reachable the moment someone
-adds a customer-chosen identifier anywhere in the tuple.
-
-`test_aad_encoding_is_not_injective_in_general` asserts the collision today so
-this is not rediscovered. **That test should be deleted as part of this work** —
-in step 4, with v1 itself, and not before. `tests/test_byok_v1_removal_gate.py`
-holds those two together in both directions: while v1 envelopes are still
-readable, that test is the only standing record of why any of this exists.
+Step 4 removes the ambiguous encoder and every V1 decrypt branch. The old
+collision-preservation test was deleted with the decoder. Permanent guards now
+retain real V1-shaped fixtures only to prove that provider, control, and
+user-model decrypt entry points reject them before unwrapping a DEK.
 
 ---
 
@@ -105,8 +101,6 @@ readable, that test is the only standing record of why any of this exists.
 Three constraints, in increasing order of how much they hurt.
 
 ### 2.1 Both the ciphertext and the wrapped DEK are bound to the AAD
-
-`byok_crypto.py:59-60`
 
 ```python
 ciphertext    = AESGCM(dek).encrypt(nonce, plaintext, aad)
@@ -131,10 +125,11 @@ Both sides reject anything they do not recognise:
 
 | | file | behaviour |
 |---|---|---|
-| control plane | `byok_crypto.py:78-79` | `raise ValueError("unsupported BYOK envelope algorithm")` |
-| enclave | `byokcache/cache.go:214-215` | `return "", fmt.Errorf("unsupported envelope algorithm %q", …)` |
+| control plane | `byok_crypto._envelope_aad` | rejects every algorithm except V2 before unwrap |
+| enclave | `byokcache.envelopeAAD` and the cache entry point | reject every algorithm except V2 before lookup or unwrap |
 
-Both constants are the same literal, `TR-BYOK-ENVELOPE-AES-256-GCM-V1`.
+The stored `algorithm` field made the staged dual-read period possible without
+guessing which AAD format had sealed a row.
 
 **This is the ordering constraint.** If the control plane starts writing v2
 envelopes before the enclave can read them, every affected BYOK key stops
@@ -356,12 +351,12 @@ docstring carries the full list of what none of this establishes.
 
 ### Step 1 — enclave learns to read v2 (`quill-cloud-proxy`)
 
-Teach `byokcache` both formats, dispatching on `envelope.Algorithm`:
+This completed step taught `byokcache` both formats, dispatching on
+`envelope.Algorithm`:
 
-- add `AlgorithmV2` alongside `Algorithm` in `cache.go:21`
-- add `aadV2(namespace, workspaceID, context)` beside `aad()` at `cache.go:275`
-- in `decryptEnvelope` (`cache.go:213`), select the AAD builder from the
-  algorithm instead of rejecting anything that is not v1
+- add `AlgorithmV2` alongside the temporary V1 constant
+- add `aadV2(namespace, workspaceID, context)` beside the temporary V1 encoder
+- in `decryptEnvelope`, select the AAD builder from the stored algorithm
 - the control plane must tell the enclave which namespace a secret belongs to.
   It already sends provider identity in the authorization payload; confirm the
   field before writing the Go side, and do not infer it from the string shape.
@@ -388,13 +383,15 @@ provider key with the same context string, which is the whole point.
 
 ### Step 3 — backfill
 
-A resumable job over both surfaces:
+A resumable job over every envelope surface known at migration time:
 
 | surface | field | context |
 |---|---|---|
 | `ByokProviderConfig` | `encrypted_secret` (`storage_models.py:211`) | provider slug |
 | broadcast destination | `encrypted_api_key` (`storage_models.py:244`) | `broadcast_secret_context(destination_id, "api_key")` |
 | broadcast destination | headers secret | `broadcast_secret_context(destination_id, "headers")` |
+| user-provided model | `encrypted_endpoint_api_key` | `user_model_endpoint_key` |
+| user-provided model | `encrypted_signing_secret` | `user_model_signing` |
 
 For each v1 row: decrypt under v1 AAD, re-encrypt under v2, write back in one
 transaction, verify by decrypting the new envelope before committing.
@@ -408,16 +405,16 @@ Properties the job must have:
   something else is already wrong.
 - **rate-limited** against the KMS quota
 
-`byok_cache_key` (`byok_crypto.py:129-156`) already includes the algorithm and
-ciphertext, so re-encrypted rows get fresh cache keys automatically and stale
-enclave cache entries expire on their own. No cache flush needed.
+`byok_cache_key` includes the algorithm and ciphertext, so re-encrypted rows
+received fresh cache keys automatically and stale enclave cache entries expired
+on their own. No cache flush was needed.
 
 ### Step 4 — drop v1
 
 Only when a query proves zero v1 rows remain across every surface **and** the
-backfill has been idle for at least one full retention window. This is the one
-step with no rollback row in §5, so its precondition is executable rather than
-written down:
+backfill has been idle for at least one full retention window. The zero-V1 half
+is executable; the retention interval is operator evidence recorded in the
+ledger notes and checked during review:
 
 ```bash
 # once per standalone cloud — they are separate databases (§4.0)
@@ -440,12 +437,15 @@ recorded:
   same table with the same credentials and found rows there, and a search for
   the literal `TR-BYOK-ENVELOPE-AES-256-GCM-V1` over whole row bodies — no kind
   filter, no assumption about which field holds an envelope — found nothing.
-  That last clause is the one carrying the weight: the per-kind census and the
-  walk restrict to the same two kinds (`MIGRATED_KINDS` on both counts and on
-  the Postgres walk; the same two names hardcoded in SQL text on the Spanner
-  walk), so a renamed entity kind or a renamed body field hides rows from both
-  and they corroborate each other's silence. The literal search is a full table
-  scan and is meant to be.
+  The same whole-body search must also match a known-present JSON-object marker.
+  That positive control prevents a broken cast, operator, or parameter path
+  from making a zero V1 count look like evidence. The V1 clause carries the
+  remaining weight: the per-kind census and the
+  walk both restrict to `MIGRATED_KINDS`, so a renamed entity kind or a renamed
+  body field hides rows from both and they corroborate each other's silence.
+  The literal searches are full table scans and are meant to be. On Postgres,
+  all census facts are returned by one SQL statement because Aurora DSQL
+  rejects `SET TRANSACTION`; on Spanner they use one multi-use snapshot.
 
 An empty result with nothing behind it is `zero_scan`, a loud refusal. A scan
 that misses rows either census question can see is `scan_disagrees_with_census`.
@@ -455,8 +455,10 @@ database. A wrong-but-populated `tr_entities` is reachable, non-empty and holds
 no v1 envelope, which is what success looks like. The run records
 `census_source` — which database the census was taken from — so check it
 against the cloud the entry claims. **Read that field knowing which adapter
-produced it.** On `--backend postgres` it is the server's own answer
-(`current_database()`, `current_user`, `inet_server_addr()`). On `--backend
+produced it.** On `--backend postgres`, the database and user come from the
+server (`current_database()`, `current_user`), while host and port come from
+the negotiated connection because Aurora DSQL does not implement
+`inet_server_addr()`. On `--backend
 spanner` — i.e. the GCP invocation in the code block above — it is not: the
 client builds `projects/…/instances/…/databases/…` by concatenating the
 `--project`, `--spanner-instance` and `--spanner-database` you passed, with no
@@ -475,33 +477,25 @@ search that stops matching fails open.
 See the module docstrings in `src/trusted_router/byok_v1_attestations.py` and
 `tests/test_byok_v1_precondition.py` for the rest of the scope limits.
 
-Then, and only then:
+The 2026-08-29 fleet ledger cleared that precondition. Step 4 has now:
 
-- remove `_aad`, `ALGORITHM`, and the v1 branches from both repos
-- delete `test_aad_encoding_is_not_injective_in_general`
-- keep a v1-shaped envelope in a test fixture asserting it is now **rejected**,
+- removed `_aad`, `ALGORITHM`, and the v1 branches from both repos
+- deleted `test_aad_encoding_is_not_injective_in_general`
+- kept a v1-shaped envelope in a test fixture asserting it is now **rejected**,
   so the removal is deliberate rather than silent
 
-`tests/test_byok_v1_removal_gate.py` fails CI if a v1-shaped envelope stops
-opening while `docs/design/byok-aad-v2-attestations.json` does not attest zero
-v1 on every cloud, and prints the commands above. Note that the third bullet
-above — a fixture asserting a v1 envelope is now **rejected** — is itself an
-edit that makes every stored v1 row unopenable, so it belongs after the ledger
-is complete like the other two, not before. The gate decides by sealing a v1
-envelope the way the stored rows were sealed and asking `decrypt_byok_secret`
-and `decrypt_control_secret` to open it, rather than by reading the source for
-`_aad`/`ALGORITHM`; that catches an entry-point rejection that leaves the v1
-code physically in place, and stays quiet through refactors that keep v1
-working. It permits the removal once the ledger is complete — it sequences the
-work rather than forbidding it. It also holds that the collision record and v1
-are deleted together: removing that test earlier drops the only standing
-evidence that the v1 encoding is not injective.
-
-Two things the gate deliberately does not do. It cannot see `quill-cloud-proxy`,
-whose enclave carries its own v1 branch and its own removal decision, so
-ordering across the two repos is still a human responsibility. And it opens a
-v1 envelope wrapped by the local/test key wrapper, so a v1 regression confined
-to the KMS wrapper is out of its scope.
+`tests/test_byok_v1_removal_gate.py` now enforces the permanent post-Step-4
+state. It requires a complete, current fleet ledger; package-wide AST discovery
+refuses any unreviewed production `decrypt_*_secret` entry point; the three
+registered decryptors each receive a byte-compatible V1 fixture and require
+rejection; confines the retired V1 identifier to the read-only census;
+and verifies the ambiguous encoder and collision-preservation test did not
+survive. The control-plane gate cannot establish the enclave's behavior, so
+the Step 4 `quill-cloud-proxy` build independently generates and publishes a
+source-bound accepted-format declaration by exercising both enclave secret
+namespaces. That declaration becomes production evidence only after the enclave
+deploy below publishes it; repository state is not evidence about the live
+fleet. Deployment rolls and verifies the two repositories separately.
 
 ---
 
@@ -511,7 +505,7 @@ to the KMS wrapper is out of its scope.
 |---|---|
 | 1 | revert the enclave build. Nothing writes v2 yet, so this is free. |
 | 2 | revert the control plane. Rows written as v2 in the interim will **not** decrypt on a v1-only control plane — so keep the read side of v2 in place and revert only the write side. Plan the revert as "stop writing v2", not "remove v2". |
-| 3 | none needed; the job is non-destructive. Stop it and leave mixed v1/v2, which both planes read. |
+| 3 | stop the resumable job and leave mixed v1/v2; each successful rewrite is independently verified and both planes read both formats at this stage. |
 | 4 | do not attempt this step until you are willing not to roll it back. |
 
 Per-cloud: rolling back step 2 on one deployment does not affect what the
@@ -527,20 +521,14 @@ permanent from the moment it ships; v2 write support is the reversible part.**
 
 ---
 
-## 6. Open questions for whoever picks this up
+## 6. Decisions and remaining limits
 
-1. **Does the enclave receive the namespace, or must it infer one?** The Go side
-   needs to know whether a secret is `provider` or `control`. If the
-   authorization payload does not carry it, that field has to be added first,
-   which makes this a three-repo change rather than two. **Check this before
-   estimating.**
-2. **Are there envelopes outside the three surfaces in §3?** The list came from
-   grepping `encrypt_byok_secret` / `encrypt_control_secret` call sites in
-   `quill-router`. If another service writes envelopes, the backfill misses them
-   and they break at step 4. Still open — a grep cannot answer it. What is now
-   handled is the *second* half of the risk: the surface list lives in one place
+1. **Namespace dispatch is explicit.** Provider and user-model secrets use
+   separate enclave resolve paths; control secrets never cross the trust
+   boundary. Cross-language vectors pin the Python and Go encoders.
+2. **A registry is still not a database proof.** The surface list lives in one place
    (`byok_v1_attestations.MIGRATED_SURFACES`, from which the backfill's field map
-   is derived) and is fingerprinted into every attestation, so adding a fourth
+   is derived) and is fingerprinted into every attestation, so adding another
    surface invalidates every zero-v1 attestation taken before it existed rather
    than silently inheriting them.
 3. **Is `provider` the right context for a BYOK key**, or should it be the

--- a/scripts/backfill_byok_aad_v2.py
+++ b/scripts/backfill_byok_aad_v2.py
@@ -1,137 +1,17 @@
 #!/usr/bin/env python3
-"""Audit or backfill BYOK/control-secret envelopes from AAD v1 to v2.
-
-The default is a read-only audit. Applying requires an exact expected count,
-which prevents an operator from accidentally migrating a larger or different
-dataset than the one they reviewed.
-
-Examples:
-  uv run python scripts/backfill_byok_aad_v2.py --backend spanner
-  uv run python scripts/backfill_byok_aad_v2.py --backend spanner \
-    --apply --expected-v1 7
-  uv run python scripts/backfill_byok_aad_v2.py --backend postgres
-"""
+"""Refuse use of the retired mutating BYOK AAD migration command."""
 
 from __future__ import annotations
 
-import argparse
-import json
-import os
 import sys
-from typing import Any
-
-from trusted_router.byok_aad_backfill import (
-    BackfillRunner,
-    EntityStore,
-    PostgresEntityStore,
-    SpannerEntityStore,
-)
-from trusted_router.key_management import KeyWrapperConfig
-
-
-def _parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--backend", choices=("spanner", "postgres"), required=True)
-    parser.add_argument("--apply", action="store_true", help="Rewrite v1 envelopes to v2")
-    parser.add_argument(
-        "--expected-v1",
-        type=int,
-        help="Required with --apply; mutation is refused unless the audit count matches exactly",
-    )
-    parser.add_argument("--batch-size", type=int, default=100)
-    parser.add_argument("--kms-operations-per-second", type=float, default=5.0)
-    parser.add_argument("--after-kind")
-    parser.add_argument("--after-id")
-    parser.add_argument(
-        "--project",
-        default=os.environ.get("TR_GCP_PROJECT_ID", "quill-cloud-proxy"),
-    )
-    parser.add_argument(
-        "--spanner-instance",
-        default=os.environ.get("TR_SPANNER_INSTANCE_ID", "trusted-router-nam6"),
-    )
-    parser.add_argument(
-        "--spanner-database",
-        default=os.environ.get("TR_SPANNER_DATABASE_ID", "trusted-router"),
-    )
-    parser.add_argument("--postgres-dsn", default=os.environ.get("TR_POSTGRES_DSN", ""))
-    parser.add_argument(
-        "--kms-key-name",
-        default=os.environ.get("TR_BYOK_KMS_KEY_NAME", ""),
-        help="Wrapping KMS key; required with --apply",
-    )
-    return parser
-
-
-def _spanner_store(args: argparse.Namespace) -> EntityStore:
-    from google.cloud import spanner
-
-    client = spanner.Client(project=args.project, disable_builtin_metrics=True)
-    database = client.instance(args.spanner_instance).database(args.spanner_database)
-    return SpannerEntityStore(database, spanner.param_types)
-
-
-def _store(args: argparse.Namespace) -> EntityStore:
-    if args.backend == "spanner":
-        return _spanner_store(args)
-    return PostgresEntityStore(args.postgres_dsn)
-
-
-def _summary(label: str, stats: Any) -> None:
-    print(f"{label}={json.dumps(stats.as_dict(), sort_keys=True)}")
 
 
 def main() -> int:
-    args = _parser().parse_args()
-    if (args.after_kind is None) != (args.after_id is None):
-        raise SystemExit("--after-kind and --after-id must be supplied together")
-    if args.apply and args.expected_v1 is None:
-        raise SystemExit("--expected-v1 is required with --apply")
-    if args.expected_v1 is not None and args.expected_v1 < 0:
-        raise SystemExit("--expected-v1 cannot be negative")
-    if args.apply and not args.kms_key_name.strip():
-        raise SystemExit("--kms-key-name or TR_BYOK_KMS_KEY_NAME is required with --apply")
-    after = None
-    if args.after_kind is not None and args.after_id is not None:
-        after = (args.after_kind, args.after_id)
-
-    store = _store(args)
-    audit = BackfillRunner(store, apply=False).run(batch_size=args.batch_size, after=after)
-    _summary("preflight", audit)
-    if audit.failures or audit.unsupported_algorithms:
-        print("REFUSED: preflight found malformed or unsupported envelopes")
-        return 2
-    if not args.apply:
-        return 0
-    if audit.v1_envelopes != args.expected_v1:
-        print(
-            "REFUSED: expected-v1 gate did not match "
-            f"expected={args.expected_v1} actual={audit.v1_envelopes}"
-        )
-        return 2
-    if audit.v1_envelopes == 0:
-        print("nothing to migrate")
-        return 0
-
-    migrated = BackfillRunner(
-        store,
-        settings=KeyWrapperConfig(byok_kms_key_name=args.kms_key_name.strip()),
-        apply=True,
-        kms_operations_per_second=args.kms_operations_per_second,
-    ).run(batch_size=args.batch_size, after=after)
-    _summary("migration", migrated)
-
-    verification = BackfillRunner(store, apply=False).run(batch_size=args.batch_size)
-    _summary("verification", verification)
-    if (
-        verification.v1_envelopes
-        or verification.failures
-        or verification.unsupported_algorithms
-    ):
-        print("FAILED: post-write audit is not clean")
-        return 3
-    print("complete: every discovered envelope is v2")
-    return 0
+    print(
+        "RETIRED: the AAD v1 backfill was removed after Step 4. "
+        "Use scripts/check_no_v1_envelopes.py for the fail-closed read-only audit."
+    )
+    return 2
 
 
 if __name__ == "__main__":

--- a/scripts/check_format_ordering.py
+++ b/scripts/check_format_ordering.py
@@ -378,9 +378,6 @@ _REHYDRATION_MODULES = frozenset(
         # ByokProviderConfig / BroadcastDestination.__post_init__, rebuilding a
         # stored dict into the dataclass.
         "src/trusted_router/storage_models.py",
-        # The v1 -> v2 backfill, reading an envelope out of a row before
-        # decrypting it. What it WRITES it writes through byok_crypto.
-        "src/trusted_router/byok_aad_backfill.py",
     }
 )
 

--- a/src/trusted_router/byok_aad_backfill.py
+++ b/src/trusted_router/byok_aad_backfill.py
@@ -1,38 +1,20 @@
-"""Resumable BYOK envelope AAD v1-to-v2 backfill primitives.
+"""Read-only scanner for the completed BYOK AAD v1-to-v2 migration.
 
-The migration touches secret-bearing rows, so the storage adapters expose only
-the generic entity body and an optimistic compare-and-swap. KMS work happens
-outside database transactions; the final write succeeds only when the row is
-still byte-for-byte (Spanner) or JSON-equivalent (Postgres) to the version that
-was decrypted. A concurrent key rotation therefore wins and is never
-overwritten by the backfill.
-
-The non-apply audit mode of `BackfillRunner` is also the measurement half of
-the step-4 precondition: `check_no_v1_envelopes` below wraps it with the one
-thing an audit cannot tell you about itself — whether it looked at anything.
-See `trusted_router.byok_v1_attestations` for the law and the ledger.
+The mutating backfill retired with Step 4. This module intentionally retains
+only the database census and envelope classifier used to prove that no V1 row
+survived. It has no decrypt path, KMS dependency, or database write method.
+See `trusted_router.byok_v1_attestations` for the law and the audit ledger.
 """
 
 from __future__ import annotations
 
-import copy
 import hashlib
 import json
-import time
 from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from typing import Any, Protocol
 
-from trusted_router.byok_crypto import (
-    ALGORITHM,
-    ALGORITHM_V2,
-    decrypt_byok_secret,
-    decrypt_control_secret,
-    decrypt_user_model_secret,
-    encrypt_byok_secret,
-    encrypt_control_secret,
-    encrypt_user_model_secret,
-)
+from trusted_router.byok_crypto import ALGORITHM_V2
 from trusted_router.byok_v1_attestations import (
     MIGRATED_KINDS,
     MIGRATED_SURFACES,
@@ -48,12 +30,8 @@ from trusted_router.byok_v1_attestations import (
     surface_fingerprint,
     utc_now,
 )
-from trusted_router.key_management import KeyWrapperSettings
-from trusted_router.services.user_model_secrets import (
-    USER_MODEL_ENDPOINT_KEY_PURPOSE,
-    USER_MODEL_SIGNING_PURPOSE,
-)
-from trusted_router.storage_models import EncryptedSecretEnvelope
+
+CENSUS_POSITIVE_LITERAL = "{"
 
 
 @dataclass(frozen=True)
@@ -61,7 +39,6 @@ class EntityRow:
     kind: str
     entity_id: str
     body: dict[str, Any]
-    original_body: Any
 
 
 @dataclass(frozen=True)
@@ -76,10 +53,10 @@ class EntityCensus:
     from "the audit could not have found anything".
 
     `v1_literal_rows` is the one that does not share the scan's assumptions.
-    The count and the walk restrict to the same two kinds — both from
+    The count and the walk restrict to the same registered kinds — all from
     `MIGRATED_KINDS`, on both adapters, since `SpannerEntityStore.scan` now
     binds `@kinds` the way its own census already did rather than writing the
-    two names out as SQL text — and the walk reads
+    names out as SQL text — and the walk reads
     envelopes only out of the field names in `MIGRATED_SURFACES`. So a renamed
     entity kind or a renamed body field hides the same rows from the walk AND
     from the count, and the disagreement they exist to expose never happens.
@@ -99,9 +76,11 @@ class EntityCensus:
     happens to store, and a pattern that stops matching fails OPEN.
 
     `source` names the database the census was taken from, and the two adapters
-    know it to different depths. Postgres asks the server — `current_database()`,
-    `current_user`, `inet_server_addr()` — so its value is the server's own
-    answer. Spanner composes `projects/…/instances/…/databases/…` client-side
+    know it to different depths. Postgres asks the server for
+    `current_database()` and `current_user`, then reads the negotiated host and
+    port from the connection object (Aurora DSQL does not implement
+    `inet_server_addr()`). Spanner composes
+    `projects/…/instances/…/databases/…` client-side
     from the arguments the CLI was given: `Database.name` is string
     concatenation in `google.cloud.spanner` and issues no RPC, so that value
     records what was ASKED FOR, not what answered, and reads identically against
@@ -114,6 +93,7 @@ class EntityCensus:
     migrated_kind_counts: dict[str, int]
     sampled_kinds: tuple[str, ...]
     v1_literal_rows: int
+    positive_control_rows: int
     source: str
 
     @property
@@ -134,9 +114,6 @@ class EntityStore(Protocol):
         limit: int,
     ) -> list[EntityRow]: ...
 
-    def compare_and_swap(self, row: EntityRow, new_body: dict[str, Any]) -> bool: ...
-
-
 class CensusStore(Protocol):
     def census(self, *, sample_limit: int = 1000) -> EntityCensus: ...
 
@@ -152,9 +129,6 @@ class BackfillStats:
     v1_envelopes: int = 0
     v2_envelopes: int = 0
     missing_envelopes: int = 0
-    rows_updated: int = 0
-    envelopes_migrated: int = 0
-    conflicts: int = 0
     failures: int = 0
     unsupported_algorithms: int = 0
     # Per-kind scan counts. A single total cannot be cross-checked against a
@@ -171,58 +145,21 @@ class BackfillStats:
         return asdict(self)
 
 
-class KmsOperationRateLimiter:
-    """Bound the average KMS operation rate without introducing concurrency."""
-
-    def __init__(
-        self,
-        operations_per_second: float,
-        *,
-        monotonic: Callable[[], float] = time.monotonic,
-        sleep: Callable[[float], None] = time.sleep,
-    ) -> None:
-        if operations_per_second <= 0:
-            raise ValueError("KMS operations per second must be positive")
-        self._operations_per_second = operations_per_second
-        self._monotonic = monotonic
-        self._sleep = sleep
-        self._next_operation_at = 0.0
-
-    def acquire(self, operations: int) -> None:
-        if operations <= 0:
-            return
-        now = self._monotonic()
-        start = max(now, self._next_operation_at)
-        if start > now:
-            self._sleep(start - now)
-        self._next_operation_at = start + operations / self._operations_per_second
-
-
 class BackfillRunner:
-    """Audit or migrate every known encrypted field in stable key order."""
+    """Read every registered encrypted field in stable key order.
+
+    The historical name is retained for operator-script compatibility. Step 4
+    removed every V1 decryptor, so this class can only classify stored formats.
+    """
 
     def __init__(
         self,
         store: EntityStore,
         *,
-        settings: KeyWrapperSettings | None = None,
-        apply: bool = False,
-        kms_operations_per_second: float = 5.0,
         reporter: Callable[[str], None] = print,
-        monotonic: Callable[[], float] = time.monotonic,
-        sleep: Callable[[float], None] = time.sleep,
     ) -> None:
-        if apply and settings is None:
-            raise ValueError("settings are required when applying the backfill")
         self._store = store
-        self._settings = settings
-        self._apply = apply
         self._report = reporter
-        self._limiter = KmsOperationRateLimiter(
-            kms_operations_per_second,
-            monotonic=monotonic,
-            sleep=sleep,
-        )
 
     def run(
         self,
@@ -251,11 +188,8 @@ class BackfillRunner:
     def _process_row(self, row: EntityRow, stats: BackfillStats) -> None:
         stats.rows_scanned += 1
         stats.rows_scanned_by_kind[row.kind] = stats.rows_scanned_by_kind.get(row.kind, 0) + 1
-        new_body = copy.deepcopy(row.body)
-        migrations = 0
-        row_failed = False
         row_v1 = 0
-        for field_name, envelope_family in _fields_for_kind(row.kind):
+        for field_name, _envelope_family in _fields_for_kind(row.kind):
             raw_envelope = row.body.get(field_name)
             if raw_envelope is None:
                 stats.missing_envelopes += 1
@@ -263,130 +197,21 @@ class BackfillRunner:
             stats.envelopes_seen += 1
             if not isinstance(raw_envelope, dict):
                 stats.failures += 1
-                row_failed = True
                 self._error(row, field_name, "invalid_envelope_shape")
                 continue
             algorithm = raw_envelope.get("algorithm")
             if algorithm == ALGORITHM_V2:
                 stats.v2_envelopes += 1
                 continue
-            if algorithm != ALGORITHM:
+            if algorithm != V1_ALGORITHM_LITERAL:
                 stats.unsupported_algorithms += 1
-                row_failed = True
                 self._error(row, field_name, "unsupported_algorithm")
                 continue
             stats.v1_envelopes += 1
             row_v1 += 1
-            if not self._apply:
-                continue
-            try:
-                # One v1 unwrap, one v2 wrap, and one v2 verification unwrap.
-                self._limiter.acquire(3)
-                new_body[field_name] = self._migrate_envelope(
-                    row,
-                    field=field_name,
-                    envelope_family=envelope_family,
-                    raw_envelope=raw_envelope,
-                )
-                migrations += 1
-            except Exception as exc:  # fail closed; never expose secret material
-                stats.failures += 1
-                row_failed = True
-                self._error(row, field_name, type(exc).__name__)
 
         if row_v1:
             stats.rows_with_v1 += 1
-
-        if not self._apply or row_failed or migrations == 0:
-            return
-        if self._store.compare_and_swap(row, new_body):
-            stats.rows_updated += 1
-            stats.envelopes_migrated += migrations
-            return
-        stats.conflicts += 1
-        self._error(row, "*", "concurrent_change")
-
-    def _migrate_envelope(
-        self,
-        row: EntityRow,
-        *,
-        field: str,
-        envelope_family: str,
-        raw_envelope: dict[str, Any],
-    ) -> dict[str, str]:
-        assert self._settings is not None
-        workspace_id = _required_string(
-            row.body,
-            "owner_workspace_id" if row.kind == "user_provided_model" else "workspace_id",
-        )
-        envelope = EncryptedSecretEnvelope(**raw_envelope)
-        if envelope_family == "provider":
-            provider = _required_string(row.body, "provider")
-            plaintext = decrypt_byok_secret(
-                envelope,
-                self._settings,
-                workspace_id=workspace_id,
-                provider=provider,
-            )
-            migrated = encrypt_byok_secret(
-                plaintext,
-                self._settings,
-                workspace_id=workspace_id,
-                provider=provider,
-            )
-            verified = decrypt_byok_secret(
-                migrated,
-                self._settings,
-                workspace_id=workspace_id,
-                provider=provider,
-            )
-        elif envelope_family == "user_model":
-            purpose = _broadcast_context(row.entity_id, field)
-            # A v1 envelope has no namespace: its AAD is the same bytes for
-            # every family, so the control opener reads it. Re-seal under the
-            # user_model namespace and verify with the strict (v2-only) opener
-            # the application uses.
-            plaintext = decrypt_control_secret(
-                envelope,
-                self._settings,
-                workspace_id=workspace_id,
-                purpose=purpose,
-            )
-            migrated = encrypt_user_model_secret(
-                plaintext,
-                self._settings,
-                workspace_id=workspace_id,
-                purpose=purpose,
-            )
-            verified = decrypt_user_model_secret(
-                migrated,
-                self._settings,
-                workspace_id=workspace_id,
-                purpose=purpose,
-            )
-        else:
-            purpose = _broadcast_context(row.entity_id, field)
-            plaintext = decrypt_control_secret(
-                envelope,
-                self._settings,
-                workspace_id=workspace_id,
-                purpose=purpose,
-            )
-            migrated = encrypt_control_secret(
-                plaintext,
-                self._settings,
-                workspace_id=workspace_id,
-                purpose=purpose,
-            )
-            verified = decrypt_control_secret(
-                migrated,
-                self._settings,
-                workspace_id=workspace_id,
-                purpose=purpose,
-            )
-        if verified != plaintext or migrated.algorithm != ALGORITHM_V2:
-            raise ValueError("v2 verification failed")
-        return asdict(migrated)
 
     def _error(self, row: EntityRow, field: str, reason: str) -> None:
         self._report(
@@ -435,7 +260,6 @@ class SpannerEntityStore:
                     kind=kind,
                     entity_id=entity_id,
                     body=json.loads(body),
-                    original_body=body,
                 )
                 for kind, entity_id, body in rows
             ]
@@ -464,7 +288,10 @@ class SpannerEntityStore:
         """
         counts: dict[str, int] = {}
         sampled: set[str] = set()
-        with self._database.snapshot() as snapshot:
+        # This method deliberately executes three queries against one
+        # consistent read-only view. Spanner snapshots are single-use unless
+        # requested otherwise, so the default fails on the second query.
+        with self._database.snapshot(multi_use=True) as snapshot:
             rows = snapshot.execute_sql(
                 "SELECT kind, COUNT(*) FROM tr_entities WHERE kind IN UNNEST(@kinds) GROUP BY kind",
                 params={"kinds": list(MIGRATED_KINDS)},
@@ -494,42 +321,26 @@ class SpannerEntityStore:
                 literal_rows = int(count)
             if literal_rows is None:
                 raise ValueError("the v1 literal count returned no row")
+            positive_rows: int | None = None
+            for (count,) in snapshot.execute_sql(
+                "SELECT COUNT(*) FROM tr_entities WHERE STRPOS(body, @literal) > 0",
+                params={"literal": CENSUS_POSITIVE_LITERAL},
+                param_types={"literal": self._param_types.STRING},
+            ):
+                positive_rows = int(count)
+            if positive_rows is None:
+                raise ValueError("the literal-search positive control returned no row")
         return EntityCensus(
             migrated_kind_counts=counts,
             sampled_kinds=tuple(sorted(sampled)),
             v1_literal_rows=literal_rows,
+            positive_control_rows=positive_rows,
             # Spelled out because it is not what it looks like: `Database.name`
             # is built by concatenating the project, instance and database the
             # CLI was told to use, with no RPC. This says which database was
             # addressed, not which one answered.
             source=f"spanner:{self._database.name} (from CLI arguments, not asked of the server)",
         )
-
-    def compare_and_swap(self, row: EntityRow, new_body: dict[str, Any]) -> bool:
-        new_body_json = _json_body(new_body)
-
-        def update(transaction: Any) -> bool:
-            changed = transaction.execute_update(
-                "UPDATE tr_entities SET body=@new_body, "
-                "updated_at=PENDING_COMMIT_TIMESTAMP() "
-                "WHERE kind=@kind AND id=@id AND body=@old_body",
-                params={
-                    "new_body": new_body_json,
-                    "kind": row.kind,
-                    "id": row.entity_id,
-                    "old_body": row.original_body,
-                },
-                param_types={
-                    "new_body": self._param_types.STRING,
-                    "kind": self._param_types.STRING,
-                    "id": self._param_types.STRING,
-                    "old_body": self._param_types.STRING,
-                },
-            )
-            return changed == 1
-
-        return bool(self._database.run_in_transaction(update))
-
 
 class PostgresEntityStore:
     def __init__(self, dsn: str) -> None:
@@ -568,7 +379,6 @@ class PostgresEntityStore:
                     kind=kind,
                     entity_id=entity_id,
                     body=body,
-                    original_body=copy.deepcopy(body),
                 )
             )
         return result
@@ -584,56 +394,78 @@ class PostgresEntityStore:
         import psycopg
 
         with psycopg.connect(self._dsn) as conn:
-            counted = conn.execute(
-                "SELECT kind, COUNT(*) FROM tr_entities WHERE kind = ANY(%s) GROUP BY kind",
-                (list(MIGRATED_KINDS),),
+            # All census facts come from one SQL statement and therefore one
+            # database snapshot. Aurora DSQL rejects SET TRANSACTION outright,
+            # so relying on a repeatable-read GUC makes the very cloud this
+            # precondition protects unauditable. Keeping the three questions in
+            # one UNION is both stronger than separate READ COMMITTED queries
+            # and portable across PostgreSQL, Azure Flexible Server, and DSQL.
+            facts = conn.execute(
+                "WITH sampled AS ("
+                "  SELECT DISTINCT kind FROM ("
+                "    SELECT kind FROM tr_entities LIMIT %s"
+                "  ) AS peek"
+                ") "
+                "SELECT 'count' AS metric, kind, COUNT(*) AS value "
+                "FROM tr_entities WHERE kind = ANY(%s) GROUP BY kind "
+                "UNION ALL "
+                "SELECT 'sample' AS metric, kind, 0 AS value FROM sampled "
+                "UNION ALL "
+                "SELECT 'v1_literal' AS metric, '' AS kind, COUNT(*) AS value "
+                "FROM tr_entities WHERE body::text LIKE %s "
+                "UNION ALL "
+                "SELECT 'positive_control' AS metric, '' AS kind, COUNT(*) AS value "
+                "FROM tr_entities WHERE body::text LIKE %s",
+                (
+                    sample_limit,
+                    list(MIGRATED_KINDS),
+                    f"%{V1_ALGORITHM_LITERAL}%",
+                    f"%{CENSUS_POSITIVE_LITERAL}%",
+                ),
             ).fetchall()
-            sampled = conn.execute(
-                "SELECT DISTINCT kind FROM (SELECT kind FROM tr_entities LIMIT %s) AS peek",
-                (sample_limit,),
-            ).fetchall()
-            # A missing row from either aggregate raises rather than defaulting
-            # to zero: "the server told me nothing" must never become "there is
-            # nothing", which is the confusion this whole module exists for.
-            literal_row = conn.execute(
-                "SELECT COUNT(*) FROM tr_entities WHERE body::text LIKE %s",
-                (f"%{V1_ALGORITHM_LITERAL}%",),
-            ).fetchone()
-            if literal_row is None:
+            counts: dict[str, int] = {}
+            sampled: set[str] = set()
+            literal_rows: int | None = None
+            positive_rows: int | None = None
+            for metric, kind, value in facts:
+                if metric == "count":
+                    counts[str(kind)] = int(value)
+                elif metric == "sample":
+                    sampled.add(str(kind))
+                elif metric == "v1_literal":
+                    if literal_rows is not None:
+                        raise ValueError("the v1 literal count returned more than one row")
+                    literal_rows = int(value)
+                elif metric == "positive_control":
+                    if positive_rows is not None:
+                        raise ValueError("the literal-search positive control returned more than one row")
+                    positive_rows = int(value)
+                else:
+                    raise ValueError(f"the census returned an unknown metric: {metric!r}")
+            # A missing aggregate raises rather than defaulting to zero: "the
+            # server told me nothing" must never become "there is nothing".
+            if literal_rows is None:
                 raise ValueError("the v1 literal count returned no row")
-            source_row = conn.execute(
-                "SELECT current_database(), current_user, "
-                "coalesce(host(inet_server_addr()), 'local'), inet_server_port()"
-            ).fetchone()
+            if positive_rows is None:
+                raise ValueError("the literal-search positive control returned no row")
+            source_row = conn.execute("SELECT current_database(), current_user").fetchone()
             if source_row is None:
                 raise ValueError("the database could not identify itself")
-        (literal_rows,) = literal_row
-        database, user, host, port = source_row
+            host = str(conn.info.host or "unknown")
+            port = int(conn.info.port or 0)
+        database, user = source_row
         return EntityCensus(
-            migrated_kind_counts={kind: int(count) for kind, count in counted},
-            sampled_kinds=tuple(sorted(kind for (kind,) in sampled)),
-            v1_literal_rows=int(literal_rows),
+            migrated_kind_counts=counts,
+            sampled_kinds=tuple(sorted(sampled)),
+            v1_literal_rows=literal_rows,
+            positive_control_rows=positive_rows,
             # Asked of the server rather than parsed out of the DSN, and the
             # DSN never appears here: it carries the password.
-            source=f"postgres:{database}@{host}:{port} as {user}",
+            source=(
+                f"postgres:{database}@{host}:{port} as {user} "
+                "(database/user from server; host/port from negotiated connection)"
+            ),
         )
-
-    def compare_and_swap(self, row: EntityRow, new_body: dict[str, Any]) -> bool:
-        import psycopg
-
-        with psycopg.connect(self._dsn) as conn:
-            changed = conn.execute(
-                "UPDATE tr_entities SET body=%s::jsonb, updated_at=CURRENT_TIMESTAMP "
-                "WHERE kind=%s AND id=%s AND body=%s::jsonb",
-                (
-                    _json_body(new_body),
-                    row.kind,
-                    row.entity_id,
-                    _json_body(row.original_body),
-                ),
-            ).rowcount
-        return changed == 1
-
 
 def _fields_for_kind(kind: str) -> tuple[tuple[str, str], ...]:
     """Derived from MIGRATED_SURFACES so the surface list has exactly one home.
@@ -653,31 +485,8 @@ def _fields_for_kind(kind: str) -> tuple[tuple[str, str], ...]:
     return fields
 
 
-def _broadcast_context(destination_id: str, field: str) -> str:
-    if field == "encrypted_endpoint_api_key":
-        return USER_MODEL_ENDPOINT_KEY_PURPOSE
-    if field == "encrypted_signing_secret":
-        return USER_MODEL_SIGNING_PURPOSE
-    suffix = {"encrypted_api_key": "api_key", "encrypted_headers": "headers"}[field]
-    # Byte-identical to services.broadcast.broadcast_secret_context. Keeping
-    # this tiny helper here avoids importing the application-global STORE into
-    # an offline secret migration process.
-    return f"broadcast:{destination_id}:{suffix}"
-
-
-def _required_string(body: dict[str, Any], field: str) -> str:
-    value = body.get(field)
-    if not isinstance(value, str) or not value:
-        raise ValueError(f"missing {field}")
-    return value
-
-
 def _row_ref(kind: str, entity_id: str) -> str:
     return hashlib.sha256(f"{kind}\x00{entity_id}".encode()).hexdigest()[:12]
-
-
-def _json_body(value: Any) -> str:
-    return json.dumps(value, separators=(",", ":"), sort_keys=True)
 
 
 # ------------------------------------------------- the step-4 precondition ---
@@ -707,6 +516,7 @@ class PreconditionResult:
                 "migrated_kind_counts": dict(sorted(self.census.migrated_kind_counts.items())),
                 "sampled_kinds": list(self.census.sampled_kinds),
                 "v1_literal_rows": self.census.v1_literal_rows,
+                "positive_control_rows": self.census.positive_control_rows,
                 "source": self.census.source,
             },
         }
@@ -722,7 +532,7 @@ def check_no_v1_envelopes(
 ) -> PreconditionResult:
     """Audit one cloud's database and say whether it attests zero v1 envelopes.
 
-    The audit alone cannot do this. `BackfillRunner(apply=False)` reports
+    The audit alone cannot do this. `BackfillRunner` reports
     `v1_envelopes == 0` just as happily for a migrated database as for a run
     that scanned nothing at all. Both render as a green check, and on AWS and
     Azure a green check is exactly what a zero-row audit produced. So this
@@ -737,10 +547,9 @@ def check_no_v1_envelopes(
           here. The per-kind counts cannot catch either: the count and the walk
           restrict to the same two kind names, so a renamed kind is hidden from
           both, and neither reads a field name the surface map does not list.
-          (The count takes those names from `MIGRATED_KINDS` on both adapters;
-          the walk takes them from `MIGRATED_KINDS` on Postgres and from
-          hardcoded SQL text on Spanner. Identical today, and a divergence
-          would show up as an undercount, which is a refusal.) An earlier
+          (The count and walk both take those names from `MIGRATED_KINDS` on
+          both adapters; a divergence would show up as an undercount, which is
+          a refusal.) An earlier
           revision of this docstring claimed the per-kind census covered a
           renamed kind. It did not, and a live v1 envelope under a renamed
           field passed as `empty_witnessed`.
@@ -772,7 +581,35 @@ def check_no_v1_envelopes(
     have covered the beginning. This walks the whole table or reports nothing.
     """
     census = store.census(sample_limit=sample_limit)
-    stats = BackfillRunner(store, apply=False, reporter=reporter).run(batch_size=batch_size)
+    stats = BackfillRunner(store, reporter=reporter).run(batch_size=batch_size)
+
+    if not census.reachable:
+        return PreconditionResult(
+            cloud=cloud,
+            outcome=OUTCOME_ZERO_SCAN,
+            detail=(
+                "the independent whole-table census found no rows of any kind. Even if the "
+                "paged migrated-kind walk returned envelopes, there is no independent witness "
+                "that the census could have found a retired format. This is zero evidence, not "
+                "an attestation."
+            ),
+            stats=stats,
+            census=census,
+        )
+
+    if census.positive_control_rows <= 0:
+        return PreconditionResult(
+            cloud=cloud,
+            outcome=OUTCOME_SCAN_DISAGREES,
+            detail=(
+                "the census reached populated rows, but its whole-body literal-search positive "
+                "control matched none. A zero V1-literal count is not evidence until the same "
+                "column, cast, operator, and parameter path demonstrates that it can match a "
+                "known JSON-object marker."
+            ),
+            stats=stats,
+            census=census,
+        )
 
     undercounted = {
         kind: (counted, stats.rows_scanned_by_kind.get(kind, 0))
@@ -831,21 +668,9 @@ def check_no_v1_envelopes(
             cloud=cloud,
             outcome=OUTCOME_V1_REMAINS,
             detail=(
-                f"{stats.v1_envelopes} v1 envelopes are still stored. Run the backfill "
-                "(scripts/backfill_byok_aad_v2.py --apply) before attempting step 4."
-            ),
-            stats=stats,
-            census=census,
-        )
-    if stats.envelopes_seen == 0 and not census.reachable:
-        return PreconditionResult(
-            cloud=cloud,
-            outcome=OUTCOME_ZERO_SCAN,
-            detail=(
-                "the audit saw no envelopes AND the census found no rows of any kind, so "
-                "nothing distinguishes a migrated deployment from a broken query, a wrong "
-                "database, or a credential that can read nothing. This is not zero v1 "
-                "envelopes; it is zero evidence."
+                f"{stats.v1_envelopes} v1 envelopes are still stored. V1 decrypt support "
+                "has been retired; stop the rollout and use reviewed pre-Step-4 recovery code "
+                "rather than attempting to overwrite these rows."
             ),
             stats=stats,
             census=census,
@@ -923,6 +748,7 @@ def attestation_for(
         census_migrated_kind_counts=dict(result.census.migrated_kind_counts),
         census_sampled_kinds=list(result.census.sampled_kinds),
         census_v1_literal_rows=result.census.v1_literal_rows,
+        census_positive_control_rows=result.census.positive_control_rows,
         census_source=result.census.source,
         operator=operator,
         note=note,

--- a/src/trusted_router/byok_crypto.py
+++ b/src/trusted_router/byok_crypto.py
@@ -11,16 +11,9 @@ from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from trusted_router.key_management import KeyWrapperSettings, key_wrapper_for
 from trusted_router.storage_models import EncryptedSecretEnvelope
 
-# v1 associated data is colon-joined with no escaping or length prefix, so
-# component boundaries are ambiguous: _aad("a:b", "c") == _aad("a", "b:c").
-# Kept because envelopes written before the migration are still v1 and must
-# keep decrypting. See docs/design/byok-aad-v2-migration.md.
-ALGORITHM = "TR-BYOK-ENVELOPE-AES-256-GCM-V1"
-
 # v2 length-prefixes every AAD component and adds a namespace, making the
-# encoding injective. Written only because every enclave region can already
-# read it (quill-cloud-proxy#162 shipped first) — writing v2 before that would
-# break BYOK for every customer using it.
+# encoding injective. V1 read support was removed only after every standalone
+# cloud attested that no V1 envelope remained.
 ALGORITHM_V2 = "TR-BYOK-ENVELOPE-AES-256-GCM-V2"
 
 # The two secret families. A purpose can no longer collide with a provider slug
@@ -147,15 +140,8 @@ def decrypt_control_secret(
     workspace_id: str,
     purpose: str,
 ) -> str:
-    """Decrypt a control-plane secret.
-
-    A v1 envelope predates the namespace split, so it is opened with the v1 AAD
-    that sealed it — which is the same shape a BYOK key used. That collision is
-    exactly what the backfill (step 3) removes; until then v1 rows keep working
-    as they always did.
-    """
-    namespace = NAMESPACE_CONTROL if envelope.algorithm == ALGORITHM_V2 else NAMESPACE_PROVIDER
-    aad = _envelope_aad(envelope.algorithm, namespace, workspace_id, purpose)
+    """Decrypt a namespace-bound control-plane secret."""
+    aad = _envelope_aad(envelope.algorithm, NAMESPACE_CONTROL, workspace_id, purpose)
     dek = _unwrap_dek(envelope, aad, settings)
     plaintext = AESGCM(dek).decrypt(_unb64(envelope.nonce), _unb64(envelope.ciphertext), aad)
     return plaintext.decode("utf-8")
@@ -214,6 +200,8 @@ def decrypt_user_model_secret(
 def encrypted_secret_payload(envelope: EncryptedSecretEnvelope | None) -> dict[str, str] | None:
     if envelope is None:
         return None
+    if envelope.algorithm != ALGORITHM_V2:
+        raise ValueError("unsupported encrypted secret envelope algorithm")
     return {
         "algorithm": envelope.algorithm,
         "key_ref": envelope.key_ref,
@@ -235,6 +223,11 @@ def byok_cache_key(
     Gateways use this to cache decrypted BYOK material briefly in enclave
     memory. A raw-key rotation creates a new ciphertext/DEK, therefore a new
     cache key; deleting BYOK stops returning an envelope at authorization time.
+
+    The ``v1`` marker below versions this cache-key serialization, not the
+    encrypted-envelope format. It remains stable across the V1 envelope
+    retirement so rolling enclave updates preserve cache identity for a V2
+    envelope.
     """
     if envelope is None:
         return None
@@ -289,11 +282,6 @@ def _key_ref(settings: KeyWrapperSettings) -> str:
     return key_wrapper_for(settings).key_ref
 
 
-def _aad(workspace_id: str, provider: str) -> bytes:
-    """v1 associated data. Not injective — see the module header."""
-    return f"trustedrouter:byok:{workspace_id}:{provider}".encode()
-
-
 def _aad_v2(namespace: str, workspace_id: str, context: str) -> bytes:
     """v2 associated data: length-prefixed, so it is injective.
 
@@ -318,17 +306,10 @@ def _aad_v2(namespace: str, workspace_id: str, context: str) -> bytes:
 def _envelope_aad(
     algorithm: str, namespace: str, workspace_id: str, context: str
 ) -> bytes:
-    """Select the associated data for an envelope's declared format.
-
-    Dispatching on the stored algorithm rather than trying v2 and falling back
-    to v1: a permanent fallback would keep the substitution weakness alive and
-    make the migration impossible to declare finished.
-    """
-    if algorithm == ALGORITHM:
-        return _aad(workspace_id, context)
-    if algorithm == ALGORITHM_V2:
-        return _aad_v2(namespace, workspace_id, context)
-    raise ValueError("unsupported BYOK envelope algorithm")
+    """Reject every retired or unknown format before any unwrap operation."""
+    if algorithm != ALGORITHM_V2:
+        raise ValueError("unsupported BYOK envelope algorithm")
+    return _aad_v2(namespace, workspace_id, context)
 
 
 def _b64(value: bytes) -> str:

--- a/src/trusted_router/byok_v1_attestations.py
+++ b/src/trusted_router/byok_v1_attestations.py
@@ -47,12 +47,12 @@ WHY EVERY CLOUD, AND NOT EACH CLOUD ON ITS OWN
 WHY THIS EXISTS AS A LEDGER AND NOT AS A SENTENCE
     Until now the only artifact standing between an engineer and permanently
     unreadable customer BYOK keys was a table cell in a markdown file. Step 4
-    is the one irreversible step in the plan: once `_aad`/`ALGORITHM` are gone
-    from the control plane and the enclave, a surviving v1 row is not a bug
-    that can be rolled back — the plaintext provider key is gone, because the
-    AAD that seals both the ciphertext and the wrapped DEK cannot be
-    reconstructed from a format nobody implements any more. A markdown claim is
-    not a precondition. A file that a test reads is.
+    is the one intentionally one-way production step in the plan: once
+    `_aad`/`ALGORITHM` are gone from the control plane and enclave, a V1 row
+    cannot be opened by the running fleet. Recovery would require an isolated
+    rollback to reviewed pre-Step-4 code (or equivalent dedicated recovery
+    tooling) with KMS access. A markdown claim is not a precondition. A file
+    that a test reads is.
 
 THE NEAR-MISS THIS ENCODES
     As of 2026-08-15 the migration doc renders step 3 as a green check on all
@@ -104,9 +104,10 @@ SCOPE LIMIT — what a full ledger does NOT establish
       than invisible. Compare it against the cloud the entry claims.
 
       Read that field knowing how each adapter obtains it, because they are
-      not equally strong. `PostgresEntityStore` asks the server
-      (`current_database()`, `current_user`, `inet_server_addr()`), so its
-      value is the server's own answer. `SpannerEntityStore` does not: it
+      not equally strong. `PostgresEntityStore` asks the server for
+      `current_database()` and `current_user`, then obtains host and port from
+      the negotiated connection (Aurora DSQL does not implement
+      `inet_server_addr()`). `SpannerEntityStore` does not: it
       composes the name client-side out of the `--project`,
       `--spanner-instance` and `--spanner-database` the CLI was given —
       `Database.name` is `Instance.name + "/databases/" + database_id` and
@@ -242,14 +243,15 @@ MIGRATED_KINDS: tuple[str, ...] = tuple(
 #: The census below searches row bodies for this string, and it has to keep
 #: working in the tree where step 4 has deleted that constant — a precondition
 #: that stops being expressible the moment someone starts the edit it guards is
-#: not a precondition. `tests/test_byok_v1_precondition.py` asserts the two are
-#: equal while both exist.
+#: not a precondition. Post-Step-4 tests keep this literal confined to the
+#: read-only census and explicit rejection fixtures.
 V1_ALGORITHM_LITERAL = "TR-BYOK-ENVELOPE-AES-256-GCM-V1"
 
-#: v2: `census_v1_literal_rows` and `census_source` became required, because a
-#: v1 attestation could be earned without either. Entries written under v1 are
-#: not upgradable — the runs behind them never asked those questions.
-SCHEMA = "trustedrouter/byok-aad-v1-zero-attestation/v2"
+#: v3: `census_positive_control_rows` became required so a zero literal count
+#: cannot pass until the same whole-body search path demonstrates that it can
+#: match a known-present JSON-object marker. Older runs never asked that
+#: question and are deliberately not upgradable by changing the schema string.
+SCHEMA = "trustedrouter/byok-aad-v1-zero-attestation/v3"
 
 OUTCOME_CLEAN = "clean"
 OUTCOME_EMPTY_WITNESSED = "empty_witnessed"
@@ -319,6 +321,9 @@ class Attestation:
     #: found without a kind filter and without assuming a body field name. The
     #: one count in here that is not downstream of `MIGRATED_SURFACES`.
     census_v1_literal_rows: int
+    #: Rows matched by the same whole-body literal-search path using a
+    #: known-present JSON-object marker. Must be positive for any passing run.
+    census_positive_control_rows: int
     #: Which database the census was taken from: the server's own answer on
     #: Postgres, the database the CLI was pointed at on Spanner (the string
     #: says which). Not proof of the right deployment; the thing a reviewer
@@ -343,6 +348,7 @@ class Attestation:
             "census_migrated_kind_counts": dict(sorted(self.census_migrated_kind_counts.items())),
             "census_sampled_kinds": sorted(self.census_sampled_kinds),
             "census_v1_literal_rows": self.census_v1_literal_rows,
+            "census_positive_control_rows": self.census_positive_control_rows,
             "census_source": self.census_source,
             "operator": self.operator,
             "note": self.note,
@@ -364,6 +370,7 @@ _REQUIRED_FIELDS = (
     "census_migrated_kind_counts",
     "census_sampled_kinds",
     "census_v1_literal_rows",
+    "census_positive_control_rows",
     "census_source",
     "operator",
 )
@@ -378,6 +385,17 @@ _INT_FIELDS = (
     "v2_envelopes",
     "missing_envelopes",
     "census_v1_literal_rows",
+    "census_positive_control_rows",
+)
+
+_COUNT_MAP_FIELDS = ("rows_scanned_by_kind", "census_migrated_kind_counts")
+_TEXT_FIELDS = (
+    "cloud",
+    "outcome",
+    "recorded_at",
+    "backend",
+    "surface_fingerprint",
+    "operator",
 )
 
 
@@ -449,6 +467,47 @@ def ledger_defects(ledger: dict[str, Any]) -> list[str]:
         if mistyped:
             defects.append(f"{cloud}: these counts are not integers: {', '.join(mistyped)}")
             continue
+        negative = [name for name in _INT_FIELDS if entry[name] < 0]
+        if negative:
+            defects.append(f"{cloud}: these counts are negative: {', '.join(negative)}")
+            continue
+        mistyped_text = [
+            name
+            for name in _TEXT_FIELDS
+            if not isinstance(entry[name], str) or not entry[name].strip()
+        ]
+        if mistyped_text:
+            defects.append(
+                f"{cloud}: these fields are not non-empty strings: {', '.join(mistyped_text)}"
+            )
+            continue
+        invalid_count_maps = [
+            name
+            for name in _COUNT_MAP_FIELDS
+            if not isinstance(entry[name], dict)
+            or any(
+                not isinstance(kind, str)
+                or not kind
+                or not isinstance(count, int)
+                or isinstance(count, bool)
+                or count < 0
+                for kind, count in (
+                    entry[name].items() if isinstance(entry[name], dict) else ()
+                )
+            )
+        ]
+        if invalid_count_maps:
+            defects.append(
+                f"{cloud}: these fields are not string-to-nonnegative-integer maps: "
+                f"{', '.join(invalid_count_maps)}"
+            )
+            continue
+        sampled_kinds = entry["census_sampled_kinds"]
+        if not isinstance(sampled_kinds, list) or any(
+            not isinstance(kind, str) or not kind for kind in sampled_kinds
+        ):
+            defects.append(f"{cloud}: census_sampled_kinds is not a list of non-empty strings")
+            continue
         if entry["cloud"] != cloud:
             defects.append(f"{cloud}: attestation records cloud={entry['cloud']!r}")
         if entry["outcome"] not in ALL_OUTCOMES:
@@ -462,8 +521,9 @@ def ledger_defects(ledger: dict[str, Any]) -> list[str]:
             )
         if entry["surface_fingerprint"] != fingerprint:
             defects.append(
-                f"{cloud}: attestation covers surfaces {entry['surface_fingerprint']} but this "
-                f"repository now writes {fingerprint} — re-run the precondition"
+                f"{cloud}: attestation surface fingerprint "
+                f"{entry['surface_fingerprint']} does not match this repository's "
+                f"{fingerprint} — re-run the precondition"
             )
         if entry["outcome"] == OUTCOME_CLEAN and not entry["envelopes_seen"]:
             defects.append(f"{cloud}: outcome 'clean' with envelopes_seen=0 is self-contradictory")
@@ -489,6 +549,12 @@ def ledger_defects(ledger: dict[str, Any]) -> list[str]:
                 f"{cloud}: attestation records census_v1_literal_rows="
                 f"{entry['census_v1_literal_rows']} — rows carrying the v1 algorithm literal "
                 "were counted in the table, so this run did not establish zero v1"
+            )
+        if entry["census_positive_control_rows"] <= 0:
+            defects.append(
+                f"{cloud}: attestation records census_positive_control_rows="
+                f"{entry['census_positive_control_rows']} — the whole-body literal search "
+                "never demonstrated that it could match"
             )
         if not isinstance(entry["census_source"], str) or not entry["census_source"].strip():
             defects.append(
@@ -561,6 +627,11 @@ def record_attestation(
             f"refusing to record a pass with census_v1_literal_rows="
             f"{attestation.census_v1_literal_rows}: rows carrying the v1 algorithm literal were "
             "counted in that table"
+        )
+    if attestation.census_positive_control_rows <= 0:
+        raise ValueError(
+            "refusing to record an attestation whose whole-body literal-search positive "
+            "control matched no rows"
         )
     if not attestation.census_source.strip():
         raise ValueError("refusing to record an attestation that does not name the database read")

--- a/tests/test_byok_aad_backfill.py
+++ b/tests/test_byok_aad_backfill.py
@@ -1,35 +1,17 @@
 from __future__ import annotations
 
-import base64
 import copy
-import secrets
-from dataclasses import asdict
 from typing import Any
 
-import pytest
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-
-from trusted_router.byok_aad_backfill import (
-    BackfillRunner,
-    EntityRow,
-    KmsOperationRateLimiter,
-)
-from trusted_router.byok_crypto import (
-    ALGORITHM,
-    ALGORITHM_V2,
-    _aad,
-    decrypt_byok_secret,
-    decrypt_control_secret,
-)
-from trusted_router.config import Settings
-from trusted_router.key_management import KeyWrapperConfig, key_wrapper_for
-from trusted_router.storage_models import EncryptedSecretEnvelope
+from scripts import backfill_byok_aad_v2 as retired_cli
+from trusted_router.byok_aad_backfill import BackfillRunner, EntityRow
+from trusted_router.byok_crypto import ALGORITHM_V2
+from trusted_router.byok_v1_attestations import V1_ALGORITHM_LITERAL
 
 
 class MemoryEntityStore:
     def __init__(self, rows: dict[tuple[str, str], dict[str, Any]]) -> None:
         self.rows = copy.deepcopy(rows)
-        self.force_conflict = False
 
     def scan(
         self,
@@ -43,230 +25,79 @@ class MemoryEntityStore:
                 kind=kind,
                 entity_id=entity_id,
                 body=copy.deepcopy(self.rows[(kind, entity_id)]),
-                original_body=copy.deepcopy(self.rows[(kind, entity_id)]),
             )
             for kind, entity_id in keys
         ]
 
-    def compare_and_swap(self, row: EntityRow, new_body: dict[str, Any]) -> bool:
-        key = (row.kind, row.entity_id)
-        if self.force_conflict:
-            self.rows[key]["concurrent_rotation"] = True
-            self.force_conflict = False
-        if self.rows[key] != row.original_body:
-            return False
-        self.rows[key] = copy.deepcopy(new_body)
-        return True
+
+def _envelope(algorithm: str) -> dict[str, str]:
+    return {
+        "algorithm": algorithm,
+        "key_ref": "fixture-key",
+        "encrypted_dek": "ZGVr",
+        "dek_nonce": "bm9uY2U=",
+        "ciphertext": "Y2lwaGVydGV4dA==",
+        "nonce": "bm9uY2U=",
+    }
 
 
-def _settings() -> Settings:
-    return Settings(environment="test")
-
-
-def _v1_envelope(
-    plaintext: str,
-    settings: Settings,
-    *,
-    workspace_id: str,
-    context: str,
-) -> dict[str, str]:
-    dek = secrets.token_bytes(32)
-    nonce = secrets.token_bytes(12)
-    dek_nonce = secrets.token_bytes(12)
-    aad = _aad(workspace_id, context)
-    wrapper = key_wrapper_for(settings)
-    envelope = EncryptedSecretEnvelope(
-        algorithm=ALGORITHM,
-        key_ref=wrapper.key_ref,
-        encrypted_dek=base64.urlsafe_b64encode(
-            wrapper.wrap(dek, nonce=dek_nonce, aad=aad)
-        ).decode("ascii"),
-        dek_nonce=base64.urlsafe_b64encode(dek_nonce).decode("ascii"),
-        ciphertext=base64.urlsafe_b64encode(
-            AESGCM(dek).encrypt(nonce, plaintext.encode(), aad)
-        ).decode("ascii"),
-        nonce=base64.urlsafe_b64encode(nonce).decode("ascii"),
-    )
-    return asdict(envelope)
-
-
-def _apply(store: MemoryEntityStore, settings: Settings, logs: list[str] | None = None):
-    return BackfillRunner(
-        store,
-        settings=settings,
-        apply=True,
-        kms_operations_per_second=1000,
-        reporter=(logs.append if logs is not None else lambda _message: None),
-        sleep=lambda _seconds: None,
-    ).run(batch_size=1)
-
-
-def test_operator_key_config_is_kms_only_and_fails_closed() -> None:
-    key_name = "projects/example/locations/global/keyRings/ring/cryptoKeys/byok"
-
-    assert key_wrapper_for(KeyWrapperConfig(byok_kms_key_name=key_name)).key_ref == key_name
-    with pytest.raises(ValueError, match="required outside local/test"):
-        key_wrapper_for(KeyWrapperConfig())
-
-
-def test_provider_backfill_is_verified_resumable_and_idempotent() -> None:
-    settings = _settings()
-    token_value = "provider-secret-never-log"  # noqa: S105 - synthetic crypto fixture
+def test_retired_backfill_classifies_v1_without_mutating_it() -> None:
     body = {
         "workspace_id": "workspace-1",
         "provider": "anthropic",
-        "secret_ref": "encrypted://anthropic",
-        "encrypted_secret": _v1_envelope(
-            token_value,
-            settings,
-            workspace_id="workspace-1",
-            context="anthropic",
-        ),
+        "encrypted_secret": _envelope(V1_ALGORITHM_LITERAL),
     }
     store = MemoryEntityStore({("byok", "workspace-1#anthropic"): body})
 
-    audit = BackfillRunner(store, reporter=lambda _message: None).run()
-    assert audit.v1_envelopes == 1
-    assert audit.rows_updated == 0
-
-    migrated = _apply(store, settings)
-    assert migrated.envelopes_migrated == 1
-    assert migrated.rows_updated == 1
-    raw = store.rows[("byok", "workspace-1#anthropic")]["encrypted_secret"]
-    assert raw["algorithm"] == ALGORITHM_V2
-    assert (
-        decrypt_byok_secret(
-            EncryptedSecretEnvelope(**raw),
-            settings,
-            workspace_id="workspace-1",
-            provider="anthropic",
-        )
-        == token_value
-    )
-
-    repeated = _apply(store, settings)
-    assert repeated.v1_envelopes == 0
-    assert repeated.v2_envelopes == 1
-    assert repeated.rows_updated == 0
-
-
-def test_broadcast_backfill_migrates_both_secret_fields_atomically() -> None:
-    settings = _settings()
-    destination_id = "bdst_123"
-    workspace_id = "workspace-2"
-    api_key = "posthog-project-token"
-    headers = '{"Authorization":"Bearer private"}'
-    body = {
-        "id": destination_id,
-        "workspace_id": workspace_id,
-        "type": "webhook",
-        "encrypted_api_key": _v1_envelope(
-            api_key,
-            settings,
-            workspace_id=workspace_id,
-            context=f"broadcast:{destination_id}:api_key",
-        ),
-        "encrypted_headers": _v1_envelope(
-            headers,
-            settings,
-            workspace_id=workspace_id,
-            context=f"broadcast:{destination_id}:headers",
-        ),
-    }
-    store = MemoryEntityStore({("broadcast_destination", destination_id): body})
-
-    migrated = _apply(store, settings)
-    assert migrated.envelopes_migrated == 2
-    assert migrated.rows_updated == 1
-    current = store.rows[("broadcast_destination", destination_id)]
-    assert current["encrypted_api_key"]["algorithm"] == ALGORITHM_V2
-    assert current["encrypted_headers"]["algorithm"] == ALGORITHM_V2
-    assert (
-        decrypt_control_secret(
-            EncryptedSecretEnvelope(**current["encrypted_api_key"]),
-            settings,
-            workspace_id=workspace_id,
-            purpose=f"broadcast:{destination_id}:api_key",
-        )
-        == api_key
-    )
-    assert (
-        decrypt_control_secret(
-            EncryptedSecretEnvelope(**current["encrypted_headers"]),
-            settings,
-            workspace_id=workspace_id,
-            purpose=f"broadcast:{destination_id}:headers",
-        )
-        == headers
-    )
-
-
-def test_decrypt_failure_never_writes_or_logs_secret_material() -> None:
-    settings = _settings()
-    token_value = "must-not-appear-anywhere"  # noqa: S105 - synthetic crypto fixture
-    envelope = _v1_envelope(
-        token_value,
-        settings,
-        workspace_id="workspace-3",
-        context="openai",
-    )
-    envelope["ciphertext"] = "corrupt"
-    body = {
-        "workspace_id": "workspace-3",
-        "provider": "openai",
-        "encrypted_secret": envelope,
-    }
-    store = MemoryEntityStore({("byok", "workspace-3#openai"): body})
-    logs: list[str] = []
-
-    result = _apply(store, settings, logs)
-
-    assert result.failures == 1
-    assert result.rows_updated == 0
-    assert store.rows[("byok", "workspace-3#openai")] == body
-    assert token_value not in "\n".join(logs)
-    assert envelope["ciphertext"] not in "\n".join(logs)
-
-
-def test_concurrent_rotation_wins_compare_and_swap() -> None:
-    settings = _settings()
-    body = {
-        "workspace_id": "workspace-4",
-        "provider": "anthropic",
-        "encrypted_secret": _v1_envelope(
-            "old-key",
-            settings,
-            workspace_id="workspace-4",
-            context="anthropic",
-        ),
-    }
-    store = MemoryEntityStore({("byok", "workspace-4#anthropic"): body})
-    store.force_conflict = True
-
-    result = _apply(store, settings)
-
-    assert result.conflicts == 1
-    assert result.rows_updated == 0
-    assert store.rows[("byok", "workspace-4#anthropic")]["concurrent_rotation"] is True
-    assert (
-        store.rows[("byok", "workspace-4#anthropic")]["encrypted_secret"]["algorithm"]
-        == ALGORITHM
-    )
-
-
-def test_unknown_algorithm_is_reported_and_never_rewritten() -> None:
-    body = {
-        "workspace_id": "workspace-5",
-        "provider": "anthropic",
-        "encrypted_secret": {"algorithm": "future-v99"},
-    }
-    store = MemoryEntityStore({("byok", "workspace-5#anthropic"): body})
-
     result = BackfillRunner(store, reporter=lambda _message: None).run()
 
+    assert result.v1_envelopes == 1
+    assert result.rows_with_v1 == 1
+    assert store.rows[("byok", "workspace-1#anthropic")] == body
+
+
+def test_v2_and_missing_optional_fields_are_counted() -> None:
+    store = MemoryEntityStore(
+        {
+            ("byok", "a"): {
+                "workspace_id": "w",
+                "provider": "anthropic",
+                "encrypted_secret": _envelope(ALGORITHM_V2),
+            },
+            ("broadcast_destination", "b"): {"workspace_id": "w"},
+        }
+    )
+
+    result = BackfillRunner(store, reporter=lambda _message: None).run(batch_size=1)
+
+    assert result.rows_scanned == 2
+    assert result.v2_envelopes == 1
+    assert result.missing_envelopes == 2
+
+
+def test_unknown_or_malformed_envelopes_fail_closed_without_logging_payloads() -> None:
+    secret_marker = "must-not-appear"  # noqa: S105 - redaction sentinel, not a credential
+    store = MemoryEntityStore(
+        {
+            ("byok", "a"): {
+                "workspace_id": "w",
+                "provider": "anthropic",
+                "encrypted_secret": {"algorithm": "future-v99", "ciphertext": secret_marker},
+            },
+            ("byok", "b"): {
+                "workspace_id": "w",
+                "provider": "openai",
+                "encrypted_secret": secret_marker,
+            },
+        }
+    )
+    logs: list[str] = []
+
+    result = BackfillRunner(store, reporter=logs.append).run()
+
     assert result.unsupported_algorithms == 1
-    assert result.rows_updated == 0
-    assert store.rows[("byok", "workspace-5#anthropic")] == body
+    assert result.failures == 1
+    assert secret_marker not in "\n".join(logs)
 
 
 def test_resume_cursor_and_small_batches_do_not_repeat_rows() -> None:
@@ -287,20 +118,8 @@ def test_resume_cursor_and_small_batches_do_not_repeat_rows() -> None:
     assert result.missing_envelopes == 2
 
 
-def test_kms_rate_limiter_accounts_for_multiple_operations() -> None:
-    now = [10.0]
-    sleeps: list[float] = []
-
-    def sleep(seconds: float) -> None:
-        sleeps.append(seconds)
-        now[0] += seconds
-
-    limiter = KmsOperationRateLimiter(
-        5.0,
-        monotonic=lambda: now[0],
-        sleep=sleep,
-    )
-    limiter.acquire(3)
-    limiter.acquire(3)
-
-    assert sleeps == [pytest.approx(0.6)]
+def test_retired_mutating_cli_refuses_and_points_to_the_safe_audit(
+    capsys: Any,
+) -> None:
+    assert retired_cli.main() == 2
+    assert "scripts/check_no_v1_envelopes.py" in capsys.readouterr().out

--- a/tests/test_byok_aad_namespace_property.py
+++ b/tests/test_byok_aad_namespace_property.py
@@ -2,16 +2,16 @@
 
 AES-GCM gives cross-binding rejection — an envelope sealed for one context
 failing to open in another — only if the associated data map is injective.
-The BYOK AAD is
+The retired V1 BYOK AAD was
 
     f"trustedrouter:byok:{workspace_id}:{provider}"
 
-and `encrypt_control_secret` seals control secrets in the SAME namespace with
-its `purpose` in the `provider` slot. So a BYOK entry whose provider string
-equals a control purpose produces two envelopes in one workspace under
-identical associated data, and each opens the other.
+and the retired `encrypt_control_secret` path sealed control secrets in the
+same namespace with its `purpose` in the `provider` slot. A BYOK entry whose
+provider string equalled a control purpose therefore produced two envelopes in
+one workspace under identical associated data, and each opened the other.
 
-The console POST route accepted any lowercased string up to 64 characters as
+The console POST route formerly accepted any lowercased string up to 64 characters as
 `provider` and passed it straight into `encrypt_byok_secret`, so a tenant could
 create that collision through the ordinary UI. The API route already validated
 against the catalog. This module pins that both doors agree, and that no
@@ -22,11 +22,9 @@ catalog-valid provider slug can collide with a control purpose.
         and aad(workspace, p) differs from aad(workspace, purpose)
         for every control purpose
 
-Since step 2 of the migration this module also covers the v2 format, which
-length-prefixes every AAD component and adds a namespace separating provider
-keys from control secrets. v1 envelopes still exist in storage until the step-3
-backfill, so both formats must open and the v1 collision is still asserted
-below rather than quietly dropped.
+The completed migration uses the v2 format, which length-prefixes every AAD
+component and adds a namespace separating provider keys from control secrets.
+V1 is retained only as a fixed rejection fixture: production must never open it.
 
 The v2 encoding must stay byte-identical to aadV2 in quill-cloud-proxy. Both
 sides pin the same hex vector; see test_the_v2_vector_matches_the_enclave.
@@ -44,12 +42,10 @@ from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
 from trusted_router.byok_crypto import (
-    ALGORITHM,
     ALGORITHM_V2,
     NAMESPACE_CONTROL,
     NAMESPACE_PROVIDER,
     NAMESPACE_USER_MODEL,
-    _aad,
     _aad_v2,
     decrypt_byok_secret,
     decrypt_control_secret,
@@ -58,6 +54,7 @@ from trusted_router.byok_crypto import (
     encrypt_control_secret,
     encrypt_user_model_secret,
 )
+from trusted_router.byok_v1_attestations import V1_ALGORITHM_LITERAL
 from trusted_router.catalog import PROVIDERS
 from trusted_router.config import Settings
 from trusted_router.main import create_app
@@ -98,9 +95,8 @@ def _post_provider(console: TestClient, provider: str) -> str:
     assert response.status_code == 303
     return response.headers["location"]
 
-# The control-secret purposes that share the BYOK namespace. Broadcast
-# destination keys are the reachable family: their ids are short enough to fit
-# inside the console form's 64-character limit.
+# Control-secret purposes used by the historical collision regression. V2
+# places them in a separate namespace; production no longer has a V1 encoder.
 CONTROL_PURPOSES = [
     "broadcast:bdst_abc123:api-key",
     "broadcast:bdst_abc123:signing-key",
@@ -145,9 +141,9 @@ def test_whatever_the_console_stores_never_collides_with_a_control_purpose(
         return
 
     assert stored is not None
-    byok_aad = _aad(workspace_id, stored.provider)
+    byok_aad = _aad_v2(NAMESPACE_PROVIDER, workspace_id, stored.provider)
     for purpose in CONTROL_PURPOSES:
-        assert byok_aad != _aad(workspace_id, purpose), (
+        assert byok_aad != _aad_v2(NAMESPACE_CONTROL, workspace_id, purpose), (
             f"stored provider {stored.provider!r} shares associated data with "
             f"control purpose {purpose!r}"
         )
@@ -192,30 +188,7 @@ def test_console_and_api_agree_on_which_providers_are_acceptable(
         assert console_ok == api_ok, f"routes disagree about provider {provider!r}"
 
 
-# --------------------------------------------- known gap, asserted not hidden ---
-
-
-def test_aad_encoding_is_not_injective_in_general() -> None:
-    """A standing record of the unfixed half.
-
-    `_aad` joins with ":" without escaping or length-prefixing, so component
-    boundaries are ambiguous. Reaching this needs a colon inside a workspace
-    id, and all three backends mint str(uuid.uuid4()), so it is not reachable
-    by normal issuance — but the encoding is still wrong, and repairing it
-    needs a V2 envelope algorithm plus a dual-read migration because existing
-    ciphertexts and wrapped DEKs were sealed under the current AAD.
-
-    If this test ever starts FAILING, the encoding was fixed and this test
-    should be deleted along with the workaround it documents.
-    """
-    assert _aad("a:b", "c") == _aad("a", "b:c")
-
-
 # ---------------------------------------------------------------- v2 format ---
-#
-# Step 2 of docs/design/byok-aad-v2-migration.md. New envelopes are written v2,
-# whose AAD is length-prefixed and carries a namespace component. v1 envelopes
-# still exist in storage until the step-3 backfill, so both formats must open.
 
 
 def _settings() -> Settings:
@@ -261,9 +234,7 @@ def test_v2_aad_is_injective(namespace: str, workspace: str, context: str) -> No
             assert _aad_v2(*other) != encoded
 
 
-def test_v2_separates_the_two_v1_collision_classes() -> None:
-    """Both concrete v1 collisions are gone under v2."""
-    assert _aad("a:b", "c") == _aad("a", "b:c")  # v1, still true
+def test_v2_separates_ambiguous_components_and_namespaces() -> None:
     assert _aad_v2("provider", "a:b", "c") != _aad_v2("provider", "a", "b:c")
     assert _aad_v2(NAMESPACE_PROVIDER, "w", "x") != _aad_v2(NAMESPACE_CONTROL, "w", "x")
 
@@ -374,19 +345,14 @@ def test_user_model_secrets_are_v2_and_open_only_in_their_namespace() -> None:
         decrypt_user_model_secret(sealed, _settings(), workspace_id="ws-other", purpose=purpose)
 
 
-def test_v1_envelopes_still_decrypt() -> None:
-    """Rows written before the migration must keep working until the backfill.
-
-    Sealed here the way v1 sealed them, since nothing writes v1 any more.
-    """
+def test_v1_envelopes_are_explicitly_rejected() -> None:
+    """A real V1-shaped fixture must fail before any unwrap operation."""
     envelope = _seal_v1("legacy-secret", workspace_id=WORKSPACE, context="openai")
-    assert envelope.algorithm == ALGORITHM
-    assert (
+    assert envelope.algorithm == V1_ALGORITHM_LITERAL
+    with pytest.raises(ValueError, match="unsupported BYOK envelope algorithm"):
         decrypt_byok_secret(
             envelope, _settings(), workspace_id=WORKSPACE, provider="openai"
         )
-        == "legacy-secret"
-    )
 
 
 def test_an_unknown_algorithm_is_still_refused() -> None:
@@ -415,7 +381,7 @@ def test_v2_still_rejects_a_wrong_binding(workspace: str, context: str) -> None:
 
 
 def _seal_v1(secret: str, *, workspace_id: str, context: str):
-    """Seal an envelope the way v1 did, for backward-compatibility tests."""
+    """Seal the retired wire format without importing a production decoder."""
     from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
     from trusted_router.byok_crypto import _b64, _key_ref, _wrap_dek
@@ -423,9 +389,9 @@ def _seal_v1(secret: str, *, workspace_id: str, context: str):
     dek = secrets_module.token_bytes(32)
     nonce = secrets_module.token_bytes(12)
     dek_nonce = secrets_module.token_bytes(12)
-    aad = _aad(workspace_id, context)
+    aad = f"trustedrouter:byok:{workspace_id}:{context}".encode()
     return EncryptedSecretEnvelope(
-        algorithm=ALGORITHM,
+        algorithm=V1_ALGORITHM_LITERAL,
         key_ref=_key_ref(_settings()),
         encrypted_dek=_b64(_wrap_dek(dek, dek_nonce, aad, _settings())),
         dek_nonce=_b64(dek_nonce),

--- a/tests/test_byok_envelope_registry_totality_property.py
+++ b/tests/test_byok_envelope_registry_totality_property.py
@@ -1,10 +1,12 @@
-"""Proof that the BYOK AAD v2 backfill's envelope registry is total.
+"""Proof that the retired-V1 census registry covers every envelope surface.
 
-`byok_aad_backfill` decides what to migrate from two hand-written tables:
-`MIGRATED_KINDS` and `_fields_for_kind`. Between them they name three
+`byok_aad_backfill` decides what to scan from one source-of-truth registry,
+`MIGRATED_SURFACES`, exposed through `MIGRATED_KINDS` and `_fields_for_kind`.
+It currently names five
 locations — byok.encrypted_secret, broadcast_destination.encrypted_api_key and
-broadcast_destination.encrypted_headers — and tag each with the AAD namespace
-("provider" or "control") its envelope was sealed under. The law:
+broadcast_destination.encrypted_headers, plus the user-provided model endpoint
+and signing secrets — and tags each with the AAD namespace it is sealed under.
+The law:
 
     for every dataclass D the package defines, and every field f of D whose
     RESOLVED annotation admits an EncryptedSecretEnvelope,
@@ -58,7 +60,7 @@ disclose was itself a review finding:
     other name would not. On the read side that fails closed, because a model
     with no recognised read gets no kind and the law reports it as uncovered.
     On the write side it does not: see the scope limit below.
-  - `NON_ENVELOPE_KINDS`, one entry today, and `LOOSELY_TYPED_FIELDS`, two.
+  - `NON_ENVELOPE_KINDS`, five entries today, and `LOOSELY_TYPED_FIELDS`, two.
     Both are declarations with reasons and both are asserted in both
     directions, so an entry that stops being true fails the build.
   - `_OPAQUE_CONTAINERS`, the five builtin container types `_admits_any` calls
@@ -106,8 +108,8 @@ in the package now qualifies — and narrower within the two original files. Two
 real kinds left coverage that way: `broadcast_delivery` and
 `broadcast_delivery_due`, both written by `_write_delivery` in
 storage_gcp_broadcast.py, a method that names no envelope model, field, sealer
-or id helper. That is why `NON_ENVELOPE_KINDS` shrank from three entries to one
-— the two that went are out of scope, not proven safe — and why a new
+or id helper. Two former entries left `NON_ENVELOPE_KINDS` as out of scope,
+not proven safe, and a new
 `write_entity("broadcast_delivery_archive", ...)` beside them passes this file
 today where the old list would have caught it. Measured both ways against both
 versions, not reasoned about. The cost is bounded by what those functions
@@ -116,9 +118,9 @@ is the loosely typed field `LOOSELY_TYPED_FIELDS` documents, so this is the same
 hole as the settle_body refutation approached from the other side.
 
 Why this is a proof and not a test. The registry is exactly right today — every
-caller of the two encrypt functions was walked by hand and maps to precisely
-those three fields. The failure mode is not "the registry is wrong", it is
-"someone adds a fourth place an envelope lives". `_process_row` only ever looks
+caller of the encrypt functions maps to precisely those five fields. The
+failure mode is not "the registry is wrong", it is "someone adds a sixth place
+an envelope lives". `_process_row` only ever looks
 at the fields `_fields_for_kind` names, so an unregistered field is never
 counted, never migrated, and never reported: the audit run comes back clean and
 all-v2 while v1 envelopes sit in the rows it just walked past. That clean audit
@@ -126,22 +128,11 @@ result is what signed off step 3 on AWS and Azure. A migration declaring itself
 finished with v1 envelopes still in storage is the entire reason this module
 exists.
 
-The family half is the same defect class in a sharper form. A wrong family does
-not skip the field, it re-seals it under the wrong namespace: the v1 unwrap
-still succeeds, because v1 AAD has no namespace component at all (see
-`_envelope_aad`), so nothing inside the backfill objects and the application
-later reads the row back through the other namespace and gets InvalidTag for a
-secret that is now unrecoverable.
-
-Measured rather than assumed, because the first draft of this paragraph
-asserted that outcome as inevitable and it is not. Both family flips were run
-against this module: with today's two body shapes each one fails CLOSED inside
-`_migrate_envelope` — the provider branch demands a `provider` field the
-broadcast body has not got, and the control branch demands a purpose suffix
-`_broadcast_context` has no entry for. So today the `envelopes_migrated`
-assertion is what catches a wrong family, and the decrypt beside it is the
-guard for a future body carrying both context fields, where the silent
-corruption above becomes reachable.
+The family half remains useful after the mutating backfill was retired: it
+proves that the registry's namespace metadata agrees with each active writer.
+The read-only census does not use that family to decrypt or rewrite anything,
+but keeping the derivation accurate prevents a future operator or migration
+from treating hand-written namespace claims as evidence.
 
 Near-miss recorded against this module's own first draft, because it is the
 same mistake in miniature. `_derived_pairs` originally built its set by
@@ -154,22 +145,11 @@ green. A proof whose central assertion is silent on its motivating case is not
 a proof, so unresolvable halves now surface as the `UNPLACED_KIND` /
 `UNSEALED_FAMILY` sentinels and read as locations the registry does not cover.
 
-Finding recorded here because it refutes the assumption this module started
-from — that `MIGRATED_KINDS` is the one place a kind is listed. It is not, and
-neither entity store reads it as a set. `SpannerEntityStore.scan` hardcodes
-`kind IN ('broadcast_destination', 'byok')` into its SQL text and never
-references the registry; `PostgresEntityStore.scan` binds `MIGRATED_KINDS[0],
-MIGRATED_KINDS[1]` positionally against a two-placeholder IN list. Adding a
-third kind to the registry today updates neither scan, so the backfill would
-never fetch the rows it had just been taught to migrate, and would once again
-report clean. The two store tests below capture the statement each scan
-actually issues and check the registry kinds against it. Calling that
-"behavioural" would be an overclaim, and the first draft did: the fakes return
-no rows, so nothing about retrieval, decoding or pagination is exercised. What
-they establish is narrower and still worth having — adding a kind to the
-registry without editing the SQL text and the placeholder count stops the
-build. The source is deliberately left as it is: this module records the
-coupling rather than burying it in a refactor.
+An earlier review found that both entity scans duplicated the registry's kind
+list in SQL. That defect is now closed: Spanner binds `UNNEST(@kinds)` and
+Postgres binds `kind = ANY(%s)`, both from `MIGRATED_KINDS`. The store tests
+capture the actual statement and parameters, and a retrieval test proves a
+newly registered kind is returned rather than merely appearing in SQL text.
 
 Refutation, from an adversarial review of this module, of its own central
 claim. Reflection follows types, and `dict[str, Any]` is the absence of one.
@@ -276,33 +256,19 @@ from typing import Any
 import pytest
 
 import trusted_router
-from tests.test_byok_aad_backfill import MemoryEntityStore, _v1_envelope
+from tests.test_byok_aad_backfill import MemoryEntityStore
 from trusted_router import byok_aad_backfill as backfill
 from trusted_router import byok_crypto, storage_models
 from trusted_router.byok_aad_backfill import (
     BackfillRunner,
     PostgresEntityStore,
     SpannerEntityStore,
-    _broadcast_context,
     _fields_for_kind,
 )
-from trusted_router.byok_crypto import (
-    ALGORITHM_V2,
-    NAMESPACE_CONTROL,
-    NAMESPACE_PROVIDER,
-    NAMESPACE_USER_MODEL,
-    decrypt_byok_secret,
-    decrypt_control_secret,
-    decrypt_user_model_secret,
-)
+from trusted_router.byok_crypto import NAMESPACE_CONTROL, NAMESPACE_PROVIDER, NAMESPACE_USER_MODEL
 from trusted_router.byok_v1_attestations import MIGRATED_KINDS
-from trusted_router.config import Settings
 from trusted_router.services.broadcast import broadcast_secret_context
 from trusted_router.services.broadcast_adapters import _secret_context as adapter_secret_context
-from trusted_router.services.user_model_secrets import (
-    USER_MODEL_ENDPOINT_KEY_PURPOSE,
-    USER_MODEL_SIGNING_PURPOSE,
-)
 from trusted_router.storage_models import EncryptedSecretEnvelope
 
 SRC = pathlib.Path(trusted_router.__file__).parent
@@ -1185,9 +1151,9 @@ def test_every_envelope_typed_attribute_lives_in_storage_models() -> None:
 # any more because they are OUT OF SCOPE, not because they were shown to be
 # safe: the method that writes them, `_write_delivery` in
 # storage_gcp_broadcast.py, mentions no envelope model, field, sealer or id
-# helper, so the scope-based derivation never reaches it. Read the shrink from
-# three to one as a coverage trade, recorded in the module docstring, rather
-# than as two fewer risks.
+# helper, so the scope-based derivation never reaches it. Later non-envelope
+# entity kinds expanded this declaration; the two omitted delivery kinds remain
+# a coverage trade rather than two fewer risks.
 NON_ENVELOPE_KINDS = {
     # Index row written as a dict literal: {"destination_id": ...}. See
     # SpannerBroadcastDestinations.create in storage_gcp_broadcast.py.
@@ -1207,7 +1173,7 @@ NON_ENVELOPE_KINDS = {
 # storage_codec.json_body's recursive asdict into the persisted row.
 LOOSELY_TYPED_FIELDS = {
     ("BroadcastDeliveryJob", "settle_body"): (
-        "persisted under kind 'broadcast_delivery', which the backfill does not "
+        "persisted under kind 'broadcast_delivery', which the retired-V1 census does not "
         "scan. A serialised envelope echoed into a settle body would keep its v1 "
         "algorithm with nothing to report it."
     ),
@@ -1421,20 +1387,19 @@ def test_the_registry_covers_every_envelope_location_exactly() -> None:
     """The law. No missing entries, no stale ones.
 
     This is the assertion that prevents the defect class. The rest of the
-    module checks that today's three locations behave; this one checks
-    tomorrow's fourth.
+    module checks that today's five locations behave; this one checks
+    tomorrow's sixth.
     """
     derived = _derived_pairs()
     registry = _registry_pairs()
 
     missing = sorted(derived - registry)
     assert not missing, (
-        f"the backfill registry does not cover {len(missing)} envelope location(s): "
+        f"the retired-V1 census registry does not cover {len(missing)} envelope location(s): "
         + ", ".join(f"{kind}.{field} (family {family})" for kind, field, family in missing)
         + ". `_process_row` only walks the fields `_fields_for_kind` names, so these "
         "would keep their v1 envelopes while the audit reported clean. Add them to "
-        "`_fields_for_kind` with the namespace their encrypt_* call site uses — and "
-        "check `_broadcast_context` can build a purpose for any new control field."
+        "`MIGRATED_SURFACES` with the namespace their encrypt_* call site uses."
     )
 
     stale = sorted(registry - derived)
@@ -1486,42 +1451,24 @@ def _entity_id_for(family: str) -> str:
     return f"{WORKSPACE}#{PROVIDER}" if family == NAMESPACE_PROVIDER else "bdst_totality"
 
 
-def _context_for(family: str, entity_id: str, field: str) -> str:
-    if family == NAMESPACE_PROVIDER:
-        return PROVIDER
-    if field == "encrypted_endpoint_api_key":
-        return USER_MODEL_ENDPOINT_KEY_PURPOSE
-    if field == "encrypted_signing_secret":
-        return USER_MODEL_SIGNING_PURPOSE
-    # The purpose the application uses is the field name minus its prefix; the
-    # identity between that and the backfill's private copy is pinned below.
-    return broadcast_secret_context(entity_id, field.removeprefix("encrypted_"))
+def _retired_v1_envelope() -> dict[str, str]:
+    """Opaque fixture for proving the read-only census still finds retired data."""
+    return {
+        "algorithm": backfill.V1_ALGORITHM_LITERAL,
+        "key_ref": "fixture-key",
+        "encrypted_dek": "ZGVr",
+        "dek_nonce": "bm9uY2U=",
+        "ciphertext": "Y2lwaGVydGV4dA==",
+        "nonce": "bm9uY2U=",
+    }
 
 
 @pytest.mark.parametrize(("kind", "field", "family"), sorted(_resolved_pairs()))
-def test_each_derived_location_round_trips_through_the_backfill(
+def test_each_derived_location_is_counted_by_the_retired_v1_census(
     kind: str, field: str, family: str
 ) -> None:
-    """Seal v1 as the application would, migrate, reopen as the application would.
-
-    The reopen uses the family derived from the *call sites*, not the family in
-    the registry, which is what makes this a check on the registry rather than
-    a restatement of it.
-
-    Both family flips were run against this test. Each surfaced as a hard
-    failure inside `_migrate_envelope` rather than as a silently unreadable
-    envelope: the provider branch demands a `provider` field the broadcast body
-    has not got, and the control branch demands a purpose suffix
-    `_broadcast_context` has no entry for. So with today's two body shapes a
-    wrong family fails closed, and the `envelopes_migrated` assertion is what
-    actually catches it. The decrypt below is the guard for the shape that does
-    not fail closed — a body carrying both a provider slug and a broadcast
-    purpose, where a wrong family would migrate cleanly and report success.
-    """
-    settings = Settings(environment="test")
-    secret = "registry-totality-probe-secret"  # noqa: S105 - synthetic crypto fixture
+    """The retired migration's read-only census still covers every envelope field."""
     entity_id = _entity_id_for(family)
-    context = _context_for(family, entity_id, field)
 
     body: dict[str, Any] = {
         (
@@ -1529,7 +1476,7 @@ def test_each_derived_location_round_trips_through_the_backfill(
             if kind == "user_provided_model"
             else "workspace_id"
         ): WORKSPACE,
-        field: _v1_envelope(secret, settings, workspace_id=WORKSPACE, context=context),
+        field: _retired_v1_envelope(),
     }
     if family == NAMESPACE_PROVIDER:
         body["provider"] = PROVIDER
@@ -1537,34 +1484,15 @@ def test_each_derived_location_round_trips_through_the_backfill(
 
     stats = BackfillRunner(
         store,
-        settings=settings,
-        apply=True,
-        kms_operations_per_second=1000,
         reporter=lambda _message: None,
-        sleep=lambda _seconds: None,
     ).run()
 
-    assert stats.envelopes_migrated == 1, (
-        f"{kind}.{field} was not migrated (failures={stats.failures}, "
-        f"unsupported={stats.unsupported_algorithms}); the registry's family for it "
-        f"disagrees with the {family} namespace its call sites seal under"
+    assert stats.v1_envelopes == 1, (
+        f"{kind}.{field} was not counted (failures={stats.failures}, "
+        f"unsupported={stats.unsupported_algorithms}); the retired audit must remain "
+        "able to fail closed if a V1 envelope reappears"
     )
-    raw = store.rows[(kind, entity_id)][field]
-    assert raw["algorithm"] == ALGORITHM_V2
-
-    envelope = EncryptedSecretEnvelope(**raw)
-    if family == NAMESPACE_PROVIDER:
-        opened = decrypt_byok_secret(envelope, settings, workspace_id=WORKSPACE, provider=context)
-    elif family == NAMESPACE_USER_MODEL:
-        opened = decrypt_user_model_secret(
-            envelope, settings, workspace_id=WORKSPACE, purpose=context
-        )
-    else:
-        opened = decrypt_control_secret(envelope, settings, workspace_id=WORKSPACE, purpose=context)
-    assert opened == secret, (
-        f"{kind}.{field} re-sealed under a namespace the application does not read "
-        f"it with; that secret is now unrecoverable"
-    )
+    assert store.rows[(kind, entity_id)] == body
 
 
 @pytest.mark.parametrize(
@@ -1577,38 +1505,12 @@ def test_each_derived_location_round_trips_through_the_backfill(
     ),
 )
 def test_the_broadcast_context_helper_matches_the_service(field: str) -> None:
-    """There are THREE copies of this format string, not two.
-
-    `_broadcast_context` in the backfill, `broadcast_secret_context` on the
-    write side, and `_secret_context` in broadcast_adapters on the READ side.
-    The backfill's source comment claims byte-identity with the write-side copy
-    only; adversarial review pointed out the read-side copy is the one that has
-    to reconstruct the AAD after migration, and it was never compared. All
-    three are pinned here — a divergence re-seals a control secret against a
-    purpose the reader cannot rebuild.
-    """
+    """The writer and reader must reconstruct identical V2 AAD context."""
     destination_id = "bdst_context_identity"
     suffix = field.removeprefix("encrypted_")
-    assert _broadcast_context(destination_id, field) == broadcast_secret_context(
+    assert broadcast_secret_context(destination_id, suffix) == adapter_secret_context(
         destination_id, suffix
     )
-    assert _broadcast_context(destination_id, field) == adapter_secret_context(
-        destination_id, suffix
-    )
-
-
-@pytest.mark.parametrize(
-    ("field", "purpose"),
-    (
-        ("encrypted_endpoint_api_key", USER_MODEL_ENDPOINT_KEY_PURPOSE),
-        ("encrypted_signing_secret", USER_MODEL_SIGNING_PURPOSE),
-    ),
-)
-def test_the_user_model_context_helper_matches_the_service(
-    field: str,
-    purpose: str,
-) -> None:
-    assert _broadcast_context("ignored", field) == purpose
 
 
 # ---------------------------------------------------------------------------
@@ -1719,14 +1621,13 @@ def test_a_newly_registered_kind_is_actually_fetched(scan: Any, monkeypatch: Any
     """The finding this file was written for, as a live property.
 
     Both adapters once derived their filter from something other than the
-    registry: Spanner embedded the two kinds as SQL text, Postgres bound
-    `MIGRATED_KINDS[0], MIGRATED_KINDS[1]` positionally against a
-    two-placeholder list. Registering a third kind would have left both
-    fetching the old two, and the backfill would have reported clean over rows
+    registry: Spanner embedded fixed kinds as SQL text, while Postgres bound a
+    fixed number of positional entries. Registering another kind would have
+    left both fetching the old set, and the census would have reported clean over rows
     it never scanned — correct only by arity coincidence.
 
-    Asserting today's two kinds cannot see that, because today there are
-    exactly two. Adding a third and requiring it to be fetched can.
+    Asserting today's set cannot see that. Adding one more and requiring it to
+    be fetched can.
     """
     widened = (*MIGRATED_KINDS, "totality_probe_kind")
     monkeypatch.setattr(backfill, "MIGRATED_KINDS", widened, raising=True)

--- a/tests/test_byok_v1_precondition.py
+++ b/tests/test_byok_v1_precondition.py
@@ -81,6 +81,8 @@ from __future__ import annotations
 
 import copy
 import json
+import sys
+import types
 from pathlib import Path
 from typing import Any
 
@@ -90,6 +92,8 @@ from scripts import check_no_v1_envelopes as check_script
 from trusted_router.byok_aad_backfill import (
     EntityCensus,
     EntityRow,
+    PostgresEntityStore,
+    SpannerEntityStore,
     attestation_for,
     check_no_v1_envelopes,
 )
@@ -119,6 +123,120 @@ V1 = "TR-BYOK-ENVELOPE-AES-256-GCM-V1"
 V2 = "TR-BYOK-ENVELOPE-AES-256-GCM-V2"
 
 
+class _FakeParamTypes:
+    STRING = object()
+    INT64 = object()
+
+    @staticmethod
+    def Array(value: object) -> tuple[str, object]:
+        return ("array", value)
+
+
+class _FakeSpannerSnapshot:
+    def __enter__(self) -> _FakeSpannerSnapshot:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def execute_sql(self, sql: str, **kwargs: object) -> list[tuple[object, ...]]:
+        if "GROUP BY kind" in sql:
+            return [("byok", 1)]
+        if "STRPOS" in sql:
+            params = kwargs.get("params")
+            assert isinstance(params, dict)
+            return [(7 if params["literal"] == "{" else 0,)]
+        return [("workspace",)]
+
+
+class _FakeSpannerDatabase:
+    name = "projects/p/instances/i/databases/d"
+
+    def __init__(self) -> None:
+        self.snapshot_calls: list[dict[str, object]] = []
+
+    def snapshot(self, **kwargs: object) -> _FakeSpannerSnapshot:
+        self.snapshot_calls.append(kwargs)
+        return _FakeSpannerSnapshot()
+
+
+def test_spanner_census_uses_a_multi_use_snapshot() -> None:
+    database = _FakeSpannerDatabase()
+    store = SpannerEntityStore(database, _FakeParamTypes)
+
+    census = store.census()
+
+    assert database.snapshot_calls == [{"multi_use": True}]
+    assert census.migrated_kind_counts == {"byok": 1}
+    assert census.sampled_kinds == ("workspace",)
+    assert census.v1_literal_rows == 0
+    assert census.positive_control_rows == 7
+
+
+class _FakePostgresCursor:
+    def __init__(self, rows: list[tuple[object, ...]]) -> None:
+        self._rows = rows
+
+    def fetchall(self) -> list[tuple[object, ...]]:
+        return self._rows
+
+    def fetchone(self) -> tuple[object, ...] | None:
+        return self._rows[0] if self._rows else None
+
+
+class _FakePostgresConnection:
+    info = types.SimpleNamespace(host="dsql.example", port=5432)
+
+    def __init__(self) -> None:
+        self.executed: list[str] = []
+
+    def __enter__(self) -> _FakePostgresConnection:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def execute(self, sql: str, _params: object = None) -> _FakePostgresCursor:
+        self.executed.append(sql)
+        if "'v1_literal' AS metric" in sql:
+            assert "GROUP BY kind" in sql
+            assert "DISTINCT kind" in sql
+            assert "body::text LIKE" in sql
+            return _FakePostgresCursor(
+                [
+                    ("count", "byok", 1),
+                    ("sample", "workspace", 0),
+                    ("v1_literal", "", 0),
+                    ("positive_control", "", 7),
+                ]
+            )
+        if "current_database()" in sql:
+            assert "inet_server_addr" not in sql
+            return _FakePostgresCursor([("postgres", "admin")])
+        raise AssertionError(f"unexpected SQL: {sql}")
+
+
+def test_postgres_census_supports_dsql_without_inet_server_addr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_psycopg = types.ModuleType("psycopg")
+    connection = _FakePostgresConnection()
+    fake_psycopg.connect = lambda _dsn: connection  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "psycopg", fake_psycopg)
+
+    census = PostgresEntityStore("dbname=postgres").census()
+
+    assert census.v1_literal_rows == 0
+    assert census.positive_control_rows == 7
+    assert len(connection.executed) == 2
+    assert connection.executed[0].startswith("WITH sampled AS")
+    assert all(not sql.startswith("SET TRANSACTION") for sql in connection.executed)
+    assert census.source == (
+        "postgres:postgres@dsql.example:5432 as admin "
+        "(database/user from server; host/port from negotiated connection)"
+    )
+
+
 def _envelope(algorithm: str) -> dict[str, str]:
     """An envelope's shape, not its contents. The audit classifies on
     `algorithm` alone and never decrypts, so real ciphertext would add nothing
@@ -141,15 +259,11 @@ class FakeCloudDatabase:
 
     The important fidelity here is what the two halves SHARE, because that is
     where an earlier version of these tests lied. Both `scan` and the per-kind
-    census restrict to the same kind list, as both real adapters do — the
-    per-kind census from `MIGRATED_KINDS` on each, the scan from
-    `MIGRATED_KINDS` on `PostgresEntityStore` and from the same two names
-    hardcoded in SQL text on `SpannerEntityStore` — and the walk reads
+    census restrict to `MIGRATED_KINDS` on both real adapters, and the walk reads
     envelopes only out of the field names in `MIGRATED_SURFACES`. This fixture
-    models the shared list, which is the property that matters; it does not
-    model Spanner's duplicate copy of it, whose only failure mode is an
-    undercount, which is a refusal. So a test cannot make those two
-    disagree by renaming a kind — renaming it renames it in both — and any
+    models the shared list, which is the property that matters. So a test
+    cannot make those two disagree by renaming a kind — renaming it renames it
+    in both — and any
     fixture that pretends otherwise is testing a decoupling production cannot
     exhibit. `scan_returns_nothing` is kept for the one class where they really
     do diverge in production: a cursor, ordering or pagination bug in the paged
@@ -186,7 +300,6 @@ class FakeCloudDatabase:
                 kind=kind,
                 entity_id=entity_id,
                 body=copy.deepcopy(self.rows[(kind, entity_id)]),
-                original_body=copy.deepcopy(self.rows[(kind, entity_id)]),
             )
             for kind, entity_id in keys
         ]
@@ -209,6 +322,7 @@ class FakeCloudDatabase:
             v1_literal_rows=sum(
                 1 for body in self.rows.values() if V1_ALGORITHM_LITERAL in json.dumps(body)
             ),
+            positive_control_rows=len(self.rows),
             source=SOURCE,
         )
 
@@ -294,6 +408,27 @@ def test_a_zero_scan_is_not_reportable_as_zero_v1() -> None:
         attestation_for(result, backend="postgres", operator="you@lorehex.co")
 
 
+def test_a_populated_scan_cannot_substitute_for_an_unwitnessed_census() -> None:
+    census = EntityCensus(
+        migrated_kind_counts={"byok": 1},
+        sampled_kinds=(),
+        v1_literal_rows=0,
+        positive_control_rows=1,
+        source=SOURCE,
+    )
+    store = FakeCloudDatabase(
+        {("byok", "a"): _byok_row(V2)},
+        census=census,
+    )
+
+    result = check_no_v1_envelopes(store, cloud="aws", reporter=lambda _m: None)
+
+    assert result.stats.envelopes_seen == 1
+    assert result.outcome == OUTCOME_ZERO_SCAN
+    assert not result.passed
+    assert "zero evidence" in result.detail
+
+
 def test_an_empty_deployment_passes_only_with_a_census_witness() -> None:
     """Same scan result as the test above; different, corroborated conclusion.
 
@@ -312,6 +447,26 @@ def test_an_empty_deployment_passes_only_with_a_census_witness() -> None:
     assert result.outcome == OUTCOME_EMPTY_WITNESSED
     assert result.passed
     assert result.outcome != OUTCOME_CLEAN, "an absence is a weaker claim and is named as one"
+
+
+def test_a_zero_literal_count_without_a_working_positive_control_is_not_evidence() -> None:
+    census = EntityCensus(
+        migrated_kind_counts={},
+        sampled_kinds=("workspace",),
+        v1_literal_rows=0,
+        positive_control_rows=0,
+        source=SOURCE,
+    )
+    store = FakeCloudDatabase(
+        {("workspace", "w"): {"name": "acme"}},
+        census=census,
+    )
+
+    result = check_no_v1_envelopes(store, cloud="aws", reporter=lambda _m: None)
+
+    assert result.outcome == OUTCOME_SCAN_DISAGREES
+    assert not result.passed
+    assert "positive control matched none" in result.detail
 
 
 def test_rows_of_a_migrated_kind_that_hold_no_secret_are_not_a_failure() -> None:
@@ -519,6 +674,7 @@ def _passing_attestation(cloud: str, **overrides: Any) -> Attestation:
         "census_migrated_kind_counts": {"byok": 7},
         "census_sampled_kinds": ["byok", "workspace"],
         "census_v1_literal_rows": 0,
+        "census_positive_control_rows": 7,
         "census_source": SOURCE,
         "operator": "you@lorehex.co",
         "note": "",
@@ -595,6 +751,23 @@ def test_a_hand_written_pass_that_counted_v1_rows_is_reported_as_a_defect() -> N
     assert zero_v1_blockers(ledger) != []
 
 
+def test_a_hand_written_pass_without_a_literal_search_positive_control_is_a_defect() -> None:
+    ledger = empty_ledger()
+    ledger["attestations"]["aws"] = _passing_attestation(
+        "aws", census_positive_control_rows=0
+    ).to_dict()
+
+    defects = ledger_defects(ledger)
+
+    assert any("census_positive_control_rows=0" in defect for defect in defects)
+    assert zero_v1_blockers(ledger) != []
+    with pytest.raises(ValueError, match="positive control matched no rows"):
+        record_attestation(
+            _passing_attestation("aws", census_positive_control_rows=0),
+            ledger=empty_ledger(),
+        )
+
+
 def test_an_attestation_that_does_not_name_the_database_it_read_is_a_defect() -> None:
     """Since a wrong-but-populated database passes, the one mitigation is that
     the ledger says which database was read — the server's own answer on
@@ -617,11 +790,31 @@ def test_counts_written_as_strings_do_not_read_as_zero() -> None:
     ledger["attestations"]["aws"] = _passing_attestation("aws").to_dict()
     ledger["attestations"]["aws"]["v1_envelopes"] = "0"
     ledger["attestations"]["aws"]["census_v1_literal_rows"] = "0"
+    ledger["attestations"]["aws"]["census_positive_control_rows"] = "7"
 
     defects = ledger_defects(ledger)
 
     assert any("are not integers" in defect for defect in defects)
     assert any("v1_envelopes" in defect for defect in defects)
+
+
+@pytest.mark.parametrize(
+    ("field", "bad_value", "message"),
+    [
+        ("rows_scanned_by_kind", "none", "string-to-nonnegative-integer maps"),
+        ("census_migrated_kind_counts", {"byok": "0"}, "string-to-nonnegative-integer maps"),
+        ("census_sampled_kinds", "byok", "list of non-empty strings"),
+        ("census_sampled_kinds", [""], "list of non-empty strings"),
+    ],
+)
+def test_ledger_rejects_mistyped_census_witnesses(
+    field: str, bad_value: object, message: str
+) -> None:
+    ledger = empty_ledger()
+    ledger["attestations"]["aws"] = _passing_attestation("aws").to_dict()
+    ledger["attestations"]["aws"][field] = bad_value
+
+    assert any(message in defect for defect in ledger_defects(ledger))
 
 
 # ------------------------------------------------ one fleet, not three clouds ---
@@ -685,10 +878,10 @@ def test_an_empty_witnessed_entry_with_no_witness_is_a_zero_scan() -> None:
 def test_adding_an_encrypted_surface_invalidates_every_attestation(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Open question #2 in the migration doc, made executable.
+    """The migration plan's registry-coverage limit, made executable.
 
-    "Are there envelopes outside the three surfaces?" — if the answer ever
-    becomes "yes, here is a fourth", every attestation recorded before it was
+    "Are there envelopes outside the registered surfaces?" — if the answer ever
+    becomes "yes, here is another", every attestation recorded before it was
     taken by a run that never walked that surface. The fingerprint makes those
     attestations stale rather than silently reusable.
     """
@@ -715,12 +908,11 @@ def test_adding_an_encrypted_surface_invalidates_every_attestation(
 
 
 def test_the_committed_ledger_is_well_formed() -> None:
-    """The real file, as committed. Empty is fine — forged is not.
+    """The committed fleet evidence parses and covers today's surfaces.
 
-    Recording nothing is the honest state today: nobody has run this against a
-    real database. What this asserts is that whatever is in there parses, is
-    for a known cloud, carries a passing outcome, and covers the surfaces this
-    repository writes now.
+    What this asserts is that every recorded entry is for a known cloud,
+    carries a passing outcome, and covers the surfaces this repository writes
+    now. It cannot prove the operator pointed at the intended database.
 
     The path assertion is not ceremony. A missing ledger reads as the empty
     ledger — the fail-closed choice — so a default path that quietly stopped
@@ -819,20 +1011,6 @@ def test_status_only_exits_nonzero_while_the_ledger_blocks(
     cleared = check_script.main(["--status-only", "--ledger", str(ledger_path)])
     assert cleared == 0
     assert "every standalone cloud attests" in capsys.readouterr().out
-
-
-def test_the_pinned_v1_literal_is_the_one_the_module_writes() -> None:
-    """The census searches for `V1_ALGORITHM_LITERAL`, which is a copy.
-
-    It is pinned rather than imported so that the check survives step 4
-    deleting `byok_crypto.ALGORITHM` — but a copy that drifts would search for
-    a string no row contains and report zero forever, which is the quietest
-    possible way for this whole file to stop meaning anything. Held equal while
-    both exist; delete this assertion with v1, not before.
-    """
-    from trusted_router.byok_crypto import ALGORITHM
-
-    assert V1_ALGORITHM_LITERAL == ALGORITHM == V1
 
 
 def test_the_script_reports_a_failed_run_as_inconclusive(

--- a/tests/test_byok_v1_removal_gate.py
+++ b/tests/test_byok_v1_removal_gate.py
@@ -1,752 +1,188 @@
-"""The gate on step 4: v1 envelope support may not be deleted unattested.
+"""Permanent Step 4 guards after BYOK AAD v1 was retired.
 
-THE LAW
-    If a v1-shaped envelope — sealed exactly as the stored rows were sealed —
-    no longer opens through `decrypt_byok_secret` and `decrypt_control_secret`,
-    then `docs/design/byok-aad-v2-attestations.json` must carry a passing
-    zero-v1 attestation for **every** standalone cloud, covering the surfaces
-    this repository writes today. Otherwise CI fails and says what to run.
+The production migration is intentionally one-way: a V1 row cannot be opened
+by a Step 4 build after the old AAD encoder is removed. These tests keep the
+post-migration contract explicit:
 
-    While a v1 envelope still opens, this gate asserts nothing about the
-    ledger.
+* every standalone cloud attested zero V1 before removal;
+* the production module contains no V1 encoder or dispatch path; and
+* a byte-compatible V1 fixture is rejected before any unwrap succeeds.
 
-WHY THE TEST IS BEHAVIOURAL AND THE AST PROBE IS ONLY THE EXPLANATION
-    An earlier revision of this file decided by reading `byok_crypto.py`'s AST
-    for three named pieces: the `ALGORITHM` constant, the `_aad` builder, and
-    the v1 arm of `_envelope_aad`. That got it wrong in both directions.
-
-    It stayed **quiet** on the removal the migration doc's own step-4 bullet
-    invites — rejecting v1 at `decrypt_byok_secret`/`decrypt_control_secret`
-    while leaving all three pieces physically in place. Every stored v1
-    envelope is permanently unopenable after that edit, and the gate returned
-    no verdict at all.
-
-    It **fired** on edits that changed nothing: annotating the constant as
-    `ALGORITHM: Final[str]` (an `ast.AnnAssign`, which the probe did not match)
-    and extracting the v1 arm into a helper that `_envelope_aad` calls. Both
-    preserve v1 completely. A gate that cries wolf on a type annotation is a
-    gate somebody deletes, and deleting it is the whole failure.
-
-    So the verdict now comes from sealing a v1 envelope the way a stored row
-    was sealed and asking the public API to open it. Refactors are invisible to
-    that; anything that stops a stored row opening is not, wherever the change
-    lives. The AST probe survives only to name which pieces went missing in the
-    failure message, and it no longer decides anything on its own.
-
-WHY THIS IS A PROOF AND NOT A TEST
-    Step 4 of docs/design/byok-aad-v2-migration.md is the only irreversible
-    step in that plan. A v1 envelope that outlives the deletion is not a
-    revertable bug: the associated data that seals both the ciphertext and the
-    KMS-wrapped DEK cannot be reconstructed once no implementation of the v1
-    encoding exists, so the customer's provider key is gone. Everything else in
-    the migration has a rollback row in §5. This one has "do not attempt this
-    step until you are willing not to roll it back."
-
-    What made it worth writing as a proof is the shape of the evidence. Until
-    now the precondition for that irreversible step was a sentence in a
-    markdown table: "clean audit: no BYOK or Broadcast secret rows existed".
-    Nothing executes a sentence. Nothing dates it, re-runs it, or notices when
-    it stops being true. This gate does not verify the migration — it verifies
-    that somebody ran the precondition, on each cloud, and that the run
-    established something.
-
-THE REAL NEAR-MISS THIS ENCODES
-    On 2026-08-15 the migration doc shows step 3 green on all three clouds. On
-    AWS and Azure step 3 was a **read-only audit that found no rows to
-    rewrite**. That is not the same claim as GCP's "7 migrated, 0 v1 after an
-    independent audit", but the table renders them identically — and an audit
-    that returns nothing looks exactly the same whether the database is
-    migrated, empty, or unreachable behind a bad cursor or the wrong
-    credentials. See tests/test_byok_v1_precondition.py for the outcome split
-    that makes those cases distinguishable; this file is what refuses to let
-    the ambiguous one authorise a deletion.
-
-SCOPE LIMIT — what this gate does NOT establish
-    * It does not prove no v1 envelope exists. It proves that a precondition
-      run which could distinguish "none" from "did not look" was recorded for
-      each cloud. The truth of those runs rests on the databases they queried,
-      at the moment they queried them.
-    * It cannot see `quill-cloud-proxy`. The enclave has its own `Algorithm`
-      constant and its own v1 branch in `byokcache/cache.go`, and removing v1
-      there is a separate decision this repository has no visibility into.
-      Ordering across the two repos remains a human responsibility.
-    * The behavioural probe opens a v1 envelope wrapped by the local/test key
-      wrapper (`KeyWrapperConfig(environment="test")`). It establishes that the
-      v1 AAD path and the algorithm dispatch still work; it does not exercise
-      the KMS wrapper, so a v1 regression that lives only in `GcpKmsKeyWrapper`
-      is out of scope here.
-    * It probes the two public decrypt entry points. A caller that reaches a v1
-      envelope by some other route is not covered, and neither is a v1 branch
-      that some *other* module reimplements privately — but note that a v1 row
-      which those two functions refuse is already unopenable in production,
-      which is the condition the gate cares about.
-    * The v1 wire format (`V1_ALGORITHM` and `_v1_aad` below) is pinned here
-      rather than imported, because it has to stay expressible in the tree
-      where step 4 has deleted the originals. A pin can drift; while `_aad`
-      still exists, `test_the_pinned_v1_format_is_the_one_the_module_seals`
-      holds them equal.
-    * Nothing stops someone deleting this file along with v1. No in-repo guard
-      can prevent that; what it can do is make the deliberate version of the
-      edit cost a sentence in a pull request instead of nothing at all.
+The fixture carries the retired wire format only in test code. Production must
+never regain a V1 constant, encoder, or fallback branch.
 """
 
 from __future__ import annotations
 
 import ast
-import secrets as secrets_module
-import sys
-import types
-import uuid
-from dataclasses import dataclass
+import secrets
 from pathlib import Path
 from typing import Any
 
 import pytest
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
+from trusted_router import byok_crypto
 from trusted_router.byok_v1_attestations import (
-    OUTCOME_CLEAN,
     STANDALONE_CLOUDS,
-    empty_ledger,
     load_ledger,
-    surface_fingerprint,
     zero_v1_blockers,
 )
 from trusted_router.key_management import KeyWrapperConfig
 from trusted_router.storage_models import EncryptedSecretEnvelope
 
 REPO = Path(__file__).resolve().parents[1]
+PRODUCTION_SRC = REPO / "src" / "trusted_router"
 BYOK_CRYPTO = REPO / "src" / "trusted_router" / "byok_crypto.py"
 NAMESPACE_PROPERTY_TEST = REPO / "tests" / "test_byok_aad_namespace_property.py"
-CHECK_SCRIPT = "scripts/check_no_v1_envelopes.py"
-
-#: Pinned rather than imported. This module must still load — and still explain
-#: itself — in the tree where `ALGORITHM` has just been deleted, which is
-#: precisely the tree it is here to judge.
 V1_ALGORITHM = "TR-BYOK-ENVELOPE-AES-256-GCM-V1"
-
-#: The local/test wrapping path, so the probe needs no KMS. See the scope limit.
 PROBE_SETTINGS = KeyWrapperConfig(environment="test")
 
 
 def _v1_aad(workspace_id: str, context: str) -> bytes:
-    """The v1 associated data, as it was sealed into the rows that exist.
-
-    Pinned, not imported, for the same reason as `V1_ALGORITHM`: a stored row
-    carries these bytes whatever the module later calls the function that
-    produced them, and the probe has to keep working after step 4 deletes
-    `_aad`. `test_the_pinned_v1_format_is_the_one_the_module_seals` holds this
-    equal to the real `_aad` while the real one exists.
-    """
     return f"trustedrouter:byok:{workspace_id}:{context}".encode()
 
 
-#: The migration doc's step 4 says to delete this test along with v1. Until
-#: then it is the standing record of the v1 collision, and deleting it early
-#: would erase the reason any of this exists.
-V1_COLLISION_RECORD = "test_aad_encoding_is_not_injective_in_general"
-
-
-@dataclass(frozen=True)
-class V1Support:
-    """What `byok_crypto.py`'s SOURCE still mentions of the v1 envelope format.
-
-    Descriptive only. `present` here is not the gate's verdict — a refactor can
-    move any of these and keep v1 working perfectly, and an entry-point guard
-    can leave all three in place and break it. `v1_envelope_opens()` decides;
-    this explains.
-    """
-
-    algorithm_constant: str | None
-    has_aad_builder: bool
-    dispatch_selects_v1: bool
-
-    @property
-    def present(self) -> bool:
-        return not self.missing
-
-    @property
-    def missing(self) -> tuple[str, ...]:
-        gaps: list[str] = []
-        if self.algorithm_constant != V1_ALGORITHM:
-            gaps.append(
-                f"the ALGORITHM constant (found {self.algorithm_constant!r}, "
-                f"expected {V1_ALGORITHM!r})"
-            )
-        if not self.has_aad_builder:
-            gaps.append("the _aad v1 associated-data builder")
-        if not self.dispatch_selects_v1:
-            gaps.append("the v1 branch of _envelope_aad")
-        return tuple(gaps)
-
-
-def probe_v1_support(source: str) -> V1Support:
-    """Read the module's AST for the three pieces step 4 removes.
-
-    An AST walk rather than a grep because the v1 algorithm string also appears
-    in this file's own prose, in the module docstring of `byok_crypto.py`, and
-    in comments — a grep would keep reporting v1 as present long after the code
-    implementing it was gone, which is the failure mode that makes a guard
-    worthless.
-
-    `ast.AnnAssign` is matched as well as `ast.Assign`: `ALGORITHM: Final[str] =
-    "…"` is the same constant, and reading it as an absence used to turn a type
-    annotation into a CI failure about permanently unreadable customer keys.
-    """
-    tree = ast.parse(source)
-    algorithm_constant: str | None = None
-    has_aad_builder = False
-    dispatcher: ast.FunctionDef | None = None
-
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Assign | ast.AnnAssign):
-            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
-            for target in targets:
-                if isinstance(target, ast.Name) and target.id == "ALGORITHM":
-                    if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
-                        algorithm_constant = node.value.value
-        elif isinstance(node, ast.FunctionDef):
-            if node.name == "_aad":
-                has_aad_builder = True
-            elif node.name == "_envelope_aad":
-                dispatcher = node
-
-    dispatch_selects_v1 = False
-    if dispatcher is not None:
-        compares_algorithm = any(
-            isinstance(node, ast.Compare)
-            and any(
-                isinstance(comparator, ast.Name) and comparator.id == "ALGORITHM"
-                for comparator in node.comparators
-            )
-            for node in ast.walk(dispatcher)
-        )
-        calls_v1_builder = any(
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id == "_aad"
-            for node in ast.walk(dispatcher)
-        )
-        dispatch_selects_v1 = compares_algorithm and calls_v1_builder
-
-    return V1Support(
-        algorithm_constant=algorithm_constant,
-        has_aad_builder=has_aad_builder,
-        dispatch_selects_v1=dispatch_selects_v1,
-    )
-
-
-@dataclass(frozen=True)
-class V1Behaviour:
-    """Whether a stored v1 envelope still opens through the public API."""
-
-    #: True: it opened. False: it did not. None: the probe could not be built,
-    #: so this says nothing and the AST probe is all there is.
-    opens: bool | None
-    reason: str
-
-    @property
-    def removed(self) -> bool:
-        """True only for a definite refusal. `None` is never treated as removal.
-
-        An indeterminate probe must not fire the gate: the message it prints is
-        a multi-line warning about unrecoverable customer keys, and printing it
-        because an import failed is how a guard gets deleted.
-        """
-        return self.opens is False
-
-
-def load_module(source: str, name: str = "byok_crypto_under_probe") -> types.ModuleType:
-    """Execute `source` as a module, so the probe can run against a mutation.
-
-    The mutation tests below edit the real `byok_crypto.py` text and need the
-    edited version to be *callable*, not merely parseable. Registered in
-    `sys.modules` under a scratch name while it executes, because dataclass and
-    typing machinery resolves `__module__` through there.
-
-    The `exec` is the point rather than a shortcut: the input is always this
-    repository's own source file, read from disk, optionally with a mutation
-    this file wrote. Nothing external reaches it.
-    """
-    module = types.ModuleType(name)
-    module.__file__ = str(BYOK_CRYPTO)
-    sys.modules[name] = module
-    try:
-        exec(compile(source, str(BYOK_CRYPTO), "exec"), module.__dict__)  # noqa: S102
-    finally:
-        sys.modules.pop(name, None)
-    return module
-
-
-def seal_v1(module: types.ModuleType, secret: str, *, workspace_id: str, context: str) -> Any:
-    """Build the envelope a pre-migration row holds, using only v2-era helpers.
-
-    Deliberately does not touch `ALGORITHM` or `_aad`: the algorithm string and
-    the AAD bytes are pinned above, exactly as a stored row carries them. So
-    retargeting the constant, renaming the builder, or deleting either is
-    invisible to the sealing side and shows up only where it matters — in
-    whether the module can still open the result.
-    """
-    dek = secrets_module.token_bytes(32)
-    nonce = secrets_module.token_bytes(12)
-    dek_nonce = secrets_module.token_bytes(12)
+def _v1_envelope(*, workspace_id: str, context: str) -> EncryptedSecretEnvelope:
+    """Seal an opaque fixture exactly as the retired implementation did."""
+    plaintext = b"retired-v1-fixture"  # noqa: S105 - synthetic crypto fixture
+    dek = secrets.token_bytes(32)
+    nonce = secrets.token_bytes(12)
+    dek_nonce = secrets.token_bytes(12)
     aad = _v1_aad(workspace_id, context)
     return EncryptedSecretEnvelope(
         algorithm=V1_ALGORITHM,
-        key_ref=module._key_ref(PROBE_SETTINGS),
-        encrypted_dek=module._b64(module._wrap_dek(dek, dek_nonce, aad, PROBE_SETTINGS)),
-        dek_nonce=module._b64(dek_nonce),
-        ciphertext=module._b64(AESGCM(dek).encrypt(nonce, secret.encode(), aad)),
-        nonce=module._b64(nonce),
+        key_ref=byok_crypto._key_ref(PROBE_SETTINGS),
+        encrypted_dek=byok_crypto._b64(
+            byok_crypto._wrap_dek(dek, dek_nonce, aad, PROBE_SETTINGS)
+        ),
+        dek_nonce=byok_crypto._b64(dek_nonce),
+        ciphertext=byok_crypto._b64(AESGCM(dek).encrypt(nonce, plaintext, aad)),
+        nonce=byok_crypto._b64(nonce),
     )
 
 
-def v1_envelope_opens(module: types.ModuleType) -> V1Behaviour:
-    """The gate's actual question: can a stored v1 row still be decrypted?
+@pytest.mark.parametrize("family", ("provider", "control", "user_model"))
+def test_retired_v1_envelopes_are_rejected_before_unwrap(family: str) -> None:
+    workspace_id = "workspace-step4-fixture"
+    context = {
+        "provider": "openai",
+        "control": "broadcast:fixture:api_key",
+        "user_model": "user_model_signing",
+    }[family]
+    envelope = _v1_envelope(workspace_id=workspace_id, context=context)
 
-    Both public entry points are tried, because they dispatch differently —
-    `decrypt_control_secret` picks the namespace from the algorithm — and
-    because rejecting v1 at either one is enough to make a stored row
-    unopenable in production.
-    """
-    workspace_id = str(uuid.uuid4())
-    try:
-        provider_envelope = seal_v1(
-            module, "v1-provider", workspace_id=workspace_id, context="openai"
-        )
-        control_envelope = seal_v1(
-            module, "v1-control", workspace_id=workspace_id, context="broadcast:bdst_1:api_key"
-        )
-    except Exception as exc:
-        return V1Behaviour(
-            opens=None,
-            reason=(
-                f"could not seal a v1 envelope with this module's own helpers "
-                f"({type(exc).__name__}: {exc}), so the behavioural probe says nothing"
-            ),
-        )
-
-    try:
-        opened_provider = module.decrypt_byok_secret(
-            provider_envelope, PROBE_SETTINGS, workspace_id=workspace_id, provider="openai"
-        )
-    except Exception as exc:
-        return V1Behaviour(
-            opens=False,
-            reason=(
-                f"decrypt_byok_secret refused a stored v1 envelope: {type(exc).__name__}: {exc}"
-            ),
-        )
-    try:
-        opened_control = module.decrypt_control_secret(
-            control_envelope,
-            PROBE_SETTINGS,
-            workspace_id=workspace_id,
-            purpose="broadcast:bdst_1:api_key",
-        )
-    except Exception as exc:
-        return V1Behaviour(
-            opens=False,
-            reason=(
-                f"decrypt_control_secret refused a stored v1 envelope: {type(exc).__name__}: {exc}"
-            ),
-        )
-    if (opened_provider, opened_control) != ("v1-provider", "v1-control"):
-        return V1Behaviour(
-            opens=False,
-            reason="a v1 envelope decrypted to the wrong plaintext, which is worse than a refusal",
-        )
-    return V1Behaviour(opens=True, reason="a v1 envelope still opens through both entry points")
+    expected = (
+        "user-model secrets are always v2 envelopes"
+        if family == "user_model"
+        else "unsupported BYOK envelope algorithm"
+    )
+    with pytest.raises(ValueError, match=expected):
+        if family == "provider":
+            byok_crypto.decrypt_byok_secret(
+                envelope,
+                PROBE_SETTINGS,
+                workspace_id=workspace_id,
+                provider=context,
+            )
+        elif family == "control":
+            byok_crypto.decrypt_control_secret(
+                envelope,
+                PROBE_SETTINGS,
+                workspace_id=workspace_id,
+                purpose=context,
+            )
+        else:
+            byok_crypto.decrypt_user_model_secret(
+                envelope,
+                PROBE_SETTINGS,
+                workspace_id=workspace_id,
+                purpose=context,
+            )
 
 
-def gate(source: str, ledger: dict[str, Any]) -> str | None:
-    """The CI verdict: a failure message, or None when there is nothing to say.
-
-    Behaviour decides. The AST probe only supplies the "what changed" lines,
-    and is consulted for a verdict solely when the behavioural probe could not
-    run at all.
-    """
-    support = probe_v1_support(source)
-    behaviour = v1_envelope_opens(load_module(source))
-    if behaviour.opens is True:
-        return None
-    if behaviour.opens is None and support.present:
-        return None
-    blockers = zero_v1_blockers(ledger)
-    if not blockers:
-        return None
-    gaps = list(support.missing) or ["nothing in the module's source text, but:"]
-    removed = "\n".join(f"  - {gap}" for gap in gaps + [behaviour.reason])
-    still_blocking = "\n".join(f"  - {blocker}" for blocker in blockers)
-    return (
-        "v1 BYOK envelope support is being removed from src/trusted_router/byok_crypto.py:\n"
-        f"{removed}\n"
-        "\n"
-        "but no zero-v1 attestation exists for every cloud. This is step 4 of\n"
-        "docs/design/byok-aad-v2-migration.md and it cannot be rolled back: a v1 envelope\n"
-        "that survives the deletion is a customer's BYOK provider key that nothing can\n"
-        "decrypt again, because the AAD sealing both the ciphertext and the wrapped DEK\n"
-        "cannot be rebuilt from a format no implementation carries.\n"
-        "\n"
-        "Every cloud must attest, not just the one you are looking at. Each is a\n"
-        "standalone deployment with its own database, AND an AWS or Azure enclave falls\n"
-        "over to the home control plane when its own cannot be dialled — so a v1 envelope\n"
-        "left in any one database can be handed to any cloud's enclave, during an outage.\n"
-        f"    uv run python {CHECK_SCRIPT} --backend <spanner|postgres> \\\n"
-        "        --cloud <" + "|".join(STANDALONE_CLOUDS) + "> --record --operator <you>\n"
-        "then commit docs/design/byok-aad-v2-attestations.json.\n"
-        "\n"
-        "Still blocking:\n"
-        f"{still_blocking}"
+def test_retired_v1_envelopes_cannot_be_forwarded_to_the_enclave() -> None:
+    envelope = _v1_envelope(
+        workspace_id="workspace-step4-fixture",
+        context="openai",
     )
 
-
-# --------------------------------------------------------------- the gate ---
-
-
-def test_v1_support_is_not_removed_before_every_cloud_attests_zero_v1() -> None:
-    """The gate itself, against the tree as committed."""
-    verdict = gate(BYOK_CRYPTO.read_text(), load_ledger())
-
-    if verdict is not None:
-        # pytest.fail rather than assert: the verdict is a multi-line
-        # instruction sheet, and assertion rewriting would print it as one
-        # escaped string. The whole value of this failure is that it reads.
-        pytest.fail(verdict, pytrace=False)
+    with pytest.raises(ValueError, match="unsupported encrypted secret envelope algorithm"):
+        byok_crypto.encrypted_secret_payload(envelope)
 
 
-def test_the_probe_sees_v1_support_in_the_module_today() -> None:
-    """Anti-vacuity, first half.
+def test_production_crypto_contains_only_the_v2_format() -> None:
+    tree = ast.parse(BYOK_CRYPTO.read_text())
+    assignments: dict[str, Any] = {}
+    functions: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    assignments[target.id] = node.value
+        elif isinstance(node, ast.FunctionDef):
+            functions.add(node.name)
 
-    The gate above is quiet today because a v1 envelope still opens. If the
-    probe had silently stopped being able to ask — an import that no longer
-    resolves, a helper it needs renamed — the gate would be quiet for the
-    opposite reason and would never fire again. This asserts the reason.
-    """
-    behaviour = v1_envelope_opens(load_module(BYOK_CRYPTO.read_text()))
-    assert behaviour.opens is True, behaviour.reason
-
-    support = probe_v1_support(BYOK_CRYPTO.read_text())
-    assert support.algorithm_constant == V1_ALGORITHM
-    assert support.has_aad_builder
-    assert support.dispatch_selects_v1
-    assert support.present
-
-
-def test_the_pinned_v1_format_is_the_one_the_module_seals() -> None:
-    """The pin above must be the real thing while the real thing exists.
-
-    `_v1_aad` and `V1_ALGORITHM` are copies of a wire format, kept so the probe
-    outlives step 4's deletions. A copy can drift, and a drifted copy makes the
-    behavioural probe report a refusal that never happened — a false CI failure
-    on the scariest message in the repository. Held equal here, and this test
-    is the one that becomes unrunnable (and should be deleted) at step 4.
-    """
-    from trusted_router import byok_crypto
-
-    assert byok_crypto.ALGORITHM == V1_ALGORITHM
-    assert byok_crypto._aad("ws", "ctx") == _v1_aad("ws", "ctx")
+    assert "ALGORITHM" not in assignments
+    assert "_aad" not in functions
+    assert V1_ALGORITHM not in BYOK_CRYPTO.read_text()
+    assert byok_crypto.ALGORITHM_V2 == "TR-BYOK-ENVELOPE-AES-256-GCM-V2"
 
 
-# ------------------------------------------- the edits it must not permit ---
+def test_every_production_secret_decryptor_is_covered_by_the_v1_rejection_fixture() -> None:
+    actual: set[tuple[str, Path]] = set()
+    for path in PRODUCTION_SRC.rglob("*.py"):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and node.name.startswith("decrypt_")
+                and node.name.endswith("_secret")
+            ):
+                actual.add((node.name, path))
+    expected = {
+        ("decrypt_byok_secret", BYOK_CRYPTO),
+        ("decrypt_control_secret", BYOK_CRYPTO),
+        ("decrypt_user_model_secret", BYOK_CRYPTO),
+    }
+    assert actual == expected, actual
 
 
-@pytest.fixture(name="v1_source")
-def _v1_source() -> str:
-    """The module as committed, while it still has v1 support to remove.
-
-    The tests below work by performing step 4's edits on the real source. Once
-    step 4 has actually been performed there is nothing left to mutate, and the
-    tests above are the ones that speak. Skipping here keeps that moment
-    legible: a failing gate plus a handful of "already removed" skips, rather
-    than mutation helpers failing about text they cannot find.
-    """
-    source = BYOK_CRYPTO.read_text()
-    if v1_envelope_opens(load_module(source)).removed:
-        pytest.skip("v1 support is already removed; the gate test above is the live one")
-    return source
+def test_retired_v1_identifier_is_confined_to_the_read_only_census() -> None:
+    allowed_symbol_files = {
+        PRODUCTION_SRC / "byok_v1_attestations.py",
+        PRODUCTION_SRC / "byok_aad_backfill.py",
+    }
+    for path in PRODUCTION_SRC.rglob("*.py"):
+        body = path.read_text()
+        if V1_ALGORITHM in body:
+            assert path == PRODUCTION_SRC / "byok_v1_attestations.py", path
+        if "V1_ALGORITHM_LITERAL" in body:
+            assert path in allowed_symbol_files, path
 
 
-def _without_function(source: str, name: str) -> str:
-    tree = ast.parse(source)
-    target = next(
-        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == name
-    )
-    return _without_lines(source, target)
+def test_committed_fleet_ledger_authorizes_step4() -> None:
+    assert zero_v1_blockers(load_ledger()) == []
 
 
-def _without_v1_dispatch(source: str) -> str:
-    """Delete the `if algorithm == ALGORITHM:` arm of `_envelope_aad`.
-
-    Located through the AST rather than by matching source text, so that
-    reformatting `byok_crypto.py` cannot turn this into a mutation that
-    silently stops mutating — a no-op mutation makes every test below pass for
-    the wrong reason.
-    """
-    tree = ast.parse(source)
-    dispatcher = next(
-        node
-        for node in ast.walk(tree)
-        if isinstance(node, ast.FunctionDef) and node.name == "_envelope_aad"
-    )
-    branch = next(
-        node
-        for node in dispatcher.body
-        if isinstance(node, ast.If)
-        and any(
-            isinstance(comparator, ast.Name) and comparator.id == "ALGORITHM"
-            for comparator in getattr(node.test, "comparators", [])
-        )
-    )
-    return _without_lines(source, branch)
-
-
-def _without_algorithm_constant(source: str) -> str:
-    tree = ast.parse(source)
-    assignment = next(
-        node
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Assign)
-        and any(
-            isinstance(target, ast.Name) and target.id == "ALGORITHM" for target in node.targets
-        )
-    )
-    return _without_lines(source, assignment)
-
-
-def _algorithm_constant_retargeted(source: str) -> str:
-    """The subtle one: the constant survives, pointing at the v2 literal.
-
-    A stored v1 row then dispatches to the v2 AAD builder and fails to open,
-    which surfaces as an InvalidTag that looks like corruption rather than like
-    a migration mistake.
-    """
-    return source.replace(
-        f'ALGORITHM = "{V1_ALGORITHM}"', 'ALGORITHM = "TR-BYOK-ENVELOPE-AES-256-GCM-V2"'
-    )
-
-
-def _rejected_at_the_entry_points(source: str) -> str:
-    """The staged removal the migration doc's own step-4 bullet invites.
-
-    "Keep a v1-shaped envelope in a test fixture asserting it is now rejected"
-    describes exactly this edit: refuse v1 where callers arrive, leave
-    `ALGORITHM`, `_aad` and the dispatch arm physically in place for now. Every
-    stored v1 row is permanently unopenable the moment it ships, and the
-    source-reading version of this gate had nothing to say about it.
-    """
-    guard = (
-        "    if envelope.algorithm != ALGORITHM_V2:\n"
-        '        raise ValueError("v1 BYOK envelopes are no longer supported")\n'
-    )
-    mutated = source.replace(
-        "    aad = _envelope_aad(envelope.algorithm, NAMESPACE_PROVIDER, workspace_id, provider)",
-        guard
-        + "    aad = _envelope_aad(envelope.algorithm, NAMESPACE_PROVIDER, workspace_id, provider)",
-    )
-    return mutated.replace(
-        "    namespace = NAMESPACE_CONTROL if envelope.algorithm == ALGORITHM_V2 "
-        "else NAMESPACE_PROVIDER",
-        guard + "    namespace = NAMESPACE_CONTROL",
-    )
-
-
-def _rejected_only_for_control_secrets(source: str) -> str:
-    """Half of the above: BYOK keeps working, broadcast secrets stop opening.
-
-    A partial removal is the likelier accident, and it is just as unrecoverable
-    for the rows it touches.
-    """
-    return source.replace(
-        "    namespace = NAMESPACE_CONTROL if envelope.algorithm == ALGORITHM_V2 "
-        "else NAMESPACE_PROVIDER",
-        "    if envelope.algorithm != ALGORITHM_V2:\n"
-        '        raise ValueError("v1 control-plane envelopes are no longer supported")\n'
-        "    namespace = NAMESPACE_CONTROL",
-    )
-
-
-def _without_lines(source: str, node: ast.stmt) -> str:
-    lines = source.splitlines(keepends=True)
-    assert node.end_lineno is not None
-    del lines[node.lineno - 1 : node.end_lineno]
-    return "".join(lines)
-
-
-@pytest.mark.parametrize(
-    ("mutate", "expected_gap"),
-    [
-        (_without_v1_dispatch, "the v1 branch of _envelope_aad"),
-        (lambda source: _without_function(source, "_aad"), "the _aad v1 associated-data builder"),
-        (_without_algorithm_constant, "the ALGORITHM constant"),
-        (_algorithm_constant_retargeted, "the ALGORITHM constant"),
-        (_rejected_at_the_entry_points, "decrypt_byok_secret refused"),
-        (_rejected_only_for_control_secrets, "decrypt_control_secret refused"),
-    ],
-)
-def test_the_gate_fires_on_each_half_of_the_v1_deletion(
-    v1_source: str, mutate: Any, expected_gap: str
-) -> None:
-    """Every way v1 stops opening, one at a time, on the real module.
-
-    Partial removals matter as much as the whole edit: deleting the dispatch
-    branch alone already makes every stored v1 envelope unreadable, and it is
-    the smallest diff that does so. The last two entries are the edits that
-    leave the source text looking untouched — the gate's previous shape passed
-    them both.
-    """
-    mutated = mutate(v1_source)
-    assert mutated != v1_source, "the mutation did not apply"
-
-    behaviour = v1_envelope_opens(load_module(mutated))
-    verdict = gate(mutated, load_ledger())
-
-    assert behaviour.removed, behaviour.reason
-    reported = list(probe_v1_support(mutated).missing) + [behaviour.reason]
-    assert any(expected_gap in line for line in reported), reported
-    assert verdict is not None, "v1 was removed with no attestation and the gate stayed quiet"
-    assert CHECK_SCRIPT in verdict
-    for cloud in STANDALONE_CLOUDS:
-        assert cloud in verdict, "the failure must name every cloud that still owes a run"
-
-
-def test_the_gate_permits_the_removal_once_every_cloud_attests(v1_source: str) -> None:
-    """Not a "never delete v1" test, which would simply be deleted.
-
-    The gate exists to sequence the work, not to forbid it. Given a ledger in
-    which all three deployments attest zero v1 envelopes, the same edit the
-    test above rejects is allowed through without further argument.
-    """
-    ledger = _full_ledger()
-    assert zero_v1_blockers(ledger) == []
-
-    assert gate(_without_v1_dispatch(v1_source), ledger) is None
-    assert gate(_rejected_at_the_entry_points(v1_source), ledger) is None
-
-
-def _full_ledger() -> dict[str, Any]:
-    ledger = empty_ledger()
-    for cloud in STANDALONE_CLOUDS:
-        ledger["attestations"][cloud] = {
-            "cloud": cloud,
-            "outcome": OUTCOME_CLEAN,
-            "recorded_at": "2026-09-01T00:00:00+00:00",
-            "backend": "spanner",
-            "surface_fingerprint": surface_fingerprint(),
-            "rows_scanned": 12,
-            "rows_scanned_by_kind": {"byok": 12},
-            "envelopes_seen": 12,
-            "v1_envelopes": 0,
-            "v2_envelopes": 12,
-            "missing_envelopes": 0,
-            "census_migrated_kind_counts": {"byok": 12},
-            "census_sampled_kinds": ["byok", "workspace"],
-            "census_v1_literal_rows": 0,
-            "census_source": (
-                f"spanner:projects/tr-{cloud}/instances/i/databases/d"
-                " (from CLI arguments, not asked of the server)"
-            ),
-            "operator": "release-engineer@lorehex.co",
-            "note": "step 4 precondition",
-        }
-    return ledger
-
-
-def test_one_cloud_short_of_a_full_ledger_still_refuses(v1_source: str) -> None:
-    """There is no per-cloud version of this permission.
-
-    An AWS enclave that can no longer read v1 is broken by a v1 envelope in the
-    GCP database, because it falls over to the home control plane whenever its
-    own is undialable (byok_v1_attestations, "WHY EVERY CLOUD"). So dropping
-    every cloud but one from the ledger must still refuse the edit, whichever
-    cloud is the one left owing.
-    """
+def test_every_cloud_remains_required_by_the_fleet_gate() -> None:
     for absent in STANDALONE_CLOUDS:
-        ledger = _full_ledger()
+        ledger = load_ledger()
         del ledger["attestations"][absent]
-
-        verdict = gate(_without_v1_dispatch(v1_source), ledger)
-
-        assert verdict is not None, f"the gate cleared with {absent} unattested"
-        assert absent in verdict
+        blockers = zero_v1_blockers(ledger)
+        assert any(absent in blocker for blocker in blockers)
 
 
-@pytest.mark.parametrize(
-    ("name", "mutate"),
-    [
-        (
-            "an ordinary comment",
-            lambda source: source.replace(
-                "def _b64(value: bytes) -> str:",
-                "def _b64(value: bytes) -> str:\n    # an ordinary comment\n",
-            ),
-        ),
-        (
-            "a Final[str] annotation on ALGORITHM",
-            lambda source: source.replace(
-                "import secrets\n", "import secrets\nfrom typing import Final\n", 1
-            ).replace(f'ALGORITHM = "{V1_ALGORITHM}"', f'ALGORITHM: Final[str] = "{V1_ALGORITHM}"'),
-        ),
-        (
-            "the v1 arm extracted into a helper",
-            lambda source: source.replace(
-                "    if algorithm == ALGORITHM:\n        return _aad(workspace_id, context)",
-                "    if algorithm == ALGORITHM:\n        return _legacy_aad(workspace_id, context)",
-            ).replace(
-                "def _aad_v2(",
-                "def _legacy_aad(workspace_id: str, context: str) -> bytes:\n"
-                "    return _aad(workspace_id, context)\n\n\ndef _aad_v2(",
-            ),
-        ),
-    ],
-)
-def test_an_unrelated_edit_to_byok_crypto_keeps_the_gate_quiet(
-    v1_source: str, name: str, mutate: Any
-) -> None:
-    """The annoyance check, which is a safety check.
-
-    The gate's failure message is a multi-line warning about customer keys
-    nothing will ever decrypt again. Printing it for a type annotation or a
-    helper extraction — both of which leave every stored v1 envelope opening
-    exactly as before — teaches the reader to ignore it, and the next reader
-    deletes it. The source-reading gate fired on the last two of these.
-    """
-    source = mutate(v1_source)
-    assert source != v1_source, f"the {name} mutation did not apply"
-    assert v1_envelope_opens(load_module(source)).opens is True
-
-    assert gate(source, load_ledger()) is None, name
+def test_a_new_encrypted_surface_invalidates_old_attestations() -> None:
+    ledger = load_ledger()
+    ledger["attestations"]["gcp"]["surface_fingerprint"] = "stale-fingerprint"
+    assert any("surface fingerprint" in blocker for blocker in zero_v1_blockers(ledger))
 
 
-# ---------------------------------------------- the record step 4 deletes ---
-
-
-def _defines(path: Path, name: str) -> bool:
-    return any(
-        isinstance(node, ast.FunctionDef) and node.name == name
-        for node in ast.walk(ast.parse(path.read_text()))
-    )
-
-
-def test_the_v1_collision_record_lives_exactly_as_long_as_v1_does() -> None:
-    """`test_aad_encoding_is_not_injective_in_general` and v1 go together.
-
-    The migration doc lists deleting that test as a step-4 item, and it is
-    correct to delete it then: it asserts `_aad("a:b", "c") == _aad("a", "b:c")`,
-    which cannot even be expressed once `_aad` is gone. Deleting it EARLIER is
-    the edit worth catching — it is the only standing record that the v1
-    encoding is not injective, and losing it while v1 envelopes are still
-    stored erases the reason the migration exists. Without this assertion that
-    early deletion shows up as nothing at all; with it, the collection error
-    that would otherwise appear becomes a sentence.
-    """
-    v1_supported = not v1_envelope_opens(load_module(BYOK_CRYPTO.read_text())).removed
-    record_kept = _defines(NAMESPACE_PROPERTY_TEST, V1_COLLISION_RECORD)
-
-    assert v1_supported == record_kept, (
-        f"{V1_COLLISION_RECORD} is "
-        f"{'present' if record_kept else 'absent'} in {NAMESPACE_PROPERTY_TEST.name} while v1 "
-        f"envelope support is {'present' if v1_supported else 'absent'} in byok_crypto.py. They "
-        "are removed together, in step 4, after every cloud attests zero v1 envelopes — never "
-        "before. If the test was renamed rather than deleted, update V1_COLLISION_RECORD here."
-    )
+def test_the_v1_collision_preservation_test_was_removed_with_v1() -> None:
+    names = {
+        node.name
+        for node in ast.walk(ast.parse(NAMESPACE_PROPERTY_TEST.read_text()))
+        if isinstance(node, ast.FunctionDef)
+    }
+    assert "test_aad_encoding_is_not_injective_in_general" not in names

--- a/tests/test_check_format_ordering.py
+++ b/tests/test_check_format_ordering.py
@@ -1193,7 +1193,7 @@ def test_written_formats_fails_closed_when_it_cannot_derive_the_format(source: s
 def test_a_rehydration_site_is_allowed_only_where_it_rebuilds_a_stored_row() -> None:
     """`EncryptedSecretEnvelope(**stored)` reads a format, it does not choose one.
 
-    Two modules do this today and both are rebuilding a database row. The
+    One module does this today and it is rebuilding a database row. The
     allowlist is a refusal boundary, not a rule: the same shape anywhere else
     refuses until someone decides which kind it is. This asserts both halves.
     """
@@ -1231,7 +1231,6 @@ def test_the_real_write_surface_writes_exactly_v2_today() -> None:
 
     assert scan.formats == frozenset({V2})
     assert tuple(site.rsplit(":", 1)[0] for site in scan.rehydration_sites) == (
-        "src/trusted_router/byok_aad_backfill.py",
         "src/trusted_router/storage_models.py",
         "src/trusted_router/storage_models.py",
         "src/trusted_router/storage_models.py",


### PR DESCRIPTION
## Summary

- remove all production BYOK AAD V1 encoding and decryption paths
- retire the mutating backfill while preserving a read-only whole-fleet census
- record fresh GCP, AWS, and Azure zero-V1 evidence with a positive-control count
- make the permanent Step 4 gates reject V1 envelopes before unwrap or enclave forwarding

## Preconditions

- Step 3 completed on 2026-08-15 and remained idle for 14 days
- GCP: 11 V2 envelopes, 0 V1; 9,074,020 positive-control rows
- AWS: 0 envelopes, 0 V1; 4,939,183 positive-control rows
- Azure: 0 envelopes, 0 V1; 2,634,120 positive-control rows
- whole-table V1 literal census: zero in every standalone cloud
- all current writers and every registered secret write entry point emit V2

## Verification

- focused migration/security suite: 198 passed
- full Python suite: 7,648 passed, 346 skipped, 10 xfailed; socket-only sandbox failures rerun outside the sandbox: 64 passed
- Ruff and mypy passed
- ledger status gate passed
- Claude Opus review found no blocker; its deterministic decryptor-discovery finding and census positive-control edge case were fixed

Companion [quill-cloud-proxy PR #263](https://github.com/Lore-Hex/quill-cloud-proxy/pull/263) carries the matching V1 reader removal and all five cloud build/test/vet variants.
