### PR TITLE
Link the other clouds' status pages from the status page

### DIFF
--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -14,7 +14,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qsl, urlencode
+from urllib.parse import parse_qsl, urlencode, urlparse
 
 import httpx
 from fastapi import BackgroundTasks, FastAPI, HTTPException, Query, Request
@@ -170,7 +170,7 @@ from trusted_router.storage_models import (
     iso_now,
     utcnow,
 )
-from trusted_router.synthetic.fleet import fleet_snapshot
+from trusted_router.synthetic.fleet import fleet_peers, fleet_snapshot
 from trusted_router.synthetic.leaderboard import aggregate_leaderboard
 from trusted_router.synthetic.status import history_payload, status_snapshot
 from trusted_router.synthetic.video_leaderboard import aggregate_video_leaderboard
@@ -3024,6 +3024,38 @@ def _dates_covering_recent_hours(*, hours: int) -> list[str]:
     return dates
 
 
+_CLOUD_LABELS = {"gcp": "Google Cloud", "aws": "AWS", "azure": "Azure"}
+
+
+def _peer_status_pages(settings: Settings, *, hostname: str) -> list[dict[str, Any]]:
+    """The other clouds' independently computed status pages.
+
+    Every deployment builds this page from its OWN probes and its own store —
+    the documents differ in components and in freshness, they are not mirrors.
+    That is exactly why the links are worth rendering: when the cloud serving
+    this page is the thing that is broken, the page a reader needs is served
+    from somewhere else, and a reader who cannot reach this origin has no way
+    to discover that another origin exists. Absolute cross-origin URLs for the
+    same reason.
+
+    Peers come from ``synthetic_fleet_peers``, the same list the peer_monitor
+    probes already watch, so a cloud added to the fleet appears here with no
+    second edit.
+    """
+    pages: list[dict[str, Any]] = []
+    for name, base_url in fleet_peers(settings):
+        peer_hostname = (urlparse(base_url).hostname or "").casefold()
+        pages.append(
+            {
+                "name": name,
+                "label": _CLOUD_LABELS.get(name, name.upper()),
+                "url": f"{base_url.rstrip('/')}/status",
+                "current": bool(peer_hostname) and peer_hostname == hostname,
+            }
+        )
+    return pages
+
+
 def _status_page_html(settings: Settings, *, host: str) -> str:
     hostname = host.split(":", 1)[0].lower()
     domain = control_domain_for_hostname(settings, hostname)
@@ -3073,4 +3105,5 @@ def _status_page_html(settings: Settings, *, host: str) -> str:
         public_client_observed_enabled=settings.public_client_observed_enabled,
         provider_health=provider_health,
         provider_health_window=leaderboard.get("window_label"),
+        peer_status_pages=_peer_status_pages(settings, hostname=hostname),
     )

