### PR TITLE
spend-lease: provision the Bigtable ledger (decisions 33/39)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -285,6 +285,9 @@ jobs:
         # exist before any serving revision can enable the workspace canary.
         run: bash scripts/deploy/regional_quota_ledger.sh
 
+      - name: Provision spend-lease Bigtable ledger
+        run: bash scripts/deploy/spend_lease_ledger.sh
+
   sync-runtime-secrets:
     # Validate the small set of runtime credentials while the image build and
     # schema verification run. SES credentials are rotated directly in GCP

--- a/scripts/deploy-gcp.sh
+++ b/scripts/deploy-gcp.sh
@@ -34,6 +34,8 @@ bash "${SCRIPT_DIR}/deploy/image.sh"
 bash "${SCRIPT_DIR}/deploy/secrets.sh"
 bash "${SCRIPT_DIR}/deploy/regional_quota_ledger.sh" \
   </dev/null
+bash "${SCRIPT_DIR}/deploy/spend_lease_ledger.sh" \
+  </dev/null
 bash "${SCRIPT_DIR}/deploy/rollout.sh"
 bash "${SCRIPT_DIR}/deploy/regional_quota_reconciler.sh"
 bash "${SCRIPT_DIR}/deploy/synthetic.sh"

--- a/scripts/deploy/_lib.sh
+++ b/scripts/deploy/_lib.sh
@@ -95,6 +95,8 @@ BIGTABLE_INSTANCE_TYPE="${TR_BIGTABLE_INSTANCE_TYPE:-PRODUCTION}"
 # forcibly bypassed. EU and other gateways therefore use exact Spanner until
 # they receive isolated regional ledgers.
 TR_REGIONAL_QUOTA_CLUSTER_MAP="${TR_REGIONAL_QUOTA_CLUSTER_MAP:-us-central1=trusted-router-logs-c1}"
+# Decision 33: Same regional single-cluster routing as the regional quota ledger; override only to split clusters.
+TR_SPEND_LEASE_CLUSTER_MAP="${TR_SPEND_LEASE_CLUSTER_MAP:-$TR_REGIONAL_QUOTA_CLUSTER_MAP}"
 TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES="${TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES:-us-central1=tr-quota-us-central1}"
 KMS_KEYRING_ID="${TR_KMS_KEYRING_ID:-trusted-router}"
 BYOK_KMS_KEY_ID="${TR_BYOK_KMS_KEY_ID:-byok-envelope}"

--- a/scripts/deploy/spend_lease_ledger.sh
+++ b/scripts/deploy/spend_lease_ledger.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Provision the isolated Bigtable ledger used by spend-lease escrow.
+#
+# Usage:
+#   GCP_PROJECT_ID=quill-cloud-proxy \
+#   TR_BIGTABLE_INSTANCE_ID=trusted-router-logs \
+#   TR_SPEND_LEASE_CLUSTER_MAP='us-central1=tr-us-central1' \
+#     scripts/deploy/spend_lease_ledger.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+PROJECT="${GCP_PROJECT_ID:-$PROJECT_ID}"
+INSTANCE="${TR_BIGTABLE_INSTANCE_ID:-$BIGTABLE_INSTANCE_ID}"
+TABLE="${TR_SPEND_LEASE_BIGTABLE_TABLE:-trustedrouter-spend-lease}"
+CLUSTER_MAP="$TR_SPEND_LEASE_CLUSTER_MAP"
+
+log() { printf '%s %s\n' '[spend_lease_ledger]' "$*"; }
+
+if gcloud bigtable instances tables describe "$TABLE" \
+  --project="$PROJECT" --instance="$INSTANCE" >/dev/null 2>&1; then
+  log "table $TABLE exists"
+  table_schema="$(
+    gcloud bigtable instances tables describe "$TABLE" \
+      --project="$PROJECT" \
+      --instance="$INSTANCE" \
+      --format=json
+  )"
+  if ! python3 - "$table_schema" <<'PY'
+import json
+import sys
+
+try:
+    schema = json.loads(sys.argv[1])
+    lease_rule = schema.get("columnFamilies", {}).get("lease", {}).get("gcRule")
+except (AttributeError, json.JSONDecodeError, TypeError):
+    raise SystemExit(1) from None
+raise SystemExit(0 if lease_rule == {"maxNumVersions": 1} else 1)
+PY
+  then
+    log "refusing spend-lease table drift: lease must use maxversions=1 with no maxage"
+    exit 1
+  fi
+else
+  log "creating $TABLE with latest-version-only lease state and no age-based GC"
+  # Decision 33: No age-based GC on the state family: QUARANTINED is open and may
+  # hold escrow until an operator acts, so no finite maxage is safe; committed rows
+  # are deleted by the reconciler's explicit deletion.
+  gcloud bigtable instances tables create "$TABLE" \
+    --project="$PROJECT" \
+    --instance="$INSTANCE" \
+    --column-families='lease:maxversions=1'
+fi
+
+IFS=',' read -r -a entries <<< "$CLUSTER_MAP"
+profiles=()
+for entry in "${entries[@]}"; do
+  region="${entry%%=*}"
+  cluster="${entry#*=}"
+  if [ -z "$region" ] || [ -z "$cluster" ] || [ "$region" = "$cluster" ]; then
+    log "invalid cluster-map entry: $entry"
+    exit 2
+  fi
+  profile="tr-spend-${region}"
+  profiles+=("${region}=${profile}")
+  if gcloud bigtable app-profiles describe "$profile" \
+    --project="$PROJECT" --instance="$INSTANCE" >/dev/null 2>&1; then
+    profile_config="$(
+      gcloud bigtable app-profiles describe "$profile" \
+        --project="$PROJECT" \
+        --instance="$INSTANCE" \
+        --format='value(singleClusterRouting.clusterId,singleClusterRouting.allowTransactionalWrites)'
+    )"
+    read -r actual_cluster transactional_writes <<<"$profile_config"
+    if [ "$actual_cluster" != "$cluster" ] || [ "$transactional_writes" != "True" ]; then
+      log "refusing spend-lease profile drift: ${profile} must route only to ${cluster} with transactional writes"
+      exit 1
+    fi
+    log "app profile $profile is transactionally pinned to $cluster"
+  else
+    log "creating transactional single-cluster profile $profile -> $cluster"
+    gcloud bigtable app-profiles create "$profile" \
+      --project="$PROJECT" \
+      --instance="$INSTANCE" \
+      --route-to="$cluster" \
+      --transactional-writes \
+      --description="TrustedRouter spend-lease escrow for ${region}"
+  fi
+done
+
+profile_csv="$(IFS=','; printf '%s' "${profiles[*]}")"
+log "set TR_SPEND_LEASE_BIGTABLE_APP_PROFILES=${profile_csv}"

