### PR TITLE
Honor the spending limit the user chose on the consent page

### DIFF
--- a/src/trusted_router/routes/oauth_keys.py
+++ b/src/trusted_router/routes/oauth_keys.py
@@ -171,7 +171,14 @@ def register_oauth_key_routes(router: APIRouter) -> None:
         if consent.client_app_id and chosen not in {"5", "20", "100", "none"}:
             raise api_error(400, "Invalid monthly budget", ErrorType.BAD_REQUEST)
         posted_limit_present = "limit" in form
-        posted_limit = _limit_microdollars(form.get("limit")) if posted_limit_present else None
+        posted_limit = (
+            _limit_microdollars(
+                form.get("limit"),
+                maximum_microdollars=CONSENT_FORM_LIMIT_MAX_DOLLARS * 1_000_000,
+            )
+            if posted_limit_present
+            else None
+        )
         posted_reset_present = "usage_limit_type" in form
         posted_reset = _limit_reset(form.get("usage_limit_type")) if posted_reset_present else None
         consumed = STORE.consume_consent_request(
@@ -526,13 +533,23 @@ def _suggested_monthly_budget(raw: Any) -> str:
     return str(dollars) if not cents else f"{dollars}.{cents.ljust(2, '0')}"
 
 
-#: Server-side ceiling for a delegated key's spend limit, matching the maximum
-#: the consent page's input advertises. Also the overflow guard: Decimal happily
-#: parses 1e400, which then breaks BIGINT/INT64 microdollar columns downstream.
-LIMIT_MAX_DOLLARS = 10_000
+#: Ceiling for a limit typed into the consent page, matching the maximum the
+#: input advertises client-side. UI policy only -- the programmatic paths keep
+#: their documented no-maximum contract, bounded solely by storage safety.
+CONSENT_FORM_LIMIT_MAX_DOLLARS = 10_000
+
+#: Storage-safety ceiling for every path: the largest microdollar value the
+#: BIGINT/INT64 limit columns can hold. Decimal happily parses 1e400 into an
+#: integer that previously approved, burned the consent, and then failed (or
+#: 500d outright via decimal.Overflow) when the key was serialized.
+LIMIT_MAX_STORABLE_MICRODOLLARS = 2**63 - 1
 
 
-def _limit_microdollars(raw: Any) -> int | None:
+def _limit_microdollars(
+    raw: Any,
+    *,
+    maximum_microdollars: int = LIMIT_MAX_STORABLE_MICRODOLLARS,
+) -> int | None:
     if raw in {None, ""}:
         return None
     try:
@@ -541,10 +558,10 @@ def _limit_microdollars(raw: Any) -> int | None:
         raise api_error(400, "limit must be a dollar amount", ErrorType.BAD_REQUEST) from exc
     if value < 0:
         raise api_error(400, "limit must be non-negative", ErrorType.BAD_REQUEST)
-    if value > LIMIT_MAX_DOLLARS * 1_000_000:
+    if value > maximum_microdollars:
         raise api_error(
             400,
-            f"limit must be at most ${LIMIT_MAX_DOLLARS}",
+            f"limit must be at most ${maximum_microdollars // 1_000_000}",
             ErrorType.BAD_REQUEST,
         )
     return value

--- a/src/trusted_router/routes/oauth_keys.py
+++ b/src/trusted_router/routes/oauth_keys.py
@@ -181,6 +181,19 @@ def register_oauth_key_routes(router: APIRouter) -> None:
         if consumed.client_app_id:
             consumed.limit_microdollars = None if chosen == "none" else dollars_to_microdollars(chosen)
             consumed.limit_reset = None if chosen == "none" else "monthly"
+        else:
+            # The legacy consent page renders "Maximum spend (USD)" and "Limit
+            # resets" as editable fields, but only the app's query-suggested
+            # limit ever reached the key: the posted values were discarded, so
+            # an app that suggested nothing (the Cowork desktop flow) minted an
+            # UNCAPPED key while the page showed a $20 maximum, and a user who
+            # edited a suggested limit was silently overridden. Honor what the
+            # form actually posted; absent fields keep the consent's stored
+            # values so programmatic approvals are unchanged.
+            if "limit" in form:
+                consumed.limit_microdollars = _limit_microdollars(form.get("limit"))
+            if "usage_limit_type" in form:
+                consumed.limit_reset = _limit_reset(form.get("usage_limit_type"))
         raw_code, code = _create_code_from_consent(consumed, settings)
         callback_url = (
             _conformant_callback_with_code(code.callback_url, raw_code, state=consumed.state)

--- a/src/trusted_router/routes/oauth_keys.py
+++ b/src/trusted_router/routes/oauth_keys.py
@@ -876,7 +876,7 @@ def _consent_html(
     # Headless callers who need more use the JSON path, which has no ceiling.
     effective_limit = OAUTH_DEFAULT_KEY_LIMIT if limit is None else microdollars_to_decimal(limit)
     if limit is not None and limit > CONSENT_FORM_LIMIT_MAX_DOLLARS * 1_000_000:
-        effective_limit = CONSENT_FORM_LIMIT_MAX_DOLLARS
+        effective_limit = microdollars_to_decimal(CONSENT_FORM_LIMIT_MAX_DOLLARS * 1_000_000)
     reset = _limit_reset(params.get("usage_limit_type")) or ""
     summary = live_credit_summary(workspace_id)
     available = summary["available"] if summary else 0

--- a/src/trusted_router/routes/oauth_keys.py
+++ b/src/trusted_router/routes/oauth_keys.py
@@ -867,7 +867,16 @@ def _consent_html(
         f"{oauth_app.name} · {oauth_app.id}" if oauth_app is not None else key_label
     )
     limit = _limit_microdollars(params.get("limit"))
+    # The consent input advertises max=10000 and the approve handler enforces
+    # the same ceiling on posted values, so render any larger app suggestion
+    # clamped: the user sees, edits, and approves the number that will actually
+    # bind. (Un-clamped, a $20,000 suggestion pre-filled an unsubmittable field
+    # -- and before posted values were honored at all, the browser forced the
+    # user to type a smaller number and then minted the app's larger one.)
+    # Headless callers who need more use the JSON path, which has no ceiling.
     effective_limit = OAUTH_DEFAULT_KEY_LIMIT if limit is None else microdollars_to_decimal(limit)
+    if limit is not None and limit > CONSENT_FORM_LIMIT_MAX_DOLLARS * 1_000_000:
+        effective_limit = CONSENT_FORM_LIMIT_MAX_DOLLARS
     reset = _limit_reset(params.get("usage_limit_type")) or ""
     summary = live_credit_summary(workspace_id)
     available = summary["available"] if summary else 0

--- a/src/trusted_router/routes/oauth_keys.py
+++ b/src/trusted_router/routes/oauth_keys.py
@@ -170,6 +170,10 @@ def register_oauth_key_routes(router: APIRouter) -> None:
         chosen = str(form.get("monthly_budget") or "20")
         if consent.client_app_id and chosen not in {"5", "20", "100", "none"}:
             raise api_error(400, "Invalid monthly budget", ErrorType.BAD_REQUEST)
+        posted_limit_present = "limit" in form
+        posted_limit = _limit_microdollars(form.get("limit")) if posted_limit_present else None
+        posted_reset_present = "usage_limit_type" in form
+        posted_reset = _limit_reset(form.get("usage_limit_type")) if posted_reset_present else None
         consumed = STORE.consume_consent_request(
             consent.id,
             user_id=str(_principal_user_id(principal) or ""),
@@ -188,12 +192,13 @@ def register_oauth_key_routes(router: APIRouter) -> None:
             # an app that suggested nothing (the Cowork desktop flow) minted an
             # UNCAPPED key while the page showed a $20 maximum, and a user who
             # edited a suggested limit was silently overridden. Honor what the
-            # form actually posted; absent fields keep the consent's stored
-            # values so programmatic approvals are unchanged.
-            if "limit" in form:
-                consumed.limit_microdollars = _limit_microdollars(form.get("limit"))
-            if "usage_limit_type" in form:
-                consumed.limit_reset = _limit_reset(form.get("usage_limit_type"))
+            # form actually posted (validated above, before the consent was
+            # consumed); absent fields keep the consent's stored values so
+            # programmatic approvals are unchanged.
+            if posted_limit_present:
+                consumed.limit_microdollars = posted_limit
+            if posted_reset_present:
+                consumed.limit_reset = posted_reset
         raw_code, code = _create_code_from_consent(consumed, settings)
         callback_url = (
             _conformant_callback_with_code(code.callback_url, raw_code, state=consumed.state)
@@ -521,15 +526,27 @@ def _suggested_monthly_budget(raw: Any) -> str:
     return str(dollars) if not cents else f"{dollars}.{cents.ljust(2, '0')}"
 
 
+#: Server-side ceiling for a delegated key's spend limit, matching the maximum
+#: the consent page's input advertises. Also the overflow guard: Decimal happily
+#: parses 1e400, which then breaks BIGINT/INT64 microdollar columns downstream.
+LIMIT_MAX_DOLLARS = 10_000
+
+
 def _limit_microdollars(raw: Any) -> int | None:
     if raw in {None, ""}:
         return None
     try:
         value = dollars_to_microdollars(raw)
-    except ValueError as exc:
+    except (ValueError, ArithmeticError) as exc:
         raise api_error(400, "limit must be a dollar amount", ErrorType.BAD_REQUEST) from exc
     if value < 0:
         raise api_error(400, "limit must be non-negative", ErrorType.BAD_REQUEST)
+    if value > LIMIT_MAX_DOLLARS * 1_000_000:
+        raise api_error(
+            400,
+            f"limit must be at most ${LIMIT_MAX_DOLLARS}",
+            ErrorType.BAD_REQUEST,
+        )
     return value
 
 

--- a/tests/test_oauth_key_delegation.py
+++ b/tests/test_oauth_key_delegation.py
@@ -867,6 +867,50 @@ def test_oauth_browser_approve_rejects_oversized_and_overflowing_limits(client: 
         assert response.status_code == 400, f"{bad!r}: {response.status_code}"
 
 
+def test_programmatic_limits_above_the_consent_ceiling_still_work(client: TestClient) -> None:
+    # The $10,000 ceiling is consent-page policy. The query/JSON contract
+    # documents no maximum, so a headless caller's $20,000 limit must still
+    # mint -- bounded only by what the storage columns can hold.
+    user = STORE.ensure_user("alice@example.com")
+    raw_session, _ = STORE.create_auth_session(
+        user_id=user.id,
+        provider="google",
+        label="alice@example.com",
+        ttl_seconds=3600,
+        state="active",
+    )
+    client.cookies.set("tr_session", raw_session)
+
+    form = _consent_form(
+        client,
+        {
+            "callback_url": "https://app.example.com/callback",
+            "key_label": "Example app",
+            "limit": "20000",
+            "usage_limit_type": "monthly",
+        },
+    )
+    approved = client.post("/auth/approve", data=form, follow_redirects=False)
+    assert approved.status_code == 302
+    code = parse_qs(urlsplit(approved.headers["location"]).query)["code"][0]
+    exchanged = client.post("/v1/auth/keys", json={"code": code})
+    assert exchanged.status_code == 200
+    key = STORE.get_key_by_raw(exchanged.json()["key"])
+    assert key is not None
+    assert key.limit_microdollars == 20_000_000_000
+
+    # Storage safety still refuses what INT64 cannot hold, as a 400 not a 500.
+    oversized = client.get(
+        "/auth",
+        params={
+            "callback_url": "https://app.example.com/callback",
+            "key_label": "Example app",
+            "limit": "1e400",
+        },
+    )
+    assert oversized.status_code == 400
+
+
 def test_oauth_browser_approve_validation_failure_keeps_the_consent_usable(
     client: TestClient,
 ) -> None:

--- a/tests/test_oauth_key_delegation.py
+++ b/tests/test_oauth_key_delegation.py
@@ -843,6 +843,70 @@ def test_oauth_browser_approve_lets_the_user_edit_a_suggested_limit(client: Test
     assert key.limit_reset == "monthly"
 
 
+def test_oauth_browser_approve_rejects_oversized_and_overflowing_limits(client: TestClient) -> None:
+    user = STORE.ensure_user("alice@example.com")
+    raw_session, _ = STORE.create_auth_session(
+        user_id=user.id,
+        provider="google",
+        label="alice@example.com",
+        ttl_seconds=3600,
+        state="active",
+    )
+    client.cookies.set("tr_session", raw_session)
+
+    form = _consent_form(
+        client,
+        {"callback_url": "https://app.example.com/callback", "key_label": "Example app"},
+    )
+    for bad in ("10000.01", "20000", "1e400", "1e999999"):
+        response = client.post(
+            "/auth/approve",
+            data={**form, "limit": bad},
+            follow_redirects=False,
+        )
+        assert response.status_code == 400, f"{bad!r}: {response.status_code}"
+
+
+def test_oauth_browser_approve_validation_failure_keeps_the_consent_usable(
+    client: TestClient,
+) -> None:
+    # A 400 on a bad posted limit must not burn the consent: the user fixes the
+    # field and resubmits the same form successfully.
+    user = STORE.ensure_user("alice@example.com")
+    raw_session, _ = STORE.create_auth_session(
+        user_id=user.id,
+        provider="google",
+        label="alice@example.com",
+        ttl_seconds=3600,
+        state="active",
+    )
+    client.cookies.set("tr_session", raw_session)
+
+    form = _consent_form(
+        client,
+        {"callback_url": "https://app.example.com/callback", "key_label": "Example app"},
+    )
+    rejected = client.post(
+        "/auth/approve",
+        data={**form, "limit": "not-a-number"},
+        follow_redirects=False,
+    )
+    assert rejected.status_code == 400
+
+    retried = client.post(
+        "/auth/approve",
+        data={**form, "limit": "20", "usage_limit_type": ""},
+        follow_redirects=False,
+    )
+    assert retried.status_code == 302
+    code = parse_qs(urlsplit(retried.headers["location"]).query)["code"][0]
+    exchanged = client.post("/v1/auth/keys", json={"code": code})
+    assert exchanged.status_code == 200
+    key = STORE.get_key_by_raw(exchanged.json()["key"])
+    assert key is not None
+    assert key.limit_microdollars == 20_000_000
+
+
 def test_oauth_browser_approve_rejects_a_malformed_posted_limit(client: TestClient) -> None:
     user = STORE.ensure_user("alice@example.com")
     raw_session, _ = STORE.create_auth_session(

--- a/tests/test_oauth_key_delegation.py
+++ b/tests/test_oauth_key_delegation.py
@@ -776,6 +776,94 @@ def test_oauth_browser_user_selected_limit_is_issued_to_app(client: TestClient) 
     assert key.limit_reset == "weekly"
 
 
+def test_oauth_browser_approve_honors_the_limit_the_user_chose(client: TestClient) -> None:
+    # The consent page's "Maximum spend (USD)" field is what the user agrees
+    # to. When the app suggests no limit (the Cowork desktop flow), the posted
+    # value must cap the key -- it used to be discarded, minting an uncapped
+    # key under a page that displayed a $20 maximum.
+    user = STORE.ensure_user("alice@example.com")
+    raw_session, _ = STORE.create_auth_session(
+        user_id=user.id,
+        provider="google",
+        label="alice@example.com",
+        ttl_seconds=3600,
+        state="active",
+    )
+    client.cookies.set("tr_session", raw_session)
+
+    form = _consent_form(
+        client,
+        {"callback_url": "https://app.example.com/callback", "key_label": "Example app"},
+    )
+    form["limit"] = "20"
+    form["usage_limit_type"] = ""
+    approved = client.post("/auth/approve", data=form, follow_redirects=False)
+
+    code = parse_qs(urlsplit(approved.headers["location"]).query)["code"][0]
+    exchanged = client.post("/v1/auth/keys", json={"code": code})
+
+    assert exchanged.status_code == 200
+    key = STORE.get_key_by_raw(exchanged.json()["key"])
+    assert key is not None
+    assert key.limit_microdollars == 20_000_000
+    assert key.limit_reset is None
+
+
+def test_oauth_browser_approve_lets_the_user_edit_a_suggested_limit(client: TestClient) -> None:
+    user = STORE.ensure_user("alice@example.com")
+    raw_session, _ = STORE.create_auth_session(
+        user_id=user.id,
+        provider="google",
+        label="alice@example.com",
+        ttl_seconds=3600,
+        state="active",
+    )
+    client.cookies.set("tr_session", raw_session)
+
+    form = _consent_form(
+        client,
+        {
+            "callback_url": "https://app.example.com/callback",
+            "key_label": "Example app",
+            "limit": "5",
+            "usage_limit_type": "weekly",
+        },
+    )
+    form["limit"] = "2.50"
+    form["usage_limit_type"] = "monthly"
+    approved = client.post("/auth/approve", data=form, follow_redirects=False)
+
+    code = parse_qs(urlsplit(approved.headers["location"]).query)["code"][0]
+    exchanged = client.post("/v1/auth/keys", json={"code": code})
+
+    assert exchanged.status_code == 200
+    key = STORE.get_key_by_raw(exchanged.json()["key"])
+    assert key is not None
+    assert key.limit_microdollars == 2_500_000
+    assert key.limit_reset == "monthly"
+
+
+def test_oauth_browser_approve_rejects_a_malformed_posted_limit(client: TestClient) -> None:
+    user = STORE.ensure_user("alice@example.com")
+    raw_session, _ = STORE.create_auth_session(
+        user_id=user.id,
+        provider="google",
+        label="alice@example.com",
+        ttl_seconds=3600,
+        state="active",
+    )
+    client.cookies.set("tr_session", raw_session)
+
+    form = _consent_form(
+        client,
+        {"callback_url": "https://app.example.com/callback", "key_label": "Example app"},
+    )
+    form["limit"] = "not-a-number"
+    response = client.post("/auth/approve", data=form, follow_redirects=False)
+
+    assert response.status_code == 400
+
+
 def test_oauth_browser_approve_redirects_with_code_and_user_id(client: TestClient) -> None:
     user = STORE.ensure_user("alice@example.com")
     raw_session, _ = STORE.create_auth_session(

--- a/tests/test_oauth_key_delegation.py
+++ b/tests/test_oauth_key_delegation.py
@@ -867,6 +867,57 @@ def test_oauth_browser_approve_rejects_oversized_and_overflowing_limits(client: 
         assert response.status_code == 400, f"{bad!r}: {response.status_code}"
 
 
+def test_consent_page_clamps_an_oversized_suggestion_to_what_it_can_approve(
+    client: TestClient,
+) -> None:
+    # An app may suggest more than the form's $10,000 ceiling. The page must
+    # render the number the user can actually approve, and the approval must
+    # mint exactly that -- not the app's larger suggestion.
+    user = STORE.ensure_user("alice@example.com")
+    raw_session, _ = STORE.create_auth_session(
+        user_id=user.id,
+        provider="google",
+        label="alice@example.com",
+        ttl_seconds=3600,
+        state="active",
+    )
+    client.cookies.set("tr_session", raw_session)
+
+    page = client.get(
+        "/auth",
+        params={
+            "callback_url": "https://app.example.com/callback",
+            "key_label": "Example app",
+            "limit": "20000",
+        },
+    )
+    assert page.status_code == 200
+    assert 'name="limit"' in page.text
+    assert 'value="10000"' in page.text
+    assert 'value="20000"' not in page.text
+
+    def value(name: str) -> str:
+        return page.text.split(f'name="{name}" value="', 1)[1].split('"', 1)[0]
+
+    approved = client.post(
+        "/auth/approve",
+        data={
+            "consent": value("consent"),
+            "csrf_token": value("csrf_token"),
+            "limit": "10000",
+            "usage_limit_type": "",
+        },
+        follow_redirects=False,
+    )
+    assert approved.status_code == 302
+    code = parse_qs(urlsplit(approved.headers["location"]).query)["code"][0]
+    exchanged = client.post("/v1/auth/keys", json={"code": code})
+    assert exchanged.status_code == 200
+    key = STORE.get_key_by_raw(exchanged.json()["key"])
+    assert key is not None
+    assert key.limit_microdollars == 10_000_000_000
+
+
 def test_programmatic_limits_above_the_consent_ceiling_still_work(client: TestClient) -> None:
     # The $10,000 ceiling is consent-page policy. The query/JSON contract
     # documents no maximum, so a headless caller's $20,000 limit must still


### PR DESCRIPTION
Found by walking the Cowork OAuth flow end to end in a browser as a brand-new account (seeded local stack, real consent page, real approve, real exchange).

## The bug

The consent page's step 2 — "Maximum spend (USD)" and "Limit resets" — is an editable form, but `/auth/approve` never read those fields. Only an app's **query-suggested** `limit` reached the key (which is why `test_oauth_browser_consent_query_limit...` passed):

- App suggests no limit (the Cowork desktop flow): page displays an editable **$20**, user approves, key mints **uncapped**. Observed empirically: `limit=None` on the minted key.
- App suggests $5, user edits to $2.50: the edit is silently discarded.

On a page whose entire pitch is bounded delegation ("The limit belongs only to the key issued to …"), the bound was decorative.

## Fix

For legacy consents (no `client_app_id`), honor posted `limit` / `usage_limit_type` through the same validators the query path uses (`_limit_microdollars`, `_limit_reset`). Fields absent from the form keep the consent's stored values, so programmatic approvals that post only `consent`+`csrf_token` are unchanged. The registered-app `monthly_budget` branch is untouched.

## Verification

- 81/81 in `tests/test_oauth_key_delegation.py`, including three new: posted default caps the key ($20/Never), user's edit beats the app's suggestion ($2.50/monthly over $5/weekly), malformed posted limit → 400.
- Live re-run of the full flow against the fixed server: the minted `Quill Cowork` key now reads `limit=20.0`.

## Note for reviewers

The hidden-field replay means `limit` can appear twice in the POST when the app suggested one; `dict(form)` keeps the last occurrence, which is the visible (user-edited) input. The new "edit beats suggestion" test pins that behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)