### PR TITLE
Continuous soak probe for the Stage A spend-lease cohort (default off)

### DIFF
--- a/scripts/deploy/synthetic.sh
+++ b/scripts/deploy/synthetic.sh
@@ -416,6 +416,54 @@ for legacy_throughput_scheduler_name in "${legacy_throughput_scheduler_names[@]}
   fi
 done
 
+# Stage A spend-lease soak: one tiny Credits chat completion every minute.
+# This is isolated from the regional health jobs so its cadence does not
+# multiply their paid model checks. The worker exits before secret access while
+# disabled; its API key is fetched by NAME from Secret Manager at run time.
+spend_lease_region="us-central1"
+spend_lease_ingest_base="$(synthetic_ingest_base_for_region "$spend_lease_region")"
+spend_lease_job_name="trusted-router-spend-lease-soak-${spend_lease_region}"
+spend_lease_scheduler_name="${spend_lease_job_name}-every-minute"
+spend_lease_probe_enabled="${TR_SPEND_LEASE_SOAK_PROBE_ENABLED:-false}"
+spend_lease_probe_key_secret="${TR_SPEND_LEASE_PROBE_KEY_SECRET:-trustedrouter-spend-lease-probe-key}"
+if [ "$spend_lease_probe_enabled" = "true" ]; then
+  if ! gc secrets describe "$spend_lease_probe_key_secret" >/dev/null 2>&1; then
+    echo "ERROR: spend-lease soak key secret ${spend_lease_probe_key_secret} is required" >&2
+    exit 1
+  fi
+fi
+spend_lease_env_vars=(
+  "${BASE_ENV_VARS[@]}"
+  "TR_SYNTHETIC_MONITOR_REGION=${spend_lease_region}"
+  "TR_SYNTHETIC_INGEST_URL=${spend_lease_ingest_base}/v1/internal/synthetic/samples"
+  "TR_SPEND_LEASE_SOAK_PROBE_ENABLED=${spend_lease_probe_enabled}"
+  "TR_SPEND_LEASE_PROBE_KEY_SECRET=${spend_lease_probe_key_secret}"
+)
+spend_lease_set_env_vars="$(IFS='|'; echo "^|^${spend_lease_env_vars[*]}")"
+
+prepare_synthetic_ingest_target "$spend_lease_region"
+log "deploying isolated spend-lease soak Cloud Run job ${spend_lease_job_name}"
+gc run jobs deploy "$spend_lease_job_name" \
+  --region "$spend_lease_region" \
+  --image "$IMAGE" \
+  --command="/app/.venv/bin/python" \
+  --args="-m,trusted_router.synthetic.spend_lease_soak" \
+  --service-account "$RUN_SERVICE_ACCOUNT" \
+  "${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]+"${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]}"}" \
+  --set-env-vars "$spend_lease_set_env_vars" \
+  "$JOB_SECRET_FLAG" "$JOB_SECRETS" \
+  --max-retries 0 \
+  --task-timeout 60s \
+  --cpu 1 \
+  --memory 512Mi \
+  --quiet >/dev/null
+
+upsert_scheduler \
+  "$spend_lease_scheduler_name" \
+  "$spend_lease_job_name" \
+  "$spend_lease_region" \
+  "* * * * *"
+
 # Image generation is materially more expensive than text PONG probes. Keep it
 # isolated and run one canonical end-to-end request every six hours.
 image_region="us-central1"

--- a/scripts/deploy/synthetic_image_refresh.sh
+++ b/scripts/deploy/synthetic_image_refresh.sh
@@ -39,6 +39,7 @@ jobs=(
   "us-central1:trusted-router-synthetic-us-central1:health"
   "europe-west4:trusted-router-synthetic-europe-west4:health"
   "us-central1:trusted-router-throughput-us-central1:worker"
+  "us-central1:trusted-router-spend-lease-soak-us-central1:worker"
   "us-central1:trusted-router-image-generation-us-central1:worker"
   "us-central1:trusted-router-video-generation-us-central1:worker"
 )

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -859,6 +859,13 @@ class Settings(BaseSettings):
     spend_lease_skew_seconds: int = 10
     spend_lease_max_microdollars: int = 1_000_000
     spend_lease_max_available_basis_points: int = 1_000
