### PR TITLE
Retire Wafer GLM 5.2 at the announced cutoff

### DIFF
--- a/src/trusted_router/data/provider_models/wafer.json
+++ b/src/trusted_router/data/provider_models/wafer.json
@@ -80,7 +80,8 @@
       "output_token_price_per_m": 3960000,
       "zdr_supported": true,
       "context_length": 1048576,
-      "cached_input_token_price_per_m": 230000
+      "cached_input_token_price_per_m": 230000,
+      "retirement_at": "2026-09-05T06:59:00Z"
     },
     {
       "id": "z-ai/glm-5.2-fast",

--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -32,6 +32,7 @@ FRIENDLI_QWEN3_235B_RETIREMENT_AT = datetime(2026, 8, 5, 0, 0, tzinfo=UTC)
 FRIENDLI_K_EXAONE_236B_RETIREMENT_AT = datetime(2026, 8, 20, 0, 0, tzinfo=UTC)
 CRUSOE_NEMOTRON_3_ULTRA_RETIREMENT_AT = datetime(2026, 7, 28, 18, 0, tzinfo=UTC)
 WAFER_AUGUST_2026_RETIREMENT_AT = datetime(2026, 8, 17, 0, 0, tzinfo=UTC)
+WAFER_GLM52_RETIREMENT_AT = datetime(2026, 9, 5, 6, 59, tzinfo=UTC)
 DEEPINFRA_TERMINUS_RETIREMENT_AT = datetime(2026, 8, 17, 0, 0, tzinfo=UTC)
 DEEPINFRA_QWEN3_235B_THINKING_RETIREMENT_AT = datetime(
     2026, 8, 24, 0, 0, tzinfo=UTC
@@ -386,6 +387,16 @@ _RETIREMENTS = (
             }
         ),
         effective_at=WAFER_AUGUST_2026_RETIREMENT_AT,
+    ),
+    # Wafer announced that standard GLM 5.2 retires from Serverless on Friday,
+    # 2026-09-04 at 23:59 Pacific. Pacific daylight time is UTC-7 on that date,
+    # so the exact announced cutoff is 2026-09-05 06:59 UTC. Retire only the
+    # Wafer route; equivalent GLM 5.2 routes on other providers are unaffected.
+    _Retirement(
+        provider="wafer",
+        model_ids=frozenset({"z-ai/glm-5.2"}),
+        upstream_ids=frozenset({"GLM-5.2"}),
+        effective_at=WAFER_GLM52_RETIREMENT_AT,
     ),
     # Crusoe announced that Nemotron 3 Ultra retires from its Serverless
     # offering at 2026-07-28 11:00 PT, which is 2026-07-28 18:00 UTC.

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -2207,7 +2207,6 @@ def test_wafer_kimi_k26_is_available_but_standard_tier_only() -> None:
 @pytest.mark.parametrize(
     "endpoint_id",
     [
-        "z-ai/glm-5.2@wafer/prepaid",
         "moonshotai/kimi-k3@wafer/prepaid",
         # moonshotai/kimi-k3-fast@wafer/prepaid retired 2026-08-17 00:00 UTC
         # (provider_lifecycle WAFER_AUGUST_2026_RETIREMENT_AT); the catalog is
@@ -2247,7 +2246,6 @@ def test_glm_52_supplements_publish_current_model_across_providers() -> None:
     parasail = MODEL_ENDPOINTS["z-ai/glm-5.2@parasail/prepaid"]
     friendli = MODEL_ENDPOINTS["z-ai/glm-5.2@friendli/prepaid"]
     baseten = MODEL_ENDPOINTS["z-ai/glm-5.2@baseten/prepaid"]
-    wafer = MODEL_ENDPOINTS["z-ai/glm-5.2@wafer/prepaid"]
 
     assert model.provider == "zai"
     assert model.context_length == 1_048_576
@@ -2267,14 +2265,12 @@ def test_glm_52_supplements_publish_current_model_across_providers() -> None:
     assert parasail.upstream_id == "parasail-glm-52"
     assert friendli.upstream_id == "zai-org/GLM-5.2"
     assert baseten.upstream_id == "zai-org/GLM-5.2"
-    assert wafer.upstream_id == "GLM-5.2"
     for endpoint in (
         deepinfra,
         fireworks,
         novita,
         friendli,
         baseten,
-        wafer,
     ):
         assert endpoint.prompt_price_microdollars_per_million_tokens > 0
         assert endpoint.completion_price_microdollars_per_million_tokens > 0

--- a/tests/test_wafer_august_2026_lifecycle.py
+++ b/tests/test_wafer_august_2026_lifecycle.py
@@ -62,10 +62,6 @@ def test_wafer_retirements_are_provider_scoped(
             at=_CUTOFF,
         )
 
-    for model_id in _REPLACEMENTS:
-        providers = {endpoint.provider for endpoint in endpoints_for_model(model_id)}
-        assert "wafer" in providers
-
 
 def test_hourly_refresh_cannot_restore_retired_wafer_routes(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_wafer_september_2026_lifecycle.py
+++ b/tests/test_wafer_september_2026_lifecycle.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from scripts.pricing import refresh
+from scripts.pricing.base import ModelPrice, ProviderPricingResult
+from scripts.pricing.providers import wafer
+from trusted_router import provider_lifecycle
+from trusted_router.catalog import endpoints_for_model
+
+_CUTOFF = datetime(2026, 9, 5, 6, 59, tzinfo=UTC)
+_MODEL_ID = "z-ai/glm-5.2"
+_UPSTREAM_ID = "GLM-5.2"
+
+
+def test_wafer_glm52_retires_at_announced_pacific_cutoff() -> None:
+    assert not provider_lifecycle.provider_model_retired(
+        "wafer",
+        _MODEL_ID,
+        _UPSTREAM_ID,
+        at=_CUTOFF - timedelta(microseconds=1),
+    )
+    assert provider_lifecycle.provider_model_retired(
+        "wafer",
+        _MODEL_ID,
+        _UPSTREAM_ID,
+        at=_CUTOFF,
+    )
+
+
+def test_wafer_glm52_retirement_is_provider_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+
+    providers = {endpoint.provider for endpoint in endpoints_for_model(_MODEL_ID)}
+    assert "wafer" not in providers
+    assert providers
+    assert not provider_lifecycle.provider_model_retired(
+        "another-provider",
+        _MODEL_ID,
+        _UPSTREAM_ID,
+        at=_CUTOFF,
+    )
+
+
+def test_hourly_refresh_cannot_restore_retired_wafer_glm52(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = ProviderPricingResult(
+        slug="wafer",
+        prices={_MODEL_ID: ModelPrice(1_260_000, 3_960_000)},
+        source="api",
+        fetched_url=wafer.URL,
+    )
+
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF - timedelta(microseconds=1),
+    )
+    assert refresh._index_provider_prices({"wafer": result})[_MODEL_ID]["wafer"]
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    assert _MODEL_ID not in refresh._index_provider_prices({"wafer": result})
+
+
+def test_wafer_parser_filters_glm52_from_stale_feed_after_cutoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def row(native_id: str) -> dict[str, object]:
+        return {
+            "id": native_id,
+            "wafer": {
+                "pricing": {
+                    "input_cents_per_million": 126,
+                    "output_cents_per_million": 396,
+                }
+            },
+        }
+
+    payload = {
+        "data": [
+            row(_UPSTREAM_ID),
+            row("Kimi-K2.6"),
+        ]
+    }
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return payload
+
+    class FakeClient:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def get(self, *_args: object, **_kwargs: object) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setattr(wafer.httpx, "Client", FakeClient)
+
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF - timedelta(microseconds=1),
+    )
+    assert _MODEL_ID in wafer.fetch().prices
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    after = wafer.fetch()
+    assert _MODEL_ID not in after.prices
+    assert "moonshotai/kimi-k2.6" in after.prices
+    assert _MODEL_ID not in wafer._DISCOVERED_MANIFEST_ROWS
+
+
+def test_wafer_manifest_records_glm52_retirement() -> None:
+    rows = {
+        row["id"]: row
+        for row in json.loads(wafer.MANIFEST_PATH.read_text())["models"]
+    }
+
+    assert rows[_MODEL_ID]["retirement_at"] == "2026-09-05T06:59:00Z"


### PR DESCRIPTION
## Summary
- retire only the Wafer Serverless route for `z-ai/glm-5.2` at 2026-09-05 06:59 UTC (September 4 11:59 p.m. PDT)
- preserve GLM 5.2 routes from every other provider
- prevent stale Wafer discovery and hourly pricing feeds from restoring the route after cutoff
- record the effective retirement in the provider manifest and remove timeless endpoint assumptions from tests

## Validation
- 243 focused lifecycle/catalog/API/refresh tests pass at the current clock
- 243 focused tests pass with the lifecycle clock advanced beyond all scheduled cutovers
- full suite: 7,783 passed before sandbox-localhost failures; all 154 affected socket tests pass outside the sandbox
- Ruff and `git diff --check` pass