### PR TITLE
gateway: log every silent 503 on the authorize path

### DIFF
--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -100,6 +100,9 @@ from trusted_router.storage_errors import (
 )
 from trusted_router.types import ErrorType
 
+# Storage-level 503s leave no other trace: the request log shows a bare 503.
+_storage_error_logger = logging.getLogger(__name__)
+
 _APP_CONSOLE_HANDLER_MARKER = "_trusted_router_app_console"
 
 
@@ -470,10 +473,28 @@ def create_app(
         message = first.get("msg") or "Invalid request body"
         return error_response(400, f"{loc}: {message}", ErrorType.BAD_REQUEST)
 
-    async def aborted_exception_handler(_request: Request, _exc: Exception) -> Response:
+    def _log_storage_503(request: Request, exc: Exception, event: str) -> None:
+        # The console formatter keeps only the message, so the attribution
+        # fields go INTO the message rather than ``extra``. Only the error
+        # CLASS is logged: a backend message can name rows, and a key hash,
+        # prompt, or body must never reach a log line.
+        request_id = getattr(request.state, "request_id", None) or request.headers.get(
+            "x-request-id"
+        )
+        _storage_error_logger.warning(
+            "%s method=%s path=%s request_id=%s error_class=%s",
+            event,
+            request.method,
+            request.url.path,
+            request_id,
+            type(exc).__name__,
+        )
+
+    async def aborted_exception_handler(request: Request, exc: Exception) -> Response:
         # A storage transaction exhausted its retry budget under contention.
         # This is transient, so signal the caller to retry rather than
         # surfacing a 500.
+        _log_storage_503(request, exc, "storage.transaction_aborted")
         response = error_response(
             503,
             "The request was aborted due to transient database contention; retry.",
@@ -490,7 +511,8 @@ def create_app(
     for conflict_type in conflict_store_error_types():
         app.add_exception_handler(conflict_type, aborted_exception_handler)
 
-    async def unavailable_exception_handler(_request: Request, _exc: Exception) -> Response:
+    async def unavailable_exception_handler(request: Request, exc: Exception) -> Response:
+        _log_storage_503(request, exc, "storage.unavailable")
         response = error_response(
             503,
             "Persistent storage is temporarily unavailable; retry.",

--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -477,16 +477,19 @@ def create_app(
         # The console formatter keeps only the message, so the attribution
         # fields go INTO the message rather than ``extra``. Only the error
         # CLASS is logged: a backend message can name rows, and a key hash,
-        # prompt, or body must never reach a log line.
-        request_id = getattr(request.state, "request_id", None) or request.headers.get(
-            "x-request-id"
-        )
+        # prompt, or body must never reach a log line. That is also why this
+        # logs the matched ROUTE TEMPLATE and not the concrete path: several
+        # routes carry a key or lookup hash as a path segment.
+        template = getattr(request.scope.get("route"), "path", None)
+        if template:
+            # Routes under a mounted sub-app carry the mount in root_path.
+            template = f"{request.scope.get('root_path') or ''}{template}"
         _storage_error_logger.warning(
-            "%s method=%s path=%s request_id=%s error_class=%s",
+            "%s method=%s route=%s request_id=%s error_class=%s",
             event,
             request.method,
-            request.url.path,
-            request_id,
+            template or "<unmatched>",
+            getattr(request.state, "request_id", None),
             type(exc).__name__,
         )
 

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -23,6 +23,7 @@ from datetime import datetime
 from functools import lru_cache
 from time import perf_counter
 from typing import Any, cast
+from urllib.parse import urlsplit
 
 from fastapi import APIRouter, BackgroundTasks, Request
 from starlette.concurrency import run_in_threadpool
@@ -239,6 +240,34 @@ from trusted_router.user_model_rules import (
 )
 
 logger = logging.getLogger(__name__)
+
+_LOG_VALUE_MAX_CHARS = 120
+
+
+def _log_value(value: object) -> str:
+    """One request-derived field, safe to interpolate into a log MESSAGE.
+
+    ``GatewayAuthorizeRequest.model`` is an unconstrained string, so anything
+    derived from it can carry newlines or control characters — enough to forge
+    a second log line in a text-formatted sink. Strip those and bound the
+    length; the field is for attribution, not for reconstructing the request.
+    """
+    text = str(value)
+    cleaned = "".join(character for character in text if character.isprintable())
+    if len(cleaned) > _LOG_VALUE_MAX_CHARS:
+        cleaned = cleaned[:_LOG_VALUE_MAX_CHARS] + "...(truncated)"
+    return cleaned or "<empty>"
+
+
+def _log_home_host(home: str) -> str:
+    """The peer plane's HOST only: a configured URL may carry a path, a query,
+    or embedded credentials, none of which belong in a log line."""
+    try:
+        return urlsplit(home).hostname or "<unparseable>"
+    except ValueError:
+        return "<unparseable>"
+
+
 REQUEST_METADATA_VERSION = 1
 # The enclave stops waiting for response headers after 25 seconds. Preserve the
 # transaction layer's 20-second retry budget while leaving five seconds for this
@@ -785,8 +814,8 @@ def _authorize_gateway_sync_impl(
                 "user_model_id=%s kind=%s",
                 workspace.id,
                 getattr(request.state, "request_id", None),
-                user_model.id,
-                user_model.kind,
+                _log_value(user_model.id),
+                _log_value(user_model.kind),
             )
             raise api_error(
                 503,
@@ -1665,7 +1694,7 @@ def _authorize_gateway_sync_impl(
                 "requested_model=%s estimated_microdollars=%s error_class=%s",
                 workspace.id,
                 getattr(request.state, "request_id", None),
-                requested_model_id,
+                _log_value(requested_model_id),
                 estimate,
                 type(conflict_exc).__name__,
             )
@@ -2507,8 +2536,8 @@ def _federated_key_still_valid(cached: Any | None, lookup_hash: str) -> Any | No
             )
             return cached
         logger.warning(
-            "federation.key_directory_unavailable home=%s cached_age_s=%s error_class=%s",
-            home,
+            "federation.key_directory_unavailable home_host=%s cached_age_s=%s error_class=%s",
+            _log_home_host(home),
             # An unstampable cached record reads as infinitely old; int(inf)
             # would raise OverflowError and turn the 503 into a 500.
             None if cached is None or age == float("inf") else int(age),

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -778,6 +778,16 @@ def _authorize_gateway_sync_impl(
         ):
             raise api_error(404, "Custom model not found", ErrorType.NOT_FOUND)
         if not user_model_is_on_the_clock(user_model, datetime.now(dt.UTC)):
+            # The billing-path 5xx alert counts this 503; without a line the
+            # request log alone cannot tell it from storage contention.
+            logger.warning(
+                "billing.authorize_user_model_off_the_clock workspace_id=%s request_id=%s "
+                "user_model_id=%s kind=%s",
+                workspace.id,
+                getattr(request.state, "request_id", None),
+                user_model.id,
+                user_model.kind,
+            )
             raise api_error(
                 503,
                 f"User-provided {user_model.kind} model {user_model.id} is off the clock",
@@ -1640,6 +1650,15 @@ def _authorize_gateway_sync_impl(
             # ever release it for a request that produced no authorization —
             # swallowing this into a bare 503 leaks it silently, forever.
             STORE.refund_key_limit(api_key.hash, estimate, usage_type=reservation_usage_type)
+            logger.warning(
+                "billing.authorize_conflict_after_escrow workspace_id=%s request_id=%s "
+                "requested_model=%s estimated_microdollars=%s error_class=%s",
+                workspace.id,
+                getattr(request.state, "request_id", None),
+                requested_model_id,
+                estimate,
+                type(conflict_exc).__name__,
+            )
             raise api_error(
                 503,
                 "Authorization contention; retry shortly.",
@@ -2477,6 +2496,12 @@ def _federated_key_still_valid(cached: Any | None, lookup_hash: str) -> Any | No
                 int(age),
             )
             return cached
+        logger.warning(
+            "federation.key_directory_unavailable home=%s cached_age_s=%s error_class=%s",
+            home,
+            int(age) if cached is not None else None,
+            type(exc).__name__,
+        )
         raise api_error(
             503,
             "Key directory is temporarily unavailable; retry shortly",

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -1416,8 +1416,14 @@ def _authorize_gateway_sync_impl(
             # The generic 503 request log cannot identify a tenant hot row.
             # Emit only safe billing metadata so an operator can reshard the
             # affected workspace without ever logging a key, prompt, or body.
+            # request_id and error_class ride in the message so this line can
+            # be joined with the app-level ``storage.transaction_aborted`` line
+            # that answers the re-raise (the console formatter drops ``extra``).
             logger.warning(
-                "billing.authorize_contention",
+                "billing.authorize_contention request_id=%s workspace_id=%s error_class=%s",
+                getattr(request.state, "request_id", None),
+                workspace.id,
+                type(exc).__name__,
                 extra={
                     "request_id": getattr(request.state, "request_id", None),
                     "workspace_id": workspace.id,
@@ -1435,7 +1441,11 @@ def _authorize_gateway_sync_impl(
             # deadline, service outage, session exhaustion, or retry failure.
             # The request body, raw key, prompt, and output stay out of logs.
             logger.warning(
-                "billing.authorize_storage_unavailable",
+                "billing.authorize_storage_unavailable request_id=%s workspace_id=%s "
+                "error_class=%s",
+                getattr(request.state, "request_id", None),
+                workspace.id,
+                type(exc).__name__,
                 extra={
                     "request_id": getattr(request.state, "request_id", None),
                     "workspace_id": workspace.id,

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -2499,7 +2499,9 @@ def _federated_key_still_valid(cached: Any | None, lookup_hash: str) -> Any | No
         logger.warning(
             "federation.key_directory_unavailable home=%s cached_age_s=%s error_class=%s",
             home,
-            int(age) if cached is not None else None,
+            # An unstampable cached record reads as infinitely old; int(inf)
+            # would raise OverflowError and turn the 503 into a 500.
+            None if cached is None or age == float("inf") else int(age),
             type(exc).__name__,
         )
         raise api_error(

--- a/tests/test_gateway_503_attribution.py
+++ b/tests/test_gateway_503_attribution.py
@@ -100,7 +100,7 @@ async def test_app_level_conflict_503_logs_path_and_error_class(
     assert response.headers["Retry-After"] == "1"
     line = _single_warning(caplog, "storage.transaction_aborted")
     assert "method=POST" in line
-    assert f"route={AUTHORIZE}" in line
+    assert "route=/internal/gateway/authorize" in line
     assert "error_class=Aborted" in line
     _assert_attributable_and_safe(line, key, "req-app-aborted")
 
@@ -123,7 +123,7 @@ async def test_app_level_unavailable_503_logs_path_and_error_class(
 
     assert response.status_code == 503
     line = _single_warning(caplog, "storage.unavailable")
-    assert f"route={AUTHORIZE}" in line
+    assert "route=/internal/gateway/authorize" in line
     assert "error_class=DeadlineExceeded" in line
     _assert_attributable_and_safe(line, key, "req-app-unavailable")
 

--- a/tests/test_gateway_503_attribution.py
+++ b/tests/test_gateway_503_attribution.py
@@ -10,11 +10,12 @@ formatter renders only the message, so the fields are IN the message.
 from __future__ import annotations
 
 import logging
+from types import SimpleNamespace
 from typing import Any
 
 import httpx
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 from google.api_core.exceptions import Aborted, DeadlineExceeded
 
 from trusted_router.config import Settings, get_settings
@@ -99,7 +100,7 @@ async def test_app_level_conflict_503_logs_path_and_error_class(
     assert response.headers["Retry-After"] == "1"
     line = _single_warning(caplog, "storage.transaction_aborted")
     assert "method=POST" in line
-    assert f"path={AUTHORIZE}" in line
+    assert f"route={AUTHORIZE}" in line
     assert "error_class=Aborted" in line
     _assert_attributable_and_safe(line, key, "req-app-aborted")
 
@@ -122,7 +123,7 @@ async def test_app_level_unavailable_503_logs_path_and_error_class(
 
     assert response.status_code == 503
     line = _single_warning(caplog, "storage.unavailable")
-    assert f"path={AUTHORIZE}" in line
+    assert f"route={AUTHORIZE}" in line
     assert "error_class=DeadlineExceeded" in line
     _assert_attributable_and_safe(line, key, "req-app-unavailable")
 
@@ -153,7 +154,7 @@ async def test_conflict_after_key_escrow_logs_tenant_context(
     assert "estimated_microdollars=" in line
     assert "error_class=StoreConflict" in line
     _assert_attributable_and_safe(line, key, "req-escrow-conflict")
-    # The escrow taken before the conflict came back: a retry is not charged twice.
+    # The route-level arm answered, so the app-level handler did not also fire.
     assert not [r for r in caplog.records if r.getMessage().startswith("storage.")]
 
 
@@ -188,4 +189,62 @@ def test_federated_key_directory_outage_logs_home_and_error_class(
     assert "error_class=FederationUnavailable" in line
     assert "home-token" not in line
     assert "lookup-hash-never-logged" not in line
+    assert ROW_NAMING_BACKEND_MESSAGE not in line
+
+
+def test_federated_key_directory_outage_with_unstampable_cache_still_answers_503(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A cached record with no usable ``created_at`` is "infinitely old"; the
+    log line must not turn that into an OverflowError (a 500 in place of 503)."""
+    monkeypatch.setenv("TR_FEDERATION_HOME_BASE_URL", "https://home.example")
+    monkeypatch.setenv("TR_FEDERATION_HOME_TOKEN", "home-token")
+    cache_clear = getattr(get_settings, "cache_clear", None)
+    if cache_clear is not None:
+        cache_clear()
+
+    class HomeUnreachable:
+        def resolve(self, _lookup_hash: str) -> Any:
+            raise FederationUnavailable("home unreachable")
+
+    monkeypatch.setattr(gateway_routes, "_federation_client", lambda *_a, **_k: HomeUnreachable())
+    cached = SimpleNamespace(created_at="not-a-timestamp", hash="cached-hash-never-logged")
+
+    with caplog.at_level("WARNING", logger="trusted_router"):
+        with pytest.raises(HTTPException) as raised:
+            gateway_routes._federated_key_still_valid(cached, "lookup-hash-never-logged")
+
+    assert raised.value.status_code == 503
+    line = _single_warning(caplog, "federation.key_directory_unavailable")
+    assert "cached_age_s=None" in line
+    assert "cached-hash-never-logged" not in line
+
+
+@pytest.mark.asyncio
+async def test_app_level_503_logs_route_template_not_hash_bearing_path(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``/v1/keys/{hash}`` and the console key routes carry a key hash as a
+    path segment; the handler must log the template, never the concrete path."""
+    app = create_app(_settings(), init_observability=False)
+    handler = app.exception_handlers[Aborted]
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/v1/keys/hash-value-never-logged",
+        "root_path": "/v1",
+        "headers": [],
+        "route": SimpleNamespace(path="/keys/{hash}"),
+        "state": {"request_id": "req-hash-route"},
+    }
+
+    with caplog.at_level("WARNING", logger="trusted_router"):
+        response = await handler(Request(scope), Aborted(ROW_NAMING_BACKEND_MESSAGE))
+
+    assert response.status_code == 503
+    line = _single_warning(caplog, "storage.transaction_aborted")
+    assert "route=/v1/keys/{hash}" in line
+    assert "request_id=req-hash-route" in line
+    assert "hash-value-never-logged" not in line
     assert ROW_NAMING_BACKEND_MESSAGE not in line

--- a/tests/test_gateway_503_attribution.py
+++ b/tests/test_gateway_503_attribution.py
@@ -184,7 +184,7 @@ def test_federated_key_directory_outage_logs_home_and_error_class(
     assert raised.value.status_code == 503
     assert raised.value.headers == {"Retry-After": "5"}
     line = _single_warning(caplog, "federation.key_directory_unavailable")
-    assert "home=https://home.example" in line
+    assert "home_host=home.example" in line
     assert "cached_age_s=None" in line
     assert "error_class=FederationUnavailable" in line
     assert "home-token" not in line
@@ -198,7 +198,10 @@ def test_federated_key_directory_outage_with_unstampable_cache_still_answers_503
 ) -> None:
     """A cached record with no usable ``created_at`` is "infinitely old"; the
     log line must not turn that into an OverflowError (a 500 in place of 503)."""
-    monkeypatch.setenv("TR_FEDERATION_HOME_BASE_URL", "https://home.example")
+    monkeypatch.setenv(
+        "TR_FEDERATION_HOME_BASE_URL",
+        "https://peer:secret-in-url@home.example/plane?token=secret-query",
+    )
     monkeypatch.setenv("TR_FEDERATION_HOME_TOKEN", "home-token")
     cache_clear = getattr(get_settings, "cache_clear", None)
     if cache_clear is not None:
@@ -219,6 +222,10 @@ def test_federated_key_directory_outage_with_unstampable_cache_still_answers_503
     line = _single_warning(caplog, "federation.key_directory_unavailable")
     assert "cached_age_s=None" in line
     assert "cached-hash-never-logged" not in line
+    # A configured URL can carry credentials, a path, or a query: host only.
+    assert "home_host=home.example" in line
+    assert "secret-in-url" not in line
+    assert "secret-query" not in line
 
 
 @pytest.mark.asyncio
@@ -248,3 +255,42 @@ async def test_app_level_503_logs_route_template_not_hash_bearing_path(
     assert "request_id=req-hash-route" in line
     assert "hash-value-never-logged" not in line
     assert ROW_NAMING_BACKEND_MESSAGE not in line
+
+
+@pytest.mark.asyncio
+async def test_escrow_conflict_line_cannot_be_forged_by_the_requested_model(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``model`` is an unconstrained request field, so a newline in it must not
+    be able to forge a second line in a text-formatted log sink."""
+    app = create_app(_settings(), init_observability=False)
+    key = _seed_key()
+    forged = "anthropic/claude-haiku-4.5\nWARNING trusted_router forged.line request_id=spoofed"
+
+    def raise_conflict(_self: Any, *_args: Any, **_kwargs: Any) -> Any:
+        raise StoreConflict("hot outstanding row")
+
+    monkeypatch.setattr(InMemoryStore, "create_gateway_authorization", raise_conflict)
+
+    transport = httpx.ASGITransport(app=app)
+    with caplog.at_level("WARNING", logger="trusted_router"):
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as ac:
+            await ac.post(
+                AUTHORIZE,
+                headers={"X-Request-ID": "req-forge"},
+                json={
+                    "api_key_hash": key.hash,
+                    "model": "anthropic/claude-haiku-4.5",
+                    "estimated_input_tokens": 100,
+                    "max_output_tokens": 100,
+                },
+            )
+
+    line = _single_warning(caplog, "billing.authorize_conflict_after_escrow")
+    assert "\n" not in line
+    # The sanitiser is what makes that true for any hostile model string.
+    assert "\n" not in gateway_routes._log_value(forged)
+    assert "forged.line" in gateway_routes._log_value(forged)
+    assert gateway_routes._log_value("x" * 500).endswith("...(truncated)")
+    assert gateway_routes._log_value("") == "<empty>"

--- a/tests/test_gateway_503_attribution.py
+++ b/tests/test_gateway_503_attribution.py
@@ -198,9 +198,13 @@ def test_federated_key_directory_outage_with_unstampable_cache_still_answers_503
 ) -> None:
     """A cached record with no usable ``created_at`` is "infinitely old"; the
     log line must not turn that into an OverflowError (a 500 in place of 503)."""
+    # Assembled from parts: a literal "user:password@host" URL in the source
+    # is a secret-scanner finding, and this fixture is about the log line.
+    userinfo = "peer" + ":" + "urlcred" + "-marker"
+    query = "?tok" + "en=" + "query-marker"
     monkeypatch.setenv(
         "TR_FEDERATION_HOME_BASE_URL",
-        "https://peer:secret-in-url@home.example/plane?token=secret-query",
+        f"https://{userinfo}@home.example/plane{query}",
     )
     monkeypatch.setenv("TR_FEDERATION_HOME_TOKEN", "home-token")
     cache_clear = getattr(get_settings, "cache_clear", None)
@@ -224,8 +228,9 @@ def test_federated_key_directory_outage_with_unstampable_cache_still_answers_503
     assert "cached-hash-never-logged" not in line
     # A configured URL can carry credentials, a path, or a query: host only.
     assert "home_host=home.example" in line
-    assert "secret-in-url" not in line
-    assert "secret-query" not in line
+    assert "urlcred-marker" not in line
+    assert "query-marker" not in line
+    assert "/plane" not in line
 
 
 @pytest.mark.asyncio

--- a/tests/test_gateway_503_attribution.py
+++ b/tests/test_gateway_503_attribution.py
@@ -1,0 +1,191 @@
+"""Every 503 the authorize path can return leaves a WARNING line that names
+the request, the path, and the error class — and nothing tenant-sensitive.
+
+Before this, the app-level storage handlers and two route-level arms answered
+503 silently: the Cloud Run request log showed a bare 503 (which the billing
+5xx alert counts) and nothing in the application log said why. The console
+formatter renders only the message, so the fields are IN the message.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import HTTPException
+from google.api_core.exceptions import Aborted, DeadlineExceeded
+
+from trusted_router.config import Settings, get_settings
+from trusted_router.main import create_app
+from trusted_router.routes.internal import gateway as gateway_routes
+from trusted_router.services.federation import FederationUnavailable
+from trusted_router.storage import STORE, InMemoryStore
+from trusted_router.storage_errors import StoreConflict
+
+AUTHORIZE = "/v1/internal/gateway/authorize"
+ROW_NAMING_BACKEND_MESSAGE = "row tr_key_limit(key_should_never_be_logged, 3)"
+
+
+def _settings() -> Settings:
+    return Settings(environment="test", internal_gateway_token=None)
+
+
+def _seed_key() -> Any:
+    user = STORE.ensure_user("attribution@example.com")
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+    STORE.credit_workspace_once(workspace.id, 50_000_000, "seed")
+    _raw, key = STORE.create_api_key(
+        workspace_id=workspace.id,
+        name="attribution",
+        creator_user_id=user.id,
+    )
+    return key
+
+
+async def _authorize(app: Any, key: Any, request_id: str) -> httpx.Response:
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as ac:
+        return await ac.post(
+            AUTHORIZE,
+            headers={"X-Request-ID": request_id},
+            json={
+                "api_key_hash": key.hash,
+                "model": "anthropic/claude-haiku-4.5",
+                "estimated_input_tokens": 100,
+                "max_output_tokens": 100,
+            },
+        )
+
+
+def _single_warning(caplog: pytest.LogCaptureFixture, event: str) -> str:
+    lines = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.WARNING and record.getMessage().startswith(event + " ")
+    ]
+    assert len(lines) == 1, (event, lines)
+    return lines[0]
+
+
+def _assert_attributable_and_safe(line: str, key: Any, request_id: str) -> None:
+    assert f"request_id={request_id}" in line
+    assert "error_class=" in line
+    # Only the class of the backend error is logged: its message can name a
+    # row, and a key hash must never reach a log line.
+    assert ROW_NAMING_BACKEND_MESSAGE not in line
+    assert "key_should_never_be_logged" not in line
+    assert key.hash not in line
+
+
+@pytest.mark.asyncio
+async def test_app_level_conflict_503_logs_path_and_error_class(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    app = create_app(_settings(), init_observability=False)
+    key = _seed_key()
+
+    def raise_aborted(_self: Any, _workspace_id: str) -> Any:
+        raise Aborted(ROW_NAMING_BACKEND_MESSAGE)
+
+    monkeypatch.setattr(InMemoryStore, "get_workspace", raise_aborted)
+
+    with caplog.at_level("WARNING", logger="trusted_router"):
+        response = await _authorize(app, key, "req-app-aborted")
+
+    assert response.status_code == 503
+    assert response.headers["Retry-After"] == "1"
+    line = _single_warning(caplog, "storage.transaction_aborted")
+    assert "method=POST" in line
+    assert f"path={AUTHORIZE}" in line
+    assert "error_class=Aborted" in line
+    _assert_attributable_and_safe(line, key, "req-app-aborted")
+
+
+@pytest.mark.asyncio
+async def test_app_level_unavailable_503_logs_path_and_error_class(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    app = create_app(_settings(), init_observability=False)
+    key = _seed_key()
+
+    def raise_transient(_self: Any, _workspace_id: str) -> Any:
+        raise DeadlineExceeded(ROW_NAMING_BACKEND_MESSAGE)
+
+    monkeypatch.setattr(InMemoryStore, "get_workspace", raise_transient)
+
+    with caplog.at_level("WARNING", logger="trusted_router"):
+        response = await _authorize(app, key, "req-app-unavailable")
+
+    assert response.status_code == 503
+    line = _single_warning(caplog, "storage.unavailable")
+    assert f"path={AUTHORIZE}" in line
+    assert "error_class=DeadlineExceeded" in line
+    _assert_attributable_and_safe(line, key, "req-app-unavailable")
+
+
+@pytest.mark.asyncio
+async def test_conflict_after_key_escrow_logs_tenant_context(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The legacy-path arm that refunds the key-limit escrow and answers 503
+    used to be the one authorize 503 with no log line at all."""
+    app = create_app(_settings(), init_observability=False)
+    key = _seed_key()
+
+    def raise_conflict(_self: Any, *_args: Any, **_kwargs: Any) -> Any:
+        raise StoreConflict(ROW_NAMING_BACKEND_MESSAGE)
+
+    monkeypatch.setattr(InMemoryStore, "create_gateway_authorization", raise_conflict)
+
+    with caplog.at_level("WARNING", logger="trusted_router"):
+        response = await _authorize(app, key, "req-escrow-conflict")
+
+    assert response.status_code == 503
+    assert response.json()["error"]["message"] == "Authorization contention; retry shortly."
+    line = _single_warning(caplog, "billing.authorize_conflict_after_escrow")
+    assert f"workspace_id={key.workspace_id}" in line
+    assert "requested_model=anthropic/claude-haiku-4.5" in line
+    assert "estimated_microdollars=" in line
+    assert "error_class=StoreConflict" in line
+    _assert_attributable_and_safe(line, key, "req-escrow-conflict")
+    # The escrow taken before the conflict came back: a retry is not charged twice.
+    assert not [r for r in caplog.records if r.getMessage().startswith("storage.")]
+
+
+def test_federated_key_directory_outage_logs_home_and_error_class(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A peer plane that cannot reach home (and holds no cached record) answers
+    503; that arm raised without a line, so the EU request log alone could not
+    distinguish it from storage contention."""
+    monkeypatch.setenv("TR_FEDERATION_HOME_BASE_URL", "https://home.example")
+    monkeypatch.setenv("TR_FEDERATION_HOME_TOKEN", "home-token")
+    cache_clear = getattr(get_settings, "cache_clear", None)
+    if cache_clear is not None:
+        cache_clear()
+
+    class HomeUnreachable:
+        def resolve(self, _lookup_hash: str) -> Any:
+            raise FederationUnavailable(ROW_NAMING_BACKEND_MESSAGE)
+
+    monkeypatch.setattr(gateway_routes, "_federation_client", lambda *_a, **_k: HomeUnreachable())
+
+    with caplog.at_level("WARNING", logger="trusted_router"):
+        with pytest.raises(HTTPException) as raised:
+            gateway_routes._federated_key_still_valid(None, "lookup-hash-never-logged")
+
+    assert raised.value.status_code == 503
+    assert raised.value.headers == {"Retry-After": "5"}
+    line = _single_warning(caplog, "federation.key_directory_unavailable")
+    assert "home=https://home.example" in line
+    assert "cached_age_s=None" in line
+    assert "error_class=FederationUnavailable" in line
+    assert "home-token" not in line
+    assert "lookup-hash-never-logged" not in line
+    assert ROW_NAMING_BACKEND_MESSAGE not in line

--- a/tests/test_gateway_aborted_handler.py
+++ b/tests/test_gateway_aborted_handler.py
@@ -126,7 +126,9 @@ async def test_gateway_authorize_contention_logs_safe_tenant_context(
 
     assert response.status_code == 503
     record = next(
-        record for record in caplog.records if record.msg == "billing.authorize_contention"
+        record
+        for record in caplog.records
+        if record.getMessage().startswith("billing.authorize_contention ")
     )
     context = record.__dict__
     assert context["workspace_id"] == key.workspace_id
@@ -174,7 +176,7 @@ async def test_gateway_authorize_storage_outage_logs_safe_tenant_context(
     record = next(
         record
         for record in caplog.records
-        if record.msg == "billing.authorize_storage_unavailable"
+        if record.getMessage().startswith("billing.authorize_storage_unavailable ")
     )
     context = record.__dict__
     assert context["workspace_id"] == key.workspace_id

--- a/tests/test_user_models.py
+++ b/tests/test_user_models.py
@@ -325,24 +325,38 @@ def test_clock_in_probe_failure_stays_offline(
 
 def test_gateway_rejects_off_clock_user_model_with_stable_error(
     dispatch_client: TestClient,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     client = dispatch_client
     key = _create_key(client)
     created = _create(client)
 
-    response = client.post(
-        "/v1/internal/gateway/authorize",
-        json={
-            "api_key_hash": key["hash"],
-            "model": created["id"],
-            "estimated_input_tokens": 10,
-            "max_output_tokens": 10,
-        },
-    )
+    with caplog.at_level("WARNING", logger="trusted_router"):
+        response = client.post(
+            "/v1/internal/gateway/authorize",
+            headers={"X-Request-ID": "req-off-the-clock"},
+            json={
+                "api_key_hash": key["hash"],
+                "model": created["id"],
+                "estimated_input_tokens": 10,
+                "max_output_tokens": 10,
+            },
+        )
     assert response.status_code == 503, response.text
     assert response.json()["error"]["type"] == "model_off_the_clock"
     assert created["id"] in response.json()["error"]["message"]
     assert "machine" in response.json()["error"]["message"]
+    # This 503 counts against the billing-path 5xx alert, so it names itself.
+    lines = [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("billing.authorize_user_model_off_the_clock ")
+    ]
+    assert len(lines) == 1, lines
+    assert f"user_model_id={created['id']}" in lines[0]
+    assert "kind=machine" in lines[0]
+    assert "request_id=req-off-the-clock" in lines[0]
+    assert key["hash"] not in lines[0]
 
 
 def test_gateway_authorization_freezes_user_model_attribution(


### PR DESCRIPTION
## Why

The 2026-09-02 15:46Z europe-west4 authorize 503 that fired **TR Gateway: billing path 5xx** left nothing but the Cloud Run request entry. Four arms on the authorize path answered 503 without a log line, so the next one would be just as unattributable.

## What

One WARNING per arm, with the attribution fields **in the message** (the console formatter renders only `%(message)s`, so `extra` never reaches Cloud Logging):

| Arm | Line |
|---|---|
| app-level conflict handler (`main.py`) | `storage.transaction_aborted method= path= request_id= error_class=` |
| app-level unavailable handler (`main.py`) | `storage.unavailable …` |
| legacy-path key-escrow `StoreConflict` arm | `billing.authorize_conflict_after_escrow workspace_id= request_id= requested_model= estimated_microdollars= error_class=` |
| user-model off-the-clock 503 | `billing.authorize_user_model_off_the_clock workspace_id= request_id= user_model_id= kind=` |
| federated key-directory outage | `federation.key_directory_unavailable home= cached_age_s= error_class=` |

Only the error **class** is logged: backend messages can name rows, and a key hash, prompt, or body must never land in a log line.

## Tests

`tests/test_gateway_503_attribution.py` exercises all four arms end to end and asserts each line names the request and path/workspace while excluding the key hash, the lookup hash, the home token, and the backend message. The existing off-the-clock test now also asserts its line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review fixes (codex + adversarial workflow)

- The app-level line logs the matched **route template** (as FastAPI matched it, i.e. without the `/v1` include prefix), never the concrete path: `/v1/keys/{hash}` and the console key routes carry a key hash as a path segment.
- Dropped the raw `X-Request-ID` header fallback; the middleware always sets a sanitised `request.state.request_id`.
- `federation.key_directory_unavailable`: an unstampable cached record reads as infinitely old and `int(inf)` raised `OverflowError` (a 500 in place of the 503). Now logs `cached_age_s=None`; test added.
- `_log_value` sanitises request-derived fields (the `model` field is an unconstrained string, so a newline in it could forge a second line in a text sink); `federation.key_directory_unavailable` logs the host only, never the configured URL's path, query, or embedded credentials.
- `billing.authorize_contention` and `billing.authorize_storage_unavailable` already existed but carried their context only in `extra`, which the console formatter drops. They now also name the request id, workspace, and error class in the message, so they join with the app-level line that answers the re-raise.
