### PR TITLE
Keep provider failures separate from rollout health

### DIFF
--- a/docs/provider-independent-deploys.md
+++ b/docs/provider-independent-deploys.md
@@ -1,0 +1,39 @@
+# Provider Health And Deployment Gates
+
+Upstream model availability is a separate operational signal from release
+correctness. A provider outage must not be treated as a broken router release.
+
+## Control Plane
+
+- CI runs offline routing, expiry rejection, billing, fallback and privacy tests.
+- Time-sensitive catalog counts run in `Provider catalog health`, independently
+  of release CI. Failures stay visible in that workflow.
+- The deployment watchdog selects `router_core` or `control_plane`. Its older
+  `current.checks` fallback filters to the same probe families, rather than
+  folding provider inference into router availability. Unclassified probe types
+  cannot supply a healthy router signal.
+- SDK probes retain explicit gateway `error.source` as `provider_error` or
+  `router_error`, alongside the original HTTP status. Unclassified failures
+  remain failures. Error text, prompts and outputs are not added to samples.
+
+## Attested Gateway
+
+The companion change in `quill-cloud-proxy` consumes this classification.
+Fresh chat/Responses samples explicitly attributed to a provider do not block
+the immediate regional gate. They remain down on the public inference status
+component. TLS and attestation must still pass; each monitor must still report
+fresh samples. Transport failures and errors without explicit attribution are
+not presumed to be upstream outages.
+
+Per-instance probes distinguish an exact PONG from an explicit provider error.
+Either way, the streaming request must supply valid durable authorization
+evidence. Required boot-key binding and usage-heartbeat evidence are unchanged.
+An uncommitted settlement/refund is a billing failure, not an excusable provider
+failure. Provider errors never waive that check.
+
+## Release Order
+
+Deploy the control-plane classification first, then the gateway gate consumer.
+Old monitor samples remain conservatively unclassified until fresh probes run.
+There are no production error injections or paid provider calls in these
+regression tests.

--- a/scripts/deploy/watchdog.py
+++ b/scripts/deploy/watchdog.py
@@ -61,6 +61,21 @@ from trusted_router.enclave_regions import ENCLAVE_REGIONS  # noqa: E402
 SEVERITY = {"up": 0, "degraded": 1, "trust_degraded": 2, "down": 2}
 # Statuses that count toward the consecutive-failure rollback counter.
 ROLLBACK_STATUSES = frozenset({"down", "trust_degraded"})
+# Keep the legacy payload fallback scoped just like the SLO-aware path.
+# This script runs with stdlib Python in CI, without application dependencies.
+SLO_PROBES = {
+    "router_core": frozenset(
+        {
+            "tls_health",
+            "attestation_nonce",
+            "gateway_authorize",
+            "gateway_settle",
+            "gateway_authorize_settle",
+            "provider_fallback",
+        }
+    ),
+    "control_plane": frozenset({"control_plane_health"}),
+}
 
 
 def normalize_watchdog_status(status: object) -> str:
