### PR TITLE
Prevent stale catalogs from restoring retired Friendli EXAONE 2

### DIFF
--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -32,6 +32,7 @@ NEAR_AI_SEPTEMBER_2026_RETIREMENT_AT = datetime(2026, 9, 11, 13, 0, tzinfo=UTC)
 PARASAIL_AUGUST_2026_RETIREMENT_AT = datetime(2026, 8, 4, 0, 0, tzinfo=UTC)
 FRIENDLI_QWEN3_235B_RETIREMENT_AT = datetime(2026, 8, 5, 0, 0, tzinfo=UTC)
 FRIENDLI_K_EXAONE_236B_RETIREMENT_AT = datetime(2026, 8, 20, 0, 0, tzinfo=UTC)
+FRIENDLI_K_EXAONE_2_RETIREMENT_AT = datetime(2026, 9, 6, 0, 0, tzinfo=UTC)
 CRUSOE_NEMOTRON_3_ULTRA_RETIREMENT_AT = datetime(2026, 7, 28, 18, 0, tzinfo=UTC)
 WAFER_AUGUST_2026_RETIREMENT_AT = datetime(2026, 8, 17, 0, 0, tzinfo=UTC)
 WAFER_GLM52_RETIREMENT_AT = datetime(2026, 9, 5, 6, 59, tzinfo=UTC)
