### PR TITLE
infra: terraform root for the static cloud plumbing

### DIFF
--- a/.github/workflows/deploy-aws-control-plane.yml
+++ b/.github/workflows/deploy-aws-control-plane.yml
@@ -15,13 +15,20 @@ name: Deploy AWS control plane
 on:
   workflow_dispatch:
     inputs:
+      mode:
+        description: "deploy = full control-plane deploy; drain-install = only install the outbox drain on the ClickHouse VM and verify cloud completeness"
+        required: false
+        default: "deploy"
+        type: choice
+        options: ["deploy", "drain-install"]
       skip_eventbridge:
         description: "Skip the EventBridge alignment section (SKIP_EVENTBRIDGE=1)"
         required: false
         default: "0"
       attestation_pcr0:
-        description: "Published enclave PCR0 pin (from trust/aws-release.json) - the script refuses to run without it; pinning is the point"
-        required: true
+        description: "Published enclave PCR0 pin (from trust/aws-release.json) - deploy mode refuses to run without it; pinning is the point"
+        required: false
+        default: ""
       bake_override_reason:
         description: "Non-empty ONLY to override the cloud bake gate (TR_CLOUD_BAKE_OVERRIDE); state the incident/justification - it is recorded in the run log"
         required: false
@@ -71,9 +78,17 @@ jobs:
       - uses: docker/setup-buildx-action@v3
 
       - name: Deploy tr-eu from this commit
+        if: ${{ inputs.mode == 'deploy' }}
         env:
           SKIP_EVENTBRIDGE: ${{ inputs.skip_eventbridge }}
           ATTESTATION_PCR0: ${{ inputs.attestation_pcr0 }}
           TR_CLOUD_BAKE_OVERRIDE: ${{ inputs.bake_override_reason }}
         working-directory: src
         run: bash scripts/deploy/aws_eu_control_plane.sh
+
+      - name: Install outbox drain and verify cloud completeness
+        if: ${{ inputs.mode == 'drain-install' }}
+        working-directory: src
+        run: |
+          bash scripts/deploy/aws_eu_clickhouse_drain_install.sh
+          bash scripts/deploy/verify_cloud_complete.sh aws

