### PR TITLE
Prevent full-table Spanner payment ownership searches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,17 @@ is a no-op — the next rollout overwrites it.
 
 **Never** run large unbatched DML against production Spanner during a rolling deploy.
 
+**Read-only is not load-safe.** Never search production `tr_entities.body` with
+`LIKE`, regular expressions, or JSON predicates without a complete indexed key.
+`LIMIT 5` limits results, not the rows scanned. Do not discover entity kinds with
+wildcard `COUNT(*)` queries. Three ad hoc Stripe-ID body searches caused the
+September 6 CPU incident. Use `python -m scripts.inspect_payment_owner` for
+payment ownership; it retrieves the Stripe object and performs at most two
+complete-primary-key Spanner reads, at LOW priority, with short deadlines and
+no retries. Missing metadata is a stop condition, not permission to full-scan.
+Use bounded `SPANNER_SYS` statistics for CPU investigations and ClickHouse for
+request analytics. Never loosen the 45% CPU alarm to make operator scans pass.
+
 ## Money code
 
 `reserve` / `settle` / `refund` and anything touching credits are the highest-risk code in the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# Repository instructions
+
+Read [AGENTS.md](AGENTS.md) before operating on this repository or production.
+Its Spanner query safety rules apply to read-only investigations too. A small
+SQL LIMIT does not make a legacy JSON-body search safe. Use the bounded payment
+ownership helper for Stripe attribution and ClickHouse for request analytics.

--- a/docs/incidents/2026-09-06-spanner-operator-search-cpu.md
+++ b/docs/incidents/2026-09-06-spanner-operator-search-cpu.md
@@ -1,0 +1,65 @@
+# Spanner CPU spike from administrative payment searches
+
+## Evidence
+
+All timestamps below are UTC, on 2026-09-06 (September 5 evening in California).
+
+- Three literal Stripe PaymentIntent searches completed in the 03:15 and 03:16
+  query-statistics buckets. Each searched `tr_entities` with a leading-wildcard
+  `body LIKE` or `id LIKE`, without a leading primary-key predicate, and used
+  `LIMIT 5`.
+- The three searches consumed 30.38, 30.26 and 30.14 CPU-seconds respectively;
+  each took approximately 35 seconds wall time.
+- Top-query CPU was normally about 7-8 seconds per minute. At 03:15 it was
+  67.30 CPU-seconds, of which 60.63 came from these searches; at 03:16 it was
+  45.80, of which 30.14 came from the searches.
+- The high-priority CPU alert opened at approximately 03:23, reporting 61.03%
+  against the unchanged 45% threshold. Its recovery notification approximately
+  78 seconds later reported 19.73%.
+- The alert definition uses five-minute maximum alignment and a five-minute
+  condition duration. Email time is not the start time of the expensive query.
+- No internal gateway billing HTTP 5xx was found in Cloud Run request logs
+  between 03:10 and 03:26. This does not assert that every customer request was
+  successful; fast authorization 429s require separate classification.
+- No recurrence of these body searches was found in the bounded system
+  statistics after 03:17 at the follow-up check.
+
+## Root cause
+
+A read-only administrative lookup was treated as harmless because it returned
+at most five rows. The result limit did not bound work: finding an absent or
+unindexed substring still scans the legacy entity table. The payment processor
+already supports direct retrieval by the identifiers being investigated.
+
+The accounts associated with the searched payments were resolved privately by
+an exact Stripe GET and complete-key workspace/user reads. They are subjects
+of the investigation, not proof that those customers caused the incident.
+Payment IDs, customer emails and workspace IDs are deliberately omitted here.
+
+Spanner data-access audit records for the original query window were not
+available to the incident reader, so the original authenticated caller remains
+unverified. Do not attribute the queries to a named person or agent by inference.
+
+## Remediation
+
+- Added `scripts.inspect_payment_owner`: one exact Stripe GET and at most two
+  complete-primary-key Spanner reads. There is no arbitrary-SQL option and no
+  fallback body search when metadata is absent.
+- All Spanner reads use LOW priority, the `tr_ops_payment_owner` request tag,
+  five-second RPC deadlines and no automatic retries. Session creation and
+  deletion also have explicit deadlines and no retries.
+- Use the generated RPC client, not the high-level session manager. A live
+  test exposed unbounded SDK session setup and an unnecessary background
+  metrics exporter with a read-only credential; neither is used by the helper.
+- The helper emits start/end/failure receipts, including its own operator
+  service-account identity, without keys, payment response bodies, or card data.
+  Email output requires `--include-email`.
+- Added explicit guidance in AGENTS.md, a Claude entry point, and the Spanner
+  runbook. Tested complete-key constraints, privacy, failure paths, session
+  lifecycle and the absence of retry/search fallbacks.
+
+The spike recovered before remediation. No customer balance, application
+deployment, alert threshold, suppression, or IAM grant was changed. This tool
+is a safe operational path, not an IAM-enforced restriction on arbitrary SQL.
+Replacing broad operator SQL access with a reviewed query broker is a separate
+access-design change; existing audits must be migrated before removing access.

