### PR TITLE
Batch synthetic route health analytics reads

### DIFF
--- a/src/trusted_router/operational_analytics.py
+++ b/src/trusted_router/operational_analytics.py
@@ -173,6 +173,44 @@ FORMAT JSON
         )
         return [_benchmark_sample(row) for row in rows]
 
+    def route_benchmark_samples(
+        self,
+        *,
+        cutoff: str,
+        per_route_limit: int,
+        limit: int,
+    ) -> list[ProviderBenchmarkSample]:
+        """Read a bounded recent window for every synthetic provider/model route."""
+        rows = self._query(
+            """
+SELECT
+  id, model, provider, provider_name, status, usage_type, streamed,
+  input_tokens, output_tokens, total_cost_microdollars,
+  speed_tokens_per_second, elapsed_milliseconds,
+  first_token_milliseconds, ttfb_milliseconds, finish_reason,
+  error_type, error_status, error_message, region, source, app, created_at
+FROM
+(
+  SELECT *, row_number() OVER (
+    PARTITION BY provider, model ORDER BY created_at DESC, id DESC
+  ) AS route_rank
+  FROM provider_benchmark_samples FINAL
+  WHERE source = 'synthetic'
+    AND created_at >= parseDateTime64BestEffort({cutoff:String}, 3)
+)
+WHERE route_rank <= {per_route_limit:UInt32}
+ORDER BY created_at DESC, id DESC
+LIMIT {limit:UInt32}
+FORMAT JSON
+""",
+            params={
+                "cutoff": cutoff,
+                "per_route_limit": max(1, per_route_limit),
+                "limit": max(1, limit),
+            },
+        )
+        return [_benchmark_sample(row) for row in rows]
+
     def activity_generations(
         self,
         *,

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -2077,6 +2077,19 @@ class InMemoryStore:
             date=date, provider=provider, model=model, limit=limit
         )
 
+    def provider_route_benchmark_samples(
+        self,
+        *,
+        cutoff: str,
+        per_route_limit: int,
+        limit: int,
+    ) -> list[ProviderBenchmarkSample]:
+        return self.generation_store.route_benchmark_samples(
+            cutoff=cutoff,
+            per_route_limit=per_route_limit,
+            limit=limit,
+        )
+
     def record_synthetic_probe_sample(self, sample: SyntheticProbeSample) -> None:
         self.synthetic_store.record(sample)
 

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -4010,6 +4010,23 @@ class SpannerBigtableStore:
             limit=limit,
         )
 
+    def provider_route_benchmark_samples(
+        self,
+        *,
+        cutoff: str,
+        per_route_limit: int,
+        limit: int,
+    ) -> list[ProviderBenchmarkSample]:
+        # This is one derived monitoring sweep, not a customer read. Exact
+        # parity is owned by the background verifier; synchronously shadowing
+        # every route to Bigtable recreated the N x 2 fanout this method exists
+        # to remove.
+        return self._require_operational_analytics().route_benchmark_samples(
+            cutoff=cutoff,
+            per_route_limit=per_route_limit,
+            limit=limit,
+        )
+
     def public_analytics_snapshot(self, name: str) -> dict[str, Any] | None:
         return self._require_operational_analytics().public_snapshot(name)
 

--- a/src/trusted_router/storage_generations.py
+++ b/src/trusted_router/storage_generations.py
@@ -84,6 +84,33 @@ class InMemoryGenerations:
         rows.sort(key=lambda sample: sample.created_at, reverse=True)
         return rows[:limit]
 
+    def route_benchmark_samples(
+        self,
+        *,
+        cutoff: str,
+        per_route_limit: int,
+        limit: int,
+    ) -> list[ProviderBenchmarkSample]:
+        with self._lock:
+            rows = [
+                sample
+                for sample in self.provider_benchmarks
+                if sample.source == "synthetic" and sample.created_at >= cutoff
+            ]
+        rows.sort(key=lambda sample: (sample.created_at, sample.id), reverse=True)
+        route_counts: dict[tuple[str, str], int] = {}
+        selected: list[ProviderBenchmarkSample] = []
+        for sample in rows:
+            route = (sample.provider, sample.model)
+            count = route_counts.get(route, 0)
+            if count >= max(1, per_route_limit):
+                continue
+            route_counts[route] = count + 1
+            selected.append(sample)
+            if len(selected) >= max(1, limit):
+                break
+        return selected
+
     def get(self, generation_id: str) -> Generation | None:
         with self._lock:
             return self.generations.get(generation_id)

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -4755,6 +4755,42 @@ class PostgresStore:
 
         return self._run_transaction(list_samples)
 
