### PR TITLE
Boot registration accepts the enclave's wire shape

### DIFF
--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -88,6 +88,8 @@ from trusted_router.provider_contracts import (
 )
 from trusted_router.provider_types import estimate_tokens_from_text
 from trusted_router.receipt_keys import (
+    AWS_ATTESTATION_KIND,
+    AZURE_ATTESTATION_KIND,
     GCP_ATTESTATION_KIND,
     attestation_commits_to_jwk,
     gcp_attestation_image_digest,
@@ -213,6 +215,11 @@ _BROADCAST_EMPTY_CACHE: OrderedDict[str, float] = OrderedDict()
 _BROADCAST_EMPTY_CACHE_LOCK = threading.Lock()
 _SPEND_LEASE_SIGNERS: dict[tuple[str, str], SpendLeaseSigner] = {}
 _SPEND_LEASE_SIGNERS_LOCK = threading.Lock()
+_SPEND_LEASE_WIRE_ATTESTATION_KINDS = {
+    "aws": AWS_ATTESTATION_KIND,
+    "azure": AZURE_ATTESTATION_KIND,
+    "gcp": GCP_ATTESTATION_KIND,
+}
 _NATIVE_BATCH_ROUTE_PREFIX = "batch.native."
 _NATIVE_BATCH_BILLED_FRACTION_BPS = {
     "openai": 5_000,
@@ -303,16 +310,26 @@ def _register_spend_lease_boot_sync(
 ) -> dict[str, Any]:
     require_internal_gateway(request, settings)
     try:
-        jwk = normalize_receipt_jwk(body.jwk)
+        jwk = normalize_receipt_jwk(body.receipt_public_key)
         kid = receipt_kid(jwk)
-        if not attestation_commits_to_jwk(body.attestation, body.attestation_kind, jwk):
+        if body.kid != kid:
+            raise ValueError("kid does not match the receipt public key")
+        attestation_kind = _SPEND_LEASE_WIRE_ATTESTATION_KINDS.get(
+            body.attestation_kind,
+            body.attestation_kind,
+        )
+        if not attestation_commits_to_jwk(
+            body.attestation_evidence,
+            attestation_kind,
+            jwk,
+        ):
             raise ValueError("attestation does not commit to the receipt public key")
         verified = False
         approved = False
         image_digest = ""
-        if body.attestation_kind == GCP_ATTESTATION_KIND:
-            verify_gcp_attestation_chain(body.attestation)
-            image_digest = gcp_attestation_image_digest(body.attestation)
+        if attestation_kind == GCP_ATTESTATION_KIND:
+            verify_gcp_attestation_chain(body.attestation_evidence)
+            image_digest = gcp_attestation_image_digest(body.attestation_evidence)
             verified = True
             approved = image_digest in settings.spend_lease_accepted_gcp_digests
         record = SpendLeaseBoot(
@@ -321,20 +338,13 @@ def _register_spend_lease_boot_sync(
             approved=approved,
             verified=verified,
             image_digest=image_digest,
-            attestation_kind=body.attestation_kind,
+            attestation_kind=attestation_kind,
             registered_at=iso_now(),
         )
         stored = STORE.observe_spend_lease_boot(record)
     except ValueError as exc:
         raise api_error(400, str(exc), ErrorType.BAD_REQUEST) from exc
-    return {
-        "data": {
-            "boot_kid": stored.kid,
-            "verified": stored.verified,
-            "approved": stored.approved,
-            "image_digest": stored.image_digest or None,
-        }
-    }
+    return {"data": {"verified": stored.verified}}
 
 
 async def authorize_gateway(

--- a/src/trusted_router/schemas.py
+++ b/src/trusted_router/schemas.py
@@ -264,9 +264,10 @@ class SpendLeaseEcho(_Strict):
 
 
 class SpendLeaseBootRegistrationRequest(_Strict):
-    jwk: dict[str, Any]
-    attestation: str = Field(min_length=1, max_length=2 * 1024 * 1024)
-    attestation_kind: Literal["gcp-cs-jwt", "aws-nitro-cose", "azure-maa-jwt"]
+    kid: str = Field(min_length=1, max_length=128)
+    receipt_public_key: dict[str, Any]
+    attestation_evidence: str = Field(min_length=1, max_length=2 * 1024 * 1024)
+    attestation_kind: str = Field(min_length=1, max_length=64)
 
 
 class GatewayAuthorizeRequest(_Lenient):

--- a/tests/test_spend_lease_gateway.py
+++ b/tests/test_spend_lease_gateway.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from fastapi import HTTPException
+from fastapi.testclient import TestClient
 from starlette.requests import Request
 
 from trusted_router.config import Settings
@@ -61,18 +62,14 @@ def test_boot_registration_accepts_verified_gcp_approved_digest(
     response = gateway._register_spend_lease_boot_sync(  # noqa: SLF001
         _request("/v1/internal/gateway/spend-lease/register-boot"),
         SpendLeaseBootRegistrationRequest(
-            jwk=jwk,
-            attestation="signed-gcp-evidence",
-            attestation_kind="gcp-cs-jwt",
+            kid=receipt_kid(jwk),
+            receipt_public_key=jwk,
+            attestation_evidence="signed-gcp-evidence",
+            attestation_kind="gcp",
         ),
         _registration_settings(digest),
     )
-    assert response["data"] == {
-        "boot_kid": receipt_kid(jwk),
-        "verified": True,
-        "approved": True,
-        "image_digest": digest,
-    }
+    assert response == {"data": {"verified": True}}
 
 
 def test_boot_registration_rejects_wrong_gcp_image_digest(
@@ -88,14 +85,14 @@ def test_boot_registration_rejects_wrong_gcp_image_digest(
     response = gateway._register_spend_lease_boot_sync(  # noqa: SLF001
         _request("/v1/internal/gateway/spend-lease/register-boot"),
         SpendLeaseBootRegistrationRequest(
-            jwk=jwk,
-            attestation="signed-gcp-evidence",
-            attestation_kind="gcp-cs-jwt",
+            kid=receipt_kid(jwk),
+            receipt_public_key=jwk,
+            attestation_evidence="signed-gcp-evidence",
+            attestation_kind="gcp",
         ),
         _registration_settings(configured),
     )
-    assert response["data"]["verified"] is True
-    assert response["data"]["approved"] is False
+    assert response == {"data": {"verified": True}}
     assert STORE.get_spend_lease_boot(receipt_kid(jwk)).approved is False  # type: ignore[union-attr]
 
 
@@ -114,9 +111,10 @@ def test_boot_registration_rejects_bad_gcp_chain_without_storing(
         gateway._register_spend_lease_boot_sync(  # noqa: SLF001
             _request("/v1/internal/gateway/spend-lease/register-boot"),
             SpendLeaseBootRegistrationRequest(
-                jwk=jwk,
-                attestation="forged",
-                attestation_kind="gcp-cs-jwt",
+                kid=receipt_kid(jwk),
+                receipt_public_key=jwk,
+                attestation_evidence="forged",
+                attestation_kind="gcp",
             ),
             _registration_settings("sha256:" + "11" * 32),
         )
@@ -132,14 +130,42 @@ def test_boot_registration_records_aws_as_unverified(
     response = gateway._register_spend_lease_boot_sync(  # noqa: SLF001
         _request("/v1/internal/gateway/spend-lease/register-boot"),
         SpendLeaseBootRegistrationRequest(
-            jwk=jwk,
-            attestation="bound-aws-cose",
-            attestation_kind="aws-nitro-cose",
+            kid=receipt_kid(jwk),
+            receipt_public_key=jwk,
+            attestation_evidence="bound-aws-cose",
+            attestation_kind="aws",
         ),
         _registration_settings("sha256:" + "11" * 32),
     )
-    assert response["data"]["verified"] is False
-    assert response["data"]["approved"] is False
+    assert response == {"data": {"verified": False}}
+    assert STORE.get_spend_lease_boot(receipt_kid(jwk)).approved is False  # type: ignore[union-attr]
+
+
+def test_boot_registration_wire_contract_accepts_literal_enclave_body(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wire_fixture = (
+        '{"kid":"testkid","receipt_public_key":{"kty":"OKP","crv":"Ed25519",'
+        '"x":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="},'
+        '"attestation_evidence":"<...>","attestation_kind":"gcp"}'
+    )
+    monkeypatch.setattr(gateway, "receipt_kid", lambda _jwk: "testkid")
+    monkeypatch.setattr(gateway, "attestation_commits_to_jwk", lambda *_args: True)
+    monkeypatch.setattr(gateway, "verify_gcp_attestation_chain", lambda _att: None)
+    monkeypatch.setattr(gateway, "gcp_attestation_image_digest", lambda _att: "")
+
+    response = client.post(
+        "/internal/gateway/spend-lease/register-boot",
+        content=wire_fixture,
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert set(payload) == {"data"}
+    assert set(payload["data"]) == {"verified"}
+    assert isinstance(payload["data"]["verified"], bool)
 
 
 def _seed_authorize() -> tuple[Any, Any, Ed25519PrivateKey, SpendLeaseBoot]:


### PR DESCRIPTION
Second integration mismatch on the registration endpoint (path was #936; now the body): `jwk` vs `receipt_public_key` plus attestation field alignment. [Record v10](https://claude.ai/code/artifact/88463c46-2627-4754-83a8-b4d6fb3d3a6e) pins the complete wire contract; the new contract test posts the enclave's literal JSON fixture — never a request built from the server's own schema, which is how both mismatches passed both repos' suites. Focused suite + route inventory green (52 total), mypy/ruff clean, full suite at baseline. Fail-closed dormancy contained both mismatches to telemetry. Needs admin merge.

Authored by Sol (codex-cli); reviewed by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)