### PR TITLE
reconciler: an unprovisioned spend-lease ledger fails worker health while binding is enabled

### DIFF
--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -1522,6 +1522,10 @@ class Settings(BaseSettings):
             raise ValueError(
                 "TR_SPEND_LEASE_BINDING_ENABLED requires TR_SPEND_LEASE_ISSUANCE_ENABLED"
             )
+        if self.spend_lease_binding_enabled and not self.spend_lease_bigtable_app_profile_map:
+            raise ValueError(
+                "TR_SPEND_LEASE_BINDING_ENABLED requires TR_SPEND_LEASE_BIGTABLE_APP_PROFILES"
+            )
         if self.spend_lease_admission_accept and not self.spend_lease_binding_enabled:
             raise ValueError(
                 "TR_SPEND_LEASE_ADMISSION_ACCEPT requires TR_SPEND_LEASE_BINDING_ENABLED"

--- a/src/trusted_router/spend_lease_reconcile_cli.py
+++ b/src/trusted_router/spend_lease_reconcile_cli.py
@@ -110,14 +110,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         try:
             regions = verify()
         except SpendLeaseLedgerUnprovisioned as exc:
-            logger.info(
-                "spend_lease.reconciler_ledger_unprovisioned "
-                "table=%s profile=%s region=%s",
-                exc.table_id,
-                exc.profile,
-                exc.region,
-            )
-            exit_code = 0
+            if settings.spend_lease_binding_enabled:
+                logger.error(
+                    "spend_lease.reconcile.ledger_unprovisioned "
+                    "table=%s profile=%s region=%s",
+                    exc.table_id,
+                    exc.profile,
+                    exc.region,
+                )
+            else:
+                logger.info(
+                    "spend_lease.reconciler_ledger_unprovisioned "
+                    "table=%s profile=%s region=%s",
+                    exc.table_id,
+                    exc.profile,
+                    exc.region,
+                )
+                exit_code = 0
         except Exception:
             logger.exception("spend_lease.reconciler_health_check_failed")
         else:

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -2703,6 +2703,7 @@ def test_inline_spend_lease_overrun_caps_charge_generation_typed_cost_and_outbox
         operational_analytics_outbox_enabled=True,
         spend_lease_issuance_enabled=True,
         spend_lease_binding_enabled=True,
+        spend_lease_bigtable_app_profiles="us-central1=tr-spend-us-central1",
         spend_lease_pilot_workspace_ids=ws,
         spend_lease_signing_secret_name="test-secret",  # noqa: S106
     )

--- a/tests/test_spend_lease_authorize.py
+++ b/tests/test_spend_lease_authorize.py
@@ -199,12 +199,39 @@ def test_binding_settings_requires_issuance() -> None:
         environment="test",
         spend_lease_issuance_enabled=True,
         spend_lease_binding_enabled=True,
+        spend_lease_bigtable_app_profiles="us-central1=tr-spend-us-central1",
         spend_lease_pilot_workspace_ids="workspace-1",
         spend_lease_signing_secret_name="projects/test/secrets/spend-lease",  # noqa: S106
         operational_analytics_sink="direct",
     )
     assert settings.spend_lease_binding_enabled is True
     assert settings.spend_lease_issuance_enabled is True
+
+
+@pytest.mark.parametrize("profiles", ["", "   ", " , , "])
+@pytest.mark.parametrize("binding_enabled", [False, True])
+def test_binding_settings_requires_nonempty_app_profile_map(
+    profiles: str, binding_enabled: bool,
+) -> None:
+    def make_settings() -> Settings:
+        return Settings(
+            environment="test",
+            spend_lease_issuance_enabled=True,
+            spend_lease_binding_enabled=binding_enabled,
+            spend_lease_bigtable_app_profiles=profiles,
+            spend_lease_pilot_workspace_ids="workspace-1",
+            spend_lease_signing_secret_name="projects/test/secrets/spend-lease",  # noqa: S106
+            operational_analytics_sink="direct",
+        )
+
+    if binding_enabled:
+        with pytest.raises(
+            ValueError,
+            match="TR_SPEND_LEASE_BINDING_ENABLED requires TR_SPEND_LEASE_BIGTABLE_APP_PROFILES",
+        ):
+            make_settings()
+    else:
+        assert make_settings().spend_lease_bigtable_app_profile_map == {}
 
 
 def test_candidate_id_includes_creating_authorization_and_is_stable() -> None:

--- a/tests/test_spend_lease_authorize.py
+++ b/tests/test_spend_lease_authorize.py
@@ -208,6 +208,47 @@ def test_binding_settings_requires_issuance() -> None:
     assert settings.spend_lease_issuance_enabled is True
 
 
