### PR TITLE
Fix canonical redirects for public model aliases

### DIFF
--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -186,6 +186,29 @@ LEGACY_MODEL_PAGE_REDIRECTS: dict[str, str] = {
     # backlink by sending readers to the current open-weight catalog.
     "meta/muse-spark-1.1": "/models?filter=open",
 }
+LEGACY_MODEL_ID_ALIASES: dict[str, str] = {
+    "lightning-ai/nemotron-3-nano-omni-30b-a3b-reasoning": (
+        "nvidia/nemotron-3-nano-omni-reasoning-30b-a3b"
+    ),
+    "nvidia/nemotron-120b-a12b": "nvidia/nemotron-3-120b-a12b",
+    "nvidia/nvidia-nemotron-3-ultra-550b-a55b": "nvidia/nemotron-3-ultra-550b-a55b",
+    "xiaomi/mimo-v2-flash": "xiaomimimo/mimo-v2-flash",
+    "zai-org/glm-4.5": "z-ai/glm-4.5",
+}
+
+
+def _canonical_public_model_id(model_id: str) -> str:
+    """Resolve known aliases and unambiguous casing to existing catalog IDs."""
+    # Exact native IDs remain authoritative, including mixed-case provider IDs.
+    if model_id in MODELS:
+        return model_id
+    alias = LEGACY_MODEL_ID_ALIASES.get(model_id)
+    if alias is not None and alias in MODELS:
+        return alias
+    matches = [candidate for candidate in MODELS if candidate.casefold() == model_id.casefold()]
+    return matches[0] if len(matches) == 1 else model_id
+
+
 STATUS_RAW_SAMPLE_LIMIT_PER_DAY = 35_000
 STATUS_LIVE_SAMPLE_LIMIT = 500
 STATUS_HOUR_ROLLUP_LIMIT = 5_000
@@ -1866,11 +1889,13 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
         right_author: str,
         right_slug: str,
     ) -> Response:
-        left_id = f"{left_author.strip()}/{left_slug.strip()}"
-        right_id = f"{right_author.strip()}/{right_slug.strip()}"
+        requested_left_id = f"{left_author.strip()}/{left_slug.strip()}"
+        requested_right_id = f"{right_author.strip()}/{right_slug.strip()}"
+        left_id = _canonical_public_model_id(requested_left_id)
+        right_id = _canonical_public_model_id(requested_right_id)
         canonical_path = canonical_model_comparison_path(left_id, right_id)
         if canonical_path is not None:
-            requested_path = f"/compare/models/{left_id}/vs/{right_id}"
+            requested_path = f"/compare/models/{requested_left_id}/vs/{requested_right_id}"
             if requested_path != canonical_path:
                 return RedirectResponse(url=canonical_path, status_code=301)
         body = public_model_compare_html(settings, left_id, right_id)
@@ -1933,6 +1958,15 @@ def register_public_routes(app: FastAPI, settings: Settings) -> None:
         legacy_model_id = (
             maybe_base_model_id if separator and maybe_section in MODEL_SEO_SECTIONS else cleaned
         )
+        canonical_model_id = _canonical_public_model_id(legacy_model_id)
+        if canonical_model_id != legacy_model_id:
+            section_suffix = (
+                f"/{maybe_section}" if separator and maybe_section in MODEL_SEO_SECTIONS else ""
+            )
+            return RedirectResponse(
+                url=f"/models/{canonical_model_id}{section_suffix}",
+                status_code=301,
+            )
         legacy_target = LEGACY_MODEL_PAGE_REDIRECTS.get(legacy_model_id)
         if legacy_target:
             return RedirectResponse(url=legacy_target, status_code=301)

--- a/src/trusted_router/routes/public.py
+++ b/src/trusted_router/routes/public.py
@@ -202,7 +202,7 @@ def _canonical_public_model_id(model_id: str) -> str:
     # Exact native IDs remain authoritative, including mixed-case provider IDs.
     if model_id in MODELS:
         return model_id
