### PR TITLE
Add a copyable agent verification prompt to the trust page

### DIFF
--- a/src/trusted_router/static/copy-icon.svg
+++ b/src/trusted_router/static/copy-icon.svg
@@ -1,0 +1,12 @@
+<!-- Lucide 0.468.0 Copy icon. ISC License.
+Copyright (c) for portions of Lucide are held by Cole Bemis 2013-2022 as part of Feather (MIT).
+All other copyright (c) for Lucide are held by Lucide Contributors 2022.
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without
+fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE
+INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE
+FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+Source: https://unpkg.com/lucide-static@0.468.0/icons/copy.svg -->
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>

--- a/src/trusted_router/static/trust-prompt.js
+++ b/src/trusted_router/static/trust-prompt.js
@@ -1,0 +1,31 @@
+"use strict";
+
+(() => {
+  const button = document.getElementById("copy-trust-prompt");
+  const prompt = document.getElementById("trust-agent-prompt");
+  const status = document.getElementById("trust-copy-status");
+  if (!button || !prompt || !status) return;
+
+  button.hidden = false;
+  button.addEventListener("click", async () => {
+    button.disabled = true;
+    status.textContent = "";
+    try {
+      await navigator.clipboard.writeText(prompt.textContent.trim());
+      status.textContent = "Copied. Ready for your agent chat.";
+    } catch {
+      const selection = window.getSelection();
+      if (selection) {
+        const range = document.createRange();
+        range.selectNodeContents(prompt);
+        selection.removeAllRanges();
+        selection.addRange(range);
+        status.textContent = "Prompt selected. Use your device's copy command.";
+      } else {
+        status.textContent = "Clipboard unavailable. You can select and copy the prompt.";
+      }
+    } finally {
+      button.disabled = false;
+    }
+  });
+})();