--- a/.github/workflows/infra-apply.yml
+++ b/.github/workflows/infra-apply.yml
@@ -1,0 +1,77 @@
+# This workflow itself must be in the WIF provider allowlist. The Terraform in
+# infra/ manages that allowlist; chicken-and-egg is resolved by the operator
+# adding infra-apply.yml once by hand (already scripted for the operator).
+
+name: Terraform static infrastructure
+
+on:
+  pull_request:
+    paths:
+      - "infra/**"
+  push:
+    branches:
+      - main
+    paths:
+      - "infra/**"
+  workflow_dispatch:
+
+concurrency:
+  group: infra-apply
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+
+      - name: Check Terraform formatting
+        run: terraform -chdir=infra fmt -check
+
+      - name: Initialize Terraform without backend
+        run: terraform -chdir=infra init -backend=false
+
+      - name: Validate Terraform
+        run: terraform -chdir=infra validate
+
+  apply:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      # Keep the repository below the workspace root. The GCP auth action
+      # writes gha-creds-* into that root, so src/ remains a clean work tree.
+      - uses: actions/checkout@v4
+        with:
+          path: src
+
+      - name: Authenticate to AWS via GitHub OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::330422590279:role/tr-router-github-deploy
+          aws-region: eu-west-3
+
+      - name: Authenticate to GCP via WIF
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: projects/44325983244/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v3
+
+      - uses: hashicorp/setup-terraform@v3
+
+      - name: Plan static infrastructure
+        run: terraform -chdir=src/infra init && terraform -chdir=src/infra plan -out=tfplan
+
+      - name: Apply reviewed plan
+        run: terraform -chdir=src/infra apply tfplan

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,64 @@
+# TrustedRouter static cloud infrastructure
+
+This Terraform root owns static, rarely changing cloud plumbing whose drift
+would otherwise be silent. Changes to these resources should be reviewed as
+pull requests. Release and deployment procedures remain owned by the scripts
+under `scripts/deploy/`; Terraform must not absorb those procedures.
+
+## Scope boundary
+
+Terraform manages only the resources declared in this directory: the GitHub
+AWS deploy role and policies, the AWS EU synthetic-monitoring rule/target,
+DLQ/policies/alarms/topic, and the existing GCP GitHub workload identity pool
+provider allowlist.
+
+The following remain outside Terraform:
+
+- The EventBridge connection `tr-eu-synthetic`. Its API-key value must never
+  enter Terraform state; `scripts/deploy/aws_eu_control_plane.sh` owns its
+  re-authentication.
+- App Runner, ECR, DSQL, and the enclave NLBs. They are deploy-owned or
+  data-plane resources.
+- The dead IAM user and access keys formerly used by the deleted `TR_AWS_*`
+  secrets. Key-based CI authentication is retired and must not be recreated.
+
+The GCS state bucket `tr-infra-tfstate-quill-cloud-proxy` is also pre-existing
+bootstrap infrastructure. This root uses it but does not manage it.
+
+## Running Terraform
+
+Terraform 1.6 or newer is required. Authenticate to AWS account `330422590279`
+and GCP project `quill-cloud-proxy`, then run from the repository root:
+
+```bash
+terraform -chdir=infra fmt -check
+terraform -chdir=infra init
+terraform -chdir=infra validate
+terraform -chdir=infra plan -out=tfplan
+terraform -chdir=infra apply tfplan
+```
+
+For credential-free structural validation, initialize without the backend:
+
+```bash
+terraform -chdir=infra init -backend=false
+terraform -chdir=infra validate
+```
+
+## Existing-resource imports
+
+Every declared resource already exists. `imports.tf` uses Terraform's
+declarative import blocks, so the first state-writing apply adopts those live
+objects instead of creating them. No separate `terraform import` commands are
+required. Keep the import blocks until the first apply has completed and the
+state is safely stored in GCS.
+
+Before the first apply, inspect the complete plan. It must show no changes
+except adding `.github/workflows/infra-apply.yml@refs/heads/main` to the GCP WIF
+condition. Any other proposed update, replacement, creation, or destruction
+means the configuration does not exactly mirror live state. Fix the Terraform
+configuration; do not change the cloud to fit it.
+
+The apply workflow itself needs GCP WIF before it can update the WIF allowlist.
+That chicken-and-egg bootstrap is resolved by an operator adding
+`infra-apply.yml` once by hand (the operator command is already scripted).

--- a/infra/aws_deploy_role.tf
+++ b/infra/aws_deploy_role.tf
@@ -1,0 +1,70 @@
+resource "aws_iam_role" "tr_router_github_deploy" {
+  name = "tr-router-github-deploy"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Federated = "arn:aws:iam::${local.aws_account_id}:oidc-provider/token.actions.githubusercontent.com"
+      }
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+        }
+        StringLike = {
+          "token.actions.githubusercontent.com:sub" = "repo:${local.github_owner}/quill-router:ref:refs/heads/main"
+        }
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "tr_router_github_deploy_power_user" {
+  role       = aws_iam_role.tr_router_github_deploy.name
+  policy_arn = "arn:aws:iam::aws:policy/PowerUserAccess"
+}
+
+resource "aws_iam_role_policy" "tr_eu_role_writes" {
+  role = aws_iam_role.tr_router_github_deploy.name
+  name = "tr-eu-role-writes"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "iam:PutRolePolicy",
+          "iam:PassRole",
+          "iam:GetRole",
+        ]
+        Resource = "arn:aws:iam::${local.aws_account_id}:role/tr-eu-*"
+      },
+      {
+        # Terraform manages this role's own inline policy; PowerUserAccess
+        # denies iam:* writes, so without this the first policy change to
+        # this very role fails. PassRole is deliberately absent here.
+        Effect = "Allow"
+        Action = [
+          "iam:PutRolePolicy",
+          "iam:GetRole",
+          "iam:GetRolePolicy",
+          "iam:ListRolePolicies",
+          "iam:ListAttachedRolePolicies",
+        ]
+        Resource = "arn:aws:iam::${local.aws_account_id}:role/tr-router-github-deploy"
+      },
+      {
+        # Read-only. The drain installer verifies the ClickHouse VM's
+        # instance profile, and PowerUserAccess denies all iam:* reads:
+        # run 33270881625 failed on exactly this. Instance-profile names
+        # are not tr-eu-prefixed, so the read is account-wide.
+        Effect   = "Allow"
+        Action   = "iam:GetInstanceProfile"
+        Resource = "arn:aws:iam::${local.aws_account_id}:instance-profile/*"
+      },
+    ]
+  })
+}

