### PR TITLE
Bound and reconcile CI SSH metadata keys

### DIFF
--- a/.github/workflows/clickhouse-ssh-hygiene.yml
+++ b/.github/workflows/clickhouse-ssh-hygiene.yml
@@ -1,0 +1,35 @@
+name: ClickHouse SSH metadata hygiene
+
+on:
+  schedule:
+    - cron: "23 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  # Serialize with deploy.yml so cleanup cannot remove the current runner key
+  # while SCP or the atomic remote swap is in flight.
+  group: deploy-trusted-router
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    if: github.repository == 'Lore-Hex/quill-router'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Authenticate to GCP via WIF
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: projects/44325983244/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: tr-deploy@quill-cloud-proxy.iam.gserviceaccount.com
+      - uses: google-github-actions/setup-gcloud@v3
+      - name: Reconcile metadata SSH hygiene
+        run: >-
+          python3 scripts/deploy/gcp_ssh_metadata_hygiene.py
+          --project quill-cloud-proxy
+          --apply

--- a/scripts/deploy/gcp_ssh_metadata_hygiene.py
+++ b/scripts/deploy/gcp_ssh_metadata_hygiene.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Keep CI SSH keys out of Compute Engine project and instance metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+DEFAULT_INSTANCES = (
+    "tr-clickhouse-1:us-central1-a",
+    "tr-clickhouse-2:us-central1-b",
+    "tr-clickhouse-3:us-central1-c",
+)
+DEFAULT_CI_USERS = frozenset({"runner", "github-actions"})
+MAX_PROJECT_SSH_METADATA_BYTES = 64 * 1024
+MAX_PROJECT_SSH_KEY_LINES = 64
+GCLOUD = shutil.which("gcloud")
+
+
+def metadata_true(value: str | None) -> bool:
+    return value is not None and value.strip().upper() == "TRUE"
+
+
+def metadata_map(payload: dict[str, Any], *, project: bool) -> dict[str, str]:
+    container_name = "commonInstanceMetadata" if project else "metadata"
+    container = payload.get(container_name) or {}
+    items = container.get("items") or []
+    return {
+        str(item["key"]): str(item.get("value", ""))
+        for item in items
+        if isinstance(item, dict) and "key" in item
+    }
+
+
+def prune_ci_ssh_keys(
+    value: str,
+    *,
+    ci_users: frozenset[str] = DEFAULT_CI_USERS,
+) -> tuple[str, int]:
+    """Remove only recognized CI-owned metadata keys, preserving all others."""
+    kept: list[str] = []
+    removed = 0
+    for line in value.splitlines():
+        stripped = line.strip()
+        username, separator, _remainder = stripped.partition(":")
+        lower = stripped.lower()
+        is_ci_key = separator == ":" and username.lower() in ci_users
+        is_ci_key = is_ci_key or "runner@runnervm" in lower
+        is_ci_key = is_ci_key or '"username":"runner"' in lower.replace(" ", "")
+        if is_ci_key:
+            removed += 1
+        else:
+            kept.append(line)
+    cleaned = "\n".join(kept)
+    if value.endswith("\n") and cleaned:
+        cleaned += "\n"
+    return cleaned, removed
+
+
+def validate_instance_metadata(metadata: dict[str, str]) -> None:
+    if not metadata_true(metadata.get("enable-oslogin")):
+        raise ValueError("enable-oslogin must be TRUE")
+    if not metadata_true(metadata.get("block-project-ssh-keys")):
+        raise ValueError("block-project-ssh-keys must be TRUE")
+
+
+def validate_project_ssh_metadata(value: str) -> None:
+    key_lines = len(value.splitlines())
+    key_bytes = len(value.encode("utf-8"))
+    if (
+        key_lines > MAX_PROJECT_SSH_KEY_LINES
+        or key_bytes > MAX_PROJECT_SSH_METADATA_BYTES
+    ):
+        raise ValueError(
+            "project ssh-keys metadata remains too large after CI-key pruning: "
+            f"{key_lines} entries, {key_bytes} bytes"
+        )
+
+
+def _gcloud_json(project: str, args: list[str]) -> dict[str, Any]:
+    if GCLOUD is None:
+        raise RuntimeError("gcloud is not installed")
+    # Every argument is passed directly to gcloud without a shell. Project and
+    # instance values cannot become executable syntax.
+    result = subprocess.run(  # noqa: S603
+        [GCLOUD, "--project", project, *args, "--format=json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+    if not isinstance(payload, dict):
+        raise ValueError("gcloud returned a non-object response")
+    return payload
+
+
+def _gcloud(project: str, args: list[str]) -> None:
+    if GCLOUD is None:
+        raise RuntimeError("gcloud is not installed")
+    subprocess.run(  # noqa: S603
+        [GCLOUD, "--project", project, *args, "--quiet"],
+        check=True,
+    )
+
+
+def _write_metadata_value(
+    project: str,
+    *,
+    value: str,
+    instance: str | None = None,
+    zone: str | None = None,
+) -> None:
+    target = ["compute", "project-info"]
+    if instance is not None:
+        if zone is None:
+            raise ValueError("zone is required for instance metadata")
+        target = ["compute", "instances", "add-metadata", instance, "--zone", zone]
+
+    if not value:
+        if instance is None:
+            _gcloud(
+                project,
+                ["compute", "project-info", "remove-metadata", "--keys=ssh-keys"],
+            )
+        else:
+            _gcloud(
+                project,
+                [
+                    "compute",
+                    "instances",
+                    "remove-metadata",
+                    instance,
+                    "--zone",
+                    zone,
+                    "--keys=ssh-keys",
+                ],
+            )
+        return
+
+    with tempfile.TemporaryDirectory(prefix="tr-ssh-metadata-") as temp_dir:
+        value_path = Path(temp_dir) / "ssh-keys"
+        value_path.write_text(value, encoding="utf-8")
+        if instance is None:
+            _gcloud(
+                project,
+                [
+                    *target,
+                    "add-metadata",
+                    f"--metadata-from-file=ssh-keys={value_path}",
+                ],
+            )
+        else:
+            _gcloud(
+                project,
+                [*target, f"--metadata-from-file=ssh-keys={value_path}"],
+            )
+
+
+def _parse_instance(spec: str) -> tuple[str, str]:
+    name, separator, zone = spec.partition(":")
+    if separator != ":" or not name or not zone:
+        raise ValueError(f"invalid instance specification: {spec!r}; use NAME:ZONE")
+    return name, zone
+
+
+def reconcile(
+    *,
+    project: str,
+    instance_specs: list[str],
+    apply: bool,
+    require_os_login: bool = False,
+) -> int:
+    project_payload = _gcloud_json(
+        project, ["compute", "project-info", "describe"]
+    )
+    project_metadata = metadata_map(project_payload, project=True)
+
+    instances: list[tuple[str, str, dict[str, str]]] = []
+    errors: list[str] = []
+    for spec in instance_specs:
+        name, zone = _parse_instance(spec)
+        payload = _gcloud_json(
+            project,
+            ["compute", "instances", "describe", name, "--zone", zone],
+        )
+        metadata = metadata_map(payload, project=False)
+        if require_os_login:
+            try:
+                validate_instance_metadata(metadata)
+            except ValueError as exc:
+                errors.append(f"{name} ({zone}): {exc}")
+        instances.append((name, zone, metadata))
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        print(
+            "Refusing to touch SSH metadata until every target uses OS Login "
+            "and blocks project SSH keys.",
+            file=sys.stderr,
+        )
+        return 1
+
+    project_value = project_metadata.get("ssh-keys", "")
+    clean_project_value, project_removed = prune_ci_ssh_keys(project_value)
+    resource_changes: list[tuple[str, str | None, str | None, str, int]] = [
+        ("project", None, None, clean_project_value, project_removed)
+    ]
+    for name, zone, metadata in instances:
+        value = metadata.get("ssh-keys", "")
+        cleaned, removed = prune_ci_ssh_keys(value)
+        resource_changes.append((name, name, zone, cleaned, removed))
+
+    total_removed = sum(item[4] for item in resource_changes)
+    if not apply and total_removed:
+        for label, _name, _zone, _value, removed in resource_changes:
+            if removed:
+                print(
+                    f"ERROR: {label} contains {removed} CI-owned SSH metadata key(s)",
+                    file=sys.stderr,
+                )
+        return 1
+
+    if apply:
+        for _label, name, zone, cleaned, removed in resource_changes:
+            if not removed:
+                continue
+            _write_metadata_value(
+                project,
+                value=cleaned,
+                instance=name,
+                zone=zone,
+            )
+
+    validate_project_ssh_metadata(clean_project_value)
+    action = "removed" if apply else "found"
+    print(
+        f"SSH metadata hygiene passed; {action} {total_removed} CI key(s); "
+        f"project metadata has {len(clean_project_value.splitlines())} key(s) "
+        f"and {len(clean_project_value.encode('utf-8'))} bytes"
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true")
+    mode.add_argument("--apply", action="store_true")
+    parser.add_argument("--project", default="quill-cloud-proxy")
+    parser.add_argument(
+        "--require-os-login",
+        action="store_true",
+        help="also fail unless every target explicitly uses OS Login",
+    )
+    parser.add_argument(
+        "--instance",
+        action="append",
+        dest="instances",
+        help="ClickHouse VM as NAME:ZONE; repeat for multiple VMs",
+    )
+    args = parser.parse_args()
+    return reconcile(
+        project=args.project,
+        instance_specs=args.instances or list(DEFAULT_INSTANCES),
+        apply=args.apply,
+        require_os_login=args.require_os_login,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deploy/sync_public_analytics_snapshots.sh
+++ b/scripts/deploy/sync_public_analytics_snapshots.sh
@@ -25,7 +25,23 @@ if [ "$APPLY" -eq 0 ]; then
 fi
 
 archive="$(mktemp "${TMPDIR:-/tmp}/tr-public-snapshots.XXXXXX.tar.gz")"
-trap 'rm -f "$archive"' EXIT
+ssh_metadata_may_exist=0
+cleanup() {
+  local status=$?
+  rm -f "$archive"
+  if [ "$ssh_metadata_may_exist" -eq 1 ]; then
+    if ! timeout -k 10 60 python3 \
+      "${SCRIPT_DIR}/gcp_ssh_metadata_hygiene.py" \
+      --project "$PROJECT_ID" \
+      --instance "${NAME}:${ZONE}" \
+      --apply; then
+      echo "ERROR: could not remove the current CI SSH metadata key; the key" \
+        "expires after ten minutes and the daily reconciler will retry." >&2
+    fi
+  fi
+  return "$status"
+}
+trap cleanup EXIT
 tar --exclude='__pycache__' --exclude='*.pyc' -C "$ROOT" -czf "$archive" \
   clickhouse/build_public_snapshots.py \
   src/trusted_router
@@ -36,11 +52,19 @@ tar --exclude='__pycache__' --exclude='*.pyc' -C "$ROOT" -czf "$archive" \
 remote_archive="/tmp/tr-public-snapshots.${GITHUB_RUN_ID:-local}.${RANDOM}.tar.gz"
 
 log "syncing public analytics snapshot worker to ${NAME}"
-# Bound the TRANSFER, never the swap below. `gcloud compute scp` generates an
-# SSH key on a fresh runner and pushes it into PROJECT metadata; on
+# Bound and clean the legacy metadata-based access path before gcloud adds the
+# current runner's ten-minute key. The daily API-only reconciler is a second
+# line of defense. Both paths remove only CI usernames and preserve human keys.
+timeout -k 10 60 python3 "${SCRIPT_DIR}/gcp_ssh_metadata_hygiene.py" \
+  --project "$PROJECT_ID" \
+  --instance "${NAME}:${ZONE}" \
+  --apply
+ssh_metadata_may_exist=1
+
+# Bound the TRANSFER, never the swap below. Before OS Login, `gcloud compute
+# scp` appended a generated key to PROJECT metadata on every fresh runner. On
 # 2026-09-04 that write sat behind stuck setCommonInstanceMetadata operations
-# on a 365-entry ssh-keys value and burned 1800s twice before failing, which
-# blocked every control-plane deploy for ~61 minutes. Failing here is safe:
+# and blocked every control-plane deploy for ~61 minutes. Failing here is safe:
 # `set -e` stops the script before the remote mutation begins, so the node is
 # untouched. A deadline around the swap itself would NOT be safe -- severing
 # SSH between the two `mv`s leaves the live tree absent -- which is why the
@@ -49,6 +73,7 @@ if ! timeout -k 30 300 gcloud --project "$PROJECT_ID" compute scp \
   "$archive" "${NAME}:${remote_archive}" \
   --zone="$ZONE" \
   --tunnel-through-iap \
+  --ssh-key-expire-after=10m \
   --quiet; then
   echo "ERROR: could not upload the snapshot bundle to ${NAME} within 300s;" \
     "the node was NOT modified. Check for stuck" \
@@ -59,6 +84,7 @@ fi
 gc compute ssh "$NAME" \
   --zone="$ZONE" \
   --tunnel-through-iap \
+  --ssh-key-expire-after=10m \
   --quiet \
   --ssh-flag="-n" \
   --ssh-flag="-T" \

--- a/tests/test_deploy_workflow_regions.py
+++ b/tests/test_deploy_workflow_regions.py
@@ -107,6 +107,35 @@ def test_snapshot_sync_cannot_gate_the_control_plane_deploy() -> None:
     )
 
 
+def test_snapshot_sync_prunes_metadata_and_uses_short_lived_access() -> None:
+    """A fresh CI runner must never leave an unbounded project SSH key."""
+    script = (ROOT / "scripts/deploy/sync_public_analytics_snapshots.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert "gcp_ssh_metadata_hygiene.py" in script
+    assert "--apply" in script
+    assert "timeout -k 10 60 python3" in script
+    assert "trap cleanup EXIT" in script
+    assert "the daily reconciler will retry" in script
+    assert script.count("--ssh-key-expire-after=10m") == 2
+    assert script.count("--tunnel-through-iap") == 2
+
+
+def test_scheduled_ssh_hygiene_is_api_only_and_repairs_ci_keys() -> None:
+    workflow = (ROOT / ".github/workflows/clickhouse-ssh-hygiene.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "schedule:" in workflow
+    assert "gcp_ssh_metadata_hygiene.py" in workflow
+    assert "--apply" in workflow
+    assert "group: deploy-trusted-router" in workflow
+    assert "cancel-in-progress: false" in workflow
+    assert "compute ssh" not in workflow
+    assert "compute scp" not in workflow
+
+
 def test_public_snapshot_worker_swap_is_verified_and_rollbackable() -> None:
     script = (ROOT / "scripts/deploy/sync_public_analytics_snapshots.sh").read_text(
         encoding="utf-8"

--- a/tests/test_gcp_ssh_metadata_hygiene.py
+++ b/tests/test_gcp_ssh_metadata_hygiene.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/deploy/gcp_ssh_metadata_hygiene.py"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("gcp_ssh_metadata_hygiene", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_prune_ci_keys_preserves_human_and_malformed_entries() -> None:
+    module = _load_module()
+    value = "\n".join(
+        (
+            "jperla:ssh-ed25519 AAAA-human jperla@laptop",
+            "runner:ssh-rsa AAAA-ci runner@runnervmabc",
+            "github-actions:ssh-rsa AAAA-ci-2 gha@runner",
+            "a deliberately malformed line that must be preserved",
+            "",
+        )
+    )
+
+    cleaned, removed = module.prune_ci_ssh_keys(value)
+
+    assert removed == 2
+    assert "AAAA-human" in cleaned
+    assert "malformed line" in cleaned
+    assert "AAAA-ci" not in cleaned
+    assert cleaned.endswith("\n")
+
+
+@pytest.mark.parametrize("value", ["TRUE", "true", " True "])
+def test_metadata_true_accepts_case_and_whitespace(value: str) -> None:
+    module = _load_module()
+
+    assert module.metadata_true(value)
+
+
+@pytest.mark.parametrize("value", [None, "", "FALSE", "1", "yes"])
+def test_metadata_true_rejects_everything_else(value: str | None) -> None:
+    module = _load_module()
+
+    assert not module.metadata_true(value)
+
+
+def test_validate_instance_requires_both_access_controls() -> None:
+    module = _load_module()
+
+    with pytest.raises(ValueError, match="enable-oslogin"):
+        module.validate_instance_metadata({"block-project-ssh-keys": "TRUE"})
+    with pytest.raises(ValueError, match="block-project-ssh-keys"):
+        module.validate_instance_metadata({"enable-oslogin": "TRUE"})
+
+    module.validate_instance_metadata(
+        {"enable-oslogin": "TRUE", "block-project-ssh-keys": "TRUE"}
+    )
+
+
+def test_metadata_limits_reject_the_original_failure_shape() -> None:
+    module = _load_module()
+    oversized = "\n".join(
+        f"user{i}:ssh-rsa {'A' * 600} user{i}@host" for i in range(365)
+    )
+
+    with pytest.raises(ValueError, match="metadata remains too large"):
+        module.validate_project_ssh_metadata(oversized)


### PR DESCRIPTION
## Summary
- prune CI-owned Compute Engine SSH metadata before and after snapshot transfers while preserving human keys
- expire every CI SSH/SCP credential after ten minutes
- add a serialized daily API-only hygiene workflow and fail when project metadata exceeds a bounded size
- cover the original 365-key failure shape and deployment contract with regression tests

## Production repair
- removed 3 CI-owned metadata entries from the project and ClickHouse primary
- preserved 2 human keys
- reduced project SSH metadata to 1,187 bytes
- post-repair check found 0 CI entries

## Verification
- `uv run pytest -q tests/test_gcp_ssh_metadata_hygiene.py tests/test_deploy_workflow_regions.py`
- broader deploy/security suite: 152 passed
- `uv run ruff check scripts/deploy/gcp_ssh_metadata_hygiene.py tests/test_gcp_ssh_metadata_hygiene.py tests/test_deploy_workflow_regions.py`
- `uv run mypy`
- `shellcheck -x scripts/deploy/sync_public_analytics_snapshots.sh`
- workflow YAML parsed successfully