### PR TITLE
Defer pending quota leases during initialization

### DIFF
--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -3249,6 +3249,15 @@ class SpannerBigtableStore:
                     continue
                 local = ledger.get(record.lease_id, region=record.region)
                 if local is None:
+                    # Granting is intentionally two-phase: Spanner first
+                    # reserves the bounded escrow and publishes a pending
+                    # lease, then the regional ledger row is initialized and
+                    # the global lease becomes active. The reconciler can
+                    # observe that short, valid gap. Leave live pending leases
+                    # alone so the initializer can finish; only expired or
+                    # quarantined missing rows belong to recovery.
+                    if record.state == "pending" and record.expires_datetime > now:
+                        continue
                     closed = close_expired_uninitialized_regional_quota_lease(
                         self,
                         record,

--- a/tests/test_regional_quota_spanner.py
+++ b/tests/test_regional_quota_spanner.py
@@ -823,6 +823,52 @@ def test_reconciler_closes_expired_quarantine_when_local_initialization_is_absen
     assert store._list_entities("regional_quota_lease_open", cls=OpenRegionalQuotaLease) == []
 
 
+def test_reconciler_defers_live_pending_lease_before_local_initialization() -> None:
+    store, database, _ = make_fake_store(request_record_write_mode="typed")
+    ledger = InMemoryRegionalQuotaLedger()
+    store._regional_quota_ledger = ledger
+    workspace = store.create_workspace(
+        "owner",
+        "regional-pending-initialization",
+        trial_credit_microdollars=10_000_000,
+    )
+    lease = grant_regional_quota_lease(
+        store,
+        workspace_id=workspace.id,
+        region="us-central1",
+        requested_microdollars=1_000_000,
+        per_lease_cap_microdollars=1_000_000,
+        max_available_basis_points=1_000,
+        ttl_seconds=60,
+        minimum_grant_microdollars=1_000,
+        now=NOW,
+    )
+    assert lease is not None
+
+    result = store.reconcile_regional_quota_leases(now=NOW + timedelta(seconds=1))
+
+    assert result == {
+        "inspected": 1,
+        "reconciled": 0,
+        "closed": 0,
+        "errors": 0,
+    }
+    assert _credit_totals(database, workspace.id)[2] == lease.granted_microdollars
+    pending = store._read_entity(
+        "regional_quota_lease",
+        lease.entity_id,
+        GlobalRegionalQuotaLease,
+    )
+    assert pending is not None and pending.state == "pending"
+    assert ledger.get(lease.lease_id, region=lease.region) is None
+
+    ledger.initialize(regional_lease_from_global(lease))
+    activate_regional_quota_lease(store, lease, now=NOW + timedelta(seconds=2))
+    recovered = store.reconcile_regional_quota_leases(now=NOW + timedelta(seconds=3))
+    assert recovered["errors"] == 0
+    assert recovered["reconciled"] == 1
+
+
 def test_reconciler_cleans_stale_open_index_for_already_closed_lease() -> None:
     store, database, _ = make_fake_store(request_record_write_mode="typed")
     ledger = InMemoryRegionalQuotaLedger()


### PR DESCRIPTION
## Summary

- treat a live pending Spanner lease with no regional row as the valid two-phase initialization window
- leave expired and quarantined missing rows on the existing fail-closed recovery path
- add a regression test that reproduces the production race and proves initialization can finish normally

## Production root cause

Lease `rql-f32acff4d7674127b55521a5e41e572b` was created in Spanner at 00:52:01.927Z. The reconciler inspected it about one second later, before the Bigtable initialization write and global activation completed. It incorrectly passed the live pending lease to the expired-quarantine recovery function and exited with `regional lease row is missing`. The lease then initialized, served 10 microdollars of usage, and closed cleanly at 00:54:59Z, so no customer credit was lost or misbilled.

## Verification

- regression test failed against prior code with `errors=1`
- 26 regional quota and reconciler tests pass
- `uv run ruff check ...` passes
- `uv run mypy` passes