### PR TITLE
Expose Cloud Build failure details

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -180,6 +180,10 @@ jobs:
                   docker push "${_CACHE_IMAGE}"
           options:
             machineType: E2_HIGHCPU_8
+            # Keep builder output in Cloud Logging so the read-only ops
+            # identity can diagnose a failed build without broad project
+            # Viewer permissions or access to the source staging bucket.
+            logging: CLOUD_LOGGING_ONLY
           EOF
           BUILD_ID=$(gcloud builds submit \
             --config=/tmp/cloudbuild-control-plane.yaml \
@@ -197,7 +201,13 @@ jobs:
             echo "  status: ${STATUS}"
             case "${STATUS}" in
               SUCCESS) break ;;
-              FAILURE|TIMEOUT|CANCELLED|EXPIRED) echo "build ${STATUS}"; exit 1 ;;
+              FAILURE|TIMEOUT|CANCELLED|EXPIRED)
+                echo "build ${STATUS}"
+                gcloud builds describe "${BUILD_ID}" \
+                  --project="${PROJECT_ID}" --region="${REGION}" \
+                  --format='yaml(id,status,statusDetail,failureInfo,steps)'
+                exit 1
+                ;;
             esac
             sleep 5
           done


### PR DESCRIPTION
## Summary
- retain Cloud Build step output in Cloud Logging for read-only incident response
- print status details, failure metadata, and per-step results when an asynchronous build fails

## Verification
- `git diff --check`
- parsed `.github/workflows/deploy.yml` with PyYAML
- reproduced the current application image successfully with a local Docker build

## Incident context
Two production deploy attempts for `b282f9c3` failed inside Cloud Build before any image or traffic change. Existing polling exposed only `FAILURE`, leaving the actual builder step opaque.
