### PR TITLE
Mark Tencent HY4 as open weights

### DIFF
--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -434,6 +434,7 @@ _OPEN_WEIGHT_PREFIXES = (
     "moonshotai/kimi",
     "nvidia/nemotron",
     "qwen/",
+    "tencent/hy4",
     "thinkingmachines/",
     "xiaomi/mimo",
     "z-ai/glm",

--- a/tests/test_kimi_k3_gmi_phala.py
+++ b/tests/test_kimi_k3_gmi_phala.py
@@ -7,7 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from scripts.pricing.providers import gmi
-from trusted_router.catalog import MODEL_ENDPOINTS
+from trusted_router.catalog import MODEL_ENDPOINTS, MODELS, model_open_weights
 from trusted_router.catalog_data import PRIVACY_TIER_STANDARD
 from trusted_router.catalog_privacy import (
     endpoint_confidential_compute,
@@ -257,6 +257,7 @@ def test_gmi_hy4_preview_is_a_verified_prepaid_route() -> None:
     assert endpoint.upstream_id == HY4_PREVIEW
     assert endpoint.prompt_price_microdollars_per_million_tokens == 879_870
     assert endpoint.completion_price_microdollars_per_million_tokens == 2_638_555
+    assert model_open_weights(MODELS[HY4_PREVIEW]) is True
 
 
 def test_every_gmi_prepaid_route_is_billed_from_provider_list_price() -> None:


### PR DESCRIPTION
## Summary
- classify the official Tencent HY4 family as open weights
- assert the deployed HY4 preview model retains its open-weights badge

## Verification
- `uv run pytest -q tests/test_kimi_k3_gmi_phala.py tests/test_catalog_routing_contracts.py tests/test_models_catalog_cache.py` (132 passed)
- `git diff --check`

Follow-up to #953, which activated and production-smoked the GMI prepaid route.
