### PR TITLE
Resolve the settle-outbox intent inside the finalize commit, not after it

### DIFF
--- a/docs/design/durable-settle-outbox.md
+++ b/docs/design/durable-settle-outbox.md
@@ -233,11 +233,17 @@ lease-claims due `pending` rows and for each:
 - **Lost-charge safety rests ENTIRELY on the reaper guard** (§4): the reaper never
   frees a hold with a `pending`/`dead` outbox row, re-checked in-transaction. It is
   NOT provided by "drain wins the race" (v1's false claim).
-- Residual, explicitly accepted: a crash between the inline finalize commit and the
-  `status='done'` UPDATE leaves a `pending` row for an already-charged auth — safe
-  (drain replay → `already_settled_with_charge` → done), just a redundant replay
-  (SF4). If the outbox shares the Spanner instance, prefer writing `status='done'`
-  in the same txn as the finalize to close even that.
+- Residual, explicitly accepted in v1: a crash between the inline finalize commit
+  and the `status='done'` UPDATE leaves a `pending` row for an already-charged auth
+  — safe (drain replay → `already_settled_with_charge` → done), just a redundant
+  replay (SF4). **Closed 2026-09-02:** the outbox does share the instance, and the
+  typed finalize now writes `status='done'` in the same transaction as the charge
+  (`typed_finalize_atomic(settle_outbox_done=...)` →
+  `mark_done_unleased_tx`). The lease fence is unchanged: a row a drain worker
+  owns at that moment is left `pending` and the drain re-derives `done`. The
+  legacy finalize contract still marks in a separate commit. Measured motivation:
+  `mark_ms` was a full multi-region commit on every settle (p50 224–709 ms, p90
+  ~775 ms), one of three serial commits behind the ~3 s settle p90.
 
 ## 8. Rollout (default-off, Joseph-gated)
 

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -487,9 +487,7 @@ def _persist_spend_lease_shadow(event_id: str, payload: dict[str, Any]) -> None:
     STORE.record_spend_lease_shadow(event_id, payload)
 
 
-_SPEND_LEASE_SHADOW_DISPATCHER = SpendLeaseShadowDispatcher(
-    _persist_spend_lease_shadow
-)
+_SPEND_LEASE_SHADOW_DISPATCHER = SpendLeaseShadowDispatcher(_persist_spend_lease_shadow)
 
 
 def _record_spend_lease_shadow(
@@ -2812,6 +2810,13 @@ def _settle_gateway_authorization(
                         generation=generation,
                         user_model_payout=user_model_payout,
                         app_markup_payout=app_markup_payout,
+                        # Resolve the durable intent in the finalize commit
+                        # itself (docs/design/durable-settle-outbox.md §7).
+                        settle_outbox_done=(
+                            (authorization.id, intent_kind)
+                            if settings.settle_outbox_enabled and outbox_enqueued
+                            else None
+                        ),
                     ),
                 )
             except (RegionalLeaseLedgerError, LeaseSettlementError):
@@ -2889,26 +2894,40 @@ def _settle_gateway_authorization(
     )
     mark_ms = 0.0
     if settings.settle_outbox_enabled and outbox_enqueued and finalize_result.activity_indexed:
-        mark_start = perf_counter()
-        try:
-            marked = spanner_settle_outbox().mark(authorization.id, intent_kind, done=True)
-            if marked is None:
+        if finalize_result.outbox_marked is not None:
+            # Resolved inside the finalize commit; mark_ms stays 0.0 so the
+            # timing line keeps its shape (finalize_ms now includes the mark).
+            if not finalize_result.outbox_marked:
                 logger.info(
                     "settle outbox done mark skipped authorization_id=%s intent_kind=%s; "
                     "row leased or already resolved; drain will re-derive done",
                     authorization.id,
                     intent_kind,
                 )
-        except Exception:
-            # Safe to swallow: §7 says a crash/failure after inline finalize
-            # leaves a pending replay, and the drain will re-derive done via
-            # ALREADY_SETTLED_WITH_CHARGE / ALREADY_SETTLED_LEGACY.
-            logger.error(
-                "settle outbox done mark failed authorization_id=%s",
-                authorization.id,
-                exc_info=True,
-            )
-        mark_ms = (perf_counter() - mark_start) * 1000
+        else:
+            # Legacy finalize contract: the intent was not resolved in the
+            # finalize commit, so resolve it here as before.
+            mark_start = perf_counter()
+            try:
+                marked = spanner_settle_outbox().mark(authorization.id, intent_kind, done=True)
+                if marked is None:
+                    logger.info(
+                        "settle outbox done mark skipped authorization_id=%s "
+                        "intent_kind=%s; row leased or already resolved; drain will "
+                        "re-derive done",
+                        authorization.id,
+                        intent_kind,
+                    )
+            except Exception:
+                # Safe to swallow: §7 says a crash/failure after inline finalize
+                # leaves a pending replay, and the drain will re-derive done via
+                # ALREADY_SETTLED_WITH_CHARGE / ALREADY_SETTLED_LEGACY.
+                logger.error(
+                    "settle outbox done mark failed authorization_id=%s",
+                    authorization.id,
+                    exc_info=True,
+                )
+            mark_ms = (perf_counter() - mark_start) * 1000
     elif finalized and settings.settle_outbox_enabled and outbox_enqueued:
         logger.warning(
             "settle activity index pending repair authorization_id=%s",

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -2768,6 +2768,7 @@ class SpannerBigtableStore:
         generation: Generation | None = None,
         user_model_payout: UserModelPayout | None = None,
         app_markup_payout: AppMarkupPayout | None = None,
+        settle_outbox_done: tuple[str, str] | None = None,
     ) -> TypedFinalizeResult:
         """Route-facing typed settle: same contract as
         finalize_gateway_authorization, with explicit activity-index status.
@@ -2877,6 +2878,7 @@ class SpannerBigtableStore:
             user_model_payout=user_model_payout,
             app_markup_payout=app_markup_payout,
             regional_hold_unknown=regional_hold_unknown,
+            settle_outbox_done=settle_outbox_done,
         )
         spanner_ms = (time.perf_counter() - spanner_start) * 1000
         if result["outcome"] == SettleOutcome.ERROR:
@@ -2911,6 +2913,7 @@ class SpannerBigtableStore:
                 finalized=True,
                 activity_indexed=activity_indexed,
                 request_record_typed=bool(result.get("request_record_typed")),
+                outbox_marked=result.get("outbox_marked"),
             )
         return TypedFinalizeResult(
             finalized=False,

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -56,7 +56,11 @@ from trusted_router.storage_gcp_request_records import (
     insert_gateway_authorization,
     mark_gateway_authorization_settled,
 )
-from trusted_router.storage_gcp_settle_outbox import _GUARD_STATUS_SQL, GUARD_COUNT_SQL
+from trusted_router.storage_gcp_settle_outbox import (
+    _GUARD_STATUS_SQL,
+    GUARD_COUNT_SQL,
+    mark_done_unleased_tx,
+)
 from trusted_router.storage_models import (
     AppMarkupPayout,
     GatewayAuthorization,
@@ -176,19 +180,13 @@ def key_window_limit_decision(
     # over (or never started) = zero spend this window.
     current = {
         "daily": sum(
-            int(row[1] or 0)
-            for row in rows
-            if row[2] is not None and row[2] >= floors["daily"]
+            int(row[1] or 0) for row in rows if row[2] is not None and row[2] >= floors["daily"]
         ),
         "weekly": sum(
-            int(row[3] or 0)
-            for row in rows
-            if row[4] is not None and row[4] >= floors["weekly"]
+            int(row[3] or 0) for row in rows if row[4] is not None and row[4] >= floors["weekly"]
         ),
         "monthly": sum(
-            int(row[5] or 0)
-            for row in rows
-            if row[6] is not None and row[6] >= floors["monthly"]
+            int(row[5] or 0) for row in rows if row[6] is not None and row[6] >= floors["monthly"]
         ),
     }
     return decide_key_window_limits(
@@ -286,13 +284,8 @@ def authorize_atomic(
         raise ValueError("credit shards must be non-negative")
     if len(set(shard_candidates)) != len(shard_candidates):
         raise ValueError("credit_shard_candidates must be unique")
-    if (
-        has_credit_candidate
-        and len(shard_candidates) > MAX_CREDIT_SHARD_ATTEMPTS_PER_TRANSACTION
-    ):
-        raise ValueError(
-            "credit_shard_candidates exceeds the hot-path transaction limit"
-        )
+    if has_credit_candidate and len(shard_candidates) > MAX_CREDIT_SHARD_ATTEMPTS_PER_TRANSACTION:
+        raise ValueError("credit_shard_candidates exceeds the hot-path transaction limit")
     if not has_credit_candidate and shard_candidates != (UNSHARDED,):
         raise ValueError("BYOK-only authorization must use credit shard zero")
     key_candidates = tuple(key_shard_candidates)
@@ -315,9 +308,7 @@ def authorize_atomic(
     if authorization is not None:
         authorization.created_at = created_at.isoformat().replace("+00:00", "Z")
     legacy_auth_body = (
-        build_auth_body(authorization_id, reservation_id)
-        if build_auth_body is not None
-        else None
+        build_auth_body(authorization_id, reservation_id) if build_auth_body is not None else None
     )
 
     def _replay(existing: dict) -> dict:
@@ -359,9 +350,7 @@ def authorize_atomic(
             break
         if key_result == KEY_MISSING:
             raise _Reject(
-                AuthorizeOutcome.KEY_LIMIT_EXCEEDED
-                if saw_key_row
-                else AuthorizeOutcome.KEY_MISSING
+                AuthorizeOutcome.KEY_LIMIT_EXCEEDED if saw_key_row else AuthorizeOutcome.KEY_MISSING
             )
         key_hold = estimate if key_result == KEY_ACCEPTED else 0
 
@@ -377,13 +366,20 @@ def authorize_atomic(
             credit_hold = estimate
 
         insert_reservation(
-            transaction, pt,
-            reservation_id=reservation_id, workspace_id=workspace_id, key_hash=key_hash,
-            ws_shard=selected_credit_shard, credit_shard=selected_credit_shard,
+            transaction,
+            pt,
+            reservation_id=reservation_id,
+            workspace_id=workspace_id,
+            key_hash=key_hash,
+            ws_shard=selected_credit_shard,
+            credit_shard=selected_credit_shard,
             key_shard=selected_key_shard,
-            credit_reserved_micro=credit_hold, key_reserved_micro=key_hold,
-            hold_usage_type=reservation_usage_type, authorization_id=authorization_id,
-            idempotency_scope=idempotency_scope, idempotency_fingerprint=idempotency_fingerprint,
+            credit_reserved_micro=credit_hold,
+            key_reserved_micro=key_hold,
+            hold_usage_type=reservation_usage_type,
+            authorization_id=authorization_id,
+            idempotency_scope=idempotency_scope,
+            idempotency_fingerprint=idempotency_fingerprint,
             expires_at=expires_at,
             created_at=created_at,
         )
@@ -540,9 +536,7 @@ def settle_atomic(
     book_to_byok = settled_usage_type == "BYOK"
     terminal_at = utcnow()
     resolved_outbox_available = (
-        _outbox_table_available(database, pt)
-        if outbox_available is None
-        else outbox_available
+        _outbox_table_available(database, pt) if outbox_available is None else outbox_available
     )
 
     def txn(transaction: Any) -> dict:
@@ -556,15 +550,19 @@ def settle_atomic(
                 # real interlock; Spanner serializes it against a concurrent
                 # enqueue commit. Snapshot scans are advisory latency filters
                 # only and can miss that commit.
-                rows = list(transaction.execute_sql(
-                    GUARD_COUNT_SQL,
-                    params={"aid": aid},
-                    param_types={"aid": pt.STRING},
-                ))
+                rows = list(
+                    transaction.execute_sql(
+                        GUARD_COUNT_SQL,
+                        params={"aid": aid},
+                        param_types={"aid": pt.STRING},
+                    )
+                )
                 if rows and int(rows[0][0]) > 0:
                     return {"outcome": SettleOutcome.OUTBOX_GUARDED}
         won = claim_reservation(
-            transaction, pt, reservation_id,
+            transaction,
+            pt,
+            reservation_id,
             actual_micro=book_actual,
             settled_usage_type=settled_usage_type,
             terminal_at=terminal_at,
@@ -606,7 +604,10 @@ def settle_atomic(
         if res["credit_reserved_micro"] > 0:
             credit_actual = book_actual if settled_usage_type == "Credits" else 0
             credit_count = release_credit(
-                transaction, pt, res["workspace_id"], res["credit_reserved_micro"],
+                transaction,
+                pt,
+                res["workspace_id"],
+                res["credit_reserved_micro"],
                 credit_actual,
                 shard=res["credit_shard"],
             )
@@ -738,11 +739,13 @@ def _outbox_table_available(database: Any, param_types: Any) -> bool:
             return cached
         try:
             with database.snapshot() as snapshot:
-                list(snapshot.execute_sql(
-                    GUARD_COUNT_SQL,
-                    params={"aid": ""},
-                    param_types={"aid": param_types.STRING},
-                ))
+                list(
+                    snapshot.execute_sql(
+                        GUARD_COUNT_SQL,
+                        params={"aid": ""},
+                        param_types={"aid": param_types.STRING},
+                    )
+                )
         except Exception as exc:
             if not _is_table_missing(exc):
                 log.warning(
@@ -797,11 +800,13 @@ def reap_expired_reservations(
     guard_active = True
     try:
         with database.snapshot() as snapshot:
-            list(snapshot.execute_sql(
-                GUARD_COUNT_SQL,
-                params={"aid": ""},
-                param_types={"aid": pt.STRING},
-            ))
+            list(
+                snapshot.execute_sql(
+                    GUARD_COUNT_SQL,
+                    params={"aid": ""},
+                    param_types={"aid": pt.STRING},
+                )
+            )
     except Exception as exc:
         if not _is_table_missing(exc):
             raise
@@ -827,8 +832,13 @@ def reap_expired_reservations(
     reaped = 0
     for reservation_id, _authorization_id in rows:
         result = settle_atomic(
-            database, pt, reservation_id=reservation_id, actual_micro=0,
-            settled_usage_type="Credits", success=False, guard_outbox=guard_active,
+            database,
+            pt,
+            reservation_id=reservation_id,
+            actual_micro=0,
+            settled_usage_type="Credits",
+            success=False,
+            guard_outbox=guard_active,
             mark_authorization_terminal=True,
             outbox_available=guard_active,
         )
@@ -857,8 +867,15 @@ def typed_finalize_atomic(
     user_model_payout: UserModelPayout | None = None,
     app_markup_payout: AppMarkupPayout | None = None,
     regional_hold_unknown: bool = False,
+    settle_outbox_done: tuple[str, str] | None = None,
 ) -> dict:
     """Full DML-only finalize for the typed path (codex 3e, Option B).
+
+    ``settle_outbox_done=(authorization_id, intent_kind)`` also resolves that
+    durable settle-outbox intent to ``done`` in the SAME transaction, when the
+    activity row is durable in this commit and the outbox table exists. The
+    result carries ``outbox_marked``: True (marked), False (row leased or
+    already resolved -- the drain re-derives), or None (not attempted).
 
     ONE transaction reproduces legacy finalize_gateway_authorization's whole
     behavior so a crash can't leave counters charged but the authorization
@@ -884,9 +901,7 @@ def typed_finalize_atomic(
     book_to_byok = settled_usage_type == "BYOK"
     writes = generation_writes or []
     resolved_outbox_available = (
-        _outbox_table_available(database, pt)
-        if outbox_available is None
-        else outbox_available
+        _outbox_table_available(database, pt) if outbox_available is None else outbox_available
     )
 
     def txn(transaction: Any) -> dict:
@@ -894,7 +909,9 @@ def typed_finalize_atomic(
         if res is None:
             return {"outcome": SettleOutcome.NOT_FOUND}
         won = claim_reservation(
-            transaction, pt, reservation_id,
+            transaction,
+            pt,
+            reservation_id,
             actual_micro=book_actual,
             settled_usage_type=settled_usage_type,
             terminal_at=now,
@@ -916,7 +933,10 @@ def typed_finalize_atomic(
         if res["credit_reserved_micro"] > 0:
             credit_actual = book_actual if settled_usage_type == "Credits" else 0
             credit_count = release_credit(
-                transaction, pt, res["workspace_id"], res["credit_reserved_micro"],
+                transaction,
+                pt,
+                res["workspace_id"],
+                res["credit_reserved_micro"],
                 credit_actual,
                 shard=res["credit_shard"],
             )
@@ -1002,6 +1022,19 @@ def typed_finalize_atomic(
                 terminal_at=now,
                 outbox_available=resolved_outbox_available,
             )
+        activity_durable = generation is None or operational_analytics_outbox is not None
+        outbox_marked: bool | None = None
+        if settle_outbox_done is not None and resolved_outbox_available and activity_durable:
+            # Same commit as the charge: no post-finalize window in which a
+            # crash leaves an already-charged authorization pending, and one
+            # fewer multi-region round trip per settle. A leased row is left
+            # to its drain worker (False), exactly as the standalone mark did.
+            outbox_marked = mark_done_unleased_tx(
+                transaction,
+                pt,
+                authorization_id=settle_outbox_done[0],
+                intent_kind=settle_outbox_done[1],
+            )
         if success and generation is not None:
             if persist_generation_record:
                 insert_generation_record(
@@ -1021,8 +1054,8 @@ def typed_finalize_atomic(
             "outcome": SettleOutcome.SETTLED,
             "missing_key_releases": missing_key_releases,
             "request_record_typed": request_record_typed,
-            "activity_durable": generation is None
-            or operational_analytics_outbox is not None,
+            "activity_durable": activity_durable,
+            "outbox_marked": outbox_marked,
         }
 
     try:

--- a/src/trusted_router/storage_gcp_settle_outbox.py
+++ b/src/trusted_router/storage_gcp_settle_outbox.py
@@ -98,6 +98,163 @@ ENQ_EXISTS_TERMINAL = "terminal"  # existing done/dead/release_approved row — 
 ENQ_LEASED = "leased"  # existing pending row is actively leased by a drain — deferred
 
 
+def _defer_retention_tx(
+    transaction: Any, param_types: Any, authorization_id: str, reservation_id: Any
+) -> None:
+    """Keep both referenced records TTL-ineligible (see _defer_retention)."""
+    clear_gateway_authorization_retention(transaction, param_types, authorization_id)
+    if reservation_id:
+        clear_reservation_retention(transaction, param_types, str(reservation_id))
+
+
+def _resolve_done_retention_tx(
+    transaction: Any,
+    param_types: Any,
+    *,
+    authorization_id: str,
+    intent_kind: str,
+    reservation_id: Any,
+    now: str,
+) -> None:
+    """After an intent row goes ``done``: arm or defer retention on the shared
+    authorization and reservation records, in the SAME transaction.
+
+    The PK is (authorization_id, intent_kind): settle and refund coexist by
+    design, so shared records must outlive the last pending/dead intent, not
+    merely the first one to finish. Skipping the arm is not enough when a
+    sibling is outstanding: a winning claim (or a rolling legacy finalize) may
+    have ALREADY armed terminal_at after this row was enqueued, so the shared
+    records would stay TTL-eligible while the sibling intent is outstanding.
+
+    Shared by ``SpannerSettleOutbox.mark`` (the standalone commit) and
+    ``mark_done_unleased_tx`` (inside the finalize commit) so the two cannot
+    drift: the fold moved the mark, it must not move the retention contract.
+    """
+    sibling_rows = list(
+        transaction.execute_sql(
+            _SIBLING_GUARD_COUNT_SQL,
+            params={"aid": authorization_id, "kind": intent_kind},
+            param_types={"aid": param_types.STRING, "kind": param_types.STRING},
+        )
+    )
+    outstanding_siblings = int(sibling_rows[0][0]) if sibling_rows else 0
+    if outstanding_siblings == 0:
+        complete_gateway_authorization_retention(
+            transaction,
+            param_types,
+            authorization_id,
+            terminal_at=now,
+            outbox_available=True,
+        )
+        if reservation_id:
+            complete_reservation_retention(
+                transaction,
+                param_types,
+                str(reservation_id),
+                terminal_at=now,
+                outbox_available=True,
+            )
+    else:
+        _defer_retention_tx(transaction, param_types, authorization_id, reservation_id)
+
+
+# The two statements mark() issues, spelled once more here for the inline
+# finalize transaction. They are deliberately byte-identical to mark()'s: the
+# test fake is SQL-sensitive by design (it asserts each predicate), so a drift
+# between the two would fail one of them against the single modeled shape.
+_PENDING_ROW_SQL = (
+    "SELECT attempts, lease_owner, reservation_id FROM tr_settle_outbox "
+    "WHERE authorization_id=@aid AND intent_kind=@kind AND status='pending'"
+)
+_RESOLVE_ROW_SQL = (
+    "UPDATE tr_settle_outbox SET status=@status, attempts=@attempts, "
+    "last_error=@err, next_attempt_at=@next_at, lease_owner=NULL, "
+    "leased_until=NULL, updated_at=@now, terminal_at=@terminal_at, "
+    "settle_body=IF(@done, CAST(NULL AS STRING), settle_body) "
+    "WHERE authorization_id=@aid "
+    "AND intent_kind=@kind AND status='pending' "
+    "AND ((@lease_owner IS NULL AND lease_owner IS NULL) OR "
+    "(@lease_owner IS NOT NULL AND lease_owner=@lease_owner))"
+)
+
+
+def mark_done_unleased_tx(
+    transaction: Any,
+    param_types: Any,
+    *,
+    authorization_id: str,
+    intent_kind: str,
+) -> bool:
+    """Resolve the pending intent row to ``done`` INSIDE a caller's transaction.
+
+    Same lease fence as the inline path's ``mark(done=True)``: only an UNLEASED
+    ``pending`` row is touched. A row a drain worker currently owns is left
+    alone (returns False) and the drain re-derives ``done`` from the finalize
+    outcome, exactly as when the standalone mark was skipped.
+
+    Called from ``typed_finalize_atomic`` so the charge and the done-mark
+    commit together. Before this the mark was a separate commit after
+    finalize: one more multi-region round trip per settle, and a window in
+    which a crash left an already-charged authorization ``pending`` -- the
+    residual that docs/design/durable-settle-outbox.md §7 accepted and said
+    to close this way once the outbox shared the Spanner instance.
+    """
+    rows = list(
+        transaction.execute_sql(
+            _PENDING_ROW_SQL,
+            params={"aid": authorization_id, "kind": intent_kind},
+            param_types={"aid": param_types.STRING, "kind": param_types.STRING},
+        )
+    )
+    if not rows:
+        return False
+    attempts, cur_owner, reservation_id = int(rows[0][0] or 0), rows[0][1], rows[0][2]
+    if cur_owner is not None:
+        return False
+    now = _iso_now()
+    updated = transaction.execute_update(
+        _RESOLVE_ROW_SQL,
+        params={
+            "status": "done",
+            "attempts": attempts + 1,
+            "err": None,
+            "next_at": None,
+            "now": now,
+            "terminal_at": now,
+            "done": True,
+            "aid": authorization_id,
+            "kind": intent_kind,
+            "lease_owner": None,
+        },
+        param_types={
+            "status": param_types.STRING,
+            "attempts": param_types.INT64,
+            "err": param_types.STRING,
+            "next_at": param_types.TIMESTAMP,
+            "now": param_types.TIMESTAMP,
+            "aid": param_types.STRING,
+            "kind": param_types.STRING,
+            "lease_owner": param_types.STRING,
+            "terminal_at": param_types.TIMESTAMP,
+            "done": param_types.BOOL,
+        },
+    )
+    if int(updated) != 1:
+        return False
+    # The mark moved into the finalize commit; the retention contract that
+    # rode along with it (arm terminal_at on the shared records, or defer it
+    # while a sibling intent is outstanding) moves with it.
+    _resolve_done_retention_tx(
+        transaction,
+        param_types,
+        authorization_id=authorization_id,
+        intent_kind=intent_kind,
+        reservation_id=reservation_id,
+        now=now,
+    )
+    return True
+
+
 def _iso_now() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
@@ -214,9 +371,7 @@ class SpannerSettleOutbox:
                 "auto_refill_status": "pending" if auto_refill_requested else None,
                 "auto_refill_attempts": 0,
                 "auto_refill_last_error": None,
-                "auto_refill_next_attempt_at": (
-                    next_attempt_at if auto_refill_requested else None
-                ),
+                "auto_refill_next_attempt_at": (next_attempt_at if auto_refill_requested else None),
                 "auto_refill_lease_owner": None,
                 "auto_refill_leased_until": None,
                 "auto_refill_enqueued_at": now if auto_refill_requested else None,
@@ -504,42 +659,14 @@ class SpannerSettleOutbox:
             if updated != 1:
                 return None
             if done:
-                sibling_rows = list(
-                    transaction.execute_sql(
-                        _SIBLING_GUARD_COUNT_SQL,
-                        params={"aid": authorization_id, "kind": intent_kind},
-                        param_types={
-                            "aid": self._pt.STRING,
-                            "kind": self._pt.STRING,
-                        },
-                    )
+                _resolve_done_retention_tx(
+                    transaction,
+                    self._pt,
+                    authorization_id=authorization_id,
+                    intent_kind=intent_kind,
+                    reservation_id=reservation_id,
+                    now=now,
                 )
-                outstanding_siblings = int(sibling_rows[0][0]) if sibling_rows else 0
-                # The PK is (authorization_id, intent_kind): settle and refund
-                # coexist by design, so shared records must outlive the last
-                # pending/dead intent, not merely the first one to finish.
-                if outstanding_siblings == 0:
-                    complete_gateway_authorization_retention(
-                        transaction,
-                        self._pt,
-                        authorization_id,
-                        terminal_at=now,
-                        outbox_available=True,
-                    )
-                    if reservation_id:
-                        complete_reservation_retention(
-                            transaction,
-                            self._pt,
-                            str(reservation_id),
-                            terminal_at=now,
-                            outbox_available=True,
-                        )
-                else:
-                    # Skipping the arm is not enough: a winning claim (or a
-                    # rolling legacy finalize) may have ALREADY armed terminal_at
-                    # after this row was enqueued, so the shared records would
-                    # stay TTL-eligible while the sibling intent is outstanding.
-                    self._defer_retention(transaction, authorization_id, reservation_id)
             else:
                 # Non-terminal outcome (backoff to pending, or dead awaiting a
                 # human): repair work is still outstanding, so the referenced
@@ -569,9 +696,7 @@ class SpannerSettleOutbox:
         defense-in-depth for already-armed state and every path that leaves or
         keeps an intent outstanding.
         """
-        clear_gateway_authorization_retention(transaction, self._pt, authorization_id)
-        if reservation_id:
-            clear_reservation_retention(transaction, self._pt, str(reservation_id))
+        _defer_retention_tx(transaction, self._pt, authorization_id, reservation_id)
 
     def park(
         self,

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -739,6 +739,10 @@ class TypedFinalizeResult:
     finalized: bool
     activity_indexed: bool
     request_record_typed: bool = False
+    # Settle-outbox intent resolved in the finalize commit: True marked, False
+    # left to a drain worker holding the lease, None not attempted (caller
+    # keeps the standalone mark).
+    outbox_marked: bool | None = None
 
 
 @dataclass(frozen=True)

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -63,6 +63,24 @@ def fake_store() -> Iterator[tuple[Any, Any, Any]]:
         configure_store(InMemoryStore())
 
 
+@pytest.fixture
+def prod_shaped_store() -> Iterator[tuple[Any, Any, Any]]:
+    """The store as production runs it: the ClickHouse delivery intent is
+    written INSIDE the finalize transaction (operational analytics outbox on,
+    typed request records). That in-commit durability is what allows the
+    settle-outbox done-mark to be folded into the same commit."""
+    store, db, bt = make_fake_store(
+        operational_analytics_outbox_enabled=True,
+        request_record_write_mode="typed",
+        generation_records_enabled=True,
+    )
+    configure_store(store)
+    try:
+        yield store, db, bt
+    finally:
+        configure_store(InMemoryStore())
+
+
 def _client(settings: Settings, *, raise_server_exceptions: bool = True) -> TestClient:
     return TestClient(
         create_app(settings, configure_store_arg=False, init_observability=False),
@@ -280,9 +298,7 @@ def _row(
         selected_endpoint_id=ENDPOINT_ID,
         model_id=MODEL_ID,
         selected_usage_type=selected_usage_type,
-        settle_body=settle_body
-        if settle_body is not None
-        else json.dumps(_settle_json(auth.id)),
+        settle_body=settle_body if settle_body is not None else json.dumps(_settle_json(auth.id)),
     )
 
 
@@ -297,7 +313,9 @@ def _settle_timing_records(caplog: pytest.LogCaptureFixture) -> list[logging.Log
 # Unit (storage)
 
 
-def test_park_leaves_attempts_unchanged_and_respects_lease(fake_store: tuple[Any, Any, Any]) -> None:
+def test_park_leaves_attempts_unchanged_and_respects_lease(
+    fake_store: tuple[Any, Any, Any],
+) -> None:
     store, _db, _bt = fake_store
     ob = _outbox(store)
     row = _row(
@@ -746,16 +764,13 @@ def test_auto_refill_pass_debounces_transient_store_errors_until_sustained(
         assert "consecutive_failures=3" in alerts[0].getMessage()
 
         assert drain_pass.run(settings, limit=10) is None
-        assert len(
-            [record for record in caplog.records if record.levelno >= logging.ERROR]
-        ) == 1
+        assert len([record for record in caplog.records if record.levelno >= logging.ERROR]) == 1
 
         assert drain_pass.run(settings, limit=10) == {"claimed": 0}
 
     assert drain_pass.consecutive_transient_failures == 0
     assert any(
-        "recovered after 4 transient failures" in record.getMessage()
-        for record in caplog.records
+        "recovered after 4 transient failures" in record.getMessage() for record in caplog.records
     )
 
 
@@ -1003,21 +1018,15 @@ def test_activity_pending_second_cycle_preserves_original_since(
     first_row = ob.get(auth.id, "settle")
     assert first["claimed"] == 1
     assert first_row is not None and first_row.last_error is not None
-    first_since = first_row.last_error.removeprefix(
-        f"{drain_mod._ACTIVITY_PARK_NOTE} since="
-    )
-    db.settle_outbox[(auth.id, "settle")]["next_attempt_at"] = (
-        "2000-01-01T00:00:00Z"
-    )
+    first_since = first_row.last_error.removeprefix(f"{drain_mod._ACTIVITY_PARK_NOTE} since=")
+    db.settle_outbox[(auth.id, "settle")]["next_attempt_at"] = "2000-01-01T00:00:00Z"
 
     second = drain_mod.drain_settle_outbox(10)
 
     second_row = ob.get(auth.id, "settle")
     assert second["claimed"] == 1
     assert second_row is not None and second_row.last_error is not None
-    second_since = second_row.last_error.removeprefix(
-        f"{drain_mod._ACTIVITY_PARK_NOTE} since="
-    )
+    second_since = second_row.last_error.removeprefix(f"{drain_mod._ACTIVITY_PARK_NOTE} since=")
     assert second_since == first_since
     assert second_row.attempts == 0
 
@@ -1034,8 +1043,7 @@ def test_typed_park_preserves_expired_activity_window(
         seconds=drain_mod._ACTIVITY_REPAIR_MAX_AGE_SECONDS + 1
     )
     activity_note = (
-        f"{drain_mod._ACTIVITY_PARK_NOTE} since="
-        f"{since.isoformat().replace('+00:00', 'Z')}"
+        f"{drain_mod._ACTIVITY_PARK_NOTE} since={since.isoformat().replace('+00:00', 'Z')}"
     )
     db.settle_outbox[(auth.id, "settle")]["last_error"] = activity_note
     outcomes = iter(
@@ -1057,9 +1065,7 @@ def test_typed_park_preserves_expired_activity_window(
     assert pending is not None and pending.status == "pending"
     assert pending.attempts == 0
     assert pending.last_error == activity_note
-    db.settle_outbox[(auth.id, "settle")]["next_attempt_at"] = (
-        "2000-01-01T00:00:00Z"
-    )
+    db.settle_outbox[(auth.id, "settle")]["next_attempt_at"] = "2000-01-01T00:00:00Z"
 
     second = drain_mod.drain_settle_outbox(10)
 
@@ -1122,9 +1128,7 @@ def test_inline_zero_cost_activity_failure_keeps_payload_without_park_note(
     assert pending is not None and pending.status == "pending"
     assert pending.last_error is None
     assert pending.settle_body is not None
-    db.settle_outbox[(auth.id, "settle")]["next_attempt_at"] = (
-        "2000-01-01T00:00:00Z"
-    )
+    db.settle_outbox[(auth.id, "settle")]["next_attempt_at"] = "2000-01-01T00:00:00Z"
 
     result = drain_mod.drain_settle_outbox(10)
 
@@ -1171,15 +1175,11 @@ def test_inline_zero_cost_without_park_note_resolves_after_index_succeeds(
     assert pending is not None and pending.status == "pending"
     assert pending.last_error is None
     assert bt.committed == []
-    db.settle_outbox[(auth.id, "settle")]["next_attempt_at"] = (
-        "2000-01-01T00:00:00Z"
-    )
+    db.settle_outbox[(auth.id, "settle")]["next_attempt_at"] = "2000-01-01T00:00:00Z"
 
     result = drain_mod.drain_settle_outbox(10)
 
-    assert result["outcomes"] == {
-        ApplyOutcome.RESOLVED_ZERO_COST_ELSEWHERE: 1
-    }
+    assert result["outcomes"] == {ApplyOutcome.RESOLVED_ZERO_COST_ELSEWHERE: 1}
     completed = ob.get(auth.id, "settle")
     assert completed is not None and completed.status == "done"
     assert len(index_attempts) == 2
@@ -1208,9 +1208,7 @@ def test_zero_cost_activity_pending_keeps_retrying_and_preserves_payload(
     assert first["outcomes"] == {ApplyOutcome.ACTIVITY_PENDING: 1}
     assert first_row is not None and first_row.status == "pending"
     assert first_row.settle_body is not None
-    db.settle_outbox[(auth.id, "settle")]["next_attempt_at"] = (
-        "2000-01-01T00:00:00Z"
-    )
+    db.settle_outbox[(auth.id, "settle")]["next_attempt_at"] = "2000-01-01T00:00:00Z"
 
     second = drain_mod.drain_settle_outbox(10)
 
@@ -1245,16 +1243,12 @@ def test_zero_cost_activity_pending_resolves_after_index_succeeds(
     first = drain_mod.drain_settle_outbox(10)
     assert first["outcomes"] == {ApplyOutcome.ACTIVITY_PENDING: 1}
     assert bt.committed == []
-    db.settle_outbox[(auth.id, "settle")]["next_attempt_at"] = (
-        "2000-01-01T00:00:00Z"
-    )
+    db.settle_outbox[(auth.id, "settle")]["next_attempt_at"] = "2000-01-01T00:00:00Z"
 
     second = drain_mod.drain_settle_outbox(10)
 
     completed = ob.get(auth.id, "settle")
-    assert second["outcomes"] == {
-        ApplyOutcome.RESOLVED_ZERO_COST_ELSEWHERE: 1
-    }
+    assert second["outcomes"] == {ApplyOutcome.RESOLVED_ZERO_COST_ELSEWHERE: 1}
     assert completed is not None and completed.status == "done"
     assert len(index_attempts) == 2
     assert bt.committed
@@ -1271,8 +1265,8 @@ def test_activity_pending_old_row_with_new_window_still_parks(
     created_at = dt.datetime.now(dt.UTC) - dt.timedelta(
         seconds=drain_mod._ACTIVITY_REPAIR_MAX_AGE_SECONDS * 2
     )
-    db.settle_outbox[(auth.id, "settle")]["created_at"] = (
-        created_at.isoformat().replace("+00:00", "Z")
+    db.settle_outbox[(auth.id, "settle")]["created_at"] = created_at.isoformat().replace(
+        "+00:00", "Z"
     )
     db.settle_outbox[(auth.id, "settle")]["last_error"] = "unrelated failure"
     monkeypatch.setattr(
@@ -1302,17 +1296,14 @@ def test_activity_pending_over_window_marks_dead_preserves_payload_and_alerts(
     ob.enqueue(
         _row(
             auth,
-            settle_body=json.dumps(
-                _settle_json(auth.id, request_id="req-activity-expired")
-            ),
+            settle_body=json.dumps(_settle_json(auth.id, request_id="req-activity-expired")),
         )
     )
     since = dt.datetime.now(dt.UTC) - dt.timedelta(
         seconds=drain_mod._ACTIVITY_REPAIR_MAX_AGE_SECONDS + 1
     )
     db.settle_outbox[(auth.id, "settle")]["last_error"] = (
-        f"{drain_mod._ACTIVITY_PARK_NOTE} since="
-        f"{since.isoformat().replace('+00:00', 'Z')}"
+        f"{drain_mod._ACTIVITY_PARK_NOTE} since={since.isoformat().replace('+00:00', 'Z')}"
     )
     monkeypatch.setattr(
         drain_mod,
@@ -1336,10 +1327,7 @@ def test_activity_pending_over_window_marks_dead_preserves_payload_and_alerts(
     ]
     assert len(alerts) == 1
     assert f"authorization_id={auth.id}" in alerts[0]
-    assert (
-        f"generation_id={drain_mod.generation_id_for_authorization(auth.id)}"
-        in alerts[0]
-    )
+    assert f"generation_id={drain_mod.generation_id_for_authorization(auth.id)}" in alerts[0]
     assert "request_id=req-activity-expired" in alerts[0]
     assert f"reservation_id={auth.credit_reservation_id}" in alerts[0]
     assert "CHARGE IS ALREADY APPLIED" in alerts[0]
@@ -1364,8 +1352,7 @@ def test_activity_pending_lost_lease_skips_false_alert(
         seconds=drain_mod._ACTIVITY_REPAIR_MAX_AGE_SECONDS + 1
     )
     db.settle_outbox[(auth.id, "settle")]["last_error"] = (
-        f"{drain_mod._ACTIVITY_PARK_NOTE} since="
-        f"{since.isoformat().replace('+00:00', 'Z')}"
+        f"{drain_mod._ACTIVITY_PARK_NOTE} since={since.isoformat().replace('+00:00', 'Z')}"
     )
     monkeypatch.setattr(
         drain_mod,
@@ -1402,10 +1389,7 @@ def test_lost_lease_dead_letter_alerts_only_when_fence_wins(
     winner_auth = _bare_authorization("gwa-missing-winning-owner")
     ob.enqueue(_row(stale_auth))
     ob.enqueue(_row(winner_auth))
-    claimed = {
-        row.authorization_id: row
-        for row in ob.claim(limit=2, lease_seconds=300)
-    }
+    claimed = {row.authorization_id: row for row in ob.claim(limit=2, lease_seconds=300)}
     stale = claimed[stale_auth.id]
     winner = claimed[winner_auth.id]
     stale_record = db.settle_outbox[(stale_auth.id, "settle")]
@@ -1479,8 +1463,7 @@ def test_activity_pending_escalation_keeps_retention_pinned(
         seconds=drain_mod._ACTIVITY_REPAIR_MAX_AGE_SECONDS + 1
     )
     db.settle_outbox[(auth.id, "settle")]["last_error"] = (
-        f"{drain_mod._ACTIVITY_PARK_NOTE} since="
-        f"{since.isoformat().replace('+00:00', 'Z')}"
+        f"{drain_mod._ACTIVITY_PARK_NOTE} since={since.isoformat().replace('+00:00', 'Z')}"
     )
 
     result = drain_mod.drain_settle_outbox(10)
@@ -1508,9 +1491,7 @@ def test_activity_pending_dead_row_reset_to_pending_is_reclaimed(
         force_dead=True,
     )
     db.settle_outbox[(auth.id, "settle")]["status"] = "pending"
-    db.settle_outbox[(auth.id, "settle")]["next_attempt_at"] = (
-        "2000-01-01T00:00:00Z"
-    )
+    db.settle_outbox[(auth.id, "settle")]["next_attempt_at"] = "2000-01-01T00:00:00Z"
     applied: list[str] = []
 
     def apply_repaired(row: SettleOutboxRow) -> str:
@@ -1533,9 +1514,7 @@ def test_activity_pending_dead_row_reset_to_pending_is_reclaimed(
         "not-an-iso-timestamp",
         (
             dt.datetime.now(dt.UTC)
-            - dt.timedelta(
-                seconds=drain_mod._ACTIVITY_REPAIR_MAX_AGE_SECONDS + 1
-            )
+            - dt.timedelta(seconds=drain_mod._ACTIVITY_REPAIR_MAX_AGE_SECONDS + 1)
         )
         .replace(tzinfo=None)
         .isoformat(),
@@ -1571,9 +1550,9 @@ def test_activity_pending_malformed_or_naive_since_still_parks(
     assert pending.attempts == 0
     assert pending.last_error is not None
     stamped_since = dt.datetime.fromisoformat(
-        pending.last_error.removeprefix(
-            f"{drain_mod._ACTIVITY_PARK_NOTE} since="
-        ).replace("Z", "+00:00")
+        pending.last_error.removeprefix(f"{drain_mod._ACTIVITY_PARK_NOTE} since=").replace(
+            "Z", "+00:00"
+        )
     )
     assert stamped_since.tzinfo is not None
     assert any(
@@ -1597,12 +1576,11 @@ def test_activity_pending_future_since_is_clamped(
         seconds=drain_mod._ACTIVITY_REPAIR_MAX_AGE_SECONDS + 1
     )
     future_since = dt.datetime.now(dt.UTC) + dt.timedelta(hours=1)
-    db.settle_outbox[(auth.id, "settle")]["created_at"] = (
-        created_at.isoformat().replace("+00:00", "Z")
+    db.settle_outbox[(auth.id, "settle")]["created_at"] = created_at.isoformat().replace(
+        "+00:00", "Z"
     )
     db.settle_outbox[(auth.id, "settle")]["last_error"] = (
-        f"{drain_mod._ACTIVITY_PARK_NOTE} since="
-        f"{future_since.isoformat().replace('+00:00', 'Z')}"
+        f"{drain_mod._ACTIVITY_PARK_NOTE} since={future_since.isoformat().replace('+00:00', 'Z')}"
     )
     monkeypatch.setattr(
         drain_mod,
@@ -1618,9 +1596,9 @@ def test_activity_pending_future_since_is_clamped(
     assert pending is not None and pending.status == "pending"
     assert pending.last_error is not None
     stamped_since = dt.datetime.fromisoformat(
-        pending.last_error.removeprefix(
-            f"{drain_mod._ACTIVITY_PARK_NOTE} since="
-        ).replace("Z", "+00:00")
+        pending.last_error.removeprefix(f"{drain_mod._ACTIVITY_PARK_NOTE} since=").replace(
+            "Z", "+00:00"
+        )
     )
     assert stamped_since < future_since
     assert any(
@@ -1700,10 +1678,7 @@ def test_drain_reap_limit_respected(fake_store: tuple[Any, Any, Any]) -> None:
     ws = "ws-drain-reap-limit"
     _seed_credit(store, ws)
     key = _make_key(store, ws)
-    auths = [
-        _expired_authorization(store, workspace_id=ws, key_hash=key.hash)
-        for _ in range(3)
-    ]
+    auths = [_expired_authorization(store, workspace_id=ws, key_hash=key.hash) for _ in range(3)]
     assert _typed_credit(db, ws)["reserved"] == ESTIMATE * 3
 
     result = drain_mod.drain_settle_outbox(10)
@@ -1970,10 +1945,7 @@ def test_user_model_inline_finalize_loss_repairs_one_payout_from_frozen_outbox(
 
     store.typed_finalize_gateway_authorization_result = original
     assert apply_mod.apply_frozen_settle(row) == ApplyOutcome.SETTLED_NOW
-    assert (
-        apply_mod.apply_frozen_settle(row)
-        == ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE
-    )
+    assert apply_mod.apply_frozen_settle(row) == ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE
     payout = 5_600
     assert store.earnings_summary("owner-outbox-repair")["total_earned"] == payout
     movements = store.list_credit_movements("user:owner-outbox-repair")
@@ -2007,16 +1979,12 @@ def test_charged_settle_then_sibling_refund_resolves_and_arms_retention(
     assert ob.get(auth.id, "refund").status == "pending"
     assert db.reservations[auth.credit_reservation_id]["terminal_at"] is None
     assert db.gateway_authorizations[auth.id]["terminal_at"] is None
-    db.settle_outbox[(auth.id, "refund")]["next_attempt_at"] = (
-        "2000-01-01T00:00:00Z"
-    )
+    db.settle_outbox[(auth.id, "refund")]["next_attempt_at"] = "2000-01-01T00:00:00Z"
 
     with caplog.at_level(logging.WARNING, logger=drain_mod.__name__):
         refunded = drain_mod.drain_settle_outbox(10)
 
-    assert refunded["outcomes"] == {
-        ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE: 1
-    }
+    assert refunded["outcomes"] == {ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE: 1}
     completed_refund = ob.get(auth.id, "refund")
     assert completed_refund is not None and completed_refund.status == "done"
     assert any(
@@ -2045,10 +2013,7 @@ def test_charged_settle_with_no_generation_dead_letters_as_invalid_row(
     _seed_credit(store, ws)
     key = _make_key(store, ws)
     auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
-    assert (
-        apply_mod.apply_frozen_settle(_row(auth, cost=777_777))
-        == ApplyOutcome.SETTLED_NOW
-    )
+    assert apply_mod.apply_frozen_settle(_row(auth, cost=777_777)) == ApplyOutcome.SETTLED_NOW
     ob = _outbox(store)
     ob.enqueue(_row(auth, cost=777_777))
 
@@ -2194,7 +2159,9 @@ def test_drain_resolves_recovery_outcomes_and_warning_gates(
         _row(_bare_authorization("gwa-legacy-settle"), intent="refund", origin="legacy"),
         initial_delay_seconds=60,
     )
-    ob.enqueue(_row(_bare_authorization("gwa-legacy-refund-self"), intent="refund", origin="legacy"))
+    ob.enqueue(
+        _row(_bare_authorization("gwa-legacy-refund-self"), intent="refund", origin="legacy")
+    )
     ob.enqueue(_row(_bare_authorization("gwa-refund-already-free"), intent="refund"))
     ob.enqueue(_row(_bare_authorization("gwa-missing")))
     ob.enqueue(_row(_bare_authorization("gwa-unknown")))
@@ -2229,11 +2196,20 @@ def test_drain_resolves_recovery_outcomes_and_warning_gates(
     assert unknown.attempts == 1
     assert unknown.last_error == "unknown outcome: mystery_outcome"
     messages = [rec.message for rec in caplog.records]
-    assert any("kept charge beat refund intent authorization_id=gwa-refund-kept-charge" in msg for msg in messages)
+    assert any(
+        "kept charge beat refund intent authorization_id=gwa-refund-kept-charge" in msg
+        for msg in messages
+    )
     assert not any("gwa-refund-zero" in msg for msg in messages)
-    assert any("legacy settled with sibling refund intent authorization_id=gwa-legacy-settle" in msg for msg in messages)
+    assert any(
+        "legacy settled with sibling refund intent authorization_id=gwa-legacy-settle" in msg
+        for msg in messages
+    )
     assert not any("gwa-legacy-refund-self" in msg for msg in messages)
-    assert any("ALERT settle outbox reservation missing authorization_id=gwa-missing" in msg for msg in messages)
+    assert any(
+        "ALERT settle outbox reservation missing authorization_id=gwa-missing" in msg
+        for msg in messages
+    )
 
 
 def test_drain_resolve_errors_do_not_abort_later_rows(
@@ -2319,7 +2295,13 @@ def test_drain_endpoint_requires_internal_token(fake_store: tuple[Any, Any, Any]
     assert missing.status_code == 401
     assert wrong.status_code == 401
     assert ok.status_code == 200
-    assert ok.json() == {"claimed": 0, "outcomes": {}, "recovered_micro": 0, "purged": 0, "reaped": 0}
+    assert ok.json() == {
+        "claimed": 0,
+        "outcomes": {},
+        "recovered_micro": 0,
+        "purged": 0,
+        "reaped": 0,
+    }
 
 
 # --- Review-round regressions: the primary prod payout path -----------------
@@ -2492,3 +2474,153 @@ def test_user_model_settle_refuses_a_different_model_id(
         json=_typed_settle_body(auth, selected_model="trustedrouter/user-someone-else"),
     )
     assert other.status_code == 400, other.text
+
+
+# ── Done-mark folded into the finalize commit ─────────────────────────────────
+#
+# Settle p90 was ~3.1s: three SERIAL multi-region Spanner commits (enqueue,
+# finalize, mark) at 500-1000ms p90 each, attempts=1 always. The design doc's
+# own §7 said to write status='done' in the finalize transaction once the
+# outbox shared the instance. These pin that: one commit fewer, same lease
+# fence, and the leased-row case still defers to the drain.
+
+
+def _settle_with_sql_spy(
+    store: Any, monkeypatch: pytest.MonkeyPatch, *, ws: str
+) -> tuple[Any, list[tuple[int, str]], Any]:
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    calls: list[tuple[int, str]] = []
+    original_update = _FakeTransaction.execute_update
+    # A monotonic per-transaction number, NOT id(): CPython reuses the id of a
+    # freed transaction object, so a later standalone-mark transaction could
+    # alias the finalize one and pass a same-transaction check vacuously.
+    sequence: dict[int, int] = {}
+
+    def spy(self: Any, sql: str, **kwargs: Any) -> int:
+        txn = sequence.setdefault(id(self), len(sequence))
+        self.__dict__.setdefault("_spy_txn", txn)
+        calls.append((self.__dict__["_spy_txn"], sql))
+        return original_update(self, sql, **kwargs)
+
+    monkeypatch.setattr(_FakeTransaction, "execute_update", spy)
+    return auth, calls, _client(Settings(environment="test", settle_outbox_enabled=True))
+
+
+def test_inline_settle_resolves_the_outbox_row_inside_the_finalize_commit(
+    prod_shaped_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, db, _bt = prod_shaped_store
+    auth, calls, client = _settle_with_sql_spy(store, monkeypatch, ws="ws-fold-done")
+
+    with caplog.at_level(logging.INFO, logger=GATEWAY_LOGGER):
+        resp = client.post("/v1/internal/gateway/settle", json=_settle_json(auth.id))
+
+    assert resp.status_code == 200, resp.text
+    row = db.settle_outbox[(auth.id, "settle")]
+    assert row["status"] == "done"
+    assert row["lease_owner"] is None
+    assert row["terminal_at"] is not None
+    # The retention contract rode along: no outstanding sibling intent, so the
+    # shared records are armed for the 30-day policy in the SAME commit.
+    assert db.gateway_authorizations[auth.id]["terminal_at"] is not None
+    assert db.reservations[auth.credit_reservation_id]["terminal_at"] is not None
+
+    marks = [
+        txn for txn, sql in calls if sql.startswith("UPDATE tr_settle_outbox SET status=@status")
+    ]
+    assert len(marks) == 1, "the done-mark must run exactly once"
+    [mark_txn] = marks
+    finalize_tables = {
+        txn for txn, sql in calls if "tr_reservation" in sql or "tr_credit_balance" in sql
+    }
+    assert mark_txn in finalize_tables, (
+        "the done-mark ran in its own transaction, not the finalize's"
+    )
+
+    [record] = _settle_timing_records(caplog)
+    assert isinstance(record.args, tuple)
+    assert record.args[7] == 0.0  # mark_ms: no standalone mark commit
+
+
+def test_inline_settle_leaves_a_leased_outbox_row_to_its_drain_worker(
+    prod_shaped_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A drain worker that claimed the row between enqueue and finalize keeps it."""
+    store, db, _bt = prod_shaped_store
+    auth, calls, client = _settle_with_sql_spy(store, monkeypatch, ws="ws-fold-leased")
+    original_enqueue = SpannerSettleOutbox.enqueue
+
+    def enqueue_then_lease(self: Any, row: Any, **kwargs: Any) -> Any:
+        result = original_enqueue(self, row, **kwargs)
+        db.settle_outbox[(row.authorization_id, row.intent_kind)]["lease_owner"] = "drain-w1"
+        return result
+
+    monkeypatch.setattr(SpannerSettleOutbox, "enqueue", enqueue_then_lease)
+
+    with caplog.at_level(logging.INFO, logger=GATEWAY_LOGGER):
+        resp = client.post("/v1/internal/gateway/settle", json=_settle_json(auth.id))
+
+    assert resp.status_code == 200, resp.text
+    row = db.settle_outbox[(auth.id, "settle")]
+    assert row["status"] == "pending"
+    assert row["lease_owner"] == "drain-w1"
+    assert not any(
+        sql.startswith("UPDATE tr_settle_outbox SET status=@status") for _txn, sql in calls
+    ), "a leased row must not be rewritten by the inline path"
+    assert "settle outbox done mark skipped" in caplog.text
+
+
+def test_without_in_commit_activity_durability_the_standalone_mark_still_runs(
+    fake_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No operational-analytics outbox in the commit: durability is only
+    established by the post-commit index write, so the finalize transaction
+    must NOT mark the intent done; the standalone mark after the index does."""
+    store, db, _bt = fake_store
+    auth, calls, client = _settle_with_sql_spy(store, monkeypatch, ws="ws-fold-fallback")
+
+    with caplog.at_level(logging.INFO, logger=GATEWAY_LOGGER):
+        resp = client.post("/v1/internal/gateway/settle", json=_settle_json(auth.id))
+
+    assert resp.status_code == 200, resp.text
+    assert db.settle_outbox[(auth.id, "settle")]["status"] == "done"
+    marks = [
+        txn for txn, sql in calls if sql.startswith("UPDATE tr_settle_outbox SET status=@status")
+    ]
+    # The finalize commit is the one that releases the hold. In this
+    # configuration a later retention commit also touches the reservation,
+    # so "any transaction touching tr_reservation" is NOT the finalize.
+    release_txn = min(txn for txn, sql in calls if "tr_credit_balance" in sql)
+    assert len(marks) == 1
+    assert marks[0] != release_txn, "mark must stay post-commit when durability is post-commit"
+    [record] = _settle_timing_records(caplog)
+    assert isinstance(record.args, tuple)
+    assert record.args[7] > 0.0  # a real standalone mark commit was timed
+
+
+def test_folded_mark_defers_retention_while_a_sibling_intent_is_outstanding(
+    prod_shaped_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Settle and refund intents share the authorization; while the refund is
+    still pending, the folded settle mark must leave the shared records
+    TTL-ineligible exactly as the standalone mark did."""
+    store, db, _bt = prod_shaped_store
+    auth, _calls, client = _settle_with_sql_spy(store, monkeypatch, ws="ws-fold-sibling")
+    _outbox(store).enqueue(_row(auth, intent="refund"), initial_delay_seconds=60)
+
+    resp = client.post("/v1/internal/gateway/settle", json=_settle_json(auth.id))
+
+    assert resp.status_code == 200, resp.text
+    assert db.settle_outbox[(auth.id, "settle")]["status"] == "done"
+    assert db.settle_outbox[(auth.id, "refund")]["status"] == "pending"
+    assert db.gateway_authorizations[auth.id]["terminal_at"] is None
+    assert db.reservations[auth.credit_reservation_id].get("terminal_at") is None


### PR DESCRIPTION
`/internal/gateway/settle` p90 ≈ 3.1s was structural: **three serial multi-region Spanner commits** per settle — enqueue, finalize, mark — at 500–1,000ms p90 each, `attempts=1` always (not contention). Decomposed from the `settle timing` log lines:

| phase | quiet p50 | slow p50 | p90 (both) |
|---|---:|---:|---:|
| enqueue | 160 | 475 | ~520 |
| finalize | 782 | 898 | ~1450 |
| **mark** | **224** | **709** | **~775** |
| total | 1214 | 2226 | ~2850 |

**Enqueue must stay separate and first** — it's the durable intent that lets the drain re-drive a crashed finalize. **The mark is the opposite:** it records that finalize committed, and `docs/design/durable-settle-outbox.md` §7 already said to write `status='done'` in the finalize transaction once the outbox shared the instance. It does. This does that.

`typed_finalize_atomic(settle_outbox_done=…)` resolves the intent inside the finalize commit, gated on the activity row being durable **in that commit** (operational-analytics outbox present — production's configuration). Without it, durability is only established post-commit, so the route keeps its standalone mark (`outbox_marked=None`). Lease fence unchanged: a drain-owned row is left pending and the drain re-derives `done`.

**The regression I nearly shipped:** the mark carries a retention contract — enqueue stops the 30-day TTL clock, done restarts it on authorization/reservation/outbox or *defers* it while a sibling refund intent is outstanding. My first fold updated only the outbox row and would have left `tr_gateway_authorization.terminal_at` NULL forever; the fake's transaction map exposed the standalone mark's extra statements. That logic is now one shared function used by both paths.

Tests: done-mark runs once, in the hold-releasing transaction, all three `terminal_at` set, `mark_ms=0.0`; leased row deferred to the drain; pending refund sibling defers retention; no-outbox config still marks standalone. Transaction identity uses a monotonic sequence — `id()` reuse made the first version pass vacuously. **Mutation-tested three ways**, each failing exactly one test.

Expected: one multi-region commit fewer per settle (~225–700ms p50, ~775ms p90 off the critical path), and the accepted crash-window closed.

Gates: ruff ✓, mypy ✓ (324 files), pytest 7,967 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)