### PR TITLE
Remove spend-lease shadow writes from authorize latency

### DIFF
--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -142,6 +142,9 @@ from trusted_router.services.settle_outbox_drain import (
     drain_settle_outbox,
     spanner_settle_outbox,
 )
+from trusted_router.services.spend_lease_shadow_dispatch import (
+    SpendLeaseShadowDispatcher,
+)
 from trusted_router.services.user_model_gateway_health import (
     record_user_model_gateway_result,
 )
@@ -209,9 +212,9 @@ REQUEST_METADATA_VERSION = 1
 # transaction layer's 20-second retry budget while leaving five seconds for this
 # process to serialize a structured retryable 503 and for network transit.
 _BILLING_PATH_SPANNER_BUDGET_SECONDS = 20.0
-# Spend-lease shadow rows are non-authoritative rollout evidence. They must
-# never consume the paid authorize path's full Spanner budget when their
-# separate outbox transaction stalls.
+# Spend-lease shadow rows are non-authoritative rollout evidence. The dispatcher
+# keeps their outbox transaction off the paid authorize thread; this budget
+# limits each background delivery attempt during a storage incident.
 _SPEND_LEASE_SHADOW_SPANNER_BUDGET_SECONDS = 0.5
 _AUTHORIZE_ADMISSION = KeyedConcurrencyAdmission()
 # Process-local harm limitation: this keeps one key from exhausting this
