### PR TITLE
Schedule NEAR DeepSeek V4 Flash retirement for September 17

### DIFF
--- a/docs/providers/near-ai-deepseek-september-2026.md
+++ b/docs/providers/near-ai-deepseek-september-2026.md
@@ -1,0 +1,26 @@
+# NEAR AI DeepSeek V4 Flash retirement
+
+NEAR's customer notice schedules `deepseek-ai/DeepSeek-V4-Flash` for retirement
+on **September 17, 2026 at 13:00 UTC**. Its recommended replacement is
+`z-ai/glm-5.3-flash`.
+
+TrustedRouter keeps the existing NEAR route for `deepseek/deepseek-v4-flash`
+until that exact cutoff. The shared lifecycle policy then excludes it from
+new routing, catalog ingestion, discovery normalization, and refreshed price
+indexes, including stale results. Other providers serving DeepSeek V4 Flash
+are unaffected. Existing authorized requests retain their normal settlement
+path; there is no retroactive billing change.
+
+The suggested GLM model is a migration choice, not an automatic substitution
+for a DeepSeek request. This release does not add that NEAR workload to the
+enclave's verified direct-endpoint policy or reuse DeepSeek's attestation
+pins. Confidential routing continues to fail closed if no eligible route
+exists. The separate NEAR GLM 5.1/5.2 retirement remains September 11 at
+13:00 UTC.
+
+Boundary tests cover the microsecond before and the exact cutoff, a live
+process without catalog reload, provider isolation, stale feeds with and
+without prices, and the migration annotation. Six new cases failed before
+the policy and metadata were added. Full post-cutover CI also verifies that
+this scheduled removal cannot invalidate tests that assumed NEAR's DeepSeek
+route existed forever.

--- a/src/trusted_router/data/provider_models/near-ai.json
+++ b/src/trusted_router/data/provider_models/near-ai.json
@@ -17,6 +17,8 @@
       "status": 1,
       "id": "deepseek/deepseek-v4-flash",
       "upstream_id": "deepseek-ai/DeepSeek-V4-Flash",
+      "retirement_at": "2026-09-17T13:00:00Z",
+      "replacement_model_id": "z-ai/glm-5.3-flash",
       "confidential_compute": true,
       "context_length": 1048576,
       "input_token_price_per_m": 170000,

--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -29,6 +29,7 @@ BASETEN_JULY_2026_RETIREMENT_AT = datetime(2026, 7, 25, 0, 0, tzinfo=UTC)
 TINFOIL_KIMI_K26_RETIREMENT_AT = datetime(2026, 8, 3, 0, 0, tzinfo=UTC)
 TINFOIL_GLM52_RETIREMENT_AT = datetime(2026, 9, 10, 0, 0, tzinfo=UTC)
 NEAR_AI_SEPTEMBER_2026_RETIREMENT_AT = datetime(2026, 9, 11, 13, 0, tzinfo=UTC)
+NEAR_AI_DEEPSEEK_V4_FLASH_RETIREMENT_AT = datetime(2026, 9, 17, 13, 0, tzinfo=UTC)
 PARASAIL_AUGUST_2026_RETIREMENT_AT = datetime(2026, 8, 4, 0, 0, tzinfo=UTC)
 FRIENDLI_QWEN3_235B_RETIREMENT_AT = datetime(2026, 8, 5, 0, 0, tzinfo=UTC)
 FRIENDLI_K_EXAONE_236B_RETIREMENT_AT = datetime(2026, 8, 20, 0, 0, tzinfo=UTC)
@@ -159,6 +160,15 @@ _RETIREMENTS = (
         model_ids=frozenset({"z-ai/glm-5.1", "z-ai/glm-5.2"}),
         upstream_ids=frozenset({"zai-org/GLM-5.1-FP8", "z-ai/glm-5.2"}),
         effective_at=NEAR_AI_SEPTEMBER_2026_RETIREMENT_AT,
+    ),
+    # NEAR's separate DeepSeek notice specifies September 17 at 13:00 UTC.
+    # Its GLM migration recommendation is not a same-model alias and cannot
+    # inherit the retired workload's attestation pins.
+    _Retirement(
+        provider="near-ai",
+        model_ids=frozenset({"deepseek/deepseek-v4-flash"}),
+        upstream_ids=frozenset({"deepseek-ai/DeepSeek-V4-Flash"}),
+        effective_at=NEAR_AI_DEEPSEEK_V4_FLASH_RETIREMENT_AT,
     ),
     # Xiaomi announced that the limited-beta MiMo V2.5 Pro UltraSpeed Model
     # API ends on 2026-09-08 in UTC+08. No exact hour or replacement was

