### PR TITLE
spend-lease: reconciler job, deployed idle behind the binding flag (decisions 20, 33, 35–38, 43, 46, 48)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -944,6 +944,9 @@ jobs:
           reconciler_log="${RUNNER_TEMP}/regional-quota-reconciler.log"
           bash scripts/deploy/regional_quota_reconciler.sh >"${reconciler_log}" 2>&1 &
           reconciler_pid=$!
+          spend_lease_reconciler_log="${RUNNER_TEMP}/spend-lease-reconciler.log"
+          bash scripts/deploy/spend_lease_reconciler.sh >"${spend_lease_reconciler_log}" 2>&1 &
+          spend_lease_reconciler_pid=$!
 
           ramp_status=0
           if ! ramp_secondary "europe-west4" "${NEW_EU}"; then
@@ -967,8 +970,16 @@ jobs:
           else
             reconciler_status=$?
           fi
+          spend_lease_reconciler_status=0
+          if wait "${spend_lease_reconciler_pid}"; then
+            spend_lease_reconciler_status=0
+          else
+            spend_lease_reconciler_status=$?
+          fi
           printf '\n=== regional quota reconciler deploy ===\n'
           cat "${reconciler_log}"
+          printf '\n=== spend lease reconciler deploy ===\n'
+          cat "${spend_lease_reconciler_log}"
 
           if [ "${ramp_status}" -ne 0 ]; then
             exit "${ramp_status}"
@@ -976,6 +987,10 @@ jobs:
           if [ "${reconciler_status}" -ne 0 ]; then
             echo "::error::Regional quota reconciler deploy failed with status ${reconciler_status}."
             exit "${reconciler_status}"
