### PR TITLE
Authorize: skip tr_key_limit for every key with no lifetime cap

### DIFF
--- a/docs/storage-portability/uncapped-skip-validation.md
+++ b/docs/storage-portability/uncapped-skip-validation.md
@@ -1,11 +1,11 @@
 # Uncapped authorize contention regression proof
 
 The gateway derives `skip_key_limit` from its already-authenticated ApiKey:
-`limit_microdollars is None` and the request-applicable `window_limits` is empty.
-BYOK-excluded requests omit window limits, including enforced windows on uncapped keys.
-A BYOK-excluded request on a capped key still follows the original reserve path.
-The typed store also refuses the skip when supplied blocking window limits.
-Older/direct callers default to the original behavior.
+`limit_microdollars is None`, regardless of request-applicable window limits.
+BYOK-excluded requests still omit window limits; a BYOK-excluded request on a
+capped key still follows the original reserve path. The typed store forwards
+the skip after the unchanged lock-free snapshot window check. Older/direct
+callers default to the original behavior.
 
 `authorize_atomic` records the first pre-randomized key candidate and a zero
 key hold without calling `reserve_key`. The existing reserve loop and its SQL
@@ -206,3 +206,59 @@ Local logs: `/tmp/qr-round2-full-final.log` and
 `/tmp/qr-round2-U2-stale-removal.log`, and
 `/tmp/qr-round2-keyless-revert.log`. All implementation mutations were restored
 before the final full and explicit-path gates.
+
+
+## Window-cap extension (September 2026)
+
+Baseline: `a7056ae783fc2b24ee40f200f04f9b453815ba20` (HEAD and origin/main).
+NULL lifetime caps now skip reserve even with enforced windows. The complete
+snapshot window-check block and counter DML module were compared byte-for-byte
+with origin/main and are unchanged. Settlement, shard recovery, replay, and the
+cap-change race bound above are unchanged.
+
+The statement recorder now distinguishes snapshot reads from transaction SQL,
+DML, and buffered mutations. The five cases of
+`test_daily_window_uncapped_skip_and_preserved_contracts` each start by admitting
+an enforced daily-window request with zero transaction counter operations and a
+real snapshot read, then check one boundary: settlement to one shard (including
+window counters), refusal after settlement crosses the daily cap, exact baseline
+reserve SQL/parameters after adding a lifetime cap, direct NULL-cap reserve with
+KEY_NO_HOLD and no pending or committed writes, or transition to alert-only.
+The common admission assertion is intentional: the preserved behaviors alone
+cannot distinguish a faithful reversion. Each complete scenario can.
+
+Actual temporary reversion runs (source restored in a `finally` block):
+
+| Reversion/mutation | Result on the five new cases |
+| --- | --- |
+| Restore all three implementation files to HEAD | 5 failed |
+| Restore gateway guard only | 5 failed |
+| Restore store guard only | 5 failed |
+| Remove reserve SQL's NULL predicate | 2 failed, 3 passed |
+| Disable snapshot window check | 5 failed |
+
+The SQL assertion is necessary because the fake dispatches recognized statements
+rather than evaluating arbitrary SQL predicates. Removing the NULL predicate is
+therefore explicitly detected even if the fake still returns KEY_NO_HOLD.
+Logs: `/tmp/qr-windows-{revert,gateway-revert,store-revert,null-predicate,window-check}.log`.
+
+Restored-tree gates:
+
+- `uv run --no-sync ruff check .`: passed.
+- `uv run --no-sync mypy`: passed, 370 source files.
+- Explicit required paths: **174 passed**, zero failures (40.81 seconds).
+- Full suite: **9,517 passed, 377 skipped, 10 xfailed**, zero failures,
+  exit 0 (568.19 seconds). Coverage **84.17%**, exceeding 70%.
+- `git diff --check`: passed. No unrelated tracked files changed; no commits
+  or file deletions.
+
+Commands used `UV_CACHE_DIR=/tmp/qr-locks-uv-cache` with the existing virtualenv:
+
+```bash
+uv run --no-sync pytest -q tests/test_uncapped_authorize_skip.py tests/test_billing_typed_enforcement.py tests/test_gateway_authorize_spanner_operations.py tests/test_settle_outbox_apply.py
+uv run --no-sync pytest -q -n 4 --dist loadgroup --cov=trusted_router --cov-report=term:skip-covered --cov-fail-under=70
+```
+
+The full suite had test-owned loopback networking permitted. Gate logs:
+`/tmp/qr-windows-targeted.log`, `/tmp/qr-windows-mypy.log`, and
+`/tmp/qr-windows-full.log`.

