### PR TITLE
spend-lease: typed refusal reason, creating identity, RecoveryProof, tombstone_unminted (unit-1 follow-up)

### DIFF
--- a/src/trusted_router/spend_lease_state.py
+++ b/src/trusted_router/spend_lease_state.py
@@ -1,14 +1,15 @@
 """Pure state machine for authoritative spend-lease allocations.
 
-Implements Stage B decisions 9–22 of the spend-lease design record (the pure state
-machine, decided over twenty adversarial rounds); each invariant below cites its decision.
+Implements Stage B decisions 9–22 and decision 46 of the spend-lease design
+record; each invariant below cites its decision.
 
 This module contains no storage or clock I/O.  It implements design decisions
 9--22: lifetime-monotonic capacity (9), proof-derived allocation terminality
 (10, 14, 20, 22), separate grant generation and CAS version (12), the ordered
 authorization-first replay table (13), admission/freeze rules (15, 16, 18),
 construction-time amount and provenance checks (17), the unified open predicate
-(18--20, 22), and owner-fenced bind/compensate transitions (21--22).
+(18--20, 22), owner-fenced bind/compensate transitions (21--22), and durable
+recovery of never-minted candidates (46).
 
 Only the regional precedent's immutable-record, ``__post_init__`` validation,
 and true-replay-before-lifecycle shape is reused.  In particular, refunds never
@@ -23,6 +24,15 @@ from dataclasses import InitVar, dataclass, replace
 from datetime import datetime, timedelta
 from enum import StrEnum
 from typing import TypeAlias
+
+
+class SpendLeaseRefusalReason(StrEnum):
+    FROZEN_DRAINING = "frozen_draining"
+    FROZEN_TOMBSTONED = "frozen_tombstoned"
+    WINDOW_EXPIRED = "window_expired"
+    WINDOW_NOT_ELAPSED = "window_not_elapsed"
+    CLOSED = "closed"
+    EXHAUSTED = "exhausted"
 
 
 class SpendLeaseStateError(ValueError):
@@ -44,9 +54,26 @@ class SpendLeaseProofError(SpendLeaseConflictError):
 class SpendLeaseUnavailableError(SpendLeaseStateError):
     """The lease cannot admit a new allocation."""
 
+    reason: SpendLeaseRefusalReason
+
+    def __init__(self, message: str, *, reason: SpendLeaseRefusalReason) -> None:
+        super().__init__(message)
+        self.reason = reason
+
 
 class SpendLeaseExhaustedError(SpendLeaseUnavailableError):
     """The lease lacks monotonic capacity for a new allocation."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, reason=SpendLeaseRefusalReason.EXHAUSTED)
+
+
+def is_authoritative_exhaustion(exc: SpendLeaseUnavailableError) -> bool:
+    """Return whether ``exc`` proves authoritative exhaustion (decision 46)."""
+
+    return isinstance(exc, SpendLeaseExhaustedError) or (
+        exc.reason == SpendLeaseRefusalReason.FROZEN_TOMBSTONED
+    )
 
 
 class BindingState(StrEnum):
@@ -155,6 +182,19 @@ class ClaimProof:
             raise SpendLeaseInvariantError("claim proof identity is required")
         if self.registration != ClaimRegistration.CLAIM:
             raise SpendLeaseInvariantError("claim proof must carry a CLAIM registration")
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryProof:
+    """A durable control-plane work row committed to the ``recovering`` phase."""
+
+    recovering_at: datetime
+    creating_authorization_id: str
+
+    def __post_init__(self) -> None:
+        _require_aware(self.recovering_at, "recovering_at")
+        if not self.creating_authorization_id:
+            raise SpendLeaseInvariantError("recovery proof identity is required")
 
 
 @dataclass(frozen=True, slots=True)
@@ -444,11 +484,17 @@ class SpendLeaseAllocation:
         self,
         *,
         expected_provisional_id: str,
-        claim: ClaimProof,
+        claim: ClaimProof | RecoveryProof,
         absence: BindingAbsenceProof,
