### PR TITLE
Boot approval is decided at use time, not frozen at registration

### DIFF
--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -157,6 +157,7 @@ from trusted_router.spend_leases import (
     SpendLeaseEchoValue,
     SpendLeaseEligibilityFailure,
     SpendLeaseSigner,
+    boot_auth_fails_only_on_digest_approval,
     build_spend_lease_shadow_event,
     freeze_spend_lease_catalog,
     mint_shadow_spend_lease,
@@ -334,17 +335,19 @@ def _register_spend_lease_boot_sync(
         ):
             raise ValueError("attestation does not commit to the receipt public key")
         verified = False
-        approved = False
+        approved_at_registration = False
         image_digest = ""
         if attestation_kind == GCP_ATTESTATION_KIND:
             verify_gcp_attestation_chain(body.attestation_evidence)
             image_digest = gcp_attestation_image_digest(body.attestation_evidence)
             verified = True
-            approved = image_digest in settings.spend_lease_accepted_gcp_digests
+            approved_at_registration = (
+                image_digest in settings.spend_lease_accepted_gcp_digests
+            )
         record = SpendLeaseBoot(
             kid=kid,
             jwk=jwk,
-            approved=approved,
+            approved=approved_at_registration,
             verified=verified,
             image_digest=image_digest,
             attestation_kind=attestation_kind,
@@ -452,6 +455,7 @@ def _authorize_gateway_sync(
         "boot_auth": boot_auth,
         "boot_kid": boot_auth.kid if boot_auth is not None else "",
         "boot_verified": False,
+        "boot_failure_reason": None,
         "no_lease_reason": None,
         "echo": echo,
         "server_estimate_micro": None,
@@ -517,6 +521,7 @@ def _authorize_gateway_sync_impl(
     boot_auth = cast(BootAuthHeader | None, spend_context["boot_auth"])
     if settings.spend_lease_issuance_enabled and boot_auth is not None:
         boot = STORE.get_spend_lease_boot(boot_auth.kid)
+        accepted_image_digests = settings.spend_lease_accepted_gcp_digests
         spend_context["boot_verified"] = verify_boot_auth(
             boot=boot,
             auth=boot_auth,
@@ -525,7 +530,19 @@ def _authorize_gateway_sync_impl(
             exact_body_bytes=cast(bytes, spend_context["raw_body"]),
             signed_lookup_hash=body.api_key_lookup_hash,
             resolved_lookup_hash=api_key.lookup_hash,
+            accepted_image_digests=accepted_image_digests,
         )
+        if not spend_context["boot_verified"] and boot_auth_fails_only_on_digest_approval(
+            boot=boot,
+            auth=boot_auth,
+            method=request.method,
+            path=request.url.path,
+            exact_body_bytes=cast(bytes, spend_context["raw_body"]),
+            signed_lookup_hash=body.api_key_lookup_hash,
+            resolved_lookup_hash=api_key.lookup_hash,
+            accepted_image_digests=accepted_image_digests,
+        ):
+            spend_context["boot_failure_reason"] = "boot_digest_not_accepted"
     workspace = STORE.get_workspace(api_key.workspace_id)
     if workspace is None:
         raise api_error(403, "Workspace is unavailable", ErrorType.FORBIDDEN)
@@ -923,7 +940,9 @@ def _authorize_gateway_sync_impl(
         app_markup_basis_points=app_markup_basis_points,
         regional_lease_authorization=bool(regional_eligible),
     )
-    spend_context["no_lease_reason"] = no_lease_reason
+    spend_context["no_lease_reason"] = no_lease_reason or spend_context.get(
+        "boot_failure_reason"
+    )
     if (
         settings.spend_lease_issuance_enabled
         and bool(spend_context["boot_verified"])

--- a/src/trusted_router/spend_leases.py
+++ b/src/trusted_router/spend_leases.py
@@ -12,7 +12,7 @@ import json
 import threading
 import time
 import uuid
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Collection, Mapping, Sequence
 from dataclasses import asdict, dataclass
 from typing import Any, Literal
 
@@ -49,6 +49,7 @@ LeaseStatus = Literal["active", "terminal", "expired"]
 ShadowVerdict = Literal["accepted", "declined_funds", "declined_other"]
 ShadowDivergence = Literal["none", "admit_diverged", "estimate_low", "echo_invalid"]
 SpendLeaseEligibilityFailure = Literal[
+    "boot_digest_not_accepted",
     "not_pilot",
     "route_type",
     "no_candidates",
@@ -68,7 +69,7 @@ SpendLeaseEligibilityFailure = Literal[
 class SpendLeaseBoot:
     kid: str
     jwk: dict[str, str]
-    approved: bool
+    approved: bool  # At-registration observation only; never an authorization gate.
     verified: bool
     image_digest: str
     attestation_kind: str
@@ -425,26 +426,82 @@ def verify_boot_auth(
     exact_body_bytes: bytes,
     signed_lookup_hash: str | None,
     resolved_lookup_hash: str,
+    accepted_image_digests: Collection[str],
 ) -> bool:
-    """Verify a boot signature; every failure is a lease-less verdict."""
+    """Verify a boot against the current trust config and its signed request."""
+    return (
+        _boot_auth_failure_reason(
+            boot=boot,
+            auth=auth,
+            method=method,
+            path=path,
+            exact_body_bytes=exact_body_bytes,
+            signed_lookup_hash=signed_lookup_hash,
+            resolved_lookup_hash=resolved_lookup_hash,
+            accepted_image_digests=accepted_image_digests,
+        )
+        is None
+    )
+
+
+def boot_auth_fails_only_on_digest_approval(
+    *,
+    boot: SpendLeaseBoot | None,
+    auth: BootAuthHeader,
+    method: str,
+    path: str,
+    exact_body_bytes: bytes,
+    signed_lookup_hash: str | None,
+    resolved_lookup_hash: str,
+    accepted_image_digests: Collection[str],
+) -> bool:
+    """Return whether every boot-auth gate except current digest approval passed."""
+    return (
+        _boot_auth_failure_reason(
+            boot=boot,
+            auth=auth,
+            method=method,
+            path=path,
+            exact_body_bytes=exact_body_bytes,
+            signed_lookup_hash=signed_lookup_hash,
+            resolved_lookup_hash=resolved_lookup_hash,
+            accepted_image_digests=accepted_image_digests,
+        )
+        == "boot_digest_not_accepted"
+    )
+
+
+def _boot_auth_failure_reason(
+    *,
+    boot: SpendLeaseBoot | None,
+    auth: BootAuthHeader,
+    method: str,
+    path: str,
+    exact_body_bytes: bytes,
+    signed_lookup_hash: str | None,
+    resolved_lookup_hash: str,
+    accepted_image_digests: Collection[str],
+) -> Literal["boot_auth_invalid", "boot_digest_not_accepted"] | None:
     try:
-        if boot is None or not boot.approved or not boot.verified:
-            return False
+        if boot is None or not boot.verified:
+            return "boot_auth_invalid"
         if auth.kid != boot.kid:
-            return False
+            return "boot_auth_invalid"
         if signed_lookup_hash != resolved_lookup_hash:
-            return False
+            return "boot_auth_invalid"
         signature = b64url_decode(auth.signature)
         public_bytes = b64url_decode(normalize_receipt_jwk(boot.jwk)["x"])
         Ed25519PublicKey.from_public_bytes(public_bytes).verify(
             signature,
             boot_auth_digest(method, path, exact_body_bytes),
         )
-        return True
+        if boot.image_digest not in accepted_image_digests:
+            return "boot_digest_not_accepted"
+        return None
     except (TypeError, ValueError):
-        return False
+        return "boot_auth_invalid"
     except Exception:
-        return False
+        return "boot_auth_invalid"
 
 
 class SpendLeaseSigner:

--- a/tests/test_spend_lease_gateway.py
+++ b/tests/test_spend_lease_gateway.py
@@ -227,6 +227,68 @@ def _signed_authorize_body(
     return body, raw_body, header
 
 
+def test_authorize_mutation_guard_uses_current_digest_not_persisted_approval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    STORE.reset()
+    user = STORE.ensure_user("spend-lease-current-approval@example.com")
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+    STORE.credit_workspace_once(workspace.id, 20_000_000, "seed")
+    _raw, key = STORE.create_api_key(
+        workspace_id=workspace.id,
+        name="spend lease current approval",
+        creator_user_id=user.id,
+    )
+    old_digest = "sha256:" + "11" * 32
+    boot_digest = "sha256:" + "22" * 32
+    private = Ed25519PrivateKey.generate()
+    jwk = _jwk(private)
+    monkeypatch.setattr(gateway, "attestation_commits_to_jwk", lambda *_args: True)
+    monkeypatch.setattr(gateway, "verify_gcp_attestation_chain", lambda _att: None)
+    monkeypatch.setattr(gateway, "gcp_attestation_image_digest", lambda _att: boot_digest)
+
+    gateway._register_spend_lease_boot_sync(  # noqa: SLF001
+        _request("/v1/internal/gateway/spend-lease/register-boot"),
+        SpendLeaseBootRegistrationRequest(
+            kid=receipt_kid(jwk),
+            receipt_public_key=jwk,
+            attestation_evidence="signed-gcp-evidence",
+            attestation_kind="gcp",
+        ),
+        _registration_settings(old_digest),
+    )
+    boot = STORE.get_spend_lease_boot(receipt_kid(jwk))
+    assert boot is not None
+    assert boot.verified is True
+    assert boot.approved is False
+
+    monkeypatch.setattr(
+        gateway,
+        "_spend_lease_signer",
+        lambda _settings: SpendLeaseSigner(lambda: bytes(range(32))),
+    )
+    body_dict, raw_body, header = _signed_authorize_body(key, private, boot)
+    current_settings = Settings(
+        environment="test",
+        spend_lease_issuance_enabled=True,
+        operational_analytics_outbox_enabled=True,
+        spend_lease_pilot_workspace_ids=workspace.id,
+        spend_lease_signing_secret_name="test-secret-name",  # noqa: S106
+        trust_gcp_image_digest=boot_digest,
+    )
+
+    authorized = gateway._authorize_gateway_sync(  # noqa: SLF001
+        _request(boot_auth_header=header),
+        GatewayAuthorizeRequest(**body_dict),
+        current_settings,
+        raw_body,
+    )
+
+    assert "spend_lease" in authorized["data"]
+    assert STORE.get_spend_lease_boot(boot.kid) is boot
+    assert boot.approved is False
+
+
 def test_authorize_mints_shadow_grant_and_replay_returns_byte_identical_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -241,6 +303,7 @@ def test_authorize_mints_shadow_grant_and_replay_returns_byte_identical_token(
         operational_analytics_outbox_enabled=True,
         spend_lease_pilot_workspace_ids=workspace.id,
         spend_lease_signing_secret_name="test-secret-name",  # noqa: S106
+        spend_lease_accepted_gcp_image_digests=boot.image_digest,
     )
     first = gateway._authorize_gateway_sync(  # noqa: SLF001
         _request(boot_auth_header=header), body, settings, raw_body
@@ -275,6 +338,7 @@ def test_authorize_retains_one_active_grant_until_exhaustion_then_increases_gen(
         operational_analytics_outbox_enabled=True,
         spend_lease_pilot_workspace_ids=workspace.id,
         spend_lease_signing_secret_name="test-secret-name",  # noqa: S106
+        spend_lease_accepted_gcp_image_digests=boot.image_digest,
     )
 
     first_dict, first_raw, first_header = _signed_authorize_body(
@@ -344,6 +408,7 @@ def test_authorize_shadow_records_reason_without_lease_and_null_when_minted(
         operational_analytics_outbox_enabled=True,
         spend_lease_pilot_workspace_ids=workspace.id,
         spend_lease_signing_secret_name="test-secret-name",  # noqa: S106
+        spend_lease_accepted_gcp_image_digests=boot.image_digest,
     )
     rejected_dict, rejected_raw, rejected_header = _signed_authorize_body(
         key,
@@ -377,6 +442,36 @@ def test_authorize_shadow_records_reason_without_lease_and_null_when_minted(
     minted_event = STORE.spend_lease_shadow_events[minted["data"]["authorization_id"]]
     assert rejected_event["no_lease_reason"] == "route_type"
     assert minted_event["no_lease_reason"] is None
+
+
+def test_authorize_shadow_names_current_boot_digest_approval_failure() -> None:
+    workspace, key, private, boot = _seed_authorize()
+    body_dict, raw_body, header = _signed_authorize_body(
+        key,
+        private,
+        boot,
+        idempotency_key="shadow-boot-digest-not-accepted",
+    )
+    settings = Settings(
+        environment="test",
+        spend_lease_issuance_enabled=True,
+        operational_analytics_outbox_enabled=True,
+        spend_lease_pilot_workspace_ids=workspace.id,
+        spend_lease_signing_secret_name="test-secret-name",  # noqa: S106
+        spend_lease_accepted_gcp_image_digests="sha256:" + "22" * 32,
+    )
+
+    response = gateway._authorize_gateway_sync(  # noqa: SLF001
+        _request(boot_auth_header=header),
+        GatewayAuthorizeRequest(**body_dict),
+        settings,
+        raw_body,
+    )
+
+    assert "spend_lease" not in response["data"]
+    event = STORE.spend_lease_shadow_events[response["data"]["authorization_id"]]
+    assert event["boot_verified"] is False
+    assert event["no_lease_reason"] == "boot_digest_not_accepted"
 
 
 def test_authorize_shadow_events_include_accept_and_decline_and_keep_echo_invalid() -> None:

--- a/tests/test_spend_leases.py
+++ b/tests/test_spend_leases.py
@@ -322,6 +322,7 @@ def test_boot_auth_verifies_exact_body_bytes_and_resolved_lookup_hash() -> None:
         exact_body_bytes=raw_body,
         signed_lookup_hash="lookup",
         resolved_lookup_hash="lookup",
+        accepted_image_digests={boot.image_digest},
     )
     assert not verify_boot_auth(
         boot=boot,
@@ -331,6 +332,7 @@ def test_boot_auth_verifies_exact_body_bytes_and_resolved_lookup_hash() -> None:
         exact_body_bytes=raw_body,
         signed_lookup_hash="lookup",
         resolved_lookup_hash="different",
+        accepted_image_digests={boot.image_digest},
     )
 
 
@@ -360,6 +362,36 @@ def test_boot_auth_rejects_one_byte_tamper_inside_received_echo_body() -> None:
         exact_body_bytes=bytes(mutated),
         signed_lookup_hash="lookup",
         resolved_lookup_hash="lookup",
+        accepted_image_digests={boot.image_digest},
+    )
+
+
+def test_boot_auth_refuses_unknown_digest_even_if_persisted_approved() -> None:
+    _private, boot, raw_body, auth = _boot_auth_fixture()
+    assert boot.approved is True
+    assert not verify_boot_auth(
+        boot=boot,
+        auth=auth,
+        method="POST",
+        path="/v1/internal/gateway/authorize",
+        exact_body_bytes=raw_body,
+        signed_lookup_hash="lookup",
+        resolved_lookup_hash="lookup",
+        accepted_image_digests={"sha256:" + "22" * 32},
+    )
+
+
+def test_boot_auth_empty_current_accepted_set_refuses_every_digest() -> None:
+    _private, boot, raw_body, auth = _boot_auth_fixture()
+    assert not verify_boot_auth(
+        boot=boot,
+        auth=auth,
+        method="POST",
+        path="/v1/internal/gateway/authorize",
+        exact_body_bytes=raw_body,
+        signed_lookup_hash="lookup",
+        resolved_lookup_hash="lookup",
+        accepted_image_digests=frozenset(),
     )
 
 


### PR DESCRIPTION
**The last blocker on the Stage A soak, and it is a deploy-ordering race rather than a logic bug.** Every serving enclave boot carries `verified=true, approved=false`, so `verify_boot_auth` refuses every request and no lease can mint — even though each boot's attested digest is exactly the control plane's current `TR_TRUST_GCP_IMAGE_DIGEST`. Approval was decided once at registration, against the digest the control plane happened to hold at that moment; the two services deploy independently, so boots registering just after an enclave release freeze a stale `false` and are never re-evaluated.

Approval now resolves against the **current** accepted set at use time. Registration keeps its real job (verify the attestation chain, record the digest). A control-plane deploy that learns a new digest immediately approves boots already running it. Fail-closed is preserved — an empty accepted set approves nothing — and approval failures now report a distinct `no_lease_reason` instead of NULL, which tonight disguised an approval failure as an eligible request.

Gate: 53 focused tests, route inventory 519, ruff/mypy clean, mutation verified (reading the persisted flag fails the named guard). No other authorization consumer of the persisted flag exists. Needs admin merge.

Authored by Sol (codex-cli); reviewed by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)