### PR TITLE
Fix Axios campaign landing attribution

### DIFF
--- a/src/trusted_router/middleware.py
+++ b/src/trusted_router/middleware.py
@@ -102,6 +102,12 @@ COOKIE_FREE_PUBLIC_ANALYTICS_PATHS = frozenset(
         "/status/history",
     }
 )
+CAMPAIGN_LANDING_PATHS = {
+    # The original X creative accidentally pointed at the Bedrock group-buy
+    # page. Keep its campaign identifier useful while sending future clicks to
+    # the Axios article the ad describes.
+    "axios_viral_landing_20260830": "/blog/axios-tried-trustedrouter",
+}
 
 
 def register_http_middleware(app: FastAPI, settings: Settings) -> None:
@@ -218,6 +224,9 @@ def register_http_middleware(app: FastAPI, settings: Settings) -> None:
                 url=_apex_public_url(settings, request, hostname),
                 status_code=308,
             )
+        campaign_url = _canonical_campaign_url(request)
+        if campaign_url is not None:
+            return RedirectResponse(url=campaign_url, status_code=307)
         return await call_next(request)
 
     @app.middleware("http")
@@ -516,6 +525,16 @@ def _apex_public_url(settings: Settings, request: Request, hostname: str) -> str
     suffix = f"?{query}" if query else ""
     domain = control_domain_for_hostname(settings, hostname)
     return f"https://{domain}{request.url.path}{suffix}"
+
+
+def _canonical_campaign_url(request: Request) -> str | None:
+    if request.method.upper() not in {"GET", "HEAD"}:
+        return None
+    campaign = request.query_params.get("utm_campaign", "")
+    target_path = CAMPAIGN_LANDING_PATHS.get(campaign)
+    if target_path is None or request.url.path == target_path:
+        return None
+    return str(request.url.replace(path=target_path))
 
 
 async def _rate_limit_request(

--- a/tests/test_acquisition_attribution.py
+++ b/tests/test_acquisition_attribution.py
@@ -273,6 +273,32 @@ def test_paid_experiment_preserves_exact_landing_path(client: TestClient) -> Non
     assert context.last_touch["utm_content"] == "or_quickstart_v1"
 
 
+def test_misconfigured_axiom_campaign_redirects_to_tracked_article(
+    client: TestClient,
+) -> None:
+    query = (
+        "utm_source=x&utm_medium=paid_social"
+        "&utm_campaign=axios_viral_landing_20260830"
+        "&utm_content=axios_blog_ad_v1&twclid=axios-click-123"
+    )
+
+    redirect = client.get(f"/bedrock-group-buy?{query}", follow_redirects=False)
+
+    assert redirect.status_code == 307
+    assert redirect.headers["location"] == (
+        f"http://testserver/blog/axios-tried-trustedrouter?{query}"
+    )
+
+    final = client.get(redirect.headers["location"])
+    assert final.status_code == 200
+    context = decode_attribution_cookie(
+        client.cookies.get(ATTRIBUTION_COOKIE_NAME), client.app.state.settings
+    )
+    assert context is not None
+    assert context.last_touch["utm_campaign"] == "axios_viral_landing_20260830"
+    assert context.last_touch["landing_path"] == "/blog/axios-tried-trustedrouter"
+
+
 def test_multiarm_landing_redirect_attributes_the_selected_page(
     client: TestClient,
 ) -> None:


### PR DESCRIPTION
Summary:
- Redirect the misconfigured Axios X campaign from the Bedrock group-buy page to the Axios launch article.
- Preserve all UTM and X click parameters through the redirect.
- Verify the final attribution cookie records the corrected landing path.

Verification:
- Ruff passed for the touched files.
- 54 focused acquisition and Axios tests passed.