### PR TITLE
AWS drain: installer restarts the unit, verify can fail, subprocess cwd pinned, wedged drain exits

### DIFF
--- a/clickhouse/ingest_operational_outbox.py
+++ b/clickhouse/ingest_operational_outbox.py
@@ -362,6 +362,10 @@ class SpannerOperationalOutboxSource:
         return oldest
 
 
+class ClickHouseInsertError(RuntimeError):
+    """A ClickHouse target did not accept a complete logical batch."""
+
+
 class ClickHouseOperationalWriter:
     """Inserts a batch into one ClickHouse endpoint via clickhouse-client.
 
@@ -444,6 +448,12 @@ class ClickHouseOperationalWriter:
                     command,
                     input=payload,
                     env=env,
+                    # Do not inherit the daemon's cwd.  The systemd unit must
+                    # keep /opt/tr-clickhouse as WorkingDirectory so `python
+                    # -m` can import the installed package, but an installer
+                    # rotating that tree must not make every future child die
+                    # before clickhouse-client can process its arguments.
+                    cwd="/",
                     capture_output=True,
                     check=False,
                     timeout=self._timeout_seconds,
@@ -451,14 +461,24 @@ class ClickHouseOperationalWriter:
             except subprocess.TimeoutExpired as exc:
                 # Raising is the point: the caller must not reach its DELETE,
                 # so the rows stay queued and the next sweep retries them.
-                raise RuntimeError(
+                raise ClickHouseInsertError(
                     f"ClickHouse {event_kind} insert to "
                     f"{self._host or 'localhost'} timed out after "
                     f"{self._timeout_seconds}s"
                 ) from exc
+            except OSError as exc:
+                # Includes exec failures such as a missing binary.  Keep these
+                # distinguishable from source, normalisation and DELETE errors
+                # so the Postgres daemon's liveness bound only counts a writer
+                # that is actually unable to deliver.
+                raise ClickHouseInsertError(
+                    f"ClickHouse {event_kind} insert could not start: {exc}"
+                ) from exc
             if result.returncode != 0:
                 detail = result.stderr.decode("utf-8", errors="replace")[:1000]
-                raise RuntimeError(f"ClickHouse {event_kind} insert failed: {detail}")
+                raise ClickHouseInsertError(
+                    f"ClickHouse {event_kind} insert failed: {detail}"
+                )
 
 
 def _event_id(tenant_id: str, batch_id: str, kind: str, index: int) -> str:

--- a/clickhouse/ingest_operational_outbox_postgres.py
+++ b/clickhouse/ingest_operational_outbox_postgres.py
@@ -25,7 +25,7 @@ nothing can recover.
 Aurora DSQL reports every optimistic-concurrency abort as SQLSTATE 40001, which
 is routine rather than exceptional, so each statement runs under a retry.
 
-**Failures are contained, not fatal.**  This is a daemon whose silence looks
+**Recoverable failures are contained.**  This is a daemon whose silence looks
 exactly like success — nothing downstream notices undelivered rows except the
 lag metric — so it never exits on an error it could survive.  Shards are swept
 independently and a failing one is logged and counted rather than allowed to
@@ -33,6 +33,14 @@ unwind the sweep, because a single undeliverable row would otherwise stop
 delivery for all 32 shards.  Non-retryable errors drop the connection so the
 next pass reconnects; DSQL expires long-lived connections, so that path is
 ordinary rather than exceptional.
+
+There is one bounded exception: if every configured ClickHouse target rejects
+every attempted batch for three consecutive complete sweeps, the process exits
+non-zero.  ``Restart=on-failure`` then starts a fresh process after
+``RestartSec``.  This does not turn partial degradation into a restart loop: if
+one target accepts the batch in a copies>1 deployment, the drain stays alive,
+continues feeding that copy, and reports ``degraded_targets``.  The restart is
+for the zero-success case where fresh process state can heal a wedged daemon.
 
 **That silence has one bound this module cannot provide.**  ``backlog_alarm``
 below is emitted BY this process, so it says nothing when the process does not
@@ -91,11 +99,13 @@ The cost of that is a bounded re-write: during an outage each full pass re-offer
 the backlog to the nodes that are up, and `ReplacingMergeTree` collapses it.  One
 rewrite per pass, not one per poll.
 
-**Unbounded outbox growth when a node stays down.**  There is no automatic
-bound, and that is deliberate: any automatic bound would have to either delete
-undelivered rows — the exact loss this design exists to prevent — or stop the
-drain, which does not help.  So the bound is operator-enforced and the drain's
-job is to make the condition impossible to miss:
+**Unbounded outbox growth when a node stays down.**  There is no automatic data
+bound, and that is deliberate: such a bound would have to delete undelivered
+rows, the exact loss this design exists to prevent.  A zero-success drain does
+restart to heal stale process state, but a real node outage survives that
+restart and still needs the operator decision below.  So the storage bound is
+operator-enforced and the drain's job is to make the condition impossible to
+miss:
 
 * every sweep logs ``degraded_targets=`` naming each endpoint whose last write
   failed, so "which node is behind" is never a guess;
@@ -169,10 +179,12 @@ than one whose edges are known:
   so both nodes hold them empty. If such a job is ever pointed at Paris, its
   output is NOT replicated by this drain and the second copy is not complete.
 * **The alarm needs this process alive.**  ``backlog_alarm`` is emitted from the
-  sweep loop, so it says nothing while the drain is not running.  A
-  configuration error therefore exits with ``CONFIG_EXIT_CODE``, which the unit
-  file refuses to restart, so a bad environment leaves a *failed* unit rather
-  than a silent crash-loop with the outbox growing behind it.
+  sweep loop, so it says nothing while the drain is not running.  A total writer
+  failure exits non-zero only after logging complete sweeps; systemd restarts it,
+  which both keeps the alarm alive and can heal stale process state.  A
+  configuration error instead exits with ``CONFIG_EXIT_CODE``, which the unit
+  refuses to restart, so a bad environment leaves a *failed* unit rather than a
+  silent crash-loop with the outbox growing behind it.
 """
 
 from __future__ import annotations
