### PR TITLE
trust tiers, slice 1b′: Stripe and x402 adverse facts, principal recovery, pause causes, the inbox (inert)

### DIFF
--- a/scripts/deploy/migrate_typed_counters.sh
+++ b/scripts/deploy/migrate_typed_counters.sh
@@ -266,6 +266,15 @@ else
     ON tr_trust_event (provider, original_payment_ref, kind)"
 fi
 
+if table_exists tr_trust_inbox; then log "tr_trust_inbox exists, skip"; else
+  apply_ddl "CREATE TABLE tr_trust_inbox (
+    provider STRING(16) NOT NULL,
+    adverse_ref STRING(255) NOT NULL,
+    payload STRING(MAX) NOT NULL,
+    received_at TIMESTAMP NOT NULL,
+  ) PRIMARY KEY (provider, adverse_ref)"
+fi
+
 # Historical trust-column backfill statement. It is intentionally a separate,
 # operator-run artifact rather than an automatic deploy-time DML rewrite.
 log "historical trust-column backfill: scripts/deploy/backfill_credit_balance_trust.sql"

--- a/scripts/recompute_trust_tiers.py
+++ b/scripts/recompute_trust_tiers.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from typing import Any, Protocol, cast
 
 from trusted_router.config import get_settings
+from trusted_router.services.trust_recovery import alert_stale_trust_inbox
 from trusted_router.storage import create_store
 
 log = logging.getLogger(__name__)
@@ -29,6 +30,8 @@ class _TrustTierStore(Protocol):
 
 def run(store: _TrustTierStore, settings: Any, *, now: datetime | None = None) -> int:
     computed_at = now or datetime.now(UTC)
