### PR TITLE
trust tiers: arm lease eligibility in production (retry)

### DIFF
--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -788,8 +788,31 @@ ENV_VARS=(
   # key is in the cohort. Clearing this list is the later fleet-expansion step,
   # not part of arming.
   "TR_STAGE_D_PILOT_WORKSPACE_IDS=45819281-0ce9-4811-a0cd-c660ab3a116d,91d7810e-93b2-4c37-b1bd-ba9227585416"
-  # Trust eligibility remains inert; its arm gate validates the completed program.
-  "TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED=false"
+  # Decisions 75-76. The first attempt at this flip (#1131) was reverted the same
+  # day: the arm gate evaluated the whole owner inventory inside the authorize
+  # transaction, hit the RPC bound and returned 503 at 20.02s. #1133 moved that
+  # fan-out into the tier job behind a persisted verdict, so admission now costs
+  # a handful of point reads once per 15s. Do not re-arm without it.
+  #
+  # Conditions verified against production immediately before this flip:
+  # typed Spanner settlement (TR_STORAGE_BACKEND=spanner-bigtable,
+  # TR_REQUEST_RECORD_WRITE_MODE=typed) on the serving revision in all four
+  # regions; stripe and x402 markers complete, zero unmatched, zero semantic
+  # mismatches, 900 s consistency delay; the Stripe account pin reaching the
+  # router; the pilot workspace tier 2, unlatched, on all 16 shards with no null
+  # reconciliation; and the owner-budget verdict written by the tier job from
+  # this same image, scan_complete with no violating owners and a maximum
+  # fan-out of 420 against the 20,000 budget.
+  #
+  # NEW RUNTIME DEPENDENCY: the gate reads what the tier job persists. If that
+  # job stops running, the verdict goes stale after
+  # TR_TRUST_RECONCILE_MAX_AGE_SECONDS and admission fails closed, refusing
+  # leases rather than issuing them. TR_TRUST_JOBS_DEPLOY=1 keeps the job image
+  # in step with main so it cannot drift.
+  #
+  # Settings.spend_lease_trust_eligibility_enabled stays False so only a deployed
+  # router is armed. Rollback is the reverse one-line edit to false.
+  "TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED=true"
   "TR_TRUST_STRIPE_ACCOUNT_ID=${TR_TRUST_STRIPE_ACCOUNT_ID}"
   "TR_TRUST_QUALIFYING_PROVIDERS=stripe,x402"
   "TR_TRUST_RECONCILE_INTERVAL_SECONDS=900"

--- a/tests/test_trust_eligibility_pr2.py
+++ b/tests/test_trust_eligibility_pr2.py
@@ -953,6 +953,7 @@ def test_additional_arm_preconditions_fail_closed(condition: str) -> None:
 def test_rollout_preserves_account_pin_without_ungated_provider_lookup(
     pin: str, live: str, jobs: str, expected: str
 ) -> None:
+    """The armed rollout preserves the account pin without ungated provider lookup."""
     import os
     import subprocess
     from pathlib import Path
@@ -981,7 +982,7 @@ def test_rollout_preserves_account_pin_without_ungated_provider_lookup(
         },
     )
     assert result.stdout == expected
-    assert '"TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED=false"' in text
+    assert '"TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED=true"' in text
 
 
 @pytest.mark.parametrize(

--- a/tests/test_trust_tier_slice1a.py
+++ b/tests/test_trust_tier_slice1a.py
@@ -1019,6 +1019,7 @@ def test_armed_shadow_and_authoritative_claims_carry_the_effective_tier() -> Non
 
 
 def test_new_settings_are_inert_and_pinned_to_scope_defaults() -> None:
+    """Only the deployed router is armed; code and scope defaults stay unchanged."""
     settings = Settings(environment="test")
 
     assert settings.spend_lease_trust_eligibility_enabled is False
@@ -1036,7 +1037,7 @@ def test_new_settings_are_inert_and_pinned_to_scope_defaults() -> None:
         settings.spend_lease_tier3_cap_microdollars,
     ) == (5_000_000, 25_000_000, 100_000_000)
     rollout = (ROOT / "scripts/deploy/rollout.sh").read_text()
