### PR TITLE
Keep API key creation open and add feature requests

### DIFF
--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -288,6 +288,7 @@ _SUPPORT_CATEGORIES = {
     "account": "Account access",
     "billing": "Billing and credits",
     "provider": "Provider or model",
+    "feature": "Feature request",
     "other": "Other",
 }
 

--- a/src/trusted_router/static/console.css
+++ b/src/trusted_router/static/console.css
@@ -815,44 +815,6 @@ body.console {
   background: transparent;
 }
 
-.key-create-panel summary {
-  display: grid;
-  grid-template-columns: 24px minmax(0, max-content) minmax(0, 1fr);
-  gap: 12px;
-  align-items: baseline;
-  cursor: pointer;
-  padding: 16px 18px;
-  color: var(--ink);
-  font-weight: 750;
-  list-style: none;
-}
-
-.key-create-panel summary::-webkit-details-marker {
-  display: none;
-}
-
-.key-create-panel summary::before {
-  content: "+";
-  display: inline-grid;
-  place-items: center;
-  width: 24px;
-  height: 24px;
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  color: var(--muted);
-  font-weight: 700;
-}
-
-.key-create-panel[open] summary::before {
-  content: "-";
-}
-
-.key-create-panel .summary-hint {
-  color: var(--muted);
-  font-size: 13px;
-  font-weight: 500;
-}
-
 .key-budget-form {
   display: grid;
   grid-template-columns: 1fr auto;

--- a/src/trusted_router/static/console.js
+++ b/src/trusted_router/static/console.js
@@ -439,7 +439,6 @@ function initConsole() {
       event.preventDefault();
       const panel = document.getElementById("new-api-key");
       if (panel) {
-        panel.open = true;
         panel.scrollIntoView({ behavior: "smooth", block: "start" });
         const input = panel.querySelector('input[name="name"]');
         if (input) {

--- a/src/trusted_router/templates/console/_layout.html
+++ b/src/trusted_router/templates/console/_layout.html
@@ -35,6 +35,8 @@
       <a href="/models">Models</a>
       <a href="https://trust.trustedrouter.com">Trust</a>
       <a href="https://github.com/Lore-Hex/trusted-router-py">SDK</a>
+      <a href="/support">Help</a>
+      <a href="/support?category=feature#support-inquiry">Feature request</a>
     </nav>
     {% if workspaces %}
     <form class="workspace-selector" method="post" action="/console/workspaces/select">

--- a/src/trusted_router/templates/console/api_keys.html
+++ b/src/trusted_router/templates/console/api_keys.html
@@ -102,14 +102,16 @@
   </div>
 </section>
 {% if keys %}
-<details class="panel key-create-panel" id="new-api-key">
-  <summary>
-    <span>Create a new API key</span>
-    <span class="summary-hint">Open only when you need another application or environment key.</span>
-  </summary>
+<section class="panel key-create-panel" id="new-api-key">
+  <div class="panel-head">
+    <div>
+      <h2>Create a new API key</h2>
+      <p class="panel-kicker">Use a separate key for each application or environment.</p>
+    </div>
+  </div>
   <div class="panel-body">
     {{ create_key_form() }}
   </div>
-</details>
+</section>
 {% endif %}
 {% endblock %}

--- a/src/trusted_router/templates/public/_footer.html
+++ b/src/trusted_router/templates/public/_footer.html
@@ -65,6 +65,7 @@
       <a href="/resources">Resources</a>
       <a href="/careers">Careers</a>
       <a href="/support">Support</a>
+      <a href="/support?category=feature#support-inquiry">Feature request</a>
       <a href="https://discord.gg/FREVts9KAG" target="_blank" rel="noopener noreferrer">Discord community</a>
       <a href="/legal">Legal</a>
       <a href="/terms">Terms</a>

--- a/src/trusted_router/templates/public/support.html
+++ b/src/trusted_router/templates/public/support.html
@@ -14,7 +14,10 @@
         <span class="card-label">Product support</span>
         <h2>Contact support</h2>
       </div>
-      <a href="mailto:{{ support_email }}">{{ support_email }}</a>
+      <div class="support-head-actions">
+        <a href="mailto:{{ support_email }}">{{ support_email }}</a>
+        <a class="btn" href="/support?category=feature#support-inquiry">Feature request</a>
+      </div>
     </div>
     <div class="panel-body">
       <form class="support-form" id="support-inquiry" novalidate>
@@ -34,6 +37,7 @@
               <option value="account">Account access</option>
               <option value="billing">Billing and credits</option>
               <option value="provider">Provider or model</option>
+              <option value="feature">Feature request</option>
               <option value="other">Other</option>
             </select>
           </label>
@@ -106,6 +110,13 @@
   }
   .support-panel { margin: 0; }
   .support-panel .panel-head { align-items: end; }
+  .support-head-actions {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
   .support-panel .panel-head h2,
   .support-aside h2 { margin: 4px 0 0; }
   .support-grid {
@@ -182,6 +193,13 @@
     if (!form) return;
     var status = form.querySelector('[data-role="status"]');
     var button = form.querySelector('[data-role="submit"]');
+
+    if (new URLSearchParams(window.location.search).get("category") === "feature") {
+      form.category.value = "feature";
+      button.textContent = "Send feature request";
+      form.subject.placeholder = "What would you like TrustedRouter to add?";
+      form.message.placeholder = "Describe the feature, who it helps, and how you handle it today.";
+    }
     var defaultButtonText = button.textContent;
 
     function show(message, tone) {

--- a/tests/test_console_keys_manage.py
+++ b/tests/test_console_keys_manage.py
@@ -191,9 +191,12 @@ def test_budget_inputs_have_no_number_spinners(console: dict) -> None:
 
 
 def test_existing_keys_are_primary_when_workspace_has_keys(console: dict) -> None:
-    """Once a workspace has keys, monitoring them should be above creation."""
+    """Existing keys stay primary while creation remains permanently visible."""
     page = console["client"].get("/console/api-keys").text
 
     assert page.index("Existing keys") < page.index("Create a new API key")
     assert 'data-action="open-new-key"' in page
-    assert '<details class="panel key-create-panel" id="new-api-key">' in page
+    assert '<section class="panel key-create-panel" id="new-api-key">' in page
+    assert '<details class="panel key-create-panel"' not in page
+    assert 'href="/support">Help</a>' in page
+    assert 'href="/support?category=feature#support-inquiry">Feature request</a>' in page

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -961,6 +961,9 @@ def test_public_privacy_terms_and_support_pages_are_distinct(client: TestClient)
     assert "help@trustedrouter.com" in support.text
     assert 'id="support-inquiry"' in support.text
     assert 'fetch("/support/inquiry"' in support.text
+    assert '<option value="feature">Feature request</option>' in support.text
+    assert 'href="/support?category=feature#support-inquiry"' in support.text
+    assert 'button.textContent = "Send feature request"' in support.text
     assert "github.com/Lore-Hex/quill-router/issues" in support.text
     assert "Never send an API key" in support.text
     assert "status.trustedrouter.com" in support.text

--- a/tests/test_support_form.py
+++ b/tests/test_support_form.py
@@ -100,6 +100,41 @@ def test_support_submission_sends_to_help_with_reply_to(
     )
 
 
+def test_feature_request_uses_the_support_delivery_path(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sent_messages: list[EmailMessage] = []
+
+    class FakeEmailService:
+        def send(self, message: EmailMessage) -> bool:
+            sent_messages.append(message)
+            return True
+
+    monkeypatch.setattr(
+        public_routes,
+        "get_email_service",
+        lambda _settings: FakeEmailService(),
+    )
+
+    response = client.post(
+        "/support/inquiry",
+        json=_payload(
+            category="feature",
+            subject="Add a route comparison export",
+            message="Please add a machine-readable comparison export.",
+        ),
+    )
+
+    assert response.status_code == 200
+    assert len(sent_messages) == 1
+    message = sent_messages[0]
+    assert message.to == "help@trustedrouter.com"
+    assert message.subject == (
+        "TrustedRouter support: Feature request: Add a route comparison export"
+    )
+
+
 @pytest.mark.parametrize(
     "overrides",
     (


### PR DESCRIPTION
## Summary
- keep the API key creation form permanently expanded while preserving existing keys as the primary section
- add Help and Feature request links to the console and public footer
- route feature requests through the existing support form, protections, and configured support email

## Verification
- 92 focused tests passed
- Ruff passed
- Node syntax check passed
- git diff --check passed