### PR TITLE
Fix video synthetic classification

### DIFF
--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -210,6 +210,7 @@ from trusted_router.storage_errors import (
 from trusted_router.storage_gcp_io import spanner_rpc_budget
 from trusted_router.storage_gcp_secrets import secret_manager_seed_loader
 from trusted_router.storage_models import (
+    SYNTHETIC_APP_NAME,
     AppMarkupPayout,
     CustomModelMarkupPayout,
     GatewayAuthorization,
@@ -601,7 +602,10 @@ def _authorize_gateway_sync_impl(
     # the deep probes stop proving anything). One set-lookup for monitor
     # traffic, zero cost for everyone else.
     monitor_hash = monitor_lookup_hash(settings)
-    if monitor_hash is not None and body.api_key_lookup_hash == monitor_hash:
+    is_monitor_request = (
+        monitor_hash is not None and body.api_key_lookup_hash == monitor_hash
+    )
+    if is_monitor_request:
         ensure_monitor_funding(STORE, settings, workspace.id)
     body_dict = body.model_dump(exclude_none=True)
     # Preserve pre-web-search idempotency fingerprints byte-for-byte for every
@@ -616,6 +620,11 @@ def _authorize_gateway_sync_impl(
         effective_tags = merge_tags(api_key.tags, body.tags)
     except InvalidTags as exc:
         raise api_error(400, str(exc), ErrorType.INVALID_TAGS) from exc
+    if is_monitor_request:
+        # The dedicated key is the server-owned source of truth. Media
+        # requests intentionally expose a smaller public schema than chat and
+        # cannot carry metadata.trustedrouter_synthetic themselves.
+        effective_tags = {**effective_tags, "purpose": "synthetic_monitoring"}
     try:
         attribution = validate_request_attribution(
             user=body.user,
@@ -2511,6 +2520,12 @@ def _settle_gateway_authorization(
 
     settle_body = _settle_body_with_safe_attribution(body, authorization.id)
     settle_body = _settle_body_with_safe_client_context(settle_body, authorization.id)
+    if _authorization_is_synthetic(authorization):
+        metadata = settle_body.get("metadata")
+        synthetic_metadata = dict(metadata) if isinstance(metadata, dict) else {}
+        synthetic_metadata["trustedrouter_synthetic"] = "true"
+        settle_body["metadata"] = synthetic_metadata
+        settle_body["app"] = SYNTHETIC_APP_NAME
     if not success:
         client_context = settle_body.get("client")
         client_fields = client_context if isinstance(client_context, dict) else {}
@@ -3207,7 +3222,7 @@ def _settle_gateway_authorization(
             )
         elif broadcast_enqueued and should_drain_inline(settings):
             drain_broadcast_queue(settings=settings)
-    if not success and not _is_synthetic_settlement(body):
+    if not success and not _is_synthetic_settlement(body, authorization):
         STORE.record_provider_benchmark(
             ProviderBenchmarkSample.from_provider_error(
                 model=model,
@@ -3512,7 +3527,17 @@ def _synthetic_metadata_enabled(metadata: dict[str, Any]) -> bool:
     }
 
 
-def _is_synthetic_settlement(body: GatewaySettleRequest) -> bool:
+def _authorization_is_synthetic(authorization: Any) -> bool:
+    tags = getattr(authorization, "tags", None)
+    return isinstance(tags, dict) and tags.get("purpose") == "synthetic_monitoring"
+
+
+def _is_synthetic_settlement(
+    body: GatewaySettleRequest,
+    authorization: Any | None = None,
+) -> bool:
+    if authorization is not None and _authorization_is_synthetic(authorization):
+        return True
     if body.app == "TrustedRouter Synthetic":
         return True
     metadata = body.metadata

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -1436,10 +1436,6 @@ async def video_generation_probe(
         "aspect_ratio": "16:9",
         "generate_audio": generate_audio,
         "provider": {"only": [provider], "allow_fallbacks": False},
-        "metadata": {
-            "trustedrouter_synthetic": "true",
-            "probe": "video_generation",
-        },
     }
     started = time.perf_counter()
     try:

--- a/tests/test_synthetic_flag_provenance.py
+++ b/tests/test_synthetic_flag_provenance.py
@@ -4,14 +4,15 @@ Every usage and revenue query filters ``WHERE synthetic = 0``, so a probe whose
 generation lands with the flag off is counted as a paying customer. That has
 happened twice for structurally different reasons, and each is pinned here:
 
-* the ``/videos`` probe was the only one of six gateway request bodies in
-  ``probes.py`` built without ``metadata.trustedrouter_synthetic``;
+* ordinary gateway probes carry ``metadata.trustedrouter_synthetic``;
+* the strict ``/videos`` API deliberately has no public metadata field, so its
+  dedicated monitor key is classified server-side during authorization;
 * ``from_chat_result`` and ``from_embeddings_result`` never set ``synthetic``
   at all, so the direct (non-attested) path took the ``False`` field default
   no matter what it was serving.
 
-The first test is the load-bearing one: it fails on the NEXT probe that forgets
-the marker, which is the failure mode that actually recurs.
+The first test is load-bearing: it permits exactly one server-classified probe
+and fails on the next probe that forgets the marker.
 """
 
 from __future__ import annotations
@@ -35,6 +36,7 @@ PROBES_PATH = (
 # the count guards against the test silently finding NOTHING (a rename of
 # `_api_url`, a refactor to a helper) and passing vacuously.
 MINIMUM_GATEWAY_PROBE_BODIES = 6
+SERVER_CLASSIFIED_PROBES = {"video_generation_probe"}
 
 
 def _gateway_probe_functions() -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
@@ -66,7 +68,7 @@ def _marks_synthetic(node: ast.AST) -> bool:
     return False
 
 
-def test_every_gateway_probe_body_marks_itself_synthetic() -> None:
+def test_gateway_probe_bodies_mark_synthetic_or_are_server_classified() -> None:
     functions = _gateway_probe_functions()
 
     assert len(functions) >= MINIMUM_GATEWAY_PROBE_BODIES, (
@@ -75,10 +77,12 @@ def test_every_gateway_probe_body_marks_itself_synthetic() -> None:
         "matches the code, so this test proves nothing"
     )
 
-    unmarked = sorted(node.name for node in functions if not _marks_synthetic(node))
-    assert unmarked == [], (
-        "these probe bodies omit metadata.trustedrouter_synthetic, so their "
-        f"generations are indexed as real customer traffic: {unmarked}"
+    unmarked = {node.name for node in functions if not _marks_synthetic(node)}
+    assert unmarked == SERVER_CLASSIFIED_PROBES, (
+        "gateway probes without metadata.trustedrouter_synthetic must be "
+        "explicitly classified from the dedicated monitor key; unexpected "
+        f"unmarked probes: {sorted(unmarked - SERVER_CLASSIFIED_PROBES)}; "
+        f"missing expected exceptions: {sorted(SERVER_CLASSIFIED_PROBES - unmarked)}"
     )
 
 

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -48,7 +48,12 @@ from trusted_router.storage_gcp_synthetic_index import (
 from trusted_router.storage_gcp_synthetic_rollups import (
     synthetic_rollups as _bt_synthetic_rollups,
 )
-from trusted_router.storage_models import ProviderBenchmarkSample, iso_now, utcnow
+from trusted_router.storage_models import (
+    SYNTHETIC_APP_NAME,
+    ProviderBenchmarkSample,
+    iso_now,
+    utcnow,
+)
 from trusted_router.synthetic.components import sample_slo_class_ids
 from trusted_router.synthetic.inference_sdk import build_inference_sdk, close_inference_sdk
 from trusted_router.synthetic.probes import (
@@ -761,6 +766,85 @@ def test_chat_monitor_model_requires_configured_monitor_key() -> None:
         "trustedrouter/monitor is restricted to the synthetic monitor key"
     )
     assert allowed.status_code == 200, allowed.text
+
+
+def test_monitor_key_is_server_classified_without_request_metadata() -> None:
+    monitor_key = "sk-tr-monitor-server-classified"  # noqa: S105 - test key.
+    app = create_app(
+        Settings(environment="test", synthetic_monitor_api_key=monitor_key),
+        init_observability=False,
+    )
+    local_client = TestClient(app)
+    monitor_user = STORE.ensure_user("monitor", email="monitor@trustedrouter.local")
+    monitor_workspace = STORE.list_workspaces_for_user(monitor_user.id)[0]
+    STORE.create_api_key(
+        workspace_id=monitor_workspace.id,
+        name="Synthetic monitor",
+        creator_user_id=monitor_user.id,
+        raw_key=monitor_key,
+    )
+
+    authorize = local_client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_lookup_hash": lookup_hash_api_key(monitor_key),
+            "model": CHEAP_MODEL_ID,
+            "estimated_input_tokens": 1,
+            "max_output_tokens": 1,
+        },
+    )
+    assert authorize.status_code == 200, authorize.text
+    data = authorize.json()["data"]
+    authorization = STORE.get_gateway_authorization(data["authorization_id"])
+    assert authorization is not None
+    assert authorization.tags["purpose"] == "synthetic_monitoring"
+    selected = data["route_candidates"][0]
+
+    settle = local_client.post(
+        "/v1/internal/gateway/settle",
+        json={
+            "authorization_id": data["authorization_id"],
+            "input_tokens": 1,
+            "output_tokens": 1,
+            "request_id": "req_server_classified_synthetic",
+            "model": selected["model"],
+            "selected_endpoint": selected["endpoint_id"],
+        },
+    )
+
+    assert settle.status_code == 200, settle.text
+    events = STORE.activity_events(monitor_workspace.id, limit=10)
+    assert len(events) == 1
+    assert events[0]["app"] == SYNTHETIC_APP_NAME
+    assert STORE.provider_benchmark_samples() == []
+
+    failed_authorize = local_client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_lookup_hash": lookup_hash_api_key(monitor_key),
+            "model": CHEAP_MODEL_ID,
+            "estimated_input_tokens": 1,
+            "max_output_tokens": 1,
+        },
+    )
+    assert failed_authorize.status_code == 200, failed_authorize.text
+    failed_data = failed_authorize.json()["data"]
+    failed_route = failed_data["route_candidates"][0]
+    refund = local_client.post(
+        "/v1/internal/gateway/refund",
+        json={
+            "authorization_id": failed_data["authorization_id"],
+            "input_tokens": 1,
+            "output_tokens": 0,
+            "request_id": "req_server_classified_synthetic_failure",
+            "model": failed_route["model"],
+            "selected_endpoint": failed_route["endpoint_id"],
+            "error_status": 502,
+            "error_type": "provider_error",
+        },
+    )
+    assert refund.status_code == 200, refund.text
+    assert STORE.provider_benchmark_samples() == []
 
 
 def test_status_rollups_cover_current_5m_24h_and_daily_windows() -> None:

--- a/tests/test_video_synthetic.py
+++ b/tests/test_video_synthetic.py
@@ -120,13 +120,6 @@ async def test_video_probe_generates_once_validates_media_and_keeps_only_metadat
             "aspect_ratio": "16:9",
             "generate_audio": False,
             "provider": {"only": [VIDEO_GENERATION_PROVIDER], "allow_fallbacks": False},
-            # Without this the video probe's generation lands with synthetic=0
-            # and is counted as real customer traffic; it was the only probe
-            # body in the file that omitted the marker.
-            "metadata": {
-                "trustedrouter_synthetic": "true",
-                "probe": "video_generation",
-            },
         }
     ]
     public = json.dumps(sample.public_dict())


### PR DESCRIPTION
## Summary
- classify the dedicated synthetic monitor key server-side during gateway authorization
- preserve synthetic classification through settlement and refund without widening the public video API
- remove unsupported metadata from scheduled video-generation requests
- prevent synthetic video successes and provider failures from entering customer benchmarks

## Verification
- uv run pytest -q tests/test_video_synthetic.py tests/test_synthetic_monitoring.py (127 passed)
- uv run pytest -q tests/test_gateway_authorize_admission.py tests/test_gateway_authorize_extract.py tests/test_gateway_settle_admission.py tests/test_gateway_error_taxonomy.py (11 passed)
- uv run ruff check on changed files
- uv run mypy src/trusted_router
- git diff --check