### PR TITLE
Display ScaleDown free output prices explicitly

### DIFF
--- a/src/trusted_router/dashboard.py
+++ b/src/trusted_router/dashboard.py
@@ -96,6 +96,7 @@ from trusted_router.provider_contract import (
     PROVIDER_CATALOG_V2_EXAMPLE,
     PROVIDER_MODEL_DOCUMENTATION_EXAMPLE,
 )
+from trusted_router.provider_contracts import INPUT_ONLY_PROVIDER_MODELS
 from trusted_router.provider_lifecycle import provider_pricing_schedule
 from trusted_router.seo_catalog import seo_catalog_evidence
 from trusted_router.seo_meta import (
@@ -4954,7 +4955,7 @@ def _minimum_model_price(
     endpoints: Sequence[ModelEndpoint],
     attr: str,
 ) -> int | None:
-    values = [getattr(endpoint, attr) for endpoint in endpoints if getattr(endpoint, attr) > 0]
+    values = _endpoint_price_values(endpoints, attr)
     if values:
         return min(values)
     model_value = getattr(model, attr)
@@ -5170,8 +5171,8 @@ def _model_detail_view(
                 "provider_logo_url": provider_logo_url(endpoint.provider),
                 "prompt_price": _price(endpoint.prompt_price_microdollars_per_million_tokens),
                 "cached_prompt_price": _cached_prompt_price_range((endpoint,)),
-                "completion_price": _price(
-                    endpoint.completion_price_microdollars_per_million_tokens
+                "completion_price": _endpoint_price_range(
+                    (endpoint,), "completion_price_microdollars_per_million_tokens"
                 ),
                 "prompt_microdollars_per_million_tokens": endpoint.prompt_price_microdollars_per_million_tokens,
                 "completion_microdollars_per_million_tokens": endpoint.completion_price_microdollars_per_million_tokens,
@@ -5219,7 +5220,10 @@ def _model_detail_view(
         "cached_prompt_price": (
             "selected route" if is_meta else _cached_prompt_price_range(endpoints)
         ),
-        "completion_price": _price(model.completion_price_microdollars_per_million_tokens),
+        "completion_price": _price(
+            model.completion_price_microdollars_per_million_tokens,
+            include_zero=(model.provider, model.id) in INPUT_ONLY_PROVIDER_MODELS,
+        ),
         "minimum_charge": (
             format_money_precise(model.minimum_charge_microdollars)
             if model.minimum_charge_microdollars
@@ -5607,7 +5611,12 @@ def _model_route_evidence(
     return {
         "lowest_prompt_price": _price(lowest_prompt) if lowest_prompt is not None else None,
         "lowest_completion_price": (
-            _price(lowest_completion) if lowest_completion is not None else None
+            _price(
+                lowest_completion,
+                include_zero=(model.provider, model.id) in INPUT_ONLY_PROVIDER_MODELS,
+            )
+            if lowest_completion is not None
+            else None
         ),
         "fastest_ttft_ms": fastest_ttft_ms,
         "fastest_ttft": (
@@ -6061,11 +6070,26 @@ def _model_service_node(settings: Settings, model: Model, site_url: str) -> dict
     }
 
 
+def _endpoint_price_values(endpoints: Sequence[ModelEndpoint], attr: str) -> list[int]:
+    """Include free output only when the pinned contract makes zero authoritative."""
+    values = []
+    for endpoint in endpoints:
+        value = getattr(endpoint, attr)
+        free_output = (
+            value == 0
+            and attr == "completion_price_microdollars_per_million_tokens"
+            and (endpoint.provider, endpoint.model_id) in INPUT_ONLY_PROVIDER_MODELS
+        )
+        if value > 0 or free_output:
+            values.append(value)
+    return values
+
+
 def _endpoint_price_range(endpoints: Sequence[ModelEndpoint], attr: str) -> str:
-    values = [getattr(ep, attr) for ep in endpoints if getattr(ep, attr) > 0]
+    values = _endpoint_price_values(endpoints, attr)
     if not values:
         return _price(0)
-    return _price_values_range(values)
+    return _price_values_range(values, include_zero=True)
 
 
 def _price_values_range(values: Sequence[int], *, include_zero: bool = False) -> str:
@@ -6093,8 +6117,8 @@ def _price_range(models: list[Model], attr: str) -> str:
     return f"{_price(low)} to {_price(high)}"
 
 
-def _price(microdollars_per_million: int) -> str:
-    if microdollars_per_million <= 0:
+def _price(microdollars_per_million: int, *, include_zero: bool = False) -> str:
+    if microdollars_per_million < 0 or (microdollars_per_million == 0 and not include_zero):
         return "selected route"
     value = Decimal(microdollars_per_million) / Decimal(MICRODOLLARS_PER_DOLLAR)
     return f"${value.normalize():f}/1M"

--- a/tests/test_scaledown_provider.py
+++ b/tests/test_scaledown_provider.py
@@ -261,3 +261,43 @@ def test_public_pages_and_usage_examples(client):
         page = client.get(f"/models/scaledown/{task}")
         assert page.status_code == 200
         assert "input-only" in page.text.lower()
+
+
+@pytest.mark.parametrize("task", scaledown.TASKS)
+def test_free_output_is_visible_in_all_model_prices(task):
+    from trusted_router.catalog import MODELS
+    from trusted_router.dashboard import _model_detail_view, _model_route_evidence, _model_view
+
+    model = MODELS[f"scaledown/{task}"]
+    listing = _model_view(model, test_mode=True)
+    detail = _model_detail_view(model, test_mode=True)
+    evidence = _model_route_evidence(model, test_mode=True)
+    assert listing["completion_price"] == "$0/1M"
+    assert listing["completion_price_sort"] == 0
+    assert detail["completion_price"] == "$0/1M"
+    assert all(endpoint["completion_price"] == "$0/1M" for endpoint in detail["endpoints"])
+    assert evidence["lowest_completion_price"] == "$0/1M"
+
+
+def test_unknown_zero_prices_still_mean_selected_route():
+    from dataclasses import replace
+
+    from trusted_router.catalog import endpoints_for_model
+    from trusted_router.dashboard import _endpoint_price_range, _price
+
+    endpoint = endpoints_for_model("scaledown/compress")[0]
+    attr = "completion_price_microdollars_per_million_tokens"
+    assert _price(0) == "selected route"
+    assert _price(-1, include_zero=True) == "selected route"
+    assert _endpoint_price_range((replace(endpoint, provider="unknown"),), attr) == "selected route"
+    assert _endpoint_price_range((replace(endpoint, model_id="unknown"),), attr) == "selected route"
+    assert (
+        _endpoint_price_range(
+            (
+                endpoint,
+                replace(endpoint, completion_price_microdollars_per_million_tokens=1_000_000),
+            ),
+            attr,
+        )
+        == "$0/1M to $1/1M"
+    )


### PR DESCRIPTION
## Summary

Follow-up to #1142. Explicit input-only ScaleDown contracts have free output, but the public formatter treated every zero as dynamic pricing and rendered `selected route`.

- Share the endpoint-price selection used by catalog display and numeric sorting.
- Include zero output only for pinned input-only provider/model contracts.
- Render `$0/1M` on listings, provider tables, model details, endpoint rows and lowest-output-price evidence.
- Preserve dynamic/unknown zero and negative-price behavior. No billing, routing, or enclave changes.

## Verification

- Reproduced all four new regression tests failing before the fix.
- 270 focused catalog, SEO, routing, ScaleDown and meta-pricing tests pass after the fix.
- Tests cover unknown provider/model zeros, negative values, and mixed free/paid ranges.
- Ruff and diff whitespace checks pass.
- Claude CLI Opus review unavailable: local CLI is logged out; no alternate API-key workaround used.
