### PR TITLE
stage D: open the cohort to every workspace (HELD for the secondaries' clean day)

### DIFF
--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -782,12 +782,13 @@ ENV_VARS=(
   # heartbeats only where QUILL_USAGE_HEARTBEAT=on, which rolls region by region
   # after this lands.
   "TR_STAGE_D_ELIGIBILITY_ENABLED=true"
-  # Decision 77 (d): the spend-lease pilot plus the dedicated Stage D probe
-  # workspace (provisioned 2026-09-06, heartbeat-capable local typed key).
-  # The probe is deliberately NOT on the regional-quota path so the roll gate's
-  # key is in the cohort. Clearing this list is the later fleet-expansion step,
-  # not part of arming.
-  "TR_STAGE_D_PILOT_WORKSPACE_IDS=45819281-0ce9-4811-a0cd-c660ab3a116d,91d7810e-93b2-4c37-b1bd-ba9227585416"
+  # Decision 77 (d): an empty list puts every workspace in the Stage D cohort.
+  # Heartbeat has been live in all three regions since 2026-09-09 21:35Z.
+  # Merge precondition: wait for a clean day of heartbeat on the secondaries;
+  # hold this change even when CI is green until that precondition is met.
+  # Rollback: restore the two pilot IDs below and redeploy:
+  # 45819281-0ce9-4811-a0cd-c660ab3a116d,91d7810e-93b2-4c37-b1bd-ba9227585416
+  "TR_STAGE_D_PILOT_WORKSPACE_IDS="
   # Decisions 75-76. The first attempt at this flip (#1131) was reverted the same
   # day: the arm gate evaluated the whole owner inventory inside the authorize
   # transaction, hit the RPC bound and returned 503 at 20.02s. #1133 moved that

--- a/tests/test_stage_d_authorize.py
+++ b/tests/test_stage_d_authorize.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -279,8 +280,8 @@ def test_app_markup_and_receipt_fee_remain_in_stage_d_cohort(
 
 
 def test_stage_d_eligibility_kill_switch_declares_nothing_eligible() -> None:
-    """The code default is off; production pins eligibility on for exactly the
-    two-workspace cohort. The kill switch declares nothing eligible when disabled.
+    """The code default is off; production opens the cohort to every workspace.
+    The kill switch declares nothing eligible when disabled.
     """
     from trusted_router.routes.internal.gateway import _stage_d_eligibility_reason
 
@@ -289,7 +290,7 @@ def test_stage_d_eligibility_kill_switch_declares_nothing_eligible() -> None:
     for literal in (
         '"TR_STAGE_D_ELIGIBILITY_ENABLED=true"',
         '"TR_STAGE_D_HEARTBEAT_ENABLED=true"',
-        '"TR_STAGE_D_PILOT_WORKSPACE_IDS=45819281-0ce9-4811-a0cd-c660ab3a116d,91d7810e-93b2-4c37-b1bd-ba9227585416"',
+        '"TR_STAGE_D_PILOT_WORKSPACE_IDS="',
         '"TR_SPEND_LEASE_ACCEPTED_GCP_IMAGE_DIGESTS="',
         '"TR_REAP_SNAPSHOT_BOOKING_ENABLED=false"',
     ):
@@ -304,6 +305,35 @@ def test_stage_d_eligibility_kill_switch_declares_nothing_eligible() -> None:
         settlement_backend=True,
     )
     assert reason == "stage_d_disabled"
+
+
+def test_stage_d_deploy_cohort_is_empty() -> None:
+    rollout = (Path(__file__).parents[1] / "scripts" / "deploy" / "rollout.sh").read_text()
+    assert re.findall(r'^\s*"TR_STAGE_D_PILOT_WORKSPACE_IDS=([^"\n]*)"', rollout, re.M) == [""]
+
+
+@pytest.mark.parametrize("route_type", ["chat.completions", "responses"])
+@pytest.mark.parametrize(
+    ("pilot_workspace_ids", "expected_reason"),
+    [("", "ok"), ("other-workspace", "workspace_not_pilot")],
+)
+def test_stage_d_empty_cohort_admits_arbitrary_workspace(
+    route_type: str, pilot_workspace_ids: str, expected_reason: str
+) -> None:
+    settings = Settings(environment="test", stage_d_pilot_workspace_ids=pilot_workspace_ids)
+    assert _stage_d_eligibility_reason(
+        eligibility_enabled=True,
+        workspace_id="arbitrary-workspace",
+        pilot_workspace_ids=settings.stage_d_pilot_workspaces,
+        heartbeat_enabled=True,
+        boot_accepted=True,
+        stream=True,
+        route_type=route_type,
+        endpoint_candidates=[_credit_candidate()],
+        standard_endpoint_pricing=True,
+        service_tier=None,
+        settlement_backend=True,
+    ) == expected_reason
 
 
 def test_stage_d_replay_is_always_ineligible_and_echoes_stored_nonce(


### PR DESCRIPTION
## HELD — do not merge on green

This opens the Stage D cohort from two pilot workspaces to every workspace. It is the largest blast-radius step left in Stage D, and it waits on evidence: a clean day of the usage heartbeat on the two secondary regions, which went live at 21:35Z on 2026-09-09. A soak watcher samples heartbeat acceptance, billing 5xx and every alert policy every thirty minutes and prints a merge verdict at the end of that day. This PR merges only on that verdict.

## What

`TR_STAGE_D_PILOT_WORKSPACE_IDS` in `scripts/deploy/rollout.sh` goes from the two pilot ids to empty. `_stage_d_eligibility_reason` returns `workspace_not_pilot` only when the list is non-empty, so empty admits every workspace; that is the designed fleet-expansion step the pin's own comment described. The deploy-contract pin now asserts the list is empty, and a new test proves the eligibility function admits an arbitrary workspace when the list is empty and still refuses one absent from a non-empty list. No other flag moves. Rollback is restoring the two ids, which the comment lists.

## Blast radius

With the cohort open, every streaming chat or responses request on a CREDITS endpoint with standard pricing and a non-priority tier takes the Stage D path. If the enclave's heartbeat is rejected, `stage_d.go` falls the stream back to the synchronous path rather than surfacing an error, so the failure mode is loss of Stage D accounting, not a user-visible failure.

## Proof

Fable gate on an isolated snapshot: 125 tests green across the Stage D authorize and heartbeat suites and the deploy-secret wiring; ruff clean. Two mutations red: putting a pilot id back, and changing the eligibility function so an empty list no longer admits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
