### PR TITLE
Improve status history, monitor visibility, and leaderboard evidence

### DIFF
--- a/clickhouse/build_public_snapshots.py
+++ b/clickhouse/build_public_snapshots.py
@@ -11,6 +11,7 @@ import datetime as dt
 import json
 import os
 import subprocess
+import sys
 from typing import Any
 
 from trusted_router.apps import aggregate_apps
@@ -29,6 +30,7 @@ PER_PROVIDER_LIMIT = 500
 STATUS_SAMPLES_PER_DIMENSION = 30
 STATUS_LIVE_SAMPLE_LIMIT = 5_000
 STATUS_HOUR_ROLLUP_LIMIT = 5_000
+STATUS_MONTH_ROLLUP_LIMIT = 5_000
 VIDEO_SAMPLE_LIMIT = 5_000
 CLIENT_ROLLUP_LIMIT = 100_000
 # Published rows and calibration rows are fetched by separate queries, each
@@ -91,10 +93,11 @@ def _dataclass_rows(cls: type[Any], output: str) -> list[Any]:
 
 
 def _clickhouse_string_array(values: list[str]) -> str:
-    return "[" + ",".join(
-        "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
-        for value in values
-    ) + "]"
+    return (
+        "["
+        + ",".join("'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'" for value in values)
+        + "]"
+    )
 
 
 def _samples(password: str) -> list[ProviderBenchmarkSample]:
@@ -113,6 +116,36 @@ FROM
 WHERE provider_rank <= 500
 ORDER BY created_at DESC, id DESC
 LIMIT 10000
+FORMAT JSONEachRow
+""",
+    )
+    return _dataclass_rows(ProviderBenchmarkSample, output)
+
+
+def _evidence_samples(password: str) -> list[ProviderBenchmarkSample]:
+    # Equal opportunity for quiet routes without extra paid probes. Keep
+    # source-specific slots so long throughput calls cannot displace uptime.
+    output = _query(
+        password,
+        """
+SELECT * EXCEPT (ingest_version, route_rank, provider_rank)
+FROM (
+  SELECT *, row_number() OVER (
+    PARTITION BY provider ORDER BY route_rank, created_at DESC, id DESC
+  ) AS provider_rank
+  FROM (
+    SELECT *, row_number() OVER (
+      PARTITION BY provider, model, source ORDER BY created_at DESC, id DESC
+    ) AS route_rank
+    FROM provider_benchmark_samples FINAL
+    WHERE created_at >= now64(3) - INTERVAL 7 DAY
+  )
+  WHERE route_rank <= 30
+)
+WHERE provider_rank <= 500
+ORDER BY provider_rank, created_at DESC, id DESC
+LIMIT 10000
+SETTINGS max_execution_time = 15, max_memory_usage = 268435456, max_threads = 2
 FORMAT JSONEachRow
 """,
     )
@@ -168,17 +201,19 @@ FORMAT JSONEachRow
         SyntheticRollup,
         _query(
             password,
-            """
+            f"""
 SELECT * EXCEPT ingest_version
 FROM synthetic_status_rollups FINAL
-WHERE period = 'hour'
-  AND period_start >= toStartOfHour(now()) - INTERVAL 48 HOUR
+WHERE (period = 'hour' AND period_start >= toStartOfHour(now()) - INTERVAL 48 HOUR)
+   OR (period = 'month' AND period_start >= toStartOfMonth(now()) - INTERVAL 23 MONTH)
 ORDER BY period_start DESC, id DESC
-LIMIT 5000
+LIMIT {STATUS_HOUR_ROLLUP_LIMIT + STATUS_MONTH_ROLLUP_LIMIT}
 FORMAT JSONEachRow
 """,
         ),
     )
+    if len(rollups) >= STATUS_HOUR_ROLLUP_LIMIT + STATUS_MONTH_ROLLUP_LIMIT:
+        raise RuntimeError("public status rollup limit reached; refusing partial history")
     return samples, rollups
 
 
@@ -267,6 +302,7 @@ def build_snapshots(
     video_samples: list[ProviderBenchmarkSample] | None = None,
     status_samples: list[SyntheticProbeSample] | None = None,
     status_rollups: list[SyntheticRollup] | None = None,
+    evidence_samples: list[ProviderBenchmarkSample] | None = None,
     client_reliability_rows: list[dict[str, Any]] | None = None,
     client_reliability_signals: dict[str, Any] | None = None,
     client_reliability_all_traffic_rows: list[dict[str, Any]] | None = None,
@@ -283,14 +319,29 @@ def build_snapshots(
             "generated_at": generated_at,
             "sample_window_count": len(samples),
             "sample_limit": SAMPLE_LIMIT,
-            "window_label": (
-                f"rolling benchmark set of up to {SAMPLE_LIMIT:,} samples"
-            ),
+            "window_label": (f"rolling benchmark set of up to {SAMPLE_LIMIT:,} samples"),
             "rank_minimums": {
                 "model_availability_samples": 10,
                 "provider_availability_samples": 30,
                 "ttft_samples": 3,
             },
+        }
+    )
+    evidence = aggregate_leaderboard(
+        evidence_samples or [],
+        min_samples=1,
+        model_rank_min_samples=10,
+        provider_rank_min_samples=30,
+        rank_min_ttft_samples=3,
+    )
+    evidence.update(
+        {
+            "generated_at": generated_at,
+            "sample_window_count": len(evidence_samples or []),
+            "sample_limit": SAMPLE_LIMIT,
+            "window": "7d",
+            "window_label": "7-day evidence sample, balanced across providers and models",
+            "rank_minimums": leaderboard["rank_minimums"],
         }
     )
     apps = aggregate_apps(samples)
