### PR TITLE
spend-lease reconciler: treat an unprovisioned ledger as a clean idle pass

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1384,6 +1384,13 @@ spend-lease binding is off: an empty pass verifies the regional Bigtable
 profiles, records both lag values as zero, publishes
 `job:spend-lease-reconcile`, and exits.
 
+Until the spend-lease Bigtable table and fixed regional app profiles are
+provisioned, the job reports `spend_lease.reconciler_ledger_unprovisioned` as
+a clean idle pass and records its heartbeat; this means the job is alive while
+binding remains off, not that the ledger health proof was weakened or skipped.
+Once provisioning lands, the next scheduled execution automatically performs
+the conditional-write and strong-read proof through every configured profile.
+
 For `spend_lease.reconcile_lag_exceeded`, compare
 `eligibility_lag_seconds` with `open_age_lag_seconds`. Eligibility lag measures
 rows that have already produced the frozen/zero-open close proof. Open-age lag

--- a/src/trusted_router/spend_lease_ledger.py
+++ b/src/trusted_router/spend_lease_ledger.py
@@ -17,6 +17,8 @@ from datetime import UTC, datetime, timedelta
 from time import sleep
 from typing import Any, Protocol, TypeVar, cast
 
+from google.api_core import exceptions as google_exceptions
+
 from trusted_router.spend_lease_state import (
     AllocateResult,
     AllocationState,
@@ -58,6 +60,19 @@ class SpendLeaseLedgerError(RuntimeError):
     """The durable spend-lease ledger could not safely complete an operation."""
 
 
+class SpendLeaseLedgerUnprovisioned(SpendLeaseLedgerError):
+    """The configured Bigtable table or fixed app profile does not exist."""
+
+    def __init__(self, *, table_id: str, profile: str, region: str) -> None:
+        self.table_id = table_id
+        self.profile = profile
+        self.region = region
+        super().__init__(
+            "spend lease ledger is unprovisioned "
+            f"(table={table_id}, profile={profile}, region={region})"
+        )
+
+
 class SpendLeaseNotFound(SpendLeaseLedgerError):
     """The requested regional spend lease does not exist."""
 
@@ -68,6 +83,30 @@ class SpendLeaseCasExhausted(SpendLeaseLedgerError):
 
 class SpendLeaseVersionError(SpendLeaseLedgerError):
     """A pure transition attempted to reuse or skip a durable CAS version."""
+
+
+def _is_unprovisioned_bigtable_error(exc: Exception, *, profile: str) -> bool:
+    if isinstance(exc, google_exceptions.NotFound):
+        return True
+    if not isinstance(
+        exc,
+        (google_exceptions.FailedPrecondition, google_exceptions.InvalidArgument),
+    ):
+        return False
+
+    message = str(exc).casefold().replace("_", " ").replace("-", " ")
+    normalized_profile = profile.casefold().replace("_", " ").replace("-", " ")
+    identifies_profile = "app profile" in message or (
+        profile != "<unknown>" and normalized_profile in message
+    )
+    missing_profile = any(
+        marker in message
+        for marker in ("not found", "does not exist", "unknown", "missing")
+    )
+    invalid_profile = isinstance(exc, google_exceptions.InvalidArgument) and (
+        "invalid" in message
+    )
+    return identifies_profile and (missing_profile or invalid_profile)
 
 
 class SpendLeaseLedger(Protocol):
@@ -262,6 +301,8 @@ class BigtableSpendLeaseLedger:
 
         for region in sorted(self._tables):
             table = self._tables[region]
+            table_id = str(getattr(table, "table_id", "<unknown>"))
+            profile = str(getattr(table, "_app_profile_id", "<unknown>"))
             row_key = f"health#spend-lease#{region}".encode()
             version = uuid.uuid4().hex.encode("ascii")
             row = table.row(row_key, filter_=self._version_exists_filter())
@@ -272,9 +313,13 @@ class BigtableSpendLeaseLedger:
                 row.commit()
                 durable = table.read_row(row_key, filter_=self._state_filter())
             except Exception as exc:  # pragma: no cover - remote transport
-                raise SpendLeaseLedgerError(
-                    "spend lease ledger transactional health check failed"
-                ) from exc
+                if _is_unprovisioned_bigtable_error(exc, profile=profile):
+                    raise SpendLeaseLedgerUnprovisioned(
+                        table_id=table_id,
+                        profile=profile,
+                        region=region,
+                    ) from exc
+                raise
             if durable is None:
                 raise SpendLeaseLedgerError(
                     "spend lease ledger health check write was not durable"

--- a/src/trusted_router/spend_lease_reconcile_cli.py
+++ b/src/trusted_router/spend_lease_reconcile_cli.py
@@ -11,6 +11,7 @@ from typing import Any, cast
 
 from trusted_router.config import get_settings
 from trusted_router.sentry_config import init_sentry
+from trusted_router.spend_lease_ledger import SpendLeaseLedgerUnprovisioned
 from trusted_router.storage import configure_store, create_store
 from trusted_router.synthetic.fleet import record_heartbeat
 
@@ -49,6 +50,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     if command == "requeue-dead":
         try:
             regions = verify()
+        except SpendLeaseLedgerUnprovisioned as exc:
+            logger.error(
+                "spend_lease.requeue_ledger_unprovisioned "
+                "table=%s profile=%s region=%s nothing_to_requeue=true",
+                exc.table_id,
+                exc.profile,
+                exc.region,
+            )
+            return 1
         except Exception:
             logger.exception("spend_lease.reconciler_health_check_failed")
             return 1
@@ -99,6 +109,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         try:
             regions = verify()
+        except SpendLeaseLedgerUnprovisioned as exc:
+            logger.info(
+                "spend_lease.reconciler_ledger_unprovisioned "
+                "table=%s profile=%s region=%s",
+                exc.table_id,
+                exc.profile,
+                exc.region,
+            )
+            exit_code = 0
         except Exception:
             logger.exception("spend_lease.reconciler_health_check_failed")
         else:

--- a/tests/fakes/spend_lease_bigtable.py
+++ b/tests/fakes/spend_lease_bigtable.py
@@ -38,6 +38,8 @@ class FakeConditionalRow:
 
     def commit(self) -> bool:
         self.table.commit_attempts += 1
+        if self.table.commit_error is not None:
+            raise self.table.commit_error
         current = self.table.rows.get(self.row_key)
         regex_filter = next(
             (
@@ -83,9 +85,17 @@ class FakeDirectRow:
 
 
 class FakeBigtableTable:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        table_id: str = "trustedrouter-spend-lease",
+        app_profile_id: str = "tr-spend-us-central1",
+    ) -> None:
+        self.table_id = table_id
+        self._app_profile_id = app_profile_id
         self.rows: dict[bytes, dict[bytes, bytes]] = {}
         self.commit_attempts = 0
+        self.commit_error: Exception | None = None
         self.force_cas_misses = False
         self.raise_after_next_applied_commit = False
 

--- a/tests/test_spend_lease_ledger.py
+++ b/tests/test_spend_lease_ledger.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
+from google.api_core import exceptions as google_exceptions
 
 import trusted_router.spend_lease_ledger as ledger_module
 from tests.fakes.spend_lease_bigtable import FakeBigtableTable as _FakeBigtableTable
@@ -16,6 +17,7 @@ from trusted_router.spend_lease_ledger import (
     BigtableSpendLeaseLedger,
     SpendLeaseCasExhausted,
     SpendLeaseLedgerError,
+    SpendLeaseLedgerUnprovisioned,
     SpendLeaseVersionError,
 )
 from trusted_router.spend_lease_state import (
@@ -85,6 +87,104 @@ def _allocate(ledger: BigtableSpendLeaseLedger) -> Created:
     )
     assert isinstance(result, Created)
     return result
+
+
+def test_health_check_classifies_missing_table_as_unprovisioned() -> None:
+    table = _FakeBigtableTable()
+    missing = google_exceptions.NotFound(
+        "Table trustedrouter-spend-lease was not found"
+    )
+    table.commit_error = missing
+    ledger = BigtableSpendLeaseLedger({REGION: table})
+
+    with pytest.raises(SpendLeaseLedgerUnprovisioned) as raised:
+        ledger.health_check()
+
+    assert raised.value.table_id == "trustedrouter-spend-lease"
+    assert raised.value.profile == "tr-spend-us-central1"
+    assert raised.value.region == REGION
+    assert raised.value.__cause__ is missing
+
+
+@pytest.mark.parametrize(
+    "missing",
+    [
+        google_exceptions.FailedPrecondition(
+            "App profile tr-spend-us-central1 does not exist"
+        ),
+        google_exceptions.InvalidArgument(
+            "Invalid app_profile_id: tr-spend-us-central1"
+        ),
+    ],
+)
+def test_health_check_classifies_missing_profile_as_unprovisioned(
+    missing: Exception,
+) -> None:
+    table = _FakeBigtableTable()
+    table.commit_error = missing
+    ledger = BigtableSpendLeaseLedger({REGION: table})
+
+    with pytest.raises(SpendLeaseLedgerUnprovisioned) as raised:
+        ledger.health_check()
+
+    assert raised.value.table_id == "trustedrouter-spend-lease"
+    assert raised.value.profile == "tr-spend-us-central1"
+    assert raised.value.region == REGION
+    assert raised.value.__cause__ is missing
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        google_exceptions.PermissionDenied("missing permission"),
+        google_exceptions.DeadlineExceeded("request timed out"),
+    ],
+)
+def test_health_check_propagates_non_provisioning_failures_unchanged(
+    failure: Exception,
+) -> None:
+    table = _FakeBigtableTable()
+    table.commit_error = failure
+    ledger = BigtableSpendLeaseLedger({REGION: table})
+
+    with pytest.raises(type(failure)) as raised:
+        ledger.health_check()
+
+    assert raised.value is failure
+
+
+def test_health_check_propagates_unrelated_precondition_failure_unchanged() -> None:
+    table = _FakeBigtableTable()
+    failure = google_exceptions.FailedPrecondition(
+        "single-row transactions are disabled for this routing policy"
+    )
+    table.commit_error = failure
+    ledger = BigtableSpendLeaseLedger({REGION: table})
+
+    with pytest.raises(google_exceptions.FailedPrecondition) as raised:
+        ledger.health_check()
+
+    assert raised.value is failure
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        google_exceptions.FailedPrecondition("column family lease not found"),
+        google_exceptions.InvalidArgument("instance missing"),
+    ],
+)
+def test_health_check_propagates_unrelated_missing_resource_unchanged(
+    failure: Exception,
+) -> None:
+    table = _FakeBigtableTable()
+    table.commit_error = failure
+    ledger = BigtableSpendLeaseLedger({REGION: table})
+
+    with pytest.raises(type(failure)) as raised:
+        ledger.health_check()
+
+    assert raised.value is failure
 
 
 def test_allocate_created_writes_decision_33_row_at_version_one() -> None:

