### PR TITLE
fix(chat): keep picker badges below full model names

### DIFF
--- a/src/trusted_router/static/chat.css
+++ b/src/trusted_router/static/chat.css
@@ -1608,6 +1608,7 @@
 
 .chat-model-picker-filters {
     display: flex;
+    flex-wrap: wrap;
     gap: 6px;
     padding: 8px 14px;
     border-bottom: 1px solid var(--chat-border);
@@ -1749,7 +1750,7 @@
     padding: 10px 16px;
     cursor: pointer;
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr);
     gap: 4px 16px;
     align-items: center;
     font-family: inherit;
@@ -1807,6 +1808,8 @@
 
 .chat-model-row-meta {
     display: flex;
+    flex-wrap: wrap;
+    padding-left: 34px;
     gap: 10px;
     font-size: 11px;
     color: var(--chat-muted);
@@ -2883,8 +2886,6 @@
 @media (max-width: 600px) {
     .chat-header-title { max-width: 100%; }
     .chat-header-actions { flex-wrap: wrap; }
-    .chat-model-row { grid-template-columns: minmax(0, 1fr); }
-    .chat-model-row-meta { padding-left: 34px; flex-wrap: wrap; white-space: normal; }
     .chat-input { font-size: 16px; }
     .chat-empty { padding: 16px 0; }
     .chat-suggest-grid { grid-template-columns: 1fr 1fr; }

--- a/tests/browser/chat.spec.js
+++ b/tests/browser/chat.spec.js
@@ -12,6 +12,8 @@ async function setup(page, context, signedIn = true) {
   await page.route(/\/v1\/models(?:\/picker)?$/, (route) => route.fulfill({ json: { data: [{
     id: MODEL, name: LONG_NAME, context_length: 1_000_000,
     pricing: { prompt: "0.000001", completion: "0.000002" },
+    trustedrouter: { open_weights: true, us_provider_available: true,
+      eu_focused_provider_available: true, capabilities: ["vision", "tools"] },
   }] } }));
   // All inference is mocked. Unexpected requests must never leave the test.
   await page.route("**/v1/chat/completions", (route) => route.fulfill({
@@ -48,6 +50,16 @@ test("chat and picker show full names with composer in viewport on desktop and m
     const rowName = page.locator(".chat-model-row-name").first();
     await expect(rowName).toHaveText(LONG_NAME);
     expect(await rowName.evaluate((el) => el.scrollWidth <= el.clientWidth + 1 && getComputedStyle(el).textOverflow !== "ellipsis")).toBe(true);
+    const rowLayout = await rowName.evaluate((el) => {
+      const row = el.closest(".chat-model-row");
+      return {
+        mainBottom: row.querySelector(".chat-model-row-main").getBoundingClientRect().bottom,
+        metaTop: row.querySelector(".chat-model-row-meta").getBoundingClientRect().top,
+        clipped: row.scrollWidth > row.clientWidth + 1,
+      };
+    });
+    expect(rowLayout.metaTop).toBeGreaterThanOrEqual(rowLayout.mainBottom);
+    expect(rowLayout.clipped).toBe(false);
     await page.screenshot({ path: testInfo.outputPath(`picker-${width}.png`) });
   }
 });


### PR DESCRIPTION
Follow-up to #1105 from the live production visual check. Provider badges and prices could squeeze model names into a narrow column on desktop. Put metadata below the full-width model name at every viewport and wrap filter buttons. Extend the browser fixture with all real catalog badges and assert metadata stays below the name without overflow. The regression reproduced before this fix. CSS lint passed; the complete browser suite is being rerun serially after local concurrency timeouts. No routing, pricing, or billing changes.