### PR TITLE
trust tiers, slice 1c: owner inventory, atomic identity demotion, overrides, operator routes (inert)

### DIFF
--- a/scripts/backfill_owner_inventory.py
+++ b/scripts/backfill_owner_inventory.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Rebuild both directions of the owner inventory and publish its arm marker."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from typing import Protocol, cast
+
+from trusted_router.config import get_settings
+from trusted_router.storage import create_store
+
+log = logging.getLogger(__name__)
+
+
+class _OwnerInventoryStore(Protocol):
+    def backfill_owner_inventory(self, *, source_version: str, environment: str) -> int: ...
+
+
+def run(
+    store: _OwnerInventoryStore, *, source_version: str, environment: str
+) -> int:
+    changed = store.backfill_owner_inventory(
+        source_version=source_version, environment=environment
+    )
+    log.info(
+        "trust.owner_inventory_backfill_complete changed=%d source_version=%s environment=%s",
+        changed,
+        source_version,
+        environment,
+    )
+    return changed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source-version", required=True)
+    parser.add_argument("--environment")
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO)
+    settings = get_settings()
+    run(
+        cast(_OwnerInventoryStore, create_store(settings)),
+        source_version=args.source_version,
+        environment=args.environment or settings.environment,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deploy/internal_surface.sh
+++ b/scripts/deploy/internal_surface.sh
@@ -404,6 +404,7 @@ ENV_VARS=(
   "TR_TRUST_GCP_RELEASE_FALLBACK_URLS=$(legacy_env_required TR_TRUST_GCP_RELEASE_FALLBACK_URLS)"
   "TR_TRUST_AWS_RELEASE_URL=$(legacy_env_required TR_TRUST_AWS_RELEASE_URL)"
   "TR_TRUST_AZURE_RELEASE_URL=$(legacy_env_required TR_TRUST_AZURE_RELEASE_URL)"
+  "TR_OPERATOR_IDENTITIES=$(legacy_env_required TR_OPERATOR_IDENTITIES)"
 )
 
 # Preserve the money-path and federation feature switches exactly. Missing
@@ -442,6 +443,7 @@ done
 SECRET_ENVS=()
 for required_secret_env in \
   TR_INTERNAL_GATEWAY_TOKEN \
+  TR_OPERATOR_TOKEN \
   TR_OBSERVER_INTERNAL_TOKEN \
   TR_SYNTHETIC_MONITOR_API_KEY \
   TR_SENTRY_DSN; do

--- a/scripts/deploy/migrate_typed_counters.sh
+++ b/scripts/deploy/migrate_typed_counters.sh
@@ -275,6 +275,53 @@ if table_exists tr_trust_inbox; then log "tr_trust_inbox exists, skip"; else
   ) PRIMARY KEY (provider, adverse_ref)"
 fi
 
+if table_exists tr_owner_workspace; then log "tr_owner_workspace exists, skip"; else
+  apply_ddl "CREATE TABLE tr_owner_workspace (
+    owner_user_id STRING(64) NOT NULL,
+    workspace_id STRING(64) NOT NULL,
+  ) PRIMARY KEY (owner_user_id, workspace_id)"
+fi
+
+if table_exists tr_trust_override; then log "tr_trust_override exists, skip"; else
+  apply_ddl "CREATE TABLE tr_trust_override (
+    workspace_id STRING(64) NOT NULL,
+    tier INT64 NOT NULL,
+    identity_bypass BOOL NOT NULL,
+    operator_identity STRING(255) NOT NULL,
+    reason STRING(500) NOT NULL,
+    set_at TIMESTAMP NOT NULL,
+    CONSTRAINT tr_trust_override_tier CHECK (tier >= 0 AND tier <= 3),
+  ) PRIMARY KEY (workspace_id)"
+fi
+
+if table_exists tr_trust_demotion_remainder; then log "tr_trust_demotion_remainder exists, skip"; else
+  apply_ddl "CREATE TABLE tr_trust_demotion_remainder (
+    owner_user_id STRING(64) NOT NULL,
+    workspace_id STRING(64) NOT NULL,
+    target_identity_ceiling INT64 NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    attempts INT64 NOT NULL DEFAULT (0),
+    last_error STRING(MAX),
+  ) PRIMARY KEY (owner_user_id, workspace_id)"
+fi
+
+if table_exists tr_trust_backfill; then log "tr_trust_backfill exists, skip"; else
+  apply_ddl "CREATE TABLE tr_trust_backfill (
+    provider STRING(32) NOT NULL,
+    account_id STRING(255) NOT NULL,
+    environment STRING(32) NOT NULL,
+    source STRING(255) NOT NULL,
+    source_version STRING(64) NOT NULL,
+    history_start TIMESTAMP NOT NULL,
+    closed_through TIMESTAMP NOT NULL,
+    consistency_delay_seconds INT64 NOT NULL,
+    unmatched_count INT64 NOT NULL,
+    semantic_mismatch_count INT64 NOT NULL,
+    completed_at TIMESTAMP,
+    CONSTRAINT tr_trust_backfill_complete CHECK (completed_at IS NULL OR (unmatched_count = 0 AND semantic_mismatch_count = 0)),
+  ) PRIMARY KEY (provider, account_id, environment)"
+fi
+
 # Historical trust-column backfill statement. It is intentionally a separate,
 # operator-run artifact rather than an automatic deploy-time DML rewrite.
 log "historical trust-column backfill: scripts/deploy/backfill_credit_balance_trust.sql"

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -90,6 +90,7 @@ SECRET_ENVS=(
   "TR_STRIPE_SECRET_KEY=trustedrouter-stripe-secret-key:latest"
   "TR_STRIPE_WEBHOOK_SECRET=trustedrouter-stripe-webhook-secret:latest"
   "TR_INTERNAL_GATEWAY_TOKEN=trustedrouter-internal-gateway-token:latest"
+  "TR_OPERATOR_TOKEN=trustedrouter-operator-token:latest"
 )
 # Retired environment bindings remain on Cloud Run until explicitly removed.
 REMOVE_SECRET_ENVS=("TR_GOOGLE_ADS_CONVERSION_FEED_PASSWORD")
@@ -532,6 +533,7 @@ fi
 ENV_VARS=(
   "TR_ENVIRONMENT=production"
   "TR_SERVICE_SURFACE=combined"
+  "TR_OPERATOR_IDENTITIES=${TR_OPERATOR_IDENTITIES:-joseph@jperla.com}"
   "TR_ALLOW_DEPLOYED_COMBINED_SURFACE=${ALLOW_DEPLOYED_COMBINED_SURFACE}"
   # The legacy backend does not yet receive a trusted, edge-overwritten client
   # identity. The #714 process-local limiter would collapse all Internet users

--- a/scripts/deploy/synthetic.sh
+++ b/scripts/deploy/synthetic.sh
@@ -52,6 +52,7 @@ if [ "$DEPLOYED_COMBINED_BRIDGE" = "true" ]; then
     "TR_STRIPE_SECRET_KEY=trustedrouter-stripe-secret-key:latest"
     "TR_STRIPE_WEBHOOK_SECRET=trustedrouter-stripe-webhook-secret:latest"
     "TR_INTERNAL_GATEWAY_TOKEN=trustedrouter-internal-gateway-token:latest"
+    "TR_OPERATOR_TOKEN=trustedrouter-operator-token:latest"
     "TR_SYNTHETIC_MONITOR_API_KEY=trustedrouter-synthetic-monitor-api-key:latest"
   )
   JOB_SECRET_FLAG="--update-secrets"
@@ -95,6 +96,7 @@ if [ "$DEPLOYED_COMBINED_BRIDGE" = "true" ]; then
   BASE_ENV_VARS+=(
     "TR_SERVICE_SURFACE=combined"
     "TR_ALLOW_DEPLOYED_COMBINED_SURFACE=true"
+    "TR_OPERATOR_IDENTITIES=${TR_OPERATOR_IDENTITIES:-joseph@jperla.com}"
     "TR_RATE_LIMIT_ENABLED=false"
   )
 else

--- a/scripts/process_trust_demotion_remainders.py
+++ b/scripts/process_trust_demotion_remainders.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Drain the alerted identity-demotion invariant fallback in bounded chunks."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from typing import Protocol, cast
+
+from trusted_router.config import get_settings
+from trusted_router.storage import create_store
+
+log = logging.getLogger(__name__)
+
+
+class _RemainderStore(Protocol):
+    def process_trust_demotion_remainders(self, *, limit: int = 25) -> int: ...
+
+
+def run(store: _RemainderStore, *, limit: int) -> int:
+    completed = store.process_trust_demotion_remainders(limit=limit)
+    if completed:
+        log.error("trust.identity_demotion_remainder_drained count=%d", completed)
+    return completed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--limit", type=int, default=25)
+    args = parser.parse_args()
+    if args.limit <= 0:
+        parser.error("--limit must be positive")
+    logging.basicConfig(level=logging.INFO)
+    run(cast(_RemainderStore, create_store(get_settings())), limit=args.limit)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -18,6 +18,11 @@ from pydantic_settings import (
     SettingsConfigDict,
 )
 
+from trusted_router.trust_ownership import (
+    TRUST_OWNER_MUTATION_BUDGET,
+    TRUST_REPLICATED_COLUMN_COUNT,
+)
+
 # Target names the synthetic monitor already assigns itself. A configured
 # entry reusing one would quietly merge two different measurements into one
 # status component, so it is rejected instead.
@@ -243,6 +248,7 @@ SERVICE_SURFACE_SECRET_OWNERS: dict[str, frozenset[str]] = {
     "attribution_cookie_key": frozenset({"public", "control"}),
     "attribution_cookie_secret": frozenset({"public", "control"}),
     "internal_gateway_token": frozenset({"internal"}),
+    "operator_token": frozenset({"internal"}),
     # Internal owns this only for synthetic/Sentry routes; its billing routes
     # still select internal_gateway_token by path.
     "observer_internal_token": frozenset({"internal", "observer"}),
@@ -289,6 +295,28 @@ SERVICE_SURFACE_SECRET_OWNERS: dict[str, frozenset[str]] = {
     "federation_settlement_inbound_tokens": frozenset({"internal"}),
     "federation_settlement_home_token": frozenset({"internal"}),
 }
+
+_OPERATOR_CREDENTIAL_PREFIXES = (
+    "internal_",
+    "observer_",
+    "synthetic_",
+    "federation_",
+)
+_OPERATOR_CREDENTIAL_SUFFIXES = ("_token", "_tokens", "_api_key")
+
+
+def operator_credential_setting_names(settings_type: type[BaseSettings]) -> frozenset[str]:
+    """Fields whose values must never share the operator credential."""
+
+    discovered = set(SERVICE_SURFACE_SECRET_OWNERS)
+    discovered.update(
+        name
+        for name in settings_type.model_fields
+        if name.startswith(_OPERATOR_CREDENTIAL_PREFIXES)
+        and name.endswith(_OPERATOR_CREDENTIAL_SUFFIXES)
+    )
+    discovered.discard("operator_token")
+    return frozenset(discovered)
 
 
 def _sensitive_setting_is_configured(field_name: str, value: object) -> bool:
@@ -1418,6 +1446,18 @@ class Settings(BaseSettings):
             raise ValueError("TR_TRUST_TIER3_MIN_PAID_MICRODOLLARS must be positive")
         if self.max_workspaces_per_owner <= 0:
             raise ValueError("TR_MAX_WORKSPACES_PER_OWNER must be positive")
+        if (
+            self.max_workspaces_per_owner * 64 * TRUST_REPLICATED_COLUMN_COUNT
+            > TRUST_OWNER_MUTATION_BUDGET
+        ):
+            raise ValueError(
+                "TR_MAX_WORKSPACES_PER_OWNER × TR_CREDIT_SHARDS_MAX × 7 "
+                "must not exceed the pinned 20000-mutation trust budget"
+            )
+        if bool(self.operator_token) != bool(self.operator_identities.strip()):
+            raise ValueError(
+                "TR_OPERATOR_TOKEN and TR_OPERATOR_IDENTITIES must both be set or both unset"
+            )
         if self.trust_reconcile_interval_seconds <= 0:
             raise ValueError("TR_TRUST_RECONCILE_INTERVAL_SECONDS must be positive")
         # The scope pins 15 minutes for Stripe/x402 and three hours for PayPal.
@@ -1525,6 +1565,21 @@ class Settings(BaseSettings):
         settlement_tokens = parse_settlement_inbound_tokens(
             self.federation_settlement_inbound_tokens
         )
+        if self.operator_token:
+            for field_name in sorted(operator_credential_setting_names(type(self))):
+                raw_value = getattr(self, field_name)
+                values: tuple[str, ...]
+                if field_name == "federation_settlement_inbound_tokens":
+                    values = tuple(settlement_tokens)
+                elif isinstance(raw_value, str):
+                    values = (raw_value,) if raw_value else ()
+                else:
+                    values = ()
+                if any(value and hmac.compare_digest(self.operator_token, value) for value in values):
+                    raise ValueError(
+                        "TR_OPERATOR_TOKEN must differ from "
+                        f"TR_{field_name.upper()}"
+                    )
         if self.federation_settlement_home_token and not self.federation_home_base_url:
             raise ValueError(
                 "TR_FEDERATION_SETTLEMENT_HOME_TOKEN is set but "
@@ -1792,6 +1847,12 @@ class Settings(BaseSettings):
             self.internal_gateway_token
         ):
             missing.append("TR_INTERNAL_GATEWAY_TOKEN")
+        if (surface == "internal" or deployed_combined_bridge) and not self.operator_token:
+            missing.append("TR_OPERATOR_TOKEN")
+        if (surface == "internal" or deployed_combined_bridge) and not (
+            self.operator_identities.strip()
+        ):
+            missing.append("TR_OPERATOR_IDENTITIES")
         if surface in {"internal", "observer"} and not self.observer_internal_token:
             missing.append("TR_OBSERVER_INTERNAL_TOKEN")
         if (surface == "control" or deployed_combined_bridge) and environment != "worker":
@@ -2093,6 +2154,14 @@ class Settings(BaseSettings):
             provider.strip().lower()
             for provider in self.trust_qualifying_providers.split(",")
             if provider.strip()
+        )
+
+    @property
+    def operator_identity_set(self) -> frozenset[str]:
+        return frozenset(
+            identity.strip()
+            for identity in self.operator_identities.split(",")
+            if identity.strip()
         )
 
     @property

--- a/src/trusted_router/routes/internal/__init__.py
+++ b/src/trusted_router/routes/internal/__init__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from . import admin as admin
 from . import adyen as adyen
 from . import broadcast_queue as broadcast_queue
 from . import chat_browser_key as chat_browser_key
@@ -44,6 +45,7 @@ def register_gateway_internal_routes(router: APIRouter) -> None:
     fetch_image.register(router)
     reconcile.register(router)
     federation.register(router)
+    admin.register(router)
 
 
 def register_observer_internal_routes(router: APIRouter) -> None:

--- a/src/trusted_router/routes/internal/_shared.py
+++ b/src/trusted_router/routes/internal/_shared.py
@@ -29,6 +29,10 @@ def internal_service_credential(
 ) -> tuple[str, str | None]:
     """Return the credential class and configured secret for an internal path."""
     normalized_path = path[3:] if path.startswith("/v1/internal/") else path
+    from trusted_router.routes.internal.admin import is_operator_route
+
+    if is_operator_route(normalized_path):
+        return "operator", settings.operator_token
     observer_path = normalized_path in _OBSERVER_INTERNAL_EXACT_PATHS or normalized_path.startswith(
         _OBSERVER_INTERNAL_PATH_PREFIXES
     )

