### PR TITLE
Fix final smoke for private Cloud Run ingress

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1010,6 +1010,7 @@ jobs:
       - name: Smoke test prod
         run: |
           set -euo pipefail
+          source scripts/deploy/_cloud_run_revision_probe.sh
           check_url() {
             local name="$1"
             local url="$2"
@@ -1047,18 +1048,26 @@ jobs:
             "https://trust.trustedrouter.com/trust/gcp-release.json?nocache=${GITHUB_RUN_ID}"
 
           # A global request can repeatedly land on a healthy warm region and
-          # miss a stale cold revision. Exercise the shared-storage reader in
-          # every load-balanced control-plane region directly.
+          # miss a stale cold revision. Public Cloud Run origins can be probed
+          # directly. Private origins intentionally return Google's platform
+          # 404 outside the load balancer, so retain the staged regional
+          # canaries above and require exact revision/config convergence here.
           for region in us-central1 us-east4 europe-west4 southamerica-east1; do
             service_json=$(gcloud run services describe "${SERVICE}" \
               --project="${PROJECT_ID}" --region="${region}" \
               --format=json)
-            service_url=$(jq -r '.status.url' <<<"${service_json}")
-            check_url "ready_${region}" "${service_url}/ready"
-            check_url "status_${region}" "${service_url}/status.json"
-            check_url "status_page_${region}" "${service_url}/status"
-            check_url "leaderboard_${region}" "${service_url}/leaderboard"
-            check_url "video_leaderboard_${region}" "${service_url}/leaderboard/video"
+            service_ingress=$(cloud_run_service_ingress \
+              "${SERVICE}" "${region}" "${PROJECT_ID}")
+            if [ "${service_ingress}" = "all" ]; then
+              service_url=$(jq -r '.status.url' <<<"${service_json}")
+              check_url "ready_${region}" "${service_url}/ready"
+              check_url "status_${region}" "${service_url}/status.json"
+              check_url "status_page_${region}" "${service_url}/status"
+              check_url "leaderboard_${region}" "${service_url}/leaderboard"
+              check_url "video_leaderboard_${region}" "${service_url}/leaderboard/video"
+            else
+              echo "${region}: private Cloud Run ingress (${service_ingress}); validated through staged regional canary and revision convergence"
+            fi
 
             latest_ready=$(jq -r '.status.latestReadyRevisionName // ""' \
               <<<"${service_json}")

--- a/tests/test_deploy_workflow_regions.py
+++ b/tests/test_deploy_workflow_regions.py
@@ -20,28 +20,36 @@ def test_every_load_balanced_control_plane_region_is_staged() -> None:
         assert f'ramp_secondary "{region}"' in rollout
 
 
-def test_prod_smoke_checks_each_control_plane_region_directly() -> None:
+def test_prod_smoke_checks_public_origins_and_converges_private_regions() -> None:
     workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
 
     assert (
         "for region in us-central1 us-east4 europe-west4 southamerica-east1; do"
         in workflow
     )
-    assert 'check_url "ready_${region}" "${service_url}/ready"' in workflow
-    assert 'check_url "status_${region}" "${service_url}/status.json"' in workflow
-    assert 'check_url "status_page_${region}" "${service_url}/status"' in workflow
-    assert 'check_url "leaderboard_${region}" "${service_url}/leaderboard"' in workflow
+    smoke = workflow.split("- name: Smoke test prod", 1)[1]
+    assert "source scripts/deploy/_cloud_run_revision_probe.sh" in smoke
+    assert "service_ingress=$(cloud_run_service_ingress" in smoke
+    assert 'if [ "${service_ingress}" = "all" ]; then' in smoke
+    direct = smoke.split('if [ "${service_ingress}" = "all" ]; then', 1)[1].split(
+        "else", 1
+    )[0]
+    assert 'check_url "ready_${region}" "${service_url}/ready"' in direct
+    assert 'check_url "status_${region}" "${service_url}/status.json"' in direct
+    assert 'check_url "status_page_${region}" "${service_url}/status"' in direct
+    assert 'check_url "leaderboard_${region}" "${service_url}/leaderboard"' in direct
     assert (
         'check_url "video_leaderboard_${region}" "${service_url}/leaderboard/video"'
-        in workflow
+        in direct
     )
-    assert 'active_revision=$(jq -r' in workflow
-    assert '[ "${active_count}" != "1" ]' in workflow
-    assert '[ "${active_revision}" != "${latest_ready}" ]' in workflow
-    assert '[ "${latest_ready}" != "${latest_created}" ]' in workflow
-    assert 'gcloud run revisions describe "${active_revision}"' in workflow
-    assert '[ "${active_release}" != "${SHA}" ]' in workflow
-    assert '[ "${retired_secret_count}" != "0" ]' in workflow
+    assert "private Cloud Run ingress" in smoke
+    assert 'active_revision=$(jq -r' in smoke
+    assert '[ "${active_count}" != "1" ]' in smoke
+    assert '[ "${active_revision}" != "${latest_ready}" ]' in smoke
+    assert '[ "${latest_ready}" != "${latest_created}" ]' in smoke
+    assert 'gcloud run revisions describe "${active_revision}"' in smoke
+    assert '[ "${active_release}" != "${SHA}" ]' in smoke
+    assert '[ "${retired_secret_count}" != "0" ]' in smoke
 
 
 def test_deploy_syncs_the_shared_public_snapshot_worker() -> None:


### PR DESCRIPTION
## Summary
- preserve direct regional HTTP smoke checks for public Cloud Run services
- skip impossible direct run.app curls only for explicitly private ingress
- keep public load-balancer smoke, staged regional canaries, exact revision convergence, release identity, and config verification mandatory
- fail closed on unknown ingress through the shared parser

## Verification
- uv run pytest -q tests/test_deploy_workflow_regions.py tests/test_deploy_watchdog.py
- uv run ruff check tests/test_deploy_workflow_regions.py
- git diff --check

Claude CLI review was attempted but the local CLI session was not authenticated; normal PR CI remains required before merge.