### PR TITLE
stage D: arm eligibility for the pilot and probe cohort

### DIFF
--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -771,8 +771,22 @@ ENV_VARS=(
   # kill switch; verification stays deployed so in-flight receipts fail closed.
   "TR_SPEND_LEASE_ADMISSION_ACCEPT=false"
   "TR_STAGE_D_HEARTBEAT_ENABLED=true"
-  "TR_STAGE_D_ELIGIBILITY_ENABLED=false"
-  "TR_STAGE_D_PILOT_WORKSPACE_IDS=45819281-0ce9-4811-a0cd-c660ab3a116d"
+  # Re-enabled 2026-09-06 after decision 77's four preconditions landed:
+  # signed accepted-digest policy with a durable Spanner watermark (plane gcp,
+  # sequence 873), naming the running enclave digest
+  # sha256:cf91973741331833afed5fb47a55f39b8d748000d26d5b6c8298ac0b5c97a0ff;
+  # boot-bound eligibility that fails open to the synchronous path; streaming
+  # roll gates; and the staged cohort. Settings.stage_d_eligibility_enabled
+  # stays False so only a deployed router is in the cohort. The enclave still
+  # heartbeats only where QUILL_USAGE_HEARTBEAT=on, which rolls region by region
+  # after this lands.
+  "TR_STAGE_D_ELIGIBILITY_ENABLED=true"
+  # Decision 77 (d): the spend-lease pilot plus the dedicated Stage D probe
+  # workspace (provisioned 2026-09-06, heartbeat-capable local typed key).
+  # The probe is deliberately NOT on the regional-quota path so the roll gate's
+  # key is in the cohort. Clearing this list is the later fleet-expansion step,
+  # not part of arming.
+  "TR_STAGE_D_PILOT_WORKSPACE_IDS=45819281-0ce9-4811-a0cd-c660ab3a116d,91d7810e-93b2-4c37-b1bd-ba9227585416"
   # Trust eligibility remains inert; its arm gate validates the completed program.
   "TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED=false"
   "TR_TRUST_STRIPE_ACCOUNT_ID=${TR_TRUST_STRIPE_ACCOUNT_ID}"

--- a/tests/test_stage_d_authorize.py
+++ b/tests/test_stage_d_authorize.py
@@ -279,16 +279,17 @@ def test_app_markup_and_receipt_fee_remain_in_stage_d_cohort(
 
 
 def test_stage_d_eligibility_kill_switch_declares_nothing_eligible() -> None:
-    """Emergency kill (2026-09-03): with eligibility off the router never puts a
-    request in the Stage D cohort, so the enclave never sends a heartbeat."""
+    """The code default is off; production pins eligibility on for exactly the
+    two-workspace cohort. The kill switch declares nothing eligible when disabled.
+    """
     from trusted_router.routes.internal.gateway import _stage_d_eligibility_reason
 
     assert Settings(environment="test").stage_d_eligibility_enabled is False
     rollout = (Path(__file__).parents[1] / "scripts" / "deploy" / "rollout.sh").read_text()
     for literal in (
-        '"TR_STAGE_D_ELIGIBILITY_ENABLED=false"',
+        '"TR_STAGE_D_ELIGIBILITY_ENABLED=true"',
         '"TR_STAGE_D_HEARTBEAT_ENABLED=true"',
-        '"TR_STAGE_D_PILOT_WORKSPACE_IDS=45819281-0ce9-4811-a0cd-c660ab3a116d"',
+        '"TR_STAGE_D_PILOT_WORKSPACE_IDS=45819281-0ce9-4811-a0cd-c660ab3a116d,91d7810e-93b2-4c37-b1bd-ba9227585416"',
         '"TR_SPEND_LEASE_ACCEPTED_GCP_IMAGE_DIGESTS="',
         '"TR_REAP_SNAPSHOT_BOOKING_ENABLED=false"',
     ):


### PR DESCRIPTION
## Why

Stage D has been off since the 2026-09-03 emergency kill, when turning `QUILL_USAGE_HEARTBEAT` on made every streaming chat completion in the rolled regions fail with `heartbeat_unavailable`. Decision 77 named four preconditions, one per line of defence that failed. All four have landed:

- **(a) Digest acceptance follows releases.** The release pipeline publishes and signs the accepted set; the router verifies it against the pinned publish-workflow identity and keeps a durable Spanner watermark. Production today: plane `gcp`, sequence 873, naming the running enclave digest `sha256:cf9197…`. `TR_SPEND_LEASE_ACCEPTED_GCP_IMAGE_DIGESTS` is empty and stays an audited emergency override only.
- **(b) Eligibility is decided where it can fail open, and bound to the boot** (`stage_d_boot_kid`; replays are never eligible).
- **(c) The roll gates exercise the path that changed** — a blocking streaming completion per instance, asserting Stage D actually executed when the template under test carries the flag.
- **(d) A staged cohort before the fleet** — this change.

## What

Two literals in `scripts/deploy/rollout.sh`, with the reasoning recorded beside them, plus the test that pins them:

- `TR_STAGE_D_ELIGIBILITY_ENABLED` false → **true**.
- `TR_STAGE_D_PILOT_WORKSPACE_IDS` gains the dedicated Stage D probe workspace `91d7810e-93b2-4c37-b1bd-ba9227585416`, provisioned 2026-09-06 with a heartbeat-capable local typed key and deliberately kept off the regional-quota path so the roll gate's key is inside the cohort.

`Settings.stage_d_eligibility_enabled` stays `False`, so only a deployed router joins the cohort. The trust arm flag is untouched. Clearing the pilot list is the later fleet-expansion step, not part of arming.

## Blast radius

Eligibility is one conjunction: kill switch on **and** pilot membership **and** heartbeat endpoint enabled **and** a verified accepted boot. The enclave heartbeats only where `QUILL_USAGE_HEARTBEAT=on`, and every region's template currently has it **off**, so this change alone puts two workspaces in the cohort and changes no request path. The enclave flag rolls region by region afterwards, primary first, each region gated on positive Stage D evidence. Rollback is the reverse two-line edit.

## Proof

Written by codex (gpt-6-astra); reviewed by Fable. Codex: 208 targeted tests, ruff and mypy clean, and no other pin of either literal anywhere in the repo. Fable gate on a fresh snapshot: 564 tests green across the Stage D, Stage C flag-off, spend-lease, trust-tier and deploy-contract suites, linters clean, three mutations red (revert eligibility, drop the probe from the cohort, flip the code default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
