### PR TITLE
pricing: approve the SiliconFlow DeepSeek and GLM-5.3-Flash transitions

### DIFF
--- a/scripts/check_price_spike.py
+++ b/scripts/check_price_spike.py
@@ -308,6 +308,116 @@ APPROVED_ENDPOINT_PRICE_TRANSITIONS = frozenset(
             Decimal("0.00000003"),
             Decimal("0.000000075"),
         ),
+        # SiliconFlow's public prices, verified 2026-09-09, per million
+        # tokens (input / cached input / output): Flash-0731 0.22 / 0.014 / 0.66;
+        # Flash-Vision-Exp 0.44 / 0.028 / 1.32. Pin only these observed spikes:
+        # https://siliconflow.com/pricing
+        # These rates match the DeepSeek first-party schedule effective
+        # 2026-08-16 used for the existing GMI approvals:
+        # https://api-docs.deepseek.com/quick_start/pricing/
+        (
+            "deepseek/deepseek-v4-flash-0731 "
+            "[siliconflow:siliconflow/fp8:deepseek-ai/DeepSeek-V4-Flash-0731]",
+            "completion",
+            Decimal("0.00000028"),
+            Decimal("0.00000066"),
+        ),
+        (
+            "deepseek/deepseek-v4-flash-0731 "
+            "[siliconflow:siliconflow:deepseek-ai/DeepSeek-V4-Flash-0731]",
+            "completion",
+            Decimal("0.00000028"),
+            Decimal("0.00000066"),
+        ),
+        (
+            "deepseek/deepseek-v4-flash-vision-exp "
+            "[siliconflow:siliconflow/fp8:deepseek-ai/DeepSeek-V4-Flash-Vision-Exp]",
+            "prompt",
+            Decimal("0.00000013"),
+            Decimal("0.00000044"),
+        ),
+        (
+            "deepseek/deepseek-v4-flash-vision-exp "
+            "[siliconflow:siliconflow/fp8:deepseek-ai/DeepSeek-V4-Flash-Vision-Exp]",
+            "completion",
+            Decimal("0.00000028"),
+            Decimal("0.00000132"),
+        ),
+        (
+            "deepseek/deepseek-v4-flash-vision-exp "
+            "[siliconflow:siliconflow:deepseek-ai/DeepSeek-V4-Flash-Vision-Exp]",
+            "prompt",
+            Decimal("0.00000013"),
+            Decimal("0.00000044"),
+        ),
+        (
+            "deepseek/deepseek-v4-flash-vision-exp "
+            "[siliconflow:siliconflow:deepseek-ai/DeepSeek-V4-Flash-Vision-Exp]",
+            "completion",
+            Decimal("0.00000028"),
+            Decimal("0.00000132"),
+        ),
+        # Z.ai's public GLM-5.3-Flash list prices, verified 2026-09-09:
+        # $0.15 input / $0.03 cached input / $0.50 output per million tokens.
+        # Novita and Telnyx ended a 50% promotion; the new rates equal list.
+        # Pin each exact endpoint, including the separate cached-input keys:
+        # https://docs.z.ai/guides/overview/pricing
+        (
+            "z-ai/glm-5.3-flash "
+            "[novita:novita/fp8:z-ai/glm-5.3-flash]",
+            "prompt",
+            Decimal("0.000000075"),
+            Decimal("0.00000015"),
+        ),
+        (
+            "z-ai/glm-5.3-flash "
+            "[novita:novita/fp8:z-ai/glm-5.3-flash]",
+            "completion",
+            Decimal("0.00000025"),
+            Decimal("0.0000005"),
+        ),
+        (
+            "z-ai/glm-5.3-flash "
+            "[novita:novita:zai-org/glm-5.3-flash]",
+            "prompt",
+            Decimal("0.000000075"),
+            Decimal("0.00000015"),
+        ),
+        (
+            "z-ai/glm-5.3-flash "
+            "[novita:novita:zai-org/glm-5.3-flash]",
+            "completion",
+            Decimal("0.00000025"),
+            Decimal("0.0000005"),
+        ),
+        (
+            "z-ai/glm-5.3-flash "
+            "[novita:novita:zai-org/glm-5.3-flash] cached-input",
+            "prompt",
+            Decimal("0.000000015"),
+            Decimal("0.00000003"),
+        ),
+        (
+            "z-ai/glm-5.3-flash "
+            "[telnyx:telnyx:zai-org/GLM-5.3-Flash]",
+            "prompt",
+            Decimal("0.000000075"),
+            Decimal("0.00000015"),
+        ),
+        (
+            "z-ai/glm-5.3-flash "
+            "[telnyx:telnyx:zai-org/GLM-5.3-Flash]",
+            "completion",
+            Decimal("0.00000025"),
+            Decimal("0.0000005"),
+        ),
+        (
+            "z-ai/glm-5.3-flash "
+            "[telnyx:telnyx:zai-org/GLM-5.3-Flash] cached-input",
+            "prompt",
+            Decimal("0.000000015"),
+            Decimal("0.00000003"),
+        ),
     }
 )
 