--- a/infra/aws_synthetic_monitoring.tf
+++ b/infra/aws_synthetic_monitoring.tf
@@ -1,0 +1,108 @@
+# Intentionally not managed here: the tr-eu-synthetic EventBridge connection
+# (scripts/deploy/aws_eu_control_plane.sh owns its secret-bearing re-auth), App
+# Runner, ECR, DSQL, and enclave NLBs. Those are deploy-owned or data-plane.
+
+resource "aws_cloudwatch_event_rule" "tr_eu_synthetic_1min" {
+  name                = "tr-eu-synthetic-1min"
+  schedule_expression = "rate(2 minutes)"
+  state               = "ENABLED"
+}
+
+resource "aws_sqs_queue" "tr_eu_synthetic_dlq" {
+  name = "tr-eu-synthetic-dlq"
+}
+
+resource "aws_sqs_queue_policy" "tr_eu_synthetic_dlq" {
+  queue_url = aws_sqs_queue.tr_eu_synthetic_dlq.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid    = "AllowEventBridgeRuleToSendToDLQ"
+      Effect = "Allow"
+      Principal = {
+        Service = "events.amazonaws.com"
+      }
+      Action   = "sqs:SendMessage"
+      Resource = aws_sqs_queue.tr_eu_synthetic_dlq.arn
+      Condition = {
+        ArnEquals = {
+          "aws:SourceArn" = aws_cloudwatch_event_rule.tr_eu_synthetic_1min.arn
+        }
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "tr_eu_synthetic_dlq_send" {
+  role = "tr-eu-eventbridge-invoke-par"
+  name = "tr-eu-synthetic-dlq-send"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid      = "SendSyntheticFailuresToDLQ"
+      Effect   = "Allow"
+      Action   = "sqs:SendMessage"
+      Resource = aws_sqs_queue.tr_eu_synthetic_dlq.arn
+    }]
+  })
+}
+
+resource "aws_cloudwatch_event_target" "tr_eu_synthetic" {
+  rule      = aws_cloudwatch_event_rule.tr_eu_synthetic_1min.name
+  target_id = "synthetic"
+  arn       = "arn:aws:events:${local.aws_region}:${local.aws_account_id}:api-destination/tr-eu-synthetic-run/abd17881-6593-4db5-b3c7-e4bb7fa35e7c"
+  role_arn  = "arn:aws:iam::${local.aws_account_id}:role/tr-eu-eventbridge-invoke-par"
+
+  dead_letter_config {
+    arn = aws_sqs_queue.tr_eu_synthetic_dlq.arn
+  }
+
+  # scripts/deploy/aws_eu_control_plane.sh also writes this input. Keep both
+  # definitions identical, including this key order and every value.
+  input = jsonencode({
+    monitor_region = "eu-west-3"
+    rotation_count = 8
+    run_remediator = true
+    detach         = true
+  })
+}
+
+resource "aws_sns_topic" "tr_eu_synthetic_alarms" {
+  name = "tr-eu-synthetic-alarms"
+}
+
+resource "aws_cloudwatch_metric_alarm" "tr_eu_synthetic_failed_invocations" {
+  alarm_name          = "tr-eu-synthetic-failed-invocations"
+  alarm_description   = "EventBridge failed to invoke the AWS EU synthetic monitor"
+  namespace           = "AWS/Events"
+  metric_name         = "FailedInvocations"
+  dimensions          = { RuleName = aws_cloudwatch_event_rule.tr_eu_synthetic_1min.name }
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 3
+  datapoints_to_alarm = 1
+  threshold           = 0
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  actions_enabled     = true
+  alarm_actions       = [aws_sns_topic.tr_eu_synthetic_alarms.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "tr_eu_synthetic_dlq_messages_visible" {
+  alarm_name          = "tr-eu-synthetic-dlq-messages-visible"
+  alarm_description   = "An AWS EU synthetic invocation was dropped into the DLQ"
+  namespace           = "AWS/SQS"
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  dimensions          = { QueueName = aws_sqs_queue.tr_eu_synthetic_dlq.name }
+  statistic           = "Maximum"
+  period              = 300
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = 0
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  actions_enabled     = true
+  alarm_actions       = [aws_sns_topic.tr_eu_synthetic_alarms.arn]
+}

--- a/infra/backend.tf
+++ b/infra/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "tr-infra-tfstate-quill-cloud-proxy"
+    prefix = "infra"
+  }
+}