+    if hasattr(store, "list_stale_trust_inbox"):
+        alert_stale_trust_inbox(store, now=computed_at)
     workspace_ids = store.list_trust_tier_workspace_ids()
     for workspace_id in workspace_ids:
         tier = store.recompute_workspace_trust_tier(

--- a/src/trusted_router/errors.py
+++ b/src/trusted_router/errors.py
@@ -5,6 +5,8 @@ from typing import Any
 from fastapi import HTTPException
 from fastapi.responses import JSONResponse
 
+from trusted_router.storage_models import workspace_billing_paused
+
 PROVIDER_ERROR_TYPES = frozenset(
     {
         "provider_auth_error",
@@ -61,7 +63,7 @@ def assert_workspace_billing_active(workspace: Any) -> None:
     code exchange, chat-browser key issuance) — so a paused workspace truly drains
     to zero holds before a flip. Settle is intentionally NOT guarded (it routes by
     reservation origin and must still finalize in-flight work)."""
-    if workspace is not None and getattr(workspace, "billing_paused", False):
+    if workspace_billing_paused(workspace):
         from trusted_router.types import ErrorType
 
         raise api_error(

--- a/src/trusted_router/routes/internal/federation.py
+++ b/src/trusted_router/routes/internal/federation.py
@@ -51,6 +51,7 @@ from trusted_router.services.credit_transfer import (
     recover_credit_transfers,
 )
 from trusted_router.storage import STORE
+from trusted_router.storage_models import workspace_billing_paused
 from trusted_router.types import ErrorType
 
 
@@ -195,9 +196,7 @@ def register(router: APIRouter) -> None:
                 getattr(api_key, "include_byok_in_limit", True)
             ),
             "budget_alert_only": bool(getattr(api_key, "budget_alert_only", False)),
-            "workspace_billing_paused": bool(
-                getattr(workspace, "billing_paused", False)
-            ),
+            "workspace_billing_paused": workspace_billing_paused(workspace),
             # Lets the peer detect a changed record without diffing every
             # field, and lets a future revocation feed say "anything older
             # than X is stale".

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -229,6 +229,7 @@ from trusted_router.storage_models import (
     UserModelPayout,
     UserProvidedModel,
     iso_now,
+    workspace_billing_paused,
 )
 from trusted_router.synthetic.fleet import record_heartbeat
 from trusted_router.synthetic.funding import ensure_monitor_funding, monitor_lookup_hash
@@ -870,7 +871,7 @@ def _authorize_gateway_sync_impl(
     workspace = STORE.get_workspace(api_key.workspace_id)
     if workspace is None:
         raise api_error(403, "Workspace is unavailable", ErrorType.FORBIDDEN)
-    if workspace.billing_paused:
+    if workspace_billing_paused(workspace):
         # Keep tenant attribution in the rendered message because Cloud Run's
         # stderr collector does not preserve arbitrary LogRecord extras. This
         # is billing metadata only: never include the raw key, body, or content.

--- a/src/trusted_router/routes/internal/webhook.py
+++ b/src/trusted_router/routes/internal/webhook.py
@@ -15,6 +15,7 @@ here, not in __init__.py.
 
 from __future__ import annotations
 
+import json
 import logging
 import uuid
 from datetime import UTC, datetime
@@ -33,7 +34,7 @@ from trusted_router.money import MICRODOLLARS_PER_CENT
 from trusted_router.routes.helpers import json_body
 from trusted_router.services.x402_billing import X402_PAYMENT_METHOD, credit_x402_payment_intent
 from trusted_router.storage import STORE
-from trusted_router.storage_models import CreditProvenance
+from trusted_router.storage_models import AdverseTrustEvent, CreditProvenance
 from trusted_router.types import ErrorType
 
 log = logging.getLogger(__name__)
@@ -92,6 +93,25 @@ def register(router: APIRouter) -> None:
             )
         event_id = str(event.get("id") or uuid.uuid4())
         event_type = event.get("type")
+
+        adverse_events = _stripe_adverse_events(event, event_id=event_id)
+        if adverse_events:
+            results = []
+            for adverse in adverse_events:
+                adverse_result = STORE.record_adverse_trust_event(adverse)
+                results.append(
+                    {
+                        "adverse_ref": adverse.adverse_ref,
+                        "provider": adverse_result.provider or adverse.provider,
+                        "kind": adverse.kind,
+                        "status": adverse.lifecycle_status,
+                        "outcome": adverse_result.outcome,
+                        "workspace_id": adverse_result.workspace_id,
+                        "recovery_target": adverse_result.recovery_target,
+                        "unrecovered_micro": adverse_result.unrecovered_micro,
+                    }
+                )
+            return {"data": {"event_id": event_id, "adverse": results}}
 
         if event_type in {
             "checkout.session.completed",
@@ -355,7 +375,11 @@ def register(router: APIRouter) -> None:
                 STORE.record_auto_refill_outcome(workspace_id, status=f"failed:{code}")
                 return {"data": {"event_id": event_id, "auto_refill_failed": True, "code": code}}
 
-        if event_type in {"charge.refunded", "charge.refund.updated"}:
+        # A charge.refunded delivery without any refund objects cannot provide
+        # the per-refund dedup key required for order-independent partials.
+        # Preserve the existing visible fallback instead of inventing one from
+        # the charge id; canonical Stripe deliveries are handled above.
+        if event_type == "charge.refunded":
             obj = event.get("data", {}).get("object", {})
             metadata = obj.get("metadata") or {}
             if metadata.get("payment_method") == X402_PAYMENT_METHOD:
@@ -364,7 +388,6 @@ def register(router: APIRouter) -> None:
                     extra={
                         "event_id": event_id,
                         "payment_intent_id": obj.get("payment_intent"),
-                        "refund_id": obj.get("id"),
                     },
                 )
                 return {
@@ -377,6 +400,138 @@ def register(router: APIRouter) -> None:
                 }
 
         return {"data": {"ignored": True, "event_id": event_id}}
+
+
+def _object_id(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        return str(value.get("id") or "")
+    return ""
+
+
+def _stripe_adverse_events(
+    event: dict[str, Any], *, event_id: str
+) -> tuple[AdverseTrustEvent, ...]:
+    event_type = str(event.get("type") or "")
+    obj = event.get("data", {}).get("object", {})
+    if not isinstance(obj, dict):
+        return ()
+    created = int(event.get("created") or obj.get("created") or 0)
+    occurred_at = datetime.fromtimestamp(created, tz=UTC)
+    watermark = f"{created:020d}:{event_id}"
+    raw_payload = json.dumps(event, separators=(",", ":"), sort_keys=True, default=str)
+
+    refund_objects: list[dict[str, Any]] = []
+    if event_type == "charge.refunded":
+        refunds = obj.get("refunds") or {}
+        data = refunds.get("data") if isinstance(refunds, dict) else None
+        if isinstance(data, list):
+            refund_objects = [row for row in data if isinstance(row, dict)]
+    elif event_type in {
+        "charge.refund.updated",
+        "refund.created",
+        "refund.updated",
+        "refund.failed",
+    }:
+        refund_objects = [obj]
+    if refund_objects:
+        parsed: list[AdverseTrustEvent] = []
+        for refund in refund_objects:
+            adverse_ref = str(refund.get("id") or "")
+            payment_intent = _object_id(
+                refund.get("payment_intent") or obj.get("payment_intent")
+            )
+            if not adverse_ref or not payment_intent:
+                continue
+            metadata = refund.get("metadata") or obj.get("metadata") or {}
+            provider = (
+                "x402"
+                if isinstance(metadata, dict)
+                and metadata.get("payment_method") == X402_PAYMENT_METHOD
+                else "stripe"
+            )
+            raw_status = str(refund.get("status") or "succeeded").lower()
+            status = {
+                "pending": "pending",
+                "requires_action": "pending",
+                "succeeded": "succeeded",
+                "failed": "failed",
+                "canceled": "failed",
+                "cancelled": "failed",
+                "reversed": "reversed",
+            }.get(raw_status, "pending")
+            parsed.append(
+                AdverseTrustEvent(
+                    event_id=f"{event_id}:{adverse_ref}",
+                    provider=provider,
+                    kind="refund",
+                    adverse_ref=adverse_ref,
+                    original_payment_ref=payment_intent,
+                    amount_micro=int(refund.get("amount") or 0)
+                    * MICRODOLLARS_PER_CENT,
+                    provider_subtype=event_type,
+                    lifecycle_status=status,
+                    occurred_at=occurred_at,
+                    provider_ordering_watermark=watermark,
+                    payload=raw_payload,
+                )
+            )
+        return tuple(parsed)
+
+    if event_type in {
+        "charge.dispute.created",
+        "charge.dispute.updated",
+        "charge.dispute.closed",
+        "charge.dispute.funds_withdrawn",
+        "charge.dispute.funds_reinstated",
+    }:
+        adverse_ref = str(obj.get("id") or "")
+        charge = obj.get("charge") or {}
+        payment_intent = _object_id(
+            obj.get("payment_intent")
+            or (charge.get("payment_intent") if isinstance(charge, dict) else None)
+        )
+        if not adverse_ref or not payment_intent:
+            return ()
+        metadata = obj.get("metadata") or (
+            charge.get("metadata") if isinstance(charge, dict) else {}
+        )
+        provider = (
+            "x402"
+            if isinstance(metadata, dict)
+            and metadata.get("payment_method") == X402_PAYMENT_METHOD
+            else "stripe"
+        )
+        raw_status = str(obj.get("status") or "").lower()
+        if event_type == "charge.dispute.funds_reinstated" or raw_status == "won":
+            status = "won"
+        elif raw_status == "lost":
+            status = "lost"
+        elif raw_status in {"closed", "warning_closed"}:
+            status = "closed"
+        elif raw_status in {"warning_needs_response", "warning_under_review"}:
+            status = "pending"
+        else:
+            # A real dispute removes the funds immediately, before Stripe has
+            # adjudicated it; that active state claims all credited principal.
+            status = "succeeded"
+        return (
+            AdverseTrustEvent(
+                event_id=f"{event_id}:{adverse_ref}",
+                provider=provider,
+                kind="dispute",
+                adverse_ref=adverse_ref,
+                original_payment_ref=payment_intent,
+                amount_micro=int(obj.get("amount") or 0) * MICRODOLLARS_PER_CENT,
+                provider_subtype=event_type,
+                lifecycle_status=status,
+                occurred_at=occurred_at,
+                provider_ordering_watermark=watermark,
+                payload=raw_payload,
+            ),
+        )
+    return ()
 
 
 def _lifetime_topup_user_id(workspace_id: str, metadata: dict[str, Any]) -> str | None:

--- a/src/trusted_router/services/trust_recovery.py
+++ b/src/trusted_router/services/trust_recovery.py
@@ -1,0 +1,43 @@
+"""Operational alerts for durable trust recovery work."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from trusted_router.synthetic.alerts import ops_alert
+
+PROVIDER_CONSISTENCY_DELAY_SECONDS = {"stripe": 900, "x402": 900}
+
+
+def alert_unrecovered_principal(result: Any) -> bool:
+    if result.unrecovered_micro <= 0 or result.workspace_id is None:
+        return False
+    return ops_alert(
+        "trust.unrecovered_principal "
+        f"workspace_id={result.workspace_id} "
+        f"unrecovered_micro={result.unrecovered_micro}",
+        fingerprint=["trust.unrecovered_principal", result.workspace_id],
+        tags={"workspace_id": result.workspace_id},
+    )
+
+
+def alert_stale_trust_inbox(store: Any, *, now: datetime | None = None) -> int:
+    observed_at = now or datetime.now(UTC)
+    alerted = 0
+    for provider, delay in PROVIDER_CONSISTENCY_DELAY_SECONDS.items():
+        rows = store.list_stale_trust_inbox(
+            older_than=observed_at - timedelta(seconds=delay)
+        )
+        for row in rows:
+            if row.provider != provider:
+                continue
+            ops_alert(
+                "trust.inbox_stale "
+                f"provider={row.provider} adverse_ref={row.adverse_ref} "
+                f"received_at={row.received_at.isoformat()}",
+                fingerprint=["trust.inbox_stale", row.provider, row.adverse_ref],
+                tags={"provider": row.provider, "adverse_ref": row.adverse_ref},
+            )
+            alerted += 1
+    return alerted

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -53,6 +53,8 @@ from trusted_router.storage_keys import InMemoryApiKeys
 from trusted_router.storage_models import (
     AcquisitionAttribution,
     ActivationReminderTask,
+    AdverseTrustEvent,
+    AdverseTrustResult,
     ApiKey,
     ApiKeyAuthContext,
     ApiKeyUsageSnapshot,
@@ -90,6 +92,7 @@ from trusted_router.storage_models import (
     SyntheticProbeSample,
     SyntheticRollup,
     TrustEvent,
+    TrustInboxRow,
     User,
     UserProvidedModel,
     VerificationToken,
@@ -111,7 +114,14 @@ from trusted_router.storage_user_models import InMemoryUserProvidedModels
 from trusted_router.storage_verification_tokens import InMemoryVerificationTokens
 from trusted_router.storage_video_jobs import InMemoryVideoJobs
 from trusted_router.storage_wallet_challenges import InMemoryWalletChallenges
-from trusted_router.trust_tiers import payment_or_grant_event
+from trusted_router.trust_tiers import (
+    adverse_event_from_payload,
+    adverse_event_payload,
+    adverse_transition_outcome,
+    payment_or_grant_event,
+    payment_recovery_target,
+    validate_adverse_event,
+)
 from trusted_router.types import IdentityVerificationStatus, UsageType
 
 
@@ -136,6 +146,7 @@ class InMemoryStore:
         self.credit_money: dict[str, CreditMoney] = {}
         self.stripe_events: set[str] = set()
         self.trust_events: dict[tuple[str, str], TrustEvent] = {}
+        self.trust_inbox: dict[tuple[str, str], TrustInboxRow] = {}
         self.webhook_events: set[tuple[str, str]] = set()
         self.earnings_money: dict[str, tuple[int, int]] = {}
         self.credit_movements: dict[tuple[str, str], CreditMovement] = {}
@@ -669,7 +680,13 @@ class InMemoryStore:
             if deleted is not None:
                 workspace.deleted = deleted
             if billing_paused is not None:
-                workspace.billing_paused = billing_paused
+                causes = set(workspace.billing_pause_causes)
+                if billing_paused:
+                    causes.add("migration")
+                else:
+                    causes.discard("migration")
+                workspace.billing_pause_causes = sorted(causes)
+                workspace.billing_paused = bool(causes)
             if billing_pause_reason is not None:
                 workspace.billing_pause_reason = billing_pause_reason
             return workspace
@@ -1554,13 +1571,239 @@ class InMemoryStore:
                 self.stripe_events.add(event_id)
                 return False
             self.stripe_events.add(event_id)
-            money.total_credits_microdollars += amount_microdollars
             self.trust_events[(workspace_id, event_id)] = trust_event
+            available = int(amount_microdollars)
+            for payment in sorted(
+                (
+                    row
+                    for row in self.trust_events.values()
+                    if row.workspace_id == workspace_id
+                    and row.kind == "payment"
+                    and int(row.unrecovered_micro or 0) > 0
+                ),
+                key=lambda row: (row.occurred_at, row.event_id),
+            ):
+                take = min(available, int(payment.unrecovered_micro or 0))
+                if take == 0:
+                    break
+                payment.recovered_micro = int(payment.recovered_micro or 0) + take
+                payment.unrecovered_micro = int(payment.unrecovered_micro or 0) - take
+                payment.debit_status = (
+                    "debited" if payment.unrecovered_micro == 0 else "partial"
+                )
+                available -= take
+            money.total_credits_microdollars += available
+            self._sync_principal_recovery_pause_locked(workspace_id)
+            for key, inbox in sorted(
+                tuple(self.trust_inbox.items()),
+                key=lambda item: (item[1].received_at, item[1].adverse_ref),
+            ):
+                pending = adverse_event_from_payload(inbox.payload)
+                if (
+                    pending.provider == provenance.provider
+                    and pending.original_payment_ref == provenance.external_ref
+                ):
+                    self._apply_adverse_trust_event_locked(pending)
+                    del self.trust_inbox[key]
             if lifetime_topup_user_id is not None:
                 self.lifetime_topups[lifetime_topup_user_id] = self.lifetime_topups.get(
                     lifetime_topup_user_id, 0
                 ) + int(amount_microdollars)
             return True
+
+    def _sync_principal_recovery_pause_locked(self, workspace_id: str) -> None:
+        workspace = self.workspaces.get(workspace_id)
+        if workspace is None:
+            return
+        debt = any(
+            row.workspace_id == workspace_id
+            and row.kind == "payment"
+            and int(row.unrecovered_micro or 0) > 0
+            for row in self.trust_events.values()
+        )
+        causes = set(workspace.billing_pause_causes)
+        if debt:
+            causes.add("principal_recovery")
+        else:
+            causes.discard("principal_recovery")
+        workspace.billing_pause_causes = sorted(causes)
+        workspace.billing_paused = bool(causes)
+        if debt:
+            workspace.billing_pause_reason = "principal_recovery"
+        elif not causes and workspace.billing_pause_reason == "principal_recovery":
+            workspace.billing_pause_reason = ""
+
+    def _apply_adverse_trust_event_locked(
+        self, event: AdverseTrustEvent
+    ) -> AdverseTrustResult | None:
+        payment = next(
+            (
+                row
+                for row in self.trust_events.values()
+                if row.kind == "payment"
+                and row.provider == event.provider
+                and row.original_payment_ref == event.original_payment_ref
+            ),
+            None,
+        )
+        if payment is None:
+            return None
+        existing = next(
+            (
+                row
+                for row in self.trust_events.values()
+                if row.provider == event.provider and row.adverse_ref == event.adverse_ref
+            ),
+            None,
+        )
+        if existing is not None and existing.kind != event.kind:
+            return AdverseTrustResult(
+                "illegal", workspace_id=payment.workspace_id, provider=event.provider
+            )
+        transition = adverse_transition_outcome(
+            kind=event.kind,
+            old_status=existing.lifecycle_status if existing else None,
+            old_watermark=existing.provider_ordering_watermark if existing else None,
+            new_status=event.lifecycle_status,
+            new_watermark=event.provider_ordering_watermark,
+        )
+        if transition != "applied":
+            return AdverseTrustResult(
+                transition,
+                payment.workspace_id,
+                int(payment.recovery_target or 0),
+                int(payment.recovered_micro or 0),
+                int(payment.unrecovered_micro or 0),
+                event.provider,
+            )
+        now = dt.datetime.now(dt.UTC)
+        if existing is None:
+            existing = TrustEvent(
+                payment.workspace_id,
+                event.event_id,
+                event.kind,
+                event.provider,
+                event.amount_micro,
+                event.original_payment_ref,
+                event.adverse_ref,
+                event.occurred_at,
+                now,
+                payment.payment_amount_micro,
+                payment.currency,
+                payment.credited_micro,
+                None,
+                event.provider_subtype,
+                event.lifecycle_status,
+                None,
+                None,
+                None,
+                None,
+                event.provider_ordering_watermark,
+            )
+            self.trust_events[(payment.workspace_id, event.event_id)] = existing
+        else:
+            existing.amount_micro = event.amount_micro
+            existing.occurred_at = event.occurred_at
+            existing.recorded_at = now
+            existing.provider_subtype = event.provider_subtype
+            existing.lifecycle_status = event.lifecycle_status
+            existing.provider_ordering_watermark = event.provider_ordering_watermark
+        adverse = [
+            row
+            for row in self.trust_events.values()
+            if row.workspace_id == payment.workspace_id
+            and row.provider == payment.provider
+            and row.original_payment_ref == payment.original_payment_ref
+            and row.kind != "payment"
+        ]
+        target, net_refunded = payment_recovery_target(payment, adverse)
+        recovered = int(payment.recovered_micro or 0)
+        unrecovered = int(payment.unrecovered_micro or 0)
+        if int(payment.recovery_target or 0) != recovered + unrecovered:
+            raise RuntimeError("payment recovery invariant violated")
+        delta = target - int(payment.recovery_target or 0)
+        money = self.credit_money[payment.workspace_id]
+        if delta > 0:
+            safe = max(
+                0,
+                money.total_credits_microdollars
+                - money.total_usage_microdollars
+                - money.reserved_microdollars,
+            )
+            debit = min(delta, safe)
+            money.total_credits_microdollars -= debit
+            recovered += debit
+            unrecovered += delta - debit
+        elif delta < 0:
+            decrease = -delta
+            canceled = min(decrease, unrecovered)
+            unrecovered -= canceled
+            restore = min(decrease - canceled, recovered)
+            recovered -= restore
+            money.total_credits_microdollars += restore
+        payment.recovery_target = target
+        payment.recovered_micro = recovered
+        payment.unrecovered_micro = unrecovered
+        payment.cumulative_refunded = net_refunded
+        payment.debit_status = (
+            "debited" if unrecovered == 0 else ("unrecovered" if recovered == 0 else "partial")
+        )
+        existing.recovery_target = target
+        existing.cumulative_refunded = net_refunded
+        existing.unrecovered_micro = unrecovered
+        existing.debit_status = payment.debit_status
+        self._sync_principal_recovery_pause_locked(payment.workspace_id)
+        return AdverseTrustResult(
+            "applied",
+            payment.workspace_id,
+            target,
+            recovered,
+            unrecovered,
+            event.provider,
+        )
+
+    def record_adverse_trust_event(self, event: AdverseTrustEvent) -> AdverseTrustResult:
+        validate_adverse_event(event)
+        with self._lock:
+            resolved_event = event
+            result = self._apply_adverse_trust_event_locked(resolved_event)
+            if result is None and event.provider == "stripe":
+                x402_event = dataclasses.replace(event, provider="x402")
+                x402_result = self._apply_adverse_trust_event_locked(x402_event)
+                if x402_result is not None:
+                    resolved_event = x402_event
+                    result = x402_result
+            if result is not None:
+                resolved = result
+            else:
+                self.trust_inbox.setdefault(
+                    (resolved_event.provider, resolved_event.adverse_ref),
+                    TrustInboxRow(
+                        resolved_event.provider,
+                        resolved_event.adverse_ref,
+                        adverse_event_payload(resolved_event),
+                        dt.datetime.now(dt.UTC),
+                    ),
+                )
+                resolved = AdverseTrustResult("inbox", provider=resolved_event.provider)
+        if resolved.unrecovered_micro > 0 and resolved.workspace_id is not None:
+            from trusted_router.services.trust_recovery import (
+                alert_unrecovered_principal,
+            )
+
+            alert_unrecovered_principal(resolved)
+        return resolved
+
+    def list_stale_trust_inbox(
+        self, *, older_than: dt.datetime
+    ) -> tuple[TrustInboxRow, ...]:
+        with self._lock:
+            return tuple(
+                sorted(
+                    (row for row in self.trust_inbox.values() if row.received_at < older_than),
+                    key=lambda row: (row.received_at, row.provider, row.adverse_ref),
+                )
+            )
 
     # Earnings & movement primitives -----------------------------------------
 

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -63,6 +63,8 @@ from trusted_router.spend_windows import KeyWindowLimitDecision
 from trusted_router.storage import (
     AcquisitionAttribution,
     ActivationReminderTask,
+    AdverseTrustEvent,
+    AdverseTrustResult,
     ApiKey,
     ApiKeyUsageSnapshot,
     AuthSession,
@@ -185,7 +187,11 @@ from trusted_router.storage_gcp_synthetic_rollups import (
 )
 from trusted_router.storage_gcp_trust import (
     TRUST_EVENT_COLUMNS,
+    absorb_unrecovered_recovery_tx,
+    apply_adverse_trust_event_tx,
+    drain_matching_trust_inbox_tx,
     insert_credit_trust_event,
+    insert_trust_inbox_tx,
     recompute_workspace_trust_tier_tx,
     trust_event_row,
 )
@@ -1094,7 +1100,13 @@ class SpannerBigtableStore:
             if deleted is not None:
                 workspace.deleted = deleted
             if billing_paused is not None:
-                workspace.billing_paused = billing_paused
+                causes = set(workspace.billing_pause_causes)
+                if billing_paused:
+                    causes.add("migration")
+                else:
+                    causes.discard("migration")
+                workspace.billing_pause_causes = sorted(causes)
+                workspace.billing_paused = bool(causes)
             if billing_pause_reason is not None:
                 workspace.billing_pause_reason = billing_pause_reason
             self._write_entity_tx(transaction, "workspace", workspace.id, workspace)
@@ -2109,9 +2121,9 @@ class SpannerBigtableStore:
         currency: str | None = None,
         lifetime_topup_user_id: str | None = None,
     ) -> bool:
-        def txn(transaction: Any) -> bool:
+        def txn(transaction: Any) -> tuple[bool, tuple[AdverseTrustResult, ...]]:
             if self._read_entity_tx(transaction, "stripe_event", event_id, dict) is not None:
-                return False
+                return False, ()
             amount = int(amount_microdollars)
             account = self._read_entity_tx(transaction, "credit", workspace_id, CreditAccount)
             if account is None:
@@ -2132,7 +2144,7 @@ class SpannerBigtableStore:
                 ),
             )
             if not trust_event_inserted:
-                return False
+                return False, ()
             self._credit_workspace_balance_tx(
                 transaction,
                 workspace_id,
@@ -2156,9 +2168,92 @@ class SpannerBigtableStore:
                 _json_body({"created_at": created_at}),
                 now,
             )
-            return True
+            drained: tuple[AdverseTrustResult, ...] = ()
+            if provenance.external_ref is not None:
+                drained = drain_matching_trust_inbox_tx(
+                    transaction,
+                    self._param_types,
+                    provider=provenance.provider,
+                    original_payment_ref=provenance.external_ref,
+                    now=now,
+                    read_entity_tx=self._read_entity_tx,
+                    write_entity_tx=self._write_entity_trust_dml_tx,
+                )
+            return True, drained
 
-        return self._run_in_transaction(txn)
+        credited, drained = self._run_in_transaction(txn)
+        for result in drained:
+            self._alert_unrecovered_principal(result)
+        return credited
+
+    @staticmethod
+    def _alert_unrecovered_principal(result: AdverseTrustResult) -> None:
+        from trusted_router.services.trust_recovery import alert_unrecovered_principal
+
+        alert_unrecovered_principal(result)
+
+    def record_adverse_trust_event(self, event: AdverseTrustEvent) -> AdverseTrustResult:
+        now = dt.datetime.now(dt.UTC).replace(microsecond=0)
+
+        def txn(transaction: Any) -> AdverseTrustResult:
+            resolved_event = event
+            result = apply_adverse_trust_event_tx(
+                transaction,
+                self._param_types,
+                event,
+                now=now,
+                read_entity_tx=self._read_entity_tx,
+                write_entity_tx=self._write_entity_trust_dml_tx,
+            )
+            if result is None and event.provider == "stripe":
+                x402_event = dataclasses.replace(event, provider="x402")
+                x402_result = apply_adverse_trust_event_tx(
+                    transaction,
+                    self._param_types,
+                    x402_event,
+                    now=now,
+                    read_entity_tx=self._read_entity_tx,
+                    write_entity_tx=self._write_entity_trust_dml_tx,
+                )
+                if x402_result is not None:
+                    resolved_event = x402_event
+                    result = x402_result
+            if result is not None:
+                return result
+            insert_trust_inbox_tx(
+                transaction,
+                self._param_types,
+                resolved_event,
+                received_at=now,
+            )
+            return AdverseTrustResult("inbox", provider=resolved_event.provider)
+
+        result = self._run_in_transaction(txn)
+        if result.outcome in {"stale", "illegal"}:
+            log.warning(
+                "trust.adverse_transition_%s provider=%s adverse_ref=%s status=%s",
+                result.outcome,
+                event.provider,
+                event.adverse_ref,
+                event.lifecycle_status,
+            )
+        self._alert_unrecovered_principal(result)
+        return result
+
+    def list_stale_trust_inbox(
+        self, *, older_than: dt.datetime
+    ) -> tuple[Any, ...]:
+        from trusted_router.storage_models import TrustInboxRow
+
+        with self._database.snapshot() as snapshot:
+            rows = snapshot.execute_sql(
+                "SELECT provider, adverse_ref, payload, received_at "
+                "FROM tr_trust_inbox WHERE received_at<@older_than "
+                "ORDER BY received_at, provider, adverse_ref",
+                params={"older_than": older_than},
+                param_types={"older_than": self._param_types.TIMESTAMP},
+            )
+            return tuple(TrustInboxRow(*row) for row in rows)
 
     def credit_workspace_once(
         self, workspace_id: str, amount_microdollars: int, event_id: str
@@ -2197,9 +2292,21 @@ class SpannerBigtableStore:
             account = self._read_entity_tx(transaction, "credit", workspace_id, CreditAccount)
         if account is None:
             raise ValueError("credit_account_not_found")
+        amount = int(amount_microdollars)
+        shard_count = credit_shard_count(account)
+        absorbed = absorb_unrecovered_recovery_tx(
+            transaction,
+            self._param_types,
+            workspace_id=workspace_id,
+            amount_micro=amount,
+            shard_count=shard_count,
+            now=now,
+            read_entity_tx=self._read_entity_tx,
+            write_entity_tx=self._write_entity_trust_dml_tx,
+        )
         deltas = distribute_credit_amount(
-            int(amount_microdollars),
-            credit_shard_count(account),
+            amount - absorbed,
+            shard_count,
         )
         for shard, delta in enumerate(deltas):
             updated = credit_credit_shard(
@@ -2215,6 +2322,24 @@ class SpannerBigtableStore:
                     "missing authoritative tr_credit_balance shard "
                     f"{shard} for workspace {workspace_id}"
                 )
+
+    def _write_entity_trust_dml_tx(
+        self,
+        transaction: Any,
+        kind: str,
+        entity_id: str,
+        value: Any,
+    ) -> None:
+        updated = update_entity_body_dml(
+            transaction,
+            self._param_types,
+            kind,
+            entity_id,
+            _json_body(value),
+            dt.datetime.now(dt.UTC),
+        )
+        if int(updated) != 1:
+            raise RuntimeError("trust transaction lost its workspace compatibility row")
 
     def _increment_lifetime_topup_tx(
         self,

--- a/src/trusted_router/storage_gcp_counter_dml.py
+++ b/src/trusted_router/storage_gcp_counter_dml.py
@@ -310,7 +310,7 @@ def release_credit(
         "SET reserved = reserved - @hold, total_usage = total_usage + @actual "
         "WHERE workspace_id=@ws AND shard=@shard AND reserved >= @hold"
     )
-    return transaction.execute_update(
+    count = transaction.execute_update(
         sql,
         params={"hold": int(hold), "actual": int(actual), "ws": workspace_id, "shard": shard},
         param_types={
@@ -320,6 +320,55 @@ def release_credit(
             "shard": param_types.INT64,
         },
     )
+    free = int(hold) - int(actual)
+    if count == 1 and free > 0:
+        from trusted_router.storage_gcp_trust import absorb_unrecovered_recovery_tx
+
+        absorbed = absorb_unrecovered_recovery_tx(
+            transaction,
+            param_types,
+            workspace_id=workspace_id,
+            amount_micro=free,
+            shard_count=_credit_shard_count_from_rows(transaction, param_types, workspace_id),
+            now=datetime.now(UTC),
+            read_entity_tx=None,
+            write_entity_tx=None,
+        )
+        if absorbed:
+            debited = transaction.execute_update(
+                "UPDATE tr_credit_balance SET total_credits=total_credits-@amount "
+                "WHERE workspace_id=@ws AND shard=@shard "
+                "AND (total_credits-total_usage-reserved)>=@amount",
+                params={
+                    "amount": absorbed,
+                    "ws": workspace_id,
+                    "shard": shard,
+                },
+                param_types={
+                    "amount": param_types.INT64,
+                    "ws": param_types.STRING,
+                    "shard": param_types.INT64,
+                },
+            )
+            if int(debited) != 1:
+                raise RuntimeError("released credit could not satisfy recovery debt")
+    return count
+
+
+def _credit_shard_count_from_rows(
+    transaction: Any, param_types: Any, workspace_id: str
+) -> int:
+    rows = list(
+        transaction.execute_sql(
+            "SELECT shard FROM tr_credit_balance WHERE workspace_id=@pk ORDER BY shard",
+            params={"pk": workspace_id},
+            param_types={"pk": param_types.STRING},
+        )
+    )
+    observed = [int(row[0]) for row in rows]
+    if observed != list(range(len(observed))) or not observed:
+        raise RuntimeError("configured tr_credit_balance shard set is incomplete")
+    return len(observed)
 
 
 def reserve_key(

--- a/src/trusted_router/storage_gcp_counter_reconcile.py
+++ b/src/trusted_router/storage_gcp_counter_reconcile.py
@@ -7,7 +7,12 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from trusted_router.storage_gcp_counters import credit_shard_count, key_usage_shard_count
-from trusted_router.storage_models import ApiKey, CreditAccount, Workspace
+from trusted_router.storage_models import (
+    ApiKey,
+    CreditAccount,
+    Workspace,
+    workspace_billing_paused,
+)
 
 # ── Standing typed-side invariant auditor ───────────────────────────────────
 # This auditor is the standing typed-side tripwire: for every typed counter row,
@@ -629,7 +634,7 @@ def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False)
             param_types={"ws": pt.STRING},
         ))[0][0]
 
-    if workspace is None or not getattr(workspace, "billing_paused", False):
+    if workspace is None or not workspace_billing_paused(workspace):
         res.reasons.append("workspace not billing-paused — pause it before repair")
     if credit_account is not None and credit_shard_count(credit_account) != 1:
         res.reasons.append("credit ledger is sharded — consolidate before shard-zero repair")
@@ -657,7 +662,7 @@ def repair_typed_reserved(store: Any, workspace_id: str, *, apply: bool = False)
         # any write. A missing typed row (a key deleted mid-repair, or never
         # created) must ABORT — never be re-created as a partial (uncapped) row.
         ws = store._read_entity_tx(transaction, "workspace", workspace_id, Workspace)
-        if ws is None or not ws.billing_paused:
+        if ws is None or not workspace_billing_paused(ws):
             return None
         credit = store._read_entity_tx(transaction, "credit", workspace_id, CreditAccount)
         if credit is not None and credit_shard_count(credit) != 1:
@@ -813,7 +818,7 @@ def repair_typed_usage(
     elif baseline_row and baseline_row[0][0] is not None:
         baseline = int(baseline_row[0][0])
 
-    if workspace is None or not getattr(workspace, "billing_paused", False):
+    if workspace is None or not workspace_billing_paused(workspace):
         res.reasons.append("workspace not billing-paused — pause it before repair")
     if credit_account is not None and credit_shard_count(credit_account) != 1:
         res.reasons.append("credit ledger is sharded — consolidate before shard-zero repair")
@@ -880,7 +885,7 @@ def repair_typed_usage(
         # as repair_typed_reserved: a workspace unpaused, a hold opened, or the
         # baseline cleaned up between the snapshot and here must abort.
         ws = store._read_entity_tx(transaction, "workspace", workspace_id, Workspace)
-        if ws is None or not ws.billing_paused:
+        if ws is None or not workspace_billing_paused(ws):
             return None
         credit = store._read_entity_tx(transaction, "credit", workspace_id, CreditAccount)
         if credit is not None and credit_shard_count(credit) != 1:

--- a/src/trusted_router/storage_gcp_credit_shard_admin.py
+++ b/src/trusted_router/storage_gcp_credit_shard_admin.py
@@ -15,7 +15,11 @@ from trusted_router.storage_gcp_counters import (
 from trusted_router.storage_gcp_legacy_reservations import (
     legacy_reservation_snapshot,
 )
-from trusted_router.storage_models import CreditAccount, Workspace
+from trusted_router.storage_models import (
+    CreditAccount,
+    Workspace,
+    workspace_billing_paused,
+)
 
 _RESHARD_COLUMNS = (
     "workspace_id",
@@ -163,7 +167,7 @@ def inspect_credit_reshard(
     account = store.get_credit_account(workspace_id)
     if workspace is None:
         result.reasons.append("workspace not found")
-    elif not workspace.billing_paused:
+    elif not workspace_billing_paused(workspace):
         result.reasons.append("workspace not billing-paused")
     if account is None:
         result.reasons.append("credit account not found")
@@ -249,7 +253,7 @@ def reshard_credit_account(
     def txn(transaction: Any) -> dict[str, int] | None:
         workspace = store._read_entity_tx(transaction, "workspace", workspace_id, Workspace)
         account = store._read_entity_tx(transaction, "credit", workspace_id, CreditAccount)
-        if workspace is None or not workspace.billing_paused or account is None:
+        if workspace is None or not workspace_billing_paused(workspace) or account is None:
             return None
         current_count = credit_shard_count(account)
         rows = list(

--- a/src/trusted_router/storage_gcp_key_shard_admin.py
+++ b/src/trusted_router/storage_gcp_key_shard_admin.py
@@ -21,7 +21,12 @@ from trusted_router.storage_gcp_counters import (
 from trusted_router.storage_gcp_legacy_reservations import (
     legacy_reservation_snapshot,
 )
-from trusted_router.storage_models import ApiKey, Workspace, iso_now
+from trusted_router.storage_models import (
+    ApiKey,
+    Workspace,
+    iso_now,
+    workspace_billing_paused,
+)
 
 _KEY_RESHARD_COLUMNS = (
     "key_hash",
@@ -151,7 +156,7 @@ def inspect_key_usage_reshard(
     workspace = store.get_workspace(key.workspace_id)
     if workspace is None:
         result.reasons.append("workspace not found")
-    elif not workspace.billing_paused:
+    elif not workspace_billing_paused(workspace):
         result.reasons.append("workspace not billing-paused")
     try:
         current_count = key_usage_shard_count(key)
@@ -232,7 +237,7 @@ def reshard_key_usage(
             key.workspace_id,
             Workspace,
         )
-        if workspace is None or not workspace.billing_paused:
+        if workspace is None or not workspace_billing_paused(workspace):
             return None
         current_count = key_usage_shard_count(key)
         rows = list(

--- a/src/trusted_router/storage_gcp_trust.py
+++ b/src/trusted_router/storage_gcp_trust.py
@@ -3,12 +3,33 @@
 from __future__ import annotations
 
 import datetime as dt
+import json
 from collections.abc import Callable
 from typing import Any
 
-from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TRUST_COLUMNS, credit_shard_count
-from trusted_router.storage_models import CreditAccount, TrustEvent, User, Workspace
-from trusted_router.trust_tiers import compute_trust_tier
+from trusted_router.storage_gcp_counter_dml import credit_credit_shard
+from trusted_router.storage_gcp_counters import (
+    CREDIT_BALANCE_TRUST_COLUMNS,
+    credit_shard_count,
+    distribute_credit_amount,
+)
+from trusted_router.storage_models import (
+    AdverseTrustEvent,
+    AdverseTrustResult,
+    CreditAccount,
+    TrustEvent,
+    User,
+    Workspace,
+)
+from trusted_router.trust_tiers import (
+    TRUST_PAUSE_CAUSES,
+    adverse_event_from_payload,
+    adverse_event_payload,
+    adverse_transition_outcome,
+    compute_trust_tier,
+    payment_recovery_target,
+    validate_adverse_event,
+)
 
 TRUST_EVENT_COLUMNS = (
     "workspace_id",
@@ -106,6 +127,586 @@ def insert_credit_trust_event(
         },
     )
     return int(inserted) == 1
+
+
+def _event_from_row(row: list[Any] | tuple[Any, ...]) -> TrustEvent:
+    return TrustEvent(*row)
+
+
+def _read_payment_tx(
+    transaction: Any,
+    param_types: Any,
+    *,
+    provider: str,
+    original_payment_ref: str,
+) -> TrustEvent | None:
+    rows = list(
+        transaction.execute_sql(
+            "SELECT " + ", ".join(TRUST_EVENT_COLUMNS) + " FROM tr_trust_event "  # noqa: S608 - fixed column tuple.
+            "WHERE provider=@provider AND kind='payment' "
+            "AND original_payment_ref=@original_payment_ref",
+            params={
+                "provider": provider,
+                "original_payment_ref": original_payment_ref,
+            },
+            param_types={
+                "provider": param_types.STRING,
+                "original_payment_ref": param_types.STRING,
+            },
+        )
+    )
+    if len(rows) > 1:
+        raise RuntimeError("payment trust-event dedup invariant violated")
+    return None if not rows else _event_from_row(rows[0])
+
+
+def _sync_principal_recovery_pause_tx(
+    transaction: Any,
+    param_types: Any,
+    *,
+    workspace_id: str,
+    shard_count: int,
+    paused: bool,
+    now: dt.datetime,
+    read_entity_tx: Callable[..., Any] | None,
+    write_entity_tx: Callable[..., Any] | None,
+) -> None:
+    rows = list(
+        transaction.execute_sql(
+            "SELECT shard, billing_pause_causes, pause_epoch FROM tr_credit_balance "
+            "WHERE workspace_id=@pk AND shard>=0 AND shard<@shard_count ORDER BY shard",
+            params={"pk": workspace_id, "shard_count": shard_count},
+            param_types={"pk": param_types.STRING, "shard_count": param_types.INT64},
+        )
+    )
+    if [int(row[0]) for row in rows] != list(range(shard_count)):
+        raise RuntimeError("configured tr_credit_balance shard set is incomplete")
+    observed = {tuple(sorted(row[1] or ())) for row in rows}
+    if len(observed) != 1:
+        raise RuntimeError("replicated billing pause causes diverged")
+    causes = set(next(iter(observed)))
+    if not causes <= TRUST_PAUSE_CAUSES:
+        raise RuntimeError("unsupported billing pause cause persisted")
+    before = set(causes)
+    if paused:
+        causes.add("principal_recovery")
+    else:
+        causes.discard("principal_recovery")
+    if causes == before:
+        return
+    normalized = sorted(causes)
+    updated = transaction.execute_update(
+        "UPDATE tr_credit_balance SET billing_pause_causes=@causes, "
+        "pause_epoch=COALESCE(pause_epoch,0)+1, updated_at=@now "
+        "WHERE workspace_id=@pk AND shard>=0 AND shard<@shard_count",
+        params={
+            "causes": normalized,
+            "now": now,
+            "pk": workspace_id,
+            "shard_count": shard_count,
+        },
+        param_types={
+            "causes": param_types.Array(param_types.STRING),
+            "now": param_types.TIMESTAMP,
+            "pk": param_types.STRING,
+            "shard_count": param_types.INT64,
+        },
+    )
+    if int(updated) != shard_count:
+        raise RuntimeError("billing pause update did not cover every active shard")
+    if read_entity_tx is not None and write_entity_tx is not None:
+        workspace = read_entity_tx(transaction, "workspace", workspace_id, Workspace)
+        if workspace is not None:
+            workspace.billing_pause_causes = normalized
+            workspace.billing_paused = bool(normalized)
+            if paused:
+                workspace.billing_pause_reason = "principal_recovery"
+            elif not normalized and workspace.billing_pause_reason == "principal_recovery":
+                workspace.billing_pause_reason = ""
+            write_entity_tx(transaction, "workspace", workspace_id, workspace)
+    else:
+        reason = "principal_recovery" if paused else ""
+        transaction.execute_update(
+            "UPDATE tr_entities SET body=TO_JSON_STRING(JSON_SET(PARSE_JSON(body), "
+            "'$.billing_paused', @paused, '$.billing_pause_causes', "
+            "PARSE_JSON(@causes_json), '$.billing_pause_reason', @reason)), "
+            "updated_at=@now WHERE kind='workspace' AND id=@workspace_id",
+            params={
+                "paused": bool(normalized),
+                "causes_json": json.dumps(normalized, separators=(",", ":")),
+                "reason": reason,
+                "now": now,
+                "workspace_id": workspace_id,
+            },
+            param_types={
+                "paused": param_types.BOOL,
+                "causes_json": param_types.STRING,
+                "reason": param_types.STRING,
+                "now": param_types.TIMESTAMP,
+                "workspace_id": param_types.STRING,
+            },
+        )
+
+
+def absorb_unrecovered_recovery_tx(
+    transaction: Any,
+    param_types: Any,
+    *,
+    workspace_id: str,
+    amount_micro: int,
+    shard_count: int,
+    now: dt.datetime,
+    read_entity_tx: Callable[..., Any] | None,
+    write_entity_tx: Callable[..., Any] | None,
+) -> int:
+    """Move later credit into oldest payment claims; return amount absorbed."""
+
+    remaining = max(0, int(amount_micro))
+    rows = list(
+        transaction.execute_sql(
+            "SELECT " + ", ".join(TRUST_EVENT_COLUMNS) + " FROM tr_trust_event "  # noqa: S608 - fixed column tuple.
+            "WHERE workspace_id=@pk AND kind='payment' AND unrecovered_micro>0 "
+            "ORDER BY occurred_at, event_id",
+            params={"pk": workspace_id},
+            param_types={"pk": param_types.STRING},
+        )
+    )
+    if not rows:
+        return 0
+    absorbed = 0
+    for raw in rows:
+        if remaining == 0:
+            break
+        payment = _event_from_row(raw)
+        debt = int(payment.unrecovered_micro or 0)
+        take = min(remaining, debt)
+        if take == 0:
+            continue
+        updated = transaction.execute_update(
+            "UPDATE tr_trust_event SET recovered_micro=recovered_micro+@amount, "
+            "unrecovered_micro=unrecovered_micro-@amount, "
+            "debit_status=IF(unrecovered_micro=@amount,'debited','partial') "
+            "WHERE workspace_id=@workspace_id AND event_id=@event_id "
+            "AND kind='payment' AND unrecovered_micro>=@amount",
+            params={
+                "amount": take,
+                "workspace_id": workspace_id,
+                "event_id": payment.event_id,
+            },
+            param_types={
+                "amount": param_types.INT64,
+                "workspace_id": param_types.STRING,
+                "event_id": param_types.STRING,
+            },
+        )
+        if int(updated) != 1:
+            raise RuntimeError("recovery absorption lost its payment claim guard")
+        absorbed += take
+        remaining -= take
+    # A strong sum after our guarded updates is the authoritative cause-clear
+    # predicate, including claims that this credit did not fully absorb.
+    debt_rows = list(
+        transaction.execute_sql(
+            "SELECT COALESCE(SUM(unrecovered_micro),0) FROM tr_trust_event "
+            "WHERE workspace_id=@pk AND kind='payment'",
+            params={"pk": workspace_id},
+            param_types={"pk": param_types.STRING},
+        )
+    )
+    still_unrecovered = bool(debt_rows and int(debt_rows[0][0] or 0) > 0)
+    _sync_principal_recovery_pause_tx(
+        transaction,
+        param_types,
+        workspace_id=workspace_id,
+        shard_count=shard_count,
+        paused=still_unrecovered,
+        now=now,
+        read_entity_tx=read_entity_tx,
+        write_entity_tx=write_entity_tx,
+    )
+    return absorbed
+
+
+def _debit_available_principal_tx(
+    transaction: Any,
+    param_types: Any,
+    *,
+    workspace_id: str,
+    shard_count: int,
+    amount_micro: int,
+    now: dt.datetime,
+) -> int:
+    rows = list(
+        transaction.execute_sql(
+            "SELECT shard, total_credits, total_usage, reserved FROM tr_credit_balance "
+            "WHERE workspace_id=@pk AND shard>=0 AND shard<@shard_count ORDER BY shard",
+            params={"pk": workspace_id, "shard_count": shard_count},
+            param_types={"pk": param_types.STRING, "shard_count": param_types.INT64},
+        )
+    )
+    if [int(row[0]) for row in rows] != list(range(shard_count)):
+        raise RuntimeError("configured tr_credit_balance shard set is incomplete")
+    remaining = int(amount_micro)
+    debited = 0
+    for shard, credits, usage, reserved in rows:
+        take = min(remaining, max(0, int(credits) - int(usage) - int(reserved)))
+        if take == 0:
+            continue
+        updated = transaction.execute_update(
+            "UPDATE tr_credit_balance SET total_credits=total_credits-@amount, "
+            "updated_at=@now WHERE workspace_id=@ws AND shard=@shard "
+            "AND (total_credits-total_usage-reserved)>=@amount",
+            params={
+                "amount": take,
+                "now": now,
+                "ws": workspace_id,
+                "shard": int(shard),
+            },
+            param_types={
+                "amount": param_types.INT64,
+                "now": param_types.TIMESTAMP,
+                "ws": param_types.STRING,
+                "shard": param_types.INT64,
+            },
+        )
+        if int(updated) != 1:
+            raise RuntimeError("principal recovery debit lost its headroom guard")
+        debited += take
+        remaining -= take
+        if remaining == 0:
+            break
+    return debited
+
+
+def apply_adverse_trust_event_tx(
+    transaction: Any,
+    param_types: Any,
+    event: AdverseTrustEvent,
+    *,
+    now: dt.datetime,
+    read_entity_tx: Callable[..., Any],
+    write_entity_tx: Callable[..., Any],
+) -> AdverseTrustResult | None:
+    """Apply fact, latch, recovery, and pause in one local transaction."""
+
+    validate_adverse_event(event)
+    payment = _read_payment_tx(
+        transaction,
+        param_types,
+        provider=event.provider,
+        original_payment_ref=event.original_payment_ref,
+    )
+    if payment is None:
+        return None
+    workspace_id = payment.workspace_id
+    existing_rows = list(
+        transaction.execute_sql(
+            "SELECT " + ", ".join(TRUST_EVENT_COLUMNS) + " FROM tr_trust_event "  # noqa: S608 - fixed column tuple.
+            "WHERE provider=@provider AND adverse_ref=@adverse_ref",
+            params={"provider": event.provider, "adverse_ref": event.adverse_ref},
+            param_types={
+                "provider": param_types.STRING,
+                "adverse_ref": param_types.STRING,
+            },
+        )
+    )
+    if len(existing_rows) > 1:
+        raise RuntimeError("adverse lifecycle key is not unique")
+    existing = _event_from_row(existing_rows[0]) if existing_rows else None
+    if existing is not None and existing.kind != event.kind:
+        return AdverseTrustResult(
+            "illegal", workspace_id=workspace_id, provider=event.provider
+        )
+    transition = adverse_transition_outcome(
+        kind=event.kind,
+        old_status=existing.lifecycle_status if existing else None,
+        old_watermark=existing.provider_ordering_watermark if existing else None,
+        new_status=event.lifecycle_status,
+        new_watermark=event.provider_ordering_watermark,
+    )
+    if transition != "applied":
+        return AdverseTrustResult(
+            transition,
+            workspace_id,
+            int(payment.recovery_target or 0),
+            int(payment.recovered_micro or 0),
+            int(payment.unrecovered_micro or 0),
+            event.provider,
+        )
+    if existing is None:
+        inserted = insert_credit_trust_event(
+            transaction,
+            param_types,
+            TrustEvent(
+                workspace_id=workspace_id,
+                event_id=event.event_id,
+                kind=event.kind,
+                provider=event.provider,
+                amount_micro=event.amount_micro,
+                original_payment_ref=event.original_payment_ref,
+                adverse_ref=event.adverse_ref,
+                occurred_at=event.occurred_at,
+                recorded_at=now,
+                payment_amount_micro=payment.payment_amount_micro,
+                currency=payment.currency,
+                credited_micro=payment.credited_micro,
+                recovered_micro=None,
+                provider_subtype=event.provider_subtype,
+                lifecycle_status=event.lifecycle_status,
+                cumulative_refunded=None,
+                recovery_target=None,
+                debit_status=None,
+                unrecovered_micro=None,
+                provider_ordering_watermark=event.provider_ordering_watermark,
+            ),
+        )
+        if not inserted:
+            raise RuntimeError("adverse insert lost dedup race inside transaction")
+        adverse_event_id = event.event_id
+    else:
+        updated = transaction.execute_update(
+            "UPDATE tr_trust_event SET amount_micro=@amount_micro, occurred_at=@occurred_at, "
+            "recorded_at=@recorded_at, provider_subtype=@provider_subtype, "
+            "lifecycle_status=@lifecycle_status, "
+            "provider_ordering_watermark=@provider_ordering_watermark "
+            "WHERE workspace_id=@workspace_id AND event_id=@event_id "
+            "AND provider=@provider AND adverse_ref=@adverse_ref",
+            params={
+                "amount_micro": event.amount_micro,
+                "occurred_at": event.occurred_at,
+                "recorded_at": now,
+                "provider_subtype": event.provider_subtype,
+                "lifecycle_status": event.lifecycle_status,
+                "provider_ordering_watermark": event.provider_ordering_watermark,
+                "workspace_id": workspace_id,
+                "event_id": existing.event_id,
+                "provider": event.provider,
+                "adverse_ref": event.adverse_ref,
+            },
+            param_types={
+                "amount_micro": param_types.INT64,
+                "occurred_at": param_types.TIMESTAMP,
+                "recorded_at": param_types.TIMESTAMP,
+                "provider_subtype": param_types.STRING,
+                "lifecycle_status": param_types.STRING,
+                "provider_ordering_watermark": param_types.STRING,
+                "workspace_id": param_types.STRING,
+                "event_id": param_types.STRING,
+                "provider": param_types.STRING,
+                "adverse_ref": param_types.STRING,
+            },
+        )
+        if int(updated) != 1:
+            raise RuntimeError("adverse lifecycle update lost its key guard")
+        adverse_event_id = existing.event_id
+
+    account = read_entity_tx(transaction, "credit", workspace_id, CreditAccount)
+    if account is None:
+        raise RuntimeError("payment fact has no credit account")
+    shard_count = credit_shard_count(account)
+    latched = transaction.execute_update(
+        "UPDATE tr_credit_balance SET trust_latched_at=COALESCE(trust_latched_at,@now), "
+        "updated_at=@now WHERE workspace_id=@pk AND shard>=0 AND shard<@shard_count",
+        params={"now": now, "pk": workspace_id, "shard_count": shard_count},
+        param_types={
+            "now": param_types.TIMESTAMP,
+            "pk": param_types.STRING,
+            "shard_count": param_types.INT64,
+        },
+    )
+    if int(latched) != shard_count:
+        raise RuntimeError("adverse latch did not cover every active shard")
+    adverse_rows = list(
+        transaction.execute_sql(
+            "SELECT " + ", ".join(TRUST_EVENT_COLUMNS) + " FROM tr_trust_event "  # noqa: S608 - fixed column tuple.
+            "WHERE workspace_id=@workspace_id AND provider=@provider "
+            "AND original_payment_ref=@original_payment_ref AND kind!='payment'",
+            params={
+                "workspace_id": workspace_id,
+                "provider": event.provider,
+                "original_payment_ref": event.original_payment_ref,
+            },
+            param_types={
+                "workspace_id": param_types.STRING,
+                "provider": param_types.STRING,
+                "original_payment_ref": param_types.STRING,
+            },
+        )
+    )
+    target, net_refunded = payment_recovery_target(
+        payment,
+        (_event_from_row(row) for row in adverse_rows),
+    )
+    old_target = int(payment.recovery_target or 0)
+    recovered = int(payment.recovered_micro or 0)
+    unrecovered = int(payment.unrecovered_micro or 0)
+    if old_target != recovered + unrecovered:
+        raise RuntimeError("payment recovery invariant violated before transition")
+    delta = target - old_target
+    if delta > 0:
+        debited = _debit_available_principal_tx(
+            transaction,
+            param_types,
+            workspace_id=workspace_id,
+            shard_count=shard_count,
+            amount_micro=delta,
+            now=now,
+        )
+        recovered += debited
+        unrecovered += delta - debited
+    elif delta < 0:
+        decrease = -delta
+        canceled = min(decrease, unrecovered)
+        unrecovered -= canceled
+        restore = min(decrease - canceled, recovered)
+        recovered -= restore
+        if restore:
+            for shard, amount in enumerate(distribute_credit_amount(restore, shard_count)):
+                if amount and credit_credit_shard(
+                    transaction,
+                    param_types,
+                    workspace_id,
+                    amount,
+                    shard=shard,
+                    now=now,
+                ) != 1:
+                    raise RuntimeError("principal restoration found a missing shard")
+    if target != recovered + unrecovered:
+        raise RuntimeError("payment recovery invariant violated after transition")
+    debit_status = "debited" if unrecovered == 0 else ("unrecovered" if recovered == 0 else "partial")
+    payment_updated = transaction.execute_update(
+        "UPDATE tr_trust_event SET recovered_micro=@recovered_micro, "
+        "unrecovered_micro=@unrecovered_micro, recovery_target=@recovery_target, "
+        "cumulative_refunded=@cumulative_refunded, debit_status=@debit_status "
+        "WHERE workspace_id=@workspace_id AND event_id=@event_id AND kind='payment'",
+        params={
+            "recovered_micro": recovered,
+            "unrecovered_micro": unrecovered,
+            "recovery_target": target,
+            "cumulative_refunded": net_refunded,
+            "debit_status": debit_status,
+            "workspace_id": workspace_id,
+            "event_id": payment.event_id,
+        },
+        param_types={
+            "recovered_micro": param_types.INT64,
+            "unrecovered_micro": param_types.INT64,
+            "recovery_target": param_types.INT64,
+            "cumulative_refunded": param_types.INT64,
+            "debit_status": param_types.STRING,
+            "workspace_id": param_types.STRING,
+            "event_id": param_types.STRING,
+        },
+    )
+    if int(payment_updated) != 1:
+        raise RuntimeError("payment recovery update lost its fact guard")
+    transaction.execute_update(
+        "UPDATE tr_trust_event SET recovery_target=@recovery_target, "
+        "cumulative_refunded=@cumulative_refunded, debit_status=@debit_status, "
+        "unrecovered_micro=@unrecovered_micro WHERE workspace_id=@workspace_id "
+        "AND event_id=@event_id AND kind=@kind",
+        params={
+            "recovery_target": target,
+            "cumulative_refunded": net_refunded,
+            "debit_status": debit_status,
+            "unrecovered_micro": unrecovered,
+            "workspace_id": workspace_id,
+            "event_id": adverse_event_id,
+            "kind": event.kind,
+        },
+        param_types={
+            "recovery_target": param_types.INT64,
+            "cumulative_refunded": param_types.INT64,
+            "debit_status": param_types.STRING,
+            "unrecovered_micro": param_types.INT64,
+            "workspace_id": param_types.STRING,
+            "event_id": param_types.STRING,
+            "kind": param_types.STRING,
+        },
+    )
+    _sync_principal_recovery_pause_tx(
+        transaction,
+        param_types,
+        workspace_id=workspace_id,
+        shard_count=shard_count,
+        paused=unrecovered > 0,
+        now=now,
+        read_entity_tx=read_entity_tx,
+        write_entity_tx=write_entity_tx,
+    )
+    return AdverseTrustResult(
+        "applied", workspace_id, target, recovered, unrecovered, event.provider
+    )
+
+
+def insert_trust_inbox_tx(
+    transaction: Any,
+    param_types: Any,
+    event: AdverseTrustEvent,
+    *,
+    received_at: dt.datetime,
+) -> None:
+    transaction.execute_update(
+        "INSERT INTO tr_trust_inbox (provider, adverse_ref, payload, received_at) "
+        "SELECT @provider, @adverse_ref, @payload, @received_at WHERE NOT EXISTS ("
+        "SELECT 1 FROM tr_trust_inbox WHERE provider=@provider AND adverse_ref=@adverse_ref)",
+        params={
+            "provider": event.provider,
+            "adverse_ref": event.adverse_ref,
+            "payload": adverse_event_payload(event),
+            "received_at": received_at,
+        },
+        param_types={
+            "provider": param_types.STRING,
+            "adverse_ref": param_types.STRING,
+            "payload": param_types.STRING,
+            "received_at": param_types.TIMESTAMP,
+        },
+    )
+
+
+def drain_matching_trust_inbox_tx(
+    transaction: Any,
+    param_types: Any,
+    *,
+    provider: str,
+    original_payment_ref: str,
+    now: dt.datetime,
+    read_entity_tx: Callable[..., Any],
+    write_entity_tx: Callable[..., Any],
+) -> tuple[AdverseTrustResult, ...]:
+    rows = list(
+        transaction.execute_sql(
+            "SELECT provider, adverse_ref, payload, received_at FROM tr_trust_inbox "
+            "WHERE provider=@provider ORDER BY received_at, adverse_ref",
+            params={"provider": provider},
+            param_types={"provider": param_types.STRING},
+        )
+    )
+    results: list[AdverseTrustResult] = []
+    for _provider, adverse_ref, payload, _received_at in rows:
+        event = adverse_event_from_payload(str(payload))
+        if event.original_payment_ref != original_payment_ref:
+            continue
+        result = apply_adverse_trust_event_tx(
+            transaction,
+            param_types,
+            event,
+            now=now,
+            read_entity_tx=read_entity_tx,
+            write_entity_tx=write_entity_tx,
+        )
+        if result is None:
+            raise RuntimeError("matching inbox row still cannot resolve its payment")
+        results.append(result)
+        deleted = transaction.execute_update(
+            "DELETE FROM tr_trust_inbox WHERE provider=@provider AND adverse_ref=@adverse_ref",
+            params={"provider": provider, "adverse_ref": str(adverse_ref)},
+            param_types={"provider": param_types.STRING, "adverse_ref": param_types.STRING},
+        )
+        if int(deleted) != 1:
+            raise RuntimeError("trust inbox drain lost its row guard")
+    return tuple(results)
 
 
 def recompute_workspace_trust_tier_tx(

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -207,6 +207,10 @@ class Workspace:
     # already-authorized requests is NOT blocked — only new work is.
     billing_paused: bool = False
     billing_pause_reason: str = ""
+    # The replicated balance-shard set is authoritative for new pause owners.
+    # This copy keeps the legacy workspace document useful to old revisions and
+    # lets every scalar reader derive the compatibility boolean from the set.
+    billing_pause_causes: list[str] = field(default_factory=list)
     # Non-empty marks a SHADOW of a home-plane workspace, materialized locally
     # so a federated key can resolve (see federated_workspace_from_record). It
     # is not a workspace anyone created here: it has no owner, no member row,
@@ -214,6 +218,24 @@ class Workspace:
     # later reconciliation needs to tell shadows from locally-issued
     # workspaces, and a boolean would not say WHICH home to reconcile against.
     federated_home: str = ""
+
+    def __post_init__(self) -> None:
+        # A pre-cause workspace document can still carry the old migration
+        # quiesce bit. Preserve that pause as the legacy migration owner; new
+        # code subsequently clears only that owner.
+        if self.billing_paused and not self.billing_pause_causes:
+            self.billing_pause_causes = ["migration"]
+        self.billing_pause_causes = sorted(set(self.billing_pause_causes))
+        self.billing_paused = bool(self.billing_pause_causes)
+
+
+def workspace_billing_paused(workspace: object | None) -> bool:
+    """Derive the compatibility scalar from the composable cause set."""
+
+    return bool(
+        workspace is not None
+        and getattr(workspace, "billing_pause_causes", ())
+    )
 
 
 @dataclass
@@ -589,7 +611,7 @@ class CreditProvenance:
         return cls("grant", "system", None, dt.datetime.now(dt.UTC))
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class TrustEvent:
     workspace_id: str
     event_id: str
@@ -611,6 +633,41 @@ class TrustEvent:
     debit_status: str | None
     unrecovered_micro: int | None
     provider_ordering_watermark: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class AdverseTrustEvent:
+    """One provider adverse-object observation, independent of delivery ID."""
+
+    event_id: str
+    provider: str
+    kind: str
+    adverse_ref: str
+    original_payment_ref: str
+    amount_micro: int
+    provider_subtype: str
+    lifecycle_status: str
+    occurred_at: dt.datetime
+    provider_ordering_watermark: str
+    payload: str
+
+
+@dataclass(frozen=True, slots=True)
+class AdverseTrustResult:
+    outcome: str
+    workspace_id: str | None = None
+    recovery_target: int = 0
+    recovered_micro: int = 0
+    unrecovered_micro: int = 0
+    provider: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TrustInboxRow:
+    provider: str
+    adverse_ref: str
+    payload: str
+    received_at: dt.datetime
 
 
 @dataclass

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -111,6 +111,8 @@ from trusted_router.storage_models import (
     FUTURE_SAMPLE_SKEW_SECONDS,
     AcquisitionAttribution,
     ActivationReminderTask,
+    AdverseTrustEvent,
+    AdverseTrustResult,
     ApiKey,
     ApiKeyAuthContext,
     ApiKeyUsageSnapshot,
@@ -146,6 +148,8 @@ from trusted_router.storage_models import (
     SignupResult,
     SyntheticProbeSample,
     SyntheticRollup,
+    TrustEvent,
+    TrustInboxRow,
     User,
     UserProvidedModel,
     VerificationToken,
@@ -188,7 +192,13 @@ from trusted_router.synthetic.rollups import (
     new_rollup_for_sample,
     sample_rollup_ids,
 )
-from trusted_router.trust_tiers import payment_or_grant_event
+from trusted_router.trust_tiers import (
+    adverse_event_payload,
+    adverse_transition_outcome,
+    payment_or_grant_event,
+    payment_recovery_target,
+    validate_adverse_event,
+)
 from trusted_router.types import IdentityVerificationStatus, UsageType
 
 T = TypeVar("T")
@@ -3409,6 +3419,281 @@ class PostgresStore:
                 external_ref=None,
                 occurred_at=dt.datetime.now(dt.UTC),
             ),
+        )
+
+    @staticmethod
+    def _trust_event_from_row(row: Any) -> TrustEvent:
+        values = list(row)
+        for index in (7, 8):
+            if isinstance(values[index], str):
+                values[index] = dt.datetime.fromisoformat(values[index].replace("Z", "+00:00"))
+        return TrustEvent(*values)
+
+    @staticmethod
+    def _trust_event_select() -> str:
+        return (
+            "workspace_id, event_id, kind, provider, amount_micro, "
+            "original_payment_ref, adverse_ref, occurred_at, recorded_at, "
+            "payment_amount_micro, currency, credited_micro, recovered_micro, "
+            "provider_subtype, lifecycle_status, cumulative_refunded, "
+            "recovery_target, debit_status, unrecovered_micro, "
+            "provider_ordering_watermark"
+        )
+
+    def record_adverse_trust_event(self, event: AdverseTrustEvent) -> AdverseTrustResult:
+        validate_adverse_event(event)
+
+        def apply(conn: Any) -> AdverseTrustResult:
+            payment_row = conn.execute(
+                "SELECT " + self._trust_event_select() + " FROM tr_trust_event "  # noqa: S608 - fixed columns.
+                "WHERE provider = %s AND kind = 'payment' "
+                "AND original_payment_ref = %s FOR UPDATE",
+                (event.provider, event.original_payment_ref),
+                prepare=False,
+            ).fetchone()
+            if payment_row is None:
+                conn.execute(
+                    "INSERT INTO tr_trust_inbox "
+                    "(provider, adverse_ref, payload, received_at) "
+                    "VALUES (%s, %s, %s, CURRENT_TIMESTAMP) "
+                    "ON CONFLICT (provider, adverse_ref) DO NOTHING",
+                    (event.provider, event.adverse_ref, adverse_event_payload(event)),
+                    prepare=False,
+                )
+                return AdverseTrustResult("inbox", provider=event.provider)
+            payment = self._trust_event_from_row(payment_row)
+            existing_row = conn.execute(
+                "SELECT " + self._trust_event_select() + " FROM tr_trust_event "  # noqa: S608 - fixed columns.
+                "WHERE provider = %s AND adverse_ref = %s FOR UPDATE",
+                (event.provider, event.adverse_ref),
+                prepare=False,
+            ).fetchone()
+            existing = self._trust_event_from_row(existing_row) if existing_row else None
+            if existing is not None and existing.kind != event.kind:
+                return AdverseTrustResult(
+                    "illegal", workspace_id=payment.workspace_id, provider=event.provider
+                )
+            outcome = adverse_transition_outcome(
+                kind=event.kind,
+                old_status=existing.lifecycle_status if existing else None,
+                old_watermark=existing.provider_ordering_watermark if existing else None,
+                new_status=event.lifecycle_status,
+                new_watermark=event.provider_ordering_watermark,
+            )
+            if outcome != "applied":
+                return AdverseTrustResult(
+                    outcome,
+                    payment.workspace_id,
+                    int(payment.recovery_target or 0),
+                    int(payment.recovered_micro or 0),
+                    int(payment.unrecovered_micro or 0),
+                    event.provider,
+                )
+            if existing is None:
+                conn.execute(
+                    "INSERT INTO tr_trust_event "
+                    "(workspace_id, event_id, kind, provider, amount_micro, "
+                    "original_payment_ref, adverse_ref, occurred_at, recorded_at, "
+                    "payment_amount_micro, currency, credited_micro, provider_subtype, "
+                    "lifecycle_status, provider_ordering_watermark) VALUES ("
+                    "%s, %s, %s, %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, %s, %s, "
+                    "%s, %s, %s, %s) ON CONFLICT (provider, adverse_ref, kind) DO NOTHING",
+                    (
+                        payment.workspace_id,
+                        event.event_id,
+                        event.kind,
+                        event.provider,
+                        event.amount_micro,
+                        event.original_payment_ref,
+                        event.adverse_ref,
+                        event.occurred_at,
+                        payment.payment_amount_micro,
+                        payment.currency,
+                        payment.credited_micro,
+                        event.provider_subtype,
+                        event.lifecycle_status,
+                        event.provider_ordering_watermark,
+                    ),
+                    prepare=False,
+                )
+                adverse_event_id = event.event_id
+            else:
+                conn.execute(
+                    "UPDATE tr_trust_event SET amount_micro = %s, occurred_at = %s, "
+                    "recorded_at = CURRENT_TIMESTAMP, provider_subtype = %s, "
+                    "lifecycle_status = %s, provider_ordering_watermark = %s "
+                    "WHERE workspace_id = %s AND event_id = %s",
+                    (
+                        event.amount_micro,
+                        event.occurred_at,
+                        event.provider_subtype,
+                        event.lifecycle_status,
+                        event.provider_ordering_watermark,
+                        payment.workspace_id,
+                        existing.event_id,
+                    ),
+                )
+                adverse_event_id = existing.event_id
+            balance_rows = conn.execute(
+                "SELECT shard, total_credits, total_usage, reserved, "
+                "billing_pause_causes FROM tr_credit_balance "
+                "WHERE workspace_id = %s ORDER BY shard FOR UPDATE",
+                (payment.workspace_id,),
+                prepare=False,
+            ).fetchall()
+            conn.execute(
+                "UPDATE tr_credit_balance SET trust_latched_at = "
+                "COALESCE(trust_latched_at, CURRENT_TIMESTAMP), "
+                "updated_at = CURRENT_TIMESTAMP WHERE workspace_id = %s",
+                (payment.workspace_id,),
+            )
+            adverse_rows = conn.execute(
+                "SELECT " + self._trust_event_select() + " FROM tr_trust_event "  # noqa: S608 - fixed columns.
+                "WHERE workspace_id = %s AND provider = %s "
+                "AND original_payment_ref = %s AND kind != 'payment'",
+                (payment.workspace_id, payment.provider, payment.original_payment_ref),
+                prepare=False,
+            ).fetchall()
+            target, net_refunded = payment_recovery_target(
+                payment, (self._trust_event_from_row(row) for row in adverse_rows)
+            )
+            recovered = int(payment.recovered_micro or 0)
+            unrecovered = int(payment.unrecovered_micro or 0)
+            old_target = int(payment.recovery_target or 0)
+            if old_target != recovered + unrecovered:
+                raise RuntimeError("payment recovery invariant violated")
+            delta = target - old_target
+            if delta > 0:
+                remaining = delta
+                for shard, credits, usage, reserved, _causes in balance_rows:
+                    take = min(remaining, max(0, int(credits) - int(usage) - int(reserved)))
+                    if take:
+                        changed = conn.execute(
+                            "UPDATE tr_credit_balance SET total_credits = total_credits - %s "
+                            "WHERE workspace_id = %s AND shard = %s "
+                            "AND total_credits - total_usage - reserved >= %s",
+                            (take, payment.workspace_id, shard, take),
+                        )
+                        if changed.rowcount != 1:
+                            raise RuntimeError("principal recovery debit guard lost")
+                        recovered += take
+                        remaining -= take
+                    if remaining == 0:
+                        break
+                unrecovered += remaining
+            elif delta < 0:
+                decrease = -delta
+                canceled = min(decrease, unrecovered)
+                unrecovered -= canceled
+                restore = min(decrease - canceled, recovered)
+                recovered -= restore
+                for shard, amount in enumerate(distribute_credit_amount(restore, len(balance_rows))):
+                    if amount:
+                        conn.execute(
+                            "UPDATE tr_credit_balance SET total_credits = total_credits + %s "
+                            "WHERE workspace_id = %s AND shard = %s",
+                            (amount, payment.workspace_id, shard),
+                        )
+            debit_status = (
+                "debited"
+                if unrecovered == 0
+                else ("unrecovered" if recovered == 0 else "partial")
+            )
+            conn.execute(
+                "UPDATE tr_trust_event SET recovered_micro = %s, unrecovered_micro = %s, "
+                "recovery_target = %s, cumulative_refunded = %s, debit_status = %s "
+                "WHERE workspace_id = %s AND event_id = %s",
+                (
+                    recovered,
+                    unrecovered,
+                    target,
+                    net_refunded,
+                    debit_status,
+                    payment.workspace_id,
+                    payment.event_id,
+                ),
+            )
+            conn.execute(
+                "UPDATE tr_trust_event SET recovery_target = %s, cumulative_refunded = %s, "
+                "debit_status = %s, unrecovered_micro = %s "
+                "WHERE workspace_id = %s AND event_id = %s",
+                (
+                    target,
+                    net_refunded,
+                    debit_status,
+                    unrecovered,
+                    payment.workspace_id,
+                    adverse_event_id,
+                ),
+            )
+            causes = set()
+            if balance_rows:
+                raw_causes = balance_rows[0][4]
+                if isinstance(raw_causes, str):
+                    causes = set(json.loads(raw_causes or "[]"))
+                elif raw_causes:
+                    causes = set(raw_causes)
+            before = set(causes)
+            if unrecovered:
+                causes.add("principal_recovery")
+            else:
+                causes.discard("principal_recovery")
+            if causes != before:
+                conn.execute(
+                    "UPDATE tr_credit_balance SET billing_pause_causes = %s::jsonb, "
+                    "pause_epoch = COALESCE(pause_epoch, 0) + 1 "
+                    "WHERE workspace_id = %s",
+                    (json.dumps(sorted(causes)), payment.workspace_id),
+                )
+                workspace = self._read_entity_tx(
+                    conn, "workspace", payment.workspace_id, Workspace, for_update=True
+                )
+                if workspace is not None:
+                    workspace.billing_pause_causes = sorted(causes)
+                    workspace.billing_paused = bool(causes)
+                    workspace.billing_pause_reason = (
+                        "principal_recovery" if unrecovered else ""
+                    )
+                    self._write_entity_tx(conn, "workspace", workspace.id, workspace)
+            return AdverseTrustResult(
+                "applied",
+                payment.workspace_id,
+                target,
+                recovered,
+                unrecovered,
+                event.provider,
+            )
+
+        result = self._run_transaction(apply)
+        if result.unrecovered_micro > 0 and result.workspace_id is not None:
+            from trusted_router.services.trust_recovery import (
+                alert_unrecovered_principal,
+            )
+
+            alert_unrecovered_principal(result)
+        return result
+
+    def list_stale_trust_inbox(
+        self, *, older_than: dt.datetime
+    ) -> tuple[TrustInboxRow, ...]:
+        with self._pool.connection() as conn:
+            rows = conn.execute(
+                "SELECT provider, adverse_ref, payload, received_at "
+                "FROM tr_trust_inbox WHERE received_at < %s "
+                "ORDER BY received_at, provider, adverse_ref",
+                (older_than,),
+                prepare=False,
+            ).fetchall()
+        return tuple(
+            TrustInboxRow(
+                str(row[0]),
+                str(row[1]),
+                str(row[2]),
+                row[3]
+                if isinstance(row[3], dt.datetime)
+                else dt.datetime.fromisoformat(str(row[3]).replace("Z", "+00:00")),
+            )
+            for row in rows
         )
 
     # Earnings & movement primitives -----------------------------------------

--- a/src/trusted_router/storage_postgres_schema.sql
+++ b/src/trusted_router/storage_postgres_schema.sql
@@ -114,6 +114,14 @@ CREATE UNIQUE INDEX IF NOT EXISTS tr_trust_event_adverse_dedup
 CREATE UNIQUE INDEX IF NOT EXISTS tr_trust_event_payment_dedup
     ON tr_trust_event (provider, original_payment_ref, kind);
 
+CREATE TABLE IF NOT EXISTS tr_trust_inbox (
+    provider TEXT NOT NULL,
+    adverse_ref TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    received_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (provider, adverse_ref)
+);
+
 CREATE TABLE IF NOT EXISTS tr_earnings_balance (
     user_id TEXT NOT NULL,
     shard BIGINT NOT NULL DEFAULT 0,

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -18,6 +18,8 @@ from trusted_router.spend_windows import KeyWindowLimitDecision
 from trusted_router.storage_models import (
     AcquisitionAttribution,
     ActivationReminderTask,
+    AdverseTrustEvent,
+    AdverseTrustResult,
     ApiKey,
     ApiKeyAuthContext,
     ApiKeyUsageSnapshot,
@@ -55,6 +57,7 @@ from trusted_router.storage_models import (
     SignupResult,
     SyntheticProbeSample,
     SyntheticRollup,
+    TrustInboxRow,
     User,
     UserModelPayout,
     UserProvidedModel,
@@ -673,6 +676,12 @@ class Store(Protocol):
     def credit_workspace_once(
         self, workspace_id: str, amount_microdollars: int, event_id: str
     ) -> bool: ...
+    def record_adverse_trust_event(
+        self, event: AdverseTrustEvent
+    ) -> AdverseTrustResult: ...
+    def list_stale_trust_inbox(
+        self, *, older_than: Any
+    ) -> tuple[TrustInboxRow, ...]: ...
 
     # Earnings & movement primitives -----------------------------------------
     def debit_workspace_guarded(

--- a/src/trusted_router/trust_tiers.py
+++ b/src/trusted_router/trust_tiers.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
-from trusted_router.storage_models import CreditProvenance, TrustEvent
+from trusted_router.storage_models import AdverseTrustEvent, CreditProvenance, TrustEvent
 
 TRUST_EVENT_KINDS = frozenset({"payment", "refund", "dispute", "abuse", "grant"})
 TRUST_EVENT_PROVIDERS = frozenset(
@@ -31,6 +32,132 @@ _PAYMENT_SOURCES = {
     "adyen": frozenset({"authorisation"}),
     "x402": frozenset({"x402"}),
 }
+
+TRUST_PAUSE_CAUSES = frozenset(
+    {"abuse", "principal_recovery", "resharding", "federation", "migration"}
+)
+
+_REFUND_TRANSITIONS = {
+    None: frozenset({"pending", "succeeded", "failed", "reversed"}),
+    "pending": frozenset({"pending", "succeeded", "failed", "reversed"}),
+    "succeeded": frozenset({"succeeded", "reversed"}),
+    "failed": frozenset({"failed"}),
+    "reversed": frozenset({"reversed"}),
+    "terminal_by_horizon": frozenset({"terminal_by_horizon"}),
+}
+_DISPUTE_TRANSITIONS = {
+    None: frozenset({"pending", "succeeded", "won", "lost", "closed"}),
+    "pending": frozenset({"pending", "succeeded", "won", "lost", "closed"}),
+    "succeeded": frozenset({"succeeded", "won", "lost", "closed"}),
+    "won": frozenset({"won"}),
+    "lost": frozenset({"lost", "closed"}),
+    "closed": frozenset({"closed"}),
+    "terminal_by_horizon": frozenset({"terminal_by_horizon"}),
+}
+
+
+def validate_adverse_event(event: AdverseTrustEvent) -> None:
+    if event.provider not in {"stripe", "x402"}:
+        raise ValueError("slice 1b adverse provider must be stripe or x402")
+    if event.kind not in {"refund", "dispute"}:
+        raise ValueError("adverse trust event must be a refund or dispute")
+    if not event.adverse_ref or not event.original_payment_ref:
+        raise ValueError("adverse and original payment references are required")
+    if not event.original_payment_ref.startswith("pi_"):
+        raise ValueError("Stripe/x402 adverse event requires a PaymentIntent id")
+    if event.amount_micro < 0:
+        raise ValueError("adverse amount must not be negative")
+    if event.lifecycle_status not in TRUST_EVENT_LIFECYCLE_STATUSES:
+        raise ValueError("unsupported adverse lifecycle status")
+    if event.occurred_at.tzinfo is None or event.occurred_at.utcoffset() is None:
+        raise ValueError("adverse occurred_at must be timezone-aware")
+    if not event.provider_ordering_watermark:
+        raise ValueError("provider ordering watermark is required")
+
+
+def adverse_event_payload(event: AdverseTrustEvent) -> str:
+    """Serialize the canonical observation used by transactional inbox drain."""
+
+    return json.dumps(
+        {
+            "event_id": event.event_id,
+            "provider": event.provider,
+            "kind": event.kind,
+            "adverse_ref": event.adverse_ref,
+            "original_payment_ref": event.original_payment_ref,
+            "amount_micro": event.amount_micro,
+            "provider_subtype": event.provider_subtype,
+            "lifecycle_status": event.lifecycle_status,
+            "occurred_at": event.occurred_at.isoformat(),
+            "provider_ordering_watermark": event.provider_ordering_watermark,
+            "payload": event.payload,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def adverse_event_from_payload(payload: str) -> AdverseTrustEvent:
+    body = json.loads(payload)
+    event = AdverseTrustEvent(
+        event_id=str(body["event_id"]),
+        provider=str(body["provider"]),
+        kind=str(body["kind"]),
+        adverse_ref=str(body["adverse_ref"]),
+        original_payment_ref=str(body["original_payment_ref"]),
+        amount_micro=int(body["amount_micro"]),
+        provider_subtype=str(body["provider_subtype"]),
+        lifecycle_status=str(body["lifecycle_status"]),
+        occurred_at=datetime.fromisoformat(str(body["occurred_at"])),
+        provider_ordering_watermark=str(body["provider_ordering_watermark"]),
+        payload=str(body.get("payload") or ""),
+    )
+    validate_adverse_event(event)
+    return event
+
+
+def adverse_transition_outcome(
+    *,
+    kind: str,
+    old_status: str | None,
+    old_watermark: str | None,
+    new_status: str,
+    new_watermark: str,
+) -> str:
+    """Classify one lifecycle observation without applying money."""
+
+    if old_status == new_status:
+        return "replay"
+    if old_watermark is not None and new_watermark <= old_watermark:
+        return "stale"
+    graph = _REFUND_TRANSITIONS if kind == "refund" else _DISPUTE_TRANSITIONS
+    if new_status not in graph.get(old_status, frozenset()):
+        return "illegal"
+    return "applied"
+
+
+def payment_recovery_target(payment: TrustEvent, adverse: Iterable[TrustEvent]) -> tuple[int, int]:
+    """Return (target, net_refunded) from aggregate current adverse state."""
+
+    credited = int(payment.credited_micro or 0)
+    payment_amount = int(payment.payment_amount_micro or 0)
+    if payment_amount <= 0:
+        raise ValueError("payment fact has no positive payment amount")
+    rows = list(adverse)
+    net_refunded = min(
+        payment_amount,
+        sum(
+            int(row.amount_micro or 0)
+            for row in rows
+            if row.kind == "refund" and row.lifecycle_status == "succeeded"
+        ),
+    )
+    refund_target = credited * net_refunded // payment_amount
+    dispute_claims_all = any(
+        row.kind == "dispute" and row.lifecycle_status in {"succeeded", "lost", "closed"}
+        for row in rows
+    )
+    return (credited if dispute_claims_all else refund_target), net_refunded
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/fakes/postgres.py
+++ b/tests/fakes/postgres.py
@@ -119,6 +119,7 @@ SCHEMA_TABLES = (
     "CREATE TABLE IF NOT EXISTS tr_trust_event",
     "CREATE UNIQUE INDEX IF NOT EXISTS tr_trust_event_adverse_dedup",
     "CREATE UNIQUE INDEX IF NOT EXISTS tr_trust_event_payment_dedup",
+    "CREATE TABLE IF NOT EXISTS tr_trust_inbox",
     "CREATE TABLE IF NOT EXISTS tr_key_limit",
     # Deferred settlement. The cap's whole claim to being a real bound is the
     # predicate on its UPDATE and the rowcount that reads it, and the outbox's

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -612,6 +612,8 @@ class _FakeTransaction:
         DML can't see mutations; mixing is rejected in execute_update). Records
         the read version on first read for conflict detection."""
         for op in reversed(self.pending_writes):
+            if op[0] == "delete_typed" and op[1] == table and op[2] == pk:
+                return None
             if op[0] in ("insert_typed_dml", "update_typed") and op[1] == table and op[2] == pk:
                 return dict(op[3])
         return self._pinned_read(
@@ -853,6 +855,152 @@ class _FakeTransaction:
                 raise FakeAlreadyExists(f"tr_trust_event/{pk}")
             record = dict(p)
             self.pending_writes.append(("insert_typed_dml", "tr_trust_event", pk, record))
+            return 1
+        if sql.startswith("INSERT INTO tr_trust_inbox"):
+            pk = (p["provider"], p["adverse_ref"])
+            if self._typed_current("tr_trust_inbox", pk) is not None:
+                return 0
+            self.pending_writes.append(
+                ("insert_typed_dml", "tr_trust_inbox", pk, dict(p))
+            )
+            return 1
+        if sql.startswith("DELETE FROM tr_trust_inbox"):
+            pk = (p["provider"], p["adverse_ref"])
+            if self._typed_current("tr_trust_inbox", pk) is None:
+                return 0
+            self.pending_writes.append(("delete_typed", "tr_trust_inbox", pk))
+            return 1
+        if sql.startswith("UPDATE tr_trust_event SET amount_micro=@amount_micro"):
+            pk = (p["workspace_id"], p["event_id"])
+            rec = self._typed_current("tr_trust_event", pk)
+            if (
+                rec is None
+                or rec.get("provider") != p["provider"]
+                or rec.get("adverse_ref") != p["adverse_ref"]
+            ):
+                return 0
+            new = dict(
+                rec,
+                amount_micro=p["amount_micro"],
+                occurred_at=p["occurred_at"],
+                recorded_at=p["recorded_at"],
+                provider_subtype=p["provider_subtype"],
+                lifecycle_status=p["lifecycle_status"],
+                provider_ordering_watermark=p["provider_ordering_watermark"],
+            )
+            self.pending_writes.append(("update_typed", "tr_trust_event", pk, new))
+            return 1
+        if sql.startswith("UPDATE tr_trust_event SET recovered_micro=recovered_micro+"):
+            pk = (p["workspace_id"], p["event_id"])
+            rec = self._typed_current("tr_trust_event", pk)
+            if rec is None or int(rec.get("unrecovered_micro") or 0) < p["amount"]:
+                return 0
+            remaining = int(rec.get("unrecovered_micro") or 0) - p["amount"]
+            new = dict(
+                rec,
+                recovered_micro=int(rec.get("recovered_micro") or 0) + p["amount"],
+                unrecovered_micro=remaining,
+                debit_status="debited" if remaining == 0 else "partial",
+            )
+            self.pending_writes.append(("update_typed", "tr_trust_event", pk, new))
+            return 1
+        if sql.startswith("UPDATE tr_trust_event SET recovered_micro=@recovered_micro"):
+            pk = (p["workspace_id"], p["event_id"])
+            rec = self._typed_current("tr_trust_event", pk)
+            if rec is None or rec.get("kind") != "payment":
+                return 0
+            new = dict(
+                rec,
+                recovered_micro=p["recovered_micro"],
+                unrecovered_micro=p["unrecovered_micro"],
+                recovery_target=p["recovery_target"],
+                cumulative_refunded=p["cumulative_refunded"],
+                debit_status=p["debit_status"],
+            )
+            self.pending_writes.append(("update_typed", "tr_trust_event", pk, new))
+            return 1
+        if sql.startswith("UPDATE tr_trust_event SET recovery_target=@recovery_target"):
+            pk = (p["workspace_id"], p["event_id"])
+            rec = self._typed_current("tr_trust_event", pk)
+            if rec is None or rec.get("kind") != p["kind"]:
+                return 0
+            new = dict(
+                rec,
+                recovery_target=p["recovery_target"],
+                cumulative_refunded=p["cumulative_refunded"],
+                debit_status=p["debit_status"],
+                unrecovered_micro=p["unrecovered_micro"],
+            )
+            self.pending_writes.append(("update_typed", "tr_trust_event", pk, new))
+            return 1
+        if sql.startswith("UPDATE tr_credit_balance SET trust_latched_at=COALESCE"):
+            updated = 0
+            for pk in self.db.typed.get("tr_credit_balance", {}):
+                if pk[0] != p["pk"] or not 0 <= int(pk[1]) < int(p["shard_count"]):
+                    continue
+                rec = self._typed_current("tr_credit_balance", pk)
+                if rec is None:
+                    continue
+                new = dict(
+                    rec,
+                    trust_latched_at=rec.get("trust_latched_at") or p["now"],
+                    updated_at=p["now"],
+                )
+                self.pending_writes.append(("update_typed", "tr_credit_balance", pk, new))
+                updated += 1
+            return updated
+        if sql.startswith("UPDATE tr_credit_balance SET billing_pause_causes=@causes"):
+            updated = 0
+            for pk in self.db.typed.get("tr_credit_balance", {}):
+                if pk[0] != p["pk"] or not 0 <= int(pk[1]) < int(p["shard_count"]):
+                    continue
+                rec = self._typed_current("tr_credit_balance", pk)
+                if rec is None:
+                    continue
+                new = dict(
+                    rec,
+                    billing_pause_causes=list(p["causes"]),
+                    pause_epoch=int(rec.get("pause_epoch") or 0) + 1,
+                    updated_at=p["now"],
+                )
+                self.pending_writes.append(("update_typed", "tr_credit_balance", pk, new))
+                updated += 1
+            return updated
+        if sql.startswith("UPDATE tr_credit_balance SET total_credits=total_credits-@amount"):
+            pk = (p["ws"], p["shard"])
+            rec = self._typed_current("tr_credit_balance", pk)
+            available = (
+                int(rec["total_credits"]) - int(rec["total_usage"]) - int(rec["reserved"])
+                if rec is not None
+                else -1
+            )
+            if rec is None or available < p["amount"]:
+                return 0
+            new = dict(rec, total_credits=rec["total_credits"] - p["amount"])
+            if "now" in p:
+                new["updated_at"] = p["now"]
+            self.pending_writes.append(("update_typed", "tr_credit_balance", pk, new))
+            return 1
+        if (
+            sql.startswith("UPDATE tr_entities SET body=TO_JSON_STRING(JSON_SET")
+            and "'$.billing_paused'" in sql
+        ):
+            rec = self._entity_current("workspace", p["workspace_id"])
+            if rec is None:
+                return 0
+            body = json.loads(rec["body"])
+            body["billing_paused"] = p["paused"]
+            body["billing_pause_causes"] = json.loads(p["causes_json"])
+            body["billing_pause_reason"] = p["reason"]
+            self.pending_writes.append(
+                (
+                    "update_entity_dml",
+                    "workspace",
+                    p["workspace_id"],
+                    json.dumps(body, separators=(",", ":"), sort_keys=True),
+                    p["now"],
+                )
+            )
             return 1
         if "UPDATE tr_credit_balance SET reserved = reserved - @hold" in sql:
             _require_pred(
@@ -3681,9 +3829,81 @@ def _execute_sql(
             column.strip()
             for column in sql.split("SELECT", 1)[1].split("FROM", 1)[0].split(",")
         ]
-        rows = db.typed.get("tr_trust_event", {}).values()
+        keys = set(db.typed.get("tr_trust_event", {}))
+        if txn is not None:
+            keys.update(
+                op[2]
+                for op in txn.pending_writes
+                if op[0] in {"insert_typed_dml", "update_typed"}
+                and op[1] == "tr_trust_event"
+            )
+        rows = [
+            txn._typed_current("tr_trust_event", pk)
+            if txn is not None
+            else db.typed.get("tr_trust_event", {}).get(pk)
+            for pk in keys
+        ]
+        rows = [row for row in rows if row is not None]
         if "pk" in params:
             rows = [row for row in rows if row.get("workspace_id") == params["pk"]]
+        if "workspace_id" in params:
+            rows = [
+                row for row in rows if row.get("workspace_id") == params["workspace_id"]
+            ]
+        if "provider" in params:
+            rows = [row for row in rows if row.get("provider") == params["provider"]]
+        if "original_payment_ref" in params:
+            rows = [
+                row
+                for row in rows
+                if row.get("original_payment_ref") == params["original_payment_ref"]
+            ]
+        if "adverse_ref" in params:
+            rows = [
+                row for row in rows if row.get("adverse_ref") == params["adverse_ref"]
+            ]
+        if "kind='payment'" in sql:
+            rows = [row for row in rows if row.get("kind") == "payment"]
+        if "kind!='payment'" in sql:
+            rows = [row for row in rows if row.get("kind") != "payment"]
+        if "unrecovered_micro>0" in sql:
+            rows = [row for row in rows if int(row.get("unrecovered_micro") or 0) > 0]
+        if "ORDER BY occurred_at, event_id" in sql:
+            rows.sort(key=lambda row: (row.get("occurred_at"), row.get("event_id")))
+        if cols == ["COALESCE(SUM(unrecovered_micro)", "0)"]:
+            return [[sum(int(row.get("unrecovered_micro") or 0) for row in rows)]]
+        return [[row.get(column) for column in cols] for row in rows]
+    if "FROM tr_trust_inbox" in sql:
+        keys = set(db.typed.get("tr_trust_inbox", {}))
+        if txn is not None:
+            keys.update(
+                op[2]
+                for op in txn.pending_writes
+                if op[0] in {"insert_typed_dml", "update_typed", "delete_typed"}
+                and op[1] == "tr_trust_inbox"
+            )
+        rows = [
+            txn._typed_current("tr_trust_inbox", pk)
+            if txn is not None
+            else db.typed.get("tr_trust_inbox", {}).get(pk)
+            for pk in keys
+        ]
+        rows = [row for row in rows if row is not None]
+        if "provider" in params:
+            rows = [row for row in rows if row.get("provider") == params["provider"]]
+        if "older_than" in params:
+            rows = [row for row in rows if row.get("received_at") < params["older_than"]]
+        rows.sort(
+            key=lambda row: (
+                row.get("received_at"),
+                row.get("provider"),
+                row.get("adverse_ref"),
+            )
+        )
+        cols = [
+            column.strip()
+            for column in sql.split("SELECT", 1)[1].split("FROM", 1)[0].split(",")
+        ]
         return [[row.get(column) for column in cols] for row in rows]
     # Typed counter tables: full scan (Step 2 reconcile) OR a single-row read by
     # pk (the typed_balance overlay uses WHERE <pk_col>=@pk AND shard=0).

--- a/tests/test_trust_recovery_slice1b.py
+++ b/tests/test_trust_recovery_slice1b.py
@@ -1,0 +1,480 @@
+from __future__ import annotations
+
+import datetime as dt
+import threading
+from pathlib import Path
+from typing import Any
+
+from tests.fakes.postgres import postgres_store_on, sqlite_postgres_conn
+from tests.fakes.spanner import make_fake_store
+from trusted_router.services import trust_recovery
+from trusted_router.storage import STORE, InMemoryStore
+from trusted_router.storage_gcp_counter_dml import release_credit
+from trusted_router.storage_models import AdverseTrustEvent, CreditProvenance
+
+NOW = dt.datetime(2026, 9, 3, 12, tzinfo=dt.UTC)
+ROOT = Path(__file__).parents[1]
+
+
+def _adverse(
+    *,
+    adverse_ref: str = "re_1",
+    kind: str = "refund",
+    status: str = "succeeded",
+    amount: int = 600,
+    watermark: str = "00000000000000000001:evt_1",
+    provider: str = "stripe",
+) -> AdverseTrustEvent:
+    return AdverseTrustEvent(
+        event_id=f"evt:{adverse_ref}",
+        provider=provider,
+        kind=kind,
+        adverse_ref=adverse_ref,
+        original_payment_ref="pi_recovery",
+        amount_micro=amount,
+        provider_subtype=f"charge.{kind}.updated",
+        lifecycle_status=status,
+        occurred_at=NOW,
+        provider_ordering_watermark=watermark,
+        payload="{}",
+    )
+
+
+def _store_with_payment(
+    *, credited: int = 1_000, charged: int = 1_200
+) -> tuple[Any, Any, str]:
+    store, database, _ = make_fake_store()
+    workspace = store.create_workspace("owner", "recovery", trial_credit_microdollars=0)
+    assert store.credit_workspace_typed_direct(
+        workspace.id,
+        credited,
+        "evt_payment",
+        provenance=CreditProvenance("checkout", "stripe", "pi_recovery", NOW),
+        payment_amount_microdollars=charged,
+        currency="usd",
+    )
+    return store, database, workspace.id
+
+
+def _payment(database: Any, workspace_id: str) -> dict[str, Any]:
+    return database.typed["tr_trust_event"][(workspace_id, "evt_payment")]
+
+
+def _balance(database: Any, workspace_id: str) -> int:
+    return sum(
+        int(row["total_credits"])
+        for (owner, _shard), row in database.typed["tr_credit_balance"].items()
+        if owner == workspace_id
+    )
+
+
+def test_refund_recovers_principal_pro_rata_not_fee_inclusive_charge() -> None:
+    store, database, workspace_id = _store_with_payment()
+
+    result = store.record_adverse_trust_event(_adverse())
+
+    assert result.outcome == "applied"
+    assert result.recovery_target == 500
+    assert (result.recovered_micro, result.unrecovered_micro) == (500, 0)
+    assert _balance(database, workspace_id) == 500
+    payment = _payment(database, workspace_id)
+    assert payment["recovery_target"] == 500
+    assert payment["recovery_target"] == (
+        payment["recovered_micro"] + payment["unrecovered_micro"]
+    )
+    shards = [
+        row
+        for (owner, _), row in database.typed["tr_credit_balance"].items()
+        if owner == workspace_id
+    ]
+    assert all(row["trust_latched_at"] is not None for row in shards)
+    assert all(row["billing_pause_causes"] == [] for row in shards)
+
+
+def test_partial_refunds_are_order_independent_and_replay_is_a_noop() -> None:
+    store, database, workspace_id = _store_with_payment(credited=900, charged=1_000)
+    first = _adverse(adverse_ref="re_a", amount=200, watermark="01:a")
+    second = _adverse(adverse_ref="re_b", amount=300, watermark="02:b")
+
+    assert store.record_adverse_trust_event(second).recovery_target == 270
+    assert store.record_adverse_trust_event(first).recovery_target == 450
+    before = _balance(database, workspace_id)
+    replay = store.record_adverse_trust_event(first)
+
+    assert replay.outcome == "replay"
+    assert _balance(database, workspace_id) == before == 450
+    assert _payment(database, workspace_id)["cumulative_refunded"] == 500
+
+
+def test_dispute_then_refund_reversal_keeps_full_claim_until_dispute_won() -> None:
+    store, database, workspace_id = _store_with_payment()
+    refund = _adverse(amount=600, watermark="01:refund")
+    dispute = _adverse(
+        adverse_ref="dp_1",
+        kind="dispute",
+        amount=1_200,
+        watermark="02:dispute",
+    )
+
+    assert store.record_adverse_trust_event(refund).recovery_target == 500
+    assert store.record_adverse_trust_event(dispute).recovery_target == 1_000
+    reversed_refund = _adverse(
+        status="reversed", amount=600, watermark="03:refund-reversed"
+    )
+    assert store.record_adverse_trust_event(reversed_refund).recovery_target == 1_000
+    won = _adverse(
+        adverse_ref="dp_1",
+        kind="dispute",
+        status="won",
+        amount=1_200,
+        watermark="04:won",
+    )
+    result = store.record_adverse_trust_event(won)
+
+    assert result.recovery_target == 0
+    assert (result.recovered_micro, result.unrecovered_micro) == (0, 0)
+    assert _balance(database, workspace_id) == 1_000
+
+
+def test_multi_shard_debit_takes_maximum_safe_and_pauses_for_remainder() -> None:
+    store, database, workspace_id = _store_with_payment()
+    shards = {
+        shard: row
+        for (owner, shard), row in database.typed["tr_credit_balance"].items()
+        if owner == workspace_id
+    }
+    for row in shards.values():
+        row["total_usage"] = row["total_credits"]
+    shards[0]["total_usage"] -= 100
+    shards[1]["total_usage"] -= 75
+
+    result = store.record_adverse_trust_event(
+        _adverse(kind="dispute", adverse_ref="dp_partial", amount=1_200)
+    )
+
+    assert (result.recovery_target, result.recovered_micro, result.unrecovered_micro) == (
+        1_000,
+        175,
+        825,
+    )
+    committed_shards = [
+        row
+        for (owner, _), row in database.typed["tr_credit_balance"].items()
+        if owner == workspace_id
+    ]
+    assert all(
+        row["billing_pause_causes"] == ["principal_recovery"]
+        and row["pause_epoch"] == 1
+        for row in committed_shards
+    )
+    assert store.get_workspace(workspace_id).billing_paused is True
+
+
+def test_later_topup_absorbs_oldest_debt_and_clears_only_recovery_cause() -> None:
+    store, database, workspace_id = _store_with_payment(credited=1_000, charged=1_000)
+    for (owner, _), row in database.typed["tr_credit_balance"].items():
+        if owner == workspace_id:
+            row["total_usage"] = row["total_credits"]
+            row["billing_pause_causes"] = ["migration"]
+    workspace = store.get_workspace(workspace_id)
+    workspace.billing_pause_causes = ["migration"]
+    workspace.billing_paused = True
+    store._write_entity("workspace", workspace_id, workspace)
+    result = store.record_adverse_trust_event(
+        _adverse(kind="dispute", adverse_ref="dp_debt", amount=1_000)
+    )
+    assert result.unrecovered_micro == 1_000
+
+    assert store.credit_workspace_typed_direct(
+        workspace_id,
+        1_200,
+        "evt_later_payment",
+        provenance=CreditProvenance("checkout", "stripe", "pi_later", NOW),
+        payment_amount_microdollars=1_200_000,
+        currency="usd",
+    )
+
+    assert _payment(database, workspace_id)["unrecovered_micro"] == 0
+    assert _balance(database, workspace_id) == 1_200
+    assert all(
+        row["billing_pause_causes"] == ["migration"]
+        for (owner, _), row in database.typed["tr_credit_balance"].items()
+        if owner == workspace_id
+    )
+    assert store.get_workspace(workspace_id).billing_pause_causes == ["migration"]
+
+
+def test_inbox_before_payment_drains_in_payment_transaction() -> None:
+    store, database, _ = make_fake_store()
+    workspace = store.create_workspace("owner", "inbox", trial_credit_microdollars=0)
+    adverse = _adverse(amount=600)
+    assert store.record_adverse_trust_event(adverse).outcome == "inbox"
+    assert ("stripe", "re_1") in database.typed["tr_trust_inbox"]
+
+    assert store.credit_workspace_typed_direct(
+        workspace.id,
+        1_000_000,
+        "evt_payment",
+        provenance=CreditProvenance("checkout", "stripe", "pi_recovery", NOW),
+        payment_amount_microdollars=1_200_000,
+        currency="usd",
+    )
+
+    assert ("stripe", "re_1") not in database.typed["tr_trust_inbox"]
+    assert _payment(database, workspace.id)["recovery_target"] == 500
+    payment_version = database.typed_versions[
+        ("tr_trust_event", (workspace.id, "evt_payment"))
+    ]
+    assert database.typed_versions[
+        ("tr_trust_event", (workspace.id, adverse.event_id))
+    ] == payment_version
+
+
+def test_stale_and_illegal_transitions_apply_no_money() -> None:
+    store, database, workspace_id = _store_with_payment()
+    assert store.record_adverse_trust_event(_adverse(watermark="10:new")).outcome == "applied"
+    before = (_balance(database, workspace_id), dict(_payment(database, workspace_id)))
+
+    stale = store.record_adverse_trust_event(
+        _adverse(status="reversed", watermark="09:old")
+    )
+    illegal = store.record_adverse_trust_event(
+        _adverse(status="pending", watermark="11:later")
+    )
+
+    assert (stale.outcome, illegal.outcome) == ("stale", "illegal")
+    assert (_balance(database, workspace_id), _payment(database, workspace_id)) == before
+
+
+def test_concurrent_replay_debits_once() -> None:
+    store, database, workspace_id = _store_with_payment()
+    database._ready_barrier = threading.Barrier(2)
+    results: list[str] = []
+
+    def apply() -> None:
+        results.append(store.record_adverse_trust_event(_adverse()).outcome)
+
+    first = threading.Thread(target=apply)
+    second = threading.Thread(target=apply)
+    first.start()
+    second.start()
+    first.join(timeout=10)
+    second.join(timeout=10)
+    database._ready_barrier = None
+
+    assert sorted(results) == ["applied", "replay"]
+    assert _balance(database, workspace_id) == 500
+
+
+def test_reservation_release_satisfies_open_recovery_claim() -> None:
+    store, database, workspace_id = _store_with_payment(credited=1_000, charged=1_000)
+    for (owner, _), row in database.typed["tr_credit_balance"].items():
+        if owner == workspace_id:
+            row["total_usage"] = row["total_credits"]
+    shard = database.typed["tr_credit_balance"][(workspace_id, 0)]
+    shard["reserved"] = 50
+    shard["total_usage"] = shard["total_credits"] - 50
+    result = store.record_adverse_trust_event(
+        _adverse(kind="dispute", adverse_ref="dp_release", amount=1_000)
+    )
+    assert result.unrecovered_micro == 1_000
+
+    count = database.run_in_transaction(
+        lambda transaction: release_credit(
+            transaction,
+            store._param_types,
+            workspace_id,
+            50,
+            0,
+            shard=0,
+        )
+    )
+
+    assert count == 1
+    assert _payment(database, workspace_id)["unrecovered_micro"] == 950
+    assert _payment(database, workspace_id)["recovered_micro"] == 50
+
+
+def test_inbox_schema_and_every_conflict_clause_have_explicit_targets() -> None:
+    ddl = (ROOT / "scripts/deploy/migrate_typed_counters.sh").read_text()
+    postgres = (ROOT / "src/trusted_router/storage_postgres_schema.sql").read_text()
+    source = (ROOT / "src/trusted_router/storage_postgres.py").read_text()
+    assert "CREATE TABLE tr_trust_inbox" in ddl
+    assert "CREATE TABLE IF NOT EXISTS tr_trust_inbox" in postgres
+    assert "PRIMARY KEY (provider, adverse_ref)" in ddl
+    assert "PRIMARY KEY (provider, adverse_ref)" in postgres
+    assert "ON CONFLICT DO NOTHING" not in source
+    assert "ON CONFLICT (provider, adverse_ref) DO NOTHING" in source
+    assert "ON CONFLICT (provider, adverse_ref, kind) DO NOTHING" in source
+
+
+def test_stripe_refund_webhook_records_recovery_before_ack(client: Any) -> None:
+    workspace = STORE.create_workspace("owner", "stripe webhook", trial_credit_microdollars=0)
+    assert STORE.credit_workspace_typed_direct(
+        workspace.id,
+        1_000_000,
+        "evt_route_payment",
+        provenance=CreditProvenance("checkout", "stripe", "pi_route", NOW),
+        payment_amount_microdollars=1_200_000,
+        currency="usd",
+    )
+
+    response = client.post(
+        "/v1/internal/stripe/webhook",
+        json={
+            "id": "evt_route_refund",
+            "created": int(NOW.timestamp()),
+            "type": "refund.updated",
+            "data": {
+                "object": {
+                    "id": "re_route",
+                    "payment_intent": "pi_route",
+                    "amount": 60,
+                    "status": "succeeded",
+                }
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"]["adverse"] == [
+        {
+            "adverse_ref": "re_route",
+            "provider": "stripe",
+            "kind": "refund",
+            "status": "succeeded",
+            "outcome": "applied",
+            "workspace_id": workspace.id,
+            "recovery_target": 500_000,
+            "unrecovered_micro": 0,
+        }
+    ]
+    assert STORE.credit_money_snapshot(workspace.id) == (500_000, 0, 0)
+
+
+def test_x402_refund_uses_same_webhook_handler_under_x402_provider(client: Any) -> None:
+    workspace = STORE.create_workspace("owner", "x402 webhook", trial_credit_microdollars=0)
+    assert STORE.credit_workspace_typed_direct(
+        workspace.id,
+        1_000_000,
+        "evt_x402_route_payment",
+        provenance=CreditProvenance("x402", "x402", "pi_x402_route", NOW),
+        payment_amount_microdollars=1_000_000,
+        currency="usd",
+    )
+
+    response = client.post(
+        "/v1/internal/stripe/webhook",
+        json={
+            "id": "evt_x402_route_refund",
+            "created": int(NOW.timestamp()),
+            "type": "refund.created",
+            "data": {
+                "object": {
+                    "id": "re_x402_route",
+                    "payment_intent": "pi_x402_route",
+                    "amount": 25,
+                    "status": "succeeded",
+                    "metadata": {"payment_method": "x402"},
+                }
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    adverse = response.json()["data"]["adverse"][0]
+    assert (adverse["provider"], adverse["recovery_target"], adverse["outcome"]) == (
+        "x402",
+        250_000,
+        "applied",
+    )
+    assert STORE.credit_money_snapshot(workspace.id) == (750_000, 0, 0)
+
+
+def test_stripe_dispute_webhook_claims_all_then_won_restores(client: Any) -> None:
+    workspace = STORE.create_workspace("owner", "dispute webhook", trial_credit_microdollars=0)
+    assert STORE.credit_workspace_typed_direct(
+        workspace.id,
+        1_000_000,
+        "evt_dispute_payment",
+        provenance=CreditProvenance("checkout", "stripe", "pi_dispute_route", NOW),
+        payment_amount_microdollars=1_200_000,
+        currency="usd",
+    )
+    body = {
+        "id": "evt_dispute_created",
+        "created": int(NOW.timestamp()),
+        "type": "charge.dispute.created",
+        "data": {
+            "object": {
+                "id": "dp_route",
+                "payment_intent": "pi_dispute_route",
+                "amount": 120,
+                "status": "needs_response",
+            }
+        },
+    }
+    created = client.post("/v1/internal/stripe/webhook", json=body)
+    assert created.status_code == 200
+    assert created.json()["data"]["adverse"][0]["recovery_target"] == 1_000_000
+    assert STORE.credit_money_snapshot(workspace.id) == (0, 0, 0)
+
+    body["id"] = "evt_dispute_won"
+    body["created"] += 1
+    body["type"] = "charge.dispute.closed"
+    body["data"]["object"]["status"] = "won"
+    won = client.post("/v1/internal/stripe/webhook", json=body)
+
+    assert won.status_code == 200
+    assert won.json()["data"]["adverse"][0]["recovery_target"] == 0
+    assert STORE.credit_money_snapshot(workspace.id) == (1_000_000, 0, 0)
+
+
+def test_inbox_sweeper_alerts_after_provider_consistency_delay(monkeypatch: Any) -> None:
+    store = InMemoryStore()
+    assert store.record_adverse_trust_event(_adverse()).outcome == "inbox"
+    row = store.trust_inbox[("stripe", "re_1")]
+    store.trust_inbox[("stripe", "re_1")] = type(row)(
+        row.provider,
+        row.adverse_ref,
+        row.payload,
+        NOW - dt.timedelta(minutes=16),
+    )
+    calls: list[tuple[str, list[str], dict[str, str]]] = []
+    monkeypatch.setattr(
+        trust_recovery,
+        "ops_alert",
+        lambda message, *, fingerprint, tags: calls.append(
+            (message, fingerprint, tags)
+        ),
+    )
+
+    assert trust_recovery.alert_stale_trust_inbox(store, now=NOW) == 1
+    assert calls[0][0].startswith("trust.inbox_stale provider=stripe adverse_ref=re_1")
+
+
+def test_postgres_adverse_recovery_uses_explicit_dedup_key() -> None:
+    conn = sqlite_postgres_conn()
+    store = postgres_store_on(conn)
+    workspace = store.create_workspace(
+        "owner", "postgres recovery", trial_credit_microdollars=0
+    )
+    assert store.credit_workspace_typed_direct(
+        workspace.id,
+        1_000,
+        "evt_pg_payment",
+        provenance=CreditProvenance("checkout", "stripe", "pi_recovery", NOW),
+        payment_amount_microdollars=1_200,
+        currency="usd",
+    )
+
+    applied = store.record_adverse_trust_event(_adverse())
+    replay = store.record_adverse_trust_event(_adverse())
+
+    assert (applied.outcome, applied.recovery_target) == ("applied", 500)
+    assert replay.outcome == "replay"
+    balance = conn.execute(
+        "SELECT SUM(total_credits) FROM tr_credit_balance WHERE workspace_id = %s",
+        (workspace.id,),
+    ).fetchone()
+    assert balance == (500,)


### PR DESCRIPTION
Slice 1b′ of trust-tier PR 1 (spend-lease design record, decisions 75–76 converged at v83): adverse facts and principal recovery for Stripe and x402. Inert: `TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED` stays pinned false and the mint guard from slice 1a is untouched; with the flag off the slice-1a goldens still pass byte-for-byte.

- **Stripe refund and dispute handlers** (new event families on the existing Stripe webhook route) and x402 refunds through the same handler under provider `x402`, resolving the workspace through the payment fact's PaymentIntent. Each handler records the adverse fact with its provider subtype and lifecycle status keyed by `(provider, adverse_ref)`, latches every active shard, and runs recovery in one Spanner transaction before the webhook is acknowledged; replays are no-ops, status changes follow the pinned transition graph, and stale or illegal transitions apply no money.
- **Order-independent recovery** as the scope pins: `recovery_target = max(floor(credited × net_refunded ÷ payment_amount), credited while any successful dispute is active)`, the invariant `recovery_target = recovered_micro + unrecovered_micro` enforced before and after every transition, won or reversed outcomes cancelling unrecovered debt before restoring at most what was recovered, deterministic allocation by `(occurred_at, event_id)`, principal-only debits through a new multi-shard debit that takes the maximum safe amount across all active shards and stamps `debit_status` with any `unrecovered_micro`.
- **Composable pause causes**: `principal_recovery` joins `billing_pause_causes` while unrecovered debt exists (with `pause_epoch` incremented), the legacy scalar stays in sync, every later top-up and release satisfies open recovery debt before crediting, and only zero remaining debt clears the cause; producers for the other causes are later slices.
- **`tr_trust_inbox`** for adverse events that arrive before their payment fact: written durably and only then acknowledged, drained in the transaction that records the payment, swept with an alert past the provider's consistency delay.
- Alerts `trust.unrecovered_principal` and `trust.inbox_stale`; every new ON CONFLICT carries an explicit target.

Reviewed by Fable on an isolated snapshot: the slice-1a and 1b′ suites, the schema and reshard suites, the spend-lease gateway and billing suites, ruff and mypy pass. Mutations that let a dispute claim only pro rata, make refunds fee-inclusive, drop the recovery pause cause, apply stale transitions, or treat every refund as pending each turn the suite red (results in the review comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
