### PR TITLE
Harden public origins against regional filesystem failures

### DIFF
--- a/scripts/deploy/public_surface.sh
+++ b/scripts/deploy/public_surface.sh
@@ -34,6 +34,8 @@ PUBLIC_RUNTIME_SA="${TR_PUBLIC_RUNTIME_SA:-tr-public@${PROJECT_ID}.iam.gservicea
 PUBLIC_REGIONS="${TR_PUBLIC_REGIONS:-$TR_CONTROL_PLANE_REGIONS}"
 PUBLIC_PROBE_ATTEMPTS="${TR_PUBLIC_PROBE_ATTEMPTS:-3}"
 PUBLIC_PROBE_RETRY_SECONDS="${TR_PUBLIC_PROBE_RETRY_SECONDS:-2}"
+PUBLIC_CONCURRENCY="${TR_PUBLIC_CONCURRENCY:-16}"
+PUBLIC_MIN_INSTANCES="${TR_PUBLIC_MIN_INSTANCES:-2}"
 PUBLIC_PROBE_TAG="public-revision-probe"
 PUBLIC_PROBE_REGION=""
 PUBLIC_PROBE_TAG_CLEANUP_REQUIRED=0
@@ -52,6 +54,14 @@ HISTORY_REGIONS=()
 HISTORY_OLD_REVISIONS=()
 HISTORY_NEW_REVISIONS=()
 HISTORY_OLD_INGRESSES=()