--- a/tests/test_check_price_spike.py
+++ b/tests/test_check_price_spike.py
@@ -2,10 +2,12 @@
 from __future__ import annotations
 
 import json
+from decimal import Decimal
 from pathlib import Path
 
 import pytest
 
+from scripts import check_price_spike
 from scripts.check_price_spike import _load_provider_manifests, _summary_line, check
 
 ROOT = Path(__file__).parents[1]
@@ -1194,4 +1196,164 @@ def test_confirmed_digitalocean_official_price_transitions_are_allowed() -> None
 
     assert failures == []
     assert len(changes) == len(before)
+    assert removed == []
+
+
+# Exact failing-run 34384146856 values; E-notation independently pins the
+# positional Decimals in the production approval set.
+CONFIRMED_REFRESH_TRANSITIONS = [
+    (
+        "deepseek/deepseek-v4-flash-0731 "
+        "[siliconflow:siliconflow/fp8:deepseek-ai/DeepSeek-V4-Flash-0731]",
+        "completion", "2.8E-7", "6.6E-7",
+    ),
+    (
+        "deepseek/deepseek-v4-flash-0731 "
+        "[siliconflow:siliconflow:deepseek-ai/DeepSeek-V4-Flash-0731]",
+        "completion", "2.8E-7", "6.6E-7",
+    ),
+    (
+        "deepseek/deepseek-v4-flash-vision-exp "
+        "[siliconflow:siliconflow/fp8:deepseek-ai/DeepSeek-V4-Flash-Vision-Exp]",
+        "prompt", "1.3E-7", "4.4E-7",
+    ),
+    (
+        "deepseek/deepseek-v4-flash-vision-exp "
+        "[siliconflow:siliconflow/fp8:deepseek-ai/DeepSeek-V4-Flash-Vision-Exp]",
+        "completion", "2.8E-7", "1.32E-6",
+    ),
+    (
+        "deepseek/deepseek-v4-flash-vision-exp "
+        "[siliconflow:siliconflow:deepseek-ai/DeepSeek-V4-Flash-Vision-Exp]",
+        "prompt", "1.3E-7", "4.4E-7",
+    ),
+    (
+        "deepseek/deepseek-v4-flash-vision-exp "
+        "[siliconflow:siliconflow:deepseek-ai/DeepSeek-V4-Flash-Vision-Exp]",
+        "completion", "2.8E-7", "1.32E-6",
+    ),
+    (
+        "z-ai/glm-5.3-flash "
+        "[novita:novita/fp8:z-ai/glm-5.3-flash]",
+        "prompt", "7.5E-8", "1.5E-7",
+    ),
+    (
+        "z-ai/glm-5.3-flash "
+        "[novita:novita/fp8:z-ai/glm-5.3-flash]",
+        "completion", "2.5E-7", "5E-7",
+    ),
+    (
+        "z-ai/glm-5.3-flash "
+        "[novita:novita:zai-org/glm-5.3-flash]",
+        "prompt", "7.5E-8", "1.5E-7",
+    ),
+    (
+        "z-ai/glm-5.3-flash "
+        "[novita:novita:zai-org/glm-5.3-flash]",
+        "completion", "2.5E-7", "5E-7",
+    ),
+    (
+        "z-ai/glm-5.3-flash "
+        "[novita:novita:zai-org/glm-5.3-flash] cached-input",
+        "prompt", "1.5E-8", "3E-8",
+    ),
+    (
+        "z-ai/glm-5.3-flash "
+        "[telnyx:telnyx:zai-org/GLM-5.3-Flash]",
+        "prompt", "7.5E-8", "1.5E-7",
+    ),
+    (
+        "z-ai/glm-5.3-flash "
+        "[telnyx:telnyx:zai-org/GLM-5.3-Flash]",
+        "completion", "2.5E-7", "5E-7",
+    ),
+    (
+        "z-ai/glm-5.3-flash "
+        "[telnyx:telnyx:zai-org/GLM-5.3-Flash] cached-input",
+        "prompt", "1.5E-8", "3E-8",
+    ),
+]
+
+
+def _confirmed_refresh_prices(
+    transitions: list[tuple[str, str, str, str]],
+) -> tuple[dict[str, dict[str, str]], dict[str, dict[str, str]]]:
+    before: dict[str, dict[str, str]] = {}
+    after: dict[str, dict[str, str]] = {}
+    for route, dimension, old, new in transitions:
+        before.setdefault(route, {"prompt": "0", "completion": "0"})[dimension] = old
+        after.setdefault(route, {"prompt": "0", "completion": "0"})[dimension] = new
+    return before, after
+
+
+@pytest.mark.parametrize(("route", "dimension", "old", "new"), CONFIRMED_REFRESH_TRANSITIONS)
+def test_confirmed_refresh_transition_is_allowed(
+    route: str, dimension: str, old: str, new: str,
+) -> None:
+    before, after = _confirmed_refresh_prices([(route, dimension, old, new)])
+
+    failures, changes, removed = check(before, after)
+
+    assert failures == []
+    assert len(changes) == 1
+    assert removed == []
+    # Decimal equality confirms both positional literals equal the run's E-notation.
+    assert (route, dimension, Decimal(old), Decimal(new)) in (
+        check_price_spike.APPROVED_ENDPOINT_PRICE_TRANSITIONS
+    )
+
+
+def test_all_fourteen_confirmed_refresh_transitions_are_allowed() -> None:
+    assert len(CONFIRMED_REFRESH_TRANSITIONS) == 14
+    before, after = _confirmed_refresh_prices(CONFIRMED_REFRESH_TRANSITIONS)
+
+    failures, changes, removed = check(before, after)
+
+    assert failures == []
+    assert len(changes) == len(before) == 9
+    assert removed == []
+
+
+@pytest.mark.parametrize(("route", "dimension", "old", "new"), CONFIRMED_REFRESH_TRANSITIONS)
+@pytest.mark.parametrize("mutation", ["remove-approval", "after-price", "endpoint-tag"])
+def test_confirmed_refresh_mutations_still_block(
+    monkeypatch: pytest.MonkeyPatch,
+    route: str, dimension: str, old: str, new: str, mutation: str,
+) -> None:
+    if mutation == "remove-approval":
+        approval = (route, dimension, Decimal(old), Decimal(new))
+        monkeypatch.setattr(
+            check_price_spike,
+            "APPROVED_ENDPOINT_PRICE_TRANSITIONS",
+            check_price_spike.APPROVED_ENDPOINT_PRICE_TRANSITIONS - {approval},
+        )
+    elif mutation == "after-price":
+        # Increase only the final digit, keeping every mutation above the 2x gate.
+        new = format(Decimal(new), "f")
+        new = new[:-1] + str(int(new[-1]) + 1)
+    else:
+        # Change the tag in BOTH snapshots so this remains a continuing endpoint.
+        model_provider, tag, upstream = route.split(":", 2)
+        tag = tag.replace("/fp8", "/fp16") if "/fp8" in tag else f"{tag}/fp16"
+        route = f"{model_provider}:{tag}:{upstream}"
+    before, after = _confirmed_refresh_prices([(route, dimension, old, new)])
+
+    failures, _changes, _removed = check(before, after)
+
+    assert len(failures) == 1
+    assert failures[0].startswith(f"{route} {dimension}:")
+
+
+def test_fifteenth_unapproved_refresh_transition_still_blocks() -> None:
+    route = "other/model [siliconflow:siliconflow/fp8:other/model]"
+    before, after = _confirmed_refresh_prices([
+        *CONFIRMED_REFRESH_TRANSITIONS,
+        (route, "prompt", "1E-7", "2E-7"),
+    ])
+
+    failures, changes, removed = check(before, after)
+
+    assert len(failures) == 1
+    assert failures[0].startswith(f"{route} prompt:")
+    assert len(changes) == 10
     assert removed == []


