### PR TITLE
trust: make PR 2's new enforcement honour the arm flag

### DIFF
--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -1918,7 +1918,10 @@ def _authorize_gateway_sync_impl(
         )
         from trusted_router.storage_legacy_trust import BillingPausedError, legacy_pause_epoch
 
-        expected_pause_epoch = legacy_pause_epoch(STORE, workspace.id)
+        expected_pause_epoch = (
+            legacy_pause_epoch(STORE, workspace.id)
+            if settings.spend_lease_trust_eligibility_enabled else None
+        )
         try:
             window_decision = STORE.reserve_key_limit(
                 api_key.hash,

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -50,6 +50,7 @@ from trusted_router.storage_errors import StoreConflict
 from trusted_router.storage_generations import InMemoryGenerations
 from trusted_router.storage_group_buy import InMemoryBedrockGroupBuy
 from trusted_router.storage_keys import InMemoryApiKeys
+from trusted_router.storage_legacy_trust import trust_program_armed
 from trusted_router.storage_models import (
     AcquisitionAttribution,
     ActivationReminderTask,
@@ -151,12 +152,14 @@ class InMemoryStore:
     def __init__(
         self,
         *,
+        trust_settings: Any = None,
         max_workspaces_per_owner: int = 25,
         trust_qualifying_providers: frozenset[str] = frozenset({"stripe", "x402"}),
         trust_tier3_min_days: int = 30,
         trust_tier3_min_paid_microdollars: int = 50_000_000,
     ) -> None:
         self._lock = threading.RLock()
+        self.trust_settings = trust_settings
         self.max_workspaces_per_owner = int(max_workspaces_per_owner)
         self.trust_qualifying_providers = trust_qualifying_providers
         self.trust_tier3_min_days = int(trust_tier3_min_days)
@@ -2784,18 +2787,20 @@ class InMemoryStore:
     ) -> Reservation:
         from trusted_router.storage_legacy_trust import BillingPausedError
         with self._lock:
-            terminal_key = (workspace_id, key_hash, idempotency_key or "")
-            if self._legacy_paused(workspace_id) or terminal_key in self._paused_authorizations:
-                if idempotency_key is not None:
-                    existing_id = self.api_keys.reservation_id_by_idempotency_key.get(idempotency_key)
-                    if existing_id is not None:
-                        self.refund(existing_id)
-                    self._paused_authorizations.add(terminal_key)
-                self.api_keys.refund_limit(key_hash, amount_microdollars, usage_type=UsageType.CREDITS)
-                raise BillingPausedError()
+            if trust_program_armed(self):
+                terminal_key = (workspace_id, key_hash, idempotency_key or "")
+                if self._legacy_paused(workspace_id) or terminal_key in self._paused_authorizations:
+                    if idempotency_key is not None:
+                        existing_id = self.api_keys.reservation_id_by_idempotency_key.get(idempotency_key)
+                        if existing_id is not None:
+                            self.refund(existing_id)
+                        self._paused_authorizations.add(terminal_key)
+                    self.api_keys.refund_limit(key_hash, amount_microdollars, usage_type=UsageType.CREDITS)
+                    raise BillingPausedError()
             reservation = self.api_keys.reserve(workspace_id, key_hash, amount_microdollars,
                                                 idempotency_key=idempotency_key)
-            self._reservation_pause_epochs.setdefault(reservation.id, self._legacy_pause_epoch(workspace_id))
+            if trust_program_armed(self):
+                self._reservation_pause_epochs.setdefault(reservation.id, self._legacy_pause_epoch(workspace_id))
             return reservation
 
     def _legacy_pause_epoch(self, workspace_id: str) -> int:
@@ -2827,7 +2832,8 @@ class InMemoryStore:
     def refund(self, reservation_id: str) -> None:
         with self._lock:
             self.api_keys.refund(reservation_id)
-            self._recover_released_credit_locked(self.api_keys.reservations[reservation_id].workspace_id)
+            if trust_program_armed(self):
+                self._recover_released_credit_locked(self.api_keys.reservations[reservation_id].workspace_id)
 
     # --- Cross-plane credit transfer ---------------------------------------
     #
@@ -3039,20 +3045,21 @@ class InMemoryStore:
     ) -> GatewayAuthorization:
         from trusted_router.storage_legacy_trust import BillingPausedError
         with self._lock:
