### PR TITLE
trust: accept lifetime-backfill markers as credit evidence; isolate per-provider unmatched ids

### DIFF
--- a/src/trusted_router/stripe_trust_history.py
+++ b/src/trusted_router/stripe_trust_history.py
@@ -39,6 +39,9 @@ class StripeTrustScan:
     #: the payment was credited locally. Empty means no derivable evidence: the
     #: writer must then refuse the payment fact (decision 76, P1-B).
     credit_evidence: Mapping[str, tuple[str, ...]] = field(default_factory=dict)
+    #: Unmatched adverse id -> provider inferred from the referenced PI metadata.
+    #: Without an x402 stamp, the Stripe API object belongs to Stripe's summary.
+    unmatched_providers: Mapping[str, str] = field(default_factory=dict)
 
 
 def _mapping(value: Any) -> dict[str, Any]:
@@ -380,8 +383,8 @@ def credit_evidence_ids(
 ) -> tuple[str, ...]:
     """Candidate ``stripe_event`` marker ids proving this payment was credited.
 
-    The live credit paths key their idempotency marker as follows, and only
-    these keys count as local credit evidence:
+    The accepted marker keys are listed below. Each is only a candidate:
+    local credit evidence still requires the marker row to exist.
 
     * x402: ``x402_event_id(pi)`` (services/x402_billing.py);
     * ACH Checkout: ``stripe_checkout:<payment_intent or session id>``
@@ -389,6 +392,12 @@ def credit_evidence_ids(
     * card Checkout and auto-refill: the Stripe Event id of the crediting
       webhook, which is only knowable from Stripe's Events API (30-day
       retention) or an operator-attested list (``--credited-events``).
+    * Stripe (non-x402): ``lifetime_backfill:stripe:<payment_intent_id>``
+      records an applied lifetime paid-top-up total backfill for that PI.
+      ``scripts/backfill_lifetime_topups.py`` says: "This script changes only
+      ``tr_user_lifetime_topup`` through ``Store.add_lifetime_topup``; it never
+      grants workspace credits." It attests the historical paid top-up, not
+      a new workspace credit grant.
     """
 
     payment_intent_id = str(payment_intent.get("id") or "")