--- a/infra/gcp_wif.tf
+++ b/infra/gcp_wif.tf
@@ -1,0 +1,60 @@
+locals {
+  quill_router_workflow_refs = [
+    "${local.github_owner}/quill-router/.github/workflows/cloud-security-baseline.yml@refs/heads/main",
+    "${local.github_owner}/quill-router/.github/workflows/cloud-staleness.yml@refs/heads/main",
+    "${local.github_owner}/quill-router/.github/workflows/check-archive-freshness.yml@refs/heads/main",
+    "${local.github_owner}/quill-router/.github/workflows/daily-embeddings-probe.yml@refs/heads/main",
+    "${local.github_owner}/quill-router/.github/workflows/deploy.yml@refs/heads/main",
+    "${local.github_owner}/quill-router/.github/workflows/gateway-reliability.yml@refs/heads/main",
+    "${local.github_owner}/quill-router/.github/workflows/mirror-repo.yml@refs/heads/main",
+    "${local.github_owner}/quill-router/.github/workflows/refresh-prices.yml@refs/heads/main",
+    "${local.github_owner}/quill-router/.github/workflows/reshard-billing-workspace.yml@refs/heads/main",
+    "${local.github_owner}/quill-router/.github/workflows/typed-audit.yml@refs/heads/main",
+    "${local.github_owner}/quill-router/.github/workflows/deploy-aws-control-plane.yml@refs/heads/main",
+    "${local.github_owner}/quill-router/.github/workflows/infra-apply.yml@refs/heads/main",
+  ]
+
+  quill_cloud_proxy_workflow_refs = [
+    "${local.github_owner}/quill-cloud-proxy/.github/workflows/deploy-enclave-dns-reconciler.yml@refs/heads/main",
+    "${local.github_owner}/quill-cloud-proxy/.github/workflows/deploy-enclave-gcp.yml@refs/heads/main",
+    "${local.github_owner}/quill-cloud-proxy/.github/workflows/reconcile-enclave-dns.yml@refs/heads/main",
+  ]
+
+  github_attribute_condition = join(" ", [
+    "assertion.repository_owner == '${local.github_owner}'",
+    "&& assertion.repository_owner_id == '${local.github_owner_id}'",
+    "&& assertion.ref == 'refs/heads/main'",
+    "&& (",
+    "(assertion.repository == '${local.github_owner}/quill-router'",
+    "&& assertion.repository_id == '${local.quill_router_repository_id}'",
+    "&& assertion.workflow_ref in [${join(", ", formatlist("'%s'", local.quill_router_workflow_refs))}])",
+    "||",
+    "(assertion.repository == '${local.github_owner}/quill-cloud-proxy'",
+    "&& assertion.repository_id == '${local.quill_cloud_proxy_repository_id}'",
+    "&& assertion.workflow_ref in [${join(", ", formatlist("'%s'", local.quill_cloud_proxy_workflow_refs))}])",
+    ")",
+  ])
+}
+
+# !!! ADOPTION SAFETY CHECK !!!
+# THE FIRST PLAN MUST SHOW NO CHANGES except adding infra-apply.yml to this
+# condition. Any other diff means this mirror is wrong: fix the code, not the
+# cloud. In particular, do not apply a formatting-only condition rewrite.
+resource "google_iam_workload_identity_pool_provider" "github" {
+  project                            = local.gcp_project_id
+  workload_identity_pool_id          = "github-actions"
+  workload_identity_pool_provider_id = "github"
+
+  attribute_condition = local.github_attribute_condition
+  attribute_mapping = {
+    "google.subject"             = "assertion.sub"
+    "attribute.actor"            = "assertion.actor"
+    "attribute.ref"              = "assertion.ref"
+    "attribute.repository"       = "assertion.repository"
+    "attribute.repository_owner" = "assertion.repository_owner"
+  }
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}