--- a/src/trusted_router/routes/internal/admin.py
+++ b/src/trusted_router/routes/internal/admin.py
@@ -1,0 +1,134 @@
+"""Dedicated operator-only trust controls."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Request
+
+from trusted_router.auth import SettingsDep, get_authorization_bearer
+from trusted_router.errors import api_error
+from trusted_router.routes.helpers import json_body
+from trusted_router.security import constant_time_equal
+from trusted_router.storage import STORE
+from trusted_router.types import ErrorType
+
+_OPERATOR_PATH_PREFIX = "/internal/admin/workspaces/"
+_MAX_OPERATOR_TEXT = 500
+_MAX_ABUSE_REF = 255
+
+
+def _operator_identity(request: Request, settings: SettingsDep) -> str:
+    supplied = (
+        get_authorization_bearer(request)
+        or request.headers.get("x-trustedrouter-internal-token")
+        or ""
+    )
+    if not settings.operator_token or not constant_time_equal(
+        supplied, settings.operator_token
+    ):
+        raise api_error(401, "Invalid operator token", ErrorType.UNAUTHORIZED)
+    identity = request.headers.get("x-trustedrouter-operator-identity", "").strip()
+    if identity not in settings.operator_identity_set:
+        raise api_error(403, "Invalid operator identity", ErrorType.FORBIDDEN)
+    return identity
+
+
+def _required_text(
+    body: dict[str, Any], field: str, *, limit: int = _MAX_OPERATOR_TEXT
+) -> str:
+    value = body.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise api_error(400, f"{field} is required", ErrorType.BAD_REQUEST)
+    normalized = value.strip()
+    if len(normalized) > limit:
+        raise api_error(
+            400, f"{field} must be at most {limit} characters", ErrorType.BAD_REQUEST
+        )
+    return normalized
+
+
+def register(router: APIRouter) -> None:
+    @router.post("/internal/admin/workspaces/{workspace_id}/trust-override")
+    async def trust_override(
+        workspace_id: str,
+        request: Request,
+        settings: SettingsDep,
+    ) -> dict[str, Any]:
+        identity = _operator_identity(request, settings)
+        body = await json_body(request)
+        tier = body.get("tier")
+        if isinstance(tier, bool) or not isinstance(tier, int) or not 0 <= tier <= 3:
+            raise api_error(400, "tier must be an integer from 0 through 3", ErrorType.BAD_REQUEST)
+        try:
+            record = STORE.set_workspace_trust_override(
+                workspace_id,
+                tier=tier,
+                identity_bypass=bool(body.get("identity_bypass", False)),
+                operator_identity=identity,
+                reason=_required_text(body, "reason"),
+            )
+        except ValueError as exc:
+            if str(exc) == "workspace_not_found":
+                raise api_error(404, "Resource not found", ErrorType.NOT_FOUND) from exc
+            raise
+        return {
+            "data": {
+                "workspace_id": record.workspace_id,
+                "tier": record.tier,
+                "identity_bypass": record.identity_bypass,
+                "operator_identity": record.operator_identity,
+                "reason": record.reason,
+                "set_at": record.set_at.isoformat(),
+            }
+        }
+
+    @router.post("/internal/admin/workspaces/{workspace_id}/abuse")
+    async def workspace_abuse(
+        workspace_id: str,
+        request: Request,
+        settings: SettingsDep,
+    ) -> dict[str, Any]:
+        identity = _operator_identity(request, settings)
+        body = await json_body(request)
+        abuse_ref = _required_text(body, "abuse_ref", limit=_MAX_ABUSE_REF)
+        reason = _required_text(body, "reason")
+        try:
+            if body.get("action") == "clear":
+                applied = STORE.clear_workspace_abuse_pause(
+                    workspace_id,
+                    abuse_ref=abuse_ref,
+                    operator_identity=identity,
+                    reason=reason,
+                )
+                action = "clear"
+            else:
+                applied = STORE.record_workspace_abuse_and_demote(
+                    workspace_id,
+                    abuse_ref=abuse_ref,
+                    operator_identity=identity,
+                    reason=reason,
+                )
+                action = "latch"
+        except ValueError as exc:
+            if str(exc) == "workspace_not_found":
+                raise api_error(404, "Resource not found", ErrorType.NOT_FOUND) from exc
+            if str(exc) == "abuse_ref_conflict":
+                raise api_error(409, "abuse_ref is already used", ErrorType.CONFLICT) from exc
+            raise
+        return {"data": {"applied": applied, "replayed": not applied, "action": action}}
+
+
+def is_operator_route(path: str) -> bool:
+    normalized = path[3:] if path.startswith("/v1/internal/") else path
+    if not normalized.startswith(_OPERATOR_PATH_PREFIX):
+        return False
+    workspace_id, separator, action = normalized[len(_OPERATOR_PATH_PREFIX) :].partition(
+        "/"
+    )
+    return bool(
+        workspace_id
+        and separator
+        and "/" not in action
+        and action in {"trust-override", "abuse"}
+    )

--- a/src/trusted_router/routes/internal/veriff.py
+++ b/src/trusted_router/routes/internal/veriff.py
@@ -71,27 +71,23 @@ def register(router: APIRouter) -> None:
             return {"data": {"ignored": True}}
 
         event_id = f"{session_id}#{provider_status}#{code}"
-        if not STORE.record_webhook_event_once("veriff", event_id):
-            return {"data": {"replayed": True}}
-
-        user = STORE.get_user(vendor_data)
-        if user is None:
-            log.info("veriff_webhook.ignored reason=unknown_user")
-            return {"data": {"ignored": True}}
-        if session_id != user.veriff_session_id:
-            log.info("veriff_webhook.ignored reason=stale_session")
-            return {"data": {"ignored": True}}
-
         approved_name = verified_name(verification) if decision_status == "approved" else None
         reason, reason_code = decision_reason(verification)
-        STORE.set_user_identity_status(
-            user.id,
+        outcome = STORE.apply_veriff_identity_decision(
+            vendor_data,
+            event_id=event_id,
+            session_id=session_id,
             status=decision_status,
             decision_code=code,
             decision_reason=reason,
             decision_reason_code=reason_code,
             verified_name=approved_name,
         )
+        if outcome == "replayed":
+            return {"data": {"replayed": True}}
+        if outcome == "ignored":
+            log.info("veriff_webhook.ignored reason=unknown_user_or_stale_session")
+            return {"data": {"ignored": True}}
         log.info(
             "veriff_webhook.decision status=%s code=%s reason_code=%s",
             decision_status,

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -93,6 +93,7 @@ from trusted_router.storage_models import (
     SyntheticRollup,
     TrustEvent,
     TrustInboxRow,
+    TrustOverride,
     User,
     UserProvidedModel,
     VerificationToken,
@@ -114,10 +115,17 @@ from trusted_router.storage_user_models import InMemoryUserProvidedModels
 from trusted_router.storage_verification_tokens import InMemoryVerificationTokens
 from trusted_router.storage_video_jobs import InMemoryVideoJobs
 from trusted_router.storage_wallet_challenges import InMemoryWalletChallenges
+from trusted_router.trust_ownership import (
+    TRUST_OWNER_MUTATION_BUDGET,
+    TRUST_REPLICATED_COLUMN_COUNT,
+    WorkspaceOwnerLimitExceeded,
+    require_owner_trust_budget,
+)
 from trusted_router.trust_tiers import (
     adverse_event_from_payload,
     adverse_event_payload,
     adverse_transition_outcome,
+    compute_trust_tier,
     payment_or_grant_event,
     payment_recovery_target,
     validate_adverse_event,
@@ -133,8 +141,21 @@ class InMemoryStore:
     - Bigtable-like append/query metadata for generation usage.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        max_workspaces_per_owner: int = 25,
+        trust_qualifying_providers: frozenset[str] = frozenset({"stripe", "x402"}),
+        trust_tier3_min_days: int = 30,
+        trust_tier3_min_paid_microdollars: int = 50_000_000,
+    ) -> None:
         self._lock = threading.RLock()
+        self.max_workspaces_per_owner = int(max_workspaces_per_owner)
+        self.trust_qualifying_providers = trust_qualifying_providers
+        self.trust_tier3_min_days = int(trust_tier3_min_days)
+        self.trust_tier3_min_paid_microdollars = int(
+            trust_tier3_min_paid_microdollars
+        )
         self.users: dict[str, User] = {}
         self.user_ids_by_email: dict[str, str] = {}
         self.user_ids_by_wallet: dict[str, str] = {}
@@ -147,6 +168,13 @@ class InMemoryStore:
         self.stripe_events: set[str] = set()
         self.trust_events: dict[tuple[str, str], TrustEvent] = {}
         self.trust_inbox: dict[tuple[str, str], TrustInboxRow] = {}
+        self.owner_workspaces: set[tuple[str, str]] = set()
+        self.trust_overrides: dict[str, TrustOverride] = {}
+        self.trust_abuse_audits: dict[tuple[str, str], dict[str, Any]] = {}
+        self.trust_demotion_remainders: set[tuple[str, str]] = set()
+        self.trust_backfills: dict[tuple[str, str, str], dict[str, Any]] = {}
+        self.credit_trust_shards: dict[tuple[str, int], dict[str, Any]] = {}
+        self.abuse_pause_clears: set[tuple[str, str]] = set()
         self.webhook_events: set[tuple[str, str]] = set()
         self.earnings_money: dict[str, tuple[int, int]] = {}
         self.credit_movements: dict[tuple[str, str], CreditMovement] = {}
@@ -217,6 +245,15 @@ class InMemoryStore:
             self.credits.clear()
             self.credit_money.clear()
             self.stripe_events.clear()
+            self.trust_events.clear()
+            self.trust_inbox.clear()
+            self.owner_workspaces.clear()
+            self.trust_overrides.clear()
+            self.trust_abuse_audits.clear()
+            self.trust_demotion_remainders.clear()
+            self.trust_backfills.clear()
+            self.credit_trust_shards.clear()
+            self.abuse_pause_clears.clear()
             self.webhook_events.clear()
             self.earnings_money.clear()
             self.credit_movements.clear()
@@ -626,6 +663,19 @@ class InMemoryStore:
         trial_credit_microdollars: int | None = None,
     ) -> Workspace:
         with self._lock:
+            owned = sorted(
+                workspace_id
+                for owner_id, workspace_id in self.owner_workspaces
+                if owner_id == owner_user_id
+            )
+            if len(owned) >= self.max_workspaces_per_owner:
+                raise WorkspaceOwnerLimitExceeded(
+                    "owner has reached TR_MAX_WORKSPACES_PER_OWNER"
+                )
+            require_owner_trust_budget(
+                [self.credits[workspace_id].shard_count for workspace_id in owned]
+                + [1]
+            )
             workspace = Workspace(id=str(uuid.uuid4()), name=name, owner_user_id=owner_user_id)
             self.workspaces[workspace.id] = workspace
             self.members[(workspace.id, owner_user_id)] = Member(
@@ -636,6 +686,19 @@ class InMemoryStore:
             initial_total = 0 if trial_credit_microdollars is None else trial_credit_microdollars
             self.credits[workspace.id] = CreditAccount(workspace_id=workspace.id)
             self.credit_money[workspace.id] = CreditMoney(total_credits_microdollars=initial_total)
+            self.owner_workspaces.add((owner_user_id, workspace.id))
+            owner = self.users.get(owner_user_id)
+            if owner is not None:
+                owner.owner_workspace_count = len(owned) + 1
+            self.credit_trust_shards[(workspace.id, 0)] = {
+                "trust_tier": 0,
+                "trust_computed_at": None,
+                "trust_latched_at": None,
+                "trust_override_tier": None,
+                "billing_pause_causes": [],
+                "pause_epoch": 0,
+                "trust_reconciled_through": None,
+            }
             if initial_total > 0:
                 recorded_at = dt.datetime.now(dt.UTC)
                 event_id = f"provisioning:{workspace.id}"
@@ -678,6 +741,43 @@ class InMemoryStore:
             if name is not None:
                 workspace.name = name
             if deleted is not None:
+                inventory_key = (workspace.owner_user_id, workspace.id)
+                if workspace.deleted and not deleted:
+                    owned = [
+                        wid
+                        for owner_id, wid in self.owner_workspaces
+                        if owner_id == workspace.owner_user_id
+                    ]
+                    if len(owned) >= self.max_workspaces_per_owner:
+                        raise WorkspaceOwnerLimitExceeded(
+                            "owner has reached TR_MAX_WORKSPACES_PER_OWNER"
+                        )
+                    require_owner_trust_budget(
+                        [self.credits[wid].shard_count for wid in owned]
+                        + [self.credits[workspace.id].shard_count]
+                    )
+                    self.owner_workspaces.add(inventory_key)
+                    owner = self.users.get(workspace.owner_user_id)
+                    if owner is not None:
+                        owner.owner_workspace_count = len(owned) + 1
+                elif not workspace.deleted and deleted:
+                    self.owner_workspaces.discard(inventory_key)
+                    owner = self.users.get(workspace.owner_user_id)
+                    if owner is not None:
+                        owner.owner_workspace_count = max(0, owner.owner_workspace_count - 1)
+                    now = dt.datetime.now(dt.UTC)
+                    for (candidate_workspace_id, _), row in self.credit_trust_shards.items():
+                        if candidate_workspace_id == workspace.id:
+                            row["trust_tier"] = 0
+                            row["trust_latched_at"] = row["trust_latched_at"] or now
+                    self.active_spend_leases = {
+                        key: lease
+                        for key, lease in self.active_spend_leases.items()
+                        if (
+                            (api_key := self.api_keys.get_by_hash(key[0])) is None
+                            or api_key.workspace_id != workspace.id
+                        )
+                    }
                 workspace.deleted = deleted
             if billing_paused is not None:
                 causes = set(workspace.billing_pause_causes)
@@ -690,6 +790,235 @@ class InMemoryStore:
             if billing_pause_reason is not None:
                 workspace.billing_pause_reason = billing_pause_reason
             return workspace
+
+    def transfer_workspace_ownership(
+        self, workspace_id: str, new_owner_user_id: str
+    ) -> Workspace:
+        with self._lock:
+            workspace = self.workspaces.get(workspace_id)
+            if workspace is None or workspace.deleted:
+                raise ValueError("workspace_not_found")
+            if new_owner_user_id == workspace.owner_user_id:
+                return workspace
+            owned = [
+                wid
+                for owner_id, wid in self.owner_workspaces
+                if owner_id == new_owner_user_id
+            ]
+            if len(owned) >= self.max_workspaces_per_owner:
+                raise WorkspaceOwnerLimitExceeded(
+                    "owner has reached TR_MAX_WORKSPACES_PER_OWNER"
+                )
+            require_owner_trust_budget(
+                [self.credits[wid].shard_count for wid in owned]
+                + [self.credits[workspace_id].shard_count]
+            )
+            old_owner_id = workspace.owner_user_id
+            self.owner_workspaces.discard((old_owner_id, workspace_id))
+            self.owner_workspaces.add((new_owner_user_id, workspace_id))
+            old_member = self.members.pop((workspace_id, old_owner_id), None)
+            if old_member is not None:
+                self.members[(workspace_id, old_owner_id)] = Member(
+                    workspace_id=workspace_id,
+                    user_id=old_owner_id,
+                    role="admin",
+                    created_at=old_member.created_at,
+                )
+            self.members[(workspace_id, new_owner_user_id)] = Member(
+                workspace_id=workspace_id,
+                user_id=new_owner_user_id,
+                role="owner",
+            )
+            workspace.owner_user_id = new_owner_user_id
+            old_owner = self.users.get(old_owner_id)
+            if old_owner is not None:
+                old_owner.owner_workspace_count = max(0, old_owner.owner_workspace_count - 1)
+            new_owner = self.users.get(new_owner_user_id)
+            if new_owner is not None:
+                new_owner.owner_workspace_count = len(owned) + 1
+            return workspace
+
+    def set_workspace_trust_override(
+        self,
+        workspace_id: str,
+        *,
+        tier: int,
+        identity_bypass: bool,
+        operator_identity: str,
+        reason: str,
+    ) -> TrustOverride:
+        if not 0 <= int(tier) <= 3:
+            raise ValueError("trust override tier must be between 0 and 3")
+        if not operator_identity.strip() or not reason.strip():
+            raise ValueError("operator identity and reason are required")
+        with self._lock:
+            workspace = self.workspaces.get(workspace_id)
+            account = self.credits.get(workspace_id)
+            if workspace is None or workspace.deleted or account is None:
+                raise ValueError("workspace_not_found")
+            now = dt.datetime.now(dt.UTC)
+            record = TrustOverride(
+                workspace_id=workspace_id,
+                tier=int(tier),
+                identity_bypass=bool(identity_bypass),
+                operator_identity=operator_identity.strip(),
+                reason=reason.strip(),
+                set_at=now,
+            )
+            owner = self.users.get(workspace.owner_user_id)
+            events = [
+                event
+                for (candidate_workspace_id, _), event in self.trust_events.items()
+                if candidate_workspace_id == workspace_id
+            ]
+            for shard in range(account.shard_count):
+                row = self.credit_trust_shards[(workspace_id, shard)]
+                decision = compute_trust_tier(
+                    events,
+                    owner_identity_status=(owner.identity_status if owner else "none"),
+                    trust_latched_at=row["trust_latched_at"],
+                    trust_override_tier=tier,
+                    qualifying_providers=self.trust_qualifying_providers,
+                    tier3_min_days=self.trust_tier3_min_days,
+                    tier3_min_paid_microdollars=self.trust_tier3_min_paid_microdollars,
+                    now=now,
+                    identity_bypass=identity_bypass,
+                )
+                row["trust_override_tier"] = int(tier)
+                row["trust_tier"] = decision.effective_tier
+                row["trust_computed_at"] = now
+            self.trust_overrides[workspace_id] = record
+            return record
+
+    def record_workspace_abuse_and_demote(
+        self,
+        workspace_id: str,
+        *,
+        abuse_ref: str,
+        operator_identity: str,
+        reason: str,
+    ) -> bool:
+        if not abuse_ref.strip() or not operator_identity.strip() or not reason.strip():
+            raise ValueError("abuse_ref, operator identity and reason are required")
+        with self._lock:
+            for event in self.trust_events.values():
+                if event.provider == "operator" and event.adverse_ref == abuse_ref:
+                    if event.workspace_id != workspace_id or event.kind != "abuse":
+                        raise ValueError("abuse_ref_conflict")
+                    return False
+            workspace = self.workspaces.get(workspace_id)
+            account = self.credits.get(workspace_id)
+            if workspace is None or workspace.deleted or account is None:
+                raise ValueError("workspace_not_found")
+            now = dt.datetime.now(dt.UTC)
+            event_id = f"abuse:{abuse_ref}"
+            self.trust_events[(workspace_id, event_id)] = TrustEvent(
+                workspace_id=workspace_id,
+                event_id=event_id,
+                kind="abuse",
+                provider="operator",
+                amount_micro=0,
+                original_payment_ref=None,
+                adverse_ref=abuse_ref,
+                occurred_at=now,
+                recorded_at=now,
+                payment_amount_micro=None,
+                currency=None,
+                credited_micro=None,
+                recovered_micro=None,
+                provider_subtype="operator",
+                lifecycle_status="succeeded",
+                cumulative_refunded=None,
+                recovery_target=0,
+                debit_status="debited",
+                unrecovered_micro=0,
+                provider_ordering_watermark=None,
+            )
+            self.trust_abuse_audits[(workspace_id, abuse_ref)] = {
+                "workspace_id": workspace_id,
+                "abuse_ref": abuse_ref,
+                "operator_identity": operator_identity.strip(),
+                "reason": reason.strip(),
+                "recorded_at": now.isoformat(),
+            }
+            workspace.billing_pause_causes = sorted(
+                {*workspace.billing_pause_causes, "abuse"}
+            )
+            workspace.billing_paused = True
+            workspace.billing_pause_reason = reason.strip()
+            for shard in range(account.shard_count):
+                row = self.credit_trust_shards[(workspace_id, shard)]
+                causes = sorted({*row["billing_pause_causes"], "abuse"})
+                row.update(
+                    trust_tier=0,
+                    trust_latched_at=row["trust_latched_at"] or now,
+                    billing_pause_causes=causes,
+                    pause_epoch=int(row["pause_epoch"] or 0) + 1,
+                )
+            return True
+
+    def clear_workspace_abuse_pause(
+        self,
+        workspace_id: str,
+        *,
+        abuse_ref: str,
+        operator_identity: str,
+        reason: str,
+    ) -> bool:
+        if not abuse_ref.strip() or not operator_identity.strip() or not reason.strip():
+            raise ValueError("abuse_ref, operator identity and reason are required")
+        with self._lock:
+            audit_key = (workspace_id, abuse_ref)
+            if audit_key in self.abuse_pause_clears:
+                return False
+            workspace = self.workspaces.get(workspace_id)
+            account = self.credits.get(workspace_id)
+            if workspace is None or workspace.deleted or account is None:
+                raise ValueError("workspace_not_found")
+            self.abuse_pause_clears.add(audit_key)
+            workspace.billing_pause_causes = sorted(
+                set(workspace.billing_pause_causes) - {"abuse"}
+            )
+            workspace.billing_paused = bool(workspace.billing_pause_causes)
+            workspace.billing_pause_reason = reason.strip()
+            for shard in range(account.shard_count):
+                row = self.credit_trust_shards[(workspace_id, shard)]
+                causes = sorted(set(row["billing_pause_causes"]) - {"abuse"})
+                if causes != row["billing_pause_causes"]:
+                    row["pause_epoch"] = int(row["pause_epoch"] or 0) + 1
+                row["billing_pause_causes"] = causes
+            return True
+
+    def backfill_owner_inventory(self, *, source_version: str, environment: str) -> int:
+        if not source_version.strip() or not environment.strip():
+            raise ValueError("source_version and environment are required")
+        with self._lock:
+            expected = {
+                (workspace.owner_user_id, workspace.id)
+                for workspace in self.workspaces.values()
+                if not workspace.deleted and not workspace.federated_home
+            }
+            changed = len(self.owner_workspaces ^ expected)
+            self.owner_workspaces = expected
+            for user in self.users.values():
+                user.owner_workspace_count = sum(
+                    owner_id == user.id for owner_id, _ in expected
+                )
+            now = dt.datetime.now(dt.UTC)
+            self.trust_backfills[("owner_inventory", "local", environment)] = {
+                "provider": "owner_inventory",
+                "account_id": "local",
+                "environment": environment,
+                "source": "tr_entities.workspace",
+                "source_version": source_version,
+                "history_start": now,
+                "closed_through": now,
+                "consistency_delay_seconds": 0,
+                "unmatched_count": 0,
+                "semantic_mismatch_count": 0,
+                "completed_at": now,
+            }
+            return changed
 
     def get_credit_account(self, workspace_id: str) -> CreditAccount | None:
         with self._lock:
@@ -827,6 +1156,28 @@ class InMemoryStore:
             user.email_verified = True
             return user
 
+    def _demote_owner_locked(self, owner_user_id: str, *, now: dt.datetime) -> None:
+        workspace_ids = sorted(
+            workspace_id
+            for candidate_owner, workspace_id in self.owner_workspaces
+            if candidate_owner == owner_user_id
+        )
+        shard_counts = [self.credits[workspace_id].shard_count for workspace_id in workspace_ids]
+        mutations = sum(shard_counts) * TRUST_REPLICATED_COLUMN_COUNT
+        remaining_budget = TRUST_OWNER_MUTATION_BUDGET
+        for workspace_id, shard_count in zip(workspace_ids, shard_counts, strict=True):
+            cost = shard_count * TRUST_REPLICATED_COLUMN_COUNT
+            if mutations > TRUST_OWNER_MUTATION_BUDGET and cost > remaining_budget:
+                self.trust_demotion_remainders.add((owner_user_id, workspace_id))
+                continue
+            remaining_budget -= cost
+            override = self.trust_overrides.get(workspace_id)
+            for shard in range(shard_count):
+                row = self.credit_trust_shards[(workspace_id, shard)]
+                if not (override and override.identity_bypass):
+                    row["trust_tier"] = min(int(row["trust_tier"] or 0), 1)
+                row["trust_computed_at"] = now
+
     def set_user_identity_status(
         self,
         user_id: str,
@@ -844,6 +1195,7 @@ class InMemoryStore:
             user = self.users.get(user_id)
             if user is None:
                 return None
+            was_approved = user.identity_status == "approved"
             normalized = IdentityVerificationStatus.coerce(status)
             if normalized is IdentityVerificationStatus.APPROVED and not user.identity_verified_at:
                 user.identity_verified_at = iso_now()
@@ -864,7 +1216,55 @@ class InMemoryStore:
                 user.identity_verified_name = verified_name
             if increment_attempts:
                 user.veriff_attempt_count += 1
+            if was_approved and normalized is not IdentityVerificationStatus.APPROVED:
+                self._demote_owner_locked(user_id, now=dt.datetime.now(dt.UTC))
             return user
+
+    def apply_veriff_identity_decision(
+        self,
+        user_id: str,
+        *,
+        event_id: str,
+        session_id: str,
+        status: str,
+        decision_code: int,
+        decision_reason: str | None = None,
+        decision_reason_code: int | None = None,
+        verified_name: str | None = None,
+    ) -> str:
+        with self._lock:
+            marker = ("veriff", event_id)
+            if marker in self.webhook_events:
+                return "replayed"
+            self.webhook_events.add(marker)
+            user = self.users.get(user_id)
+            if user is None or user.veriff_session_id != session_id:
+                return "ignored"
+            self.set_user_identity_status(
+                user_id,
+                status=status,
+                decision_code=decision_code,
+                decision_reason=decision_reason,
+                decision_reason_code=decision_reason_code,
+                verified_name=verified_name,
+            )
+            return "applied"
+
+    def process_trust_demotion_remainders(self, *, limit: int = 25) -> int:
+        with self._lock:
+            completed = 0
+            for owner_user_id, workspace_id in sorted(self.trust_demotion_remainders)[:limit]:
+                account = self.credits.get(workspace_id)
+                if account is not None:
+                    override = self.trust_overrides.get(workspace_id)
+                    for shard in range(account.shard_count):
+                        row = self.credit_trust_shards[(workspace_id, shard)]
+                        if not (override and override.identity_bypass):
+                            row["trust_tier"] = min(int(row["trust_tier"] or 0), 1)
+                        row["trust_computed_at"] = dt.datetime.now(dt.UTC)
+                self.trust_demotion_remainders.discard((owner_user_id, workspace_id))
+                completed += 1
+            return completed
 
     def begin_phone_verification(
         self, user_id: str, phone: str, channel: str | None = None
@@ -3181,7 +3581,18 @@ def configure_analytics_sink(sink: AnalyticsSink) -> None:
 def create_store(settings: Any) -> Store:
     backend = str(getattr(settings, "storage_backend", "memory")).lower()
     if backend == "memory":
-        return InMemoryStore()
+        return InMemoryStore(
+            max_workspaces_per_owner=int(
+                getattr(settings, "max_workspaces_per_owner", 25)
+            ),
+            trust_qualifying_providers=frozenset(
+                getattr(settings, "trust_qualifying_provider_set", {"stripe", "x402"})
+            ),
+            trust_tier3_min_days=int(getattr(settings, "trust_tier3_min_days", 30)),
+            trust_tier3_min_paid_microdollars=int(
+                getattr(settings, "trust_tier3_min_paid_microdollars", 50_000_000)
+            ),
+        )
     if backend == "postgres":
         # Postgres-wire system of record for the non-GCP deployments. The same
         # implementation runs on Azure Flexible Server / Citus, AWS Aurora DSQL,
@@ -3201,6 +3612,16 @@ def create_store(settings: Any) -> Store:
             postgres_iam_region=str(getattr(settings, "postgres_iam_region", "") or ""),
             operational_analytics_outbox_enabled=bool(
                 getattr(settings, "operational_analytics_outbox_enabled", False)
+            ),
+            max_workspaces_per_owner=int(
+                getattr(settings, "max_workspaces_per_owner", 25)
+            ),
+            trust_qualifying_providers=frozenset(
+                getattr(settings, "trust_qualifying_provider_set", {"stripe", "x402"})
+            ),
+            trust_tier3_min_days=int(getattr(settings, "trust_tier3_min_days", 30)),
+            trust_tier3_min_paid_microdollars=int(
+                getattr(settings, "trust_tier3_min_paid_microdollars", 50_000_000)
             ),
         )
         store.apply_schema()
@@ -3279,6 +3700,16 @@ def create_store(settings: Any) -> Store:
             ),
             spend_lease_bigtable_app_profiles=getattr(
                 settings, "spend_lease_bigtable_app_profile_map", {}
+            ),
+            max_workspaces_per_owner=int(
+                getattr(settings, "max_workspaces_per_owner", 25)
+            ),
+            trust_qualifying_providers=frozenset(
+                getattr(settings, "trust_qualifying_provider_set", {"stripe", "x402"})
+            ),
+            trust_tier3_min_days=int(getattr(settings, "trust_tier3_min_days", 30)),
+            trust_tier3_min_paid_microdollars=int(
+                getattr(settings, "trust_tier3_min_paid_microdollars", 50_000_000)
             ),
         )
     raise ValueError(f"unsupported storage backend: {backend}")

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -92,6 +92,8 @@ from trusted_router.storage import (
     SignupResult,
     SyntheticProbeSample,
     SyntheticRollup,
+    TrustEvent,
+    TrustOverride,
     User,
     UserProvidedModel,
     VerificationToken,
@@ -219,7 +221,13 @@ from trusted_router.storage_models import (
 from trusted_router.storage_operational_analytics import (
     OperationalAnalyticsWriter,
 )
-from trusted_router.trust_tiers import payment_or_grant_event
+from trusted_router.trust_ownership import (
+    TRUST_OWNER_MUTATION_BUDGET,
+    TRUST_REPLICATED_COLUMN_COUNT,
+    WorkspaceOwnerLimitExceeded,
+    require_owner_trust_budget,
+)
+from trusted_router.trust_tiers import compute_trust_tier, payment_or_grant_event
 from trusted_router.types import IdentityVerificationStatus, UsageType
 
 T = TypeVar("T")
@@ -376,6 +384,10 @@ class SpannerBigtableStore:
         regional_quota_ledger_timeout_seconds: float = 4.0,
         spend_lease_bigtable_table: str = "trustedrouter-spend-lease",
         spend_lease_bigtable_app_profiles: dict[str, str] | None = None,
+        max_workspaces_per_owner: int = 25,
+        trust_qualifying_providers: frozenset[str] = frozenset({"stripe", "x402"}),
+        trust_tier3_min_days: int = 30,
+        trust_tier3_min_paid_microdollars: int = 50_000_000,
     ) -> None:
         if not spanner_instance_id or not spanner_database_id:
             raise ValueError("Spanner instance and database IDs are required")
@@ -395,6 +407,12 @@ class SpannerBigtableStore:
         if not bigtable_enabled and analytics_read_mode != "clickhouse-only":
             raise ValueError("Bigtable-free storage requires clickhouse-only reads")
         self.request_record_write_mode = request_record_write_mode
+        self.max_workspaces_per_owner = int(max_workspaces_per_owner)
+        self.trust_qualifying_providers = trust_qualifying_providers
+        self.trust_tier3_min_days = int(trust_tier3_min_days)
+        self.trust_tier3_min_paid_microdollars = int(
+            trust_tier3_min_paid_microdollars
+        )
         self._generation_records_enabled = generation_records_enabled
         self._bigtable_enabled = bigtable_enabled
         self._bigtable_writes_enabled = bigtable_writes_enabled and bigtable_enabled
@@ -808,7 +826,10 @@ class SpannerBigtableStore:
                     return user
 
             new_user = User(
-                id=str(uuid.uuid4()), email=normalized_email, email_verified=email_verified
+                id=str(uuid.uuid4()),
+                email=normalized_email,
+                email_verified=email_verified,
+                owner_workspace_count=1,
             )
             workspace = Workspace(
                 id=str(uuid.uuid4()),
@@ -836,6 +857,7 @@ class SpannerBigtableStore:
                 initial_total,
                 shard_count=credit.shard_count,
             )
+            self._insert_owner_inventory_tx(transaction, new_user.id, workspace.id)
             return new_user
 
         return self._run_in_transaction(txn)
@@ -947,6 +969,57 @@ class SpannerBigtableStore:
                 values=[trust_event_row(event)],
             )
 
+    def _owner_workspace_ids_tx(self, transaction: Any, owner_user_id: str) -> list[str]:
+        return [
+            str(row[0])
+            for row in transaction.execute_sql(
+                "SELECT workspace_id FROM tr_owner_workspace "
+                "WHERE owner_user_id=@owner ORDER BY workspace_id",
+                params={"owner": owner_user_id},
+                param_types={"owner": self._param_types.STRING},
+            )
+        ]
+
+    def _owner_shard_counts_tx(
+        self, transaction: Any, owner_user_id: str
+    ) -> tuple[list[str], list[int]]:
+        workspace_ids = self._owner_workspace_ids_tx(transaction, owner_user_id)
+        counts: list[int] = []
+        for workspace_id in workspace_ids:
+            account = self._read_entity_tx(transaction, "credit", workspace_id, CreditAccount)
+            if account is None:
+                raise RuntimeError("owner inventory references a missing credit account")
+            counts.append(credit_shard_count(account))
+        return workspace_ids, counts
+
+    def _require_owner_growth_tx(
+        self,
+        transaction: Any,
+        owner_user_id: str,
+        *,
+        added_shards: int,
+        enforce_count: bool,
+    ) -> tuple[list[str], User | None]:
+        workspace_ids, shard_counts = self._owner_shard_counts_tx(
+            transaction, owner_user_id
+        )
+        if enforce_count and len(workspace_ids) >= self.max_workspaces_per_owner:
+            raise WorkspaceOwnerLimitExceeded(
+                "owner has reached TR_MAX_WORKSPACES_PER_OWNER"
+            )
+        require_owner_trust_budget([*shard_counts, added_shards])
+        owner = self._read_entity_tx(transaction, "user", owner_user_id, User)
+        return workspace_ids, owner
+
+    def _insert_owner_inventory_tx(
+        self, transaction: Any, owner_user_id: str, workspace_id: str
+    ) -> None:
+        transaction.insert_or_update(
+            table="tr_owner_workspace",
+            columns=("owner_user_id", "workspace_id"),
+            values=[(owner_user_id, workspace_id)],
+        )
+
     # Auth sessions delegate to storage_gcp_auth_sessions.SpannerAuthSessions.
     def create_auth_session(
         self,
@@ -1052,19 +1125,31 @@ class SpannerBigtableStore:
             workspace_id=workspace.id,
             shard_count=DEFAULT_NEW_BILLING_SHARDS,
         )
-        with self._database.batch() as batch:
-            self._write_entity_batch(batch, "workspace", workspace.id, workspace)
-            self._write_entity_batch(
-                batch, "member", _member_id(workspace.id, owner_user_id), member
+        def txn(transaction: Any) -> Workspace:
+            owned, owner = self._require_owner_growth_tx(
+                transaction,
+                owner_user_id,
+                added_shards=credit.shard_count,
+                enforce_count=True,
             )
-            self._write_entity_batch(batch, "credit", workspace.id, credit)
+            self._write_entity_tx(transaction, "workspace", workspace.id, workspace)
+            self._write_entity_tx(
+                transaction, "member", _member_id(workspace.id, owner_user_id), member
+            )
+            self._write_entity_tx(transaction, "credit", workspace.id, credit)
             self._seed_credit_balance_on_create(
-                batch,
+                transaction,
                 workspace.id,
                 initial_total,
                 shard_count=credit.shard_count,
             )
-        return workspace
+            self._insert_owner_inventory_tx(transaction, owner_user_id, workspace.id)
+            if owner is not None:
+                owner.owner_workspace_count = len(owned) + 1
+                self._write_entity_tx(transaction, "user", owner.id, owner)
+            return workspace
+
+        return self._run_in_transaction(txn)
 
     def list_workspaces_for_user(self, user_id: str) -> list[Workspace]:
         members = self._list_entities("member", suffix=f"#{user_id}", cls=Member)
@@ -1096,6 +1181,100 @@ class SpannerBigtableStore:
             workspace = self._read_entity_tx(transaction, "workspace", workspace_id, Workspace)
             if workspace is None:
                 return None
+            owner: User | None = None
+            account: CreditAccount | None = None
+            owned: list[str] = []
+            if deleted is not None and deleted != workspace.deleted:
+                account = self._read_entity_tx(
+                    transaction, "credit", workspace_id, CreditAccount
+                )
+                if account is None:
+                    raise RuntimeError("workspace is missing its credit account")
+                if deleted:
+                    owned = self._owner_workspace_ids_tx(
+                        transaction, workspace.owner_user_id
+                    )
+                    owner = self._read_entity_tx(
+                        transaction, "user", workspace.owner_user_id, User
+                    )
+                    transaction.delete(
+                        "tr_owner_workspace",
+                        self._spanner.KeySet(
+                            keys=[(workspace.owner_user_id, workspace_id)]
+                        ),
+                    )
+                    now = dt.datetime.now(dt.UTC)
+                    shard_rows = list(
+                        transaction.execute_sql(
+                            "SELECT shard, trust_latched_at FROM tr_credit_balance "
+                            "WHERE workspace_id=@pk AND shard>=0 AND shard<@shard_count "
+                            "ORDER BY shard",
+                            params={
+                                "pk": workspace_id,
+                                "shard_count": credit_shard_count(account),
+                            },
+                            param_types={
+                                "pk": self._param_types.STRING,
+                                "shard_count": self._param_types.INT64,
+                            },
+                        )
+                    )
+                    if len(shard_rows) != credit_shard_count(account):
+                        raise RuntimeError(
+                            "configured tr_credit_balance shard set is incomplete"
+                        )
+                    lease_rows = list(
+                        transaction.execute_sql(
+                            "SELECT kind, id, body FROM tr_entities WHERE "
+                            "kind IN ('spend_lease','regional_quota_lease') "
+                            "AND JSON_VALUE(body, '$.workspace_id')=@pk ORDER BY kind, id",
+                            params={"pk": workspace_id},
+                            param_types={"pk": self._param_types.STRING},
+                        )
+                    )
+                    for lease_kind, lease_id, raw_body in lease_rows:
+                        body = json.loads(str(raw_body))
+                        if lease_kind == "spend_lease" and body.get("state") != "CLOSED":
+                            body["state"] = "TOMBSTONED"
+                            body["closing_at"] = now.isoformat()
+                        elif (
+                            lease_kind == "regional_quota_lease"
+                            and body.get("state") != "closed"
+                        ):
+                            body["state"] = "quarantined"
+                            body["last_error"] = "workspace_archived"
+                            body["updated_at"] = now.isoformat()
+                        else:
+                            continue
+                        self._write_entity_tx(
+                            transaction,
+                            str(lease_kind),
+                            str(lease_id),
+                            body,
+                        )
+                    transaction.insert_or_update(
+                        table=CREDIT_BALANCE_TABLE,
+                        columns=(
+                            "workspace_id",
+                            "shard",
+                            "trust_tier",
+                            "trust_latched_at",
+                        ),
+                        values=[
+                            (workspace_id, int(shard), 0, latched_at or now)
+                            for shard, latched_at in shard_rows
+                        ],
+                    )
+                else:
+                    owned, owner = self._require_owner_growth_tx(
+                        transaction,
+                        workspace.owner_user_id,
+                        added_shards=credit_shard_count(account),
+                        enforce_count=True,
+                    )
+                    self._insert_owner_inventory_tx(
+                        transaction, workspace.owner_user_id, workspace_id
+                    )
             if name is not None:
                 workspace.name = name
             if deleted is not None:
@@ -1110,10 +1289,658 @@ class SpannerBigtableStore:
                 workspace.billing_paused = bool(causes)
             if billing_pause_reason is not None:
                 workspace.billing_pause_reason = billing_pause_reason
+            if owner is not None and deleted is not None:
+                owner.owner_workspace_count = (
+                    max(0, len(owned) - 1) if deleted else len(owned) + 1
+                )
+                self._write_entity_tx(transaction, "user", owner.id, owner)
             self._write_entity_tx(transaction, "workspace", workspace.id, workspace)
             return None if workspace.deleted else workspace
 
         return self._run_in_transaction(txn)
+
+    def transfer_workspace_ownership(
+        self, workspace_id: str, new_owner_user_id: str
+    ) -> Workspace:
+        def txn(transaction: Any) -> Workspace:
+            workspace = self._read_entity_tx(
+                transaction, "workspace", workspace_id, Workspace
+            )
+            account = self._read_entity_tx(
+                transaction, "credit", workspace_id, CreditAccount
+            )
+            if workspace is None or workspace.deleted or account is None:
+                raise ValueError("workspace_not_found")
+            old_owner_user_id = workspace.owner_user_id
+            if old_owner_user_id == new_owner_user_id:
+                return workspace
+            new_owned, new_owner = self._require_owner_growth_tx(
+                transaction,
+                new_owner_user_id,
+                added_shards=credit_shard_count(account),
+                enforce_count=True,
+            )
+            old_owned = self._owner_workspace_ids_tx(transaction, old_owner_user_id)
+            old_owner = self._read_entity_tx(
+                transaction, "user", old_owner_user_id, User
+            )
+            transaction.delete(
+                "tr_owner_workspace",
+                self._spanner.KeySet(keys=[(old_owner_user_id, workspace_id)]),
+            )
+            self._insert_owner_inventory_tx(
+                transaction, new_owner_user_id, workspace_id
+            )
+            workspace.owner_user_id = new_owner_user_id
+            self._write_entity_tx(transaction, "workspace", workspace_id, workspace)
+            old_member = self._read_entity_tx(
+                transaction,
+                "member",
+                _member_id(workspace_id, old_owner_user_id),
+                Member,
+            )
+            if old_member is not None:
+                old_member.role = "admin"
+                self._write_entity_tx(
+                    transaction,
+                    "member",
+                    _member_id(workspace_id, old_owner_user_id),
+                    old_member,
+                )
+            self._write_entity_tx(
+                transaction,
+                "member",
+                _member_id(workspace_id, new_owner_user_id),
+                Member(
+                    workspace_id=workspace_id,
+                    user_id=new_owner_user_id,
+                    role="owner",
+                ),
+            )
+            if old_owner is not None:
+                old_owner.owner_workspace_count = max(0, len(old_owned) - 1)
+                self._write_entity_tx(transaction, "user", old_owner.id, old_owner)
+            if new_owner is not None:
+                new_owner.owner_workspace_count = len(new_owned) + 1
+                self._write_entity_tx(transaction, "user", new_owner.id, new_owner)
+            return workspace
+
+        return self._run_in_transaction(txn)
+
+    def _workspace_trust_events_tx(
+        self, transaction: Any, workspace_id: str
+    ) -> list[TrustEvent]:
+        rows = transaction.execute_sql(
+            "SELECT " + ", ".join(TRUST_EVENT_COLUMNS) + " FROM tr_trust_event "  # noqa: S608
+            "WHERE workspace_id=@pk",
+            params={"pk": workspace_id},
+            param_types={"pk": self._param_types.STRING},
+        )
+        return [TrustEvent(*row) for row in rows]
+
+    def set_workspace_trust_override(
+        self,
+        workspace_id: str,
+        *,
+        tier: int,
+        identity_bypass: bool,
+        operator_identity: str,
+        reason: str,
+    ) -> TrustOverride:
+        if isinstance(tier, bool) or not 0 <= int(tier) <= 3:
+            raise ValueError("trust override tier must be between 0 and 3")
+        if not operator_identity.strip() or not reason.strip():
+            raise ValueError("operator identity and reason are required")
+
+        def txn(transaction: Any) -> TrustOverride:
+            workspace = self._read_entity_tx(
+                transaction, "workspace", workspace_id, Workspace
+            )
+            account = self._read_entity_tx(
+                transaction, "credit", workspace_id, CreditAccount
+            )
+            if workspace is None or workspace.deleted or account is None:
+                raise ValueError("workspace_not_found")
+            owner = self._read_entity_tx(
+                transaction, "user", workspace.owner_user_id, User
+            )
+            shard_count = credit_shard_count(account)
+            shard_rows = list(
+                transaction.execute_sql(
+                    "SELECT shard, trust_latched_at FROM tr_credit_balance "
+                    "WHERE workspace_id=@pk AND shard>=0 AND shard<@shard_count "
+                    "ORDER BY shard",
+                    params={"pk": workspace_id, "shard_count": shard_count},
+                    param_types={
+                        "pk": self._param_types.STRING,
+                        "shard_count": self._param_types.INT64,
+                    },
+                )
+            )
+            if [int(row[0]) for row in shard_rows] != list(range(shard_count)):
+                raise RuntimeError("configured tr_credit_balance shard set is incomplete")
+            latches = {row[1] for row in shard_rows}
+            if len(latches) != 1:
+                raise RuntimeError("replicated trust latch diverged")
+            now = dt.datetime.now(dt.UTC)
+            decision = compute_trust_tier(
+                self._workspace_trust_events_tx(transaction, workspace_id),
+                owner_identity_status=owner.identity_status if owner else "none",
+                trust_latched_at=shard_rows[0][1],
+                trust_override_tier=int(tier),
+                qualifying_providers=self.trust_qualifying_providers,
+                tier3_min_days=self.trust_tier3_min_days,
+                tier3_min_paid_microdollars=self.trust_tier3_min_paid_microdollars,
+                now=now,
+                identity_bypass=bool(identity_bypass),
+            )
+            record = TrustOverride(
+                workspace_id=workspace_id,
+                tier=int(tier),
+                identity_bypass=bool(identity_bypass),
+                operator_identity=operator_identity.strip(),
+                reason=reason.strip(),
+                set_at=now,
+            )
+            transaction.insert_or_update(
+                table="tr_trust_override",
+                columns=(
+                    "workspace_id",
+                    "tier",
+                    "identity_bypass",
+                    "operator_identity",
+                    "reason",
+                    "set_at",
+                ),
+                values=[(
+                    record.workspace_id,
+                    record.tier,
+                    record.identity_bypass,
+                    record.operator_identity,
+                    record.reason,
+                    record.set_at,
+                )],
+            )
+            transaction.insert_or_update(
+                table=CREDIT_BALANCE_TABLE,
+                columns=(
+                    "workspace_id",
+                    "shard",
+                    "trust_tier",
+                    "trust_computed_at",
+                    "trust_override_tier",
+                ),
+                values=[
+                    (
+                        workspace_id,
+                        int(shard),
+                        decision.effective_tier,
+                        now,
+                        int(tier),
+                    )
+                    for shard, _latch in shard_rows
+                ],
+            )
+            return record
+
+        return self._run_in_transaction(txn)
+
+    def _existing_operator_abuse(self, abuse_ref: str) -> tuple[str, str] | None:
+        with self._database.snapshot() as snapshot:
+            rows = list(
+                snapshot.execute_sql(
+                    "SELECT workspace_id, kind FROM tr_trust_event "
+                    "WHERE provider=@provider AND adverse_ref=@adverse_ref",
+                    params={"provider": "operator", "adverse_ref": abuse_ref},
+                    param_types={
+                        "provider": self._param_types.STRING,
+                        "adverse_ref": self._param_types.STRING,
+                    },
+                )
+            )
+        if len(rows) > 1:
+            raise RuntimeError("operator abuse reference dedup invariant violated")
+        return None if not rows else (str(rows[0][0]), str(rows[0][1]))
+
+    def record_workspace_abuse_and_demote(
+        self,
+        workspace_id: str,
+        *,
+        abuse_ref: str,
+        operator_identity: str,
+        reason: str,
+    ) -> bool:
+        abuse_ref = abuse_ref.strip()
+        operator_identity = operator_identity.strip()
+        reason = reason.strip()
+        if not abuse_ref or not operator_identity or not reason:
+            raise ValueError("abuse_ref, operator identity and reason are required")
+
+        def txn(transaction: Any) -> bool:
+            existing = list(
+                transaction.execute_sql(
+                    "SELECT workspace_id, kind FROM tr_trust_event "
+                    "WHERE provider=@provider AND adverse_ref=@adverse_ref",
+                    params={"provider": "operator", "adverse_ref": abuse_ref},
+                    param_types={
+                        "provider": self._param_types.STRING,
+                        "adverse_ref": self._param_types.STRING,
+                    },
+                )
+            )
+            if existing:
+                if str(existing[0][0]) != workspace_id or str(existing[0][1]) != "abuse":
+                    raise ValueError("abuse_ref_conflict")
+                return False
+            workspace = self._read_entity_tx(
+                transaction, "workspace", workspace_id, Workspace
+            )
+            account = self._read_entity_tx(
+                transaction, "credit", workspace_id, CreditAccount
+            )
+            if workspace is None or workspace.deleted or account is None:
+                raise ValueError("workspace_not_found")
+            shard_count = credit_shard_count(account)
+            shard_rows = list(
+                transaction.execute_sql(
+                    "SELECT shard, trust_latched_at, billing_pause_causes, pause_epoch "
+                    "FROM tr_credit_balance WHERE workspace_id=@pk AND shard>=0 "
+                    "AND shard<@shard_count ORDER BY shard",
+                    params={"pk": workspace_id, "shard_count": shard_count},
+                    param_types={
+                        "pk": self._param_types.STRING,
+                        "shard_count": self._param_types.INT64,
+                    },
+                )
+            )
+            if [int(row[0]) for row in shard_rows] != list(range(shard_count)):
+                raise RuntimeError("configured tr_credit_balance shard set is incomplete")
+            replicated = {
+                (row[1], tuple(sorted(row[2] or ())), int(row[3] or 0))
+                for row in shard_rows
+            }
+            if len(replicated) != 1:
+                raise RuntimeError("replicated trust controls diverged")
+            latched_at, old_causes, _pause_epoch = next(iter(replicated))
+            now = dt.datetime.now(dt.UTC)
+            event = TrustEvent(
+                workspace_id=workspace_id,
+                event_id=f"abuse:{abuse_ref}",
+                kind="abuse",
+                provider="operator",
+                amount_micro=0,
+                original_payment_ref=None,
+                adverse_ref=abuse_ref,
+                occurred_at=now,
+                recorded_at=now,
+                payment_amount_micro=None,
+                currency=None,
+                credited_micro=None,
+                recovered_micro=None,
+                provider_subtype="operator",
+                lifecycle_status="succeeded",
+                cumulative_refunded=None,
+                recovery_target=0,
+                debit_status="debited",
+                unrecovered_micro=0,
+                provider_ordering_watermark=None,
+            )
+            if not insert_credit_trust_event(
+                transaction, self._param_types, event
+            ):
+                return False
+            insert_entity_dml_at(
+                transaction,
+                self._param_types,
+                "trust_abuse",
+                f"{workspace_id}#{abuse_ref}",
+                _json_body(
+                    {
+                        "workspace_id": workspace_id,
+                        "abuse_ref": abuse_ref,
+                        "operator_identity": operator_identity,
+                        "reason": reason,
+                        "recorded_at": now.isoformat(),
+                    }
+                ),
+                now,
+            )
+            causes = sorted({*old_causes, "abuse"})
+            updated = transaction.execute_update(
+                "UPDATE tr_credit_balance SET trust_tier=0, "
+                "trust_latched_at=COALESCE(trust_latched_at,@now), "
+                "billing_pause_causes=@causes, pause_epoch=COALESCE(pause_epoch,0)+1, "
+                "updated_at=@now WHERE workspace_id=@pk AND shard>=0 "
+                "AND shard<@shard_count",
+                params={
+                    "now": now,
+                    "causes": causes,
+                    "pk": workspace_id,
+                    "shard_count": shard_count,
+                },
+                param_types={
+                    "now": self._param_types.TIMESTAMP,
+                    "causes": self._param_types.Array(self._param_types.STRING),
+                    "pk": self._param_types.STRING,
+                    "shard_count": self._param_types.INT64,
+                },
+            )
+            if int(updated) != shard_count:
+                raise RuntimeError("abuse latch did not cover every active shard")
+            workspace.billing_pause_causes = causes
+            workspace.billing_paused = True
+            workspace.billing_pause_reason = reason
+            if update_entity_body_dml(
+                transaction,
+                self._param_types,
+                "workspace",
+                workspace_id,
+                _json_body(workspace),
+                now,
+            ) != 1:
+                raise RuntimeError("workspace disappeared during abuse latch")
+            return True
+
+        try:
+            return self._run_in_transaction(txn)
+        except Exception as exc:
+            if not is_duplicate_key_error(exc):
+                raise
+            existing = self._existing_operator_abuse(abuse_ref)
+            if existing == (workspace_id, "abuse"):
+                return False
+            raise ValueError("abuse_ref_conflict") from exc
+
+    def clear_workspace_abuse_pause(
+        self,
+        workspace_id: str,
+        *,
+        abuse_ref: str,
+        operator_identity: str,
+        reason: str,
+    ) -> bool:
+        abuse_ref = abuse_ref.strip()
+        operator_identity = operator_identity.strip()
+        reason = reason.strip()
+        if not abuse_ref or not operator_identity or not reason:
+            raise ValueError("abuse_ref, operator identity and reason are required")
+        audit_id = f"{workspace_id}#{abuse_ref}"
+
+        def txn(transaction: Any) -> bool:
+            if self._read_entity_tx(
+                transaction, "trust_abuse_clear", audit_id, dict
+            ) is not None:
+                return False
+            workspace = self._read_entity_tx(
+                transaction, "workspace", workspace_id, Workspace
+            )
+            account = self._read_entity_tx(
+                transaction, "credit", workspace_id, CreditAccount
+            )
+            if workspace is None or workspace.deleted or account is None:
+                raise ValueError("workspace_not_found")
+            shard_count = credit_shard_count(account)
+            shard_rows = list(
+                transaction.execute_sql(
+                    "SELECT shard, billing_pause_causes, pause_epoch "
+                    "FROM tr_credit_balance WHERE workspace_id=@pk AND shard>=0 "
+                    "AND shard<@shard_count ORDER BY shard",
+                    params={"pk": workspace_id, "shard_count": shard_count},
+                    param_types={
+                        "pk": self._param_types.STRING,
+                        "shard_count": self._param_types.INT64,
+                    },
+                )
+            )
+            if [int(row[0]) for row in shard_rows] != list(range(shard_count)):
+                raise RuntimeError("configured tr_credit_balance shard set is incomplete")
+            controls = {
+                (tuple(sorted(row[1] or ())), int(row[2] or 0))
+                for row in shard_rows
+            }
+            if len(controls) != 1:
+                raise RuntimeError("replicated pause controls diverged")
+            old_causes, _pause_epoch = next(iter(controls))
+            causes = sorted(set(old_causes) - {"abuse"})
+            now = dt.datetime.now(dt.UTC)
+            insert_entity_dml_at(
+                transaction,
+                self._param_types,
+                "trust_abuse_clear",
+                audit_id,
+                _json_body(
+                    {
+                        "workspace_id": workspace_id,
+                        "abuse_ref": abuse_ref,
+                        "operator_identity": operator_identity,
+                        "reason": reason,
+                        "cleared_at": now.isoformat(),
+                    }
+                ),
+                now,
+            )
+            updated = transaction.execute_update(
+                "UPDATE tr_credit_balance SET billing_pause_causes=@causes, "
+                "pause_epoch=COALESCE(pause_epoch,0)+1, updated_at=@now "
+                "WHERE workspace_id=@pk AND shard>=0 AND shard<@shard_count",
+                params={
+                    "causes": causes,
+                    "now": now,
+                    "pk": workspace_id,
+                    "shard_count": shard_count,
+                },
+                param_types={
+                    "causes": self._param_types.Array(self._param_types.STRING),
+                    "now": self._param_types.TIMESTAMP,
+                    "pk": self._param_types.STRING,
+                    "shard_count": self._param_types.INT64,
+                },
+            )
+            if int(updated) != shard_count:
+                raise RuntimeError("abuse clear did not cover every active shard")
+            workspace.billing_pause_causes = causes
+            workspace.billing_paused = bool(causes)
+            workspace.billing_pause_reason = reason
+            if update_entity_body_dml(
+                transaction,
+                self._param_types,
+                "workspace",
+                workspace_id,
+                _json_body(workspace),
+                now,
+            ) != 1:
+                raise RuntimeError("workspace disappeared during abuse clear")
+            return True
+
+        try:
+            return self._run_in_transaction(txn)
+        except Exception as exc:
+            if is_duplicate_key_error(exc):
+                return False
+            raise
+
+    def backfill_owner_inventory(self, *, source_version: str, environment: str) -> int:
+        source_version = source_version.strip()
+        environment = environment.strip()
+        if not source_version or not environment:
+            raise ValueError("source_version and environment are required")
+
+        def txn(transaction: Any) -> int:
+            workspace_rows = list(
+                transaction.execute_sql(
+                    "SELECT id, body FROM tr_entities WHERE kind='workspace' ORDER BY id"
+                )
+            )
+            expected: set[tuple[str, str]] = set()
+            for workspace_id, raw in workspace_rows:
+                workspace = _auth_record(str(raw), Workspace)
+                if not workspace.deleted and not workspace.federated_home:
+                    expected.add((workspace.owner_user_id, str(workspace_id)))
+            actual = {
+                (str(owner), str(workspace_id))
+                for owner, workspace_id in transaction.execute_sql(
+                    "SELECT owner_user_id, workspace_id FROM tr_owner_workspace "
+                    "ORDER BY owner_user_id, workspace_id"
+                )
+            }
+            for owner_user_id, workspace_id in sorted(expected - actual):
+                self._insert_owner_inventory_tx(
+                    transaction, owner_user_id, workspace_id
+                )
+            extra = sorted(actual - expected)
+            if extra:
+                transaction.delete(
+                    "tr_owner_workspace", self._spanner.KeySet(keys=extra)
+                )
+            owners = {owner for owner, _workspace_id in expected | actual}
+            for owner_user_id in sorted(owners):
+                user = self._read_entity_tx(
+                    transaction, "user", owner_user_id, User
+                )
+                if user is not None:
+                    user.owner_workspace_count = sum(
+                        owner == owner_user_id for owner, _workspace_id in expected
+                    )
+                    self._write_entity_tx(transaction, "user", user.id, user)
+            now = dt.datetime.now(dt.UTC)
+            transaction.insert_or_update(
+                table="tr_trust_backfill",
+                columns=(
+                    "provider",
+                    "account_id",
+                    "environment",
+                    "source",
+                    "source_version",
+                    "history_start",
+                    "closed_through",
+                    "consistency_delay_seconds",
+                    "unmatched_count",
+                    "semantic_mismatch_count",
+                    "completed_at",
+                ),
+                values=[(
+                    "owner_inventory",
+                    "local",
+                    environment,
+                    "tr_entities.workspace",
+                    source_version,
+                    now,
+                    now,
+                    0,
+                    0,
+                    0,
+                    now,
+                )],
+            )
+            return len(expected ^ actual)
+
+        return self._run_in_transaction(txn)
+
+    def process_trust_demotion_remainders(self, *, limit: int = 25) -> int:
+        if limit <= 0:
+            return 0
+        with self._database.snapshot() as snapshot:
+            rows = list(
+                snapshot.execute_sql(
+                    "SELECT owner_user_id, workspace_id, target_identity_ceiling "
+                    "FROM tr_trust_demotion_remainder ORDER BY created_at LIMIT @limit",
+                    params={"limit": int(limit)},
+                    param_types={"limit": self._param_types.INT64},
+                )
+            )
+        completed = 0
+        for owner_user_id, workspace_id, ceiling in rows:
+            owner_id = str(owner_user_id)
+            remainder_workspace_id = str(workspace_id)
+            target_ceiling = int(ceiling)
+
+            def txn(
+                transaction: Any,
+                *,
+                owner_id: str = owner_id,
+                remainder_workspace_id: str = remainder_workspace_id,
+                target_ceiling: int = target_ceiling,
+            ) -> bool:
+                current = list(
+                    transaction.execute_sql(
+                        "SELECT target_identity_ceiling FROM tr_trust_demotion_remainder "
+                        "WHERE owner_user_id=@owner AND workspace_id=@workspace",
+                        params={
+                            "owner": owner_id,
+                            "workspace": remainder_workspace_id,
+                        },
+                        param_types={
+                            "owner": self._param_types.STRING,
+                            "workspace": self._param_types.STRING,
+                        },
+                    )
+                )
+                if not current:
+                    return False
+                override_rows = list(
+                    transaction.execute_sql(
+                        "SELECT identity_bypass FROM tr_trust_override "
+                        "WHERE workspace_id=@pk",
+                        params={"pk": remainder_workspace_id},
+                        param_types={"pk": self._param_types.STRING},
+                    )
+                )
+                identity_bypass = bool(override_rows and override_rows[0][0])
+                account = self._read_entity_tx(
+                    transaction, "credit", remainder_workspace_id, CreditAccount
+                )
+                if account is None:
+                    raise RuntimeError("demotion remainder references missing credit")
+                shard_count = credit_shard_count(account)
+                shard_rows = list(
+                    transaction.execute_sql(
+                        "SELECT shard, trust_tier FROM tr_credit_balance "
+                        "WHERE workspace_id=@pk AND shard>=0 AND shard<@shard_count "
+                        "ORDER BY shard",
+                        params={
+                            "pk": remainder_workspace_id,
+                            "shard_count": shard_count,
+                        },
+                        param_types={
+                            "pk": self._param_types.STRING,
+                            "shard_count": self._param_types.INT64,
+                        },
+                    )
+                )
+                if [int(row[0]) for row in shard_rows] != list(range(shard_count)):
+                    raise RuntimeError(
+                        "configured tr_credit_balance shard set is incomplete"
+                    )
+                now = dt.datetime.now(dt.UTC)
+                if not identity_bypass:
+                    transaction.insert_or_update(
+                        table=CREDIT_BALANCE_TABLE,
+                        columns=(
+                            "workspace_id",
+                            "shard",
+                            "trust_tier",
+                            "trust_computed_at",
+                        ),
+                        values=[
+                            (
+                                remainder_workspace_id,
+                                int(shard),
+                                min(int(tier or 0), target_ceiling),
+                                now,
+                            )
+                            for shard, tier in shard_rows
+                        ],
+                    )
+                transaction.delete(
+                    "tr_trust_demotion_remainder",
+                    self._spanner.KeySet(
+                        keys=[(owner_id, remainder_workspace_id)]
+                    ),
+                )
+                return True
+
+            completed += int(self._run_in_transaction(txn))
+        return completed
 
     def get_credit_account(self, workspace_id: str) -> CreditAccount | None:
         return self._read_entity("credit", workspace_id, CreditAccount)
@@ -1269,7 +2096,12 @@ class SpannerBigtableStore:
                 user = self._read_entity_tx(transaction, "user", existing_record["user_id"], User)
                 if user is not None:
                     return user
-            new_user = User(id=str(uuid.uuid4()), email=None, wallet_address=normalized)
+            new_user = User(
+                id=str(uuid.uuid4()),
+                email=None,
+                wallet_address=normalized,
+                owner_workspace_count=1,
+            )
             workspace = Workspace(
                 id=str(uuid.uuid4()),
                 name="Personal Workspace",
@@ -1293,6 +2125,7 @@ class SpannerBigtableStore:
                 0,
                 shard_count=credit.shard_count,
             )
+            self._insert_owner_inventory_tx(transaction, new_user.id, workspace.id)
             return new_user
 
         return self._run_in_transaction(txn)
@@ -1333,6 +2166,80 @@ class SpannerBigtableStore:
 
         return self._run_in_transaction(txn)
 
+    def _demote_owner_trust_tx(
+        self, transaction: Any, owner_user_id: str, *, now: dt.datetime
+    ) -> None:
+        workspace_ids, shard_counts = self._owner_shard_counts_tx(
+            transaction, owner_user_id
+        )
+        total_cost = sum(shard_counts) * TRUST_REPLICATED_COLUMN_COUNT
+        remaining_budget = TRUST_OWNER_MUTATION_BUDGET
+        for workspace_id, shard_count in zip(
+            workspace_ids, shard_counts, strict=True
+        ):
+            cost = shard_count * TRUST_REPLICATED_COLUMN_COUNT
+            if total_cost > TRUST_OWNER_MUTATION_BUDGET and cost > remaining_budget:
+                transaction.insert_or_update(
+                    table="tr_trust_demotion_remainder",
+                    columns=(
+                        "owner_user_id",
+                        "workspace_id",
+                        "target_identity_ceiling",
+                        "created_at",
+                        "attempts",
+                        "last_error",
+                    ),
+                    values=[(owner_user_id, workspace_id, 1, now, 0, None)],
+                )
+                log.error(
+                    "trust.identity_demotion_remainder owner=%s workspace=%s",
+                    owner_user_id,
+                    workspace_id,
+                )
+                continue
+            remaining_budget -= cost
+            bypass_rows = list(
+                transaction.execute_sql(
+                    "SELECT identity_bypass FROM tr_trust_override "
+                    "WHERE workspace_id=@pk",
+                    params={"pk": workspace_id},
+                    param_types={"pk": self._param_types.STRING},
+                )
+            )
+            identity_bypass = bool(bypass_rows and bypass_rows[0][0])
+            rows = list(
+                transaction.execute_sql(
+                    "SELECT shard, trust_tier FROM tr_credit_balance "
+                    "WHERE workspace_id=@pk AND shard>=0 AND shard<@shard_count "
+                    "ORDER BY shard",
+                    params={"pk": workspace_id, "shard_count": shard_count},
+                    param_types={
+                        "pk": self._param_types.STRING,
+                        "shard_count": self._param_types.INT64,
+                    },
+                )
+            )
+            if [int(row[0]) for row in rows] != list(range(shard_count)):
+                raise RuntimeError("configured tr_credit_balance shard set is incomplete")
+            transaction.insert_or_update(
+                table=CREDIT_BALANCE_TABLE,
+                columns=(
+                    "workspace_id",
+                    "shard",
+                    "trust_tier",
+                    "trust_computed_at",
+                ),
+                values=[
+                    (
+                        workspace_id,
+                        int(shard),
+                        int(tier or 0) if identity_bypass else min(int(tier or 0), 1),
+                        now,
+                    )
+                    for shard, tier in rows
+                ],
+            )
+
     def set_user_identity_status(
         self,
         user_id: str,
@@ -1350,6 +2257,7 @@ class SpannerBigtableStore:
             user = self._read_entity_tx(transaction, "user", user_id, User)
             if user is None:
                 return None
+            was_approved = user.identity_status == "approved"
             normalized = IdentityVerificationStatus.coerce(status)
             if normalized is IdentityVerificationStatus.APPROVED and not user.identity_verified_at:
                 user.identity_verified_at = iso_now()
@@ -1371,7 +2279,54 @@ class SpannerBigtableStore:
             if increment_attempts:
                 user.veriff_attempt_count += 1
             self._write_entity_tx(transaction, "user", user.id, user)
+            if was_approved and normalized is not IdentityVerificationStatus.APPROVED:
+                self._demote_owner_trust_tx(
+                    transaction, user_id, now=dt.datetime.now(dt.UTC)
+                )
             return user
+
+        return self._run_in_transaction(txn)
+
+    def apply_veriff_identity_decision(
+        self,
+        user_id: str,
+        *,
+        event_id: str,
+        session_id: str,
+        status: str,
+        decision_code: int,
+        decision_reason: str | None = None,
+        decision_reason_code: int | None = None,
+        verified_name: str | None = None,
+    ) -> str:
+        marker_id = f"veriff#{event_id}"
+
+        def txn(transaction: Any) -> str:
+            if self._read_entity_tx(transaction, "webhook_event", marker_id, dict):
+                return "replayed"
+            now = dt.datetime.now(dt.UTC)
+            self._write_entity_tx(
+                transaction, "webhook_event", marker_id, {"created_at": iso_now()}
+            )
+            user = self._read_entity_tx(transaction, "user", user_id, User)
+            if user is None or user.veriff_session_id != session_id:
+                return "ignored"
+            was_approved = user.identity_status == "approved"
+            normalized = IdentityVerificationStatus.coerce(status)
+            if normalized is IdentityVerificationStatus.APPROVED and not user.identity_verified_at:
+                user.identity_verified_at = iso_now()
+            user.identity_status = normalized.value
+            user.veriff_decision_code = decision_code
+            if decision_reason is not None:
+                user.veriff_decision_reason = decision_reason
+            if decision_reason_code is not None:
+                user.veriff_decision_reason_code = decision_reason_code
+            if verified_name is not None:
+                user.identity_verified_name = verified_name
+            self._write_entity_tx(transaction, "user", user.id, user)
+            if was_approved and normalized is not IdentityVerificationStatus.APPROVED:
+                self._demote_owner_trust_tx(transaction, user_id, now=now)
+            return "applied"
 
         return self._run_in_transaction(txn)
 

--- a/src/trusted_router/storage_gcp_credit_shard_admin.py
+++ b/src/trusted_router/storage_gcp_credit_shard_admin.py
@@ -17,9 +17,11 @@ from trusted_router.storage_gcp_legacy_reservations import (
 )
 from trusted_router.storage_models import (
     CreditAccount,
+    User,
     Workspace,
     workspace_billing_paused,
 )
+from trusted_router.trust_ownership import require_owner_trust_budget
 
 _RESHARD_COLUMNS = (
     "workspace_id",
@@ -256,6 +258,34 @@ def reshard_credit_account(
         if workspace is None or not workspace_billing_paused(workspace) or account is None:
             return None
         current_count = credit_shard_count(account)
+        owned_workspace_ids, owned_shard_counts = store._owner_shard_counts_tx(
+            transaction, workspace.owner_user_id
+        )
+        if workspace_id not in owned_workspace_ids:
+            # A slice-1a/1b' workspace can legitimately predate the inventory
+            # backfill. Repair that legacy gap on touch so reshard remains
+            # available while the fleet-wide backfill drains, and so the
+            # resulting fan-out is represented before this transaction commits.
+            store._insert_owner_inventory_tx(
+                transaction, workspace.owner_user_id, workspace_id
+            )
+            owner = store._read_entity_tx(
+                transaction, "user", workspace.owner_user_id, User
+            )
+            if owner is not None:
+                owner.owner_workspace_count = len(owned_workspace_ids) + 1
+                store._write_entity_tx(transaction, "user", owner.id, owner)
+            owned_workspace_ids.append(workspace_id)
+            owned_shard_counts.append(current_count)
+        if target_count > current_count:
+            require_owner_trust_budget(
+                [
+                    target_count if owned_id == workspace_id else shard_count
+                    for owned_id, shard_count in zip(
+                        owned_workspace_ids, owned_shard_counts, strict=True
+                    )
+                ]
+            )
         rows = list(
             transaction.execute_sql(
                 "SELECT shard, total_credits, total_usage, reserved, "

--- a/src/trusted_router/storage_gcp_trust.py
+++ b/src/trusted_router/storage_gcp_trust.py
@@ -729,6 +729,18 @@ def recompute_workspace_trust_tier_tx(
             raise ValueError("workspace_or_credit_account_not_found")
         owner = read_entity_tx(transaction, "user", workspace.owner_user_id, User)
         owner_status = owner.identity_status if owner is not None else "none"
+        override_rows = list(
+            transaction.execute_sql(
+                "SELECT tier, identity_bypass FROM tr_trust_override "
+                "WHERE workspace_id=@pk",
+                params={"pk": workspace_id},
+                param_types={"pk": param_types.STRING},
+            )
+        )
+        if len(override_rows) > 1:
+            raise RuntimeError("trust override primary key invariant violated")
+        override_tier = None if not override_rows else int(override_rows[0][0])
+        identity_bypass = bool(override_rows and override_rows[0][1])
         event_rows = list(
             transaction.execute_sql(
                 "SELECT event_id, kind, provider, amount_micro, original_payment_ref, "
@@ -764,15 +776,18 @@ def recompute_workspace_trust_tier_tx(
         override_values = {row[3] for row in shard_rows}
         if len(latch_values) != 1 or len(override_values) != 1:
             raise RuntimeError("replicated trust columns diverged")
+        if next(iter(override_values)) != override_tier:
+            raise RuntimeError("trust override row and replicated shard value diverged")
         decision = compute_trust_tier(
             events,
             owner_identity_status=owner_status,
             trust_latched_at=shard_rows[0][2],
-            trust_override_tier=shard_rows[0][3],
+            trust_override_tier=override_tier,
             qualifying_providers=qualifying_providers,
             tier3_min_days=tier3_min_days,
             tier3_min_paid_microdollars=tier3_min_paid_microdollars,
             now=now,
+            identity_bypass=identity_bypass,
         )
         updated = transaction.execute_update(
             "UPDATE tr_credit_balance SET trust_tier=@trust_tier, "

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -160,6 +160,9 @@ class User:
     veriff_decision_reason: str | None = None
     veriff_decision_reason_code: int | None = None
     veriff_attempt_count: int = 0
+    # Maintained with tr_owner_workspace. This is an inventory invariant, not
+    # a cached display count: every ownership-changing transaction rewrites it.
+    owner_workspace_count: int = 0
 
     @property
     def identity_verified(self) -> bool:
@@ -227,6 +230,16 @@ class Workspace:
             self.billing_pause_causes = ["migration"]
         self.billing_pause_causes = sorted(set(self.billing_pause_causes))
         self.billing_paused = bool(self.billing_pause_causes)
+
+
+@dataclass(frozen=True, slots=True)
+class TrustOverride:
+    workspace_id: str
+    tier: int
+    identity_bypass: bool
+    operator_identity: str
+    reason: str
+    set_at: dt.datetime
 
 
 def workspace_billing_paused(workspace: object | None) -> bool:

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -150,6 +150,7 @@ from trusted_router.storage_models import (
     SyntheticRollup,
     TrustEvent,
     TrustInboxRow,
+    TrustOverride,
     User,
     UserProvidedModel,
     VerificationToken,
@@ -192,9 +193,16 @@ from trusted_router.synthetic.rollups import (
     new_rollup_for_sample,
     sample_rollup_ids,
 )
+from trusted_router.trust_ownership import (
+    TRUST_OWNER_MUTATION_BUDGET,
+    TRUST_REPLICATED_COLUMN_COUNT,
+    WorkspaceOwnerLimitExceeded,
+    require_owner_trust_budget,
+)
 from trusted_router.trust_tiers import (
     adverse_event_payload,
     adverse_transition_outcome,
+    compute_trust_tier,
     payment_or_grant_event,
     payment_recovery_target,
     validate_adverse_event,
@@ -506,12 +514,22 @@ class PostgresStore:
         postgres_iam_auth: str = "",
         postgres_iam_region: str = "",
         operational_analytics_outbox_enabled: bool = False,
+        max_workspaces_per_owner: int = 25,
+        trust_qualifying_providers: frozenset[str] = frozenset({"stripe", "x402"}),
+        trust_tier3_min_days: int = 30,
+        trust_tier3_min_paid_microdollars: int = 50_000_000,
     ) -> None:
         if not dsn:
             raise ValueError("Postgres DSN is required")
         if transaction_attempts < 1:
             raise ValueError("transaction_attempts must be positive")
         self._transaction_attempts = transaction_attempts
+        self.max_workspaces_per_owner = int(max_workspaces_per_owner)
+        self.trust_qualifying_providers = trust_qualifying_providers
+        self.trust_tier3_min_days = int(trust_tier3_min_days)
+        self.trust_tier3_min_paid_microdollars = int(
+            trust_tier3_min_paid_microdollars
+        )
         # Aurora DSQL refuses the GUC outright -- `SET LOCAL statement_timeout`
         # answers `ERROR: setting configuration parameter "statement_timeout"
         # not supported` -- so issuing it does not merely fail to bound the
@@ -980,6 +998,50 @@ class PostgresStore:
         )
         return cursor.rowcount == 1
 
+    def _owner_workspace_shards_tx(
+        self, conn: Any, owner_user_id: str
+    ) -> list[tuple[str, int]]:
+        rows = conn.execute(
+            "SELECT ow.workspace_id, COUNT(cb.shard) "
+            "FROM tr_owner_workspace AS ow "
+            "JOIN tr_credit_balance AS cb ON cb.workspace_id = ow.workspace_id "
+            "WHERE ow.owner_user_id = %s GROUP BY ow.workspace_id "
+            "ORDER BY ow.workspace_id",
+            (owner_user_id,),
+        ).fetchall()
+        return [(str(workspace_id), int(shards)) for workspace_id, shards in rows]
+
+    def _require_owner_growth_tx(
+        self,
+        conn: Any,
+        owner_user_id: str,
+        *,
+        added_shards: int,
+        enforce_count: bool,
+    ) -> list[tuple[str, int]]:
+        # The owner row serializes count-and-insert on ordinary PostgreSQL.
+        # Aurora DSQL/PGAdapter may abort instead; _run_transaction retries it.
+        self._read_entity_tx(conn, "user", owner_user_id, User, for_update=True)
+        owned = self._owner_workspace_shards_tx(conn, owner_user_id)
+        if enforce_count and len(owned) >= self.max_workspaces_per_owner:
+            raise WorkspaceOwnerLimitExceeded(
+                "owner has reached TR_MAX_WORKSPACES_PER_OWNER"
+            )
+        require_owner_trust_budget([*([shards for _workspace, shards in owned]), added_shards])
+        return owned
+
+    def _insert_owner_inventory_tx(
+        self, conn: Any, owner_user_id: str, workspace_id: str
+    ) -> None:
+        inserted = conn.execute(
+            "INSERT INTO tr_owner_workspace (owner_user_id, workspace_id) "
+            "VALUES (%s, %s) "
+            "ON CONFLICT (owner_user_id, workspace_id) DO NOTHING",
+            (owner_user_id, workspace_id),
+        )
+        if inserted.rowcount != 1:
+            raise RuntimeError("new workspace owner inventory already exists")
+
     def _create_workspace_tx(
         self,
         conn: Any,
@@ -998,6 +1060,12 @@ class PostgresStore:
             role="owner",
         )
         credit = CreditAccount(workspace_id=workspace.id)
+        owned = self._require_owner_growth_tx(
+            conn,
+            owner_user_id,
+            added_shards=credit_shard_count(credit),
+            enforce_count=True,
+        )
         initial_total = 0 if trial_credit_microdollars is None else int(trial_credit_microdollars)
         self._write_entity_tx(conn, "workspace", workspace.id, workspace)
         self._write_entity_tx(
@@ -1013,6 +1081,13 @@ class PostgresStore:
             "VALUES (%s, 0, %s, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
             (workspace.id, initial_total),
         )
+        self._insert_owner_inventory_tx(conn, owner_user_id, workspace.id)
+        owner = self._read_entity_tx(
+            conn, "user", owner_user_id, User, for_update=True
+        )
+        if owner is not None:
+            owner.owner_workspace_count = len(owned) + 1
+            self._write_entity_tx(conn, "user", owner.id, owner)
         if initial_total > 0:
             recorded_at = dt.datetime.now(dt.UTC)
             self._insert_credit_trust_event_tx(
@@ -1344,7 +1419,428 @@ class PostgresStore:
         billing_paused: bool | None = None,
         billing_pause_reason: str | None = None,
     ) -> Workspace | None:
-        self._not_implemented("update_workspace")
+        def txn(conn: Any) -> Workspace | None:
+            workspace = self._read_entity_tx(
+                conn, "workspace", workspace_id, Workspace, for_update=True
+            )
+            if workspace is None:
+                return None
+            owner = self._read_entity_tx(
+                conn, "user", workspace.owner_user_id, User, for_update=True
+            )
+            if deleted is not None and deleted != workspace.deleted:
+                credit = self._read_entity_tx(
+                    conn, "credit", workspace_id, CreditAccount, for_update=True
+                )
+                if credit is None:
+                    raise RuntimeError("workspace is missing its credit account")
+                if deleted:
+                    removed = conn.execute(
+                        "DELETE FROM tr_owner_workspace "
+                        "WHERE owner_user_id = %s AND workspace_id = %s",
+                        (workspace.owner_user_id, workspace_id),
+                    )
+                    if removed.rowcount != 1:
+                        raise RuntimeError(
+                            "active workspace is missing from tr_owner_workspace"
+                        )
+                    changed = conn.execute(
+                        "UPDATE tr_credit_balance SET trust_tier = 0, "
+                        "trust_latched_at = COALESCE(trust_latched_at, CURRENT_TIMESTAMP), "
+                        "updated_at = CURRENT_TIMESTAMP WHERE workspace_id = %s",
+                        (workspace_id,),
+                    )
+                    if changed.rowcount != credit_shard_count(credit):
+                        raise RuntimeError(
+                            "archive trust latch did not cover every active shard"
+                        )
+                    lease_rows = conn.execute(
+                        "SELECT kind, id, body FROM tr_entities WHERE "
+                        "kind IN ('spend_lease', 'regional_quota_lease')"
+                    ).fetchall()
+                    for lease_kind, lease_id, raw_body in lease_rows:
+                        body = (
+                            json.loads(raw_body)
+                            if isinstance(raw_body, str)
+                            else dict(raw_body)
+                        )
+                        if body.get("workspace_id") != workspace_id:
+                            continue
+                        if lease_kind == "spend_lease" and body.get("state") != "CLOSED":
+                            body["state"] = "TOMBSTONED"
+                            body["closing_at"] = iso_now()
+                        elif (
+                            lease_kind == "regional_quota_lease"
+                            and body.get("state") != "closed"
+                        ):
+                            body["state"] = "quarantined"
+                            body["last_error"] = "workspace_archived"
+                            body["updated_at"] = iso_now()
+                        else:
+                            continue
+                        self._write_entity_tx(
+                            conn, str(lease_kind), str(lease_id), body
+                        )
+                else:
+                    owned = self._require_owner_growth_tx(
+                        conn,
+                        workspace.owner_user_id,
+                        added_shards=credit_shard_count(credit),
+                        enforce_count=True,
+                    )
+                    self._insert_owner_inventory_tx(
+                        conn, workspace.owner_user_id, workspace_id
+                    )
+                    if owner is not None:
+                        owner.owner_workspace_count = len(owned) + 1
+                if deleted and owner is not None:
+                    owner.owner_workspace_count = len(
+                        self._owner_workspace_shards_tx(
+                            conn, workspace.owner_user_id
+                        )
+                    )
+                workspace.deleted = deleted
+            if name is not None:
+                workspace.name = name
+            if billing_paused is not None:
+                causes = set(workspace.billing_pause_causes)
+                if billing_paused:
+                    causes.add("migration")
+                else:
+                    causes.discard("migration")
+                workspace.billing_pause_causes = sorted(causes)
+                workspace.billing_paused = bool(causes)
+            if billing_pause_reason is not None:
+                workspace.billing_pause_reason = billing_pause_reason
+            if owner is not None:
+                self._write_entity_tx(conn, "user", owner.id, owner)
+            self._write_entity_tx(conn, "workspace", workspace_id, workspace)
+            return None if workspace.deleted else workspace
+
+        return self._run_transaction(txn)
+
+    def set_workspace_trust_override(
+        self,
+        workspace_id: str,
+        *,
+        tier: int,
+        identity_bypass: bool,
+        operator_identity: str,
+        reason: str,
+    ) -> TrustOverride:
+        if isinstance(tier, bool) or not 0 <= int(tier) <= 3:
+            raise ValueError("trust override tier must be between 0 and 3")
+        if not operator_identity.strip() or not reason.strip():
+            raise ValueError("operator identity and reason are required")
+
+        def txn(conn: Any) -> TrustOverride:
+            workspace = self._read_entity_tx(
+                conn, "workspace", workspace_id, Workspace, for_update=True
+            )
+            account = self._read_entity_tx(
+                conn, "credit", workspace_id, CreditAccount, for_update=True
+            )
+            if workspace is None or workspace.deleted or account is None:
+                raise ValueError("workspace_not_found")
+            owner = self._read_entity_tx(conn, "user", workspace.owner_user_id, User)
+            event_rows = conn.execute(
+                "SELECT " + self._trust_event_select() + " FROM tr_trust_event "  # noqa: S608
+                "WHERE workspace_id = %s",
+                (workspace_id,),
+                prepare=False,
+            ).fetchall()
+            shard_rows = conn.execute(
+                "SELECT shard, trust_latched_at FROM tr_credit_balance "
+                "WHERE workspace_id = %s ORDER BY shard FOR UPDATE",
+                (workspace_id,),
+            ).fetchall()
+            shard_count = credit_shard_count(account)
+            if [int(row[0]) for row in shard_rows] != list(range(shard_count)):
+                raise RuntimeError("configured tr_credit_balance shard set is incomplete")
+            latches = {row[1] for row in shard_rows}
+            if len(latches) != 1:
+                raise RuntimeError("replicated trust latch diverged")
+            now = dt.datetime.now(dt.UTC)
+            decision = compute_trust_tier(
+                [self._trust_event_from_row(row) for row in event_rows],
+                owner_identity_status=owner.identity_status if owner else "none",
+                trust_latched_at=shard_rows[0][1],
+                trust_override_tier=int(tier),
+                qualifying_providers=self.trust_qualifying_providers,
+                tier3_min_days=self.trust_tier3_min_days,
+                tier3_min_paid_microdollars=self.trust_tier3_min_paid_microdollars,
+                now=now,
+                identity_bypass=bool(identity_bypass),
+            )
+            record = TrustOverride(
+                workspace_id,
+                int(tier),
+                bool(identity_bypass),
+                operator_identity.strip(),
+                reason.strip(),
+                now,
+            )
+            conn.execute(
+                "INSERT INTO tr_trust_override "
+                "(workspace_id, tier, identity_bypass, operator_identity, reason, set_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s) "
+                "ON CONFLICT (workspace_id) DO UPDATE SET "
+                "tier = EXCLUDED.tier, identity_bypass = EXCLUDED.identity_bypass, "
+                "operator_identity = EXCLUDED.operator_identity, reason = EXCLUDED.reason, "
+                "set_at = EXCLUDED.set_at",
+                dataclasses.astuple(record),
+            )
+            updated = conn.execute(
+                "UPDATE tr_credit_balance SET trust_tier = %s, "
+                "trust_computed_at = %s, trust_override_tier = %s, "
+                "updated_at = CURRENT_TIMESTAMP WHERE workspace_id = %s",
+                (decision.effective_tier, now, int(tier), workspace_id),
+            )
+            if updated.rowcount != shard_count:
+                raise RuntimeError("trust override did not cover every active shard")
+            return record
+
+        return self._run_transaction(txn)
+
+    def record_workspace_abuse_and_demote(
+        self,
+        workspace_id: str,
+        *,
+        abuse_ref: str,
+        operator_identity: str,
+        reason: str,
+    ) -> bool:
+        abuse_ref = abuse_ref.strip()
+        operator_identity = operator_identity.strip()
+        reason = reason.strip()
+        if not abuse_ref or not operator_identity or not reason:
+            raise ValueError("abuse_ref, operator identity and reason are required")
+
+        def txn(conn: Any) -> bool:
+            existing = conn.execute(
+                "SELECT workspace_id, kind FROM tr_trust_event "
+                "WHERE provider = %s AND adverse_ref = %s FOR UPDATE",
+                ("operator", abuse_ref),
+            ).fetchone()
+            if existing is not None:
+                if str(existing[0]) != workspace_id or str(existing[1]) != "abuse":
+                    raise ValueError("abuse_ref_conflict")
+                return False
+            workspace = self._read_entity_tx(
+                conn, "workspace", workspace_id, Workspace, for_update=True
+            )
+            account = self._read_entity_tx(
+                conn, "credit", workspace_id, CreditAccount, for_update=True
+            )
+            if workspace is None or workspace.deleted or account is None:
+                raise ValueError("workspace_not_found")
+            rows = conn.execute(
+                "SELECT shard, trust_latched_at, billing_pause_causes, pause_epoch "
+                "FROM tr_credit_balance WHERE workspace_id = %s ORDER BY shard FOR UPDATE",
+                (workspace_id,),
+            ).fetchall()
+            shard_count = credit_shard_count(account)
+            if [int(row[0]) for row in rows] != list(range(shard_count)):
+                raise RuntimeError("configured tr_credit_balance shard set is incomplete")
+            controls = {
+                (row[1], tuple(json.loads(row[2])) if isinstance(row[2], str) else tuple(row[2] or ()))
+                for row in rows
+            }
+            if len(controls) != 1:
+                raise RuntimeError("replicated trust controls diverged")
+            latched_at, old_causes = next(iter(controls))
+            now = dt.datetime.now(dt.UTC)
+            event = TrustEvent(
+                workspace_id,
+                f"abuse:{abuse_ref}",
+                "abuse",
+                "operator",
+                0,
+                None,
+                abuse_ref,
+                now,
+                now,
+                None,
+                None,
+                None,
+                None,
+                "operator",
+                "succeeded",
+                None,
+                0,
+                "debited",
+                0,
+                None,
+            )
+            inserted = conn.execute(
+                "INSERT INTO tr_trust_event (" + self._trust_event_select() + ") "  # noqa: S608
+                "VALUES (" + ",".join(["%s"] * 20) + ") "  # noqa: S608
+                "ON CONFLICT (provider, adverse_ref, kind) "
+                "WHERE adverse_ref IS NOT NULL DO NOTHING",
+                dataclasses.astuple(event),
+                prepare=False,
+            )
+            if inserted.rowcount != 1:
+                existing = conn.execute(
+                    "SELECT workspace_id, kind FROM tr_trust_event "
+                    "WHERE provider = %s AND adverse_ref = %s FOR UPDATE",
+                    ("operator", abuse_ref),
+                ).fetchone()
+                if existing is None:
+                    raise RuntimeError("operator abuse reference insert disappeared")
+                if str(existing[0]) != workspace_id or str(existing[1]) != "abuse":
+                    raise ValueError("abuse_ref_conflict")
+                return False
+            if not self._insert_entity_once_tx(
+                conn,
+                "trust_abuse",
+                f"{workspace_id}#{abuse_ref}",
+                {
+                    "workspace_id": workspace_id,
+                    "abuse_ref": abuse_ref,
+                    "operator_identity": operator_identity,
+                    "reason": reason,
+                    "recorded_at": now.isoformat(),
+                },
+            ):
+                raise RuntimeError("operator abuse audit reference already exists")
+            causes = sorted({*old_causes, "abuse"})
+            updated = conn.execute(
+                "UPDATE tr_credit_balance SET trust_tier = 0, "
+                "trust_latched_at = COALESCE(trust_latched_at, %s), "
+                "billing_pause_causes = %s::jsonb, pause_epoch = pause_epoch + 1, "
+                "updated_at = CURRENT_TIMESTAMP WHERE workspace_id = %s",
+                (latched_at or now, json.dumps(causes), workspace_id),
+            )
+            if updated.rowcount != shard_count:
+                raise RuntimeError("abuse latch did not cover every active shard")
+            workspace.billing_pause_causes = causes
+            workspace.billing_paused = True
+            workspace.billing_pause_reason = reason
+            self._write_entity_tx(conn, "workspace", workspace_id, workspace)
+            return True
+
+        return self._run_transaction(txn)
+
+    def clear_workspace_abuse_pause(
+        self,
+        workspace_id: str,
+        *,
+        abuse_ref: str,
+        operator_identity: str,
+        reason: str,
+    ) -> bool:
+        if not abuse_ref.strip() or not operator_identity.strip() or not reason.strip():
+            raise ValueError("abuse_ref, operator identity and reason are required")
+
+        def txn(conn: Any) -> bool:
+            audit_id = f"{workspace_id}#{abuse_ref.strip()}"
+            if not self._insert_entity_once_tx(
+                conn,
+                "trust_abuse_clear",
+                audit_id,
+                {
+                    "workspace_id": workspace_id,
+                    "abuse_ref": abuse_ref.strip(),
+                    "operator_identity": operator_identity.strip(),
+                    "reason": reason.strip(),
+                    "cleared_at": iso_now(),
+                },
+            ):
+                return False
+            workspace = self._read_entity_tx(
+                conn, "workspace", workspace_id, Workspace, for_update=True
+            )
+            account = self._read_entity_tx(
+                conn, "credit", workspace_id, CreditAccount, for_update=True
+            )
+            if workspace is None or workspace.deleted or account is None:
+                raise ValueError("workspace_not_found")
+            causes = sorted(set(workspace.billing_pause_causes) - {"abuse"})
+            updated = conn.execute(
+                "UPDATE tr_credit_balance SET billing_pause_causes = %s::jsonb, "
+                "pause_epoch = pause_epoch + 1, updated_at = CURRENT_TIMESTAMP "
+                "WHERE workspace_id = %s",
+                (json.dumps(causes), workspace_id),
+            )
+            if updated.rowcount != credit_shard_count(account):
+                raise RuntimeError("abuse clear did not cover every active shard")
+            workspace.billing_pause_causes = causes
+            workspace.billing_paused = bool(causes)
+            workspace.billing_pause_reason = reason.strip()
+            self._write_entity_tx(conn, "workspace", workspace_id, workspace)
+            return True
+
+        return self._run_transaction(txn)
+
+    def transfer_workspace_ownership(
+        self, workspace_id: str, new_owner_user_id: str
+    ) -> Workspace:
+        def txn(conn: Any) -> Workspace:
+            workspace = self._read_entity_tx(
+                conn, "workspace", workspace_id, Workspace, for_update=True
+            )
+            credit = self._read_entity_tx(
+                conn, "credit", workspace_id, CreditAccount, for_update=True
+            )
+            if workspace is None or workspace.deleted or credit is None:
+                raise ValueError("workspace_not_found")
+            old_owner_user_id = workspace.owner_user_id
+            if old_owner_user_id == new_owner_user_id:
+                return workspace
+            new_owned = self._require_owner_growth_tx(
+                conn,
+                new_owner_user_id,
+                added_shards=credit_shard_count(credit),
+                enforce_count=True,
+            )
+            old_owned = self._owner_workspace_shards_tx(conn, old_owner_user_id)
+            removed = conn.execute(
+                "DELETE FROM tr_owner_workspace "
+                "WHERE owner_user_id = %s AND workspace_id = %s",
+                (old_owner_user_id, workspace_id),
+            )
+            if removed.rowcount != 1:
+                raise RuntimeError("active workspace is missing from owner inventory")
+            self._insert_owner_inventory_tx(conn, new_owner_user_id, workspace_id)
+            old_owner = self._read_entity_tx(
+                conn, "user", old_owner_user_id, User, for_update=True
+            )
+            new_owner = self._read_entity_tx(
+                conn, "user", new_owner_user_id, User, for_update=True
+            )
+            if old_owner is not None:
+                old_owner.owner_workspace_count = max(0, len(old_owned) - 1)
+                self._write_entity_tx(conn, "user", old_owner.id, old_owner)
+            if new_owner is not None:
+                new_owner.owner_workspace_count = len(new_owned) + 1
+                self._write_entity_tx(conn, "user", new_owner.id, new_owner)
+            old_member = self._read_entity_tx(
+                conn,
+                "member",
+                member_id(workspace_id, old_owner_user_id),
+                Member,
+                for_update=True,
+            )
+            if old_member is not None:
+                old_member.role = "admin"
+                self._write_entity_tx(
+                    conn,
+                    "member",
+                    member_id(workspace_id, old_owner_user_id),
+                    old_member,
+                )
+            self._write_entity_tx(
+                conn,
+                "member",
+                member_id(workspace_id, new_owner_user_id),
+                Member(workspace_id, new_owner_user_id, "owner"),
+            )
+            workspace.owner_user_id = new_owner_user_id
+            self._write_entity_tx(conn, "workspace", workspace_id, workspace)
+            return workspace
+
+        return self._run_transaction(txn)
 
     def add_members(
         self,
@@ -1373,7 +1869,10 @@ class PostgresStore:
         self._not_implemented("find_user_by_email")
 
     def find_user_by_wallet(self, address: str) -> User | None:
-        self._not_implemented("find_user_by_wallet")
+        record = self._read_entity("wallet_user", address.strip().lower(), dict)
+        if record is None:
+            return None
+        return self.get_user(str(record["user_id"]))
 
     def find_user_by_username(self, username: str) -> User | None:
         self._not_implemented("find_user_by_username")
@@ -1382,13 +1881,78 @@ class PostgresStore:
         self._not_implemented("claim_user_username")
 
     def create_wallet_user(self, address: str) -> User:
-        self._not_implemented("create_wallet_user")
+        normalized = address.strip().lower()
+
+        def txn(conn: Any) -> User:
+            existing = self._read_entity_tx(
+                conn, "wallet_user", normalized, dict, for_update=True
+            )
+            if existing is not None:
+                user = self._read_entity_tx(
+                    conn, "user", str(existing["user_id"]), User
+                )
+                if user is not None:
+                    return user
+                raise RuntimeError("wallet index references a missing user")
+            user = User(id=str(uuid.uuid4()), email=None, wallet_address=normalized)
+            self._write_entity_tx(conn, "user", user.id, user)
+            self._write_entity_tx(
+                conn, "wallet_user", normalized, {"user_id": user.id}
+            )
+            self._create_workspace_tx(conn, user.id, "Personal Workspace", 0)
+            return user
+
+        return self._run_transaction(txn)
 
     def set_user_email(self, user_id: str, email: str) -> User | None:
         self._not_implemented("set_user_email")
 
     def mark_user_email_verified(self, user_id: str) -> User | None:
         self._not_implemented("mark_user_email_verified")
+
+    def _demote_owner_trust_tx(
+        self, conn: Any, owner_user_id: str, *, now: dt.datetime
+    ) -> None:
+        owned = self._owner_workspace_shards_tx(conn, owner_user_id)
+        total_cost = sum(shards for _workspace, shards in owned) * (
+            TRUST_REPLICATED_COLUMN_COUNT
+        )
+        remaining_budget = TRUST_OWNER_MUTATION_BUDGET
+        for workspace_id, shard_count in owned:
+            cost = shard_count * TRUST_REPLICATED_COLUMN_COUNT
+            if total_cost > TRUST_OWNER_MUTATION_BUDGET and cost > remaining_budget:
+                conn.execute(
+                    "INSERT INTO tr_trust_demotion_remainder "
+                    "(owner_user_id, workspace_id, target_identity_ceiling, "
+                    "created_at, attempts, last_error) VALUES (%s, %s, 1, %s, 0, NULL) "
+                    "ON CONFLICT (owner_user_id, workspace_id) DO UPDATE SET "
+                    "target_identity_ceiling = EXCLUDED.target_identity_ceiling, "
+                    "last_error = NULL",
+                    (owner_user_id, workspace_id, now),
+                )
+                log.error(
+                    "trust.identity_demotion_remainder owner=%s workspace=%s",
+                    owner_user_id,
+                    workspace_id,
+                )
+                continue
+            remaining_budget -= cost
+            override = conn.execute(
+                "SELECT identity_bypass FROM tr_trust_override "
+                "WHERE workspace_id = %s",
+                (workspace_id,),
+            ).fetchone()
+            if override is not None and bool(override[0]):
+                continue
+            updated = conn.execute(
+                "UPDATE tr_credit_balance SET trust_tier = "
+                "CASE WHEN trust_tier > 1 THEN 1 ELSE trust_tier END, "
+                "trust_computed_at = %s, updated_at = CURRENT_TIMESTAMP "
+                "WHERE workspace_id = %s",
+                (now, workspace_id),
+            )
+            if updated.rowcount != shard_count:
+                raise RuntimeError("identity demotion did not cover every active shard")
 
     def set_user_identity_status(
         self,
@@ -1407,6 +1971,7 @@ class PostgresStore:
             user = self._read_entity_tx(conn, "user", user_id, User, for_update=True)
             if user is None:
                 return None
+            was_approved = user.identity_status == "approved"
             normalized = IdentityVerificationStatus.coerce(status)
             if normalized is IdentityVerificationStatus.APPROVED and not user.identity_verified_at:
                 user.identity_verified_at = iso_now()
@@ -1428,7 +1993,158 @@ class PostgresStore:
             if increment_attempts:
                 user.veriff_attempt_count += 1
             self._write_entity_tx(conn, "user", user.id, user)
+            if was_approved and normalized is not IdentityVerificationStatus.APPROVED:
+                self._demote_owner_trust_tx(
+                    conn, user_id, now=dt.datetime.now(dt.UTC)
+                )
             return user
+
+        return self._run_transaction(txn)
+
+    def apply_veriff_identity_decision(
+        self,
+        user_id: str,
+        *,
+        event_id: str,
+        session_id: str,
+        status: str,
+        decision_code: int,
+        decision_reason: str | None = None,
+        decision_reason_code: int | None = None,
+        verified_name: str | None = None,
+    ) -> str:
+        def txn(conn: Any) -> str:
+            marker_id = f"veriff#{event_id}"
+            if not self._insert_entity_once_tx(
+                conn, "webhook_event", marker_id, {"created_at": iso_now()}
+            ):
+                return "replayed"
+            user = self._read_entity_tx(
+                conn, "user", user_id, User, for_update=True
+            )
+            if user is None or user.veriff_session_id != session_id:
+                return "ignored"
+            was_approved = user.identity_status == "approved"
+            normalized = IdentityVerificationStatus.coerce(status)
+            if normalized is IdentityVerificationStatus.APPROVED and not user.identity_verified_at:
+                user.identity_verified_at = iso_now()
+            user.identity_status = normalized.value
+            user.veriff_decision_code = decision_code
+            if decision_reason is not None:
+                user.veriff_decision_reason = decision_reason
+            if decision_reason_code is not None:
+                user.veriff_decision_reason_code = decision_reason_code
+            if verified_name is not None:
+                user.identity_verified_name = verified_name
+            self._write_entity_tx(conn, "user", user.id, user)
+            if was_approved and normalized is not IdentityVerificationStatus.APPROVED:
+                self._demote_owner_trust_tx(
+                    conn, user_id, now=dt.datetime.now(dt.UTC)
+                )
+            return "applied"
+
+        return self._run_transaction(txn)
+
+    def backfill_owner_inventory(self, *, source_version: str, environment: str) -> int:
+        if not source_version.strip() or not environment.strip():
+            raise ValueError("source_version and environment are required")
+
+        def txn(conn: Any) -> int:
+            rows = conn.execute(
+                "SELECT body FROM tr_entities WHERE kind = 'workspace' ORDER BY id"
+            ).fetchall()
+            expected: set[tuple[str, str]] = set()
+            for (raw,) in rows:
+                data = json.loads(raw) if isinstance(raw, str) else dict(raw)
+                workspace = Workspace(
+                    **{
+                        key: value
+                        for key, value in data.items()
+                        if key in {field.name for field in dataclasses.fields(Workspace)}
+                    }
+                )
+                if not workspace.deleted and not workspace.federated_home:
+                    expected.add((workspace.owner_user_id, workspace.id))
+            actual = {
+                (str(owner), str(workspace))
+                for owner, workspace in conn.execute(
+                    "SELECT owner_user_id, workspace_id FROM tr_owner_workspace"
+                ).fetchall()
+            }
+            for owner_user_id, workspace_id in sorted(expected - actual):
+                conn.execute(
+                    "INSERT INTO tr_owner_workspace (owner_user_id, workspace_id) "
+                    "VALUES (%s, %s) "
+                    "ON CONFLICT (owner_user_id, workspace_id) DO NOTHING",
+                    (owner_user_id, workspace_id),
+                )
+            for owner_user_id, workspace_id in sorted(actual - expected):
+                conn.execute(
+                    "DELETE FROM tr_owner_workspace "
+                    "WHERE owner_user_id = %s AND workspace_id = %s",
+                    (owner_user_id, workspace_id),
+                )
+            for owner_user_id in sorted({owner for owner, _workspace in expected | actual}):
+                user = self._read_entity_tx(
+                    conn, "user", owner_user_id, User, for_update=True
+                )
+                if user is not None:
+                    user.owner_workspace_count = sum(
+                        owner == owner_user_id for owner, _workspace in expected
+                    )
+                    self._write_entity_tx(conn, "user", user.id, user)
+            now = dt.datetime.now(dt.UTC)
+            conn.execute(
+                "INSERT INTO tr_trust_backfill "
+                "(provider, account_id, environment, source, source_version, "
+                "history_start, closed_through, consistency_delay_seconds, "
+                "unmatched_count, semantic_mismatch_count, completed_at) "
+                "VALUES ('owner_inventory', 'local', %s, 'tr_entities.workspace', "
+                "%s, %s, %s, 0, 0, 0, %s) "
+                "ON CONFLICT (provider, account_id, environment) DO UPDATE SET "
+                "source = EXCLUDED.source, source_version = EXCLUDED.source_version, "
+                "history_start = EXCLUDED.history_start, "
+                "closed_through = EXCLUDED.closed_through, "
+                "consistency_delay_seconds = EXCLUDED.consistency_delay_seconds, "
+                "unmatched_count = EXCLUDED.unmatched_count, "
+                "semantic_mismatch_count = EXCLUDED.semantic_mismatch_count, "
+                "completed_at = EXCLUDED.completed_at",
+                (environment.strip(), source_version.strip(), now, now, now),
+            )
+            return len(expected ^ actual)
+
+        return self._run_transaction(txn)
+
+    def process_trust_demotion_remainders(self, *, limit: int = 25) -> int:
+        if limit <= 0:
+            return 0
+
+        def txn(conn: Any) -> int:
+            rows = conn.execute(
+                "SELECT owner_user_id, workspace_id, target_identity_ceiling "
+                "FROM tr_trust_demotion_remainder ORDER BY created_at LIMIT %s FOR UPDATE",
+                (int(limit),),
+            ).fetchall()
+            for owner_user_id, workspace_id, ceiling in rows:
+                override = conn.execute(
+                    "SELECT identity_bypass FROM tr_trust_override "
+                    "WHERE workspace_id = %s",
+                    (str(workspace_id),),
+                ).fetchone()
+                if override is None or not bool(override[0]):
+                    conn.execute(
+                        "UPDATE tr_credit_balance SET trust_tier = "
+                        "CASE WHEN trust_tier > %s THEN %s ELSE trust_tier END, "
+                        "trust_computed_at = CURRENT_TIMESTAMP, "
+                        "updated_at = CURRENT_TIMESTAMP WHERE workspace_id = %s",
+                        (int(ceiling), int(ceiling), str(workspace_id)),
+                    )
+                conn.execute(
+                    "DELETE FROM tr_trust_demotion_remainder "
+                    "WHERE owner_user_id = %s AND workspace_id = %s",
+                    (str(owner_user_id), str(workspace_id)),
+                )
+            return len(rows)
 
         return self._run_transaction(txn)
 

--- a/src/trusted_router/storage_postgres_schema.sql
+++ b/src/trusted_router/storage_postgres_schema.sql
@@ -122,6 +122,47 @@ CREATE TABLE IF NOT EXISTS tr_trust_inbox (
     PRIMARY KEY (provider, adverse_ref)
 );
 
+CREATE TABLE IF NOT EXISTS tr_owner_workspace (
+    owner_user_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    PRIMARY KEY (owner_user_id, workspace_id)
+);
+
+CREATE TABLE IF NOT EXISTS tr_trust_override (
+    workspace_id TEXT NOT NULL PRIMARY KEY,
+    tier BIGINT NOT NULL CHECK (tier >= 0 AND tier <= 3),
+    identity_bypass BOOLEAN NOT NULL,
+    operator_identity TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    set_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS tr_trust_demotion_remainder (
+    owner_user_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    target_identity_ceiling BIGINT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    attempts BIGINT NOT NULL DEFAULT 0,
+    last_error TEXT,
+    PRIMARY KEY (owner_user_id, workspace_id)
+);
+
+CREATE TABLE IF NOT EXISTS tr_trust_backfill (
+    provider TEXT NOT NULL,
+    account_id TEXT NOT NULL,
+    environment TEXT NOT NULL,
+    source TEXT NOT NULL,
+    source_version TEXT NOT NULL,
+    history_start TIMESTAMPTZ NOT NULL,
+    closed_through TIMESTAMPTZ NOT NULL,
+    consistency_delay_seconds BIGINT NOT NULL,
+    unmatched_count BIGINT NOT NULL,
+    semantic_mismatch_count BIGINT NOT NULL,
+    completed_at TIMESTAMPTZ,
+    CHECK (completed_at IS NULL OR (unmatched_count = 0 AND semantic_mismatch_count = 0)),
+    PRIMARY KEY (provider, account_id, environment)
+);
+
 CREATE TABLE IF NOT EXISTS tr_earnings_balance (
     user_id TEXT NOT NULL,
     shard BIGINT NOT NULL DEFAULT 0,

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -58,6 +58,7 @@ from trusted_router.storage_models import (
     SyntheticProbeSample,
     SyntheticRollup,
     TrustInboxRow,
+    TrustOverride,
     User,
     UserModelPayout,
     UserProvidedModel,
@@ -113,6 +114,18 @@ class Store(Protocol):
         verified_name: str | None = ...,
         increment_attempts: bool = ...,
     ) -> User | None: ...
+    def apply_veriff_identity_decision(
+        self,
+        user_id: str,
+        *,
+        event_id: str,
+        session_id: str,
+        status: str,
+        decision_code: int,
+        decision_reason: str | None = ...,
+        decision_reason_code: int | None = ...,
+        verified_name: str | None = ...,
+    ) -> str: ...
     # Phone ownership proof for notifications. The rules live in
     # phone_verification.py; a backend only reads the user, applies them, and
     # writes it back, so the three stores cannot drift apart on policy.
@@ -212,6 +225,38 @@ class Store(Protocol):
         billing_paused: bool | None = ...,
         billing_pause_reason: str | None = ...,
     ) -> Workspace | None: ...
+    def transfer_workspace_ownership(
+        self, workspace_id: str, new_owner_user_id: str
+    ) -> Workspace: ...
+    def set_workspace_trust_override(
+        self,
+        workspace_id: str,
+        *,
+        tier: int,
+        identity_bypass: bool,
+        operator_identity: str,
+        reason: str,
+    ) -> TrustOverride: ...
+    def record_workspace_abuse_and_demote(
+        self,
+        workspace_id: str,
+        *,
+        abuse_ref: str,
+        operator_identity: str,
+        reason: str,
+    ) -> bool: ...
+    def clear_workspace_abuse_pause(
+        self,
+        workspace_id: str,
+        *,
+        abuse_ref: str,
+        operator_identity: str,
+        reason: str,
+    ) -> bool: ...
+    def backfill_owner_inventory(
+        self, *, source_version: str, environment: str
+    ) -> int: ...
+    def process_trust_demotion_remainders(self, *, limit: int = ...) -> int: ...
     def add_members(
         self, workspace_id: str, emails: list[str], role: str = ...
     ) -> list[Member]: ...

--- a/src/trusted_router/trust_ownership.py
+++ b/src/trusted_router/trust_ownership.py
@@ -1,0 +1,42 @@
+"""Owner-inventory and trust-demotion invariants.
+
+The constants in this module are deliberately not settings.  They describe
+the shape of one deployed schema and the conservative transaction budget the
+trust design was proved against; changing either is a design/migration event,
+not a rollout knob.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+TRUST_REPLICATED_COLUMN_COUNT = 7
+TRUST_OWNER_MUTATION_BUDGET = 20_000
+
+
+class WorkspaceOwnerLimitExceeded(ValueError):
+    """A new workspace would exceed the configured per-owner count."""
+
+
+class OwnerTrustMutationBudgetExceeded(ValueError):
+    """An owner transition would exceed the pinned all-shard write budget."""
+
+
+def owner_trust_mutations(shard_counts: Iterable[int]) -> int:
+    """Return the conservative trust rewrite cost for one owner."""
+
+    counts = tuple(int(count) for count in shard_counts)
+    if any(count < 1 for count in counts):
+        raise ValueError("owner inventory contains an invalid shard count")
+    return sum(counts) * TRUST_REPLICATED_COLUMN_COUNT
+
+
+def require_owner_trust_budget(shard_counts: Iterable[int]) -> int:
+    """Validate and return an owner's conservative trust rewrite cost."""
+
+    mutations = owner_trust_mutations(shard_counts)
+    if mutations > TRUST_OWNER_MUTATION_BUDGET:
+        raise OwnerTrustMutationBudgetExceeded(
+            "owner trust fan-out exceeds the pinned 20000-mutation budget"
+        )
+    return mutations

