### PR TITLE
deploy: drain-install mode for the AWS ops workflow

### DIFF
--- a/.github/workflows/deploy-aws-control-plane.yml
+++ b/.github/workflows/deploy-aws-control-plane.yml
@@ -15,13 +15,20 @@ name: Deploy AWS control plane
 on:
   workflow_dispatch:
     inputs:
+      mode:
+        description: "deploy = full control-plane deploy; drain-install = only install the outbox drain on the ClickHouse VM and verify cloud completeness"
+        required: false
+        default: "deploy"
+        type: choice
+        options: ["deploy", "drain-install"]
       skip_eventbridge:
         description: "Skip the EventBridge alignment section (SKIP_EVENTBRIDGE=1)"
         required: false
         default: "0"
       attestation_pcr0:
-        description: "Published enclave PCR0 pin (from trust/aws-release.json) - the script refuses to run without it; pinning is the point"
-        required: true
+        description: "Published enclave PCR0 pin (from trust/aws-release.json) - deploy mode refuses to run without it; pinning is the point"
+        required: false
+        default: ""
       bake_override_reason:
         description: "Non-empty ONLY to override the cloud bake gate (TR_CLOUD_BAKE_OVERRIDE); state the incident/justification - it is recorded in the run log"
         required: false
@@ -71,9 +78,17 @@ jobs:
       - uses: docker/setup-buildx-action@v3
 
       - name: Deploy tr-eu from this commit
+        if: ${{ inputs.mode == 'deploy' }}
         env:
           SKIP_EVENTBRIDGE: ${{ inputs.skip_eventbridge }}
           ATTESTATION_PCR0: ${{ inputs.attestation_pcr0 }}
           TR_CLOUD_BAKE_OVERRIDE: ${{ inputs.bake_override_reason }}
         working-directory: src
         run: bash scripts/deploy/aws_eu_control_plane.sh
+
+      - name: Install outbox drain and verify cloud completeness
+        if: ${{ inputs.mode == 'drain-install' }}
+        working-directory: src
+        run: |
+          bash scripts/deploy/aws_eu_clickhouse_drain_install.sh
+          bash scripts/deploy/verify_cloud_complete.sh aws


### PR DESCRIPTION
Adds a `mode` choice input: `drain-install` runs aws_eu_clickhouse_drain_install.sh + verify_cloud_complete.sh aws via SSM under the existing OIDC role — closing the completeness gap the last deploy run reported, from CI, with no operator token window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)