### PR TITLE
Flag monitor traffic as synthetic on every path, not just attested settle

### DIFF
--- a/docs/clickhouse-synthetic-backfill.md
+++ b/docs/clickhouse-synthetic-backfill.md
@@ -1,0 +1,129 @@
+# Backfilling `synthetic` on historical monitor rows
+
+**Status: proposed, not run. Needs Joseph's approval before any `ALTER`.**
+
+Every usage and revenue query filters `WHERE synthetic = 0`, so the synthetic
+monitoring workspace's unflagged rows are counted as real customer traffic.
+This note says exactly what to change, why the statement is safe on a
+replicated table, and the one way it can silently revert.
+
+## What is wrong
+
+Measured 2026-08-29 on `tr.activity_generations`:
+
+| | rows | tokens | cost |
+|---|---|---|---|
+| unflagged, partition `202607` | 53,838 | | |
+| unflagged, partition `202608` | 280,711 | | |
+| **unflagged, all history** | **334,549** | **25.87M** | **$63.29** |
+| flagged | 336,932 | | |
+
+Split at the moment flagging began (#623 deployed 2026-08-16 23:33:33 UTC):
+
+| | rows | tokens | cost |
+|---|---|---|---|
+| before | 330,606 | 19.60M | $54.12 |
+| after | 3,943 | 6.27M | $9.17 |
+
+The 330,606 rows before the cutover are the backfill's subject: `synthetic` did
+not exist on `Generation` then, so no code change can account for them.
+
+## Scope decision — read this before choosing a predicate
+
+The 3,943 rows *after* the cutover are not one population:
+
+* ~800 are monitor-shaped (gpt-4.1-mini, 7–13 tokens, all four monitor
+  regions, sporadic) and belong under the flag;
+* the rest, and 6.24M of the 6.27M tokens, are **not probes**. They share the
+  monitor's API key but run 100–250× larger requests (`gemma-4-31b-it` averages
+  12,541 tokens against the monitor's 47) and return
+  `finish_reason=tool_calls`, between 2026-08-25 14:58 and 2026-08-27 07:01.
+
+Flagging that second group hides real model traffic behind a "synthetic" label
+rather than classifying it. It is still first-party — the workspace is
+dedicated, and its key carries `analytics: excluded` — so it does not belong in
+customer figures either. **The recommendation is to bound the backfill at the
+cutover** and give that consumer its own key, rather than laundering it through
+the synthetic flag.
+
+## The statement
+
+```sql
+ALTER TABLE tr.activity_generations
+UPDATE synthetic = 1
+WHERE tenant_id = 'c2a8c0bced45f106d63bd6db73a51129edf7045dc5caec506caf5555df10016e'
+  AND synthetic = 0
+  AND created_at < '2026-08-16 23:33:33';
+```
+
+`tenant_id` is `analytics_surrogate("workspace", "d385c399-b245-4147-a528-0a4f6f170c71")`
+and is the first column of the sorting key `(tenant_id, created_at, generation_id)`.
+Predicating on `workspace_id` instead is equivalent but reads the whole table.
+Verified: that surrogate selects 671,491 rows, the workspace's full history.
+
+Only one workspace in the table carries `tags['analytics'] = 'excluded'`, so a
+tag-based predicate would select exactly the same rows today. It is not used
+here because tags are a `Map` and would defeat the primary index.
+
+### Why it is deterministic
+
+Mutations on a `Replicated*` table must be deterministic or replicas diverge.
+This one assigns a constant under a constant predicate: no `joinGet`, no
+`dictGet`, no `now()`, no `rand()`, no subquery. Every replica computes the
+same result from its own parts.
+
+### Issue it once, not `ON CLUSTER`
+
+`tr.activity_generations` is `ReplicatedReplacingMergeTree`, so a mutation
+entered on one replica propagates through the replicated log to the other two.
+Adding `ON CLUSTER trustedrouter` would enqueue the same mutation three times.
+Run it on one node and watch `system.mutations` on all three.
+
+### Optionally narrow by partition
+
+`PARTITION BY toYYYYMM(created_at)`, and the affected rows live only in
+`202607` and `202608`. Adding `IN PARTITION` bounds the rewrite, at the cost of
+two statements. The table is small — 4.04M rows, 415 MiB, 18 active parts — so
+this is optional.
+
+## The way this silently reverts
+
+The engine's version column is `ingest_version`. A `ReplacingMergeTree` keeps
+the row with the highest version, so **any later re-insert of a mutated row
+with a newer `ingest_version` restores `synthetic = 0`** and the backfill
+quietly disappears at the next merge.
+
+`tr-clickhouse-reconcile.service` replays historical rows from Bigtable and is
+exactly such a re-inserter. Before running the backfill, confirm it cannot
+replay the pre-cutover window — or accept that the backfill must be re-run
+after any reconcile that touches it. Bigtable's stored generations predate
+`synthetic`, so a replay reintroduces the defect at the source.
+
+This is the reason to prefer verifying with `FINAL` and to re-check a week
+later rather than declaring the backfill done when `system.mutations` reports
+`is_done = 1`.
+
+## Verification
+
+Before:
+
+```sql
+SELECT countIf(synthetic = 0) AS unflagged, countIf(synthetic = 1) AS flagged
+FROM tr.activity_generations FINAL
+WHERE tenant_id = 'c2a8c0bced45f106d63bd6db73a51129edf7045dc5caec506caf5555df10016e'
+  AND created_at < '2026-08-16 23:33:33';
+```
+
+Expect `unflagged = 330606`. After the mutation reports done on all three
+replicas, expect `unflagged = 0` and `flagged` up by 330,606 — on **each**
+replica, queried separately, not through a load balancer.
+
+Then re-run the August figure and confirm it moves by the predicted amount:
+external tokens down 19.60M and external revenue down $54.12, with the
+workspace no longer appearing in a distinct-external-workspace count.
+
+## Do not do this instead
+
+Deleting the rows. They are the monitor's own history and back the status page
+and provider benchmarks; the flag is what excludes them from customer
+analytics, and it is the thing that was missing.

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -48,6 +48,9 @@ def _is_byok(usage_type: str | UsageType) -> bool:
     return UsageType.coerce(usage_type).is_byok()
 
 
+SYNTHETIC_APP_NAME = "TrustedRouter Synthetic"
+
+
 def _is_synthetic_metadata(metadata: Any) -> bool:
     return isinstance(metadata, dict) and str(metadata.get("trustedrouter_synthetic")).lower() in (
         "1",
@@ -55,6 +58,24 @@ def _is_synthetic_metadata(metadata: Any) -> bool:
         "yes",
         "on",
     )
+
+
+def resolve_synthetic(*, metadata: Any = None, app: Any = None) -> bool:
+    """The one rule that decides whether a generation is monitor traffic.
+
+    Every ``Generation`` constructor calls this. It exists because the rule
+    used to live in ``from_settle_body`` alone: the other two constructors
+    took the ``synthetic: bool = False`` field default, so a probe that
+    settled through the direct (non-attested) path was silently indexed as
+    real customer traffic. Two independent signals, either sufficient:
+
+    * ``metadata.trustedrouter_synthetic`` -- what the probes send, and the
+      only signal that survives a settle repair (see
+      ``_settle_repair_metadata``);
+    * the reserved app name, which the gateway stamps on synthetic
+      settlements and which survives when metadata does not.
+    """
+    return _is_synthetic_metadata(metadata) or app == SYNTHETIC_APP_NAME
 
 
 def _coerce_tool_calls(value: Any) -> list[dict[str, Any]] | None:
@@ -857,6 +878,7 @@ class Generation:
                 else None
             ),
             region=region,