--- a/docs/spanner-reliability.md
+++ b/docs/spanner-reliability.md
@@ -81,6 +81,28 @@ latency, and error analytics from ClickHouse. Do not aggregate or full-scan raw
 Spanner generation, entity, or analytics-outbox rows for reporting. Spanner is
 reserved for bounded ledger and control-plane reads on this path.
 
+For payment ownership, use the bounded operator helper rather than searching
+JSON bodies for a Stripe ID:
+
+```bash
+uv run python -m scripts.inspect_payment_owner \
+  --project quill-cloud-proxy --instance trusted-router-nam6 \
+  --database trusted-router --payment-intent pi_EXAMPLE --include-email
+```
+
+Supply the existing read-only credential through
+`CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE` and the Stripe key through
+`STRIPE_SECRET_KEY`; never print key values. The helper performs one exact
+Stripe GET followed by at most two Spanner primary-key reads. Reads are tagged
+`tr_ops_payment_owner`, LOW priority, have five-second RPC timeouts, and do not
+retry. It reports missing attribution without scanning for a replacement.
+An owner found this way is the **current workspace owner**, not proof of who
+made a historical payment or caused a database incident.
+
+`LIMIT` is not a query-work budget. A leading-wildcard body search still scans
+the table when it returns zero rows. Operators with direct SQL access can bypass
+the helper, so it is an approved safe path, not an IAM-enforced SQL firewall.
+
 ### Transaction contention
 
 Inspect Spanner transaction and lock insights. A high abort ratio or lock-wait

