### PR TITLE
tests: deploy-harness stub records each call atomically (fixes red main in the post-cutover shard)

### DIFF
--- a/tests/test_deploy_script_execution.py
+++ b/tests/test_deploy_script_execution.py
@@ -229,13 +229,17 @@ if "--baseline-output" in sys.argv:
         ("scripts/deploy/regional_quota_reconciler.sh", "regional_quota_reconciler.sh"),
         ("scripts/deploy/spend_lease_reconciler.sh", "spend_lease_reconciler.sh"),
     ):
+        # The reconcilers launch concurrently, so append each invocation with
+        # one printf; separate name/newline writes can merge into one record.
         isolated.write_script(
             relative,
             "#!/usr/bin/env bash\n"
-            "{ printf '%s' '"
+            "record='"
             + command_name
-            + "'; for argument in \"$@\"; do printf '\\t%s' \"$argument\"; done; "
-            "printf '\\n'; } >>\"$HARNESS_ARGV_LOG\"\n",
+            + "'\n"
+            "for argument in \"$@\"; do "
+            "printf -v record '%s\\t%s' \"$record\" \"$argument\"; done\n"
+            "printf '%s\\n' \"$record\" >>\"$HARNESS_ARGV_LOG\"\n",
         )
 
     env = {


### PR DESCRIPTION
Main is red on one test in the post-cutover shard after #1063 merged: `tests/test_deploy_script_execution.py::test_secondary_reconcilers_launch_when_every_region_is_held` asserted that no `regional_quota_reconciler.sh` call was recorded.

Root cause: a race in the test harness, not in the ramp. `ramp_secondaries.sh` launches both reconcilers concurrently, and the harness's recording stubs wrote the command name and the trailing newline as separate writes to one shared log, so two launches could interleave into `regional_quota_reconciler.shspend_lease_reconciler.sh` and neither name matched. The future-clock shard only changed the scheduling enough to expose it.

Fix: each stub builds its whole record and appends it with a single `printf`. Sol reproduced the interleaving on the fifth iteration before the fix and ran 200 clean iterations after; Fable ran the test 15 times under each clock on an isolated snapshot: fixed 0/15 failures under both clocks; the unfixed harness on main fails 15/15 under the post-cutover clock. Test-only change; the ramp script and what the test proves are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
