### PR TITLE
Allow Chat web search cost reservations

### DIFF
--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -221,6 +221,14 @@ _SPEND_LEASE_WIRE_ATTESTATION_KINDS = {
     "gcp": GCP_ATTESTATION_KIND,
 }
 _NATIVE_BATCH_ROUTE_PREFIX = "batch.native."
+_ADDITIONAL_COST_ROUTE_TYPES = frozenset(
+    {
+        "responses.web_search.planner",
+        "chat.completions.web_search.planner",
+        "images",
+        "videos",
+    }
+)
 _NATIVE_BATCH_BILLED_FRACTION_BPS = {
     "openai": 5_000,
     "parasail": 5_000,
@@ -694,7 +702,7 @@ def _authorize_gateway_sync_impl(
     )
     additional_cost_reservation = body.additional_cost_reservation_microdollars
     if additional_cost_reservation:
-        if body.route_type not in {"responses.web_search.planner", "images", "videos"}:
+        if body.route_type not in _ADDITIONAL_COST_ROUTE_TYPES:
             raise api_error(
                 400,
                 "additional cost reservations are only available for hosted search, image, or video",
@@ -2474,7 +2482,7 @@ def _settle_gateway_authorization(
             ErrorType.BAD_REQUEST,
         )
     if additional_cost:
-        if body.route_type not in {"responses.web_search.planner", "images", "videos"}:
+        if body.route_type not in _ADDITIONAL_COST_ROUTE_TYPES:
             raise api_error(
                 400,
                 "additional cost settlement is only available for hosted search, image, or video",

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -477,9 +477,17 @@ def test_settlement_over_reservation_emits_bounded_billing_warning(
     assert context["output_tokens"] == 1_000
 
 
+@pytest.mark.parametrize(
+    "route_type",
+    (
+        "responses.web_search.planner",
+        "chat.completions.web_search.planner",
+    ),
+)
 def test_web_search_additional_cost_is_reserved_and_settled_exactly_once(
     user_headers: dict[str, str],
     client,
+    route_type: str,
 ) -> None:
     created = client.post("/v1/keys", headers=user_headers, json={"name": "web search"}).json()
     key_hash = created["data"]["hash"]
@@ -494,9 +502,9 @@ def test_web_search_additional_cost_is_reserved_and_settled_exactly_once(
             "model": "anthropic/claude-opus-4.7",
             "estimated_input_tokens": 20,
             "max_output_tokens": 4,
-            "route_type": "responses.web_search.planner",
+            "route_type": route_type,
             "additional_cost_reservation_microdollars": reserve_microdollars,
-            "idempotency_key": "web-search-cost-once",
+            "idempotency_key": f"web-search-cost-once:{route_type}",
         },
     )
     assert authorize.status_code == 200, authorize.text
@@ -515,8 +523,8 @@ def test_web_search_additional_cost_is_reserved_and_settled_exactly_once(
             "authorization_id": auth_data["authorization_id"],
             "actual_input_tokens": 20,
             "actual_output_tokens": 2,
-            "request_id": "web-search-cost-once",
-            "route_type": "responses.web_search.planner",
+            "request_id": f"web-search-cost-once:{route_type}",
+            "route_type": route_type,
             "additional_cost_microdollars": actual_search_microdollars,
             "elapsed_seconds": 0.5,
         },
@@ -535,7 +543,7 @@ def test_web_search_additional_cost_is_reserved_and_settled_exactly_once(
             "authorization_id": auth_data["authorization_id"],
             "actual_input_tokens": 20,
             "actual_output_tokens": 2,
-            "route_type": "responses.web_search.planner",
+            "route_type": route_type,
             "additional_cost_microdollars": actual_search_microdollars,
         },
     )


### PR DESCRIPTION
## Summary
- authorize `chat.completions.web_search.planner` to reserve operator-funded Exa search cost
- use one shared allowlist for authorization and settlement
- run the existing exact-once billing contract for both Chat Completions and Responses search planners

## Regression proof
The new Chat parameter failed before the implementation with `400 additional cost reservations are only available for hosted search, image, or video`. After fixing authorization it exposed the duplicated settlement allowlist, which also failed `400`; both paths now share one constant.

## Verification
- `uv run pytest -q tests/test_billing.py` (33 passed)
- `uv run pytest -q tests/test_gateway_fallback_billing.py tests/test_image_generation.py tests/test_video_generation_control_plane.py` (43 passed)
- `uv run ruff check src/trusted_router/routes/internal/gateway.py tests/test_billing.py`
- `uv run mypy`