+        lease_creating_authorization_id: str | None = None,
     ) -> AllocationTransition:
-        # Decisions 10, 15, 21(d/g), 22: claim plus durable absence, owner fenced.
-        self._validate_binding_absence(expected_provisional_id, claim, absence)
+        # Decisions 10, 15, 21(d/g), 22, 46: durable non-binding proof, owner fenced.
+        self._validate_binding_absence(
+            expected_provisional_id,
+            claim,
+            absence,
+            lease_creating_authorization_id=lease_creating_authorization_id,
+        )
         if self.state == AllocationState.REFUNDED and (
             self.terminal_source == TerminalSource.BINDING_ABSENCE
         ):
@@ -479,7 +525,10 @@ class SpendLeaseAllocation:
             return AllocationTransition(self, True)
         self._require_provisional_owner(expected_provisional_id)
         if now < self.abandon_after:
-            raise SpendLeaseUnavailableError("allocation is not eligible for abandonment")
+            raise SpendLeaseUnavailableError(
+                "allocation is not eligible for abandonment",
+                reason=SpendLeaseRefusalReason.WINDOW_NOT_ELAPSED,
+            )
         abandoned = replace(
             self,
             state=AllocationState.ABANDONED,
@@ -612,15 +661,23 @@ class SpendLeaseAllocation:
     def _validate_binding_absence(
         self,
         expected_provisional_id: str,
-        claim: ClaimProof,
+        claim: ClaimProof | RecoveryProof,
         absence: BindingAbsenceProof,
+        *,
+        lease_creating_authorization_id: str | None = None,
     ) -> None:
         if expected_provisional_id != self.authorization_id:
             raise SpendLeaseConflictError("stale provisional allocation owner")
-        if claim.idempotency_scope != self.idempotency_scope:
-            raise SpendLeaseProofError("claim proof scope mismatch")
-        if claim.provisional_id != expected_provisional_id:
-            raise SpendLeaseProofError("claim proof provisional owner mismatch")
+        if isinstance(claim, ClaimProof):
+            if claim.idempotency_scope != self.idempotency_scope:
+                raise SpendLeaseProofError("claim proof scope mismatch")
+            if claim.provisional_id != expected_provisional_id:
+                raise SpendLeaseProofError("claim proof provisional owner mismatch")
+        else:
+            if claim.creating_authorization_id != lease_creating_authorization_id:
+                raise SpendLeaseProofError("recovery proof lease identity mismatch")
+            if self.authorization_id != lease_creating_authorization_id:
+                raise SpendLeaseProofError("recovery proof requires the creating allocation")
         if absence.idempotency_scope != self.idempotency_scope:
             raise SpendLeaseProofError("absence proof scope mismatch")
         if absence.provisional_id != expected_provisional_id:
@@ -737,16 +794,26 @@ class SpendLease:
     key_hash: str
     boot_kid: str
     workspace_id: str
+    creating_authorization_id: str
     cap_micro: int
     expires_at: datetime
     skew: timedelta
     version: int
     state: SpendLeaseState = SpendLeaseState.ACTIVE
     allocations: tuple[SpendLeaseAllocation, ...] = ()
+    tombstoned_unminted: bool = False
 
     def __post_init__(self) -> None:
         # Decisions 12 and 17: grant generation and local CAS version are distinct.
-        if not all((self.lease_id, self.key_hash, self.boot_kid, self.workspace_id)):
+        if not all(
+            (
+                self.lease_id,
+                self.key_hash,
+                self.boot_kid,
+                self.workspace_id,
+                self.creating_authorization_id,
+            )
+        ):
             raise SpendLeaseInvariantError("lease identity fields are required")
         if self.gen <= 0:
             raise SpendLeaseInvariantError("lease generation must be positive")
@@ -757,6 +824,11 @@ class SpendLease:
         _require_aware(self.expires_at, "expires_at")
         if self.skew < timedelta(0):
             raise SpendLeaseInvariantError("lease skew cannot be negative")
+        if self.tombstoned_unminted and self.state not in {
+            SpendLeaseState.TOMBSTONED,
+            SpendLeaseState.CLOSED,
+        }:
+            raise SpendLeaseInvariantError("unminted tombstone provenance requires a frozen lease")
         scopes = [allocation.idempotency_scope for allocation in self.allocations]
         owners = [allocation.authorization_id for allocation in self.allocations]
         if len(scopes) != len(set(scopes)):
@@ -838,9 +910,19 @@ class SpendLease:
 
         # Decisions 15, 16, 18: only NEW reaches lifecycle and capacity checks.
         if self.state != SpendLeaseState.ACTIVE:
-            raise SpendLeaseUnavailableError(f"lease is {self.state}")
+            refusal_reason = {
+                SpendLeaseState.DRAINING: SpendLeaseRefusalReason.FROZEN_DRAINING,
+                SpendLeaseState.TOMBSTONED: SpendLeaseRefusalReason.FROZEN_TOMBSTONED,
+                SpendLeaseState.CLOSED: SpendLeaseRefusalReason.CLOSED,
+            }[self.state]
+            raise SpendLeaseUnavailableError(
+                f"lease is {self.state}", reason=refusal_reason
+            )
         if now >= self.expires_at + self.skew:
-            raise SpendLeaseUnavailableError("lease admission window has expired")
+            raise SpendLeaseUnavailableError(
+                "lease admission window has expired",
+                reason=SpendLeaseRefusalReason.WINDOW_EXPIRED,
+            )
         if allocated_micro <= 0:
             raise SpendLeaseInvariantError("allocated_micro must be positive")
         if allocated_micro > self.available_micro:
@@ -868,6 +950,15 @@ class SpendLease:
             provisional_id=provisional_authorization_id,
         )
 
