### PR TITLE
Bound regional quota ledger RPCs

### DIFF
--- a/src/trusted_router/regional_quota_ledger.py
+++ b/src/trusted_router/regional_quota_ledger.py
@@ -15,6 +15,7 @@ import threading
 import uuid
 from collections.abc import Callable
 from datetime import UTC, datetime
+from time import monotonic
 from typing import Any, Protocol
 
 from trusted_router.services.regional_quota_leases import (
@@ -28,6 +29,9 @@ _FAMILY = "lease"
 _STATE_COLUMN = b"state"
 _VERSION_COLUMN = b"version"
 _MAX_CAS_ATTEMPTS = 16
+_DEFAULT_OPERATION_TIMEOUT_SECONDS = 2.0
+_BIGTABLE_READ_TIMEOUT_PADDING_SECONDS = 1.0
+_MIN_BIGTABLE_READ_BUDGET_SECONDS = _BIGTABLE_READ_TIMEOUT_PADDING_SECONDS + 0.05
 
 
 class RegionalLeaseLedgerError(RuntimeError):
@@ -243,11 +247,20 @@ class InMemoryRegionalQuotaLedger:
 class BigtableRegionalQuotaLedger:
     """Single-row CAS ledger routed through fixed regional app profiles."""
 
-    def __init__(self, tables_by_region: dict[str, Any]) -> None:
+    def __init__(
+        self,
+        tables_by_region: dict[str, Any],
+        *,
+        operation_timeout_seconds: float = _DEFAULT_OPERATION_TIMEOUT_SECONDS,
+    ) -> None:
         if not tables_by_region:
             raise ValueError("at least one regional Bigtable table is required")
+        if not 1.1 <= operation_timeout_seconds <= 10.0:
+            raise ValueError("operation_timeout_seconds must be between 1.1 and 10")
         self._tables = dict(tables_by_region)
+        self._operation_timeout_seconds = operation_timeout_seconds
         try:
+            from google.cloud.bigtable.row_data import DEFAULT_RETRY_READ_ROWS
             from google.cloud.bigtable.row_filters import (
                 CellsColumnLimitFilter,
                 ColumnQualifierRegexFilter,
@@ -262,6 +275,7 @@ class BigtableRegionalQuotaLedger:
         self._family_filter = FamilyNameRegexFilter
         self._chain_filter = RowFilterChain
         self._value_filter = ValueRegexFilter
+        self._default_read_retry = DEFAULT_RETRY_READ_ROWS
 
     def supports_region(self, region: str) -> bool:
         return region in self._tables
@@ -276,7 +290,10 @@ class BigtableRegionalQuotaLedger:
         row.set_cell(_FAMILY, _STATE_COLUMN, state, state=False)
         row.set_cell(_FAMILY, _VERSION_COLUMN, version, state=False)
         try:
-            matched = bool(row.commit())
+            matched = self._commit_conditional_row(
+                row,
+                timeout_seconds=self._operation_timeout_seconds,
+            )
         except Exception as exc:  # pragma: no cover - remote transport
             raise RegionalLeaseLedgerError("regional lease initialization failed") from exc
         if not matched:
@@ -291,7 +308,8 @@ class BigtableRegionalQuotaLedger:
     def get(self, lease_id: str, *, region: str) -> RegionalQuotaLease | None:
         table = self._table(region)
         try:
-            row = table.read_row(
+            row = self._read_row(
+                table,
                 _row_key_for(region, lease_id),
                 filter_=self._state_filter(),
             )
@@ -314,8 +332,15 @@ class BigtableRegionalQuotaLedger:
                 row.set_cell(_FAMILY, _STATE_COLUMN, b'{"status":"ok"}', state=state)
                 row.set_cell(_FAMILY, _VERSION_COLUMN, version, state=state)
             try:
-                row.commit()
-                durable = table.read_row(row_key, filter_=self._state_filter())
+                self._commit_conditional_row(
+                    row,
+                    timeout_seconds=self._operation_timeout_seconds,
+                )
+                durable = self._read_row(
+                    table,
+                    row_key,
+                    filter_=self._state_filter(),
+                )
             except Exception as exc:  # pragma: no cover - remote transport
                 raise RegionalLeaseLedgerError(
                     "regional ledger transactional health check failed"
@@ -433,9 +458,19 @@ class BigtableRegionalQuotaLedger:
         table = self._table(region)
         row_key = _row_key_for(region, lease_id)
         last_error: Exception | None = None
+        deadline = monotonic() + self._operation_timeout_seconds
         for _attempt in range(_MAX_CAS_ATTEMPTS):
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                last_error = TimeoutError("regional ledger operation budget exhausted")
+                break
             try:
-                row_data = table.read_row(row_key, filter_=self._state_filter())
+                row_data = self._read_row(
+                    table,
+                    row_key,
+                    filter_=self._state_filter(),
+                    timeout_seconds=remaining,
+                )
             except Exception as exc:  # pragma: no cover - remote transport
                 raise RegionalLeaseLedgerError("regional lease read failed") from exc
             if row_data is None:
@@ -449,7 +484,14 @@ class BigtableRegionalQuotaLedger:
             row.set_cell(_FAMILY, _STATE_COLUMN, updated_state, state=True)
             row.set_cell(_FAMILY, _VERSION_COLUMN, next_version, state=True)
             try:
-                if row.commit():
+                remaining = deadline - monotonic()
+                if remaining <= 0:
+                    last_error = TimeoutError("regional ledger operation budget exhausted")
+                    break
+                if self._commit_conditional_row(
+                    row,
+                    timeout_seconds=remaining,
+                ):
                     return updated
             except Exception as exc:  # pragma: no cover - remote transport
                 # The commit may have reached Bigtable. Re-read on the next
@@ -459,6 +501,62 @@ class BigtableRegionalQuotaLedger:
         raise RegionalLeaseCasExhausted(
             "regional lease compare-and-swap retries were exhausted"
         ) from last_error
+
+    def _read_row(
+        self,
+        table: Any,
+        row_key: bytes,
+        *,
+        filter_: Any,
+        timeout_seconds: float | None = None,
+    ) -> Any:
+        # PartialRowsData adds one second to the Retry deadline when creating
+        # the streaming RPC. Subtract that padding so a transient Bigtable
+        # failure cannot consume the gateway's 25-second request budget.
+        operation_budget = min(
+            self._operation_timeout_seconds,
+            timeout_seconds if timeout_seconds is not None else self._operation_timeout_seconds,
+        )
+        if operation_budget < _MIN_BIGTABLE_READ_BUDGET_SECONDS:
+            raise TimeoutError("regional ledger read budget exhausted")
+        retry_deadline = max(
+            0.05,
+            operation_budget - _BIGTABLE_READ_TIMEOUT_PADDING_SECONDS,
+        )
+        return table.read_row(
+            row_key,
+            filter_=filter_,
+            retry=self._default_read_retry.with_deadline(retry_deadline),
+        )
+
+    @staticmethod
+    def _commit_conditional_row(row: Any, *, timeout_seconds: float) -> bool:
+        """Commit a legacy ConditionalRow with an explicit RPC deadline.
+
+        google-cloud-bigtable's ConditionalRow.commit() does not expose the
+        generated client's timeout argument. Use the same request fields as
+        that method so the billing hot path cannot inherit its 20-second
+        default. Test doubles without the legacy client's private attributes
+        keep using their ordinary commit implementation.
+        """
+
+        table = getattr(row, "_table", None)
+        if table is None:
+            return bool(row.commit())
+        data_client = table._instance._client.table_data_client
+        true_mutations = row._get_mutations(state=True)
+        false_mutations = row._get_mutations(state=False)
+        response = data_client.check_and_mutate_row(
+            table_name=table.name,
+            row_key=row._row_key,
+            predicate_filter=row._filter.to_pb(),
+            app_profile_id=table._app_profile_id,
+            true_mutations=true_mutations,
+            false_mutations=false_mutations,
+            timeout=max(0.05, timeout_seconds),
+        )
+        row.clear()
+        return bool(response.predicate_matched)
 
     def _table(self, region: str) -> Any:
         table = self._tables.get(region)

--- a/tests/test_gateway_fallback_billing.py
+++ b/tests/test_gateway_fallback_billing.py
@@ -15,7 +15,10 @@ from trusted_router.partner_billing import (
     PARTNER_OPERATOR_COST_SETTLE_FIELD,
 )
 from trusted_router.provider_lifecycle import provider_model_retired
-from trusted_router.regional_quota_ledger import InMemoryRegionalQuotaLedger
+from trusted_router.regional_quota_ledger import (
+    InMemoryRegionalQuotaLedger,
+    RegionalLeaseLedgerError,
+)
 from trusted_router.routes.helpers import cost_microdollars
 from trusted_router.routes.internal import gateway as gateway_routes
 from trusted_router.storage import STORE, CreditAccount, Workspace, configure_store
@@ -169,6 +172,58 @@ def test_allowlisted_uncapped_key_authorizes_from_bounded_regional_escrow() -> N
     assert reservation["hold_usage_type"] == "RegionalCredits"
     assert reservation["credit_reserved_micro"] == 0
     assert sum(row["reserved"] for row in db.typed[CREDIT_BALANCE_TABLE].values()) > 0
+
+
+def test_regional_ledger_failure_falls_back_to_exact_global_authorization() -> None:
+    class UnavailableRegionalLedger(InMemoryRegionalQuotaLedger):
+        def initialize(self, lease: object) -> object:
+            del lease
+            raise RegionalLeaseLedgerError("regional ledger unavailable")
+
+    store, db, _ = make_fake_store(request_record_write_mode="typed")
+    store._regional_quota_ledger = UnavailableRegionalLedger()
+    workspace = store.create_workspace(
+        "owner",
+        "regional-fallback",
+        trial_credit_microdollars=100_000_000,
+    )
+    _raw, api_key = store.create_api_key(
+        workspace_id=workspace.id,
+        name="regional-fallback",
+        creator_user_id="owner",
+    )
+    configure_store(store)
+    client = TestClient(
+        create_app(
+            Settings(
+                environment="test",
+                regional_quota_leases_enabled=True,
+                regional_quota_lease_issuance_enabled=True,
+                regional_quota_lease_pilot_workspace_ids=workspace.id,
+            ),
+            configure_store_arg=False,
+            init_observability=False,
+        )
+    )
+
+    response = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": api_key.hash,
+            "model": "anthropic/claude-opus-4.7",
+            "estimated_input_tokens": 1_000,
+            "max_output_tokens": 100,
+            "route_type": "chat.completions",
+            "idempotency_key": "regional-ledger-global-fallback",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    authorization = store.get_gateway_authorization(response.json()["data"]["authorization_id"])
+    assert authorization is not None
+    assert authorization.settlement == "local"
+    reservation = db.reservations[str(authorization.credit_reservation_id)]
+    assert reservation["credit_reserved_micro"] > 0
 
 
 def test_sakana_fugu_uses_exact_global_settlement_not_regional_escrow() -> None:

--- a/tests/test_regional_quota_ledger.py
+++ b/tests/test_regional_quota_ledger.py
@@ -138,6 +138,72 @@ def test_bigtable_health_check_fails_when_transactional_writes_fail() -> None:
         ledger.health_check()
 
 
+def test_bigtable_reads_use_a_bounded_hot_path_retry_deadline() -> None:
+    table = _FakeBigtableTable()
+    ledger = BigtableRegionalQuotaLedger(
+        {"us-central1": table},
+        operation_timeout_seconds=2.0,
+    )
+    ledger.initialize(_lease())
+
+    assert ledger.get("rql-test", region="us-central1") == _lease()
+    assert table.read_retry_deadlines
+    assert max(table.read_retry_deadlines) <= 1.0
+
+
+def test_bigtable_cas_commit_uses_remaining_operation_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    table = _FakeBigtableTable()
+    ledger = BigtableRegionalQuotaLedger(
+        {"us-central1": table},
+        operation_timeout_seconds=2.0,
+    )
+    ledger.initialize(_lease())
+    observed_timeouts: list[float] = []
+    original = ledger._commit_conditional_row
+
+    def recording_commit(row: Any, *, timeout_seconds: float) -> bool:
+        observed_timeouts.append(timeout_seconds)
+        return original(row, timeout_seconds=timeout_seconds)
+
+    monkeypatch.setattr(ledger, "_commit_conditional_row", recording_commit)
+
+    ledger.reserve(
+        "rql-test",
+        region="us-central1",
+        hold_id="bounded-hold",
+        fingerprint="bounded-fingerprint",
+        amount_microdollars=100,
+        fencing_token=9,
+        key_hash="key-1",
+        key_shard=1,
+        now=NOW,
+    )
+
+    assert observed_timeouts
+    assert all(0 < timeout <= 2.0 for timeout in observed_timeouts)
+
+
+def test_bigtable_conditional_commit_forwards_explicit_rpc_timeout() -> None:
+    row = _FakeLegacyConditionalRow()
+
+    assert BigtableRegionalQuotaLedger._commit_conditional_row(
+        row,
+        timeout_seconds=0.75,
+    )
+    assert row._table._instance._client.table_data_client.calls == [0.75]
+    assert row.cleared is True
+
+
+def test_bigtable_operation_timeout_rejects_unsafe_values() -> None:
+    with pytest.raises(ValueError, match="between 1.1 and 10"):
+        BigtableRegionalQuotaLedger(
+            {"us-central1": _FakeBigtableTable()},
+            operation_timeout_seconds=1.0,
+        )
+
+
 def test_bigtable_cas_matches_only_the_latest_version_cell() -> None:
     ledger = BigtableRegionalQuotaLedger({"us-central1": _FakeBigtableTable()})
 
@@ -219,11 +285,47 @@ class _FakeBigtableTable:
         self.rows: dict[bytes, dict[bytes, bytes]] = {}
         self.raise_after_next_applied_commit = False
         self.reject_conditional_commits = False
+        self.read_retry_deadlines: list[float] = []
 
     def row(self, row_key: bytes, *, filter_: Any) -> _FakeConditionalRow:
         return _FakeConditionalRow(self, row_key, filter_)
 
-    def read_row(self, row_key: bytes, *, filter_: Any) -> _ReadRow | None:
+    def read_row(self, row_key: bytes, *, filter_: Any, retry: Any) -> _ReadRow | None:
         del filter_
+        self.read_retry_deadlines.append(float(retry._deadline))
         values = self.rows.get(row_key)
         return None if values is None else _ReadRow(values)
+
+
+class _FakeGeneratedDataClient:
+    def __init__(self) -> None:
+        self.calls: list[float] = []
+
+    def check_and_mutate_row(self, **kwargs: Any) -> Any:
+        self.calls.append(float(kwargs["timeout"]))
+        return type("Response", (), {"predicate_matched": True})()
+
+
+class _FakeLegacyConditionalRow:
+    def __init__(self) -> None:
+        data_client = _FakeGeneratedDataClient()
+        client = type("Client", (), {"table_data_client": data_client})()
+        instance = type("Instance", (), {"_client": client})()
+        self._table = type(
+            "Table",
+            (),
+            {
+                "_instance": instance,
+                "_app_profile_id": "tr-rql-us-central1",
+                "name": "projects/test/instances/test/tables/quota",
+            },
+        )()
+        self._row_key = b"row-key"
+        self._filter = type("Filter", (), {"to_pb": lambda _self: object()})()
+        self.cleared = False
+
+    def _get_mutations(self, *, state: bool) -> list[object]:
+        return [object()] if state else []
+
+    def clear(self) -> None:
+        self.cleared = True


### PR DESCRIPTION
## Summary

- Cap regional Bigtable reads and conditional writes to a two-second hot-path budget.
- Preserve safe global Spanner fallback for authorization.
- Preserve durable retry semantics for settlement and refund.
- Add regression coverage for explicit RPC deadlines and fallback billing.

## Incident

Six synthetic-monitor authorize/settle calls returned 503 from us-central1 after legacy Bigtable defaults waited 27 to 61 seconds. No customer workspace was affected, but the same behavior could have delayed customer billing calls.

## Verification

- `ruff check .`
- `mypy`
- 116 focused regional quota, gateway billing, and settle-outbox tests
