### PR TITLE
Guard cloud workflows and harden deployment smoke

### DIFF
--- a/.github/workflows/check-archive-freshness.yml
+++ b/.github/workflows/check-archive-freshness.yml
@@ -46,6 +46,7 @@ concurrency:
 
 jobs:
   check:
+    if: github.repository == 'Lore-Hex/quill-router'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/cloud-security-baseline.yml
+++ b/.github/workflows/cloud-security-baseline.yml
@@ -62,6 +62,7 @@ permissions:
 
 jobs:
   gcp:
+    if: github.repository == 'Lore-Hex/quill-router'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/daily-embeddings-probe.yml
+++ b/.github/workflows/daily-embeddings-probe.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   probe:
     name: probe /v1/embeddings
+    if: github.repository == 'Lore-Hex/quill-router'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-aws-control-plane.yml
+++ b/.github/workflows/deploy-aws-control-plane.yml
@@ -44,6 +44,7 @@ permissions:
 
 jobs:
   deploy:
+    if: github.repository == 'Lore-Hex/quill-router'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,7 @@ permissions:
 
 jobs:
   gate-on-ci:
+    if: github.repository == 'Lore-Hex/quill-router'
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
@@ -113,6 +114,7 @@ jobs:
           done
 
   build-image:
+    if: github.repository == 'Lore-Hex/quill-router'
     runs-on: ubuntu-latest
     outputs:
       sha: ${{ steps.set-vars.outputs.sha }}
@@ -206,6 +208,7 @@ jobs:
     # read-only INFORMATION_SCHEMA verification. A newly added column therefore
     # always exists before code that writes it can receive traffic.
     needs: [gate-on-ci]
+    if: github.repository == 'Lore-Hex/quill-router'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -272,6 +275,7 @@ jobs:
     # Secret Manager; deploys must never copy a stale long-lived key back from
     # GitHub Actions and silently undo an incident-response rotation.
     needs: [gate-on-ci]
+    if: github.repository == 'Lore-Hex/quill-router'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -339,7 +343,7 @@ jobs:
 
   deploy:
     needs: [build-image, migrate-schema, sync-runtime-secrets, confirm-current-main]
-    if: ${{ needs.confirm-current-main.outputs.proceed == 'true' }}
+    if: ${{ github.repository == 'Lore-Hex/quill-router' && needs.confirm-current-main.outputs.proceed == 'true' }}
     runs-on: ubuntu-latest
     outputs:
       TR_DEPLOY_MUTEX_OPERATION: ${{ steps.acquire_mutex.outputs.TR_DEPLOY_MUTEX_OPERATION }}
@@ -725,7 +729,7 @@ jobs:
 
   rollout-secondaries:
     needs: [deploy]
-    if: ${{ success() }}
+    if: ${{ github.repository == 'Lore-Hex/quill-router' && success() }}
     runs-on: ubuntu-latest
     # The mutex TTL is 90 minutes. The two lock-owning job bounds total
     # 25 + 55 = 80 minutes, leaving 10 minutes for the job handoff queue gap.
@@ -1234,6 +1238,7 @@ jobs:
     # it detects the public backend in the live map and preserves routed-mode
     # ingress/header trust on every later automatic deploy.
     needs: [rollout-secondaries]
+    if: github.repository == 'Lore-Hex/quill-router'
     continue-on-error: false
     runs-on: ubuntu-latest
     # Four sequential regional Cloud Run deploys normally finish in 12-20

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1007,17 +1007,26 @@ jobs:
           check_url() {
             local name="$1"
             local url="$2"
-            local code
-            code=$(curl -fsS --max-time 15 -o "/tmp/${name}.body" -w "%{http_code}" "$url") || {
-              echo "${name} failed to fetch: ${url}"
+            local attempt code
+            for attempt in 1 2 3; do
+              rm -f "/tmp/${name}.body"
+              code=""
+              if code=$(curl -fsS --connect-timeout 5 --max-time 15 \
+                  -o "/tmp/${name}.body" -w "%{http_code}" "$url"); then
+                if [[ "$code" == "200" ]]; then
+                  return 0
+                fi
+                echo "${name} returned ${code} on attempt ${attempt}/3: ${url}"
+              else
+                echo "${name} failed to fetch on attempt ${attempt}/3: ${url}"
+              fi
               cat "/tmp/${name}.body" 2>/dev/null || true
-              exit 1
-            }
-            [[ "$code" == "200" ]] || {
-              echo "${name} returned ${code}: ${url}"
-              cat "/tmp/${name}.body" 2>/dev/null || true
-              exit 1
-            }
+              if [ "$attempt" -lt 3 ]; then
+                sleep "$attempt"
+              fi
+            done
+            echo "${name} failed after 3 attempts: ${url}" >&2
+            return 1
           }
 
           check_url homepage https://trustedrouter.com/