+    # Dedicated Stage A traffic. The key belongs to a Credits-only pilot
+    # workspace and is loaded lazily from Secret Manager by the isolated
+    # once-a-minute synthetic job; it is never placed in an environment
+    # variable. Default-off keeps deploying this code behavior-neutral until
+    # an operator deliberately starts the soak.
+    spend_lease_soak_probe_enabled: bool = False
+    spend_lease_probe_key_secret: str = "trustedrouter-spend-lease-probe-key"  # noqa: S105
     # Operational read-only flag. When set, write paths (credit
     # reservations, gateway authorize, signup, etc.) return 503 with
     # `Retry-After`; reads keep working. Used for the Spanner →
@@ -1345,6 +1352,11 @@ class Settings(BaseSettings):
                     "TR_SPEND_LEASE_ISSUANCE_ENABLED requires the operational "
                     "analytics outbox or direct sink"
                 )
+        if self.spend_lease_soak_probe_enabled and not self.spend_lease_probe_key_secret.strip():
+            raise ValueError(
+                "TR_SPEND_LEASE_SOAK_PROBE_ENABLED requires "
+                "TR_SPEND_LEASE_PROBE_KEY_SECRET"
+            )
         if self.regional_quota_leases_enabled:
             if environment not in {"local", "test"}:
                 if self.storage_backend not in {

--- a/src/trusted_router/storage_gcp_secrets.py
+++ b/src/trusted_router/storage_gcp_secrets.py
@@ -1,4 +1,4 @@
-"""GCP Secret Manager adapter for lazily loaded signing material."""
+"""GCP Secret Manager adapters for lazily loaded runtime material."""
 
 from __future__ import annotations
 
@@ -8,8 +8,10 @@ from collections.abc import Callable
 from trusted_router.spend_leases import decode_secret_seed
 
 
-def secret_manager_seed_loader(*, project_id: str, secret_name: str) -> Callable[[], bytes]:
-    """Build a lazy loader; constructing it imports no Google SDK module."""
+def _secret_manager_payload_loader(
+    *, project_id: str, secret_name: str
+) -> Callable[[], bytes]:
+    """Build a lazy raw-payload loader without importing a Google SDK module."""
 
     def load() -> bytes:
         import google.auth
@@ -34,6 +36,35 @@ def secret_manager_seed_loader(*, project_id: str, secret_name: str) -> Callable
         encoded = response.json().get("payload", {}).get("data")
         if not isinstance(encoded, str):
             raise ValueError("Secret Manager response omitted payload.data")
-        return decode_secret_seed(base64.b64decode(encoded, validate=True))
+        return base64.b64decode(encoded, validate=True)
+
+    return load
+
+
+def secret_manager_seed_loader(*, project_id: str, secret_name: str) -> Callable[[], bytes]:
+    """Build the existing lazy spend-lease signing-seed loader."""
+    payload_loader = _secret_manager_payload_loader(
+        project_id=project_id,
+        secret_name=secret_name,
+    )
+
+    def load() -> bytes:
+        return decode_secret_seed(payload_loader())
+
+    return load
+
+
+def secret_manager_text_loader(*, project_id: str, secret_name: str) -> Callable[[], str]:
+    """Build a lazy UTF-8 secret loader for synthetic credentials."""
+    payload_loader = _secret_manager_payload_loader(
+        project_id=project_id,
+        secret_name=secret_name,
+    )
+
+    def load() -> str:
+        value = payload_loader().decode("utf-8").strip()
+        if not value:
+            raise ValueError("Secret Manager secret is empty")
+        return value
 
     return load

--- a/src/trusted_router/synthetic/components.py
+++ b/src/trusted_router/synthetic/components.py
@@ -35,14 +35,20 @@ MONITOR_CONFIGURATION_ERROR_TYPES = frozenset(
         "monitor_workspace_paused",
     }
 )
