### PR TITLE
catalog: advertise the context window a route can actually serve

### DIFF
--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -2488,8 +2488,11 @@ SYNTH_QUALITY_MODEL_ORDER = (
     DEEPSEEK_V4_PRO_0813_MODEL_ID,
 )
 
+# Every member must serve the 1M window this model advertises. minimax-m3 tops
+# out at 524288 and was only ever eligible here because upstream reseller
+# metadata over-reported its context; routing does not filter candidates by
+# capacity, so a large request could land on it and fail at the provider.
 SYNTH_QUALITY_1M_MODEL_ORDER = (
-    "minimax/minimax-m3",
     "xiaomi/mimo-v2.5-pro",
     "z-ai/glm-5.2",
     DEEPSEEK_V4_PRO_0423_MODEL_ID,

--- a/src/trusted_router/catalog_ingest.py
+++ b/src/trusted_router/catalog_ingest.py
@@ -709,11 +709,27 @@ def _ingested_models_and_endpoints() -> tuple[dict[str, Model], dict[str, ModelE
         # headline rate above).
         cheapest_tiers = next(t for p, _c, t, _s, _e in per_endpoint_prices if p == cheapest_prompt)
 
-        ctx_candidates = [
-            int(raw_model.get("context_length") or 0),
-            *(int(ep.get("context_length") or 0) for _p, _c, _t, _s, ep in per_endpoint_prices),
-        ]
-        context_length = max(ctx_candidates) or 0
+        # Model-level context is advertised, so like the price above it must
+        # not lie. `max()` over every endpoint takes the most optimistic
+        # number any reseller published, and resellers get this wrong:
+        # z-ai/glm-5.3-flash carries 1310720 on six third-party endpoints
+        # while Z.AI's own endpoint -- and upstream's `top_provider` -- say
+        # 1048576. Prefer `top_provider`, which is upstream's canonical
+        # capability summary for the model, and fall back to the endpoints
+        # only when it is absent.
+        top_provider = raw_model.get("top_provider")
+        if not isinstance(top_provider, dict):
+            top_provider = {}
+        context_length = int(top_provider.get("context_length") or 0)
+        if not context_length:
+            ctx_candidates = [
+                int(raw_model.get("context_length") or 0),
+                *(
+                    int(ep.get("context_length") or 0)
+                    for _p, _c, _t, _s, ep in per_endpoint_prices
+                ),
+            ]
+            context_length = max(ctx_candidates) or 0
 
         # Anthropic-native `/v1/messages` is only available for models
         # Anthropic actually serves; for everything else, /v1/messages is

--- a/tests/test_catalog_context_not_overadvertised.py
+++ b/tests/test_catalog_context_not_overadvertised.py
@@ -1,0 +1,58 @@
+"""Advertised context must be a window some route will actually honour.
+
+Upstream endpoint metadata is not trustworthy: resellers publish context
+windows larger than the publisher's own endpoint serves. Taking the max
+across endpoints therefore advertised a window no route accepts -- callers
+sized a request to it and got a provider-side rejection.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from trusted_router.catalog_ingest import _INGEST_PATH, _ingested_models_and_endpoints
+
+
+def _snapshot() -> list[dict]:
+    raw = json.loads(Path(_INGEST_PATH).read_text())
+    items = raw if isinstance(raw, list) else raw.get("data", raw.get("models", []))
+    return [m for m in items if isinstance(m, dict)]
+
+
+def test_advertised_context_never_exceeds_canonical_top_provider() -> None:
+    models, _ = _ingested_models_and_endpoints()
+    by_id = {m["id"]: m for m in _snapshot() if m.get("id")}
+
+    over = []
+    for model_id, model in models.items():
+        raw = by_id.get(model_id)
+        if not raw:
+            continue
+        top = raw.get("top_provider")
+        canonical = int((top or {}).get("context_length") or 0)
+        if canonical and model.context_length > canonical:
+            over.append((model_id, model.context_length, canonical))
+
+    assert not over, (
+        "advertised context exceeds upstream's canonical top_provider window "
+        f"for {len(over)} model(s): {over[:5]}"
+    )
+
+
+def test_glm_5_3_flash_advertises_the_publisher_window() -> None:
+    """Regression: six reseller endpoints report 1310720; Z.AI's own says 1048576."""
+    models, _ = _ingested_models_and_endpoints()
+    model = models.get("z-ai/glm-5.3-flash")
+    assert model is not None, "z-ai/glm-5.3-flash missing from the ingested catalog"
+    assert model.context_length == 1_048_576, (
+        f"expected the publisher's 1,048,576 window, got {model.context_length:,}"
+    )
+
+
+def test_every_ingested_model_keeps_a_usable_context() -> None:
+    """Narrowing must never zero a model out."""
+    models, _ = _ingested_models_and_endpoints()
+    assert models, "no models ingested"
+    zeroed = [mid for mid, m in models.items() if not m.context_length]
+    assert not zeroed, f"models left with no context window: {zeroed[:5]}"

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -1504,7 +1504,6 @@ def test_prometheus_1m_uses_only_long_context_open_weight_components() -> None:
     assert model.name == "TrustedRouter Prometheus 1.0 1M"
     assert model.context_length == 1_048_576
     assert candidate_ids == [
-        "minimax/minimax-m3",
         "xiaomi/mimo-v2.5-pro",
         "z-ai/glm-5.2",
         DEEPSEEK_V4_PRO_0423_MODEL_ID,


### PR DESCRIPTION
## What

`context_length` came from `max()` across upstream's model-level value and every endpoint's. That takes the most optimistic number any reseller published — and resellers get it wrong.

`z-ai/glm-5.3-flash` is the case that surfaced it: **six third-party endpoints report 1310720**, while **Z.AI's own endpoint and upstream's `top_provider` both say 1048576**. We advertised 1.25M for a window no route will honour.

This prefers `top_provider` (upstream's canonical capability summary), falling back to the endpoints only when it is absent.

That mirrors what the price aggregation a few lines above already does on purpose — it takes the *cheapest* endpoint so the headline "doesn't lie". Context was doing the opposite.

## Blast radius

**29 of 162 models change. Every one narrows. None widens, none is zeroed.** Verified against the real snapshot, not a fixture. Sample:

| model | before | after |
|---|---|---|
| `nvidia/nemotron-3-super-120b-a12b` | 1,000,000 | 262,144 |
| `minimax/minimax-m3` | 1,048,576 | 524,288 |
| `thinkingmachines/inkling` | 1,048,576 | 524,288 |
| `deepseek/deepseek-v4-flash-0731` | 1,310,720 | 1,048,576 |
| `z-ai/glm-5.3-flash` | 1,310,720 | 1,048,576 |

## The defect this was hiding

`trustedrouter/prometheus-1.0-1m` advertises 1M, but `SYNTH_QUALITY_1M_MODEL_ORDER` contained `minimax/minimax-m3` at **524288**. Routing does not filter candidates by capacity, so a large request could be dispatched there and fail at the provider.

`test_prometheus_1m_uses_only_long_context_open_weight_components` passed only because ingest was inflating that component. It exists to enforce exactly this property, so the component is dropped from the 1M order rather than the assertion being weakened.

## Deliberately not fixed here

`prometheus-2.0` has the same shape — advertises 1M, panel carries `minimax-m3`. Its panel is **frozen by contract** (`test_prometheus_versions_are_frozen`), so customers pinning a version get stable behaviour. I reverted an edit to it rather than break that freeze.

Closing that gap needs **context-aware routing** — skipping candidates that cannot fit the request — which preserves both the freeze and the 1M promise. Separate work, and it lives in the enclave too.

## Tests

- `tests/test_catalog_context_not_overadvertised.py` (new, 3 tests): no model exceeds its canonical `top_provider` window; glm-5.3-flash regression; narrowing never zeroes a model out.
- Full suite: **7725 passed, 346 skipped, 10 xfailed, 0 failed**.
- `ruff check`, `ruff format --check`, `mypy` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)