+            synthetic=resolve_synthetic(app=app_name),
         )
 
     @classmethod
@@ -901,6 +923,7 @@ class Generation:
             provider=provider,
             elapsed_milliseconds=_seconds_to_milliseconds(elapsed_seconds),
             region=region,
+            synthetic=resolve_synthetic(app=app_name),
         )
 
     @classmethod
@@ -926,12 +949,10 @@ class Generation:
         first_byte = max(float(first_byte_raw), 0.001) if first_byte_raw is not None else None
         client_context = parse_client_context(body.get("client"))
         gateway_request_id = parse_gateway_request_id(body.get("gateway_request_id"))
-        synthetic = _is_synthetic_metadata(body.get("metadata")) or (
-            body.get("app") == "TrustedRouter Synthetic"
-        )
+        synthetic = resolve_synthetic(metadata=body.get("metadata"), app=body.get("app"))
         app = str(body.get("app") or "TrustedRouter Gateway")
         if synthetic:
-            app = "TrustedRouter Synthetic"
+            app = SYNTHETIC_APP_NAME
         return cls(
             id=generation_id_for_authorization(authorization.id),
             request_id=str(

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -1389,6 +1389,10 @@ async def video_generation_probe(
         "aspect_ratio": "16:9",
         "generate_audio": generate_audio,
         "provider": {"only": [provider], "allow_fallbacks": False},
+        "metadata": {
+            "trustedrouter_synthetic": "true",
+            "probe": "video_generation",
+        },
     }
     started = time.perf_counter()
     try:

--- a/tests/test_synthetic_flag_provenance.py
+++ b/tests/test_synthetic_flag_provenance.py
@@ -1,0 +1,147 @@
+"""Monitor traffic must never be indexed as real customer traffic.
+
+Every usage and revenue query filters ``WHERE synthetic = 0``, so a probe whose
+generation lands with the flag off is counted as a paying customer. That has
+happened twice for structurally different reasons, and each is pinned here:
+
+* the ``/videos`` probe was the only one of six gateway request bodies in
+  ``probes.py`` built without ``metadata.trustedrouter_synthetic``;
+* ``from_chat_result`` and ``from_embeddings_result`` never set ``synthetic``
+  at all, so the direct (non-attested) path took the ``False`` field default
+  no matter what it was serving.
+
+The first test is the load-bearing one: it fails on the NEXT probe that forgets
+the marker, which is the failure mode that actually recurs.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+from typing import Any
+
+import pytest
+
+from trusted_router.storage_models import SYNTHETIC_APP_NAME, Generation
+
+PROBES_PATH = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "src"
+    / "trusted_router"
+    / "synthetic"
+    / "probes.py"
+)
+# Six bodies exist today. The assertion is ">=" so adding a probe is allowed;
+# the count guards against the test silently finding NOTHING (a rename of
+# `_api_url`, a refactor to a helper) and passing vacuously.
+MINIMUM_GATEWAY_PROBE_BODIES = 6
+
+
+def _gateway_probe_functions() -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Every probe function that posts a body to a gateway inference route."""
+    tree = ast.parse(PROBES_PATH.read_text())
+    found: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        calls_api_url = any(
+            isinstance(inner, ast.Call)
+            and isinstance(inner.func, ast.Name)
+            and inner.func.id == "_api_url"
+            for inner in ast.walk(node)
+        )
+        if calls_api_url:
+            found.append(node)
+    return found
+
+
+def _marks_synthetic(node: ast.AST) -> bool:
+    """True when this function builds a dict carrying the synthetic marker."""
+    for inner in ast.walk(node):
+        if not isinstance(inner, ast.Dict):
+            continue
+        for key in inner.keys:
+            if isinstance(key, ast.Constant) and key.value == "trustedrouter_synthetic":
+                return True
+    return False
+
+
+def test_every_gateway_probe_body_marks_itself_synthetic() -> None:
+    functions = _gateway_probe_functions()
+
+    assert len(functions) >= MINIMUM_GATEWAY_PROBE_BODIES, (
+        "found only "
+        f"{len(functions)} gateway probe functions; the discovery rule no longer "
+        "matches the code, so this test proves nothing"
+    )
+
+    unmarked = sorted(node.name for node in functions if not _marks_synthetic(node))
+    assert unmarked == [], (
+        "these probe bodies omit metadata.trustedrouter_synthetic, so their "
+        f"generations are indexed as real customer traffic: {unmarked}"
+    )
+
+
+def test_discovery_rule_is_not_vacuous() -> None:
+    """The marker check must be able to FAIL, not just pass."""
+    stripped = ast.parse('def probe():\n    url = _api_url(base, "/chat/completions")\n')
+    node = next(item for item in ast.walk(stripped) if isinstance(item, ast.FunctionDef))
+    assert not _marks_synthetic(node)
+
+
+class _StubResult:
+    request_id = "req-stub"
+    provider_name = "OpenAI"
+    input_tokens = 3
+    output_tokens = 4
+    elapsed_seconds = 0.5
+    finish_reason = "stop"
+    usage_estimated = False
+    first_token_seconds = None
+    first_byte_seconds = None
+    cached_input_tokens = 0
+    reasoning_tokens = 0
+    tool_calls = None
+
+
+@pytest.mark.parametrize(
+    ("app_name", "expected"),
+    [(SYNTHETIC_APP_NAME, True), ("TrustedRouter Gateway", False)],
+    ids=["monitor", "customer"],
+)
+def test_direct_chat_path_records_synthetic(app_name: str, expected: bool) -> None:
+    generation = Generation.from_chat_result(
+        result=_StubResult(),
+        workspace_id="ws-1",
+        key_hash="key-1",
+        model_id="openai/gpt-4.1-mini",
+        app_name=app_name,
+        actual_cost_microdollars=0,
+        usage_type="Credits",
+        streamed=False,
+        provider="openai",
+    )
+
+    assert generation.synthetic is expected
+
+
+@pytest.mark.parametrize(
+    ("app_name", "expected"),
+    [(SYNTHETIC_APP_NAME, True), ("TrustedRouter Gateway", False)],
+    ids=["monitor", "customer"],
+)
+def test_direct_embeddings_path_records_synthetic(app_name: str, expected: bool) -> None:
+    result: dict[str, Any] = {"id": "emb-1"}
+    generation = Generation.from_embeddings_result(
+        result=result,
+        workspace_id="ws-1",
+        key_hash="key-1",
+        model_id="openai/text-embedding-3-small",
+        app_name=app_name,
+        actual_cost_microdollars=0,
+        usage_type="Credits",
+        input_tokens=7,
+        provider="openai",
+    )
+
+    assert generation.synthetic is expected

--- a/tests/test_video_synthetic.py
+++ b/tests/test_video_synthetic.py
@@ -118,6 +118,13 @@ async def test_video_probe_generates_once_validates_media_and_keeps_only_metadat
             "aspect_ratio": "16:9",
             "generate_audio": False,
             "provider": {"only": [VIDEO_GENERATION_PROVIDER], "allow_fallbacks": False},
+            # Without this the video probe's generation lands with synthetic=0
+            # and is counted as real customer traffic; it was the only probe
+            # body in the file that omitted the marker.
+            "metadata": {
+                "trustedrouter_synthetic": "true",
+                "probe": "video_generation",
+            },
         }
     ]
     public = json.dumps(sample.public_dict())


