### PR TITLE
Fix multi-call billing blocked by unique trace IDs

### DIFF
--- a/docs/incidents/2026-09-05-shared-trace-settlement.md
+++ b/docs/incidents/2026-09-05-shared-trace-settlement.md
@@ -1,0 +1,54 @@
+# Shared trace ID blocked multi-call settlement
+
+## Cause
+
+The Stage D schema made `gateway_request_id` globally unique in the typed
+authorization table. It is a parent audit trace, not a billing idempotency key.
+Responses web search, fusion, and other multi-call requests can legitimately
+settle several different authorizations under the same trace. The first
+settlement succeeded; the next rolled back at the unique index. Background
+retries hit the deterministic conflict repeatedly and could exhaust the drain's
+HTTP deadline. The former schema test explicitly expected uniqueness; the
+in-memory Spanner fake did not enforce it during settlement.
+
+Production evidence on September 5 identified 24 outstanding web-search final
+calls, all in the operator's own workspace. Preserve exact customer attribution
+in private incident records, not this public document. No prompt/output was
+inspected. A separate successful call sharing a trace is not evidence that the
+failed authorization has been charged.
+
+## Repair sequence
+
+1. Run `scripts/deploy/migrate_gateway_request_index.sh --prepare` using the
+   deployment identity and the existing project/instance/database environment.
+   This creates a sparse nonunique `tr_gateway_authorization_by_trace_id` index
+   without removing the existing unique index or changing billing rows.
+2. Deploy the new readers to every active control-plane region. They use the
+   new index with `LIMIT 2`. A request with several authorizations returns
+   `409 ambiguous_gateway_request_id` instead of attributing one call to the
+   whole request. Use the authorization-specific disposition route for a leg.
+3. After all readers are verified, run the script with `--retire-unique`.
+   Only the obsolete index is dropped. Reservation claims, authorization primary
+   keys, and true idempotency indexes remain unchanged. Do not roll back to a
+   reader that requires the old index after this step.
+4. Re-arm only the reviewed pending/dead settlement rows whose preserved error
+   is this exact index violation. Leave frozen costs and settlement bodies
+   unchanged. Use the normal drain in small bounded passes. Verify each
+   authorization/reservation/outbox and exactly one generation, with no held
+   credit remaining for those requests. Do not mark rows done or edit balances
+   manually.
+
+## Regression evidence
+
+- The old evidence reader returned 200 for an ambiguous trace; its regression
+  failed before the fix and returns 409 afterward.
+- A real loopback Spanner emulator reproduces the old unique-index rejection,
+  retains it during prepare, and settles both rows exactly once after retirement.
+- A typed billing test settles two calls under one trace, releases both holds,
+  and proves replay does not move any counter.
+- Executed migration tests cover preparation, retirement, idempotence, and
+  refusal to retire before the nonunique index is ready.
+- Memory/Postgres lookup tests cover absent, single, and ambiguous traces.
+
+No alert thresholds, retention policies, upstream requests, or billing formulas
+are changed by this repair.