-# Liveness/ops probe types (synthetic/fleet.py): scheduler heartbeats and
-# cross-cloud peer policing. They ride the synthetic-sample pipeline for
-# storage and streak alerts but are NOT evidence about this deployment's
-# service, so they must stay out of every component, every SLO, and — most
-# importantly — the monitor-freshness clock: a heartbeat from a loop that is
-# not the probe fleet must never make a dead probe fleet look fresh.
+# Liveness/ops and internal-soak probe types. They ride the synthetic-sample
+# pipeline for storage and streak alerts but are NOT evidence for a published
+# service component, so they must stay out of every component, every SLO, and
+# — most importantly — the monitor-freshness clock. The spend-lease soak has
+# its own scheduler; letting it refresh that clock would mask a dead main probe
+# fleet for the full 14-day soak.
 OPS_PROBE_TYPES = frozenset(
-    {"client_telemetry_ingest", "heartbeat", "peer_monitor", "remediation"}
+    {
+        "client_telemetry_ingest",
+        "heartbeat",
+        "peer_monitor",
+        "remediation",
+        "spend_lease_soak",
+    }
 )
 # Deep end-to-end model calls: a real OpenAI-SDK chat completion and a real
 # Responses round-trip, output-verified. These probes previously fed NO

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -49,6 +49,9 @@ VIDEO_GENERATION_MODEL = "x-ai/grok-imagine-video"
 VIDEO_GENERATION_PROVIDER = "grok"
 VIDEO_GENERATION_DURATION_SECONDS = 1
 VIDEO_GENERATION_RESOLUTION = "480p"
+SPEND_LEASE_SOAK_MODEL = "anthropic/claude-haiku-4.5"
+SPEND_LEASE_SOAK_ROUTE_TYPE = "chat.completions"
+SPEND_LEASE_SOAK_PROMPT = "Reply OK."
 # Reverted from "Respond with only the word PONG." back to
 # "reply exactly PONG" — the original phrasing worked at
 # 99.97% uptime for ~24h on the same monitor pool, then the
@@ -1189,6 +1192,67 @@ async def openai_chat_pong_probe(
         model=model,
         output_match=ok,
     )