-    assert '"TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED=false"' in rollout
+    assert '"TR_SPEND_LEASE_TRUST_ELIGIBILITY_ENABLED=true"' in rollout
 
 
 def test_reconciliation_freshness_covers_delay_plus_two_cadences() -> None:


### PR DESCRIPTION
## Why now

This re-arms trust-tier lease eligibility. The first attempt, #1131, was reverted the same day: the arm gate evaluated the entire owner inventory inside the authorize transaction and again at startup, roughly 2,000 sequential Spanner operations per evaluation. Over the 9.5 minutes it held traffic it served 509 authorize calls, **28 of them 503 at ~20.02s**, the RPC bound, and southamerica-east1 never passed its 4-minute startup probe.

#1133 removed that. Admission now costs a handful of point reads, computed at most once per 15 seconds in its own snapshot outside any transaction, and a transactional caller that is not handed a verdict refuses without performing any I/O.

## Preconditions, read from production immediately before this flip

| Condition | Evidence |
|---|---|
| Gate is cheap | `162e633c` deployed; serving revisions `01403-tb6`, `01209-4v9`, `01339-bzs`, `01034-qjf` |
| Typed Spanner settlement | `spanner-bigtable` / `typed` on the **serving** revision in all four regions |
| Stripe account pin | `acct_…` present in all four regions |
| Markers | stripe and x402 complete, age 987s against a 3600s max, unmatched 0, mismatches 0 |
| Owner-budget verdict | written by the tier job **from this same image**: `scan_complete: true`, `violating_owners: []`, max fan-out 420 against 20,000, age 28s |
| Tier data | 582 of 582 reconciled shards fresh |
| Pilot workspace | tier 2, unlatched, all 16 shards, no null reconciliation, max age 1896s |

The owner-budget verdict is the new one, and it is the reason this retry is safe rather than hopeful: the expensive computation has already happened, off the request path, and its result is durable.

Both trust jobs were re-imaged to `162e633` by setting the repository variable `TR_TRUST_JOBS_DEPLOY=1`, the runbook step 8-9 opt-in that had never been switched on. They had been running `06225b8` since they were first deployed by hand.

## What changes at runtime

Lease issuance and reuse require effective tier ≥ 1, a clear latch, empty pause causes and fresh reconciliation; caps become `min(global ceiling, tier cap)` at $5, $25 and $100; the regional-quota path enforces the same and records `issuance_tier`. Refusals surface as `unpaid_workspace`, `billing_paused` or `reconciliation_stale`, and a failing gate refuses with `trust_gate_unarmed`. Every refusal falls back to the synchronous path, so a refusal is a lost lease, not a failed request.

**New runtime dependency:** the gate reads what the tier job persists. If that job stops running, the verdict goes stale after `TR_TRUST_RECONCILE_MAX_AGE_SECONDS` and admission fails closed, refusing leases rather than issuing them. That is the correct direction to fail, but it is a dependency that did not exist before, and the rationale comment in `rollout.sh` now says so.

**Unchanged from #1131 and still true:** the regional-quota lease pilot is one workspace, the synthetic monitor `d385c399…`, which is tier 0 on all 16 shards. Armed, it gets `unpaid_workspace` and issues no lease. It fails open to the synchronous path, so the monitor keeps working and its authorizations become `local_typed`, which the Stage D rollout gate actually prefers. Whether to grant that workspace a tier or move the pilot is a separate decision, still not taken here.

## Proof

Fable gate on a fresh snapshot: 732 tests green across the gate-cost, trust eligibility, tier, Stage C flag-off differential, Stage D, spend-lease and all three deploy-contract suites; ruff and mypy clean. Static checks confirm the code default is still `False`, the Stage D flip is intact, the trust job scripts keep their own `false`, the gate-cost machinery is present, the gate does not fan out over owners, and startup evaluates nothing. The flip is pinned: reverting the literal to `false` turns the deploy-contract tests red.

## What to watch on deploy

The billing-path gate that caught #1131 is the same one guarding this. Beyond it: `/internal/gateway/authorize` p99 during the us-central1 ramp, the `trustedrouter_gateway_billing_slow` metric against its threshold of 2, and the first pilot lease appearing at `cap_micro` 25000000 instead of 1000000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
