### PR TITLE
Add sourced company affiliations to Sign in with TrustedRouter

### DIFF
--- a/docs/design/company-affiliations.md
+++ b/docs/design/company-affiliations.md
@@ -1,0 +1,104 @@
+# Company directory affiliations
+
+Sign in with TrustedRouter can disclose a sourced company-directory match under
+the existing `profile` scope. This does not establish employment, eligibility,
+investor endorsement, or a new identity-verification level. It is not OAuth with
+YC, StartX, or an investor. Google verifies an email when used to sign in; the
+directory supplies the separately sourced company association.
+
+## Data, not code
+
+The private Google Sheet is the editable source of truth. Never commit the
+company dataset, CSV exports, or generated snapshots. Keep all public records
+in the Sheet, including missing data and uncertain/retired companies. Unknown
+founding years are blank, never inferred from batch or investment year.
+
+The Companies tab has these columns:
+
+| Column | Meaning |
+|---|---|
+| funding_organization | One of the supported accelerator or VC names |
+| company_name | Display name from the official directory |
+| directory_url | Official organization listing/profile source |
+| company_url | Official linked company website |
+| domain | Exact email hostname, lowercase/IDNA, without www or URL parts |
+| founding_year | Sourced four-digit year, or blank |
+| founding_year_source | URL supporting the founding year |
+| listing_status | active, operating, public, private, or listed for usable rows |
+| verified_at | Last actual evidence review, ISO 8601 UTC |
+| notes | Missing data, redirects, ambiguity, review explanation |
+| enabled | TRUE only after evidence/domain review; otherwise FALSE |
+
+A listing is not proof that a domain remains owned by the original company.
+Before enabling, check the official directory, the linked website, current
+identity, and redirects. Hold acquired, parked, shared-email/hosting, ambiguous,
+unresolved, programs/funds, and careers-only evidence for manual review. Do not
+assign an acquirer's hostname to the acquired company. Never enable by name
+similarity alone. Snapshot validation rejects conflicting domain ownership and
+founding years. Additional reviewed exact email domains need explicit rows;
+subdomains do not inherit matches.
+
+## Publish and refresh
+
+Export the Companies tab as CSV outside the checkout. Run from the deployed
+revision with the intended cloud's normal storage configuration and identity.
+The same importer supports GCP Spanner and AWS/Azure PostgreSQL-wire stores.
+It does not create schema, change IAM, touch billing, or make direct DML calls.
+
+```sh
+PYTHONPATH=src python scripts/import_company_affiliations.py \
+  --csv /secure/path/companies.csv --sheet-url 'https://docs.google.com/spreadsheets/d/SHEET_ID/edit'
+PYTHONPATH=src python scripts/import_company_affiliations.py --status
+PYTHONPATH=src python scripts/import_company_affiliations.py \
+  --csv /secure/path/companies.csv --sheet-url 'https://docs.google.com/spreadsheets/d/SHEET_ID/edit' \
+  --apply --expected-revision none
+```
+
+Use the exact prior revision instead of `none` on subsequent imports. A mismatch
+aborts the entire transaction. Read-back must match. Deploy code before import,
+then repeat the same reviewed export for every independently stored cloud.
+Read-only dry runs never open a database connection. `--status` does. Protect
+write access to the Sheet and database as authorization-adjacent configuration.
+
+Data lives in `tr_entities`, kind `company_affiliation`: a `current` pointer and
+immutable revision-qualified hash buckets. All buckets and the pointer publish
+in one transaction. Old buckets are retained for readers of prior revisions.
+Only reviewed imports advance the pointer. No user email is stored in the
+directory, sent to Google, or included in enrichment logs.
+
+Per-process cache TTL is 60 seconds. Both observations and snapshots expire
+after 30 days. Re-review sources before refreshing timestamps; do not extend
+old evidence by merely reimporting it. Expired/unavailable data yields no claim,
+not a negative statement about the company. Imports do not run automatically
+without review. Enrichment has a one-second deadline and never blocks sign-in.
+Rollback by publishing a reviewed prior export with a fresh expected revision,
+or publish an all-disabled export to remove claims within the cache TTL.
+
+## Claims
+
+`/v1/auth/userinfo` and the legacy PKCE exchange's `identity` share one builder.
+The RFC token endpoint includes affiliations under `trustedrouter` only when
+the grant includes `profile`. Unmatched/unverified users omit the field.
+Inference-only grants never receive affiliation metadata.
+
+```json
+{
+  "company_affiliations": [{
+    "company_name": "Example Company",
+    "funding_organization": "Y Combinator",
+    "relationship": "accelerator",
+    "domain": "example.com",
+    "founding_year": 2020,
+    "source_url": "https://www.ycombinator.com/companies/example-company",
+    "checked_at": "2026-09-12T00:00:00+00:00",
+    "match_method": "verified_email_domain"
+  }]
+}
+```
+
+Multiple organizations remain separate. `relationship` is `accelerator` for YC
+and StartX, `portfolio` for VCs; it does not imply that StartX invested. Consumers
+must tolerate absent claims, null years, and future fields. Fetch userinfo for
+current metadata rather than treating an old token-exchange response as
+permanent. Display "Company listed by Y Combinator" or "YC company email-domain
+match", not "YC authenticated" or "verified YC employee".

