### PR TITLE
Isolate monitor stalls from billing capacity

### DIFF
--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -1088,6 +1088,11 @@ class Settings(BaseSettings):
     # waves; adding the normal 10-17s probe work gives ~97s. 240s is ~2.47x
     # that budget while ensuring a wedged read cannot own the run slot forever.
     synthetic_run_deadline_seconds: float = 240.0
+    # Remediation is an observe-only monitor read running through an internal
+    # HTTP surface during the service split. Keep its request budget far below
+    # the general synthetic pass budget so an unavailable analytics replica
+    # cannot occupy control-plane request capacity for minutes.
+    synthetic_remediator_deadline_seconds: float = 15.0
     # Monthly self-funding for the monitor workspace, applied lazily on its
     # own gateway-authorize path (synthetic/funding.py). Each deployment has
     # its own database, so each cloud's monitor funds itself from config —
@@ -1226,6 +1231,8 @@ class Settings(BaseSettings):
             raise ValueError("TR_MAX_REQUEST_BODY_BYTES must be positive")
         if self.synthetic_run_deadline_seconds <= 0:
             raise ValueError("TR_SYNTHETIC_RUN_DEADLINE_SECONDS must be positive")
+        if self.synthetic_remediator_deadline_seconds <= 0:
+            raise ValueError("TR_SYNTHETIC_REMEDIATOR_DEADLINE_SECONDS must be positive")
         if self.max_in_flight_request_body_bytes < self.max_request_body_bytes:
             raise ValueError(
                 "TR_MAX_IN_FLIGHT_REQUEST_BODY_BYTES must be at least TR_MAX_REQUEST_BODY_BYTES"

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -209,6 +209,10 @@ REQUEST_METADATA_VERSION = 1
 # transaction layer's 20-second retry budget while leaving five seconds for this
 # process to serialize a structured retryable 503 and for network transit.
 _BILLING_PATH_SPANNER_BUDGET_SECONDS = 20.0
+# Spend-lease shadow rows are non-authoritative rollout evidence. They must
+# never consume the paid authorize path's full Spanner budget when their
+# separate outbox transaction stalls.
+_SPEND_LEASE_SHADOW_SPANNER_BUDGET_SECONDS = 0.5
 _AUTHORIZE_ADMISSION = KeyedConcurrencyAdmission()
 # Process-local harm limitation: this keeps one key from exhausting this
 # instance's Spanner session pool. It cannot stop a fleet-wide settle convoy;
@@ -474,6 +478,7 @@ def _authorize_gateway_sync(
     return response
 
 
+@spanner_rpc_budget(_SPEND_LEASE_SHADOW_SPANNER_BUDGET_SECONDS)
 def _record_spend_lease_shadow(
     context: dict[str, Any],
     *,

--- a/src/trusted_router/routes/internal/synthetic.py
+++ b/src/trusted_router/routes/internal/synthetic.py
@@ -6,6 +6,7 @@ import logging
 import random
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict
 from typing import Any
 
@@ -64,17 +65,20 @@ _OPERATION_SLOTS = {
     "run": threading.BoundedSemaphore(1),
 }
 _BACKGROUND_RUNS: set[asyncio.Task[dict[str, Any]]] = set()
+_REMEDIATOR_EXECUTOR = ThreadPoolExecutor(
+    max_workers=1,
+    thread_name_prefix="synthetic-remediator",
+)
 
 
 class _HeldOperationSlot:
     """A semaphore admission that can cross an unkillable worker thread.
 
     Async run tasks release their raw BoundedSemaphore in ``finally``. A
-    remediator pass is different: cancelling the threadpool await cannot stop
-    the worker. This lease lets the deadline owner free capacity immediately
-    while making the worker's eventual ``finally`` a no-op instead of an
-    over-release. The underlying semaphore remains bounded as the guard on
-    every real release.
+    remediator pass is different: cancelling the executor await cannot stop
+    the worker. This lease lets the HTTP request return at its deadline while
+    the worker retains admission until its eventual ``finally``. The
+    underlying semaphore remains bounded as the guard on every real release.
     """
 
     def __init__(self, semaphore: threading.BoundedSemaphore) -> None:
@@ -356,21 +360,43 @@ def _run_remediator_with_held_slot(
         slot.release()
 
 
+def _run_remediator_worker(
+    settings: Settings,
+    slot: _HeldOperationSlot,
+    started: threading.Event,
+) -> int:
+    started.set()
+    return _run_remediator_with_held_slot(settings, slot)
+
+
 async def _run_remediator_with_deadline(
     settings: Settings,
     slot: _HeldOperationSlot,
 ) -> int:
     started = time.monotonic()
+    worker_started = threading.Event()
+    loop = asyncio.get_running_loop()
+    worker = loop.run_in_executor(
+        _REMEDIATOR_EXECUTOR,
+        _run_remediator_worker,
+        settings,
+        slot,
+        worker_started,
+    )
     try:
         return await asyncio.wait_for(
-            run_in_threadpool(_run_remediator_with_held_slot, settings, slot),
-            timeout=settings.synthetic_run_deadline_seconds,
+            asyncio.shield(worker),
+            timeout=settings.synthetic_remediator_deadline_seconds,
         )
     except TimeoutError:
-        # The worker thread cannot be killed. Relinquish its admission now;
-        # its own finally calls release() too, but the lease makes that late
-        # call a no-op rather than a BoundedSemaphore over-release.
-        slot.release()
+        # The worker thread cannot be killed. Abandon the await so this HTTP
+        # request releases Cloud Run concurrency immediately, but leave the
+        # process-local admission with the live worker until it actually exits.
+        # This prevents each scheduler tick from piling another blocked reader
+        # onto the same process. If cancellation won before the worker started,
+        # nobody else can own the admission, so release it here.
+        if not worker_started.is_set():
+            slot.release()
         log.error(
             "synthetic.remediator_deadline_exceeded elapsed_seconds=%.3f",
             time.monotonic() - started,

--- a/tests/test_billing_path_rpc_budget.py
+++ b/tests/test_billing_path_rpc_budget.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 from trusted_router.routes.internal.gateway import (
     _BILLING_PATH_SPANNER_BUDGET_SECONDS,
+    _SPEND_LEASE_SHADOW_SPANNER_BUDGET_SECONDS,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -37,6 +38,7 @@ BILLING_PATH_FUNCTIONS = frozenset(
 )
 
 _BUDGET = "spanner_rpc_budget(_BILLING_PATH_SPANNER_BUDGET_SECONDS)"
+_SHADOW_BUDGET = "spanner_rpc_budget(_SPEND_LEASE_SHADOW_SPANNER_BUDGET_SECONDS)"
 
 
 def _functions_carrying_the_budget() -> frozenset[str]:
@@ -80,3 +82,19 @@ def test_billing_budget_finishes_before_enclave_header_timeout() -> None:
     """The enclave's direct control-plane client has a 25-second header cap."""
 
     assert _BILLING_PATH_SPANNER_BUDGET_SECONDS == 20.0
+
+
+def test_non_authoritative_spend_shadow_has_its_own_subsecond_budget() -> None:
+    """A stalled shadow outbox must not spend the paid request's 20s budget."""
+
+    tree = ast.parse(GATEWAY.read_text(encoding="utf-8"))
+    shadow_functions = {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        for decorator in node.decorator_list
+        if ast.unparse(decorator) == _SHADOW_BUDGET
+    }
+
+    assert shadow_functions == {"_record_spend_lease_shadow"}
+    assert _SPEND_LEASE_SHADOW_SPANNER_BUDGET_SECONDS == 0.5

--- a/tests/test_synthetic_admission.py
+++ b/tests/test_synthetic_admission.py
@@ -207,17 +207,19 @@ def test_synchronous_run_deadline_releases_slot(
         assert recovered.status_code == 200
 
 
-def test_remediator_deadline_releases_slot_before_worker_exits(
+def test_remediator_deadline_keeps_slot_until_abandoned_worker_exits(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     started = threading.Event()
     release = threading.Event()
     calls = 0
+    worker_names: list[str] = []
 
     def first_call_blocks(_settings: Settings) -> list[object]:
         nonlocal calls
         calls += 1
+        worker_names.append(threading.current_thread().name)
         if calls == 1:
             started.set()
             release.wait()
@@ -226,16 +228,19 @@ def test_remediator_deadline_releases_slot_before_worker_exits(
     monkeypatch.setattr(synthetic_routes, "run_remediator_pass", first_call_blocks)
     settings = Settings(
         environment="test",
-        synthetic_run_deadline_seconds=0.2,
+        synthetic_remediator_deadline_seconds=0.2,
     )
     try:
         with caplog.at_level("ERROR"):
             assert asyncio.run(synthetic_routes._run_scheduled_remediator_pass(settings)) is None  # noqa: SLF001
         assert started.is_set()
+        assert worker_names == ["synthetic-remediator_0"]
 
-        # The timed-out worker is still alive, but its lease no longer blocks
-        # a fresh remediation pass.
-        assert asyncio.run(synthetic_routes._run_scheduled_remediator_pass(settings)) == 0  # noqa: SLF001
+        # The request has returned, but the timed-out worker retains the slot
+        # until it exits. A scheduler retry therefore cannot pile up another
+        # blocked analytics reader on this process.
+        assert asyncio.run(synthetic_routes._run_scheduled_remediator_pass(settings)) is None  # noqa: SLF001
+        assert calls == 1
     finally:
         release.set()
 
@@ -243,7 +248,14 @@ def test_remediator_deadline_releases_slot_before_worker_exits(
         record.getMessage().startswith("synthetic.remediator_deadline_exceeded")
         for record in caplog.records
     )
-    time.sleep(0.05)
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        if asyncio.run(synthetic_routes._run_scheduled_remediator_pass(settings)) == 0:  # noqa: SLF001
+            break
+        time.sleep(0.02)
+    else:
+        pytest.fail("remediator admission was not released after the worker exited")
+    assert calls == 2
     semaphore = synthetic_routes._OPERATION_SLOTS["remediate"]  # noqa: SLF001
     assert semaphore.acquire(blocking=False)
     assert not semaphore.acquire(blocking=False)


### PR DESCRIPTION
## Incident\nAt 2026-09-01 14:41 UTC, one control-plane instance returned ten 503s while a remediator request held one of its two Cloud Run concurrency slots for 107s and four non-authoritative spend-shadow Spanner writes consumed the remaining billing-path budget.\n\n## Fix\n- Give spend-lease shadow outbox writes a nested 500ms Spanner budget. Core authorize state remains on the existing 20s budget.\n- Give remediator requests a dedicated 15s deadline.\n- Abandon the HTTP wait on timeout while retaining process-local single-flight admission until the worker actually exits.\n- Run remediator blocking work outside the shared Starlette request threadpool.\n\n## Verification\n- 193 focused billing, Spanner deadline, spend-lease, and synthetic tests pass.\n- Ruff and mypy pass for all changed source files.\n- Regression tests pin both timeout contracts.