### PR TITLE
Allow quota reconciler cold starts

### DIFF
--- a/scripts/deploy/regional_quota_reconciler.sh
+++ b/scripts/deploy/regional_quota_reconciler.sh
@@ -63,8 +63,7 @@ env_vars=(
   "TR_SPANNER_INSTANCE_ID=${SPANNER_INSTANCE_ID}"
   "TR_SPANNER_DATABASE_ID=${SPANNER_DATABASE_ID}"
   # This one-shot worker is strictly serial. Giving it the serving process's
-  # eight-session pool makes a cold run create seven unused Spanner sessions
-  # and can consume the entire 50-second fail-closed task budget.
+  # eight-session pool makes a cold run create seven unused Spanner sessions.
   "TR_SPANNER_POOL_SIZE=1"
   "TR_BIGTABLE_INSTANCE_ID=${BIGTABLE_INSTANCE_ID}"
   "TR_BIGTABLE_GENERATION_TABLE=${BIGTABLE_GENERATION_TABLE}"
@@ -103,6 +102,10 @@ if [ "$versioned_job_exists" = true ]; then
 else
   job_mutation=create
 fi
+# Cloud Run can occasionally spend more than 50 seconds provisioning a cold
+# task before Python starts. Keep the application's work bounded by its
+# single-session pool, distributed lock, and reconcile limit, while giving
+# the platform enough startup envelope to avoid killing untouched work.
 gc run jobs "$job_mutation" "$JOB_NAME" \
   --region "$JOB_REGION" \
   --image "$IMAGE" \
@@ -112,7 +115,7 @@ gc run jobs "$job_mutation" "$JOB_NAME" \
   --set-env-vars "$set_env_vars" \
   --update-secrets "TR_SENTRY_DSN=trustedrouter-sentry-dsn:latest" \
   --max-retries 0 \
-  --task-timeout 50s \
+  --task-timeout 180s \
   --cpu 1 \
   --memory 512Mi \
   --quiet >/dev/null

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -268,7 +268,7 @@ def test_production_deploy_provisions_and_schedules_regional_quota_reconciliatio
     assert reconciler.index("gc run jobs execute") < reconciler.index("gc scheduler jobs update")
     assert reconciler.index("gc run jobs execute") < reconciler.index("gc scheduler jobs create")
     assert "--max-retries 0" in reconciler
-    assert "--task-timeout 50s" in reconciler
+    assert "--task-timeout 180s" in reconciler
     assert "--max-retry-attempts=3" in reconciler
     assert "--max-retry-duration=45s" in reconciler
     assert "--max-doublings=1" in reconciler


### PR DESCRIPTION
## Summary
- raise the Cloud Run Job outer timeout from 50s to 180s so occasional platform cold-start delays do not kill the worker before Python begins
- preserve the bounded reconcile limit, one-session Spanner pool, zero application retries, distributed lock, and strict nonzero failures
- update the deployment contract test

## Root cause
Execution c4xsj exhausted its 50-second task budget during Cloud Run provisioning/container startup and never reached Spanner. Adjacent executions completed in 8-9 seconds with zero reconciliation errors, so this was an infrastructure startup-envelope failure rather than slow application work.

## Verification
- bash -n scripts/deploy/regional_quota_reconciler.sh
- 21 focused deployment and worker tests pass