### PR TITLE
deploy: a public-analytics sync must not gate the control plane

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -286,9 +286,13 @@ jobs:
         # backlog of stuck setCommonInstanceMetadata operations on a 212KB,
         # 365-entry ssh-keys value that every CI run appends to. A stale
         # analytics snapshot is a reporting defect; a control plane that
-        # cannot ship is an outage. Bound it and let the deploy continue --
-        # the step still goes red in the run, so the failure stays visible.
-        timeout-minutes: 8
+        # cannot ship is an outage. So the deploy continues past a failure --
+        # the step still goes red in the run, so it stays visible.
+        #
+        # Deliberately NO timeout-minutes here: the script bounds the upload,
+        # which is the part that hangs, and a deadline on the step could
+        # instead sever SSH midway through the remote swap and leave the node
+        # with no live source tree. Bound the transfer, never the swap.
         continue-on-error: true
         run: scripts/deploy/sync_public_analytics_snapshots.sh --apply
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -278,6 +278,18 @@ jobs:
           SPANNER_DATABASE_ID: trusted-router
         run: scripts/deploy/migrate_operational_analytics_outbox.sh
       - name: Sync shared public analytics snapshots
+        # Publishing the public snapshot builder MUST NOT gate the control
+        # plane. On 2026-09-04 this step blocked every deploy for ~61 minutes
+        # and then failed, holding a Stripe-credit fix out of production:
+        # `gcloud compute scp` pushes a freshly generated SSH key into PROJECT
+        # metadata, and that write was timing out (1800s, twice) behind a
+        # backlog of stuck setCommonInstanceMetadata operations on a 212KB,
+        # 365-entry ssh-keys value that every CI run appends to. A stale
+        # analytics snapshot is a reporting defect; a control plane that
+        # cannot ship is an outage. Bound it and let the deploy continue --
+        # the step still goes red in the run, so the failure stays visible.
+        timeout-minutes: 8
+        continue-on-error: true
         run: scripts/deploy/sync_public_analytics_snapshots.sh --apply
 
       - name: Provision bounded regional quota ledger

--- a/scripts/deploy/sync_public_analytics_snapshots.sh
+++ b/scripts/deploy/sync_public_analytics_snapshots.sh
@@ -36,10 +36,26 @@ tar --exclude='__pycache__' --exclude='*.pyc' -C "$ROOT" -czf "$archive" \
 remote_archive="/tmp/tr-public-snapshots.${GITHUB_RUN_ID:-local}.${RANDOM}.tar.gz"
 
 log "syncing public analytics snapshot worker to ${NAME}"
-gc compute scp "$archive" "${NAME}:${remote_archive}" \
+# Bound the TRANSFER, never the swap below. `gcloud compute scp` generates an
+# SSH key on a fresh runner and pushes it into PROJECT metadata; on
+# 2026-09-04 that write sat behind stuck setCommonInstanceMetadata operations
+# on a 365-entry ssh-keys value and burned 1800s twice before failing, which
+# blocked every control-plane deploy for ~61 minutes. Failing here is safe:
+# `set -e` stops the script before the remote mutation begins, so the node is
+# untouched. A deadline around the swap itself would NOT be safe -- severing
+# SSH between the two `mv`s leaves the live tree absent -- which is why the
+# deadline lives here and the workflow step carries no timeout-minutes.
+if ! timeout -k 30 300 gcloud --project "$PROJECT_ID" compute scp \
+  "$archive" "${NAME}:${remote_archive}" \
   --zone="$ZONE" \
   --tunnel-through-iap \
-  --quiet
+  --quiet; then
+  echo "ERROR: could not upload the snapshot bundle to ${NAME} within 300s;" \
+    "the node was NOT modified. Check for stuck" \
+    "compute.projects.setCommonInstanceMetadata operations and the size of" \
+    "the project ssh-keys metadata value." >&2
+  exit 1
+fi
 gc compute ssh "$NAME" \
   --zone="$ZONE" \
   --tunnel-through-iap \

--- a/tests/test_deploy_workflow_regions.py
+++ b/tests/test_deploy_workflow_regions.py
@@ -71,6 +71,27 @@ def test_deploy_syncs_the_shared_public_snapshot_worker() -> None:
     assert "scripts/deploy/sync_public_analytics_snapshots.sh --apply" in workflow
 
 
