### PR TITLE
spend-lease: the settlement clamp (unit 4, decisions 49–57)

### DIFF
--- a/docs/design/durable-settle-outbox.md
+++ b/docs/design/durable-settle-outbox.md
@@ -189,6 +189,17 @@ lease-claims due `pending` rows and for each:
   full `_settle_gateway_authorization` HTTP handler — which would re-run pricing
   and re-fire non-idempotent side effects (budget alerts, auto-refill, metadata
   broadcast, provider-benchmark samples) on every replay (SF7).
+- Spend-lease rows have one corrective exception to the general frozen-cost rule.
+  A rolling pre-clamp revision may have frozen a successful charge above its typed
+  allocation. While the reservation is still unclaimed, the drain caps that charge,
+  re-derives every charge-dependent payout hidden in `settle_body`, and rewrites both
+  fields in the same billing transaction. The rewrite is fenced by
+  `status='pending'` and the drain worker's `lease_owner`; a zero-row rewrite aborts
+  the transaction, so billing cannot commit while durable replay authority is stale.
+  The generation and analytics intent are constructed only from the corrected amount.
+  If an older revision already won the reservation, its historical booked charge is
+  left untouched and used for generation repair, then surfaced for spend-lease
+  quarantine rather than charged again.
 - Interprets the **richer finalize outcome** (§3): `settled_now` or
   `already_settled_with_charge` → `status='done'`; `already_released_free` on a
   row that intended a charge → **`dead` + alert** (the reaper beat us — invariant
@@ -204,6 +215,9 @@ lease-claims due `pending` rows and for each:
   outbox terminal retention timestamps in the same transaction. The
   authorization keeps only its content-free replay record so a client
   idempotency key remains valid for the full window.
+  Spend-lease finalization follows the same split retention rule: finalization
+  defers retention, and only the existing lease-fenced `mark(done)` arms it after
+  sibling-intent checks.
 - Final `ApplyOutcome` contract for the drain:
   `settled_now` → done. `already_settled_with_charge` means done for settle
   intent; for refund intent with a charged reservation, done plus the same

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -142,6 +142,10 @@ from trusted_router.services.settle_outbox_drain import (
     drain_settle_outbox,
     spanner_settle_outbox,
 )
+from trusted_router.services.spend_lease_settlement import (
+    clamp_spend_lease_charge,
+    mirror_finalized_spend_lease_best_effort,
+)
 from trusted_router.services.spend_lease_shadow_dispatch import (
     SpendLeaseShadowDispatcher,
 )
@@ -169,6 +173,7 @@ from trusted_router.spend_leases import (
     freeze_spend_lease_catalog,
     mint_shadow_spend_lease,
     parse_boot_auth_header,
+    spend_lease_binding_ineligibility_reason,
     spend_lease_ineligibility_reason,
     verify_boot_auth,
 )
@@ -1036,12 +1041,23 @@ def _authorize_gateway_sync_impl(
             # Signer, Secret Manager, catalog, and generation failures all
             # degrade to today's synchronous authorization with no lease.
             logger.exception("spend_lease_mint_failed")
+    binding_no_lease_reason = spend_lease_binding_ineligibility_reason(
+        no_lease_reason,
+        deferred_settlement_applies=(
+            settings.spend_lease_binding_enabled
+            and _deferred_settlement_applies(settings, api_key)
+        ),
+    )
+    if binding_no_lease_reason != no_lease_reason:
+        # Binding-only: Stage A eligibility also drives flag-off shadow issuance,
+        # which must remain unchanged when deferred settlement is available.
+        spend_context["no_lease_reason"] = binding_no_lease_reason
     if (
         settings.spend_lease_binding_enabled
         and settings.spend_lease_issuance_enabled
         and bool(spend_context["boot_verified"])
         and boot_auth is not None
-        and no_lease_reason is None
+        and binding_no_lease_reason is None
     ):
         prepare_binding = getattr(_typed_store, "prepare_gateway_spend_lease_binding", None)
         if callable(prepare_binding):
@@ -2659,6 +2675,8 @@ def _settle_gateway_authorization(
             },
         )
         actual_cost = authorization.estimated_microdollars
+    if success and authorization.settlement == "spend_lease":
+        actual_cost = clamp_spend_lease_charge(authorization, actual_cost)
     if success and authorization.app_markup_basis_points > 0:
         # THE PAYOUT IS A FUNCTION OF THE FINAL CHARGE: authorization freezes
         # the rate, while every clamp/cap/adjustment above decides the base.
@@ -2950,6 +2968,16 @@ def _settle_gateway_authorization(
             activity_indexed=finalized,
         )
     finalize_ms = (perf_counter() - finalize_start) * 1000
+    if finalized and is_typed and authorization.settlement == "spend_lease":
+        assert _typed_store is not None
+        committed = cast(Any, _typed_store).get_gateway_authorization(authorization.id)
+        if committed is None:
+            logger.error(
+                "spend_lease.eager_mirror_read_missing",
+                extra={"authorization_id": authorization.id},
+            )
+        else:
+            mirror_finalized_spend_lease_best_effort(_typed_store, committed)
     _release_user_model_slot_safely(authorization)
     if not finalized:
         # §3/§6/§7: leave the row pending on purpose. Inline's False only says

--- a/src/trusted_router/services/settle_outbox_apply.py
+++ b/src/trusted_router/services/settle_outbox_apply.py
@@ -28,6 +28,10 @@ from trusted_router.partner_billing import PARTNER_OPERATOR_COST_SETTLE_FIELD
 from trusted_router.regional_quota_ledger import RegionalLeaseLedgerError
 from trusted_router.schemas import GatewaySettleRequest
 from trusted_router.services.regional_quota_leases import LeaseSettlementError
+from trusted_router.services.spend_lease_settlement import (
+    derive_spend_lease_repair_amounts,
+    mirror_finalized_spend_lease_best_effort,
+)
 from trusted_router.storage import STORE, Generation, typed_billing_store
 from trusted_router.storage_errors import transient_store_error_types
 from trusted_router.storage_gcp_authorize import SettleOutcome
@@ -148,6 +152,43 @@ def apply_frozen_settle(row: SettleOutboxRow) -> str:
     if auth is None:
         return ApplyOutcome.RESERVATION_MISSING
 
+    corrective_rewrite: tuple[str, str, str, int, str] | None = None
+    if (
+        success
+        and auth.settlement == "spend_lease"
+        and auth.spend_lease_id is not None
+        and auth.spend_lease_gen is not None
+        and auth.spend_lease_allocated_micro is not None
+        and row.actual_cost_micro > auth.spend_lease_allocated_micro
+    ):
+        if row.lease_owner is None:
+            return ApplyOutcome.ERROR
+        repair = derive_spend_lease_repair_amounts(auth, row.actual_cost_micro, parsed_body)
+        rewritten_body = json.dumps(repair.settle_body, separators=(",", ":"))
+        original_cost = row.actual_cost_micro
+        row.actual_cost_micro = repair.actual_cost_micro
+        row.settle_body = rewritten_body
+        body = GatewaySettleRequest(**repair.settle_body)
+        body_dict = body.model_dump(exclude_none=True)
+        corrective_rewrite = (
+            row.authorization_id,
+            row.intent_kind,
+            row.lease_owner,
+            repair.actual_cost_micro,
+            rewritten_body,
+        )
+        logger.error(
+            "spend_lease.frozen_charge_capped_at_allocation",
+            extra={
+                "authorization_id": auth.id,
+                "spend_lease_id": auth.spend_lease_id,
+                "spend_lease_gen": auth.spend_lease_gen,
+                "spend_lease_allocated_micro": auth.spend_lease_allocated_micro,
+                "original_actual_microdollars": original_cost,
+                "booked_actual_microdollars": repair.actual_cost_micro,
+            },
+        )
+
     # Do not short-circuit auth.settled here. The claim/finalize layer is the
     # authority; this pre-read is only for body construction and is TOCTOU-prone.
     usage_type = UsageType.coerce(row.selected_usage_type)
@@ -185,6 +226,11 @@ def apply_frozen_settle(row: SettleOutboxRow) -> str:
                 body_dict,
                 usage_type,
                 operator_cost_microdollars=operator_cost,
+                app_markup_microdollars=app_markup_microdollars_from_charge(
+                    row.actual_cost_micro, auth.app_markup_basis_points
+                )
+                if auth.app_markup_basis_points > 0
+                else 0,
             )
             if success
             else None
@@ -203,6 +249,7 @@ def apply_frozen_settle(row: SettleOutboxRow) -> str:
             generation,
             user_model_payout,
             app_markup_payout,
