### PR TITLE
spend-lease: Spanner data-access layer for arbitration and open-work rows (decisions 24–27, 35, 46)

### DIFF
--- a/src/trusted_router/spend_leases.py
+++ b/src/trusted_router/spend_leases.py
@@ -66,6 +66,12 @@ SpendLeaseEligibilityFailure = Literal[
 ]
 
 
+def spend_lease_scope_salt(idempotency_scope: str) -> str:
+    """Return the stable four-hex-character Spanner arbitration key prefix."""
+
+    return hashlib.sha256(idempotency_scope.encode("utf-8")).hexdigest()[:4]
+
+
 @dataclass(frozen=True)
 class SpendLeaseBoot:
     kid: str

--- a/src/trusted_router/storage_gcp_spend_lease.py
+++ b/src/trusted_router/storage_gcp_spend_lease.py
@@ -1,0 +1,597 @@
+"""Inert native-Spanner data access for spend-lease unit 2.
+
+This module contains only statement-sized persistence primitives.  It does not
+select protocol outcomes, run recovery, consume feature flags, or participate
+in the gateway path.  Callers own transaction boundaries and interpret every
+returned modified-row count.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from trusted_router import spend_leases
+from trusted_router.spend_lease_state import BindingTuple
+
+RegistrationKind = Literal["BOUND", "CLAIM"]
+OpenPhase = Literal["candidate", "recovering", "open", "done"]
+
+AUTHORIZATION_TYPED_COLUMNS = (
+    "spend_lease_id",
+    "spend_lease_gen",
+    "spend_lease_allocated_micro",
+    "spend_lease_token",
+    "spend_lease_status",
+    "spend_lease_exp",
+    "idempotency_fingerprint",
+    "finalization_outcome",
+    "finalized_cost_microdollars",
+)
+
+ARBITRATION_COLUMNS = (
+    "registration_kind",
+    "authorization_id",
+    "spend_lease_id",
+    "spend_lease_gen",
+    "spend_lease_allocated_micro",
+    "provisional_id",
+)
+
+OPEN_COLUMNS = (
+    "lease_id",
+    "phase",
+    "gen",
+    "key_hash",
+    "boot_kid",
+    "cap_micro",
+    "skew_seconds",
+    "workspace_id",
+    "region",
+    "creating_authorization_id",
+    "idempotency_scope",
+    "expires_at",
+    "next_attempt_at",
+    "attempts",
+    "last_error",
+    "dead",
+    "close_eligible_since",
+    "global_closed_at",
+    "local_closed_at",
+    "recovering_at",
+    "created_at",
+)
+
+
+class SpendLeaseDataError(ValueError):
+    """A persisted spend-lease value violates the unit-2 storage contract."""
+
+
+class SpendLeaseDmlError(RuntimeError):
+    """A primary-key DML statement returned an impossible modified-row count."""
+
+
+@dataclass(frozen=True, slots=True)
+class Registration:
+    """The sole arbitration registration for one idempotency scope."""
+
+    kind: RegistrationKind
+    authorization_id: str | None
+    lease: BindingTuple | None
+    provisional_id: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateIdentity:
+    """Immutable identity persisted before any candidate-local write."""
+
+    lease_id: str
+    gen: int
+    key_hash: str
+    boot_kid: str
+    cap_micro: int
+    skew_seconds: int
+    workspace_id: str
+    region: str
+    creating_authorization_id: str
+    idempotency_scope: str
+    expires_at: Any
+
+    def __post_init__(self) -> None:
+        required = (
+            self.lease_id,
+            self.key_hash,
+            self.boot_kid,
+            self.workspace_id,
+            self.region,
+            self.creating_authorization_id,
+            self.idempotency_scope,
+        )
+        if not all(required):
+            raise SpendLeaseDataError("candidate identity fields must be non-empty")
+        if self.gen <= 0 or self.cap_micro <= 0 or self.skew_seconds < 0:
+            raise SpendLeaseDataError(
+                "candidate gen and cap must be positive and skew must be non-negative"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class OpenRow:
+    """Full durable spend-lease work row, including recovery ownership proof."""
+
+    lease_id: str
+    phase: OpenPhase
+    gen: int
+    key_hash: str
+    boot_kid: str
+    cap_micro: int
+    skew_seconds: int
+    workspace_id: str
+    region: str
+    creating_authorization_id: str
+    idempotency_scope: str
+    expires_at: Any
+    next_attempt_at: Any | None
+    attempts: int
+    last_error: str | None
+    dead: bool
+    close_eligible_since: Any | None
+    global_closed_at: Any | None
+    local_closed_at: Any | None
+    recovering_at: Any | None
+    created_at: Any
+
+    @property
+    def identity(self) -> CandidateIdentity:
+        return CandidateIdentity(
+            lease_id=self.lease_id,
+            gen=self.gen,
+            key_hash=self.key_hash,
+            boot_kid=self.boot_kid,
+            cap_micro=self.cap_micro,
+            skew_seconds=self.skew_seconds,
+            workspace_id=self.workspace_id,
+            region=self.region,
+            creating_authorization_id=self.creating_authorization_id,
+            idempotency_scope=self.idempotency_scope,
+            expires_at=self.expires_at,
+        )
+
+
+def register_bound(
+    transaction: Any,
+    param_types: Any,
+    scope: str,
+    authorization_id: str,
+    lease_id: str,
+    gen: int,
+    allocated_micro: int,
+) -> int:
+    """Insert the scope's BOUND registration, returning exactly 1 or 0."""
+    BindingTuple(lease_id, gen, allocated_micro)
+    if not scope or not authorization_id:
+        raise SpendLeaseDataError("BOUND scope and authorization id must be non-empty")
+    return _single_row_count(
+        "register_bound",
+        transaction.execute_update(
+            "INSERT OR IGNORE INTO spend_lease_scope_arbitration ("
+            "scope_salt, idempotency_scope, registration_kind, authorization_id, "
+            "spend_lease_id, spend_lease_gen, spend_lease_allocated_micro, "
+            "provisional_id, created_at, terminal_at) VALUES ("
+            "@scope_salt, @scope, 'BOUND', @authorization_id, @lease_id, @gen, "
+            "@allocated_micro, NULL, CURRENT_TIMESTAMP(), NULL)",
+            params={
+                "scope_salt": spend_leases.spend_lease_scope_salt(scope),
+                "scope": scope,
+                "authorization_id": authorization_id,
+                "lease_id": lease_id,
+                "gen": int(gen),
+                "allocated_micro": int(allocated_micro),
+            },
+            param_types={
+                "scope_salt": param_types.STRING,
+                "scope": param_types.STRING,
+                "authorization_id": param_types.STRING,
+                "lease_id": param_types.STRING,
+                "gen": param_types.INT64,
+                "allocated_micro": param_types.INT64,
+            },
+        ),
+    )
+
+
+def register_claim(
+    transaction: Any,
+    param_types: Any,
+    scope: str,
+    provisional_id: str,
+) -> int:
+    """Insert an already-retention-armed CLAIM, returning exactly 1 or 0."""
+    if not scope or not provisional_id:
+        raise SpendLeaseDataError("CLAIM scope and provisional id must be non-empty")
+    return _single_row_count(
+        "register_claim",
+        transaction.execute_update(
+            "INSERT OR IGNORE INTO spend_lease_scope_arbitration ("
+            "scope_salt, idempotency_scope, registration_kind, authorization_id, "
+            "spend_lease_id, spend_lease_gen, spend_lease_allocated_micro, "
+            "provisional_id, created_at, terminal_at) VALUES ("
+            "@scope_salt, @scope, 'CLAIM', NULL, NULL, NULL, NULL, "
+            "@provisional_id, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP())",
+            params={
+                "scope_salt": spend_leases.spend_lease_scope_salt(scope),
+                "scope": scope,
+                "provisional_id": provisional_id,
+            },
+            param_types={
+                "scope_salt": param_types.STRING,
+                "scope": param_types.STRING,
+                "provisional_id": param_types.STRING,
+            },
+        ),
+    )
+
+
+def read_registration(
+    transaction: Any,
+    param_types: Any,
+    scope: str,
+) -> Registration | None:
+    """Point-read the registration selected by the salted primary key."""
+    rows = list(
+        transaction.execute_sql(
+            f"SELECT {', '.join(ARBITRATION_COLUMNS)} "  # noqa: S608 - fixed columns
+            "FROM spend_lease_scope_arbitration "
+            "WHERE scope_salt=@scope_salt AND idempotency_scope=@scope",
+            params={
+                "scope_salt": spend_leases.spend_lease_scope_salt(scope),
+                "scope": scope,
+            },
+            param_types={
+                "scope_salt": param_types.STRING,
+                "scope": param_types.STRING,
+            },
+        )
+    )
+    if not rows:
+        return None
+    kind, authorization_id, lease_id, gen, allocated_micro, provisional_id = rows[0]
+    if kind == "BOUND":
+        if authorization_id is None or lease_id is None or gen is None or allocated_micro is None:
+            raise SpendLeaseDataError("corrupt BOUND arbitration registration")
+        return Registration(
+            kind="BOUND",
+            authorization_id=str(authorization_id),
+            lease=BindingTuple(str(lease_id), int(gen), int(allocated_micro)),
+            provisional_id=None,
+        )
+    if kind == "CLAIM":
+        if provisional_id is None:
+            raise SpendLeaseDataError("corrupt CLAIM arbitration registration")
+        return Registration(
+            kind="CLAIM",
+            authorization_id=None,
+            lease=None,
+            provisional_id=str(provisional_id),
+        )
+    raise SpendLeaseDataError(f"unknown arbitration registration kind: {kind!r}")
+
+
+def arm_bound_retention(
+    transaction: Any,
+    param_types: Any,
+    authorization_id: str,
+    terminal_at: Any,
+) -> int:
+    """Set BOUND retention through the authorization index; return row count."""
+    return int(
+        transaction.execute_update(
+            "UPDATE spend_lease_scope_arbitration"
+            "@{FORCE_INDEX=spend_lease_scope_arbitration_by_authorization} "
+            "SET terminal_at=@terminal_at WHERE authorization_id=@authorization_id "
+            "AND registration_kind='BOUND'",
+            params={
+                "authorization_id": authorization_id,
+                "terminal_at": terminal_at,
+            },
+            param_types={
+                "authorization_id": param_types.STRING,
+                "terminal_at": param_types.TIMESTAMP,
+            },
+        )
+    )
+
+
+def insert_candidate(
+    transaction: Any,
+    param_types: Any,
+    identity: CandidateIdentity,
+    *,
+    created_at: Any,
+) -> int:
+    """Step 1: insert the durable candidate before any local ledger write."""
+    return _single_row_count(
+        "insert_candidate",
+        transaction.execute_update(
+            "INSERT OR IGNORE INTO spend_lease_open ("
+            "lease_id, phase, gen, key_hash, boot_kid, cap_micro, skew_seconds, "
+            "workspace_id, region, creating_authorization_id, idempotency_scope, "
+            "expires_at, next_attempt_at, attempts, last_error, dead, "
+            "close_eligible_since, global_closed_at, local_closed_at, recovering_at, "
+            "created_at) VALUES (@lease_id, 'candidate', @gen, @key_hash, @boot_kid, "
+            "@cap_micro, @skew_seconds, @workspace_id, @region, @creator, @scope, "
+            "@expires_at, TIMESTAMP_ADD(@expires_at, INTERVAL @skew_seconds SECOND), "
+            "0, NULL, false, NULL, NULL, NULL, NULL, @created_at)",
+            params={
+                "lease_id": identity.lease_id,
+                "gen": int(identity.gen),
+                "key_hash": identity.key_hash,
+                "boot_kid": identity.boot_kid,
+                "cap_micro": int(identity.cap_micro),
+                "skew_seconds": int(identity.skew_seconds),
+                "workspace_id": identity.workspace_id,
+                "region": identity.region,
+                "creator": identity.creating_authorization_id,
+                "scope": identity.idempotency_scope,
+                "expires_at": identity.expires_at,
+                "created_at": created_at,
+            },
+            param_types={
+                "lease_id": param_types.STRING,
+                "gen": param_types.INT64,
+                "key_hash": param_types.STRING,
+                "boot_kid": param_types.STRING,
+                "cap_micro": param_types.INT64,
+                "skew_seconds": param_types.INT64,
+                "workspace_id": param_types.STRING,
+                "region": param_types.STRING,
+                "creator": param_types.STRING,
+                "scope": param_types.STRING,
+                "expires_at": param_types.TIMESTAMP,
+                "created_at": param_types.TIMESTAMP,
+            },
+        ),
+    )
+
+
+def upgrade_candidate_to_open(
+    transaction: Any,
+    param_types: Any,
+    lease_id: str,
+    creating_authorization_id: str,
+    expires_at: Any,
+    skew_seconds: int,
+) -> int:
+    """Step 3: guarded candidate-to-open handoff; zero means MINT_LOST."""
+    return _single_row_count(
+        "upgrade_candidate_to_open",
+        transaction.execute_update(
+            "UPDATE spend_lease_open SET phase='open', "
+            "next_attempt_at=TIMESTAMP_ADD(@expires_at, INTERVAL @skew_seconds SECOND) "
+            "WHERE lease_id=@lease_id AND phase='candidate' "
+            "AND creating_authorization_id=@creator",
+            params={
+                "lease_id": lease_id,
+                "creator": creating_authorization_id,
+                "expires_at": expires_at,
+                "skew_seconds": int(skew_seconds),
+            },
+            param_types={
+                "lease_id": param_types.STRING,
+                "creator": param_types.STRING,
+                "expires_at": param_types.TIMESTAMP,
+                "skew_seconds": param_types.INT64,
+            },
+        ),
+    )
+
+
+def take_recovery_ownership(
+    transaction: Any,
+    param_types: Any,
+    lease_id: str,
+) -> int:
+    """Step 4a: fence mint by moving candidate to recovering.
+
+    The caller must end the transaction immediately after this statement and
+    its row-count check.  ``recovering_at`` uses PENDING_COMMIT_TIMESTAMP(), and
+    Spanner forbids later access to ``spend_lease_open`` in this transaction.
+    """
+    return _single_row_count(
+        "take_recovery_ownership",
+        transaction.execute_update(
+            "UPDATE spend_lease_open SET phase='recovering', "
+            "recovering_at=PENDING_COMMIT_TIMESTAMP() "
+            "WHERE lease_id=@lease_id AND phase='candidate'",
+            params={"lease_id": lease_id},
+            param_types={"lease_id": param_types.STRING},
+        ),
+    )
+
+
+def complete_candidate(
+    transaction: Any,
+    param_types: Any,
+    lease_id: str,
+) -> int:
+    """Step 4c: finish owned recovery and remove it from the due index."""
+    return _single_row_count(
+        "complete_candidate",
+        transaction.execute_update(
+            "UPDATE spend_lease_open SET phase='done', next_attempt_at=NULL "
+            "WHERE lease_id=@lease_id AND phase='recovering'",
+            params={"lease_id": lease_id},
+            param_types={"lease_id": param_types.STRING},
+        ),
+    )
+
+
+def read_open_row(
+    reader: Any,
+    param_types: Any,
+    lease_id: str,
+) -> OpenRow | None:
+    """Strong point read when called with a transaction or strong snapshot."""
+    rows = list(
+        reader.execute_sql(
+            f"SELECT {', '.join(OPEN_COLUMNS)} FROM spend_lease_open "  # noqa: S608
+            "WHERE lease_id=@lease_id",
+            params={"lease_id": lease_id},
+            param_types={"lease_id": param_types.STRING},
+        )
+    )
+    return _open_row(rows[0]) if rows else None
+
+
+def due_candidates(
+    snapshot: Any,
+    param_types: Any,
+    limit: int,
+) -> list[OpenRow]:
+    """Ordered candidate/recovering recovery work from the NULL-filtered index."""
+    return _due_rows(snapshot, param_types, limit, phases=("candidate", "recovering"))
+
+
+def due_open(snapshot: Any, param_types: Any, limit: int) -> list[OpenRow]:
+    """Ordered open-lease work from the NULL-filtered due index."""
+    return _due_rows(snapshot, param_types, limit, phases=("open",))
+
+
+def authorization_typed_columns(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Map JSON payload lease/finalization facts to the nine typed columns.
+
+    ``spend_lease_exp`` is an epoch second in the JSON payload and a TIMESTAMP
+    in Spanner.  ``spend_lease_allocated_micro`` is deliberately distinct from
+    the payload's lease-wide ``spend_lease_cap_micro``; callers must supply the
+    former explicitly once a request allocation is bound.
+    """
+    values = {column: payload.get(column) for column in AUTHORIZATION_TYPED_COLUMNS}
+    allocated = values["spend_lease_allocated_micro"]
+    if allocated is not None and int(allocated) <= 0:
+        raise SpendLeaseDataError("spend_lease_allocated_micro must be NULL or positive")
+    expires = values["spend_lease_exp"]
+    if expires is not None:
+        values["spend_lease_exp"] = _timestamp_from_payload(expires)
+    return values
+
+
+def merge_authorization_typed_columns(
+    payload: Mapping[str, Any] | None,
+    typed_columns: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Merge mixed-revision authorization facts, one field at a time.
+
+    A non-NULL typed value wins; a typed NULL falls back to the JSON payload.
+    This preserves rows written payload-only by an older rolling revision.
+    """
+    merged = dict(payload or {})
+    for column in AUTHORIZATION_TYPED_COLUMNS:
+        value = typed_columns.get(column)
+        if value is None:
+            continue
+        merged[column] = _payload_expiry(value) if column == "spend_lease_exp" else value
+    allocated = merged.get("spend_lease_allocated_micro")
+    if allocated is not None and int(allocated) <= 0:
+        raise SpendLeaseDataError("spend_lease_allocated_micro must be NULL or positive")
+    return merged
+
+
+def authorization_typed_param_types(param_types: Any) -> dict[str, Any]:
+    """Return the Spanner type map paired with :func:`authorization_typed_columns`."""
+    return {
+        "spend_lease_id": param_types.STRING,
+        "spend_lease_gen": param_types.INT64,
+        "spend_lease_allocated_micro": param_types.INT64,
+        "spend_lease_token": param_types.STRING,
+        "spend_lease_status": param_types.STRING,
+        "spend_lease_exp": param_types.TIMESTAMP,
+        "idempotency_fingerprint": param_types.STRING,
+        "finalization_outcome": param_types.STRING,
+        "finalized_cost_microdollars": param_types.INT64,
+    }
+
+
+def _due_rows(
+    snapshot: Any,
+    param_types: Any,
+    limit: int,
+    *,
+    phases: tuple[OpenPhase, ...],
+) -> list[OpenRow]:
+    if limit <= 0:
+        return []
+    phase_sql = ", ".join(f"'{phase}'" for phase in phases)
+    rows = list(
+        snapshot.execute_sql(
+            f"SELECT {', '.join(OPEN_COLUMNS)} FROM spend_lease_open"  # noqa: S608
+            "@{FORCE_INDEX=spend_lease_open_due} "
+            "WHERE next_attempt_at IS NOT NULL "
+            f"AND phase IN ({phase_sql}) "  # noqa: S608 - enum literals only
+            "AND next_attempt_at <= CURRENT_TIMESTAMP() "
+            "ORDER BY next_attempt_at LIMIT @limit",
+            params={"limit": int(limit)},
+            param_types={"limit": param_types.INT64},
+        )
+    )
+    return [_open_row(row) for row in rows]
+
+
+def _open_row(values: Any) -> OpenRow:
+    row = dict(zip(OPEN_COLUMNS, values, strict=True))
+    phase = row["phase"]
+    if phase not in ("candidate", "recovering", "open", "done"):
+        raise SpendLeaseDataError(f"unknown spend-lease open phase: {phase!r}")
+    return OpenRow(
+        lease_id=str(row["lease_id"]),
+        phase=phase,
+        gen=int(row["gen"]),
+        key_hash=str(row["key_hash"]),
+        boot_kid=str(row["boot_kid"]),
+        cap_micro=int(row["cap_micro"]),
+        skew_seconds=int(row["skew_seconds"]),
+        workspace_id=str(row["workspace_id"]),
+        region=str(row["region"]),
+        creating_authorization_id=str(row["creating_authorization_id"]),
+        idempotency_scope=str(row["idempotency_scope"]),
+        expires_at=row["expires_at"],
+        next_attempt_at=row["next_attempt_at"],
+        attempts=int(row["attempts"]),
+        last_error=str(row["last_error"]) if row["last_error"] is not None else None,
+        dead=bool(row["dead"]),
+        close_eligible_since=row["close_eligible_since"],
+        global_closed_at=row["global_closed_at"],
+        local_closed_at=row["local_closed_at"],
+        recovering_at=row["recovering_at"],
+        created_at=row["created_at"],
+    )
+
+
+def _timestamp_from_payload(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, bool):
+        raise SpendLeaseDataError("spend_lease_exp must be an epoch second or timestamp")
+    try:
+        return datetime.fromtimestamp(int(value), tz=UTC)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise SpendLeaseDataError(
+            "spend_lease_exp must be an epoch second or timestamp"
+        ) from exc
+
+
+def _payload_expiry(value: Any) -> Any:
+    if not isinstance(value, datetime):
+        return value
+    normalized = value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+    return int(normalized.astimezone(UTC).timestamp())
+
+
+def _single_row_count(statement: str, count: Any) -> int:
+    modified = int(count)
+    if modified not in (0, 1):
+        raise SpendLeaseDmlError(
+            f"{statement} modified impossible row count: {modified}"
+        )
+    return modified

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+import re
 import threading
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -158,6 +159,14 @@ class FakeSpannerDatabase:
         # catch accidental fallback writes after the typed cutover.
         self.gateway_authorizations: dict[str, dict] = {}
         self.gateway_authorization_versions: dict[str, int] = {}
+        # Unit-2 spend-lease tables. Arbitration is keyed by its salted
+        # two-column primary key; open work is keyed by lease_id. Both keep
+        # per-row versions so INSERT OR IGNORE and guarded phase transitions
+        # serialize like native Spanner DML.
+        self.spend_lease_arbitrations: dict[tuple[str, str], dict] = {}
+        self.spend_lease_arbitration_versions: dict[tuple[str, str], int] = {}
+        self.spend_lease_open: dict[str, dict] = {}
+        self.spend_lease_open_versions: dict[str, int] = {}
         # Metadata-only typed generation records and durable ClickHouse handoff.
         self.generation_records: dict[str, dict] = {}
         self.operational_analytics_outbox: list[dict] = []
@@ -263,6 +272,12 @@ class FakeSpannerDatabase:
                         key[1],
                         0,
                     )
