### PR TITLE
spend-lease: local Bigtable ledger over the unit-1 state machine (decisions 32–34, 42)

### DIFF
--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -838,6 +838,7 @@ class Settings(BaseSettings):
     regional_quota_lease_max_available_basis_points: int = 1_000
     regional_quota_lease_shard_count: int = 16
     regional_quota_bigtable_table: str = "trustedrouter-regional-quota"
+    spend_lease_bigtable_table: str = "trustedrouter-spend-lease"
     # True only in the one-shot reconciliation Cloud Run Job. Serving
     # processes must never set this: it exempts the worker from duplicating the
     # traffic-issuance allowlist because the worker can only drain leases that
@@ -847,6 +848,7 @@ class Settings(BaseSettings):
     # Comma-separated region=single-cluster-app-profile pairs. A fixed profile
     # is required because one lease has exactly one regional writer authority.
     regional_quota_bigtable_app_profiles: str = ""
+    spend_lease_bigtable_app_profiles: str = ""
     # Stage A spend leases are signed advisory artifacts only. This one flag
     # gates both minting and shadow evidence; default-off deploys never touch
     # Secret Manager. The accepted digest CSV preserves both sides of a GCP
@@ -1947,6 +1949,27 @@ class Settings(BaseSettings):
             if region in profiles:
                 raise ValueError(
                     "TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES contains a duplicate region"
+                )
+            profiles[region] = profile
+        return profiles
+
+    @property
+    def spend_lease_bigtable_app_profile_map(self) -> dict[str, str]:
+        profiles: dict[str, str] = {}
+        for raw_entry in self.spend_lease_bigtable_app_profiles.split(","):
+            entry = raw_entry.strip()
+            if not entry:
+                continue
+            region, separator, profile = entry.partition("=")
+            region = region.strip()
+            profile = profile.strip()
+            if not separator or not region or not profile:
+                raise ValueError(
+                    "TR_SPEND_LEASE_BIGTABLE_APP_PROFILES entries must be region=app-profile"
+                )
+            if region in profiles:
+                raise ValueError(
+                    "TR_SPEND_LEASE_BIGTABLE_APP_PROFILES contains a duplicate region"
                 )
             profiles[region] = profile
         return profiles