@@ -479,6 +482,15 @@ def _authorize_gateway_sync(
 
 
 @spanner_rpc_budget(_SPEND_LEASE_SHADOW_SPANNER_BUDGET_SECONDS)
+def _persist_spend_lease_shadow(event_id: str, payload: dict[str, Any]) -> None:
+    STORE.record_spend_lease_shadow(event_id, payload)
+
+
+_SPEND_LEASE_SHADOW_DISPATCHER = SpendLeaseShadowDispatcher(
+    _persist_spend_lease_shadow
+)
+
+
 def _record_spend_lease_shadow(
     context: dict[str, Any],
     *,
@@ -500,9 +512,9 @@ def _record_spend_lease_shadow(
             server_estimate_micro=cast(int | None, context.get("server_estimate_micro")),
             server_verdict=cast(Any, verdict),
         )
-        STORE.record_spend_lease_shadow(event.event_id, event.payload())
+        _SPEND_LEASE_SHADOW_DISPATCHER.submit(event.event_id, event.payload())
     except Exception:
-        logger.exception("spend_lease_shadow_enqueue_failed")
+        logger.exception("spend_lease_shadow_dispatch_failed")
 
 
 def _authorize_gateway_sync_impl(

--- a/src/trusted_router/services/spend_lease_shadow_dispatch.py
+++ b/src/trusted_router/services/spend_lease_shadow_dispatch.py
@@ -1,0 +1,186 @@
+"""Bounded background delivery for non-authoritative spend-lease evidence.
+
+Spend-lease shadow rows help validate a rollout, but they do not authorize,
+reserve, settle, or refund money. A telemetry-store stall therefore must not
+delay a paid gateway request. This dispatcher keeps delivery off the request
+thread, retries the in-flight row, and drops the oldest queued evidence when
+the bounded buffer fills so memory use remains fixed.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+DEFAULT_MAX_PENDING = 4_096
+DEFAULT_RETRY_SECONDS = 0.25
+MAX_RETRY_SECONDS = 30.0
+
+
+@dataclass(frozen=True)
+class SpendLeaseShadowDispatchStats:
+    submitted: int = 0
+    delivered: int = 0
+    dropped: int = 0
+    failures: int = 0
+
+
+class SpendLeaseShadowDispatcher:
+    """Deliver shadow evidence on one lazy daemon thread."""
+
+    def __init__(
+        self,
+        deliver: Callable[[str, dict[str, Any]], None],
+        *,
+        max_pending: int = DEFAULT_MAX_PENDING,
+        retry_seconds: float = DEFAULT_RETRY_SECONDS,
+    ) -> None:
+        if max_pending <= 0:
+            raise ValueError("spend-lease shadow queue size must be positive")
+        if retry_seconds <= 0:
+            raise ValueError("spend-lease shadow retry delay must be positive")
+        self._deliver = deliver
+        self._max_pending = max_pending
+        self._retry_seconds = retry_seconds
+        self._pending: deque[tuple[str, dict[str, Any]]] = deque(maxlen=max_pending)
+        self._condition = threading.Condition()
+        self._thread: threading.Thread | None = None
+        self._active = False
+        self._closed = False
+        self._submitted = 0
+        self._delivered = 0
+        self._dropped = 0
+        self._failures = 0
+
+    def submit(self, event_id: str, payload: dict[str, Any]) -> None:
+        dropped_total: int | None = None
+        with self._condition:
+            if self._closed:
+                raise RuntimeError("spend-lease shadow dispatcher is closed")
+            if len(self._pending) == self._max_pending:
+                self._dropped += 1
+                dropped_total = self._dropped
+            self._pending.append((event_id, payload))
+            self._submitted += 1
+            self._ensure_thread_locked()
+            self._condition.notify()
+
+        if dropped_total is not None and _should_log_count(dropped_total):
+            log.error(
+                "spend_lease_shadow_queue_overflow",
+                extra={
+                    "dropped_total": dropped_total,
+                    "max_pending": self._max_pending,
+                },
+            )
+
+    def stats(self) -> SpendLeaseShadowDispatchStats:
+        with self._condition:
+            return SpendLeaseShadowDispatchStats(
+                submitted=self._submitted,
+                delivered=self._delivered,
+                dropped=self._dropped,
+                failures=self._failures,
+            )
+
+    def wait_for_idle(self, timeout: float) -> bool:
+        deadline = time.monotonic() + timeout
+        with self._condition:
+            while self._pending or self._active:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                self._condition.wait(remaining)
+            return True
+
+    def close(self, timeout: float = 1.0) -> None:
+        with self._condition:
+            self._closed = True
+            self._condition.notify_all()
+            thread = self._thread
+        if thread is not None:
+            thread.join(timeout)
+
+    def _ensure_thread_locked(self) -> None:
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(
+            target=self._run,
+            name="spend-lease-shadow",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def _run(self) -> None:
+        current: tuple[str, dict[str, Any]] | None = None
+        consecutive_failures = 0
+        while True:
+            if current is None:
+                with self._condition:
+                    while not self._pending and not self._closed:
+                        self._condition.wait()
+                    if self._closed and not self._pending:
+                        return
+                    current = self._pending.popleft()
+                    self._active = True
+
+            event_id, payload = current
+            try:
+                self._deliver(event_id, payload)
+            except Exception as exc:  # noqa: BLE001 - telemetry must not kill worker
+                consecutive_failures += 1
+                with self._condition:
+                    self._failures += 1
+                    queued = len(self._pending)
+                    failures = self._failures
+                if consecutive_failures == 1:
+                    log.error(
+                        "spend_lease_shadow_delivery_failed",
+                        exc_info=True,
+                        extra={"error_class": type(exc).__name__, "queued": queued},
+                    )
+                elif _should_log_count(failures):
+                    log.warning(
+                        "spend_lease_shadow_delivery_still_failing",
+                        extra={
+                            "error_class": type(exc).__name__,
+                            "failure_total": failures,
+                            "queued": queued,
+                        },
+                    )
+                delay = min(
+                    self._retry_seconds * (2 ** min(consecutive_failures - 1, 16)),
+                    MAX_RETRY_SECONDS,
+                )
+                with self._condition:
+                    if self._closed:
+                        self._active = False
+                        self._condition.notify_all()
+                        return
+                time.sleep(delay)
+                continue
+
+            with self._condition:
+                self._delivered += 1
+                self._active = False
+                self._condition.notify_all()
+            if consecutive_failures:
+                log.info(
+                    "spend_lease_shadow_delivery_recovered",
+                    extra={"consecutive_failures": consecutive_failures},
+                )
+            consecutive_failures = 0
+            current = None
+
+
+def _should_log_count(value: int) -> bool:
+    """Log the first event and powers of two without creating an alert flood."""
+
+    return value > 0 and value & (value - 1) == 0

--- a/tests/test_billing_path_rpc_budget.py
+++ b/tests/test_billing_path_rpc_budget.py
@@ -85,7 +85,7 @@ def test_billing_budget_finishes_before_enclave_header_timeout() -> None:
 
 
 def test_non_authoritative_spend_shadow_has_its_own_subsecond_budget() -> None:
-    """A stalled shadow outbox must not spend the paid request's 20s budget."""
+    """Each background shadow attempt has a short independent RPC budget."""
 
     tree = ast.parse(GATEWAY.read_text(encoding="utf-8"))
     shadow_functions = {
@@ -96,5 +96,21 @@ def test_non_authoritative_spend_shadow_has_its_own_subsecond_budget() -> None:
         if ast.unparse(decorator) == _SHADOW_BUDGET
     }
 
-    assert shadow_functions == {"_record_spend_lease_shadow"}
+    assert shadow_functions == {"_persist_spend_lease_shadow"}
     assert _SPEND_LEASE_SHADOW_SPANNER_BUDGET_SECONDS == 0.5
+
+
+def test_spend_shadow_recording_is_not_decorated_as_a_spanner_call() -> None:
+    """The request-thread helper may enqueue only; it cannot call Spanner."""
+
+    tree = ast.parse(GATEWAY.read_text(encoding="utf-8"))
+    record = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "_record_spend_lease_shadow"
+    )
+    assert not record.decorator_list
+    calls = {ast.unparse(node.func) for node in ast.walk(record) if isinstance(node, ast.Call)}
+    assert "STORE.record_spend_lease_shadow" not in calls
+    assert "_SPEND_LEASE_SHADOW_DISPATCHER.submit" in calls

--- a/tests/test_spend_lease_gateway.py
+++ b/tests/test_spend_lease_gateway.py
@@ -22,6 +22,17 @@ from trusted_router.spend_leases import (
 from trusted_router.storage import STORE
 
 
+def _wait_for_shadow_delivery() -> None:
+    assert gateway._SPEND_LEASE_SHADOW_DISPATCHER.wait_for_idle(1)  # noqa: SLF001
+
+
+@pytest.fixture(autouse=True)
+def _isolate_shadow_delivery() -> Any:
+    _wait_for_shadow_delivery()
+    yield
+    _wait_for_shadow_delivery()
+
+
 def _request(
     path: str = "/v1/internal/gateway/authorize",
     boot_auth_header: str | None = None,
@@ -435,6 +446,7 @@ def test_authorize_shadow_records_reason_without_lease_and_null_when_minted(
         settings,
         minted_raw,
     )
+    _wait_for_shadow_delivery()
 
     assert "spend_lease" not in rejected["data"]
     assert "spend_lease" in minted["data"]
@@ -467,6 +479,7 @@ def test_authorize_shadow_names_current_boot_digest_approval_failure() -> None:
         settings,
         raw_body,
     )
+    _wait_for_shadow_delivery()
 
     assert "spend_lease" not in response["data"]
     event = STORE.spend_lease_shadow_events[response["data"]["authorization_id"]]
@@ -506,6 +519,7 @@ def test_authorize_shadow_events_include_accept_and_decline_and_keep_echo_invali
             settings,
             json.dumps(declined_raw).encode(),
         )
+    _wait_for_shadow_delivery()
     events = list(STORE.spend_lease_shadow_events.values())
     assert {event["server_verdict"] for event in events} == {"accepted", "declined_other"}
     assert all(event["divergence"] == "echo_invalid" for event in events)

--- a/tests/test_spend_lease_shadow_dispatch.py
+++ b/tests/test_spend_lease_shadow_dispatch.py
@@ -50,7 +50,9 @@ def test_delivery_retries_then_recovers() -> None:
     dispatcher.close()
 
 
-def test_full_queue_drops_oldest_pending_event() -> None:
+def test_full_queue_drops_oldest_pending_event(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     first_started = threading.Event()
     release_first = threading.Event()
     delivered: list[str] = []
@@ -62,16 +64,21 @@ def test_full_queue_drops_oldest_pending_event() -> None:
         delivered.append(event_id)
 
     dispatcher = SpendLeaseShadowDispatcher(deliver, max_pending=2)
-    dispatcher.submit("event-1", {})
-    assert first_started.wait(1)
-    dispatcher.submit("event-2", {})
-    dispatcher.submit("event-3", {})
-    dispatcher.submit("event-4", {})
+    with caplog.at_level(
+        logging.ERROR,
+        logger="trusted_router.services.spend_lease_shadow_dispatch",
+    ):
+        dispatcher.submit("event-1", {})
+        assert first_started.wait(1)
+        dispatcher.submit("event-2", {})
+        dispatcher.submit("event-3", {})
+        dispatcher.submit("event-4", {})
     release_first.set()
 
     assert dispatcher.wait_for_idle(1)
     assert delivered == ["event-1", "event-3", "event-4"]
     assert dispatcher.stats().dropped == 1
+    assert "spend_lease_shadow_queue_overflow" in caplog.text
     dispatcher.close()
 
 

--- a/tests/test_spend_lease_shadow_dispatch.py
+++ b/tests/test_spend_lease_shadow_dispatch.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import logging
+import threading
+
+import pytest
+
+from trusted_router.services.spend_lease_shadow_dispatch import (
+    SpendLeaseShadowDispatcher,
+)
+
+
+def test_submit_never_waits_for_delivery() -> None:
+    started = threading.Event()
+    release = threading.Event()
+    delivered: list[str] = []
+
+    def deliver(event_id: str, _payload: dict[str, object]) -> None:
+        started.set()
+        assert release.wait(1)
+        delivered.append(event_id)
+
+    dispatcher = SpendLeaseShadowDispatcher(deliver)
+    dispatcher.submit("event-1", {"value": 1})
+
+    assert started.wait(1)
+    assert delivered == []
+    release.set()
+    assert dispatcher.wait_for_idle(1)
+    assert delivered == ["event-1"]
+    dispatcher.close()
+
+
+def test_delivery_retries_then_recovers() -> None:
+    attempts = 0
+
+    def deliver(_event_id: str, _payload: dict[str, object]) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise TimeoutError("temporary telemetry outage")
+
+    dispatcher = SpendLeaseShadowDispatcher(deliver, retry_seconds=0.001)
+    dispatcher.submit("event-1", {})
+
+    assert dispatcher.wait_for_idle(1)
+    assert attempts == 2
+    assert dispatcher.stats().failures == 1
+    assert dispatcher.stats().delivered == 1
+    dispatcher.close()
+
+
+def test_full_queue_drops_oldest_pending_event() -> None:
+    first_started = threading.Event()
+    release_first = threading.Event()
+    delivered: list[str] = []
+
+    def deliver(event_id: str, _payload: dict[str, object]) -> None:
+        if event_id == "event-1":
+            first_started.set()
+            assert release_first.wait(1)
+        delivered.append(event_id)
+
+    dispatcher = SpendLeaseShadowDispatcher(deliver, max_pending=2)
+    dispatcher.submit("event-1", {})
+    assert first_started.wait(1)
+    dispatcher.submit("event-2", {})
+    dispatcher.submit("event-3", {})
+    dispatcher.submit("event-4", {})
+    release_first.set()
+
+    assert dispatcher.wait_for_idle(1)
+    assert delivered == ["event-1", "event-3", "event-4"]
+    assert dispatcher.stats().dropped == 1
+    dispatcher.close()
+
+
+def test_failure_log_never_contains_payload(caplog: pytest.LogCaptureFixture) -> None:
+    failed = threading.Event()
+    private_marker = "private-payload-marker"
+
+    def deliver(_event_id: str, _payload: dict[str, object]) -> None:
+        failed.set()
+        raise RuntimeError("storage unavailable")
+
+    dispatcher = SpendLeaseShadowDispatcher(deliver, retry_seconds=1)
+    with caplog.at_level(
+        logging.ERROR,
+        logger="trusted_router.services.spend_lease_shadow_dispatch",
+    ):
+        dispatcher.submit("event-1", {"private": private_marker})
+        assert failed.wait(1)
+        dispatcher.close()
+
+    assert "spend_lease_shadow_delivery_failed" in caplog.text
+    assert private_marker not in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("max_pending", "retry_seconds"),
+    [(0, 1.0), (1, 0.0)],
+)
+def test_invalid_dispatcher_limits_fail_closed(
+    max_pending: int,
+    retry_seconds: float,
+) -> None:
+    with pytest.raises(ValueError):
+        SpendLeaseShadowDispatcher(
+            lambda _event_id, _payload: None,
+            max_pending=max_pending,
+            retry_seconds=retry_seconds,
+        )


### PR DESCRIPTION
## Summary
- dispatch non-authoritative spend-lease shadow evidence on a lazy background worker
- bound the queue at 4,096 rows and drop oldest pending evidence under sustained backpressure
- retry the active row with capped exponential backoff and rate-limit failure/overflow logs
- preserve the independent 500ms Spanner RPC budget on each background attempt

## Incident
During the 2026-09-01 GCP networking incident, one southamerica authorize completed with HTTP 200 but took 2.34s because its best-effort shadow outbox transaction synchronously waited for a Spanner deadline. Billing and settlement remained correct; observability added avoidable customer latency.

## Verification
- focused tests: 24 passed
- Ruff clean
- MyPy clean across 323 source files
- no shadow payload data is emitted in failure logs