### PR TITLE
tests: prove axiom shipping is off-thread with events, and fake the price audit

### DIFF
--- a/tests/test_axiom_nonblocking.py
+++ b/tests/test_axiom_nonblocking.py
@@ -65,6 +65,25 @@ class _SlowShipper(logging.Handler):
         self.arrived.set()
 
 
+class _BlockingShipper(logging.Handler):
+    """Block shipping until the test explicitly allows it to finish."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.started = threading.Event()
+        self.release_event = threading.Event()
+        self.finished = threading.Event()
+        self.thread_id: int | None = None
+        self.received: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.thread_id = threading.get_ident()
+        self.started.set()
+        self.release_event.wait()
+        self.received.append(record)
+        self.finished.set()
+
+
 def _record(message: str, **extra: object) -> logging.LogRecord:
     record = logging.LogRecord(
         name="trusted_router.test",
@@ -82,20 +101,40 @@ def _record(message: str, **extra: object) -> logging.LogRecord:
 
 def test_emitting_does_not_wait_for_the_shipper() -> None:
     """The property the whole change exists for."""
-    shipper = _SlowShipper(delay=0.5)
-    handler = _DroppingQueueHandler(queue.Queue(maxsize=100))
-    listener = logging.handlers.QueueListener(handler.queue, shipper)
+    shipper = _BlockingShipper()
+    handler, listener = build_axiom_pipeline(shipper, resolved_level=logging.INFO)
     listener.start()
-    try:
-        started = time.monotonic()
-        handler.handle(_record("event happened"))
-        elapsed = time.monotonic() - started
+    worker = listener._thread
+    assert worker is not None
+    test_thread_id = threading.get_ident()
+    emitting_thread_ids: list[int] = []
+    emit_returned = threading.Event()
 
-        assert elapsed < 0.05, f"emit blocked for {elapsed:.3f}s; shipping must be off-thread"
-        assert shipper.arrived.wait(timeout=5), "record never reached the shipper"
-        assert len(shipper.received) == 1
+    def emit_record() -> None:
+        emitting_thread_ids.append(threading.get_ident())
+        handler.handle(_record("event happened"))
+        emit_returned.set()
+
+    emitter = threading.Thread(target=emit_record, daemon=True)
+    emitter.start()
+    try:
+        assert shipper.started.wait(timeout=5), "record never reached the shipper"
+        assert emit_returned.wait(timeout=5), "emit waited for the blocked shipper"
+        assert not shipper.release_event.is_set(), "shipper was released before emit returned"
+        assert not shipper.finished.is_set(), "emit waited for the blocked shipper"
+        assert shipper.thread_id != test_thread_id, "shipping ran on the test thread"
+        assert shipper.thread_id != emitting_thread_ids[0], "shipping ran on the emitting thread"
+        assert shipper.thread_id == worker.ident
     finally:
-        listener.stop()
+        shipper.release_event.set()
+        emitter.join(timeout=5)
+        listener.enqueue_sentinel()
+        worker.join(timeout=5)
+        assert not emitter.is_alive(), "emitting thread did not stop"
+        assert not worker.is_alive(), "shipper worker did not stop"
+
+    assert shipper.finished.is_set()
+    assert len(shipper.received) == 1
 
 
 def test_scrubbing_runs_before_the_queue() -> None:

--- a/tests/test_check_price_coverage.py
+++ b/tests/test_check_price_coverage.py
@@ -1153,19 +1153,17 @@ def test_strict_model_discovery_allows_visibility_only_price_warnings(
 def test_strict_model_discovery_does_not_fail_provider_api_visibility_warning(
     monkeypatch,
 ) -> None:
-    def fake_model_discovery_audit(*args, **kwargs):  # noqa: ANN001, ANN202
+    def fake_run_audit(*args, **kwargs):  # noqa: ANN001, ANN202
         return (
             ["novita: live model API lists unpublished model(s) test/model"],
             ["zai: model discovery matched catalog (1 docs model(s)) ✓"],
+            [],
         )
 
-    monkeypatch.setattr(
-        check_price_coverage,
-        "_model_discovery_audit",
-        fake_model_discovery_audit,
+    monkeypatch.setattr(check_price_coverage, "_run_audit", fake_run_audit)
+
+    rc = check_price_coverage.main(
+        ["--strict-model-discovery", "--now", "2026-06-14T00:00:00Z"]
     )
 
-    assert (
-        check_price_coverage.main(["--strict-model-discovery", "--now", "2026-06-14T00:00:00Z"])
-        == 0
-    )
+    assert rc == 0


### PR DESCRIPTION
Two tests failed CI without a code change: `tests/test_axiom_nonblocking.py::test_emitting_does_not_wait_for_the_shipper` (a wall-clock budget: emit measured 0.478 s against a 50 ms limit on a loaded post-cutover runner, on #1048) and `tests/test_check_price_coverage.py::test_strict_model_discovery_does_not_fail_provider_api_visibility_warning` (it faked only the model-discovery audit and let the real price audit call live scrapers; it failed one run in three locally on main). Same class as the two made deterministic in #1037.

- **Axiom emit is proven off-thread, not timed.** The shipper double now blocks on events the test controls: it signals `started` when invoked and waits on `release`. Emit runs on a helper thread; the test asserts emit returned while the shipper is still blocked (`release` unset, `finished` unset), that shipping ran on the listener's worker thread rather than the test or emitting thread, and only then releases the shipper and joins both threads with bounded timeouts, asserting neither leaked. Delivery is still asserted after release. No production seam was needed: `build_axiom_pipeline` already accepts the handler.
- **Price coverage fakes `_run_audit`** the way its sibling tests do, keeping the assertion that a provider-API visibility warning does not fail strict model discovery.

Reviewed by Fable on an isolated snapshot: the axiom file passes five consecutive runs, the price-coverage file passes, ruff and mypy are clean, the visibility-warning test no longer references the network path, and reintroducing synchronous shipping in production (`enqueue` joining the queue after `put_nowait`) turns the new test red rather than hanging it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
