### PR TITLE
spend-lease: authorize-path hooks behind TR_SPEND_LEASE_BINDING_ENABLED (decisions 24, 28–31, 36–41, 43–47)

### DIFF
--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -699,6 +699,8 @@ ENV_VARS=(
   # is for operator-set values, and a source default cannot override an existing
   # deployed marker.
   "TR_SPEND_LEASE_ISSUANCE_ENABLED=true"
+  # Unit 2 authorize hooks ship inert; the binding flip is a later rollout.
+  "TR_SPEND_LEASE_BINDING_ENABLED=false"
   "TR_SPEND_LEASE_PILOT_WORKSPACE_IDS=45819281-0ce9-4811-a0cd-c660ab3a116d"
   "TR_SPEND_LEASE_SIGNING_SECRET_NAME=trustedrouter-spend-lease-signing-seed"
   "TR_SPEND_LEASE_ACCEPTED_GCP_IMAGE_DIGESTS=${SPEND_LEASE_ACCEPTED_GCP_IMAGE_DIGESTS}"

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -854,6 +854,9 @@ class Settings(BaseSettings):
     # Secret Manager. The accepted digest CSV preserves both sides of a GCP
     # rolling deploy; when empty, the embedded trust digest is the singleton.
     spend_lease_issuance_enabled: bool = False
+    # Stage B traffic mutation.  Keep independent from Stage A issuance so a
+    # deployed revision can continue shadowing while binding remains inert.
+    spend_lease_binding_enabled: bool = False
     spend_lease_pilot_workspace_ids: str = ""
     spend_lease_signing_secret_name: str = ""
     spend_lease_accepted_gcp_image_digests: str = ""
@@ -1361,6 +1364,10 @@ class Settings(BaseSettings):
                     "TR_SPEND_LEASE_ISSUANCE_ENABLED requires the operational "
                     "analytics outbox or direct sink"
                 )
