### PR TITLE
trust: make the arm gate cheap enough for the authorize path

### DIFF
--- a/docs/trust-arm-gate-cost.md
+++ b/docs/trust-arm-gate-cost.md
@@ -1,0 +1,126 @@
+# Trust arm gate: bounded admission reads
+
+Why this exists: arming trust eligibility on 2026-09-07 evaluated the whole owner
+inventory inside the authorize transaction and at process startup, roughly two
+thousand sequential Spanner operations per gate evaluation. Authorize hit its
+transaction budget and returned 503 at 20.02s, and one region never passed its
+startup probe. This document is the contract that replaced it.
+
+## Admission contract
+
+`global_trust_verdict` evaluates configuration and three required markers with
+full-primary-key reads, then reads one owner-budget entity by its complete
+`(kind, id)` key. No owner or workspace inventory scan occurs on admission.
+A process-local, store-scoped cache serializes cold refreshes and caches both
+passes and refusals for 15 seconds. Configuration/database identity changes
+invalidate the cache. There is no refresh thread.
+
+`lease_eligibility` with a caller-supplied reader requires a precomputed
+`GlobalTrustVerdict`. Absence, expiration, configuration mismatch, or evidence
+staleness refuses without opening another snapshot. Markers' original max-age
+and consistency-delay rules are retained. Cached success cannot extend a
+marker's or owner verdict's max age. A binding plan delayed beyond its verdict's
+TTL fails closed; a later request can refresh outside its transaction.
+
+The workspace credit account, complete shard set, and `read_lease_trust` remain
+on the caller's transaction. The shard-scoped billing pause read from #1119 is
+unchanged. `create_app` performs no trust eligibility evaluation.
+
+Existing caller reasons remain unchanged (`trust_gate_unarmed` for a global
+failure, or existing workspace reasons). Operator gate conditions distinguish
+`owner_budget_missing` and `owner_budget_stale`, plus `global_verdict_missing`
+and `global_verdict_expired` for invalid transaction evidence. Over-budget and
+failed scans retain the old `read_failed` condition.
+
+## Durable owner-budget proof
+
+The existing `trusted-router-trust-tier-15m` job calls `recompute_owner_budget`
+regardless of the arm flag and passes its explicit target environment. It reads
+the entire owner inventory and each owner's credit shard counts in one strong,
+multi-use snapshot. Only this recurring job performs the fleet scan.
+
+One `tr_entities` row holds the proof:
+
+- `kind = trust_owner_budget`
+- `id = owner-budget-v1:<environment>`
+- `source_version`, `environment`, and `computed_at` (UTC scan-start watermark)
+- `max_observed_mutations`: maximum sum of an owner's shard counts times the
+  pinned replicated-column count (currently seven)
+- `mutation_budget`: the exact budget checked (currently 20,000)
+- `violating_owners`: every over-budget owner; an empty list means no violation
+- `scan_complete`: false if inventory/account reads or count validation failed
+
+The job persists violations and failed scans, invalidating an earlier successful
+proof, and exits nonzero on failure. An older overlapping job cannot overwrite
+a newer proof. A persistence failure leaves the previous proof to expire under
+`trust_reconcile_max_age_seconds`. The marker schema cannot store these budget
+and diagnostic fields, so the implementation reuses entity persistence and the
+existing marker freshness predicate instead of adding a table or migration.
+
+Before a later arming PR, deploy this code and let the tier job persist a fresh,
+complete proof with no violations. Missing evidence refuses. Both the rollout
+arm flag and `Settings.spend_lease_trust_eligibility_enabled` remain false.
+
+## Executed negative controls
+
+Reproduce: `uv run python scripts/prove_trust_gate_cost.py`. The runner verifies
+a green baseline, applies one exact mutation, requires a failing assertion,
+restores the source in `finally`, and finishes with a green baseline. Do not edit
+the tree concurrently with this runner.
+
+Every test below is in `tests/test_trust_gate_cost.py`. Each row was executed:
+
+| Test name | Mutation | Mutated / restored |
+|---|---|---|
+| `test_global_verdict_once_per_ttl_across_authorize_calls` | Disable cache hits | RED / GREEN |
+| `test_concurrent_cold_global_verdict_single_flight` | Disable cache hits | RED / GREEN |
+| `test_regional_authorize_transactions_never_evaluate_global_gate` | Insert owner fan-out using the caller's reader | RED / GREEN |
+| `test_spend_authorize_transaction_never_evaluates_global_gate` | Insert owner fan-out using the caller's reader | RED / GREEN |
+| `test_missing_owner_budget_refuses` | Accept a missing budget record | RED / GREEN |
+| `test_stale_owner_budget_refuses` | Accept a stale budget record | RED / GREEN |
+| `test_owner_over_budget_refuses_and_job_persists_diagnostics` | Ignore the persisted over-budget verdict | RED / GREEN |
+| `test_owner_over_budget_refuses_and_job_persists_diagnostics` | Remove recurring computation/persistence | RED / GREEN |
+| `test_workspace_checks_use_exact_caller_transaction` | Move the credit-account read to a separate snapshot | RED / GREEN |
+| `test_workspace_checks_use_exact_caller_transaction` | Swap the workspace ID passed to `read_lease_trust` | RED / GREEN |
+| `test_startup_does_not_read_trust_or_fan_out` | Restore startup gate evaluation | RED / GREEN |
+
+The authorize test runs 12 accepted regional authorizations, asserts exactly one
+set of four Spanner reads with exact SQL and parameter contents, advances an
+injected monotonic clock across TTL, and asserts exactly one additional set.
+Transaction tests inspect SQL, entity keys, workspace IDs, and reader identity;
+they exercise both regional grant/record and spend-lease minting. Additional
+coverage checks evidence expiry within TTL, malformed/mismatched budget
+contracts, failed-scan invalidation, actual account fan-out, and older-job fencing.
+
+## Local validation (2026-09-07)
+
+- `uv run ruff check .`: PASS.
+- `uv run mypy`: PASS (373 source files).
+- `uv run python scripts/prove_trust_gate_cost.py`: all 11 mutations RED;
+  restored baseline GREEN (23 cases).
+- Full suite, using CI's worker grouping:
+  `uv run pytest -q -n 4 --dist loadgroup --cov=trusted_router --cov-report=term:skip-covered --cov-fail-under=70`.
+  **9,850 passed, 408 skipped, 11 xfailed, 15 failed, 8 setup errors**.
+  Coverage **84.19%**, above the 70% requirement. This is not a green full-suite run.
+
+All 23 failed/error cases were rerun on both this tree and an untouched archive
+of local `origin/main` at the revert commit. Results were identical:
+**11 failed, 8 setup errors, 4 passed** on each tree.
+
+- Ten `test_gateway_reuse_probe.py` failures and eight
+  `test_per_enclave_probes.py` setup errors cannot bind loopback sockets in this
+  sandbox (`PermissionError: Operation not permitted`).
+- `test_operational_analytics_dual_write.py::test_the_own_address_check_reaches_a_real_local_address`
+  also fails on both trees because the local network operation is denied.
+- The three full-suite request-body timeout failures in
+  `test_settle_outbox_drain.py`, `test_stubs_and_security.py`, and
+  `test_veriff_webhook.py` pass on rerun on both trees.
+- `test_cloud_rollout_completeness.py::test_verifier_refuses_an_unknown_cloud_without_touching_the_network`
+  passes on both trees after removing the incomplete environment left by a
+  blocked dependency installation. Tests used the existing repository environment
+  with `UV_NO_SYNC=1`, `UV_PROJECT_ENVIRONMENT` pointing to that environment,
+  `PYTHONPATH=src`, and a writable temporary `UV_CACHE_DIR`.
+
+`git fetch` could not update this worktree's external Git metadata under the
+filesystem sandbox; both local `HEAD` and `origin/main` were verified at #1132.
+No production queries, deployments, arm-flag changes, or commits were performed.

