### PR TITLE
Pin the AWS analytics freshness check to the region that runs the drain

### DIFF
--- a/clickhouse/check_fleet_analytics_freshness.py
+++ b/clickhouse/check_fleet_analytics_freshness.py
@@ -77,6 +77,7 @@ from typing import Any
 from trusted_router.operational_analytics_fleet import (
     ANALYTICS_FRESHNESS_FLEET,
     FleetAnalyticsEndpoint,
+    fleet_endpoint,
     registry_defects,
 )
 from trusted_router.operational_analytics_freshness import (
@@ -103,7 +104,18 @@ from trusted_router.operational_analytics_freshness import (
 #: Kept for the single-cloud alias in :mod:`clickhouse.check_aws_analytics_freshness`.
 #: The AWS-EU control plane; not trustedrouter.com, which is the GCP deployment
 #: and would answer this question about the wrong cloud.
-DEFAULT_STATUS_URL = "https://gchircrcif.eu-west-3.awsapprunner.com/status.json"
+#:
+#: DERIVED from the registry rather than written out again. It was a second
+#: copy of the same URL until 2026-09-04, and when the first copy moved off the
+#: retired App Runner hostname this one stayed behind — two checkers, two
+#: clouds' worth of confidence, one of them reading a name that no longer
+#: resolved. A constant that must equal another constant should be that other
+#: constant.
+_AWS_ENDPOINT = fleet_endpoint("aws")
+assert _AWS_ENDPOINT is not None and _AWS_ENDPOINT.status_url, (
+    "the fleet registry must carry a checkable AWS endpoint"
+)
+DEFAULT_STATUS_URL = _AWS_ENDPOINT.status_url
 
 #: A direct sink has no durable, unbounded backlog: its buffer drops oldest
 #: rows. Delivery age is therefore its primary liveness signal and must page

--- a/src/trusted_router/operational_analytics_fleet.py
+++ b/src/trusted_router/operational_analytics_fleet.py
@@ -150,15 +150,23 @@ class FleetAnalyticsEndpoint:
 ANALYTICS_FRESHNESS_FLEET: tuple[FleetAnalyticsEndpoint, ...] = (
     FleetAnalyticsEndpoint(
         cloud="aws",
-        status_url="https://gchircrcif.eu-west-3.awsapprunner.com/status.json",
+        status_url="https://aws-euw3.trustedrouter.com/status.json",
         expected_backend=BACKEND_POSTGRES,
         note=(
-            "The tr-eu App Runner control plane -- the deployment that holds the "
-            "Aurora DSQL connection this signal is read through, and the one whose "
-            "drain was missing for fifteen days. Deliberately NOT "
-            "aws.trustedrouter.com: that vanity name fronts the Fargate control "
-            "plane through Global Accelerator, and pointing the check at the wrong "
-            "AWS front end would answer a question nobody asked."
+            "The eu-west-3 Fargate control plane, REGION-PINNED. It holds the "
+            "Aurora DSQL connection this signal is read through, and it is the "
+            "deployment whose drain was missing for fifteen days. This was the "
+            "tr-eu App Runner hostname until that service was retired on "
+            "2026-09-03, at which point the check simply failed DNS. "
+            "Deliberately NOT aws.trustedrouter.com, and the reason is now "
+            "sharper than 'wrong front end': that vanity name is Global "
+            "Accelerator anycast across BOTH EU regions, and the two are not "
+            "interchangeable for this question. eu-west-3 runs the outbox; "
+            "eu-west-1 has TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=false and "
+            "correctly publishes not_configured. Pointed at the anycast name, "
+            "the check reads whichever region GA happens to pick, so a healthy "
+            "drain reports 'not configured' on roughly half of all runs -- an "
+            "alert that fires on routing rather than on the drain."
         ),
     ),
     FleetAnalyticsEndpoint(

--- a/tests/test_analytics_freshness_registry.py
+++ b/tests/test_analytics_freshness_registry.py
@@ -475,7 +475,7 @@ def test_two_clouds_sharing_one_status_url_is_a_defect() -> None:
     Postgres, so whichever plane answers publishes the backend BOTH entries
     expect, and the run reports two clouds checked after reading one.
     """
-    url = "https://gchircrcif.eu-west-3.awsapprunner.com/status.json"
+    url = "https://aws-euw3.trustedrouter.com/status.json"
     defects = registry_defects(
         ["aws", "azure"],
         registry=[
@@ -691,11 +691,24 @@ def test_registry_points_at_control_planes_not_the_inference_plane() -> None:
 
 
 def test_aws_entry_is_the_deployment_that_holds_the_dsql_connection() -> None:
-    """Not aws.trustedrouter.com: that vanity name fronts the other AWS plane."""
+    """Region-pinned, because the AWS EU regions differ on exactly this signal.
+
+    aws.trustedrouter.com is Global Accelerator anycast over eu-west-3 and
+    eu-west-1. Only eu-west-3 runs the operational-analytics outbox; eu-west-1
+    has it disabled and correctly publishes ``not_configured``. A check on the
+    anycast name therefore reads a different deployment run to run and reports
+    a healthy drain as unconfigured whenever GA picks Ireland.
+    """
     entry = fleet_endpoint("aws")
 
     assert entry is not None
-    assert entry.status_url == "https://gchircrcif.eu-west-3.awsapprunner.com/status.json"
+    assert entry.status_url == "https://aws-euw3.trustedrouter.com/status.json"
+    # The region that holds the drain has to be named in the URL, not resolved
+    # to at request time by something outside this repo's control.
+    assert "euw3" in entry.status_url
+    # The retired App Runner host: pinning this again would fail DNS, which is
+    # how this check broke on 2026-09-03.
+    assert "awsapprunner.com" not in entry.status_url
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cloud_rollout_completeness.py
+++ b/tests/test_cloud_rollout_completeness.py
@@ -157,20 +157,26 @@ def test_the_cloud_list_is_the_fleet_module_s_and_not_a_second_copy() -> None:
 
 
 def test_the_gate_asks_the_front_end_that_holds_the_dsql_connection() -> None:
-    """The AWS URL is the App Runner plane, not the vanity hostname.
+    """The AWS URL names one region, not the anycast hostname.
 
     This is the concrete reason stage (a) reads the fleet registry instead of
-    anything else. `aws.trustedrouter.com` fronts the Fargate control plane
-    through Global Accelerator; the deployment that holds the Aurora DSQL
-    connection — and whose drain was missing for fifteen days — is the tr-eu App
-    Runner service. A gate pointed at the wrong AWS front end would have been
-    green throughout the outage.
+    anything else. The deployment that holds the Aurora DSQL connection — and
+    whose drain was missing for fifteen days — is the eu-west-3 control plane.
+    `aws.trustedrouter.com` is Global Accelerator anycast over eu-west-3 and
+    eu-west-1, and only eu-west-3 runs the operational-analytics outbox, so a
+    gate pointed at the vanity name reads a different deployment run to run
+    and calls a healthy drain unconfigured whenever GA picks Ireland.
+
+    It was the tr-eu App Runner hostname until that service was retired on
+    2026-09-03; the gate then failed DNS rather than reading anything at all.
     """
     aws = crc.freshness_registry()["aws"]
     entry = fleet.fleet_endpoint("aws")
     assert entry is not None and entry.status_url == aws
+    # The bare vanity name is anycast across both EU regions and only one of
+    # them runs the outbox, so the URL must name its region.
     assert "aws.trustedrouter.com" not in aws
-    assert "awsapprunner.com" in aws
+    assert "aws-euw3.trustedrouter.com" in aws
 
 
 def test_a_new_cloud_fails_ci_until_it_is_checkable(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
The fleet freshness alert reported an AWS DNS failure. It is accurate: the AWS entry in `ANALYTICS_FRESHNESS_FLEET` pointed at the `tr-eu` App Runner hostname, and that service was retired on 2026-09-03, so the check has been resolving nothing rather than reading a signal.

The obvious replacement is wrong, for a sharper reason than the old note gave. `aws.trustedrouter.com` is Global Accelerator anycast over both EU regions, and the two differ on exactly this signal:

| Endpoint | analytics | backend | drain lag |
|---|---|---|---|
| aws-euw3.trustedrouter.com | available | postgres | 0.0 s |
| aws-euw1.trustedrouter.com | `not_configured` | — | — |
| aws.trustedrouter.com (anycast) | whichever of the two GA picks | | |

eu-west-3 runs the operational-analytics outbox; eu-west-1 has `TR_OPERATIONAL_ANALYTICS_OUTBOX_ENABLED=false` and correctly publishes `not_configured`. Pointed at the vanity name, the check reads a different deployment run to run and calls a healthy drain unconfigured whenever Ireland answers. That is an alert that fires on routing rather than on the drain.

Pinned to the region-pinned hostname instead.

**The drain itself is healthy.** Verified live while making this change: eu-west-3 reports `available`, backend postgres, drain lag 0.0 s, with an advancing timestamp; Azure and GCP likewise advance. The staleness in the alert was the checker being unable to read a working signal, not a stalled pipeline.

Both guardrail tests keep their original intent, gain an explicit region assertion, and lose the assertion that pinned the dead host. Each was mutation-checked twice: reverting to the App Runner URL fails both, and substituting the anycast name fails both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)