### PR TITLE
tests: make two timing-sensitive tests deterministic without weakening them

### DIFF
--- a/src/trusted_router/routes/internal/synthetic.py
+++ b/src/trusted_router/routes/internal/synthetic.py
@@ -6,6 +6,7 @@ import logging
 import random
 import threading
 import time
+from collections.abc import Awaitable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict
 from typing import Any
@@ -151,6 +152,15 @@ async def _run_with_held_slot(
         slot.release()
 
 
+async def _wait_for_run_deadline(
+    run: Awaitable[dict[str, Any]],
+    *,
+    timeout: float,
+) -> dict[str, Any]:
+    """Wait for one synthetic run behind an injectable deadline boundary."""
+    return await asyncio.wait_for(run, timeout=timeout)
+
+
 async def _run_with_deadline(
     settings: Settings,
     body: dict[str, Any],
@@ -158,7 +168,7 @@ async def _run_with_deadline(
 ) -> dict[str, Any]:
     started = time.monotonic()
     try:
-        return await asyncio.wait_for(
+        return await _wait_for_run_deadline(
             _run_with_held_slot(settings, body, slot),
             timeout=settings.synthetic_run_deadline_seconds,
         )
@@ -194,7 +204,7 @@ async def _run_high_authority_with_deadline(
 ) -> dict[str, Any]:
     started = time.monotonic()
     try:
-        return await asyncio.wait_for(
+        return await _wait_for_run_deadline(
             _run_high_authority_with_held_slot(settings, body, slot),
             timeout=settings.synthetic_run_deadline_seconds,
         )

--- a/tests/test_public_analytics_freshness.py
+++ b/tests/test_public_analytics_freshness.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import datetime as dt
 import logging
+import threading
 import time
 
 import httpx
@@ -443,27 +444,35 @@ def test_a_leaky_reason_cannot_reach_the_wire_either(client: TestClient, monkeyp
 
 
 def test_a_backend_that_answers_slowly_does_not_hold_the_status_build_open(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The bound this module OWNS, tested by exceeding it twentyfold.
+    """The bound this module owns, proven by return-before-backend ordering.
 
     The failure it prevents: this read sits on the public /status.json build
     path inside an async handler, so a blocking wait there stops the EVENT LOOP
     -- every request this process is serving, not one worker thread.
 
-    This is written to FAIL against an unbounded implementation, which the
-    previous version of it could not: a backend that slept 0.25s under a 2.0s
-    assertion passes whether anything bounds it or not. Here the backend takes
-    a full second, the bound is 50ms, and the assertion is a tenth of a second
-    -- so the only way to pass is to stop waiting. It also does not rely on the
-    store's own timeouts: this backend does not have any, which is precisely
-    the case (a driver that ignores its cap, a backend added later) the
+    The backend is held on an event with no timeout of its own. The status
+    build must finish while that event is still closed, which cannot happen if
+    the caller waits for the backend. Five-second waits are only hang
+    backstops. This does not rely on the store's own timeouts, which is exactly
+    the case (a driver that ignores its cap, or a backend added later) the
     caller-side bound exists for.
     """
     monkeypatch.setattr(public_routes, "STATUS_ANALYTICS_READ_TIMEOUT_SECONDS", 0.05)
+    backend_started = threading.Event()
+    release_backend = threading.Event()
+    backend_finished = threading.Event()
+    status_finished = threading.Event()
+    sections: list[object] = []
+    errors: list[BaseException] = []
 
     def answers_eventually() -> OutboxFreshness:
-        time.sleep(1.0)
+        backend_started.set()
+        try:
+            release_backend.wait()
+        finally:
+            backend_finished.set()
         return OutboxFreshness(backend=BACKEND_POSTGRES, oldest_enqueued_at=None)
 
     monkeypatch.setattr(
@@ -473,12 +482,27 @@ def test_a_backend_that_answers_slowly_does_not_hold_the_status_build_open(
         raising=False,
     )
 
-    started = time.monotonic()
-    section = _snapshot(monkeypatch)[ANALYTICS_STATUS_KEY]
-    elapsed = time.monotonic() - started
+    def build_status() -> None:
+        try:
+            sections.append(_snapshot(monkeypatch)[ANALYTICS_STATUS_KEY])
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            status_finished.set()
 
-    assert section == {"available": False, "reason": REASON_UNREACHABLE}
-    assert elapsed < 0.5, "the status build waited on the backend rather than bounding it"
+    status_thread = threading.Thread(target=build_status, name="test-status-build")
+    status_thread.start()
+    try:
+        assert backend_started.wait(timeout=5), "status build did not start the backend read"
+        assert status_finished.wait(timeout=5), "status build waited on the blocked backend"
+        assert not errors
+        assert sections == [{"available": False, "reason": REASON_UNREACHABLE}]
+        assert not backend_finished.is_set(), "backend answered before the status build returned"
+    finally:
+        release_backend.set()
+        status_thread.join(timeout=5)
+    assert not status_thread.is_alive(), "status build did not stop after backend release"
+    assert backend_finished.wait(timeout=5), "backend worker did not stop after release"
 
 
 def test_a_backend_that_raises_after_its_own_timeout_publishes_unavailable(

--- a/tests/test_synthetic_admission.py
+++ b/tests/test_synthetic_admission.py
@@ -118,6 +118,8 @@ def test_detached_run_deadline_releases_slot_and_logs_tripwire(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     started = threading.Event()
+    deadline_armed = threading.Event()
+    expire_deadline = threading.Event()
     run_calls = 0
 
     async def blocked_forever(
@@ -130,34 +132,65 @@ def test_detached_run_deadline_releases_slot_and_logs_tripwire(
         await asyncio.Event().wait()
         raise AssertionError("unreachable")
 
+    async def controlled_deadline(
+        run: object,
+        *,
+        timeout: float,
+    ) -> dict[str, object]:
+        assert timeout == 0.2
+        task = asyncio.ensure_future(run)  # type: ignore[arg-type]
+        # Let the child reach the blocked backend before exposing the explicit
+        # deadline control to the request thread.
+        await asyncio.sleep(0)
+        assert started.is_set()
+        deadline_armed.set()
+        assert await asyncio.to_thread(expire_deadline.wait, 5.0)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        raise TimeoutError
+
     monkeypatch.setattr(synthetic_routes, "_run_and_record", blocked_forever)
+    monkeypatch.setattr(synthetic_routes, "_wait_for_run_deadline", controlled_deadline)
     with caplog.at_level("ERROR"), _client(synthetic_run_deadline_seconds=0.2) as client:
-        first = client.post(
-            "/v1/internal/synthetic/run",
-            headers=_headers(),
-            json={"detach": True, "rotation_count": 8},
-        )
-        assert first.status_code == 202
-        assert started.wait(timeout=1)
+        try:
+            first = client.post(
+                "/v1/internal/synthetic/run",
+                headers=_headers(),
+                json={"detach": True, "rotation_count": 8},
+            )
+            assert first.status_code == 202
+            assert deadline_armed.wait(timeout=5), "detached run did not arm its deadline"
+            assert started.is_set()
 
-        overlap = client.post(
-            "/v1/internal/synthetic/run",
-            headers=_headers(),
-            json={"detach": True},
-        )
-        assert overlap.status_code == 429
+            # The test controls expiration, so this request necessarily lands
+            # while the first run still owns admission.
+            overlap = client.post(
+                "/v1/internal/synthetic/run",
+                headers=_headers(),
+                json={"detach": True},
+            )
+            assert overlap.status_code == 429
 
-        deadline = time.monotonic() + 2
-        while synthetic_routes._BACKGROUND_RUNS and time.monotonic() < deadline:  # noqa: SLF001
-            time.sleep(0.01)
-        assert not synthetic_routes._BACKGROUND_RUNS  # noqa: SLF001
+            expire_deadline.set()
+            deadline = time.monotonic() + 5
+            while (
+                synthetic_routes._BACKGROUND_RUNS  # noqa: SLF001
+                and time.monotonic() < deadline
+            ):
+                time.sleep(0.01)
+            assert not synthetic_routes._BACKGROUND_RUNS  # noqa: SLF001
 
-        recovered = client.post(
-            "/v1/internal/synthetic/run",
-            headers=_headers(),
-            json={"detach": True, "monitor_region": "recovered"},
-        )
-        assert recovered.status_code == 202
+            recovered = client.post(
+                "/v1/internal/synthetic/run",
+                headers=_headers(),
+                json={"detach": True, "monitor_region": "recovered"},
+            )
+            assert recovered.status_code == 202
+        finally:
+            expire_deadline.set()
 
     deadline_logs = [
         record.getMessage()


### PR DESCRIPTION
Both tests flaked on GitHub-hosted runners on 2026-09-02 and each blocked a production deploy through `gate-on-ci`.

- `test_detached_run_deadline_releases_slot_and_logs_tripwire` raced the 0.2 s run deadline: on a loaded runner it could expire and release the admission slot before the overlapping request was posted, so the overlap was admitted (202) instead of refused (429). The synthetic route gains `_wait_for_run_deadline`, a thin injectable wrapper around the existing `asyncio.wait_for` with no behaviour change; the test holds expiry until the first run has started and the overlap is refused, then triggers expiry and asserts slot recovery and the tripwire log. Wall-clock waits are 5 s hang backstops only.
- `test_a_backend_that_answers_slowly_does_not_hold_the_status_build_open` asserted `elapsed < 0.5` while a 1 s backend was bounded at 50 ms, which a slow runner exceeded (0.88 s) even though the bound worked. The backend now blocks on an event and the test asserts the status build returns unavailable while the backend is provably still blocked; the 5 s wait is a hang backstop.

Review: isolated snapshot; ruff; mypy on the route; each test 20/20; both full files and twelve neighbouring suites green; two production mutations each failing deterministically 5/5 (admission never refusing an overlap; the status build waiting on the backend). A third wall-clock assertion of the same shape was reported by another session in `tests/test_console_credits_stripe_deferred.py` and is left for a follow-up.

Written by codex; reviewed by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)