### PR TITLE
Prevent quota reconciler initializer overlap

### DIFF
--- a/docs/design/regional-quota-leases.md
+++ b/docs/design/regional-quota-leases.md
@@ -150,9 +150,13 @@ issued even after operators disable the serving feature, so a kill switch
 cannot strand globally reserved credit. Cloud Scheduler invokes the job with
 Google OAuth; the deploy identity never reads the internal gateway token. A
 new version must complete a real Spanner read and a Bigtable data read through
-every fixed app profile before the stable schedule points to it. Executions
-have no task or scheduler retry and a 50-second deadline under the one-minute
-cadence, preventing retry-driven overlap. Clean runs publish the
+every fixed app profile before the stable schedule points to it. A private GCS
+generation-guarded admission lease runs before importing Sentry, Spanner, or
+Bigtable. Cloud Scheduler's `jobs:run` request completes when Cloud Run accepts
+an execution, so a slow execution can overlap the next one-minute tick even
+though Scheduler itself has no outstanding request. Overlaps exit before
+opening database clients; the admitted worker then takes the existing Spanner
+fencing lock before reconciliation. Clean runs publish the
 `job:regional-quota-reconcile` heartbeat; failures reach Cloud Logging and
 Sentry.
 

--- a/scripts/deploy/regional_quota_reconciler.sh
+++ b/scripts/deploy/regional_quota_reconciler.sh
@@ -16,6 +16,8 @@ RELEASE="$(git rev-parse --short HEAD 2>/dev/null || echo local)"
 JOB_PREFIX="${TR_REGIONAL_QUOTA_RECONCILER_JOB_PREFIX:-trusted-router-regional-quota-reconciler}"
 JOB_NAME="${TR_REGIONAL_QUOTA_RECONCILER_JOB:-${JOB_PREFIX}-${RELEASE}}"
 RECONCILE_LIMIT="${TR_REGIONAL_QUOTA_RECONCILE_LIMIT:-25}"
+LOCK_BUCKET="${TR_REGIONAL_QUOTA_RECONCILER_LOCK_BUCKET:-${PROJECT_ID}-regional-quota-reconciler-state}"
+LOCK_OBJECT="${TR_REGIONAL_QUOTA_RECONCILER_LOCK_OBJECT:-regional-quota-reconciler/singleflight.json}"
 scheduler_state=""
 scheduler_exists=false
 scheduler_describe_stderr="$(mktemp "${TMPDIR:-/tmp}/regional-quota-scheduler-describe.XXXXXX")"
@@ -50,6 +52,33 @@ if ! gc artifacts docker images describe "$IMAGE" >/dev/null 2>&1; then
   exit 1
 fi
 