--- a/src/trusted_router/spend_lease_ledger.py
+++ b/src/trusted_router/spend_lease_ledger.py
@@ -1,0 +1,836 @@
+"""Durable, regional Bigtable adapter for the spend-lease state machine.
+
+The pure state machine owns every transition and its replay classification.
+This adapter owns only serialization and single-row compare-and-swap.  In
+particular, a typed replay is returned unchanged and never rewritten.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import secrets
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from time import sleep
+from typing import Any, Protocol, TypeVar, cast
+
+from trusted_router.spend_lease_state import (
+    AllocateResult,
+    AllocationState,
+    AuthorizationObservation,
+    AuthorizationOutcome,
+    AuthorizationView,
+    BindingAbsenceProof,
+    BindingState,
+    BindingTuple,
+    BoundProof,
+    ClaimProof,
+    CommittedRowAbsentProof,
+    ConflictingBound,
+    ConflictingClaim,
+    ContradictionProof,
+    Created,
+    LeaseAllocationTransition,
+    LeaseTransition,
+    RecoveryProof,
+    RowBindingMismatch,
+    SpendLease,
+    SpendLeaseAllocation,
+    SpendLeaseState,
+    TerminalSource,
+)
+
+_FAMILY = "lease"
+_STATE_COLUMN = b"state"
+_VERSION_COLUMN = b"version"
+_MAX_CAS_ATTEMPTS = 16
+_MAX_CAS_JITTER_SECONDS = 0.025
+_ISO_DURATION = re.compile(
+    r"^P(?:(?P<days>\d+)D)?T(?:(?P<hours>\d+)H)?"
+    r"(?:(?P<minutes>\d+)M)?(?P<seconds>\d+(?:\.\d{1,6})?)S$"
+)
+
+
+class SpendLeaseLedgerError(RuntimeError):
+    """The durable spend-lease ledger could not safely complete an operation."""
+
+
+class SpendLeaseNotFound(SpendLeaseLedgerError):
+    """The requested regional spend lease does not exist."""
+
+
+class SpendLeaseCasExhausted(SpendLeaseLedgerError):
+    """The spend-lease row did not converge within the bounded CAS attempts."""
+
+
+class SpendLeaseVersionError(SpendLeaseLedgerError):
+    """A pure transition attempted to reuse or skip a durable CAS version."""
+
+
+class SpendLeaseLedger(Protocol):
+    def supports_region(self, region: str) -> bool: ...
+
+    def initialize(self, candidate: SpendLease, *, region: str) -> LeaseTransition: ...
+
+    def get(self, lease_id: str, *, region: str) -> SpendLease | None: ...
+
+    def allocate(
+        self,
+        authorization_view: AuthorizationView | None,
+        lease_id: str,
+        *,
+        region: str,
+        idempotency_scope: str,
+        provisional_authorization_id: str,
+        request_fingerprint: str,
+        allocated_micro: int,
+        abandon_after: datetime,
+        now: datetime,
+    ) -> AllocateResult: ...
+
+    def bind(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        expected_provisional_id: str,
+        proof: BoundProof,
+    ) -> LeaseAllocationTransition: ...
+
+    def compensate(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        idempotency_scope: str,
+        expected_provisional_id: str,
+        claim: ClaimProof | RecoveryProof,
+        absence: BindingAbsenceProof,
+    ) -> LeaseAllocationTransition: ...
+
+    def abandon(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        idempotency_scope: str,
+        expected_provisional_id: str,
+        claim: ClaimProof,
+        absence: BindingAbsenceProof,
+        now: datetime,
+    ) -> LeaseAllocationTransition: ...
+
+    def mirror(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        observation: AuthorizationObservation,
+    ) -> LeaseAllocationTransition: ...
+
+    def lost(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        proof: CommittedRowAbsentProof,
+    ) -> LeaseAllocationTransition: ...
+
+    def quarantine(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        idempotency_scope: str,
+        proof: ContradictionProof,
+    ) -> LeaseAllocationTransition: ...
+
+    def begin_drain(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        now: datetime,
+    ) -> LeaseTransition: ...
+
+    def tombstone(self, lease_id: str, *, region: str) -> LeaseTransition: ...
+
+    def tombstone_unminted(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        proof: RecoveryProof,
+    ) -> LeaseTransition: ...
+
+    def close(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        now: datetime,
+    ) -> LeaseTransition: ...
+
+
+class _TransitionResult(Protocol):
+    @property
+    def lease(self) -> SpendLease: ...
+
+    @property
+    def replayed(self) -> bool: ...
+
+
+_ResultT = TypeVar("_ResultT", bound=_TransitionResult)
+
+
+class BigtableSpendLeaseLedger:
+    """One-row CAS ledger routed through fixed, regional app-profile tables."""
+
+    def __init__(self, tables_by_region: dict[str, Any]) -> None:
+        if not tables_by_region:
+            raise ValueError("at least one regional Bigtable table is required")
+        self._tables = dict(tables_by_region)
+        try:
+            from google.cloud.bigtable.row_filters import (
+                CellsColumnLimitFilter,
+                ColumnQualifierRegexFilter,
+                FamilyNameRegexFilter,
+                RowFilterChain,
+                ValueRegexFilter,
+            )
+        except ImportError as exc:  # pragma: no cover - production dependency
+            raise RuntimeError("google-cloud-bigtable is required") from exc
+        filter_factory = Callable[..., Any]
+        self._cells_limit_filter: Callable[..., Any] = cast(
+            filter_factory, CellsColumnLimitFilter
+        )
+        self._column_filter: Callable[..., Any] = cast(
+            filter_factory, ColumnQualifierRegexFilter
+        )
+        self._family_filter: Callable[..., Any] = cast(
+            filter_factory, FamilyNameRegexFilter
+        )
+        self._chain_filter: Callable[..., Any] = cast(filter_factory, RowFilterChain)
+        self._value_filter: Callable[..., Any] = cast(filter_factory, ValueRegexFilter)
+
+    def supports_region(self, region: str) -> bool:
+        return region in self._tables
+
+    def initialize(self, candidate: SpendLease, *, region: str) -> LeaseTransition:
+        """Create version zero, or classify an existing row through the pure layer."""
+
+        table = self._table(region)
+        row_key = _row_key_for(region, candidate.lease_id)
+        _assert_next_version(-1, candidate)
+        last_error: Exception | None = None
+        for attempt in range(_MAX_CAS_ATTEMPTS):
+            existing = self._read_lease(table, row_key)
+            if existing is not None:
+                return existing.initialize(candidate)
+
+            row = table.row(row_key, filter_=self._version_exists_filter())
+            row.set_cell(_FAMILY, _STATE_COLUMN, _serialize_lease(candidate), state=False)
+            row.set_cell(_FAMILY, _VERSION_COLUMN, _encode_version(candidate.version), state=False)
+            try:
+                matched = bool(row.commit())
+            except Exception as exc:  # pragma: no cover - remote transport
+                # A lost response may follow a durable false-branch mutation.
+                last_error = exc
+                self._jitter(attempt)
+                continue
+            if not matched:
+                return LeaseTransition(candidate, False)
+            # A surviving row matched. Re-read it rather than ever placing
+            # initialization mutations on the true branch.
+            self._jitter(attempt)
+        raise SpendLeaseCasExhausted(
+            "spend lease initialization CAS attempts were exhausted"
+        ) from last_error
+
+    def get(self, lease_id: str, *, region: str) -> SpendLease | None:
+        return self._read_lease(self._table(region), _row_key_for(region, lease_id))
+
+    def allocate(
+        self,
+        authorization_view: AuthorizationView | None,
+        lease_id: str,
+        *,
+        region: str,
+        idempotency_scope: str,
+        provisional_authorization_id: str,
+        request_fingerprint: str,
+        allocated_micro: int,
+        abandon_after: datetime,
+        now: datetime,
+    ) -> AllocateResult:
+        # The strong authorization view is deliberately supplied before the
+        # lease ID. This adapter performs no local-first convenience read.
+        return self._transition(
+            lease_id,
+            region=region,
+            transition=lambda lease: lease.allocate(
+                authorization_view=authorization_view,
+                idempotency_scope=idempotency_scope,
+                provisional_authorization_id=provisional_authorization_id,
+                request_fingerprint=request_fingerprint,
+                allocated_micro=allocated_micro,
+                abandon_after=abandon_after,
+                now=now,
+            ),
+            should_write=lambda result: isinstance(result, Created) and not result.replayed,
+        )
+
+    def bind(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        expected_provisional_id: str,
+        proof: BoundProof,
+    ) -> LeaseAllocationTransition:
+        return self._mutating_transition(
+            lease_id,
+            region=region,
+            transition=lambda lease: lease.bind(
+                expected_provisional_id=expected_provisional_id,
+                proof=proof,
+            ),
+        )
+
+    def compensate(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        idempotency_scope: str,
+        expected_provisional_id: str,
+        claim: ClaimProof | RecoveryProof,
+        absence: BindingAbsenceProof,
+    ) -> LeaseAllocationTransition:
+        return self._mutating_transition(
+            lease_id,
+            region=region,
+            transition=lambda lease: lease.compensate(
+                idempotency_scope=idempotency_scope,
+                expected_provisional_id=expected_provisional_id,
+                claim=claim,
+                absence=absence,
+            ),
+        )
+
+    def abandon(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        idempotency_scope: str,
+        expected_provisional_id: str,
+        claim: ClaimProof,
+        absence: BindingAbsenceProof,
+        now: datetime,
+    ) -> LeaseAllocationTransition:
+        return self._mutating_transition(
+            lease_id,
+            region=region,
+            transition=lambda lease: lease.abandon(
+                idempotency_scope=idempotency_scope,
+                expected_provisional_id=expected_provisional_id,
+                claim=claim,
+                absence=absence,
+                now=now,
+            ),
+        )
+
+    def mirror(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        observation: AuthorizationObservation,
+    ) -> LeaseAllocationTransition:
+        return self._mutating_transition(
+            lease_id,
+            region=region,
+            transition=lambda lease: lease.mirror(observation),
+        )
+
+    def lost(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        proof: CommittedRowAbsentProof,
+    ) -> LeaseAllocationTransition:
+        return self._mutating_transition(
+            lease_id,
+            region=region,
+            transition=lambda lease: lease.lost(proof),
+        )
+
+    def quarantine(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        idempotency_scope: str,
+        proof: ContradictionProof,
+    ) -> LeaseAllocationTransition:
+        return self._mutating_transition(
+            lease_id,
+            region=region,
+            transition=lambda lease: lease.quarantine(
+                idempotency_scope=idempotency_scope,
+                proof=proof,
+            ),
+        )
+
+    def begin_drain(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        now: datetime,
+    ) -> LeaseTransition:
+        return self._mutating_transition(
+            lease_id,
+            region=region,
+            transition=lambda lease: lease.begin_drain(now=now),
+        )
+
+    def tombstone(self, lease_id: str, *, region: str) -> LeaseTransition:
+        return self._mutating_transition(
+            lease_id,
+            region=region,
+            transition=SpendLease.tombstone,
+        )
+
+    def tombstone_unminted(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        proof: RecoveryProof,
+    ) -> LeaseTransition:
+        return self._mutating_transition(
+            lease_id,
+            region=region,
+            transition=lambda lease: lease.tombstone_unminted(proof),
+        )
+
+    def close(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        now: datetime,
+    ) -> LeaseTransition:
+        return self._mutating_transition(
+            lease_id,
+            region=region,
+            transition=lambda lease: lease.close(now=now),
+        )
+
+    def _mutating_transition(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        transition: Callable[[SpendLease], _ResultT],
+    ) -> _ResultT:
+        return self._transition(
+            lease_id,
+            region=region,
+            transition=transition,
+            should_write=lambda result: not result.replayed,
+        )
+
+    def _transition(
+        self,
+        lease_id: str,
+        *,
+        region: str,
+        transition: Callable[[SpendLease], _ResultT],
+        should_write: Callable[[_ResultT], bool],
+    ) -> _ResultT:
+        table = self._table(region)
+        row_key = _row_key_for(region, lease_id)
+        last_error: Exception | None = None
+        for attempt in range(_MAX_CAS_ATTEMPTS):
+            current = self._read_lease(table, row_key)
+            if current is None:
+                raise SpendLeaseNotFound("spend lease was not found")
+            result = transition(current)
+            if not should_write(result):
+                return result
+
+            updated = result.lease
+            _assert_next_version(current.version, updated)
+            row = table.row(
+                row_key,
+                filter_=self._version_equals_filter(_encode_version(current.version)),
+            )
+            row.set_cell(_FAMILY, _STATE_COLUMN, _serialize_lease(updated), state=True)
+            row.set_cell(_FAMILY, _VERSION_COLUMN, _encode_version(updated.version), state=True)
+            try:
+                if bool(row.commit()):
+                    return result
+            except Exception as exc:  # pragma: no cover - remote transport
+                # Ambiguous commits are classified by re-reading and invoking
+                # the same idempotent pure transition on the next attempt.
+                last_error = exc
+            self._jitter(attempt)
+        raise SpendLeaseCasExhausted(
+            "spend lease compare-and-swap attempts were exhausted"
+        ) from last_error
+
+    def _read_lease(self, table: Any, row_key: bytes) -> SpendLease | None:
+        try:
+            row = table.read_row(row_key, filter_=self._state_filter())
+            if row is None:
+                return None
+            state, stored_version = _state_and_version(row)
+            lease = _deserialize_lease(state)
+            if lease.version != stored_version:
+                raise ValueError("state version does not match the CAS version cell")
+            return lease
+        except SpendLeaseLedgerError:
+            raise
+        except Exception as exc:
+            # A corrupt or incomplete row is unavailable, never an absent row
+            # that a caller may safely recreate.
+            raise SpendLeaseLedgerError(
+                "spend lease row could not be deserialized; treating it as unavailable"
+            ) from exc
+
+    def _table(self, region: str) -> Any:
+        table = self._tables.get(region)
+        if table is None:
+            raise SpendLeaseLedgerError(
+                f"no fixed Bigtable app profile is configured for region {region}"
+            )
+        return table
+
+    def _version_exists_filter(self) -> Any:
+        return self._chain_filter(
+            [
+                self._family_filter(f"^{_FAMILY}$"),
+                self._column_filter(b"^version$"),
+                self._cells_limit_filter(1),
+            ]
+        )
+
+    def _version_equals_filter(self, version: bytes) -> Any:
+        # Bigtable GC is asynchronous. Select the newest version cell before
+        # matching its value so a retained historical cell cannot win a CAS.
+        return self._chain_filter(
+            [
+                self._family_filter(f"^{_FAMILY}$"),
+                self._column_filter(b"^version$"),
+                self._cells_limit_filter(1),
+                self._value_filter(b"^" + re.escape(version) + b"$"),
+            ]
+        )
+
+    def _state_filter(self) -> Any:
+        return self._chain_filter(
+            [
+                self._family_filter(f"^{_FAMILY}$"),
+                self._column_filter(b"^(state|version)$"),
+                self._cells_limit_filter(1),
+            ]
+        )
+
+    @staticmethod
+    def _jitter(attempt: int) -> None:
+        ceiling = min(_MAX_CAS_JITTER_SECONDS, 0.001 * (2**attempt))
+        sleep(ceiling * secrets.randbelow(1_000_001) / 1_000_000)
+
+
+def _row_key_for(region: str, lease_id: str) -> bytes:
+    spread = hashlib.sha256(lease_id.encode("utf-8")).hexdigest()[:4]
+    return f"{spread}#spend#{region}#{lease_id}".encode()
+
+
+def _assert_next_version(old_version: int, updated: SpendLease) -> None:
+    expected = old_version + 1
+    if updated.version != expected:
+        raise SpendLeaseVersionError(
+            f"spend lease transition produced version {updated.version}; expected {expected}"
+        )
+
+
+def _encode_version(version: int) -> bytes:
+    if version < 0:
+        raise SpendLeaseVersionError("spend lease CAS version cannot be negative")
+    return str(version).encode("ascii")
+
+
+def _serialize_lease(lease: SpendLease) -> bytes:
+    payload = {
+        "allocations": [_serialize_allocation(allocation) for allocation in lease.allocations],
+        "boot_kid": lease.boot_kid,
+        "cap_micro": lease.cap_micro,
+        "creating_authorization_id": lease.creating_authorization_id,
+        "expires_at": lease.expires_at.astimezone(UTC).isoformat(),
+        "gen": lease.gen,
+        "key_hash": lease.key_hash,
+        "lease_id": lease.lease_id,
+        "skew": _serialize_duration(lease.skew),
+        "state": lease.state.value,
+        "tombstoned_unminted": lease.tombstoned_unminted,
+        "version": lease.version,
+        "workspace_id": lease.workspace_id,
+    }
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _serialize_allocation(allocation: SpendLeaseAllocation) -> dict[str, object]:
+    return {
+        "abandon_after": allocation.abandon_after.astimezone(UTC).isoformat(),
+        "actual_micro": allocation.actual_micro,
+        "allocated_micro": allocation.allocated_micro,
+        "authorization_id": allocation.authorization_id,
+        "authorization_outcome": (
+            None
+            if allocation.authorization_outcome is None
+            else allocation.authorization_outcome.value
+        ),
+        "binding_state": allocation.binding_state.value,
+        "contradiction_proof": _serialize_contradiction(allocation.contradiction_proof),
+        "gen": allocation.gen,
+        "idempotency_scope": allocation.idempotency_scope,
+        "key_hash": allocation.key_hash,
+        "lease_id": allocation.lease_id,
+        "request_fingerprint": allocation.request_fingerprint,
+        "state": allocation.state.value,
+        "terminal_source": (
+            None if allocation.terminal_source is None else allocation.terminal_source.value
+        ),
+        "workspace_id": allocation.workspace_id,
+    }
+
+
+def _serialize_contradiction(proof: ContradictionProof | None) -> dict[str, object] | None:
+    if proof is None:
+        return None
+    if isinstance(proof, ConflictingBound):
+        return {
+            "authorization_id": proof.authorization_id,
+            "observed_tuple": _serialize_binding(proof.observed_tuple),
+            "type": "conflicting_bound",
+        }
+    if isinstance(proof, ConflictingClaim):
+        return {"provisional_id": proof.provisional_id, "type": "conflicting_claim"}
+    return {
+        "authorization_id": proof.authorization_id,
+        "observed_tuple_or_absent": (
+            None
+            if proof.observed_tuple_or_absent is None
+            else _serialize_binding(proof.observed_tuple_or_absent)
+        ),
+        "type": "row_binding_mismatch",
+    }
+
+
+def _serialize_binding(binding: BindingTuple) -> dict[str, object]:
+    return {
+        "allocated_micro": binding.allocated_micro,
+        "gen": binding.gen,
+        "lease_id": binding.lease_id,
+    }
+
+
+def _deserialize_lease(value: bytes) -> SpendLease:
+    payload = _object(json.loads(value.decode("utf-8")), "lease")
+    allocations_value = payload["allocations"]
+    if not isinstance(allocations_value, list):
+        raise ValueError("allocations must be a list")
+    return SpendLease(
+        lease_id=_string(payload, "lease_id"),
+        gen=_integer(payload, "gen"),
+        key_hash=_string(payload, "key_hash"),
+        boot_kid=_string(payload, "boot_kid"),
+        workspace_id=_string(payload, "workspace_id"),
+        creating_authorization_id=_string(payload, "creating_authorization_id"),
+        cap_micro=_integer(payload, "cap_micro"),
+        expires_at=datetime.fromisoformat(_string(payload, "expires_at")),
+        skew=_deserialize_duration(_string(payload, "skew")),
+        version=_integer(payload, "version"),
+        state=SpendLeaseState(_string(payload, "state")),
+        allocations=tuple(_deserialize_allocation(item) for item in allocations_value),
+        tombstoned_unminted=_boolean(payload, "tombstoned_unminted"),
+    )
+
+
+def _deserialize_allocation(value: object) -> SpendLeaseAllocation:
+    payload = _object(value, "allocation")
+    binding_state = BindingState(_string(payload, "binding_state"))
+    lease_id = _string(payload, "lease_id")
+    gen = _integer(payload, "gen")
+    allocated_micro = _integer(payload, "allocated_micro")
+    authorization_id = _string(payload, "authorization_id")
+    idempotency_scope = _string(payload, "idempotency_scope")
+    bound_proof = (
+        BoundProof(
+            idempotency_scope=idempotency_scope,
+            authorization_id=authorization_id,
+            lease_id=lease_id,
+            gen=gen,
+            allocated_micro=allocated_micro,
+        )
+        if binding_state == BindingState.COMMITTED
+        else None
+    )
+    return SpendLeaseAllocation(
+        idempotency_scope=idempotency_scope,
+        authorization_id=authorization_id,
+        request_fingerprint=_string(payload, "request_fingerprint"),
+        lease_id=lease_id,
+        gen=gen,
+        allocated_micro=allocated_micro,
+        abandon_after=datetime.fromisoformat(_string(payload, "abandon_after")),
+        key_hash=_string(payload, "key_hash"),
+        workspace_id=_string(payload, "workspace_id"),
+        binding_state=binding_state,
+        actual_micro=_optional_integer(payload, "actual_micro"),
+        state=AllocationState(_string(payload, "state")),
+        terminal_source=_optional_enum(payload, "terminal_source", TerminalSource),
+        authorization_outcome=_optional_enum(
+            payload,
+            "authorization_outcome",
+            AuthorizationOutcome,
+        ),
+        contradiction_proof=_deserialize_contradiction(payload["contradiction_proof"]),
+        bound_proof=bound_proof,
+    )
+
+
+def _deserialize_contradiction(value: object) -> ContradictionProof | None:
+    if value is None:
+        return None
+    payload = _object(value, "contradiction_proof")
+    discriminator = _string(payload, "type")
+    if discriminator == "conflicting_bound":
+        return ConflictingBound(
+            authorization_id=_string(payload, "authorization_id"),
+            observed_tuple=_deserialize_binding(payload["observed_tuple"]),
+        )
+    if discriminator == "conflicting_claim":
+        return ConflictingClaim(provisional_id=_string(payload, "provisional_id"))
+    if discriminator == "row_binding_mismatch":
+        observed = payload["observed_tuple_or_absent"]
+        return RowBindingMismatch(
+            authorization_id=_string(payload, "authorization_id"),
+            observed_tuple_or_absent=(
+                None if observed is None else _deserialize_binding(observed)
+            ),
+        )
+    raise ValueError(f"unknown contradiction_proof discriminator {discriminator!r}")
+
+
+def _deserialize_binding(value: object) -> BindingTuple:
+    payload = _object(value, "binding")
+    return BindingTuple(
+        lease_id=_string(payload, "lease_id"),
+        gen=_integer(payload, "gen"),
+        allocated_micro=_integer(payload, "allocated_micro"),
+    )
+
+
+def _serialize_duration(value: timedelta) -> str:
+    total_microseconds = (
+        value.days * 86_400_000_000 + value.seconds * 1_000_000 + value.microseconds
+    )
+    if total_microseconds < 0:
+        raise ValueError("duration cannot be negative")
+    days, remainder = divmod(total_microseconds, 86_400_000_000)
+    hours, remainder = divmod(remainder, 3_600_000_000)
+    minutes, remainder = divmod(remainder, 60_000_000)
+    seconds, microseconds = divmod(remainder, 1_000_000)
+    seconds_text = str(seconds)
+    if microseconds:
+        seconds_text += f".{microseconds:06d}".rstrip("0")
+    day_text = f"{days}D" if days else ""
+    hour_text = f"{hours}H" if hours else ""
+    minute_text = f"{minutes}M" if minutes else ""
+    return f"P{day_text}T{hour_text}{minute_text}{seconds_text}S"
+
+
+def _deserialize_duration(value: str) -> timedelta:
+    match = _ISO_DURATION.fullmatch(value)
+    if match is None:
+        raise ValueError("skew must be an ISO-8601 duration")
+    seconds_text = match.group("seconds")
+    whole_seconds_text, separator, fraction = seconds_text.partition(".")
+    microseconds = int(fraction.ljust(6, "0")) if separator else 0
+    return timedelta(
+        days=int(match.group("days") or 0),
+        hours=int(match.group("hours") or 0),
+        minutes=int(match.group("minutes") or 0),
+        seconds=int(whole_seconds_text),
+        microseconds=microseconds,
+    )
+
+
+def _object(value: object, field: str) -> dict[str, object]:
+    if not isinstance(value, dict) or not all(isinstance(key, str) for key in value):
+        raise ValueError(f"{field} must be an object with string keys")
+    return cast(dict[str, object], value)
+
+
+def _string(payload: dict[str, object], field: str) -> str:
+    value = payload[field]
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a string")
+    return value
+
+
+def _integer(payload: dict[str, object], field: str) -> int:
+    value = payload[field]
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field} must be an integer")
+    return value
+
+
+def _optional_integer(payload: dict[str, object], field: str) -> int | None:
+    value = payload[field]
+    if value is None:
+        return None
+    return _integer(payload, field)
+
+
+def _boolean(payload: dict[str, object], field: str) -> bool:
+    value = payload[field]
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a boolean")
+    return value
+
+
+_EnumT = TypeVar("_EnumT", bound=str)
+
+
+def _optional_enum(
+    payload: dict[str, object],
+    field: str,
+    enum_type: Callable[[str], _EnumT],
+) -> _EnumT | None:
+    value = payload[field]
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a string or null")
+    return enum_type(value)
+
+
+def _state_and_version(row: Any) -> tuple[bytes, int]:
+    try:
+        family = row.cells[_FAMILY]
+        state = bytes(family[_STATE_COLUMN][0].value)
+        version_raw = bytes(family[_VERSION_COLUMN][0].value)
+        if not version_raw or not version_raw.isdigit():
+            raise ValueError("version cell must be a non-negative decimal integer")
+        return state, int(version_raw)
+    except (KeyError, IndexError, TypeError, AttributeError, ValueError) as exc:
+        raise SpendLeaseLedgerError("spend lease row is incomplete or corrupt") from exc

--- a/tests/test_cloud_sdk_boundary.py
+++ b/tests/test_cloud_sdk_boundary.py
@@ -47,6 +47,8 @@ ALLOWED = {
     "storage_gcp_synthetic_index.py",
     # Fixed-cluster Bigtable CAS implementation of the regional storage port.
     "regional_quota_ledger.py",
+    # Fixed-cluster Bigtable CAS implementation of the spend-lease storage port.
+    "spend_lease_ledger.py",
     # The two explicit cloud ports. Both import lazily so a non-GCP deployment
     # need not install the Google libraries at all.
     "storage_errors.py",

--- a/tests/test_spend_lease_ledger.py
+++ b/tests/test_spend_lease_ledger.py
@@ -1,0 +1,541 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from google.cloud.bigtable.row_filters import ValueRegexFilter
+
+import trusted_router.spend_lease_ledger as ledger_module
+from trusted_router.config import Settings
+from trusted_router.spend_lease_ledger import (
+    BigtableSpendLeaseLedger,
+    SpendLeaseCasExhausted,
+    SpendLeaseLedgerError,
+    SpendLeaseVersionError,
+)
+from trusted_router.spend_lease_state import (
+    AbsenceObservation,
+    AllocationState,
+    AuthorizationDurability,
+    AuthorizationObservation,
+    BindingAbsenceProof,
+    BoundProof,
+    ClaimProof,
+    ClosedLeaseReplay,
+    Created,
+    ExistingLocal,
+    FinalizationOutcome,
+    Mismatch,
+    RecoveryProof,
+    SpendLease,
+    SpendLeaseAllocation,
+    TrueReplay,
+    UnboundExisting,
+)
+
+NOW = datetime(2026, 8, 29, tzinfo=UTC)
+REGION = "us-central1"
+
+
+def _candidate() -> SpendLease:
+    return SpendLease(
+        lease_id="spend-lease-test",
+        gen=4,
+        key_hash="key-hash",
+        boot_kid="boot-kid",
+        workspace_id="workspace-test",
+        creating_authorization_id="creator-auth",
+        cap_micro=10_000,
+        expires_at=NOW + timedelta(minutes=1),
+        skew=timedelta(seconds=10),
+        version=0,
+    )
+
+
+def _allocation() -> SpendLeaseAllocation:
+    return SpendLeaseAllocation(
+        idempotency_scope="scope-1",
+        authorization_id="provisional-1",
+        request_fingerprint="fingerprint-1",
+        lease_id="spend-lease-test",
+        gen=4,
+        allocated_micro=500,
+        abandon_after=NOW + timedelta(minutes=2),
+        key_hash="key-hash",
+        workspace_id="workspace-test",
+    )
+
+
+def _allocate(ledger: BigtableSpendLeaseLedger) -> Created:
+    result = ledger.allocate(
+        None,
+        "spend-lease-test",
+        region=REGION,
+        idempotency_scope="scope-1",
+        provisional_authorization_id="provisional-1",
+        request_fingerprint="fingerprint-1",
+        allocated_micro=500,
+        abandon_after=NOW + timedelta(minutes=2),
+        now=NOW,
+    )
+    assert isinstance(result, Created)
+    return result
+
+
+def test_allocate_created_writes_decision_33_row_at_version_one() -> None:
+    table = _FakeBigtableTable()
+    ledger = BigtableSpendLeaseLedger({REGION: table})
+    ledger.initialize(_candidate(), region=REGION)
+
+    result = _allocate(ledger)
+
+    spread = hashlib.sha256(b"spend-lease-test").hexdigest()[:4]
+    expected_key = f"{spread}#spend#{REGION}#spend-lease-test".encode()
+    assert result.replayed is False
+    assert set(table.rows) == {expected_key}
+    assert table.rows[expected_key][b"version"] == b"1"
+    assert ledger.get("spend-lease-test", region=REGION) == result.lease
+
+
+@pytest.mark.parametrize(
+    "result_kind",
+    [
+        "true_replay",
+        "existing_local",
+        "mismatch",
+        "unbound_existing",
+        "closed_lease_replay",
+        "created_replayed",
+    ],
+)
+def test_allocate_replay_results_write_nothing(
+    result_kind: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    table = _FakeBigtableTable()
+    ledger = BigtableSpendLeaseLedger({REGION: table})
+    ledger.initialize(_candidate(), region=REGION)
+    allocation = _allocation()
+    carried_lease = replace(_candidate(), allocations=(allocation,), version=1)
+    results = {
+        "true_replay": TrueReplay(carried_lease, allocation, True),
+        "existing_local": ExistingLocal(carried_lease, allocation, True),
+        # Mismatch is intentionally non-replayed but still carries no new record.
+        "mismatch": Mismatch(carried_lease, "other-authorization"),
+        "unbound_existing": UnboundExisting(carried_lease, "other-authorization"),
+        "closed_lease_replay": ClosedLeaseReplay(carried_lease, "other-authorization"),
+        "created_replayed": Created(
+            carried_lease,
+            allocation,
+            True,
+            provisional_id="provisional-1",
+        ),
+    }
+    expected = results[result_kind]
+
+    def classified_result(_self: SpendLease, **_kwargs: Any) -> Any:
+        return expected
+
+    monkeypatch.setattr(SpendLease, "allocate", classified_result)
+    commits_before = table.commit_attempts
+
+    actual = ledger.allocate(
+        None,
+        "spend-lease-test",
+        region=REGION,
+        idempotency_scope="scope-1",
+        provisional_authorization_id="provisional-1",
+        request_fingerprint="fingerprint-1",
+        allocated_micro=500,
+        abandon_after=NOW + timedelta(minutes=2),
+        now=NOW,
+    )
+
+    assert actual is expected
+    assert table.commit_attempts == commits_before
+    assert ledger.get("spend-lease-test", region=REGION) == _candidate()
+
+
+def test_transition_refuses_skipped_version_without_writing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    table = _FakeBigtableTable()
+    ledger = BigtableSpendLeaseLedger({REGION: table})
+    ledger.initialize(_candidate(), region=REGION)
+    allocation = _allocation()
+    skipped = replace(_candidate(), allocations=(allocation,), version=2)
+    crafted = Created(skipped, allocation, False, provisional_id="provisional-1")
+
+    def skipped_result(_self: SpendLease, **_kwargs: Any) -> Created:
+        return crafted
+
+    monkeypatch.setattr(SpendLease, "allocate", skipped_result)
+    commits_before = table.commit_attempts
+
+    with pytest.raises(SpendLeaseVersionError, match="expected 1"):
+        _allocate(ledger)
+
+    assert table.commit_attempts == commits_before
+    assert ledger.get("spend-lease-test", region=REGION) == _candidate()
+
+
+def test_initialize_surviving_row_never_resets_state() -> None:
+    table = _FakeBigtableTable()
+    ledger = BigtableSpendLeaseLedger({REGION: table})
+    candidate = _candidate()
+    ledger.initialize(candidate, region=REGION)
+    allocated = _allocate(ledger).lease
+    commits_before = table.commit_attempts
+
+    replay = ledger.initialize(candidate, region=REGION)
+
+    assert replay.replayed is True
+    assert replay.lease == allocated
+    assert table.commit_attempts == commits_before
+    assert ledger.get("spend-lease-test", region=REGION) == allocated
+
+
+def test_ambiguous_commit_that_landed_rereads_as_replay_without_second_write() -> None:
+    table = _FakeBigtableTable()
+    ledger = BigtableSpendLeaseLedger({REGION: table})
+    ledger.initialize(_candidate(), region=REGION)
+    table.raise_after_next_applied_commit = True
+    commits_before = table.commit_attempts
+
+    result = _allocate(ledger)
+
+    assert result.replayed is True
+    assert table.commit_attempts == commits_before + 1
+    assert ledger.get("spend-lease-test", region=REGION) == result.lease
+    assert result.lease.version == 1
+
+
+@pytest.mark.parametrize("transition_name", ["compensate", "bind", "tombstone_unminted"])
+def test_replayed_mutating_transition_is_write_free(transition_name: str) -> None:
+    table = _FakeBigtableTable()
+    ledger = BigtableSpendLeaseLedger({REGION: table})
+    ledger.initialize(_candidate(), region=REGION)
+
+    if transition_name in {"compensate", "bind"}:
+        _allocate(ledger)
+
+    if transition_name == "compensate":
+        claim = ClaimProof("scope-1", "provisional-1")
+        absence = BindingAbsenceProof(
+            "scope-1",
+            "provisional-1",
+            AbsenceObservation.ABSENT_ROW,
+        )
+
+        def apply_transition() -> Any:
+            return ledger.compensate(
+                "spend-lease-test",
+                region=REGION,
+                idempotency_scope="scope-1",
+                expected_provisional_id="provisional-1",
+                claim=claim,
+                absence=absence,
+            )
+
+    elif transition_name == "bind":
+        proof = BoundProof(
+            idempotency_scope="scope-1",
+            authorization_id="authorization-1",
+            lease_id="spend-lease-test",
+            gen=4,
+            allocated_micro=500,
+        )
+
+        def apply_transition() -> Any:
+            return ledger.bind(
+                "spend-lease-test",
+                region=REGION,
+                expected_provisional_id="provisional-1",
+                proof=proof,
+            )
+
+    else:
+        proof = RecoveryProof(
+            recovering_at=NOW,
+            creating_authorization_id="creator-auth",
+        )
+
+        def apply_transition() -> Any:
+            return ledger.tombstone_unminted(
+                "spend-lease-test",
+                region=REGION,
+                proof=proof,
+            )
+
+    commits_before = table.commit_attempts
+    first = apply_transition()
+    row = next(iter(table.rows.values()))
+    stored_version_after_first = row[b"version"]
+    stored_state_after_first = row[b"state"]
+
+    replay = apply_transition()
+
+    assert first.replayed is False
+    assert replay.replayed is True
+    assert table.commit_attempts == commits_before + 1
+    assert row[b"version"] == stored_version_after_first
+    assert row[b"state"] == stored_state_after_first
+    assert replay.lease.version == first.lease.version
+
+
+def test_corrupt_stored_json_raises_ledger_error_not_decoder_error() -> None:
+    table = _FakeBigtableTable()
+    ledger = BigtableSpendLeaseLedger({REGION: table})
+    ledger.initialize(_candidate(), region=REGION)
+    row = next(iter(table.rows.values()))
+    row[b"state"] = b"{not-json"
+    commits_before = table.commit_attempts
+
+    with pytest.raises(SpendLeaseLedgerError) as raised:
+        ledger.get("spend-lease-test", region=REGION)
+
+    assert not isinstance(raised.value, ValueError)
+    assert table.commit_attempts == commits_before
+
+
+@pytest.mark.parametrize(
+    "corruption",
+    [
+        "missing_required_key",
+        "unknown_lease_state",
+        "invalid_expires_at",
+        "invalid_duration",
+        "unknown_contradiction_discriminator",
+    ],
+)
+def test_get_treats_structurally_invalid_json_as_no_lease(corruption: str) -> None:
+    table = _FakeBigtableTable()
+    ledger = BigtableSpendLeaseLedger({REGION: table})
+    ledger.initialize(_candidate(), region=REGION)
+    _allocate(ledger)
+    row = next(iter(table.rows.values()))
+    payload = json.loads(row[b"state"])
+
+    if corruption == "missing_required_key":
+        del payload["lease_id"]
+    elif corruption == "unknown_lease_state":
+        payload["state"] = "future_state"
+    elif corruption == "invalid_expires_at":
+        payload["expires_at"] = "not-an-iso-datetime"
+    elif corruption == "invalid_duration":
+        payload["skew"] = "not-an-iso-duration"
+    else:
+        payload["allocations"][0]["contradiction_proof"] = {"type": "future_proof"}
+
+    row[b"state"] = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    assert json.loads(row[b"state"]) == payload
+    commits_before = table.commit_attempts
+
+    with pytest.raises(SpendLeaseLedgerError) as raised:
+        ledger.get("spend-lease-test", region=REGION)
+
+    assert not isinstance(raised.value, (KeyError, ValueError, TypeError))
+    assert table.commit_attempts == commits_before
+
+
+def test_get_treats_incomplete_bigtable_row_as_no_lease() -> None:
+    table = _FakeBigtableTable()
+    ledger = BigtableSpendLeaseLedger({REGION: table})
+    ledger.initialize(_candidate(), region=REGION)
+    row = next(iter(table.rows.values()))
+    assert json.loads(row[b"state"])["lease_id"] == "spend-lease-test"
+    del row[b"version"]
+    commits_before = table.commit_attempts
+
+    with pytest.raises(SpendLeaseLedgerError) as decoder_error:
+        ledger_module._state_and_version(_ReadRow(row))
+
+    with pytest.raises(SpendLeaseLedgerError) as raised:
+        ledger.get("spend-lease-test", region=REGION)
+
+    assert not isinstance(decoder_error.value, (KeyError, ValueError, TypeError))
+    assert not isinstance(raised.value, (KeyError, ValueError, TypeError))
+    assert table.commit_attempts == commits_before
+
+
+def test_cas_exhaustion_stops_after_sixteen_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    table = _FakeBigtableTable()
+    ledger = BigtableSpendLeaseLedger({REGION: table})
+    ledger.initialize(_candidate(), region=REGION)
+    table.force_cas_misses = True
+    monkeypatch.setattr(ledger_module, "sleep", lambda _seconds: None)
+    commits_before = table.commit_attempts
+
+    with pytest.raises(SpendLeaseCasExhausted):
+        _allocate(ledger)
+
+    assert table.commit_attempts - commits_before == 16
+    assert ledger.get("spend-lease-test", region=REGION) == _candidate()
+
+
+def test_unknown_region_raises_typed_error_naming_region() -> None:
+    ledger = BigtableSpendLeaseLedger({REGION: _FakeBigtableTable()})
+
+    with pytest.raises(SpendLeaseLedgerError, match="europe-west4"):
+        ledger.get("spend-lease-test", region="europe-west4")
+
+
+def test_canonical_encoding_synthesizes_bound_proof_on_read() -> None:
+    table = _FakeBigtableTable()
+    ledger = BigtableSpendLeaseLedger({REGION: table})
+    ledger.initialize(_candidate(), region=REGION)
+    _allocate(ledger)
+    proof = BoundProof(
+        idempotency_scope="scope-1",
+        authorization_id="authorization-1",
+        lease_id="spend-lease-test",
+        gen=4,
+        allocated_micro=500,
+    )
+    bound = ledger.bind(
+        "spend-lease-test",
+        region=REGION,
+        expected_provisional_id="provisional-1",
+        proof=proof,
+    )
+
+    # A read reconstructs the InitVar proof from the committed allocation's
+    # stored binding fields, so a later proof-requiring transition succeeds.
+    assert ledger.get("spend-lease-test", region=REGION) == bound.lease
+    mirrored = ledger.mirror(
+        "spend-lease-test",
+        region=REGION,
+        observation=AuthorizationObservation(
+            idempotency_scope="scope-1",
+            authorization_id="authorization-1",
+            request_fingerprint="fingerprint-1",
+            lease_id="spend-lease-test",
+            gen=4,
+            allocated_micro=500,
+            key_hash="key-hash",
+            workspace_id="workspace-test",
+            durability=AuthorizationDurability.TERMINAL,
+            finalization_outcome=FinalizationOutcome.SETTLED,
+            finalized_cost_microdollars=275,
+        ),
+    )
+
+    assert mirrored.allocation.state == AllocationState.SETTLED
+    stored_state = next(iter(table.rows.values()))[b"state"]
+    payload = json.loads(stored_state)
+    assert payload["skew"] == "PT10S"
+    assert stored_state == json.dumps(
+        payload,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+
+
+def test_spend_lease_bigtable_settings_parse_fixed_profiles() -> None:
+    settings = Settings(
+        environment="test",
+        spend_lease_bigtable_app_profiles=(
+            "us-central1=spend-us,europe-west4=spend-eu"
+        ),
+    )
+
+    assert settings.spend_lease_bigtable_table == "trustedrouter-spend-lease"
+    assert settings.spend_lease_bigtable_app_profile_map == {
+        "us-central1": "spend-us",
+        "europe-west4": "spend-eu",
+    }
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["missing-separator", "=profile", "region=", "region=a,region=b"],
+)
+def test_spend_lease_profile_map_rejects_ambiguous_entries(value: str) -> None:
+    with pytest.raises(ValueError, match="TR_SPEND_LEASE_BIGTABLE_APP_PROFILES"):
+        _ = Settings(
+            environment="test",
+            spend_lease_bigtable_app_profiles=value,
+        ).spend_lease_bigtable_app_profile_map
+
+
+@dataclass
+class _Cell:
+    value: bytes
+
+
+class _ReadRow:
+    def __init__(self, values: dict[bytes, bytes]) -> None:
+        self.cells = {
+            "lease": {qualifier: [_Cell(value)] for qualifier, value in values.items()}
+        }
+
+
+class _FakeConditionalRow:
+    def __init__(self, table: _FakeBigtableTable, row_key: bytes, filter_: Any) -> None:
+        self.table = table
+        self.row_key = row_key
+        self.filter = filter_
+        self.mutations: list[tuple[bool, bytes, bytes]] = []
+
+    def set_cell(
+        self,
+        _family: str,
+        column: bytes,
+        value: bytes,
+        *,
+        state: bool,
+    ) -> None:
+        self.mutations.append((state, column, value))
+
+    def commit(self) -> bool:
+        self.table.commit_attempts += 1
+        current = self.table.rows.get(self.row_key)
+        regex_filter = next(
+            (
+                candidate
+                for candidate in self.filter.filters
+                if isinstance(candidate, ValueRegexFilter)
+            ),
+            None,
+        )
+        if regex_filter is None:
+            matched = current is not None and b"version" in current
+        else:
+            expected = regex_filter.regex.removeprefix(b"^").removesuffix(b"$")
+            matched = (
+                not self.table.force_cas_misses
+                and current is not None
+                and re.fullmatch(expected, current.get(b"version", b"")) is not None
+            )
+        selected = [mutation for mutation in self.mutations if mutation[0] == matched]
+        if selected:
+            values = self.table.rows.setdefault(self.row_key, {})
+            for _state, column, value in selected:
+                values[column] = value
+        if self.table.raise_after_next_applied_commit and selected:
+            self.table.raise_after_next_applied_commit = False
+            raise TimeoutError("reply lost after durable apply")
+        return matched
+
+
+class _FakeBigtableTable:
+    def __init__(self) -> None:
+        self.rows: dict[bytes, dict[bytes, bytes]] = {}
+        self.commit_attempts = 0
+        self.force_cas_misses = False
+        self.raise_after_next_applied_commit = False
+
+    def row(self, row_key: bytes, *, filter_: Any) -> _FakeConditionalRow:
+        return _FakeConditionalRow(self, row_key, filter_)
+
+    def read_row(self, row_key: bytes, *, filter_: Any) -> _ReadRow | None:
+        del filter_
+        values = self.rows.get(row_key)
+        return None if values is None else _ReadRow(values)


### PR DESCRIPTION
Third unit-2 PR of the spend-lease program, part (a): the inert local ledger (design record v49, decisions 32–34 and 42). No callers, no gateway or storage wiring, no flag.

- `spend_lease_ledger.py`: result-type-aware ledger over the pure state machine — each method wraps one unit-1 transition and writes only when the result carries a new record; every replay class and every `replayed=True` result writes nothing and passes through intact.
- Decision-33 row: `f"{spread}#spend#{region}#{lease_id}"`, one version cell, CAS on the record's own monotonic integer version, every write asserting `new.version == old.version + 1`, sixteen bounded-jitter attempts, ambiguous commits re-read and classified through the pure layer.
- Canonical JSON with a discriminator for the contradiction-proof union; every deserialization failure is wrapped into the ledger's error type and fails closed to no lease.
- Settings `spend_lease_bigtable_table` / `spend_lease_bigtable_app_profiles`; cloud-SDK boundary allowlist registration.

Review: isolated snapshot; scope limited to the module, its tests, `config.py`, and the boundary allowlist; ruff; mypy --strict; 28 tests; seven mutations each red (version old+1, allocate replay gate, transition replay gate, CAS bound, incomplete-record wrapper, row-key spread, duplicate-region rejection). Two of those were coverage gaps found by review and closed before this PR.

Written by codex; reviewed by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)