+    def initialize(self, candidate: SpendLease) -> LeaseTransition:
+        """Replay the same lease identity or reject a corrupt re-initialization."""
+
+        if self._initialization_identity != candidate._initialization_identity:
+            raise SpendLeaseInvariantError(
+                "spend lease initialization identity mismatch is corruption"
+            )
+        return LeaseTransition(self, True)
+
     def bind(self, *, expected_provisional_id: str, proof: BoundProof) -> LeaseAllocationTransition:
         allocation = self._required_allocation(proof.idempotency_scope)
         transition = allocation.bind(expected_provisional_id=expected_provisional_id, proof=proof)
@@ -878,7 +969,7 @@ class SpendLease:
         *,
         idempotency_scope: str,
         expected_provisional_id: str,
-        claim: ClaimProof,
+        claim: ClaimProof | RecoveryProof,
         absence: BindingAbsenceProof,
     ) -> LeaseAllocationTransition:
         allocation = self._required_allocation(idempotency_scope)
@@ -886,6 +977,7 @@ class SpendLease:
             expected_provisional_id=expected_provisional_id,
             claim=claim,
             absence=absence,
+            lease_creating_authorization_id=self.creating_authorization_id,
         )
         return self._apply_allocation(transition)
 
@@ -929,9 +1021,17 @@ class SpendLease:
         if self.state == SpendLeaseState.DRAINING:
             return LeaseTransition(self, True)
         if self.state != SpendLeaseState.ACTIVE:
-            raise SpendLeaseUnavailableError(f"lease is {self.state}")
+            refusal_reason = {
+                SpendLeaseState.TOMBSTONED: SpendLeaseRefusalReason.FROZEN_TOMBSTONED,
+            }[self.state]
+            raise SpendLeaseUnavailableError(
+                f"lease is {self.state}", reason=refusal_reason
+            )
         if now < self.expires_at + self.skew:
-            raise SpendLeaseUnavailableError("lease admission window has not elapsed")
+            raise SpendLeaseUnavailableError(
+                "lease admission window has not elapsed",
+                reason=SpendLeaseRefusalReason.WINDOW_NOT_ELAPSED,
+            )
         return LeaseTransition(replace(self, state=SpendLeaseState.DRAINING, version=self.version + 1), False)
 
     def tombstone(self) -> LeaseTransition:
@@ -943,17 +1043,50 @@ class SpendLease:
             False,
         )
 
+    def tombstone_unminted(self, proof: RecoveryProof) -> LeaseTransition:
+        """Decision 46 step 4b — closes a never-minted candidate's local row so a
+        lagging producer's late ``allocate()`` is refused; serialized against
+        ``allocate()`` by the row CAS.
+        """
+
+        if proof.creating_authorization_id != self.creating_authorization_id:
+            raise SpendLeaseProofError("recovery proof lease identity mismatch")
+        if self.state == SpendLeaseState.TOMBSTONED and self.tombstoned_unminted:
+            return LeaseTransition(self, True)
+        if self.state != SpendLeaseState.ACTIVE:
+            raise SpendLeaseConflictError("unminted tombstone requires an active lease")
+        if self.open_allocations:
+            raise SpendLeaseConflictError("unminted tombstone requires terminal allocations")
+        return LeaseTransition(
+            replace(
+                self,
+                state=SpendLeaseState.TOMBSTONED,
+                version=self.version + 1,
+                tombstoned_unminted=True,
+            ),
+            False,
+        )
+
     def close(self, *, now: datetime) -> LeaseTransition:
         # Decisions 5, 18, 19, 22: two guards, using the one open predicate.
         _require_aware(now, "now")
         if self.state == SpendLeaseState.CLOSED:
             return LeaseTransition(self, True)
         if self.state not in {SpendLeaseState.DRAINING, SpendLeaseState.TOMBSTONED}:
-            raise SpendLeaseUnavailableError("lease must be frozen before close")
+            raise SpendLeaseUnavailableError(
+                "lease must be frozen before close",
+                reason=SpendLeaseRefusalReason.CLOSED,
+            )
         if now < self.expires_at + self.skew:
-            raise SpendLeaseUnavailableError("lease cannot close before expiry plus skew")
+            raise SpendLeaseUnavailableError(
+                "lease cannot close before expiry plus skew",
+                reason=SpendLeaseRefusalReason.WINDOW_NOT_ELAPSED,
+            )
         if self.open_allocations:
-            raise SpendLeaseUnavailableError("lease still has open allocations")
+            raise SpendLeaseUnavailableError(
+                "lease still has open allocations",
+                reason=SpendLeaseRefusalReason.CLOSED,
+            )
         return LeaseTransition(replace(self, state=SpendLeaseState.CLOSED, version=self.version + 1), False)
 
     def _allocation(self, idempotency_scope: str) -> SpendLeaseAllocation | None:
@@ -964,6 +1097,20 @@ class SpendLease:
                 if allocation.idempotency_scope == idempotency_scope
             ),
             None,
+        )
+
+    @property
+    def _initialization_identity(self) -> tuple[object, ...]:
+        return (
+            self.lease_id,
+            self.gen,
+            self.key_hash,
+            self.boot_kid,
+            self.workspace_id,
+            self.creating_authorization_id,
+            self.cap_micro,
+            self.expires_at,
+            self.skew,
         )
 
     def _required_allocation(self, idempotency_scope: str) -> SpendLeaseAllocation:

