### PR TITLE
Implement PostgresStore.update_key so AWS and Azure reach parity

### DIFF
--- a/src/trusted_router/storage_gcp_keys.py
+++ b/src/trusted_router/storage_gcp_keys.py
@@ -14,7 +14,6 @@ import hashlib
 import uuid
 from typing import Any
 
-from trusted_router.money import dollars_to_microdollars
 from trusted_router.scopes import validate_api_key_scopes
 from trusted_router.security import (
     hash_api_key,
@@ -35,13 +34,13 @@ from trusted_router.storage_gcp_counters import (
     key_usage_shard_count,
 )
 from trusted_router.storage_gcp_io import SpannerIO, run_in_transaction_with_retry
+from trusted_router.storage_key_patch import TYPED_LIMIT_PATCH_FIELDS, apply_key_patch
 from trusted_router.storage_key_usage import api_key_from_json, api_key_usage_snapshot
 from trusted_router.storage_models import (
     ApiKey,
     ApiKeyUsageSnapshot,
     GatewayAuthorization,
     _is_byok,
-    iso_now,
 )
 from trusted_router.types import UsageType
 
@@ -79,50 +78,6 @@ _CONSOLE_API_KEYS_SQL = """
              key_record.id,
              key_limit.shard
 """
-
-_TYPED_LIMIT_PATCH_FIELDS = frozenset(
-    {
-        "limit",
-        "limit_microdollars",
-        "limit_daily_microdollars",
-        "limit_weekly_microdollars",
-        "limit_monthly_microdollars",
-        "include_byok_in_limit",
-    }
-)
-
-
-def _apply_key_patch(key: ApiKey, patch: dict[str, Any]) -> None:
-    if "name" in patch and patch["name"]:
-        key.name = str(patch["name"])
-    if "disabled" in patch:
-        key.disabled = bool(patch["disabled"])
-    if "limit" in patch:
-        value = patch["limit"]
-        key.limit_microdollars = None if value is None else dollars_to_microdollars(value)
-    if "limit_microdollars" in patch:
-        key.limit_microdollars = patch["limit_microdollars"]
-    if "limit_reset" in patch:
-        key.limit_reset = patch["limit_reset"]
-    for window in ("daily", "weekly", "monthly"):
-        field = f"limit_{window}_microdollars"
-        if field in patch:
-            setattr(key, field, patch[field])
-    if "include_byok_in_limit" in patch:
-        key.include_byok_in_limit = bool(patch["include_byok_in_limit"])
-    if patch.get("budget_alert_only") is not None:
-        key.budget_alert_only = bool(patch["budget_alert_only"])
-    if "budget_alerted" in patch:
-        key.budget_alerted = dict(patch["budget_alerted"] or {})
-    if "tags" in patch:
-        key.tags = dict(patch["tags"] or {})
-    if "scopes" in patch:
-        key.scopes = validate_api_key_scopes(
-            patch["scopes"],
-            management=key.management,
-        )
-    key.updated_at = iso_now()
-
 
 class SpannerApiKeys:
     def __init__(self, io: SpannerIO) -> None:
@@ -280,11 +235,11 @@ class SpannerApiKeys:
         key = self.get_by_hash(key_hash)
         if key is None:
             return None
-        if not (_TYPED_LIMIT_PATCH_FIELDS & patch.keys()):
+        if not (TYPED_LIMIT_PATCH_FIELDS & patch.keys()):
             # Metadata edits do not touch typed counter configuration. Besides
             # avoiding unnecessary hot-row writes, this preserves an existing
             # escrow partition exactly.
-            _apply_key_patch(key, patch)
+            apply_key_patch(key, patch)
             self._io.write_entity("api_key", key.hash, key)
             return key
 
@@ -302,7 +257,7 @@ class SpannerApiKeys:
             )
             if current is None:
                 return None
