### PR TITLE
Build public pages off the event loop; one slow ClickHouse query stalled a whole instance

### DIFF
--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -820,7 +820,7 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
                 headers=trust_response_headers(release.status),
             )
         if is_status_hostname(settings, hostname):
-            return _cached_status_page_response(
+            return await _cached_status_page_response(
                 settings,
                 host=hostname,
                 background_tasks=background_tasks,
@@ -994,15 +994,15 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     # catalog-derived pages rather than recomputed per request.
     @public_html_route("/us-ai-models")
     async def seo_us_ai_models(background_tasks: BackgroundTasks) -> Response:
-        return _model_region_response(settings, "us-ai-models", background_tasks)
+        return await _model_region_response(settings, "us-ai-models", background_tasks)
 
     @public_html_route("/eu-ai-models")
     async def seo_eu_ai_models(background_tasks: BackgroundTasks) -> Response:
-        return _model_region_response(settings, "eu-ai-models", background_tasks)
+        return await _model_region_response(settings, "eu-ai-models", background_tasks)
 
     @public_html_route("/china-ai-models")
     async def seo_china_ai_models(background_tasks: BackgroundTasks) -> Response:
-        return _model_region_response(settings, "china-ai-models", background_tasks)
+        return await _model_region_response(settings, "china-ai-models", background_tasks)
 
     @public_html_route("/minimax-m3-api")
     async def seo_minimax_m3_api() -> str:
@@ -1200,7 +1200,7 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
 
     @public_html_route("/choose")
     async def choose(background_tasks: BackgroundTasks) -> Response:
-        return _cached_public_response(
+        return await _cached_public_response(
             settings,
             key=f"choose:page:{settings.release}",
             media_type="text/html",
@@ -1212,7 +1212,7 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
 
     @app.get("/choose/catalog.json")
     async def choose_catalog(background_tasks: BackgroundTasks) -> Response:
-        return _cached_public_response(
+        return await _cached_public_response(
             settings,
             key=f"choose:catalog:{settings.release}",
             media_type="application/json",
@@ -1640,7 +1640,7 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
 
     @public_html_route("/status")
     async def status_page(request: Request, background_tasks: BackgroundTasks) -> Response:
-        return _cached_status_page_response(
+        return await _cached_status_page_response(
             settings,
             host=request.headers.get("host", ""),
             background_tasks=background_tasks,
@@ -1649,7 +1649,7 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
     @public_html_route("/leaderboard")
     async def leaderboard_page(request: Request, background_tasks: BackgroundTasks) -> Response:
         _ = request
-        return _cached_public_response(
+        return await _cached_public_response(
             settings,
             key="leaderboard:page",
             media_type="text/html",
@@ -1666,7 +1666,7 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
         request: Request, background_tasks: BackgroundTasks
     ) -> Response:
         _ = request
-        return _cached_public_response(
+        return await _cached_public_response(
             settings,
             key="leaderboard:video:page",
             media_type="text/html",
@@ -1680,7 +1680,7 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
 
     @app.get("/leaderboard/video.json")
     async def video_leaderboard_json(background_tasks: BackgroundTasks) -> Response:
-        return _cached_public_response(
+        return await _cached_public_response(
             settings,
             key="leaderboard:video:json",
             media_type="application/json",
@@ -1706,7 +1706,7 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
 
     @app.get("/status.json")
     async def status_json(background_tasks: BackgroundTasks) -> Response:
-        return _cached_public_response(
+        return await _cached_public_response(
             settings,
             key=f"status:json:{int(settings.public_client_observed_enabled)}",
             media_type="application/json",
@@ -1737,7 +1737,7 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
                 status_code=400,
             )
         if not _wants_history_html(request, explicit_format=response_format):
-            return _cached_public_response(
+            return await _cached_public_response(
                 settings,
                 key=f"status:history:{window}:json",
                 media_type="application/json",
@@ -1747,7 +1747,7 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
                 build=lambda: _json_body({"data": _status_history_payload(window)}),
             )
         render_host = _status_render_host(settings, request.headers.get("host", ""))
-        return _cached_public_response(
+        return await _cached_public_response(
             settings,
             key=f"status:history:{window}:html:{render_host}",
             media_type="text/html",
@@ -2093,14 +2093,14 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
         )
 
 
-def _cached_status_page_response(
+async def _cached_status_page_response(
     settings: Settings,
     *,
     host: str,
     background_tasks: BackgroundTasks,
 ) -> Response:
     render_host = _status_render_host(settings, host)
-    return _cached_public_response(
+    return await _cached_public_response(
         settings,
         key=f"status:page:{render_host}:{int(settings.public_client_observed_enabled)}",
         media_type="text/html",
@@ -2120,12 +2120,12 @@ def _status_render_host(settings: Settings, host: str) -> str:
     return settings.trusted_domain
 
 
-def _model_region_response(
+async def _model_region_response(
     settings: Settings,
     slug: str,
     background_tasks: BackgroundTasks,
 ) -> Response:
-    return _cached_public_response(
+    return await _cached_public_response(
         settings,
         key=f"model-region:{slug}:{settings.release}",
         media_type="text/html",
@@ -2136,7 +2136,7 @@ def _model_region_response(
     )
 
 
-def _cached_public_response(
+async def _cached_public_response(
     settings: Settings,
     *,
     key: str,
@@ -2147,12 +2147,23 @@ def _cached_public_response(
     build: Callable[[], bytes],
     cache_control_override: str | None = None,
 ) -> Response:
+    """Serve a cached public body, building it OFF the event loop on a miss.
+
+    `build` reaches ClickHouse through a synchronous httpx client with a
+    20-second timeout (`OperationalAnalytics._query`). Calling it inline from
+    an async route blocked the worker's whole event loop for as long as that
+    query took, so every other request on the instance -- including
+    /internal/gateway/authorize and /settle on the paid inference path --
+    queued behind a status-page render. The stale-refresh path already ran on
+    a daemon thread for exactly this reason; only the cold/expired path was
+    left on the loop.
+    """
     cache_control = cache_control_override or _public_cache_control(
         ttl_seconds=ttl_seconds, stale_seconds=stale_seconds
     )
     if settings.environment == "test":
         return Response(
-            content=build(),
+            content=await run_in_threadpool(build),
             media_type=media_type,
             headers={"cache-control": cache_control, "x-tr-cache": "bypass"},
         )
@@ -2176,7 +2187,7 @@ def _cached_public_response(
                 )
                 return _cached_body_response(cached, cache_state="stale")
 
-    body = build()
+    body = await run_in_threadpool(build)
     cached = _CachedPublicBody(
         cached_at=time.monotonic(),
         body=body,

--- a/tests/test_public_cache_does_not_block_event_loop.py
+++ b/tests/test_public_cache_does_not_block_event_loop.py
@@ -1,0 +1,114 @@
+"""A slow public-page render must not stall the worker's event loop.
+
+`_cached_public_response`'s `build` reaches ClickHouse through a SYNCHRONOUS
+httpx client with a 20-second timeout (`OperationalAnalytics._query`). It used
+to be called inline from `async def` route handlers, so one cold /status render
+against a slow ClickHouse blocked the entire event loop: with
+containerConcurrency=8 every other in-flight request on that instance queued
+behind it, including /internal/gateway/authorize and /settle on the paid
+inference path.
+
+Observed in production 2026-09-01 14:41-14:42Z: a burst of 503s, all from a
+single instanceId, with authorize latencies of exactly 20.017s -- the
+`timeout_seconds: float = 20.0` default -- and victims queued behind at 43-78s,
+with NO traffic spike (51-146 req/min, flat).
+
+The test asserts the property (the loop keeps turning during a slow build),
+not the call shape, so it still fails if someone reintroduces the inline call
+by a different route.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+from starlette.background import BackgroundTasks
+
+from trusted_router.config import Settings
+from trusted_router.routes import public as public_routes
+
+BUILD_SECONDS = 0.5
+
+
+@pytest.mark.anyio
+async def test_slow_build_does_not_block_the_event_loop() -> None:
+    settings = Settings(environment="test")
+
+    def slow_build() -> bytes:
+        # Stands in for the blocking ClickHouse round trip.
+        time.sleep(BUILD_SECONDS)
+        return b"payload"
+
+    ticks = 0
+    stop = False
+
+    async def heartbeat() -> None:
+        # A co-running task the event loop must keep servicing. It ticks until
+        # told to stop, and the assertion reads the count taken the moment the
+        # build returned -- NOT after awaiting this task, which would let the
+        # ticks accrue afterwards and make the test unable to fail.
+        nonlocal ticks
+        while not stop:
+            ticks += 1
+            await asyncio.sleep(0.01)
+
+    beat = asyncio.create_task(heartbeat())
+    # Let the heartbeat actually start before the build begins.
+    await asyncio.sleep(0.02)
+    ticks_before = ticks
+
+    response = await public_routes._cached_public_response(
+        settings,
+        key="test:evloop",
+        media_type="text/plain",
+        ttl_seconds=1,
+        stale_seconds=1,
+        background_tasks=BackgroundTasks(),
+        build=slow_build,
+    )
+    ticks_during_build = ticks - ticks_before
+
+    stop = True
+    await beat
+
+    assert response.status_code == 200
+    # A blocked loop yields ~0 ticks while the build runs; a healthy one
+    # yields tens (BUILD_SECONDS / 0.01).
+    assert ticks_during_build > 10, (
+        f"event loop was starved during build (ticks={ticks_during_build})"
+    )
+
+
+@pytest.mark.anyio
+async def test_concurrent_slow_builds_overlap_instead_of_serializing() -> None:
+    """Two cold renders must run concurrently, not one-after-the-other.
+
+    Serialization is what turned one slow ClickHouse query into a
+    whole-instance stall.
+    """
+    settings = Settings(environment="test")
+
+    def slow_build() -> bytes:
+        time.sleep(BUILD_SECONDS)
+        return b"payload"
+
+    async def one(key: str) -> None:
+        await public_routes._cached_public_response(
+            settings,
+            key=key,
+            media_type="text/plain",
+            ttl_seconds=1,
+            stale_seconds=1,
+            background_tasks=BackgroundTasks(),
+            build=slow_build,
+        )
+
+    started = time.monotonic()
+    await asyncio.gather(one("test:a"), one("test:b"))
+    elapsed = time.monotonic() - started
+
+    assert elapsed < BUILD_SECONDS * 1.8, (
+        f"cold renders serialized ({elapsed:.2f}s for two {BUILD_SECONDS}s builds)"
+    )

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -398,7 +398,8 @@ def test_gateway_latency_anatomy_distinguishes_global_and_direct_targets() -> No
     }
 
 
-def test_public_status_response_cache_reuses_rendered_body() -> None:
+@pytest.mark.anyio
+async def test_public_status_response_cache_reuses_rendered_body() -> None:
     import trusted_router.routes.public as public_routes
 
     with public_routes._STATUS_RESPONSE_CACHE_LOCK:
@@ -412,7 +413,7 @@ def test_public_status_response_cache_reuses_rendered_body() -> None:
         return f"payload-{calls}".encode()
 
     try:
-        first = public_routes._cached_public_response(
+        first = await public_routes._cached_public_response(
             Settings(environment="local"),
             key="test:status-cache",
             media_type="application/json",
@@ -421,7 +422,7 @@ def test_public_status_response_cache_reuses_rendered_body() -> None:
             background_tasks=BackgroundTasks(),
             build=build,
         )
-        second = public_routes._cached_public_response(
+        second = await public_routes._cached_public_response(
             Settings(environment="local"),
             key="test:status-cache",
             media_type="application/json",
@@ -442,7 +443,8 @@ def test_public_status_response_cache_reuses_rendered_body() -> None:
     assert calls == 1
 
 
-def test_public_response_cache_is_bounded() -> None:
+@pytest.mark.anyio
+async def test_public_response_cache_is_bounded() -> None:
     import trusted_router.routes.public as public_routes
 
     with public_routes._STATUS_RESPONSE_CACHE_LOCK:
@@ -450,7 +452,7 @@ def test_public_response_cache_is_bounded() -> None:
         public_routes._STATUS_RESPONSE_REFRESHING.clear()
     try:
         for index in range(public_routes.PUBLIC_RESPONSE_CACHE_MAX_ENTRIES + 5):
-            public_routes._cached_public_response(
+            await public_routes._cached_public_response(
                 Settings(environment="local"),
                 key=f"bounded-cache-{index}",
                 media_type="application/json",


### PR DESCRIPTION
Root cause of today's 14:41–14:42Z 503 burst **and** the recurring multi-second `/status`, `/status.json` and homepage renders. Found while investigating slow pages on Product Hunt launch day — and the launch did **not** cause it.

## The defect

`_cached_public_response`'s `build` callback reaches ClickHouse through a **synchronous** httpx client with a 20-second timeout (`OperationalAnalytics._query`). It was called inline from `async def` route handlers, so a cold or expired render blocked the worker's **entire event loop** for as long as that query took. With `containerConcurrency: 8`, up to seven other in-flight requests on that instance queued behind a status-page render — including `/internal/gateway/authorize` and `/settle`, which are on the paid inference path.

```
async def status_page                    ← event loop
  └─ _cached_status_page_response        (sync)
       └─ _cached_public_response        (sync)
            └─ build()                   ← ON THE LOOP
                 └─ _status_snapshot → OperationalAnalytics._query
                      └─ httpx.Client.post(timeout=20.0)   ← BLOCKING
```

## Why the evidence is conclusive

| observation | implication |
|---|---|
| every 503 came from **one** `instanceId`, one revision | a single blocked loop, not the fleet |
| volume **flat** through the window (51–146 req/min) | not capacity, not a launch spike |
| several authorize latencies of exactly **20.017s** | the `timeout_seconds: float = 20.0` default |
| victims queued behind at 43–78s | requests stacked on the blocked loop |
| `/status` + `/status.json` = 49 of the day's slow public requests | the blocking build itself |

The strongest hint was already in the code: the **stale-refresh path already runs on a daemon thread** (`_schedule_cached_response_refresh`) for exactly this reason. Only the cold/expired path was left on the loop.

## The fix

`build` now runs via `run_in_threadpool` — already the established idiom in this module (used at lines 558 and 1980). `_cached_public_response` and its two wrappers become async; their ten call sites await. Cache **hits** still return with no thread hop.

## Tests assert the property, not the call shape

So reintroducing an inline build by a different route still fails them:
- the event loop keeps ticking during a slow build;
- two cold renders **overlap** instead of serializing.

Both mutation-tested by putting `build()` back on the loop — they fail with `ticks=0` and `serialized (1.01s for two 0.5s builds)`.

Worth flagging: **my first version of the loop-starvation test was vacuous.** It awaited the heartbeat task *after* the build, so ticks accrued afterwards and it passed against the unfixed code. It now samples the count the moment the build returns, and fails correctly.

Gates: ruff ✓, mypy ✓ (323 files), pytest 7,838 passed / 346 skipped / 10 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)