### PR TITLE
Pause disabled spend lease soak scheduler

### DIFF
--- a/scripts/deploy/synthetic.sh
+++ b/scripts/deploy/synthetic.sh
@@ -458,11 +458,54 @@ gc run jobs deploy "$spend_lease_job_name" \
   --memory 512Mi \
   --quiet >/dev/null
 
-upsert_scheduler \
-  "$spend_lease_scheduler_name" \
-  "$spend_lease_job_name" \
-  "$spend_lease_region" \
-  "* * * * *"
+if [ "$spend_lease_probe_enabled" = "true" ]; then
+  upsert_scheduler \
+    "$spend_lease_scheduler_name" \
+    "$spend_lease_job_name" \
+    "$spend_lease_region" \
+    "* * * * *"
+
+  # Updating a paused scheduler preserves its paused state. Enabling the
+  # probe must therefore explicitly resume a previously disabled schedule.
+  spend_lease_scheduler_state="$(
+    gc scheduler jobs describe "$spend_lease_scheduler_name" \
+      --location "$spend_lease_region" \
+      --format='value(state)'
+  )"
+  if [ "$spend_lease_scheduler_state" = "PAUSED" ]; then
+    gc scheduler jobs resume "$spend_lease_scheduler_name" \
+      --location "$spend_lease_region" \
+      --quiet >/dev/null
+  elif [ "$spend_lease_scheduler_state" != "ENABLED" ]; then
+    echo "ERROR: unexpected spend-lease scheduler state: ${spend_lease_scheduler_state:-empty}" >&2
+    exit 1
+  fi
+else
+  # A disabled probe must not keep launching a no-op container every minute.
+  # Besides wasting control-plane capacity, overlapping cold starts can emit
+  # Cloud Run startup failures even though the application never runs.
+  scheduler_error="$(mktemp "${TMPDIR:-/tmp}/spend-lease-scheduler.XXXXXX")"
+  if spend_lease_scheduler_state="$(
+    gc scheduler jobs describe "$spend_lease_scheduler_name" \
+      --location "$spend_lease_region" \
+      --format='value(state)' 2>"$scheduler_error"
+  )"; then
+    if [ "$spend_lease_scheduler_state" = "ENABLED" ]; then
+      gc scheduler jobs pause "$spend_lease_scheduler_name" \
+        --location "$spend_lease_region" \
+        --quiet >/dev/null
+    elif [ "$spend_lease_scheduler_state" != "PAUSED" ]; then
+      echo "ERROR: unexpected spend-lease scheduler state: ${spend_lease_scheduler_state:-empty}" >&2
+      rm -f "$scheduler_error"
+      exit 1
+    fi
+  elif ! grep -qE '(^|[[:space:]])NOT_FOUND([[:space:]:]|$)' "$scheduler_error"; then
+    cat "$scheduler_error" >&2
+    rm -f "$scheduler_error"
+    exit 1
+  fi
+  rm -f "$scheduler_error"
+fi
 
 # Image generation is materially more expensive than text PONG probes. Keep it
 # isolated and run one canonical end-to-end request every six hours.

--- a/scripts/deploy/synthetic_image_refresh.sh
+++ b/scripts/deploy/synthetic_image_refresh.sh
@@ -44,6 +44,8 @@ jobs=(
   "us-central1:trusted-router-video-generation-us-central1:worker"
 )
 
