### PR TITLE
stage-d: turn snapshot booking on (decision 70)

### DIFF
--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -646,9 +646,9 @@ ENV_VARS=(
   # Flipped 2026-07-04 with Joseph's authorization. Remove to revert — the
   # flag-off settle path is byte-identical.
   "TR_SETTLE_OUTBOX_ENABLED=true"
-  # Stage D decision 70 is an explicit billing-policy switch. Keep snapshot
-  # booking dark until Joseph approves the dedicated rollout step.
-  "TR_REAP_SNAPSHOT_BOOKING_ENABLED=false"
+  # Stage D decision 70 snapshot booking was enabled on Joseph's word on
+  # 2026-09-03 after the enclave heartbeat rollout.
+  "TR_REAP_SNAPSHOT_BOOKING_ENABLED=true"
   # Provider benchmark events use their own best-effort durable queue. Tenant
   # activity is different: its operational outbox insert is part of the typed
   # settlement transaction, so a charge and its delivery intent cannot split.

--- a/tests/test_stage_d_heartbeat.py
+++ b/tests/test_stage_d_heartbeat.py
@@ -1024,7 +1024,7 @@ def test_literal_deferred_and_terminal_disposition_responses_match_router_helper
     assert _json("refund_response_finalized.json")["data"]["disposition"] == "finalized"
 
 
-def test_reaper_flag_defaults_off_and_rollout_pins_it_off() -> None:
+def test_reaper_flag_defaults_off_and_rollout_pins_it_on() -> None:
     assert Settings(environment="test").reap_snapshot_booking_enabled is False
     rollout = (Path(__file__).parents[1] / "scripts" / "deploy" / "rollout.sh").read_text()
-    assert '"TR_REAP_SNAPSHOT_BOOKING_ENABLED=false"' in rollout
+    assert '"TR_REAP_SNAPSHOT_BOOKING_ENABLED=true"' in rollout


### PR DESCRIPTION
Second Stage D flag, on Joseph's word (2026-09-03): the production rollout pin for `TR_REAP_SNAPSHOT_BOOKING_ENABLED` becomes `true`. This is the billing change of decision 70: a reaped cohort authorization that has a started heartbeat marker books its priced last snapshot (settle's cost function on the persisted pricing document, unit 4's clamp for lease-bound rows) instead of refunding to zero. Requests without a started marker, and every out-of-cohort request, are refunded exactly as today. The code default stays off; only the rollout pin changes, and the pinning test is updated.

Merge order: after the enclave heartbeat rollout (quill-cloud-proxy heartbeat-flag PR) is live on every region, so that snapshots exist to book and the soak signal is attributable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