--- a/tests/test_near_ai_provider.py
+++ b/tests/test_near_ai_provider.py
@@ -246,13 +246,14 @@ def test_near_ai_manifest_and_catalog_are_attested_prepaid_only() -> None:
 
 
 def test_near_ai_is_e2e_eligible_but_never_satisfies_zdr_or_deny() -> None:
+    model_id = "openai/gpt-oss-120b"
     e2e_ids = {model.id for model in e2e_candidate_models(limit=100)}
-    assert "deepseek/deepseek-v4-flash" in e2e_ids
+    assert model_id in e2e_ids
 
     settings = Settings(environment="test")
     e2e = chat_route_endpoint_candidates(
         {
-            "model": "deepseek/deepseek-v4-flash",
+            "model": model_id,
             "provider": {"only": ["near-ai"], "min_privacy": "e2e"},
         },
         settings,
@@ -265,7 +266,7 @@ def test_near_ai_is_e2e_eligible_but_never_satisfies_zdr_or_deny() -> None:
     ):
         with pytest.raises(HTTPException) as exc_info:
             chat_route_endpoint_candidates(
-                {"model": "deepseek/deepseek-v4-flash", "provider": provider_filter},
+                {"model": model_id, "provider": provider_filter},
                 settings,
             )
         assert getattr(exc_info.value, "status_code", None) == 400
@@ -279,7 +280,10 @@ def test_near_ai_hourly_refresh_secret_and_authority_wiring_are_complete() -> No
     url, env_names, normalize = discoverable["near-ai"]
     assert url == near_ai.CATALOG_URL
     assert env_names == ("NEAR_API_KEY",)
-    assert normalize("deepseek-ai/DeepSeek-V4-Flash") == "deepseek/deepseek-v4-flash"
+    expected = None if provider_lifecycle.provider_model_retired(
+        "near-ai", "deepseek/deepseek-v4-flash", at=CATALOG_CLOCK,
+    ) else "deepseek/deepseek-v4-flash"
+    assert normalize("deepseek-ai/DeepSeek-V4-Flash") == expected
     assert normalize("unreviewed/model") is None
     assert "near_ai" in PROVIDER_SLUGS
     assert "near-ai" in _AUTHORITATIVE_PROVIDER_MANIFEST_SLUGS

--- a/tests/test_near_ai_september_2026_lifecycle.py
+++ b/tests/test_near_ai_september_2026_lifecycle.py
@@ -1,73 +1,93 @@
 from __future__ import annotations
 
 import json
-from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import httpx
 import pytest
 
+from scripts.pricing import refresh
+from scripts.pricing.base import ModelPrice, ProviderPricingResult
 from scripts.pricing.providers import near_ai
 from tests.lifecycle_clock import catalog_predates
 from tests.test_near_ai_provider import _catalog_row, _endpoints
 from trusted_router import catalog, provider_lifecycle
+from trusted_router.catalog_data import ModelEndpoint
 
 _CUTOFF = datetime(2026, 9, 11, 13, 0, tzinfo=UTC)
-_RETIRING = (("z-ai/glm-5.1", "zai-org/GLM-5.1-FP8"), ("z-ai/glm-5.2", "z-ai/glm-5.2"))
+_DEEPSEEK_CUTOFF = datetime(2026, 9, 17, 13, 0, tzinfo=UTC)
 _DSV4 = "deepseek-ai/DeepSeek-V4-Flash"
