### PR TITLE
Authorize: uncapped keys skip tr_key_limit entirely

### DIFF
--- a/docs/storage-portability/uncapped-skip-validation.md
+++ b/docs/storage-portability/uncapped-skip-validation.md
@@ -1,0 +1,208 @@
+# Uncapped authorize contention regression proof
+
+The gateway derives `skip_key_limit` from its already-authenticated ApiKey:
+`limit_microdollars is None` and the request-applicable `window_limits` is empty.
+BYOK-excluded requests omit window limits, including enforced windows on uncapped keys.
+A BYOK-excluded request on a capped key still follows the original reserve path.
+The typed store also refuses the skip when supplied blocking window limits.
+Older/direct callers default to the original behavior.
+
+`authorize_atomic` records the first pre-randomized key candidate and a zero
+key hold without calling `reserve_key`. The existing reserve loop and its SQL
+are unchanged. The shared settle/reaper/drain release helper now recovers positive zero-hold
+usage on shard zero if the recorded shard disappeared. It emits the committed
+`key_usage_shard_fallback_total` counter event (value 1) and a warning naming the
+key, missing shard and amount. Both text and structured log fields carry the
+metric. This is a log-based counter event, not a newly provisioned Cloud
+Monitoring metric. If shard zero cannot book either, it raises `RuntimeError`
+with reservation ID, key, shard, actual amount and usage type. Transactional
+claims roll back and the outbox retains the frozen usage for retry/dead-letter.
+No schema flag distinguishes skip reservations from legacy zero-hold records,
+so this protection deliberately covers both. Held/capped deleted-key handling,
+keyless pre-migration credit reservations, zero-usage refunds, usage display, and #1101's hot-row releases LAST in the same
+transaction remain unchanged.
+
+## Tests
+
+`tests/test_uncapped_authorize_skip.py` records snapshot SQL, transaction SQL,
+DML, and buffered mutations on the shared Spanner fake. Assertions cover the
+entire gateway authorize call, not only the transaction helper.
+
+| Spec invariant | Test |
+| --- | --- |
+| 1. Zero counter access for uncapped keys | `test_uncapped_authorize_zero_counter_statements_or_mutations` (both include-BYOK settings; no-window and alert-only-window configurations) |
+| 2. Capped behavior unchanged | `test_capped_and_window_paths_keep_exact_reserve_sql_and_parameters` (literal pre-change SQL and parameter types/values) |
+| 3. Daily/weekly/monthly windows retain enforcement | Same parameterized SQL test, plus `test_uncapped_window_limit_still_blocks` |
+| 4. BYOK/include-BYOK behavior | Same SQL test for capped/window-only keys, plus `test_uncapped_byok_skips_authorize_and_settles_byok_usage` |
+| 5. One booking shard and correct summed display | `test_uncapped_settle_books_one_selected_shard_and_display_sums` (nonzero usage already on another shard; all three windows; zero hold release) |
+| 6. Legacy authorization settlement | `test_legacy_authorization_still_settles` (old caller omits opt-in and creates the original zero-hold reservation) |
+| 7. Replay identity and exactly-once booking | `test_uncapped_replay_keeps_authorization_and_books_once` (candidate order changes before replay; repeats settlement) |
+
+## Actual reversion and mutation runs
+
+Rebased main baseline: `94c0cb4251849b270c2e7183123f7bc6872ab96f`
+(`git merge-base HEAD origin/main`, also the WIP commit's parent).
+Round-1 WIP: `b909e3fc`.
+
+The following round-1 evidence is historical; the round-2 results below supersede
+its gate counts. The original pre-rebase baseline was
+`fe917a614e0228d33662f7577ac708e8919f81da`.
+
+On 2026-09-05, the three implementation files were temporarily overwritten with
+`git show HEAD:<path>` (gateway.py, storage_gcp.py, storage_gcp_authorize.py), the
+new tests were run, and the fixed bytes were restored in a `finally` block.
+No commit, checkout, or production operation was performed.
+
+**Full implementation reversion: 8 failed, 16 passed.** The 16 preserved-behavior
+cases correctly pass against the original code; making these fail on a faithful
+reversion would contradict the requirement that those behaviors stay unchanged.
+Their sensitivity was verified by individually breaking the behavior they guard:
+
+| Temporary change | Failed / passed |
+| --- | --- |
+| Remove gateway opt-in | 8 / 16 |
+| Remove store forwarding | 8 / 16 |
+| Allow capped keys to skip | 3 / 21 |
+| Remove both window skip guards | 9 / 15 |
+| Pass `is_byok=False` to the existing reserve loop | 8 / 16 |
+| Record shard zero instead of the first candidate | 6 / 18 |
+| Treat skipped key as KEY_ACCEPTED (nonzero hold) | 8 / 16 |
+| Release/book zero actual usage during settlement | 5 / 19 |
+| Settle legacy records against shard zero | 2 / 22 |
+| Display only the first usage shard | 3 / 21 |
+| Return a fresh authorization ID on replay | 1 / 23 |
+| Remove the settlement claim's replay early return | 1 / 23 |
+
+Removing only the initial authorize idempotency lookup **survived**: the existing
+unique-insert conflict fallback still returns the correct replay. This mutation
+does not violate invariant 7. The last two mutations above directly break its
+identity and settlement guards and both fail. All mutations were restored.
+
+Targeted restored suite: **24 passed**.
+
+## Historical round-1 gates
+
+The existing virtualenv was used with `UV_CACHE_DIR=/tmp/qr-locks-uv-cache` and
+`uv run --no-sync` because the default uv cache is outside the writable sandbox.
+
+- `ruff check .`: passed.
+- `mypy src/trusted_router`: passed, 355 source files.
+- Full suite, partitioned into two disjoint batches: **8,848 passed, 368 skipped,
+  10 xfailed, zero failures**.
+- Measured coverage: **83.73%**, exceeding the required 70%. This is the
+  conservative coverage from the main batch alone; the separately passing
+  sitemap crawl is not needed to reach the floor.
+
+The successful main batch passed all **481 other test file paths explicitly**
+to pytest (no shell-expanded path variable), with `-q -n 4 --dist loadgroup
+--cov=trusted_router --cov-report=term:skip-covered --cov-fail-under=70`.
+It returned exit 0: **8,846 passed, 368 skipped, 10 xfailed** in 1,511.92 seconds.
+The separate `pytest -q tests/test_sitemap_seo_hygiene.py` returned exit 0:
+**2 passed** in 228.09 seconds. Together these batches cover every test file;
+no test assertion was changed or disabled.
+
+Two earlier attempts did not constitute passing gates:
+
+1. The sandboxed run hit loopback `bind` PermissionErrors in the existing
+   gateway/TLS probe tests. The reruns permitted test-owned local networking.
+2. A worker in the next monolithic run terminated during
+   `test_every_sitemap_page_has_clean_search_metadata`, the existing crawl of
+   over 3,500 pages. That attempt reported 8,845 passed and one worker crash
+   before interruption. Temporary-file cleanup delayed its summary. The
+   unmodified sitemap file then passed alone, and **every other file was rerun**
+   successfully with coverage as described above.
+
+All results above are local validation; no production operation or commit was
+performed. The two pre-existing `.codex-*-spec.md` files were left untouched.
+
+
+## Round 2: bounded cap-change race
+
+The skip intentionally uses the gateway's already-authenticated entity read.
+A lifetime cap created after that read and before the authorize transaction can
+miss requests already in flight at the cap commit. The admission bound is the
+sum of those requests' estimates: each request carries its own estimate; this
+is not an extra allowance for subsequent fresh requests. The next request that
+reads the committed entity follows the capped reserve predicate. Cap removal
+also takes effect on the next fresh entity read, without a cached-cap refusal.
+An already-in-flight reader may still use its previous cap decision.
+This describes the authorize/admission bound, not a new clamp on actual usage
+at settlement. No counter or api_key read was added inside authorize to close
+the window, since that would restore the hot-row read being removed.
+
+`test_cap_commit_bounded_inflight_slip_and_fresh_removal` commits a real
+`update_key` after the gateway entity read, before typed authorize. It observes
+one admitted request with its exact credit estimate and no key hold, rejects
+the next request with 402, then removes the cap through `update_key` and admits
+the next request with zero key-counter statements.
+
+## Round-2 regression and actual reversion proof
+
+All runs use the existing virtualenv (`UV_CACHE_DIR=/tmp/qr-locks-uv-cache`,
+`uv run --no-sync`). Implementation bytes were temporarily replaced and restored
+in `finally` blocks; no checkout, commit, deletion, or production operation.
+The full-suite run uses restored source, separate from mutation runs.
+
+| Temporary reversion/mutation | Observed result |
+| --- | --- |
+| U1: restore HEAD's shared release helper / authorize module | **5 failed** (Credits/BYOK shard-9 shrink, zero rows with selected shard 0/3, frozen outbox rollback) |
+| U3: restore HEAD's gateway skip condition | **3 failed, 9 passed** (all three BYOK-excluded windows fail; included/capped behavior passes) |
+| U2: disable the atomic skip | **1 failed** (the in-flight slip/zero-statement contract) |
+| U2: let capped keys skip | **1 failed** (the next request is no longer rejected) |
+| U1: suppress the fallback metric field | **2 failed** (Credits and BYOK recovery telemetry) |
+| U1: revert helper with the differential ledger tests | **2 failed** (healthy and recovered ledgers diverge) |
+| U2: retain the old cap when removal commits | **1 failed** (the fresh request after removal is rejected) |
+| Remove the keyless-legacy exemption | **1 failed** (existing pre-migration credit-shard settlement test) |
+
+The shard-9 race removes the row after the entity read and before authorize;
+settle books 700 on shard zero with correct lifetime/window attribution and no
+replay double-booking. The zero-row cases deliberately pin the changed
+KEY_MISSING behavior: authorize succeeds without counter access, settle raises
+with the preserved amount, and a repaired row permits exactly-once retry.
+The differential ledger check compares healthy settlement with missing-shard
+recovery for Credits and BYOK: all credit balances, holds, lifetime and window
+usage match. The outbox case proves the frozen payload, reservation claim,
+authorization claim and credit hold survive the booking failure. Existing capped SQL and
+#1101 ordering assertions remain in the required targeted gate.
+
+## Round-2 gates on this tree
+
+- `ruff check .`: passed.
+- `mypy` and `mypy src/trusted_router`: passed, **370 source files**.
+- Required explicit-path gate on the corrected/restored tree: **249 passed**
+  in 48.31 seconds (the six paths below).
+- Full suite on the corrected/restored tree: **9,429 passed, 368 skipped,
+  10 xfailed, zero failures**, exit 0, in 651.36 seconds.
+- Coverage: **84.11%**, above the required 70%.
+- Final `git diff --check`: passed. No commits or file deletions.
+
+```bash
+uv run --no-sync pytest -q tests/test_uncapped_authorize_skip.py tests/test_billing_typed_enforcement.py tests/test_gateway_authorize_spanner_operations.py tests/test_settle_outbox_apply.py tests/test_settle_outbox_drain.py tests/test_settle_books_usage_always.py
+```
+
+The first completed round-2 full run found one real compatibility regression:
+**1 failed, 9,426 passed, 368 skipped, 10 xfailed; 84.11% coverage**. A
+pre-migration credit-only reservation has `key_hash=None` and must still settle
+its credit usage. The new helper initially treated it as a missing key. The
+fix excludes only those genuinely keyless records from key-usage recovery; the
+existing migration test fails with that exemption reverted. No test was weakened.
+The two additional differential cases were added after that run's collection.
+The corrected full run collects them as well. An earlier exploratory full run
+was interrupted before mutation testing; it is not counted as a passing gate.
+
+
+Final full-suite command (test-owned loopback listeners permitted):
+
+```bash
+UV_CACHE_DIR=/tmp/qr-locks-uv-cache uv run --no-sync pytest -q -n 4 --dist loadgroup --cov=trusted_router --cov-report=term:skip-covered --cov-fail-under=70
+```
+
+Local logs: `/tmp/qr-round2-full-final.log` and
+`/tmp/qr-round2-targeted-restored.log`. Reversion logs are
+`/tmp/qr-round2-U1-revert.log`, `/tmp/qr-round2-U3-revert.log`,
+`/tmp/qr-round2-U2-remove-skip.log`, `/tmp/qr-round2-U2-skip-capped.log`,
+`/tmp/qr-round2-U1-remove-metric.log`,
+`/tmp/qr-round2-U1-differential-revert.log`,
+`/tmp/qr-round2-U2-stale-removal.log`, and
+`/tmp/qr-round2-keyless-revert.log`. All implementation mutations were restored
+before the final full and explicit-path gates.

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -1747,6 +1747,12 @@ def _authorize_gateway_sync_impl(
                     receipt_fee_basis_points=receipt_fee_basis_points,
                     app_owner_user_id=app_owner_user_id,
                     key_usage_shards=key_usage_shards,
+                    # The entity is already authenticated; a no-op reserve
+                    # UPDATE would still lock uncapped usage counter rows.
+                    skip_key_limit=(
+                        api_key.limit_microdollars is None
+                        and not window_limits
+                    ),
                     custom_model_id=custom_model.id if custom_model else None,
                     custom_model_revision=custom_model.revision if custom_model else None,
                     custom_model_markup_basis_points=(

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -5326,6 +5326,7 @@ class SpannerBigtableStore:
         receipt_fee_basis_points: int = 0,
         app_owner_user_id: str = "",
         key_usage_shards: int = 1,
+        skip_key_limit: bool = False,
         tags: dict[str, str] | None = None,
         custom_model_id: str | None = None,
         custom_model_revision: int | None = None,
@@ -5578,6 +5579,7 @@ class SpannerBigtableStore:
                     # configured shard.
                     credit_shard_candidates=bounded_credit_shard_candidates(candidates),
                     key_shard_candidates=key_shard_candidates,
+                    skip_key_limit=skip_key_limit and not window_limits,
                     authorization_id=authorization_id,
                     spend_lease_hook=spend_hook,
                     build_authorization_for_lease=(

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -54,6 +54,7 @@ from trusted_router.storage_gcp_counter_dml import (
     KEY_ACCEPTED,
     KEY_INSUFFICIENT,
     KEY_MISSING,
+    KEY_NO_HOLD,
     complete_reservation_retention,
     insert_entity_dml,
     insert_reservation,
@@ -275,6 +276,7 @@ def authorize_atomic(
     credit_shard: int = UNSHARDED,
     credit_shard_candidates: tuple[int, ...] | None = None,
     key_shard_candidates: tuple[int, ...] = (UNSHARDED,),
+    skip_key_limit: bool = False,
     authorization_id: str | None = None,
     spend_lease_hook: Callable[[Any, int], dict[str, Any]] | None = None,
     build_authorization_for_lease: (
@@ -299,6 +301,12 @@ def authorize_atomic(
     enough independent sub-budget is recorded durably on the reservation. The
     store wrapper applies `bounded_credit_shard_candidates`; direct callers must
     likewise pass no more than the hot-path limit.
+
+    `skip_key_limit` is opt-in: the gateway's already-loaded ApiKey must have
+    no lifetime cap and no window caps applicable to this request. Omitted
+    by older callers, it preserves the existing reserve SQL. The first candidate
+    still receives settlement usage, with zero held, without an authorize read
+    or write of tr_key_limit.
 
     Per-window key caps are checked by the CALLER via check_key_window_limits on
     a lock-free snapshot BEFORE this transaction — deliberately NOT in here: a
@@ -395,30 +403,39 @@ def authorize_atomic(
             if existing is not None:
                 return _replay(transaction, existing)
 
-        key_result = KEY_MISSING
-        selected_key_shard = UNSHARDED
-        saw_key_row = False
-        for candidate in key_candidates:
-            candidate_result = reserve_key(
-                transaction,
-                pt,
-                key_hash,
-                estimate,
-                is_byok=is_byok,
-                shard=candidate,
-            )
-            if candidate_result == KEY_MISSING:
-                continue
-            saw_key_row = True
-            if candidate_result == KEY_INSUFFICIENT:
-                continue
-            key_result = candidate_result
-            selected_key_shard = candidate
-            break
-        if key_result == KEY_MISSING:
-            raise _Reject(
-                AuthorizeOutcome.KEY_LIMIT_EXCEEDED if saw_key_row else AuthorizeOutcome.KEY_MISSING
-            )
+        # Bounded lifetime-cap TOCTOU: a cap committed after the gateway's
+        # entity read can miss only requests already in flight at that commit,
+        # each admitted for its own estimate (aggregate: sum of those estimates).
+        # The next fresh entity read enforces the cap; removal likewise takes
+        # effect on the next request. Do not add a hot api_key/counter read here.
+        if skip_key_limit:
+            key_result = KEY_NO_HOLD
+            selected_key_shard = key_candidates[0]
+        else:
+            key_result = KEY_MISSING
+            selected_key_shard = UNSHARDED
+            saw_key_row = False
+            for candidate in key_candidates:
+                candidate_result = reserve_key(
+                    transaction,
+                    pt,
+                    key_hash,
+                    estimate,
+                    is_byok=is_byok,
+                    shard=candidate,
+                )
+                if candidate_result == KEY_MISSING:
+                    continue
+                saw_key_row = True
+                if candidate_result == KEY_INSUFFICIENT:
+                    continue
+                key_result = candidate_result
+                selected_key_shard = candidate
+                break
+            if key_result == KEY_MISSING:
+                raise _Reject(
+                    AuthorizeOutcome.KEY_LIMIT_EXCEEDED if saw_key_row else AuthorizeOutcome.KEY_MISSING
+                )
         key_hold = estimate if key_result == KEY_ACCEPTED else 0
 
         credit_hold = 0
@@ -625,8 +642,9 @@ def _release_key_or_skip_deleted(
     `release_key` deliberately returns the raw UPDATE count. A 0 count is
     ambiguous only here, after the reservation has been claimed: the key row may
     have been deleted, or the `reserved >= hold` corruption guard may have fired.
-    Missing row is a committed-success warning; present row keeps the loud
-    row-count failure path.
+    Zero-hold usage (including skip-path reservations) must book even after a
+    shrink reshard: recover on shard zero or raise with the amount preserved.
+    Held/deleted keys and zero-usage refunds retain their historical behavior.
     """
     from trusted_router.storage_gcp_counter_dml import key_limit_exists, release_key
 
@@ -645,6 +663,26 @@ def _release_key_or_skip_deleted(
     )
     if count == 1:
         return count, None
+    # Pre-migration credit-only reservations can legitimately have no key.
+    if res["key_hash"] is not None and key_hold == 0 and actual_micro > 0:
+        if key_shard != 0:
+            recovered = release_key(
+                transaction, param_types, key_hash, 0, int(actual_micro),
+                book_to_byok=book_to_byok, window_floors=window_floors(utcnow()),
+                shard=0,
+            )
+            if recovered == 1:
+                return 1, {
+                    "key_hash": key_hash, "hold_micro": 0,
+                    "missing_shard": key_shard, "actual_micro": int(actual_micro),
+                }
+        # Deliberately not _SettleError: callers must see the amount and retry
+        # (the outbox retains its frozen payload), never report SETTLED.
+        raise RuntimeError(
+            f"key usage booking failed reservation_id={res['reservation_id']} "
+            f"key_hash={key_hash} shard={key_shard} fallback_shard=0 "
+            f"actual_micro={actual_micro} book_to_byok={book_to_byok}"
+        )
     if key_limit_exists(transaction, param_types, key_hash, shard=key_shard):
         return count, None
     return 1, {"key_hash": key_hash, "hold_micro": key_hold}
@@ -653,6 +691,16 @@ def _release_key_or_skip_deleted(
 def _log_missing_key_releases(result: dict[str, Any]) -> None:
     warnings = result.pop("missing_key_releases", ())
     for warning in warnings:
+        if "missing_shard" in warning:
+            # Structured counter event for log-based metrics; emit after commit
+            # so Spanner transaction retries do not count speculative recovery.
+            log.warning(
+                "metric=key_usage_shard_fallback_total value=1 "
+                "key usage recovered key_hash=%s shard=%s fallback_shard=0 actual_micro=%s",
+                warning["key_hash"], warning["missing_shard"], warning["actual_micro"],
+                extra={"metric": "key_usage_shard_fallback_total", "value": 1, **warning},
+            )
+            continue
         log.warning(
             "skipped key release for missing tr_key_limit row key_hash=%s hold_micro=%s",
             warning["key_hash"],
@@ -746,7 +794,7 @@ def settle_atomic(
         if warning is not None:
             missing_key_releases.append(warning)
         # A recorded hold MUST release; an uncapped/no-hold row (key_reserved==0)
-        # may 0-row and is tolerated (best-effort usage tracking).
+        # with positive usage must book or raise in the shared helper.
         if res["key_reserved_micro"] > 0 and key_count != 1:
             raise _SettleError("key release row-count != 1")
 

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -1114,6 +1114,7 @@ class TypedBillingStore(Protocol):
         receipt_fee_basis_points: int = ...,
         app_owner_user_id: str = ...,
         key_usage_shards: int = ...,
+        skip_key_limit: bool = ...,
         tags: dict[str, str] | None = ...,
         custom_model_id: str | None = ...,
         custom_model_revision: int | None = ...,

--- a/tests/test_settle_outbox_apply.py
+++ b/tests/test_settle_outbox_apply.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import json
 import logging
 from collections.abc import Iterator
@@ -1704,3 +1705,33 @@ def test_typed_finalize_releases_hot_rows_last_in_the_same_transaction(
     assert _typed_key(db, key.hash)["reserved"] == 0
     assert db.reservations[auth.credit_reservation_id]["settled"] is True
     assert store.get_gateway_authorization(auth.id).settled is True
+
+
+def test_zero_hold_missing_key_rolls_back_finalize_and_preserves_frozen_usage(
+    fake_store: tuple[Any, Any, Any],
+) -> None:
+    store, db, _bt = fake_store
+    store.request_record_write_mode = "typed"
+    ws = "ws-missing-uncapped-key"
+    _seed_credit(store, ws)
+    key = _make_key(store, ws, limit=None)
+    auth = _typed_authorization(store, workspace_id=ws, key_hash=key.hash)
+    assert db.reservations[auth.credit_reservation_id]["key_reserved_micro"] == 0
+    original_row = dict(_typed_key(db, key.hash))
+    db.typed[KEY_LIMIT_TABLE].clear()
+    outbox = SpannerSettleOutbox(db, store._param_types)
+    outbox.enqueue(_row(auth, cost=777_777))
+    [claimed] = outbox.claim(limit=1)
+    frozen_before = copy.deepcopy(db.settle_outbox)
+    with pytest.raises(RuntimeError, match="actual_micro=777777"):
+        apply_frozen_settle(claimed)
+    assert copy.deepcopy(db.settle_outbox) == frozen_before
+    assert not db.reservations[auth.credit_reservation_id]["settled"]
+    assert not store.get_gateway_authorization(auth.id).settled
+    assert _typed_credit(db, ws)["total_usage"] == 0
+    assert _typed_credit(db, ws)["reserved"] == ESTIMATE
+    db.typed[KEY_LIMIT_TABLE][(key.hash, 0)] = original_row
+    assert apply_frozen_settle(claimed) == ApplyOutcome.SETTLED_NOW
+    assert _typed_key(db, key.hash)["usage"] == 777_777
+    assert _typed_credit(db, ws)["total_usage"] == 777_777
+    assert apply_frozen_settle(claimed) == ApplyOutcome.ALREADY_SETTLED_WITH_CHARGE

--- a/tests/test_uncapped_authorize_skip.py
+++ b/tests/test_uncapped_authorize_skip.py
@@ -1,0 +1,393 @@
+"""Contention contract, observed at the fake Spanner statement/mutation boundary.
+
+Reversion/mutation checks are documented in docs/storage-portability/uncapped-skip-validation.md.
+"""
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+import pytest
+
+from tests.fakes import spanner
+from tests.test_gateway_authorize_spanner_operations import (
+    _body,
+    _request,
+    _seed_typed_gateway_store,
+)
+from trusted_router import storage_gcp
+from trusted_router.config import Settings
+from trusted_router.routes.internal import gateway
+from trusted_router.spend_windows import utcnow, window_floors
+from trusted_router.storage_gcp_authorize import SettleOutcome, settle_atomic
+from trusted_router.storage_gcp_counters import KEY_LIMIT_TABLE
+
+RESERVE_SQL = (
+    "UPDATE tr_key_limit SET reserved = reserved + @est "
+    "WHERE key_hash=@kh AND shard=@shard AND limit_micro IS NOT NULL "
+    "AND (@is_byok = FALSE OR include_byok = TRUE) "
+    "AND (limit_micro - usage - IF(include_byok, byok_usage, 0) - reserved) >= @est"
+)
+
+
+@pytest.fixture
+def operations(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str, dict[str, Any]]]:
+    log: list[tuple[str, str, dict[str, Any]]] = []
+
+    def wrap(cls: Any, name: str) -> None:
+        original = getattr(cls, name)
+
+        def record(self: Any, *args: Any, **kwargs: Any) -> Any:
+            target = str(args[0] if args else kwargs.get("table", ""))
+            log.append((name, target, copy.deepcopy(kwargs)))
+            return original(self, *args, **kwargs)
+
+        monkeypatch.setattr(cls, name, record)
+
+    for cls in (spanner._FakeTransaction, spanner._FakeSnapshot):
+        wrap(cls, "execute_sql")
+    wrap(spanner._FakeTransaction, "execute_update")
+    for cls in (spanner._FakeTransaction, spanner._FakeBatch):
+        wrap(cls, "insert_or_update")
+        wrap(cls, "delete")
+    return log
+
+
+def seed(monkeypatch: pytest.MonkeyPatch, *, cap: int | None = None,
+         window: str | None = None, include_byok: bool = True,
+         alert_only: bool = False) -> tuple[Any, Any, Any]:
+    store, db, key = _seed_typed_gateway_store()
+    key.limit_microdollars = cap
+    key.include_byok_in_limit = include_byok
+    key.usage_shard_count = 4
+    key.budget_alert_only = alert_only
+    if window:
+        setattr(key, f"limit_{window}_microdollars", 50_000_000)
+    store._write_entity("api_key", key.hash, key)
+    base = db.typed[KEY_LIMIT_TABLE][(key.hash, 0)]
+    for shard in range(4):
+        row = dict(base, shard=shard, limit_micro=cap, include_byok=include_byok)
+        for period, floor in window_floors(utcnow()).items():
+            row[{"daily": "day_start", "weekly": "week_start", "monthly": "month_start"}[period]] = floor
+        db.typed[KEY_LIMIT_TABLE][(key.hash, shard)] = row
+    monkeypatch.setattr(storage_gcp, "randomized_credit_shards",
+                        lambda count: (3, 1, 2, 0) if count == 4 else (0,))
+    return store, db, key
+
+
+def authorize(key: Any, *, byok: bool = False, idem: str = "uncapped") -> dict[str, Any]:
+    body = _body(key.hash, idempotency_key=idem)
+    if byok:
+        body = type(body).model_validate(dict(body.model_dump(), provider={"usage": "byok"}))
+    return gateway._authorize_gateway_sync(_request(), body, Settings(environment="test"))["data"]
+
+
+def key_ops(log: list[tuple[str, str, dict[str, Any]]]) -> list[Any]:
+    return [op for op in log if KEY_LIMIT_TABLE in op[1]]
+
+
+@pytest.mark.parametrize("include_byok", [False, True])
+@pytest.mark.parametrize("alert_only", [False, True])
+def test_uncapped_authorize_zero_counter_statements_or_mutations(
+    monkeypatch: pytest.MonkeyPatch, operations: list[Any], include_byok: bool, alert_only: bool,
+) -> None:
+    _, db, key = seed(monkeypatch, include_byok=include_byok,
+                      window="daily" if alert_only else None, alert_only=alert_only)
+    operations.clear()
+    data = authorize(key)
+    assert key_ops(operations) == []
+    res = db.reservations[data["credit_reservation_id"]]
+    assert res["key_shard"] == 3
+    assert res["key_reserved_micro"] == 0
+
+
+@pytest.mark.parametrize("window", [None, "daily", "weekly", "monthly"])
+@pytest.mark.parametrize("byok,include_byok", [(False, True), (True, False), (True, True)])
+def test_capped_and_window_paths_keep_exact_reserve_sql_and_parameters(
+    monkeypatch: pytest.MonkeyPatch, operations: list[Any], window: str | None,
+    byok: bool, include_byok: bool,
+) -> None:
+    cap = 50_000_000 if window is None else None
+    store, db, key = seed(monkeypatch, cap=cap, window=window, include_byok=include_byok)
+    if byok:
+        store.upsert_byok_provider(workspace_id=key.workspace_id, provider="anthropic",
+                                   secret_ref="env://ANTHROPIC_API_KEY", key_hint="test")  # noqa: S106
+    operations.clear()
+    data = authorize(key, byok=byok)
+    res = db.reservations[data["credit_reservation_id"]]
+    estimate = store.get_gateway_authorization(data["authorization_id"]).estimated_microdollars
+    assert estimate > 0
+    updates = [op for op in key_ops(operations) if op[0] == "execute_update"]
+    if window is not None and byok and not include_byok:
+        assert key_ops(operations) == []
+        assert res["key_reserved_micro"] == 0
+        return
+    assert len(updates) == 1
+    assert updates[0] == ("execute_update", RESERVE_SQL, {
+        "params": {"est": estimate,
+                   "kh": key.hash, "shard": 3, "is_byok": byok},
+        "param_types": {"est": store._param_types.INT64, "kh": store._param_types.STRING,
+                        "shard": store._param_types.INT64, "is_byok": store._param_types.BOOL},
+    })
+    assert res["key_reserved_micro"] == (
+        estimate if cap is not None and (not byok or include_byok) else 0
+    )
+    reads = [op for op in key_ops(operations) if op[0] == "execute_sql"]
+    assert bool(reads) == (window is not None or (byok and not include_byok))
+
+
+def settle(store: Any, reservation_id: str, amount: int = 700) -> dict[str, Any]:
+    return settle_atomic(store._database, store._param_types, reservation_id=reservation_id,
+                         actual_micro=amount, settled_usage_type="Credits", success=True)
+
+
+def test_uncapped_settle_books_one_selected_shard_and_display_sums(
+    monkeypatch: pytest.MonkeyPatch, operations: list[Any],
+) -> None:
+    store, db, key = seed(monkeypatch)
+    db.typed[KEY_LIMIT_TABLE][(key.hash, 1)]["usage"] = 123
+    operations.clear()
+    data = authorize(key)
+    assert key_ops(operations) == []
+    operations.clear()
+    assert settle(store, data["credit_reservation_id"])["outcome"] == SettleOutcome.SETTLED
+    updates = [op for op in key_ops(operations) if op[0] == "execute_update"]
+    assert len(updates) == 1
+    assert updates[0][2]["params"]["shard"] == 3
+    assert updates[0][2]["params"]["hold"] == 0
+    rows = db.typed[KEY_LIMIT_TABLE]
+    assert [rows[(key.hash, i)]["usage"] for i in range(4)] == [0, 123, 0, 700]
+    [display] = store.list_api_keys_with_usage(key.workspace_id)
+    assert display.usage_microdollars == 823
+    assert display.reserved_microdollars == 0
+    assert display.windows == {"daily": 700, "weekly": 700, "monthly": 700}
+
+
+def test_legacy_authorization_still_settles(monkeypatch: pytest.MonkeyPatch) -> None:
+    store, db, key = seed(monkeypatch)
+    # Old callers omit the opt-in, yielding the pre-change KEY_NO_HOLD record.
+    _, auth = store.authorize_gateway_typed(
+        workspace_id=key.workspace_id, key_hash=key.hash, estimate=1000,
+        has_credit_candidate=True, reservation_usage_type="Credits", model_id="m",
+        provider="anthropic", requested_model_id="m", candidate_model_ids=["m"],
+        region=None, endpoint_id=None, candidate_endpoint_ids=[], idempotency_key=None,
+        idempotency_fingerprint=None, key_usage_shards=4,
+    )
+    assert auth is not None
+    rid = auth.credit_reservation_id
+    assert db.reservations[rid]["key_reserved_micro"] == 0
+    assert settle(store, rid)["outcome"] == SettleOutcome.SETTLED
+    assert db.typed[KEY_LIMIT_TABLE][(key.hash, 3)]["usage"] == 700
+
+
+def test_uncapped_replay_keeps_authorization_and_books_once(
+    monkeypatch: pytest.MonkeyPatch, operations: list[Any],
+) -> None:
+    store, db, key = seed(monkeypatch)
+    operations.clear()
+    first = authorize(key)
+    assert key_ops(operations) == []
+    monkeypatch.setattr(storage_gcp, "randomized_credit_shards", lambda count: tuple(range(count)))
+    replay = authorize(key)
+    assert replay["authorization_id"] == first["authorization_id"]
+    assert replay["credit_reservation_id"] == first["credit_reservation_id"]
+    assert replay["idempotent_replay"] is True
+    assert key_ops(operations) == []
+    rid = first["credit_reservation_id"]
+    assert db.reservations[rid]["key_shard"] == 3
+    assert len(db.reservations) == 1
+    assert settle(store, rid)["outcome"] == SettleOutcome.SETTLED
+    operations.clear()
+    assert settle(store, rid)["outcome"] == SettleOutcome.ALREADY_SETTLED
+    assert key_ops(operations) == []
+    assert sum(row["usage"] for row in db.typed[KEY_LIMIT_TABLE].values()) == 700
+
+
+@pytest.mark.parametrize("include_byok", [False, True])
+def test_uncapped_byok_skips_authorize_and_settles_byok_usage(
+    monkeypatch: pytest.MonkeyPatch, operations: list[Any], include_byok: bool,
+) -> None:
+    store, db, key = seed(monkeypatch, include_byok=include_byok)
+    store.upsert_byok_provider(
+        workspace_id=key.workspace_id, provider="anthropic",
+        secret_ref="env://ANTHROPIC_API_KEY", key_hint="test",  # noqa: S106
+    )
+    operations.clear()
+    data = authorize(key, byok=True)
+    assert key_ops(operations) == []
+    rid = data["credit_reservation_id"]
+    assert db.reservations[rid]["key_reserved_micro"] == 0
+    assert db.reservations[rid]["credit_reserved_micro"] == 0
+    result = settle_atomic(store._database, store._param_types, reservation_id=rid,
+                           actual_micro=700, settled_usage_type="BYOK", success=True)
+    assert result["outcome"] == SettleOutcome.SETTLED
+    [display] = store.list_api_keys_with_usage(key.workspace_id)
+    assert display.usage_microdollars == 0
+    assert display.byok_usage_microdollars == 700
+    assert display.windows == dict.fromkeys(("daily", "weekly", "monthly"),
+                                            700 if include_byok else 0)
+
+
+@pytest.mark.parametrize("window", ["daily", "weekly", "monthly"])
+def test_uncapped_window_limit_still_blocks(
+    monkeypatch: pytest.MonkeyPatch, operations: list[Any], window: str,
+) -> None:
+    store, db, key = seed(monkeypatch, window=window)
+    setattr(key, f"limit_{window}_microdollars", 1)
+    store._write_entity("api_key", key.hash, key)
+    operations.clear()
+    with pytest.raises(Exception) as raised:
+        authorize(key)
+    assert getattr(raised.value, "status_code", None) == 429
+    assert key_ops(operations)
+    assert not db.reservations
+
+
+@pytest.mark.parametrize("byok", [False, True])
+def test_shrink_after_entity_read_books_shard_zero(
+    monkeypatch: pytest.MonkeyPatch, operations: list[Any],
+    caplog: pytest.LogCaptureFixture, byok: bool,
+) -> None:
+    store, db, key = seed(monkeypatch)
+    key.usage_shard_count = 10
+    store._write_entity("api_key", key.hash, key)
+    db.typed[KEY_LIMIT_TABLE][(key.hash, 9)] = dict(
+        db.typed[KEY_LIMIT_TABLE][(key.hash, 0)], shard=9,
+    )
+    monkeypatch.setattr(storage_gcp, "randomized_credit_shards",
+                        lambda count: (9, 0) if count == 10 else (0,))
+    if byok:
+        store.upsert_byok_provider(workspace_id=key.workspace_id, provider="anthropic",
+                                   secret_ref="env://ANTHROPIC_API_KEY", key_hint="test")  # noqa: S106
+    original = type(store).authorize_gateway_typed
+
+    def shrink(self: Any, **kwargs: Any) -> Any:
+        assert kwargs["key_usage_shards"] == 10
+        db.typed[KEY_LIMIT_TABLE].pop((key.hash, 9))
+        key.usage_shard_count = 4
+        store._write_entity("api_key", key.hash, key)
+        return original(self, **kwargs)
+
+    monkeypatch.setattr(type(store), "authorize_gateway_typed", shrink)
+    data = authorize(key, byok=byok)
+    rid = data["credit_reservation_id"]
+    assert db.reservations[rid]["key_shard"] == 9
+    result = settle_atomic(db, store._param_types, reservation_id=rid, actual_micro=700,
+                           settled_usage_type="BYOK" if byok else "Credits", success=True)
+    assert result["outcome"] == SettleOutcome.SETTLED
+    row = db.typed[KEY_LIMIT_TABLE][(key.hash, 0)]
+    assert row["byok_usage" if byok else "usage"] == 700
+    assert row["day_usage"] == 700
+    events = [r for r in caplog.records
+              if getattr(r, "metric", None) == "key_usage_shard_fallback_total"]
+    assert len(events) == 1
+    assert events[0].value == 1
+    assert key.hash in events[0].getMessage()
+    assert "shard=9" in events[0].getMessage()
+    assert settle(store, rid)["outcome"] == SettleOutcome.ALREADY_SETTLED
+    assert row["byok_usage" if byok else "usage"] == 700
+
+
+@pytest.mark.parametrize("selected_shard", [0, 3])
+def test_zero_rows_authorizes_then_fails_loudly_and_can_retry(
+    monkeypatch: pytest.MonkeyPatch, operations: list[Any], selected_shard: int,
+) -> None:
+    store, db, key = seed(monkeypatch)
+    backup = copy.deepcopy(db.typed[KEY_LIMIT_TABLE][(key.hash, 0)])
+    db.typed[KEY_LIMIT_TABLE].clear()
+    monkeypatch.setattr(storage_gcp, "randomized_credit_shards",
+                        lambda count: (selected_shard,) if count == 4 else (0,))
+    operations.clear()
+    data = authorize(key)  # Deliberate KEY_MISSING change: no 402 on the skip path.
+    assert key_ops(operations) == []
+    rid = data["credit_reservation_id"]
+    before = copy.deepcopy(db.reservations[rid])
+    with pytest.raises(RuntimeError, match="actual_micro=700") as raised:
+        settle(store, rid)
+    assert key.hash in str(raised.value)
+    assert rid in str(raised.value)
+    assert db.reservations[rid] == before  # failed claim rolls back, still retryable
+    db.typed[KEY_LIMIT_TABLE][(key.hash, 0)] = backup
+    assert settle(store, rid)["outcome"] == SettleOutcome.SETTLED
+    assert db.typed[KEY_LIMIT_TABLE][(key.hash, 0)]["usage"] == 700
+
+
+def test_capped_zero_rows_still_rejects_at_authorize(monkeypatch: pytest.MonkeyPatch) -> None:
+    _, db, key = seed(monkeypatch, cap=50_000_000)
+    db.typed[KEY_LIMIT_TABLE].clear()
+    with pytest.raises(Exception) as raised:
+        authorize(key)
+    assert getattr(raised.value, "status_code", None) == 402
+    assert not db.reservations
+
+
+def test_cap_commit_bounded_inflight_slip_and_fresh_removal(
+    monkeypatch: pytest.MonkeyPatch, operations: list[Any],
+) -> None:
+    store, db, key = seed(monkeypatch)
+    original = type(store).authorize_gateway_typed
+    changed = False
+
+    def commit_cap(self: Any, **kwargs: Any) -> Any:
+        nonlocal changed
+        if not changed:
+            assert kwargs["skip_key_limit"] is True
+            changed = True
+            assert store.update_key(key.hash, {"limit_microdollars": 1}) is not None
+            operations.clear()
+        return original(self, **kwargs)
+
+    monkeypatch.setattr(type(store), "authorize_gateway_typed", commit_cap)
+    first = authorize(key, idem="inflight")
+    assert key_ops(operations) == []
+    auth = store.get_gateway_authorization(first["authorization_id"])
+    assert auth.estimated_microdollars > 1
+    res = db.reservations[first["credit_reservation_id"]]
+    assert res["key_reserved_micro"] == 0
+    assert res["credit_reserved_micro"] == auth.estimated_microdollars
+    with pytest.raises(Exception) as raised:
+        authorize(key, idem="after-cap")
+    assert getattr(raised.value, "status_code", None) == 402
+    assert len(db.reservations) == 1
+    assert store.update_key(key.hash, {"limit_microdollars": None}) is not None
+    operations.clear()
+    after = authorize(key, idem="after-removal")
+    assert after["authorization_id"] != first["authorization_id"]
+    assert key_ops(operations) == []
+    assert len(db.reservations) == 2
+
+
+@pytest.mark.parametrize("byok", [False, True])
+def test_missing_shard_settlement_matches_healthy_ledger(
+    monkeypatch: pytest.MonkeyPatch, byok: bool,
+) -> None:
+    """Differential money check: only booking location may change after shrink."""
+    from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE
+
+    ledgers = []
+    for missing in (False, True):
+        store, db, key = seed(monkeypatch)
+        if byok:
+            store.upsert_byok_provider(
+                workspace_id=key.workspace_id, provider="anthropic",
+                secret_ref="env://ANTHROPIC_API_KEY", key_hint="test",  # noqa: S106
+            )
+        data = authorize(key, byok=byok)
+        rid = data["credit_reservation_id"]
+        if missing:
+            db.typed[KEY_LIMIT_TABLE].pop((key.hash, 3))
+        result = settle_atomic(
+            db, store._param_types, reservation_id=rid, actual_micro=700,
+            settled_usage_type="BYOK" if byok else "Credits", success=True,
+        )
+        assert result["outcome"] == SettleOutcome.SETTLED
+        key_fields = ("usage", "byok_usage", "reserved", "day_usage", "week_usage", "month_usage")
+        credit_fields = ("total_credits", "total_usage", "reserved")
+        ledgers.append((
+            {field: sum(row[field] for row in db.typed[KEY_LIMIT_TABLE].values())
+             for field in key_fields},
+            {field: sum(row[field] for row in db.typed[CREDIT_BALANCE_TABLE].values())
+             for field in credit_fields},
+            db.reservations[rid]["actual_micro"],
+        ))
+    assert ledgers[0] == ledgers[1]


### PR DESCRIPTION
Follow-up to #1083. After the boundary-column locks were removed, `LOCK_STATS` for an **uncapped** key (`limit_microdollars` NULL, no windows) sharded 16 ways still showed 330–510 s of lock wait per shard per 10-minute interval. All of it was bookkeeping for a cap that doesn't exist: `reserve_key`'s conditional `UPDATE` reads the shard row to evaluate `limit_micro IS NOT NULL` even when nothing matches, the `KEY_MISSING` classification reads it again, and every settle exclusively rewrites the same row.

**The change.** When the `ApiKey` the gateway already loaded is uncapped with no enforced windows — or the request is BYOK on a key that excludes BYOK — authorize passes `skip_key_limit` and issues **no `tr_key_limit` read or write**, treating the key as `KEY_NO_HOLD`. Settle still books usage to one shard, chosen as the reserve loop would have.

**Capped keys are byte-identical**, verified by mutation: forcing the skip on capped keys fails the exact-SQL-and-params tests; disabling it fails the zero-statement tests.

**Two things the adversarial review made me get right.** A shrink reshard committing between the entity read and the transaction can leave the recorded booking shard missing at settle — previously that would have settled with usage silently unbooked. It now recovers onto shard 0 (every key has it) or fails loudly with the amount preserved; skipping the recovery fails both shrink tests. And the lifetime-cap check moving from an in-transaction predicate to the entity read is a bounded TOCTOU: a cap created mid-flight lets that one request through, bounded by its own estimate; the next request is enforced and cap removal takes effect immediately. Closing it by reading the entity inside the transaction would put a hot read back on the `api_key` row that `add_usage` writes per settle, so the bound is documented and tested rather than "fixed".

Rebased on current main (#1101's settle ordering preserved). Full suite **9429 passed, 0 failed**. Adversarial review round 2: PASS, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)