### PR TITLE
deploy: pass the Stripe account pin to the rollout, not only to the trust jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -484,6 +484,7 @@ jobs:
         id: warm_all
         env:
           IMAGE_TAG: ${{ needs.build-image.outputs.sha }}
+          TR_TRUST_STRIPE_ACCOUNT_ID: ${{ vars.TR_TRUST_STRIPE_ACCOUNT_ID || '' }}
         run: |
           set -euo pipefail
 

--- a/tests/test_deploy_secret_wiring.py
+++ b/tests/test_deploy_secret_wiring.py
@@ -1,16 +1,70 @@
+import json
 import os
 import re
 import subprocess
+from dataclasses import replace
 from pathlib import Path
+
+import pytest
 
 from scripts.check_price_coverage import (
     _DISCOVERABLE_MANIFEST_PROVIDERS,
     _GLM_DISCOVERABLE_PROVIDER_APIS,
     _OPTIONAL_STALE_MANIFEST_PROVIDER_SLUGS,
 )
+from tests.deploy_script_harness import SCRIPT_FIXTURES, DeployScriptHarness, summarise
 from trusted_router.enclave_regions import ENCLAVE_REGIONS
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize("incoming", ["acct_repository", "", None])
+@pytest.mark.parametrize("serving", ["acct_serving", "", None])
+@pytest.mark.parametrize("region", ["us-central1", "europe-west4", "us-east4", "southamerica-east1"])
+def test_rollout_stripe_account_override_and_preservation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    incoming: str | None,
+    serving: str | None,
+    region: str,
+) -> None:
+    script = "scripts/deploy/rollout.sh"
+    fixture = SCRIPT_FIXTURES[script]
+    responses = []
+    for pattern, reply in fixture.responses:
+        if "run revisions describe trusted-router-active" in pattern:
+            revision = json.loads(reply)
+            if serving is not None:
+                revision["spec"]["containers"][0]["env"].append(
+                    {"name": "TR_TRUST_STRIPE_ACCOUNT_ID", "value": serving}
+                )
+            reply = json.dumps(revision)
+        responses.append((pattern, reply))
+    monkeypatch.setitem(
+        SCRIPT_FIXTURES, script, replace(fixture, responses=tuple(responses))
+    )
+    # Match the workflow's one-region-per-process rollout invocation. The
+    # harness argv recorder does not serialize concurrent CLI writers.
+    env = {"TR_DEPLOY_TARGET_REGIONS": region}
+    if incoming is not None:
+        env["TR_TRUST_STRIPE_ACCOUNT_ID"] = incoming
+    run = DeployScriptHarness(tmp_path).run(script, extra_env=env)
+    assert run.returncode == 0, summarise(run)
+    deploys = [
+        call for call in run.calls
+        if call[:6] == ["gcloud", "--project", "quill-cloud-proxy", "run", "deploy", "trusted-router"]
+    ]
+    assert len(deploys) == 1
+    assert deploys[0][deploys[0].index("--region") + 1] == region
+    for call in deploys:
+        # These are the candidate revisions the workflow subsequently ramps.
+        assert "--no-traffic" in call
+        raw = call[call.index("--set-env-vars") + 1]
+        assert raw.startswith("^|^")
+        emitted = dict(item.split("=", 1) for item in raw.removeprefix("^|^").split("|"))
+        assert emitted["TR_TRUST_STRIPE_ACCOUNT_ID"] == (incoming or serving or "")
+    # An ordinary release must not resolve a missing pin by contacting Stripe.
+    assert not any("https://api.stripe.com/v1/account" in call for call in run.calls)
 
 
 def test_top_level_deploy_passes_spanner_config_to_unshared_migration() -> None:

--- a/tests/test_deploy_workflow_regions.py
+++ b/tests/test_deploy_workflow_regions.py
@@ -38,6 +38,27 @@ def test_every_load_balanced_control_plane_region_is_staged() -> None:
         assert region in ramp
 
 
