### PR TITLE
Fix the stale cursor-predicate comment in storage_gcp

### DIFF
--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -7766,8 +7766,9 @@ class SpannerBigtableStore:
                 "SELECT body FROM versioned UNION ALL SELECT body FROM legacy"
             )
         else:
-            # GoogleSQL structs have no ordering comparisons, so spell out the
-            # same lexicographic tuple predicate that Postgres writes directly.
+            # GoogleSQL structs have no ordering comparisons, and Spanner's
+            # PostgreSQL dialect rejects row-value comparisons (RowCompareExpr),
+            # so both backends spell out the same lexicographic predicate.
             query = (
                 "WITH versioned AS (SELECT body FROM "
                 "tr_entities@{FORCE_INDEX=tr_receipt_key_versions} "


### PR DESCRIPTION
Comment-only follow-up to #1159, flagged in its final codex review: the GoogleSQL comment still said Postgres writes the row-value tuple predicate directly, but #1159 expanded it on Postgres too because Spanner's PostgreSQL dialect rejects RowCompareExpr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)