### PR TITLE
Approve canonical GMI cache transition

### DIFF
--- a/scripts/check_price_spike.py
+++ b/scripts/check_price_spike.py
@@ -115,6 +115,13 @@ APPROVED_ENDPOINT_PRICE_TRANSITIONS = frozenset(
             Decimal("0.000000044"),
             Decimal("0.000000145"),
         ),
+        (
+            "deepseek/deepseek-v4-pro "
+            "[gmi:gmi:deepseek-ai/DeepSeek-V4-Pro] cached-input",
+            "prompt",
+            Decimal("0.000000044"),
+            Decimal("0.000000145"),
+        ),
         # Atlas's authenticated /v1/models feed distinguishes the cheap
         # unversioned route from the newer 0731 weights. The old snapshot had
         # inherited the unversioned rate; approve only the exact correction.

--- a/tests/test_check_price_spike.py
+++ b/tests/test_check_price_spike.py
@@ -772,6 +772,22 @@ def test_confirmed_gmi_deepseek_pro_cached_transition_is_allowed() -> None:
     assert removed == []
 
 
+def test_confirmed_gmi_canonical_deepseek_pro_cached_transition_is_allowed() -> None:
+    route = (
+        "deepseek/deepseek-v4-pro "
+        "[gmi:gmi:deepseek-ai/DeepSeek-V4-Pro] cached-input"
+    )
+
+    failures, changes, removed = check(
+        {route: {"prompt": "0.000000044", "completion": "0"}},
+        {route: {"prompt": "0.000000145", "completion": "0"}},
+    )
+
+    assert failures == []
+    assert len(changes) == 1
+    assert removed == []
+
+
 def test_confirmed_atlas_v4_flash_0731_transition_is_allowed(
     tmp_path: Path, capsys
 ) -> None:


### PR DESCRIPTION
## Summary
- approve GMI's same verified DeepSeek V4 Pro cached-input correction under the canonical `gmi:gmi` endpoint identity emitted by the live refresh
- retain exact route, dimension, old value, and new value matching
- add a regression test that fails on the prior implementation

Follow-up to #954 after the real provider refresh exposed GMI's second endpoint identity.

## Verification
- `uv run pytest -q tests/test_check_price_spike.py` (46 passed)
- `uv run ruff check scripts/check_price_spike.py tests/test_check_price_spike.py`
- `uv run mypy scripts/check_price_spike.py`
- `git diff --check`