+# Cloud Scheduler considers jobs:run complete once Cloud Run accepts an
+# execution, not when that execution exits. A slow minute can therefore overlap
+# the next minute. The Spanner fencing lock is intentionally authoritative for
+# reconciliation, but it is acquired after expensive client initialization and
+# cannot prevent an initializer herd. This private GCS object admits one worker
+# before application imports; generation preconditions make acquisition atomic.
+if ! gc storage buckets describe "gs://${LOCK_BUCKET}" >/dev/null 2>&1; then
+  gc storage buckets create "gs://${LOCK_BUCKET}" \
+    --location="${JOB_REGION}" \
+    --default-storage-class=STANDARD \
+    --uniform-bucket-level-access \
+    --public-access-prevention \
+    --soft-delete-duration=0 \
+    --quiet >/dev/null
+fi
+gc storage buckets update "gs://${LOCK_BUCKET}" \
+  --uniform-bucket-level-access \
+  --public-access-prevention \
+  --no-versioning \
+  --clear-soft-delete \
+  --quiet >/dev/null
+gc storage buckets add-iam-policy-binding "gs://${LOCK_BUCKET}" \
+  --member="serviceAccount:${RUN_SERVICE_ACCOUNT}" \
+  --role=roles/storage.objectUser \
+  --condition=None \
+  --quiet >/dev/null
+
 env_vars=(
   "TR_ENVIRONMENT=worker"
   # The one-shot CLI initializes Sentry and reconciles account-ledger storage,
@@ -74,6 +103,11 @@ env_vars=(
   "TR_REGIONAL_QUOTA_BIGTABLE_TABLE=${TR_REGIONAL_QUOTA_BIGTABLE_TABLE:-trustedrouter-regional-quota}"
   "TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES=${TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES}"
   "TR_REGIONAL_QUOTA_RECONCILE_LIMIT=${RECONCILE_LIMIT}"
+  "TR_REGIONAL_QUOTA_RECONCILER_LOCK_BUCKET=${LOCK_BUCKET}"
+  "TR_REGIONAL_QUOTA_RECONCILER_LOCK_OBJECT=${LOCK_OBJECT}"
+  "TR_REGIONAL_QUOTA_RECONCILER_LOCK_LEASE_SECONDS=240"
+  "TR_REGIONAL_QUOTA_RECONCILER_MIN_INTERVAL_SECONDS=50"
+  "TR_REGIONAL_QUOTA_RECONCILER_FAILURE_COOLDOWN_SECONDS=30"
   "TR_PRIMARY_REGION=${TR_PRIMARY_REGION}"
   "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true"
 )
@@ -110,7 +144,7 @@ gc run jobs "$job_mutation" "$JOB_NAME" \
   --region "$JOB_REGION" \
   --image "$IMAGE" \
   --command="/app/.venv/bin/python" \
-  --args="-m,trusted_router.regional_quota_reconcile_cli" \
+  --args="-m,trusted_router.regional_quota_reconcile_gate" \
   --service-account "$RUN_SERVICE_ACCOUNT" \
   --set-env-vars "$set_env_vars" \
   --update-secrets "TR_SENTRY_DSN=trustedrouter-sentry-dsn:latest" \

--- a/src/trusted_router/gcs_singleflight.py
+++ b/src/trusted_router/gcs_singleflight.py
@@ -1,0 +1,260 @@
+"""Small GCS generation-guarded leases for one-shot worker admission.
+
+This module intentionally uses only the standard library. Workers import it
+before application configuration, Sentry, Spanner, or Bigtable so duplicate
+Cloud Run Job executions can leave without opening expensive clients.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from dataclasses import dataclass
+
+_METADATA_CREDENTIAL_URL = (
+    "http://metadata.google.internal/computeMetadata/v1/instance/"
+    "service-accounts/default/token"
+)
+_STORAGE_API = "https://storage.googleapis.com/storage/v1"
+_STORAGE_UPLOAD_API = "https://storage.googleapis.com/upload/storage/v1"
+
+
+@dataclass(frozen=True)
+class GCSLeaseConfig:
+    bucket: str
+    object_name: str
+    lease_seconds: float
+    min_interval_seconds: float
+    failure_cooldown_seconds: float
+    request_timeout_seconds: float = 10.0
+
+    def validate(self) -> None:
+        if not self.bucket:
+            raise ValueError("GCS lease bucket must not be empty")
+        if not self.object_name:
+            raise ValueError("GCS lease object name must not be empty")
+        if self.lease_seconds <= 0:
+            raise ValueError("GCS lease duration must be positive")
+        if self.min_interval_seconds < 0:
+            raise ValueError("GCS lease minimum interval must not be negative")
+        if self.failure_cooldown_seconds < 0:
+            raise ValueError("GCS lease failure cooldown must not be negative")
+        if self.request_timeout_seconds <= 0:
+            raise ValueError("GCS lease request timeout must be positive")
+
+
+@dataclass(frozen=True)
+class GCSLease:
+    owner: str
+    generation: int
+    acquired_at: float
+
+
+class GCSGenerationLease:
+    """Acquire and finish a lease using GCS object generation preconditions."""
+
+    def __init__(self, config: GCSLeaseConfig) -> None:
+        config.validate()
+        self._config = config
+
+    def acquire(
+        self,
+        *,
+        now: float | None = None,
+        owner: str | None = None,
+    ) -> GCSLease | None:
+        acquired_at = time.time() if now is None else now
+        lease_owner = owner or os.environ.get("CLOUD_RUN_EXECUTION") or (
+            f"manual-{os.getpid()}-{uuid.uuid4().hex}"
+        )
+        token = self._access_token()
+        for _attempt in range(3):
+            current = self._read(token)
+            if current is not None:
+                current_payload, current_generation = current
+                expires_at = current_payload["expires_at"]
+                if not isinstance(expires_at, (int, float)):
+                    raise RuntimeError("GCS lease payload has no numeric expiry")
+                if float(expires_at) > acquired_at:
+                    return None
+                if not self._delete(token, current_generation):
+                    continue
+
+            new_payload: dict[str, object] = {
+                "owner": lease_owner,
+                "state": "running",
+                "acquired_at": acquired_at,
+                "expires_at": acquired_at + self._config.lease_seconds,
+            }
+            new_generation = self._write(token, new_payload, if_generation_match=0)
+            if new_generation is not None:
+                return GCSLease(
+                    owner=lease_owner,
+                    generation=new_generation,
+                    acquired_at=acquired_at,
+                )
+        return None
+
+    def finish(
+        self,
+        lease: GCSLease,
+        *,
+        succeeded: bool,
+        now: float | None = None,
+    ) -> float:
+        completed_at = time.time() if now is None else now
+        expires_at = (
+            max(
+                completed_at,
+                lease.acquired_at + self._config.min_interval_seconds,
+            )
+            if succeeded
+            else completed_at + self._config.failure_cooldown_seconds
+        )
+        payload: dict[str, object] = {
+            "owner": lease.owner,
+            "state": "cooldown" if succeeded else "failed",
+            "acquired_at": lease.acquired_at,
+            "completed_at": completed_at,
+            "expires_at": expires_at,
+        }
+        token = self._access_token()
+        generation = self._write(
+            token,
+            payload,
+            if_generation_match=lease.generation,
+        )
+        if generation is None:
+            raise RuntimeError("GCS lease ownership changed before completion")
+        return max(0.0, expires_at - completed_at)
+
+    def _access_token(self) -> str:
+        request = urllib.request.Request(
+            _METADATA_CREDENTIAL_URL,
+            headers={"Metadata-Flavor": "Google"},
+        )
+        with urllib.request.urlopen(  # noqa: S310 - URL is the fixed metadata host.
+            request,
+            timeout=self._config.request_timeout_seconds,
+        ) as response:
+            payload = json.loads(response.read())
+        token = payload.get("access_token")
+        if not isinstance(token, str) or not token:
+            raise RuntimeError("metadata server returned no GCS access token")
+        return token
+
+    def _request(
+        self,
+        url: str,
+        *,
+        token: str,
+        method: str = "GET",
+        body: bytes | None = None,
+    ) -> tuple[int, bytes]:
+        headers = {"Authorization": f"Bearer {token}"}
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+        if not url.startswith((_STORAGE_API, _STORAGE_UPLOAD_API)):
+            raise ValueError("GCS lease requests must target the Google Storage API")
+        request = urllib.request.Request(  # noqa: S310 - host is allowlisted above.
+            url,
+            data=body,
+            headers=headers,
+            method=method,
+        )
+        try:
+            with urllib.request.urlopen(  # noqa: S310 - host is allowlisted above.
+                request,
+                timeout=self._config.request_timeout_seconds,
+            ) as response:
+                return int(response.status), response.read()
+        except urllib.error.HTTPError as exc:
+            return exc.code, exc.read()
+
+    def _object_url(
+        self,
+        *,
+        media: bool = False,
+        generation: int | None = None,
+    ) -> str:
+        bucket = urllib.parse.quote(self._config.bucket, safe="")
+        name = urllib.parse.quote(self._config.object_name, safe="")
+        query: dict[str, str] = {}
+        if media:
+            query["alt"] = "media"
+        if generation is not None:
+            query["generation"] = str(generation)
+        suffix = "?" + urllib.parse.urlencode(query) if query else ""
+        return f"{_STORAGE_API}/b/{bucket}/o/{name}{suffix}"
+
+    def _read(self, token: str) -> tuple[dict[str, object], int] | None:
+        status, raw_metadata = self._request(self._object_url(), token=token)
+        if status == 404:
+            return None
+        if status != 200:
+            raise RuntimeError(f"GCS lease metadata read failed with HTTP {status}")
+        metadata = json.loads(raw_metadata)
+        generation = int(metadata["generation"])
+        status, raw_payload = self._request(
+            self._object_url(media=True, generation=generation),
+            token=token,
+        )
+        if status in {404, 412}:
+            return None
+        if status != 200:
+            raise RuntimeError(f"GCS lease payload read failed with HTTP {status}")
+        payload = json.loads(raw_payload)
+        if not isinstance(payload, dict):
+            raise RuntimeError("GCS lease payload must be a JSON object")
+        owner = payload.get("owner")
+        expires_at = payload.get("expires_at")
+        if not isinstance(owner, str) or not owner:
+            raise RuntimeError("GCS lease payload has no owner")
+        if not isinstance(expires_at, (int, float)):
+            raise RuntimeError("GCS lease payload has no numeric expiry")
+        return payload, generation
+
+    def _write(
+        self,
+        token: str,
+        payload: dict[str, object],
+        *,
+        if_generation_match: int,
+    ) -> int | None:
+        bucket = urllib.parse.quote(self._config.bucket, safe="")
+        query = urllib.parse.urlencode(
+            {
+                "uploadType": "media",
+                "name": self._config.object_name,
+                "ifGenerationMatch": str(if_generation_match),
+            }
+        )
+        status, raw = self._request(
+            f"{_STORAGE_UPLOAD_API}/b/{bucket}/o?{query}",
+            token=token,
+            method="POST",
+            body=json.dumps(payload, sort_keys=True).encode(),
+        )
+        if status == 412:
+            return None
+        if status not in {200, 201}:
+            raise RuntimeError(f"GCS lease write failed with HTTP {status}")
+        metadata = json.loads(raw)
+        return int(metadata["generation"])
+
+    def _delete(self, token: str, generation: int) -> bool:
+        separator = "&" if "?" in self._object_url() else "?"
+        url = self._object_url() + separator + urllib.parse.urlencode(
+            {"ifGenerationMatch": str(generation)}
+        )
+        status, _raw = self._request(url, token=token, method="DELETE")
+        if status in {404, 412}:
+            return False
+        if status not in {200, 204}:
+            raise RuntimeError(f"GCS lease delete failed with HTTP {status}")
+        return True

--- a/src/trusted_router/regional_quota_reconcile_gate.py
+++ b/src/trusted_router/regional_quota_reconcile_gate.py
@@ -1,0 +1,91 @@
+"""Early single-flight admission for the regional quota reconciler."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from trusted_router.gcs_singleflight import GCSGenerationLease, GCSLeaseConfig
+
+logger = logging.getLogger(__name__)
+_TASK_TIMEOUT_SECONDS = 180.0
+
+
+def _lease_from_environment() -> GCSGenerationLease:
+    lease_seconds = float(
+        os.environ.get("TR_REGIONAL_QUOTA_RECONCILER_LOCK_LEASE_SECONDS", "240")
+    )
+    if lease_seconds <= _TASK_TIMEOUT_SECONDS:
+        raise ValueError(
+            "regional quota reconciler lease must exceed the Cloud Run task timeout"
+        )
+    return GCSGenerationLease(
+        GCSLeaseConfig(
+            bucket=os.environ.get(
+                "TR_REGIONAL_QUOTA_RECONCILER_LOCK_BUCKET", ""
+            ).strip(),
+            object_name=os.environ.get(
+                "TR_REGIONAL_QUOTA_RECONCILER_LOCK_OBJECT",
+                "regional-quota-reconciler/singleflight.json",
+            ).strip(),
+            lease_seconds=lease_seconds,
+            min_interval_seconds=float(
+                os.environ.get(
+                    "TR_REGIONAL_QUOTA_RECONCILER_MIN_INTERVAL_SECONDS", "50"
+                )
+            ),
+            failure_cooldown_seconds=float(
+                os.environ.get(
+                    "TR_REGIONAL_QUOTA_RECONCILER_FAILURE_COOLDOWN_SECONDS", "30"
+                )
+            ),
+        )
+    )
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO)
+    try:
+        singleflight = _lease_from_environment()
+        lease = singleflight.acquire()
+    except Exception:
+        logger.exception("regional_quota.reconciler_singleflight_failed")
+        return 1
+    if lease is None:
+        logger.info("regional_quota.reconciler_singleflight_skip")
+        return 0
+
+    logger.info(
+        "regional_quota.reconciler_singleflight_acquired owner=%s generation=%d",
+        lease.owner,
+        lease.generation,
+    )
+    exit_code = 1
+    try:
+        # Keep this import behind admission. Importing application config and
+        # the GCP clients is part of the expensive initialization this gate
+        # prevents duplicate executions from performing.
+        from trusted_router.regional_quota_reconcile_cli import main as reconcile
+
+        exit_code = reconcile()
+    except Exception:
+        logger.exception("regional_quota.reconciler_unhandled_failure")
+        exit_code = 1
+    try:
+        cooldown_seconds = singleflight.finish(
+            lease,
+            succeeded=exit_code == 0,
+        )
+    except Exception:
+        logger.exception("regional_quota.reconciler_singleflight_release_failed")
+        return 1
+    logger.info(
+        "regional_quota.reconciler_singleflight_released success=%s cooldown_seconds=%.1f",
+        exit_code == 0,
+        cooldown_seconds,
+    )
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -256,10 +256,15 @@ def test_production_deploy_provisions_and_schedules_regional_quota_reconciliatio
     assert "us-central1=tr-quota-us-central1" in library
     assert "europe-west4=tr-quota-europe-west4" not in library
     assert 'SCHEDULE="${TR_REGIONAL_QUOTA_RECONCILER_SCHEDULE:-* * * * *}"' in reconciler
