### PR TITLE
Fix private Cloud Run rollout probes

### DIFF
--- a/scripts/deploy/_cloud_run_revision_probe.sh
+++ b/scripts/deploy/_cloud_run_revision_probe.sh
@@ -123,3 +123,68 @@ cloud_run_probe_tagged_base_url() {
     *) return 1 ;;
   esac
 }
+
+cloud_run_service_ingress() {
+  local service="$1"
+  local region="$2"
+  local project="$3"
+  local document
+
+  document="$(gcloud run services describe "$service" \
+    --region="$region" \
+    --project="$project" \
+    --format=json)" || return 1
+  printf '%s' "$document" | python3 -c '
+import json, sys
+try:
+    document = json.load(sys.stdin)
+except Exception:
+    raise SystemExit(1)
+ingress = (
+    document.get("metadata", {})
+    .get("annotations", {})
+    .get("run.googleapis.com/ingress")
+)
+if ingress is None:
+    ingress = "all"
+if ingress not in {"all", "internal", "internal-and-cloud-load-balancing"}:
+    raise SystemExit(1)
+print(ingress)
+'
+}
+
+cloud_run_revision_capacity_ready() {
+  local service="$1"
+  local region="$2"
+  local project="$3"
+  local revision="$4"
+  local minimum="$5"
+  local document
+
+  document="$(gcloud run revisions describe "$revision" \
+    --region="$region" \
+    --project="$project" \
+    --format=json)" || return 1
+  printf '%s' "$document" | python3 -c '
+import json, sys
+revision, minimum_text = sys.argv[1:3]
+try:
+    document = json.load(sys.stdin)
+    minimum = int(minimum_text)
+except Exception:
+    raise SystemExit(1)
+if document.get("metadata", {}).get("name") not in {None, revision}:
+    raise SystemExit(1)
+conditions = {
+    item.get("type"): str(item.get("status", "")).casefold()
+    for item in document.get("status", {}).get("conditions", [])
+}
+if conditions.get("Ready") != "true":
+    raise SystemExit(1)
+if minimum > 0 and conditions.get("MinInstancesProvisioned") != "true":
+    raise SystemExit(1)
+desired = document.get("status", {}).get("desiredReplicas")
+if minimum > 0 and (not isinstance(desired, int) or desired < minimum):
+    raise SystemExit(1)
+' "$revision" "$minimum"
+}

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -775,6 +775,28 @@ cloud_run_min_instances_for_region() {
   fi
 }
 
