### PR TITLE
Schedule Venice DeepSeek V4 Flash retirement for September 15

### DIFF
--- a/docs/venice-deepseek-september-2026.md
+++ b/docs/venice-deepseek-september-2026.md
@@ -1,0 +1,47 @@
+# Venice DeepSeek Flash Migration
+
+Venice's customer notice retires `deepseek-v4-flash` on September 15, 2026
+and names `deepseek-v4-1-flash` as its replacement. The notice does not give
+an hour or time zone. TrustedRouter conservatively stops selecting the old
+Venice route at **2026-09-15 00:00 UTC**.
+
+## Model Selection
+
+- Existing TrustedRouter model: `deepseek/deepseek-v4-flash`.
+- Replacement TrustedRouter model: `deepseek/deepseek-v4-1-flash`.
+- Replacement Venice upstream ID: `deepseek-v4-1-flash`.
+
+The hourly discovery feed already added the replacement. Explicit V4
+requests do not silently become V4.1 requests. Other providers serving V4
+remain eligible subject to the caller's routing constraints. Venice's
+dated `0731`, `0731-fast`, and E2EE variants are not named by this notice
+and are not retired by this change. GLM 5.3 Flash is not being retired.
+Venice's recommendation is not independent evidence that V4.1 is better
+for every workload.
+
+## Verified Catalog Data
+
+On September 12, Venice's public [text models API](https://api.venice.ai/api/v1/models?type=text)
+reported the replacement online, with text and image input, function
+calling, reasoning, and structured output. Context is 1,000,000 tokens;
+maximum completion is 131,072 tokens.
+
+The API reports upstream USD per million tokens: $0.375 input, $1.50
+output, and $0.0075 cached input. These are provider prices, before
+TrustedRouter's markup, and remain controlled by regular price refreshes.
+Do not copy the old V4 prices onto V4.1. The API advertises neither TEE
+attestation nor E2EE for this model; its vision support does not change
+that privacy classification.
+
+See also Venice's [replacement model page](https://venice.ai/models/deepseek-v4-1-flash).
+
+## Enforcement
+
+The effective-dated guard applies during catalog ingestion, live endpoint
+selection, and pricing refresh. An already-running process or stale
+provider feed cannot restore the old route after the cutoff. The manifest
+keeps the migration metadata for operators.
+
+Regression tests cover the exact boundary, provider and version isolation,
+no silent weight substitution, stale-feed exclusion, replacement native ID,
+integer prices, and image/tool/structured-output discovery metadata.

--- a/scripts/pricing/providers/venice.py
+++ b/scripts/pricing/providers/venice.py
@@ -11,6 +11,7 @@ from scripts.pricing.base import ModelPrice, ProviderPricingResult, fetch_json, 
 from scripts.pricing.manifest import write_discovered_chat_manifest
 from scripts.pricing.model_ids import canonicalize_unqualified_model_id
 from scripts.pricing.openai_catalog import positive_int
+from trusted_router.provider_lifecycle import provider_model_retired
 
 SLUG = "venice"
 BASE_URL = "https://api.venice.ai/api/v1"
@@ -90,7 +91,11 @@ def fetch() -> ProviderPricingResult:
             continue
         model_id = _model_id(native_id)
         pricing = spec.get("pricing")
-        if model_id is None or not isinstance(pricing, dict):
+        if (
+            model_id is None
+            or provider_model_retired(SLUG, model_id, native_id)
+            or not isinstance(pricing, dict)
+        ):
             continue
         input_rate = pricing.get("input")
         output_rate = pricing.get("output")

--- a/src/trusted_router/data/provider_models/venice.json
+++ b/src/trusted_router/data/provider_models/venice.json
@@ -75,6 +75,9 @@
       "status": 1,
       "id": "deepseek/deepseek-v4-flash",
       "upstream_id": "deepseek-v4-flash",
