### PR TITLE
Drain the operational outbox with one watermarked seek instead of a garbage walk

### DIFF
--- a/clickhouse/ingest_operational_outbox.py
+++ b/clickhouse/ingest_operational_outbox.py
@@ -21,6 +21,9 @@ SPANNER_INSTANCE = "trusted-router-nam6"
 SPANNER_DATABASE = "trusted-router"
 OUTBOX_TABLE = "tr_operational_analytics_outbox"
 OUTBOX_SHARDS = 32
+# Watermark used before the first acknowledged batch of a process: seeks from
+# the start of every shard, i.e. the old full walk, exactly once.
+_WATERMARK_EPOCH = dt.datetime(1970, 1, 1, tzinfo=dt.UTC)
 
 ACTIVITY_COLUMNS = (
     "generation_id",
@@ -305,24 +308,65 @@ class SpannerOperationalOutboxSource:
         )
         self._pt = param_types
         self._shard_count = shard_count
+        # Commit-timestamp watermark: every row committed at or before it has
+        # already been drained and deleted. See fetch() for why it is safe.
+        self._after: dt.datetime | None = None
 
     def fetch(self, *, limit: int) -> list[OperationalOutboxRow]:
         if limit < 1:
             return []
-        # Delivery order is not load-bearing: ClickHouse replacement uses the
-        # stable outbox commit timestamp as its version, and delete addresses
-        # only the exact fetched primary keys after every insert succeeds.
-        # Quarantine rows are append-only diagnostics and can repeat after a
-        # partial insert retry, but they have no ordering semantics.
-        # One global LIMIT therefore replaces the ordered query per shard.
+        # One statement, thirty-two key-range seeks, one watermark.
+        #
+        # This table churns: every drained row is deleted, and under the
+        # database's 7-day version retention each deleted row stays behind as
+        # a dead version the storage layer must step over. The previous
+        # unfiltered ``LIMIT @limit`` therefore walked garbage from the head of
+        # the table on EVERY poll: SPANNER_SYS.QUERY_STATS_TOP_HOUR on
+        # 2026-09-01 showed it at 0.207s CPU per execution to return ~2 rows,
+        # 3,300 executions/hour -- ~690 CPU-seconds/hour, the single largest
+        # load on the shared billing-plane instance, in the same hours the
+        # authorize/settle path stalled for seconds. Measured in PROFILE mode
+        # against the live table at the same moment: unfiltered 280ms CPU;
+        # this statement with a warm watermark 24ms (19ms of it plan creation,
+        # amortised by parameterisation); with the epoch watermark 297ms, i.e.
+        # the cost is paid once per process start, not per poll.
+        #
+        # Why a single global watermark is safe: rows are consumed in global
+        # commit_ts order (ORDER BY commit_ts across all shards, then LIMIT),
+        # and each fetch is a strong snapshot read. Any row not yet visible
+        # was committed after the snapshot and carries a larger commit_ts than
+        # every row we have seen, so nothing live can sit below the largest
+        # commit_ts we have deleted. ``>=`` keeps rows that share a commit
+        # timestamp with the last deleted batch (one transaction, several
+        # events) from being skipped when LIMIT cut through the tie; the ones
+        # already deleted do not come back.
+        #
+        # The per-shard predicate is what turns the scan into seeks: the
+        # primary key is (shard, commit_ts, ...), so ``shard IN UNNEST`` gives
+        # one range per shard starting at the watermark. A plain
+        # ``commit_ts >= @after`` alone is not a key prefix and would scan.
+        #
+        # An earlier per-shard loop of 32 statements per poll was itself the
+        # largest query load (measured 2026-08-25); this keeps one statement.
         rows: list[OperationalOutboxRow] = []
