### PR TITLE
pricing: quarantine unpriced OpenAI discoveries per model instead of degrading the provider

### DIFF
--- a/scripts/pricing/base.py
+++ b/scripts/pricing/base.py
@@ -1518,6 +1518,7 @@ def fetch_provider(
     expected_models: list[str],
     required_models: list[str] | tuple[str, ...] | frozenset[str] = (),
     required_model_price_aliases: dict[str, str] | None = None,
+    require_runtime_models: bool = True,
     extra_headers: dict[str, str] | None = None,
     accepted_status_codes: frozenset[int] = frozenset(),
 ) -> ProviderPricingResult:
@@ -1527,6 +1528,10 @@ def fetch_provider(
     `extra_headers` lets a provider config request specific headers on
     the fetch — e.g. `{"X-Return-Format": "markdown"}` for Jina-proxied
     URLs that should return clean markdown instead of HTML.
+
+    ``require_runtime_models=False`` lets an adapter isolate unpriced launch
+    hints from third-party discovery. Explicit ``required_models`` and all
+    price validation still apply; the adapter must keep unpriced models dark.
 
     Steps:
       1. fetch_html(url, extra_headers=...)
@@ -1540,7 +1545,11 @@ def fetch_provider(
       9. validate the sandbox output.
       10. only after all pass, write the new source to disk and return.
     """
-    strict_models = frozenset(required_models) | runtime_required_models(slug)
+    # Authenticated adapters can quarantine unpriced discoveries per model.
+    # A third-party launch hint must not invalidate their other official prices.
+    strict_models = frozenset(required_models)
+    if require_runtime_models:
+        strict_models |= runtime_required_models(slug)
     log.info(
         "pricing.fetch slug=%s url=%s required_models=%d",
         slug,

--- a/scripts/pricing/providers/openai.py
+++ b/scripts/pricing/providers/openai.py
@@ -7,7 +7,13 @@ import re
 from pathlib import Path
 from typing import Any
 
-from scripts.pricing.base import ProviderPricingResult, fetch_json, fetch_provider
+from scripts.pricing.base import (
+    ProviderPricingResult,
+    emit_workflow_warning,
+    fetch_json,
+    fetch_provider,
+    runtime_required_models,
+)
 from scripts.pricing.manifest import (
     apply_canary_results,
     models_requiring_canary,
@@ -93,7 +99,13 @@ def fetch() -> ProviderPricingResult:
         slug=SLUG,
         url=URL,
         expected_models=EXPECTED_MODELS,
+        require_runtime_models=False,
     )
+    unpriced = sorted(runtime_required_models(SLUG) - result.prices.keys())
+    if unpriced:
+        note = f"openai: no official price for discovered models; excluded from routing: {unpriced}"
+        emit_workflow_warning(note)
+        result.notes.append(note)
     api_key = os.environ.get("OPENAI_API_KEY") or os.environ.get("CHATGPT_API_KEY")
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY is required for model discovery")

--- a/tests/test_openai_pricing.py
+++ b/tests/test_openai_pricing.py
@@ -1,0 +1,115 @@
+"""OpenAI launch hints cannot invalidate independently verified routes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.pricing import base
+from scripts.pricing.parsers import openai as parser
+from scripts.pricing.providers import openai
+from trusted_router import catalog_ingest
+from trusted_router.catalog_capabilities import manifest_supported_parameters
+
+# Standard row fetched from https://developers.openai.com/api/docs/pricing
+# on 2026-09-06. No Astra Pro row was published there at capture time.
+ASTRA_PRICING = (
+    "| gpt-6-astra | $10.00 | $1.00 | $12.50 | $50.00 | "
+    "$20.00 | $2.00 | $25.00 | $75.00 |"
+)
+
+
+def test_astra_pro_id_is_already_recognized_without_inventing_a_price() -> None:
+    assert parser._canonical_id("gpt-6-astra-pro") == "openai/gpt-6-astra-pro"
+    assert "openai/gpt-6-astra-pro" not in parser.parse(ASTRA_PRICING)
+
+
+@pytest.mark.parametrize("native_id", ["gpt-6-astra-pro", "gpt-99-novel"])
+@pytest.mark.parametrize("available", [False, True])
+def test_unknown_openai_model_does_not_strip_other_models_supported_parameters(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    native_id: str,
+    available: bool,
+) -> None:
+    manifest = tmp_path / "openai.json"
+    existing = {
+        "id": "openai/gpt-4.1",
+        "upstream_id": "gpt-4.1",
+        "model_type": "chat",
+        "endpoints": ["chat/completions"],
+        "input_modalities": ["text", "image"],
+        "output_modalities": ["text"],
+        "supported_parameters": ["tools", "seed"],
+    }
+    manifest.write_text(json.dumps({"models": [existing]}), encoding="utf-8")
+    monkeypatch.setattr(openai, "MANIFEST_PATH", manifest)
+    monkeypatch.setattr(openai, "UPSTREAM_ID_MAP", {})
+    monkeypatch.setattr(openai, "_DISCOVERED_MANIFEST_ROWS", {})
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(base, "fetch_html", lambda *_args, **_kwargs: ASTRA_PRICING)
+    model_id = f"openai/{native_id}"
+    monkeypatch.setattr(base, "_RUNTIME_REQUIRED_MODELS", {"openai": frozenset({model_id})})
+    rows = [{"id": "gpt-6-astra"}, {"id": "gpt-4.1"}]
+    if available:
+        rows.append({"id": native_id})
+    monkeypatch.setattr(openai, "fetch_json", lambda *_args, **_kwargs: {"data": rows})
+
+    def unexpected_self_heal(**_kwargs: object) -> str:
+        pytest.fail("An unpriced launch hint must not trigger provider-wide self-heal")
+
+    monkeypatch.setattr(base, "self_heal_parser", unexpected_self_heal)
+    probes: list[str] = []
+
+    def probe(**kwargs: object) -> bool:
+        probes.append(str(kwargs["model"]))
+        return True
+
+    monkeypatch.setattr(openai, "probe_openai_chat", probe)
+    result = openai.fetch()
+    openai.write_provider_manifest(result)
+
+    assert result.heal_diff is None
+    assert model_id not in result.prices
+    assert any(model_id in note and "no official price" in note for note in result.notes)
+    assert probes == ["gpt-6-astra"]
+    written = {row["id"]: row for row in json.loads(manifest.read_text())["models"]}
+    assert manifest_supported_parameters(written[existing["id"]]) == (
+        manifest_supported_parameters(existing)
+    )
+    assert written[existing["id"]]["input_modalities"] == ["text", "image"]
+    assert model_id not in written
+
+    # Exercise the real manifest-to-catalog capability translation as well.
+    monkeypatch.setattr(catalog_ingest, "_PROVIDER_MODELS_DIR", tmp_path)
+    models, endpoints = catalog_ingest._supplemental_provider_models_and_endpoints()
+    astra = models["openai/gpt-6-astra"]
+    assert astra.context_length == 1_050_000
+    assert set(astra.input_modalities) == {"text", "image"}
+    assert astra.output_modalities == ("text",)
+    assert set(astra.supported_parameters) == {
+        "tools", "max_tokens", "reasoning", "reasoning_effort",
+        "include_reasoning", "structured_outputs",
+    }
+    assert endpoints["openai/gpt-6-astra@openai/prepaid"].upstream_id == "gpt-6-astra"
+    assert model_id not in models
+
+
+def test_openai_isolation_does_not_accept_invalid_prices(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        base, "fetch_html", lambda *_args, **_kwargs: "| gpt-6-astra | $99999 | - | $50 |"
+    )
+    monkeypatch.setattr(
+        base, "_RUNTIME_REQUIRED_MODELS", {"openai": frozenset({"openai/gpt-99-novel"})}
+    )
+
+    def fail_self_heal(**_kwargs: object) -> str:
+        raise RuntimeError("invalid price still requires repair")
+
+    monkeypatch.setattr(base, "self_heal_parser", fail_self_heal)
+    with pytest.raises(RuntimeError, match="invalid price still requires repair"):
+        openai.fetch()


### PR DESCRIPTION
## Why

After #1114 the hourly price refresh's regenerated tree failed one more test (`test_openai_astra_uses_first_party_long_context_vision_route`, run 34017106595): OpenAI's authenticated models list now returns `gpt-6-astra-pro`, which has no published price on the pricing page and a 404 documentation URL. The OpenAI adapter treated a discovered-but-unpriced runtime model as a whole-provider deterministic failure, fell back, and the regenerated `openai.json` lost gpt-6-astra's supported parameters.

## What

- `scripts/pricing/base.py`: `fetch_provider` gains `require_runtime_models` (default unchanged). Authenticated adapters may set it false to quarantine unpriced discoveries per model; explicit required models and every price validation still apply, and unpriced models stay dark.
- `scripts/pricing/providers/openai.py`: uses that isolation, keeps the 35 priced models (Astra's capabilities identical), and emits a workflow warning naming the excluded unpriced ids (`gpt-6-astra-pro` today) instead of degrading the provider. No price is invented for Pro; it is published only when OpenAI publishes one.
- Tests: Pro is recognised without a price; an unknown OpenAI model does not strip other models' supported parameters; isolation never accepts an invalid price.

## Proof

Written by codex (gpt-6-astra); reviewed by Fable. Codex: 794 selected tests, full suite 9,368 passed, live regeneration with the real key produced an identical manifest (timestamp only, not committed). Fable gate on a fresh snapshot: pricing, catalog, discovery, branding and monitoring suites green, linters clean, three mutation sites red (isolation flag on the adapter, the base-level gate, the exclusion warning). The proof of publication is the manual `refresh-prices.yml` dispatch after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
