### PR TITLE
Schedule Crusoe September 12 serverless retirements

### DIFF
--- a/scripts/pricing/model_ids.py
+++ b/scripts/pricing/model_ids.py
@@ -16,6 +16,7 @@ _AUTHOR_ALIASES = {
     "minimaxai": "minimax",
     "moonshotai": "moonshotai",
     "qwen": "qwen",
+    "zai": "z-ai",
     "zai-org": "z-ai",
     "zhipuai": "z-ai",
     "zhipu-ai": "z-ai",

--- a/src/trusted_router/data/provider_models/crusoe.json
+++ b/src/trusted_router/data/provider_models/crusoe.json
@@ -8,6 +8,8 @@
   "models": [
     {
       "id": "deepseek/deepseek-v3-0324",
+      "retirement_at": "2026-09-13T04:00:00Z",
+      "replacement_model_id": "deepseek/deepseek-v4-pro",
       "upstream_id": "deepseek-ai/DeepSeek-V3-0324",
       "display_name": "deepseek-ai/DeepSeek-V3-0324",
       "title": "deepseek-ai/DeepSeek-V3-0324",
@@ -202,6 +204,8 @@
     },
     {
       "id": "meta-llama/llama-3.3-70b-instruct",
+      "retirement_at": "2026-09-13T04:00:00Z",
+      "replacement_model_id": "deepseek/deepseek-v4-flash",
       "upstream_id": "meta-llama/Llama-3.3-70B-Instruct",
       "display_name": "meta-llama/Llama-3.3-70B-Instruct",
       "title": "meta-llama/Llama-3.3-70B-Instruct",
@@ -542,6 +546,8 @@
     },
     {
       "id": "qwen/qwen3-235b-a22b-2507",
+      "retirement_at": "2026-09-13T04:00:00Z",
+      "replacement_model_id": "deepseek/deepseek-v4-flash",
       "upstream_id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
       "display_name": "Qwen/Qwen3-235B-A22B-Instruct-2507",
       "title": "Qwen/Qwen3-235B-A22B-Instruct-2507",
@@ -638,6 +644,8 @@
     },
     {
       "id": "z-ai/glm-5.1",
+      "retirement_at": "2026-09-13T04:00:00Z",
+      "replacement_model_id": "z-ai/glm-5.3",
       "upstream_id": "zai/GLM-5.1",
       "display_name": "zai/GLM-5.1",
       "title": "zai/GLM-5.1",
@@ -686,6 +694,8 @@
     },
     {
       "id": "z-ai/glm-5.2",
+      "retirement_at": "2026-09-13T04:00:00Z",
+      "replacement_model_id": "z-ai/glm-5.3",
       "upstream_id": "zai/GLM-5.2",
       "display_name": "zai/GLM-5.2",
       "title": "zai/GLM-5.2",

--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -33,6 +33,7 @@ PARASAIL_AUGUST_2026_RETIREMENT_AT = datetime(2026, 8, 4, 0, 0, tzinfo=UTC)
 FRIENDLI_QWEN3_235B_RETIREMENT_AT = datetime(2026, 8, 5, 0, 0, tzinfo=UTC)
 FRIENDLI_K_EXAONE_236B_RETIREMENT_AT = datetime(2026, 8, 20, 0, 0, tzinfo=UTC)
 CRUSOE_NEMOTRON_3_ULTRA_RETIREMENT_AT = datetime(2026, 7, 28, 18, 0, tzinfo=UTC)
+CRUSOE_SEPTEMBER_2026_RETIREMENT_AT = datetime(2026, 9, 13, 4, 0, tzinfo=UTC)
 WAFER_AUGUST_2026_RETIREMENT_AT = datetime(2026, 8, 17, 0, 0, tzinfo=UTC)
 WAFER_GLM52_RETIREMENT_AT = datetime(2026, 9, 5, 6, 59, tzinfo=UTC)
 DEEPINFRA_TERMINUS_RETIREMENT_AT = datetime(2026, 8, 17, 0, 0, tzinfo=UTC)
@@ -442,6 +443,28 @@ _RETIREMENTS = (
         model_ids=frozenset({"nvidia/nemotron-3-ultra-550b"}),
         upstream_ids=frozenset({"nvidia/NVIDIA-Nemotron-3-Ultra-550B"}),
         effective_at=CRUSOE_NEMOTRON_3_ULTRA_RETIREMENT_AT,
+    ),
+    # Crusoe's Serverless cutoff is September 12 at 21:00 Pacific daylight
+    # time (UTC-7), hence September 13 at 04:00 UTC. Match only the announced
+    # checkpoints; keep other providers and dedicated deployments untouched.
+    # Replacements are migration guidance, never silent routing aliases.
+    _Retirement(
+        provider="crusoe",
+        model_ids=frozenset({
+            "z-ai/glm-5.1",
+            "z-ai/glm-5.2",
+            "deepseek/deepseek-v3-0324",
+            "qwen/qwen3-235b-a22b-2507",
+            "meta-llama/llama-3.3-70b-instruct",
+        }),
+        upstream_ids=frozenset({
+            "zai/GLM-5.1",
+            "zai/GLM-5.2",
+            "deepseek-ai/DeepSeek-V3-0324",
+            "Qwen/Qwen3-235B-A22B-Instruct-2507",
+            "meta-llama/Llama-3.3-70B-Instruct",
+        }),
+        effective_at=CRUSOE_SEPTEMBER_2026_RETIREMENT_AT,
     ),
     # Baseten announced that these Model API routes become inactive at
     # 2026-07-24 17:00 PT, which is 2026-07-25 00:00 UTC. Dedicated

--- a/tests/test_crusoe_pricing.py
+++ b/tests/test_crusoe_pricing.py
@@ -24,7 +24,7 @@ def test_crusoe_fetch_discovers_prices_and_native_ids(monkeypatch) -> None:  # n
     payload = {
         "data": [
             {
-                "id": "zai/GLM-5.2",
+                "id": "zai/GLM-5.3",
                 "pricing": {
                     "prompt": "1.40",
                     "completion": "4.40",
@@ -74,14 +74,14 @@ def test_crusoe_fetch_discovers_prices_and_native_ids(monkeypatch) -> None:  # n
     monkeypatch.setattr(crusoe.httpx, "Client", FakeClient)
 
     result = crusoe.fetch()
-    glm = result.prices["z-ai/glm-5.2"]
+    glm = result.prices["z-ai/glm-5.3"]
     flash = result.prices["deepseek/deepseek-v4-flash"]
 
     assert glm.prompt_micro_per_m == 1_400_000
     assert glm.completion_micro_per_m == 4_400_000
     assert glm.tiers[0].prompt_cached_micro_per_m == 260_000
     assert flash.prompt_micro_per_m == 140_000
-    assert crusoe.UPSTREAM_ID_MAP["z-ai/glm-5.2"] == "zai/GLM-5.2"
+    assert crusoe.UPSTREAM_ID_MAP["z-ai/glm-5.3"] == "zai/GLM-5.3"
     assert (
         crusoe.UPSTREAM_ID_MAP["deepseek/deepseek-v4-flash"]
         == "deepseek-ai/Deepseek-V4-Flash"

--- a/tests/test_crusoe_september_2026_lifecycle.py
+++ b/tests/test_crusoe_september_2026_lifecycle.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import httpx
+import pytest
+
+from scripts.pricing import refresh
+from scripts.pricing.base import ModelPrice, ProviderPricingResult
+from scripts.pricing.providers import crusoe
+from trusted_router import catalog, provider_lifecycle
+from trusted_router.catalog_data import ModelEndpoint
+
+_CUTOFF = datetime(2026, 9, 13, 4, tzinfo=UTC)
+_RETIRING = (
+    ("z-ai/glm-5.1", "zai/GLM-5.1", "z-ai/glm-5.3"),
+    ("z-ai/glm-5.2", "zai/GLM-5.2", "z-ai/glm-5.3"),
+    ("deepseek/deepseek-v3-0324", "deepseek-ai/DeepSeek-V3-0324", "deepseek/deepseek-v4-pro"),
+    ("qwen/qwen3-235b-a22b-2507", "Qwen/Qwen3-235B-A22B-Instruct-2507", "deepseek/deepseek-v4-flash"),
+    ("meta-llama/llama-3.3-70b-instruct", "meta-llama/Llama-3.3-70B-Instruct", "deepseek/deepseek-v4-flash"),
+)
+_REPLACEMENTS = {
+    "z-ai/glm-5.3": "zai/GLM-5.3",
+    "deepseek/deepseek-v4-pro": "deepseek-ai/DeepSeek-V4-Pro",
+    "deepseek/deepseek-v4-flash": "deepseek-ai/Deepseek-V4-Flash",
+}
+
+
+def test_crusoe_cutoff_matches_announced_pacific_time() -> None:
+    announced = datetime(2026, 9, 12, 21, tzinfo=ZoneInfo("America/Los_Angeles"))
+    assert announced.astimezone(UTC) == _CUTOFF
+    assert provider_lifecycle.CRUSOE_SEPTEMBER_2026_RETIREMENT_AT == _CUTOFF
+
+
+@pytest.mark.parametrize(("model_id", "native_id", "replacement"), _RETIRING)
+def test_crusoe_exact_cutoff_and_provider_scope(
+    model_id: str, native_id: str, replacement: str,
+) -> None:
+    retired = provider_lifecycle.provider_model_retired
+    assert not retired("crusoe", model_id, native_id, at=_CUTOFF - timedelta(microseconds=1))
+    assert retired("crusoe", model_id, at=_CUTOFF)
+    assert retired("crusoe", "other-canonical-id", native_id, at=_CUTOFF)
+    assert not retired("novita", model_id, native_id, at=_CUTOFF)
+    assert not retired("crusoe", replacement, _REPLACEMENTS[replacement], at=_CUTOFF)
+
+
+@pytest.mark.parametrize(("model_id", "native_id", "_replacement"), _RETIRING)
+def test_crusoe_runtime_cutoff_without_catalog_reload(
+    monkeypatch: pytest.MonkeyPatch, model_id: str, native_id: str, _replacement: str,
+) -> None:
+    # Isolate the clock gate from independently changing discovery manifests.
+    endpoints = {}
+    for provider in ("crusoe", "novita"):
+        for usage in ("Credits", "BYOK"):
+            endpoint = ModelEndpoint(
+                id=f"{model_id}@{provider}/{usage}", model_id=model_id,
+                provider=provider, usage_type=usage, upstream_id=native_id,
+            )
+            endpoints[endpoint.id] = endpoint
+    monkeypatch.setattr(catalog, "MODEL_ENDPOINTS", endpoints)
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF - timedelta(microseconds=1))
+    assert len(catalog.endpoints_for_model(model_id)) == 4
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    after = catalog.endpoints_for_model(model_id)
+    assert len(after) == 2
+    assert {endpoint.provider for endpoint in after} == {"novita"}
+    assert {endpoint.model_id for endpoint in after} == {model_id}
+
+
+def test_crusoe_refresh_cannot_restore_retired_prices(monkeypatch: pytest.MonkeyPatch) -> None:
+    retiring = {model for model, _native, _replacement in _RETIRING}
+    result = ProviderPricingResult(
+        slug="crusoe", source="api", fetched_url=crusoe.URL,
+        prices={model: ModelPrice(1_000_000, 2_000_000) for model in retiring | _REPLACEMENTS.keys()},
+    )
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF - timedelta(microseconds=1))
+    before = refresh._index_provider_prices({"crusoe": result})
+    assert retiring <= before.keys()
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    after = refresh._index_provider_prices({"crusoe": result})
+    assert set(after) == set(_REPLACEMENTS)
+
+
+@pytest.mark.parametrize("after_cutoff", [False, True])
+def test_crusoe_parser_and_manifest_cannot_rediscover_retired_models(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, after_cutoff: bool,
+) -> None:
+    native_ids = [native for _model, native, _replacement in _RETIRING] + list(_REPLACEMENTS.values())
+    payload = {"data": [
+        {"id": native, "pricing": {"prompt": "1.40", "completion": "4.40", "input_cache_reads": "0.26"}}
+        for native in native_ids
+    ]}
+    monkeypatch.setattr(
+        crusoe.httpx, "HTTPTransport",
+        lambda **_: httpx.MockTransport(lambda request: httpx.Response(200, json=payload)),
+    )
+    monkeypatch.setattr(crusoe, "UPSTREAM_ID_MAP", dict(crusoe.UPSTREAM_ID_MAP))
+    monkeypatch.setattr(crusoe, "_DISCOVERED_MANIFEST_ROWS", {})
+    monkeypatch.setattr(crusoe, "_LIVE_CANARY_OK", True)
+    monkeypatch.setattr(crusoe, "MANIFEST_PATH", tmp_path / "crusoe.json")
+    monkeypatch.setattr(
+        provider_lifecycle, "_utc_now",
+        lambda: _CUTOFF if after_cutoff else _CUTOFF - timedelta(microseconds=1),
+    )
+    result = crusoe.fetch()
+    expected = set(_REPLACEMENTS)
+    if not after_cutoff:
+        expected.update(model for model, _native, _replacement in _RETIRING)
+    assert set(result.prices) == expected
+    assert set(crusoe._DISCOVERED_MANIFEST_ROWS) == expected
+    for model_id, native_id, _replacement in _RETIRING:
+        if not after_cutoff:
+            assert crusoe._DISCOVERED_MANIFEST_ROWS[model_id]["upstream_id"] == native_id
+    crusoe.write_provider_manifest(result)
+    rows = json.loads(crusoe.MANIFEST_PATH.read_text())["models"]
+    assert {row["id"] for row in rows} == expected
+
+
+def test_crusoe_manifest_records_announced_migrations() -> None:
+    rows = {row["id"]: row for row in json.loads(crusoe.MANIFEST_PATH.read_text())["models"]}
+    for model_id, native_id, replacement in _RETIRING:
+        assert rows[model_id]["upstream_id"] == native_id
+        assert rows[model_id]["retirement_at"] == "2026-09-13T04:00:00Z"
+        assert rows[model_id]["replacement_model_id"] == replacement
+
+
+def test_crusoe_retirement_does_not_match_unannounced_models() -> None:
+    for model_id in ("z-ai/glm-5.3-flash", "deepseek/deepseek-v3.2", "openai/gpt-oss-120b"):
+        assert not provider_lifecycle.provider_model_retired("crusoe", model_id, at=_CUTOFF)

--- a/tests/test_friendli_august_2026_lifecycle.py
+++ b/tests/test_friendli_august_2026_lifecycle.py
@@ -8,8 +8,9 @@ from scripts.pricing import refresh
 from scripts.pricing.base import ModelPrice, ProviderPricingResult
 from scripts.pricing.providers import friendli
 from tests.lifecycle_clock import catalog_predates
-from trusted_router import provider_lifecycle
+from trusted_router import catalog, provider_lifecycle
 from trusted_router.catalog import endpoints_for_model
+from trusted_router.catalog_data import ModelEndpoint
 
 _QWEN_CUTOFF = datetime(2026, 8, 5, 0, 0, tzinfo=UTC)
 _EXAONE_CUTOFF = datetime(2026, 8, 20, 0, 0, tzinfo=UTC)
@@ -65,12 +66,27 @@ def test_friendli_exaone_retires_at_announced_instant() -> None:
 def test_friendli_qwen_retirement_is_provider_scoped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # This historical Friendli boundary must not depend on providers that
+    # independently retire Qwen later (Crusoe in September).
+    endpoints = {}
+    for provider in ("friendli", "atlas-cloud", "crusoe"):
+        endpoint = ModelEndpoint(
+            id=f"{_QWEN}@{provider}/prepaid", model_id=_QWEN,
+            provider=provider, usage_type="Credits", upstream_id=_QWEN_UPSTREAM,
+        )
+        endpoints[endpoint.id] = endpoint
+    monkeypatch.setattr(catalog, "MODEL_ENDPOINTS", endpoints)
+    monkeypatch.setattr(
+        provider_lifecycle, "_utc_now", lambda: _QWEN_CUTOFF - timedelta(microseconds=1),
+    )
+    assert {endpoint.provider for endpoint in endpoints_for_model(_QWEN)} == {
+        "friendli", "atlas-cloud", "crusoe",
+    }
     monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _QWEN_CUTOFF)
 
     providers = {endpoint.provider for endpoint in endpoints_for_model(_QWEN)}
 
-    assert "friendli" not in providers
-    assert {"atlas-cloud", "crusoe"}.issubset(providers)
+    assert providers == {"atlas-cloud", "crusoe"}
 
 
 def test_friendli_exaone_catalog_route_retires_on_schedule(

--- a/tests/test_pricing_model_ids.py
+++ b/tests/test_pricing_model_ids.py
@@ -13,6 +13,8 @@ def test_canonicalize_provider_native_ids_for_new_model_discovery() -> None:
     assert canonicalize_native_model_id("moonshotai/Kimi-K2.7-Code") == "moonshotai/kimi-k2.7-code"
     assert canonicalize_native_model_id("Qwen/Qwen3.5-397B-A17B") == ("qwen/qwen3.5-397b-a17b")
     assert canonicalize_native_model_id("zai-org/GLM-5.2") == "z-ai/glm-5.2"
+    assert canonicalize_native_model_id("zai/GLM-5.3") == "z-ai/glm-5.3"
+    assert canonicalize_native_model_id("ZAI/GLM-5.3-Flash") == "z-ai/glm-5.3-flash"
     assert canonicalize_native_model_id("MiniMaxAI/MiniMax-M2.7") == ("minimax/minimax-m2.7")
 
 


### PR DESCRIPTION
## Summary

Honor Crusoe's Serverless retirement notice for **September 12, 2026 at 9:00 PM Pacific**, exactly **September 13, 2026 at 04:00 UTC** (PDT, not PST).

| Existing Crusoe checkpoint | Recommended replacement recorded in manifest |
| --- | --- |
| GLM 5.1 | GLM 5.3 |
| GLM 5.2 | GLM 5.3 |
| DeepSeek V3 0324 | DeepSeek V4 Pro |
| Qwen3 235B A22B Instruct 2507 | DeepSeek V4 Flash |
| Llama 3.3 70B Instruct | DeepSeek V4 Flash |

The notice also recommends V4 Flash for DeepSeek V3 and next week's Qwen 3.8 27B for Qwen3 235B. Record an already-announced current replacement rather than inventing a future route or price. Replacements remain explicit model choices, never silent aliases.

- Reuse shared effective-dated lifecycle protection for runtime routing, import, refresh, and discovery. Other providers remain unaffected. Do not disable routes early or alter prices.
- Record the exact cutoff and migration metadata in the Crusoe manifest.
- Fix the shared author normalization `zai` -> `z-ai`: without this, automatically discovering Crusoe-style `zai/GLM-5.3` produced the incorrect separate `zai/glm-5.3` public ID. Preserve the native upstream name and semantic suffixes. No fabricated live models or prices.
- Move the existing parser fixture from retiring GLM 5.2 to GLM 5.3 so future-cutover CI tests discovery without keeping the retired route alive.
- Make the historical Friendli Qwen scope test use a fixed catalog: Crusoe's later September retirement must not invalidate an August-only test. Assert all three providers before Friendli's cutoff and exactly the two surviving providers after it.

## Verification

- Reproduced failures before implementation: **15 failed, 1 passed** (cutoff, stale runtime/discovery, namespace normalization, missing metadata).
- **142 focused tests passed** at the current clock; the expanded set including Friendli has **150 passing tests** with the clock advanced beyond all scheduled cutovers.
- Future-cutover CI exposed the historical Friendli fixture dependency. Reproduced its failure locally before fixing the fixture; no assertion or lifecycle safety gate was weakened.
- `ruff check .`: passed.
- `mypy`: passed, 372 source files.
- Full local suite: **9,703 passed, 408 skipped, 11 xfailed**. The final Friendli fixture also passed a separate normal-clock run after editing.
- Final normal and future-cutover CI: green, including coverage, browser, proofs, and security checks.
- Fresh authenticated read-only Crusoe catalog check returned **HTTP 401 using the local keyfile credential**. This is not evidence about the production secret. Fresh replacement availability could not be verified; existing authentication safety behavior is unchanged.
- Local Claude CLI reports `loggedIn: false`; Opus review is unavailable. No API-key workaround used.

## Rollout

Normal main-branch deployment, preserving the existing regional readiness, billing, and staged-traffic gates. No enclave or infrastructure changes are needed.