+
+
+async def spend_lease_soak_probe(
+    client: httpx.AsyncClient,
+    target: SyntheticTarget,
+    *,
+    monitor_region: str,
+    api_key: str,
+) -> SyntheticProbeSample:
+    """Exercise exactly the Credits-only Stage A spend-lease cohort."""
+    url = _api_url(
+        target.api_base_url,
+        f"/{SPEND_LEASE_SOAK_ROUTE_TYPE.replace('.', '/')}",
+    )
+    body = {
+        # A plain catalog model: no custom/user/partner model and no provider
+        # override that could introduce a non-Credits fallback.
+        "model": SPEND_LEASE_SOAK_MODEL,
+        "messages": [{"role": "user", "content": SPEND_LEASE_SOAK_PROMPT}],
+        "max_tokens": 8,
+        # This marks analytics synthetic; it is not OAuth app attribution and
+        # does not create app markup.
+        "metadata": {
+            "trustedrouter_synthetic": "true",
+            "probe": "spend_lease_soak",
+        },
+    }
+    started = time.perf_counter()
+    try:
+        response = await client.post(url, json=body, headers=_auth_headers(api_key))
+        latency_ms = _elapsed_ms(started)
+        payload = _json_object(response)
+        metadata = _completion_metadata(payload)
+        ok = response.status_code == 200
+        return _sample(
+            "spend_lease_soak",
+            target,
+            monitor_region,
+            url,
+            status="up" if ok else "down",
+            latency_milliseconds=latency_ms,
+            ttfb_milliseconds=latency_ms,
+            http_status=response.status_code,
+            error_type=None if ok else "spend_lease_soak_http_error",
+            model=SPEND_LEASE_SOAK_MODEL,
+            selected_provider=metadata["selected_provider"],
+            selected_model=metadata["selected_model"],
+            generation_id=metadata["generation_id"],
+            cost_microdollars=metadata["cost_microdollars"],
+        )
+    except httpx.HTTPError as exc:
+        return _sample(
+            "spend_lease_soak",
+            target,
+            monitor_region,
+            url,
+            status="down",
+            latency_milliseconds=_elapsed_ms(started),
+            error_type=exc.__class__.__name__,
+            model=SPEND_LEASE_SOAK_MODEL,
+        )
 
 
 async def responses_pong_probe(

--- a/src/trusted_router/synthetic/spend_lease_soak.py
+++ b/src/trusted_router/synthetic/spend_lease_soak.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+
+import httpx
+
+from trusted_router.config import get_settings
+from trusted_router.storage_gcp_secrets import secret_manager_text_loader
+from trusted_router.synthetic.internal_auth import synthetic_observer_token
+from trusted_router.synthetic.probes import SyntheticTarget, spend_lease_soak_probe
+
+
+async def run() -> int:
+    settings = get_settings()
+    if not settings.spend_lease_soak_probe_enabled:
+        print('{"enabled":false,"probe_type":"spend_lease_soak"}')
+        return 0
+
+    internal_token = synthetic_observer_token(settings)
+    if not internal_token:
+        print("TR_OBSERVER_INTERNAL_TOKEN is required", file=sys.stderr)
+        return 2
+
+    api_key_loader = secret_manager_text_loader(
+        project_id=settings.gcp_project_id,
+        secret_name=settings.spend_lease_probe_key_secret,
+    )
+    api_key = await asyncio.to_thread(api_key_loader)
+    monitor_region = os.environ.get("TR_SYNTHETIC_MONITOR_REGION", "us-central1")
+    control_plane = os.environ.get(
+        "TR_SYNTHETIC_CONTROL_PLANE_URL",
+        "https://trustedrouter.com",
+    )
+    ingest_url = os.environ.get(
+        "TR_SYNTHETIC_INGEST_URL",
+        f"{control_plane.rstrip('/')}/v1/internal/synthetic/samples",
+    )
+    target = SyntheticTarget("canonical", settings.api_base_url, settings.primary_region)
+
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(settings.synthetic_monitor_timeout_seconds)
+    ) as client:
+        sample = await spend_lease_soak_probe(
+            client,
+            target,
+            monitor_region=monitor_region,
+            api_key=api_key,
+        )
+        response = await client.post(
+            ingest_url,
+            headers={"x-trustedrouter-internal-token": internal_token},
+            json={"samples": [sample.public_dict()]},
+        )
+
+    print(
+        json.dumps(
+            {
+                "probe_type": sample.probe_type,
+                "status": sample.status,
+                "http_status": sample.http_status,
+                "error_type": sample.error_type,
+                "model": sample.model,
+                "provider": sample.selected_provider,
+                "generation_id": sample.generation_id,
+                "cost_microdollars": sample.cost_microdollars,
+                "ingest_status": response.status_code,
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    )
+    return 0 if sample.status == "up" and response.status_code == 200 else 1
+
+
+def main() -> int:
+    return asyncio.run(run())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ddos_edge_deploy.py
+++ b/tests/test_ddos_edge_deploy.py
@@ -729,11 +729,11 @@ def test_every_synthetic_job_uses_the_ingress_appropriate_ingest_base() -> None:
     ) in deploy
     assert 'SYNTHETIC_INGEST_SERVICE="$SERVICE"' in deploy
     assert "TR_SYNTHETIC_INGEST_SERVICE" not in deploy
-    assert deploy.count("$(synthetic_ingest_base_for_region") == 4
+    assert deploy.count("$(synthetic_ingest_base_for_region") == 5
     assert 'printf \'%s\\n\' "https://trustedrouter.com"' in deploy
     assert "printf 'https://%s-%s.%s.run.app\\n'" in deploy
-    assert deploy.count("gc run jobs deploy") == 4
-    assert deploy.count('"$JOB_SECRET_FLAG" "$JOB_SECRETS"') == 4
+    assert deploy.count("gc run jobs deploy") == 5
+    assert deploy.count('"$JOB_SECRET_FLAG" "$JOB_SECRETS"') == 5
     assert 'JOB_SECRET_FLAG="--set-secrets"' in deploy
     assert 'JOB_SECRET_FLAG="--update-secrets"' in deploy
     assert deploy.count("ensure_private_run_app_access") == 1
@@ -742,7 +742,7 @@ def test_every_synthetic_job_uses_the_ingress_appropriate_ingest_base() -> None:
         '"${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]+'
         '"${PRIVATE_RUN_APP_JOB_NETWORK_ARGS[@]}"}"'
     )