--- a/scripts/deploy/migrate_gateway_request_index.sh
+++ b/scripts/deploy/migrate_gateway_request_index.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Two-phase migration. Prepare before deploying trace-aware readers to every
+# region; retire the old unique index only after those readers are verified.
+# No authorization, reservation, balance, or idempotency records are deleted.
+set -euo pipefail
+
+INSTANCE="${SPANNER_INSTANCE_ID:?set SPANNER_INSTANCE_ID}"
+DATABASE="${SPANNER_DATABASE_ID:?set SPANNER_DATABASE_ID}"
+PROJECT="${GCP_PROJECT_ID:?set GCP_PROJECT_ID}"
+MODE="${1:---prepare}"
+case "$MODE" in
+  --prepare|--retire-unique) ;;
+  *) echo "usage: $0 [--prepare|--retire-unique]" >&2; exit 2 ;;
+esac
+
+sql() {
+  gcloud spanner databases execute-sql "$DATABASE" --instance="$INSTANCE" \
+    --project="$PROJECT" --sql="$1" --format='value(rows[0])'
+}
+ddl() {
+  gcloud spanner databases ddl update "$DATABASE" --instance="$INSTANCE" \
+    --project="$PROJECT" --ddl="$1"
+}
+NEW=tr_gateway_authorization_by_trace_id
+OLD=tr_gateway_authorization_by_gateway_request_id
+
+count=$(sql "SELECT COUNT(*) FROM INFORMATION_SCHEMA.INDEXES WHERE INDEX_NAME='$NEW'")
+if [[ "$count" == 0 && "$MODE" == --prepare ]]; then
+  ddl "CREATE NULL_FILTERED INDEX $NEW ON tr_gateway_authorization (gateway_request_id)"
+elif [[ "$count" != 1 ]]; then
+  echo "Trace index is absent or its existence could not be verified" >&2
+  exit 1
+fi
+ready=$(sql "SELECT COUNT(*) FROM INFORMATION_SCHEMA.INDEXES WHERE INDEX_NAME='$NEW' AND INDEX_STATE='READ_WRITE' AND IS_UNIQUE=FALSE AND IS_NULL_FILTERED=TRUE")
+if [[ "$ready" != 1 ]]; then
+  echo "Trace index is not ready with the expected nonunique, sparse shape" >&2
+  exit 1
+fi
+if [[ "$MODE" == --retire-unique ]]; then
+  old_count=$(sql "SELECT COUNT(*) FROM INFORMATION_SCHEMA.INDEXES WHERE INDEX_NAME='$OLD'")
+  case "$old_count" in
+    1) ddl "DROP INDEX $OLD" ;;
+    0) echo "Legacy unique index is already absent" ;;
+    *) echo "Could not verify legacy index state" >&2; exit 1 ;;
+  esac
+fi
+echo "Gateway trace index migration complete: $MODE"

--- a/scripts/deploy/migrate_spend_lease.sh
+++ b/scripts/deploy/migrate_spend_lease.sh
@@ -134,14 +134,17 @@ ensure_column tr_gateway_authorization invocation_nonce \
 ensure_column tr_gateway_authorization gateway_request_id \
   "STRING(37)"
 
-if index_exists tr_gateway_authorization_by_gateway_request_id; then
-  log "tr_gateway_authorization_by_gateway_request_id: already present"
+# A trace is not an idempotency key: web search and fusion bill multiple
+# authorizations under one trace. Keep any legacy unique index until every
+# reader is deployed, then retire it with migrate_gateway_request_index.sh.
+if index_exists tr_gateway_authorization_by_trace_id; then
+  log "tr_gateway_authorization_by_trace_id: already present"
 else
-  apply_ddl "CREATE UNIQUE NULL_FILTERED INDEX tr_gateway_authorization_by_gateway_request_id
+  apply_ddl "CREATE NULL_FILTERED INDEX tr_gateway_authorization_by_trace_id
     ON tr_gateway_authorization (gateway_request_id)"
-  log "tr_gateway_authorization_by_gateway_request_id: created"
+  log "tr_gateway_authorization_by_trace_id: created"
 fi
