### PR TITLE
Precompile bytecode into the image so cold starts stop compiling on the vCPU

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,17 @@ RUN uv sync --frozen --no-dev --no-install-project
 
 COPY src ./src
 RUN uv sync --frozen --no-dev
+# Precompile bytecode into the image. PYTHONDONTWRITEBYTECODE=1 above means a
+# running container never writes .pyc, so without this step EVERY cold start
+# re-parses and compiles every module in src/ and site-packages on a throttled
+# vCPU before uvicorn can bind. Measured on Cloud Run 2026-09-01: startup
+# latency p50 34.6s / p95 217s, with 22.7s elapsing between "Starting new
+# instance" and uvicorn's first log line while the app's own startup handlers
+# took 14ms. compileall writes .pyc explicitly (py_compile), unaffected by the
+# env var. src/ must compile cleanly; site-packages is best-effort because a
+# few third-party packages ship intentionally-broken example files.
+RUN /app/.venv/bin/python -m compileall -q -j 0 /app/src \
+ && (/app/.venv/bin/python -m compileall -q -j 0 /app/.venv/lib/python3.12/site-packages >/dev/null 2>&1 || true)
 
 COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
Cloud Run startup latency for `trusted-router`, 24h to 2026-09-01: **p50 34.6s, p95 217s**. A cold-start timeline from the logs puts **22.7s between "Starting new instance" and uvicorn's first log line**, while the app's own startup handlers took 14ms. The gap is interpreter start plus importing the app on a throttled vCPU — and `PYTHONDONTWRITEBYTECODE=1` means no `.pyc` is ever written, so every cold start parses and compiles every module from source.

`compileall` writes `.pyc` explicitly (`py_compile`), unaffected by the env var. `src/` must compile cleanly; site-packages is best-effort (a few third-party packages ship intentionally-broken example files).

Measured, both images built locally, `--cpus=1`, three cold imports each:

| image | `import trusted_router.main` | size |
|---|---|---|
| baseline (origin/main) | 1.75s / 1.70s / 1.70s | 842MB |
| **precompiled** | **1.19s / 1.20s / 1.19s** | 918MB |

**30% off import time for +9% image.** On Cloud Run's slower vCPU with cold layer streaming the absolute savings are larger; the ratio is the honest number.

Not addressed here, flagged as the next lever: the image is **842MB** for a Python service — layer streaming of that on a fresh node is a plausible dominant term in the 22.7s. No CI job builds the image (Cloud Build does at deploy); the local build succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)