### PR TITLE
Add private Archimedes 1.0 model alias

### DIFF
--- a/src/trusted_router/catalog.py
+++ b/src/trusted_router/catalog.py
@@ -17,6 +17,7 @@ from trusted_router.catalog_data import (  # noqa: F401 - re-exported for back-c
     _UNSERVED_CREDITS_MODELS,
     ADVISOR_CATALOG_MODEL_ORDERS,
     ADVISOR_MODEL_ID,
+    ARCHIMEDES_1_0_MODEL_ID,
     ARISTOTLE_1_0_MODEL_ID,
     ARISTOTLE_1_1_MODEL_ID,
     ARISTOTLE_2_0_MODEL_ID,
@@ -54,6 +55,7 @@ from trusted_router.catalog_data import (  # noqa: F401 - re-exported for back-c
     MAPREDUCE_CATALOG_MODEL_ORDER,
     MAPREDUCE_MODEL_ID,
     META_MODEL_IDS,
+    MISTRAL_LARGE_MODEL_ID,
     MONITOR_MODEL_ID,
     OPEN_PATCHER_A1_MODEL_ID,
     OPEN_PATCHER_FAST1_MODEL_ID,
@@ -81,6 +83,7 @@ from trusted_router.catalog_data import (  # noqa: F401 - re-exported for back-c
     PRIVACY_TIER_NO_STORE,
     PRIVACY_TIER_STANDARD,
     PRIVACY_TIER_ZERO_RETENTION,
+    PRIVATE_PROXY_MODEL_TARGETS,
     PROMETHEUS_1_0_1M_MODEL_ID,
     PROMETHEUS_1_0_MODEL_ID,
     PROMETHEUS_2_0_MODEL_ID,
@@ -287,6 +290,8 @@ def canonical_orchestration_model_id(model_id: str) -> str | None:
 def orchestration_role(model_id: str) -> str | None:
     if model_id not in META_MODEL_IDS:
         return None
+    if model_id in PRIVATE_PROXY_MODEL_TARGETS:
+        return "private_proxy"
     if model_id in ORCHESTRATION_LEGACY_ALIAS_MODEL_IDS:
         return "legacy_alias"
     if model_id in ORCHESTRATION_ROLLING_ALIAS_MODEL_IDS:
@@ -627,7 +632,7 @@ def model_to_openrouter_shape(model: Model) -> dict[str, object]:
     if is_meta and not model.hidden_public_metadata:
         auto_candidates = [c.id for c in meta_candidate_models(model.id)]
     if model.hidden_public_metadata:
-        route_kind = "private_orchestration"
+        route_kind = "private_proxy" if model.id in PRIVATE_PROXY_MODEL_TARGETS else "private_orchestration"
 
     tr_block: dict[str, object] = {
         "provider": model.provider,
@@ -726,6 +731,25 @@ def model_to_openrouter_shape(model: Model) -> dict[str, object]:
         tr_block["published_prompt_price_max_microdollars_per_million_tokens"] = pub_prompt_max
         tr_block["published_completion_price_max_microdollars_per_million_tokens"] = (
             pub_completion_max
+        )
+    if model.id in PRIVATE_PROXY_MODEL_TARGETS:
+        tr_block.update(
+            {
+                "provider_zero_data_retention": False,
+                "zero_data_retention_available": False,
+                "provider_confidential_compute": False,
+                "provider_e2ee": False,
+                "provider_policy": (
+                    "Private route configuration. Standard provider data-handling terms apply."
+                ),
+                "provider_policy_url": "https://trust.trustedrouter.com",
+                "provider_headquarters_country": None,
+                "provider_us_based": False,
+                "us_provider_available": False,
+                "eu_focused_provider_available": False,
+                "privacy_tier": PRIVACY_TIER_STANDARD,
+                "privacy_tier_label": PRIVACY_TIER_LABELS[PRIVACY_TIER_STANDARD],
+            }
         )
 
     return {

--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -2098,6 +2098,17 @@ DEEPSEEK_V4_PRO_0423_MODEL_ID = "deepseek/deepseek-v4-pro-0423"
 
 DEEPSEEK_V4_PRO_0813_MODEL_ID = "deepseek/deepseek-v4-pro-0813"
 
+MISTRAL_LARGE_MODEL_ID = "mistralai/mistral-large"
+
+ARCHIMEDES_1_0_MODEL_ID = "trustedrouter/archimedes-1.0"
+
+# Private proxy aliases select one ordinary catalog model without publishing
+# the backing model/provider in customer-visible responses or catalog metadata.
+# Billing and provider fallback still use the concrete target internally.
+PRIVATE_PROXY_MODEL_TARGETS: dict[str, str] = {
+    ARCHIMEDES_1_0_MODEL_ID: MISTRAL_LARGE_MODEL_ID,
+}
+
 SOCRATES_1_0_MODEL_ID = "trustedrouter/socrates-1.0"
 
 SOCRATES_1_1_MODEL_ID = "trustedrouter/socrates-1.1"
@@ -2243,6 +2254,7 @@ META_MODEL_IDS = frozenset(
         E2E_MODEL_ID,
         CONFIDENTIAL_MODEL_ID,
         MONITOR_MODEL_ID,
+        ARCHIMEDES_1_0_MODEL_ID,
         SOCRATES_1_0_MODEL_ID,
         SOCRATES_1_1_MODEL_ID,
         SOCRATES_2_0_MODEL_ID,

--- a/src/trusted_router/catalog_registry.py
+++ b/src/trusted_router/catalog_registry.py
@@ -23,6 +23,7 @@ from trusted_router.catalog_data import (  # noqa: F401 - re-exported for back-c
     _UNSERVED_CREDITS_MODELS,
     ADVISOR_CATALOG_MODEL_ORDERS,
     ADVISOR_MODEL_ID,
+    ARCHIMEDES_1_0_MODEL_ID,
     ARISTOTLE_1_0_MODEL_ID,
     ARISTOTLE_1_1_MODEL_ID,
     ARISTOTLE_2_0_MODEL_ID,
@@ -58,6 +59,7 @@ from trusted_router.catalog_data import (  # noqa: F401 - re-exported for back-c
     MAPREDUCE_CATALOG_MODEL_ORDER,
     MAPREDUCE_MODEL_ID,
     META_MODEL_IDS,
+    MISTRAL_LARGE_MODEL_ID,
     MONITOR_MODEL_ID,
     OPEN_PATCHER_A1_MODEL_ID,
     OPEN_PATCHER_FAST1_MODEL_ID,
@@ -896,6 +898,21 @@ for _model_id, _model in _SUPPLEMENTAL_MODELS.items():
             dict.fromkeys((*_existing_model.output_modalities, *_model.output_modalities))
         ),
     )
+
+# Archimedes is a one-model private proxy. Clone the canonical model after
+# native manifests have merged so context, capabilities, cache pricing, and
+# future price refreshes remain byte-for-byte aligned with Mistral Large.
+_archimedes_backing_model = MODELS[MISTRAL_LARGE_MODEL_ID]
+MODELS[ARCHIMEDES_1_0_MODEL_ID] = replace(
+    _archimedes_backing_model,
+    id=ARCHIMEDES_1_0_MODEL_ID,
+    name="TrustedRouter Archimedes 1.0",
+    provider="trustedrouter",
+    upstream_id=None,
+    prepaid_available=True,
+    byok_available=False,
+    hidden_public_metadata=True,
+)
 # Embedding models override any snapshot/supplemental collision: the
 # hand-curated embedding entry (input-only pricing, supports_embeddings) is
 # authoritative for these IDs. Merge BEFORE `_build_endpoints` so each gets

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -46,6 +46,7 @@ from trusted_router.byok_crypto import byok_cache_key, encrypted_secret_payload
 from trusted_router.catalog import (
     MODELS,
     MONITOR_MODEL_ID,
+    PRIVATE_PROXY_MODEL_TARGETS,
     PROVIDERS,
     Model,
     ModelEndpoint,
@@ -821,6 +822,17 @@ def _authorize_gateway_sync_impl(
     body_dict.update(attribution.body_fields())
     _require_monitor_model_key(body_dict, api_key.lookup_hash, settings)
     requested_model_id = body.model
+    private_proxy_ids = {
+        model_id
+        for model_id in (requested_model_id, *(body.models or []))
+        if model_id in PRIVATE_PROXY_MODEL_TARGETS
+    }
+    if private_proxy_ids and body.models:
+        raise api_error(
+            400,
+            "Private proxy models cannot be combined with models fallback arrays",
+            ErrorType.BAD_REQUEST,
+        )
     if any(is_creator_model_id(model_id) for model_id in (body.models or [])):
         raise api_error(
             400,
@@ -2264,6 +2276,9 @@ def _gateway_authorize_response(
         authorization,
         reason_override=stage_d_reason_override,
     )
+    response_model = (
+        requested_model_id if requested_model_id in PRIVATE_PROXY_MODEL_TARGETS else None
+    )
     return {
         "data": {
             "authorization_id": authorization.id,
@@ -2276,6 +2291,8 @@ def _gateway_authorize_response(
             "provider_name": PROVIDERS[endpoint.provider].name,
             **_gateway_provider_route_payload(endpoint),
             "requested_model": requested_model_id,
+            "response_model": response_model,
+            "hide_public_metadata": response_model is not None,
             "usage_type": model_usage_type.value,
             "limit_usage_type": limit_usage_type.value,
             **money_pair("estimated_cost", estimate),

--- a/src/trusted_router/routing_candidates.py
+++ b/src/trusted_router/routing_candidates.py
@@ -44,6 +44,7 @@ from trusted_router.catalog_data import (
     PRIVACY_TIER_CONFIDENTIAL,
     PRIVACY_TIER_STANDARD,
     PRIVACY_TIER_ZERO_RETENTION,
+    PRIVATE_PROXY_MODEL_TARGETS,
     PROMETHEUS_1_0_1M_MODEL_ID,
     PROMETHEUS_1_0_MODEL_ID,
     PROMETHEUS_2_0_MODEL_ID,
@@ -342,6 +343,9 @@ def socrates_candidate_models() -> list[Model]:
 
 def meta_candidate_models(model_id: str) -> list[Model]:
     model_id = ROUTING_MODEL_ALIAS_TARGETS.get(model_id, model_id)
+    private_proxy_target = PRIVATE_PROXY_MODEL_TARGETS.get(model_id)
+    if private_proxy_target is not None:
+        return _models_for_ids((private_proxy_target,))
     if model_id == AUTO_MODEL_ID:
         return auto_candidate_models()
     if model_id == FREE_MODEL_ID:
@@ -415,6 +419,8 @@ def meta_candidate_models(model_id: str) -> list[Model]:
 
 def _meta_route_kind(model_id: str) -> str:
     model_id = ROUTING_MODEL_ALIAS_TARGETS.get(model_id, model_id)
+    if model_id in PRIVATE_PROXY_MODEL_TARGETS:
+        return "private_proxy"
     if model_id == FREE_MODEL_ID:
         return "free_pool"
     if model_id == CHEAP_MODEL_ID:

--- a/tests/test_catalog_routing_contracts.py
+++ b/tests/test_catalog_routing_contracts.py
@@ -8,6 +8,7 @@ from tests.lifecycle_clock import catalog_predates
 from trusted_router.catalog import (
     ADVISOR_CATALOG_MODEL_ORDERS,
     ADVISOR_MODEL_ID,
+    ARCHIMEDES_1_0_MODEL_ID,
     ARISTOTLE_1_0_MODEL_ID,
     ARISTOTLE_1_1_MODEL_ID,
     ARISTOTLE_2_0_MODEL_ID,
@@ -34,6 +35,7 @@ from trusted_router.catalog import (
     LIBERTY_3_0_MODEL_ID,
     MAPREDUCE_MODEL_ID,
     META_MODEL_IDS,
+    MISTRAL_LARGE_MODEL_ID,
     MODEL_ENDPOINTS,
     MODELS,
     OPEN_PATCHER_A1_MODEL_ID,
@@ -105,6 +107,37 @@ from trusted_router.routing import chat_route_candidates, chat_route_endpoint_ca
 
 def _cataloged_model_ids(model_ids: list[str]) -> list[str]:
     return [model_id for model_id in model_ids if model_id in MODELS]
+
+
+def test_archimedes_private_proxy_tracks_mistral_large_without_exposing_it() -> None:
+    archimedes = MODELS[ARCHIMEDES_1_0_MODEL_ID]
+    backing = MODELS[MISTRAL_LARGE_MODEL_ID]
+    archimedes_shape = model_to_openrouter_shape(archimedes)
+    backing_shape = model_to_openrouter_shape(backing)
+
+    assert [candidate.id for candidate in meta_candidate_models(archimedes.id)] == [backing.id]
+    assert archimedes.context_length == backing.context_length
+    assert archimedes.supported_parameters == backing.supported_parameters
+    assert archimedes.input_modalities == backing.input_modalities
+    assert archimedes.output_modalities == backing.output_modalities
+    assert archimedes.price_tiers == backing.price_tiers
+    assert archimedes_shape["pricing"] == backing_shape["pricing"]
+
+    metadata = archimedes_shape["trustedrouter"]
+    assert metadata["route_kind"] == "private_proxy"
+    assert metadata["configuration_hidden"] is True
+    assert metadata["auto_candidates"] is None
+    assert metadata["byok_available"] is False
+    assert metadata["orchestration_primitive"] is None
+    assert metadata["orchestration_role"] == "private_proxy"
+    assert metadata["provider_zero_data_retention"] is False
+    assert metadata["provider_confidential_compute"] is False
+    assert metadata["provider_e2ee"] is False
+    assert metadata["privacy_tier"] == PRIVACY_TIER_STANDARD
+
+    encoded = json.dumps(archimedes_shape)
+    assert MISTRAL_LARGE_MODEL_ID not in encoded
+    assert "mistral-large-latest" not in encoded
 
 
 def test_every_catalog_model_has_integer_prices_and_valid_provider() -> None:

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -804,6 +804,7 @@ def test_models_providers_credits_and_zdr(client: TestClient, user_headers: dict
     assert models
     assert {
         "trustedrouter/auto",
+        "trustedrouter/archimedes-1.0",
         "trustedrouter/fast",
         "trustedrouter/eu",
         "trustedrouter/zdr",

--- a/tests/test_gateway_fallback_billing.py
+++ b/tests/test_gateway_fallback_billing.py
@@ -7,7 +7,13 @@ import pytest
 from fastapi.testclient import TestClient
 
 from tests.fakes.spanner import make_fake_store
-from trusted_router.catalog import MODELS, default_endpoint_for_model, endpoint_for_id
+from trusted_router.catalog import (
+    ARCHIMEDES_1_0_MODEL_ID,
+    MISTRAL_LARGE_MODEL_ID,
+    MODELS,
+    default_endpoint_for_model,
+    endpoint_for_id,
+)
 from trusted_router.config import Settings
 from trusted_router.main import create_app
 from trusted_router.money import token_cost_microdollars
@@ -39,6 +45,83 @@ def _client_and_key() -> tuple[TestClient, dict]:
     )
     assert created.status_code == 201, created.text
     return client, created.json()["data"]
+
+
+def test_gateway_archimedes_authorizes_private_credits_route() -> None:
+    client, key = _client_and_key()
+
+    response = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": key["hash"],
+            "model": ARCHIMEDES_1_0_MODEL_ID,
+            "estimated_input_tokens": 11,
+            "max_output_tokens": 3,
+            "idempotency_key": "archimedes-private-proxy",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    data = response.json()["data"]
+    assert data["requested_model"] == ARCHIMEDES_1_0_MODEL_ID
+    assert data["response_model"] == ARCHIMEDES_1_0_MODEL_ID
+    assert data["hide_public_metadata"] is True
+    assert data["model"] == MISTRAL_LARGE_MODEL_ID
+    assert data["usage_type"] == "Credits"
+    assert {candidate["model"] for candidate in data["route_candidates"]} == {
+        MISTRAL_LARGE_MODEL_ID
+    }
+    assert {candidate["usage_type"] for candidate in data["route_candidates"]} == {"Credits"}
+
+    direct = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": key["hash"],
+            "model": MISTRAL_LARGE_MODEL_ID,
+            "estimated_input_tokens": 11,
+            "max_output_tokens": 3,
+            "idempotency_key": "mistral-large-direct-price-comparison",
+            "provider": {"usage": "credits"},
+        },
+    )
+    assert direct.status_code == 200, direct.text
+    assert data["estimated_cost_microdollars"] == direct.json()["data"][
+        "estimated_cost_microdollars"
+    ]
+
+
+def test_gateway_archimedes_rejects_byok_and_fallback_arrays() -> None:
+    client, key = _client_and_key()
+
+    byok = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": key["hash"],
+            "model": ARCHIMEDES_1_0_MODEL_ID,
+            "estimated_input_tokens": 1,
+            "max_output_tokens": 1,
+            "idempotency_key": "archimedes-byok",
+            "provider": {"usage": "byok"},
+        },
+    )
+    assert byok.status_code == 400, byok.text
+
+    fallbacks = client.post(
+        "/v1/internal/gateway/authorize",
+        json={
+            "api_key_hash": key["hash"],
+            "model": ARCHIMEDES_1_0_MODEL_ID,
+            "models": ["openai/gpt-5.4-nano"],
+            "estimated_input_tokens": 1,
+            "max_output_tokens": 1,
+            "idempotency_key": "archimedes-fallback-array",
+        },
+    )
+    assert fallbacks.status_code == 400, fallbacks.text
+    assert (
+        fallbacks.json()["error"]["message"]
+        == "Private proxy models cannot be combined with models fallback arrays"
+    )
 
 
 def test_gateway_authorize_never_escapes_no_fallback_provider_order() -> None:


### PR DESCRIPTION
## Summary
- add trustedrouter/archimedes-1.0 as a Credits-only private proxy to the canonical Mistral Large model
- inherit live price tiers, cached-input pricing, context, modalities, and capabilities from that canonical model
- mark the internal authorization so the enclave returns only the Archimedes identity
- avoid false ZDR, E2E, or confidential-compute claims and reject fallback arrays that could make hidden routing ambiguous

## Tests
- 115 catalog and focused API tests
- full core API and gateway fallback/billing test files
- mypy and Ruff checks on touched source
- exact authorization-price equality against direct mistralai/mistral-large