--- a/src/trusted_router/trust_tiers.py
+++ b/src/trusted_router/trust_tiers.py
@@ -256,6 +256,7 @@ def compute_trust_tier(
     tier3_min_days: int,
     tier3_min_paid_microdollars: int,
     now: datetime,
+    identity_bypass: bool = False,
 ) -> TrustTierDecision:
     """Compute the converged tier without mutating or clearing a latch."""
 
@@ -286,7 +287,7 @@ def compute_trust_tier(
             computed = 3
 
     override = max(0, min(3, int(trust_override_tier or 0)))
-    identity_ceiling = 3 if approved else 1
+    identity_ceiling = 3 if approved or identity_bypass else 1
     effective = min(identity_ceiling, max(computed, override), 3)
     if trust_latched_at is not None:
         effective = 0

--- a/tests/deploy_script_harness.py
+++ b/tests/deploy_script_harness.py
@@ -948,6 +948,19 @@ _SYNTHETIC_INGEST_SERVICE_JSON = json.dumps(
                                         }
                                     },
                                 },
+                                {
+                                    "name": "TR_OPERATOR_TOKEN",
+                                    "valueFrom": {
+                                        "secretKeyRef": {
+                                            "name": "trustedrouter-operator-token",
+                                            "key": "latest",
+                                        }
+                                    },
+                                },
+                                {
+                                    "name": "TR_OPERATOR_IDENTITIES",
+                                    "value": "joseph@jperla.com",
+                                },
                             ]
                         }
                     ]
