### PR TITLE
Fix Anthropic cache price parsing by label

### DIFF
--- a/scripts/pricing/parsers/anthropic.py
+++ b/scripts/pricing/parsers/anthropic.py
@@ -7,9 +7,9 @@
 #   * Each model is an <h3 class="card_pricing_title_text"> with text like
 #     "Opus 4.7", "Sonnet 4.6", "Haiku 4.5".
 #   * Walking up two ancestors from the h3 lands on the model card.
-#   * Inside each card, four <span class="tokens_main_val_number" data-value="N">
-#     elements appear in order: Input, Output, Cache Write, Cache Read.
-#   * We use the first two (Input, Output) for prompt/completion pricing.
+#   * Each price row has a .tokens_main_label and .tokens_main_val_number.
+#   * Labels, rather than row position, identify Input, Output, cache Read,
+#     and cache Write. Anthropic changed the Read/Write order in September 2026.
 """Anthropic pricing-page parser."""
 from __future__ import annotations
 
@@ -44,27 +44,34 @@ def parse(html: str) -> dict:
         card = heading.parent.parent if heading.parent else None
         if card is None:
             continue
-        # First two .tokens_main_val_number values are Input / Output in $/MTok.
-        spans = card.select(".tokens_main_val_number")
-        if len(spans) < 2:
+        prices: dict[str, Decimal] = {}
+        for price_node in card.select(".tokens_main_wrap"):
+            label = price_node.select_one(".tokens_main_label")
+            value = price_node.select_one(".tokens_main_val_number")
+            if label is None or value is None:
+                continue
+            name = label.get_text(" ", strip=True).lower()
+            if name not in {"input", "output", "read", "write"} or name in prices:
+                continue
+            try:
+                raw_value = value.get("data-value")
+                if not isinstance(raw_value, str):
+                    raw_value = value.get_text(strip=True)
+                prices[name] = Decimal(raw_value)
+            except (InvalidOperation, TypeError, ValueError):
+                continue
+        if "input" not in prices or "output" not in prices:
             continue
-        try:
-            prompt_usd = Decimal(spans[0].get("data-value") or spans[0].text)
-            completion_usd = Decimal(spans[1].get("data-value") or spans[1].text)
-            cache_read_usd = (
-                Decimal(spans[3].get("data-value") or spans[3].text)
-                if len(spans) >= 4
-                else None
-            )
-        except (InvalidOperation, TypeError, ValueError):
-            continue
-        row = {
+        prompt_usd = prices["input"]
+        completion_usd = prices["output"]
+        cache_read_usd = prices.get("read")
+        price_row = {
             "prompt_micro_per_m": int(prompt_usd * 1_000_000),
             "completion_micro_per_m": int(completion_usd * 1_000_000),
         }
         if cache_read_usd is not None:
-            row["prompt_cached_micro_per_m"] = int(cache_read_usd * 1_000_000)
-        out[or_id] = row
+            price_row["prompt_cached_micro_per_m"] = int(cache_read_usd * 1_000_000)
+        out[or_id] = price_row
 
     # Anthropic documents Fast mode as a multiplier below the standard model
     # cards rather than rendering a second pricing card. Publish the distinct

--- a/tests/test_anthropic_model_discovery.py
+++ b/tests/test_anthropic_model_discovery.py
@@ -33,10 +33,22 @@ def test_anthropic_parser_discovers_future_claude_names_and_cache_price() -> Non
     html = """
     <div class="card">
       <div><h3 class="card_pricing_title_text">Opus 6</h3></div>
-      <span class="tokens_main_val_number" data-value="5"></span>
-      <span class="tokens_main_val_number" data-value="25"></span>
-      <span class="tokens_main_val_number" data-value="6.25"></span>
-      <span class="tokens_main_val_number" data-value="0.50"></span>
+      <div class="tokens_main_wrap">
+        <span class="tokens_main_label">Input</span>
+        <span class="tokens_main_val_number" data-value="5"></span>
+      </div>
+      <div class="tokens_main_wrap">
+        <span class="tokens_main_label">Output</span>
+        <span class="tokens_main_val_number" data-value="25"></span>
+      </div>
+      <div class="tokens_main_wrap">
+        <span class="tokens_main_label">Read</span>
+        <span class="tokens_main_val_number" data-value="0.50"></span>
+      </div>
+      <div class="tokens_main_wrap">
+        <span class="tokens_main_label">Write</span>
+        <span class="tokens_main_val_number" data-value="6.25"></span>
+      </div>
     </div>
     """
 
@@ -51,10 +63,22 @@ def test_anthropic_parser_derives_documented_fast_mode_multiplier() -> None:
     html = """
     <div class="card">
       <div><h3 class="card_pricing_title_text">Opus 5</h3></div>
-      <span class="tokens_main_val_number" data-value="5"></span>
-      <span class="tokens_main_val_number" data-value="25"></span>
-      <span class="tokens_main_val_number" data-value="6.25"></span>
-      <span class="tokens_main_val_number" data-value="0.50"></span>
+      <div class="tokens_main_wrap">
+        <span class="tokens_main_label">Input</span>
+        <span class="tokens_main_val_number" data-value="5"></span>
+      </div>
+      <div class="tokens_main_wrap">
+        <span class="tokens_main_label">Output</span>
+        <span class="tokens_main_val_number" data-value="25"></span>
+      </div>
+      <div class="tokens_main_wrap">
+        <span class="tokens_main_label">Write</span>
+        <span class="tokens_main_val_number" data-value="6.25"></span>
+      </div>
+      <div class="tokens_main_wrap">
+        <span class="tokens_main_label">Read</span>
+        <span class="tokens_main_val_number" data-value="0.50"></span>
+      </div>
     </div>
     <p>Get faster speeds with fast mode for Opus 5 at 2x standard pricing.</p>
     """
@@ -66,6 +90,50 @@ def test_anthropic_parser_derives_documented_fast_mode_multiplier() -> None:
         "completion_micro_per_m": 50_000_000,
         "prompt_cached_micro_per_m": 1_000_000,
     }
