### PR TITLE
Repair live billing hotspot without pausing customers

### DIFF
--- a/docs/incidents/2026-09-08-legacy-billing-shard-contention.md
+++ b/docs/incidents/2026-09-08-legacy-billing-shard-contention.md
@@ -1,0 +1,118 @@
+# Legacy billing shard contention, September 8, 2026
+
+## Status
+
+Root cause confirmed from production lock statistics, exact-key metadata reads,
+deployed feature flags, and request logs. The affected workspace and uncapped
+key were expanded atomically from one to 16 shards at approximately
+2026-09-09 03:41 UTC. Read-only verification confirmed both new shard counts
+and unchanged total credit. Billing was never paused. No existing hold, usage
+counter, alert threshold, IAM grant, or rollout flag was changed.
+
+Customer-identifying metadata is intentionally omitted from this public report.
+The operator investigation resolved the contended key and workspace to their
+owner using complete-primary-key, low-priority, read-only Spanner queries.
+
+## Evidence
+
+- The lock-wait alert opened at 2026-09-09 01:31 UTC, after sustained lock waits
+  and aborted-commit alerts. The displayed lock-wait value was 14.7797 against
+  a threshold of 2 seconds per second.
+- At 01:41 UTC, one `tr_key_limit` shard accumulated 723.197207 lock-wait
+  seconds within a one-minute interval. Concurrent waiting transactions make
+  this accumulated value larger than wall-clock time. The sampled transaction
+  tag was `tr_finalize`.
+- Its workspace's `tr_credit_balance` shard was also contended, by
+  `tr_authorize` and `tr_finalize`. Both the key and workspace still had exactly
+  one configured shard. The key, created on September 8, had no lifetime,
+  daily, weekly, or monthly limit.
+- The owner account predates the August 21 introduction of 16-shard defaults.
+  The newly created key inherited its existing workspace's shard count.
+- In the complete 01:10-02:00 UTC log query, 1,413 authorize/settle calls took
+  at least 10 seconds and returned HTTP 200. This is a fleet-wide count, not an
+  assertion that every slow call belonged to the one hot workspace. One other
+  slow call was a video-job claim and is excluded from that billing count.
+- The earlier 19:16:47 UTC authorize call returned 503 after 20.15 seconds.
+  Its corresponding `billing.authorize_storage_unavailable` warning at
+  19:17:07 named the same workspace and `DeadlineExceeded`.
+- No internal gateway HTTP 5xx was found in the later alert-window query from
+  01:10 UTC through the read. Successful control-plane HTTP responses alone do
+  not prove that clients waited long enough or that every inference succeeded.
+- All three GCP control-plane services had healthy latest revisions receiving
+  100% of untagged traffic. Both lease systems were enabled, but the affected
+  workspace was absent from both pilot allowlists. Spend-lease admission was
+  also explicitly disabled.
+
+## Why it happened
+
+1. Billing calls waited because concurrent transactions competed for the same
+   usage and credit rows.
+2. The rows remained single-sharded despite concurrent traffic from multiple
+   gateway regions.
+3. The 16-shard default applied to new workspaces, not to existing accounts;
+   new keys in those old workspaces inherited the single-shard configuration.
+4. Removing the uncapped key reservation from authorization did not eliminate
+   the finalization write needed to account for that key's usage. Lock samples
+   confirm the remaining contention is predominantly on finalization.
+5. Regional lease infrastructure was enabled but remained scoped to explicit
+   pilot workspaces. Deployment of that infrastructure did not enroll this
+   customer or remove its existing global-counter bottleneck.
+
+This is a router billing-path scaling limitation, not evidence of provider
+downtime or improper customer use. Increasing timeouts or adding service
+instances cannot remove a shared-row serialization point.
+
+## Repair requirements
+
+The targeted repair is implemented in `scripts/expand_billing_shards.py`.
+It is deliberately expansion-only and limited to uncapped keys. One serializable
+transaction reads a bounded owner inventory and exact metadata/counter keys,
+checks owner trust limits and replicated trust state, redistributes only free
+credit capacity, and inserts zero-usage key rows with the new metadata counts.
+Existing usage, reserved amounts, window counters and hold references are not
+rewritten. Concurrent accounting transactions conflict and cause a fresh retry.
+Rerunning an already completed expansion makes no further changes.
+
+The first attempt was aborted by contention, with no committed change. Review
+found its read order inverted finalization's key-then-credit order. The corrected
+operation matches that order and uses ordinary priority for its bounded write
+transaction; all independent preflight and verification reads remain low priority.
+A regression test pins that order. The successful application used a separately
+authenticated operator; the read-only ops identity received no extra permissions.
+
+Property tests verify integer conservation and unchanged old holds. Tests using
+the existing billing primitives exercise settlement/refund of pre-expansion
+holds, all 16 new shards, duplicate settlement, aborted retries, unknown commit
+timeouts, metadata preservation, and rejection of unsafe account states.
+
+1. Use the bounded, workspace-scoped, hold-preserving expansion to at least 16
+   credit and key-usage shards. Verify exact balances, usage, reserved amounts,
+   and existing hold-to-shard ownership before and after. Never clear counters
+   or release a live hold merely to make contention disappear.
+2. Do not run the current `scripts/shard_workspace.py online-split` unchanged
+   during this incident. Its `legacy_reservation_snapshot` guard scans the
+   legacy reservation kind with JSON predicates, and its global invariant audit
+   is not scoped to the target account. This conflicts with the current
+   production read-safety rules. Failure can also leave customer billing paused.
+   Fix and test bounded preflight and explicit pause ownership/recovery first.
+3. Proactively identify eligible legacy single-shard accounts through a bounded
+   inventory, so they do not require a customer incident before migration.
+4. Keep lease adoption a separately verified rollout. Merely enabling a global
+   flag or adding an account to a pilot is not proof that every request feature
+   uses leases or that settlement no longer contends on a key counter.
+5. Validate improvement through per-operation lock statistics and billing
+   latency, plus attribution-aware request errors and post-migration accounting
+   invariants. Do not relax the existing alerts.
+
+## Separate snapshot defect
+
+The public seven-day leaderboard requested `leaderboard_evidence`, but
+`OperationalAnalyticsClient.public_snapshot` rejected that name before querying
+ClickHouse. The snapshot writer and route already supported it. The missing
+reader allowlist entry produced `ValueError: unsupported public analytics
+snapshot` logs and prevented the evidence view from loading its stored data.
+
+The fix adds that reader entry without expanding access to arbitrary names.
+The actual HTTP-backed reader contract test was extended to cover it and was
+observed failing on the previous code. Unknown-product rejection remains tested.
+This independent fix does not repair the billing contention described above.

