### PR TITLE
Repair control-plane SLO and synthetic refresh

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -977,13 +977,17 @@ jobs:
         # 06:00Z 2026-06-02 pong surge to persist after PR #14 + #15
         # "deployed".
         #
-        # The script is idempotent and gracefully no-ops if the
-        # synthetic monitor secret isn't present in this environment
-        # (test, staging). Failure here does NOT block the API rollout
-        # (continue-on-error) because synthetic monitoring is observability,
-        # not user-serving traffic.
-        continue-on-error: true
-        run: bash scripts/deploy/synthetic.sh
+        # Before the six-service cutover, refresh only existing jobs. This
+        # preserves their identities, networks, schedules, and secret bindings
+        # instead of bypassing synthetic.sh's split-service guard. Once the
+        # isolated billing service is configured, use the full deployment.
+        # Either path is a release gate: stale monitoring must not look green.
+        run: |
+          if [ -n "${TR_BILLING_SERVICE:-}" ]; then
+            bash scripts/deploy/synthetic.sh
+          else
+            bash scripts/deploy/synthetic_image_refresh.sh
+          fi
 
       - name: Deploy Google Ads conversion uploader
         if: ${{ steps.optional.outputs.deploy_google_data_manager == 'true' }}

--- a/scripts/deploy/synthetic_image_refresh.sh
+++ b/scripts/deploy/synthetic_image_refresh.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Refresh code on existing pre-split synthetic jobs without changing their
+# identity, network, scheduler, or secret bindings. The full synthetic.sh path
+# remains reserved for the isolated observer/billing service deployment.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+[ -n "${IMAGE:-}" ] || {
+  echo "ERROR: IMAGE is required" >&2
+  exit 2
+}
+
+release="${TR_SYNTHETIC_RELEASE:-${SHA:-}}"
+if [ -z "$release" ]; then
+  release="$(git rev-parse --short HEAD 2>/dev/null || true)"
+fi
+[ -n "$release" ] || {
+  echo "ERROR: SHA or TR_SYNTHETIC_RELEASE is required" >&2
+  exit 2
+}
+release="${release:0:7}"
+
+if [ -n "${TR_BILLING_SERVICE:-}" ]; then
+  echo "ERROR: split service is configured; use synthetic.sh" >&2
+  exit 2
+fi
+if [ "${TR_ALLOW_DEPLOYED_COMBINED_SURFACE:-}" = "true" ]; then
+  echo "ERROR: image refresh must not enable the combined-surface bridge" >&2
+  exit 2
+fi
+
+gc artifacts docker images describe "$IMAGE" >/dev/null
+
+jobs=(
+  "us-central1:trusted-router-synthetic-us-central1:health"
+  "europe-west4:trusted-router-synthetic-europe-west4:health"
+  "us-central1:trusted-router-throughput-us-central1:worker"
+  "us-central1:trusted-router-image-generation-us-central1:worker"
+  "us-central1:trusted-router-video-generation-us-central1:worker"
+)
+
+for entry in "${jobs[@]}"; do
+  IFS=: read -r job_region job_name job_kind <<<"$entry"
+  before="$(gc run jobs describe "$job_name" --region "$job_region" --format=json)" || {
+    echo "ERROR: existing synthetic job ${job_name} is required" >&2
+    exit 1
+  }
+
+  surface="$(jq -r '
+    [.spec.template.spec.template.spec.containers[0].env[]?
+      | select(.name == "TR_SERVICE_SURFACE") | .value][0] // ""
+  ' <<<"$before")"
+  observer_secret_count="$(jq -r '
+    [.spec.template.spec.template.spec.containers[0].env[]?
+      | select(.name == "TR_OBSERVER_INTERNAL_TOKEN")]
+    | length
+  ' <<<"$before")"
+  if [ "$surface" != "combined" ] || [ "$observer_secret_count" != "0" ]; then
+    echo "ERROR: ${job_name} is not an approved pre-split combined job" >&2
+    exit 1
+  fi
+
+  sensitive_before="$(jq -cS '{
+    serviceAccountName: (.spec.template.spec.template.spec.serviceAccountName // null),
+    vpcAccess: (.spec.template.spec.template.spec.vpcAccess // null),
+    annotations: (.spec.template.spec.template.metadata.annotations // {}),
+    secrets: ([.spec.template.spec.template.spec.containers[0].env[]?
+      | select(.valueFrom != null)
+      | {name, valueFrom}] | sort_by(.name))
+  }' <<<"$before")"
+
+  env_updates="TR_RELEASE=${release}"
+  if [ "$job_kind" = "health" ]; then
+    env_updates="${env_updates},TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL=https://trustedrouter.com"
+  fi
+
+  log "refreshing existing synthetic job ${job_name} in ${job_region}"
+  gc run jobs update "$job_name" \
+    --region "$job_region" \
+    --image "$IMAGE" \
+    --update-env-vars "$env_updates" \
+    --quiet >/dev/null
+
+  after="$(gc run jobs describe "$job_name" --region "$job_region" --format=json)"
+  sensitive_after="$(jq -cS '{
+    serviceAccountName: (.spec.template.spec.template.spec.serviceAccountName // null),
+    vpcAccess: (.spec.template.spec.template.spec.vpcAccess // null),
+    annotations: (.spec.template.spec.template.metadata.annotations // {}),
+    secrets: ([.spec.template.spec.template.spec.containers[0].env[]?
+      | select(.valueFrom != null)
+      | {name, valueFrom}] | sort_by(.name))
+  }' <<<"$after")"
+  if [ "$sensitive_after" != "$sensitive_before" ]; then
+    echo "ERROR: ${job_name} identity, network, or secret bindings changed" >&2
+    exit 1
+  fi
+done
+
+log "synthetic image refresh complete; no identities, networks, schedulers, or secrets changed"

--- a/src/trusted_router/synthetic/components.py
+++ b/src/trusted_router/synthetic/components.py
@@ -468,7 +468,12 @@ def _slo_class_ids(*, probe_type: str, target: str) -> list[str]:
         target == "control-plane" and probe_type in BILLING_PROBES | {"provider_fallback"}
     ):
         ids.append("router_core")
-    if probe_type in CONTROL_PLANE_PROBES:
+    # Control-plane availability is a global load-balanced service signal.
+    # Older monitor images emitted region-targeted control_plane_health rows
+    # against private run.app origins; those requests were rejected by Cloud
+    # Run before reaching the application and must remain forensic telemetry,
+    # not SLO downtime. New probes use the explicit "control-plane" target.
+    if target == "control-plane" and probe_type in CONTROL_PLANE_PROBES:
         ids.append("control_plane")
     return ids
 

--- a/tests/deploy_script_harness.py
+++ b/tests/deploy_script_harness.py
@@ -870,6 +870,47 @@ _SYNTHETIC_INGEST_SERVICE_JSON = json.dumps(
     },
     separators=(",", ":"),
 )
+_SYNTHETIC_COMBINED_JOB_JSON = json.dumps(
+    {
+        "metadata": {"name": "trusted-router-synthetic-harness"},
+        "spec": {
+            "template": {
+                "spec": {
+                    "template": {
+                        "metadata": {"annotations": {}},
+                        "spec": {
+                            "serviceAccountName": (
+                                "44325983244-compute@developer.gserviceaccount.com"
+                            ),
+                            "containers": [
+                                {
+                                    "image": "example.invalid/trusted-router:old",
+                                    "env": [
+                                        {
+                                            "name": "TR_SERVICE_SURFACE",
+                                            "value": "combined",
+                                        },
+                                        {
+                                            "name": "TR_INTERNAL_GATEWAY_TOKEN",
+                                            "valueFrom": {
+                                                "secretKeyRef": {
+                                                    "name": (
+                                                        "trustedrouter-internal-gateway-token"
+                                                    ),
+                                                    "key": "latest",
+                                                }
+                                            },
+                                        },
+                                    ],
+                                }
+                            ],
+                        },
+                    }
+                }
+            }
+        },
+    }
+)
 
 _PUBLIC_SURFACE_LEGACY_SERVICE_JSON = json.dumps(
     {
@@ -1544,6 +1585,18 @@ SCRIPT_FIXTURES: dict[str, ScriptFixture] = {
                 '"privateVisibilityConfig":{"networks":['
                 '{"networkUrl":"projects/quill-cloud-proxy/global/networks/default"}]}}',
             ),
+        ),
+    ),
+    "scripts/deploy/synthetic_image_refresh.sh": ScriptFixture(
+        env={
+            "IMAGE": (
+                "us-central1-docker.pkg.dev/quill-cloud-proxy/"
+                "trusted-router/trusted-router:harness"
+            ),
+            "SHA": "1234567890abcdef",
+        },
+        responses=(
+            (r"run jobs describe .*--format=json", _SYNTHETIC_COMBINED_JOB_JSON),
         ),
     ),
 }

--- a/tests/test_deploy_script_execution.py
+++ b/tests/test_deploy_script_execution.py
@@ -1913,6 +1913,64 @@ def test_synthetic_deploy_requires_explicit_split_billing_service_before_any_gcl
     assert run.calls == []
 
 
+def test_combined_synthetic_refresh_preserves_security_boundaries(tmp_path: Path) -> None:
+    script = "scripts/deploy/synthetic_image_refresh.sh"
+    isolated = DeployScriptHarness(tmp_path / "synthetic-image-refresh")
+
+    run = isolated.run(
+        script,
+        verifier_rc=0,
+        omit_env=("TR_BILLING_SERVICE", "TR_ALLOW_DEPLOYED_COMBINED_SURFACE"),
+    )
+
+    assert run.returncode == 0, summarise(run)
+    updates = [
+        call
+        for call in run.calls
+        if call[:4] == ["gcloud", "--project", "quill-cloud-proxy", "run"]
+        and call[4:6] == ["jobs", "update"]
+    ]
+    assert [(call[6], call[call.index("--region") + 1]) for call in updates] == [
+        ("trusted-router-synthetic-us-central1", "us-central1"),
+        ("trusted-router-synthetic-europe-west4", "europe-west4"),
+        ("trusted-router-throughput-us-central1", "us-central1"),
+        ("trusted-router-image-generation-us-central1", "us-central1"),
+        ("trusted-router-video-generation-us-central1", "us-central1"),
+    ]
+    assert not any(call[4:6] == ["jobs", "deploy"] for call in run.calls if len(call) > 5)
+    for update in updates:
+        update_text = " ".join(update)
+        assert "--image" in update
+        assert "--update-env-vars" in update
+        assert "TR_RELEASE=1234567" in update_text
+        assert "--set-secrets" not in update
+        assert "--update-secrets" not in update
+        assert "--service-account" not in update
+        assert "--network" not in update
+        assert "--subnet" not in update
+        assert "--vpc-egress" not in update
+    for update in updates[:2]:
+        assert (
+            "TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL=https://trustedrouter.com"
+            in " ".join(update)
+        )
+
+
+def test_combined_synthetic_refresh_is_a_visible_release_gate() -> None:
+    workflow = (ROOT / ".github/workflows/deploy.yml").read_text()
+    rollout = workflow.split("\n  rollout-secondaries:\n", 1)[1].split(
+        "\n  public-surface-companion:\n", 1
+    )[0]
+    synthetic_step = rollout.split(
+        "- name: Deploy synthetic monitor Cloud Run Job", 1
+    )[1].split("- name: Deploy Google Ads conversion uploader", 1)[0]
+
+    assert "synthetic_image_refresh.sh" in synthetic_step
+    assert "synthetic.sh" in synthetic_step
+    assert "continue-on-error" not in synthetic_step
+    assert "TR_ALLOW_DEPLOYED_COMBINED_SURFACE" not in synthetic_step
+
+
 def test_synthetic_combined_bridge_restores_legacy_job_deploys(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_status_component_scope.py
+++ b/tests/test_status_component_scope.py
@@ -23,6 +23,8 @@ from trusted_router.synthetic.components import (
     COMPONENT_DEFINITIONS,
     COMPONENT_PROBE_TARGETS,
     applicable_component_definitions,
+    rollup_slo_class_ids,
+    sample_slo_class_ids,
 )
 from trusted_router.synthetic.status import status_snapshot
 
@@ -176,6 +178,62 @@ def test_gcp_current_checks_expose_regions_without_blending_router_core_slo() ->
     slo_classes = snapshot["slo_classes"]
     assert isinstance(slo_classes, dict)
     assert slo_classes["router_core"]["windows"]["5m"]["sample_count"] == 1
+
+
+def test_legacy_regional_control_plane_probes_do_not_burn_global_slo() -> None:
+    """Private run.app probe artifacts remain visible but never count as downtime."""
+    now = utcnow()
+    created_at = _iso(now - dt.timedelta(seconds=10))
+    canonical = SyntheticProbeSample(
+        id="syn-control-plane-global",
+        probe_type="control_plane_health",
+        target="control-plane",
+        target_url="https://trustedrouter.com/health",
+        monitor_region="us-central1",
+        status="up",
+        created_at=created_at,
+    )
+    legacy_regional = SyntheticProbeSample(
+        id="syn-control-plane-legacy-region",
+        probe_type="control_plane_health",
+        target="us-central1",
+        target_region="us-central1",
+        target_url="https://trusted-router.example.run.app/health",
+        monitor_region="us-central1",
+        status="down",
+        http_status=404,
+        created_at=created_at,
+    )
+    legacy_rollup = SyntheticRollup(
+        id="rollup-control-plane-legacy-region",
+        period="hour",
+        period_start=_iso(now.replace(minute=0, second=0, microsecond=0)),
+        component="uncategorized",
+        target="us-central1",
+        probe_type="control_plane_health",
+        monitor_region="us-central1",
+        target_region="us-central1",
+        sample_count=31,
+        down_count=31,
+        error_counts={"bad_health_response": 31},
+        last_checked_at=created_at,
+    )
+
+    assert sample_slo_class_ids(canonical) == ["control_plane"]
+    assert sample_slo_class_ids(legacy_regional) == []
+    assert rollup_slo_class_ids(legacy_rollup) == []
+
+    snapshot = status_snapshot(
+        [canonical, legacy_regional],
+        rollups=[legacy_rollup],
+        now=now,
+        settings=_gcp_settings(),
+    )
+    control_plane = snapshot["slo_classes"]["control_plane"]
+    assert control_plane["status"] == "up"
+    assert control_plane["windows"]["5m"]["sample_count"] == 1
+    assert control_plane["windows"]["5m"]["uptime_percent"] == 100.0
+    assert set(control_plane["current_by_region"]) == {"global"}
 
 
 def test_gcp_current_checks_keep_complete_regional_deploy_canaries() -> None:


### PR DESCRIPTION
## Summary

- Count only the canonical `control-plane` target in control-plane SLO and burn-rate math.
- Retain legacy region-targeted `run.app` probe rows as raw forensic telemetry.
- Refresh existing pre-split synthetic jobs without changing identity, networking, schedules, or secret bindings.
- Make synthetic refresh failure visible instead of masking it with `continue-on-error`.

## Root causes

Older synthetic images derived private regional Cloud Run `run.app` origins. Restricted ingress returned Google platform 404s before requests reached TrustedRouter, incorrectly reducing the control-plane SLO.

The monitor image then stayed stale because `synthetic.sh` correctly rejected a combined-service deployment, while the workflow masked that failure. The new pre-split refresh path can update only existing jobs' image and nonsecret release metadata. It refuses split/observer jobs, refuses job creation, and verifies that identity, networking, annotations, and secret bindings remain byte-identical.

## Verification

- `uv run pytest -q tests/test_status_component_scope.py tests/test_synthetic_monitoring.py tests/test_deploy_secret_wiring.py tests/test_deploy_script_execution.py` (254 passed)
- `uv run ruff check src/trusted_router/synthetic/components.py tests/test_status_component_scope.py tests/test_deploy_secret_wiring.py tests/test_deploy_script_execution.py tests/deploy_script_harness.py`
- `uv run mypy`
- `bash -n scripts/deploy/synthetic_image_refresh.sh`
- `shellcheck -x scripts/deploy/synthetic_image_refresh.sh`
