### PR TITLE
rollout: pin the spend-lease Bigtable table and app profiles (no lease could mint without them)

### DIFF
--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -463,6 +463,14 @@ REGIONAL_QUOTA_BIGTABLE_TABLE="${TR_REGIONAL_QUOTA_BIGTABLE_TABLE:-$(
 REGIONAL_QUOTA_BIGTABLE_APP_PROFILES="${TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES:-$(
   read_primary_regional_quota_env "TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES"
 )}"
+SPEND_LEASE_BIGTABLE_TABLE="${TR_SPEND_LEASE_BIGTABLE_TABLE:-$(
+  read_primary_regional_quota_env "TR_SPEND_LEASE_BIGTABLE_TABLE" "trustedrouter-spend-lease"
+)}"
+SPEND_LEASE_BIGTABLE_APP_PROFILES="${TR_SPEND_LEASE_BIGTABLE_APP_PROFILES:-$(
+  read_primary_regional_quota_env \
+    "TR_SPEND_LEASE_BIGTABLE_APP_PROFILES" \
+    "us-central1=tr-spend-us-central1"
+)}"
 REGIONAL_QUOTA_LEASE_TTL_SECONDS="${TR_REGIONAL_QUOTA_LEASE_TTL_SECONDS:-$(
   read_primary_regional_quota_env "TR_REGIONAL_QUOTA_LEASE_TTL_SECONDS" "60"
 )}"
@@ -501,6 +509,11 @@ fi
 # those rules. The emergency rollback path is explicit: deploy with binding
 # disabled, then investigate or roll forward from there.
 SPEND_LEASE_BINDING_TARGET="${TR_SPEND_LEASE_BINDING_ENABLED:-true}"
+if [ "$SPEND_LEASE_BINDING_TARGET" = "true" ] &&
+   [ -z "$SPEND_LEASE_BIGTABLE_APP_PROFILES" ]; then
+  log "refusing rollout: TR_SPEND_LEASE_BINDING_ENABLED=true requires non-empty TR_SPEND_LEASE_BIGTABLE_APP_PROFILES"
+  exit 1
+fi
 case "$SPEND_LEASE_BINDING_TARGET" in
   true)
     spend_lease_unit_4_source="${SCRIPT_DIR}/../../src/trusted_router/services/spend_lease_settlement.py"