+def test_snapshot_sync_cannot_gate_the_control_plane_deploy() -> None:
+    """A public-analytics sync must never hold the control plane hostage.
+
+    It did on 2026-09-04: `gcloud compute scp` pushes a generated SSH key into
+    project metadata, that write timed out twice at 1800s behind a backlog of
+    stuck setCommonInstanceMetadata operations, and the whole deploy failed
+    ~61 minutes in -- with a Stripe-credit fix sitting in the image it was
+    carrying. Bounded and non-fatal, so a snapshot problem degrades snapshots.
+    """
+    workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
+    step = workflow.split("- name: Sync shared public analytics snapshots", 1)[1].split(
+        "- name:", 1
+    )[0]
+    assert "continue-on-error: true" in step, (
+        "the snapshot sync must not fail the deploy job"
+    )
+    assert "timeout-minutes:" in step, "the snapshot sync must be time-bounded"
+    minutes = int(step.split("timeout-minutes:", 1)[1].split("\n", 1)[0].strip())
+    assert 0 < minutes <= 15, f"snapshot sync deadline is {minutes}m; keep it short"
+
+
 def test_public_snapshot_worker_swap_is_verified_and_rollbackable() -> None:
     script = (ROOT / "scripts/deploy/sync_public_analytics_snapshots.sh").read_text(
         encoding="utf-8"

--- a/tests/test_deploy_workflow_regions.py
+++ b/tests/test_deploy_workflow_regions.py
@@ -87,9 +87,24 @@ def test_snapshot_sync_cannot_gate_the_control_plane_deploy() -> None:
     assert "continue-on-error: true" in step, (
         "the snapshot sync must not fail the deploy job"
     )
-    assert "timeout-minutes:" in step, "the snapshot sync must be time-bounded"
-    minutes = int(step.split("timeout-minutes:", 1)[1].split("\n", 1)[0].strip())
-    assert 0 < minutes <= 15, f"snapshot sync deadline is {minutes}m; keep it short"
+    # The deadline belongs on the upload, not the step: a step-level timeout
+    # can sever SSH between the two `mv`s of the remote swap and leave the
+    # node with no live source tree, and the next run deletes the backup.
+    assert "timeout-minutes:" not in step, (
+        "a step deadline can interrupt the remote swap; bound the upload instead"
+    )
+    script = (ROOT / "scripts/deploy/sync_public_analytics_snapshots.sh").read_text(
+        encoding="utf-8"
+    )
+    upload = script.split("compute scp", 1)[0].rsplit("\n", 3)[-1] + script.split(
+        "compute scp", 1
+    )[0][-80:]
+    assert "timeout -k 30 300" in script, "the snapshot upload must be time-bounded"
+    assert "timeout" in upload or "timeout -k 30 300 gcloud" in script, upload
+    swap = script.split("compute ssh", 1)[1]
+    assert "timeout" not in swap.split("--command", 1)[0], (
+        "the remote swap must not carry a deadline that can interrupt it"
+    )
 
 
 def test_public_snapshot_worker_swap_is_verified_and_rollbackable() -> None:
@@ -103,7 +118,11 @@ def test_public_snapshot_worker_swap_is_verified_and_rollbackable() -> None:
     assert "rollback()" in script
     assert r"if [ \"\$count\" != 4 ]; then" in script
     assert r"mv \"\$previous_builder\" \"\$builder\"" in script
-    assert 'gc compute scp "$archive" "${NAME}:${remote_archive}"' in script
+    # Upload first, then swap (#1080): the archive must not be streamed over
+    # SSH stdin. Asserted by behaviour rather than by one exact spelling, so
+    # the line can carry a deadline without breaking this.
+    assert "compute scp" in script
+    assert '"$archive" "${NAME}:${remote_archive}"' in script
     assert '--ssh-flag="-n"' in script
     assert '--ssh-flag="-T"' in script
     assert 'tar -xzf \\"\\$archive\\" -C \\"\\$stage\\"' in script


### PR DESCRIPTION
## Why now

Every control-plane deploy today blocked ~61 minutes on **Sync shared public analytics snapshots** and then failed, holding the merged Stripe-credit fix ([#1077](https://github.com/Lore-Hex/quill-router/pull/1077)) out of production while payments kept failing. Both deploys of that fix were also cancelled by newer commits, so it has not reached prod at all.

## The hang is one layer below #1079 / #1080

Those addressed the IAP transport and stdin. The actual stall is in `gcloud compute scp` itself: it generates an SSH key on the runner and pushes it into **project** metadata. That write is timing out twice at 1800s, because

- the project `ssh-keys` value is **365 entries / 212KB** (every CI run appends one), and
- several `setCommonInstanceMetadata` operations are stuck `RUNNING`/`PENDING` behind each other (oldest from 07:36 PDT).

```
ERROR: (gcloud.compute.scp) Could not add SSH key to instance metadata
 - Did not update the following resources within 1800s
```

## What this changes

The step is bounded at 8 minutes and `continue-on-error`. That is the correct ordering of harms: a stale public analytics snapshot is a reporting defect; a control plane that cannot deploy is an outage. The step still reports red in the run, so the failure stays visible rather than silently passing.

## What this deliberately does NOT do

Pruning the 365 accumulated project SSH keys and clearing the stuck metadata operations are production changes that could remove someone's access, so they are left for a human. Until they happen, any deploy step that shells to the ClickHouse node will keep paying this cost — this change just stops it from being fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review fix

The first cut put `timeout-minutes: 8` on the step. Codex flagged that this can sever SSH partway through the remote swap, between the two `mv`s, leaving the node with no live source tree — and the next run deletes the only backup before failing.

The deadline now sits on the upload instead (`timeout -k 30 300`), which is the part that actually hangs. Failing there is safe: `set -e` stops the script before any remote mutation, so the node is untouched. The step keeps `continue-on-error` and deliberately carries no `timeout-minutes`, which the test pins along with the reason.

Separately worth a follow-up, and pre-existing: the remote swap only rolls back on service-start and verification failure, not on interruption, so a network drop mid-swap has always been able to leave the node in that state.
