### PR TITLE
Pace partial operational analytics batches to reduce Spanner CPU

### DIFF
--- a/clickhouse/ingest_operational_outbox.py
+++ b/clickhouse/ingest_operational_outbox.py
@@ -866,6 +866,10 @@ def main() -> int:
             idle_delay = min(idle_delay * 2, 30.0)
         else:
             idle_delay = max(0.1, args.poll_seconds)
+            # A steady trickle must not turn partial batches into a busy loop.
+            # Full batches still drain immediately to catch up with a backlog.
+            if result.fetched < max(1, args.batch_size):
+                time.sleep(idle_delay)
 
 
 if __name__ == "__main__":

--- a/tests/test_operational_outbox_pacing.py
+++ b/tests/test_operational_outbox_pacing.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from clickhouse import ingest_operational_outbox as worker
+
+
+@pytest.mark.parametrize(
+    ("batches", "expected_sleeps"),
+    [
+        ([1, 1, 1], [2, 2, 2]),
+        ([0, 0, 1, 0, 0], [2, 4, 2, 2, 4]),
+        ([5, 5, 1], [2]),
+        ([0, 0, 0, 0, 0, 0], [2, 4, 8, 16, 30, 30]),
+    ],
+)
+@pytest.mark.parametrize("quarantined", [False, True])
+def test_worker_paces_partial_batches_without_delaying_full_backlogs(
+    monkeypatch: pytest.MonkeyPatch,
+    batches: list[int],
+    expected_sleeps: list[int],
+    quarantined: bool,
+) -> None:
+    sleeps: list[float] = []
+    pending = iter(batches)
+
+    def drain(*args: Any, **kwargs: Any) -> SimpleNamespace:
+        assert kwargs["batch_size"] == 5
+        fetched = next(pending)
+        return SimpleNamespace(
+            fetched=fetched,
+            inserted=0 if quarantined else fetched,
+            quarantined=fetched if quarantined else 0,
+            rows_per_second=1.0,
+            lag_seconds=0.0,
+        )
+
+    monkeypatch.setenv("CH_PASSWORD", "local-fake")
+    monkeypatch.setattr(sys, "argv", ["worker", "--batch-size", "5", "--poll-seconds", "2"])
+    monkeypatch.setattr(worker, "SpannerOperationalOutboxSource", lambda **_: object())
+    monkeypatch.setattr(worker, "ClickHouseOperationalWriter", lambda **_: object())
+    monkeypatch.setattr(worker, "sd_notify", lambda _: None)
+    monkeypatch.setattr(worker, "drain_once", drain)
+    monkeypatch.setattr(worker, "time", SimpleNamespace(sleep=sleeps.append))
+    with pytest.raises(StopIteration):
+        worker.main()
+    assert sleeps == expected_sleeps
+
+
+def test_once_does_not_wait_after_processing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CH_PASSWORD", "local-fake")
+    monkeypatch.setattr(sys, "argv", ["worker", "--once"])
+    monkeypatch.setattr(worker, "SpannerOperationalOutboxSource", lambda **_: object())
+    monkeypatch.setattr(worker, "ClickHouseOperationalWriter", lambda **_: object())
+    monkeypatch.setattr(worker, "sd_notify", lambda _: None)
+    monkeypatch.setattr(
+        worker, "drain_once",
+        lambda *_, **__: SimpleNamespace(
+            fetched=1, inserted=1, quarantined=0, rows_per_second=1.0, lag_seconds=0.0,
+        ),
+    )
+
+    def unexpected_sleep(_: float) -> None:
+        pytest.fail("one-shot drain must not sleep")
+
+    monkeypatch.setattr(worker, "time", SimpleNamespace(sleep=unexpected_sleep))
+    assert worker.main() == 0


### PR DESCRIPTION
Production query profiles after #1093 showed the operational outbox fetch becoming the largest query CPU consumer: 93-233 executions/minute at about 45-50 ms CPU each. The idle backoff never applied to a steady stream of small nonempty batches. Respect the existing two-second poll interval for partial batches, including quarantine-only batches; full backlogs still drain immediately, and idle backoff and one-shot behavior stay unchanged. No query, cursor, billing, retention, or alarm thresholds change.

Six new regressions failed against the previous loop and pass with this four-line fix. Tests cover steady trickles, full backlogs, idle/reset/cap behavior, quarantined rows, and one-shot execution. Focused analytics suite: 92 passed with localhost sockets enabled; ruff and mypy pass. Full local suite is running. Deploy only the reviewed worker file and restart the operational ingester after CI, keeping it separate from the ongoing #1097 billing rollout.