@@ -409,6 +418,8 @@ def credit_evidence_ids(
         session_id = str(session.get("id") or "")
         if payment_method == "ach" and session_id:
             candidates.append(f"stripe_checkout:{session_id}")
+    if payment_intent_id and _provider_for_payment(payment_intent) == "stripe":
+        candidates.append(f"lifetime_backfill:stripe:{payment_intent_id}")
     for event_id in crediting_event_ids:
         if event_id and event_id not in candidates:
             candidates.append(str(event_id))
@@ -530,13 +541,18 @@ def scan_stripe_responses(
     source_adverse: list[TrustEvent] = []
     outstanding: list[OutstandingAdverse] = []
     unmatched: list[str] = []
+    unmatched_providers: dict[str, str] = {}
 
     def append_adverse(obj: dict[str, Any], *, kind: str) -> None:
         adverse_ref = str(obj.get("id") or "")
         payment_ref = _object_id(obj.get("payment_intent"))
         payment = payment_events.get(payment_ref)
         if not adverse_ref or payment is None:
-            unmatched.append(adverse_ref or f"{kind}:missing_id")
+            unmatched_id = adverse_ref or f"{kind}:missing_id"
+            unmatched.append(unmatched_id)
+            unmatched_providers[unmatched_id] = _provider_for_payment(
+                payment_by_id.get(payment_ref, {})
+            )
             return
         status = (
             _refund_status(obj.get("status"))
@@ -623,6 +639,7 @@ def scan_stripe_responses(
         outstanding=tuple(outstanding),
         unmatched_ids=tuple(sorted(unmatched)),
         credit_evidence=credit_evidence,
+        unmatched_providers=unmatched_providers,
     )
 
 

--- a/src/trusted_router/trust_reconcile_job.py
+++ b/src/trusted_router/trust_reconcile_job.py
@@ -420,7 +420,10 @@ def plan_historical_backfill(
         provider=provider,
         payments=tuple(payments),
         adverse=tuple(adverse_plans),
-        unmatched_ids=tuple(scan.unmatched_ids),
+        unmatched_ids=tuple(
+            ref for ref in scan.unmatched_ids
+            if scan.unmatched_providers.get(ref, "stripe") == provider
+        ),
     )
 
 

--- a/tests/test_trust_p1_operability.py
+++ b/tests/test_trust_p1_operability.py
@@ -333,8 +333,8 @@ def test_backfill_refuses_payment_fact_without_local_credit_evidence(
         recorded_at=NOW,
         checkout_sessions={"pi_1": _checkout_session(workspace_id)},
     )
-    # A card Checkout payment has no derivable marker id: evidence is empty.
-    assert scan.credit_evidence == {"pi_1": ()}
+    # A candidate alone is not evidence: the lifetime marker is absent.
+    assert scan.credit_evidence == {"pi_1": ("lifetime_backfill:stripe:pi_1",)}
 
     result = _backfill(repository, scan)
 
@@ -373,14 +373,56 @@ def test_derivable_evidence_ids_match_the_live_marker_keys() -> None:
     ach = _payment_intent("ws", payment_method="ach")
     assert credit_evidence_ids(
         ach, checkout_session=_checkout_session("ws", payment_method="ach")
-    ) == ("stripe_checkout:pi_1", "stripe_checkout:cs_1")
+    ) == ("stripe_checkout:pi_1", "stripe_checkout:cs_1", "lifetime_backfill:stripe:pi_1")
     x402 = _payment_intent("ws", payment_method="x402", amount_microdollars="5000000")
     assert credit_evidence_ids(x402) == ("x402:pi_1",)
     card = _payment_intent("ws")
-    assert credit_evidence_ids(card) == ()
-    assert credit_evidence_ids(card, crediting_event_ids=("evt_a", "evt_a", "")) == ("evt_a",)
+    assert credit_evidence_ids(card, checkout_session=_checkout_session("ws")) == (
+        "lifetime_backfill:stripe:pi_1",
+    )
+    assert credit_evidence_ids(card, crediting_event_ids=("evt_a", "evt_a", "")) == (
+        "lifetime_backfill:stripe:pi_1", "evt_a",
+    )
     auto_refill = _payment_intent("ws", auto_refill="true", amount_microdollars="5000000")
-    assert credit_evidence_ids(auto_refill, crediting_event_ids=("evt_pi",)) == ("evt_pi",)
+    assert credit_evidence_ids(auto_refill, crediting_event_ids=("evt_pi",)) == (
+        "lifetime_backfill:stripe:pi_1", "evt_pi",
+    )
+
+
+@pytest.mark.parametrize("marker_exists", [False, True])
+def test_lifetime_marker_controls_plan_and_backfill_credit_evidence(
+    marker_exists: bool, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    _alerts(monkeypatch)
+    store, database, workspace_id = _spanner_workspace()
+    repository = trust_reconciliation_repository(store)
+    if marker_exists:
+        store._write_entity(
+            "stripe_event", "lifetime_backfill:stripe:pi_1",
+            {"created_at": "2026-08-16T06:00:00Z"},
+        )
+    scan = scan_stripe_responses(
+        payment_intents=(_payment_intent(workspace_id),),
+        refunds=(), disputes=(), recorded_at=NOW,
+        checkout_sessions={"pi_1": _checkout_session(workspace_id)},
+    )
+    assert trust_backfill_cli.print_plan(
+        repository, scan, providers=("stripe",),
+        history_start=HISTORY_START, closed_through=CLOSED_THROUGH,
+    ) == int(not marker_exists)
+    payment, summary = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert payment["credited_locally"] is marker_exists
+    assert payment["action"] == ("write" if marker_exists else "refuse_uncredited")
+    assert summary["payments_credited_locally"] == int(marker_exists)
+    assert _facts(database, workspace_id) == {}
+
+    result = _backfill(repository, scan)
+    assert result.uncredited_payment_refs == (() if marker_exists else ("pi_1",))
+    assert result.marker.is_complete is marker_exists
+    assert set(_facts(database, workspace_id)) == (
+        {"trust-backfill:stripe:payment:pi_1"} if marker_exists else set()
+    )
+    assert _balance(database, workspace_id) == 0
 
 
 def test_postgres_writer_applies_the_same_evidence_rule() -> None:
@@ -685,7 +727,9 @@ def test_converter_resolves_the_checkout_session_and_events_through_the_client()
     payment = scan.payments[0]
     assert payment.occurred_at == SESSION_CREATED
     assert payment.provider_ordering_watermark is None
-    assert scan.credit_evidence == {"pi_1": ("evt_checkout_1", "evt_attested")}
+    assert scan.credit_evidence == {
+        "pi_1": ("lifetime_backfill:stripe:pi_1", "evt_checkout_1", "evt_attested"),
+    }
     assert ("checkout.Session.list", {"payment_intent": "pi_1", "limit": 1}) in stripe.calls
     event_lists = [kwargs for name, kwargs in stripe.calls if name == "Event.list"]
     assert {kwargs["type"] for kwargs in event_lists} == {
@@ -748,6 +792,40 @@ def test_plan_mode_lists_credit_status_and_every_adverse_consequence_without_wri
     assert lines[-1]["recovery_debit_micro"] == 2_500_000
     assert lines[-1]["latches_implied"] == 1
     assert (dict(database.typed.get("tr_trust_event", {})), dict(database.typed.get("tr_trust_backfill", {}))) == before
+
+
+@pytest.mark.parametrize("include_x402_unmatched", [False, True])
+def test_plan_summaries_isolate_unmatched_ids_by_provider(
+    include_x402_unmatched: bool, capsys: pytest.CaptureFixture[str],
+) -> None:
+    store, _, _ = _spanner_workspace()
+    refunds = [_refund_event(refund_id="re_stripe", payment_intent_id="pi_missing")["data"]["object"]]
+    if include_x402_unmatched:
+        refunds.append(
+            _refund_event(refund_id="re_x402", payment_intent_id="pi_x402")["data"]["object"]
+        )
+    scan = scan_stripe_responses(
+        payment_intents=(),
+        # No workspace attribution: the adverse fact is unmatched, but its
+        # provider is still knowable from the original PaymentIntent.
+        known_payment_intents=(
+            _payment_intent("", payment_intent_id="pi_x402", payment_method="x402"),
+        ),
+        refunds=refunds, disputes=(), recorded_at=NOW,
+    )
+    assert scan.unmatched_ids == (
+        ("re_stripe", "re_x402") if include_x402_unmatched else ("re_stripe",)
+    )
+    assert trust_backfill_cli.print_plan(
+        trust_reconciliation_repository(store), scan, providers=("stripe", "x402"),
+        history_start=HISTORY_START, closed_through=CLOSED_THROUGH,
+    ) == 0
+    summaries = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert [(row["provider"], row["unmatched_ids"]) for row in summaries] == [
+        ("stripe", ["re_stripe"]),
+        ("x402", ["re_x402"] if include_x402_unmatched else []),
+    ]
+    assert all(row["plan"] == "summary" and row["payments"] == 0 for row in summaries)
 
 
 def test_backfill_cli_requires_plan_or_apply_and_keeps_them_exclusive(


### PR DESCRIPTION
## Why

The trust backfill plan run in production (2026-09-06 03:09Z, `--plan`, history from 2026-05-01) refused 54 of 144 Stripe payments (2026-05-23 to 2026-08-05, $2,287 across 36 workspaces) as "uncredited": the crediting webhook's Stripe Event id is not derivable from a PaymentIntent and Stripe's Events API only reaches back 30 days, so the only derivable evidence keys (x402, ACH checkout) never matched. An incomplete marker blocks the trust-tier arm gate.

Every one of those 54 PaymentIntents has a local `stripe_event` marker `lifetime_backfill:stripe:<pi>`, written on 2026-08-16 by `scripts/backfill_lifetime_topups.py` after a reviewed dry run (paid Checkout Session with workspace metadata, refunds excluded). Independently, every affected workspace's ledger shows `SUM(total_credits)` at or above the sum of its Stripe payments (36 of 36).

## What

- `stripe_trust_history.credit_evidence_ids` now also emits `lifetime_backfill:stripe:<pi>` as a candidate for Stripe (non-x402) payment intents. Evidence still requires the marker row to exist; the docstring states exactly what that marker attests (a historical paid top-up recorded for lifetime totals, not a new credit grant). Manual makeup markers stay excluded because their ids are not derivable from the PaymentIntent.
- Per-provider plan summaries list only their own unmatched adverse ids (the x402 summary was echoing Stripe's).

## Proof

Written by codex (gpt-6-astra); reviewed by Fable. Tests: lifetime candidate emitted for card Checkout and not for x402; the plan counts a payment credited when only the lifetime marker exists and still refuses with no marker; summary isolation across two providers. Gate: trust/backfill/reconciliation suites green, ruff and mypy clean, both mutation sites red (drop the candidate; drop the summary filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
