### PR TITLE
Schedule Xiaomi MiMo UltraSpeed retirement

### DIFF
--- a/scripts/pricing/providers/xiaomi.py
+++ b/scripts/pricing/providers/xiaomi.py
@@ -7,6 +7,9 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from scripts.pricing.base import ProviderPricingResult, fetch_provider
+from trusted_router.provider_lifecycle import (
+    XIAOMI_MIMO_V25_PRO_ULTRASPEED_RETIREMENT_AT,
+)
 
 SLUG = "xiaomi"
 PUBLIC_PRICING_URL = "https://mimo.mi.com/docs/en-US/price/pay-as-you-go"
@@ -24,6 +27,7 @@ EXPECTED_MODELS = [
     "xiaomi/mimo-v2.5",
     "xiaomi/mimo-v2.5-pro",
 ]
+_ULTRASPEED_MODEL_ID = "xiaomi/mimo-v2.5-pro-ultraspeed"
 
 
 def fetch() -> ProviderPricingResult:
@@ -47,6 +51,12 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
         model_id = row.get("id")
         if not isinstance(model_id, str):
             continue
+        if model_id == _ULTRASPEED_MODEL_ID:
+            row["retirement_at"] = (
+                XIAOMI_MIMO_V25_PRO_ULTRASPEED_RETIREMENT_AT.astimezone(UTC)
+                .isoformat()
+                .replace("+00:00", "Z")
+            )
         price = result.prices.get(model_id)
         if price is None:
             continue
@@ -67,10 +77,10 @@ def write_provider_manifest(result: ProviderPricingResult) -> list[str]:
     raw["_note"] = (
         "Xiaomi MiMo provider-native routes. PAYG prices for MiMo V2.5 and "
         "V2.5 Pro are refreshed hourly from Xiaomi's official overseas USD "
-        "table. V2.5 Pro UltraSpeed remains live in Xiaomi's authenticated "
-        "/v1/models feed but has no public PAYG row, so its last verified "
-        "price is retained until Xiaomi republishes one. Legacy V2 rows are "
-        "kept only as historical fallback metadata."
+        "table. The limited-beta V2.5 Pro UltraSpeed Model API is scheduled "
+        "to retire at the start of September 8, 2026 in UTC+08; its last "
+        "verified price is retained until that provider-scoped cutoff. "
+        "Legacy V2 rows are kept only as historical fallback metadata."
     )
     raw["generated_at"] = (
         datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/src/trusted_router/data/provider_models/xiaomi.json
+++ b/src/trusted_router/data/provider_models/xiaomi.json
@@ -3,7 +3,7 @@
   "source": "https://mimo.mi.com/docs/en-US/price/pay-as-you-go",
   "generated_at": "2026-09-03T03:27:13Z",
   "model_count": 5,
-  "_note": "Xiaomi MiMo provider-native routes. PAYG prices for MiMo V2.5 and V2.5 Pro are refreshed hourly from Xiaomi's official overseas USD table. V2.5 Pro UltraSpeed remains live in Xiaomi's authenticated /v1/models feed but has no public PAYG row, so its last verified price is retained until Xiaomi republishes one. Legacy V2 rows are kept only as historical fallback metadata.",
+  "_note": "Xiaomi MiMo provider-native routes. PAYG prices for MiMo V2.5 and V2.5 Pro are refreshed hourly from Xiaomi's official overseas USD table. The limited-beta V2.5 Pro UltraSpeed Model API is scheduled to retire at the start of September 8, 2026 in UTC+08; its last verified price is retained until that provider-scoped cutoff. Legacy V2 rows are kept only as historical fallback metadata.",
   "models": [
     {
       "id": "xiaomi/mimo-v2-flash",
@@ -131,7 +131,8 @@
       "output_modalities": [
         "text"
       ],
-      "cached_input_token_price_per_m": 10800
+      "cached_input_token_price_per_m": 10800,
+      "retirement_at": "2026-09-07T16:00:00Z"
     }
   ]
 }

--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -51,6 +51,9 @@ FIREWORKS_DSV4_FLASH_0731_PRICING_EFFECTIVE_AT = datetime(
 )
 FIREWORKS_AUGUST_2026_RETIREMENT_AT = datetime(2026, 8, 27, 0, 0, tzinfo=UTC)
 FIREWORKS_QWEN37_RETIREMENT_AT = datetime(2026, 9, 4, 0, 0, tzinfo=UTC)
+XIAOMI_MIMO_V25_PRO_ULTRASPEED_RETIREMENT_AT = datetime(
+    2026, 9, 8, 0, 0, tzinfo=timezone(timedelta(hours=8), "Asia/Shanghai")
+)
 
 # DeepSeek prices direct V4 traffic at twice the off-peak rate during these
 # half-open UTC windows. Keep them as seconds since midnight so boundary
