### PR TITLE
Fix custom model deletion and white-label payout copy

### DIFF
--- a/docs/custom-models.md
+++ b/docs/custom-models.md
@@ -49,8 +49,8 @@ curl https://trustedrouter.com/v1/custom-models \
   -H "Authorization: Bearer $TRUSTEDROUTER_MANAGEMENT_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "name": "Contract reviewer",
-    "slug": "contract-reviewer",
+    "name": "Custom model name",
+    "slug": "custom-model-name",
     "base_model_id": "anthropic/claude-sonnet-4.6",
     "hidden_prompt": "Review the contract and cite each material clause.",
     "markup_basis_points": 1500,

--- a/docs/custom-models.md
+++ b/docs/custom-models.md
@@ -33,14 +33,14 @@ authorization-scoped idempotency event.
 Custom-model and registered-app markup enter the same creator earnings wallet.
 Creators may transfer any available amount into a TrustedRouter workspace. At
 $100 or more, an identity-verified creator with a verified email may request a
-USD cash-out through Routable. Routable's hosted onboarding collects bank and
-tax details; TrustedRouter stores only opaque Routable identifiers, payout
-status, and the exact integer-microdollar ledger movement.
+USD cash-out. A secure hosted payout flow collects bank and tax details;
+TrustedRouter stores only opaque payout identifiers, payout status, and the
+exact integer-microdollar ledger movement.
 
 Cash-out requests require an idempotency key. TrustedRouter reserves earnings
-before contacting Routable, reconciles ambiguous retries by external ID, and
-keeps restartable failure states reserved. A final Routable cancellation
-releases the reservation exactly once.
+before contacting the payout processor, reconciles ambiguous retries by
+external ID, and keeps restartable failure states reserved. A final processor
+cancellation releases the reservation exactly once.
 
 ## Create
 

--- a/docs/sign-in-with-trustedrouter.md
+++ b/docs/sign-in-with-trustedrouter.md
@@ -62,9 +62,9 @@ the creator earnings wallet; TrustedRouter keeps 30%.
 
 Owners can transfer any available earnings into a TrustedRouter workspace. At
 $100 or more, an owner with full identity verification and a verified email
-can request a USD cash-out through Routable. Routable's hosted onboarding
-collects bank and tax details. TrustedRouter stores only opaque recipient and
-payable identifiers, status, and exact integer-microdollar ledger movements.
+can request a USD cash-out. A secure hosted payout flow collects bank and tax
+details. TrustedRouter stores only opaque recipient and payable identifiers,
+status, and exact integer-microdollar ledger movements.
 
 ### Legacy migration
 

--- a/src/trusted_router/routes/console/custom_models.py
+++ b/src/trusted_router/routes/console/custom_models.py
@@ -72,6 +72,15 @@ def register(app: FastAPI) -> None:
             raise
         return RedirectResponse(url="/console/custom-models?saved=created", status_code=303)
 