--- a/scripts/prove_trust_gate_cost.py
+++ b/scripts/prove_trust_gate_cost.py
@@ -1,0 +1,135 @@
+"""Run the arm-gate negative controls, restoring every mutation before returning.
+
+Run from the repo root: uv run python scripts/prove_trust_gate_cost.py
+The working tree must not be edited concurrently with this script.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+GATE = "src/trusted_router/trust_eligibility.py"
+TESTS = "tests/test_trust_gate_cost.py"
+# Each exact source replacement is deliberately small enough to review.
+MUTATIONS = [
+    (
+        "test_global_verdict_once_per_ttl_across_authorize_calls",
+        GATE,
+        "and cache.verdict.key == key",
+        "and False",
+        "disable cache hits",
+    ),
+    (
+        "test_concurrent_cold_global_verdict_single_flight",
+        GATE,
+        "and cache.verdict.key == key",
+        "and False",
+        "disable cache hits",
+    ),
+    *[
+        (
+            name,
+            GATE,
+            '    from trusted_router.storage_gcp_counters import credit_shard_count\n',
+            '    store._owner_shard_counts_tx(reader, "mutation-owner")\n'
+            '    from trusted_router.storage_gcp_counters import credit_shard_count\n',
+            "insert owner fan-out with the caller's reader",
+        )
+        for name in (
+            "test_regional_authorize_transactions_never_evaluate_global_gate",
+            "test_spend_authorize_transaction_never_evaluates_global_gate",
+        )
+    ],
+    (
+        "test_missing_owner_budget_refuses",
+        GATE,
+        'return "owner_budget_missing"',
+        'return None',
+        "accept an absent owner-budget record",
+    ),
+    (
+        "test_stale_owner_budget_refuses",
+        GATE,
+        'return "owner_budget_stale"',
+        'return None',
+        "accept stale owner-budget evidence",
+    ),
+    (
+        "test_owner_over_budget_refuses_and_job_persists_diagnostics",
+        GATE,
+        '    if budget["violating_owners"] or budget["max_observed_mutations"] > TRUST_OWNER_MUTATION_BUDGET:',
+        '    if False:',
+        "ignore the persisted over-budget verdict",
+    ),
+    (
+        "test_owner_over_budget_refuses_and_job_persists_diagnostics",
+        "src/trusted_router/trust_tier_cli.py",
+        '    if hasattr(store, "_owner_shard_counts_tx"):',
+        '    if False:',
+        "omit recurring budget computation/persistence",
+    ),
+    (
+        "test_workspace_checks_use_exact_caller_transaction",
+        GATE,
+        'account = store._read_entity_tx(reader, "credit", workspace_id, CreditAccount)',
+        'account = store._read_entity("credit", workspace_id, CreditAccount)',
+        "move the credit-account read outside the caller transaction",
+    ),
+    (
+        "test_workspace_checks_use_exact_caller_transaction",
+        GATE,
+        'state = read_lease_trust(reader, store._param_types, workspace_id)',
+        'state = read_lease_trust(reader, store._param_types, "wrong-workspace")',
+        "swap the workspace ID in the transactional trust read",
+    ),
+    (
+        "test_startup_does_not_read_trust_or_fan_out",
+        "src/trusted_router/main.py",
+        '    # Trust admission populates its fail-closed global cache lazily on requests.',
+        '    from trusted_router.trust_eligibility import lease_eligibility\n'
+        '    lease_eligibility(STORE, settings)',
+        "restore startup gate evaluation",
+    ),
+]
+
+
+def pytest_run(selection: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 - fixed local test command
+        ["uv", "run", "pytest", "-q", selection, "--no-cov", "--tb=short"],  # noqa: S607 - repository uv tool
+        cwd=ROOT,
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def main() -> None:
+    baseline = pytest_run(TESTS)
+    if baseline.returncode:
+        raise RuntimeError("green baseline failed:\n" + baseline.stdout + baseline.stderr)
+    print("Baseline GREEN", flush=True)
+    for name, relative, before, after, description in MUTATIONS:
+        path = ROOT / relative
+        original = path.read_text()
+        if original.count(before) != 1:
+            raise RuntimeError(f"mutation is ambiguous: {name}: {before}")
+        try:
+            path.write_text(original.replace(before, after))
+            result = pytest_run(f"{TESTS}::{name}")
+            if result.returncode != 1 or "1 failed" not in result.stdout:
+                raise RuntimeError(f"mutation did not turn test red: {name}\n" + result.stdout + result.stderr)
+            print(f"{name} -> {description} -> RED (mutated) / GREEN (baseline)", flush=True)
+        finally:
+            path.write_text(original)
+    restored = pytest_run(TESTS)
+    if restored.returncode:
+        raise RuntimeError("restored baseline failed:\n" + restored.stdout + restored.stderr)
+    print("Restored baseline GREEN", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/trusted_router/main.py
+++ b/src/trusted_router/main.py
@@ -209,10 +209,7 @@ def create_app(
     if init_observability:
         init_sentry(settings)
         init_axiom(settings)
-    if settings.spend_lease_trust_eligibility_enabled:
-        from trusted_router.trust_eligibility import lease_eligibility
-
-        lease_eligibility(STORE, settings)
+    # Trust admission populates its fail-closed global cache lazily on requests.
     _configure_application_logging()
     # Swagger UI moves to /api/reference so the public docs hub can own
     # /docs (the marketing nav points "Docs" there). ReDoc stays at /redoc.

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -6152,11 +6152,18 @@ class SpannerBigtableStore:
             return None, None
         expected_trust_tier: int | None = None
         if trust_eligibility_enabled:
-            from trusted_router.trust_eligibility import lease_eligibility, spend_cap
+            from trusted_router.trust_eligibility import (
+                global_trust_verdict,
+                lease_eligibility,
+                spend_cap,
+            )
             trust_settings = self.trust_settings
             if trust_settings is None or not trust_settings.spend_lease_trust_eligibility_enabled:
                 return None, "trust_gate_unarmed"
-            expected_trust_tier, reason = lease_eligibility(self, trust_settings, workspace_id)
+            global_verdict = global_trust_verdict(self, trust_settings)
+            expected_trust_tier, reason = lease_eligibility(
+                self, trust_settings, workspace_id, global_verdict=global_verdict
+            )
             if reason:
                 return None, reason
             max_microdollars = spend_cap(trust_settings, expected_trust_tier)
@@ -6270,7 +6277,7 @@ class SpannerBigtableStore:
                             trust_max_age_seconds=(self.trust_settings.trust_reconcile_max_age_seconds
                                                    if trust_eligibility_enabled else 3600),
                             trust_gate=(lambda tx: lease_eligibility(self, self.trust_settings,
-                                        workspace_id, reader=tx)[1]) if trust_eligibility_enabled else None,
+                                        workspace_id, reader=tx, global_verdict=global_verdict)[1]) if trust_eligibility_enabled else None,
                         ),
                         None,
                     )
@@ -6329,7 +6336,7 @@ class SpannerBigtableStore:
                             trust_max_age_seconds=(self.trust_settings.trust_reconcile_max_age_seconds
                                                    if trust_eligibility_enabled else 3600),
                             trust_gate=(lambda tx: lease_eligibility(self, self.trust_settings,
-                                        workspace_id, reader=tx)[1]) if trust_eligibility_enabled else None,
+                                        workspace_id, reader=tx, global_verdict=global_verdict)[1]) if trust_eligibility_enabled else None,
             ),
             None,
         )
@@ -6456,10 +6463,13 @@ class SpannerBigtableStore:
 
         expected_trust_tier: int | None = None
         if trust_eligibility_enabled:
-            from trusted_router.trust_eligibility import lease_eligibility
+            from trusted_router.trust_eligibility import global_trust_verdict, lease_eligibility
             if self.trust_settings is None:
                 return None, "hold_refused", None
-            expected_trust_tier, reason = lease_eligibility(self, self.trust_settings, workspace_id)
+            global_verdict = global_trust_verdict(self, self.trust_settings)
+            expected_trust_tier, reason = lease_eligibility(
+                self, self.trust_settings, workspace_id, global_verdict=global_verdict
+            )
             if reason:
                 return None, "hold_refused", None
             from trusted_router.trust_eligibility import artifact_trust_tier
@@ -6521,7 +6531,7 @@ class SpannerBigtableStore:
                 trust_max_age_seconds=(self.trust_settings.trust_reconcile_max_age_seconds
                                        if trust_eligibility_enabled else 3600),
                 trust_gate=(lambda tx: lease_eligibility(self, self.trust_settings,
-                            workspace_id, reader=tx)[1]) if trust_eligibility_enabled else None,
+                            workspace_id, reader=tx, global_verdict=global_verdict)[1]) if trust_eligibility_enabled else None,
             ),
             None,
             None,

--- a/src/trusted_router/storage_gcp_regional_quota.py
+++ b/src/trusted_router/storage_gcp_regional_quota.py
@@ -266,6 +266,12 @@ def grant_regional_quota_lease(
     entity_id = _lease_entity_id(workspace_id, region, lease_id)
     fence_id = _fence_entity_id(workspace_id, region, quota_shard)
 
+    from trusted_router.trust_eligibility import global_trust_verdict
+
+    settings: Any = getattr(store, "trust_settings", None)
+    armed = settings is not None and settings.spend_lease_trust_eligibility_enabled
+    global_verdict = global_trust_verdict(store, settings) if armed else None
+
     def txn(transaction: Any) -> GlobalRegionalQuotaLease | None:
         fence = store._read_entity_tx(
             transaction,
@@ -279,13 +285,11 @@ def grant_regional_quota_lease(
         if fence is not None and fence.active_lease_id is not None:
             return None
         from trusted_router.trust_eligibility import lease_eligibility, tier_cap
-        settings: Any = getattr(store, "trust_settings", None)
         tier = None
         cap = None
         tx_grant = grant
-        armed = settings is not None and settings.spend_lease_trust_eligibility_enabled
         if armed:
-            tier, reason = lease_eligibility(store, settings, workspace_id, reader=transaction)
+            tier, reason = lease_eligibility(store, settings, workspace_id, reader=transaction, global_verdict=global_verdict)
             if reason:
                 log.info("regional_quota.no_lease_reason=%s workspace_id=%s", reason, workspace_id)
                 return None
@@ -696,6 +700,12 @@ def record_regional_gateway_authorization(
             "authorization_id": existing["authorization_id"],
         }
 
+    from trusted_router.trust_eligibility import global_trust_verdict
+
+    settings: Any = getattr(store, "trust_settings", None)
+    armed = settings is not None and settings.spend_lease_trust_eligibility_enabled
+    global_verdict = global_trust_verdict(store, settings) if armed else None
+
     def txn(transaction: Any) -> dict[str, Any]:
         if idempotency_scope is not None:
             existing = read_reservation_by_idempotency(
@@ -708,8 +718,6 @@ def record_regional_gateway_authorization(
                     return {"outcome": "idempotency_mismatch"}
                 return replay(existing)
         from trusted_router.trust_eligibility import billing_paused_tx, lease_eligibility, tier_cap
-        settings: Any = getattr(store, "trust_settings", None)
-        armed = settings is not None and settings.spend_lease_trust_eligibility_enabled
         reason = "billing_paused" if armed and billing_paused_tx(transaction, store._param_types, authorization.workspace_id) else None
         current = None
         if armed or reason:
@@ -717,7 +725,7 @@ def record_regional_gateway_authorization(
                 _lease_entity_id(authorization.workspace_id, str(authorization.region),
                                  str(authorization.regional_lease_id)), GlobalRegionalQuotaLease)
         if armed:
-            tier, gate_reason = lease_eligibility(store, settings, authorization.workspace_id, reader=transaction)
+            tier, gate_reason = lease_eligibility(store, settings, authorization.workspace_id, reader=transaction, global_verdict=global_verdict)
             reason = reason or gate_reason
             if reason is None:
                 cap = tier_cap(settings, tier or 0)

--- a/src/trusted_router/trust_eligibility.py
+++ b/src/trusted_router/trust_eligibility.py
@@ -3,12 +3,20 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
-from datetime import UTC, datetime
+import threading
+import time
+import weakref
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from trusted_router.config import Settings
-from trusted_router.trust_ownership import require_owner_trust_budget
+from trusted_router.trust_owner_budget import (
+    OWNER_BUDGET_KIND,
+    OWNER_BUDGET_VERSION,
+    owner_budget_id,
+)
+from trusted_router.trust_ownership import TRUST_OWNER_MUTATION_BUDGET
 from trusted_router.trust_reconciliation import (
     OWNER_INVENTORY_ACCOUNT_ID,
     OWNER_INVENTORY_PROVIDER,
@@ -126,6 +134,7 @@ def trust_gate_failure(
     *,
     reader: Any,
     now: datetime,
+    deadlines: list[tuple[datetime, str]],
 ) -> str | None:
     from trusted_router.storage_trust_reconciliation import MARKER_COLUMNS, _marker_from_row
 
@@ -161,13 +170,18 @@ def trust_gate_failure(
             OWNER_INVENTORY_SOURCE_VERSION,
         )
     )
-    markers = [
-        _marker_from_row(row)
-        for row in reader.execute_sql(
-            "SELECT " + ", ".join(MARKER_COLUMNS) + " FROM tr_trust_backfill",  # noqa: S608 - fixed columns
-        )
-    ]
     for requirement in requirements:
+        params = asdict(requirement)
+        markers = [
+            _marker_from_row(row)
+            for row in reader.execute_sql(
+                "SELECT " + ", ".join(MARKER_COLUMNS) + " FROM tr_trust_backfill "  # noqa: S608 - fixed columns
+                "WHERE provider=@provider AND account_id=@account_id "
+                "AND environment=@environment AND source=@source AND source_version=@source_version",
+                params=params,
+                param_types={key: store._param_types.STRING for key in params},
+            )
+        ]
         marker = next((m for m in markers if completed_marker_satisfies(m, requirement)), None)
         if (
             marker is None
@@ -189,17 +203,134 @@ def trust_gate_failure(
                 max_age_seconds=settings.trust_reconcile_max_age_seconds,
             ):
                 return "marker_stale"
-    owners = {
-        str(row[0])
-        for row in reader.execute_sql(
-            "SELECT owner_user_id, workspace_id FROM tr_owner_workspace "
-            "ORDER BY owner_user_id, workspace_id",
-        )
-    }
-    for owner in owners:
-        _ids, counts = store._owner_shard_counts_tx(reader, owner)
-        require_owner_trust_budget(counts)
+            deadlines.append((
+                marker.closed_through + timedelta(seconds=settings.trust_reconcile_max_age_seconds),
+                "marker_stale",
+            ))
+    budget = store._read_entity_tx(
+        reader, OWNER_BUDGET_KIND, owner_budget_id(settings.environment), dict
+    )
+    if budget is None:
+        return "owner_budget_missing"
+    if (
+        budget["source_version"] != OWNER_BUDGET_VERSION
+        or budget["environment"] != settings.environment
+        or budget["mutation_budget"] != TRUST_OWNER_MUTATION_BUDGET
+        or budget["scan_complete"] is not True
+        or type(budget["max_observed_mutations"]) is not int
+        or budget["max_observed_mutations"] < 0
+    ):
+        return "read_failed"
+    computed_at = datetime.fromisoformat(budget["computed_at"])
+    if not reconciliation_is_fresh(
+        computed_at, now=now, max_age_seconds=settings.trust_reconcile_max_age_seconds
+    ):
+        return "owner_budget_stale"
+    deadlines.append((
+        computed_at + timedelta(seconds=settings.trust_reconcile_max_age_seconds),
+        "owner_budget_stale",
+    ))
+    if budget["violating_owners"] or budget["max_observed_mutations"] > TRUST_OWNER_MUTATION_BUDGET:
+        # The old require_owner_trust_budget exception was exposed as read_failed.
+        return "read_failed"
     return None
+
+
+GLOBAL_TRUST_TTL_SECONDS = 15
+
+
+def _global_key(store: Any, settings: Settings) -> tuple[Any, ...]:
+    return (
+        id(getattr(store, "_database", None)),
+        getattr(store, "request_record_write_mode", None),
+        settings.storage_backend,
+        settings.request_record_write_mode,
+        settings.spend_lease_trust_eligibility_enabled,
+        settings.trust_qualifying_provider_set,
+        settings.trust_stripe_account_id,
+        settings.environment,
+        settings.trust_reconcile_max_age_seconds,
+        settings.trust_reconcile_interval_seconds,
+    )
+
+
+@dataclass(frozen=True)
+class GlobalTrustVerdict:
+    key: tuple[Any, ...]
+    failure: str | None
+    evaluated_at: datetime
+    expires_monotonic: float
+    deadlines: tuple[tuple[datetime, str], ...] = ()
+
+    def refusal(self, store: Any, settings: Settings, now: datetime) -> str | None:
+        # Pure consumption, including after a transaction retry or a delayed
+        # binding plan. Never refresh from within the caller's transaction.
+        if self.key != _global_key(store, settings) or time.monotonic() >= self.expires_monotonic:
+            return "global_verdict_expired"
+        if now < self.evaluated_at:
+            return "read_failed"
+        if self.failure:
+            return self.failure
+        for deadline, reason in self.deadlines:
+            if now > deadline:
+                return reason
+        return None
+
+
+@dataclass
+class _GlobalCache:
+    lock: Any = field(default_factory=threading.Lock)
+    verdict: GlobalTrustVerdict | None = None
+
+
+_caches: weakref.WeakKeyDictionary[Any, _GlobalCache] = weakref.WeakKeyDictionary()
+_caches_lock = threading.Lock()
+
+
+def global_trust_verdict(
+    store: Any, settings: Settings, *, now: datetime | None = None
+) -> GlobalTrustVerdict:
+    """Lazy single-flight refresh outside transactions; cache refusals too.
+
+    Evidence deadlines are checked again at consumption, so a TTL never extends
+    a marker's max age. Configuration changes get a separate evaluation.
+    """
+    with _caches_lock:
+        cache = _caches.setdefault(store, _GlobalCache())
+    with cache.lock:
+        key = _global_key(store, settings)
+        if (
+            cache.verdict is not None
+            and cache.verdict.key == key
+            and time.monotonic() < cache.verdict.expires_monotonic
+        ):
+            return cache.verdict
+        evaluated_at = now or datetime.now(UTC)
+        started = time.monotonic()
+        deadlines: list[tuple[datetime, str]] = []
+        try:
+            with store._database.snapshot(multi_use=True) as snapshot:
+                failure = trust_gate_failure(
+                    store, settings, reader=snapshot, now=evaluated_at, deadlines=deadlines
+                )
+        except Exception:
+            log.exception("trust.gate_unarmed read_failed")
+            failure = "read_failed"
+        verdict = GlobalTrustVerdict(
+            key, failure, evaluated_at, started + GLOBAL_TRUST_TTL_SECONDS, tuple(deadlines)
+        )
+        cache.verdict = verdict
+        return verdict
+
+
+def _unarmed(failure: str) -> tuple[int | None, str | None]:
+    from trusted_router.synthetic.alerts import ops_alert
+
+    log.error("trust.gate_unarmed condition=%s", failure)
+    ops_alert(
+        f"trust.gate_unarmed condition={failure}", fingerprint=["trust.gate_unarmed", failure]
+    )
+    return None, "trust_gate_unarmed"
 
 
 def lease_eligibility(
@@ -209,28 +340,39 @@ def lease_eligibility(
     *,
     reader: Any = None,
     now: datetime | None = None,
+    global_verdict: GlobalTrustVerdict | None = None,
 ) -> tuple[int | None, str | None]:
     if not settings.spend_lease_trust_eligibility_enabled:
         return None, None
     now = now or datetime.now(UTC)
-    try:
-        if reader is None:
-            with store._database.snapshot(multi_use=True) as snapshot:
-                return lease_eligibility(store, settings, workspace_id, reader=snapshot, now=now)
-        failure = trust_gate_failure(store, settings, reader=reader, now=now)
-    except Exception:
-        log.exception("trust.gate_unarmed read_failed")
-        failure = "read_failed"
+    if reader is None:
+        try:
+            global_verdict = global_verdict or global_trust_verdict(store, settings, now=now)
+        except Exception:
+            log.exception("trust.gate_unarmed read_failed")
+            return _unarmed("read_failed")
+    # A caller supplying a transaction MUST also supply the global verdict.
+    # Missing/expired evidence refuses without opening a snapshot or doing I/O.
+    failure = (
+        global_verdict.refusal(store, settings, now)
+        if global_verdict is not None else "global_verdict_missing"
+    )
     if failure:
-        from trusted_router.synthetic.alerts import ops_alert
-
-        log.error("trust.gate_unarmed condition=%s", failure)
-        ops_alert(
-            f"trust.gate_unarmed condition={failure}", fingerprint=["trust.gate_unarmed", failure]
-        )
-        return None, "trust_gate_unarmed"
+        return _unarmed(failure)
     if workspace_id is None:
         return None, None
+    if reader is None:
+        try:
+            with store._database.snapshot(multi_use=True) as snapshot:
+                return lease_eligibility(
+                    store, settings, workspace_id, reader=snapshot, now=now,
+                    global_verdict=global_verdict,
+                )
+        except Exception:
+            # Preserve the non-transactional admission refusal on snapshot or
+            # workspace-read failure. Transaction callers still own retries.
+            log.exception("trust.gate_unarmed read_failed")
+            return _unarmed("read_failed")
     from trusted_router.storage_gcp_counters import credit_shard_count
     from trusted_router.storage_models import CreditAccount
 

--- a/src/trusted_router/trust_owner_budget.py
+++ b/src/trusted_router/trust_owner_budget.py
@@ -1,0 +1,82 @@
+"""Recurring, durable proof of the fleet-wide owner trust mutation budget.
+
+The backfill marker schema cannot hold the budget and operator diagnostics.
+Use one versioned, environment-scoped entity and the marker freshness policy;
+only the tier job scans owners. Admission reads this entity by its full key.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from trusted_router.trust_ownership import (
+    TRUST_OWNER_MUTATION_BUDGET,
+    OwnerTrustMutationBudgetExceeded,
+    owner_trust_mutations,
+    require_owner_trust_budget,
+)
+
+log = logging.getLogger(__name__)
+OWNER_BUDGET_KIND = "trust_owner_budget"
+OWNER_BUDGET_VERSION = "owner-budget-v1"
+
+
+def owner_budget_id(environment: str) -> str:
+    return f"{OWNER_BUDGET_VERSION}:{environment}"
+
+
+def recompute_owner_budget(
+    store: Any, *, environment: str, now: datetime | None = None
+) -> dict[str, Any]:
+    # Stamp the beginning, not completion: a slow scan must not rejuvenate old
+    # evidence. All owners and credit accounts come from one strong snapshot.
+    computed_at = now or datetime.now(UTC)
+    maximum = 0
+    violating: list[str] = []
+    scan_complete = False
+    try:
+        with store._database.snapshot(multi_use=True) as reader:
+            owners = {
+                str(row[0])
+                for row in reader.execute_sql(
+                    "SELECT owner_user_id, workspace_id FROM tr_owner_workspace "
+                    "ORDER BY owner_user_id, workspace_id"
+                )
+            }
+            for owner in sorted(owners):
+                _ids, counts = store._owner_shard_counts_tx(reader, owner)
+                maximum = max(maximum, owner_trust_mutations(counts))
+                try:
+                    require_owner_trust_budget(counts)
+                except OwnerTrustMutationBudgetExceeded:
+                    violating.append(owner)
+            scan_complete = True
+    except Exception:
+        # Invalidate the previous success even on a partial/failed scan.
+        log.exception("trust.owner_budget_scan_failed")
+    verdict = {
+        "source_version": OWNER_BUDGET_VERSION,
+        "environment": environment,
+        "computed_at": computed_at.isoformat(),
+        "max_observed_mutations": maximum,
+        "mutation_budget": TRUST_OWNER_MUTATION_BUDGET,
+        "violating_owners": violating,
+        "scan_complete": scan_complete,
+    }
+
+    def save(transaction: Any) -> None:
+        previous = store._read_entity_tx(
+            transaction, OWNER_BUDGET_KIND, owner_budget_id(environment), dict
+        )
+        # Overlapping scheduler retries cannot replace newer evidence.
+        if previous and datetime.fromisoformat(previous["computed_at"]) > computed_at:
+            return
+        store._write_entity_tx(
+            transaction, OWNER_BUDGET_KIND, owner_budget_id(environment), verdict
+        )
+
+    store._run_in_transaction(save)
+    log.info("trust.owner_budget verdict=%s", verdict)
+    return verdict