-    alias = LEGACY_MODEL_ID_ALIASES.get(model_id)
+    alias = LEGACY_MODEL_ID_ALIASES.get(model_id.casefold())
     if alias is not None and alias in MODELS:
         return alias
     matches = [candidate for candidate in MODELS if candidate.casefold() == model_id.casefold()]

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -1685,6 +1685,77 @@ def test_retired_model_pages_redirect_to_current_catalog_entries(client: TestCli
         assert response.headers["location"] == target
 
 
+@pytest.mark.parametrize("method", ["GET", "HEAD"])
+@pytest.mark.parametrize(
+    ("requested", "canonical"),
+    [
+        ("nvidia/Nemotron-3-Ultra-550b-a55b", "nvidia/nemotron-3-ultra-550b-a55b"),
+        ("xiaomi/mimo-v2-flash", "xiaomimimo/mimo-v2-flash"),
+        ("xiaomi/mimo-v2-flash/pricing", "xiaomimimo/mimo-v2-flash/pricing"),
+        ("nvidia/nvidia-nemotron-3-ultra-550b-a55b/providers", "nvidia/nemotron-3-ultra-550b-a55b/providers"),
+        ("zai-org/glm-4.5", "z-ai/glm-4.5"),
+        ("nvidia/nemotron-120b-a12b", "nvidia/nemotron-3-120b-a12b"),
+        ("lightning-ai/nemotron-3-nano-omni-30b-a3b-reasoning", "nvidia/nemotron-3-nano-omni-reasoning-30b-a3b"),
+    ],
+)
+def test_model_aliases_redirect_once_to_existing_pages(
+    client: TestClient, method: str, requested: str, canonical: str,
+) -> None:
+    response = client.request(method, f"/models/{requested}", follow_redirects=False)
+    assert response.status_code == 301
+    assert response.headers["location"] == f"/models/{canonical}"
+    target = client.request(method, response.headers["location"], follow_redirects=False)
+    assert target.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/models/nvidia/unknown-model",
+        "/models/xiaomi/mimo-v2-flash/unknown-section",
+        "/compare/models/xiaomi/mimo-v2-flash/vs/unknown/model",
+        "/compare/models/xiaomi/mimo-v2-flash/vs/xiaomimimo/mimo-v2-flash",
+    ],
+)
+def test_model_normalization_preserves_unknown_and_invalid_pair_404s(
+    client: TestClient, path: str,
+) -> None:
+    assert client.get(path, follow_redirects=False).status_code == 404
+
+
+def test_model_comparison_normalizes_alias_case_and_order_in_one_redirect(
+    client: TestClient,
+) -> None:
+    response = client.get(
+        "/compare/models/zai-org/glm-4.5/vs/nvidia/Nemotron-3-Ultra-550b-a55b",
+        follow_redirects=False,
+    )
+    assert response.status_code == 301
+    assert response.headers["location"] == (
+        "/compare/models/nvidia/nemotron-3-ultra-550b-a55b/vs/z-ai/glm-4.5"
+    )
+    assert client.get(response.headers["location"], follow_redirects=False).status_code == 200
+
+
+def test_model_normalization_requires_live_unambiguous_targets(monkeypatch) -> None:
+    from trusted_router.routes import public
+
+    monkeypatch.setattr(public, "MODELS", {"native/MixedCase": object()})
+    assert public._canonical_public_model_id("native/MixedCase") == "native/MixedCase"
+    assert public._canonical_public_model_id("NATIVE/mixedcase") == "native/MixedCase"
+    assert public._canonical_public_model_id("xiaomi/mimo-v2-flash") == "xiaomi/mimo-v2-flash"
+    monkeypatch.setattr(public, "MODELS", {"native/Case": object(), "native/case": object()})
+    assert public._canonical_public_model_id("native/Case") == "native/Case"
+    assert public._canonical_public_model_id("native/CASE") == "native/CASE"
+
+
+def test_native_mixed_case_model_page_remains_canonical(client: TestClient) -> None:
+    path = "/models/Sao10K/L3-8B-Stheno-v3.2"
+    response = client.get(path, follow_redirects=False)
+    assert response.status_code == 200
+    assert f'<link rel="canonical" href="https://trustedrouter.com{path}">' in response.text
+
+
 def test_benchmarks_and_rankings_pages_link_model_clusters(client: TestClient) -> None:
     for path in ["/benchmarks", "/rankings"]:
         response = client.get(path)

--- a/tests/test_public_seo_pages.py
+++ b/tests/test_public_seo_pages.py
@@ -1692,6 +1692,9 @@ def test_retired_model_pages_redirect_to_current_catalog_entries(client: TestCli
         ("nvidia/Nemotron-3-Ultra-550b-a55b", "nvidia/nemotron-3-ultra-550b-a55b"),
         ("xiaomi/mimo-v2-flash", "xiaomimimo/mimo-v2-flash"),
         ("xiaomi/mimo-v2-flash/pricing", "xiaomimimo/mimo-v2-flash/pricing"),
+        ("Xiaomi/MiMo-V2-Flash", "xiaomimimo/mimo-v2-flash"),
+        ("Xiaomi/MiMo-V2-Flash/pricing", "xiaomimimo/mimo-v2-flash/pricing"),
+        ("nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B", "nvidia/nemotron-3-ultra-550b-a55b"),
         ("nvidia/nvidia-nemotron-3-ultra-550b-a55b/providers", "nvidia/nemotron-3-ultra-550b-a55b/providers"),
         ("zai-org/glm-4.5", "z-ai/glm-4.5"),
         ("nvidia/nemotron-120b-a12b", "nvidia/nemotron-3-120b-a12b"),
@@ -1727,7 +1730,7 @@ def test_model_comparison_normalizes_alias_case_and_order_in_one_redirect(
     client: TestClient,
 ) -> None:
     response = client.get(
-        "/compare/models/zai-org/glm-4.5/vs/nvidia/Nemotron-3-Ultra-550b-a55b",
+        "/compare/models/Zai-Org/GLM-4.5/vs/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
         follow_redirects=False,
     )
     assert response.status_code == 301


### PR DESCRIPTION
Known public model aliases and case variants currently return 404 even when the same model has a working canonical catalog page. For example, `/models/xiaomi/mimo-v2-flash` will now return one 301 to `/models/xiaomimimo/mimo-v2-flash`; NVIDIA casing variants and equivalent comparison URLs also resolve to their existing canonical URLs.

Resolution is limited to existing catalog targets and unambiguous case matches. Exact native mixed-case IDs remain authoritative, unknown or retired models remain 404, supported section suffixes are preserved, and comparison order is normalized in the same redirect.

Validation: pinned Ruff and mypy pass; all 97 public SEO tests pass, including GET/HEAD redirects, working destinations, mixed-case upstream aliases, preserved unknown-model 404s, and native/ambiguous case handling. The full local suite reached 83.92% coverage (9,377 passed, 368 skipped, 10 xfailed, 11 failures, 8 setup errors). All failures/errors were localhost socket-bind restrictions from the sandbox; all 107 tests in the three affected modules then passed in an authorized non-sandboxed rerun. No test or production-code workaround was needed. All PR CI checks passed, including twelve test shards and combined coverage. Merged as 04e073ec8a3611784bd8d8835e701c22bd351ffd on September 6 at 15:49:32 UTC.