@@ -731,6 +744,8 @@ ENV_VARS=(
   "TR_REGIONAL_QUOTA_LEDGER_TIMEOUT_SECONDS=${REGIONAL_QUOTA_LEDGER_TIMEOUT_SECONDS}"
   "TR_REGIONAL_QUOTA_BIGTABLE_TABLE=${REGIONAL_QUOTA_BIGTABLE_TABLE}"
   "TR_REGIONAL_QUOTA_BIGTABLE_APP_PROFILES=${REGIONAL_QUOTA_BIGTABLE_APP_PROFILES}"
+  "TR_SPEND_LEASE_BIGTABLE_TABLE=${SPEND_LEASE_BIGTABLE_TABLE}"
+  "TR_SPEND_LEASE_BIGTABLE_APP_PROFILES=${SPEND_LEASE_BIGTABLE_APP_PROFILES}"
   # 2026-08-30 pilot: Joseph's own Personal Workspace (first-party, his account,
   # at his direction). The previous pilot, TrustedRouter Synthetic Monitoring
   # (d385c399-b245-4147-a528-0a4f6f170c71), was structurally ineligible because

--- a/tests/test_deploy_script_execution.py
+++ b/tests/test_deploy_script_execution.py
@@ -530,6 +530,77 @@ def test_rollout_binding_unit_4_fence_passes_with_settle_clamp(
     )
     serialized_env = deploy[deploy.index("--set-env-vars") + 1]
     assert "TR_SPEND_LEASE_BINDING_ENABLED=true" in serialized_env.split("|")
+    assert "TR_SPEND_LEASE_BIGTABLE_TABLE=trustedrouter-spend-lease" in serialized_env.split(
+        "|"
+    )
+    assert (
+        "TR_SPEND_LEASE_BIGTABLE_APP_PROFILES=us-central1=tr-spend-us-central1"
+        in serialized_env.split("|")
+    )
+
+
+def test_rollout_binding_refuses_empty_spend_lease_app_profiles(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    script = "scripts/deploy/rollout.sh"
+    fixture = SCRIPT_FIXTURES[script]
+    active_revision = json.dumps(
+        {
+            "spec": {
+                "containers": [
+                    {
+                        "env": [
+                            {
+                                "name": "TR_REGIONAL_QUOTA_LEASES_ENABLED",
+                                "value": "false",
+                            },
+                            {
+                                "name": "TR_REGIONAL_QUOTA_LEASE_ISSUANCE_ENABLED",
+                                "value": "false",
+                            },
+                            {
+                                "name": "TR_SPEND_LEASE_BIGTABLE_APP_PROFILES",
+                                "value": "",
+                            },
+                        ]
+                    }
+                ]
+            }
+        },
+        separators=(",", ":"),
+    )
+    responses = (
+        (
+            r"run revisions describe trusted-router-active .*--format=json",
+            active_revision,
+        ),
+        *(
+            response
+            for response in fixture.responses
+            if "run revisions describe trusted-router-active" not in response[0]
+        ),
+    )
+    monkeypatch.setitem(
+        SCRIPT_FIXTURES,
+        script,
+        replace(fixture, responses=responses),
+    )
+    isolated = DeployScriptHarness(tmp_path / "spend-lease-profiles-empty")
+
+    run = isolated.run(script)
+
+    assert run.returncode != 0
+    assert (
+        "TR_SPEND_LEASE_BINDING_ENABLED=true requires non-empty "
+        "TR_SPEND_LEASE_BIGTABLE_APP_PROFILES"
+        in run.stderr
+    )
+    assert not any(
+        call[0:4] == ["gcloud", "--project", "quill-cloud-proxy", "run"]
+        and call[4:6] == ["deploy", "trusted-router"]
+        for call in run.calls
+    )
 
 
 def test_rollout_binding_unit_4_fence_refuses_missing_settle_clamp(

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -94,6 +94,21 @@ def test_deploy_enables_spend_lease_binding_with_emergency_override() -> None:
         '"TR_SPEND_LEASE_PILOT_WORKSPACE_IDS='
         '45819281-0ce9-4811-a0cd-c660ab3a116d"' in rollout
     )
+    assert (
+        'read_primary_regional_quota_env "TR_SPEND_LEASE_BIGTABLE_TABLE" '
+        '"trustedrouter-spend-lease"' in rollout
+    )
+    assert (
+        '"TR_SPEND_LEASE_BIGTABLE_APP_PROFILES" \\\n'
+        '    "us-central1=tr-spend-us-central1"' in rollout
+    )
+    assert (
+        '"TR_SPEND_LEASE_BIGTABLE_TABLE=${SPEND_LEASE_BIGTABLE_TABLE}"' in rollout
+    )
+    assert (
+        '"TR_SPEND_LEASE_BIGTABLE_APP_PROFILES='
+        '${SPEND_LEASE_BIGTABLE_APP_PROFILES}"' in rollout
+    )
 
 
 def test_deploy_removes_only_explicitly_missing_optional_secrets() -> None:


### PR DESCRIPTION
The pilot binding has been live in all four regions since this morning with boots verifying, but **no lease has ever been minted**: every pilot authorization records `no_lease_reason=ledger_unavailable`, and `spend_lease_open` is empty.

Cause: `SpannerBigtableStore` constructs its spend-lease ledger only when `spend_lease_bigtable_app_profiles` is non-empty. Settings default it to the empty string and `rollout.sh` never pinned it, so `self._spend_lease_ledger` stayed `None` and the mint returned `ledger_unavailable` before doing anything. The regional-quota ledger beside it is pinned exactly this way and works.

The infrastructure already exists in `quill-cloud-proxy`, Bigtable instance `trusted-router-logs`: table `trustedrouter-spend-lease` and app profile `tr-spend-us-central1` routing to `trusted-router-logs-c1`. Nothing needs creating.

- Pin `TR_SPEND_LEASE_BIGTABLE_TABLE` and `TR_SPEND_LEASE_BIGTABLE_APP_PROFILES` the same way the regional-quota pair is resolved: env override, else carry-forward from the current primary revision, else the literal defaults `trustedrouter-spend-lease` and `us-central1=tr-spend-us-central1`.
- Refuse the rollout when binding is enabled and the resolved app profiles are empty, so a binding-enabled deploy can never again ship without a ledger.

Only us-central1 has a spend app profile, so the ledger supports exactly that region and every other region keeps taking the synchronous path. That is the intended pilot shape, and it matches decision 15: allocations and the local lease live in Bigtable, escrow and the global lease live in Spanner. Leases stay GCP-only, as confirmed today; AWS and Azure remain out of cohort and unaffected.

Reviewed by Fable on an isolated snapshot: the wiring and deploy-script modules pass (the two `combined_synthetic_refresh` tests fail identically on clean main in this environment and are excluded), `bash -n`, shellcheck, ruff and mypy are clean. Mutations that blank the app-profile pin, corrupt the table pin, or remove the refusal each turn a test red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