--- a/tests/test_spend_lease_state.py
+++ b/tests/test_spend_lease_state.py
@@ -35,6 +35,7 @@ from trusted_router.spend_lease_state import (
     ExistingLocal,
     FinalizationOutcome,
     Mismatch,
+    RecoveryProof,
     RowBindingMismatch,
     SpendLease,
     SpendLeaseAllocation,
@@ -42,11 +43,13 @@ from trusted_router.spend_lease_state import (
     SpendLeaseExhaustedError,
     SpendLeaseInvariantError,
     SpendLeaseProofError,
+    SpendLeaseRefusalReason,
     SpendLeaseState,
     SpendLeaseUnavailableError,
     TerminalSource,
     TrueReplay,
     UnboundExisting,
+    is_authoritative_exhaustion,
 )
 
 NOW = datetime(2026, 9, 1, 12, tzinfo=UTC)
@@ -62,6 +65,7 @@ def _lease(*, cap: int = 1_000, state: SpendLeaseState = SpendLeaseState.ACTIVE)
         key_hash="key-hash",
         boot_kid="boot-kid",
         workspace_id="workspace-1",
+        creating_authorization_id="provisional-1",
         cap_micro=cap,
         expires_at=EXPIRY,
         skew=SKEW,
@@ -120,6 +124,15 @@ def _absence(allocation: SpendLeaseAllocation) -> BindingAbsenceProof:
         idempotency_scope=allocation.idempotency_scope,
         provisional_id=allocation.authorization_id,
         observation=AbsenceObservation.ABSENT_ROW,
+    )
+
+
+def _recovery(
+    *, creating_authorization_id: str = "provisional-1",
+) -> RecoveryProof:
+    return RecoveryProof(
+        recovering_at=NOW + timedelta(minutes=5),
+        creating_authorization_id=creating_authorization_id,
     )
 
 
@@ -204,6 +217,146 @@ def test_capacity_is_lifetime_monotonic_across_refund_and_abandon() -> None:
             provisional_id="provisional-3",
             amount=501,
         )
