### PR TITLE
alerts: exclude CreateSession from the Spanner any-method latency condition

### DIFF
--- a/scripts/deploy/spanner-alerts/latency.yaml
+++ b/scripts/deploy/spanner-alerts/latency.yaml
@@ -21,8 +21,11 @@ conditions:
       trigger:
         count: 1
   - displayName: "Any request p99 exceeds 3 seconds for 10 minutes"
+    # CreateSession excursions of 2.7-2.9 s track Cloud Run revision rollouts
+    # (155 calls in 48 h on 2026-09-04/05), not Spanner health; Commit keeps its
+    # own 1.5 s condition above.
     conditionThreshold:
-      filter: 'resource.type = "spanner_instance" AND resource.labels.instance_id = "trusted-router-nam6" AND metric.type = "spanner.googleapis.com/api/request_latencies"'
+      filter: 'resource.type = "spanner_instance" AND resource.labels.instance_id = "trusted-router-nam6" AND metric.type = "spanner.googleapis.com/api/request_latencies" AND metric.labels.method != "CreateSession"'
       aggregations:
         - alignmentPeriod: 300s
           perSeriesAligner: ALIGN_PERCENTILE_99

--- a/tests/test_spanner_reliability_deploy.py
+++ b/tests/test_spanner_reliability_deploy.py
@@ -132,3 +132,19 @@ def test_cross_project_backup_uses_an_isolated_project() -> None:
     assert 'DR_PROJECT_ID="${TR_SPANNER_DR_PROJECT_ID:-trustedrouter-dr}"' in reliability
     assert "projects/trustedrouter-dr/instances/trusted-router-backups" in workflow
     assert "--service-account=\"$BACKUP_SERVICE_ACCOUNT_EMAIL\"" in reliability
+
+
+def test_latency_any_method_condition_excludes_createsession() -> None:
+    """CreateSession p99 excursions track revision rollouts, not Spanner health.
+
+    The Commit condition keeps its own 1.5 s threshold; the any-method 3 s
+    condition must not page on session creation during a rollout.
+    """
+    policy = yaml.safe_load(
+        (DEPLOY / "spanner-alerts" / "latency.yaml").read_text(encoding="utf-8")
+    )
+    by_name = {c["displayName"]: c for c in policy["conditions"]}
+    any_method = by_name["Any request p99 exceeds 3 seconds for 10 minutes"]
+    assert 'metric.labels.method != "CreateSession"' in any_method["conditionThreshold"]["filter"]
+    commit = by_name["Commit p99 exceeds 1.5 seconds for 10 minutes"]
+    assert 'metric.labels.method = "Commit"' in commit["conditionThreshold"]["filter"]


### PR DESCRIPTION
The "TR Spanner: request latency" policy's any-method condition (p99 > 3 s for 10 min) opened twice on 2026-09-05 (15:47 and 16:50 UTC) on CreateSession excursions of 2.7 to 2.9 s that coincide with Cloud Run revision rollouts, not with Spanner health (155 such calls in 48 hours). The Commit condition, which caught the real 14.5 s convoy at 16:44, keeps its own 1.5 s threshold unchanged.

Authored by Fable directly (codex is at its usage cap until 2026-09-07 02:38 UTC); the deploy-policy test asserts the exclusion and dropping it turns the test red. Applied to production with `scripts/deploy/spanner_reliability.sh` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)