### PR TITLE
trust tiers: arm lease eligibility in production

### DIFF
--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -788,8 +788,17 @@ ENV_VARS=(
   # key is in the cohort. Clearing this list is the later fleet-expansion step,
   # not part of arming.
   "TR_STAGE_D_PILOT_WORKSPACE_IDS=45819281-0ce9-4811-a0cd-c660ab3a116d,91d7810e-93b2-4c37-b1bd-ba9227585416"
-  # Trust eligibility remains inert; its arm gate validates the completed program.
-  "TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED=false"
+  # Decisions 75-76: the arm gate's conditions are satisfied in production as of
+  # 2026-09-07: typed Spanner settlement (TR_STORAGE_BACKEND=spanner-bigtable,
+  # TR_REQUEST_RECORD_WRITE_MODE=typed); stripe, x402 and owner-inventory markers
+  # complete with zero unmatched and zero semantic mismatches and a 900 s
+  # consistency delay; maximum per-owner fan-out 420 against the 20,000 budget;
+  # and the Stripe account pin now reaching the router. The recurring reconciler
+  # and tier job have run four consecutive clean cadences with every tiered shard
+  # fresh, and the pilot workspace is tier 2, unlatched, on all 16 shards.
+  # Settings.spend_lease_trust_eligibility_enabled stays False so only a deployed
+  # router is armed. Rollback is the reverse one-line edit to false.
+  "TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED=true"
   "TR_TRUST_STRIPE_ACCOUNT_ID=${TR_TRUST_STRIPE_ACCOUNT_ID}"
   "TR_TRUST_QUALIFYING_PROVIDERS=stripe,x402"
   "TR_TRUST_RECONCILE_INTERVAL_SECONDS=900"

--- a/tests/test_trust_eligibility_pr2.py
+++ b/tests/test_trust_eligibility_pr2.py
@@ -938,6 +938,7 @@ def test_additional_arm_preconditions_fail_closed(condition: str) -> None:
 def test_rollout_preserves_account_pin_without_ungated_provider_lookup(
     pin: str, live: str, jobs: str, expected: str
 ) -> None:
+    """The armed rollout preserves the account pin without ungated provider lookup."""
     import os
     import subprocess
     from pathlib import Path
@@ -966,7 +967,7 @@ def test_rollout_preserves_account_pin_without_ungated_provider_lookup(
         },
     )
     assert result.stdout == expected
-    assert '"TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED=false"' in text
+    assert '"TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED=true"' in text
 
 
 @pytest.mark.parametrize(

--- a/tests/test_trust_tier_slice1a.py
+++ b/tests/test_trust_tier_slice1a.py
@@ -1019,6 +1019,7 @@ def test_armed_shadow_and_authoritative_claims_carry_the_effective_tier() -> Non
 
 
 def test_new_settings_are_inert_and_pinned_to_scope_defaults() -> None:
+    """Only the deployed router is armed; code and scope defaults stay unchanged."""
     settings = Settings(environment="test")
 
     assert settings.spend_lease_trust_eligibility_enabled is False
@@ -1036,7 +1037,7 @@ def test_new_settings_are_inert_and_pinned_to_scope_defaults() -> None:
         settings.spend_lease_tier3_cap_microdollars,
     ) == (5_000_000, 25_000_000, 100_000_000)
     rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
-    assert '"TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED=false"' in rollout
+    assert '"TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED=true"' in rollout
 
 
 def test_reconciliation_freshness_covers_delay_plus_two_cadences() -> None:


### PR DESCRIPTION
## Why

This arms trust-tier lease eligibility in production (decisions 75 and 76, runbook step 12). Every prerequisite has landed and every arm-gate condition is satisfied, each verified against production on 2026-09-07 rather than inferred:

| Gate condition | Evidence |
|---|---|
| Typed Spanner settlement | `TR_STORAGE_BACKEND=spanner-bigtable`, `TR_REQUEST_RECORD_WRITE_MODE=typed` |
| Qualifying providers pinned | `TR_TRUST_QUALIFYING_PROVIDERS=stripe,x402` |
| Stripe account pin | reaches the router after #1130; empty before it, which would have made this flip a silent no-op |
| Markers complete | stripe, x402 and owner-inventory rows, `completed_at` set, unmatched 0, semantic mismatches 0 |
| Consistency delay | 900 s, and `TR_TRUST_RECONCILE_MAX_AGE_SECONDS` 3600 ≥ 900 + 2×900 |
| Owner fan-out budget | maximum 420 against 20,000 |

The data behind those markers was produced by the arming run: the pause-cause backfill (6,421 rows, no nulls left), the historical backfill (148 Stripe payments all credited locally, 141 facts written, one refund applied as a $5 recovery with its latch), and the drain-window sweep. The recurring reconciler and the tier job have since run four consecutive clean cadences; 8,037 of 8,037 shards are computed, every tiered shard is fresh, and the pilot workspace is tier 2, unlatched, across all 16 shards.

## What

One literal in `scripts/deploy/rollout.sh`, `TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED` false → **true**, plus the two tests that pin it.

`Settings.spend_lease_trust_eligibility_enabled` stays `False`, so only a deployed router is armed. The three trust job scripts keep their own `false` in their job environments, deliberately: the jobs must not evaluate eligibility. Rollback is the reverse one-line edit.

## What changes at runtime

Lease issuance and reuse now require an effective tier ≥ 1 with a clear latch, empty pause causes and fresh reconciliation; caps become `min(global ceiling, tier cap)` at $5, $25 and $100; the regional-quota path enforces the same and records `issuance_tier`. Refusals surface as `unpaid_workspace`, `billing_paused` or `reconciliation_stale`, and a failing gate refuses with `trust_gate_unarmed`. Every refusal falls back to the synchronous path, so a refusal is a lost lease, not a failed request.

## One consequence worth naming

The regional-quota lease pilot goes quiet when this lands. `TR_REGIONAL_QUOTA_LEASE_PILOT_WORKSPACE_IDS` holds exactly one workspace, `d385c399-b245-4147-a528-0a4f6f170c71`, which is the synthetic monitor. Read from production on 2026-09-07 it is trust tier 0 across all 16 shards, unlatched, with `trust_reconciled_through` null on every shard. Armed, `storage_gcp_regional_quota` calls the same gate, gets `unpaid_workspace`, logs `regional_quota.no_lease_reason=unpaid_workspace` and issues no lease.

That is the designed behaviour, not a defect: the refusal falls back to the synchronous path, so the monitor keeps working and its authorizations become `local_typed` instead of `regional_lease`. The Stage D rollout gate is unaffected, and in fact prefers `local_typed`, which is what the probe key already produces.

It does mean the regional-quota lease path has no exercising pilot from this point on, because an internal workspace never makes a qualifying payment and so can never earn a tier. Whether to grant that workspace a tier, move the pilot to a tiered workspace, or accept the pause is a separate decision, deliberately not taken here.

## Proof

Written by codex (gpt-6-astra); reviewed by Fable. Fable gate on a fresh snapshot: 962 tests green across the trust, Stage C flag-off differential, Stage D, spend-lease, regional and all three deploy-contract suites; ruff and mypy clean; the flip's pin verified red when the literal is reverted to false. Static checks confirm the code default is still `False`, the Stage D flip is intact, and each trust job script keeps its own `false`.

First-hour watch after deploy: new pilot leases should carry the tier-2 cap, `no_lease_reason` should stay empty for pilot traffic, marker freshness and tier counts should hold across the hour, both jobs should keep ticking, and none of `trust.backfill.unmatched`, `trust.reconcile.outstanding` or `trust.backfill.uncredited_payment` should fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
