### PR TITLE
spend-lease: MonetaryMismatchProof and a typed mirror refusal (decision 56)

### DIFF
--- a/src/trusted_router/spend_lease_ledger.py
+++ b/src/trusted_router/spend_lease_ledger.py
@@ -37,6 +37,7 @@ from trusted_router.spend_lease_state import (
     Created,
     LeaseAllocationTransition,
     LeaseTransition,
+    MonetaryMismatchProof,
     RecoveryProof,
     RowBindingMismatch,
     SpendLease,
@@ -708,6 +709,12 @@ def _serialize_contradiction(proof: ContradictionProof | None) -> dict[str, obje
         }
     if isinstance(proof, ConflictingClaim):
         return {"provisional_id": proof.provisional_id, "type": "conflicting_claim"}
+    if isinstance(proof, MonetaryMismatchProof):
+        return {
+            "allocated_micro": proof.allocated_micro,
+            "finalized_cost_microdollars": proof.finalized_cost_microdollars,
+            "type": "monetary_mismatch",
+        }
     return {
         "authorization_id": proof.authorization_id,
         "observed_tuple_or_absent": (
@@ -811,6 +818,13 @@ def _deserialize_contradiction(value: object) -> ContradictionProof | None:
             observed_tuple_or_absent=(
                 None if observed is None else _deserialize_binding(observed)
             ),
+        )
+    if discriminator == "monetary_mismatch":
+        return MonetaryMismatchProof(
+            finalized_cost_microdollars=_integer(
+                payload, "finalized_cost_microdollars"
+            ),
+            allocated_micro=_integer(payload, "allocated_micro"),
         )
     raise ValueError(f"unknown contradiction_proof discriminator {discriminator!r}")
 

--- a/src/trusted_router/spend_lease_state.py
+++ b/src/trusted_router/spend_lease_state.py
@@ -1,11 +1,11 @@
 """Pure state machine for authoritative spend-lease allocations.
 
-Implements Stage B decisions 9–22 and decision 46 of the spend-lease design
+Implements Stage B decisions 9–22, 46, and 56 of the spend-lease design
 record; each invariant below cites its decision.
 
 This module contains no storage or clock I/O.  It implements design decisions
-9--22: lifetime-monotonic capacity (9), proof-derived allocation terminality
-(10, 14, 20, 22), separate grant generation and CAS version (12), the ordered
+9--22 and 56: lifetime-monotonic capacity (9), proof-derived allocation terminality
+(10, 14, 20, 22, 56), separate grant generation and CAS version (12), the ordered
 authorization-first replay table (13), admission/freeze rules (15, 16, 18),
 construction-time amount and provenance checks (17), the unified open predicate
 (18--20, 22), owner-fenced bind/compensate transitions (21--22), and durable
@@ -45,6 +45,18 @@ class SpendLeaseInvariantError(SpendLeaseStateError):
 
 class SpendLeaseConflictError(SpendLeaseStateError):
     """A transition conflicts with the allocation's durable state."""
+
+
+class SpendLeaseMonetaryMismatch(SpendLeaseConflictError):
+    """A finalized authorization cost exceeds its committed allocation."""
+
+    finalized_cost_microdollars: int
+    allocated_micro: int
+
+    def __init__(self, *, finalized_cost_microdollars: int, allocated_micro: int) -> None:
+        super().__init__("settled actual must fit inside the allocation")
+        self.finalized_cost_microdollars = finalized_cost_microdollars
+        self.allocated_micro = allocated_micro
 
 
 class SpendLeaseProofError(SpendLeaseConflictError):
@@ -258,7 +270,21 @@ class RowBindingMismatch:
             raise SpendLeaseInvariantError("row authorization ID is required")
 
 
-ContradictionProof: TypeAlias = ConflictingBound | ConflictingClaim | RowBindingMismatch
+@dataclass(frozen=True, slots=True)
+class MonetaryMismatchProof:
+    finalized_cost_microdollars: int
+    allocated_micro: int
+
+    def __post_init__(self) -> None:
+        if self.finalized_cost_microdollars <= self.allocated_micro:
+            raise SpendLeaseProofError(
+                "monetary mismatch proof requires finalized cost above allocation"
+            )
+
+
+ContradictionProof: TypeAlias = (
+    ConflictingBound | ConflictingClaim | RowBindingMismatch | MonetaryMismatchProof
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -431,6 +457,10 @@ class SpendLeaseAllocation:
             self.binding_state != BindingState.COMMITTED
         ):
             raise SpendLeaseInvariantError("row-binding contradiction retains COMMITTED binding")
+        if isinstance(self.contradiction_proof, MonetaryMismatchProof) and (
+            self.binding_state != BindingState.COMMITTED
+        ):
+            raise SpendLeaseInvariantError("monetary contradiction retains COMMITTED binding")
 
         # Decisions 17, 21, 22: provenance constrains binding, and COMMITTED needs proof.
         if self.terminal_source == TerminalSource.MIRROR and (
@@ -550,8 +580,11 @@ class SpendLeaseAllocation:
         if observation.finalization_outcome == FinalizationOutcome.SETTLED and (
             observation.finalized_cost_microdollars is not None
         ):
-            if not 0 <= observation.finalized_cost_microdollars <= self.allocated_micro:
-                raise SpendLeaseConflictError("settled actual must fit inside the allocation")
+            if observation.finalized_cost_microdollars > self.allocated_micro:
+                raise SpendLeaseMonetaryMismatch(
+                    finalized_cost_microdollars=observation.finalized_cost_microdollars,
+                    allocated_micro=self.allocated_micro,
+                )
             target_state = AllocationState.SETTLED
             target_outcome = AuthorizationOutcome.SETTLED
             actual = observation.finalized_cost_microdollars
@@ -606,7 +639,7 @@ class SpendLeaseAllocation:
         return AllocationTransition(lost, False)
 
     def quarantine(self, proof: ContradictionProof) -> AllocationTransition:
-        # Decision 22: exactly three contradictions, with binding phase retained.
+        # Decisions 22 and 56: contradiction proofs retain their binding phase.
         if self.state == AllocationState.QUARANTINED:
             if self.contradiction_proof == proof:
                 return AllocationTransition(self, True)
@@ -631,6 +664,11 @@ class SpendLeaseAllocation:
                 and proof.observed_tuple_or_absent == self.binding
             ):
                 raise SpendLeaseProofError("observed row binding matches the allocation")
+        elif isinstance(proof, MonetaryMismatchProof):
+            if self.binding_state != BindingState.COMMITTED:
+                raise SpendLeaseProofError("MonetaryMismatchProof requires COMMITTED allocation")
+            if proof.allocated_micro != self.allocated_micro:
+                raise SpendLeaseProofError("monetary mismatch proof allocation amount mismatch")
         else:  # pragma: no cover - closed union, defensive against dynamic callers
             raise SpendLeaseProofError("unknown contradiction proof")
         quarantined = replace(

--- a/tests/test_spend_lease_ledger.py
+++ b/tests/test_spend_lease_ledger.py
@@ -33,6 +33,7 @@ from trusted_router.spend_lease_state import (
     ExistingLocal,
     FinalizationOutcome,
     Mismatch,
+    MonetaryMismatchProof,
     RecoveryProof,
     SpendLease,
     SpendLeaseAllocation,
@@ -313,6 +314,49 @@ def test_ambiguous_commit_that_landed_rereads_as_replay_without_second_write() -
     assert table.commit_attempts == commits_before + 1
     assert ledger.get("spend-lease-test", region=REGION) == result.lease
     assert result.lease.version == 1
+
+
+def test_monetary_mismatch_quarantine_round_trips_and_replays_without_write() -> None:
+    table = _FakeBigtableTable()
+    ledger = BigtableSpendLeaseLedger({REGION: table})
+    ledger.initialize(_candidate(), region=REGION)
+    _allocate(ledger)
+    ledger.bind(
+        "spend-lease-test",
+        region=REGION,
+        expected_provisional_id="provisional-1",
+        proof=BoundProof(
+            idempotency_scope="scope-1",
+            authorization_id="authorization-1",
+            lease_id="spend-lease-test",
+            gen=4,
+            allocated_micro=500,
+        ),
+    )
+    proof = MonetaryMismatchProof(
+        finalized_cost_microdollars=501,
+        allocated_micro=500,
+    )
+
+    first = ledger.quarantine(
+        "spend-lease-test",
+        region=REGION,
+        idempotency_scope="scope-1",
+        proof=proof,
+    )
+    commits_after_first = table.commit_attempts
+    replay = ledger.quarantine(
+        "spend-lease-test",
+        region=REGION,
+        idempotency_scope="scope-1",
+        proof=proof,
+    )
+
+    assert first.allocation.contradiction_proof == proof
+    assert ledger.get("spend-lease-test", region=REGION) == first.lease
+    assert replay.replayed
+    assert replay.lease == first.lease
+    assert table.commit_attempts == commits_after_first
 
 
 @pytest.mark.parametrize("transition_name", ["compensate", "bind", "tombstone_unminted"])

--- a/tests/test_spend_lease_state.py
+++ b/tests/test_spend_lease_state.py
@@ -35,6 +35,7 @@ from trusted_router.spend_lease_state import (
     ExistingLocal,
     FinalizationOutcome,
     Mismatch,
+    MonetaryMismatchProof,
     RecoveryProof,
     RowBindingMismatch,
     SpendLease,
@@ -42,6 +43,7 @@ from trusted_router.spend_lease_state import (
     SpendLeaseConflictError,
     SpendLeaseExhaustedError,
     SpendLeaseInvariantError,
+    SpendLeaseMonetaryMismatch,
     SpendLeaseProofError,
     SpendLeaseRefusalReason,
     SpendLeaseState,
@@ -914,8 +916,113 @@ def test_mirror_requires_committed_terminal_view_and_open_view_leaves_reserved()
     unchanged = committed.mirror(open_observation)
     assert unchanged.replayed
     assert unchanged.allocation.state == AllocationState.RESERVED
-    with pytest.raises(SpendLeaseConflictError, match="fit inside"):
+
+
+def test_mirror_cost_above_allocation_raises_monetary_mismatch_with_amounts() -> None:
+    committed = _bind(_created())
+    allocation = committed.allocations[0]
+
+    with pytest.raises(SpendLeaseMonetaryMismatch) as caught:
         committed.mirror(_observation(allocation, actual=allocation.allocated_micro + 1))
+    assert caught.value.finalized_cost_microdollars == allocation.allocated_micro + 1
+    assert caught.value.allocated_micro == allocation.allocated_micro
+
+
+def test_monetary_mismatch_proof_quarantines_committed_allocation_and_blocks_close() -> None:
+    committed = _bind(_created())
+    allocation = committed.allocations[0]
+    proof = MonetaryMismatchProof(
+        finalized_cost_microdollars=allocation.allocated_micro + 1,
+        allocated_micro=allocation.allocated_micro,
+    )
+
+    quarantined = committed.quarantine(
+        idempotency_scope=allocation.idempotency_scope,
+        proof=proof,
+    )
+
+    assert quarantined.allocation.state == AllocationState.QUARANTINED
+    assert quarantined.allocation.terminal_source == TerminalSource.QUARANTINE
+    assert quarantined.allocation.authorization_outcome == AuthorizationOutcome.CONTRADICTION
+    assert quarantined.allocation.contradiction_proof == proof
+    assert quarantined.allocation.actual_micro is None
+    frozen = quarantined.lease.tombstone().lease
+    assert frozen.open_allocations == (quarantined.allocation,)
+    with pytest.raises(SpendLeaseUnavailableError, match="open allocations"):
+        frozen.close(now=EXPIRY + SKEW)
+
+
+def test_monetary_mismatch_quarantine_replays_equal_proof() -> None:
+    committed = _bind(_created())
+    allocation = committed.allocations[0]
+    proof = MonetaryMismatchProof(
+        finalized_cost_microdollars=allocation.allocated_micro + 1,
+        allocated_micro=allocation.allocated_micro,
+    )
+    first = committed.quarantine(
+        idempotency_scope=allocation.idempotency_scope,
+        proof=proof,
+    )
+
+    replay = first.lease.quarantine(
+        idempotency_scope=allocation.idempotency_scope,
+        proof=proof,
+    )
+
+    assert replay.replayed
+    assert replay.lease is first.lease
+    assert replay.allocation is first.allocation
+
+
+def test_monetary_mismatch_proof_rejects_non_mismatch_amounts() -> None:
+    with pytest.raises(SpendLeaseProofError, match="above allocation"):
+        MonetaryMismatchProof(finalized_cost_microdollars=400, allocated_micro=400)
+
+
+def test_monetary_mismatch_proof_rejects_provisional_allocation() -> None:
+    created = _created()
+    proof = MonetaryMismatchProof(
+        finalized_cost_microdollars=created.allocation.allocated_micro + 1,
+        allocated_micro=created.allocation.allocated_micro,
+    )
+
+    with pytest.raises(SpendLeaseProofError, match="requires COMMITTED"):
+        created.lease.quarantine(
+            idempotency_scope=created.allocation.idempotency_scope,
+            proof=proof,
+        )
+
+
+def test_monetary_mismatch_quarantine_construction_requires_committed_binding() -> None:
+    provisional = _created().allocation
+    proof = MonetaryMismatchProof(
+        finalized_cost_microdollars=provisional.allocated_micro + 1,
+        allocated_micro=provisional.allocated_micro,
+    )
+
+    with pytest.raises(SpendLeaseInvariantError, match="retains COMMITTED binding"):
+        replace(
+            provisional,
+            state=AllocationState.QUARANTINED,
+            terminal_source=TerminalSource.QUARANTINE,
+            authorization_outcome=AuthorizationOutcome.CONTRADICTION,
+            contradiction_proof=proof,
+        )
+
+
+def test_monetary_mismatch_proof_rejects_different_allocation_amount() -> None:
+    committed = _bind(_created())
+    allocation = committed.allocations[0]
+    proof = MonetaryMismatchProof(
+        finalized_cost_microdollars=allocation.allocated_micro + 2,
+        allocated_micro=allocation.allocated_micro + 1,
+    )
+
+    with pytest.raises(SpendLeaseProofError, match="allocation amount mismatch"):
+        committed.quarantine(
+            idempotency_scope=allocation.idempotency_scope,
+            proof=proof,
+        )
 
 
 def test_terminal_allocations_are_absorbing_and_same_terminal_input_replays() -> None:


### PR DESCRIPTION
Unit-1 follow-up for Stage B unit 4 (design record v54, decision 56, which supersedes decision 22's closed set of contradiction proofs).

- `MonetaryMismatchProof(finalized_cost_microdollars, allocated_micro)`, constructible only when the finalized cost exceeds the allocation; the quarantine transition accepts it for a COMMITTED allocation whose amount equals the proof's, reaching QUARANTINED / CONTRADICTION with actual NULL (decision 17 unchanged) and counting as open for close; an equal proof replays; PROVISIONAL or a different amount is a typed proof error; a construction invariant keeps the COMMITTED binding on a monetary contradiction.
- `mirror` refuses finalized cost above the allocation with the typed `SpendLeaseMonetaryMismatch` carrying both amounts, so the eager and reconciler mirrors can map it to quarantine without string matching.
- The ledger serializes the new proof under its own discriminator so it survives the durable CAS round-trip.

Review: isolated snapshot; ruff; mypy --strict on both modules; 90 state and 37 ledger tests; six mutations each red (proof construction, PROVISIONAL rejection, amount equality, the mirror refusal, the construction invariant, the ledger discriminator). The invariant test was a coverage gap found in review.

Lands before the unit-4 settlement-clamp PR, which consumes it.

Written by codex; reviewed by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)