--- a/scripts/expand_billing_shards.py
+++ b/scripts/expand_billing_shards.py
@@ -1,0 +1,324 @@
+"""Atomically expand a live typed workspace and one uncapped key, without a pause.
+
+Dry-run uses the read-only ops credential. Apply requires a separately named
+gcloud identity. Existing holds, usage, window counters and pause ownership are
+never modified. Only free credit capacity moves; new counter rows start at zero.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import re
+import shutil
+import subprocess
+import time
+from typing import Any
+
+from trusted_router.storage_gcp_counters import (
+    CREDIT_BALANCE_TRUST_COLUMNS,
+    MAX_CREDIT_SHARDS,
+    distribute_credit_amount,
+)
+from trusted_router.trust_ownership import require_owner_trust_budget
+
+READ_SECONDS = 5.0
+APPLY_SECONDS = 20.0
+MAX_OWNER_WORKSPACES = 32
+CREDIT_COLUMNS = (
+    "workspace_id", "shard", "total_credits", "total_usage", "reserved",
+    *CREDIT_BALANCE_TRUST_COLUMNS,
+)
+KEY_COLUMNS = (
+    "key_hash", "shard", "limit_micro", "usage", "byok_usage", "reserved",
+    "include_byok", "day_limit_micro", "week_limit_micro", "month_limit_micro",
+    "day_usage", "day_start", "week_usage", "week_start", "month_usage", "month_start",
+)
+CAP_FIELDS = (
+    "limit_microdollars", "limit_daily_microdollars", "limit_weekly_microdollars",
+    "limit_monthly_microdollars",
+)
+
+
+def expand_credit_rows(rows: list[dict[str, Any]], target: int) -> list[dict[str, Any]]:
+    """Conserve money exactly while preserving every existing hold's shard."""
+    if not rows or not len(rows) <= target <= MAX_CREDIT_SHARDS:
+        raise ValueError("expansion only; expected 1..64 configured shards")
+    if [int(row["shard"]) for row in rows] != list(range(len(rows))):
+        raise ValueError("incomplete or unexpected credit shard set")
+    trust = [rows[0].get(column) for column in CREDIT_BALANCE_TRUST_COLUMNS]
+    for row in rows:
+        credits, usage, reserved = (int(row[name]) for name in ("total_credits", "total_usage", "reserved"))
+        if min(credits, usage, reserved) < 0 or usage + reserved > credits:
+            raise ValueError("invalid credit counter or exhausted shard")
+        if [row.get(column) for column in CREDIT_BALANCE_TRUST_COLUMNS] != trust:
+            raise ValueError("divergent trust replication")
+        if row.get("billing_pause_causes"):
+            raise ValueError("workspace is paused")
+    if len(rows) == target:
+        return copy.deepcopy(rows)
+    free = sum(int(row["total_credits"]) - int(row["total_usage"]) - int(row["reserved"]) for row in rows)
+    parts = distribute_credit_amount(free, target)
+    result = copy.deepcopy(rows)
+    for shard in range(len(rows), target):
+        result.append({
+            "workspace_id": rows[0]["workspace_id"], "shard": shard,
+            "total_usage": 0, "reserved": 0,
+            **dict(zip(CREDIT_BALANCE_TRUST_COLUMNS, trust, strict=True)),
+        })
+    for shard, row in enumerate(result):
+        row["total_credits"] = int(row["total_usage"]) + int(row["reserved"]) + parts[shard]
+    return result
+
+
+def _integer(value: Any, name: str) -> int:
+    if isinstance(value, bool) or value is None:
+        raise ValueError(f"invalid {name}")
+    result = int(value)
+    if str(result) != str(value):
+        raise ValueError(f"invalid {name}")
+    return result
+
+
+def make_plan(
+    workspace: dict[str, Any], credit: dict[str, Any], key: dict[str, Any],
+    credit_rows: list[dict[str, Any]], key_rows: list[dict[str, Any]],
+    owner: dict[str, Any], owner_credits: dict[str, dict[str, Any]], target: int,
+) -> dict[str, Any]:
+    """Validate one coherent transactional snapshot before staging mutations."""
+    ws = workspace["id"]
+    if workspace.get("deleted") or workspace.get("federated_home"):
+        raise ValueError("workspace is deleted or federated")
+    if workspace.get("billing_paused") or workspace.get("billing_pause_causes"):
+        raise ValueError("workspace is paused")
+    if credit.get("workspace_id") != ws or key.get("workspace_id") != ws:
+        raise ValueError("workspace mismatch")
+    if key.get("disabled") or key.get("federated_home") or key.get("management"):
+        raise ValueError("key is disabled, federated, or management")
+    if any(key.get(name) is not None for name in CAP_FIELDS):
+        raise ValueError("only uncapped keys may be expanded without a pause")
+    current = _integer(credit.get("shard_count", 1), "credit shard count")
+    key_current = _integer(key.get("usage_shard_count", 1), "key shard count")
+    if not 1 <= current <= target <= MAX_CREDIT_SHARDS or not 1 <= key_current <= target:
+        raise ValueError("invalid target or consolidation requested")
+    if len(credit_rows) != current or len(key_rows) != key_current:
+        raise ValueError("metadata and physical shard counts differ")
+    if any(row["workspace_id"] != ws for row in credit_rows):
+        raise ValueError("credit row workspace mismatch")
+    if [int(row["shard"]) for row in key_rows] != list(range(key_current)):
+        raise ValueError("incomplete or unexpected key shard set")
+    for row in key_rows:
+        if row["key_hash"] != key["hash"]:
+            raise ValueError("key row identity mismatch")
+        if any(row.get(name) is not None for name in ("limit_micro", "day_limit_micro", "week_limit_micro", "month_limit_micro")):
+            raise ValueError("typed key caps disagree with uncapped metadata")
+        if int(row["reserved"]) != 0:
+            raise ValueError("uncapped key has a reserved hold")
+        if any(int(row[name]) < 0 for name in ("usage", "byok_usage", "day_usage", "week_usage", "month_usage")):
+            raise ValueError("negative key usage")
+        if row["include_byok"] != key.get("include_byok_in_limit", True):
+            raise ValueError("typed key flags disagree with metadata")
+    if owner.get("id") != workspace["owner_user_id"] or ws not in owner_credits:
+        raise ValueError("owner inventory missing target workspace")
+    if not 1 <= len(owner_credits) <= MAX_OWNER_WORKSPACES:
+        raise ValueError("owner inventory exceeds bounded repair scope")
+    if _integer(owner.get("owner_workspace_count"), "owner workspace count") != len(owner_credits):
+        raise ValueError("owner inventory count mismatch")
+    counts = []
+    for owned_id, account in owner_credits.items():
+        if account.get("workspace_id") != owned_id:
+            raise ValueError("owner inventory credit account mismatch")
+        count = _integer(account.get("shard_count", 1), "owner shard count")
+        if not 1 <= count <= MAX_CREDIT_SHARDS:
+            raise ValueError("invalid owner shard count")
+        counts.append(target if owned_id == ws else count)
+    require_owner_trust_budget(counts)
+    expanded = expand_credit_rows(credit_rows, target)
+    return {
+        "workspace_id": ws, "key_id": key["hash"], "target": target,
+        "current_credit_shards": current, "current_key_shards": key_current,
+        "credit": {**credit, "shard_count": target},
+        "key": {**key, "usage_shard_count": target},
+        "credit_rows": expanded, "key_rows": key_rows,
+        "totals": {name: sum(int(row[name]) for row in credit_rows) for name in ("total_credits", "total_usage", "reserved")},
+        "changed": current != target or key_current != target,
+    }
+
+
+class Reader:
+    def __init__(self, client: Any, session: str, transaction: dict[str, Any], deadline: float, *, priority: str = "PRIORITY_LOW"):
+        self.client, self.session, self.transaction, self.deadline = client, session, transaction, deadline
+        self.priority = priority
+
+    def timeout(self) -> float:
+        remaining = self.deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("bounded billing expansion deadline expired")
+        return min(READ_SECONDS, remaining)
+
+    def read(self, table: str, columns: tuple[str, ...], keys: list[list[Any]]) -> list[dict[str, Any]]:
+        from google.protobuf.json_format import MessageToDict
+
+        result = self.client.read(request={
+            "session": self.session, "transaction": self.transaction,
+            "table": table, "columns": columns,
+            "key_set": {"keys": keys}, "limit": len(keys),
+            "request_options": {"priority": self.priority, "request_tag": "tr_ops_expand_billing"},
+        }, timeout=self.timeout(), retry=None)
+        return [dict(zip(columns, row, strict=True)) for row in MessageToDict(result._pb).get("rows", [])]
+
+    def entities(self, keys: list[list[str]]) -> dict[tuple[str, str], dict[str, Any]]:
+        result = {}
+        for row in self.read("tr_entities", ("kind", "id", "body"), keys):
+            body = json.loads(row["body"])
+            if not isinstance(body, dict):
+                raise ValueError("invalid entity JSON")
+            result[(row["kind"], row["id"])] = body
+        if len(result) != len(keys):
+            raise ValueError("missing required entity")
+        return result
+
+    def plan(self, workspace_id: str, key_id: str, target: int) -> dict[str, Any]:
+        from google.protobuf.json_format import MessageToDict
+
+        records = self.entities([["workspace", workspace_id], ["credit", workspace_id], ["api_key", key_id]])
+        workspace = records[("workspace", workspace_id)]
+        owner_id = workspace["owner_user_id"]
+        result = self.client.execute_sql(request={
+            "session": self.session, "transaction": self.transaction,
+            "sql": "SELECT workspace_id FROM tr_owner_workspace WHERE owner_user_id=@owner ORDER BY workspace_id LIMIT 33",
+            "params": {"owner": owner_id}, "param_types": {"owner": {"code": "STRING"}},
+            "request_options": {"priority": self.priority, "request_tag": "tr_ops_expand_billing"},
+        }, timeout=self.timeout(), retry=None)
+        inventory = [row[0] for row in MessageToDict(result._pb).get("rows", [])]
+        if not 1 <= len(inventory) <= MAX_OWNER_WORKSPACES:
+            raise ValueError("missing or oversized owner inventory")
+        owned = self.entities([["user", owner_id], *[["credit", ws] for ws in inventory]])
+        # Match finalization's key -> credit lock order. The inverse produces
+        # S-credit/X-key versus X-key/X-credit cycles on a busy account.
+        key_rows = self.read("tr_key_limit", KEY_COLUMNS, [[key_id, str(shard)] for shard in range(MAX_CREDIT_SHARDS)])
+        credits = self.read("tr_credit_balance", CREDIT_COLUMNS, [[workspace_id, str(shard)] for shard in range(MAX_CREDIT_SHARDS)])
+        credits.sort(key=lambda row: int(row["shard"]))
+        key_rows.sort(key=lambda row: int(row["shard"]))
+        return make_plan(workspace, records[("credit", workspace_id)], records[("api_key", key_id)], credits, key_rows, owned[("user", owner_id)], {ws: owned[("credit", ws)] for ws in inventory}, target)
+
+
+def mutations(plan: dict[str, Any]) -> list[dict[str, Any]]:
+    """Update only capacity on old credit rows; never rewrite existing counters."""
+    if not plan["changed"]:
+        return []
+    ws, key_id, target = plan["workspace_id"], plan["key_id"], plan["target"]
+    old = plan["current_credit_shards"]
+    changes = []
+    if old != target:
+        changes.append({"update": {
+            "table": "tr_credit_balance", "columns": ["workspace_id", "shard", "total_credits", "updated_at"],
+            "values": [[ws, str(row["shard"]), str(row["total_credits"]), "spanner.commit_timestamp()"] for row in plan["credit_rows"][:old]],
+        }})
+        changes.append({"insert": {
+            "table": "tr_credit_balance", "columns": [*CREDIT_COLUMNS, "source_updated_at", "updated_at"],
+            "values": [[_wire(row[column]) for column in CREDIT_COLUMNS] + ["spanner.commit_timestamp()"] * 2 for row in plan["credit_rows"][old:]],
+        }})
+    if plan["current_key_shards"] != target:
+        changes.append({"insert": {
+            "table": "tr_key_limit", "columns": ["key_hash", "shard", "include_byok", "source_updated_at", "updated_at"],
+            "values": [[key_id, str(shard), plan["key"].get("include_byok_in_limit", True), "spanner.commit_timestamp()", "spanner.commit_timestamp()"] for shard in range(plan["current_key_shards"], target)],
+        }})
+    changes.append({"update": {
+        "table": "tr_entities", "columns": ["kind", "id", "body", "updated_at"],
+        "values": [[kind, identifier, json.dumps(plan[field], separators=(",", ":")), "spanner.commit_timestamp()"] for kind, identifier, field in (("credit", ws, "credit"), ("api_key", key_id, "key"))],
+    }})
+    return changes
+
+
+def _wire(value: Any) -> Any:
+    return str(value) if isinstance(value, int) and not isinstance(value, bool) else value
+
+
+def execute(client: Any, session: str, ws: str, key: str, target: int, *, apply: bool) -> dict[str, Any]:
+    from google.api_core.exceptions import Aborted
+
+    deadline = time.monotonic() + (APPLY_SECONDS if apply else 30)
+    for attempt in range(6):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("bounded billing expansion deadline expired")
+        mode = {"read_write": {}} if apply else {"read_only": {"strong": True}}
+        tx = client.begin_transaction(request={"session": session, "options": mode}, timeout=min(READ_SECONDS, remaining), retry=None)
+        reader = Reader(client, session, {"id": tx.id}, deadline, priority="PRIORITY_MEDIUM" if apply else "PRIORITY_LOW")
+        committed = False
+        aborted = False
+        try:
+            plan = reader.plan(ws, key, target)
+            changes = mutations(plan) if apply else []
+            if changes:
+                client.commit(request={"session": session, "transaction_id": tx.id, "mutations": changes,
+                    "request_options": {"transaction_tag": "tr_ops_expand_billing"}}, timeout=reader.timeout(), retry=None)
+                committed = True
+            return {name: plan[name] for name in ("workspace_id", "key_id", "target", "current_credit_shards", "current_key_shards", "totals", "changed")} | {"applied": bool(changes)}
+        except Aborted:
+            aborted = True
+            if attempt == 5 or time.monotonic() >= deadline:
+                raise
+            time.sleep(min(0.1 * (attempt + 1), max(0, deadline - time.monotonic())))
+        finally:
+            if apply and not committed and not aborted:
+                try:
+                    client.rollback(request={"session": session, "transaction_id": tx.id}, timeout=2, retry=None)
+                except Exception as exc:
+                    print(json.dumps({"event": "expansion_rollback_error", "error_type": type(exc).__name__}), flush=True)
+    raise RuntimeError("expansion retry exhausted")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workspace", required=True)
+    parser.add_argument("--key-id", required=True)
+    parser.add_argument("--shards", type=int, default=16)
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--account", help="Separate gcloud deployment identity, required for apply")
+    args = parser.parse_args()
+    from google.cloud.spanner_v1.services.spanner import SpannerClient
+    from google.oauth2 import credentials as oauth_credentials
+    from google.oauth2 import service_account
+
+    if args.apply and (not args.account or "tr-ops-local" in args.account or not re.fullmatch(r"[A-Za-z0-9_.+@-]+@[A-Za-z0-9.-]+", args.account)):
+        parser.error("apply requires a separate deployment identity")
+    database = "projects/quill-cloud-proxy/instances/trusted-router-nam6/databases/trusted-router"
+
+    def run(credentials: Any, *, apply: bool) -> dict[str, Any]:
+        with SpannerClient(credentials=credentials) as client:
+            session = client.create_session(request={"database": database}, timeout=READ_SECONDS, retry=None)
+            try:
+                return execute(client, session.name, args.workspace, args.key_id, args.shards, apply=apply)
+            finally:
+                client.delete_session(request={"name": session.name}, timeout=READ_SECONDS, retry=None)
+
+    try:
+        ops_credentials = service_account.Credentials.from_service_account_file(os.environ["CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE"], scopes=["https://www.googleapis.com/auth/spanner.data"])
+        print(json.dumps({"preflight": run(ops_credentials, apply=False)}), flush=True)
+        if args.apply:
+            gcloud = shutil.which("gcloud")
+            if not gcloud:
+                raise ValueError("gcloud is required")
+            env = {name: value for name, value in os.environ.items() if name != "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE"}
+            token = subprocess.run(  # noqa: S603 - validated operator identity; no shell; resolved executable.
+                [gcloud, "auth", "print-access-token", "--account", args.account],
+                check=True, capture_output=True, text=True, timeout=30, env=env,
+            ).stdout.strip()
+            print(json.dumps({"operator": args.account, "result": run(oauth_credentials.Credentials(token), apply=True)}), flush=True)
+            verified = run(ops_credentials, apply=False)
+            if verified["changed"]:
+                raise RuntimeError("post-commit shard verification failed")
+            print(json.dumps({"verification": verified}), flush=True)
+    except Exception as exc:
+        # Entity JSON includes credential hashes. Never dump plans or RPC payloads.
+        print(json.dumps({"error_type": type(exc).__name__, "message": str(exc) if isinstance(exc, ValueError) else "repair did not verify; inspect exact-key state before retry"}), flush=True)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trusted_router/operational_analytics.py
+++ b/src/trusted_router/operational_analytics.py
@@ -408,6 +408,7 @@ FORMAT JSON
     def public_snapshot(self, name: str) -> dict[str, Any] | None:
         if name not in {
             "leaderboard",
+            "leaderboard_evidence",
             "apps",
             "video_leaderboard",
             "status_inputs",

--- a/tests/test_live_billing_expansion.py
+++ b/tests/test_live_billing_expansion.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import copy
+import dataclasses
+import json
+from types import SimpleNamespace
+
+import pytest
+from google.api_core.exceptions import Aborted, DeadlineExceeded
+from hypothesis import given
+from hypothesis import strategies as st
+
+from scripts import expand_billing_shards as repair
+from tests.test_key_usage_row_sharding import _auth_body, _seed
+from trusted_router.storage_gcp_authorize import authorize_atomic, settle_atomic
+from trusted_router.storage_gcp_counters import CREDIT_BALANCE_TABLE, KEY_LIMIT_TABLE
+
+
+def state():
+    ws = {"id": "ws", "owner_user_id": "owner", "unknown_future": "preserve"}
+    credit = {"workspace_id": "ws", "shard_count": 1, "unknown_future": 123}
+    key = {"hash": "key", "workspace_id": "ws", "usage_shard_count": 1, "include_byok_in_limit": True, "secret_hash": "inert-hash"}
+    rows = [{"workspace_id": "ws", "shard": 0, "total_credits": 1000000, "total_usage": 100, "reserved": 200,
+             **dict.fromkeys(repair.CREDIT_BALANCE_TRUST_COLUMNS), "billing_pause_causes": [], "pause_epoch": 3}]
+    key_rows = [{"key_hash": "key", "shard": 0, "include_byok": True, "usage": 100, "byok_usage": 7,
+                 "reserved": 0, "day_usage": 100, "week_usage": 100, "month_usage": 100}]
+    owner = {"id": "owner", "owner_workspace_count": 1}
+    return [ws, credit, key, rows, key_rows, owner, {"ws": credit}, 16]
+
+
+@given(usage=st.integers(0, 10**12), reserved=st.integers(0, 10**12), free=st.integers(0, 10**12), target=st.integers(1, 64))
+def test_expansion_conserves_every_integer_and_old_hold(usage, reserved, free, target):
+    rows = state()[3]
+    rows[0].update(total_credits=usage + reserved + free, total_usage=usage, reserved=reserved)
+    before = copy.deepcopy(rows)
+    expanded = repair.expand_credit_rows(rows, target)
+    assert rows == before
+    for name in ("total_credits", "total_usage", "reserved"):
+        assert sum(int(row[name]) for row in expanded) == rows[0][name]
+    assert expanded[0]["reserved"] == reserved
+    assert expanded[0]["total_usage"] == usage
+    assert all(row["total_credits"] >= row["total_usage"] + row["reserved"] for row in expanded)
+    assert all(row["pause_epoch"] == 3 for row in expanded)
+    assert repair.expand_credit_rows(expanded, target) == expanded
+
+
+def test_plan_preserves_metadata_and_never_mutates_old_usage_or_holds():
+    inputs = state()
+    before = copy.deepcopy(inputs)
+    plan = repair.make_plan(*inputs)
+    assert inputs == before
+    assert plan["credit"]["unknown_future"] == 123
+    assert plan["key"]["secret_hash"] == before[2]["secret_hash"]
+    changes = repair.mutations(plan)
+    assert {change[next(iter(change))]["table"] for change in changes} == {"tr_credit_balance", "tr_key_limit", "tr_entities"}
+    assert "delete" not in str(changes)
+    old_credit_update = changes[0]["update"]
+    assert old_credit_update["columns"] == ["workspace_id", "shard", "total_credits", "updated_at"]
+    new_keys = changes[2]["insert"]
+    assert all(int(row[1]) >= 1 for row in new_keys["values"])
+    assert "usage" not in new_keys["columns"]
+    assert "reserved" not in new_keys["columns"]
+
+
+@pytest.mark.parametrize("cap", repair.CAP_FIELDS)
+def test_key_cap_refuses_all_mutations(cap):
+    inputs = state()
+    inputs[2][cap] = 1000000
+    with pytest.raises(ValueError, match="uncapped"):
+        repair.make_plan(*inputs)
+
+
+@pytest.mark.parametrize("defect", ["paused", "credit_pause", "wrong_workspace", "wrong_key", "key_hold", "typed_cap", "negative_usage", "inventory", "missing_inventory", "extra_shard", "bad_credit", "federated", "consolidation", "trust_divergence"])
+def test_unsafe_state_fails_closed(defect):
+    inputs = state()
+    ws, credit, key, rows, key_rows, owner, inventory, _ = inputs
+    if defect == "paused":
+        ws["billing_pause_causes"] = ["fraud"]
+    elif defect == "credit_pause":
+        rows[0]["billing_pause_causes"] = ["fraud"]
+    elif defect == "wrong_workspace":
+        key["workspace_id"] = "other"
+    elif defect == "wrong_key":
+        key_rows[0]["key_hash"] = "other"
+    elif defect == "key_hold":
+        key_rows[0]["reserved"] = 1
+    elif defect == "typed_cap":
+        key_rows[0]["limit_micro"] = 1
+    elif defect == "negative_usage":
+        key_rows[0]["usage"] = -1
+    elif defect == "inventory":
+        owner["owner_workspace_count"] = 2
+    elif defect == "missing_inventory":
+        inventory.clear()
+    elif defect == "extra_shard":
+        rows.append({**rows[0], "shard": 1})
+    elif defect == "bad_credit":
+        rows[0]["total_credits"] = 0
+    elif defect == "federated":
+        ws["federated_home"] = "remote"
+    elif defect == "consolidation":
+        inputs[-1] = 0
+    elif defect == "trust_divergence":
+        credit["shard_count"] = 2
+        rows.append({**rows[0], "shard": 1, "pause_epoch": 4})
+    with pytest.raises(ValueError):
+        repair.make_plan(*inputs)
+
+
+def test_idempotent_rerun_does_not_rebalance_again():
+    inputs = state()
+    plan = repair.make_plan(*inputs)
+    inputs[1] = plan["credit"]
+    inputs[2] = plan["key"]
+    inputs[3] = plan["credit_rows"]
+    inputs[4] += [{**inputs[4][0], "shard": n, "usage": 0, "byok_usage": 0, "day_usage": 0, "week_usage": 0, "month_usage": 0} for n in range(1, 16)]
+    inputs[6] = {"ws": inputs[1]}
+    repeated = repair.make_plan(*inputs)
+    assert not repeated["changed"]
+    assert repair.mutations(repeated) == []
+
+
+def test_aborted_commit_recomputes_entire_plan_and_timeout_is_not_retried(monkeypatch):
+    plans = []
+    class Client:
+        commits = 0
+        rollbacks = 0
+        def begin_transaction(self, **kwargs):
+            assert kwargs["retry"] is None
+            return SimpleNamespace(id=b"tx")
+        def commit(self, **kwargs):
+            self.commits += 1
+            assert kwargs["retry"] is None
+            if self.commits == 1:
+                raise Aborted("concurrent settlement")
+        def rollback(self, **kwargs):
+            self.rollbacks += 1
+    def plan(*args):
+        inputs = state()
+        inputs[3][0]["total_usage"] += len(plans)
+        result = repair.make_plan(*inputs)
+        plans.append(result)
+        return result
+    monkeypatch.setattr(repair.Reader, "plan", plan)
+    client = Client()
+    result = repair.execute(client, "session", "ws", "key", 16, apply=True)
+    assert result["totals"]["total_usage"] == 101
+    assert client.commits == 2 and client.rollbacks == 0
+    def timeout(**kwargs):
+        raise DeadlineExceeded("uncertain commit")
+    client.commit = timeout
+    with pytest.raises(DeadlineExceeded):
+        repair.execute(client, "session", "ws", "key", 16, apply=True)
+    assert len(plans) == 3
+
+
+@pytest.mark.parametrize("refund_old", [False, True])
+def test_real_billing_primitives_settle_old_holds_and_new_shards_exactly_once(refund_old):
+    store, database, key = _seed(key_shards=1)
+    def authorize(index, shard):
+        return authorize_atomic(store._database, store._param_types,
+            workspace_id=key.workspace_id, key_hash=key.hash, estimate=1000,
+            has_credit_candidate=True, reservation_usage_type="Credits",
+            idempotency_scope=f"expand-{index}", idempotency_fingerprint="same",
+            expires_at="2026-12-01T00:00:00Z", build_auth_body=_auth_body,
+            credit_shard=shard, key_shard_candidates=(shard,), skip_key_limit=True)
+    old = [authorize(index, 0) for index in range(3)]
+    rows = list(database.typed[CREDIT_BALANCE_TABLE].values())
+    expanded = repair.expand_credit_rows(rows, 16)
+    inputs = state()
+    inputs[0] = {"id": key.workspace_id, "owner_user_id": "owner"}
+    inputs[1] = {"workspace_id": key.workspace_id, "shard_count": 1}
+    inputs[2] = dataclasses.asdict(key)
+    inputs[3] = rows
+    inputs[4] = list(database.typed[KEY_LIMIT_TABLE].values())
+    inputs[6] = {key.workspace_id: inputs[1]}
+    plan = repair.make_plan(*inputs)
+    # Apply the generated mutations through the store's transaction API.
+    def apply(tx):
+        for change in repair.mutations(plan):
+            body = next(iter(change.values()))
+            table, columns = body["table"], body["columns"]
+            values = copy.deepcopy(body["values"])
+            for row in values:
+                for n, column in enumerate(columns):
+                    if column in {"shard", "total_credits", "total_usage", "reserved", "pause_epoch", "trust_tier", "trust_override_tier"} and row[n] is not None:
+                        row[n] = int(row[n])
+                    if row[n] == "spanner.commit_timestamp()":
+                        row[n] = None
+            tx.insert_or_update(table=table, columns=columns, values=values)
+    database.run_in_transaction(apply)
+    assert sum(row["reserved"] for row in expanded) == 3000
+    new = [authorize(10 + shard, shard) for shard in range(16)]
+    for result in old + new:
+        assert result["outcome"] == "accepted"
+        refund = refund_old and result in old
+        for _ in range(2):
+            settled = settle_atomic(store._database, store._param_types,
+                reservation_id=result["reservation_id"], actual_micro=0 if refund else 900,
+                settled_usage_type="Credits", success=not refund)
+            assert settled["outcome"] in {"settled", "already_settled"}
+    expected = (16 if refund_old else 19) * 900
+    assert sum(row["total_usage"] for row in database.typed[CREDIT_BALANCE_TABLE].values()) == expected
+    assert sum(row["usage"] for row in database.typed[KEY_LIMIT_TABLE].values()) == expected
+    assert sum(row["reserved"] for row in database.typed[CREDIT_BALANCE_TABLE].values()) == 0
+    assert len([row for row in database.typed[KEY_LIMIT_TABLE].values() if row["usage"] > 0]) == 16
+    assert json.loads(database.rows[("credit", key.workspace_id)].body)["shard_count"] == 16
+
+
+def test_read_contract_is_exact_key_bounded_and_uses_same_transaction():
+    from google.cloud.spanner_v1.types import ResultSet
+
+    calls = []
+    class Client:
+        def read(self, **kwargs):
+            calls.append(kwargs)
+            return ResultSet(rows=[["ws", "0", "123"]])
+    reader = repair.Reader(Client(), "session", {"id": b"tx"}, repair.time.monotonic() + 10)
+    rows = reader.read("tr_credit_balance", ("workspace_id", "shard", "total_credits"), [["ws", "0"]])
+    assert rows == [{"workspace_id": "ws", "shard": "0", "total_credits": "123"}]
+    call = calls[0]
+    assert call["retry"] is None and call["timeout"] <= 5
+    assert call["request"]["transaction"] == {"id": b"tx"}
+    assert call["request"]["key_set"] == {"keys": [["ws", "0"]]}
+    assert call["request"]["request_options"]["priority"] == "PRIORITY_LOW"
+
+
+def test_dry_run_never_commits_or_rolls_back(monkeypatch):
+    class Client:
+        def begin_transaction(self, **kwargs):
+            assert kwargs["request"]["options"] == {"read_only": {"strong": True}}
+            return SimpleNamespace(id=b"read")
+        def commit(self, **kwargs):
+            pytest.fail("dry-run tried to commit")
+        def rollback(self, **kwargs):
+            pytest.fail("dry-run tried to mutate transaction state")
+    monkeypatch.setattr(repair.Reader, "plan", lambda *args: repair.make_plan(*state()))
+    result = repair.execute(Client(), "session", "ws", "key", 16, apply=False)
+    assert result["changed"] and not result["applied"]
+    assert "secret_hash" not in json.dumps(result)
+
+
+def test_transaction_reads_key_before_credit_to_match_settlement(monkeypatch):
+    from google.cloud.spanner_v1.types import ResultSet
+
+    inputs = state()
+    ws, credit, key, credit_rows, key_rows, owner, _, _ = inputs
+    entities = {("workspace", "ws"): ws, ("credit", "ws"): credit, ("api_key", "key"): key, ("user", "owner"): owner}
+    class Client:
+        def execute_sql(self, **kwargs):
+            assert "WHERE owner_user_id=@owner" in kwargs["request"]["sql"]
+            assert "LIMIT 33" in kwargs["request"]["sql"]
+            return ResultSet(rows=[["ws"]])
+    reader = repair.Reader(Client(), "s", {"id": b"tx"}, repair.time.monotonic() + 10)
+    monkeypatch.setattr(reader, "entities", lambda keys: {tuple(k): entities[tuple(k)] for k in keys})
+    tables = []
+    def read(table, columns, keys):
+        tables.append(table)
+        assert len(keys) == 64
+        assert len({tuple(k) for k in keys}) == 64
+        return key_rows if table == "tr_key_limit" else credit_rows
+    monkeypatch.setattr(reader, "read", read)
+    assert reader.plan("ws", "key", 16)["changed"]
+    assert tables == ["tr_key_limit", "tr_credit_balance"]

--- a/tests/test_operational_analytics.py
+++ b/tests/test_operational_analytics.py
@@ -551,6 +551,7 @@ def test_postgres_route_health_batch_read_uses_one_partitioned_query() -> None:
     "snapshot_name",
     [
         "leaderboard",
+        "leaderboard_evidence",
         "apps",
         "video_leaderboard",
         "status_inputs",


### PR DESCRIPTION
## Summary

- Add a bounded operator-only live expansion for legacy single-shard billing accounts and uncapped keys. The whole change is atomic, preserves active holds and existing usage/window counters, and never pauses the workspace.
- Keep read-only preflight and verification on the ops credential; require a separate authenticated operator for writes. Refuse caps, malformed shard sets, divergent trust state, and incomplete owner inventory. Preserve future JSON fields and pin key-before-credit lock order.
- Accept the already-published `leaderboard_evidence` snapshot in the reader. Its new contract case was confirmed to fail before the fix.
- Document the confirmed billing hotspot and its production repair without customer-identifying data.

## Verification

- Ruff and mypy pass, including an explicit mypy pass over the new operator script.
- Full local suite passed on this exact revision: 10,010 passed, 408 skipped, 11 xfailed.
- 54 focused expansion and existing key-shard tests pass, including real billing primitives for old holds, refunds, new shards, and duplicate settlement.
- Production atomic expansion completed at approximately 03:41 UTC on September 9. Read-only verification confirmed 16 credit and 16 key shards, unchanged total credit, no billing pause, and subsequent live usage on all 16 key shards.
- First fresh post-repair log sample (03:43:00 through 03:44:22 UTC): 773 billing requests, no HTTP 5xx, and no calls over 10 seconds. US Central authorization p50 was 114 ms. No new Cloud Run ERROR logs were found after the repair.
- Expanded post-repair sample through 03:49:42 UTC: 3,593 billing calls, zero HTTP 5xx and zero calls over 10 seconds. US Central authorization p50/p95 were 110/371 ms. The residual 429 responses correlate with `billing.authorize_admission_limited`, not storage errors; admission limits are unchanged.
- Bounded post-repair Spanner lock statistics (03:43 through 03:48 UTC) showed a worst single-row accumulated lock wait of 7.09 seconds/minute, compared with more than 500 seconds/minute immediately before expansion. Transaction aborts have not disappeared, but no longer produce the observed long billing stalls.
- Cost-free homepage, leaderboard, and status-page GET checks all returned HTTP 200.
- No alerts, IAM permissions, lease rollout flags, or inference security boundaries changed.

The operator mutation has already been applied to the diagnosed account. Merging this PR preserves the reusable repair and deploys the separate one-line leaderboard reader fix through the normal gated rollout.
