### PR TITLE
Simplify public model pricing routes

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -4714,8 +4714,8 @@ def docs_llms_full_txt(settings: Settings) -> str:
 def _model_view(model: Model, *, test_mode: bool = False) -> dict[str, object]:
     provider = PROVIDERS[model.provider]
     is_meta = model.id in META_MODEL_IDS
-    endpoints = endpoints_for_model(model.id) if not is_meta else []
-    route_endpoints = _model_route_endpoints(model)
+    endpoints = _credits_endpoints(endpoints_for_model(model.id)) if not is_meta else []
+    route_endpoints = _credits_endpoints(_model_route_endpoints(model))
     ai_iq = (
         ai_iq_for_model(model.id, test_mode=test_mode) if model.id not in META_MODEL_IDS else None
     )
@@ -4737,12 +4737,14 @@ def _model_view(model: Model, *, test_mode: bool = False) -> dict[str, object]:
         completion = _price(model.completion_price_microdollars_per_million_tokens)
     cached_prices = _cached_prompt_prices(route_endpoints)
     if cached_prices:
-        cached_prompt = _price_values_range(cached_prices)
+        cached_prompt = _price_values_range(cached_prices, include_zero=True)
     elif is_meta:
         cached_prompt = "selected route"
     else:
         cached_prompt = "Not published"