--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -1749,10 +1749,8 @@ def _authorize_gateway_sync_impl(
                     key_usage_shards=key_usage_shards,
                     # The entity is already authenticated; a no-op reserve
                     # UPDATE would still lock uncapped usage counter rows.
-                    skip_key_limit=(
-                        api_key.limit_microdollars is None
-                        and not window_limits
-                    ),
+                    # Window caps are enforced separately on a snapshot.
+                    skip_key_limit=api_key.limit_microdollars is None,
                     custom_model_id=custom_model.id if custom_model else None,
                     custom_model_revision=custom_model.revision if custom_model else None,
                     custom_model_markup_basis_points=(

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -5594,7 +5594,7 @@ class SpannerBigtableStore:
                     # configured shard.
                     credit_shard_candidates=bounded_credit_shard_candidates(candidates),
                     key_shard_candidates=key_shard_candidates,
-                    skip_key_limit=skip_key_limit and not window_limits,
+                    skip_key_limit=skip_key_limit,
                     authorization_id=authorization_id,
                     spend_lease_hook=spend_hook,
                     build_authorization_for_lease=(

--- a/src/trusted_router/storage_gcp_authorize.py
+++ b/src/trusted_router/storage_gcp_authorize.py
@@ -303,7 +303,7 @@ def authorize_atomic(
     likewise pass no more than the hot-path limit.
 
     `skip_key_limit` is opt-in: the gateway's already-loaded ApiKey must have
-    no lifetime cap and no window caps applicable to this request. Omitted
+    no lifetime cap, regardless of window caps checked by the caller. Omitted
     by older callers, it preserves the existing reserve SQL. The first candidate
     still receives settlement usage, with zero held, without an authorize read
     or write of tr_key_limit.

--- a/tests/test_uncapped_authorize_skip.py
+++ b/tests/test_uncapped_authorize_skip.py
@@ -39,7 +39,8 @@ def operations(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str, dict[str
 
         def record(self: Any, *args: Any, **kwargs: Any) -> Any:
             target = str(args[0] if args else kwargs.get("table", ""))
-            log.append((name, target, copy.deepcopy(kwargs)))
+            source = "snapshot_execute_sql" if isinstance(self, spanner._FakeSnapshot) else name
+            log.append((source, target, copy.deepcopy(kwargs)))
             return original(self, *args, **kwargs)
 
         monkeypatch.setattr(cls, name, record)
@@ -118,8 +119,9 @@ def test_capped_and_window_paths_keep_exact_reserve_sql_and_parameters(
     estimate = store.get_gateway_authorization(data["authorization_id"]).estimated_microdollars
     assert estimate > 0
     updates = [op for op in key_ops(operations) if op[0] == "execute_update"]
-    if window is not None and byok and not include_byok:
-        assert key_ops(operations) == []
+    if window is not None:
+        assert [op for op in key_ops(operations) if op[0] != "snapshot_execute_sql"] == []
+        assert bool(key_ops(operations)) == (not byok or include_byok)
         assert res["key_reserved_micro"] == 0
         return
     assert len(updates) == 1
@@ -391,3 +393,83 @@ def test_missing_shard_settlement_matches_healthy_ledger(
             db.reservations[rid]["actual_micro"],
         ))
     assert ledgers[0] == ledgers[1]
+
+
+@pytest.mark.parametrize("scenario", ["settle", "over_window", "lifetime_cap", "reserve_noop",
+                                      "alert_only"])
+def test_daily_window_uncapped_skip_and_preserved_contracts(
+    monkeypatch: pytest.MonkeyPatch, operations: list[Any], scenario: str,
+) -> None:
+    """Exercise the new path before each boundary/transition's preserved behavior.
+
+    Every case must detect reverting either skip guard. Exact reserve SQL also
+    pins the NULL predicate: the fake itself does not interpret arbitrary SQL.
+    """
+    from trusted_router.storage_gcp_counter_dml import KEY_NO_HOLD, reserve_key
+
+    store, db, key = seed(monkeypatch, window="daily")
+    before = copy.deepcopy(db.typed[KEY_LIMIT_TABLE])
+    operations.clear()
+    data = authorize(key)
+    observed = key_ops(operations)
+    assert observed
+    assert all(op[0] == "snapshot_execute_sql" for op in observed), observed
+    assert any("day_usage" in op[1] for op in observed)
+    assert db.typed[KEY_LIMIT_TABLE] == before
+    rid = data["credit_reservation_id"]
+    assert db.reservations[rid]["key_reserved_micro"] == 0
+    assert db.reservations[rid]["key_shard"] == 3
+    operations.clear()
+
+    if scenario == "settle":
+        assert settle(store, rid)["outcome"] == SettleOutcome.SETTLED
+        updates = [op for op in key_ops(operations) if op[0] == "execute_update"]
+        assert len(updates) == 1
+        assert updates[0][2]["params"]["shard"] == 3
+        assert updates[0][2]["params"]["hold"] == 0
+        rows = db.typed[KEY_LIMIT_TABLE]
+        for field in ("usage", "day_usage", "week_usage", "month_usage"):
+            assert [rows[(key.hash, i)][field] for i in range(4)] == [0, 0, 0, 700]
+    elif scenario == "over_window":
+        # Settle crosses the window; the next fresh request must be refused.
+        assert settle(store, rid, amount=50_000_001)["outcome"] == SettleOutcome.SETTLED
+        operations.clear()
+        with pytest.raises(Exception) as raised:
+            authorize(key, idem="over-window")
+        assert getattr(raised.value, "status_code", None) == 429
+        assert key_ops(operations)
+        assert all(op[0] == "snapshot_execute_sql" for op in key_ops(operations))
+        assert len(db.reservations) == 1
+    elif scenario == "lifetime_cap":
+        # A fresh entity read after adding a cap must restore the old reserve.
+        assert store.update_key(key.hash, {"limit_microdollars": 50_000_000}) is not None
+        operations.clear()
+        capped = authorize(key, idem="capped-window")
+        estimate = store.get_gateway_authorization(capped["authorization_id"]).estimated_microdollars
+        assert estimate > 0
+        updates = [op for op in key_ops(operations) if op[0] == "execute_update"]
+        assert updates == [("execute_update", RESERVE_SQL, {
+            "params": {"est": estimate, "kh": key.hash, "shard": 3, "is_byok": False},
+            "param_types": {"est": store._param_types.INT64, "kh": store._param_types.STRING,
+                            "shard": store._param_types.INT64, "is_byok": store._param_types.BOOL},
+        })]
+        assert any(op[0] == "snapshot_execute_sql" for op in key_ops(operations))
+        assert db.reservations[capped["credit_reservation_id"]]["key_reserved_micro"] == estimate
+    elif scenario == "reserve_noop":
+        def reserve(transaction: Any) -> str:
+            outcome = reserve_key(transaction, store._param_types, key.hash, 1234,
+                                  is_byok=False, shard=3)
+            assert transaction.pending_writes == []
+            return outcome
+
+        assert db.run_in_transaction(reserve) == KEY_NO_HOLD
+        assert db.typed[KEY_LIMIT_TABLE] == before
+        assert [op[0] for op in key_ops(operations)] == ["execute_update", "execute_sql"]
+        assert key_ops(operations)[0][1] == RESERVE_SQL
+    else:
+        assert store.update_key(key.hash, {"budget_alert_only": True,
+                                           "limit_daily_microdollars": 1}) is not None
+        operations.clear()
+        alert = authorize(key, idem="alert-window")
+        assert key_ops(operations) == []
+        assert db.reservations[alert["credit_reservation_id"]]["key_reserved_micro"] == 0


### PR DESCRIPTION
Follow-up to #1120, which deployed cleanly and **changed nothing for the key that prompted it**. `prod3` has `limit_microdollars` NULL but a $25/day window cap; #1120's skip required no window caps, so it never fired. Same-day `LOCK_STATS` before and after the deploy showed the key's shard rows at the same 71–88 s per interval, and the lock tally still carried the authorize-side `ReaderShared` on `reserved` and `usage`. My original diagnosis had read the lifetime cap and missed the window.

**Why the window condition was unnecessary.** `reserve_key`'s `UPDATE` is guarded by `limit_micro IS NOT NULL`, so for a NULL lifetime cap it can never match; the `KEY_MISSING` point-read that follows contributes nothing to window enforcement. Windows are enforced by `key_window_limit_decision` on a lock-free snapshot *before* the transaction, and their counters are written at settle. For a lifetime-uncapped key, the reserve is pure lock traffic.

**The change.** The skip applies to every key with a NULL lifetime cap, windows or not. The snapshot window check is byte-identical — an over-window request is still refused, now with zero in-transaction `tr_key_limit` statements — and the reserve's no-op-on-NULL property is pinned by a test so a future change to that `WHERE` clause fails loudly. Re-imposing the window condition fails 11 tests.

Full suite **9517 passed, 0 failed**. Adversarial review: PASS, no findings. The proof this time will be the same `LOCK_STATS` query on `prod3` after deploy, compared against same-day pre-deploy intervals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)