### PR TITLE
Spend-lease allocate() recognizes its own retry (decisions 34, 42)

### DIFF
--- a/src/trusted_router/spend_lease_state.py
+++ b/src/trusted_router/spend_lease_state.py
@@ -819,9 +819,21 @@ class SpendLease:
                 return TrueReplay(self, existing, True)
             return Mismatch(self, authorization_view.authorization_id)
 
-        # Decision 21(b): a local CAS loser gets no compensation capability.
         existing = self._allocation(idempotency_scope)
         if existing is not None:
+            # Decision 34 / 21(h): equality proves this is the creator's same-attempt retry.
+            if (
+                existing.state == AllocationState.RESERVED
+                and existing.binding_state == BindingState.PROVISIONAL
+                and existing.authorization_id == provisional_authorization_id
+            ):
+                return Created(
+                    lease=self,
+                    allocation=existing,
+                    replayed=True,
+                    provisional_id=provisional_authorization_id,
+                )
+            # Decision 21(b): a local CAS loser gets no compensation capability.
             return ExistingLocal(self, existing, True)
 
         # Decisions 15, 16, 18: only NEW reaches lifecycle and capacity checks.

--- a/tests/test_spend_lease_state.py
+++ b/tests/test_spend_lease_state.py
@@ -293,7 +293,31 @@ def test_replay_table_is_ordered_disjoint_and_capacity_neutral() -> None:
     assert closed.lease.available_micro == before
 
 
-def test_existing_local_returns_no_compensation_capability_and_never_allocates_twice() -> None:
+def test_same_provisional_id_kills_always_existing_local_mutant() -> None:
+    created = _created()
+    capacity_before = created.lease.available_micro
+    allocations_before = len(created.lease.allocations)
+
+    replay = created.lease.allocate(
+        authorization_view=None,
+        idempotency_scope=created.allocation.idempotency_scope,
+        provisional_authorization_id=created.provisional_id,
+        request_fingerprint=created.allocation.request_fingerprint,
+        allocated_micro=created.allocation.allocated_micro,
+        abandon_after=ABANDON_AFTER,
+        now=NOW,
+    )
+
+    assert isinstance(replay, Created)
+    assert replay.replayed
+    assert replay.provisional_id == created.provisional_id
+    assert replay.allocation is created.allocation
+    assert replay.lease is created.lease
+    assert replay.lease.available_micro == capacity_before
+    assert len(replay.lease.allocations) == allocations_before
+
+
+def test_different_provisional_id_kills_any_reserved_created_mutant() -> None:
     created = _created()
     existing = created.lease.allocate(
         authorization_view=None,
@@ -307,6 +331,27 @@ def test_existing_local_returns_no_compensation_capability_and_never_allocates_t
     assert isinstance(existing, ExistingLocal)
     assert not hasattr(existing, "provisional_id")
     assert existing.lease is created.lease
+    assert len(existing.lease.allocations) == 1
+
+
+def test_same_provisional_id_for_committed_allocation_is_existing_local() -> None:
+    created = _created()
+    committed = _bind(created, authorization_id=created.provisional_id)
+    allocation = committed.allocations[0]
+
+    existing = committed.allocate(
+        authorization_view=None,
+        idempotency_scope=allocation.idempotency_scope,
+        provisional_authorization_id=created.provisional_id,
+        request_fingerprint=allocation.request_fingerprint,
+        allocated_micro=allocation.allocated_micro,
+        abandon_after=ABANDON_AFTER,
+        now=NOW,
+    )
+
+    assert isinstance(existing, ExistingLocal)
+    assert not hasattr(existing, "provisional_id")
+    assert existing.lease is committed
     assert len(existing.lease.allocations) == 1
 
 


### PR DESCRIPTION
**Unit-1 amendment surfaced by unit-2 grounding.** After an ambiguous Bigtable commit that actually landed, a creator's retry of `allocate()` was classified as `ExistingLocal` — which by design carries no compensation capability — so the creator lost the provisional id that is the only key into `compensate()` and `abandon()`. The regional precedent's retry safety rested on the local-hold-first lookup that unit 1 deliberately reversed (carve-out viii), so unit 1 needs its own rule.

**The rule (design record decisions 34 and 42).** An existing `RESERVED/PROVISIONAL` allocation whose `authorization_id` equals the provisional id *this attempt* presents is this attempt's own creation — the route's pre-minted id is unique per attempt, so equality proves it — and `allocate()` returns `Created` for it as a replay: `replayed=True`, same provisional id, no capacity consumed, no version change. `ExistingLocal` remains the result only for a different attempt or a `COMMITTED` allocation. That replay flag is what lets unit 2's ledger keep its integer CAS version never-reused.

**Gate (Fable, isolated snapshot):** two files only, 58/58, ruff, mypy `--strict`; three mutations each produce a genuine `1 failed` — force always-`ExistingLocal`, loosen to any-reserved `Created`, and flip `replayed` to `False` on the self-retry. Full suite per Sol: 7,886 passed with sandbox-only failures. Needs admin merge.

Authored by Sol (codex-cli); reviewed and gated by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)