+_RETIRING = (
+    ("z-ai/glm-5.1", "zai-org/GLM-5.1-FP8", _CUTOFF),
+    ("z-ai/glm-5.2", "z-ai/glm-5.2", _CUTOFF),
+    ("deepseek/deepseek-v4-flash", _DSV4, _DEEPSEEK_CUTOFF),
+)
+_SURVIVOR = "google/gemma-4-31B-it"
+_SURVIVOR_MODEL = "google/gemma-4-31b-it"
 
 
-@pytest.mark.parametrize(("model_id", "native_id"), _RETIRING)
-def test_near_ai_exact_cutoff_and_provider_scope(model_id: str, native_id: str) -> None:
-    retired = provider_lifecycle.provider_model_retired
-    assert not retired("near-ai", model_id, native_id, at=_CUTOFF - timedelta(microseconds=1))
-    assert retired("near-ai", model_id, at=_CUTOFF)
-    assert retired("near-ai", "other-canonical-id", native_id, at=_CUTOFF)
-    assert not retired("deepinfra", model_id, native_id, at=_CUTOFF)
-    assert not retired("near-ai", "z-ai/glm-5.3-flash", at=_CUTOFF)
-    assert not retired("near-ai", "z-ai/glm-5.2-long", at=_CUTOFF)
-
-
-@pytest.mark.parametrize(("model_id", "native_id"), _RETIRING)
-def test_near_ai_runtime_cutoff_without_catalog_reload(
-    monkeypatch: pytest.MonkeyPatch, model_id: str, native_id: str
+@pytest.mark.parametrize(("model_id", "native_id", "cutoff"), _RETIRING)
+def test_near_ai_exact_cutoff_and_provider_scope(
+    model_id: str, native_id: str, cutoff: datetime,
 ) -> None:
-    template = catalog.MODEL_ENDPOINTS["deepseek/deepseek-v4-flash@near-ai/prepaid"]
-    endpoint = replace(template, model_id=model_id, upstream_id=native_id)
-    monkeypatch.setattr(catalog, "MODEL_ENDPOINTS", {endpoint.id: endpoint})
-    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF - timedelta(microseconds=1))
-    assert catalog.endpoints_for_model(model_id) == [endpoint]
+    retired = provider_lifecycle.provider_model_retired
+    assert not retired("near-ai", model_id, native_id, at=cutoff - timedelta(microseconds=1))
+    assert retired("near-ai", model_id, at=cutoff)
+    assert retired("near-ai", "other-canonical-id", native_id, at=cutoff)
+    assert not retired("deepinfra", model_id, native_id, at=cutoff)
+    assert not retired("near-ai", "z-ai/glm-5.3-flash", at=cutoff)
+    assert not retired("near-ai", model_id + "-other", at=cutoff)
+
+
+@pytest.mark.parametrize(("model_id", "native_id", "cutoff"), _RETIRING)
+def test_near_ai_runtime_cutoff_without_catalog_reload(
+    monkeypatch: pytest.MonkeyPatch, model_id: str, native_id: str, cutoff: datetime,
+) -> None:
+    endpoints = {
+        provider: ModelEndpoint(
+            id=f"{model_id}@{provider}/prepaid", model_id=model_id,
+            provider=provider, upstream_id=native_id, usage_type="Credits",
+        ) for provider in ("near-ai", "deepinfra")
+    }
+    monkeypatch.setattr(catalog, "MODEL_ENDPOINTS", {e.id: e for e in endpoints.values()})
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: cutoff - timedelta(microseconds=1))
+    assert len(catalog.endpoints_for_model(model_id)) == 2
     assert near_ai.canonical_model_id(native_id) == model_id
-    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
-    assert catalog.endpoints_for_model(model_id) == []
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: cutoff)
+    assert catalog.endpoints_for_model(model_id) == [endpoints["deepinfra"]]
     assert near_ai.canonical_model_id(native_id) is None
 
 
 def test_near_ai_imported_catalog_matches_cutoff() -> None:
-    for model_id, _native_id in _RETIRING:
-        assert (f"{model_id}@near-ai/prepaid" in catalog.MODEL_ENDPOINTS) is catalog_predates(_CUTOFF)
+    for model_id, _native_id, cutoff in _RETIRING:
+        assert (f"{model_id}@near-ai/prepaid" in catalog.MODEL_ENDPOINTS) is catalog_predates(cutoff)
 
 
 @pytest.mark.parametrize("after_cutoff", [False, True])
 @pytest.mark.parametrize("price_rows_present", [False, True])
+@pytest.mark.parametrize("cutoff", [_CUTOFF, _DEEPSEEK_CUTOFF])
 def test_near_ai_refresh_cutoff_and_missing_price_guard(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     after_cutoff: bool,
     price_rows_present: bool,
+    cutoff: datetime,
 ) -> None:
+    now = cutoff if after_cutoff else cutoff - timedelta(microseconds=1)
     monkeypatch.setattr(
         provider_lifecycle, "_utc_now",
-        lambda: _CUTOFF if after_cutoff else _CUTOFF - timedelta(microseconds=1),
+        lambda: now,
     )
-    retiring_ids = [native for _model, native in _RETIRING]
+    retiring_ids = [native for _model, native, _cutoff in _RETIRING]
     # A stale direct registry may still advertise retired endpoints after their
     # pricing rows disappear. Only retired models may bypass that safety gate.
-    rows = [_catalog_row(_DSV4), _catalog_row("z-ai/glm-5.3-flash")]
-    if price_rows_present:
-        rows.extend(_catalog_row(native) for native in retiring_ids)
-    endpoints = _endpoints(_DSV4, *retiring_ids)
+    rows = [_catalog_row(_SURVIVOR), _catalog_row("z-ai/glm-5.3-flash")]
+    rows.extend(
+        _catalog_row(native) for _model, native, model_cutoff in _RETIRING
+        if price_rows_present or model_cutoff != cutoff
+    )
+    endpoints = _endpoints(_SURVIVOR, *retiring_ids)
     endpoints["endpoints"].append({
         "domain": "glm-5-3-flash.completions.near.ai", "models": ["z-ai/glm-5.3-flash"],
     })