+                elif isinstance(key, tuple) and len(key) == 3 and key[0] == "spend_arb":
+                    current_version = self.spend_lease_arbitration_versions.get(
+                        (key[1], key[2]), 0
+                    )
+                elif isinstance(key, tuple) and len(key) == 2 and key[0] == "spend_open":
+                    current_version = self.spend_lease_open_versions.get(key[1], 0)
                 else:
                     current = self.rows.get(key)
                     current_version = current.version if current is not None else 0
@@ -325,6 +340,28 @@ class FakeSpannerDatabase:
                     _, authorization_id, record = op
                     self.gateway_authorizations[authorization_id] = record
                     self.gateway_authorization_versions[authorization_id] = new_version
+                elif op[0] in ("insert_spend_arbitration", "update_spend_arbitration"):
+                    _, pk, record = op
+                    commit_timestamp = dt.datetime.now(dt.UTC)
+                    record = {
+                        column: commit_timestamp
+                        if value == _SpannerModule.COMMIT_TIMESTAMP
+                        else value
+                        for column, value in record.items()
+                    }
+                    self.spend_lease_arbitrations[pk] = record
+                    self.spend_lease_arbitration_versions[pk] = new_version
+                elif op[0] in ("insert_spend_open", "update_spend_open"):
+                    _, lease_id, record = op
+                    commit_timestamp = dt.datetime.now(dt.UTC)
+                    record = {
+                        column: commit_timestamp
+                        if value == _SpannerModule.COMMIT_TIMESTAMP
+                        else value
+                        for column, value in record.items()
+                    }
+                    self.spend_lease_open[lease_id] = record
+                    self.spend_lease_open_versions[lease_id] = new_version
                 elif op[0] in ("insert_generation", "upsert_generation"):
                     _, generation_id, record = op
                     self.generation_records[generation_id] = record
