### PR TITLE
Remove residual BYOK model pricing copy

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -5566,9 +5566,9 @@ def _model_route_evidence(
         else None
     )
     return {
-        "lowest_prompt_price": _price(lowest_prompt) if lowest_prompt is not None else "BYOK only",
+        "lowest_prompt_price": _price(lowest_prompt) if lowest_prompt is not None else None,
         "lowest_completion_price": (
-            _price(lowest_completion) if lowest_completion is not None else "BYOK only"
+            _price(lowest_completion) if lowest_completion is not None else None
         ),
         "fastest_ttft_ms": fastest_ttft_ms,
         "fastest_ttft": (
@@ -5617,6 +5617,18 @@ def _model_faq_items(
     else:
         provider_answer = ", ".join(str(name) for name in provider_names[:-1])
         provider_answer = f"{provider_answer}, and {provider_names[-1]}"
+    if route_evidence["route_count"]:
+        price_answer = (
+            f"The current lowest Credits input price is "
+            f"{route_evidence['lowest_prompt_price']} and the lowest Credits output price is "
+            f"{route_evidence['lowest_completion_price']}. Prices are per one million tokens "
+            "and come from the current route catalog."
+        )
+    else:
+        price_answer = (
+            f"TrustedRouter currently publishes no Credits provider route for {model.name}, "
+            "so no public Credits price is available."
+        )
     return (
         (
             f"What model ID should I use for {model.name}?",
@@ -5630,9 +5642,7 @@ def _model_faq_items(
         ),
         (
             f"How much does {model.name} cost through TrustedRouter?",
-            f"The current lowest prepaid input price is {route_evidence['lowest_prompt_price']} "
-            f"and the lowest output price is {route_evidence['lowest_completion_price']}. "
-            "Prices are per one million tokens and come from the current route catalog.",
+            price_answer,
         ),
         (
             f"How do I require zero data retention for {model.name}?",

--- a/src/trusted_router/templates/public/model_detail.html
+++ b/src/trusted_router/templates/public/model_detail.html
@@ -91,12 +91,16 @@
   <div class="panel-head"><h2>Current route evidence</h2><a href="/leaderboard">Live leaderboard</a></div>
   <div class="panel-body">
     <div class="public-proof-strip">
-      <div><strong>{{ route_evidence.lowest_prompt_price }}</strong><span>Lowest prepaid input price</span></div>
-      <div><strong>{{ route_evidence.lowest_completion_price }}</strong><span>Lowest prepaid output price</span></div>
+      {% if route_evidence.route_count %}
+      <div><strong>{{ route_evidence.lowest_prompt_price }}</strong><span>Lowest Credits input price</span></div>
+      <div><strong>{{ route_evidence.lowest_completion_price }}</strong><span>Lowest Credits output price</span></div>
+      {% else %}
+      <div><strong>Unavailable</strong><span>No Credits provider route</span></div>
+      {% endif %}
       <div><strong>{{ route_evidence.fastest_ttft }}</strong><span>Fastest measured p50 TTFT{% if route_evidence.fastest_ttft_provider %} via <a href="/providers/{{ route_evidence.fastest_ttft_provider }}">{{ route_evidence.fastest_ttft_provider }}</a>{% endif %}</span></div>
       <div><strong>{{ route_evidence.fastest_throughput }}</strong><span>Highest measured throughput{% if route_evidence.fastest_throughput_provider %} via <a href="/providers/{{ route_evidence.fastest_throughput_provider }}">{{ route_evidence.fastest_throughput_provider }}</a>{% endif %}</span></div>
     </div>
-    <p class="muted-copy">Recent provider-route uptime spans {{ route_evidence.uptime_range }} across {{ route_evidence.route_count }} route{{ '' if route_evidence.route_count == 1 else 's' }} and {{ route_evidence.provider_count }} provider{{ '' if route_evidence.provider_count == 1 else 's' }}. Price comes from the current prepaid catalog. Speed and uptime come from routed probes rather than vendor claims.</p>
+    <p class="muted-copy">Recent provider-route uptime spans {{ route_evidence.uptime_range }} across {{ route_evidence.route_count }} route{{ '' if route_evidence.route_count == 1 else 's' }} and {{ route_evidence.provider_count }} provider{{ '' if route_evidence.provider_count == 1 else 's' }}. Price comes from the current Credits catalog. Speed and uptime come from routed probes rather than vendor claims.</p>
     <div class="mini-links">
       {% if model.pricing_href %}<a href="{{ model.pricing_href }}">All route prices</a>{% endif %}
       {% if model.providers_href %}<a href="{{ model.providers_href }}">All providers</a>{% endif %}

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -575,6 +575,9 @@ def test_byok_only_model_page_reports_no_credits_route(client: TestClient) -> No
     assert "no Credits provider route for Tencent: Hy3 preview" in response.text
     assert "<th>Billing</th>" not in response.text
     assert ">BYOK<" not in response.text
+    assert "BYOK only" not in response.text
+    assert "lowest prepaid" not in response.text
+    assert "No Credits provider route" in response.text
 
 
 def test_public_partner_model_discloses_fixed_price_and_minimum(

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -1202,7 +1202,7 @@ def test_model_overview_surfaces_cached_route_evidence(
 
     assert response.status_code == 200
     assert "Current route evidence" in response.text
-    assert "Lowest prepaid input price" in response.text
+    assert "Lowest Credits input price" in response.text
     assert "140 ms" in response.text
     assert "91 tok/s" in response.text
     assert "99.00% to 100.00%" in response.text
@@ -1239,8 +1239,8 @@ def test_model_route_evidence_does_not_invent_a_prepaid_price(
         test_mode=True,
     )
 
-    assert evidence["lowest_prompt_price"] == "BYOK only"
-    assert evidence["lowest_completion_price"] == "BYOK only"
+    assert evidence["lowest_prompt_price"] is None
+    assert evidence["lowest_completion_price"] is None
 
 
 def test_model_overview_links_canonical_related_comparisons(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- remove residual BYOK-only pricing text from public model evidence and FAQ JSON-LD
- show one explicit no-Credits-route state when a model has no public Credits route
- use Credits terminology consistently in public pricing evidence

## Verification
- `uv run pytest -q tests/test_catalog_prepaid_display.py tests/test_public_revenue_pages.py tests/test_public_seo_pages.py tests/test_models_catalog_cache.py -p no:warnings` (136 passed)
- `uv run mypy src/trusted_router`
- `uv run ruff check src/trusted_router/dashboard.py tests/test_public_revenue_pages.py tests/test_public_seo_pages.py`