@@ -189,6 +201,7 @@ from typing import Any
 
 from clickhouse._sdnotify import sd_notify
 from clickhouse.ingest_operational_outbox import (
+    ClickHouseInsertError,
     ClickHouseOperationalWriter,
     OperationalOutboxRow,
     _lag_seconds,
@@ -319,6 +332,11 @@ DEFAULT_REPLICA_TIMEOUT_SECONDS = 60.0
 #: catch-up and becomes something an operator has to decide about.
 DEFAULT_MAX_LAG_SECONDS = 3600.0
 
+#: Full zero-success sweeps tolerated before systemd gets a chance to replace
+#: potentially wedged process state.  A transient sweep remains contained, and
+#: partial fan-out success never increments this counter.
+DEFAULT_ALL_TARGET_FAILURE_SWEEPS = 3
+
 #: Aurora DSQL expires connections at roughly one hour. Reconnect while the
 #: handle is still predictably usable instead of discovering expiry mid-poll.
 CONNECTION_MAX_AGE_SECONDS = 45 * 60
@@ -341,7 +359,7 @@ SWEEP_TARGET_FAILURE_LIMIT = 3
 
 #: Exit status for a configuration error, distinct from a crash so systemd can
 #: refuse to restart it (RestartPreventExitStatus in the unit file). A bad
-#: environment cannot be fixed by running again: with Restart=always the drain
+#: environment cannot be fixed by running again: with a restart policy the drain
 #: would crash-loop invisibly while the outbox grew at full rate, and the alarm
 #: that is supposed to bound that growth is emitted BY the process that is not
 #: running. A unit in `failed` is visible; a unit restarting every 5s is not.
@@ -445,6 +463,10 @@ class FanOutOperationalWriter:
     def begin_sweep(self) -> None:
         """Re-arm the per-sweep breaker. Called by `drain_once` per sweep."""
         self._sweep_failures = {name: 0 for name, _ in self._targets}
+
+    @property
+    def target_count(self) -> int:
+        return len(self._targets)
 
     def insert(self, events: list[Any]) -> None:
         failures: list[tuple[str, BaseException]] = []
@@ -698,6 +720,11 @@ class SweepResult:
     failed_shards: int = 0
     degraded_targets: tuple[str, ...] = ()
     quarantined: int = 0
+    # Liveness fields distinguish an actually wedged ClickHouse writer from a
+    # source, normalisation or DELETE failure.  A partial fan-out failure has
+    # successful_target_writes > 0 and therefore must keep running.
+    all_targets_failed_shards: int = 0
+    successful_target_writes: int = 0
 
 
 def _is_retryable(exc: BaseException) -> bool:
@@ -1033,6 +1060,8 @@ def drain_once(
     inserted = 0
     quarantined = 0
     failed_shards = 0
+    all_targets_failed_shards = 0
+    successful_target_writes = 0
     degraded: dict[str, None] = {}
     # Lets a fan-out stop re-dialling a target that has already failed several
     # times THIS sweep; see FanOutOperationalWriter.begin_sweep. Absent on the
@@ -1059,6 +1088,13 @@ def drain_once(
             # as healthy in the one field the runbook says to watch.
             for name in getattr(exc, "failed_targets", ()):
                 degraded[str(name)] = None
+            if isinstance(exc, FanOutWriteError):
+                successful_target_writes += len(exc.succeeded_targets)
+                if exc.failed_targets and not exc.succeeded_targets:
+                    all_targets_failed_shards += 1
+            elif isinstance(exc, ClickHouseInsertError):
+                # The bare writer represents exactly one configured target.
+                all_targets_failed_shards += 1
             log.exception(
                 "operational_analytics_outbox.shard_failed backend=postgres shard=%d",
                 shard,
@@ -1067,6 +1103,9 @@ def drain_once(
         fetched += result.fetched
         inserted += result.inserted
         quarantined += result.quarantined
+        if result.fetched:
+            # A normal return means every configured target accepted the batch.
+            successful_target_writes += int(getattr(writer, "target_count", 1))
     elapsed = max(time.monotonic() - started, 0.000_001)
     return SweepResult(
         fetched=fetched,
@@ -1075,6 +1114,8 @@ def drain_once(
         failed_shards=failed_shards,
         degraded_targets=tuple(degraded),
         quarantined=quarantined,
+        all_targets_failed_shards=all_targets_failed_shards,
+        successful_target_writes=successful_target_writes,
     )
 
 
@@ -1098,6 +1139,15 @@ def main() -> int:
         default=float(
             os.environ.get("TR_OPERATIONAL_ANALYTICS_MAX_LAG_SECONDS", "")
             or DEFAULT_MAX_LAG_SECONDS
+        ),
+    )
+    parser.add_argument(
+        "--all-target-failure-sweeps",
+        type=int,
+        default=DEFAULT_ALL_TARGET_FAILURE_SWEEPS,
+        help=(
+            "exit non-zero after this many consecutive complete sweeps in which "
+            "no ClickHouse target accepts a batch"
         ),
     )
     parser.add_argument("--once", action="store_true")
@@ -1148,10 +1198,19 @@ def main() -> int:
             max_lag_seconds,
         )
         raise SystemExit(CONFIG_EXIT_CODE)
+    all_target_failure_bound = int(args.all_target_failure_sweeps)
+    if all_target_failure_bound <= 0:
+        log.error(
+            "operational_analytics_outbox.config_invalid backend=postgres "
+            "error=--all-target-failure-sweeps must be positive (got %s)",
+            all_target_failure_bound,
+        )
+        raise SystemExit(CONFIG_EXIT_CODE)
     # Per-shard read position, owned here so it survives ACROSS sweeps: a batch
     # that could not be deleted is stepped over, and that only helps if the next
     # sweep remembers where it got to.
     cursors: dict[int, tuple[str, str]] = {}
+    consecutive_all_target_failure_sweeps = 0
     sd_notify("READY=1")
     while True:
         sd_notify("WATCHDOG=1")
@@ -1172,10 +1231,20 @@ def main() -> int:
         # right now". The first is what the operator is asking; the second
         # carries across a sweep in which the target was skipped by the breaker.
         degraded = sorted({*result.degraded_targets, *degraded_target_names(writer)})
+        all_targets_failed = (
+            result.failed_shards > 0
+            and result.all_targets_failed_shards == result.failed_shards
+            and result.successful_target_writes == 0
+        )
+        if all_targets_failed:
+            consecutive_all_target_failure_sweeps += 1
+        else:
+            consecutive_all_target_failure_sweeps = 0
         log.info(
             "operational_analytics_outbox.metrics backend=postgres rows=%d "
             "rows_per_second=%.3f drain_lag_seconds=%.3f failed_shards=%d "
-            "copies=%d degraded_targets=%s quarantined=%d",
+            "copies=%d degraded_targets=%s quarantined=%d "
+            "all_target_failure_sweeps=%d",
             result.inserted,
             result.rows_per_second,
             lag_seconds,
@@ -1183,12 +1252,11 @@ def main() -> int:
             len(targets),
             ",".join(degraded) or "-",
             result.quarantined,
+            consecutive_all_target_failure_sweeps,
         )
-        # The bound on outbox growth is this line plus an operator. There is no
-        # automatic one: the only automatic bounds available are "delete rows a
-        # copy never received", which is the loss this whole design exists to
-        # prevent, and "stop draining", which helps nobody. See the module
-        # docstring for the two actions this alarm asks for.
+        # The storage bound is this line plus an operator.  Restarting below can
+        # heal wedged process state but cannot make a genuinely down target
+        # accept rows, and deletion without every copy remains forbidden.
         if lag_seconds >= max_lag_seconds > 0:
             log.error(
                 "operational_analytics_outbox.backlog_alarm backend=postgres "
@@ -1198,6 +1266,14 @@ def main() -> int:
                 max_lag_seconds,
                 ",".join(degraded) or "-",
             )
+        if consecutive_all_target_failure_sweeps >= all_target_failure_bound:
+            log.critical(
+                "operational_analytics_outbox.liveness_exit backend=postgres "
+                "all_target_failure_sweeps=%d bound=%d action=systemd-restart",
+                consecutive_all_target_failure_sweeps,
+                all_target_failure_bound,
+            )
+            raise SystemExit(1)
         if args.once:
             return 1 if result.failed_shards else 0
         # Back off after a failing sweep as well as an empty one. Without this

--- a/clickhouse/tr-clickhouse-operational-ingest-postgres.service
+++ b/clickhouse/tr-clickhouse-operational-ingest-postgres.service
@@ -59,11 +59,13 @@ Environment=HOME=/var/lib/tr-clickhouse-ingest
 EnvironmentFile=/etc/tr-clickhouse-ingest-postgres.env
 ExecStart=/opt/tr-clickhouse/venv/bin/python -m clickhouse.ingest_operational_outbox_postgres
 # The drain sweeps shards independently and contains per-shard failures, so it
-# survives a bad row or a ClickHouse blip on its own. Restart=always covers
-# what it cannot: process-fatal faults, and Aurora DSQL expiring the long-lived
-# connection. Without this the first such event silently ends delivery and the
-# ClickHouse tables quietly return to reading zero rows.
-Restart=always
+# survives a bad row or a ClickHouse blip on its own. It now exits non-zero after
+# three complete zero-success writer sweeps so a fresh process can heal stale
+# state; partial fan-out degradation stays alive to feed the healthy copy and
+# emit the backlog alarm. Restart=on-failure covers that exit, process-fatal
+# faults, and Aurora DSQL expiring the long-lived connection. Without this the
+# first such event silently ends delivery.
+Restart=on-failure
 RestartSec=5
 # ...except for a CONFIGURATION error (EX_CONFIG), which running again cannot
 # fix. Without this, a typo in the replica block below crash-loops every 5s

--- a/scripts/deploy/aws_eu_clickhouse_drain_install.sh
+++ b/scripts/deploy/aws_eu_clickhouse_drain_install.sh
@@ -151,6 +151,28 @@ fi
 [ -n "$INSTANCE_ID" ] && [ "$INSTANCE_ID" != "None" ] || die "no running instance named $NODE_NAME in $REGION"
 log "node $INSTANCE_ID ($NODE_NAME, $REGION)"
 
+# Capture both values on the node, whose clock systemd uses for
+# ExecMainStartTimestamp.  The pre-install PID is the identity proof that the
+# install did not leave the old in-memory code running.  A missing unit reports
+# PID 0 so the same path also covers a first install.
+INSTALL_STATE="$(ssm "drain: capture running process" "
+set -eu
+printf 'install_started_at=%s\n' \"\$(date --utc +%s)\"
+if pid=\$(systemctl show $SERVICE --property=ExecMainPID --value 2>/dev/null); then
+  case \"\$pid\" in ''|*[!0-9]*) pid=0 ;; esac
+else
+  pid=0
+fi
+printf 'pre_install_pid=%s\n' \"\$pid\"
+")"
+INSTALL_STARTED_AT="$(printf '%s\n' "$INSTALL_STATE" | sed -n 's/^install_started_at=//p' | tail -1)"
+PRE_INSTALL_PID="$(printf '%s\n' "$INSTALL_STATE" | sed -n 's/^pre_install_pid=//p' | tail -1)"
+case "$INSTALL_STARTED_AT:$PRE_INSTALL_PID" in
+  *[!0-9:]*) die "invalid install identity from node: $INSTALL_STATE" ;;
+  :*|*:) die "incomplete install identity from node: $INSTALL_STATE" ;;
+esac
+log "install epoch $INSTALL_STARTED_AT; pre-install PID $PRE_INSTALL_PID"
+
 # ---------------------------------------------------------------------------
 # 2. PREFLIGHT: can the node authenticate to DSQL at all?
 #
@@ -332,6 +354,12 @@ cd '$STAGE_DIR'
 # ---------------------------------------------------------------------------
 ssm "drain: activate $REMOTE_ROOT" "
 set -eux
+# Stop before touching the process's WorkingDirectory.  Moving a live cwd and
+# then deleting it on the next install leaves every child unable to start with
+# Poco 'cannot get current directory', while the Python loop remains active.
+if systemctl show $SERVICE >/dev/null 2>&1; then
+  systemctl stop $SERVICE
+fi
 rm -rf '${REMOTE_ROOT}.previous'
 if [ -d '$REMOTE_ROOT' ]; then mv '$REMOTE_ROOT' '${REMOTE_ROOT}.previous'; fi
 mv '$STAGE_DIR' '$REMOTE_ROOT'
@@ -393,22 +421,43 @@ printf '%s' '$UNIT_B64' | base64 -d > /etc/systemd/system/$SERVICE
 chmod 644 /etc/systemd/system/$SERVICE
 chown -R '$SERVICE_USER':'$SERVICE_USER' '$REMOTE_ROOT'
 systemctl daemon-reload
-systemctl enable --now $SERVICE
+systemctl enable $SERVICE
+# Explicit start, not enable --now: --now is a no-op for an already-active
+# service and was the mechanism that kept the old PID running old bytecode.
+systemctl start $SERVICE
 "
 
 # ---------------------------------------------------------------------------
-# 9. Verify. A unit that is 'active' proves only that execve succeeded.
-#
-# The proof is the metrics line the sweep loop emits every poll, and a
-# ClickHouse count that is no longer zero.
+# 9. Verify. A unit that is 'active' proves only that execve succeeded.  Require
+# a different PID started during this install and a complete, error-free sweep
+# from that PID.  The ClickHouse counts remain useful operator context, but an
+# idle healthy drain may legitimately have rows=0 for a sweep.
 # ---------------------------------------------------------------------------
 log "waiting 45s for the first sweeps"
 sleep 45
 ssm "drain: verify" "
 set -eu
-systemctl is-active $SERVICE || true
-echo '--- metrics (operational_analytics_outbox.metrics) ---'
-journalctl -u $SERVICE --no-pager -n 200 | grep -E 'outbox\.(metrics|targets|config_invalid|backlog_alarm)' | tail -20
+systemctl is-active $SERVICE
+NEW_PID=\$(systemctl show $SERVICE --property=ExecMainPID --value)
+test -n \"\$NEW_PID\"
+test \"\$NEW_PID\" -gt 0
+test \"\$NEW_PID\" != '$PRE_INSTALL_PID'
+EXEC_MAIN_STARTED_AT=\$(systemctl show $SERVICE --property=ExecMainStartTimestamp --value)
+EXEC_MAIN_STARTED_EPOCH=\$(date --date=\"\$EXEC_MAIN_STARTED_AT\" +%s)
+test \"\$EXEC_MAIN_STARTED_EPOCH\" -ge '$INSTALL_STARTED_AT'
+
+# A metrics line is emitted after a complete sweep.  Filter by the new PID so
+# healthy-looking rows=0 output from the replaced process cannot satisfy the
+# install, then reject the exact failure signatures from the incident.
+NEW_JOURNAL=\$(journalctl _PID=\"\$NEW_PID\" --since '@$INSTALL_STARTED_AT' --no-pager -o cat)
+printf '%s\n' \"\$NEW_JOURNAL\" | grep -q 'operational_analytics_outbox.metrics'
+if printf '%s\n' \"\$NEW_JOURNAL\" | grep -Eq 'shard_failed|Traceback'; then
+  echo 'new drain PID logged a failed shard or traceback' >&2
+  exit 1
+fi
+echo \"new PID \$NEW_PID started at \$EXEC_MAIN_STARTED_AT and completed a clean sweep\"
+echo '--- metrics (new PID only) ---'
+printf '%s\n' \"\$NEW_JOURNAL\" | grep -E 'outbox\.(metrics|targets|config_invalid|backlog_alarm)' | tail -20
 echo '--- clickhouse ---'
 export CLICKHOUSE_PASSWORD=\"\$('$REMOTE_ROOT/venv/bin/python' -c \"import boto3;print(boto3.client('secretsmanager',region_name='${REGION}').get_secret_value(SecretId='${SECRET_ID}')['SecretString'],end='')\")\"
 clickhouse-client --user '$CH_USER' --database '$CH_DATABASE' --query \\
@@ -444,13 +493,11 @@ EOF
 # ---------------------------------------------------------------------------
 # 10. The outside view.
 #
-# Step 9 ran systemctl, the journal and a ClickHouse count on the node and
-# PRINTED them. Be exact about what that is: this script does not assert on any
-# of those three outputs, so what step 9 establishes is that the commands ran —
-# a human still has to read `copies=`, `rows=` and the two counts and decide.
-# An earlier version of the paragraph below said the run had established that
-# the unit "swept, and moved rows out of the outbox", which is the same
-# printing-is-doing mistake one level down, inside the file written to end it.
+# Step 9 proves that systemd is active, replaced the pre-install PID with one
+# started during this run, and that the new PID completed a sweep without a
+# shard failure or traceback.  It also prints ClickHouse counts as operator
+# context; those counts are not a movement proof because an idle healthy drain
+# may have nothing new to insert.
 #
 # What the gate below adds is the question a rollout has to answer and no
 # in-VPC command can: whether anyone WITHOUT a session on that node can tell.
@@ -481,9 +528,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # absence caused the outage could not be run by the person most likely to run
 # it. tests/test_deploy_script_execution.py now parses every deploy script with
 # the local shell, so a repeat is caught wherever the old shell is.
-NEXT_STEPS='The drain install itself did not fail. Read step 9 output above before
-touching anything: copies=, drain_lag_seconds, and the two ClickHouse
-counts are printed there and asserted nowhere.'
+NEXT_STEPS='The drain install itself did not fail. Step 9 proved the new PID
+completed a clean sweep. Read copies=, drain_lag_seconds, and the ClickHouse
+counts there for current state; the counts are context, not a movement proof.'
 
 VERIFY_RC=0
 require_cloud_complete aws "$NEXT_STEPS" || VERIFY_RC=$?
@@ -494,8 +541,8 @@ if [ "$VERIFY_RC" -eq 5 ]; then
 DRAIN INSTALLED; NOT YET OBSERVABLE FROM OUTSIDE.
 
 What this run did: shipped the code, installed and enabled the unit, and then
-printed the drain's journal and a ClickHouse row count from the node (step 9).
-Read those. Nothing in this script asserts on them.
+proved the new PID completed a clean sweep, and printed a ClickHouse row count
+from the node (step 9). Read the count as context, not as a movement proof.
 
 What it could not do at all: tell whether anyone WITHOUT a session on this node
 can see the drain. The tr-eu App Runner control plane -- the deployment holding

--- a/tests/test_aws_analytics_drain_install.py
+++ b/tests/test_aws_analytics_drain_install.py
@@ -89,7 +89,9 @@ def test_drain_unit_is_notify_watchdog_managed() -> None:
     assert "Type=notify" in unit
     assert "NotifyAccess=main" in unit
     assert "WatchdogSec=600" in unit
-    assert "Restart=always" in unit
+    assert "Restart=on-failure" in unit
+    assert "RestartSec=5" in unit
+    assert "RestartPreventExitStatus=78" in unit
 
 
 def test_install_refuses_to_proceed_without_dsql_permission() -> None:
@@ -131,6 +133,39 @@ def test_install_stages_and_verifies_before_swapping_anything_in() -> None:
     # The swap happens after the smoke test, never before.
     assert script.index("import smoke test (staging)") < script.index("drain: activate")
     assert "${REMOTE_ROOT}.previous" in script
+
+
+def test_aws_installer_replaces_the_running_process_and_verify_can_fail() -> None:
+    """A process must not keep its cwd inside the tree the installer rotates.
+
+    ``enable --now`` does not restart an active unit.  The 2026-08-30 install
+    therefore left the old PID running from ``/opt/tr-clickhouse.previous
+    (deleted)`` for 47 hours, while the verify swallowed ``is-active`` and read
+    healthy-looking ``rows=0`` metrics from that old process.
+
+    Pin the ordering and the identity proof, not merely the presence of a
+    restart-shaped command: deleting the stop, replacing the explicit start
+    with ``enable --now``, or restoring ``|| true`` must make this test red.
+    """
+    script = INSTALL.read_text()
+    capture = script.index('ssm "drain: capture running process"')
+    stop = script.index("systemctl stop $SERVICE")
+    rotate = script.index("rm -rf '${REMOTE_ROOT}.previous'")
+    start = script.index("systemctl start $SERVICE")
+    verify_start = script.index('ssm "drain: verify"')
+    verify = script[verify_start : script.index("cat <<EOF", verify_start)]
+
+    assert capture < stop < rotate < start
+    assert "systemctl enable --now $SERVICE" not in script
+    assert "systemctl is-active $SERVICE" in verify
+    assert "|| true" not in verify
+    assert 'ExecMainPID --value' in verify
+    assert 'ExecMainStartTimestamp --value' in verify
+    assert "test \\\"\\$NEW_PID\\\" != '$PRE_INSTALL_PID'" in verify
+    assert "test \\\"\\$EXEC_MAIN_STARTED_EPOCH\\\" -ge '$INSTALL_STARTED_AT'" in verify
+    assert 'journalctl _PID=\\"\\$NEW_PID\\"' in verify
+    assert "operational_analytics_outbox.metrics" in verify
+    assert "shard_failed|Traceback" in verify
 
 
 def test_install_writes_the_secret_by_running_a_command_not_by_pasting() -> None:

--- a/tests/test_azure_clickhouse_drain_install.py
+++ b/tests/test_azure_clickhouse_drain_install.py
@@ -93,7 +93,9 @@ def test_installed_unit_is_notify_watchdog_managed() -> None:
     assert "Type=notify" in unit
     assert "NotifyAccess=main" in unit
     assert "WatchdogSec=600" in unit
-    assert "Restart=always" in unit
+    assert "Restart=on-failure" in unit
+    assert "RestartSec=5" in unit
+    assert "RestartPreventExitStatus=78" in unit
 
 
 def test_final_verification_requires_a_clickhouse_row_count_to_advance(

--- a/tests/test_clickhouse_node_provisioning.py
+++ b/tests/test_clickhouse_node_provisioning.py
@@ -369,7 +369,7 @@ def test_stockholm_states_which_tables_the_second_copy_covers() -> None:
 def test_the_drain_unit_refuses_to_restart_a_misconfigured_drain() -> None:
     """A config error cannot be fixed by running again.
 
-    With a bare Restart=always, a typo in the replica block crash-loops every
+    With a bare restart policy, a typo in the replica block crash-loops every
     RestartSec while the outbox grows at full rate -- and the backlog alarm that
     is supposed to bound that growth is emitted BY the process that is not
     running. The exit status the drain uses for configuration errors must be
@@ -380,7 +380,8 @@ def test_the_drain_unit_refuses_to_restart_a_misconfigured_drain() -> None:
     unit = (ROOT / "clickhouse/tr-clickhouse-operational-ingest-postgres.service").read_text()
 
     assert f"RestartPreventExitStatus={CONFIG_EXIT_CODE}" in unit
-    assert "Restart=always" in unit
+    assert "Restart=on-failure" in unit
+    assert "RestartSec=5" in unit
 
 
 def test_stockholm_documents_that_it_starts_empty_and_is_not_backfilled() -> None:

--- a/tests/test_operational_analytics_dual_write.py
+++ b/tests/test_operational_analytics_dual_write.py
@@ -734,6 +734,8 @@ def test_a_hard_down_target_is_skipped_after_a_few_failures_in_one_sweep(
     )
     # Every shard still failed -- a skipped target is an undelivered target.
     assert result.failed_shards == 12
+    assert result.all_targets_failed_shards == 0
+    assert result.successful_target_writes == 12
     assert source.delete_calls == []
     assert len(source.rows) == 12
     # And the healthy node still got every shard: the breaker is per-target.
@@ -793,6 +795,21 @@ def test_both_nodes_failing_is_reported_as_both(monkeypatch: pytest.MonkeyPatch)
     assert failure.value.failed_targets == ["primary", "stockholm"]
     assert failure.value.succeeded_targets == []
     assert sorted(degraded_target_names(writer)) == ["primary", "stockholm"]
+
+
+def test_a_sweep_classifies_zero_success_only_when_every_target_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The liveness counter consumes real fan-out outcomes, not metrics guesses."""
+    fleet = _Fleet(down={"local", STOCKHOLM})
+    fleet.install(monkeypatch)
+    rows = [_row(f"gen-total-outage-{index}", shard=index) for index in range(4)]
+
+    result = drain_once(_Source(rows), _dual_writer(), batch_size=10, shard_count=4)
+
+    assert result.failed_shards == 4
+    assert result.all_targets_failed_shards == 4
+    assert result.successful_target_writes == 0
 
 
 def test_a_persistently_failing_node_keeps_the_backlog_rather_than_dropping_it(
@@ -1133,6 +1150,85 @@ def test_the_drain_reuses_one_read_cursor_across_sweeps(
 
     assert len(seen) == 3
     assert len(set(seen)) == 1, "each sweep must resume the previous sweep's cursor"
+
+
+def test_n_consecutive_all_target_failure_sweeps_exit_nonzero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fully wedged writer must let systemd replace the process.
+
+    Disabling the liveness exit makes the sentinel fourth call exit zero, so
+    this is a mutation guard on the exit itself rather than only its counter.
+    """
+    bound = 3
+    sweeps = 0
+
+    def all_targets_failed(*_args: Any, **_kwargs: Any) -> Any:
+        nonlocal sweeps
+        sweeps += 1
+        if sweeps > bound:
+            raise SystemExit(0)
+        return drain_module.SweepResult(
+            fetched=0,
+            inserted=0,
+            rows_per_second=0.0,
+            failed_shards=32,
+            all_targets_failed_shards=32,
+            successful_target_writes=0,
+        )
+
+    monkeypatch.setattr(drain_module, "drain_once", all_targets_failed)
+    monkeypatch.setattr(drain_module.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(SystemExit) as exit_info:
+        _run_main(
+            monkeypatch,
+            DUAL_ENV,
+            oldest=None,
+            once=False,
+            argv=["--all-target-failure-sweeps", str(bound)],
+        )
+
+    assert exit_info.value.code != 0
+    assert sweeps == bound
+
+
+def test_one_failed_target_with_copies_two_does_not_trigger_liveness_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Partial degradation stays alive to feed and alarm from the good copy."""
+    bound = 3
+    sweeps = 0
+
+    def one_target_failed(*_args: Any, **_kwargs: Any) -> Any:
+        nonlocal sweeps
+        sweeps += 1
+        if sweeps > bound:
+            raise SystemExit(0)
+        return drain_module.SweepResult(
+            fetched=0,
+            inserted=0,
+            rows_per_second=0.0,
+            failed_shards=32,
+            all_targets_failed_shards=0,
+            successful_target_writes=32,
+            degraded_targets=("stockholm",),
+        )
+
+    monkeypatch.setattr(drain_module, "drain_once", one_target_failed)
+    monkeypatch.setattr(drain_module.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(SystemExit) as exit_info:
+        _run_main(
+            monkeypatch,
+            DUAL_ENV,
+            oldest=None,
+            once=False,
+            argv=["--all-target-failure-sweeps", str(bound)],
+        )
+
+    assert exit_info.value.code == 0
+    assert sweeps == bound + 1
 
 
 def test_a_healthy_drain_raises_no_alarm(

--- a/tests/test_operational_analytics_outbox_postgres.py
+++ b/tests/test_operational_analytics_outbox_postgres.py
@@ -1366,6 +1366,31 @@ class TestClickHouseIdentityIsConfigurable:
         assert command[command.index("--user") + 1] == "default"
         assert command[command.index("--database") + 1] == "default"
 
+    def test_clickhouse_client_subprocess_uses_a_stable_explicit_cwd(
+        self, monkeypatch: Any
+    ) -> None:
+        """A rotated parent cwd must not prevent clickhouse-client from starting.
+
+        The systemd unit deliberately uses ``/opt/tr-clickhouse`` so ``python
+        -m`` can import the flat installed package.  If an installer ever moves
+        that directory out from under a running process, each child must still
+        start somewhere valid.  Removing ``cwd=`` from the subprocess call is
+        the mutation this test guards.
+        """
+        from clickhouse import ingest_operational_outbox as mod
+        from clickhouse.ingest_operational_outbox import ClickHouseOperationalWriter
+
+        calls: list[dict[str, Any]] = []
+
+        def fake_run(_command: list[str], **kwargs: Any) -> Any:
+            calls.append(kwargs)
+            return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+        monkeypatch.setattr(mod.subprocess, "run", fake_run)
+        ClickHouseOperationalWriter(password="x").insert([self._event()])  # noqa: S106
+
+        assert calls[0]["cwd"] == "/"
+
 
 # --------------------------------------------------------------------------
 # The published lag read


### PR DESCRIPTION
Root cause and recovery of the 47-hour AWS-EU analytics outage (#638), as three separately reviewable commits.

**What happened.** The 2026-08-30 drain-install reported success and killed the drain it was installing. `systemctl enable --now` is a no-op on a running unit, so the install rotated `/opt/tr-clickhouse` on disk and left the two-day-old process inside the deleted tree (`readlink /proc/<pid>/cwd → /opt/tr-clickhouse.previous (deleted)`). Every `clickhouse-client` it spawned then died at startup with Poco `cannot get current directory`; every shard logged `shard_failed`; the daemon caught each one and looped — `active`, `NRestarts=0`, delivering nothing. The install's verify passed on that doomed PID because `is-active || true` cannot fail and a `rows=0` metrics line looks healthy.

**Three defects, three commits.**
1. **Installer** — stop before rotating, explicit start after (no `enable --now`); verify now fails unless the PID changed, started during this install, and the new PID's own journal (`_PID=`) shows a clean sweep. Azure and GCP installers already restart and verify honestly (swept, unchanged).
2. **Subprocess cwd** — `clickhouse-client` runs with `cwd=/` so an inherited dead cwd cannot kill delivery. Unit `WorkingDirectory` unchanged (`python -m` depends on it).
3. **Liveness** — after three consecutive complete sweeps with zero successful target writes the drain exits 1 and systemd restarts it with fresh state. Partial degradation (one target down, copies>1) keeps running by design. Unit `Restart=always → on-failure`: the only clean exit is the deliberate `--once` mode, which `always` would have restart-looped; DSQL expiry reconnects in-loop; the liveness exit is 1, not the restart-prevented 78 (`RestartPreventExitStatus=78`, `RestartSec=5` retained).

**Gate (Fable, on an isolated snapshot of the final tree, never the live worktree):** five test files fully green (37/55/44/7/27); four mutations each produce a genuine `1 failed` — cwd removed, `|| true` restored, `enable --now` restored, liveness exit disabled — files restored byte-identical. Ruff and mypy clean; full suite 7,819 passed with only sandbox-environment failures (loopback binds, missing `jq`). Needs admin merge.

Authored by Sol (codex-cli); reviewed and gated by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)