+def test_every_rollout_step_receives_the_repository_stripe_account_pin() -> None:
+    workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
+    invocations = []
+    for step in workflow.split("\n      - ")[1:]:
+        metadata, separator, run = step.partition("\n        run:")
+        if not separator:
+            continue
+        commands = "\n".join(
+            line for line in run.splitlines() if not line.lstrip().startswith("#")
+        )
+        if not re.search(r"scripts/(?:deploy/rollout|deploy-gcp)\.sh", commands):
+            continue
+        invocations.append(metadata.splitlines()[0])
+        assert "\n        env:\n" in metadata
+        assert (
+            "\n          TR_TRUST_STRIPE_ACCOUNT_ID: "
+            "${{ vars.TR_TRUST_STRIPE_ACCOUNT_ID || '' }}"
+        ) in metadata, metadata
+    assert invocations == ["name: Warm all four regions in parallel (no traffic)"]
+
+
 def test_prod_smoke_checks_public_origins_and_converges_private_regions() -> None:
     workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
 

--- a/tests/test_internal_surface_deploy.py
+++ b/tests/test_internal_surface_deploy.py
@@ -163,7 +163,10 @@ def test_internal_deploy_pins_each_region_stage_and_exact_secret_allowlist(
     stage: str,
     client_ip_mode: str,
 ) -> None:
-    run = harness.run(SCRIPT, args=(stage,))
+    # A control-plane account pin must not widen this surface's env allowlist.
+    run = harness.run(
+        SCRIPT, args=(stage,), extra_env={"TR_TRUST_STRIPE_ACCOUNT_ID": "acct_repository"}
+    )
     assert run.returncode == 0, summarise(run)
     calls = _deploy_calls(run)
     assert len(calls) == 4

--- a/tests/test_public_surface_deploy.py
+++ b/tests/test_public_surface_deploy.py
@@ -149,7 +149,10 @@ def test_public_deploy_pins_every_region_and_stage_contract(
     ingress: str,
     client_ip_mode: str,
 ) -> None:
-    run = harness.run(SCRIPT, args=(stage,))
+    # A control-plane account pin must not widen this surface's env allowlist.
+    run = harness.run(
+        SCRIPT, args=(stage,), extra_env={"TR_TRUST_STRIPE_ACCOUNT_ID": "acct_repository"}
+    )
     assert run.returncode == 0, summarise(run)
     calls = _deploy_calls(run)
     assert len(calls) == 4


### PR DESCRIPTION
## Why

The deployed router has `TR_TRUST_STRIPE_ACCOUNT_ID` **empty in every region**, verified against production on 2026-09-07.

PR 2's arm gate (`trust_eligibility.trust_gate_failure`) returns `provider_not_configured` unless that setting starts with `acct_`. So arming the trust program today would refuse every lease decision with `trust_gate_unarmed` — failing open to the synchronous path and raising an ops alert each time. The flip would have been a silent no-op.

Cause: `deploy.yml` passes `vars.TR_TRUST_STRIPE_ACCOUNT_ID` only to the trust-jobs step. The step that runs `scripts/deploy/rollout.sh` does not, so `rollout.sh` falls back to reading the serving revision, finds the empty value it wrote last time, and writes it again. The repository variable itself has been set since 2026-09-06.

## What

Pass the repository variable to the step that runs the rollout, exactly as the trust-jobs step already does. That step is the only rollout invocation in the workflow and it covers all four regions; there is no `deploy-gcp.sh` invocation there.

`rollout.sh` is unchanged, so a deploy without the variable still preserves whatever is already deployed, which matters for the other planes that run the same script.

## Proof

Written by codex (gpt-6-astra); reviewed by Fable. Fable gate on a fresh snapshot: 513 tests green across the deploy-secret wiring, workflow-region, both surface deploy-contract and trust suites plus the Stage C flag-off differential; ruff and mypy clean. Mutation red: removing the new env line fails the workflow contract test. Codex additionally verified that forcing the serving-revision lookup fails the explicit-override test, and that the account pin does not widen the public surface's env allowlist.

After this deploys, the arm gate's four conditions are all satisfied in production: typed Spanner settlement, complete stripe/x402/owner-inventory markers with a 900 s consistency delay, a maximum owner fan-out of 420 against the 20,000 budget, and the account pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
