### PR TITLE
Avoid hanging public snapshot deploys

### DIFF
--- a/scripts/deploy/sync_public_analytics_snapshots.sh
+++ b/scripts/deploy/sync_public_analytics_snapshots.sh
@@ -30,13 +30,25 @@ tar --exclude='__pycache__' --exclude='*.pyc' -C "$ROOT" -czf "$archive" \
   clickhouse/build_public_snapshots.py \
   src/trusted_router
 
+# Streaming the archive over gcloud's SSH stdin can leave the IAP transport
+# alive after the remote shell exits. Upload first so the deployment command
+# has no open stdin channel to keep the GitHub runner stuck.
+remote_archive="/tmp/tr-public-snapshots.${GITHUB_RUN_ID:-local}.${RANDOM}.tar.gz"
+
 log "syncing public analytics snapshot worker to ${NAME}"
+gc compute scp "$archive" "${NAME}:${remote_archive}" \
+  --zone="$ZONE" \
+  --tunnel-through-iap \
+  --quiet
 gc compute ssh "$NAME" \
   --zone="$ZONE" \
   --tunnel-through-iap \
   --quiet \
+  --ssh-flag="-T" \
   --command="sudo sh -c '
     set -eu
+    archive=${remote_archive}
+    trap \"rm -f ${remote_archive}\" EXIT
     stage=/opt/tr-clickhouse-public-snapshots-next
     previous=/opt/tr-clickhouse/src.previous-public-snapshots
     builder=/opt/tr-clickhouse/clickhouse/build_public_snapshots.py
@@ -51,7 +63,7 @@ gc compute ssh "$NAME" \
     }
     rm -rf \"\$stage\" \"\$previous\" \"\$previous_builder\"
     mkdir -p \"\$stage\"
-    tar -xzf - -C \"\$stage\"
+    tar -xzf \"\$archive\" -C \"\$stage\"
     PYTHONPATH=\"\$stage/src\" /opt/tr-clickhouse/venv/bin/python \
       -m py_compile \"\$stage/clickhouse/build_public_snapshots.py\"
     systemctl stop tr-clickhouse-public-snapshots.timer \
@@ -76,6 +88,6 @@ gc compute ssh "$NAME" \
       exit 1
     fi
     rm -rf \"\$previous\" \"\$previous_builder\" \"\$stage\"
-  '" <"$archive"
+  '"
 
 log "public analytics snapshot worker is current and publishing all four products"

--- a/tests/test_deploy_workflow_regions.py
+++ b/tests/test_deploy_workflow_regions.py
@@ -82,6 +82,10 @@ def test_public_snapshot_worker_swap_is_verified_and_rollbackable() -> None:
     assert "rollback()" in script
     assert r"if [ \"\$count\" != 4 ]; then" in script
     assert r"mv \"\$previous_builder\" \"\$builder\"" in script
+    assert 'gc compute scp "$archive" "${NAME}:${remote_archive}"' in script
+    assert '--ssh-flag="-T"' in script
+    assert 'tar -xzf \\"\\$archive\\" -C \\"\\$stage\\"' in script
+    assert '<"$archive"' not in script
 
 
 def test_all_regions_launch_together_but_only_primary_warm_gates_traffic() -> None:


### PR DESCRIPTION
## Summary
- upload the public snapshot archive with `gcloud compute scp`
- run the remote swap over noninteractive SSH without an attached stdin stream
- preserve atomic verification and rollback behavior

## Verification
- `bash -n scripts/deploy/sync_public_analytics_snapshots.sh`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_deploy_workflow_regions.py` (19 passed)
- `git diff --check`

## Production evidence
The remote snapshot service completed successfully and published all products, but the GitHub runner remained blocked in the stdin-backed IAP SSH transport on two attempts.