+spend_lease_probe_enabled=""
+
 for entry in "${jobs[@]}"; do
   IFS=: read -r job_region job_name job_kind <<<"$entry"
   before="$(gc run jobs describe "$job_name" --region "$job_region" --format=json)" || {
@@ -63,6 +65,18 @@ for entry in "${jobs[@]}"; do
   if [ "$surface" != "combined" ] || [ "$observer_secret_count" != "0" ]; then
     echo "ERROR: ${job_name} is not an approved pre-split combined job" >&2
     exit 1
+  fi
+
+  if [ "$job_name" = "trusted-router-spend-lease-soak-us-central1" ]; then
+    spend_lease_probe_enabled="$(jq -r '
+      [.spec.template.spec.template.spec.containers[0].env[]?
+        | select(.name == "TR_SPEND_LEASE_SOAK_PROBE_ENABLED") | .value][0] // "false"
+    ' <<<"$before")"
+    if [ "$spend_lease_probe_enabled" != "true" ] && \
+       [ "$spend_lease_probe_enabled" != "false" ]; then
+      echo "ERROR: ${job_name} has invalid TR_SPEND_LEASE_SOAK_PROBE_ENABLED=${spend_lease_probe_enabled}" >&2
+      exit 1
+    fi
   fi
 
   sensitive_before="$(jq -cS '{
@@ -101,4 +115,38 @@ for entry in "${jobs[@]}"; do
   fi
 done
 
-log "synthetic image refresh complete; no identities, networks, schedulers, or secrets changed"
+[ -n "$spend_lease_probe_enabled" ] || {
+  echo "ERROR: spend-lease soak job was not inspected" >&2
+  exit 1
+}
+
+# Keep scheduler state aligned with the inherited job configuration. A
+# disabled worker that exits immediately still consumes a Cloud Run execution
+# every minute and can emit platform startup failures during overlapping cold
+# starts. This is the only scheduler mutation allowed by the legacy image-only
+# refresh path.
+spend_lease_scheduler_name="trusted-router-spend-lease-soak-us-central1-every-minute"
+spend_lease_scheduler_state="$(
+  gc scheduler jobs describe "$spend_lease_scheduler_name" \
+    --location us-central1 \
+    --format='value(state)'
+)"
+if [ "$spend_lease_probe_enabled" = "true" ]; then
+  if [ "$spend_lease_scheduler_state" = "PAUSED" ]; then
+    gc scheduler jobs resume "$spend_lease_scheduler_name" \
+      --location us-central1 \
+      --quiet >/dev/null
+  elif [ "$spend_lease_scheduler_state" != "ENABLED" ]; then
+    echo "ERROR: unexpected spend-lease scheduler state: ${spend_lease_scheduler_state:-empty}" >&2
+    exit 1
+  fi
+elif [ "$spend_lease_scheduler_state" = "ENABLED" ]; then
+  gc scheduler jobs pause "$spend_lease_scheduler_name" \
+    --location us-central1 \
+    --quiet >/dev/null
+elif [ "$spend_lease_scheduler_state" != "PAUSED" ]; then
+  echo "ERROR: unexpected spend-lease scheduler state: ${spend_lease_scheduler_state:-empty}" >&2
+  exit 1
+fi
+
+log "synthetic image refresh complete; identities, networks, and secrets unchanged"