--- a/src/trusted_router/trust_tier_cli.py
+++ b/src/trusted_router/trust_tier_cli.py
@@ -41,6 +41,7 @@ class _TrustTierStore(Protocol):
 class TrustTierJobResult:
     attempted: int
     failed: tuple[str, ...] = field(default_factory=tuple)
+    owner_budget_failed: bool = False
 
     @property
     def succeeded(self) -> int:
@@ -93,7 +94,21 @@ def run(
         except Exception:
             failed.append(workspace_id)
             log.exception("trust.tier_job_workspace_failed workspace_id=%s", workspace_id)
-    return TrustTierJobResult(attempted=len(workspace_ids), failed=tuple(failed))
+    owner_budget_failed = False
+    # Only typed Spanner can arm lease trust. Legacy backends have no fleet
+    # proof consumer, but continue their existing tier/watermark work.
+    if hasattr(store, "_owner_shard_counts_tx"):
+        from trusted_router.trust_owner_budget import recompute_owner_budget
+
+        try:
+            verdict = recompute_owner_budget(store, environment=environment, now=computed_at)
+            owner_budget_failed = not verdict["scan_complete"] or bool(verdict["violating_owners"])
+        except Exception:
+            owner_budget_failed = True
+            log.exception("trust.owner_budget_persist_failed")
+    return TrustTierJobResult(
+        attempted=len(workspace_ids), failed=tuple(failed), owner_budget_failed=owner_budget_failed
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -113,7 +128,7 @@ def main(argv: list[str] | None = None) -> int:
         len(result.failed),
         args.environment,
     )
-    if result.failed:
+    if result.failed or result.owner_budget_failed:
         log.error("trust.tier_job_failures workspace_ids=%s", ",".join(result.failed))
         return 1
     return 0

--- a/tests/test_trust_eligibility_pr2.py
+++ b/tests/test_trust_eligibility_pr2.py
@@ -45,6 +45,9 @@ def arm_store(store: Any, db: Any) -> Settings:
         db.typed.setdefault("tr_trust_backfill", {})[
             (provider, marker.account_id, "test", marker.source, marker.source_version)
         ] = row
+    from trusted_router.trust_owner_budget import recompute_owner_budget
+
+    recompute_owner_budget(store, environment=settings.environment)
     return settings
 
 
@@ -132,6 +135,9 @@ def test_gate_other_preconditions(condition: str, monkeypatch: pytest.MonkeyPatc
         monkeypatch.setattr(
             type(store), "_owner_shard_counts_tx", lambda *_: (["workspace"], [3000])
         )
+        from trusted_router.trust_owner_budget import recompute_owner_budget
+
+        recompute_owner_budget(store, environment=settings.environment)
     elif condition == "stale":
         marker["closed_through"] = datetime.now(UTC) - timedelta(seconds=3601)
     elif condition == "future":
@@ -330,6 +336,10 @@ def test_regional_record_race_refunds_bigtable_hold_and_retires(
             current["trust_reconciled_through"] = None
         elif change == "gate":
             db.typed["tr_trust_backfill"].clear()
+            from trusted_router.trust_eligibility import _caches
+
+            # The next admission refreshes outside its transaction after TTL.
+            object.__setattr__(_caches[store].verdict, "expires_monotonic", 0)
         else:
             for (kind, _id), record in db.rows.items():
                 if kind == "regional_quota_lease":
@@ -804,7 +814,7 @@ def test_flag_off_regional_payload_is_byte_identical() -> None:
     assert _regional_json_body(lease).encode() == json_body(before).encode()
 
 
-def test_startup_alerts_for_unarmed_flag_and_runtime_can_recover(
+def test_startup_does_not_evaluate_gate_and_runtime_can_recover(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from trusted_router.main import create_app
@@ -818,7 +828,12 @@ def test_startup_alerts_for_unarmed_flag_and_runtime_can_recover(
     messages: list[str] = []
     monkeypatch.setattr(alerts, "ops_alert", lambda message, **_kw: messages.append(message))
     create_app(settings, configure_store_arg=False, init_observability=False)
+    assert messages == []
+    assert lease_eligibility(store, settings, "workspace")[1] == "trust_gate_unarmed"
     assert any("trust.gate_unarmed" in message for message in messages)
+    from trusted_router.trust_eligibility import _caches
+
+    _caches.pop(store)
     arm_store(store, db)
     workspace_state(db)
     assert lease_eligibility(store, settings, "workspace") == (3, None)
@@ -1015,6 +1030,12 @@ def test_authoritative_mint_rechecks_after_candidate_preparation(change: str, re
         row["billing_pause_causes"] = ["abuse"]
     else:
         db.typed["tr_trust_backfill"].clear()
+        # Prepared callbacks never refresh global evidence in a transaction.
+        # A delayed plan must refuse once its captured verdict expires.
+        from trusted_router.trust_eligibility import _caches
+
+        verdict = _caches[store].verdict
+        object.__setattr__(verdict, "expires_monotonic", 0)
     outcome, authorization = _authorize_store(store, key.hash, plan)
     if change == "pause":
         assert (outcome, authorization) == ("billing_paused", None)

--- a/tests/test_trust_gate_cost.py
+++ b/tests/test_trust_gate_cost.py
@@ -1,0 +1,440 @@
+"""Operation-content proofs for the lazy fleet gate and transactional workspace gate."""
+
+from __future__ import annotations
+
+import json
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from tests.fakes.spanner import _FakeTransaction, make_fake_store
+from tests.test_trust_eligibility_pr2 import arm_store, regional_args, workspace_state
+from trusted_router import trust_eligibility as gate
+from trusted_router.regional_quota_ledger import InMemoryRegionalQuotaLedger
+from trusted_router.storage_models import CreditAccount
+from trusted_router.trust_owner_budget import (
+    OWNER_BUDGET_KIND,
+    owner_budget_id,
+    recompute_owner_budget,
+)
+from trusted_router.trust_ownership import TRUST_OWNER_MUTATION_BUDGET
+
+
+@pytest.fixture
+def armed() -> tuple[Any, Any, Any]:
+    store, db, _ = make_fake_store(request_record_write_mode="typed")
+    settings = arm_store(store, db)
+    workspace_state(db)
+    return store, db, settings
+
+
+def _budget(store: Any, **changes: Any) -> None:
+    value = store._read_entity(OWNER_BUDGET_KIND, owner_budget_id("test"), dict)
+    value.update(changes)
+    store._write_entity(OWNER_BUDGET_KIND, owner_budget_id("test"), value)
+
+
+def _global_reads(db: Any) -> list[tuple[str, dict[str, Any]]]:
+    return [
+        (sql, params)
+        for sql, params in zip(db.snapshot_sql, db.snapshot_sql_params, strict=True)
+        if "tr_trust_backfill" in sql or params.get("kind") == OWNER_BUDGET_KIND
+    ]
+
+
+def _assert_global_read_contents(db: Any, evaluations: int) -> None:
+    from trusted_router.storage_trust_reconciliation import MARKER_COLUMNS
+
+    marker_sql = (
+        "SELECT " + ", ".join(MARKER_COLUMNS) + " FROM tr_trust_backfill "  # noqa: S608 - fixed columns
+        "WHERE provider=@provider AND account_id=@account_id "
+        "AND environment=@environment AND source=@source AND source_version=@source_version"
+    )
+    expected = [
+        (marker_sql, dict(provider=provider, account_id="acct_1", environment="test",
+                         source="stripe-created-lists", source_version="stripe-trust-v1"))
+        for provider in ("stripe", "x402")
+    ] + [
+        (marker_sql, dict(provider="owner_inventory", account_id="local", environment="test",
+                         source="tr_entities.workspace", source_version="owner-inventory-v1")),
+        ("SELECT body FROM tr_entities WHERE kind=@kind AND id=@id",
+         {"kind": "trust_owner_budget", "id": "owner-budget-v1:test"}),
+    ]
+    assert _global_reads(db) == expected * evaluations
+
+
+def _regional_setup(armed: tuple[Any, Any, Any]) -> tuple[Any, Any, Any]:
+    store, db, _ = armed
+    ws = store.create_workspace("owner-hot", "gate-cost", trial_credit_microdollars=200_000_000)
+    workspace_state(db, 3, ws.id)
+    _raw, key = store.create_api_key(workspace_id=ws.id, name="key", creator_user_id="owner-hot")
+    store._regional_quota_ledger = InMemoryRegionalQuotaLedger()
+    db.snapshot_sql.clear()
+    db.snapshot_sql_params.clear()
+    return store, db, key
+
+
+def test_global_verdict_once_per_ttl_across_authorize_calls(armed: Any, monkeypatch: Any) -> None:
+    store, db, key = _regional_setup(armed)
+    clock = [100.0]
+    monkeypatch.setattr(gate.time, "monotonic", lambda: clock[0])
+    before = db.snapshot_execute_sql_calls
+    for i in range(12):
+        args = regional_args(key.workspace_id, key)
+        args["idempotency_key"] = f"request-{i}"
+        result, authorization = store.authorize_gateway_regional(authorization_id=f"auth-{i}", **args)
+        assert result == "accepted" and authorization is not None
+        _assert_global_read_contents(db, 1)
+    assert db.snapshot_execute_sql_calls > before  # Real Spanner-shaped calls were exercised.
+    assert not any("tr_owner_workspace" in sql for sql in db.snapshot_sql)
+    clock[0] += gate.GLOBAL_TRUST_TTL_SECONDS
+    args["idempotency_key"] = "after-ttl"
+    result, authorization = store.authorize_gateway_regional(authorization_id="after-ttl", **args)
+    assert result == "accepted" and authorization is not None
+    _assert_global_read_contents(db, 2)
+
+
+def test_global_verdict_ttl_bounds_refusal_recovery() -> None:
+    # Increasing the recovery ceiling must be an explicit contract change.
+    assert 0 < gate.GLOBAL_TRUST_TTL_SECONDS <= 15
+
+
+def test_cached_refusal_recovers_after_ttl(armed: Any, monkeypatch: Any, caplog: Any) -> None:
+    store, db, settings = armed
+    clock = [100.0]
+    monkeypatch.setattr(gate.time, "monotonic", lambda: clock[0])
+    now = datetime.now(UTC)
+    budget_key = (OWNER_BUDGET_KIND, owner_budget_id("test"))
+    budget = db.rows.pop(budget_key)
+    db.snapshot_sql.clear()
+    db.snapshot_sql_params.clear()
+    assert gate.lease_eligibility(store, settings, "workspace", now=now) == (
+        None, "trust_gate_unarmed"
+    )
+    assert "condition=owner_budget_missing" in caplog.text
+    refused = gate.global_trust_verdict(store, settings, now=now)
+    assert refused.failure == "owner_budget_missing"
+    _assert_global_read_contents(db, 1)
+
+    # Repair the evidence while its refusal is still cached.
+    db.rows[budget_key] = budget
+    clock[0] += min(gate.GLOBAL_TRUST_TTL_SECONDS, 15) - 0.001
+    assert gate.global_trust_verdict(store, settings, now=now) is refused
+    assert gate.lease_eligibility(store, settings, "workspace", now=now) == (
+        None, "trust_gate_unarmed"
+    )
+    _assert_global_read_contents(db, 1)
+
+    # Fixed recovery budget: deriving this advance from the TTL would permit 86400.
+    clock[0] = 115.0
+    assert gate.lease_eligibility(store, settings, "workspace", now=now) == (3, None)
+    refreshed = gate.global_trust_verdict(store, settings, now=now)
+    assert refreshed is not refused and refreshed.failure is None
+    _assert_global_read_contents(db, 2)
+
+
+def test_concurrent_cold_global_verdict_single_flight(armed: Any) -> None:
+    store, db, settings = armed
+    db.snapshot_sql.clear()
+    db.snapshot_sql_params.clear()
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        verdicts = list(executor.map(lambda _: gate.global_trust_verdict(store, settings), range(32)))
+    assert all(verdict is verdicts[0] for verdict in verdicts)
+    _assert_global_read_contents(db, 1)
+
+
+def _spy_transactions(monkeypatch: Any) -> list[tuple[Any, str, dict[str, Any]]]:
+    calls: list[tuple[Any, str, dict[str, Any]]] = []
+    original = _FakeTransaction.execute_sql
+
+    def execute(self: Any, sql: str, **kwargs: Any) -> Any:
+        calls.append((self, sql, dict(kwargs.get("params") or {})))
+        return original(self, sql, **kwargs)
+
+    monkeypatch.setattr(_FakeTransaction, "execute_sql", execute)
+    return calls
+
+
+def _assert_workspace_ops(calls: Any, workspace: str) -> None:
+    assert calls
+    assert not any("tr_owner_workspace" in sql or "tr_trust_backfill" in sql
+                   or params.get("kind") == OWNER_BUDGET_KIND for _, sql, params in calls)
+    reads = [(sql, params) for _, sql, params in calls]
+    assert ("SELECT body FROM tr_entities WHERE kind=@kind AND id=@id",
+            {"kind": "credit", "id": workspace}) in reads
+    assert ("SELECT shard FROM tr_credit_balance WHERE workspace_id=@ws ORDER BY shard",
+            {"ws": workspace}) in reads
+    assert ("SELECT trust_tier, trust_latched_at, billing_pause_causes, pause_epoch, "
+            "trust_reconciled_through FROM tr_credit_balance WHERE workspace_id=@ws",
+            {"ws": workspace}) in reads
+
+
+def test_regional_authorize_transactions_never_evaluate_global_gate(armed: Any, monkeypatch: Any) -> None:
+    store, db, key = _regional_setup(armed)
+    calls = _spy_transactions(monkeypatch)
+    result, authorization = store.authorize_gateway_regional(
+        authorization_id="auth", **regional_args(key.workspace_id, key)
+    )
+    assert result == "accepted" and authorization is not None
+    _assert_workspace_ops(calls, key.workspace_id)
+    # Both grant and record must independently perform the workspace check.
+    shard_readers = {id(reader) for reader, sql, _ in calls if sql.startswith("SELECT shard FROM")}
+    assert len(shard_readers) == 2
+    assert not any("tr_owner_workspace" in sql for sql in db.snapshot_sql)
+    _assert_global_read_contents(db, 1)
+
+
+def _prepare(store: Any, key: Any) -> Any:
+    from trusted_router.spend_leases import SpendLeaseSigner
+
+    plan, refusal = store.prepare_gateway_spend_lease_binding(
+        workspace_id="workspace-1", key_hash=key.hash, authorization_id="authorization-bound",
+        idempotency_key="idem-bound", idempotency_fingerprint="fingerprint-bound", estimate=500,
+        boot_kid="boot-1", region="us-central1", signer=SpendLeaseSigner(lambda: bytes(range(32))),
+        catalog={"version": "v", "candidates": []}, ttl_seconds=60, skew_seconds=10,
+        max_microdollars=1_000_000, max_available_basis_points=1000,
+        echo_lease_id=None, echo_state=None,
+    )
+    assert refusal is None and plan is not None
+    return plan
+
+
+def test_spend_authorize_transaction_never_evaluates_global_gate(monkeypatch: Any) -> None:
+    from tests.test_spend_lease_authorize import _authorize_store, _store_binding_harness
+
+    store, db, key, _, _ = _store_binding_harness()
+    arm_store(store, db)
+    workspace_state(db, 3, "workspace-1")
+    db.snapshot_sql.clear()
+    db.snapshot_sql_params.clear()
+    plan = _prepare(store, key)
+    calls = _spy_transactions(monkeypatch)
+    before = len(db.snapshot_sql)
+    _, authorization = _authorize_store(store, key.hash, plan)
+    assert authorization is not None and authorization.spend_lease_token is not None
+    _assert_workspace_ops(calls, "workspace-1")
+    # Existing shard-count cache hydration happens before authorize's transaction.
+    assert list(zip(db.snapshot_sql[before:], db.snapshot_sql_params[before:], strict=True)) == [
+        ("SELECT body FROM tr_entities WHERE kind=@kind AND id=@id",
+         {"kind": "credit", "id": "workspace-1"})
+    ]
+    _assert_global_read_contents(db, 1)
+
+
+def test_missing_owner_budget_refuses(armed: Any, caplog: Any) -> None:
+    store, db, settings = armed
+    del db.rows[(OWNER_BUDGET_KIND, owner_budget_id("test"))]
+    assert gate.lease_eligibility(store, settings, "workspace") == (None, "trust_gate_unarmed")
+    assert "condition=owner_budget_missing" in caplog.text
+
+
+def test_stale_owner_budget_refuses(armed: Any, caplog: Any) -> None:
+    store, _, settings = armed
+    _budget(store, computed_at=(datetime.now(UTC) - timedelta(seconds=3601)).isoformat())
+    assert gate.lease_eligibility(store, settings, "workspace") == (None, "trust_gate_unarmed")
+    assert "condition=owner_budget_stale" in caplog.text
+
+
+def test_owner_over_budget_refuses_and_job_persists_diagnostics(armed: Any, monkeypatch: Any, caplog: Any) -> None:
+    from trusted_router.trust_tier_cli import run
+
+    store, db, settings = armed
+    db.typed["tr_owner_workspace"] = {
+        (owner, ws): {"owner_user_id": owner, "workspace_id": ws}
+        for owner, ws in [("over-owner", "w1"), ("over-owner", "w2"), ("ok-owner", "w3")]
+    }
+    observed: list[tuple[Any, str]] = []
+
+    def counts(self: Any, reader: Any, owner: str) -> Any:
+        assert self is store and not isinstance(reader, _FakeTransaction)
+        observed.append((reader, owner))
+        return (["w1", "w2"], [1500, 1500]) if owner == "over-owner" else (["w3"], [16])
+
+    monkeypatch.setattr(type(store), "_owner_shard_counts_tx", counts)
+    monkeypatch.setattr(type(store), "list_trust_tier_workspace_ids", lambda self: ())
+    now = datetime.now(UTC)
+    result = run(store, settings, environment="test", now=now)
+    assert result.owner_budget_failed
+    assert [owner for _, owner in observed] == ["ok-owner", "over-owner"]
+    assert observed[0][0] is observed[1][0]
+    persisted = json.loads(db.rows[("trust_owner_budget", "owner-budget-v1:test")].body)
+    assert persisted == {
+        "source_version": "owner-budget-v1", "environment": "test", "computed_at": now.isoformat(),
+        "mutation_budget": TRUST_OWNER_MUTATION_BUDGET, "max_observed_mutations": 21000,
+        "violating_owners": ["over-owner"], "scan_complete": True,
+    }
+    assert gate.lease_eligibility(store, settings, "workspace") == (None, "trust_gate_unarmed")
+    assert "condition=read_failed" in caplog.text
+
+
+def test_workspace_checks_use_exact_caller_transaction(armed: Any, monkeypatch: Any) -> None:
+    store, db, settings = armed
+    verdict = gate.global_trust_verdict(store, settings)
+    calls = _spy_transactions(monkeypatch)
+    before = db.snapshot_execute_sql_calls
+    readers = []
+
+    def txn(reader: Any) -> Any:
+        readers.append(reader)
+        return gate.lease_eligibility(store, settings, "workspace", reader=reader, global_verdict=verdict)
+
+    assert store._run_in_transaction(txn) == (3, None)
+    _assert_workspace_ops(calls, "workspace")
+    assert all(reader is readers[0] for reader, _, _ in calls)
+    assert db.snapshot_execute_sql_calls == before
+    assert len(calls) == 3
+
+
+def test_transaction_without_global_verdict_refuses_without_io(armed: Any, caplog: Any) -> None:
+    store, db, settings = armed
+    before = (db.snapshot_execute_sql_calls, db.transaction_execute_sql_calls)
+    result = store._run_in_transaction(
+        lambda tx: gate.lease_eligibility(store, settings, "workspace", reader=tx)
+    )
+    assert result == (None, "trust_gate_unarmed")
+    assert "condition=global_verdict_missing" in caplog.text
+    assert (db.snapshot_execute_sql_calls, db.transaction_execute_sql_calls) == before
+
+
+def test_transaction_expired_global_verdict_refuses_without_io(
+    armed: Any, monkeypatch: Any, caplog: Any
+) -> None:
+    store, db, settings = armed
+    clock = [100.0]
+    monkeypatch.setattr(gate.time, "monotonic", lambda: clock[0])
+    now = datetime.now(UTC)
+    verdict = gate.global_trust_verdict(store, settings, now=now)
+    assert verdict.refusal(store, settings, now) is None
+    assert store._run_in_transaction(
+        lambda tx: gate.lease_eligibility(
+            store, settings, "workspace", reader=tx, global_verdict=verdict, now=now
+        )
+    ) == (3, None)
+    before = (len(db.snapshot_calls), db.snapshot_execute_sql_calls,
+              db.transaction_execute_sql_calls, db.transaction_execute_update_calls)
+
+    clock[0] = verdict.expires_monotonic + 0.001
+    assert verdict.key == gate._global_key(store, settings)
+    result = store._run_in_transaction(
+        lambda tx: gate.lease_eligibility(
+            store, settings, "workspace", reader=tx, global_verdict=verdict, now=now
+        )
+    )
+    assert result == (None, "trust_gate_unarmed")
+    assert "condition=global_verdict_expired" in caplog.text
+    assert (len(db.snapshot_calls), db.snapshot_execute_sql_calls,
+            db.transaction_execute_sql_calls, db.transaction_execute_update_calls) == before
+
+
+def test_transaction_changed_global_key_refuses_without_io(
+    armed: Any, monkeypatch: Any, caplog: Any
+) -> None:
+    store, db, settings = armed
+    monkeypatch.setattr(gate.time, "monotonic", lambda: 100.0)
+    now = datetime.now(UTC)
+    verdict = gate.global_trust_verdict(store, settings, now=now)
+    assert verdict.refusal(store, settings, now) is None
+    assert store._run_in_transaction(
+        lambda tx: gate.lease_eligibility(
+            store, settings, "workspace", reader=tx, global_verdict=verdict, now=now
+        )
+    ) == (3, None)
+    before = (len(db.snapshot_calls), db.snapshot_execute_sql_calls,
+              db.transaction_execute_sql_calls, db.transaction_execute_update_calls)
+
+    monkeypatch.setattr(settings, "trust_stripe_account_id", "acct_changed")
+    assert verdict.key != gate._global_key(store, settings)
+    assert gate.time.monotonic() < verdict.expires_monotonic
+    result = store._run_in_transaction(
+        lambda tx: gate.lease_eligibility(
+            store, settings, "workspace", reader=tx, global_verdict=verdict, now=now
+        )
+    )
+    assert result == (None, "trust_gate_unarmed")
+    assert "condition=global_verdict_expired" in caplog.text
+    assert (len(db.snapshot_calls), db.snapshot_execute_sql_calls,
+            db.transaction_execute_sql_calls, db.transaction_execute_update_calls) == before
+
+
+def test_startup_does_not_read_trust_or_fan_out(armed: Any) -> None:
+    from trusted_router.main import create_app
+    from trusted_router.storage import configure_store
+
+    store, db, settings = armed
+    configure_store(store)
+    before = (db.snapshot_execute_sql_calls, db.transaction_execute_sql_calls)
+    create_app(settings, configure_store_arg=False, init_observability=False)
+    assert (db.snapshot_execute_sql_calls, db.transaction_execute_sql_calls) == before
+    assert store not in gate._caches
+
+
+@pytest.mark.parametrize("evidence,reason", [("owner", "owner_budget_stale"), ("marker", "marker_stale")])
+def test_cache_never_extends_evidence_max_age(armed: Any, evidence: str, reason: str) -> None:
+    store, db, settings = armed
+    now = datetime.now(UTC)
+    through = now - timedelta(seconds=settings.trust_reconcile_max_age_seconds - 1)
+    if evidence == "owner":
+        _budget(store, computed_at=through.isoformat())
+    else:
+        next(row for row in db.typed["tr_trust_backfill"].values()
+             if row["provider"] == "stripe")["closed_through"] = through
+    verdict = gate.global_trust_verdict(store, settings, now=now)
+    assert verdict.refusal(store, settings, now) is None
+    assert verdict.refusal(store, settings, now + timedelta(seconds=2)) == reason
+
+
+@pytest.mark.parametrize("changes", [
+    {"mutation_budget": 20001}, {"source_version": "wrong"}, {"environment": "wrong"},
+    {"scan_complete": False}, {"max_observed_mutations": -1},
+    {"max_observed_mutations": 21000},
+    {"computed_at": (datetime.now(UTC) + timedelta(hours=1)).isoformat()},
+])
+def test_owner_budget_contract_fails_closed(armed: Any, changes: Any) -> None:
+    store, _, settings = armed
+    _budget(store, **changes)
+    assert gate.lease_eligibility(store, settings, "workspace") == (None, "trust_gate_unarmed")
+
+
+def test_failed_owner_scan_invalidates_previous_pass(armed: Any, monkeypatch: Any) -> None:
+    store, db, settings = armed
+    db.typed["tr_owner_workspace"] = {
+        ("broken", "missing-credit"): {"owner_user_id": "broken", "workspace_id": "missing-credit"}
+    }
+    verdict = recompute_owner_budget(store, environment="test")
+    assert verdict["scan_complete"] is False
+    assert gate.lease_eligibility(store, settings, "workspace")[1] == "trust_gate_unarmed"
+
+
+def test_owner_job_reads_actual_credit_fanout_and_cannot_overwrite_newer(armed: Any) -> None:
+    store, db, _ = armed
+    db.typed["tr_owner_workspace"] = {
+        ("owner", ws): {"owner_user_id": "owner", "workspace_id": ws}
+        for ws in ("first", "second")
+    }
+    for ws, shards in [("first", 8), ("second", 16)]:
+        store._write_entity("credit", ws, CreditAccount(workspace_id=ws, shard_count=shards))
+    now = datetime.now(UTC)
+    first = recompute_owner_budget(store, environment="test", now=now)
+    assert first["scan_complete"] and first["max_observed_mutations"] == 24 * 7
+    recompute_owner_budget(store, environment="test", now=now - timedelta(seconds=1))
+    assert store._read_entity(OWNER_BUDGET_KIND, owner_budget_id("test"), dict) == first
+
+
+@pytest.mark.parametrize("read", ["workspace", "snapshot"])
+def test_lazy_workspace_read_errors_preserve_gate_refusal(armed: Any, monkeypatch: Any, read: str, caplog: Any) -> None:
+    store, db, settings = armed
+    verdict = gate.global_trust_verdict(store, settings)
+
+    def broken(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("injected read failure")
+
+    if read == "workspace":
+        monkeypatch.setattr(type(store), "_read_entity_tx", broken)
+    else:
+        monkeypatch.setattr(type(db), "snapshot", broken)
+    assert gate.lease_eligibility(store, settings, "workspace", global_verdict=verdict) == (
+        None, "trust_gate_unarmed"
+    )
+    assert "condition=read_failed" in caplog.text


### PR DESCRIPTION
## Why

Arming trust eligibility on 2026-09-07 took the billing path down and rolled itself back. `trust_gate_failure` was evaluated **per call, with an unbounded owner fan-out, inside the authorize transaction**, and once more at process startup:

| Work per gate evaluation | Count in production |
|---|---|
| read backfill markers | 1 query, all rows |
| `SELECT owner_user_id, workspace_id FROM tr_owner_workspace` | 1 query, 1008 rows |
| `_owner_shard_counts_tx` per distinct owner | 994 queries |
| credit-account point reads inside those | ~1008 reads |

Roughly 2,000 sequential Spanner operations, with no cache. The confirmed traceback:

```
trust_eligibility.py:220  lease_eligibility -> trust_gate_failure
trust_eligibility.py:200  _ids, counts = store._owner_shard_counts_tx(reader, owner)
storage_gcp.py:1016       for row in transaction.execute_sql(
storage_gcp_io.py:160     bounded_rpc
```

Over the 9.5 minutes the armed revision held traffic it served 509 authorize calls, **28 of them 503 at ~20.02s**, the RPC bound, plus 20 successful-but-slow billing calls that tripped the billing-path-pressure policy. southamerica-east1, which runs at zero minimum instances, never passed its 4-minute startup probe.

Nothing the gate checks is per-request or per-workspace. Storage backend, qualifying providers, the account pin, marker completeness and freshness, and the per-owner shard budget are all global and move on a 15-minute cadence at most.

## What

**The fan-out leaves the request path.** `trust_owner_budget.recompute_owner_budget` runs it in the existing tier job and persists one versioned, environment-scoped entity. It stamps `computed_at` at the **start** of the scan so a slow scan cannot rejuvenate old evidence, writes `scan_complete=False` on any partial or failed scan so a failure invalidates the previous pass, and refuses to overwrite newer evidence. Admission reads that entity by its full key: one point read.

**The gate splits.** `global_trust_verdict` evaluates the global half in its **own snapshot, outside any transaction**, under a per-store single-flight lock, and caches passes and refusals for 15 seconds. Marker reads are now per-requirement with a full-key `WHERE` clause instead of a full table read.

**Transactional callers must be handed the verdict.** With none, `lease_eligibility` returns `global_verdict_missing` and refuses **without performing any I/O**. All three `storage_gcp.py` sites and both `storage_gcp_regional_quota.py` sites now compute the verdict before opening their transaction and pass it in.

**A cache can never outlive its evidence.** The verdict carries the deadline at which each freshness condition expires, checked again at consumption, so the TTL cannot extend a marker's max age. Expiry and any configuration change refuse with `global_verdict_expired`.

**Startup evaluates nothing.** The gate fails closed, so the first request populates the cache. There is no refresh thread: Cloud Run throttles CPU between requests and a daemon in this codebase has failed that way before.

Refusals stay fail-closed and gain distinct reasons: `owner_budget_missing`, `owner_budget_stale`, `global_verdict_missing`, `global_verdict_expired`.

## Proof

Written by codex (gpt-6-astra) over two rounds; reviewed by Fable on an isolated snapshot.

Fable gate: 592 tests green across the gate-cost, PR 2 eligibility, tier, Stage C flag-off differential, spend-lease, regional authorize and deploy-contract suites; ruff and mypy clean; static checks confirm the arm flag is still `false`, the code default still `False`, startup no longer evaluates, and the gate no longer calls `require_owner_trust_budget` or `_owner_shard_counts_tx`. Eight mutations red, including the two that survived round one and sent it back: raising the TTL, and deleting the expiry refusal that is the only place the configuration key is compared for transactional consumers.

`scripts/prove_trust_gate_cost.py` ships the negative controls and runs 11 more, all red and all restored, including **inserting the owner fan-out back into the caller's transaction** and **swapping the workspace id in the transactional trust read**.

## Landing order

This does not arm anything. Arming additionally requires the trust jobs to be re-imaged from this commit and to have written a verdict, because the gate now reads what the tier job produces. Those jobs live in **us-east4**, still run image `06225b8`, and a router deploy does not re-image them: `deploy.yml` gates that on the repository variable `TR_TRUST_JOBS_DEPLOY`, which is unset. Arming before the job has run would fail closed on `owner_budget_missing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
