### PR TITLE
Recommend GLM 5.3 Flash and GLM 5.3 in auto and cheap routing

### DIFF
--- a/src/trusted_router/catalog_data.py
+++ b/src/trusted_router/catalog_data.py
@@ -2480,20 +2480,21 @@ US_FOCUSED_PROVIDER_ORDER: tuple[str, ...] = (
 #   1. Privacy and jurisdiction requirements are applied before authorization;
 #      an incompatible leading model is skipped rather than silently weakening
 #      a caller's requested policy.
-#   2. The ladder spans MORE THAN ONE provider. The 0813 leader itself has
-#      release-pinned first-party and Baseten routes, and it is followed by
-#      independent model/provider families.
+#   2. The ladder spans MORE THAN ONE provider. The GLM leaders have multiple
+#      serving providers and are followed by independent model families.
 #
-# Order: strongest current DeepSeek release first, then cheap qualifying
-# fallbacks. Privacy and jurisdiction requirements are still applied before
-# any candidate is authorized.
+# Order: GLM 5.3 Flash, GLM 5.3, then the existing independent fallbacks.
+# Privacy and jurisdiction requirements still apply before authorization.
 #
 # Anthropic sits at the BOTTOM deliberately. Its endpoints are currently
 # PRIVACY_TIER_STANDARD (not yet zero-retention), so it is filtered out of any
 # request that demands ZDR — but it remains a capable last-resort fallback for
 # requests with no privacy floor, and it moves up on its own merits the moment
 # its endpoint tier is raised.
+GLM_5_3_RECOMMENDED_MODEL_IDS = ("z-ai/glm-5.3-flash", "z-ai/glm-5.3")
+
 DEFAULT_AUTO_MODEL_ORDER = [
+    *GLM_5_3_RECOMMENDED_MODEL_IDS,
     DEEPSEEK_V4_PRO_0813_MODEL_ID,
     "deepseek/deepseek-v4-flash-0731",
     "moonshotai/kimi-k3",

--- a/src/trusted_router/routing_candidates.py
+++ b/src/trusted_router/routing_candidates.py
@@ -24,6 +24,7 @@ from trusted_router.catalog_data import (
     FREE_MODEL_ID,
     FUSION_CODE_MODEL_ID,
     FUSION_MODEL_ID,
+    GLM_5_3_RECOMMENDED_MODEL_IDS,
     IRIS_1_0_MODEL_ID,
     IRIS_2_0_MODEL_ID,
     IRIS_3_0_MODEL_ID,
@@ -146,6 +147,17 @@ def free_candidate_models(limit: int = 16) -> list[Model]:
 
 
 def cheap_candidate_models(limit: int = 8) -> list[Model]:
+    if limit <= 0:
+        return []
+    # Keep the current general-purpose recommendations as available fallbacks,
+    # even when an older, cheaper model wins their family's catalog slot.
+    # Final ordering remains by price; recommendation is not a price override.
+    recommended = [
+        model
+        for model_id in GLM_5_3_RECOMMENDED_MODEL_IDS
+        if (model := MODELS.get(model_id)) is not None and _is_regular_chat_model(model)
+    ][: max(0, limit - 1)]
+    recommended_ids = {model.id for model in recommended}
     by_provider: dict[str, Model] = {}
     for model in MODELS.values():
         if not _is_regular_chat_model(model) or model.id.endswith(":free"):
@@ -153,7 +165,12 @@ def cheap_candidate_models(limit: int = 8) -> list[Model]:
         current = by_provider.get(model.provider)
         if current is None or _price_sort_key(model) < _price_sort_key(current):
             by_provider[model.provider] = model
-    return sorted(by_provider.values(), key=_price_sort_key)[:limit]
+    remaining = [
+        model
+        for model in sorted(by_provider.values(), key=_price_sort_key)
+        if model.id not in recommended_ids
+    ][: limit - len(recommended)]
+    return sorted([*recommended, *remaining], key=_price_sort_key)
 
 
 FAST_MODEL_ORDER = (

--- a/src/trusted_router/templates/public/provider_routing.html
+++ b/src/trusted_router/templates/public/provider_routing.html
@@ -35,6 +35,14 @@
   <p style="margin-top:12px">Rejected field names and status codes are emitted as bounded operational metadata so compatibility demand can be measured. Field values, request bodies, prompts, and outputs are excluded, and Sentry remains outside the enclave.</p>
 </section>
 
+<section class="status-section" style="margin-top:48px" id="recommended-models">
+  <div class="status-section-head"><div>
+    <h2>Recommended automatic routes</h2>
+    <p><code>trustedrouter/auto</code> starts with <a href="/models/z-ai/glm-5.3-flash">GLM 5.3 Flash</a>, then <a href="/models/z-ai/glm-5.3">GLM 5.3</a>, followed by DeepSeek, Kimi, and the rest of the fallback pool. Your provider, privacy, and capability requirements still determine which routes qualify.</p>
+    <p><code>trustedrouter/cheap</code> includes both GLM models alongside lower-cost alternatives. It orders the pool by published input plus output token prices, so GLM 5.3 remains a higher-cost fallback. Set <code>provider.max_price</code> to enforce your per-token price ceiling.</p>
+  </div></div>
+</section>
+
 <section class="status-section" style="margin-top:48px" id="fields">
   <div class="status-section-head">
     <div>

--- a/tests/test_auto_model_order_single_source.py
+++ b/tests/test_auto_model_order_single_source.py
@@ -36,10 +36,10 @@ def test_documented_ladder_survives_catalog_filtering() -> None:
     assert len(auto_candidate_models(None)) >= 3
 
 
-def test_auto_leads_with_the_current_deepseek_release() -> None:
-    """The global ladder must start with the explicitly pinned 0813 release."""
-    assert DEFAULT_AUTO_MODEL_ORDER[0] == "deepseek/deepseek-v4-pro-0813"
-    assert auto_candidate_models(None)[0].id == "deepseek/deepseek-v4-pro-0813"
+def test_auto_leads_with_glm53_flash_then_glm53() -> None:
+    expected = ["z-ai/glm-5.3-flash", "z-ai/glm-5.3"]
+    assert DEFAULT_AUTO_MODEL_ORDER[:2] == expected
+    assert [model.id for model in auto_candidate_models(None)[:2]] == expected
 
 
 def test_explicit_override_still_wins() -> None:

--- a/tests/test_auto_route_privacy_floor.py
+++ b/tests/test_auto_route_privacy_floor.py
@@ -28,7 +28,7 @@ from trusted_router.config import Settings
 from trusted_router.routing import chat_route_endpoint_candidates
 from trusted_router.routing_candidates import auto_candidate_models
 
-# The models the default route should reach for after the global 0813 leader.
+# The leading models that can satisfy a US zero-retention request.
 QUALIFYING_LEAD_MODELS = 3
 
 
@@ -76,8 +76,10 @@ def test_auto_ladder_spans_more_than_one_provider() -> None:
     assert len(providers) > 1, f"the leading auto candidates share one provider: {providers}"
 
 
-def test_current_release_then_cheap_qualifying_models_lead_the_ladder() -> None:
-    assert DEFAULT_AUTO_MODEL_ORDER[:4] == [
+def test_glm53_recommendations_preserve_independent_fallbacks() -> None:
+    assert DEFAULT_AUTO_MODEL_ORDER[:6] == [
+        "z-ai/glm-5.3-flash",
+        "z-ai/glm-5.3",
         "deepseek/deepseek-v4-pro-0813",
         "deepseek/deepseek-v4-flash-0731",
         "moonshotai/kimi-k3",

--- a/tests/test_glm53_recommended_routing.py
+++ b/tests/test_glm53_recommended_routing.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from trusted_router.catalog import (
+    MODELS,
+    endpoint_privacy_tier,
+    model_to_openrouter_shape,
+)
+from trusted_router.catalog_data import PRIVACY_TIER_ZERO_RETENTION
+from trusted_router.config import Settings
+from trusted_router.routing import chat_route_endpoint_candidates
+from trusted_router.routing_candidates import cheap_candidate_models
+
+GLM53_MODELS = ("z-ai/glm-5.3-flash", "z-ai/glm-5.3")
+
+
+def test_auto_routes_start_with_glm53_recommendations() -> None:
+    candidates = chat_route_endpoint_candidates(
+        {"model": "trustedrouter/auto", "provider": {"usage": "credits"}}, Settings()
+    )
+    model_ids = list(dict.fromkeys(model.id for model, _endpoint in candidates))
+    assert model_ids[:2] == list(GLM53_MODELS)
+    advertised = model_to_openrouter_shape(MODELS["trustedrouter/auto"])
+    assert advertised["trustedrouter"]["auto_candidates"][:2] == list(GLM53_MODELS)
+
+
+def test_cheap_includes_glm53_without_replacing_price_order() -> None:
+    candidates = cheap_candidate_models()
+    ids = [model.id for model in candidates]
+    assert set(GLM53_MODELS) <= set(ids)
+    assert len(ids) == len(set(ids)) == 8
+    assert len({model.provider for model in candidates}) >= 3
+    prices = [
+        model.prompt_price_microdollars_per_million_tokens
+        + model.completion_price_microdollars_per_million_tokens
+        for model in candidates
+    ]
+    assert prices == sorted(prices)
+    assert ids[0] not in GLM53_MODELS
+    advertised = model_to_openrouter_shape(MODELS["trustedrouter/cheap"])
+    assert advertised["trustedrouter"]["auto_candidates"] == ids
+
+
+@pytest.mark.parametrize("limit", [0, 1, 2, 4, 8])
+def test_cheap_recommendations_respect_pool_limit(limit: int) -> None:
+    candidates = cheap_candidate_models(limit=limit)
+    assert len(candidates) == limit
+    assert len({model.id for model in candidates}) == limit
+
+
+def test_cheap_small_pool_keeps_the_lowest_price_first() -> None:
+    lowest = cheap_candidate_models()[0]
+    assert cheap_candidate_models(limit=1) == [lowest]
+    assert cheap_candidate_models(limit=2)[0] == lowest
+
+
+def test_cheap_skips_missing_recommendation(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delitem(MODELS, GLM53_MODELS[0])
+    ids = [model.id for model in cheap_candidate_models()]
+    assert GLM53_MODELS[0] not in ids
+    assert GLM53_MODELS[1] in ids
+    assert len(ids) == 8
+
+
+def test_cheap_deduplicates_recommendation_that_is_also_cheapest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_id = GLM53_MODELS[0]
+    monkeypatch.setitem(
+        MODELS,
+        model_id,
+        replace(
+            MODELS[model_id],
+            prompt_price_microdollars_per_million_tokens=1,
+            completion_price_microdollars_per_million_tokens=1,
+        ),
+    )
+    ids = [model.id for model in cheap_candidate_models()]
+    assert ids.count(model_id) == 1
+    assert GLM53_MODELS[1] in ids
+    assert len(ids) == 8
+
+
+@pytest.mark.parametrize("alias", ["trustedrouter/auto", "trustedrouter/cheap"])
+def test_glm53_recommendations_obey_explicit_privacy_floor(alias: str) -> None:
+    candidates = chat_route_endpoint_candidates(
+        {"model": alias, "provider": {"min_privacy": "zdr", "usage": "credits"}},
+        Settings(),
+    )
+    assert set(GLM53_MODELS) <= {model.id for model, _endpoint in candidates}
+    assert all(
+        endpoint_privacy_tier(endpoint) >= PRIVACY_TIER_ZERO_RETENTION
+        for _model, endpoint in candidates
+    )


### PR DESCRIPTION
## Summary

- Put `z-ai/glm-5.3-flash` first and `z-ai/glm-5.3` second in `trustedrouter/auto`, preserving the existing DeepSeek/Kimi/other fallback order afterward.
- Include both models in `trustedrouter/cheap` (the existing cheap alias), alongside the cheapest per-family candidates. Retain the eight-model cap, deduplication, price ordering, and a lowest-price slot even for small limits.
- Keep provider, jurisdiction, privacy, and price filters authoritative. A recommendation is not permission to override a caller's constraints.
- Explain the selection behavior at `/docs/provider-routing`, including GLM 5.3's higher-cost fallback position and `provider.max_price`.

No provider prices, existing versioned combo models, or production configuration overrides are changed.

## Validation

- Eight new/updated assertions failed against the previous routing implementation, then passed after the change.
- 25 focused tests pass: actual endpoint expansion, advertised catalog order, unchanged fallback order, missing recommendation, duplicate suppression, pool limits, lowest-price preservation, and ZDR filtering.
- Full mypy gate passes (373 source files).
- Full lint gate passes with the repository-pinned Ruff 0.16.4. The older shared local Ruff 0.15.12 reports an unrelated metadata-URL warning; no unrelated code was changed to work around it.
- CI run 34295472770 passed every check, including all twelve normal/post-cutover test shards, lint, mypy, browser, frontend, formal proofs, and the combined coverage gate (85%).
- Full local suite: 9,979 passed, 408 skipped, 11 xfailed, two gateway log-path assertions failed (`/internal/...` versus `/v1/internal/...`). All seven tests in that unchanged file pass when rerun in isolation, on both this branch and unchanged main. The full unchanged-main baseline passed (9,970 passed, 408 skipped, 11 xfailed). The local aggregate-only discrepancy was not reproduced in CI; no gateway logging code is changed by this PR. This does not claim the initial local aggregate run was green.
- Both exact model IDs returned HTTP 200, nonempty `PONG`, usage, and `[DONE]` through the production streaming API. Combined smoke cost: 671 microdollars ($0.000671).

After deployment, verify that the public catalog advertises the new auto order and both cheap candidates, then smoke `trustedrouter/auto`.

Merged as `fce7f0a9578edcca6b9591f252b4fa4e3c638c5e`. Guarded production rollout: https://github.com/Lore-Hex/quill-router/actions/runs/34296392512 . Production activation remains pending that rollout.
