### PR TITLE
trust: give the guarded inserts a row source so Spanner accepts them

### DIFF
--- a/src/trusted_router/storage_gcp_trust.py
+++ b/src/trusted_router/storage_gcp_trust.py
@@ -75,7 +75,12 @@ def insert_credit_trust_event(
         "@payment_amount_micro, @currency, @credited_micro, @recovered_micro, "
         "@provider_subtype, @lifecycle_status, @cumulative_refunded, "
         "@recovery_target, @debit_status, @unrecovered_micro, "
-        "@provider_ordering_watermark WHERE NOT EXISTS ("
+        # FROM UNNEST([1]) is load-bearing, not decoration: GoogleSQL rejects a
+        # FROM-less SELECT that carries a WHERE clause ("Query without FROM
+        # clause cannot have a WHERE clause"), so the Postgres spelling of this
+        # guarded insert fails EVERY call on Spanner. One row when the guard
+        # finds nothing, zero when it matches -- the contract the caller reads.
+        "@provider_ordering_watermark FROM UNNEST([1]) AS _one WHERE NOT EXISTS ("
         "SELECT 1 FROM tr_trust_event WHERE provider=@provider AND kind=@kind AND ("
         "(@kind='payment' AND @original_payment_ref IS NOT NULL "
         "AND original_payment_ref=@original_payment_ref) OR "
@@ -648,7 +653,9 @@ def insert_trust_inbox_tx(
 ) -> None:
     transaction.execute_update(
         "INSERT INTO tr_trust_inbox (provider, adverse_ref, payload, received_at) "
-        "SELECT @provider, @adverse_ref, @payload, @received_at WHERE NOT EXISTS ("
+        # Same GoogleSQL rule as insert_credit_trust_event above.
+        "SELECT @provider, @adverse_ref, @payload, @received_at "
+        "FROM UNNEST([1]) AS _one WHERE NOT EXISTS ("
         "SELECT 1 FROM tr_trust_inbox WHERE provider=@provider AND adverse_ref=@adverse_ref)",
         params={
             "provider": event.provider,

--- a/tests/test_spanner_googlesql_shape.py
+++ b/tests/test_spanner_googlesql_shape.py
@@ -1,0 +1,146 @@
+"""Native-Spanner SQL is never parsed anywhere in CI, so parse its SHAPE here.
+
+`tests/conformance/conftest.py` documents the gap in its own docstring: the
+`spanner-pg` backend points a PostgresStore at Spanner (right dialect, wrong
+store), `spanner-emulator` skips unconditionally, and the in-process fake
+executes the native store but "is not the Spanner query planner". The result
+is that a GoogleSQL syntax error in `storage_gcp*.py` reaches production
+green.
+
+This guard closes the one class that has actually shipped: GoogleSQL rejects
+a FROM-less SELECT carrying a WHERE clause ("Query without FROM clause cannot
+have a WHERE clause"), while PostgreSQL accepts it. The Postgres spelling of a
+guarded insert --
+
+    INSERT INTO t (...) SELECT @a, @b WHERE NOT EXISTS (SELECT 1 FROM t ...)
+
+-- therefore fails EVERY call on Spanner. It shipped in trust-tiers slice 1a
+and broke Stripe credit application until the fix that added this test. The
+Spanner spelling adds a one-row source: `FROM UNNEST([1]) AS _one`.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import re
+
+import pytest
+
+SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "trusted_router"
+SQL_METHODS = {"execute_sql", "execute_update", "execute_partitioned_dml"}
+# A non-constant fragment (e.g. ", ".join(COLUMNS)) stands in as one token: no
+# fragment the code builds that way introduces or removes a FROM/WHERE clause.
+PLACEHOLDER = " _dyn "
+WORD = re.compile(r"[A-Za-z_][A-Za-z_0-9]*|[(),]")
+
+
+def _native_spanner_modules() -> list[pathlib.Path]:
+    return sorted(SRC.glob("storage_gcp*.py"))
+
+
+def _fold(node: ast.AST) -> str | None:
+    """The statement text, with dynamic fragments replaced by a placeholder."""
+    if isinstance(node, ast.Constant):
+        return node.value if isinstance(node.value, str) else PLACEHOLDER
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left, right = _fold(node.left), _fold(node.right)
+        if left is None or right is None:
+            return None
+        return left + right
+    if isinstance(node, ast.JoinedStr):
+        parts = [_fold(value) for value in node.values]
+        return None if any(part is None for part in parts) else "".join(parts)  # type: ignore[arg-type]
+    return PLACEHOLDER
+
+
+def _statements(path: pathlib.Path) -> list[tuple[int, str]]:
+    tree = ast.parse(path.read_text())
+    found: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        func = node.func
+        name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+        if name not in SQL_METHODS:
+            continue
+        text = _fold(node.args[0])
+        if text and "SELECT" in text.upper():
+            found.append((node.lineno, " ".join(text.split())))
+    return found
+
+
+def _from_less_select_with_where(sql: str) -> bool:
+    """True when some SELECT has a WHERE at its own paren depth and no FROM.
+
+    Each SELECT is judged at the depth it opens on, so a subquery that has its
+    own FROM never excuses the outer query, and vice versa.
+    """
+    words: list[tuple[str, int]] = []
+    depth = 0
+    for match in WORD.finditer(sql):
+        word = match.group(0)
+        if word == "(":
+            depth += 1
+        elif word == ")":
+            depth -= 1
+        else:
+            words.append((word.upper(), depth))
+    for index, (word, depth) in enumerate(words):
+        if word != "SELECT":
+            continue
+        for later, later_depth in words[index + 1 :]:
+            if later_depth < depth:
+                break  # this SELECT's scope closed
+            if later_depth != depth:
+                continue  # inside a subquery: not this SELECT's clause
+            if later == "FROM":
+                break  # has a row source, fine
+            if later in {"WHERE", "UNION", "INTERSECT", "EXCEPT"}:
+                return later == "WHERE"
+    return False
+
+
+@pytest.mark.parametrize("path", _native_spanner_modules(), ids=lambda p: p.name)
+def test_no_from_less_select_with_where(path: pathlib.Path) -> None:
+    offenders = [
+        f"{path.name}:{line} -> {sql[:120]}"
+        for line, sql in _statements(path)
+        if _from_less_select_with_where(sql)
+    ]
+    assert not offenders, (
+        "GoogleSQL rejects a FROM-less SELECT that has a WHERE clause. "
+        "Add a one-row source (FROM UNNEST([1]) AS _one):\n" + "\n".join(offenders)
+    )
+
+
+def test_the_guard_actually_reads_statements() -> None:
+    """An extractor that silently finds nothing would make the guard vacuous."""
+    modules = _native_spanner_modules()
+    assert modules, "no storage_gcp*.py modules found"
+    total = sum(len(_statements(path)) for path in modules)
+    assert total > 100, f"only {total} statements extracted; the extractor regressed"
+    trust = SRC / "storage_gcp_trust.py"
+    guarded = [sql for _line, sql in _statements(trust) if "NOT EXISTS" in sql]
+    assert guarded, "the guarded inserts in storage_gcp_trust.py were not extracted"
+    assert all("UNNEST([1])" in sql for sql in guarded), guarded
+
+
+@pytest.mark.parametrize(
+    ("sql", "flagged"),
+    [
+        ("INSERT INTO t (a) SELECT @a WHERE NOT EXISTS (SELECT 1 FROM t WHERE a=@a)", True),
+        ("SELECT @a, @b WHERE TRUE", True),
+        (
+            "INSERT INTO t (a) SELECT @a FROM UNNEST([1]) AS _one "
+            "WHERE NOT EXISTS (SELECT 1 FROM t WHERE a=@a)",
+            False,
+        ),
+        ("SELECT a FROM t WHERE a=@a", False),
+        ("SELECT a FROM t WHERE EXISTS (SELECT 1 FROM u WHERE u.a=t.a)", False),
+        ("SELECT (SELECT 1 FROM u LIMIT 1) AS x FROM t WHERE t.a=@a", False),
+        ("SELECT @a", False),
+    ],
+)
+def test_detector_semantics(sql: str, flagged: bool) -> None:
+    assert _from_less_select_with_where(sql) is flagged

--- a/tests/test_spanner_googlesql_shape.py
+++ b/tests/test_spanner_googlesql_shape.py
@@ -3,20 +3,24 @@
 `tests/conformance/conftest.py` documents the gap in its own docstring: the
 `spanner-pg` backend points a PostgresStore at Spanner (right dialect, wrong
 store), `spanner-emulator` skips unconditionally, and the in-process fake
-executes the native store but "is not the Spanner query planner". The result
-is that a GoogleSQL syntax error in `storage_gcp*.py` reaches production
-green.
+executes the native store but "is not the Spanner query planner". So a
+GoogleSQL syntax error in the native store reaches production green.
 
-This guard closes the one class that has actually shipped: GoogleSQL rejects
-a FROM-less SELECT carrying a WHERE clause ("Query without FROM clause cannot
-have a WHERE clause"), while PostgreSQL accepts it. The Postgres spelling of a
-guarded insert --
+This guard closes the class that has actually shipped: GoogleSQL rejects a
+FROM-less SELECT carrying a WHERE clause ("Query without FROM clause cannot
+have a WHERE clause"), while PostgreSQL accepts it. The Postgres spelling of
+a guarded insert --
 
     INSERT INTO t (...) SELECT @a, @b WHERE NOT EXISTS (SELECT 1 FROM t ...)
 
 -- therefore fails EVERY call on Spanner. It shipped in trust-tiers slice 1a
 and broke Stripe credit application until the fix that added this test. The
 Spanner spelling adds a one-row source: `FROM UNNEST([1]) AS _one`.
+
+Two things this file guards about itself, because a shape checker that
+quietly inspects nothing is worse than none: `test_guard_resolves_nearly_every_call_site`
+pins how much of the real SQL it can actually read, and `test_detector_semantics`
+pins the detector against hand-written cases in both directions.
 """
 
 from __future__ import annotations
@@ -28,54 +32,136 @@ import re
 import pytest
 
 SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "trusted_router"
+# The Spanner client's own method names. psycopg spells it `.execute(`, so
+# matching on these keeps the Postgres store (a dialect where the shape under
+# test is perfectly legal) out of scope by construction.
 SQL_METHODS = {"execute_sql", "execute_update", "execute_partitioned_dml"}
-# A non-constant fragment (e.g. ", ".join(COLUMNS)) stands in as one token: no
-# fragment the code builds that way introduces or removes a FROM/WHERE clause.
+# One fragment the code builds at runtime, e.g. ", ".join(COLUMNS). No such
+# fragment in this tree introduces or removes a FROM or WHERE clause.
 PLACEHOLDER = " _dyn "
 WORD = re.compile(r"[A-Za-z_][A-Za-z_0-9]*|[(),]")
+STRING_LITERAL = re.compile(r"'(?:[^'\\]|\\.)*'")
+LINE_COMMENT = re.compile(r"--[^\n]*")
+SET_OPERATORS = {"UNION", "INTERSECT", "EXCEPT"}
+MAX_VARIANTS = 8
 
 
 def _native_spanner_modules() -> list[pathlib.Path]:
-    return sorted(SRC.glob("storage_gcp*.py"))
+    """Every module that drives Spanner directly, found by what it calls."""
+    modules = []
+    for path in sorted(SRC.rglob("*.py")):
+        if "postgres" in path.name:
+            continue
+        try:
+            tree = ast.parse(path.read_text())
+        except SyntaxError:  # pragma: no cover - the repo does not hold these
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and _call_name(node) in SQL_METHODS:
+                modules.append(path)
+                break
+    return modules
 
 
-def _fold(node: ast.AST) -> str | None:
-    """The statement text, with dynamic fragments replaced by a placeholder."""
+def _call_name(node: ast.Call) -> str:
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return getattr(func, "id", "")
+
+
+def _bound_strings(tree: ast.Module) -> dict[str, list[str]]:
+    """name -> the SQL it can hold, for statements assigned before use.
+
+    Module constants and plain local assignments both land here; without this
+    the guard sees only SQL written inline at the call site, which is about
+    three quarters of it.
+    """
+    bound: dict[str, list[str]] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target, value = node.targets[0], node.value
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            target, value = node.target, node.value
+        else:
+            continue
+        if not isinstance(target, ast.Name):
+            continue
+        # Every string-valued binding, not only the ones that say SELECT: a
+        # name holding an UPDATE is still a statement this file must be able
+        # to SEE, and coverage is the measure of whether it can.
+        values = [text for text in _fold(value, {}) if PLACEHOLDER not in text]
+        if values:
+            bound.setdefault(target.id, []).extend(values)
+    return bound
+
+
+def _fold(node: ast.AST, bound: dict[str, list[str]]) -> list[str]:
+    """Every string the expression can be, with dynamic parts as placeholders.
+
+    A list rather than one string so a conditional (`a if c else b`) is judged
+    as both of its arms instead of a meaningless splice of the two.
+    """
     if isinstance(node, ast.Constant):
-        return node.value if isinstance(node.value, str) else PLACEHOLDER
+        return [node.value] if isinstance(node.value, str) else [PLACEHOLDER]
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
-        left, right = _fold(node.left), _fold(node.right)
-        if left is None or right is None:
-            return None
-        return left + right
+        left = _fold(node.left, bound)
+        right = _fold(node.right, bound)
+        return [a + b for a in left for b in right][:MAX_VARIANTS]
     if isinstance(node, ast.JoinedStr):
-        parts = [_fold(value) for value in node.values]
-        return None if any(part is None for part in parts) else "".join(parts)  # type: ignore[arg-type]
-    return PLACEHOLDER
+        parts = [_fold(value, bound) for value in node.values]
+        combined = [""]
+        for part in parts:
+            combined = [a + b for a in combined for b in part][:MAX_VARIANTS]
+        return combined
+    if isinstance(node, ast.IfExp):
+        return (_fold(node.body, bound) + _fold(node.orelse, bound))[:MAX_VARIANTS]
+    if isinstance(node, ast.Name) and node.id in bound:
+        return bound[node.id][:MAX_VARIANTS]
+    return [PLACEHOLDER]
 
 
 def _statements(path: pathlib.Path) -> list[tuple[int, str]]:
     tree = ast.parse(path.read_text())
+    bound = _bound_strings(tree)
     found: list[tuple[int, str]] = []
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Call) or not node.args:
+        if not isinstance(node, ast.Call) or _call_name(node) not in SQL_METHODS:
             continue
-        func = node.func
-        name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
-        if name not in SQL_METHODS:
+        argument = node.args[0] if node.args else _keyword(node, "sql")
+        if argument is None:
             continue
-        text = _fold(node.args[0])
-        if text and "SELECT" in text.upper():
-            found.append((node.lineno, " ".join(text.split())))
+        for text in _fold(argument, bound):
+            if "SELECT" in text.upper():
+                found.append((node.lineno, " ".join(text.split())))
     return found
+
+
+def _keyword(node: ast.Call, name: str) -> ast.AST | None:
+    for keyword in node.keywords:
+        if keyword.arg == name:
+            return keyword.value
+    return None
+
+
+def _call_sites(path: pathlib.Path) -> list[int]:
+    tree = ast.parse(path.read_text())
+    return [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and _call_name(node) in SQL_METHODS
+    ]
 
 
 def _from_less_select_with_where(sql: str) -> bool:
     """True when some SELECT has a WHERE at its own paren depth and no FROM.
 
-    Each SELECT is judged at the depth it opens on, so a subquery that has its
-    own FROM never excuses the outer query, and vice versa.
+    Each SELECT is judged in the scope it opens, so a subquery with its own
+    FROM never excuses the outer query and vice versa. A set operator ends the
+    arm under examination WITHOUT ending the walk: every arm of a UNION is its
+    own SELECT and each one needs its own row source.
     """
+    sql = LINE_COMMENT.sub(" ", STRING_LITERAL.sub(" _str ", sql))
     words: list[tuple[str, int]] = []
     depth = 0
     for match in WORD.finditer(sql):
@@ -93,11 +179,13 @@ def _from_less_select_with_where(sql: str) -> bool:
             if later_depth < depth:
                 break  # this SELECT's scope closed
             if later_depth != depth:
-                continue  # inside a subquery: not this SELECT's clause
+                continue  # inside a subquery: not this SELECT's own clause
             if later == "FROM":
                 break  # has a row source, fine
-            if later in {"WHERE", "UNION", "INTERSECT", "EXCEPT"}:
-                return later == "WHERE"
+            if later == "WHERE":
+                return True
+            if later in SET_OPERATORS:
+                break  # next arm is judged on its own terms
     return False
 
 
@@ -110,20 +198,50 @@ def test_no_from_less_select_with_where(path: pathlib.Path) -> None:
     ]
     assert not offenders, (
         "GoogleSQL rejects a FROM-less SELECT that has a WHERE clause. "
-        "Add a one-row source (FROM UNNEST([1]) AS _one):\n" + "\n".join(offenders)
+        "Give it a one-row source (FROM UNNEST([1]) AS _one):\n" + "\n".join(offenders)
     )
 
 
-def test_the_guard_actually_reads_statements() -> None:
-    """An extractor that silently finds nothing would make the guard vacuous."""
-    modules = _native_spanner_modules()
-    assert modules, "no storage_gcp*.py modules found"
-    total = sum(len(_statements(path)) for path in modules)
-    assert total > 100, f"only {total} statements extracted; the extractor regressed"
+def test_guard_reads_the_modules_it_claims_to() -> None:
+    modules = {path.name for path in _native_spanner_modules()}
+    assert "storage_gcp_trust.py" in modules, modules
+    assert "storage_gcp.py" in modules, modules
+    assert not [name for name in modules if "postgres" in name], modules
     trust = SRC / "storage_gcp_trust.py"
     guarded = [sql for _line, sql in _statements(trust) if "NOT EXISTS" in sql]
     assert guarded, "the guarded inserts in storage_gcp_trust.py were not extracted"
     assert all("UNNEST([1])" in sql for sql in guarded), guarded
+
+
+def test_guard_resolves_nearly_every_call_site() -> None:
+    """A shape checker is only worth its coverage, so pin the coverage.
+
+    SQL assigned to a name before use is the majority of these call sites. If
+    the resolver regresses to inline literals only, the guard would still pass
+    every other test in this file while reading a quarter of the statements.
+    """
+    resolved = unresolved = 0
+    misses: list[str] = []
+    for path in _native_spanner_modules():
+        tree = ast.parse(path.read_text())
+        bound = _bound_strings(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or _call_name(node) not in SQL_METHODS:
+                continue
+            argument = node.args[0] if node.args else _keyword(node, "sql")
+            texts = _fold(argument, bound) if argument is not None else []
+            if any(PLACEHOLDER not in text for text in texts):
+                resolved += 1
+            else:
+                unresolved += 1
+                misses.append(f"{path.name}:{node.lineno}")
+    total = resolved + unresolved
+    assert total > 150, f"only {total} call sites found; the scanner regressed"
+    coverage = resolved / total
+    assert coverage >= 0.85, (
+        f"resolved {resolved}/{total} ({coverage:.0%}) native Spanner statements; "
+        f"unread: {', '.join(misses[:12])}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -131,15 +249,23 @@ def test_the_guard_actually_reads_statements() -> None:
     [
         ("INSERT INTO t (a) SELECT @a WHERE NOT EXISTS (SELECT 1 FROM t WHERE a=@a)", True),
         ("SELECT @a, @b WHERE TRUE", True),
+        # A set operator must not disarm the walk for the arms after it.
+        ("SELECT @a UNION ALL SELECT @b WHERE TRUE", True),
+        ("SELECT @a FROM t UNION ALL SELECT @b WHERE TRUE", True),
+        ("SELECT * EXCEPT (secret) FROM t UNION ALL SELECT @b WHERE TRUE", True),
         (
             "INSERT INTO t (a) SELECT @a FROM UNNEST([1]) AS _one "
             "WHERE NOT EXISTS (SELECT 1 FROM t WHERE a=@a)",
             False,
         ),
+        ("SELECT @a FROM UNNEST([1]) UNION ALL SELECT @b FROM UNNEST([1]) WHERE TRUE", False),
         ("SELECT a FROM t WHERE a=@a", False),
         ("SELECT a FROM t WHERE EXISTS (SELECT 1 FROM u WHERE u.a=t.a)", False),
         ("SELECT (SELECT 1 FROM u LIMIT 1) AS x FROM t WHERE t.a=@a", False),
         ("SELECT @a", False),
+        # A literal or a comment that merely contains the words is not a clause.
+        ("SELECT 'where the FROM is' AS x", False),
+        ("SELECT @a -- WHERE this is a comment\n", False),
     ],
 )
 def test_detector_semantics(sql: str, flagged: bool) -> None:


### PR DESCRIPTION
## The bug

GoogleSQL rejects a FROM-less `SELECT` that carries a `WHERE` clause. PostgreSQL accepts it, so the Postgres spelling of a guarded insert fails **every** call on the native Spanner store:

```sql
INSERT INTO t (...) SELECT @a, @b WHERE NOT EXISTS (SELECT 1 FROM t ...)
-- InvalidArgument: Query without FROM clause cannot have a WHERE clause
```

Both trust-fact inserts were written that way in slice 1a. Since it deployed, every path through `insert_credit_trust_event` raised `InvalidArgument` (Sentry [QUILL-ROUTER-5T](https://lore-hex-corp.sentry.io/issues/QUILL-ROUTER-5T)):

| Path | Effect |
|---|---|
| Stripe payment credit (`credit_workspace_typed_direct`) | The insert runs **before** the balance update in the same transaction, so the credit aborted entirely and the webhook returned 500 |
| Refunds and disputes (`record_adverse_trust_event`) | Never recorded |
| Abuse path, cross-plane credit transfer | Never recorded |
| Account provisioning | **Kept working** — it writes the same table with a mutation, not DML |

That last row is why this hid: `tr_trust_event` looked alive while holding nothing but provisioning grants, and zero `stripe_event` records were written all day against a baseline of 2–9.

## The fix

`FROM UNNEST([1]) AS _one` gives the SELECT a one-row source and preserves the semantics exactly: one row when the guard matches nothing, zero when it matches, which is the `int(inserted) == 1` contract the callers read. Both fixed statements were verified to parse against production Spanner.

## The guard

Nothing in CI parses native-Spanner SQL, and `tests/conformance/conftest.py` explains why in its own docstring: `spanner-pg` builds a **PostgresStore** (right dialect, wrong store), `spanner-emulator` skips unconditionally, and the in-process fake "is not the Spanner query planner".

`tests/test_spanner_googlesql_shape.py` parses the shape of every statement in `storage_gcp*.py` and fails on a FROM-less SELECT with a WHERE, at the correct paren depth so subqueries are judged independently. It was verified to **fail on the pre-fix statements** (naming both) and pass on the fixed ones, plus a table of detector cases and a non-vacuity check on the extractor.

## Recovery

The whole transaction rolled back, so no idempotency marker was written and Stripe's ~3-day retries should deliver the missed events once this is live. Worth confirming in the Stripe dashboard rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review fixes (codex + adversarial workflow)

Two holes the first cut of the guard had, both confirmed by independent refuters:
- **Set operators disarmed the walk.** `return` instead of `break` on UNION/INTERSECT/EXCEPT abandoned every later SELECT, so `SELECT @a UNION ALL SELECT @b WHERE TRUE` read as clean. That shape is live in the operational-analytics outbox.
- **SQL bound to a name was invisible** — about three quarters of these call sites. The same bug written the Postgres way and assigned to a variable would have shipped green. The binder now resolves string assignments, and the bare `total > 100` vacuity check is replaced by a coverage assertion over call sites (224/256, 88%).

Module discovery also moved from a filename glob to "calls the Spanner client's own methods", so the Postgres store is out of scope by construction rather than by name.
