### PR TITLE
Avoid audit errors for expected firewall absence

### DIFF
--- a/scripts/deploy/gcp_security_baseline_check.sh
+++ b/scripts/deploy/gcp_security_baseline_check.sh
@@ -200,14 +200,18 @@ if [ "$IAP_ALL" = "35.235.240.0/20" ]; then
 else
   drift "tr-allow-iap-ssh-all missing or wrong source range (got: '${IAP_ALL:-none}') — IAP SSH may be broken"
 fi
+# Expected absence must not be probed with `firewall-rules describe`: the API
+# returns NOT_FOUND and records that successful security assertion as an ERROR
+# audit event. Read the collection once and test exact names locally instead.
+FIREWALL_NAMES="$(g compute firewall-rules list --format='value(name)')"
 for r in default-allow-ssh default-allow-rdp; do
-  if g compute firewall-rules describe "$r" --format='value(name)' | grep -q .; then
+  if grep -Fxq "$r" <<<"$FIREWALL_NAMES"; then
     drift "$r EXISTS again — 0.0.0.0/0 to every instance in the network"
   else
     ok "$r absent"
   fi
 done
-if g compute firewall-rules describe allow-iap-ssh-tmp --format='value(name)' | grep -q .; then
+if grep -Fxq allow-iap-ssh-tmp <<<"$FIREWALL_NAMES"; then
   # Created 2026-06-18, still live. Functionally identical to
   # tr-allow-iap-ssh-all, so it grants nothing extra — the textbook shape of a
   # temporary widening that became permanent. Reported, not failed.

--- a/tests/test_cloud_security_baseline.py
+++ b/tests/test_cloud_security_baseline.py
@@ -164,6 +164,17 @@ def test_gcp_checks_the_iap_path_before_asserting_ssh_is_closed() -> None:
     assert body.index("tr-allow-iap-ssh-all") < body.index("for r in default-allow-ssh")
 
 
+def test_gcp_expected_firewall_absence_does_not_emit_not_found_audits() -> None:
+    """An expected 404 is still an ERROR audit record. Negative controls read
+    the collection once and compare names locally instead of issuing GETs for
+    resources that should not exist."""
+    body = _executable_lines(GCP)
+    assert body.count("compute firewall-rules list --format='value(name)'") == 1
+    assert 'firewall-rules describe "$r"' not in body
+    assert "firewall-rules describe allow-iap-ssh-tmp" not in body
+    assert 'grep -Fxq "$r" <<<"$FIREWALL_NAMES"' in body
+
+
 def test_gcp_resolves_essential_contacts_by_inheritance() -> None:
     """`essential-contacts list --project=` returns [] here and that does not
     mean absent -- contacts inherit from the org. A check written the obvious


### PR DESCRIPTION
## Summary
- read firewall rule names once and check expected absence locally
- keep the IAP replacement rule as a strict positive GET check
- add a regression test that forbids negative resource GET probes

## Incident
The security baseline correctly confirmed that default-allow-ssh and default-allow-rdp were absent, but it did so with individual describe calls. GCP records each expected NOT_FOUND response as an ERROR audit event, producing false cloud alerts from a successful security assertion.

## Tests
- bash -n scripts/deploy/gcp_security_baseline_check.sh
- uv run pytest -q tests/test_cloud_security_baseline.py (20 passed)