+    def provider_route_benchmark_samples(
+        self,
+        *,
+        cutoff: str,
+        per_route_limit: int,
+        limit: int,
+    ) -> list[ProviderBenchmarkSample]:
+        def list_samples(conn: Any) -> list[ProviderBenchmarkSample]:
+            rows = conn.execute(
+                "WITH ranked AS ("
+                "SELECT body, id, ROW_NUMBER() OVER ("
+                "PARTITION BY body ->> 'provider', body ->> 'model' "
+                "ORDER BY (body ->> 'created_at')::timestamptz DESC, id DESC"
+                ") AS route_rank FROM tr_entities "
+                "WHERE kind = 'provider_benchmark' "
+                "AND body ->> 'source' = 'synthetic' "
+                "AND (body ->> 'created_at')::timestamptz >= %s::timestamptz"
+                ") SELECT body FROM ranked WHERE route_rank <= %s "
+                "ORDER BY (body ->> 'created_at')::timestamptz DESC, id DESC "
+                "LIMIT %s",
+                (cutoff, max(1, per_route_limit), max(1, limit)),
+            ).fetchall()
+            samples: list[ProviderBenchmarkSample] = []
+            known = {field.name for field in dataclasses.fields(ProviderBenchmarkSample)}
+            for row in rows:
+                raw = row[0]
+                data = json.loads(raw) if isinstance(raw, str) else dict(raw)
+                samples.append(
+                    ProviderBenchmarkSample(
+                        **{key: value for key, value in data.items() if key in known}
+                    )
+                )
+            return samples
+
+        return self._run_transaction(list_samples)
+
     def record_synthetic_probe_sample(self, sample: SyntheticProbeSample) -> None:
         def record(conn: Any) -> None:
             self._write_indexed_entity_tx(

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -824,6 +824,13 @@ class Store(Protocol):
         model: str | None = ...,
         limit: int = ...,
     ) -> list[ProviderBenchmarkSample]: ...
+    def provider_route_benchmark_samples(
+        self,
+        *,
+        cutoff: str,
+        per_route_limit: int,
+        limit: int,
+    ) -> list[ProviderBenchmarkSample]: ...
     def record_synthetic_probe_sample(self, sample: SyntheticProbeSample) -> None: ...
     def synthetic_probe_samples(
         self,

--- a/src/trusted_router/synthetic/route_health.py
+++ b/src/trusted_router/synthetic/route_health.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import datetime as dt
 from dataclasses import dataclass
 
-from trusted_router.storage_models import SyntheticProbeSample
+from trusted_router.storage_models import ProviderBenchmarkSample, SyntheticProbeSample
 from trusted_router.store_protocol import Store
 from trusted_router.synthetic.probes import rotation_candidates
 
 _SAMPLES_PER_ROUTE_LIMIT = 48
+_BATCH_SAMPLE_LIMIT = 100_000
 
 # A route-health alert means "this route is structurally broken — quarantine
 # it". Transient/capacity failures (rate limits, gateway/no-upstream, timeouts,
@@ -65,19 +66,29 @@ def evaluate_route_health(
             for provider, models in rotation_candidates().items()
             for model in models
         ]
+    if not routes:
+        return []
+
+    route_set = set(routes)
+    samples_by_route: dict[tuple[str, str], list[ProviderBenchmarkSample]] = {
+        route: [] for route in route_set
+    }
+    samples = store.provider_route_benchmark_samples(
+        cutoff=cutoff.isoformat().replace("+00:00", "Z"),
+        per_route_limit=_SAMPLES_PER_ROUTE_LIMIT,
+        limit=min(_BATCH_SAMPLE_LIMIT, len(route_set) * _SAMPLES_PER_ROUTE_LIMIT),
+    )
+    for sample in samples:
+        route = (sample.provider, sample.model)
+        if route in samples_by_route:
+            samples_by_route[route].append(sample)
 
     flags: list[RouteHealthFlag] = []
     for provider, model in routes:
         sample_count = 0
         failure_count = 0
         newest_error: tuple[dt.datetime, str | None, str | None] | None = None
-        samples = store.provider_benchmark_samples(
-            date=None,
-            provider=provider,
-            model=model,
-            limit=_SAMPLES_PER_ROUTE_LIMIT,
-        )
-        for sample in samples:
+        for sample in samples_by_route[(provider, model)]:
             if sample.source != "synthetic":
                 continue
             created_at = _parse_created_at(sample.created_at)

--- a/tests/test_operational_analytics.py
+++ b/tests/test_operational_analytics.py
@@ -49,6 +49,7 @@ from trusted_router.storage_operational_analytics import (
     OPERATIONAL_ANALYTICS_OUTBOX_SHARDS,
     build_client_events_payload,
 )
+from trusted_router.storage_postgres import PostgresStore
 from trusted_router.storage_postgres_operational_analytics_outbox import (
     PostgresOperationalAnalyticsOutbox,
 )
@@ -397,6 +398,158 @@ def test_clickhouse_balanced_benchmark_reader_uses_one_window_query() -> None:
             created_at="2026-07-31T12:34:56.789Z",
         )
     ]
