### PR TITLE
Fix typed usage audit for bounded retention

### DIFF
--- a/docs/design/billing-dual-system-deletion-handoff.md
+++ b/docs/design/billing-dual-system-deletion-handoff.md
@@ -101,7 +101,15 @@ print("tr_reservation total", tot, "open", opn, "topopen", [(w[:8], c) for w, c 
 
 ## 4. STEP 2 — Fix `ea7dd3d8` $3.42 + finish #89 (only AFTER 1b)
 
-Now JSON usage is frozen, so `typed total_usage = JSON.total_usage + Σ settled-Credits actual_micro` is permanently correct.
+At cutover, before terminal-row retention began deleting settled reservations,
+`typed total_usage = JSON.total_usage + Σ settled-Credits actual_micro` was a
+valid reconciliation equation. It is **not a permanent lifetime invariant**:
+`total_usage` is monotonic and lifetime-scoped, while terminal
+`tr_reservation` rows are deleted after 30 days. After that boundary, a
+positive remainder is unretained history and must never be used to lower the
+customer counter. Standing audits may still fail on a counter below the
+retained ledger or on an orphan booking; exact lifetime equality requires a
+bounded delta audit or an independently verified historical checkpoint.
 
 1. **Reap `ea7dd3d8`'s 18 dead typed holds.** They expired 2026-06-25 15:36+ (settles failed in the clobber incident). Use **reviewed tooling** — either add a `reap` subcommand to `ramp_typed_billing.py` (thin wrapper over the tested `store.reap_expired_reservations(now, limit)`, `storage_gcp_authorize.py:238`; fleet-wide, oldest-expired first, claim-gated so a racing settle is safe) — codex-review + merge it — or rely on the scheduled reaper if one is wired. Verify `ea7dd3d8` open holds → 0 and its typed reserved → 0; auditor stays CLEAN.
 2. **Finish PR #89** (`billing-usage-reconcile` branch): its blocker was "can't prove no pending legacy settle" — now there *is* no legacy settle path, so the concern is moot. Either drop the JSON-stability worry entirely (document why: legacy settle path deleted in 1b) or keep the existing **drain guard** (no open typed holds; already added). Re-run codex; it should PASS now. Merge.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -860,9 +860,14 @@ fails closed if the configured typed shard set is incomplete.
   11:43 UTC; a failing run alerts). It is now purely typed-INTERNAL: `reserved`
   equals the sum of that workspace/key's open typed-origin holds (both
   directions — it also flags an orphan open-hold group with no typed row), and
-  `reserved >= 0`. It does NOT compare against JSON (that book is dead), so a
-  stale JSON total can never false-alarm it. A failure means real drift between
-  the reserved counter and live holds — investigate, do not just re-run.
+  `reserved >= 0`. Its usage arm requires the lifetime counter to cover all
+  retained bookings and flags bookings with no typed balance. Terminal request
+  rows expire after 30 days, so a positive lifetime-counter remainder is
+  reported as partial history coverage, not a violation and never a reason to
+  lower `total_usage`. It does NOT compare against JSON (that book is dead), so
+  a stale JSON total can never false-alarm it. A hard failure means real drift
+  between typed counters and retained holds/bookings — investigate, do not just
+  re-run.
 - `repair_typed_reserved` — the fix for a drifted `reserved` (e.g. holds the
   reaper freed without decrementing under some past bug). Recomputes `reserved`
   from live open holds. Run read-only/dry first, then `--apply`. It still refuses

--- a/scripts/record_usage_baselines.py
+++ b/scripts/record_usage_baselines.py
@@ -1,21 +1,23 @@
-"""Record the pre-ledger usage baseline for workspaces that still need one.
+"""Record a verified pre-ledger usage baseline for workspaces that still need one.
 
 Read-only unless ``--apply``. It records no number of its own: the baseline is