+        if self.spend_lease_binding_enabled and not self.spend_lease_issuance_enabled:
+            raise ValueError(
+                "TR_SPEND_LEASE_BINDING_ENABLED requires TR_SPEND_LEASE_ISSUANCE_ENABLED"
+            )
         if self.spend_lease_soak_probe_enabled and not self.spend_lease_probe_key_secret.strip():
             raise ValueError(
                 "TR_SPEND_LEASE_SOAK_PROBE_ENABLED requires "

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -162,7 +162,7 @@ from trusted_router.spend_leases import (
     SpendLeaseArtifact,
     SpendLeaseBoot,
     SpendLeaseEchoValue,
-    SpendLeaseEligibilityFailure,
+    SpendLeaseNoLeaseReason,
     SpendLeaseSigner,
     boot_auth_fails_only_on_digest_approval,
     build_spend_lease_shadow_event,
@@ -506,9 +506,10 @@ def _record_spend_lease_shadow(
             boot_kid=str(context.get("boot_kid") or ""),
             boot_verified=bool(context.get("boot_verified")),
             no_lease_reason=cast(
-                SpendLeaseEligibilityFailure | None,
+                SpendLeaseNoLeaseReason | None,
                 context.get("no_lease_reason"),
             ),
+            binding_outcome=cast(Any, context.get("binding_outcome")),
             echo=cast(SpendLeaseEchoValue | None, context.get("echo")),
             server_estimate_micro=cast(int | None, context.get("server_estimate_micro")),
             server_verdict=cast(Any, verdict),
@@ -654,7 +655,8 @@ def _authorize_gateway_sync_impl(
                 body_dict,
                 error_message="User-provided models do not support BYOK routes",
             )
-    request_idempotency_key = _gateway_idempotency_key(request, body) or str(uuid.uuid4())
+    presented_idempotency_key = _gateway_idempotency_key(request, body)
+    request_idempotency_key = presented_idempotency_key or str(uuid.uuid4())
     _require_native_batch_route_binding(body.route_type, request_idempotency_key)
     partner_mode = _partner_billing_mode_or_error(
         requested_model_id=requested_model_id,
@@ -951,6 +953,7 @@ def _authorize_gateway_sync_impl(
         and receipt_fee_basis_points == 0
     )
     spend_lease: SpendLeaseArtifact | None = None
+    spend_lease_binding_plan: Any | None = None
     no_lease_reason = spend_lease_ineligibility_reason(
         workspace_id=workspace.id,
         pilot_workspace_ids=settings.spend_lease_pilot_workspaces,
@@ -969,6 +972,7 @@ def _authorize_gateway_sync_impl(
     spend_context["no_lease_reason"] = no_lease_reason or spend_context.get("boot_failure_reason")
     if (
         settings.spend_lease_issuance_enabled
+        and not settings.spend_lease_binding_enabled
         and bool(spend_context["boot_verified"])
         and boot_auth is not None
         and no_lease_reason is None
@@ -1033,6 +1037,48 @@ def _authorize_gateway_sync_impl(
             # Signer, Secret Manager, catalog, and generation failures all
             # degrade to today's synchronous authorization with no lease.
             logger.exception("spend_lease_mint_failed")
+    if (
+        settings.spend_lease_binding_enabled
+        and settings.spend_lease_issuance_enabled
+        and bool(spend_context["boot_verified"])
+        and boot_auth is not None
+        and no_lease_reason is None
+    ):
+        prepare_binding = getattr(_typed_store, "prepare_gateway_spend_lease_binding", None)
+        if callable(prepare_binding):
+            echo = cast(SpendLeaseEchoValue | None, spend_context.get("echo"))
+            catalog = freeze_spend_lease_catalog(
+                endpoint_candidates,
+                region=region,
+                route_type=cast(str, body.route_type),
+                service_tier=service_tier,
+            )
+            spend_lease_binding_plan, binding_reason = prepare_binding(
+                workspace_id=workspace.id,
+                key_hash=api_key.hash,
+                authorization_id=authorization_id,
+                idempotency_key=presented_idempotency_key,
+                idempotency_fingerprint=request_fingerprint,
+                estimate=estimate,
+                boot_kid=boot_auth.kid,
+                region=region,
+                signer=_spend_lease_signer(settings),
+                catalog=catalog,
+                ttl_seconds=settings.spend_lease_ttl_seconds,
+                skew_seconds=settings.spend_lease_skew_seconds,
+                max_microdollars=settings.spend_lease_max_microdollars,
+                max_available_basis_points=(
+                    settings.spend_lease_max_available_basis_points
+                ),
+                echo_lease_id=echo.lease_id if echo is not None else None,
+                echo_state=echo.state if echo is not None else None,
+            )
+            if binding_reason is not None:
+                spend_context["no_lease_reason"] = binding_reason
+                spend_context["binding_outcome"] = "ordinary"
+        else:
+            spend_context["no_lease_reason"] = "ledger_unavailable"
+            spend_context["binding_outcome"] = "ledger_unavailable"
     user_model_slot_acquired = False
     if user_model is not None:
         user_model_slot_acquired = acquire_user_model_slot(
@@ -1158,6 +1204,7 @@ def _authorize_gateway_sync_impl(
                     expires_at=expires_at,
                     window_limits=window_limits or None,
                     spend_lease=spend_lease,
+                    spend_lease_binding_plan=spend_lease_binding_plan,
                 )
         except conflict_store_error_types() as exc:
             release_user_model_slot_after_error()
@@ -1181,6 +1228,13 @@ def _authorize_gateway_sync_impl(
             release_user_model_slot_after_error()
             raise
         window_decision = getattr(outcome, "rate_limit", None)
+        if settings.spend_lease_binding_enabled:
+            spend_context["no_lease_reason"] = getattr(
+                outcome, "no_lease_reason", None
+            ) or spend_context.get("no_lease_reason")
+            spend_context["binding_outcome"] = getattr(
+                outcome, "spend_lease_outcome", None
+            ) or spend_context.get("binding_outcome")
         remember_spend_window_decision(request, window_decision)
         if outcome == AuthorizeOutcome.INSUFFICIENT_CREDITS:
             release_user_model_slot_after_error()

--- a/src/trusted_router/spend_lease_authorize.py
+++ b/src/trusted_router/spend_lease_authorize.py
@@ -1,0 +1,184 @@
+"""Pure authorize-path decisions for bound spend leases (unit 2).
+
+Storage and clocks are inputs.  In particular, this module never imports a
+cloud SDK and never logs or exposes a lease token while classifying a loss.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import StrEnum
+from typing import Literal
+
+from trusted_router.spend_lease_state import SpendLease, SpendLeaseRefusalReason
+
+NoLeaseReason = Literal[
+    "no_idempotency_key",
+    "escrow_headroom",
+    "scope_arbitrated",
+    "predecessor_limit",
+    "lease_transferred",
+    "lease_expired",
+    "stale_advisory",
+    "ledger_unavailable",
+    "window_open",
+    "mint_lost",
+]
+
+
+class SpendLeaseArbitrationConflict(RuntimeError):
+    """A foreign BOUND won; retry only in a fresh Spanner transaction."""
+
+
+class SpendLeaseMintLost(RuntimeError):
+    """Recovery or the statement-time expiry guard fenced this mint."""
+
+
+class SpendLeaseContractError(RuntimeError):
+    """Persisted fence/arbitration state violates the protocol contract."""
+
+
+class FenceOutcome(StrEnum):
+    LOST_RACE = "lost_race"
+    STALE_ADVISORY = "stale_advisory"
+    COUNT_EXHAUSTED = "count_exhausted"
+    WINDOW_OPEN = "window_open"
+    MISSING_OR_CORRUPT = "missing_or_corrupt"
+    CONTRACT_VIOLATION = "contract_violation"
+
+
+@dataclass(frozen=True, slots=True)
+class FenceView:
+    gen: int | None
+    open_predecessor_count: int | None
+    active_lease_id: str | None
+    active_lease_valid: bool | None
+
+
+@dataclass(frozen=True, slots=True)
+class FenceDecision:
+    outcome: FenceOutcome
+    reason: NoLeaseReason | None
+
+
+def derive_candidate_lease_id(
+    key_hash: str,
+    boot_kid: str,
+    gen: int,
+    creating_authorization_id: str,
+) -> str:
+    """Decision 46's stable, attempt-unique candidate identity."""
+
+    if not key_hash or not boot_kid or gen <= 0 or not creating_authorization_id:
+        raise ValueError("candidate lease identity fields must be non-empty and positive")
+    material = "\0".join((key_hash, boot_kid, str(gen), creating_authorization_id))
+    return hashlib.sha256(material.encode()).hexdigest()
+
+
+def classify_fence_loss(
+    *,
+    observed_gen: int,
+    incumbent_mark_count: int,
+    predecessor_limit: int,
+    window_closed: bool,
+    authoritative_exhaustion: bool,
+    statement_window_open: bool,
+    current: FenceView | None,
+) -> FenceDecision:
+    """Decision 45's precedence-ordered zero-row truth table."""
+
+    if not statement_window_open:
+        raise SpendLeaseMintLost("candidate expiry guard rejected the fence update")
+    if (
+        current is None
+        or current.gen is None
+        or current.open_predecessor_count is None
+        or current.active_lease_id is None
+        or current.active_lease_valid is None
+        or current.gen < observed_gen
+        or current.open_predecessor_count < 0
+        or current.open_predecessor_count > predecessor_limit
+    ):
+        return FenceDecision(FenceOutcome.MISSING_OR_CORRUPT, None)
+    if current.gen > observed_gen:
+        if current.active_lease_valid:
+            return FenceDecision(FenceOutcome.LOST_RACE, "lease_transferred")
+        return FenceDecision(FenceOutcome.STALE_ADVISORY, "stale_advisory")
+    if current.open_predecessor_count + incumbent_mark_count > predecessor_limit:
+        return FenceDecision(FenceOutcome.COUNT_EXHAUSTED, "predecessor_limit")
+    if not window_closed and not authoritative_exhaustion:
+        return FenceDecision(FenceOutcome.WINDOW_OPEN, "window_open")
+    return FenceDecision(FenceOutcome.CONTRACT_VIOLATION, None)
+
+
+PresentedRoute = Literal["reuse", "successor", "ordinary"]
+
+
+@dataclass(frozen=True, slots=True)
+class PresentedDecision:
+    route: PresentedRoute
+    reason: NoLeaseReason | None = None
+    authoritative_exhaustion: bool = False
+
+
+def route_local_presented(
+    local: SpendLease,
+    *,
+    now: datetime,
+) -> PresentedDecision:
+    """Decision 47 Table A, evaluated from local state and deadline."""
+
+    from trusted_router.spend_lease_state import SpendLeaseState
+
+    if local.state == SpendLeaseState.ACTIVE:
+        if now < local.expires_at + local.skew:
+            return PresentedDecision("reuse")
+        return PresentedDecision("successor")
+    if local.state == SpendLeaseState.TOMBSTONED:
+        return PresentedDecision("successor", authoritative_exhaustion=True)
+    if local.state in {SpendLeaseState.DRAINING, SpendLeaseState.CLOSED}:
+        return PresentedDecision("successor")
+    raise SpendLeaseContractError(f"unknown local lease state: {local.state!r}")
+
+
+def route_local_refusal(reason: SpendLeaseRefusalReason) -> PresentedDecision:
+    """Decision 47 A2--A5 for a typed allocation refusal."""
+
+    if reason == SpendLeaseRefusalReason.WINDOW_NOT_ELAPSED:
+        return PresentedDecision("ordinary", "window_open")
+    if reason == SpendLeaseRefusalReason.EXHAUSTED:
+        return PresentedDecision("successor", authoritative_exhaustion=True)
+    if reason == SpendLeaseRefusalReason.FROZEN_TOMBSTONED:
+        return PresentedDecision("successor", authoritative_exhaustion=True)
+    if reason in {
+        SpendLeaseRefusalReason.FROZEN_DRAINING,
+        SpendLeaseRefusalReason.CLOSED,
+        SpendLeaseRefusalReason.WINDOW_EXPIRED,
+    }:
+        return PresentedDecision("successor")
+    raise SpendLeaseContractError(f"unknown refusal reason: {reason!r}")
+
+
+@dataclass(frozen=True, slots=True)
+class GlobalLeaseView:
+    state: Literal["ACTIVE", "DRAINING", "TOMBSTONED", "CLOSED"]
+    expires_at: datetime
+    skew_seconds: int
+
+
+def route_missing_local(
+    global_lease: GlobalLeaseView | None,
+    *,
+    now: datetime,
+) -> PresentedDecision:
+    """Decision 47 Table B, deadline first and state second."""
+
+    if global_lease is None:
+        return PresentedDecision("ordinary", "ledger_unavailable")
+    if now >= global_lease.expires_at + timedelta(seconds=global_lease.skew_seconds):
+        return PresentedDecision("successor", authoritative_exhaustion=True)
+    if global_lease.state in {"CLOSED", "TOMBSTONED"}:
+        return PresentedDecision("successor", authoritative_exhaustion=True)
+    return PresentedDecision("ordinary", "ledger_unavailable")

--- a/src/trusted_router/spend_leases.py
+++ b/src/trusted_router/spend_leases.py
@@ -64,6 +64,34 @@ SpendLeaseEligibilityFailure = Literal[
     "regional_lease",
     "key_window_limit",
 ]
+SpendLeaseBindingFailure = Literal[
+    "no_idempotency_key",
+    "escrow_headroom",
+    "scope_arbitrated",
+    "predecessor_limit",
+    "lease_transferred",
+    "lease_expired",
+    "stale_advisory",
+    "ledger_unavailable",
+    "window_open",
+    "mint_lost",
+]
+SpendLeaseNoLeaseReason = SpendLeaseEligibilityFailure | SpendLeaseBindingFailure
+SpendLeaseBindingOutcome = Literal[
+    "not_eligible",
+    "ordinary",
+    "replay",
+    "reuse_bound",
+    "mint_bound",
+    "escrow_refused",
+    "scope_claimed",
+    "fence_lost_race",
+    "fence_stale_advisory",
+    "fence_count_exhausted",
+    "fence_window_open",
+    "mint_lost",
+    "ledger_unavailable",
+]
 
 
 def spend_lease_scope_salt(idempotency_scope: str) -> str:
@@ -101,6 +129,7 @@ class SpendLeaseArtifact:
     boot_kid: str
     catalog_version: str
     lease_status: LeaseStatus = "active"
+    open_predecessor_count: int = 0
 
 
 @dataclass(frozen=True)
@@ -138,7 +167,8 @@ class SpendLeaseShadowEvent:
     boot_kid: str
     boot_verified: bool
     lease_id: str | None
-    no_lease_reason: SpendLeaseEligibilityFailure | None
+    no_lease_reason: SpendLeaseNoLeaseReason | None
+    binding_outcome: SpendLeaseBindingOutcome | None
     echo_state: str
     would_admit: bool | None
     enclave_estimate_micro: int | None
@@ -621,7 +651,8 @@ def build_spend_lease_shadow_event(
     key_hash: str,
     boot_kid: str,
     boot_verified: bool,
-    no_lease_reason: SpendLeaseEligibilityFailure | None,
+    no_lease_reason: SpendLeaseNoLeaseReason | None,
+    binding_outcome: SpendLeaseBindingOutcome | None = None,
     echo: SpendLeaseEchoValue | None,
     server_estimate_micro: int | None,
     server_verdict: ShadowVerdict,
@@ -646,6 +677,7 @@ def build_spend_lease_shadow_event(
         boot_verified=boot_verified,
         lease_id=echo.lease_id if echo else None,
         no_lease_reason=no_lease_reason,
+        binding_outcome=binding_outcome,
         echo_state=echo.state if echo else "missing",
         would_admit=echo.would_admit if echo else None,
         enclave_estimate_micro=echo.enclave_estimate_micro if echo else None,

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -2630,6 +2630,12 @@ def create_store(settings: Any) -> Store:
                 "regional_quota_bigtable_app_profile_map",
                 {},
             ),
+            spend_lease_bigtable_table=getattr(
+                settings, "spend_lease_bigtable_table", "trustedrouter-spend-lease"
+            ),
+            spend_lease_bigtable_app_profiles=getattr(
+                settings, "spend_lease_bigtable_app_profile_map", {}
+            ),
         )
     raise ValueError(f"unsupported storage backend: {backend}")
 

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -334,6 +334,8 @@ class SpannerBigtableStore:
         regional_quota_leases_enabled: bool = False,
         regional_quota_bigtable_table: str = "trustedrouter-regional-quota",
         regional_quota_bigtable_app_profiles: dict[str, str] | None = None,
+        spend_lease_bigtable_table: str = "trustedrouter-spend-lease",
+        spend_lease_bigtable_app_profiles: dict[str, str] | None = None,
     ) -> None:
         if not spanner_instance_id or not spanner_database_id:
             raise ValueError("Spanner instance and database IDs are required")
@@ -451,6 +453,7 @@ class SpannerBigtableStore:
                 self._bt_table = bt_instance.table(generation_table)
         self._bigtable_app_profile_id = bigtable_app_profile_id
         self._regional_quota_ledger = None
+        self._spend_lease_ledger = None
         self._regional_quota_lease_cache: dict[tuple[str, str, int], Any] = {}
         self._regional_quota_lease_cache_lock = threading.Lock()
         profiles = dict(regional_quota_bigtable_app_profiles or {})
@@ -487,6 +490,32 @@ class SpannerBigtableStore:
                         app_profile_id=profile,
                     )
                     for region, profile in profiles.items()
+                }
+            )
+        spend_profiles = dict(spend_lease_bigtable_app_profiles or {})
+        if spend_profiles:
+            if not bigtable_instance_id:
+                raise ValueError("spend lease app profiles require a Bigtable instance")
+            try:
+                from google.cloud import bigtable
+            except ImportError as exc:  # pragma: no cover - production image.
+                raise RuntimeError(
+                    "Install google-cloud-bigtable when spend lease access is configured"
+                ) from exc
+            from trusted_router.spend_lease_ledger import BigtableSpendLeaseLedger
+
+            spend_instance = bigtable.Client(
+                project=project_id,
+                credentials=credentials,
+                admin=False,
+            ).instance(bigtable_instance_id)
+            self._spend_lease_ledger = BigtableSpendLeaseLedger(
+                {
+                    profile_region: spend_instance.table(
+                        spend_lease_bigtable_table,
+                        app_profile_id=profile,
+                    )
+                    for profile_region, profile in spend_profiles.items()
                 }
             )
         # Composed feature stores. Each owns its own logic and is importable
@@ -3414,6 +3443,7 @@ class SpannerBigtableStore:
         expires_at: Any = None,
         window_limits: dict[str, int] | None = None,
         spend_lease: SpendLeaseArtifact | None = None,
+        spend_lease_binding_plan: Any = None,
     ) -> tuple[str, GatewayAuthorization | None]:
         """Route-facing typed authorize. Runs the atomic conditional-DML authorize
         (holds + reservation + gateway_authorization DML-insert) and returns
@@ -3440,6 +3470,7 @@ class SpannerBigtableStore:
         )
 
         built_authorizations: dict[str, GatewayAuthorization] = {}
+        base_authorizations: dict[str, GatewayAuthorization] = {}
 
         def build_authorization(
             authorization_id: str,
@@ -3502,7 +3533,50 @@ class SpannerBigtableStore:
                 spend_lease_status=spend_lease.lease_status if spend_lease else None,
             )
             built_authorizations[authorization_id] = built
+            base_authorizations[authorization_id] = built
             return built
+
+        def build_authorization_for_lease(
+            authorization_id: str,
+            reservation_id: str,
+            bound: bool,
+        ) -> GatewayAuthorization:
+            base = base_authorizations.get(authorization_id)
+            if base is None:
+                base = build_authorization(authorization_id, reservation_id)
+            if not bound:
+                selected = dataclasses.replace(
+                    base,
+                    spend_lease_token=None,
+                    spend_lease_id=None,
+                    spend_lease_cap_micro=None,
+                    spend_lease_gen=None,
+                    spend_lease_iat=None,
+                    spend_lease_exp=None,
+                    spend_lease_issuer_kid=None,
+                    spend_lease_boot_kid=None,
+                    spend_lease_catalog_version=None,
+                    spend_lease_status=None,
+                    spend_lease_allocated_micro=None,
+                )
+            else:
+                artifact = spend_lease_binding_plan.artifact
+                selected = dataclasses.replace(
+                    base,
+                    spend_lease_token=artifact.token,
+                    spend_lease_id=artifact.lease_id,
+                    spend_lease_cap_micro=artifact.cap_micro,
+                    spend_lease_gen=artifact.gen,
+                    spend_lease_iat=artifact.iat,
+                    spend_lease_exp=artifact.exp,
+                    spend_lease_issuer_kid=artifact.issuer_kid,
+                    spend_lease_boot_kid=artifact.boot_kid,
+                    spend_lease_catalog_version=artifact.catalog_version,
+                    spend_lease_status=artifact.lease_status,
+                    spend_lease_allocated_micro=spend_lease_binding_plan.allocation_micro,
+                )
+            built_authorizations[authorization_id] = selected
+            return selected
 
         def build_body(authorization_id: str, reservation_id: str) -> str:
             return _json_body(build_authorization(authorization_id, reservation_id))
@@ -3545,7 +3619,22 @@ class SpannerBigtableStore:
         )
 
         def run_authorize(candidates: tuple[int, ...]) -> dict[str, Any]:
-            def invoke() -> dict[str, Any]:
+            def invoke(*, use_binding: bool = True) -> dict[str, Any]:
+                spend_hook = None
+                retry_types: tuple[type[BaseException], ...] = ()
+                if spend_lease_binding_plan is not None and use_binding:
+                    from trusted_router.spend_lease_authorize import (
+                        SpendLeaseArbitrationConflict,
+                    )
+
+                    def spend_hook(transaction: Any, shard: int) -> dict[str, Any]:
+                        return spend_lease_binding_plan.transaction_hook(
+                            transaction,
+                            self._param_types,
+                            workspace_id,
+                            shard,
+                        )
+                    retry_types = (SpendLeaseArbitrationConflict,)
                 return authorize_atomic(
                     self._database,
                     self._param_types,
@@ -3567,6 +3656,13 @@ class SpannerBigtableStore:
                     credit_shard_candidates=bounded_credit_shard_candidates(candidates),
                     key_shard_candidates=key_shard_candidates,
                     authorization_id=authorization_id,
+                    spend_lease_hook=spend_hook,
+                    build_authorization_for_lease=(
+                        build_authorization_for_lease
+                        if spend_lease_binding_plan is not None and use_binding
+                        else None
+                    ),
+                    also_retry=retry_types,
                 )
 
             try:
@@ -3578,6 +3674,53 @@ class SpannerBigtableStore:
                 # read, so a winner replays before any new key/credit hold DML.
                 built_authorizations.pop(replay.authorization_id, None)
                 return invoke()
+            except Exception as exc:
+                if spend_lease_binding_plan is None:
+                    raise
+                from trusted_router.storage_gcp_spend_lease_authorize import (
+                    SpendLeaseMintLost,
+                    SpendLeaseReuseLost,
+                )
+
+                if isinstance(exc, SpendLeaseMintLost):
+                    built_authorizations.pop(
+                        spend_lease_binding_plan.provisional_id, None
+                    )
+                    base_authorizations.pop(
+                        spend_lease_binding_plan.provisional_id, None
+                    )
+                    result = invoke(use_binding=False)
+                    result.update(
+                        bound=False,
+                        no_lease_reason="mint_lost",
+                        spend_lease_outcome="mint_lost",
+                    )
+                    return result
+                if isinstance(exc, SpendLeaseReuseLost):
+                    built_authorizations.pop(
+                        spend_lease_binding_plan.provisional_id, None
+                    )
+                    base_authorizations.pop(
+                        spend_lease_binding_plan.provisional_id, None
+                    )
+                    result = invoke(use_binding=False)
+                    result.update(
+                        bound=False,
+                        no_lease_reason=exc.reason,
+                        spend_lease_outcome="ordinary",
+                        compensate_reuse=True,
+                    )
+                    return result
+                from trusted_router.spend_lease_authorize import (
+                    SpendLeaseArbitrationConflict,
+                )
+                from trusted_router.storage_errors import StoreConflict
+
+                if isinstance(exc, SpendLeaseArbitrationConflict):
+                    raise StoreConflict(
+                        "spend-lease scope arbitration remained contended"
+                    ) from exc
+                raise
 
         result = run_authorize(credit_shard_candidates)
         if result["outcome"] == AuthorizeOutcome.KEY_LIMIT_EXCEEDED and key_counter_shards > 1:
@@ -3747,7 +3890,237 @@ class SpannerBigtableStore:
             authorization = self.get_gateway_authorization(result["authorization_id"])
         from trusted_router.storage_gcp_authorize import AuthorizeVerdict
 
-        return AuthorizeVerdict(outcome, rate_limit=window_decision), authorization
+        verdict = AuthorizeVerdict(
+            outcome,
+            rate_limit=window_decision,
+            spend_lease_bound=bool(result.get("bound")),
+            no_lease_reason=result.get("no_lease_reason"),
+            spend_lease_outcome=result.get("spend_lease_outcome"),
+        )
+        if outcome == AuthorizeOutcome.REPLAY and authorization is not None:
+            verdict.spend_lease_bound = bool(
+                authorization.spend_lease_token
+                and authorization.spend_lease_id
+                and authorization.spend_lease_gen
+                and authorization.spend_lease_allocated_micro
+            )
+        if spend_lease_binding_plan is not None and outcome == AuthorizeOutcome.ACCEPTED:
+            if verdict.spend_lease_bound:
+                spend_lease_binding_plan.bind_after_commit()
+            elif result.get("compensate_reuse") or (
+                result.get("spend_lease_outcome")
+                in {
+                    "escrow_refused",
+                    "scope_claimed",
+                    "fence_lost_race",
+                    "fence_stale_advisory",
+                    "fence_count_exhausted",
+                    "fence_window_open",
+                }
+            ):
+                spend_lease_binding_plan.compensate_with_claim(
+                    self._database,
+                    self._param_types,
+                )
+        return verdict, authorization
+
+    def prepare_gateway_spend_lease_binding(
+        self,
+        *,
+        workspace_id: str,
+        key_hash: str,
+        authorization_id: str,
+        idempotency_key: str | None,
+        idempotency_fingerprint: str,
+        estimate: int,
+        boot_kid: str,
+        region: str,
+        signer: Any,
+        catalog: dict[str, Any],
+        ttl_seconds: int,
+        skew_seconds: int,
+        max_microdollars: int,
+        max_available_basis_points: int,
+        echo_lease_id: str | None,
+        echo_state: str | None,
+    ) -> tuple[Any | None, str | None]:
+        """Decision 31/46 preparation, called only behind the binding flag."""
+        from trusted_router.spend_lease_ledger import SpendLeaseLedgerError
+        from trusted_router.spend_lease_state import (
+            Created,
+            ExistingLocal,
+            SpendLeaseUnavailableError,
+            is_authoritative_exhaustion,
+        )
+        from trusted_router.storage_gcp_keys import (
+            _gateway_authorization_idempotency_index_id,
+        )
+        from trusted_router.storage_gcp_spend_lease_authorize import (
+            BindingPlan,
+            prepare_candidate,
+            reservation_exists,
+        )
+
+        if idempotency_key is None:
+            return None, "no_idempotency_key"
+        scope = _gateway_authorization_idempotency_index_id(
+            workspace_id, key_hash, idempotency_key
+        )
+        if reservation_exists(self._database, self._param_types, scope):
+            return None, None
+        ledger = self._spend_lease_ledger
+        if ledger is None or not ledger.supports_region(region):
+            return None, "ledger_unavailable"
+        now = dt.datetime.now(dt.UTC)
+        active = self.get_active_spend_lease(key_hash, boot_kid)
+        if (
+            active is not None
+            and echo_lease_id is not None
+            and echo_lease_id != active.lease_id
+        ):
+            return None, "lease_transferred"
+        authoritative_exhaustion = bool(
+            active is not None
+            and echo_lease_id == active.lease_id
+            and echo_state in {"exhausted", "terminal"}
+        )
+        window_closed = active is None or now >= dt.datetime.fromtimestamp(
+            active.exp + skew_seconds, tz=dt.UTC
+        )
+        if active is not None and not window_closed and not authoritative_exhaustion:
+            try:
+                result = ledger.allocate(
+                    None,
+                    active.lease_id,
+                    region=region,
+                    idempotency_scope=scope,
+                    provisional_authorization_id=authorization_id,
+                    request_fingerprint=idempotency_fingerprint,
+                    allocated_micro=estimate,
+                    abandon_after=dt.datetime.fromtimestamp(
+                        active.exp + skew_seconds, tz=dt.UTC
+                    ),
+                    now=now,
+                )
+            except SpendLeaseLedgerError:
+                global_lease = self._read_entity(
+                    "spend_lease", active.lease_id, dict
+                )
+                if global_lease is None:
+                    log.error(
+                        "spend_lease.local_missing_without_global_record",
+                        extra={"workspace_id": workspace_id, "region": region},
+                    )
+                    return None, "ledger_unavailable"
+                raw_global_exp = global_lease.get("expires_at")
+                if isinstance(raw_global_exp, str):
+                    try:
+                        global_deadline = dt.datetime.fromisoformat(
+                            raw_global_exp.replace("Z", "+00:00")
+                        )
+                    except ValueError:
+                        return None, "ledger_unavailable"
+                else:
+                    global_deadline = dt.datetime.fromtimestamp(
+                        int(global_lease.get("exp", 0)), tz=dt.UTC
+                    )
+                global_skew = int(global_lease.get("skew_seconds", skew_seconds))
+                global_state = str(global_lease.get("state") or "")
+                if now >= global_deadline + dt.timedelta(seconds=global_skew):
+                    window_closed = True
+                    authoritative_exhaustion = True
+                elif global_state in {"CLOSED", "TOMBSTONED"}:
+                    window_closed = True
+                    authoritative_exhaustion = True
+                else:
+                    log.error(
+                        "spend_lease.local_global_inconsistency",
+                        extra={"workspace_id": workspace_id, "region": region},
+                    )
+                    return None, "ledger_unavailable"
+            except SpendLeaseUnavailableError as exc:
+                authoritative_exhaustion = is_authoritative_exhaustion(exc)
+                window_closed = exc.reason.value in {
+                    "frozen_draining", "frozen_tombstoned", "closed", "window_expired"
+                }
+                if not window_closed and not authoritative_exhaustion:
+                    return None, "window_open"
+            else:
+                if isinstance(result, ExistingLocal):
+                    return None, None
+                if isinstance(result, Created):
+                    return (
+                        BindingPlan(
+                            ledger=ledger,
+                            scope=scope,
+                            fence_id=self._spend_lease_pair_id(key_hash, boot_kid),
+                            region=region,
+                            provisional_id=authorization_id,
+                            artifact=active,
+                            allocation_micro=estimate,
+                            admission_deadline=dt.datetime.fromtimestamp(
+                                active.exp + skew_seconds, tz=dt.UTC
+                            ),
+                            mode="reuse",
+                            candidate=None,
+                            observed_gen=active.gen,
+                            incumbent_lease_id=active.lease_id,
+                            incumbent_window_closed=False,
+                            authoritative_exhaustion=False,
+                        ),
+                        None,
+                    )
+                return None, None
+
+        snapshot = self.typed_credit_snapshot(workspace_id)
+        if snapshot is None:
+            return None, "ledger_unavailable"
+        available = max(0, int(snapshot[0]) - int(snapshot[1]) - int(snapshot[2]))
+        cap_micro = min(
+            max_microdollars,
+            max(0, available - estimate) * max_available_basis_points // 10_000,
+        )
+        if cap_micro <= 0:
+            return None, "escrow_headroom"
+        observed_gen = active.gen if active is not None else 0
+        if active is None:
+            from trusted_router.storage_gcp_spend_lease_authorize import ensure_initial_fence
+
+            ensure_initial_fence(
+                self._database,
+                self._param_types,
+                self._spend_lease_pair_id(key_hash, boot_kid),
+            )
+        return (
+            prepare_candidate(
+                database=self._database,
+                param_types=self._param_types,
+                ledger=ledger,
+                signer=signer,
+                scope=scope,
+                fence_id=self._spend_lease_pair_id(key_hash, boot_kid),
+                provisional_id=authorization_id,
+                workspace_id=workspace_id,
+                key_hash=key_hash,
+                boot_kid=boot_kid,
+                region=region,
+                gen=observed_gen + 1,
+                cap_micro=cap_micro,
+                allocation_micro=estimate,
+                ttl_seconds=ttl_seconds,
+                skew_seconds=skew_seconds,
+                request_fingerprint=idempotency_fingerprint,
+                catalog=catalog,
+                observed_gen=observed_gen,
+                observed_predecessor_count=(
+                    active.open_predecessor_count if active is not None else 0
+                ),
+                incumbent_lease_id=active.lease_id if active is not None else None,
+                incumbent_window_closed=window_closed,
+                authoritative_exhaustion=authoritative_exhaustion,
+            ),
+            None,
+        )
 
     def reap_expired_reservations(self, *, now: Any, limit: int = 100) -> int:
         from trusted_router.storage_gcp_authorize import (
@@ -4770,10 +5143,16 @@ class SpannerBigtableStore:
         return hashlib.sha256(f"{key_hash}\0{boot_kid}".encode()).hexdigest()
 
     def get_active_spend_lease(self, key_hash: str, boot_kid: str) -> SpendLeaseArtifact | None:
-        return self._read_entity(
+        payload = self._read_entity(
             SPEND_LEASE_ACTIVE_GRANT_KIND,
             self._spend_lease_pair_id(key_hash, boot_kid),
-            SpendLeaseArtifact,
+            dict,
+        )
+        if payload is None or not payload.get("token"):
+            return None
+        known = {field.name for field in dataclasses.fields(SpendLeaseArtifact)}
+        return SpendLeaseArtifact(
+            **{key: value for key, value in payload.items() if key in known}
         )
 
     def retain_spend_lease(

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -96,15 +96,24 @@ class AuthorizeVerdict(str):
     """String-compatible typed-authorize outcome with its window decision."""
 
     rate_limit: KeyWindowLimitDecision | None
+    spend_lease_bound: bool
+    no_lease_reason: str | None
+    spend_lease_outcome: str | None
 
     def __new__(
         cls,
         outcome: str,
         *,
         rate_limit: KeyWindowLimitDecision | None = None,
+        spend_lease_bound: bool = False,
+        no_lease_reason: str | None = None,
+        spend_lease_outcome: str | None = None,
     ) -> AuthorizeVerdict:
         verdict = super().__new__(cls, outcome)
         verdict.rate_limit = rate_limit
+        verdict.spend_lease_bound = spend_lease_bound
+        verdict.no_lease_reason = no_lease_reason
+        verdict.spend_lease_outcome = spend_lease_outcome
         return verdict
 
 
@@ -245,6 +254,11 @@ def authorize_atomic(
     credit_shard_candidates: tuple[int, ...] | None = None,
     key_shard_candidates: tuple[int, ...] = (UNSHARDED,),
     authorization_id: str | None = None,
+    spend_lease_hook: Callable[[Any, int], dict[str, Any]] | None = None,
+    build_authorization_for_lease: (
+        Callable[[str, str, bool], GatewayAuthorization] | None
+    ) = None,
+    also_retry: tuple[type[BaseException], ...] = (),
 ) -> dict:
     """Run the atomic authorize. Returns {outcome, reservation_id?, authorization_id?}.
 
@@ -376,6 +390,14 @@ def authorize_atomic(
                 raise _Reject(AuthorizeOutcome.INSUFFICIENT_CREDITS)
             credit_hold = estimate
 
+        lease_result: dict[str, Any] = {
+            "bound": False,
+            "no_lease_reason": None,
+            "spend_lease_outcome": None,
+        }
+        if spend_lease_hook is not None:
+            lease_result = spend_lease_hook(transaction, selected_credit_shard)
+
         insert_reservation(
             transaction, pt,
             reservation_id=reservation_id, workspace_id=workspace_id, key_hash=key_hash,
@@ -388,11 +410,21 @@ def authorize_atomic(
             created_at=created_at,
         )
         if request_record_write_mode == "typed":
-            assert authorization is not None
+            selected_authorization = authorization
+            if build_authorization_for_lease is not None:
+                selected_authorization = build_authorization_for_lease(
+                    authorization_id,
+                    reservation_id,
+                    bool(lease_result.get("bound")),
+                )
+                selected_authorization.created_at = created_at.isoformat().replace(
+                    "+00:00", "Z"
+                )
+            assert selected_authorization is not None
             insert_gateway_authorization(
                 transaction,
                 pt,
-                authorization,
+                selected_authorization,
                 created_at=created_at,
             )
         else:
@@ -410,6 +442,7 @@ def authorize_atomic(
             "authorization_id": authorization_id,
             "credit_shard": selected_credit_shard,
             "key_shard": selected_key_shard,
+            **lease_result,
         }
 
     try:
@@ -417,6 +450,7 @@ def authorize_atomic(
             database,
             txn,
             transaction_tag="tr_authorize",
+            also_retry=also_retry,
         )
     except _Reject as reject:
         return {"outcome": reject.outcome}

--- a/src/trusted_router/storage_gcp_io.py
+++ b/src/trusted_router/storage_gcp_io.py
@@ -191,6 +191,7 @@ def run_in_transaction_with_retry(
     attempts_out: list[int] | None = None,
     total_budget_seconds: float = TXN_BUDGET_SECONDS,
     transaction_tag: str | None = None,
+    also_retry: tuple[type[BaseException], ...] = (),
 ) -> T:
     """Run a Spanner transaction, retrying on ABORTED within a wall-clock budget.
 
@@ -216,10 +217,11 @@ def run_in_transaction_with_retry(
     callback performs a non-idempotent side effect. Exponential backoff with
     jitter de-synchronizes contenders so they stop lockstepping on the row.
 
-    Only ``Aborted`` is retried; every other callback exception (including
-    ``TypeError``) propagates unchanged and is never mistaken for a signature
-    mismatch. On budget exhaustion the final ``Aborted`` is raised so callers
-    can map it to a retryable error rather than a multi-minute hang.
+    By default only ``Aborted`` is retried. ``also_retry`` lets one caller add
+    its own typed callback conflict without teaching the Spanner client about
+    that exception; every other callback exception (including ``TypeError``)
+    propagates unchanged. On budget exhaustion the final retryable exception
+    is raised so the caller can map it to its ordinary contention response.
 
     ``attempts_out``, if given, receives the winning attempt number (1 = no
     retry) — used to attribute finalize latency to contention.
@@ -230,14 +232,15 @@ def run_in_transaction_with_retry(
     """
     from google.api_core.exceptions import Aborted
 
+    retryable_errors = (Aborted,) + also_retry
     deadline = time.monotonic() + max(total_budget_seconds, _MIN_INNER_TIMEOUT_SECONDS)
     delay = 0.05
-    last_aborted: Aborted | None = None
+    last_retryable: BaseException | None = None
     for attempt in range(1, attempts + 1):
         remaining = deadline - time.monotonic()
-        if remaining <= 0 and last_aborted is not None:
+        if remaining <= 0 and last_retryable is not None:
             # Budget spent between the last abort's backoff and here.
-            raise last_aborted
+            raise last_retryable
         # Cap the client's internal retry to what's left of our wall-clock so a
         # single attempt cannot outlive the caller's budget (min floor keeps a
         # valid positive deadline for the final sliver).
@@ -247,8 +250,8 @@ def run_in_transaction_with_retry(
             if transaction_tag is not None:
                 transaction_kwargs["transaction_tag"] = transaction_tag
             result = database.run_in_transaction(func, **transaction_kwargs)
-        except Aborted as exc:
-            last_aborted = exc
+        except retryable_errors as exc:
+            last_retryable = exc
             if attempt >= attempts:
                 raise
             remaining_after = deadline - time.monotonic()

--- a/src/trusted_router/storage_gcp_request_records.py
+++ b/src/trusted_router/storage_gcp_request_records.py
@@ -23,6 +23,12 @@ from datetime import UTC, datetime
 from typing import Any
 
 from trusted_router.storage_gcp_codec import json_body
+from trusted_router.storage_gcp_spend_lease import (
+    AUTHORIZATION_TYPED_COLUMNS,
+    authorization_typed_columns,
+    authorization_typed_param_types,
+    merge_authorization_typed_columns,
+)
 from trusted_router.storage_models import GatewayAuthorization
 from trusted_router.types import UsageType
 
@@ -55,15 +61,23 @@ def insert_gateway_authorization(
     created_at: Any,
 ) -> None:
     """Insert active authorization state in the caller's billing transaction."""
+    payload = dataclasses.asdict(authorization)
+    typed = authorization_typed_columns(payload)
     transaction.execute_update(
         "INSERT INTO tr_gateway_authorization ("
         "authorization_id, workspace_id, key_hash, reservation_id, model_id, "
         "provider, usage_type, estimated_microdollars, settled, created_at, "
-        "terminal_at, payload"
+        "terminal_at, payload, spend_lease_id, spend_lease_gen, "
+        "spend_lease_allocated_micro, spend_lease_token, spend_lease_status, "
+        "spend_lease_exp, idempotency_fingerprint, finalization_outcome, "
+        "finalized_cost_microdollars"
         ") VALUES ("
         "@authorization_id, @workspace_id, @key_hash, @reservation_id, @model_id, "
         "@provider, @usage_type, @estimated_microdollars, false, @created_at, "
-        "NULL, @payload"
+        "NULL, @payload, @spend_lease_id, @spend_lease_gen, "
+        "@spend_lease_allocated_micro, @spend_lease_token, @spend_lease_status, "
+        "@spend_lease_exp, @idempotency_fingerprint, @finalization_outcome, "
+        "@finalized_cost_microdollars"
         ")",
         params={
             "authorization_id": authorization.id,
@@ -76,6 +90,7 @@ def insert_gateway_authorization(
             "estimated_microdollars": int(authorization.estimated_microdollars),
             "created_at": created_at,
             "payload": json_body(authorization),
+            **typed,
         },
         param_types={
             "authorization_id": param_types.STRING,
@@ -88,6 +103,7 @@ def insert_gateway_authorization(
             "estimated_microdollars": param_types.INT64,
             "created_at": param_types.TIMESTAMP,
             "payload": param_types.STRING,
+            **authorization_typed_param_types(param_types),
         },
     )
 
@@ -101,7 +117,11 @@ def read_gateway_authorization(
         reader.execute_sql(
             "SELECT authorization_id, workspace_id, key_hash, reservation_id, "
             "model_id, provider, usage_type, estimated_microdollars, settled, "
-            "created_at, payload FROM tr_gateway_authorization "
+            "created_at, payload, spend_lease_id, spend_lease_gen, "
+            "spend_lease_allocated_micro, spend_lease_token, spend_lease_status, "
+            "spend_lease_exp, idempotency_fingerprint, finalization_outcome, "
+            "finalized_cost_microdollars "
+            "FROM tr_gateway_authorization "
             "WHERE authorization_id=@authorization_id",
             params={"authorization_id": authorization_id},
             param_types={"authorization_id": param_types.STRING},
@@ -121,12 +141,17 @@ def read_gateway_authorization(
         settled,
         created_at,
         payload,
+        *typed_values,
     ) = rows[0]
+    typed = dict(zip(AUTHORIZATION_TYPED_COLUMNS, typed_values, strict=True))
     if payload:
-        authorization = _authorization_from_payload(payload)
+        authorization = _authorization_from_payload(
+            json.dumps(merge_authorization_typed_columns(json.loads(payload), typed))
+        )
         authorization.settled = bool(settled)
         authorization.created_at = _timestamp_string(created_at)
         return authorization
+    merged = merge_authorization_typed_columns(None, typed)
     return GatewayAuthorization(
         id=str(row_id),
         workspace_id=str(workspace_id),
@@ -140,6 +165,15 @@ def read_gateway_authorization(
         ),
         settled=bool(settled),
         created_at=_timestamp_string(created_at),
+        spend_lease_id=merged.get("spend_lease_id"),
+        spend_lease_gen=merged.get("spend_lease_gen"),
+        spend_lease_allocated_micro=merged.get("spend_lease_allocated_micro"),
+        spend_lease_token=merged.get("spend_lease_token"),
+        spend_lease_status=merged.get("spend_lease_status"),
+        spend_lease_exp=merged.get("spend_lease_exp"),
+        idempotency_fingerprint=merged.get("idempotency_fingerprint"),
+        finalization_outcome=merged.get("finalization_outcome"),
+        finalized_cost_microdollars=merged.get("finalized_cost_microdollars"),
     )
 
 
@@ -149,16 +183,23 @@ def mark_gateway_authorization_settled(
     authorization: GatewayAuthorization,
 ) -> int:
     """Mark billing settled while keeping repair metadata and TTL disabled."""
+    typed = authorization_typed_columns(dataclasses.asdict(authorization))
     return transaction.execute_update(
-        "UPDATE tr_gateway_authorization SET settled=true, payload=@payload "
+        "UPDATE tr_gateway_authorization SET settled=true, payload=@payload, "
+        "finalization_outcome=@finalization_outcome, "
+        "finalized_cost_microdollars=@finalized_cost_microdollars "
         "WHERE authorization_id=@authorization_id",
         params={
             "authorization_id": authorization.id,
             "payload": json_body(authorization),
+            "finalization_outcome": typed["finalization_outcome"],
+            "finalized_cost_microdollars": typed["finalized_cost_microdollars"],
         },
         param_types={
             "authorization_id": param_types.STRING,
             "payload": param_types.STRING,
+            "finalization_outcome": param_types.STRING,
+            "finalized_cost_microdollars": param_types.INT64,
         },
     )
 

--- a/src/trusted_router/storage_gcp_spend_lease.py
+++ b/src/trusted_router/storage_gcp_spend_lease.py
@@ -279,6 +279,34 @@ def read_registration(
     raise SpendLeaseDataError(f"unknown arbitration registration kind: {kind!r}")
 
 
+def delete_bound(
+    transaction: Any,
+    param_types: Any,
+    scope: str,
+    authorization_id: str,
+) -> int:
+    """Delete only this attempt's BOUND registration during an exact inverse."""
+
+    return _single_row_count(
+        "delete_bound",
+        transaction.execute_update(
+            "DELETE FROM spend_lease_scope_arbitration "
+            "WHERE scope_salt=@scope_salt AND idempotency_scope=@scope "
+            "AND registration_kind='BOUND' AND authorization_id=@authorization_id",
+            params={
+                "scope_salt": spend_leases.spend_lease_scope_salt(scope),
+                "scope": scope,
+                "authorization_id": authorization_id,
+            },
+            param_types={
+                "scope_salt": param_types.STRING,
+                "scope": param_types.STRING,
+                "authorization_id": param_types.STRING,
+            },
+        ),
+    )
+
+
 def arm_bound_retention(
     transaction: Any,
     param_types: Any,

--- a/src/trusted_router/storage_gcp_spend_lease_authorize.py
+++ b/src/trusted_router/storage_gcp_spend_lease_authorize.py
@@ -1,0 +1,508 @@
+"""Flag-gated Spanner/Bigtable coordinator for bound spend-lease authorize.
+
+The gateway imports this module only when ``TR_SPEND_LEASE_BINDING_ENABLED`` is
+true.  Candidate creation is deliberately outside the billing transaction;
+all cross-store authority is represented by the candidate work row, BOUND or
+CLAIM proof, and the post-commit bind seam.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Literal
+
+from trusted_router.spend_lease_authorize import (
+    FenceView,
+    SpendLeaseArbitrationConflict,
+    SpendLeaseContractError,
+    SpendLeaseMintLost,
+    classify_fence_loss,
+    derive_candidate_lease_id,
+)
+from trusted_router.spend_lease_ledger import SpendLeaseLedger
+from trusted_router.spend_lease_state import (
+    AbsenceObservation,
+    BindingAbsenceProof,
+    BoundProof,
+    ClaimProof,
+    Created,
+    ExistingLocal,
+    Mismatch,
+    SpendLease,
+)
+from trusted_router.spend_leases import SpendLeaseArtifact, SpendLeaseSigner
+from trusted_router.storage_gcp_counter_dml import (
+    insert_entity_dml,
+    read_reservation_by_idempotency,
+    release_credit,
+    reserve_credit,
+)
+from trusted_router.storage_gcp_io import run_in_transaction_with_retry
+from trusted_router.storage_gcp_spend_lease import (
+    CandidateIdentity,
+    delete_bound,
+    insert_candidate,
+    read_registration,
+    register_bound,
+    register_claim,
+    upgrade_candidate_to_open,
+)
+
+SPEND_LEASE_KIND = "spend_lease"
+FENCE_KIND = "spend_lease_active_grant"
+PREDECESSOR_LIMIT = 3
+
+
+class SpendLeaseReuseLost(RuntimeError):
+    def __init__(self, reason: Literal["lease_transferred", "lease_expired"]) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+class SpendLeaseExistingLocal(RuntimeError):
+    """A different local creator owns this scope; use ordinary authorize."""
+
+
+@dataclass(frozen=True, slots=True)
+class BindingPlan:
+    ledger: SpendLeaseLedger
+    scope: str
+    fence_id: str
+    region: str
+    provisional_id: str
+    artifact: SpendLeaseArtifact
+    allocation_micro: int
+    admission_deadline: datetime
+    mode: Literal["reuse", "mint"]
+    candidate: CandidateIdentity | None
+    observed_gen: int
+    incumbent_lease_id: str | None
+    incumbent_window_closed: bool
+    authoritative_exhaustion: bool
+
+    def transaction_hook(self, transaction: Any, param_types: Any, workspace_id: str, shard: int) -> dict[str, Any]:
+        if self.mode == "reuse":
+            return self._reuse_hook(transaction, param_types)
+        return self._mint_hook(transaction, param_types, workspace_id, shard)
+
+    def _register(self, transaction: Any, param_types: Any) -> bool:
+        count = register_bound(
+            transaction,
+            param_types,
+            self.scope,
+            self.provisional_id,
+            self.artifact.lease_id,
+            self.artifact.gen,
+            self.allocation_micro,
+        )
+        if count == 1:
+            return True
+        winner = read_registration(transaction, param_types, self.scope)
+        if winner is None:
+            raise SpendLeaseContractError("BOUND insert returned zero without a winner")
+        if winner.kind == "CLAIM":
+            return False
+        if winner.authorization_id != self.provisional_id:
+            raise SpendLeaseArbitrationConflict("foreign BOUND won scope arbitration")
+        return True
+
+    def _reuse_hook(self, transaction: Any, param_types: Any) -> dict[str, Any]:
+        if not self._register(transaction, param_types):
+            return _unbound("scope_arbitrated", "scope_claimed")
+        fence = _read_fence(transaction, param_types, self.fence_id, self.artifact.lease_id)
+        if fence is None or fence["gen"] > self.observed_gen:
+            raise SpendLeaseReuseLost("lease_transferred")
+        now = datetime.now(UTC)
+        if fence["gen"] != self.observed_gen or now >= self.admission_deadline:
+            raise SpendLeaseReuseLost("lease_expired")
+        return _bound("reuse_bound")
+
+    def _mint_hook(self, transaction: Any, param_types: Any, workspace_id: str, shard: int) -> dict[str, Any]:
+        if not reserve_credit(transaction, param_types, workspace_id, self.artifact.cap_micro, shard=shard):
+            return _unbound("escrow_headroom", "escrow_refused")
+        if not self._register(transaction, param_types):
+            _require_one(
+                release_credit(
+                    transaction,
+                    param_types,
+                    workspace_id,
+                    self.artifact.cap_micro,
+                    0,
+                    shard=shard,
+                ),
+                "CLAIM escrow inverse",
+            )
+            return _unbound("scope_arbitrated", "scope_claimed")
+
+        mark_count = _mark_incumbent(
+            transaction,
+            param_types,
+            self.incumbent_lease_id,
+        )
+        fence_count = _advance_fence(
+            transaction,
+            param_types,
+            artifact=self.artifact,
+            fence_id=self.fence_id,
+            observed_gen=self.observed_gen,
+            mark_count=mark_count,
+            window_closed=self.incumbent_window_closed,
+            authoritative_exhaustion=self.authoritative_exhaustion,
+        )
+        if fence_count == 0:
+            current = _read_fence(
+                transaction, param_types, self.fence_id, self.artifact.lease_id
+            )
+            decision = classify_fence_loss(
+                observed_gen=self.observed_gen,
+                incumbent_mark_count=mark_count,
+                predecessor_limit=PREDECESSOR_LIMIT,
+                window_closed=self.incumbent_window_closed,
+                authoritative_exhaustion=self.authoritative_exhaustion,
+                statement_window_open=datetime.now(UTC) < _artifact_expiry(self.artifact),
+                current=None if current is None else FenceView(
+                    gen=current.get("gen"),
+                    open_predecessor_count=current.get("open_predecessor_count"),
+                    active_lease_id=current.get("lease_id"),
+                    active_lease_valid=current.get("active_valid"),
+                ),
+            )
+            _require_one(delete_bound(transaction, param_types, self.scope, self.provisional_id), "BOUND inverse")
+            if mark_count:
+                _require_one(_unmark_incumbent(transaction, param_types, self.incumbent_lease_id), "incumbent inverse")
+            _require_one(
+                release_credit(transaction, param_types, workspace_id, self.artifact.cap_micro, 0, shard=shard),
+                "fence escrow inverse",
+            )
+            if decision.reason is None:
+                raise SpendLeaseContractError(f"fence loss: {decision.outcome}")
+            outcomes = {
+                "lease_transferred": "fence_lost_race",
+                "stale_advisory": "fence_stale_advisory",
+                "predecessor_limit": "fence_count_exhausted",
+                "window_open": "fence_window_open",
+            }
+            return _unbound(decision.reason, outcomes[decision.reason])
+
+        assert self.candidate is not None
+        insert_entity_dml(
+            transaction,
+            param_types,
+            SPEND_LEASE_KIND,
+            self.artifact.lease_id,
+            json.dumps(
+                {
+                    "state": "ACTIVE",
+                    "lease_id": self.artifact.lease_id,
+                    "gen": self.artifact.gen,
+                    "key_hash": self.candidate.key_hash,
+                    "boot_kid": self.candidate.boot_kid,
+                    "workspace_id": self.candidate.workspace_id,
+                    "region": self.candidate.region,
+                    "cap_micro": self.artifact.cap_micro,
+                    "expires_at": self.candidate.expires_at.isoformat(),
+                    "skew_seconds": self.candidate.skew_seconds,
+                    "credit_shard": shard,
+                    "frozen_local_version": None,
+                    "holds_predecessor_slot": False,
+                    "closing_at": None,
+                    "last_error": None,
+                },
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+        )
+        if upgrade_candidate_to_open(
+            transaction,
+            param_types,
+            self.candidate.lease_id,
+            self.provisional_id,
+            self.candidate.expires_at,
+            self.candidate.skew_seconds,
+        ) != 1:
+            raise SpendLeaseMintLost("candidate recovery won the phase handoff")
+        return _bound("mint_bound")
+
+    def bind_after_commit(self) -> None:
+        proof = BoundProof(
+            self.scope,
+            self.provisional_id,
+            self.artifact.lease_id,
+            self.artifact.gen,
+            self.allocation_micro,
+        )
+        # TODO(decision 21(f)): PR 4's reconciler binds from the surviving open
+        # row if this process crashes after Spanner commit and before this CAS.
+        self.ledger.bind(
+            self.artifact.lease_id,
+            region=self.region,
+            expected_provisional_id=self.provisional_id,
+            proof=proof,
+        )
+
+    def compensate_with_claim(self, database: Any, param_types: Any) -> None:
+        def claim_txn(transaction: Any) -> None:
+            if register_claim(transaction, param_types, self.scope, self.provisional_id) == 0:
+                registration = read_registration(transaction, param_types, self.scope)
+                if registration is None or registration.kind != "CLAIM" or registration.provisional_id != self.provisional_id:
+                    raise SpendLeaseContractError("compensation CLAIM was not authoritative")
+
+        run_in_transaction_with_retry(database, claim_txn, transaction_tag="tr_spend_lease_claim")
+        self.ledger.compensate(
+            self.artifact.lease_id,
+            region=self.region,
+            idempotency_scope=self.scope,
+            expected_provisional_id=self.provisional_id,
+            claim=ClaimProof(self.scope, self.provisional_id),
+            absence=BindingAbsenceProof(self.scope, self.provisional_id, AbsenceObservation.NON_BINDING_ROW),
+        )
+
+
+def reservation_exists(database: Any, param_types: Any, scope: str) -> bool:
+    """Decision 31's one strong, reservation-only pre-read."""
+    with database.snapshot() as snapshot:
+        return read_reservation_by_idempotency(snapshot, param_types, scope) is not None
+
+
+def ensure_initial_fence(database: Any, param_types: Any, fence_id: str) -> None:
+    """Idempotently create generation zero before the first bound mint."""
+
+    body = json.dumps(
+        {
+            "lease_id": "unminted",
+            "gen": 0,
+            "open_predecessor_count": 0,
+            "lease_status": "terminal",
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+    def txn(transaction: Any) -> None:
+        transaction.execute_update(
+            "INSERT OR IGNORE INTO tr_entities (kind, id, body, updated_at) "
+            "VALUES (@kind, @id, @body, PENDING_COMMIT_TIMESTAMP())",
+            params={"kind": FENCE_KIND, "id": fence_id, "body": body},
+            param_types={
+                "kind": param_types.STRING,
+                "id": param_types.STRING,
+                "body": param_types.STRING,
+            },
+        )
+
+    run_in_transaction_with_retry(database, txn, transaction_tag="tr_spend_lease_fence_init")
+
+
+def prepare_candidate(
+    *,
+    database: Any,
+    param_types: Any,
+    ledger: SpendLeaseLedger,
+    signer: SpendLeaseSigner,
+    scope: str,
+    fence_id: str,
+    provisional_id: str,
+    workspace_id: str,
+    key_hash: str,
+    boot_kid: str,
+    region: str,
+    gen: int,
+    cap_micro: int,
+    allocation_micro: int,
+    ttl_seconds: int,
+    skew_seconds: int,
+    request_fingerprint: str,
+    catalog: dict[str, Any],
+    observed_gen: int,
+    observed_predecessor_count: int,
+    incumbent_lease_id: str | None,
+    incumbent_window_closed: bool,
+    authoritative_exhaustion: bool,
+) -> BindingPlan:
+    now = datetime.now(UTC)
+    lease_id = derive_candidate_lease_id(key_hash, boot_kid, gen, provisional_id)
+    expires_at = now + timedelta(seconds=ttl_seconds)
+    claims = {
+        "v": 1, "typ": "spend-lease+jws", "authoritative": True,
+        "lease_id": lease_id, "key_hash": key_hash, "workspace_id": workspace_id,
+        "cap_micro": cap_micro, "gen": gen, "iat": int(now.timestamp()),
+        "exp": int(expires_at.timestamp()), "boot_kid": boot_kid, "catalog": catalog,
+    }
+    artifact = SpendLeaseArtifact(
+        token=signer.sign(claims), lease_id=lease_id, cap_micro=cap_micro, gen=gen,
+        iat=int(now.timestamp()), exp=int(expires_at.timestamp()), issuer_kid=signer.kid,
+        boot_kid=boot_kid, catalog_version=str(catalog["version"]),
+        open_predecessor_count=observed_predecessor_count,
+    )
+    identity = CandidateIdentity(
+        lease_id, gen, key_hash, boot_kid, cap_micro, skew_seconds, workspace_id,
+        region, provisional_id, scope, expires_at,
+    )
+    run_in_transaction_with_retry(
+        database,
+        lambda transaction: insert_candidate(transaction, param_types, identity, created_at=now),
+        transaction_tag="tr_spend_lease_candidate",
+    )
+    ledger.initialize(
+        SpendLease(
+            lease_id, gen, key_hash, boot_kid, workspace_id, provisional_id,
+            cap_micro, expires_at, timedelta(seconds=skew_seconds), 0,
+        ),
+        region=region,
+    )
+    result = ledger.allocate(
+        None, lease_id, region=region, idempotency_scope=scope,
+        provisional_authorization_id=provisional_id,
+        request_fingerprint=request_fingerprint, allocated_micro=allocation_micro,
+        abandon_after=expires_at + timedelta(seconds=skew_seconds), now=now,
+    )
+    if isinstance(result, Mismatch):
+        raise SpendLeaseContractError("candidate allocation mismatched its creating attempt")
+    if isinstance(result, ExistingLocal):
+        raise SpendLeaseExistingLocal("different local creator owns the allocation")
+    if not isinstance(result, Created):
+        raise SpendLeaseContractError(f"unexpected new-candidate result: {type(result).__name__}")
+    return BindingPlan(
+        ledger, scope, fence_id, region, provisional_id, artifact, allocation_micro,
+        expires_at + timedelta(seconds=skew_seconds), "mint", identity,
+        observed_gen, incumbent_lease_id, incumbent_window_closed, authoritative_exhaustion,
+    )
+
+
+def _bound(outcome: str) -> dict[str, Any]:
+    return {"bound": True, "no_lease_reason": None, "spend_lease_outcome": outcome}
+
+
+def _unbound(reason: str, outcome: str) -> dict[str, Any]:
+    return {"bound": False, "no_lease_reason": reason, "spend_lease_outcome": outcome}
+
+
+def _require_one(count: int, inverse: str) -> None:
+    if count != 1:
+        raise SpendLeaseContractError(f"{inverse} modified {count} rows")
+
+
+def _read_fence(
+    transaction: Any,
+    param_types: Any,
+    fence_id: str,
+    candidate_lease_id: str,
+) -> dict[str, Any] | None:
+    rows = list(transaction.execute_sql(
+        "SELECT body FROM tr_entities WHERE kind=@kind AND id=@id",
+        params={"kind": FENCE_KIND, "id": fence_id},
+        param_types={"kind": param_types.STRING, "id": param_types.STRING},
+    ))
+    if not rows:
+        return None
+    body = json.loads(rows[0][0])
+    active_id = str(body.get("lease_id") or "")
+    if body.get("lease_status") == "terminal" or active_id == "unminted":
+        body["active_valid"] = False
+    else:
+        global_rows = list(
+            transaction.execute_sql(
+                "SELECT body FROM tr_entities WHERE kind=@kind AND id=@id",
+                params={"kind": SPEND_LEASE_KIND, "id": active_id},
+                param_types={"kind": param_types.STRING, "id": param_types.STRING},
+            )
+        )
+        if not global_rows:
+            body["active_valid"] = None
+        else:
+            global_lease = json.loads(global_rows[0][0])
+            consistent = (
+                global_lease.get("lease_id") == active_id
+                and int(global_lease.get("gen", -1)) == int(body.get("gen", -2))
+            )
+            expires_at = _global_expiry(global_lease)
+            body["active_valid"] = bool(
+                consistent
+                and global_lease.get("state") == "ACTIVE"
+                and expires_at is not None
+                and expires_at > datetime.now(UTC)
+            )
+    return {str(key): value for key, value in body.items()}
+
+
+def _mark_incumbent(transaction: Any, param_types: Any, lease_id: str | None) -> int:
+    if lease_id is None:
+        return 0
+    return int(transaction.execute_update(
+        "UPDATE tr_entities SET body=TO_JSON_STRING(JSON_SET(PARSE_JSON(body), "
+        "'$.holds_predecessor_slot', true)) "
+        "WHERE kind=@kind AND id=@id AND JSON_VALUE(body, '$.state') IN ('ACTIVE','DRAINING','TOMBSTONED') "
+        "AND JSON_VALUE(body, '$.holds_predecessor_slot')='false'",
+        params={"kind": SPEND_LEASE_KIND, "id": lease_id},
+        param_types={"kind": param_types.STRING, "id": param_types.STRING},
+    ))
+
+
+def _unmark_incumbent(transaction: Any, param_types: Any, lease_id: str | None) -> int:
+    if lease_id is None:
+        return 0
+    return int(transaction.execute_update(
+        "UPDATE tr_entities SET body=TO_JSON_STRING(JSON_SET(PARSE_JSON(body), "
+        "'$.holds_predecessor_slot', false)) "
+        "WHERE kind=@kind AND id=@id AND JSON_VALUE(body, '$.holds_predecessor_slot')='true'",
+        params={"kind": SPEND_LEASE_KIND, "id": lease_id},
+        param_types={"kind": param_types.STRING, "id": param_types.STRING},
+    ))
+
+
+def _advance_fence(
+    transaction: Any,
+    param_types: Any,
+    *,
+    artifact: SpendLeaseArtifact,
+    fence_id: str,
+    observed_gen: int,
+    mark_count: int,
+    window_closed: bool,
+    authoritative_exhaustion: bool,
+) -> int:
+    next_artifact = dataclasses.replace(
+        artifact,
+        open_predecessor_count=artifact.open_predecessor_count + mark_count,
+    )
+    body = json.dumps(
+        dataclasses.asdict(next_artifact), separators=(",", ":"), sort_keys=True
+    )
+    return int(transaction.execute_update(
+        "UPDATE tr_entities SET body=@body WHERE kind=@kind AND id=@id "
+        "AND CAST(JSON_VALUE(body, '$.gen') AS INT64)=@observed_gen "
+        "AND CAST(COALESCE(JSON_VALUE(body, '$.open_predecessor_count'),'0') AS INT64)+@mark_count<=@limit "
+        "AND (@window_closed OR @authoritative_exhaustion) AND CURRENT_TIMESTAMP()<@candidate_expires_at",
+        params={
+            "body": body, "kind": FENCE_KIND, "id": fence_id, "observed_gen": observed_gen,
+            "mark_count": mark_count, "limit": PREDECESSOR_LIMIT,
+            "window_closed": window_closed, "authoritative_exhaustion": authoritative_exhaustion,
+            "candidate_expires_at": _artifact_expiry(artifact),
+        },
+        param_types={
+            "body": param_types.STRING, "kind": param_types.STRING, "id": param_types.STRING,
+            "observed_gen": param_types.INT64, "mark_count": param_types.INT64,
+            "limit": param_types.INT64, "window_closed": param_types.BOOL,
+            "authoritative_exhaustion": param_types.BOOL, "candidate_expires_at": param_types.TIMESTAMP,
+        },
+    ))
+
+
+def _artifact_expiry(artifact: SpendLeaseArtifact) -> datetime:
+    return datetime.fromtimestamp(artifact.exp, tz=UTC)
+
+
+def _global_expiry(payload: dict[str, Any]) -> datetime | None:
+    value = payload.get("expires_at")
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    legacy_exp = payload.get("exp")
+    if isinstance(legacy_exp, int):
+        return datetime.fromtimestamp(legacy_exp, tz=UTC)
+    return None

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -673,6 +673,9 @@ class GatewayAuthorization:
     spend_lease_boot_kid: str | None = None
     spend_lease_catalog_version: str | None = None
     spend_lease_status: str | None = None
+    # Per-request amount bound inside the lease.  Distinct from cap_micro,
+    # which is the lease-wide escrow ceiling.
+    spend_lease_allocated_micro: int | None = None
     # Only deferred authorizations carry an expiry: it is what lets the reaper
     # reclaim the outstanding-counter estimate when the enclave dies between
     # authorize and settle. Local authorizations keep their pre-existing

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -997,6 +997,7 @@ class TypedBillingStore(Protocol):
         expires_at: Any = ...,
         window_limits: dict[str, int] | None = ...,
         spend_lease: SpendLeaseArtifact | None = ...,
+        spend_lease_binding_plan: Any = ...,
     ) -> tuple[str, GatewayAuthorization | None]: ...
 
     def typed_finalize_gateway_authorization(

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -140,7 +140,12 @@ class FakeSpannerDatabase:
     Spanner's optimistic concurrency contract closely enough to test the
     credit-ledger retry path."""
 
-    def __init__(self, *, ready_barrier: threading.Barrier | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        ready_barrier: threading.Barrier | None = None,
+        now: dt.datetime | None = None,
+    ) -> None:
         self.rows: dict[tuple[str, str], _Row] = {}
         # Typed counter tables (tr_credit_balance, tr_key_limit): table ->
         # (pk col0, pk col1) -> {column: value}. PK is the first two columns.
@@ -211,6 +216,10 @@ class FakeSpannerDatabase:
         self.snapshot_sql: list[str] = []
         self.transaction_execute_sql_calls = 0
         self.transaction_execute_update_calls = 0
+        self.now = now
+
+    def current_timestamp(self) -> dt.datetime:
+        return _utc_datetime(self.now) if self.now is not None else dt.datetime.now(dt.UTC)
 
     def run_in_transaction(
         self,
@@ -342,7 +351,7 @@ class FakeSpannerDatabase:
                     self.gateway_authorization_versions[authorization_id] = new_version
                 elif op[0] in ("insert_spend_arbitration", "update_spend_arbitration"):
                     _, pk, record = op
-                    commit_timestamp = dt.datetime.now(dt.UTC)
+                    commit_timestamp = self.current_timestamp()
                     record = {
                         column: commit_timestamp
                         if value == _SpannerModule.COMMIT_TIMESTAMP
@@ -351,9 +360,13 @@ class FakeSpannerDatabase:
                     }
                     self.spend_lease_arbitrations[pk] = record
                     self.spend_lease_arbitration_versions[pk] = new_version
+                elif op[0] == "delete_spend_arbitration":
+                    _, pk = op
+                    self.spend_lease_arbitrations.pop(pk, None)
+                    self.spend_lease_arbitration_versions[pk] = new_version
                 elif op[0] in ("insert_spend_open", "update_spend_open"):
                     _, lease_id, record = op
-                    commit_timestamp = dt.datetime.now(dt.UTC)
+                    commit_timestamp = self.current_timestamp()
                     record = {
                         column: commit_timestamp
                         if value == _SpannerModule.COMMIT_TIMESTAMP
@@ -563,6 +576,30 @@ class _FakeTransaction:
             self.db.typed_versions.get((table, pk), 0),
             self.db.typed.get(table, {}).get(pk),
         )
+
+    def _entity_current(self, kind: str, entity_id: str) -> dict[str, Any] | None:
+        entity_key = (kind, entity_id)
+        for op in reversed(self.pending_writes):
+            if op[0] == "delete_entity_dml" and (op[1], op[2]) == entity_key:
+                return None
+            if op[0] in ("insert_entity_dml", "update_entity_dml") and (
+                op[1],
+                op[2],
+            ) == entity_key:
+                return {
+                    "kind": kind,
+                    "id": entity_id,
+                    "body": op[3],
+                }
+        row = self.db.rows.get(entity_key)
+        pinned = self._pinned_read(
+            entity_key,
+            row.version if row is not None else 0,
+            None
+            if row is None
+            else {"kind": kind, "id": entity_id, "body": row.body},
+        )
+        return pinned
 
     def execute_update(
         self, sql: str, *, params: dict[str, Any] | None = None, param_types: Any = None
@@ -1024,7 +1061,7 @@ class _FakeTransaction:
             return 1
         spend_lease_dml = sql.strip()
         if re.match(
-            r"^(?:INSERT(?:\s+OR\s+IGNORE)?\s+INTO|UPDATE)\s+"
+            r"^(?:INSERT(?:\s+OR\s+IGNORE)?\s+INTO|UPDATE|DELETE\s+FROM)\s+"
             r"spend_lease_(?:scope_arbitration|open)\b",
             spend_lease_dml,
             re.IGNORECASE,
@@ -1062,7 +1099,13 @@ class _FakeTransaction:
             rec = self._gateway_authorization_current(authorization_id)
             if rec is None:
                 return 0
-            new = dict(rec, settled=True, payload=p["payload"])
+            new = dict(
+                rec,
+                settled=True,
+                payload=p["payload"],
+                finalization_outcome=p.get("finalization_outcome"),
+                finalized_cost_microdollars=p.get("finalized_cost_microdollars"),
+            )
             self.pending_writes.append(("update_gateway_authorization", authorization_id, new))
             return 1
         if sql.startswith("UPDATE tr_gateway_authorization SET terminal_at=@terminal_at"):
@@ -1126,6 +1169,27 @@ class _FakeTransaction:
             )
             self.pending_writes.append(("update_gateway_authorization", authorization_id, new))
             return 1
+        if sql.startswith("INSERT OR IGNORE INTO tr_entities"):
+            entity_key = (p["kind"], p["id"])
+            present = entity_key in self.db.rows
+            for op in reversed(self.pending_writes):
+                if op[0] in ("insert_entity_dml", "update_entity_dml") and (
+                    op[1], op[2]
+                ) == entity_key:
+                    present = True
+                    break
+            if present:
+                return 0
+            self.pending_writes.append(
+                ("insert_entity_dml", p["kind"], p["id"], p["body"])
+            )
+            return 1
+        if sql.startswith("UPDATE tr_entities SET body=TO_JSON_STRING(JSON_SET"):
+            return _execute_spend_lease_entity_update(self, sql, p)
+        if sql.startswith("UPDATE tr_entities SET body=@body") and p.get("kind") == (
+            "spend_lease_active_grant"
+        ):
+            return _execute_spend_lease_entity_update(self, sql, p)
         if sql.startswith("INSERT INTO tr_entities"):
             entity_key = (p["kind"], p["id"])
             if entity_key in self.db.rows:
@@ -1658,6 +1722,241 @@ def _evaluate_spanner_expression(
     raise AssertionError(f"unknown spend-lease SQL expression: {expression!r}")
 
 
+def _strip_sql_parentheses(expression: str) -> str:
+    expression = expression.strip()
+    while expression.startswith("(") and expression.endswith(")"):
+        depth = 0
+        in_quote = False
+        encloses_all = True
+        for index, char in enumerate(expression):
+            if char == "'":
+                in_quote = not in_quote
+            elif not in_quote:
+                if char == "(":
+                    depth += 1
+                elif char == ")":
+                    depth -= 1
+                    if depth == 0 and index != len(expression) - 1:
+                        encloses_all = False
+                        break
+        if not encloses_all or depth != 0 or in_quote:
+            break
+        expression = expression[1:-1].strip()
+    return expression
+
+
+def _split_spanner_disjunction(source: str) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    in_quote = False
+    index = 0
+    while index < len(source):
+        char = source[index]
+        if char == "'":
+            if in_quote and index + 1 < len(source) and source[index + 1] == "'":
+                index += 2
+                continue
+            in_quote = not in_quote
+            index += 1
+            continue
+        if not in_quote:
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+            elif (
+                depth == 0
+                and source[index : index + 2].upper() == "OR"
+                and (index == 0 or source[index - 1].isspace())
+                and (index + 2 == len(source) or source[index + 2].isspace())
+            ):
+                parts.append(source[start:index].strip())
+                start = index + 2
+                index += 2
+                continue
+        index += 1
+    if in_quote or depth != 0:
+        raise AssertionError(f"unbalanced spend-lease OR expression: {source!r}")
+    parts.append(source[start:].strip())
+    return parts
+
+
+def _entity_json_value(record: dict[str, Any], path: str) -> Any:
+    if not path.startswith("$.") or "." in path[2:]:
+        raise AssertionError(f"unsupported tr_entities JSON path: {path!r}")
+    body = json.loads(str(record["body"]))
+    value = body.get(path[2:])
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (str, int, float)):
+        return str(value)
+    raise AssertionError(f"tr_entities JSON_VALUE cannot scalarize {path!r}: {value!r}")
+
+
+def _evaluate_entity_operand(
+    expression: str,
+    record: dict[str, Any],
+    params: dict[str, Any],
+    now: dt.datetime,
+) -> Any:
+    expression = _strip_sql_parentheses(expression)
+    if expression in {"kind", "id", "body"}:
+        return record[expression]
+    cast_coalesce = re.fullmatch(
+        r"CAST\s*\(\s*COALESCE\s*\(\s*JSON_VALUE\s*\(\s*body\s*,\s*"
+        r"('(?:''|[^'])*')\s*\)\s*,\s*('(?:''|[^'])*')\s*\)\s+AS\s+INT64\s*\)"
+        r"(?:\s*\+\s*(.+))?",
+        expression,
+        re.IGNORECASE,
+    )
+    if cast_coalesce is not None:
+        path_sql, fallback_sql, increment_sql = cast_coalesce.groups()
+        path = _evaluate_spanner_expression(path_sql, params, now)
+        value = _entity_json_value(record, str(path))
+        fallback = _evaluate_spanner_expression(fallback_sql, params, now)
+        result = int(fallback if value is None else value)
+        if increment_sql is not None:
+            result += int(_evaluate_spanner_expression(increment_sql, params, now))
+        return result
+    cast_json = re.fullmatch(
+        r"CAST\s*\(\s*JSON_VALUE\s*\(\s*body\s*,\s*('(?:''|[^'])*')\s*\)"
+        r"\s+AS\s+INT64\s*\)",
+        expression,
+        re.IGNORECASE,
+    )
+    if cast_json is not None:
+        path = _evaluate_spanner_expression(cast_json.group(1), params, now)
+        value = _entity_json_value(record, str(path))
+        return None if value is None else int(value)
+    json_value = re.fullmatch(
+        r"JSON_VALUE\s*\(\s*body\s*,\s*('(?:''|[^'])*')\s*\)",
+        expression,
+        re.IGNORECASE,
+    )
+    if json_value is not None:
+        path = _evaluate_spanner_expression(json_value.group(1), params, now)
+        return _entity_json_value(record, str(path))
+    return _evaluate_spanner_expression(expression, params, now)
+
+
+def _entity_predicate_matches(
+    predicate: str,
+    record: dict[str, Any],
+    params: dict[str, Any],
+    now: dt.datetime,
+) -> bool:
+    predicate = _strip_sql_parentheses(predicate)
+    disjunction = _split_spanner_disjunction(predicate)
+    if len(disjunction) > 1:
+        return any(
+            _entity_predicate_matches(part, record, params, now)
+            for part in disjunction
+        )
+    if predicate.upper() in {"TRUE", "FALSE"}:
+        return bool(_evaluate_spanner_expression(predicate, params, now))
+    if re.fullmatch(r"@[A-Za-z_][A-Za-z0-9_]*", predicate):
+        return bool(_evaluate_spanner_expression(predicate, params, now))
+    membership = re.fullmatch(
+        r"(.+?)\s+IN\s*\((.+)\)", predicate, re.IGNORECASE | re.DOTALL
+    )
+    if membership is not None:
+        operand, values_sql = membership.groups()
+        value = _evaluate_entity_operand(operand, record, params, now)
+        values = [
+            _evaluate_spanner_expression(part, params, now)
+            for part in _split_spanner_sql_list(values_sql)
+        ]
+        return value in values
+    comparison = re.fullmatch(
+        r"(.+?)\s*(<=|>=|=|<|>)\s*(.+)", predicate, re.DOTALL
+    )
+    if comparison is None:
+        raise AssertionError(f"unknown tr_entities WHERE predicate: {predicate!r}")
+    left_sql, operator, right_sql = comparison.groups()
+    left = _evaluate_entity_operand(left_sql, record, params, now)
+    right = _evaluate_entity_operand(right_sql, record, params, now)
+    if operator == "=":
+        return left == right
+    if left is None or right is None:
+        return False
+    if operator == "<=":
+        return bool(left <= right)
+    if operator == ">=":
+        return bool(left >= right)
+    if operator == "<":
+        return bool(left < right)
+    return bool(left > right)
+
+
+def _execute_spend_lease_entity_update(
+    transaction: _FakeTransaction,
+    sql: str,
+    params: dict[str, Any],
+) -> int:
+    """Evaluate the incumbent/fence entity UPDATE directly from its SQL."""
+    update = re.fullmatch(
+        r"UPDATE\s+tr_entities\s+SET\s+body\s*=\s*(.*?)\s+WHERE\s+(.+?)\s*",
+        sql.strip(),
+        re.IGNORECASE | re.DOTALL,
+    )
+    if update is None:
+        raise AssertionError(f"unknown spend-lease tr_entities UPDATE: {sql}")
+    assignment_sql, where_sql = update.groups()
+    kind = str(params.get("kind", ""))
+    entity_id = str(params.get("id", ""))
+    if not kind or not entity_id:
+        raise AssertionError("spend-lease tr_entities UPDATE requires @kind and @id")
+    record = transaction._entity_current(kind, entity_id)
+    if record is None:
+        return 0
+    now = transaction.db.current_timestamp()
+    predicates = _split_spanner_conjunction(where_sql)
+    if not any(
+        re.fullmatch(r"kind\s*=\s*@kind", predicate, re.IGNORECASE)
+        for predicate in predicates
+    ):
+        raise AssertionError("spend-lease tr_entities UPDATE must constrain kind=@kind")
+    if not any(
+        re.fullmatch(r"id\s*=\s*@id", predicate, re.IGNORECASE)
+        for predicate in predicates
+    ):
+        raise AssertionError("spend-lease tr_entities UPDATE must constrain id=@id")
+    for predicate in predicates:
+        if not _entity_predicate_matches(predicate, record, params, now):
+            return 0
+
+    if assignment_sql.strip() == "@body":
+        new_body = _evaluate_spanner_expression("@body", params, now)
+        json.loads(str(new_body))
+    else:
+        json_set = re.fullmatch(
+            r"TO_JSON_STRING\s*\(\s*JSON_SET\s*\(\s*PARSE_JSON\s*\(\s*body\s*\)\s*,"
+            r"\s*('(?:''|[^'])*')\s*,\s*(TRUE|FALSE)\s*\)\s*\)",
+            assignment_sql,
+            re.IGNORECASE,
+        )
+        if json_set is None:
+            raise AssertionError(
+                f"unknown spend-lease tr_entities assignment: {assignment_sql!r}"
+            )
+        path_sql, value_sql = json_set.groups()
+        path = str(_evaluate_spanner_expression(path_sql, params, now))
+        if path != "$.holds_predecessor_slot":
+            raise AssertionError(f"unsupported tr_entities JSON_SET path: {path!r}")
+        body = json.loads(str(record["body"]))
+        body["holds_predecessor_slot"] = bool(
+            _evaluate_spanner_expression(value_sql, params, now)
+        )
+        new_body = json.dumps(body, separators=(",", ":"), sort_keys=True)
+    transaction.pending_writes.append(
+        ("update_entity_dml", kind, entity_id, str(new_body))
+    )
+    return 1
+
+
 def _spend_lease_row_matches(
     record: dict[str, Any],
     where_sql: str,
@@ -1734,7 +2033,7 @@ def _execute_spend_lease_dml(
     params: dict[str, Any],
 ) -> int:
     """Evaluate the spend-lease DML subset from SQL instead of restating it."""
-    now = dt.datetime.now(dt.UTC)
+    now = transaction.db.current_timestamp()
     insert = re.fullmatch(
         r"INSERT(?:\s+(OR)\s+IGNORE)?\s+INTO\s+"
         r"(spend_lease_scope_arbitration|spend_lease_open)\s*"
@@ -1773,6 +2072,23 @@ def _execute_spend_lease_dml(
             (_spend_lease_operation_name(table, "insert"), key, record)
         )
         return 1
+
+    delete = re.fullmatch(
+        r"DELETE\s+FROM\s+(spend_lease_scope_arbitration)\s+WHERE\s+(.+?)\s*",
+        sql,
+        re.DOTALL | re.IGNORECASE,
+    )
+    if delete is not None:
+        table, where_sql = delete.groups()
+        deleted = 0
+        for key, record in _spend_lease_rows(transaction, table):
+            if not _spend_lease_row_matches(record, where_sql, params, now):
+                continue
+            transaction.pending_writes.append(
+                (_spend_lease_operation_name(table, "delete"), key)
+            )
+            deleted += 1
+        return deleted
 
     update = re.fullmatch(
         r"UPDATE\s+(spend_lease_scope_arbitration|spend_lease_open)"
@@ -3289,6 +3605,7 @@ def make_fake_store(
     store._analytics_dual_read_grace_seconds = 0
     store._operational_analytics = None
     store._regional_quota_ledger = None
+    store._spend_lease_ledger = None
     store._regional_quota_lease_cache = {}
     store._regional_quota_lease_cache_lock = threading.Lock()
     from trusted_router.storage_gcp_credit_shards import CreditShardCountCache

--- a/tests/test_gateway_authorize_spanner_operations.py
+++ b/tests/test_gateway_authorize_spanner_operations.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
 import dataclasses
+import inspect
 
 import pytest
 from starlette.requests import Request
 
 from tests.fakes.spanner import make_fake_store
-from trusted_router import storage_gcp_authorize, storage_gcp_key_escrow
+from trusted_router import (
+    spend_lease_authorize,
+    storage_gcp_authorize,
+    storage_gcp_key_escrow,
+    storage_gcp_spend_lease_authorize,
+)
 from trusted_router.config import Settings
 from trusted_router.routes.internal import gateway
 from trusted_router.schemas import GatewayAuthorizeRequest
@@ -97,6 +103,34 @@ def test_typed_authorize_route_does_not_call_typed_pretransaction_probe(
 
     assert response["data"]["authorization_id"]
     assert response["data"]["idempotent_replay"] is False
+
+
+def test_spend_lease_binding_flag_off_never_calls_prepare_hook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _store, _database, key = _seed_typed_gateway_store()
+
+    def forbidden(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("flag-off authorize touched the unit-2 binding path")
+
+    for module in (spend_lease_authorize, storage_gcp_spend_lease_authorize):
+        for name, value in vars(module).items():
+            if (
+                not name.startswith("_")
+                and inspect.isfunction(value)
+                and value.__module__ == module.__name__
+            ):
+                monkeypatch.setattr(module, name, forbidden)
+    monkeypatch.setattr(
+        SpannerBigtableStore,
+        "prepare_gateway_spend_lease_binding",
+        forbidden,
+    )
+
+    response = gateway._authorize_gateway_sync(
+        _request(), _body(key.hash), Settings(environment="test")
+    )
+    assert response["data"]["authorization_id"]
 
 
 def test_typed_authorize_replay_and_mismatch_still_come_from_transaction() -> None:

--- a/tests/test_spend_lease_authorize.py
+++ b/tests/test_spend_lease_authorize.py
@@ -1,0 +1,1023 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+
+import pytest
+
+from tests.fakes.spanner import FakeSpannerDatabase, _ParamTypes, make_fake_store
+from trusted_router.config import Settings
+from trusted_router.spend_lease_authorize import (
+    FenceOutcome,
+    FenceView,
+    GlobalLeaseView,
+    SpendLeaseArbitrationConflict,
+    SpendLeaseContractError,
+    SpendLeaseMintLost,
+    classify_fence_loss,
+    derive_candidate_lease_id,
+    route_local_presented,
+    route_local_refusal,
+    route_missing_local,
+)
+from trusted_router.spend_lease_state import (
+    AllocationState,
+    Created,
+    LeaseTransition,
+    SpendLease,
+    SpendLeaseRefusalReason,
+    SpendLeaseState,
+    TerminalSource,
+)
+from trusted_router.spend_leases import SpendLeaseArtifact, SpendLeaseSigner
+from trusted_router.storage_gcp_authorize import authorize_atomic
+from trusted_router.storage_gcp_counter_dml import insert_entity_dml
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
+from trusted_router.storage_gcp_spend_lease import (
+    CandidateIdentity,
+    insert_candidate,
+    register_bound,
+    register_claim,
+    take_recovery_ownership,
+)
+from trusted_router.storage_gcp_spend_lease_authorize import (
+    BindingPlan,
+    SpendLeaseReuseLost,
+    ensure_initial_fence,
+)
+from trusted_router.storage_models import CreditAccount, GatewayAuthorization, Workspace
+from trusted_router.types import UsageType
+
+NOW = datetime(2026, 9, 1, tzinfo=UTC)
+
+
+def _lease(*, state: SpendLeaseState = SpendLeaseState.ACTIVE) -> SpendLease:
+    return SpendLease(
+        lease_id="lease-1",
+        gen=4,
+        key_hash="key-hash",
+        boot_kid="boot-kid",
+        workspace_id="workspace-1",
+        creating_authorization_id="authorization-1",
+        cap_micro=10_000,
+        expires_at=NOW + timedelta(seconds=30),
+        skew=timedelta(seconds=10),
+        version=0,
+        state=state,
+    )
+
+
+@pytest.mark.parametrize(
+    ("local", "now", "route", "reason", "exhausted"),
+    [
+        (_lease(), NOW, "reuse", None, False),  # A1
+        (_lease(), NOW + timedelta(seconds=45), "successor", None, False),  # A2
+        (_lease(state=SpendLeaseState.DRAINING), NOW, "successor", None, False),
+        (_lease(state=SpendLeaseState.CLOSED), NOW, "successor", None, False),
+        (_lease(state=SpendLeaseState.TOMBSTONED), NOW, "successor", None, True),  # A3
+    ],
+)
+def test_decision_47_table_a_local_rows(
+    local: SpendLease,
+    now: datetime,
+    route: str,
+    reason: str | None,
+    exhausted: bool,
+) -> None:
+    decision = route_local_presented(local, now=now)
+    assert (decision.route, decision.reason, decision.authoritative_exhaustion) == (
+        route,
+        reason,
+        exhausted,
+    )
+
+
+@pytest.mark.parametrize(
+    ("refusal", "route", "reason", "exhausted"),
+    [
+        (SpendLeaseRefusalReason.WINDOW_EXPIRED, "successor", None, False),
+        (SpendLeaseRefusalReason.FROZEN_DRAINING, "successor", None, False),
+        (SpendLeaseRefusalReason.CLOSED, "successor", None, False),
+        (SpendLeaseRefusalReason.FROZEN_TOMBSTONED, "successor", None, True),
+        (SpendLeaseRefusalReason.WINDOW_NOT_ELAPSED, "ordinary", "window_open", False),
+        (SpendLeaseRefusalReason.EXHAUSTED, "successor", None, True),
+    ],
+)
+def test_decision_47_table_a_typed_refusals(
+    refusal: SpendLeaseRefusalReason,
+    route: str,
+    reason: str | None,
+    exhausted: bool,
+) -> None:
+    decision = route_local_refusal(refusal)
+    assert (decision.route, decision.reason, decision.authoritative_exhaustion) == (
+        route,
+        reason,
+        exhausted,
+    )
+
+
+@pytest.mark.parametrize(
+    ("global_lease", "route", "reason", "exhausted"),
+    [
+        (None, "ordinary", "ledger_unavailable", False),  # B1
+        (GlobalLeaseView("ACTIVE", NOW - timedelta(seconds=11), 10), "successor", None, True),  # B2
+        (GlobalLeaseView("DRAINING", NOW - timedelta(seconds=11), 10), "successor", None, True),
+        (GlobalLeaseView("CLOSED", NOW + timedelta(seconds=30), 10), "successor", None, True),  # B3
+        (GlobalLeaseView("TOMBSTONED", NOW + timedelta(seconds=30), 10), "successor", None, True),
+        (GlobalLeaseView("ACTIVE", NOW + timedelta(seconds=30), 10), "ordinary", "ledger_unavailable", False),  # B4
+    ],
+)
+def test_decision_47_table_b_missing_or_corrupt_local(
+    global_lease: GlobalLeaseView | None,
+    route: str,
+    reason: str | None,
+    exhausted: bool,
+) -> None:
+    decision = route_missing_local(global_lease, now=NOW)
+    assert (decision.route, decision.reason, decision.authoritative_exhaustion) == (
+        route,
+        reason,
+        exhausted,
+    )
+
+
+@pytest.mark.parametrize(
+    ("current", "mark", "closed", "exhausted", "outcome", "reason"),
+    [
+        (None, 0, True, False, FenceOutcome.MISSING_OR_CORRUPT, None),
+        (FenceView(8, 0, "winner", True), 0, True, False, FenceOutcome.LOST_RACE, "lease_transferred"),
+        (FenceView(8, 0, "winner", False), 0, True, False, FenceOutcome.STALE_ADVISORY, "stale_advisory"),
+        (FenceView(7, 3, "incumbent", True), 1, True, False, FenceOutcome.COUNT_EXHAUSTED, "predecessor_limit"),
+        (FenceView(7, 1, "incumbent", True), 0, False, False, FenceOutcome.WINDOW_OPEN, "window_open"),
+        (FenceView(7, 1, "incumbent", True), 0, True, False, FenceOutcome.CONTRACT_VIOLATION, None),
+    ],
+)
+def test_decision_45_fence_truth_table(
+    current: FenceView | None,
+    mark: int,
+    closed: bool,
+    exhausted: bool,
+    outcome: FenceOutcome,
+    reason: str | None,
+) -> None:
+    decision = classify_fence_loss(
+        observed_gen=7,
+        incumbent_mark_count=mark,
+        predecessor_limit=3,
+        window_closed=closed,
+        authoritative_exhaustion=exhausted,
+        statement_window_open=True,
+        current=current,
+    )
+    assert (decision.outcome, decision.reason) == (outcome, reason)
+
+
+def test_decision_45_statement_window_guard_false_is_mint_lost_first() -> None:
+    with pytest.raises(SpendLeaseMintLost):
+        classify_fence_loss(
+            observed_gen=7,
+            incumbent_mark_count=1,
+            predecessor_limit=3,
+            window_closed=False,
+            authoritative_exhaustion=False,
+            statement_window_open=False,
+            current=None,
+        )
+
+
+def test_binding_settings_requires_issuance() -> None:
+    with pytest.raises(
+        ValueError,
+        match="TR_SPEND_LEASE_BINDING_ENABLED requires TR_SPEND_LEASE_ISSUANCE_ENABLED",
+    ):
+        Settings(environment="test", spend_lease_binding_enabled=True)
+
+    settings = Settings(
+        environment="test",
+        spend_lease_issuance_enabled=True,
+        spend_lease_binding_enabled=True,
+        spend_lease_pilot_workspace_ids="workspace-1",
+        spend_lease_signing_secret_name="projects/test/secrets/spend-lease",  # noqa: S106
+        operational_analytics_sink="direct",
+    )
+    assert settings.spend_lease_binding_enabled is True
+    assert settings.spend_lease_issuance_enabled is True
+
+
+def test_candidate_id_includes_creating_authorization_and_is_stable() -> None:
+    first = derive_candidate_lease_id("key", "boot", 3, "auth-1")
+    assert first == derive_candidate_lease_id("key", "boot", 3, "auth-1")
+    assert first != derive_candidate_lease_id("key", "boot", 3, "auth-2")
+    assert len(first) == 64
+
+
+class _RecordingLedger:
+    def __init__(self) -> None:
+        self.binds = 0
+        self.compensations = 0
+        self.leases: dict[str, SpendLease] = {}
+
+    def supports_region(self, _region: str) -> bool:
+        return True
+
+    def initialize(self, candidate: SpendLease, *, region: str) -> LeaseTransition:
+        del region
+        existing = self.leases.setdefault(candidate.lease_id, candidate)
+        return LeaseTransition(existing, existing is not candidate)
+
+    def get(self, lease_id: str, *, region: str) -> SpendLease | None:
+        del region
+        return self.leases.get(lease_id)
+
+    def allocate(self, authorization_view: object, lease_id: str, **kwargs: object) -> object:
+        del authorization_view
+        lease = self.leases[lease_id]
+        result = lease.allocate(
+            authorization_view=None,
+            idempotency_scope=str(kwargs["idempotency_scope"]),
+            provisional_authorization_id=str(kwargs["provisional_authorization_id"]),
+            request_fingerprint=str(kwargs["request_fingerprint"]),
+            allocated_micro=cast(int, kwargs["allocated_micro"]),
+            abandon_after=cast(datetime, kwargs["abandon_after"]),
+            now=cast(datetime, kwargs["now"]),
+        )
+        if isinstance(result, Created):
+            self.leases[lease_id] = result.lease
+        return result
+
+    def bind(self, lease_id: str, **kwargs: object) -> object:
+        self.binds += 1
+        result = self.leases[lease_id].bind(
+            expected_provisional_id=str(kwargs["expected_provisional_id"]),
+            proof=kwargs["proof"],  # type: ignore[arg-type]
+        )
+        self.leases[lease_id] = result.lease
+        return result
+
+    def compensate(self, lease_id: str, **kwargs: object) -> object:
+        self.compensations += 1
+        result = self.leases[lease_id].compensate(
+            idempotency_scope=str(kwargs["idempotency_scope"]),
+            expected_provisional_id=str(kwargs["expected_provisional_id"]),
+            claim=kwargs["claim"],  # type: ignore[arg-type]
+            absence=kwargs["absence"],  # type: ignore[arg-type]
+        )
+        self.leases[lease_id] = result.lease
+        return result
+
+
+def _atomic_harness(*, total_credits: int = 10_000) -> tuple[
+    FakeSpannerDatabase, BindingPlan, _RecordingLedger
+]:
+    db = FakeSpannerDatabase()
+    db.typed["tr_credit_balance"] = {
+        ("workspace-1", 0): {
+            "workspace_id": "workspace-1",
+            "shard": 0,
+            "total_credits": total_credits,
+            "total_usage": 0,
+            "reserved": 0,
+        }
+    }
+    db.typed["tr_key_limit"] = {
+        ("key-hash", 0): {
+            "key_hash": "key-hash",
+            "shard": 0,
+            "limit_micro": 100_000,
+            "usage": 0,
+            "byok_usage": 0,
+            "reserved": 0,
+            "include_byok": True,
+        }
+    }
+    ensure_initial_fence(db, _ParamTypes, "fence-1")
+    expires_at = datetime.now(UTC) + timedelta(minutes=1)
+    identity = CandidateIdentity(
+        lease_id="candidate-1",
+        gen=1,
+        key_hash="key-hash",
+        boot_kid="boot-kid",
+        cap_micro=2_000,
+        skew_seconds=10,
+        workspace_id="workspace-1",
+        region="us-central1",
+        creating_authorization_id="authorization-1",
+        idempotency_scope="scope-1",
+        expires_at=expires_at,
+    )
+    db.run_in_transaction(
+        lambda transaction: insert_candidate(
+            transaction, _ParamTypes, identity, created_at=NOW
+        )
+    )
+    artifact = SpendLeaseArtifact(
+        token="test-token",  # noqa: S106 - inert signed-artifact fixture
+        lease_id=identity.lease_id, cap_micro=identity.cap_micro,
+        gen=identity.gen, iat=int(NOW.timestamp()), exp=int(identity.expires_at.timestamp()),
+        issuer_kid="issuer", boot_kid=identity.boot_kid, catalog_version="catalog",
+    )
+    ledger = _RecordingLedger()
+    ledger.initialize(
+        SpendLease(
+            identity.lease_id,
+            identity.gen,
+            identity.key_hash,
+            identity.boot_kid,
+            identity.workspace_id,
+            identity.creating_authorization_id,
+            identity.cap_micro,
+            identity.expires_at,
+            timedelta(seconds=identity.skew_seconds),
+            0,
+        ),
+        region=identity.region,
+    )
+    created = ledger.allocate(
+        None,
+        identity.lease_id,
+        region=identity.region,
+        idempotency_scope=identity.idempotency_scope,
+        provisional_authorization_id=identity.creating_authorization_id,
+        request_fingerprint="fingerprint-1",
+        allocated_micro=500,
+        abandon_after=identity.expires_at + timedelta(seconds=identity.skew_seconds),
+        now=NOW,
+    )
+    assert isinstance(created, Created)
+    plan = BindingPlan(
+        ledger=ledger,  # type: ignore[arg-type]
+        scope=identity.idempotency_scope,
+        fence_id="fence-1",
+        region=identity.region,
+        provisional_id=identity.creating_authorization_id,
+        artifact=artifact,
+        allocation_micro=500,
+        admission_deadline=identity.expires_at + timedelta(seconds=10),
+        mode="mint",
+        candidate=identity,
+        observed_gen=0,
+        incumbent_lease_id=None,
+        incumbent_window_closed=True,
+        authoritative_exhaustion=False,
+    )
+    return db, plan, ledger
+
+
+def _run_plan(
+    db: FakeSpannerDatabase, plan: BindingPlan | None
+) -> dict[str, object]:
+    def build(authorization_id: str, reservation_id: str) -> GatewayAuthorization:
+        return GatewayAuthorization(
+            id=authorization_id,
+            workspace_id="workspace-1",
+            key_hash="key-hash",
+            model_id="model-1",
+            provider="provider-1",
+            usage_type=UsageType.CREDITS,
+            estimated_microdollars=500,
+            credit_reservation_id=reservation_id,
+        )
+
+    def build_lease(
+        authorization_id: str, reservation_id: str, bound: bool
+    ) -> GatewayAuthorization:
+        authorization = build(authorization_id, reservation_id)
+        if bound:
+            assert plan is not None
+            authorization.spend_lease_token = plan.artifact.token
+            authorization.spend_lease_id = plan.artifact.lease_id
+            authorization.spend_lease_gen = plan.artifact.gen
+            authorization.spend_lease_allocated_micro = plan.allocation_micro
+            authorization.spend_lease_status = "active"
+            authorization.spend_lease_exp = plan.artifact.exp
+        return authorization
+
+    return authorize_atomic(
+        db,
+        _ParamTypes,
+        workspace_id="workspace-1",
+        key_hash="key-hash",
+        estimate=500,
+        has_credit_candidate=True,
+        reservation_usage_type="Credits",
+        idempotency_scope="scope-1",
+        idempotency_fingerprint="fingerprint-1",
+        expires_at=NOW + timedelta(hours=1),
+        build_authorization=build,
+        request_record_write_mode="typed",
+        authorization_id="authorization-1",
+        spend_lease_hook=(
+            None
+            if plan is None
+            else lambda transaction, shard: plan.transaction_hook(
+                transaction, _ParamTypes, "workspace-1", shard
+            )
+        ),
+        build_authorization_for_lease=build_lease if plan is not None else None,
+    )
+
+
+def test_decision_44_success_durable_seam_and_token_invariant() -> None:
+    db, plan, ledger = _atomic_harness()
+
+    result = _run_plan(db, plan)
+    plan.bind_after_commit()
+
+    assert result["bound"] is True
+    assert db.typed["tr_credit_balance"][("workspace-1", 0)]["reserved"] == 2_500
+    assert len(db.spend_lease_arbitrations) == 1
+    assert db.spend_lease_open["candidate-1"]["phase"] == "open"
+    assert ("spend_lease", "candidate-1") in db.rows
+    assert len(db.reservations) == len(db.gateway_authorizations) == 1
+    authorization = db.gateway_authorizations["authorization-1"]
+    assert bool(authorization["spend_lease_token"]) is bool(result["bound"])
+    assert ledger.binds == 1
+
+
+def test_decision_44_hold_zero_is_the_ordinary_reject_seam() -> None:
+    db, plan, ledger = _atomic_harness(total_credits=0)
+
+    result = _run_plan(db, plan)
+
+    assert result["outcome"] == "insufficient_credits"
+    assert db.typed["tr_credit_balance"][("workspace-1", 0)]["reserved"] == 0
+    assert db.spend_lease_arbitrations == {}
+    assert json.loads(db.rows[("spend_lease_active_grant", "fence-1")].body)["gen"] == 0
+    assert db.spend_lease_open["candidate-1"]["phase"] == "candidate"
+    assert db.reservations == db.gateway_authorizations == {}
+    assert ledger.leases["candidate-1"].allocations[0].state.value == "reserved"
+
+
+def test_decision_44_claim_loss_restores_escrow_and_commits_unbound() -> None:
+    db, plan, ledger = _atomic_harness()
+    db.run_in_transaction(
+        lambda transaction: register_claim(
+            transaction, _ParamTypes, plan.scope, plan.provisional_id
+        )
+    )
+
+    result = _run_plan(db, plan)
+    plan.compensate_with_claim(db, _ParamTypes)
+
+    assert result["no_lease_reason"] == "scope_arbitrated"
+    assert db.typed["tr_credit_balance"][("workspace-1", 0)]["reserved"] == 500
+    assert db.spend_lease_open["candidate-1"]["phase"] == "candidate"
+    assert ("spend_lease", "candidate-1") not in db.rows
+    assert not db.gateway_authorizations["authorization-1"]["spend_lease_token"]
+    assert ledger.compensations == 1
+
+
+def test_decision_44_escrow_zero_keeps_only_request_hold() -> None:
+    db, plan, ledger = _atomic_harness(total_credits=1_000)
+
+    result = _run_plan(db, plan)
+    plan.compensate_with_claim(db, _ParamTypes)
+
+    assert result["no_lease_reason"] == "escrow_headroom"
+    assert db.typed["tr_credit_balance"][("workspace-1", 0)]["reserved"] == 500
+    assert db.spend_lease_arbitrations
+    registration = next(iter(db.spend_lease_arbitrations.values()))
+    assert registration["registration_kind"] == "CLAIM"
+    assert json.loads(db.rows[("spend_lease_active_grant", "fence-1")].body)["gen"] == 0
+    assert db.spend_lease_open["candidate-1"]["phase"] == "candidate"
+    assert ("spend_lease", "candidate-1") not in db.rows
+    assert len(db.reservations) == len(db.gateway_authorizations) == 1
+    assert not db.gateway_authorizations["authorization-1"]["spend_lease_token"]
+    assert ledger.compensations == 1
+
+
+def test_decision_44_fence_zero_runs_all_inverses_before_unbound_commit() -> None:
+    db, plan, ledger = _atomic_harness()
+    fence = db.rows[("spend_lease_active_grant", "fence-1")]
+    fence.body = json.dumps(
+        {
+            "lease_id": "winner-2",
+            "gen": 2,
+            "open_predecessor_count": 0,
+            "lease_status": "active",
+        }
+    )
+    db.run_in_transaction(
+        lambda transaction: insert_entity_dml(
+            transaction,
+            _ParamTypes,
+            "spend_lease",
+            "winner-2",
+            json.dumps(
+                {
+                    "state": "ACTIVE",
+                    "lease_id": "winner-2",
+                    "gen": 2,
+                    "expires_at": (datetime.now(UTC) + timedelta(minutes=5)).isoformat(),
+                }
+            ),
+        )
+    )
+
+    result = _run_plan(db, plan)
+    plan.compensate_with_claim(db, _ParamTypes)
+
+    assert result["no_lease_reason"] == "lease_transferred"
+    assert db.typed["tr_credit_balance"][("workspace-1", 0)]["reserved"] == 500
+    registration = next(iter(db.spend_lease_arbitrations.values()))
+    assert registration["registration_kind"] == "CLAIM"
+    assert json.loads(fence.body)["lease_id"] == "winner-2"
+    assert db.spend_lease_open["candidate-1"]["phase"] == "candidate"
+    assert ("spend_lease", "candidate-1") not in db.rows
+    assert len(db.reservations) == len(db.gateway_authorizations) == 1
+    assert not db.gateway_authorizations["authorization-1"]["spend_lease_token"]
+    assert ledger.compensations == 1
+
+
+def test_decision_46_foreign_bound_loser_leaves_candidate_to_recovery() -> None:
+    db, plan, ledger = _atomic_harness()
+    db.run_in_transaction(
+        lambda transaction: register_bound(
+            transaction,
+            _ParamTypes,
+            plan.scope,
+            "foreign-authorization",
+            "foreign-candidate",
+            1,
+            500,
+        )
+    )
+
+    with pytest.raises(SpendLeaseArbitrationConflict):
+        db.run_in_transaction(
+            lambda transaction: plan.transaction_hook(
+                transaction, _ParamTypes, "workspace-1", 0
+            )
+        )
+
+    assert db.typed["tr_credit_balance"][("workspace-1", 0)]["reserved"] == 0
+    assert db.spend_lease_open["candidate-1"]["phase"] == "candidate"
+    assert ledger.leases["candidate-1"].allocations[0].state.value == "reserved"
+    assert ledger.compensations == 0
+    assert ("spend_lease", "candidate-1") not in db.rows
+
+
+def test_decision_44_mint_lost_rolls_back_every_mint_effect() -> None:
+    db, plan, _ledger = _atomic_harness()
+    db.run_in_transaction(
+        lambda transaction: take_recovery_ownership(
+            transaction, _ParamTypes, "candidate-1"
+        )
+    )
+
+    with pytest.raises(SpendLeaseMintLost):
+        _run_plan(db, plan)
+
+    result = _run_plan(db, None)
+
+    assert result["outcome"] == "accepted"
+    assert db.typed["tr_credit_balance"][("workspace-1", 0)]["reserved"] == 500
+    assert db.spend_lease_arbitrations == {}
+    assert db.spend_lease_open["candidate-1"]["phase"] == "recovering"
+    assert ("spend_lease", "candidate-1") not in db.rows
+    assert len(db.reservations) == len(db.gateway_authorizations) == 1
+    assert not db.gateway_authorizations["authorization-1"]["spend_lease_token"]
+
+
+def test_decision_47_a1_transfer_aborts_without_returning_presented_token() -> None:
+    db, mint_plan, _ledger = _atomic_harness()
+    fence = db.rows[("spend_lease_active_grant", "fence-1")]
+    fence.body = json.dumps(
+        {
+            "lease_id": "winner-2",
+            "gen": 2,
+            "open_predecessor_count": 0,
+            "lease_status": "active",
+        }
+    )
+    reuse_plan = replace(
+        mint_plan,
+        mode="reuse",
+        candidate=None,
+        artifact=replace(mint_plan.artifact, lease_id="presented-1", gen=1),
+        observed_gen=1,
+    )
+
+    with pytest.raises(SpendLeaseReuseLost, match="lease_transferred"):
+        db.run_in_transaction(
+            lambda transaction: reuse_plan.transaction_hook(
+                transaction, _ParamTypes, "workspace-1", 0
+            )
+        )
+
+    assert db.spend_lease_arbitrations == {}
+
+
+def _insert_global_lease(
+    db: FakeSpannerDatabase,
+    *,
+    lease_id: str,
+    gen: int,
+    expires_at: datetime,
+    holds_predecessor_slot: bool = False,
+) -> None:
+    db.run_in_transaction(
+        lambda transaction: insert_entity_dml(
+            transaction,
+            _ParamTypes,
+            "spend_lease",
+            lease_id,
+            json.dumps(
+                {
+                    "state": "ACTIVE",
+                    "lease_id": lease_id,
+                    "gen": gen,
+                    "expires_at": expires_at.isoformat(),
+                    "holds_predecessor_slot": holds_predecessor_slot,
+                }
+            ),
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_reason", "expected_bound"),
+    [
+        pytest.param("missing", None, None, id="missing-or-corrupt"),
+        pytest.param("lost", "lease_transferred", False, id="lost-race"),
+        pytest.param("stale", "stale_advisory", False, id="stale-advisory"),
+        pytest.param("count", "predecessor_limit", False, id="count-exhausted"),
+        pytest.param("window", "window_open", False, id="window-open"),
+        pytest.param("pass", None, True, id="all-guards-pass"),
+    ],
+)
+def test_decision_45_fence_truth_table_runs_statement_through_hook(
+    case: str,
+    expected_reason: str | None,
+    expected_bound: bool | None,
+) -> None:
+    db, plan, _ledger = _atomic_harness()
+    fence_key = ("spend_lease_active_grant", plan.fence_id)
+    fence = db.rows[fence_key]
+    if case == "missing":
+        del db.rows[fence_key]
+    elif case in {"lost", "stale"}:
+        fence.body = json.dumps(
+            {
+                "lease_id": "winner-2",
+                "gen": 2,
+                "open_predecessor_count": 0,
+                "lease_status": "active",
+            }
+        )
+        _insert_global_lease(
+            db,
+            lease_id="winner-2",
+            gen=2,
+            expires_at=(
+                datetime.now(UTC) + timedelta(minutes=5)
+                if case == "lost"
+                else datetime.now(UTC) - timedelta(minutes=5)
+            ),
+        )
+    elif case == "count":
+        fence.body = json.dumps(
+            {
+                "lease_id": "incumbent-1",
+                "gen": 0,
+                "open_predecessor_count": 3,
+                "lease_status": "active",
+            }
+        )
+        _insert_global_lease(
+            db,
+            lease_id="incumbent-1",
+            gen=0,
+            expires_at=datetime.now(UTC) + timedelta(minutes=5),
+        )
+        plan = replace(plan, incumbent_lease_id="incumbent-1")
+    elif case == "window":
+        plan = replace(plan, incumbent_window_closed=False)
+
+    if case == "missing":
+        with pytest.raises(SpendLeaseContractError, match="fence loss"):
+            _run_plan(db, plan)
+        return
+
+    result = _run_plan(db, plan)
+    assert result["bound"] is expected_bound
+    assert result["no_lease_reason"] == expected_reason
+
+
+def test_decision_45_statement_clock_expiry_is_mint_lost_before_other_causes() -> None:
+    db, plan, _ledger = _atomic_harness()
+    expired_at = datetime.now(UTC) - timedelta(seconds=2)
+    assert plan.candidate is not None
+    candidate = replace(plan.candidate, expires_at=expired_at)
+    plan = replace(
+        plan,
+        artifact=replace(plan.artifact, exp=int(expired_at.timestamp())),
+        candidate=candidate,
+    )
+    db.spend_lease_open[candidate.lease_id]["expires_at"] = expired_at
+    db.now = expired_at + timedelta(seconds=1)
+
+    with pytest.raises(SpendLeaseMintLost, match="candidate expiry guard"):
+        _run_plan(db, plan)
+
+    fence = json.loads(db.rows[("spend_lease_active_grant", plan.fence_id)].body)
+    assert fence["gen"] == 0
+
+
+def test_decision_44_fence_loss_unmarks_marked_incumbent() -> None:
+    db, plan, _ledger = _atomic_harness()
+    incumbent_id = "winner-marked"
+    _insert_global_lease(
+        db,
+        lease_id=incumbent_id,
+        gen=2,
+        expires_at=datetime.now(UTC) + timedelta(minutes=5),
+    )
+    db.rows[("spend_lease_active_grant", plan.fence_id)].body = json.dumps(
+        {
+            "lease_id": incumbent_id,
+            "gen": 2,
+            "open_predecessor_count": 0,
+            "lease_status": "active",
+        }
+    )
+    plan = replace(plan, incumbent_lease_id=incumbent_id)
+
+    result = _run_plan(db, plan)
+
+    assert result["spend_lease_outcome"] == "fence_lost_race"
+    incumbent = json.loads(db.rows[("spend_lease", incumbent_id)].body)
+    assert incumbent["holds_predecessor_slot"] is False
+
+
+def _store_binding_harness() -> tuple[Any, FakeSpannerDatabase, Any, BindingPlan, _RecordingLedger]:
+    store, db, _table = make_fake_store(request_record_write_mode="typed")
+    workspace = Workspace(id="workspace-1", name="Test", owner_user_id="user-1")
+    store._write_entity("workspace", workspace.id, workspace)
+    store._write_entity("credit", workspace.id, CreditAccount(workspace_id=workspace.id))
+    db.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(workspace.id, 0)] = {
+        "workspace_id": workspace.id,
+        "shard": 0,
+        "total_credits": 50_000_000,
+        "total_usage": 0,
+        "reserved": 0,
+        "source_updated_at": None,
+        "updated_at": None,
+    }
+    _raw, key = store.api_keys.create(
+        workspace_id=workspace.id,
+        name="binding",
+        creator_user_id=workspace.owner_user_id,
+        limit_microdollars=50_000_000,
+    )
+    ledger = _RecordingLedger()
+    store._spend_lease_ledger = ledger
+    plan, reason = store.prepare_gateway_spend_lease_binding(
+        workspace_id=workspace.id,
+        key_hash=key.hash,
+        authorization_id="authorization-bound",
+        idempotency_key="idem-bound",
+        idempotency_fingerprint="fingerprint-bound",
+        estimate=500,
+        boot_kid="boot-1",
+        region="us-central1",
+        signer=SpendLeaseSigner(lambda: bytes(range(32))),
+        catalog={"version": "catalog-1", "candidates": []},
+        ttl_seconds=60,
+        skew_seconds=10,
+        max_microdollars=1_000_000,
+        max_available_basis_points=1_000,
+        echo_lease_id=None,
+        echo_state="empty",
+    )
+    assert reason is None and isinstance(plan, BindingPlan)
+    return store, db, key, plan, ledger
+
+
+def _authorize_store(
+    store: Any,
+    key_hash: str,
+    plan: BindingPlan,
+) -> tuple[Any, GatewayAuthorization | None]:
+    result: tuple[Any, GatewayAuthorization | None] = store.authorize_gateway_typed(
+        workspace_id="workspace-1",
+        key_hash=key_hash,
+        authorization_id="authorization-bound",
+        estimate=500,
+        has_credit_candidate=True,
+        reservation_usage_type=UsageType.CREDITS,
+        model_id="model-1",
+        provider="provider-1",
+        requested_model_id="model-1",
+        candidate_model_ids=["model-1"],
+        region="us-central1",
+        endpoint_id="endpoint-1",
+        candidate_endpoint_ids=["endpoint-1"],
+        idempotency_key="idem-bound",
+        idempotency_fingerprint="fingerprint-bound",
+        expires_at=datetime.now(UTC) + timedelta(hours=2),
+        spend_lease_binding_plan=plan,
+    )
+    return result
+
+
+def _assert_no_spend_lease_fields(authorization: GatewayAuthorization) -> None:
+    assert (
+        authorization.spend_lease_token,
+        authorization.spend_lease_id,
+        authorization.spend_lease_cap_micro,
+        authorization.spend_lease_gen,
+        authorization.spend_lease_iat,
+        authorization.spend_lease_exp,
+        authorization.spend_lease_issuer_kid,
+        authorization.spend_lease_boot_kid,
+        authorization.spend_lease_catalog_version,
+        authorization.spend_lease_status,
+        authorization.spend_lease_allocated_micro,
+    ) == (None,) * 11
+
+
+def _configure_unbound_entrypoint_case(
+    db: FakeSpannerDatabase,
+    plan: BindingPlan,
+    case: str,
+) -> BindingPlan:
+    fence_key = ("spend_lease_active_grant", plan.fence_id)
+    if case == "escrow_refused":
+        db.typed["tr_credit_balance"][("workspace-1", 0)]["total_credits"] = 500
+    elif case == "scope_claimed":
+        db.run_in_transaction(
+            lambda transaction: register_claim(
+                transaction, _ParamTypes, plan.scope, plan.provisional_id
+            )
+        )
+    elif case in {"fence_lost_race", "fence_stale_advisory"}:
+        db.rows[fence_key].body = json.dumps(
+            {
+                "lease_id": "winner-2",
+                "gen": 2,
+                "open_predecessor_count": 0,
+                "lease_status": "active",
+            }
+        )
+        _insert_global_lease(
+            db,
+            lease_id="winner-2",
+            gen=2,
+            expires_at=(
+                datetime.now(UTC) + timedelta(minutes=5)
+                if case == "fence_lost_race"
+                else datetime.now(UTC) - timedelta(minutes=5)
+            ),
+        )
+    elif case == "fence_count_exhausted":
+        db.rows[fence_key].body = json.dumps(
+            {
+                "lease_id": "incumbent-1",
+                "gen": 0,
+                "open_predecessor_count": 3,
+                "lease_status": "active",
+            }
+        )
+        _insert_global_lease(
+            db,
+            lease_id="incumbent-1",
+            gen=0,
+            expires_at=datetime.now(UTC) + timedelta(minutes=5),
+        )
+        plan = replace(plan, incumbent_lease_id="incumbent-1")
+    elif case == "fence_window_open":
+        plan = replace(plan, incumbent_window_closed=False)
+    elif case == "mint_lost":
+        db.run_in_transaction(
+            lambda transaction: take_recovery_ownership(
+                transaction, _ParamTypes, plan.artifact.lease_id
+            )
+        )
+    elif case == "reuse_transfer":
+        db.rows[fence_key].body = json.dumps(
+            {
+                "lease_id": "winner-2",
+                "gen": 2,
+                "open_predecessor_count": 0,
+                "lease_status": "active",
+            }
+        )
+        _insert_global_lease(
+            db,
+            lease_id="winner-2",
+            gen=2,
+            expires_at=datetime.now(UTC) + timedelta(minutes=5),
+        )
+        plan = replace(plan, mode="reuse", candidate=None, observed_gen=1)
+    elif case == "reuse_expiry":
+        db.rows[fence_key].body = json.dumps(
+            {
+                "lease_id": plan.artifact.lease_id,
+                "gen": 1,
+                "open_predecessor_count": 0,
+                "lease_status": "active",
+            }
+        )
+        _insert_global_lease(
+            db,
+            lease_id=plan.artifact.lease_id,
+            gen=1,
+            expires_at=datetime.now(UTC) + timedelta(minutes=5),
+        )
+        plan = replace(
+            plan,
+            mode="reuse",
+            candidate=None,
+            observed_gen=1,
+            admission_deadline=datetime.now(UTC) - timedelta(seconds=1),
+        )
+    else:  # pragma: no cover - parametrization owns the cases
+        raise AssertionError(f"unknown unbound entrypoint case: {case}")
+    return plan
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_reason", "expected_outcome"),
+    [
+        ("escrow_refused", "escrow_headroom", "escrow_refused"),
+        ("scope_claimed", "scope_arbitrated", "scope_claimed"),
+        ("fence_lost_race", "lease_transferred", "fence_lost_race"),
+        ("fence_stale_advisory", "stale_advisory", "fence_stale_advisory"),
+        ("fence_count_exhausted", "predecessor_limit", "fence_count_exhausted"),
+        ("fence_window_open", "window_open", "fence_window_open"),
+        ("mint_lost", "mint_lost", "mint_lost"),
+        ("reuse_transfer", "lease_transferred", "ordinary"),
+        ("reuse_expiry", "lease_expired", "ordinary"),
+    ],
+)
+def test_entrypoint_unbound_seams_return_no_spend_lease_fields(
+    case: str,
+    expected_reason: str,
+    expected_outcome: str,
+) -> None:
+    store, db, key, plan, _ledger = _store_binding_harness()
+    plan = _configure_unbound_entrypoint_case(db, plan, case)
+
+    verdict, authorization = _authorize_store(store, key.hash, plan)
+
+    assert verdict.spend_lease_bound is False
+    assert verdict.no_lease_reason == expected_reason
+    assert verdict.spend_lease_outcome == expected_outcome
+    assert authorization is not None
+    _assert_no_spend_lease_fields(authorization)
+
+
+def test_entrypoint_mint_lost_commits_one_fresh_ordinary_authorization() -> None:
+    store, db, key, plan, ledger = _store_binding_harness()
+    plan = _configure_unbound_entrypoint_case(db, plan, "mint_lost")
+    fence_before = db.rows[("spend_lease_active_grant", plan.fence_id)].body
+    commits_before = db.commits
+
+    verdict, authorization = _authorize_store(store, key.hash, plan)
+
+    assert db.commits == commits_before + 1
+    assert verdict.no_lease_reason == "mint_lost"
+    assert verdict.spend_lease_bound is False
+    assert authorization is not None
+    _assert_no_spend_lease_fields(authorization)
+    assert len(db.reservations) == len(db.gateway_authorizations) == 1
+    assert db.typed["tr_credit_balance"][("workspace-1", 0)]["reserved"] == 500
+    assert db.spend_lease_arbitrations == {}
+    assert db.rows[("spend_lease_active_grant", plan.fence_id)].body == fence_before
+    assert db.spend_lease_open[plan.artifact.lease_id]["phase"] == "recovering"
+    assert ledger.leases[plan.artifact.lease_id].allocations[0].state == AllocationState.RESERVED
+
+
+@pytest.mark.parametrize(
+    "case",
+    [pytest.param("reuse_transfer", id="a1-transfer"), pytest.param("reuse_expiry", id="a1-expiry")],
+)
+def test_entrypoint_a1_reuse_losses_compensate_with_claim(case: str) -> None:
+    store, db, key, plan, ledger = _store_binding_harness()
+    plan = _configure_unbound_entrypoint_case(db, plan, case)
+
+    verdict, authorization = _authorize_store(store, key.hash, plan)
+
+    assert verdict.spend_lease_bound is False
+    assert authorization is not None
+    allocation = ledger.leases[plan.artifact.lease_id].allocations[0]
+    assert allocation.terminal_source == TerminalSource.BINDING_ABSENCE
+    assert ledger.compensations == 1
+    registration = next(iter(db.spend_lease_arbitrations.values()))
+    assert registration["registration_kind"] == "CLAIM"
+    assert registration["provisional_id"] == plan.provisional_id
+
+
+def test_flag_on_store_path_mints_binds_and_returns_token_iff_bound() -> None:
+    store, _db, key, plan, ledger = _store_binding_harness()
+
+    verdict, authorization = _authorize_store(store, key.hash, plan)
+
+    assert verdict.spend_lease_bound is True
+    assert authorization is not None
+    assert bool(authorization.spend_lease_token) is verdict.spend_lease_bound
+    assert ledger.binds == 1


### PR DESCRIPTION
Third unit-2 PR of the spend-lease program, part (b-ii): the authorize-path hooks, shipped inert (design record v49).

**Flag off (default; pinned false in `rollout.sh`):** the authorize path is Stage A byte for byte. A poison test proves no public function of the new modules is called. Enabling binding requires issuance (Settings validator).

**Flag on:** exactly the converged order and seams.
- Pre-transaction (decisions 29–31, 47): eligibility predicate; one strong reservation-scope pre-read routing any existing reservation to the ordinary transaction; decision 47's Tables A and B; the candidate work row inserted before any local write; local allocation first (decisions 15, 46).
- In the Spanner transaction (decisions 41, 44, 45): escrow → BOUND via INSERT OR IGNORE with the point read that tells a CLAIM from a foreign BOUND → incumbent mark → the fence CAS guarded on generation, predecessor count, window-closed-or-exhaustion, and the statement-time window → global lease record → the guarded candidate→open upgrade whose zero rows is MINT_LOST. Exact inverses on every seam, each asserted to one row. A foreign BOUND is a typed conflict retried through the callback's own replay read; MINT_LOST and reuse losses fall to one fresh ordinary transaction; unbound losses compensate through the CLAIM path.
- After commit: the local bind with the BOUND proof. A token is present iff the authorization is bound.

**Fake fidelity:** the Spanner fake now evaluates the fence statement's full WHERE, the incumbent mark/unmark JSON predicates and JSON_SET against a controllable clock, and rejects unknown predicate shapes.

**Review:** isolated snapshot; ruff; mypy --strict on both new modules; 55 new tests plus every existing authorize suite with the flag off; full suite 8,059 passed (two known jq-missing harness tests fail locally only); fourteen mutations each red: all four fence guard terms, foreign-BOUND classification, reuse validation, the BOUND/incumbent/escrow inverses, the MINT_LOST raise and fallback, reuse-loss compensation, token absence on unbound, and the settings validator. Eight of those were coverage or fake-fidelity gaps found in review, and the entrypoint-level tests they required exposed and fixed a real defect: the ordinary fallback after a lost mint reused an authorization built with the aborted attempt's lease fields.

Lands after #1029 (already merged). No reconciler (PR 4), no flag flip.

Written by codex; reviewed by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)