+
+for numeric_setting in PUBLIC_CONCURRENCY PUBLIC_MIN_INSTANCES; do
+  numeric_value="${!numeric_setting}"
+  if ! [[ "$numeric_value" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ERROR: ${numeric_setting} must be a positive integer" >&2
+    exit 1
+  fi
+done
 
 cleanup_public_probe_tag() {
   [ "$PUBLIC_PROBE_TAG_CLEANUP_REQUIRED" -eq 1 ] || return 0
@@ -765,12 +775,12 @@ for index in "${!TARGET_REGIONS[@]}"; do
     --port 8080
     --ingress "$INGRESS"
     --service-account "$PUBLIC_RUNTIME_SA"
-    --concurrency 8
+    --concurrency "$PUBLIC_CONCURRENCY"
     --cpu 1
     --memory 2Gi
     --timeout 60
     --max-instances 20
-    --min-instances 1
+    --min-instances "$PUBLIC_MIN_INSTANCES"
     "${NETWORK_ARGS[@]}"
     --set-env-vars "$SET_ENV_VARS"
     --set-secrets "$SET_SECRETS"

--- a/scripts/deploy/public_surface_edge.sh
+++ b/scripts/deploy/public_surface_edge.sh
@@ -179,7 +179,7 @@ prepare_edge() {
     --cache-key-include-query-string \
     --cache-key-query-string-blacklist= \
     --compression-mode=AUTOMATIC \
-    --serve-while-stale=600 \
+    --serve-while-stale=86400 \
     --no-negative-caching \
     --custom-request-header='X-TrustedRouter-Client-IP:{client_ip_address}' \
     --enable-logging \

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -1128,7 +1128,7 @@ elif gc compute backend-services describe "$LB_BACKEND_SERVICE" --global >/dev/n
     --cache-key-include-query-string \
     --cache-key-query-string-blacklist= \
     --compression-mode=AUTOMATIC \
-    --serve-while-stale=600 \
+    --serve-while-stale=86400 \
     --no-negative-caching \
     --quiet >/dev/null
 else

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -12,6 +12,7 @@ import uuid
 from collections import OrderedDict
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -227,6 +228,8 @@ _STATUS_RESPONSE_CACHE: OrderedDict[str, _CachedPublicBody] = OrderedDict()
 _STATUS_RESPONSE_REFRESHING: set[str] = set()
 _STATUS_RESPONSE_CACHE_LOCK = threading.RLock()
 _STATUS_RESPONSE_REFRESH_SLOTS = threading.BoundedSemaphore(PUBLIC_RESPONSE_REFRESH_MAX_THREADS)
+_STATIC_ASSET_CACHE_LOCK = threading.Lock()
+_STATIC_ASSET_BYTES_BY_ROOT: dict[str, dict[str, bytes]] = {}
 
 
 @dataclass(frozen=True)
@@ -238,17 +241,51 @@ class _CachedPublicBody:
 
 
 class _CachedStaticFiles(StaticFiles):
-    """StaticFiles + a public 1-day Cache-Control header.
+    """Serve immutable image assets without runtime container-file reads.
 
-    The default StaticFiles ships no cache directive, which means every
-    visit to the marketing page re-fetches every CSS/JS/SVG asset on
-    cold-load. We hash-bust nothing today, so the conservative play is
-    a 24-hour public cache — long enough to take the edge off Cloud Run
-    bandwidth, short enough that a deploy reaches users within a day."""
+    Cloud Run's container filesystem is normally reliable, but a regional
+    storage incident must not turn a cache miss for a logo into a website
+    outage. Public images are small enough to load once before the instance is
+    ready. Range requests retain Starlette's disk-backed behavior; ordinary
+    GET and HEAD requests use the in-memory copy.
+
+    Browser caches keep unversioned paths for one day while Cloud CDN keeps a
+    shared copy for seven. Explicit ``?v=`` URLs are immutable for one year.
+    """
+
+    _SHARED_MAX_AGE = 7 * 86_400
+    _VERSIONED_MAX_AGE = 365 * 86_400
 
     def __init__(self, *args: Any, max_age: int = 86_400, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._max_age = max_age
+        self._asset_bytes: dict[str, bytes] = {}
+        for directory in self.all_directories:
+            root = Path(directory).resolve()
+            root_key = str(root)
+            with _STATIC_ASSET_CACHE_LOCK:
+                cached = _STATIC_ASSET_BYTES_BY_ROOT.get(root_key)
+                if cached is None:
+                    cached = {
+                        str(asset.resolve()): asset.read_bytes()
+                        for asset in root.rglob("*")
+                        if asset.is_file()
+                    }
+                    _STATIC_ASSET_BYTES_BY_ROOT[root_key] = cached
+            self._asset_bytes.update(cached)
+
+    def _cache_control(self, scope: Scope) -> str:
+        query = scope.get("query_string", b"")
+        versioned = any(
+            field.partition(b"=")[0] == b"v" for field in query.split(b"&") if field
+        )
+        if versioned:
+            return f"public, max-age={self._VERSIONED_MAX_AGE}, immutable"
+        return (
+            f"public, max-age={self._max_age}, s-maxage={self._SHARED_MAX_AGE}, "
+            f"stale-while-revalidate={self._max_age}, "
+            f"stale-if-error={self._SHARED_MAX_AGE}"
+        )
 
     def file_response(
         self,
@@ -260,8 +297,21 @@ class _CachedStaticFiles(StaticFiles):
         response = super().file_response(full_path, stat_result, scope, status_code=status_code)
         if str(full_path).casefold().endswith(".woff2"):
             response.headers["content-type"] = "font/woff2"
-        response.headers.setdefault("cache-control", f"public, max-age={self._max_age}")
-        return response
+        response.headers.setdefault("cache-control", self._cache_control(scope))
+        if response.status_code == 304 or any(
+            name.lower() == b"range" for name, _value in scope.get("headers", [])
+        ):
+            return response
+
+        content = self._asset_bytes.get(str(Path(full_path).resolve()))
+        if content is None:
+            return response
+        body = b"" if scope.get("method") == "HEAD" else content
+        return Response(
+            content=body,
+            status_code=response.status_code,
+            headers=dict(response.headers),
+        )
 
 
 log = logging.getLogger(__name__)

--- a/tests/test_public_cdn_deploy.py
+++ b/tests/test_public_cdn_deploy.py
@@ -11,7 +11,7 @@ def test_rollout_enables_origin_controlled_public_cdn() -> None:
     assert "--cache-key-include-host" in rollout
     assert "--cache-key-include-protocol" in rollout
     assert "--cache-key-include-query-string" in rollout
-    assert "--serve-while-stale=600" in rollout
+    assert "--serve-while-stale=86400" in rollout
     assert "--no-negative-caching" in rollout
 
 

--- a/tests/test_public_surface_deploy.py
+++ b/tests/test_public_surface_deploy.py
@@ -173,12 +173,12 @@ def test_public_deploy_pins_every_region_and_stage_contract(
         else:
             assert "--no-traffic" not in call
         for flag, value in (
-            ("--concurrency", "8"),
+            ("--concurrency", "16"),
             ("--cpu", "1"),
             ("--memory", "2Gi"),
             ("--timeout", "60"),
             ("--max-instances", "20"),
-            ("--min-instances", "1"),
+            ("--min-instances", "2"),
             ("--network", "default"),
             ("--subnet", "default"),
             ("--vpc-egress", "private-ranges-only"),
@@ -233,6 +233,31 @@ def test_missing_runtime_service_account_fails_before_cloud_mutation(
     assert "roles/serviceusage.serviceUsageConsumer" in run.stderr
     mutating = ("create", "update", "deploy", "add-backend", "import")
     assert not any(any(part in mutating for part in call[1:]) for call in run.calls)
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("TR_PUBLIC_CONCURRENCY", "0"),
+        ("TR_PUBLIC_CONCURRENCY", "many"),
+        ("TR_PUBLIC_MIN_INSTANCES", "-1"),
+        ("TR_PUBLIC_MIN_INSTANCES", "1.5"),
+    ],
+)
+def test_invalid_public_capacity_fails_before_cloud_mutation(
+    tmp_path: Path,
+    name: str,
+    value: str,
+) -> None:
+    run = DeployScriptHarness(tmp_path / f"invalid-{name}-{value}").run(
+        SCRIPT,
+        args=("routed",),
+        extra_env={name: value},
+    )
+
+    assert run.returncode != 0
+    assert "must be a positive integer" in run.stderr
+    assert not _deploy_calls(run)
 
 
 def test_bigtable_mode_omits_clickhouse_secret_env_and_vpc_flags(

--- a/tests/test_public_surface_edge.py
+++ b/tests/test_public_surface_edge.py
@@ -99,6 +99,7 @@ def test_prepare_attaches_existing_policy_without_mutating_it(tmp_path: Path) ->
     assert len(backend_updates) == 1
     update = backend_updates[0]
     assert "--enable-cdn" in update
+    assert "--serve-while-stale=86400" in update
     assert "--custom-request-header=X-TrustedRouter-Client-IP:{client_ip_address}" in update
     assert "--logging-sample-rate=0.1" in update
     assert "--security-policy=trusted-router-public-edge" in update

--- a/tests/test_stubs_and_security.py
+++ b/tests/test_stubs_and_security.py
@@ -671,6 +671,41 @@ def test_static_fonts_force_woff2_media_type(
     assert font.headers["content-type"] == "font/woff2"
 
 
+def test_static_assets_are_memory_served_with_resilient_cdn_headers(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def fail_runtime_file_open(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("static asset performed a runtime file read")
+
+    monkeypatch.setattr("anyio.open_file", fail_runtime_file_open)
+
+    plain = client.get("/static/provider-logos/openai.png")
+    assert plain.status_code == 200
+    assert plain.content.startswith(b"\x89PNG\r\n\x1a\n")
+    assert plain.headers["cache-control"] == (
+        "public, max-age=86400, s-maxage=604800, "
+        "stale-while-revalidate=86400, stale-if-error=604800"
+    )
+
+    versioned = client.get("/static/dashboard.js?v=release-123")
+    assert versioned.status_code == 200
+    assert versioned.headers["cache-control"] == (
+        "public, max-age=31536000, immutable"
+    )
+
+    head = client.head("/static/dashboard.js?v=release-123")
+    assert head.status_code == 200
+    assert head.content == b""
+    assert int(head.headers["content-length"]) == len(versioned.content)
+
+    unchanged = client.get(
+        "/static/dashboard.js?v=release-123",
+        headers={"if-none-match": versioned.headers["etag"]},
+    )
+    assert unchanged.status_code == 304
+    assert unchanged.content == b""
+
+
 def test_read_only_blocks_writes_but_lets_reads_through() -> None:
     """Operational read-only flag (Stage 1 Spanner cutover prerequisite):
     POST/PUT/PATCH/DELETE return 503 with `Retry-After`; GET/HEAD/OPTIONS


### PR DESCRIPTION
## Summary
- preload packaged public assets into process memory before readiness and serve ordinary GET/HEAD requests without runtime file reads
- raise public-only warm capacity to two instances per region and concurrency to 16
- extend Cloud CDN stale serving to 24 hours while retaining immutable versioned asset caching

## Incident
During the 2026-09-01 Google Cloud us-central1-b network incident, the us-central1 public origin produced startup/readiness failures and container filesystem EIOs. Other regions and the inference API remained healthy, but serverless NEG origins are not automatically health-ejected.

## Verification
- `uv run pytest -q tests/test_public_cdn_deploy.py tests/test_public_surface_deploy.py tests/test_public_surface_edge.py tests/test_stubs_and_security.py` (93 passed)
- `uv run ruff check ...`
- `bash -n scripts/deploy/public_surface.sh scripts/deploy/public_surface_edge.sh scripts/deploy/rollout.sh`
- `git diff --check`