### PR TITLE
Spend-lease pure state machine (Stage B unit 1)

### DIFF
--- a/src/trusted_router/spend_lease_state.py
+++ b/src/trusted_router/spend_lease_state.py
@@ -1,0 +1,1003 @@
+"""Pure state machine for authoritative spend-lease allocations.
+
+Implements Stage B decisions 9–22 of the spend-lease design record (the pure state
+machine, decided over twenty adversarial rounds); each invariant below cites its decision.
+
+This module contains no storage or clock I/O.  It implements design decisions
+9--22: lifetime-monotonic capacity (9), proof-derived allocation terminality
+(10, 14, 20, 22), separate grant generation and CAS version (12), the ordered
+authorization-first replay table (13), admission/freeze rules (15, 16, 18),
+construction-time amount and provenance checks (17), the unified open predicate
+(18--20, 22), and owner-fenced bind/compensate transitions (21--22).
+
+Only the regional precedent's immutable-record, ``__post_init__`` validation,
+and true-replay-before-lifecycle shape is reused.  In particular, refunds never
+restore capacity (decision 9) and a local allocation is never consulted before
+the caller's durable authorization observation (decision 13, carve-outs iii and
+viii).
+"""
+
+from __future__ import annotations
+
+from dataclasses import InitVar, dataclass, replace
+from datetime import datetime, timedelta
+from enum import StrEnum
+from typing import TypeAlias
+
+
+class SpendLeaseStateError(ValueError):
+    """Base class for deterministic state-machine failures."""
+
+
+class SpendLeaseInvariantError(SpendLeaseStateError):
+    """A record cannot represent a valid durable state."""
+
+
+class SpendLeaseConflictError(SpendLeaseStateError):
+    """A transition conflicts with the allocation's durable state."""
+
+
+class SpendLeaseProofError(SpendLeaseConflictError):
+    """A supplied durable proof does not prove the requested transition."""
+
+
+class SpendLeaseUnavailableError(SpendLeaseStateError):
+    """The lease cannot admit a new allocation."""
+
+
+class SpendLeaseExhaustedError(SpendLeaseUnavailableError):
+    """The lease lacks monotonic capacity for a new allocation."""
+
+
+class BindingState(StrEnum):
+    PROVISIONAL = "provisional"
+    COMMITTED = "committed"
+
+
+class AllocationState(StrEnum):
+    RESERVED = "reserved"
+    SETTLED = "settled"
+    REFUNDED = "refunded"
+    ABANDONED = "abandoned"
+    QUARANTINED = "quarantined"
+
+
+class TerminalSource(StrEnum):
+    MIRROR = "mirror"
+    BINDING_ABSENCE = "binding_absence"
+    COMMITTED_LOST = "committed_lost"
+    QUARANTINE = "quarantine"
+
+
+class AuthorizationOutcome(StrEnum):
+    SETTLED = "settled"
+    REFUNDED = "refunded"
+    TERMINAL_NO_OUTCOME = "terminal_no_outcome"
+    NONE = "none"
+    CONTRADICTION = "contradiction"
+
+
+class SpendLeaseState(StrEnum):
+    ACTIVE = "active"
+    DRAINING = "draining"
+    TOMBSTONED = "tombstoned"
+    CLOSED = "closed"
+
+
+class AuthorizationBinding(StrEnum):
+    """Typed result of the caller's strong read; never a caller boolean."""
+
+    UNBOUND = "unbound"
+    BOUND = "bound"
+    CLOSED_LEASE = "closed_lease"
+
+
+class AuthorizationDurability(StrEnum):
+    OPEN = "open"
+    TERMINAL = "terminal"
+
+
+class FinalizationOutcome(StrEnum):
+    SETTLED = "settled"
+    REFUNDED = "refunded"
+
+
+class ClaimRegistration(StrEnum):
+    CLAIM = "claim"
+
+
+class AbsenceObservation(StrEnum):
+    ABSENT_ROW = "absent_row"
+    NON_BINDING_ROW = "non_binding_row"
+
+
+class RetentionDiscipline(StrEnum):
+    TERMINAL_ROW_RETENTION = "terminal_row_retention"
+
+
+@dataclass(frozen=True, slots=True)
+class BindingTuple:
+    lease_id: str
+    gen: int
+    allocated_micro: int
+
+    def __post_init__(self) -> None:
+        if not self.lease_id or self.gen <= 0 or self.allocated_micro <= 0:
+            raise SpendLeaseInvariantError("binding tuple fields must be positive and non-empty")
+
+
+@dataclass(frozen=True, slots=True)
+class BoundProof:
+    idempotency_scope: str
+    authorization_id: str
+    lease_id: str
+    gen: int
+    allocated_micro: int
+
+    def __post_init__(self) -> None:
+        if not self.idempotency_scope or not self.authorization_id:
+            raise SpendLeaseInvariantError("bound proof identity is required")
+        BindingTuple(self.lease_id, self.gen, self.allocated_micro)
+
+    @property
+    def binding(self) -> BindingTuple:
+        return BindingTuple(self.lease_id, self.gen, self.allocated_micro)
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimProof:
+    idempotency_scope: str
+    provisional_id: str
+    registration: ClaimRegistration = ClaimRegistration.CLAIM
+
+    def __post_init__(self) -> None:
+        if not self.idempotency_scope or not self.provisional_id:
+            raise SpendLeaseInvariantError("claim proof identity is required")
+        if self.registration != ClaimRegistration.CLAIM:
+            raise SpendLeaseInvariantError("claim proof must carry a CLAIM registration")
+
+
+@dataclass(frozen=True, slots=True)
+class BindingAbsenceProof:
+    """Durable absence/non-binding observation paired with a committed claim."""
+
+    idempotency_scope: str
+    provisional_id: str
+    observation: AbsenceObservation
+    observed_authorization_id: str | None = None
+    observed_tuple: BindingTuple | None = None
+
+    def __post_init__(self) -> None:
+        if not self.idempotency_scope or not self.provisional_id:
+            raise SpendLeaseInvariantError("binding-absence proof identity is required")
+        if self.observation == AbsenceObservation.ABSENT_ROW and (
+            self.observed_authorization_id is not None or self.observed_tuple is not None
+        ):
+            raise SpendLeaseInvariantError("absent-row proof cannot contain an observed row")
+
+
+@dataclass(frozen=True, slots=True)
+class CommittedRowAbsentProof:
+    idempotency_scope: str
+    authorization_id: str
+    retention: RetentionDiscipline = RetentionDiscipline.TERMINAL_ROW_RETENTION
+
+    def __post_init__(self) -> None:
+        if not self.idempotency_scope or not self.authorization_id:
+            raise SpendLeaseInvariantError("committed-row absence proof identity is required")
+        if self.retention != RetentionDiscipline.TERMINAL_ROW_RETENTION:
+            raise SpendLeaseInvariantError("unknown authorization-row retention discipline")
+
+
+@dataclass(frozen=True, slots=True)
+class ConflictingBound:
+    authorization_id: str
+    observed_tuple: BindingTuple
+
+    def __post_init__(self) -> None:
+        if not self.authorization_id:
+            raise SpendLeaseInvariantError("conflicting authorization ID is required")
+
+
+@dataclass(frozen=True, slots=True)
+class ConflictingClaim:
+    provisional_id: str
+
+    def __post_init__(self) -> None:
+        if not self.provisional_id:
+            raise SpendLeaseInvariantError("conflicting provisional ID is required")
+
+
+@dataclass(frozen=True, slots=True)
+class RowBindingMismatch:
+    authorization_id: str
+    observed_tuple_or_absent: BindingTuple | None
+
+    def __post_init__(self) -> None:
+        if not self.authorization_id:
+            raise SpendLeaseInvariantError("row authorization ID is required")
+
+
+ContradictionProof: TypeAlias = ConflictingBound | ConflictingClaim | RowBindingMismatch
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizationView:
+    """Strong-read view used by the ordered replay table (decision 13)."""
+
+    idempotency_scope: str
+    authorization_id: str
+    request_fingerprint: str
+    key_hash: str
+    workspace_id: str
+    binding: AuthorizationBinding
+    lease_id: str | None = None
+    gen: int | None = None
+    allocated_micro: int | None = None
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.idempotency_scope,
+                self.authorization_id,
+                self.request_fingerprint,
+                self.key_hash,
+                self.workspace_id,
+            )
+        ):
+            raise SpendLeaseInvariantError("authorization view identity fields are required")
+        typed_binding = (self.lease_id, self.gen, self.allocated_micro)
+        if self.binding == AuthorizationBinding.UNBOUND:
+            if typed_binding != (None, None, None):
+                raise SpendLeaseInvariantError("unbound authorization cannot carry a binding")
+        elif any(value is None for value in typed_binding):
+            raise SpendLeaseInvariantError("bound authorization requires every binding field")
+        else:
+            BindingTuple(self.lease_id or "", self.gen or 0, self.allocated_micro or 0)
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizationObservation:
+    """Typed, durable authorization observation used only for MIRROR."""
+
+    idempotency_scope: str
+    authorization_id: str
+    request_fingerprint: str
+    lease_id: str
+    gen: int
+    allocated_micro: int
+    key_hash: str
+    workspace_id: str
+    durability: AuthorizationDurability
+    finalization_outcome: FinalizationOutcome | None = None
+    finalized_cost_microdollars: int | None = None
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.idempotency_scope,
+                self.authorization_id,
+                self.request_fingerprint,
+                self.lease_id,
+                self.key_hash,
+                self.workspace_id,
+            )
+        ):
+            raise SpendLeaseInvariantError("authorization observation identity is required")
+        BindingTuple(self.lease_id, self.gen, self.allocated_micro)
+        if self.durability == AuthorizationDurability.OPEN and (
+            self.finalization_outcome is not None
+            or self.finalized_cost_microdollars is not None
+        ):
+            raise SpendLeaseInvariantError("open authorization cannot carry finalization facts")
+        if self.finalized_cost_microdollars is not None and self.finalized_cost_microdollars < 0:
+            raise SpendLeaseInvariantError("finalized cost cannot be negative")
+
+
+@dataclass(frozen=True, slots=True)
+class AllocationTransition:
+    allocation: SpendLeaseAllocation
+    replayed: bool
+
+
+@dataclass(frozen=True, slots=True)
+class SpendLeaseAllocation:
+    idempotency_scope: str
+    authorization_id: str
+    request_fingerprint: str
+    lease_id: str
+    gen: int
+    allocated_micro: int
+    abandon_after: datetime
+    key_hash: str
+    workspace_id: str
+    binding_state: BindingState = BindingState.PROVISIONAL
+    actual_micro: int | None = None
+    state: AllocationState = AllocationState.RESERVED
+    terminal_source: TerminalSource | None = None
+    authorization_outcome: AuthorizationOutcome | None = None
+    contradiction_proof: ContradictionProof | None = None
+    bound_proof: InitVar[BoundProof | None] = None
+
+    def __post_init__(self, bound_proof: BoundProof | None) -> None:
+        # Decision 17: identity and amount corruption must fail construction.
+        if not all(
+            (
+                self.idempotency_scope,
+                self.authorization_id,
+                self.request_fingerprint,
+                self.lease_id,
+                self.key_hash,
+                self.workspace_id,
+            )
+        ):
+            raise SpendLeaseInvariantError("allocation identity fields are required")
+        if self.gen <= 0:
+            raise SpendLeaseInvariantError("allocation generation must be positive")
+        if self.allocated_micro <= 0:
+            raise SpendLeaseInvariantError("allocated_micro must be positive")
+        _require_aware(self.abandon_after, "abandon_after")
+
+        # Decision 17: NULL and zero are distinct; only SETTLED has an actual.
+        if (self.actual_micro is not None) != (self.state == AllocationState.SETTLED):
+            raise SpendLeaseInvariantError("actual_micro is non-null exactly for SETTLED")
+        if self.actual_micro is not None and not 0 <= self.actual_micro <= self.allocated_micro:
+            raise SpendLeaseInvariantError("settled actual must fit inside the allocation")
+
+        # Decision 17: terminal source and outcome are both NULL exactly while RESERVED.
+        reserved = self.state == AllocationState.RESERVED
+        if (self.terminal_source is None) != reserved:
+            raise SpendLeaseInvariantError("terminal_source is null exactly for RESERVED")
+        if (self.authorization_outcome is None) != reserved:
+            raise SpendLeaseInvariantError("authorization_outcome is null exactly for RESERVED")
+
+        # Decision 17: enforce the full state/source/outcome equivalence, not implications.
+        expected_pairs: dict[AllocationState, frozenset[tuple[TerminalSource, AuthorizationOutcome]]] = {
+            AllocationState.SETTLED: frozenset(
+                {(TerminalSource.MIRROR, AuthorizationOutcome.SETTLED)}
+            ),
+            AllocationState.REFUNDED: frozenset(
+                {
+                    (TerminalSource.MIRROR, AuthorizationOutcome.REFUNDED),
+                    (TerminalSource.BINDING_ABSENCE, AuthorizationOutcome.NONE),
+                }
+            ),
+            AllocationState.ABANDONED: frozenset(
+                {
+                    (TerminalSource.MIRROR, AuthorizationOutcome.TERMINAL_NO_OUTCOME),
+                    (TerminalSource.COMMITTED_LOST, AuthorizationOutcome.TERMINAL_NO_OUTCOME),
+                    (TerminalSource.BINDING_ABSENCE, AuthorizationOutcome.NONE),
+                }
+            ),
+            AllocationState.QUARANTINED: frozenset(
+                {(TerminalSource.QUARANTINE, AuthorizationOutcome.CONTRADICTION)}
+            ),
+        }
+        if not reserved and (self.terminal_source, self.authorization_outcome) not in expected_pairs[
+            self.state
+        ]:
+            raise SpendLeaseInvariantError("allocation state/source/outcome provenance conflicts")
+
+        # Decisions 17 and 22: contradiction provenance exists only for quarantine.
+        if (self.contradiction_proof is not None) != (
+            self.state == AllocationState.QUARANTINED
+        ):
+            raise SpendLeaseInvariantError("contradiction proof exists exactly for QUARANTINED")
+        if isinstance(self.contradiction_proof, (ConflictingBound, ConflictingClaim)) and (
+            self.binding_state != BindingState.PROVISIONAL
+        ):
+            raise SpendLeaseInvariantError("phase-two contradictions retain PROVISIONAL binding")
+        if isinstance(self.contradiction_proof, RowBindingMismatch) and (
+            self.binding_state != BindingState.COMMITTED
+        ):
+            raise SpendLeaseInvariantError("row-binding contradiction retains COMMITTED binding")
+
+        # Decisions 17, 21, 22: provenance constrains binding, and COMMITTED needs proof.
+        if self.terminal_source == TerminalSource.MIRROR and (
+            self.binding_state != BindingState.COMMITTED
+        ):
+            raise SpendLeaseInvariantError("MIRROR terminal state requires COMMITTED binding")
+        if self.terminal_source == TerminalSource.BINDING_ABSENCE and (
+            self.binding_state != BindingState.PROVISIONAL
+        ):
+            raise SpendLeaseInvariantError("BINDING_ABSENCE requires PROVISIONAL binding")
+        if self.terminal_source == TerminalSource.COMMITTED_LOST and (
+            self.binding_state != BindingState.COMMITTED
+        ):
+            raise SpendLeaseInvariantError("COMMITTED_LOST requires COMMITTED binding")
+        if self.binding_state == BindingState.COMMITTED:
+            if bound_proof is None:
+                raise SpendLeaseProofError("COMMITTED allocation requires a BoundProof")
+            self._validate_bound_proof(bound_proof)
+        elif bound_proof is not None:
+            raise SpendLeaseProofError("PROVISIONAL allocation cannot consume a BoundProof")
+
+    @property
+    def binding(self) -> BindingTuple:
+        return BindingTuple(self.lease_id, self.gen, self.allocated_micro)
+
+    @property
+    def is_open(self) -> bool:
+        # Decisions 5, 18--20, 22: this is the single close predicate definition.
+        return self.state in {AllocationState.RESERVED, AllocationState.QUARANTINED}
+
+    def bind(self, *, expected_provisional_id: str, proof: BoundProof) -> AllocationTransition:
+        # Decisions 21(c), 22: validate every proof field before owner/state handling.
+        self._validate_bound_proof(proof, validate_authorization=False)
+        if self.binding_state == BindingState.COMMITTED:
+            if self.authorization_id != proof.authorization_id:
+                raise SpendLeaseConflictError("allocation is committed to another authorization")
+            return AllocationTransition(self, True)
+        if self.state != AllocationState.RESERVED:
+            raise SpendLeaseConflictError("only a reserved allocation can bind")
+        if self.authorization_id != expected_provisional_id:
+            raise SpendLeaseConflictError("stale provisional allocation owner")
+        committed = replace(
+            self,
+            authorization_id=proof.authorization_id,
+            binding_state=BindingState.COMMITTED,
+            bound_proof=proof,
+        )
+        return AllocationTransition(committed, False)
+
+    def compensate(
+        self,
+        *,
+        expected_provisional_id: str,
+        claim: ClaimProof,
+        absence: BindingAbsenceProof,
+    ) -> AllocationTransition:
+        # Decisions 10, 15, 21(d/g), 22: claim plus durable absence, owner fenced.
+        self._validate_binding_absence(expected_provisional_id, claim, absence)
+        if self.state == AllocationState.REFUNDED and (
+            self.terminal_source == TerminalSource.BINDING_ABSENCE
+        ):
+            return AllocationTransition(self, True)
+        self._require_provisional_owner(expected_provisional_id)
+        refunded = replace(
+            self,
+            state=AllocationState.REFUNDED,
+            terminal_source=TerminalSource.BINDING_ABSENCE,
+            authorization_outcome=AuthorizationOutcome.NONE,
+        )
+        return AllocationTransition(refunded, False)
+
+    def abandon(
+        self,
+        *,
+        expected_provisional_id: str,
+        claim: ClaimProof,
+        absence: BindingAbsenceProof,
+        now: datetime,
+    ) -> AllocationTransition:
+        # Decisions 10, 20, 21(g): a timer gates a proof-bearing transition only.
+        _require_aware(now, "now")
+        self._validate_binding_absence(expected_provisional_id, claim, absence)
+        if self.state == AllocationState.ABANDONED and (
+            self.terminal_source == TerminalSource.BINDING_ABSENCE
+        ):
+            return AllocationTransition(self, True)
+        self._require_provisional_owner(expected_provisional_id)
+        if now < self.abandon_after:
+            raise SpendLeaseUnavailableError("allocation is not eligible for abandonment")
+        abandoned = replace(
+            self,
+            state=AllocationState.ABANDONED,
+            terminal_source=TerminalSource.BINDING_ABSENCE,
+            authorization_outcome=AuthorizationOutcome.NONE,
+        )
+        return AllocationTransition(abandoned, False)
+
+    def mirror(self, observation: AuthorizationObservation) -> AllocationTransition:
+        # Decisions 10, 14, 22: MIRROR consumes a matching durable committed observation.
+        self._validate_observation(observation)
+        if self.binding_state != BindingState.COMMITTED:
+            raise SpendLeaseProofError("MIRROR requires a committed allocation binding")
+        if observation.durability == AuthorizationDurability.OPEN:
+            if self.state != AllocationState.RESERVED:
+                raise SpendLeaseConflictError("terminal allocation conflicts with open observation")
+            return AllocationTransition(self, True)
+
+        if observation.finalization_outcome == FinalizationOutcome.SETTLED and (
+            observation.finalized_cost_microdollars is not None
+        ):
+            if not 0 <= observation.finalized_cost_microdollars <= self.allocated_micro:
+                raise SpendLeaseConflictError("settled actual must fit inside the allocation")
+            target_state = AllocationState.SETTLED
+            target_outcome = AuthorizationOutcome.SETTLED
+            actual = observation.finalized_cost_microdollars
+        elif observation.finalization_outcome == FinalizationOutcome.REFUNDED:
+            target_state = AllocationState.REFUNDED
+            target_outcome = AuthorizationOutcome.REFUNDED
+            actual = None
+        else:
+            target_state = AllocationState.ABANDONED
+            target_outcome = AuthorizationOutcome.TERMINAL_NO_OUTCOME
+            actual = None
+
+        if self.state != AllocationState.RESERVED:
+            if (
+                self.state == target_state
+                and self.terminal_source == TerminalSource.MIRROR
+                and self.authorization_outcome == target_outcome
+                and self.actual_micro == actual
+            ):
+                return AllocationTransition(self, True)
+            raise SpendLeaseConflictError("different terminal authorization outcome")
+        proof = self._current_bound_proof()
+        mirrored = replace(
+            self,
+            state=target_state,
+            terminal_source=TerminalSource.MIRROR,
+            authorization_outcome=target_outcome,
+            actual_micro=actual,
+            bound_proof=proof,
+        )
+        return AllocationTransition(mirrored, False)
+
+    def lost(self, proof: CommittedRowAbsentProof) -> AllocationTransition:
+        # Decisions 10 and 20: only retention-proven loss of a COMMITTED row is terminal.
+        if proof.idempotency_scope != self.idempotency_scope:
+            raise SpendLeaseProofError("committed-row proof scope mismatch")
+        if proof.authorization_id != self.authorization_id:
+            raise SpendLeaseProofError("committed-row proof authorization mismatch")
+        if self.state == AllocationState.ABANDONED and (
+            self.terminal_source == TerminalSource.COMMITTED_LOST
+        ):
+            return AllocationTransition(self, True)
+        if self.state != AllocationState.RESERVED or self.binding_state != BindingState.COMMITTED:
+            raise SpendLeaseConflictError("COMMITTED_LOST requires reserved committed allocation")
+        lost = replace(
+            self,
+            state=AllocationState.ABANDONED,
+            terminal_source=TerminalSource.COMMITTED_LOST,
+            authorization_outcome=AuthorizationOutcome.TERMINAL_NO_OUTCOME,
+            bound_proof=self._current_bound_proof(),
+        )
+        return AllocationTransition(lost, False)
+
+    def quarantine(self, proof: ContradictionProof) -> AllocationTransition:
+        # Decision 22: exactly three contradictions, with binding phase retained.
+        if self.state == AllocationState.QUARANTINED:
+            if self.contradiction_proof == proof:
+                return AllocationTransition(self, True)
+            raise SpendLeaseConflictError("different contradiction proof")
+        if self.state != AllocationState.RESERVED:
+            raise SpendLeaseConflictError("terminal allocations are absorbing")
+        if isinstance(proof, ConflictingBound):
+            if self.binding_state != BindingState.PROVISIONAL:
+                raise SpendLeaseProofError("ConflictingBound requires PROVISIONAL allocation")
+            if proof.observed_tuple == self.binding:
+                raise SpendLeaseProofError("matching BOUND_ELSEWHERE must bind, not quarantine")
+        elif isinstance(proof, ConflictingClaim):
+            if self.binding_state != BindingState.PROVISIONAL:
+                raise SpendLeaseProofError("ConflictingClaim requires PROVISIONAL allocation")
+            if proof.provisional_id == self.authorization_id:
+                raise SpendLeaseProofError("allocation's own claim is not contradictory")
+        elif isinstance(proof, RowBindingMismatch):
+            if self.binding_state != BindingState.COMMITTED:
+                raise SpendLeaseProofError("RowBindingMismatch requires COMMITTED allocation")
+            if (
+                proof.authorization_id == self.authorization_id
+                and proof.observed_tuple_or_absent == self.binding
+            ):
+                raise SpendLeaseProofError("observed row binding matches the allocation")
+        else:  # pragma: no cover - closed union, defensive against dynamic callers
+            raise SpendLeaseProofError("unknown contradiction proof")
+        quarantined = replace(
+            self,
+            state=AllocationState.QUARANTINED,
+            terminal_source=TerminalSource.QUARANTINE,
+            authorization_outcome=AuthorizationOutcome.CONTRADICTION,
+            contradiction_proof=proof,
+            bound_proof=self._current_bound_proof()
+            if self.binding_state == BindingState.COMMITTED
+            else None,
+        )
+        return AllocationTransition(quarantined, False)
+
+    def _validate_bound_proof(
+        self,
+        proof: BoundProof,
+        *,
+        validate_authorization: bool = True,
+    ) -> None:
+        if proof.idempotency_scope != self.idempotency_scope:
+            raise SpendLeaseProofError("bound proof scope mismatch")
+        if proof.binding != self.binding:
+            raise SpendLeaseProofError("bound proof tuple mismatch")
+        if validate_authorization and proof.authorization_id != self.authorization_id:
+            raise SpendLeaseProofError("bound proof authorization mismatch")
+
+    def _validate_binding_absence(
+        self,
+        expected_provisional_id: str,
+        claim: ClaimProof,
+        absence: BindingAbsenceProof,
+    ) -> None:
+        if expected_provisional_id != self.authorization_id:
+            raise SpendLeaseConflictError("stale provisional allocation owner")
+        if claim.idempotency_scope != self.idempotency_scope:
+            raise SpendLeaseProofError("claim proof scope mismatch")
+        if claim.provisional_id != expected_provisional_id:
+            raise SpendLeaseProofError("claim proof provisional owner mismatch")
+        if absence.idempotency_scope != self.idempotency_scope:
+            raise SpendLeaseProofError("absence proof scope mismatch")
+        if absence.provisional_id != expected_provisional_id:
+            raise SpendLeaseProofError("absence proof provisional owner mismatch")
+        if (
+            absence.observation == AbsenceObservation.NON_BINDING_ROW
+            and absence.observed_authorization_id == self.authorization_id
+            and absence.observed_tuple == self.binding
+        ):
+            raise SpendLeaseProofError("observed row is bound to this allocation")
+
+    def _require_provisional_owner(self, expected_provisional_id: str) -> None:
+        if self.state != AllocationState.RESERVED:
+            raise SpendLeaseConflictError("terminal allocations are absorbing")
+        if self.binding_state != BindingState.PROVISIONAL:
+            raise SpendLeaseConflictError("committed allocation cannot be compensated")
+        if self.authorization_id != expected_provisional_id:
+            raise SpendLeaseConflictError("stale provisional allocation owner")
+
+    def _validate_observation(self, observation: AuthorizationObservation) -> None:
+        expected = (
+            self.idempotency_scope,
+            self.authorization_id,
+            self.request_fingerprint,
+            self.lease_id,
+            self.gen,
+            self.allocated_micro,
+            self.key_hash,
+            self.workspace_id,
+        )
+        observed = (
+            observation.idempotency_scope,
+            observation.authorization_id,
+            observation.request_fingerprint,
+            observation.lease_id,
+            observation.gen,
+            observation.allocated_micro,
+            observation.key_hash,
+            observation.workspace_id,
+        )
+        if observed != expected:
+            raise SpendLeaseProofError("authorization observation identity or binding mismatch")
+
+    def _current_bound_proof(self) -> BoundProof:
+        if self.binding_state != BindingState.COMMITTED:
+            raise SpendLeaseProofError("allocation has no committed binding proof")
+        return BoundProof(
+            idempotency_scope=self.idempotency_scope,
+            authorization_id=self.authorization_id,
+            lease_id=self.lease_id,
+            gen=self.gen,
+            allocated_micro=self.allocated_micro,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class LeaseTransition:
+    lease: SpendLease
+    replayed: bool
+
+
+@dataclass(frozen=True, slots=True)
+class LeaseAllocationTransition:
+    lease: SpendLease
+    allocation: SpendLeaseAllocation
+    replayed: bool
+
+
+@dataclass(frozen=True, slots=True)
+class Created(LeaseAllocationTransition):
+    provisional_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class ExistingLocal(LeaseAllocationTransition):
+    """Existing local record; intentionally carries no compensation capability."""
+
+
+@dataclass(frozen=True, slots=True)
+class TrueReplay(LeaseAllocationTransition):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class Mismatch:
+    lease: SpendLease
+    authorization_id: str
+    replayed: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class UnboundExisting:
+    lease: SpendLease
+    authorization_id: str
+    replayed: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class ClosedLeaseReplay:
+    lease: SpendLease
+    authorization_id: str
+    replayed: bool = True
+
+
+AllocateResult: TypeAlias = (
+    Created | ExistingLocal | TrueReplay | Mismatch | UnboundExisting | ClosedLeaseReplay
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SpendLease:
+    lease_id: str
+    gen: int
+    key_hash: str
+    boot_kid: str
+    workspace_id: str
+    cap_micro: int
+    expires_at: datetime
+    skew: timedelta
+    version: int
+    state: SpendLeaseState = SpendLeaseState.ACTIVE
+    allocations: tuple[SpendLeaseAllocation, ...] = ()
+
+    def __post_init__(self) -> None:
+        # Decisions 12 and 17: grant generation and local CAS version are distinct.
+        if not all((self.lease_id, self.key_hash, self.boot_kid, self.workspace_id)):
+            raise SpendLeaseInvariantError("lease identity fields are required")
+        if self.gen <= 0:
+            raise SpendLeaseInvariantError("lease generation must be positive")
+        if self.version < 0:
+            raise SpendLeaseInvariantError("CAS version cannot be negative")
+        if self.cap_micro <= 0:
+            raise SpendLeaseInvariantError("lease cap must be positive")
+        _require_aware(self.expires_at, "expires_at")
+        if self.skew < timedelta(0):
+            raise SpendLeaseInvariantError("lease skew cannot be negative")
+        scopes = [allocation.idempotency_scope for allocation in self.allocations]
+        owners = [allocation.authorization_id for allocation in self.allocations]
+        if len(scopes) != len(set(scopes)):
+            raise SpendLeaseInvariantError("allocation scopes must be unique within a lease")
+        if len(owners) != len(set(owners)):
+            raise SpendLeaseInvariantError("allocation authorization owners must be unique")
+        for allocation in self.allocations:
+            if (
+                allocation.lease_id != self.lease_id
+                or allocation.gen != self.gen
+                or allocation.key_hash != self.key_hash
+                or allocation.workspace_id != self.workspace_id
+            ):
+                raise SpendLeaseInvariantError("allocation does not belong to this lease")
+        # Decisions 9 and 17: every historical allocation remains counted forever.
+        if self.allocated_micro > self.cap_micro:
+            raise SpendLeaseInvariantError("lease allocation total exceeds its cap")
+
+    @property
+    def allocated_micro(self) -> int:
+        return sum(allocation.allocated_micro for allocation in self.allocations)
+
+    @property
+    def available_micro(self) -> int:
+        # Decision 9: terminalization never returns capacity.
+        return self.cap_micro - self.allocated_micro
+
+    @property
+    def open_allocations(self) -> tuple[SpendLeaseAllocation, ...]:
+        # Decisions 5, 18--20, 22: RESERVED and QUARANTINED are both open.
+        return tuple(allocation for allocation in self.allocations if allocation.is_open)
+
+    def allocate(
+        self,
+        *,
+        authorization_view: AuthorizationView | None,
+        idempotency_scope: str,
+        provisional_authorization_id: str,
+        request_fingerprint: str,
+        allocated_micro: int,
+        abandon_after: datetime,
+        now: datetime,
+    ) -> AllocateResult:
+        # Decision 13 and carve-out viii: the durable authorization view is classified first.
+        _require_aware(now, "now")
+        _require_aware(abandon_after, "abandon_after")
+        if authorization_view is not None:
+            if (
+                authorization_view.idempotency_scope != idempotency_scope
+                or authorization_view.key_hash != self.key_hash
+                or authorization_view.workspace_id != self.workspace_id
+            ):
+                raise SpendLeaseProofError("authorization view identity mismatch")
+            if authorization_view.binding == AuthorizationBinding.UNBOUND:
+                return UnboundExisting(self, authorization_view.authorization_id)
+            if authorization_view.binding == AuthorizationBinding.CLOSED_LEASE:
+                return ClosedLeaseReplay(self, authorization_view.authorization_id)
+            existing = self._allocation(idempotency_scope)
+            if existing is not None and self._view_matches(authorization_view, existing):
+                return TrueReplay(self, existing, True)
+            return Mismatch(self, authorization_view.authorization_id)
+
+        # Decision 21(b): a local CAS loser gets no compensation capability.
+        existing = self._allocation(idempotency_scope)
+        if existing is not None:
+            return ExistingLocal(self, existing, True)
+
+        # Decisions 15, 16, 18: only NEW reaches lifecycle and capacity checks.
+        if self.state != SpendLeaseState.ACTIVE:
+            raise SpendLeaseUnavailableError(f"lease is {self.state}")
+        if now >= self.expires_at + self.skew:
+            raise SpendLeaseUnavailableError("lease admission window has expired")
+        if allocated_micro <= 0:
+            raise SpendLeaseInvariantError("allocated_micro must be positive")
+        if allocated_micro > self.available_micro:
+            raise SpendLeaseExhaustedError("spend lease has insufficient capacity")
+        allocation = SpendLeaseAllocation(
+            idempotency_scope=idempotency_scope,
+            authorization_id=provisional_authorization_id,
+            request_fingerprint=request_fingerprint,
+            lease_id=self.lease_id,
+            gen=self.gen,
+            allocated_micro=allocated_micro,
+            abandon_after=abandon_after,
+            key_hash=self.key_hash,
+            workspace_id=self.workspace_id,
+        )
+        lease = replace(
+            self,
+            allocations=(*self.allocations, allocation),
+            version=self.version + 1,
+        )
+        return Created(
+            lease=lease,
+            allocation=allocation,
+            replayed=False,
+            provisional_id=provisional_authorization_id,
+        )
+
+    def bind(self, *, expected_provisional_id: str, proof: BoundProof) -> LeaseAllocationTransition:
+        allocation = self._required_allocation(proof.idempotency_scope)
+        transition = allocation.bind(expected_provisional_id=expected_provisional_id, proof=proof)
+        return self._apply_allocation(transition)
+
+    def compensate(
+        self,
+        *,
+        idempotency_scope: str,
+        expected_provisional_id: str,
+        claim: ClaimProof,
+        absence: BindingAbsenceProof,
+    ) -> LeaseAllocationTransition:
+        allocation = self._required_allocation(idempotency_scope)
+        transition = allocation.compensate(
+            expected_provisional_id=expected_provisional_id,
+            claim=claim,
+            absence=absence,
+        )
+        return self._apply_allocation(transition)
+
+    def abandon(
+        self,
+        *,
+        idempotency_scope: str,
+        expected_provisional_id: str,
+        claim: ClaimProof,
+        absence: BindingAbsenceProof,
+        now: datetime,
+    ) -> LeaseAllocationTransition:
+        allocation = self._required_allocation(idempotency_scope)
+        transition = allocation.abandon(
+            expected_provisional_id=expected_provisional_id,
+            claim=claim,
+            absence=absence,
+            now=now,
+        )
+        return self._apply_allocation(transition)
+
+    def mirror(self, observation: AuthorizationObservation) -> LeaseAllocationTransition:
+        allocation = self._required_allocation(observation.idempotency_scope)
+        return self._apply_allocation(allocation.mirror(observation))
+
+    def lost(self, proof: CommittedRowAbsentProof) -> LeaseAllocationTransition:
+        allocation = self._required_allocation(proof.idempotency_scope)
+        return self._apply_allocation(allocation.lost(proof))
+
+    def quarantine(
+        self, *, idempotency_scope: str, proof: ContradictionProof
+    ) -> LeaseAllocationTransition:
+        allocation = self._required_allocation(idempotency_scope)
+        return self._apply_allocation(allocation.quarantine(proof))
+
+    def begin_drain(self, *, now: datetime) -> LeaseTransition:
+        # Decision 18: time enters DRAINING only at the admission boundary.
+        _require_aware(now, "now")
+        if self.state == SpendLeaseState.CLOSED:
+            return LeaseTransition(self, True)
+        if self.state == SpendLeaseState.DRAINING:
+            return LeaseTransition(self, True)
+        if self.state != SpendLeaseState.ACTIVE:
+            raise SpendLeaseUnavailableError(f"lease is {self.state}")
+        if now < self.expires_at + self.skew:
+            raise SpendLeaseUnavailableError("lease admission window has not elapsed")
+        return LeaseTransition(replace(self, state=SpendLeaseState.DRAINING, version=self.version + 1), False)
+
+    def tombstone(self) -> LeaseTransition:
+        # Decision 18: trigger-refund freezes ACTIVE/DRAINING; CLOSED is absorbing.
+        if self.state in {SpendLeaseState.TOMBSTONED, SpendLeaseState.CLOSED}:
+            return LeaseTransition(self, True)
+        return LeaseTransition(
+            replace(self, state=SpendLeaseState.TOMBSTONED, version=self.version + 1),
+            False,
+        )
+
+    def close(self, *, now: datetime) -> LeaseTransition:
+        # Decisions 5, 18, 19, 22: two guards, using the one open predicate.
+        _require_aware(now, "now")
+        if self.state == SpendLeaseState.CLOSED:
+            return LeaseTransition(self, True)
+        if self.state not in {SpendLeaseState.DRAINING, SpendLeaseState.TOMBSTONED}:
+            raise SpendLeaseUnavailableError("lease must be frozen before close")
+        if now < self.expires_at + self.skew:
+            raise SpendLeaseUnavailableError("lease cannot close before expiry plus skew")
+        if self.open_allocations:
+            raise SpendLeaseUnavailableError("lease still has open allocations")
+        return LeaseTransition(replace(self, state=SpendLeaseState.CLOSED, version=self.version + 1), False)
+
+    def _allocation(self, idempotency_scope: str) -> SpendLeaseAllocation | None:
+        return next(
+            (
+                allocation
+                for allocation in self.allocations
+                if allocation.idempotency_scope == idempotency_scope
+            ),
+            None,
+        )
+
+    def _required_allocation(self, idempotency_scope: str) -> SpendLeaseAllocation:
+        allocation = self._allocation(idempotency_scope)
+        if allocation is None:
+            raise SpendLeaseConflictError("unknown spend-lease allocation")
+        return allocation
+
+    def _apply_allocation(self, transition: AllocationTransition) -> LeaseAllocationTransition:
+        if transition.replayed:
+            return LeaseAllocationTransition(self, transition.allocation, True)
+        lease = replace(
+            self,
+            allocations=tuple(
+                transition.allocation
+                if allocation.idempotency_scope == transition.allocation.idempotency_scope
+                else allocation
+                for allocation in self.allocations
+            ),
+            version=self.version + 1,
+        )
+        return LeaseAllocationTransition(lease, transition.allocation, False)
+
+    @staticmethod
+    def _view_matches(view: AuthorizationView, allocation: SpendLeaseAllocation) -> bool:
+        return (
+            view.idempotency_scope,
+            view.authorization_id,
+            view.request_fingerprint,
+            view.lease_id,
+            view.gen,
+            view.allocated_micro,
+            view.key_hash,
+            view.workspace_id,
+        ) == (
+            allocation.idempotency_scope,
+            allocation.authorization_id,
+            allocation.request_fingerprint,
+            allocation.lease_id,
+            allocation.gen,
+            allocation.allocated_micro,
+            allocation.key_hash,
+            allocation.workspace_id,
+        )
+
+
+def _require_aware(value: datetime, field: str) -> None:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise SpendLeaseInvariantError(f"{field} must be timezone-aware")

--- a/tests/test_spend_lease_state.py
+++ b/tests/test_spend_lease_state.py
@@ -1,0 +1,896 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError, replace
+from datetime import UTC, datetime, timedelta
+from itertools import permutations
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from trusted_router.services.regional_quota_leases import (
+    LeaseState as RegionalLeaseState,
+)
+from trusted_router.services.regional_quota_leases import (
+    RegionalQuotaLease,
+)
+from trusted_router.spend_lease_state import (
+    AbsenceObservation,
+    AllocationState,
+    AuthorizationBinding,
+    AuthorizationDurability,
+    AuthorizationObservation,
+    AuthorizationOutcome,
+    AuthorizationView,
+    BindingAbsenceProof,
+    BindingState,
+    BindingTuple,
+    BoundProof,
+    ClaimProof,
+    ClosedLeaseReplay,
+    CommittedRowAbsentProof,
+    ConflictingBound,
+    ConflictingClaim,
+    Created,
+    ExistingLocal,
+    FinalizationOutcome,
+    Mismatch,
+    RowBindingMismatch,
+    SpendLease,
+    SpendLeaseAllocation,
+    SpendLeaseConflictError,
+    SpendLeaseExhaustedError,
+    SpendLeaseInvariantError,
+    SpendLeaseProofError,
+    SpendLeaseState,
+    SpendLeaseUnavailableError,
+    TerminalSource,
+    TrueReplay,
+    UnboundExisting,
+)
+
+NOW = datetime(2026, 9, 1, 12, tzinfo=UTC)
+EXPIRY = NOW + timedelta(seconds=60)
+SKEW = timedelta(seconds=10)
+ABANDON_AFTER = NOW + timedelta(hours=2)
+
+
+def _lease(*, cap: int = 1_000, state: SpendLeaseState = SpendLeaseState.ACTIVE) -> SpendLease:
+    return SpendLease(
+        lease_id="lease-1",
+        gen=7,
+        key_hash="key-hash",
+        boot_kid="boot-kid",
+        workspace_id="workspace-1",
+        cap_micro=cap,
+        expires_at=EXPIRY,
+        skew=SKEW,
+        version=11,
+        state=state,
+    )
+
+
+def _created(
+    lease: SpendLease | None = None,
+    *,
+    scope: str = "scope-1",
+    provisional_id: str = "provisional-1",
+    fingerprint: str = "fingerprint-1",
+    amount: int = 400,
+) -> Created:
+    target = _lease() if lease is None else lease
+    result = target.allocate(
+        authorization_view=None,
+        idempotency_scope=scope,
+        provisional_authorization_id=provisional_id,
+        request_fingerprint=fingerprint,
+        allocated_micro=amount,
+        abandon_after=ABANDON_AFTER,
+        now=NOW,
+    )
+    assert isinstance(result, Created)
+    return result
+
+
+def _bound_proof(
+    allocation: SpendLeaseAllocation, *, authorization_id: str = "authorization-1"
+) -> BoundProof:
+    return BoundProof(
+        idempotency_scope=allocation.idempotency_scope,
+        authorization_id=authorization_id,
+        lease_id=allocation.lease_id,
+        gen=allocation.gen,
+        allocated_micro=allocation.allocated_micro,
+    )
+
+
+def _bind(created: Created, *, authorization_id: str = "authorization-1") -> SpendLease:
+    return created.lease.bind(
+        expected_provisional_id=created.provisional_id,
+        proof=_bound_proof(created.allocation, authorization_id=authorization_id),
+    ).lease
+
+
+def _claim(allocation: SpendLeaseAllocation) -> ClaimProof:
+    return ClaimProof(allocation.idempotency_scope, allocation.authorization_id)
+
+
+def _absence(allocation: SpendLeaseAllocation) -> BindingAbsenceProof:
+    return BindingAbsenceProof(
+        idempotency_scope=allocation.idempotency_scope,
+        provisional_id=allocation.authorization_id,
+        observation=AbsenceObservation.ABSENT_ROW,
+    )
+
+
+def _observation(
+    allocation: SpendLeaseAllocation,
+    *,
+    durability: AuthorizationDurability = AuthorizationDurability.TERMINAL,
+    outcome: FinalizationOutcome | None = FinalizationOutcome.SETTLED,
+    actual: int | None = 250,
+) -> AuthorizationObservation:
+    return AuthorizationObservation(
+        idempotency_scope=allocation.idempotency_scope,
+        authorization_id=allocation.authorization_id,
+        request_fingerprint=allocation.request_fingerprint,
+        lease_id=allocation.lease_id,
+        gen=allocation.gen,
+        allocated_micro=allocation.allocated_micro,
+        key_hash=allocation.key_hash,
+        workspace_id=allocation.workspace_id,
+        durability=durability,
+        finalization_outcome=outcome,
+        finalized_cost_microdollars=actual,
+    )
+
+
+def _view(
+    allocation: SpendLeaseAllocation,
+    *,
+    binding: AuthorizationBinding = AuthorizationBinding.BOUND,
+) -> AuthorizationView:
+    if binding == AuthorizationBinding.UNBOUND:
+        return AuthorizationView(
+            idempotency_scope=allocation.idempotency_scope,
+            authorization_id=allocation.authorization_id,
+            request_fingerprint=allocation.request_fingerprint,
+            key_hash=allocation.key_hash,
+            workspace_id=allocation.workspace_id,
+            binding=binding,
+        )
+    return AuthorizationView(
+        idempotency_scope=allocation.idempotency_scope,
+        authorization_id=allocation.authorization_id,
+        request_fingerprint=allocation.request_fingerprint,
+        key_hash=allocation.key_hash,
+        workspace_id=allocation.workspace_id,
+        binding=binding,
+        lease_id=allocation.lease_id,
+        gen=allocation.gen,
+        allocated_micro=allocation.allocated_micro,
+    )
+
+
+def test_capacity_is_lifetime_monotonic_across_refund_and_abandon() -> None:
+    first = _created(amount=300)
+    refunded = first.lease.compensate(
+        idempotency_scope=first.allocation.idempotency_scope,
+        expected_provisional_id=first.provisional_id,
+        claim=_claim(first.allocation),
+        absence=_absence(first.allocation),
+    ).lease
+    second = _created(
+        refunded,
+        scope="scope-2",
+        provisional_id="provisional-2",
+        fingerprint="fingerprint-2",
+        amount=200,
+    )
+    abandoned = second.lease.abandon(
+        idempotency_scope=second.allocation.idempotency_scope,
+        expected_provisional_id=second.provisional_id,
+        claim=_claim(second.allocation),
+        absence=_absence(second.allocation),
+        now=ABANDON_AFTER,
+    ).lease
+
+    assert abandoned.allocated_micro == 500
+    assert abandoned.available_micro == 500
+    with pytest.raises(SpendLeaseExhaustedError):
+        _created(
+            abandoned,
+            scope="scope-3",
+            provisional_id="provisional-3",
+            amount=501,
+        )
+
+
+def test_cas_version_advances_without_changing_grant_generation() -> None:
+    initial = _lease()
+    created = _created(initial)
+    bound = _bind(created)
+    assert (initial.gen, created.lease.gen, bound.gen) == (7, 7, 7)
+    assert (initial.version, created.lease.version, bound.version) == (11, 12, 13)
+
+
+def test_allocated_positive_and_actual_null_vs_zero_are_construction_invariants() -> None:
+    base = _created().allocation
+    with pytest.raises(SpendLeaseInvariantError, match="positive"):
+        replace(base, allocated_micro=0)
+    with pytest.raises(SpendLeaseInvariantError, match="non-null exactly"):
+        replace(base, actual_micro=0)
+    committed = _bind(_created()).allocations[0]
+    settled_zero = committed.mirror(_observation(committed, actual=0)).allocation
+    assert settled_zero.actual_micro == 0
+    assert settled_zero.state == AllocationState.SETTLED
+
+
+def test_terminal_source_and_authorization_outcome_equivalence_is_exact() -> None:
+    committed = _bind(_created()).allocations[0]
+    with pytest.raises(SpendLeaseInvariantError, match="provenance conflicts"):
+        replace(
+            committed,
+            state=AllocationState.REFUNDED,
+            terminal_source=TerminalSource.MIRROR,
+            authorization_outcome=AuthorizationOutcome.TERMINAL_NO_OUTCOME,
+            bound_proof=_bound_proof(committed),
+        )
+
+
+def test_replay_table_is_ordered_disjoint_and_capacity_neutral() -> None:
+    created = _created()
+    bound = _bind(created)
+    allocation = bound.allocations[0]
+    before = bound.available_micro
+
+    replay = bound.allocate(
+        authorization_view=_view(allocation),
+        idempotency_scope=allocation.idempotency_scope,
+        provisional_authorization_id="unused",
+        request_fingerprint=allocation.request_fingerprint,
+        allocated_micro=allocation.allocated_micro,
+        abandon_after=ABANDON_AFTER,
+        now=EXPIRY + SKEW + timedelta(days=1),
+    )
+    assert isinstance(replay, TrueReplay)
+    assert replay.replayed
+
+    mismatch = bound.allocate(
+        authorization_view=replace(_view(allocation), allocated_micro=401),
+        idempotency_scope=allocation.idempotency_scope,
+        provisional_authorization_id="unused",
+        request_fingerprint=allocation.request_fingerprint,
+        allocated_micro=999,
+        abandon_after=ABANDON_AFTER,
+        now=NOW,
+    )
+    assert isinstance(mismatch, Mismatch)
+    assert mismatch.lease.available_micro == before
+
+    unbound = bound.allocate(
+        authorization_view=_view(allocation, binding=AuthorizationBinding.UNBOUND),
+        idempotency_scope=allocation.idempotency_scope,
+        provisional_authorization_id="unused",
+        request_fingerprint="different-is-not-tested-before-unbound",
+        allocated_micro=999,
+        abandon_after=ABANDON_AFTER,
+        now=NOW,
+    )
+    assert isinstance(unbound, UnboundExisting)
+    assert len(unbound.lease.allocations) == 1
+
+    closed = bound.allocate(
+        authorization_view=_view(allocation, binding=AuthorizationBinding.CLOSED_LEASE),
+        idempotency_scope=allocation.idempotency_scope,
+        provisional_authorization_id="unused",
+        request_fingerprint="unused",
+        allocated_micro=999,
+        abandon_after=ABANDON_AFTER,
+        now=NOW,
+    )
+    assert isinstance(closed, ClosedLeaseReplay)
+    assert closed.lease.available_micro == before
+
+
+def test_existing_local_returns_no_compensation_capability_and_never_allocates_twice() -> None:
+    created = _created()
+    existing = created.lease.allocate(
+        authorization_view=None,
+        idempotency_scope=created.allocation.idempotency_scope,
+        provisional_authorization_id="racing-provisional",
+        request_fingerprint="racing-fingerprint",
+        allocated_micro=600,
+        abandon_after=ABANDON_AFTER,
+        now=NOW,
+    )
+    assert isinstance(existing, ExistingLocal)
+    assert not hasattr(existing, "provisional_id")
+    assert existing.lease is created.lease
+    assert len(existing.lease.allocations) == 1
+
+
+@given(
+    first_scope=st.sampled_from(["scope-k1", "scope-k2"]),
+    first_amount=st.integers(min_value=1, max_value=499),
+)
+def test_round_fourteen_scope_identity_prevents_fingerprint_sharing(
+    first_scope: str, first_amount: int
+) -> None:
+    other_scope = "scope-k2" if first_scope == "scope-k1" else "scope-k1"
+    first = _created(scope=first_scope, fingerprint="same-body", amount=first_amount)
+    second = _created(
+        first.lease,
+        scope=other_scope,
+        provisional_id="other-provisional",
+        fingerprint="same-body",
+        amount=500 - first_amount,
+    )
+    assert {item.idempotency_scope for item in second.lease.allocations} == {
+        "scope-k1",
+        "scope-k2",
+    }
+    assert len(second.lease.allocations) == 2
+
+
+def test_bind_committed_to_different_authorization_conflicts() -> None:
+    created = _created()
+    bound = _bind(created)
+    with pytest.raises(SpendLeaseConflictError, match="another authorization"):
+        bound.bind(
+            expected_provisional_id=created.provisional_id,
+            proof=_bound_proof(created.allocation, authorization_id="authorization-2"),
+        )
+
+
+def test_compensate_stale_owner_never_refunds() -> None:
+    created = _created()
+    with pytest.raises(SpendLeaseConflictError, match="stale"):
+        created.lease.compensate(
+            idempotency_scope=created.allocation.idempotency_scope,
+            expected_provisional_id="stale-owner",
+            claim=ClaimProof(created.allocation.idempotency_scope, "stale-owner"),
+            absence=BindingAbsenceProof(
+                created.allocation.idempotency_scope,
+                "stale-owner",
+                AbsenceObservation.ABSENT_ROW,
+            ),
+        )
+    assert created.lease.allocations[0].state == AllocationState.RESERVED
+
+
+def test_committed_allocation_requires_matching_bound_proof_for_construction() -> None:
+    provisional = _created().allocation
+    with pytest.raises(SpendLeaseProofError, match="requires"):
+        replace(provisional, binding_state=BindingState.COMMITTED)
+    proof = _bound_proof(provisional)
+    committed = replace(
+        provisional,
+        authorization_id=proof.authorization_id,
+        binding_state=BindingState.COMMITTED,
+        bound_proof=proof,
+    )
+    assert committed.binding_state == BindingState.COMMITTED
+    with pytest.raises(SpendLeaseProofError, match="tuple mismatch"):
+        replace(committed, bound_proof=replace(proof, gen=proof.gen + 1))
+
+
+def test_matching_bound_elsewhere_binds_and_different_tuple_quarantines() -> None:
+    created = _created()
+    matching = created.lease.bind(
+        expected_provisional_id=created.provisional_id,
+        proof=_bound_proof(created.allocation, authorization_id="winner"),
+    )
+    assert matching.allocation.authorization_id == "winner"
+    assert matching.allocation.binding_state == BindingState.COMMITTED
+
+    conflicting = _created(scope="scope-other", provisional_id="provisional-other")
+    quarantined = conflicting.lease.quarantine(
+        idempotency_scope=conflicting.allocation.idempotency_scope,
+        proof=ConflictingBound(
+            "winner",
+            BindingTuple(
+                conflicting.allocation.lease_id,
+                conflicting.allocation.gen,
+                conflicting.allocation.allocated_micro + 1,
+            ),
+        ),
+    )
+    assert quarantined.allocation.state == AllocationState.QUARANTINED
+    with pytest.raises(SpendLeaseProofError, match="must bind"):
+        conflicting.lease.quarantine(
+            idempotency_scope=conflicting.allocation.idempotency_scope,
+            proof=ConflictingBound("winner", conflicting.allocation.binding),
+        )
+
+
+def test_all_three_quarantine_transitions_revalidate_state_and_evidence() -> None:
+    provisional = _created()
+    claimed = provisional.lease.quarantine(
+        idempotency_scope=provisional.allocation.idempotency_scope,
+        proof=ConflictingClaim("other-provisional"),
+    )
+    assert claimed.allocation.binding_state == BindingState.PROVISIONAL
+    assert claimed.allocation.terminal_source == TerminalSource.QUARANTINE
+    with pytest.raises(SpendLeaseProofError, match="not contradictory"):
+        provisional.lease.quarantine(
+            idempotency_scope=provisional.allocation.idempotency_scope,
+            proof=ConflictingClaim(provisional.provisional_id),
+        )
+
+    committed = _bind(_created(scope="committed-scope"))
+    allocation = committed.allocations[0]
+    mismatch = committed.quarantine(
+        idempotency_scope=allocation.idempotency_scope,
+        proof=RowBindingMismatch(allocation.authorization_id, None),
+    )
+    assert mismatch.allocation.binding_state == BindingState.COMMITTED
+    with pytest.raises(SpendLeaseProofError, match="matches"):
+        committed.quarantine(
+            idempotency_scope=allocation.idempotency_scope,
+            proof=RowBindingMismatch(allocation.authorization_id, allocation.binding),
+        )
+
+
+def test_quarantined_allocation_blocks_close_under_unified_open_predicate() -> None:
+    created = _created()
+    quarantined = created.lease.quarantine(
+        idempotency_scope=created.allocation.idempotency_scope,
+        proof=ConflictingClaim("other"),
+    ).lease
+    frozen = quarantined.tombstone().lease
+    assert frozen.open_allocations[0].state == AllocationState.QUARANTINED
+    with pytest.raises(SpendLeaseUnavailableError, match="open allocations"):
+        frozen.close(now=EXPIRY + SKEW)
+
+
+@pytest.mark.parametrize("order", list(permutations(("bind", "compensate"))))
+def test_round_fifteen_bind_compensate_race_has_exactly_one_winner(
+    order: tuple[str, str],
+) -> None:
+    created = _created()
+    lease = created.lease
+    successes = 0
+    for action in order:
+        try:
+            if action == "bind":
+                lease = lease.bind(
+                    expected_provisional_id=created.provisional_id,
+                    proof=_bound_proof(created.allocation),
+                ).lease
+            else:
+                lease = lease.compensate(
+                    idempotency_scope=created.allocation.idempotency_scope,
+                    expected_provisional_id=created.provisional_id,
+                    claim=_claim(created.allocation),
+                    absence=_absence(created.allocation),
+                ).lease
+            successes += 1
+        except SpendLeaseConflictError:
+            pass
+    assert successes == 1
+    allocation = lease.allocations[0]
+    assert not (
+        allocation.binding_state == BindingState.COMMITTED
+        and allocation.state == AllocationState.REFUNDED
+    )
+
+
+@pytest.mark.parametrize(
+    "actions",
+    list(permutations(("bind", "compensate", "close"))),
+)
+def test_round_sixteen_delayed_creator_never_closes_over_bound_open_authorization(
+    actions: tuple[str, str, str],
+) -> None:
+    created = _created()
+    lease = created.lease.tombstone().lease
+    for action in actions:
+        try:
+            if action == "bind":
+                lease = lease.bind(
+                    expected_provisional_id=created.provisional_id,
+                    proof=_bound_proof(created.allocation),
+                ).lease
+            elif action == "compensate":
+                lease = lease.compensate(
+                    idempotency_scope=created.allocation.idempotency_scope,
+                    expected_provisional_id=created.provisional_id,
+                    claim=_claim(created.allocation),
+                    absence=_absence(created.allocation),
+                ).lease
+            else:
+                lease = lease.close(now=EXPIRY + SKEW).lease
+        except SpendLeaseConflictError:
+            pass
+        except SpendLeaseUnavailableError:
+            pass
+    allocation = lease.allocations[0]
+    if allocation.binding_state == BindingState.COMMITTED and allocation.state == AllocationState.RESERVED:
+        assert lease.state != SpendLeaseState.CLOSED
+
+
+def test_committed_lost_is_refused_for_provisional_and_replays_for_committed() -> None:
+    created = _created()
+    provisional_proof = CommittedRowAbsentProof(
+        created.allocation.idempotency_scope,
+        created.allocation.authorization_id,
+    )
+    with pytest.raises(SpendLeaseConflictError, match="committed"):
+        created.lease.lost(provisional_proof)
+
+    committed = _bind(created)
+    allocation = committed.allocations[0]
+    proof = CommittedRowAbsentProof(allocation.idempotency_scope, allocation.authorization_id)
+    lost = committed.lost(proof)
+    replay = lost.lease.lost(proof)
+    assert lost.allocation.terminal_source == TerminalSource.COMMITTED_LOST
+    assert replay.replayed
+
+
+def test_claim_and_bound_proofs_for_one_scope_cannot_both_win() -> None:
+    created = _created()
+    bound = _bind(created)
+    with pytest.raises(SpendLeaseConflictError, match="stale|committed"):
+        bound.compensate(
+            idempotency_scope=created.allocation.idempotency_scope,
+            expected_provisional_id=created.provisional_id,
+            claim=_claim(created.allocation),
+            absence=_absence(created.allocation),
+        )
+    compensated = created.lease.compensate(
+        idempotency_scope=created.allocation.idempotency_scope,
+        expected_provisional_id=created.provisional_id,
+        claim=_claim(created.allocation),
+        absence=_absence(created.allocation),
+    ).lease
+    with pytest.raises(SpendLeaseConflictError, match="reserved"):
+        compensated.bind(
+            expected_provisional_id=created.provisional_id,
+            proof=_bound_proof(created.allocation),
+        )
+
+
+def test_frozen_lease_refuses_new_but_returns_true_replay() -> None:
+    created = _created()
+    bound = _bind(created)
+    allocation = bound.allocations[0]
+    frozen = bound.tombstone().lease
+    with pytest.raises(SpendLeaseUnavailableError, match="tombstoned"):
+        _created(frozen, scope="new-scope", provisional_id="new-provisional")
+    replay = frozen.allocate(
+        authorization_view=_view(allocation),
+        idempotency_scope=allocation.idempotency_scope,
+        provisional_authorization_id="unused",
+        request_fingerprint=allocation.request_fingerprint,
+        allocated_micro=allocation.allocated_micro,
+        abandon_after=ABANDON_AFTER,
+        now=EXPIRY + SKEW,
+    )
+    assert isinstance(replay, TrueReplay)
+
+
+def test_close_refuses_reserved_allocation_and_before_expiry_plus_skew() -> None:
+    frozen_empty = _lease().tombstone().lease
+    with pytest.raises(SpendLeaseUnavailableError, match="before"):
+        frozen_empty.close(now=EXPIRY + SKEW - timedelta(microseconds=1))
+    frozen_open = _created().lease.tombstone().lease
+    with pytest.raises(SpendLeaseUnavailableError, match="open allocations"):
+        frozen_open.close(now=EXPIRY + SKEW)
+
+
+def test_mirror_requires_committed_terminal_view_and_open_view_leaves_reserved() -> None:
+    created = _created()
+    with pytest.raises(SpendLeaseProofError, match="committed"):
+        created.lease.mirror(_observation(created.allocation))
+    committed = _bind(created)
+    allocation = committed.allocations[0]
+    open_observation = _observation(
+        allocation,
+        durability=AuthorizationDurability.OPEN,
+        outcome=None,
+        actual=None,
+    )
+    unchanged = committed.mirror(open_observation)
+    assert unchanged.replayed
+    assert unchanged.allocation.state == AllocationState.RESERVED
+    with pytest.raises(SpendLeaseConflictError, match="fit inside"):
+        committed.mirror(_observation(allocation, actual=allocation.allocated_micro + 1))
+
+
+def test_terminal_allocations_are_absorbing_and_same_terminal_input_replays() -> None:
+    committed = _bind(_created())
+    allocation = committed.allocations[0]
+    observation = _observation(allocation, actual=100)
+    settled = committed.mirror(observation)
+    assert settled.lease.mirror(observation).replayed
+    with pytest.raises(SpendLeaseConflictError):
+        settled.lease.quarantine(
+            idempotency_scope=allocation.idempotency_scope,
+            proof=RowBindingMismatch(allocation.authorization_id, None),
+        )
+    with pytest.raises(SpendLeaseConflictError):
+        settled.lease.lost(
+            CommittedRowAbsentProof(allocation.idempotency_scope, allocation.authorization_id)
+        )
+
+
+def test_closed_lease_is_absorbing_for_lifecycle_transitions() -> None:
+    closed = _lease().tombstone().lease.close(now=EXPIRY + SKEW).lease
+    assert closed.close(now=EXPIRY + SKEW).replayed
+    assert closed.tombstone().replayed
+    assert closed.begin_drain(now=EXPIRY + SKEW).replayed
+    assert closed.state == SpendLeaseState.CLOSED
+
+
+@pytest.mark.parametrize(
+    ("outcome", "actual", "state", "authorization_outcome"),
+    [
+        (FinalizationOutcome.SETTLED, 0, AllocationState.SETTLED, AuthorizationOutcome.SETTLED),
+        (FinalizationOutcome.REFUNDED, 0, AllocationState.REFUNDED, AuthorizationOutcome.REFUNDED),
+        (None, None, AllocationState.ABANDONED, AuthorizationOutcome.TERMINAL_NO_OUTCOME),
+        (
+            FinalizationOutcome.SETTLED,
+            None,
+            AllocationState.ABANDONED,
+            AuthorizationOutcome.TERMINAL_NO_OUTCOME,
+        ),
+    ],
+)
+def test_mirror_mapping_and_same_outcome_replay_are_exact(
+    outcome: FinalizationOutcome | None,
+    actual: int | None,
+    state: AllocationState,
+    authorization_outcome: AuthorizationOutcome,
+) -> None:
+    committed = _bind(_created())
+    allocation = committed.allocations[0]
+    observation = _observation(allocation, outcome=outcome, actual=actual)
+    first = committed.mirror(observation)
+    replay = first.lease.mirror(observation)
+    assert first.allocation.state == state
+    assert first.allocation.authorization_outcome == authorization_outcome
+    assert replay.replayed
+    if outcome == FinalizationOutcome.SETTLED and actual is not None:
+        with pytest.raises(SpendLeaseConflictError, match="different terminal"):
+            first.lease.mirror(replace(observation, finalized_cost_microdollars=actual + 1))
+
+
+def test_abandon_requires_claim_absence_and_deadline_not_timer_alone() -> None:
+    created = _created()
+    with pytest.raises(TypeError):
+        created.allocation.abandon(  # type: ignore[call-arg]
+            expected_provisional_id=created.provisional_id,
+            now=ABANDON_AFTER,
+        )
+    with pytest.raises(SpendLeaseUnavailableError, match="not eligible"):
+        created.lease.abandon(
+            idempotency_scope=created.allocation.idempotency_scope,
+            expected_provisional_id=created.provisional_id,
+            claim=_claim(created.allocation),
+            absence=_absence(created.allocation),
+            now=ABANDON_AFTER - timedelta(microseconds=1),
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "bad_value"),
+    [
+        ("idempotency_scope", "wrong-scope"),
+        ("lease_id", "wrong-lease"),
+        ("gen", 999),
+        ("allocated_micro", 399),
+    ],
+)
+def test_bound_proof_revalidates_every_scope_and_tuple_field(field: str, bad_value: object) -> None:
+    created = _created()
+    proof = replace(_bound_proof(created.allocation), **{field: bad_value})
+    with pytest.raises(SpendLeaseProofError, match="scope|tuple"):
+        created.allocation.bind(expected_provisional_id=created.provisional_id, proof=proof)
+
+
+@pytest.mark.parametrize("proof_name", ["claim_scope", "claim_owner", "absence_scope", "absence_owner"])
+def test_binding_absence_revalidates_claim_and_observation_identity(proof_name: str) -> None:
+    created = _created()
+    claim = _claim(created.allocation)
+    absence = _absence(created.allocation)
+    if proof_name == "claim_scope":
+        claim = replace(claim, idempotency_scope="wrong")
+    elif proof_name == "claim_owner":
+        claim = replace(claim, provisional_id="wrong")
+    elif proof_name == "absence_scope":
+        absence = replace(absence, idempotency_scope="wrong")
+    else:
+        absence = replace(absence, provisional_id="wrong")
+    with pytest.raises(SpendLeaseProofError, match="scope|owner"):
+        created.lease.compensate(
+            idempotency_scope=created.allocation.idempotency_scope,
+            expected_provisional_id=created.provisional_id,
+            claim=claim,
+            absence=absence,
+        )
+
+
+def test_binding_absence_rejects_a_row_that_matches_the_allocation_tuple() -> None:
+    created = _created()
+    matching_row = BindingAbsenceProof(
+        created.allocation.idempotency_scope,
+        created.provisional_id,
+        AbsenceObservation.NON_BINDING_ROW,
+        observed_authorization_id=created.provisional_id,
+        observed_tuple=created.allocation.binding,
+    )
+    with pytest.raises(SpendLeaseProofError, match="bound"):
+        created.lease.compensate(
+            idempotency_scope=created.allocation.idempotency_scope,
+            expected_provisional_id=created.provisional_id,
+            claim=_claim(created.allocation),
+            absence=matching_row,
+        )
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "idempotency_scope",
+        "authorization_id",
+        "request_fingerprint",
+        "lease_id",
+        "gen",
+        "allocated_micro",
+        "key_hash",
+        "workspace_id",
+    ],
+)
+def test_mirror_observation_revalidates_every_identity_and_binding_field(field: str) -> None:
+    committed = _bind(_created())
+    allocation = committed.allocations[0]
+    observation = _observation(allocation)
+    value: object = 999 if field in {"gen", "allocated_micro"} else "wrong"
+    with pytest.raises(SpendLeaseProofError, match="mismatch"):
+        allocation.mirror(replace(observation, **{field: value}))
+
+
+@pytest.mark.parametrize("field", ["idempotency_scope", "authorization_id"])
+def test_committed_lost_proof_revalidates_identity(field: str) -> None:
+    committed = _bind(_created())
+    allocation = committed.allocations[0]
+    proof = CommittedRowAbsentProof(allocation.idempotency_scope, allocation.authorization_id)
+    with pytest.raises(SpendLeaseProofError, match="mismatch"):
+        allocation.lost(replace(proof, **{field: "wrong"}))
+
+
+def test_authorization_scope_view_wrong_scope_is_rejected_before_local_lookup() -> None:
+    created = _created()
+    with pytest.raises(SpendLeaseProofError, match="identity"):
+        created.lease.allocate(
+            authorization_view=replace(_view(created.allocation), idempotency_scope="wrong"),
+            idempotency_scope=created.allocation.idempotency_scope,
+            provisional_authorization_id="unused",
+            request_fingerprint=created.allocation.request_fingerprint,
+            allocated_micro=created.allocation.allocated_micro,
+            abandon_after=ABANDON_AFTER,
+            now=NOW,
+        )
+
+
+@given(
+    operations=st.lists(
+        st.sampled_from(["allocate-a", "allocate-b", "freeze", "replay-a", "replay-b"]),
+        min_size=1,
+        max_size=40,
+    )
+)
+def test_round_eleven_over_admission_execution_never_exceeds_allocations(
+    operations: list[str],
+) -> None:
+    lease = _lease(cap=20)
+    executions: set[str] = set()
+    views: dict[str, AuthorizationView] = {}
+    for operation in operations:
+        scope = operation[-1] if operation[-1] in {"a", "b"} else ""
+        try:
+            if operation.startswith("allocate"):
+                result = lease.allocate(
+                    authorization_view=None,
+                    idempotency_scope=scope,
+                    provisional_authorization_id=f"provisional-{scope}",
+                    request_fingerprint="shared-body",
+                    allocated_micro=10,
+                    abandon_after=ABANDON_AFTER,
+                    now=NOW,
+                )
+                lease = result.lease
+                if isinstance(result, Created):
+                    lease = _bind(result, authorization_id=f"authorization-{scope}")
+                    allocation = next(a for a in lease.allocations if a.idempotency_scope == scope)
+                    views[scope] = _view(allocation)
+                    executions.add(scope)
+            elif operation == "freeze":
+                lease = lease.tombstone().lease
+            elif scope in views:
+                result = lease.allocate(
+                    authorization_view=views[scope],
+                    idempotency_scope=scope,
+                    provisional_authorization_id="unused",
+                    request_fingerprint="shared-body",
+                    allocated_micro=10,
+                    abandon_after=ABANDON_AFTER,
+                    now=EXPIRY + SKEW,
+                )
+                assert isinstance(result, TrueReplay)
+        except SpendLeaseUnavailableError:
+            pass
+        assert len(executions) * 10 <= lease.allocated_micro <= lease.cap_micro
+
+
+def test_differential_copied_shape_is_frozen_validated_and_replays_before_lifecycle() -> None:
+    regional = RegionalQuotaLease(
+        lease_id="regional",
+        workspace_id="workspace",
+        region="us-east4",
+        fencing_token=1,
+        granted_microdollars=100,
+        expires_at=NOW + timedelta(seconds=1),
+    )
+    regional_reserved = regional.reserve(
+        hold_id="scope",
+        fingerprint="fingerprint",
+        amount_microdollars=10,
+        fencing_token=1,
+        now=NOW,
+    ).lease
+    regional_draining = regional_reserved.begin_drain(fencing_token=1)
+    regional_replay = regional_draining.reserve(
+        hold_id="scope",
+        fingerprint="fingerprint",
+        amount_microdollars=10,
+        fencing_token=1,
+        now=NOW + timedelta(days=1),
+    )
+
+    spend_created = _created()
+    spend_bound = _bind(spend_created)
+    spend_frozen = spend_bound.tombstone().lease
+    spend_allocation = spend_frozen.allocations[0]
+    spend_replay = spend_frozen.allocate(
+        authorization_view=_view(spend_allocation),
+        idempotency_scope=spend_allocation.idempotency_scope,
+        provisional_authorization_id="unused",
+        request_fingerprint=spend_allocation.request_fingerprint,
+        allocated_micro=spend_allocation.allocated_micro,
+        abandon_after=ABANDON_AFTER,
+        now=NOW + timedelta(days=1),
+    )
+
+    assert regional_draining.state == RegionalLeaseState.DRAINING
+    assert regional_replay.replayed and isinstance(spend_replay, TrueReplay)
+    with pytest.raises(FrozenInstanceError):
+        spend_frozen.version = 99  # type: ignore[misc]
+    with pytest.raises(SpendLeaseInvariantError):
+        replace(spend_frozen, cap_micro=spend_frozen.allocated_micro - 1)
+
+
+def test_carveouts_refund_does_not_restore_capacity_and_authorization_lookup_is_first() -> None:
+    created = _created(amount=400)
+    refunded = created.lease.compensate(
+        idempotency_scope=created.allocation.idempotency_scope,
+        expected_provisional_id=created.provisional_id,
+        claim=_claim(created.allocation),
+        absence=_absence(created.allocation),
+    ).lease
+    assert refunded.available_micro == 600
+
+    # Unlike the regional local-hold-first precedent, UNBOUND wins even though
+    # a conflicting local allocation exists for this scope.
+    outcome = refunded.allocate(
+        authorization_view=_view(created.allocation, binding=AuthorizationBinding.UNBOUND),
+        idempotency_scope=created.allocation.idempotency_scope,
+        provisional_authorization_id="different",
+        request_fingerprint="different",
+        allocated_micro=1,
+        abandon_after=ABANDON_AFTER,
+        now=NOW,
+    )
+    assert isinstance(outcome, UnboundExisting)
+    assert len(outcome.lease.allocations) == 1