+
+
+def test_clickhouse_route_benchmark_reader_uses_one_partitioned_query() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        assert request.url.params["param_per_route_limit"] == "48"
+        assert request.url.params["param_limit"] == "47088"
+        assert request.url.params["param_cutoff"] == "2026-08-29T00:00:00Z"
+        sql = request.content.decode()
+        assert "source = 'synthetic'" in sql
+        assert "PARTITION BY provider, model" in sql
+        assert "route_rank <= {per_route_limit:UInt32}" in sql
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "id": "bench-route-1",
+                        "model": "openai/gpt-5.5",
+                        "provider": "openai",
+                        "provider_name": "OpenAI",
+                        "status": "success",
+                        "usage_type": "Credits",
+                        "streamed": 1,
+                        "input_tokens": 4,
+                        "output_tokens": 1,
+                        "total_cost_microdollars": 3,
+                        "speed_tokens_per_second": 9.0,
+                        "elapsed_milliseconds": 180,
+                        "first_token_milliseconds": 90,
+                        "ttfb_milliseconds": 15,
+                        "finish_reason": "stop",
+                        "error_type": None,
+                        "error_status": None,
+                        "error_message": None,
+                        "region": "us-central1",
+                        "source": "synthetic",
+                        "app": "TrustedRouter Synthetic",
+                        "created_at": "2026-08-30 12:34:56.789",
+                    }
+                ]
+            },
+        )
+
+    client = OperationalAnalyticsClient(
+        base_url="http://clickhouse",
+        user="reader",
+        password="sec" + "ret",
+        transport=httpx.MockTransport(handler),
+    )
+    rows = client.route_benchmark_samples(
+        cutoff="2026-08-29T00:00:00Z",
+        per_route_limit=48,
+        limit=47_088,
+    )
+
+    assert calls == 1
+    assert [(row.provider, row.model, row.id) for row in rows] == [
+        ("openai", "openai/gpt-5.5", "bench-route-1")
+    ]
+
+
+def test_gcp_route_health_batch_read_does_not_shadow_to_bigtable() -> None:
+    class FakeAnalytics:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+
+        def route_benchmark_samples(
+            self,
+            *,
+            cutoff: str,
+            per_route_limit: int,
+            limit: int,
+        ) -> list[ProviderBenchmarkSample]:
+            self.calls.append(
+                {
+                    "cutoff": cutoff,
+                    "per_route_limit": per_route_limit,
+                    "limit": limit,
+                }
+            )
+            return []
+
+    store = object.__new__(SpannerBigtableStore)
+    analytics = FakeAnalytics()
+    store._operational_analytics = analytics  # type: ignore[assignment]
+
+    rows = store.provider_route_benchmark_samples(
+        cutoff="2026-08-29T00:00:00Z",
+        per_route_limit=48,
+        limit=47_088,
+    )
+
+    assert rows == []
+    assert analytics.calls == [
+        {
+            "cutoff": "2026-08-29T00:00:00Z",
+            "per_route_limit": 48,
+            "limit": 47_088,
+        }
+    ]
+
+
+def test_postgres_route_health_batch_read_uses_one_partitioned_query() -> None:
+    statements: list[tuple[str, tuple[object, ...]]] = []
+    body = dataclasses.asdict(
+        ProviderBenchmarkSample(
+            id="bench-postgres-route-1",
+            model="openai/gpt-5.5",
+            provider="openai",
+            provider_name="OpenAI",
+            status="success",
+            usage_type="Credits",
+            streamed=True,
+            input_tokens=4,
+            output_tokens=1,
+            total_cost_microdollars=3,
+            created_at="2026-08-30T12:34:56.789Z",
+            source="synthetic",
+        )
+    )
+
+    class Cursor:
+        def fetchall(self) -> list[tuple[dict[str, object]]]:
+            return [(body,)]
+
+    class Connection:
+        def execute(self, sql: str, params: tuple[object, ...]) -> Cursor:
+            statements.append((sql, params))
+            return Cursor()
+
+    connection = Connection()
+    store = PostgresStore.__new__(PostgresStore)
+    store._run_transaction = lambda operation: operation(connection)  # type: ignore[method-assign]
+
+    rows = store.provider_route_benchmark_samples(
+        cutoff="2026-08-29T00:00:00Z",
+        per_route_limit=48,
+        limit=47_088,
+    )
+
+    assert [(row.provider, row.model, row.id) for row in rows] == [
+        ("openai", "openai/gpt-5.5", "bench-postgres-route-1")
+    ]
+    [(sql, params)] = statements
+    assert "PARTITION BY body ->> 'provider', body ->> 'model'" in sql
+    assert "body ->> 'source' = 'synthetic'" in sql
+    assert "route_rank <= %s" in sql
+    assert params == ("2026-08-29T00:00:00Z", 48, 47_088)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -4083,6 +4083,7 @@ class _RouteHealthStore:
     def __init__(self, samples: list[ProviderBenchmarkSample]) -> None:
         self.samples = samples
         self.calls: list[dict[str, Any]] = []
