### PR TITLE
Fix post-refresh deployment dispatch

### DIFF
--- a/.github/workflows/refresh-prices.yml
+++ b/.github/workflows/refresh-prices.yml
@@ -452,8 +452,7 @@ jobs:
           # Discovered live on 2026-05-13: hourly bot was committing
           # but TR's deployed catalog was stuck on a 3-phala-endpoint
           # snapshot for hours because deploy.yml never auto-fired.
-          gh workflow run deploy.yml --ref main --repo "${GITHUB_REPOSITORY}" \
-            -f deploy_synthetic_monitor=true
+          gh workflow run deploy.yml --ref main --repo "${GITHUB_REPOSITORY}"
           echo "  dispatched deploy.yml for new snapshot"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/test_refresh_workflow_dispatch.py
+++ b/tests/test_refresh_workflow_dispatch.py
@@ -54,6 +54,7 @@ def test_price_refresh_checks_exact_branch_sha_before_advancing_main() -> None:
     ) < workflow.index(status_bridge)
     assert workflow.index(status_bridge) < workflow.index(main_push)
     assert workflow.index(main_push) < workflow.index(deploy_dispatch)
+    assert "deploy_synthetic_monitor" not in workflow
     assert "WARN: failed to dispatch deploy.yml" not in workflow
 
 


### PR DESCRIPTION
## Summary

- remove the retired `deploy_synthetic_monitor` input from the post-refresh deploy dispatch
- add a workflow contract assertion that rejects the stale input

## Production evidence

The generated snapshot passed its full exact-SHA CI and was pushed to `main` as `73e1e2a5`. The refresh run then failed only because GitHub returned HTTP 422 for this obsolete deploy input. A correct deployment was dispatched manually in run `33307241791`.

## Tests

- `uv run pytest -q tests/test_refresh_workflow_dispatch.py`
- `uv run ruff check tests/test_refresh_workflow_dispatch.py`
- `uv run mypy`