### PR DESCRIPTION
Every usage and revenue query filters `WHERE synthetic = 0`, so a probe whose generation lands with the flag off is counted as a paying customer. In August, 280,711 rows on the synthetic-monitoring workspace were unflagged — **0.44% of "external" tokens but 3.8% of "external" revenue** ($50.35 of $1,312.21), plus one phantom entry in every distinct-external-workspace count. It quietly biases the traction numbers.

Three causes. Two are fixed here; the third is not a flagging bug.

### 1. The field did not exist (98.4% of the rows)

`Generation.synthetic` arrived in #623, merged 2026-08-16 22:56 UTC; the first flagged row is 23:33:33 UTC, a 37-minute merge-to-deploy gap. **276,309 of August's 280,711 unflagged rows predate it.** No code change accounts for those — see `docs/clickhouse-synthetic-backfill.md`, proposed and deliberately not run.

### 2. The video probe never marked itself

`video_generation_probe` built the one `/videos` body of the **six** gateway request bodies in `probes.py` with no `metadata.trustedrouter_synthetic`. Confirmed in production data — `veo-3.1-fast`, `ltx-2.3-fast`, `hailuo-3`, `kling/v3-pro`, `gen-4.5`, `wan-2.7`, `grok-imagine-video`, all zero-token, ~$4.50 of the $9.19 spent since #623, still writing today.

