### PR TITLE
Always refresh synthetic monitors during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,10 +40,6 @@ on:
         description: "Skip synthetic-watchdog + CI-green gating (ship aggressively when prod is sick)"
         type: boolean
         default: false
-      deploy_synthetic_monitor:
-        description: "Force redeploy synthetic monitor jobs"
-        type: boolean
-        default: false
       regional_quota_lease_issuance:
         description: "Regional quota issuance: preserve active state, force off, or enable after fleet compatibility preflight"
         type: choice
@@ -786,13 +782,9 @@ jobs:
         id: optional
         run: |
           set -euo pipefail
-          deploy_synthetic_monitor="false"
           deploy_google_data_manager="false"
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            if [ "${{ inputs.deploy_synthetic_monitor }}" = "true" ]; then
-              deploy_synthetic_monitor="true"
-            fi
             deploy_google_data_manager="true"
           fi
 
@@ -806,18 +798,11 @@ jobs:
             if [ -z "$changed" ]; then
               changed="$(git diff --name-only HEAD~1 HEAD 2>/dev/null || true)"
             fi
-            # Any app source change can affect the synthetic monitor image; it
-            # imports the same trusted_router package as the API service.
-            if printf '%s\n' "$changed" | grep -Eq '^(src/trusted_router/|scripts/deploy/synthetic\.sh$|\.github/workflows/deploy\.yml$)'; then
-              deploy_synthetic_monitor="true"
-            fi
             if printf '%s\n' "$changed" | grep -Eq '^(src/trusted_router/|scripts/deploy/google_data_manager\.sh$|scripts/deploy/infra\.sh$|scripts/deploy/_lib\.sh$|\.github/workflows/deploy\.yml$)'; then
               deploy_google_data_manager="true"
             fi
           fi
 
-          echo "deploy_synthetic_monitor=${deploy_synthetic_monitor}" >> "$GITHUB_OUTPUT"
-          echo "deploy_synthetic_monitor=${deploy_synthetic_monitor}"
           echo "deploy_google_data_manager=${deploy_google_data_manager}" >> "$GITHUB_OUTPUT"
           echo "deploy_google_data_manager=${deploy_google_data_manager}"
 
@@ -968,7 +953,6 @@ jobs:
           fi
 
       - name: Deploy synthetic monitor Cloud Run Job
-        if: ${{ steps.optional.outputs.deploy_synthetic_monitor == 'true' }}
         # Re-deploys the synthetic monitor Cloud Run Job + Cloud Scheduler
         # cron with the latest image. Without this step, probe code or
         # cron-config (TR_SYNTHETIC_RUNS_PER_INVOCATION, monitor pool
@@ -981,6 +965,7 @@ jobs:
         # preserves their identities, networks, schedules, and secret bindings
         # instead of bypassing synthetic.sh's split-service guard. Once the
         # isolated billing service is configured, use the full deployment.
+        # This runs for every control-plane release, including manual dispatches.
         # Either path is a release gate: stale monitoring must not look green.
         run: |
           if [ -n "${TR_BILLING_SERVICE:-}" ]; then

--- a/tests/test_deploy_script_execution.py
+++ b/tests/test_deploy_script_execution.py
@@ -1967,8 +1967,10 @@ def test_combined_synthetic_refresh_is_a_visible_release_gate() -> None:
 
     assert "synthetic_image_refresh.sh" in synthetic_step
     assert "synthetic.sh" in synthetic_step
+    assert "if:" not in synthetic_step
     assert "continue-on-error" not in synthetic_step
     assert "TR_ALLOW_DEPLOYED_COMBINED_SURFACE" not in synthetic_step
+    assert "deploy_synthetic_monitor" not in workflow
 
 
 def test_synthetic_combined_bridge_restores_legacy_job_deploys(


### PR DESCRIPTION
## Summary
- make synthetic monitor refresh mandatory for every control-plane deployment
- remove the manual-dispatch path that could silently leave monitor jobs on an older image
- keep the existing fail-closed split-service/full-deploy selection
- add a regression assertion that the release gate is unconditional

## Verification
- `uv run pytest -q tests/test_deploy_workflow_regions.py tests/test_deploy_script_execution.py` (118 passed)
- `uv run ruff check tests/test_deploy_script_execution.py`
- `git diff --check`