### PR TITLE
synthetic: bucket rollup latency histograms (bounded keys, no migration)

### DIFF
--- a/clickhouse/backfill_operational_analytics.py
+++ b/clickhouse/backfill_operational_analytics.py
@@ -26,6 +26,16 @@ from trusted_router.storage_gcp_operational_analytics_outbox import (
     synthetic_payload,
 )
 from trusted_router.storage_models import Generation, SyntheticProbeSample, SyntheticRollup
+from trusted_router.synthetic.rollups import compact_histogram
+
+ROLLUP_HISTOGRAM_FIELDS = (
+    "latency_histogram",
+    "ttfb_histogram",
+    "dns_histogram",
+    "tcp_connect_histogram",
+    "tls_handshake_histogram",
+    "gateway_processing_histogram",
+)
 
 PROJECT = "quill-cloud-proxy"
 INSTANCE = "trusted-router-logs"
@@ -199,6 +209,12 @@ def insert_rollups(clickhouse: ClickHouse, rollups: list[SyntheticRollup]) -> No
         json.dumps(
             {
                 **dataclasses.asdict(rollup),
+                # Legacy Bigtable bodies keep one key per millisecond until
+                # their next write; never carry that shape into ClickHouse.
+                **{
+                    field: compact_histogram(getattr(rollup, field))
+                    for field in ROLLUP_HISTOGRAM_FIELDS
+                },
                 "target_region": rollup.target_region or "",
                 "ingest_version": version,
             },
@@ -238,32 +254,22 @@ def main() -> int:
     if args.recent_limit is not None and args.recent_limit < 1:
         raise SystemExit("--recent-limit must be positive")
 
-    table = (
-        bigtable.Client(project=PROJECT, admin=False)
-        .instance(INSTANCE)
-        .table(TABLE)
-    )
+    table = bigtable.Client(project=PROJECT, admin=False).instance(INSTANCE).table(TABLE)
     password = os.environ.get("CH_PASSWORD", "")
     if args.apply and not password:
         raise SystemExit("CH_PASSWORD is required with --apply")
 
     clickhouse = ClickHouse(password=password) if args.apply else None
     writer = (
-        ClickHouseOperationalWriter(password=password, database=DATABASE)
-        if args.apply
-        else None
+        ClickHouseOperationalWriter(password=password, database=DATABASE) if args.apply else None
     )
     counts = {"activity": 0, "synthetic": 0, "rollup": 0}
 
     sources = []
     if not args.skip_activity:
-        sources.append(
-            ("activity", iter_activity_events(table, limit=args.recent_limit))
-        )
+        sources.append(("activity", iter_activity_events(table, limit=args.recent_limit)))
     if not args.skip_synthetic:
-        sources.append(
-            ("synthetic", iter_synthetic_events(table, limit=args.recent_limit))
-        )
+        sources.append(("synthetic", iter_synthetic_events(table, limit=args.recent_limit)))
     for kind, events in sources:
         for batch in _batches(events, args.batch):
             counts[kind] += len(batch)

--- a/clickhouse/backfill_operational_analytics.py
+++ b/clickhouse/backfill_operational_analytics.py
@@ -245,22 +245,32 @@ def main() -> int:
     if args.recent_limit is not None and args.recent_limit < 1:
         raise SystemExit("--recent-limit must be positive")
 
-    table = bigtable.Client(project=PROJECT, admin=False).instance(INSTANCE).table(TABLE)
+    table = (
+        bigtable.Client(project=PROJECT, admin=False)
+        .instance(INSTANCE)
+        .table(TABLE)
+    )
     password = os.environ.get("CH_PASSWORD", "")
     if args.apply and not password:
         raise SystemExit("CH_PASSWORD is required with --apply")
 
     clickhouse = ClickHouse(password=password) if args.apply else None
     writer = (
-        ClickHouseOperationalWriter(password=password, database=DATABASE) if args.apply else None
+        ClickHouseOperationalWriter(password=password, database=DATABASE)
+        if args.apply
+        else None
     )
     counts = {"activity": 0, "synthetic": 0, "rollup": 0}
 
     sources = []
     if not args.skip_activity:
-        sources.append(("activity", iter_activity_events(table, limit=args.recent_limit)))
+        sources.append(
+            ("activity", iter_activity_events(table, limit=args.recent_limit))
+        )
     if not args.skip_synthetic:
-        sources.append(("synthetic", iter_synthetic_events(table, limit=args.recent_limit)))
+        sources.append(
+            ("synthetic", iter_synthetic_events(table, limit=args.recent_limit))
+        )
     for kind, events in sources:
         for batch in _batches(events, args.batch):
             counts[kind] += len(batch)

--- a/clickhouse/backfill_operational_analytics.py
+++ b/clickhouse/backfill_operational_analytics.py
@@ -26,16 +26,7 @@ from trusted_router.storage_gcp_operational_analytics_outbox import (
     synthetic_payload,
 )
 from trusted_router.storage_models import Generation, SyntheticProbeSample, SyntheticRollup
-from trusted_router.synthetic.rollups import compact_histogram
-
-ROLLUP_HISTOGRAM_FIELDS = (
-    "latency_histogram",
-    "ttfb_histogram",
-    "dns_histogram",
-    "tcp_connect_histogram",
-    "tls_handshake_histogram",
-    "gateway_processing_histogram",
-)
+from trusted_router.synthetic.rollups import ROLLUP_HISTOGRAM_FIELDS, compact_histogram
 
 PROJECT = "quill-cloud-proxy"
 INSTANCE = "trusted-router-logs"

--- a/clickhouse/operational_fingerprint.py
+++ b/clickhouse/operational_fingerprint.py
@@ -13,6 +13,7 @@ from clickhouse.ingest_operational_outbox import (
     ACTIVITY_BOOLEAN_COLUMNS,
     ACTIVITY_OPTIONAL_DEFAULTS,
 )
+from trusted_router.synthetic.rollups import ROLLUP_HISTOGRAM_FIELDS, compact_histogram
 
 SAFE_ID = re.compile(r"^[A-Za-z0-9._:-]{1,160}$")
 
@@ -46,11 +47,21 @@ def canonical_fingerprint(payload: dict[str, Any], *, surface: str) -> str:
             if canonical.get(field) is not None:
                 canonical[field] = bool(canonical[field])
         if canonical.get("speed_tokens_per_second") is not None:
-            canonical["speed_tokens_per_second"] = float(
-                canonical["speed_tokens_per_second"]
-            )
-    if surface == "rollup" and canonical.get("target_region") is None:
-        canonical["target_region"] = ""
+            canonical["speed_tokens_per_second"] = float(canonical["speed_tokens_per_second"])
+    if surface == "rollup":
+        if canonical.get("target_region") is None:
+            canonical["target_region"] = ""
+        # A source row for a closed period keeps its pre-bucketing exact keys
+        # (never rewritten) while the rebuilt row is bucketed; fold both so
+        # the parity timer compares shape, not key granularity.
+        for field in ROLLUP_HISTOGRAM_FIELDS:
+            histogram = canonical.get(field)
+            if not isinstance(histogram, dict):
+                continue
+            try:
+                canonical[field] = compact_histogram(histogram)
+            except (TypeError, ValueError):
+                continue
     if surface == "benchmark" and canonical.get("speed_tokens_per_second") is not None:
         canonical["speed_tokens_per_second"] = struct.unpack(
             "!f",
@@ -109,8 +120,4 @@ def _iso(value: Any) -> str:
         return text if text.endswith("Z") else text + "Z"
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=dt.UTC)
-    return (
-        parsed.astimezone(dt.UTC)
-        .isoformat(timespec="milliseconds")
-        .replace("+00:00", "Z")
-    )
+    return parsed.astimezone(dt.UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")

--- a/clickhouse/operational_fingerprint.py
+++ b/clickhouse/operational_fingerprint.py
@@ -47,7 +47,9 @@ def canonical_fingerprint(payload: dict[str, Any], *, surface: str) -> str:
             if canonical.get(field) is not None:
                 canonical[field] = bool(canonical[field])
         if canonical.get("speed_tokens_per_second") is not None:
-            canonical["speed_tokens_per_second"] = float(canonical["speed_tokens_per_second"])
+            canonical["speed_tokens_per_second"] = float(
+                canonical["speed_tokens_per_second"]
+            )
     if surface == "rollup":
         if canonical.get("target_region") is None:
             canonical["target_region"] = ""
@@ -120,4 +122,8 @@ def _iso(value: Any) -> str:
         return text if text.endswith("Z") else text + "Z"
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=dt.UTC)
-    return parsed.astimezone(dt.UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+    return (
+        parsed.astimezone(dt.UTC)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )

--- a/clickhouse/rollup_synthetic.py
+++ b/clickhouse/rollup_synthetic.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from trusted_router.storage_models import SyntheticProbeSample, SyntheticRollup, iso_now
 from trusted_router.synthetic.rollups import (
+    ROLLUP_HISTOGRAM_FIELDS,
     apply_sample_to_rollup,
     compact_histogram,
     new_rollup_for_sample,
@@ -279,14 +280,7 @@ def _merge_rollup(target: SyntheticRollup, source: SyntheticRollup) -> None:
     # Daily rows written before histogram bucketing carry one key per
     # millisecond; fold them so a month row is bounded regardless of the
     # shape of what it was built from.
-    for field in (
-        "latency_histogram",
-        "ttfb_histogram",
-        "dns_histogram",
-        "tcp_connect_histogram",
-        "tls_handshake_histogram",
-        "gateway_processing_histogram",
-    ):
+    for field in ROLLUP_HISTOGRAM_FIELDS:
         setattr(target, field, compact_histogram(getattr(target, field)))
     if source.last_checked_at and (
         target.last_checked_at is None or source.last_checked_at > target.last_checked_at

--- a/clickhouse/rollup_synthetic.py
+++ b/clickhouse/rollup_synthetic.py
@@ -18,6 +18,7 @@ from typing import Any
 from trusted_router.storage_models import SyntheticProbeSample, SyntheticRollup, iso_now
 from trusted_router.synthetic.rollups import (
     apply_sample_to_rollup,
+    compact_histogram,
     new_rollup_for_sample,
     rollup_id,
     sample_rollup_ids,
@@ -67,9 +68,7 @@ def fetch_samples(
         "ORDER BY created_at FORMAT JSONEachRow"
     )
     return [
-        _sample_from_dict(json.loads(line))
-        for line in rows.decode().splitlines()
-        if line.strip()
+        _sample_from_dict(json.loads(line)) for line in rows.decode().splitlines() if line.strip()
     ]
 
 
@@ -143,9 +142,7 @@ def complete_window_rollups(
         safe_start = safe_starts.get(rollup.period)
         if safe_start is None:
             continue
-        period_start = dt.datetime.fromisoformat(
-            rollup.period_start.replace("Z", "+00:00")
-        )
+        period_start = dt.datetime.fromisoformat(rollup.period_start.replace("Z", "+00:00"))
         if _utc(period_start) >= safe_start:
             result.append(rollup)
     return result
@@ -165,9 +162,7 @@ def fetch_daily_rollups(
         "FORMAT JSONEachRow"
     )
     return [
-        _rollup_from_dict(json.loads(line))
-        for line in rows.decode().splitlines()
-        if line.strip()
+        _rollup_from_dict(json.loads(line)) for line in rows.decode().splitlines() if line.strip()
     ]
 
 
@@ -281,9 +276,20 @@ def _merge_rollup(target: SyntheticRollup, source: SyntheticRollup) -> None:
         destination = getattr(target, field)
         for key, count in getattr(source, field).items():
             destination[key] = destination.get(key, 0) + count
+    # Daily rows written before histogram bucketing carry one key per
+    # millisecond; fold them so a month row is bounded regardless of the
+    # shape of what it was built from.
+    for field in (
+        "latency_histogram",
+        "ttfb_histogram",
+        "dns_histogram",
+        "tcp_connect_histogram",
+        "tls_handshake_histogram",
+        "gateway_processing_histogram",
+    ):
+        setattr(target, field, compact_histogram(getattr(target, field)))
     if source.last_checked_at and (
-        target.last_checked_at is None
-        or source.last_checked_at > target.last_checked_at
+        target.last_checked_at is None or source.last_checked_at > target.last_checked_at
     ):
         target.last_checked_at = source.last_checked_at
     target.updated_at = iso_now()

--- a/clickhouse/rollup_synthetic.py
+++ b/clickhouse/rollup_synthetic.py
@@ -69,7 +69,9 @@ def fetch_samples(
         "ORDER BY created_at FORMAT JSONEachRow"
     )
     return [
-        _sample_from_dict(json.loads(line)) for line in rows.decode().splitlines() if line.strip()
+        _sample_from_dict(json.loads(line))
+        for line in rows.decode().splitlines()
+        if line.strip()
     ]
 
 
@@ -143,7 +145,9 @@ def complete_window_rollups(
         safe_start = safe_starts.get(rollup.period)
         if safe_start is None:
             continue
-        period_start = dt.datetime.fromisoformat(rollup.period_start.replace("Z", "+00:00"))
+        period_start = dt.datetime.fromisoformat(
+            rollup.period_start.replace("Z", "+00:00")
+        )
         if _utc(period_start) >= safe_start:
             result.append(rollup)
     return result
@@ -163,7 +167,9 @@ def fetch_daily_rollups(
         "FORMAT JSONEachRow"
     )
     return [
-        _rollup_from_dict(json.loads(line)) for line in rows.decode().splitlines() if line.strip()
+        _rollup_from_dict(json.loads(line))
+        for line in rows.decode().splitlines()
+        if line.strip()
     ]
 
 
@@ -275,7 +281,8 @@ def _merge_rollup(target: SyntheticRollup, source: SyntheticRollup) -> None:
     for field in ROLLUP_HISTOGRAM_FIELDS:
         setattr(target, field, compact_histogram(getattr(target, field)))
     if source.last_checked_at and (
-        target.last_checked_at is None or source.last_checked_at > target.last_checked_at
+        target.last_checked_at is None
+        or source.last_checked_at > target.last_checked_at
     ):
         target.last_checked_at = source.last_checked_at
     target.updated_at = iso_now()

--- a/clickhouse/rollup_synthetic.py
+++ b/clickhouse/rollup_synthetic.py
@@ -265,15 +265,7 @@ def _merge_rollup(target: SyntheticRollup, source: SyntheticRollup) -> None:
         "cost_microdollars",
     ):
         setattr(target, field, getattr(target, field) + getattr(source, field))
-    for field in (
-        "latency_histogram",
-        "ttfb_histogram",
-        "dns_histogram",
-        "tcp_connect_histogram",
-        "tls_handshake_histogram",
-        "gateway_processing_histogram",
-        "error_counts",
-    ):
+    for field in (*ROLLUP_HISTOGRAM_FIELDS, "error_counts"):
         destination = getattr(target, field)
         for key, count in getattr(source, field).items():
             destination[key] = destination.get(key, 0) + count

--- a/src/trusted_router/operational_analytics.py
+++ b/src/trusted_router/operational_analytics.py
@@ -526,8 +526,14 @@ def stable_rows_fingerprint(rows: list[Any], *, grace_seconds: int = 30) -> tupl
         # period is bucketed. Fold both to the same shape before comparing.
         for field in ROLLUP_HISTOGRAM_FIELDS:
             histogram = payload.get(field)
-            if isinstance(histogram, dict):
+            if not isinstance(histogram, dict):
+                continue
+            try:
                 payload[field] = compact_histogram(histogram)
+            except (TypeError, ValueError):
+                # A count that is not an integer cannot be folded; compare the
+                # row as stored rather than turning a shadow read into a raise.
+                continue
         speed = payload.get("speed_tokens_per_second")
         if speed is not None and "input_tokens" in payload:
             # The long-lived provider benchmark table intentionally stores

--- a/src/trusted_router/operational_analytics.py
+++ b/src/trusted_router/operational_analytics.py
@@ -22,6 +22,7 @@ from trusted_router.storage_models import (
     SyntheticProbeSample,
     SyntheticRollup,
 )
+from trusted_router.synthetic.rollups import ROLLUP_HISTOGRAM_FIELDS, compact_histogram
 from trusted_router.types import UsageType
 
 _IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -479,14 +480,8 @@ def _generation(row: dict[str, Any], *, tenant_id: str) -> Generation:
         ttfb_milliseconds=_optional_int(row.get("ttfb_milliseconds")),
         region=str(row["region"]) if row.get("region") is not None else None,
         user=str(row["user"]) if row.get("user") is not None else None,
-        session_id=(
-            str(row["session_id"]) if row.get("session_id") is not None else None
-        ),
-        http_referer=(
-            str(row["http_referer"])
-            if row.get("http_referer") is not None
-            else None
-        ),
+        session_id=(str(row["session_id"]) if row.get("session_id") is not None else None),
+        http_referer=(str(row["http_referer"]) if row.get("http_referer") is not None else None),
         app_categories=[str(item) for item in row.get("app_categories") or []],
         tags={str(key): str(value) for key, value in (row.get("tags") or {}).items()},
         created_at=_iso(row["created_at"]),
@@ -506,9 +501,7 @@ def _client_event(row: dict[str, Any]) -> dict[str, Any]:
         "first_error_class": str(row.get("first_error_class") or "") or None,
         "sdk": str(row.get("sdk") or ""),
         "sdk_version": str(row.get("sdk_version") or ""),
-        "attempt_request_id": [
-            str(item) for item in row.get("attempt_request_id") or [] if item
-        ],
+        "attempt_request_id": [str(item) for item in row.get("attempt_request_id") or [] if item],
     }
 
 
@@ -521,16 +514,20 @@ def stable_rows_fingerprint(rows: list[Any], *, grace_seconds: int = 30) -> tupl
     cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=max(0, grace_seconds))
     stable: list[dict[str, Any]] = []
     for row in rows:
-        payload = (
-            dataclasses.asdict(cast(Any, row))
-            if dataclasses.is_dataclass(row)
-            else dict(row)
-        )
+        payload = dataclasses.asdict(cast(Any, row)) if dataclasses.is_dataclass(row) else dict(row)
         # Rebuild timestamps are expected to differ across stores. Raw tenant
         # and key identifiers are intentionally replaced by opaque surrogates
         # in ClickHouse, so they are not parity fields either.
         for volatile in ("updated_at", "workspace_id", "key_hash"):
             payload.pop(volatile, None)
+        # Synthetic rollup histograms are bucketed on write, but a Bigtable
+        # row for an already-closed period keeps its pre-bucketing exact keys
+        # (it is never rewritten) while the ClickHouse rebuild of the same
+        # period is bucketed. Fold both to the same shape before comparing.
+        for field in ROLLUP_HISTOGRAM_FIELDS:
+            histogram = payload.get(field)
+            if isinstance(histogram, dict):
+                payload[field] = compact_histogram(histogram)
         speed = payload.get("speed_tokens_per_second")
         if speed is not None and "input_tokens" in payload:
             # The long-lived provider benchmark table intentionally stores
@@ -552,8 +549,7 @@ def stable_rows_fingerprint(rows: list[Any], *, grace_seconds: int = 30) -> tupl
                 continue
         stable.append(payload)
     canonical_rows = sorted(
-        json.dumps(row, sort_keys=True, separators=(",", ":"), default=str)
-        for row in stable
+        json.dumps(row, sort_keys=True, separators=(",", ":"), default=str) for row in stable
     )
     encoded = "\n".join(canonical_rows)
     return len(stable), hashlib.sha256(encoded.encode("utf-8")).hexdigest()

--- a/src/trusted_router/operational_analytics.py
+++ b/src/trusted_router/operational_analytics.py
@@ -480,8 +480,14 @@ def _generation(row: dict[str, Any], *, tenant_id: str) -> Generation:
         ttfb_milliseconds=_optional_int(row.get("ttfb_milliseconds")),
         region=str(row["region"]) if row.get("region") is not None else None,
         user=str(row["user"]) if row.get("user") is not None else None,
-        session_id=(str(row["session_id"]) if row.get("session_id") is not None else None),
-        http_referer=(str(row["http_referer"]) if row.get("http_referer") is not None else None),
+        session_id=(
+            str(row["session_id"]) if row.get("session_id") is not None else None
+        ),
+        http_referer=(
+            str(row["http_referer"])
+            if row.get("http_referer") is not None
+            else None
+        ),
         app_categories=[str(item) for item in row.get("app_categories") or []],
         tags={str(key): str(value) for key, value in (row.get("tags") or {}).items()},
         created_at=_iso(row["created_at"]),
@@ -501,7 +507,9 @@ def _client_event(row: dict[str, Any]) -> dict[str, Any]:
         "first_error_class": str(row.get("first_error_class") or "") or None,
         "sdk": str(row.get("sdk") or ""),
         "sdk_version": str(row.get("sdk_version") or ""),
-        "attempt_request_id": [str(item) for item in row.get("attempt_request_id") or [] if item],
+        "attempt_request_id": [
+            str(item) for item in row.get("attempt_request_id") or [] if item
+        ],
     }
 
 
@@ -514,7 +522,11 @@ def stable_rows_fingerprint(rows: list[Any], *, grace_seconds: int = 30) -> tupl
     cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=max(0, grace_seconds))
     stable: list[dict[str, Any]] = []
     for row in rows:
-        payload = dataclasses.asdict(cast(Any, row)) if dataclasses.is_dataclass(row) else dict(row)
+        payload = (
+            dataclasses.asdict(cast(Any, row))
+            if dataclasses.is_dataclass(row)
+            else dict(row)
+        )
         # Rebuild timestamps are expected to differ across stores. Raw tenant
         # and key identifiers are intentionally replaced by opaque surrogates
         # in ClickHouse, so they are not parity fields either.
@@ -555,7 +567,8 @@ def stable_rows_fingerprint(rows: list[Any], *, grace_seconds: int = 30) -> tupl
                 continue
         stable.append(payload)
     canonical_rows = sorted(
-        json.dumps(row, sort_keys=True, separators=(",", ":"), default=str) for row in stable
+        json.dumps(row, sort_keys=True, separators=(",", ":"), default=str)
+        for row in stable
     )
     encoded = "\n".join(canonical_rows)
     return len(stable), hashlib.sha256(encoded.encode("utf-8")).hexdigest()

--- a/src/trusted_router/storage_gcp_synthetic_rollups.py
+++ b/src/trusted_router/storage_gcp_synthetic_rollups.py
@@ -9,6 +9,7 @@ from trusted_router.storage_gcp_codec import json_body
 from trusted_router.storage_models import SyntheticProbeSample, SyntheticRollup, utcnow
 from trusted_router.synthetic.rollups import (
     apply_sample_to_rollup,
+    compact_rollup,
     new_rollup_for_sample,
     rollup_is_within_retention,
     sample_rollup_ids,
@@ -38,6 +39,7 @@ def write_synthetic_rollups(
         if existing is None:
             existing = update
         else:
+            compact_rollup(existing)
             apply_sample_to_rollup(existing, sample)
         _write_json_row(table, family, _rollup_key(existing), existing)
         _write_json_row(table, family, marker_key, {"seen": True})

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -165,6 +165,7 @@ from trusted_router.synthetic.rollups import (
     RAW_SYNTHETIC_RETENTION_DAYS,
     ROLLUP_RETENTION_MONTHS,
     apply_sample_to_rollup,
+    compact_rollup,
     new_rollup_for_sample,
     sample_rollup_ids,
 )
@@ -4848,6 +4849,7 @@ class PostgresStore:
                 )
                 if existing is None:
                     raise StoreConflict("Synthetic rollup disappeared during update")
+                compact_rollup(existing)
                 apply_sample_to_rollup(existing, sample)
                 self._write_indexed_entity_tx(
                     conn,

--- a/src/trusted_router/synthetic/rollups.py
+++ b/src/trusted_router/synthetic/rollups.py
@@ -49,7 +49,13 @@ def new_rollup_for_sample(
     *,
     period: str,
     component: str,
+    bucket: bool = True,
 ) -> SyntheticRollup:
+    """Build a one-sample rollup. `bucket=False` keeps exact-millisecond
+    keys; use it only for transient rollups that are never persisted (the
+    status page's raw-sample windows), so they agree with the exact
+    percentiles computed from the same samples. Anything written to a
+    store must stay bucketed."""
     rollup = SyntheticRollup(
         id=rollup_id(
             period=period,
@@ -68,16 +74,22 @@ def new_rollup_for_sample(
         monitor_region=sample.monitor_region,
         target_region=sample.target_region,
     )
-    apply_sample_to_rollup(rollup, sample)
+    apply_sample_to_rollup(rollup, sample, bucket=bucket)
     return rollup
 
 
-def apply_sample_to_rollup(rollup: SyntheticRollup, sample: SyntheticProbeSample) -> None:
-    # A rollup written before bucketing carries one key per distinct
-    # millisecond. Fold it here, so the body shrinks on the very next
-    # read-modify-write rather than growing until the period rolls over.
-    for histogram in _rollup_histograms(rollup):
-        _compact_histogram_in_place(histogram)
+def apply_sample_to_rollup(
+    rollup: SyntheticRollup,
+    sample: SyntheticProbeSample,
+    *,
+    bucket: bool = True,
+) -> None:
+    if bucket:
+        # A rollup written before bucketing carries one key per distinct
+        # millisecond. Fold it here, so the body shrinks on the very next
+        # read-modify-write rather than growing until the period rolls over.
+        for histogram in _rollup_histograms(rollup):
+            _compact_histogram_in_place(histogram)
     rollup.sample_count += 1
     if sample.status == "up":
         rollup.up_count += 1
@@ -91,21 +103,16 @@ def apply_sample_to_rollup(rollup: SyntheticRollup, sample: SyntheticProbeSample
         rollup.trust_degraded_count += 1
     else:
         rollup.unknown_count += 1
-    if sample.latency_milliseconds is not None:
-        _increment_histogram(rollup.latency_histogram, sample.latency_milliseconds)
-    if sample.ttfb_milliseconds is not None:
-        _increment_histogram(rollup.ttfb_histogram, sample.ttfb_milliseconds)
-    if sample.dns_milliseconds is not None:
-        _increment_histogram(rollup.dns_histogram, sample.dns_milliseconds)
-    if sample.tcp_connect_milliseconds is not None:
-        _increment_histogram(rollup.tcp_connect_histogram, sample.tcp_connect_milliseconds)
-    if sample.tls_handshake_milliseconds is not None:
-        _increment_histogram(rollup.tls_handshake_histogram, sample.tls_handshake_milliseconds)
-    if sample.gateway_processing_milliseconds is not None:
-        _increment_histogram(
-            rollup.gateway_processing_histogram,
-            sample.gateway_processing_milliseconds,
-        )
+    for histogram, value in (
+        (rollup.latency_histogram, sample.latency_milliseconds),
+        (rollup.ttfb_histogram, sample.ttfb_milliseconds),
+        (rollup.dns_histogram, sample.dns_milliseconds),
+        (rollup.tcp_connect_histogram, sample.tcp_connect_milliseconds),
+        (rollup.tls_handshake_histogram, sample.tls_handshake_milliseconds),
+        (rollup.gateway_processing_histogram, sample.gateway_processing_milliseconds),
+    ):
+        if value is not None:
+            _increment_histogram(histogram, value, bucket=bucket)
     if sample.error_type:
         rollup.error_counts[sample.error_type] = rollup.error_counts.get(sample.error_type, 0) + 1
     rollup.cost_microdollars += sample.cost_microdollars
@@ -252,7 +259,7 @@ def raw_sample_is_within_retention(
 #: integer milliseconds (as strings), so every reader that sorts keys with
 #: int() and walks counts keeps working, and pre-bucketing rows — whose keys
 #: are just finer-grained integers — need no migration: `compact_histogram`
-#: folds them into buckets lazily, on the next write or merge.
+#: folds them into buckets lazily, on the row's next write.
 HISTOGRAM_EXACT_BELOW = 100
 HISTOGRAM_SIGNIFICANT_DIGITS = 2
 
@@ -267,8 +274,14 @@ def histogram_bucket(value: int) -> int:
     and Bigtable backends is the size of the body re-read and re-written
     on EVERY sample for the rest of the period. The map is monotone
     (a <= b implies bucket(a) <= bucket(b)) and idempotent, so a percentile
-    taken from bucketed counts is exactly bucket(exact percentile):
-    error is at most half a bucket, i.e. <= 5% above 100 ms and 0 below.
+    taken from bucketed counts is exactly bucket(exact percentile). Rounding
+    is to nearest, so the error is at most half a step (10^(digits-2) / 2):
+    within +/-5% above 100 ms, exact below. Nearest keeps the published
+    p50/p95 unbiased; it can sit slightly under the true value as well as
+    over it, unlike `client_reliability.LATENCY_BUCKETS`, which reports
+    bucket upper bounds. (Buckets straddling a decade boundary, e.g. the one
+    keyed 1000 covering 995..1049, are wider than a step but never exceed
+    the 5% bound.)
     """
     value = max(int(value), 0)
     if value < HISTOGRAM_EXACT_BELOW:
@@ -287,9 +300,15 @@ def compact_histogram(histogram: dict[str, int]) -> dict[str, int]:
 
 
 def _compact_histogram_in_place(histogram: dict[str, int]) -> None:
-    if all(str(histogram_bucket(int(key))) == key for key in histogram):
+    try:
+        if all(str(histogram_bucket(int(key))) == key for key in histogram):
+            return
+        compacted = compact_histogram(histogram)
+    except (TypeError, ValueError):
+        # A key that is not an integer literal cannot be folded. Leave the
+        # row exactly as it was (the pre-bucketing behaviour) rather than
+        # failing the sample write that happens in the same transaction.
         return
-    compacted = compact_histogram(histogram)
     histogram.clear()
     histogram.update(compacted)
 
@@ -305,14 +324,18 @@ def _rollup_histograms(rollup: SyntheticRollup) -> tuple[dict[str, int], ...]:
     )
 
 
-def _increment_histogram(histogram: dict[str, int], value: int) -> None:
-    key = str(histogram_bucket(value))
+def _increment_histogram(histogram: dict[str, int], value: int, *, bucket: bool = True) -> None:
+    key = str(histogram_bucket(value) if bucket else max(int(value), 0))
     histogram[key] = histogram.get(key, 0) + 1
 
 
 def _merge_histograms(target: dict[str, int], source: dict[str, int]) -> None:
-    for raw_key, count in source.items():
-        key = str(histogram_bucket(int(raw_key)))
+    # A plain key-sum on purpose: merging never changes precision. Persisted
+    # rows arrive bucketed (or legacy-exact until their next write), transient
+    # status-window rows arrive exact, and a mixed walk still lands within
+    # half a bucket of the exact percentile because every element moved by
+    # at most that much.
+    for key, count in source.items():
         target[key] = target.get(key, 0) + count
 
 

--- a/src/trusted_router/synthetic/rollups.py
+++ b/src/trusted_router/synthetic/rollups.py
@@ -73,6 +73,11 @@ def new_rollup_for_sample(
 
 
 def apply_sample_to_rollup(rollup: SyntheticRollup, sample: SyntheticProbeSample) -> None:
+    # A rollup written before bucketing carries one key per distinct
+    # millisecond. Fold it here, so the body shrinks on the very next
+    # read-modify-write rather than growing until the period rolls over.
+    for histogram in _rollup_histograms(rollup):
+        _compact_histogram_in_place(histogram)
     rollup.sample_count += 1
     if sample.status == "up":
         rollup.up_count += 1
@@ -242,13 +247,72 @@ def raw_sample_is_within_retention(
     return created >= now - dt.timedelta(days=days)
 
 
+#: Millisecond values below this are stored exactly; above it they are
+#: rounded to HISTOGRAM_SIGNIFICANT_DIGITS significant digits. Keys stay
+#: integer milliseconds (as strings), so every reader that sorts keys with
+#: int() and walks counts keeps working, and pre-bucketing rows — whose keys
+#: are just finer-grained integers — need no migration: `compact_histogram`
+#: folds them into buckets lazily, on the next write or merge.
+HISTOGRAM_EXACT_BELOW = 100
+HISTOGRAM_SIGNIFICANT_DIGITS = 2
+
+
+def histogram_bucket(value: int) -> int:
+    """Map a millisecond value to its bucket representative.
+
+    Exact below HISTOGRAM_EXACT_BELOW, then log-linear: 2 significant
+    digits, rounded to nearest (ties up). Each decade contributes at most
+    90 keys, so a histogram over 0..10^7 ms holds fewer than 600 keys
+    instead of one per distinct millisecond — which on the Postgres/DSQL
+    and Bigtable backends is the size of the body re-read and re-written
+    on EVERY sample for the rest of the period. The map is monotone
+    (a <= b implies bucket(a) <= bucket(b)) and idempotent, so a percentile
+    taken from bucketed counts is exactly bucket(exact percentile):
+    error is at most half a bucket, i.e. <= 5% above 100 ms and 0 below.
+    """
+    value = max(int(value), 0)
+    if value < HISTOGRAM_EXACT_BELOW:
+        return value
+    step = 10 ** (len(str(value)) - HISTOGRAM_SIGNIFICANT_DIGITS)
+    return (value + step // 2) // step * step
+
+
+def compact_histogram(histogram: dict[str, int]) -> dict[str, int]:
+    """Fold every key into its bucket, preserving total count."""
+    compacted: dict[str, int] = {}
+    for raw_key, count in histogram.items():
+        key = str(histogram_bucket(int(raw_key)))
+        compacted[key] = compacted.get(key, 0) + int(count)
+    return compacted
+
+
+def _compact_histogram_in_place(histogram: dict[str, int]) -> None:
+    if all(str(histogram_bucket(int(key))) == key for key in histogram):
+        return
+    compacted = compact_histogram(histogram)
+    histogram.clear()
+    histogram.update(compacted)
+
+
+def _rollup_histograms(rollup: SyntheticRollup) -> tuple[dict[str, int], ...]:
+    return (
+        rollup.latency_histogram,
+        rollup.ttfb_histogram,
+        rollup.dns_histogram,
+        rollup.tcp_connect_histogram,
+        rollup.tls_handshake_histogram,
+        rollup.gateway_processing_histogram,
+    )
+
+
 def _increment_histogram(histogram: dict[str, int], value: int) -> None:
-    key = str(max(int(value), 0))
+    key = str(histogram_bucket(value))
     histogram[key] = histogram.get(key, 0) + 1
 
 
 def _merge_histograms(target: dict[str, int], source: dict[str, int]) -> None:
-    for key, count in source.items():
+    for raw_key, count in source.items():
+        key = str(histogram_bucket(int(raw_key)))
         target[key] = target.get(key, 0) + count
 
 

--- a/src/trusted_router/synthetic/rollups.py
+++ b/src/trusted_router/synthetic/rollups.py
@@ -290,25 +290,30 @@ def histogram_bucket(value: int) -> int:
     return (value + step // 2) // step * step
 
 
+def _bucket_key(raw_key: str) -> str:
+    """The stored key for a histogram key. A key that is not an integer
+    literal cannot be folded; it is kept verbatim, exactly as every writer
+    kept it before bucketing, so one odd historical key never aborts a
+    sample write, a ClickHouse recompute, or a backfill."""
+    try:
+        return str(histogram_bucket(int(raw_key)))
+    except (TypeError, ValueError):
+        return str(raw_key)
+
+
 def compact_histogram(histogram: dict[str, int]) -> dict[str, int]:
-    """Fold every key into its bucket, preserving total count."""
+    """Fold every integer key into its bucket, preserving total count."""
     compacted: dict[str, int] = {}
     for raw_key, count in histogram.items():
-        key = str(histogram_bucket(int(raw_key)))
+        key = _bucket_key(raw_key)
         compacted[key] = compacted.get(key, 0) + int(count)
     return compacted
 
 
 def _compact_histogram_in_place(histogram: dict[str, int]) -> None:
-    try:
-        if all(str(histogram_bucket(int(key))) == key for key in histogram):
-            return
-        compacted = compact_histogram(histogram)
-    except (TypeError, ValueError):
-        # A key that is not an integer literal cannot be folded. Leave the
-        # row exactly as it was (the pre-bucketing behaviour) rather than
-        # failing the sample write that happens in the same transaction.
+    if all(_bucket_key(key) == key for key in histogram):
         return
+    compacted = compact_histogram(histogram)
     histogram.clear()
     histogram.update(compacted)
 

--- a/src/trusted_router/synthetic/rollups.py
+++ b/src/trusted_router/synthetic/rollups.py
@@ -21,6 +21,26 @@ ROLLUP_PERIODS = {"hour", "day", "month"}
 ROLLUP_RETENTION_MONTHS = 24
 RAW_SYNTHETIC_RETENTION_DAYS = 14
 
+#: The six latency-phase histograms on a SyntheticRollup, in one place for
+#: every writer that has to fold or copy them.
+ROLLUP_HISTOGRAM_FIELDS = (
+    "latency_histogram",
+    "ttfb_histogram",
+    "dns_histogram",
+    "tcp_connect_histogram",
+    "tls_handshake_histogram",
+    "gateway_processing_histogram",
+)
+
+#: Millisecond values below this are stored exactly; above it they are
+#: rounded to HISTOGRAM_SIGNIFICANT_DIGITS significant digits. Keys stay
+#: integer milliseconds (as strings), so every reader that sorts keys with
+#: int() and walks counts keeps working, and pre-bucketing rows — whose keys
+#: are just finer-grained integers — need no migration: `compact_rollup`
+#: folds them into buckets lazily, when a store reads the row to update it.
+HISTOGRAM_EXACT_BELOW = 100
+HISTOGRAM_SIGNIFICANT_DIGITS = 2
+
 
 def rollup_period_start(created_at: str, period: str) -> str:
     parsed = _parse_time(created_at)
@@ -84,12 +104,6 @@ def apply_sample_to_rollup(
     *,
     bucket: bool = True,
 ) -> None:
-    if bucket:
-        # A rollup written before bucketing carries one key per distinct
-        # millisecond. Fold it here, so the body shrinks on the very next
-        # read-modify-write rather than growing until the period rolls over.
-        for histogram in _rollup_histograms(rollup):
-            _compact_histogram_in_place(histogram)
     rollup.sample_count += 1
     if sample.status == "up":
         rollup.up_count += 1
@@ -213,15 +227,23 @@ def merge_rollups(rollups: list[SyntheticRollup]) -> dict[str, Any]:
 
 
 def percentile_from_histogram(histogram: dict[str, int], percentile: int) -> int | None:
-    total = sum(histogram.values())
+    # Mirror the writer's tolerance: a key that is not an integer literal is
+    # preserved on write (see _bucket_key) and simply not counted here.
+    entries: list[tuple[int, int]] = []
+    for raw_value, count in histogram.items():
+        try:
+            entries.append((int(raw_value), int(count)))
+        except (TypeError, ValueError):
+            continue
+    total = sum(count for _, count in entries)
     if total <= 0:
         return None
     threshold = max(1, math.ceil(total * percentile / 100))
     seen = 0
-    for raw_value, count in sorted(histogram.items(), key=lambda item: int(item[0])):
+    for value, count in sorted(entries):
         seen += count
         if seen >= threshold:
-            return int(raw_value)
+            return value
     return None
 
 
@@ -254,21 +276,11 @@ def raw_sample_is_within_retention(
     return created >= now - dt.timedelta(days=days)
 
 
-#: Millisecond values below this are stored exactly; above it they are
-#: rounded to HISTOGRAM_SIGNIFICANT_DIGITS significant digits. Keys stay
-#: integer milliseconds (as strings), so every reader that sorts keys with
-#: int() and walks counts keeps working, and pre-bucketing rows — whose keys
-#: are just finer-grained integers — need no migration: `compact_histogram`
-#: folds them into buckets lazily, on the row's next write.
-HISTOGRAM_EXACT_BELOW = 100
-HISTOGRAM_SIGNIFICANT_DIGITS = 2
-
-
 def histogram_bucket(value: int) -> int:
     """Map a millisecond value to its bucket representative.
 
-    Exact below HISTOGRAM_EXACT_BELOW, then log-linear: 2 significant
-    digits, rounded to nearest (ties up). Each decade contributes at most
+    Exact below HISTOGRAM_EXACT_BELOW, then log-linear:
+    HISTOGRAM_SIGNIFICANT_DIGITS significant digits, rounded to nearest (ties up). Each decade contributes at most
     90 keys, so a histogram over 0..10^7 ms holds fewer than 600 keys
     instead of one per distinct millisecond — which on the Postgres/DSQL
     and Bigtable backends is the size of the body re-read and re-written
@@ -310,6 +322,22 @@ def compact_histogram(histogram: dict[str, int]) -> dict[str, int]:
     return compacted
 
 
+def compact_rollup(rollup: SyntheticRollup) -> None:
+    """Fold a rollup's six histograms into bucket keys, in place.
+
+    Call this where a persisted rollup enters memory for a read-modify-write
+    (the Postgres and Bigtable stores do): a row written before bucketing
+    carries one key per distinct millisecond, and folding it there means the
+    body shrinks on that very write instead of growing until the period
+    rolls over. It is deliberately NOT inside apply_sample_to_rollup — batch
+    rebuilders (ClickHouse recompute, backfills, the in-memory store) only
+    ever apply to rollups they created themselves, and an O(keys) scan on
+    every one of their samples measured 6-14x slower for nothing.
+    """
+    for histogram in _rollup_histograms(rollup):
+        _compact_histogram_in_place(histogram)
+
+
 def _compact_histogram_in_place(histogram: dict[str, int]) -> None:
     if all(_bucket_key(key) == key for key in histogram):
         return
@@ -319,14 +347,7 @@ def _compact_histogram_in_place(histogram: dict[str, int]) -> None:
 
 
 def _rollup_histograms(rollup: SyntheticRollup) -> tuple[dict[str, int], ...]:
-    return (
-        rollup.latency_histogram,
-        rollup.ttfb_histogram,
-        rollup.dns_histogram,
-        rollup.tcp_connect_histogram,
-        rollup.tls_handshake_histogram,
-        rollup.gateway_processing_histogram,
-    )
+    return tuple(getattr(rollup, field) for field in ROLLUP_HISTOGRAM_FIELDS)
 
 
 def _increment_histogram(histogram: dict[str, int], value: int, *, bucket: bool = True) -> None:

--- a/src/trusted_router/synthetic/status.py
+++ b/src/trusted_router/synthetic/status.py
@@ -117,8 +117,7 @@ def status_snapshot(
         for sample in ordered
         if not sample_component_ids(sample)
         or any(
-            component_id in published_component_ids
-            for component_id in sample_component_ids(sample)
+            component_id in published_component_ids for component_id in sample_component_ids(sample)
         )
     ]
     # Control-plane health is an SLO-only signal, so its rollups intentionally
@@ -128,10 +127,7 @@ def status_snapshot(
         rollup
         for rollup in precomputed_rollups
         if rollup.component in published_component_ids
-        or (
-            rollup.component == UNCATEGORIZED_COMPONENT
-            and bool(rollup_slo_class_ids(rollup))
-        )
+        or (rollup.component == UNCATEGORIZED_COMPONENT and bool(rollup_slo_class_ids(rollup)))
     ]
     router_core_samples = [
         sample
@@ -617,8 +613,10 @@ def _window_rollup_with_rollup_backfill(
         for rollup in _hour_rollups_in_window(rollups, now=now, seconds=seconds)
         if _rollup_hour_dimension(rollup) not in raw_hour_keys
     ]
+    # Transient and never persisted, so keep exact keys: the window's p50/p95
+    # must agree with the raw-sample percentiles reported beside it.
     combined_rollups = [
-        new_rollup_for_sample(sample, period="hour", component="status_window")
+        new_rollup_for_sample(sample, period="hour", component="status_window", bucket=False)
         for sample in raw_rows
     ]
     combined_rollups.extend(backfill_rollups)

--- a/src/trusted_router/synthetic/status.py
+++ b/src/trusted_router/synthetic/status.py
@@ -117,7 +117,8 @@ def status_snapshot(
         for sample in ordered
         if not sample_component_ids(sample)
         or any(
-            component_id in published_component_ids for component_id in sample_component_ids(sample)
+            component_id in published_component_ids
+            for component_id in sample_component_ids(sample)
         )
     ]
     # Control-plane health is an SLO-only signal, so its rollups intentionally
@@ -127,7 +128,10 @@ def status_snapshot(
         rollup
         for rollup in precomputed_rollups
         if rollup.component in published_component_ids
-        or (rollup.component == UNCATEGORIZED_COMPONENT and bool(rollup_slo_class_ids(rollup)))
+        or (
+            rollup.component == UNCATEGORIZED_COMPONENT
+            and bool(rollup_slo_class_ids(rollup))
+        )
     ]
     router_core_samples = [
         sample

--- a/tests/test_synthetic_histogram_bucketing.py
+++ b/tests/test_synthetic_histogram_bucketing.py
@@ -11,15 +11,19 @@ and prove the readers stay correct rather than assuming it.
 
 from __future__ import annotations
 
+import dataclasses
 import datetime as dt
 import json
 import math
 import random
+from contextlib import contextmanager
 from typing import Any
 
 from clickhouse.backfill_operational_analytics import insert_rollups as backfill_insert_rollups
+from clickhouse.operational_fingerprint import canonical_fingerprint
 from clickhouse.rollup_synthetic import monthly_from_daily
 from trusted_router.operational_analytics import stable_rows_fingerprint
+from trusted_router.storage_errors import StoreConflict
 from trusted_router.storage_gcp_synthetic_rollups import (
     _rollup_key,
     _write_json_row,
@@ -27,6 +31,7 @@ from trusted_router.storage_gcp_synthetic_rollups import (
     write_synthetic_rollups,
 )
 from trusted_router.storage_models import SyntheticProbeSample, SyntheticRollup, iso_now
+from trusted_router.storage_postgres import PostgresStore
 from trusted_router.synthetic import status as synthetic_status
 from trusted_router.synthetic.rollups import (
     HISTOGRAM_EXACT_BELOW,
@@ -237,7 +242,13 @@ def test_compact_rollup_folds_a_legacy_rollup_preserves_counts_and_is_idempotent
     assert len(legacy.ttfb_histogram) <= MAX_KEYS_TO_TEN_MILLION_MS
     assert sum(legacy.latency_histogram.values()) == len(values) + 1
     assert sum(legacy.ttfb_histogram.values()) == len(values) + 1
-    assert legacy.latency_histogram[str(histogram_bucket(777))] >= 1
+    # The applied sample landed in its bucket on top of what the seed held.
+    expected_latency = sum(1 for v in values if histogram_bucket(v) == histogram_bucket(777)) + 1
+    assert legacy.latency_histogram[str(histogram_bucket(777))] == expected_latency
+    expected_ttfb = (
+        sum(1 for v in values if histogram_bucket(v // 2) == histogram_bucket(777 // 2)) + 1
+    )
+    assert legacy.ttfb_histogram[str(histogram_bucket(777 // 2))] == expected_ttfb
     before = dict(legacy.latency_histogram)
     compact_rollup(legacy)
     assert legacy.latency_histogram == before
@@ -516,3 +527,125 @@ def test_dual_read_fingerprint_treats_legacy_and_bucketed_rows_as_the_same_row()
     assert stable_rows_fingerprint([legacy], grace_seconds=0) != stable_rows_fingerprint(
         [other], grace_seconds=0
     )
+
+
+def test_parity_timer_fingerprint_folds_rollup_histograms_too() -> None:
+    values = list(range(100, 2_100))
+    base = {
+        "id": "closed-day",
+        "period": "day",
+        "period_start": "2026-05-01T00:00:00Z",
+        "component": "canonical_api",
+        "target": "api",
+        "probe_type": "tls_health",
+        "monitor_region": "us-central1",
+        "target_region": None,
+        "sample_count": len(values),
+        "up_count": len(values),
+    }
+    legacy = {**base, "latency_histogram": _legacy_histogram_of(values)}
+    bucketed = {**base, "latency_histogram": _histogram_of(values)}
+    other = {**base, "latency_histogram": _histogram_of([v + 500 for v in values])}
+    assert canonical_fingerprint(legacy, surface="rollup") == canonical_fingerprint(
+        bucketed, surface="rollup"
+    )
+    assert canonical_fingerprint(legacy, surface="rollup") != canonical_fingerprint(
+        other, surface="rollup"
+    )
+    # Other surfaces are untouched by the fold.
+    sample = {"id": "s1", "created_at": "2026-05-01T00:00:00Z", "latency_milliseconds": 123}
+    assert canonical_fingerprint(sample, surface="synthetic") == canonical_fingerprint(
+        dict(sample), surface="synthetic"
+    )
+
+
+class _FakeTransaction:
+    def __init__(self, log: list[str]) -> None:
+        self.log = log
+
+    def __enter__(self) -> _FakeTransaction:
+        self.log.append("begin")
+        return self
+
+    def __exit__(self, *_exc: object) -> bool:
+        self.log.append("commit")
+        return False
+
+
+class _FakeConnection:
+    def __init__(self, log: list[str]) -> None:
+        self.log = log
+
+    def transaction(self) -> _FakeTransaction:
+        return _FakeTransaction(self.log)
+
+
+class _FakePool:
+    def __init__(self, log: list[str]) -> None:
+        self.log = log
+
+    @contextmanager
+    def connection(self) -> Any:
+        yield _FakeConnection(self.log)
+
+
+def test_postgres_record_sample_compacts_the_legacy_body_it_reads_for_update() -> None:
+    """Drives the real PostgresStore.record_synthetic_probe_sample body with the
+    SQL helpers stubbed at the row level: the FOR UPDATE read returns a legacy
+    exact-key rollup and the upsert that follows must carry a bucketed body,
+    inside the same transaction."""
+    created_at = iso_now()
+    seed = _sample("seed", 150, created_at=created_at)
+    (period, component) = next(
+        (period, component) for period, component in sample_rollup_ids(seed) if period == "month"
+    )
+    legacy_values = list(range(100, 2_100))
+    legacy = new_rollup_for_sample(seed, period=period, component=component, bucket=False)
+    legacy.latency_histogram = _legacy_histogram_of(legacy_values)
+    legacy.sample_count = len(legacy_values)
+    legacy.up_count = len(legacy_values)
+
+    log: list[str] = []
+    writes: list[tuple[str, str, Any]] = []
+    store = object.__new__(PostgresStore)
+    store._transaction_attempts = 1
+    store._pool = _FakePool(log)  # type: ignore[assignment]
+    store._operational_analytics_outbox = None  # type: ignore[assignment]
+
+    def write_indexed(_conn: Any, kind: str, entity_id: str, value: Any, **_: Any) -> None:
+        log.append(f"write:{kind}")
+        writes.append((kind, entity_id, dataclasses.replace(value)))
+
+    def insert_once(_conn: Any, kind: str, *_a: Any, **_k: Any) -> bool:
+        log.append(f"insert:{kind}")
+        return kind == "synthetic_rollup_seen"  # marker is new; rollup row already exists
+
+    def read_entity(_conn: Any, kind: str, entity_id: str, _cls: Any, **_: Any) -> Any:
+        log.append(f"read:{kind}")
+        if kind == "synthetic_rollup" and entity_id == legacy.id:
+            return dataclasses.replace(legacy)
+        raise StoreConflict(f"unexpected read {kind}/{entity_id}")
+
+    store._write_indexed_entity_tx = write_indexed  # type: ignore[method-assign]
+    store._insert_entity_once_tx = insert_once  # type: ignore[method-assign]
+    store._insert_indexed_entity_once_tx = insert_once  # type: ignore[method-assign]
+    store._read_entity_tx = read_entity  # type: ignore[method-assign]
+
+    # Only the month rollup pre-exists in this fixture; hour/day reads would
+    # raise, so steer sample_rollup_ids to the one period under test.
+    import trusted_router.storage_postgres as storage_postgres_module
+
+    original = storage_postgres_module.sample_rollup_ids
+    storage_postgres_module.sample_rollup_ids = lambda s: [(period, component)]  # type: ignore[assignment]
+    try:
+        store.record_synthetic_probe_sample(_sample("next", 777, created_at=created_at))
+    finally:
+        storage_postgres_module.sample_rollup_ids = original  # type: ignore[assignment]
+
+    assert log[0] == "begin" and log[-1] == "commit"
+    assert log.index("read:synthetic_rollup") < log.index("write:synthetic_rollup") < len(log) - 1
+    (written,) = [value for kind, _, value in writes if kind == "synthetic_rollup"]
+    assert written.sample_count == len(legacy_values) + 1
+    assert len(written.latency_histogram) <= MAX_KEYS_TO_TEN_MILLION_MS
+    assert sum(written.latency_histogram.values()) == len(legacy_values) + 1
+    assert all(str(histogram_bucket(int(key))) == key for key in written.latency_histogram)

--- a/tests/test_synthetic_histogram_bucketing.py
+++ b/tests/test_synthetic_histogram_bucketing.py
@@ -12,23 +12,27 @@ and prove the readers stay correct rather than assuming it.
 from __future__ import annotations
 
 import datetime as dt
+import json
 import math
 import random
 from typing import Any
 
+from clickhouse.backfill_operational_analytics import insert_rollups as backfill_insert_rollups
 from clickhouse.rollup_synthetic import monthly_from_daily
+from trusted_router.operational_analytics import stable_rows_fingerprint
 from trusted_router.storage_gcp_synthetic_rollups import (
     _rollup_key,
     _write_json_row,
     synthetic_rollups,
     write_synthetic_rollups,
 )
-from trusted_router.storage_models import SyntheticProbeSample, SyntheticRollup
+from trusted_router.storage_models import SyntheticProbeSample, SyntheticRollup, iso_now
 from trusted_router.synthetic import status as synthetic_status
 from trusted_router.synthetic.rollups import (
     HISTOGRAM_EXACT_BELOW,
     apply_sample_to_rollup,
     compact_histogram,
+    compact_rollup,
     histogram_bucket,
     merge_rollups,
     new_rollup_for_sample,
@@ -214,7 +218,7 @@ def test_legacy_exact_keys_and_bucketed_keys_merge_to_the_same_answer() -> None:
         assert merged[key] == histogram_bucket(exact), (percentile, exact, merged[key])
 
 
-def test_applying_a_sample_compacts_a_legacy_rollup_and_preserves_counts() -> None:
+def test_compact_rollup_folds_a_legacy_rollup_preserves_counts_and_is_idempotent() -> None:
     values = _distributions()["uniform_ms"]
     legacy = new_rollup_for_sample(
         _sample("seed", values[0]), period="month", component="uncategorized"
@@ -225,6 +229,7 @@ def test_applying_a_sample_compacts_a_legacy_rollup_and_preserves_counts() -> No
     legacy.up_count = len(values)
     assert len(legacy.latency_histogram) > MAX_KEYS_TO_TEN_MILLION_MS
 
+    compact_rollup(legacy)
     apply_sample_to_rollup(legacy, _sample("next", 777))
 
     assert legacy.sample_count == len(values) + 1
@@ -233,14 +238,19 @@ def test_applying_a_sample_compacts_a_legacy_rollup_and_preserves_counts() -> No
     assert sum(legacy.latency_histogram.values()) == len(values) + 1
     assert sum(legacy.ttfb_histogram.values()) == len(values) + 1
     assert legacy.latency_histogram[str(histogram_bucket(777))] >= 1
-    # Every stored key is now a bucket representative: a second apply is a no-op fold.
     before = dict(legacy.latency_histogram)
-    apply_sample_to_rollup(legacy, _sample("again", 777))
-    assert set(legacy.latency_histogram) == set(before)
-    assert (
-        legacy.latency_histogram[str(histogram_bucket(777))]
-        == before[str(histogram_bucket(777))] + 1
-    )
+    compact_rollup(legacy)
+    assert legacy.latency_histogram == before
+
+
+def test_apply_sample_to_rollup_does_not_scan_the_histogram() -> None:
+    # The fold lives at the store read boundary (compact_rollup), so the
+    # per-sample seam used by batch rebuilders stays O(1) in histogram size.
+    rollup = new_rollup_for_sample(_sample("seed", 150), period="day", component="uncategorized")
+    rollup.latency_histogram = _legacy_histogram_of(list(range(100, 3_000)))
+    keys_before = set(rollup.latency_histogram)
+    apply_sample_to_rollup(rollup, _sample("next", 777))
+    assert set(rollup.latency_histogram) == keys_before | {str(histogram_bucket(777))}
 
 
 def test_a_month_of_samples_stays_bounded_where_it_used_to_grow_per_millisecond() -> None:
@@ -274,6 +284,7 @@ def test_an_odd_legacy_key_never_aborts_a_write_or_a_clickhouse_recompute() -> N
     odd = {"100.0": 1, **_legacy_histogram_of(list(range(100, 800)))}
     rollup = new_rollup_for_sample(_sample("seed", 150), period="month", component="uncategorized")
     rollup.latency_histogram = dict(odd)
+    compact_rollup(rollup)
     apply_sample_to_rollup(rollup, _sample("next", 777))
     assert rollup.latency_histogram["100.0"] == 1
     assert len(rollup.latency_histogram) <= MAX_KEYS_TO_TEN_MILLION_MS + 1
@@ -294,6 +305,10 @@ def test_an_odd_legacy_key_never_aborts_a_write_or_a_clickhouse_recompute() -> N
     (month,) = monthly_from_daily([daily])
     assert month.latency_histogram["100.0"] == 1
     assert sum(month.latency_histogram.values()) == sum(odd.values())
+    # ...and the reader skips what it cannot parse instead of raising.
+    assert percentile_from_histogram(month.latency_histogram, 50) == histogram_bucket(
+        _exact_percentile(list(range(100, 800)), 50)
+    )
 
 
 # --- persistence boundary ------------------------------------------------
@@ -342,7 +357,8 @@ def test_store_round_trip_compacts_a_legacy_body_and_preserves_counts() -> None:
     # A month rollup persisted before bucketing: one key per millisecond,
     # well past the bound. Writing ONE more sample through the store must
     # shrink the persisted body and keep every count.
-    seed = _sample("seed", 150)
+    created_at = iso_now()
+    seed = _sample("seed", 150, created_at=created_at)
     (period, component) = next(
         (period, component) for period, component in sample_rollup_ids(seed) if period == "month"
     )
@@ -355,7 +371,7 @@ def test_store_round_trip_compacts_a_legacy_body_and_preserves_counts() -> None:
     table = _MiniBigtable()
     _write_json_row(table, "m", _rollup_key(legacy), legacy)
 
-    write_synthetic_rollups(table, "m", _sample("next", 777))
+    write_synthetic_rollups(table, "m", _sample("next", 777, created_at=created_at))
 
     stored = next(
         row
@@ -424,8 +440,79 @@ def test_status_window_percentiles_from_raw_samples_stay_exact() -> None:
     snapshot = synthetic_status.status_snapshot(samples, now=now)
 
     window = snapshot["windows"]["5m"]["groups"][0]
-    breakdown = snapshot["components"][0]["latency_breakdown_5m"][0]
+    component = next(c for c in snapshot["components"] if c["id"] == "canonical_api")
+    breakdown = component["latency_breakdown_5m"][0]
     assert window["p50_latency_milliseconds"] == _exact_percentile(latencies, 50) == 1240
     assert window["p95_latency_milliseconds"] == _exact_percentile(latencies, 95) == 1270
     assert window["p50_latency_milliseconds"] == breakdown["p50_latency_milliseconds"]
     assert window["p95_latency_milliseconds"] == breakdown["p95_latency_milliseconds"]
+
+
+def test_bigtable_to_clickhouse_backfill_never_carries_legacy_keys() -> None:
+    class _CapturingClickHouse:
+        def __init__(self) -> None:
+            self.payloads: list[bytes] = []
+
+        def query(self, sql: str, *, input_bytes: bytes | None = None, **_: Any) -> str:
+            assert sql.startswith("INSERT INTO synthetic_status_rollups")
+            assert input_bytes is not None
+            self.payloads.append(input_bytes)
+            return ""
+
+    legacy_values = list(range(100, 2_100))
+    rollup = SyntheticRollup(
+        id="legacy",
+        period="day",
+        period_start="2026-05-01T00:00:00Z",
+        component="canonical_api",
+        target="api",
+        probe_type="tls_health",
+        monitor_region="us-central1",
+        sample_count=len(legacy_values),
+        up_count=len(legacy_values),
+        latency_histogram=_legacy_histogram_of(legacy_values),
+    )
+    clickhouse = _CapturingClickHouse()
+
+    backfill_insert_rollups(clickhouse, [rollup])  # type: ignore[arg-type]
+
+    (line,) = clickhouse.payloads[0].split(b"\n")
+    row = json.loads(line)
+    assert len(row["latency_histogram"]) <= MAX_KEYS_TO_TEN_MILLION_MS
+    assert sum(row["latency_histogram"].values()) == len(legacy_values)
+    assert all(str(histogram_bucket(int(key))) == key for key in row["latency_histogram"])
+    assert len(rollup.latency_histogram) == len(legacy_values)  # input left untouched
+
+
+def test_dual_read_fingerprint_treats_legacy_and_bucketed_rows_as_the_same_row() -> None:
+    # Bigtable keeps a closed period's exact keys forever; the ClickHouse
+    # rebuild of that period is bucketed. The parity fingerprint must fold
+    # both, or the shadow comparison mismatches for as long as the row lives.
+    values = list(range(100, 2_100))
+
+    def rollup(histogram: dict[str, int]) -> SyntheticRollup:
+        return SyntheticRollup(
+            id="closed-day",
+            period="day",
+            period_start="2026-05-01T00:00:00Z",
+            component="canonical_api",
+            target="api",
+            probe_type="tls_health",
+            monitor_region="us-central1",
+            sample_count=len(values),
+            up_count=len(values),
+            latency_histogram=histogram,
+            updated_at="2026-05-02T00:00:00Z",
+        )
+
+    legacy = rollup(_legacy_histogram_of(values))
+    bucketed = rollup(_histogram_of(values))
+    assert legacy.latency_histogram != bucketed.latency_histogram
+    assert stable_rows_fingerprint([legacy], grace_seconds=0) == stable_rows_fingerprint(
+        [bucketed], grace_seconds=0
+    )
+    # A genuinely different row still differs.
+    other = rollup(_histogram_of([v + 500 for v in values]))
+    assert stable_rows_fingerprint([legacy], grace_seconds=0) != stable_rows_fingerprint(
+        [other], grace_seconds=0
+    )

--- a/tests/test_synthetic_histogram_bucketing.py
+++ b/tests/test_synthetic_histogram_bucketing.py
@@ -11,10 +11,20 @@ and prove the readers stay correct rather than assuming it.
 
 from __future__ import annotations
 
+import datetime as dt
 import math
 import random
+from typing import Any
 
+from clickhouse.rollup_synthetic import monthly_from_daily
+from trusted_router.storage_gcp_synthetic_rollups import (
+    _rollup_key,
+    _write_json_row,
+    synthetic_rollups,
+    write_synthetic_rollups,
+)
 from trusted_router.storage_models import SyntheticProbeSample, SyntheticRollup
+from trusted_router.synthetic import status as synthetic_status
 from trusted_router.synthetic.rollups import (
     HISTOGRAM_EXACT_BELOW,
     apply_sample_to_rollup,
@@ -23,6 +33,7 @@ from trusted_router.synthetic.rollups import (
     merge_rollups,
     new_rollup_for_sample,
     percentile_from_histogram,
+    sample_rollup_ids,
 )
 
 
@@ -147,8 +158,8 @@ def test_percentiles_from_bucketed_histograms_equal_bucket_of_exact_percentile()
         for percentile in (50, 90, 95, 99):
             exact = _exact_percentile(values, percentile)
             approx = percentile_from_histogram(histogram, percentile)
+            assert approx is not None, (name, percentile)
             assert approx == histogram_bucket(exact), (name, percentile, exact, approx)
-            assert approx is not None
             if exact < HISTOGRAM_EXACT_BELOW:
                 assert approx == exact, (name, percentile)
             else:
@@ -186,7 +197,18 @@ def test_legacy_exact_keys_and_bucketed_keys_merge_to_the_same_answer() -> None:
 
     merged = merge_rollups([legacy, bucketed])
 
+    # Merging is a plain key-sum (it never changes precision), so a mixed
+    # legacy+bucketed walk lands within half a step of the exact percentile:
+    # every element moved by at most that much, so the order statistic does too.
     assert merged["sample_count"] == len(values)
+    for percentile, key in ((50, "p50_latency_milliseconds"), (95, "p95_latency_milliseconds")):
+        exact = _exact_percentile(values, percentile)
+        assert abs(merged[key] - exact) <= exact * 0.05, (percentile, exact, merged[key])
+
+    # And once both sides are bucketed (every persisted row after its next
+    # write), the identity is exact.
+    legacy.latency_histogram = _histogram_of(values[:half])
+    merged = merge_rollups([legacy, bucketed])
     for percentile, key in ((50, "p50_latency_milliseconds"), (95, "p95_latency_milliseconds")):
         exact = _exact_percentile(values, percentile)
         assert merged[key] == histogram_bucket(exact), (percentile, exact, merged[key])
@@ -224,18 +246,18 @@ def test_applying_a_sample_compacts_a_legacy_rollup_and_preserves_counts() -> No
 def test_a_month_of_samples_stays_bounded_where_it_used_to_grow_per_millisecond() -> None:
     rng = random.Random(7)  # noqa: S311 - deterministic fixture, not security
     rollup = new_rollup_for_sample(_sample("first", 150), period="month", component="uncategorized")
-    for index in range(1, 50_000):
+    for index in range(1, 5_000):
         apply_sample_to_rollup(
             rollup, _sample(f"s{index}", int(math.exp(rng.gauss(math.log(150), 0.8))))
         )
-    assert rollup.sample_count == 50_000
+    assert rollup.sample_count == 5_000
     for histogram in (
         rollup.latency_histogram,
         rollup.ttfb_histogram,
         rollup.gateway_processing_histogram,
     ):
         assert len(histogram) <= MAX_KEYS_TO_TEN_MILLION_MS
-        assert sum(histogram.values()) == 50_000
+        assert sum(histogram.values()) == 5_000
     assert percentile_from_histogram(rollup.latency_histogram, 50) is not None
 
 
@@ -244,3 +266,138 @@ def test_compact_histogram_rejects_nothing_it_would_have_read_before() -> None:
     histogram = {"0": 3, "99": 1, "100": 2, "123": 5, "987654": 1}
     assert compact_histogram(histogram) == {"0": 3, "99": 1, "100": 2, "120": 5, "990000": 1}
     assert sum(compact_histogram(histogram).values()) == sum(histogram.values())
+
+
+# --- persistence boundary ------------------------------------------------
+
+
+class _Cell:
+    def __init__(self, value: bytes) -> None:
+        self.value = value
+
+
+class _Row:
+    def __init__(self, value: bytes) -> None:
+        self.cells = {"m": {b"body": [_Cell(value)]}}
+
+
+class _DirectRow:
+    def __init__(self, key: bytes, table: _MiniBigtable) -> None:
+        self.key = key
+        self.table = table
+        self.value: bytes | None = None
+
+    def set_cell(self, _family: str, _qualifier: bytes, value: bytes) -> None:
+        self.value = value
+
+    def commit(self) -> None:
+        if self.value is not None:
+            self.table.rows[self.key] = _Row(self.value)
+
+
+class _MiniBigtable:
+    """Just enough of the Bigtable table API for the rollup write/read path."""
+
+    def __init__(self) -> None:
+        self.rows: dict[bytes, _Row] = {}
+
+    def read_rows(
+        self, *, start_key: bytes, end_key: bytes, limit: int, filter_: Any = None
+    ) -> list[_Row]:
+        return [row for key, row in sorted(self.rows.items()) if start_key <= key < end_key][:limit]
+
+    def direct_row(self, key: bytes) -> _DirectRow:
+        return _DirectRow(key, self)
+
+
+def test_store_round_trip_compacts_a_legacy_body_and_preserves_counts() -> None:
+    # A month rollup persisted before bucketing: one key per millisecond,
+    # well past the bound. Writing ONE more sample through the store must
+    # shrink the persisted body and keep every count.
+    seed = _sample("seed", 150)
+    (period, component) = next(
+        (period, component) for period, component in sample_rollup_ids(seed) if period == "month"
+    )
+    legacy_values = list(range(100, 2_100))
+    legacy = new_rollup_for_sample(seed, period=period, component=component, bucket=False)
+    legacy.latency_histogram = _legacy_histogram_of(legacy_values)
+    legacy.sample_count = len(legacy_values)
+    legacy.up_count = len(legacy_values)
+    assert len(legacy.latency_histogram) > MAX_KEYS_TO_TEN_MILLION_MS
+    table = _MiniBigtable()
+    _write_json_row(table, "m", _rollup_key(legacy), legacy)
+
+    write_synthetic_rollups(table, "m", _sample("next", 777))
+
+    stored = next(
+        row
+        for row in synthetic_rollups(table, "m", period="month", limit=50)
+        if row.component == component
+    )
+    assert stored.sample_count == len(legacy_values) + 1
+    assert len(stored.latency_histogram) <= MAX_KEYS_TO_TEN_MILLION_MS
+    assert sum(stored.latency_histogram.values()) == len(legacy_values) + 1
+    assert all(str(histogram_bucket(int(key))) == key for key in stored.latency_histogram)
+    exact_p95 = _exact_percentile([*legacy_values, 777], 95)
+    assert percentile_from_histogram(stored.latency_histogram, 95) == histogram_bucket(exact_p95)
+
+
+def test_clickhouse_month_rollups_are_bucketed_even_from_legacy_daily_rows() -> None:
+    # clickhouse/rollup_synthetic.py is a second rollup writer: month rows are
+    # folded from daily rows it reads back, so it must bucket on its own.
+    def daily(day: int, values: list[int]) -> SyntheticRollup:
+        return SyntheticRollup(
+            id=f"day{day}",
+            period="day",
+            period_start=f"2026-05-{day:02d}T00:00:00Z",
+            component="canonical_api",
+            target="api",
+            probe_type="tls_health",
+            monitor_region="us-central1",
+            sample_count=len(values),
+            up_count=len(values),
+            latency_histogram=_legacy_histogram_of(values),
+            ttfb_histogram=_legacy_histogram_of([v // 2 for v in values]),
+        )
+
+    first, second = list(range(100, 1_100)), list(range(1_000, 2_000))
+    (month,) = monthly_from_daily([daily(1, first), daily(2, second)])
+
+    assert month.period == "month"
+    assert month.sample_count == len(first) + len(second)
+    for histogram in (month.latency_histogram, month.ttfb_histogram):
+        assert len(histogram) <= MAX_KEYS_TO_TEN_MILLION_MS
+        assert sum(histogram.values()) == len(first) + len(second)
+    exact_p50 = _exact_percentile(first + second, 50)
+    assert percentile_from_histogram(month.latency_histogram, 50) == histogram_bucket(exact_p50)
+
+
+def test_status_window_percentiles_from_raw_samples_stay_exact() -> None:
+    # The 5m window builds transient rollups from raw samples; those are never
+    # persisted, so they keep exact keys and agree with the sibling fields
+    # computed straight from the same samples.
+    now = dt.datetime(2026, 5, 5, 12, 4, tzinfo=dt.UTC)
+    latencies = [1210, 1230, 1240, 1249, 1270]
+    samples = [
+        SyntheticProbeSample(
+            id=f"s{index}",
+            probe_type="attestation_nonce",
+            target="canonical",
+            target_url="https://api.trustedrouter.com/health",
+            monitor_region="us-central1",
+            status="up",
+            latency_milliseconds=latency,
+            ttfb_milliseconds=latency,
+            created_at=f"2026-05-05T12:0{index}:00Z",
+        )
+        for index, latency in enumerate(latencies)
+    ]
+
+    snapshot = synthetic_status.status_snapshot(samples, now=now)
+
+    window = snapshot["windows"]["5m"]["groups"][0]
+    breakdown = snapshot["components"][0]["latency_breakdown_5m"][0]
+    assert window["p50_latency_milliseconds"] == _exact_percentile(latencies, 50) == 1240
+    assert window["p95_latency_milliseconds"] == _exact_percentile(latencies, 95) == 1270
+    assert window["p50_latency_milliseconds"] == breakdown["p50_latency_milliseconds"]
+    assert window["p95_latency_milliseconds"] == breakdown["p95_latency_milliseconds"]

--- a/tests/test_synthetic_histogram_bucketing.py
+++ b/tests/test_synthetic_histogram_bucketing.py
@@ -1,0 +1,230 @@
+"""Bucketed synthetic histograms: bounded key cardinality, exact-rank
+percentiles, and safe coexistence with rows written before bucketing.
+
+Before this, `_increment_histogram` keyed every distinct millisecond, so a
+month rollup for a probe firing every few seconds accumulated hundreds of
+thousands of JSON keys — and on the Postgres/DSQL and Bigtable backends that
+whole body is re-read and re-written on every sample (see
+`PostgresStore.record_synthetic_probe_sample`). These tests pin the bound
+and prove the readers stay correct rather than assuming it.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+
+from trusted_router.storage_models import SyntheticProbeSample, SyntheticRollup
+from trusted_router.synthetic.rollups import (
+    HISTOGRAM_EXACT_BELOW,
+    apply_sample_to_rollup,
+    compact_histogram,
+    histogram_bucket,
+    merge_rollups,
+    new_rollup_for_sample,
+    percentile_from_histogram,
+)
+
+# Worst case for values in 0..10^7 ms: 100 exact keys + 90 per decade above.
+MAX_KEYS_TO_TEN_MILLION_MS = HISTOGRAM_EXACT_BELOW + 90 * 5
+
+
+def _exact_percentile(values: list[int], percentile: int) -> int:
+    """The same rank rule `percentile_from_histogram` uses, on raw values."""
+    ordered = sorted(values)
+    threshold = max(1, math.ceil(len(ordered) * percentile / 100))
+    return ordered[threshold - 1]
+
+
+def _histogram_of(values: list[int]) -> dict[str, int]:
+    histogram: dict[str, int] = {}
+    for value in values:
+        key = str(histogram_bucket(value))
+        histogram[key] = histogram.get(key, 0) + 1
+    return histogram
+
+
+def _legacy_histogram_of(values: list[int]) -> dict[str, int]:
+    """Exactly what pre-bucketing writers stored: one key per millisecond."""
+    histogram: dict[str, int] = {}
+    for value in values:
+        key = str(max(int(value), 0))
+        histogram[key] = histogram.get(key, 0) + 1
+    return histogram
+
+
+def _sample(
+    sample_id: str, latency: int, *, created_at: str = "2026-05-05T12:00:00Z"
+) -> SyntheticProbeSample:
+    return SyntheticProbeSample(
+        id=sample_id,
+        probe_type="tls_health",
+        target="api",
+        target_url="https://api.trustedrouter.com/health",
+        monitor_region="us-central1",
+        status="up",
+        latency_milliseconds=latency,
+        ttfb_milliseconds=latency // 2,
+        dns_milliseconds=3,
+        tcp_connect_milliseconds=12,
+        tls_handshake_milliseconds=26,
+        gateway_processing_milliseconds=max(latency - 60, 0),
+        created_at=created_at,
+    )
+
+
+def _distributions() -> dict[str, list[int]]:
+    rng = random.Random(20260902)  # noqa: S311 - deterministic fixture, not security
+    return {
+        "uniform_ms": [rng.randint(0, 5_000) for _ in range(20_000)],
+        "sub_100ms_exact": [rng.randint(0, 99) for _ in range(5_000)],
+        "lognormal_gateway": [int(math.exp(rng.gauss(math.log(180), 0.6))) for _ in range(20_000)],
+        "heavy_tail_timeouts": [rng.randint(20, 400) for _ in range(9_500)]
+        + [rng.randint(30_000, 120_000) for _ in range(500)],
+        "single_value": [4_242] * 1_000,
+    }
+
+
+# --- the map itself -------------------------------------------------------
+
+
+def test_bucket_is_exact_below_threshold_and_two_significant_digits_above() -> None:
+    assert [histogram_bucket(v) for v in (0, 1, 57, 99)] == [0, 1, 57, 99]
+    assert histogram_bucket(100) == 100
+    assert histogram_bucket(104) == 100
+    assert histogram_bucket(105) == 110
+    assert histogram_bucket(123) == 120
+    assert histogram_bucket(994) == 990
+    assert histogram_bucket(995) == 1000
+    assert histogram_bucket(1_049) == 1_000
+    assert histogram_bucket(1_050) == 1_100
+    assert histogram_bucket(87_654) == 88_000
+    assert histogram_bucket(-5) == 0
+
+
+def test_bucket_is_monotone_and_idempotent() -> None:
+    previous = histogram_bucket(0)
+    for value in range(1, 300_000):
+        bucket = histogram_bucket(value)
+        assert bucket >= previous, (value, bucket, previous)
+        assert histogram_bucket(bucket) == bucket, (value, bucket)
+        # Never more than half a bucket away, and never more than 5% above 100.
+        assert abs(bucket - value) <= (value // 20 if value >= HISTOGRAM_EXACT_BELOW else 0)
+        previous = bucket
+
+
+def test_key_cardinality_is_bounded_regardless_of_distinct_values() -> None:
+    every_millisecond = {str(v): 1 for v in range(0, 2_000_000)}
+    compacted = compact_histogram(every_millisecond)
+    assert len(compacted) <= MAX_KEYS_TO_TEN_MILLION_MS
+    assert len(compacted) < 600
+    assert sum(compacted.values()) == 2_000_000
+
+
+# --- readers stay correct ------------------------------------------------
+
+
+def test_percentiles_from_bucketed_histograms_equal_bucket_of_exact_percentile() -> None:
+    for name, values in _distributions().items():
+        histogram = _histogram_of(values)
+        assert len(histogram) <= MAX_KEYS_TO_TEN_MILLION_MS, name
+        for percentile in (50, 90, 95, 99):
+            exact = _exact_percentile(values, percentile)
+            approx = percentile_from_histogram(histogram, percentile)
+            assert approx == histogram_bucket(exact), (name, percentile, exact, approx)
+            assert approx is not None
+            if exact < HISTOGRAM_EXACT_BELOW:
+                assert approx == exact, (name, percentile)
+            else:
+                assert abs(approx - exact) <= exact * 0.05, (name, percentile, exact, approx)
+
+
+def test_legacy_exact_keys_and_bucketed_keys_merge_to_the_same_answer() -> None:
+    values = _distributions()["lognormal_gateway"]
+    half = len(values) // 2
+    legacy = SyntheticRollup(
+        id="legacy",
+        period="month",
+        period_start="2026-05-01T00:00:00Z",
+        component="canonical_api",
+        target="api",
+        probe_type="tls_health",
+        monitor_region="us-central1",
+        sample_count=half,
+        up_count=half,
+        latency_histogram=_legacy_histogram_of(values[:half]),
+    )
+    bucketed = SyntheticRollup(
+        id="bucketed",
+        period="month",
+        period_start="2026-05-01T00:00:00Z",
+        component="canonical_api",
+        target="api",
+        probe_type="tls_health",
+        monitor_region="us-central1",
+        sample_count=len(values) - half,
+        up_count=len(values) - half,
+        latency_histogram=_histogram_of(values[half:]),
+    )
+    assert len(legacy.latency_histogram) > MAX_KEYS_TO_TEN_MILLION_MS  # the old shape
+
+    merged = merge_rollups([legacy, bucketed])
+
+    assert merged["sample_count"] == len(values)
+    for percentile, key in ((50, "p50_latency_milliseconds"), (95, "p95_latency_milliseconds")):
+        exact = _exact_percentile(values, percentile)
+        assert merged[key] == histogram_bucket(exact), (percentile, exact, merged[key])
+
+
+def test_applying_a_sample_compacts_a_legacy_rollup_and_preserves_counts() -> None:
+    values = _distributions()["uniform_ms"]
+    legacy = new_rollup_for_sample(
+        _sample("seed", values[0]), period="month", component="uncategorized"
+    )
+    legacy.latency_histogram = _legacy_histogram_of(values)
+    legacy.ttfb_histogram = _legacy_histogram_of([v // 2 for v in values])
+    legacy.sample_count = len(values)
+    legacy.up_count = len(values)
+    assert len(legacy.latency_histogram) > MAX_KEYS_TO_TEN_MILLION_MS
+
+    apply_sample_to_rollup(legacy, _sample("next", 777))
+
+    assert legacy.sample_count == len(values) + 1
+    assert len(legacy.latency_histogram) <= MAX_KEYS_TO_TEN_MILLION_MS
+    assert len(legacy.ttfb_histogram) <= MAX_KEYS_TO_TEN_MILLION_MS
+    assert sum(legacy.latency_histogram.values()) == len(values) + 1
+    assert sum(legacy.ttfb_histogram.values()) == len(values) + 1
+    assert legacy.latency_histogram[str(histogram_bucket(777))] >= 1
+    # Every stored key is now a bucket representative: a second apply is a no-op fold.
+    before = dict(legacy.latency_histogram)
+    apply_sample_to_rollup(legacy, _sample("again", 777))
+    assert set(legacy.latency_histogram) == set(before)
+    assert (
+        legacy.latency_histogram[str(histogram_bucket(777))]
+        == before[str(histogram_bucket(777))] + 1
+    )
+
+
+def test_a_month_of_samples_stays_bounded_where_it_used_to_grow_per_millisecond() -> None:
+    rng = random.Random(7)  # noqa: S311 - deterministic fixture, not security
+    rollup = new_rollup_for_sample(_sample("first", 150), period="month", component="uncategorized")
+    for index in range(1, 50_000):
+        apply_sample_to_rollup(
+            rollup, _sample(f"s{index}", int(math.exp(rng.gauss(math.log(150), 0.8))))
+        )
+    assert rollup.sample_count == 50_000
+    for histogram in (
+        rollup.latency_histogram,
+        rollup.ttfb_histogram,
+        rollup.gateway_processing_histogram,
+    ):
+        assert len(histogram) <= MAX_KEYS_TO_TEN_MILLION_MS
+        assert sum(histogram.values()) == 50_000
+    assert percentile_from_histogram(rollup.latency_histogram, 50) is not None
+
+
+def test_compact_histogram_rejects_nothing_it_would_have_read_before() -> None:
+    # Whatever percentile_from_histogram could parse, compaction can fold.
+    histogram = {"0": 3, "99": 1, "100": 2, "123": 5, "987654": 1}
+    assert compact_histogram(histogram) == {"0": 3, "99": 1, "100": 2, "120": 5, "990000": 1}
+    assert sum(compact_histogram(histogram).values()) == sum(histogram.values())

--- a/tests/test_synthetic_histogram_bucketing.py
+++ b/tests/test_synthetic_histogram_bucketing.py
@@ -25,8 +25,15 @@ from trusted_router.synthetic.rollups import (
     percentile_from_histogram,
 )
 
-# Worst case for values in 0..10^7 ms: 100 exact keys + 90 per decade above.
-MAX_KEYS_TO_TEN_MILLION_MS = HISTOGRAM_EXACT_BELOW + 90 * 5
+
+def _max_keys_up_to(power_of_ten: int) -> int:
+    """Exact key count for every integer in 0..10**power_of_ten inclusive:
+    100 exact keys, 90 per full decade above, plus the top value's own bucket."""
+    return HISTOGRAM_EXACT_BELOW + 90 * (power_of_ten - 2) + 1
+
+
+# Worst case for values in 0..10^7 ms inclusive (551 keys).
+MAX_KEYS_TO_TEN_MILLION_MS = _max_keys_up_to(7)
 
 
 def _exact_percentile(values: list[int], percentile: int) -> int:
@@ -119,6 +126,15 @@ def test_key_cardinality_is_bounded_regardless_of_distinct_values() -> None:
     assert len(compacted) <= MAX_KEYS_TO_TEN_MILLION_MS
     assert len(compacted) < 600
     assert sum(compacted.values()) == 2_000_000
+
+
+def test_key_cardinality_formula_is_exact_on_an_inclusive_decade_range() -> None:
+    # Pins the formula, not just an upper bound: every integer in 0..10^6
+    # inclusive lands in exactly 100 + 90*4 + 1 buckets (the top value,
+    # 1_000_000, is a bucket of its own). Sweeping 0..10^7 would be the same
+    # arithmetic with one more decade, at 10x the runtime.
+    every_millisecond = {str(v): 1 for v in range(0, 10**6 + 1)}
+    assert len(compact_histogram(every_millisecond)) == _max_keys_up_to(6) == 461
 
 
 # --- readers stay correct ------------------------------------------------

--- a/tests/test_synthetic_histogram_bucketing.py
+++ b/tests/test_synthetic_histogram_bucketing.py
@@ -261,11 +261,39 @@ def test_a_month_of_samples_stays_bounded_where_it_used_to_grow_per_millisecond(
     assert percentile_from_histogram(rollup.latency_histogram, 50) is not None
 
 
-def test_compact_histogram_rejects_nothing_it_would_have_read_before() -> None:
-    # Whatever percentile_from_histogram could parse, compaction can fold.
-    histogram = {"0": 3, "99": 1, "100": 2, "123": 5, "987654": 1}
-    assert compact_histogram(histogram) == {"0": 3, "99": 1, "100": 2, "120": 5, "990000": 1}
-    assert sum(compact_histogram(histogram).values()) == sum(histogram.values())
+def test_compact_histogram_folds_integer_keys_and_keeps_odd_keys_verbatim() -> None:
+    # Whatever percentile_from_histogram could parse, compaction folds; a key
+    # it could not parse is kept exactly as every writer kept it before.
+    histogram = {"0": 3, "99": 1, "100": 2, "123": 5, "987654": 1, "100.0": 1}
+    compacted = compact_histogram(histogram)
+    assert compacted == {"0": 3, "99": 1, "100": 2, "120": 5, "990000": 1, "100.0": 1}
+    assert sum(compacted.values()) == sum(histogram.values())
+
+
+def test_an_odd_legacy_key_never_aborts_a_write_or_a_clickhouse_recompute() -> None:
+    odd = {"100.0": 1, **_legacy_histogram_of(list(range(100, 800)))}
+    rollup = new_rollup_for_sample(_sample("seed", 150), period="month", component="uncategorized")
+    rollup.latency_histogram = dict(odd)
+    apply_sample_to_rollup(rollup, _sample("next", 777))
+    assert rollup.latency_histogram["100.0"] == 1
+    assert len(rollup.latency_histogram) <= MAX_KEYS_TO_TEN_MILLION_MS + 1
+    assert sum(rollup.latency_histogram.values()) == sum(odd.values()) + 1
+
+    daily = SyntheticRollup(
+        id="day1",
+        period="day",
+        period_start="2026-05-01T00:00:00Z",
+        component="canonical_api",
+        target="api",
+        probe_type="tls_health",
+        monitor_region="us-central1",
+        sample_count=sum(odd.values()),
+        up_count=sum(odd.values()),
+        latency_histogram=dict(odd),
+    )
+    (month,) = monthly_from_daily([daily])
+    assert month.latency_histogram["100.0"] == 1
+    assert sum(month.latency_histogram.values()) == sum(odd.values())
 
 
 # --- persistence boundary ------------------------------------------------

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -1519,7 +1519,8 @@ def test_synthetic_rollups_are_idempotent_and_monthly_queryable() -> None:
 
     assert canonical.sample_count == 1
     assert canonical.up_count == 1
-    assert canonical.latency_histogram == {"123": 1}
+    # 123 ms lands in its 2-significant-digit bucket; see histogram_bucket.
+    assert canonical.latency_histogram == {"120": 1}
 
 
 def test_synthetic_rollup_retains_latency_phase_histograms() -> None:


### PR DESCRIPTION
## Why

`_increment_histogram` (`synthetic/rollups.py`) keyed every distinct millisecond. A `SyntheticRollup` carries six such histograms, and `record_synthetic_probe_sample` on the Postgres/Aurora DSQL backend (`storage_postgres.py`) fans each sample into 3 rollups (hour/day/month) with a full-body `SELECT ... FOR UPDATE` + upsert for existing rows. A month rollup for a high-frequency probe therefore grew one key per distinct millisecond for the whole month, and every later sample re-read and re-wrote that growing JSONB body. Same shape on Bigtable (`storage_gcp_synthetic_rollups.py`).

## What

- `histogram_bucket(value)`: exact below 100 ms, then 2 significant digits (log-linear, round to nearest). Monotone and idempotent. Bounds a histogram to 551 keys over 0..10^7 ms.
- Bucketing happens at the **persistence boundary**: `_increment_histogram` writes bucket keys; `compact_rollup(rollup)` folds a legacy exact-key body and is called by the Postgres and Bigtable stores right after they read a row for update (inside the same transaction on Postgres). It is deliberately not inside `apply_sample_to_rollup`: batch rebuilders (ClickHouse 5-minute recompute, backfills, in-memory store) never see legacy rows, and a per-sample scan there measured 6–14× slower.
- `new_rollup_for_sample` / `apply_sample_to_rollup` take `bucket=False` for **transient, never-persisted** rollups. The only caller is the status page's raw-sample window (`status.py` `_window_rollup_with_rollup_backfill`), so the 5m window's p50/p95 stay identical to the exact percentiles reported beside them.
- `_merge_histograms` is a plain key-sum: merging never changes precision. A mixed legacy+bucketed walk stays within half a step of the exact percentile.
- The two other rollup writers bucket too: `clickhouse/rollup_synthetic.py` `_merge_rollup` (month rows folded from daily rows) and `clickhouse/backfill_operational_analytics.py` `insert_rollups` (Bigtable → ClickHouse replay).
- Both parity fingerprints (`stable_rows_fingerprint` for the dual-read shadow, `canonical_fingerprint` for the scheduled parity timer) fold the six histograms before hashing: a Bigtable row for a closed period keeps exact keys forever while the ClickHouse rebuild is bucketed; without this the shadow comparison mismatched persistently.
- Tolerance both ways: a non-integer legacy key is kept verbatim on every write path (never aborts a sample transaction, recompute, or backfill), and `percentile_from_histogram` skips it instead of raising.
- Keys remain integer-millisecond strings, so every reader that sorts keys with `int()` is unchanged in shape. `client_reliability.py` has its own fixed-bucket histograms and is untouched. `ROLLUP_HISTOGRAM_FIELDS` is defined once in `rollups.py`.

## Correctness

The map is monotone and count-preserving, so a percentile computed from a fully bucketed histogram is exactly `bucket(exact percentile)`: error at most half a step, i.e. within ±5% above 100 ms and 0 below. Rounding to nearest keeps published p50/p95 unbiased (it can sit slightly under the true value as well as over; documented in the docstring).

## Migration

None needed for correctness. Pre-bucketing rows hold finer-grained integer keys that read correctly today; a store folds them the next time it updates the row, so an open period's body shrinks on its next read-modify-write. Rows for already-closed periods keep their old shape until retention (size-only effect; percentiles and parity stay correct). A one-off compaction pass for closed rows is a possible follow-up, not a prerequisite.

## Deploy notes (ClickHouse host)

- After the ClickHouse host picks up this change, run `python -m clickhouse.rollup_synthetic` (or start `tr-clickhouse-synthetic-rollup.service`) before the parity timer's next tick, so rows written by the previous worker run don't mismatch for one cycle.
- The first post-deploy rollup rewrite touches 14 days but `archive_daily` revisits 7; run `archive_daily --backfill` (or per-day for days 8–14) for `synthetic_status_rollups` if archived fingerprints matter.

## Tests

`tests/test_synthetic_histogram_bucketing.py` (18): bound (2M distinct values → < 600 keys, counts preserved), exact-formula bound on an inclusive decade range, monotone + idempotent over 300k values with the 5% bound, percentile identity on uniform / lognormal / heavy-tail / constant distributions at p50/p90/p95/p99, mixed legacy+bucketed merge within 5% and exact identity once both are bucketed, `compact_rollup` folds/preserves/idempotent, `apply_sample_to_rollup` does not scan, month rollup stays bounded, odd legacy key never aborts a write or a recompute and the reader skips it, a legacy body persisted in a Bigtable fake shrinks after one store write (clock-anchored), ClickHouse month rows bounded from legacy daily rows, Bigtable→ClickHouse backfill never carries legacy keys, the status 5m window matches raw-sample percentiles, both parity fingerprints (`stable_rows_fingerprint` and the parity timer's `canonical_fingerprint`) treat a legacy row and its bucketed twin as equal while still distinguishing a different row, and the real Postgres `record_synthetic_probe_sample` body writes back a bucketed rollup inside the same transaction as its FOR UPDATE read. One existing assertion updated (`{"123": 1}` → `{"120": 1}`).

Reviewed over three rounds by a multi-lens adversarial workflow with refutation voting and by codex; every confirmed finding addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

