### PR TITLE
Add onboarding video to Axios blog post

### DIFF
--- a/src/trusted_router/content/blog.py
+++ b/src/trusted_router/content/blog.py
@@ -63,6 +63,12 @@ BLOG_POSTS: tuple[BlogPost, ...] = (
         ),
         og_image="/static/og/blog/axios-tried-trustedrouter.png",
         body_html="""
+<div class="video-embed blog-video-embed" data-action="load-video" data-video-id="vfOj_im2A1o" data-video-title="Joseph Perla demonstrates TrustedRouter onboarding" role="button" tabindex="0" aria-label="Play: Joseph Perla demonstrates TrustedRouter onboarding (loads YouTube)">
+  <img class="video-embed-poster" src="/static/og/blog/axios-tried-trustedrouter.png" alt="Axios tried TrustedRouter in under 30 seconds" width="1200" height="630" decoding="async">
+  <span class="video-embed-shade" aria-hidden="true"></span>
+  <span class="video-embed-play" aria-hidden="true"></span>
+  <span class="video-embed-label"><strong>Watch the onboarding</strong><span>YouTube loads after you press play</span></span>
+</div>
 <figure class="blog-hero-image"><img src="/static/og/blog/axios-tried-trustedrouter.svg" alt="Axios tried DeepSeek through TrustedRouter in under 30 seconds" width="1200" height="630"></figure>
 <p>Axios tried TrustedRouter. Reporter Madison Mills opened the product, chose DeepSeek, and had it working in under 30 seconds.</p>
 

--- a/src/trusted_router/templates/public/blog_post.html
+++ b/src/trusted_router/templates/public/blog_post.html
@@ -22,6 +22,7 @@
   .blog-body p { margin: 0 0 26px; }
   .blog-body strong { color: var(--inkstrong); font-weight: 700; }
   .blog-body a { color: var(--blue); text-decoration: underline; text-underline-offset: 2px; }
+  .blog-body .blog-video-embed { margin: 0 0 32px; border-radius: var(--r-panel); }
   .blog-body .blog-hero-image { margin: 0 0 32px; }
   .blog-body .blog-hero-image img { display: block; width: 100%; height: auto;
     border: 1px solid var(--line); border-radius: var(--r-panel); }

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -1794,6 +1794,12 @@ def test_axios_blog_post_links_source_and_conversion_path(client: TestClient) ->
     assert 'href="/?reason=signin"' in response.text
     assert f'property="og:image" content="https://trustedrouter.com{image_path}"' in response.text
     assert f'name="twitter:image" content="https://trustedrouter.com{image_path}"' in response.text
+    assert 'data-video-id="vfOj_im2A1o"' in response.text
+    assert 'data-video-title="Joseph Perla demonstrates TrustedRouter onboarding"' in response.text
+    assert "youtube.com/embed/vfOj_im2A1o" not in response.text
+    assert response.text.index('data-video-id="vfOj_im2A1o"') < response.text.index(
+        f'<img src="/static/og/blog/{slug}.svg"'
+    )
     assert f'<img src="/static/og/blog/{slug}.svg"' in response.text
     assert client.get(image_path).status_code == 200
     assert client.get(f"/static/og/blog/{slug}.svg").status_code == 200


### PR DESCRIPTION
Summary:
- add Joseph's TrustedRouter onboarding video above the Axios post content
- use the existing click-to-load privacy-enhanced YouTube player
- test placement and initial-load privacy behavior

Tests:
- focused Axios SEO test passed
- Ruff passed