### PR DESCRIPTION
## Why

The hourly price refresher has failed nine consecutive scheduled runs since 2026-09-08 14:56Z, every one at the price-spike guard, and the catalog has not published since 2026-09-07 09:01Z with 76 changed prices queued behind it. The guard is right: these are genuine upstream increases at or above ×2.0. Joseph's instruction on 2026-09-09 was to fix the refresher in production, which is the acceptance decision.

## What

Fourteen exact transitions added to `APPROVED_ENDPOINT_PRICE_TRANSITIONS` in `scripts/check_price_spike.py`, the guard's designed escape hatch: `(endpoint, dimension, before, after)` tuples that `check()` skips. Each is cited to its upstream source in the same form as the existing DeepSeek-on-GMI approvals. Nothing else changes: the ratio, the guard's logic and every existing approval are untouched, and a fifteenth unapproved spike on another model still fails.

| Model | Routes | Transition (per M tokens) | Source |
|---|---|---|---|
| DeepSeek-V4-Flash-0731 | SiliconFlow, plain and fp8 | output 0.28 → 0.66 | siliconflow.com/pricing lists 0.22 / 0.014 / 0.66 |
| DeepSeek-V4-Flash-Vision-Exp | SiliconFlow, plain and fp8 | input 0.13 → 0.44, output 0.28 → 1.32 | same page lists 0.44 / 0.028 / 1.32 |
| GLM-5.3-Flash | Novita plain and fp8, Telnyx | input 0.075 → 0.15, output 0.25 → 0.50, cached 0.015 → 0.03 | docs.z.ai lists $0.15 / $0.03 / $0.50 |

The DeepSeek values equal the GMI values already approved against DeepSeek's first-party schedule. The GLM values are Z.ai's list price exactly; the previous baseline was precisely half on every dimension, a promotion that ended rather than a rise above list.

## Proof

Written by codex (gpt-6-astra); reviewed by Fable on an isolated snapshot. `check()` fed the exact before/after values from the failing run (34384146856) returns zero failures, and an unapproved ×2 on another model still fails. 112 tests green across the spike-guard and zero-guard suites; ruff clean. Mutations red: delete a SiliconFlow tuple, delete a GLM tuple, perturb one digit of an approved value, change one endpoint tag. Codex additionally ran each of those across all fourteen entries: 14/14 red each.

After merge the refresher is dispatched and success is judged by the bot's price-refresh commit landing on main, not by the run going green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
