### PR TITLE
Schedule NEAR AI GLM 5.1/5.2 retirement for September 11

### DIFF
--- a/scripts/pricing/providers/near_ai.py
+++ b/scripts/pricing/providers/near_ai.py
@@ -25,6 +25,7 @@ from scripts.pricing.base import (
 )
 from scripts.pricing.manifest import write_discovered_chat_manifest
 from scripts.pricing.model_ids import remember_upstream_id
+from trusted_router.provider_lifecycle import provider_model_retired
 
 SLUG = "near-ai"
 CATALOG_URL = "https://cloud-api.near.ai/v1/models"
@@ -88,10 +89,13 @@ _DISCOVERED_MANIFEST_ROWS: dict[str, dict[str, Any]] = {}
 
 
 def canonical_model_id(native_id: str) -> str | None:
-    """Return a canonical ID only for a release-pinned direct workload."""
+    """Discover only active, release-pinned direct workloads."""
 
-    entry = _VERIFIED_DIRECT_MODELS.get(native_id.strip())
-    return entry[0] if entry is not None else None
+    native_id = native_id.strip()
+    entry = _VERIFIED_DIRECT_MODELS.get(native_id)
+    if entry is None or provider_model_retired(SLUG, entry[0], native_id):
+        return None
+    return entry[0]
 
 
 def _microdollars_per_million_from_per_token(value: object) -> int | None:
@@ -179,6 +183,11 @@ def fetch() -> ProviderPricingResult:
     if not isinstance(rows, list):
         raise RuntimeError("near-ai: authenticated model catalog returned an unexpected shape")
     domains = _direct_domains(endpoints_response.json())
+    active_direct_models = {
+        native_id: entry
+        for native_id, entry in _VERIFIED_DIRECT_MODELS.items()
+        if not provider_model_retired(SLUG, entry[0], native_id)
+    }
 
     prices: dict[str, ModelPrice] = {}
     discovered: dict[str, dict[str, Any]] = {}
@@ -187,9 +196,9 @@ def fetch() -> ProviderPricingResult:
         if not isinstance(source, dict) or source.get("owned_by") != "nearai":
             continue
         native_id = source.get("id")
-        if not isinstance(native_id, str) or native_id not in _VERIFIED_DIRECT_MODELS:
+        if not isinstance(native_id, str) or native_id not in active_direct_models:
             continue
-        model_id, pinned_domain = _VERIFIED_DIRECT_MODELS[native_id]
+        model_id, pinned_domain = active_direct_models[native_id]
         if domains.get(native_id) != pinned_domain:
             notes.append(f"direct endpoint mismatch for {native_id}")
             continue
@@ -224,7 +233,7 @@ def fetch() -> ProviderPricingResult:
 
     live_endpoints_without_prices = sorted(
         native_id
-        for native_id, (model_id, pinned_domain) in _VERIFIED_DIRECT_MODELS.items()
+        for native_id, (model_id, pinned_domain) in active_direct_models.items()
         if domains.get(native_id) == pinned_domain and model_id not in prices
     )
     if live_endpoints_without_prices:
@@ -234,7 +243,8 @@ def fetch() -> ProviderPricingResult:
         )
 
     _DISCOVERED_MANIFEST_ROWS = discovered