@@ -381,6 +418,7 @@ class _FakeTransaction:
         # buffers mutations after DML and DML can't see them); fail fast if both.
         self._did_mutation = False
         self._did_dml = False
+        self._spend_open_pending_commit_timestamp_written = False
 
     def execute_sql(
         self,
@@ -389,6 +427,13 @@ class _FakeTransaction:
         params: dict[str, Any] | None = None,
         param_types: Any = None,
     ) -> list[list[str]]:
+        if (
+            self._spend_open_pending_commit_timestamp_written
+            and "spend_lease_open" in sql
+        ):
+            raise FakeFailedPrecondition(
+                "spend_lease_open cannot be read after PENDING_COMMIT_TIMESTAMP()"
+            )
         self.db.transaction_execute_sql_calls += 1
         return _execute_sql(self.db, self, sql, params or {})
 
@@ -485,6 +530,26 @@ class _FakeTransaction:
             self.db.gateway_authorizations.get(authorization_id),
         )
 
+    def _spend_arbitration_current(self, pk: tuple[str, str]) -> dict | None:
+        for op in reversed(self.pending_writes):
+            if op[0] in ("insert_spend_arbitration", "update_spend_arbitration") and op[1] == pk:
+                return dict(op[2])
+        return self._pinned_read(
+            ("spend_arb", *pk),
+            self.db.spend_lease_arbitration_versions.get(pk, 0),
+            self.db.spend_lease_arbitrations.get(pk),
+        )
+
+    def _spend_open_current(self, lease_id: str) -> dict | None:
+        for op in reversed(self.pending_writes):
+            if op[0] in ("insert_spend_open", "update_spend_open") and op[1] == lease_id:
+                return dict(op[2])
+        return self._pinned_read(
+            ("spend_open", lease_id),
+            self.db.spend_lease_open_versions.get(lease_id, 0),
+            self.db.spend_lease_open.get(lease_id),
+        )
+
     def _typed_current(self, table: str, pk: tuple) -> dict | None:
         """In-txn view of a typed row for DML: sees prior DML writes
         (update_typed = read-your-writes) but NOT buffered mutations (real Spanner
@@ -509,6 +574,13 @@ class _FakeTransaction:
         conditionally buffers the SET. Returns the modified-row count.
         """
         self.db.transaction_execute_update_calls += 1