--- a/tests/deploy_script_harness.py
+++ b/tests/deploy_script_harness.py
@@ -891,6 +891,10 @@ _SYNTHETIC_COMBINED_JOB_JSON = json.dumps(
                                             "value": "combined",
                                         },
                                         {
+                                            "name": "TR_SPEND_LEASE_SOAK_PROBE_ENABLED",
+                                            "value": "false",
+                                        },
+                                        {
                                             "name": "TR_INTERNAL_GATEWAY_TOKEN",
                                             "valueFrom": {
                                                 "secretKeyRef": {
@@ -1575,6 +1579,7 @@ SCRIPT_FIXTURES: dict[str, ScriptFixture] = {
     "scripts/deploy/synthetic.sh": ScriptFixture(
         env={"TR_BILLING_SERVICE": "trusted-router-billing"},
         responses=(
+            (r"scheduler jobs describe .*spend-lease-soak", "ENABLED"),
             (
                 r"run services describe trusted-router-billing.*--format=json",
                 _SYNTHETIC_INGEST_SERVICE_JSON,
@@ -1597,6 +1602,7 @@ SCRIPT_FIXTURES: dict[str, ScriptFixture] = {
         },
         responses=(
             (r"run jobs describe .*--format=json", _SYNTHETIC_COMBINED_JOB_JSON),
+            (r"scheduler jobs describe .*spend-lease-soak", "ENABLED"),
         ),
     ),
 }

--- a/tests/test_deploy_script_execution.py
+++ b/tests/test_deploy_script_execution.py
@@ -1795,6 +1795,9 @@ def test_synthetic_jobs_execute_private_ingress_preflight_in_their_own_region(
     run = isolated.run("scripts/deploy/synthetic.sh", verifier_rc=0)
 
     assert run.returncode == 0, summarise(run)
+    scheduler_pauses = _gcloud_calls(run, "scheduler", "jobs", "pause")
+    assert len(scheduler_pauses) == 1
+    assert "trusted-router-spend-lease-soak-us-central1-every-minute" in scheduler_pauses[0]
     deploys = [
         (index, call)
         for index, call in enumerate(run.calls)
@@ -1955,6 +1958,49 @@ def test_combined_synthetic_refresh_preserves_security_boundaries(tmp_path: Path
             "TR_SYNTHETIC_CONTROL_PLANE_HEALTH_URL=https://trustedrouter.com"
             in " ".join(update)
         )
+    scheduler_pauses = _gcloud_calls(run, "scheduler", "jobs", "pause")
+    assert len(scheduler_pauses) == 1
+    assert "trusted-router-spend-lease-soak-us-central1-every-minute" in scheduler_pauses[0]
+    assert not _gcloud_calls(run, "scheduler", "jobs", "resume")
+
+
+def test_combined_synthetic_refresh_resumes_enabled_spend_lease_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    script = "scripts/deploy/synthetic_image_refresh.sh"
+    fixture = SCRIPT_FIXTURES[script]
+    job_json = json.loads(fixture.responses[0][1])
+    env = job_json["spec"]["template"]["spec"]["template"]["spec"]["containers"][0][
+        "env"
+    ]
+    next(
+        item for item in env if item["name"] == "TR_SPEND_LEASE_SOAK_PROBE_ENABLED"
+    )["value"] = "true"
+    monkeypatch.setitem(
+        SCRIPT_FIXTURES,
+        script,
+        replace(
+            fixture,
+            responses=(
+                (fixture.responses[0][0], json.dumps(job_json)),
+                (fixture.responses[1][0], "PAUSED"),
+            ),
+        ),
+    )
+    isolated = DeployScriptHarness(tmp_path / "synthetic-image-refresh-enabled-soak")
+
+    run = isolated.run(
+        script,
+        verifier_rc=0,
+        omit_env=("TR_BILLING_SERVICE", "TR_ALLOW_DEPLOYED_COMBINED_SURFACE"),
+    )
+
+    assert run.returncode == 0, summarise(run)
+    scheduler_resumes = _gcloud_calls(run, "scheduler", "jobs", "resume")
+    assert len(scheduler_resumes) == 1
+    assert "trusted-router-spend-lease-soak-us-central1-every-minute" in scheduler_resumes[0]
+    assert not _gcloud_calls(run, "scheduler", "jobs", "pause")
 
 
 def test_combined_synthetic_refresh_is_a_visible_release_gate() -> None:

--- a/tests/test_spend_lease_soak_probe.py
+++ b/tests/test_spend_lease_soak_probe.py
@@ -161,7 +161,7 @@ async def test_spend_lease_soak_job_loads_named_key_and_ingests_sample(
     assert ingested[0]["samples"][0]["probe_type"] == "spend_lease_soak"
 
 
-def test_spend_lease_soak_probe_is_registered_on_one_minute_schedule() -> None:
+def test_spend_lease_soak_probe_schedule_tracks_feature_flag() -> None:
     script = Path(__file__).resolve().parents[1] / "scripts/deploy/synthetic.sh"
     body = script.read_text()
     section = body.split("Stage A spend-lease soak", maxsplit=1)[1].split(
@@ -175,4 +175,7 @@ def test_spend_lease_soak_probe_is_registered_on_one_minute_schedule() -> None:
     assert '"TR_SPEND_LEASE_SOAK_PROBE_ENABLED=${spend_lease_probe_enabled}"' in section
     assert '"TR_SPEND_LEASE_PROBE_KEY_SECRET=${spend_lease_probe_key_secret}"' in section
     assert '"* * * * *"' in section
+    assert 'if [ "$spend_lease_probe_enabled" = "true" ]' in section
+    assert 'scheduler jobs pause "$spend_lease_scheduler_name"' in section
+    assert 'scheduler jobs resume "$spend_lease_scheduler_name"' in section
     assert "--max-retries 0" in section


### PR DESCRIPTION
## Summary
- stop scheduling the spend-lease soak while its feature flag is disabled
- keep scheduler state aligned during legacy image-only refreshes
- resume the scheduler explicitly when the probe is enabled

## Root cause
The disabled job still ran every minute. Cloud Run cold starts overlapped for up to two minutes, and one platform process start failed even though adjacent identical no-op executions succeeded.

## Verification
- `uv run pytest -q tests/test_spend_lease_soak_probe.py tests/test_deploy_script_execution.py -k "spend_lease or combined_synthetic_refresh or synthetic_jobs_execute_private_ingress"`
- `uv run ruff check tests/deploy_script_harness.py tests/test_deploy_script_execution.py tests/test_spend_lease_soak_probe.py`
- `bash -n scripts/deploy/synthetic.sh scripts/deploy/synthetic_image_refresh.sh`
- production scheduler paused immediately