### PR TITLE
Stage D: idempotent replays honor the kill switch; reason stage_d_disabled

### DIFF
--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -1133,6 +1133,11 @@ def _authorize_gateway_sync_impl(
             endpoint_candidates=existing_candidates,
             idempotent_replay=True,
             custom_model=custom_model,
+            stage_d_reason_override=(
+                None
+                if settings.stage_d_eligibility_enabled
+                else "stage_d_disabled"
+            ),
         )
 
     _typed_store = typed_billing_store(STORE)
@@ -2346,7 +2351,7 @@ def _stage_d_eligibility_reason(
     # the Stage D cohort, so the enclave never sends a heartbeat and streaming
     # takes the synchronous path exactly as before Stage D.
     if not eligibility_enabled:
-        return "settlement_backend"
+        return "stage_d_disabled"
     if stream is not True:
         return "not_streaming"
     if route_type not in {"chat.completions", "responses"}:
@@ -2370,8 +2375,10 @@ def _gateway_stage_d_payload(
     *,
     reason_override: str | None = None,
 ) -> dict[str, Any]:
+    if reason_override is not None and reason_override != "ok":
+        return {"stage_d": {"eligible": False, "reason": reason_override}}
     snapshot = authorization.pricing_snapshot
-    reason = authorization.stage_d_reason or reason_override or "settlement_backend"
+    reason = reason_override or authorization.stage_d_reason or "settlement_backend"
     if snapshot is None:
         return {"stage_d": {"eligible": False, "reason": reason}}
     document = parse_pricing_snapshot(snapshot)

--- a/tests/test_stage_d_authorize.py
+++ b/tests/test_stage_d_authorize.py
@@ -9,6 +9,7 @@ from starlette.requests import Request
 
 from tests.fakes.spanner import make_fake_store
 from trusted_router.catalog import MODEL_ENDPOINTS, MODELS, effective_endpoint
+from trusted_router.catalog_data import Model, ModelEndpoint
 from trusted_router.config import Settings
 from trusted_router.routes.internal import gateway
 from trusted_router.routes.internal.gateway import (
@@ -26,7 +27,7 @@ from trusted_router.types import UsageType
 FIXTURES = Path(__file__).parent / "fixtures" / "stage_d"
 
 
-def _credit_candidate() -> tuple[object, object]:
+def _credit_candidate() -> tuple[Model, ModelEndpoint]:
     endpoint = effective_endpoint(
         next(endpoint for endpoint in MODEL_ENDPOINTS.values() if endpoint.usage_type == "Credits")
     )
@@ -43,6 +44,7 @@ def _credit_candidate() -> tuple[object, object]:
         ({"standard_endpoint_pricing": False}, "pricing_kind"),
         ({"service_tier": "priority"}, "service_tier"),
         ({"settlement_backend": False}, "settlement_backend"),
+        ({"eligibility_enabled": False}, "stage_d_disabled"),
     ],
 )
 def test_stage_d_eligibility_has_each_closed_reason(
@@ -62,7 +64,8 @@ def test_stage_d_eligibility_has_each_closed_reason(
         "settlement_backend": True,
         **overrides,
     }
-    assert _stage_d_eligibility_reason(eligibility_enabled=True, **kwargs) == reason  # type: ignore[arg-type]
+    eligibility_enabled = bool(kwargs.pop("eligibility_enabled", True))
+    assert _stage_d_eligibility_reason(eligibility_enabled=eligibility_enabled, **kwargs) == reason  # type: ignore[arg-type]
 
 
 def test_typed_authorize_inserts_cohort_sequence_zero_and_snapshot() -> None:
@@ -266,4 +269,60 @@ def test_stage_d_eligibility_kill_switch_declares_nothing_eligible() -> None:
         service_tier=None,
         settlement_backend=True,
     )
-    assert reason == "settlement_backend"
+    assert reason == "stage_d_disabled"
+
+
+def test_stage_d_replay_applies_current_kill_switch() -> None:
+    store, db, _table = make_fake_store(request_record_write_mode="typed")
+    workspace = Workspace(id="stage-d-replay", name="Stage D replay", owner_user_id="user-1")
+    store._write_entity("workspace", workspace.id, workspace)
+    store._write_entity("credit", workspace.id, CreditAccount(workspace_id=workspace.id))
+    db.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(workspace.id, 0)] = {
+        "workspace_id": workspace.id,
+        "shard": 0,
+        "total_credits": 1_000_000,
+        "total_usage": 0,
+        "reserved": 0,
+        "source_updated_at": None,
+        "updated_at": None,
+    }
+    _raw, key = store.api_keys.create(
+        workspace_id=workspace.id,
+        name="stage-d-replay",
+        creator_user_id=workspace.owner_user_id,
+        limit_microdollars=1_000_000,
+    )
+    configure_store(store)
+    body = GatewayAuthorizeRequest(
+        api_key_hash=key.hash,
+        idempotency_key="stage-d-replay",
+        model="anthropic/claude-haiku-4.5",
+        estimated_input_tokens=100,
+        max_output_tokens=100,
+        stream=True,
+        route_type="chat.completions",
+    )
+    request = Request({"type": "http", "method": "POST", "path": "/", "headers": []})
+    enabled = Settings(environment="test", stage_d_eligibility_enabled=True)
+
+    first = gateway._authorize_gateway_sync(request, body, enabled)["data"]
+    assert first["stage_d"] == {"eligible": True, "reason": "ok"}
+
+    disabled_replay = gateway._authorize_gateway_sync(
+        request,
+        body,
+        Settings(environment="test", stage_d_eligibility_enabled=False),
+    )["data"]
+    assert disabled_replay["idempotent_replay"] is True
+    assert disabled_replay["stage_d"] == {
+        "eligible": False,
+        "reason": "stage_d_disabled",
+    }
+    assert "candidate_prices" not in disabled_replay
+    assert "cap_micro" not in disabled_replay
+
+    enabled_replay = gateway._authorize_gateway_sync(request, body, enabled)["data"]
+    assert enabled_replay["idempotent_replay"] is True
+    assert enabled_replay["stage_d"] == first["stage_d"]
+    assert enabled_replay["candidate_prices"] == first["candidate_prices"]
+    assert enabled_replay["cap_micro"] == first["cap_micro"]


### PR DESCRIPTION
Follow-up to #1059 (the Stage D kill switch). Two gaps it left:

- **Idempotent replays ignored the switch.** A replay returned the stored Stage D verdict, so an authorization minted while eligibility was on would tell the enclave to heartbeat even after the switch was flipped off. The replay path now passes an explicit `stage_d_disabled` override whenever `TR_STAGE_D_ELIGIBILITY_ENABLED` is false, and `_gateway_stage_d_payload` returns `{eligible: false, reason}` with no `candidate_prices` or `cap_micro` for any non-`ok` override. With the switch on, replays still return the stored verdict byte for byte.
- **The kill-switch reason was overloaded.** `settlement_backend` now means only what it says; the switch reports `stage_d_disabled`.

Tests: `test_stage_d_replay_applies_current_kill_switch` (switch off → replay disabled without prices; switch on → replay equals the first response) plus the closed-reason update.

Reviewed by Fable on an isolated snapshot: the Stage D authorize, heartbeat, pricing, golden and Spanner-operations suites pass; ruff and mypy are clean. Mutations: dropping the replay override, removing the early return in the payload builder, and reverting the reason name each turn the new test red. Swapping the precedence of the stored reason and the override on the fallback line is an equivalent mutant (the early return handles every non-`ok` override before that line), not a coverage gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
