### PR TITLE
trust: classify adverse events on non-workspace payments as out of scope

### DIFF
--- a/src/trusted_router/stripe_trust_history.py
+++ b/src/trusted_router/stripe_trust_history.py
@@ -42,6 +42,10 @@ class StripeTrustScan:
     #: Unmatched adverse id -> provider inferred from the referenced PI metadata.
     #: Without an x402 stamp, the Stripe API object belongs to Stripe's summary.
     unmatched_providers: Mapping[str, str] = field(default_factory=dict)
+    #: Adverse ids whose stored PI has no workspace_id, regardless of status.
+    out_of_scope_ids: tuple[str, ...] = ()
+    #: Same PI-metadata provider attribution as unmatched_providers.
+    out_of_scope_providers: Mapping[str, str] = field(default_factory=dict)
 
 
 def _mapping(value: Any) -> dict[str, Any]:
@@ -473,6 +477,9 @@ def scan_stripe_responses(
     ``checkout_sessions`` maps PaymentIntent id -> Checkout Session object (for
     ``occurred_at`` parity and ACH evidence); ``crediting_events`` maps
     PaymentIntent id -> Stripe Event ids whose processing credited it.
+
+    Adverse objects are out of scope only when a stored PaymentIntent has no
+    workspace_id. Unknown PIs and unmodeled workspace payments stay unmatched.
     """
 
     sessions = {
@@ -542,10 +549,21 @@ def scan_stripe_responses(
     outstanding: list[OutstandingAdverse] = []
     unmatched: list[str] = []
     unmatched_providers: dict[str, str] = {}
+    out_of_scope: list[str] = []
+    out_of_scope_providers: dict[str, str] = {}
 
     def append_adverse(obj: dict[str, Any], *, kind: str) -> None:
         adverse_ref = str(obj.get("id") or "")
         payment_ref = _object_id(obj.get("payment_intent"))
+        stored_payment = payment_by_id.get(payment_ref)
+        stored_metadata = stored_payment.get("metadata") if stored_payment is not None else None
+        if stored_payment is not None and not (
+            isinstance(stored_metadata, Mapping) and stored_metadata.get("workspace_id")
+        ):
+            out_of_scope_id = adverse_ref or f"{kind}:missing_id"
+            out_of_scope.append(out_of_scope_id)
+            out_of_scope_providers[out_of_scope_id] = _provider_for_payment(stored_payment)
+            return
         payment = payment_events.get(payment_ref)
         if not adverse_ref or payment is None:
             unmatched_id = adverse_ref or f"{kind}:missing_id"
@@ -640,6 +658,8 @@ def scan_stripe_responses(
         unmatched_ids=tuple(sorted(unmatched)),
         credit_evidence=credit_evidence,
         unmatched_providers=unmatched_providers,
+        out_of_scope_ids=tuple(sorted(out_of_scope)),
+        out_of_scope_providers=out_of_scope_providers,
     )
 
 

--- a/src/trusted_router/trust_backfill_cli.py
+++ b/src/trusted_router/trust_backfill_cli.py
@@ -145,6 +145,7 @@ def print_plan(
                     ),
                     "latches_implied": sum(row.latch_implied for row in plan.adverse),
                     "unmatched_ids": list(plan.unmatched_ids),
+                    "out_of_scope_ids": list(plan.out_of_scope_ids),
                     "writes": 0,
                 }
             )

--- a/src/trusted_router/trust_reconcile_job.py
+++ b/src/trusted_router/trust_reconcile_job.py
@@ -38,6 +38,7 @@ class TrustReconcileResult:
     watermark_advanced: bool
     uncredited_payment_refs: tuple[str, ...] = ()
     marker_saved: bool = True
+    out_of_scope_ids: tuple[str, ...] = ()
 
 
 def _provider_mapping(
@@ -60,7 +61,7 @@ def _provider_mapping(
     # live writer moves that on every status change, while the scan lists
     # refunds/disputes by the OBJECT's created: an old pending refund that
     # succeeds inside this window would be local-only by clock alone. Adverse
-    # completeness is proven the other way (every listed refund/dispute needs
+    # completeness is proven the other way (every in-scope refund/dispute needs
     # a local key; non-terminal ones are re-fetched), so local adverse facts
     # join the diff only when the source lists them (P1 review, finding 9).
     local_records = tuple(
@@ -210,6 +211,16 @@ def reconcile_scan(
     marker_saved = clean or write_payments
     if marker_saved:
         repository.save_marker(marker)
+    out_of_scope_ids = tuple(
+        ref for ref in scan.out_of_scope_ids
+        if scan.out_of_scope_providers.get(ref, "stripe") == provider
+    )
+    if out_of_scope_ids:
+        log.info(
+            "trust.reconcile.out_of_scope provider=%s out_of_scope_ids=%s",
+            provider,
+            out_of_scope_ids,
+        )
     log.info(
         "trust.backfill.unmatched provider=%s value=%d semantic_mismatch=%d",
         provider,
@@ -229,6 +240,7 @@ def reconcile_scan(
         watermark_advanced=clean and persisted_closed_through != previous_closed_through,
         uncredited_payment_refs=uncredited,
         marker_saved=marker_saved,
+        out_of_scope_ids=out_of_scope_ids,
     )
 
 
@@ -300,6 +312,7 @@ class BackfillPlan:
     payments: tuple[PaymentPlan, ...]
     adverse: tuple[AdversePlan, ...]
     unmatched_ids: tuple[str, ...]
+    out_of_scope_ids: tuple[str, ...] = ()
 
     @property
     def uncredited_count(self) -> int:
@@ -423,6 +436,10 @@ def plan_historical_backfill(
         unmatched_ids=tuple(
             ref for ref in scan.unmatched_ids
             if scan.unmatched_providers.get(ref, "stripe") == provider
+        ),
+        out_of_scope_ids=tuple(
+            ref for ref in scan.out_of_scope_ids
+            if scan.out_of_scope_providers.get(ref, "stripe") == provider
         ),
     )
 

--- a/tests/test_trust_p1_operability.py
+++ b/tests/test_trust_p1_operability.py
@@ -795,7 +795,7 @@ def test_plan_mode_lists_credit_status_and_every_adverse_consequence_without_wri
 
 
 @pytest.mark.parametrize("include_x402_unmatched", [False, True])
-def test_plan_summaries_isolate_unmatched_ids_by_provider(
+def test_plan_summaries_isolate_unmatched_and_out_of_scope_ids_by_provider(
     include_x402_unmatched: bool, capsys: pytest.CaptureFixture[str],
 ) -> None:
     store, _, _ = _spanner_workspace()
@@ -804,12 +804,20 @@ def test_plan_summaries_isolate_unmatched_ids_by_provider(
         refunds.append(
             _refund_event(refund_id="re_x402", payment_intent_id="pi_x402")["data"]["object"]
         )
+    out_of_scope_payments = []
+    for provider in ("stripe", "x402"):
+        out_of_scope_payments.append(
+            _payment_intent("", payment_intent_id=f"pi_external_{provider}", payment_method=provider)
+        )
+        refunds.append(
+            _refund_event(refund_id=f"re_external_{provider}", payment_intent_id=f"pi_external_{provider}")["data"]["object"]
+        )
     scan = scan_stripe_responses(
-        payment_intents=(),
-        # No workspace attribution: the adverse fact is unmatched, but its
-        # provider is still knowable from the original PaymentIntent.
+        payment_intents=out_of_scope_payments,
+        # A workspace PI that did not succeed remains a money-relevant gap.
         known_payment_intents=(
-            _payment_intent("", payment_intent_id="pi_x402", payment_method="x402"),
+            {**_payment_intent("ws_x402", payment_intent_id="pi_x402", payment_method="x402"),
+             "status": "requires_payment_method"},
         ),
         refunds=refunds, disputes=(), recorded_at=NOW,
     )
@@ -824,6 +832,9 @@ def test_plan_summaries_isolate_unmatched_ids_by_provider(
     assert [(row["provider"], row["unmatched_ids"]) for row in summaries] == [
         ("stripe", ["re_stripe"]),
         ("x402", ["re_x402"] if include_x402_unmatched else []),
+    ]
+    assert [(row["provider"], row["out_of_scope_ids"]) for row in summaries] == [
+        ("stripe", ["re_external_stripe"]), ("x402", ["re_external_x402"]),
     ]
     assert all(row["plan"] == "summary" and row["payments"] == 0 for row in summaries)
 
@@ -1854,6 +1865,38 @@ def test_reconcile_cli_alerts_a_refused_provider_and_still_reconciles_the_other(
     # Runbook steps 6 and 8 grep the job log for exactly this line.
     assert "trust.reconcile.outstanding provider=x402 value=0" in caplog.text
     assert "trust.backfill.unmatched provider=x402 value=0 semantic_mismatch=0" in caplog.text
+
+
+def test_reconcile_cli_logs_out_of_scope_without_unmatched_alert(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture,
+) -> None:
+    repository = _ProviderRepository({
+        "stripe": _complete_marker(), "x402": _complete_marker(provider="x402"),
+    })
+    _settings, _sentry, _configured, alerts = _reconcile_cli_fixture(monkeypatch, repository)
+    payment = _payment_intent("", created=NOW - timedelta(hours=1))
+    payment["metadata"] = {}
+    stripe = _FakeStripe(
+        payment_intents=[payment], refunds=[_refund_event()["data"]["object"]],
+    )
+    with caplog.at_level(logging.INFO, logger="trusted_router.trust_reconcile_job"):
+        code = trust_reconcile_cli.main(
+            ["--account-id", "acct_test", "--now", (NOW + timedelta(minutes=15)).isoformat()],
+            stripe_client=stripe,
+        )
+    assert code == 0 and alerts == []
+    printed = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert [(row["marker"]["provider"], row["out_of_scope_ids"]) for row in printed] == [
+        ("stripe", ["re_1"]), ("x402", []),
+    ]
+    assert len(repository.saved) == 2
+    assert all(marker.is_complete and marker.unmatched_count == 0 for marker in repository.saved)
+    assert repository.payment_writes == repository.adverse_writes == []
+    scope_logs = [record for record in caplog.records if "trust.reconcile.out_of_scope" in record.message]
+    assert [(record.levelno, record.message) for record in scope_logs] == [
+        (logging.INFO, "trust.reconcile.out_of_scope provider=stripe out_of_scope_ids=('re_1',)"),
+    ]
+    assert all("re_1" not in record.message for record in caplog.records if "trust.backfill.unmatched" in record.message)
 
 
 def test_reconcile_cli_exits_one_and_alerts_on_an_unclean_tick_without_a_marker_write(

--- a/tests/test_trust_reconciliation_slice1d.py
+++ b/tests/test_trust_reconciliation_slice1d.py
@@ -300,6 +300,50 @@ def test_recorded_history_backfill_is_rerunnable_and_uses_pro_rata_target() -> N
     assert canonical[("stripe", "payment", "pi_fee")].recovery_target == 500_000
 
 
+@pytest.mark.parametrize("kind", ["refund", "dispute"])
+@pytest.mark.parametrize("known", [False, True], ids=["listed", "known"])
+@pytest.mark.parametrize(
+    "payment_case", ["non_workspace", "non_workspace_failed", "unknown", "workspace_failed"]
+)
+def test_adverse_scope_requires_stored_non_workspace_payment(
+    kind: str, known: bool, payment_case: str,
+) -> None:
+    payment = _payment_intent()
+    out_of_scope = payment_case.startswith("non_workspace")
+    if out_of_scope:
+        payment["metadata"] = {}
+    if payment_case.endswith("failed"):
+        payment["status"] = "requires_payment_method"
+    payments = () if payment_case == "unknown" else (payment,)
+    adverse = _refund() if kind == "refund" else _dispute()
+    scan = scan_stripe_responses(
+        payment_intents=() if known else payments,
+        known_payment_intents=payments if known else (),
+        refunds=(adverse,) if kind == "refund" else (),
+        disputes=(adverse,) if kind == "dispute" else (),
+        recorded_at=NOW,
+    )
+    assert scan.out_of_scope_ids == ((adverse["id"],) if out_of_scope else ())
+    assert scan.out_of_scope_providers == ({adverse["id"]: "stripe"} if out_of_scope else {})
+    assert scan.unmatched_ids == (() if out_of_scope else (adverse["id"],))
+    assert scan.unmatched_providers == ({} if out_of_scope else {adverse["id"]: "stripe"})
+    assert scan.payments == scan.adverse == scan.source_events == scan.outstanding == ()
+    repository = _Repository()
+    result = run_historical_backfill(
+        repository, scan, provider="stripe", account_id="acct_1",
+        environment="production", source="stripe-created-lists", source_version="stripe-trust-v1",
+        history_start=HISTORY_START, closed_through=NOW - timedelta(minutes=15),
+        consistency_delay_seconds=900, now=NOW,
+    )
+    assert result.marker.unmatched_count == int(not out_of_scope)
+    assert result.marker.is_complete is out_of_scope
+    assert result.marker.completed_at == (NOW if out_of_scope else None)
+    assert result.marker.closed_through == (NOW - timedelta(minutes=15) if out_of_scope else HISTORY_START)
+    assert result.out_of_scope_ids == scan.out_of_scope_ids
+    assert tuple(repository.markers.values()) == (result.marker,)
+    assert repository.events == {} and repository.payment_writes == []
+
+
 def test_unmatched_id_keeps_initial_safe_watermark() -> None:
     repository = _Repository()
     scan = scan_stripe_responses(


### PR DESCRIPTION
## Why

After #1111, the production trust backfill plan credits all 144 Stripe payments, and exactly one adverse id still counts as unmatched: refund `re_3TaPnBQuWGscJyRc02sdhHSO` ($1.00, 2026-05-24) on `pi_3TaPnBQuWGscJyRc0TO6Dwc6`, a $1.00 succeeded PaymentIntent with empty metadata. That charge never credited a workspace, so its refund cannot affect any trust tier, yet `unmatched_count=1` keeps the Stripe marker incomplete forever (`tr_trust_backfill`'s CHECK requires zero unmatched for completion), which blocks the arm gate.

## What

An adverse event is classified out of scope only when the referenced PaymentIntent is present in the scan's stored payments and carries no `workspace_id` in its metadata, regardless of status. Everything else stays unmatched and fail-closed: unknown PaymentIntents, and workspace payments the scan did not model (for example a non-succeeded status). Out-of-scope ids are surfaced in the plan summary per provider next to `unmatched_ids`, carried on the reconcile result, and logged at INFO by the recurring reconciliation instead of raising the unmatched alert.

## Proof

Written by codex (gpt-6-astra); reviewed by Fable. Tests: out-of-scope refund lets the marker complete; unknown PI still unmatched; workspace PI with a non-succeeded status still unmatched; summary prints both lists; recurring reconciliation stays silent for out-of-scope. Gate: trust/backfill/reconciliation suites green, ruff and mypy clean, mutation sites red (drop the classification; widen it to any stored PI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