+
+
+def test_anthropic_parser_uses_cache_labels_when_read_precedes_write() -> None:
+    html = """
+    <div class="card">
+      <div><h3 class="card_pricing_title_text">Sonnet 5</h3></div>
+      <div class="tokens_main_wrap">
+        <span class="tokens_main_label">Input</span>
+        <span class="tokens_main_val_number" data-value="2"></span>
+      </div>
+      <div class="tokens_main_wrap">
+        <span class="tokens_main_label">Output</span>
+        <span class="tokens_main_val_number" data-value="10"></span>
+      </div>
+      <div class="tokens_main_wrap">
+        <span class="tokens_main_label">Read</span>
+        <span class="tokens_main_val_number" data-value="0.20"></span>
+      </div>
+      <div class="tokens_main_wrap">
+        <span class="tokens_main_label">Write</span>
+        <span class="tokens_main_val_number" data-value="2.50"></span>
+      </div>
+    </div>
+    """
+
+    assert anthropic_parser.parse(html)["anthropic/claude-sonnet-5"] == {
+        "prompt_micro_per_m": 2_000_000,
+        "completion_micro_per_m": 10_000_000,
+        "prompt_cached_micro_per_m": 200_000,
+    }
+
+
+def test_anthropic_parser_does_not_guess_unlabeled_cache_price() -> None:
+    html = """
+    <div class="card">
+      <div><h3 class="card_pricing_title_text">Opus 6</h3></div>
+      <span class="tokens_main_val_number" data-value="5"></span>
+      <span class="tokens_main_val_number" data-value="25"></span>
+      <span class="tokens_main_val_number" data-value="0.50"></span>
+      <span class="tokens_main_val_number" data-value="6.25"></span>
+    </div>
+    """
+
+    assert anthropic_parser.parse(html) == {}
 
 
 def test_anthropic_models_api_row_preserves_native_id_and_capabilities(


### PR DESCRIPTION
## Summary
- parse Anthropic Input, Output, Read, and Write prices by visible row label
- fail closed when labeled prompt/completion prices are absent
- add a regression for reordered Read/Write rows

## Root cause
Anthropic changed the pricing page from Input, Output, Write, Read to Input, Output, Read, Write. The positional parser treated cache Write as cache Read, producing a guarded 12.5x apparent increase. The price guard correctly blocked publication, so customer prices were not changed.

## Verification
- focused Ruff passed
- focused mypy passed
- 163 focused pricing tests passed
- live Anthropic page parses Opus 4.8 cache read at $0.50/M, Sonnet 5 at $0.20/M, and Haiku 4.5 at $0.10/M