### PR TITLE
Prevent trust-tier timeout from starving global owner-budget evidence

### DIFF
--- a/scripts/deploy/trust_tier_job.sh
+++ b/scripts/deploy/trust_tier_job.sh
@@ -52,7 +52,7 @@ gc run jobs "$mutation" "$JOB_NAME" \
   --set-env-vars "$set_env_vars" \
   --update-secrets="TR_SENTRY_DSN=trustedrouter-sentry-dsn:latest" \
   --max-retries=0 \
-  --task-timeout=10m \
+  --task-timeout=14m \
   --cpu=1 \
   --memory=512Mi \
   --quiet >/dev/null

--- a/src/trusted_router/trust_tier_cli.py
+++ b/src/trusted_router/trust_tier_cli.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import time
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any, Protocol, cast
@@ -64,12 +65,32 @@ def run(
     ``failed`` is non-empty.
     """
 
+    started = time.monotonic()
     computed_at = now or datetime.now(UTC)
+    owner_budget_failed = False
+    # Global admission evidence must not wait behind the fleet-sized workspace
+    # sweep: a platform timeout would otherwise starve every owner's leases.
+    # Only typed Spanner consumes this proof; legacy tier work stays unchanged.
+    if hasattr(store, "_owner_shard_counts_tx"):
+        from trusted_router.trust_owner_budget import recompute_owner_budget
+
+        try:
+            # Let the scan stamp its own start, never the end of the tier pass.
+            verdict = recompute_owner_budget(store, environment=environment, now=now)
+            owner_budget_failed = not verdict["scan_complete"] or bool(verdict["violating_owners"])
+        except Exception:
+            owner_budget_failed = True
+            log.exception("trust.owner_budget_persist_failed")
+        log.info(
+            "trust.owner_budget_phase_complete failed=%s elapsed_seconds=%.3f",
+            owner_budget_failed, time.monotonic() - started,
+        )
     if hasattr(store, "list_stale_trust_inbox"):
         alert_stale_trust_inbox(store, now=computed_at)
     workspace_ids = store.list_trust_tier_workspace_ids()
     failed: list[str] = []
-    for workspace_id in workspace_ids:
+    log.info("trust.tier_job_started workspaces=%d environment=%s", len(workspace_ids), environment)
+    for completed, workspace_id in enumerate(workspace_ids, start=1):
         try:
             replicated, reconciled_through = replicate_tier_job_watermark(
                 store,
@@ -94,18 +115,11 @@ def run(
         except Exception:
             failed.append(workspace_id)
             log.exception("trust.tier_job_workspace_failed workspace_id=%s", workspace_id)
-    owner_budget_failed = False
-    # Only typed Spanner can arm lease trust. Legacy backends have no fleet
-    # proof consumer, but continue their existing tier/watermark work.
-    if hasattr(store, "_owner_shard_counts_tx"):
-        from trusted_router.trust_owner_budget import recompute_owner_budget
-
-        try:
-            verdict = recompute_owner_budget(store, environment=environment, now=computed_at)
-            owner_budget_failed = not verdict["scan_complete"] or bool(verdict["violating_owners"])
-        except Exception:
-            owner_budget_failed = True
-            log.exception("trust.owner_budget_persist_failed")
+        if completed % 100 == 0 or completed == len(workspace_ids):
+            log.info(
+                "trust.tier_job_progress completed=%d total=%d failed=%d elapsed_seconds=%.3f",
+                completed, len(workspace_ids), len(failed), time.monotonic() - started,
+            )
     return TrustTierJobResult(
         attempted=len(workspace_ids), failed=tuple(failed), owner_budget_failed=owner_budget_failed
     )

--- a/tests/test_trust_p1_operability.py
+++ b/tests/test_trust_p1_operability.py
@@ -1177,6 +1177,7 @@ def test_trust_job_scripts_deploy_module_invocations_with_the_pinned_account(
     assert tier.returncode == 0, summarise(tier)
     (job,) = _job_calls(tier, "run", "jobs", "update", "trusted-router-trust-tier")
     assert "--args=-m,trusted_router.trust_tier_cli,--environment,production" in job
+    assert "--task-timeout=14m" in job
     assert "--region" in job and job[job.index("--region") + 1] == "us-east4"
     (schedule,) = _job_calls(tier, "scheduler", "jobs", "update", "http", "trusted-router-trust-tier-15m")
     assert "--schedule=7,22,37,52 * * * *" in schedule

--- a/tests/test_trust_tier_liveness.py
+++ b/tests/test_trust_tier_liveness.py
@@ -1,0 +1,110 @@
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from trusted_router import trust_owner_budget, trust_tier_cli
+
+NOW = datetime(2026, 9, 11, 21, tzinfo=UTC)
+
+
+class WorkerStopped(BaseException):
+    """A platform deadline must not be swallowed as a workspace failure."""
+
+
+class TierStore:
+    def __init__(self, count: int = 1) -> None:
+        self.calls: list[str] = []
+        self.count = count
+
+    def _owner_shard_counts_tx(self, *_args: Any) -> None:
+        raise AssertionError("the owner scan is replaced by a test spy")
+
+    def list_trust_tier_workspace_ids(self) -> tuple[str, ...]:
+        self.calls.append("enumerate")
+        return tuple(f"ws-{index}" for index in range(self.count))
+
+    def recompute_workspace_trust_tier(self, workspace_id: str, **_kwargs: Any) -> int:
+        self.calls.append(workspace_id)
+        return 1
+
+
+def settings() -> SimpleNamespace:
+    return SimpleNamespace(
+        trust_qualifying_provider_set=frozenset({"stripe", "x402"}),
+        trust_tier3_min_days=30,
+        trust_tier3_min_paid_microdollars=50_000_000,
+    )
+
+
+def test_owner_evidence_refresh_precedes_a_killed_workspace_sweep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class InterruptedStore(TierStore):
+        def recompute_workspace_trust_tier(self, workspace_id: str, **kwargs: Any) -> int:
+            raise WorkerStopped()
+
+    store = InterruptedStore()
+
+    def refresh(actual_store: Any, **kwargs: Any) -> dict[str, Any]:
+        assert actual_store is store
+        assert kwargs == {"environment": "production", "now": NOW}
+        store.calls.append("owner_budget")
+        return {"scan_complete": True, "violating_owners": []}
+
+    monkeypatch.setattr(trust_owner_budget, "recompute_owner_budget", refresh)
+    with pytest.raises(WorkerStopped):
+        trust_tier_cli.run(store, settings(), now=NOW)
+    assert store.calls == ["owner_budget", "enumerate"]
+
+
+def test_owner_scan_uses_its_own_start_clock_without_a_test_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: list[Any] = []
+
+    def refresh(_store: Any, **kwargs: Any) -> dict[str, Any]:
+        observed.append(kwargs["now"])
+        return {"scan_complete": True, "violating_owners": []}
+
+    monkeypatch.setattr(trust_owner_budget, "recompute_owner_budget", refresh)
+    result = trust_tier_cli.run(TierStore(), settings())
+    assert observed == [None]
+    assert result.succeeded == 1
+
+
+@pytest.mark.parametrize("failure", ["scan", "violation", "persist"])
+def test_owner_failure_does_not_skip_workspace_reconciliation(
+    monkeypatch: pytest.MonkeyPatch, failure: str,
+) -> None:
+    def refresh(_store: Any, **_kwargs: Any) -> dict[str, Any]:
+        if failure == "persist":
+            raise RuntimeError("persistence unavailable")
+        return {
+            "scan_complete": failure != "scan",
+            "violating_owners": ["owner"] if failure == "violation" else [],
+        }
+
+    monkeypatch.setattr(trust_owner_budget, "recompute_owner_budget", refresh)
+    store = TierStore(3)
+    result = trust_tier_cli.run(store, settings(), now=NOW)
+    assert result.owner_budget_failed
+    assert result.succeeded == 3
+    assert store.calls == ["enumerate", "ws-0", "ws-1", "ws-2"]
+
+
+def test_large_sweep_reports_bounded_progress(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(
+        trust_owner_budget, "recompute_owner_budget",
+        lambda *_args, **_kwargs: {"scan_complete": True, "violating_owners": []},
+    )
+    caplog.set_level("INFO", logger="trusted_router.trust_tier_cli")
+    result = trust_tier_cli.run(TierStore(1001), settings(), now=NOW)
+    progress = [r.getMessage() for r in caplog.records if "trust.tier_job_progress" in r.message]
+    assert result.succeeded == 1001
+    assert len(progress) == 11
+    assert "completed=100 total=1001 failed=0 elapsed_seconds=" in progress[0]
+    assert "completed=1001 total=1001 failed=0 elapsed_seconds=" in progress[-1]


### PR DESCRIPTION
## Root cause

The trust-tier worker had a 600-second task deadline. At roughly 1,100 workspaces, its sequential tier/watermark pass consumed the deadline before the final fleet owner-budget scan could run. Five consecutive executions timed out after the last successful pass at 2026-09-11 19:47 UTC. The last evidence was stamped 19:37:36 UTC, so the one-hour freshness gate correctly began refusing lease eligibility around 20:38 UTC (Sentry QUILL-ROUTER-66).

The ordinary typed billing fallback remains intact. No control-plane HTTP 5xx entries were found in the initial alert-window read. This is not evidence that every end-user request was unaffected.

## Changes

- Refresh the global owner-budget proof before the fleet-sized workspace sweep, using the scan-start clock. Never stamp completion or extend evidence validity.
- Keep per-workspace reconciliation and failure isolation intact. Owner scan/persistence failures still make the job fail.
- Record phase duration and progress every 100 workspaces plus the final workspace.
- Allow a bounded 14-minute task runtime beneath the existing 15-minute cadence. The same timeout-only mitigation was applied to production through the existing deploy identity. No IAM, alarm, freshness, billing policy, or money mutation was changed.

## Verification

- New interruption/clock/progress regression tests failed against the original implementation, then passed after the fix.
- 161 focused trust, deployment, and worker tests passed.
- Ruff and mypy passed.
- Full local suite passed: 10,330 passed, 408 skipped, 11 expected failures; coverage 84.42% (70% required). All PR CI checks passed.
- Claude CLI review was attempted but its OAuth session was expired, so it did not produce a review.

## Live recovery

The existing owner-budget scan was also run once with execution-only arguments, without changing the scheduled command. It published valid proof at 21:17:56 UTC (scan start 21:17:14 UTC); the execution succeeded at 21:18:02 UTC. Exact-key verification found zero violating owners. No trust-gate errors have appeared in the bounded post-recovery logs. The next scheduled execution retained normal arguments and adopted the 840-second timeout.

## Remaining scale boundary

The sweep and owner scan still grow with the fleet. This repair removes starvation of the global proof and restores runtime headroom, not unlimited scalability. Further work should partition/checkpoint tier reconciliation and batch indexed owner-account reads, with billing conformance tests. Do not use a wider freshness window to conceal increasing duration.