-            terminal_key = (workspace_id, key_hash, idempotency_key or "")
-            existing = self.api_keys.get_gateway_authorization_by_idempotency_key(workspace_id, key_hash, idempotency_key) if idempotency_key else None
-            if existing is not None:
-                return existing
-            stale_epoch = (expected_pause_epoch is not None and expected_pause_epoch != self._legacy_pause_epoch(workspace_id)) or (credit_reservation_id is not None and
-                self._reservation_pause_epochs.get(credit_reservation_id, 0) != self._legacy_pause_epoch(workspace_id))
-            if self._legacy_paused(workspace_id) or stale_epoch or terminal_key in self._paused_authorizations:
-                if terminal_key not in self._paused_authorizations or idempotency_key is None:
-                    if credit_reservation_id is not None:
-                        self.refund(credit_reservation_id)
-                    self.api_keys.refund_limit(key_hash, estimated_microdollars, usage_type=usage_type)
-                    if idempotency_key is not None:
-                        self._paused_authorizations.add(terminal_key)
-                raise BillingPausedError()
+            if trust_program_armed(self):
+                terminal_key = (workspace_id, key_hash, idempotency_key or "")
+                existing = self.api_keys.get_gateway_authorization_by_idempotency_key(workspace_id, key_hash, idempotency_key) if idempotency_key else None
+                if existing is not None:
+                    return existing
+                stale_epoch = (expected_pause_epoch is not None and expected_pause_epoch != self._legacy_pause_epoch(workspace_id)) or (credit_reservation_id is not None and
+                    self._reservation_pause_epochs.get(credit_reservation_id, 0) != self._legacy_pause_epoch(workspace_id))
+                if self._legacy_paused(workspace_id) or stale_epoch or terminal_key in self._paused_authorizations:
+                    if terminal_key not in self._paused_authorizations or idempotency_key is None:
+                        if credit_reservation_id is not None:
+                            self.refund(credit_reservation_id)
+                        self.api_keys.refund_limit(key_hash, estimated_microdollars, usage_type=usage_type)
+                        if idempotency_key is not None:
+                            self._paused_authorizations.add(terminal_key)
+                    raise BillingPausedError()
             return self.api_keys.create_gateway_authorization(
                 workspace_id=workspace_id,
                 key_hash=key_hash,
@@ -3116,7 +3123,7 @@ class InMemoryStore:
     def get_gateway_authorization_by_idempotency_key(
         self, workspace_id: str, key_hash: str, idempotency_key: str
     ) -> GatewayAuthorization | None:
-        if (workspace_id, key_hash, idempotency_key) in self._paused_authorizations:
+        if trust_program_armed(self) and (workspace_id, key_hash, idempotency_key) in self._paused_authorizations:
             from trusted_router.storage_legacy_trust import BillingPausedError
             raise BillingPausedError()
         return self.api_keys.get_gateway_authorization_by_idempotency_key(
@@ -3670,6 +3677,7 @@ def create_store(settings: Any) -> Store:
     backend = str(getattr(settings, "storage_backend", "memory")).lower()
     if backend == "memory":
         return InMemoryStore(
+            trust_settings=settings,
             max_workspaces_per_owner=int(
                 getattr(settings, "max_workspaces_per_owner", 25)
             ),
@@ -3696,6 +3704,7 @@ def create_store(settings: Any) -> Store:
             )
         store = PostgresStore(
             dsn,
+            trust_settings=settings,
             postgres_iam_auth=str(getattr(settings, "postgres_iam_auth", "") or ""),
             postgres_iam_region=str(getattr(settings, "postgres_iam_region", "") or ""),
             operational_analytics_outbox_enabled=bool(

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -4478,6 +4478,7 @@ class SpannerBigtableStore:
             spend_lease=spend_lease,
             invocation_nonce=invocation_nonce,
             expected_pause_epoch=expected_pause_epoch,
+            trust_eligibility_enabled=bool(self.trust_settings is not None and self.trust_settings.spend_lease_trust_eligibility_enabled),
         )
 
     def get_gateway_authorization(self, authorization_id: str) -> GatewayAuthorization | None:
@@ -4519,7 +4520,8 @@ class SpannerBigtableStore:
         self, workspace_id: str, key_hash: str, idempotency_key: str
     ) -> GatewayAuthorization | None:
         return self.api_keys.get_gateway_authorization_by_idempotency_key(
-            workspace_id, key_hash, idempotency_key
+            workspace_id, key_hash, idempotency_key,
+            trust_eligibility_enabled=bool(self.trust_settings is not None and self.trust_settings.spend_lease_trust_eligibility_enabled),
         )
 
     def mark_gateway_authorization_settled(self, authorization_id: str) -> None:
@@ -4542,7 +4544,7 @@ class SpannerBigtableStore:
     def authorize_gateway_atomic(self, **kwargs: Any) -> dict:
         from trusted_router.storage_gcp_authorize import authorize_atomic
 
-        return authorize_atomic(self._database, self._param_types, **kwargs)
+        return authorize_atomic(self._database, self._param_types, trust_settings=self.trust_settings, **kwargs)
 
     def typed_finalize_gateway(self, **kwargs: Any) -> dict:
         from trusted_router.storage_gcp_authorize import typed_finalize_atomic
@@ -5561,6 +5563,7 @@ class SpannerBigtableStore:
                     workspace_id=workspace_id,
                     key_hash=key_hash,
                     estimate=estimate,
+                    trust_settings=self.trust_settings,
                     has_credit_candidate=has_credit_candidate,
                     reservation_usage_type=str(usage),
                     idempotency_scope=scope,

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -284,6 +284,7 @@ def authorize_atomic(
     spend_lease_receipt_hash: str | None = None,
     credit_escrowed_by_spend_lease: bool = False,
     spend_lease_admission_replay_protection: bool = False,
+    trust_settings: Any = None,
 ) -> dict:
     """Run the atomic authorize. Returns {outcome, reservation_id?, authorization_id?}.
 
@@ -431,15 +432,19 @@ def authorize_atomic(
                 raise _Reject(AuthorizeOutcome.INSUFFICIENT_CREDITS)
             credit_hold = estimate
 
-        # Pause state is replicated atomically across the credit shards. Read
-        # only the selected shard, whose balance DML already joined this txn's
-        # read set; a workspace-wide scan couples otherwise independent holds
-        # and can exhaust the retry budget under contention. BYOK / lease-
-        # escrowed requests use shard zero. A pause still conflicts on this
-        # shard and rejection rolls back every staged key and credit hold.
-        from trusted_router.trust_eligibility import billing_paused_tx
-        if billing_paused_tx(transaction, pt, workspace_id, shard=selected_credit_shard):
-            raise _Reject("billing_paused")
+        # Authorize-time pause enforcement belongs to the armed trust program,
+        # not today's path. Shipping it unarmed changed the enclave rollout
+        # gate's behavior in production.
+        if trust_settings is not None and trust_settings.spend_lease_trust_eligibility_enabled:
+            # Pause state is replicated atomically across the credit shards. Read
+            # only the selected shard, whose balance DML already joined this txn's
+            # read set; a workspace-wide scan couples otherwise independent holds
+            # and can exhaust the retry budget under contention. BYOK / lease-
+            # escrowed requests use shard zero. A pause still conflicts on this
+            # shard and rejection rolls back every staged key and credit hold.
+            from trusted_router.trust_eligibility import billing_paused_tx
+            if billing_paused_tx(transaction, pt, workspace_id, shard=selected_credit_shard):
+                raise _Reject("billing_paused")
 
         lease_result: dict[str, Any] = {
             "bound": False,

--- a/src/trusted_router/storage_gcp_keys.py
+++ b/src/trusted_router/storage_gcp_keys.py
@@ -408,6 +408,7 @@ class SpannerApiKeys:
         spend_lease: SpendLeaseArtifact | None = None,
         invocation_nonce: str | None = None,
         expected_pause_epoch: int | None = None,
+        trust_eligibility_enabled: bool = False,
     ) -> GatewayAuthorization:
         if deferred_cap_microdollars is not None:
             # Deferred settlement is a PEER-plane mechanism: a plane spending
@@ -475,6 +476,22 @@ class SpannerApiKeys:
             spend_lease_status=spend_lease.lease_status if spend_lease else None,
             invocation_nonce=invocation_nonce,
         )
+        if not trust_eligibility_enabled:
+            if idempotency_key is None:
+                self._io.write_entity("gateway_authorization", auth.id, auth)
+                return auth
+            with self._io.database.batch() as batch:
+                self._io.write_entity_batch(batch, "gateway_authorization", auth.id, auth)
+                self._io.write_entity_batch(
+                    batch,
+                    "gateway_authorization_idempotency",
+                    _gateway_authorization_idempotency_index_id(
+                        workspace_id, key_hash, idempotency_key
+                    ),
+                    {"authorization_id": auth.id},
+                )
+            return auth
+
         from trusted_router.storage_legacy_trust import create_spanner_legacy_authorization
         index_id = (_gateway_authorization_idempotency_index_id(workspace_id, key_hash, idempotency_key)
                     if idempotency_key is not None else None)
@@ -484,7 +501,8 @@ class SpannerApiKeys:
         return self._io.read_entity("gateway_authorization", authorization_id, GatewayAuthorization)
 
     def get_gateway_authorization_by_idempotency_key(
-        self, workspace_id: str, key_hash: str, idempotency_key: str
+        self, workspace_id: str, key_hash: str, idempotency_key: str,
+        *, trust_eligibility_enabled: bool = False,
     ) -> GatewayAuthorization | None:
         ref = self._io.read_entity(
             "gateway_authorization_idempotency",
@@ -493,7 +511,7 @@ class SpannerApiKeys:
         )
         if not ref:
             return None
-        if ref.get("reason") == "billing_paused":
+        if trust_eligibility_enabled and ref.get("reason") == "billing_paused":
             from trusted_router.storage_legacy_trust import BillingPausedError
             raise BillingPausedError()
         return self.get_gateway_authorization(str(ref["authorization_id"]))

--- a/src/trusted_router/storage_gcp_regional_quota.py
+++ b/src/trusted_router/storage_gcp_regional_quota.py
@@ -709,8 +709,8 @@ def record_regional_gateway_authorization(
                 return replay(existing)
         from trusted_router.trust_eligibility import billing_paused_tx, lease_eligibility, tier_cap
         settings: Any = getattr(store, "trust_settings", None)
-        reason = "billing_paused" if billing_paused_tx(transaction, store._param_types, authorization.workspace_id) else None
         armed = settings is not None and settings.spend_lease_trust_eligibility_enabled
+        reason = "billing_paused" if armed and billing_paused_tx(transaction, store._param_types, authorization.workspace_id) else None
         current = None
         if armed or reason:
             current = store._read_entity_tx(transaction, _LEASE_KIND,

--- a/src/trusted_router/storage_legacy_trust.py
+++ b/src/trusted_router/storage_legacy_trust.py
@@ -6,6 +6,12 @@ import json
 from typing import Any
 
 
+def trust_program_armed(store: Any) -> bool:
+    """Legacy trust enforcement must also ship inert until the arm flag flips."""
+    settings = getattr(store, "trust_settings", None)
+    return bool(getattr(settings, "spend_lease_trust_eligibility_enabled", False))
+
+
 class BillingPausedError(ValueError):
     def __init__(self) -> None:
         super().__init__("billing_paused")
@@ -165,6 +171,8 @@ def spanner_pause_epoch(reader: Any, pt: Any, workspace_id: str) -> int:
 
 def legacy_pause_epoch(store: Any, workspace_id: str) -> int:
     """Snapshot for split legacy authorization; creation rechecks it atomically."""
+    if not trust_program_armed(store):
+        return 0
     if hasattr(store, "_legacy_pause_epoch"):
         return int(store._legacy_pause_epoch(workspace_id))
     if hasattr(store, "_database"):

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -108,6 +108,7 @@ from trusted_router.storage_gcp_codec import (
 from trusted_router.storage_gcp_counters import credit_shard_count, distribute_credit_amount
 from trusted_router.storage_key_patch import TYPED_LIMIT_PATCH_FIELDS, apply_key_patch
 from trusted_router.storage_key_usage import api_key_from_json, api_key_usage_snapshot
+from trusted_router.storage_legacy_trust import trust_program_armed
 from trusted_router.storage_models import (
     FUTURE_SAMPLE_SKEW_SECONDS,
     AcquisitionAttribution,
@@ -522,6 +523,7 @@ class PostgresStore:
         postgres_iam_auth: str = "",
         postgres_iam_region: str = "",
         operational_analytics_outbox_enabled: bool = False,
+        trust_settings: Any = None,
         max_workspaces_per_owner: int = 25,
         trust_qualifying_providers: frozenset[str] = frozenset({"stripe", "x402"}),
         trust_tier3_min_days: int = 30,
@@ -532,6 +534,7 @@ class PostgresStore:
         if transaction_attempts < 1:
             raise ValueError("transaction_attempts must be positive")
         self._transaction_attempts = transaction_attempts
+        self.trust_settings = trust_settings
         self.max_workspaces_per_owner = int(max_workspaces_per_owner)
         self.trust_qualifying_providers = trust_qualifying_providers
         self.trust_tier3_min_days = int(trust_tier3_min_days)
@@ -5409,22 +5412,23 @@ class PostgresStore:
         from trusted_router.storage_legacy_trust import BillingPausedError, postgres_pause
 
         def reserve_credit(conn: Any) -> Reservation | None:
-            paused, epoch = postgres_pause(conn, workspace_id)
-            terminal = self._read_entity_tx(conn, _RESERVATION_IDEMPOTENCY_KIND, idempotency_key, dict) if idempotency_key else None
-            if paused or (terminal and terminal.get("reason") == "billing_paused"):
-                from trusted_router.storage_legacy_trust import reject_postgres_reservation
+            if trust_program_armed(self):
+                paused, epoch = postgres_pause(conn, workspace_id)
+                terminal = self._read_entity_tx(conn, _RESERVATION_IDEMPOTENCY_KIND, idempotency_key, dict) if idempotency_key else None
+                if paused or (terminal and terminal.get("reason") == "billing_paused"):
+                    from trusted_router.storage_legacy_trust import reject_postgres_reservation
 
-                if terminal and terminal.get("id"):
-                    reject_postgres_reservation(conn, self, str(terminal["id"]))
-                if idempotency_key:
-                    self._write_entity_tx(conn, _RESERVATION_IDEMPOTENCY_KIND, idempotency_key,
-                                          {"reason": "billing_paused"})
-                    self._write_entity_tx(conn, _GATEWAY_IDEMPOTENCY_KIND,
-                        _gateway_idempotency_id(workspace_id, key_hash, idempotency_key),
-                        {"reason": "billing_paused"})
-                self._release_key_hold_tx(conn, key_hash, amount_microdollars,
-                                          usage_type=UsageType.CREDITS, window_amount=0)
-                return None
+                    if terminal and terminal.get("id"):
+                        reject_postgres_reservation(conn, self, str(terminal["id"]))
+                    if idempotency_key:
+                        self._write_entity_tx(conn, _RESERVATION_IDEMPOTENCY_KIND, idempotency_key,
+                                              {"reason": "billing_paused"})
+                        self._write_entity_tx(conn, _GATEWAY_IDEMPOTENCY_KIND,
+                            _gateway_idempotency_id(workspace_id, key_hash, idempotency_key),
+                            {"reason": "billing_paused"})
+                    self._release_key_hold_tx(conn, key_hash, amount_microdollars,
+                                              usage_type=UsageType.CREDITS, window_amount=0)
+                    return None
             if idempotency_key is not None:
                 won = self._insert_entity_once_tx(
                     conn,
@@ -5465,7 +5469,8 @@ class PostgresStore:
             )
             if cursor.rowcount != 1:
                 raise ValueError("insufficient credits")
-            self._write_entity_tx(conn, "reservation_pause_epoch", reservation.id, {"pause_epoch": epoch})
+            if trust_program_armed(self):
+                self._write_entity_tx(conn, "reservation_pause_epoch", reservation.id, {"pause_epoch": epoch})
             return reservation
 
         result = self._run_transaction(reserve_credit)
@@ -6009,23 +6014,24 @@ class PostgresStore:
         )
 
         def create(conn: Any) -> GatewayAuthorization | None:
-            paused, epoch = postgres_pause(conn, workspace_id)
-            pointer_id = _gateway_idempotency_id(workspace_id, key_hash, idempotency_key) if idempotency_key else None
-            prior = self._read_entity_tx(conn, _GATEWAY_IDEMPOTENCY_KIND, pointer_id, dict, for_update=True) if pointer_id else None
-            if prior and prior.get("reason") == "billing_paused":
-                return None
-            if prior and prior.get("authorization_id"):
-                existing = self._read_entity_tx(conn, _GATEWAY_AUTHORIZATION_KIND, str(prior["authorization_id"]), GatewayAuthorization)
-                if existing is not None:
-                    return existing
-            observed = self._read_entity_tx(conn, "reservation_pause_epoch", credit_reservation_id, dict) if credit_reservation_id else None
-            if paused or (expected_pause_epoch is not None and expected_pause_epoch != epoch) or (credit_reservation_id and int((observed or {}).get("pause_epoch", 0)) != epoch):
-                if credit_reservation_id:
-                    reject_postgres_reservation(conn, self, credit_reservation_id)
-                self._release_key_hold_tx(conn, key_hash, estimated_microdollars, usage_type=usage_type, window_amount=0)
-                if pointer_id:
-                    self._write_entity_tx(conn, _GATEWAY_IDEMPOTENCY_KIND, pointer_id, {"reason": "billing_paused"})
-                return None
+            if trust_program_armed(self):
+                paused, epoch = postgres_pause(conn, workspace_id)
+                pointer_id = _gateway_idempotency_id(workspace_id, key_hash, idempotency_key) if idempotency_key else None
+                prior = self._read_entity_tx(conn, _GATEWAY_IDEMPOTENCY_KIND, pointer_id, dict, for_update=True) if pointer_id else None
+                if prior and prior.get("reason") == "billing_paused":
+                    return None
+                if prior and prior.get("authorization_id"):
+                    existing = self._read_entity_tx(conn, _GATEWAY_AUTHORIZATION_KIND, str(prior["authorization_id"]), GatewayAuthorization)
+                    if existing is not None:
+                        return existing
+                observed = self._read_entity_tx(conn, "reservation_pause_epoch", credit_reservation_id, dict) if credit_reservation_id else None
+                if paused or (expected_pause_epoch is not None and expected_pause_epoch != epoch) or (credit_reservation_id and int((observed or {}).get("pause_epoch", 0)) != epoch):
+                    if credit_reservation_id:
+                        reject_postgres_reservation(conn, self, credit_reservation_id)
+                    self._release_key_hold_tx(conn, key_hash, estimated_microdollars, usage_type=usage_type, window_amount=0)
+                    if pointer_id:
+                        self._write_entity_tx(conn, _GATEWAY_IDEMPOTENCY_KIND, pointer_id, {"reason": "billing_paused"})
+                    return None
             if idempotency_key:
                 index_id = _gateway_idempotency_id(workspace_id, key_hash, idempotency_key)
                 won = self._insert_entity_once_tx(
@@ -6111,7 +6117,7 @@ class PostgresStore:
             _gateway_idempotency_id(workspace_id, key_hash, idempotency_key),
             dict,
         )
-        if pointer and pointer.get("reason") == "billing_paused":
+        if trust_program_armed(self) and pointer and pointer.get("reason") == "billing_paused":
             from trusted_router.storage_legacy_trust import BillingPausedError
             raise BillingPausedError()
         authorization_id = str((pointer or {}).get("authorization_id") or "")

--- a/tests/test_credit_row_sharding_stress.py
+++ b/tests/test_credit_row_sharding_stress.py
@@ -8,6 +8,7 @@ import pytest
 
 from scripts.stress_credit_shards import _seed, run_stress
 from tests.fakes.spanner import _FakeTransaction
+from trusted_router.config import Settings
 from trusted_router.storage_gcp_authorize import authorize_atomic, settle_atomic
 from trusted_router.storage_gcp_counter_dml import reserve_credit
 from trusted_router.storage_gcp_trust import _sync_principal_recovery_pause_tx
@@ -95,6 +96,7 @@ def test_authorize_pause_read_conflicts_only_with_relevant_writes(
         has_credit_candidate=True, reservation_usage_type="Credits",
         idempotency_scope="scope", idempotency_fingerprint="body", expires_at=None,
         credit_shard=credit_shard,
+        trust_settings=Settings(environment="test", spend_lease_trust_eligibility_enabled=True),
         build_auth_body=lambda aid, rid: json.dumps(
             {"id": aid, "credit_reservation_id": rid},
         ),

--- a/tests/test_gateway_authorize_spanner_operations.py
+++ b/tests/test_gateway_authorize_spanner_operations.py
@@ -277,8 +277,10 @@ def test_typed_accepted_authorization_matches_persisted_record() -> None:
     assert dataclasses.asdict(authorization) == dataclasses.asdict(persisted)
 
 
-def test_fresh_typed_gateway_authorize_has_exact_sequential_spanner_operation_count() -> None:
-    _store, database, key = _seed_typed_gateway_store()
+@pytest.mark.parametrize("armed", [False, True])
+def test_fresh_typed_gateway_authorize_has_exact_sequential_spanner_operation_count(armed: bool) -> None:
+    store, database, key = _seed_typed_gateway_store()
+    store.trust_settings = Settings(environment="test", spend_lease_trust_eligibility_enabled=armed)
     gateway._BROADCAST_EMPTY_CACHE.clear()
     assert gateway._broadcast_destinations_for_authorize(key.workspace_id) == []
     before = (
@@ -300,8 +302,9 @@ def test_fresh_typed_gateway_authorize_has_exact_sequential_spanner_operation_co
     assert response["data"]["authorization_id"]
     # Representative steady-state fresh request: the workspace's observed-empty
     # broadcast cache is warm, while this idempotency key and authorization are new.
-    # Trust PR 2 adds the transactional pause/epoch read before either hold.
-    assert operation_count == 11
+    # The original ten operations stay exact with the trust program disarmed.
+    # Armed authorization adds one selected-shard pause/epoch read.
+    assert operation_count == 10 + int(armed)
 
 
 def test_broadcast_empty_results_are_cached_until_ttl(

--- a/tests/test_postgres_iam_auth.py
+++ b/tests/test_postgres_iam_auth.py
@@ -154,17 +154,17 @@ def test_settings_and_create_store_pass_iam_configuration(
     assert settings.postgres_iam_region == "us-east-2"
 
     monkeypatch.setattr(storage_postgres, "PostgresStore", FakeStore)
-    result = create_store(
-        SimpleNamespace(
-            storage_backend="postgres",
-            postgres_dsn="postgresql://admin@cluster.example/postgres",
-            postgres_iam_auth="aws-dsql",
-            postgres_iam_region="us-east-2",
-        )
+    store_settings = SimpleNamespace(
+        storage_backend="postgres",
+        postgres_dsn="postgresql://admin@cluster.example/postgres",
+        postgres_iam_auth="aws-dsql",
+        postgres_iam_region="us-east-2",
     )
+    result = create_store(store_settings)
 
     assert isinstance(result, FakeStore)
     assert captured == {
+        "trust_settings": store_settings,
         "dsn": "postgresql://admin@cluster.example/postgres",
         "postgres_iam_auth": "aws-dsql",
         "postgres_iam_region": "us-east-2",

--- a/tests/test_stage_c_flag_off_differential.py
+++ b/tests/test_stage_c_flag_off_differential.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import json
 import uuid
 from pathlib import Path
+from typing import Any
 
 import pytest
+from fastapi import HTTPException
 from starlette.requests import Request
 
-from tests.fakes.spanner import _ParamTypes, make_fake_store
+from tests.fakes.spanner import _FakeTransaction, _ParamTypes, make_fake_store
 from trusted_router import spend_leases, storage_gcp_authorize
 from trusted_router.catalog import MODELS, endpoints_for_model
 from trusted_router.config import Settings
@@ -33,10 +35,28 @@ def _canonical(value: object) -> bytes:
     return json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
 
 
+@pytest.mark.parametrize("shard", [0, 3], ids=["shard-zero", "selected-shard-three"])
+@pytest.mark.parametrize(
+    "paused,armed",
+    [(False, False), (True, False), (True, True)],
+    ids=["clear-flag-off", "paused-flag-off", "paused-flag-on"],
+)
 def test_flag_off_authorize_response_is_byte_exact_origin_main(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, paused: bool, armed: bool, shard: int,
 ) -> None:
     store, database, _ = make_fake_store(request_record_write_mode="typed")
+    settings = Settings(environment="test", spend_lease_trust_eligibility_enabled=armed)
+    store.trust_settings = settings
+    pause_reads: list[dict[str, Any]] = []
+    execute_sql = _FakeTransaction.execute_sql
+
+    def record_sql(self: Any, sql: str, **kwargs: Any) -> Any:
+        if "billing_pause_causes" in sql:
+            pause_reads.append(kwargs["params"])
+        return execute_sql(self, sql, **kwargs)
+
+    monkeypatch.setattr(_FakeTransaction, "execute_sql", record_sql)
+    monkeypatch.setattr(type(store), "_credit_shard_candidates", lambda *_: (shard,))
     workspace = Workspace(
         id="ws-origin-golden",
         name="Golden",
@@ -48,12 +68,14 @@ def test_flag_off_authorize_response_is_byte_exact_origin_main(
         workspace.id,
         CreditAccount(workspace_id=workspace.id),
     )
-    database.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(workspace.id, 0)] = {
+    database.typed.setdefault(CREDIT_BALANCE_TABLE, {})[(workspace.id, shard)] = {
         "workspace_id": workspace.id,
-        "shard": 0,
+        "shard": shard,
         "total_credits": 50_000_000,
         "total_usage": 0,
         "reserved": 0,
+        "billing_pause_causes": ["abuse"] if paused else [],
+        "pause_epoch": 1 if paused else 0,
         "source_updated_at": None,
         "updated_at": None,
     }
@@ -80,14 +102,29 @@ def test_flag_off_authorize_response_is_byte_exact_origin_main(
         estimated_input_tokens=100,
         max_output_tokens=100,
     )
-    response = gateway._authorize_gateway_sync(  # noqa: SLF001
-        Request({"type": "http", "method": "POST", "path": "/", "headers": []}),
-        body,
-        Settings(environment="test"),
-    )
-    response["data"]["api_key_hash"] = "<api-key-hash>"
+    def authorize() -> Any:
+        return gateway._authorize_gateway_sync(  # noqa: SLF001
+            Request({"type": "http", "method": "POST", "path": "/", "headers": []}),
+            body,
+            settings,
+        )
 
-    assert _canonical(response) == (GOLDENS / "authorize_response.json").read_bytes()
+    if armed:
+        with pytest.raises(HTTPException) as rejected:
+            authorize()
+        assert rejected.value.status_code == 403
+        assert rejected.value.detail["error"]["message"] == "billing_paused"
+        assert pause_reads == [{"ws": workspace.id, "shard": shard}]
+        assert database.typed[CREDIT_BALANCE_TABLE][(workspace.id, shard)]["reserved"] == 0
+        assert database.typed["tr_key_limit"][(key.hash, 0)]["reserved"] == 0
+        assert not database.reservations
+        assert not database.typed.get("tr_gateway_authorization")
+    else:
+        response = authorize()
+        response["data"]["api_key_hash"] = "<api-key-hash>"
+        assert _canonical(response) == (GOLDENS / "authorize_response.json").read_bytes()
+        assert pause_reads == []
+        assert database.typed[CREDIT_BALANCE_TABLE][(workspace.id, shard)]["reserved"] > 0
 
 
 def test_flag_off_lease_claims_are_byte_exact_origin_main(
@@ -168,3 +205,107 @@ def test_origin_main_golden_commit_and_literal_deploy_default_are_pinned() -> No
     rollout = (Path(__file__).parents[1] / "scripts" / "deploy" / "rollout.sh").read_text()
     assert '"TR_SPEND_LEASE_ADMISSION_ACCEPT=false"' in rollout
     assert "TR_SPEND_LEASE_ADMISSION_ACCEPT=${" not in rollout
+
+
+@pytest.mark.parametrize("backend,byok", [("memory", False), ("memory", True), ("postgres", False), ("postgres", True), ("spanner", True)])
+def test_flag_off_legacy_pause_keeps_holds_and_skips_trust_queries(
+    backend: str, byok: bool, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tests.fakes.postgres import postgres_store_on, sqlite_postgres_conn
+    from trusted_router import storage_legacy_trust
+    from trusted_router.storage import InMemoryStore
+
+    store: Any
+    db: Any = None
+    conn: Any = None
+    if backend == "memory":
+        store = InMemoryStore()
+    elif backend == "postgres":
+        conn = sqlite_postgres_conn()
+        store = postgres_store_on(conn)
+    else:
+        store, db, _ = make_fake_store(request_record_write_mode="legacy")
+    store.trust_settings = Settings(environment="test", spend_lease_trust_eligibility_enabled=False)
+    ws = store.create_workspace("owner", "unarmed", trial_credit_microdollars=1000)
+    _raw, key = store.create_api_key(
+        workspace_id=ws.id, name="key", creator_user_id="owner", limit_microdollars=1000,
+    )
+    if backend == "memory":
+        store.credit_trust_shards[(ws.id, 0)].update(billing_pause_causes=["abuse"], pause_epoch=7)
+    elif backend == "postgres":
+        conn.execute(
+            "UPDATE tr_credit_balance SET billing_pause_causes = %s, pause_epoch = 7 WHERE workspace_id = %s",
+            ('["abuse"]', ws.id),
+        )
+    else:
+        for (workspace_id, _), row in db.typed[CREDIT_BALANCE_TABLE].items():
+            if workspace_id == ws.id:
+                row.update(billing_pause_causes=["abuse"], pause_epoch=7)
+
+    def unexpected_trust_read(*_args: Any, **_kwargs: Any) -> Any:
+        pytest.fail("flag-off legacy authorize entered the trust program")
+
+    for name in ("postgres_pause", "spanner_pause_epoch", "create_spanner_legacy_authorization"):
+        monkeypatch.setattr(storage_legacy_trust, name, unexpected_trust_read)
+    if backend == "memory":
+        monkeypatch.setattr(type(store), "_legacy_paused", unexpected_trust_read)
+        monkeypatch.setattr(type(store), "_legacy_pause_epoch", unexpected_trust_read)
+        monkeypatch.setattr(type(store), "_recover_released_credit_locked", unexpected_trust_read)
+    assert storage_legacy_trust.legacy_pause_epoch(store, ws.id) == 0
+    usage = UsageType.BYOK if byok else UsageType.CREDITS
+    store.reserve_key_limit(key.hash, 100, usage_type=usage)
+    reservation = None if byok else store.reserve(ws.id, key.hash, 100, idempotency_key="unarmed")
+    authorization = store.create_gateway_authorization(
+        workspace_id=ws.id, key_hash=key.hash, model_id="m", provider="p", usage_type=usage,
+        estimated_microdollars=100, credit_reservation_id=reservation.id if reservation else None,
+        idempotency_key="unarmed", expected_pause_epoch=0,
+    )
+    assert authorization.estimated_microdollars == 100
+    assert store.get_gateway_authorization_by_idempotency_key(ws.id, key.hash, "unarmed").id == authorization.id
+    if backend == "memory":
+        assert store.api_keys.get_by_hash(key.hash).reserved_microdollars == 100
+        assert store.credit_money[ws.id].reserved_microdollars == (0 if byok else 100)
+        assert not store._reservation_pause_epochs
+        if reservation:
+            store.refund(reservation.id)
+            assert store.credit_money[ws.id].reserved_microdollars == 0
+    elif backend == "postgres":
+        assert conn.balance(ws.id) == (1000, 0, 0 if byok else 100)
+        assert conn.count_entities("reservation_pause_epoch") == 0
+        assert conn.execute("SELECT reserved FROM tr_key_limit WHERE key_hash = %s", (key.hash,)).fetchone()[0] == 100
+    else:
+        assert store.api_keys.get_by_hash(key.hash).reserved_microdollars == 100
+
+
+def test_flag_off_regional_pause_preserves_grant_and_authorization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tests.test_trust_eligibility_pr2 import regional_args
+    from trusted_router import trust_eligibility
+    from trusted_router.regional_quota_ledger import InMemoryRegionalQuotaLedger
+
+    store, db, _ = make_fake_store(request_record_write_mode="typed")
+    store.trust_settings = Settings(environment="test", spend_lease_trust_eligibility_enabled=False)
+    ws = store.create_workspace("owner", "regional-unarmed", trial_credit_microdollars=200_000_000)
+    _raw, key = store.create_api_key(workspace_id=ws.id, name="key", creator_user_id="owner")
+    store._regional_quota_ledger = InMemoryRegionalQuotaLedger()
+    for (workspace_id, _), row in db.typed[CREDIT_BALANCE_TABLE].items():
+        if workspace_id == ws.id:
+            row.update(billing_pause_causes=["abuse"], pause_epoch=1, trust_tier=0)
+
+    def unexpected_trust_read(*_args: Any, **_kwargs: Any) -> Any:
+        pytest.fail("flag-off regional authorize entered the trust program")
+
+    monkeypatch.setattr(trust_eligibility, "billing_paused_tx", unexpected_trust_read)
+    monkeypatch.setattr(trust_eligibility, "lease_eligibility", unexpected_trust_read)
+    outcome, authorization = store.authorize_gateway_regional(
+        authorization_id="regional-unarmed", **regional_args(ws.id, key)
+    )
+    assert outcome == "accepted" and authorization is not None
+    leases = [json.loads(record.body) for (kind, _), record in db.rows.items() if kind == "regional_quota_lease"]
+    assert len(leases) == 1
+    assert leases[0]["state"] == "active"
+    assert leases[0]["granted_microdollars"] == 10_000_000 // 16
+    assert "issuance_tier" not in leases[0] and "tier_cap_micro" not in leases[0]
+    local = store._regional_quota_ledger.get(leases[0]["lease_id"], region="us-central1")
+    assert local is not None and local.reserved_microdollars == 10000

--- a/tests/test_trust_eligibility_pr2.py
+++ b/tests/test_trust_eligibility_pr2.py
@@ -401,6 +401,7 @@ def test_legacy_pause_rejects_atomically_and_terminal_key_survives_unpause(
     from trusted_router.types import UsageType
 
     store = InMemoryStore() if backend == "memory" else postgres_store_on(sqlite_postgres_conn())
+    store.trust_settings = Settings(environment="test", spend_lease_trust_eligibility_enabled=True)
     ws = store.create_workspace("owner", "legacy", trial_credit_microdollars=1_000_000)
     _raw, key = store.create_api_key(
         workspace_id=ws.id, name="key", creator_user_id="owner", limit_microdollars=1_000_000
@@ -465,6 +466,7 @@ def test_selected_shard_pause_during_typed_authorize_takes_no_holds() -> None:
     from tests.test_spend_lease_authorize import _authorize_store, _store_binding_harness
 
     store, db, key, plan, _ledger = _store_binding_harness()
+    store.trust_settings = Settings(environment="test", spend_lease_trust_eligibility_enabled=True)
     row = db.typed["tr_credit_balance"][("workspace-1", 0)]
     row["billing_pause_causes"] = ["abuse"]
     row["pause_epoch"] = 1
@@ -480,6 +482,7 @@ def test_legacy_spanner_byok_rechecks_pause_inside_creation() -> None:
     from trusted_router.types import UsageType
 
     store, db, _ = make_fake_store(request_record_write_mode="legacy")
+    store.trust_settings = Settings(environment="test", spend_lease_trust_eligibility_enabled=True)
     ws = store.create_workspace("owner", "legacy-gcp")
     _raw, key = store.create_api_key(
         workspace_id=ws.id, name="key", creator_user_id="owner", limit_microdollars=1000
@@ -522,6 +525,7 @@ def test_legacy_release_recovers_principal_before_unpause(backend: str) -> None:
     from trusted_router.types import UsageType
 
     store = InMemoryStore() if backend == "memory" else postgres_store_on(sqlite_postgres_conn())
+    store.trust_settings = Settings(environment="test", spend_lease_trust_eligibility_enabled=True)
     ws = store.create_workspace("owner", "debt-release", trial_credit_microdollars=0)
     now = datetime.now(UTC)
     store.credit_workspace_typed_direct(
@@ -595,6 +599,7 @@ def test_pause_at_reservation_is_terminal_and_cannot_settle_released_hold(
     from trusted_router.types import UsageType
 
     store = InMemoryStore() if backend == "memory" else postgres_store_on(sqlite_postgres_conn())
+    store.trust_settings = Settings(environment="test", spend_lease_trust_eligibility_enabled=True)
     ws = store.create_workspace("owner", "reserve-race", trial_credit_microdollars=1000)
     _raw, key = store.create_api_key(
         workspace_id=ws.id, name="key", creator_user_id="owner", limit_microdollars=1000
@@ -658,6 +663,7 @@ def test_legacy_pause_cleared_between_reserve_and_create_still_refuses(
         store = (
             InMemoryStore() if backend == "memory" else postgres_store_on(sqlite_postgres_conn())
         )
+    store.trust_settings = Settings(environment="test", spend_lease_trust_eligibility_enabled=True)
     ws = store.create_workspace("owner", "epoch-race", trial_credit_microdollars=1000)
     _raw, key = store.create_api_key(
         workspace_id=ws.id, name="key", creator_user_id="owner", limit_microdollars=1000
@@ -1028,6 +1034,7 @@ def test_legacy_partial_release_allocates_recovery_in_payment_order(backend: str
     from trusted_router.types import UsageType
 
     store = InMemoryStore() if backend == "memory" else postgres_store_on(sqlite_postgres_conn())
+    store.trust_settings = Settings(environment="test", spend_lease_trust_eligibility_enabled=True)
     ws = store.create_workspace("owner", "partial-release", trial_credit_microdollars=0)
     now = datetime.now(UTC)
     # Insertion order deliberately differs from the canonical payment order.


### PR DESCRIPTION
## Why

PR 2 (#1113, merged `a028a0e1`, deployed to production 2026-09-06 08:26Z) is documented and was reviewed as shipping **inert**: "with the flag off every path is byte-for-byte today's behaviour" (decision 76, round three). It is not. It added live behaviour on paths reachable with `TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED=false`, most visibly:

```
src/trusted_router/storage_gcp_authorize.py  (PR 2, unguarded)
    if billing_paused_tx(transaction, pt, workspace_id, shard=selected_credit_shard):
        raise _Reject("billing_paused")
```

`git show a028a0e1^:src/trusted_router/storage_gcp_authorize.py | grep billing_pause` is empty, and `tests/test_stage_c_flag_off_differential.py` mentioned `billing_pause` zero times, so the differential that was supposed to guarantee inertness never exercised a paused workspace.

**Observed consequence.** The first enclave rollout after that deploy (quill-cloud-proxy run 34044037548, 2026-09-06 16:00Z) failed its blocking per-instance gate: the direct inference canary returned HTTP 403 three times against the new template's instance and again against the previous template's instance during recovery, with attestation green on both. A `_Reject("billing_paused")` is rendered as `api_error(403, "billing_paused", FORBIDDEN)`; an invalid key returns 401, verified against a live instance. The enclave rollout is blocked, and with it the Stage D heartbeat rollout.

This change does not by itself prove the production canary's 403 was that rejection; confirming that needs a query against the monitor workspace's pause state. It does restore the contract PR 2 claimed.

## What

Every PR 2 call site that could change an outcome with the flag off now requires the arm flag. `git diff a028a0e1^ a028a0e1 -- src/trusted_router/` was audited call site by call site; the table is in the branch's review notes. The ones that changed behaviour and are now armed-only:

- **Typed authorize**: the selected-shard pause read and `billing_paused` rejection. Armed behaviour, including the shard scoping from the CI-race fix and the transactional rollback, is unchanged.
- **Legacy authorization** (`storage_gcp_keys.py`, `storage_legacy_trust.py`, `routes/internal/gateway.py`): the extra pause-epoch snapshot, the new read/write transaction replacing the old direct/batch writer, terminal-pointer rejection, and epoch arguments. With the flag off the pre-PR 2 writer and idempotency behaviour return exactly.
- **Regional quota recording**: the pause query, the consequent lease read, quarantine, refusal and Bigtable hold refund.
- **In-memory and Postgres stores**: reserve pause/terminal/epoch, refund principal recovery, the create replay/pause/epoch block, and terminal replay refusal. Both now receive the settings object from `create_store`, as the GCP store already did.

A small helper, `storage_legacy_trust.trust_program_armed(store)`, reads the same setting so the legacy paths cannot drift from the typed one. The pre-existing workspace pause check (503, older than PR 2) is untouched.

## Proof

Written by codex (gpt-6-astra); reviewed by Fable. Codex: 585 requested tests, ruff and mypy clean, 29 Stage C fixtures byte-identical, new differential cases for clear/off, paused/off and paused/on on two shards, new flag-off cases for memory, Postgres and GCP legacy paths that fail if a trust read is attempted, and a regional flag-off case asserting the original grant, hold and JSON.

Fable gate on a fresh snapshot: 1,109 tests green across the flag-off differential, trust, billing-pause, sharding-stress, spend-lease, regional, Postgres and Stage D suites; ruff and mypy clean; `tests/fixtures` byte-identical to `origin/main`; the Stage D flip and the arm flag both still pinned as they are on main. Four mutations red: force the typed guard on (flag-off differential fails), force it off (armed test fails), make `trust_program_armed` always true (flag-off differential fails), and drop the `armed and` conjunct from the regional recorder (flag-off differential fails).

## Follow-up

When the trust program is armed, a workspace with a pause cause will be refused at authorize. If the synthetic monitor workspace carries one, the enclave rollout gate will fail again at arming time, so its pause state has to be resolved first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
