### PR TITLE
Honor OpenRouter provider routing controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,8 @@ remains available.
   first, and `trustedrouter/e2e` forces confidential + E2EE routes with
   Tinfoil first. Chat requests also honor OpenRouter-style `models` and
   `provider` routing filters (`order`, `only`, `ignore`, `allow_fallbacks`,
-  `min_privacy`, `data_collection`, and `sort`) so clients can request explicit
+  `min_privacy`, `data_collection`, `sort`, `max_price`, `require_parameters`,
+  and `zdr`) so clients can request explicit
   fallback chains or provider preferences. `provider.order` is a preference
   while fallbacks are enabled, and unlisted providers remain eligible after the
   preferred list. With `allow_fallbacks=false`, routing is restricted to the
@@ -306,6 +307,9 @@ remains available.
   hard provider-side confidential-compute + E2EE requirement and fails closed;
   the request-value aliases `e2e` and `e2ee` select the same tier
   rather than falling back to a weaker route.
+  Unknown request or provider options return `400` with the exact field name.
+  Recognized OpenRouter controls that are not implemented return a stable
+  `501 not_supported_in_alpha`; they are never accepted as router no-ops.
 - Billing: prepaid credits and BYOK first; no subscription is required.
 - Trust: hosted open source, with the running API's source commit, image
   reference, image digest, and attestation policy published at

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -1337,8 +1337,8 @@ PUBLIC_PAGES: dict[str, PublicPage] = {
         title="Provider Routing And Pinning",
         description=(
             "Pin, prefer, or exclude providers per request with the OpenRouter-compatible "
-            "provider object: only, ignore, order, allow_fallbacks, sort, hard privacy "
-            "floors, billing path, and jurisdiction filters that fail closed."
+            "provider object: only, ignore, order, allow_fallbacks, sort, max_price, "
+            "require_parameters, ZDR, and hard filters that fail closed."
         ),
     ),
     "docs/receipts": PublicPage(

--- a/src/trusted_router/routing.py
+++ b/src/trusted_router/routing.py
@@ -4,6 +4,7 @@ import dataclasses
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
 from typing import Any, TypeVar
 
 from trusted_router.catalog import (
@@ -17,6 +18,7 @@ from trusted_router.catalog import (
     META_MODEL_IDS,
     MODELS,
     PRIVACY_TIER_ALIASES,
+    PRIVACY_TIER_ZERO_RETENTION,
     PROVIDER_JURISDICTION_US,
     PROVIDERS,
     ROUTING_MODEL_ALIAS_TARGETS,
@@ -48,6 +50,7 @@ class RoutePreferences:
     allow_fallbacks: bool = True
     data_collection: str | None = None
     sort: str | None = None
+    sort_partition: str = "model"
     usage_type: str | None = None
     provider_jurisdiction: str | None = None
     # Requested upstream privacy posture (see catalog.PRIVACY_TIER_*). These
@@ -57,6 +60,10 @@ class RoutePreferences:
     # such as both ZDR and confidential compute. The legacy rank remains for
     # API/debug compatibility; routing enforces every value in this set.
     privacy_requirements: frozenset[int] = frozenset()
+    require_parameters: bool = False
+    requested_parameters: frozenset[str] = frozenset()
+    max_prompt_price_microdollars_per_million_tokens: int | None = None
+    max_completion_price_microdollars_per_million_tokens: int | None = None
 
 
 _PROVIDER_ALIASES = {
@@ -95,6 +102,34 @@ _ROUTER_PROVIDER_SLUGS = frozenset(
         "quill-router",
     }
 )
+
+_PROVIDER_ROUTING_FIELDS = frozenset(
+    {
+        "allow_fallbacks",
+        "billing",
+        "country",
+        "data_collection",
+        "headquarters_country",
+        "ignore",
+        "jurisdiction",
+        "max_price",
+        "min_privacy",
+        "only",
+        "order",
+        "provider_country",
+        "require_parameters",
+        "sort",
+        "usage",
+        "usage_type",
+        "zdr",
+    }
+)
+
+_PARAMETER_CAPABILITY_ALIASES: dict[str, frozenset[str]] = {
+    "max_tokens": frozenset({"max_tokens", "max_completion_tokens"}),
+    "reasoning": frozenset({"reasoning", "reasoning_effort"}),
+    "response_format": frozenset({"response_format", "structured_outputs"}),
+}
 
 # OpenRouter-style model-id suffixes. Append `:nitro` to a model id to
 # re-sort the upstream provider list by throughput-first (equivalent to
@@ -391,6 +426,13 @@ def video_route_endpoint_candidates(
 def provider_route_preferences(body: dict[str, Any]) -> RoutePreferences:
     raw_provider = body.get("provider")
     raw = raw_provider if isinstance(raw_provider, dict) else {}
+    unknown = sorted(set(raw) - _PROVIDER_ROUTING_FIELDS)
+    if unknown:
+        raise api_error(
+            400,
+            f"Unknown provider routing option: {unknown[0]}",
+            ErrorType.BAD_REQUEST,
+        )
 
     order = tuple(_provider_filter_list("order", raw.get("order")))
     only = frozenset(_provider_filter_list("only", raw.get("only")))
@@ -433,7 +475,7 @@ def provider_route_preferences(body: dict[str, Any]) -> RoutePreferences:
                 ErrorType.BAD_REQUEST,
             )
 
-    sort = _sort_mode(raw.get("sort"))
+    sort, sort_partition = _sort_preferences(raw.get("sort"))
     usage_type = _usage_type(raw.get("usage") or raw.get("usage_type") or raw.get("billing"))
     provider_jurisdiction = _provider_jurisdiction(
         raw.get("jurisdiction")
@@ -458,6 +500,23 @@ def provider_route_preferences(body: dict[str, Any]) -> RoutePreferences:
         min_privacy_rank = PRIVACY_TIER_ALIASES[key]
     privacy_requirements = frozenset({min_privacy_rank}) if min_privacy_rank else frozenset()
 
+    zdr = raw.get("zdr")
+    if zdr is not None and not isinstance(zdr, bool):
+        raise api_error(400, "provider.zdr must be a boolean", ErrorType.BAD_REQUEST)
+    if zdr:
+        privacy_requirements = privacy_requirements | frozenset({PRIVACY_TIER_ZERO_RETENTION})
+        min_privacy_rank = max(privacy_requirements)
+
+    require_parameters = raw.get("require_parameters", False)
+    if not isinstance(require_parameters, bool):
+        raise api_error(
+            400,
+            "provider.require_parameters must be a boolean",
+            ErrorType.BAD_REQUEST,
+        )
+    requested_parameters = _requested_parameters(body)
+    max_prompt_price, max_completion_price = _max_token_prices(raw.get("max_price"))
+
     return RoutePreferences(
         order=order,
         only=only,
@@ -467,9 +526,62 @@ def provider_route_preferences(body: dict[str, Any]) -> RoutePreferences:
         min_privacy_rank=min_privacy_rank,
         privacy_requirements=privacy_requirements,
         sort=sort,
+        sort_partition=sort_partition,
         usage_type=usage_type,
         provider_jurisdiction=provider_jurisdiction,
+        require_parameters=require_parameters,
+        requested_parameters=requested_parameters,
+        max_prompt_price_microdollars_per_million_tokens=max_prompt_price,
+        max_completion_price_microdollars_per_million_tokens=max_completion_price,
     )
+
+
+def _requested_parameters(body: dict[str, Any]) -> frozenset[str]:
+    raw = body.get("requested_parameters")
+    if raw is None:
+        return frozenset()
+    if not isinstance(raw, list) or any(not isinstance(item, str) for item in raw):
+        raise api_error(400, "requested_parameters must be a string array", ErrorType.BAD_REQUEST)
+    return frozenset(item.strip() for item in raw if item.strip())
+
+
+def _max_token_prices(value: Any) -> tuple[int | None, int | None]:
+    if value is None:
+        return None, None
+    if not isinstance(value, dict):
+        raise api_error(400, "provider.max_price must be an object", ErrorType.BAD_REQUEST)
+    unknown = sorted(set(value) - {"prompt", "completion"})
+    if unknown:
+        raise api_error(
+            400,
+            f"Unsupported provider.max_price option: {unknown[0]}",
+            ErrorType.BAD_REQUEST,
+        )
+    return (
+        _price_limit_microdollars(value.get("prompt"), "provider.max_price.prompt"),
+        _price_limit_microdollars(value.get("completion"), "provider.max_price.completion"),
+    )
+
+
+def _price_limit_microdollars(value: Any, field: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise api_error(400, f"{field} must be a non-negative decimal", ErrorType.BAD_REQUEST)
+    try:
+        amount = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        raise api_error(400, f"{field} must be a non-negative decimal", ErrorType.BAD_REQUEST) from None
+    if not amount.is_finite() or amount < 0:
+        raise api_error(400, f"{field} must be a non-negative decimal", ErrorType.BAD_REQUEST)
+    microdollars = amount * Decimal(1_000_000)
+    if microdollars != microdollars.to_integral_value():
+        raise api_error(
+            400,
+            f"{field} supports at most six decimal places",
+            ErrorType.BAD_REQUEST,
+        )
+    return int(microdollars)
 
 
 def _strip_variant_suffix(model_id: str) -> tuple[str, dict[str, str]]:
@@ -751,6 +863,15 @@ def _apply_provider_filters(candidates: list[Model], prefs: RoutePreferences) ->
             for endpoint in model_endpoints
         ):
             continue
+        if (
+            prefs.require_parameters
+            or prefs.max_prompt_price_microdollars_per_million_tokens is not None
+            or prefs.max_completion_price_microdollars_per_million_tokens is not None
+        ) and not any(
+            _endpoint_matches_parameter_and_price_filters(endpoint, prefs)
+            for endpoint in model_endpoints
+        ):
+            continue
         out.append(model)
     return out
 
@@ -803,8 +924,43 @@ def _apply_endpoint_provider_filters(
             continue
         if prefs.usage_type is not None and endpoint.usage_type != prefs.usage_type:
             continue
+        if not _endpoint_matches_parameter_and_price_filters(endpoint, prefs):
+            continue
         out.append((model, endpoint))
     return out
+
+
+def _endpoint_supports_requested_parameters(
+    endpoint: ModelEndpoint,
+    requested: frozenset[str],
+) -> bool:
+    supported = frozenset(endpoint.supported_parameters)
+    for parameter in requested:
+        alternatives = _PARAMETER_CAPABILITY_ALIASES.get(parameter, frozenset({parameter}))
+        if supported.isdisjoint(alternatives):
+            return False
+    return True
+
+
+def _endpoint_matches_parameter_and_price_filters(
+    endpoint: ModelEndpoint,
+    prefs: RoutePreferences,
+) -> bool:
+    if prefs.require_parameters and not _endpoint_supports_requested_parameters(
+        endpoint, prefs.requested_parameters
+    ):
+        return False
+    if (
+        prefs.max_prompt_price_microdollars_per_million_tokens is not None
+        and endpoint.prompt_price_microdollars_per_million_tokens
+        > prefs.max_prompt_price_microdollars_per_million_tokens
+    ):
+        return False
+    return not (
+        prefs.max_completion_price_microdollars_per_million_tokens is not None
+        and endpoint.completion_price_microdollars_per_million_tokens
+        > prefs.max_completion_price_microdollars_per_million_tokens
+    )
 
 
 def _sort_endpoint_candidates(
@@ -816,9 +972,17 @@ def _sort_endpoint_candidates(
     candidate_model_ids = {model.id for model, _endpoint in candidates}
     single_model_id = next(iter(candidate_model_ids)) if len(candidate_model_ids) == 1 else None
 
-    def key(item: tuple[int, tuple[Model, ModelEndpoint]]) -> tuple[int, int, int]:
+    model_order: dict[str, int] = {}
+    for model, _endpoint in candidates:
+        model_order.setdefault(model.id, len(model_order))
+
+    def key(item: tuple[int, tuple[Model, ModelEndpoint]]) -> tuple[int, int, int, int]:
         original_index, (model, endpoint) = item
         order_rank = provider_order.get(endpoint.provider, len(provider_order))
+        # Provider preference ranks endpoints within each requested model. It
+        # must not reorder the caller's model fallback chain. The only explicit
+        # opt-out is OpenRouter's global sort partition.
+        model_rank = model_order[model.id] if prefs.sort_partition == "model" else 0
         if prefs.sort == "price":
             sort_rank = (
                 endpoint.prompt_price_microdollars_per_million_tokens
@@ -838,7 +1002,7 @@ def _sort_endpoint_candidates(
                 endpoint.provider,
                 _PROVIDER_PREFERENCE.get(endpoint.provider, _DEFAULT_PROVIDER_PREFERENCE),
             )
-        return order_rank, sort_rank, original_index
+        return model_rank, order_rank, sort_rank, original_index
 
     return [candidate for _, candidate in sorted(with_index, key=key)]
 
@@ -929,21 +1093,31 @@ def _string_list(field: str, value: Any) -> list[str]:
     return out
 
 
-def _sort_mode(value: Any) -> str | None:
+def _sort_preferences(value: Any) -> tuple[str | None, str]:
     if value is None:
-        return None
+        return None, "model"
+    partition = "model"
     if isinstance(value, str):
         candidate = value.strip().lower()
     elif isinstance(value, dict):
         raw = value.get("sort") or value.get("strategy") or value.get("by")
         candidate = str(raw or "").strip().lower()
+        raw_partition = value.get("partition")
+        if raw_partition is not None:
+            partition = str(raw_partition).strip().lower()
+            if partition not in {"model", "none"}:
+                raise api_error(
+                    400,
+                    "provider.sort.partition must be 'model' or 'none'",
+                    ErrorType.BAD_REQUEST,
+                )
     else:
         raise api_error(400, "provider.sort must be a string or object", ErrorType.BAD_REQUEST)
     if candidate in {"price", "latency", "throughput"}:
-        return candidate
+        return candidate, partition
     if candidate:
         raise api_error(400, "provider.sort is unsupported", ErrorType.BAD_REQUEST)
-    return None
+    return None, partition
 
 
 def _usage_type(value: Any) -> str | None:

--- a/src/trusted_router/schemas.py
+++ b/src/trusted_router/schemas.py
@@ -277,6 +277,7 @@ class GatewayAuthorizeRequest(_Lenient):
     model: str = Field(min_length=1)
     models: list[str] | None = None
     provider: dict[str, Any] | None = None
+    requested_parameters: list[str] | None = None
     estimated_input_tokens: int = Field(default=1, ge=0)
     max_output_tokens: int | None = Field(default=None, ge=1)
     max_completion_tokens: int | None = Field(default=None, ge=1)

--- a/src/trusted_router/templates/public/provider_routing.html
+++ b/src/trusted_router/templates/public/provider_routing.html
@@ -5,7 +5,7 @@
   <div class="marketing-copy">
     <span class="eyebrow">OpenRouter-compatible routing controls</span>
     <h2>Pin, prefer, or exclude providers per request.</h2>
-    <p>Every chat, responses, and completions request accepts a <code>provider</code> object that narrows which providers may serve it and in what order. Filters are hard: when nothing matches, the request fails with <code>400</code> before any inference happens rather than silently relaxing. Invalid values are also a <code>400</code> — a typo can never weaken what you asked for.</p>
+    <p>Every Chat Completions and Responses request accepts a <code>provider</code> object that narrows which providers may serve it and in what order. Hard filters fail with <code>400</code> before inference when nothing matches. Unknown options also return <code>400</code>. OpenRouter options recognized but not implemented by this release return <code>501 not_supported_in_alpha</code>. Accepted router options never disappear silently.</p>
     <p>Lists accept either a JSON array or one comma-separated string. Provider slugs are the ones on the <a href="/providers">providers page</a> and in <a href="https://api.trustedrouter.com/v1/models"><code>GET /v1/models</code></a>.</p>
   </div>
   <div class="marketing-grid two">
@@ -32,6 +32,7 @@
 }</code></pre>
     </div>
   </div>
+  <p style="margin-top:12px">Rejected field names and status codes are emitted as bounded operational metadata so compatibility demand can be measured. Field values, request bodies, prompts, and outputs are excluded, and Sentry remains outside the enclave.</p>
 </section>
 
 <section class="status-section" style="margin-top:48px" id="fields">
@@ -47,9 +48,12 @@
       <tbody>
         <tr><td><code>only</code></td><td>Provider slugs (array or comma string)</td><td>Allowlist. Candidates outside it are removed; an empty result is a <code>400</code>.</td></tr>
         <tr><td><code>ignore</code></td><td>Provider slugs</td><td>Blocklist, applied after <code>only</code>.</td></tr>
-        <tr><td><code>order</code></td><td>Provider slugs</td><td>Preferred order for the remaining candidates; unlisted providers follow the listed ones.</td></tr>
+        <tr><td><code>order</code></td><td>Provider slugs</td><td>Soft preferred order while fallbacks are enabled; unlisted providers remain eligible afterward. Combine with <code>allow_fallbacks: false</code> or use <code>only</code> for a hard restriction.</td></tr>
         <tr><td><code>allow_fallbacks</code></td><td><code>true</code> (default) / <code>false</code></td><td><code>false</code> serves only the single first candidate; a top-level <code>allow_fallbacks</code> is also accepted, and disagreeing values are a <code>400</code>.</td></tr>
-        <tr><td><code>sort</code></td><td><code>price</code>, <code>latency</code>, <code>throughput</code></td><td>Orders candidates by tracked per-endpoint metrics before <code>order</code> preferences.</td></tr>
+        <tr><td><code>sort</code></td><td><code>price</code>, <code>latency</code>, <code>throughput</code>, or <code>{"by":"price","partition":"model|none"}</code></td><td>Orders endpoints by tracked metrics. The default <code>model</code> partition preserves the primary and fallback model order; <code>none</code> sorts every endpoint together.</td></tr>
+        <tr><td><code>require_parameters</code></td><td><code>true</code> / <code>false</code> (default)</td><td><code>true</code> removes endpoints that do not publish support for every model parameter present in the request.</td></tr>
+        <tr><td><code>max_price</code></td><td><code>{"prompt":"0.15","completion":"0.40"}</code></td><td>Hard maximum USD price per million prompt or completion tokens. Compared as integer microdollars.</td></tr>
+        <tr><td><code>zdr</code></td><td><code>true</code> / <code>false</code></td><td><code>true</code> restricts routing to endpoints with a tracked zero-data-retention guarantee.</td></tr>
         <tr><td><code>min_privacy</code></td><td><code>any</code>, <code>no_store</code>, <code>zdr</code>, <code>confidential</code> (aliases <code>e2e</code>, <code>e2ee</code>)</td><td>A hard privacy floor: no endpoint with the required tracked guarantee means a <code>400</code>, never a downgrade.</td></tr>
         <tr><td><code>data_collection</code></td><td><code>allow</code>, <code>deny</code></td><td>OpenRouter-compatible preference against providers that retain data; use <code>min_privacy</code> when the floor must be unrelaxable.</td></tr>
         <tr><td><code>usage</code></td><td><code>credits</code>, <code>byok</code> (aliases <code>prepaid</code>, <code>bring-your-own-key</code>; also accepted as <code>usage_type</code> or <code>billing</code>)</td><td>Restricts billing path — platform credits or your own upstream key.</td></tr>
@@ -57,7 +61,26 @@
       </tbody>
     </table>
   </div>
-  <p style="margin-top:12px"><code>require_parameters</code>, <code>quantizations</code>, <code>max_price</code>, and <code>options</code> are accepted for OpenRouter request compatibility but are not applied to routing today; a request relying on them routes as if they were unset.</p>
+  <p style="margin-top:12px"><code>quantizations</code>, <code>preferred_max_latency</code>, <code>preferred_min_throughput</code>, <code>enforce_distillable_text</code>, non-token <code>max_price</code> units, and <code>sort: "exacto"</code> are recognized OpenRouter controls but are not implemented yet. They return <code>501 not_supported_in_alpha</code> rather than routing as if unset.</p>
+</section>
+
+<section class="status-section" style="margin-top:48px" id="parameter-contract">
+  <div class="status-section-head"><div>
+    <h2>Parameter contract</h2>
+    <p>TrustedRouter validates the current OpenRouter request field, provider field, and plugin names at the attested boundary. This catches spelling mistakes and API drift before authorization or billing.</p>
+  </div></div>
+  <div class="marketing-grid two">
+    <div class="marketing-card">
+      <span class="card-label">Unknown option</span>
+      <h3><code>400 invalid_request_error</code></h3>
+      <p>The error names the exact field in <code>error.param</code>, such as <code>provider.future_option</code>.</p>
+    </div>
+    <div class="marketing-card">
+      <span class="card-label">Known but unavailable</span>
+      <h3><code>501 not_supported_in_alpha</code></h3>
+      <p>The field is part of OpenRouter's API, but this TrustedRouter release cannot honor it. The request stops before inference.</p>
+    </div>
+  </div>
 </section>
 
 <section class="status-section" style="margin-top:48px" id="suffixes">

--- a/tests/test_routing_unit.py
+++ b/tests/test_routing_unit.py
@@ -13,7 +13,11 @@ from __future__ import annotations
 import pytest
 from fastapi import HTTPException
 
-from trusted_router.catalog import PROVIDER_JURISDICTION_US
+from trusted_router.catalog import (
+    PRIVACY_TIER_ZERO_RETENTION,
+    PROVIDER_JURISDICTION_US,
+    endpoint_meets_privacy_requirement,
+)
 from trusted_router.config import Settings
 from trusted_router.routing import (
     _sort_endpoint_candidates,
@@ -52,6 +56,7 @@ def test_chat_route_candidates_models_array_dedupes_and_preserves_order() -> Non
         },
         _settings(),
     )
+
     assert [c.id for c in candidates] == [
         "openai/gpt-5.4-nano",
         "mistralai/mistral-small-2603",
@@ -212,6 +217,96 @@ def test_provider_only_remains_hard_with_fallbacks_enabled() -> None:
 
     assert candidates
     assert {endpoint.provider for _model, endpoint in candidates} == {"tinfoil"}
+
+
+def test_provider_require_parameters_filters_incompatible_endpoints() -> None:
+    unfiltered = chat_route_endpoint_candidates(
+        {"model": "google/gemma-4-31b-it"},
+        _settings(),
+    )
+    filtered = chat_route_endpoint_candidates(
+        {
+            "model": "google/gemma-4-31b-it",
+            "requested_parameters": ["temperature", "tools"],
+            "provider": {"require_parameters": True},
+        },
+        _settings(),
+    )
+
+    assert filtered
+    assert len(filtered) < len(unfiltered)
+    assert all(
+        {"temperature", "tools"}.issubset(endpoint.supported_parameters)
+        for _model, endpoint in filtered
+    )
+
+
+def test_provider_max_price_filters_prompt_and_completion_prices() -> None:
+    candidates = chat_route_endpoint_candidates(
+        {
+            "model": "google/gemma-4-31b-it",
+            "provider": {
+                "max_price": {"prompt": "0.15", "completion": "0.40"},
+            },
+        },
+        _settings(),
+    )
+
+    assert candidates
+    assert all(
+        endpoint.prompt_price_microdollars_per_million_tokens <= 150_000
+        and endpoint.completion_price_microdollars_per_million_tokens <= 400_000
+        for _model, endpoint in candidates
+    )
+
+
+def test_provider_sort_partition_preserves_or_flattens_model_fallback_order() -> None:
+    body = {
+        "models": ["anthropic/claude-opus-4.8", "google/gemma-4-31b-it"],
+        "provider": {"sort": {"by": "price", "partition": "model"}},
+    }
+    model_partition = chat_route_endpoint_candidates(body, _settings())
+    assert model_partition[0][0].id == "anthropic/claude-opus-4.8"
+
+    body["provider"] = {"sort": {"by": "price", "partition": "none"}}
+    global_partition = chat_route_endpoint_candidates(body, _settings())
+    assert global_partition[0][0].id == "google/gemma-4-31b-it"
+
+
+def test_provider_order_never_promotes_a_fallback_model_over_primary() -> None:
+    candidates = chat_route_endpoint_candidates(
+        {
+            "models": ["anthropic/claude-opus-4.8", "google/gemma-4-31b-it"],
+            "provider": {"order": ["cerebras"]},
+        },
+        _settings(),
+    )
+
+    assert candidates[0][0].id == "anthropic/claude-opus-4.8"
+
+
+def test_provider_zdr_true_filters_to_zero_retention_endpoints() -> None:
+    candidates = chat_route_endpoint_candidates(
+        {
+            "model": "google/gemma-4-31b-it",
+            "provider": {"zdr": True},
+        },
+        _settings(),
+    )
+
+    assert candidates
+    assert all(
+        endpoint_meets_privacy_requirement(endpoint, PRIVACY_TIER_ZERO_RETENTION)
+        for _model, endpoint in candidates
+    )
+
+
+def test_unknown_provider_routing_option_fails_closed() -> None:
+    with pytest.raises(HTTPException) as ctx:
+        provider_route_preferences({"provider": {"future_router_option": True}})
+
+    assert ctx.value.status_code == 400
+    assert "future_router_option" in ctx.value.detail["error"]["message"]
 
 
 def test_disjoint_only_and_no_fallback_order_fail_closed() -> None:
@@ -789,7 +884,12 @@ def test_default_endpoint_routing_prefers_reliable_host_over_flaky() -> None:
     # tries deepinfra before parasail even when parasail is listed first.
     flaky = _credits_endpoint("parasail")
     reliable = _credits_endpoint("deepinfra")
-    ordered = _sort_endpoint_candidates([flaky, reliable], provider_route_preferences({}))
+    # Sorting providers is model-local. Reuse one model to isolate provider
+    # preference from the separate model fallback order contract.
+    ordered = _sort_endpoint_candidates(
+        [(flaky[0], flaky[1]), (flaky[0], reliable[1])],
+        provider_route_preferences({}),
+    )
     assert [ep.provider for _, ep in ordered] == ["deepinfra", "parasail"]
 
 
@@ -797,7 +897,10 @@ def test_explicit_provider_order_overrides_reliability_preference() -> None:
     flaky = _credits_endpoint("parasail")
     reliable = _credits_endpoint("deepinfra")
     prefs = provider_route_preferences({"provider": {"order": ["parasail"]}})
-    ordered = _sort_endpoint_candidates([flaky, reliable], prefs)
+    ordered = _sort_endpoint_candidates(
+        [(flaky[0], flaky[1]), (flaky[0], reliable[1])],
+        prefs,
+    )
     assert ordered[0][1].provider == "parasail"  # caller's explicit order wins
 
 


### PR DESCRIPTION
## Summary
- implement require_parameters, max_price token limits, zdr, and sort partition semantics
- preserve model fallback order while ranking providers within a model
- make provider.order soft by default and hard when allow_fallbacks is false
- reject unknown provider controls and document every recognized unsupported control explicitly

## Verification
- ruff and mypy pass
- 7,702 product tests passed, with 346 skipped and 10 expected failures
- focused routing, billing, catalog, and docs suites pass after rebasing on main