+        self.batch_calls: list[dict[str, Any]] = []
 
     def provider_benchmark_samples(
         self,
@@ -4103,6 +4104,39 @@ class _RouteHealthStore:
         ]
         samples.sort(key=lambda sample: sample.created_at, reverse=True)
         return samples[:limit]
+
+    def provider_route_benchmark_samples(
+        self,
+        *,
+        cutoff: str,
+        per_route_limit: int,
+        limit: int,
+    ) -> list[ProviderBenchmarkSample]:
+        self.batch_calls.append(
+            {
+                "cutoff": cutoff,
+                "per_route_limit": per_route_limit,
+                "limit": limit,
+            }
+        )
+        rows = [
+            sample
+            for sample in self.samples
+            if sample.source == "synthetic" and sample.created_at >= cutoff
+        ]
+        rows.sort(key=lambda sample: (sample.created_at, sample.id), reverse=True)
+        route_counts: dict[tuple[str, str], int] = {}
+        selected: list[ProviderBenchmarkSample] = []
+        for sample in rows:
+            route = (sample.provider, sample.model)
+            count = route_counts.get(route, 0)
+            if count >= per_route_limit:
+                continue
+            route_counts[route] = count + 1
+            selected.append(sample)
+            if len(selected) >= limit:
+                break
+        return selected
 
 
 def _route_health_sample(
@@ -4230,10 +4264,10 @@ def test_evaluate_route_health_flags_dead_route_but_not_healthy_or_thin_routes()
             newest_error_message="latest failure",
         )
     ]
-    assert store.calls == [
-        {"date": None, "provider": provider, "model": model, "limit": 48}
-        for provider, model in routes
-    ]
+    assert store.calls == []
+    assert len(store.batch_calls) == 1
+    assert store.batch_calls[0]["per_route_limit"] == 48
+    assert store.batch_calls[0]["limit"] >= len(routes) * 48
 
 
 def test_evaluate_route_health_excludes_unsupported_samples_from_rate() -> None:
@@ -4325,11 +4359,10 @@ def test_evaluate_route_health_derives_routes_from_rotation_candidates(
     flags = evaluate_route_health(store)  # type: ignore[arg-type]
 
     assert [(flag.provider, flag.model) for flag in flags] == [("provider-a", "model-3")]
-    assert store.calls == [
-        {"date": None, "provider": provider, "model": model, "limit": 48}
-        for provider, models in candidates.items()
-        for model in models
-    ]
+    assert store.calls == []
+    assert len(store.batch_calls) == 1
+    assert store.batch_calls[0]["per_route_limit"] == 48
+    assert store.batch_calls[0]["limit"] >= sum(map(len, candidates.values())) * 48
 
 
 def test_report_route_health_uses_one_sentry_fingerprint_per_route(


### PR DESCRIPTION
## Summary

- replace the per-provider/model route-health fanout with one bounded ClickHouse window query
- avoid synchronous Bigtable shadow reads for this derived monitoring sweep while retaining background exact parity verification
- provide equivalent in-memory and Postgres implementations
- add regression coverage for one-query behavior and storage adapter contracts

## Root cause

A cold route-health request evaluated 981 provider/model routes. Each route performed a ClickHouse read and a synchronous Bigtable shadow read, and the remediator repeated the sweep. This produced 74-100 second internal requests and caused the 30-second synthetic client to time out even though the server eventually returned 200.

## Verification

- regression assertions failed on the prior implementation because it made one call per route
- `uv run pytest -q`: 7,791 passed, 346 skipped, 10 expected failures
- focused route-health and analytics tests: 15 passed
- `uv run ruff check ...`: passed
- `uv run mypy`: passed