-the remainder the typed ledger cannot account for, which is by definition usage
-booked before the ledger began. Recording it changes no counter and moves no
-money -- it makes ``audit_typed_invariants`` able to check that workspace at
-all, where today it reports it as unauditable.
+the remainder the retained typed ledger cannot account for. Before terminal-row
+retention began, that remainder was pre-ledger usage. It is no longer safe to
+infer this automatically because settled reservations expire after 30 days.
+Recording changes no counter and moves no money, but a wrong baseline would
+make an incomplete audit look exact.
 
 Most workspaces need nothing. Where the ledger already explains the counter the
 baseline is zero and no row is written; only a counter that EXCEEDS its ledger
 has history to record.
 
   uv run python scripts/record_usage_baselines.py            # preflight
-  uv run python scripts/record_usage_baselines.py --apply
+  uv run python scripts/record_usage_baselines.py --apply \
+    --verified-retained-ledger-complete
 
-Refuses to overwrite an existing baseline. A baseline is a claim about history,
-so a second, different value for one workspace means one of them is wrong and a
-person should decide which.
+Apply is fail-closed unless the operator explicitly confirms independent
+evidence that no terminal rows are missing from the proposed retained ledger.
+It also refuses to overwrite an existing baseline.
 """
 
 from __future__ import annotations
@@ -42,10 +44,23 @@ def main(argv: list[str] | None = None, *, store: Any | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--workspace", action="append", dest="workspaces")
     parser.add_argument("--apply", action="store_true")
+    parser.add_argument(
+        "--verified-retained-ledger-complete",
+        action="store_true",
+        help="confirm independent evidence that no settled rows have aged out",
+    )
     args = parser.parse_args(argv)
 
     if args.apply and os.environ.get("TR_STORAGE_BACKEND") != "spanner-bigtable":
         print("ERROR: --apply requires TR_STORAGE_BACKEND=spanner-bigtable", file=sys.stderr)
+        return 2
+    if args.apply and not args.verified_retained_ledger_complete:
+        print(
+            "ERROR: refusing to infer a baseline from a retained ledger after "
+            "30-day row expiry. Independently verify that the proposed ledger "
+            "is complete, then pass --verified-retained-ledger-complete.",
+            file=sys.stderr,
+        )
         return 2
 
     active_store = create_store(Settings()) if store is None else store
@@ -78,7 +93,13 @@ def main(argv: list[str] | None = None, *, store: Any | None = None) -> int:
     recorded_at = dt.datetime.now(dt.UTC).isoformat().replace("+00:00", "Z")
     written = 0
     for proposal in outstanding:
-        if record_usage_baseline(active_store, proposal, recorded_at=recorded_at, apply=True):
+        if record_usage_baseline(
+            active_store,
+            proposal,
+            recorded_at=recorded_at,
+            apply=True,
+            retained_ledger_complete=True,
+        ):
             written += 1
         else:
             print(f"  skipped {proposal.workspace_id}: a baseline appeared concurrently")

--- a/src/trusted_router/storage_gcp_counter_reconcile.py
+++ b/src/trusted_router/storage_gcp_counter_reconcile.py
@@ -40,9 +40,14 @@ _OPEN_REGIONAL_QUOTA_ESCROW = (
     "ORDER BY open_index.id"
 )
 _OPEN_REGIONAL_QUOTA_STATES = frozenset({"pending", "active", "draining", "quarantined"})
-# ── Typed `total_usage` ledger reconstruction ───────────────────────────────
-# `total_usage` has exactly TWO writers on this store, and both leave a durable
-# row, so the counter is reconstructible rather than merely trusted:
+# ── Typed `total_usage` retained-ledger check ───────────────────────────────
+# `total_usage` is a lifetime counter, while terminal request rows are retained
+# for only 30 days. The retained ledger can therefore prove that a counter is
+# BELOW booked usage, and can expose orphan bookings, but it cannot prove exact
+# lifetime equality once terminal rows begin expiring. A positive remainder is
+# coverage-limited history, never permission to lower the monotonic counter.
+#
+# Two retained booking record families represented in this view are:
 #
 #   1. the typed settle (storage_gcp_counter_dml.release_credit) adds `actual`,
 #      and only for Credits traffic -- storage_gcp_authorize passes
@@ -54,7 +59,8 @@ _OPEN_REGIONAL_QUOTA_STATES = frozenset({"pending", "active", "draining", "quara
 #      federated_settlement_claim.
 #
 # Summing only (1) -- which is what the retired PR #89 did -- reads every
-# federated microdollar as drift. Both arms are required.
+# federated microdollar as drift. Both arms are required while their rows are
+# retained, but neither makes the lifetime equality durable forever.
 #: Shard-0 only, unlike the fleet-wide form above, because its only caller --
 #: repair_typed_usage -- refuses a sharded workspace outright. Keeping the
 #: filter also makes it fail SAFE if one ever slipped through: booked would come
@@ -145,11 +151,12 @@ class InvariantReport:
     key_violations: int = 0
     regional_lease_violations: int = 0
     usage_rows: int = 0
-    usage_violations: int = 0  # total_usage != baseline + settled actuals + federated
-    #: Rows whose baseline is unrecoverable, so usage can be neither confirmed nor
-    #: faulted. Counted apart from violations: calling them clean would overstate
-    #: coverage, and calling them violations would cry wolf on every workspace the
-    #: JSON cleanup has already run against.
+    usage_violations: int = 0  # counter below retained ledger, or orphan booking
+    #: Rows whose lifetime equality is unrecoverable, either because the legacy
+    #: baseline is absent or because 30-day terminal-row retention has removed
+    #: part of the settled ledger. Counted apart from violations: calling them
+    #: fully audited would overstate coverage, while calling them violations would
+    #: turn normal TTL progress into a billing incident.
     usage_unauditable: int = 0
     #: Counter below its ledger. Reported, NOT faulted, and deliberately so.
     #: A settle credits the balance and marks its reservation in separate
@@ -375,7 +382,7 @@ def audit_typed_invariants(store: Any, *, max_samples: int = 20) -> InvariantRep
 
     report.credit_rows, report.credit_violations = _check(typed_credit, credit_holds, "credit")
     report.key_rows, report.key_violations = _check(typed_key, key_holds, "api_key")
-    # ── usage: total_usage must equal everything the ledger says was booked ──
+    # ── usage: total_usage must cover everything the RETAINED ledger booked ──
     # Both directions again, in the same spirit as _check: a federated claim or a
     # settled actual for a workspace with NO typed row is a booking that landed
     # nowhere, and iterating typed rows alone cannot see it.
@@ -407,9 +414,11 @@ def audit_typed_invariants(store: Any, *, max_samples: int = 20) -> InvariantRep
                 # ledger accounts for the counter exactly. Fleet-wide this is
                 # 604 of 643 workspaces, which used to report as uncheckable.
                 continue
-            # Counter exceeds the ledger by an amount only pre-ledger history
-            # explains. Genuinely uncheckable until that number is recorded --
-            # and the remainder below IS the number to record.
+            # Counter exceeds the retained ledger. Before request-row TTL this
+            # meant pre-ledger history; now it can also mean settled rows aged
+            # out normally. Those cases are indistinguishable from this
+            # snapshot, so never turn the remainder into a baseline
+            # automatically.
             report.usage_unauditable += 1
             _unauditable(
                 f"usage-unauditable:{workspace_id}",
@@ -417,15 +426,15 @@ def audit_typed_invariants(store: Any, *, max_samples: int = 20) -> InvariantRep
                     "typed_total_usage": actual_usage,
                     "ledger_booked": booked,
                     "unexplained": actual_usage - booked,
-                    "why": "usage predates the ledger and no baseline is "
-                    "recorded. `unexplained` is the value to record as "
-                    f"kind={USAGE_BASELINE_KIND!r} to make this workspace "
-                    "auditable.",
+                    "why": "usage is not represented by the retained ledger. "
+                    "It may predate typed billing or may have aged out under "
+                    "the 30-day terminal-row policy. Do not record or repair "
+                    "this remainder without independent historical evidence.",
                 },
             )
             continue
         expected = baseline + booked
-        if actual_usage != expected or actual_usage < 0:
+        if actual_usage < expected or actual_usage < 0:
             report.usage_violations += 1
             _sample(
                 f"usage:{workspace_id}",
@@ -436,6 +445,28 @@ def audit_typed_invariants(store: Any, *, max_samples: int = 20) -> InvariantRep
                     "settled_actuals": settled_actuals.get(workspace_id, 0),
                     "federated_applied": federated_applied.get(workspace_id, 0),
                     "delta": actual_usage - expected,
+                },
+            )
+        elif actual_usage > expected:
+            # Terminal reservations have a 30-day row-deletion policy. Once one
+            # expires, the retained sum falls while lifetime total_usage must not.
+            # This is incomplete audit coverage, not evidence that the customer's
+            # usage counter is too high. In particular, never feed this remainder
+            # to the downward repair path.
+            report.usage_unauditable += 1
+            _unauditable(
+                f"usage-retained-history-gap:{workspace_id}",
+                {
+                    "typed_total_usage": actual_usage,
+                    "retained_expected": expected,
+                    "baseline": baseline,
+                    "retained_settled_actuals": settled_actuals.get(workspace_id, 0),
+                    "federated_applied": federated_applied.get(workspace_id, 0),
+                    "unretained_history": actual_usage - expected,
+                    "why": "terminal reservation rows expire after 30 days while "
+                    "total_usage is lifetime and monotonic. This retained-ledger "
+                    "gap cannot be repaired downward; use a bounded delta audit "
+                    "or an independently verified historical checkpoint.",
                 },
             )
     for workspace_id in set(settled_actuals) | set(federated_applied):
@@ -531,10 +562,10 @@ def _confirm_behind_ledger(
 # mirror overwrote typed `reserved` with the stale JSON value, so already-typed
 # workspaces have `reserved` frozen far from the truth (auditor flags them). Fix:
 # set credit + each key `reserved` = SUM of that scope's OPEN typed holds. We do
-# NOT touch total_usage — it is monotonic and verified ledger-consistent
-# (JSON baseline + Σ settled actuals) for active workspaces; the lone usage-damaged
-# case (ea7dd3d8) is handled separately. Fail-closed: requires billing_paused so
-# the open-hold set is stable while we write.
+# NOT touch total_usage: it is monotonic, and exact lifetime reconstruction from
+# 30-day terminal rows is impossible after retention begins. Usage repair is a
+# separate, stronger-gated operation. Fail-closed: requires billing_paused so the
+# open-hold set is stable while we write.
 
 
 @dataclass
@@ -728,13 +759,16 @@ def repair_typed_usage(
     *,
     apply: bool = False,
     allow_decrease: bool = False,
+    retained_ledger_complete: bool = False,
 ) -> UsageRepairResult:
     """Set typed `total_usage` = JSON baseline + settled Credits actuals +
     federated settlement claims, for a fully drained PAUSED workspace.
 
     Read-only when apply=False (reports before/after). Fail-closed: refuses
     unless billing_paused, unsharded, fully drained, and the JSON baseline still