-    providers = _endpoint_provider_views(endpoints, fallback_provider=model.provider)
+    providers = (
+        _endpoint_provider_views(endpoints, fallback_provider=model.provider) if endpoints else []
+    )
     endpoint_postures = {
         (
             endpoint_zero_data_retention(endpoint),
@@ -4794,13 +4796,11 @@ def _model_view(model: Model, *, test_mode: bool = False) -> dict[str, object]:
         "prompt_price_sort": prompt_price_sort,
         "cached_price_sort": min(cached_prices) if cached_prices else None,
         "completion_price_sort": completion_price_sort,
-        # Derive from endpoints (not the raw Model flag): supplemental
-        # provider-native models carry prepaid_available=False as a catalog
-        # dedup marker, but DO have a priced Credits endpoint and are fully
-        # prepaid-routable. Mirror model_to_openrouter_shape so the public
-        # catalog/detail page matches /v1/models.
-        "prepaid": any(endpoint.usage_type == "Credits" for endpoint in endpoints)
-        or model.prepaid_available,
+        # Public pricing is route-backed. A raw model flag without a current
+        # Credits endpoint must not claim that customers can fund the route.
+        # Orchestration aliases remain Credits models even though their
+        # component routes are resolved only after authorization.
+        "prepaid": bool(endpoints) or (is_meta and model.prepaid_available),
         "byok": model.byok_available,
         "attested": provider.attested_gateway,
         "provider_zero_data_retention": provider_zero_data_retention,
@@ -4881,15 +4881,33 @@ def _model_route_endpoints(
     ]
 
 
+def _credits_endpoints(endpoints: Sequence[ModelEndpoint]) -> list[ModelEndpoint]:
+    """Return the customer-funded routes used by public pricing pages.
+
+    The catalog intentionally carries a separate BYOK endpoint for many
+    provider/model pairs. Rendering that raw shape duplicates providers and
+    makes the less-used billing mode look like a distinct serving route.
+    Public model pages focus on Credits; the endpoint API remains complete.
+    """
+    return [endpoint for endpoint in endpoints if endpoint.usage_type == "Credits"]
+
+
 def _cached_prompt_prices(endpoints: Sequence[ModelEndpoint]) -> list[int]:
     prices: list[int] = []
     for endpoint in endpoints:
         tiers = endpoint.price_tiers or ()
         for tier in tiers:
             cached = tier.prompt_cached_price_microdollars_per_million_tokens
-            if cached is not None and cached > 0:
+            if cached is not None and cached >= 0:
                 prices.append(cached)
     return prices
+
+
+def _cached_prompt_price_range(endpoints: Sequence[ModelEndpoint]) -> str:
+    prices = _cached_prompt_prices(endpoints)
+    if not prices:
+        return "Not published"
+    return _price_values_range(prices, include_zero=True)
 
 
 def _minimum_model_price(
@@ -4920,9 +4938,8 @@ def _endpoint_provider_views(
 ) -> list[dict[str, str]]:
     """Return distinct serving providers in endpoint order.
 
-    A model can have separate Credits and BYOK endpoints on the same
-    provider. The public catalog should list provider companies once,
-    then let the detail table expose individual endpoint rows.
+    Public callers pass Credits endpoints, so every provider appears once
+    without exposing the catalog's parallel BYOK billing record.
     """
     seen: set[str] = set()
     provider_views: list[dict[str, str]] = []
@@ -4993,8 +5010,7 @@ def _provider_detail_view(
 ) -> dict[str, object]:
     view = _provider_view(provider)
     view["served_model_count"] = len(served_models)
-    view["prepaid_model_count"] = sum(1 for model in served_models if model["prepaid"])
-    view["byok_model_count"] = sum(1 for model in served_models if model["byok"])
+    view["credits_model_count"] = len(served_models)
     return view
 
 
@@ -5097,7 +5113,7 @@ def _model_detail_view(
         model.prompt_price_microdollars_per_million_tokens > 0
         or model.completion_price_microdollars_per_million_tokens > 0
     )
-    endpoints = endpoints_for_model(model.id)
+    endpoints = _credits_endpoints(endpoints_for_model(model.id))
     ai_iq = None if is_meta else ai_iq_for_model(model.id, test_mode=test_mode)
     candidate_models = []
     if not model.hidden_public_metadata:
@@ -5114,8 +5130,8 @@ def _model_detail_view(
                 "provider_slug": endpoint.provider,
                 "provider_href": f"/providers/{endpoint.provider}",
                 "provider_logo_url": provider_logo_url(endpoint.provider),
-                "usage_type": endpoint.usage_type,
                 "prompt_price": _price(endpoint.prompt_price_microdollars_per_million_tokens),
+                "cached_prompt_price": _cached_prompt_price_range((endpoint,)),
                 "completion_price": _price(
                     endpoint.completion_price_microdollars_per_million_tokens
                 ),
@@ -5166,6 +5182,9 @@ def _model_detail_view(
         "context_length_int": model.context_length,
         "fixed_price": fixed_price,
         "prompt_price": _price(model.prompt_price_microdollars_per_million_tokens),
+        "cached_prompt_price": (
+            "selected route" if is_meta else _cached_prompt_price_range(endpoints)
+        ),
         "completion_price": _price(model.completion_price_microdollars_per_million_tokens),
         "minimum_charge": (
             format_money_precise(model.minimum_charge_microdollars)
@@ -5214,13 +5233,10 @@ def _model_detail_view(
         "supports_chat": model.supports_chat,
         "supports_messages": model.supports_messages,
         "supports_embeddings": model.supports_embeddings,
-        # Derive from endpoints (not the raw Model flag): supplemental
-        # provider-native models carry prepaid_available=False as a catalog
-        # dedup marker, but DO have a priced Credits endpoint and are fully
-        # prepaid-routable. Mirror model_to_openrouter_shape so the public
-        # catalog/detail page matches /v1/models.
-        "prepaid": any(endpoint.usage_type == "Credits" for endpoint in endpoints)
-        or model.prepaid_available,
+        # Keep the public billing claim tied to an actual Credits route. Meta
+        # models are the only exception because they authorize component
+        # routes dynamically rather than carrying direct endpoint rows.
+        "prepaid": bool(endpoints) or (is_meta and model.prepaid_available),
         "byok": model.byok_available,
     }
 
@@ -5279,7 +5295,7 @@ def _model_section_description(model: Model, section: str) -> str:
     if section == "pricing":
         return (
             f"Compare prompt and completion token prices for every {name} route on TrustedRouter, "
-            "including provider-specific rates and prepaid or BYOK availability."
+            "including provider-specific cached-input rates."
         )
     if section == "uptime":
         return (
@@ -5303,7 +5319,7 @@ def _model_section_indexable(
         sample_count = sum(_sample_count(row) for row in measured)
         return sample_count >= MODEL_PERFORMANCE_INDEX_MIN_SAMPLES
     if section in {"providers", "pricing"}:
-        return len(endpoints_for_model(model.id)) >= 2
+        return len(_credits_endpoints(endpoints_for_model(model.id))) >= 2
     if section == "benchmarks":
         return bool(scores_for_model(model.id))
     return False
@@ -5414,7 +5430,7 @@ def _model_comparison_pairs() -> tuple[tuple[Model, Model], ...]:
     all_models = sorted(
         _public_models_for_seo(),
         key=lambda model: (
-            -len(endpoints_for_model(model.id)),
+            -len(_credits_endpoints(endpoints_for_model(model.id))),
             -(model.context_length or 0),
             model.id.lower(),
         ),
@@ -5493,9 +5509,9 @@ def _model_route_evidence(
     *,
     test_mode: bool = False,
 ) -> dict[str, object]:
-    endpoints = endpoints_for_model(model.id)
+    endpoints = _credits_endpoints(endpoints_for_model(model.id))
     measured = measured_for_model(model.id, test_mode=test_mode)
-    priced_endpoints = [endpoint for endpoint in endpoints if endpoint.usage_type == "Credits"]
+    priced_endpoints = endpoints
     prompt_prices = [
         endpoint.prompt_price_microdollars_per_million_tokens for endpoint in priced_endpoints
     ]
@@ -5573,8 +5589,10 @@ def _model_route_evidence(
         ),
         "uptime_range": uptime_range,
         "route_count": len(endpoints),
-        "provider_count": len(
-            _endpoint_provider_views(endpoints, fallback_provider=model.provider)
+        "provider_count": (
+            len(_endpoint_provider_views(endpoints, fallback_provider=model.provider))
+            if endpoints
+            else 0
         ),
     }
 
@@ -5584,14 +5602,17 @@ def _model_faq_items(
     *,
     route_evidence: Mapping[str, object],
 ) -> tuple[tuple[str, str], ...]:
+    credits_endpoints = _credits_endpoints(endpoints_for_model(model.id))
     provider_names = [
         provider["name"]
         for provider in _endpoint_provider_views(
-            endpoints_for_model(model.id),
+            credits_endpoints,
             fallback_provider=model.provider,
         )
-    ]
-    if len(provider_names) == 1:
+    ] if credits_endpoints else []
+    if not provider_names:
+        provider_answer = "no Credits provider route"
+    elif len(provider_names) == 1:
         provider_answer = str(provider_names[0])
     else:
         provider_answer = ", ".join(str(name) for name in provider_names[:-1])
@@ -5600,7 +5621,7 @@ def _model_faq_items(
         (
             f"What model ID should I use for {model.name}?",
             f"Use {model.id} as the model field with the TrustedRouter OpenAI-compatible "
-            "API. The same model ID works for prepaid and eligible BYOK routes.",
+            "API. Credits routing and provider fallback happen behind that model ID.",
         ),
         (
             f"Which providers serve {model.name}?",
@@ -5635,7 +5656,8 @@ def _model_comparison_index() -> dict[
             f"{left.name} vs {right.name}",
             left.id,
             right.id,
-            len(endpoints_for_model(left.id)) + len(endpoints_for_model(right.id)),
+            len(_credits_endpoints(endpoints_for_model(left.id)))
+            + len(_credits_endpoints(endpoints_for_model(right.id))),
         )
         for model_id in {left.id.casefold(), right.id.casefold()}:
             indexed.setdefault(model_id, []).append(row)
@@ -5720,8 +5742,8 @@ def _comparison_view(
 ) -> dict[str, object]:
     left_total = _cheapest_total_microdollars(left)
     right_total = _cheapest_total_microdollars(right)
-    left_routes = len(endpoints_for_model(left.id))
-    right_routes = len(endpoints_for_model(right.id))
+    left_routes = len(_credits_endpoints(endpoints_for_model(left.id)))
+    right_routes = len(_credits_endpoints(endpoints_for_model(right.id)))
     left_evidence = _model_route_evidence(left, test_mode=test_mode)
     right_evidence = _model_route_evidence(right, test_mode=test_mode)
     left_measured = cast(int | None, left_evidence["fastest_ttft_ms"])
@@ -5839,7 +5861,7 @@ def _cheapest_total_microdollars(model: Model) -> int:
 
 
 def _privacy_summary(model: Model) -> str:
-    endpoints = endpoints_for_model(model.id)
+    endpoints = _credits_endpoints(endpoints_for_model(model.id))
     if any(endpoint_e2ee(endpoint) for endpoint in endpoints):
         return "has provider E2EE route"
     if any(endpoint_confidential_compute(endpoint) for endpoint in endpoints):
@@ -5852,8 +5874,11 @@ def _privacy_summary(model: Model) -> str:
 def _provider_model_rows(provider_slug: str, *, test_mode: bool = False) -> list[dict[str, object]]:
     rows: list[dict[str, object]] = []
     for model in _public_models_for_seo():
-        all_endpoints = endpoints_for_model(model.id)
-        endpoints = [endpoint for endpoint in all_endpoints if endpoint.provider == provider_slug]
+        endpoints = [
+            endpoint
+            for endpoint in _credits_endpoints(endpoints_for_model(model.id))
+            if endpoint.provider == provider_slug
+        ]
         if not endpoints:
             continue
         rows.append(
@@ -5865,10 +5890,10 @@ def _provider_model_rows(provider_slug: str, *, test_mode: bool = False) -> list
                     f"/models/{model.id}/benchmarks" if scores_for_model(model.id) else None
                 ),
                 "providers_href": (
-                    f"/models/{model.id}/providers" if len(all_endpoints) >= 2 else None
+                    f"/models/{model.id}/providers" if len(endpoints) >= 2 else None
                 ),
                 "pricing_href": (
-                    f"/models/{model.id}/pricing" if len(all_endpoints) >= 2 else None
+                    f"/models/{model.id}/pricing" if len(endpoints) >= 2 else None
                 ),
                 "context_length": f"{model.context_length:,}",
                 "endpoint_count": len(endpoints),
@@ -5876,13 +5901,12 @@ def _provider_model_rows(provider_slug: str, *, test_mode: bool = False) -> list
                     endpoints,
                     "prompt_price_microdollars_per_million_tokens",
                 ),
+                "cached_prompt_price": _cached_prompt_price_range(endpoints),
                 "completion_price": _endpoint_price_range(
                     endpoints,
                     "completion_price_microdollars_per_million_tokens",
                 ),
                 "ai_iq": ai_iq_for_model(model.id, test_mode=test_mode),
-                "prepaid": any(not endpoint.is_byok for endpoint in endpoints),
-                "byok": any(endpoint.is_byok for endpoint in endpoints),
             }
         )
     return sorted(rows, key=lambda row: str(row["id"]))
@@ -5937,7 +5961,7 @@ def _model_json_ld(
 
 
 def _model_service_node(settings: Settings, model: Model, site_url: str) -> dict[str, object]:
-    endpoints = endpoints_for_model(model.id)
+    endpoints = _credits_endpoints(endpoints_for_model(model.id))
     prompt_prices = [
         ep.prompt_price_microdollars_per_million_tokens
         for ep in endpoints
@@ -5995,12 +6019,18 @@ def _endpoint_price_range(endpoints: Sequence[ModelEndpoint], attr: str) -> str:
     return _price_values_range(values)
 
 
-def _price_values_range(values: Sequence[int]) -> str:
+def _price_values_range(values: Sequence[int], *, include_zero: bool = False) -> str:
     low = min(values)
     high = max(values)
+
+    def formatted(value: int) -> str:
+        if include_zero and value == 0:
+            return "$0/1M"
+        return _price(value)
+
     if low == high:
-        return _price(low)
-    return f"{_price(low)} to {_price(high)}"
+        return formatted(low)
+    return f"{formatted(low)} to {formatted(high)}"
 
 
 def _price_range(models: list[Model], attr: str) -> str:

--- a/src/trusted_router/static/charter.css
+++ b/src/trusted_router/static/charter.css
@@ -3089,7 +3089,7 @@ body.auth.auth-shell {
 .model-route-head,
 .model-route-row {
   display: grid;
-  grid-template-columns: minmax(150px, 1.25fr) minmax(80px, .7fr) repeat(3, minmax(105px, .9fr)) minmax(80px, .65fr);
+  grid-template-columns: minmax(150px, 1.25fr) repeat(3, minmax(105px, .9fr)) minmax(80px, .65fr);
   min-width: 0;
   gap: 10px;
   align-items: center;

--- a/src/trusted_router/static/models.js
+++ b/src/trusted_router/static/models.js
@@ -151,20 +151,21 @@
 
   function renderRoutes(container, routes) {
     container.replaceChildren();
-    if (!routes.length) {
-      container.append(element("p", "model-route-error", "No active provider routes are published for this model."));
+    const creditRoutes = routes.filter((route) => route.usage_type === "Credits");
+    if (!creditRoutes.length) {
+      container.append(element("p", "model-route-error", "No active Credits provider routes are published for this model."));
       return;
     }
 
     const grouped = new Map();
-    routes.forEach((route) => {
+    creditRoutes.forEach((route) => {
       const key = route.provider || route.provider_name || "provider";
       if (!grouped.has(key)) grouped.set(key, []);
       grouped.get(key).push(route);
     });
 
     const header = element("div", "model-route-head");
-    ["Provider", "Routes", "Input", "Cached input", "Output", "Privacy"].forEach((label) => header.append(element("span", "", label)));
+    ["Provider", "Input", "Cached input", "Output", "Privacy"].forEach((label) => header.append(element("span", "", label)));
     container.append(header);
 
     [...grouped.entries()]
@@ -184,7 +185,6 @@
         providerCell.dataset.label = "Provider";
         providerCell.append(providerLink);
         row.append(providerCell);
-        row.append(routeCell("Routes", [...new Set(providerRoutes.map((route) => route.usage_type))].join(" + ")));
         row.append(routeCell("Input", priceRange(providerRoutes, "prompt"), "model-route-price"));
         row.append(routeCell("Cached input", priceRange(providerRoutes, "input_cache_read"), "model-route-price"));
         row.append(routeCell("Output", priceRange(providerRoutes, "completion"), "model-route-price"));

--- a/src/trusted_router/templates/public/model_compare.html
+++ b/src/trusted_router/templates/public/model_compare.html
@@ -48,10 +48,13 @@
     <span>Context</span><span>{{ left.context_length }} tokens</span><span>{{ right.context_length }} tokens</span>
   </div>
   <div class="matrix-row">
-    <span>Provider routes</span><span>{{ left.endpoint_count }}</span><span>{{ right.endpoint_count }}</span>
+    <span>Credits provider routes</span><span>{{ left.endpoint_count }}</span><span>{{ right.endpoint_count }}</span>
   </div>
   <div class="matrix-row">
     <span>Cheapest route</span><span>{{ comparison.left_price }}</span><span>{{ comparison.right_price }}</span>
+  </div>
+  <div class="matrix-row">
+    <span>Cached input</span><span>{{ left.cached_prompt_price }}</span><span>{{ right.cached_prompt_price }}</span>
   </div>
   <div class="matrix-row">
     <span>Privacy posture</span><span>{{ comparison.left_privacy }}</span><span>{{ comparison.right_privacy }}</span>
@@ -85,8 +88,8 @@
     <div class="panel-head"><h2>{{ left.name }} routes</h2></div>
     <div class="panel-body">
       <ul class="link-list">
-        <li><a href="/models/{{ left.id }}">Overview</a><span>{{ left.endpoint_count }} endpoints</span></li>
-        {% if left.pricing_href %}<li><a href="{{ left.pricing_href }}">Pricing</a><span>Prompt and completion rates</span></li>{% endif %}
+        <li><a href="/models/{{ left.id }}">Overview</a><span>{{ left.endpoint_count }} Credits routes</span></li>
+        {% if left.pricing_href %}<li><a href="{{ left.pricing_href }}">Pricing</a><span>Input, cached input, and output rates</span></li>{% endif %}
         {% if left.benchmarks_href %}<li><a href="{{ left.benchmarks_href }}">Benchmarks</a><span>TrustedRouter and external sources</span></li>{% endif %}
         {% if left.providers_href %}<li><a href="{{ left.providers_href }}">Providers</a><span>All serving providers</span></li>{% endif %}
       </ul>
@@ -96,8 +99,8 @@
     <div class="panel-head"><h2>{{ right.name }} routes</h2></div>
     <div class="panel-body">
       <ul class="link-list">
-        <li><a href="/models/{{ right.id }}">Overview</a><span>{{ right.endpoint_count }} endpoints</span></li>
-        {% if right.pricing_href %}<li><a href="{{ right.pricing_href }}">Pricing</a><span>Prompt and completion rates</span></li>{% endif %}
+        <li><a href="/models/{{ right.id }}">Overview</a><span>{{ right.endpoint_count }} Credits routes</span></li>
+        {% if right.pricing_href %}<li><a href="{{ right.pricing_href }}">Pricing</a><span>Input, cached input, and output rates</span></li>{% endif %}
         {% if right.benchmarks_href %}<li><a href="{{ right.benchmarks_href }}">Benchmarks</a><span>TrustedRouter and external sources</span></li>{% endif %}
         {% if right.providers_href %}<li><a href="{{ right.providers_href }}">Providers</a><span>All serving providers</span></li>{% endif %}
       </ul>

--- a/src/trusted_router/templates/public/model_detail.html
+++ b/src/trusted_router/templates/public/model_detail.html
@@ -57,13 +57,16 @@
           <div class="provider-chip-list">
             {% for provider in model.providers %}
             <a class="pill provider-chip" href="/providers/{{ provider.slug }}" title="{{ provider.slug }}"><img class="provider-logo" src="{{ provider.logo_url }}" alt="{{ provider.name }} logo" aria-hidden="true" width="22" height="22" loading="lazy" decoding="async"><span>{{ provider.name }}</span></a>
+            {% else %}
+            <span class="muted-copy">No Credits provider route is currently published.</span>
             {% endfor %}
           </div>
           {% endif %}
         </td></tr>
-        <tr><th>Endpoints</th><td>{{ model.endpoint_count }} endpoint{{ '' if model.endpoint_count == 1 else 's' }}</td></tr>
+        <tr><th>Credits routes</th><td>{{ model.endpoint_count }} provider route{{ '' if model.endpoint_count == 1 else 's' }}</td></tr>
         {% if model.fixed_price %}
         <tr><th>Input price</th><td>{{ model.prompt_price }} tokens</td></tr>
+        <tr><th>Cached input</th><td>{{ model.cached_prompt_price }}</td></tr>
         <tr><th>Output price</th><td>{{ model.completion_price }} tokens</td></tr>
         {% if model.minimum_charge %}
         <tr><th>Minimum charge</th><td>{{ model.minimum_charge }} per successful request</td></tr>
@@ -77,10 +80,7 @@
           {% if model.us_provider_available %}<span class="pill">US providers</span>{% endif %}
           {% if model.eu_focused_provider_available %}<span class="pill">EU-focused</span>{% endif %}
         </td></tr>
-        <tr><th>Routes</th><td>
-          {% if model.prepaid %}<span class="pill good">prepaid</span>{% endif %}
-          {% if model.byok %}<span class="pill">BYOK</span>{% endif %}
-        </td></tr>
+        {% if model.prepaid %}<tr><th>Billing</th><td><span class="pill good">Credits</span></td></tr>{% endif %}
       </tbody>
     </table>
   </div>
@@ -128,6 +128,7 @@
           <th>Component</th>
           <th>Provider</th>
           <th>Prompt</th>
+          <th>Cached input</th>
           <th>Completion</th>
         </tr>
       </thead>
@@ -137,6 +138,7 @@
           <td><a href="{{ candidate.detail_href }}">{{ candidate.id }}</a>{% if candidate.open_weights %} <span class="pill good">open weights</span>{% endif %}<br><span class="muted-copy">{{ candidate.name }}</span></td>
           <td>{{ provider_identity(candidate.publisher_slug, candidate.provider, "/providers/" ~ candidate.publisher_slug) }}</td>
           <td>{{ candidate.prompt_price }}</td>
+          <td>{{ candidate.cached_prompt_price }}</td>
           <td>{{ candidate.completion_price }}</td>
         </tr>
         {% endfor %}
@@ -155,14 +157,15 @@
       TrustedRouter gateway only. Provider policy separately describes the
       upstream model host's retention, confidential compute, and E2EE posture.
     </p>
+    {% if model.endpoints %}
     <div class="model-table-wrap">
     <table data-sortable="true">
       <thead>
         <tr>
           <th>Provider</th>
-          <th>Usage</th>
-          <th>Prompt</th>
-          <th>Completion</th>
+          <th>Input</th>
+          <th>Cached input</th>
+          <th>Output</th>
           <th>TR router attested</th>
           <th>Provider policy</th>
         </tr>
@@ -171,8 +174,8 @@
         {% for endpoint in model.endpoints %}
         <tr>
           <td>{{ provider_identity(endpoint.provider_slug, endpoint.provider, endpoint.provider_href, subtitle=endpoint.provider_slug) }}</td>
-          <td>{{ endpoint.usage_type }}</td>
           <td>{{ endpoint.prompt_price }}</td>
+          <td>{{ endpoint.cached_prompt_price }}</td>
           <td>{{ endpoint.completion_price }}</td>
           <td>{% if endpoint.attested_gateway %}<span class="pill good">yes</span>{% else %}no{% endif %}</td>
           <td>
@@ -183,6 +186,9 @@
       </tbody>
     </table>
     </div>
+    {% else %}
+    <p class="muted-copy">No Credits provider route is currently published for this model.</p>
+    {% endif %}
     <p class="signup-foot">
       Endpoint JSON: <span class="mono">{{ api_base_url }}/models/{{ model.id }}/endpoints</span>
     </p>

--- a/src/trusted_router/templates/public/model_section.html
+++ b/src/trusted_router/templates/public/model_section.html
@@ -70,14 +70,15 @@
       </div>
     </div>
     {% elif section == "providers" %}
-    <p class="muted-copy">All provider endpoints currently serving this model through TrustedRouter.</p>
+    <p class="muted-copy">Credits provider routes currently serving this model through TrustedRouter.</p>
+    {% if model.endpoints %}
     <table>
       <thead>
         <tr>
           <th>Provider</th>
-          <th>Usage</th>
-          <th>Prompt</th>
-          <th>Completion</th>
+          <th>Input</th>
+          <th>Cached input</th>
+          <th>Output</th>
           <th>Provider policy</th>
         </tr>
       </thead>
@@ -85,8 +86,8 @@
         {% for endpoint in model.endpoints %}
         <tr>
           <td>{{ provider_identity(endpoint.provider_slug, endpoint.provider, endpoint.provider_href, subtitle=endpoint.provider_slug) }}</td>
-          <td>{{ endpoint.usage_type }}</td>
           <td>{{ endpoint.prompt_price }}</td>
+          <td>{{ endpoint.cached_prompt_price }}</td>
           <td>{{ endpoint.completion_price }}</td>
           <td>
             {{ provider_privacy_badges(endpoint) }}
@@ -95,6 +96,9 @@
         {% endfor %}
       </tbody>
     </table>
+    {% else %}
+    <p class="muted-copy">No Credits provider route is currently published for this model.</p>
+    {% endif %}
     {% elif section == "performance" %}
     {% if measured %}
     <h3>Measured performance</h3>
@@ -138,14 +142,15 @@
     </div>
     <p class="signup-foot"><a href="/status">View public status</a> or inspect <a href="/models/{{ model.id }}/providers">provider routes</a>.</p>
     {% elif section == "pricing" %}
-    <p class="muted-copy">Prices are shown as USD per million tokens and billed internally as integer microdollars, not floats.</p>
+    <p class="muted-copy">Credits prices are shown as USD per million tokens and billed internally as integer microdollars, not floats. Cached input appears when the provider publishes a distinct cache-read rate.</p>
+    {% if model.endpoints %}
     <table>
       <thead>
         <tr>
           <th>Provider</th>
-          <th>Usage</th>
-          <th>Prompt</th>
-          <th>Completion</th>
+          <th>Input</th>
+          <th>Cached input</th>
+          <th>Output</th>
           <th>Schedule</th>
         </tr>
       </thead>
@@ -153,8 +158,8 @@
         {% for endpoint in model.endpoints %}
         <tr>
           <td>{{ provider_identity(endpoint.provider_slug, endpoint.provider, endpoint.provider_href) }}</td>
-          <td>{{ endpoint.usage_type }}</td>
           <td>{{ endpoint.prompt_price }}</td>
+          <td>{{ endpoint.cached_prompt_price }}</td>
           <td>{{ endpoint.completion_price }}</td>
           <td>
             {% if endpoint.pricing_schedule %}
@@ -167,6 +172,9 @@
         {% endfor %}
       </tbody>
     </table>
+    {% else %}
+    <p class="muted-copy">No Credits provider route is currently published for this model.</p>
+    {% endif %}
     {% elif section == "uptime" %}
     <div class="seo-two-col">
       <div>

--- a/src/trusted_router/templates/public/provider_detail.html
+++ b/src/trusted_router/templates/public/provider_detail.html
@@ -14,8 +14,7 @@
         <tr><th>Routing status</th><td><span class="pill {% if provider.routing_status == 'active' %}good{% endif %}">{{ provider.routing_status_label }}</span></td></tr>
         {% if provider.homepage_url %}<tr><th>Provider website</th><td><a href="{{ provider.homepage_url }}" rel="nofollow noopener">{{ provider.homepage_url }}</a></td></tr>{% endif %}
         <tr><th>Models</th><td>{{ provider.served_model_count }} public model{{ '' if provider.served_model_count == 1 else 's' }}</td></tr>
-        <tr><th>Credits routes</th><td>{{ provider.prepaid_model_count }}</td></tr>
-        <tr><th>BYOK routes</th><td>{{ provider.byok_model_count }}</td></tr>
+        <tr><th>Credits routes</th><td>{{ provider.credits_model_count }}</td></tr>
         <tr><th>Zero data retention</th><td><span class="pill {% if provider.zero_data_retention or provider.prepaid_zero_data_retention %}good{% endif %}">{{ provider.zero_data_retention_label }}</span>{% if provider.zero_data_retention_scope_label %} <span class="provider-scope-note">{{ provider.zero_data_retention_scope_label }}</span>{% endif %}</td></tr>
         <tr><th>Confidential compute</th><td><span class="pill {% if provider.confidential_compute %}good{% endif %}">{{ provider.confidential_compute_label }}</span></td></tr>
         <tr><th>Provider E2EE</th><td><span class="pill {% if provider.provider_e2ee %}good{% endif %}">{{ provider.provider_e2ee_label }}</span></td></tr>
@@ -79,10 +78,9 @@
           <th>Model</th>
           <th>AI IQ</th>
           <th>Context</th>
-          <th>Endpoints</th>
-          <th>Prompt</th>
-          <th>Completion</th>
-          <th>Routes</th>
+          <th>Input</th>
+          <th>Cached input</th>
+          <th>Output</th>
         </tr>
       </thead>
       <tbody>
@@ -106,13 +104,9 @@
             {% endif %}
           </td>
           <td>{{ model.context_length }}</td>
-          <td>{{ model.endpoint_count }}</td>
           <td>{{ model.prompt_price }}</td>
+          <td>{{ model.cached_prompt_price }}</td>
           <td>{{ model.completion_price }}</td>
-          <td>
-            {% if model.prepaid %}<span class="pill good">prepaid</span>{% endif %}
-            {% if model.byok %}<span class="pill">BYOK</span>{% endif %}
-          </td>
         </tr>
         {% endfor %}
       </tbody>

--- a/tests/browser/models.spec.js
+++ b/tests/browser/models.spec.js
@@ -28,6 +28,8 @@ test("models explorer loads provider cache prices without horizontal overflow", 
   await card.locator("summary").click();
   await expect(card.locator(".model-route-row").first()).toBeVisible();
   await expect(card.getByText("Cached input", { exact: true }).first()).toBeVisible();
+  await expect(card.locator(".model-route-head")).not.toContainText("Routes");
+  await expect(card.locator(".model-route-results")).not.toContainText("BYOK");
 
   for (const viewport of [
     { width: 1280, height: 800 },

--- a/tests/test_catalog_prepaid_display.py
+++ b/tests/test_catalog_prepaid_display.py
@@ -54,6 +54,34 @@ def test_byok_only_model_stays_not_prepaid() -> None:
     # assert — not a failure.
 
 
+def test_model_detail_prices_credits_routes_once_and_shows_cached_input() -> None:
+    model_id = "z-ai/glm-5.3-flash"
+    endpoints = endpoints_for_model(model_id)
+    credits = [endpoint for endpoint in endpoints if endpoint.usage_type == "Credits"]
+
+    assert credits
+    assert any(endpoint.usage_type == "BYOK" for endpoint in endpoints)
+    assert any(
+        tier.prompt_cached_price_microdollars_per_million_tokens is not None
+        for endpoint in credits
+        for tier in (endpoint.price_tiers or ())
+    )
+
+    view = _model_detail_view(MODELS[model_id])
+    rendered_endpoints = view["endpoints"]
+
+    assert isinstance(rendered_endpoints, list)
+    assert {endpoint["endpoint_id"] for endpoint in rendered_endpoints} == {
+        endpoint.id for endpoint in credits
+    }
+    assert all("usage_type" not in endpoint for endpoint in rendered_endpoints)
+    assert view["cached_prompt_price"] != "Not published"
+    assert any(
+        endpoint["cached_prompt_price"] != "Not published"
+        for endpoint in rendered_endpoints
+    )
+
+
 def test_cerebras_only_credits_serves_allowlisted_models() -> None:
     # Cerebras's public account-callable feed is authoritative for Credits.
     # The generated manifest replaces a stale source allowlist so new models

--- a/tests/test_openai_contracted_zdr.py
+++ b/tests/test_openai_contracted_zdr.py
@@ -113,6 +113,6 @@ def test_public_pages_explain_active_openai_prepaid_scope(client: TestClient) ->
     model = client.get("/models/openai/gpt-5.5")
     assert model.status_code == 200
     assert "Credits" in model.text
-    assert "BYOK" in model.text
+    assert "BYOK" not in model.text
     assert ">ZDR<" in model.text
-    assert "no verified privacy claim" in model.text
+    assert "no verified privacy claim" not in model.text

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -551,13 +551,30 @@ def test_public_model_detail_lists_distinct_serving_providers(client: TestClient
 
     assert response.status_code == 200
     assert "Providers serving this model" in response.text
-    assert "Endpoints</th>" in response.text
+    assert "Credits routes</th>" in response.text
+    assert "Cached input</th>" in response.text
+    assert "Usage</th>" not in response.text
+    assert ">BYOK<" not in response.text
     assert 'href="https://aiiq.org/models/kimi-k2.6/"' in response.text
     assert "IQ 116" in response.text
-    expected_providers = {endpoint.provider for endpoint in endpoints_for_model(model_id)}
+    expected_providers = {
+        endpoint.provider
+        for endpoint in endpoints_for_model(model_id)
+        if endpoint.usage_type == "Credits"
+    }
     assert "kimi" in expected_providers
     for provider in expected_providers:
         assert f'title="{provider}"' in response.text
+
+
+def test_byok_only_model_page_reports_no_credits_route(client: TestClient) -> None:
+    response = client.get("/models/tencent/hy3-preview")
+
+    assert response.status_code == 200
+    assert "No Credits provider route is currently published" in response.text
+    assert "no Credits provider route for Tencent: Hy3 preview" in response.text
+    assert "<th>Billing</th>" not in response.text
+    assert ">BYOK<" not in response.text
 
 
 def test_public_partner_model_discloses_fixed_price_and_minimum(


### PR DESCRIPTION
## Summary

- Show one Credits route per provider instead of paired Credits and BYOK rows across model pages.
- Remove route billing columns and add cached-input pricing to overview, pricing, comparison, and provider views.
- Render an explicit no-Credits state for BYOK-only catalog models while keeping the raw endpoint API complete.

## Verification

- `uv run pytest -q tests/test_catalog_prepaid_display.py tests/test_public_revenue_pages.py tests/test_public_seo_pages.py tests/test_models_catalog_cache.py -p no:warnings` (136 passed)
- `uv run ruff check src/trusted_router/dashboard.py tests/test_catalog_prepaid_display.py tests/test_public_revenue_pages.py`
- `uv run mypy src/trusted_router`
- `npm run lint:css`
- `npm run typecheck`
- `npm run lint`
- `node --check src/trusted_router/static/models.js`
- `npm run test:browser -- tests/browser/models.spec.js` (2 passed)