+        if (
+            self._spend_open_pending_commit_timestamp_written
+            and "spend_lease_open" in sql
+        ):
+            raise FakeFailedPrecondition(
+                "spend_lease_open cannot be accessed after PENDING_COMMIT_TIMESTAMP()"
+            )
         if self._did_mutation:
             raise RuntimeError(
                 "DML after a mutation in the same transaction — DML+mutation "
@@ -950,6 +1022,14 @@ class _FakeTransaction:
             new = dict(rec, terminal_at=None)
             self.pending_writes.append(("update_reservation", p["rid"], new))
             return 1
+        spend_lease_dml = sql.strip()
+        if re.match(
+            r"^(?:INSERT(?:\s+OR\s+IGNORE)?\s+INTO|UPDATE)\s+"
+            r"spend_lease_(?:scope_arbitration|open)\b",
+            spend_lease_dml,
+            re.IGNORECASE,
+        ):
+            return _execute_spend_lease_dml(self, spend_lease_dml, p)
         if sql.startswith("INSERT INTO tr_gateway_authorization"):
             authorization_id = p["authorization_id"]
             if authorization_id in self.db.gateway_authorizations:
@@ -1452,6 +1532,280 @@ def _utc_datetime(value: Any) -> dt.datetime:
         return value if value.tzinfo is not None else value.replace(tzinfo=dt.UTC)
     parsed = dt.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
     return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=dt.UTC)
