### PR TITLE
Run quota reconciliation outside the primary region

### DIFF
--- a/scripts/deploy/regional_quota_reconciler.sh
+++ b/scripts/deploy/regional_quota_reconciler.sh
@@ -9,8 +9,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/_lib.sh"
 
 SCHEDULER_NAME="${TR_REGIONAL_QUOTA_RECONCILER_SCHEDULER:-trusted-router-regional-quota-reconcile}"
-JOB_REGION="${TR_REGIONAL_QUOTA_RECONCILER_JOB_REGION:-${TR_PRIMARY_REGION}}"
-SCHEDULER_REGION="${TR_REGIONAL_QUOTA_RECONCILER_SCHEDULER_REGION:-${JOB_REGION}}"
+# Reconciliation is region-independent: Spanner is authoritative and the
+# Bigtable profile names the ledger being repaired. Keep execution outside the
+# primary serving region so a regional Cloud Run Jobs provisioning incident
+# cannot amplify control-plane pressure there. The stable Scheduler resource
+# remains in the primary region; only its verified target runs in us-east4.
+JOB_REGION="${TR_REGIONAL_QUOTA_RECONCILER_JOB_REGION:-us-east4}"
+SCHEDULER_REGION="${TR_REGIONAL_QUOTA_RECONCILER_SCHEDULER_REGION:-${TR_PRIMARY_REGION}}"
 SCHEDULE="${TR_REGIONAL_QUOTA_RECONCILER_SCHEDULE:-* * * * *}"
 RELEASE="$(git rev-parse --short HEAD 2>/dev/null || echo local)"
 JOB_PREFIX="${TR_REGIONAL_QUOTA_RECONCILER_JOB_PREFIX:-trusted-router-regional-quota-reconciler}"

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -256,6 +256,11 @@ def test_production_deploy_provisions_and_schedules_regional_quota_reconciliatio
     assert "us-central1=tr-quota-us-central1" in library
     assert "europe-west4=tr-quota-europe-west4" not in library
     assert 'SCHEDULE="${TR_REGIONAL_QUOTA_RECONCILER_SCHEDULE:-* * * * *}"' in reconciler
+    assert 'JOB_REGION="${TR_REGIONAL_QUOTA_RECONCILER_JOB_REGION:-us-east4}"' in reconciler
+    assert (
+        'SCHEDULER_REGION="${TR_REGIONAL_QUOTA_RECONCILER_SCHEDULER_REGION:-${TR_PRIMARY_REGION}}"'
+        in reconciler
+    )
     assert "trusted_router.regional_quota_reconcile_gate" in reconciler
     assert "trusted_router.regional_quota_reconcile_cli" not in reconciler
     assert '"TR_ENVIRONMENT=worker"' in reconciler


### PR DESCRIPTION
## Summary
- default the region-independent quota reconciler execution to `us-east4`
- keep the stable Cloud Scheduler resource in the primary `us-central1` region
- preserve exact Spanner authority and the existing us-central1 Bigtable quota profile
- add deployment contract tests for the separated worker and scheduler locations

## Incident
On 2026-09-01, unrelated Cloud Run Jobs in `us-central1` repeatedly spent minutes provisioning or failed before application code. The minute quota worker amplified that regional startup backlog. The reviewed GCS singleflight fix was healthy when executed in `us-east4` and production was failed over there after a successful release gate.

## Verification
- `uv run pytest -q tests/test_deploy_secret_wiring.py tests/test_deploy_script_execution.py tests/test_regional_quota_reconcile_gate.py tests/test_regional_quota_reconcile_cli.py` (141 passed)
- `uv run ruff check tests/test_deploy_secret_wiring.py`
- `bash -n scripts/deploy/regional_quota_reconciler.sh`
- production release gate in `us-east4`: 34s, 16 reconciled, 0 errors
- first scheduled run: 44s, 12 reconciled, 0 errors