### PR TITLE
Spend-lease boot registration serves the canonical path

### DIFF
--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -1513,7 +1513,7 @@ def register(router: APIRouter) -> None:
     ) -> dict[str, Any]:
         return await authorize_gateway(request, body, settings)
 
-    @router.post("/internal/gateway/spend-lease/boot/register")
+    @router.post("/internal/gateway/spend-lease/register-boot")
     async def gateway_spend_lease_boot_register(
         request: Request,
         body: SpendLeaseBootRegistrationRequest,

--- a/tests/test_service_surface_routing.py
+++ b/tests/test_service_surface_routing.py
@@ -172,7 +172,7 @@ def test_internal_surface_route_inventory_matches_capability_audit() -> None:
         ("POST", "/internal/gateway/refund"),
         ("POST", "/internal/gateway/settle-outbox/drain"),
         ("POST", "/internal/gateway/receipt-keys/collect"),
-        ("POST", "/internal/gateway/spend-lease/boot/register"),
+        ("POST", "/internal/gateway/spend-lease/register-boot"),
         ("POST", "/internal/gateway/regional-quota/reconcile"),
         ("POST", "/internal/gateway/home-settlement/drain"),
         ("POST", "/internal/gateway/deferred/reap"),

--- a/tests/test_spend_lease_gateway.py
+++ b/tests/test_spend_lease_gateway.py
@@ -59,7 +59,7 @@ def test_boot_registration_accepts_verified_gcp_approved_digest(
     monkeypatch.setattr(gateway, "verify_gcp_attestation_chain", lambda _att: None)
     monkeypatch.setattr(gateway, "gcp_attestation_image_digest", lambda _att: digest)
     response = gateway._register_spend_lease_boot_sync(  # noqa: SLF001
-        _request("/v1/internal/gateway/spend-lease/boot/register"),
+        _request("/v1/internal/gateway/spend-lease/register-boot"),
         SpendLeaseBootRegistrationRequest(
             jwk=jwk,
             attestation="signed-gcp-evidence",
@@ -86,7 +86,7 @@ def test_boot_registration_rejects_wrong_gcp_image_digest(
     monkeypatch.setattr(gateway, "verify_gcp_attestation_chain", lambda _att: None)
     monkeypatch.setattr(gateway, "gcp_attestation_image_digest", lambda _att: observed)
     response = gateway._register_spend_lease_boot_sync(  # noqa: SLF001
-        _request("/v1/internal/gateway/spend-lease/boot/register"),
+        _request("/v1/internal/gateway/spend-lease/register-boot"),
         SpendLeaseBootRegistrationRequest(
             jwk=jwk,
             attestation="signed-gcp-evidence",
@@ -112,7 +112,7 @@ def test_boot_registration_rejects_bad_gcp_chain_without_storing(
     monkeypatch.setattr(gateway, "verify_gcp_attestation_chain", bad_chain)
     with pytest.raises(HTTPException, match="bad chain"):
         gateway._register_spend_lease_boot_sync(  # noqa: SLF001
-            _request("/v1/internal/gateway/spend-lease/boot/register"),
+            _request("/v1/internal/gateway/spend-lease/register-boot"),
             SpendLeaseBootRegistrationRequest(
                 jwk=jwk,
                 attestation="forged",
@@ -130,7 +130,7 @@ def test_boot_registration_records_aws_as_unverified(
     jwk = _jwk(Ed25519PrivateKey.generate())
     monkeypatch.setattr(gateway, "attestation_commits_to_jwk", lambda *_args: True)
     response = gateway._register_spend_lease_boot_sync(  # noqa: SLF001
-        _request("/v1/internal/gateway/spend-lease/boot/register"),
+        _request("/v1/internal/gateway/spend-lease/register-boot"),
         SpendLeaseBootRegistrationRequest(
             jwk=jwk,
             attestation="bound-aws-cose",


### PR DESCRIPTION
Integration fix for the Stage A pilot: the enclave calls `/internal/gateway/spend-lease/register-boot`; the router had `/spend-lease/boot/register`. Both halves' Sol runs invented a path because the design record pinned wire *fields* but not *URLs* — [record v9](https://claude.ai/code/artifact/88463c46-2627-4754-83a8-b4d6fb3d3a6e) now pins the path, and the failure chain worked exactly as designed: 404 → bounded retries → dormant shadow → `echo_invalid` events recording the anomaly (127 events, zero behavior impact).

One canonical path, no alias. Zero old-path references repo-wide; focused suites + route inventory green; mypy clean. After deploy, an enclave re-roll re-registers the dormant boots and the soak starts for real. Needs admin merge.

Authored by Sol (codex-cli); reviewed by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)