### PR TITLE
monitors: derive enclave gateway probes from a three-region inventory (São Paulo enclave retired; control plane unchanged)

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,9 +409,16 @@ gateway replicas before public traffic is allowed to ramp.
 Multi-region is feasible while preserving the trust boundary, but it has to be
 done carefully:
 
+São Paulo (`southamerica-east1`) remains a live Cloud Run control plane:
+`trusted-router` continues deploying and serving through the global load balancer.
+Only its enclave gateway MIG was retired (quill-cloud-proxy #309); its stale
+regional gateway DNS record has been deleted. Control-plane deployment regions
+remain `us-central1`, `us-east4`, `europe-west4`, and `southamerica-east1`.
+
 - Run independent warm attested gateway pools in `us-central1`, `us-east4`,
-  `europe-west4`, and `southamerica-east1`, then add Asia after the four-region
-  fleet is operationally boring.
+  and `europe-west4`. The enclave inventory is
+  `src/trusted_router/enclave_regions.py`, shared by synthetic probes, provider
+  smoke checks, the watchdog defaults, and `TR_REGIONS` deploy defaults.
 - Keep TLS private keys inside each regional Confidential Space workload.
 - Keep certificate issuance inside the attested workload. Certificates are
   shared between replicas through the encrypted cache. A first regional
@@ -419,8 +426,8 @@ done carefully:
   attestation and a settled PONG; it is expanded only after the regional
   certificate and the same gates pass on every node.
 - Keep regional hostnames such as `api-us-central1.quillrouter.com`,
-  `api-us-east4.quillrouter.com`, `api-europe-west4.quillrouter.com`, and
-  `api-southamerica-east1.quillrouter.com` for deterministic attestation,
+  `api-us-east4.quillrouter.com`, and `api-europe-west4.quillrouter.com`
+  for deterministic attestation,
   smoke tests, and SDK failover.
 - Put `api.trustedrouter.com` behind latency/geo DNS or TCP passthrough that does
   not terminate TLS. Cloudflare orange-cloud proxying remains incompatible

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1389,13 +1389,13 @@ for prov, n in sorted(c.items(), key=lambda kv: -kv[1]):
 "
 ```
 
-Per-region MIG status (GCP enclave):
+Per-region MIG status (GCP enclave). São Paulo’s enclave MIG is retired; its
+`southamerica-east1` Cloud Run control plane remains live and deployed:
 ```bash
 for entry in \
   us-central1:quill-enclave-mig-us \
   us-east4:quill-enclave-mig-useast4 \
-  europe-west4:quill-enclave-mig-eu \
-  southamerica-east1:quill-enclave-mig-sa; do
+  europe-west4:quill-enclave-mig-eu; do
   region=${entry%%:*}
   mig=${entry#*:}
   echo "=== ${region} ==="

--- a/scripts/deploy/_lib.sh
+++ b/scripts/deploy/_lib.sh
@@ -15,7 +15,7 @@ REGION="${REGION:-us-central1}"
 # /v1/regions which the SDK's region= shortcut resolves against. Adding
 # a region without a backing gateway VM gives callers a TLS-broken
 # `api-<region>.quillrouter.com` and weakens the trust story.
-TR_REGIONS="${TR_REGIONS:-us-central1,us-east4,europe-west4}"
+TR_REGIONS="${TR_REGIONS:-$(python3 "$(dirname "${BASH_SOURCE[0]}")/../../src/trusted_router/enclave_regions.py")}"
 TR_PRIMARY_REGION="${TR_PRIMARY_REGION:-us-central1}"
 # Cloud Run control-plane regions behind trustedrouter.com. This is broader
 # than TR_REGIONS because cold control-plane regions can serve cached public

--- a/scripts/deploy/watchdog.py
+++ b/scripts/deploy/watchdog.py
@@ -45,6 +45,10 @@ import urllib.request
 from collections.abc import Iterable
 from pathlib import Path
 
+# This script also runs directly from a checkout during deploys.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+from trusted_router.enclave_regions import ENCLAVE_REGIONS  # noqa: E402
+
 # Worst-of: the per-region effective_status is the worst over its checks.
 # `unknown` is treated as severity 0 for ranking but reported separately
 # so the operator can tell "no signal" apart from "all healthy."
@@ -193,7 +197,7 @@ def main() -> int:
     parser.add_argument("--rollback-after", type=int, default=3)
     parser.add_argument(
         "--regions",
-        default="us-central1,us-east4,europe-west4",
+        default=",".join(ENCLAVE_REGIONS),
         help="Comma-separated list of target regions to monitor.",
     )
     parser.add_argument(

--- a/scripts/smoke_all_providers.py
+++ b/scripts/smoke_all_providers.py
@@ -21,8 +21,13 @@ import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
+from pathlib import Path
 
 import httpx
+
+# Keep direct script execution independent of an installed router package.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from trusted_router.enclave_regions import ENCLAVE_REGIONS  # noqa: E402
 
 # (provider_slug, model_id) — picks one canonical-routed model per
 # provider that should always be available on the keyed credential.
@@ -65,9 +70,7 @@ PROBES: list[tuple[str, str]] = [
 # whichever region was geographically closest to the smoke client,
 # which left other regions un-monitored.
 #
-# Regions are listed in the same order as TR_REGIONS in
-# scripts/deploy/_lib.sh — the source of truth for "which regions
-# are configured."
+# Region membership comes from trusted_router.enclave_regions.
 #
 # Caveats per region:
 #   - us-central1: this is the primary region. The canonical hostname
@@ -81,26 +84,17 @@ PROBES: list[tuple[str, str]] = [
 #     running instance. If the MIG is at targetSize=0 the smoke will
 #     fail TLS for this region — that's a deployment-state signal,
 #     not a smoke bug. Resize the MIG and re-probe.
-#   - asia-northeast1, asia-southeast1: control-plane only (no enclave
-#     MIG by design). They serve
-#     authorize/settle from local Cloud Run instances but the
-#     inference path lands on the closest warm enclave. The smoke
-#     skips the enclave probe for these regions; the synthetic
-#     monitor's separate /health probe via Cloud Run direct URLs
-#     covers the control-plane health for them.
+# Control-plane-only regions have no entry in this gateway inventory.
 REGIONS = {
-    "us-central1": "https://api.trustedrouter.com",
-    "europe-west4": "https://api-europe-west4.quillrouter.com",
-    "us-east4": "https://api-us-east4.quillrouter.com",
-    # Aliases preserved for backward-compat with operator muscle memory.
-    "us": "https://api.trustedrouter.com",
-    "europe": "https://api-europe-west4.quillrouter.com",
+    region: (
+        "https://api.trustedrouter.com"
+        if region == "us-central1"
+        else f"https://api-{region}.quillrouter.com"
+    )
+    for region in ENCLAVE_REGIONS
 }
-
-# Regions that have a regional enclave MIG. The smoke iterates these
-# by default; the aliases above are accepted via --regions for legacy
-# callers but produce duplicate probes against the same backend.
-ENCLAVE_REGIONS = ("us-central1", "europe-west4", "us-east4")
+# Aliases preserved for backward-compat with operator muscle memory.
+REGIONS.update(us=REGIONS["us-central1"], europe=REGIONS["europe-west4"])
 
 
 @dataclass
@@ -194,7 +188,7 @@ def main(argv: list[str] | None = None) -> int:
         nargs="+",
         default=list(ENCLAVE_REGIONS),
         help="Regions to probe. Default: all enclave-capable regions "
-        "(us-central1, europe-west4, us-east4). Pass legacy "
+        f"({', '.join(ENCLAVE_REGIONS)}). Pass legacy "
         "aliases ('us', 'europe') if you want the old behavior.",
     )
     parser.add_argument(

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -18,6 +18,7 @@ from pydantic_settings import (
     SettingsConfigDict,
 )
 
+from trusted_router.enclave_regions import ENCLAVE_REGIONS
 from trusted_router.trust_ownership import (
     TRUST_OWNER_MUTATION_BUDGET,
     TRUST_REPLICATED_COLUMN_COUNT,
@@ -1008,7 +1009,7 @@ class Settings(BaseSettings):
     # regions where we've actually deployed a VM. Adding a region here
     # without an actual VM in that region is dishonest — the cert SAN
     # mismatch breaks TLS and the attestation page lies.
-    regions: str = "us-central1,us-east4,europe-west4"
+    regions: str = ",".join(ENCLAVE_REGIONS)
     marketing_regions: str = (
         "us-central1,europe-west4,us-east4,"
         "asia-northeast1,asia-east2,asia-southeast1,"

--- a/src/trusted_router/enclave_regions.py
+++ b/src/trusted_router/enclave_regions.py
@@ -1,0 +1,11 @@
+"""Live GCP enclave gateway inventory, separate from Cloud Run deployments.
+
+Run this dependency-free module as a script to read the same inventory from
+deploy shell scripts. Standalone AWS/Azure gateways have their own inventory.
+"""
+
+ENCLAVE_REGIONS = ("us-central1", "us-east4", "europe-west4")
+
+
+if __name__ == "__main__":
+    print(",".join(ENCLAVE_REGIONS))

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -25,6 +25,7 @@ from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from trustedrouter import AsyncTrustedRouter
 
 from trusted_router.config import Settings, parse_gateway_region_targets
+from trusted_router.enclave_regions import ENCLAVE_REGIONS
 from trusted_router.provider_reliability import model_deadlines
 from trusted_router.regions import choose_region, region_payload
 from trusted_router.security import lookup_hash_api_key
@@ -198,6 +199,7 @@ def _gateway_region_targets(
             paid_probes=False,
         )
         for entry in parse_gateway_region_targets(settings.synthetic_gateway_region_targets)
+        if not settings.synthetic_regional_probes_enabled or entry.name in ENCLAVE_REGIONS
     ]
 
 
@@ -248,6 +250,10 @@ def configured_targets(settings: Settings) -> list[SyntheticTarget]:
         return targets
     for region in region_payload(settings):
         name = str(region["id"])
+        # Old job environments can still advertise control-plane-only regions.
+        # Only the live enclave inventory may produce regional gateway probes.
+        if name not in ENCLAVE_REGIONS:
+            continue
         api_base_url = str(region["api_base_url"])
         control_plane_url = region.get("control_plane_url") or None
         if name == choose_region(settings):

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -8,6 +8,7 @@ from scripts.check_price_coverage import (
     _GLM_DISCOVERABLE_PROVIDER_APIS,
     _OPTIONAL_STALE_MANIFEST_PROVIDER_SLUGS,
 )
+from trusted_router.enclave_regions import ENCLAVE_REGIONS
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -206,7 +207,8 @@ def test_all_attested_control_plane_regions_remain_warm() -> None:
         assert match is not None, f"{name} default not found in _lib.sh"
         return match.group(1)
 
-    attested = [r for r in _default("TR_REGIONS").split(",") if r]
+    # The shell reads this inventory; deploy execution tests cover that wiring.
+    attested = ENCLAVE_REGIONS
     warm = [r for r in _default("TR_WARM_REGIONS").split(",") if r]
     minimums = dict(
         entry.split("=", 1)

--- a/tests/test_deploy_workflow_regions.py
+++ b/tests/test_deploy_workflow_regions.py
@@ -1,6 +1,11 @@
+import re
 from pathlib import Path
 
 import pytest
+
+from scripts.smoke_all_providers import REGIONS as SMOKE_REGIONS
+from trusted_router.config import Settings
+from trusted_router.enclave_regions import ENCLAVE_REGIONS
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -461,3 +466,18 @@ def test_mutex_acquire_step_cannot_swallow_a_blocked_exit() -> None:
                 "deploy_mutex.sh acquire is piped; a blocked acquire would "
                 "exit 0 through the pipe under bash -e without pipefail: " + line.strip()
             )
+
+
+def test_enclave_inventory_is_separate_from_live_control_plane_regions() -> None:
+    assert ENCLAVE_REGIONS == ("us-central1", "us-east4", "europe-west4")
+    assert "southamerica-east1" not in ENCLAVE_REGIONS
+    assert Settings().regions == ",".join(ENCLAVE_REGIONS)
+    assert set(SMOKE_REGIONS) - {"us", "europe"} == set(ENCLAVE_REGIONS)
+    assert SMOKE_REGIONS["us"] == SMOKE_REGIONS["us-central1"]
+    assert SMOKE_REGIONS["europe"] == SMOKE_REGIONS["europe-west4"]
+
+    library = (ROOT / "scripts/deploy/_lib.sh").read_text()
+    match = re.search(r'TR_CONTROL_PLANE_REGIONS:-([^}]+)', library)
+    assert match is not None
+    control_plane_regions = set(match.group(1).split(","))
+    assert control_plane_regions == set(ENCLAVE_REGIONS) | {"southamerica-east1"}

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -2358,7 +2358,7 @@ def _jwt(payload: dict[str, Any]) -> bytes:
     return f"header.{body}.signature".encode()
 
 
-def test_configured_targets_include_primary_regional_gateway() -> None:
+def test_configured_targets_include_primary_gateway_and_ignore_retired_enclave() -> None:
     from trusted_router.synthetic.probes import configured_targets
 
     settings = Settings(
@@ -2383,14 +2383,28 @@ def test_configured_targets_include_primary_regional_gateway() -> None:
     assert by_name["europe-west4"].api_base_url == (
         "https://api-europe-west4.quillrouter.com/v1"
     )
-    assert by_name["southamerica-east1"].api_base_url == (
-        "https://api-southamerica-east1.quillrouter.com/v1"
-    )
+    assert "southamerica-east1" not in by_name
+    assert set(by_name) == {"canonical", "us-central1", "us-east4", "europe-west4"}
     assert all(
         target.control_plane_url is None
         for name, target in by_name.items()
         if name != "canonical"
     )
+
+
+def test_stale_pinned_gcp_gateway_targets_use_enclave_inventory() -> None:
+    from trusted_router.enclave_regions import ENCLAVE_REGIONS
+    from trusted_router.synthetic.probes import configured_targets
+
+    settings = Settings(
+        environment="test",
+        synthetic_gateway_region_targets=(
+            "us-east4=live.example,southamerica-east1=retired.example"
+        ),
+    )
+    pinned = [target for target in configured_targets(settings) if target.connect_host]
+    assert [target.name for target in pinned] == ["us-east4"]
+    assert all(target.region in ENCLAVE_REGIONS for target in pinned)
 
 
 def test_status_components_include_all_warm_regional_gateways() -> None:


### PR DESCRIPTION
Router half of the São Paulo enclave retirement, scoped to the enclave gateway only. quill-cloud-proxy #309 removed the `southamerica-east1` enclave MIG from rollout and trust discovery, #312 stopped probing and declaring it, and the stale regional record was deleted. The São Paulo control plane stays: its Cloud Run service serves about 32,000 requests a day through the global load balancer and keeps deploying exactly as before.

- Every monitor, probe and check that targets an enclave gateway hostname (`api-<region>.quillrouter.com`) or an enclave region list now derives it from one enclave-region inventory covering us-central1, us-east4 and europe-west4, consistent with #1090's `TR_REGIONS` reconciliation.
- Where one list served both purposes, it is split into control-plane regions (still four, including São Paulo) and enclave regions (three).
- Nothing in the Cloud Run deploy path changes; no cloud resource is touched.

Reviewed by Fable on an isolated snapshot: the deploy-script harness, wiring and workflow-region suites pass, every touched script passes `bash -n` and shellcheck, actionlint and ruff are clean. Mutations that reintroduce São Paulo into the enclave inventory or drop it from the control-plane set each turn a test red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