--- a/docs/sign-in-with-trustedrouter.md
+++ b/docs/sign-in-with-trustedrouter.md
@@ -187,6 +187,29 @@ console session).
             "workspace_id": "ws_…", "created_at": "…" } }
 ```
 
+### Company directory affiliations
+
+With `profile` permission, verified email domains can receive an optional
+`company_affiliations` array alongside their identity. It contains the company
+name, `funding_organization`, exact `domain`, sourced `founding_year` (or null),
+`source_url`, `checked_at`, `relationship`, and
+`match_method: "verified_email_domain"`. Multiple investor listings are preserved.
+The RFC `/oauth/token` response exposes this array inside `trustedrouter` when
+the grant includes `profile`; `/auth/keys` exposes it inside `identity`.
+
+This means the verified email domain matches a reviewed public company listing.
+It does **not** verify employment, investor endorsement, funding eligibility, or
+authentication by YC/StartX/a VC. Unmatched, unverified, stale, or unavailable
+directory data omits the field. Do not require it for general sign-in or infer
+that an absent claim disproves an affiliation. Use `/auth/userinfo` for current
+claims rather than relying indefinitely on the initial token exchange.
+
+Supported directories: Y Combinator, StartX, Sequoia Capital, a16z, Lightspeed,
+General Catalyst, Accel, Insight Partners, Bain Capital Ventures, Khosla
+Ventures, Bessemer Venture Partners, and Lux Capital. Coverage is of their
+public listings, not undisclosed investments. Data is managed outside the code
+in a Google Sheet; [matching and refresh policy](design/company-affiliations.md).
+
 ## SDK usage
 
 All three official TrustedRouter SDKs have first-class Sign in with

--- a/scripts/import_company_affiliations.py
+++ b/scripts/import_company_affiliations.py
@@ -1,0 +1,55 @@
+"""Publish a reviewed Google Sheet CSV export; directory data stays outside git."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+from trusted_router.company_affiliations import build_snapshot, validate_documents
+from trusted_router.config import Settings
+from trusted_router.storage import create_store
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--csv", type=Path, help="Local export of the Companies tab")
+    parser.add_argument("--sheet-url", help="Private source Google Sheet URL")
+    parser.add_argument("--status", action="store_true", help="Read current snapshot metadata only")
+    parser.add_argument("--apply", action="store_true", help="Publish atomically in the configured store")
+    parser.add_argument("--expected-revision", help="Current revision from --status; 'none' for first import")
+    args = parser.parse_args()
+    if args.status:
+        if args.apply or args.csv or args.sheet_url:
+            parser.error("--status cannot be combined with an import")
+        store = create_store(Settings(), initialize_schema=False)
+        print(json.dumps(store.get_company_affiliation_document("current"), sort_keys=True))
+        return
+    if args.csv is None or not args.sheet_url:
+        parser.error("--csv and --sheet-url are required")
+    if args.csv.stat().st_size > 50_000_000:
+        parser.error("CSV exceeds 50 MB")
+    with args.csv.open(encoding="utf-8-sig", newline="") as source:
+        reader = csv.DictReader(source)
+        required = {"company_name", "funding_organization", "domain", "company_url", "directory_url", "founding_year", "founding_year_source", "verified_at", "listing_status", "enabled"}
+        if not required.issubset(reader.fieldnames or []):
+            parser.error("CSV must include all documented company affiliation columns")
+        documents = build_snapshot(reader, source_sheet_url=args.sheet_url)
+    validate_documents(documents)
+    if args.apply:
+        if args.expected_revision is None:
+            parser.error("--apply requires --expected-revision from a fresh --status")
+        settings = Settings()
+        if settings.storage_backend == "memory":
+            parser.error("Cannot publish to an ephemeral memory store")
+        store = create_store(settings, initialize_schema=False)
+        expected = None if args.expected_revision == "none" else args.expected_revision
+        store.publish_company_affiliation_documents(documents, expected_revision=expected)
+        if store.get_company_affiliation_document("current") != documents["current"]:
+            raise RuntimeError("Snapshot read-back mismatch")
+    print(json.dumps({"applied": args.apply, **documents["current"]}, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/trusted_router/company_affiliations.py
+++ b/src/trusted_router/company_affiliations.py
@@ -1,0 +1,302 @@
+"""Sourced company-domain affiliations. The directory is data, never bundled code.
+
+An affiliation proves only an exact verified-email domain match to a reviewed
+directory listing, not employment, funding eligibility, or investor endorsement.
+"""
+
+from __future__ import annotations
+
+import copy
+import datetime as dt
+import hashlib
+import ipaddress
+import json
+import logging
+import re
+import threading
+import time
+from collections import OrderedDict
+from collections.abc import Callable, Iterable, Mapping
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
+
+if TYPE_CHECKING:
+    from trusted_router.store_protocol import Store
+
+logger = logging.getLogger(__name__)
+ENTITY_KIND = "company_affiliation"
+MAX_AGE = dt.timedelta(days=30)
+MAX_ROWS = 50_000
+MAX_BUCKET_BYTES = 512_000
+CACHE_SECONDS = 60
+SCHEMA_VERSION = 1
+
+# These are verification-policy origins, not the company directory itself.
+SOURCE_HOSTS = {
+    "Y Combinator": ("ycombinator.com",),
+    "StartX": ("startx.com", "startx.stanford.edu"),
+    "Sequoia Capital": ("sequoiacap.com",),
+    "Andreessen Horowitz (a16z)": ("a16z.com", "a16zcrypto.com"),
+    "Lightspeed Venture Partners": ("lsvp.com",),
+    "General Catalyst": ("generalcatalyst.com",),
+    "Accel": ("accel.com",),
+    "Insight Partners": ("insightpartners.com",),
+    "Bain Capital Ventures": ("baincapitalventures.com",),
+    "Khosla Ventures": ("khoslaventures.com",),
+    "Bessemer Venture Partners": ("bvp.com",),
+    "Lux Capital": ("luxcapital.com",),
+}
+_SHARED_DOMAINS = frozenset({
+    "gmail.com", "googlemail.com", "outlook.com", "hotmail.com", "live.com",
+    "msn.com", "yahoo.com", "ymail.com", "aol.com", "icloud.com", "me.com",
+    "mac.com", "proton.me", "protonmail.com", "pm.me", "mail.com",
+    "fastmail.com", "hey.com", "qq.com", "163.com", "126.com", "gmx.com",
+    "gmx.de", "yandex.com", "yandex.ru", "github.io", "gitlab.io",
+    "netlify.app", "vercel.app", "webflow.io", "wixsite.com", "notion.site",
+    "framer.website", "framer.app", "substack.com", "medium.com",
+    "linkedin.com", "facebook.com", "instagram.com", "twitter.com", "x.com",
+    "co.uk", "com.au", "co.in", "co.jp", "com.br", "com.cn", "com.sg",
+})
+_ACTIVE_STATUSES = frozenset({"active", "operating", "public", "private", "listed"})
+_LABEL = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\Z")
+
+
+def normalize_company_domain(value: str) -> str:
+    value = value.strip().lower()
+    if any(character in value for character in "/:@*\\") or value.endswith("."):
+        raise ValueError("Invalid company domain")
+    try:
+        domain = value.encode("idna").decode("ascii")
+    except UnicodeError as exc:
+        raise ValueError("Invalid company domain") from exc
+    labels = domain.split(".")
+    if len(domain) > 253 or len(labels) < 2 or not all(_LABEL.fullmatch(p) for p in labels):
+        raise ValueError("Invalid company domain")
+    try:
+        ipaddress.ip_address(domain)
+    except ValueError:
+        pass
+    else:
+        raise ValueError("IP addresses are not company domains")
+    if any(domain == shared or domain.endswith("." + shared) for shared in _SHARED_DOMAINS):
+        raise ValueError("Shared domains cannot establish company affiliation")
+    return domain
+
+
+def _url(value: str) -> str:
+    parsed = urlsplit(value)
+    if (
+        len(value) > 2048 or parsed.scheme not in {"http", "https"}
+        or not parsed.hostname or parsed.username or parsed.password
+        or parsed.port not in {None, 80, 443}
+        or any(ord(char) < 32 for char in value)
+    ):
+        raise ValueError("A public source URL is required")
+    return value
+
+
+def _timestamp(value: str) -> dt.datetime:
+    parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed.astimezone(dt.UTC)
+
+
+def _canonical(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+
+
+def _bucket(domain: str) -> str:
+    return hashlib.sha256(domain.encode()).hexdigest()[:2]
+
+
+def build_snapshot(
+    rows: Iterable[Mapping[str, Any]], *, source_sheet_url: str,
+    now: dt.datetime | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Validate a Sheet export and build bounded immutable domain buckets."""
+    now = now or dt.datetime.now(dt.UTC)
+    sheet = urlsplit(_url(source_sheet_url))
+    if sheet.scheme != "https" or sheet.hostname != "docs.google.com" or not sheet.path.startswith("/spreadsheets/d/"):
+        raise ValueError("The source must be a Google Sheet")
+    by_domain: dict[str, list[dict[str, Any]]] = {}
+    owners: dict[str, str] = {}
+    for number, row in enumerate(rows, 1):
+        if number > MAX_ROWS:
+            raise ValueError("Company directory exceeds row limit")
+        if str(row.get("enabled", "")).strip().lower() != "true":
+            continue
+        if str(row.get("listing_status", "")).strip().lower() not in _ACTIVE_STATUSES:
+            continue
+        domain = normalize_company_domain(str(row.get("domain", "")))
+        company_name = str(row.get("company_name", "")).strip()
+        organization = str(row.get("funding_organization", "")).strip()
+        if not company_name or len(company_name) > 200 or organization not in SOURCE_HOSTS:
+            raise ValueError(f"Invalid company or organization at row {number}")
+        source_url = _url(str(row.get("directory_url", "")).strip())
+        source_host = urlsplit(source_url).hostname or ""
+        if not any(source_host == host or source_host.endswith("." + host) for host in SOURCE_HOSTS[organization]):
+            raise ValueError(f"Directory source is not owned by the organization at row {number}")
+        website = _url(str(row.get("company_url", "")).strip())
+        website_domain = normalize_company_domain((urlsplit(website).hostname or "").removeprefix("www."))
+        if website_domain != domain:
+            raise ValueError(f"Company website and email domain disagree at row {number}")
+        checked_at = _timestamp(str(row.get("verified_at", "")))
+        if checked_at > now + dt.timedelta(minutes=5):
+            raise ValueError(f"Future observation at row {number}")
+        if now - checked_at > MAX_AGE:
+            continue
+        raw_year = str(row.get("founding_year", "") or "").strip()
+        year: int | None = None
+        if raw_year:
+            if not re.fullmatch(r"\d{4}", raw_year) or not 1000 <= int(raw_year) <= now.year:
+                raise ValueError(f"Invalid founding year at row {number}")
+            _url(str(row.get("founding_year_source", "")).strip())
+            year = int(raw_year)
+        owner = company_name.casefold()
+        if domain in owners and owners[domain] != owner:
+            raise ValueError(f"ambiguous company ownership for {domain}")
+        owners[domain] = owner
+        record = {
+            "company_name": company_name,
+            "funding_organization": organization,
+            "relationship": "accelerator" if organization in {"Y Combinator", "StartX"} else "portfolio",
+            "domain": domain,
+            "founding_year": year,
+            "source_url": source_url,
+            "checked_at": checked_at.isoformat(),
+            "match_method": "verified_email_domain",
+        }
+        existing = by_domain.setdefault(domain, [])
+        if record not in existing:
+            if any(item["funding_organization"] == organization for item in existing):
+                raise ValueError(f"Conflicting duplicate affiliation for {domain}")
+            existing.append(record)
+    for records in by_domain.values():
+        records.sort(key=lambda item: (item["funding_organization"], item["source_url"]))
+        if len({record["founding_year"] for record in records if record["founding_year"] is not None}) > 1:
+            raise ValueError("Conflicting founding years require review")
+    metadata: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION, "source_sheet_url": source_sheet_url,
+        "generated_at": now.isoformat(), "expires_at": (now + MAX_AGE).isoformat(),
+        "domain_count": len(by_domain), "record_count": sum(map(len, by_domain.values())),
+    }
+    revision = hashlib.sha256(_canonical({"metadata": metadata, "domains": by_domain})).hexdigest()
+    metadata["revision"] = revision
+    documents = {"current": metadata}
+    for domain, records in sorted(by_domain.items()):
+        document = documents.setdefault(f"{revision}:{_bucket(domain)}", {"revision": revision, "domains": {}})
+        document["domains"][domain] = records
+    if any(len(_canonical(doc)) > MAX_BUCKET_BYTES for doc in documents.values()):
+        raise ValueError("Company directory bucket exceeds size limit")
+    return documents
+
+
+def validate_documents(documents: dict[str, dict[str, Any]]) -> str:
+    """Reject malformed or oversized imports before opening a transaction."""
+    current = documents.get("current", {})
+    revision = current.get("revision", "")
+    if not isinstance(revision, str) or not re.fullmatch(r"[a-f0-9]{64}", revision):
+        raise ValueError("Invalid affiliation revision")
+    if len(documents) > 257 or current.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("Invalid affiliation snapshot")
+    by_domain: dict[str, Any] = {}
+    for key, value in documents.items():
+        if len(_canonical(value)) > MAX_BUCKET_BYTES:
+            raise ValueError("Affiliation snapshot document too large")
+        if key != "current" and (
+            not re.fullmatch(re.escape(revision) + r":[a-f0-9]{2}", key)
+            or value.get("revision") != revision or not isinstance(value.get("domains"), dict)
+        ):
+            raise ValueError("Invalid affiliation bucket")
+        if key != "current":
+            for domain, records in value["domains"].items():
+                if key != f"{revision}:{_bucket(domain)}" or domain in by_domain:
+                    raise ValueError("Incorrect affiliation bucket placement")
+                by_domain[domain] = records
+    metadata = {key: value for key, value in current.items() if key != "revision"}
+    digest = hashlib.sha256(_canonical({"metadata": metadata, "domains": by_domain})).hexdigest()
+    if digest != revision or current.get("domain_count") != len(by_domain) or current.get("record_count") != sum(map(len, by_domain.values())):
+        raise ValueError("Incomplete or modified affiliation snapshot")
+    return revision
+
+
+class AffiliationDirectory:
+    """A bounded per-process cache. Cache keys are domains, never email addresses."""
+
+    def __init__(self, read: Callable[[str], dict[str, Any] | None]) -> None:
+        self._read = read
+        self._cache: OrderedDict[str, tuple[float, dict[str, Any] | None]] = OrderedDict()
+        self._lock = threading.RLock()
+        self._retry_after = 0.0
+
+    def clear(self) -> None:
+        with self._lock:
+            self._cache.clear()
+            self._retry_after = 0.0
+
+    def defer_retries(self) -> None:
+        # No lock: a timed-out database read may still hold the cache lock.
+        self._retry_after = time.monotonic() + CACHE_SECONDS
+
+    def _document(self, key: str) -> dict[str, Any] | None:
+        with self._lock:
+            monotonic = time.monotonic()
+            cached = self._cache.get(key)
+            if cached and cached[0] > monotonic:
+                self._cache.move_to_end(key)
+                return cached[1]
+            value = self._read(key)
+            self._cache[key] = (monotonic + CACHE_SECONDS, value)
+            self._cache.move_to_end(key)
+            while len(self._cache) > 257:
+                self._cache.popitem(last=False)
+            return value
+
+    def lookup(
+        self, email: str | None, *, email_verified: bool,
+        now: dt.datetime | None = None,
+    ) -> list[dict[str, Any]]:
+        if email_verified is not True or not email or email.count("@") != 1:
+            return []
+        local, raw_domain = email.split("@")
+        if not local or any(char.isspace() for char in email):
+            return []
+        try:
+            domain = normalize_company_domain(raw_domain)
+        except ValueError:
+            return []
+        now = now or dt.datetime.now(dt.UTC)
+        if time.monotonic() < self._retry_after:
+            return []
+        try:
+            metadata = self._document("current")
+            if not metadata or metadata.get("schema_version") != SCHEMA_VERSION:
+                return []
+            if not _timestamp(metadata["generated_at"]) <= now < _timestamp(metadata["expires_at"]):
+                return []
+            revision = metadata["revision"]
+            if not isinstance(revision, str) or not re.fullmatch(r"[a-f0-9]{64}", revision):
+                return []
+            document = self._document(f"{revision}:{_bucket(domain)}")
+            if not document or document.get("revision") != revision:
+                return []
+            records = document.get("domains", {}).get(domain, [])
+            return copy.deepcopy([
+                record for record in records
+                if record.get("domain") == domain and
+                dt.timedelta(0) <= now - _timestamp(record["checked_at"]) <= MAX_AGE
+            ])
+        except Exception:  # noqa: BLE001 - optional enrichment must not break authentication.
+            self.defer_retries()
+            # Do not attach exceptions or identifiers: a storage error may contain data.
+            logger.warning("company_affiliation_lookup_unavailable")
+            return []
+
+
+def directory_for_store(store: Store) -> AffiliationDirectory:
+    directory = getattr(store, "_company_affiliation_directory", None)
+    if not isinstance(directory, AffiliationDirectory):
+        directory = AffiliationDirectory(store.get_company_affiliation_document)
+        setattr(store, "_company_affiliation_directory", directory)  # noqa: B010 - private backend cache, outside the public Store contract.
+    return directory

--- a/src/trusted_router/company_affiliations.py
+++ b/src/trusted_router/company_affiliations.py
@@ -55,6 +55,8 @@ _SHARED_DOMAINS = frozenset({
     "netlify.app", "vercel.app", "webflow.io", "wixsite.com", "notion.site",
     "framer.website", "framer.app", "substack.com", "medium.com",
     "linkedin.com", "facebook.com", "instagram.com", "twitter.com", "x.com",
+})
+_PUBLIC_SUFFIXES = frozenset({
     "co.uk", "com.au", "co.in", "co.jp", "com.br", "com.cn", "com.sg",
 })
 _ACTIVE_STATUSES = frozenset({"active", "operating", "public", "private", "listed"})
@@ -78,7 +80,9 @@ def normalize_company_domain(value: str) -> str:
         pass
     else:
         raise ValueError("IP addresses are not company domains")
-    if any(domain == shared or domain.endswith("." + shared) for shared in _SHARED_DOMAINS):
+    if domain in _PUBLIC_SUFFIXES or any(
+        domain == shared or domain.endswith("." + shared) for shared in _SHARED_DOMAINS
+    ):
         raise ValueError("Shared domains cannot establish company affiliation")
     return domain
 

--- a/src/trusted_router/routes/auth.py
+++ b/src/trusted_router/routes/auth.py
@@ -18,12 +18,13 @@ from trusted_router.errors import api_error
 from trusted_router.scopes import SCOPE_PROFILE
 from trusted_router.storage import STORE, User, Workspace
 from trusted_router.types import ErrorType
-from trusted_router.verification import identity_payload
+from trusted_router.verification import enriched_identity_payload
 
 
 def register_auth_routes(router: APIRouter) -> None:
     @router.get("/auth/userinfo")
     async def auth_userinfo(
+        response: Response,
         principal: Annotated[Principal, Depends(require_scope(SCOPE_PROFILE))],
     ) -> dict[str, Any]:
         """OIDC-style userinfo for "Sign in with TrustedRouter". Works with a
@@ -32,6 +33,7 @@ def register_auth_routes(router: APIRouter) -> None:
         A delegated key carries the approving user's id via `creator_user_id`,
         so apps that did the PKCE sign-in can fetch the user's email/profile
         with just the key they received."""
+        response.headers["Cache-Control"] = "private, no-store"
         user = principal.user
         if (
             user is None
@@ -55,7 +57,7 @@ def register_auth_routes(router: APIRouter) -> None:
                 "A user-owned session or API key is required",
                 ErrorType.FORBIDDEN,
             )
-        return {"data": identity_payload(user, principal.workspace.id)}
+        return {"data": await enriched_identity_payload(user, principal.workspace.id)}
 
     @router.get("/auth/session")
     async def auth_session(principal: ManagementPrincipal) -> dict[str, Any]:

--- a/src/trusted_router/routes/oauth_keys.py
+++ b/src/trusted_router/routes/oauth_keys.py
@@ -30,13 +30,13 @@ from trusted_router.money import (
 from trusted_router.oauth_app_policy import oauth_app_can_authorize
 from trusted_router.routes.helpers import enforce_rate_limit, json_body
 from trusted_router.schemas import CheckoutRequest
-from trusted_router.scopes import DEFAULT_DELEGATED_SCOPES, KNOWN_SCOPES
+from trusted_router.scopes import DEFAULT_DELEGATED_SCOPES, KNOWN_SCOPES, SCOPE_PROFILE
 from trusted_router.serialization import key_shape
 from trusted_router.services.stripe_billing import create_checkout_session
 from trusted_router.storage import STORE, ConsentRequest, OAuthApp, OAuthAuthorizationCode
 from trusted_router.typed_balance import live_credit_summary
 from trusted_router.types import ErrorType
-from trusted_router.verification import identity_payload
+from trusted_router.verification import enriched_identity_payload, identity_payload
 from trusted_router.views import render_template
 
 PKCE_METHODS = {"S256", "plain"}
@@ -272,9 +272,10 @@ def register_oauth_key_routes(router: APIRouter) -> None:
             {
                 "key": raw_key,
                 "user_id": code.user_id,
-                "identity": identity_payload(user, code.workspace_id),
+                "identity": await enriched_identity_payload(user, code.workspace_id),
                 "data": key_shape(key),
-            }
+            },
+            headers={"Cache-Control": "no-store", "Pragma": "no-cache"},
         )
 
     @router.post("/oauth/token")
@@ -312,7 +313,12 @@ def register_oauth_key_routes(router: APIRouter) -> None:
         )
         user = STORE.get_user(code.user_id) if code.user_id else None
         identity = identity_payload(user, code.workspace_id) or {"verification_level": "none"}
-        return JSONResponse({"access_token": raw_key, "token_type": "bearer", "scope": " ".join(code.scopes), "trustedrouter": {"verification_level": identity["verification_level"], "app_id": code.client_app_id, "workspace_id": code.workspace_id}}, headers={"Cache-Control": "no-store", "Pragma": "no-cache"})
+        metadata = {"verification_level": identity["verification_level"], "app_id": code.client_app_id, "workspace_id": code.workspace_id}
+        if SCOPE_PROFILE in code.scopes:
+            profile = await enriched_identity_payload(user, code.workspace_id) or {}
+            if profile.get("company_affiliations"):
+                metadata["company_affiliations"] = profile["company_affiliations"]
+        return JSONResponse({"access_token": raw_key, "token_type": "bearer", "scope": " ".join(code.scopes), "trustedrouter": metadata}, headers={"Cache-Control": "no-store", "Pragma": "no-cache"})
 
 
 def _create_code(

--- a/src/trusted_router/storage.py
+++ b/src/trusted_router/storage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import dataclasses
 import datetime as dt
 import hmac
@@ -170,6 +171,8 @@ class InMemoryStore:
             trust_tier3_min_paid_microdollars
         )
         self.users: dict[str, User] = {}
+        self._company_affiliation_documents: dict[str, dict[str, Any]] = {}
+        self._company_affiliation_directory: Any = None
         self.user_ids_by_email: dict[str, str] = {}
         self.user_ids_by_wallet: dict[str, str] = {}
         self.user_ids_by_username: dict[str, str] = {}
@@ -251,6 +254,8 @@ class InMemoryStore:
 
     def reset(self) -> None:
         with self._lock:
+            self._company_affiliation_documents.clear()
+            self._company_affiliation_directory = None
             self.users.clear()
             self.user_ids_by_email.clear()
             self.user_ids_by_wallet.clear()
@@ -1612,6 +1617,28 @@ class InMemoryStore:
 
     def delete_byok_provider(self, workspace_id: str, provider: str) -> bool:
         return self.byok_store.delete(workspace_id, provider)
+
+    def get_company_affiliation_document(self, document_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            return copy.deepcopy(self._company_affiliation_documents.get(document_id))
+
+    def get_company_affiliation_directory(self) -> Any:
+        from trusted_router.company_affiliations import directory_for_store
+
+        return directory_for_store(self)
+
+    def publish_company_affiliation_documents(
+        self, documents: dict[str, dict[str, Any]], *, expected_revision: str | None,
+    ) -> None:
+        from trusted_router.company_affiliations import validate_documents
+
+        validate_documents(documents)
+        with self._lock:
+            current = self._company_affiliation_documents.get("current", {})
+            if current.get("revision") != expected_revision:
+                raise StoreConflict("Company affiliation directory changed during import")
+            self._company_affiliation_documents.update(copy.deepcopy(documents))
+            self._company_affiliation_directory = None
 
     def create_custom_model(
         self,
@@ -3849,7 +3876,7 @@ def configure_analytics_sink(sink: AnalyticsSink) -> None:
     _ANALYTICS_SINK = sink
 
 
-def create_store(settings: Any) -> Store:
+def create_store(settings: Any, *, initialize_schema: bool = True) -> Store:
     backend = str(getattr(settings, "storage_backend", "memory")).lower()
     if backend == "memory":
         return InMemoryStore(
@@ -3897,7 +3924,8 @@ def create_store(settings: Any) -> Store:
                 getattr(settings, "trust_tier3_min_paid_microdollars", 50_000_000)
             ),
         )
-        store.apply_schema()
+        if initialize_schema:
+            store.apply_schema()
         return store
     if backend in {"spanner-bigtable", "spanner-clickhouse"}:
         from trusted_router.storage_gcp import SpannerBigtableStore

--- a/src/trusted_router/storage_gcp.py
+++ b/src/trusted_router/storage_gcp.py
@@ -7977,6 +7977,33 @@ class SpannerBigtableStore:
 
         return cast(SpendLeaseArtifact, self._run_in_transaction(txn))
 
+    def get_company_affiliation_document(self, document_id: str) -> dict[str, Any] | None:
+        from trusted_router.company_affiliations import ENTITY_KIND
+
+        return self._read_entity(ENTITY_KIND, document_id, dict)
+
+    def get_company_affiliation_directory(self) -> Any:
+        from trusted_router.company_affiliations import directory_for_store
+
+        return directory_for_store(self)
+
+    def publish_company_affiliation_documents(
+        self, documents: dict[str, dict[str, Any]], *, expected_revision: str | None,
+    ) -> None:
+        from trusted_router.company_affiliations import ENTITY_KIND, validate_documents
+
+        validate_documents(documents)
+
+        def txn(transaction: Any) -> None:
+            current = self._read_entity_tx(transaction, ENTITY_KIND, "current", dict) or {}
+            if current.get("revision") != expected_revision:
+                raise StoreConflict("Company affiliation directory changed during import")
+            for document_id, document in documents.items():
+                self._write_entity_tx(transaction, ENTITY_KIND, document_id, document)
+
+        run_in_transaction_with_retry(self._database, txn)
+        self._company_affiliation_directory = None
+
     def _read_entity(self, kind: str, entity_id: str, cls: type[T]) -> T | None:
         # This generic helper serves membership, key, and workspace authorization
         # reads as well as display reads, so weakening it globally is unsafe.

--- a/src/trusted_router/storage_postgres.py
+++ b/src/trusted_router/storage_postgres.py
@@ -1392,6 +1392,36 @@ class PostgresStore:
 
     # Users + workspaces -----------------------------------------------------
 
+    def get_company_affiliation_document(self, document_id: str) -> dict[str, Any] | None:
+        from trusted_router.company_affiliations import ENTITY_KIND
+
+        return self._read_entity(ENTITY_KIND, document_id, dict)
+
+    def get_company_affiliation_directory(self) -> Any:
+        from trusted_router.company_affiliations import directory_for_store
+
+        return directory_for_store(self)
+
+    def publish_company_affiliation_documents(
+        self, documents: dict[str, dict[str, Any]], *, expected_revision: str | None,
+    ) -> None:
+        from trusted_router.company_affiliations import ENTITY_KIND, validate_documents
+
+        validate_documents(documents)
+
+        def operation(conn: Any) -> None:
+            current = self._read_entity_tx(conn, ENTITY_KIND, "current", dict, for_update=True) or {}
+            if current.get("revision") != expected_revision:
+                raise StoreConflict("Company affiliation directory changed during import")
+            # SELECT FOR UPDATE cannot lock an absent initial pointer.
+            if not current and not self._insert_entity_once_tx(conn, ENTITY_KIND, "current", documents["current"]):
+                raise StoreConflict("Company affiliation directory changed during import")
+            for document_id, document in documents.items():
+                self._write_entity_tx(conn, ENTITY_KIND, document_id, document)
+
+        self._run_transaction(operation)
+        self._company_affiliation_directory = None
+
     def ensure_user(
         self,
         user_id: str,

--- a/src/trusted_router/store_protocol.py
+++ b/src/trusted_router/store_protocol.py
@@ -77,6 +77,13 @@ class Store(Protocol):
     # Lifecycle ---------------------------------------------------------------
     def reset(self) -> None: ...
 
+    def get_company_affiliation_document(self, document_id: str) -> dict[str, Any] | None: ...
+
+    def get_company_affiliation_directory(self) -> Any: ...
+    def publish_company_affiliation_documents(
+        self, documents: dict[str, dict[str, Any]], *, expected_revision: str | None,
+    ) -> None: ...
+
     #: False on a backend whose key writes are unimplemented. Callers that
     #: mutate keys check this BEFORE writing: discovering the gap by catching
     #: the raise mid-sequence cannot distinguish "nothing was written" from

--- a/src/trusted_router/templates/auth/oauth_consent.html
+++ b/src/trusted_router/templates/auth/oauth_consent.html
@@ -63,7 +63,7 @@
     </div>
     <ul class="consent-facts">
       <li>Run model inference and read the requests this key made.</li>
-      <li>Read your profile and verification level.</li>
+      <li>Read your profile, verification level, and company directory affiliations matched to your verified email domain.</li>
       <li>Read your remaining credit balance, but not account management details.</li>
       <li>TrustedRouter keeps no prompt or output logs, always.</li>
       <li>You can revoke the key from the console at any time.</li>

--- a/src/trusted_router/templates/auth/oauth_consent_registered.html
+++ b/src/trusted_router/templates/auth/oauth_consent_registered.html
@@ -69,7 +69,7 @@
     </div>
     <ul class="consent-facts">
       <li>Run model inference and read the requests this key made.</li>
-      <li>Read your profile and verification level.</li>
+      <li>Read your profile, verification level, and company directory affiliations matched to your verified email domain.</li>
       <li>Read your remaining credit balance, but not account management details.</li>
       <li>TrustedRouter keeps no prompt or output logs, always.</li>
       <li>You can revoke the key from the console at any time.</li>

--- a/src/trusted_router/templates/public/seo_sign_in_with_trustedrouter.html
+++ b/src/trusted_router/templates/public/seo_sign_in_with_trustedrouter.html
@@ -157,6 +157,12 @@ let token = try await oauth.authenticate(
   <p class="sdk-stack-note">Sign in with TrustedRouter is built into the official <a href="https://github.com/Lore-Hex/trusted-router-py">Python</a>, <a href="https://github.com/Lore-Hex/trusted-router-js">TypeScript</a>, and <a href="https://github.com/jperla/trusted-router-swift">Swift</a> SDKs. PKCE <code>S256</code> works on every platform with no client secret. Desktop and CLI apps use the loopback flow (<code>http://localhost:3000/callback</code>). Full reference: <a href="https://github.com/Lore-Hex/quill-router/blob/main/docs/sign-in-with-trustedrouter.md">Sign in with TrustedRouter docs</a>.</p>
 </section>
 
+<section class="sdk-stack" id="company-affiliations" aria-label="Company directory affiliations">
+  <div class="section-head"><h2>Company context, with sources.</h2></div>
+  <p>Apps with profile permission can receive company directory affiliations for an exact verified email-domain match: the funding organization, company domain, founding year when known, and the source listing. Directories include Y Combinator, StartX, and ten venture firms.</p>
+  <p>A directory match is not employment verification, investor endorsement, or sign-in through an investor. Missing or stale evidence produces no claim. <a href="https://github.com/Lore-Hex/quill-router/blob/main/docs/sign-in-with-trustedrouter.md#company-directory-affiliations">Read the affiliation contract</a>.</p>
+</section>
+
 <section class="compare-matrix" aria-label="Roll your own vs Sign in with TrustedRouter">
   <div class="matrix-row matrix-head">
     <span></span><strong>Roll your own</strong><strong>Sign in with TrustedRouter</strong>

--- a/src/trusted_router/verification.py
+++ b/src/trusted_router/verification.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
+from functools import partial
 from typing import Any
 
-from trusted_router.storage import User
+import anyio
+
+from trusted_router.company_affiliations import AffiliationDirectory
+from trusted_router.storage import STORE, User
+
+AFFILIATION_TIMEOUT_SECONDS = 1.0
 
 
 def verification_level(user: User | None) -> str:
@@ -35,3 +42,23 @@ def identity_payload(user: User | None, workspace_id: str) -> dict[str, Any] | N
         "workspace_id": workspace_id,
         "created_at": user.created_at,
     }
+
+
+async def enriched_identity_payload(user: User | None, workspace_id: str) -> dict[str, Any] | None:
+    """Optional profile enrichment must never become a sign-in dependency."""
+    identity = identity_payload(user, workspace_id)
+    if identity is None or user is None or user.email_verified is not True:
+        return identity
+    directory: AffiliationDirectory = STORE.get_company_affiliation_directory()
+    try:
+        async with asyncio.timeout(AFFILIATION_TIMEOUT_SECONDS):
+            affiliations = await anyio.to_thread.run_sync(
+                partial(directory.lookup, user.email, email_verified=True),
+                abandon_on_cancel=True,
+            )
+    except TimeoutError:
+        directory.defer_retries()
+        return identity
+    if affiliations:
+        identity["company_affiliations"] = affiliations
+    return identity

--- a/tests/conformance/test_company_affiliations.py
+++ b/tests/conformance/test_company_affiliations.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+from trusted_router.company_affiliations import build_snapshot
+from trusted_router.storage_errors import StoreConflict
+
+
+def _documents(*, name: str = "Example") -> dict:
+    return build_snapshot([{
+        "enabled": "TRUE", "listing_status": "active", "domain": "example.com",
+        "company_name": name, "company_url": "https://example.com",
+        "funding_organization": "Y Combinator",
+        "directory_url": "https://www.ycombinator.com/companies/example",
+        "founding_year": "", "verified_at": "2026-09-12",
+    }], source_sheet_url="https://docs.google.com/spreadsheets/d/example/edit",
+        now=dt.datetime(2026, 9, 12, tzinfo=dt.UTC))
+
+
+def test_affiliation_atomic_publish_and_read(store) -> None:
+    assert store.get_company_affiliation_document("missing") is None
+    old = store.get_company_affiliation_document("current")
+    docs = _documents()
+    store.publish_company_affiliation_documents(docs, expected_revision=old["revision"] if old else None)
+    assert store.get_company_affiliation_document("current") == docs["current"]
+    for key in docs:
+        assert store.get_company_affiliation_document(key) == docs[key]
+
+
+def test_affiliation_stale_writer_cannot_partially_publish(store) -> None:
+    old = store.get_company_affiliation_document("current")
+    first, second = _documents(), _documents(name="Other")
+    store.publish_company_affiliation_documents(first, expected_revision=old["revision"] if old else None)
+    with pytest.raises(StoreConflict):
+        store.publish_company_affiliation_documents(second, expected_revision="stale-revision")
+    assert store.get_company_affiliation_document("current") == first["current"]
+    for key in second:
+        if key != "current":
+            assert store.get_company_affiliation_document(key) is None
+
+
+def test_affiliation_malformed_snapshot_rejected_before_write(store) -> None:
+    before = store.get_company_affiliation_document("current")
+    with pytest.raises(ValueError):
+        store.publish_company_affiliation_documents({"current": {"revision": "wrong"}}, expected_revision=None)
+    assert store.get_company_affiliation_document("current") == before

--- a/tests/test_company_affiliation_import.py
+++ b/tests/test_company_affiliation_import.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import csv
+import datetime as dt
+import json
+
+import pytest
+
+from scripts import import_company_affiliations as importer
+from tests.test_company_affiliations import SHEET, row
+
+
+def test_dry_run_validates_export_without_connecting_to_storage(tmp_path, monkeypatch, capsys) -> None:
+    source = tmp_path / "companies.csv"
+    record = row(verified_at=dt.datetime.now(dt.UTC).date().isoformat())
+    with source.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(record))
+        writer.writeheader()
+        writer.writerow(record)
+    monkeypatch.setattr("sys.argv", ["import", "--csv", str(source), "--sheet-url", SHEET])
+    monkeypatch.setattr(importer, "create_store", lambda *args, **kwargs: pytest.fail("Dry run opened storage"))
+    importer.main()
+    result = json.loads(capsys.readouterr().out)
+    assert result["applied"] is False
+    assert result["domain_count"] == 1
+
+
+def test_bad_export_schema_does_not_connect_or_publish(tmp_path, monkeypatch) -> None:
+    source = tmp_path / "companies.csv"
+    source.write_text("company_name,domain\nFake,example.com\n")
+    monkeypatch.setattr("sys.argv", ["import", "--csv", str(source), "--sheet-url", SHEET, "--apply"])
+    monkeypatch.setattr(importer, "create_store", lambda *args, **kwargs: pytest.fail("Invalid export opened storage"))
+    with pytest.raises(SystemExit, match="2"):
+        importer.main()

--- a/tests/test_company_affiliations.py
+++ b/tests/test_company_affiliations.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import copy
+import datetime as dt
+from typing import Any
+
+import pytest
+
+from trusted_router.company_affiliations import (
+    AffiliationDirectory,
+    build_snapshot,
+    normalize_company_domain,
+    validate_documents,
+)
+
+NOW = dt.datetime(2026, 9, 12, tzinfo=dt.UTC)
+SHEET = "https://docs.google.com/spreadsheets/d/test-directory/edit"
+
+
+def row(**changes: Any) -> dict[str, Any]:
+    result = {
+        "company_name": "Example Company",
+        "funding_organization": "Y Combinator",
+        "domain": "example.com",
+        "company_url": "https://www.example.com/",
+        "directory_url": "https://www.ycombinator.com/companies/example-company",
+        "founding_year": "2020",
+        "founding_year_source": "https://www.example.com/about",
+        "verified_at": "2026-09-12",
+        "listing_status": "active",
+        "enabled": "TRUE",
+    }
+    return result | changes
+
+
+def directory(rows: list[dict[str, Any]]) -> AffiliationDirectory:
+    documents = build_snapshot(rows, source_sheet_url=SHEET, now=NOW)
+    return AffiliationDirectory(lambda key: copy.deepcopy(documents.get(key)))
+
+
+def test_exact_verified_domain_returns_sourced_affiliation() -> None:
+    result = directory([row()]).lookup("Person@EXAMPLE.COM", email_verified=True, now=NOW)
+    assert len(result) == 1
+    assert result[0]["domain"] == "example.com"
+    assert result[0]["funding_organization"] == "Y Combinator"
+    assert result[0]["founding_year"] == 2020
+    assert result[0]["match_method"] == "verified_email_domain"
+    assert result[0]["source_url"].startswith("https://www.ycombinator.com/")
+
+
+@pytest.mark.parametrize("verified", [False, None, "true", "false", 1])
+def test_unverified_emails_do_not_even_read_directory(verified: Any) -> None:
+    def forbidden_read(key: str) -> None:
+        pytest.fail("Unverified identities must not query affiliation data")
+
+    assert AffiliationDirectory(forbidden_read).lookup(
+        "person@example.com", email_verified=verified, now=NOW
+    ) == []
+
+
+@pytest.mark.parametrize("email", [
+    "person@sub.example.com", "person@example.com.attacker.net",
+    "person@notexample.com", "person@example.co", "person@examp1e.com",
+    "person@gmail.com", "person@example.com@attacker.net", "example.com",
+    "person@example.com.", "person@www.example.com", "person@éxample.com",
+])
+def test_no_suffix_fuzzy_subdomain_or_invalid_email_matches(email: str) -> None:
+    assert directory([row()]).lookup(email, email_verified=True, now=NOW) == []
+
+
+@pytest.mark.parametrize("domain", [
+    "gmail.com", "outlook.com", "yahoo.com", "github.io", "co.uk", "localhost",
+    "127.0.0.1", "example.com/path", "*.example.com", "user@example.com",
+    "https://example.com", "example.com:443", "-bad.example", "example.com.",
+])
+def test_invalid_or_shared_domains_are_rejected(domain: str) -> None:
+    with pytest.raises(ValueError):
+        normalize_company_domain(domain)
+
+
+def test_multiple_organizations_are_preserved_and_duplicates_removed() -> None:
+    records = [row(), row(), row(
+        funding_organization="Accel", directory_url="https://www.accel.com/companies/example"
+    )]
+    result = directory(records).lookup("x@example.com", email_verified=True, now=NOW)
+    assert {item["funding_organization"] for item in result} == {"Y Combinator", "Accel"}
+    assert len(result) == 2
+
+
+def test_missing_founding_year_remains_null() -> None:
+    result = directory([row(founding_year="", founding_year_source="")]).lookup(
+        "x@example.com", email_verified=True, now=NOW
+    )
+    assert result[0]["founding_year"] is None
+
+
+def test_enabled_rows_require_source_evidence_and_real_founding_year() -> None:
+    for changes in [
+        {"directory_url": ""}, {"company_url": "https://other.example/"},
+        {"founding_year": "W2020"}, {"founding_year": "2030"},
+        {"founding_year_source": ""}, {"verified_at": ""},
+        {"directory_url": "javascript:alert(1)"},
+    ]:
+        with pytest.raises(ValueError):
+            build_snapshot([row(**changes)], source_sheet_url=SHEET, now=NOW)
+
+
+def test_unreviewed_disabled_and_retired_rows_cannot_make_claims() -> None:
+    for changes in [
+        {"enabled": "FALSE"}, {"enabled": ""}, {"listing_status": "inactive"},
+        {"listing_status": "defunct"}, {"listing_status": "acquired"},
+    ]:
+        assert directory([row(**changes)]).lookup(
+            "x@example.com", email_verified=True, now=NOW
+        ) == []
+
+
+def test_conflicting_domain_ownership_rejects_snapshot() -> None:
+    with pytest.raises(ValueError, match="ambiguous"):
+        build_snapshot([row(), row(company_name="Unrelated Company")], source_sheet_url=SHEET, now=NOW)
+
+
+def test_stale_rows_and_expired_snapshot_do_not_make_claims() -> None:
+    assert directory([row(verified_at="2025-01-01")]).lookup(
+        "x@example.com", email_verified=True, now=NOW
+    ) == []
+    assert directory([row()]).lookup(
+        "x@example.com", email_verified=True, now=NOW + dt.timedelta(days=31)
+    ) == []
+
+
+def test_snapshot_is_deterministic_and_bounded() -> None:
+    a, b = row(), row(domain="other.example", company_url="https://other.example", company_name="Other")
+    assert build_snapshot([a, b], source_sheet_url=SHEET, now=NOW) == build_snapshot(
+        [b, a], source_sheet_url=SHEET, now=NOW
+    )
+    docs = build_snapshot([a, b], source_sheet_url=SHEET, now=NOW)
+    assert len(docs) <= 257
+    assert docs["current"]["domain_count"] == 2
+
+
+def test_cache_is_local_and_cannot_be_mutated_by_a_caller() -> None:
+    docs = build_snapshot([row()], source_sheet_url=SHEET, now=NOW)
+    reads: list[str] = []
+
+    def read(key: str) -> Any:
+        reads.append(key)
+        return copy.deepcopy(docs.get(key))
+
+    lookup = AffiliationDirectory(read)
+    first = lookup.lookup("first@example.com", email_verified=True, now=NOW)
+    first[0]["funding_organization"] = "Forged"
+    second = lookup.lookup("second@example.com", email_verified=True, now=NOW)
+    assert second[0]["funding_organization"] == "Y Combinator"
+    assert len(reads) == 2
+    assert all("@" not in key for key in reads)
+
+
+def test_missing_or_broken_catalog_never_breaks_login_or_claims_a_match() -> None:
+    assert AffiliationDirectory(lambda _: None).lookup("x@example.com", email_verified=True, now=NOW) == []
+
+    def unavailable(_: str) -> Any:
+        raise ConnectionError("backend down")
+
+    assert AffiliationDirectory(unavailable).lookup("x@example.com", email_verified=True, now=NOW) == []
+
+
+def test_modified_or_incomplete_snapshot_cannot_publish() -> None:
+    docs = build_snapshot([row()], source_sheet_url=SHEET, now=NOW)
+    bucket = next(key for key in docs if key != "current")
+    for change in ("record", "count", "missing"):
+        modified = copy.deepcopy(docs)
+        if change == "record":
+            modified[bucket]["domains"]["example.com"][0]["founding_year"] = 1900
+        elif change == "count":
+            modified["current"]["domain_count"] = 999
+        else:
+            del modified[bucket]
+        with pytest.raises(ValueError):
+            validate_documents(modified)

--- a/tests/test_company_affiliations.py
+++ b/tests/test_company_affiliations.py
@@ -78,6 +78,15 @@ def test_invalid_or_shared_domains_are_rejected(domain: str) -> None:
         normalize_company_domain(domain)
 
 
+@pytest.mark.parametrize("domain", ["example.co.uk", "example.com.au", "example.co.in"])
+def test_companies_under_multilabel_public_suffixes_are_valid(domain: str) -> None:
+    assert normalize_company_domain(domain) == domain
+    records = directory([row(domain=domain, company_url=f"https://{domain}")]).lookup(
+        f"person@{domain}", email_verified=True, now=NOW
+    )
+    assert records[0]["domain"] == domain
+
+
 def test_multiple_organizations_are_preserved_and_duplicates_removed() -> None:
     records = [row(), row(), row(
         funding_organization="Accel", directory_url="https://www.accel.com/companies/example"

--- a/tests/test_company_affiliations_postgres.py
+++ b/tests/test_company_affiliations_postgres.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from tests.fakes.postgres import postgres_store_on, sqlite_postgres_conn
+from tests.test_company_affiliations import NOW, SHEET, row
+from trusted_router.company_affiliations import build_snapshot
+from trusted_router.storage_errors import StoreConflict
+
+
+def test_postgres_snapshot_roundtrip_and_lost_initial_race() -> None:
+    conn = sqlite_postgres_conn()
+    store = postgres_store_on(conn)
+    docs = build_snapshot([row()], source_sheet_url=SHEET, now=NOW)
+    with patch.object(store, "_insert_entity_once_tx", return_value=False):
+        with pytest.raises(StoreConflict):
+            store.publish_company_affiliation_documents(docs, expected_revision=None)
+    assert conn.count_entities("company_affiliation") == 0
+    store.publish_company_affiliation_documents(docs, expected_revision=None)
+    assert store.get_company_affiliation_document("current") == docs["current"]
+
+
+def test_postgres_failure_rolls_back_pointer_and_all_buckets() -> None:
+    conn = sqlite_postgres_conn()
+    store = postgres_store_on(conn)
+    first = build_snapshot([row()], source_sheet_url=SHEET, now=NOW)
+    store.publish_company_affiliation_documents(first, expected_revision=None)
+    second = build_snapshot([row(company_name="Renamed")], source_sheet_url=SHEET, now=NOW)
+    original = store._write_entity_tx
+
+    def failing_write(connection, kind, key, value):
+        original(connection, kind, key, value)
+        if key != "current":
+            raise RuntimeError("injected failure after write")
+
+    with patch.object(store, "_write_entity_tx", side_effect=failing_write):
+        with pytest.raises(RuntimeError):
+            store.publish_company_affiliation_documents(second, expected_revision=first["current"]["revision"])
+    assert store.get_company_affiliation_document("current") == first["current"]
+    assert conn.count_entities("company_affiliation") == len(first)

--- a/tests/test_oauth_company_affiliations.py
+++ b/tests/test_oauth_company_affiliations.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import datetime as dt
+import threading
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.test_oauth_increment_d import APP_ID, REDIRECT, VERIFIER, _approve, _authorize, _setup
+from tests.test_oauth_key_delegation import _create_code
+from trusted_router.company_affiliations import build_snapshot
+from trusted_router.scopes import SCOPE_INFERENCE, SCOPE_PROFILE
+from trusted_router.storage import STORE
+
+
+def _seed() -> None:
+    now = dt.datetime.now(dt.UTC)
+    docs = build_snapshot([{
+        "enabled": "TRUE", "listing_status": "active", "domain": "example.com",
+        "company_name": "Example Company", "company_url": "https://example.com",
+        "funding_organization": "Y Combinator",
+        "directory_url": "https://www.ycombinator.com/companies/example",
+        "founding_year": "2020", "founding_year_source": "https://example.com/about",
+        "verified_at": now.date().isoformat(),
+    }], source_sheet_url="https://docs.google.com/spreadsheets/d/test-directory/edit", now=now)
+    STORE.publish_company_affiliation_documents(docs, expected_revision=None)
+
+
+def test_pkce_exchange_and_userinfo_share_verified_company_metadata(client: TestClient, user_headers: dict[str, str]) -> None:
+    _seed()
+    verifier = "test-verifier-" + "c" * 43
+    code, _ = _create_code(client, user_headers, verifier=verifier)
+    alice = STORE.find_user_by_email("alice@example.com")
+    STORE.mark_user_email_verified(alice.id)
+    response = client.post("/v1/auth/keys", json={"code": code, "code_verifier": verifier})
+    assert response.status_code == 200
+    assert "no-store" in response.headers.get("cache-control", "")
+    identity = response.json()["identity"]
+    assert identity["company_affiliations"][0]["funding_organization"] == "Y Combinator"
+    assert identity["company_affiliations"][0]["founding_year"] == 2020
+    assert identity["verification_level"] == "email"
+    info = client.get("/v1/auth/userinfo", headers={"authorization": "Bearer " + response.json()["key"]})
+    assert info.json()["data"] == identity
+    assert "no-store" in info.headers.get("cache-control", "")
+
+
+def test_unverified_identity_and_inference_only_keys_never_disclose_affiliations(client: TestClient) -> None:
+    _seed()
+    user = STORE.ensure_user("unverified@example.com")
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+    key, _ = STORE.create_api_key(workspace_id=workspace.id, name="profile", creator_user_id=user.id, management=False, scopes=[SCOPE_PROFILE])
+    response = client.get("/v1/auth/userinfo", headers={"authorization": "Bearer " + key})
+    assert response.status_code == 200
+    assert "company_affiliations" not in response.json()["data"]
+    STORE.mark_user_email_verified(user.id)
+    inference, _ = STORE.create_api_key(workspace_id=workspace.id, name="inference", creator_user_id=user.id, management=False, scopes=[SCOPE_INFERENCE])
+    assert client.get("/v1/auth/userinfo", headers={"authorization": "Bearer " + inference}).status_code == 403
+
+
+def test_changed_email_loses_old_affiliation(client: TestClient) -> None:
+    _seed()
+    user = STORE.ensure_user("verified@example.com")
+    STORE.mark_user_email_verified(user.id)
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+    key, _ = STORE.create_api_key(workspace_id=workspace.id, name="profile", creator_user_id=user.id, management=False, scopes=[SCOPE_PROFILE])
+    headers = {"authorization": "Bearer " + key}
+    assert client.get("/v1/auth/userinfo", headers=headers).json()["data"]["company_affiliations"]
+    STORE.set_user_email(user.id, "verified@other.example")
+    assert "company_affiliations" not in client.get("/v1/auth/userinfo", headers=headers).json()["data"]
+
+
+@pytest.mark.parametrize("scope", ["inference", "inference profile"])
+def test_registered_oauth_grants_disclose_only_with_profile_scope(client: TestClient, scope: str) -> None:
+    _seed()
+    _setup(client)
+    user = STORE.find_user_by_email("alice@example.com")
+    assert user is not None
+    STORE.mark_user_email_verified(user.id)
+    page = _authorize(client, scope=scope)
+    approved = _approve(client, page)
+    code = parse_qs(urlsplit(approved.headers["location"]).query)["code"][0]
+    token = client.post("/v1/oauth/token", data={"grant_type": "authorization_code", "code": code, "code_verifier": VERIFIER, "client_id": APP_ID, "redirect_uri": REDIRECT})
+    assert token.status_code == 200
+    assert ("company_affiliations" in token.json()["trustedrouter"]) == ("profile" in scope)
+
+
+def test_slow_directory_cannot_block_signin(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    import trusted_router.verification as verification
+
+    _seed()
+    user = STORE.ensure_user("slow@example.com")
+    STORE.mark_user_email_verified(user.id)
+    workspace = STORE.list_workspaces_for_user(user.id)[0]
+    key, _ = STORE.create_api_key(workspace_id=workspace.id, name="profile", creator_user_id=user.id, management=False, scopes=[SCOPE_PROFILE])
+    reads = []
+    release = threading.Event()
+    finished = threading.Event()
+
+    def slow_read(key: str):
+        reads.append(key)
+        release.wait(5)
+        finished.set()
+        return None
+
+    monkeypatch.setattr(STORE.target, "get_company_affiliation_document", slow_read)
+    monkeypatch.setattr(verification, "AFFILIATION_TIMEOUT_SECONDS", 0.02)
+    headers = {"authorization": "Bearer " + key}
+    try:
+        for _ in range(2):
+            response = client.get("/v1/auth/userinfo", headers=headers)
+            assert response.status_code == 200
+            assert "company_affiliations" not in response.json()["data"]
+        assert not finished.is_set(), "Sign-in waited for optional directory read"
+        assert len(reads) == 1
+    finally:
+        release.set()


### PR DESCRIPTION
## Summary
- Enrich profile-scoped delegated identities with exact verified-email company-domain matches, sourced funding organizations, founding years, and provenance.
- Keep all company data outside git in a private Google Sheet and a validated, atomic store snapshot. Support memory, Spanner, and PostgreSQL-wire stores.
- Omit claims for stale, ambiguous, disabled, or unavailable evidence; preserve sign-in availability, scope boundaries, and existing verification levels.
- Document consent, claim semantics, and guarded data import. No investor authentication, employment verification, or endorsement claim.

## Validation
- Observed failing regressions before implementation: missing identity affiliation, mutable/incomplete snapshots accepted, missing no-store headers, legitimate multi-label public-suffix domains rejected.
- Focused new tests: 60 passed, 9 optional live-backend cases skipped. PostgreSQL SQL/rollback harness passed; broader OAuth coverage passed earlier.
- Full Ruff and mypy passed (376 source files).
- Full local suite: 10,449 passed, 417 skipped, 11 xfailed; one existing provider-health manifest-count failure for AkashML/Arcee, reproduced separately on the unchanged base 03744917. No catalog/branding changes included here.
- Claude CLI Opus review attempted; local CLI is logged out. No private Claude API key used.

## Rollout
Code deploy first, then reviewed CSV importer with fresh expected revision and atomic read-back. Dataset and evidence archives are not included in this PR.