+          fi
+          if [ "${spend_lease_reconciler_status}" -ne 0 ]; then
+            echo "::error::Spend lease reconciler deploy failed with status ${spend_lease_reconciler_status}."
+            exit "${spend_lease_reconciler_status}"
           fi
 
       - name: Deploy synthetic monitor Cloud Run Job

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -30,6 +30,7 @@ Index:
 - [One workspace 503s "Workspace billing is paused" (interrupted reshard)](#reshard-interrupted)
 - [DNS-vendor-split symptoms (Cloudflare vs Cloud DNS)](#dns-vendor-split)
 - [Adding a cloud (and when it is allowed to be called done)](#adding-a-cloud)
+- [Spend-lease reconciler](#spend-lease-reconciler)
 
 ---
 
@@ -1375,3 +1376,29 @@ for entry in \
     --format='value(versions[0].instanceTemplate,targetSize,status.isStable)'
 done
 ```
+# Spend-lease reconciler
+
+The versioned `trusted-router-spend-lease-reconciler-*` Cloud Run Job runs once
+per minute with a 50-second task deadline. It is intentionally active while
+spend-lease binding is off: an empty pass verifies the regional Bigtable
+profiles, records both lag values as zero, publishes
+`job:spend-lease-reconcile`, and exits.
+
+For `spend_lease.reconcile_lag_exceeded`, compare
+`eligibility_lag_seconds` with `open_age_lag_seconds`. Eligibility lag measures
+rows that have already produced the frozen/zero-open close proof. Open-age lag
+also includes expired dead rows, so a pre-eligibility failure cannot disappear
+from the signal. Inspect `spend_lease_open` by `lease_id`, including `phase`,
+`attempts`, `last_error`, and all three close timestamps. Do not manually
+release credit: close step 2 deliberately couples release, lease guards, fence
+slot accounting, and `global_closed_at` in one transaction.
+
+For a dead row, repair the reported cause, then run:
+
+```bash
+python -m trusted_router.spend_lease_reconcile_cli requeue-dead LEASE_ID
+```
+
+Omit `LEASE_ID` to requeue all dead rows. A quarantine alert requires comparing
+the local allocation proof with the strong typed authorization before any
+operator action; quarantined allocations remain open and can retain escrow.

--- a/scripts/deploy-gcp.sh
+++ b/scripts/deploy-gcp.sh
@@ -38,4 +38,5 @@ bash "${SCRIPT_DIR}/deploy/spend_lease_ledger.sh" \
   </dev/null
 bash "${SCRIPT_DIR}/deploy/rollout.sh"
 bash "${SCRIPT_DIR}/deploy/regional_quota_reconciler.sh"
+bash "${SCRIPT_DIR}/deploy/spend_lease_reconciler.sh"
 bash "${SCRIPT_DIR}/deploy/synthetic.sh"

--- a/scripts/deploy/gateway-alerts/spend-lease-reconcile-dead.yaml
+++ b/scripts/deploy/gateway-alerts/spend-lease-reconcile-dead.yaml
@@ -1,0 +1,16 @@
+displayName: "TR Spend Lease: dead reconciliation rows"
+combiner: OR
+enabled: true
+documentation:
+  mimeType: text/markdown
+  content: |
+    At least one spend-lease work row exhausted automatic retries. Inspect the
+    durable last_error before requeueing it. Runbook: docs/runbook.md#spend-lease-reconciler.
+conditions:
+  - displayName: "Spend-lease dead-row count is nonzero"
+    conditionMatchedLog:
+      filter: 'resource.type = "cloud_run_job" AND textPayload:"spend_lease.reconcile_dead_count"'
+alertStrategy:
+  notificationRateLimit:
+    period: 1800s
+  autoClose: 86400s

--- a/scripts/deploy/gateway-alerts/spend-lease-reconcile-lag.yaml
+++ b/scripts/deploy/gateway-alerts/spend-lease-reconcile-lag.yaml
@@ -1,0 +1,16 @@
+displayName: "TR Spend Lease: reconciliation lag exceeded"
+combiner: OR
+enabled: true
+documentation:
+  mimeType: text/markdown
+  content: |
+    Spend-lease close eligibility or expired-open age exceeds 24 hours. This is
+    a client-invisible escrow-retention outage. Runbook: docs/runbook.md#spend-lease-reconciler.
+conditions:
+  - displayName: "Spend-lease reconciliation lag above 24 hours"
+    conditionMatchedLog:
+      filter: 'resource.type = "cloud_run_job" AND textPayload:"spend_lease.reconcile_lag_exceeded"'
+alertStrategy:
+  notificationRateLimit:
+    period: 1800s
+  autoClose: 86400s

--- a/scripts/deploy/gateway-alerts/spend-lease-reconcile-quarantine.yaml
+++ b/scripts/deploy/gateway-alerts/spend-lease-reconcile-quarantine.yaml
@@ -1,0 +1,16 @@
+displayName: "TR Spend Lease: allocation quarantine"
+combiner: OR
+enabled: true
+documentation:
+  mimeType: text/markdown
+  content: |
+    A durable authorization contradicted a local spend-lease allocation and the
+    allocation entered quarantine. Runbook: docs/runbook.md#spend-lease-reconciler.
+conditions:
+  - displayName: "Spend-lease allocation entered quarantine"
+    conditionMatchedLog:
+      filter: 'resource.type = "cloud_run_job" AND textPayload:"spend_lease.reconcile_quarantine"'
+alertStrategy:
+  notificationRateLimit:
+    period: 1800s
+  autoClose: 86400s

--- a/scripts/deploy/spend_lease_reconciler.sh
+++ b/scripts/deploy/spend_lease_reconciler.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Deploy the versioned, one-shot spend-lease reconciler and its stable cadence.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/deploy/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+SCHEDULER_NAME="${TR_SPEND_LEASE_RECONCILER_SCHEDULER:-trusted-router-spend-lease-reconcile}"
+JOB_REGION="${TR_SPEND_LEASE_RECONCILER_JOB_REGION:-us-east4}"
+SCHEDULER_REGION="${TR_SPEND_LEASE_RECONCILER_SCHEDULER_REGION:-${TR_PRIMARY_REGION}}"
+SCHEDULE="${TR_SPEND_LEASE_RECONCILER_SCHEDULE:-* * * * *}"
+RELEASE="$(git rev-parse --short HEAD 2>/dev/null || echo local)"
+JOB_PREFIX="${TR_SPEND_LEASE_RECONCILER_JOB_PREFIX:-trusted-router-spend-lease-reconciler}"
+JOB_NAME="${TR_SPEND_LEASE_RECONCILER_JOB:-${JOB_PREFIX}-${RELEASE}}"
+
+scheduler_state=""
+scheduler_exists=false
+describe_error="$(mktemp "${TMPDIR:-/tmp}/spend-lease-scheduler.XXXXXX")"
+if scheduler_state="$(gc scheduler jobs describe "$SCHEDULER_NAME" \
+    --location="$SCHEDULER_REGION" --format='value(state)' 2>"$describe_error")"; then
+  describe_status=0
+  scheduler_exists=true
+  [ -n "$scheduler_state" ] || { log "scheduler state is empty"; exit 1; }
+else
+  describe_status=$?
+fi
+if [ "$describe_status" -ne 0 ] && \
+    grep -qE '(^|[[:space:]])NOT_FOUND([[:space:]:]|$)' "$describe_error"; then
+  scheduler_exists=false
+elif [ "$describe_status" -ne 0 ]; then
+  log "unable to describe spend-lease scheduler: $(<"$describe_error")"
+  exit "$describe_status"
+fi
+rm -f "$describe_error"
+
+gc artifacts docker images describe "$IMAGE" >/dev/null 2>&1 || {
+  log "refusing spend-lease reconciler deploy: image ${IMAGE} does not exist"
+  exit 1
+}
+
+profiles=()
+IFS=',' read -r -a clusters <<<"$TR_SPEND_LEASE_CLUSTER_MAP"
+for entry in "${clusters[@]}"; do
+  profiles+=("${entry%%=*}=tr-spend-${entry%%=*}")
+done
+profile_csv="$(IFS=','; printf '%s' "${profiles[*]}")"
+env_vars=(
+  "TR_ENVIRONMENT=worker"
+  "TR_SERVICE_SURFACE=control"
+  "TR_RELEASE=${RELEASE}"
+  "TR_STORAGE_BACKEND=spanner-bigtable"
+  "TR_GCP_PROJECT_ID=${PROJECT_ID}"
+  "TR_SPANNER_INSTANCE_ID=${SPANNER_INSTANCE_ID}"
+  "TR_SPANNER_DATABASE_ID=${SPANNER_DATABASE_ID}"
+  "TR_SPANNER_POOL_SIZE=1"
+  "TR_BIGTABLE_INSTANCE_ID=${BIGTABLE_INSTANCE_ID}"
+  "TR_BIGTABLE_GENERATION_TABLE=${BIGTABLE_GENERATION_TABLE}"
+  "TR_REQUEST_RECORD_WRITE_MODE=typed"
+  "TR_SPEND_LEASE_BIGTABLE_TABLE=${TR_SPEND_LEASE_BIGTABLE_TABLE:-trustedrouter-spend-lease}"
+  "TR_SPEND_LEASE_BIGTABLE_APP_PROFILES=${TR_SPEND_LEASE_BIGTABLE_APP_PROFILES:-$profile_csv}"
+  "TR_SPEND_LEASE_RECONCILER_WORKER=true"
+  "TR_SPEND_LEASE_RECONCILE_LIMIT=${TR_SPEND_LEASE_RECONCILE_LIMIT:-25}"
+  "TR_SPEND_LEASE_RECONCILE_MAX_ATTEMPTS=${TR_SPEND_LEASE_RECONCILE_MAX_ATTEMPTS:-12}"
+  # Binding and issuance intentionally remain absent/default-off.
+  "TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=true"
+)
+set_env_vars="$(IFS='|'; echo "^|^${env_vars[*]}")"
+
+if gc run jobs describe "$JOB_NAME" --region "$JOB_REGION" >/dev/null 2>&1; then
+  mutation=update
+else
+  mutation=create
+fi
+gc run jobs "$mutation" "$JOB_NAME" \
+  --region "$JOB_REGION" \
+  --image "$IMAGE" \
+  --command="/app/.venv/bin/python" \
+  --args="-m,trusted_router.spend_lease_reconcile_cli,reconcile" \
+  --service-account "$RUN_SERVICE_ACCOUNT" \
+  --set-env-vars "$set_env_vars" \
+  --update-secrets "TR_SENTRY_DSN=trustedrouter-sentry-dsn:latest" \
+  --max-retries 0 \
+  --task-timeout 50s \
+  --cpu 1 \
+  --memory 512Mi \
+  --quiet >/dev/null
+
+gc run jobs add-iam-policy-binding "$JOB_NAME" \
+  --region "$JOB_REGION" \
+  --member="serviceAccount:${RUN_SERVICE_ACCOUNT}" \
+  --role=roles/run.invoker \
+  --quiet >/dev/null
+
+verified=false
+if [ "$scheduler_state" != "PAUSED" ]; then
+  gc run jobs execute "$JOB_NAME" --region "$JOB_REGION" --wait --quiet >/dev/null
+  verified=true
+fi
+
+uri="https://${JOB_REGION}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${PROJECT_ID}/jobs/${JOB_NAME}:run"
+common=(
+  --location="$SCHEDULER_REGION"
+  --schedule="$SCHEDULE"
+  --time-zone=UTC
+  --uri="$uri"
+  --http-method=POST
+  --oauth-service-account-email="$RUN_SERVICE_ACCOUNT"
+  --attempt-deadline=30s
+  --max-retry-attempts=0
+  --quiet
+)
+if [ "$scheduler_exists" = true ]; then
+  gc scheduler jobs update http "$SCHEDULER_NAME" "${common[@]}" --clear-headers >/dev/null
+else
+  gc scheduler jobs create http "$SCHEDULER_NAME" "${common[@]}" >/dev/null
+fi
+if [ "$scheduler_state" = "PAUSED" ]; then
+  gc scheduler jobs pause "$SCHEDULER_NAME" --location="$SCHEDULER_REGION" --quiet >/dev/null
+elif [ "$scheduler_exists" = true ]; then
+  gc scheduler jobs resume "$SCHEDULER_NAME" --location="$SCHEDULER_REGION" --quiet >/dev/null 2>&1 || true
+fi
+
+if [ "$verified" = true ]; then
+  kept=0
+  while IFS= read -r old_job; do
+    [[ "$old_job" == "${JOB_PREFIX}-"* ]] || continue
+    [ "$old_job" = "$JOB_NAME" ] && continue
+    if [ "$kept" -eq 0 ]; then kept=1; continue; fi
+    gc run jobs delete "$old_job" --region="$JOB_REGION" --async --quiet >/dev/null || true
+  done < <(gc run jobs list --region "$JOB_REGION" \
+    --sort-by='~metadata.creationTimestamp' --format='value(metadata.name)')
+  log "spend-lease reconciler verified and scheduled once per minute"
+else
+  log "spend-lease reconciler deployed and operator pause preserved"
+fi

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -849,6 +849,11 @@ class Settings(BaseSettings):
     # is required because one lease has exactly one regional writer authority.
     regional_quota_bigtable_app_profiles: str = ""
     spend_lease_bigtable_app_profiles: str = ""
+    # Reconciliation is deployed before binding and remains active when the
+    # traffic flag is off. Only the one-shot Cloud Run Job sets worker=True.
+    spend_lease_reconciler_worker: bool = False
+    spend_lease_reconcile_limit: int = 25
+    spend_lease_reconcile_max_attempts: int = 12
     # Stage A spend leases are signed advisory artifacts only. This one flag
     # gates both minting and shadow evidence; default-off deploys never touch
     # Secret Manager. The accepted digest CSV preserves both sides of a GCP

--- a/src/trusted_router/spend_lease_ledger.py
+++ b/src/trusted_router/spend_lease_ledger.py
@@ -11,6 +11,7 @@ import hashlib
 import json
 import re
 import secrets
+import uuid
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from time import sleep
@@ -71,6 +72,8 @@ class SpendLeaseVersionError(SpendLeaseLedgerError):
 
 class SpendLeaseLedger(Protocol):
     def supports_region(self, region: str) -> bool: ...
+
+    def health_check(self) -> tuple[str, ...]: ...
 
     def initialize(self, candidate: SpendLease, *, region: str) -> LeaseTransition: ...
 
@@ -173,6 +176,8 @@ class SpendLeaseLedger(Protocol):
         now: datetime,
     ) -> LeaseTransition: ...
 
+    def delete(self, lease_id: str, *, region: str) -> None: ...
+
 
 class _TransitionResult(Protocol):
     @property
@@ -251,6 +256,30 @@ class BigtableSpendLeaseLedger:
 
     def get(self, lease_id: str, *, region: str) -> SpendLease | None:
         return self._read_lease(self._table(region), _row_key_for(region, lease_id))
+
+    def health_check(self) -> tuple[str, ...]:
+        """Prove a conditional write and strong read through every fixed profile."""
+
+        for region in sorted(self._tables):
+            table = self._tables[region]
+            row_key = f"health#spend-lease#{region}".encode()
+            version = uuid.uuid4().hex.encode("ascii")
+            row = table.row(row_key, filter_=self._version_exists_filter())
+            for state in (False, True):
+                row.set_cell(_FAMILY, _STATE_COLUMN, b'{"status":"ok"}', state=state)
+                row.set_cell(_FAMILY, _VERSION_COLUMN, version, state=state)
+            try:
+                row.commit()
+                durable = table.read_row(row_key, filter_=self._state_filter())
+            except Exception as exc:  # pragma: no cover - remote transport
+                raise SpendLeaseLedgerError(
+                    "spend lease ledger transactional health check failed"
+                ) from exc
+            if durable is None:
+                raise SpendLeaseLedgerError(
+                    "spend lease ledger health check write was not durable"
+                )
+        return tuple(sorted(self._tables))
 
     def allocate(
         self,
@@ -431,6 +460,17 @@ class BigtableSpendLeaseLedger:
             region=region,
             transition=lambda lease: lease.close(now=now),
         )
+
+    def delete(self, lease_id: str, *, region: str) -> None:
+        """Delete a reconciler-proven retained CLOSED row."""
+
+        table = self._table(region)
+        row = table.direct_row(_row_key_for(region, lease_id))
+        row.delete()
+        try:
+            row.commit()
+        except Exception as exc:  # pragma: no cover - remote transport
+            raise SpendLeaseLedgerError("spend lease row deletion failed") from exc
 
     def _mutating_transition(
         self,

--- a/src/trusted_router/spend_lease_reconcile_cli.py
+++ b/src/trusted_router/spend_lease_reconcile_cli.py
@@ -1,0 +1,143 @@
+"""One-shot spend-lease reconciler and dead-row operator command."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import time
+import uuid
+from collections.abc import Callable, Sequence
+from typing import Any, cast
+
+from trusted_router.config import get_settings
+from trusted_router.sentry_config import init_sentry
+from trusted_router.storage import configure_store, create_store
+from trusted_router.synthetic.fleet import record_heartbeat
+
+logger = logging.getLogger(__name__)
+_LOCK_TTL_SECONDS = 55
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subcommands = parser.add_subparsers(dest="command")
+    subcommands.add_parser("reconcile", help="run one bounded reconciliation pass")
+    requeue = subcommands.add_parser("requeue-dead", help="requeue dead open rows")
+    requeue.add_argument("lease_ids", nargs="*", help="specific lease IDs; default is all")
+    requeue.add_argument("--limit", type=int, default=1000)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO)
+    args = _parser().parse_args(argv)
+    command = args.command or "reconcile"
+    started_at = time.monotonic()
+    settings = get_settings()
+    init_sentry(settings)
+    store = create_store(settings)
+    configure_store(store)
+
+    verify = cast(
+        Callable[[], tuple[str, ...]] | None,
+        getattr(store, "verify_spend_lease_ledger", None),
+    )
+    if verify is None:
+        logger.error("spend_lease.reconciler_health_check_unsupported")
+        return 1
+
+    if command == "requeue-dead":
+        try:
+            regions = verify()
+        except Exception:
+            logger.exception("spend_lease.reconciler_health_check_failed")
+            return 1
+        if not regions:
+            logger.error("spend_lease.reconciler_has_no_regions")
+            return 1
+        requeue = cast(
+            Callable[..., int] | None,
+            getattr(store, "requeue_dead_spend_leases", None),
+        )
+        if requeue is None:
+            logger.error("spend_lease.reconciler_requeue_unsupported")
+            return 1
+        count = requeue(lease_ids=tuple(args.lease_ids), limit=int(args.limit))
+        logger.info("spend_lease.requeue_complete count=%d", count)
+        return 0
+
+    if not settings.spend_lease_reconciler_worker:
+        logger.info("spend_lease.reconciler_disabled")
+        return 0
+    acquire = cast(
+        Callable[..., Any] | None,
+        getattr(store, "acquire_spend_lease_reconciler_lock", None),
+    )
+    release = cast(
+        Callable[..., bool] | None,
+        getattr(store, "release_spend_lease_reconciler_lock", None),
+    )
+    reconcile = cast(
+        Callable[..., dict[str, int | float]] | None,
+        getattr(store, "reconcile_spend_leases", None),
+    )
+    if acquire is None or release is None or reconcile is None:
+        logger.error("spend_lease.reconciler_store_unsupported")
+        return 1
+
+    owner = f"slrec-{uuid.uuid4().hex}"
+    lock = acquire(owner=owner, ttl_seconds=_LOCK_TTL_SECONDS)
+    if lock is None:
+        logger.info("spend_lease.reconciler_lock_busy")
+        return 0
+    logger.info(
+        "spend_lease.reconciler_lock_acquired owner=%s fencing_token=%d",
+        owner,
+        int(lock.fencing_token),
+    )
+    exit_code = 1
+    try:
+        try:
+            regions = verify()
+        except Exception:
+            logger.exception("spend_lease.reconciler_health_check_failed")
+        else:
+            if not regions:
+                logger.error("spend_lease.reconciler_has_no_regions")
+            else:
+                result = reconcile(
+                    limit=settings.spend_lease_reconcile_limit,
+                    max_attempts=settings.spend_lease_reconcile_max_attempts,
+                )
+                logger.info(
+                    "spend_lease.reconcile_complete candidates=%d open=%d recovered=%d "
+                    "bound=%d closed=%d deferred=%d errors=%d dead=%d",
+                    *(int(result.get(key, 0)) for key in (
+                        "candidates", "open", "recovered", "bound", "closed",
+                        "deferred", "errors", "dead",
+                    )),
+                )
+                exit_code = 0
+    except Exception:
+        logger.exception("spend_lease.reconciler_failed")
+    finally:
+        try:
+            released = release(owner=owner, fencing_token=int(lock.fencing_token))
+        except Exception:
+            logger.exception("spend_lease.reconciler_lock_release_failed")
+            exit_code = 1
+        else:
+            if not released:
+                logger.error("spend_lease.reconciler_lock_release_lost")
+                exit_code = 1
+    if exit_code == 0:
+        record_heartbeat("job:spend-lease-reconcile", settings=settings)
+        logger.info(
+            "spend_lease.reconciler_complete elapsed_ms=%.1f",
+            (time.monotonic() - started_at) * 1000.0,
+        )
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -3407,6 +3407,71 @@ class SpannerBigtableStore:
             raise RuntimeError("regional quota ledger is disabled")
         return ledger.health_check()
 
+    def verify_spend_lease_ledger(self) -> tuple[str, ...]:
+        """Prove conditional writes and reads through every fixed app profile."""
+
+        ledger = self._spend_lease_ledger
+        if ledger is None:
+            raise RuntimeError("spend lease ledger is disabled")
+        return ledger.health_check()
+
+    def acquire_spend_lease_reconciler_lock(
+        self,
+        *,
+        owner: str,
+        ttl_seconds: int,
+        now: dt.datetime | None = None,
+    ) -> Any | None:
+        from trusted_router.storage_gcp_spend_lease_reconcile import (
+            acquire_spend_lease_reconciler_lock,
+        )
+
+        return acquire_spend_lease_reconciler_lock(
+            self, owner=owner, ttl_seconds=ttl_seconds, now=now
+        )
+
+    def release_spend_lease_reconciler_lock(
+        self,
+        *,
+        owner: str,
+        fencing_token: int,
+        now: dt.datetime | None = None,
+    ) -> bool:
+        from trusted_router.storage_gcp_spend_lease_reconcile import (
+            release_spend_lease_reconciler_lock,
+        )
+
+        return release_spend_lease_reconciler_lock(
+            self, owner=owner, fencing_token=fencing_token, now=now
+        )
+
+    def reconcile_spend_leases(
+        self,
+        *,
+        limit: int = 25,
+        max_attempts: int = 12,
+        now: dt.datetime | None = None,
+    ) -> dict[str, int | float]:
+        from trusted_router.storage_gcp_spend_lease_reconcile import (
+            reconcile_spend_leases,
+        )
+
+        return reconcile_spend_leases(
+            self, limit=limit, max_attempts=max_attempts, now=now
+        )
+
+    def requeue_dead_spend_leases(
+        self,
+        *,
+        lease_ids: tuple[str, ...] = (),
+        limit: int = 1000,
+    ) -> int:
+        from trusted_router.storage_gcp_spend_lease_reconcile import (
+            requeue_dead_spend_leases,
+        )
+
+        return requeue_dead_spend_leases(self, lease_ids=lease_ids, limit=limit)
+
     def authorize_gateway_typed(
         self,
         *,

--- a/src/trusted_router/storage_gcp_spend_lease.py
+++ b/src/trusted_router/storage_gcp_spend_lease.py
@@ -160,6 +160,15 @@ class OpenRow:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class LagInputs:
+    """Oldest timestamps used to publish both decision-38 lag numbers."""
+
+    close_eligible_since: Any | None
+    expired_open_created_at: Any | None
+    dead_rows: int
+
+
 def register_bound(
     transaction: Any,
     param_types: Any,
@@ -485,6 +494,200 @@ def due_candidates(
 def due_open(snapshot: Any, param_types: Any, limit: int) -> list[OpenRow]:
     """Ordered open-lease work from the NULL-filtered due index."""
     return _due_rows(snapshot, param_types, limit, phases=("open",))
+
+
+def defer_open_row(
+    transaction: Any,
+    param_types: Any,
+    row: OpenRow,
+    *,
+    next_attempt_at: Any,
+    error: str | None,
+    increment_attempts: bool,
+    dead: bool = False,
+) -> int:
+    """Guarded per-row retry update; closeability polling does not count."""
+
+    attempts = row.attempts + int(increment_attempts)
+    return _single_row_count(
+        "defer_open_row",
+        transaction.execute_update(
+            "UPDATE spend_lease_open SET attempts=@attempts, last_error=@error, "
+            "next_attempt_at=@next_attempt_at, dead=@dead "
+            "WHERE lease_id=@lease_id AND phase=@phase AND attempts=@expected_attempts",
+            params={
+                "attempts": attempts,
+                "error": None if error is None else error[:1000],
+                "next_attempt_at": None if dead else next_attempt_at,
+                "dead": dead,
+                "lease_id": row.lease_id,
+                "phase": row.phase,
+                "expected_attempts": row.attempts,
+            },
+            param_types={
+                "attempts": param_types.INT64,
+                "error": param_types.STRING,
+                "next_attempt_at": param_types.TIMESTAMP,
+                "dead": param_types.BOOL,
+                "lease_id": param_types.STRING,
+                "phase": param_types.STRING,
+                "expected_attempts": param_types.INT64,
+            },
+        ),
+    )
+
+
+def set_close_eligible_once(
+    transaction: Any,
+    param_types: Any,
+    lease_id: str,
+    observed_at: Any,
+) -> int:
+    """Set the monotonic close proof timestamp without ever clearing it."""
+
+    return _single_row_count(
+        "set_close_eligible_once",
+        transaction.execute_update(
+            "UPDATE spend_lease_open SET close_eligible_since=@observed_at "
+            "WHERE lease_id=@lease_id AND phase='open' AND close_eligible_since IS NULL",
+            params={"lease_id": lease_id, "observed_at": observed_at},
+            param_types={
+                "lease_id": param_types.STRING,
+                "observed_at": param_types.TIMESTAMP,
+            },
+        ),
+    )
+
+
+def mark_global_closed(
+    transaction: Any,
+    param_types: Any,
+    lease_id: str,
+    closed_at: Any,
+) -> int:
+    return _single_row_count(
+        "mark_global_closed",
+        transaction.execute_update(
+            "UPDATE spend_lease_open SET global_closed_at=@closed_at, "
+            "next_attempt_at=@closed_at WHERE lease_id=@lease_id AND phase='open' "
+            "AND global_closed_at IS NULL",
+            params={"lease_id": lease_id, "closed_at": closed_at},
+            param_types={
+                "lease_id": param_types.STRING,
+                "closed_at": param_types.TIMESTAMP,
+            },
+        ),
+    )
+
+
+def mark_local_closed(
+    transaction: Any,
+    param_types: Any,
+    lease_id: str,
+    closed_at: Any,
+) -> int:
+    return _single_row_count(
+        "mark_local_closed",
+        transaction.execute_update(
+            "UPDATE spend_lease_open SET local_closed_at=@closed_at, "
+            "next_attempt_at=TIMESTAMP_ADD(@closed_at, INTERVAL 30 DAY) "
+            "WHERE lease_id=@lease_id AND phase='open' "
+            "AND global_closed_at IS NOT NULL AND local_closed_at IS NULL",
+            params={"lease_id": lease_id, "closed_at": closed_at},
+            param_types={
+                "lease_id": param_types.STRING,
+                "closed_at": param_types.TIMESTAMP,
+            },
+        ),
+    )
+
+
+def delete_open_row(
+    transaction: Any,
+    param_types: Any,
+    lease_id: str,
+    *,
+    phase: OpenPhase,
+) -> int:
+    return _single_row_count(
+        "delete_open_row",
+        transaction.execute_update(
+            "DELETE FROM spend_lease_open WHERE lease_id=@lease_id AND phase=@phase",
+            params={"lease_id": lease_id, "phase": phase},
+            param_types={"lease_id": param_types.STRING, "phase": param_types.STRING},
+        ),
+    )
+
+
+def requeue_dead(
+    transaction: Any,
+    param_types: Any,
+    lease_id: str,
+    next_attempt_at: Any,
+) -> int:
+    return _single_row_count(
+        "requeue_dead",
+        transaction.execute_update(
+            "UPDATE spend_lease_open SET attempts=0, last_error=NULL, dead=false, "
+            "next_attempt_at=@next_attempt_at "
+            "WHERE lease_id=@lease_id AND phase='open' AND dead=true",
+            params={"lease_id": lease_id, "next_attempt_at": next_attempt_at},
+            param_types={
+                "lease_id": param_types.STRING,
+                "next_attempt_at": param_types.TIMESTAMP,
+            },
+        ),
+    )
+
+
+def dead_rows(snapshot: Any, param_types: Any, limit: int) -> list[OpenRow]:
+    rows = list(
+        snapshot.execute_sql(
+            f"SELECT {', '.join(OPEN_COLUMNS)} FROM spend_lease_open "  # noqa: S608
+            "WHERE phase='open' AND dead=true ORDER BY created_at LIMIT @limit",
+            params={"limit": int(limit)},
+            param_types={"limit": param_types.INT64},
+        )
+    )
+    return [_open_row(row) for row in rows]
+
+
+def retained_done_candidates(
+    snapshot: Any,
+    param_types: Any,
+    cutoff: Any,
+    limit: int,
+) -> list[OpenRow]:
+    rows = list(
+        snapshot.execute_sql(
+            f"SELECT {', '.join(OPEN_COLUMNS)} FROM spend_lease_open "  # noqa: S608
+            "WHERE phase='done' AND created_at<=@cutoff "
+            "ORDER BY created_at LIMIT @limit",
+            params={"cutoff": cutoff, "limit": int(limit)},
+            param_types={
+                "cutoff": param_types.TIMESTAMP,
+                "limit": param_types.INT64,
+            },
+        )
+    )
+    return [_open_row(row) for row in rows]
+
+
+def lag_inputs(snapshot: Any, param_types: Any, now: Any) -> LagInputs:
+    rows = list(
+        snapshot.execute_sql(
+            "SELECT MIN(close_eligible_since), "
+            "MIN(IF(TIMESTAMP_ADD(expires_at, INTERVAL skew_seconds SECOND)<=@now, "
+            "created_at, NULL)), "
+            "(SELECT COUNTIF(dead) FROM spend_lease_open) "
+            "FROM spend_lease_open WHERE phase='open' AND local_closed_at IS NULL",
+            params={"now": now},
+            param_types={"now": param_types.TIMESTAMP},
+        )
+    )
+    if not rows:
+        return LagInputs(None, None, 0)
+    return LagInputs(rows[0][0], rows[0][1], int(rows[0][2] or 0))
 
 
 def authorization_typed_columns(payload: Mapping[str, Any]) -> dict[str, Any]:

--- a/src/trusted_router/storage_gcp_spend_lease_authorize.py
+++ b/src/trusted_router/storage_gcp_spend_lease_authorize.py
@@ -431,7 +431,7 @@ def _read_fence(
 def _mark_incumbent(transaction: Any, param_types: Any, lease_id: str | None) -> int:
     if lease_id is None:
         return 0
-    return int(transaction.execute_update(
+    return int(transaction.execute_update(  # noqa: S608 - fixed trusted suffix
         "UPDATE tr_entities SET body=TO_JSON_STRING(JSON_SET(PARSE_JSON(body), "
         "'$.holds_predecessor_slot', true)) "
         "WHERE kind=@kind AND id=@id AND JSON_VALUE(body, '$.state') IN ('ACTIVE','DRAINING','TOMBSTONED') "
@@ -441,16 +441,106 @@ def _mark_incumbent(transaction: Any, param_types: Any, lease_id: str | None) ->
     ))
 
 
-def _unmark_incumbent(transaction: Any, param_types: Any, lease_id: str | None) -> int:
+def _unmark_incumbent(
+    transaction: Any,
+    param_types: Any,
+    lease_id: str | None,
+    *,
+    frozen_only: bool = False,
+) -> int:
     if lease_id is None:
         return 0
+    if frozen_only:
+        statement = (
+            "UPDATE tr_entities SET body=TO_JSON_STRING(JSON_SET(PARSE_JSON(body), "
+            "'$.holds_predecessor_slot', false)) "
+            "WHERE kind=@kind AND id=@id "
+            "AND JSON_VALUE(body, '$.holds_predecessor_slot')='true' "
+            "AND JSON_VALUE(body, '$.state') IN ('DRAINING','TOMBSTONED')"
+        )
+    else:
+        statement = (
+            "UPDATE tr_entities SET body=TO_JSON_STRING(JSON_SET(PARSE_JSON(body), "
+            "'$.holds_predecessor_slot', false)) "
+            "WHERE kind=@kind AND id=@id "
+            "AND JSON_VALUE(body, '$.holds_predecessor_slot')='true'"
+        )
     return int(transaction.execute_update(
-        "UPDATE tr_entities SET body=TO_JSON_STRING(JSON_SET(PARSE_JSON(body), "
-        "'$.holds_predecessor_slot', false)) "
-        "WHERE kind=@kind AND id=@id AND JSON_VALUE(body, '$.holds_predecessor_slot')='true'",
+        statement,
         params={"kind": SPEND_LEASE_KIND, "id": lease_id},
         param_types={"kind": param_types.STRING, "id": param_types.STRING},
     ))
+
+
+def _mark_closing(
+    transaction: Any,
+    param_types: Any,
+    lease_id: str,
+    closing_at: datetime,
+) -> int:
+    """Flag-false close guard; callers abort the transaction on zero."""
+
+    return int(
+        transaction.execute_update(
+            "UPDATE tr_entities SET body=TO_JSON_STRING(JSON_SET(PARSE_JSON(body), "
+            "'$.closing_at', @closing_at_text)) "
+            "WHERE kind=@kind AND id=@id "
+            "AND JSON_VALUE(body, '$.state') IN ('DRAINING','TOMBSTONED') "
+            "AND JSON_VALUE(body, '$.holds_predecessor_slot')='false'",
+            params={
+                "kind": SPEND_LEASE_KIND,
+                "id": lease_id,
+                "closing_at_text": closing_at.isoformat(),
+            },
+            param_types={
+                "kind": param_types.STRING,
+                "id": param_types.STRING,
+                "closing_at_text": param_types.STRING,
+            },
+        )
+    )
+
+
+def _decrement_fence(
+    transaction: Any,
+    param_types: Any,
+    fence_id: str,
+) -> int:
+    """Release one predecessor slot, guarded against count underflow."""
+
+    return int(
+        transaction.execute_update(
+            "UPDATE tr_entities SET body=TO_JSON_STRING(JSON_SET(PARSE_JSON(body), "
+            "'$.open_predecessor_count', "
+            "CAST(COALESCE(JSON_VALUE(body, '$.open_predecessor_count'),'0') AS INT64)-1)) "
+            "WHERE kind=@kind AND id=@id "
+            "AND CAST(COALESCE(JSON_VALUE(body, '$.open_predecessor_count'),'0') AS INT64)>0",
+            params={"kind": FENCE_KIND, "id": fence_id},
+            param_types={"kind": param_types.STRING, "id": param_types.STRING},
+        )
+    )
+
+
+def _close_global_lease(
+    transaction: Any,
+    param_types: Any,
+    lease_id: str,
+    body: str,
+) -> int:
+    """Publish CLOSED only after every earlier close-step guard succeeded."""
+
+    return int(
+        transaction.execute_update(
+            "UPDATE tr_entities SET body=@body WHERE kind=@kind AND id=@id "
+            "AND JSON_VALUE(body, '$.state') IN ('DRAINING','TOMBSTONED')",
+            params={"body": body, "kind": SPEND_LEASE_KIND, "id": lease_id},
+            param_types={
+                "body": param_types.STRING,
+                "kind": param_types.STRING,
+                "id": param_types.STRING,
+            },
+        )
+    )
 
 
 def _advance_fence(

--- a/src/trusted_router/storage_gcp_spend_lease_reconcile.py
+++ b/src/trusted_router/storage_gcp_spend_lease_reconcile.py
@@ -1,0 +1,902 @@
+"""One-pass spend-lease recovery and close coordinator.
+
+Spanner owns work and global escrow; the regional Bigtable row owns the local
+state machine.  Every cross-store step is replayable, and the candidate phase
+handoff is the only fence against an in-flight mint.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+
+from trusted_router.spend_lease_ledger import SpendLeaseLedger
+from trusted_router.spend_lease_state import (
+    AbsenceObservation,
+    AllocationState,
+    AuthorizationDurability,
+    AuthorizationObservation,
+    BindingAbsenceProof,
+    BindingState,
+    BindingTuple,
+    BoundProof,
+    ClaimProof,
+    ConflictingBound,
+    FinalizationOutcome,
+    RecoveryProof,
+    RowBindingMismatch,
+    SpendLease,
+    SpendLeaseConflictError,
+    SpendLeaseState,
+)
+from trusted_router.storage_gcp_counter_dml import release_credit
+from trusted_router.storage_gcp_io import run_in_transaction_with_retry
+from trusted_router.storage_gcp_spend_lease import (
+    OpenRow,
+    complete_candidate,
+    dead_rows,
+    defer_open_row,
+    delete_open_row,
+    due_candidates,
+    due_open,
+    lag_inputs,
+    mark_global_closed,
+    mark_local_closed,
+    read_open_row,
+    read_registration,
+    register_claim,
+    requeue_dead,
+    retained_done_candidates,
+    set_close_eligible_once,
+    take_recovery_ownership,
+)
+from trusted_router.storage_gcp_spend_lease_authorize import (
+    SPEND_LEASE_KIND,
+    _close_global_lease,
+    _decrement_fence,
+    _mark_closing,
+    _read_fence,
+    _unmark_incumbent,
+)
+
+log = logging.getLogger(__name__)
+
+_LOCK_KIND = "spend_lease_reconciler_lock"
+_LOCK_ID = "singleton"
+_RETENTION = timedelta(days=30)
+_LAG_LIMIT = timedelta(hours=24)
+
+
+@dataclass(frozen=True, slots=True)
+class SpendLeaseReconcilerLock:
+    owner: str | None
+    fencing_token: int
+    expires_at: str
+    updated_at: str
+    previous_owner: str | None = None
+    previous_fencing_token: int | None = None
+
+    @property
+    def expires_datetime(self) -> datetime:
+        return datetime.fromisoformat(self.expires_at.replace("Z", "+00:00"))
+
+
+def acquire_spend_lease_reconciler_lock(
+    store: Any,
+    *,
+    owner: str,
+    ttl_seconds: int,
+    now: datetime | None = None,
+) -> SpendLeaseReconcilerLock | None:
+    """Acquire the singleton worker lease with an expiry and fencing token."""
+
+    now = datetime.now(UTC) if now is None else now
+    if now.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+    if not owner or len(owner) > 128:
+        raise ValueError("owner must contain between 1 and 128 characters")
+    if not 1 <= ttl_seconds <= 600:
+        raise ValueError("ttl_seconds must be between 1 and 600")
+
+    def txn(transaction: Any) -> SpendLeaseReconcilerLock | None:
+        current = store._read_entity_tx(
+            transaction, _LOCK_KIND, _LOCK_ID, SpendLeaseReconcilerLock
+        )
+        if current is not None and current.owner is not None and current.expires_datetime > now:
+            return None
+        lock = SpendLeaseReconcilerLock(
+            owner=owner,
+            fencing_token=1 if current is None else current.fencing_token + 1,
+            expires_at=_iso(now + timedelta(seconds=ttl_seconds)),
+            updated_at=_iso(now),
+        )
+        _upsert_lock(store, transaction, lock)
+        if current is not None and current.owner is not None:
+            return dataclasses.replace(
+                lock,
+                previous_owner=current.owner,
+                previous_fencing_token=current.fencing_token,
+            )
+        return lock
+
+    return cast(SpendLeaseReconcilerLock | None, store._run_in_transaction(txn))
+
+
+def release_spend_lease_reconciler_lock(
+    store: Any,
+    *,
+    owner: str,
+    fencing_token: int,
+    now: datetime | None = None,
+) -> bool:
+    """Release only the lock generation owned by this worker."""
+
+    now = datetime.now(UTC) if now is None else now
+    if now.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+
+    def txn(transaction: Any) -> bool:
+        current = store._read_entity_tx(
+            transaction, _LOCK_KIND, _LOCK_ID, SpendLeaseReconcilerLock
+        )
+        if current is None or current.owner != owner or current.fencing_token != fencing_token:
+            return False
+        _upsert_lock(
+            store,
+            transaction,
+            dataclasses.replace(
+                current,
+                owner=None,
+                expires_at=_iso(now),
+                updated_at=_iso(now),
+            ),
+        )
+        return True
+
+    return bool(store._run_in_transaction(txn))
+
+
+def reconcile_spend_leases(
+    store: Any,
+    *,
+    limit: int = 25,
+    max_attempts: int = 12,
+    now: datetime | None = None,
+) -> dict[str, int | float]:
+    """Run one ordered candidate pass followed by one ordered open pass."""
+
+    ledger: SpendLeaseLedger | None = store._spend_lease_ledger
+    if ledger is None:
+        raise RuntimeError("spend lease ledger is disabled")
+    now = datetime.now(UTC) if now is None else now
+    bounded_limit = max(1, min(int(limit), 1000))
+    result: dict[str, int | float] = {
+        "candidates": 0,
+        "open": 0,
+        "recovered": 0,
+        "bound": 0,
+        "closed": 0,
+        "deleted": 0,
+        "deferred": 0,
+        "errors": 0,
+        "dead": 0,
+    }
+
+    with store._database.snapshot() as snapshot:
+        candidates = due_candidates(snapshot, store._param_types, bounded_limit)
+    for row in candidates:
+        result["candidates"] += 1
+        try:
+            if _recover_candidate(store, ledger, row, now=now):
+                result["recovered"] += 1
+        except Exception as exc:
+            result["errors"] += 1
+            if _record_failure(store, row.lease_id, exc, max_attempts=max_attempts, now=now):
+                result["dead"] += 1
+            log.exception("spend_lease.reconcile_candidate_failed lease_id=%s", row.lease_id)
+
+    with store._database.snapshot() as snapshot:
+        open_rows = due_open(snapshot, store._param_types, bounded_limit)
+    for row in open_rows:
+        result["open"] += 1
+        try:
+            outcome = _reconcile_open(store, ledger, row, now=now)
+            result[outcome] = int(result.get(outcome, 0)) + 1
+        except _Contradiction as exc:
+            result["errors"] += 1
+            result["dead"] += 1
+            _mark_contradiction(store, row.lease_id, str(exc), now=now)
+            log.error(
+                "spend_lease.reconcile_contradiction lease_id=%s error=%s",
+                row.lease_id,
+                exc,
+            )
+        except Exception as exc:
+            result["errors"] += 1
+            if _record_failure(store, row.lease_id, exc, max_attempts=max_attempts, now=now):
+                result["dead"] += 1
+            log.exception("spend_lease.reconcile_open_failed lease_id=%s", row.lease_id)
+
+    with store._database.snapshot() as snapshot:
+        retained = retained_done_candidates(
+            snapshot, store._param_types, now - _RETENTION, bounded_limit
+        )
+    for row in retained:
+        changed = run_in_transaction_with_retry(
+            store._database,
+            lambda transaction, item=row: delete_open_row(
+                transaction, store._param_types, item.lease_id, phase="done"
+            ),
+            transaction_tag="tr_spend_lease_delete_done",
+        )
+        result["deleted"] += int(changed)
+
+    _log_lag(store, now=now, result=result)
+    return result
+
+
+def requeue_dead_spend_leases(
+    store: Any,
+    *,
+    lease_ids: tuple[str, ...] = (),
+    limit: int = 1000,
+    now: datetime | None = None,
+) -> int:
+    now = datetime.now(UTC) if now is None else now
+    if lease_ids:
+        selected = lease_ids
+    else:
+        with store._database.snapshot() as snapshot:
+            selected = tuple(
+                row.lease_id for row in dead_rows(snapshot, store._param_types, limit)
+            )
+    count = 0
+    for lease_id in selected:
+        count += int(
+            run_in_transaction_with_retry(
+                store._database,
+                lambda transaction, item=lease_id: requeue_dead(
+                    transaction, store._param_types, item, now
+                ),
+                transaction_tag="tr_spend_lease_requeue",
+            )
+        )
+    return count
+
+
+class _Contradiction(RuntimeError):
+    pass
+
+
+def _recover_candidate(
+    store: Any,
+    ledger: SpendLeaseLedger,
+    candidate: OpenRow,
+    *,
+    now: datetime,
+) -> bool:
+    if candidate.phase == "candidate":
+        owned = run_in_transaction_with_retry(
+            store._database,
+            lambda transaction: take_recovery_ownership(
+                transaction, store._param_types, candidate.lease_id
+            ),
+            transaction_tag="tr_spend_lease_recovery_ownership",
+        )
+        # The ownership transaction deliberately ends immediately after 4a.
+        if owned == 0:
+            return False
+
+    row = _strong_open_row(store, candidate.lease_id)
+    if row is None or row.phase != "recovering" or row.recovering_at is None:
+        return False
+    proof = RecoveryProof(_aware(row.recovering_at), row.creating_authorization_id)
+    absence = BindingAbsenceProof(
+        row.idempotency_scope,
+        row.creating_authorization_id,
+        AbsenceObservation.ABSENT_ROW,
+    )
+    for _ in range(16):
+        local = ledger.get(row.lease_id, region=row.region)
+        if local is None:
+            ledger.initialize(_candidate_from_row(row), region=row.region)
+            local = ledger.get(row.lease_id, region=row.region)
+            if local is None:
+                raise RuntimeError("candidate initialization was not durable")
+        creating = next(
+            (
+                allocation
+                for allocation in local.allocations
+                if allocation.authorization_id == row.creating_authorization_id
+            ),
+            None,
+        )
+        if creating is not None and creating.is_open:
+            ledger.compensate(
+                row.lease_id,
+                region=row.region,
+                idempotency_scope=creating.idempotency_scope,
+                expected_provisional_id=row.creating_authorization_id,
+                claim=proof,
+                absence=absence,
+            )
+        try:
+            ledger.tombstone_unminted(row.lease_id, region=row.region, proof=proof)
+        except SpendLeaseConflictError:
+            continue
+        break
+    else:
+        raise RuntimeError("candidate recovery did not converge after CAS losses")
+
+    completed = run_in_transaction_with_retry(
+        store._database,
+        lambda transaction: complete_candidate(
+            transaction, store._param_types, row.lease_id
+        ),
+        transaction_tag="tr_spend_lease_recovery_complete",
+    )
+    if completed != 1:
+        raise RuntimeError("candidate completion lost its recovering guard")
+    return True
+
+
+def _reconcile_open(
+    store: Any,
+    ledger: SpendLeaseLedger,
+    row: OpenRow,
+    *,
+    now: datetime,
+) -> str:
+    local = ledger.get(row.lease_id, region=row.region)
+    if local is None:
+        raise RuntimeError("open spend lease has no local row")
+    global_body = _read_global_body(store, row.lease_id)
+    if global_body is None:
+        raise RuntimeError("open spend lease has no global record")
+    _validate_global_identity(row, global_body)
+
+    if row.local_closed_at is not None:
+        if now < _aware(row.local_closed_at) + _RETENTION:
+            return _defer(store, row, now=now)
+        fence = _strong_fence(store, row)
+        if fence is not None and fence.get("lease_id") == row.lease_id:
+            return _defer(store, row, now=now)
+        ledger.delete(row.lease_id, region=row.region)
+        _delete_work_row(store, row)
+        return "deleted"
+
+    bound_count = _bind_last_resort(ledger, row, local, global_body)
+    if bound_count:
+        local = ledger.get(row.lease_id, region=row.region)
+        if local is None:
+            raise RuntimeError("bound spend lease disappeared")
+    local = _mirror_allocations(store, ledger, row, local, now=now)
+
+    cutoff = _aware(row.expires_at) + timedelta(seconds=row.skew_seconds)
+    if now >= cutoff and local.state == SpendLeaseState.ACTIVE:
+        ledger.begin_drain(row.lease_id, region=row.region, now=now)
+        local = ledger.get(row.lease_id, region=row.region)
+        if local is None:
+            raise RuntimeError("draining spend lease disappeared")
+
+    eligible = local.state in {SpendLeaseState.DRAINING, SpendLeaseState.TOMBSTONED} and not (
+        local.open_allocations
+    )
+    if row.close_eligible_since is not None and not eligible and row.global_closed_at is None:
+        raise _Contradiction("close eligibility was followed by an open allocation or state")
+    if not eligible and row.global_closed_at is None:
+        return _defer(store, row, now=now)
+    if row.close_eligible_since is None:
+        run_in_transaction_with_retry(
+            store._database,
+            lambda transaction: set_close_eligible_once(
+                transaction, store._param_types, row.lease_id, now
+            ),
+            transaction_tag="tr_spend_lease_close_eligible",
+        )
+
+    if row.global_closed_at is None:
+        _close_global(store, row, local, global_body, now=now)
+    else:
+        frozen_version = global_body.get("frozen_local_version")
+        expected = local.version - int(local.state == SpendLeaseState.CLOSED)
+        if frozen_version != expected:
+            raise _Contradiction("global frozen_local_version disagrees with local snapshot")
+
+    if local.state != SpendLeaseState.CLOSED:
+        ledger.close(row.lease_id, region=row.region, now=now)
+    marked = run_in_transaction_with_retry(
+        store._database,
+        lambda transaction: mark_local_closed(
+            transaction, store._param_types, row.lease_id, now
+        ),
+        transaction_tag="tr_spend_lease_local_closed",
+    )
+    if marked != 1:
+        refreshed = _strong_open_row(store, row.lease_id)
+        if refreshed is None or refreshed.local_closed_at is None:
+            raise RuntimeError("local close marker lost its guard")
+    return "closed" if not bound_count else "bound"
+
+
+def _bind_last_resort(
+    ledger: SpendLeaseLedger,
+    row: OpenRow,
+    local: SpendLease,
+    global_body: dict[str, Any],
+) -> int:
+    if global_body.get("state") not in {"ACTIVE", "DRAINING", "TOMBSTONED", "CLOSED"}:
+        return 0
+    bound = 0
+    for allocation in local.allocations:
+        if allocation.binding_state != BindingState.PROVISIONAL:
+            continue
+        if allocation.authorization_id != row.creating_authorization_id:
+            continue
+        proof = BoundProof(
+            allocation.idempotency_scope,
+            allocation.authorization_id,
+            row.lease_id,
+            row.gen,
+            allocation.allocated_micro,
+        )
+        ledger.bind(
+            row.lease_id,
+            region=row.region,
+            expected_provisional_id=allocation.authorization_id,
+            proof=proof,
+        )
+        bound += 1
+    return bound
+
+
+def _mirror_allocations(
+    store: Any,
+    ledger: SpendLeaseLedger,
+    row: OpenRow,
+    local: SpendLease,
+    *,
+    now: datetime,
+) -> SpendLease:
+    for allocation in local.allocations:
+        if allocation.state != AllocationState.RESERVED:
+            continue
+        authorization = store.get_gateway_authorization(allocation.authorization_id)
+        if authorization is None:
+            if allocation.binding_state == BindingState.COMMITTED and now >= allocation.abandon_after:
+                # Retention makes disappearance after the abandonment horizon a
+                # durable terminal observation for a committed allocation.
+                from trusted_router.spend_lease_state import CommittedRowAbsentProof
+
+                ledger.lost(
+                    row.lease_id,
+                    region=row.region,
+                    proof=CommittedRowAbsentProof(
+                        allocation.idempotency_scope, allocation.authorization_id
+                    ),
+                )
+            elif now >= allocation.abandon_after:
+                _abandon_provisional(store, ledger, row, allocation)
+            continue
+        observed_tuple = (
+            authorization.spend_lease_id,
+            authorization.spend_lease_gen,
+            authorization.spend_lease_allocated_micro,
+        )
+        expected_tuple = (row.lease_id, row.gen, allocation.allocated_micro)
+        observed_binding = (
+            BindingTuple(
+                str(observed_tuple[0]),
+                int(observed_tuple[1]),
+                int(observed_tuple[2]),
+            )
+            if all(value is not None for value in observed_tuple)
+            else None
+        )
+        if observed_tuple != expected_tuple:
+            if allocation.binding_state == BindingState.PROVISIONAL and observed_binding is None:
+                if now >= allocation.abandon_after:
+                    _abandon_provisional(store, ledger, row, allocation, authorization)
+                continue
+            assert observed_binding is not None
+            proof = (
+                ConflictingBound(allocation.authorization_id, observed_binding)
+                if allocation.binding_state == BindingState.PROVISIONAL
+                else RowBindingMismatch(allocation.authorization_id, observed_binding)
+            )
+            ledger.quarantine(
+                row.lease_id,
+                region=row.region,
+                idempotency_scope=allocation.idempotency_scope,
+                proof=proof,
+            )
+            log.error(
+                "spend_lease.reconcile_quarantine lease_id=%s authorization_id=%s",
+                row.lease_id,
+                allocation.authorization_id,
+            )
+            continue
+        if allocation.binding_state == BindingState.PROVISIONAL:
+            ledger.bind(
+                row.lease_id,
+                region=row.region,
+                expected_provisional_id=allocation.authorization_id,
+                proof=BoundProof(
+                    allocation.idempotency_scope,
+                    allocation.authorization_id,
+                    row.lease_id,
+                    row.gen,
+                    allocation.allocated_micro,
+                ),
+            )
+        outcome = (
+            None
+            if authorization.finalization_outcome is None
+            else FinalizationOutcome(authorization.finalization_outcome)
+        )
+        ledger.mirror(
+            row.lease_id,
+            region=row.region,
+            observation=AuthorizationObservation(
+                idempotency_scope=allocation.idempotency_scope,
+                authorization_id=allocation.authorization_id,
+                request_fingerprint=allocation.request_fingerprint,
+                lease_id=row.lease_id,
+                gen=row.gen,
+                allocated_micro=allocation.allocated_micro,
+                key_hash=row.key_hash,
+                workspace_id=row.workspace_id,
+                durability=(
+                    AuthorizationDurability.TERMINAL
+                    if authorization.settled
+                    else AuthorizationDurability.OPEN
+                ),
+                finalization_outcome=outcome,
+                finalized_cost_microdollars=(
+                    authorization.finalized_cost_microdollars
+                    if outcome == FinalizationOutcome.SETTLED
+                    else None
+                ),
+            ),
+        )
+    refreshed = ledger.get(row.lease_id, region=row.region)
+    if refreshed is None:
+        raise RuntimeError("spend lease disappeared during allocation mirror")
+    return refreshed
+
+
+def _abandon_provisional(
+    store: Any,
+    ledger: SpendLeaseLedger,
+    row: OpenRow,
+    allocation: Any,
+    authorization: Any | None = None,
+) -> None:
+    def claim_txn(transaction: Any) -> ClaimProof:
+        if register_claim(
+            transaction,
+            store._param_types,
+            allocation.idempotency_scope,
+            allocation.authorization_id,
+        ) == 1:
+            return ClaimProof(allocation.idempotency_scope, allocation.authorization_id)
+        registration = read_registration(
+            transaction, store._param_types, allocation.idempotency_scope
+        )
+        if (
+            registration is None
+            or registration.kind != "CLAIM"
+            or registration.provisional_id != allocation.authorization_id
+        ):
+            observed = None if registration is None else registration.lease
+            raise _Contradiction(f"provisional allocation has conflicting registration {observed}")
+        return ClaimProof(allocation.idempotency_scope, allocation.authorization_id)
+
+    claim = run_in_transaction_with_retry(
+        store._database, claim_txn, transaction_tag="tr_spend_lease_abandon_claim"
+    )
+    ledger.abandon(
+        row.lease_id,
+        region=row.region,
+        idempotency_scope=allocation.idempotency_scope,
+        expected_provisional_id=allocation.authorization_id,
+        claim=claim,
+        absence=BindingAbsenceProof(
+            allocation.idempotency_scope,
+            allocation.authorization_id,
+            (
+                AbsenceObservation.ABSENT_ROW
+                if authorization is None
+                else AbsenceObservation.NON_BINDING_ROW
+            ),
+            observed_authorization_id=(
+                None if authorization is None else authorization.id
+            ),
+        ),
+        now=datetime.now(UTC),
+    )
+
+
+def _close_global(
+    store: Any,
+    row: OpenRow,
+    local: SpendLease,
+    global_body: dict[str, Any],
+    *,
+    now: datetime,
+) -> None:
+    credit_shard = int(global_body["credit_shard"])
+    holds_slot = bool(global_body.get("holds_predecessor_slot"))
+    fence_id = store._spend_lease_pair_id(row.key_hash, row.boot_kid)
+    closed_body = dict(global_body)
+    closed_body.update(
+        {
+            "state": "CLOSED",
+            "frozen_local_version": local.version,
+            "closing_at": closed_body.get("closing_at") or now.isoformat(),
+        }
+    )
+
+    def txn(transaction: Any) -> None:
+        _require_one(
+            release_credit(
+                transaction,
+                store._param_types,
+                row.workspace_id,
+                row.cap_micro,
+                0,
+                shard=credit_shard,
+            ),
+            "spend lease escrow release",
+        )
+        if holds_slot:
+            _require_one(
+                _unmark_incumbent(
+                    transaction,
+                    store._param_types,
+                    row.lease_id,
+                    frozen_only=True,
+                ),
+                "predecessor owner clear",
+            )
+            _require_one(
+                _decrement_fence(transaction, store._param_types, fence_id),
+                "predecessor fence decrement",
+            )
+            closed_body["holds_predecessor_slot"] = False
+        else:
+            _require_one(
+                _mark_closing(transaction, store._param_types, row.lease_id, now),
+                "spend lease closing guard",
+            )
+        _require_one(
+            mark_global_closed(transaction, store._param_types, row.lease_id, now),
+            "global close work marker",
+        )
+        _require_one(
+            _close_global_lease(
+                transaction,
+                store._param_types,
+                row.lease_id,
+                json.dumps(closed_body, separators=(",", ":"), sort_keys=True),
+            ),
+            "global spend lease close",
+        )
+
+    run_in_transaction_with_retry(
+        store._database, txn, transaction_tag="tr_spend_lease_global_close"
+    )
+
+
+def _record_failure(
+    store: Any,
+    lease_id: str,
+    error: Exception,
+    *,
+    max_attempts: int,
+    now: datetime,
+) -> bool:
+    row = _strong_open_row(store, lease_id)
+    if row is None or row.phase == "done":
+        return False
+    next_attempts = row.attempts + 1
+    dead = next_attempts >= max_attempts
+    next_at = now + timedelta(seconds=_backoff_seconds(next_attempts))
+    changed = run_in_transaction_with_retry(
+        store._database,
+        lambda transaction: defer_open_row(
+            transaction,
+            store._param_types,
+            row,
+            next_attempt_at=next_at,
+            error=str(error),
+            increment_attempts=True,
+            dead=dead,
+        ),
+        transaction_tag="tr_spend_lease_retry",
+    )
+    if changed != 1:
+        return False
+    if dead:
+        log.error("spend_lease.reconcile_dead lease_id=%s count=1", lease_id)
+    return dead
+
+
+def _mark_contradiction(store: Any, lease_id: str, error: str, *, now: datetime) -> None:
+    row = _strong_open_row(store, lease_id)
+    if row is None:
+        return
+    run_in_transaction_with_retry(
+        store._database,
+        lambda transaction: defer_open_row(
+            transaction,
+            store._param_types,
+            row,
+            next_attempt_at=now,
+            error=error,
+            increment_attempts=False,
+            dead=True,
+        ),
+        transaction_tag="tr_spend_lease_contradiction",
+    )
+
+
+def _defer(store: Any, row: OpenRow, *, now: datetime) -> str:
+    current = _strong_open_row(store, row.lease_id) or row
+    next_at = now + timedelta(seconds=_backoff_seconds(max(current.attempts, 1)))
+    run_in_transaction_with_retry(
+        store._database,
+        lambda transaction: defer_open_row(
+            transaction,
+            store._param_types,
+            current,
+            next_attempt_at=next_at,
+            error=current.last_error,
+            increment_attempts=False,
+        ),
+        transaction_tag="tr_spend_lease_not_closeable",
+    )
+    return "deferred"
+
+
+def _log_lag(store: Any, *, now: datetime, result: dict[str, int | float]) -> None:
+    with store._database.snapshot() as snapshot:
+        inputs = lag_inputs(snapshot, store._param_types, now)
+    eligibility = _lag_seconds(now, inputs.close_eligible_since)
+    open_age = _lag_seconds(now, inputs.expired_open_created_at)
+    result["eligibility_lag_seconds"] = eligibility
+    result["open_age_lag_seconds"] = open_age
+    result["dead"] = inputs.dead_rows
+    log.info(
+        "spend_lease.reconcile_lag eligibility_lag_seconds=%.3f "
+        "open_age_lag_seconds=%.3f dead_rows=%d",
+        eligibility,
+        open_age,
+        inputs.dead_rows,
+    )
+    if eligibility > _LAG_LIMIT.total_seconds() or open_age > _LAG_LIMIT.total_seconds():
+        log.error(
+            "spend_lease.reconcile_lag_exceeded eligibility_lag_seconds=%.3f "
+            "open_age_lag_seconds=%.3f",
+            eligibility,
+            open_age,
+        )
+    if inputs.dead_rows:
+        log.error("spend_lease.reconcile_dead_count count=%d", inputs.dead_rows)
+
+
+def _strong_open_row(store: Any, lease_id: str) -> OpenRow | None:
+    with store._database.snapshot() as snapshot:
+        return read_open_row(snapshot, store._param_types, lease_id)
+
+
+def _read_global_body(store: Any, lease_id: str) -> dict[str, Any] | None:
+    with store._database.snapshot() as snapshot:
+        rows = list(
+            snapshot.execute_sql(
+                "SELECT body FROM tr_entities WHERE kind=@kind AND id=@id",
+                params={"kind": SPEND_LEASE_KIND, "id": lease_id},
+                param_types={
+                    "kind": store._param_types.STRING,
+                    "id": store._param_types.STRING,
+                },
+            )
+        )
+    return None if not rows else dict(json.loads(rows[0][0]))
+
+
+def _strong_fence(store: Any, row: OpenRow) -> dict[str, Any] | None:
+    with store._database.snapshot(multi_use=True) as snapshot:
+        return _read_fence(
+            snapshot,
+            store._param_types,
+            store._spend_lease_pair_id(row.key_hash, row.boot_kid),
+            row.lease_id,
+        )
+
+
+def _delete_work_row(store: Any, row: OpenRow) -> None:
+    changed = run_in_transaction_with_retry(
+        store._database,
+        lambda transaction: delete_open_row(
+            transaction, store._param_types, row.lease_id, phase="open"
+        ),
+        transaction_tag="tr_spend_lease_delete_open",
+    )
+    if changed != 1:
+        raise RuntimeError("retained spend lease work row delete lost its guard")
+
+
+def _candidate_from_row(row: OpenRow) -> SpendLease:
+    return SpendLease(
+        lease_id=row.lease_id,
+        gen=row.gen,
+        key_hash=row.key_hash,
+        boot_kid=row.boot_kid,
+        workspace_id=row.workspace_id,
+        creating_authorization_id=row.creating_authorization_id,
+        cap_micro=row.cap_micro,
+        expires_at=_aware(row.expires_at),
+        skew=timedelta(seconds=row.skew_seconds),
+        version=0,
+    )
+
+
+def _validate_global_identity(row: OpenRow, body: dict[str, Any]) -> None:
+    expected = (row.lease_id, row.gen, row.key_hash, row.boot_kid, row.workspace_id, row.region)
+    observed = tuple(body.get(key) for key in (
+        "lease_id", "gen", "key_hash", "boot_kid", "workspace_id", "region"
+    ))
+    if observed != expected:
+        raise _Contradiction("global spend lease identity changed")
+
+
+def _upsert_lock(store: Any, transaction: Any, lock: SpendLeaseReconcilerLock) -> None:
+    body = json.dumps(dataclasses.asdict(lock), separators=(",", ":"), sort_keys=True)
+    params = {"kind": _LOCK_KIND, "id": _LOCK_ID, "body": body}
+    types = {
+        "kind": store._param_types.STRING,
+        "id": store._param_types.STRING,
+        "body": store._param_types.STRING,
+    }
+    changed = transaction.execute_update(
+        "UPDATE tr_entities SET body=@body, updated_at=PENDING_COMMIT_TIMESTAMP() "
+        "WHERE kind=@kind AND id=@id",
+        params=params,
+        param_types=types,
+    )
+    if changed == 0:
+        transaction.execute_update(
+            "INSERT INTO tr_entities (kind, id, body, updated_at) "
+            "VALUES (@kind, @id, @body, PENDING_COMMIT_TIMESTAMP())",
+            params=params,
+            param_types=types,
+        )
+
+
+def _require_one(count: int, operation: str) -> None:
+    if count != 1:
+        raise RuntimeError(f"{operation} modified {count} rows")
+
+
+def _backoff_seconds(attempts: int) -> int:
+    return int(min(60 * 60, 2 ** max(attempts - 1, 0)))
+
+
+def _lag_seconds(now: datetime, value: Any | None) -> float:
+    return 0.0 if value is None else max(0.0, (now - _aware(value)).total_seconds())
+
+
+def _aware(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+    parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")

--- a/src/trusted_router/synthetic/fleet.py
+++ b/src/trusted_router/synthetic/fleet.py
@@ -66,6 +66,7 @@ BUILTIN_HEARTBEAT_TARGETS = frozenset(
     {
         "job:settle-outbox-drain",
         "job:regional-quota-reconcile",
+        "job:spend-lease-reconcile",
         "job:receipt-key-collector",
         "scheduler:auto-refill-outbox",
         "scheduler:home-settlement",

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -375,6 +375,10 @@ class FakeSpannerDatabase:
                     }
                     self.spend_lease_open[lease_id] = record
                     self.spend_lease_open_versions[lease_id] = new_version
+                elif op[0] == "delete_spend_open":
+                    _, lease_id = op
+                    self.spend_lease_open.pop(lease_id, None)
+                    self.spend_lease_open_versions[lease_id] = new_version
                 elif op[0] in ("insert_generation", "upsert_generation"):
                     _, generation_id, record = op
                     self.generation_records[generation_id] = record
@@ -1713,6 +1717,19 @@ def _evaluate_spanner_expression(
         return _utc_datetime(params[timestamp_name]) + dt.timedelta(
             seconds=int(params[seconds_name])
         )
+    timestamp_add_days = re.fullmatch(
+        r"TIMESTAMP_ADD\s*\(\s*@([A-Za-z_][A-Za-z0-9_]*)\s*,\s*"
+        r"INTERVAL\s+([0-9]+)\s+DAY\s*\)",
+        expression,
+        re.IGNORECASE,
+    )
+    if timestamp_add_days is not None:
+        timestamp_name, days = timestamp_add_days.groups()
+        if timestamp_name not in params:
+            raise AssertionError(
+                f"spend-lease SQL references missing parameter @{timestamp_name}"
+            )
+        return _utc_datetime(params[timestamp_name]) + dt.timedelta(days=int(days))
     if re.fullmatch(r"'(?:''|[^'])*'", expression):
         return expression[1:-1].replace("''", "'")
     if re.fullmatch(r"-?[0-9]+", expression):
@@ -1934,7 +1951,7 @@ def _execute_spend_lease_entity_update(
     else:
         json_set = re.fullmatch(
             r"TO_JSON_STRING\s*\(\s*JSON_SET\s*\(\s*PARSE_JSON\s*\(\s*body\s*\)\s*,"
-            r"\s*('(?:''|[^'])*')\s*,\s*(TRUE|FALSE)\s*\)\s*\)",
+            r"\s*('(?:''|[^'])*')\s*,\s*(.+)\s*\)\s*\)",
             assignment_sql,
             re.IGNORECASE,
         )
@@ -1944,12 +1961,25 @@ def _execute_spend_lease_entity_update(
             )
         path_sql, value_sql = json_set.groups()
         path = str(_evaluate_spanner_expression(path_sql, params, now))
-        if path != "$.holds_predecessor_slot":
-            raise AssertionError(f"unsupported tr_entities JSON_SET path: {path!r}")
         body = json.loads(str(record["body"]))
-        body["holds_predecessor_slot"] = bool(
-            _evaluate_spanner_expression(value_sql, params, now)
-        )
+        if path in {"$.holds_predecessor_slot", "$.closing_at"}:
+            body[path[2:]] = _evaluate_spanner_expression(value_sql, params, now)
+        elif path == "$.open_predecessor_count":
+            decrement = re.fullmatch(
+                r"CAST\s*\(\s*COALESCE\s*\(\s*JSON_VALUE\s*\(\s*body\s*,\s*"
+                r"'\$\.open_predecessor_count'\s*\)\s*,\s*'0'\s*\)\s+AS\s+INT64\s*\)\s*-\s*1",
+                value_sql,
+                re.IGNORECASE,
+            )
+            if decrement is None:
+                raise AssertionError(
+                    f"unsupported predecessor count update: {value_sql!r}"
+                )
+            body["open_predecessor_count"] = int(
+                body.get("open_predecessor_count", 0)
+            ) - 1
+        else:
+            raise AssertionError(f"unsupported tr_entities JSON_SET path: {path!r}")
         new_body = json.dumps(body, separators=(",", ":"), sort_keys=True)
     transaction.pending_writes.append(
         ("update_entity_dml", kind, entity_id, str(new_body))
@@ -2074,7 +2104,7 @@ def _execute_spend_lease_dml(
         return 1
 
     delete = re.fullmatch(
-        r"DELETE\s+FROM\s+(spend_lease_scope_arbitration)\s+WHERE\s+(.+?)\s*",
+        r"DELETE\s+FROM\s+(spend_lease_scope_arbitration|spend_lease_open)\s+WHERE\s+(.+?)\s*",
         sql,
         re.DOTALL | re.IGNORECASE,
     )
@@ -3034,6 +3064,57 @@ def _execute_sql(
                 else db.spend_lease_open.get(lease_id)
             )
             return [[rec.get(col) for col in cols]] if rec is not None else []
+        if "SELECT MIN(close_eligible_since)" in sql:
+            records = [
+                rec
+                for rec in db.spend_lease_open.values()
+                if rec.get("phase") == "open" and rec.get("local_closed_at") is None
+            ]
+            eligible = [
+                rec["close_eligible_since"]
+                for rec in records
+                if rec.get("close_eligible_since") is not None
+            ]
+            expired_created = [
+                rec["created_at"]
+                for rec in records
+                if _utc_datetime(rec["expires_at"])
+                + dt.timedelta(seconds=int(rec["skew_seconds"]))
+                <= _utc_datetime(params["now"])
+            ]
+            return [[
+                min(eligible) if eligible else None,
+                min(expired_created) if expired_created else None,
+                sum(bool(rec.get("dead")) for rec in db.spend_lease_open.values()),
+            ]]
+        if "WHERE phase='open' AND dead=true" in sql:
+            records = sorted(
+                (
+                    rec
+                    for rec in db.spend_lease_open.values()
+                    if rec.get("phase") == "open" and rec.get("dead") is True
+                ),
+                key=lambda rec: _utc_datetime(rec["created_at"]),
+            )
+            return [
+                [rec.get(col) for col in cols]
+                for rec in records[: int(params["limit"])]
+            ]
+        if "WHERE phase='done' AND created_at<=@cutoff" in sql:
+            records = sorted(
+                (
+                    rec
+                    for rec in db.spend_lease_open.values()
+                    if rec.get("phase") == "done"
+                    and _utc_datetime(rec["created_at"])
+                    <= _utc_datetime(params["cutoff"])
+                ),
+                key=lambda rec: _utc_datetime(rec["created_at"]),
+            )
+            return [
+                [rec.get(col) for col in cols]
+                for rec in records[: int(params["limit"])]
+            ]
         _require_pred(
             sql,
             "@{FORCE_INDEX=spend_lease_open_due}",
@@ -3056,7 +3137,7 @@ def _execute_sql(
             phases = {"open"}
         else:
             raise AssertionError("spend-lease due query missing phase predicate")
-        now = dt.datetime.now(dt.UTC)
+        now = db.current_timestamp()
         records = [
             rec
             for rec in db.spend_lease_open.values()

--- a/tests/fakes/spend_lease_bigtable.py
+++ b/tests/fakes/spend_lease_bigtable.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from google.cloud.bigtable.row_filters import ValueRegexFilter
+
+
+@dataclass
+class Cell:
+    value: bytes
+
+
+class ReadRow:
+    def __init__(self, values: dict[bytes, bytes]) -> None:
+        self.cells = {
+            "lease": {qualifier: [Cell(value)] for qualifier, value in values.items()}
+        }
+
+
+class FakeConditionalRow:
+    def __init__(self, table: FakeBigtableTable, row_key: bytes, filter_: Any) -> None:
+        self.table = table
+        self.row_key = row_key
+        self.filter = filter_
+        self.mutations: list[tuple[bool, bytes, bytes]] = []
+
+    def set_cell(
+        self,
+        _family: str,
+        column: bytes,
+        value: bytes,
+        *,
+        state: bool,
+    ) -> None:
+        self.mutations.append((state, column, value))
+
+    def commit(self) -> bool:
+        self.table.commit_attempts += 1
+        current = self.table.rows.get(self.row_key)
+        regex_filter = next(
+            (
+                candidate
+                for candidate in self.filter.filters
+                if isinstance(candidate, ValueRegexFilter)
+            ),
+            None,
+        )
+        if regex_filter is None:
+            matched = current is not None and b"version" in current
+        else:
+            expected = regex_filter.regex.removeprefix(b"^").removesuffix(b"$")
+            matched = (
+                not self.table.force_cas_misses
+                and current is not None
+                and re.fullmatch(expected, current.get(b"version", b"")) is not None
+            )
+        selected = [mutation for mutation in self.mutations if mutation[0] == matched]
+        if selected:
+            values = self.table.rows.setdefault(self.row_key, {})
+            for _state, column, value in selected:
+                values[column] = value
+        if self.table.raise_after_next_applied_commit and selected:
+            self.table.raise_after_next_applied_commit = False
+            raise TimeoutError("reply lost after durable apply")
+        return matched
+
+
+class FakeDirectRow:
+    def __init__(self, table: FakeBigtableTable, row_key: bytes) -> None:
+        self.table = table
+        self.row_key = row_key
+        self.deleted = False
+
+    def delete(self) -> None:
+        self.deleted = True
+
+    def commit(self) -> None:
+        self.table.commit_attempts += 1
+        if self.deleted:
+            self.table.rows.pop(self.row_key, None)
+
+
+class FakeBigtableTable:
+    def __init__(self) -> None:
+        self.rows: dict[bytes, dict[bytes, bytes]] = {}
+        self.commit_attempts = 0
+        self.force_cas_misses = False
+        self.raise_after_next_applied_commit = False
+
+    def row(self, row_key: bytes, *, filter_: Any) -> FakeConditionalRow:
+        return FakeConditionalRow(self, row_key, filter_)
+
+    def direct_row(self, row_key: bytes) -> FakeDirectRow:
+        return FakeDirectRow(self, row_key)
+
+    def read_row(self, row_key: bytes, *, filter_: Any) -> ReadRow | None:
+        del filter_
+        values = self.rows.get(row_key)
+        return None if values is None else ReadRow(values)

--- a/tests/test_spend_lease_ledger.py
+++ b/tests/test_spend_lease_ledger.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 
 import hashlib
 import json
-import re
-from dataclasses import dataclass, replace
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
-from google.cloud.bigtable.row_filters import ValueRegexFilter
 
 import trusted_router.spend_lease_ledger as ledger_module
+from tests.fakes.spend_lease_bigtable import FakeBigtableTable as _FakeBigtableTable
+from tests.fakes.spend_lease_bigtable import ReadRow as _ReadRow
 from trusted_router.config import Settings
 from trusted_router.spend_lease_ledger import (
     BigtableSpendLeaseLedger,
@@ -463,79 +463,3 @@ def test_spend_lease_profile_map_rejects_ambiguous_entries(value: str) -> None:
             environment="test",
             spend_lease_bigtable_app_profiles=value,
         ).spend_lease_bigtable_app_profile_map
-
-
-@dataclass
-class _Cell:
-    value: bytes
-
-
-class _ReadRow:
-    def __init__(self, values: dict[bytes, bytes]) -> None:
-        self.cells = {
-            "lease": {qualifier: [_Cell(value)] for qualifier, value in values.items()}
-        }
-
-
-class _FakeConditionalRow:
-    def __init__(self, table: _FakeBigtableTable, row_key: bytes, filter_: Any) -> None:
-        self.table = table
-        self.row_key = row_key
-        self.filter = filter_
-        self.mutations: list[tuple[bool, bytes, bytes]] = []
-
-    def set_cell(
-        self,
-        _family: str,
-        column: bytes,
-        value: bytes,
-        *,
-        state: bool,
-    ) -> None:
-        self.mutations.append((state, column, value))
-
-    def commit(self) -> bool:
-        self.table.commit_attempts += 1
-        current = self.table.rows.get(self.row_key)
-        regex_filter = next(
-            (
-                candidate
-                for candidate in self.filter.filters
-                if isinstance(candidate, ValueRegexFilter)
-            ),
-            None,
-        )
-        if regex_filter is None:
-            matched = current is not None and b"version" in current
-        else:
-            expected = regex_filter.regex.removeprefix(b"^").removesuffix(b"$")
-            matched = (
-                not self.table.force_cas_misses
-                and current is not None
-                and re.fullmatch(expected, current.get(b"version", b"")) is not None
-            )
-        selected = [mutation for mutation in self.mutations if mutation[0] == matched]
-        if selected:
-            values = self.table.rows.setdefault(self.row_key, {})
-            for _state, column, value in selected:
-                values[column] = value
-        if self.table.raise_after_next_applied_commit and selected:
-            self.table.raise_after_next_applied_commit = False
-            raise TimeoutError("reply lost after durable apply")
-        return matched
-
-
-class _FakeBigtableTable:
-    def __init__(self) -> None:
-        self.rows: dict[bytes, dict[bytes, bytes]] = {}
-        self.commit_attempts = 0
-        self.force_cas_misses = False
-        self.raise_after_next_applied_commit = False
-
-    def row(self, row_key: bytes, *, filter_: Any) -> _FakeConditionalRow:
-        return _FakeConditionalRow(self, row_key, filter_)
-
-    def read_row(self, row_key: bytes, *, filter_: Any) -> _ReadRow | None:
-        del filter_
-        values = self.rows.get(row_key)
-        return None if values is None else _ReadRow(values)

--- a/tests/test_spend_lease_reconcile.py
+++ b/tests/test_spend_lease_reconcile.py
@@ -290,6 +290,57 @@ def test_close_step_two_lost_guard_rolls_back_credit_release(
     assert database.spend_lease_open[identity.lease_id]["global_closed_at"] is None
 
 
+def test_close_step_two_zero_row_credit_release_aborts_every_close_write() -> None:
+    store, database, ledger = _store()
+    identity = _identity()
+    _insert_candidate(store, identity)
+    _open_candidate(store, identity)
+    ledger.initialize(
+        _local_candidate(identity, state=SpendLeaseState.DRAINING), region=REGION
+    )
+    _seed_global(store, identity, state="DRAINING", slot=True, count=1)
+    _seed_credit(database, identity)
+    credit = database.typed["tr_credit_balance"][(identity.workspace_id, 0)]
+    credit["reserved"] = 0
+    fence_id = store._spend_lease_pair_id(identity.key_hash, identity.boot_kid)
+
+    first = reconcile_spend_leases(store, now=NOW, max_attempts=99)
+
+    row = database.spend_lease_open[identity.lease_id]
+    global_body = store._read_entity(SPEND_LEASE_KIND, identity.lease_id, dict)
+    fence = store._read_entity(FENCE_KIND, fence_id, dict)
+    local = ledger.get(identity.lease_id, region=REGION)
+    assert first["errors"] == 1
+    assert first["closed"] == 0
+    assert credit["reserved"] == 0
+    assert credit["total_usage"] == 0
+    assert global_body["state"] == "DRAINING"
+    assert global_body["frozen_local_version"] is None
+    assert global_body["holds_predecessor_slot"] is True
+    assert fence["open_predecessor_count"] == 1
+    assert row["global_closed_at"] is None
+    assert row["local_closed_at"] is None
+    assert row["attempts"] == 1
+    assert row["last_error"] == "spend lease escrow release modified 0 rows"
+    assert row["next_attempt_at"] == NOW + timedelta(seconds=1)
+    assert local is not None and local.state == SpendLeaseState.DRAINING
+
+    database.now = NOW + timedelta(seconds=1)
+    second = reconcile_spend_leases(
+        store, now=NOW + timedelta(seconds=1), max_attempts=99
+    )
+
+    retried = database.spend_lease_open[identity.lease_id]
+    assert second["errors"] == 1
+    assert second["closed"] == 0
+    assert retried["attempts"] == 2
+    assert retried["global_closed_at"] is None
+    assert credit["reserved"] == 0
+    assert credit["total_usage"] == 0
+    assert store._read_entity(FENCE_KIND, fence_id, dict)["open_predecessor_count"] == 1
+    assert store._read_entity(SPEND_LEASE_KIND, identity.lease_id, dict) == global_body
+
+
 @pytest.mark.parametrize("slot", [False, True], ids=["active-owner", "predecessor-owner"])
 def test_close_step_two_and_three_close_global_then_local(slot: bool) -> None:
     store, database, ledger = _store()
@@ -322,6 +373,43 @@ def test_close_step_two_and_three_close_global_then_local(slot: bool) -> None:
             dict,
         )
         assert fence["open_predecessor_count"] == 0
+
+
+def test_global_close_reentry_rejects_changed_local_frozen_version(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, database, ledger = _store()
+    identity = _identity()
+    _insert_candidate(store, identity)
+    _open_candidate(store, identity)
+    ledger.initialize(_local_candidate(identity), region=REGION)
+    ledger.begin_drain(identity.lease_id, region=REGION, now=NOW)
+    global_body = _global_body(identity, state="CLOSED")
+    global_body["frozen_local_version"] = 0
+    global_body["closing_at"] = (NOW - timedelta(seconds=1)).isoformat()
+    store._write_entity(SPEND_LEASE_KIND, identity.lease_id, global_body)
+    database.spend_lease_open[identity.lease_id]["global_closed_at"] = NOW - timedelta(
+        seconds=1
+    )
+    caplog.set_level(logging.ERROR)
+
+    result = reconcile_spend_leases(store, now=NOW)
+
+    row = database.spend_lease_open[identity.lease_id]
+    local = ledger.get(identity.lease_id, region=REGION)
+    assert result["errors"] == 1
+    assert result["dead"] == 1
+    assert row["dead"] is True
+    assert row["attempts"] == 0
+    assert row["next_attempt_at"] is None
+    assert row["last_error"] == (
+        "global frozen_local_version disagrees with local snapshot"
+    )
+    assert row["local_closed_at"] is None
+    assert local is not None
+    assert local.version == 1
+    assert local.state == SpendLeaseState.DRAINING
+    assert "spend_lease.reconcile_contradiction" in caplog.text
 
 
 def test_close_eligible_since_is_monotonic_and_contrary_state_is_dead(
@@ -393,6 +481,62 @@ def test_dead_row_requeue_resets_attempts_and_due_time() -> None:
     assert requeued["attempts"] == 0
     assert requeued["last_error"] is None
     assert requeued["next_attempt_at"] == NOW
+
+
+def test_ordinary_failures_reach_max_attempts_then_requeue_and_sweep_again(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, database, _ledger = _store()
+    identity = _identity()
+    _insert_candidate(store, identity)
+    _open_candidate(store, identity)
+    caplog.set_level(logging.INFO)
+
+    first = reconcile_spend_leases(store, now=NOW, max_attempts=2)
+
+    row = database.spend_lease_open[identity.lease_id]
+    assert first["open"] == 1
+    assert first["errors"] == 1
+    assert first["dead"] == 0
+    assert row["attempts"] == 1
+    assert row["dead"] is False
+    assert row["last_error"] == "open spend lease has no local row"
+    assert row["next_attempt_at"] == NOW + timedelta(seconds=1)
+
+    database.now = NOW + timedelta(seconds=1)
+    second = reconcile_spend_leases(
+        store, now=NOW + timedelta(seconds=1), max_attempts=2
+    )
+
+    dead = database.spend_lease_open[identity.lease_id]
+    assert second["open"] == 1
+    assert second["errors"] == 1
+    assert second["dead"] == 1
+    assert dead["attempts"] == 2
+    assert dead["dead"] is True
+    assert dead["last_error"] == "open spend lease has no local row"
+    assert dead["next_attempt_at"] is None
+    assert "spend_lease.reconcile_dead_count count=1" in caplog.text
+
+    requeue_at = NOW + timedelta(minutes=1)
+    assert requeue_dead_spend_leases(store, now=requeue_at) == 1
+    requeued = database.spend_lease_open[identity.lease_id]
+    assert requeued["attempts"] == 0
+    assert requeued["dead"] is False
+    assert requeued["last_error"] is None
+    assert requeued["next_attempt_at"] == requeue_at
+
+    database.now = requeue_at
+    swept = reconcile_spend_leases(store, now=requeue_at, max_attempts=2)
+
+    swept_row = database.spend_lease_open[identity.lease_id]
+    assert swept["open"] == 1
+    assert swept["errors"] == 1
+    assert swept["dead"] == 0
+    assert swept_row["attempts"] == 1
+    assert swept_row["dead"] is False
+    assert swept_row["last_error"] == "open spend lease has no local row"
+    assert swept_row["next_attempt_at"] == requeue_at + timedelta(seconds=1)
 
 
 def test_spend_lease_singleton_lock_fences_takeover_and_stale_release() -> None:

--- a/tests/test_spend_lease_reconcile.py
+++ b/tests/test_spend_lease_reconcile.py
@@ -1,0 +1,485 @@
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from tests.fakes.spanner import FakeSpannerDatabase, make_fake_store
+from tests.fakes.spend_lease_bigtable import FakeBigtableTable
+from trusted_router.spend_lease_ledger import BigtableSpendLeaseLedger
+from trusted_router.spend_lease_state import (
+    BindingState,
+    SpendLease,
+    SpendLeaseConflictError,
+    SpendLeaseState,
+)
+from trusted_router.storage_gcp_spend_lease import (
+    CandidateIdentity,
+    insert_candidate,
+    take_recovery_ownership,
+    upgrade_candidate_to_open,
+)
+from trusted_router.storage_gcp_spend_lease_authorize import FENCE_KIND, SPEND_LEASE_KIND
+from trusted_router.storage_gcp_spend_lease_reconcile import (
+    acquire_spend_lease_reconciler_lock,
+    reconcile_spend_leases,
+    release_spend_lease_reconciler_lock,
+    requeue_dead_spend_leases,
+)
+
+NOW = datetime(2026, 9, 2, 12, tzinfo=UTC)
+REGION = "us-central1"
+
+
+def _store() -> tuple[Any, FakeSpannerDatabase, BigtableSpendLeaseLedger]:
+    store, database, _ = make_fake_store(request_record_write_mode="typed")
+    database.now = NOW
+    table = FakeBigtableTable()
+    ledger = BigtableSpendLeaseLedger({REGION: table})
+    store._spend_lease_ledger = ledger
+    return store, database, ledger
+
+
+def _identity(
+    *,
+    lease_id: str = "lease-1",
+    expires_at: datetime | None = None,
+) -> CandidateIdentity:
+    return CandidateIdentity(
+        lease_id=lease_id,
+        gen=3,
+        key_hash="k" * 64,
+        boot_kid="boot-1",
+        cap_micro=10_000,
+        skew_seconds=10,
+        workspace_id="workspace-1",
+        region=REGION,
+        creating_authorization_id="creator-1",
+        idempotency_scope="workspace-1:scope-1",
+        expires_at=expires_at or NOW - timedelta(minutes=2),
+    )
+
+
+def _insert_candidate(store: Any, identity: CandidateIdentity) -> None:
+    store._database.run_in_transaction(
+        lambda transaction: insert_candidate(
+            transaction,
+            store._param_types,
+            identity,
+            created_at=NOW - timedelta(hours=2),
+        )
+    )
+
+
+def _local_candidate(identity: CandidateIdentity, *, state: SpendLeaseState = SpendLeaseState.ACTIVE) -> SpendLease:
+    return SpendLease(
+        lease_id=identity.lease_id,
+        gen=identity.gen,
+        key_hash=identity.key_hash,
+        boot_kid=identity.boot_kid,
+        workspace_id=identity.workspace_id,
+        creating_authorization_id=identity.creating_authorization_id,
+        cap_micro=identity.cap_micro,
+        expires_at=identity.expires_at,
+        skew=timedelta(seconds=identity.skew_seconds),
+        version=0,
+        state=state,
+    )
+
+
+def _allocate(ledger: BigtableSpendLeaseLedger, identity: CandidateIdentity) -> None:
+    ledger.allocate(
+        None,
+        identity.lease_id,
+        region=identity.region,
+        idempotency_scope=identity.idempotency_scope,
+        provisional_authorization_id=identity.creating_authorization_id,
+        request_fingerprint="fingerprint-1",
+        allocated_micro=500,
+        abandon_after=identity.expires_at + timedelta(seconds=identity.skew_seconds),
+        now=identity.expires_at - timedelta(seconds=1),
+    )
+
+
+def _open_candidate(store: Any, identity: CandidateIdentity) -> None:
+    store._database.run_in_transaction(
+        lambda transaction: upgrade_candidate_to_open(
+            transaction,
+            store._param_types,
+            identity.lease_id,
+            identity.creating_authorization_id,
+            identity.expires_at,
+            identity.skew_seconds,
+        )
+    )
+
+
+def _global_body(identity: CandidateIdentity, *, state: str = "DRAINING", slot: bool = False) -> dict[str, Any]:
+    return {
+        "state": state,
+        "lease_id": identity.lease_id,
+        "gen": identity.gen,
+        "key_hash": identity.key_hash,
+        "boot_kid": identity.boot_kid,
+        "workspace_id": identity.workspace_id,
+        "region": identity.region,
+        "cap_micro": identity.cap_micro,
+        "expires_at": identity.expires_at.isoformat(),
+        "skew_seconds": identity.skew_seconds,
+        "credit_shard": 0,
+        "frozen_local_version": None,
+        "holds_predecessor_slot": slot,
+        "closing_at": None,
+        "last_error": None,
+    }
+
+
+def _seed_global(store: Any, identity: CandidateIdentity, *, state: str = "DRAINING", slot: bool = False, count: int = 1) -> None:
+    store._write_entity(SPEND_LEASE_KIND, identity.lease_id, _global_body(identity, state=state, slot=slot))
+    store._write_entity(
+        FENCE_KIND,
+        store._spend_lease_pair_id(identity.key_hash, identity.boot_kid),
+        {
+            "lease_id": "successor" if slot else identity.lease_id,
+            "gen": identity.gen + int(slot),
+            "open_predecessor_count": count,
+            "lease_status": "open",
+        },
+    )
+
+
+def _seed_credit(database: FakeSpannerDatabase, identity: CandidateIdentity) -> None:
+    database.typed.setdefault("tr_credit_balance", {})[(identity.workspace_id, 0)] = {
+        "workspace_id": identity.workspace_id,
+        "shard": 0,
+        "total_credits": 100_000,
+        "total_usage": 0,
+        "reserved": identity.cap_micro,
+    }
+
+
+def test_candidate_recovery_compensates_then_tombstones_then_completes() -> None:
+    store, database, ledger = _store()
+    identity = _identity()
+    _insert_candidate(store, identity)
+    ledger.initialize(_local_candidate(identity), region=REGION)
+    _allocate(ledger, identity)
+
+    result = reconcile_spend_leases(store, now=NOW)
+
+    row = database.spend_lease_open[identity.lease_id]
+    local = ledger.get(identity.lease_id, region=REGION)
+    assert result["recovered"] == 1
+    assert row["phase"] == "done"
+    assert row["next_attempt_at"] is None
+    assert local is not None and local.state == SpendLeaseState.TOMBSTONED
+    assert not local.open_allocations
+
+
+def test_candidate_recovery_resumes_after_crash_immediately_after_ownership() -> None:
+    store, database, ledger = _store()
+    identity = _identity()
+    _insert_candidate(store, identity)
+    ledger.initialize(_local_candidate(identity), region=REGION)
+    _allocate(ledger, identity)
+    assert database.run_in_transaction(
+        lambda transaction: take_recovery_ownership(
+            transaction, store._param_types, identity.lease_id
+        )
+    ) == 1
+
+    result = reconcile_spend_leases(store, now=NOW)
+
+    assert result["recovered"] == 1
+    assert database.spend_lease_open[identity.lease_id]["phase"] == "done"
+
+
+def test_candidate_recovery_rereads_and_compensates_a_4b_cas_loser(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, database, ledger = _store()
+    identity = _identity()
+    _insert_candidate(store, identity)
+    calls = 0
+    real_tombstone = BigtableSpendLeaseLedger.tombstone_unminted
+
+    def lose_once(self: BigtableSpendLeaseLedger, lease_id: str, *, region: str, proof: Any) -> Any:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            _allocate(self, identity)
+            raise SpendLeaseConflictError("late producer won the first CAS")
+        return real_tombstone(self, lease_id, region=region, proof=proof)
+
+    monkeypatch.setattr(BigtableSpendLeaseLedger, "tombstone_unminted", lose_once)
+
+    result = reconcile_spend_leases(store, now=NOW)
+
+    local = ledger.get(identity.lease_id, region=REGION)
+    assert calls == 2
+    assert result["recovered"] == 1
+    assert local is not None and local.state == SpendLeaseState.TOMBSTONED
+    assert not local.open_allocations
+    assert database.spend_lease_open[identity.lease_id]["phase"] == "done"
+
+
+def test_open_sweep_binds_as_last_resort_without_incrementing_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, database, ledger = _store()
+    identity = _identity(expires_at=NOW + timedelta(minutes=5))
+    _insert_candidate(store, identity)
+    _open_candidate(store, identity)
+    database.spend_lease_open[identity.lease_id]["next_attempt_at"] = NOW
+    ledger.initialize(_local_candidate(identity), region=REGION)
+    _allocate(ledger, identity)
+    _seed_global(store, identity, state="ACTIVE")
+
+    class Authorization:
+        id = identity.creating_authorization_id
+        spend_lease_id = identity.lease_id
+        spend_lease_gen = identity.gen
+        spend_lease_allocated_micro = 500
+        finalization_outcome = None
+        finalized_cost_microdollars = None
+        settled = False
+
+    monkeypatch.setattr(type(store), "get_gateway_authorization", lambda *_: Authorization())
+
+    result = reconcile_spend_leases(store, now=NOW)
+
+    local = ledger.get(identity.lease_id, region=REGION)
+    row = database.spend_lease_open[identity.lease_id]
+    assert local is not None
+    assert local.allocations[0].binding_state == BindingState.COMMITTED
+    assert result["deferred"] == 1
+    assert row["attempts"] == 0
+
+
+@pytest.mark.parametrize(
+    ("slot", "global_state", "fence_count"),
+    [
+        (False, "ACTIVE", 1),
+        (True, "DRAINING", 0),
+        (True, "ACTIVE", 1),
+    ],
+    ids=["closing-guard", "fence-count-guard", "slot-owner-guard"],
+)
+def test_close_step_two_lost_guard_rolls_back_credit_release(
+    slot: bool,
+    global_state: str,
+    fence_count: int,
+) -> None:
+    store, database, ledger = _store()
+    identity = _identity()
+    _insert_candidate(store, identity)
+    _open_candidate(store, identity)
+    ledger.initialize(
+        _local_candidate(identity, state=SpendLeaseState.DRAINING), region=REGION
+    )
+    _seed_global(store, identity, state=global_state, slot=slot, count=fence_count)
+    _seed_credit(database, identity)
+    before = dict(database.typed["tr_credit_balance"][(identity.workspace_id, 0)])
+
+    result = reconcile_spend_leases(store, now=NOW, max_attempts=99)
+
+    assert result["errors"] == 1
+    assert database.typed["tr_credit_balance"][(identity.workspace_id, 0)] == before
+    assert database.spend_lease_open[identity.lease_id]["global_closed_at"] is None
+
+
+@pytest.mark.parametrize("slot", [False, True], ids=["active-owner", "predecessor-owner"])
+def test_close_step_two_and_three_close_global_then_local(slot: bool) -> None:
+    store, database, ledger = _store()
+    identity = _identity()
+    _insert_candidate(store, identity)
+    _open_candidate(store, identity)
+    ledger.initialize(
+        _local_candidate(identity, state=SpendLeaseState.DRAINING), region=REGION
+    )
+    _seed_global(store, identity, state="DRAINING", slot=slot, count=1)
+    _seed_credit(database, identity)
+
+    result = reconcile_spend_leases(store, now=NOW)
+
+    credit = database.typed["tr_credit_balance"][(identity.workspace_id, 0)]
+    global_body = store._read_entity(SPEND_LEASE_KIND, identity.lease_id, dict)
+    local = ledger.get(identity.lease_id, region=REGION)
+    open_row = database.spend_lease_open[identity.lease_id]
+    assert result["closed"] == 1
+    assert credit["reserved"] == 0
+    assert global_body["state"] == "CLOSED"
+    assert global_body["frozen_local_version"] == 0
+    assert local is not None and local.state == SpendLeaseState.CLOSED
+    assert open_row["global_closed_at"] == NOW
+    assert open_row["local_closed_at"] == NOW
+    if slot:
+        fence = store._read_entity(
+            FENCE_KIND,
+            store._spend_lease_pair_id(identity.key_hash, identity.boot_kid),
+            dict,
+        )
+        assert fence["open_predecessor_count"] == 0
+
+
+def test_close_eligible_since_is_monotonic_and_contrary_state_is_dead(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, database, ledger = _store()
+    identity = _identity()
+    _insert_candidate(store, identity)
+    _open_candidate(store, identity)
+    ledger.initialize(
+        _local_candidate(identity, state=SpendLeaseState.DRAINING), region=REGION
+    )
+    _seed_global(store, identity)
+    _seed_credit(database, identity)
+    database.spend_lease_open[identity.lease_id]["close_eligible_since"] = NOW - timedelta(hours=1)
+
+    # Inject an impossible ACTIVE observation without changing the durable
+    # timestamp; this is the contradiction decision 38 requires us to detect.
+    impossible = _local_candidate(identity, state=SpendLeaseState.ACTIVE)
+    monkeypatch.setattr(BigtableSpendLeaseLedger, "get", lambda *_args, **_kwargs: impossible)
+    caplog.set_level(logging.ERROR)
+
+    result = reconcile_spend_leases(store, now=NOW)
+
+    row = database.spend_lease_open[identity.lease_id]
+    assert result["dead"] == 1
+    assert row["close_eligible_since"] == NOW - timedelta(hours=1)
+    assert row["dead"] is True
+    assert "spend_lease.reconcile_contradiction" in caplog.text
+
+
+def test_lag_logs_eligibility_and_expired_open_age_including_dead(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, database, _ledger = _store()
+    identity = _identity()
+    _insert_candidate(store, identity)
+    _open_candidate(store, identity)
+    row = database.spend_lease_open[identity.lease_id]
+    row["next_attempt_at"] = None
+    row["created_at"] = NOW - timedelta(hours=30)
+    row["close_eligible_since"] = NOW - timedelta(hours=25)
+    row["dead"] = True
+    caplog.set_level(logging.INFO)
+
+    result = reconcile_spend_leases(store, now=NOW)
+
+    assert result["eligibility_lag_seconds"] == 25 * 3600
+    assert result["open_age_lag_seconds"] == 30 * 3600
+    assert "spend_lease.reconcile_lag_exceeded" in caplog.text
+    assert "spend_lease.reconcile_dead_count" in caplog.text
+
+
+def test_dead_row_requeue_resets_attempts_and_due_time() -> None:
+    store, database, _ledger = _store()
+    identity = _identity()
+    _insert_candidate(store, identity)
+    _open_candidate(store, identity)
+    row = database.spend_lease_open[identity.lease_id]
+    row.update({"dead": True, "attempts": 12, "last_error": "broken", "next_attempt_at": None})
+
+    count = requeue_dead_spend_leases(store, now=NOW)
+
+    assert count == 1
+    assert row is not database.spend_lease_open[identity.lease_id]
+    requeued = database.spend_lease_open[identity.lease_id]
+    assert requeued["dead"] is False
+    assert requeued["attempts"] == 0
+    assert requeued["last_error"] is None
+    assert requeued["next_attempt_at"] == NOW
+
+
+def test_spend_lease_singleton_lock_fences_takeover_and_stale_release() -> None:
+    store, _database, _ledger = _store()
+    first = acquire_spend_lease_reconciler_lock(
+        store, owner="slrec-first", ttl_seconds=30, now=NOW
+    )
+    busy = acquire_spend_lease_reconciler_lock(
+        store, owner="slrec-second", ttl_seconds=30, now=NOW + timedelta(seconds=1)
+    )
+    takeover = acquire_spend_lease_reconciler_lock(
+        store, owner="slrec-second", ttl_seconds=30, now=NOW + timedelta(seconds=31)
+    )
+
+    assert first is not None and first.fencing_token == 1
+    assert busy is None
+    assert takeover is not None and takeover.fencing_token == 2
+    assert takeover.previous_owner == "slrec-first"
+    assert not release_spend_lease_reconciler_lock(
+        store,
+        owner="slrec-first",
+        fencing_token=first.fencing_token,
+        now=NOW + timedelta(seconds=32),
+    )
+    assert release_spend_lease_reconciler_lock(
+        store,
+        owner="slrec-second",
+        fencing_token=takeover.fencing_token,
+        now=NOW + timedelta(seconds=32),
+    )
+
+
+def test_done_candidate_work_row_is_deleted_after_thirty_days_only() -> None:
+    store, database, ledger = _store()
+    identity = _identity()
+    _insert_candidate(store, identity)
+    ledger.initialize(_local_candidate(identity), region=REGION)
+    reconcile_spend_leases(store, now=NOW)
+    assert identity.lease_id in database.spend_lease_open
+
+    result = reconcile_spend_leases(store, now=NOW + timedelta(days=31))
+
+    assert result["deleted"] == 1
+    assert identity.lease_id not in database.spend_lease_open
+    # Decision 33 keeps never-committed candidate history in Bigtable.
+    assert ledger.get(identity.lease_id, region=REGION) is not None
+
+
+def test_closed_local_row_deletes_only_after_fence_no_longer_names_lease() -> None:
+    store, database, ledger = _store()
+    identity = _identity()
+    _insert_candidate(store, identity)
+    _open_candidate(store, identity)
+    closed = _local_candidate(identity, state=SpendLeaseState.CLOSED)
+    ledger.initialize(closed, region=REGION)
+    _seed_global(store, identity, state="CLOSED")
+    row = database.spend_lease_open[identity.lease_id]
+    row.update(
+        {
+            "close_eligible_since": NOW - timedelta(days=31),
+            "global_closed_at": NOW - timedelta(days=31),
+            "local_closed_at": NOW - timedelta(days=31),
+            "next_attempt_at": NOW,
+        }
+    )
+    global_body = _global_body(identity, state="CLOSED")
+    global_body["frozen_local_version"] = 0
+    store._write_entity(SPEND_LEASE_KIND, identity.lease_id, global_body)
+
+    kept = reconcile_spend_leases(store, now=NOW)
+
+    assert kept["deferred"] == 1
+    assert identity.lease_id in database.spend_lease_open
+    store._write_entity(
+        FENCE_KIND,
+        store._spend_lease_pair_id(identity.key_hash, identity.boot_kid),
+        {
+            "lease_id": "successor",
+            "gen": identity.gen + 1,
+            "open_predecessor_count": 0,
+            "lease_status": "open",
+        },
+    )
+    database.spend_lease_open[identity.lease_id]["next_attempt_at"] = NOW
+
+    deleted = reconcile_spend_leases(store, now=NOW)
+
+    assert deleted["deleted"] == 1
+    assert identity.lease_id not in database.spend_lease_open
+    assert ledger.get(identity.lease_id, region=REGION) is None

--- a/tests/test_spend_lease_reconcile_cli.py
+++ b/tests/test_spend_lease_reconcile_cli.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import trusted_router.spend_lease_reconcile_cli as cli
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class _Store:
+    def __init__(self) -> None:
+        self.events: list[str] = []
+
+    def verify_spend_lease_ledger(self) -> tuple[str, ...]:
+        self.events.append("health")
+        return ("us-central1",)
+
+    def acquire_spend_lease_reconciler_lock(self, **_kwargs: Any) -> Any:
+        self.events.append("acquire")
+        return SimpleNamespace(fencing_token=7)
+
+    def release_spend_lease_reconciler_lock(self, **_kwargs: Any) -> bool:
+        self.events.append("release")
+        return True
+
+    def reconcile_spend_leases(self, **_kwargs: Any) -> dict[str, int]:
+        self.events.append("reconcile")
+        return {
+            "candidates": 0,
+            "open": 0,
+            "recovered": 0,
+            "bound": 0,
+            "closed": 0,
+            "deferred": 0,
+            "errors": 0,
+            "dead": 0,
+        }
+
+    def requeue_dead_spend_leases(self, **_kwargs: Any) -> int:
+        self.events.append("requeue")
+        return 2
+
+
+def _settings() -> SimpleNamespace:
+    return SimpleNamespace(
+        spend_lease_reconciler_worker=True,
+        spend_lease_reconcile_limit=25,
+        spend_lease_reconcile_max_attempts=12,
+    )
+
+
+def _wire(monkeypatch: pytest.MonkeyPatch, store: _Store) -> list[str]:
+    heartbeats: list[str] = []
+    monkeypatch.setattr(cli, "get_settings", _settings)
+    monkeypatch.setattr(cli, "init_sentry", lambda _settings: None)
+    monkeypatch.setattr(cli, "create_store", lambda _settings: store)
+    monkeypatch.setattr(cli, "configure_store", lambda _store: None)
+    monkeypatch.setattr(
+        cli,
+        "record_heartbeat",
+        lambda target, *, settings: heartbeats.append(target),
+    )
+    return heartbeats
+
+
+def test_clean_empty_pass_health_checks_before_work_and_heartbeats(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _Store()
+    heartbeats = _wire(monkeypatch, store)
+
+    assert cli.main(["reconcile"]) == 0
+
+    assert store.events == ["acquire", "health", "reconcile", "release"]
+    assert heartbeats == ["job:spend-lease-reconcile"]
+
+
+def test_failed_ledger_health_gate_does_no_work_or_heartbeat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _Store()
+    heartbeats = _wire(monkeypatch, store)
+    monkeypatch.setattr(store, "verify_spend_lease_ledger", lambda: ())
+
+    assert cli.main(["reconcile"]) == 1
+
+    assert store.events == ["acquire", "release"]
+    assert heartbeats == []
+
+
+def test_operator_requeue_runs_after_health_gate_without_worker_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _Store()
+    _wire(monkeypatch, store)
+
+    assert cli.main(["requeue-dead", "lease-a", "lease-b"]) == 0
+
+    assert store.events == ["health", "requeue"]
+
+
+def test_spend_lease_reconciler_deploy_and_workflow_wiring() -> None:
+    script = (ROOT / "scripts/deploy/spend_lease_reconciler.sh").read_text()
+    orchestrator = (ROOT / "scripts/deploy-gcp.sh").read_text()
+    workflow = (ROOT / ".github/workflows/deploy.yml").read_text()
+
+    assert "trusted-router-spend-lease-reconciler" in script
+    assert "--task-timeout 50s" in script
+    assert "--max-retries 0" in script
+    assert "--max-retry-attempts=0" in script
+    assert '* * * * *' in script
+    assert 'scheduler_state" = "PAUSED' in script
+    assert "TR_SPEND_LEASE_BINDING_ENABLED" not in script
+    assert "spend_lease_reconcile_cli,reconcile" in script
+    assert "bash \"${SCRIPT_DIR}/deploy/spend_lease_reconciler.sh\"" in orchestrator
+    assert "bash scripts/deploy/spend_lease_reconciler.sh" in workflow


### PR DESCRIPTION
Fourth unit-2 PR of the spend-lease program (design record v49): the reconciler, a Cloud Run Job cloned from the regional quota reconciler. With binding off it health-checks, logs zero lag, heartbeats (`job:spend-lease-reconcile`, added to the fleet targets) and exits.

**The pass** (decisions 35, 36, 46, 43, 38): ordered due scans under FORCE_INDEX with per-row attempts, backoff and dead-after-max in the settle-outbox shape ("not yet closeable" advances without counting an attempt); candidate recovery as 4a ownership in its own transaction, 4b strong read of the committed proof, compensate the creating allocation and tombstone the local row through the ledger with CAS-loss retry, 4c completion; open-row sweep binding creator allocations as last resort, mirroring, abandoning and quarantining, draining after expiry plus skew; close step 2 as one transaction (credit release asserted to one row, the two-branch guarded lease/fence close, abort on any lost guard, `frozen_local_version` stored) then the local close against it; retention at `local_closed_at` + 30 days only after a strong read shows the fence no longer names the lease, and done candidate rows at `created_at` + 30 days; `close_eligible_since` monotonic with contradictions marked dead and alerted; both lag values logged; dead-row, quarantine and lag-exceeded alert policies; an operator requeue subcommand; a runbook section.

The close path calls the fence and global-record statements the authorize PR owns (no statement duplicated); `_unmark_incumbent` gains a frozen-only guard and `_decrement_fence`/`_mark_closing` are added beside them.

**Review:** isolated snapshot; ruff; mypy --strict on the three new modules; 22 new tests plus every spend-lease suite and the existing authorize suites with the flag off; full suite 8,078 passed (two known jq-missing harness tests fail locally only); eleven mutations each red: 4a ownership skipped, tombstone skipped, credit-release abort suppressed, fence-decrement abort suppressed, not-yet-closeable counting an attempt, contradiction check removed, frozen-version re-entry ignored, dead threshold disabled, retention ignoring a fence that still names the lease, heartbeat name, lag limit. Three of those were coverage gaps found in review and closed by the second commit.

Lands after #1030 (merged). No flag flip.

Written by codex; reviewed by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)