@@ -112,6 +113,17 @@ class _Retirement:
 
 
 _RETIREMENTS = (
+    # Friendli's September 4 notice specifies September 6 00:00 UTC
+    # (September 5 17:00 PDT). Only the shared Model API is retiring;
+    # dedicated endpoints and equivalent models on other providers survive.
+    # Discovery already delisted this route. The clock guard additionally
+    # protects stale processes and prevents a later feed from resurrecting it.
+    _Retirement(
+        provider="friendli",
+        model_ids=frozenset({"lgai-exaone/k-exaone-2.0-750b-a37b"}),
+        upstream_ids=frozenset({"LGAI-EXAONE/K-EXAONE-2.0-750B-A37B"}),
+        effective_at=FRIENDLI_K_EXAONE_2_RETIREMENT_AT,
+    ),
     # NEAR announced both GLM retirements for 2026-09-11 13:00 UTC. Do not
     # silently substitute the suggested GLM 5.3 Flash: its direct workload
     # requires separate attestation review. Other providers are unaffected.

--- a/tests/test_friendli_september_2026_lifecycle.py
+++ b/tests/test_friendli_september_2026_lifecycle.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+
+from scripts.pricing import refresh
+from scripts.pricing.base import ModelPrice, ProviderPricingResult
+from scripts.pricing.providers import friendli
+from trusted_router import catalog, provider_lifecycle
+from trusted_router.catalog import ModelEndpoint
+
+_CUTOFF = datetime(2026, 9, 6, tzinfo=UTC)
+_MODEL = "lgai-exaone/k-exaone-2.0-750b-a37b"
+_NATIVE = "LGAI-EXAONE/K-EXAONE-2.0-750B-A37B"
+_OTHER = "z-ai/glm-5.2"
+
+
+def test_friendli_exaone_2_exact_boundary_and_scope() -> None:
+    retired = provider_lifecycle.provider_model_retired
+    assert not retired("friendli", _MODEL, _NATIVE, at=_CUTOFF - timedelta(microseconds=1))
+    assert retired("friendli", _MODEL, at=_CUTOFF)
+    assert retired("friendli", "alternate-canonical-id", _NATIVE, at=_CUTOFF)
+    assert not retired("another-provider", _MODEL, _NATIVE, at=_CUTOFF)
+    assert not retired("friendli", _OTHER, "zai-org/GLM-5.2", at=_CUTOFF)
+
+
+def test_stale_runtime_catalog_retires_without_reload(monkeypatch: pytest.MonkeyPatch) -> None:
+    endpoints = {}
+    for provider in ("friendli", "another-provider"):
+        for usage in ("Credits", "BYOK"):
+            endpoint = ModelEndpoint(
+                id=f"{_MODEL}@{provider}/{usage}", model_id=_MODEL,
+                provider=provider, usage_type=usage, upstream_id=_NATIVE,
+            )
+            endpoints[endpoint.id] = endpoint
+    monkeypatch.setattr(catalog, "MODEL_ENDPOINTS", endpoints)
+    monkeypatch.setattr(
+        provider_lifecycle, "_utc_now", lambda: _CUTOFF - timedelta(microseconds=1),
+    )
+    assert len(catalog.endpoints_for_model(_MODEL)) == 4
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    remaining = catalog.endpoints_for_model(_MODEL)
+    assert len(remaining) == 2
+    assert {row.provider for row in remaining} == {"another-provider"}
+    assert {row.model_id for row in remaining} == {_MODEL}
+
+
+def test_hourly_refresh_cannot_resurrect_retired_route(monkeypatch: pytest.MonkeyPatch) -> None:
+    result = ProviderPricingResult(
+        slug="friendli",
+        prices={_MODEL: ModelPrice(600_000, 2_400_000), _OTHER: ModelPrice(1_400_000, 4_400_000)},
+        source="api", fetched_url=friendli.URL,
+    )
+    monkeypatch.setattr(
+        provider_lifecycle, "_utc_now", lambda: _CUTOFF - timedelta(microseconds=1),
+    )
+    assert "friendli" in refresh._index_provider_prices({"friendli": result})[_MODEL]
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    after = refresh._index_provider_prices({"friendli": result})
+    assert _MODEL not in after
+    assert "friendli" in after[_OTHER]
+
+
+@pytest.mark.parametrize("after_cutoff", [False, True])
+def test_discovery_filters_stale_feed(
+    monkeypatch: pytest.MonkeyPatch, after_cutoff: bool,
+) -> None:
+    payload = {"data": [
+        {"id": native, "pricing": {"input": "0.0000006", "output": "0.0000024"}}
+        for native in (_NATIVE, "zai-org/GLM-5.2")
+    ]}
+    monkeypatch.setattr(
+        friendli.httpx, "HTTPTransport",
+        lambda **_: httpx.MockTransport(lambda request: httpx.Response(200, json=payload)),
+    )
+    monkeypatch.setattr(friendli, "UPSTREAM_ID_MAP", dict(friendli.UPSTREAM_ID_MAP))
+    monkeypatch.setattr(friendli, "_DISCOVERED_MANIFEST_ROWS", {})
+    monkeypatch.setattr(
+        provider_lifecycle, "_utc_now",
+        lambda: _CUTOFF if after_cutoff else _CUTOFF - timedelta(microseconds=1),
+    )
+    result = friendli.fetch()
+    expected = {_OTHER} if after_cutoff else {_OTHER, _MODEL}
+    assert set(result.prices) == expected
+    assert set(friendli._DISCOVERED_MANIFEST_ROWS) == expected


### PR DESCRIPTION
## Summary
- Add the exact Friendli shared Model API cutoff for K-EXAONE-2.0-750B-A37B: 2026-09-06 00:00 UTC, from the provider September 4 notice.
- The committed manifest already marks this route delisted. This guard additionally protects stale runtimes and prevents a future discovery feed from restoring the retired route.
- Other providers and models are unaffected. No replacement-model substitution, pricing change, trust change, or direct production write.

## Validation
- ruff check: passed
- mypy: passed (372 source files)
- five boundary/runtime/provider-scope/stale-feed regression tests: passed
- full suite: 9,692 passed, 408 skipped, 11 expected failures
- total coverage: 84.31% (70% required)
- required remote CI checks must pass before merge

Provider notice explicitly preserves dedicated endpoints; this catalog provider is the shared serverless Model API.