### PR TITLE
Repair public engagement telemetry

### DIFF
--- a/docs/marketing/first-party-attribution.md
+++ b/docs/marketing/first-party-attribution.md
@@ -149,6 +149,12 @@ does not request search text, user identifiers, or audience data. Spend and
 revenue remain integer microdollars. Use `--google-ads-spend required` in a
 decision report so missing credentials or permissions fail closed.
 
+Landing engagements from the isolated public service are written as native
+Cloud Logging JSON with an explicit metadata allowlist. The report merges those
+rows with conversion events from Axiom. The public service receives no Axiom
+credential, and Google Ads reporting remains read-only: no TrustedRouter user,
+signup, activation, or purchase data is uploaded to Google.
+
 One `utm_content` value is one measurable creative cell. Multiple headlines
 inside one responsive search ad share that cell, so create separately tagged
 ads when headline-level downstream measurement is required.

--- a/scripts/marketing_funnel_report.py
+++ b/scripts/marketing_funnel_report.py
@@ -29,6 +29,7 @@ from trusted_router.marketing_funnel import (  # noqa: E402
     aggregate_cohort_funnel_rows,
     build_axiom_cohort_query,
     parse_axiom_json_lines,
+    parse_cloud_logging_engagements,
     render_markdown,
     render_measurement_markdown,
     summarize_measurement,
@@ -73,6 +74,15 @@ def parse_args() -> argparse.Namespace:
             "'required' fails instead of withholding CAC/ROAS."
         ),
     )