-wait_index_read_write tr_gateway_authorization_by_gateway_request_id
+wait_index_read_write tr_gateway_authorization_by_trace_id
 
 if table_exists spend_lease_scope_arbitration; then
   log "spend_lease_scope_arbitration: already present"

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -234,6 +234,7 @@ from trusted_router.storage_gcp_io import spanner_rpc_budget
 from trusted_router.storage_gcp_secrets import secret_manager_seed_loader
 from trusted_router.storage_models import (
     SYNTHETIC_APP_NAME,
+    AmbiguousGatewayRequestId,
     AppMarkupPayout,
     CustomModelMarkupPayout,
     GatewayAuthorization,
@@ -718,9 +719,16 @@ def _gateway_authorization_by_gateway_request_id_sync(
             "gateway request id must be rlog_ followed by 32 lowercase hex characters",
             ErrorType.BAD_REQUEST,
         )
-    authorization = STORE.get_gateway_authorization_by_gateway_request_id(
-        gateway_request_id
-    )
+    try:
+        authorization = STORE.get_gateway_authorization_by_gateway_request_id(
+            gateway_request_id
+        )
+    except AmbiguousGatewayRequestId:
+        raise api_error(
+            409,
+            "Multiple authorizations share this trace; look up an authorization ID instead",
+            "ambiguous_gateway_request_id",
+        ) from None
     if authorization is None:
         return JSONResponse(
             {

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -55,6 +55,7 @@ from trusted_router.storage_models import (
     ActivationReminderTask,
     AdverseTrustEvent,
     AdverseTrustResult,
+    AmbiguousGatewayRequestId,
     ApiKey,
     ApiKeyAuthContext,
     ApiKeyUsageSnapshot,
@@ -3023,14 +3024,17 @@ class InMemoryStore:
         self, gateway_request_id: str
     ) -> GatewayAuthorization | None:
         with self._lock:
-            return next(
-                (
-                    authorization
-                    for authorization in self.api_keys.gateway_authorizations.values()
-                    if authorization.gateway_request_id == gateway_request_id
-                ),
-                None,
+            matches = (
+                authorization
+                for authorization in self.api_keys.gateway_authorizations.values()
+                if authorization.gateway_request_id == gateway_request_id
             )
+            first = next(matches, None)
+            if next(matches, None) is not None:
+                raise AmbiguousGatewayRequestId(
+                    "multiple authorizations share the gateway request id"
+                )
+            return first
 
     def get_gateway_authorization_by_idempotency_key(
         self, workspace_id: str, key_hash: str, idempotency_key: str

--- a/src/trusted_router/storage_gcp_request_records.py
+++ b/src/trusted_router/storage_gcp_request_records.py
@@ -32,7 +32,7 @@ from trusted_router.storage_gcp_spend_lease import (
     authorization_typed_param_types,
     merge_authorization_typed_columns,
 )
-from trusted_router.storage_models import GatewayAuthorization
+from trusted_router.storage_models import AmbiguousGatewayRequestId, GatewayAuthorization
 from trusted_router.types import UsageType
 
 AUTHORIZATION_TABLE = "tr_gateway_authorization"
@@ -289,19 +289,22 @@ def read_gateway_authorization_by_gateway_request_id(
     param_types: Any,
     gateway_request_id: str,
 ) -> GatewayAuthorization | None:
-    """Read one authorization through the request-id secondary index."""
+    """Resolve single-call evidence without misattributing a multi-call trace."""
 
     rows = list(
         reader.execute_sql(
             "SELECT authorization_id FROM "
-            "tr_gateway_authorization@{FORCE_INDEX=tr_gateway_authorization_by_gateway_request_id} "
-            "WHERE gateway_request_id=@gateway_request_id",
+            "tr_gateway_authorization@{FORCE_INDEX=tr_gateway_authorization_by_trace_id} "
+            "WHERE gateway_request_id=@gateway_request_id "
+            "AND gateway_request_id IS NOT NULL LIMIT 2",
             params={"gateway_request_id": gateway_request_id},
             param_types={"gateway_request_id": param_types.STRING},
         )
     )
     if not rows:
         return None
+    if len(rows) > 1:
+        raise AmbiguousGatewayRequestId("multiple authorizations share the gateway request id")
     return read_gateway_authorization(reader, param_types, str(rows[0][0]))
 
 

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -11,6 +11,10 @@ from trusted_router.money import microdollars_to_float
 from trusted_router.types import UsageType
 
 
+class AmbiguousGatewayRequestId(ValueError):
+    """A parent trace contains multiple independently billable authorizations."""
+
+
 def utcnow() -> dt.datetime:
     return dt.datetime.now(dt.UTC).replace(microsecond=0)
 

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -114,6 +114,7 @@ from trusted_router.storage_models import (
     ActivationReminderTask,
     AdverseTrustEvent,
     AdverseTrustResult,
+    AmbiguousGatewayRequestId,
     ApiKey,
     ApiKeyAuthContext,
     ApiKeyUsageSnapshot,
@@ -5944,15 +5945,19 @@ class PostgresStore:
         self, gateway_request_id: str
     ) -> GatewayAuthorization | None:
         def read(conn: Any) -> GatewayAuthorization | None:
-            row = conn.execute(
+            rows = conn.execute(
                 "SELECT body FROM tr_entities "
                 "WHERE kind = %s AND body ->> 'gateway_request_id' = %s "
-                "ORDER BY id LIMIT 1",
+                "ORDER BY id LIMIT 2",
                 (_GATEWAY_AUTHORIZATION_KIND, gateway_request_id),
-            ).fetchone()
-            if row is None:
+            ).fetchall()
+            if not rows:
                 return None
-            raw = row[0]
+            if len(rows) > 1:
+                raise AmbiguousGatewayRequestId(
+                    "multiple authorizations share the gateway request id"
+                )
+            raw = rows[0][0]
             data = json.loads(raw) if isinstance(raw, str) else dict(raw)
             known = {field.name for field in dataclasses.fields(GatewayAuthorization)}
             return GatewayAuthorization(**{key: value for key, value in data.items() if key in known})

--- a/tests/test_gateway_trace_index_emulator.py
+++ b/tests/test_gateway_trace_index_emulator.py
@@ -1,0 +1,83 @@
+"""Real Spanner unique-index regression; opt in with a loopback emulator only."""
+from __future__ import annotations
+
+import os
+import uuid
+from dataclasses import replace
+
+import pytest
+
+from trusted_router.storage_gcp_request_records import mark_gateway_authorization_settled
+from trusted_router.storage_models import GatewayAuthorization
+from trusted_router.types import UsageType
+
+
+def test_real_spanner_shared_trace_migration_preserves_each_authorization() -> None:
+    host = os.environ.get("TR_TRACE_TEST_SPANNER_EMULATOR", "")
+    if not host:
+        pytest.skip("local Spanner emulator not requested")
+    assert host.startswith(("127.0.0.1:", "localhost:")), "emulator must be loopback"
+    from google.api_core.exceptions import AlreadyExists
+    from google.auth.credentials import AnonymousCredentials
+    from google.cloud import spanner
+    from google.cloud.spanner_v1 import param_types
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setenv("SPANNER_EMULATOR_HOST", host)
+        client = spanner.Client(project="trace-index-test", credentials=AnonymousCredentials())
+        instance = client.instance("trace-" + uuid.uuid4().hex[:12])
+        instance.create().result(timeout=30)
+        database = instance.database("trace-test", ddl_statements=[
+            "CREATE TABLE tr_gateway_authorization ("
+            "authorization_id STRING(64) NOT NULL, settled BOOL NOT NULL, "
+            "payload STRING(MAX), finalization_outcome STRING(32), "
+            "finalized_cost_microdollars INT64, gateway_request_id STRING(37)"
+            ") PRIMARY KEY (authorization_id)",
+            "CREATE UNIQUE NULL_FILTERED INDEX tr_gateway_authorization_by_gateway_request_id "
+            "ON tr_gateway_authorization (gateway_request_id)",
+        ])
+        try:
+            database.create().result(timeout=30)
+            first = GatewayAuthorization(
+                id="gwa-first", workspace_id="test-workspace", key_hash="test-key-hash",
+                model_id="vendor/model", provider="vendor", usage_type=UsageType.CREDITS,
+                estimated_microdollars=100, credit_reservation_id="reservation-first",
+                gateway_request_id="rlog_00112233445566778899aabbccddeeff",
+                finalized_cost_microdollars=7, finalization_outcome="settled",
+            )
+            second = replace(first, id="gwa-second", finalized_cost_microdollars=11)
+            with database.batch() as batch:
+                batch.insert("tr_gateway_authorization", ("authorization_id", "settled"),
+                             [(first.id, False), (second.id, False)])
+
+            def settle(authorization: GatewayAuthorization) -> int:
+                return database.run_in_transaction(
+                    lambda tx: mark_gateway_authorization_settled(tx, param_types, authorization)
+                )
+
+            assert settle(first) == 1
+            with pytest.raises(AlreadyExists):
+                settle(second)
+            # Preparing the nonunique index cannot remove the old guard.
+            database.update_ddl([
+                "CREATE NULL_FILTERED INDEX tr_gateway_authorization_by_trace_id "
+                "ON tr_gateway_authorization (gateway_request_id)"
+            ]).result(timeout=30)
+            with pytest.raises(AlreadyExists):
+                settle(second)
+            database.update_ddl([
+                "DROP INDEX tr_gateway_authorization_by_gateway_request_id"
+            ]).result(timeout=30)
+            assert settle(second) == 1
+            assert settle(first) == settle(second) == 0
+            with database.snapshot() as snapshot:
+                rows = list(snapshot.execute_sql(
+                    "SELECT authorization_id, finalized_cost_microdollars FROM "
+                    "tr_gateway_authorization "
+                    "WHERE gateway_request_id='rlog_00112233445566778899aabbccddeeff' "
+                    "AND gateway_request_id IS NOT NULL "
+                    "ORDER BY authorization_id"
+                ))
+            assert rows == [["gwa-first", 7], ["gwa-second", 11]]
+        finally:
+            instance.delete()

--- a/tests/test_gateway_trace_index_migration.py
+++ b/tests/test_gateway_trace_index_migration.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+import pytest
+
+from tests.deploy_script_harness import SCRIPT_FIXTURES, DeployScriptHarness, ScriptFixture
+from tests.test_spend_lease_migration import _ddls
+
+SCRIPT = "scripts/deploy/migrate_gateway_request_index.sh"
+
+
+@pytest.mark.parametrize(
+    "mode,exists,ready,old,expected,success",
+    [
+        ("--prepare", "0", "1", "1", ["CREATE NULL_FILTERED INDEX"], True),
+        ("--prepare", "1", "1", "1", [], True),
+        ("--prepare", "1", "0", "1", [], False),
+        ("--prepare", "garbled", "1", "1", [], False),
+        ("--retire-unique", "0", "0", "1", [], False),
+        ("--retire-unique", "1", "0", "1", [], False),
+        ("--retire-unique", "1", "1", "1", ["DROP INDEX"], True),
+        ("--retire-unique", "1", "1", "0", [], True),
+        ("--retire-unique", "1", "1", "garbled", [], False),
+        ("--bad-mode", "1", "1", "1", [], False),
+    ],
+)
+def test_trace_index_migration_preserves_data_and_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    mode: str, exists: str, ready: str, old: str,
+    expected: list[str], success: bool,
+) -> None:
+    monkeypatch.setitem(SCRIPT_FIXTURES, SCRIPT, ScriptFixture(
+        env={"GCP_PROJECT_ID": "test", "SPANNER_INSTANCE_ID": "test", "SPANNER_DATABASE_ID": "test"},
+        responses=(
+            (r"INDEX_STATE='READ_WRITE'", ready),
+            (r"INDEX_NAME='tr_gateway_authorization_by_trace_id'", exists),
+            (r"INDEX_NAME='tr_gateway_authorization_by_gateway_request_id'", old),
+        ),
+    ))
+    run = DeployScriptHarness(tmp_path).run(SCRIPT, args=(mode,))
+    assert (run.returncode == 0) is success, run.stderr
+    ddls = _ddls(run)
+    assert len(ddls) == len(expected)
+    for ddl, prefix in zip(ddls, expected, strict=True):
+        assert ddl.startswith(prefix)
+        assert "DROP TABLE" not in ddl
+    if mode == "--prepare":
+        assert not any("DROP" in ddl for ddl in ddls)

--- a/tests/test_gateway_trace_lookup.py
+++ b/tests/test_gateway_trace_lookup.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from trusted_router.storage import InMemoryStore
+from trusted_router.storage_models import AmbiguousGatewayRequestId, GatewayAuthorization
+from trusted_router.storage_postgres import PostgresStore
+from trusted_router.types import UsageType
+
+TRACE = "rlog_00112233445566778899aabbccddeeff"
+
+
+@pytest.mark.parametrize("backend", ["memory", "postgres"])
+@pytest.mark.parametrize("count", [0, 1, 2])
+def test_trace_lookup_never_silently_selects_one_of_multiple_calls(
+    backend: str, count: int,
+) -> None:
+    auths = [GatewayAuthorization(
+        id=f"gwa-{i}", workspace_id="test", key_hash="test-key", model_id="test/model",
+        provider="test", usage_type=UsageType.CREDITS, estimated_microdollars=1,
+        credit_reservation_id=None, gateway_request_id=TRACE,
+    ) for i in range(count)]
+    store: Any
+    if backend == "memory":
+        store = InMemoryStore()
+        store.api_keys.gateway_authorizations.update({auth.id: auth for auth in auths})
+    else:
+        def execute(sql: str, params: tuple[str, str]) -> Any:
+            assert "ORDER BY id LIMIT 2" in sql
+            assert params == ("gateway_authorization", TRACE)
+            return SimpleNamespace(fetchall=lambda: [(asdict(auth),) for auth in auths])
+
+        store = object.__new__(PostgresStore)
+        store._run_transaction = lambda fn: fn(SimpleNamespace(execute=execute))
+    if count == 2:
+        with pytest.raises(AmbiguousGatewayRequestId):
+            store.get_gateway_authorization_by_gateway_request_id(TRACE)
+    else:
+        result = store.get_gateway_authorization_by_gateway_request_id(TRACE)
+        assert (result.id if result else None) == (auths[0].id if auths else None)

--- a/tests/test_request_record_retention.py
+++ b/tests/test_request_record_retention.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import json
 from collections.abc import Iterator
 from pathlib import Path
@@ -193,6 +194,48 @@ def test_typed_authorize_avoids_generic_rows_and_replays_one_hold(
     assert len(database.gateway_authorizations) == 1
     assert database.gateway_authorizations[first.id]["terminal_at"] is None
     assert _generic_request_kinds(database) == set()
+
+
+def test_shared_trace_settles_each_call_once_and_releases_both_holds(
+    typed_request_store: tuple[Any, Any, Any],
+) -> None:
+    store, database, _bigtable = typed_request_store
+    workspace_id = "ws-shared-trace"
+    _seed_credit(store, workspace_id)
+    key = _make_key(store, workspace_id)
+    authorizations = []
+    for _ in range(2):
+        outcome, authorization = _authorize(
+            store, workspace_id=workspace_id, key_hash=key.hash,
+        )
+        assert outcome == AuthorizeOutcome.ACCEPTED and authorization is not None
+        authorizations.append(authorization)
+
+    client = _client()
+    for authorization in authorizations:
+        response = client.post(
+            "/v1/internal/gateway/settle", json=_settle_body(authorization.id),
+        )
+        assert response.status_code == 200, response.text
+    balances_before_replay = copy.deepcopy(database.typed)
+    for authorization in reversed(authorizations):
+        response = client.post(
+            "/v1/internal/gateway/settle", json=_settle_body(authorization.id),
+        )
+        assert response.status_code == 200, response.text
+        assert database.reservations[authorization.credit_reservation_id]["settled"]
+        assert database.settle_outbox[(authorization.id, "settle")]["status"] == "done"
+    assert database.typed == balances_before_replay
+    credit = database.typed[CREDIT_BALANCE_TABLE][(workspace_id, 0)]
+    assert credit["reserved"] == 0
+    assert credit["total_usage"] == sum(
+        database.reservations[authorization.credit_reservation_id]["actual_micro"]
+        for authorization in authorizations
+    )
+    assert len({
+        database.gateway_authorizations[authorization.id]["gateway_request_id"]
+        for authorization in authorizations
+    }) == 1
 
 
 def test_typed_settle_starts_bounded_replay_window_after_activity_commit(

--- a/tests/test_spend_lease_migration.py
+++ b/tests/test_spend_lease_migration.py
@@ -249,17 +249,17 @@ def test_arbitration_secondary_index_is_named_sparse_and_non_unique(
     _assert_arbitration_index_is_non_unique(fresh_ddls)
 
 
-def test_gateway_request_id_index_is_unique_sparse_and_exact(
+def test_gateway_request_id_index_is_nonunique_sparse_and_exact(
     fresh_ddls: list[str],
 ) -> None:
     index = _ddl_starting(
         fresh_ddls,
-        "CREATE UNIQUE NULL_FILTERED INDEX tr_gateway_authorization_by_gateway_request_id",
+        "CREATE NULL_FILTERED INDEX tr_gateway_authorization_by_trace_id",
     )
 
     assert _normalize_sql(index) == (
-        "CREATE UNIQUE NULL_FILTERED INDEX "
-        "tr_gateway_authorization_by_gateway_request_id "
+        "CREATE NULL_FILTERED INDEX "
+        "tr_gateway_authorization_by_trace_id "
         "ON tr_gateway_authorization (gateway_request_id)"
     )
 
@@ -292,7 +292,7 @@ def test_indexes_are_waited_until_read_write(fresh_ddls: list[str]) -> None:
 
     assert len(fresh_ddls) == 26
     for name in (
-        "tr_gateway_authorization_by_gateway_request_id",
+        "tr_gateway_authorization_by_trace_id",
         "spend_lease_scope_arbitration_by_authorization",
         "spend_lease_open_due",
     ):
@@ -311,7 +311,7 @@ def test_fresh_apply_reports_every_object_created(
     assert len(_ddls(run)) == 26
     for object_name in (
         *(f"tr_gateway_authorization.{name}" for name in AUTHORIZATION_COLUMNS),
-        "tr_gateway_authorization_by_gateway_request_id",
+        "tr_gateway_authorization_by_trace_id",
         "spend_lease_scope_arbitration",
         "spend_lease_scope_arbitration_by_authorization",
         "spend_lease_open",
@@ -336,7 +336,7 @@ def test_second_apply_is_idempotent_and_emits_no_ddl(
     assert _ddls(run) == []
     for object_name in (
         *(f"tr_gateway_authorization.{name}" for name in AUTHORIZATION_COLUMNS),
-        "tr_gateway_authorization_by_gateway_request_id",
+        "tr_gateway_authorization_by_trace_id",
         "spend_lease_scope_arbitration",
         "spend_lease_scope_arbitration_by_authorization",
         "spend_lease_open",

--- a/tests/test_stage_d_evidence_lookup.py
+++ b/tests/test_stage_d_evidence_lookup.py
@@ -12,7 +12,7 @@ from fastapi.testclient import TestClient
 from tests.fakes.spanner import make_fake_store
 from trusted_router.config import Settings
 from trusted_router.main import create_app
-from trusted_router.storage import InMemoryStore, configure_store
+from trusted_router.storage import STORE, InMemoryStore, configure_store
 from trusted_router.storage_gcp_codec import json_body
 from trusted_router.storage_gcp_spend_lease import authorization_typed_columns
 from trusted_router.storage_models import GatewayAuthorization
@@ -128,6 +128,21 @@ def test_evidence_lookup_requires_internal_gateway_token(
 
     assert response.status_code == 401
     assert response.json()["error"]["type"] == "unauthorized"
+
+
+def test_evidence_lookup_rejects_shared_parent_trace_instead_of_picking_a_call(
+    evidence_client: TestClient,
+) -> None:
+    database = STORE._database
+    first = next(iter(database.gateway_authorizations.values()))
+    second = dict(first, authorization_id="gwa-ffffffffffffffffffffffffffffffff")
+    database.gateway_authorizations[second["authorization_id"]] = second
+
+    response = evidence_client.get(_path(), headers=_headers())
+
+    assert response.status_code == 409
+    assert response.json()["error"]["type"] == "ambiguous_gateway_request_id"
+    assert "workspace_id" not in response.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Root cause
Responses web search creates multiple independently billable authorizations under one parent audit trace. The Stage D unique request-ID index rejected the second settlement. Its durable retries then repeatedly failed and timed out the scheduled drain.

## Repair
Prepare a nonunique sparse trace index, deploy bounded readers that reject ambiguous evidence with 409, then explicitly retire only the obsolete unique index. True authorization/reservation/idempotency constraints and all billing formulas remain unchanged. Add a two-phase migration and incident runbook.

## Verification
The ambiguous-evidence regression failed on old code and passes on the fix. A real local Spanner emulator reproduces the original unique violation and verifies both settlements and replay after migration. Focused suite: 54 passed, plus six backend lookup cases and the emulator test. Ruff and mypy pass. Full local suite is running; required CI must pass before merge.

Production preparation is complete; the old unique index has NOT yet been removed. Retirement and normal outbox replay follow only after all readers are deployed.