### PR TITLE
ci: guard the remaining scheduled workflows against running on forks

### DIFF
--- a/.github/workflows/check-analytics-freshness.yml
+++ b/.github/workflows/check-analytics-freshness.yml
@@ -176,6 +176,9 @@ concurrency:
 
 jobs:
   check:
+    # Scheduled runs belong to the canonical repo only; a fork's copy has no
+    # GCP identity and would fail its credential exchange every hour.
+    if: github.repository == 'Lore-Hex/quill-router'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/check-client-telemetry-freshness.yml
+++ b/.github/workflows/check-client-telemetry-freshness.yml
@@ -37,6 +37,9 @@ concurrency:
 
 jobs:
   check:
+    # Scheduled runs belong to the canonical repo only; a fork's copy has no
+    # GCP identity and would fail its credential exchange every hour.
+    if: github.repository == 'Lore-Hex/quill-router'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/check-repo-security-coverage.yml
+++ b/.github/workflows/check-repo-security-coverage.yml
@@ -37,6 +37,9 @@ concurrency:
 
 jobs:
   check:
+    # Scheduled runs belong to the canonical repo only; a fork's copy has no
+    # GCP identity and would fail its credential exchange every hour.
+    if: github.repository == 'Lore-Hex/quill-router'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/cloud-staleness.yml
+++ b/.github/workflows/cloud-staleness.yml
@@ -26,6 +26,9 @@ permissions:
 
 jobs:
   staleness:
+    # Scheduled runs belong to the canonical repo only; a fork's copy has no
+    # GCP identity and would fail its credential exchange every hour.
+    if: github.repository == 'Lore-Hex/quill-router'
     name: how old is each cloud
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -19,7 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     # Don't fail PRs on prod issues — only main + scheduled + manual runs
     # touch the live service. PRs run the offline suite via ci.yml.
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    if: >-
+      github.repository == 'Lore-Hex/quill-router'
+      && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/trust-drift.yml
+++ b/.github/workflows/trust-drift.yml
@@ -56,7 +56,9 @@ jobs:
     # Same rule as prod-smoke: never fail a PR on the state of production. PRs
     # get the offline proofs (tests/test_trust_measurement_drift.py) via ci.yml,
     # which is what keeps this script honest without depending on prod being up.
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    if: >-
+      github.repository == 'Lore-Hex/quill-router'
+      && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Why

A public fork (`ahuserious/quill-router`, last synced Aug 21) runs this repo's scheduled workflows on its own cron. Every run fails at `google-github-actions/auth`: the workload-identity provider's attribute condition rejects `repo:ahuserious/...`, which leaves an ERROR-severity `SecurityTokenService.ExchangeToken` audit entry in `quill-cloud-proxy` (~15/day observed) and a failed run in the fork.

## What

Adds `if: github.repository == 'Lore-Hex/quill-router'` to every job of the six scheduled workflows that still lacked it (`check-analytics-freshness`, `check-client-telemetry-freshness`, `check-repo-security-coverage`, `cloud-staleness`, `prod-smoke`, `trust-drift`). Where a job already had a `workflow_run` condition it is combined, not replaced. `refresh-prices`, `typed-audit`, `daily-embeddings-probe`, `check-archive-freshness`, `cloud-security-baseline`, `mirror-repo` already carried the guard.

Note: this stops the noise only once the fork syncs (or its owner disables Actions on it); forks run their own copy of the workflow file.

## Tests

YAML parsed; every job in the six files verified to carry the guard; the four tests that read these workflow files pass (200 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
