### PR TITLE
Fix AWS deploy completeness verifier setup

### DIFF
--- a/.github/workflows/deploy-aws-control-plane.yml
+++ b/.github/workflows/deploy-aws-control-plane.yml
@@ -75,6 +75,12 @@ jobs:
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v3
 
+      # The deploy ends by running the repository's Python completeness gate.
+      # A bare GitHub runner has Python but not the project's dependencies, so
+      # without uv the service can deploy successfully and then report a false
+      # failure while importing the verifier.
+      - uses: astral-sh/setup-uv@v7
+
       - uses: docker/setup-buildx-action@v3
 
       - name: Deploy tr-eu from this commit

--- a/tests/test_cloud_deploy_workflows.py
+++ b/tests/test_cloud_deploy_workflows.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_aws_control_plane_installs_uv_before_running_completeness_gate() -> None:
+    workflow = (ROOT / ".github/workflows/deploy-aws-control-plane.yml").read_text()
+
+    setup_uv = workflow.index("uses: astral-sh/setup-uv@v7")
+    deploy = workflow.index("run: bash scripts/deploy/aws_eu_control_plane.sh")
+
+    assert setup_uv < deploy


### PR DESCRIPTION
## Summary
- install uv before the AWS control-plane deploy invokes the Python completeness gate
- add a regression test that locks the setup step before the deploy command

## Root cause
The App Runner service deployed successfully, but the final read-only completeness gate fell back to bare python3 on the GitHub runner. It could import local TrustedRouter modules through PYTHONPATH but not their dependencies, so pydantic import failed and the workflow reported a false deployment failure.

## Verification
- `uv run ruff check tests/test_cloud_deploy_workflows.py`
- `uv run pytest -q tests/test_cloud_deploy_workflows.py tests/test_cloud_rollout_completeness.py` (51 passed)