--- a/src/trusted_router/static/dashboard.css
+++ b/src/trusted_router/static/dashboard.css
@@ -543,6 +543,9 @@ input, select { width:100%; border:1px solid var(--line); border-radius:7px; pad
 .event-row p { margin:0; color:var(--muted); font-size:12px; line-height:1.45; overflow-wrap:anywhere; }
 .status-empty { margin:0; }
 .status-actions { display:flex; gap:10px; flex-wrap:wrap; }
+.status-peers { display:grid; gap:10px; margin-top:14px; }
+.status-peers .status-note { margin:0; }
+.status-peer-current { color:var(--muted); cursor:default; opacity:.75; }
 .status-history-page .status-section { overflow:hidden; }
 .status-section-subhead { border-top:1px solid var(--line2); }
 .status-history-summary { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:12px; padding:0 18px 18px; }

--- a/src/trusted_router/templates/public/status.html
+++ b/src/trusted_router/templates/public/status.html
@@ -370,5 +370,26 @@
     <a class="btn" href="/status/history?window=48h">View 48h rollup</a>
     <a class="btn" href="/status/history?window=monthly">View monthly rollups</a>
   </div>
+
+  {% if peer_status_pages %}
+  <div class="status-peers">
+    <p class="status-note">
+      Every cloud runs its own probes and builds this page from its own samples, so these
+      are independent reports rather than copies of one. If the cloud serving this page is
+      the thing that is down, the others keep answering. Every cloud also watches every
+      other cloud's page each pass and flags one that stops reporting.
+    </p>
+    <div class="status-actions">
+      <a class="btn" href="/fleet">View fleet health</a>
+      {% for peer in peer_status_pages %}
+      {% if peer.current %}
+      <span class="btn status-peer-current" aria-current="page">{{ peer.label }} &middot; this page</span>
+      {% else %}
+      <a class="btn" href="{{ peer.url }}" rel="noopener">{{ peer.label }} status</a>
+      {% endif %}
+      {% endfor %}
+    </div>
+  </div>
+  {% endif %}
 </section>
 {% endblock %}

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -724,6 +724,55 @@ def test_status_subdomain_root_renders_status_page(client: TestClient) -> None:
     assert "Provider Effective" not in page.text
 
 
+def test_status_page_links_the_other_clouds_status_pages(client: TestClient) -> None:
+    """The page must offer a way off this origin.
+
+    Each cloud computes its own status document; the links exist so a reader
+    whose cloud is the broken one can reach a report that is still being
+    produced. A reader who cannot load this origin cannot discover the others
+    unless this page names them, so the URLs are absolute and cross-origin.
+    """
+    page = client.get("/status")
+
+    assert page.status_code == 200
+    assert "https://aws.trustedrouter.com/status" in page.text
+    assert "https://azure.trustedrouter.com/status" in page.text
+    assert "AWS status" in page.text
+    assert "Azure status" in page.text
+    # The cross-cloud watch already runs every pass; the page has to surface it.
+    assert 'href="/fleet"' in page.text
+
+
+def test_status_page_does_not_link_the_cloud_serving_it(client: TestClient) -> None:
+    """Self-link would be a dead end during the outage the links are for."""
+    page = client.get("/status", headers={"host": "trustedrouter.com"})
+
+    assert page.status_code == 200
+    # Rendered as a marker, not a link, when the peer IS this origin.
+    assert "Google Cloud &middot; this page" in page.text or "Google Cloud · this page" in page.text
+    assert '<a class="btn" href="https://trustedrouter.com/status"' not in page.text
+    # ...while the other two stay reachable.
+    assert 'href="https://aws.trustedrouter.com/status"' in page.text
+
+
+def test_status_page_peer_links_follow_the_fleet_setting() -> None:
+    """One list drives peer probes and peer links, so a new cloud needs one edit."""
+    app = create_app(
+        Settings(
+            environment="test",
+            synthetic_fleet_peers="gcp=https://trustedrouter.com,oracle=https://oci.trustedrouter.com",
+        )
+    )
+    local_client = TestClient(app)
+
+    page = local_client.get("/status")
+
+    assert page.status_code == 200
+    assert "https://oci.trustedrouter.com/status" in page.text
+    assert "ORACLE status" in page.text
+    assert "aws.trustedrouter.com" not in page.text
+
+
 def test_chat_monitor_model_requires_configured_monitor_key() -> None:
     monitor_key = "sk-tr-monitor-test"  # noqa: S105 - test key.
     app = create_app(


### PR DESCRIPTION
All three deployments already compute the status page independently. Verified live on 2026-09-03: the GCP, AWS and Azure documents carry different components and independent sample timestamps, so they are three reports, not one mirrored three ways.

| Origin | Components | Sample age |
|---|---|---|
| trustedrouter.com | canonical API, four GCP regional APIs, attestation, image generation | 42 s |
| aws.trustedrouter.com | canonical API, both EU gateways, attestation, model inference | 136 s |
| azure.trustedrouter.com | canonical API, Dubai and Sydney gateways, attestation, model inference | 60 s |

Each one also runs a `peer_monitor` probe against the other two every pass and marks a peer down when it is unreachable, non-200, unparseable, or reporting its own monitor as stale.

None of that was reachable from the status page. A reader whose cloud is the broken one had no way to discover that two other origins were still producing a correct report, and an origin cannot tell you about its alternatives once you can no longer load it. The page now names them, as absolute cross-origin links, and links the fleet view that already renders the cross-cloud watch.

The peer list comes from `synthetic_fleet_peers`, the same setting the probes use, so a cloud added to the fleet appears here with no second edit. The peer that is this origin renders as a marker rather than a link, because a self-link is a dead end during exactly the outage these links exist for.

Three tests, each mutation-checked against a stubbed-empty peer list. `status.json` is untouched; this is HTML-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)