### PR TITLE
spend-lease: unwire Bigtable provisioning from deploy until IAM is granted

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -285,8 +285,11 @@ jobs:
         # exist before any serving revision can enable the workspace canary.
         run: bash scripts/deploy/regional_quota_ledger.sh
 
-      - name: Provision spend-lease Bigtable ledger
-        run: bash scripts/deploy/spend_lease_ledger.sh
+      # Provisioning the spend-lease Bigtable ledger (scripts/deploy/spend_lease_ledger.sh)
+      # is NOT wired here yet: on 2026-09-02 the first run failed with PERMISSION_DENIED
+      # (bigtable.tables.create) for this job's service account and blocked every deploy.
+      # Re-add the step once that account holds roles/bigtable.admin on trusted-router-logs;
+      # until then provision by hand via scripts/deploy-gcp.sh (design record decision 39).
 
   sync-runtime-secrets:
     # Validate the small set of runtime credentials while the image build and

--- a/tests/test_spend_lease_bigtable.py
+++ b/tests/test_spend_lease_bigtable.py
@@ -18,10 +18,7 @@ from .deploy_script_harness import (
 
 ROOT = Path(__file__).parents[1]
 SCRIPT = "scripts/deploy/spend_lease_ledger.sh"
-CLUSTER_MAP = (
-    "us-central1=trusted-router-logs-c1,"
-    "europe-west4=trusted-router-logs-eu"
-)
+CLUSTER_MAP = "us-central1=trusted-router-logs-c1,europe-west4=trusted-router-logs-eu"
 VALID_TABLE_SCHEMA = json.dumps(
     {"columnFamilies": {"lease": {"gcRule": {"maxNumVersions": 1}}}},
     separators=(",", ":"),
@@ -38,9 +35,7 @@ def _fixture(
     responses: list[tuple[str, str]] = []
     failures: list[str] = []
     if table_schema is None:
-        failures.append(
-            r"bigtable instances tables describe trustedrouter-spend-lease"
-        )
+        failures.append(r"bigtable instances tables describe trustedrouter-spend-lease")
         failures.append(r"bigtable app-profiles describe tr-spend-")
     else:
         responses.append(
@@ -108,9 +103,7 @@ def _assert_workflow_order(workflow: str) -> None:
 
 
 def _assert_orchestrator_order(orchestrator: str) -> None:
-    deploy_scripts = re.findall(
-        r'bash "\$\{SCRIPT_DIR\}/deploy/([^" ]+\.sh)"', orchestrator
-    )
+    deploy_scripts = re.findall(r'bash "\$\{SCRIPT_DIR\}/deploy/([^" ]+\.sh)"', orchestrator)
     regional = deploy_scripts.index("regional_quota_ledger.sh")
     assert deploy_scripts[regional + 1] == "spend_lease_ledger.sh"
 
@@ -123,9 +116,7 @@ def test_fresh_run_creates_latest_version_only_family_without_maxage(
 
     assert run.returncode == 0, summarise(run)
     assert os.access(ROOT / SCRIPT, os.X_OK)
-    assert _gcloud_calls(
-        run, "bigtable", "instances", "tables", "create"
-    ) == [
+    assert _gcloud_calls(run, "bigtable", "instances", "tables", "create") == [
         [
             "gcloud",
             "bigtable",
@@ -277,28 +268,29 @@ def test_second_run_creates_nothing_and_prints_profile_environment(
     ) in run.stdout
 
 
-def test_deploy_workflow_runs_spend_lease_immediately_after_regional_quota() -> None:
-    workflow = (ROOT / ".github/workflows/deploy.yml").read_text()
+def test_deploy_workflow_does_not_run_spend_lease_provisioning_until_iam_granted() -> None:
+    """2026-09-02: the migrate-schema service account lacks bigtable.tables.create, so the
+    workflow must not invoke spend_lease_ledger.sh until that grant lands (see the comment
+    beside the regional quota step). deploy-gcp.sh remains the manual provisioning path."""
 
-    _assert_workflow_order(workflow)
-    spend_step = workflow.split(
-        "      - name: Provision spend-lease Bigtable ledger\n", 1
-    )[1].split("\n      - name:", 1)[0]
-    assert "env:" not in spend_step
-    assert "        run: bash scripts/deploy/spend_lease_ledger.sh" in spend_step
+    workflow_path = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "deploy.yml"
+    workflow = workflow_path.read_text(encoding="utf-8")
+    run_lines = [line for line in workflow.splitlines() if line.strip().startswith("run:")]
+    assert not any("spend_lease_ledger.sh" in line for line in run_lines)
+    assert "bigtable.tables.create" in workflow
 
 
 def test_deploy_gcp_invokes_spend_lease_immediately_after_regional_quota() -> None:
     orchestrator = (ROOT / "scripts/deploy-gcp.sh").read_text()
 
     _assert_orchestrator_order(orchestrator)
-    assert 'TR_SPEND_LEASE_CLUSTER_MAP=' not in orchestrator
+    assert "TR_SPEND_LEASE_CLUSTER_MAP=" not in orchestrator
 
 
 def test_deploy_lib_defaults_spend_lease_cluster_map_and_honours_override() -> None:
     command = (
         'gcloud() { printf "123456\\n"; }; '
-        'source scripts/deploy/_lib.sh; '
+        "source scripts/deploy/_lib.sh; "
         'printf "%s\\n%s\\n" '
         '"$TR_REGIONAL_QUOTA_CLUSTER_MAP" "$TR_SPEND_LEASE_CLUSTER_MAP"'
     )


### PR DESCRIPTION
Deploy run 33591039902 (main at 0a0a3baf) failed in `migrate-schema`: `scripts/deploy/spend_lease_ledger.sh` hit `PERMISSION_DENIED` on `bigtable.tables.create` for `tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com`. The regional quota precedent never exercised table creation from this job because its table already existed. Every deploy of main is blocked until this lands.

- Removes the workflow step; the script and the manual `deploy-gcp.sh` path stay.
- Replaces the workflow-order test with one asserting the step is absent and the reason is documented (mutation: re-adding the run line turns it red).
- The spend-lease schema migration itself completed successfully in the same run (nine columns, both tables, both indexes read-write).

Re-add the step once the service account holds `roles/bigtable.admin` on the `trusted-router-logs` instance.

Authored by Fable directly as an outage-class revert, disclosed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)