--- a/tests/test_spend_lease_bigtable.py
+++ b/tests/test_spend_lease_bigtable.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from .deploy_script_harness import (
+    SCRIPT_FIXTURES,
+    DeployScriptHarness,
+    HarnessRun,
+    ScriptFixture,
+    summarise,
+)
+
+ROOT = Path(__file__).parents[1]
+SCRIPT = "scripts/deploy/spend_lease_ledger.sh"
+CLUSTER_MAP = (
+    "us-central1=trusted-router-logs-c1,"
+    "europe-west4=trusted-router-logs-eu"
+)
+VALID_TABLE_SCHEMA = json.dumps(
+    {"columnFamilies": {"lease": {"gcRule": {"maxNumVersions": 1}}}},
+    separators=(",", ":"),
+)
+
+
+def _fixture(
+    *,
+    table_schema: str | None,
+    profiles: dict[str, tuple[str, bool]] | None = None,
+    cluster_map: str = CLUSTER_MAP,
+) -> ScriptFixture:
+    profile_config = profiles or {}
+    responses: list[tuple[str, str]] = []
+    failures: list[str] = []
+    if table_schema is None:
+        failures.append(
+            r"bigtable instances tables describe trustedrouter-spend-lease"
+        )
+        failures.append(r"bigtable app-profiles describe tr-spend-")
+    else:
+        responses.append(
+            (
+                r"bigtable instances tables describe trustedrouter-spend-lease "
+                r".*--format=json",
+                table_schema,
+            )
+        )
+        for region, (cluster, transactional) in profile_config.items():
+            responses.append(
+                (
+                    rf"bigtable app-profiles describe tr-spend-{re.escape(region)} "
+                    r".*--format=value\(",
+                    f"{cluster} {'True' if transactional else 'False'}",
+                )
+            )
+    return ScriptFixture(
+        env={
+            "GCP_PROJECT_ID": "harness-project",
+            "TR_BIGTABLE_INSTANCE_ID": "harness-instance",
+            "TR_SPEND_LEASE_CLUSTER_MAP": cluster_map,
+        },
+        responses=tuple(responses),
+        failures=tuple(failures),
+    )
+
+
+def _run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    table_schema: str | None,
+    profiles: dict[str, tuple[str, bool]] | None = None,
+    cluster_map: str = CLUSTER_MAP,
+) -> HarnessRun:
+    monkeypatch.setitem(
+        SCRIPT_FIXTURES,
+        SCRIPT,
+        _fixture(
+            table_schema=table_schema,
+            profiles=profiles,
+            cluster_map=cluster_map,
+        ),
+    )
+    return DeployScriptHarness(tmp_path / "harness").run(SCRIPT)
+
+
+def _gcloud_calls(run: HarnessRun, *prefix: str) -> list[list[str]]:
+    expected = ["gcloud", *prefix]
+    return [call for call in run.calls if call[: len(expected)] == expected]
+
+
+def _assert_workflow_order(workflow: str) -> None:
+    migrate_schema = workflow.split("\n  migrate-schema:\n", 1)[1].split(
+        "\n  sync-runtime-secrets:\n", 1
+    )[0]
+    ledger_scripts = re.findall(
+        r"^        run: bash scripts/deploy/([a-z_]+_ledger\.sh)$",
+        migrate_schema,
+        re.MULTILINE,
+    )
+    regional = ledger_scripts.index("regional_quota_ledger.sh")
+    assert ledger_scripts[regional + 1] == "spend_lease_ledger.sh"
+
+
+def _assert_orchestrator_order(orchestrator: str) -> None:
+    deploy_scripts = re.findall(
+        r'bash "\$\{SCRIPT_DIR\}/deploy/([^" ]+\.sh)"', orchestrator
+    )
+    regional = deploy_scripts.index("regional_quota_ledger.sh")
+    assert deploy_scripts[regional + 1] == "spend_lease_ledger.sh"
+
+
+def test_fresh_run_creates_latest_version_only_family_without_maxage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = _run(tmp_path, monkeypatch, table_schema=None)
+
+    assert run.returncode == 0, summarise(run)
+    assert os.access(ROOT / SCRIPT, os.X_OK)
+    assert _gcloud_calls(
+        run, "bigtable", "instances", "tables", "create"
+    ) == [
+        [
+            "gcloud",
+            "bigtable",
+            "instances",
+            "tables",
+            "create",
+            "trustedrouter-spend-lease",
+            "--project=harness-project",
+            "--instance=harness-instance",
+            "--column-families=lease:maxversions=1",
+        ]
+    ]
+
+
+def test_fresh_run_creates_transactional_profile_for_each_mapped_cluster(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = _run(tmp_path, monkeypatch, table_schema=None)
+
+    assert run.returncode == 0, summarise(run)
+    creates = _gcloud_calls(run, "bigtable", "app-profiles", "create")
+    assert creates == [
+        [
+            "gcloud",
+            "bigtable",
+            "app-profiles",
+            "create",
+            "tr-spend-us-central1",
+            "--project=harness-project",
+            "--instance=harness-instance",
+            "--route-to=trusted-router-logs-c1",
+            "--transactional-writes",
+            "--description=TrustedRouter spend-lease escrow for us-central1",
+        ],
+        [
+            "gcloud",
+            "bigtable",
+            "app-profiles",
+            "create",
+            "tr-spend-europe-west4",
+            "--project=harness-project",
+            "--instance=harness-instance",
+            "--route-to=trusted-router-logs-eu",
+            "--transactional-writes",
+            "--description=TrustedRouter spend-lease escrow for europe-west4",
+        ],
+    ]
+
+
+def test_existing_profile_routed_to_another_cluster_is_refused(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = _run(
+        tmp_path,
+        monkeypatch,
+        table_schema=VALID_TABLE_SCHEMA,
+        profiles={"us-central1": ("wrong-cluster", True)},
+        cluster_map="us-central1=trusted-router-logs-c1",
+    )
+
+    assert run.returncode == 1, summarise(run)
+    assert "refusing spend-lease profile drift" in run.stdout
+    assert not _gcloud_calls(run, "bigtable", "app-profiles", "create")
+
+
+def test_existing_profile_without_transactional_writes_is_refused(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = _run(
+        tmp_path,
+        monkeypatch,
+        table_schema=VALID_TABLE_SCHEMA,
+        profiles={"us-central1": ("trusted-router-logs-c1", False)},
+        cluster_map="us-central1=trusted-router-logs-c1",
+    )
+
+    assert run.returncode == 1, summarise(run)
+    assert "refusing spend-lease profile drift" in run.stdout
+    assert not _gcloud_calls(run, "bigtable", "app-profiles", "create")
+
+
+def test_existing_table_with_age_based_gc_is_refused(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    schema = json.dumps(
+        {
+            "columnFamilies": {
+                "lease": {
+                    "gcRule": {
+                        "union": {
+                            "rules": [
+                                {"maxNumVersions": 1},
+                                {"maxAge": "604800s"},
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        separators=(",", ":"),
+    )
+    run = _run(tmp_path, monkeypatch, table_schema=schema)
+
+    assert run.returncode == 1, summarise(run)
+    assert "lease must use maxversions=1 with no maxage" in run.stdout
+    assert not _gcloud_calls(run, "bigtable", "app-profiles")
+
+
+def test_malformed_cluster_map_entry_exits_two(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = _run(
+        tmp_path,
+        monkeypatch,
+        table_schema=VALID_TABLE_SCHEMA,
+        cluster_map="malformed",
+    )
+
+    assert run.returncode == 2, summarise(run)
+    assert "invalid cluster-map entry: malformed" in run.stdout
+
+
+def test_second_run_creates_nothing_and_prints_profile_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = _run(
+        tmp_path,
+        monkeypatch,
+        table_schema=VALID_TABLE_SCHEMA,
+        profiles={
+            "us-central1": ("trusted-router-logs-c1", True),
+            "europe-west4": ("trusted-router-logs-eu", True),
+        },
+    )
+
+    assert run.returncode == 0, summarise(run)
+    assert not _gcloud_calls(run, "bigtable", "instances", "tables", "create")
+    assert not _gcloud_calls(run, "bigtable", "app-profiles", "create")
+    assert (
+        "set TR_SPEND_LEASE_BIGTABLE_APP_PROFILES="
+        "us-central1=tr-spend-us-central1,"
+        "europe-west4=tr-spend-europe-west4"
+    ) in run.stdout
+
+
+def test_deploy_workflow_runs_spend_lease_immediately_after_regional_quota() -> None:
+    workflow = (ROOT / ".github/workflows/deploy.yml").read_text()
+
+    _assert_workflow_order(workflow)
+    spend_step = workflow.split(
+        "      - name: Provision spend-lease Bigtable ledger\n", 1
+    )[1].split("\n      - name:", 1)[0]
+    assert "env:" not in spend_step
+    assert "        run: bash scripts/deploy/spend_lease_ledger.sh" in spend_step
+
+
+def test_deploy_gcp_invokes_spend_lease_immediately_after_regional_quota() -> None:
+    orchestrator = (ROOT / "scripts/deploy-gcp.sh").read_text()
+
+    _assert_orchestrator_order(orchestrator)
+    assert 'TR_SPEND_LEASE_CLUSTER_MAP=' not in orchestrator
+
+
+def test_deploy_lib_defaults_spend_lease_cluster_map_and_honours_override() -> None:
+    command = (
+        'gcloud() { printf "123456\\n"; }; '
+        'source scripts/deploy/_lib.sh; '
+        'printf "%s\\n%s\\n" '
+        '"$TR_REGIONAL_QUOTA_CLUSTER_MAP" "$TR_SPEND_LEASE_CLUSTER_MAP"'
+    )
+
+    defaulted = subprocess.run(  # noqa: S603 - fixed shell and repo-owned script
+        ["/bin/bash", "-c", command],
+        cwd=ROOT,
+        env={
+            **os.environ,
+            "TR_REGIONAL_QUOTA_CLUSTER_MAP": "us-test1=quota-cluster",
+        },
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    overridden = subprocess.run(  # noqa: S603 - fixed shell and repo-owned script
+        ["/bin/bash", "-c", command],
+        cwd=ROOT,
+        env={
+            **os.environ,
+            "TR_REGIONAL_QUOTA_CLUSTER_MAP": "us-test1=quota-cluster",
+            "TR_SPEND_LEASE_CLUSTER_MAP": "eu-test1=spend-cluster",
+        },
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert defaulted.returncode == 0, defaulted.stderr
+    assert defaulted.stdout.splitlines() == [
+        "us-test1=quota-cluster",
+        "us-test1=quota-cluster",
+    ]
+    assert overridden.returncode == 0, overridden.stderr
+    assert overridden.stdout.splitlines() == [
+        "us-test1=quota-cluster",
+        "eu-test1=spend-cluster",
+    ]


### PR DESCRIPTION
Second unit-2 PR of the spend-lease program (design record v49, decisions 33 and 39): Bigtable provisioning only.

- `scripts/deploy/spend_lease_ledger.sh`, a clone of `regional_quota_ledger.sh`: table `trustedrouter-spend-lease`, family `lease:maxversions=1` with deliberately **no maxage** (decision 33: a quarantined lease may hold escrow until an operator acts, so no finite age-based GC is safe), one single-cluster transactional app profile per region (`tr-spend-<region>`) with the precedent's drift refusal, plus a GC-rule drift check on an existing table.
- `TR_SPEND_LEASE_CLUSTER_MAP` defaults to `TR_REGIONAL_QUOTA_CLUSTER_MAP` in `_lib.sh` (single source); wired into `deploy.yml` immediately after the regional quota ledger step and into `deploy-gcp.sh`.
- No `src/` change, no config field, no reader or writer, no flag.

Lands after #1023 (schema) per the confirmed landing order.

Review: isolated snapshot; scope limited to the script, `_lib.sh`, `deploy-gcp.sh`, the workflow step, and tests; bash -n and shellcheck; 10 tests; seven mutations each red (maxage added, transactional writes dropped, GC drift check disabled, malformed-map exit disabled, route-drift refusal disabled, workflow order swapped, `_lib.sh` fallback dropped).

Written by codex; reviewed by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)