-    assert deploy.count(guarded_network_args) == 4
+    assert deploy.count(guarded_network_args) == 5
 
 
 def test_secret_bootstrap_provisions_a_distinct_observer_credential() -> None:

--- a/tests/test_deploy_script_execution.py
+++ b/tests/test_deploy_script_execution.py
@@ -1801,7 +1801,7 @@ def test_synthetic_jobs_execute_private_ingress_preflight_in_their_own_region(
         if call[:4] == ["gcloud", "--project", "quill-cloud-proxy", "run"]
         and call[4:6] == ["jobs", "deploy"]
     ]
-    assert len(deploys) == 5
+    assert len(deploys) == 6
     subnet_updates = [
         (index, call)
         for index, call in enumerate(run.calls)
@@ -1816,7 +1816,7 @@ def test_synthetic_jobs_execute_private_ingress_preflight_in_their_own_region(
             "update",
         ]
     ]
-    assert len(subnet_updates) == 5
+    assert len(subnet_updates) == 6
     service_contract_reads = [
         (index, call)
         for index, call in enumerate(run.calls)
@@ -1831,7 +1831,7 @@ def test_synthetic_jobs_execute_private_ingress_preflight_in_their_own_region(
         ]
         and call[6] == "trusted-router-billing"
     ]
-    assert len(service_contract_reads) == 5
+    assert len(service_contract_reads) == 6
     previous_deploy_index = -1
     for deploy_index, deploy in deploys:
         region = deploy[deploy.index("--region") + 1]
@@ -1934,6 +1934,7 @@ def test_combined_synthetic_refresh_preserves_security_boundaries(tmp_path: Path
         ("trusted-router-synthetic-us-central1", "us-central1"),
         ("trusted-router-synthetic-europe-west4", "europe-west4"),
         ("trusted-router-throughput-us-central1", "us-central1"),
+        ("trusted-router-spend-lease-soak-us-central1", "us-central1"),
         ("trusted-router-image-generation-us-central1", "us-central1"),
         ("trusted-router-video-generation-us-central1", "us-central1"),
     ]
@@ -2002,6 +2003,7 @@ def test_synthetic_combined_bridge_restores_legacy_job_deploys(
         ("trusted-router-synthetic-us-central1", "us-central1"),
         ("trusted-router-synthetic-europe-west4", "europe-west4"),
         ("trusted-router-throughput-us-central1", "us-central1"),
+        ("trusted-router-spend-lease-soak-us-central1", "us-central1"),
         ("trusted-router-image-generation-us-central1", "us-central1"),
         ("trusted-router-video-generation-us-central1", "us-central1"),
     ]
@@ -2083,7 +2085,7 @@ def test_synthetic_combined_bridge_job_environment_constructs_settings(
         if call[:4] == ["gcloud", "--project", "quill-cloud-proxy", "run"]
         and call[4:6] == ["jobs", "deploy"]
     ]