@@ -118,6 +133,10 @@ def fetch_per_region(
     # reads very differently from an unreachable region).
     worst: dict[str, str] = {}
     for check in checks:
+        if not isinstance(check, dict) or check.get("probe_type") not in SLO_PROBES.get(
+            slo_class, ()
+        ):
+            continue
         target = (check or {}).get("target_region")
         status = normalize_watchdog_status(
             (check or {}).get("effective_status") or (check or {}).get("status")

--- a/src/trusted_router/synthetic/inference_sdk.py
+++ b/src/trusted_router/synthetic/inference_sdk.py
@@ -115,9 +115,11 @@ def classify_sdk_failure(exc: BaseException) -> SdkFailure:
     * a transport failure arrives as ``InternalError(503)`` raised ``from``
       the httpx exception. The cause chain, not the status, tells it apart
       from a real 503, and the httpx class name is kept;
-    * any other ``TrustedRouterError`` is a response the probe could not
-      accept: ``pong_mismatch`` with the status the SDK saw. A 2xx whose JSON
-      is not an object lands here too, status intact;
+    * a ``TrustedRouterError`` with the gateway's explicit ``error.source``
+      retains that attribution as ``provider_error`` or ``router_error``.
+      HTTP status alone is not enough to excuse a failed deployment probe;
+    * any unclassified response is ``pong_mismatch`` with the status the SDK
+      saw. A 2xx whose JSON is not an object lands here too, status intact;
     * a successful body that is not JSON surfaces as the bare ``ValueError``;
       this path is only reached after ``response.is_success``, and these two
       gateway endpoints' success contract is 200, so the old status is kept;
@@ -129,6 +131,11 @@ def classify_sdk_failure(exc: BaseException) -> SdkFailure:
     if transport is not None:
         return SdkFailure(type(transport).__name__, None, False)
     if isinstance(exc, TrustedRouterError):
+        payload = exc.payload
+        error = payload.get("error") if isinstance(payload, dict) else None
+        source = error.get("source") if isinstance(error, dict) else None
+        if exc.status_code >= 400 and isinstance(source, str) and source in {"provider", "router"}:
+            return SdkFailure(f"{source}_error", exc.status_code, True)
         return SdkFailure("pong_mismatch", exc.status_code, True)
     if isinstance(exc, ValueError):
         return SdkFailure("pong_mismatch", 200, True)

--- a/tests/test_deploy_watchdog.py
+++ b/tests/test_deploy_watchdog.py
@@ -71,8 +71,16 @@ def test_watchdog_falls_back_to_current_checks_and_normalizes_degraded(monkeypat
         "data": {
             "current": {
                 "checks": [
-                    {"target_region": "us-central1", "effective_status": "routing_degraded"},
-                    {"target_region": "europe-west4", "effective_status": "up"},
+                    {
+                        "target_region": "us-central1",
+                        "probe_type": "tls_health",
+                        "effective_status": "routing_degraded",
+                    },
+                    {
+                        "target_region": "europe-west4",
+                        "probe_type": "tls_health",
+                        "effective_status": "up",
+                    },
                 ]
             }
         }
@@ -102,8 +110,16 @@ def test_trust_degraded_is_preserved_not_folded_into_degraded(monkeypatch) -> No
         "data": {
             "current": {
                 "checks": [
-                    {"target_region": "eu-west-3", "effective_status": "trust_degraded"},
-                    {"target_region": "us-central1", "effective_status": "up"},
+                    {
+                        "target_region": "eu-west-3",
+                        "probe_type": "attestation_nonce",
+                        "effective_status": "trust_degraded",
+                    },
+                    {
+                        "target_region": "us-central1",
+                        "probe_type": "tls_health",
+                        "effective_status": "up",
+                    },
                 ]
             }
         }
@@ -130,6 +146,88 @@ def test_rollback_statuses_cover_down_and_trust_degraded() -> None:
     assert "unknown" not in watchdog.ROLLBACK_STATUSES
 
 
+@pytest.mark.parametrize(
+    "slo_class,core_probe",
+    [
+        ("router_core", "tls_health"),
+        ("control_plane", "control_plane_health"),
+    ],
+)
+@pytest.mark.parametrize(
+    "other_probe",
+    [
+        "openai_sdk_pong",
+        "responses_pong",
+        "image_generation",
+        "video_generation",
+        "provider_benchmark",
+        "",
+        "future_probe",
+    ],
+)
+def test_legacy_watchdog_does_not_blend_other_probes_into_release_health(
+    monkeypatch,
+    slo_class: str,
+    core_probe: str,
+    other_probe: str,
+) -> None:
+    watchdog = _load_watchdog()
+    payload = {
+        "data": {
+            "current": {
+                "checks": [
+                    {"target_region": "us-central1", "probe_type": core_probe, "status": "up"},
+                    {"target_region": "us-central1", "probe_type": other_probe, "status": "down"},
+                    {"target_region": "europe-west4", "probe_type": other_probe, "status": "down"},
+                ]
+            }
+        }
+    }
+    monkeypatch.setattr(
+        watchdog.urllib.request,
+        "urlopen",
+        lambda *_a, **_k: _FakeResponse(json.dumps(payload).encode()),
+    )
+    assert watchdog.fetch_per_region(
+        "https://status.example", ["us-central1", "europe-west4"], slo_class=slo_class
+    ) == {
+        "us-central1": "up",
+        "europe-west4": "unknown",
+    }
+
+
+@pytest.mark.parametrize(
+    "probe",
+    [
+        "tls_health",
+        "attestation_nonce",
+        "gateway_authorize",
+        "gateway_settle",
+        "gateway_authorize_settle",
+        "provider_fallback",
+    ],
+)
+def test_legacy_watchdog_keeps_router_failures_blocking(monkeypatch, probe: str) -> None:
+    watchdog = _load_watchdog()
+    payload = {
+        "data": {
+            "current": {
+                "checks": [
+                    {"target_region": "us-central1", "probe_type": probe, "status": "down"},
+                ]
+            }
+        }
+    }
+    monkeypatch.setattr(
+        watchdog.urllib.request,
+        "urlopen",
+        lambda *_a, **_k: _FakeResponse(json.dumps(payload).encode()),
+    )
+    assert watchdog.fetch_per_region("https://status.example", ["us-central1"]) == {
+        "us-central1": "down"
+    }
+
+
 def test_normalize_maps_routing_degraded_but_not_trust_degraded() -> None:
     watchdog = _load_watchdog()
     assert watchdog.normalize_watchdog_status("routing_degraded") == "degraded"
@@ -153,9 +251,7 @@ def test_watchdog_baseline_artifact_round_trips_atomically(tmp_path: Path) -> No
         {"us-central1": "up", "europe-west4": "down"},
     )
 
-    assert watchdog.read_baseline(
-        str(artifact), ["us-central1", "europe-west4", "us-east4"]
-    ) == {
+    assert watchdog.read_baseline(str(artifact), ["us-central1", "europe-west4", "us-east4"]) == {
         "us-central1": "up",
         "europe-west4": "down",
         "us-east4": "unknown",
@@ -347,8 +443,7 @@ def test_private_ingress_skips_runapp_probe_and_keeps_watchdog_gate(
     traffic_calls = [
         call
         for call in calls
-        if call.startswith("gcloud run services update-traffic")
-        and "--to-revisions=" in call
+        if call.startswith("gcloud run services update-traffic") and "--to-revisions=" in call
     ]
     assert any("--to-revisions=new-rev=10,old-rev=90" in call for call in traffic_calls)
     assert any("--to-revisions=new-rev=50,old-rev=50" in call for call in traffic_calls)
@@ -422,13 +517,7 @@ esac
 
     call_log.write_text("")
     service_json.write_text(
-        json.dumps(
-            {
-                "status": {
-                    "traffic": [{"percent": 100, "revisionName": "old-rev"}]
-                }
-            }
-        )
+        json.dumps({"status": {"traffic": [{"percent": 100, "revisionName": "old-rev"}]}})
     )
     unresolved = subprocess.run(  # noqa: S603 - fixed shell with stubbed gcloud
         ["/bin/bash", "-c", command],
@@ -515,9 +604,7 @@ def test_staged_legacy_probe_uses_regional_origin_and_classifies_results(
     curl_calls = [call for call in calls if call.startswith("curl ")]
     assert curl_calls
     assert all(
-        call.startswith(
-            "curl https://staged-probe---trusted-router-hash-uc.a.run.app/"
-        )
+        call.startswith("curl https://staged-probe---trusted-router-hash-uc.a.run.app/")
         for call in curl_calls
     )
     assert any(
@@ -526,9 +613,7 @@ def test_staged_legacy_probe_uses_regional_origin_and_classifies_results(
         if call.startswith("gcloud run services update-traffic")
     )
     assert any(
-        "--format=json" in call
-        for call in calls
-        if call.startswith("gcloud run services describe")
+        "--format=json" in call for call in calls if call.startswith("gcloud run services describe")
     )
     assert not any("status.traffic[?tag=" in call for call in calls)
     assert not any("status.traffic[?" in call for call in calls)
@@ -623,14 +708,12 @@ def test_failed_traffic_shift_restores_the_old_desired_revision(tmp_path: Path) 
     traffic_calls = [
         call
         for call in calls
-        if call.startswith("gcloud run services update-traffic")
-        and "--to-revisions=" in call
+        if call.startswith("gcloud run services update-traffic") and "--to-revisions=" in call
     ]
     assert any("--to-revisions=new-rev=10,old-rev=90" in call for call in traffic_calls)
     assert any("--to-revisions=old-rev=100" in call for call in traffic_calls)
     assert "ROLLBACK" in run.stdout
     assert "traffic update to 10% failed" in run.stdout
-
 
 
 def test_staged_ramp_rolls_back_when_the_watchdog_reports_unhealthy(
@@ -684,9 +767,5 @@ def test_watchdog_gate_releases_only_after_the_traffic_shift(
         if call.startswith("gcloud run services update-traffic")
         and "--to-revisions=new-rev=10" in call
     )
-    first_gate = next(
-        index for index, call in enumerate(calls) if "gate-released" in call
-    )
-    assert first_gate > first_shift, (
-        "the watchdog gate was released before the first traffic shift"
-    )
+    first_gate = next(index for index, call in enumerate(calls) if "gate-released" in call)
+    assert first_gate > first_shift, "the watchdog gate was released before the first traffic shift"

--- a/tests/test_synthetic_sdk_probes.py
+++ b/tests/test_synthetic_sdk_probes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 from collections.abc import Callable, Iterator
+from dataclasses import asdict
 from typing import Any
 
 import httpx
@@ -184,6 +185,41 @@ async def test_real_sdk_pong_probes_restore_httpx_transport_error_taxonomy(
         assert sample.output_match is False
         assert sample.latency_milliseconds is not None
         assert sample.ttfb_milliseconds is None
+
+
+@pytest.mark.parametrize("status", [401, 429, 500, 502, 503, 504])
+@pytest.mark.parametrize("source", ["provider", "router", None, "unknown"])
+@pytest.mark.asyncio
+async def test_pong_failures_preserve_explicit_gateway_error_source(
+    telemetry_requests: list[httpx.Request],
+    status: int,
+    source: str | None,
+) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            status,
+            json={"error": {"source": source, "message": "private failure detail"}},
+        )
+
+    samples = await _run_pair(handler)
+
+    for sample in samples:
+        assert sample.status == "down"
+        assert sample.http_status == status
+        assert sample.error_type == (
+            f"{source}_error" if source in {"provider", "router"} else "pong_mismatch"
+        )
+        assert "private failure detail" not in str(asdict(sample))
+
+
+@pytest.mark.parametrize("payload", [[], {"error": "provider"}, {"source": "provider"}])
+@pytest.mark.asyncio
+async def test_pong_malformed_errors_are_not_attributed_to_providers(
+    telemetry_requests: list[httpx.Request],
+    payload: object,
+) -> None:
+    samples = await _run_pair(lambda _request: httpx.Response(503, json=payload))
+    assert all(sample.error_type == "pong_mismatch" for sample in samples)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Preserve gateway error.source in SDK synthetic probes as provider_error or router_error. Keep HTTP status, and never export the error body.
- Scope legacy watchdog payloads to the requested router-core or control-plane probe families, matching the SLO-aware path.
- Keep provider catalog health independent of release CI and document release ordering with the companion enclave change.

## Verification
- Regression-first: 26 new cases failed on the previous implementation; all 76 focused tests pass after the fix.
- Ruff and mypy pass.
- Full release suite is running with local socket permissions; provider_health remains its separately reported operational workflow.
- No production failure injection or new provider calls.

Deploy this attribution producer before the quill-cloud-proxy gate consumer.