@@ -106,6 +109,17 @@ class _Retirement:
 
 
 _RETIREMENTS = (
+    # Xiaomi announced that the limited-beta MiMo V2.5 Pro UltraSpeed Model
+    # API ends on 2026-09-08 in UTC+08. No exact hour or replacement was
+    # provided, so retire conservatively at the start of that local date.
+    # This is provider-specific: regular MiMo V2.5 Pro and equivalent models
+    # served elsewhere are unaffected.
+    _Retirement(
+        provider="xiaomi",
+        model_ids=frozenset({"xiaomi/mimo-v2.5-pro-ultraspeed"}),
+        upstream_ids=frozenset({"mimo-v2.5-pro-ultraspeed"}),
+        effective_at=XIAOMI_MIMO_V25_PRO_ULTRASPEED_RETIREMENT_AT,
+    ),
     # Fireworks announced that these Serverless routes retire on 2026-08-27.
     # The two Kimi retirements apply only to the separately billed Fast
     # routers; standard Kimi K2.6 and Kimi K2.7 Code remain available. The

--- a/src/trusted_router/routing_candidates.py
+++ b/src/trusted_router/routing_candidates.py
@@ -157,17 +157,14 @@ def cheap_candidate_models(limit: int = 8) -> list[Model]:
 
 FAST_MODEL_ORDER = (
     "cerebras/gpt-oss-120b",
-    "xiaomi/mimo-v2.5-pro-ultraspeed",
     "cerebras/zai-glm-4.7",
 )
 
 
 def fast_candidate_models(limit: int = 8) -> list[Model]:
-    # Low-latency pool: Cerebras first, then Xiaomi MiMo's UltraSpeed tier.
-    # Keep this as a small explicit pool so callers who choose
+    # Keep this as a small explicit Cerebras pool so callers who choose
     # `trustedrouter/fast` do not accidentally get a cheap-but-slower model
-    # just because it has a lower token price. Delisted provider-native aliases
-    # disappear from MODELS and are pruned here without blocking catalog refresh.
+    # just because it has a lower token price.
     candidates: list[Model] = []
     seen: set[str] = set()
     for model_id in FAST_MODEL_ORDER:

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 
+from tests.lifecycle_clock import catalog_predates
 from trusted_router.catalog import (
     ADVISOR_CATALOG_MODEL_ORDERS,
     ADVISOR_MODEL_ID,
@@ -94,7 +95,10 @@ from trusted_router.catalog import (
 from trusted_router.catalog_ingest import _authoritative_provider_model_ids, _modalities
 from trusted_router.config import Settings
 from trusted_router.main import create_app
-from trusted_router.provider_lifecycle import provider_model_retired
+from trusted_router.provider_lifecycle import (
+    XIAOMI_MIMO_V25_PRO_ULTRASPEED_RETIREMENT_AT,
+    provider_model_retired,
+)
 from trusted_router.routes.internal.gateway import _gateway_provider_route_payload
 from trusted_router.routing import chat_route_candidates, chat_route_endpoint_candidates
 
@@ -1958,8 +1962,9 @@ def test_xiaomi_mimo_provider_models_present_and_routable() -> None:
     expected = {
         "xiaomi/mimo-v2.5": "mimo-v2.5",
         "xiaomi/mimo-v2.5-pro": "mimo-v2.5-pro",
-        "xiaomi/mimo-v2.5-pro-ultraspeed": "mimo-v2.5-pro-ultraspeed",
     }
+    if catalog_predates(XIAOMI_MIMO_V25_PRO_ULTRASPEED_RETIREMENT_AT):
+        expected["xiaomi/mimo-v2.5-pro-ultraspeed"] = "mimo-v2.5-pro-ultraspeed"
     xiaomi_credits = {}
     for model_id, upstream in expected.items():
         model = MODELS.get(model_id)
@@ -1993,14 +1998,15 @@ def test_xiaomi_mimo_provider_models_present_and_routable() -> None:
     # ($1.305/$2.61) cost, marked up by the manifest loader (cost x 1.055,
     # $0.01/M floor). Guard the exact prices so a regen can't silently
     # collapse them onto the regular v2.5-pro numbers.
-    ultraspeed_xiaomi = xiaomi_credits["xiaomi/mimo-v2.5-pro-ultraspeed"]
-    assert ultraspeed_xiaomi.prompt_price_microdollars_per_million_tokens == 1_376_775
-    assert ultraspeed_xiaomi.completion_price_microdollars_per_million_tokens == 2_753_550
-    # ...and that it is genuinely a distinct row from regular v2.5-pro.
-    assert (
-        ultraspeed_xiaomi.completion_price_microdollars_per_million_tokens
-        != pro_xiaomi.completion_price_microdollars_per_million_tokens
-    )
+    if catalog_predates(XIAOMI_MIMO_V25_PRO_ULTRASPEED_RETIREMENT_AT):
+        ultraspeed_xiaomi = xiaomi_credits["xiaomi/mimo-v2.5-pro-ultraspeed"]
+        assert ultraspeed_xiaomi.prompt_price_microdollars_per_million_tokens == 1_376_775
+        assert ultraspeed_xiaomi.completion_price_microdollars_per_million_tokens == 2_753_550
+        # It is genuinely a distinct tier from regular V2.5 Pro.
+        assert (
+            ultraspeed_xiaomi.completion_price_microdollars_per_million_tokens
+            != pro_xiaomi.completion_price_microdollars_per_million_tokens
+        )
 
 
 def test_crusoe_provider_models_follow_authoritative_manifest() -> None:

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -980,11 +980,15 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
     ]
     socrates_pro_plus_meta = models_by_id["trustedrouter/socrates-pro-plus-1.0"]["trustedrouter"]
     assert socrates_pro_plus_meta["auto_candidates"] == [
-        "xiaomi/mimo-v2.5-pro-ultraspeed",
-        "minimax/minimax-m3",
-        "z-ai/glm-5.2-fast",
-        "deepseek/deepseek-v4-flash",
-        "trustedrouter/zeus-1.0",
+        model_id
+        for model_id in [
+            "xiaomi/mimo-v2.5-pro-ultraspeed",
+            "minimax/minimax-m3",
+            "z-ai/glm-5.2-fast",
+            "deepseek/deepseek-v4-flash",
+            "trustedrouter/zeus-1.0",
+        ]
+        if model_id in MODELS
     ]
     assert (
         models_by_id["trustedrouter/socrates-1.1"]["trustedrouter"]["auto_candidates"]

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -6,8 +6,12 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
+from tests.lifecycle_clock import catalog_predates
 from trusted_router.catalog import PROVIDERS, endpoints_for_model
 from trusted_router.dashboard import PUBLIC_PAGES
+from trusted_router.provider_lifecycle import (
+    XIAOMI_MIMO_V25_PRO_ULTRASPEED_RETIREMENT_AT,
+)
 from trusted_router.storage import STORE
 
 
@@ -658,7 +662,10 @@ def test_public_meta_model_detail_renders_orchestration_components(client: TestC
     assert '<span class="pill">advisor</span>' in response.text
     assert '<span class="pill">named preset</span>' in response.text
     assert "Models used by this orchestration" in response.text
-    assert "xiaomi/mimo-v2.5-pro-ultraspeed" in response.text
+    if catalog_predates(XIAOMI_MIMO_V25_PRO_ULTRASPEED_RETIREMENT_AT):
+        assert "xiaomi/mimo-v2.5-pro-ultraspeed" in response.text
+    else:
+        assert "xiaomi/mimo-v2.5-pro-ultraspeed" not in response.text
     assert "minimax/minimax-m3" in response.text
     assert "z-ai/glm-5.2-fast" in response.text
     assert "deepseek/deepseek-v4-flash" in response.text

--- a/tests/test_xiaomi_september_2026_lifecycle.py
+++ b/tests/test_xiaomi_september_2026_lifecycle.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from scripts.pricing import refresh
+from scripts.pricing.base import ModelPrice, ProviderPricingResult
+from scripts.pricing.providers import xiaomi
+from tests.lifecycle_clock import catalog_predates
+from trusted_router import provider_lifecycle
+from trusted_router.catalog import FAST_MODEL_ORDER, endpoints_for_model
+
+_CUTOFF = datetime(2026, 9, 7, 16, 0, tzinfo=UTC)
+_ULTRASPEED = "xiaomi/mimo-v2.5-pro-ultraspeed"
+_ULTRASPEED_UPSTREAM = "mimo-v2.5-pro-ultraspeed"
+_PRO = "xiaomi/mimo-v2.5-pro"
+
+
+def test_xiaomi_ultraspeed_retires_at_announced_local_date() -> None:
+    assert provider_lifecycle.XIAOMI_MIMO_V25_PRO_ULTRASPEED_RETIREMENT_AT == _CUTOFF
+    assert not provider_lifecycle.provider_model_retired(
+        "xiaomi",
+        _ULTRASPEED,
+        _ULTRASPEED_UPSTREAM,
+        at=_CUTOFF - timedelta(microseconds=1),
+    )
+    assert provider_lifecycle.provider_model_retired(
+        "xiaomi",
+        _ULTRASPEED,
+        _ULTRASPEED_UPSTREAM,
+        at=_CUTOFF,
+    )
+
+
+def test_xiaomi_ultraspeed_retirement_is_provider_scoped() -> None:
+    assert not provider_lifecycle.provider_model_retired(
+        "another-provider",
+        _ULTRASPEED,
+        _ULTRASPEED_UPSTREAM,
+        at=_CUTOFF,
+    )
+    assert not provider_lifecycle.provider_model_retired(
+        "xiaomi",
+        _PRO,
+        "mimo-v2.5-pro",
+        at=_CUTOFF,
+    )
+
+
+def test_xiaomi_catalog_route_retires_on_schedule(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if catalog_predates(_CUTOFF):
+        monkeypatch.setattr(
+            provider_lifecycle,
+            "_utc_now",
+            lambda: _CUTOFF - timedelta(microseconds=1),
+        )
+        assert "xiaomi" in {endpoint.provider for endpoint in endpoints_for_model(_ULTRASPEED)}
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    assert "xiaomi" not in {endpoint.provider for endpoint in endpoints_for_model(_ULTRASPEED)}
+    assert "xiaomi" in {endpoint.provider for endpoint in endpoints_for_model(_PRO)}
+
+
+def test_hourly_refresh_cannot_restore_retired_xiaomi_ultraspeed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = ProviderPricingResult(
+        slug="xiaomi",
+        prices={
+            _ULTRASPEED: ModelPrice(1_305_000, 2_610_000),
+            _PRO: ModelPrice(435_000, 870_000),
+        },
+        source="api",
+        fetched_url=xiaomi.URL,
+    )
+
+    monkeypatch.setattr(
+        provider_lifecycle,
+        "_utc_now",
+        lambda: _CUTOFF - timedelta(microseconds=1),
+    )
+    before = refresh._index_provider_prices({"xiaomi": result})
+    assert "xiaomi" in before[_ULTRASPEED]
+
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    after = refresh._index_provider_prices({"xiaomi": result})
+    assert _ULTRASPEED not in after
+    assert "xiaomi" in after[_PRO]
+
+
+def test_xiaomi_manifest_records_retirement_without_inventing_replacement() -> None:
+    rows = {
+        row["id"]: row
+        for row in json.loads(xiaomi.MANIFEST_PATH.read_text(encoding="utf-8"))["models"]
+    }
+
+    assert rows[_ULTRASPEED]["retirement_at"] == "2026-09-07T16:00:00Z"
+    assert "replacement_model_id" not in rows[_ULTRASPEED]
+
+
+def test_xiaomi_manifest_refresh_restores_retirement_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = tmp_path / "xiaomi.json"
+    raw = json.loads(xiaomi.MANIFEST_PATH.read_text(encoding="utf-8"))
+    ultraspeed = next(row for row in raw["models"] if row["id"] == _ULTRASPEED)
+    ultraspeed.pop("retirement_at", None)
+    manifest_path.write_text(json.dumps(raw), encoding="utf-8")
+    monkeypatch.setattr(xiaomi, "MANIFEST_PATH", manifest_path)
+
+    xiaomi.write_provider_manifest(
+        ProviderPricingResult(
+            slug="xiaomi",
+            prices={
+                "xiaomi/mimo-v2.5": ModelPrice(140_000, 280_000),
+                _PRO: ModelPrice(435_000, 870_000),
+            },
+            source="fixture",
+            fetched_url=xiaomi.URL,
+        )
+    )
+
+    refreshed = json.loads(manifest_path.read_text(encoding="utf-8"))
+    refreshed_ultraspeed = next(row for row in refreshed["models"] if row["id"] == _ULTRASPEED)
+    assert refreshed_ultraspeed["retirement_at"] == "2026-09-07T16:00:00Z"
+
+
+def test_fast_pool_no_longer_depends_on_limited_beta() -> None:
+    assert _ULTRASPEED not in FAST_MODEL_ORDER


### PR DESCRIPTION
## Summary

- retire Xiaomi's provider-native MiMo V2.5 Pro UltraSpeed route at the conservative start of September 8 in UTC+8
- prevent hourly catalog refreshes from restoring the route after cutoff
- remove the limited-beta route from `trustedrouter/fast` while preserving immutable versioned orchestration graphs
- record the cutoff in the provider manifest and keep regular MiMo routes unaffected

## Verification

- `uv run ruff check .`
- `uv run mypy`
- affected current-clock suite: 201 passed
- affected post-cutover suite: 191 passed
- full suite: 8,327 passed; sandbox-denied loopback tests rerun outside sandbox: 107 passed
