### PR TITLE
Bound quota reconciler Spanner startup

### DIFF
--- a/scripts/deploy/regional_quota_reconciler.sh
+++ b/scripts/deploy/regional_quota_reconciler.sh
@@ -62,6 +62,10 @@ env_vars=(
   "TR_GCP_PROJECT_ID=${PROJECT_ID}"
   "TR_SPANNER_INSTANCE_ID=${SPANNER_INSTANCE_ID}"
   "TR_SPANNER_DATABASE_ID=${SPANNER_DATABASE_ID}"
+  # This one-shot worker is strictly serial. Giving it the serving process's
+  # eight-session pool makes a cold run create seven unused Spanner sessions
+  # and can consume the entire 50-second fail-closed task budget.
+  "TR_SPANNER_POOL_SIZE=1"
   "TR_BIGTABLE_INSTANCE_ID=${BIGTABLE_INSTANCE_ID}"
   "TR_BIGTABLE_GENERATION_TABLE=${BIGTABLE_GENERATION_TABLE}"
   "TR_REQUEST_RECORD_WRITE_MODE=typed"

--- a/src/trusted_router/regional_quota_reconcile_cli.py
+++ b/src/trusted_router/regional_quota_reconcile_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import time
 import uuid
 from collections.abc import Callable
 from typing import Any, cast
@@ -18,7 +19,13 @@ _LOCK_TTL_SECONDS = 90
 
 def main() -> int:
     logging.basicConfig(level=logging.INFO)
+    started_at = time.monotonic()
+    logger.info("regional_quota.reconciler_start")
     settings = get_settings()
+    logger.info(
+        "regional_quota.reconciler_settings_loaded elapsed_ms=%.1f",
+        _elapsed_ms(started_at),
+    )
     init_sentry(settings)
     if not settings.regional_quota_reconciler_worker:
         logger.info("regional_quota.reconciler_disabled")
@@ -27,8 +34,16 @@ def main() -> int:
         logger.error("regional_quota.reconciler_ledger_disabled")
         return 1
 
+    logger.info(
+        "regional_quota.reconciler_store_open_start elapsed_ms=%.1f",
+        _elapsed_ms(started_at),
+    )
     store = create_store(settings)
     configure_store(store)
+    logger.info(
+        "regional_quota.reconciler_store_open_complete elapsed_ms=%.1f",
+        _elapsed_ms(started_at),
+    )
     acquire = cast(
         Callable[..., Any] | None,
         getattr(store, "acquire_regional_quota_reconciler_lock", None),
@@ -41,6 +56,10 @@ def main() -> int:
         logger.error("regional_quota.reconciler_lock_unsupported")
         return 1
     owner = f"rqrec-{uuid.uuid4().hex}"
+    logger.info(
+        "regional_quota.reconciler_lock_acquire_start elapsed_ms=%.1f",
+        _elapsed_ms(started_at),
+    )
     lock = acquire(owner=owner, ttl_seconds=_LOCK_TTL_SECONDS)
     if lock is None:
         logger.info("regional_quota.reconciler_lock_busy")
@@ -90,7 +109,15 @@ def main() -> int:
                 exit_code = 1
     if exit_code == 0:
         record_heartbeat("job:regional-quota-reconcile", settings=settings)
+        logger.info(
+            "regional_quota.reconciler_complete elapsed_ms=%.1f",
+            _elapsed_ms(started_at),
+        )
     return exit_code
+
+
+def _elapsed_ms(started_at: float) -> float:
+    return (time.monotonic() - started_at) * 1_000.0
 
 
 def _run_reconcile(settings: Any, store: Any) -> int:

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -259,6 +259,7 @@ def test_production_deploy_provisions_and_schedules_regional_quota_reconciliatio
     assert "trusted_router.regional_quota_reconcile_cli" in reconciler
     assert '"TR_ENVIRONMENT=worker"' in reconciler
     assert '"TR_SERVICE_SURFACE=control"' in reconciler
+    assert '"TR_SPANNER_POOL_SIZE=1"' in reconciler
     assert "--oauth-service-account-email=\"$RUN_SERVICE_ACCOUNT\"" in reconciler
     assert "--clear-headers" in reconciler
     assert "gc secrets" not in reconciler

--- a/tests/test_regional_quota_reconcile_cli.py
+++ b/tests/test_regional_quota_reconcile_cli.py
@@ -122,8 +122,14 @@ def test_worker_reconciles_with_bounded_limit(
     assert len(store.released) == 1
     assert store.released[0][1] == 7
     assert heartbeats == ["job:regional-quota-reconcile"]
+    assert "regional_quota.reconciler_start" in caplog.text
+    assert "regional_quota.reconciler_settings_loaded" in caplog.text
+    assert "regional_quota.reconciler_store_open_start" in caplog.text
+    assert "regional_quota.reconciler_store_open_complete" in caplog.text
+    assert "regional_quota.reconciler_lock_acquire_start" in caplog.text
     assert "regional_quota.reconciler_lock_acquired" in caplog.text
     assert "regional_quota.reconciler_lock_released" in caplog.text
+    assert "regional_quota.reconciler_complete" in caplog.text
 
 
 def test_worker_logs_expired_lock_takeover(


### PR DESCRIPTION
## Summary
- give the serial regional quota reconciliation job a one-session Spanner pool
- keep the existing strict 50-second task timeout
- add phase timing logs around settings, store creation, lock acquisition, and completion

## Production evidence
- no open GCP Monitoring incidents
- no customer-facing Cloud Run 5xx in the last six hours
- latest quota-worker failure reached the 50-second task timeout before its first app log
- successful workers perform the actual reconcile in under one second

## Tests
- `pytest -q tests/test_regional_quota_reconcile_cli.py tests/test_deploy_secret_wiring.py`
- `pytest -q tests/test_deploy_script_execution.py -k regional_quota_reconciler`
- `ruff check ...`
- `bash -n scripts/deploy/regional_quota_reconciler.sh`
- `git diff --check`