+
+
+_SPEND_LEASE_PRIMARY_KEYS = {
+    "spend_lease_scope_arbitration": ("scope_salt", "idempotency_scope"),
+    "spend_lease_open": ("lease_id",),
+}
+
+
+def _split_spanner_sql_list(source: str) -> list[str]:
+    """Split a comma list without splitting nested function arguments."""
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    in_quote = False
+    index = 0
+    while index < len(source):
+        char = source[index]
+        if char == "'":
+            if in_quote and index + 1 < len(source) and source[index + 1] == "'":
+                index += 2
+                continue
+            in_quote = not in_quote
+        elif not in_quote:
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth < 0:
+                    raise AssertionError(f"unbalanced spend-lease SQL expression list: {source!r}")
+            elif char == "," and depth == 0:
+                parts.append(source[start:index].strip())
+                start = index + 1
+        index += 1
+    if in_quote or depth != 0:
+        raise AssertionError(f"unbalanced spend-lease SQL expression list: {source!r}")
+    parts.append(source[start:].strip())
+    if any(not part for part in parts):
+        raise AssertionError(f"empty spend-lease SQL expression: {source!r}")
+    return parts
+
+
+def _split_spanner_conjunction(source: str) -> list[str]:
+    """Split top-level AND predicates while respecting literals and functions."""
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    in_quote = False
+    index = 0
+    while index < len(source):
+        char = source[index]
+        if char == "'":
+            if in_quote and index + 1 < len(source) and source[index + 1] == "'":
+                index += 2
+                continue
+            in_quote = not in_quote
+            index += 1
+            continue
+        if not in_quote:
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+            elif (
+                depth == 0
+                and source[index : index + 3].upper() == "AND"
+                and (index == 0 or source[index - 1].isspace())
+                and (index + 3 == len(source) or source[index + 3].isspace())
+            ):
+                parts.append(source[start:index].strip())
+                start = index + 3
+                index += 3
+                continue
+        index += 1
+    if in_quote or depth != 0:
+        raise AssertionError(f"unbalanced spend-lease WHERE clause: {source!r}")
+    parts.append(source[start:].strip())
+    if any(not part for part in parts):
+        raise AssertionError(f"empty spend-lease WHERE predicate: {source!r}")
+    return parts
+
+
+def _evaluate_spanner_expression(
+    expression: str,
+    params: dict[str, Any],
+    now: dt.datetime,
+) -> Any:
+    expression = expression.strip()
+    param = re.fullmatch(r"@([A-Za-z_][A-Za-z0-9_]*)", expression)
+    if param is not None:
+        name = param.group(1)
+        if name not in params:
+            raise AssertionError(f"spend-lease SQL references missing parameter @{name}")
+        return params[name]
+    if expression.upper() == "NULL":
+        return None
+    if re.fullmatch(r"CURRENT_TIMESTAMP\s*\(\s*\)", expression, re.IGNORECASE):
+        return now
+    if re.fullmatch(
+        r"PENDING_COMMIT_TIMESTAMP\s*\(\s*\)", expression, re.IGNORECASE
+    ):
+        return _SpannerModule.COMMIT_TIMESTAMP
+    timestamp_add = re.fullmatch(
+        r"TIMESTAMP_ADD\s*\(\s*@([A-Za-z_][A-Za-z0-9_]*)\s*,\s*"
+        r"INTERVAL\s+@([A-Za-z_][A-Za-z0-9_]*)\s+SECOND\s*\)",
+        expression,
+        re.IGNORECASE,
+    )
+    if timestamp_add is not None:
+        timestamp_name, seconds_name = timestamp_add.groups()
+        missing = [name for name in (timestamp_name, seconds_name) if name not in params]
+        if missing:
+            raise AssertionError(
+                f"spend-lease SQL references missing parameter(s): {', '.join(missing)}"
+            )
+        return _utc_datetime(params[timestamp_name]) + dt.timedelta(
+            seconds=int(params[seconds_name])
+        )
+    if re.fullmatch(r"'(?:''|[^'])*'", expression):
+        return expression[1:-1].replace("''", "'")
+    if re.fullmatch(r"-?[0-9]+", expression):
+        return int(expression)
+    if expression.upper() in ("TRUE", "FALSE"):
+        return expression.upper() == "TRUE"
+    raise AssertionError(f"unknown spend-lease SQL expression: {expression!r}")
+
+
+def _spend_lease_row_matches(
+    record: dict[str, Any],
+    where_sql: str,
+    params: dict[str, Any],
+    now: dt.datetime,
+) -> bool:
+    for predicate in _split_spanner_conjunction(where_sql):
+        null_match = re.fullmatch(
+            r"([A-Za-z_][A-Za-z0-9_]*)\s+IS\s+(NOT\s+)?NULL",
+            predicate,
+            re.IGNORECASE,
+        )
+        if null_match is not None:
+            column, not_null = null_match.groups()
+            matches = record.get(column) is not None if not_null else record.get(column) is None
+        else:
+            equality = re.fullmatch(
+                r"([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+)",
+                predicate,
+            )
+            if equality is None:
+                raise AssertionError(f"unknown spend-lease WHERE predicate: {predicate!r}")
+            column, expression = equality.groups()
+            matches = record.get(column) == _evaluate_spanner_expression(expression, params, now)
+        if not matches:
+            return False
+    return True
+
+
+def _spend_lease_rows(
+    transaction: _FakeTransaction,
+    table: str,
+) -> list[tuple[Any, dict[str, Any]]]:
+    if table == "spend_lease_scope_arbitration":
+        keys: set[Any] = set(transaction.db.spend_lease_arbitrations)
+        operation_names = ("insert_spend_arbitration", "update_spend_arbitration")
+    elif table == "spend_lease_open":
+        keys = set(transaction.db.spend_lease_open)
+        operation_names = ("insert_spend_open", "update_spend_open")
+    else:  # pragma: no cover - caller validates the table before dispatch
+        raise AssertionError(f"unknown spend-lease table: {table}")
+    keys.update(
+        operation[1]
+        for operation in transaction.pending_writes
+        if operation[0] in operation_names
+    )
+    return [
+        (key, record)
+        for key in keys
+        if (record := _spend_lease_current(transaction, table, key)) is not None
+    ]
+
+
+def _spend_lease_current(
+    transaction: _FakeTransaction,
+    table: str,
+    key: Any,
+) -> dict[str, Any] | None:
+    if table == "spend_lease_scope_arbitration":
+        return transaction._spend_arbitration_current(key)
+    if table == "spend_lease_open":
+        return transaction._spend_open_current(key)
+    raise AssertionError(f"unknown spend-lease table: {table}")
+
+
+def _spend_lease_operation_name(table: str, action: str) -> str:
+    suffix = "arbitration" if table == "spend_lease_scope_arbitration" else "open"
+    return f"{action}_spend_{suffix}"
+
+
+def _execute_spend_lease_dml(
+    transaction: _FakeTransaction,
+    sql: str,
+    params: dict[str, Any],
+) -> int:
+    """Evaluate the spend-lease DML subset from SQL instead of restating it."""
+    now = dt.datetime.now(dt.UTC)
+    insert = re.fullmatch(
+        r"INSERT(?:\s+(OR)\s+IGNORE)?\s+INTO\s+"
+        r"(spend_lease_scope_arbitration|spend_lease_open)\s*"
+        r"\((.*?)\)\s*VALUES\s*\((.*)\)\s*",
+        sql,
+        re.DOTALL | re.IGNORECASE,
+    )
+    if insert is not None:
+        ignore_sql, table, columns_sql, values_sql = insert.groups()
+        columns = _split_spanner_sql_list(columns_sql)
+        expressions = _split_spanner_sql_list(values_sql)
+        if len(columns) != len(expressions):
+            raise AssertionError(
+                f"spend-lease INSERT column/value count mismatch: {len(columns)} != "
+                f"{len(expressions)}"
+            )
+        if any(re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", column) is None for column in columns):
+            raise AssertionError(f"invalid spend-lease INSERT column list: {columns!r}")
+        record = {
+            column: _evaluate_spanner_expression(expression, params, now)
+            for column, expression in zip(columns, expressions, strict=True)
+        }
+        primary_key_columns = _SPEND_LEASE_PRIMARY_KEYS[table]
+        try:
+            primary_key_values = tuple(str(record[column]) for column in primary_key_columns)
+        except KeyError as error:
+            raise AssertionError(
+                f"spend-lease INSERT is missing primary-key column {error.args[0]!r}"
+            ) from error
+        key: Any = primary_key_values if len(primary_key_values) > 1 else primary_key_values[0]
+        if _spend_lease_current(transaction, table, key) is not None:
+            if ignore_sql is not None:
+                return 0
+            raise FakeAlreadyExists(str(key))
+        transaction.pending_writes.append(
+            (_spend_lease_operation_name(table, "insert"), key, record)
+        )
+        return 1
+
+    update = re.fullmatch(
+        r"UPDATE\s+(spend_lease_scope_arbitration|spend_lease_open)"
+        r"(?:@\{[^}]+\})?\s+SET\s+(.*?)\s+WHERE\s+(.+?)\s*",
+        sql,
+        re.DOTALL | re.IGNORECASE,
+    )
+    if update is None:
+        raise AssertionError(f"unknown spend-lease DML statement: {sql}")
+    table, assignments_sql, where_sql = update.groups()
+    assignments: dict[str, Any] = {}
+    for assignment in _split_spanner_sql_list(assignments_sql):
+        match = re.fullmatch(r"([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+)", assignment)
+        if match is None:
+            raise AssertionError(f"unknown spend-lease assignment: {assignment!r}")
+        column, expression = match.groups()
+        assignments[column] = _evaluate_spanner_expression(expression, params, now)
+
+    updated = 0
+    for key, record in _spend_lease_rows(transaction, table):
+        if not _spend_lease_row_matches(record, where_sql, params, now):
+            continue
+        transaction.pending_writes.append(
+            (_spend_lease_operation_name(table, "update"), key, dict(record, **assignments))
+        )
+        updated += 1
+    if (
+        updated
+        and table == "spend_lease_open"
+        and _SpannerModule.COMMIT_TIMESTAMP in assignments.values()
+    ):
+        transaction._spend_open_pending_commit_timestamp_written = True
+    return updated
 
 
 def _execute_settle_outbox_sql(
@@ -2338,6 +2692,67 @@ def _execute_sql(
             if len(out) >= limit:
                 break
         return out
+    if "FROM spend_lease_scope_arbitration" in sql:
+        _require_pred(
+            sql,
+            "scope_salt=@scope_salt AND idempotency_scope=@scope",
+            "spend-lease arbitration primary-key read",
+        )
+        pk = (str(params["scope_salt"]), str(params["scope"]))
+        rec = (
+            txn._spend_arbitration_current(pk)
+            if txn is not None
+            else db.spend_lease_arbitrations.get(pk)
+        )
+        if rec is None:
+            return []
+        cols = [col.strip() for col in sql.split("SELECT", 1)[1].split("FROM", 1)[0].split(",")]
+        return [[rec.get(col) for col in cols]]
+    if "FROM spend_lease_open" in sql:
+        cols = [col.strip() for col in sql.split("SELECT", 1)[1].split("FROM", 1)[0].split(",")]
+        if "WHERE lease_id=@lease_id" in sql:
+            lease_id = str(params["lease_id"])
+            rec = (
+                txn._spend_open_current(lease_id)
+                if txn is not None
+                else db.spend_lease_open.get(lease_id)
+            )
+            return [[rec.get(col) for col in cols]] if rec is not None else []
+        _require_pred(
+            sql,
+            "@{FORCE_INDEX=spend_lease_open_due}",
+            "spend-lease due index",
+        )
+        _require_pred(
+            sql,
+            "WHERE next_attempt_at IS NOT NULL",
+            "spend-lease due NULL filter",
+        )
+        _require_pred(
+            sql,
+            "AND next_attempt_at <= CURRENT_TIMESTAMP()",
+            "spend-lease due deadline",
+        )
+        _require_pred(sql, "ORDER BY next_attempt_at LIMIT @limit", "spend-lease due order")
+        if "phase IN ('candidate', 'recovering')" in sql:
+            phases = {"candidate", "recovering"}
+        elif "phase IN ('open')" in sql:
+            phases = {"open"}
+        else:
+            raise AssertionError("spend-lease due query missing phase predicate")
+        now = dt.datetime.now(dt.UTC)
+        records = [
+            rec
+            for rec in db.spend_lease_open.values()
+            if rec.get("phase") in phases
+            and rec.get("next_attempt_at") is not None
+            and _utc_datetime(rec["next_attempt_at"]) <= now
+        ]
+        records.sort(key=lambda rec: _utc_datetime(rec["next_attempt_at"]))
+        return [
+            [rec.get(col) for col in cols]
+            for rec in records[: int(params["limit"])]
+        ]
     # tr_settle_outbox (durable settle outbox) — modeled explicitly so a guard/
     # column/status typo makes a test FAIL rather than silently matching a
     # generic branch (the substring-collision hazard the design flags).

--- a/tests/test_fake_spanner_fidelity.py
+++ b/tests/test_fake_spanner_fidelity.py
@@ -33,6 +33,49 @@ def test_multi_use_snapshot_allows_multiple_reads() -> None:
                              params={"pk": "ws_x"})  # no raise
 
 
+def test_spend_lease_bound_insert_evaluates_armed_terminal_at() -> None:
+    """The fake must derive retention from VALUES, not the registration kind."""
+    db = _db()
+    scope = "workspace-1:request-armed-bound"
+
+    modified = db.run_in_transaction(
+        lambda transaction: transaction.execute_update(
+            "INSERT OR IGNORE INTO spend_lease_scope_arbitration ("
+            "scope_salt, idempotency_scope, registration_kind, authorization_id, "
+            "spend_lease_id, spend_lease_gen, spend_lease_allocated_micro, "
+            "provisional_id, created_at, terminal_at) VALUES ("
+            "@scope_salt, @scope, 'BOUND', @authorization_id, @lease_id, @gen, "
+            "@allocated_micro, NULL, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP())",
+            params={
+                "scope_salt": "abcd",
+                "scope": scope,
+                "authorization_id": "authorization-1",
+                "lease_id": "lease-1",
+                "gen": 1,
+                "allocated_micro": 100,
+            },
+        )
+    )
+
+    assert modified == 1
+    record = db.spend_lease_arbitrations[("abcd", scope)]
+    assert record["terminal_at"] is not None
+    assert record["terminal_at"] == record["created_at"]
+
+
+def test_spend_lease_dml_rejects_unknown_expression() -> None:
+    db = _db()
+
+    with pytest.raises(AssertionError, match="unknown spend-lease SQL expression"):
+        db.run_in_transaction(
+            lambda transaction: transaction.execute_update(
+                "INSERT OR IGNORE INTO spend_lease_scope_arbitration "
+                "(scope_salt, idempotency_scope) VALUES (@scope_salt, DEFAULT)",
+                params={"scope_salt": "abcd"},
+            )
+        )
+
+
 def test_paged_entity_range_scan_serializes_against_a_concurrent_commit() -> None:
     """A range read must join the read set, or a scan-then-DELETE acts on stale state.
 

--- a/tests/test_spend_leases.py
+++ b/tests/test_spend_leases.py
@@ -24,6 +24,7 @@ from trusted_router.spend_leases import (
     spend_lease_catalog_estimate,
     spend_lease_eligible,
     spend_lease_ineligibility_reason,
+    spend_lease_scope_salt,
     verify_boot_auth,
 )
 
@@ -95,6 +96,10 @@ def _ineligibility_reason(**overrides: object) -> str | None:
     }
     values.update(overrides)
     return spend_lease_ineligibility_reason(**values)  # type: ignore[arg-type]
+
+
+def test_spend_lease_scope_salt_pins_sha256_hex_prefix() -> None:
+    assert spend_lease_scope_salt("workspace:ws-123:request:req-456") == "8399"
 
 
 def test_spend_lease_eligibility_accepts_exact_credits_chat_cohort() -> None:

--- a/tests/test_storage_gcp_spend_lease.py
+++ b/tests/test_storage_gcp_spend_lease.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from tests.fakes.spanner import FakeSpannerDatabase
+from trusted_router import spend_leases
+from trusted_router.storage_gcp_spend_lease import (
+    AUTHORIZATION_TYPED_COLUMNS,
+    CandidateIdentity,
+    SpendLeaseDataError,
+    arm_bound_retention,
+    authorization_typed_columns,
+    complete_candidate,
+    due_candidates,
+    due_open,
+    insert_candidate,
+    merge_authorization_typed_columns,
+    read_open_row,
+    read_registration,
+    register_bound,
+    register_claim,
+    take_recovery_ownership,
+    upgrade_candidate_to_open,
+)
+
+PT = SimpleNamespace(STRING="STRING", INT64="INT64", BOOL="BOOL", TIMESTAMP="TIMESTAMP")
+NOW = datetime.now(UTC).replace(microsecond=0)
+
+
+def _txn(db: FakeSpannerDatabase, fn: Callable[[Any], Any]) -> Any:
+    return db.run_in_transaction(fn)
+
+
+def _candidate(
+    lease_id: str = "lease-1",
+    *,
+    creator: str = "authorization-1",
+    expires_at: datetime | None = None,
+) -> CandidateIdentity:
+    return CandidateIdentity(
+        lease_id=lease_id,
+        gen=7,
+        key_hash="k" * 64,
+        boot_kid="boot-1",
+        cap_micro=50_000,
+        skew_seconds=30,
+        workspace_id="workspace-1",
+        region="us-central1",
+        creating_authorization_id=creator,
+        idempotency_scope=f"workspace-1:{lease_id}",
+        expires_at=expires_at or NOW - timedelta(minutes=5),
+    )
+
+
+def _insert(db: FakeSpannerDatabase, identity: CandidateIdentity) -> int:
+    return int(
+        _txn(
+            db,
+            lambda transaction: insert_candidate(
+                transaction,
+                PT,
+                identity,
+                created_at=NOW - timedelta(minutes=10),
+            ),
+        )
+    )
+
+
+def test_bound_then_bound_returns_zero_and_reads_first_registration() -> None:
+    db = FakeSpannerDatabase()
+    scope = "workspace-1:request-1"
+
+    first = _txn(
+        db,
+        lambda transaction: register_bound(
+            transaction, PT, scope, "authorization-1", "lease-1", 3, 700
+        ),
+    )
+
+    def lose_and_read(transaction: Any) -> tuple[int, Any]:
+        count = register_bound(
+            transaction, PT, scope, "authorization-2", "lease-2", 4, 900
+        )
+        return count, read_registration(transaction, PT, scope)
+
+    second, registration = _txn(db, lose_and_read)
+    assert (first, second) == (1, 0)
+    assert registration is not None
+    assert registration.kind == "BOUND"
+    assert registration.authorization_id == "authorization-1"
+    assert registration.lease is not None
+    assert (
+        registration.lease.lease_id,
+        registration.lease.gen,
+        registration.lease.allocated_micro,
+    ) == ("lease-1", 3, 700)
+    assert registration.provisional_id is None
+
+
+def test_claim_then_bound_returns_zero_and_reads_claim_registration() -> None:
+    db = FakeSpannerDatabase()
+    scope = "workspace-1:request-claim"
+    assert _txn(db, lambda transaction: register_claim(transaction, PT, scope, "prov-1")) == 1
+
+    def lose_and_read(transaction: Any) -> tuple[int, Any]:
+        count = register_bound(
+            transaction, PT, scope, "authorization-1", "lease-1", 1, 100
+        )
+        return count, read_registration(transaction, PT, scope)
+
+    count, registration = _txn(db, lose_and_read)
+    assert count == 0
+    assert registration is not None
+    assert registration.kind == "CLAIM"
+    assert registration.provisional_id == "prov-1"
+    assert registration.authorization_id is None
+    assert registration.lease is None
+
+
+def test_claim_is_armed_at_insert_and_bound_is_armed_explicitly() -> None:
+    db = FakeSpannerDatabase()
+    claim_scope = "workspace-1:claim"
+    bound_scope = "workspace-1:bound"
+    assert _txn(
+        db, lambda transaction: register_claim(transaction, PT, claim_scope, "prov-1")
+    ) == 1
+    assert _txn(
+        db,
+        lambda transaction: register_bound(
+            transaction, PT, bound_scope, "authorization-1", "lease-1", 1, 100
+        ),
+    ) == 1
+
+    claim = db.spend_lease_arbitrations[
+        (spend_leases.spend_lease_scope_salt(claim_scope), claim_scope)
+    ]
+    bound = db.spend_lease_arbitrations[
+        (spend_leases.spend_lease_scope_salt(bound_scope), bound_scope)
+    ]
+    assert claim["terminal_at"] is not None
+    assert bound["terminal_at"] is None
+
+    terminal_at = NOW + timedelta(hours=1)
+    assert _txn(
+        db,
+        lambda transaction: arm_bound_retention(
+            transaction, PT, "authorization-1", terminal_at
+        ),
+    ) == 1
+    assert bound["terminal_at"] is None  # committed records are replaced, not mutated in place
+    assert db.spend_lease_arbitrations[
+        (spend_leases.spend_lease_scope_salt(bound_scope), bound_scope)
+    ]["terminal_at"] == terminal_at
+
+
+def test_every_scope_key_path_uses_shared_scope_salt_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = FakeSpannerDatabase()
+    calls: list[str] = []
+
+    def sentinel(scope: str) -> str:
+        calls.append(scope)
+        return "beef"
+
+    monkeypatch.setattr(spend_leases, "spend_lease_scope_salt", sentinel)
+    bound_scope = "workspace-1:bound"
+    claim_scope = "workspace-1:claim"
+    assert _txn(
+        db,
+        lambda transaction: register_bound(
+            transaction, PT, bound_scope, "authorization-1", "lease-1", 1, 100
+        ),
+    ) == 1
+    assert _txn(
+        db, lambda transaction: register_claim(transaction, PT, claim_scope, "prov-1")
+    ) == 1
+    registration = _txn(
+        db, lambda transaction: read_registration(transaction, PT, bound_scope)
+    )
+
+    assert registration is not None
+    assert set(db.spend_lease_arbitrations) == {
+        ("beef", bound_scope),
+        ("beef", claim_scope),
+    }
+    assert calls == [bound_scope, claim_scope, bound_scope]
+
+
+def test_candidate_insert_is_primary_key_idempotent_and_read_preserves_identity() -> None:
+    db = FakeSpannerDatabase()
+    identity = _candidate()
+    assert _insert(db, identity) == 1
+    assert _insert(db, identity) == 0
+
+    with db.snapshot() as snapshot:
+        row = read_open_row(snapshot, PT, identity.lease_id)
+    assert row is not None
+    assert row.phase == "candidate"
+    assert row.identity == identity
+    assert row.recovering_at is None
+    assert row.created_at == NOW - timedelta(minutes=10)
+    assert row.next_attempt_at == identity.expires_at + timedelta(seconds=identity.skew_seconds)
+
+
+def test_upgrade_requires_candidate_phase_and_matching_creator() -> None:
+    db = FakeSpannerDatabase()
+    identity = _candidate()
+    assert _insert(db, identity) == 1
+    assert _txn(
+        db,
+        lambda transaction: upgrade_candidate_to_open(
+            transaction,
+            PT,
+            identity.lease_id,
+            "wrong-creator",
+            identity.expires_at,
+            identity.skew_seconds,
+        ),
+    ) == 0
+    assert _txn(
+        db,
+        lambda transaction: upgrade_candidate_to_open(
+            transaction,
+            PT,
+            identity.lease_id,
+            identity.creating_authorization_id,
+            identity.expires_at,
+            identity.skew_seconds,
+        ),
+    ) == 1
+    assert _txn(
+        db,
+        lambda transaction: upgrade_candidate_to_open(
+            transaction,
+            PT,
+            identity.lease_id,
+            identity.creating_authorization_id,
+            identity.expires_at,
+            identity.skew_seconds,
+        ),
+    ) == 0
+
+
+def test_recovery_ownership_fences_later_upgrade_and_records_proof_time() -> None:
+    db = FakeSpannerDatabase()
+    identity = _candidate()
+    assert _insert(db, identity) == 1
+    assert _txn(
+        db, lambda transaction: take_recovery_ownership(transaction, PT, identity.lease_id)
+    ) == 1
+    assert _txn(
+        db,
+        lambda transaction: upgrade_candidate_to_open(
+            transaction,
+            PT,
+            identity.lease_id,
+            identity.creating_authorization_id,
+            identity.expires_at,
+            identity.skew_seconds,
+        ),
+    ) == 0
+    with db.snapshot() as snapshot:
+        row = read_open_row(snapshot, PT, identity.lease_id)
+    assert row is not None
+    assert row.phase == "recovering"
+    assert row.recovering_at is not None
+
+
+def test_open_upgrade_fences_later_recovery_ownership() -> None:
+    db = FakeSpannerDatabase()
+    identity = _candidate()
+    assert _insert(db, identity) == 1
+    assert _txn(
+        db,
+        lambda transaction: upgrade_candidate_to_open(
+            transaction,
+            PT,
+            identity.lease_id,
+            identity.creating_authorization_id,
+            identity.expires_at,
+            identity.skew_seconds,
+        ),
+    ) == 1
+    assert _txn(
+        db, lambda transaction: take_recovery_ownership(transaction, PT, identity.lease_id)
+    ) == 0
+
+
+def test_complete_candidate_only_matches_recovering_phase() -> None:
+    db = FakeSpannerDatabase()
+    identity = _candidate()
+    assert _insert(db, identity) == 1
+    assert _txn(
+        db, lambda transaction: complete_candidate(transaction, PT, identity.lease_id)
+    ) == 0
+    assert _txn(
+        db, lambda transaction: take_recovery_ownership(transaction, PT, identity.lease_id)
+    ) == 1
+    assert _txn(
+        db, lambda transaction: complete_candidate(transaction, PT, identity.lease_id)
+    ) == 1
+    assert _txn(
+        db, lambda transaction: complete_candidate(transaction, PT, identity.lease_id)
+    ) == 0
+
+
+def test_due_scans_are_phase_partitioned_ordered_and_exclude_done_rows() -> None:
+    db = FakeSpannerDatabase()
+    done = _candidate("lease-done", expires_at=NOW - timedelta(minutes=30))
+    candidate = _candidate("lease-candidate", expires_at=NOW - timedelta(minutes=20))
+    opened = _candidate("lease-open", expires_at=NOW - timedelta(minutes=10))
+    for identity in (opened, done, candidate):
+        assert _insert(db, identity) == 1
+    assert _txn(
+        db, lambda transaction: take_recovery_ownership(transaction, PT, done.lease_id)
+    ) == 1
+    assert _txn(
+        db, lambda transaction: complete_candidate(transaction, PT, done.lease_id)
+    ) == 1
+    assert _txn(
+        db,
+        lambda transaction: upgrade_candidate_to_open(
+            transaction,
+            PT,
+            opened.lease_id,
+            opened.creating_authorization_id,
+            opened.expires_at,
+            opened.skew_seconds,
+        ),
+    ) == 1
+
+    with db.snapshot() as snapshot:
+        candidate_rows = due_candidates(snapshot, PT, 10)
+    with db.snapshot() as snapshot:
+        open_rows = due_open(snapshot, PT, 10)
+    assert [row.lease_id for row in candidate_rows] == ["lease-candidate"]
+    assert [row.lease_id for row in open_rows] == ["lease-open"]
+    assert "lease-done" not in {
+        *(row.lease_id for row in candidate_rows),
+        *(row.lease_id for row in open_rows),
+    }
+
+
+def test_authorization_typed_columns_round_trip_merge_and_reject_zero_allocation() -> None:
+    payload = {
+        "authorization_id": "authorization-1",
+        "spend_lease_id": "lease-1",
+        "spend_lease_gen": 3,
+        "spend_lease_allocated_micro": 700,
+        "spend_lease_token": "signed-token",
+        "spend_lease_status": "active",
+        "spend_lease_exp": 1_800_000_000,
+        "idempotency_fingerprint": "f" * 64,
+        "finalization_outcome": "settled",
+        "finalized_cost_microdollars": 650,
+    }
+    typed = authorization_typed_columns(payload)
+    assert tuple(typed) == AUTHORIZATION_TYPED_COLUMNS
+    assert typed["spend_lease_exp"] == datetime.fromtimestamp(1_800_000_000, tz=UTC)
+    assert merge_authorization_typed_columns(None, typed) == {
+        key: value for key, value in payload.items() if key != "authorization_id"
+    }
+
+    old_writer_payload = dict(payload, spend_lease_status="expired", finalization_outcome="refunded")
+    merged = merge_authorization_typed_columns(
+        old_writer_payload,
+        {"spend_lease_status": None, "finalization_outcome": "settled"},
+    )
+    assert merged["spend_lease_status"] == "expired"
+    assert merged["finalization_outcome"] == "settled"
+
+    with pytest.raises(SpendLeaseDataError, match="NULL or positive"):
+        authorization_typed_columns({"spend_lease_allocated_micro": 0})
+    with pytest.raises(SpendLeaseDataError, match="NULL or positive"):
+        merge_authorization_typed_columns(
+            {"spend_lease_allocated_micro": 0},
+            {},
+        )


### PR DESCRIPTION
Third unit-2 PR of the spend-lease program, part (b-i): the inert Spanner data-access layer (design record v49). No callers, no gateway change, no flag.

- `storage_gcp_spend_lease.py`: arbitration registrations (`register_bound` / `register_claim` as INSERT OR IGNORE on the salted scope key, statement-time `created_at`, CLAIM armed for retention at claim time, BOUND armed later via `arm_bound_retention`; `read_registration` for decision 27's point read); open-work rows (`insert_candidate` before any local write, the guarded candidate→open upgrade whose zero row count is MINT_LOST, recovery ownership with `PENDING_COMMIT_TIMESTAMP()`, completion from `recovering` only, phase-partitioned due scans under FORCE_INDEX); typed authorization-column mapping (NULL never 0).
- `spend_lease_scope_salt`: the single derivation helper decision 25 requires, with a test that every scope-key path uses it.
- Spanner fake: models both tables by evaluating VALUES/SET expressions positionally with PK-only INSERT OR IGNORE and guarded UPDATE row counts, so statement-level defects are visible to tests (fidelity test added).

Review: isolated snapshot; scope limited to the module, its tests, the fake and its fidelity test, and the salt helper; ruff; mypy --strict; nine mutations each red (CLAIM and BOUND retention arming both ways, creator and phase guards, both due-scan predicates, both zero-allocation checks). One of those was invisible until the fake evaluated statements instead of matching their text, which is why the fake changed.

Written by codex; reviewed by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)