### PR TITLE
Revert the trust arming flip: the arm gate is too expensive for the authorize path

### DIFF
--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -788,17 +788,8 @@ ENV_VARS=(
   # key is in the cohort. Clearing this list is the later fleet-expansion step,
   # not part of arming.
   "TR_STAGE_D_PILOT_WORKSPACE_IDS=45819281-0ce9-4811-a0cd-c660ab3a116d,91d7810e-93b2-4c37-b1bd-ba9227585416"
-  # Decisions 75-76: the arm gate's conditions are satisfied in production as of
-  # 2026-09-07: typed Spanner settlement (TR_STORAGE_BACKEND=spanner-bigtable,
-  # TR_REQUEST_RECORD_WRITE_MODE=typed); stripe, x402 and owner-inventory markers
-  # complete with zero unmatched and zero semantic mismatches and a 900 s
-  # consistency delay; maximum per-owner fan-out 420 against the 20,000 budget;
-  # and the Stripe account pin now reaching the router. The recurring reconciler
-  # and tier job have run four consecutive clean cadences with every tiered shard
-  # fresh, and the pilot workspace is tier 2, unlatched, on all 16 shards.
-  # Settings.spend_lease_trust_eligibility_enabled stays False so only a deployed
-  # router is armed. Rollback is the reverse one-line edit to false.
-  "TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED=true"
+  # Trust eligibility remains inert; its arm gate validates the completed program.
+  "TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED=false"
   "TR_TRUST_STRIPE_ACCOUNT_ID=${TR_TRUST_STRIPE_ACCOUNT_ID}"
   "TR_TRUST_QUALIFYING_PROVIDERS=stripe,x402"
   "TR_TRUST_RECONCILE_INTERVAL_SECONDS=900"

--- a/tests/test_trust_eligibility_pr2.py
+++ b/tests/test_trust_eligibility_pr2.py
@@ -938,7 +938,6 @@ def test_additional_arm_preconditions_fail_closed(condition: str) -> None:
 def test_rollout_preserves_account_pin_without_ungated_provider_lookup(
     pin: str, live: str, jobs: str, expected: str
 ) -> None:
-    """The armed rollout preserves the account pin without ungated provider lookup."""
     import os
     import subprocess
     from pathlib import Path
@@ -967,7 +966,7 @@ def test_rollout_preserves_account_pin_without_ungated_provider_lookup(
         },
     )
     assert result.stdout == expected
-    assert '"TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED=true"' in text
+    assert '"TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED=false"' in text
 
 
 @pytest.mark.parametrize(

--- a/tests/test_trust_tier_slice1a.py
+++ b/tests/test_trust_tier_slice1a.py
@@ -1019,7 +1019,6 @@ def test_armed_shadow_and_authoritative_claims_carry_the_effective_tier() -> Non
 
 
 def test_new_settings_are_inert_and_pinned_to_scope_defaults() -> None:
-    """Only the deployed router is armed; code and scope defaults stay unchanged."""
     settings = Settings(environment="test")
 
     assert settings.spend_lease_trust_eligibility_enabled is False
@@ -1037,7 +1036,7 @@ def test_new_settings_are_inert_and_pinned_to_scope_defaults() -> None:
         settings.spend_lease_tier3_cap_microdollars,
     ) == (5_000_000, 25_000_000, 100_000_000)
     rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
-    assert '"TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED=true"' in rollout
+    assert '"TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED=false"' in rollout
 
 
 def test_reconciliation_freshness_covers_delay_plus_two_cadences() -> None:


### PR DESCRIPTION
## What happened

Deploy `34164499332` of the arming flip (#1131, `b510a294`) **failed and rolled itself back** at 22:27Z on 2026-09-07. Two independent failures, one cause.

**1. Billing-path 5xx in us-central1.** The deploy's own gate caught it and reverted traffic to the previous revision:

```
billing-path 5xx detected in us-central1 revision trusted-router-01401-768 after 2026-09-07T22:10:01Z:
  https://trustedrouter.com/internal/gateway/authorize  503  20.029131688s
us-central1 emitted billing-path 5xx; rolling back to trusted-router-01400-znb
```

20.029 s is the transaction budget, not a coincidence: it is the same signature as the hot-key settle convoy.

**2. southamerica-east1 never became healthy.** `Container failed to become healthy. Startup probes timed out after 4m`, so no secondary traffic moved.

## Why

`trust_gate_failure` is evaluated **per call, with an unbounded owner fan-out, inside the authorize transaction**, and once more at process startup. Per evaluation it performs:

| Work | Count in production today |
|---|---|
| read all backfill markers | 1 query |
| `SELECT owner_user_id, workspace_id FROM tr_owner_workspace` | 1 query, 1008 rows |
| `_owner_shard_counts_tx(owner)` for **every** distinct owner | 994 queries |
| `_read_entity_tx(..., "credit", workspace_id, ...)` inside those | ~1008 point reads |

That is roughly **2,000 sequential Spanner operations per gate evaluation**, and there is no cache: `grep` for `lru_cache`, a TTL, or a stored verdict in `trust_eligibility.py` returns nothing.

It runs in two places that cannot afford it:

- `storage_gcp.py:6159` on the lease-issuance path and `storage_gcp_regional_quota.py:288` with `reader=transaction`, so the fan-out happens **inside** the authorize transaction. That is the 20.029 s budget exhaustion and the 503.
- `main.py:213-215` calls `lease_eligibility(STORE, settings)` at startup whenever the flag is on. In southamerica-east1, which runs at `min-instances=0` and is furthest from the `nam6` Spanner instance, ~2,000 round trips did not finish inside the 4-minute startup probe.

The arm gate checks the right conditions. Nothing it reads is per-request or per-workspace: storage backend, qualifying providers, the account pin, marker completeness and freshness, and per-owner shard budgets are all global and move on a 15-minute cadence at most. Evaluating them on the hot path, per request, in the transaction, is the defect.

The step-11 arming check measured "maximum owner fan-out 420 against the 20,000 budget". That is a bound on *shards per owner*, not on the *number of owners*, so it could not have caught this.

## What this PR does

Reverts `b510a294`, putting `TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED` back to `false`. One literal plus the two tests that pin it.

This is not cosmetic. Main currently arms on **every** deploy, so any unrelated deploy re-runs the failure and emits real 503s on the billing path until the gate trips again. The flag must be off in source until the gate is cheap.

Everything else from the arming run stands and needs no rework: the backfills, the markers, the tiers, the schedulers, and the account pin are all correct and stay in place.

## What has to land before arming is retried

Make the verdict cheap and keep it fail-closed. The owner-budget fan-out belongs in the existing 15-minute trust job, persisted as a verdict the request path reads as one row, rather than recomputed per authorize. The request path must never open that fan-out inside a transaction, and startup must not block a probe on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