@@ -87,13 +107,13 @@ def test_near_ai_refresh_cutoff_and_missing_price_guard(
         return
 
     result = near_ai.fetch()
-    expected = {"deepseek/deepseek-v4-flash"}
-    if not after_cutoff:
-        expected.update(model for model, _native in _RETIRING)
+    expected = {_SURVIVOR_MODEL} | {
+        model for model, _native, model_cutoff in _RETIRING if now < model_cutoff
+    }
     assert set(result.prices) == expected
     assert set(near_ai._DISCOVERED_MANIFEST_ROWS) == expected
-    for model_id, native_id in _RETIRING:
-        if not after_cutoff:
+    for model_id, native_id, model_cutoff in _RETIRING:
+        if now < model_cutoff:
             assert near_ai._DISCOVERED_MANIFEST_ROWS[model_id]["upstream_id"] == native_id
     # The replacement must pass separate attestation review, not inherit pins
     # from either retired model just because the upstream suggests migration.
@@ -101,3 +121,25 @@ def test_near_ai_refresh_cutoff_and_missing_price_guard(
     near_ai.write_provider_manifest(result)
     manifest = json.loads(near_ai.MANIFEST_PATH.read_text())
     assert {row["id"] for row in manifest["models"]} == expected
+
+
+def test_near_ai_stale_price_result_cannot_restore_retired_deepseek(monkeypatch) -> None:
+    model = "deepseek/deepseek-v4-flash"
+    result = ProviderPricingResult(
+        slug="near-ai", source="api", fetched_url=near_ai.CATALOG_URL,
+        prices={m: ModelPrice(170_000, 350_000) for m in (model, _SURVIVOR_MODEL)},
+    )
+    monkeypatch.setattr(
+        provider_lifecycle, "_utc_now", lambda: _DEEPSEEK_CUTOFF - timedelta(microseconds=1),
+    )
+    assert model in refresh._index_provider_prices({"near-ai": result})
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _DEEPSEEK_CUTOFF)
+    assert set(refresh._index_provider_prices({"near-ai": result})) == {_SURVIVOR_MODEL}
+
+
+def test_near_ai_manifest_records_deepseek_migration() -> None:
+    rows = json.loads(near_ai.MANIFEST_PATH.read_text())["models"]
+    row = next(row for row in rows if row["id"] == "deepseek/deepseek-v4-flash")
+    assert row["upstream_id"] == _DSV4
+    assert row["retirement_at"] == "2026-09-17T13:00:00Z"
+    assert row["replacement_model_id"] == "z-ai/glm-5.3-flash"


### PR DESCRIPTION
## Summary

- Schedule NEAR AI's `deepseek-ai/DeepSeek-V4-Flash` retirement for September 17, 2026 at 13:00 UTC through the existing shared lifecycle policy.
- Keep the route until the exact cutoff, then exclude it from runtime routing, catalog ingestion, normalization, and price refresh, including stale price results. Other providers are unchanged.
- Record the provider's `z-ai/glm-5.3-flash` migration recommendation in the manifest. Do not silently substitute a different model or transfer DeepSeek's attestation pins to an unreviewed workload.
- Reuse the existing NEAR lifecycle tests for both September cutoffs and remove test assumptions that DeepSeek's NEAR route exists forever.

## Verification

- Six new regression cases failed before the production policy/metadata change.
- Focused current-clock suite: 28 passed.
- Forward-clock suite (October 11, after all scheduled retirements): 143 passed.
- Ruff and mypy passed. Full local suite with coverage is running; local results and protected CI must pass before merge/deployment.
- Read-only live catalog and direct-endpoint registry checks confirm the retiring DeepSeek ID and recommended GLM ID are both still published, with explicit token prices. No live inference or credential mutation was needed.
- Local Claude CLI is logged out; no private API-key substitute was used.

## Separate Existing Catalog Block

NEAR's full authenticated refresh currently fails closed because its direct registry still lists four workloads without matching pricing rows: `Qwen/Qwen3.5-122B-A10B`, `Qwen/Qwen3.6-27B-FP8`, `google/gemma-4-31B-it`, and `openai/gpt-oss-120b`. This PR does not weaken that guard, invent prices, or assume those workloads are retired. The new effective-dated retirement works even while last-known-good manifests remain in service.

## Release

Merge through protected CI, deploy through the normal regional canaries, and verify public/runtime availability is unchanged before the deadline. No new secrets, enclave image changes, billing-row mutations, or retrospective customer charges are required.