### 3. The direct path could not mark anything

The rule lived only in `from_settle_body`. `from_chat_result` and `from_embeddings_result` took the `synthetic: bool = False` field default, so a probe settling through the non-attested path was indexed as real customer traffic no matter what it sent. All three constructors now share `resolve_synthetic()`.

## The test that matters

The load-bearing test is structural, not example-based: it walks `probes.py`'s AST, finds every function that posts to a gateway route, and fails **naming** any whose body omits the marker. Forgetting the marker is the failure mode that actually recurs — a test for the video probe alone would not catch the next one.

It carries a vacuity guard (`>= 6` bodies found) so renaming `_api_url` cannot make it pass by discovering nothing, plus a companion test proving the marker check can still return `False`.

Both fixes were mutation-tested:

| reverted | result |
|---|---|
| video marker | fails with `['video_generation_probe']` |
| constructor change | fails both direct-path cases |

`test_video_synthetic` pinned the request body byte-for-byte, so it was asserting the defect; its expectation is updated with a comment saying why the key is there.

## Not fixed, and deliberately so

**6.24M of the 6.28M tokens still landing unflagged since #623 are not probes.** They share the monitor's API key but run 100–250× larger requests (`gemma-4-31b-it` averages 12,541 tokens against the monitor's 47) and return `finish_reason=tool_calls`, between 2026-08-25 14:58 and 2026-08-27 07:01. Flagging that hides real traffic rather than classifying it — it needs its own key. A further ~800 rows (gpt-4.1-mini across all four monitor regions, 7–13 tokens, sporadic) are monitor-shaped and remain unattributed to a specific caller.

One design note for a follow-up: the monitor key already carries server-side tags (`purpose=synthetic_monitoring`, `analytics=excluded`) that are present on **every** unflagged row, so the authoritative signal exists and is unused. Deriving `synthetic` from them is *not* safe as-is — `merge_tags` lets request tags override key defaults, so any customer could self-exclude. Doing it properly means either the reserved `trustedrouter:` tag prefix or a frozen field on `GatewayAuthorization`, and it interacts with `tags_match` at settle. Out of scope for a fix that had to be safe to land today.

## Gates

- `uv run ruff check .` — pass
- `uv run mypy` — pass, 319 files
- `uv run pytest` — 7,695 passed, 346 skipped, 10 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)