+
+
+@pytest.mark.parametrize(
+    ("site", "state", "expected_reason"),
+    [
+        pytest.param(
+            "allocate_frozen",
+            SpendLeaseState.DRAINING,
+            SpendLeaseRefusalReason.FROZEN_DRAINING,
+            id="allocate-frozen-draining",
+        ),
+        pytest.param(
+            "allocate_frozen",
+            SpendLeaseState.TOMBSTONED,
+            SpendLeaseRefusalReason.FROZEN_TOMBSTONED,
+            id="allocate-frozen-tombstoned",
+        ),
+        pytest.param(
+            "allocate_frozen",
+            SpendLeaseState.CLOSED,
+            SpendLeaseRefusalReason.CLOSED,
+            id="allocate-closed",
+        ),
+        pytest.param(
+            "allocate_window",
+            SpendLeaseState.ACTIVE,
+            SpendLeaseRefusalReason.WINDOW_EXPIRED,
+            id="allocate-window-expired",
+        ),
+        pytest.param(
+            "allocate_capacity",
+            SpendLeaseState.ACTIVE,
+            SpendLeaseRefusalReason.EXHAUSTED,
+            id="allocate-exhausted",
+        ),
+        pytest.param(
+            "abandon_window",
+            SpendLeaseState.ACTIVE,
+            SpendLeaseRefusalReason.WINDOW_NOT_ELAPSED,
+            id="abandon-window-not-elapsed",
+        ),
+        pytest.param(
+            "begin_drain_frozen",
+            SpendLeaseState.TOMBSTONED,
+            SpendLeaseRefusalReason.FROZEN_TOMBSTONED,
+            id="begin-drain-frozen-tombstoned",
+        ),
+        pytest.param(
+            "begin_drain_window",
+            SpendLeaseState.ACTIVE,
+            SpendLeaseRefusalReason.WINDOW_NOT_ELAPSED,
+            id="begin-drain-window-not-elapsed",
+        ),
+        pytest.param(
+            "close_state",
+            SpendLeaseState.ACTIVE,
+            SpendLeaseRefusalReason.CLOSED,
+            id="close-requires-frozen",
+        ),
+        pytest.param(
+            "close_window",
+            SpendLeaseState.TOMBSTONED,
+            SpendLeaseRefusalReason.WINDOW_NOT_ELAPSED,
+            id="close-window-not-elapsed",
+        ),
+        pytest.param(
+            "close_open",
+            SpendLeaseState.TOMBSTONED,
+            SpendLeaseRefusalReason.CLOSED,
+            id="close-open-allocation",
+        ),
+    ],
+)
+def test_each_unavailable_raise_site_has_typed_reason(
+    site: str,
+    state: SpendLeaseState,
+    expected_reason: SpendLeaseRefusalReason,
+) -> None:
+    with pytest.raises(SpendLeaseUnavailableError) as caught:
+        if site == "allocate_frozen":
+            _created(_lease(state=state))
+        elif site == "allocate_window":
+            _lease(state=state).allocate(
+                authorization_view=None,
+                idempotency_scope="scope-expired",
+                provisional_authorization_id="provisional-expired",
+                request_fingerprint="fingerprint-expired",
+                allocated_micro=1,
+                abandon_after=ABANDON_AFTER,
+                now=EXPIRY + SKEW,
+            )
+        elif site == "allocate_capacity":
+            _created(_lease(cap=1), amount=2)
+        elif site == "abandon_window":
+            created = _created()
+            created.lease.abandon(
+                idempotency_scope=created.allocation.idempotency_scope,
+                expected_provisional_id=created.provisional_id,
+                claim=_claim(created.allocation),
+                absence=_absence(created.allocation),
+                now=ABANDON_AFTER - timedelta(microseconds=1),
+            )
+        elif site == "begin_drain_frozen":
+            _lease(state=state).begin_drain(now=EXPIRY + SKEW)
+        elif site == "begin_drain_window":
+            _lease(state=state).begin_drain(now=EXPIRY + SKEW - timedelta(microseconds=1))
+        elif site == "close_state":
+            _lease(state=state).close(now=EXPIRY + SKEW)
+        elif site == "close_window":
+            _lease(state=state).close(now=EXPIRY + SKEW - timedelta(microseconds=1))
+        else:
+            _created().lease.tombstone().lease.close(now=EXPIRY + SKEW)
+
+    assert caught.value.reason == expected_reason
+
+
+def test_authoritative_exhaustion_accepts_exhausted_and_tombstoned_site_mutation_guard() -> None:
+    with pytest.raises(SpendLeaseExhaustedError) as exhausted:
+        _created(_lease(cap=1), amount=2)
+    with pytest.raises(SpendLeaseUnavailableError) as tombstoned:
+        _created(_lease(state=SpendLeaseState.TOMBSTONED))
+
+    assert is_authoritative_exhaustion(exhausted.value)
+    assert is_authoritative_exhaustion(tombstoned.value)
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        SpendLeaseRefusalReason.FROZEN_DRAINING,
+        SpendLeaseRefusalReason.WINDOW_EXPIRED,
+        SpendLeaseRefusalReason.WINDOW_NOT_ELAPSED,
+        SpendLeaseRefusalReason.CLOSED,
+    ],
+)
+def test_authoritative_exhaustion_rejects_frozen_draining_mutation_guard(
+    reason: SpendLeaseRefusalReason,
+) -> None:
+    exc = SpendLeaseUnavailableError("refused", reason=reason)
+    assert not is_authoritative_exhaustion(exc)
 
 
 def test_cas_version_advances_without_changing_grant_generation() -> None:
@@ -402,6 +555,128 @@ def test_compensate_stale_owner_never_refunds() -> None:
             ),
         )
     assert created.lease.allocations[0].state == AllocationState.RESERVED