-    errors = validate(prices, EXPECTED_MODELS)
+    active_model_ids = {model_id for model_id, _domain in active_direct_models.values()}
+    errors = validate(prices, [model_id for model_id in EXPECTED_MODELS if model_id in active_model_ids])
     if errors:
         raise RuntimeError("; ".join(errors))
     return ProviderPricingResult(

--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -28,6 +28,7 @@ TOGETHER_MINIMAX_M27_RETIREMENT_AT = datetime(2026, 7, 27, 0, 0, tzinfo=UTC)
 BASETEN_JULY_2026_RETIREMENT_AT = datetime(2026, 7, 25, 0, 0, tzinfo=UTC)
 TINFOIL_KIMI_K26_RETIREMENT_AT = datetime(2026, 8, 3, 0, 0, tzinfo=UTC)
 TINFOIL_GLM52_RETIREMENT_AT = datetime(2026, 9, 10, 0, 0, tzinfo=UTC)
+NEAR_AI_SEPTEMBER_2026_RETIREMENT_AT = datetime(2026, 9, 11, 13, 0, tzinfo=UTC)
 PARASAIL_AUGUST_2026_RETIREMENT_AT = datetime(2026, 8, 4, 0, 0, tzinfo=UTC)
 FRIENDLI_QWEN3_235B_RETIREMENT_AT = datetime(2026, 8, 5, 0, 0, tzinfo=UTC)
 FRIENDLI_K_EXAONE_236B_RETIREMENT_AT = datetime(2026, 8, 20, 0, 0, tzinfo=UTC)
@@ -110,6 +111,15 @@ class _Retirement:
 
 
 _RETIREMENTS = (
+    # NEAR announced both GLM retirements for 2026-09-11 13:00 UTC. Do not
+    # silently substitute the suggested GLM 5.3 Flash: its direct workload
+    # requires separate attestation review. Other providers are unaffected.
+    _Retirement(
+        provider="near-ai",
+        model_ids=frozenset({"z-ai/glm-5.1", "z-ai/glm-5.2"}),
+        upstream_ids=frozenset({"zai-org/GLM-5.1-FP8", "z-ai/glm-5.2"}),
+        effective_at=NEAR_AI_SEPTEMBER_2026_RETIREMENT_AT,
+    ),
     # Xiaomi announced that the limited-beta MiMo V2.5 Pro UltraSpeed Model
     # API ends on 2026-09-08 in UTC+08. No exact hour or replacement was
     # provided, so retire conservatively at the start of that local date.

--- a/tests/test_near_ai_provider.py
+++ b/tests/test_near_ai_provider.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +12,8 @@ from fastapi import HTTPException
 from scripts.check_price_coverage import _DISCOVERABLE_MANIFEST_PROVIDERS
 from scripts.pricing.providers import near_ai
 from scripts.pricing.refresh import PROVIDER_SLUGS
+from tests.lifecycle_clock import CATALOG_CLOCK
+from trusted_router import provider_lifecycle
 from trusted_router.catalog import MODEL_ENDPOINTS, PROVIDERS
 from trusted_router.catalog_data import (
     PRIVACY_TIER_CONFIDENTIAL,
@@ -60,6 +63,7 @@ def _endpoints(*native_ids: str) -> dict[str, Any]:
 def test_near_ai_fetch_intersects_catalog_direct_registry_and_release_policy(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: datetime(2026, 9, 5, tzinfo=UTC))
     dsv4 = "deepseek-ai/DeepSeek-V4-Flash"
     glm = "z-ai/glm-5.2"
     catalog = {
@@ -220,7 +224,10 @@ def test_near_ai_manifest_and_catalog_are_attested_prepaid_only() -> None:
         endpoint for endpoint in MODEL_ENDPOINTS.values() if endpoint.provider == "near-ai"
     ]
     assert endpoints
-    assert {endpoint.model_id for endpoint in endpoints} == manifest_ids
+    assert {endpoint.model_id for endpoint in endpoints} == {
+        model_id for model_id in manifest_ids
+        if not provider_lifecycle.provider_model_retired("near-ai", model_id, at=CATALOG_CLOCK)
+    }
     assert {endpoint.usage_type for endpoint in endpoints} == {"Credits"}
     assert all(not endpoint.is_byok for endpoint in endpoints)
     assert all(
@@ -240,12 +247,12 @@ def test_near_ai_manifest_and_catalog_are_attested_prepaid_only() -> None:
 
 def test_near_ai_is_e2e_eligible_but_never_satisfies_zdr_or_deny() -> None:
     e2e_ids = {model.id for model in e2e_candidate_models(limit=100)}
-    assert "z-ai/glm-5.2" in e2e_ids
+    assert "deepseek/deepseek-v4-flash" in e2e_ids
 
     settings = Settings(environment="test")
     e2e = chat_route_endpoint_candidates(
         {
-            "model": "z-ai/glm-5.2",
+            "model": "deepseek/deepseek-v4-flash",
             "provider": {"only": ["near-ai"], "min_privacy": "e2e"},
         },
         settings,
@@ -258,7 +265,7 @@ def test_near_ai_is_e2e_eligible_but_never_satisfies_zdr_or_deny() -> None:
     ):
         with pytest.raises(HTTPException) as exc_info:
             chat_route_endpoint_candidates(
-                {"model": "z-ai/glm-5.2", "provider": provider_filter},
+                {"model": "deepseek/deepseek-v4-flash", "provider": provider_filter},
                 settings,
             )
         assert getattr(exc_info.value, "status_code", None) == 400
@@ -272,7 +279,7 @@ def test_near_ai_hourly_refresh_secret_and_authority_wiring_are_complete() -> No
     url, env_names, normalize = discoverable["near-ai"]
     assert url == near_ai.CATALOG_URL
     assert env_names == ("NEAR_API_KEY",)
-    assert normalize("z-ai/glm-5.2") == "z-ai/glm-5.2"
+    assert normalize("deepseek-ai/DeepSeek-V4-Flash") == "deepseek/deepseek-v4-flash"
     assert normalize("unreviewed/model") is None
     assert "near_ai" in PROVIDER_SLUGS
     assert "near-ai" in _AUTHORITATIVE_PROVIDER_MANIFEST_SLUGS

--- a/tests/test_near_ai_september_2026_lifecycle.py
+++ b/tests/test_near_ai_september_2026_lifecycle.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import httpx
+import pytest
+
+from scripts.pricing.providers import near_ai
+from tests.lifecycle_clock import catalog_predates
+from tests.test_near_ai_provider import _catalog_row, _endpoints
+from trusted_router import catalog, provider_lifecycle
+
+_CUTOFF = datetime(2026, 9, 11, 13, 0, tzinfo=UTC)
+_RETIRING = (("z-ai/glm-5.1", "zai-org/GLM-5.1-FP8"), ("z-ai/glm-5.2", "z-ai/glm-5.2"))
+_DSV4 = "deepseek-ai/DeepSeek-V4-Flash"
+
+
+@pytest.mark.parametrize(("model_id", "native_id"), _RETIRING)
+def test_near_ai_exact_cutoff_and_provider_scope(model_id: str, native_id: str) -> None:
+    retired = provider_lifecycle.provider_model_retired
+    assert not retired("near-ai", model_id, native_id, at=_CUTOFF - timedelta(microseconds=1))
+    assert retired("near-ai", model_id, at=_CUTOFF)
+    assert retired("near-ai", "other-canonical-id", native_id, at=_CUTOFF)
+    assert not retired("deepinfra", model_id, native_id, at=_CUTOFF)
+    assert not retired("near-ai", "z-ai/glm-5.3-flash", at=_CUTOFF)
+    assert not retired("near-ai", "z-ai/glm-5.2-long", at=_CUTOFF)
+
+
+@pytest.mark.parametrize(("model_id", "native_id"), _RETIRING)
+def test_near_ai_runtime_cutoff_without_catalog_reload(
+    monkeypatch: pytest.MonkeyPatch, model_id: str, native_id: str
+) -> None:
+    template = catalog.MODEL_ENDPOINTS["deepseek/deepseek-v4-flash@near-ai/prepaid"]
+    endpoint = replace(template, model_id=model_id, upstream_id=native_id)
+    monkeypatch.setattr(catalog, "MODEL_ENDPOINTS", {endpoint.id: endpoint})
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF - timedelta(microseconds=1))
+    assert catalog.endpoints_for_model(model_id) == [endpoint]
+    assert near_ai.canonical_model_id(native_id) == model_id
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    assert catalog.endpoints_for_model(model_id) == []
+    assert near_ai.canonical_model_id(native_id) is None
+
+
+def test_near_ai_imported_catalog_matches_cutoff() -> None:
+    for model_id, _native_id in _RETIRING:
+        assert (f"{model_id}@near-ai/prepaid" in catalog.MODEL_ENDPOINTS) is catalog_predates(_CUTOFF)
+
+
+@pytest.mark.parametrize("after_cutoff", [False, True])
+@pytest.mark.parametrize("price_rows_present", [False, True])
+def test_near_ai_refresh_cutoff_and_missing_price_guard(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    after_cutoff: bool,
+    price_rows_present: bool,
+) -> None:
+    monkeypatch.setattr(
+        provider_lifecycle, "_utc_now",
+        lambda: _CUTOFF if after_cutoff else _CUTOFF - timedelta(microseconds=1),
+    )
+    retiring_ids = [native for _model, native in _RETIRING]
+    # A stale direct registry may still advertise retired endpoints after their
+    # pricing rows disappear. Only retired models may bypass that safety gate.
+    rows = [_catalog_row(_DSV4), _catalog_row("z-ai/glm-5.3-flash")]
+    if price_rows_present:
+        rows.extend(_catalog_row(native) for native in retiring_ids)
+    endpoints = _endpoints(_DSV4, *retiring_ids)
+    endpoints["endpoints"].append({
+        "domain": "glm-5-3-flash.completions.near.ai", "models": ["z-ai/glm-5.3-flash"],
+    })
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        payload = {"data": rows} if str(request.url) == near_ai.CATALOG_URL else endpoints
+        return httpx.Response(200, json=payload)
+
+    monkeypatch.setenv("NEAR_API_KEY", "test-key")
+    monkeypatch.setattr(near_ai.httpx, "HTTPTransport", lambda **_: httpx.MockTransport(respond))
+    monkeypatch.setattr(near_ai, "_DISCOVERED_MANIFEST_ROWS", {})
+    monkeypatch.setattr(near_ai, "UPSTREAM_ID_MAP", dict(near_ai.UPSTREAM_ID_MAP))
+    monkeypatch.setattr(near_ai, "MANIFEST_PATH", tmp_path / "near-ai.json")
+    if not after_cutoff and not price_rows_present:
+        with pytest.raises(RuntimeError, match="endpoint remains published without a pricing row"):
+            near_ai.fetch()
+        return
+
+    result = near_ai.fetch()
+    expected = {"deepseek/deepseek-v4-flash"}
+    if not after_cutoff:
+        expected.update(model for model, _native in _RETIRING)
+    assert set(result.prices) == expected
+    assert set(near_ai._DISCOVERED_MANIFEST_ROWS) == expected
+    for model_id, native_id in _RETIRING:
+        if not after_cutoff:
+            assert near_ai._DISCOVERED_MANIFEST_ROWS[model_id]["upstream_id"] == native_id
+    # The replacement must pass separate attestation review, not inherit pins
+    # from either retired model just because the upstream suggests migration.
+    assert "z-ai/glm-5.3-flash" not in result.prices
+    near_ai.write_provider_manifest(result)
+    manifest = json.loads(near_ai.MANIFEST_PATH.read_text())
+    assert {row["id"] for row in manifest["models"]} == expected


### PR DESCRIPTION
## Change
- Retire only NEAR AI `zai-org/GLM-5.1-FP8` and `z-ai/glm-5.2` at **2026-09-11 13:00 UTC** using the shared lifecycle policy.
- Keep the original upstream IDs until cutoff; do not silently substitute GLM 5.3 Flash or affect equivalent models on other providers.
- Filter retired workloads consistently from authenticated pricing discovery, expected-model validation, missing-price checks, and coverage normalization. Active workloads still fail closed on missing prices or attestation/domain drift.
- Keep the GLM 5.3 Flash replacement behind its own attestation review. The live NEAR direct registry publishes it, but our released workload allowlist does not yet pin it.

## Validation
- Reproduced **6 failing regressions before the fix**.
- **20 focused tests passed** with the normal clock and **20 passed** with the post-cutover clock (2027-01-01).
- Tests cover exact cutoff, provider scope, running-server filtering without catalog reload, unchanged upstream IDs, stale feeds, missing pricing, and replacement not bypassing attestation.
- Whole-tree Ruff and mypy pass. Full local suite/coverage running; CI required before merge.
- Claude CLI Opus review attempted, but local CLI reports not logged in. No API-key fallback was used.

## Rollout
Normal CI-gated control-plane deployment. No enclave changes, credential changes, or immediate traffic migration.