### PR TITLE
Shadow events name the clause that blocked a lease

### DIFF
--- a/clickhouse/004_operational_analytics_replicated.sql
+++ b/clickhouse/004_operational_analytics_replicated.sql
@@ -92,6 +92,7 @@ CREATE TABLE IF NOT EXISTS spend_lease_shadow
     boot_kid                    String,
     boot_verified               UInt8,
     lease_id                    Nullable(String),
+    no_lease_reason             Nullable(String) DEFAULT NULL,
     echo_state                  LowCardinality(String),
     would_admit                 Nullable(UInt8),
     enclave_estimate_micro      Nullable(Int64),
@@ -110,6 +111,9 @@ ENGINE = ReplicatedReplacingMergeTree(
 PARTITION BY toYYYYMMDD(created_at)
 ORDER BY (workspace_id, created_at, event_id)
 TTL toDateTime(created_at) + INTERVAL 30 DAY;
+
+ALTER TABLE spend_lease_shadow
+    ADD COLUMN IF NOT EXISTS no_lease_reason Nullable(String) DEFAULT NULL AFTER lease_id;
 
 CREATE TABLE IF NOT EXISTS synthetic_status_rollups
 (

--- a/clickhouse/006_operational_analytics_single_node.sql
+++ b/clickhouse/006_operational_analytics_single_node.sql
@@ -109,6 +109,7 @@ CREATE TABLE IF NOT EXISTS spend_lease_shadow
     boot_kid                    String,
     boot_verified               UInt8,
     lease_id                    Nullable(String),
+    no_lease_reason             Nullable(String) DEFAULT NULL,
     echo_state                  LowCardinality(String),
     would_admit                 Nullable(UInt8),
     enclave_estimate_micro      Nullable(Int64),
@@ -123,6 +124,9 @@ ENGINE = ReplacingMergeTree(ingest_version)
 PARTITION BY toYYYYMMDD(created_at)
 ORDER BY (workspace_id, created_at, event_id)
 TTL toDateTime(created_at) + INTERVAL 30 DAY;
+
+ALTER TABLE spend_lease_shadow
+    ADD COLUMN IF NOT EXISTS no_lease_reason Nullable(String) DEFAULT NULL AFTER lease_id;
 
 CREATE TABLE IF NOT EXISTS synthetic_status_rollups
 (

--- a/clickhouse/ingest_operational_outbox.py
+++ b/clickhouse/ingest_operational_outbox.py
@@ -136,6 +136,7 @@ SPEND_LEASE_SHADOW_COLUMNS = (
     "boot_kid",
     "boot_verified",
     "lease_id",
+    "no_lease_reason",
     "echo_state",
     "would_admit",
     "enclave_estimate_micro",
@@ -649,7 +650,9 @@ def normalise_operational_event(
         required = SYNTHETIC_COLUMNS
     elif row.event_kind == "spend_lease_shadow":
         allowed = SPEND_LEASE_SHADOW_COLUMNS
-        required = SPEND_LEASE_SHADOW_COLUMNS
+        required = tuple(
+            column for column in SPEND_LEASE_SHADOW_COLUMNS if column != "no_lease_reason"
+        )
         if raw.get("schema_version") != 1:
             raise ValueError("spend_lease_shadow schema_version must be 1")
         if raw.get("event_id") != row.event_id:

--- a/src/trusted_router/operational_analytics_direct.py
+++ b/src/trusted_router/operational_analytics_direct.py
@@ -168,6 +168,7 @@ SPEND_LEASE_SHADOW_COLUMNS = (
     "boot_kid",
     "boot_verified",
     "lease_id",
+    "no_lease_reason",
     "echo_state",
     "would_admit",
     "enclave_estimate_micro",
@@ -483,7 +484,9 @@ def normalise_operational_event(
         required = SYNTHETIC_COLUMNS
     elif row.event_kind == "spend_lease_shadow":
         allowed = SPEND_LEASE_SHADOW_COLUMNS
-        required = SPEND_LEASE_SHADOW_COLUMNS
+        required = tuple(
+            column for column in SPEND_LEASE_SHADOW_COLUMNS if column != "no_lease_reason"
+        )
         if raw.get("schema_version") != 1:
             raise ValueError("spend_lease_shadow schema_version must be 1")
         if raw.get("event_id") != row.event_id:

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -155,12 +155,13 @@ from trusted_router.spend_leases import (
     SpendLeaseArtifact,
     SpendLeaseBoot,
     SpendLeaseEchoValue,
+    SpendLeaseEligibilityFailure,
     SpendLeaseSigner,
     build_spend_lease_shadow_event,
     freeze_spend_lease_catalog,
     mint_shadow_spend_lease,
     parse_boot_auth_header,
-    spend_lease_eligible,
+    spend_lease_ineligibility_reason,
     verify_boot_auth,
 )
 from trusted_router.storage import (
@@ -443,6 +444,7 @@ def _authorize_gateway_sync(
         "boot_auth": boot_auth,
         "boot_kid": boot_auth.kid if boot_auth is not None else "",
         "boot_verified": False,
+        "no_lease_reason": None,
         "echo": echo,
         "server_estimate_micro": None,
     }
@@ -475,6 +477,10 @@ def _record_spend_lease_shadow(
             key_hash=str(context.get("key_hash") or ""),
             boot_kid=str(context.get("boot_kid") or ""),
             boot_verified=bool(context.get("boot_verified")),
+            no_lease_reason=cast(
+                SpendLeaseEligibilityFailure | None,
+                context.get("no_lease_reason"),
+            ),
             echo=cast(SpendLeaseEchoValue | None, context.get("echo")),
             server_estimate_micro=cast(int | None, context.get("server_estimate_micro")),
             server_verdict=cast(Any, verdict),
@@ -886,24 +892,26 @@ def _authorize_gateway_sync_impl(
         and app_markup_basis_points == 0
     )
     spend_lease: SpendLeaseArtifact | None = None
+    no_lease_reason = spend_lease_ineligibility_reason(
+        workspace_id=workspace.id,
+        pilot_workspace_ids=settings.spend_lease_pilot_workspaces,
+        api_key=api_key,
+        route_type=body.route_type,
+        endpoint_candidates=endpoint_candidates,
+        custom_model=custom_model,
+        user_model=user_model,
+        partner_mode=partner_mode,
+        additional_cost_reservation_microdollars=additional_cost_reservation,
+        native_batch_eligible=native_batch_eligible,
+        app_markup_basis_points=app_markup_basis_points,
+        regional_lease_authorization=bool(regional_eligible),
+    )
+    spend_context["no_lease_reason"] = no_lease_reason
     if (
         settings.spend_lease_issuance_enabled
         and bool(spend_context["boot_verified"])
         and boot_auth is not None
-        and spend_lease_eligible(
-            workspace_id=workspace.id,
-            pilot_workspace_ids=settings.spend_lease_pilot_workspaces,
-            api_key=api_key,
-            route_type=body.route_type,
-            endpoint_candidates=endpoint_candidates,
-            custom_model=custom_model,
-            user_model=user_model,
-            partner_mode=partner_mode,
-            additional_cost_reservation_microdollars=additional_cost_reservation,
-            native_batch_eligible=native_batch_eligible,
-            app_markup_basis_points=app_markup_basis_points,
-            regional_lease_authorization=bool(regional_eligible),
-        )
+        and no_lease_reason is None
     ):
         try:
             boot_kid = boot_auth.kid

--- a/src/trusted_router/spend_leases.py
+++ b/src/trusted_router/spend_leases.py
@@ -48,6 +48,20 @@ SPEND_LEASE_ACTIVE_GRANT_KIND = "spend_lease_active_grant"
 LeaseStatus = Literal["active", "terminal", "expired"]
 ShadowVerdict = Literal["accepted", "declined_funds", "declined_other"]
 ShadowDivergence = Literal["none", "admit_diverged", "estimate_low", "echo_invalid"]
+SpendLeaseEligibilityFailure = Literal[
+    "not_pilot",
+    "route_type",
+    "no_candidates",
+    "candidate_not_credits",
+    "custom_model",
+    "user_model",
+    "partner_mode",
+    "additional_cost",
+    "native_batch",
+    "app_markup",
+    "regional_lease",
+    "key_window_limit",
+]
 
 
 @dataclass(frozen=True)
@@ -116,6 +130,7 @@ class SpendLeaseShadowEvent:
     boot_kid: str
     boot_verified: bool
     lease_id: str | None
+    no_lease_reason: SpendLeaseEligibilityFailure | None
     echo_state: str
     would_admit: bool | None
     enclave_estimate_micro: int | None
@@ -140,6 +155,56 @@ def _has_window_limit(api_key: Any) -> bool:
     )
 
 
+def spend_lease_ineligibility_reason(
+    *,
+    workspace_id: str,
+    pilot_workspace_ids: frozenset[str],
+    api_key: Any,
+    route_type: str | None,
+    endpoint_candidates: Sequence[tuple[Model, ModelEndpoint]],
+    custom_model: Any | None,
+    user_model: Any | None,
+    partner_mode: Any | None,
+    additional_cost_reservation_microdollars: int,
+    native_batch_eligible: bool,
+    app_markup_basis_points: int,
+    regional_lease_authorization: bool,
+) -> SpendLeaseEligibilityFailure | None:
+    """Return the first failing Stage A cohort clause, or ``None`` if eligible.
+
+    Keep the clauses visibly separate: each represents an independently tested
+    security boundary and every fallback candidate must pass.
+    """
+    if workspace_id not in pilot_workspace_ids:
+        return "not_pilot"
+    if route_type not in SPEND_LEASE_ROUTE_TYPES:
+        return "route_type"
+    if not endpoint_candidates:
+        return "no_candidates"
+    if any(
+        UsageType.for_endpoint(endpoint) != UsageType.CREDITS
+        for _model, endpoint in endpoint_candidates
+    ):
+        return "candidate_not_credits"
+    if custom_model is not None:
+        return "custom_model"
+    if user_model is not None:
+        return "user_model"
+    if partner_mode is not None:
+        return "partner_mode"
+    if additional_cost_reservation_microdollars != 0:
+        return "additional_cost"
+    if native_batch_eligible:
+        return "native_batch"
+    if app_markup_basis_points != 0:
+        return "app_markup"
+    if regional_lease_authorization:
+        return "regional_lease"
+    if _has_window_limit(api_key):
+        return "key_window_limit"
+    return None
+
+
 def spend_lease_eligible(
     *,
     workspace_id: str,
@@ -155,39 +220,26 @@ def spend_lease_eligible(
     app_markup_basis_points: int,
     regional_lease_authorization: bool,
 ) -> bool:
-    """The complete Stage A cohort boundary (decision 8).
-
-    Keep the clauses visibly separate: each represents an independently tested
-    security boundary and every fallback candidate must pass.
-    """
-    if workspace_id not in pilot_workspace_ids:
-        return False
-    if route_type not in SPEND_LEASE_ROUTE_TYPES:
-        return False
-    if not endpoint_candidates:
-        return False
-    if any(
-        UsageType.for_endpoint(endpoint) != UsageType.CREDITS
-        for _model, endpoint in endpoint_candidates
-    ):
-        return False
-    if custom_model is not None:
-        return False
-    if user_model is not None:
-        return False
-    if partner_mode is not None:
-        return False
-    if additional_cost_reservation_microdollars != 0:
-        return False
-    if native_batch_eligible:
-        return False
-    if app_markup_basis_points != 0:
-        return False
-    if regional_lease_authorization:
-        return False
-    if _has_window_limit(api_key):
-        return False
-    return True
+    """Boolean compatibility wrapper for the Stage A cohort boundary."""
+    return (
+        spend_lease_ineligibility_reason(
+            workspace_id=workspace_id,
+            pilot_workspace_ids=pilot_workspace_ids,
+            api_key=api_key,
+            route_type=route_type,
+            endpoint_candidates=endpoint_candidates,
+            custom_model=custom_model,
+            user_model=user_model,
+            partner_mode=partner_mode,
+            additional_cost_reservation_microdollars=(
+                additional_cost_reservation_microdollars
+            ),
+            native_batch_eligible=native_batch_eligible,
+            app_markup_basis_points=app_markup_basis_points,
+            regional_lease_authorization=regional_lease_authorization,
+        )
+        is None
+    )
 
 
 def _tiers(endpoint: ModelEndpoint) -> tuple[PriceTier, ...]:
@@ -507,6 +559,7 @@ def build_spend_lease_shadow_event(
     key_hash: str,
     boot_kid: str,
     boot_verified: bool,
+    no_lease_reason: SpendLeaseEligibilityFailure | None,
     echo: SpendLeaseEchoValue | None,
     server_estimate_micro: int | None,
     server_verdict: ShadowVerdict,
@@ -530,6 +583,7 @@ def build_spend_lease_shadow_event(
         boot_kid=boot_kid,
         boot_verified=boot_verified,
         lease_id=echo.lease_id if echo else None,
+        no_lease_reason=no_lease_reason,
         echo_state=echo.state if echo else "missing",
         would_admit=echo.would_admit if echo else None,
         enclave_estimate_micro=echo.enclave_estimate_micro if echo else None,

--- a/tests/test_clickhouse_operational_deploy.py
+++ b/tests/test_clickhouse_operational_deploy.py
@@ -6,6 +6,8 @@ import sys
 import tarfile
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).parents[1]
 
 
@@ -48,7 +50,27 @@ def test_operational_schema_is_replicated_bounded_and_content_free() -> None:
     ):
         assert forbidden_column not in schema.lower()
     assert "CREATE TABLE IF NOT EXISTS spend_lease_shadow" in schema
+    assert "no_lease_reason             Nullable(String) DEFAULT NULL" in schema
+    assert "ADD COLUMN IF NOT EXISTS no_lease_reason" in schema
     assert "lease_token" not in schema.lower()
+
+
+@pytest.mark.parametrize(
+    "schema_name",
+    [
+        "004_operational_analytics_replicated.sql",
+        "006_operational_analytics_single_node.sql",
+    ],
+)
+def test_spend_lease_shadow_reason_column_is_additive_and_nullable(
+    schema_name: str,
+) -> None:
+    schema = (ROOT / "clickhouse" / schema_name).read_text()
+    assert "no_lease_reason             Nullable(String) DEFAULT NULL" in schema
+    assert (
+        "ADD COLUMN IF NOT EXISTS no_lease_reason Nullable(String) DEFAULT NULL"
+        in schema
+    )
 
 
 def test_provider_rollup_schema_replicates_all_published_granularities() -> None:

--- a/tests/test_operational_analytics_direct.py
+++ b/tests/test_operational_analytics_direct.py
@@ -84,6 +84,7 @@ SPEND_LEASE_SHADOW_PAYLOAD = {
     "boot_kid": "boot-1",
     "boot_verified": True,
     "lease_id": None,
+    "no_lease_reason": "route_type",
     "echo_state": "empty",
     "would_admit": False,
     "enclave_estimate_micro": 12,
@@ -125,7 +126,9 @@ class TestCanonicalParityWithTheFrozenDrainer:
         )
         assert [(e.event_kind, e.row) for e in ours] == [(e.event_kind, e.row) for e in theirs]
 
-    def test_spend_lease_shadow_rows_identical_and_keep_invalid_evidence(self) -> None:
+    def test_spend_lease_shadow_v1_ingesters_accept_reason_and_keep_invalid_evidence(
+        self,
+    ) -> None:
         drainer = _load_drainer()
         payload = dict(SPEND_LEASE_SHADOW_PAYLOAD, divergence="echo_invalid")
         ours = normalise_operational_event(_row("spend_lease_shadow", payload))
@@ -143,7 +146,25 @@ class TestCanonicalParityWithTheFrozenDrainer:
         ]
         assert ours[0].row["boot_verified"] == 1
         assert ours[0].row["would_admit"] == 0
+        assert ours[0].row["no_lease_reason"] == "route_type"
         assert ours[0].row["divergence"] == "echo_invalid"
+
+    def test_spend_lease_shadow_v1_ingesters_default_missing_reason_to_null(self) -> None:
+        drainer = _load_drainer()
+        payload = dict(SPEND_LEASE_SHADOW_PAYLOAD)
+        del payload["no_lease_reason"]
+        ours = normalise_operational_event(_row("spend_lease_shadow", payload))
+        theirs = drainer.normalise_operational_event(
+            drainer.OperationalOutboxRow(
+                shard=0,
+                commit_ts=COMMIT_TS,
+                event_kind="spend_lease_shadow",
+                event_id="evt-1",
+                payload=json.dumps(payload),
+            )
+        )
+        assert ours[0].row["no_lease_reason"] is None
+        assert theirs[0].row["no_lease_reason"] is None
 
     def test_bad_payload_raises_in_both(self) -> None:
         drainer = _load_drainer()

--- a/tests/test_spend_lease_gateway.py
+++ b/tests/test_spend_lease_gateway.py
@@ -200,6 +200,7 @@ def _signed_authorize_body(
     *,
     idempotency_key: str = "spend-lease-replay",
     echo: dict[str, Any] | None = None,
+    route_type: str | None = "chat.completions",
 ) -> tuple[dict[str, Any], bytes, str]:
     body: dict[str, Any] = {
         "api_key_lookup_hash": key.lookup_hash,
@@ -207,7 +208,7 @@ def _signed_authorize_body(
         "model": "anthropic/claude-haiku-4.5",
         "estimated_input_tokens": 100,
         "max_tokens": 100,
-        "route_type": "chat.completions",
+        "route_type": route_type,
         "spend_lease_echo": echo
         or {
             "lease_id": None,
@@ -326,6 +327,56 @@ def test_authorize_retains_one_active_grant_until_exhaustion_then_increases_gen(
     third_claims = json.loads(b64url_decode(third.split(".")[1]))
     assert third != first
     assert third_claims["gen"] > first_claims["gen"]
+
+
+def test_authorize_shadow_records_reason_without_lease_and_null_when_minted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace, key, private, boot = _seed_authorize()
+    monkeypatch.setattr(
+        gateway,
+        "_spend_lease_signer",
+        lambda _settings: SpendLeaseSigner(lambda: bytes(range(32))),
+    )
+    settings = Settings(
+        environment="test",
+        spend_lease_issuance_enabled=True,
+        operational_analytics_outbox_enabled=True,
+        spend_lease_pilot_workspace_ids=workspace.id,
+        spend_lease_signing_secret_name="test-secret-name",  # noqa: S106
+    )
+    rejected_dict, rejected_raw, rejected_header = _signed_authorize_body(
+        key,
+        private,
+        boot,
+        idempotency_key="shadow-reason-rejected",
+        route_type=None,
+    )
+    rejected = gateway._authorize_gateway_sync(  # noqa: SLF001
+        _request(boot_auth_header=rejected_header),
+        GatewayAuthorizeRequest(**rejected_dict),
+        settings,
+        rejected_raw,
+    )
+    minted_dict, minted_raw, minted_header = _signed_authorize_body(
+        key,
+        private,
+        boot,
+        idempotency_key="shadow-reason-minted",
+    )
+    minted = gateway._authorize_gateway_sync(  # noqa: SLF001
+        _request(boot_auth_header=minted_header),
+        GatewayAuthorizeRequest(**minted_dict),
+        settings,
+        minted_raw,
+    )
+
+    assert "spend_lease" not in rejected["data"]
+    assert "spend_lease" in minted["data"]
+    rejected_event = STORE.spend_lease_shadow_events[rejected["data"]["authorization_id"]]
+    minted_event = STORE.spend_lease_shadow_events[minted["data"]["authorization_id"]]
+    assert rejected_event["no_lease_reason"] == "route_type"
+    assert minted_event["no_lease_reason"] is None
 
 
 def test_authorize_shadow_events_include_accept_and_decline_and_keep_echo_invalid() -> None:

--- a/tests/test_spend_leases.py
+++ b/tests/test_spend_leases.py
@@ -23,6 +23,7 @@ from trusted_router.spend_leases import (
     parse_boot_auth_header,
     spend_lease_catalog_estimate,
     spend_lease_eligible,
+    spend_lease_ineligibility_reason,
     verify_boot_auth,
 )
 
@@ -73,6 +74,25 @@ def _eligible(**overrides: object) -> bool:
     }
     values.update(overrides)
     return spend_lease_eligible(**values)  # type: ignore[arg-type]
+
+
+def _ineligibility_reason(**overrides: object) -> str | None:
+    values: dict[str, object] = {
+        "workspace_id": "ws-pilot",
+        "pilot_workspace_ids": frozenset({"ws-pilot"}),
+        "api_key": _key(),
+        "route_type": "chat.completions",
+        "endpoint_candidates": _candidates(),
+        "custom_model": None,
+        "user_model": None,
+        "partner_mode": None,
+        "additional_cost_reservation_microdollars": 0,
+        "native_batch_eligible": False,
+        "app_markup_basis_points": 0,
+        "regional_lease_authorization": False,
+    }
+    values.update(overrides)
+    return spend_lease_ineligibility_reason(**values)  # type: ignore[arg-type]
 
 
 def test_spend_lease_eligibility_accepts_exact_credits_chat_cohort() -> None:
@@ -137,6 +157,37 @@ def test_spend_lease_eligibility_rejects_regional_lease_authorizations() -> None
 )
 def test_spend_lease_eligibility_rejects_each_window_limited_key(field: str) -> None:
     assert not _eligible(api_key=_key(**{field: 1_000_000}))
+
+
+@pytest.mark.parametrize(
+    ("expected", "overrides"),
+    [
+        ("not_pilot", {"workspace_id": "ws-other"}),
+        ("route_type", {"route_type": None}),
+        ("no_candidates", {"endpoint_candidates": []}),
+        ("candidate_not_credits", {"endpoint_candidates": _candidates(usage_type="BYOK")}),
+        ("custom_model", {"custom_model": object()}),
+        ("user_model", {"user_model": object()}),
+        ("partner_mode", {"partner_mode": object()}),
+        (
+            "additional_cost",
+            {"additional_cost_reservation_microdollars": 1},
+        ),
+        ("native_batch", {"native_batch_eligible": True}),
+        ("app_markup", {"app_markup_basis_points": 1}),
+        ("regional_lease", {"regional_lease_authorization": True}),
+        ("key_window_limit", {"api_key": _key(limit_daily_microdollars=1)}),
+    ],
+)
+def test_spend_lease_ineligibility_reason_names_each_security_clause(
+    expected: str,
+    overrides: dict[str, object],
+) -> None:
+    assert _ineligibility_reason(**overrides) == expected
+
+
+def test_spend_lease_ineligibility_reason_is_none_for_eligible_cohort() -> None:
+    assert _ineligibility_reason() is None
 
 
 def test_spend_lease_signer_round_trip_with_python_ed25519_verifier() -> None:
@@ -328,6 +379,7 @@ def test_shadow_event_constructs_declines_and_never_drops_invalid_echo() -> None
         key_hash="key",
         boot_kid="boot",
         boot_verified=False,
+        no_lease_reason="route_type",
         echo=echo,
         server_estimate_micro=None,
         server_verdict="declined_other",
@@ -335,6 +387,7 @@ def test_shadow_event_constructs_declines_and_never_drops_invalid_echo() -> None
     assert event.divergence == "echo_invalid"
     assert event.server_verdict == "declined_other"
     assert event.server_estimate_micro is None
+    assert event.no_lease_reason == "route_type"
     assert event.payload()["schema_version"] == 1
 
 


### PR DESCRIPTION
The pilot flip is live and healthy — boots register with verified attestation (`boot_verified=1`, `divergence=none`), authorize accepts, events flow — but **zero leases mint**, and the soak's own telemetry cannot say why. The predicate's inputs live only inside the request, so this is not answerable by querying Spanner or ClickHouse after the fact.

Adds `no_lease_reason` to `spend_lease_shadow`: the eligibility predicate returns its failing clause (`candidate_not_credits`, `key_window_limit`, `app_markup`, …), the event carries it, ClickHouse stores it (additive, nullable). Schema stays v1 — old ingesters ignore the field, new ones default it to NULL, so rolling deploys are safe in either order.

Same principle the record already applies to negative controls: an instrument that cannot explain its dominant outcome isn't evidence. Focused suites + route inventory green (49), ruff/mypy clean, mutation verified. Needs admin merge.

Authored by Sol (codex-cli); reviewed by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)