-            _apply_key_patch(current, patch)
+            apply_key_patch(current, patch)
             shard_count = key_usage_shard_count(current)
             usage_rows = list(
                 transaction.execute_sql(

--- a/src/trusted_router/storage_key_patch.py
+++ b/src/trusted_router/storage_key_patch.py
@@ -1,0 +1,54 @@
+"""Backend-neutral API-key patch semantics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from trusted_router.money import dollars_to_microdollars
+from trusted_router.scopes import validate_api_key_scopes
+from trusted_router.storage_models import ApiKey, iso_now
+
+TYPED_LIMIT_PATCH_FIELDS = frozenset(
+    {
+        "limit",
+        "limit_microdollars",
+        "limit_daily_microdollars",
+        "limit_weekly_microdollars",
+        "limit_monthly_microdollars",
+        "include_byok_in_limit",
+    }
+)
+
+
+def apply_key_patch(key: ApiKey, patch: dict[str, Any]) -> None:
+    if "name" in patch and patch["name"]:
+        key.name = str(patch["name"])
+    if "disabled" in patch:
+        key.disabled = bool(patch["disabled"])
+    if "limit" in patch:
+        value = patch["limit"]
+        key.limit_microdollars = (
+            None if value is None else dollars_to_microdollars(value)
+        )
+    if "limit_microdollars" in patch:
+        key.limit_microdollars = patch["limit_microdollars"]
+    if "limit_reset" in patch:
+        key.limit_reset = patch["limit_reset"]
+    for window in ("daily", "weekly", "monthly"):
+        field = f"limit_{window}_microdollars"
+        if field in patch:
+            setattr(key, field, patch[field])
+    if "include_byok_in_limit" in patch:
+        key.include_byok_in_limit = bool(patch["include_byok_in_limit"])
+    if patch.get("budget_alert_only") is not None:
+        key.budget_alert_only = bool(patch["budget_alert_only"])
+    if "budget_alerted" in patch:
+        key.budget_alerted = dict(patch["budget_alerted"] or {})
+    if "tags" in patch:
+        key.tags = dict(patch["tags"] or {})
+    if "scopes" in patch:
+        key.scopes = validate_api_key_scopes(
+            patch["scopes"],
+            management=key.management,
+        )
+    key.updated_at = iso_now()

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -106,6 +106,7 @@ from trusted_router.storage_gcp_codec import (
     workspace_key_id,
 )
 from trusted_router.storage_gcp_counters import credit_shard_count, distribute_credit_amount
+from trusted_router.storage_key_patch import TYPED_LIMIT_PATCH_FIELDS, apply_key_patch
 from trusted_router.storage_key_usage import api_key_from_json, api_key_usage_snapshot
 from trusted_router.storage_models import (
     FUTURE_SAMPLE_SKEW_SECONDS,
@@ -3462,14 +3463,66 @@ class PostgresStore:
         _ = limit_micro  # read for the BYOK/uncapped guard above only.
 
     def supports_key_writes(self) -> bool:
-        return False
+        return True
 
     def update_key(
         self,
         key_hash: str,
         patch: dict[str, Any],
     ) -> ApiKey | None:
-        self._not_implemented("update_key")
+        def update(conn: Any) -> ApiKey | None:
+            key = self._read_entity_tx(
+                conn,
+                "api_key",
+                key_hash,
+                ApiKey,
+                for_update=True,
+            )
+            if key is None:
+                return None
+            apply_key_patch(key, patch)
+            typed_limit_patch = bool(TYPED_LIMIT_PATCH_FIELDS & patch.keys())
+            if typed_limit_patch:
+                shard_count = int(
+                    conn.execute(
+                        "SELECT COUNT(*) FROM tr_key_limit WHERE key_hash = %s",
+                        (key.hash,),
+                        prepare=False,
+                    ).fetchone()[0]
+                )
+                if shard_count > 1:
+                    raise RuntimeError(
+                        f"cannot update caps for key_hash={key.hash}: "
+                        f"shard_count={shard_count}; distributing a cap across shards "
+                        "is not implemented on this backend"
+                    )
+            self._write_entity_tx(conn, "api_key", key.hash, key)
+            if typed_limit_patch:
+                # Postgres creates exactly one typed row, shard 0. The count
+                # above makes that assumption fail closed if multiple shards
+                # ever appear. For a legacy/orphaned entity with zero typed
+                # rows, this remains a no-op while the entity update succeeds.
+                conn.execute(
+                    "UPDATE tr_key_limit SET"
+                    " limit_micro = %s::bigint, include_byok = %s,"
+                    " day_limit_micro = %s::bigint,"
+                    " week_limit_micro = %s::bigint,"
+                    " month_limit_micro = %s::bigint,"
+                    " updated_at = CURRENT_TIMESTAMP"
+                    " WHERE key_hash = %s AND shard = 0",
+                    (
+                        _int8_param(key.limit_microdollars),
+                        key.include_byok_in_limit,
+                        _int8_param(key.limit_daily_microdollars),
+                        _int8_param(key.limit_weekly_microdollars),
+                        _int8_param(key.limit_monthly_microdollars),
+                        key.hash,
+                    ),
+                    prepare=False,
+                )
+            return key
+
+        return self._run_transaction(update)
 
     # BYOK -------------------------------------------------------------------
 

--- a/tests/conformance/test_store_semantics.py
+++ b/tests/conformance/test_store_semantics.py
@@ -1167,6 +1167,72 @@ def test_api_key_usage_projection_is_immediate_and_scoped(
     assert store.list_api_keys_with_usage(workspace_id) == []
 
 
+def test_update_key_metadata_round_trips_without_disturbing_caps(
+    store: Store, workspace_id: str, user_id: str
+) -> None:
+    _raw, key = store.create_api_key(
+        workspace_id=workspace_id,
+        name="before",
+        creator_user_id=user_id,
+        limit_microdollars=11_000,
+        limit_daily_microdollars=2_000,
+    )
+
+    updated = store.update_key(key.hash, {"name": "after", "disabled": True})
+
+    assert updated is not None
+    assert updated.name == "after"
+    assert updated.disabled is True
+    projected = store.list_api_keys_with_usage(workspace_id)
+    assert len(projected) == 1
+    assert projected[0].api_key.limit_microdollars == 11_000
+    assert projected[0].api_key.limit_daily_microdollars == 2_000
+
+
+def test_update_key_cap_changes_effective_projection(
+    store: Store, workspace_id: str, user_id: str
+) -> None:
+    _raw, key = store.create_api_key(
+        workspace_id=workspace_id,
+        name="cap",
+        creator_user_id=user_id,
+        limit_microdollars=11_000,
+    )
+
+    store.update_key(
+        key.hash,
+        {"limit_microdollars": 19_000},
+    )
+
+    projected = store.list_api_keys_with_usage(workspace_id)
+    assert len(projected) == 1
+    assert projected[0].api_key.limit_microdollars == 19_000
+    # The projection pins the entity write; enforcement pins the typed write.
+    store.reserve_key_limit(key.hash, 19_000, usage_type=UsageType.CREDITS)
+
+
+def test_update_key_cap_none_round_trips_as_uncapped(
+    store: Store, workspace_id: str, user_id: str
+) -> None:
+    _raw, key = store.create_api_key(
+        workspace_id=workspace_id,
+        name="uncap",
+        creator_user_id=user_id,
+        limit_microdollars=11_000,
+    )
+
+    store.update_key(key.hash, {"limit_microdollars": None})
+
+    projected = store.list_api_keys_with_usage(workspace_id)
+    assert len(projected) == 1
+    assert projected[0].api_key.limit_microdollars is None
+    store.reserve_key_limit(key.hash, 11_001, usage_type=UsageType.CREDITS)
+
+
+def test_update_key_unknown_hash_returns_none(store: Store, unique: str) -> None:
+    assert store.update_key(f"missing-{unique}", {"disabled": True}) is None
+
+
 def test_api_key_scopes_round_trip_across_storage(
     store: Store,
     workspace_id: str,
@@ -1553,8 +1619,8 @@ def test_key_limit_window_columns_and_index_exist(store: Store, unique: str) -> 
 # --------------------------------------------------------------------------
 # Per-key spend caps (reserve/settle/refund_key_limit)
 #
-# Seeded through direct SQL because update_key is still _not_implemented on
-# PostgresStore; these skip on backends with no SQL pool. The semantic
+# Seeded through direct SQL to exercise exact counter states independently of
+# update_key, which is now implemented. These skip on backends with no SQL pool. The semantic
 # reference is InMemoryApiKeys.reserve_limit — same rules, different engine.
 # --------------------------------------------------------------------------
 

--- a/tests/fakes/postgres.py
+++ b/tests/fakes/postgres.py
@@ -52,7 +52,10 @@ class SqlitePostgresConn:
         # WITHOUT the lock — which is the point, since row-lock behaviour is
         # what differs most between plain Postgres and Aurora DSQL.
         translated = (
-            sql.replace("%s", "?").replace("::jsonb", "").replace(" FOR UPDATE", "")
+            sql.replace("%s", "?")
+            .replace("::jsonb", "")
+            .replace("::bigint", "")
+            .replace(" FOR UPDATE", "")
             # SQLite's scalar max is multi-arg MAX(); it has no GREATEST.
             # GREATEST always takes >=2 args here, so the mapping is exact —
             # single-arg MAX (the aggregate) can never be produced by it.

--- a/tests/test_oauth_authorized_apps_increment_e.py
+++ b/tests/test_oauth_authorized_apps_increment_e.py
@@ -258,7 +258,7 @@ def test_backend_without_key_writes_reports_why_not_a_phantom_repair_failure(
     user_headers: dict[str, str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """PostgresStore.update_key is still increment-1 unimplemented.
+    """A backend without key writes reports an explicit capability gap.
 
     Without this branch the NotImplementedError falls into the repair path,
     which calls update_key again, raises again, and escalates a critical

--- a/tests/test_postgres_update_key.py
+++ b/tests/test_postgres_update_key.py
@@ -1,0 +1,155 @@
+"""Postgres API-key patch transaction regressions."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.fakes.postgres import postgres_store_on, sqlite_postgres_conn
+
+
+def _key_store():
+    conn = sqlite_postgres_conn()
+    store = postgres_store_on(conn)
+    _raw, key = store.create_api_key(
+        workspace_id="ws-update-key",
+        name="before",
+        creator_user_id=None,
+        limit_microdollars=10,
+        limit_daily_microdollars=20,
+    )
+    return store, conn, key
+
+
+def _assert_second_shard_cap_patch_is_rejected(store, conn, key) -> None:
+    conn.execute(
+        "INSERT INTO tr_key_limit"
+        " (workspace_id, key_hash, shard, limit_micro, include_byok, day_limit_micro)"
+        " VALUES (%s, %s, 1, 7, TRUE, 8)",
+        (key.workspace_id, key.hash),
+    )
+    before = conn.execute(
+        "SELECT shard, limit_micro, include_byok, day_limit_micro"
+        " FROM tr_key_limit WHERE key_hash = %s ORDER BY shard",
+        (key.hash,),
+    ).fetchall()
+
+    with pytest.raises(RuntimeError):
+        store.update_key(key.hash, {"limit_microdollars": 101})
+
+    after = conn.execute(
+        "SELECT shard, limit_micro, include_byok, day_limit_micro"
+        " FROM tr_key_limit WHERE key_hash = %s ORDER BY shard",
+        (key.hash,),
+    ).fetchall()
+    assert after == before
+
+
+def test_postgres_update_key_declares_write_capability() -> None:
+    store, _conn, _key = _key_store()
+    assert store.supports_key_writes() is True
+
+
+def test_postgres_metadata_patch_does_not_write_typed_limit() -> None:
+    store, conn, key = _key_store()
+    before = conn.execute(
+        "SELECT shard, limit_micro, day_limit_micro"
+        " FROM tr_key_limit WHERE key_hash = %s ORDER BY shard",
+        (key.hash,),
+    ).fetchall()
+    conn.fail_on = "tr_key_limit"
+
+    updated = store.update_key(key.hash, {"name": "after", "disabled": True})
+
+    assert updated is not None
+    assert updated.name == "after"
+    assert updated.disabled is True
+    conn.fail_on = None
+    after = conn.execute(
+        "SELECT shard, limit_micro, day_limit_micro"
+        " FROM tr_key_limit WHERE key_hash = %s ORDER BY shard",
+        (key.hash,),
+    ).fetchall()
+    assert after == before
+    # The metadata behavior predates the guard, so retain an in-test mutation
+    # tripwire proving this test also fails if the cap guard is removed.
+    _assert_second_shard_cap_patch_is_rejected(store, conn, key)
+
+
+def test_postgres_cap_patch_updates_single_shard_zero() -> None:
+    store, conn, key = _key_store()
+
+    updated = store.update_key(
+        key.hash,
+        {
+            "limit_microdollars": 99,
+            "limit_daily_microdollars": 30,
+            "include_byok_in_limit": False,
+        },
+    )
+
+    assert updated is not None
+    assert updated.limit_microdollars == 99
+    rows = conn.execute(
+        "SELECT shard, limit_micro, include_byok, day_limit_micro"
+        " FROM tr_key_limit WHERE key_hash = %s ORDER BY shard",
+        (key.hash,),
+    ).fetchall()
+    assert rows == [(0, 99, 0, 30)]
+    # The successful one-shard behavior predates the guard; this negative
+    # control makes the test independently sensitive to removing that guard.
+    _assert_second_shard_cap_patch_is_rejected(store, conn, key)
+
+
+def test_postgres_cap_patch_rejects_multiple_shards_without_changes() -> None:
+    store, conn, key = _key_store()
+    conn.execute(
+        "INSERT INTO tr_key_limit"
+        " (workspace_id, key_hash, shard, limit_micro, include_byok, day_limit_micro)"
+        " VALUES (%s, %s, 1, 7, TRUE, 8)",
+        (key.workspace_id, key.hash),
+    )
+    before = conn.execute(
+        "SELECT shard, limit_micro, include_byok, day_limit_micro"
+        " FROM tr_key_limit WHERE key_hash = %s ORDER BY shard",
+        (key.hash,),
+    ).fetchall()
+
+    with pytest.raises(RuntimeError) as exc_info:
+        store.update_key(
+            key.hash,
+            {
+                "name": "must-roll-back",
+                "limit_microdollars": 99,
+                "limit_daily_microdollars": 30,
+                "include_byok_in_limit": False,
+            },
+        )
+
+    message = str(exc_info.value)
+    assert f"key_hash={key.hash}" in message
+    assert "shard_count=2" in message
+    assert "distributing a cap across shards is not implemented on this backend" in message
+    after = conn.execute(
+        "SELECT shard, limit_micro, include_byok, day_limit_micro"
+        " FROM tr_key_limit WHERE key_hash = %s ORDER BY shard",
+        (key.hash,),
+    ).fetchall()
+    assert after == before
+    stored = store.get_key_by_hash(key.hash)
+    assert stored is not None
+    assert stored.name == "before"
+    assert stored.limit_microdollars == 10
+
+
+def test_postgres_cap_and_entity_writes_roll_back_together() -> None:
+    store, conn, key = _key_store()
+    conn.fail_on = "UPDATE tr_key_limit"
+
+    with pytest.raises(RuntimeError, match="connection reset"):
+        store.update_key(key.hash, {"name": "must-roll-back", "limit_microdollars": 99})
+
+    conn.fail_on = None
+    stored = store.get_key_by_hash(key.hash)
+    assert stored is not None
+    assert stored.name == "before"
+    assert stored.limit_microdollars == 10


### PR DESCRIPTION
`PostgresStore.update_key` raised `_not_implemented`, so on the AWS and Azure planes the OAuth authorized-apps surface (increment E) returned 501 for budget changes and revokes.

**Shared patch semantics.** `apply_key_patch` and `TYPED_LIMIT_PATCH_FIELDS` move out of the Spanner module into `storage_key_patch`, imported by both backends. Two backends applying a patch by two separate code paths is exactly how they drift — the field a new feature adds gets handled in one and silently ignored in the other. Spanner behaviour is unchanged. (Resolving the rebase caught this in the act: main's copy had a `scopes` branch, and I verified all eleven branches survived into the shared module before accepting the resolution.)

**One transaction.** The entity is read `FOR UPDATE`, and the entity write and the typed `tr_key_limit` write commit together, so a concurrent authorize cannot interleave and mint headroom against a stale cap. A metadata-only patch leaves the typed row untouched.

**A latent overspend bug, caught in review and confirmed against production.** Caps are *distributed* sub-budgets, not replicated: key `key_g9jW…` has `limit_microdollars = 30000000` on its entity and 16 shard rows whose `limit_micro` sum to exactly `30000000`. The first version wrote the *full* cap to every shard row — on a multi-shard key that authorizes `limit × shard_count`, i.e. $480 for a $30 key. Harmless today since Postgres only creates shard 0, so rather than invent an escrow algorithm this backend does not have, the assumption is now explicit and loud: more than one shard row raises, naming the key, **before** anything is written. Removing that guard fails the multi-shard test, which asserts neither row changed.

Full suite: **8664 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)