### PR TITLE
drain: a preflight that cannot run has not failed

### DIFF
--- a/.github/workflows/deploy-aws-control-plane.yml
+++ b/.github/workflows/deploy-aws-control-plane.yml
@@ -89,6 +89,13 @@ jobs:
       - name: Install outbox drain and verify cloud completeness
         if: ${{ inputs.mode == 'drain-install' }}
         working-directory: src
+        env:
+          # The installer refuses an admin DSN: the ClickHouse host must not
+          # hold superuser-equivalent credentials for the operational
+          # database. tr_drain is the scoped DSQL role (LOGIN, plus SELECT
+          # and DELETE on the outbox table only) created once by an operator
+          # with admin, per the installer's own instructions.
+          DSQL_USER: tr_drain
         run: |
           bash scripts/deploy/aws_eu_clickhouse_drain_install.sh
           bash scripts/deploy/verify_cloud_complete.sh aws

--- a/infra/aws_deploy_role.tf
+++ b/infra/aws_deploy_role.tf
@@ -44,6 +44,10 @@ resource "aws_iam_role_policy" "tr_eu_role_writes" {
           "iam:GetRolePolicy",
           "iam:ListRolePolicies",
           "iam:ListAttachedRolePolicies",
+          # The drain installer's preflight asks whether the ClickHouse node
+          # may reach DSQL. Without this the simulation errors, and run
+          # 33335052109 reported a node permission gap that did not exist.
+          "iam:SimulatePrincipalPolicy",
         ]
         Resource = "arn:aws:iam::${local.aws_account_id}:role/tr-eu-*"
       },

--- a/scripts/deploy/aws_eu_clickhouse_drain_install.sh
+++ b/scripts/deploy/aws_eu_clickhouse_drain_install.sh
@@ -169,11 +169,32 @@ NODE_ROLE="$(aws iam get-instance-profile --instance-profile-name "$NODE_ROLE" \
   --query 'InstanceProfile.Roles[0].RoleName' --output text)"
 CLUSTER_ARN="arn:aws:dsql:${DSQL_REGION}:${ACCOUNT}:cluster/${CLUSTER_ID}"
 log "node role: $NODE_ROLE; checking DSQL connect permission on $CLUSTER_ARN"
-DSQL_DECISION="$(aws iam simulate-principal-policy \
+# Distinguish "the node is not allowed" from "we could not ask". Discarding
+# the simulate error made a CALLER permission gap read as a NODE permission
+# gap: run 33335052109 printed the whole grant-the-node remediation while the
+# node already held dsql:DbConnect, and only the caller lacked
+# iam:SimulatePrincipalPolicy. A preflight that cannot run has not passed and
+# has not failed; say which.
+SIMULATE_ERROR=""
+if ! DSQL_DECISION="$(aws iam simulate-principal-policy \
   --policy-source-arn "arn:aws:iam::${ACCOUNT}:role/${NODE_ROLE}" \
   --action-names dsql:DbConnectAdmin dsql:DbConnect \
   --resource-arns "$CLUSTER_ARN" \
-  --query 'EvaluationResults[?EvalDecision==`allowed`].EvalActionName' --output text 2>/dev/null || true)"
+  --query 'EvaluationResults[?EvalDecision==`allowed`].EvalActionName' --output text 2>&1)"; then
+  SIMULATE_ERROR="$DSQL_DECISION"
+  DSQL_DECISION=""
+fi
+if [ -n "$SIMULATE_ERROR" ]; then
+  cat >&2 <<EOF
+
+FATAL: could not evaluate ${NODE_ROLE}'s DSQL permission; this says nothing
+about the node. The caller needs iam:SimulatePrincipalPolicy on
+arn:aws:iam::${ACCOUNT}:role/${NODE_ROLE}.
+
+  $SIMULATE_ERROR
+EOF
+  exit 1
+fi
 if [ -z "$DSQL_DECISION" ]; then
   cat >&2 <<EOF
 


### PR DESCRIPTION
Diagnosed live: the ClickHouse node role already holds `dsql:DbConnect` on the cluster; the preflight's `2>/dev/null || true` masked the caller's missing `iam:SimulatePrincipalPolicy` as a node-side gap and printed pages of irrelevant remediation. Preflight now distinguishes the two cases and names the missing caller permission; terraform grants it (auto-applies on merge via the infra/** push trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)