--- a/src/trusted_router/trust.py
+++ b/src/trusted_router/trust.py
@@ -514,7 +514,7 @@ def trust_html(
     <section class="agent-verify" aria-labelledby="agent-verify-title">
       <div class="agent-verify-head">
         <h2 id="agent-verify-title">Ask your agent to verify TrustedRouter</h2>
-        <button class="copy-prompt" id="copy-trust-prompt" type="button" aria-controls="trust-agent-prompt" title="Copy verification prompt" hidden><img src="/static/copy-icon.svg" width="18" height="18" alt=""><span>Copy prompt</span></button>
+        <button class="copy-prompt" id="copy-trust-prompt" type="button" aria-controls="trust-agent-prompt" title="Copy verification prompt" hidden><img src="/static/copy-icon.svg" width="18" height="18" alt="Copy" aria-hidden="true"><span>Copy prompt</span></button>
       </div>
       <blockquote class="agent-prompt"><p id="trust-agent-prompt">{agent_prompt}</p></blockquote>
       <span class="copy-status" id="trust-copy-status" role="status" aria-live="polite" aria-atomic="true"></span>

--- a/src/trusted_router/trust.py
+++ b/src/trusted_router/trust.py
@@ -22,8 +22,8 @@ JAVASCRIPT_SDK_REPO = "https://github.com/Lore-Hex/trusted-router-js"
 PROVIDER_CHECK_REPO = "https://github.com/Lore-Hex/trustedrouter-provider-check"
 
 TRUST_AGENT_PROMPT = (
-    "Verify https://trustedrouter.com using https://trust.trustedrouter.com. "
-    "Check fresh, TLS-bound attestation and trace the running build to published "
+    "Use https://trust.trustedrouter.com to verify https://trustedrouter.com "
+    "with fresh, TLS-bound attestation. Trace the running build to published "
     "source and build provenance. Separate router protections from model-provider "
     "privacy claims. Report verified evidence, failures, and anything you cannot verify."
 )

--- a/src/trusted_router/trust.py
+++ b/src/trusted_router/trust.py
@@ -21,6 +21,13 @@ PYTHON_SDK_REPO = "https://github.com/Lore-Hex/trusted-router-py"
 JAVASCRIPT_SDK_REPO = "https://github.com/Lore-Hex/trusted-router-js"
 PROVIDER_CHECK_REPO = "https://github.com/Lore-Hex/trustedrouter-provider-check"
 
+TRUST_AGENT_PROMPT = (
+    "Verify https://trustedrouter.com using https://trust.trustedrouter.com. "
+    "Check fresh, TLS-bound attestation and trace the running build to published "
+    "source and build provenance. Separate router protections from model-provider "
+    "privacy claims. Report verified evidence, failures, and anything you cannot verify."
+)
+
 
 NOT_CONFIGURED = "not-configured"
 
@@ -387,6 +394,7 @@ def trust_html(
     python_sdk_repo = html.escape(PYTHON_SDK_REPO)
     javascript_sdk_repo = html.escape(JAVASCRIPT_SDK_REPO)
     provider_check_repo = html.escape(PROVIDER_CHECK_REPO)
+    agent_prompt = html.escape(TRUST_AGENT_PROMPT)
     if release_metadata_status == "stale":
         release_warning = (
             '<section class="panel warn"><h2>Release record temporarily stale</h2>'
@@ -456,6 +464,17 @@ def trust_html(
     .mark {{ width:30px; height:30px; border-radius:7px; background:linear-gradient(135deg,#2c6ecb,#19a06d); display:grid; place-items:center; font-size:13px; color:#fff; }}
     .links {{ display:flex; gap:14px; flex-wrap:wrap; font-size:14px; }}
     .wrap {{ max-width:1120px; margin:0 auto; padding:34px 22px 56px; display:grid; gap:18px; }}
+    .agent-verify {{ padding:0 0 18px; border-bottom:1px solid var(--line); min-width:0; }}
+    .agent-verify-head {{ display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:12px; min-height:44px; margin-bottom:14px; }}
+    .agent-verify-head h2 {{ font-size:22px; line-height:1.3; margin:0; text-wrap:balance; }}
+    .agent-prompt {{ margin:0; border-left:3px solid var(--green); padding:4px 0 4px 18px; }}
+    .agent-prompt p {{ color:var(--ink); margin:0; font-size:17px; line-height:1.65; overflow-wrap:anywhere; }}
+    .copy-prompt {{ display:inline-flex; flex-shrink:0; align-items:center; justify-content:center; gap:8px; min-height:44px; padding:10px 16px; border:1px solid var(--green); border-radius:6px; background:var(--green); color:#fff; font:inherit; font-weight:600; cursor:pointer; }}
+    .copy-prompt[hidden] {{ display:none; }}
+    .copy-prompt:hover {{ background:#0d5a3c; }}
+    .copy-prompt:focus-visible {{ outline:3px solid var(--blue); outline-offset:3px; }}
+    .copy-prompt:disabled {{ cursor:wait; }}
+    .copy-status {{ display:block; min-height:24px; margin-top:8px; color:var(--muted); font-size:14px; line-height:1.5; }}
     .hero {{ display:grid; grid-template-columns:minmax(0,1.15fr) minmax(300px,.85fr); gap:20px; align-items:start; }}
     h1 {{ font-size:42px; line-height:1.08; margin:0 0 12px; letter-spacing:0; }}
     h2 {{ font-size:17px; margin:0 0 12px; letter-spacing:0; }}
@@ -482,6 +501,7 @@ def trust_html(
       h1 {{ font-size:31px; }}
     }}
   </style>
+  <script src="/static/trust-prompt.js" defer></script>
 </head>
 <body>
   <header>
@@ -491,6 +511,14 @@ def trust_html(
     </nav>
   </header>
   <main class="wrap">
+    <section class="agent-verify" aria-labelledby="agent-verify-title">
+      <div class="agent-verify-head">
+        <h2 id="agent-verify-title">Ask your agent to verify TrustedRouter</h2>
+        <button class="copy-prompt" id="copy-trust-prompt" type="button" aria-controls="trust-agent-prompt" title="Copy verification prompt" hidden><img src="/static/copy-icon.svg" width="18" height="18" alt=""><span>Copy prompt</span></button>
+      </div>
+      <blockquote class="agent-prompt"><p id="trust-agent-prompt">{agent_prompt}</p></blockquote>
+      <span class="copy-status" id="trust-copy-status" role="status" aria-live="polite" aria-atomic="true"></span>
+    </section>
     {release_warning}
     <section class="hero">
       <div class="panel">

--- a/tests/browser/trust-prompt.spec.js
+++ b/tests/browser/trust-prompt.spec.js
@@ -1,0 +1,58 @@
+const { test, expect } = require("@playwright/test");
+
+test("copies exactly the visible prompt under the real page CSP", async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: async (text) => { window.copiedTrustPrompt = text; } },
+    });
+  });
+  await page.goto("/trust");
+  await page.getByRole("button", { name: "Copy prompt" }).click();
+  const prompt = (await page.locator("#trust-agent-prompt").textContent()).trim();
+  expect(await page.evaluate(() => window.copiedTrustPrompt)).toBe(prompt);
+  await expect(page.getByRole("status")).toHaveText("Copied. Ready for your agent chat.");
+  await expect(page.getByRole("button", { name: "Copy prompt" })).toBeEnabled();
+});
+
+for (const mode of ["denied", "unavailable"]) {
+  test(`selects the prompt when clipboard access is ${mode}`, async ({ page }) => {
+    await page.addInitScript((mode) => {
+      Object.defineProperty(navigator, "clipboard", {
+        value: mode === "unavailable" ? undefined : {
+          writeText: async () => { throw new DOMException("Denied", "NotAllowedError"); },
+        },
+      });
+    }, mode);
+    await page.goto("/trust");
+    await page.getByRole("button", { name: "Copy prompt" }).click();
+    const prompt = (await page.locator("#trust-agent-prompt").textContent()).trim();
+    expect(await page.evaluate(() => window.getSelection().toString())).toBe(prompt);
+    await expect(page.getByRole("status")).toContainText("Prompt selected");
+    await expect(page.getByRole("button", { name: "Copy prompt" })).toBeEnabled();
+  });
+}
+
+test("the prompt remains readable without JavaScript", async ({ browser, baseURL }) => {
+  const context = await browser.newContext({ baseURL, javaScriptEnabled: false });
+  const page = await context.newPage();
+  await page.goto("/trust");
+  await expect(page.locator("#trust-agent-prompt")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Copy prompt" })).toBeHidden();
+  await context.close();
+});
+
+for (const width of [375, 1440]) {
+  test(`prompt fits the first viewport at ${width}px`, async ({ page }, testInfo) => {
+    await page.setViewportSize({ width, height: 900 });
+    await page.goto("/trust");
+    const prompt = await page.locator(".agent-verify").boundingBox();
+    expect(prompt.y + prompt.height).toBeLessThan(900);
+    const heading = await page.locator("#agent-verify-title").boundingBox();
+    const button = await page.getByRole("button", { name: "Copy prompt" }).boundingBox();
+    expect(button.height).toBeGreaterThanOrEqual(44);
+    expect(button.x >= heading.x + heading.width || button.y >= heading.y + heading.height).toBeTruthy();
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBeTruthy();
+    await expect(page.locator(".copy-prompt img")).toHaveJSProperty("naturalWidth", 24);
+    await page.screenshot({ path: testInfo.outputPath("trust-prompt.png") });
+  });
+}

--- a/tests/test_trust_agent_prompt.py
+++ b/tests/test_trust_agent_prompt.py
@@ -39,6 +39,10 @@ def test_agent_verification_prompt_is_first_on_both_trust_surfaces(url: str) -> 
     assert button.get("type") == "button"
     assert button.get("aria-controls") == "trust-agent-prompt"
     assert button.get("onclick") is None
+    icon = button.find("img")
+    assert icon is not None
+    assert icon.get("alt") == "Copy"
+    assert icon.get("aria-hidden") == "true"
     assert first.find(id="trust-copy-status").get("role") == "status"
     script = page.find("script", src="/static/trust-prompt.js")
     assert script is not None

--- a/tests/test_trust_agent_prompt.py
+++ b/tests/test_trust_agent_prompt.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import pytest
+from bs4 import BeautifulSoup
+from fastapi.testclient import TestClient
+
+from trusted_router.config import Settings
+from trusted_router.main import create_app
+from trusted_router.trust import trust_html
+
+
+@pytest.mark.parametrize("url", ["/trust", "https://trust.trustedrouter.com/"])
+def test_agent_verification_prompt_is_first_on_both_trust_surfaces(url: str) -> None:
+    settings = Settings(environment="test", trust_gcp_image_digest="sha256:" + "00" * 32)
+    with TestClient(create_app(settings, init_observability=False)) as client:
+        response = client.get(url)
+    assert response.status_code == 200
+    page = BeautifulSoup(response.text, "html.parser")
+    main = page.find("main")
+    assert main is not None
+    first = main.find("section", recursive=False)
+    assert first is not None
+    assert first.get("aria-labelledby") == "agent-verify-title"
+    prompt = first.find(id="trust-agent-prompt")
+    assert prompt is not None
+    text = prompt.get_text()
+    assert len(text.split()) <= 55
+    for required in (
+        "https://trustedrouter.com",
+        "https://trust.trustedrouter.com",
+        "fresh, TLS-bound attestation",
+        "published source and build provenance",
+        "model-provider privacy claims",
+        "anything you cannot verify",
+    ):
+        assert required in text
+    button = first.find("button", id="copy-trust-prompt")
+    assert button is not None
+    assert button.get("type") == "button"
+    assert button.get("aria-controls") == "trust-agent-prompt"
+    assert button.get("onclick") is None
+    assert first.find(id="trust-copy-status").get("role") == "status"
+    script = page.find("script", src="/static/trust-prompt.js")
+    assert script is not None
+    assert script.has_attr("defer")
+
+
+@pytest.mark.parametrize("status", ["stale", "unavailable"])
+def test_prompt_keeps_release_failures_visible(status: str) -> None:
+    page = BeautifulSoup(
+        trust_html(Settings(environment="test"), release_metadata_status=status),
+        "html.parser",
+    )
+    sections = page.find("main").find_all("section", recursive=False)
+    assert sections[0].find(id="trust-agent-prompt") is not None
+    assert "warn" in sections[1].get("class", [])
+    assert "HTTP 503" in sections[1].get_text()


### PR DESCRIPTION
## Summary
Put a short agent verification prompt before the technical trust details on `/trust` and the control-plane trust-host route.

The prompt asks for fresh TLS-bound attestation, published source/build provenance, an explicit distinction between router protections and downstream provider claims, and disclosure of anything unverifiable.

Add a small same-origin copy script with accessible status feedback and a text-selection fallback. The prompt remains readable without JavaScript. Existing stale/unavailable release warnings remain immediately below it.

The independently hosted static trust site is updated and live via https://github.com/Lore-Hex/quill-cloud-proxy/pull/327, preserving that site's no-script policy.

## Verification
- Regression-first: all four new Python cases failed before implementation.
- 32 focused Python trust tests pass.
- Six Playwright tests pass: successful copy, denied/unavailable clipboard, no JavaScript, desktop/mobile layout. Screenshots inspected.
- `ruff check .` and `mypy` pass.
- Full local Python suite: 10,014 passed, 408 skipped, 11 expected failures. Initial coverage run measured 84.37% and exposed the now-fixed copy-icon alt-text integration issue.
- Full local browser suite: all 53 pass, including the six new prompt checks. CI's unrelated existing `/blog` navigation hit its 30-second timeout; that same test passes locally. Merge waits for the unchanged job retry and all remaining CI gates.
