### PR TITLE
Restart AWS analytics drain after code swap

### DIFF
--- a/clickhouse/ingest_operational_outbox.py
+++ b/clickhouse/ingest_operational_outbox.py
@@ -444,6 +444,11 @@ class ClickHouseOperationalWriter:
                     command,
                     input=payload,
                     env=env,
+                    # Do not inherit the daemon's working directory. Deploys
+                    # replace /opt/tr-clickhouse atomically; if an old process
+                    # survives a bad rollout, that directory can be deleted and
+                    # clickhouse-client otherwise fails before opening a socket.
+                    cwd="/",
                     capture_output=True,
                     check=False,
                     timeout=self._timeout_seconds,

--- a/scripts/deploy/aws_eu_clickhouse_drain_install.sh
+++ b/scripts/deploy/aws_eu_clickhouse_drain_install.sh
@@ -332,6 +332,12 @@ cd '$STAGE_DIR'
 # ---------------------------------------------------------------------------
 ssm "drain: activate $REMOTE_ROOT" "
 set -eux
+# A running drain holds WorkingDirectory=/opt/tr-clickhouse. Moving that tree
+# leaves the process on the old inode, and a later refresh deletes that inode
+# when it removes .previous. clickhouse-client then fails every insert with
+# 'cannot get current directory' while systemd still reports the unit active.
+# Stop before the swap; the durable outbox safely absorbs this short deploy gap.
+systemctl stop $SERVICE 2>/dev/null || true
 rm -rf '${REMOTE_ROOT}.previous'
 if [ -d '$REMOTE_ROOT' ]; then mv '$REMOTE_ROOT' '${REMOTE_ROOT}.previous'; fi
 mv '$STAGE_DIR' '$REMOTE_ROOT'
@@ -393,7 +399,14 @@ printf '%s' '$UNIT_B64' | base64 -d > /etc/systemd/system/$SERVICE
 chmod 644 /etc/systemd/system/$SERVICE
 chown -R '$SERVICE_USER':'$SERVICE_USER' '$REMOTE_ROOT'
 systemctl daemon-reload
-systemctl enable --now $SERVICE
+systemctl enable $SERVICE
+# enable --now is a no-op for an already-active unit and caused the old
+# process to survive code refreshes. restart also starts an inactive unit.
+systemctl restart $SERVICE
+systemctl is-active --quiet $SERVICE
+main_pid=\"\$(systemctl show --property MainPID --value $SERVICE)\"
+test \"\$main_pid\" -gt 1
+test \"\$(readlink -f /proc/\$main_pid/cwd)\" = '$REMOTE_ROOT'
 "
 
 # ---------------------------------------------------------------------------

--- a/tests/test_aws_analytics_drain_install.py
+++ b/tests/test_aws_analytics_drain_install.py
@@ -133,6 +133,27 @@ def test_install_stages_and_verifies_before_swapping_anything_in() -> None:
     assert "${REMOTE_ROOT}.previous" in script
 
 
+def test_install_stops_before_swap_and_restarts_on_the_new_working_directory() -> None:
+    """An active unit must not retain a working directory removed by a later deploy.
+
+    `systemctl enable --now` does not restart an active service. Two consecutive
+    refreshes therefore left the drain running from `.previous`, deleted that
+    directory, and made every clickhouse-client invocation fail while systemd
+    continued to report the unit active.
+    """
+    script = INSTALL.read_text()
+
+    stop = script.index("systemctl stop $SERVICE")
+    remove_previous = script.index("rm -rf '${REMOTE_ROOT}.previous'")
+    restart = script.index("systemctl restart $SERVICE")
+
+    assert stop < remove_previous < restart
+    assert "systemctl enable --now $SERVICE" not in script
+    assert "systemctl is-active --quiet $SERVICE" in script
+    assert "readlink -f /proc/\\$main_pid/cwd" in script
+    assert "= '$REMOTE_ROOT'" in script
+
+
 def test_install_writes_the_secret_by_running_a_command_not_by_pasting() -> None:
     """EnvironmentFile does no substitution: a pasted $(...) BECOMES the password.
 

--- a/tests/test_operational_analytics_dual_write.py
+++ b/tests/test_operational_analytics_dual_write.py
@@ -97,6 +97,7 @@ class _Call:
     command: list[str]
     payload: bytes
     timeout: float | None
+    cwd: str | None
 
     @property
     def host(self) -> str:
@@ -130,6 +131,7 @@ class _Fleet:
                 command=list(command),
                 payload=kwargs.get("input", b"") or b"",
                 timeout=kwargs.get("timeout"),
+                cwd=kwargs.get("cwd"),
             )
             self.calls.append(call)
             if call.host in self.down:
@@ -282,6 +284,8 @@ def test_single_endpoint_emits_the_byte_identical_historical_command(
     # And no timeout, which is also how it always behaved: a bound belongs on
     # a REMOTE endpoint, and adding one here would be a behaviour change.
     assert fleet.calls[0].timeout is None
+    # A deleted service cwd must not stop clickhouse-client before it connects.
+    assert fleet.calls[0].cwd == "/"
 
 
 def test_single_endpoint_keeps_todays_exception_rather_than_a_fan_out_error(


### PR DESCRIPTION
## Summary
- stop the active analytics drain before replacing its working directory
- restart it unconditionally after installing the new unit and environment
- verify the running process cwd resolves to the newly activated tree
- start every clickhouse-client child from / so a deleted inherited cwd cannot block delivery
- add regressions for deployment ordering and child cwd isolation

## Root cause
The installer moved /opt/tr-clickhouse to .previous while the active drain kept that directory as its cwd. systemctl enable --now did not restart an already-active service. On a later refresh, removing .previous deleted the live process cwd, causing every clickhouse-client insert to fail with cannot get current directory while systemd still reported active. The durable AWS outbox preserved all rows, but freshness lag reached about 47 hours until the unit restarted.

## Verification
- bash syntax check passed
- focused Ruff and mypy passed
- 78 focused AWS drain and writer tests passed
- 103 deploy-script execution tests passed