### PR TITLE
Postgres update_key hardening: freeze the hold, guard cap writes, fix the pause path

### DIFF
--- a/src/trusted_router/routes/internal/gateway.py
+++ b/src/trusted_router/routes/internal/gateway.py
@@ -1927,11 +1927,12 @@ def _authorize_gateway_sync_impl(
             if settings.spend_lease_trust_eligibility_enabled else None
         )
         try:
-            window_decision = STORE.reserve_key_limit(
+            key_limit_reservation = STORE.reserve_key_limit(
                 api_key.hash,
                 estimate,
                 usage_type=reservation_usage_type,
             )
+            window_decision = key_limit_reservation.window_decision
             remember_spend_window_decision(request, window_decision)
         except KeyWindowLimitExceeded as exc:
             release_user_model_slot_after_error()
@@ -1991,7 +1992,9 @@ def _authorize_gateway_sync_impl(
                 if not _deferred_settlement_applies(settings, api_key):
                     release_user_model_slot_after_error()
                     STORE.refund_key_limit(
-                        api_key.hash, estimate, usage_type=reservation_usage_type
+                        api_key.hash,
+                        key_limit_reservation.reserved_microdollars,
+                        usage_type=reservation_usage_type,
                     )
                     raise _insufficient_credits_error(workspace) from exc
                 settlement = _DEFERRED_HOME_SETTLEMENT
@@ -2006,6 +2009,7 @@ def _authorize_gateway_sync_impl(
             usage_type=reservation_usage_type,
             estimated_microdollars=estimate,
             credit_reservation_id=credit_reservation_id,
+            key_reserved_microdollars=key_limit_reservation.reserved_microdollars,
             authorization_id=authorization_id,
             requested_model_id=requested_model_id,
             candidate_model_ids=[
@@ -2065,7 +2069,11 @@ def _authorize_gateway_sync_impl(
             # The key-limit escrow taken above must come back: nothing on this
             # plane would ever release it for a request that never became an
             # authorization (the reaper only sees authorizations).
-            STORE.refund_key_limit(api_key.hash, estimate, usage_type=reservation_usage_type)
+            STORE.refund_key_limit(
+                api_key.hash,
+                key_limit_reservation.reserved_microdollars,
+                usage_type=reservation_usage_type,
+            )
             raise api_error(
                 402,
                 "This plane is holding the maximum unsettled spend for this workspace "
@@ -2081,7 +2089,11 @@ def _authorize_gateway_sync_impl(
             # committed OUTSIDE this transaction, so nothing downstream will
             # ever release it for a request that produced no authorization —
             # swallowing this into a bare 503 leaks it silently, forever.
-            STORE.refund_key_limit(api_key.hash, estimate, usage_type=reservation_usage_type)
+            STORE.refund_key_limit(
+                api_key.hash,
+                key_limit_reservation.reserved_microdollars,
+                usage_type=reservation_usage_type,
+            )
             logger.warning(
                 "billing.authorize_conflict_after_escrow workspace_id=%s request_id=%s "
                 "requested_model=%s estimated_microdollars=%s error_class=%s",

--- a/src/trusted_router/routes/notify.py
+++ b/src/trusted_router/routes/notify.py
@@ -297,11 +297,13 @@ class _Charge:
         reservation_id: str | None,
         amount: int,
         *,
+        key_reserved_microdollars: int = 0,
         billable: bool = True,
     ) -> None:
         self._key_hash = key_hash
         self._reservation_id = reservation_id
         self._amount = amount
+        self._key_reserved_microdollars = key_reserved_microdollars
         self._finalized = False
         # False when no credit hold could be taken. The send still happens; the
         # response must then report zero rather than a price nobody charged.
@@ -321,11 +323,12 @@ class _Charge:
 
         key_hash = principal.api_key.hash
         try:
-            window_decision = STORE.reserve_key_limit(
+            key_limit_reservation = STORE.reserve_key_limit(
                 key_hash,
                 amount,
                 usage_type=UsageType.CREDITS,
             )
+            window_decision = key_limit_reservation.window_decision
             remember_spend_window_decision(request, window_decision)
         except KeyWindowLimitExceeded as exc:
             remember_spend_window_decision(request, exc.decision)
@@ -364,16 +367,31 @@ class _Charge:
         try:
             reservation = STORE.reserve(principal.workspace.id, key_hash, amount)
         except ValueError as exc:
-            STORE.refund_key_limit(key_hash, amount, usage_type=UsageType.CREDITS)
+            STORE.refund_key_limit(
+                key_hash,
+                key_limit_reservation.reserved_microdollars,
+                usage_type=UsageType.CREDITS,
+            )
             raise api_error(402, "Insufficient credits", ErrorType.INSUFFICIENT_CREDITS) from exc
         except RuntimeError:
             log.warning(
                 "notify: credit reservation unavailable on this backend; "
                 "delivering unbilled (workspace=%s)", principal.workspace.id,
             )
-            return cls(key_hash, None, amount, billable=False)
+            return cls(
+                key_hash,
+                None,
+                amount,
+                key_reserved_microdollars=key_limit_reservation.reserved_microdollars,
+                billable=False,
+            )
 
-        return cls(key_hash, reservation.id, amount)
+        return cls(
+            key_hash,
+            reservation.id,
+            amount,
+            key_reserved_microdollars=key_limit_reservation.reserved_microdollars,
+        )
 
     def settle(self, actual: int) -> None:
         if self._finalized or self._key_hash is None:
@@ -381,7 +399,12 @@ class _Charge:
         self._finalized = True
         if self._reservation_id is not None:
             STORE.settle(self._reservation_id, actual)
-        STORE.settle_key_limit(self._key_hash, self._amount, actual, usage_type=UsageType.CREDITS)
+        STORE.settle_key_limit(
+            self._key_hash,
+            self._key_reserved_microdollars,
+            actual,
+            usage_type=UsageType.CREDITS,
+        )
 
     def refund(self) -> None:
         if self._finalized or self._key_hash is None:
@@ -389,4 +412,8 @@ class _Charge:
         self._finalized = True
         if self._reservation_id is not None:
             STORE.refund(self._reservation_id)
-        STORE.refund_key_limit(self._key_hash, self._amount, usage_type=UsageType.CREDITS)
+        STORE.refund_key_limit(
+            self._key_hash,
+            self._key_reserved_microdollars,
+            usage_type=UsageType.CREDITS,
+        )

--- a/src/trusted_router/services/inference_quota.py
+++ b/src/trusted_router/services/inference_quota.py
@@ -51,6 +51,7 @@ class QuotaTicket:
     usage_type: UsageType
     reservation_id: str | None
     key_hash: str
+    key_reserved_microdollars: int
     _finalized: bool = False
 
     def settle(self, actual_cost_microdollars: int) -> None:
@@ -61,7 +62,7 @@ class QuotaTicket:
             STORE.settle(self.reservation_id, actual_cost_microdollars)
         STORE.settle_key_limit(
             self.key_hash,
-            self.reserve_amount,
+            self.key_reserved_microdollars,
             actual_cost_microdollars,
             usage_type=self.usage_type,
         )
@@ -74,7 +75,7 @@ class QuotaTicket:
             STORE.refund(self.reservation_id)
         STORE.refund_key_limit(
             self.key_hash,
-            self.reserve_amount,
+            self.key_reserved_microdollars,
             usage_type=self.usage_type,
         )
 
@@ -98,11 +99,12 @@ async def reserved_quota(
     assert principal.api_key is not None
     usage_type = usage_type_override or UsageType.for_model(model)
     try:
-        window_decision = STORE.reserve_key_limit(
+        key_limit_reservation = STORE.reserve_key_limit(
             principal.api_key.hash,
             reserve_amount,
             usage_type=usage_type,
         )
+        window_decision = key_limit_reservation.window_decision
         remember_spend_window_decision(request, window_decision)
     except KeyWindowLimitExceeded as exc:
         remember_spend_window_decision(request, exc.decision)
@@ -138,7 +140,7 @@ async def reserved_quota(
         except ValueError as exc:
             STORE.refund_key_limit(
                 principal.api_key.hash,
-                reserve_amount,
+                key_limit_reservation.reserved_microdollars,
                 usage_type=usage_type,
             )
             raise api_error(
@@ -152,6 +154,7 @@ async def reserved_quota(
         usage_type=usage_type,
         reservation_id=reservation_id,
         key_hash=principal.api_key.hash,
+        key_reserved_microdollars=key_limit_reservation.reserved_microdollars,
     )
     started_at = time.monotonic()
     try:
@@ -202,6 +205,7 @@ def apply_authorization_outcome(
     """
     reservation_usage_type = authorization.usage_type
     actual_usage_type = UsageType.coerce(selected_usage_type or authorization.usage_type)
+    key_reserved_microdollars = authorization.frozen_key_hold_microdollars()
     if success:
         if authorization.credit_reservation_id is not None:
             if actual_usage_type == UsageType.CREDITS:
@@ -214,7 +218,7 @@ def apply_authorization_outcome(
                 STORE.refund(authorization.credit_reservation_id)
         STORE.settle_key_limit(
             authorization.key_hash,
-            authorization.estimated_microdollars,
+            key_reserved_microdollars,
             actual_cost_microdollars,
             usage_type=reservation_usage_type,
         )
@@ -223,7 +227,7 @@ def apply_authorization_outcome(
             STORE.refund(authorization.credit_reservation_id)
         STORE.refund_key_limit(
             authorization.key_hash,
-            authorization.estimated_microdollars,
+            key_reserved_microdollars,
             usage_type=reservation_usage_type,
         )
 

--- a/src/trusted_router/spend_windows.py
+++ b/src/trusted_router/spend_windows.py
@@ -59,6 +59,20 @@ class KeyWindowLimitDecision:
     allowed: bool
 
 
+@dataclass(frozen=True)
+class KeyLimitReserveResult:
+    """One key-cap admission result, including the hold actually taken.
+
+    ``reserved_microdollars`` is deliberately separate from the requested
+    estimate. An uncapped or BYOK-excluded request takes no lifetime-cap hold,
+    and settlement must preserve that authorize-time fact even if the key's
+    configuration changes while the request is in flight.
+    """
+
+    window_decision: KeyWindowLimitDecision | None
+    reserved_microdollars: int
+
+
 class KeyWindowLimitExceeded(ValueError):
     """A per-window key spend limit blocked the request."""
 

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -38,7 +38,7 @@ from trusted_router.routable_payouts import (
     validate_routable_release_status,
 )
 from trusted_router.spend_leases import SpendLeaseArtifact, SpendLeaseBoot
-from trusted_router.spend_windows import KeyWindowLimitDecision
+from trusted_router.spend_windows import KeyLimitReserveResult
 from trusted_router.storage_attribution import InMemoryAcquisitionAttribution
 from trusted_router.storage_auth_context import build_session_auth_context
 from trusted_router.storage_auth_sessions import InMemoryAuthSessions
@@ -1479,7 +1479,7 @@ class InMemoryStore:
         amount_microdollars: int,
         *,
         usage_type: str,
-    ) -> KeyWindowLimitDecision | None:
+    ) -> KeyLimitReserveResult:
         return self.api_keys.reserve_limit(key_hash, amount_microdollars, usage_type=usage_type)
 
     def settle_key_limit(
@@ -3113,6 +3113,7 @@ class InMemoryStore:
         usage_type: UsageType | str,
         estimated_microdollars: int,
         credit_reservation_id: str | None,
+        key_reserved_microdollars: int,
         authorization_id: str | None = None,
         requested_model_id: str | None = None,
         candidate_model_ids: list[str] | None = None,
@@ -3169,6 +3170,7 @@ class InMemoryStore:
                 usage_type=usage_type,
                 estimated_microdollars=estimated_microdollars,
                 credit_reservation_id=credit_reservation_id,
+                key_reserved_microdollars=key_reserved_microdollars,
                 authorization_id=authorization_id,
                 requested_model_id=requested_model_id,
                 candidate_model_ids=candidate_model_ids,
@@ -3261,10 +3263,11 @@ class InMemoryStore:
                 else:
                     self.api_keys.refund(authorization.credit_reservation_id)
 
+            key_reserved_microdollars = authorization.frozen_key_hold_microdollars()
             if success:
                 self.api_keys.settle_limit(
                     authorization.key_hash,
-                    authorization.estimated_microdollars,
+                    key_reserved_microdollars,
                     actual_microdollars,
                     usage_type=authorization.usage_type,
                 )
@@ -3273,7 +3276,7 @@ class InMemoryStore:
             else:
                 self.api_keys.refund_limit(
                     authorization.key_hash,
-                    authorization.estimated_microdollars,
+                    key_reserved_microdollars,
                     usage_type=authorization.usage_type,
                 )
 

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -3113,7 +3113,7 @@ class InMemoryStore:
         usage_type: UsageType | str,
         estimated_microdollars: int,
         credit_reservation_id: str | None,
-        key_reserved_microdollars: int,
+        key_reserved_microdollars: int | None = None,
         authorization_id: str | None = None,
         requested_model_id: str | None = None,
         candidate_model_ids: list[str] | None = None,
@@ -3158,7 +3158,13 @@ class InMemoryStore:
                     if terminal_key not in self._paused_authorizations or idempotency_key is None:
                         if credit_reservation_id is not None:
                             self.refund(credit_reservation_id)
-                        self.api_keys.refund_limit(key_hash, estimated_microdollars, usage_type=usage_type)
+                        from trusted_router.storage_legacy_trust import legacy_key_hold
+
+                        hold = (
+                            legacy_key_hold(self.api_keys.get_by_hash(key_hash), estimated_microdollars, usage_type)
+                            if key_reserved_microdollars is None else max(0, int(key_reserved_microdollars))
+                        )
+                        self.api_keys.refund_limit(key_hash, hold, usage_type=usage_type)
                         if idempotency_key is not None:
                             self._paused_authorizations.add(terminal_key)
                     raise BillingPausedError()

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -64,7 +64,7 @@ from trusted_router.spend_leases import (
     SpendLeaseArtifact,
     SpendLeaseBoot,
 )
-from trusted_router.spend_windows import KeyWindowLimitDecision
+from trusted_router.spend_windows import KeyLimitReserveResult
 from trusted_router.storage import (
     AcquisitionAttribution,
     ActivationReminderTask,
@@ -4646,6 +4646,7 @@ class SpannerBigtableStore:
         usage_type: UsageType | str,
         estimated_microdollars: int,
         credit_reservation_id: str | None,
+        key_reserved_microdollars: int,
         authorization_id: str | None = None,
         requested_model_id: str | None = None,
         candidate_model_ids: list[str] | None = None,
@@ -4685,6 +4686,7 @@ class SpannerBigtableStore:
             usage_type=usage_type,
             estimated_microdollars=estimated_microdollars,
             credit_reservation_id=credit_reservation_id,
+            key_reserved_microdollars=key_reserved_microdollars,
             authorization_id=authorization_id,
             requested_model_id=requested_model_id,
             candidate_model_ids=candidate_model_ids,
@@ -6772,7 +6774,7 @@ class SpannerBigtableStore:
         amount_microdollars: int,
         *,
         usage_type: str,
-    ) -> KeyWindowLimitDecision | None:
+    ) -> KeyLimitReserveResult:
         return self.api_keys.reserve_limit(key_hash, amount_microdollars, usage_type=usage_type)
 
     def settle_key_limit(

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -4646,7 +4646,7 @@ class SpannerBigtableStore:
         usage_type: UsageType | str,
         estimated_microdollars: int,
         credit_reservation_id: str | None,
-        key_reserved_microdollars: int,
+        key_reserved_microdollars: int | None = None,
         authorization_id: str | None = None,
         requested_model_id: str | None = None,
         candidate_model_ids: list[str] | None = None,

--- a/src/trusted_router/storage_gcp_keys.py
+++ b/src/trusted_router/storage_gcp_keys.py
@@ -383,7 +383,7 @@ class SpannerApiKeys:
         usage_type: UsageType | str,
         estimated_microdollars: int,
         credit_reservation_id: str | None,
-        key_reserved_microdollars: int,
+        key_reserved_microdollars: int | None = None,
         authorization_id: str | None = None,
         requested_model_id: str | None = None,
         candidate_model_ids: list[str] | None = None,
@@ -427,7 +427,8 @@ class SpannerApiKeys:
             )
         existing = (
             self.get_gateway_authorization_by_idempotency_key(
-                workspace_id, key_hash, idempotency_key
+                workspace_id, key_hash, idempotency_key,
+                trust_eligibility_enabled=trust_eligibility_enabled,
             )
             if idempotency_key is not None
             else None

--- a/src/trusted_router/storage_gcp_keys.py
+++ b/src/trusted_router/storage_gcp_keys.py
@@ -25,7 +25,7 @@ from trusted_router.security import (
     verify_api_key,
 )
 from trusted_router.spend_leases import SpendLeaseArtifact
-from trusted_router.spend_windows import KeyWindowLimitDecision
+from trusted_router.spend_windows import KeyLimitReserveResult
 from trusted_router.storage_gcp_codec import workspace_key_id as _workspace_key_id
 from trusted_router.storage_gcp_counters import (
     KEY_LIMIT_COLUMNS,
@@ -291,13 +291,13 @@ class SpannerApiKeys:
         amount_microdollars: int,
         *,
         usage_type: str,
-    ) -> KeyWindowLimitDecision | None:
-        def txn(transaction: Any) -> None:
+    ) -> KeyLimitReserveResult:
+        def txn(transaction: Any) -> int:
             key = self._io.read_entity_tx(transaction, "api_key", key_hash, ApiKey)
             if key is None or key.limit_microdollars is None:
-                return
+                return 0
             if _is_byok(usage_type) and not key.include_byok_in_limit:
-                return
+                return 0
             used = key.usage_microdollars
             if key.include_byok_in_limit:
                 used += key.byok_usage_microdollars
@@ -306,12 +306,13 @@ class SpannerApiKeys:
                 raise ValueError("key limit exceeded")
             key.reserved_microdollars += amount_microdollars
             self._io.write_entity_tx(transaction, "api_key", key.hash, key)
+            return amount_microdollars
 
-        run_in_transaction_with_retry(self._io.database, txn)
+        reserved = run_in_transaction_with_retry(self._io.database, txn)
         # This retired JSON-counter path has no authoritative spend-window
         # counters. Production gateway authorization uses the typed path below;
         # never fabricate window headers here from stale JSON mirrors.
-        return None
+        return KeyLimitReserveResult(None, int(reserved))
 
     def settle_limit(
         self,
@@ -358,13 +359,12 @@ class SpannerApiKeys:
     ) -> None:
         def txn(transaction: Any) -> None:
             key = self._io.read_entity_tx(transaction, "api_key", key_hash, ApiKey)
-            if key is None or key.limit_microdollars is None:
-                return
-            if _is_byok(usage_type) and not key.include_byok_in_limit:
+            if key is None:
                 return
             key.reserved_microdollars = max(0, key.reserved_microdollars - reserved_microdollars)
             self._io.write_entity_tx(transaction, "api_key", key.hash, key)
 
+        _ = usage_type
         run_in_transaction_with_retry(self._io.database, txn)
 
     # ── Gateway authorizations ──────────────────────────────────────────
@@ -378,6 +378,7 @@ class SpannerApiKeys:
         usage_type: UsageType | str,
         estimated_microdollars: int,
         credit_reservation_id: str | None,
+        key_reserved_microdollars: int,
         authorization_id: str | None = None,
         requested_model_id: str | None = None,
         candidate_model_ids: list[str] | None = None,
@@ -437,6 +438,7 @@ class SpannerApiKeys:
             usage_type=UsageType.coerce(usage_type),
             estimated_microdollars=estimated_microdollars,
             credit_reservation_id=credit_reservation_id,
+            key_reserved_microdollars=key_reserved_microdollars,
             settlement=settlement,
             expires_at=expires_at,
             requested_model_id=requested_model_id,

--- a/src/trusted_router/storage_gcp_keys.py
+++ b/src/trusted_router/storage_gcp_keys.py
@@ -357,6 +357,11 @@ class SpannerApiKeys:
         *,
         usage_type: str,
     ) -> None:
+        # Avoid mutating the hot key row for reservations without a hold.
+        # Positive holds must still release after cap/configuration edits.
+        if reserved_microdollars <= 0:
+            return
+
         def txn(transaction: Any) -> None:
             key = self._io.read_entity_tx(transaction, "api_key", key_hash, ApiKey)
             if key is None:

--- a/src/trusted_router/storage_keys.py
+++ b/src/trusted_router/storage_keys.py
@@ -39,7 +39,7 @@ from trusted_router.security import (
 from trusted_router.spend_leases import SpendLeaseArtifact
 from trusted_router.spend_windows import (
     KeyLimitExceeded,
-    KeyWindowLimitDecision,
+    KeyLimitReserveResult,
     KeyWindowLimitExceeded,
     decide_key_window_limits,
     enforced_window_limits,
@@ -269,11 +269,12 @@ class InMemoryApiKeys:
         amount_microdollars: int,
         *,
         usage_type: str,
-    ) -> KeyWindowLimitDecision | None:
+    ) -> KeyLimitReserveResult:
         with self._lock:
             key = self.keys[key_hash]
             if _is_byok(usage_type) and not key.include_byok_in_limit:
-                return None  # BYOK excluded from this key's caps (lifetime AND windows)
+                # BYOK excluded from this key's caps (lifetime AND windows).
+                return KeyLimitReserveResult(None, 0)
             # Window limits are independent of the lifetime cap: check first,
             # approximately (in-flight reserved is deliberately not counted —
             # same semantics as the typed authorize check).
@@ -290,7 +291,7 @@ class InMemoryApiKeys:
                 if decision is not None and not decision.allowed:
                     raise KeyWindowLimitExceeded(decision)
             if key.limit_microdollars is None:
-                return decision
+                return KeyLimitReserveResult(decision, 0)
             used = key.usage_microdollars
             if key.include_byok_in_limit:
                 used += key.byok_usage_microdollars
@@ -298,7 +299,7 @@ class InMemoryApiKeys:
             if amount_microdollars > available:
                 raise KeyLimitExceeded(decision)
             key.reserved_microdollars += amount_microdollars
-            return decision
+            return KeyLimitReserveResult(decision, amount_microdollars)
 
     def settle_limit(
         self,
@@ -310,14 +311,13 @@ class InMemoryApiKeys:
     ) -> None:
         with self._lock:
             key = self.keys.get(key_hash)
-            if key is None or key.limit_microdollars is None:
-                return
-            if _is_byok(usage_type) and not key.include_byok_in_limit:
+            if key is None:
                 return
             key.reserved_microdollars = max(0, key.reserved_microdollars - reserved_microdollars)
             # Actual usage is added by add_usage; this method only releases
-            # the estimated key-limit hold.
-            _ = actual_microdollars
+            # the exact authorize-time key-limit hold. Current cap settings
+            # cannot change whether that recorded hold is released.
+            _ = actual_microdollars, usage_type
 
     def refund_limit(
         self,
@@ -328,11 +328,10 @@ class InMemoryApiKeys:
     ) -> None:
         with self._lock:
             key = self.keys.get(key_hash)
-            if key is None or key.limit_microdollars is None:
-                return
-            if _is_byok(usage_type) and not key.include_byok_in_limit:
+            if key is None:
                 return
             key.reserved_microdollars = max(0, key.reserved_microdollars - reserved_microdollars)
+            _ = usage_type
 
     def add_usage(self, key_hash: str, cost_microdollars: int, *, is_byok: bool) -> None:
         """Roll a settled generation's actual cost into the key counters.
@@ -431,6 +430,7 @@ class InMemoryApiKeys:
         usage_type: UsageType | str,
         estimated_microdollars: int,
         credit_reservation_id: str | None,
+        key_reserved_microdollars: int,
         authorization_id: str | None = None,
         requested_model_id: str | None = None,
         candidate_model_ids: list[str] | None = None,
@@ -490,6 +490,7 @@ class InMemoryApiKeys:
                 usage_type=UsageType.coerce(usage_type),
                 estimated_microdollars=estimated_microdollars,
                 credit_reservation_id=credit_reservation_id,
+                key_reserved_microdollars=key_reserved_microdollars,
                 requested_model_id=requested_model_id,
                 candidate_model_ids=list(candidate_model_ids or []),
                 region=region,

--- a/src/trusted_router/storage_keys.py
+++ b/src/trusted_router/storage_keys.py
@@ -430,7 +430,7 @@ class InMemoryApiKeys:
         usage_type: UsageType | str,
         estimated_microdollars: int,
         credit_reservation_id: str | None,
-        key_reserved_microdollars: int,
+        key_reserved_microdollars: int | None = None,
         authorization_id: str | None = None,
         requested_model_id: str | None = None,
         candidate_model_ids: list[str] | None = None,

--- a/src/trusted_router/storage_legacy_trust.py
+++ b/src/trusted_router/storage_legacy_trust.py
@@ -17,6 +17,19 @@ class BillingPausedError(ValueError):
         super().__init__("billing_paused")
 
 
+def legacy_key_hold(key: Any, estimate: int, usage_type: Any) -> int:
+    """Compatibility for callers predating the frozen-hold argument.
+
+    New callers must pass the reserve result explicitly, including zero, so
+    cap edits between reserve and creation cannot change the release amount.
+    """
+    if key is None or key.limit_microdollars is None:
+        return 0
+    if str(usage_type).lower() == "byok" and not key.include_byok_in_limit:
+        return 0
+    return max(0, int(estimate))
+
+
 def postgres_pause(conn: Any, workspace_id: str) -> tuple[bool, int]:
     rows = conn.execute(
         "SELECT billing_pause_causes, pause_epoch FROM tr_credit_balance "
@@ -130,14 +143,13 @@ def create_spanner_legacy_authorization(
             if authorization.credit_reservation_id is not None:
                 raise RuntimeError("legacy credit reservation requires typed recovery")
             key = io.read_entity_tx(tx, "api_key", authorization.key_hash, ApiKey)
-            if (
-                key is not None
-                and key.limit_microdollars is not None
-                and (str(authorization.usage_type).lower() != "byok" or key.include_byok_in_limit)
-            ):
-                key.reserved_microdollars = max(
-                    0, key.reserved_microdollars - authorization.estimated_microdollars
+            if key is not None:
+                hold = (
+                    legacy_key_hold(key, authorization.estimated_microdollars, authorization.usage_type)
+                    if authorization.key_reserved_microdollars is None
+                    else authorization.frozen_key_hold_microdollars()
                 )
+                key.reserved_microdollars = max(0, key.reserved_microdollars - hold)
                 io.write_entity_tx(tx, "api_key", key.hash, key)
             if index_id:
                 io.write_entity_tx(

--- a/src/trusted_router/storage_models.py
+++ b/src/trusted_router/storage_models.py
@@ -791,6 +791,10 @@ class GatewayAuthorization:
     usage_type: UsageType
     estimated_microdollars: int
     credit_reservation_id: str | None = None
+    # Exact lifetime key-cap hold taken at authorize. None means a legacy JSON
+    # record created before this fact was persisted; it must never be guessed
+    # from mutable current key configuration during settlement.
+    key_reserved_microdollars: int | None = None
     settled: bool = False
     created_at: str = field(default_factory=iso_now)
     requested_model_id: str | None = None
@@ -906,6 +910,17 @@ class GatewayAuthorization:
         # is always a UsageType at runtime regardless of construction path.
         if not isinstance(self.usage_type, UsageType):
             self.usage_type = UsageType.coerce(self.usage_type)
+
+    def frozen_key_hold_microdollars(self) -> int:
+        """Return only the authorize-time key hold recorded for this request.
+
+        Old JSON records have no trustworthy value. Releasing zero can leave
+        an old hold for reconciliation, but guessing from the estimate can
+        release a newer request's money after the key configuration changes.
+        """
+        if self.key_reserved_microdollars is None:
+            return 0
+        return max(0, int(self.key_reserved_microdollars))
 
     def record_finalization(
         self,

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -3556,9 +3556,9 @@ class PostgresStore:
             (authorization.key_hash,),
             prepare=False,
         ).fetchone()
-        if row is None or row[0] is None:
-            return 0
-        if _is_byok(authorization.usage_type) and not row[1]:
+        # A removed cap must not strand a hold taken before rollout. Only
+        # BYOK exclusion suppressed the legacy estimate-based release.
+        if row is not None and _is_byok(authorization.usage_type) and not row[1]:
             return 0
         return max(0, int(authorization.estimated_microdollars))
 
@@ -6146,7 +6146,7 @@ class PostgresStore:
         usage_type: UsageType | str,
         estimated_microdollars: int,
         credit_reservation_id: str | None,
-        key_reserved_microdollars: int,
+        key_reserved_microdollars: int | None = None,
         authorization_id: str | None = None,
         requested_model_id: str | None = None,
         candidate_model_ids: list[str] | None = None,
@@ -6269,7 +6269,17 @@ class PostgresStore:
                 if paused or (expected_pause_epoch is not None and expected_pause_epoch != epoch) or (credit_reservation_id and int((observed or {}).get("pause_epoch", 0)) != epoch):
                     if credit_reservation_id:
                         reject_postgres_reservation(conn, self, credit_reservation_id)
-                    self._release_key_hold_tx(conn, key_hash, estimated_microdollars, usage_type=usage_type, window_amount=0)
+                    from trusted_router.storage_legacy_trust import legacy_key_hold
+
+                    hold = (
+                        legacy_key_hold(
+                            self._read_entity_tx(conn, "api_key", key_hash, ApiKey, for_update=True),
+                            estimated_microdollars, usage_type,
+                        )
+                        if key_reserved_microdollars is None
+                        else authorization.frozen_key_hold_microdollars()
+                    )
+                    self._release_key_hold_tx(conn, key_hash, hold, usage_type=usage_type, window_amount=0)
                     if pointer_id:
                         self._write_entity_tx(conn, _GATEWAY_IDEMPOTENCY_KIND, pointer_id, {"reason": "billing_paused"})
                     return None

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -86,6 +86,7 @@ from trusted_router.spend_leases import (
 )
 from trusted_router.spend_windows import (
     KeyLimitExceeded,
+    KeyLimitReserveResult,
     KeyWindowLimitDecision,
     KeyWindowLimitExceeded,
     decide_key_window_limits,
@@ -2741,6 +2742,55 @@ class PostgresStore:
 
     # API keys ---------------------------------------------------------------
 
+    def _write_key_limit_caps_tx(self, conn: Any, key: ApiKey) -> None:
+        """Write cap configuration only for the one supported shard layout.
+
+        Postgres key-limit rows are single-shard by construction. Keeping all
+        cap writes here makes a future or damaged multi-shard layout fail
+        closed instead of replicating a full cap across shards or updating no
+        row while reporting success.
+        """
+        rows = conn.execute(
+            "SELECT workspace_id, shard FROM tr_key_limit"
+            " WHERE key_hash = %s ORDER BY workspace_id, shard FOR UPDATE",
+            (key.hash,),
+            prepare=False,
+        ).fetchall()
+        layout = [(str(workspace_id), int(shard)) for workspace_id, shard in rows]
+        expected = [(key.workspace_id, 0)]
+        if layout != expected:
+            shards = [shard for _workspace_id, shard in layout]
+            raise RuntimeError(
+                f"cannot write caps for key_hash={key.hash}: "
+                f"shard_count={len(layout)}, shards={shards}; exactly one row at "
+                "shard 0 is required; distributing a cap across shards is not "
+                "implemented on this backend"
+            )
+        cursor = conn.execute(
+            "UPDATE tr_key_limit SET"
+            " limit_micro = %s::bigint, include_byok = %s,"
+            " day_limit_micro = %s::bigint,"
+            " week_limit_micro = %s::bigint,"
+            " month_limit_micro = %s::bigint,"
+            " updated_at = CURRENT_TIMESTAMP"
+            " WHERE workspace_id = %s AND key_hash = %s AND shard = 0",
+            (
+                _int8_param(key.limit_microdollars),
+                key.include_byok_in_limit,
+                _int8_param(key.limit_daily_microdollars),
+                _int8_param(key.limit_weekly_microdollars),
+                _int8_param(key.limit_monthly_microdollars),
+                key.workspace_id,
+                key.hash,
+            ),
+            prepare=False,
+        )
+        if cursor.rowcount != 1:
+            raise RuntimeError(
+                f"cannot write caps for key_hash={key.hash}: cap UPDATE affected "
+                f"{cursor.rowcount} rows; exactly one row at shard 0 is required"
+            )
+
     def create_api_key(
         self,
         *,
@@ -2803,21 +2853,11 @@ class PostgresStore:
             )
             conn.execute(
                 "INSERT INTO tr_key_limit "
-                "(workspace_id, key_hash, shard, limit_micro, include_byok, "
-                "day_limit_micro, week_limit_micro, month_limit_micro, "
-                "source_updated_at, updated_at) "
-                "VALUES (%s, %s, 0, %s, %s, %s, %s, %s, "
-                "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
-                (
-                    workspace_id,
-                    key.hash,
-                    _int8_param(limit_microdollars),
-                    include_byok_in_limit,
-                    _int8_param(limit_daily_microdollars),
-                    _int8_param(limit_weekly_microdollars),
-                    _int8_param(limit_monthly_microdollars),
-                ),
+                "(workspace_id, key_hash, shard, source_updated_at, updated_at) "
+                "VALUES (%s, %s, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                (workspace_id, key.hash),
             )
+            self._write_key_limit_caps_tx(conn, key)
 
         self._run_transaction(create)
         return raw, key
@@ -2865,28 +2905,12 @@ class PostgresStore:
             # from the home record; usage and reserved start at zero.
             conn.execute(
                 "INSERT INTO tr_key_limit"
-                " (workspace_id, key_hash, shard, limit_micro, usage, byok_usage,"
-                "  reserved, include_byok, day_limit_micro, week_limit_micro,"
-                "  month_limit_micro)"
-                " VALUES (%s, %s, 0, %s, 0, 0, 0, %s, %s, %s, %s)"
-                " ON CONFLICT (workspace_id, key_hash, shard) DO UPDATE SET"
-                "   limit_micro = EXCLUDED.limit_micro"
-                " , include_byok = EXCLUDED.include_byok"
-                " , day_limit_micro = EXCLUDED.day_limit_micro"
-                " , week_limit_micro = EXCLUDED.week_limit_micro"
-                " , month_limit_micro = EXCLUDED.month_limit_micro"
-                " , updated_at = CURRENT_TIMESTAMP",
-                (
-                    key.workspace_id,
-                    key.hash,
-                    _int8_param(key.limit_microdollars),
-                    key.include_byok_in_limit,
-                    _int8_param(key.limit_daily_microdollars),
-                    _int8_param(key.limit_weekly_microdollars),
-                    _int8_param(key.limit_monthly_microdollars),
-                ),
+                " (workspace_id, key_hash, shard) VALUES (%s, %s, 0)"
+                " ON CONFLICT (workspace_id, key_hash, shard) DO NOTHING",
+                (key.workspace_id, key.hash),
                 prepare=False,
             )
+            self._write_key_limit_caps_tx(conn, key)
             return key
 
         return self._run_transaction(upsert)
@@ -3025,7 +3049,7 @@ class PostgresStore:
         amount_microdollars: int,
         *,
         usage_type: UsageType | str,
-    ) -> KeyWindowLimitDecision | None:
+    ) -> KeyLimitReserveResult:
         """Hold `amount` against this key's caps, or raise.
 
         Mirrors InMemoryApiKeys.reserve_limit (storage_keys.py), which is the
@@ -3050,19 +3074,27 @@ class PostgresStore:
         decision_now = utcnow()
         window_floor_map = window_floors(decision_now)
 
-        def reserve(conn: Any) -> KeyWindowLimitDecision | None:
+        def reserve(conn: Any) -> KeyLimitReserveResult:
             row = conn.execute(
-                "SELECT limit_micro, usage, byok_usage, reserved, include_byok,"
-                " day_limit_micro, week_limit_micro, month_limit_micro,"
-                " day_usage, day_start, week_usage, week_start, month_usage, month_start"
-                " FROM tr_key_limit WHERE key_hash = %s AND shard = 0",
+                "SELECT key_limit.limit_micro, key_limit.usage,"
+                " key_limit.byok_usage, key_limit.reserved, key_limit.include_byok,"
+                " key_limit.day_limit_micro, key_limit.week_limit_micro,"
+                " key_limit.month_limit_micro, key_limit.day_usage,"
+                " key_limit.day_start, key_limit.week_usage, key_limit.week_start,"
+                " key_limit.month_usage, key_limit.month_start,"
+                " key_record.body ->> 'budget_alert_only'"
+                " FROM tr_key_limit AS key_limit"
+                " LEFT JOIN tr_entities AS key_record"
+                "   ON key_record.kind = 'api_key'"
+                "  AND key_record.id = key_limit.key_hash"
+                " WHERE key_limit.key_hash = %s AND key_limit.shard = 0",
                 (key_hash,),
                 prepare=False,
             ).fetchone()
             if row is None:
                 # No typed row: nothing to enforce here. The gateway's own
                 # KEY_MISSING handling covers the typed-authorize path.
-                return None
+                return KeyLimitReserveResult(None, 0)
             (
                 limit_micro,
                 _usage,
@@ -3078,39 +3110,48 @@ class PostgresStore:
                 week_start,
                 month_usage,
                 month_start,
+                budget_alert_only_raw,
             ) = row
 
             if _is_byok(usage_type) and not include_byok:
-                return None
+                return KeyLimitReserveResult(None, 0)
 
-            # Lazy windows: a NULL or stale *_start means the window has not
-            # started in this period, so its usage reads as ZERO. No reset job
-            # exists (or could silently stop and leave keys stuck over limit).
-            windows = (
-                ("daily", day_limit, day_usage, day_start),
-                ("weekly", week_limit, week_usage, week_start),
-                ("monthly", month_limit, month_usage, month_start),
-            )
-            window_limits: dict[str, int] = {}
-            used_by_window: dict[str, int] = {}
-            for name, limit, used, started in windows:
-                if limit is None:
-                    continue
-                floor = window_floor_map[name]
-                current = 0 if started is None or _as_utc(started) < floor else int(used or 0)
-                window_limits[name] = int(limit)
-                used_by_window[name] = current
-            decision = decide_key_window_limits(
-                window_limits,
-                used_by_window,
-                amount_microdollars,
-                now=decision_now,
-            )
-            if decision is not None and not decision.allowed:
-                raise KeyWindowLimitExceeded(decision)
+            decision: KeyWindowLimitDecision | None = None
+            budget_alert_only = str(budget_alert_only_raw).lower() in {"1", "true"}
+            if not budget_alert_only:
+                # Lazy windows: a NULL or stale *_start means the window has
+                # not started in this period, so its usage reads as ZERO. No
+                # reset job exists (or could silently stop and leave keys
+                # stuck over limit).
+                windows = (
+                    ("daily", day_limit, day_usage, day_start),
+                    ("weekly", week_limit, week_usage, week_start),
+                    ("monthly", month_limit, month_usage, month_start),
+                )
+                window_limits: dict[str, int] = {}
+                used_by_window: dict[str, int] = {}
+                for name, limit, used, started in windows:
+                    if limit is None:
+                        continue
+                    floor = window_floor_map[name]
+                    current = (
+                        0
+                        if started is None or _as_utc(started) < floor
+                        else int(used or 0)
+                    )
+                    window_limits[name] = int(limit)
+                    used_by_window[name] = current
+                decision = decide_key_window_limits(
+                    window_limits,
+                    used_by_window,
+                    amount_microdollars,
+                    now=decision_now,
+                )
+                if decision is not None and not decision.allowed:
+                    raise KeyWindowLimitExceeded(decision)
 
             if limit_micro is None:
-                return decision
+                return KeyLimitReserveResult(decision, 0)
 
             updated = conn.execute(
                 "UPDATE tr_key_limit"
@@ -3129,7 +3170,7 @@ class PostgresStore:
             ).rowcount
             if updated == 0:
                 raise KeyLimitExceeded(decision)
-            return decision
+            return KeyLimitReserveResult(decision, amount_microdollars)
 
         return self._run_transaction(reserve)
 
@@ -3435,25 +3476,21 @@ class PostgresStore:
         is whether the spend being rolled into the windows was BYOK. They
         differ on a mixed-candidate authorization: the hold is Credits-typed
         whenever any credit candidate existed, but the enclave may select a
-        BYOK endpoint. Deriving both from one value made the early-return
-        below skip the RELEASE for include_byok=false keys — stranding
-        `reserved` forever — when what should be skipped is only the window
-        contribution.
+        BYOK endpoint. Deriving both from one value used to skip the RELEASE
+        for include_byok=false keys — stranding `reserved` forever — when
+        what should be skipped is only the window contribution. Mutable
+        current configuration must never decide whether a recorded hold is
+        released.
         """
         floors = window_floors(utcnow())
         row = conn.execute(
-            "SELECT limit_micro, include_byok FROM tr_key_limit WHERE key_hash = %s AND shard = 0",
+            "SELECT include_byok FROM tr_key_limit WHERE key_hash = %s AND shard = 0",
             (key_hash,),
             prepare=False,
         ).fetchone()
         if row is None:
             return
-        limit_micro, include_byok = row
-        if _is_byok(usage_type) and not include_byok:
-            # Symmetric with reserve_key_limit: no hold was ever taken for a
-            # BYOK-typed reservation on a key that excludes BYOK, so there is
-            # nothing to release and nothing to roll.
-            return
+        (include_byok,) = row
         if window_is_byok is None:
             window_is_byok = _is_byok(usage_type)
         if window_is_byok and not include_byok:
@@ -3503,7 +3540,21 @@ class PostgresStore:
             ),
             prepare=False,
         )
-        _ = limit_micro  # read for the BYOK/uncapped guard above only.
+
+    @staticmethod
+    def _recorded_key_hold(authorization: GatewayAuthorization) -> int:
+        """Return only a hold durably frozen on the authorization.
+
+        A legacy JSON record has no safe answer: current cap configuration can
+        describe a different request's hold. Releasing zero may strand an old
+        hold for reconciliation, but it cannot steal newer headroom.
+        """
+        if authorization.key_reserved_microdollars is None:
+            log.error(
+                "authorization %s has no frozen key hold; releasing zero",
+                authorization.id,
+            )
+        return authorization.frozen_key_hold_microdollars()
 
     def supports_key_writes(self) -> bool:
         return True
@@ -3548,43 +3599,8 @@ class PostgresStore:
             apply_key_patch(key, patch)
             typed_limit_patch = bool(TYPED_LIMIT_PATCH_FIELDS & patch.keys())
             if typed_limit_patch:
-                shard_count = int(
-                    conn.execute(
-                        "SELECT COUNT(*) FROM tr_key_limit WHERE key_hash = %s",
-                        (key.hash,),
-                        prepare=False,
-                    ).fetchone()[0]
-                )
-                if shard_count > 1:
-                    raise RuntimeError(
-                        f"cannot update caps for key_hash={key.hash}: "
-                        f"shard_count={shard_count}; distributing a cap across shards "
-                        "is not implemented on this backend"
-                    )
+                self._write_key_limit_caps_tx(conn, key)
             self._write_entity_tx(conn, "api_key", key.hash, key)
-            if typed_limit_patch:
-                # Postgres creates exactly one typed row, shard 0. The count
-                # above makes that assumption fail closed if multiple shards
-                # ever appear. For a legacy/orphaned entity with zero typed
-                # rows, this remains a no-op while the entity update succeeds.
-                conn.execute(
-                    "UPDATE tr_key_limit SET"
-                    " limit_micro = %s::bigint, include_byok = %s,"
-                    " day_limit_micro = %s::bigint,"
-                    " week_limit_micro = %s::bigint,"
-                    " month_limit_micro = %s::bigint,"
-                    " updated_at = CURRENT_TIMESTAMP"
-                    " WHERE key_hash = %s AND shard = 0",
-                    (
-                        _int8_param(key.limit_microdollars),
-                        key.include_byok_in_limit,
-                        _int8_param(key.limit_daily_microdollars),
-                        _int8_param(key.limit_weekly_microdollars),
-                        _int8_param(key.limit_monthly_microdollars),
-                        key.hash,
-                    ),
-                    prepare=False,
-                )
             return key
 
         return self._run_transaction(update)
@@ -6124,6 +6140,7 @@ class PostgresStore:
         usage_type: UsageType | str,
         estimated_microdollars: int,
         credit_reservation_id: str | None,
+        key_reserved_microdollars: int,
         authorization_id: str | None = None,
         requested_model_id: str | None = None,
         candidate_model_ids: list[str] | None = None,
@@ -6184,6 +6201,7 @@ class PostgresStore:
             usage_type=cast(Any, usage_type),
             estimated_microdollars=estimated_microdollars,
             credit_reservation_id=credit_reservation_id,
+            key_reserved_microdollars=key_reserved_microdollars,
             requested_model_id=requested_model_id,
             candidate_model_ids=list(candidate_model_ids or []),
             region=region,
@@ -6436,7 +6454,7 @@ class PostgresStore:
                 self._release_key_hold_tx(
                     conn,
                     authorization.key_hash,
-                    authorization.estimated_microdollars,
+                    self._recorded_key_hold(authorization),
                     # The hold was reserved under the AUTHORIZE-time type
                     # (Credits whenever a credit candidate existed) — release
                     # under the same type, or an include_byok=false key whose
@@ -6553,7 +6571,7 @@ class PostgresStore:
             self._release_key_hold_tx(
                 conn,
                 authorization.key_hash,
-                authorization.estimated_microdollars,
+                self._recorded_key_hold(authorization),
                 usage_type=authorization.usage_type,
                 window_amount=booked,
                 window_is_byok=_is_byok(selected_usage_type),
@@ -6683,7 +6701,7 @@ class PostgresStore:
                 self._release_key_hold_tx(
                     conn,
                     authorization.key_hash,
-                    authorization.estimated_microdollars,
+                    self._recorded_key_hold(authorization),
                     usage_type=authorization.usage_type,
                     window_amount=0,
                 )

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -3542,19 +3542,25 @@ class PostgresStore:
         )
 
     @staticmethod
-    def _recorded_key_hold(authorization: GatewayAuthorization) -> int:
-        """Return only a hold durably frozen on the authorization.
+    def _recorded_key_hold(conn: Any, authorization: GatewayAuthorization) -> int:
+        """Honor frozen holds, including zero; retain legacy rollout behavior.
 
-        A legacy JSON record has no safe answer: current cap configuration can
-        describe a different request's hold. Releasing zero may strand an old
-        hold for reconciliation, but it cannot steal newer headroom.
+        Pre-deploy authorizations lack the field. Compute their release from
+        current configuration in the settlement transaction, as before rollout.
         """
-        if authorization.key_reserved_microdollars is None:
-            log.error(
-                "authorization %s has no frozen key hold; releasing zero",
-                authorization.id,
-            )
-        return authorization.frozen_key_hold_microdollars()
+        if authorization.key_reserved_microdollars is not None:
+            return authorization.frozen_key_hold_microdollars()
+        row = conn.execute(
+            "SELECT limit_micro, include_byok FROM tr_key_limit"
+            " WHERE key_hash = %s AND shard = 0",
+            (authorization.key_hash,),
+            prepare=False,
+        ).fetchone()
+        if row is None or row[0] is None:
+            return 0
+        if _is_byok(authorization.usage_type) and not row[1]:
+            return 0
+        return max(0, int(authorization.estimated_microdollars))
 
     def supports_key_writes(self) -> bool:
         return True
@@ -3598,9 +3604,9 @@ class PostgresStore:
                 return None
             apply_key_patch(key, patch)
             typed_limit_patch = bool(TYPED_LIMIT_PATCH_FIELDS & patch.keys())
+            self._write_entity_tx(conn, "api_key", key.hash, key)
             if typed_limit_patch:
                 self._write_key_limit_caps_tx(conn, key)
-            self._write_entity_tx(conn, "api_key", key.hash, key)
             return key
 
         return self._run_transaction(update)
@@ -6454,7 +6460,7 @@ class PostgresStore:
                 self._release_key_hold_tx(
                     conn,
                     authorization.key_hash,
-                    self._recorded_key_hold(authorization),
+                    self._recorded_key_hold(conn, authorization),
                     # The hold was reserved under the AUTHORIZE-time type
                     # (Credits whenever a credit candidate existed) — release
                     # under the same type, or an include_byok=false key whose
@@ -6571,7 +6577,7 @@ class PostgresStore:
             self._release_key_hold_tx(
                 conn,
                 authorization.key_hash,
-                self._recorded_key_hold(authorization),
+                self._recorded_key_hold(conn, authorization),
                 usage_type=authorization.usage_type,
                 window_amount=booked,
                 window_is_byok=_is_byok(selected_usage_type),
@@ -6701,7 +6707,7 @@ class PostgresStore:
                 self._release_key_hold_tx(
                     conn,
                     authorization.key_hash,
-                    self._recorded_key_hold(authorization),
+                    self._recorded_key_hold(conn, authorization),
                     usage_type=authorization.usage_type,
                     window_amount=0,
                 )

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -14,7 +14,7 @@ from typing import Any, Protocol, runtime_checkable
 
 from trusted_router.operational_analytics_freshness import OutboxFreshness
 from trusted_router.spend_leases import SpendLeaseArtifact, SpendLeaseBoot
-from trusted_router.spend_windows import KeyWindowLimitDecision
+from trusted_router.spend_windows import KeyLimitReserveResult
 from trusted_router.storage_models import (
     AcquisitionAttribution,
     ActivationReminderTask,
@@ -493,7 +493,7 @@ class Store(Protocol):
         amount_microdollars: int,
         *,
         usage_type: UsageType | str,
-    ) -> KeyWindowLimitDecision | None: ...
+    ) -> KeyLimitReserveResult: ...
     def settle_key_limit(
         self,
         key_hash: str,
@@ -908,6 +908,7 @@ class Store(Protocol):
         usage_type: UsageType | str,
         estimated_microdollars: int,
         credit_reservation_id: str | None,
+        key_reserved_microdollars: int,
         authorization_id: str | None = ...,
         requested_model_id: str | None = ...,
         candidate_model_ids: list[str] | None = ...,

--- a/tests/conformance/conftest.py
+++ b/tests/conformance/conftest.py
@@ -277,6 +277,7 @@ _SPANNER_FAKE_KNOWN_GAPS: dict[str, str] = {
     "test_insufficient_reserve_does_not_mutate_balance": _C1_LEGACY_MONEY,
     "test_finalize_gateway_authorization_is_exactly_once": _C1_LEGACY_MONEY,
     "test_finalize_unknown_authorization_is_false_not_error": _C1_LEGACY_MONEY,
+    "test_legacy_authorization_missing_frozen_hold_releases_zero": _C1_LEGACY_MONEY,
     "test_synthetic_rollups_apply_ranges_order_limit_and_histogram_option": (_FAKE_ROLLUP_ORDERING),
 }
 

--- a/tests/conformance/conftest.py
+++ b/tests/conformance/conftest.py
@@ -277,7 +277,7 @@ _SPANNER_FAKE_KNOWN_GAPS: dict[str, str] = {
     "test_insufficient_reserve_does_not_mutate_balance": _C1_LEGACY_MONEY,
     "test_finalize_gateway_authorization_is_exactly_once": _C1_LEGACY_MONEY,
     "test_finalize_unknown_authorization_is_false_not_error": _C1_LEGACY_MONEY,
-    "test_legacy_authorization_missing_frozen_hold_releases_zero": _C1_LEGACY_MONEY,
+    "test_authorization_frozen_zero_hold_releases_zero": _C1_LEGACY_MONEY,
     "test_synthetic_rollups_apply_ranges_order_limit_and_histogram_option": (_FAKE_ROLLUP_ORDERING),
 }
 

--- a/tests/conformance/test_spend_lease_semantics.py
+++ b/tests/conformance/test_spend_lease_semantics.py
@@ -69,6 +69,7 @@ def test_gateway_authorization_replay_preserves_verbatim_spend_lease_token(
         "usage_type": "Credits",
         "estimated_microdollars": 100,
         "credit_reservation_id": None,
+        "key_reserved_microdollars": 0,
         "idempotency_key": f"lease-idem-{unique}",
         "spend_lease": artifact,
     }

--- a/tests/conformance/test_store_semantics.py
+++ b/tests/conformance/test_store_semantics.py
@@ -1802,6 +1802,81 @@ def test_reserve_key_limit_byok_excluded_is_noop(store: Store, unique: str) -> N
     assert _key_limit_row(store, kh)["reserved"] == 0
 
 
+def test_key_limit_hold_result_is_frozen_across_uncapped_to_capped_edit(
+    store: Store,
+    workspace_id: str,
+    user_id: str,
+) -> None:
+    """A zero hold recorded while uncapped cannot release a later request."""
+    _raw, key = store.create_api_key(
+        workspace_id=workspace_id,
+        name="uncapped-then-capped",
+        creator_user_id=user_id,
+        limit_microdollars=None,
+    )
+    uncapped = store.reserve_key_limit(key.hash, 100, usage_type="Credits")
+    assert uncapped.reserved_microdollars == 0
+
+    store.update_key(key.hash, {"limit_microdollars": 100})
+    capped = store.reserve_key_limit(key.hash, 100, usage_type="Credits")
+    assert capped.reserved_microdollars == 100
+
+    store.refund_key_limit(
+        key.hash,
+        uncapped.reserved_microdollars,
+        usage_type="Credits",
+    )
+    with pytest.raises(ValueError):
+        store.reserve_key_limit(key.hash, 1, usage_type="Credits")
+
+
+def test_key_limit_hold_releases_after_cap_is_removed(
+    store: Store,
+    workspace_id: str,
+    user_id: str,
+) -> None:
+    """Release uses the recorded hold even when the current key is uncapped."""
+    _raw, key = store.create_api_key(
+        workspace_id=workspace_id,
+        name="capped-then-uncapped",
+        creator_user_id=user_id,
+        limit_microdollars=100,
+    )
+    held = store.reserve_key_limit(key.hash, 100, usage_type="Credits")
+    assert held.reserved_microdollars == 100
+
+    store.update_key(key.hash, {"limit_microdollars": None})
+    store.refund_key_limit(key.hash, held.reserved_microdollars, usage_type="Credits")
+    store.update_key(key.hash, {"limit_microdollars": 100})
+
+    replacement = store.reserve_key_limit(key.hash, 100, usage_type="Credits")
+    assert replacement.reserved_microdollars == 100
+
+
+def test_byok_key_limit_hold_releases_after_include_flag_is_disabled(
+    store: Store,
+    workspace_id: str,
+    user_id: str,
+) -> None:
+    """Current BYOK policy cannot strand a hold taken under the old policy."""
+    _raw, key = store.create_api_key(
+        workspace_id=workspace_id,
+        name="byok-policy-flip",
+        creator_user_id=user_id,
+        limit_microdollars=100,
+        include_byok_in_limit=True,
+    )
+    held = store.reserve_key_limit(key.hash, 100, usage_type="BYOK")
+    assert held.reserved_microdollars == 100
+
+    store.update_key(key.hash, {"include_byok_in_limit": False})
+    store.refund_key_limit(key.hash, held.reserved_microdollars, usage_type="BYOK")
+    store.update_key(key.hash, {"include_byok_in_limit": True})
+
+    replacement = store.reserve_key_limit(key.hash, 100, usage_type="BYOK")
+    assert replacement.reserved_microdollars == 100
+
+
 def test_reserve_key_limit_counts_byok_when_included(store: Store, unique: str) -> None:
     kh = f"kl-byok-in-{unique}"
     _seed_key_limit(
@@ -1841,7 +1916,8 @@ def test_reserve_key_limit_window_blocks_before_lifetime(store: Store, unique: s
     assert excinfo.value.decision.allowed is False
     assert excinfo.value.decision.reset_seconds >= 1
     # Under the window cap still succeeds against the same row.
-    decision = store.reserve_key_limit(kh, 5, usage_type="Credits")
+    result = store.reserve_key_limit(kh, 5, usage_type="Credits")
+    decision = result.window_decision
     assert decision is not None
     assert decision.window == "daily"
     assert decision.limit == 100
@@ -1970,6 +2046,7 @@ def _authorize(store: Store, workspace_id: str, key_hash: str, **kw: object) -> 
         usage_type="Credits",
         estimated_microdollars=100,
         credit_reservation_id=None,
+        key_reserved_microdollars=0,
     )
     params.update(kw)
     return store.create_gateway_authorization(**params)  # type: ignore[arg-type]
@@ -2069,8 +2146,14 @@ def test_finalize_failure_books_no_usage(store: Store, workspace_id: str, unique
     _seed_key_limit(
         store, kh, limit_micro=1_000, usage=0, byok_usage=0, reserved=0, include_byok=True
     )
-    auth = _authorize(store, workspace_id, kh, estimated_microdollars=60)
-    store.reserve_key_limit(kh, 60, usage_type="Credits")
+    reservation = store.reserve_key_limit(kh, 60, usage_type="Credits")
+    auth = _authorize(
+        store,
+        workspace_id,
+        kh,
+        estimated_microdollars=60,
+        key_reserved_microdollars=reservation.reserved_microdollars,
+    )
 
     assert (
         store.finalize_gateway_authorization(
@@ -2089,6 +2172,42 @@ def test_finalize_failure_books_no_usage(store: Store, workspace_id: str, unique
     assert settled is not None
     assert settled.finalization_outcome == "refunded"
     assert settled.finalized_cost_microdollars == 0
+
+
+def test_legacy_authorization_missing_frozen_hold_releases_zero(
+    store: Store,
+    workspace_id: str,
+    user_id: str,
+) -> None:
+    """A pre-field authorization must never guess a hold from its estimate."""
+    _raw, key = store.create_api_key(
+        workspace_id=workspace_id,
+        name="legacy-missing-hold",
+        creator_user_id=user_id,
+        limit_microdollars=None,
+    )
+    uncapped = store.reserve_key_limit(key.hash, 100, usage_type="Credits")
+    assert uncapped.reserved_microdollars == 0
+    legacy = _authorize(
+        store,
+        workspace_id,
+        key.hash,
+        estimated_microdollars=100,
+        key_reserved_microdollars=None,
+    )
+
+    store.update_key(key.hash, {"limit_microdollars": 100})
+    current = store.reserve_key_limit(key.hash, 100, usage_type="Credits")
+    assert current.reserved_microdollars == 100
+
+    assert store.finalize_gateway_authorization(
+        legacy.id,  # type: ignore[attr-defined]
+        success=False,
+        actual_microdollars=0,
+        selected_usage_type="Credits",
+    )
+    with pytest.raises(ValueError):
+        store.reserve_key_limit(key.hash, 1, usage_type="Credits")
 
 
 def test_federated_key_is_resolvable_on_a_LATER_request(store: Store, unique: str) -> None:

--- a/tests/conformance/test_store_semantics.py
+++ b/tests/conformance/test_store_semantics.py
@@ -2174,26 +2174,30 @@ def test_finalize_failure_books_no_usage(store: Store, workspace_id: str, unique
     assert settled.finalized_cost_microdollars == 0
 
 
-def test_legacy_authorization_missing_frozen_hold_releases_zero(
+def test_authorization_frozen_zero_hold_releases_zero(
     store: Store,
     workspace_id: str,
     user_id: str,
 ) -> None:
-    """A pre-field authorization must never guess a hold from its estimate."""
+    """A recorded zero must never guess a hold from its estimate.
+
+    Missing legacy fields retain the Postgres rollout fallback; explicit zero
+    is the cross-backend guarantee, even after configuration changes.
+    """
     _raw, key = store.create_api_key(
         workspace_id=workspace_id,
-        name="legacy-missing-hold",
+        name="frozen-zero-hold",
         creator_user_id=user_id,
         limit_microdollars=None,
     )
     uncapped = store.reserve_key_limit(key.hash, 100, usage_type="Credits")
     assert uncapped.reserved_microdollars == 0
-    legacy = _authorize(
+    authorization = _authorize(
         store,
         workspace_id,
         key.hash,
         estimated_microdollars=100,
-        key_reserved_microdollars=None,
+        key_reserved_microdollars=0,
     )
 
     store.update_key(key.hash, {"limit_microdollars": 100})
@@ -2201,7 +2205,7 @@ def test_legacy_authorization_missing_frozen_hold_releases_zero(
     assert current.reserved_microdollars == 100
 
     assert store.finalize_gateway_authorization(
-        legacy.id,  # type: ignore[attr-defined]
+        authorization.id,  # type: ignore[attr-defined]
         success=False,
         actual_microdollars=0,
         selected_usage_type="Credits",

--- a/tests/conformance/test_user_model_store.py
+++ b/tests/conformance/test_user_model_store.py
@@ -185,6 +185,7 @@ def test_gateway_authorization_round_trips_frozen_user_model_fields(
         usage_type=UsageType.CREDITS,
         estimated_microdollars=123,
         credit_reservation_id=None,
+        key_reserved_microdollars=0,
         user_provided_model_id="tr-user-model/owner-frozen",
         user_provided_model_revision=7,
         user_model_prompt_price_microdollars_per_m=11,

--- a/tests/fakes/postgres.py
+++ b/tests/fakes/postgres.py
@@ -30,6 +30,7 @@ import contextlib
 import sqlite3
 from collections.abc import Iterator
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 
@@ -180,7 +181,8 @@ def postgres_store_on(conn: SqlitePostgresConn) -> Any:
     from trusted_router.storage_postgres import PostgresStore
 
     store = PostgresStore.__new__(PostgresStore)
-    store._run_transaction = lambda operation: _run(conn, operation)  # type: ignore[method-assign]
+    store._pool = SimpleNamespace(connection=lambda: contextlib.nullcontext(conn))
+    store._transaction_attempts = 3
     store.max_workspaces_per_owner = 25
     store.trust_qualifying_providers = frozenset({"stripe", "x402"})
     store.trust_tier3_min_days = 30

--- a/tests/test_console_api_key_batch.py
+++ b/tests/test_console_api_key_batch.py
@@ -478,6 +478,12 @@ def test_postgres_key_limit_seed_binds_small_limits_as_int8(
     class Result:
         rowcount = 1
 
+        def __init__(self, rows: list[tuple[str, int]] | None = None) -> None:
+            self._rows = rows or []
+
+        def fetchall(self) -> list[tuple[str, int]]:
+            return self._rows
+
     class Connection:
         def __init__(self) -> None:
             self.calls: list[tuple[str, tuple[Any, ...]]] = []
@@ -491,6 +497,8 @@ def test_postgres_key_limit_seed_binds_small_limits_as_int8(
         ) -> Result:
             del prepare
             self.calls.append((sql, params))
+            if sql.startswith("SELECT workspace_id, shard FROM tr_key_limit"):
+                return Result([("ws-int8", 0)])
             return Result()
 
     connection = Connection()
@@ -512,10 +520,12 @@ def test_postgres_key_limit_seed_binds_small_limits_as_int8(
     )
 
     sql, params = next(
-        (sql, params) for sql, params in connection.calls if "INSERT INTO tr_key_limit" in sql
+        (sql, params)
+        for sql, params in connection.calls
+        if sql.startswith("UPDATE tr_key_limit SET") and " limit_micro = %s" in sql
     )
     assert "limit_micro" in sql
-    assert [type(value) for value in (params[2], params[4], params[5], params[6])] == [
+    assert [type(value) for value in (params[0], params[2], params[3], params[4])] == [
         Int8,
         Int8,
         Int8,

--- a/tests/test_credit_ledger_idempotency_audit.py
+++ b/tests/test_credit_ledger_idempotency_audit.py
@@ -204,6 +204,7 @@ def test_mark_gateway_authorization_settled_is_idempotent() -> None:
         usage_type=UsageType.CREDITS,
         estimated_microdollars=100_000,
         credit_reservation_id=None,
+        key_reserved_microdollars=0,
     )
 
     STORE.mark_gateway_authorization_settled(auth.id)
@@ -237,6 +238,7 @@ def test_create_gateway_authorization_dedupes_by_idempotency_key() -> None:
         usage_type=UsageType.CREDITS,
         estimated_microdollars=10_000,
         credit_reservation_id=None,
+        key_reserved_microdollars=0,
         idempotency_key="idk_gw_create_audit_1",
     )
     # Lookup via the explicit dedup path that the gateway route uses.
@@ -266,6 +268,7 @@ def test_finalize_gateway_authorization_returns_false_on_replay() -> None:
         usage_type=UsageType.CREDITS,
         estimated_microdollars=200_000,
         credit_reservation_id=reservation.id,
+        key_reserved_microdollars=0,
     )
 
     first = STORE.finalize_gateway_authorization(

--- a/tests/test_deferred_settlement.py
+++ b/tests/test_deferred_settlement.py
@@ -53,6 +53,7 @@ def _authorize(
     expires_at: str | None = None,
     cap: int | None = CAP,
     idempotency_key: str | None = None,
+    key_reserved_microdollars: int = 0,
 ) -> Any:
     return store.create_gateway_authorization(
         workspace_id=WS,
@@ -62,6 +63,7 @@ def _authorize(
         usage_type="Credits",
         estimated_microdollars=estimate,
         credit_reservation_id=None,
+        key_reserved_microdollars=key_reserved_microdollars,
         idempotency_key=idempotency_key,
         settlement="deferred_home",
         expires_at=expires_at or _in(hours=2),
@@ -269,7 +271,7 @@ def test_byok_selected_settle_releases_the_credits_hold(
         " VALUES (%s, %s, 0, 10000000, 0, 0, 1000000, 0, CURRENT_TIMESTAMP)",
         (WS, KEY),
     )
-    auth = _authorize(store, estimate=1_000_000)
+    auth = _authorize(store, estimate=1_000_000, key_reserved_microdollars=1_000_000)
 
     assert store.finalize_gateway_authorization(
         auth.id, success=True, actual_microdollars=400_000, selected_usage_type="BYOK"
@@ -421,6 +423,7 @@ def test_reaper_ignores_local_authorizations(harness: tuple[Any, Any]) -> None:
         usage_type="Credits",
         estimated_microdollars=1_000_000,
         credit_reservation_id=None,
+        key_reserved_microdollars=0,
     )
     assert local.settlement == "local"
     assert local.expires_at is None

--- a/tests/test_federated_workspace.py
+++ b/tests/test_federated_workspace.py
@@ -233,6 +233,59 @@ class TestPostgresAtomicity:
 
         assert pg_conn.spendable("ws-home-1") == 900_000
 
+    def test_refresh_rejects_extra_limit_shard_without_partial_writes(
+        self, pg_conn: SqlitePostgresConn
+    ) -> None:
+        """A federated cap refresh must not silently update only shard zero.
+
+        Postgres does not implement distributing one key cap across multiple
+        rows.  If an unexpected shard exists, succeeding would leave the
+        stored entity claiming the new cap while the typed rows carry a
+        different aggregate cap.  The layout guard must reject the refresh,
+        and the transaction must roll back the entity writes that happen
+        before that guard.
+        """
+        store = postgres_store_on(pg_conn)
+        store.upsert_federated_api_key(HOME_RECORD)
+        pg_conn.execute(
+            "INSERT INTO tr_key_limit"
+            " (workspace_id, key_hash, shard, limit_micro) VALUES (%s, %s, 1, %s)",
+            (HOME_RECORD["workspace_id"], HOME_RECORD["key_hash"], 125_000),
+        )
+        cap_rows_before = pg_conn.execute(
+            "SELECT shard, limit_micro FROM tr_key_limit"
+            " WHERE workspace_id = %s AND key_hash = %s ORDER BY shard",
+            (HOME_RECORD["workspace_id"], HOME_RECORD["key_hash"]),
+        ).fetchall()
+
+        with pytest.raises(
+            RuntimeError,
+            match=r"shard_count=2, shards=\[0, 1\].*exactly one row at shard 0",
+        ):
+            store.upsert_federated_api_key(
+                {
+                    **HOME_RECORD,
+                    "name": "refreshed name",
+                    "limit_microdollars": 7_000_000,
+                    "workspace_billing_paused": True,
+                    "revision": "2026-08-04T00:00:00Z",
+                }
+            )
+
+        assert pg_conn.execute(
+            "SELECT shard, limit_micro FROM tr_key_limit"
+            " WHERE workspace_id = %s AND key_hash = %s ORDER BY shard",
+            (HOME_RECORD["workspace_id"], HOME_RECORD["key_hash"]),
+        ).fetchall() == cap_rows_before
+        stored_key = store.get_key_by_hash(HOME_RECORD["key_hash"])
+        assert stored_key is not None
+        assert stored_key.name == HOME_RECORD["name"]
+        assert stored_key.limit_microdollars == HOME_RECORD["limit_microdollars"]
+        stored_workspace = store.get_workspace(HOME_RECORD["workspace_id"])
+        assert stored_workspace is not None
+        assert stored_workspace.billing_paused is False
+        assert stored_workspace.federated_home == HOME_RECORD["revision"]
+
 
 # --------------------------------------------------------------------------
 # End to end: the exact bug

--- a/tests/test_gateway_fallback_billing.py
+++ b/tests/test_gateway_fallback_billing.py
@@ -1186,6 +1186,7 @@ def test_gateway_settle_ancient_legacy_reservation_missing_typed_row_is_clean() 
         usage_type="Credits",
         estimated_microdollars=100_000,
         credit_reservation_id="legacy-reservation-never-in-typed",
+        key_reserved_microdollars=0,
         requested_model_id=model.id,
         candidate_model_ids=[model.id],
         region="us-central1",

--- a/tests/test_operational_analytics_outbox_postgres.py
+++ b/tests/test_operational_analytics_outbox_postgres.py
@@ -559,6 +559,7 @@ def _authorization() -> GatewayAuthorization:
         usage_type=UsageType.CREDITS,
         estimated_microdollars=100,
         credit_reservation_id=None,
+        key_reserved_microdollars=0,
     )
 
 

--- a/tests/test_pause_frozen_key_hold.py
+++ b/tests/test_pause_frozen_key_hold.py
@@ -1,0 +1,190 @@
+"""Pause rejection must release only the hold returned by reserve on every backend."""
+
+from typing import Any
+
+import pytest
+
+from tests.fakes.postgres import postgres_store_on, sqlite_postgres_conn
+from tests.fakes.spanner import make_fake_store
+from trusted_router.config import Settings
+from trusted_router.storage import InMemoryStore
+from trusted_router.storage_legacy_trust import BillingPausedError
+from trusted_router.types import UsageType
+
+
+@pytest.mark.parametrize("backend", ["memory", "postgres", "spanner"])
+@pytest.mark.parametrize("capped", [False, True], ids=["uncapped", "capped"])
+@pytest.mark.parametrize("sibling", [False, True], ids=["alone", "sibling"])
+@pytest.mark.parametrize("byok", [False, True], ids=["credits", "byok"])
+def test_pause_reject_releases_frozen_key_hold(
+    backend: str, capped: bool, sibling: bool, byok: bool
+) -> None:
+    store: Any
+    db: Any = None
+    if backend == "spanner":
+        store, db, _ = make_fake_store(request_record_write_mode="legacy")
+    elif backend == "postgres":
+        store = postgres_store_on(sqlite_postgres_conn())
+    else:
+        store = InMemoryStore()
+    store.trust_settings = Settings(environment="test", spend_lease_trust_eligibility_enabled=True)
+    ws = store.create_workspace("owner", "pause-hold", trial_credit_microdollars=1000)
+    _, key = store.create_api_key(
+        workspace_id=ws.id,
+        name="key",
+        creator_user_id="owner",
+        limit_microdollars=1000 if capped else None,
+        include_byok_in_limit=True,
+    )
+    usage = UsageType.BYOK if byok else UsageType.CREDITS
+    hold = store.reserve_key_limit(key.hash, 100, usage_type=usage).reserved_microdollars
+    assert hold == (100 if capped else 0)
+
+    def reserved() -> int:
+        if backend == "postgres":
+            return store._run_transaction(
+                lambda conn: conn.execute(
+                    "SELECT reserved FROM tr_key_limit WHERE key_hash = %s AND shard = 0",
+                    (key.hash,),
+                ).fetchone()[0]
+            )
+        return store.api_keys.get_by_hash(key.hash).reserved_microdollars
+
+    assert reserved() == hold
+    if sibling:
+        # A zero-hold request must not consume headroom owned by a newer request.
+        store.update_key(key.hash, {"limit_microdollars": 1000})
+        assert store.reserve_key_limit(
+            key.hash, 70, usage_type=usage
+        ).reserved_microdollars == 70
+    if capped:
+        # Removing the cap (or excluding BYOK) must not strand an existing hold.
+        store.update_key(key.hash, {"limit_microdollars": None, "include_byok_in_limit": False})
+
+    def pause(paused: bool) -> None:
+        causes = ["abuse"] if paused else []
+        if backend == "memory":
+            store.workspaces[ws.id].billing_pause_causes = causes
+        elif backend == "postgres":
+            store._run_transaction(
+                lambda conn: conn.execute(
+                    "UPDATE tr_credit_balance SET billing_pause_causes = %s WHERE workspace_id = %s",
+                    ('["abuse"]' if paused else "[]", ws.id),
+                )
+            )
+        else:
+            for (workspace_id, _), row in db.typed["tr_credit_balance"].items():
+                if workspace_id == ws.id:
+                    row["billing_pause_causes"] = causes
+
+    pause(True)
+    args = dict(
+        workspace_id=ws.id,
+        key_hash=key.hash,
+        model_id="m",
+        provider="p",
+        usage_type=usage,
+        estimated_microdollars=100,
+        key_reserved_microdollars=hold,
+        credit_reservation_id=None,
+        idempotency_key="paused-hold",
+    )
+    with pytest.raises(BillingPausedError):
+        store.create_gateway_authorization(**args)
+    assert reserved() == (70 if sibling else 0)
+    pause(False)
+    # The terminal marker prevents a replay from releasing the sibling's hold.
+    with pytest.raises(BillingPausedError):
+        store.create_gateway_authorization(**args)
+    assert reserved() == (70 if sibling else 0)
+    with pytest.raises(BillingPausedError):
+        store.get_gateway_authorization_by_idempotency_key(ws.id, key.hash, "paused-hold")
+
+
+def test_spanner_paused_pointer_replay_raises_billing_paused() -> None:
+    store, db, _ = make_fake_store(request_record_write_mode="legacy")
+    store.trust_settings = Settings(environment="test", spend_lease_trust_eligibility_enabled=True)
+    ws = store.create_workspace("owner", "paused-replay", trial_credit_microdollars=1000)
+    _, key = store.create_api_key(workspace_id=ws.id, name="key", creator_user_id="owner")
+    for (workspace_id, _), row in db.typed["tr_credit_balance"].items():
+        if workspace_id == ws.id:
+            row["billing_pause_causes"] = ["abuse"]
+
+    args: dict[str, Any] = dict(
+        workspace_id=ws.id,
+        key_hash=key.hash,
+        model_id="m",
+        provider="p",
+        usage_type=UsageType.CREDITS,
+        estimated_microdollars=100,
+        key_reserved_microdollars=0,
+        credit_reservation_id=None,
+        idempotency_key="paused-replay",
+    )
+    with pytest.raises(BillingPausedError):
+        store.create_gateway_authorization(**args)
+
+    # Resume billing so only the durable terminal pointer can reject the replay.
+    for (workspace_id, _), row in db.typed["tr_credit_balance"].items():
+        if workspace_id == ws.id:
+            row["billing_pause_causes"] = []
+    with pytest.raises(BillingPausedError):
+        store.create_gateway_authorization(**args)
+
+
+@pytest.mark.parametrize("backend", ["memory", "postgres", "spanner"])
+def test_unarmed_pause_is_inert(backend: str) -> None:
+    store: Any
+    db: Any = None
+    if backend == "spanner":
+        store, db, _ = make_fake_store(request_record_write_mode="legacy")
+    elif backend == "postgres":
+        store = postgres_store_on(sqlite_postgres_conn())
+    else:
+        store = InMemoryStore()
+    store.trust_settings = Settings(environment="test", spend_lease_trust_eligibility_enabled=False)
+    ws = store.create_workspace("owner", "unarmed-pause", trial_credit_microdollars=1000)
+    _, key = store.create_api_key(
+        workspace_id=ws.id, name="key", creator_user_id="owner", limit_microdollars=1000
+    )
+    hold = store.reserve_key_limit(
+        key.hash, 100, usage_type=UsageType.CREDITS
+    ).reserved_microdollars
+    assert hold == 100
+    if backend == "memory":
+        store.workspaces[ws.id].billing_pause_causes = ["abuse"]
+    elif backend == "postgres":
+        store._run_transaction(
+            lambda conn: conn.execute(
+                "UPDATE tr_credit_balance SET billing_pause_causes = %s WHERE workspace_id = %s",
+                ('["abuse"]', ws.id),
+            )
+        )
+    else:
+        for (workspace_id, _), row in db.typed["tr_credit_balance"].items():
+            if workspace_id == ws.id:
+                row["billing_pause_causes"] = ["abuse"]
+    authorization = store.create_gateway_authorization(
+        workspace_id=ws.id,
+        key_hash=key.hash,
+        model_id="m",
+        provider="p",
+        usage_type=UsageType.CREDITS,
+        estimated_microdollars=100,
+        key_reserved_microdollars=hold,
+        credit_reservation_id=None,
+        idempotency_key="unarmed-pause",
+    )
+    assert authorization is not None
+    replay = store.get_gateway_authorization_by_idempotency_key(ws.id, key.hash, "unarmed-pause")
+    assert replay is not None and replay.id == authorization.id
+    if backend == "postgres":
+        reserved = store._run_transaction(
+            lambda conn: conn.execute(
+                "SELECT reserved FROM tr_key_limit WHERE key_hash = %s AND shard = 0",
+                (key.hash,),
+            ).fetchone()[0]
+        )
+    else:
+        reserved = store.api_keys.get_by_hash(key.hash).reserved_microdollars
+    assert reserved == hold

--- a/tests/test_postgres_update_key.py
+++ b/tests/test_postgres_update_key.py
@@ -2,22 +2,62 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from tests.fakes.postgres import postgres_store_on, sqlite_postgres_conn
+from trusted_router.spend_windows import KeyLimitExceeded, KeyWindowLimitExceeded
 
 
-def _key_store():
+def _key_store(
+    *,
+    limit_microdollars: int | None = 10,
+    limit_daily_microdollars: int | None = 20,
+    include_byok_in_limit: bool = True,
+    budget_alert_only: bool = False,
+):
     conn = sqlite_postgres_conn()
     store = postgres_store_on(conn)
     _raw, key = store.create_api_key(
         workspace_id="ws-update-key",
         name="before",
         creator_user_id=None,
-        limit_microdollars=10,
-        limit_daily_microdollars=20,
+        limit_microdollars=limit_microdollars,
+        limit_daily_microdollars=limit_daily_microdollars,
+        include_byok_in_limit=include_byok_in_limit,
+        budget_alert_only=budget_alert_only,
     )
     return store, conn, key
+
+
+def _reserved(conn: Any, key_hash: str) -> int:
+    row = conn.execute(
+        "SELECT reserved FROM tr_key_limit WHERE key_hash = %s AND shard = 0",
+        (key_hash,),
+    ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _authorization(
+    store: Any,
+    key: Any,
+    *,
+    usage_type: str,
+    estimated_microdollars: int,
+    key_reserved_microdollars: int,
+):
+    return store.create_gateway_authorization(
+        workspace_id=key.workspace_id,
+        key_hash=key.hash,
+        model_id="test/model",
+        provider="test-provider",
+        usage_type=usage_type,
+        estimated_microdollars=estimated_microdollars,
+        credit_reservation_id=None,
+        key_reserved_microdollars=key_reserved_microdollars,
+    )
 
 
 def _assert_second_shard_cap_patch_is_rejected(store, conn, key) -> None:
@@ -141,6 +181,81 @@ def test_postgres_cap_patch_rejects_multiple_shards_without_changes() -> None:
     assert stored.limit_microdollars == 10
 
 
+def test_postgres_cap_patch_rejects_single_nonzero_shard_without_changes() -> None:
+    """One typed row is insufficient: the only supported layout is shard 0."""
+    store, conn, key = _key_store()
+    conn.execute(
+        "DELETE FROM tr_key_limit WHERE workspace_id = %s AND key_hash = %s",
+        (key.workspace_id, key.hash),
+    )
+    conn.execute(
+        "INSERT INTO tr_key_limit"
+        " (workspace_id, key_hash, shard, limit_micro, include_byok, day_limit_micro)"
+        " VALUES (%s, %s, 1, 7, TRUE, 8)",
+        (key.workspace_id, key.hash),
+    )
+    before = conn.execute(
+        "SELECT shard, limit_micro, include_byok, day_limit_micro"
+        " FROM tr_key_limit WHERE key_hash = %s ORDER BY shard",
+        (key.hash,),
+    ).fetchall()
+
+    with pytest.raises(RuntimeError) as exc_info:
+        store.update_key(key.hash, {"name": "must-roll-back", "limit_microdollars": 99})
+
+    message = str(exc_info.value)
+    assert "shard_count=1" in message
+    assert "shards=[1]" in message
+    assert "exactly one row at shard 0 is required" in message
+    after = conn.execute(
+        "SELECT shard, limit_micro, include_byok, day_limit_micro"
+        " FROM tr_key_limit WHERE key_hash = %s ORDER BY shard",
+        (key.hash,),
+    ).fetchall()
+    assert after == before
+    stored = store.get_key_by_hash(key.hash)
+    assert stored is not None
+    assert stored.name == "before"
+    assert stored.limit_microdollars == 10
+
+
+def test_postgres_cap_patch_rejects_zero_row_guarded_update_atomically(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A row lost after the layout read must not become a false success."""
+    store, conn, key = _key_store()
+    original_execute = conn.execute
+
+    def execute_after_row_vanishes(
+        sql: str,
+        params: tuple[Any, ...] = (),
+        **kwargs: Any,
+    ) -> Any:
+        if sql.startswith("UPDATE tr_key_limit SET") and " limit_micro = %s" in sql:
+            original_execute(
+                "DELETE FROM tr_key_limit WHERE workspace_id = %s AND key_hash = %s",
+                (key.workspace_id, key.hash),
+            )
+        return original_execute(sql, params, **kwargs)
+
+    monkeypatch.setattr(conn, "execute", execute_after_row_vanishes)
+
+    with pytest.raises(RuntimeError, match="cap UPDATE affected 0 rows"):
+        store.update_key(key.hash, {"name": "must-roll-back", "limit_microdollars": 99})
+
+    # The simulated disappearance and the entity patch share the failed
+    # transaction, so rollback must restore the typed row and old JSON entity.
+    rows = conn.execute(
+        "SELECT shard, limit_micro FROM tr_key_limit WHERE key_hash = %s ORDER BY shard",
+        (key.hash,),
+    ).fetchall()
+    assert rows == [(0, 10)]
+    stored = store.get_key_by_hash(key.hash)
+    assert stored is not None
+    assert stored.name == "before"
+    assert stored.limit_microdollars == 10
+
+
 def test_postgres_cap_and_entity_writes_roll_back_together() -> None:
     store, conn, key = _key_store()
     conn.fail_on = "UPDATE tr_key_limit"
@@ -153,3 +268,118 @@ def test_postgres_cap_and_entity_writes_roll_back_together() -> None:
     assert stored is not None
     assert stored.name == "before"
     assert stored.limit_microdollars == 10
+
+
+def test_postgres_settle_uses_frozen_zero_hold_after_uncapped_key_becomes_capped() -> None:
+    """Settling uncapped request A must not release capped request B's hold."""
+    store, conn, key = _key_store(
+        limit_microdollars=None,
+        limit_daily_microdollars=None,
+    )
+    reservation_a = store.reserve_key_limit(key.hash, 100, usage_type="Credits")
+    assert reservation_a.reserved_microdollars == 0
+    authorization_a = _authorization(
+        store,
+        key,
+        usage_type="Credits",
+        estimated_microdollars=100,
+        key_reserved_microdollars=reservation_a.reserved_microdollars,
+    )
+
+    store.update_key(key.hash, {"limit_microdollars": 100})
+    reservation_b = store.reserve_key_limit(key.hash, 100, usage_type="Credits")
+    assert reservation_b.reserved_microdollars == 100
+    assert _reserved(conn, key.hash) == 100
+
+    assert store.finalize_gateway_authorization(
+        authorization_a.id,
+        success=True,
+        actual_microdollars=0,
+        selected_usage_type="Credits",
+    )
+    assert _reserved(conn, key.hash) == 100
+    with pytest.raises(KeyLimitExceeded):
+        store.reserve_key_limit(key.hash, 1, usage_type="Credits")
+
+
+def test_postgres_settle_does_not_release_new_hold_after_byok_becomes_included() -> None:
+    """A BYOK-excluded request records zero even if the flag later flips."""
+    store, conn, key = _key_store(
+        limit_microdollars=100,
+        limit_daily_microdollars=None,
+        include_byok_in_limit=False,
+    )
+    reservation_a = store.reserve_key_limit(key.hash, 100, usage_type="BYOK")
+    assert reservation_a.reserved_microdollars == 0
+    authorization_a = _authorization(
+        store,
+        key,
+        usage_type="BYOK",
+        estimated_microdollars=100,
+        key_reserved_microdollars=reservation_a.reserved_microdollars,
+    )
+
+    store.update_key(key.hash, {"include_byok_in_limit": True})
+    reservation_b = store.reserve_key_limit(key.hash, 100, usage_type="Credits")
+    assert reservation_b.reserved_microdollars == 100
+
+    assert store.finalize_gateway_authorization(
+        authorization_a.id,
+        success=False,
+        actual_microdollars=0,
+        selected_usage_type="BYOK",
+    )
+    assert _reserved(conn, key.hash) == 100
+    with pytest.raises(KeyLimitExceeded):
+        store.reserve_key_limit(key.hash, 1, usage_type="Credits")
+
+
+def test_postgres_settle_releases_frozen_byok_hold_after_byok_becomes_excluded() -> None:
+    """A BYOK hold already taken must release after the flag flips off."""
+    store, conn, key = _key_store(
+        limit_microdollars=100,
+        limit_daily_microdollars=None,
+        include_byok_in_limit=True,
+    )
+    reservation_a = store.reserve_key_limit(key.hash, 100, usage_type="BYOK")
+    assert reservation_a.reserved_microdollars == 100
+    authorization_a = _authorization(
+        store,
+        key,
+        usage_type="BYOK",
+        estimated_microdollars=100,
+        key_reserved_microdollars=reservation_a.reserved_microdollars,
+    )
+    assert _reserved(conn, key.hash) == 100
+
+    store.update_key(key.hash, {"include_byok_in_limit": False})
+    assert store.finalize_gateway_authorization(
+        authorization_a.id,
+        success=False,
+        actual_microdollars=0,
+        selected_usage_type="BYOK",
+    )
+    assert _reserved(conn, key.hash) == 0
+    reservation_c = store.reserve_key_limit(key.hash, 100, usage_type="Credits")
+    assert reservation_c.reserved_microdollars == 100
+
+
+def test_postgres_alert_only_bypasses_window_block_but_keeps_lifetime_hold() -> None:
+    store, conn, key = _key_store(
+        limit_microdollars=100,
+        limit_daily_microdollars=0,
+        budget_alert_only=True,
+    )
+
+    reservation = store.reserve_key_limit(key.hash, 60, usage_type="Credits")
+
+    assert reservation.window_decision is None
+    assert reservation.reserved_microdollars == 60
+    assert _reserved(conn, key.hash) == 60
+    with pytest.raises(KeyLimitExceeded):
+        store.reserve_key_limit(key.hash, 41, usage_type="Credits")
+
+    # The zero daily cap remains authoritative when alert-only is disabled.
+    store.update_key(key.hash, {"budget_alert_only": False})
+    with pytest.raises(KeyWindowLimitExceeded):
+        store.reserve_key_limit(key.hash, 1, usage_type="Credits")

--- a/tests/test_postgres_update_key.py
+++ b/tests/test_postgres_update_key.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -243,27 +244,44 @@ def test_postgres_cap_patch_rejects_zero_row_guarded_update_atomically(
     with pytest.raises(RuntimeError, match="cap UPDATE affected 0 rows"):
         store.update_key(key.hash, {"name": "must-roll-back", "limit_microdollars": 99})
 
-    # The simulated disappearance and the entity patch share the failed
-    # transaction, so rollback must restore the typed row and old JSON entity.
+    # Both changes happened inside the failed transaction. Inspect the entity
+    # first so disabling transactions specifically fails the JSON rollback check.
+    stored = store.get_key_by_hash(key.hash)
+    assert stored is not None
+    assert stored.name == "before"
+    assert stored.limit_microdollars == 10
     rows = conn.execute(
         "SELECT shard, limit_micro FROM tr_key_limit WHERE key_hash = %s ORDER BY shard",
         (key.hash,),
     ).fetchall()
     assert rows == [(0, 10)]
-    stored = store.get_key_by_hash(key.hash)
-    assert stored is not None
-    assert stored.name == "before"
-    assert stored.limit_microdollars == 10
 
 
-def test_postgres_cap_and_entity_writes_roll_back_together() -> None:
+def test_postgres_cap_and_entity_writes_roll_back_together(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     store, conn, key = _key_store()
-    conn.fail_on = "UPDATE tr_key_limit"
+    original_execute = conn.execute
+    observed_partial_write = False
+
+    def fail_typed_write(sql: str, params: tuple[Any, ...] = (), **kwargs: Any) -> Any:
+        nonlocal observed_partial_write
+        if sql.startswith("UPDATE tr_key_limit SET"):
+            row = original_execute(
+                "SELECT body FROM tr_entities WHERE kind = %s AND id = %s",
+                ("api_key", key.hash),
+            ).fetchone()
+            assert json.loads(row[0])["name"] == "must-roll-back"
+            observed_partial_write = True
+            raise RuntimeError("connection reset mid-transaction")
+        return original_execute(sql, params, **kwargs)
+
+    monkeypatch.setattr(conn, "execute", fail_typed_write)
 
     with pytest.raises(RuntimeError, match="connection reset"):
         store.update_key(key.hash, {"name": "must-roll-back", "limit_microdollars": 99})
 
-    conn.fail_on = None
+    assert observed_partial_write
     stored = store.get_key_by_hash(key.hash)
     assert stored is not None
     assert stored.name == "before"
@@ -383,3 +401,70 @@ def test_postgres_alert_only_bypasses_window_block_but_keeps_lifetime_hold() -> 
     store.update_key(key.hash, {"budget_alert_only": False})
     with pytest.raises(KeyWindowLimitExceeded):
         store.reserve_key_limit(key.hash, 1, usage_type="Credits")
+
+
+@pytest.mark.parametrize("success", [True, False])
+@pytest.mark.parametrize("frozen", ["absent", 0])
+def test_postgres_legacy_missing_hold_differs_from_frozen_zero(success, frozen) -> None:
+    store, conn, key = _key_store(limit_microdollars=100, limit_daily_microdollars=None)
+    store.reserve_key_limit(key.hash, 100, usage_type="Credits")
+    auth = _authorization(
+        store, key, usage_type="Credits", estimated_microdollars=100,
+        key_reserved_microdollars=0,
+    )
+    if frozen != 0:
+        body = json.loads(conn.execute(
+            "SELECT body FROM tr_entities WHERE kind = %s AND id = %s",
+            ("gateway_authorization", auth.id),
+        ).fetchone()[0])
+        body.pop("key_reserved_microdollars")
+        conn.execute(
+            "UPDATE tr_entities SET body = %s WHERE kind = %s AND id = %s",
+            (json.dumps(body), "gateway_authorization", auth.id),
+        )
+    assert store.finalize_gateway_authorization(
+        auth.id, success=success, actual_microdollars=0, selected_usage_type="Credits",
+    )
+    assert _reserved(conn, key.hash) == (0 if frozen == "absent" else 100)
+
+
+def test_postgres_gateway_authorize_freezes_uncapped_hold() -> None:
+    from starlette.requests import Request
+
+    from trusted_router.config import Settings
+    from trusted_router.routes.internal import gateway
+    from trusted_router.schemas import GatewayAuthorizeRequest
+    from trusted_router.storage import CreditAccount, Workspace, configure_store
+
+    store, conn, key = _key_store(limit_microdollars=None, limit_daily_microdollars=None)
+    store._write_entity_tx(conn, "workspace", key.workspace_id, Workspace(
+        id=key.workspace_id, name="test", owner_user_id="user-test",
+    ))
+    store._write_entity_tx(conn, "credit", key.workspace_id, CreditAccount(
+        workspace_id=key.workspace_id,
+    ))
+    conn.execute(
+        "INSERT INTO tr_credit_balance (workspace_id, shard, total_credits)"
+        " VALUES (%s, 0, 1000000)", (key.workspace_id,),
+    )
+    configure_store(store)
+    response = gateway._authorize_gateway_sync(
+        Request({"type": "http", "method": "POST", "path": "/", "headers": []}),
+        GatewayAuthorizeRequest(
+            api_key_hash=key.hash, idempotency_key="frozen-hold-route",
+            model="anthropic/claude-haiku-4.5",
+            estimated_input_tokens=100, max_output_tokens=100,
+        ),
+        Settings(environment="test"),
+    )
+    auth_id = response["data"]["authorization_id"]
+    auth = store.get_gateway_authorization(auth_id)
+    store.update_key(key.hash, {"limit_microdollars": 100})
+    store.reserve_key_limit(key.hash, 100, usage_type="Credits")
+    assert store.finalize_gateway_authorization(
+        auth_id, success=True, actual_microdollars=0, selected_usage_type="Credits",
+    )
+    assert _reserved(conn, key.hash) == 100
+    with pytest.raises(KeyLimitExceeded):
+        store.reserve_key_limit(key.hash, 1, usage_type="Credits")
+    assert auth.key_reserved_microdollars == 0

--- a/tests/test_postgres_update_key.py
+++ b/tests/test_postgres_update_key.py
@@ -428,6 +428,90 @@ def test_postgres_legacy_missing_hold_differs_from_frozen_zero(success, frozen) 
     assert _reserved(conn, key.hash) == (0 if frozen == "absent" else 100)
 
 
+def _remove_frozen_hold(conn: Any, authorization_id: str) -> None:
+    """Persist the pre-rollout shape, with the frozen field absent entirely."""
+    body = json.loads(conn.execute(
+        "SELECT body FROM tr_entities WHERE kind = %s AND id = %s",
+        ("gateway_authorization", authorization_id),
+    ).fetchone()[0])
+    body.pop("key_reserved_microdollars")
+    conn.execute(
+        "UPDATE tr_entities SET body = %s WHERE kind = %s AND id = %s",
+        (json.dumps(body), "gateway_authorization", authorization_id),
+    )
+
+
+def test_postgres_legacy_hold_releases_after_cap_removed_and_can_recap() -> None:
+    store, conn, key = _key_store(limit_microdollars=100, limit_daily_microdollars=None)
+    reservation = store.reserve_key_limit(key.hash, 100, usage_type="Credits")
+    assert reservation.reserved_microdollars == 100
+    auth = _authorization(
+        store, key, usage_type="Credits", estimated_microdollars=100,
+        key_reserved_microdollars=100,
+    )
+    _remove_frozen_hold(conn, auth.id)
+    store.update_key(key.hash, {"limit_microdollars": None})
+    assert _reserved(conn, key.hash) == 100
+
+    assert store.finalize_gateway_authorization(
+        auth.id, success=True, actual_microdollars=0, selected_usage_type="Credits",
+    )
+    assert _reserved(conn, key.hash) == 0
+    store.update_key(key.hash, {"limit_microdollars": 100})
+    assert store.reserve_key_limit(key.hash, 1, usage_type="Credits").reserved_microdollars == 1
+
+
+def test_postgres_legacy_cap_removed_byok_release_depends_only_on_inclusion() -> None:
+    # Legacy behavior deliberately retains a BYOK hold if inclusion flips off.
+    # Pair it with the included case: removing the cap alone must still release.
+    for include_byok, expected_reserved in [(False, 100), (True, 0)]:
+        store, conn, key = _key_store(limit_microdollars=100, limit_daily_microdollars=None)
+        reservation = store.reserve_key_limit(key.hash, 100, usage_type="BYOK")
+        assert reservation.reserved_microdollars == 100
+        auth = _authorization(
+            store, key, usage_type="BYOK", estimated_microdollars=100,
+            key_reserved_microdollars=100,
+        )
+        _remove_frozen_hold(conn, auth.id)
+        store.update_key(key.hash, {
+            "limit_microdollars": None, "include_byok_in_limit": include_byok,
+        })
+        assert _reserved(conn, key.hash) == 100
+
+        assert store.finalize_gateway_authorization(
+            auth.id, success=True, actual_microdollars=0, selected_usage_type="BYOK",
+        )
+        assert _reserved(conn, key.hash) == expected_reserved
+
+
+def test_postgres_cap_removed_frozen_zero_preserves_legacy_sibling_hold() -> None:
+    store, conn, key = _key_store(limit_microdollars=None, limit_daily_microdollars=None)
+    reservation = store.reserve_key_limit(key.hash, 100, usage_type="Credits")
+    assert reservation.reserved_microdollars == 0
+    frozen = _authorization(
+        store, key, usage_type="Credits", estimated_microdollars=100,
+        key_reserved_microdollars=0,
+    )
+    store.update_key(key.hash, {"limit_microdollars": 100})
+    assert store.reserve_key_limit(key.hash, 100, usage_type="Credits").reserved_microdollars == 100
+    legacy = _authorization(
+        store, key, usage_type="Credits", estimated_microdollars=100,
+        key_reserved_microdollars=100,
+    )
+    _remove_frozen_hold(conn, legacy.id)
+    store.update_key(key.hash, {"limit_microdollars": None})
+
+    assert store.finalize_gateway_authorization(
+        frozen.id, success=True, actual_microdollars=0, selected_usage_type="Credits",
+    )
+    assert _reserved(conn, key.hash) == 100
+    # Identical estimates and current caps; only field presence differs.
+    assert store.finalize_gateway_authorization(
+        legacy.id, success=True, actual_microdollars=0, selected_usage_type="Credits",
+    )
+    assert _reserved(conn, key.hash) == 0
+
+
 def test_postgres_gateway_authorize_freezes_uncapped_hold() -> None:
     from starlette.requests import Request
 

--- a/tests/test_settle_books_usage_always.py
+++ b/tests/test_settle_books_usage_always.py
@@ -56,7 +56,9 @@ def _balance_row(conn: Any) -> dict[str, int] | None:
     return {"total_credits": row[0], "total_usage": row[1], "reserved": row[2]}
 
 
-def _authorize_with_reservation(store: Any, estimate: int) -> Any:
+def _authorize_with_reservation(
+    store: Any, estimate: int, *, key_reserved_microdollars: int = 0
+) -> Any:
     reservation = store.reserve(WS, KEY, estimate)
     return store.create_gateway_authorization(
         workspace_id=WS,
@@ -66,6 +68,7 @@ def _authorize_with_reservation(store: Any, estimate: int) -> Any:
         usage_type="Credits",
         estimated_microdollars=estimate,
         credit_reservation_id=reservation.id,
+        key_reserved_microdollars=key_reserved_microdollars,
     )
 
 
@@ -187,8 +190,12 @@ def test_local_settle_releases_hold_under_the_reserved_type(
         " VALUES (%s, %s, 0, 10000000, 0, 0, 0, 0, CURRENT_TIMESTAMP)",
         (WS, KEY),
     )
-    store.reserve_key_limit(KEY, 100, usage_type="Credits")
-    auth = _authorize_with_reservation(store, estimate=100)
+    key_reservation = store.reserve_key_limit(KEY, 100, usage_type="Credits")
+    auth = _authorize_with_reservation(
+        store,
+        estimate=100,
+        key_reserved_microdollars=key_reservation.reserved_microdollars,
+    )
 
     assert store.finalize_gateway_authorization(
         auth.id, success=True, actual_microdollars=40, selected_usage_type="BYOK"

--- a/tests/test_settle_outbox_apply.py
+++ b/tests/test_settle_outbox_apply.py
@@ -215,7 +215,7 @@ def _legacy_authorization(
     if credit is not None:
         credit["reserved_microdollars"] = int(credit.get("reserved_microdollars", 0)) + estimate
         store._write_entity("credit", workspace_id, credit)
-    store.reserve_key_limit(key_hash, estimate, usage_type="Credits")
+    key_reservation = store.reserve_key_limit(key_hash, estimate, usage_type="Credits")
     return store.create_gateway_authorization(
         workspace_id=workspace_id,
         key_hash=key_hash,
@@ -224,6 +224,7 @@ def _legacy_authorization(
         usage_type="Credits",
         estimated_microdollars=estimate,
         credit_reservation_id=reservation_id,
+        key_reserved_microdollars=key_reservation.reserved_microdollars,
         requested_model_id=MODEL_ID,
         candidate_model_ids=[MODEL_ID],
         region="us",

--- a/tests/test_settle_outbox_drain.py
+++ b/tests/test_settle_outbox_drain.py
@@ -241,7 +241,7 @@ def _legacy_authorization(
     if credit is not None:
         credit["reserved_microdollars"] = int(credit.get("reserved_microdollars", 0)) + estimate
         store._write_entity("credit", workspace_id, credit)
-    store.reserve_key_limit(key_hash, estimate, usage_type="Credits")
+    key_reservation = store.reserve_key_limit(key_hash, estimate, usage_type="Credits")
     return store.create_gateway_authorization(
         workspace_id=workspace_id,
         key_hash=key_hash,
@@ -250,6 +250,7 @@ def _legacy_authorization(
         usage_type="Credits",
         estimated_microdollars=estimate,
         credit_reservation_id=reservation_id,
+        key_reserved_microdollars=key_reservation.reserved_microdollars,
         requested_model_id=MODEL_ID,
         candidate_model_ids=[MODEL_ID],
         region="us",

--- a/tests/test_storage_gcp.py
+++ b/tests/test_storage_gcp.py
@@ -262,6 +262,7 @@ def test_gcp_read_gateway_authorization_ignores_unknown_dataclass_fields() -> No
         usage_type="Credits",
         estimated_microdollars=123,
         credit_reservation_id="res_1",
+        key_reserved_microdollars=0,
         requested_model_id="anthropic/claude-haiku-4.5",
         candidate_model_ids=["anthropic/claude-haiku-4.5"],
         region="us",

--- a/tests/test_storage_gcp_features.py
+++ b/tests/test_storage_gcp_features.py
@@ -409,6 +409,7 @@ def test_gcp_gateway_authorization_create_get_and_mark_settled() -> None:
         usage_type="Credits",
         estimated_microdollars=1_000,
         credit_reservation_id=None,
+        key_reserved_microdollars=0,
         requested_model_id="trustedrouter/auto",
         candidate_model_ids=["openai/gpt-5.4-nano", "mistralai/mistral-small-2603"],
         region="us-central1",

--- a/tests/test_storage_gcp_features.py
+++ b/tests/test_storage_gcp_features.py
@@ -522,3 +522,21 @@ def test_gcp_rate_limit_increments_in_same_window_and_rolls_over() -> None:
     assert third.retry_after_seconds > 0
     assert next_window.allowed is True
     assert next_window.remaining == 1
+
+
+def test_gcp_zero_key_hold_never_mutates_api_key() -> None:
+    for limit, include_byok, usage_type in [(None, True, "Credits"), (100, False, "BYOK")]:
+        store, db, _ = make_fake_store()
+        workspace_id, _ = _seed_workspace_and_key(store)
+        _, key = store.create_api_key(
+            workspace_id=workspace_id, name="zero-hold", creator_user_id=None,
+            limit_microdollars=limit, include_byok_in_limit=include_byok,
+        )
+        version = db.rows[("api_key", key.hash)].version
+        hold = store.reserve_key_limit(key.hash, 100, usage_type=usage_type)
+        assert hold.reserved_microdollars == 0
+        assert db.rows[("api_key", key.hash)].version == version
+        store.settle_key_limit(key.hash, hold.reserved_microdollars, 0, usage_type=usage_type)
+        assert db.rows[("api_key", key.hash)].version == version
+        store.refund_key_limit(key.hash, hold.reserved_microdollars, usage_type=usage_type)
+        assert db.rows[("api_key", key.hash)].version == version


### PR DESCRIPTION
Follow-up to #1084, which was merged on 2026-09-05 at its round-1 state — before the eight adversarial review rounds that followed. Every subsequent push landed on the already-merged branch (CI ran on it and stayed green), so none of the fixes below are on main. The AWS/Azure planes have been running round-1 `update_key` since then. This PR is rounds 2–8, rebased on current main.

**What round 1 shipped without:**
- **Hold freeze.** `reserve_key_limit` records no hold when a key is uncapped, but settlement subtracted the estimate using *current* configuration. Reproduced: authorize while uncapped, set a cap of 100, another request reserves 100, the first settles and refunds a hold it never took — 200 outstanding under a cap of 100. The hold is now frozen at reserve on Postgres as it is on Spanner, and the gateway→store wiring has a failing test.
- **Cap-write guard.** Caps are distributed sub-budgets (prod: entity `30000000`, 16 shard rows summing to exactly `30000000`); round 1 wrote the full cap to every shard row. Every cap write now goes through one guarded helper: exactly one row at shard 0, raise before any write otherwise, rowcount asserted.
- **Legacy fallback.** A pre-deploy authorization with no frozen field settles by today's computation; treating "absent" as zero stranded holds with no reconciliation.
- **Spanner byte-identical.** A zero-hold settle no longer writes the hot `api_key` row (the review caught round 2 adding a write per notification).
- **Billing-pause path (#1102/#1113/#1119).** The pause guard refunded the *estimate*; it now refunds the frozen hold on all three backends, main's 103 trust tests unchanged. Those tests exposed a pre-existing #1119 defect: replaying a `billing_paused` pointer on Spanner didn't forward the arm flag and raised `KeyError`; the flag is now forwarded.
- **Rollout hazard.** `budget_alert_only` is honoured on the Postgres reserve path; an unarmed pause is pinned as inert per backend.

Every fix above fails its tests when reverted (verified by mutation, not by inspection). Full suite **9492 passed, 0 failed** on this tree; CI green on the branch at `e9e43430`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)