-    assert len(deploys) == 5
+    assert len(deploys) == 6
     for deploy in deploys:
         settings_kwargs = _settings_kwargs_from_cloud_run_job(deploy)
         settings = Settings(**settings_kwargs)

--- a/tests/test_spend_lease_soak_probe.py
+++ b/tests/test_spend_lease_soak_probe.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from trusted_router.config import Settings
+from trusted_router.synthetic.components import OPS_PROBE_TYPES
+from trusted_router.synthetic.probes import (
+    SPEND_LEASE_SOAK_MODEL,
+    SPEND_LEASE_SOAK_ROUTE_TYPE,
+    SyntheticTarget,
+    spend_lease_soak_probe,
+)
+
+
+def test_spend_lease_soak_probe_flag_defaults_false_mutation_guard() -> None:
+    """Mutation guard: changing the Settings default to True must fail this test."""
+    assert Settings(environment="test").spend_lease_soak_probe_enabled is False
+
+
+def test_spend_lease_soak_probe_secret_name_is_configurable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    defaults = Settings(environment="test")
+    assert (
+        defaults.spend_lease_probe_key_secret
+        == "trustedrouter-spend-lease-probe-key"  # noqa: S105 - resource name.
+    )
+
+    monkeypatch.setenv("TR_SPEND_LEASE_PROBE_KEY_SECRET", "custom-soak-key")
+    assert (
+        Settings(environment="test").spend_lease_probe_key_secret
+        == "custom-soak-key"  # noqa: S105 - resource name.
+    )
+
+
+@pytest.mark.asyncio
+async def test_spend_lease_soak_request_stays_inside_stage_a_cohort() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-soak",
+                "model": SPEND_LEASE_SOAK_MODEL,
+                "choices": [{"message": {"content": "OK"}}],
+                "usage": {"cost_microdollars": 53},
+            },
+        )
+
+    target = SyntheticTarget(
+        "canonical",
+        "https://api.trustedrouter.com/v1",
+        "us-central1",
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sample = await spend_lease_soak_probe(
+            client,
+            target,
+            monitor_region="us-central1",
+            api_key="sk-tr-soak-test",
+        )
+
+    assert sample.status == "up"
+    assert sample.probe_type == "spend_lease_soak"
+    assert sample.cost_microdollars == 53
+    assert SPEND_LEASE_SOAK_ROUTE_TYPE == "chat.completions"
+    assert len(requests) == 1
+    request = requests[0]
+    assert request.url.path == "/v1/chat/completions"
+    assert request.headers["authorization"] == "Bearer sk-tr-soak-test"
+    body = json.loads(request.content)
+    assert body == {
+        "model": "anthropic/claude-haiku-4.5",
+        "messages": [{"role": "user", "content": "Reply OK."}],
+        "max_tokens": 8,
+        "metadata": {
+            "trustedrouter_synthetic": "true",
+            "probe": "spend_lease_soak",
+        },
+    }
+    # These are the Stage A disqualifiers a public request could introduce.
+    # Route type comes solely from the chat.completions path asserted above.
+    assert {
+        "app",
+        "app_id",
+        "app_markup_basis_points",
+        "additional_cost_microdollars",
+        "additional_cost_reservation_microdollars",
+        "native_batch",
+        "provider",
+        "route_type",
+    }.isdisjoint(body)
+
+
+@pytest.mark.asyncio
+async def test_spend_lease_soak_job_loads_named_key_and_ingests_sample(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trusted_router.synthetic import spend_lease_soak as soak_job
+
+    seen_secret: list[tuple[str, str]] = []
+    seen_paths: list[str] = []
+    ingested: list[dict[str, Any]] = []
+
+    def fake_loader(*, project_id: str, secret_name: str) -> Any:
+        seen_secret.append((project_id, secret_name))
+        return lambda: "sk-tr-dedicated-soak"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_paths.append(request.url.path)
+        if request.url.path == "/v1/chat/completions":
+            assert request.headers["authorization"] == "Bearer sk-tr-dedicated-soak"
+            return httpx.Response(
+                200,
+                json={
+                    "id": "chatcmpl-soak-job",
+                    "choices": [{"message": {"content": "OK"}}],
+                    "usage": {"cost_microdollars": 53},
+                },
+            )
+        if request.url.path == "/v1/internal/synthetic/samples":
+            assert request.headers["x-trustedrouter-internal-token"] == "observer-test"
+            ingested.append(json.loads(request.content))
+            return httpx.Response(200, json={"data": {"recorded": 1}})
+        return httpx.Response(404)
+
+    settings = Settings(
+        environment="test",
+        api_base_url="https://api.trustedrouter.com/v1",
+        gcp_project_id="probe-project",
+        observer_internal_token="observer-test",  # noqa: S106 - test placeholder.
+        spend_lease_soak_probe_enabled=True,
+        spend_lease_probe_key_secret="custom-soak-key",  # noqa: S106 - secret name.
+    )
+    real_async_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+
+    def client_factory(**kwargs: Any) -> httpx.AsyncClient:
+        return real_async_client(transport=transport, **kwargs)
+
+    monkeypatch.setattr(soak_job, "get_settings", lambda: settings)
+    monkeypatch.setattr(soak_job, "secret_manager_text_loader", fake_loader)
+    monkeypatch.setattr(soak_job.httpx, "AsyncClient", client_factory)
+    monkeypatch.setenv(
+        "TR_SYNTHETIC_INGEST_URL",
+        "https://trustedrouter.com/v1/internal/synthetic/samples",
+    )
+
+    result = await soak_job.run()
+
+    assert result == 0
+    assert seen_secret == [("probe-project", "custom-soak-key")]
+    assert seen_paths == ["/v1/chat/completions", "/v1/internal/synthetic/samples"]
+    assert ingested[0]["samples"][0]["probe_type"] == "spend_lease_soak"
+
+
+def test_spend_lease_soak_probe_is_registered_on_one_minute_schedule() -> None:
+    script = Path(__file__).resolve().parents[1] / "scripts/deploy/synthetic.sh"
+    body = script.read_text()
+    section = body.split("Stage A spend-lease soak", maxsplit=1)[1].split(
+        "# Image generation",
+        maxsplit=1,
+    )[0]
+
+    assert 'spend_lease_scheduler_name="${spend_lease_job_name}-every-minute"' in section
+    assert '--args="-m,trusted_router.synthetic.spend_lease_soak"' in section
+    assert "spend_lease_soak" in OPS_PROBE_TYPES
+    assert '"TR_SPEND_LEASE_SOAK_PROBE_ENABLED=${spend_lease_probe_enabled}"' in section
+    assert '"TR_SPEND_LEASE_PROBE_KEY_SECRET=${spend_lease_probe_key_secret}"' in section
+    assert '"* * * * *"' in section
+    assert "--max-retries 0" in section


### PR DESCRIPTION
Stage A is minting leases in production — verified on the authorization records: `cap_micro=1000000` ($1.00), `gen=1`, 1,378-byte signed JWS, one lease retained across requests rather than reminted.

The pilot workspace is human-paced, so this adds continuous cohort-conformant traffic: one `chat.completions` request per minute, plain catalog model, `max_tokens: 8`, direct bearer auth on the unlimited probe key (~$0.05/day). It exercises lease retention and depletion, which bursty human traffic exercises only by luck.

Registered as an internal/ops probe with its own scheduler so it cannot mask a dead primary probe fleet's freshness — Sol's call, and the right one. Gated behind `TR_SPEND_LEASE_SOAK_PROBE_ENABLED` (default false), so merging changes nothing until enabled deliberately.

Gate: 53 focused + 204 route-inventory/security tests, ruff/mypy clean, mutation verified on the flag default. Needs admin merge.

Authored by Sol (codex-cli); reviewed by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)