+      "retirement_at": "2026-09-15T00:00:00Z",
+      "replacement_model_id": "deepseek/deepseek-v4-1-flash",
+      "retirement_note": "Venice customer notice: switch before September 15, 2026. No hour or time zone supplied; use 00:00 UTC. Replacement is a separate model, not an automatic alias.",
       "features": [
         "function-calling",
         "reasoning",

--- a/src/trusted_router/provider_lifecycle.py
+++ b/src/trusted_router/provider_lifecycle.py
@@ -30,6 +30,7 @@ TINFOIL_KIMI_K26_RETIREMENT_AT = datetime(2026, 8, 3, 0, 0, tzinfo=UTC)
 TINFOIL_GLM52_RETIREMENT_AT = datetime(2026, 9, 10, 0, 0, tzinfo=UTC)
 NEAR_AI_SEPTEMBER_2026_RETIREMENT_AT = datetime(2026, 9, 11, 13, 0, tzinfo=UTC)
 NEAR_AI_DEEPSEEK_V4_FLASH_RETIREMENT_AT = datetime(2026, 9, 17, 13, 0, tzinfo=UTC)
+VENICE_DEEPSEEK_V4_FLASH_RETIREMENT_AT = datetime(2026, 9, 15, 0, 0, tzinfo=UTC)
 PARASAIL_AUGUST_2026_RETIREMENT_AT = datetime(2026, 8, 4, 0, 0, tzinfo=UTC)
 FRIENDLI_QWEN3_235B_RETIREMENT_AT = datetime(2026, 8, 5, 0, 0, tzinfo=UTC)
 FRIENDLI_K_EXAONE_236B_RETIREMENT_AT = datetime(2026, 8, 20, 0, 0, tzinfo=UTC)
@@ -124,6 +125,16 @@ class _Retirement:
 
 
 _RETIREMENTS = (
+    # Venice's September notice replaces deepseek-v4-flash with the separate
+    # deepseek-v4-1-flash model on September 15. No time zone was specified;
+    # use 00:00 UTC. The notice does not identify the dated or fast variants.
+    # Never redirect explicit V4 requests to different V4.1 weights.
+    _Retirement(
+        provider="venice",
+        model_ids=frozenset({"deepseek/deepseek-v4-flash"}),
+        upstream_ids=frozenset({"deepseek-v4-flash"}),
+        effective_at=VENICE_DEEPSEEK_V4_FLASH_RETIREMENT_AT,
+    ),
     # The first-party rolling aliases cease to identify these exact weights.
     # Retire only the dated leaves, not the rolling aliases or other providers.
     # Published combo versions stay frozen; never replace their Pro with Flash.

--- a/tests/test_venice_september_2026_lifecycle.py
+++ b/tests/test_venice_september_2026_lifecycle.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from scripts.pricing import refresh
+from scripts.pricing.providers import venice
+from tests.lifecycle_clock import catalog_predates
+from trusted_router import catalog, provider_lifecycle
+from trusted_router.catalog_data import ModelEndpoint
+
+_CUTOFF = datetime(2026, 9, 15, tzinfo=UTC)
+_OLD = "deepseek/deepseek-v4-flash"
+_NEW = "deepseek/deepseek-v4-1-flash"
+
+
+def test_venice_retirement_boundary_and_scope() -> None:
+    retired = provider_lifecycle.provider_model_retired
+    assert not retired("venice", _OLD, at=_CUTOFF - timedelta(microseconds=1))
+    assert retired("venice", _OLD, at=_CUTOFF)
+    assert retired("venice", "another-id", "deepseek-v4-flash", at=_CUTOFF)
+    assert not retired("novita", _OLD, "deepseek-v4-flash", at=_CUTOFF)
+    for model in (_NEW, _OLD + "-0731", _OLD + "-0731-fast", "z-ai/glm-5.3-flash"):
+        assert not retired("venice", model, model.split("/", 1)[1], at=_CUTOFF)
+
+
+def test_venice_runtime_cutoff_never_substitutes_new_weights(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old_endpoints = [
+        ModelEndpoint(
+            id=f"{_OLD}@{provider}/prepaid", model_id=_OLD, provider=provider,
+            upstream_id="deepseek-v4-flash", usage_type="Credits",
+        ) for provider in ("venice", "novita")
+    ]
+    replacement = ModelEndpoint(
+        id=f"{_NEW}@venice/prepaid", model_id=_NEW, provider="venice",
+        upstream_id="deepseek-v4-1-flash", usage_type="Credits",
+    )
+    monkeypatch.setattr(
+        catalog, "MODEL_ENDPOINTS", {e.id: e for e in [*old_endpoints, replacement]},
+    )
+    monkeypatch.setattr(
+        provider_lifecycle, "_utc_now", lambda: _CUTOFF - timedelta(microseconds=1),
+    )
+    assert catalog.endpoints_for_model(_OLD) == old_endpoints
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    assert catalog.endpoints_for_model(_OLD) == [old_endpoints[1]]
+    assert catalog.endpoints_for_model(_NEW) == [replacement]
+
+
+@pytest.mark.parametrize("after_cutoff", [False, True])
+def test_venice_discovery_respects_retirement_and_preserves_replacement(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, after_cutoff: bool,
+) -> None:
+    now = _CUTOFF if after_cutoff else _CUTOFF - timedelta(microseconds=1)
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: now)
+    monkeypatch.setenv("VENICE_API_KEY", "test-key")
+    monkeypatch.setattr(venice, "UPSTREAM_ID_MAP", dict(venice.UPSTREAM_ID_MAP))
+    monkeypatch.setattr(venice, "_DISCOVERED_MANIFEST_ROWS", {})
+    payload = {"data": [
+        {
+            "id": native,
+            "model_spec": {
+                "name": native, "offline": False,
+                "availableContextTokens": 1_000_000,
+                "maxCompletionTokens": 131_072,
+                "pricing": {
+                    "input": {"usd": "0.375"}, "output": {"usd": "1.5"},
+                    "cache_input": {"usd": "0.0075"},
+                },
+                "capabilities": {
+                    "supportsVision": native == "deepseek-v4-1-flash",
+                    "supportsFunctionCalling": True,
+                    "supportsReasoning": True,
+                    "supportsResponseSchema": True,
+                },
+            },
+        } for native in ("deepseek-v4-flash", "deepseek-v4-1-flash", "zai-org-glm-5-2")
+    ]}
+    monkeypatch.setattr(venice, "fetch_json", lambda *args, **kwargs: payload)
+    result = venice.fetch()
+    assert (_OLD in result.prices) is not after_cutoff
+    assert (_OLD in venice._DISCOVERED_MANIFEST_ROWS) is not after_cutoff
+    price = result.prices[_NEW]
+    assert price.prompt_micro_per_m == 375_000
+    assert price.completion_micro_per_m == 1_500_000
+    assert price.tiers[0].prompt_cached_micro_per_m == 7_500
+    new_row = venice._DISCOVERED_MANIFEST_ROWS[_NEW]
+    assert new_row["upstream_id"] == "deepseek-v4-1-flash"
+    assert new_row["input_modalities"] == ["text", "image"]
+    assert set(new_row["features"]) == {"function-calling", "reasoning", "structured-outputs"}
+    assert new_row["context_length"] == 1_000_000
+    assert new_row["max_output_tokens"] == 131_072
+
+    manifest_path = tmp_path / "venice.json"
+    manifest_path.write_text(json.dumps({"provider": "venice", "models": [{
+        "id": _OLD, "upstream_id": "deepseek-v4-flash",
+        "retirement_at": "2026-09-15T00:00:00Z", "replacement_model_id": _NEW,
+    }]}))
+    monkeypatch.setattr(venice, "MANIFEST_PATH", manifest_path)
+    venice.write_provider_manifest(result)
+    rows = {row["id"]: row for row in json.loads(manifest_path.read_text())["models"]}
+    assert rows[_NEW]["upstream_id"] == "deepseek-v4-1-flash"
+    assert rows[_NEW]["input_token_price_per_m"] == 375_000
+    if not after_cutoff:
+        assert rows[_OLD]["retirement_at"] == "2026-09-15T00:00:00Z"
+        assert rows[_OLD]["replacement_model_id"] == _NEW
+    # A result fetched before retirement cannot reintroduce the price afterward.
+    monkeypatch.setattr(provider_lifecycle, "_utc_now", lambda: _CUTOFF)
+    assert _OLD not in refresh._index_provider_prices({"venice": result})
+
+
+def test_venice_committed_catalog_records_migration() -> None:
+    rows = {row["id"]: row for row in json.loads(venice.MANIFEST_PATH.read_text())["models"]}
+    assert rows[_OLD]["retirement_at"] == "2026-09-15T00:00:00Z"
+    assert rows[_OLD]["replacement_model_id"] == _NEW
+    assert rows[_OLD]["upstream_id"] == "deepseek-v4-flash"
+    assert rows[_NEW]["upstream_id"] == "deepseek-v4-1-flash"
+    assert (f"{_OLD}@venice/prepaid" in catalog.MODEL_ENDPOINTS) is catalog_predates(_CUTOFF)
+    endpoint = catalog.MODEL_ENDPOINTS[f"{_NEW}@venice/prepaid"]
+    assert endpoint.upstream_id == "deepseek-v4-1-flash"


### PR DESCRIPTION
## Summary
- Retire only Venice deepseek-v4-flash at 2026-09-15 00:00 UTC; the customer notice supplies a date but no hour or timezone.
- Keep explicit V4 requests pinned to V4. Do not replace them with V4.1, retire other providers, or assume dated/fast variants are included.
- Filter stale discovery/pricing data after the cutoff and retain migration metadata in the provider manifest.
- V4.1 Flash was already discovered automatically and is published in production as deepseek/deepseek-v4-1-flash, with the exact native ID, image input, and its own prices. No gateway change is needed.

## Verification
- 227 routing, pricing, and lifecycle tests passed.
- Five new lifecycle tests also pass with the catalog clock advanced to 2027.
- Retirement boundary, runtime selection, and stale discovery regression assertions failed on the previous code.
- ruff and mypy passed.
- Read-only production catalog and Venice catalog checks confirmed the replacement, modalities, and integer prices; no paid inference smoke performed.

## Sources
- User-provided Venice September 15 retirement notice.
- https://api.venice.ai/api/v1/models?type=text
- https://venice.ai/models/deepseek-v4-1-flash