### PR TITLE
Detach snapshot deploy SSH stdin

### DIFF
--- a/scripts/deploy/sync_public_analytics_snapshots.sh
+++ b/scripts/deploy/sync_public_analytics_snapshots.sh
@@ -44,6 +44,7 @@ gc compute ssh "$NAME" \
   --zone="$ZONE" \
   --tunnel-through-iap \
   --quiet \
+  --ssh-flag="-n" \
   --ssh-flag="-T" \
   --command="sudo sh -c '
     set -eu

--- a/tests/test_deploy_workflow_regions.py
+++ b/tests/test_deploy_workflow_regions.py
@@ -83,6 +83,7 @@ def test_public_snapshot_worker_swap_is_verified_and_rollbackable() -> None:
     assert r"if [ \"\$count\" != 4 ]; then" in script
     assert r"mv \"\$previous_builder\" \"\$builder\"" in script
     assert 'gc compute scp "$archive" "${NAME}:${remote_archive}"' in script
+    assert '--ssh-flag="-n"' in script
     assert '--ssh-flag="-T"' in script
     assert 'tar -xzf \\"\\$archive\\" -C \\"\\$stage\\"' in script
     assert '<"$archive"' not in script


### PR DESCRIPTION
## Summary
- detach stdin for the IAP SSH command used by the public snapshot deploy
- keep no-TTY behavior and add a regression assertion

## Verification
- bash syntax check passed
- focused deployment tests passed: 19
- the remote worker completed while the prior runner remained blocked, confirming the remaining wait was the SSH client