+    # Register the action route before the catch-all model path below. Custom
+    # model IDs contain slashes, so the path converter would otherwise consume
+    # the trailing /delete segment and dispatch this POST to the edit handler.
+    @app.post("/console/custom-models/{model_id:path}/delete")
+    def console_delete_custom_model(ctx: ConsoleDep, model_id: str) -> Response:
+        model = _require_owner_model(model_id, ctx.user.id)
+        STORE.delete_custom_model(model.id, owner_user_id=ctx.user.id)
+        return RedirectResponse(url="/console/custom-models?saved=deleted", status_code=303)
+
     @app.post("/console/custom-models/{model_id:path}")
     def console_update_custom_model(
         ctx: ConsoleDep,
@@ -109,13 +118,6 @@ def register(app: FastAPI) -> None:
                 return _custom_model_redirect("error=slug_taken")
             raise
         return RedirectResponse(url="/console/custom-models?saved=updated", status_code=303)
-
-    @app.post("/console/custom-models/{model_id:path}/delete")
-    def console_delete_custom_model(ctx: ConsoleDep, model_id: str) -> Response:
-        model = _require_owner_model(model_id, ctx.user.id)
-        STORE.delete_custom_model(model.id, owner_user_id=ctx.user.id)
-        return RedirectResponse(url="/console/custom-models?saved=deleted", status_code=303)
-
 
 def _render_page(ctx: ConsoleDep, settings: SettingsDep, *, request: Request) -> str:
     models = [_model_view(model) for model in STORE.list_custom_models_for_user(ctx.user.id)]

--- a/src/trusted_router/routes/payouts.py
+++ b/src/trusted_router/routes/payouts.py
@@ -201,7 +201,7 @@ def register_payout_routes(router: APIRouter) -> None:
         if profile.company_status != "accepted" or not profile.payment_method_id:
             raise api_error(
                 409,
-                "Complete Routable payout onboarding before requesting a cash-out",
+                "Complete payout onboarding before requesting a cash-out",
                 ErrorType.CONFLICT,
             )
         payout_id = new_payout_id()
@@ -364,7 +364,7 @@ async def _refresh_profile(
     if existing is None:
         raise api_error(
             409,
-            "Start Routable payout onboarding before requesting a cash-out",
+            "Start payout onboarding before requesting a cash-out",
             ErrorType.CONFLICT,
         )
     company = await client.retrieve_company(existing.routable_company_id)

--- a/src/trusted_router/templates/console/custom_models.html
+++ b/src/trusted_router/templates/console/custom_models.html
@@ -29,12 +29,12 @@
     <form class="form" method="post" action="/console/custom-models">
       <fieldset class="form-gate" {% if not verification.met %}disabled{% endif %}>
       <label>Name
-        <input name="name" required maxlength="120" placeholder="Legal reviewer">
+        <input name="name" required maxlength="120" placeholder="Custom model name">
       </label>
       <label>Slug
         <span class="custom-model-slug-input">
           <span>{{ model_prefix }}</span>
-          <input name="slug" maxlength="64" pattern="[a-z0-9][a-z0-9-]{1,62}[a-z0-9]" placeholder="legal-reviewer">
+          <input name="slug" maxlength="64" pattern="[a-z0-9][a-z0-9-]{1,62}[a-z0-9]" placeholder="custom-model-name">
         </span>
       </label>
       <label>Base model

--- a/src/trusted_router/templates/console/earnings.html
+++ b/src/trusted_router/templates/console/earnings.html
@@ -6,7 +6,7 @@
 <section class="panel">
   <div class="panel-head"><h2>Your earnings</h2><span class="pill">70% creator share</span></div>
   <div class="panel-body">
-    <p class="earnings-copy">You receive 70% of custom model and registered app markup. Transfer earnings into a TrustedRouter workspace, or cash out at least $100 in USD through Routable.</p>
+    <p class="earnings-copy">You receive 70% of custom model and registered app markup. Transfer earnings into a TrustedRouter workspace, or cash out at least $100 in USD.</p>
     <div class="metrics">
       <div class="metric"><div class="label">Earned</div><div class="value earnings-money">{{ summary.total_earned_display }}</div><div class="sub">lifetime</div></div>
       <div class="metric"><div class="label">Transferred</div><div class="value earnings-money">{{ summary.total_transferred_display }}</div><div class="sub">lifetime</div></div>
@@ -24,9 +24,9 @@
     {% elif not payouts.identity_verified %}
       <p>Complete <a href="/console/account/verification">identity verification</a> before enabling a monetized app or requesting a USD cash-out.</p>
     {% elif not payouts.email_verified %}
-      <p class="empty">Attach and verify an email address before using Routable. Wallet-only accounts can still transfer earnings into TrustedRouter workspaces.</p>
+      <p class="empty">Attach and verify an email address before requesting a USD cash-out. Wallet-only accounts can still transfer earnings into TrustedRouter workspaces.</p>
     {% elif not payouts.profile or payouts.profile.company_status != 'accepted' or not payouts.profile.payment_method_ready %}
-      <p>Routable securely collects your bank and tax details. TrustedRouter stores only opaque account identifiers and payout status.</p>
+      <p>A secure hosted payout flow collects your bank and tax details. TrustedRouter stores only opaque account identifiers and payout status.</p>
       <form class="form" data-routable-onboarding-form>
         <input type="hidden" name="recipient_type" value="personal">
         <input type="hidden" name="country_code" value="US">
@@ -37,7 +37,7 @@
         <button class="btn primary" type="submit">Set up USD cash-outs</button>
       </form>
     {% else %}
-      <p>Your Routable payout account is ready. Cash-outs are submitted to Routable for transfer to your saved bank account.</p>
+      <p>Your payout account is ready. Cash-outs transfer to your saved bank account.</p>
       <form class="form" data-routable-cashout-form>
         <label>Amount (USD)
           <input name="amount" type="number" min="100" max="{{ payout_available_decimal }}" step="0.01" placeholder="100.00" required>

--- a/src/trusted_router/templates/public/custom_models_docs.html
+++ b/src/trusted_router/templates/public/custom_models_docs.html
@@ -10,14 +10,14 @@
   -H "Authorization: Bearer $TRUSTEDROUTER_MANAGEMENT_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "name": "Contract reviewer",
-    "slug": "contract-reviewer",
+    "name": "Custom model name",
+    "slug": "custom-model-name",
     "base_model_id": "anthropic/claude-sonnet-4.6",
     "hidden_prompt": "Review the contract and cite each material clause.",
     "markup_basis_points": 1500,
     "enabled": true
   }'</code></pre>
-      <p>For a creator named <span class="mono">ada</span>, this creates <span class="mono">tr-custom-model/ada-contract-reviewer</span>. Use that exact ID in Chat Completions or Responses requests.</p>
+      <p>For a creator named <span class="mono">ada</span>, this creates <span class="mono">tr-custom-model/ada-custom-model-name</span>. Use that exact ID in Chat Completions or Responses requests.</p>
     </div>
   </div>
 
@@ -56,7 +56,7 @@
       <div class="model-table-wrap"><table>
         <thead><tr><th>Product</th><th>Model ID</th><th>Execution</th><th>Creator earnings</th></tr></thead>
         <tbody>
-          <tr><td>Custom model</td><td class="mono">tr-custom-model/ada-reviewer</td><td>TrustedRouter catalog model plus a hidden prompt</td><td>70% of creator markup</td></tr>
+          <tr><td>Custom model</td><td class="mono">tr-custom-model/ada-custom-model-name</td><td>TrustedRouter catalog model plus a hidden prompt</td><td>70% of creator markup</td></tr>
           <tr><td>User-provided model</td><td class="mono">tr-user-model/ada-live</td><td>Your HTTPS model, agent, or human endpoint</td><td>70% of the model charge</td></tr>
         </tbody>
       </table></div>
@@ -68,7 +68,7 @@
     <div class="panel-head"><h2>Update without changing the ID</h2><span class="pill">revision bound</span></div>
     <div class="panel-body">
       <p>You can update the base model, hidden prompt, markup, or enabled state. Each edit increments a revision. Authorization freezes the revision, price, owner, and markup before inference, so an edit during a request cannot change its settlement.</p>
-      <pre><code>curl {{ control_plane_api_base_url }}/custom-models/tr-custom-model/ada-contract-reviewer \
+      <pre><code>curl {{ control_plane_api_base_url }}/custom-models/tr-custom-model/ada-custom-model-name \
   -X PATCH \
   -H "Authorization: Bearer $TRUSTEDROUTER_MANAGEMENT_KEY" \
   -H "Content-Type: application/json" \

--- a/src/trusted_router/templates/public/custom_models_docs.html
+++ b/src/trusted_router/templates/public/custom_models_docs.html
@@ -41,8 +41,8 @@
           <li><span class="mono">markup_basis_points</span> is your percentage above the routed token charge. 100 basis points is 1%.</li>
           <li>The markup applies to model token charges, not hosted tool or media charges.</li>
           <li>70% of collected markup enters your earnings wallet. TrustedRouter keeps 30%.</li>
-          <li>After your available wallet reaches $100, request a USD cash-out through Routable.</li>
-          <li>Routable collects bank and tax details on its hosted flow. TrustedRouter stores only opaque payout identifiers and status.</li>
+          <li>After your available wallet reaches $100, request a USD cash-out.</li>
+          <li>A secure hosted payout flow collects bank and tax details. TrustedRouter stores only opaque payout identifiers and status.</li>
           <li>All accounting uses integer microdollars. Retries cannot pay or charge twice.</li>
         </ul>
         <p>Identity verification and a verified email are required for USD cash-outs. You can move any available amount into a TrustedRouter workspace without waiting for the cash-out minimum.</p>

--- a/src/trusted_router/templates/public/seo_sign_in_with_trustedrouter.html
+++ b/src/trusted_router/templates/public/seo_sign_in_with_trustedrouter.html
@@ -69,7 +69,7 @@ Prompt and output logs: never</code></pre>
     <span class="eyebrow">Optional app earnings</span>
     <h2>Set a clear markup. Earn when your users build.</h2>
     <p>A registered app can add a disclosed percentage to model token costs. The user sees the exact markup before approval. You receive 70% of the collected markup in your earnings wallet.</p>
-    <p>Monetized apps require full identity verification before they can be enabled. Once your available wallet reaches $100, you can request a USD cash-out through Routable. You can also move any amount into a TrustedRouter workspace as credits.</p>
+    <p>Monetized apps require full identity verification before they can be enabled. Once your available wallet reaches $100, you can request a USD cash-out. You can also move any amount into a TrustedRouter workspace as credits.</p>
   </div>
   <div class="copy-terminal">
     <div class="code-head"><span>Creator economics</span><span>Exact ledger</span></div>
@@ -78,7 +78,7 @@ User disclosure         required before consent
 Creator share           70%
 TrustedRouter share      30%
 USD cash-out minimum     $100
-Payout partner           Routable
+Bank and tax details     held by the payout processor
 Identity verification    required for monetization</code></pre>
   </div>
 </section>

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -698,3 +698,11 @@ def test_console_custom_models_and_user_chat_locked_model_smoke() -> None:
     assert chat.status_code == 200
     assert custom.id in chat.text
     assert "tr_user_chat_state_tr_custom_model_alice_console_model" in chat.text
+
+    deleted = client.post(
+        f"/console/custom-models/{custom.id}/delete",
+        follow_redirects=False,
+    )
+    assert deleted.status_code == 303
+    assert deleted.headers["location"] == "/console/custom-models?saved=deleted"
+    assert STORE.get_custom_model(custom.id) is None

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -111,16 +111,16 @@ def test_custom_model_crud_owner_limit_and_public_catalog_redaction(client: Test
 
 
 def test_custom_model_slug_create_duplicate_and_rename(client: TestClient) -> None:
-    created = _create_custom_model(client, slug="legal-reviewer")
-    assert created["id"] == "tr-custom-model/alice-legal-reviewer"
-    assert created["slug"] == "legal-reviewer"
+    created = _create_custom_model(client, slug="custom-model-name")
+    assert created["id"] == "tr-custom-model/alice-custom-model-name"
+    assert created["slug"] == "custom-model-name"
 
     duplicate = client.post(
         "/v1/custom-models",
         headers={"x-trustedrouter-user": "alice@example.com"},
         json={
             "name": "dupe",
-            "slug": "legal-reviewer",
+            "slug": "custom-model-name",
             "base_model_id": "anthropic/claude-sonnet-4.6",
             "hidden_prompt": "x",
         },
@@ -673,6 +673,9 @@ def test_console_custom_models_and_user_chat_locked_model_smoke() -> None:
     assert "Socrates, Prometheus, Zeus" in page.text
     assert "Published" in page.text
     assert "Enabled" not in page.text
+    assert 'placeholder="Custom model name"' in page.text
+    assert 'placeholder="custom-model-name"' in page.text
+    assert "Legal reviewer" not in page.text
 
     created = client.post(
         "/console/custom-models",

--- a/tests/test_public_revenue_pages.py
+++ b/tests/test_public_revenue_pages.py
@@ -174,6 +174,22 @@ def test_signup_grant_amount_is_not_advertised(client: TestClient) -> None:
         assert "ten cents" not in source
 
 
+def test_creator_cashout_copy_is_processor_neutral(client: TestClient) -> None:
+    for path in ("/sign-in-with-trustedrouter", "/docs/custom-models"):
+        response = client.get(path)
+        assert response.status_code == 200, f"{path} returned {response.status_code}"
+        assert "$100" in response.text
+        assert "Routable" not in response.text
+
+    for path in (
+        Path("docs/sign-in-with-trustedrouter.md"),
+        Path("docs/custom-models.md"),
+    ):
+        source = path.read_text(encoding="utf-8")
+        assert "$100" in source
+        assert "Routable" not in source
+
+
 def test_revenue_pages_support_link_checkers(client: TestClient) -> None:
     paths = [
         "/compare/openrouter",

--- a/tests/test_routable_payouts.py
+++ b/tests/test_routable_payouts.py
@@ -944,7 +944,7 @@ def test_custom_model_public_docs_cover_namespaces_and_creator_cashouts() -> Non
     client = _client(Settings(environment="test"))
     page = client.get("/docs/custom-models")
     assert page.status_code == 200
-    assert "tr-custom-model/ada-contract-reviewer" in page.text
+    assert "tr-custom-model/ada-custom-model-name" in page.text
     assert "70% of collected markup" in page.text
     assert "$100" in page.text
     assert "Routable" not in page.text

--- a/tests/test_routable_payouts.py
+++ b/tests/test_routable_payouts.py
@@ -947,7 +947,8 @@ def test_custom_model_public_docs_cover_namespaces_and_creator_cashouts() -> Non
     assert "tr-custom-model/ada-contract-reviewer" in page.text
     assert "70% of collected markup" in page.text
     assert "$100" in page.text
-    assert "Routable" in page.text
+    assert "Routable" not in page.text
+    assert "secure hosted payout flow" in page.text
     assert "https://trustedrouter.com/v1/custom-models" in page.text
     assert "/v1/v1/" not in page.text
 

--- a/tests/test_user_models.py
+++ b/tests/test_user_models.py
@@ -1205,6 +1205,8 @@ def test_earnings_console_renders_and_transfers_with_idempotent_flash(
     page = client.get("/console/earnings")
     assert page.status_code == 200
     assert "You receive 70% of custom model and registered app markup" in page.text
+    assert "cash out at least $100 in USD." in page.text
+    assert "Routable" not in page.text
     assert "Earning model" in page.text
     assert 'href="/console/earnings" class="sidebar-link active"' in page.text
 


### PR DESCRIPTION
Summary:
- Register the custom-model delete route before the slash-containing catch-all edit route.
- Add a browser-route regression proving delete redirects and removes the model.
- Remove Routable branding from customer-facing payout copy and API errors.
- Keep the underlying payout integration and internal operational documentation unchanged.

Verification:
- Regression reproduced before fix: custom-model delete returned HTTP 400.
- Focused and related tests: 135 passed.
- Ruff passed.
- Mypy passed across 341 source files.