+            corrective_rewrite,
         )
     elif row.settle_origin == "legacy":
         outcome = _apply_legacy(
@@ -256,6 +303,7 @@ def _frozen_generation(
     usage_type: UsageType,
     *,
     operator_cost_microdollars: int | None = None,
+    app_markup_microdollars: int = 0,
 ) -> Generation:
     # MF5: rebuild generation metadata from the row's frozen decision and
     # settle_body only. Retired endpoints fall back to parsing the stored id;
@@ -279,6 +327,7 @@ def _frozen_generation(
         input_tokens=total_input,
         output_tokens=body.output_count,
         actual_cost_microdollars=row.actual_cost_micro,
+        app_markup_microdollars=app_markup_microdollars,
         operator_cost_microdollars=operator_cost_microdollars,
     )
 
@@ -379,6 +428,7 @@ def _apply_typed(
     generation: Generation | None,
     user_model_payout: UserModelPayout | None,
     app_markup_payout: AppMarkupPayout | None,
+    corrective_rewrite: tuple[str, str, str, int, str] | None,
 ) -> str:
     typed_store = typed_billing_store()
     if typed_store is None:
@@ -464,6 +514,7 @@ def _apply_typed(
                 generation=generation,
                 user_model_payout=user_model_payout,
                 app_markup_payout=app_markup_payout,
+                settle_outbox_rewrite=corrective_rewrite,
             )
         except _TRANSIENT_STORE_EXCS:
             return ApplyOutcome.PARK_TYPED_UNAVAILABLE
@@ -478,6 +529,15 @@ def _apply_typed(
                 generation_store.mirror_after_commit(generation)
             elif not _index_generation_after_commit(typed_store, generation):
                 return ApplyOutcome.ACTIVITY_PENDING
+        if auth.settlement == "spend_lease":
+            committed = cast(Any, typed_store).get_gateway_authorization(auth.id)
+            if committed is None:
+                logger.error(
+                    "spend_lease.eager_mirror_read_missing",
+                    extra={"authorization_id": auth.id},
+                )
+            else:
+                mirror_finalized_spend_lease_best_effort(typed_store, committed)
         return ApplyOutcome.SETTLED_NOW
     if outcome == SettleOutcome.NOT_FOUND:
         return ApplyOutcome.RESERVATION_MISSING
@@ -491,6 +551,21 @@ def _apply_typed(
         if reservation is None:
             return ApplyOutcome.RESERVATION_MISSING
         actual_micro = int(reservation.get("actual_micro") or 0)
+        if (
+            auth.settlement == "spend_lease"
+            and auth.spend_lease_allocated_micro is not None
+            and actual_micro > auth.spend_lease_allocated_micro
+        ):
+            logger.error(
+                "spend_lease.historical_overcharge",
+                extra={
+                    "authorization_id": auth.id,
+                    "spend_lease_id": auth.spend_lease_id,
+                    "spend_lease_gen": auth.spend_lease_gen,
+                    "spend_lease_allocated_micro": auth.spend_lease_allocated_micro,
+                    "finalized_cost_microdollars": actual_micro,
+                },
+            )
         if actual_micro > 0:
             # Refunds never carry a generation, so requiring one here made the
             # benign charged-settle-beats-refund replay unreachable and
@@ -499,7 +574,20 @@ def _apply_typed(
                 return ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE
             if generation is None:
                 return ApplyOutcome.INVALID_ROW
-            if not _index_generation_after_commit(typed_store, generation):
+            replay_generation = generation
+            if corrective_rewrite is not None:
+                replay_generation = replace(
+                    generation,
+                    total_cost_microdollars=actual_micro,
+                    app_markup_microdollars=(
+                        app_markup_microdollars_from_charge(
+                            actual_micro, auth.app_markup_basis_points
+                        )
+                        if auth.app_markup_basis_points > 0
+                        else 0
+                    ),
+                )
+            if not _index_generation_after_commit(typed_store, replay_generation):
                 return ApplyOutcome.ACTIVITY_PENDING
             return ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE
         if row.actual_cost_micro == 0:

--- a/src/trusted_router/services/spend_lease_settlement.py
+++ b/src/trusted_router/services/spend_lease_settlement.py
@@ -1,0 +1,228 @@
+"""Spend-lease settlement rules shared by inline and durable repair paths."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from trusted_router.app_markup_billing import (
+    APP_MARKUP_APP_ID_SETTLE_FIELD,
+    APP_MARKUP_OWNER_SETTLE_FIELD,
+    APP_MARKUP_PAYOUT_SETTLE_FIELD,
+    app_markup_microdollars_from_charge,
+    app_markup_owner_share_microdollars,
+)
+from trusted_router.custom_model_billing import (
+    USER_MODEL_ID_SETTLE_FIELD,
+    USER_MODEL_OWNER_SETTLE_FIELD,
+    USER_MODEL_PAYOUT_SETTLE_FIELD,
+    owner_share_microdollars,
+)
+from trusted_router.partner_billing import PARTNER_OPERATOR_COST_SETTLE_FIELD
+from trusted_router.spend_lease_state import (
+    AuthorizationDurability,
+    AuthorizationObservation,
+    FinalizationOutcome,
+    MonetaryMismatchProof,
+    SpendLeaseMonetaryMismatch,
+)
+from trusted_router.storage_models import GatewayAuthorization
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class SpendLeaseRepairAmounts:
+    """The complete frozen monetary authority after applying the omitted clamp."""
+
+    actual_cost_micro: int
+    app_markup_micro: int
+    operator_cost_micro: int | None
+    user_model_payout_micro: int | None
+    app_markup_payout_micro: int | None
+    settle_body: dict[str, Any]
+
+
+def complete_typed_binding(typed_columns: Mapping[str, Any]) -> bool:
+    """Whether all three typed facts that imply spend-lease settlement exist."""
+
+    return all(
+        typed_columns.get(column) is not None
+        for column in (
+            "spend_lease_id",
+            "spend_lease_gen",
+            "spend_lease_allocated_micro",
+        )
+    )
+
+
+def derive_spend_lease_settlement(
+    payload: Mapping[str, Any] | None,
+    typed_columns: Mapping[str, Any],
+    merged: dict[str, Any],
+) -> None:
+    """Make the typed binding tuple authoritative for the settlement class."""
+
+    if not complete_typed_binding(typed_columns):
+        return
+    payload_settlement = payload.get("settlement") if payload is not None else None
+    if payload_settlement not in (None, "spend_lease"):
+        log.error(
+            "spend_lease.settlement_kind_mismatch",
+            extra={
+                "spend_lease_id": typed_columns.get("spend_lease_id"),
+                "spend_lease_gen": typed_columns.get("spend_lease_gen"),
+                "payload_settlement": payload_settlement,
+                "derived_settlement": "spend_lease",
+            },
+        )
+    merged["settlement"] = "spend_lease"
+
+
+def clamp_spend_lease_charge(
+    authorization: GatewayAuthorization,
+    actual_cost_micro: int,
+) -> int:
+    """Apply decision 50's customer-charge cap to a spend-lease settlement."""
+
+    if authorization.settlement != "spend_lease":
+        return actual_cost_micro
+    allocated = authorization.spend_lease_allocated_micro
+    if allocated is None:
+        cap = int(authorization.estimated_microdollars)
+        log.error(
+            "spend_lease.settle_binding_facts_missing",
+            extra={
+                "authorization_id": authorization.id,
+                "spend_lease_id": authorization.spend_lease_id,
+                "spend_lease_gen": authorization.spend_lease_gen,
+                "estimated_microdollars": authorization.estimated_microdollars,
+                "actual_microdollars": actual_cost_micro,
+            },
+        )
+    else:
+        cap = min(int(allocated), int(authorization.estimated_microdollars))
+    if actual_cost_micro <= cap:
+        return actual_cost_micro
+    log.warning(
+        "billing.spend_lease_settle_capped_to_allocation",
+        extra={
+            "authorization_id": authorization.id,
+            "spend_lease_id": authorization.spend_lease_id,
+            "spend_lease_gen": authorization.spend_lease_gen,
+            "spend_lease_allocated_micro": allocated,
+            "actual_microdollars": actual_cost_micro,
+            "overrun_microdollars": actual_cost_micro - cap,
+        },
+    )
+    return cap
+
+
+def derive_spend_lease_repair_amounts(
+    authorization: GatewayAuthorization,
+    actual_cost_micro: int,
+    settle_body: Mapping[str, Any],
+) -> SpendLeaseRepairAmounts:
+    """Clamp and deterministically rewrite every charge-derived frozen amount."""
+
+    charge = clamp_spend_lease_charge(authorization, actual_cost_micro)
+    body = dict(settle_body)
+    app_markup = (
+        app_markup_microdollars_from_charge(charge, authorization.app_markup_basis_points)
+        if authorization.app_markup_basis_points > 0
+        else 0
+    )
+    app_payout: int | None = None
+    if authorization.app_markup_basis_points > 0:
+        app_payout = app_markup_owner_share_microdollars(app_markup)
+        body[APP_MARKUP_PAYOUT_SETTLE_FIELD] = app_payout
+        body[APP_MARKUP_OWNER_SETTLE_FIELD] = authorization.app_owner_user_id
+        body[APP_MARKUP_APP_ID_SETTLE_FIELD] = authorization.app_id
+
+    user_payout: int | None = None
+    operator_cost: int | None = None
+    if authorization.user_provided_model_id is not None:
+        user_payout = owner_share_microdollars(max(0, charge - app_markup))
+        operator_cost = user_payout
+        body[USER_MODEL_PAYOUT_SETTLE_FIELD] = user_payout
+        body[USER_MODEL_OWNER_SETTLE_FIELD] = authorization.user_model_owner_user_id
+        body[USER_MODEL_ID_SETTLE_FIELD] = authorization.user_provided_model_id
+        body[PARTNER_OPERATOR_COST_SETTLE_FIELD] = operator_cost
+
+    return SpendLeaseRepairAmounts(
+        actual_cost_micro=charge,
+        app_markup_micro=app_markup,
+        operator_cost_micro=operator_cost,
+        user_model_payout_micro=user_payout,
+        app_markup_payout_micro=app_payout,
+        settle_body=body,
+    )
+
+
+def mirror_finalized_spend_lease_best_effort(store: Any, authorization: GatewayAuthorization) -> None:
+    """Mirror a committed winning finalize; ledger failures never change settle."""
+
+    if authorization.settlement != "spend_lease" or not authorization.settled:
+        return
+    ledger = getattr(store, "_spend_lease_ledger", None)
+    try:
+        if ledger is None:
+            raise RuntimeError("spend lease ledger is unavailable")
+        lease_id = str(authorization.spend_lease_id or "")
+        region = str(authorization.region or "")
+        gen = authorization.spend_lease_gen
+        allocated_micro = authorization.spend_lease_allocated_micro
+        if not lease_id or not region or gen is None or allocated_micro is None:
+            raise RuntimeError("spend lease binding facts are incomplete")
+        local = ledger.get(lease_id, region=region)
+        if local is None:
+            raise RuntimeError("spend lease row is unavailable")
+        allocation = next(
+            item for item in local.allocations if item.authorization_id == authorization.id
+        )
+        outcome = (
+            None
+            if authorization.finalization_outcome is None
+            else FinalizationOutcome(authorization.finalization_outcome)
+        )
+        observation = AuthorizationObservation(
+            idempotency_scope=allocation.idempotency_scope,
+            authorization_id=allocation.authorization_id,
+            request_fingerprint=allocation.request_fingerprint,
+            lease_id=lease_id,
+            gen=int(gen),
+            allocated_micro=int(allocated_micro),
+            key_hash=authorization.key_hash,
+            workspace_id=authorization.workspace_id,
+            durability=AuthorizationDurability.TERMINAL,
+            finalization_outcome=outcome,
+            finalized_cost_microdollars=(
+                authorization.finalized_cost_microdollars
+                if outcome == FinalizationOutcome.SETTLED
+                else None
+            ),
+        )
+        try:
+            ledger.mirror(lease_id, region=region, observation=observation)
+        except SpendLeaseMonetaryMismatch as exc:
+            ledger.quarantine(
+                lease_id,
+                region=region,
+                idempotency_scope=allocation.idempotency_scope,
+                proof=MonetaryMismatchProof(
+                    exc.finalized_cost_microdollars,
+                    exc.allocated_micro,
+                ),
+            )
+    except Exception:
+        log.error(
+            "spend_lease.eager_mirror_failed",
+            extra={
+                "authorization_id": authorization.id,
+                "spend_lease_id": authorization.spend_lease_id,
+                "spend_lease_gen": authorization.spend_lease_gen,
+            },
+            exc_info=True,
+        )

--- a/src/trusted_router/spend_leases.py
+++ b/src/trusted_router/spend_leases.py
@@ -75,6 +75,7 @@ SpendLeaseBindingFailure = Literal[
     "ledger_unavailable",
     "window_open",
     "mint_lost",
+    "deferred_settlement",
 ]
 SpendLeaseNoLeaseReason = SpendLeaseEligibilityFailure | SpendLeaseBindingFailure
 SpendLeaseBindingOutcome = Literal[
@@ -92,6 +93,18 @@ SpendLeaseBindingOutcome = Literal[
     "mint_lost",
     "ledger_unavailable",
 ]
+
+
+def spend_lease_binding_ineligibility_reason(
+    stage_a_reason: SpendLeaseEligibilityFailure | None,
+    *,
+    deferred_settlement_applies: bool,
+) -> SpendLeaseNoLeaseReason | None:
+    """Extend Stage A only at the binding seam, leaving shadow issuance intact."""
+
+    if stage_a_reason is not None:
+        return stage_a_reason
+    return "deferred_settlement" if deferred_settlement_applies else None
 
 
 def spend_lease_scope_salt(idempotency_scope: str) -> str:

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -3631,6 +3631,7 @@ class SpannerBigtableStore:
                 artifact = spend_lease_binding_plan.artifact
                 selected = dataclasses.replace(
                     base,
+                    settlement="spend_lease",
                     spend_lease_token=artifact.token,
                     spend_lease_id=artifact.lease_id,
                     spend_lease_cap_micro=artifact.cap_micro,

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -60,6 +60,7 @@ from trusted_router.storage_gcp_settle_outbox import (
     _GUARD_STATUS_SQL,
     GUARD_COUNT_SQL,
     mark_done_unleased_tx,
+    rewrite_frozen_settlement_tx,
 )
 from trusted_router.storage_models import (
     AppMarkupPayout,
@@ -902,6 +903,7 @@ def typed_finalize_atomic(
     app_markup_payout: AppMarkupPayout | None = None,
     regional_hold_unknown: bool = False,
     settle_outbox_done: tuple[str, str] | None = None,
+    settle_outbox_rewrite: tuple[str, str, str, int, str] | None = None,
 ) -> dict:
     """Full DML-only finalize for the typed path (codex 3e, Option B).
 
@@ -954,6 +956,23 @@ def typed_finalize_atomic(
         )
         if not won:
             return {"outcome": SettleOutcome.ALREADY_SETTLED}
+
+        if settle_outbox_rewrite is not None:
+            rewrite_aid, rewrite_kind, lease_owner, rewrite_cost, rewrite_body = (
+                settle_outbox_rewrite
+            )
+            rewritten = rewrite_frozen_settlement_tx(
+                transaction,
+                pt,
+                authorization_id=rewrite_aid,
+                intent_kind=rewrite_kind,
+                lease_owner=lease_owner,
+                actual_cost_micro=rewrite_cost,
+                settle_body=rewrite_body,
+                now=now,
+            )
+            if rewritten != 1:
+                raise _SettleError("corrective settle-outbox rewrite lost its lease fence")
 
         missing_key_releases = []
         key_count, warning = _release_key_or_skip_deleted(

--- a/src/trusted_router/storage_gcp_request_records.py
+++ b/src/trusted_router/storage_gcp_request_records.py
@@ -165,6 +165,7 @@ def read_gateway_authorization(
         ),
         settled=bool(settled),
         created_at=_timestamp_string(created_at),
+        settlement=str(merged.get("settlement") or "local"),
         spend_lease_id=merged.get("spend_lease_id"),
         spend_lease_gen=merged.get("spend_lease_gen"),
         spend_lease_allocated_micro=merged.get("spend_lease_allocated_micro"),

--- a/src/trusted_router/storage_gcp_settle_outbox.py
+++ b/src/trusted_router/storage_gcp_settle_outbox.py
@@ -255,6 +255,47 @@ def mark_done_unleased_tx(
     return True
 
 
+def rewrite_frozen_settlement_tx(
+    transaction: Any,
+    param_types: Any,
+    *,
+    authorization_id: str,
+    intent_kind: str,
+    lease_owner: str,
+    actual_cost_micro: int,
+    settle_body: str,
+    now: Any,
+) -> int:
+    """Rewrite corrective replay authority under the active worker lease fence."""
+
+    if not lease_owner:
+        raise ValueError("corrective settle rewrite requires a lease owner")
+    return int(
+        transaction.execute_update(
+            "UPDATE tr_settle_outbox SET actual_cost_micro=@actual_cost_micro, "
+            "settle_body=@settle_body, updated_at=@now "
+            "WHERE authorization_id=@aid AND intent_kind=@kind "
+            "AND status='pending' AND lease_owner=@lease_owner",
+            params={
+                "actual_cost_micro": int(actual_cost_micro),
+                "settle_body": settle_body,
+                "now": now,
+                "aid": authorization_id,
+                "kind": intent_kind,
+                "lease_owner": lease_owner,
+            },
+            param_types={
+                "actual_cost_micro": param_types.INT64,
+                "settle_body": param_types.STRING,
+                "now": param_types.TIMESTAMP,
+                "aid": param_types.STRING,
+                "kind": param_types.STRING,
+                "lease_owner": param_types.STRING,
+            },
+        )
+    )
+
+
 def _iso_now() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 

--- a/src/trusted_router/storage_gcp_spend_lease.py
+++ b/src/trusted_router/storage_gcp_spend_lease.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 from typing import Any, Literal
 
 from trusted_router import spend_leases
+from trusted_router.services.spend_lease_settlement import derive_spend_lease_settlement
 from trusted_router.spend_lease_state import BindingTuple
 
 RegistrationKind = Literal["BOUND", "CLAIM"]
@@ -726,6 +727,7 @@ def merge_authorization_typed_columns(
     allocated = merged.get("spend_lease_allocated_micro")
     if allocated is not None and int(allocated) <= 0:
         raise SpendLeaseDataError("spend_lease_allocated_micro must be NULL or positive")
+    derive_spend_lease_settlement(payload, typed_columns, merged)
     return merged
 
 

--- a/src/trusted_router/storage_gcp_spend_lease_reconcile.py
+++ b/src/trusted_router/storage_gcp_spend_lease_reconcile.py
@@ -27,10 +27,12 @@ from trusted_router.spend_lease_state import (
     ClaimProof,
     ConflictingBound,
     FinalizationOutcome,
+    MonetaryMismatchProof,
     RecoveryProof,
     RowBindingMismatch,
     SpendLease,
     SpendLeaseConflictError,
+    SpendLeaseMonetaryMismatch,
     SpendLeaseState,
 )
 from trusted_router.storage_gcp_counter_dml import release_credit
@@ -538,31 +540,53 @@ def _mirror_allocations(
             if authorization.finalization_outcome is None
             else FinalizationOutcome(authorization.finalization_outcome)
         )
-        ledger.mirror(
-            row.lease_id,
-            region=row.region,
-            observation=AuthorizationObservation(
-                idempotency_scope=allocation.idempotency_scope,
-                authorization_id=allocation.authorization_id,
-                request_fingerprint=allocation.request_fingerprint,
-                lease_id=row.lease_id,
-                gen=row.gen,
-                allocated_micro=allocation.allocated_micro,
-                key_hash=row.key_hash,
-                workspace_id=row.workspace_id,
-                durability=(
-                    AuthorizationDurability.TERMINAL
-                    if authorization.settled
-                    else AuthorizationDurability.OPEN
-                ),
-                finalization_outcome=outcome,
-                finalized_cost_microdollars=(
-                    authorization.finalized_cost_microdollars
-                    if outcome == FinalizationOutcome.SETTLED
-                    else None
-                ),
+        observation = AuthorizationObservation(
+            idempotency_scope=allocation.idempotency_scope,
+            authorization_id=allocation.authorization_id,
+            request_fingerprint=allocation.request_fingerprint,
+            lease_id=row.lease_id,
+            gen=row.gen,
+            allocated_micro=allocation.allocated_micro,
+            key_hash=row.key_hash,
+            workspace_id=row.workspace_id,
+            durability=(
+                AuthorizationDurability.TERMINAL
+                if authorization.settled
+                else AuthorizationDurability.OPEN
+            ),
+            finalization_outcome=outcome,
+            finalized_cost_microdollars=(
+                authorization.finalized_cost_microdollars
+                if outcome == FinalizationOutcome.SETTLED
+                else None
             ),
         )
+        try:
+            ledger.mirror(
+                row.lease_id,
+                region=row.region,
+                observation=observation,
+            )
+        except SpendLeaseMonetaryMismatch as exc:
+            ledger.quarantine(
+                row.lease_id,
+                region=row.region,
+                idempotency_scope=allocation.idempotency_scope,
+                proof=MonetaryMismatchProof(
+                    exc.finalized_cost_microdollars,
+                    exc.allocated_micro,
+                ),
+            )
+            log.error(
+                "spend_lease.historical_overcharge",
+                extra={
+                    "authorization_id": allocation.authorization_id,
+                    "spend_lease_id": row.lease_id,
+                    "spend_lease_gen": row.gen,
+                    "spend_lease_allocated_micro": allocation.allocated_micro,
+                    "finalized_cost_microdollars": exc.finalized_cost_microdollars,
+                },
+            )
     refreshed = ledger.get(row.lease_id, region=row.region)
     if refreshed is None:
         raise RuntimeError("spend lease disappeared during allocation mirror")

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -1302,6 +1302,24 @@ class _FakeTransaction:
             new["updated_at"] = p["now"]
             self.pending_writes.append(("update_settle_outbox", pk, new))
             return 1
+        if sql.startswith("UPDATE tr_settle_outbox SET actual_cost_micro="):
+            _require_pred(sql, "authorization_id=@aid AND intent_kind=@kind", "corrective-rewrite")
+            _require_pred(sql, "status='pending'", "corrective-rewrite")
+            _require_pred(sql, "lease_owner=@lease_owner", "corrective-rewrite")
+            pk = (p["aid"], p["kind"])
+            rec = self._settle_outbox_current(pk)
+            if rec is None or rec.get("status") != "pending":
+                return 0
+            if rec.get("lease_owner") != p["lease_owner"]:
+                return 0
+            new = dict(
+                rec,
+                actual_cost_micro=p["actual_cost_micro"],
+                settle_body=p["settle_body"],
+                updated_at=p["now"],
+            )
+            self.pending_writes.append(("update_settle_outbox", pk, new))
+            return 1
         if sql.startswith(
             "UPDATE tr_settle_outbox SET auto_refill_workspace_id=@workspace_id"
         ):

--- a/tests/test_settle_outbox_apply.py
+++ b/tests/test_settle_outbox_apply.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Iterator
 from dataclasses import replace
 from typing import Any
@@ -37,6 +38,10 @@ from trusted_router.services.settle_outbox_apply import ApplyOutcome, apply_froz
 from trusted_router.storage import InMemoryStore, configure_store
 from trusted_router.storage_gcp_authorize import AuthorizeOutcome, SettleOutcome, settle_atomic
 from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
+from trusted_router.storage_gcp_operational_analytics_outbox import (
+    SpannerOperationalAnalyticsOutbox,
+)
+from trusted_router.storage_gcp_settle_outbox import SpannerSettleOutbox
 from trusted_router.storage_models import CreditAccount, GatewayAuthorization, SettleOutboxRow
 
 MODEL_ID = "anthropic/claude-haiku-4.5"
@@ -261,11 +266,40 @@ def _row(
 
 
 def _generation_bodies(db: Any) -> list[dict[str, Any]]:
-    return [
+    legacy = [
         json.loads(row.body)
         for (kind, _entity_id), row in db.rows.items()
         if kind == "generation"
     ]
+    typed = [json.loads(record["payload"]) for record in db.generation_records.values()]
+    return legacy + typed
+
+
+def _stamp_spend_lease_binding(
+    db: Any,
+    auth: GatewayAuthorization,
+    *,
+    allocation_micro: int,
+) -> None:
+    record = db.gateway_authorizations[auth.id]
+    payload = json.loads(record["payload"])
+    binding = {
+        "settlement": "spend_lease",
+        "spend_lease_id": "lease-repair",
+        "spend_lease_gen": 8,
+        "spend_lease_allocated_micro": allocation_micro,
+    }
+    payload.update(binding)
+    record.update(binding)
+    record["payload"] = json.dumps(payload, separators=(",", ":"))
+
+
+def _enable_typed_generation_durability(store: Any) -> None:
+    outbox = SpannerOperationalAnalyticsOutbox(store._database, store._param_types)
+    store._generation_records_enabled = True
+    store._operational_analytics_outbox = outbox
+    store.generation_store._generation_records_enabled = True
+    store.generation_store._operational_analytics_outbox = outbox
 
 
 class _TypedStoreProxy:
@@ -571,6 +605,203 @@ def test_zero_markup_authorization_without_payout_fields_charges_only(
     assert apply_frozen_settle(_row(auth, cost=800_000)) == ApplyOutcome.SETTLED_NOW
     assert _typed_credit(db, ws)["total_usage"] == 800_000
     assert store.list_credit_movements("user:") == []
+
+
+def test_unclaimed_frozen_overcharge_is_corrected_atomically_and_crash_replays_identically(
+    fake_store: tuple[Any, Any, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, db, _bt = fake_store
+    store.request_record_write_mode = "typed"
+    _enable_typed_generation_durability(store)
+    ws = "ws-spend-lease-corrective-repair"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_app_authorization(
+        store,
+        workspace_id=ws,
+        key_hash=key.hash,
+        markup_basis_points=2_500,
+    )
+    allocation = 400_000
+    _stamp_spend_lease_binding(db, auth, allocation_micro=allocation)
+    old_markup = app_markup_microdollars_from_charge(800_000, auth.app_markup_basis_points)
+    body = json.loads(_settle_body(auth.id))
+    body.update(
+        {
+            APP_MARKUP_PAYOUT_SETTLE_FIELD: app_markup_owner_share_microdollars(old_markup),
+            APP_MARKUP_OWNER_SETTLE_FIELD: auth.app_owner_user_id,
+            APP_MARKUP_APP_ID_SETTLE_FIELD: auth.app_id,
+        }
+    )
+    outbox = SpannerSettleOutbox(db, store._param_types)
+    outbox.enqueue(_row(auth, cost=800_000, settle_body=json.dumps(body)))
+    [claimed] = outbox.claim(limit=1)
+
+    with caplog.at_level(logging.ERROR):
+        assert apply_frozen_settle(claimed) == ApplyOutcome.SETTLED_NOW
+
+    repaired = db.settle_outbox[(auth.id, "settle")]
+    repaired_body = json.loads(repaired["settle_body"])
+    repaired_markup = app_markup_microdollars_from_charge(
+        allocation, auth.app_markup_basis_points
+    )
+    repaired_payout = app_markup_owner_share_microdollars(repaired_markup)
+    assert repaired["actual_cost_micro"] == allocation
+    assert repaired_body[APP_MARKUP_PAYOUT_SETTLE_FIELD] == repaired_payout
+    assert _typed_credit(db, ws)["total_usage"] == allocation
+    assert db.reservations[auth.credit_reservation_id]["actual_micro"] == allocation
+    assert db.gateway_authorizations[auth.id]["finalized_cost_microdollars"] == allocation
+    assert db.gateway_authorizations[auth.id]["terminal_at"] is None
+    assert db.reservations[auth.credit_reservation_id]["terminal_at"] is None
+    [generation] = _generation_bodies(db)
+    assert generation["total_cost_microdollars"] == allocation
+    assert generation["app_markup_microdollars"] == repaired_markup
+    [analytics_intent] = db.operational_analytics_outbox
+    assert json.loads(analytics_intent["payload"])["total_cost_microdollars"] == allocation
+    assert store.earnings_summary(auth.app_owner_user_id)["total_earned"] == repaired_payout
+    assert "spend_lease.frozen_charge_capped_at_allocation" in caplog.text
+
+    # Crash before mark(done): the corrected row remains the sole replay authority.
+    repaired["leased_until"] = "2000-01-01T00:00:00Z"
+    [reclaimed] = outbox.claim(limit=1)
+    assert reclaimed.actual_cost_micro == allocation
+    assert apply_frozen_settle(reclaimed) == ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE
+    assert _typed_credit(db, ws)["total_usage"] == allocation
+    assert store.earnings_summary(auth.app_owner_user_id)["total_earned"] == repaired_payout
+    assert outbox.mark(
+        auth.id,
+        "settle",
+        done=True,
+        lease_owner=reclaimed.lease_owner,
+    ) == "done"
+    assert db.gateway_authorizations[auth.id]["terminal_at"] is not None
+    assert db.reservations[auth.credit_reservation_id]["terminal_at"] is not None
+
+
+def test_lost_outbox_lease_rolls_back_corrective_finalization(
+    fake_store: tuple[Any, Any, Any],
+) -> None:
+    store, db, _bt = fake_store
+    store.request_record_write_mode = "typed"
+    _enable_typed_generation_durability(store)
+    ws = "ws-spend-lease-lost-repair-fence"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    _stamp_spend_lease_binding(db, auth, allocation_micro=400_000)
+    outbox = SpannerSettleOutbox(db, store._param_types)
+    outbox.enqueue(_row(auth, cost=800_000))
+    [claimed] = outbox.claim(limit=1)
+    db.settle_outbox[(auth.id, "settle")]["lease_owner"] = "newer-worker"
+
+    assert apply_frozen_settle(claimed) == ApplyOutcome.ERROR
+
+    assert db.reservations[auth.credit_reservation_id]["settled"] is False
+    assert _typed_credit(db, ws)["total_usage"] == 0
+    assert db.settle_outbox[(auth.id, "settle")]["actual_cost_micro"] == 800_000
+    assert _generation_bodies(db) == []
+
+
+def test_already_finalized_historical_overcharge_is_unchanged_logged_and_replayed(
+    fake_store: tuple[Any, Any, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, db, _bt = fake_store
+    store.request_record_write_mode = "typed"
+    _enable_typed_generation_durability(store)
+    ws = "ws-spend-lease-historical-overcharge"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    allocation = 400_000
+    historical = 800_000
+    _stamp_spend_lease_binding(db, auth, allocation_micro=allocation)
+    reservation = db.reservations[auth.credit_reservation_id]
+    reservation.update(settled=True, actual_micro=historical)
+    db.typed[CREDIT_BALANCE_TABLE][(ws, 0)].update(
+        total_usage=historical,
+        reserved=0,
+    )
+    record = db.gateway_authorizations[auth.id]
+    record.update(
+        settled=True,
+        finalization_outcome="settled",
+        finalized_cost_microdollars=historical,
+    )
+    payload = json.loads(record["payload"])
+    payload.update(
+        settled=True,
+        finalization_outcome="settled",
+        finalized_cost_microdollars=historical,
+    )
+    record["payload"] = json.dumps(payload)
+    outbox = SpannerSettleOutbox(db, store._param_types)
+    outbox.enqueue(_row(auth, cost=900_000))
+    [claimed] = outbox.claim(limit=1)
+
+    with caplog.at_level(logging.ERROR):
+        outcome = apply_frozen_settle(claimed)
+
+    assert outcome == ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE
+    assert reservation["actual_micro"] == historical
+    assert _typed_credit(db, ws)["total_usage"] == historical
+    [generation] = _generation_bodies(db)
+    assert generation["total_cost_microdollars"] == historical
+    assert "spend_lease.historical_overcharge" in caplog.text
+
+
+def test_two_spend_lease_repairs_book_at_most_once(
+    fake_store: tuple[Any, Any, Any],
+) -> None:
+    store, db, _bt = fake_store
+    store.request_record_write_mode = "typed"
+    ws = "ws-spend-lease-two-repairs"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    allocation = 400_000
+    _stamp_spend_lease_binding(db, auth, allocation_micro=allocation)
+    outbox = SpannerSettleOutbox(db, store._param_types)
+    outbox.enqueue(_row(auth, cost=800_000))
+    [claimed] = outbox.claim(limit=1)
+    stale_worker_view = replace(claimed)
+
+    assert apply_frozen_settle(claimed) == ApplyOutcome.SETTLED_NOW
+    assert apply_frozen_settle(stale_worker_view) == ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE
+
+    assert db.reservations[auth.credit_reservation_id]["actual_micro"] == allocation
+    assert _typed_credit(db, ws)["total_usage"] == allocation
+
+
+def test_spend_lease_repair_losing_to_reaper_never_books_charge(
+    fake_store: tuple[Any, Any, Any],
+) -> None:
+    store, db, _bt = fake_store
+    store.request_record_write_mode = "typed"
+    ws = "ws-spend-lease-repair-vs-reaper"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    _stamp_spend_lease_binding(db, auth, allocation_micro=400_000)
+    outbox = SpannerSettleOutbox(db, store._param_types)
+    outbox.enqueue(_row(auth, cost=800_000))
+    [claimed] = outbox.claim(limit=1)
+    freed = settle_atomic(
+        store._database,
+        store._param_types,
+        reservation_id=auth.credit_reservation_id,
+        actual_micro=0,
+        settled_usage_type="Credits",
+        success=False,
+        guard_outbox=False,
+    )
+    assert freed["outcome"] == SettleOutcome.SETTLED
+
+    assert apply_frozen_settle(claimed) == ApplyOutcome.ALREADY_RELEASED_FREE
+    assert db.reservations[auth.credit_reservation_id]["actual_micro"] == 0
+    assert _typed_credit(db, ws)["total_usage"] == 0
+    assert _generation_bodies(db) == []
 
 
 def test_missing_frozen_app_markup_fields_replay_credits_once(

--- a/tests/test_settle_outbox_apply.py
+++ b/tests/test_settle_outbox_apply.py
@@ -679,6 +679,32 @@ def test_unclaimed_frozen_overcharge_is_corrected_atomically_and_crash_replays_i
     assert db.reservations[auth.credit_reservation_id]["terminal_at"] is not None
 
 
+def test_ownerless_corrective_settle_returns_error_without_rewrite_claim_or_charge(
+    fake_store: tuple[Any, Any, Any],
+) -> None:
+    store, db, _bt = fake_store
+    store.request_record_write_mode = "typed"
+    ws = "ws-spend-lease-ownerless-corrective"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    allocation = 400_000
+    frozen_cost = 800_000
+    _stamp_spend_lease_binding(db, auth, allocation_micro=allocation)
+    row = _row(auth, cost=frozen_cost)
+    original_body = row.settle_body
+    assert row.lease_owner is None
+
+    assert apply_frozen_settle(row) == ApplyOutcome.ERROR
+
+    assert row.actual_cost_micro == frozen_cost
+    assert row.settle_body == original_body
+    assert db.settle_outbox == {}
+    assert db.reservations[auth.credit_reservation_id]["settled"] is False
+    assert _typed_credit(db, ws)["total_usage"] == 0
+    assert _generation_bodies(db) == []
+
+
 def test_lost_outbox_lease_rolls_back_corrective_finalization(
     fake_store: tuple[Any, Any, Any],
 ) -> None:
@@ -748,7 +774,16 @@ def test_already_finalized_historical_overcharge_is_unchanged_logged_and_replaye
     assert _typed_credit(db, ws)["total_usage"] == historical
     [generation] = _generation_bodies(db)
     assert generation["total_cost_microdollars"] == historical
-    assert "spend_lease.historical_overcharge" in caplog.text
+    [event] = [
+        record
+        for record in caplog.records
+        if record.getMessage() == "spend_lease.historical_overcharge"
+    ]
+    event_fields = vars(event)
+    assert event_fields["finalized_cost_microdollars"] == historical
+    assert event_fields["spend_lease_allocated_micro"] == allocation
+    assert event_fields["authorization_id"] == auth.id
+    assert event_fields["spend_lease_id"] == "lease-repair"
 
 
 def test_two_spend_lease_repairs_book_at_most_once(

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -5,6 +5,7 @@ import json
 import logging
 import re
 from collections.abc import Iterator
+from dataclasses import asdict, replace
 from typing import Any
 
 import pytest
@@ -12,6 +13,11 @@ from fastapi.testclient import TestClient
 from google.api_core.exceptions import DeadlineExceeded
 
 from tests.fakes.spanner import _FakeTransaction, make_fake_store
+from trusted_router.app_markup_billing import (
+    APP_MARKUP_PAYOUT_SETTLE_FIELD,
+    app_markup_microdollars_from_charge,
+    app_markup_owner_share_microdollars,
+)
 from trusted_router.config import Settings
 from trusted_router.custom_model_billing import user_model_payout_event_id
 from trusted_router.main import create_app
@@ -138,6 +144,9 @@ def _typed_authorization(
     key_hash: str,
     estimate: int = ESTIMATE,
     expires_at: str = "2026-01-01T00:00:00Z",
+    app_id: str = "",
+    app_markup_basis_points: int = 0,
+    app_owner_user_id: str = "",
 ) -> GatewayAuthorization:
     outcome, auth = store.authorize_gateway_typed(
         workspace_id=workspace_id,
@@ -154,6 +163,9 @@ def _typed_authorization(
         candidate_endpoint_ids=[ENDPOINT_ID],
         idempotency_key=None,
         idempotency_fingerprint=None,
+        app_id=app_id,
+        app_markup_basis_points=app_markup_basis_points,
+        app_owner_user_id=app_owner_user_id,
         expires_at=expires_at,
     )
     assert outcome == AuthorizeOutcome.ACCEPTED
@@ -308,6 +320,25 @@ def _settle_timing_records(caplog: pytest.LogCaptureFixture) -> list[logging.Log
         for record in caplog.records
         if record.name == GATEWAY_LOGGER and record.getMessage().startswith("settle timing ")
     ]
+
+
+def _stamp_spend_lease_binding(
+    db: Any,
+    auth: GatewayAuthorization,
+    *,
+    allocation_micro: int,
+) -> None:
+    record = db.gateway_authorizations[auth.id]
+    payload = json.loads(record["payload"])
+    binding = {
+        "settlement": "spend_lease",
+        "spend_lease_id": "lease-settle-clamp",
+        "spend_lease_gen": 7,
+        "spend_lease_allocated_micro": allocation_micro,
+    }
+    payload.update(binding)
+    record.update(binding)
+    record["payload"] = json.dumps(payload, separators=(",", ":"))
 
 
 # Unit (storage)
@@ -2496,11 +2527,13 @@ def _settle_with_sql_spy(
     # A monotonic per-transaction number, NOT id(): CPython reuses the id of a
     # freed transaction object, so a later standalone-mark transaction could
     # alias the finalize one and pass a same-transaction check vacuously.
-    sequence: dict[int, int] = {}
+    next_txn = 0
 
     def spy(self: Any, sql: str, **kwargs: Any) -> int:
-        txn = sequence.setdefault(id(self), len(sequence))
-        self.__dict__.setdefault("_spy_txn", txn)
+        nonlocal next_txn
+        if "_spy_txn" not in self.__dict__:
+            self.__dict__["_spy_txn"] = next_txn
+            next_txn += 1
         calls.append((self.__dict__["_spy_txn"], sql))
         return original_update(self, sql, **kwargs)
 
@@ -2544,6 +2577,174 @@ def test_inline_settle_resolves_the_outbox_row_inside_the_finalize_commit(
     [record] = _settle_timing_records(caplog)
     assert isinstance(record.args, tuple)
     assert record.args[7] == 0.0  # mark_ms: no standalone mark commit
+
+
+def test_inline_spend_lease_overrun_caps_charge_generation_typed_cost_and_outbox(
+    prod_shaped_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, db, _bt = prod_shaped_store
+    enqueued: list[SettleOutboxRow] = []
+    real_enqueue = SpannerSettleOutbox.enqueue
+
+    def capture(self: SpannerSettleOutbox, row: SettleOutboxRow, **kwargs: Any) -> str:
+        enqueued.append(replace(row))
+        return real_enqueue(self, row, **kwargs)
+
+    monkeypatch.setattr(SpannerSettleOutbox, "enqueue", capture)
+    ws = "ws-spend-lease-inline-clamp"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    allocation = 500
+    markup_basis_points = 2_500
+    app_owner = "owner-spend-lease-inline-clamp"
+    auth = _typed_authorization(
+        store,
+        workspace_id=ws,
+        key_hash=key.hash,
+        app_id="app-spend-lease-inline-clamp",
+        app_markup_basis_points=markup_basis_points,
+        app_owner_user_id=app_owner,
+    )
+    _stamp_spend_lease_binding(db, auth, allocation_micro=allocation)
+    settings = Settings(
+        environment="test",
+        settle_outbox_enabled=True,
+        operational_analytics_outbox_enabled=True,
+        spend_lease_issuance_enabled=True,
+        spend_lease_binding_enabled=True,
+        spend_lease_pilot_workspace_ids=ws,
+        spend_lease_signing_secret_name="test-secret",  # noqa: S106
+    )
+
+    with caplog.at_level(logging.WARNING):
+        response = _client(settings).post(
+            "/v1/internal/gateway/settle",
+            json=_settle_json(auth.id),
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["cost_microdollars"] == allocation
+    assert _typed_credit(db, ws)["total_usage"] == allocation
+    assert db.reservations[auth.credit_reservation_id]["actual_micro"] == allocation
+    typed_auth = db.gateway_authorizations[auth.id]
+    assert typed_auth["finalized_cost_microdollars"] == allocation
+    outbox = db.settle_outbox[(auth.id, "settle")]
+    assert outbox["actual_cost_micro"] == allocation
+    markup = app_markup_microdollars_from_charge(allocation, markup_basis_points)
+    payout = app_markup_owner_share_microdollars(markup)
+    [frozen] = enqueued
+    assert frozen.actual_cost_micro == allocation
+    assert json.loads(frozen.settle_body or "{}")[APP_MARKUP_PAYOUT_SETTLE_FIELD] == payout
+    [generation] = db.generation_records.values()
+    generation_payload = json.loads(generation["payload"])
+    assert generation_payload["total_cost_microdollars"] == allocation
+    assert generation_payload["app_markup_microdollars"] == markup
+    [analytics] = db.operational_analytics_outbox
+    assert json.loads(analytics["payload"])["total_cost_microdollars"] == allocation
+    assert store.earnings_summary(app_owner)["total_earned"] == payout
+
+    replay = _client(settings).post(
+        "/v1/internal/gateway/settle",
+        json=_settle_json(auth.id),
+    )
+    assert replay.status_code == 200, replay.text
+    assert replay.json()["data"]["already_settled"] is True
+    assert db.reservations[auth.credit_reservation_id]["actual_micro"] == allocation
+    assert store.earnings_summary(app_owner)["total_earned"] == payout
+    assert "billing.spend_lease_settle_capped_to_allocation" in caplog.text
+
+
+def test_eager_mirror_runs_after_won_finalize_not_lost_replay(
+    prod_shaped_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, db, _bt = prod_shaped_store
+    ws = "ws-spend-lease-eager-winner"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws)
+    winner = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    loser = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    _stamp_spend_lease_binding(db, winner, allocation_micro=ESTIMATE)
+    _stamp_spend_lease_binding(db, loser, allocation_micro=ESTIMATE)
+    mirrored: list[str] = []
+    monkeypatch.setattr(
+        "trusted_router.routes.internal.gateway.mirror_finalized_spend_lease_best_effort",
+        lambda _store, committed: mirrored.append(committed.id),
+    )
+    real_finalize = type(store).typed_finalize_gateway_authorization_result
+
+    def finalize_with_lost_replay(self: Any, authorization_id: str, **kwargs: Any) -> Any:
+        if authorization_id == loser.id:
+            return TypedFinalizeResult(finalized=False, activity_indexed=False)
+        return real_finalize(self, authorization_id, **kwargs)
+
+    monkeypatch.setattr(
+        type(store),
+        "typed_finalize_gateway_authorization_result",
+        finalize_with_lost_replay,
+    )
+    client = _client(Settings(environment="test", settle_outbox_enabled=True))
+
+    won = client.post("/v1/internal/gateway/settle", json=_settle_json(winner.id))
+    lost = client.post("/v1/internal/gateway/settle", json=_settle_json(loser.id))
+
+    assert won.status_code == lost.status_code == 200
+    assert mirrored == [winner.id]
+
+
+def test_flag_off_settle_body_outbox_and_charge_ignore_lease_named_extras(
+    prod_shaped_store: tuple[Any, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, _db, _bt = prod_shaped_store
+    captured: list[SettleOutboxRow] = []
+    real_enqueue = SpannerSettleOutbox.enqueue
+
+    def capture(self: SpannerSettleOutbox, row: SettleOutboxRow, **kwargs: Any) -> str:
+        captured.append(row)
+        return real_enqueue(self, row, **kwargs)
+
+    monkeypatch.setattr(SpannerSettleOutbox, "enqueue", capture)
+    client = _client(Settings(environment="test", settle_outbox_enabled=True))
+    responses = []
+    for suffix, extras in (
+        ("plain", {}),
+        (
+            "lease-extras",
+            {
+                "spend_lease_id": "caller-forged",
+                "spend_lease_gen": 99,
+                "spend_lease_allocated_micro": 1,
+                "settlement": "spend_lease",
+            },
+        ),
+    ):
+        ws = f"ws-flag-off-{suffix}"
+        _seed_credit(store, ws)
+        key = _make_key(store, ws)
+        auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+        body = _settle_json(auth.id, request_id="same-request")
+        body.update(extras)
+        responses.append(client.post("/v1/internal/gateway/settle", json=body))
+
+    assert [response.status_code for response in responses] == [200, 200]
+    assert responses[0].json()["data"]["cost_microdollars"] == responses[1].json()["data"][
+        "cost_microdollars"
+    ]
+    normalized_rows = []
+    for row in captured:
+        frozen = asdict(row)
+        frozen["authorization_id"] = "normalized"
+        frozen["reservation_id"] = "normalized"
+        frozen["next_attempt_at"] = "normalized"
+        frozen["created_at"] = "normalized"
+        frozen["settle_body"] = (row.settle_body or "").replace(
+            row.authorization_id, "normalized"
+        )
+        normalized_rows.append(frozen)
+    assert normalized_rows[0] == normalized_rows[1]
 
 
 def test_inline_settle_leaves_a_leased_outbox_row_to_its_drain_worker(

--- a/tests/test_spend_lease_authorize.py
+++ b/tests/test_spend_lease_authorize.py
@@ -1019,5 +1019,6 @@ def test_flag_on_store_path_mints_binds_and_returns_token_iff_bound() -> None:
 
     assert verdict.spend_lease_bound is True
     assert authorization is not None
+    assert authorization.settlement == "spend_lease"
     assert bool(authorization.spend_lease_token) is verdict.spend_lease_bound
     assert ledger.binds == 1

--- a/tests/test_spend_lease_reconcile.py
+++ b/tests/test_spend_lease_reconcile.py
@@ -10,7 +10,9 @@ from tests.fakes.spanner import FakeSpannerDatabase, make_fake_store
 from tests.fakes.spend_lease_bigtable import FakeBigtableTable
 from trusted_router.spend_lease_ledger import BigtableSpendLeaseLedger
 from trusted_router.spend_lease_state import (
+    AllocationState,
     BindingState,
+    MonetaryMismatchProof,
     SpendLease,
     SpendLeaseConflictError,
     SpendLeaseState,
@@ -256,6 +258,44 @@ def test_open_sweep_binds_as_last_resort_without_incrementing_attempts(
     assert local.allocations[0].binding_state == BindingState.COMMITTED
     assert result["deferred"] == 1
     assert row["attempts"] == 0
+
+
+def test_reconciler_monetary_mismatch_quarantines_with_proof_and_replays(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, database, ledger = _store()
+    identity = _identity(expires_at=NOW + timedelta(minutes=5))
+    _insert_candidate(store, identity)
+    _open_candidate(store, identity)
+    database.spend_lease_open[identity.lease_id]["next_attempt_at"] = NOW
+    ledger.initialize(_local_candidate(identity), region=REGION)
+    _allocate(ledger, identity)
+    _seed_global(store, identity, state="ACTIVE")
+
+    class Authorization:
+        id = identity.creating_authorization_id
+        spend_lease_id = identity.lease_id
+        spend_lease_gen = identity.gen
+        spend_lease_allocated_micro = 500
+        finalization_outcome = "settled"
+        finalized_cost_microdollars = 800
+        settled = True
+
+    monkeypatch.setattr(type(store), "get_gateway_authorization", lambda *_: Authorization())
+
+    with caplog.at_level(logging.ERROR):
+        first = reconcile_spend_leases(store, now=NOW)
+        database.spend_lease_open[identity.lease_id]["next_attempt_at"] = NOW
+        second = reconcile_spend_leases(store, now=NOW + timedelta(minutes=1))
+
+    local = ledger.get(identity.lease_id, region=REGION)
+    assert first["deferred"] == second["deferred"] == 1
+    assert local is not None
+    allocation = local.allocations[0]
+    assert allocation.state == AllocationState.QUARANTINED
+    assert allocation.contradiction_proof == MonetaryMismatchProof(800, 500)
+    assert "spend_lease.historical_overcharge" in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/test_spend_lease_settlement.py
+++ b/tests/test_spend_lease_settlement.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from trusted_router.app_markup_billing import (
+    APP_MARKUP_PAYOUT_SETTLE_FIELD,
+    app_markup_microdollars_from_charge,
+    app_markup_owner_share_microdollars,
+)
+from trusted_router.services.spend_lease_settlement import (
+    clamp_spend_lease_charge,
+    derive_spend_lease_repair_amounts,
+    mirror_finalized_spend_lease_best_effort,
+)
+from trusted_router.spend_lease_state import (
+    FinalizationOutcome,
+    MonetaryMismatchProof,
+    SpendLeaseMonetaryMismatch,
+)
+from trusted_router.storage_models import GatewayAuthorization
+from trusted_router.types import UsageType
+
+
+def _authorization(**overrides: Any) -> GatewayAuthorization:
+    values: dict[str, Any] = {
+        "id": "authorization-1",
+        "workspace_id": "workspace-1",
+        "key_hash": "key-1",
+        "model_id": "model-1",
+        "provider": "provider-1",
+        "usage_type": UsageType.CREDITS,
+        "estimated_microdollars": 900,
+        "settlement": "spend_lease",
+        "region": "us-central1",
+        "spend_lease_id": "lease-1",
+        "spend_lease_gen": 3,
+        "spend_lease_allocated_micro": 700,
+    }
+    values.update(overrides)
+    return GatewayAuthorization(**values)
+
+
+def test_spend_lease_clamp_uses_minimum_of_allocation_and_estimate() -> None:
+    assert clamp_spend_lease_charge(_authorization(), 1_200) == 700
+    assert (
+        clamp_spend_lease_charge(
+            _authorization(estimated_microdollars=600, spend_lease_allocated_micro=700),
+            1_200,
+        )
+        == 600
+    )
+
+
+def test_binding_facts_missing_falls_back_to_estimate_and_logs_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.ERROR):
+        charge = clamp_spend_lease_charge(
+            _authorization(spend_lease_allocated_micro=None),
+            1_200,
+        )
+
+    assert charge == 900
+    assert "spend_lease.settle_binding_facts_missing" in caplog.text
+
+
+def test_corrective_helper_rederives_markup_and_payout_from_capped_charge() -> None:
+    authorization = _authorization(
+        app_id="app-1",
+        app_owner_user_id="owner-1",
+        app_markup_basis_points=2_500,
+    )
+
+    repaired = derive_spend_lease_repair_amounts(
+        authorization,
+        1_200,
+        {APP_MARKUP_PAYOUT_SETTLE_FIELD: 999_999},
+    )
+
+    markup = app_markup_microdollars_from_charge(700, 2_500)
+    payout = app_markup_owner_share_microdollars(markup)
+    assert repaired.actual_cost_micro == 700
+    assert repaired.app_markup_micro == markup
+    assert repaired.app_markup_payout_micro == payout
+    assert repaired.settle_body[APP_MARKUP_PAYOUT_SETTLE_FIELD] == payout
+
+
+class _Ledger:
+    def __init__(self, *, mismatch: bool = False, failure: bool = False) -> None:
+        self.mismatch = mismatch
+        self.failure = failure
+        self.observations: list[Any] = []
+        self.quarantines: list[Any] = []
+        self.allocation = SimpleNamespace(
+            authorization_id="authorization-1",
+            idempotency_scope="scope-1",
+            request_fingerprint="fingerprint-1",
+        )
+
+    def get(self, _lease_id: str, *, region: str) -> Any:
+        assert region == "us-central1"
+        return SimpleNamespace(allocations=[self.allocation])
+
+    def mirror(self, _lease_id: str, *, region: str, observation: Any) -> None:
+        if self.failure:
+            raise RuntimeError("ledger unavailable")
+        self.observations.append(observation)
+        if self.mismatch:
+            raise SpendLeaseMonetaryMismatch(
+                finalized_cost_microdollars=800,
+                allocated_micro=700,
+            )
+
+    def quarantine(self, _lease_id: str, **kwargs: Any) -> None:
+        self.quarantines.append(kwargs)
+
+
+def test_eager_mirror_maps_settled_and_refunded_committed_outcomes() -> None:
+    ledger = _Ledger()
+    store = SimpleNamespace(_spend_lease_ledger=ledger)
+    settled = _authorization(
+        settled=True,
+        finalization_outcome="settled",
+        finalized_cost_microdollars=650,
+    )
+    refunded = _authorization(
+        settled=True,
+        finalization_outcome="refunded",
+        finalized_cost_microdollars=0,
+    )
+
+    mirror_finalized_spend_lease_best_effort(store, settled)
+    mirror_finalized_spend_lease_best_effort(store, refunded)
+
+    assert [item.finalization_outcome for item in ledger.observations] == [
+        FinalizationOutcome.SETTLED,
+        FinalizationOutcome.REFUNDED,
+    ]
+    assert [item.finalized_cost_microdollars for item in ledger.observations] == [650, None]
+
+
+def test_eager_mirror_monetary_mismatch_quarantines_with_proof() -> None:
+    ledger = _Ledger(mismatch=True)
+    store = SimpleNamespace(_spend_lease_ledger=ledger)
+
+    mirror_finalized_spend_lease_best_effort(
+        store,
+        _authorization(
+            settled=True,
+            finalization_outcome="settled",
+            finalized_cost_microdollars=800,
+        ),
+    )
+
+    assert len(ledger.quarantines) == 1
+    assert ledger.quarantines[0]["proof"] == MonetaryMismatchProof(800, 700)
+
+
+def test_eager_mirror_failure_is_harmless_and_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    ledger = _Ledger(failure=True)
+    with caplog.at_level(logging.ERROR):
+        mirror_finalized_spend_lease_best_effort(
+            SimpleNamespace(_spend_lease_ledger=ledger),
+            _authorization(
+                settled=True,
+                finalization_outcome="settled",
+                finalized_cost_microdollars=650,
+            ),
+        )
+
+    assert "spend_lease.eager_mirror_failed" in caplog.text

--- a/tests/test_spend_leases.py
+++ b/tests/test_spend_leases.py
@@ -21,6 +21,7 @@ from trusted_router.spend_leases import (
     freeze_spend_lease_catalog,
     mint_shadow_spend_lease,
     parse_boot_auth_header,
+    spend_lease_binding_ineligibility_reason,
     spend_lease_catalog_estimate,
     spend_lease_eligible,
     spend_lease_ineligibility_reason,
@@ -103,6 +104,17 @@ def test_spend_lease_scope_salt_pins_sha256_hex_prefix() -> None:
 
 
 def test_spend_lease_eligibility_accepts_exact_credits_chat_cohort() -> None:
+    assert _eligible()
+
+
+def test_deferred_settlement_is_binding_ineligible_but_stage_a_shadow_is_unchanged() -> None:
+    stage_a_reason = _ineligibility_reason()
+
+    assert stage_a_reason is None
+    assert spend_lease_binding_ineligibility_reason(
+        stage_a_reason,
+        deferred_settlement_applies=True,
+    ) == "deferred_settlement"
     assert _eligible()
 
 

--- a/tests/test_storage_gcp_spend_lease.py
+++ b/tests/test_storage_gcp_spend_lease.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
@@ -364,7 +365,8 @@ def test_authorization_typed_columns_round_trip_merge_and_reject_zero_allocation
     assert tuple(typed) == AUTHORIZATION_TYPED_COLUMNS
     assert typed["spend_lease_exp"] == datetime.fromtimestamp(1_800_000_000, tz=UTC)
     assert merge_authorization_typed_columns(None, typed) == {
-        key: value for key, value in payload.items() if key != "authorization_id"
+        **{key: value for key, value in payload.items() if key != "authorization_id"},
+        "settlement": "spend_lease",
     }
 
     old_writer_payload = dict(payload, spend_lease_status="expired", finalization_outcome="refunded")
@@ -382,3 +384,33 @@ def test_authorization_typed_columns_round_trip_merge_and_reject_zero_allocation
             {"spend_lease_allocated_micro": 0},
             {},
         )
+
+
+def test_payload_erased_complete_typed_tuple_derives_spend_lease_settlement() -> None:
+    merged = merge_authorization_typed_columns(
+        None,
+        {
+            "spend_lease_id": "lease-erased",
+            "spend_lease_gen": 4,
+            "spend_lease_allocated_micro": 900,
+        },
+    )
+
+    assert merged["settlement"] == "spend_lease"
+
+
+def test_payload_settlement_disagreement_logs_and_typed_wins(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.ERROR):
+        merged = merge_authorization_typed_columns(
+            {"settlement": "local"},
+            {
+                "spend_lease_id": "lease-mismatch",
+                "spend_lease_gen": 5,
+                "spend_lease_allocated_micro": 901,
+            },
+        )
+
+    assert merged["settlement"] == "spend_lease"
+    assert "spend_lease.settlement_kind_mismatch" in caplog.text

--- a/tests/test_storage_gcp_spend_lease.py
+++ b/tests/test_storage_gcp_spend_lease.py
@@ -10,6 +10,10 @@ import pytest
 
 from tests.fakes.spanner import FakeSpannerDatabase
 from trusted_router import spend_leases
+from trusted_router.storage_gcp_request_records import (
+    insert_gateway_authorization,
+    read_gateway_authorization,
+)
 from trusted_router.storage_gcp_spend_lease import (
     AUTHORIZATION_TYPED_COLUMNS,
     CandidateIdentity,
@@ -28,9 +32,12 @@ from trusted_router.storage_gcp_spend_lease import (
     take_recovery_ownership,
     upgrade_candidate_to_open,
 )
+from trusted_router.storage_models import GatewayAuthorization
+from trusted_router.types import UsageType
 
 PT = SimpleNamespace(STRING="STRING", INT64="INT64", BOOL="BOOL", TIMESTAMP="TIMESTAMP")
 NOW = datetime.now(UTC).replace(microsecond=0)
+LEASE_ARTIFACT = "opaque-signed-artifact"
 
 
 def _txn(db: FakeSpannerDatabase, fn: Callable[[Any], Any]) -> Any:
@@ -386,31 +393,81 @@ def test_authorization_typed_columns_round_trip_merge_and_reject_zero_allocation
         )
 
 
-def test_payload_erased_complete_typed_tuple_derives_spend_lease_settlement() -> None:
-    merged = merge_authorization_typed_columns(
-        None,
-        {
-            "spend_lease_id": "lease-erased",
-            "spend_lease_gen": 4,
-            "spend_lease_allocated_micro": 900,
-        },
+def _insert_bound_authorization(
+    db: FakeSpannerDatabase,
+    *,
+    authorization_id: str,
+    settlement: str,
+) -> None:
+    authorization = GatewayAuthorization(
+        id=authorization_id,
+        workspace_id="workspace-reader",
+        key_hash="k" * 64,
+        model_id="model-reader",
+        provider="provider-reader",
+        usage_type=UsageType.CREDITS,
+        estimated_microdollars=1_000,
+        credit_reservation_id="reservation-reader",
+        settlement=settlement,
+        spend_lease_id="lease-reader",
+        spend_lease_gen=4,
+        spend_lease_allocated_micro=900,
+        spend_lease_token=LEASE_ARTIFACT,
+        spend_lease_status="active",
+        spend_lease_exp=1_800_000_000,
+    )
+    _txn(
+        db,
+        lambda transaction: insert_gateway_authorization(
+            transaction,
+            PT,
+            authorization,
+            created_at=NOW,
+        ),
     )
 
-    assert merged["settlement"] == "spend_lease"
+
+def test_payload_erased_complete_typed_tuple_reads_back_as_spend_lease() -> None:
+    db = FakeSpannerDatabase()
+    authorization_id = "authorization-erased-reader"
+    _insert_bound_authorization(
+        db,
+        authorization_id=authorization_id,
+        settlement="spend_lease",
+    )
+    db.gateway_authorizations[authorization_id]["payload"] = None
+
+    with db.snapshot() as snapshot:
+        authorization = read_gateway_authorization(snapshot, PT, authorization_id)
+
+    assert authorization is not None
+    assert authorization.settlement == "spend_lease"
+    assert authorization.spend_lease_id == "lease-reader"
+    assert authorization.spend_lease_gen == 4
+    assert authorization.spend_lease_allocated_micro == 900
+    assert authorization.spend_lease_token == LEASE_ARTIFACT
+    assert authorization.spend_lease_status == "active"
+    assert authorization.spend_lease_exp == 1_800_000_000
 
 
-def test_payload_settlement_disagreement_logs_and_typed_wins(
+def test_payload_local_complete_typed_tuple_reads_back_as_spend_lease_and_logs_mismatch(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    with caplog.at_level(logging.ERROR):
-        merged = merge_authorization_typed_columns(
-            {"settlement": "local"},
-            {
-                "spend_lease_id": "lease-mismatch",
-                "spend_lease_gen": 5,
-                "spend_lease_allocated_micro": 901,
-            },
-        )
+    db = FakeSpannerDatabase()
+    authorization_id = "authorization-mismatch-reader"
+    _insert_bound_authorization(
+        db,
+        authorization_id=authorization_id,
+        settlement="local",
+    )
 
-    assert merged["settlement"] == "spend_lease"
+    with caplog.at_level(logging.ERROR):
+        with db.snapshot() as snapshot:
+            authorization = read_gateway_authorization(snapshot, PT, authorization_id)
+
+    assert authorization is not None
+    assert authorization.settlement == "spend_lease"
+    assert authorization.spend_lease_id == "lease-reader"
+    assert authorization.spend_lease_gen == 4
+    assert authorization.spend_lease_allocated_micro == 900
     assert "spend_lease.settlement_kind_mismatch" in caplog.text


### PR DESCRIPTION
Stage B unit 4 of the spend-lease program (design record v54, decisions 49–57): the settlement clamp, the last build step before the pilot binding flip. Ships behind `TR_SPEND_LEASE_BINDING_ENABLED`: with the flag off, settle bodies, outbox rows and charges are byte-identical to today, caller-supplied lease-named extras included.

- **Settlement classes (49):** a bound authorization is stamped `settlement="spend_lease"` inside the authorize transaction; unbound stays `local`; deferred settlement is binding-ineligible (`deferred_settlement` at the binding pre-read only; Stage A shadow issuance unchanged). The class charges and releases the ordinary request hold like `local` and never touches lease escrow.
- **The clamp (50):** at the regional precedent's position (after the markup add, before payout, generation and the outbox freeze), a successful spend-lease settle is capped at `min(allocated_micro, estimated)`, with a binding-facts-missing fallback to the estimate; markup and payout re-derive from the capped charge; the typed finalized cost is the capped charge.
- **Replay authority (51, 55):** the frozen outbox charge and payouts remain the sole replay authority. The one exception is an unclaimed spend-lease row whose frozen charge exceeds the typed allocation: repair applies the omitted clamp with the shared derivation and finalizes through the ordinary typed finalization in one transaction, rewriting the frozen amounts under the worker's lease fence with a zero-row rewrite treated as failure. An already-finalized overcharge is left unchanged, logged, and later quarantined.
- **Eager mirror (52, 53):** only after this call won the typed finalize; SETTLED / REFUNDED mapped, a monetary mismatch quarantined with `MonetaryMismatchProof`; failures logged and harmless.
- **Reconciler mapping (56)** and **the derived settlement kind after payload erasure (57)**, read back through the settle path's reader.

**Review:** isolated snapshot on the rebased tree; ruff; the new shared module strict-clean; 16 authorize, settle, outbox, ledger, reconciler and state suites green with the flag off; full suite green apart from the two known jq-missing harness tests; eleven mutations each red (clamp against the estimate, binding-facts fallback, gateway clamp removed, eager mirror after a lost replay, corrective path ignoring the overrun, corrective path without a lease owner, historical-overcharge event name, the rewrite's lease-owner fence, the settlement stamp at bind, the reader's derived kind, monetary mismatch not quarantined). Three of those were test gaps found in review and closed before this PR.

Lands after #1038 (merged). Per decision 54 the binding flip waits until this is on every serving revision, and it is Joseph's decision.

Written by codex; reviewed by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