+cloud_run_service_min_instances_for_region() {
+  local target="$1"
+  if [ -n "${TR_CLOUD_RUN_MIN_INSTANCES:-}" ]; then
+    printf '%s\n' "$TR_CLOUD_RUN_MIN_INSTANCES"
+  else
+    cloud_run_min_instances_for_region "$target"
+  fi
+}
+
+cloud_run_candidate_min_instances() {
+  local service_min="$1"
+  local prewarm_floor="${TR_CLOUD_RUN_PREWARM_MIN_INSTANCES:-2}"
+  if [[ ! "$prewarm_floor" =~ ^[0-9]+$ ]]; then
+    log "invalid TR_CLOUD_RUN_PREWARM_MIN_INSTANCES=${prewarm_floor}; using 2" >&2
+    prewarm_floor=2
+  fi
+  if [ "$service_min" != "default" ] && [ "$prewarm_floor" -gt "$service_min" ]; then
+    prewarm_floor="$service_min"
+  fi
+  printf '%s\n' "$prewarm_floor"
+}
+
 deploy_one_region() {
   local target="$1"
   local logfile="${2:-/dev/null}"
@@ -800,10 +822,8 @@ deploy_one_region() {
   # A global override wins. Otherwise use the per-region service minimum;
   # unknown warm regions retain one instance and unknown cold regions scale to
   # zero.
-  local min_instances="${TR_CLOUD_RUN_MIN_INSTANCES:-}"
-  if [ -z "$min_instances" ]; then
-    min_instances="$(cloud_run_min_instances_for_region "$target")"
-  fi
+  local min_instances
+  min_instances="$(cloud_run_service_min_instances_for_region "$target")"
   local revision_min_instances="default"
   if [ "${TR_DEPLOY_NO_TRAFFIC:-0}" = "1" ]; then
     # Cloud Run revisions are immutable: clearing a temporary revision minimum
@@ -818,17 +838,9 @@ deploy_one_region() {
     # 7m37 instead of ~2m; the 100%-stall cost moved into the warm and grew.
     # A small primer absorbs the 10% step instantly, and the staged
     # 10/50/100 ramp itself gives Cloud Run scale time for the rest.
-    local prewarm_floor="${TR_CLOUD_RUN_PREWARM_MIN_INSTANCES:-2}"
-    if [[ ! "$prewarm_floor" =~ ^[0-9]+$ ]]; then
-      log "invalid TR_CLOUD_RUN_PREWARM_MIN_INSTANCES=${prewarm_floor}; using 2"
-      prewarm_floor=2
-    fi
-    if [ "$min_instances" != "default" ] && [ "$prewarm_floor" -gt "$min_instances" ]; then
-      # Never prime ABOVE the service minimum: a cold region (min 0/1) should
-      # not pay for primer instances its steady state never runs.
-      prewarm_floor="$min_instances"
-    fi
-    revision_min_instances="$prewarm_floor"
+    # Never prime ABOVE the service minimum: a cold region (min 0/1) should
+    # not pay for primer instances its steady state never runs.
+    revision_min_instances="$(cloud_run_candidate_min_instances "$min_instances")"
     # CAVEAT (review F5): this bakes today's primer into the revision
     # forever — effective capacity is max(service, revision). With the primer
     # capped at min(2, service minimum), a later reduction of a region's
@@ -948,6 +960,7 @@ warm_no_traffic_candidate() {
   local revision="$2"
   local min_instances="$3"
   local base_url
+  local service_ingress
 
   # The tag mutation itself is traffic-free. Mark cleanup required before the
   # call because a failed reconciliation can still have applied the tag.
@@ -956,13 +969,27 @@ warm_no_traffic_candidate() {
   log "assigning ${WARM_PROBE_TAG} to ${revision} during the no-traffic warm"
   cloud_run_probe_tag_reconcile \
     "$SERVICE" "$target" "$PROJECT_ID" "$WARM_PROBE_TAG" "$revision"
-  base_url="$(cloud_run_probe_tagged_base_url \
-    "$SERVICE" "$target" "$PROJECT_ID" "$WARM_PROBE_TAG" "$revision")"
-  # The revision minimum is activated by the tag. A direct readiness request
-  # proves the tagged route has reached a started candidate before this warm
-  # process reports success; it never moves production traffic.
-  curl -fsS --max-time 30 --retry 5 --retry-all-errors \
-    "${base_url}/ready" >/dev/null
+  if ! service_ingress="$(cloud_run_service_ingress \
+      "$SERVICE" "$target" "$PROJECT_ID")"; then
+    echo "ERROR: could not determine Cloud Run ingress for ${SERVICE} in ${target}" >&2
+    return 1
+  fi
+  if [ "$service_ingress" = "all" ]; then
+    base_url="$(cloud_run_probe_tagged_base_url \
+      "$SERVICE" "$target" "$PROJECT_ID" "$WARM_PROBE_TAG" "$revision")"
+    # Public run.app ingress can prove the application route before traffic
+    # moves. Protected services deliberately return a Google platform 404 on
+    # this URL and use the capacity check below instead.
+    curl -fsS --max-time 30 --retry 5 --retry-all-errors \
+      "${base_url}/ready" >/dev/null
+  else
+    # The tag activates the revision minimum without assigning production
+    # traffic. Verify both process readiness and the requested warm capacity
+    # through the Cloud Run control plane. The staged LB watchdog below owns
+    # HTTP validation once the candidate receives canary traffic.
+    cloud_run_revision_capacity_ready \
+      "$SERVICE" "$target" "$PROJECT_ID" "$revision" "$min_instances"
+  fi
   log "capacity after ${target} warm: ${revision} ready at revision min=${min_instances}; service min unchanged"
 }
 
@@ -973,10 +1000,8 @@ if [ "${TR_DEPLOY_NO_TRAFFIC:-0}" = "1" ]; then
       echo "ERROR: could not find warmed Ready revision for ${warm_target}" >&2
       exit 1
     fi
-    warm_min_instances="${TR_CLOUD_RUN_MIN_INSTANCES:-}"
-    if [ -z "$warm_min_instances" ]; then
-      warm_min_instances="$(cloud_run_min_instances_for_region "$warm_target")"
-    fi
+    warm_service_min_instances="$(cloud_run_service_min_instances_for_region "$warm_target")"
+    warm_min_instances="$(cloud_run_candidate_min_instances "$warm_service_min_instances")"
     warm_no_traffic_candidate \
       "$warm_target" "$warm_revision" "$warm_min_instances"
   done

--- a/scripts/deploy/staged_traffic.sh
+++ b/scripts/deploy/staged_traffic.sh
@@ -197,6 +197,17 @@ probe_legacy_path() {
 probe_legacy_surface_or_rollback() {
   local stage_pct="$1"
   local base_url
+  local service_ingress
+  if ! service_ingress="$(cloud_run_service_ingress \
+      "$SERVICE" "$REGION" "$PROJECT_ID")"; then
+    rollback_to_old \
+      "could not determine Cloud Run ingress after ${stage_pct}% shift"
+    exit 1
+  fi
+  if [ "$service_ingress" != "all" ]; then
+    log "direct run.app probe disabled by service ingress after ${stage_pct}% shift; load-balancer watchdog owns HTTP validation"
+    return 0
+  fi
   if ! base_url="$(legacy_surface_base_url)"; then
     log "legacy surface probe inconclusive after ${stage_pct}% shift: regional Cloud Run URL unavailable"
     return 0

--- a/scripts/deploy/synthetic.sh
+++ b/scripts/deploy/synthetic.sh
@@ -205,6 +205,21 @@ prepare_synthetic_ingest_target() {
   verify_synthetic_ingest_service_contract "$target_region"
 }
 
+synthetic_ingest_base_for_region() {
+  local target_region="$1"
+  if [ "$DEPLOYED_COMBINED_BRIDGE" = "true" ]; then
+    # The combined service now uses private Cloud Run ingress. Its run.app URL
+    # intentionally returns a Google platform 404, including to Cloud Run jobs
+    # without the split service's VPC path. Reach the same token-protected
+    # internal routes through the external load balancer until the dedicated
+    # internal observer service is active in every region.
+    printf '%s\n' "https://trustedrouter.com"
+  else
+    printf 'https://%s-%s.%s.run.app\n' \
+      "$SYNTHETIC_INGEST_SERVICE" "$PROJECT_NUMBER" "$target_region"
+  fi
+}
+
 if ! gc artifacts docker images describe "$IMAGE" >/dev/null 2>&1; then
   echo "ERROR: image ${IMAGE} does not exist. Run scripts/deploy/image.sh before synthetic.sh." >&2
   exit 1
@@ -252,7 +267,7 @@ IFS=',' read -ra _REGION_LIST <<<"$SYNTHETIC_MONITOR_REGIONS"
 monitor_index=0
 for monitor_region in "${_REGION_LIST[@]}"; do
   [ -n "$monitor_region" ] || continue
-  regional_ingest_base="https://${SYNTHETIC_INGEST_SERVICE}-${PROJECT_NUMBER}.${monitor_region}.run.app"
+  regional_ingest_base="$(synthetic_ingest_base_for_region "$monitor_region")"
   job_name="trusted-router-synthetic-${monitor_region//[^a-zA-Z0-9-]/-}"
   scheduler_name="${job_name}-every-three-minutes"
   legacy_scheduler_names=(
@@ -328,7 +343,7 @@ done
 # has a separate Cloud Run Job so a slow 512-token stream cannot delay or
 # overlap TLS, attestation, billing, fallback, or short provider probes.
 throughput_region="us-central1"
-throughput_ingest_base="https://${SYNTHETIC_INGEST_SERVICE}-${PROJECT_NUMBER}.${throughput_region}.run.app"
+throughput_ingest_base="$(synthetic_ingest_base_for_region "$throughput_region")"
 throughput_job_name="trusted-router-throughput-${throughput_region}"
 throughput_scheduler_name="${throughput_job_name}-every-five-minutes"
 legacy_throughput_scheduler_names=(
@@ -400,7 +415,7 @@ done
 # Image generation is materially more expensive than text PONG probes. Keep it
 # isolated and run one canonical end-to-end request every six hours.
 image_region="us-central1"
-image_ingest_base="https://${SYNTHETIC_INGEST_SERVICE}-${PROJECT_NUMBER}.${image_region}.run.app"
+image_ingest_base="$(synthetic_ingest_base_for_region "$image_region")"
 image_job_name="trusted-router-image-generation-${image_region}"
 image_scheduler_name="${image_job_name}-every-six-hours"
 image_env_vars=(
@@ -443,7 +458,7 @@ upsert_scheduler \
 # or about $10.71 per 30 days. max-retries=0 plus a date-scoped idempotency key
 # prevents duplicate billing.
 video_region="us-central1"
-video_ingest_base="https://${SYNTHETIC_INGEST_SERVICE}-${PROJECT_NUMBER}.${video_region}.run.app"
+video_ingest_base="$(synthetic_ingest_base_for_region "$video_region")"
 video_job_name="trusted-router-video-generation-${video_region}"
 video_scheduler_name="${video_job_name}-daily"
 video_env_vars=(

--- a/tests/deploy_script_harness.py
+++ b/tests/deploy_script_harness.py
@@ -406,8 +406,22 @@ if tag_path.is_file():
             "tag": "staged-probe",
         }
     )
-print(json.dumps({"status": {"traffic": traffic}}, separators=(",", ":")))
+print(json.dumps({
+    "metadata": {"annotations": {
+        "run.googleapis.com/ingress": "internal-and-cloud-load-balancing"
+    }},
+    "status": {"traffic": traffic},
+}, separators=(",", ":")))
 PY
+    exit 0
+  fi
+  if [[ " $* " == *" run revisions describe trusted-router-candidate "* ]] \
+      && [[ " $* " == *" --format=json "* ]]; then
+    if [ "${HARNESS_ROLLOUT_CANDIDATE_READY:-1}" = "1" ]; then
+      printf '%s\n' '{"metadata":{"name":"trusted-router-candidate"},"status":{"conditions":[{"type":"Ready","status":"True"},{"type":"MinInstancesProvisioned","status":"True"}],"desiredReplicas":2}}'
+    else
+      printf '%s\n' '{"metadata":{"name":"trusted-router-candidate"},"status":{"conditions":[{"type":"Ready","status":"False"}],"desiredReplicas":0}}'
+    fi
     exit 0
   fi
   if [[ " $* " == *" run revisions describe trusted-router-public-active "* ]] \

--- a/tests/test_ddos_edge_deploy.py
+++ b/tests/test_ddos_edge_deploy.py
@@ -711,7 +711,7 @@ def test_azure_canary_is_public_with_only_a_dedicated_attribution_signer() -> No
     assert "public canary OAuth capability verification failed" in deploy
 
 
-def test_every_synthetic_job_uses_private_run_app_ingress() -> None:
+def test_every_synthetic_job_uses_the_ingress_appropriate_ingest_base() -> None:
     deploy = (ROOT / "scripts/deploy/synthetic.sh").read_text(encoding="utf-8")
 
     assert 'source "${SCRIPT_DIR}/_private_run_ingress.sh"' in deploy
@@ -729,7 +729,9 @@ def test_every_synthetic_job_uses_private_run_app_ingress() -> None:
     ) in deploy
     assert 'SYNTHETIC_INGEST_SERVICE="$SERVICE"' in deploy
     assert "TR_SYNTHETIC_INGEST_SERVICE" not in deploy
-    assert deploy.count("${SYNTHETIC_INGEST_SERVICE}-${PROJECT_NUMBER}") == 4
+    assert deploy.count("$(synthetic_ingest_base_for_region") == 4
+    assert 'printf \'%s\\n\' "https://trustedrouter.com"' in deploy
+    assert "printf 'https://%s-%s.%s.run.app\\n'" in deploy
     assert deploy.count("gc run jobs deploy") == 4
     assert deploy.count('"$JOB_SECRET_FLAG" "$JOB_SECRETS"') == 4
     assert 'JOB_SECRET_FLAG="--set-secrets"' in deploy

--- a/tests/test_deploy_script_execution.py
+++ b/tests/test_deploy_script_execution.py
@@ -237,7 +237,7 @@ def _initialize_bake_harness_repo(harness: DeployScriptHarness) -> str:
     ).stdout.strip()
 
 
-def test_gcp_no_traffic_warm_preprovisions_and_tags_candidate(
+def test_gcp_no_traffic_warm_preprovisions_and_validates_private_candidate(
     harness: DeployScriptHarness,
 ) -> None:
     run = harness.run("scripts/deploy/rollout.sh")
@@ -252,6 +252,15 @@ def test_gcp_no_traffic_warm_preprovisions_and_tags_candidate(
     assert deploy[deploy.index("--min") + 1] == "2"
     assert deploy[deploy.index("--min-instances") + 1] == "2"
     assert "--no-traffic" in deploy
+    assert any(
+        call[0:4] == ["gcloud", "run", "revisions", "describe"]
+        and "trusted-router-candidate" in call
+        for call in run.calls
+    )
+    assert not any(
+        call[0] == "curl" and "staged-probe---" in call[-1]
+        for call in run.calls
+    )
 
 
 def test_rollout_lists_optional_secrets_once_without_missing_secret_probes(
@@ -351,9 +360,8 @@ def test_warm_primer_never_exceeds_a_cold_service_minimum(
     warm_index = next(
         index
         for index, call in enumerate(run.calls)
-        if call[0] == "curl"
-        and call[-1]
-        == "https://staged-probe---trusted-router-hash-uc.a.run.app/ready"
+        if call[0:4] == ["gcloud", "run", "revisions", "describe"]
+        and "trusted-router-candidate" in call
     )
     assert tag_index < warm_index
     assert not any("--remove-tags=staged-probe" in call for call in run.calls)
@@ -364,7 +372,7 @@ def test_gcp_failed_candidate_warm_restores_zero_traffic_capacity(
 ) -> None:
     run = harness.run(
         "scripts/deploy/rollout.sh",
-        extra_env={"HARNESS_PUBLIC_SMOKE_TRANSPORT_PATH": "/ready"},
+        extra_env={"HARNESS_ROLLOUT_CANDIDATE_READY": "0"},
     )
     assert run.returncode != 0
 
@@ -1965,7 +1973,8 @@ def test_synthetic_combined_bridge_restores_legacy_job_deploys(
         deploy_text = " ".join(deploy)
         deployed_env = _cloud_run_job_env(deploy)
         region = deploy[deploy.index("--region") + 1]
-        assert f"https://trusted-router-stub-output.{region}.run.app" in deploy_text
+        assert "https://trustedrouter.com/v1/internal/synthetic/" in deploy_text
+        assert f"https://trusted-router-stub-output.{region}.run.app" not in deploy_text
         assert (
             "TR_INTERNAL_GATEWAY_TOKEN=trustedrouter-internal-gateway-token:latest" in deploy_text
         )
@@ -1979,9 +1988,9 @@ def test_synthetic_combined_bridge_restores_legacy_job_deploys(
         assert "--network" not in deploy
         assert "--subnet" not in deploy
         assert "--vpc-egress" not in deploy
-        # The combined service keeps ingress=all and the pre-#714 jobs reached it over
-        # the public run.app URL with no VPC; bridge mode must not grow a private path
-        # before the split actually restricts ingress.
+        # The combined service is private behind the load balancer. Bridge jobs
+        # reach token-protected ingest routes through that load balancer and must
+        # not grow a private VPC path before the split service is active.
         assert not any(
             arg == flag or arg.startswith(f"{flag}=")
             for arg in deploy

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -177,7 +177,17 @@ def test_all_attested_control_plane_regions_remain_warm() -> None:
     # the no-traffic deploy wait for that many Ready instances (us-east4 pins
     # 8; the warm step ran 7m37). The primer caps at min(2, service minimum).
     assert 'prewarm_floor="${TR_CLOUD_RUN_PREWARM_MIN_INSTANCES:-2}"' in rollout
-    assert 'revision_min_instances="$prewarm_floor"' in rollout
+    assert "cloud_run_candidate_min_instances()" in rollout
+    assert (
+        'revision_min_instances="$(cloud_run_candidate_min_instances '
+        '"$min_instances")"'
+        in rollout
+    )
+    assert (
+        'warm_min_instances="$(cloud_run_candidate_min_instances '
+        '"$warm_service_min_instances")"'
+        in rollout
+    )
     assert '--min-instances "$revision_min_instances"' in rollout
     assert '"TR_SPANNER_POOL_SIZE=${TR_SPANNER_POOL_SIZE}"' in rollout
 

--- a/tests/test_deploy_watchdog.py
+++ b/tests/test_deploy_watchdog.py
@@ -174,6 +174,7 @@ def _run_staged_probe(
     remove_leaves_tag: bool = False,
     traffic_shift_failure_pct: int | None = None,
     watchdog_exit: int = 0,
+    service_ingress: str = "all",
 ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
     stub_bin = tmp_path / "bin"
     stub_bin.mkdir()
@@ -212,9 +213,9 @@ case " $* " in
   *" --format=json"*)
     tagged_revision="$(cat "$STAGED_TAG_STATE")"
     if [ -n "$tagged_revision" ]; then
-      printf '{"status":{"traffic":[{"percent":100,"revisionName":"old-rev"},{"percent":0,"revisionName":"%s","tag":"staged-probe"}]}}\\n' "$tagged_revision"
+      printf '{"metadata":{"annotations":{"run.googleapis.com/ingress":"%s"}},"status":{"traffic":[{"percent":100,"revisionName":"old-rev"},{"percent":0,"revisionName":"%s","tag":"staged-probe"}]}}\\n' "$STAGED_SERVICE_INGRESS" "$tagged_revision"
     else
-      printf '%s\\n' '{"status":{"traffic":[{"percent":100,"revisionName":"old-rev"}]}}'
+      printf '{"metadata":{"annotations":{"run.googleapis.com/ingress":"%s"}},"status":{"traffic":[{"percent":100,"revisionName":"old-rev"}]}}\\n' "$STAGED_SERVICE_INGRESS"
     fi
     ;;
   *"status.url"*) printf '%s\\n' 'https://trusted-router-hash-uc.a.run.app' ;;
@@ -310,6 +311,7 @@ exit 0
         ),
         "STAGED_REAL_PYTHON": sys.executable,
         "STAGED_STUB_WATCHDOG_EXIT": str(watchdog_exit),
+        "STAGED_SERVICE_INGRESS": service_ingress,
         "TR_LEGACY_PROBE_RETRY_SECONDS": "0",
         "TR_PROBE_TAG_REMOVE_RETRY_SECONDS": "0",
         "TR_STAGED_WATCHDOG_BASELINE_FILE": str(tmp_path / "final-baseline.json"),
@@ -327,6 +329,30 @@ exit 0
         timeout=20,
     )
     return run, call_log.read_text().splitlines()
+
+
+def test_private_ingress_skips_runapp_probe_and_keeps_watchdog_gate(
+    tmp_path: Path,
+) -> None:
+    run, calls = _run_staged_probe(
+        tmp_path,
+        console_code="404",
+        session_code="404",
+        service_ingress="internal-and-cloud-load-balancing",
+    )
+
+    assert run.returncode == 0, run.stderr
+    assert not any(call.startswith("curl ") for call in calls)
+    assert "load-balancer watchdog owns HTTP validation" in run.stdout
+    traffic_calls = [
+        call
+        for call in calls
+        if call.startswith("gcloud run services update-traffic")
+        and "--to-revisions=" in call
+    ]
+    assert any("--to-revisions=new-rev=10,old-rev=90" in call for call in traffic_calls)
+    assert any("--to-revisions=new-rev=50,old-rev=50" in call for call in traffic_calls)
+    assert any("--to-revisions=new-rev=100" in call for call in traffic_calls)
 
 
 def test_probe_tag_resolution_uses_json_and_unset_tag_resolves_to_empty(

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -3067,8 +3067,13 @@ def test_synthetic_deploy_targets_public_api_and_private_internal_ingest() -> No
     assert '"${throughput_job_name}-every-two-minutes"' in body
     assert 'image_job_name="trusted-router-image-generation-${image_region}"' in body
     assert (
-        'regional_ingest_base="https://${SYNTHETIC_INGEST_SERVICE}-${PROJECT_NUMBER}.'
-        '${monitor_region}.run.app"'
+        'regional_ingest_base="$(synthetic_ingest_base_for_region '
+        '"$monitor_region")"'
+        in body
+    )
+    assert 'printf \'%s\\n\' "https://trustedrouter.com"' in body
+    assert (
+        "printf 'https://%s-%s.%s.run.app\\n'"
         in body
     )
     assert (


### PR DESCRIPTION
## Summary
- detect Cloud Run ingress explicitly and fail closed on malformed control-plane state
- validate private no-traffic candidates through revision readiness and provisioned capacity instead of inaccessible run.app URLs
- keep canonical load-balancer watchdogs active through the 10/50/100 staged traffic ramp
- share the candidate primer calculation between deploy and warm validation

## Verification
- bash syntax checks
- ruff
- 158 deployment, watchdog, workflow-region, and mutex tests
- new regression proves private ingress skips run.app while retaining every staged watchdog gate

The prior production deploy failed because the service intentionally uses internal-and-cloud-load-balancing ingress; Google returns a platform 404 for direct run.app URLs even when the revision is healthy.