--- a/tests/test_spend_lease_reconcile_cli.py
+++ b/tests/test_spend_lease_reconcile_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -7,6 +8,7 @@ from typing import Any
 import pytest
 
 import trusted_router.spend_lease_reconcile_cli as cli
+from trusted_router.spend_lease_ledger import SpendLeaseLedgerUnprovisioned
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -14,9 +16,12 @@ ROOT = Path(__file__).resolve().parents[1]
 class _Store:
     def __init__(self) -> None:
         self.events: list[str] = []
+        self.health_error: Exception | None = None
 
     def verify_spend_lease_ledger(self) -> tuple[str, ...]:
         self.events.append("health")
+        if self.health_error is not None:
+            raise self.health_error
         return ("us-central1",)
 
     def acquire_spend_lease_reconciler_lock(self, **_kwargs: Any) -> Any:
@@ -92,6 +97,43 @@ def test_failed_ledger_health_gate_does_no_work_or_heartbeat(
     assert heartbeats == []
 
 
+def test_unprovisioned_ledger_is_clean_idle_pass_with_heartbeat(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = _Store()
+    store.health_error = SpendLeaseLedgerUnprovisioned(
+        table_id="trustedrouter-spend-lease",
+        profile="tr-spend-us-central1",
+        region="us-central1",
+    )
+    heartbeats = _wire(monkeypatch, store)
+
+    with caplog.at_level(logging.INFO, logger=cli.__name__):
+        assert cli.main(["reconcile"]) == 0
+
+    assert store.events == ["acquire", "health", "release"]
+    assert heartbeats == ["job:spend-lease-reconcile"]
+    assert caplog.messages.count(
+        "spend_lease.reconciler_ledger_unprovisioned "
+        "table=trustedrouter-spend-lease "
+        "profile=tr-spend-us-central1 region=us-central1"
+    ) == 1
+
+
+def test_generic_health_failure_returns_one_without_heartbeat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _Store()
+    store.health_error = RuntimeError("ledger transport failed")
+    heartbeats = _wire(monkeypatch, store)
+
+    assert cli.main(["reconcile"]) == 1
+
+    assert store.events == ["acquire", "health", "release"]
+    assert heartbeats == []
+
+
 def test_operator_requeue_runs_after_health_gate_without_worker_lock(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -101,6 +143,30 @@ def test_operator_requeue_runs_after_health_gate_without_worker_lock(
     assert cli.main(["requeue-dead", "lease-a", "lease-b"]) == 0
 
     assert store.events == ["health", "requeue"]
+
+
+def test_operator_requeue_rejects_unprovisioned_ledger(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = _Store()
+    store.health_error = SpendLeaseLedgerUnprovisioned(
+        table_id="trustedrouter-spend-lease",
+        profile="tr-spend-us-central1",
+        region="us-central1",
+    )
+    heartbeats = _wire(monkeypatch, store)
+
+    with caplog.at_level(logging.ERROR, logger=cli.__name__):
+        assert cli.main(["requeue-dead"]) == 1
+
+    assert store.events == ["health"]
+    assert heartbeats == []
+    assert (
+        "spend_lease.requeue_ledger_unprovisioned "
+        "table=trustedrouter-spend-lease profile=tr-spend-us-central1 "
+        "region=us-central1 nothing_to_requeue=true"
+    ) in caplog.messages
 
 
 def test_spend_lease_reconciler_deploy_and_workflow_wiring() -> None:


### PR DESCRIPTION
Deploy run 33616200985 failed at `rollout-secondaries`: the spend-lease reconciler job's first execution health-checked the Bigtable ledger by writing through the app profile and table that provisioning creates, and provisioning is unwired from deploy (#1026) until `tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com` gains `bigtable.tables.create`. The health check raised, the job exited 1, `gcloud run jobs execute --wait` failed, and every deploy fails there until this lands; Cloud Scheduler executes the failing job every minute. All regions were already serving the new revision (the ramp runs before the reconciler status check); the T1 companion deploy was skipped and catches up on this PR's deploy.

**Fix, without weakening the health check:** `BigtableSpendLeaseLedger.health_check` raises a typed `SpendLeaseLedgerUnprovisioned` (table, profile, region) when Bigtable reports the table missing (`NotFound`) or the fixed app profile missing or invalid (`FailedPrecondition` / `InvalidArgument` naming the profile with a missing or invalid marker); every other exception propagates unchanged. `reconcile` logs `spend_lease.reconciler_ledger_unprovisioned` at info, releases its lock, records the normal heartbeat (alive and correctly idle: binding is off and provisioning is the tracked blocker) and exits 0; any other health-check failure still exits 1 without a heartbeat; `requeue-dead` refuses an unprovisioned ledger. Runbook section added.

**Review:** isolated snapshot; ruff; mypy --strict on the ledger, the CLI and the fake; 43 ledger and CLI tests plus the reconciler, authorize and data-access suites; six mutations each red (classify everything as unprovisioned, bypass the profile identification, return before the heartbeat, accept unprovisioned on requeue, initialise the exit code to 0, the generic-failure path). One of those was a coverage gap found in review and closed before this PR.

Written by codex; reviewed by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)