-    exists. Refuses to LOWER the counter unless allow_decrease=True."""
+    exists. Refuses to LOWER the counter unless both ``allow_decrease`` and
+    ``retained_ledger_complete`` are true; the latter must come from independent
+    evidence because terminal reservations expire after 30 days."""
     pt = store._param_types
     res = UsageRepairResult(workspace_id=workspace_id, ready=False)
     usage_row_sql = (
@@ -819,15 +853,20 @@ def repair_typed_usage(
         res.total_usage_before is not None
         and res.total_usage_after is not None
         and res.total_usage_after < res.total_usage_before
-        and not allow_decrease
     ):
-        res.reasons.append(
-            f"refusing to lower total_usage "
-            f"{res.total_usage_before} -> {res.total_usage_after}: it is monotonic, "
-            "so a decrease means the ledger is missing rows rather than the "
-            "counter being wrong. Investigate first; pass allow_decrease=True "
-            "only once you know why"
-        )
+        if not allow_decrease:
+            res.reasons.append(
+                f"refusing to lower total_usage "
+                f"{res.total_usage_before} -> {res.total_usage_after}: it is monotonic, "
+                "so a decrease means the retained ledger is missing rows rather "
+                "than the counter being wrong. Investigate first"
+            )
+        elif not retained_ledger_complete:
+            res.reasons.append(
+                "refusing to lower total_usage without independent proof that "
+                "the retained ledger is complete; 30-day terminal-row expiry "
+                "normally makes the computed target too low"
+            )
 
     res.ready = not res.reasons
     if not res.ready or not apply:
@@ -882,7 +921,9 @@ def repair_typed_usage(
         recomputed = fresh_base + fresh_booked
         if recomputed != target:
             return None  # the ledger moved under us — abort rather than write a stale total
-        if recomputed < int(current[0][0]) and not allow_decrease:
+        if recomputed < int(current[0][0]) and (
+            not allow_decrease or not retained_ledger_complete
+        ):
             return None
         transaction.insert_or_update(
             table="tr_credit_balance",
@@ -907,9 +948,10 @@ def repair_typed_usage(
 # ── Recording a pre-ledger usage baseline ───────────────────────────────────
 # For the workspaces whose JSON baseline was deleted before anything needed it.
 # The value is not invented: it is the remainder the ledger cannot account for,
-# which is by definition the usage booked before the ledger began. Recording it
-# makes the workspace auditable from then on; it changes no counter and moves no
-# money.
+# which was usage booked before the ledger began only while the retained ledger
+# was known complete. Once terminal rows can expire, the remainder is merely a
+# candidate that requires independent historical verification. Recording it
+# changes no counter and moves no money.
 
 
 @dataclass
@@ -926,10 +968,12 @@ class UsageBaselineProposal:
 
 
 def propose_usage_baselines(store: Any) -> list[UsageBaselineProposal]:
-    """Every workspace whose counter exceeds its ledger, with the value to record.
+    """Every workspace whose counter exceeds its retained ledger.
 
     Read-only. A workspace whose ledger already explains its counter is absent:
-    its baseline is zero and needs no row.
+    its baseline is zero and needs no row. A proposal is not proof that the
+    remainder predates typed billing: after 30-day expiry it can include normal
+    unretained settlement rows, so the writer requires independent verification.
     """
     report_rows: list[UsageBaselineProposal] = []
     with store._database.snapshot(multi_use=True) as snap:
@@ -973,17 +1017,22 @@ def record_usage_baseline(
     *,
     recorded_at: str,
     apply: bool = False,
+    retained_ledger_complete: bool = False,
 ) -> bool:
-    """Write ONE baseline row. Read-only when apply=False.
+    """Write ONE independently verified baseline row. Read-only when apply=False.
 
     Refuses to overwrite an existing row: a baseline is a statement about
     history, so a second, different value for the same workspace means one of
-    them is wrong and a human should decide which.
+    them is wrong and a human should decide which. Apply also requires explicit
+    evidence that 30-day retention has not removed any rows from the proposal's
+    ledger; otherwise its remainder is not provably pre-ledger usage.
     """
     if proposal.already_recorded is not None:
         return False
     if not apply:
         return proposal.needed
+    if not retained_ledger_complete:
+        return False
     if not proposal.needed:
         return False
 

--- a/tests/test_billing_usage_drift.py
+++ b/tests/test_billing_usage_drift.py
@@ -128,12 +128,41 @@ def test_federated_settlement_is_booked_usage_not_drift() -> None:
     assert report.clean
 
     # And the arithmetic really did depend on those claims: drop them and the
-    # same counter becomes a violation of exactly their size.
+    # same counter loses full audit coverage by exactly their size. A positive
+    # remainder cannot be called a violation because terminal reservation rows
+    # also disappear under the production 30-day retention policy.
     for claim_id in ("c1", "c2"):
         del db.rows[(_CLAIM_KIND, claim_id)]
     regressed = audit_typed_invariants(store)
-    assert regressed.usage_violations == 1
-    assert regressed.samples[f"usage:{ws}"]["delta"] == 750_000
+    assert regressed.usage_violations == 0
+    assert regressed.usage_unauditable == 1
+    assert (
+        regressed.unauditable[f"usage-retained-history-gap:{ws}"]["unretained_history"]
+        == 750_000
+    )
+
+
+def test_expired_settlement_is_retention_gap_not_usage_violation() -> None:
+    """The exact production incident: total_usage is lifetime, reservations are not."""
+    store, db, _ = make_fake_store()
+    ws = "ws_retained"
+    _credit(store, db, ws, baseline=2_000_000, total_usage=2_450_000)
+    _settled(db, "expired", ws, 300_000)
+    _settled(db, "retained", ws, 150_000)
+
+    assert audit_typed_invariants(store).fully_audited
+
+    # Model Spanner's 30-day row-deletion policy removing one terminal row.
+    del db.reservations["expired"]
+    report = audit_typed_invariants(store)
+
+    assert report.clean
+    assert report.usage_violations == 0
+    assert report.usage_unauditable == 1
+    assert not report.fully_audited
+    sample = report.unauditable[f"usage-retained-history-gap:{ws}"]
+    assert sample["unretained_history"] == 300_000
+    assert "cannot be repaired downward" in sample["why"]
 
 
 def test_non_credits_settles_do_not_count_toward_usage() -> None:
@@ -187,9 +216,10 @@ def test_a_missing_baseline_is_unauditable_not_a_violation() -> None:
     # so an unauditable row left in there prints as "VIOLATION" underneath a
     # summary that says CLEAN. Production's first run printed 643 such lines.
     sample = report.unauditable[f"usage-unauditable:{ws}"]
-    # The remainder IS the number to record, so the report hands it over rather
-    # than only saying it could not check.
+    # The remainder is useful evidence, but is not automatically a pre-ledger
+    # baseline now that terminal reservation rows expire after 30 days.
     assert sample["unexplained"] == 9_999_999 - 1_000
+    assert "Do not record or repair" in sample["why"]
     assert not report.samples, "unauditable rows must not sit in the violation samples"
 
 
@@ -279,7 +309,7 @@ def test_repair_refuses_when_the_baseline_was_cleaned_up() -> None:
     assert any("baseline" in r for r in result.reasons)
 
 
-def test_repair_refuses_to_lower_usage_unless_told_to() -> None:
+def test_repair_refuses_to_lower_usage_without_independent_ledger_proof() -> None:
     """total_usage is monotonic, so a computed decrease means the ledger is
     missing rows -- not that the counter is too high."""
     store, db, _ = make_fake_store()
@@ -292,7 +322,17 @@ def test_repair_refuses_to_lower_usage_unless_told_to() -> None:
     assert any("refusing to lower" in r for r in refused.reasons)
     assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["total_usage"] == 5_000_000
 
-    forced = repair_typed_usage(store, ws, apply=True, allow_decrease=True)
+    still_refused = repair_typed_usage(store, ws, apply=True, allow_decrease=True)
+    assert not still_refused.ready and not still_refused.applied
+    assert any("retained ledger is complete" in r for r in still_refused.reasons)
+
+    forced = repair_typed_usage(
+        store,
+        ws,
+        apply=True,
+        allow_decrease=True,
+        retained_ledger_complete=True,
+    )
     assert forced.applied
     assert db.typed[CREDIT_BALANCE_TABLE][(ws, 0)]["total_usage"] == 1_000_000
 

--- a/tests/test_record_usage_baselines.py
+++ b/tests/test_record_usage_baselines.py
@@ -49,7 +49,9 @@ def test_recording_makes_the_workspace_auditable(monkeypatch: pytest.MonkeyPatch
     _seed(store, db, "ws_history", usage=5_000_000, settled=1_000_000)
     assert audit_typed_invariants(store).usage_unauditable == 1
 
-    assert record_usage_baselines.main(["--apply"], store=store) == 0
+    assert record_usage_baselines.main(
+        ["--apply", "--verified-retained-ledger-complete"], store=store
+    ) == 0
 
     report = audit_typed_invariants(store)
     assert report.usage_unauditable == 0
@@ -72,6 +74,20 @@ def test_dry_run_writes_nothing() -> None:
     assert audit_typed_invariants(store).usage_unauditable == 1
 
 
+def test_apply_refuses_without_independent_retained_ledger_verification(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("TR_STORAGE_BACKEND", "spanner-bigtable")
+    store, db, _ = make_fake_store()
+    _seed(store, db, "ws_history", usage=5_000_000, settled=1_000_000)
+
+    assert record_usage_baselines.main(["--apply"], store=store) == 2
+
+    assert (USAGE_BASELINE_KIND, "ws_history") not in db.rows
+    assert "30-day row expiry" in capsys.readouterr().err
+
+
 def test_an_existing_baseline_is_never_overwritten(monkeypatch: pytest.MonkeyPatch) -> None:
     """A second, different value for one workspace means one is wrong."""
     monkeypatch.setenv("TR_STORAGE_BACKEND", "spanner-bigtable")
@@ -83,7 +99,9 @@ def test_an_existing_baseline_is_never_overwritten(monkeypatch: pytest.MonkeyPat
         {"workspace_id": "ws_history", "baseline_microdollars": 123},
     )
 
-    assert record_usage_baselines.main(["--apply"], store=store) == 0
+    assert record_usage_baselines.main(
+        ["--apply", "--verified-retained-ledger-complete"], store=store
+    ) == 0
 
     body = json.loads(db.rows[(USAGE_BASELINE_KIND, "ws_history")].body)
     assert body["baseline_microdollars"] == 123
@@ -119,7 +137,11 @@ def test_a_baseline_recorded_between_propose_and_write_is_not_clobbered(
     )
 
     wrote = record_usage_baseline(
-        store, proposal, recorded_at="2026-08-25T00:00:00Z", apply=True
+        store,
+        proposal,
+        recorded_at="2026-08-25T00:00:00Z",
+        apply=True,
+        retained_ledger_complete=True,
     )
 
     assert wrote is False


### PR DESCRIPTION
## Root cause

`tr_credit_balance.total_usage` is a lifetime monotonic counter, but settled `tr_reservation` rows are deleted after 30 days. The daily audit treated the retained reservation sum as a permanent lifetime ledger, so normal TTL deletion manufactured positive usage drift.

## Fix

- treat positive retained-ledger remainders as partial history coverage, never as a billing violation or downward-repair target
- preserve hard findings for counters below retained bookings, orphan bookings, leaked holds, negative counters, keys, and regional lease escrow
- require independent retained-ledger-completeness confirmation before recording a baseline or lowering lifetime usage
- correct the active runbook and historical handoff
- add regression coverage for terminal-row expiry and fail-closed operator tooling

## Verification

- live read-only production audit: credit 0/3865, key 0/4805, regional lease 0/11, usage 0/775, CLEAN (PARTIAL)
- focused tests: 39 passed
- Ruff clean
- MyPy clean across 319 source files
- no production row or balance mutation performed