### PR TITLE
Do not return 503 after committed settlement

### DIFF
--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -2945,13 +2945,26 @@ def _settle_gateway_authorization(
         # caller-supplied root field become forgeable broadcast metadata.
         broadcast_settle_body.pop("app_id", None)
         broadcast_settle_body.pop("price_tier_input_tokens", None)
-        enqueue_metadata_broadcast(generation, settle_body=broadcast_settle_body)
-        if should_drain_inline(settings) and background_tasks is not None:
+        try:
+            enqueue_metadata_broadcast(generation, settle_body=broadcast_settle_body)
+            broadcast_enqueued = True
+        except Exception:
+            # Billing is already committed. Metadata observability is
+            # best-effort and must never rewrite a successful settlement as a
+            # retryable 5xx, which could make the enclave replay billed work.
+            logger.error(
+                "broadcast_metadata_enqueue_failed generation_id=%s workspace_id=%s",
+                generation.id,
+                generation.workspace_id,
+                exc_info=True,
+            )
+            broadcast_enqueued = False
+        if broadcast_enqueued and should_drain_inline(settings) and background_tasks is not None:
             background_tasks.add_task(
                 drain_broadcast_queue,
                 settings=settings,
             )
-        elif should_drain_inline(settings):
+        elif broadcast_enqueued and should_drain_inline(settings):
             drain_broadcast_queue(settings=settings)
     if not success and not _is_synthetic_settlement(body):
         STORE.record_provider_benchmark(

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -913,6 +913,43 @@ def test_enqueue_failure_does_not_fail_settle(
     assert db.reservations[auth.credit_reservation_id]["settled"] is True
 
 
+def test_broadcast_enqueue_failure_after_commit_does_not_fail_or_double_charge(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, db, _bt = fake_store
+    ws = "ws-route-broadcast-enqueue-fails"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+
+    def fail_list_destinations(_workspace_id: str) -> list[Any]:
+        raise DeadlineExceeded("broadcast store deadline exhausted")
+
+    monkeypatch.setattr(store, "list_broadcast_destinations", fail_list_destinations)
+    client = _client(Settings(environment="test", settle_outbox_enabled=True))
+
+    with caplog.at_level(logging.ERROR, logger=GATEWAY_LOGGER):
+        first = client.post("/v1/internal/gateway/settle", json=_settle_json(auth.id))
+
+    assert first.status_code == 200, first.text
+    charged = first.json()["data"]["cost_microdollars"]
+    assert _typed_credit(db, ws)["total_usage"] == charged
+    assert db.reservations[auth.credit_reservation_id]["settled"] is True
+    assert any(
+        "broadcast_metadata_enqueue_failed" in record.getMessage()
+        and auth.workspace_id in record.getMessage()
+        for record in caplog.records
+    )
+
+    replay = client.post("/v1/internal/gateway/settle", json=_settle_json(auth.id))
+
+    assert replay.status_code == 200, replay.text
+    assert replay.json()["data"]["already_settled"] is True
+    assert _typed_credit(db, ws)["total_usage"] == charged
+
+
 # Integration (drain + reaper)
 
 


### PR DESCRIPTION
## Summary
- make metadata broadcast enqueue best-effort after billing settlement commits
- skip inline drain when enqueue fails
- add regression proving a post-commit Spanner deadline still returns 200 and replay does not double-charge

## Production incident
Two Europe settlement calls on 2026-08-31 committed their typed charges, then exhausted the shared Spanner deadline during optional post-commit work and returned 503. The affected workspace has been safely moved from 1 to 16 credit/key shards.

## Verification
- `uv run pytest -q tests/test_settle_outbox_drain.py -k "broadcast_enqueue_failure_after_commit or enqueue_failure_does_not_fail_settle"`
- `uv run ruff check src/trusted_router/services/broadcast.py src/trusted_router/routes/internal/gateway.py tests/test_settle_outbox_drain.py`
- `uv run mypy src/trusted_router/services/broadcast.py src/trusted_router/routes/internal/gateway.py`