### PR TITLE
infra: the deploy role must read tr-eu-* inline policies to import them

### DIFF
--- a/infra/aws_deploy_role.tf
+++ b/infra/aws_deploy_role.tf
@@ -39,6 +39,11 @@ resource "aws_iam_role_policy" "tr_eu_role_writes" {
           "iam:PutRolePolicy",
           "iam:PassRole",
           "iam:GetRole",
+          # Terraform must READ inline policies to import/manage them;
+          # run 33281943857 failed planning the dlq-send import without.
+          "iam:GetRolePolicy",
+          "iam:ListRolePolicies",
+          "iam:ListAttachedRolePolicies",
         ]
         Resource = "arn:aws:iam::${local.aws_account_id}:role/tr-eu-*"
       },


### PR DESCRIPTION
Plan-time import reads need iam:GetRolePolicy/List* on tr-eu-*; run 33281943857 proved it. Live policy updated in lockstep by the operator, then terraform owns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)