+    parser.add_argument(
+        "--public-engagements",
+        choices=("auto", "required", "off"),
+        default="auto",
+        help=(
+            "Merge metadata-only landing engagements from structured Cloud Logging. "
+            "'required' fails if they cannot be read."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -106,8 +116,15 @@ def main() -> int:
         detail = completed.stderr.strip() or "Axiom query failed"
         raise SystemExit(detail)
     observed_through = dt.datetime.now(dt.UTC)
+    cohort_records = parse_axiom_json_lines(completed.stdout)
+    cloud_engagements, engagement_error = _public_engagements(
+        args,
+        start_at=cohort_start,
+        end_at=observed_through,
+    )
+    cohort_records.extend(cloud_engagements)
     rows = aggregate_cohort_funnel_rows(
-        parse_axiom_json_lines(completed.stdout),
+        cohort_records,
         cohort_start=cohort_start,
         cohort_end=cohort_end,
         observed_through=observed_through,
@@ -140,6 +157,11 @@ def main() -> int:
                         if spend
                         else {"status": "unavailable", "reason": spend_error}
                     ),
+                    "public_engagements": {
+                        "status": "available" if engagement_error is None else "unavailable",
+                        "events": len(cloud_engagements),
+                        "reason": engagement_error,
+                    },
                     "funnel": [row.as_dict() for row in rows],
                 },
                 indent=2,
@@ -204,6 +226,55 @@ def _google_ads_spend(
             raise SystemExit(str(exc)) from exc
         return None, "native_spend_fetch_failed", start_at, end_at
     return spend, None, start_at, end_at
+
+
+def _public_engagements(
+    args: argparse.Namespace,
+    *,
+    start_at: dt.datetime,
+    end_at: dt.datetime,
+) -> tuple[list[dict[str, object]], str | None]:
+    if args.public_engagements == "off":
+        return [], "cloud_logging_disabled"
+    gcloud = shutil.which("gcloud")
+    if gcloud is None:
+        if args.public_engagements == "required":
+            raise SystemExit("gcloud CLI is required for public engagement telemetry")
+        return [], "gcloud_not_available"
+    start = start_at.astimezone(dt.UTC).isoformat().replace("+00:00", "Z")
+    end = end_at.astimezone(dt.UTC).isoformat().replace("+00:00", "Z")
+    log_filter = (
+        'resource.type="cloud_run_revision" '
+        'AND resource.labels.service_name="trusted-router-public" '
+        'AND jsonPayload.event="acquisition.landing_engaged" '
+        f'AND timestamp>="{start}" AND timestamp<="{end}"'
+    )
+    completed = subprocess.run(  # noqa: S603 - executable is resolved by shutil.which.
+        [
+            gcloud,
+            "logging",
+            "read",
+            log_filter,
+            "--project",
+            "quill-cloud-proxy",
+            "--format=json",
+            "--limit=100000",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        if args.public_engagements == "required":
+            detail = completed.stderr.strip() or "Cloud Logging query failed"
+            raise SystemExit(detail)
+        return [], "cloud_logging_fetch_failed"
+    try:
+        return parse_cloud_logging_engagements(completed.stdout), None
+    except ValueError as exc:
+        if args.public_engagements == "required":
+            raise SystemExit(str(exc)) from exc
+        return [], "cloud_logging_parse_failed"
 
 
 if __name__ == "__main__":

--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -13,6 +13,7 @@ Heavy logic lives elsewhere:
 
 from __future__ import annotations
 
+import json
 import logging
 import sys
 from typing import Any
@@ -105,6 +106,44 @@ from trusted_router.types import ErrorType
 _storage_error_logger = logging.getLogger(__name__)
 
 _APP_CONSOLE_HANDLER_MARKER = "_trusted_router_app_console"
+_ACQUISITION_CLOUD_FIELDS = (
+    "anonymous_fingerprint",
+    "utm_source",
+    "utm_medium",
+    "utm_campaign",
+    "utm_content",
+    "landing_path",
+    "experiment_id",
+    "experiment_cell_id",
+    "has_gclid",
+    "has_gbraid",
+    "has_wbraid",
+    "has_twclid",
+)
+
+
+class _ApplicationConsoleFormatter(logging.Formatter):
+    """Emit acquisition metadata as Cloud Logging JSON, and other logs as text."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        event = getattr(record, "event", "")
+        if (
+            record.name == "trusted_router.acquisition"
+            and isinstance(event, str)
+            and event.startswith("acquisition.")
+        ):
+            payload: dict[str, object] = {
+                "severity": record.levelname,
+                "logger": record.name,
+                "message": record.getMessage(),
+                "event": event,
+            }
+            for field in _ACQUISITION_CLOUD_FIELDS:
+                value = getattr(record, field, None)
+                if value is not None:
+                    payload[field] = value
+            return json.dumps(payload, separators=(",", ":"), sort_keys=True)
+        return super().format(record)
 
 
 def _configure_application_logging() -> None:
@@ -133,7 +172,9 @@ def _configure_application_logging() -> None:
 
     handler = logging.StreamHandler(sys.stderr)
     handler.setLevel(logging.INFO)
-    handler.setFormatter(logging.Formatter("%(levelname)s %(name)s %(message)s"))
+    handler.setFormatter(
+        _ApplicationConsoleFormatter("%(levelname)s %(name)s %(message)s")
+    )
     setattr(handler, _APP_CONSOLE_HANDLER_MARKER, True)
     app_logger.addHandler(handler)
 

--- a/src/trusted_router/marketing_funnel.py
+++ b/src/trusted_router/marketing_funnel.py
@@ -291,6 +291,59 @@ def parse_axiom_json_lines(payload: str) -> list[dict[str, object]]:
     return rows
 
 
+def parse_cloud_logging_engagements(payload: str) -> list[dict[str, object]]:
+    """Convert structured public-service log entries into cohort event rows."""
+    try:
+        entries = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Invalid Cloud Logging JSON") from exc
+    if not isinstance(entries, list):
+        raise ValueError("Cloud Logging payload is not a list")
+
+    rows: list[dict[str, object]] = []
+    for index, entry in enumerate(entries, start=1):
+        if not isinstance(entry, dict):
+            raise ValueError(f"Cloud Logging entry {index} is not an object")
+        body = entry.get("jsonPayload")
+        if not isinstance(body, dict):
+            continue
+        if body.get("event") != "acquisition.landing_engaged":
+            continue
+        timestamp = entry.get("timestamp")
+        if not isinstance(timestamp, str) or not timestamp:
+            raise ValueError(f"Cloud Logging entry {index} has no timestamp")
+        row = {
+            field: body.get(field)
+            for field in (
+                "event",
+                "anonymous_fingerprint",
+                "utm_source",
+                "utm_medium",
+                "utm_campaign",
+                "utm_content",
+                "landing_path",
+                "experiment_id",
+                "experiment_cell_id",
+            )
+        }
+        row.update(
+            {
+                "first_at": timestamp,
+                "events": 1,
+                "revenue_microdollars": 0,
+                "google_ads_click_events": int(
+                    any(
+                        body.get(field) is True
+                        for field in ("has_gclid", "has_gbraid", "has_wbraid")
+                    )
+                ),
+                "google_ads_persisted_events": 0,
+            }
+        )
+        rows.append(row)
+    return rows
+
+
 def aggregate_funnel_rows(
     records: Iterable[dict[str, object]],
     *,

--- a/tests/test_application_logging.py
+++ b/tests/test_application_logging.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import queue
 from collections.abc import Iterator
@@ -100,3 +101,36 @@ def test_application_console_configuration_is_idempotent(
 
     captured = capfd.readouterr()
     assert (captured.err + captured.out).count("only once") == 1
+
+
+def test_acquisition_console_log_is_metadata_only_cloud_logging_json(
+    capfd: pytest.CaptureFixture[str],
+    isolated_application_logging: None,
+) -> None:
+    create_app(
+        Settings(environment="test"),
+        configure_store_arg=False,
+        init_observability=False,
+    )
+
+    logging.getLogger("trusted_router.acquisition").info(
+        "acquisition.landing_engaged",
+        extra={
+            "event": "acquisition.landing_engaged",
+            "anonymous_fingerprint": "a" * 64,
+            "utm_source": "google",
+            "experiment_cell_id": "cell-a",
+            "has_gclid": True,
+            "prompt": "must stay out",
+            "email": "private@example.com",
+        },
+    )
+
+    captured = capfd.readouterr()
+    line = (captured.err + captured.out).strip()
+    payload = json.loads(line)
+    assert payload["event"] == "acquisition.landing_engaged"
+    assert payload["anonymous_fingerprint"] == "a" * 64
+    assert payload["has_gclid"] is True
+    assert "prompt" not in payload
+    assert "email" not in payload

--- a/tests/test_marketing_funnel_report.py
+++ b/tests/test_marketing_funnel_report.py
@@ -15,6 +15,7 @@ from trusted_router.marketing_funnel import (
     experiment_state,
     microdollars_to_usd,
     parse_axiom_json_lines,
+    parse_cloud_logging_engagements,
     percentage,
     render_markdown,
     render_measurement_markdown,
@@ -411,6 +412,54 @@ def test_parse_axiom_json_lines_is_strict() -> None:
         parse_axiom_json_lines("{not-json}")
     with pytest.raises(ValueError, match="not an object"):
         parse_axiom_json_lines("[]")
+
+
+def test_parse_cloud_logging_engagements_is_metadata_only_and_click_aware() -> None:
+    payload = json.dumps(
+        [
+            {
+                "timestamp": "2026-09-04T12:00:00Z",
+                "jsonPayload": {
+                    "event": "acquisition.landing_engaged",
+                    "anonymous_fingerprint": "a" * 64,
+                    "utm_source": "google",
+                    "utm_medium": "paid_search",
+                    "utm_campaign": "google_search_messages_v3",
+                    "utm_content": "cell-a",
+                    "landing_path": "/openrouter-alternative/test/cell-a",
+                    "experiment_id": "google_search_messages_v3",
+                    "experiment_cell_id": "cell-a",
+                    "has_gclid": True,
+                    "prompt": "must stay out",
+                },
+            },
+            {
+                "timestamp": "2026-09-04T12:01:00Z",
+                "jsonPayload": {"event": "unrelated"},
+            },
+        ]
+    )
+
+    rows = parse_cloud_logging_engagements(payload)
+
+    assert rows == [
+        {
+            "event": "acquisition.landing_engaged",
+            "anonymous_fingerprint": "a" * 64,
+            "utm_source": "google",
+            "utm_medium": "paid_search",
+            "utm_campaign": "google_search_messages_v3",
+            "utm_content": "cell-a",
+            "landing_path": "/openrouter-alternative/test/cell-a",
+            "experiment_id": "google_search_messages_v3",
+            "experiment_cell_id": "cell-a",
+            "first_at": "2026-09-04T12:00:00Z",
+            "events": 1,
+            "revenue_microdollars": 0,
+            "google_ads_click_events": 1,
+            "google_ads_persisted_events": 0,
+        }
+    ]
 
 
 def test_report_rendering_escapes_markdown_and_handles_empty_denominators() -> None:


### PR DESCRIPTION
## Summary
- emit acquisition events as native Cloud Logging JSON through an explicit metadata allowlist
- merge public landing engagements into cohort reports while keeping Axiom credentials out of the public service
- document the read-only Google Ads and no-upload privacy boundary

## Verification
- 107 focused tests passed
- Ruff clean
- mypy clean
- production diagnosis confirmed events existed only as dimensionless text logs before this change