@@ -311,9 +362,7 @@ def build_snapshots(
             "generated_at": generated_at,
             "sample_window_count": len(video_rows),
             "sample_limit": VIDEO_SAMPLE_LIMIT,
-            "window_label": (
-                f"rolling video benchmark set of up to {VIDEO_SAMPLE_LIMIT:,} jobs"
-            ),
+            "window_label": (f"rolling video benchmark set of up to {VIDEO_SAMPLE_LIMIT:,} jobs"),
         }
     )
     status_inputs = {
@@ -334,6 +383,7 @@ def build_snapshots(
     )
     return {
         "leaderboard": leaderboard,
+        "leaderboard_evidence": evidence,
         "apps": apps,
         "video_leaderboard": video,
         "status_inputs": status_inputs,
@@ -348,18 +398,28 @@ def main() -> int:
     now = dt.datetime.now(dt.UTC)
     generated_at = now.isoformat(timespec="milliseconds").replace("+00:00", "Z")
     status_samples, status_rollups = _status_inputs(password)
+    evidence_rows = None
+    try:
+        evidence_rows = _evidence_samples(password)
+    except RuntimeError:
+        # A bounded research view must not stop current health publication.
+        # Leave its last snapshot untouched so the normal freshness check expires it.
+        print(json.dumps({"event": "leaderboard_evidence_build_failed"}), file=sys.stderr)
     snapshots = build_snapshots(
         _samples(password),
         generated_at=generated_at,
         video_samples=_video_samples(password),
         status_samples=status_samples,
         status_rollups=status_rollups,
+        evidence_samples=evidence_rows,
         client_reliability_rows=_client_reliability_rows(password, now=now),
         client_reliability_signals=_client_reliability_signals(password, now=now),
         client_reliability_all_traffic_rows=_client_reliability_rows(
             password, now=now, scope="fleet_all"
         ),
     )
+    if evidence_rows is None:
+        snapshots.pop("leaderboard_evidence", None)
     rows = [
         {
             "name": name,

--- a/docs/status-leaderboard-evidence.md
+++ b/docs/status-leaderboard-evidence.md
@@ -1,0 +1,59 @@
+# Public status and leaderboard evidence
+
+## Status history
+
+Monthly views read persisted `period=month` rollups for the current month and
+the preceding 23 months. They retain the histogram buckets, so historical
+percentiles are merged from observations, not averaged from other percentiles.
+The public snapshot combines those records with 48 hours of hourly rollups and
+the bounded live sample. No historical samples are invented or rewritten.
+
+Monthly reads have a 5,000-row ceiling and reject a truncated result rather
+than publishing partial history. Monitor cardinality before raising that limit.
+
+## Monitoring visibility
+
+`TR_SYNTHETIC_STATUS_PROBE_TYPES` declares transaction probes run by the separate
+monitor plane. It does not enable probes or grant permissions. The GCP public
+surface declares authorize, settle, fallback, Chat PONG and Responses PONG
+without receiving their API key or billing token.
+
+Declared probes remain visible without credentials. Missing fresh evidence
+degrades the coverage banner; it does not fabricate requests or change the
+router-core uptime denominator. Provider-only failures remain separate from
+router-core availability.
+
+## Leaderboard windows
+
+The default recent sample keeps its existing 24-hour measurement window and
+ranking floors: 10 model samples, 30 provider samples, and 3 TTFT measurements.
+`/leaderboard?window=7d` is a separately labeled evidence view, not today's
+availability. The worker samples at most 30 observations per provider/model/source,
+500 per provider, and 10,000 overall. Selection does not filter out failures.
+Random probe scheduling and probe counts are unchanged.
+
+The seven-day query is worker-only, with two threads, a 256 MiB query-memory
+ceiling and a 15-second execution limit. Failure emits
+`leaderboard_evidence_build_failed`, leaves its prior snapshot to expire, and
+does not prevent the current status or recent leaderboard from publishing.
+Public requests never scan seven days of raw telemetry.
+
+Configuration-only routes are visible but unranked, with unknown availability
+when there are no eligible attempts. Explicit model-validation errors are kept
+separate from actual 429/5xx failures. Generic "service unavailable" text must
+not reclassify provider downtime as a missing model. Reasoning-first families
+get bounded completion headroom across hosts; no automatic retry hides failures.
+
+## Rollout checks
+
+1. Publish the committed public snapshot worker using the reviewed deployment
+   helper. Its rollback gate now also requires a fresh `leaderboard_evidence`.
+2. Roll out the public application and the separately scheduled probe image.
+   A frontend-only rollout does not update probe request budgets.
+3. Check monthly HTML and JSON for every month actually stored, plus histogram
+   percentiles. Verify the status components without adding observer credentials.
+4. Check recent and seven-day pages separately, including sample counts,
+   configuration-only rows, pagination, filters and mobile layout.
+5. Check subsequent probe results. Retired models and provider account/region
+   restrictions require explicit catalog or entitlement repairs; do not relabel
+   them as successful probes or promise a zero error rate.

--- a/frontend/src/leaderboard.ts
+++ b/frontend/src/leaderboard.ts
@@ -1,0 +1,96 @@
+(() => {
+  const root = document.querySelector<HTMLElement>('[data-leaderboard]');
+  if (!root) return;
+  const controls = root.querySelector<HTMLElement>('[data-lb-controls]')!;
+  const search = root.querySelector<HTMLInputElement>('[data-lb-search]')!;
+  const provider = root.querySelector<HTMLSelectElement>('[data-lb-provider]')!;
+  const sort = root.querySelector<HTMLSelectElement>('[data-lb-sort]')!;
+  const evidence = root.querySelector<HTMLSelectElement>('[data-lb-evidence]')!;
+  const tabs = Array.from(root.querySelectorAll<HTMLButtonElement>('[data-lb-tab]'));
+  const panels = Array.from(root.querySelectorAll<HTMLElement>('[data-lb-panel]'));
+  const previous = root.querySelector<HTMLButtonElement>('[data-lb-prev]')!;
+  const next = root.querySelector<HTMLButtonElement>('[data-lb-next]')!;
+  const count = root.querySelector<HTMLOutputElement>('[data-lb-count]')!;
+  const params = new URLSearchParams(location.search);
+  let view = params.get('view') === 'models' ? 'models' : 'providers';
+  let page = 0;
+  const pageSize = 25;
+  search.value = params.get('q') || '';
+  for (const [name, select] of [['provider', provider], ['sort', sort], ['evidence', evidence]] as const) {
+    const value = params.get(name);
+    if (value !== null && Array.from(select.options).some(option => option.value === value)) select.value = value;
+  }
+  const numeric = (row: HTMLElement, key: string): number | null => {
+    const value = row.dataset[key];
+    return value !== undefined && value !== '' && Number.isFinite(Number(value)) ? Number(value) : null;
+  };
+  const update = () => {
+    const terms = search.value.toLowerCase().trim().split(/\s+/).filter(Boolean);
+    for (const panel of panels) {
+      panel.hidden = panel.dataset.lbPanel !== view;
+      panel.setAttribute('role', 'tabpanel');
+      if (panel.hidden) continue;
+      const rows = Array.from(panel.querySelectorAll<HTMLTableRowElement>('[data-lb-row]'));
+      const matches = rows.filter(row => {
+        row.hidden = true;
+        return terms.every(term => row.dataset.search!.toLowerCase().includes(term))
+          && (!provider.value || row.dataset.provider === provider.value)
+          && (evidence.value !== 'qualified' || row.dataset.qualified === 'yes')
+          && (evidence.value !== 'warming' || row.dataset.qualified === 'no')
+          && (evidence.value !== 'config' || Number(row.dataset.config) > 0);
+      });
+      const direction = ['throughput', 'completion', 'samples'].includes(sort.value) ? -1 : 1;
+      matches.sort((a, b) => {
+        const left = numeric(a, sort.value), right = numeric(b, sort.value);
+        if (left === null && right !== null) return 1;
+        if (left !== null && right === null) return -1;
+        return ((left ?? 0) - (right ?? 0)) * direction || a.dataset.search!.localeCompare(b.dataset.search!);
+      });
+      page = Math.min(page, Math.max(0, Math.ceil(matches.length / pageSize) - 1));
+      const start = page * pageSize;
+      const tbody = panel.querySelector('tbody')!;
+      for (const [index, row] of matches.entries()) {
+        tbody.append(row);
+        row.hidden = index < start || index >= start + pageSize;
+      }
+      count.value = matches.length ? `${start + 1}-${Math.min(start + pageSize, matches.length)} of ${matches.length} ${view}` : `0 ${view}`;
+      panel.querySelector<HTMLElement>('[data-lb-empty]')!.hidden = matches.length > 0 || rows.length === 0;
+      previous.disabled = page === 0;
+      next.disabled = start + pageSize >= matches.length;
+    }
+    for (const tab of tabs) {
+      const selected = tab.dataset.lbTab === view;
+      tab.setAttribute('aria-selected', String(selected));
+      tab.tabIndex = selected ? 0 : -1;
+    }
+    const url = new URL(location.href);
+    for (const [key, value] of [['view', view === 'models' ? view : ''], ['q', search.value], ['provider', provider.value], ['sort', sort.value === 'rank' ? '' : sort.value], ['evidence', evidence.value === 'all' ? '' : evidence.value]]) {
+      if (value) url.searchParams.set(key, value); else url.searchParams.delete(key);
+    }
+    history.replaceState(null, '', url);
+    root.querySelectorAll<HTMLAnchorElement>('[data-lb-window]').forEach(link => {
+      const target = new URL(link.href);
+      const windowValue = target.searchParams.get('window');
+      target.search = url.search;
+      if (windowValue) target.searchParams.set('window', windowValue); else target.searchParams.delete('window');
+      link.href = target.href;
+    });
+  };
+  for (const input of [search, provider, sort, evidence]) {
+    input.addEventListener(input === search ? 'input' : 'change', () => { page = 0; update(); });
+  }
+  for (const [index, tab] of tabs.entries()) {
+    tab.addEventListener('click', () => { view = tab.dataset.lbTab!; page = 0; update(); });
+    tab.addEventListener('keydown', event => {
+      if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+      event.preventDefault();
+      const target = event.key === 'Home' ? tabs[0] : event.key === 'End' ? tabs[tabs.length - 1] : tabs[(index + (event.key === 'ArrowRight' ? 1 : tabs.length - 1)) % tabs.length];
+      target.click(); target.focus();
+    });
+  }
+  previous.addEventListener('click', () => { page--; update(); });
+  next.addEventListener('click', () => { page++; update(); });
+  controls.hidden = false;
+  root.querySelector<HTMLElement>('[data-lb-pagination]')!.hidden = false;
+  update();
+})();

--- a/scripts/deploy/public_surface.sh
+++ b/scripts/deploy/public_surface.sh
@@ -449,6 +449,9 @@ ENV_VARS=(
   "TR_GCP_PROJECT_ID=$(legacy_env_required TR_GCP_PROJECT_ID)"
   "TR_REGIONS=$(legacy_env_required TR_REGIONS)"
   "TR_PRIMARY_REGION=$(legacy_env_required TR_PRIMARY_REGION)"
+  # Capability metadata only. The public service never gets the probe key
+  # or internal billing token, but must display the separately scheduled jobs.
+  "TR_SYNTHETIC_STATUS_PROBE_TYPES=gateway_authorize,gateway_settle,provider_fallback,openai_sdk_pong,responses_pong"
   "TR_STORAGE_BACKEND=$(legacy_env_required TR_STORAGE_BACKEND)"
   "TR_SPANNER_INSTANCE_ID=$(legacy_env_required TR_SPANNER_INSTANCE_ID)"
   "TR_SPANNER_DATABASE_ID=$(legacy_env_required TR_SPANNER_DATABASE_ID)"

--- a/scripts/deploy/sync_public_analytics_snapshots.sh
+++ b/scripts/deploy/sync_public_analytics_snapshots.sh
@@ -125,12 +125,12 @@ gc compute ssh "$NAME" \
     . /etc/tr-clickhouse-ingest.env
     set +a
     count=\$(/usr/bin/clickhouse-client --user tr --password \"\$CH_PASSWORD\" \
-      --database tr --query \"SELECT uniqExact(name) FROM public_analytics_snapshots FINAL WHERE generated_at >= now() - INTERVAL 10 MINUTE AND name IN ('\''leaderboard'\'', '\''apps'\'', '\''video_leaderboard'\'', '\''status_inputs'\'') FORMAT TSVRaw\")
-    if [ \"\$count\" != 4 ]; then
+      --database tr --query \"SELECT uniqExact(name) FROM public_analytics_snapshots FINAL WHERE generated_at >= now() - INTERVAL 10 MINUTE AND name IN ('\''leaderboard'\'', '\''leaderboard_evidence'\'', '\''apps'\'', '\''video_leaderboard'\'', '\''status_inputs'\'') FORMAT TSVRaw\")
+    if [ \"\$count\" != 5 ]; then
       rollback
       exit 1
     fi
     rm -rf \"\$previous\" \"\$previous_builder\" \"\$stage\"
   '"
 
-log "public analytics snapshot worker is current and publishing all four products"
+log "public analytics snapshot worker is current and publishing all five products"

--- a/src/trusted_router/config.py
+++ b/src/trusted_router/config.py
@@ -1159,6 +1159,9 @@ class Settings(BaseSettings):
     # status page reads as "we are not sure our own service works".
     # Defaults True (the GCP shape); standalone deployments set it False.
     synthetic_image_probe_enabled: bool = True
+    # Public readers describe the monitor plane, not their own credentials.
+    # Explicit expectations also keep a stopped probe visible as stale/down.
+    synthetic_status_probe_types: str = ""
     # Explicit control-plane /health URL attached to the canonical
     # target. Standalone deployments set this to their own control plane
     # (e.g. the App Runner URL) so control_plane_health measures the
@@ -1273,6 +1276,21 @@ class Settings(BaseSettings):
     def production_is_fail_closed(self) -> Settings:
         environment = self.environment.lower()
         surface = self.service_surface
+        public_probe_types = {
+            value.strip() for value in self.synthetic_status_probe_types.split(",") if value.strip()
+        }
+        if public_probe_types - {
+            "gateway_authorize",
+            "gateway_settle",
+            "gateway_authorize_settle",
+            "provider_fallback",
+            "openai_sdk_pong",
+            "responses_pong",
+        }:
+            raise ValueError(
+                "TR_SYNTHETIC_STATUS_PROBE_TYPES contains an unknown transaction probe"
+            )
+        self.synthetic_status_probe_types = ",".join(sorted(public_probe_types))
         if self.attribution_cookie_key and self.attribution_cookie_secret:
             raise ValueError(
                 "TR_ATTRIBUTION_COOKIE_KEY and TR_ATTRIBUTION_COOKIE_SECRET must not both be set"

--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -3648,9 +3648,8 @@ def public_leaderboard_html(settings: Settings, snapshot: dict[str, object]) -> 
             title="LLM Provider & Model Speed Leaderboard | TrustedRouter",
             heading="Provider & model performance",
             description=(
-                "Measured time-to-first-token, effective throughput, and uptime for every "
-                "LLM provider and model TrustedRouter routes to — "
-                "continuously sampled, not vendor-claimed."
+                "First-token latency, completion rate and effective throughput from real "
+                "requests across TrustedRouter providers and models."
             ),
             page_kind="leaderboard",
             snapshot=snapshot,

--- a/src/trusted_router/data/provider_check_contract.json
+++ b/src/trusted_router/data/provider_check_contract.json
@@ -229,7 +229,7 @@
     "model_id_pattern": "^[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._/-]*$",
     "owner_pattern": "^[a-z0-9][a-z0-9._-]*$"
   },
-  "contract_version": "c045dbaea94b324b61e345a5e240e69c89e9552c78d2d13574d64596d3855f19",
+  "contract_version": "abf10fb4e4b68f1e188f87c1dd6d7bde6ae3e8b82a48eb9bb7ef8cff12966faf",
   "decision_tables": [
     {
       "max_tokens": 512,
@@ -346,9 +346,9 @@
       "provider": "anthropic"
     },
     {
-      "max_tokens": 16,
+      "max_tokens": 512,
       "model": "openai/gpt-5.1",
-      "omits_temperature": false,
+      "omits_temperature": true,
       "provider": "generic"
     },
     {
@@ -3795,7 +3795,7 @@
           "status": null
         },
         "name": "unsupported_message:does not exist",
-        "result": "unsupported_route"
+        "result": "provider_error"
       },
       {
         "input": {
@@ -3805,7 +3805,7 @@
           "status": null
         },
         "name": "unsupported_message:does not support",
-        "result": "unsupported_route"
+        "result": "provider_error"
       },
       {
         "input": {
@@ -3815,7 +3815,7 @@
           "status": null
         },
         "name": "unsupported_message:invalid model",
-        "result": "unsupported_route"
+        "result": "provider_error"
       },
       {
         "input": {
@@ -3825,7 +3825,7 @@
           "status": null
         },
         "name": "unsupported_message:model does not exist",
-        "result": "unsupported_route"
+        "result": "provider_error"
       },
       {
         "input": {
@@ -3835,7 +3835,7 @@
           "status": null
         },
         "name": "unsupported_message:model not found",
-        "result": "unsupported_route"
+        "result": "provider_error"
       },
       {
         "input": {
@@ -3845,7 +3845,7 @@
           "status": null
         },
         "name": "unsupported_message:model_not_found",
-        "result": "unsupported_route"
+        "result": "provider_error"
       },
       {
         "input": {
@@ -3855,7 +3855,7 @@
           "status": null
         },
         "name": "unsupported_message:no endpoint",
-        "result": "unsupported_route"
+        "result": "provider_error"
       },
       {
         "input": {
@@ -3865,7 +3865,7 @@
           "status": null
         },
         "name": "unsupported_message:no route",
-        "result": "unsupported_route"
+        "result": "provider_error"
       },
       {
         "input": {
@@ -3875,7 +3875,7 @@
           "status": null
         },
         "name": "unsupported_message:no such model",
-        "result": "unsupported_route"
+        "result": "provider_error"
       },
       {
         "input": {
@@ -3885,7 +3885,7 @@
           "status": null
         },
         "name": "unsupported_message:not authorized",
-        "result": "unsupported_route"
+        "result": "provider_error"
       },
       {
         "input": {
@@ -3895,7 +3895,7 @@
           "status": null
         },
         "name": "unsupported_message:not available",
-        "result": "unsupported_route"
+        "result": "provider_error"
       },
       {
         "input": {
@@ -3905,7 +3905,7 @@
           "status": null
         },
         "name": "unsupported_message:not enabled",
-        "result": "unsupported_route"
+        "result": "provider_error"
       },
       {
         "input": {
@@ -3915,7 +3915,7 @@
           "status": null
         },
         "name": "unsupported_message:not permitted",
-        "result": "unsupported_route"
+        "result": "provider_error"
       },
       {
         "input": {
@@ -3925,7 +3925,7 @@
           "status": null
         },
         "name": "unsupported_message:not supported",
-        "result": "unsupported_route"
+        "result": "provider_error"
       },
       {
         "input": {
@@ -3935,7 +3935,7 @@
           "status": null
         },
         "name": "unsupported_message:unavailable",
-        "result": "unsupported_route"
+        "result": "provider_error"
       },
       {
         "input": {
@@ -3945,7 +3945,7 @@
           "status": null
         },
         "name": "unsupported_message:unknown model",
-        "result": "unsupported_route"
+        "result": "provider_error"
       },
       {
         "input": {
@@ -3955,7 +3955,7 @@
           "status": null
         },
         "name": "unsupported_message:unsupported",
-        "result": "unsupported_route"
+        "result": "provider_error"
       },
       {
         "input": {
@@ -4328,7 +4328,7 @@
     "leaderboard._excluded_from_uptime": "6e673fe96aa8f6e317a2db774aa9f46de1a3c38ba958245e3d4e1527f2eb61a5",
     "leaderboard._percentile": "f400388aa9334b49eef0e7005a79478c39c5c7868c2b0a6a3909b1f443f95742",
     "leaderboard._sort_key": "ce505ca4b7d577416f080b19c67feb6791f7f3e446374677e402f5f8a10891b4",
-    "leaderboard.aggregate_leaderboard": "773c03374c2209a5bd971650658ca2deb722236969e79d51489ecd3330a5f0dd",
+    "leaderboard.aggregate_leaderboard": "650cbe204f0fd8302030fa7cb1929cb44816b3205f4f27e801b6b4f4d979257d",
     "probes._chat_text": "d93e2345277c7fc9f2f201a308768f3cc42b2d53a9715a5cfe7801e3a0f2a3bb",
     "probes._elapsed_ms_with_clock": "ffe5c0dcede88715e77c5e15672aee78b2b3eb40731a98cbce277642d82a22a4",
     "probes._first_int": "29a2c84649a74c53afb4bfe4d017f9b799908bcd08704a26d1e4d2b7ac46c64a",
@@ -4336,9 +4336,9 @@
     "probes._pong_matches": "998237bb5709cb6804b12310face8e43876dd189fa179eed2802df8871716b0b",
     "probes._response_error": "b99b11a62e9d331e655f65b612fb6dbab94885c3accb3dd30989311baa469d13",
     "probes._responses_text": "99429cf72be3c5cd8dadd9569a08bfe1c17a6c42318309a376f4bf12d31bf1fa",
-    "probes._rotation_error_type": "54584b9ec26edb80f372d63f7b3a08916b1947b99b632e009a6b46e442ff3a76",
-    "probes._rotation_max_tokens": "99b68643eeec2f398dae3a920eea77bdf04644884e015c61ae01e57d0a19653e",
-    "probes._rotation_omits_temperature": "cd342f2c4d36ce49f57acad9b8a21b7515ebbbdeec42e53b7cc514b827c04980",
+    "probes._rotation_error_type": "1847553b85e456bf3b73b9aac0752f0a8340094e06bda4837e20dd8bc4a22b44",
+    "probes._rotation_max_tokens": "54ae8b8d5204212bb00401c7886ec3ae97790d103418829147c45bc8483698e2",
+    "probes._rotation_omits_temperature": "fb885a166e3411caf17a956362426bd672ad8a74a9beb15baa627d8a4a9df758",
     "probes._sse_line_error": "bc5e36f9addbf54b9f4045d0817d41e4818a9e78de53769be58e36cc3eee5b33",
     "probes._sse_line_finish_reason": "90dfa40b8825eb4346522c1537f4a118feaa8c80e7f7b163883933748d096144",
     "probes._sse_line_has_content": "5e5e660c7a34a0f8ab529fc0462b9972a2b973723c05e4025c45bfa4c0201d64",

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -190,7 +190,7 @@ STATUS_RAW_SAMPLE_LIMIT_PER_DAY = 35_000
 STATUS_LIVE_SAMPLE_LIMIT = 500
 STATUS_HOUR_ROLLUP_LIMIT = 5_000
 STATUS_DAY_ROLLUP_LIMIT = 25_000
-STATUS_MONTH_ROLLUP_LIMIT = 50
+STATUS_MONTH_ROLLUP_LIMIT = 5_000
 STATUS_ROLLUP_RETENTION_MONTHS = 24
 STATUS_RESPONSE_CACHE_SECONDS = 60
 STATUS_RESPONSE_STALE_SECONDS = 600
@@ -1691,16 +1691,21 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
 
     @public_html_route("/leaderboard")
     async def leaderboard_page(request: Request, background_tasks: BackgroundTasks) -> Response:
-        _ = request
+        window = request.query_params.get("window", "24h")
+        if window not in {"24h", "7d"}:
+            return JSONResponse(
+                {"error": {"type": "bad_request", "message": "window must be 24h or 7d"}},
+                status_code=400,
+            )
         return await _cached_public_response(
             settings,
-            key="leaderboard:page",
+            key=f"leaderboard:page:{window}",
             media_type="text/html",
             ttl_seconds=LEADERBOARD_RESPONSE_CACHE_SECONDS,
             stale_seconds=LEADERBOARD_RESPONSE_STALE_SECONDS,
             background_tasks=background_tasks,
             build=lambda: public_leaderboard_html(
-                settings, _leaderboard_snapshot(settings)
+                settings, _leaderboard_snapshot(settings, window=window)
             ).encode(),
         )
 
@@ -2416,7 +2421,14 @@ def _status_history_page_html(
     )
 
 
-def _leaderboard_snapshot(settings: Settings) -> dict[str, Any]:
+_LEADERBOARD_EVIDENCE_CACHE: tuple[float, dict[str, Any]] | None = None
+
+
+def _leaderboard_snapshot(settings: Settings, *, window: str = "24h") -> dict[str, Any]:
+    if window == "7d":
+        return _leaderboard_evidence_snapshot(settings)
+    if window != "24h":
+        raise ValueError("unsupported leaderboard window")
     global _LEADERBOARD_CACHE
     now = time.monotonic()
     if settings.environment != "test" and _LEADERBOARD_CACHE is not None:
@@ -2464,6 +2476,39 @@ def _leaderboard_snapshot(settings: Settings) -> dict[str, Any]:
         raise
     if settings.environment != "test":
         _LEADERBOARD_CACHE = (now, payload)
+    return payload
+
+
+def _leaderboard_evidence_snapshot(settings: Settings) -> dict[str, Any]:
+    global _LEADERBOARD_EVIDENCE_CACHE
+    now = time.monotonic()
+    if settings.environment != "test" and _LEADERBOARD_EVIDENCE_CACHE is not None:
+        cached_at, cached = _LEADERBOARD_EVIDENCE_CACHE
+        if now - cached_at < LEADERBOARD_SNAPSHOT_CACHE_SECONDS:
+            return cached
+    payload = None
+    if settings.environment != "test":
+        try:
+            payload = _precomputed_public_analytics_snapshot("leaderboard_evidence")
+        except Exception as exc:
+            _log_public_analytics_snapshot_read_failure("leaderboard_evidence", exc)
+            if _LEADERBOARD_EVIDENCE_CACHE is not None:
+                return _LEADERBOARD_EVIDENCE_CACHE[1]
+    if payload is None:
+        # Never add a seven-day raw scan to the public request path. A worker
+        # that has not published yet is honestly shown as warming.
+        payload = aggregate_leaderboard([], min_samples=LEADERBOARD_MIN_SAMPLES)
+        payload.update(
+            {
+                "generated_at": utcnow().isoformat().replace("+00:00", "Z"),
+                "sample_limit": LEADERBOARD_SAMPLE_LIMIT,
+                "sample_window_count": 0,
+                "window_label": "7-day evidence sample, awaiting publication",
+            }
+        )
+    payload = {**payload, "window": "7d"}
+    if settings.environment != "test":
+        _LEADERBOARD_EVIDENCE_CACHE = (now, payload)
     return payload
 
 
@@ -2962,6 +3007,7 @@ def _status_rollups(window: str) -> list[Any]:
                 since=_hour_rollup_since(now, hours=48),
                 limit=STATUS_HOUR_ROLLUP_LIMIT,
             ),
+            *_status_rollups("monthly"),
         ]
     if window in {"24h", "48h"}:
         return STORE.synthetic_rollups(
@@ -2976,12 +3022,14 @@ def _status_rollups(window: str) -> list[Any]:
             limit=STATUS_DAY_ROLLUP_LIMIT,
         )
     if window == "monthly":
-        return STORE.synthetic_rollups(
-            period="day",
-            since=_day_rollup_since(now, months=STATUS_ROLLUP_RETENTION_MONTHS),
-            include_histograms=False,
+        rows = STORE.synthetic_rollups(
+            period="month",
+            since=_month_rollup_since(now, months=STATUS_ROLLUP_RETENTION_MONTHS),
             limit=STATUS_MONTH_ROLLUP_LIMIT,
         )
+        if len(rows) >= STATUS_MONTH_ROLLUP_LIMIT:
+            raise RuntimeError("monthly status rollup limit reached; refusing partial history")
+        return rows
     return []
 
 

--- a/src/trusted_router/static/leaderboard.css
+++ b/src/trusted_router/static/leaderboard.css
@@ -1,0 +1,58 @@
+.lb-hero { padding: 32px 0 20px; }
+.lb-hero h1 { font-size: 32px; line-height: 1.2; margin: 0 0 12px; }
+.lb-hero p { max-width: 760px; }
+.lb-muted, .lb-explorer small { color: var(--text-muted); font-size: 12px; }
+.lb-explorer { width: 100%; min-width: 0; }
+.lb-explorer [hidden] { display: none !important; }
+.lb-overview { display: flex; flex-wrap: wrap; gap: 12px 24px; padding: 16px 0; border-block: 1px solid var(--border-default); font-variant-numeric: tabular-nums; }
+.lb-overview strong { color: var(--text-display); }
+.lb-overview a { margin-left: auto; }
+.lb-windows, .lb-tabs { display: flex; gap: 8px; }
+.lb-windows { padding-top: 16px; }
+.lb-windows a, .lb-tabs button { padding: 8px 12px; border-bottom: 2px solid transparent; color: var(--text-body); }
+.lb-windows [aria-current], .lb-tabs [aria-selected="true"] { border-color: var(--text-accent); color: var(--text-display); }
+.lb-tabs button { background: none; border: 0; border-bottom: 2px solid transparent; border-radius: 0; min-height: 44px; }
+.lb-methodology { padding: 16px 0; max-width: 900px; }
+.lb-methodology summary, .lb-details summary { cursor: pointer; color: var(--text-accent); }
+.lb-methodology p { font-size: 14px; line-height: 1.6; }
+.lb-controls { display: grid; grid-template-columns: minmax(220px, 2fr) repeat(3, minmax(140px, 1fr)); gap: 12px; padding: 8px 0 20px; }
+.lb-tabs { grid-column: 1 / -1; }
+.lb-controls label { display: grid; gap: 6px; min-width: 0; font-size: 12px; }
+.lb-controls input, .lb-controls select { width: 100%; min-width: 0; min-height: 44px; margin: 0; font-size: 14px; }
+.lb-panel h2 { font-size: 20px; margin: 12px 0; }
+.lb-table { width: 100%; table-layout: fixed; border-collapse: collapse; font-size: 13px; font-variant-numeric: tabular-nums; }
+.lb-table th, .lb-table td { padding: 14px 10px; vertical-align: top; text-align: left; overflow-wrap: anywhere; border-bottom: 1px solid var(--border-default); }
+.lb-table th { color: var(--text-muted); font-size: 12px; font-weight: 500; }
+.lb-table th:first-child { width: 34px; }
+.lb-table th:nth-child(2) { width: 28%; }
+.lb-table th:last-child { width: 80px; }
+.lb-table small { display: block; margin-top: 5px; }
+.lb-table .provider-identity { display: inline-flex; max-width: 100%; }
+.lb-table img { width: 24px; height: 24px; flex-shrink: 0; }
+.lb-model { display: block; margin-bottom: 8px; color: var(--text-display); }
+.lb-badge { display: inline-block; margin: 6px 4px 0 0; padding: 2px 5px; font-size: 11px; color: var(--text-muted); border: 1px solid var(--border-default); border-radius: 4px; }
+.lb-warning { color: var(--status-pending); }
+.lb-detail-cell { position: relative; }
+.lb-details dl { position: absolute; z-index: 5; right: 0; top: 42px; width: 290px; max-width: calc(100vw - 48px); padding: 16px; background: var(--surface-raised); border: 1px solid var(--border-strong); border-radius: 6px; box-shadow: 0 6px 20px rgb(0 0 0 / 20%); }
+.lb-details dt { font-size: 12px; color: var(--text-muted); margin-top: 10px; }
+.lb-details dt:first-child { margin-top: 0; }
+.lb-details dd { margin: 3px 0 0; overflow-wrap: anywhere; }
+.lb-empty { padding: 24px 0; color: var(--text-muted); }
+.lb-pagination { display: flex; align-items: center; gap: 8px; padding: 20px 0; }
+.lb-pagination output { margin-right: auto; font-size: 13px; }
+.lb-pagination button { width: 44px; height: 44px; padding: 0; border-radius: 4px; }
+
+@media (width <= 700px) {
+  .lb-hero h1 { font-size: 28px; }
+  .lb-overview { gap: 10px 20px; }
+  .lb-overview a { margin-left: 0; }
+  .lb-controls { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .lb-search { grid-column: 1 / -1; }
+  .lb-table, .lb-table tbody { display: block; }
+  .lb-table thead, .lb-table .lb-rank { display: none; }
+  .lb-table tr { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); padding: 12px 0; border-bottom: 1px solid var(--border-default); }
+  .lb-table td { border: 0; padding: 8px 4px; }
+  .lb-identity, .lb-detail-cell { grid-column: 1 / -1; }
+  .lb-table [data-label]::before { content: attr(data-label); display: block; color: var(--text-muted); font-size: 11px; margin-bottom: 4px; }
+  .lb-details dl { position: static; width: 100%; max-width: none; box-shadow: none; margin-bottom: 0; }
+}

--- a/src/trusted_router/static/leaderboard.js
+++ b/src/trusted_router/static/leaderboard.js
@@ -1,0 +1,110 @@
+"use strict";
+(() => {
+    const root = document.querySelector('[data-leaderboard]');
+    if (!root)
+        return;
+    const controls = root.querySelector('[data-lb-controls]');
+    const search = root.querySelector('[data-lb-search]');
+    const provider = root.querySelector('[data-lb-provider]');
+    const sort = root.querySelector('[data-lb-sort]');
+    const evidence = root.querySelector('[data-lb-evidence]');
+    const tabs = Array.from(root.querySelectorAll('[data-lb-tab]'));
+    const panels = Array.from(root.querySelectorAll('[data-lb-panel]'));
+    const previous = root.querySelector('[data-lb-prev]');
+    const next = root.querySelector('[data-lb-next]');
+    const count = root.querySelector('[data-lb-count]');
+    const params = new URLSearchParams(location.search);
+    let view = params.get('view') === 'models' ? 'models' : 'providers';
+    let page = 0;
+    const pageSize = 25;
+    search.value = params.get('q') || '';
+    for (const [name, select] of [['provider', provider], ['sort', sort], ['evidence', evidence]]) {
+        const value = params.get(name);
+        if (value !== null && Array.from(select.options).some(option => option.value === value))
+            select.value = value;
+    }
+    const numeric = (row, key) => {
+        const value = row.dataset[key];
+        return value !== undefined && value !== '' && Number.isFinite(Number(value)) ? Number(value) : null;
+    };
+    const update = () => {
+        const terms = search.value.toLowerCase().trim().split(/\s+/).filter(Boolean);
+        for (const panel of panels) {
+            panel.hidden = panel.dataset.lbPanel !== view;
+            panel.setAttribute('role', 'tabpanel');
+            if (panel.hidden)
+                continue;
+            const rows = Array.from(panel.querySelectorAll('[data-lb-row]'));
+            const matches = rows.filter(row => {
+                row.hidden = true;
+                return terms.every(term => row.dataset.search.toLowerCase().includes(term))
+                    && (!provider.value || row.dataset.provider === provider.value)
+                    && (evidence.value !== 'qualified' || row.dataset.qualified === 'yes')
+                    && (evidence.value !== 'warming' || row.dataset.qualified === 'no')
+                    && (evidence.value !== 'config' || Number(row.dataset.config) > 0);
+            });
+            const direction = ['throughput', 'completion', 'samples'].includes(sort.value) ? -1 : 1;
+            matches.sort((a, b) => {
+                const left = numeric(a, sort.value), right = numeric(b, sort.value);
+                if (left === null && right !== null)
+                    return 1;
+                if (left !== null && right === null)
+                    return -1;
+                return ((left ?? 0) - (right ?? 0)) * direction || a.dataset.search.localeCompare(b.dataset.search);
+            });
+            page = Math.min(page, Math.max(0, Math.ceil(matches.length / pageSize) - 1));
+            const start = page * pageSize;
+            const tbody = panel.querySelector('tbody');
+            for (const [index, row] of matches.entries()) {
+                tbody.append(row);
+                row.hidden = index < start || index >= start + pageSize;
+            }
+            count.value = matches.length ? `${start + 1}-${Math.min(start + pageSize, matches.length)} of ${matches.length} ${view}` : `0 ${view}`;
+            panel.querySelector('[data-lb-empty]').hidden = matches.length > 0 || rows.length === 0;
+            previous.disabled = page === 0;
+            next.disabled = start + pageSize >= matches.length;
+        }
+        for (const tab of tabs) {
+            const selected = tab.dataset.lbTab === view;
+            tab.setAttribute('aria-selected', String(selected));
+            tab.tabIndex = selected ? 0 : -1;
+        }
+        const url = new URL(location.href);
+        for (const [key, value] of [['view', view === 'models' ? view : ''], ['q', search.value], ['provider', provider.value], ['sort', sort.value === 'rank' ? '' : sort.value], ['evidence', evidence.value === 'all' ? '' : evidence.value]]) {
+            if (value)
+                url.searchParams.set(key, value);
+            else
+                url.searchParams.delete(key);
+        }
+        history.replaceState(null, '', url);
+        root.querySelectorAll('[data-lb-window]').forEach(link => {
+            const target = new URL(link.href);
+            const windowValue = target.searchParams.get('window');
+            target.search = url.search;
+            if (windowValue)
+                target.searchParams.set('window', windowValue);
+            else
+                target.searchParams.delete('window');
+            link.href = target.href;
+        });
+    };
+    for (const input of [search, provider, sort, evidence]) {
+        input.addEventListener(input === search ? 'input' : 'change', () => { page = 0; update(); });
+    }
+    for (const [index, tab] of tabs.entries()) {
+        tab.addEventListener('click', () => { view = tab.dataset.lbTab; page = 0; update(); });
+        tab.addEventListener('keydown', event => {
+            if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key))
+                return;
+            event.preventDefault();
+            const target = event.key === 'Home' ? tabs[0] : event.key === 'End' ? tabs[tabs.length - 1] : tabs[(index + (event.key === 'ArrowRight' ? 1 : tabs.length - 1)) % tabs.length];
+            target.click();
+            target.focus();
+        });
+    }
+    previous.addEventListener('click', () => { page--; update(); });
+    next.addEventListener('click', () => { page++; update(); });
+    controls.hidden = false;
+    root.querySelector('[data-lb-pagination]').hidden = false;
+    update();
+})();

--- a/src/trusted_router/synthetic/components.py
+++ b/src/trusted_router/synthetic/components.py
@@ -337,6 +337,9 @@ def applicable_component_definitions(settings: Settings) -> tuple[dict[str, str]
     (regions + synthetic_regional_probes_enabled), never a per-cloud list.
     """
     targets = deployment_probe_targets(settings)
+    expected_probes = {
+        value.strip() for value in settings.synthetic_status_probe_types.split(",") if value.strip()
+    }
     applicable: list[dict[str, str]] = []
     for definition in COMPONENT_DEFINITIONS:
         component_id = str(definition["id"])
@@ -348,7 +351,8 @@ def applicable_component_definitions(settings: Settings) -> tuple[dict[str, str]
         if required is not None and required not in targets:
             continue
         capability = COMPONENT_REQUIRED_CAPABILITIES.get(component_id)
-        if capability is not None and not capability(settings):
+        declared = bool(component_probe_types(component_id) & expected_probes)
+        if capability is not None and not declared and not capability(settings):
             continue
         applicable.append(definition)
     return tuple(applicable)

--- a/src/trusted_router/synthetic/leaderboard.py
+++ b/src/trusted_router/synthetic/leaderboard.py
@@ -392,6 +392,8 @@ def aggregate_leaderboard(
         if _excluded_from_uptime(sample):
             stats.excluded_count += 1
             stats.excluded_reasons[label] += 1
+            if stats.last_seen is None or sample.created_at > stats.last_seen:
+                stats.last_seen = sample.created_at
             continue
         stats.sample_count += 1
         if sample.status == "success":
@@ -443,7 +445,9 @@ def aggregate_leaderboard(
     models = [
         stats
         for stats in by_model.values()
-        if stats.sample_count >= min_samples or stats.throughput_sample_count >= min_samples
+        if stats.sample_count >= min_samples
+        or stats.throughput_sample_count >= min_samples
+        or stats.excluded_count > 0
     ]
     models.sort(
         key=lambda stats: (

--- a/src/trusted_router/synthetic/probes.py
+++ b/src/trusted_router/synthetic/probes.py
@@ -1003,7 +1003,9 @@ async def client_telemetry_canary_probe(
         policy = payload.get("policy") if isinstance(payload, dict) else None
         accepted_events = data.get("accepted_events") if isinstance(data, dict) else None
         pause_seconds = policy.get("pause_seconds") if isinstance(policy, dict) else None
-        paused = response.status_code == 202 and isinstance(pause_seconds, int) and pause_seconds > 0
+        paused = (
+            response.status_code == 202 and isinstance(pause_seconds, int) and pause_seconds > 0
+        )
         ok = response.status_code == 202 and accepted_events == 1 and not paused
         return _sample(
             "client_telemetry_ingest",
@@ -1180,7 +1182,9 @@ async def openai_chat_pong_probe(
     try:
         payload = await sdk.request("POST", "/chat/completions", json=body)
     except Exception as exc:  # noqa: BLE001 - every SDK failure is a classified sample
-        return _sdk_failure_sample("openai_sdk_pong", target, monitor_region, url, exc, started, model)
+        return _sdk_failure_sample(
+            "openai_sdk_pong", target, monitor_region, url, exc, started, model
+        )
     latency_ms = _elapsed_ms(started)
     ok = _pong_matches(_chat_text(httpx.Response(200, json=payload)))
     return _sample(
@@ -1289,7 +1293,9 @@ async def responses_pong_probe(
     try:
         payload = await sdk.request("POST", "/responses", json=body)
     except Exception as exc:  # noqa: BLE001 - every SDK failure is a classified sample
-        return _sdk_failure_sample("responses_pong", target, monitor_region, url, exc, started, model)
+        return _sdk_failure_sample(
+            "responses_pong", target, monitor_region, url, exc, started, model
+        )
     latency_ms = _elapsed_ms(started)
     ok = _pong_matches(_responses_text(httpx.Response(200, json=payload)))
     return _sample(
@@ -2042,6 +2048,9 @@ def rotation_candidates() -> dict[str, list[str]]:
 
     pool: dict[str, list[str]] = {}
     for endpoint in MODEL_ENDPOINTS.values():
+        if endpoint.provider in {"openrouter", "trustedrouter"}:
+            # Router names are not callable provider.only targets.
+            continue
         if not endpoint.catalog_is_current():
             continue
         if endpoint.usage_type != "Credits":
@@ -2358,8 +2367,12 @@ def _rotation_error_type(
         )
     ):
         return "monitor_account_unavailable"
-    if raw_type in _UNSUPPORTED_ROUTE_ERROR_TYPES or any(
-        marker in raw_message for marker in _UNSUPPORTED_ROUTE_MESSAGE_MARKERS
+    # A 503 "service unavailable" is downtime, not a missing catalog model.
+    # Only explicit model error types or client-side validation responses
+    # justify removing an attempt from provider availability.
+    if raw_type in _UNSUPPORTED_ROUTE_ERROR_TYPES or (
+        status in {400, 404, 422}
+        and any(marker in raw_message for marker in _UNSUPPORTED_ROUTE_MESSAGE_MARKERS)
     ):
         return "unsupported_route"
     if raw_type in _PROBE_CONFIG_ERROR_TYPES or (
@@ -2469,6 +2482,11 @@ async def provider_rotation_probe(
             elapsed_ms=observation.elapsed_milliseconds,
             error_status=None,
             error_type=error_type,
+            error_message=(
+                f"probe_budget_exhausted max_tokens={body['max_tokens']}"
+                if observation.finish_reason == "length"
+                else None
+            ),
         )
     return ProviderBenchmarkSample(
         id=f"bench-{uuid.uuid4().hex}",
@@ -2665,17 +2683,32 @@ def _benchmark_route_cost_microdollars(
 
 
 def _rotation_max_tokens(provider: str, model: str) -> int:
-    provider_l = provider.lower()
     model_l = model.lower()
-    if provider_l == "openai" and (
-        "/o1" in model_l or "/o3" in model_l or "/o4" in model_l or "/gpt-5" in model_l
-    ):
+    if "/o1" in model_l or "/o3" in model_l or "/o4" in model_l or "/gpt-5" in model_l:
         return 512
     if "gemini-2.5" in model_l or "gemini-3" in model_l:
         # Gemini thinks before visible content; hidden thinking consumes the
         # budget but is absent from usage, so 16 yields empty_stream. Live
         # verification on 2026-07-19 showed 2048 works; keep generous headroom.
         return 2048
+    # Publisher/model capability is independent of the hosting provider.
+    # These families exhausted 16 tokens with finish_reason=length in real
+    # probes. One shared bounded budget avoids host-by-host special cases.
+    if any(
+        family in model_l
+        for family in (
+            "qwen3",
+            "qwen-3",
+            "deepseek-v4",
+            "deepseek-r1",
+            "kimi-k3",
+            "gemma-4",
+            "minimax-m",
+            "mercury",
+            "fugu",
+        )
+    ):
+        return 512
     if (
         "gpt-oss" in model_l
         or "glm-4.6" in model_l
@@ -2704,10 +2737,7 @@ def _rotation_omits_temperature(provider: str, model: str) -> bool:
     model_l = model.lower()
     return (
         (provider_l == "kimi" and "kimi-k2." in model_l)
-        or (
-            provider_l == "openai"
-            and ("/o1" in model_l or "/o3" in model_l or "/o4" in model_l or "/gpt-5" in model_l)
-        )
+        or ("/o1" in model_l or "/o3" in model_l or "/o4" in model_l or "/gpt-5" in model_l)
         or (
             provider_l == "anthropic"
             and ("claude-opus-4.7" in model_l or "claude-opus-4.8" in model_l)

--- a/src/trusted_router/synthetic/status.py
+++ b/src/trusted_router/synthetic/status.py
@@ -223,6 +223,21 @@ def status_snapshot(
     )
     if model_inference_down:
         overall_status = _worse_status(overall_status, "degraded")
+    expected_probes = set(settings.synthetic_status_probe_types.split(",")) - {""}
+    observed_probes = {
+        sample.probe_type
+        for sample in ordered
+        if sample_component_ids(sample)
+        and -FUTURE_SAMPLE_SKEW_SECONDS
+        <= (now - _parse_time(sample.created_at)).total_seconds()
+        <= CURRENT_SAMPLE_TTL_SECONDS
+    }
+    monitoring_gaps = sorted(expected_probes - observed_probes)
+    coverage_only_degradation = bool(monitoring_gaps) and overall_status in {"up", "unknown"}
+    if monitoring_gaps:
+        # Missing evidence must not look healthy, but is not fabricated
+        # request downtime: the SLO denominators remain measured samples.
+        overall_status = _worse_status(overall_status, "degraded")
     down_component_names = [
         str(row["name"])
         for row in components
@@ -234,12 +249,15 @@ def status_snapshot(
         "overall_status": overall_status,
         "overall_status_label": _status_label(overall_status),
         "overall_status_class": _status_class(overall_status),
-        "summary": _summary(
+        "summary": "Monitoring coverage incomplete"
+        if coverage_only_degradation
+        else _summary(
             overall_status,
             freshness=freshness,
             down_components=down_component_names,
         ),
         "monitor_freshness": freshness,
+        "monitoring_gaps": monitoring_gaps,
         "headline_metrics": _headline_metrics(ordered, now=now),
         "current": current,
         "slo_classes": slo_classes,

--- a/src/trusted_router/templates/public/leaderboard.html
+++ b/src/trusted_router/templates/public/leaderboard.html
@@ -1,127 +1,104 @@
 {% extends "public/_base.html" %}
 {% from "public/_provider_identity.html" import provider_identity %}
+{% macro percent(value) %}{% if value is not none %}{{ '%.2f'|format(value * 100) }}%{% else %}Not measured{% endif %}{% endmacro %}
+
+{% block head_extra %}<link rel="stylesheet" href="/static/leaderboard.css?v={{ static_version|default('local') }}">{% endblock %}
+{% block body_scripts %}<script src="/static/leaderboard.js?v={{ static_version|default('local') }}" defer></script>{% endblock %}
 
 {% block hero %}
-<section class="status-hero">
-  <div>
-    <span class="eyebrow">Measured performance</span>
-    <h1>{{ heading }}</h1>
-    <p class="lead">{{ description }}</p>
-  </div>
-  <div class="status-updated">
-    <span>Last updated</span>
-    <strong>{{ snapshot.generated_at }}</strong>
-  </div>
+<section class="lb-hero">
+  <h1>{{ heading }}</h1>
+  <p>{{ description }}</p>
+  <p class="lb-muted">Last updated {{ snapshot.generated_at }}</p>
 </section>
 {% endblock %}
 
 {% block body %}
-<section class="status-page leaderboard-page">
-  <p><a class="btn ghost" href="/leaderboard/video">Video leaderboard</a></p>
-  <div class="status-note">
-    Continuously sampled from TrustedRouter's monitor regions using a
-    {{ snapshot.window_label or "recent live sample" }}. Time-to-first-token (TTFT),
-    effective throughput, and success rate come from real
-    streaming requests, not vendor claims. Completion rate shows the end-user result.
-    Provider availability excludes failures owned by TrustedRouter, customers, or route
-    configuration, while still reporting those failures under their actual owner.
-    Capacity acceptance measures requests not rejected for provider overload. Effective throughput is provider-reported
-    output tokens divided by complete request time, so buffered delivery cannot inflate
-    the result. Unsupported route and probe-configuration rows are reported separately
-    and do not count as provider downtime. No prompt or output content is ever stored.
+<section class="lb-explorer" data-leaderboard>
+  <div class="lb-overview">
+    <span><strong>{{ snapshot.provider_count }}</strong> providers</span>
+    <span><strong>{{ snapshot.total_samples }}</strong> availability samples</span>
+    <span><strong>{{ snapshot.total_throughput_samples }}</strong> sustained throughput samples</span>
+    <a href="/leaderboard/video">Video leaderboard</a>
   </div>
-
-  {% if not snapshot.models %}
-  <div class="status-note status-note-warning">
-    Measurements are warming up — performance data will appear here shortly. Check back soon.
+  <nav class="lb-windows" aria-label="Measurement window">
+    <a href="/leaderboard" data-lb-window{% if snapshot.window != '7d' %} aria-current="page"{% endif %}>Recent sample</a>
+    <a href="/leaderboard?window=7d" data-lb-window{% if snapshot.window == '7d' %} aria-current="page"{% endif %}>7-day evidence</a>
+  </nav>
+  <details class="lb-methodology">
+    <summary>Measurement details</summary>
+    <p>Continuously sampled from TrustedRouter's monitor regions using a {{ snapshot.window_label or "recent live sample" }}.
+      Ranked by p50 time-to-first-token across all of a provider's models. Provider-attributed availability breaks latency ties.
+      Different model mixes are not a controlled speed comparison.</p>
+    <p>Completion rate shows the end-user result. Provider availability excludes failures owned by TrustedRouter,
+      customers, or route configuration, while still reporting those failures under their actual owner.
+      Capacity acceptance measures requests not rejected for provider overload. Effective throughput is provider-reported
+      output tokens divided by complete request time, so buffered delivery cannot inflate the result.</p>
+    <p>Models need 10 availability samples and providers need 30, each with at least 3 measured first tokens, to receive a rank.
+      Thin availability and throughput measurements stay visible below the ranked set as warming.
+      Unsupported route and probe-configuration rows are reported separately and do not count as provider downtime.
+      No prompt or output content is ever stored.</p>
+    {% if snapshot.window == '7d' %}<p>This balanced evidence sample covers seven days. It is not today's availability or a complete traffic census.</p>{% endif %}
+  </details>
+  <div class="lb-controls" data-lb-controls hidden>
+    <div class="lb-tabs" role="tablist" aria-label="Leaderboard view">
+      <button type="button" role="tab" id="tab-providers" aria-controls="lb-providers" data-lb-tab="providers">Providers</button>
+      <button type="button" role="tab" id="tab-models" aria-controls="lb-models" data-lb-tab="models">Models</button>
+    </div>
+    <label class="lb-search">Search<input type="search" data-lb-search placeholder="Provider or model" autocomplete="off"></label>
+    <label>Provider<select data-lb-provider><option value="">All providers</option>{% for p in snapshot.providers|sort(attribute='provider') %}<option value="{{ p.provider }}">{{ p.provider }}</option>{% endfor %}</select></label>
+    <label>Sort by<select data-lb-sort><option value="rank">Rank</option><option value="ttft">Lowest TTFT</option><option value="throughput">Highest throughput</option><option value="completion">Highest completion</option><option value="samples">Most samples</option></select></label>
+    <label>Evidence<select data-lb-evidence><option value="all">All measurements</option><option value="qualified">Ranked</option><option value="warming">Warming</option><option value="config">Excluded attempts</option></select></label>
   </div>
-  {% else %}
-  <section class="status-section">
-    <div class="status-section-head">
-      <div>
-        <h2>Providers</h2>
-        <p>Ranked by p50 time-to-first-token across all of a provider's models. Provider-attributed availability remains visible and breaks latency ties
-          ({{ snapshot.provider_count }} providers · {{ snapshot.total_samples }} availability samples ·
-          {{ snapshot.total_throughput_samples }} sustained throughput samples). Providers below the
-          evidence floor remain visible as warming, but do not receive a rank.</p>
-      </div>
-    </div>
-    <div class="leaderboard-table-wrap">
-      <table class="leaderboard-table">
-        <thead>
-          <tr>
-            <th>#</th><th>Provider</th><th>Models</th>
-            <th>Completion</th><th>Provider availability</th><th>Within deadline</th>
-            <th>Capacity accepted</th><th>p50 TTFT</th><th>p95 TTFT</th>
-            <th>Effective throughput</th><th>Failure owner</th><th>Config excluded</th><th>Samples</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for p in snapshot.providers %}
-          <tr>
-            <td>{% if p.rank is not none %}{{ p.rank }}{% else %}—{% endif %}</td>
-            <td>{{ provider_identity(p.provider, p.provider, "/providers/" ~ p.provider) }}
-              {% if not p.rank_eligible %}<span class="lb-badge">warming</span>{% endif %}
-            </td>
-            <td>{{ p.model_count }}</td>
-            <td>{% if p.completion_rate is not none %}{{ '%.2f'|format(p.completion_rate * 100) }}%{% else %}—{% endif %}</td>
-            <td>{% if p.provider_availability is not none %}{{ '%.2f'|format(p.provider_availability * 100) }}%{% else %}—{% endif %}</td>
-            <td>{% if p.availability_within_deadline is not none %}{{ '%.2f'|format(p.availability_within_deadline * 100) }}%{% else %}—{% endif %}</td>
-            <td>{% if p.capacity_acceptance_rate is not none %}{{ '%.2f'|format(p.capacity_acceptance_rate * 100) }}%{% else %}—{% endif %}</td>
-            <td>{% if p.p50_ttft_ms is not none %}{{ p.p50_ttft_ms }} ms{% else %}—{% endif %}</td>
-            <td>{% if p.p95_ttft_ms is not none %}{{ p.p95_ttft_ms }} ms{% else %}—{% endif %}</td>
-            <td>{% if p.p50_tokens_per_second is not none and p.throughput_sample_count %}{{ '%.0f'|format(p.p50_tokens_per_second) }} tok/s{% else %}—{% endif %}</td>
-            <td>{% if p.failure_owners %}{% for owner, count in p.failure_owners.items() %}<code>{{ owner }}</code> {{ count }}{% if not loop.last %}, {% endif %}{% endfor %}{% else %}—{% endif %}</td>
-            <td>{% if p.excluded_count %}{{ p.excluded_count }}{% if p.top_excluded %} <code>{{ p.top_excluded }}</code>{% endif %}{% else %}—{% endif %}</td>
-            <td>{{ p.sample_count }}</td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
+  {% for kind in ['providers', 'models'] %}
+  <section id="lb-{{ kind }}" class="lb-panel" data-lb-panel="{{ kind }}" aria-labelledby="tab-{{ kind }}">
+    <h2>{{ kind|capitalize }}</h2>
+    <table class="lb-table">
+      <thead><tr><th>#</th><th>{{ 'Model / provider' if kind == 'models' else 'Provider' }}</th><th>Completion</th><th>p50 TTFT</th><th>Effective throughput</th><th>Samples</th><th>Details</th></tr></thead>
+      <tbody>
+      {% for row in snapshot[kind] %}
+        <tr data-lb-row data-provider="{{ row.provider }}" data-search="{{ row.provider }} {{ row.model|default('') }}"
+          data-rank="{{ row.rank if row.rank is not none else '' }}" data-ttft="{{ row.p50_ttft_ms if row.p50_ttft_ms is not none else '' }}"
+          data-throughput="{{ row.p50_tokens_per_second if row.p50_tokens_per_second is not none else '' }}"
+          data-completion="{{ row.completion_rate if row.completion_rate is not none else '' }}" data-samples="{{ row.sample_count }}"
+          data-qualified="{{ 'yes' if row.rank_eligible else 'no' }}" data-config="{{ row.excluded_count }}">
+          <td class="lb-rank">{{ row.rank if row.rank is not none else '—' }}</td>
+          <td class="lb-identity">
+            {% if kind == 'models' %}<a class="lb-model" href="/models/{{ row.model }}/performance">{{ row.model }}</a>{% endif %}
+            {{ provider_identity(row.provider, row.provider, "/providers/" ~ row.provider) }}
+            {% if kind == 'providers' %}<small>{{ row.model_count }} models</small>{% endif %}
+            {% if not row.rank_eligible %}<span class="lb-badge">warming</span>{% endif %}
+            {% if row.excluded_count %}<span class="lb-badge lb-warning">{{ row.excluded_count }} excluded</span>{% endif %}
+          </td>
+          <td data-label="Completion">{{ percent(row.completion_rate) }}</td>
+          <td data-label="p50 TTFT">{% if row.p50_ttft_ms is not none %}{{ row.p50_ttft_ms }} ms{% else %}Not measured{% endif %}</td>
+          <td data-label="Effective throughput">{% if row.p50_tokens_per_second is not none and row.throughput_sample_count %}{{ '%.0f'|format(row.p50_tokens_per_second) }} tok/s{% else %}Not measured{% endif %}
+            <small>{{ row.throughput_sample_count }} samples{% if row.throughput_sample_count < 3 %}, warming{% endif %}</small></td>
+          <td data-label="Availability samples">{{ row.sample_count }}<small>{{ row.ttft_sample_count }} with TTFT</small></td>
+          <td class="lb-detail-cell"><details class="lb-details"><summary aria-label="Measurements for {{ row.model|default(row.provider) }}">More</summary>
+            <dl>
+              <dt>Provider availability</dt><dd>{{ percent(row.provider_availability) }} ({{ row.provider_sample_count }} samples)</dd>
+              <dt>Within deadline</dt><dd>{{ percent(row.availability_within_deadline) }}</dd>
+              <dt>Capacity accepted</dt><dd>{{ percent(row.capacity_acceptance_rate) }}</dd>
+              <dt>p95 TTFT</dt><dd>{% if row.p95_ttft_ms is not none %}{{ row.p95_ttft_ms }} ms{% else %}Not measured{% endif %}</dd>
+              <dt>Failure owner</dt><dd>{% for owner, count in row.failure_owners.items() %}{{ owner }}: {{ count }}{% if not loop.last %}, {% endif %}{% else %}None{% endfor %}</dd>
+              <dt>Errors</dt><dd>{% for error, count in row.errors.items() %}{{ error }}: {{ count }}{% if not loop.last %}, {% endif %}{% else %}None{% endfor %}</dd>
+              <dt>Excluded from provider availability</dt><dd>{% for reason, count in row.excluded_reasons.items() %}{{ reason }}: {{ count }}{% if not loop.last %}, {% endif %}{% else %}None{% endfor %}</dd>
+              {% if kind == 'models' %}<dt>Last seen</dt><dd>{{ row.last_seen }}</dd>{% endif %}
+            </dl>
+          </details></td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+    {% if not snapshot[kind] %}<p class="lb-empty">Measurements are warming up. Waiting for the next published sample.</p>{% endif %}
+    <p class="lb-empty" data-lb-empty hidden>No measurements match these filters.</p>
   </section>
-
-  <section class="status-section">
-    <div class="status-section-head">
-      <div>
-        <h2>Models</h2>
-        <p>Qualified models are ranked by p50 TTFT, with provider-attributed availability as a tie-breaker. Thin availability and
-          throughput measurements stay visible below the ranked set as warming.</p>
-      </div>
-    </div>
-    <div class="leaderboard-table-wrap">
-      <table class="leaderboard-table">
-        <thead>
-          <tr>
-            <th>#</th><th>Model</th><th>Provider</th>
-            <th>Completion</th><th>Provider availability</th><th>Within deadline</th><th>Capacity accepted</th>
-            <th>p50 TTFT</th><th>p95 TTFT</th>
-            <th>Effective throughput</th><th>Config excluded</th><th>Samples</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for m in snapshot.models %}
-          <tr>
-            <td>{% if m.rank is not none %}{{ m.rank }}{% else %}—{% endif %}</td>
-            <td><a href="/models/{{ m.model }}/performance">{{ m.model }}</a>
-              {% if not m.rank_eligible %}<span class="lb-badge">warming</span>{% endif %}
-            </td>
-            <td>{{ provider_identity(m.provider, m.provider, "/providers/" ~ m.provider) }}</td>
-            <td>{% if m.completion_rate is not none %}{{ '%.2f'|format(m.completion_rate * 100) }}%{% else %}—{% endif %}</td>
-            <td>{% if m.provider_availability is not none %}{{ '%.2f'|format(m.provider_availability * 100) }}%{% else %}—{% endif %}</td>
-            <td>{% if m.availability_within_deadline is not none %}{{ '%.2f'|format(m.availability_within_deadline * 100) }}% <span class="lb-badge">{{ '%.0f'|format(m.first_token_deadline_ms / 1000) }}s</span>{% else %}—{% endif %}</td>
-            <td>{% if m.capacity_acceptance_rate is not none %}{{ '%.2f'|format(m.capacity_acceptance_rate * 100) }}%{% else %}—{% endif %}</td>
-            <td>{% if m.p50_ttft_ms is not none %}{{ m.p50_ttft_ms }} ms{% else %}—{% endif %}</td>
-            <td>{% if m.p95_ttft_ms is not none %}{{ m.p95_ttft_ms }} ms{% else %}—{% endif %}</td>
-            <td>{% if m.p50_tokens_per_second is not none and m.throughput_sample_count %}{{ '%.0f'|format(m.p50_tokens_per_second) }} tok/s{% if m.throughput_sample_count < 3 %} <span class="lb-badge">warming</span>{% endif %}{% else %}—{% endif %}</td>
-            <td>{% if m.excluded_count %}{{ m.excluded_count }}{% if m.top_excluded %} <code>{{ m.top_excluded }}</code>{% endif %}{% else %}—{% endif %}</td>
-            <td>{{ m.sample_count }}</td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-  </section>
-  {% endif %}
+  {% endfor %}
+  <nav class="lb-pagination" data-lb-pagination aria-label="Leaderboard pages" hidden>
+    <output data-lb-count aria-live="polite"></output>
+    <button type="button" data-lb-prev aria-label="Previous page" title="Previous page">←</button>
+    <button type="button" data-lb-next aria-label="Next page" title="Next page">→</button>
+  </nav>
 </section>
 {% endblock %}

--- a/tests/browser/leaderboard.spec.js
+++ b/tests/browser/leaderboard.spec.js
@@ -1,0 +1,78 @@
+const { test, expect } = require("@playwright/test");
+const { execFileSync } = require("node:child_process");
+const path = require("node:path");
+
+const html = execFileSync("uv", ["run", "--no-sync", "python", "tests/browser/leaderboard_fixture.py"], {
+  cwd: path.resolve(__dirname, "../.."), encoding: "utf8", maxBuffer: 4 * 1024 * 1024,
+  env: { ...process.env, PYTHONPATH: "src", TR_ENVIRONMENT: "test", TR_STORAGE_BACKEND: "memory", TR_SENTRY_DSN: "" },
+});
+
+test.beforeEach(async ({ page }) => {
+  await page.route(/\/leaderboard(?:\?.*)?$/, route => route.fulfill({ status: 200, contentType: "text/html", body: html }));
+});
+
+test("provider/model tabs, search, evidence, paging and URL persistence", async ({ page }) => {
+  await page.goto("/leaderboard");
+  await expect(page.getByRole("tab", { name: "Providers", exact: true })).toHaveAttribute("aria-selected", "true");
+  await page.getByRole("tab", { name: "Models", exact: true }).click();
+  await expect(page.locator("[data-lb-count]")).toHaveText("1-25 of 62 models");
+  await expect(page.locator("#lb-models [data-lb-row]:visible")).toHaveCount(25);
+  await page.getByRole("button", { name: "Next page" }).click();
+  await expect(page.locator("[data-lb-count]")).toHaveText("26-50 of 62 models");
+  await page.locator("[data-lb-provider]").selectOption("mistral");
+  await page.locator("[data-lb-search]").fill("model-0");
+  await expect(page.locator("#lb-models [data-lb-row]:visible")).toHaveCount(3);
+  await page.reload();
+  await expect(page.locator("[data-lb-search]")).toHaveValue("model-0");
+  await expect(page.locator("#lb-models [data-lb-row]:visible")).toHaveCount(3);
+  await page.locator("[data-lb-search]").fill("");
+  await page.locator("[data-lb-evidence]").selectOption("config");
+  await expect(page.locator("#lb-models [data-lb-row]:visible")).toHaveCount(1);
+  await expect(page.locator("#lb-models [data-lb-row]:visible")).toContainText("needs-configuration");
+  await page.locator("#lb-models [data-lb-row]:visible summary").click();
+  await expect(page.locator("#lb-models [data-lb-row]:visible dl")).toContainText("probe_config_error: 1");
+  await expect(page.getByRole("link", { name: "7-day evidence", exact: true })).toHaveAttribute("href", /window=7d/);
+  await expect(page.getByRole("link", { name: "7-day evidence", exact: true })).toHaveAttribute("href", /evidence=config/);
+});
+
+test("numeric sorting keeps absent measurements last and filters unranked routes", async ({ page }) => {
+  await page.goto("/leaderboard?view=models&sort=ttft");
+  await expect(page.locator("#lb-models [data-lb-row]:visible").first()).toContainText("model-00");
+  await page.locator("[data-lb-evidence]").selectOption("qualified");
+  await expect(page.locator("[data-lb-count]")).toHaveText("1-25 of 60 models");
+  await page.locator("[data-lb-evidence]").selectOption("warming");
+  await expect(page.locator("#lb-models [data-lb-row]:visible").first()).toContainText("model-60");
+  await expect(page.locator("#lb-models [data-lb-row]:visible").last()).toContainText("needs-configuration");
+  await page.locator("[data-lb-search]").fill("no-such-model");
+  await expect(page.locator("#lb-models [data-lb-empty]")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Next page" })).toBeDisabled();
+  await page.getByRole("tab", { name: "Models", exact: true }).focus();
+  await page.keyboard.press("ArrowLeft");
+  await expect(page.getByRole("tab", { name: "Providers", exact: true })).toBeFocused();
+});
+
+for (const width of [390, 1280]) {
+  test(`fits ${width}px with details and no document overflow`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 950 });
+    const errors = [];
+    page.on("pageerror", error => errors.push(error.message));
+    await page.goto("/leaderboard?view=models");
+    await page.locator("#lb-models [data-lb-row]:visible summary").first().click();
+    await expect(page.locator("#lb-models details[open] dl")).toBeVisible();
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+    expect(await page.locator("#lb-models img").first().evaluate(img => img.complete && img.naturalWidth > 0)).toBe(true);
+    expect(errors).toEqual([]);
+    await page.screenshot({ path: `/tmp/tr-leaderboard-improved-${width}.png`, fullPage: false });
+  });
+}
+
+test("all evidence remains readable without JavaScript", async ({ browser }) => {
+  const context = await browser.newContext({ javaScriptEnabled: false });
+  const page = await context.newPage();
+  await page.route(/\/leaderboard$/, route => route.fulfill({ status: 200, contentType: "text/html", body: html }));
+  await page.goto("http://127.0.0.1:18081/leaderboard");
+  await expect(page.locator("#lb-models [data-lb-row]")).toHaveCount(62);
+  await expect(page.locator("#lb-providers")).toBeVisible();
+  await expect(page.locator("#lb-models")).toBeVisible();
+  await context.close();
+});

--- a/tests/browser/leaderboard_fixture.py
+++ b/tests/browser/leaderboard_fixture.py
@@ -1,0 +1,48 @@
+"""Render the production template with deterministic, metadata-only measurements."""
+
+from trusted_router.config import Settings
+from trusted_router.dashboard import public_leaderboard_html
+from trusted_router.storage_models import ProviderBenchmarkSample
+from trusted_router.synthetic.leaderboard import aggregate_leaderboard
+
+
+def render() -> str:
+    samples = []
+    for number in range(61):
+        provider = ("deepseek", "mistral", "anthropic")[number % 3]
+        for attempt in range(10 if number < 60 else 1):
+            samples.append(
+                ProviderBenchmarkSample(
+                    id=f"fixture-{number}-{attempt}",
+                    model=f"demo/model-{number:02d}",
+                    provider=provider,
+                    provider_name=provider,
+                    status="success",
+                    usage_type="Credits",
+                    streamed=True,
+                    first_token_milliseconds=100 + number,
+                    created_at="2026-09-05T12:00:00Z",
+                )
+            )
+    samples.append(
+        ProviderBenchmarkSample(
+            id="fixture-config",
+            model="demo/needs-configuration",
+            provider="mistral",
+            provider_name="mistral",
+            status="unsupported",
+            error_type="probe_config_error",
+            usage_type="Credits",
+            streamed=True,
+            created_at="2026-09-05T12:00:00Z",
+        )
+    )
+    snapshot = aggregate_leaderboard(
+        samples, model_rank_min_samples=10, provider_rank_min_samples=30, rank_min_ttft_samples=3
+    )
+    snapshot["generated_at"] = "2026-09-05T12:00:00Z"
+    return public_leaderboard_html(Settings(environment="test"), snapshot)
+
+
+if __name__ == "__main__":
+    print(render())

--- a/tests/test_deploy_workflow_regions.py
+++ b/tests/test_deploy_workflow_regions.py
@@ -154,7 +154,8 @@ def test_public_snapshot_worker_swap_is_verified_and_rollbackable() -> None:
     assert "tr-clickhouse-public-snapshots.service" in script
     assert "previous_builder=" in script
     assert "rollback()" in script
-    assert r"if [ \"\$count\" != 4 ]; then" in script
+    assert r"if [ \"\$count\" != 5 ]; then" in script
+    assert "leaderboard_evidence" in script
     assert r"mv \"\$previous_builder\" \"\$builder\"" in script
     # Upload first, then swap (#1080): the archive must not be streamed over
     # SSH stdin. Asserted by behaviour rather than by one exact spelling, so

--- a/tests/test_leaderboard_evidence.py
+++ b/tests/test_leaderboard_evidence.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from clickhouse import build_public_snapshots as worker
+from trusted_router.config import Settings
+from trusted_router.dashboard import public_leaderboard_html
+from trusted_router.routes import public
+from trusted_router.storage_models import ProviderBenchmarkSample
+from trusted_router.synthetic.leaderboard import aggregate_leaderboard
+from trusted_router.synthetic.probes import (
+    SyntheticTarget,
+    provider_rotation_probe,
+    rotation_candidates,
+)
+
+
+def sample(**values):
+    return ProviderBenchmarkSample(
+        **{
+            "id": "evidence-1",
+            "model": "openai/gpt-5-mini",
+            "provider": "openai",
+            "provider_name": "OpenAI",
+            "status": "success",
+            "usage_type": "Credits",
+            "streamed": True,
+            "first_token_milliseconds": 100,
+            "created_at": "2026-09-05T00:00:00Z",
+            **values,
+        }
+    )
+
+
+def test_config_only_routes_remain_visible_without_fake_availability() -> None:
+    row = sample(
+        status="unsupported", error_type="probe_config_error", first_token_milliseconds=None
+    )
+    payload = aggregate_leaderboard(
+        [row], model_rank_min_samples=10, provider_rank_min_samples=30, rank_min_ttft_samples=3
+    )
+    for result in [payload["models"][0], payload["providers"][0]]:
+        assert result["sample_count"] == 0
+        assert result["excluded_count"] == 1
+        assert result["rank"] is None
+        assert result["completion_rate"] is None
+        assert result["provider_availability"] is None
+        assert result["errors"] == {}
+    assert payload["models"][0]["last_seen"] == row.created_at
+
+
+def test_evidence_does_not_blend_into_recent_sample_or_lower_rank_floor() -> None:
+    recent = [sample(status="error", error_type="provider_error", error_status=503)]
+    historical = [sample(id=f"older-{n}") for n in range(10)]
+    snapshots = worker.build_snapshots(
+        recent, evidence_samples=historical, generated_at="2026-09-05T00:00:00Z"
+    )
+    current, evidence = snapshots["leaderboard"], snapshots["leaderboard_evidence"]
+    assert current["total_samples"] == 1
+    assert current["models"][0]["completion_rate"] == 0
+    assert current["models"][0]["rank"] is None
+    assert evidence["total_samples"] == 10
+    assert evidence["models"][0]["rank"] == 1
+    assert evidence["providers"][0]["rank"] is None
+    assert evidence["rank_minimums"] == current["rank_minimums"]
+    assert evidence["window"] == "7d"
+
+
+def test_evidence_query_is_bounded_balanced_and_does_not_filter_failures(monkeypatch) -> None:
+    queries = []
+    monkeypatch.setattr(worker, "_query", lambda password, query: queries.append(query) or "")
+    assert worker._evidence_samples("unused") == []
+    sql = queries[0]
+    for fragment in [
+        "INTERVAL 7 DAY",
+        "PARTITION BY provider, model, source",
+        "route_rank <= 30",
+        "provider_rank <= 500",
+        "LIMIT 10000",
+    ]:
+        assert fragment in sql
+    assert "status =" not in sql
+    assert "error_type =" not in sql
+
+
+def test_monthly_worker_query_uses_stored_months_and_preserves_histograms(monkeypatch) -> None:
+    queries = []
+    monkeypatch.setattr(worker, "_query", lambda password, query: queries.append(query) or "")
+    worker._status_inputs("unused")
+    sql = queries[-1]
+    assert "period = 'month'" in sql
+    assert "INTERVAL 23 MONTH" in sql
+    assert "period = 'hour'" in sql
+    assert "histogram" not in sql.split("FROM")[0]  # SELECT * retains histograms.
+
+
+def test_evidence_build_failure_does_not_stop_status_publication(monkeypatch, capsys) -> None:
+    def fail(password):
+        raise RuntimeError("query resource limit")
+    inserted = []
+    monkeypatch.setenv("CH_PASSWORD", "test-placeholder")
+    monkeypatch.setattr(worker, "_evidence_samples", fail)
+    monkeypatch.setattr(worker, "_status_inputs", lambda password: ([], []))
+    monkeypatch.setattr(worker, "_samples", lambda password: [])
+    monkeypatch.setattr(worker, "_video_samples", lambda password: [])
+    monkeypatch.setattr(worker, "_client_reliability_rows", lambda *args, **kwargs: [])
+    monkeypatch.setattr(worker, "_client_reliability_signals", lambda *args, **kwargs: {})
+    monkeypatch.setattr(worker, "_query", lambda *args, **kwargs: inserted.extend(json.loads(line) for line in kwargs["input_bytes"].splitlines()) or "")
+    assert worker.main() == 0
+    assert "status_inputs" in {row["name"] for row in inserted}
+    assert "leaderboard" in {row["name"] for row in inserted}
+    assert "leaderboard_evidence" not in {row["name"] for row in inserted}
+    assert "leaderboard_evidence_build_failed" in capsys.readouterr().err
+
+
+def test_monthly_public_read_rejects_truncated_history(monkeypatch) -> None:
+    monkeypatch.setattr(public, "STATUS_MONTH_ROLLUP_LIMIT", 2)
+    monkeypatch.setattr(
+        public, "STORE", SimpleNamespace(synthetic_rollups=lambda **kw: [object(), object()])
+    )
+    with pytest.raises(RuntimeError, match="refusing partial history"):
+        public._status_rollups("monthly")
+
+
+@pytest.mark.parametrize(
+    "precomputed", [None, {"generated_at": "2026-09-05T00:00:00Z", "total_samples": 42}]
+)
+def test_evidence_never_scans_raw_samples_and_keeps_separate_cache(
+    monkeypatch, precomputed
+) -> None:
+    def no_scan(**kwargs):
+        raise AssertionError("seven-day page must not scan raw rows")
+
+    names = []
+    monkeypatch.setattr(public, "_LEADERBOARD_EVIDENCE_CACHE", None)
+    monkeypatch.setattr(public, "_LEADERBOARD_CACHE", (0, {"total_samples": 999}))
+    monkeypatch.setattr(public, "public_benchmark_samples", no_scan)
+    monkeypatch.setattr(
+        public,
+        "_precomputed_public_analytics_snapshot",
+        lambda name: names.append(name) or precomputed,
+    )
+    payload = public._leaderboard_snapshot(Settings(environment="local"), window="7d")
+    assert payload["total_samples"] == (42 if precomputed else 0)
+    assert names == ["leaderboard_evidence"]
+    assert public._LEADERBOARD_CACHE[1]["total_samples"] == 999
+    assert public._leaderboard_snapshot(Settings(environment="local"), window="7d") is payload
+
+
+def test_unknown_evidence_window_is_rejected(client) -> None:
+    assert client.get("/leaderboard?window=forever").status_code == 400
+
+
+def test_rotation_does_not_schedule_router_names_as_direct_providers() -> None:
+    pool = rotation_candidates()
+    assert pool
+    assert {"openrouter", "trustedrouter"}.isdisjoint(pool)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [429, 500, 503])
+async def test_new_reasoning_probe_keeps_failures_and_does_not_retry(status) -> None:
+    bodies = []
+
+    def respond(request):
+        bodies.append(json.loads(request.content))
+        return httpx.Response(
+            status, json={"error": {"type": "provider_error", "message": "upstream unavailable"}}
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
+        result = await provider_rotation_probe(
+            client,
+            SyntheticTarget("rotation", "https://example.test/v1", "us-central1"),
+            monitor_region="us-central1",
+            api_key="test-placeholder",
+            provider="azure",
+            model="openai/gpt-5-mini",
+        )
+    assert len(bodies) == 1
+    assert bodies[0]["max_tokens"] == 512
+    assert "temperature" not in bodies[0]
+    assert result.status == "error"
+    assert result.error_status == status
+    assert result.error_type != "probe_config_error"
+
+
+def test_public_details_escape_model_names_and_never_render_error_body() -> None:
+    row = sample(
+        model='publisher/<script>alert("oops")</script>',
+        status="error",
+        error_type="provider_error",
+        error_message="PRIVATE-ERROR-BODY",
+        error_status=503,
+    )
+    snapshot = aggregate_leaderboard([row])
+    snapshot["generated_at"] = "2026-09-05T00:00:00Z"
+    html = public_leaderboard_html(Settings(environment="test"), snapshot)
+    assert "PRIVATE-ERROR-BODY" not in html
+    assert '<script>alert("oops")</script>' not in html
+    assert "&lt;script&gt;" in html
+    assert "data-lb-controls" in html

--- a/tests/test_leaderboard_page.py
+++ b/tests/test_leaderboard_page.py
@@ -86,7 +86,7 @@ def test_leaderboard_page_renders_measurements() -> None:
     resp = client.get("/leaderboard")
     assert resp.status_code == 200
     body = resp.text
-    assert "Measured performance" in body  # hero eyebrow
+    assert "Provider &amp; model performance" in body
     assert "rolling benchmark set of up to 10,000 samples" in body
     assert "p50 TTFT" in body  # table header
     assert "Effective throughput" in body
@@ -109,7 +109,7 @@ def test_leaderboard_page_separates_config_exclusions_from_errors() -> None:
     resp = client.get("/leaderboard")
 
     assert resp.status_code == 200
-    assert "Config excluded" in resp.text
+    assert "Excluded from provider availability" in resp.text
     assert "unsupported_route" in resp.text
     assert "Unsupported route and probe-configuration rows" in resp.text
 

--- a/tests/test_public_analytics_snapshots.py
+++ b/tests/test_public_analytics_snapshots.py
@@ -135,6 +135,7 @@ def test_snapshot_builder_precomputes_video_and_status_inputs() -> None:
         "apps",
         "client_reliability",
         "leaderboard",
+        "leaderboard_evidence",
         "status_inputs",
         "video_leaderboard",
     }

--- a/tests/test_public_status_reporting_regressions.py
+++ b/tests/test_public_status_reporting_regressions.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import replace
+
+import pytest
+
+from trusted_router.config import Settings
+from trusted_router.routes import public
+from trusted_router.storage_models import SyntheticProbeSample, SyntheticRollup
+from trusted_router.synthetic.probes import _rotation_max_tokens
+from trusted_router.synthetic.status import history_payload, status_snapshot
+
+
+def test_monthly_history_reads_months_not_fifty_daily_dimensions(monkeypatch, client) -> None:
+    calls = []
+    now = dt.datetime(2026, 9, 5, tzinfo=dt.UTC)
+    months = [
+        SyntheticRollup(
+            id=f"month-{month}",
+            period="month",
+            period_start=f"2026-{month:02d}-01T00:00:00Z",
+            component="canonical_api",
+            target="canonical",
+            probe_type="tls_health",
+            monitor_region="us-central1",
+            sample_count=100,
+            up_count=99,
+            down_count=1,
+            latency_histogram={"120": 100},
+            last_checked_at=f"2026-{month:02d}-05T00:00:00Z",
+        )
+        for month in range(5, 10)
+    ]
+
+    def read(_store, **kwargs):
+        calls.append(kwargs)
+        return months if kwargs["period"] == "month" else []
+
+    monkeypatch.setattr(public, "utcnow", lambda: now)
+    monkeypatch.setattr(type(public.STORE.target), "synthetic_rollups", read)
+    rows = public._status_rollups("monthly")
+    result = history_payload([], "monthly", rollups=rows)
+    assert [r["period_start"][:7] for r in result["data"]] == [
+        "2026-09",
+        "2026-08",
+        "2026-07",
+        "2026-06",
+        "2026-05",
+    ]
+    assert calls[0]["period"] == "month"
+    assert calls[0].get("include_histograms", True)
+    assert calls[0]["since"] == "2024-10-01T00:00:00Z"
+    assert result["data"][0]["groups"][0]["p50_latency_milliseconds"] == 120
+    response = client.get("/status/history?window=monthly", headers={"accept": "text/html"})
+    assert response.status_code == 200
+    assert "Monthly rollups" in response.text
+    for month in range(5, 10):
+        assert f"2026-{month:02d}" in response.text
+
+
+@pytest.mark.parametrize(
+    "probe,component",
+    [
+        ("gateway_authorize", "billing_settlement"),
+        ("gateway_settle", "billing_settlement"),
+        ("provider_fallback", "provider_fallback"),
+        ("openai_sdk_pong", "model_inference"),
+        ("responses_pong", "model_inference"),
+    ],
+)
+def test_public_status_declares_monitoring_without_sender_secrets(probe, component) -> None:
+    now = dt.datetime.now(dt.UTC)
+    settings = Settings(
+        environment="test",
+        internal_gateway_token=None,
+        synthetic_monitor_api_key=None,
+        synthetic_status_probe_types="gateway_authorize,gateway_settle,provider_fallback,openai_sdk_pong,responses_pong",
+    )
+    sample = SyntheticProbeSample(
+        id=f"test-{probe}",
+        probe_type=probe,
+        target="canonical" if component == "model_inference" else "control-plane",
+        target_url="https://example.test",
+        monitor_region="us-central1",
+        status="down",
+        created_at=now.isoformat(),
+    )
+    result = status_snapshot(
+        [sample, replace(sample, id=f"eu-{probe}", monitor_region="europe-west4")],
+        now=now,
+        settings=settings,
+    )
+    row = next(r for r in result["components"] if r["id"] == component)
+    assert row["status"] == "down"
+    assert result["overall_status"] != "up"
+    if component != "model_inference":
+        assert result["slo_classes"]["router_core"]["windows"]["5m"]["bad_count"] == 2
+    assert settings.internal_gateway_token is None
+    assert settings.synthetic_monitor_api_key is None
+
+
+@pytest.mark.parametrize(
+    "provider,model",
+    [
+        ("inception", "inception/mercury-2"),
+        ("sakana", "sakana-ai/fugu-ultra-v1.1"),
+        ("cerebras", "cerebras/qwen-3.8-27b"),
+        ("azure", "openai/gpt-5-mini"),
+        ("tinfoil", "moonshotai/kimi-k3"),
+        ("sail-research", "deepseek/deepseek-v4-flash-0731"),
+        ("together", "google/gemma-4-31b-it"),
+        ("telnyx", "minimax/minimax-m2.7"),
+    ],
+)
+def test_reasoning_probe_budgets_are_publisher_aware(provider, model) -> None:
+    assert 512 <= _rotation_max_tokens(provider, model) <= 2048
+
+
+def test_missing_transaction_evidence_cannot_leave_a_green_banner() -> None:
+    now = dt.datetime.now(dt.UTC)
+    settings = Settings(environment="test", synthetic_status_probe_types="gateway_authorize,gateway_settle")
+    live = SyntheticProbeSample(
+        id="live", probe_type="tls_health", target="canonical", target_url="https://example.test",
+        monitor_region="us-central1", status="up", created_at=now.isoformat(),
+    )
+    result = status_snapshot([live], now=now, settings=settings)
+    assert result["overall_status"] == "degraded"
+    assert result["summary"] == "Monitoring coverage incomplete"
+    assert result["monitoring_gaps"] == ["gateway_authorize", "gateway_settle"]
+    assert result["slo_classes"]["router_core"]["windows"]["5m"]["bad_count"] == 0
+
+
+def test_invalid_expected_probe_fails_at_configuration_time() -> None:
+    with pytest.raises(ValueError, match="unknown transaction probe"):
+        Settings(environment="test", synthetic_status_probe_types="gateway_settlee")

--- a/tests/test_public_surface_deploy.py
+++ b/tests/test_public_surface_deploy.py
@@ -38,6 +38,9 @@ BASE_ENV = {
     "TR_GCP_PROJECT_ID": "quill-cloud-proxy",
     "TR_REGIONS": "us-central1,us-east4,europe-west4,southamerica-east1",
     "TR_PRIMARY_REGION": "us-central1",
+    "TR_SYNTHETIC_STATUS_PROBE_TYPES": (
+        "gateway_authorize,gateway_settle,provider_fallback,openai_sdk_pong,responses_pong"
+    ),
     "TR_STORAGE_BACKEND": "spanner-bigtable",
     "TR_SPANNER_INSTANCE_ID": "trusted-router-nam6",
     "TR_SPANNER_DATABASE_ID": "trusted-router",
@@ -197,6 +200,9 @@ def test_exact_emitted_public_settings_validate_and_reject_control_secrets(
         kwargs = _settings_kwargs(call)
         settings = Settings(**kwargs)
         assert settings.service_surface == "public"
+        assert "gateway_settle" in settings.synthetic_status_probe_types
+        assert settings.internal_gateway_token is None
+        assert settings.synthetic_monitor_api_key is None
         for forbidden_name, forbidden_value in (
             ("internal_gateway_token", "gateway-" + "g" * 32),
             ("stripe_secret_key", "sk_live_forbidden"),

--- a/tests/test_synthetic_monitoring.py
+++ b/tests/test_synthetic_monitoring.py
@@ -682,7 +682,7 @@ def test_public_status_snapshot_uses_live_samples_plus_precomputed_rollups(
     payload = public_routes._status_snapshot(Settings(environment="test"))
 
     assert sample_calls == [{"limit": public_routes.STATUS_LIVE_SAMPLE_LIMIT}]
-    assert [call["period"] for call in rollup_calls] == ["hour"]
+    assert [call["period"] for call in rollup_calls] == ["hour", "month"]
     assert all(call["since"] for call in rollup_calls)
     assert all("until" not in call for call in rollup_calls)
     assert payload["windows"]["5m"]["sample_count"] == 1


### PR DESCRIPTION
## Summary
- Read 24 months of stored monthly status rollups with histograms instead of truncating 50 daily rows.
- Publish transaction-monitor capability metadata without exposing billing credentials; missing evidence is visibly degraded without inventing downtime.
- Add a precomputed, bounded seven-day evidence sample separate from current availability. Preserve ranking floors and random probe selection.
- Give reasoning-first probe models bounded output headroom across hosts. Do not treat generic provider 429/5xx "unavailable" messages as unsupported routes.
- Compact the leaderboard with provider/model tabs, search, filters, numeric sorting, pagination, mobile layout, and expandable metrics. Keep excluded-only routes visible and unranked.

## Validation
- Full final local regression suite: **8,913 passed, 368 skipped, 10 xfailed**, zero failures.
- Ruff, mypy (359 source files), TypeScript, ESLint and Stylelint pass.
- Five new Playwright cases pass: desktop/mobile, search/filter/sort/pagination, URL state, keyboard tabs, and JavaScript-disabled rendering. The repository CI browser job also passes.
- Production read-only query validation: 10,000 observations, 73 providers, 1,028 model/provider combinations, under the bounded worker query settings.
- Earlier full coverage measurement: 82.5%. Fake TLS servers require loopback permission; the final full suite was rerun with that permission.
- Security scan false positive: GitGuardian finding 37015673 flags the generated source SHA-256 at provider_check_contract.json:4340, not a credential. Independently recomputed and verified. No scanner exclusions added; see the investigation comment.

## Rollout
**Not deployed.** Update the committed public snapshot worker, public surface, and scheduled probe image independently. The worker swap gate requires the new evidence snapshot. See docs/status-leaderboard-evidence.md.

No billing, IAM, synthetic cadence, ranking floors, or alarm thresholds were weakened. Remaining retired-model and provider-entitlement repairs require explicit diagnosis; this change does not claim a zero provider error rate.