+def test_binding_settings_env_rejects_empty_app_profiles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TR_SPEND_LEASE_BINDING_ENABLED", "true")
+    monkeypatch.setenv("TR_SPEND_LEASE_BIGTABLE_APP_PROFILES", "")
+
+    with pytest.raises(
+        ValueError,
+        match="TR_SPEND_LEASE_BINDING_ENABLED requires TR_SPEND_LEASE_BIGTABLE_APP_PROFILES",
+    ):
+        Settings(
+            environment="test",
+            spend_lease_issuance_enabled=True,
+            spend_lease_pilot_workspace_ids="workspace-1",
+            spend_lease_signing_secret_name="projects/test/secrets/spend-lease",  # noqa: S106
+            operational_analytics_sink="direct",
+        )
+
+
+def test_binding_settings_env_accepts_configured_app_profiles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TR_SPEND_LEASE_BINDING_ENABLED", "true")
+    monkeypatch.setenv(
+        "TR_SPEND_LEASE_BIGTABLE_APP_PROFILES", "us-central1=tr-spend-us-central1",
+    )
+
+    settings = Settings(
+        environment="test",
+        spend_lease_issuance_enabled=True,
+        spend_lease_pilot_workspace_ids="workspace-1",
+        spend_lease_signing_secret_name="projects/test/secrets/spend-lease",  # noqa: S106
+        operational_analytics_sink="direct",
+    )
+
+    assert settings.spend_lease_binding_enabled is True
+    assert settings.spend_lease_bigtable_app_profile_map == {
+        "us-central1": "tr-spend-us-central1",
+    }
+
+
 @pytest.mark.parametrize("profiles", ["", "   ", " , , "])
 @pytest.mark.parametrize("binding_enabled", [False, True])
 def test_binding_settings_requires_nonempty_app_profile_map(

--- a/tests/test_spend_lease_reconcile_cli.py
+++ b/tests/test_spend_lease_reconcile_cli.py
@@ -52,6 +52,7 @@ class _Store:
 
 def _settings() -> SimpleNamespace:
     return SimpleNamespace(
+        spend_lease_binding_enabled=False,
         spend_lease_reconciler_worker=True,
         spend_lease_reconcile_limit=25,
         spend_lease_reconcile_max_attempts=12,
@@ -110,7 +111,7 @@ def test_unresolved_reconciliation_fails_without_success_heartbeat(
     assert heartbeats == []
 
 
-def test_unprovisioned_ledger_is_clean_idle_pass_with_heartbeat(
+def test_unprovisioned_ledger_binding_disabled_is_clean_idle_pass_with_heartbeat(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -132,6 +133,35 @@ def test_unprovisioned_ledger_is_clean_idle_pass_with_heartbeat(
         "table=trustedrouter-spend-lease "
         "profile=tr-spend-us-central1 region=us-central1"
     ) == 1
+
+
+def test_unprovisioned_ledger_binding_enabled_fails_without_heartbeat(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = _Store()
+    store.health_error = SpendLeaseLedgerUnprovisioned(
+        table_id="trustedrouter-spend-lease",
+        profile="tr-spend-us-central1",
+        region="us-central1",
+    )
+    heartbeats = _wire(monkeypatch, store)
+    settings = _settings()
+    settings.spend_lease_binding_enabled = True
+    monkeypatch.setattr(cli, "get_settings", lambda: settings)
+
+    with caplog.at_level(logging.INFO, logger=cli.__name__):
+        assert cli.main(["reconcile"]) == 1
+
+    assert store.events == ["acquire", "health", "release"]
+    assert heartbeats == []
+    assert caplog.record_tuples.count((
+        cli.__name__,
+        logging.ERROR,
+        "spend_lease.reconcile.ledger_unprovisioned "
+        "table=trustedrouter-spend-lease "
+        "profile=tr-spend-us-central1 region=us-central1",
+    )) == 1
 
 
 def test_generic_health_failure_returns_one_without_heartbeat(

--- a/tests/test_stage_c_admission.py
+++ b/tests/test_stage_c_admission.py
@@ -121,6 +121,7 @@ def _settings(workspace_id: str, digest: str) -> Settings:
         operational_analytics_sink="direct",
         spend_lease_issuance_enabled=True,
         spend_lease_binding_enabled=True,
+        spend_lease_bigtable_app_profiles="us-central1=tr-spend-us-central1",
         spend_lease_admission_accept=True,
         spend_lease_pilot_workspace_ids=workspace_id,
         spend_lease_signing_secret_name="stage-c-test-seed",  # noqa: S106


### PR DESCRIPTION
Follow-up from the independent review of the live spend-lease pilot (2026-09-05). The reconciler job treated an unprovisioned ledger (Bigtable table not found, or a precondition error naming the app profile) as a successful idle run and emitted its normal heartbeat. That was right before the ledger existed (#1032); with `TR_SPEND_LEASE_BINDING_ENABLED=true` and `TR_SPEND_LEASE_BIGTABLE_APP_PROFILES` pinned (#1078), a deleted table or profile would have stopped reconciliation silently while monitoring stayed green, so escrow capacity would never be reclaimed.

- With binding enabled, an unprovisioned ledger now fails worker health: no `job:spend-lease-reconcile` heartbeat, a distinct `spend_lease.reconcile.ledger_unprovisioned` signal naming the table and app profile, and a non-zero exit so the job execution is marked failed.
- With binding disabled, the idle-success behaviour is unchanged.
- Settings validation now requires non-empty spend-lease app profiles whenever binding is enabled, mirroring the rollout refusal from #1078, so the router and the job agree.

Reviewed by Fable on an isolated snapshot: the reconciler CLI, reconciler and settings suites pass, ruff and mypy are clean. Mutations that restore the heartbeat under binding, drop the non-zero exit, or remove the settings check each turn a test red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
