### PR TITLE
Schedule DeepInfra Kimi K2.5 retirement

### DIFF
--- a/src/trusted_router/data/provider_models/deepinfra.json
+++ b/src/trusted_router/data/provider_models/deepinfra.json
@@ -1107,7 +1107,9 @@
       "input_token_price_per_m": 450000,
       "output_token_price_per_m": 2250000,
       "cached_input_token_price_per_m": 70000,
-      "missing_since": "2026-08-31"
+      "missing_since": "2026-08-31",
+      "retirement_at": "2026-09-07T00:00:00Z",
+      "replacement_model_id": "moonshotai/kimi-k3"
     },
     {
       "display_name": "moonshotai/Kimi-K2.6",

--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -36,6 +36,7 @@ DEEPINFRA_TERMINUS_RETIREMENT_AT = datetime(2026, 8, 17, 0, 0, tzinfo=UTC)
 DEEPINFRA_QWEN3_235B_THINKING_RETIREMENT_AT = datetime(
     2026, 8, 24, 0, 0, tzinfo=UTC
 )
+DEEPINFRA_KIMI_K25_RETIREMENT_AT = datetime(2026, 9, 7, 0, 0, tzinfo=UTC)
 NEBIUS_AUGUST_2026_RETIREMENT_AT = datetime(2026, 8, 31, 0, 0, tzinfo=UTC)
 CEREBRAS_GEMMA4_SHARED_RETIREMENT_AT = datetime(2026, 9, 3, 0, 0, tzinfo=UTC)
 NOVITA_LING_30_TINY_RETIREMENT_AT = datetime(2026, 8, 13, 15, 0, tzinfo=UTC)
@@ -347,6 +348,19 @@ _RETIREMENTS = (
         model_ids=frozenset({"qwen/qwen3-235b-a22b-thinking-2507"}),
         upstream_ids=frozenset({"Qwen/Qwen3-235B-A22B-Thinking-2507"}),
         effective_at=DEEPINFRA_QWEN3_235B_THINKING_RETIREMENT_AT,
+    ),
+    # DeepInfra announced that Kimi K2.5 retires on 2026-09-07 and that its
+    # API will redirect subsequent requests to Kimi K3. Those are different
+    # checkpoints, so TrustedRouter must not accept the provider's silent
+    # substitution. Retire only DeepInfra's K2.5 route at 00:00 UTC, the
+    # conservative boundary for a notice without a time zone. K2.5 remains
+    # eligible through providers that still serve it, and K3 remains an
+    # independently selectable model.
+    _Retirement(
+        provider="deepinfra",
+        model_ids=frozenset({"moonshotai/kimi-k2.5"}),
+        upstream_ids=frozenset({"moonshotai/Kimi-K2.5"}),
+        effective_at=DEEPINFRA_KIMI_K25_RETIREMENT_AT,
     ),
     # Wafer announced that GLM 5.1, GLM 5.2 Fast, and Kimi K3 Fast retire on
     # 2026-08-17. Standard GLM 5.2 replaces both GLM routes, while Kimi K3

--- a/tests/test_deepinfra_september_2026_lifecycle.py
+++ b/tests/test_deepinfra_september_2026_lifecycle.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from scripts.pricing import refresh
+from scripts.pricing.base import ModelPrice, ProviderPricingResult
+from scripts.pricing.providers import deepinfra
+from trusted_router import provider_lifecycle
+
+_CUTOFF = datetime(2026, 9, 7, 0, 0, tzinfo=UTC)
+_KIMI_K25 = "moonshotai/kimi-k2.5"
+_KIMI_K25_UPSTREAM = "moonshotai/Kimi-K2.5"
+_KIMI_K3 = "moonshotai/kimi-k3"
+_KIMI_K3_UPSTREAM = "moonshotai/Kimi-K3"
+
+
+def test_deepinfra_kimi_k25_retires_at_announced_date() -> None:
+    assert not provider_lifecycle.provider_model_retired(
+        "deepinfra",
+        _KIMI_K25,
+        _KIMI_K25_UPSTREAM,
+        at=_CUTOFF - timedelta(microseconds=1),
+    )
+    assert provider_lifecycle.provider_model_retired(
+        "deepinfra",
+        _KIMI_K25,
+        _KIMI_K25_UPSTREAM,
+        at=_CUTOFF,
+    )
+    assert not provider_lifecycle.provider_model_retired(
+        "deepinfra",
+        _KIMI_K3,
+        _KIMI_K3_UPSTREAM,
+        at=_CUTOFF,
+    )
+
+
+def test_deepinfra_kimi_k25_retirement_is_provider_scoped() -> None:
+    assert provider_lifecycle.provider_model_retired(
+        "deepinfra",
+        _KIMI_K25,
+        _KIMI_K25_UPSTREAM,
+        at=_CUTOFF,
+    )
+    for provider in ("alibaba", "atlas-cloud", "kimi", "novita", "siliconflow"):
+        assert not provider_lifecycle.provider_model_retired(
+            provider,
+            _KIMI_K25,
+            at=_CUTOFF,
+        )
+
+
+def test_hourly_refresh_cannot_restore_retired_deepinfra_kimi_k25(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = ProviderPricingResult(
+        slug="deepinfra",
+        prices={
+            _KIMI_K25: ModelPrice(450_000, 2_250_000),
+            _KIMI_K3: ModelPrice(2_850_000, 14_250_000),
+        },
+        source="api",
+        fetched_url=deepinfra.URL,
+    )
+
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF - timedelta(microseconds=1),
+    )
+    before = refresh._index_provider_prices({"deepinfra": result})
+    assert "deepinfra" in before[_KIMI_K25]
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    after = refresh._index_provider_prices({"deepinfra": result})
+
+    assert _KIMI_K25 not in after
+    assert "deepinfra" in after[_KIMI_K3]
+
+
+def test_deepinfra_parser_filters_retired_kimi_k25_from_stale_feed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def row(native_id: str) -> dict[str, object]:
+        return {
+            "id": native_id,
+            "metadata": {
+                "pricing": {
+                    "input_tokens": 0.45,
+                    "output_tokens": 2.25,
+                }
+            },
+        }
+
+    payload = {"data": [row(_KIMI_K25_UPSTREAM), row(_KIMI_K3_UPSTREAM)]}
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return payload
+
+    class FakeClient:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def get(self, *_args: object, **_kwargs: object) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setattr(deepinfra.httpx, "Client", FakeClient)
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+
+    result = deepinfra.fetch()
+
+    assert _KIMI_K25 not in result.prices
+    assert _KIMI_K25 not in deepinfra._DISCOVERED_MANIFEST_ROWS
+    assert _KIMI_K3 in result.prices
+    assert _KIMI_K3 in deepinfra._DISCOVERED_MANIFEST_ROWS
+
+
+def test_deepinfra_manifest_records_announced_kimi_replacement() -> None:
+    rows = {row["id"]: row for row in json.loads(deepinfra.MANIFEST_PATH.read_text())["models"]}
+
+    retired = rows[_KIMI_K25]
+    assert retired["retirement_at"] == "2026-09-07T00:00:00Z"
+    assert retired["replacement_model_id"] == _KIMI_K3


### PR DESCRIPTION
## Summary
- retire only DeepInfra's Kimi K2.5 route at the announced 2026-09-07 cutoff
- preserve Kimi K2.5 routes on providers that still serve that checkpoint
- record Kimi K3 as the explicit replacement without accepting DeepInfra's silent model substitution
- prevent stale pricing and model-discovery feeds from restoring the retired route

## Validation
- 7,792 passed, 348 skipped, 10 xfailed with the lifecycle clock pinned to 2026-09-08
- 213 focused lifecycle, catalog, price-coverage, and discovery tests passed after rebasing onto current main
- Ruff passed