--- a/scripts/inspect_payment_owner.py
+++ b/scripts/inspect_payment_owner.py
@@ -1,0 +1,189 @@
+"""Read payment ownership without scanning the production ledger.
+
+Stripe is queried by PaymentIntent ID. Spanner is read by complete primary
+keys only. This tool never credits, refunds, retries, or repairs a payment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+READ_TIMEOUT_SECONDS = 5.0
+ALLOWED_ENTITY_KINDS = frozenset({"workspace", "user"})
+
+
+def _identifier(value: object, *, label: str) -> str:
+    if not isinstance(value, str) or not re.fullmatch(r"[A-Za-z0-9_:@.+-]{1,256}", value):
+        raise ValueError(f"Invalid {label}")
+    return value
+
+
+def stripe_payment_metadata(client: httpx.Client, payment_intent: str) -> dict[str, Any]:
+    if not re.fullmatch(r"pi_[A-Za-z0-9]{1,240}", payment_intent):
+        raise ValueError("Expected one Stripe PaymentIntent ID")
+    response = client.get(f"https://api.stripe.com/v1/payment_intents/{payment_intent}")
+    if response.status_code != 200:
+        # Do not dump provider response bodies, request headers or card details.
+        raise RuntimeError(f"Stripe lookup returned HTTP {response.status_code}")
+    payment = response.json()
+    if not isinstance(payment, dict) or payment.get("id") != payment_intent:
+        raise ValueError("Stripe returned an unexpected payment")
+    metadata = payment.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        raise ValueError("Stripe returned malformed payment metadata")
+    return {
+        "payment_intent": payment_intent,
+        "payment_status": payment.get("status"),
+        "workspace_id": metadata.get("workspace_id"),
+        "initiating_user_id": metadata.get("initiating_user_id"),
+    }
+
+
+def read_entity(client: Any, session_name: str, kind: str, entity_id: str) -> dict[str, Any] | None:
+    if kind not in ALLOWED_ENTITY_KINDS:
+        raise ValueError("Entity kind is not allowed for payment ownership lookup")
+    entity_id = _identifier(entity_id, label="entity ID")
+    rows = client.read(
+        request={
+            "session": session_name,
+            "table": "tr_entities",
+            "columns": ["body"],
+            "key_set": {"keys": [[kind, entity_id]]},
+            "limit": 1,
+            "transaction": {"single_use": {"read_only": {"strong": True}}},
+            "request_options": {"priority": "PRIORITY_LOW", "request_tag": "tr_ops_payment_owner"},
+        },
+        retry=None,
+        timeout=READ_TIMEOUT_SECONDS,
+    ).rows
+    if not rows:
+        return None
+    body = json.loads(rows[0][0])
+    if not isinstance(body, dict):
+        raise ValueError("Invalid entity metadata")
+    return body
+
+
+def resolve_owner(
+    payment: dict[str, Any],
+    reader: Callable[[str, str], dict[str, Any] | None],
+    *,
+    include_email: bool = False,
+) -> dict[str, Any]:
+    result = {
+        "payment_intent": payment["payment_intent"],
+        "payment_status": payment.get("payment_status"),
+    }
+    workspace_id = payment.get("workspace_id")
+    if not workspace_id:
+        return {**result, "attribution": "missing_workspace_metadata"}
+    workspace_id = _identifier(workspace_id, label="workspace ID")
+    workspace = reader("workspace", workspace_id)
+    result["workspace_id"] = workspace_id
+    if workspace is None:
+        return {**result, "attribution": "workspace_not_found"}
+    if workspace.get("federated_home"):
+        return {**result, "attribution": "workspace_has_remote_home"}
+    initiating_user_id = payment.get("initiating_user_id")
+    owner_user_id = workspace.get("owner_user_id")
+    user_id = initiating_user_id or owner_user_id
+    if not user_id:
+        return {**result, "attribution": "missing_user_metadata"}
+    user_id = _identifier(user_id, label="user ID")
+    user = reader("user", user_id)
+    result["user_id"] = user_id
+    if user is None:
+        return {**result, "attribution": "user_not_found"}
+    result["attribution"] = "initiating_user" if initiating_user_id else "current_workspace_owner"
+    # The current owner is not proof of who owned the workspace when it paid.
+    if include_email:
+        result["email"] = user.get("email")
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project", required=True)
+    parser.add_argument("--instance", required=True)
+    parser.add_argument("--database", required=True)
+    parser.add_argument("--payment-intent", required=True)
+    parser.add_argument("--include-email", action="store_true")
+    args = parser.parse_args(argv)
+    credential_file = os.environ.get("CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE")
+    stripe_key = os.environ.get("STRIPE_SECRET_KEY")
+    if not credential_file or not stripe_key:
+        parser.error("CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE and STRIPE_SECRET_KEY are required")
+
+    from google.cloud.spanner_v1.services.spanner import SpannerClient
+    from google.oauth2 import service_account
+
+    credentials = service_account.Credentials.from_service_account_file(
+        Path(credential_file), scopes=["https://www.googleapis.com/auth/spanner.data"]
+    )
+    print(
+        json.dumps(
+            {
+                "event": "payment_owner_lookup_started",
+                "operator_email": credentials.service_account_email,
+            }
+        ),
+        file=sys.stderr,
+    )
+    try:
+        with httpx.Client(
+            headers={"Authorization": f"Bearer {stripe_key}"},
+            timeout=READ_TIMEOUT_SECONDS,
+            follow_redirects=False,
+            transport=httpx.HTTPTransport(retries=0),
+        ) as client:
+            payment = stripe_payment_metadata(client, args.payment_intent)
+        # Missing Stripe metadata is terminal. Never try a body search to fill it.
+        if payment.get("workspace_id"):
+            # Use the bounded RPC client: no session pool, background metrics
+            # exporter, or implicit session-creation retries for an ops lookup.
+            with SpannerClient(credentials=credentials) as spanner_client:
+                session = spanner_client.create_session(
+                    request={
+                        "database": f"projects/{args.project}/instances/{args.instance}/databases/{args.database}"
+                    },
+                    retry=None,
+                    timeout=READ_TIMEOUT_SECONDS,
+                )
+                try:
+                    result = resolve_owner(
+                        payment,
+                        lambda kind, entity_id: read_entity(
+                            spanner_client, session.name, kind, entity_id
+                        ),
+                        include_email=args.include_email,
+                    )
+                finally:
+                    spanner_client.delete_session(
+                        request={"name": session.name},
+                        retry=None,
+                        timeout=READ_TIMEOUT_SECONDS,
+                    )
+        else:
+            result = {**payment, "attribution": "missing_workspace_metadata"}
+        print(json.dumps(result, sort_keys=True))
+    except Exception as exc:
+        print(
+            json.dumps({"event": "payment_owner_lookup_failed", "error_type": type(exc).__name__}),
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps({"event": "payment_owner_lookup_completed"}), file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_inspect_payment_owner.py
+++ b/tests/test_inspect_payment_owner.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+import pytest
+
+from scripts import inspect_payment_owner as lookup
+
+
+def test_point_read_has_complete_key_low_priority_deadline_and_no_retry() -> None:
+    calls: list[dict[str, Any]] = []
+
+    class Client:
+        def read(self, **kwargs: Any) -> Any:
+            from google.cloud.spanner_v1.types import ResultSet
+
+            calls.append(kwargs)
+            return ResultSet(rows=[[json.dumps({"owner_user_id": "user-1"})]])
+
+    assert lookup.read_entity(Client(), "session-1", "workspace", "ws-1") == {
+        "owner_user_id": "user-1"
+    }
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["request"]["session"] == "session-1"
+    assert call["request"]["table"] == "tr_entities"
+    assert call["request"]["key_set"] == {"keys": [["workspace", "ws-1"]]}
+    assert call["request"]["limit"] == 1
+    assert call["timeout"] == 5.0
+    assert call["retry"] is None
+    assert call["request"]["request_options"]["priority"] == "PRIORITY_LOW"
+    assert call["request"]["request_options"]["request_tag"] == "tr_ops_payment_owner"
+
+
+@pytest.mark.parametrize(
+    "kind,entity_id",
+    [("api_key", "key-1"), ("workspace", ""), ("workspace", "%"), ("user", "x' OR 1=1")],
+)
+def test_unsafe_entity_lookup_rejected_without_database_call(kind: str, entity_id: str) -> None:
+    with pytest.raises(ValueError):
+        lookup.read_entity(None, "session-1", kind, entity_id)
+
+
+def test_payment_read_is_exact_and_redacts_unrelated_provider_fields() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert str(request.url) == "https://api.stripe.com/v1/payment_intents/pi_example"
+        assert request.method == "GET"
+        return httpx.Response(
+            200,
+            json={
+                "id": "pi_example",
+                "status": "succeeded",
+                "client_secret": "must-not-appear",
+                "metadata": {"workspace_id": "ws-1", "prompt": "must-not-appear"},
+            },
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        result = lookup.stripe_payment_metadata(client, "pi_example")
+    assert result["workspace_id"] == "ws-1"
+    assert "must-not-appear" not in json.dumps(result)
+
+
+@pytest.mark.parametrize(
+    "value", ["", "pi_../../customers", "pi_x?expand[]=customer", "cus_example"]
+)
+def test_bad_payment_id_is_rejected_before_http(value: str) -> None:
+    with pytest.raises(ValueError):
+        lookup.stripe_payment_metadata(None, value)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("status", [302, 401, 404, 429, 500])
+def test_provider_errors_do_not_retry_or_expose_response_body(status: int) -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(status, text="private payment information")
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(RuntimeError, match=f"HTTP {status}") as exc:
+            lookup.stripe_payment_metadata(client, "pi_example")
+    assert calls == 1
+    assert "private" not in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "initiator,expected_user,attribution",
+    [(None, "owner", "current_workspace_owner"), ("buyer", "buyer", "initiating_user")],
+)
+def test_owner_resolution_is_two_point_reads_and_email_is_opt_in(
+    initiator: str | None, expected_user: str, attribution: str
+) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def reader(kind: str, entity_id: str) -> dict[str, Any]:
+        calls.append((kind, entity_id))
+        return (
+            {"owner_user_id": "owner"}
+            if kind == "workspace"
+            else {"email": "buyer@example.com", "password_hash": "private"}
+        )
+
+    payment = {
+        "payment_intent": "pi_example",
+        "workspace_id": "ws-1",
+        "initiating_user_id": initiator,
+    }
+    result = lookup.resolve_owner(payment, reader)
+    assert calls == [("workspace", "ws-1"), ("user", expected_user)]
+    assert result["attribution"] == attribution
+    assert "email" not in result
+    assert "private" not in json.dumps(result)
+    assert lookup.resolve_owner(payment, reader, include_email=True)["email"] == "buyer@example.com"
+
+
+def test_missing_metadata_does_not_search_for_a_customer() -> None:
+    def reader(kind: str, entity_id: str) -> dict[str, Any]:
+        pytest.fail("missing metadata must not fall back to a database scan")
+
+    assert (
+        lookup.resolve_owner({"payment_intent": "pi_example"}, reader)["attribution"]
+        == "missing_workspace_metadata"
+    )
+
+
+@pytest.mark.parametrize(
+    "workspace,expected",
+    [
+        (None, "workspace_not_found"),
+        ({}, "missing_user_metadata"),
+        ({"federated_home": "aws", "owner_user_id": "owner"}, "workspace_has_remote_home"),
+    ],
+)
+def test_missing_and_remote_workspace_is_not_guessed(
+    workspace: dict[str, Any] | None, expected: str
+) -> None:
+    calls: list[str] = []
+
+    def reader(kind: str, entity_id: str) -> dict[str, Any] | None:
+        calls.append(kind)
+        return workspace
+
+    assert (
+        lookup.resolve_owner({"payment_intent": "pi_example", "workspace_id": "ws-1"}, reader)[
+            "attribution"
+        ]
+        == expected
+    )
+    assert calls == ["workspace"]
+
+
+@pytest.mark.parametrize("with_workspace", [True, False])
+def test_cli_lifecycle_and_redacted_operator_receipt(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], with_workspace: bool
+) -> None:
+    from google.cloud.spanner_v1.services import spanner
+    from google.oauth2 import service_account
+
+    monkeypatch.setenv("CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE", "/not-read-in-test.json")
+    monkeypatch.setenv("STRIPE_SECRET_KEY", "test-placeholder")
+    monkeypatch.setattr(
+        service_account.Credentials,
+        "from_service_account_file",
+        lambda *a, **kw: SimpleNamespace(service_account_email="ops@example.com"),
+    )
+    events: list[str] = []
+
+    class FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            assert with_workspace
+            assert kwargs["credentials"].service_account_email == "ops@example.com"
+            events.append("client_opened")
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def create_session(self, **kwargs: Any) -> Any:
+            assert (
+                kwargs["request"]["database"]
+                == "projects/test-project/instances/test-instance/databases/test-database"
+            )
+            assert kwargs["retry"] is None
+            assert kwargs["timeout"] == 5.0
+            return SimpleNamespace(name="session-1")
+
+        def delete_session(self, **kwargs: Any) -> None:
+            assert kwargs == {"request": {"name": "session-1"}, "retry": None, "timeout": 5.0}
+            events.append("session_deleted")
+
+        def __exit__(self, *args: Any) -> None:
+            events.append("client_closed")
+
+    monkeypatch.setattr(spanner, "SpannerClient", FakeClient)
+    monkeypatch.setattr(
+        lookup,
+        "read_entity",
+        lambda client, session, kind, key: (
+            {"owner_user_id": "owner"} if kind == "workspace" else {"email": "owner@example.com"}
+        ),
+    )
+    real_http_client = httpx.Client
+
+    def make_http_client(**kwargs: Any) -> httpx.Client:
+        assert kwargs["timeout"] == 5.0
+        assert kwargs["follow_redirects"] is False
+        kwargs["transport"].close()
+        kwargs["transport"] = httpx.MockTransport(
+            lambda request: httpx.Response(
+                200,
+                json={
+                    "id": "pi_example",
+                    "metadata": {"workspace_id": "ws-1"} if with_workspace else {},
+                },
+            )
+        )
+        return real_http_client(**kwargs)
+
+    monkeypatch.setattr(httpx, "Client", make_http_client)
+    assert (
+        lookup.main(
+            [
+                "--project",
+                "test-project",
+                "--instance",
+                "test-instance",
+                "--database",
+                "test-database",
+                "--payment-intent",
+                "pi_example",
+                "--include-email",
+            ]
+        )
+        == 0
+    )
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert "test-placeholder" not in captured.out + captured.err
+    assert [json.loads(line)["event"] for line in captured.err.splitlines()] == [
+        "payment_owner_lookup_started",
+        "payment_owner_lookup_completed",
+    ]
+    assert json.loads(captured.err.splitlines()[0])["operator_email"] == "ops@example.com"
+    if with_workspace:
+        assert output["email"] == "owner@example.com"
+        assert events == ["client_opened", "session_deleted", "client_closed"]
+    else:
+        assert events == []
+        assert output["attribution"] == "missing_workspace_metadata"
+
+
+def test_cli_refuses_arbitrary_sql_before_credentials_are_read() -> None:
+    with pytest.raises(SystemExit) as exc:
+        lookup.main(["--sql", "SELECT body FROM tr_entities"])
+    assert exc.value.code == 2


### PR DESCRIPTION
## Incident
Three administrative Stripe-ID substring searches scanned the legacy entity table and consumed about 91 CPU-seconds. The strict 45% CPU alert correctly fired and recovered. The original caller is not proven by the available audit evidence. Customer identifiers are intentionally omitted.

## Fix
- Add a read-only PaymentIntent ownership helper: one exact Stripe GET, at most two complete-key Spanner reads, LOW priority, five-second RPC deadlines, no retries or arbitrary SQL.
- Use the generated Spanner RPC client without a background metrics exporter or session pool.
- Require opt-in email output and distinguish the current workspace owner from a recorded initiating user.
- Document safe incident queries in AGENTS.md, CLAUDE.md, the runbook, and an incident report.

## Verification
- Ruff and mypy passed, including the new script.
- 24 focused tests passed; the full local suite passed with 8,976 tests, 368 skips, 10 expected failures, and 84% coverage.
- Exact read-only production lookup succeeded for all three searched PaymentIntents.

No balances, IAM, application deployment, or alert thresholds changed. This is an approved safe lookup path, not an IAM-enforced SQL firewall.