+        after = self._after or _WATERMARK_EPOCH
         with self._database.snapshot() as snapshot:
             values = snapshot.execute_sql(
                 # OUTBOX_TABLE is a module constant, not caller input.
                 "SELECT shard, commit_ts, event_kind, event_id, payload "  # noqa: S608
-                f"FROM {OUTBOX_TABLE} LIMIT @limit",
-                params={"limit": limit},
-                param_types={"limit": self._pt.INT64},
+                f"FROM {OUTBOX_TABLE} "
+                "WHERE shard IN UNNEST(@shards) AND commit_ts >= @after "
+                "ORDER BY commit_ts LIMIT @limit",
+                params={
+                    "shards": list(range(self._shard_count)),
+                    "after": after,
+                    "limit": limit,
+                },
+                param_types={
+                    "shards": self._pt.Array(self._pt.INT64),
+                    "after": self._pt.TIMESTAMP,
+                    "limit": self._pt.INT64,
+                },
             )
             rows.extend(
                 OperationalOutboxRow(
@@ -343,6 +387,12 @@ class SpannerOperationalOutboxSource:
 
         with self._database.batch() as batch:
             batch.delete(OUTBOX_TABLE, KeySet(keys=[list(row.key) for row in rows]))
+        # Advance only after the delete committed: a failed insert never
+        # reaches here, so a row that was fetched but not acknowledged stays
+        # above the watermark and is fetched again.
+        newest = max(_utc(row.commit_ts) for row in rows)
+        if self._after is None or newest > self._after:
+            self._after = newest
 
     def oldest_commit_ts(self) -> dt.datetime | None:
         oldest: dt.datetime | None = None
@@ -476,9 +526,7 @@ class ClickHouseOperationalWriter:
                 ) from exc
             if result.returncode != 0:
                 detail = result.stderr.decode("utf-8", errors="replace")[:1000]
-                raise ClickHouseInsertError(
-                    f"ClickHouse {event_kind} insert failed: {detail}"
-                )
+                raise ClickHouseInsertError(f"ClickHouse {event_kind} insert failed: {detail}")
 
 
 def _event_id(tenant_id: str, batch_id: str, kind: str, index: int) -> str:

--- a/tests/test_operational_analytics.py
+++ b/tests/test_operational_analytics.py
@@ -14,6 +14,7 @@ import httpx
 import pytest
 
 from clickhouse.ingest_operational_outbox import (
+    _WATERMARK_EPOCH,
     CanonicalOperationalEvent,
     OperationalOutboxRow,
     OutboxSource,
@@ -87,6 +88,11 @@ def _generation() -> Generation:
 class _ParamTypes:
     INT64 = "INT64"
     STRING = "STRING"
+    TIMESTAMP = "TIMESTAMP"
+
+    @staticmethod
+    def Array(element: str) -> str:  # noqa: N802 - mirrors google.cloud.spanner_v1.param_types
+        return f"ARRAY<{element}>"
 
 
 class _Transaction:
@@ -121,9 +127,7 @@ def test_activity_payload_names_its_workspace_but_never_keys_or_content() -> Non
     payload = activity_payload(generation)
     encoded = json.dumps(payload, sort_keys=True)
 
-    assert payload["tenant_id"] == analytics_surrogate(
-        "workspace", generation.workspace_id
-    )
+    assert payload["tenant_id"] == analytics_surrogate("workspace", generation.workspace_id)
     assert payload["workspace_id"] == generation.workspace_id
     assert payload["key_id"] == analytics_surrogate("api-key", generation.key_hash)
     assert generation.key_hash not in encoded
@@ -137,17 +141,13 @@ def test_activity_payload_names_its_workspace_but_never_keys_or_content() -> Non
 def test_operational_outbox_enqueue_is_sharded_and_commit_timestamped() -> None:
     database = _Database()
     generation = _generation()
-    SpannerOperationalAnalyticsOutbox(database, _ParamTypes()).enqueue_activity(
-        generation
-    )
+    SpannerOperationalAnalyticsOutbox(database, _ParamTypes()).enqueue_activity(generation)
 
     [(sql, params, param_types)] = database.transaction.calls
     assert "PENDING_COMMIT_TIMESTAMP()" in sql
     assert params["event_kind"] == "activity"
     assert params["event_id"] == generation.id
-    assert params["shard"] == operational_analytics_shard(
-        f"activity:{generation.id}"
-    )
+    assert params["shard"] == operational_analytics_shard(f"activity:{generation.id}")
     assert json.loads(params["payload"])["tenant_id"] != generation.workspace_id
     assert param_types == {
         "shard": "INT64",
@@ -277,18 +277,14 @@ def test_spanner_client_events_enqueue_uses_one_batch_outbox_row() -> None:
     database = _Database()
     payload = _client_events_payload()
 
-    SpannerOperationalAnalyticsOutbox(database, _ParamTypes()).enqueue_client_events(
-        payload
-    )
+    SpannerOperationalAnalyticsOutbox(database, _ParamTypes()).enqueue_client_events(payload)
 
     [(sql, params, _)] = database.transaction.calls
     event_id = f"{payload['tenant_id']}:{payload['batch_id']}"
     assert "PENDING_COMMIT_TIMESTAMP()" in sql
     assert params["event_kind"] == CLIENT_EVENTS_EVENT_KIND
     assert params["event_id"] == event_id
-    assert params["shard"] == operational_analytics_shard(
-        f"{CLIENT_EVENTS_EVENT_KIND}:{event_id}"
-    )
+    assert params["shard"] == operational_analytics_shard(f"{CLIENT_EVENTS_EVENT_KIND}:{event_id}")
     assert json.loads(params["payload"]) == payload
 
 
@@ -300,9 +296,7 @@ def test_postgres_client_events_enqueue_uses_one_idempotent_batch_row() -> None:
             statements.append((sql, params))
 
     connection = Connection()
-    outbox = PostgresOperationalAnalyticsOutbox(
-        lambda operation: operation(connection)
-    )
+    outbox = PostgresOperationalAnalyticsOutbox(lambda operation: operation(connection))
     payload = _client_events_payload()
 
     outbox.enqueue_client_events(payload)
@@ -582,9 +576,7 @@ def test_public_snapshot_reads_newest_revision_across_month_partitions(
         transport=httpx.MockTransport(handler),
     )
 
-    assert client.public_snapshot(snapshot_name) == {
-        "generated_at": "2026-08-01T00:00:00Z"
-    }
+    assert client.public_snapshot(snapshot_name) == {"generated_at": "2026-08-01T00:00:00Z"}
 
 
 def test_public_snapshot_rejects_unknown_products_without_querying() -> None:
@@ -700,10 +692,12 @@ class _QueryCountingSnapshot:
     ) -> list[tuple[object, ...]]:
         self.database.select_statements.append(sql)
         self.database.select_params.append((params, param_types))
-        if len(self.database.select_statements) > 1:
+        if not self.database.pending_rows:
             return []
-        row = _outbox_row()
-        return [(row.shard, row.commit_ts, row.event_kind, row.event_id, row.payload)]
+        batch = self.database.pending_rows.pop(0)
+        return [
+            (row.shard, row.commit_ts, row.event_kind, row.event_id, row.payload) for row in batch
+        ]
 
 
 class _QueryCountingBatch:
@@ -721,10 +715,14 @@ class _QueryCountingBatch:
 
 
 class _QueryCountingDatabase:
-    def __init__(self) -> None:
+    def __init__(self, rows: list[list[OperationalOutboxRow]] | None = None) -> None:
         self.select_statements: list[str] = []
         self.select_params: list[tuple[dict[str, Any], dict[str, Any]]] = []
         self.delete_calls: list[tuple[str, object]] = []
+        # Each fetch pops one batch; an exhausted queue means an empty outbox.
+        self.pending_rows: list[list[OperationalOutboxRow]] = (
+            [[_outbox_row()]] if rows is None else rows
+        )
 
     def snapshot(self, **_kwargs: object) -> _QueryCountingSnapshot:
         return _QueryCountingSnapshot(self)
@@ -733,23 +731,66 @@ class _QueryCountingDatabase:
         return _QueryCountingBatch(self)
 
 
-def test_spanner_drain_loop_uses_one_global_fetch_query_plus_ack() -> None:
-    database = _QueryCountingDatabase()
+def _spanner_source(database: _QueryCountingDatabase) -> SpannerOperationalOutboxSource:
     source = object.__new__(SpannerOperationalOutboxSource)
     source._database = database
     source._pt = _ParamTypes()
     source._shard_count = 32
+    source._after = None
+    return source
+
+
+def test_spanner_drain_fetch_is_one_seek_statement_with_a_watermark() -> None:
+    """One statement per poll, seeking every shard from the watermark.
+
+    The unfiltered ``LIMIT @limit`` this replaces walked the table's deleted-row
+    garbage on every poll: 0.207s CPU per execution for ~2 rows, 3,300/hour --
+    the largest load on the billing-plane instance (SPANNER_SYS, 2026-09-01).
+    The per-shard predicate is what makes the read a set of key-range seeks;
+    a bare ``commit_ts >= @after`` is not a key prefix and would still scan.
+    """
+    database = _QueryCountingDatabase()
+    source = _spanner_source(database)
 
     result = drain_once(source, _Writer(), batch_size=100)
 
     assert result.fetched == 1
     assert len(database.select_statements) == 1
-    assert "WHERE shard" not in database.select_statements[0]
-    assert "ORDER BY" not in database.select_statements[0]
-    assert database.select_params == [
-        ({"limit": 100}, {"limit": _ParamTypes.INT64})
-    ]
+    statement = database.select_statements[0]
+    assert "WHERE shard IN UNNEST(@shards)" in statement
+    assert "commit_ts >= @after" in statement
+    assert "ORDER BY commit_ts LIMIT @limit" in statement
+    params, types = database.select_params[0]
+    assert params == {"shards": list(range(32)), "after": _WATERMARK_EPOCH, "limit": 100}
+    assert types == {"shards": "ARRAY<INT64>", "after": "TIMESTAMP", "limit": "INT64"}
     assert len(database.delete_calls) == 1
+
+
+def test_spanner_drain_watermark_advances_only_after_clickhouse_ack() -> None:
+    """The watermark moves to the newest DELETED commit_ts, never to a fetched one.
+
+    A batch whose insert failed is never deleted, so the next poll must seek
+    from the old watermark and see it again; after an acknowledged batch the
+    next poll seeks from that batch's newest commit timestamp (``>=`` keeps
+    tie-sharing rows that LIMIT may have cut).
+    """
+    row = _outbox_row()
+    database = _QueryCountingDatabase(rows=[[row], [row], []])
+    source = _spanner_source(database)
+
+    with pytest.raises(RuntimeError, match="ClickHouse unavailable"):
+        drain_once(source, _Writer(failures=1), batch_size=100)
+    assert database.delete_calls == []
+    assert source._after is None
+
+    acked = drain_once(source, _Writer(), batch_size=100)
+    assert acked.fetched == 1
+    assert len(database.delete_calls) == 1
+    assert source._after == row.commit_ts
+
+    drain_once(source, _Writer(), batch_size=100)
+    assert database.select_params[-1][0]["after"] == row.commit_ts
+    assert database.select_params[0][0]["after"] == _WATERMARK_EPOCH
 
 
 def test_operational_cursor_advances_only_after_clickhouse_ack() -> None:
@@ -914,9 +955,7 @@ def test_client_reliability_reader_binds_tenant_and_uses_final_rollups() -> None
         "p50_total_ms": 100,
         "p95_total_ms": 200,
         "p50_ttft_ms": 100,
-        "by_host": {
-            "apex": {"attempts": 110, "attempt_tr_fault": 2, "rate": 0.018182}
-        },
+        "by_host": {"apex": {"attempts": 110, "attempt_tr_fault": 2, "rate": 0.018182}},
     }
 
 
@@ -1249,9 +1288,7 @@ class _SnapshotDatabase:
                 outer.queries.append((sql, kwargs.get("params") or {}))
                 shards = [int(value) for value in re.findall(r"WHERE shard=(\d+)", sql)]
                 stamps = sorted(
-                    stamp
-                    for shard in shards
-                    for stamp in outer._rows_by_shard.get(shard, [])
+                    stamp for shard in shards for stamp in outer._rows_by_shard.get(shard, [])
                 )
                 return [[stamps[0]]] if stamps else [[None]]
 


### PR DESCRIPTION
The single largest query on the billing-plane Spanner instance was the ClickHouse drain's poll — an unfiltered `LIMIT @limit` that cost **0.207s CPU to return 2 rows, 3,300×/hour (~690 CPU-s/hr)**, in exactly the hours the instance hit 60–70% and authorize/settle stalled for seconds. The table churns under 7-day version retention, so every poll walked the deleted-row garbage from the head of the table.

Replacement is one statement that seeks: `WHERE shard IN UNNEST(@shards) AND commit_ts >= @after ORDER BY commit_ts LIMIT @limit`. The per-shard predicate matches the primary key prefix, so it's one key range per shard from the watermark.

Measured in PROFILE mode against the live table at the same moment:

| statement | CPU |
|---|---|
| unfiltered `LIMIT` (current) | 280 ms |
| **seek, warm watermark** | **24 ms** (19 ms plan creation, amortised by parameters) |
| seek, epoch watermark (first poll after restart) | 297 ms — paid once per process |

A 32-branch `UNION ALL` was tried first and rejected (170 ms plan creation per execution); the earlier 32-statement-per-poll loop was itself the largest load on 2026-08-25. This stays at one statement.

**Why a single global watermark is safe:** rows are consumed in global `commit_ts` order from strong snapshot reads, so any not-yet-visible row has a larger `commit_ts` than everything seen; nothing live can sit below the newest commit_ts we have *deleted*. It advances only in `delete()` after the commit, so a batch whose ClickHouse insert failed is fetched again; `>=` keeps tie-sharing rows LIMIT cut through.

Tests pin the statement shape and the ack-gated advance; mutation-tested (drop predicate / never advance / advance on fetch each fail one test).

**Deploy:** this runs on `tr-clickhouse-1`, shipped by `scripts/deploy/clickhouse_live_ingestion.sh`, not the Cloud Run rollout. I'll ship it after merge and verify at the destination — the new statement text appearing in `SPANNER_SYS` and the old one stopping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)