-    assert "trusted_router.regional_quota_reconcile_cli" in reconciler
+    assert "trusted_router.regional_quota_reconcile_gate" in reconciler
+    assert "trusted_router.regional_quota_reconcile_cli" not in reconciler
     assert '"TR_ENVIRONMENT=worker"' in reconciler
     assert '"TR_SERVICE_SURFACE=control"' in reconciler
     assert '"TR_SPANNER_POOL_SIZE=1"' in reconciler
+    assert '"TR_REGIONAL_QUOTA_RECONCILER_LOCK_BUCKET=${LOCK_BUCKET}"' in reconciler
+    assert '"TR_REGIONAL_QUOTA_RECONCILER_LOCK_LEASE_SECONDS=240"' in reconciler
+    assert "roles/storage.objectUser" in reconciler
+    assert "if ! gc storage buckets describe" in reconciler
     assert "--oauth-service-account-email=\"$RUN_SERVICE_ACCOUNT\"" in reconciler
     assert "--clear-headers" in reconciler
     assert "gc secrets" not in reconciler

--- a/tests/test_gcs_singleflight.py
+++ b/tests/test_gcs_singleflight.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from trusted_router.gcs_singleflight import (
+    GCSGenerationLease,
+    GCSLease,
+    GCSLeaseConfig,
+)
+
+
+def _singleflight() -> GCSGenerationLease:
+    return GCSGenerationLease(
+        GCSLeaseConfig(
+            bucket="private-worker-state",
+            object_name="worker/lease.json",
+            lease_seconds=240,
+            min_interval_seconds=50,
+            failure_cooldown_seconds=30,
+        )
+    )
+
+
+def test_acquire_creates_generation_guarded_lease(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    singleflight = _singleflight()
+    writes: list[tuple[dict[str, object], int]] = []
+    monkeypatch.setattr(singleflight, "_access_token", lambda: "token")
+    monkeypatch.setattr(singleflight, "_read", lambda _token: None)
+
+    def write(
+        _token: str,
+        payload: dict[str, object],
+        *,
+        if_generation_match: int,
+    ) -> int:
+        writes.append((payload, if_generation_match))
+        return 17
+
+    monkeypatch.setattr(singleflight, "_write", write)
+
+    lease = singleflight.acquire(now=100.0, owner="execution-1")
+
+    assert lease == GCSLease(owner="execution-1", generation=17, acquired_at=100.0)
+    assert writes == [
+        (
+            {
+                "owner": "execution-1",
+                "state": "running",
+                "acquired_at": 100.0,
+                "expires_at": 340.0,
+            },
+            0,
+        )
+    ]
+
+
+def test_acquire_skips_active_lease_before_any_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    singleflight = _singleflight()
+    monkeypatch.setattr(singleflight, "_access_token", lambda: "token")
+    monkeypatch.setattr(
+        singleflight,
+        "_read",
+        lambda _token: ({"owner": "leader", "expires_at": 101.0}, 8),
+    )
+    monkeypatch.setattr(
+        singleflight,
+        "_write",
+        lambda *_args, **_kwargs: pytest.fail("active lease was overwritten"),
+    )
+
+    assert singleflight.acquire(now=100.0, owner="follower") is None
+
+
+def test_acquire_replaces_expired_lease_conditionally(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    singleflight = _singleflight()
+    deletes: list[int] = []
+    monkeypatch.setattr(singleflight, "_access_token", lambda: "token")
+    monkeypatch.setattr(
+        singleflight,
+        "_read",
+        lambda _token: ({"owner": "expired", "expires_at": 99.0}, 8),
+    )
+    monkeypatch.setattr(
+        singleflight,
+        "_delete",
+        lambda _token, generation: deletes.append(generation) or True,
+    )
+    monkeypatch.setattr(singleflight, "_write", lambda *_args, **_kwargs: 9)
+
+    lease = singleflight.acquire(now=100.0, owner="replacement")
+
+    assert lease == GCSLease(owner="replacement", generation=9, acquired_at=100.0)
+    assert deletes == [8]
+
+
+def test_acquire_loses_concurrent_creation_without_guessing_ownership(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    singleflight = _singleflight()
+    monkeypatch.setattr(singleflight, "_access_token", lambda: "token")
+    monkeypatch.setattr(singleflight, "_read", lambda _token: None)
+    monkeypatch.setattr(singleflight, "_write", lambda *_args, **_kwargs: None)
+
+    assert singleflight.acquire(now=100.0, owner="loser") is None
+
+
+@pytest.mark.parametrize(
+    ("succeeded", "expected_state", "expected_expiry", "expected_cooldown"),
+    [
+        (True, "cooldown", 150.0, 10.0),
+        (False, "failed", 170.0, 30.0),
+    ],
+)
+def test_finish_updates_only_owned_generation(
+    monkeypatch: pytest.MonkeyPatch,
+    succeeded: bool,
+    expected_state: str,
+    expected_expiry: float,
+    expected_cooldown: float,
+) -> None:
+    singleflight = _singleflight()
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(singleflight, "_access_token", lambda: "token")
+
+    def write(
+        _token: str,
+        payload: dict[str, object],
+        *,
+        if_generation_match: int,
+    ) -> int:
+        captured["payload"] = payload
+        captured["generation"] = if_generation_match
+        return 18
+
+    monkeypatch.setattr(singleflight, "_write", write)
+    lease = GCSLease(owner="execution-1", generation=17, acquired_at=100.0)
+
+    cooldown = singleflight.finish(lease, succeeded=succeeded, now=140.0)
+
+    assert captured["generation"] == 17
+    assert captured["payload"] == {
+        "owner": "execution-1",
+        "state": expected_state,
+        "acquired_at": 100.0,
+        "completed_at": 140.0,
+        "expires_at": expected_expiry,
+    }
+    assert cooldown == expected_cooldown
+
+
+def test_finish_fails_when_generation_ownership_changed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    singleflight = _singleflight()
+    monkeypatch.setattr(singleflight, "_access_token", lambda: "token")
+    monkeypatch.setattr(singleflight, "_write", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(RuntimeError, match="ownership changed"):
+        singleflight.finish(
+            GCSLease(owner="old", generation=3, acquired_at=100.0),
+            succeeded=True,
+            now=120.0,
+        )
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        GCSLeaseConfig("", "object", 1, 0, 0),
+        GCSLeaseConfig("bucket", "", 1, 0, 0),
+        GCSLeaseConfig("bucket", "object", 0, 0, 0),
+        GCSLeaseConfig("bucket", "object", 1, -1, 0),
+        GCSLeaseConfig("bucket", "object", 1, 0, -1),
+        GCSLeaseConfig("bucket", "object", 1, 0, 0, 0),
+    ],
+)
+def test_invalid_config_fails_closed(config: GCSLeaseConfig) -> None:
+    with pytest.raises(ValueError):
+        GCSGenerationLease(config)

--- a/tests/test_regional_quota_reconcile_gate.py
+++ b/tests/test_regional_quota_reconcile_gate.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import pytest
+
+from trusted_router import regional_quota_reconcile_cli as worker
+from trusted_router import regional_quota_reconcile_gate as gate
+from trusted_router.gcs_singleflight import GCSLease
+
+
+@dataclass
+class _Singleflight:
+    lease: GCSLease | None
+    finish_error: Exception | None = None
+
+    def __post_init__(self) -> None:
+        self.finished: list[bool] = []
+
+    def acquire(self) -> GCSLease | None:
+        return self.lease
+
+    def finish(self, _lease: GCSLease, *, succeeded: bool) -> float:
+        self.finished.append(succeeded)
+        if self.finish_error is not None:
+            raise self.finish_error
+        return 12.5
+
+
+@pytest.fixture(autouse=True)
+def _capture_gate_logs(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger=gate.__name__)
+
+
+def test_overlap_exits_before_importing_worker(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    singleflight = _Singleflight(None)
+    monkeypatch.setattr(gate, "_lease_from_environment", lambda: singleflight)
+    monkeypatch.setattr(
+        worker,
+        "main",
+        lambda: pytest.fail("overlap reached the database worker"),
+    )
+
+    assert gate.main() == 0
+    assert singleflight.finished == []
+    assert "regional_quota.reconciler_singleflight_skip" in caplog.text
+
+
+@pytest.mark.parametrize("worker_status", [0, 1])
+def test_leader_releases_lease_with_worker_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    worker_status: int,
+) -> None:
+    lease = GCSLease(owner="execution", generation=5, acquired_at=100.0)
+    singleflight = _Singleflight(lease)
+    monkeypatch.setattr(gate, "_lease_from_environment", lambda: singleflight)
+    monkeypatch.setattr(worker, "main", lambda: worker_status)
+
+    assert gate.main() == worker_status
+    assert singleflight.finished == [worker_status == 0]
+    assert "regional_quota.reconciler_singleflight_acquired" in caplog.text
+    assert "regional_quota.reconciler_singleflight_released" in caplog.text
+
+
+def test_admission_failure_fails_closed_before_worker(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def fail() -> _Singleflight:
+        raise RuntimeError("GCS unavailable")
+
+    monkeypatch.setattr(gate, "_lease_from_environment", fail)
+    monkeypatch.setattr(
+        worker,
+        "main",
+        lambda: pytest.fail("failed admission reached worker"),
+    )
+
+    assert gate.main() == 1
+    assert "regional_quota.reconciler_singleflight_failed" in caplog.text
+
+
+def test_release_failure_is_reported_as_failed_execution(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    lease = GCSLease(owner="execution", generation=5, acquired_at=100.0)
+    singleflight = _Singleflight(lease, finish_error=RuntimeError("release lost"))
+    monkeypatch.setattr(gate, "_lease_from_environment", lambda: singleflight)
+    monkeypatch.setattr(worker, "main", lambda: 0)
+
+    assert gate.main() == 1
+    assert singleflight.finished == [True]
+    assert "regional_quota.reconciler_singleflight_release_failed" in caplog.text
+
+
+def test_lock_lease_must_outlive_cloud_run_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TR_REGIONAL_QUOTA_RECONCILER_LOCK_BUCKET", "bucket")
+    monkeypatch.setenv("TR_REGIONAL_QUOTA_RECONCILER_LOCK_LEASE_SECONDS", "180")
+
+    with pytest.raises(ValueError, match="must exceed"):
+        gate._lease_from_environment()


### PR DESCRIPTION
Root cause: Cloud Scheduler considers jobs:run complete when Cloud Run accepts an execution. A slow one-minute execution therefore overlaps the next tick. The authoritative Spanner lock was acquired only after Sentry, Spanner, and Bigtable initialization, so overlaps created an initializer herd and two production tasks hit the 180-second timeout.

This change adds a private GCS generation-precondition lease before application imports. Overlapping executions exit successfully before opening database clients; the admitted worker still takes the existing authoritative Spanner fencing lock. Deployment provisions a private bucket with bucket-scoped objectUser access and preserves the one-minute cadence and strict worker alerts.

Verification:
- ruff: clean
- mypy: 322 files clean
- focused worker/deploy tests: 51 passed
- full suite: 7,804 passed; localhost socket tests were blocked by the managed sandbox and all 104 passed when rerun with localhost binding enabled