### PR TITLE
Fix production reader for leaderboard evidence snapshots

### DIFF
--- a/src/trusted_router/operational_analytics.py
+++ b/src/trusted_router/operational_analytics.py
@@ -408,6 +408,7 @@ FORMAT JSON
     def public_snapshot(self, name: str) -> dict[str, Any] | None:
         if name not in {
             "leaderboard",
+            "leaderboard_evidence",
             "apps",
             "video_leaderboard",
             "status_inputs",

--- a/tests/test_leaderboard_evidence.py
+++ b/tests/test_leaderboard_evidence.py
@@ -9,6 +9,7 @@ import pytest
 from clickhouse import build_public_snapshots as worker
 from trusted_router.config import Settings
 from trusted_router.dashboard import public_leaderboard_html
+from trusted_router.operational_analytics import OperationalAnalyticsClient
 from trusted_router.routes import public
 from trusted_router.storage_models import ProviderBenchmarkSample
 from trusted_router.synthetic.leaderboard import aggregate_leaderboard
@@ -68,6 +69,30 @@ def test_evidence_does_not_blend_into_recent_sample_or_lower_rank_floor() -> Non
     assert evidence["providers"][0]["rank"] is None
     assert evidence["rank_minimums"] == current["rank_minimums"]
     assert evidence["window"] == "7d"
+
+
+def test_every_published_snapshot_can_be_read_by_the_production_adapter() -> None:
+    snapshots = worker.build_snapshots(
+        [sample()], evidence_samples=[sample()], generated_at="2026-09-05T00:00:00Z"
+    )
+    observed: list[str] = []
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        name = request.url.params["param_name"]
+        observed.append(name)
+        assert "WHERE name = {name:String}" in request.content.decode()
+        assert request.extensions["timeout"]["read"] == 2.0
+        return httpx.Response(200, json={"data": [{"payload": json.dumps(snapshots[name])}]})
+
+    reader = OperationalAnalyticsClient(
+        base_url="https://analytics.invalid",
+        user="reader",
+        password="unused-test-credential",  # noqa: S106 - local transport only.
+        transport=httpx.MockTransport(respond),
+    )
+    for name, payload in snapshots.items():
+        assert reader.public_snapshot(name) == payload
+    assert set(observed) == set(snapshots)
 
 
 def test_evidence_query_is_bounded_balanced_and_does_not_filter_failures(monkeypatch) -> None:

--- a/tests/test_operational_analytics.py
+++ b/tests/test_operational_analytics.py
@@ -551,6 +551,7 @@ def test_postgres_route_health_batch_read_uses_one_partitioned_query() -> None:
     "snapshot_name",
     [
         "leaderboard",
+        "leaderboard_evidence",
         "apps",
         "video_leaderboard",
         "status_inputs",


### PR DESCRIPTION
## Summary

Allow the existing `leaderboard_evidence` snapshot through the production ClickHouse reader. The snapshot publisher and public route already use that name, but the reader's allowlist omitted it, causing `ValueError: unsupported public analytics snapshot` in production.

Keep the fixed name allowlist, parameterized query, and two-second snapshot read deadline. No billing, pricing, IAM, or alert thresholds change.

## Regression Coverage

The new contract test passes every snapshot produced by the real publisher through the real production reader with a local HTTP transport. This catches future publisher/reader name drift that route-only mocks miss. Add the evidence snapshot to the cross-month newest-revision reader test as well.

Both new tests failed against unchanged production code with the exact observed exception. With the one-line fix, all 75 focused snapshot tests pass. Ruff and mypy pass.

## Release Blocked

Do not merge while CI is red. The complete local suite ran: 9,917 passed, 408 skipped, 11 xfailed, 14 failed, 8 errors. Loopback-binding restrictions explain 11 failures and all 8 setup errors; the local socket regression rerun passed 64 tests with loopback permission.

The remaining three failures are reproduced in CI run 34274214333, outside the modified snapshot reader:

- `test_every_provider_has_current_social_card`: Nscale now has zero current routes but the committed card still lists ten models.
- `test_provider_social_card_generation_is_idempotent`: regenerating that stale Nscale card changes one asset.
- `test_image_catalog_is_machine_readable_and_matches_general_filter`: generic image filtering still includes `black-forest-labs/flux.1-schnell`, whereas the dedicated image catalog excludes its expired route.

No test gate, provider freshness deadline, price-spike guard, or catalog data was changed to bypass these failures. This PR remains unmerged and undeployed pending release-gate repair.