+
+
+def test_recovery_proof_identity_mismatch_is_rejected_without_state_change() -> None:
+    created = _created()
+    with pytest.raises(SpendLeaseProofError, match="identity mismatch"):
+        created.lease.compensate(
+            idempotency_scope=created.allocation.idempotency_scope,
+            expected_provisional_id=created.provisional_id,
+            claim=_recovery(creating_authorization_id="other-authorization"),
+            absence=_absence(created.allocation),
+        )
+
+    assert created.lease.allocations == (created.allocation,)
+    assert created.lease.available_micro == 600
+
+
+def test_recovery_proof_compensates_creating_allocation_without_restoring_capacity() -> None:
+    created = _created()
+    result = created.lease.compensate(
+        idempotency_scope=created.allocation.idempotency_scope,
+        expected_provisional_id=created.provisional_id,
+        claim=_recovery(),
+        absence=_absence(created.allocation),
+    )
+
+    assert result.allocation.state == AllocationState.REFUNDED
+    assert result.allocation.terminal_source == TerminalSource.BINDING_ABSENCE
+    assert result.lease.available_micro == created.lease.available_micro == 600
+
+
+def test_recovery_proof_rejects_non_creating_allocation() -> None:
+    creating = _created(amount=200)
+    other = _created(
+        creating.lease,
+        scope="scope-2",
+        provisional_id="provisional-2",
+        fingerprint="fingerprint-2",
+        amount=100,
+    )
+    with pytest.raises(SpendLeaseProofError, match="creating allocation"):
+        other.lease.compensate(
+            idempotency_scope=other.allocation.idempotency_scope,
+            expected_provisional_id=other.provisional_id,
+            claim=_recovery(),
+            absence=_absence(other.allocation),
+        )
+
+    assert other.lease.allocations[-1].state == AllocationState.RESERVED
+
+
+@pytest.mark.parametrize("first_proof", ["claim", "recovery"])
+def test_claim_and_recovery_compensation_replay_in_both_orders(first_proof: str) -> None:
+    created = _created()
+    first = _claim(created.allocation) if first_proof == "claim" else _recovery()
+    second = _recovery() if first_proof == "claim" else _claim(created.allocation)
+
+    compensated = created.lease.compensate(
+        idempotency_scope=created.allocation.idempotency_scope,
+        expected_provisional_id=created.provisional_id,
+        claim=first,
+        absence=_absence(created.allocation),
+    )
+    replay = compensated.lease.compensate(
+        idempotency_scope=created.allocation.idempotency_scope,
+        expected_provisional_id=created.provisional_id,
+        claim=second,
+        absence=_absence(created.allocation),
+    )
+
+    assert replay.replayed
+    assert replay.lease == compensated.lease
+    assert replay.allocation == compensated.allocation
+
+
+def test_initialize_rejects_different_creating_authorization_id_as_corruption() -> None:
+    lease = _lease()
+    candidate = replace(lease, creating_authorization_id="other-authorization")
+
+    with pytest.raises(SpendLeaseInvariantError, match="corruption"):
+        lease.initialize(candidate)
+
+
+def test_tombstone_unminted_rejects_non_terminal_allocation_without_state_change() -> None:
+    created = _created()
+
+    with pytest.raises(SpendLeaseConflictError, match="terminal allocations"):
+        created.lease.tombstone_unminted(_recovery())
+
+    assert created.lease.state == SpendLeaseState.ACTIVE
+    assert created.lease.allocations == (created.allocation,)
+
+
+def test_tombstone_unminted_after_recovery_refuses_late_allocate_as_tombstoned() -> None:
+    created = _created()
+    compensated = created.lease.compensate(
+        idempotency_scope=created.allocation.idempotency_scope,
+        expected_provisional_id=created.provisional_id,
+        claim=_recovery(),
+        absence=_absence(created.allocation),
+    ).lease
+    tombstoned = compensated.tombstone_unminted(_recovery()).lease
+
+    assert tombstoned.state == SpendLeaseState.TOMBSTONED
+    with pytest.raises(SpendLeaseUnavailableError) as caught:
+        _created(tombstoned, scope="late", provisional_id="late-provisional", amount=1)
+    assert caught.value.reason == SpendLeaseRefusalReason.FROZEN_TOMBSTONED
+
+
+def test_tombstone_unminted_twice_returns_replay() -> None:
+    created = _created()
+    compensated = created.lease.compensate(
+        idempotency_scope=created.allocation.idempotency_scope,
+        expected_provisional_id=created.provisional_id,
+        claim=_recovery(),
+        absence=_absence(created.allocation),
+    ).lease
+    first = compensated.tombstone_unminted(_recovery())
+    replay = first.lease.tombstone_unminted(_recovery())
+
+    assert not first.replayed
+    assert replay.replayed
+    assert replay.lease == first.lease
 
 
 def test_committed_allocation_requires_matching_bound_proof_for_construction() -> None:
@@ -729,7 +1004,15 @@ def test_abandon_requires_claim_absence_and_deadline_not_timer_alone() -> None:
 )
 def test_bound_proof_revalidates_every_scope_and_tuple_field(field: str, bad_value: object) -> None:
     created = _created()
-    proof = replace(_bound_proof(created.allocation), **{field: bad_value})
+    original = _bound_proof(created.allocation)
+    if field == "idempotency_scope":
+        proof = replace(original, idempotency_scope=str(bad_value))
+    elif field == "lease_id":
+        proof = replace(original, lease_id=str(bad_value))
+    elif field == "gen":
+        proof = replace(original, gen=int(str(bad_value)))
+    else:
+        proof = replace(original, allocated_micro=int(str(bad_value)))
     with pytest.raises(SpendLeaseProofError, match="scope|tuple"):
         created.allocation.bind(expected_provisional_id=created.provisional_id, proof=proof)
 
@@ -791,9 +1074,24 @@ def test_mirror_observation_revalidates_every_identity_and_binding_field(field: 
     committed = _bind(_created())
     allocation = committed.allocations[0]
     observation = _observation(allocation)
-    value: object = 999 if field in {"gen", "allocated_micro"} else "wrong"
+    if field == "idempotency_scope":
+        changed = replace(observation, idempotency_scope="wrong")
+    elif field == "authorization_id":
+        changed = replace(observation, authorization_id="wrong")
+    elif field == "request_fingerprint":
+        changed = replace(observation, request_fingerprint="wrong")
+    elif field == "lease_id":
+        changed = replace(observation, lease_id="wrong")
+    elif field == "gen":
+        changed = replace(observation, gen=999)
+    elif field == "allocated_micro":
+        changed = replace(observation, allocated_micro=999)
+    elif field == "key_hash":
+        changed = replace(observation, key_hash="wrong")
+    else:
+        changed = replace(observation, workspace_id="wrong")
     with pytest.raises(SpendLeaseProofError, match="mismatch"):
-        allocation.mirror(replace(observation, **{field: value}))
+        allocation.mirror(changed)
 
 
 @pytest.mark.parametrize("field", ["idempotency_scope", "authorization_id"])
@@ -801,8 +1099,13 @@ def test_committed_lost_proof_revalidates_identity(field: str) -> None:
     committed = _bind(_created())
     allocation = committed.allocations[0]
     proof = CommittedRowAbsentProof(allocation.idempotency_scope, allocation.authorization_id)
+    changed = (
+        replace(proof, idempotency_scope="wrong")
+        if field == "idempotency_scope"
+        else replace(proof, authorization_id="wrong")
+    )
     with pytest.raises(SpendLeaseProofError, match="mismatch"):
-        allocation.lost(replace(proof, **{field: "wrong"}))
+        allocation.lost(changed)
 
 
 def test_authorization_scope_view_wrong_scope_is_rejected_before_local_lookup() -> None:


### PR DESCRIPTION
Unit-1 follow-up for Stage B unit 2 of the spend-lease design record (v49, decisions 46/47). Pure state machine only; no storage, route, or config change.

- `SpendLeaseUnavailableError.reason` typed at every raise site; `is_authoritative_exhaustion()` encodes the fence-entry rule (exhausted or frozen_tombstoned).
- Lease identity gains `creating_authorization_id`; `initialize()` rejects a different identity as corruption.
- `RecoveryProof(recovering_at, creating_authorization_id)` accepted by `compensate()` for the creating allocation only; same BINDING_ABSENCE terminal as `ClaimProof`, so double compensation replays in either order.
- `tombstone_unminted(proof)`: ACTIVE → TOMBSTONED when no allocation is non-terminal; idempotent; a later `allocate()` refuses as frozen_tombstoned.

Review: isolated snapshot, ruff, mypy --strict, 83 tests, seven mutations each red (tombstone precondition, creating-allocation check, identity check, TOMBSTONED reason swap, exhaustion helper, initialize corruption check, tombstone replay branch).

Written by codex; reviewed by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)