### PR TITLE
Pilot flip: enable Stage A spend-lease issuance for Synthetic Monitoring

### DIFF
--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -479,35 +479,9 @@ if [ "$REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED" = "true" ]; then
   regional_quota_preflight_issuance_fleet
 fi
 
-# Stage A advisory spend leases follow the regional pilot's preserve-live
-# idiom. A fresh deployment writes the explicit false marker; later rollouts
-# retain operator configuration unless the invoking environment overrides it.
-SPEND_LEASE_ISSUANCE_ENABLED="${TR_SPEND_LEASE_ISSUANCE_ENABLED:-$(
-  read_primary_regional_quota_env "TR_SPEND_LEASE_ISSUANCE_ENABLED" "false"
-)}"
-case "$SPEND_LEASE_ISSUANCE_ENABLED" in
-  true|false) ;;
-  *)
-    log "refusing rollout: TR_SPEND_LEASE_ISSUANCE_ENABLED must be true or false"
-    exit 1
-    ;;
-esac
-SPEND_LEASE_PILOT_WORKSPACE_IDS="${TR_SPEND_LEASE_PILOT_WORKSPACE_IDS:-$(
-  read_primary_regional_quota_env "TR_SPEND_LEASE_PILOT_WORKSPACE_IDS"
-)}"
-SPEND_LEASE_SIGNING_SECRET_NAME="${TR_SPEND_LEASE_SIGNING_SECRET_NAME:-$(
-  read_primary_regional_quota_env "TR_SPEND_LEASE_SIGNING_SECRET_NAME"
-)}"
 SPEND_LEASE_ACCEPTED_GCP_IMAGE_DIGESTS="${TR_SPEND_LEASE_ACCEPTED_GCP_IMAGE_DIGESTS:-$(
   read_primary_regional_quota_env "TR_SPEND_LEASE_ACCEPTED_GCP_IMAGE_DIGESTS"
 )}"
-if [ "$SPEND_LEASE_ISSUANCE_ENABLED" = "true" ] && {
-  [ -z "$SPEND_LEASE_PILOT_WORKSPACE_IDS" ] ||
-  [ -z "$SPEND_LEASE_SIGNING_SECRET_NAME" ];
-}; then
-  log "refusing rollout: spend-lease issuance requires pilot workspaces and a signing secret name"
-  exit 1
-fi
 
 # Prefer the private three-replica ClickHouse load balancer once provisioned.
 # The direct node-1 address remains only as a migration fallback for projects
@@ -714,10 +688,15 @@ ENV_VARS=(
   "TR_REGIONAL_QUOTA_LEASE_SHARD_COUNT=${REGIONAL_QUOTA_LEASE_SHARD_COUNT}"
   "TR_REGIONAL_QUOTA_BIGTABLE_TABLE=${REGIONAL_QUOTA_BIGTABLE_TABLE}"
   "TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES=${REGIONAL_QUOTA_BIGTABLE_APP_PROFILES}"
-  # Stage A advisory spend-lease issuance and its allowlisted pilot.
-  "TR_SPEND_LEASE_ISSUANCE_ENABLED=${SPEND_LEASE_ISSUANCE_ENABLED}"
-  "TR_SPEND_LEASE_PILOT_WORKSPACE_IDS=${SPEND_LEASE_PILOT_WORKSPACE_IDS}"
-  "TR_SPEND_LEASE_SIGNING_SECRET_NAME=${SPEND_LEASE_SIGNING_SECRET_NAME}"
+  # 2026-08-29 pilot: TrustedRouter Synthetic Monitoring workspace only
+  # (first-party traffic). Shadow grants are authoritative=false and escrow
+  # nothing. Revert by removing these three pins and redeploying.
+  # Deliberately non-sticky: pilot state is source-controlled; the sticky idiom
+  # is for operator-set values, and a source default cannot override an existing
+  # deployed marker.
+  "TR_SPEND_LEASE_ISSUANCE_ENABLED=true"
+  "TR_SPEND_LEASE_PILOT_WORKSPACE_IDS=d385c399-b245-4147-a528-0a4f6f170c71"
+  "TR_SPEND_LEASE_SIGNING_SECRET_NAME=trustedrouter-spend-lease-signing-seed"
   "TR_SPEND_LEASE_ACCEPTED_GCP_IMAGE_DIGESTS=${SPEND_LEASE_ACCEPTED_GCP_IMAGE_DIGESTS}"
 )
 SET_ENV_VARS="$(IFS='|'; echo "^|^${ENV_VARS[*]}")"


### PR DESCRIPTION
Joseph's pilot flip, control-plane half (pairs with quill-cloud-proxy#264, merged). Issuance turns on for exactly one workspace — **TrustedRouter Synthetic Monitoring** (first-party traffic, zero customer exposure). Shadow grants carry `authoritative=false`, escrow nothing, and the enclave's Stage A verifier refuses authoritative tokens by construction; either half alone is fail-closed.

Review history worth recording: the first draft hardcoded pins past the sticky-env machinery (finding); the rework flipped defaults instead (my instruction — **wrong**, because `read_primary_regional_quota_env` returns prod's existing explicit `false` marker over any source default, verified on the live service — the flip would have silently never flipped); final form pins explicitly with the dead machinery removed and the reasoning in-comment.

Gate: three env names appear exactly once each; zero orphaned shell vars; focused settings test, ruff, mypy green; full suite 7,653 passed (socket-bind sandbox exclusions only). Needs admin merge.

Authored by Sol (codex-cli); reviewed by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)