### PR TITLE
Repair control-plane health coverage

### DIFF
--- a/clickhouse/build_public_snapshots.py
+++ b/clickhouse/build_public_snapshots.py
@@ -26,7 +26,8 @@ from trusted_router.synthetic.video_leaderboard import aggregate_video_leaderboa
 
 SAMPLE_LIMIT = 10_000
 PER_PROVIDER_LIMIT = 500
-STATUS_LIVE_SAMPLE_LIMIT = 500
+STATUS_SAMPLES_PER_DIMENSION = 30
+STATUS_LIVE_SAMPLE_LIMIT = 5_000
 STATUS_HOUR_ROLLUP_LIMIT = 5_000
 VIDEO_SAMPLE_LIMIT = 5_000
 CLIENT_ROLLUP_LIMIT = 100_000
@@ -145,12 +146,20 @@ def _status_inputs(
         SyntheticProbeSample,
         _query(
             password,
-            """
-SELECT * EXCEPT ingest_version
-FROM synthetic_probe_samples FINAL
-WHERE created_at >= now64(3) - INTERVAL 1 HOUR
+            f"""
+SELECT * EXCEPT (ingest_version, probe_rank)
+FROM
+(
+  SELECT *, row_number() OVER (
+    PARTITION BY monitor_region, target, probe_type, target_region
+    ORDER BY created_at DESC, id DESC
+  ) AS probe_rank
+  FROM synthetic_probe_samples FINAL
+  WHERE created_at >= now64(3) - INTERVAL 1 HOUR
+)
+WHERE probe_rank <= {STATUS_SAMPLES_PER_DIMENSION}
 ORDER BY created_at DESC, id DESC
-LIMIT 500
+LIMIT {STATUS_LIVE_SAMPLE_LIMIT}
 FORMAT JSONEachRow
 """,
         ),

--- a/src/trusted_router/synthetic/status.py
+++ b/src/trusted_router/synthetic/status.py
@@ -121,8 +121,17 @@ def status_snapshot(
             for component_id in sample_component_ids(sample)
         )
     ]
+    # Control-plane health is an SLO-only signal, so its rollups intentionally
+    # use the non-display `uncategorized` component. Preserve those records
+    # when they classify into a published SLO without exposing a fake component.
     scoped_slo_rollups = [
-        rollup for rollup in precomputed_rollups if rollup.component in published_component_ids
+        rollup
+        for rollup in precomputed_rollups
+        if rollup.component in published_component_ids
+        or (
+            rollup.component == UNCATEGORIZED_COMPONENT
+            and bool(rollup_slo_class_ids(rollup))
+        )
     ]
     router_core_samples = [
         sample
@@ -602,11 +611,11 @@ def _window_rollup_with_rollup_backfill(
 ) -> dict[str, Any]:
     cutoff = now - dt.timedelta(seconds=seconds)
     raw_rows = [sample for sample in samples if _parse_time(sample.created_at) >= cutoff]
-    raw_hour_keys = {sample.created_at[:13] for sample in raw_rows}
+    raw_hour_keys = {_sample_hour_dimension(sample) for sample in raw_rows}
     backfill_rollups = [
         rollup
         for rollup in _hour_rollups_in_window(rollups, now=now, seconds=seconds)
-        if rollup.period_start[:13] not in raw_hour_keys
+        if _rollup_hour_dimension(rollup) not in raw_hour_keys
     ]
     combined_rollups = [
         new_rollup_for_sample(sample, period="hour", component="status_window")
@@ -808,11 +817,11 @@ def _slo_window(
 ) -> dict[str, Any]:
     cutoff = now - dt.timedelta(seconds=seconds)
     raw_rows = [sample for sample in samples if _parse_time(sample.created_at) >= cutoff]
-    raw_hour_keys = {sample.created_at[:13] for sample in raw_rows}
+    raw_hour_keys = {_sample_hour_dimension(sample) for sample in raw_rows}
     backfill_rollups = [
         rollup
         for rollup in _hour_rollups_in_window(rollups, now=now, seconds=seconds)
-        if rollup.period_start[:13] not in raw_hour_keys
+        if _rollup_hour_dimension(rollup) not in raw_hour_keys
     ]
     counts: dict[str, int] = defaultdict(int)
     for sample in raw_rows:
@@ -839,6 +848,26 @@ def _slo_window(
         "burn_rate": burn_rate,
         "status_counts": status_counts,
     }
+
+
+def _sample_hour_dimension(sample: SyntheticProbeSample) -> tuple[str, str, str, str, str]:
+    return (
+        sample.created_at[:13],
+        sample.target,
+        sample.probe_type,
+        sample.monitor_region,
+        sample.target_region or "",
+    )
+
+
+def _rollup_hour_dimension(rollup: SyntheticRollup) -> tuple[str, str, str, str, str]:
+    return (
+        rollup.period_start[:13],
+        rollup.target,
+        rollup.probe_type,
+        rollup.monitor_region,
+        rollup.target_region or "",
+    )
 
 
 def _rollup_status_counts(rollup: SyntheticRollup) -> dict[str, int]:

--- a/tests/test_public_analytics_snapshots.py
+++ b/tests/test_public_analytics_snapshots.py
@@ -144,6 +144,29 @@ def test_snapshot_builder_precomputes_video_and_status_inputs() -> None:
     assert snapshots["client_reliability"]["published"] is False
 
 
+def test_status_input_query_bounds_each_probe_dimension_independently(monkeypatch) -> None:
+    queries: list[str] = []
+
+    def fake_query(_password: str, sql: str, **_kwargs: object) -> str:
+        queries.append(sql)
+        return ""
+
+    monkeypatch.setattr(snapshot_builder, "_query", fake_query)
+
+    samples, rollups = snapshot_builder._status_inputs("test-password")
+
+    assert samples == []
+    assert rollups == []
+    sample_query, _rollup_query = queries
+    assert "row_number() OVER" in sample_query
+    assert "PARTITION BY monitor_region, target, probe_type, target_region" in sample_query
+    assert (
+        f"WHERE probe_rank <= {snapshot_builder.STATUS_SAMPLES_PER_DIMENSION}"
+        in sample_query
+    )
+    assert f"LIMIT {snapshot_builder.STATUS_LIVE_SAMPLE_LIMIT}" in sample_query
+
+
 def test_snapshot_builder_encodes_clickhouse_array_parameters() -> None:
     assert _clickhouse_string_array(["model/a", "model/o'clock", r"model\b"]) == (
         r"['model/a','model/o\'clock','model\\b']"

--- a/tests/test_status_component_scope.py
+++ b/tests/test_status_component_scope.py
@@ -236,6 +236,60 @@ def test_legacy_regional_control_plane_probes_do_not_burn_global_slo() -> None:
     assert set(control_plane["current_by_region"]) == {"global"}
 
 
+def test_control_plane_slo_backfills_each_monitor_dimension_from_rollups() -> None:
+    """One live monitor row must not hide its peer monitor's hourly rollup."""
+    now = dt.datetime(2026, 8, 31, 2, 30, tzinfo=dt.UTC)
+    period_start = _iso(now.replace(minute=0, second=0, microsecond=0))
+    live = SyntheticProbeSample(
+        id="syn-control-plane-eu-live",
+        probe_type="control_plane_health",
+        target="control-plane",
+        target_url="https://trustedrouter.com/health",
+        monitor_region="europe-west4",
+        status="up",
+        created_at=_iso(now - dt.timedelta(seconds=30)),
+    )
+    eu_rollup = SyntheticRollup(
+        id="rollup-control-plane-eu",
+        period="hour",
+        period_start=period_start,
+        component="uncategorized",
+        target="control-plane",
+        probe_type="control_plane_health",
+        monitor_region="europe-west4",
+        sample_count=20,
+        up_count=20,
+        last_checked_at=live.created_at,
+    )
+    us_rollup = SyntheticRollup(
+        id="rollup-control-plane-us",
+        period="hour",
+        period_start=period_start,
+        component="uncategorized",
+        target="control-plane",
+        probe_type="control_plane_health",
+        monitor_region="us-central1",
+        sample_count=20,
+        up_count=20,
+        last_checked_at=_iso(now - dt.timedelta(minutes=1)),
+    )
+
+    snapshot = status_snapshot(
+        [live],
+        rollups=[eu_rollup, us_rollup],
+        now=now,
+        settings=_gcp_settings(),
+    )
+
+    control_plane = snapshot["slo_classes"]["control_plane"]
+    one_hour = control_plane["windows"]["1h"]
+    # The live EU row supersedes its same-hour aggregate. The independent US
+    # aggregate remains valid evidence and must not be discarded with it.
+    assert one_hour["sample_count"] == 21
+    assert one_hour["up_count"] == 21
+    assert one_hour["uptime_percent"] == 100.0
+
+
 def test_gcp_current_checks_keep_complete_regional_deploy_canaries() -> None:
     """A bounded public sample tail cannot crowd deploy-gate PONGs out."""
     now = utcnow()


### PR DESCRIPTION
Summary:
- Retain SLO-only control-plane rollups in public status snapshots.
- Merge raw samples and hourly rollups per probe dimension instead of suppressing an entire hour.
- Sample recent ClickHouse rows fairly per monitor, target, probe, and target region.

Production root cause:
- 141 historical 404s were legacy direct probes of the private us-central1 run.app origin, not customer-facing downtime.
- The 404s ended at 2026-08-30 03:38:40 UTC after canonical health probing was deployed.
- Hourly rollups contain about 20 successful control-plane probes per monitor, but the public snapshot discarded their uncategorized SLO rollups and its global 500-row tail crowded out most live control-plane rows.

Verification:
- Full pytest: 7,755 passed, 346 skipped, 10 xfailed.
- MyPy clean.
- Ruff clean.
- Patched ClickHouse query validated read-only in production: 1,594 rows, 82 dimensions, 40 control-plane rows in the latest hour.