### PR TITLE
Fix creative attribution redaction and truncated funnel reports

### DIFF
--- a/docs/marketing/first-party-attribution.md
+++ b/docs/marketing/first-party-attribution.md
@@ -105,6 +105,30 @@ Google and X click identifiers can be appended by their respective auto-tagging
 features. Creative-specific `utm_content` values are required so Axiom can
 compare privacy, migration, and reliability messages within one campaign.
 
+### Creative IDs in telemetry
+
+Keep `utm_content` in tracking URLs and encrypted attribution records. Each
+funnel event also emits that identifier as `creative_id`; conversions include
+`first_creative_id` for the original touch. Axiom's content-field privacy
+scrubber intentionally removes `utm_content`, so reporting normalizes
+`creative_id` before aggregating. Prompt, output, and secret scrubbing remains
+enabled, including secret values accidentally supplied as creative IDs.
+
+The funnel report can recover historical redacted IDs from structured
+first-party Cloud Logging. Recovery requires a unique match on the anonymous
+fingerprint, event, source, medium, campaign, landing path, and experiment
+identifiers. It enriches existing Axiom rows without adding events or payment
+amounts. The evidence must cover the grouped event count and match its first
+timestamp within five seconds. It never guesses from a campaign name or another visitor. Remaining
+redacted records are shown as `(unattributed)` and cannot qualify as an
+experiment winner. JSON reports include recovered/unresolved record counts
+under `creative_attribution`. This recovery is read-only and sends no data to
+advertising platforms.
+
+The CLI splits Axiom's 1,000-row results into non-overlapping time windows.
+If a window cannot be read completely within the query/row limits, the report
+fails instead of publishing a truncated funnel.
+
 ## First-Party Funnel Report
 
 TrustedRouter records its metadata-only funnel internally and can compare

--- a/scripts/marketing_funnel_report.py
+++ b/scripts/marketing_funnel_report.py
@@ -26,10 +26,12 @@ from trusted_router.google_ads_reporting import (  # noqa: E402
     google_ads_reporting_window,
 )
 from trusted_router.marketing_funnel import (  # noqa: E402
+    FUNNEL_EVENTS,
     aggregate_cohort_funnel_rows,
     build_axiom_cohort_query,
     parse_axiom_json_lines,
-    parse_cloud_logging_engagements,
+    parse_cloud_logging_acquisition_events,
+    recover_creative_attribution,
     render_markdown,
     render_measurement_markdown,
     summarize_measurement,
@@ -79,7 +81,7 @@ def parse_args() -> argparse.Namespace:
         choices=("auto", "required", "off"),
         default="auto",
         help=(
-            "Merge metadata-only landing engagements from structured Cloud Logging. "
+            "Merge landing engagements and recover creative IDs from metadata-only Cloud Logging. "
             "'required' fails if they cannot be read."
         ),
     )
@@ -96,33 +98,20 @@ def main() -> int:
     if axiom is None:
         raise SystemExit("Axiom CLI is required. Install it and run `axiom auth login`.")
     spend, spend_error, cohort_start, cohort_end = _google_ads_spend(args)
-    query = build_axiom_cohort_query(args.dataset)
-    completed = subprocess.run(  # noqa: S603 - executable is resolved by shutil.which.
-        [
-            axiom,
-            "query",
-            query,
-            "--start-time",
-            cohort_start.isoformat().replace("+00:00", "Z"),
-            "--format",
-            "json",
-            "--no-spinner",
-        ],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    if completed.returncode != 0:
-        detail = completed.stderr.strip() or "Axiom query failed"
-        raise SystemExit(detail)
     observed_through = dt.datetime.now(dt.UTC)
-    cohort_records = parse_axiom_json_lines(completed.stdout)
-    cloud_engagements, engagement_error = _public_engagements(
+    cohort_records = fetch_axiom_cohort_records(
+        axiom, args.dataset, start_at=cohort_start, end_at=observed_through,
+    )
+    cloud_records, engagement_error = _cloud_acquisition_events(
         args,
         start_at=cohort_start,
         end_at=observed_through,
     )
+    cloud_engagements = [
+        row for row in cloud_records if row["event"] == "acquisition.landing_engaged"
+    ]
     cohort_records.extend(cloud_engagements)
+    cohort_records, recovery = recover_creative_attribution(cohort_records, cloud_records)
     rows = aggregate_cohort_funnel_rows(
         cohort_records,
         cohort_start=cohort_start,
@@ -162,6 +151,7 @@ def main() -> int:
                         "events": len(cloud_engagements),
                         "reason": engagement_error,
                     },
+                    "creative_attribution": {**recovery, "evidence_error": engagement_error},
                     "funnel": [row.as_dict() for row in rows],
                 },
                 indent=2,
@@ -169,9 +159,46 @@ def main() -> int:
             )
         )
     else:
+        print(
+            f"Creative attribution: recovered {recovery['recovered_records']} records; "
+            f"{recovery['unresolved_records']} remain unattributed."
+        )
         print(render_measurement_markdown(summary), end="")
         print(render_markdown(rows), end="")
     return 0
+
+
+def fetch_axiom_cohort_records(
+    axiom: str, dataset: str, *, start_at: dt.datetime, end_at: dt.datetime,
+) -> list[dict[str, object]]:
+    """Split capped CLI results into disjoint windows; never return partial data."""
+    pending = [(start_at, end_at)]
+    records: list[dict[str, object]] = []
+    queries = 0
+    while pending:
+        start, end = pending.pop()
+        queries += 1
+        if queries > 511:
+            raise SystemExit("Axiom report exceeds query budget; shorten the window")
+        query = build_axiom_cohort_query(dataset, start_at=start, end_at=end) + " | limit 1000"
+        completed = subprocess.run(  # noqa: S603 - caller resolves the CLI executable.
+            [axiom, "query", query, "--start-time", start.isoformat(), "--end-time",
+             end.isoformat(), "--format", "json", "--no-spinner"],
+            check=False, capture_output=True, text=True, timeout=120,
+        )
+        if completed.returncode != 0:
+            raise SystemExit(completed.stderr.strip() or "Axiom query failed")
+        batch = parse_axiom_json_lines(completed.stdout)
+        if len(batch) >= 1000:
+            if end - start <= dt.timedelta(seconds=1):
+                raise SystemExit("Axiom query remains truncated at a one-second window")
+            midpoint = start + (end - start) / 2
+            pending.extend([(midpoint, end), (start, midpoint)])
+            continue
+        records.extend(batch)
+        if len(records) > 100_000:
+            raise SystemExit("Axiom report exceeds row budget; shorten the window")
+    return records
 
 
 def _google_ads_spend(
@@ -228,7 +255,7 @@ def _google_ads_spend(
     return spend, None, start_at, end_at
 
 
-def _public_engagements(
+def _cloud_acquisition_events(
     args: argparse.Namespace,
     *,
     start_at: dt.datetime,
@@ -239,16 +266,23 @@ def _public_engagements(
     gcloud = shutil.which("gcloud")
     if gcloud is None:
         if args.public_engagements == "required":
-            raise SystemExit("gcloud CLI is required for public engagement telemetry")
+            raise SystemExit("gcloud CLI is required for acquisition telemetry")
         return [], "gcloud_not_available"
     start = start_at.astimezone(dt.UTC).isoformat().replace("+00:00", "Z")
     end = end_at.astimezone(dt.UTC).isoformat().replace("+00:00", "Z")
+    event_filter = " OR ".join(f'"{event}"' for event in FUNNEL_EVENTS)
     log_filter = (
         'resource.type="cloud_run_revision" '
-        'AND resource.labels.service_name="trusted-router-public" '
-        'AND jsonPayload.event="acquisition.landing_engaged" '
+        'AND resource.labels.service_name=("trusted-router-public" OR "trusted-router") '
+        f'AND jsonPayload.event=({event_filter}) '
         f'AND timestamp>="{start}" AND timestamp<="{end}"'
     )
+    fields = (
+        "event", "anonymous_fingerprint", "utm_source", "utm_medium", "utm_campaign",
+        "utm_content", "creative_id", "landing_path", "experiment_id", "experiment_cell_id",
+        "has_gclid", "has_gbraid", "has_wbraid", "google_ads_click_persisted",
+    )
+    projection = "json(timestamp," + ",".join(f"jsonPayload.{name}" for name in fields) + ")"
     completed = subprocess.run(  # noqa: S603 - executable is resolved by shutil.which.
         [
             gcloud,
@@ -257,7 +291,7 @@ def _public_engagements(
             log_filter,
             "--project",
             "quill-cloud-proxy",
-            "--format=json",
+            f"--format={projection}",
             "--limit=100000",
         ],
         check=False,
@@ -270,7 +304,10 @@ def _public_engagements(
             raise SystemExit(detail)
         return [], "cloud_logging_fetch_failed"
     try:
-        return parse_cloud_logging_engagements(completed.stdout), None
+        rows = parse_cloud_logging_acquisition_events(completed.stdout)
+        if len(rows) >= 100000:
+            raise ValueError("Cloud Logging acquisition query reached its row limit; shorten the window")
+        return rows, None
     except ValueError as exc:
         if args.public_engagements == "required":
             raise SystemExit(str(exc)) from exc

--- a/src/trusted_router/acquisition.py
+++ b/src/trusted_router/acquisition.py
@@ -565,6 +565,7 @@ def _log_conversion(
         "first_utm_source": record.first_touch.get("utm_source"),
         "first_utm_medium": record.first_touch.get("utm_medium"),
         "first_utm_campaign": record.first_touch.get("utm_campaign"),
+        "first_creative_id": _safe_text(record.first_touch.get("utm_content"), 128) or None,
         "first_experiment_id": record.first_touch.get("experiment_id"),
         "first_experiment_cell_id": record.first_touch.get("experiment_cell_id"),
         "first_landing_path": record.first_touch.get("landing_path"),
@@ -584,6 +585,9 @@ def _safe_touch_log_fields(touch: dict[str, str]) -> dict[str, object]:
         "utm_campaign": touch.get("utm_campaign"),
         "utm_term": touch.get("utm_term"),
         "utm_content": touch.get("utm_content"),
+        # The content-key privacy scrubber deliberately removes utm_content.
+        # Keep the campaign identifier under a metadata name at every funnel stage.
+        "creative_id": _safe_text(touch.get("utm_content"), 128) or None,
         "experiment_id": touch.get("experiment_id"),
         "experiment_cell_id": touch.get("experiment_cell_id"),
         "landing_path": touch.get("landing_path"),

--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -113,6 +113,8 @@ _ACQUISITION_CLOUD_FIELDS = (
     "utm_medium",
     "utm_campaign",
     "utm_content",
+    "creative_id",
+    "first_creative_id",
     "landing_path",
     "experiment_id",
     "experiment_cell_id",

--- a/src/trusted_router/marketing_funnel.py
+++ b/src/trusted_router/marketing_funnel.py
@@ -236,6 +236,8 @@ def build_axiom_funnel_query(dataset: str) -> str:
     return (
         f"['{dataset}'] "
         f"| where event in ({event_values}) "
+        "| extend utm_content=iff(isnotempty(column_ifexists('creative_id', '')), "
+        "column_ifexists('creative_id', ''), utm_content) "
         "| summarize people=dcount(anonymous_fingerprint), "
         "google_ads_click_people=dcountif(anonymous_fingerprint, "
         "has_gclid == true or has_gbraid == true or has_wbraid == true), "
@@ -248,7 +250,9 @@ def build_axiom_funnel_query(dataset: str) -> str:
     )
 
 
-def build_axiom_cohort_query(dataset: str) -> str:
+def build_axiom_cohort_query(
+    dataset: str, *, start_at: dt.datetime | None = None, end_at: dt.datetime | None = None,
+) -> str:
     """Return person-level event rows for local acquisition-cohort assignment.
 
     A conversion is intentionally not grouped by its event timestamp or latest
@@ -258,10 +262,21 @@ def build_axiom_cohort_query(dataset: str) -> str:
     """
     if not _DATASET_RE.fullmatch(dataset):
         raise ValueError("Axiom dataset contains unsupported characters")
+    time_filter = ""
+    if start_at is not None or end_at is not None:
+        if (start_at is None or end_at is None or start_at.tzinfo is None
+                or end_at.tzinfo is None or start_at >= end_at):
+            raise ValueError("Axiom query requires ordered, timezone-aware boundaries")
+        start = start_at.astimezone(dt.UTC).isoformat()
+        end = end_at.astimezone(dt.UTC).isoformat()
+        time_filter = f"| where _time >= datetime({start}) and _time < datetime({end}) "
     event_values = ", ".join(f"'{event}'" for event in FUNNEL_EVENTS)
     return (
         f"['{dataset}'] "
+        f"{time_filter}"
         f"| where event in ({event_values}) "
+        "| extend utm_content=iff(isnotempty(column_ifexists('creative_id', '')), "
+        "column_ifexists('creative_id', ''), utm_content) "
         "| extend experiment_id=column_ifexists('experiment_id', ''), "
         "experiment_cell_id=column_ifexists('experiment_cell_id', '') "
         "| summarize first_at=min(_time), events=count(), "
@@ -293,6 +308,14 @@ def parse_axiom_json_lines(payload: str) -> list[dict[str, object]]:
 
 def parse_cloud_logging_engagements(payload: str) -> list[dict[str, object]]:
     """Convert structured public-service log entries into cohort event rows."""
+    return [
+        row for row in parse_cloud_logging_acquisition_events(payload)
+        if row["event"] == "acquisition.landing_engaged"
+    ]
+
+
+def parse_cloud_logging_acquisition_events(payload: str) -> list[dict[str, object]]:
+    """Read only acquisition metadata for engagement and creative recovery."""
     try:
         entries = json.loads(payload)
     except json.JSONDecodeError as exc:
@@ -307,7 +330,7 @@ def parse_cloud_logging_engagements(payload: str) -> list[dict[str, object]]:
         body = entry.get("jsonPayload")
         if not isinstance(body, dict):
             continue
-        if body.get("event") != "acquisition.landing_engaged":
+        if body.get("event") not in FUNNEL_EVENTS:
             continue
         timestamp = entry.get("timestamp")
         if not isinstance(timestamp, str) or not timestamp:
@@ -326,22 +349,72 @@ def parse_cloud_logging_engagements(payload: str) -> list[dict[str, object]]:
                 "experiment_cell_id",
             )
         }
+        if "creative_id" in body:
+            row["creative_id"] = body["creative_id"]
         row.update(
             {
                 "first_at": timestamp,
                 "events": 1,
-                "revenue_microdollars": 0,
+                "revenue_microdollars": _nonnegative_int(body.get("amount_microdollars")),
                 "google_ads_click_events": int(
                     any(
                         body.get(field) is True
                         for field in ("has_gclid", "has_gbraid", "has_wbraid")
                     )
                 ),
-                "google_ads_persisted_events": 0,
+                "google_ads_persisted_events": int(body.get("google_ads_click_persisted") is True),
             }
         )
         rows.append(row)
     return rows
+
+
+def recover_creative_attribution(
+    records: Iterable[dict[str, object]],
+    evidence: Iterable[dict[str, object]],
+) -> tuple[list[dict[str, object]], dict[str, int]]:
+    """Recover only unambiguous same-person, same-event, same-touch IDs.
+
+    Cloud Logging kept the original UTM metadata when Axiom scrubbed its
+    content-named field. Evidence only enriches existing rows; replaying it
+    must never create conversions or add payment amounts.
+    """
+    identity_fields = (
+        "anonymous_fingerprint", "event", "utm_source", "utm_medium",
+        "utm_campaign", "landing_path", "experiment_id", "experiment_cell_id",
+    )
+    candidates: dict[tuple[str, ...], set[str]] = {}
+    evidence_times: dict[tuple[str, ...], set[dt.datetime]] = {}
+    for item in evidence:
+        if not _ANONYMOUS_FINGERPRINT_RE.fullmatch(_text(item.get("anonymous_fingerprint"))):
+            continue
+        if item.get("event") not in FUNNEL_EVENTS:
+            continue
+        creative = _creative_dimension(item)
+        key = tuple(_text(item.get(field)) for field in identity_fields)
+        candidates.setdefault(key, set()).add(creative)
+        evidence_times.setdefault(key, set()).add(_timestamp(item.get("first_at")))
+    fixed: list[dict[str, object]] = []
+    recovered = unresolved = 0
+    for record in records:
+        item = dict(record)
+        if _creative_dimension(item) == "(unattributed)":
+            key = tuple(_text(item.get(field)) for field in identity_fields)
+            matches = candidates.get(key, set())
+            times = evidence_times.get(key, set())
+            # A summarized row may contain multiple visits. Incomplete evidence
+            # must not assign one surviving creative to the entire group.
+            complete = len(times) >= max(1, _nonnegative_int(item.get("events")))
+            nearby = any(abs((time - _timestamp(item.get("first_at"))).total_seconds()) <= 5
+                         for time in times)
+            if (complete and nearby and len(matches) == 1
+                    and not matches.intersection({"(none)", "(unattributed)"})):
+                item["creative_id"] = next(iter(matches))
+                recovered += 1
+            else:
+                unresolved += 1
+        fixed.append(item)
+    return fixed, {"recovered_records": recovered, "unresolved_records": unresolved}
 
 
 def aggregate_funnel_rows(
@@ -363,7 +436,7 @@ def aggregate_funnel_rows(
             source=_dimension(record.get("utm_source"), "(direct)"),
             medium=_dimension(record.get("utm_medium"), "(none)"),
             campaign=_dimension(record.get("utm_campaign"), "(none)"),
-            creative=_dimension(record.get("utm_content"), "(none)"),
+            creative=_creative_dimension(record),
             landing_path=_dimension(record.get("landing_path"), "(unknown)"),
             experiment_id=_dimension(record.get("experiment_id"), "(none)"),
             experiment_cell_id=_dimension(record.get("experiment_cell_id"), "(none)"),
@@ -479,7 +552,7 @@ def aggregate_cohort_funnel_rows(
             source=_dimension(acquisition_record.get("utm_source"), "(direct)"),
             medium=_dimension(acquisition_record.get("utm_medium"), "(none)"),
             campaign=_dimension(acquisition_record.get("utm_campaign"), "(none)"),
-            creative=_dimension(acquisition_record.get("utm_content"), "(none)"),
+            creative=_creative_dimension(acquisition_record),
             landing_path=_dimension(acquisition_record.get("landing_path"), "(unknown)"),
             experiment_id=_dimension(acquisition_record.get("experiment_id"), "(none)"),
             experiment_cell_id=_dimension(
@@ -704,6 +777,8 @@ def wilson_percentage_interval(
 
 def experiment_state(row: FunnelRow) -> str:
     """Classify evidence without declaring a winner from an immature cell."""
+    if row.creative == "(unattributed)":
+        return "attribution_incomplete"
     if row.engaged_visitors < 100:
         return "collecting"
     if row.activated_users == 0:
@@ -733,6 +808,17 @@ def _ratio(numerator: int, denominator: int | None) -> str | None:
 def _dimension(value: object, fallback: str) -> str:
     text = _text(value)
     return text if text else fallback
+
+
+def _creative_dimension(record: dict[str, object]) -> str:
+    redacted = False
+    for field in ("creative_id", "utm_content"):
+        value = _text(record.get(field))
+        if value.startswith("[Filtered"):
+            redacted = True
+        elif value:
+            return value
+    return "(unattributed)" if redacted else "(none)"
 
 
 def _text(value: object) -> str:

--- a/tests/test_creative_attribution.py
+++ b/tests/test_creative_attribution.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+import queue
+import runpy
+import subprocess
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+import trusted_router.marketing_funnel as funnel
+from trusted_router.acquisition import record_successful_api_call
+from trusted_router.axiom_config import _DroppingQueueHandler
+from trusted_router.main import _ApplicationConsoleFormatter
+
+
+def test_creative_survives_real_signup_activation_payment_and_axiom_queue(
+    client: TestClient, caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.INFO, logger="trusted_router.acquisition")
+    assert client.get(
+        "/openrouter-alternative?utm_source=google&utm_medium=cpc"
+        "&utm_campaign=creative_regression&utm_content=privacy_a&gclid=test-click"
+    ).status_code == 200
+    assert client.post("/analytics/events", json={"event": "landing_engaged"}).status_code == 204
+    signup = client.post("/v1/signup", json={"email": "creative@example.com"})
+    assert signup.status_code == 201
+    workspace_id = signup.json()["data"]["workspace_id"]
+    assert client.get("/?utm_source=other&utm_content=later_visit").status_code == 200
+    record_successful_api_call(workspace_id, model="test/model", provider="test")
+    response = client.post("/v1/internal/stripe/webhook", json={
+        "id": "evt_creative_regression",
+        "type": "checkout.session.completed",
+        "data": {"object": {
+            "amount_total": 500, "payment_intent": "pi_creative_regression",
+            "payment_status": "paid", "metadata": {"workspace_id": workspace_id},
+        }},
+    })
+    assert response.status_code == 200
+    stages = {
+        "acquisition.landing_engaged", "acquisition.signup_completed",
+        "acquisition.first_successful_api_call", "acquisition.credit_purchase_completed",
+    }
+    handler = _DroppingQueueHandler(queue.Queue())
+    seen = set()
+    for record in caplog.records:
+        if record.getMessage() not in stages:
+            continue
+        record.prompt = "private-prompt-canary"
+        record.output = "private-output-canary"
+        prepared = handler.prepare(record)
+        assert getattr(prepared, "creative_id", None) == "privacy_a"
+        assert prepared.utm_content == "[Filtered]"
+        assert prepared.prompt == prepared.output == "[Filtered]"
+        cloud_record = json.loads(_ApplicationConsoleFormatter().format(record))
+        assert cloud_record["creative_id"] == "privacy_a"
+        assert "prompt" not in cloud_record and "output" not in cloud_record
+        assert "private-prompt-canary" not in json.dumps(prepared.__dict__)
+        assert "private-output-canary" not in json.dumps(prepared.__dict__)
+        seen.add(record.getMessage())
+    assert seen == stages
+
+
+def test_creative_alias_still_scrubs_secret_values() -> None:
+    handler = _DroppingQueueHandler(queue.Queue())
+    record = logging.makeLogRecord({
+        "msg": "acquisition.signup_completed", "levelno": logging.INFO,
+        "creative_id": "sk-tr-v1-private-secret-canary",
+        "first_creative_id": "ghp_private-secret-canary",
+    })
+    prepared = handler.prepare(record)
+    assert prepared.creative_id == "[Filtered]"
+    assert prepared.first_creative_id == "[Filtered]"
+
+
+def _event(event: str, creative: str = "[Filtered]") -> dict[str, object]:
+    return {
+        "event": event, "anonymous_fingerprint": "a" * 64,
+        "first_at": "2026-09-01T12:00:00Z", "events": 1,
+        "utm_source": "creator", "utm_medium": "sponsorship",
+        "utm_campaign": "creator_pilot", "utm_content": creative,
+        "landing_path": "/for-developers", "revenue_microdollars": 5_000_000,
+    }
+
+
+@pytest.mark.parametrize("query", [funnel.build_axiom_funnel_query, funnel.build_axiom_cohort_query])
+def test_query_normalizes_creative_before_aggregation(query) -> None:
+    apl = query("test-logs")
+    assert "column_ifexists('creative_id', '')" in apl
+    assert apl.index("creative_id") < apl.index("summarize")
+
+
+@pytest.mark.parametrize("old", [None, "", "[Filtered]", "legacy"])
+def test_summary_prefers_new_creative_identifier(old: str | None) -> None:
+    record = _event("acquisition.signup_completed")
+    record.update(utm_content=old, creative_id="new_creative", people=2)
+    rows = funnel.aggregate_funnel_rows([record], creative="new_creative")
+    assert len(rows) == 1
+    assert rows[0].signups == 2
+
+
+def test_recovery_uses_matching_evidence_without_duplicating_payments() -> None:
+    record = _event("acquisition.credit_purchase_completed")
+    evidence = _event("acquisition.credit_purchase_completed", "mehul_demo")
+    fixed, counts = funnel.recover_creative_attribution([record], [evidence, evidence])
+    assert len(fixed) == 1
+    assert fixed[0]["creative_id"] == "mehul_demo"
+    assert fixed[0]["events"] == 1
+    assert fixed[0]["revenue_microdollars"] == 5_000_000
+    assert "creative_id" not in record
+    assert counts["recovered_records"] == 1
+    assert counts["unresolved_records"] == 0
+
+
+@pytest.mark.parametrize("change", [
+    {"anonymous_fingerprint": "b" * 64}, {"utm_campaign": "another_campaign"},
+    {"event": "acquisition.signup_completed"}, {"landing_path": "/other"},
+    {"experiment_cell_id": "another_cell"},
+])
+def test_recovery_never_guesses_across_visitors_or_touches(change) -> None:
+    record = _event("acquisition.credit_purchase_completed")
+    evidence = _event("acquisition.credit_purchase_completed", "mehul_demo")
+    evidence.update(change)
+    fixed, counts = funnel.recover_creative_attribution([record], [evidence])
+    assert "creative_id" not in fixed[0]
+    assert counts["unresolved_records"] == 1
+
+
+def test_recovery_requires_unambiguous_evidence_and_keeps_existing_id() -> None:
+    record = _event("acquisition.signup_completed")
+    evidence = [_event("acquisition.signup_completed", name) for name in ("a", "b")]
+    fixed, counts = funnel.recover_creative_attribution([record], evidence)
+    assert "creative_id" not in fixed[0]
+    assert counts["unresolved_records"] == 1
+    record["creative_id"] = "original"
+    fixed, counts = funnel.recover_creative_attribution([record], evidence)
+    assert fixed[0]["creative_id"] == "original"
+    assert counts["recovered_records"] == 0
+
+
+@pytest.mark.parametrize("change", [
+    {"events": 2}, {"first_at": "2026-09-02T12:00:00Z"},
+])
+def test_recovery_rejects_incomplete_or_different_time_evidence(change) -> None:
+    record = _event("acquisition.credit_purchase_completed")
+    record.update(change)
+    evidence = _event("acquisition.credit_purchase_completed", "mehul_demo")
+    fixed, counts = funnel.recover_creative_attribution([record], [evidence])
+    assert "creative_id" not in fixed[0]
+    assert counts["unresolved_records"] == 1
+
+
+def test_capped_axiom_results_are_split_without_counting_partial_parent(monkeypatch) -> None:
+    report = runpy.run_path(str(Path(__file__).resolve().parents[1] / "scripts/marketing_funnel_report.py"))
+    start = dt.datetime(2026, 9, 1, tzinfo=dt.UTC)
+    midpoint = start + dt.timedelta(hours=12)
+    end = start + dt.timedelta(days=1)
+    calls = []
+
+    def run(command, **kwargs):
+        left = command[command.index("--start-time") + 1]
+        right = command[command.index("--end-time") + 1]
+        calls.append((left, right))
+        assert f"_time >= datetime({left}) and _time < datetime({right})" in command[2]
+        assert kwargs["timeout"] == 120
+        if (left, right) == (start.isoformat(), end.isoformat()):
+            rows = [{"partial": True}] * 1000
+        else:
+            rows = [_event("acquisition.credit_purchase_completed", "creative_a")]
+        return subprocess.CompletedProcess(command, 0, "\n".join(json.dumps(row) for row in rows), "")
+
+    monkeypatch.setattr(subprocess, "run", run)
+    records = report["fetch_axiom_cohort_records"]("axiom", "test", start_at=start, end_at=end)
+    assert calls == [(start.isoformat(), end.isoformat()),
+                     (start.isoformat(), midpoint.isoformat()),
+                     (midpoint.isoformat(), end.isoformat())]
+    assert len(records) == 2
+    assert sum(row["revenue_microdollars"] for row in records) == 10_000_000
+    assert all("partial" not in row for row in records)
+
+
+@pytest.mark.parametrize("exit_code", [0, 1])
+def test_axiom_report_fails_closed_on_unreadable_or_irreducible_window(monkeypatch, exit_code) -> None:
+    report = runpy.run_path(str(Path(__file__).resolve().parents[1] / "scripts/marketing_funnel_report.py"))
+    monkeypatch.setattr(subprocess, "run", lambda command, **kwargs:
+                        subprocess.CompletedProcess(command, exit_code, '{}\n' * 1000, 'failed'))
+    start = dt.datetime(2026, 9, 1, tzinfo=dt.UTC)
+    with pytest.raises(SystemExit):
+        report["fetch_axiom_cohort_records"](
+            "axiom", "test", start_at=start, end_at=start + dt.timedelta(seconds=1),
+        )
+
+
+def test_cloud_evidence_retains_only_safe_metadata_and_cohort_uses_new_id() -> None:
+    record = _event("acquisition.landing_engaged")
+    record.update(creative_id="mehul_demo", prompt="private", email="person@example.com")
+    cloud = funnel.parse_cloud_logging_acquisition_events(json.dumps([
+        {"timestamp": "2026-09-01T12:00:00Z", "jsonPayload": record},
+    ]))
+    assert "prompt" not in cloud[0] and "email" not in cloud[0]
+    assert cloud[0]["creative_id"] == "mehul_demo"
+    rows = funnel.aggregate_cohort_funnel_rows(
+        cloud, cohort_start=dt.datetime(2026, 9, 1, tzinfo=dt.UTC),
+        cohort_end=dt.datetime(2026, 9, 2, tzinfo=dt.UTC),
+        observed_through=dt.datetime(2026, 9, 3, tzinfo=dt.UTC),
+    )
+    assert rows[0].creative == "mehul_demo"
+
+
+def test_unrecoverable_creative_is_explicit_and_cannot_win_experiment() -> None:
+    record = _event("acquisition.signup_completed")
+    record["people"] = 3
+    row = funnel.aggregate_funnel_rows([record])[0]
+    assert row.creative == "(unattributed)"
+    row.engaged_visitors = 200
+    row.activated_users = 20
+    assert funnel.experiment_state(row) == "attribution_incomplete"


### PR DESCRIPTION
## Summary
- Preserve creative IDs across landing, signup, activation, and payment as `creative_id` and `first_creative_id`. Keep UTM URLs unchanged and keep the generic prompt/output/secret scrubber enabled.
- Normalize the alias before report aggregation; display irrecoverable creative IDs as unattributed and exclude them from experiment winners.
- Recover historical IDs read-only from matching metadata-only Cloud Logging evidence. Require matching anonymous identity/event/touch, complete grouped event coverage, and nearby timestamp. Never replay conversions or payment amounts.
- Fix the separate silent Axiom 1,000-row report cap with bounded, disjoint time-window reads that fail closed on incomplete results.

## Validation
- The production queue regression failed on the previous implementation (creative ID missing) before the fix.
- Full final local suite: 8,737 passed, 367 skipped, 10 expected failures; 83.92% coverage.
- Final targeted attribution, funnel, and Axiom suites: 131 passed.
- Ruff and mypy pass.
- Live read-only 30-day report confirms APL compatibility and seven evidence-backed recoveries. Most older redacted rows do not have recoverable evidence and remain unattributed.
- Regression tests cover actual landing/signup/API-success/payment hooks, privacy canaries, ambiguous/missing recovery, and capped query splitting without duplicated revenue.

No user attribution is sent to Google or other advertising platforms. No billing storage migration or inference-path changes.