--- a/.github/workflows/gateway-reliability.yml
+++ b/.github/workflows/gateway-reliability.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   configure:
+    if: github.repository == 'Lore-Hex/quill-router'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/infra-apply.yml
+++ b/.github/workflows/infra-apply.yml
@@ -41,7 +41,7 @@ jobs:
         run: terraform -chdir=infra validate
 
   apply:
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: ${{ github.repository == 'Lore-Hex/quill-router' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/mirror-repo.yml
+++ b/.github/workflows/mirror-repo.yml
@@ -30,6 +30,7 @@ concurrency:
 jobs:
   mirror:
     name: bundle and upload
+    if: github.repository == 'Lore-Hex/quill-router'
     runs-on: ubuntu-latest
     steps:
       # A shallow checkout is fine here: the script does not bundle this

--- a/.github/workflows/refresh-prices.yml
+++ b/.github/workflows/refresh-prices.yml
@@ -44,6 +44,7 @@ permissions:
 
 jobs:
   refresh:
+    if: github.repository == 'Lore-Hex/quill-router'
     runs-on: ubuntu-latest
     env:
       # The smartest model available via TR's own API, used by the

--- a/.github/workflows/reshard-billing-workspace.yml
+++ b/.github/workflows/reshard-billing-workspace.yml
@@ -47,6 +47,7 @@ concurrency:
 
 jobs:
   operate:
+    if: github.repository == 'Lore-Hex/quill-router'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/typed-audit.yml
+++ b/.github/workflows/typed-audit.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   typed-billing-invariant-audit:
     name: typed-billing-invariant-audit
+    if: github.repository == 'Lore-Hex/quill-router'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/tests/test_deploy_workflow_regions.py
+++ b/tests/test_deploy_workflow_regions.py
@@ -231,7 +231,11 @@ def test_superseded_push_stops_before_production_mutation() -> None:
     assert confirm < deploy < mutation
     assert 'git/ref/heads/main" --jq' in workflow[confirm:deploy]
     assert 'echo "proceed=false" >> "$GITHUB_OUTPUT"' in workflow[confirm:deploy]
-    assert "if: ${{ needs.confirm-current-main.outputs.proceed == 'true' }}" in workflow
+    assert (
+        "if: ${{ github.repository == 'Lore-Hex/quill-router' && "
+        "needs.confirm-current-main.outputs.proceed == 'true' }}"
+        in workflow
+    )
 
 
 def test_rollback_capture_uses_the_sole_serving_revision() -> None:

--- a/tests/test_deploy_workflow_regions.py
+++ b/tests/test_deploy_workflow_regions.py
@@ -29,6 +29,13 @@ def test_prod_smoke_checks_public_origins_and_converges_private_regions() -> Non
     )
     smoke = workflow.split("- name: Smoke test prod", 1)[1]
     assert "source scripts/deploy/_cloud_run_revision_probe.sh" in smoke
+    check_url = smoke.split("check_url() {", 1)[1].split("\n          }", 1)[0]
+    assert "for attempt in 1 2 3; do" in check_url
+    assert "--connect-timeout 5 --max-time 15" in check_url
+    assert 'if [[ "$code" == "200" ]]; then' in check_url
+    assert 'if [ "$attempt" -lt 3 ]; then' in check_url
+    assert 'echo "${name} failed after 3 attempts: ${url}" >&2' in check_url
+    assert "return 1" in check_url
     assert "service_ingress=$(cloud_run_service_ingress" in smoke
     assert 'if [ "${service_ingress}" = "all" ]; then' in smoke
     direct = smoke.split('if [ "${service_ingress}" = "all" ]; then', 1)[1].split(

--- a/tests/test_workflow_fork_isolation.py
+++ b/tests/test_workflow_fork_isolation.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+CANONICAL_GUARD = "github.repository == 'Lore-Hex/quill-router'"
+CLOUD_AUTH_ACTIONS = (
+    "google-github-actions/auth@",
+    "aws-actions/configure-aws-credentials@",
+    "azure/login@",
+)
+
+
+def test_every_cloud_authenticated_job_is_disabled_in_forks() -> None:
+    unguarded: list[str] = []
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for job_name, job in (document.get("jobs") or {}).items():
+            steps = job.get("steps") or []
+            uses = [str(step.get("uses", "")) for step in steps]
+            if not any(
+                action in use
+                for use in uses
+                for action in CLOUD_AUTH_ACTIONS
+            ):
+                continue
+            if CANONICAL_GUARD not in str(job.get("if", "")):
+                unguarded.append(f"{path.name}:{job_name}")
+
+    assert unguarded == [], (
+        "cloud-authenticated jobs must refuse fork execution before requesting "
+        f"an OIDC token: {unguarded}"
+    )


### PR DESCRIPTION
## Summary
- add a canonical repository guard to every GCP and AWS authenticated workflow job
- prevent forks with enabled schedules from requesting cloud OIDC exchanges
- add a repository wide regression test covering current and future cloud auth actions
- retry public production smoke transport failures up to three times while still failing closed after three misses

## Incident evidence
At 2026-08-31 19:30 UTC, the public fork ahuserious/quill-router ran its copied Daily Embeddings Probe schedule. GCP WIF correctly rejected the token because the repository attribute did not match, but the rejected exchange emitted an ERROR audit record and alert noise. No access was granted.

A later successful four region rollout was marked failed only because one GitHub hosted runner timed out before its /ready request reached GCP. Cloud Run had no matching request, direct readiness was 200 in 185 ms, and customer HTTP 5xx remained zero. The bounded retry handles that transport only case without weakening endpoint checks.

## Tests
- uv run pytest -q tests/test_workflow_fork_isolation.py tests/test_deploy_workflow_regions.py (17 passed)