### PR TITLE
Fix regional deploy synthetic signals

### DIFF
--- a/scripts/deploy/synthetic.sh
+++ b/scripts/deploy/synthetic.sh
@@ -124,6 +124,10 @@ BASE_ENV_VARS+=(
   # downtime, while still bounding true hangs.
   "TR_SYNTHETIC_MONITOR_TIMEOUT_SECONDS=30"
   "TR_SYNTHETIC_CONTROL_PLANE_URL=https://trustedrouter.com"
+  # Control-plane availability is a global service signal. Regional run.app
+  # URLs are not valid public origins when ingress is restricted to the load
+  # balancer, so probing a computed URL manufactures persistent 404 outages.
+  "TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL=https://trustedrouter.com"
   # One bounded pass per scheduler tick. Sub-minute passes made
   # provider-effective timeouts stack up behind health probes and caused
   # Cloud Run Job self-timeouts.

--- a/src/trusted_router/regions.py
+++ b/src/trusted_router/regions.py
@@ -215,36 +215,15 @@ def region_payload(settings: Settings) -> list[dict[str, Any]]:
                 if region == primary
                 else f"https://{settings.regional_api_hostname_template.format(region=region)}/v1"
             ),
-            # Per-region Cloud Run direct URL. The synthetic monitor
-            # uses this for /health probes that need to hit a
-            # SPECIFIC region's Cloud Run (not whichever region the
-            # global LB picks). The Cloud Run-managed cert covers
-            # `*.{region}.run.app` so it works for every region we
-            # have a Cloud Run service in — including the cold ones
-            # where the regional `api-{region}.quillrouter.com`
-            # hostname doesn't have a cert.
-            #
-            # Cold/warm doesn't matter: Cloud Run direct URLs work
-            # whether the service is at min-scale=0 or 1; they just
-            # incur a cold-start on first request after idle. The
-            # synthetic monitor probes them anyway because the cold-
-            # start tax IS the metric we want to measure.
-            "control_plane_url": _cloud_run_direct_url(settings, region),
+            # Do not guess a Cloud Run URL from service and project names.
+            # Services with internal-and-LB ingress return a Google 404 on
+            # their run.app URL, and Cloud Run's generated URL shape is not a
+            # stable derivation contract. The canonical control-plane health
+            # URL is configured explicitly on the canonical target instead.
+            "control_plane_url": None,
         }
         for region in configured_regions(settings)
     ]
-
-
-def _cloud_run_direct_url(settings: Settings, region: str) -> str:
-    """Build the Cloud Run direct URL for `region`. Format is
-    `https://{service}-{project_number}.{region}.run.app`.
-
-    project_number is read from settings if available so per-region
-    URLs work in dev/staging projects without code edits. Falls back
-    to the prod hash if unset (tests / unconfigured environments)."""
-    project_number = getattr(settings, "gcp_project_number", "") or "44325983244"
-    service = getattr(settings, "cloud_run_service_name", "") or "trusted-router"
-    return f"https://{service}-{project_number}.{region}.run.app"
 
 
 def region_map_payload(settings: Settings) -> list[dict[str, Any]]:

--- a/src/trusted_router/synthetic/components.py
+++ b/src/trusted_router/synthetic/components.py
@@ -51,6 +51,13 @@ OPS_PROBE_TYPES = frozenset(
 # probe that is recorded but surfaced nowhere is a signal that reports
 # success without measuring — this set is what makes the model path render.
 MODEL_INFERENCE_PROBES = {"openai_sdk_pong", "responses_pong"}
+# Deploy automation needs the end-to-end PONGs for every regional API target,
+# even though provider-effective failures remain outside router-core SLO math.
+# Keep this union named here so the status payload exports one complete
+# regional canary surface for deployment consumers.
+REGIONAL_DEPLOY_GATE_PROBES = frozenset(
+    REGIONAL_GATEWAY_PROBES | MODEL_INFERENCE_PROBES
+)
 
 COMPONENT_PROBES: dict[str, set[str]] = {
     "canonical_api": REGIONAL_GATEWAY_PROBES,

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -76,15 +76,10 @@ class SyntheticTarget:
     name: str
     api_base_url: str
     region: str | None = None
-    # Cloud Run direct URL for this region's control plane. When set,
-    # the synthetic monitor probes /health here too — separately from
-    # api_base_url's enclave probe — so we get a distinct per-region
-    # signal even when api_base_url's regional hostname CNAMEs to the
-    # global LB (cold regions, or warm regions whose ACME cert hasn't
-    # been issued yet because the MIG is at targetSize=0).
-    #
-    # None for the canonical target since that probe already hits the
-    # global enclave LB by definition.
+    # Explicit control-plane origin. GCP assigns the canonical load-balanced
+    # origin here; standalone clouds use their own public origin. Regional
+    # run.app URLs are not derived because private-ingress services reject
+    # those requests before application code.
     control_plane_url: str | None = None
     # ATTESTED-CERT-ONLY target: the gateway serves a self-signed cert it
     # minted inside the TEE (AWS Nitro standalone deployments), so CA
@@ -365,12 +360,10 @@ async def _run_target_synthetic_probes(
         attestation_nonce_probe(client, target, monitor_region=monitor_region),
         gateway_latency_phase_probes(target, monitor_region=monitor_region),
     ]
-    # Per-region control plane health via Cloud Run direct URL.
-    # tls_health above probes target.api_base_url which is the
-    # ENCLAVE (api-{region}.quillrouter.com) — that path can be
-    # broken by an enclave-side issue (MIG at size 0, ACME cert
-    # not issued, etc.) while the regional Cloud Run is fine.
-    # This separate probe pins the control-plane signal per region.
+    # Control-plane health is configured explicitly on the canonical target.
+    # Regional run.app URLs are not public origins when Cloud Run ingress is
+    # restricted to the load balancer, so deriving them creates false 404s.
+    # Enclave health remains independently pinned by tls_health above.
     if target.control_plane_url:
         probes.append(control_plane_health_probe(client, target, monitor_region=monitor_region))
     # Two independent conditions, deliberately. `paid_probes` is the cost
@@ -843,26 +836,16 @@ async def control_plane_health_probe(
     *,
     monitor_region: str,
 ) -> SyntheticProbeSample:
-    """Probe `/health` on the per-region Cloud Run direct URL.
-
-    Distinct from tls_health_probe (which hits the enclave-fronted
-    api_base_url) — this one bypasses the enclave LB entirely and
-    pins the request to the specific Cloud Run service running in
-    `target.region`. It's the only way to tell:
-
-      * "the Cloud Run instance in us-east4 is fine but its enclave
-        cert hasn't issued yet" (control_plane up, tls_health down),
-      * "the regional Cloud Run is OOM-killing" (control_plane down,
-        tls_health up because LB routes around to a different region).
-
-    The endpoint is /health (not /healthz) — that's what FastAPI
-    registered in main.py: `@router.get("/health")`. /healthz returns
-    401 because it falls through to the auth-required catch-all.
-    """
+    """Probe the explicitly configured global control-plane `/health` route."""
+    sample_target = SyntheticTarget(
+        "control-plane",
+        target.control_plane_url or target.api_base_url,
+        None,
+    )
     if not target.control_plane_url:
         return _sample(
             "control_plane_health",
-            target,
+            sample_target,
             monitor_region,
             "(no control_plane_url configured)",
             status="down",
@@ -883,7 +866,7 @@ async def control_plane_health_probe(
         ok = response.status_code == 200 and _health_ok(response)
         return _sample(
             "control_plane_health",
-            target,
+            sample_target,
             monitor_region,
             url,
             status="up" if ok else "down",
@@ -895,7 +878,7 @@ async def control_plane_health_probe(
     except httpx.HTTPError as exc:
         return _sample(
             "control_plane_health",
-            target,
+            sample_target,
             monitor_region,
             url,
             status="down",

--- a/src/trusted_router/synthetic/status.py
+++ b/src/trusted_router/synthetic/status.py
@@ -19,7 +19,7 @@ from trusted_router.synthetic.components import (
     COMPONENT_PROBE_TARGETS,
     GATEWAY_REGION_TARGET_NAMES,
     OPS_PROBE_TYPES,
-    REGIONAL_GATEWAY_PROBES,
+    REGIONAL_DEPLOY_GATE_PROBES,
     SLO_DEFINITIONS,
     UNCATEGORIZED_COMPONENT,
     applicable_component_definitions,
@@ -340,7 +340,7 @@ def _machine_region_samples(
     *,
     settings: Settings,
 ) -> list[SyntheticProbeSample]:
-    """Regional gateway samples consumed by deploy and watchdog automation."""
+    """Complete regional canaries consumed by deploy and watchdog automation."""
     published = {
         COMPONENT_PROBE_TARGETS[component_id]
         for component_id in published_machine_region_components(settings)
@@ -350,7 +350,7 @@ def _machine_region_samples(
     return [
         sample
         for sample in samples
-        if sample.target in published and sample.probe_type in REGIONAL_GATEWAY_PROBES
+        if sample.target in published and sample.probe_type in REGIONAL_DEPLOY_GATE_PROBES
     ]
 
 

--- a/tests/test_status_component_scope.py
+++ b/tests/test_status_component_scope.py
@@ -178,6 +178,83 @@ def test_gcp_current_checks_expose_regions_without_blending_router_core_slo() ->
     assert slo_classes["router_core"]["windows"]["5m"]["sample_count"] == 1
 
 
+def test_gcp_current_checks_keep_complete_regional_deploy_canaries() -> None:
+    """A bounded public sample tail cannot crowd deploy-gate PONGs out."""
+    now = utcnow()
+    created_at = _iso(now - dt.timedelta(seconds=10))
+    samples = [
+        _tls_sample(created_at=created_at),
+        _tls_sample(created_at=created_at, target="us-central1"),
+        SyntheticProbeSample(
+            id="syn-region-attestation",
+            probe_type="attestation_nonce",
+            target="us-central1",
+            target_region="us-central1",
+            target_url="https://api-us-central1.quillrouter.com/attestation",
+            monitor_region="europe-west4",
+            status="up",
+            created_at=created_at,
+        ),
+        SyntheticProbeSample(
+            id="syn-region-chat",
+            probe_type="openai_sdk_pong",
+            target="us-central1",
+            target_region="us-central1",
+            target_url="https://api-us-central1.quillrouter.com/v1/chat/completions",
+            monitor_region="europe-west4",
+            status="up",
+            created_at=created_at,
+        ),
+        SyntheticProbeSample(
+            id="syn-region-responses",
+            probe_type="responses_pong",
+            target="us-central1",
+            target_region="us-central1",
+            target_url="https://api-us-central1.quillrouter.com/v1/responses",
+            monitor_region="europe-west4",
+            status="down",
+            created_at=created_at,
+        ),
+    ]
+    samples.extend(
+        SyntheticProbeSample(
+            id=f"syn-newer-control-plane-{index}",
+            probe_type="gateway_authorize",
+            target="control-plane",
+            target_url="https://trustedrouter.com/internal/gateway/authorize",
+            monitor_region="europe-west4",
+            status="up",
+            created_at=_iso(now - dt.timedelta(seconds=1)),
+        )
+        for index in range(120)
+    )
+
+    snapshot = status_snapshot(samples, now=now, settings=_gcp_settings())
+    checks = snapshot["current"]["checks"]
+
+    assert {
+        row["probe_type"] for row in checks if row["target"] == "us-central1"
+    } == {
+        "attestation_nonce",
+        "openai_sdk_pong",
+        "responses_pong",
+        "tls_health",
+    }
+    assert not any(
+        row["target"] == "us-central1"
+        and row["probe_type"] in {"openai_sdk_pong", "responses_pong"}
+        for row in snapshot["samples"]
+    )
+    responses = next(
+        row
+        for row in checks
+        if row["target"] == "us-central1"
+        and row["probe_type"] == "responses_pong"
+    )
+    assert responses["effective_status"] == "down"
+    assert snapshot["slo_classes"]["router_core"]["status"] == "up"
+
+
 def test_aws_eu_does_not_advertise_gcp_regional_gateways() -> None:
     ids = tuple(
         str(definition["id"]) for definition in applicable_component_definitions(_aws_eu_settings())

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -64,6 +64,7 @@ from trusted_router.synthetic.probes import (
     _sse_line_has_content,
     attestation_nonce_probe,
     choose_rotation_target,
+    control_plane_health_probe,
     gateway_billing_probe,
     gateway_fallback_probe,
     gateway_latency_phase_probes,
@@ -1667,6 +1668,30 @@ async def test_synthetic_http_probes_parse_success_shapes() -> None:
 
 
 @pytest.mark.asyncio
+async def test_control_plane_health_is_global_not_primary_region() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url == "https://trustedrouter.com/health"
+        return httpx.Response(200, json={"status": "ok"})
+
+    target = SyntheticTarget(
+        "canonical",
+        "https://api.trustedrouter.com/v1",
+        "us-central1",
+        control_plane_url="https://trustedrouter.com",
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sample = await control_plane_health_probe(
+            client,
+            target,
+            monitor_region="europe-west4",
+        )
+
+    assert sample.status == "up"
+    assert sample.target == "control-plane"
+    assert sample.target_region is None
+
+
+@pytest.mark.asyncio
 async def test_attestation_http_error_is_availability_failure_not_format_failure() -> None:
     def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(500, json={"error": {"message": "revision starting"}})
@@ -2205,6 +2230,7 @@ def test_configured_targets_include_primary_regional_gateway() -> None:
         api_base_url="https://api.trustedrouter.com/v1",
         regions="us-central1,us-east4,europe-west4,southamerica-east1",
         primary_region="us-central1",
+        synthetic_control_plane_health_url="https://trustedrouter.com",
     )
 
     targets = configured_targets(settings)
@@ -2212,6 +2238,7 @@ def test_configured_targets_include_primary_regional_gateway() -> None:
 
     assert by_name["canonical"].api_base_url == "https://api.trustedrouter.com/v1"
     assert by_name["canonical"].region == "us-central1"
+    assert by_name["canonical"].control_plane_url == "https://trustedrouter.com"
     assert by_name["us-central1"].api_base_url == (
         "https://api-us-central1.quillrouter.com/v1"
     )
@@ -2222,6 +2249,11 @@ def test_configured_targets_include_primary_regional_gateway() -> None:
     )
     assert by_name["southamerica-east1"].api_base_url == (
         "https://api-southamerica-east1.quillrouter.com/v1"
+    )
+    assert all(
+        target.control_plane_url is None
+        for name, target in by_name.items()
+        if name != "canonical"
     )
 
 


### PR DESCRIPTION
## Summary
- expose complete per-region TLS, attestation, Chat PONG, and Responses PONG canaries in the unbounded machine-readable status surface
- stop deriving unusable private-ingress Cloud Run URLs and probe canonical control-plane health explicitly
- label the canonical control-plane health signal as global rather than US Central
- add regression coverage for bounded public sample tails and provider failures staying outside Router Core SLO math

## Verification
- 334 focused synthetic/deploy tests passed
- Ruff passed on changed Python files
- Claude Opus reviewed the patch; actionable findings were addressed

## Rollout note
This repairs the status surface consumed by the enclave deployment gate. Tencent remains dark because its paid PONG currently returns HTTP 402 INSUFFICIENT_BALANCE.