### PR DESCRIPTION
**Stage B unit 1: the pure spend-lease state machine, zero I/O.** Implements decisions 9–22 of the [design record](https://claude.ai/code/artifact/88463c46-2627-4754-83a8-b4d6fb3d3a6e), which converged after twenty adversarial rounds — round twenty could construct no over-admission, no double charge, and no escrow release under an open bound authorization, and reported that the record left no implementation choice unresolved.

**What it is.** Frozen dataclasses with every invariant in `__post_init__` (a corrupted record cannot deserialize into spendable authority); every transition returns a new record plus a `replayed` flag. Capacity is monotonic. One allocation per idempotency scope. Binding phase is stored, and `bind`/`compensate` are both fenced by the expected provisional owner so exactly one can win. The caller supplies proofs — `BoundProof`, `ClaimProof`, `BindingAbsenceProof`, `CommittedRowAbsentProof`, the three contradiction variants, an `AuthorizationObservation`, and a trusted `now` — and the module re-validates each against the stored allocation; it accepts no caller booleans. `QUARANTINED` is the fail-closed outcome for a committed allocation whose row contradicts its proof, and open = {RESERVED, QUARANTINED} is the single close predicate.

**What it is not.** No storage, routes, reconciler, settle-path, or config changes — units 2–4, and unit 2 is gated on a typed-column migration.

**Gate (Fable, on an isolated snapshot):** 56/56, ruff, mypy `--strict`; seven mutation classes each produce a genuine `1 failed`: restore capacity on refund/abandon; permit zero allocation; count only RESERVED as open; construct COMMITTED without a BoundProof; skip tuple re-validation; remove the compensation owner guard (which needed *both* redundant checks removed to break — defense in depth, both reachable); accept a rebind to another authorization. Full suite per Sol: 7,879 passed with sandbox-only failures.

**Reviewer's edit, disclosed:** one docstring line citing decisions 9–22 (the module cited 9 and 13 at the top and the rest inline; the record requires the full set in the docstring).

Authored by Sol (codex-cli); reviewed and gated by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)