--- a/infra/imports.tf
+++ b/infra/imports.tf
@@ -1,0 +1,63 @@
+# Every resource in this root predates Terraform. These declarative imports
+# make the initial apply an adoption; they must not be removed before that
+# state has been written successfully.
+
+import {
+  to = aws_iam_role.tr_router_github_deploy
+  id = "tr-router-github-deploy"
+}
+
+import {
+  to = aws_iam_role_policy_attachment.tr_router_github_deploy_power_user
+  id = "tr-router-github-deploy/arn:aws:iam::aws:policy/PowerUserAccess"
+}
+
+import {
+  to = aws_iam_role_policy.tr_eu_role_writes
+  id = "tr-router-github-deploy:tr-eu-role-writes"
+}
+
+import {
+  to = aws_cloudwatch_event_rule.tr_eu_synthetic_1min
+  id = "tr-eu-synthetic-1min"
+}
+
+import {
+  to = aws_cloudwatch_event_target.tr_eu_synthetic
+  id = "tr-eu-synthetic-1min/synthetic"
+}
+
+import {
+  to = aws_sqs_queue.tr_eu_synthetic_dlq
+  id = "https://sqs.eu-west-3.amazonaws.com/330422590279/tr-eu-synthetic-dlq"
+}
+
+import {
+  to = aws_sqs_queue_policy.tr_eu_synthetic_dlq
+  id = "https://sqs.eu-west-3.amazonaws.com/330422590279/tr-eu-synthetic-dlq"
+}
+
+import {
+  to = aws_iam_role_policy.tr_eu_synthetic_dlq_send
+  id = "tr-eu-eventbridge-invoke-par:tr-eu-synthetic-dlq-send"
+}
+
+import {
+  to = aws_sns_topic.tr_eu_synthetic_alarms
+  id = "arn:aws:sns:eu-west-3:330422590279:tr-eu-synthetic-alarms"
+}
+
+import {
+  to = aws_cloudwatch_metric_alarm.tr_eu_synthetic_failed_invocations
+  id = "tr-eu-synthetic-failed-invocations"
+}
+
+import {
+  to = aws_cloudwatch_metric_alarm.tr_eu_synthetic_dlq_messages_visible
+  id = "tr-eu-synthetic-dlq-messages-visible"
+}
+
+import {
+  to = google_iam_workload_identity_pool_provider.github
+  id = "projects/quill-cloud-proxy/locations/global/workloadIdentityPools/github-actions/providers/github"
+}

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    # CI's terraform validate confirms compatibility within this major line.
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+
+    # CI's terraform validate confirms compatibility within this major line.
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = local.aws_region
+}
+
+provider "google" {
+  project = local.gcp_project_id
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,16 @@
+# This root intentionally has no input variables. These are single-account
+# production constants, not deployment knobs; making them configurable would
+# imply portability that this narrowly scoped state does not have.
+locals {
+  aws_account_id = "330422590279"
+  aws_region     = "eu-west-3"
+
+  gcp_project_id     = "quill-cloud-proxy"
+  gcp_project_number = "44325983244"
+
+  github_owner    = "Lore-Hex"
+  github_owner_id = "279148885"
+
+  quill_router_repository_id      = "1227431177"
+  quill_cloud_proxy_repository_id = "1223401116"
+}

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 1.6.0"
+}


### PR DESCRIPTION
Codex-authored, reviewed against live state: all 14 live WIF workflow refs verified present with exactly one addition (infra-apply.yml); alarm/DLQ/target parameters mirrored from aws_eu_control_plane.sh with file:line refs; 12 import blocks matching 12 resources; no secret values in HCL (EventBridge connection deliberately unmanaged). Validate job runs cred-free on PRs; apply on main via the existing dual-auth pattern. State: gs://tr-infra-tfstate-quill-cloud-proxy (created, tr-deploy granted objectAdmin).

Operator one-shot (staged for Joseph): WIF allowlist entry for infra-apply.yml, workloadIdentityPoolAdmin for tr-deploy, and the widened deploy-role policy — after which the allowlist and role policy are managed here forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)