@@ -991,6 +1004,19 @@ _SYNTHETIC_COMBINED_JOB_JSON = json.dumps(
                                                     "key": "latest",
                                                 }
                                             },
+                                        },
+                                        {
+                                            "name": "TR_OPERATOR_TOKEN",
+                                            "valueFrom": {
+                                                "secretKeyRef": {
+                                                    "name": "trustedrouter-operator-token",
+                                                    "key": "latest",
+                                                }
+                                            },
+                                        },
+                                        {
+                                            "name": "TR_OPERATOR_IDENTITIES",
+                                            "value": "joseph@jperla.com",
                                         },
                                     ],
                                 }
@@ -1166,6 +1192,7 @@ _PUBLIC_EDGE_ROUTED_SERVICE_JSON = json.dumps(
 
 _INTERNAL_SURFACE_LEGACY_ENV = {
     **_PUBLIC_SURFACE_LEGACY_ENV,
+    "TR_OPERATOR_IDENTITIES": "joseph@jperla.com",
     "TR_GENERATION_RECORDS_ENABLED": "true",
     "TR_REQUEST_RECORD_WRITE_MODE": "typed",
     "TR_SETTLE_OUTBOX_ENABLED": "true",
@@ -1189,6 +1216,7 @@ _INTERNAL_SURFACE_LEGACY_ENV = {
 }
 _INTERNAL_SECRET_BINDINGS = (
     ("TR_INTERNAL_GATEWAY_TOKEN", "trustedrouter-internal-gateway-token"),
+    ("TR_OPERATOR_TOKEN", "trustedrouter-operator-token"),
     ("TR_OBSERVER_INTERNAL_TOKEN", "trustedrouter-observer-internal-token"),
     ("TR_SYNTHETIC_MONITOR_API_KEY", "trustedrouter-synthetic-monitor-api-key"),
     ("TR_SENTRY_DSN", "trustedrouter-sentry-dsn"),

--- a/tests/fakes/postgres.py
+++ b/tests/fakes/postgres.py
@@ -120,6 +120,10 @@ SCHEMA_TABLES = (
     "CREATE UNIQUE INDEX IF NOT EXISTS tr_trust_event_adverse_dedup",
     "CREATE UNIQUE INDEX IF NOT EXISTS tr_trust_event_payment_dedup",
     "CREATE TABLE IF NOT EXISTS tr_trust_inbox",
+    "CREATE TABLE IF NOT EXISTS tr_owner_workspace",
+    "CREATE TABLE IF NOT EXISTS tr_trust_override",
+    "CREATE TABLE IF NOT EXISTS tr_trust_demotion_remainder",
+    "CREATE TABLE IF NOT EXISTS tr_trust_backfill",
     "CREATE TABLE IF NOT EXISTS tr_key_limit",
     # Deferred settlement. The cap's whole claim to being a real bound is the
     # predicate on its UPDATE and the rowcount that reads it, and the outbox's
@@ -172,6 +176,10 @@ def postgres_store_on(conn: SqlitePostgresConn) -> Any:
 
     store = PostgresStore.__new__(PostgresStore)
     store._run_transaction = lambda operation: _run(conn, operation)  # type: ignore[method-assign]
+    store.max_workspaces_per_owner = 25
+    store.trust_qualifying_providers = frozenset({"stripe", "x402"})
+    store.trust_tier3_min_days = 30
+    store.trust_tier3_min_paid_microdollars = 50_000_000
     return store
 
 

--- a/tests/fakes/spanner.py
+++ b/tests/fakes/spanner.py
@@ -67,6 +67,19 @@ _TYPED_DEFAULTS: dict[str, dict[str, Any]] = {
     },
 }
 
+_TYPED_PRIMARY_KEYS: dict[str, tuple[str, ...]] = {
+    "tr_credit_balance": ("workspace_id", "shard"),
+    "tr_earnings_balance": ("user_id", "shard"),
+    "tr_user_lifetime_topup": ("user_id",),
+    "tr_key_limit": ("key_hash", "shard"),
+    "tr_trust_event": ("workspace_id", "event_id"),
+    "tr_trust_inbox": ("provider", "adverse_ref"),
+    "tr_owner_workspace": ("owner_user_id", "workspace_id"),
+    "tr_trust_override": ("workspace_id",),
+    "tr_trust_demotion_remainder": ("owner_user_id", "workspace_id"),
+    "tr_trust_backfill": ("provider", "account_id", "environment"),
+}
+
 
 def _apply_upsert_typed(
     typed: dict, versions: dict, table: str, columns: Any, value_tuple: tuple, version: int
@@ -76,8 +89,13 @@ def _apply_upsert_typed(
     the supplied columns and leave the rest intact. Shared by the transaction
     and batch commit paths so partial typed-row seed/update mutations behave
     identically through either writer."""
-    pk = (value_tuple[0], value_tuple[1])
     incoming = dict(zip(columns, value_tuple, strict=True))
+    key_columns = _TYPED_PRIMARY_KEYS.get(table)
+    pk = (
+        tuple(incoming[column] for column in key_columns)
+        if key_columns is not None
+        else (value_tuple[0], value_tuple[1])
+    )
     table_rows = typed.setdefault(table, {})
     existing = table_rows.get(pk)
     row = dict(existing) if existing is not None else dict(_TYPED_DEFAULTS.get(table, {}))
@@ -933,6 +951,27 @@ class _FakeTransaction:
             )
             self.pending_writes.append(("update_typed", "tr_trust_event", pk, new))
             return 1
+        if sql.startswith("UPDATE tr_credit_balance SET trust_tier=0"):
+            updated = 0
+            for pk in self.db.typed.get("tr_credit_balance", {}):
+                if pk[0] != p["pk"] or not 0 <= int(pk[1]) < int(p["shard_count"]):
+                    continue
+                rec = self._typed_current("tr_credit_balance", pk)
+                if rec is None:
+                    continue
+                new = dict(
+                    rec,
+                    trust_tier=0,
+                    trust_latched_at=rec.get("trust_latched_at") or p["now"],
+                    billing_pause_causes=list(p["causes"]),
+                    pause_epoch=int(rec.get("pause_epoch") or 0) + 1,
+                    updated_at=p["now"],
+                )
+                self.pending_writes.append(
+                    ("update_typed", "tr_credit_balance", pk, new)
+                )
+                updated += 1
+            return updated
         if sql.startswith("UPDATE tr_credit_balance SET trust_latched_at=COALESCE"):
             updated = 0
             for pk in self.db.typed.get("tr_credit_balance", {}):
@@ -1892,7 +1931,7 @@ class _FakeTransaction:
                 kind, entity_id = entry[0], entry[1]
                 self.pending_writes.append(("delete", table, kind, entity_id))
             else:
-                self.pending_writes.append(("delete_typed", table, (entry[0], entry[1])))
+                self.pending_writes.append(("delete_typed", table, tuple(entry)))
 
 
 class _FakeSnapshot:
@@ -1984,7 +2023,7 @@ class _FakeBatch:
                 kind, entity_id = entry[0], entry[1]
                 self.pending_writes.append(("delete", table, kind, entity_id))
             else:
-                self.pending_writes.append(("delete_typed", table, (entry[0], entry[1])))
+                self.pending_writes.append(("delete_typed", table, tuple(entry)))
 
 
 def _require_pred(sql: str, needle: str, what: str) -> None:
@@ -2765,6 +2804,24 @@ def _execute_sql(
     params: dict[str, Any],
 ) -> list[list[str]]:
     kind = params.get("kind", "")
+
+    def _typed_rows(table: str) -> list[dict[str, Any]]:
+        keys = set(db.typed.get(table, {}))
+        if txn is not None:
+            for op in txn.pending_writes:
+                if op[0] == "upsert_typed" and op[1] == table:
+                    incoming = dict(zip(op[2], op[3], strict=True))
+                    key_columns = _TYPED_PRIMARY_KEYS[table]
+                    keys.add(tuple(incoming[column] for column in key_columns))
+                elif op[0] in {"insert_typed_dml", "update_typed", "delete_typed"} and op[1] == table:
+                    keys.add(op[2])
+        rows = [
+            txn._typed_current(table, pk)
+            if txn is not None
+            else db.typed.get(table, {}).get(pk)
+            for pk in keys
+        ]
+        return [row for row in rows if row is not None]
 
     def _claim_bodies() -> list[dict]:
         out = []
@@ -3824,6 +3881,50 @@ def _execute_sql(
                 {str(pk[0]) for pk in db.typed.get("tr_credit_balance", {})}
             )
         ]
+    if "FROM tr_owner_workspace" in sql:
+        rows = _typed_rows("tr_owner_workspace")
+        if "owner" in params:
+            rows = [
+                row for row in rows if row.get("owner_user_id") == params["owner"]
+            ]
+        rows.sort(
+            key=lambda row: (
+                str(row.get("owner_user_id")), str(row.get("workspace_id"))
+            )
+        )
+        columns = [
+            column.strip()
+            for column in sql.split("SELECT", 1)[1].split("FROM", 1)[0].split(",")
+        ]
+        return [[row.get(column) for column in columns] for row in rows]
+    if "FROM tr_trust_override" in sql:
+        rows = [
+            row
+            for row in _typed_rows("tr_trust_override")
+            if row.get("workspace_id") == params["pk"]
+        ]
+        columns = [
+            column.strip()
+            for column in sql.split("SELECT", 1)[1].split("FROM", 1)[0].split(",")
+        ]
+        return [[row.get(column) for column in columns] for row in rows]
+    if "FROM tr_trust_demotion_remainder" in sql:
+        rows = _typed_rows("tr_trust_demotion_remainder")
+        if "owner" in params:
+            rows = [
+                row
+                for row in rows
+                if row.get("owner_user_id") == params["owner"]
+                and row.get("workspace_id") == params["workspace"]
+            ]
+        rows.sort(key=lambda row: row.get("created_at"))
+        if "limit" in params:
+            rows = rows[: int(params["limit"])]
+        columns = [
+            column.strip()
+            for column in sql.split("SELECT", 1)[1].split("FROM", 1)[0].split(",")
+        ]
+        return [[row.get(column) for column in columns] for row in rows]
     if "FROM tr_trust_event" in sql:
         cols = [
             column.strip()
@@ -3944,6 +4045,23 @@ def _execute_sql(
             ]
             recs = [rec for rec in recs if rec is not None]
             return [[rec.get(c) for c in cols] for rec in recs]
+    if "SELECT id, body FROM tr_entities WHERE kind='workspace'" in sql:
+        rows = sorted(
+            (entity_id, row.body)
+            for (row_kind, entity_id), row in db.rows.items()
+            if row_kind == "workspace"
+        )
+        return [[entity_id, body] for entity_id, body in rows]
+    if "kind IN ('spend_lease','regional_quota_lease')" in sql:
+        rows: list[list[str]] = []
+        for (row_kind, entity_id), row in db.rows.items():
+            if row_kind not in {"spend_lease", "regional_quota_lease"}:
+                continue
+            body = json.loads(row.body)
+            if body.get("workspace_id") == params["pk"]:
+                rows.append([row_kind, entity_id, row.body])
+        rows.sort(key=lambda row: (row[0], row[1]))
+        return rows
     if "AND id>@after" in sql:
         # Paged PK-prefix scan of one kind (the credit-transfer recovery
         # queue). Reads committed rows plus this transaction's own pending
@@ -4191,6 +4309,10 @@ def make_fake_store(
     store._database = db
     store._bt_table = bt
     store.request_record_write_mode = request_record_write_mode
+    store.max_workspaces_per_owner = 25
+    store.trust_qualifying_providers = frozenset({"stripe", "x402"})
+    store.trust_tier3_min_days = 30
+    store.trust_tier3_min_paid_microdollars = 50_000_000
     store._generation_records_enabled = generation_records_enabled
     store._bigtable_writes_enabled = bigtable_writes_enabled
     # `object.__new__` skips __init__, so every attribute the real constructor

--- a/tests/test_broadcast.py
+++ b/tests/test_broadcast.py
@@ -57,6 +57,8 @@ def test_broadcast_inline_drain_defaults_to_non_production_only() -> None:
             service_surface="internal",
             storage_backend="spanner-bigtable",
             internal_gateway_token="token",  # noqa: S106 - placeholder test secret.
+            operator_token="operator-token",  # noqa: S106 - placeholder test secret.
+            operator_identities="ops@example.com",
             observer_internal_token="observer-token",  # noqa: S106 - test secret.
             sentry_dsn="https://example@sentry.invalid/1",
             spanner_instance_id="inst",

--- a/tests/test_contract_regressions.py
+++ b/tests/test_contract_regressions.py
@@ -229,6 +229,8 @@ def _production_app(surface: str):
         values.update(
             {
                 "internal_gateway_token": internal_token,
+                "operator_token": "prod-operator-token",
+                "operator_identities": "ops@example.com",
                 "observer_internal_token": "prod-observer-token",
                 "settle_outbox_enabled": True,
             }

--- a/tests/test_internal_surface_deploy.py
+++ b/tests/test_internal_surface_deploy.py
@@ -19,6 +19,7 @@ REGIONS = {
 }
 EXPECTED_SECRETS = {
     "TR_INTERNAL_GATEWAY_TOKEN": "trustedrouter-internal-gateway-token:latest",
+    "TR_OPERATOR_TOKEN": "trustedrouter-operator-token:latest",
     "TR_OBSERVER_INTERNAL_TOKEN": "trustedrouter-observer-internal-token:latest",
     "TR_SYNTHETIC_MONITOR_API_KEY": (
         "trustedrouter-synthetic-monitor-api-key:latest"
@@ -44,6 +45,7 @@ EXPECTED_SECRETS = {
 }
 SECRET_VALUES = {
     "TR_INTERNAL_GATEWAY_TOKEN": "gateway-" + "g" * 40,
+    "TR_OPERATOR_TOKEN": "operator-" + "p" * 40,
     "TR_OBSERVER_INTERNAL_TOKEN": "observer-" + "o" * 40,
     "TR_SYNTHETIC_MONITOR_API_KEY": "monitor-" + "m" * 40,
     "TR_SENTRY_DSN": "https://example@example.ingest.sentry.io/1",
@@ -58,6 +60,7 @@ SECRET_VALUES = {
 EXPECTED_ENV_NAMES = {
     "TR_ENVIRONMENT",
     "TR_SERVICE_SURFACE",
+    "TR_OPERATOR_IDENTITIES",
     "TR_RELEASE",
     "TR_TRUSTED_DOMAIN",
     "TR_TRUSTED_DOMAIN_ALIASES",

--- a/tests/test_postgres_iam_auth.py
+++ b/tests/test_postgres_iam_auth.py
@@ -170,7 +170,11 @@ def test_settings_and_create_store_pass_iam_configuration(
         "postgres_iam_region": "us-east-2",
         # Absent from the SimpleNamespace above, so this pins the *default*:
         # the operational-analytics outbox stays off unless a deployment turns
-        # it on, exactly like the Spanner path.
-        "operational_analytics_outbox_enabled": False,
-        "schema_applied": True,
+            # it on, exactly like the Spanner path.
+            "operational_analytics_outbox_enabled": False,
+            "max_workspaces_per_owner": 25,
+            "trust_qualifying_providers": frozenset({"stripe", "x402"}),
+            "trust_tier3_min_days": 30,
+            "trust_tier3_min_paid_microdollars": 50_000_000,
+            "schema_applied": True,
     }

--- a/tests/test_regional_quota_leases.py
+++ b/tests/test_regional_quota_leases.py
@@ -368,6 +368,8 @@ def test_regional_lease_production_config_requires_fixed_profiles_and_outbox() -
         "environment": "staging",
         "service_surface": "internal",
         "internal_gateway_token": "staging-gateway-" + "g" * 32,
+        "operator_token": "staging-operator-" + "p" * 32,
+        "operator_identities": "ops@example.com",
         "observer_internal_token": "staging-observer-" + "o" * 32,
         "storage_backend": "spanner-bigtable",
         "bigtable_instance_id": "trusted-router-logs",

--- a/tests/test_security_contracts.py
+++ b/tests/test_security_contracts.py
@@ -102,6 +102,8 @@ def test_sentry_test_route_is_disabled_in_production_unless_explicitly_enabled()
         environment="production",
         service_surface="internal",
         internal_gateway_token="internal-prod-sentry-test",  # noqa: S106 - test config.
+        operator_token="operator-prod-sentry-test",  # noqa: S106 - test config.
+        operator_identities="ops@example.com",
         observer_internal_token="observer-prod-sentry-test",  # noqa: S106 - test config.
         sentry_dsn="https://example@example.ingest.sentry.io/1",
         storage_backend="spanner-bigtable",

--- a/tests/test_service_surface_routing.py
+++ b/tests/test_service_surface_routing.py
@@ -189,6 +189,8 @@ def test_internal_surface_route_inventory_matches_capability_audit() -> None:
         ("POST", "/internal/gateway/video/jobs/{job_id}/update"),
         ("POST", "/internal/gateway/video/jobs/{job_id}/cleaned"),
         ("POST", "/internal/gateway/fetch-image"),
+        ("POST", "/internal/admin/workspaces/{workspace_id}/trust-override"),
+        ("POST", "/internal/admin/workspaces/{workspace_id}/abuse"),
         ("POST", "/internal/reconcile/generation-activity"),
         ("POST", "/internal/federation/resolve-key"),
         ("POST", "/internal/federation/apply-usage"),

--- a/tests/test_service_surface_secret_isolation.py
+++ b/tests/test_service_surface_secret_isolation.py
@@ -18,6 +18,7 @@ from trusted_router.main import create_app
 _ATTRIBUTION_SECRET = "attribution-only-" + "a" * 32
 _ATTRIBUTION_KEY = "aDMnBV9nDwwAD1tr4MpooFMj7i8Kv6lB5Q9LTmrjTfc="
 _GATEWAY_SECRET = "gateway-only-" + "g" * 32
+_OPERATOR_SECRET = "operator-only-" + "p" * 32
 _PRODUCTION_STORAGE = {
     "environment": "production",
     "storage_backend": "spanner-bigtable",
@@ -172,6 +173,7 @@ _SENSITIVE_TEST_VALUES: dict[str, object] = {
     "attribution_cookie_key": _ATTRIBUTION_KEY,
     "attribution_cookie_secret": _ATTRIBUTION_SECRET,
     "internal_gateway_token": _GATEWAY_SECRET,
+    "operator_token": _OPERATOR_SECRET,
     "observer_internal_token": "observer-only-" + "o" * 32,
     "stripe_webhook_secret": "whsec-test",
     "stripe_secret_key": "sk-test",
@@ -284,7 +286,7 @@ _EXPECTED_OWNER_GROUPS: tuple[tuple[frozenset[str], tuple[str, ...]], ...] = (
     ),
     (
         frozenset({"internal"}),
-        ("internal_gateway_token",),
+        ("internal_gateway_token", "operator_token"),
     ),
     (
         frozenset({"internal", "observer"}),
@@ -328,6 +330,8 @@ def _production(surface: str, **overrides: object) -> Settings:
     values: dict[str, object] = {**_PRODUCTION_STORAGE, "service_surface": surface}
     if surface == "internal":
         values["settle_outbox_enabled"] = True
+        values["operator_token"] = _OPERATOR_SECRET
+        values["operator_identities"] = "ops@example.com"
     values.update(overrides)
     return Settings(**values)
 
@@ -353,6 +357,7 @@ def _full_combined_bridge_production() -> dict[str, object]:
         "federation_home_base_url": "https://home.example",
         # The test credential fixtures contain exactly this alias.
         "trusted_domain_aliases": "allyrouter.com",
+        "operator_identities": "ops@example.com",
     }
 
 
@@ -362,6 +367,8 @@ def test_production_internal_surface_requires_durable_settle_outbox() -> None:
             **_PRODUCTION_STORAGE,
             service_surface="internal",
             internal_gateway_token=_GATEWAY_SECRET,
+            operator_token=_OPERATOR_SECRET,
+            operator_identities="ops@example.com",
             observer_internal_token=_SENSITIVE_TEST_VALUES["observer_internal_token"],
             sentry_dsn="https://example@example.ingest.sentry.io/1",
             settle_outbox_enabled=False,
@@ -423,6 +430,8 @@ def test_combined_bridge_requires_the_legacy_rate_limiter_to_stay_off() -> None:
             "internal",
             {
                 "internal_gateway_token": _GATEWAY_SECRET,
+                "operator_token": _OPERATOR_SECRET,
+                "operator_identities": "ops@example.com",
                 "observer_internal_token": _SENSITIVE_TEST_VALUES[
                     "observer_internal_token"
                 ],
@@ -480,6 +489,10 @@ def test_every_sensitive_setting_rejects_an_unauthorized_deployed_surface(
         )
         if surface == "internal":
             overrides.setdefault("internal_gateway_token", _GATEWAY_SECRET)
+            overrides.setdefault("operator_token", _OPERATOR_SECRET)
+            overrides.setdefault("operator_identities", "ops@example.com")
+    if field_name == "operator_token":
+        overrides["operator_identities"] = "ops@example.com"
     if field_name == "ops_chat_webhook_secret":
         overrides["ops_chat_webhook_urls"] = "https://ops.example/hook"
     if field_name == "postgres_iam_auth":
@@ -710,6 +723,8 @@ def test_internal_and_observer_require_gateway_observability_but_not_account_sec
         }
         if surface == "internal":
             auth["internal_gateway_token"] = _GATEWAY_SECRET
+            auth["operator_token"] = _OPERATOR_SECRET
+            auth["operator_identities"] = "ops@example.com"
         settings = _production(
             surface,
             sentry_dsn="https://example@example.ingest.sentry.io/1",

--- a/tests/test_trust_owner_slice1c.py
+++ b/tests/test_trust_owner_slice1c.py
@@ -1,0 +1,612 @@
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import logging
+import re
+import threading
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from tests.fakes.postgres import postgres_store_on, sqlite_postgres_conn
+from tests.fakes.spanner import make_fake_store
+from trusted_router.config import (
+    SERVICE_SURFACE_SECRET_OWNERS,
+    Settings,
+    operator_credential_setting_names,
+)
+from trusted_router.main import create_app
+from trusted_router.routes.internal._shared import internal_service_credential
+from trusted_router.storage import InMemoryStore, configure_store
+from trusted_router.storage_gcp_credit_shard_admin import reshard_credit_account
+from trusted_router.storage_models import CreditAccount, User
+from trusted_router.trust_ownership import (
+    OwnerTrustMutationBudgetExceeded,
+    WorkspaceOwnerLimitExceeded,
+    require_owner_trust_budget,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _create_columns(ddl: str, table: str) -> tuple[str, ...]:
+    match = re.search(
+        rf"CREATE TABLE(?: IF NOT EXISTS)? {table} \((.*?)\n\s*(?:\) PRIMARY KEY|\);)",
+        ddl,
+        flags=re.DOTALL,
+    )
+    assert match is not None
+    return tuple(
+        line.strip().split()[0]
+        for line in match.group(1).splitlines()
+        if line.strip()
+        and not line.strip().startswith(("CONSTRAINT", "PRIMARY KEY", "CHECK"))
+    )
+
+
+def _trust_rows(database: Any, workspace_id: str) -> list[dict[str, object]]:
+    typed = database.typed
+    return [
+        row
+        for (candidate, _shard), row in typed["tr_credit_balance"].items()
+        if candidate == workspace_id
+    ]
+
+
+def _seed_grandfathered_owner_fanout(
+    store: Any,
+    database: Any,
+    *,
+    workspace_count: int,
+) -> tuple[User, list[str]]:
+    user = store.ensure_user("grandfathered@example.com", trial_credit_microdollars=0)
+    store.set_user_identity_status(
+        user.id, status="approved", session_id="grandfathered-session"
+    )
+    database.typed["tr_owner_workspace"].clear()
+    workspace_ids = [f"grandfathered-{index:02d}" for index in range(workspace_count)]
+    for workspace_id in workspace_ids:
+        store._write_entity(
+            "credit",
+            workspace_id,
+            CreditAccount(workspace_id=workspace_id, shard_count=64),
+        )
+        database.typed["tr_owner_workspace"][(user.id, workspace_id)] = {
+            "owner_user_id": user.id,
+            "workspace_id": workspace_id,
+        }
+        for shard in range(64):
+            database.typed["tr_credit_balance"][(workspace_id, shard)] = {
+                "workspace_id": workspace_id,
+                "shard": shard,
+                "trust_tier": 3,
+            }
+    return user, workspace_ids
+
+
+def test_in_memory_owner_inventory_lifecycle_limit_transfer_and_backfill() -> None:
+    store = InMemoryStore(max_workspaces_per_owner=2)
+    old_owner = store.ensure_user("old@example.com", trial_credit_microdollars=0)
+    first = store.list_workspaces_for_user(old_owner.id)[0]
+    second = store.create_workspace(old_owner.id, "second", trial_credit_microdollars=0)
+    assert old_owner.owner_workspace_count == 2
+    with pytest.raises(WorkspaceOwnerLimitExceeded):
+        store.create_workspace(old_owner.id, "third", trial_credit_microdollars=0)
+
+    new_owner = store.ensure_user("new@example.com", trial_credit_microdollars=0)
+    new_personal = store.list_workspaces_for_user(new_owner.id)[0]
+    store.update_workspace(new_personal.id, deleted=True)
+    transferred = store.transfer_workspace_ownership(second.id, new_owner.id)
+    assert transferred.owner_user_id == new_owner.id
+    assert old_owner.owner_workspace_count == 1
+    assert new_owner.owner_workspace_count == 1
+
+    store.update_workspace(first.id, deleted=True)
+    assert (old_owner.id, first.id) not in store.owner_workspaces
+    assert all(
+        row["trust_latched_at"] is not None and row["trust_tier"] == 0
+        for (workspace_id, _shard), row in store.credit_trust_shards.items()
+        if workspace_id == first.id
+    )
+    store.update_workspace(first.id, deleted=False)
+    assert (old_owner.id, first.id) in store.owner_workspaces
+
+    store.owner_workspaces.clear()
+    old_owner.owner_workspace_count = 99
+    assert store.backfill_owner_inventory(source_version="rev-1", environment="test") == 2
+    assert old_owner.owner_workspace_count == 1
+    assert store.trust_backfills[("owner_inventory", "local", "test")][
+        "completed_at"
+    ] is not None
+
+
+def test_spanner_account_and_wallet_bootstraps_seed_owner_inventory() -> None:
+    store, database, _ = make_fake_store()
+    email_user = store.ensure_user("bootstrap@example.com", trial_credit_microdollars=0)
+    wallet_user = store.create_wallet_user("0x" + "A" * 40)
+
+    for user in (email_user, wallet_user):
+        assert user.owner_workspace_count == 1
+        inventory = [
+            key
+            for key in database.typed["tr_owner_workspace"]
+            if key[0] == user.id
+        ]
+        assert len(inventory) == 1
+
+
+def test_postgres_wallet_bootstrap_seeds_inventory_and_counter() -> None:
+    conn = sqlite_postgres_conn()
+    store = postgres_store_on(conn)
+    user = store.create_wallet_user("0x" + "B" * 40)
+    repeated = store.create_wallet_user("0x" + "b" * 40)
+    row = conn.execute(
+        "SELECT workspace_id FROM tr_owner_workspace WHERE owner_user_id = ?",
+        (user.id,),
+    ).fetchone()
+    persisted = store.get_user(user.id)
+
+    assert repeated.id == user.id
+    assert row is not None
+    assert persisted is not None and persisted.owner_workspace_count == 1
+
+
+def test_owner_budget_uses_actual_shards_times_seven() -> None:
+    require_owner_trust_budget([64] * 44)
+    with pytest.raises(OwnerTrustMutationBudgetExceeded):
+        require_owner_trust_budget([64] * 45)
+
+
+def test_fanout_increasing_reshard_rejects_grandfathered_owner_budget() -> None:
+    store, database, _ = make_fake_store()
+    user = store.ensure_user("fanout@example.com", trial_credit_microdollars=0)
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    store.update_workspace(workspace.id, billing_paused=True)
+    for index in range(44):
+        workspace_id = f"grandfathered-{index:02d}"
+        store._write_entity(
+            "credit",
+            workspace_id,
+            CreditAccount(workspace_id=workspace_id, shard_count=64),
+        )
+        database.typed.setdefault("tr_owner_workspace", {})[(
+            user.id,
+            workspace_id,
+        )] = {"owner_user_id": user.id, "workspace_id": workspace_id}
+    with pytest.raises(OwnerTrustMutationBudgetExceeded):
+        reshard_credit_account(store, workspace.id, 64, apply=True)
+    assert store.get_credit_account(workspace.id).shard_count == 16
+
+
+def test_slice_1c_schemas_have_exact_columns_and_keys() -> None:
+    spanner = (ROOT / "scripts/deploy/migrate_typed_counters.sh").read_text()
+    postgres = (
+        ROOT / "src/trusted_router/storage_postgres_schema.sql"
+    ).read_text()
+    expected = {
+        "tr_owner_workspace": ("owner_user_id", "workspace_id"),
+        "tr_trust_override": (
+            "workspace_id",
+            "tier",
+            "identity_bypass",
+            "operator_identity",
+            "reason",
+            "set_at",
+        ),
+        "tr_trust_demotion_remainder": (
+            "owner_user_id",
+            "workspace_id",
+            "target_identity_ceiling",
+            "created_at",
+            "attempts",
+            "last_error",
+        ),
+        "tr_trust_backfill": (
+            "provider",
+            "account_id",
+            "environment",
+            "source",
+            "source_version",
+            "history_start",
+            "closed_through",
+            "consistency_delay_seconds",
+            "unmatched_count",
+            "semantic_mismatch_count",
+            "completed_at",
+        ),
+    }
+    for table, columns in expected.items():
+        assert _create_columns(spanner, table) == columns
+        assert _create_columns(postgres, table) == columns
+    assert ") PRIMARY KEY (owner_user_id, workspace_id)" in spanner
+    assert "PRIMARY KEY (provider, account_id, environment)" in postgres
+
+
+def test_spanner_creation_inventory_and_concurrent_owner_limit() -> None:
+    barrier = threading.Barrier(2)
+    store, database, _ = make_fake_store(ready_barrier=barrier)
+    store.max_workspaces_per_owner = 1
+    owner = User(id="owner", email="owner@example.com")
+    store._write_entity("user", owner.id, owner)
+    results: list[str] = []
+
+    def create(name: str) -> None:
+        try:
+            store.create_workspace(owner.id, name, trial_credit_microdollars=0)
+            results.append("created")
+        except WorkspaceOwnerLimitExceeded:
+            results.append("limited")
+
+    threads = [threading.Thread(target=create, args=(name,)) for name in ("a", "b")]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+    assert sorted(results) == ["created", "limited"]
+    assert len(database.typed["tr_owner_workspace"]) == 1
+    persisted = store.get_user(owner.id)
+    assert persisted is not None and persisted.owner_workspace_count == 1
+
+
+def test_spanner_owner_backfill_repairs_both_directions_and_marks_complete() -> None:
+    store, database, _ = make_fake_store()
+    user = store.ensure_user("backfill@example.com", trial_credit_microdollars=0)
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    database.typed["tr_owner_workspace"].clear()
+    database.typed["tr_owner_workspace"][("stale-owner", "stale-workspace")] = {
+        "owner_user_id": "stale-owner",
+        "workspace_id": "stale-workspace",
+    }
+    assert store.backfill_owner_inventory(
+        source_version="revision-7", environment="test"
+    ) == 2
+    assert set(database.typed["tr_owner_workspace"]) == {(user.id, workspace.id)}
+    marker = database.typed["tr_trust_backfill"][(
+        "owner_inventory",
+        "local",
+        "test",
+    )]
+    assert marker["source_version"] == "revision-7"
+    assert marker["completed_at"] is not None
+
+
+def test_veriff_demotion_is_atomic_with_claim_and_all_shards() -> None:
+    store, database, _ = make_fake_store()
+    user = store.ensure_user("demote@example.com", trial_credit_microdollars=0)
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    store.set_user_identity_status(
+        user.id, status="approved", session_id="session-1"
+    )
+    for row in _trust_rows(database, workspace.id):
+        row["trust_tier"] = 3
+
+    assert (
+        store.apply_veriff_identity_decision(
+            user.id,
+            event_id="decision-1",
+            session_id="session-1",
+            status="declined",
+            decision_code=9102,
+        )
+        == "applied"
+    )
+    assert {row["trust_tier"] for row in _trust_rows(database, workspace.id)} == {1}
+    assert store.get_user(user.id).identity_status == "declined"
+    assert store.apply_veriff_identity_decision(
+        user.id,
+        event_id="decision-1",
+        session_id="session-1",
+        status="declined",
+        decision_code=9102,
+    ) == "replayed"
+
+    store.set_user_identity_status(user.id, status="approved", session_id="session-2")
+    missing_key = (workspace.id, 15)
+    database.typed["tr_credit_balance"].pop(missing_key)
+    with pytest.raises(RuntimeError, match="shard set is incomplete"):
+        store.apply_veriff_identity_decision(
+            user.id,
+            event_id="decision-atomic",
+            session_id="session-2",
+            status="declined",
+            decision_code=9102,
+        )
+    assert store.get_user(user.id).identity_status == "approved"
+    assert store._read_entity("webhook_event", "veriff#decision-atomic", dict) is None
+
+
+def test_spanner_owner_demotion_over_budget_commits_fit_and_queues_remainder(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store, database, _ = make_fake_store()
+    user, workspace_ids = _seed_grandfathered_owner_fanout(
+        store, database, workspace_count=46
+    )
+
+    with caplog.at_level(logging.ERROR, logger="trusted_router.storage_gcp"):
+        store.set_user_identity_status(user.id, status="declined")
+
+    fit = workspace_ids[:44]
+    remainder = workspace_ids[44:]
+    assert all(
+        {row["trust_tier"] for row in _trust_rows(database, workspace_id)} == {1}
+        for workspace_id in fit
+    )
+    assert all(
+        {row["trust_tier"] for row in _trust_rows(database, workspace_id)} == {3}
+        for workspace_id in remainder
+    )
+    remainder_rows = database.typed["tr_trust_demotion_remainder"]
+    assert len(remainder_rows) == len(remainder)
+    assert set(remainder_rows) == {
+        (user.id, workspace_id) for workspace_id in remainder
+    }
+    assert [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("trust.identity_demotion_remainder ")
+    ] == [
+        f"trust.identity_demotion_remainder owner={user.id} workspace={workspace_id}"
+        for workspace_id in remainder
+    ]
+
+
+def test_spanner_owner_demotion_under_budget_writes_no_remainder() -> None:
+    store, database, _ = make_fake_store()
+    user, workspace_ids = _seed_grandfathered_owner_fanout(
+        store, database, workspace_count=44
+    )
+
+    store.set_user_identity_status(user.id, status="declined")
+
+    assert all(
+        {row["trust_tier"] for row in _trust_rows(database, workspace_id)} == {1}
+        for workspace_id in workspace_ids
+    )
+    assert not database.typed.get("tr_trust_demotion_remainder")
+
+
+def test_spanner_demotion_remainder_is_bounded_and_honors_identity_bypass() -> None:
+    store, database, _ = make_fake_store()
+    user = store.ensure_user("remainder@example.com", trial_credit_microdollars=0)
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    store.set_workspace_trust_override(
+        workspace.id,
+        tier=3,
+        identity_bypass=True,
+        operator_identity="ops@example.com",
+        reason="approved exception",
+    )
+    database.typed.setdefault("tr_trust_demotion_remainder", {})[(
+        user.id,
+        workspace.id,
+    )] = {
+        "owner_user_id": user.id,
+        "workspace_id": workspace.id,
+        "target_identity_ceiling": 1,
+        "created_at": None,
+        "attempts": 0,
+        "last_error": None,
+    }
+
+    assert store.process_trust_demotion_remainders(limit=0) == 0
+    assert store.process_trust_demotion_remainders(limit=1) == 1
+    assert {row["trust_tier"] for row in _trust_rows(database, workspace.id)} == {3}
+    assert not database.typed["tr_trust_demotion_remainder"]
+
+
+def test_spanner_override_rewrites_all_shards_and_audits_bypass() -> None:
+    store, database, _ = make_fake_store()
+    user = store.ensure_user("override@example.com", trial_credit_microdollars=0)
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    record = store.set_workspace_trust_override(
+        workspace.id,
+        tier=3,
+        identity_bypass=False,
+        operator_identity="ops@example.com",
+        reason="reviewed",
+    )
+    assert record.tier == 3
+    assert {row["trust_tier"] for row in _trust_rows(database, workspace.id)} == {1}
+    bypassed = store.set_workspace_trust_override(
+        workspace.id,
+        tier=3,
+        identity_bypass=True,
+        operator_identity="ops@example.com",
+        reason="verified exception",
+    )
+    assert bypassed.identity_bypass is True
+    assert {row["trust_tier"] for row in _trust_rows(database, workspace.id)} == {3}
+    override = database.typed["tr_trust_override"][(workspace.id,)]
+    assert override["operator_identity"] == "ops@example.com"
+    assert override["reason"] == "verified exception"
+
+
+def test_spanner_abuse_is_idempotent_and_clear_never_unlatches() -> None:
+    store, database, _ = make_fake_store()
+    user = store.ensure_user("abuse@example.com", trial_credit_microdollars=0)
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    assert store.record_workspace_abuse_and_demote(
+        workspace.id,
+        abuse_ref="case-7",
+        operator_identity="ops@example.com",
+        reason="confirmed abuse",
+    )
+    assert not store.record_workspace_abuse_and_demote(
+        workspace.id,
+        abuse_ref="case-7",
+        operator_identity="ops@example.com",
+        reason="confirmed abuse",
+    )
+    audit = store._read_entity(  # noqa: SLF001 - verifies the durable audit row
+        "trust_abuse", f"{workspace.id}#case-7", dict
+    )
+    assert audit is not None
+    assert audit["operator_identity"] == "ops@example.com"
+    assert audit["reason"] == "confirmed abuse"
+    assert all(
+        row["trust_tier"] == 0
+        and row["trust_latched_at"] is not None
+        and row["billing_pause_causes"] == ["abuse"]
+        for row in _trust_rows(database, workspace.id)
+    )
+    assert store.clear_workspace_abuse_pause(
+        workspace.id,
+        abuse_ref="clear-7",
+        operator_identity="ops@example.com",
+        reason="appeal accepted",
+    )
+    assert all(
+        row["trust_latched_at"] is not None
+        and row["billing_pause_causes"] == []
+        for row in _trust_rows(database, workspace.id)
+    )
+
+
+def test_spanner_archive_excludes_inventory_latches_and_retires_leases() -> None:
+    store, database, _ = make_fake_store()
+    user = store.ensure_user("archive@example.com", trial_credit_microdollars=0)
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    store._write_entity(
+        "spend_lease",
+        "lease-1",
+        {"workspace_id": workspace.id, "state": "ACTIVE", "closing_at": None},
+    )
+    store._write_entity(
+        "regional_quota_lease",
+        "regional-1",
+        {"workspace_id": workspace.id, "state": "active", "last_error": None},
+    )
+    assert store.update_workspace(workspace.id, deleted=True) is None
+    assert (user.id, workspace.id) not in database.typed["tr_owner_workspace"]
+    assert all(
+        row["trust_tier"] == 0 and row["trust_latched_at"] is not None
+        for row in _trust_rows(database, workspace.id)
+    )
+    spend = store._read_entity("spend_lease", "lease-1", dict)
+    regional = store._read_entity("regional_quota_lease", "regional-1", dict)
+    assert spend["state"] == "TOMBSTONED"
+    assert regional["state"] == "quarantined"
+
+
+def test_operator_routes_require_token_identity_and_replay_abuse() -> None:
+    store = InMemoryStore()
+    configure_store(store)
+    user = store.ensure_user("route@example.com", trial_credit_microdollars=0)
+    workspace = store.list_workspaces_for_user(user.id)[0]
+    settings = Settings(
+        environment="test",
+        service_surface="internal",
+        operator_token="operator-secret",  # noqa: S106 - test credential.
+        operator_identities="ops@example.com",
+    )
+    client = TestClient(
+        create_app(settings, configure_store_arg=False, init_observability=False)
+    )
+    url = f"/internal/admin/workspaces/{workspace.id}/abuse"
+    body = {"abuse_ref": "route-case", "reason": "confirmed"}
+    assert client.post(url, json=body).status_code == 401
+    assert client.post(
+        url,
+        headers={
+            "authorization": "Bearer operator-secret",
+            "x-trustedrouter-operator-identity": "unknown@example.com",
+        },
+        json=body,
+    ).status_code == 403
+    headers = {
+        "authorization": "Bearer operator-secret",
+        "x-trustedrouter-operator-identity": "ops@example.com",
+    }
+    first = client.post(url, headers=headers, json=body)
+    replay = client.post(url, headers=headers, json=body)
+    assert first.status_code == 200 and first.json()["data"]["applied"] is True
+    assert replay.status_code == 200 and replay.json()["data"]["replayed"] is True
+    override = client.post(
+        f"/v1/internal/admin/workspaces/{workspace.id}/trust-override",
+        headers=headers,
+        json={"tier": 2, "identity_bypass": True, "reason": "manual review"},
+    )
+    assert override.status_code == 200
+    assert override.json()["data"]["operator_identity"] == "ops@example.com"
+    for prefix in ("", "/v1"):
+        assert internal_service_credential(
+            settings, f"{prefix}/internal/admin/workspaces/{workspace.id}/abuse"
+        ) == ("operator", "operator-secret")
+        assert internal_service_credential(
+            settings,
+            f"{prefix}/internal/admin/workspaces/{workspace.id}/trust-override",
+        ) == ("operator", "operator-secret")
+    assert internal_service_credential(
+        settings, f"/internal/admin/workspaces/{workspace.id}/abuse/extra"
+    )[0] == "gateway"
+
+
+def test_operator_credential_discovery_names_are_pinned_and_values_are_isolated() -> None:
+    prefixed = {
+        name
+        for name in Settings.model_fields
+        if name.startswith(("internal_", "observer_", "synthetic_", "federation_"))
+        and name.endswith(("_token", "_tokens", "_api_key"))
+    }
+    assert prefixed == {
+        "internal_gateway_token",
+        "observer_internal_token",
+        "synthetic_monitor_api_key",
+        "federation_peer_token",
+        "federation_home_token",
+        "federation_credit_inbound_token",
+        "federation_credit_peer_token",
+        "federation_settlement_inbound_tokens",
+        "federation_settlement_home_token",
+    }
+    assert operator_credential_setting_names(Settings) == (
+        set(SERVICE_SURFACE_SECRET_OWNERS) | prefixed
+    ) - {"operator_token"}
+    with pytest.raises(ValidationError, match="TR_FEDERATION_SETTLEMENT_INBOUND_TOKENS"):
+        Settings(
+            operator_token="same-secret",  # noqa: S106 - test credential.
+            operator_identities="ops@example.com",
+            federation_settlement_inbound_tokens="aws=same-secret",
+        )
+
+
+def test_postgres_bootstrap_maintains_inventory_and_explicit_conflict_target() -> None:
+    conn = sqlite_postgres_conn()
+    store = postgres_store_on(conn)
+    user = store.ensure_user("postgres-owner@example.com", trial_credit_microdollars=0)
+    inventory = conn._raw.execute(
+        "SELECT owner_user_id, workspace_id FROM tr_owner_workspace"
+    ).fetchall()
+    assert len(inventory) == 1 and inventory[0][0] == user.id
+    assert store.get_user(user.id).owner_workspace_count == 1
+    source = inspect.getsource(store._insert_owner_inventory_tx)
+    assert "ON CONFLICT (owner_user_id, workspace_id) DO NOTHING" in source
+
+
+def test_trust_arm_flag_remains_pinned_off() -> None:
+    assert Settings().spend_lease_trust_eligibility_enabled is False
+
+
+def test_settings_reject_owner_limit_above_pinned_mutation_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TR_CREDIT_SHARDS_MAX", "64")
+    monkeypatch.setenv("TR_MAX_WORKSPACES_PER_OWNER", "45")
+    with pytest.raises(ValidationError, match="pinned 20000-mutation trust budget"):
+        Settings(environment="test")
+
+    monkeypatch.delenv("TR_CREDIT_SHARDS_MAX")
+    monkeypatch.delenv("TR_MAX_WORKSPACES_PER_OWNER")
+    settings = Settings(environment="test")
+    assert settings.max_workspaces_per_owner == 25
+
+
+def test_user_owner_counter_is_a_persisted_dataclass_field() -> None:
+    assert "owner_workspace_count" in {
+        field.name for field in dataclasses.fields(User)
+    }


### PR DESCRIPTION
Slice 1c of trust-tier PR 1 (spend-lease design record, decisions 75–76 converged at v83): owner inventory, atomic identity demotion, database-resident overrides, the operator routes and credential isolation. Inert: `TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED` stays pinned false and the flag-off goldens of slices 1a and 1b′ still pass.

- **Owner inventory.** `tr_owner_workspace` plus a counter on the user row, maintained in the same read-write transaction as every creation path (normal creation, account bootstrap, wallet bootstrap), ownership transfer, archive and restore, and fan-out-changing resharding. `TR_MAX_WORKSPACES_PER_OWNER` (25) is enforced for new creation only, concurrently safe. Archiving is transactional exclusion: the workspace leaves the inventory, its shards are latched and its leases retired in one transaction. A two-way backfill repairs existing ownership and writes a `tr_trust_backfill` marker under provider `owner_inventory`.
- **The owner budget is a maintained invariant.** Every transaction that can grow an owner's fan-out rejects when the resulting shards times seven replicated columns would exceed the pinned 20,000-mutation budget, and settings validation refuses a `TR_MAX_WORKSPACES_PER_OWNER` whose worst case exceeds it. A grandfathered owner already over the budget takes the fail-closed remainder path: the workspaces that fit are demoted in the transaction, the rest are recorded in `tr_trust_demotion_remainder` and alerted.
- **Atomic identity demotion.** Every transition of a user's persisted identity status away from approved happens in the same transaction as the Veriff webhook claim and the user transition, enumerates the owner inventory and rewrites the trust tier on every active shard of every owned workspace under the identity ceiling.
- **Database-resident overrides.** `tr_trust_override` is written only by `POST /internal/admin/workspaces/{id}/trust-override`, whose transaction records the row and rewrites every active shard; the settings-based override is gone.
- **Abuse and credential isolation.** `POST /internal/admin/workspaces/{id}/abuse` requires the operator token, an operator identity from `TR_OPERATOR_IDENTITIES` and an operator-supplied `abuse_ref`; its single transaction records the fact, latches every shard and adds the `abuse` pause cause, and clearing the pause never unlatches. Startup rejects an operator token equal to any credential discovered through the surface-ownership metadata or any internal, observer, synthetic or federation token or API key, with the asserted set pinned by name in a test.

Reviewed by Fable on an isolated snapshot: the slice suites, schema and reshard suites, spend-lease gateway and billing suites, ruff and mypy pass. Mutations that accept an unknown operator identity, skip the owner-budget remainder path, or drop the settings validation each turn the suite red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
